### PR TITLE
feat(list-filters): the universal filter server core — registry, caller-specific schema, safe compiler (plan 08, Phases 0+1)

### DIFF
--- a/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
+++ b/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
@@ -1,0 +1,263 @@
+# List filters: declared deviations from Frappe parity
+
+Plan 08 aims at Frappe-parity list filtering. Where we deliberately differ, the
+difference is written down HERE, with its rationale, so that:
+
+* plan §11.5's golden matrix (derived from the pinned Frappe `FieldSelect` /
+  `filter.js` behaviour) is not permanently red — it asserts parity *except* for
+  this list;
+* a Frappe upgrade that changes one of these behaviours forces a decision
+  instead of silently drifting;
+* reviewers have one place to argue with, rather than reading the compiler.
+
+Reference: Frappe v16 @ `9a8daf343db69a0127f470bad8be0af192cd80c8`
+(`frappe/public/js/frappe/ui/filters/filter.js`,
+`.../filters/field_select.js`, `frappe/model/model.js`,
+`frappe/model/db_query.py`). Implementation: `jarvis/chat/list_filters.py`.
+
+---
+
+## D1 — Permlevel IS enforced on filter fields (security; stricter)
+
+**Frappe:** field-level permlevel is enforced on *reads* (`get_permitted_fields`)
+but **not on filters**. `frappe.get_list(dt, filters={"secret": ["like", "a%"]})`
+runs for a user who may not read `secret`, so any list becomes a
+character-by-character oracle over a field the caller cannot see.
+
+**Jarvis:** a field whose `permlevel` is not in the caller's readable set is
+absent from the schema *and* rejected by the compiler.
+
+**Why:** in this codebase the hole reaches the agents IP moat —
+`Jarvis Agent Listing.skill_bundle` is permlevel 1, readable only by System
+Manager, and it holds the bundle rules that are the product's moat. A plain
+Jarvis User could otherwise reconstruct it through filter responses. Judgment
+C08-1 makes this binding, and it is why the compiler may never be replaced by
+"just pass the filters to the ORM".
+
+**Note on error shape:** an above-permlevel field returns the *same*
+`list_filter_unknown_field` error as a misspelled one. Distinguishing
+"exists but you may not read it" from "does not exist" is itself the oracle.
+
+**Tested:** `test_list_filters.py` — two roles, both directions, on a real
+permlevel-1 field.
+
+---
+
+## D2 — Password fields are excluded entirely
+
+**Frappe:** offers Password in the field picker with a restricted operator set
+(`invalid_condition_map["Password"]` removes Between/Timespan/comparisons/in).
+
+**Jarvis:** Password is not selectable at all.
+
+**Why:** the restricted set still leaves `=`, `!=`, `like`, `not like` and `is`.
+`like` over a stored secret is a brute-force oracle with a page-count side
+channel. Plan §1/§9 already forbid exposing secret-bearing fields "through
+schema, search, error messages, query logs, or telemetry"; excluding the field is
+the only way to honour that.
+
+---
+
+## D3 — `_assign` / `_liked_by` are restricted to the `like` family
+
+**Frappe:** defaults them to `like` (`get_default_condition` special-cases both,
+because they are stored as JSON arrays), but still offers `=`, `!=`, `in`,
+`not in`, `is`, and the comparison operators through the Data map.
+
+**Jarvis:** operators are `like`, `not like`, `is`. Default `like`. The schema
+entry carries `"json_array": true` so the UI can label the control honestly.
+
+**Why:** the column holds `["a@x.com","b@x.com"]`. `=` can only match when
+exactly one user is assigned *and* the client happens to send the JSON
+representation — i.e. it is a promise the data shape cannot keep. C08-2 required
+"like semantics or don't ship them"; this is the like-semantics option.
+
+**Related, NOT deviated:** `_comments` is also a JSON blob, and Frappe treats it
+as plain `Text` with an `=` default. We keep Frappe's behaviour there rather than
+extending D3, so the parity surface stays small — but the same "an equality
+filter on `_comments` will not match" caveat applies. Revisit if a surface ever
+exposes it prominently.
+
+---
+
+## D4 — Child-table filters compile to one `EXISTS` per child DocType
+
+**Frappe:** `db_query` LEFT JOINs the child table
+(`... join tabChild on (tabChild.parenttype = 'Parent' and tabChild.parent = tabParent.name)`)
+and then compensates for the resulting duplicate parent rows in its count paths.
+
+**Jarvis:** one `EXISTS (SELECT 1 FROM tabChild ... )` subquery per child DocType.
+
+**Why:** the join duplicates parent rows, which corrupts `total`, `has_more` and
+OFFSET pagination for every list in this app — all of which return a frozen
+`{rows, total, has_more, start, page_length}` envelope that the SPA trusts. Plan
+§4.3 and §9 both require correct totals under child filters.
+
+**Multi-clause semantics — decided (C08-2):** all clauses on the *same* child
+DocType go inside ONE `EXISTS`, ANDed together. That preserves Frappe's meaning:
+with a single join, two conditions on one child table must be satisfied by the
+SAME child row. Two clauses on *different* child DocTypes produce two independent
+`EXISTS` subqueries, which is also Frappe's meaning (two joins).
+
+**Known ambiguity, at parity:** the subquery matches on `parent` + `parenttype`
+only — not `parentfield` — exactly as Frappe's join does. If one child DocType is
+ever referenced by two `Table` fields of the same parent, a filter matches rows in
+either. The schema likewise identifies a child field by (DocType, fieldname), as
+Frappe does, so the ambiguity is inherited rather than introduced. No current
+Jarvis DocType does this.
+
+---
+
+## D5 — Default operator follows Frappe's code, not plan §5.1's table
+
+Plan §5.1 says "Data **and user-facing text-like fields** → `like`". Frappe's
+`get_default_condition` (filter.js:516-529) is narrower:
+
+| Field | Plan §5.1 default | Frappe default | Jarvis |
+|---|---|---|---|
+| `Data` (small table) | `like` | `like` | `like` |
+| `Data` (large table) | `like` | `=` | `=` |
+| `Small Text`, `Long Text`, `Text`, `Text Editor` | `like` | `=` | `=` |
+| `Attach`, `Attach Image`, `Phone`, `Barcode`, `Color`, `Code` | `like` | `=` | `=` |
+| `Date`, `Datetime` | `Between` | `Between` | `Between` |
+| `_assign`, `_liked_by` | (not covered) | `like` | `like` |
+| everything else | `=` | `=` | `=` |
+
+**Jarvis follows Frappe.** `like` remains *selectable* on every one of those
+families (it is only the default that differs), which is what plan §5.1's own
+closing sentence requires. The large-table rule is honoured via Frappe's own
+`Meta.check_if_large_table` heuristic and reported to the client as
+`is_large_table` so the UI can explain the changed default.
+
+---
+
+## D6 — `Select` values are validated against metadata options
+
+**Frappe:** does not validate; an unknown Select value simply matches nothing.
+
+**Jarvis:** `=`, `!=`, `in`, `not in` on a Select whose metadata carries options
+reject a value that is not one of them (`list_filter_invalid_value`).
+
+**Why:** it is free, it makes a client bug loud instead of silently empty, and it
+matches what the existing curated endpoints already do (`Invalid scope filter.`,
+`Invalid schedule_frequency filter.`). Skipped when options are absent or
+dynamically supplied (`link:` form).
+
+---
+
+## D7 — Nested-set operators are not offered yet
+
+**Frappe:** offers `descendants of`, `descendants of (inclusive)`,
+`not descendants of`, `ancestors of`, `not ancestors of` for a Link whose target
+DocType is a tree.
+
+**Jarvis:** not in `CONDITIONS` at all in Phase 1.
+
+**Why:** no Jarvis list has a Link to a nested-set DocType today (the pilots'
+Links target `Role` and `User`). Advertising an operator the compiler cannot
+honour would be a schema that lies; omitting it keeps the contract truthful and
+fails closed. They arrive with the first surface that has a tree Link, compiled
+the way `db_query` does it (resolve `lft`/`rgt` to a name set, then `in`).
+
+---
+
+## D8 — Unknown / optional fields fail CLOSED
+
+**Frappe:** `db_query` *silently drops* filters on `OPTIONAL_FIELDS`
+(`_user_tags`, `_comments`, `_assign`, `_liked_by`) when the column does not
+exist on the table — the query then returns a WIDER result set than the user
+asked for, with no indication.
+
+**Jarvis:** an optional field with no column is not in the schema, and a clause
+naming a field that is not in the schema is rejected with a stable code. Nothing
+is ever stripped.
+
+**Why:** silently widening a filtered list is a correctness bug in general and a
+disclosure bug on a list whose scope the user believes they narrowed. C08-2 makes
+fail-closed binding.
+
+---
+
+## D9 — An empty `in` list is rejected
+
+**Frappe:** compiles an empty `in` to `IN ('')`, i.e. "matches rows whose value is
+the empty string".
+
+**Jarvis:** `list_filter_invalid_value`.
+
+**Why:** nobody means that. It is a client bug, and Frappe's rendering of it is a
+silent wrong answer.
+
+---
+
+## D10 — Multi-value input is a real list, not a comma string
+
+**Frappe's** Link control submits `in`/`not in` values as a comma-joined string,
+which `db_query` splits on `,` — so a value containing a comma is silently split
+into two.
+
+**Jarvis** accepts a JSON array (canonical) and still tolerates a comma string for
+compatibility, but the schema/contract is a list, capped at 100 entries. Plan §5.3
+requires multi-value selection that does not "degrade to a raw comma string".
+
+---
+
+## D11 — Caps on client input (Frappe has none)
+
+20 clauses, 100 values per `in`, 1,000 characters per scalar value, 100 rows per
+page (plan §9's suggested initial limits).
+
+**Server-authored `IN` lists are exempt** (C08-5): the skills list binds "every
+skill shared with me" as an `IN` tuple. That set is derived server-side from the
+caller's grants, is not attacker-controlled, and is legitimately unbounded. The
+cap exists to bound request payloads, and the structural split in
+`ListFilterQuery` is what makes the exemption expressible without a hole — server
+predicates and client clauses are separate stores, so "exempt" is a property of
+where the SQL came from, not of a flag someone can pass.
+
+---
+
+## D12 — Facet WHERE is "identical minus the facet's own dimension"
+
+Plan §6.3.9 says rows, total, facets and `has_more` share an *identical* WHERE.
+Taken literally that breaks two shipped UIs: the Approvals `document_type` facet
+and the Learning `domain` facet deliberately drop their own filter so the tab
+strip stays populated when you click a tab.
+
+**Jarvis** implements standard faceting: rows / total / `has_more` share one
+WHERE; a facet over dimension *d* uses the identical WHERE **minus the clauses on
+*d***. `CompiledFilters.fragment(exclude_dimension=...)` is that operation, and it
+re-groups the child `EXISTS` after exclusion so D4's semantics survive.
+Judgment C08-3.
+
+---
+
+## D13 — `like` clause values keep the user's wildcards; the `search` box does not
+
+The repo's `escape_like()` (the old `_lk`) escapes `%` and `_` — correct for a
+free-text *search* box, which is not a query language.
+
+A `like` **filter clause** is the query language: Jarvis matches Frappe's UI
+(`filter.js` `get_selected_value`) and wraps the term in `%...%` unless the user
+already supplied a wildcard, leaving any `%`/`_` they typed as wildcards.
+Backslashes are doubled so a literal `\` survives LIKE's own escape processing,
+exactly as `db_query` does.
+
+Both behaviours ship, on different parameters (`search` vs `filters_v2`). This is
+recorded because the asymmetry looks like a bug until you know it is not.
+
+---
+
+## Non-deviations worth stating
+
+* **Hidden / not-in-list-view fields are filterable.** Frappe filters on readable
+  metadata, not on the visible columns. Plan §4.2.
+* **A field the fixed scope makes constant stays in the picker** (e.g. `owner` on
+  an owner-scoped list). Plan §4.1.
+* **`docstatus` appears only for submittable DocTypes**, matching
+  `FieldSelect.add_field_option`.
+* **`Table MultiSelect` exposes only its Link value field**, matching
+  `FieldSelect.build_options`.
+* **`ifnull(...)` null-handling** per operator/family is copied from
+  `db_query.prepare_filter_condition`, so `!=` still matches NULL rows the way
+  Frappe's does.

--- a/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
+++ b/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
@@ -409,6 +409,88 @@ believed was open-ended to a single day.
 `Timespan` is unaffected: it feeds `_between_bounds` a server-computed
 two-element range, which is why the tests assert it still resolves.
 
+### D14-b — malformed / non-finite numerics fail closed (round-2 P1-01)
+
+D14 keeps *blank* → `0`, but `flt`/`cint` also silently turn `"abc"` into `0` and
+accept `inf`/`nan`. Those are NOT at parity: a nonblank value that is not a finite
+number is rejected with `list_filter_invalid_value` (`_as_number` parses with
+`float()` and checks `math.isfinite`), so a hand-edited URL or direct API call
+cannot answer a different question from the one asked, and a non-finite value can
+never reach the DB binder as a driver error outside the stable code. `Int`/
+`Duration` keep Frappe's `cint` truncation of a *finite* fractional value
+(`"3.7"` → `3`) — documented, not silent.
+
+## D15 — Long Text inherits Data's operator set (effective-Data, stricter)
+
+Frappe's `Filter.set_fieldtype` scrubs string-like controls (Text, Small Text,
+Text Editor, Attach, Attach Image, Tag, Phone, JSON, Comments, Barcode, Dynamic
+Link, Read Only, Assign, Color) to an effective `Data` value control, and
+`hide_invalid_conditions` then picks
+`invalid_condition_map[original_type] || invalid_condition_map[effective]`. A
+type with no row of its own therefore inherits Data's `(Between, Timespan)`
+invalid set. The original implementation looked at the original type only
+(round-2 P0-03), so Small Text / Text / JSON / Dynamic Link advertised `Between`
+and the frontend rendered a **date range over a text column**. `invalid_conditions()`
+now models the fallback, and the golden matrix in `test_list_filters_f8` asserts
+`Between`/`Timespan` are absent at schema AND rejected by the compiler for every
+converted type. `_comments` (a standard `Text` field) is covered by the same rule.
+
+`Long Text` is a **deliberate Jarvis addition** to the effective-Data set: Frappe
+neither scrubs it nor gives it a map row, i.e. it offers `Between` on a prose body
+— the exact non-temporal-date-range nonsense this fix removes. Types that DO have
+their own row (Code, HTML Editor, Markdown Editor, Color, Password) keep it
+(`original_type` wins) and are unaffected.
+
+## D16 — two Table fields to one child DocType share one `EXISTS` (explicit)
+
+When a parent reaches ONE child DocType through TWO Table fields, the catalog
+lists each child field ONCE (deduped by `(child DocType, fieldname)` via `seen`),
+and a clause on that child compiles to a single `EXISTS` keyed by the child
+DocType (D4) — so it matches a row reached through **either** container. This is
+the known `parentfield` ambiguity, now made explicit and tested
+(`TestTwoTableFieldsSameChild`) rather than left to chance. If a future surface
+needs container-specific child filtering it must carry the `parentfield` on the
+clause; deferred until a real surface needs it.
+
+## Runtime capability flag + telemetry (round-2 P1-05)
+
+- **Per-view flag (default ON).** `view_filters_enabled(view_key)` reads the
+  opt-OUT list `jarvis_list_filters_v2_off` from `site_config.json`
+  (`frappe.conf`, the admission-flag pattern). A migrated view is live unless
+  listed, so the switch is only ever a rollback. OFF makes `get_list_filter_schema`
+  decline (the client degrades to legacy transport with the Filter action still
+  visible). The COMPILE path deliberately does NOT consult the flag: a clause a
+  stale client still sends is answered or coded, never silently dropped
+  (do-not-regress rule 8). `list_filters_capabilities()` exposes the
+  `{view_key: enabled}` map so a surface can pick transport at mount.
+- **Structural telemetry.** `emit_filter_telemetry` logs, through a dedicated
+  INFO logger (the `latency.py` pattern), one line per compiled request: view,
+  clause count, whether a child clause was used, the per-clause `{fieldtype,
+  operator}` shape, a duration BUCKET, and — on rejection — the stable error
+  code. It NEVER logs a filter value (do-not-regress rule 4). Query-level
+  duration/row telemetry at each endpoint is deferred (ledgered) — the compile
+  boundary is the one place that already sees every migrated request.
+
+## `schema_revision` hashes the full contract (round-2 P1-10)
+
+`_schema_digest` now hashes every field key the wire carries (doctype, fieldname,
+label, fieldtype, options, default_operator, operators, standard/child/json_array
+markers) plus the limits block — not the earlier five-key subset — so a relabel,
+a Select-option edit, a Link-target change or a limits change all change the
+public `schema_revision`. A caching/ETag consumer can trust it as a real revision.
+
+## Discovery widening (round-2 P0-04)
+
+The Phase-0 completeness sweep (`test_list_registry._whitelisted_list_callables`)
+walks `jarvis.chat` AND `jarvis.support`, matches the `list_*` **and**
+`admin_list_*` naming families (so `jarvis.support.api.list_tickets` and
+`user_settings_api.admin_list_user_usage` are visible), and honours the
+`list_registry.list_surface_endpoint` annotation for any differently-named
+collection endpoint. Inventory / migration / wiring are asserted separately; the
+"no pending active view" gate stays deferred to the final round — this round the
+audit REPORTS the migrated-vs-pending split and fails only on an UNCLASSIFIED
+collection.
+
 ---
 
 # MIGRATION-CHECKLIST
@@ -519,3 +601,32 @@ rather than a test.
 - [ ] The legacy argument is removed only after every shipped client sends v2
       (plan §10 Phase 5). Until then both paths must keep working, and the
       per-surface test asserting that is what makes the sunset safe to schedule.
+
+---
+
+# PER-VIEW SIGN-OFF (Wave F8) — the five migrated views
+
+Round-2 P1-12: a completed artefact for the five views flipped to `MIGRATED`,
+replacing the empty template above for them. Catalog counts are Administrator
+(the ceiling); floor-role width is reported by
+`test_list_registry.TestCuratedFilterWidthGap.test_floor_role_catalog`.
+
+| View | Endpoint | Fixed predicate (scope) | DocPerm/permlevel gate | admin main / child | Withheld fields | Wrapper-wire test | Telemetry |
+|---|---|---|---|---|---|---|---|
+| skills | `custom_skills_api.list_custom_skills_page` | owner OR shared-with-me (DocShare id set) | Jarvis User read; permlevel enforced (`skill_bundle` moat) | 19 / 2 | — | `frontend/tests/list-filters/wrapperWire.spec.js` (Skills) | compile emits view=`skills` |
+| macros | `macros_api.list_macros_page` | owner-scoped | Jarvis User read; child `Jarvis Macro Step` via parent perms | 22 / 5 | — | `wrapperWire.spec.js` (Macros) | view=`macros` |
+| saved_dashboards | `dashboards_api.list_dashboards_page` | scope (mine/role/org) visibility | Jarvis User read | 20 / 3 | — | `frontend/tests/list-filters/wave1Wrappers.spec.js` (Dashboards) | view=`saved_dashboards` |
+| triggers | `triggers_api.list_triggers_page` | owner/manager scope | Jarvis User read; **excluded_fields** redact automation logic | 19 / 0 | `condition`, `script_body`, `llm_instruction` (D1-b) | `wave1Wrappers.spec.js` (Triggers) | view=`triggers` |
+| wiki_pages | `wiki.list_wiki_pages_page` | scope_filter (all/org/role/mine) + write matrix | Jarvis User read | 27 / 0 | — | `wave1Wrappers.spec.js` (Wiki) | view=`wiki_pages` |
+
+Transport: all five send `filters_v2` (JSON, omitted when empty) through the ONE
+shared encoder `frontend/src/api/listPageArgs.js` — Skills/Macros via `api.js`,
+Dashboards/Triggers via `api/dashboards.js`/`api/triggers.js`, Wiki via
+`api/wiki.js`'s bespoke shape reusing `encodeFiltersV2`. Each wrapper has a
+wire-contract test asserting the exact `frappe-ui.call` args for the empty and
+nonempty cases (the round-2 P0-01 gap: Dashboards and Triggers rebuilt the
+request without `filters_v2`).
+
+Deferred for these views (ledgered, not this round): browser result-narrowing
+matrix, projections (File Box/Support), Waves 2-3, per-endpoint query-duration
+telemetry, Dynamic Link value picker, nested-set operators.

--- a/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
+++ b/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
@@ -382,12 +382,32 @@ this table or a deviation of its own.
 submitted with an empty value compiles to `= 0` rather than being rejected. That
 is what `db_query` does (`value = flt(f.value)`), and it is left at parity.
 
-The temporal families are **not** left at parity — see the `_scalar` guard:
-`getdate(None)`, `getdate("")` and `get_datetime(None)` all return *today/now* in
-Frappe, so an omitted date bound would silently become "today" and return a
-plausible-looking wrong answer. Those are rejected with
-`list_filter_invalid_value`. The asymmetry is deliberate: `= 0` is visibly odd in
-the result set, "everything from today" is not.
+The temporal families are **not** left at parity. Frappe's date helpers open with
+`if not string_date:` and return *today/now*, so **falsiness is the only thing
+they check** — `None`, `""`, `0`, `False`, `[]` and `{}` all mean "today" to
+`getdate()`. A blank or malformed date bound would therefore return a
+plausible-looking answer to a question nobody asked. Every one of those is
+rejected with `list_filter_invalid_value`.
+
+The asymmetry with numerics is deliberate: `= 0` is visibly odd in the result
+set; "everything from today" is not.
+
+### D14-a — `Between` requires both bounds (no `nowdate()` fallback)
+
+`db_query.get_between_date_filter` documents its own fallback: *"If any of filter
+part (to or from) are missing then start or end of current day is assumed."* We
+do not inherit it. A `Between` with a missing, blank or falsy bound —
+`None`, `""`, `[]`, `["", ""]`, `[None, None]`, `{}`, a one-element list, or a
+pair with one blank end — is rejected.
+
+This is the deviation that matters most in practice, because **`Between` is the
+*default* operator for Date and Datetime** (D5 / `get_default_condition`). It is
+the first thing a client hits on those families, so Frappe's fallback is not an
+edge case here — it is the common path, and it silently narrows a range the user
+believed was open-ended to a single day.
+
+`Timespan` is unaffected: it feeds `_between_bounds` a server-computed
+two-element range, which is why the tests assert it still resolves.
 
 ---
 
@@ -449,6 +469,16 @@ rather than a test.
 - [ ] Server-authored `IN` lists stay on the server side, where the §9 client
       caps do not apply.
 - [ ] Rows, `total` and `has_more` all use `q.where()`.
+- [ ] **Pin the SUCCESS envelope shape and do not change it.** The pilots
+      (`list_custom_skills_page`, `list_macros_page`) return the bare
+      `{rows, total, has_more, start, page_length}` dict, which is what
+      `useListPage` reads directly — only the *error* path is an envelope.
+      **Exception to reconcile:** `list_triggers_page`, `list_activity_page` and
+      `list_dashboards_page` already return `{ok: true, data: {...}}`. Those
+      surfaces keep their existing success shape at migration (changing it is a
+      client break unrelated to filters); just make sure the error envelope the
+      boundary returns is distinguishable from their success one — it is, since
+      `ok` is `false` and there is no `data` key.
 
 ## 5. Facets (D12)
 

--- a/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
+++ b/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
@@ -417,8 +417,17 @@ number is rejected with `list_filter_invalid_value` (`_as_number` parses with
 `float()` and checks `math.isfinite`), so a hand-edited URL or direct API call
 cannot answer a different question from the one asked, and a non-finite value can
 never reach the DB binder as a driver error outside the stable code. `Int`/
-`Duration` keep Frappe's `cint` truncation of a *finite* fractional value
-(`"3.7"` → `3`) — documented, not silent.
+`Duration` truncate a *finite* fractional value toward zero (`"3.7"` → `3`,
+`int(float(...))`, matching `cint`) — documented, not silent.
+
+**Thousands separators (S10).** `frappe.utils.flt` strips commas before parsing
+(`s.replace(",", "")`), so a human-shaped `"10,500.50"` is a valid number in
+Frappe. `_as_number` now does the same strip BEFORE the strict `float()` +
+`isfinite` check, and — critically — binds the SAME stripped value it validated
+(one parser for validate and bind), so the number the DB sees is provably the
+number that passed the finite check. `"abc"`, `"1,2,a"` and non-finite values are
+still rejected after the strip; the comma strip widens acceptance to real numbers,
+it does not open a hole.
 
 ## D15 — Long Text inherits Data's operator set (effective-Data, stricter)
 
@@ -441,16 +450,34 @@ neither scrubs it nor gives it a map row, i.e. it offers `Between` on a prose bo
 their own row (Code, HTML Editor, Markdown Editor, Color, Password) keep it
 (`original_type` wins) and are unaffected.
 
-## D16 — two Table fields to one child DocType share one `EXISTS` (explicit)
+## D16 — child `EXISTS` is scoped to the containers the caller may read (M2)
 
 When a parent reaches ONE child DocType through TWO Table fields, the catalog
 lists each child field ONCE (deduped by `(child DocType, fieldname)` via `seen`),
 and a clause on that child compiles to a single `EXISTS` keyed by the child
-DocType (D4) — so it matches a row reached through **either** container. This is
-the known `parentfield` ambiguity, now made explicit and tested
-(`TestTwoTableFieldsSameChild`) rather than left to chance. If a future surface
-needs container-specific child filtering it must carry the `parentfield` on the
-clause; deferred until a real surface needs it.
+DocType (D4). That `EXISTS` now binds
+`parentfield IN (<containers this caller may read>)`, computed at schema build
+from the readable containers for that child DocType and carried on the entry as
+`parentfields`.
+
+This CLOSES a container-permission bypass (round-2 M2). The old `EXISTS` matched
+`parent = ... AND parenttype = ...` only, so it matched **any** row of the child
+DocType attached to the parent — including rows under a *sibling* Table field the
+caller cannot read (its own permlevel raised, or the endpoint withholding it via
+`excluded_fields`). Because the same child DocType, same `parent` and same
+`parenttype` are shared across containers and told apart only by `parentfield`,
+a floor user filtering through a readable container leaked rows attached to the
+hidden one, character by character. Binding `parentfield IN (readable containers)`
+removes exactly those rows.
+
+The same-row semantics survive: a matching child row has ONE `parentfield`, so two
+clauses inside the one `EXISTS` are still satisfied by the SAME row under the SAME
+readable container. The both-readable case is unchanged — a System Manager (or any
+role that reads every container) gets every container in the bound set and keeps
+matching a row under either. Verified by `TestContainerParentfieldLeak`
+(behavioural leak + floor-user bind + privileged both-container + view-exclusion)
+and `TestMultiSelectContainerParentfieldScoping` (the Table MultiSelect
+equivalent, whose binding is keyed on the container fieldname identically).
 
 ## Runtime capability flag + telemetry (round-2 P1-05)
 
@@ -463,6 +490,22 @@ clause; deferred until a real surface needs it.
   stale client still sends is answered or coded, never silently dropped
   (do-not-regress rule 8). `list_filters_capabilities()` exposes the
   `{view_key: enabled}` map so a surface can pick transport at mount.
+- **The kill switch fails CLOSED (M1).** The valid shapes for
+  `jarvis_list_filters_v2_off` are a list of view-key strings, a single string, or
+  absent/empty. ANYTHING else — a bool (`true`), an int, a dict, a list with a
+  non-string member — is a misconfiguration, and a rollback switch must never fail
+  open on one. `_disabled_views` used to raise inside its set comprehension on a
+  bool and fall through to `set()` (silently re-enabling every view the operator
+  meant to disable); it now disables EVERY migrated view and writes one deduped,
+  loud `frappe.log_error`. Over-disabling is the safe direction; a typo can never
+  silently re-enable.
+- **Rolled-back ≠ never-migrated (M1).** `get_list_filter_schema` distinguishes a
+  MIGRATED view rolled back by the flag (`list_filter_view_rolled_back` —
+  "Filters are turned off for this list", no client retry) from a genuinely
+  unmigrated one (`list_filter_view_not_filterable` — "not supported yet"). The two
+  used to share one code and message, so a shared link's filters vanished behind an
+  active-looking badge with no honest notice; the client now tells the truth about
+  which case it is in.
 - **Structural telemetry.** `emit_filter_telemetry` logs, through a dedicated
   INFO logger (the `latency.py` pattern), one line per compiled request: view,
   clause count, whether a child clause was used, the per-clause `{fieldtype,

--- a/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
+++ b/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
@@ -382,6 +382,13 @@ this table or a deviation of its own.
 submitted with an empty value compiles to `= 0` rather than being rejected. That
 is what `db_query` does (`value = flt(f.value)`), and it is left at parity.
 
+Concretely, `_as_number` returns `0` for **both** a blank/whitespace string
+(`""`, `"  "`) **and** `None` (`if value is None or (isinstance(value, str) and
+not value.strip()): return 0`). This is deliberate parity, not an oversight: an
+earlier review expected `None`/`""` to be *rejected*, but `flt(None)` is `0.0`
+just as `flt("")` is, so rejecting them would be the deviation — the code is
+right, and it says `0` for the empty numeric on purpose.
+
 The temporal families are **not** left at parity. Frappe's date helpers open with
 `if not string_date:` and return *today/now*, so **falsiness is the only thing
 they check** — `None`, `""`, `0`, `False`, `[]` and `{}` all mean "today" to

--- a/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
+++ b/jarvis/chat/LIST-FILTERS-DEVIATIONS.md
@@ -39,7 +39,73 @@ C08-1 makes this binding, and it is why the compiler may never be replaced by
 "exists but you may not read it" from "does not exist" is itself the oracle.
 
 **Tested:** `test_list_filters.py` — two roles, both directions, on a real
-permlevel-1 field.
+permlevel-1 field (main *and* child, since child permlevel access is evaluated
+against the parent's permissions and can therefore be wrong independently).
+
+### D1-a — permlevel access is `if_owner`-blind (inherited limitation)
+
+Frappe's `Meta.get_permlevel_access()` checks only `perm.role in roles and
+perm.read`. It **ignores `if_owner`**. So a DocPerm pair that means "you may read
+your own row, and these extra columns on it" reads, to the permlevel machinery,
+as "this role has level-1 access to the whole table".
+
+The live example is `Jarvis User Settings`:
+
+| role | permlevel | read | if_owner |
+|---|---:|---:|---|
+| Jarvis User | 0 | 1 | **1** |
+| Jarvis User | 1 | 1 | — |
+
+Intent: a user sees their own usage counters. Effect on the *catalog*: a plain
+Jarvis User gets every permlevel-1 field (`month_tokens`, `monthly_token_limit`,
+`total_tokens`, …) offered as filterable. The floor-role audit in
+`test_list_registry.py` prints exactly this (`settings_user_usage_admin
+floor_main=27` for a Jarvis User).
+
+That is **not** currently a leak, because `admin_list_user_usage` is
+`require_jarvis_admin()`-gated and the view is `PENDING`. It becomes one the
+moment a view over that doctype is migrated with an owner-scoped SQL predicate,
+because row scoping (`if_owner`) and column scoping (permlevel) are enforced by
+two different mechanisms and only one of them is in the catalog.
+
+We do **not** try to out-think Frappe here (re-deriving `if_owner` semantics into
+the permlevel calculation would diverge from every other permlevel consumer in
+the framework). Instead the risk is handled structurally, by the migration
+invariant below and by `excluded_fields` (D1-b).
+
+### D1-b — `excluded_fields`: what the ENDPOINT hides
+
+Permlevel stops a field the *DocType* hides. It cannot stop a field the
+*endpoint* hides. `Jarvis Trigger.condition`, `.script_body` and
+`.llm_instruction` are permlevel **0** — every reader of the doctype may read
+them — yet `triggers_api._trigger_detail` blanks all three for non-managers. A
+filter over them would rebuild the redacted automation logic one `LIKE` at a
+time, and no permlevel check would ever notice.
+
+So a registered view declares `excluded_fields`, and those fields are absent from
+the schema and rejected by the compiler with the same
+`list_filter_unknown_field`. Triggers declares its three today, while still
+`PENDING`, so the guard is in place before the surface can be flipped.
+
+Withholding is **unconditional** — a manager loses filterability on those three
+as well. A per-role exclusion would need the view to declare a predicate, which
+is deliberately deferred: the conservative direction costs a manager one filter,
+the permissive direction costs the customer their automation logic.
+
+### The migration invariant (both of the above, as one rule)
+
+> A view may be flipped to `MIGRATED` only if
+> **(1)** its SQL scope is a subset of the root DocType's ORM read scope for
+> every role that can call it, and
+> **(2)** everything its projection withholds from the rows it returns appears in
+> `excluded_fields`.
+
+(1) is the answer to D1-a: the catalog is derived from doctype-level permissions,
+so if the endpoint's hand-written `WHERE` is *narrower* than the doctype's own
+read rule the schema is safe, and if it is *wider* the schema is a licence to
+read rows the ORM would have refused. (2) is the answer to D1-b. Neither is
+machine-checkable in general, which is precisely why it is written down and why
+the checklist at the end of this file makes someone assert it per surface.
 
 ---
 
@@ -73,10 +139,11 @@ representation — i.e. it is a promise the data shape cannot keep. C08-2 requir
 "like semantics or don't ship them"; this is the like-semantics option.
 
 **Related, NOT deviated:** `_comments` is also a JSON blob, and Frappe treats it
-as plain `Text` with an `=` default. We keep Frappe's behaviour there rather than
-extending D3, so the parity surface stays small — but the same "an equality
-filter on `_comments` will not match" caveat applies. Revisit if a surface ever
-exposes it prominently.
+as plain `Text` — so Frappe's default on it is `=`, which can essentially never
+match. We do not extend D3's operator restriction to it (the parity surface stays
+small), but D5-a moves `Text` to a `like` default, which incidentally makes
+`_comments` behave sensibly. Its full operator set is still Frappe's, so an
+equality filter remains selectable and remains useless.
 
 ---
 
@@ -123,11 +190,36 @@ Plan §5.1 says "Data **and user-facing text-like fields** → `like`". Frappe's
 | `_assign`, `_liked_by` | (not covered) | `like` | `like` |
 | everything else | `=` | `=` | `=` |
 
-**Jarvis follows Frappe.** `like` remains *selectable* on every one of those
-families (it is only the default that differs), which is what plan §5.1's own
-closing sentence requires. The large-table rule is honoured via Frappe's own
-`Meta.check_if_large_table` heuristic and reported to the client as
+**Jarvis follows Frappe except for D5-a below.** `like` remains *selectable* on
+every one of those families (it is only the default that differs), which is what
+plan §5.1's own closing sentence requires. The large-table rule is honoured via
+Frappe's own `Meta.check_if_large_table` heuristic and reported to the client as
 `is_large_table` so the UI can explain the changed default.
+
+## D5-a — free-text bodies default to `like` (deliberate divergence)
+
+`Small Text`, `Long Text`, `Text` and `Text Editor` default to **`like`**, not
+Frappe's `=`.
+
+**Why.** These four are where a human types prose: `description`,
+`instructions`, `question`, `review_note`. Frappe's `=` on them means a user who
+types three words into a Description filter gets zero results and no explanation
+— the control looks broken, and the recovery (open the operator menu, discover
+"Like", re-run) is a step most people will not take. Frappe's `like` default for
+`Data` exists for exactly this reason; the families it omits are the ones where
+the argument is *stronger*, not weaker.
+
+**Why not extend it further.** `Code`, `HTML Editor` and `Markdown Editor` stay
+at `=`: their content is machine-shaped, and a substring match across a stored
+script is both a worse question and a more expensive scan. `Data` keeps Frappe's
+rule intact, including the large-table downgrade to `=`.
+
+**Cost.** `like '%x%'` cannot use an index — but there is no cost *basis* for
+treating these four as large-table risks: Frappe's own `is_large_table` heuristic
+is table-level, not column-level, and none of these columns is indexed under
+either default, so the query plan is a scan either way. If a surface ever proves
+otherwise, the escape hatch already exists (`is_large_table` is reported in the
+schema and `=` stays selectable).
 
 ---
 
@@ -258,6 +350,142 @@ recorded because the asymmetry looks like a bug until you know it is not.
   `FieldSelect.add_field_option`.
 * **`Table MultiSelect` exposes only its Link value field**, matching
   `FieldSelect.build_options`.
-* **`ifnull(...)` null-handling** per operator/family is copied from
-  `db_query.prepare_filter_condition`, so `!=` still matches NULL rows the way
-  Frappe's does.
+
+### `ifnull(...)` null-handling: mirrored, not copied
+
+An earlier draft of this file claimed the null handling was "copied from
+`db_query.prepare_filter_condition`". That was overstated, and the correction
+matters because a reader would otherwise assume parity in branches we never
+reproduced. What is actually mirrored:
+
+| Rule | Source | Ours |
+|---|---|---|
+| `can_be_null` is False for `name` / `creation` / `modified` | db_query | same |
+| `can_be_null` is False for Check/Int/Float/Currency/Percent | db_query | same |
+| `can_be_null` is False for `>` / `>=` on Date/Datetime | db_query | same |
+| `can_be_null` is False when the value is truthy and the op is `=` or `like` | db_query | same |
+| `is set` → `ifnull(col,'') != ''`; `is not set` → `= ''` | db_query | same |
+| `in` does **not** coalesce (non-empty list, no falsy member) | db_query | same |
+| `not in` **does** coalesce | db_query | same |
+| per-family fallback literal (`0`, `''`, `'0001-01-01'`, …) | db_query | same |
+
+What is **not** reproduced: db_query's `not_nullable` DocField flag, its
+`Column`-valued comparisons, its `previous`/`next` operators, its
+`additional_filters_config` hook operators, and its index-friendly rewrite of
+`ifnull(col, fb) = fb` into `(col IS NULL OR col = fb)`. None of those are
+reachable through this contract today; if one becomes reachable it gets a row in
+this table or a deviation of its own.
+
+## D14 — a blank numeric filter means `= 0` (Frappe parity, stated)
+
+`flt("")` and `cint("")` are `0`, so an `Int`/`Float`/`Currency`/`Percent` filter
+submitted with an empty value compiles to `= 0` rather than being rejected. That
+is what `db_query` does (`value = flt(f.value)`), and it is left at parity.
+
+The temporal families are **not** left at parity — see the `_scalar` guard:
+`getdate(None)`, `getdate("")` and `get_datetime(None)` all return *today/now* in
+Frappe, so an omitted date bound would silently become "today" and return a
+plausible-looking wrong answer. Those are rejected with
+`list_filter_invalid_value`. The asymmetry is deliberate: `= 0` is visibly odd in
+the result set, "everything from today" is not.
+
+---
+
+# MIGRATION-CHECKLIST
+
+Work through this before flipping a registered view's `status` to `MIGRATED`.
+Most of it is not machine-checkable, which is why it is a list a person signs off
+rather than a test.
+
+## 1. Prove the scope invariant (D1 / D1-a)
+
+- [ ] Write down the endpoint's fixed `WHERE`, and the root DocType's DocPerm
+      rows (role, permlevel, `read`, `if_owner`).
+- [ ] Assert **SQL scope ⊆ ORM read scope** for every role that can call it. If
+      the endpoint is *wider* than the doctype's own read rule — a reviewer-gated
+      raw-SQL list that deliberately sidesteps `if_owner`, e.g.
+      `list_skill_promotion_requests` — the catalog is derived from the wrong
+      authority and the view is **not** ready to migrate.
+- [ ] Check the DocPerm table for the D1-a shape: a permlevel-0 row with
+      `if_owner=1` **plus** a permlevel-N row without it. If present, every
+      permlevel-N field is catalog-visible to that role regardless of ownership.
+
+## 2. Run the per-role catalog diff
+
+- [ ] `build_field_catalog(root, user=<floor role user>, view=view)` vs
+      `user="Administrator"`. The floor number is what most staff will see.
+- [ ] Reconcile every field in the diff: each one is either genuinely
+      privileged (fine) or a permlevel that does not mean what its author thought
+      (fix the doctype, not the filter layer).
+- [ ] Confirm every **current curated filter key** survives at the floor role.
+      If it does not, migrating silently removes a filter ordinary users have
+      today. (`test_list_registry.test_floor_role_catalog` asserts this.)
+- [ ] **The Approvals trap:** `Jarvis Approval Request.status` is **permlevel 1**,
+      and it works today only because the doctype ships explicit permlevel-1
+      DocPerm rows for `Jarvis User` and `System Manager`. Anyone "tidying up"
+      those rows removes `status` from the schema and breaks the board. Do not
+      remove them; do check they are still there at migration time.
+
+## 3. Declare what the projection withholds (D1-b)
+
+- [ ] List every field the endpoint blanks, redacts, or omits from its row
+      payload for *any* role.
+- [ ] Put each one in `excluded_fields` (`fieldname`, or
+      `"Child DocType.fieldname"`).
+- [ ] `test_list_registry.test_excluded_fields_name_real_fields` catches typos;
+      nothing catches an omission, so this step is the control.
+
+## 4. Wire the endpoint
+
+- [ ] Additive, **type-annotated** `filters_v2: str | list | None = None`
+      (`require_type_annotated_api_methods` is on; an un-annotated param 500s).
+- [ ] Keep the legacy `filters` argument for the compatibility window.
+- [ ] Decorate: `@frappe.whitelist()` → `@require_jarvis_user` →
+      `@filter_errors_to_envelope`, in that order.
+- [ ] Move the fixed predicate onto `ListFilterQuery.server_condition(...)`:
+      named placeholders only (no `%s`), no parameter name starting with `jf`
+      (that namespace belongs to compiled user values), and values passed as
+      kwargs — never interpolated into the SQL string.
+- [ ] Server-authored `IN` lists stay on the server side, where the §9 client
+      caps do not apply.
+- [ ] Rows, `total` and `has_more` all use `q.where()`.
+
+## 5. Facets (D12)
+
+- [ ] A facet over dimension *d* uses `q.where(exclude_dimension=(doctype, d))`,
+      **not** the full `where()` and not an unfiltered count. Dropping the
+      facet's own dimension is what keeps the tab strip populated when a tab is
+      selected.
+
+## 6. Prove equality of scope
+
+- [ ] `filters_v2` absent / `None` / `[]` / `"[]"` returns an envelope identical
+      to the pre-migration one, at **two roles** (an ordinary user and a
+      System Manager).
+- [ ] A clause naming another user's rows returns nothing — it narrows, never
+      widens.
+
+## 7. UI notes for whoever builds the panel
+
+- **Select with a leading blank option.** A `Select` whose options string starts
+  with a newline has `""` as a legitimate value, and `""` means *not set*. The
+  schema passes the options through verbatim, blank included; the control must
+  render that entry as "Not set" rather than an empty row, and must not confuse
+  it with "no filter". (Alternatively offer the `is` operator, which expresses
+  the same question explicitly.)
+- **Dynamic Link.** Fully catalogued (fieldtype, options = the controlling
+  fieldname) and compiles correctly as a plain value comparison, but the *value
+  control* cannot be a Link picker until the panel reads the controlling field's
+  current value to know which DocType to search. Until then it renders as a text
+  input. Not a deviation — an unbuilt UI affordance, recorded so nobody
+  rediscovers it as a bug.
+- **`is_large_table`** is reported per view; when true the `Data` default is `=`
+  and the UI should say why.
+
+## 8. Track the sunset
+
+- [ ] Note the legacy `filters` callers for this surface (SPA page, PWA, any
+      other client — `personalise_notes` and `file_box` each have two).
+- [ ] The legacy argument is removed only after every shipped client sends v2
+      (plan §10 Phase 5). Until then both paths must keep working, and the
+      per-surface test asserting that is what makes the sunset safe to schedule.

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -167,6 +167,7 @@ _order_by = list_filters.order_by
 
 @frappe.whitelist()
 @require_jarvis_user
+@list_filters.filter_errors_to_envelope
 def list_custom_skills_page(
 	search: str = "",
 	filters: str | dict | None = None,

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -17,6 +17,7 @@ import contextlib
 import frappe
 from frappe import _
 
+from jarvis.chat import list_filters
 from jarvis.chat.custom_skills import (
 	MANAGED_OWNER,
 	MAX_SKILLS_PER_PUSH,
@@ -153,67 +154,15 @@ _SKILLS_SORTABLE = {"skill_name": "skill_name", "modified": "modified", "enabled
 _SKILLS_FILTERS = {"scope", "enabled", "user_invocable"}
 
 
-def _lk(s: str) -> str:
-	"""Escape LIKE wildcards in user search input (``\\`` is the default escape)."""
-	return (s or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
-def _clamp_page(start, page_length) -> tuple[int, int]:
-	try:
-		start = max(0, int(start or 0))
-	except (TypeError, ValueError):
-		start = 0
-	try:
-		pl = int(page_length or 20)
-	except (TypeError, ValueError):
-		pl = 20
-	return start, max(1, min(pl, 100))
-
-
-def _bool01(v) -> int:
-	try:
-		iv = int(v)
-	except (TypeError, ValueError):
-		frappe.throw(_("Filter value must be 0 or 1."))
-	if iv not in (0, 1):
-		frappe.throw(_("Filter value must be 0 or 1."))
-	return iv
-
-
-def _load_filters(filters, allowed: set) -> dict:
-	"""Parse ``filters`` (JSON string or dict), whitelist keys (unknown → throw),
-	and drop empty values (an empty value = 'not filtering'; ``0`` is kept)."""
-	if isinstance(filters, str):
-		if filters.strip():
-			try:
-				raw = frappe.parse_json(filters)
-			except Exception:
-				raw = {}
-		else:
-			raw = {}
-	else:
-		raw = filters or {}
-	if not isinstance(raw, dict):
-		raw = {}
-	out: dict = {}
-	for k, v in raw.items():
-		if k not in allowed:
-			frappe.throw(_("Unknown filter: {0}").format(k))
-		if v in (None, ""):
-			continue
-		out[k] = v
-	return out
-
-
-def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, prefix="") -> str:
-	"""Build a safe ORDER BY: only whitelisted columns, direction normalized to
-	asc/desc, a ``name`` tiebreak for stable OFFSET pagination. No user input is
-	ever interpolated (columns come from ``sortable``; dir is a literal)."""
-	col = sortable.get(sort_field or "")
-	if not col:
-		return f"{prefix}`{sortable[default_field]}` {default_dir}, {prefix}`name` asc"
-	d = "desc" if (sort_dir or "").lower() == "desc" else "asc"
-	return f"{prefix}`{col}` {d}, {prefix}`name` asc"
+# C08-5: ``_lk`` / ``_clamp_page`` / ``_bool01`` / ``_load_filters`` /
+# ``_order_by`` were copied into six list modules and had begun to drift. The
+# canonical implementations now live in ``jarvis.chat.list_filters``; these
+# private names stay bound for this module's own readers.
+_lk = list_filters.escape_like
+_clamp_page = list_filters.clamp_page
+_bool01 = list_filters.bool01
+_load_filters = list_filters.load_legacy_filters
+_order_by = list_filters.order_by
 
 
 @frappe.whitelist()
@@ -221,6 +170,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 def list_custom_skills_page(
 	search: str = "",
 	filters: str | dict | None = None,
+	filters_v2: str | list | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -232,44 +182,50 @@ def list_custom_skills_page(
 	shared-with-me rows (``enabled=1`` only) — expressed in ONE owner-scoped SQL
 	WHERE so ``page_length``/``start`` slice the real result set (never a
 	post-filtered page). Envelope: ``{rows, total, has_more, start, page_length}``.
+
+	``filters_v2`` (plan 08 §6.2) is ADDITIVE: the canonical clause list, validated
+	and compiled against this caller's schema by ``jarvis.chat.list_filters``.
+	Legacy ``filters`` keeps working unchanged for the compatibility window. The
+	own/shared scope predicate below is server-authored and stays on the query
+	object's server side, so a user clause is ANDed INSIDE it and can never widen
+	it (C08-5).
 	"""
 	me = frappe.session.user
 	start, pl = _clamp_page(start, page_length)
 	f = _load_filters(filters, _SKILLS_FILTERS)
 	shared = tuple(_skill_names_shared_with(me))
 
-	conds: list[str] = []
-	params: dict = {"me": me, "start": start, "page_length": pl}
+	q = list_filters.new_query("skills")
 
 	scope = f.get("scope")
 	if scope is not None and scope not in ("mine", "shared"):
 		frappe.throw(_("Invalid scope filter."))
+	# The shared-name IN list is SERVER-authored (it is this user's DocShare-like
+	# grant set, not request input), so the §9 client cap on `in` values does not
+	# apply to it — C08-5.
 	if scope == "mine":
-		conds.append("owner = %(me)s")
+		q.server_condition("owner = %(me)s", me=me)
 	elif scope == "shared":
 		if not shared:
-			conds.append("1=0")
+			q.server_condition("1=0")
 		else:
-			params["shared"] = shared
-			conds.append("(name IN %(shared)s AND enabled = 1)")
+			q.server_condition("(name IN %(shared)s AND enabled = 1)", shared=shared)
 	else:  # both
 		if shared:
-			params["shared"] = shared
-			conds.append("(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))")
+			q.server_condition("(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))", me=me, shared=shared)
 		else:
-			conds.append("owner = %(me)s")
+			q.server_condition("owner = %(me)s", me=me)
 
 	if search:
-		params["q"] = f"%{_lk(search)}%"
-		conds.append("(skill_name LIKE %(q)s OR description LIKE %(q)s)")
+		q.server_condition("(skill_name LIKE %(q)s OR description LIKE %(q)s)", q=f"%{_lk(search)}%")
 	if "enabled" in f:
-		params["enabled"] = _bool01(f["enabled"])
-		conds.append("enabled = %(enabled)s")
+		q.server_condition("enabled = %(enabled)s", enabled=_bool01(f["enabled"]))
 	if "user_invocable" in f:
-		params["user_invocable"] = _bool01(f["user_invocable"])
-		conds.append("user_invocable = %(user_invocable)s")
+		q.server_condition("user_invocable = %(user_invocable)s", user_invocable=_bool01(f["user_invocable"]))
 
-	where = " AND ".join(conds)
+	q.apply(filters_v2)
+	where = q.where()
+	params = q.params({"start": start, "page_length": pl})
 	order = _order_by(sort_field, sort_dir, _SKILLS_SORTABLE, "skill_name", "asc")
 
 	total = frappe.db.sql(f"SELECT COUNT(*) FROM `tabJarvis Custom Skill` WHERE {where}", params)[0][0]

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -213,7 +213,9 @@ def list_custom_skills_page(
 			q.server_condition("(name IN %(shared)s AND enabled = 1)", shared=shared)
 	else:  # both
 		if shared:
-			q.server_condition("(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))", me=me, shared=shared)
+			q.server_condition(
+				"(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))", me=me, shared=shared
+			)
 		else:
 			q.server_condition("owner = %(me)s", me=me)
 

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -1,0 +1,1138 @@
+"""The one shared list-filter contract: caller-specific schema + safe compiler.
+
+Plan 08 §6 / Phase 1, as corrected by FABLE-JUDGMENT C08-1..C08-7. Two jobs:
+
+1. :func:`get_list_filter_schema` — for a registered ``view_key``, the catalog of
+   fields THIS caller may filter on, derived from live metadata (never from the
+   visible columns, never from a copied frontend list), with the per-family
+   default and allowed operators mirrored from Frappe's own filter UI.
+2. :func:`compile_filters_v2` / :class:`ListFilterQuery` — validate client
+   clauses against that same schema and compile them to parameterized SQL.
+
+Two invariants this module exists to hold:
+
+**Permlevel is enforced HERE (C08-1).** Frappe does not enforce field-level
+permlevel on *filters* — ``frappe.get_list(filters={"skill_bundle": ["like", "%x%"]})``
+happily answers for a user who may not read the field, turning any list into a
+character-by-character oracle. In this codebase that reaches the agents IP moat
+(``Jarvis Agent Listing.skill_bundle``, permlevel 1, readable only by System
+Manager). So a field above the caller's readable permlevel is absent from the
+schema AND rejected by the compiler. This is a declared, tested deviation from
+Frappe (see ``LIST-FILTERS-DEVIATIONS.md``).
+
+**Server predicates and user clauses never share a string list (C08-5).** The
+raw-SQL list endpoints used to build one ``conds: list[str]`` holding both the
+fixed visibility predicate and the user's filters, ``AND``-joined. That is the
+structure the permlevel rule above cannot survive. :class:`ListFilterQuery`
+splits them: :meth:`~ListFilterQuery.server_condition` takes SQL the endpoint
+author wrote (plus its values as bound params), :meth:`~ListFilterQuery.apply`
+takes client clauses and can only ever turn them into bound parameters. The two
+meet exactly once, as already-built strings, in :meth:`~ListFilterQuery.where`.
+
+Deliberate deviations from Frappe parity are documented, with rationale, in
+``jarvis/chat/LIST-FILTERS-DEVIATIONS.md``. Reviewers cite that file; the future
+golden-matrix test (plan §11.5) is written against it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import frappe
+from frappe import _
+
+from jarvis.chat import list_registry
+from jarvis.permissions import require_jarvis_user
+
+#: Bumped when the wire shape of the schema or a clause changes.
+CONTRACT_VERSION = 1
+
+# --------------------------------------------------------------------------- #
+# Limits (plan §9). These bound CLIENT input only — a server-authored predicate
+# (an owner's shared-skill id list, a permission scan's id set) is exempt, per
+# C08-5, because it is not attacker-controlled and is often legitimately large.
+# --------------------------------------------------------------------------- #
+MAX_CLAUSES = 20
+MAX_IN_VALUES = 100
+MAX_VALUE_CHARS = 1000
+MAX_PAGE_LENGTH = 100
+
+#: Schema cache TTL. Short and dumb on purpose: the cache key already carries a
+#: digest of the metadata it was built from, so a customization changes the key
+#: rather than needing an invalidation hook. The TTL only bounds everything else
+#: (role grants, DocPerm edits made outside the desk).
+SCHEMA_CACHE_TTL = 300
+
+# --------------------------------------------------------------------------- #
+# Stable error codes (plan §6.3 / §11.3: every rejection is coded, and every
+# unknown thing fails CLOSED — we never silently strip a clause the way
+# db_query strips unknown OPTIONAL_FIELDS filters).
+# --------------------------------------------------------------------------- #
+ERR_UNKNOWN_VIEW = "list_filter_unknown_view"
+ERR_VIEW_NOT_FILTERABLE = "list_filter_view_not_filterable"
+ERR_BAD_PAYLOAD = "list_filter_bad_payload"
+ERR_UNKNOWN_FIELD = "list_filter_unknown_field"
+ERR_INVALID_OPERATOR = "list_filter_invalid_operator"
+ERR_INVALID_VALUE = "list_filter_invalid_value"
+ERR_TOO_MANY_CLAUSES = "list_filter_too_many_clauses"
+ERR_TOO_MANY_VALUES = "list_filter_too_many_values"
+ERR_VALUE_TOO_LONG = "list_filter_value_too_long"
+
+
+class ListFilterError(frappe.ValidationError):
+	"""A rejected filter payload. ``filter_error_code`` is the stable machine
+	code; the message is user-facing and never echoes a secret field's value."""
+
+	filter_error_code = ERR_BAD_PAYLOAD
+
+
+def _fail(code: str, message: str) -> None:
+	"""Raise a coded, user-visible filter error (fails closed, always)."""
+	err = ListFilterError(message)
+	err.filter_error_code = code
+	# msgprint(raise_exception=<instance>) keeps the instance (and therefore the
+	# code) while still populating `messages[0]` for the SPA's error surface.
+	frappe.msgprint(message, raise_exception=err, title=_("Filter"), indicator="red")
+
+
+# --------------------------------------------------------------------------- #
+# Operator vocabulary — mirrored from frappe/public/js/frappe/ui/filters/filter.js
+# (`set_conditions`, `invalid_condition_map`, `get_default_condition`) at the
+# pinned v16 ref. Keep this block and the ledger in lockstep with that file.
+# --------------------------------------------------------------------------- #
+OP_EQ = "="
+OP_NE = "!="
+OP_LIKE = "like"
+OP_NOT_LIKE = "not like"
+OP_IN = "in"
+OP_NOT_IN = "not in"
+OP_IS = "is"
+OP_GT = ">"
+OP_LT = "<"
+OP_GTE = ">="
+OP_LTE = "<="
+OP_BETWEEN = "Between"
+OP_TIMESPAN = "Timespan"
+
+#: Frappe's condition list, MINUS the five nested-set conditions. Those are only
+#: ever valid for a Link whose target is a tree DocType; no Jarvis list has one
+#: today, and advertising an operator the compiler cannot honour would be a
+#: schema that lies. Declared deviation D7 — they arrive with the first tree Link.
+CONDITIONS: tuple[str, ...] = (
+	OP_EQ,
+	OP_NE,
+	OP_LIKE,
+	OP_NOT_LIKE,
+	OP_IN,
+	OP_NOT_IN,
+	OP_IS,
+	OP_GT,
+	OP_LT,
+	OP_GTE,
+	OP_LTE,
+	OP_BETWEEN,
+	OP_TIMESPAN,
+)
+
+_ALL_BUT_EQ = tuple(c for c in CONDITIONS if c != OP_EQ)
+
+#: frappe.ui.Filter.invalid_condition_map, reproduced in FULL (the plan
+#: reproduced roughly half of it — C08-2).
+INVALID_CONDITIONS: dict[str, tuple[str, ...]] = {
+	"Date": (OP_LIKE, OP_NOT_LIKE),
+	"Datetime": (OP_LIKE, OP_NOT_LIKE, OP_IN, OP_NOT_IN, OP_EQ, OP_NE),
+	"Data": (OP_BETWEEN, OP_TIMESPAN),
+	"Time": (OP_BETWEEN, OP_TIMESPAN),
+	"Select": (OP_LIKE, OP_NOT_LIKE, OP_BETWEEN, OP_TIMESPAN),
+	"Link": (OP_BETWEEN, OP_TIMESPAN, OP_GT, OP_LT, OP_GTE, OP_LTE),
+	"Currency": (OP_BETWEEN, OP_TIMESPAN),
+	"Color": (OP_BETWEEN, OP_TIMESPAN),
+	"Check": _ALL_BUT_EQ,
+	"Code": (OP_BETWEEN, OP_TIMESPAN, OP_GT, OP_LT, OP_GTE, OP_LTE, OP_IN, OP_NOT_IN),
+	"HTML Editor": (OP_BETWEEN, OP_TIMESPAN, OP_GT, OP_LT, OP_GTE, OP_LTE, OP_IN, OP_NOT_IN),
+	"Markdown Editor": (OP_BETWEEN, OP_TIMESPAN, OP_GT, OP_LT, OP_GTE, OP_LTE, OP_IN, OP_NOT_IN),
+	"Password": (OP_BETWEEN, OP_TIMESPAN, OP_GT, OP_LT, OP_GTE, OP_LTE, OP_IN, OP_NOT_IN),
+	"Rating": (OP_LIKE, OP_NOT_LIKE, OP_BETWEEN, OP_IN, OP_NOT_IN, OP_TIMESPAN),
+	"Int": (OP_LIKE, OP_NOT_LIKE, OP_BETWEEN, OP_IN, OP_NOT_IN, OP_TIMESPAN),
+	"Float": (OP_LIKE, OP_NOT_LIKE, OP_BETWEEN, OP_IN, OP_NOT_IN, OP_TIMESPAN),
+	"Percent": (OP_LIKE, OP_NOT_LIKE, OP_BETWEEN, OP_IN, OP_NOT_IN, OP_TIMESPAN),
+}
+
+#: frappe.model.no_value_type — layout / non-value controls. Table and Table
+#: MultiSelect are containers: not selectable themselves, but their child fields
+#: are (plan §4.3).
+NO_VALUE_FIELDTYPES = frozenset(
+	{
+		"Section Break",
+		"Column Break",
+		"Tab Break",
+		"HTML",
+		"Table",
+		"Table MultiSelect",
+		"Button",
+		"Image",
+		"Fold",
+		"Heading",
+	}
+)
+TABLE_FIELDTYPES = frozenset({"Table", "Table MultiSelect"})
+
+#: Frappe OFFERS Password with a restricted operator set. We do not — a filter is
+#: an oracle, and an oracle over a stored secret is a secret read. Deviation D2.
+SECRET_FIELDTYPES = frozenset({"Password"})
+
+NUMERIC_FIELDTYPES = frozenset({"Int", "Float", "Currency", "Percent", "Duration", "Rating"})
+#: Frappe's `can_be_null = False` set in db_query.prepare_filter_condition.
+NON_NULLABLE_FIELDTYPES = frozenset({"Check", "Int", "Float", "Currency", "Percent"})
+
+#: Standard fields, mirroring frappe.model.std_fields (model.js:169-183). `name`
+#: is a Link to the DocType itself; docstatus is added only for submittable
+#: DocTypes (frappe.ui.FieldSelect.add_field_option).
+_STANDARD_FIELDS: tuple[dict, ...] = (
+	{"fieldname": "name", "fieldtype": "Link", "label": "ID", "options": "@self"},
+	{"fieldname": "owner", "fieldtype": "Link", "label": "Created By", "options": "User"},
+	{"fieldname": "idx", "fieldtype": "Int", "label": "Index"},
+	{"fieldname": "creation", "fieldtype": "Datetime", "label": "Created On"},
+	{"fieldname": "modified", "fieldtype": "Datetime", "label": "Last Updated On"},
+	{"fieldname": "modified_by", "fieldtype": "Link", "label": "Last Updated By", "options": "User"},
+	{"fieldname": "_user_tags", "fieldtype": "Data", "label": "Tags"},
+	{"fieldname": "_liked_by", "fieldtype": "Data", "label": "Liked By"},
+	{"fieldname": "_comments", "fieldtype": "Text", "label": "Comments"},
+	{"fieldname": "_assign", "fieldtype": "Text", "label": "Assigned To"},
+	{"fieldname": "docstatus", "fieldtype": "Int", "label": "Document Status"},
+)
+
+#: Columns that only exist when the site actually created them. Frappe's db_query
+#: silently DROPS filters on a missing optional field; we fail closed instead
+#: (C08-2), so we must not offer one that has no column.
+_OPTIONAL_COLUMNS = frozenset({"_user_tags", "_comments", "_assign", "_liked_by"})
+
+#: Stored as a JSON array (``["a@x.com", "b@x.com"]``), so `=` can never hit.
+#: Frappe special-cases their DEFAULT to `like` but still offers `=`/`in`; we
+#: restrict them to the like family so the schema cannot promise a match that is
+#: structurally impossible. Deviation D3.
+_JSON_ARRAY_FIELDS = frozenset({"_assign", "_liked_by"})
+_JSON_ARRAY_OPERATORS = (OP_LIKE, OP_NOT_LIKE, OP_IS)
+
+
+def _fallback_sql(fieldtype: str) -> str:
+	"""The ``ifnull(col, <fallback>)`` literal Frappe uses per family. Server
+	authored, never user input."""
+	if fieldtype in NUMERIC_FIELDTYPES or fieldtype == "Check":
+		return "0"
+	if fieldtype == "Date":
+		return "'0001-01-01'"
+	if fieldtype == "Datetime":
+		return "'0001-01-01 00:00:00.000000'"
+	if fieldtype == "Time":
+		return "'00:00:00'"
+	return "''"
+
+
+def default_operator(fieldname: str, fieldtype: str, is_large_table: bool = False) -> str:
+	"""Frappe's ``frappe.ui.filter_utils.get_default_condition`` (filter.js:516-529),
+	copied rather than approximated.
+
+	Plan §5.1's table claimed a ``like`` default for every "text-like" family
+	(Small Text, Long Text, Attach, Phone, Barcode, Color...). Frappe does not:
+	only ``Data`` (and only on a non-large table) defaults to ``like``;
+	Date/Datetime default to ``Between``; EVERYTHING else defaults to ``=``.
+	We follow Frappe. Deviation ledger D5 records the difference.
+	"""
+	if fieldname in _JSON_ARRAY_FIELDS:
+		return OP_LIKE
+	if fieldtype == "Data" and not is_large_table:
+		return OP_LIKE
+	if fieldtype in ("Date", "Datetime"):
+		return OP_BETWEEN
+	return OP_EQ
+
+
+def allowed_operators(fieldname: str, fieldtype: str) -> tuple[str, ...]:
+	"""Valid operators for a field family (Frappe's invalid_condition_map,
+	inverted), narrowed for the JSON-array standard fields."""
+	if fieldname in _JSON_ARRAY_FIELDS:
+		return _JSON_ARRAY_OPERATORS
+	invalid = INVALID_CONDITIONS.get(fieldtype, ())
+	return tuple(c for c in CONDITIONS if c not in invalid)
+
+
+# --------------------------------------------------------------------------- #
+# Schema construction
+# --------------------------------------------------------------------------- #
+def resolve_view(view_key: str) -> list_registry.ListView:
+	"""The registered view, or a closed failure. ``view_key`` is the ONLY thing a
+	client names — never a table, doctype or column."""
+	view = list_registry.get_view(view_key)
+	if not view:
+		_fail(ERR_UNKNOWN_VIEW, _("Unknown list view."))
+	return view
+
+
+def _filterable_root(view: list_registry.ListView) -> str:
+	"""The DocType whose metadata backs this view's catalog, or a closed failure.
+
+	Projections (File Box, Support, Approvals, the agents catalog) and excluded
+	surfaces have no metadata catalog yet: they need a declared projection schema
+	(plan §4.4), which is a later phase. Until then they fail closed rather than
+	silently answering with a root-doctype catalog that does not describe the
+	rows the endpoint actually returns.
+	"""
+	if not view.is_document_list or not view.root_doctype:
+		_fail(
+			ERR_VIEW_NOT_FILTERABLE,
+			_("This list does not support field filters yet."),
+		)
+	return view.root_doctype
+
+
+def _table_columns(doctype: str) -> set[str]:
+	try:
+		return set(frappe.db.get_table_columns(doctype))
+	except Exception:
+		return set()
+
+
+def _is_large_table(meta) -> bool:
+	"""Frappe's own large-table heuristic (Meta.check_if_large_table). Reported in
+	the schema so the UI can explain a changed Data default; it never removes
+	``like`` from the operator list (plan §5.1)."""
+	try:
+		if not hasattr(meta, "is_large_table"):
+			meta.check_if_large_table()
+		return bool(getattr(meta, "is_large_table", False))
+	except Exception:
+		return False
+
+
+def _permlevels(meta, user: str, parenttype: str | None = None) -> set[int]:
+	"""Permlevels this user can READ on ``meta`` (child metas inherit the
+	parent's permissions, exactly as Frappe's Meta.get_permissions does)."""
+	try:
+		return {int(p) for p in meta.get_permlevel_access("read", parenttype=parenttype, user=user)}
+	except Exception:
+		return set()
+
+
+def _entry(
+	doctype: str,
+	df: dict,
+	*,
+	label: str,
+	is_standard: bool = False,
+	is_child: bool = False,
+	is_large_table: bool = False,
+) -> dict:
+	fieldname = df["fieldname"]
+	fieldtype = df["fieldtype"]
+	options = df.get("options") or ""
+	if options == "@self":
+		options = doctype
+	return {
+		"doctype": doctype,
+		"fieldname": fieldname,
+		"label": label,
+		"fieldtype": fieldtype,
+		"options": options,
+		"is_standard": bool(is_standard),
+		"is_child": bool(is_child),
+		"json_array": fieldname in _JSON_ARRAY_FIELDS,
+		"default_operator": default_operator(fieldname, fieldtype, is_large_table),
+		"operators": list(allowed_operators(fieldname, fieldtype)),
+	}
+
+
+def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict]:
+	"""The filterable-field catalog for ``root_doctype`` as seen by ``user``.
+
+	Plan §4: applicable standard fields + every stored, non-virtual,
+	value-bearing main field the caller may read at its permlevel + eligible
+	child-table fields, labelled ``Field (Child DocType)`` and identified by
+	(doctype, fieldname) as Frappe does. Hidden / not-in-list-view fields are NOT
+	excluded: Frappe filters on readable metadata, not on visible columns.
+
+	Exposed as a public helper (not just via the view registry) so the Phase-0
+	audit and the permlevel regression can point it at a DocType directly.
+	"""
+	user = user or frappe.session.user
+	meta = frappe.get_meta(root_doctype)
+	levels = _permlevels(meta, user)
+	if 0 not in levels:
+		# No level-0 read at all: nothing is filterable. Endpoints gate access
+		# separately; this is the belt to that braces.
+		return []
+
+	large = _is_large_table(meta)
+	columns = _table_columns(root_doctype)
+	submittable = bool(getattr(meta, "is_submittable", 0))
+
+	seen: set[tuple[str, str]] = set()
+	main: list[dict] = []
+
+	for std in _STANDARD_FIELDS:
+		fieldname = std["fieldname"]
+		if fieldname == "docstatus" and not submittable:
+			continue
+		if fieldname in _OPTIONAL_COLUMNS and fieldname not in columns:
+			continue
+		if columns and fieldname not in columns and fieldname not in _OPTIONAL_COLUMNS:
+			continue
+		seen.add((root_doctype, fieldname))
+		main.append(
+			_entry(
+				root_doctype,
+				std,
+				label=_(std["label"]),
+				is_standard=True,
+				is_large_table=large,
+			)
+		)
+
+	child_containers: list = []
+	for df in meta.fields:
+		fieldname = df.fieldname or ""
+		if not fieldname:
+			continue
+		if getattr(df, "is_virtual", 0):
+			continue
+		if df.fieldtype in TABLE_FIELDTYPES:
+			if df.options:
+				child_containers.append(df)
+			continue
+		if df.fieldtype in NO_VALUE_FIELDTYPES or df.fieldtype in SECRET_FIELDTYPES:
+			continue
+		if int(df.permlevel or 0) not in levels:
+			continue
+		if columns and fieldname not in columns:
+			continue
+		if (root_doctype, fieldname) in seen:
+			continue
+		seen.add((root_doctype, fieldname))
+		main.append(
+			_entry(
+				root_doctype,
+				{"fieldname": fieldname, "fieldtype": df.fieldtype, "options": df.options},
+				label=_(df.label or fieldname),
+				is_large_table=large,
+			)
+		)
+
+	children: list[dict] = []
+	for container in child_containers:
+		child_dt = container.options
+		try:
+			child_meta = frappe.get_meta(child_dt)
+		except Exception:
+			continue
+		child_levels = _permlevels(child_meta, user, parenttype=root_doctype)
+		if 0 not in child_levels:
+			continue
+		child_columns = _table_columns(child_dt)
+		child_fields = list(child_meta.fields)
+		if container.fieldtype == "Table MultiSelect":
+			# Frappe exposes only the Link value field of a Table MultiSelect.
+			link = next((d for d in child_fields if d.fieldtype == "Link"), None)
+			child_fields = [link] if link else []
+		for df in child_fields:
+			fieldname = df.fieldname or ""
+			if not fieldname:
+				continue
+			if getattr(df, "is_virtual", 0):
+				continue
+			# Nested tables are not recursively filterable (plan §4.3).
+			if df.fieldtype in NO_VALUE_FIELDTYPES or df.fieldtype in SECRET_FIELDTYPES:
+				continue
+			if int(df.permlevel or 0) not in child_levels:
+				continue
+			if child_columns and fieldname not in child_columns:
+				continue
+			if (child_dt, fieldname) in seen:
+				continue
+			seen.add((child_dt, fieldname))
+			children.append(
+				_entry(
+					child_dt,
+					{"fieldname": fieldname, "fieldtype": df.fieldtype, "options": df.options},
+					label=f"{_(df.label or fieldname)} ({_(child_dt)})",
+					is_child=True,
+					is_large_table=large,
+				)
+			)
+
+	main.sort(key=lambda e: (e["label"], e["doctype"], e["fieldname"]))
+	children.sort(key=lambda e: (e["label"], e["doctype"], e["fieldname"]))
+	return main + children
+
+
+def _schema_digest(fields: list[dict]) -> str:
+	payload = json.dumps(
+		[[f["doctype"], f["fieldname"], f["fieldtype"], f["default_operator"], f["operators"]] for f in fields],
+		sort_keys=True,
+	)
+	return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _cache_key(view_key: str, user: str, meta_fingerprint: str) -> str:
+	roles = ",".join(sorted(frappe.get_roles(user)))
+	lang = getattr(frappe.local, "lang", "") or ""
+	digest = hashlib.sha256(f"{roles}|{lang}|{meta_fingerprint}".encode()).hexdigest()[:24]
+	# The user is IN the key, never merely in the digest: a schema is
+	# caller-specific and must never be served to a second identity (plan §6.1).
+	return f"jarvis:list-filter-schema:{view_key}:{user}:{digest}"
+
+
+def _meta_fingerprint(root_doctype: str, user: str) -> str:
+	"""Digest of everything the catalog is derived from.
+
+	Cheap (``get_meta`` is itself cached and is invalidated by Frappe on any
+	Custom Field / Property Setter / DocPerm change), and because it covers the
+	fieldnames, fieldtypes, permlevels and the permission rows, a customization
+	changes the cache KEY. Invalidation correctness over cleverness: we never
+	have to remember to bust anything.
+	"""
+	parts: list[str] = []
+	try:
+		meta = frappe.get_meta(root_doctype)
+	except Exception:
+		return "no-meta"
+	metas = [(root_doctype, meta)]
+	for df in meta.fields:
+		if df.fieldtype in TABLE_FIELDTYPES and df.options:
+			try:
+				metas.append((df.options, frappe.get_meta(df.options)))
+			except Exception:
+				continue
+	for name, m in metas:
+		parts.append(name)
+		parts.append(str(getattr(m, "modified", "")))
+		for df in m.fields:
+			parts.append(f"{df.fieldname}:{df.fieldtype}:{int(df.permlevel or 0)}:{df.options or ''}")
+		for perm in getattr(m, "permissions", []) or []:
+			parts.append(f"P{perm.get('role')}:{int(perm.get('permlevel') or 0)}:{int(perm.get('read') or 0)}")
+	return hashlib.sha256("|".join(parts).encode()).hexdigest()[:24]
+
+
+def get_schema(view_key: str, user: str | None = None) -> dict:
+	"""The caller-specific filter schema for ``view_key`` (cached; see
+	:data:`SCHEMA_CACHE_TTL`). Internal entry point — the whitelisted wrapper is
+	:func:`get_list_filter_schema`."""
+	user = user or frappe.session.user
+	view = resolve_view(view_key)
+	root = _filterable_root(view)
+
+	fingerprint = _meta_fingerprint(root, user)
+	key = _cache_key(view_key, user, fingerprint)
+	try:
+		cached = frappe.cache().get_value(key)
+	except Exception:
+		cached = None
+	if isinstance(cached, dict) and cached.get("contract_version") == CONTRACT_VERSION:
+		return cached
+
+	fields = build_field_catalog(root, user=user)
+	meta = frappe.get_meta(root)
+	schema = {
+		"contract_version": CONTRACT_VERSION,
+		"view_key": view.view_key,
+		"label": view.label,
+		"root_doctype": root,
+		"is_large_table": _is_large_table(meta),
+		"schema_revision": _schema_digest(fields),
+		"limits": {
+			"max_clauses": MAX_CLAUSES,
+			"max_in_values": MAX_IN_VALUES,
+			"max_value_chars": MAX_VALUE_CHARS,
+			"max_page_length": MAX_PAGE_LENGTH,
+		},
+		"fields": fields,
+	}
+	try:
+		frappe.cache().set_value(key, schema, expires_in_sec=SCHEMA_CACHE_TTL)
+	except Exception:
+		pass
+	return schema
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def get_list_filter_schema(view_key: str) -> dict:
+	"""Fields THIS caller may filter ``view_key`` on, with per-field operators.
+
+	Jarvis-user gated. Never trust the browser's copy of this: every clause is
+	re-validated against a freshly resolved schema at query time.
+	"""
+	return get_schema(view_key)
+
+
+def _schema_index(schema: dict) -> dict[tuple[str, str], dict]:
+	return {(f["doctype"], f["fieldname"]): f for f in schema.get("fields") or []}
+
+
+# --------------------------------------------------------------------------- #
+# Clause parsing, validation and normalization
+# --------------------------------------------------------------------------- #
+@dataclass
+class _Clause:
+	index: int
+	entry: dict
+	operator: str
+	value: Any
+
+	@property
+	def dimension(self) -> tuple[str, str]:
+		return (self.entry["doctype"], self.entry["fieldname"])
+
+
+def parse_clauses(clauses: Any) -> list[dict]:
+	"""Accept the wire form (JSON string or list of dicts) and shape-check it."""
+	if clauses in (None, "", b""):
+		return []
+	raw = clauses
+	if isinstance(raw, str):
+		raw = raw.strip()
+		if not raw:
+			return []
+		try:
+			raw = json.loads(raw)
+		except Exception:
+			_fail(ERR_BAD_PAYLOAD, _("Filters are not valid JSON."))
+	if isinstance(raw, dict):
+		_fail(ERR_BAD_PAYLOAD, _("Filters must be a list of conditions."))
+	if not isinstance(raw, list | tuple):
+		_fail(ERR_BAD_PAYLOAD, _("Filters must be a list of conditions."))
+	out: list[dict] = []
+	for item in raw:
+		if not isinstance(item, dict):
+			_fail(ERR_BAD_PAYLOAD, _("Each filter must be an object with doctype, fieldname, operator and value."))
+		out.append(item)
+	return out
+
+
+def _cap_text(value: Any) -> str:
+	text = "" if value is None else str(value)
+	if len(text) > MAX_VALUE_CHARS:
+		_fail(ERR_VALUE_TOO_LONG, _("A filter value may not exceed {0} characters.").format(MAX_VALUE_CHARS))
+	return text
+
+
+def _as_number(entry: dict, value: Any) -> float | int:
+	from frappe.utils import cint, flt
+
+	try:
+		if entry["fieldtype"] in ("Int", "Duration"):
+			return cint(value)
+		return flt(value)
+	except Exception:
+		_fail(ERR_INVALID_VALUE, _("{0} needs a number.").format(entry["label"]))
+
+
+def _select_options(entry: dict) -> list[str] | None:
+	options = entry.get("options") or ""
+	if entry["fieldtype"] != "Select" or not options or options.startswith("link:"):
+		return None
+	return [o.strip() for o in options.split("\n")]
+
+
+def _scalar(entry: dict, operator: str, value: Any) -> Any:
+	"""Normalize ONE scalar value by fieldtype, mirroring db_query's per-family
+	conversions. The result is always a bound parameter, never SQL."""
+	from frappe.utils import get_datetime, get_time, getdate
+
+	fieldtype = entry["fieldtype"]
+	if fieldtype == "Check":
+		text = str(value).strip().lower()
+		if text in ("1", "true", "yes"):
+			return 1
+		if text in ("0", "false", "no"):
+			return 0
+		_fail(ERR_INVALID_VALUE, _("{0} is a checkbox: use 0 or 1.").format(entry["label"]))
+	if fieldtype in NUMERIC_FIELDTYPES:
+		return _as_number(entry, value)
+	if fieldtype == "Date":
+		try:
+			return str(getdate(value))
+		except Exception:
+			_fail(ERR_INVALID_VALUE, _("{0} needs a valid date.").format(entry["label"]))
+	if fieldtype == "Datetime":
+		try:
+			return str(get_datetime(value))
+		except Exception:
+			_fail(ERR_INVALID_VALUE, _("{0} needs a valid date and time.").format(entry["label"]))
+	if fieldtype == "Time":
+		try:
+			return get_time(value).strftime("%H:%M:%S.%f")
+		except Exception:
+			_fail(ERR_INVALID_VALUE, _("{0} needs a valid time.").format(entry["label"]))
+
+	text = _cap_text(value)
+	options = _select_options(entry)
+	if options is not None and operator in (OP_EQ, OP_NE, OP_IN, OP_NOT_IN) and text not in options:
+		# Stricter than Frappe, which happily runs an impossible Select filter.
+		# Deviation D6.
+		_fail(ERR_INVALID_VALUE, _("{0} has no such option.").format(entry["label"]))
+	return text
+
+
+def _like_value(value: Any) -> str:
+	"""Frappe's UI wildcard behaviour (filter.js get_selected_value): wrap the
+	term unless the user already supplied a wildcard. Backslashes are doubled so
+	a literal ``\\`` survives LIKE's own escape processing — exactly what
+	db_query does. ``%``/``_`` typed by the user stay wildcards, as in Frappe."""
+	text = _cap_text(value).replace("\\", "\\\\")
+	if text and not (text.startswith("%") or text.endswith("%")):
+		text = f"%{text}%"
+	return text
+
+
+def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
+	"""Frappe's get_between_date_filter semantics, as bound values rather than
+	interpolated literals: a bare date on a Datetime field expands to
+	[00:00:00, 23:59:59.999999]; a missing bound falls back to today."""
+	import datetime
+
+	from frappe.utils import get_datetime, getdate, nowdate
+
+	if isinstance(value, str):
+		try:
+			parsed = json.loads(value)
+			value = parsed if isinstance(parsed, list) else [value]
+		except Exception:
+			value = [v.strip() for v in value.split(",")]
+	if not isinstance(value, list | tuple):
+		value = [value]
+	frm = value[0] if len(value) >= 1 and value[0] not in (None, "") else nowdate()
+	to = value[1] if len(value) >= 2 and value[1] not in (None, "") else nowdate()
+
+	if entry["fieldtype"] == "Datetime":
+		def _expand(raw, end: bool):
+			if isinstance(raw, str) and " " in raw.strip():
+				return get_datetime(raw)
+			day = getdate(raw)
+			return datetime.datetime.combine(
+				day, datetime.time(23, 59, 59, 999999) if end else datetime.time()
+			)
+
+		try:
+			return str(_expand(frm, False)), str(_expand(to, True))
+		except Exception:
+			_fail(ERR_INVALID_VALUE, _("{0} needs two valid dates.").format(entry["label"]))
+	try:
+		return str(getdate(frm)), str(getdate(to))
+	except Exception:
+		_fail(ERR_INVALID_VALUE, _("{0} needs two valid dates.").format(entry["label"]))
+
+
+def _timespan_bounds(entry: dict, value: Any) -> tuple[str, str]:
+	from frappe.utils.data import get_timespan_date_range
+
+	token = str(value or "").strip().lower()
+	rng = get_timespan_date_range(token) if token else None
+	if not rng:
+		_fail(ERR_INVALID_VALUE, _("Unknown timespan."))
+	return _between_bounds(entry, [str(rng[0]), str(rng[1])])
+
+
+def validate_clauses(schema: dict, clauses: Any) -> list[_Clause]:
+	"""Every rule from plan §6.3 steps 3-6, in order, failing closed."""
+	items = parse_clauses(clauses)
+	if len(items) > MAX_CLAUSES:
+		_fail(ERR_TOO_MANY_CLAUSES, _("At most {0} filters at a time.").format(MAX_CLAUSES))
+
+	index = _schema_index(schema)
+	out: list[_Clause] = []
+	for position, item in enumerate(items):
+		doctype = str(item.get("doctype") or "").strip()
+		fieldname = str(item.get("fieldname") or "").strip()
+		operator = str(item.get("operator") or "").strip()
+		entry = index.get((doctype, fieldname))
+		if not entry:
+			# Unknown, removed, virtual, secret or ABOVE THIS CALLER'S PERMLEVEL.
+			# One message for all of them: a distinguishable "exists but you may
+			# not read it" is itself the oracle we are closing (C08-1).
+			_fail(ERR_UNKNOWN_FIELD, _("That field cannot be filtered on this list."))
+		if not operator:
+			operator = entry["default_operator"]
+		if operator not in entry["operators"]:
+			_fail(ERR_INVALID_OPERATOR, _("{0} does not support that condition.").format(entry["label"]))
+
+		raw = item.get("value")
+		if operator == OP_IS:
+			token = str(raw or "").strip().lower()
+			if token not in ("set", "not set"):
+				_fail(ERR_INVALID_VALUE, _("Use 'set' or 'not set'."))
+			value: Any = token
+		elif operator in (OP_IN, OP_NOT_IN):
+			values = raw
+			if isinstance(values, str):
+				try:
+					parsed = json.loads(values)
+					values = parsed if isinstance(parsed, list) else [parsed]
+				except Exception:
+					values = [v.strip() for v in values.split(",")]
+			if not isinstance(values, list | tuple):
+				values = [values]
+			values = [v for v in values if v not in (None, "")]
+			if not values:
+				_fail(ERR_INVALID_VALUE, _("{0} needs at least one value.").format(entry["label"]))
+			if len(values) > MAX_IN_VALUES:
+				_fail(
+					ERR_TOO_MANY_VALUES,
+					_("At most {0} values in one condition.").format(MAX_IN_VALUES),
+				)
+			value = tuple(_scalar(entry, operator, v) for v in values)
+		elif operator == OP_BETWEEN:
+			value = _between_bounds(entry, raw)
+		elif operator == OP_TIMESPAN:
+			value = _timespan_bounds(entry, raw)
+		elif operator in (OP_LIKE, OP_NOT_LIKE):
+			value = _like_value(raw)
+		else:
+			value = _scalar(entry, operator, raw)
+
+		out.append(_Clause(index=position, entry=entry, operator=operator, value=value))
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# Compilation
+# --------------------------------------------------------------------------- #
+#: Every parameter this module binds is namespaced, so a server-authored
+#: predicate can never collide with (or be shadowed by) a user value.
+USER_PARAM_PREFIX = "jf"
+
+
+def _column(ref: str, fieldname: str) -> str:
+	return f"{ref}.`{fieldname}`"
+
+
+def _compile_clause(clause: _Clause, ref: str) -> tuple[str, dict]:
+	"""One clause → (SQL with named placeholders, params). Identifiers come only
+	from the resolved schema entry; every value is a bound parameter."""
+	entry = clause.entry
+	fieldtype = entry["fieldtype"]
+	fieldname = entry["fieldname"]
+	col = _column(ref, fieldname)
+	op = clause.operator
+	p0 = f"{USER_PARAM_PREFIX}{clause.index}_0"
+	p1 = f"{USER_PARAM_PREFIX}{clause.index}_1"
+
+	if op == OP_IS:
+		# db_query: `is set` → ifnull(col,'') != '' ; `is not set` → = ''
+		return (f"ifnull({col}, '') {'!=' if clause.value == 'set' else '='} ''", {})
+
+	if op in (OP_BETWEEN, OP_TIMESPAN):
+		lo, hi = clause.value
+		return (f"{col} BETWEEN %({p0})s AND %({p1})s", {p0: lo, p1: hi})
+
+	if op in (OP_IN, OP_NOT_IN):
+		sql_op = "IN" if op == OP_IN else "NOT IN"
+		# `in` over a nullable column coalesces exactly as db_query does, so an
+		# empty-string member still matches NULL rows.
+		if fieldtype in NON_NULLABLE_FIELDTYPES or fieldname in ("name", "creation", "modified"):
+			return (f"{col} {sql_op} %({p0})s", {p0: tuple(clause.value)})
+		return (
+			f"ifnull({col}, {_fallback_sql(fieldtype)}) {sql_op} %({p0})s",
+			{p0: tuple(clause.value)},
+		)
+
+	sql_op = "LIKE" if op == OP_LIKE else "NOT LIKE" if op == OP_NOT_LIKE else op
+
+	# db_query's can_be_null rules, mirrored.
+	can_be_null = fieldname not in ("name", "modified", "creation")
+	if fieldtype in NON_NULLABLE_FIELDTYPES:
+		can_be_null = False
+	if op in (OP_GT, OP_GTE) and fieldtype in ("Date", "Datetime"):
+		can_be_null = False
+	if clause.value and op in (OP_EQ, OP_LIKE):
+		can_be_null = False
+
+	if can_be_null:
+		col = f"ifnull({col}, {_fallback_sql(fieldtype)})"
+	return (f"{col} {sql_op} %({p0})s", {p0: clause.value})
+
+
+@dataclass
+class CompiledFilters:
+	"""Validated + compiled client clauses. Immutable once built.
+
+	``fragment()`` can drop one dimension so a facet query reuses the identical
+	WHERE **minus the facet's own dimension** — the C08-3 rule (the shipped
+	approvals ``document_type`` and learning ``domain`` facets both depend on
+	dropping their own filter, which plan §6.3.9's literal "identical WHERE"
+	would have broken).
+	"""
+
+	root_doctype: str
+	ref: str
+	main: list[tuple[tuple[str, str], str]] = field(default_factory=list)
+	child: list[tuple[tuple[str, str], str, str]] = field(default_factory=list)
+	child_alias: dict[str, str] = field(default_factory=dict)
+	params: dict = field(default_factory=dict)
+
+	def is_empty(self) -> bool:
+		return not self.main and not self.child
+
+	def dimensions(self) -> list[tuple[str, str]]:
+		return [dim for dim, _sql in self.main] + [dim for dim, _dt, _sql in self.child]
+
+	def fragment(self, exclude_dimension: tuple[str, str] | None = None) -> str:
+		parts = [sql for dim, sql in self.main if dim != exclude_dimension]
+		groups: dict[str, list[str]] = {}
+		for dim, child_dt, sql in self.child:
+			if dim == exclude_dimension:
+				continue
+			groups.setdefault(child_dt, []).append(sql)
+		for child_dt in sorted(groups):
+			alias = self.child_alias[child_dt]
+			inner = " AND ".join(groups[child_dt])
+			# ONE EXISTS per child DocType with every clause on that child ANDed
+			# INSIDE it: that preserves Frappe's single-join meaning, where two
+			# conditions on one child table must be satisfied by the SAME child
+			# row (C08-2). EXISTS also keeps parents un-duplicated, so total /
+			# has_more / pagination stay correct without count fudging.
+			parts.append(
+				f"EXISTS (SELECT 1 FROM `tab{child_dt}` `{alias}` "
+				f"WHERE `{alias}`.`parent` = {self.ref}.`name` "
+				f"AND `{alias}`.`parenttype` = %({alias}_pt)s AND ({inner}))"
+			)
+		return " AND ".join(parts)
+
+
+def compile_validated(root_doctype: str, clauses: list[_Clause], ref: str) -> CompiledFilters:
+	child_doctypes = sorted({c.entry["doctype"] for c in clauses if c.entry["is_child"]})
+	# Alias per child DocType, assigned from the FULL clause set so a facet's
+	# exclusion cannot renumber (and therefore invalidate) a parameter name.
+	alias_map = {dt: f"jfc{i}" for i, dt in enumerate(child_doctypes)}
+
+	compiled = CompiledFilters(root_doctype=root_doctype, ref=ref, child_alias=alias_map)
+	for dt, alias in alias_map.items():
+		compiled.params[f"{alias}_pt"] = root_doctype
+	for clause in clauses:
+		entry = clause.entry
+		if entry["is_child"]:
+			alias = alias_map[entry["doctype"]]
+			sql, params = _compile_clause(clause, f"`{alias}`")
+			compiled.child.append((clause.dimension, entry["doctype"], sql))
+		else:
+			sql, params = _compile_clause(clause, ref)
+			compiled.main.append((clause.dimension, sql))
+		compiled.params.update(params)
+	return compiled
+
+
+def compile_list_filters(
+	view_key: str,
+	clauses: Any,
+	*,
+	alias: str | None = None,
+	user: str | None = None,
+) -> CompiledFilters:
+	"""Resolve the view, rebuild THIS caller's schema, validate, compile."""
+	schema = get_schema(view_key, user=user)
+	root = schema["root_doctype"]
+	ref = f"`{alias}`" if alias else f"`tab{root}`"
+	return compile_validated(root, validate_clauses(schema, clauses), ref)
+
+
+def compile_filters_v2(
+	view_key: str,
+	clauses: Any,
+	*,
+	alias: str | None = None,
+	user: str | None = None,
+	exclude_dimension: tuple[str, str] | None = None,
+) -> tuple[str, dict]:
+	"""``(sql_fragment, params)`` for an endpoint that assembles its own WHERE.
+
+	The fragment is ``""`` when there are no clauses. Endpoints that also carry a
+	fixed visibility predicate should use :func:`new_query` instead, so the
+	predicate and the user clauses stay structurally separate (C08-5).
+	"""
+	compiled = compile_list_filters(view_key, clauses, alias=alias, user=user)
+	return compiled.fragment(exclude_dimension), dict(compiled.params)
+
+
+# --------------------------------------------------------------------------- #
+# The structural barrier
+# --------------------------------------------------------------------------- #
+class ListFilterQuery:
+	"""Assembles a list WHERE clause from two things that never mix.
+
+	* :meth:`server_condition` — SQL the ENDPOINT AUTHOR wrote (``owner = %(me)s``,
+	  a DocShare id set, a scope predicate) plus its values as named params.
+	  These are the list's non-removable scope: user filters are ANDed inside it
+	  and can never widen it.
+	* :meth:`apply` — client clauses. They go through
+	  :func:`validate_clauses`, so the only thing that survives from the request
+	  is a bound parameter VALUE; identifiers and operators come from the
+	  caller's schema.
+
+	There is no method that appends client text to the server list, and none that
+	appends server SQL to the compiled-user side. ``where()`` is the single
+	junction, and it joins two already-built strings.
+
+	Server-authored ``IN`` lists are deliberately NOT capped by
+	:data:`MAX_IN_VALUES`: that cap exists to bound attacker-controlled payloads,
+	and a legitimate "the 4,000 skills shared with you" list is not one (C08-5).
+	"""
+
+	def __init__(self, view_key: str, *, alias: str | None = None, user: str | None = None):
+		self.view = resolve_view(view_key)
+		self.view_key = self.view.view_key
+		self.user = user or frappe.session.user
+		self.alias = alias
+		self._server_conds: list[str] = []
+		self._server_params: dict = {}
+		self._compiled: CompiledFilters | None = None
+
+	# -- server side ------------------------------------------------------- #
+	def server_condition(self, sql: str, **params: Any) -> ListFilterQuery:
+		"""Add a server-authored predicate. ``sql`` must use named placeholders
+		(``%(name)s``) and must not touch the user parameter namespace."""
+		if "%s" in sql:
+			raise ValueError("server_condition needs named placeholders, not %s")
+		for name in params:
+			if name.startswith(USER_PARAM_PREFIX):
+				raise ValueError(f"'{USER_PARAM_PREFIX}*' is the user parameter namespace: rename {name!r}")
+			if name in self._server_params and self._server_params[name] != params[name]:
+				raise ValueError(f"duplicate server parameter {name!r}")
+		self._server_conds.append(sql)
+		self._server_params.update(params)
+		return self
+
+	# -- user side --------------------------------------------------------- #
+	def apply(self, clauses: Any) -> ListFilterQuery:
+		"""Validate + compile client clauses. Idempotent per query object."""
+		if self._compiled is not None:
+			raise ValueError("filters_v2 already applied to this query")
+		self._compiled = compile_list_filters(
+			self.view_key, clauses, alias=self.alias, user=self.user
+		)
+		return self
+
+	@property
+	def compiled(self) -> CompiledFilters | None:
+		return self._compiled
+
+	def dimensions(self) -> list[tuple[str, str]]:
+		return self._compiled.dimensions() if self._compiled else []
+
+	# -- the single junction ----------------------------------------------- #
+	def where(self, *, exclude_dimension: tuple[str, str] | None = None) -> str:
+		parts = list(self._server_conds)
+		if self._compiled:
+			fragment = self._compiled.fragment(exclude_dimension)
+			if fragment:
+				parts.append(fragment)
+		return " AND ".join(parts) if parts else "1=1"
+
+	def params(self, extra: dict | None = None) -> dict:
+		out = dict(self._server_params)
+		if self._compiled:
+			out.update(self._compiled.params)
+		if extra:
+			out.update(extra)
+		return out
+
+
+def new_query(view_key: str, *, alias: str | None = None, user: str | None = None) -> ListFilterQuery:
+	"""Start a list query for ``view_key`` (see :class:`ListFilterQuery`)."""
+	return ListFilterQuery(view_key, alias=alias, user=user)
+
+
+def apply_filters_v2(
+	view_key: str,
+	clauses: Any,
+	server_conditions: list[tuple[str, dict]] | None = None,
+	*,
+	alias: str | None = None,
+	user: str | None = None,
+) -> ListFilterQuery:
+	"""One-shot :class:`ListFilterQuery` for rows / total / facet reuse.
+
+	``server_conditions`` is a list of ``(sql, params)`` pairs. The returned query
+	answers ``where()`` for the row and count passes and
+	``where(exclude_dimension=...)`` for a facet over its own dimension.
+	"""
+	query = new_query(view_key, alias=alias, user=user)
+	for sql, params in server_conditions or []:
+		query.server_condition(sql, **(params or {}))
+	return query.apply(clauses)
+
+
+# --------------------------------------------------------------------------- #
+# Shared list plumbing (C08-5).
+#
+# `_lk` / `_clamp_page` / `_bool01` / `_load_filters` / `_order_by` were copied
+# into six list modules and had begun to drift. These are the canonical copies;
+# the two pilot endpoints import them, and macros_api keeps private aliases so
+# its existing importers (dashboards_api, app_learning_api) are untouched until
+# their own wave.
+# --------------------------------------------------------------------------- #
+def escape_like(s: str) -> str:
+	"""Escape LIKE wildcards in a free-text SEARCH term (``\\`` is the default
+	escape). Note this is the opposite of :func:`_like_value`: a search box is
+	not a query language, a ``like`` filter clause is."""
+	return (s or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def clamp_page(start, page_length) -> tuple[int, int]:
+	try:
+		start = max(0, int(start or 0))
+	except (TypeError, ValueError):
+		start = 0
+	try:
+		pl = int(page_length or 20)
+	except (TypeError, ValueError):
+		pl = 20
+	return start, max(1, min(pl, MAX_PAGE_LENGTH))
+
+
+def bool01(v) -> int:
+	try:
+		iv = int(v)
+	except (TypeError, ValueError):
+		frappe.throw(_("Filter value must be 0 or 1."))
+	if iv not in (0, 1):
+		frappe.throw(_("Filter value must be 0 or 1."))
+	return iv
+
+
+def load_legacy_filters(filters, allowed: set) -> dict:
+	"""Parse a legacy ``filters`` argument (JSON string or dict), whitelist keys
+	(unknown → throw), and drop empty values (an empty value = 'not filtering';
+	``0`` is kept)."""
+	if isinstance(filters, str):
+		if filters.strip():
+			try:
+				raw = frappe.parse_json(filters)
+			except Exception:
+				raw = {}
+		else:
+			raw = {}
+	else:
+		raw = filters or {}
+	if not isinstance(raw, dict):
+		raw = {}
+	out: dict = {}
+	for k, v in raw.items():
+		if k not in allowed:
+			frappe.throw(_("Unknown filter: {0}").format(k))
+		if v in (None, ""):
+			continue
+		out[k] = v
+	return out
+
+
+def order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, prefix="") -> str:
+	"""Build a safe ORDER BY: only whitelisted columns, direction normalized to
+	asc/desc, a ``name`` tiebreak for stable OFFSET pagination. No user input is
+	ever interpolated (columns come from ``sortable``; dir is a literal)."""
+	col = sortable.get(sort_field or "")
+	if not col:
+		return f"{prefix}`{sortable[default_field]}` {default_dir}, {prefix}`name` asc"
+	d = "desc" if (sort_dir or "").lower() == "desc" else "asc"
+	return f"{prefix}`{col}` {d}, {prefix}`name` asc"

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -231,6 +231,60 @@ INVALID_CONDITIONS: dict[str, tuple[str, ...]] = {
 	"Percent": (OP_LIKE, OP_NOT_LIKE, OP_BETWEEN, OP_IN, OP_NOT_IN, OP_TIMESPAN),
 }
 
+#: Frappe's ``Filter.set_fieldtype`` (filter.js:530-582) rewrites these stored
+#: string-like controls to an EFFECTIVE ``Data`` value control before choosing
+#: conditions, and ``hide_invalid_conditions`` (filter.js:410-413) then picks
+#: ``invalid_condition_map[original_type] || invalid_condition_map[effective]``.
+#: A type WITHOUT its own map row (Small Text, Text, Text Editor, JSON, Dynamic
+#: Link, Attach, Phone, Tag, Comments, Barcode, Read Only, Assign) therefore
+#: inherits Data's ``(Between, Timespan)`` invalid set — the fallback the original
+#: implementation missed (P0-03), so a Small Text ``description`` or a JSON field
+#: was advertising ``Between``/``Timespan`` and the frontend rendered a date
+#: range over a text column.
+#:
+#: Types that DO have their own row (Code, HTML Editor, Markdown Editor, Color,
+#: Password) keep it — ``original_type`` wins in the lookup above — so they are
+#: absent from this map and short-circuit before it. ``Long Text`` is a DELIBERATE
+#: Jarvis addition (deviation D15): Frappe leaves it with no row and no effective
+#: conversion, i.e. it offers ``Between`` on a prose body, which is the exact
+#: non-temporal-date-range nonsense this fix exists to remove.
+_EFFECTIVE_FILTER_FIELDTYPE: dict[str, str] = {
+	ft: "Data"
+	for ft in (
+		"Text",
+		"Small Text",
+		"Text Editor",
+		"Attach",
+		"Attach Image",
+		"Tag",
+		"Phone",
+		"JSON",
+		"Comments",
+		"Barcode",
+		"Dynamic Link",
+		"Read Only",
+		"Assign",
+		"Long Text",  # deviation D15
+	)
+}
+
+
+def invalid_conditions(fieldtype: str) -> tuple[str, ...]:
+	"""Frappe's ``invalid_condition_map[original] || invalid_condition_map[effective]``.
+
+	The original type wins when it has its own row; otherwise a string-like control
+	falls back to its effective ``Data`` row (see :data:`_EFFECTIVE_FILTER_FIELDTYPE`).
+	This is the single source both :func:`allowed_operators` and the golden matrix
+	test read, so schema and test cannot drift.
+	"""
+	if fieldtype in INVALID_CONDITIONS:
+		return INVALID_CONDITIONS[fieldtype]
+	effective = _EFFECTIVE_FILTER_FIELDTYPE.get(fieldtype)
+	if effective:
+		return INVALID_CONDITIONS.get(effective, ())
+	return ()
+
+
 #: frappe.model.no_value_type — layout / non-value controls. Table and Table
 #: MultiSelect are containers: not selectable themselves, but their child fields
 #: are (plan §4.3).
@@ -338,7 +392,7 @@ def allowed_operators(fieldname: str, fieldtype: str) -> tuple[str, ...]:
 	inverted), narrowed for the JSON-array standard fields."""
 	if fieldname in _JSON_ARRAY_FIELDS:
 		return _JSON_ARRAY_OPERATORS
-	invalid = INVALID_CONDITIONS.get(fieldtype, ())
+	invalid = invalid_conditions(fieldtype)
 	return tuple(c for c in CONDITIONS if c not in invalid)
 
 
@@ -506,7 +560,15 @@ def build_field_catalog(
 		if getattr(df, "is_virtual", 0):
 			continue
 		if df.fieldtype in TABLE_FIELDTYPES:
-			if df.options:
+			# A Table field is the PERMISSION BOUNDARY around its child rows, not a
+			# mere layout control (P0-02). Discovering its children when the caller
+			# cannot read the container itself — its own permlevel is above the
+			# caller, or the endpoint withholds it via excluded_fields — turns a
+			# readable child field into an oracle over data the container hides.
+			# Both checks run BEFORE the container joins child_containers, so a
+			# withheld container suppresses its entire subtree (the excluded-field
+			# check used to sit after the `continue`, so it never reached a Table).
+			if df.options and fieldname not in excluded_main and int(df.permlevel or 0) in levels:
 				child_containers.append(df)
 			continue
 		if df.fieldtype in NO_VALUE_FIELDTYPES or df.fieldtype in SECRET_FIELDTYPES:
@@ -577,12 +639,35 @@ def build_field_catalog(
 	return main + children
 
 
-def _schema_digest(fields: list[dict]) -> str:
+def _schema_digest(fields: list[dict], limits: dict | None = None) -> str:
+	"""A revision over the FULL response contract, not a subset (P1-10).
+
+	The public ``schema_revision`` must change whenever anything the client renders
+	from the schema changes, or a caching/ETag consumer would serve a stale panel.
+	The old digest hashed only (doctype, fieldname, fieldtype, default_operator,
+	operators), so a Select-option edit, a Link-target change, a relabel, a
+	standard/child marker flip or a limits change all returned the SAME revision.
+	Hash every field key the wire carries, plus the limits block.
+	"""
 	payload = json.dumps(
-		[
-			[f["doctype"], f["fieldname"], f["fieldtype"], f["default_operator"], f["operators"]]
-			for f in fields
-		],
+		{
+			"fields": [
+				[
+					f["doctype"],
+					f["fieldname"],
+					f["label"],
+					f["fieldtype"],
+					f["options"],
+					f["default_operator"],
+					f["operators"],
+					f["is_standard"],
+					f["is_child"],
+					f["json_array"],
+				]
+				for f in fields
+			],
+			"limits": limits or {},
+		},
 		sort_keys=True,
 	)
 	return hashlib.sha256(payload.encode()).hexdigest()[:16]
@@ -686,19 +771,20 @@ def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 
 	fields = build_field_catalog(root, user=user, view=view)
 	meta = frappe.get_meta(root)
+	limits = {
+		"max_clauses": MAX_CLAUSES,
+		"max_in_values": MAX_IN_VALUES,
+		"max_value_chars": MAX_VALUE_CHARS,
+		"max_page_length": MAX_PAGE_LENGTH,
+	}
 	schema = {
 		"contract_version": CONTRACT_VERSION,
 		"view_key": view.view_key,
 		"label": view.label,
 		"root_doctype": root,
 		"is_large_table": _is_large_table(meta),
-		"schema_revision": _schema_digest(fields),
-		"limits": {
-			"max_clauses": MAX_CLAUSES,
-			"max_in_values": MAX_IN_VALUES,
-			"max_value_chars": MAX_VALUE_CHARS,
-			"max_page_length": MAX_PAGE_LENGTH,
-		},
+		"schema_revision": _schema_digest(fields, limits),
+		"limits": limits,
 		"fields": fields,
 	}
 	try:
@@ -706,6 +792,103 @@ def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 	except Exception:
 		pass
 	return schema
+
+
+# --------------------------------------------------------------------------- #
+# Runtime capability flag + structural telemetry (P1-05).
+# --------------------------------------------------------------------------- #
+#: Site-config key holding the list of MIGRATED view keys to roll BACK to legacy
+#: transport, e.g. ``"jarvis_list_filters_v2_off": ["triggers"]`` in
+#: ``site_config.json``. Absent / empty ⇒ every migrated view is ON — the flag is
+#: opt-OUT so a new migration is live by default and the switch is only ever a
+#: rollback. Mirrors the existing ``frappe.conf.get(FLAG)`` pattern
+#: (admission.py). A per-view field would need a DocType write path for what is a
+#: rare operator action, so the site-config map is the smaller honest mechanism.
+CONF_KEY_V2_OFF = "jarvis_list_filters_v2_off"
+
+
+def _disabled_views() -> set[str]:
+	off = frappe.conf.get(CONF_KEY_V2_OFF) or []
+	if isinstance(off, str):
+		off = [off]
+	try:
+		return {str(v) for v in off}
+	except TypeError:
+		return set()
+
+
+def view_filters_enabled(view_key: str) -> bool:
+	"""Whether ``view_key`` serves the ``filters_v2`` schema right now (default ON).
+
+	OFF is a rollback: the schema endpoint declines, so the client falls back to
+	legacy transport WITHOUT the Filter mandate disappearing (the button still
+	renders; it just cannot load a catalog). The compile path deliberately does
+	NOT consult this — a clause a stale client still sends is answered or coded,
+	never silently dropped (do-not-regress rule 8).
+	"""
+	return view_key not in _disabled_views()
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def list_filters_capabilities() -> dict:
+	"""Per-view ``{view_key: enabled}`` for every MIGRATED view (P1-05).
+
+	Lets a surface decide transport at mount without probing the schema endpoint
+	first. Jarvis-user gated; carries no field data, only the capability map.
+	"""
+	return {v.view_key: view_filters_enabled(v.view_key) for v in list_registry.filterable_views()}
+
+
+def _duration_bucket(ms: float) -> str:
+	"""Coarse, value-free duration bucket for telemetry."""
+	if ms < 5:
+		return "<5ms"
+	if ms < 25:
+		return "<25ms"
+	if ms < 100:
+		return "<100ms"
+	if ms < 500:
+		return "<500ms"
+	return ">=500ms"
+
+
+def _filter_logger():
+	import logging
+
+	logger = frappe.logger("jarvis.chat.list_filters", allow_site=True)
+	if logger.level == 0 or logger.level > logging.INFO:
+		logger.setLevel(logging.INFO)
+	return logger
+
+
+def emit_filter_telemetry(
+	view_key: str,
+	clauses: list[_Clause],
+	*,
+	duration_ms: float,
+	error_code: str | None = None,
+) -> None:
+	"""Bounded, PII-free structural telemetry (P1-05): view, per-clause
+	fieldtype+operator, whether a child clause was used, a duration BUCKET and the
+	stable error code — never a filter VALUE (do-not-regress rule 4). Mirrors the
+	latency logger: its own INFO logger, so it is visible without flipping levels
+	and does not make any other logger chattier."""
+	try:
+		shape = [{"ft": c.entry["fieldtype"], "op": c.operator} for c in clauses]
+		record = {
+			"view": view_key,
+			"clauses": len(clauses),
+			"child": any(c.entry.get("is_child") for c in clauses),
+			"shape": shape,
+			"bucket": _duration_bucket(duration_ms),
+		}
+		if error_code:
+			record["error"] = error_code
+		_filter_logger().info("list_filter %s", json.dumps(record, sort_keys=True))
+	except Exception:
+		# Telemetry must never break a query.
+		pass
 
 
 @frappe.whitelist()
@@ -721,9 +904,11 @@ def get_list_filter_schema(view_key: str) -> dict:
 	registered-but-unmigrated view would otherwise hand a client a perfectly
 	valid schema it has nowhere to send — the UI would render a filter panel
 	whose every clause the list endpoint ignores, which is worse than no panel.
+	A view rolled back via the runtime flag (P1-05) declines the same way, so the
+	client degrades to legacy transport with the Filter action still visible.
 	"""
 	view = resolve_view(view_key)
-	if view.status != list_registry.MIGRATED:
+	if view.status != list_registry.MIGRATED or not view_filters_enabled(view_key):
 		_fail(ERR_VIEW_NOT_FILTERABLE, _("This list does not support field filters yet."))
 	return get_schema(view_key)
 
@@ -792,14 +977,40 @@ def _cap_text(value: Any) -> str:
 
 
 def _as_number(entry: dict, value: Any) -> float | int:
+	"""Parse a numeric filter value, failing CLOSED on garbage (P1-01).
+
+	``frappe.utils.cint``/``flt`` do NOT raise on a malformed string — ``flt("abc")``
+	is ``0.0`` and ``cint("abc")`` is ``0`` — so the old ``try/except`` was inert for
+	the common case: ``"abc"`` silently became ``0`` and answered a different
+	question, and ``float('inf')``/``nan`` reached the DB binder as a driver error
+	outside the stable filter-error contract. So we parse strictly here.
+
+	- A BLANK value stays ``0`` at Frappe parity (``flt("")``==0), a deliberate
+	  documented deviation (D14): a blank numeric row is held PENDING on the client
+	  and never reaches the wire, so this only fires for a hand-edited URL / direct
+	  API call, where ``0`` is the least-surprising legacy behaviour.
+	- A nonblank value that is not a finite number is rejected with the stable
+	  ``list_filter_invalid_value`` code.
+	- ``Int``/``Duration`` keep Frappe's ``cint`` truncation of a fractional value
+	  (``cint("3.7")``==3) once it is known finite — documented, not silent.
+	"""
+	import math
+
 	from frappe.utils import cint, flt
 
+	if value is None or (isinstance(value, str) and not value.strip()):
+		return 0  # blank → 0, Frappe parity (D14)
+
 	try:
-		if entry["fieldtype"] in ("Int", "Duration"):
-			return cint(value)
-		return flt(value)
-	except Exception:
+		probe = float(value)
+	except (TypeError, ValueError):
 		_fail(ERR_INVALID_VALUE, _("{0} needs a number.").format(entry["label"]))
+	if not math.isfinite(probe):
+		_fail(ERR_INVALID_VALUE, _("{0} needs a finite number.").format(entry["label"]))
+
+	if entry["fieldtype"] in ("Int", "Duration"):
+		return cint(value)  # finite → cint truncates any fraction (Frappe parity)
+	return flt(value)
 
 
 def _select_options(entry: dict) -> list[str] | None:
@@ -1191,8 +1402,23 @@ def compile_list_filters(
 	ref = f"`{alias}`" if alias else f"`tab{root}`"
 	if not items:
 		return CompiledFilters(root_doctype=root, ref=ref)
+	import time
+
+	started = time.monotonic()
 	schema = get_schema(view_key, user=user)
-	return compile_validated(root, validate_clauses(schema, items), ref)
+	try:
+		validated = validate_clauses(schema, items)
+	except ListFilterError as e:
+		emit_filter_telemetry(
+			view_key,
+			[],
+			duration_ms=(time.monotonic() - started) * 1000,
+			error_code=getattr(e, "filter_error_code", ERR_BAD_PAYLOAD),
+		)
+		raise
+	compiled = compile_validated(root, validated, ref)
+	emit_filter_telemetry(view_key, validated, duration_ms=(time.monotonic() - started) * 1000)
+	return compiled
 
 
 def compile_filters_v2(

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -93,6 +93,14 @@ SCHEMA_CACHE_TTL = 300
 # --------------------------------------------------------------------------- #
 ERR_UNKNOWN_VIEW = "list_filter_unknown_view"
 ERR_VIEW_NOT_FILTERABLE = "list_filter_view_not_filterable"
+#: The view IS migrated, but an operator rolled it back to legacy transport via the
+#: runtime kill switch (``jarvis_list_filters_v2_off``). Distinct from
+#: ERR_VIEW_NOT_FILTERABLE ("never migrated") so the client can be HONEST about why
+#: the panel is unavailable: a rolled-back list says "filters are turned off for
+#: this list" with no retry (retrying cannot succeed until an operator flips the
+#: flag back), whereas an unmigrated one says "not supported yet". Conflating the
+#: two left a shared link's filters silently un-applied with no truthful notice.
+ERR_VIEW_ROLLED_BACK = "list_filter_view_rolled_back"
 ERR_BAD_PAYLOAD = "list_filter_bad_payload"
 ERR_UNKNOWN_FIELD = "list_filter_unknown_field"
 ERR_INVALID_OPERATOR = "list_filter_invalid_operator"
@@ -269,6 +277,12 @@ _EFFECTIVE_FILTER_FIELDTYPE: dict[str, str] = {
 }
 
 
+#: The ONLY families for which a date/time range (``Between``) or a rolling window
+#: (``Timespan``) is meaningful. Defined here (not only down in the value path) so
+#: :func:`allowed_operators` can enforce the temporal-only rule POSITIVELY.
+_TEMPORAL_FIELDTYPES = frozenset({"Date", "Datetime", "Time"})
+
+
 def invalid_conditions(fieldtype: str) -> tuple[str, ...]:
 	"""Frappe's ``invalid_condition_map[original] || invalid_condition_map[effective]``.
 
@@ -389,10 +403,22 @@ def default_operator(fieldname: str, fieldtype: str, is_large_table: bool = Fals
 
 def allowed_operators(fieldname: str, fieldtype: str) -> tuple[str, ...]:
 	"""Valid operators for a field family (Frappe's invalid_condition_map,
-	inverted), narrowed for the JSON-array standard fields."""
+	inverted), narrowed for the JSON-array standard fields.
+
+	``Between``/``Timespan`` are advertised ONLY for the explicitly temporal
+	families (S5). Frappe's invalid map removes them from the types it knows, but a
+	fieldtype with NO map row and no effective-Data conversion — ``Duration``,
+	``Autocomplete``, ``Geolocation``, any future control — used to inherit the
+	empty invalid set and so advertised the whole vocabulary, offering a date range
+	over a duration. The rule is now stated in the positive: a range operator is a
+	temporal operator, full stop, whether or not Frappe happened to enumerate the
+	type."""
 	if fieldname in _JSON_ARRAY_FIELDS:
 		return _JSON_ARRAY_OPERATORS
-	invalid = invalid_conditions(fieldtype)
+	invalid = set(invalid_conditions(fieldtype))
+	if fieldtype not in _TEMPORAL_FIELDTYPES:
+		invalid.add(OP_BETWEEN)
+		invalid.add(OP_TIMESPAN)
 	return tuple(c for c in CONDITIONS if c not in invalid)
 
 
@@ -462,6 +488,7 @@ def _entry(
 	is_standard: bool = False,
 	is_child: bool = False,
 	is_large_table: bool = False,
+	parentfields: tuple[str, ...] = (),
 ) -> dict:
 	fieldname = df["fieldname"]
 	fieldtype = df["fieldtype"]
@@ -479,6 +506,13 @@ def _entry(
 		"json_array": fieldname in _JSON_ARRAY_FIELDS,
 		"default_operator": default_operator(fieldname, fieldtype, is_large_table),
 		"operators": list(allowed_operators(fieldname, fieldtype)),
+		# M2: the READABLE containers (Table fieldnames on the root) through which
+		# this child DocType is reached. Empty for main/standard fields. The
+		# compiler binds ``parentfield IN (these)`` inside the child EXISTS so a
+		# clause via a readable container can never match rows attached to a
+		# container the caller may NOT read (permlevel-raised or view-excluded) —
+		# the same child DocType, same parent, distinguished only by parentfield.
+		"parentfields": list(parentfields),
 	}
 
 
@@ -591,6 +625,19 @@ def build_field_catalog(
 			)
 		)
 
+	# M2: the readable containers grouped by child DocType. When one child DocType
+	# is reached through several Table fields, only the ones that survived the
+	# permlevel / excluded checks above are here — so a floor user who can read
+	# container A but not container B sees {child_dt: ["a"]}, and the compiler will
+	# bind ``parentfield IN ('a')``, never matching B's rows. A System Manager who
+	# reads both sees {child_dt: ["a", "b"]} and keeps matching either, which is the
+	# pre-fix behaviour for the both-readable case.
+	readable_parentfields: dict[str, list[str]] = {}
+	for container in child_containers:
+		readable_parentfields.setdefault(container.options, []).append(container.fieldname)
+	for child_dt in readable_parentfields:
+		readable_parentfields[child_dt] = sorted(set(readable_parentfields[child_dt]))
+
 	children: list[dict] = []
 	for container in child_containers:
 		child_dt = container.options
@@ -631,6 +678,7 @@ def build_field_catalog(
 					label=f"{_(df.label or fieldname)} ({_(child_dt)})",
 					is_child=True,
 					is_large_table=large,
+					parentfields=tuple(readable_parentfields.get(child_dt, ())),
 				)
 			)
 
@@ -639,36 +687,32 @@ def build_field_catalog(
 	return main + children
 
 
-def _schema_digest(fields: list[dict], limits: dict | None = None) -> str:
-	"""A revision over the FULL response contract, not a subset (P1-10).
+def _schema_digest(fields: list[dict], limits: dict | None = None, header: dict | None = None) -> str:
+	"""A revision over the FULL response contract, not a subset (P1-10 / S8).
 
 	The public ``schema_revision`` must change whenever anything the client renders
-	from the schema changes, or a caching/ETag consumer would serve a stale panel.
-	The old digest hashed only (doctype, fieldname, fieldtype, default_operator,
-	operators), so a Select-option edit, a Link-target change, a relabel, a
-	standard/child marker flip or a limits change all returned the SAME revision.
-	Hash every field key the wire carries, plus the limits block.
+	(or the server compiles) from the schema changes, or a caching/ETag consumer
+	would serve a stale panel. Rather than hand-list the field keys — which drifts
+	the instant a new one is added (``parentfields`` is the live example) — this
+	serializes each field dict WHOLE, so every wire key is covered automatically
+	and nothing can be silently omitted. The field-picker ``group`` the client
+	renders is derived purely from ``is_child``+``doctype`` (filterModel
+	``fieldOptions``), both of which are hashed, so it too is covered.
+
+	``header`` carries the schema-LEVEL keys that also decide what the client
+	renders — ``label`` (picker heading), ``root_doctype``, ``is_large_table`` (the
+	changed-Data-default note) and ``contract_version`` — none of which live on a
+	field. Include them, or a relabelled view or a bumped contract would keep a
+	stale revision.
 	"""
 	payload = json.dumps(
 		{
-			"fields": [
-				[
-					f["doctype"],
-					f["fieldname"],
-					f["label"],
-					f["fieldtype"],
-					f["options"],
-					f["default_operator"],
-					f["operators"],
-					f["is_standard"],
-					f["is_child"],
-					f["json_array"],
-				]
-				for f in fields
-			],
+			"fields": list(fields),
 			"limits": limits or {},
+			"header": header or {},
 		},
 		sort_keys=True,
+		default=str,
 	)
 	return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
@@ -777,13 +821,20 @@ def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 		"max_value_chars": MAX_VALUE_CHARS,
 		"max_page_length": MAX_PAGE_LENGTH,
 	}
+	is_large_table = _is_large_table(meta)
+	header = {
+		"contract_version": CONTRACT_VERSION,
+		"label": view.label,
+		"root_doctype": root,
+		"is_large_table": is_large_table,
+	}
 	schema = {
 		"contract_version": CONTRACT_VERSION,
 		"view_key": view.view_key,
 		"label": view.label,
 		"root_doctype": root,
-		"is_large_table": _is_large_table(meta),
-		"schema_revision": _schema_digest(fields, limits),
+		"is_large_table": is_large_table,
+		"schema_revision": _schema_digest(fields, limits, header),
 		"limits": limits,
 		"fields": fields,
 	}
@@ -807,14 +858,58 @@ def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 CONF_KEY_V2_OFF = "jarvis_list_filters_v2_off"
 
 
+#: How long a flag-misconfiguration Error Log stays deduped. A malformed kill
+#: switch breaks EVERY list load on EVERY migrated view, so an unguarded log_error
+#: would flood the Error Log with one row per request and bury the entry that
+#: explains it.
+FLAG_MISCONFIG_LOG_TTL = 900
+
+
 def _disabled_views() -> set[str]:
-	off = frappe.conf.get(CONF_KEY_V2_OFF) or []
-	if isinstance(off, str):
-		off = [off]
-	try:
-		return {str(v) for v in off}
-	except TypeError:
+	"""View keys rolled back to legacy transport — a KILL SWITCH that fails CLOSED.
+
+	The valid shapes are a list/tuple of view-key strings, a single view-key
+	string, or absent/empty (⇒ nothing disabled, every migrated view ON). ANYTHING
+	else is a misconfiguration, and a kill switch must never fail OPEN on one: the
+	old code did ``{str(v) for v in off}`` inside a ``try``, so
+	``"jarvis_list_filters_v2_off": true`` (a bool) raised ``TypeError`` and fell
+	through to ``set()`` — silently re-enabling every view the operator meant to
+	turn off. Now a malformed value disables EVERY migrated view and logs once,
+	loudly. Over-disabling is the safe direction for a rollback switch; a typo can
+	never silently re-enable.
+	"""
+	off = frappe.conf.get(CONF_KEY_V2_OFF)
+	if off in (None, "", [], ()):
 		return set()
+	if isinstance(off, str):
+		return {off} if off else set()
+	if isinstance(off, list | tuple) and all(isinstance(v, str) and v for v in off):
+		return set(off)
+	# Malformed: fail closed — disable every migrated view.
+	_log_flag_misconfig(off)
+	return {v.view_key for v in list_registry.filterable_views()}
+
+
+def _log_flag_misconfig(value: Any) -> None:
+	key = "jarvis:list-filter-flag-misconfig"
+	try:
+		cache = frappe.cache()
+		if cache.get_value(key):
+			return
+		cache.set_value(key, "1", expires_in_sec=FLAG_MISCONFIG_LOG_TTL)
+	except Exception:
+		pass
+	try:
+		frappe.log_error(
+			title="list filter kill-switch misconfigured",
+			message=(
+				f"{CONF_KEY_V2_OFF} must be a list of view-key strings (or one string); "
+				f"got {type(value).__name__!r}: {value!r}. Failing CLOSED — every migrated "
+				f"list view is rolled back to legacy transport until this is corrected."
+			),
+		)
+	except Exception:
+		pass
 
 
 def view_filters_enabled(view_key: str) -> bool:
@@ -908,8 +1003,15 @@ def get_list_filter_schema(view_key: str) -> dict:
 	client degrades to legacy transport with the Filter action still visible.
 	"""
 	view = resolve_view(view_key)
-	if view.status != list_registry.MIGRATED or not view_filters_enabled(view_key):
+	if view.status != list_registry.MIGRATED:
+		# Never migrated: the panel genuinely has nowhere to send a clause.
 		_fail(ERR_VIEW_NOT_FILTERABLE, _("This list does not support field filters yet."))
+	if not view_filters_enabled(view_key):
+		# Migrated, then rolled back by the runtime kill switch. A DISTINCT code so
+		# the client tells the truth ("turned off", no retry) instead of "not
+		# supported yet" — and a shared link's filters get an honest "not applied"
+		# notice rather than silently vanishing behind an active-looking badge.
+		_fail(ERR_VIEW_ROLLED_BACK, _("Filters are turned off for this list."))
 	return get_schema(view_key)
 
 
@@ -989,28 +1091,32 @@ def _as_number(entry: dict, value: Any) -> float | int:
 	  documented deviation (D14): a blank numeric row is held PENDING on the client
 	  and never reaches the wire, so this only fires for a hand-edited URL / direct
 	  API call, where ``0`` is the least-surprising legacy behaviour.
+	- Thousands separators are stripped BEFORE the strict parse, exactly as
+	  ``frappe.utils.flt`` does (``flt`` runs ``s.replace(",", "")``), so a
+	  human-shaped ``"10,500.50"`` is a valid number rather than a rejected one
+	  (D14-b). The stripped value is what we validate AND what we bind — one parser,
+	  so the number the DB sees is the number we proved finite.
 	- A nonblank value that is not a finite number is rejected with the stable
 	  ``list_filter_invalid_value`` code.
-	- ``Int``/``Duration`` keep Frappe's ``cint`` truncation of a fractional value
-	  (``cint("3.7")``==3) once it is known finite — documented, not silent.
+	- ``Int``/``Duration`` truncate a fractional value toward zero once it is known
+	  finite (``int(3.7)``==3, Frappe's ``cint`` parity) — documented, not silent.
 	"""
 	import math
-
-	from frappe.utils import cint, flt
 
 	if value is None or (isinstance(value, str) and not value.strip()):
 		return 0  # blank → 0, Frappe parity (D14)
 
+	cleaned = value.replace(",", "").strip() if isinstance(value, str) else value
 	try:
-		probe = float(value)
+		probe = float(cleaned)
 	except (TypeError, ValueError):
 		_fail(ERR_INVALID_VALUE, _("{0} needs a number.").format(entry["label"]))
 	if not math.isfinite(probe):
 		_fail(ERR_INVALID_VALUE, _("{0} needs a finite number.").format(entry["label"]))
 
 	if entry["fieldtype"] in ("Int", "Duration"):
-		return cint(value)  # finite → cint truncates any fraction (Frappe parity)
-	return flt(value)
+		return int(probe)  # finite → truncate any fraction toward zero (cint parity)
+	return probe
 
 
 def _select_options(entry: dict) -> list[str] | None:
@@ -1018,9 +1124,6 @@ def _select_options(entry: dict) -> list[str] | None:
 	if entry["fieldtype"] != "Select" or not options or options.startswith("link:"):
 		return None
 	return [o.strip() for o in options.split("\n")]
-
-
-_TEMPORAL_FIELDTYPES = frozenset({"Date", "Datetime", "Time"})
 
 
 def _is_blank_temporal(value: Any) -> bool:
@@ -1114,6 +1217,13 @@ def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
 
 	from frappe.utils import get_datetime, getdate
 
+	# S5 (compile-time belt to the schema's suspenders): a range is temporal-only.
+	# ``allowed_operators`` already withholds ``Between`` from a non-temporal field,
+	# so validate_clauses rejects such a clause with ERR_INVALID_OPERATOR before it
+	# reaches here — but a future caller that bypasses the schema must not be able
+	# to run a date range over a number/duration/text column either.
+	if entry["fieldtype"] not in _TEMPORAL_FIELDTYPES:
+		_fail(ERR_INVALID_OPERATOR, _("{0} does not support a range.").format(entry["label"]))
 	_guard_length(value)
 	if isinstance(value, str):
 		try:
@@ -1154,6 +1264,9 @@ def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
 def _timespan_bounds(entry: dict, value: Any) -> tuple[str, str]:
 	from frappe.utils.data import get_timespan_date_range
 
+	# S5: a rolling window is temporal-only, same rule as Between.
+	if entry["fieldtype"] not in _TEMPORAL_FIELDTYPES:
+		_fail(ERR_INVALID_OPERATOR, _("{0} does not support a timespan.").format(entry["label"]))
 	token = str(value or "").strip().lower()
 	rng = get_timespan_date_range(token) if token else None
 	if not rng:
@@ -1348,10 +1461,20 @@ class CompiledFilters:
 			# conditions on one child table must be satisfied by the SAME child
 			# row (C08-2). EXISTS also keeps parents un-duplicated, so total /
 			# has_more / pagination stay correct without count fudging.
+			#
+			# ``parentfield IN (...)`` (M2) scopes the subquery to the containers the
+			# caller may READ. Without it, EXISTS matched ANY row of this child
+			# DocType with the same parent+parenttype — including rows attached to a
+			# sibling Table field the caller cannot read (permlevel-raised or
+			# view-excluded), leaking exactly what the container permission hides. The
+			# same-row semantics survive: a matching child row has ONE parentfield, so
+			# two clauses in this EXISTS are still satisfied by the same row under the
+			# same readable container.
 			parts.append(
 				f"EXISTS (SELECT 1 FROM `tab{child_dt}` `{alias}` "
 				f"WHERE `{alias}`.`parent` = {self.ref}.`name` "
-				f"AND `{alias}`.`parenttype` = %({alias}_pt)s AND ({inner}))"
+				f"AND `{alias}`.`parenttype` = %({alias}_pt)s "
+				f"AND `{alias}`.`parentfield` IN %({alias}_pf)s AND ({inner}))"
 			)
 		return parts
 
@@ -1363,8 +1486,17 @@ def compile_validated(root_doctype: str, clauses: list[_Clause], ref: str) -> Co
 	alias_map = {dt: f"jfc{i}" for i, dt in enumerate(child_doctypes)}
 
 	compiled = CompiledFilters(root_doctype=root_doctype, ref=ref, child_alias=alias_map)
+	# M2: the readable containers per child DocType, taken from the resolved schema
+	# entries (all clauses on one child_dt carry the same set). Bound as an IN list
+	# so the EXISTS can only ever see rows under a container the caller may read.
+	parentfields_by_dt: dict[str, tuple[str, ...]] = {}
+	for clause in clauses:
+		if clause.entry["is_child"]:
+			dt = clause.entry["doctype"]
+			parentfields_by_dt[dt] = tuple(sorted(clause.entry.get("parentfields") or ()))
 	for dt, alias in alias_map.items():
 		compiled.params[f"{alias}_pt"] = root_doctype
+		compiled.params[f"{alias}_pf"] = parentfields_by_dt.get(dt, ())
 	for clause in clauses:
 		entry = clause.entry
 		if entry["is_child"]:

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -29,13 +29,33 @@ author wrote (plus its values as bound params), :meth:`~ListFilterQuery.apply`
 takes client clauses and can only ever turn them into bound parameters. The two
 meet exactly once, as already-built strings, in :meth:`~ListFilterQuery.where`.
 
+**Every migrating endpoint wears the same error boundary.** A stable code is
+worthless if it dies inside the Python process, so :func:`filter_errors_to_envelope`
+converts a :class:`ListFilterError` into the repo's ``{ok: false, error: {code,
+message}}`` envelope (the ``dashboards_api._error_envelope`` shape) with a
+deliberate 4xx status, and every list endpoint that accepts ``filters_v2``
+declares it::
+
+    @frappe.whitelist()
+    @require_jarvis_user
+    @filter_errors_to_envelope
+    def list_widgets_page(..., filters_v2: str | list | None = None) -> dict:
+
+Order matters: the access gate stays OUTSIDE (a PermissionError is a different
+contract and must keep its 403), and the wrapper only covers the body. The 4xx is
+what stops a client from reading a rejected filter as an empty result set — the
+one failure mode a filtered list must never have.
+
 Deliberate deviations from Frappe parity are documented, with rationale, in
-``jarvis/chat/LIST-FILTERS-DEVIATIONS.md``. Reviewers cite that file; the future
-golden-matrix test (plan §11.5) is written against it.
+``jarvis/chat/LIST-FILTERS-DEVIATIONS.md``, which also carries the
+MIGRATION-CHECKLIST every surface works through before it flips to ``MIGRATED``.
+Reviewers cite that file; the future golden-matrix test (plan §11.5) is written
+against it.
 """
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 from dataclasses import dataclass, field
@@ -80,6 +100,19 @@ ERR_INVALID_VALUE = "list_filter_invalid_value"
 ERR_TOO_MANY_CLAUSES = "list_filter_too_many_clauses"
 ERR_TOO_MANY_VALUES = "list_filter_too_many_values"
 ERR_VALUE_TOO_LONG = "list_filter_value_too_long"
+#: The schema could not be built at all (metadata missing, table gone). Distinct
+#: from "your clause is wrong": it is OUR fault, and it fails closed rather than
+#: reaching the client as a raw 500 with a traceback-shaped message.
+ERR_SCHEMA_UNAVAILABLE = "list_filter_schema_unavailable"
+
+#: A malformed payload is a bad REQUEST; everything else is a well-formed request
+#: carrying an invalid filter, which is Frappe's ValidationError status; and an
+#: unbuildable schema is ours, not the caller's.
+_HTTP_STATUS_BY_CODE: dict[str, int] = {
+	ERR_BAD_PAYLOAD: 400,
+	ERR_SCHEMA_UNAVAILABLE: 503,
+}
+_DEFAULT_ERROR_STATUS = 417
 
 
 class ListFilterError(frappe.ValidationError):
@@ -96,6 +129,43 @@ def _fail(code: str, message: str) -> None:
 	# msgprint(raise_exception=<instance>) keeps the instance (and therefore the
 	# code) while still populating `messages[0]` for the SPA's error surface.
 	frappe.msgprint(message, raise_exception=err, title=_("Filter"), indicator="red")
+
+
+def error_envelope(code: str, message: str) -> dict:
+	"""The repo's ``{ok: false, error: {code, message}}`` shape (same as
+	``dashboards_api._error_envelope``)."""
+	return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def filter_errors_to_envelope(fn):
+	"""Endpoint boundary: a :class:`ListFilterError` becomes the ``{ok: false,
+	error: {code, message}}`` envelope with a deliberate 4xx/5xx status.
+
+	Without this the stable codes never leave the Python process — Frappe would
+	render the ValidationError as a generic 417 whose body carries only the
+	human message, so a client could not branch on *why* a filter was rejected.
+
+	The status is the load-bearing half: it is what stops the SPA's list
+	composable from reading a rejected filter as ``rows: []`` and silently
+	showing an empty, apparently-correct list. Every other exception is left
+	alone (an unexpected bug must still surface as a 500).
+	"""
+
+	@functools.wraps(fn)
+	def wrapper(*args, **kwargs):
+		try:
+			return fn(*args, **kwargs)
+		except ListFilterError as e:
+			code = getattr(e, "filter_error_code", ERR_BAD_PAYLOAD)
+			try:
+				frappe.local.response["http_status_code"] = _HTTP_STATUS_BY_CODE.get(
+					code, _DEFAULT_ERROR_STATUS
+				)
+			except Exception:
+				pass
+			return error_envelope(code, frappe.utils.strip_html(str(e)).strip())
+
+	return wrapper
 
 
 # --------------------------------------------------------------------------- #
@@ -232,19 +302,31 @@ def _fallback_sql(fieldtype: str) -> str:
 	return "''"
 
 
-def default_operator(fieldname: str, fieldtype: str, is_large_table: bool = False) -> str:
-	"""Frappe's ``frappe.ui.filter_utils.get_default_condition`` (filter.js:516-529),
-	copied rather than approximated.
+#: Free-text bodies a human types prose into. D5-a: these default to ``like``,
+#: which is a deliberate divergence from Frappe (see the ledger). NOT included:
+#: ``Code``/``HTML Editor``/``Markdown Editor`` (machine-shaped content, where an
+#: exact match is the useful question) and ``Data`` (which keeps Frappe's
+#: large-table rule below).
+_FREE_TEXT_FIELDTYPES = frozenset({"Small Text", "Long Text", "Text", "Text Editor"})
 
-	Plan §5.1's table claimed a ``like`` default for every "text-like" family
-	(Small Text, Long Text, Attach, Phone, Barcode, Color...). Frappe does not:
-	only ``Data`` (and only on a non-large table) defaults to ``like``;
-	Date/Datetime default to ``Between``; EVERYTHING else defaults to ``=``.
-	We follow Frappe. Deviation ledger D5 records the difference.
+
+def default_operator(fieldname: str, fieldtype: str, is_large_table: bool = False) -> str:
+	"""Default condition per field family.
+
+	Frappe's ``get_default_condition`` (filter.js:516-529) gives ``like`` only to
+	``Data`` on a non-large table, ``Between`` to Date/Datetime, and ``=`` to
+	everything else — so a Small Text ``description`` defaults to an exact match,
+	which is almost never what a user typing three words into a Description filter
+	means. Plan §5.1 assumed ``like`` for all text-like families and was wrong
+	about Frappe; the judgment's ruling (D5-a) is to diverge deliberately for the
+	four free-text bodies while keeping Frappe's rule everywhere else. ``=`` stays
+	selectable on all of them.
 	"""
 	if fieldname in _JSON_ARRAY_FIELDS:
 		return OP_LIKE
 	if fieldtype == "Data" and not is_large_table:
+		return OP_LIKE
+	if fieldtype in _FREE_TEXT_FIELDTYPES:
 		return OP_LIKE
 	if fieldtype in ("Date", "Datetime"):
 		return OP_BETWEEN
@@ -290,10 +372,11 @@ def _filterable_root(view: list_registry.ListView) -> str:
 
 
 def _table_columns(doctype: str) -> set[str]:
-	try:
-		return set(frappe.db.get_table_columns(doctype))
-	except Exception:
-		return set()
+	"""Real columns of the table. Deliberately NOT exception-swallowing: an empty
+	set would silently disable the column check below and quietly widen the
+	catalog. A missing table is a schema failure — :func:`get_schema` turns it
+	into ``list_filter_schema_unavailable``."""
+	return set(frappe.db.get_table_columns(doctype))
 
 
 def _is_large_table(meta) -> bool:
@@ -345,7 +428,13 @@ def _entry(
 	}
 
 
-def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict]:
+def build_field_catalog(
+	root_doctype: str,
+	user: str | None = None,
+	*,
+	view: list_registry.ListView | None = None,
+	excluded_fields: tuple[str, ...] | list[str] = (),
+) -> list[dict]:
 	"""The filterable-field catalog for ``root_doctype`` as seen by ``user``.
 
 	Plan §4: applicable standard fields + every stored, non-virtual,
@@ -354,10 +443,26 @@ def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict
 	(doctype, fieldname) as Frappe does. Hidden / not-in-list-view fields are NOT
 	excluded: Frappe filters on readable metadata, not on visible columns.
 
+	``view`` threads the registered surface through, so its
+	:attr:`~jarvis.chat.list_registry.ListView.excluded_fields` are withheld here
+	rather than by every caller remembering to. That is the P1 control: permlevel
+	stops what the DOCTYPE hides, ``excluded_fields`` stops what the ENDPOINT
+	hides (Triggers' redacted logic fields being the live case). A withheld field
+	is simply absent, so the compiler rejects it with the same
+	``list_filter_unknown_field`` as a misspelling — the oracle rule holds.
+
 	Exposed as a public helper (not just via the view registry) so the Phase-0
 	audit and the permlevel regression can point it at a DocType directly.
 	"""
 	user = user or frappe.session.user
+	excluded = {str(x) for x in excluded_fields}
+	if view is not None:
+		excluded |= {str(x) for x in view.excluded_fields}
+	# "fieldname" withholds a main/standard field; "Child DocType.fieldname"
+	# withholds one child field.
+	excluded_main = {x for x in excluded if "." not in x}
+	excluded_child = {tuple(x.split(".", 1)) for x in excluded if "." in x}
+
 	meta = frappe.get_meta(root_doctype)
 	levels = _permlevels(meta, user)
 	if 0 not in levels:
@@ -375,6 +480,8 @@ def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict
 	for std in _STANDARD_FIELDS:
 		fieldname = std["fieldname"]
 		if fieldname == "docstatus" and not submittable:
+			continue
+		if fieldname in excluded_main:
 			continue
 		if fieldname in _OPTIONAL_COLUMNS and fieldname not in columns:
 			continue
@@ -404,6 +511,8 @@ def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict
 			continue
 		if df.fieldtype in NO_VALUE_FIELDTYPES or df.fieldtype in SECRET_FIELDTYPES:
 			continue
+		if fieldname in excluded_main:
+			continue
 		if int(df.permlevel or 0) not in levels:
 			continue
 		if columns and fieldname not in columns:
@@ -423,10 +532,9 @@ def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict
 	children: list[dict] = []
 	for container in child_containers:
 		child_dt = container.options
-		try:
-			child_meta = frappe.get_meta(child_dt)
-		except Exception:
-			continue
+		# No swallow: a Table pointing at a missing child DocType is a broken
+		# schema, and silently dropping its fields would be a silent narrowing.
+		child_meta = frappe.get_meta(child_dt)
 		child_levels = _permlevels(child_meta, user, parenttype=root_doctype)
 		if 0 not in child_levels:
 			continue
@@ -444,6 +552,8 @@ def build_field_catalog(root_doctype: str, user: str | None = None) -> list[dict
 				continue
 			# Nested tables are not recursively filterable (plan §4.3).
 			if df.fieldtype in NO_VALUE_FIELDTYPES or df.fieldtype in SECRET_FIELDTYPES:
+				continue
+			if (child_dt, fieldname) in excluded_child:
 				continue
 			if int(df.permlevel or 0) not in child_levels:
 				continue
@@ -494,17 +604,14 @@ def _meta_fingerprint(root_doctype: str, user: str) -> str:
 	have to remember to bust anything.
 	"""
 	parts: list[str] = []
-	try:
-		meta = frappe.get_meta(root_doctype)
-	except Exception:
-		return "no-meta"
+	# No swallow anywhere in here: a fingerprint computed from partial metadata
+	# would be a STABLE key for an INCOMPLETE catalog, i.e. a cached wrong answer.
+	# get_schema turns any failure into list_filter_schema_unavailable.
+	meta = frappe.get_meta(root_doctype)
 	metas = [(root_doctype, meta)]
 	for df in meta.fields:
 		if df.fieldtype in TABLE_FIELDTYPES and df.options:
-			try:
-				metas.append((df.options, frappe.get_meta(df.options)))
-			except Exception:
-				continue
+			metas.append((df.options, frappe.get_meta(df.options)))
 	for name, m in metas:
 		parts.append(name)
 		parts.append(str(getattr(m, "modified", "")))
@@ -522,9 +629,24 @@ def get_schema(view_key: str, user: str | None = None) -> dict:
 	user = user or frappe.session.user
 	view = resolve_view(view_key)
 	root = _filterable_root(view)
+	try:
+		return _build_schema(view, root, user)
+	except ListFilterError:
+		raise
+	except Exception:
+		# Metadata gone, table dropped mid-migrate, a broken child DocType: the
+		# caller gets a stable code and no rows, never a raw 500 whose body the
+		# SPA would render as a mystery toast.
+		frappe.log_error(
+			title="list filter schema unavailable",
+			message=f"{view_key} / {root}\n{frappe.get_traceback()}",
+		)
+		_fail(ERR_SCHEMA_UNAVAILABLE, _("Filters are unavailable for this list right now."))
 
+
+def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 	fingerprint = _meta_fingerprint(root, user)
-	key = _cache_key(view_key, user, fingerprint)
+	key = _cache_key(view.view_key, user, fingerprint)
 	try:
 		cached = frappe.cache().get_value(key)
 	except Exception:
@@ -532,7 +654,7 @@ def get_schema(view_key: str, user: str | None = None) -> dict:
 	if isinstance(cached, dict) and cached.get("contract_version") == CONTRACT_VERSION:
 		return cached
 
-	fields = build_field_catalog(root, user=user)
+	fields = build_field_catalog(root, user=user, view=view)
 	meta = frappe.get_meta(root)
 	schema = {
 		"contract_version": CONTRACT_VERSION,
@@ -558,12 +680,21 @@ def get_schema(view_key: str, user: str | None = None) -> dict:
 
 @frappe.whitelist()
 @require_jarvis_user
+@filter_errors_to_envelope
 def get_list_filter_schema(view_key: str) -> dict:
 	"""Fields THIS caller may filter ``view_key`` on, with per-field operators.
 
 	Jarvis-user gated. Never trust the browser's copy of this: every clause is
 	re-validated against a freshly resolved schema at query time.
+
+	Answers only for views whose endpoint actually accepts ``filters_v2``. A
+	registered-but-unmigrated view would otherwise hand a client a perfectly
+	valid schema it has nowhere to send — the UI would render a filter panel
+	whose every clause the list endpoint ignores, which is worse than no panel.
 	"""
+	view = resolve_view(view_key)
+	if view.status != list_registry.MIGRATED:
+		_fail(ERR_VIEW_NOT_FILTERABLE, _("This list does not support field filters yet."))
 	return get_schema(view_key)
 
 
@@ -611,6 +742,15 @@ def parse_clauses(clauses: Any) -> list[dict]:
 	return out
 
 
+def _guard_length(value: Any) -> None:
+	"""The §9 length cap, applied to the RAW value before any fieldtype branch.
+
+	It used to live only on the text path, so a megabyte of digits aimed at an Int
+	field, or a pathological date string, was parsed first and capped never."""
+	if isinstance(value, str | bytes) and len(value) > MAX_VALUE_CHARS:
+		_fail(ERR_VALUE_TOO_LONG, _("A filter value may not exceed {0} characters.").format(MAX_VALUE_CHARS))
+
+
 def _cap_text(value: Any) -> str:
 	text = "" if value is None else str(value)
 	if len(text) > MAX_VALUE_CHARS:
@@ -636,12 +776,39 @@ def _select_options(entry: dict) -> list[str] | None:
 	return [o.strip() for o in options.split("\n")]
 
 
+_TEMPORAL_FIELDTYPES = frozenset({"Date", "Datetime", "Time"})
+
+
 def _scalar(entry: dict, operator: str, value: Any) -> Any:
 	"""Normalize ONE scalar value by fieldtype, mirroring db_query's per-family
 	conversions. The result is always a bound parameter, never SQL."""
 	from frappe.utils import get_datetime, get_time, getdate
 
+	_guard_length(value)
 	fieldtype = entry["fieldtype"]
+
+	if fieldtype in _TEMPORAL_FIELDTYPES:
+		# Frappe's getdate(None)/get_datetime(None) return TODAY/NOW, and
+		# getdate("") does the same. Inherited, an omitted or blank date bound
+		# would quietly become "today" — a filter that answers a question nobody
+		# asked, and the answer looks plausible. Reject instead.
+		if value is None or (isinstance(value, str) and not value.strip()):
+			_fail(ERR_INVALID_VALUE, _("{0} needs a value.").format(entry["label"]))
+		try:
+			if fieldtype == "Date":
+				parsed = getdate(value)
+			elif fieldtype == "Datetime":
+				parsed = get_datetime(value)
+			else:
+				parsed = get_time(value)
+		except Exception:
+			parsed = None
+		if parsed is None:
+			# get_datetime/get_time return None (rather than raising) on several
+			# unparseable shapes; str(None) would bind the literal "None".
+			_fail(ERR_INVALID_VALUE, _("{0} needs a valid date or time.").format(entry["label"]))
+		return parsed.strftime("%H:%M:%S.%f") if fieldtype == "Time" else str(parsed)
+
 	if fieldtype == "Check":
 		text = str(value).strip().lower()
 		if text in ("1", "true", "yes"):
@@ -650,22 +817,10 @@ def _scalar(entry: dict, operator: str, value: Any) -> Any:
 			return 0
 		_fail(ERR_INVALID_VALUE, _("{0} is a checkbox: use 0 or 1.").format(entry["label"]))
 	if fieldtype in NUMERIC_FIELDTYPES:
+		# NOTE: flt("")/cint("") == 0, so a blank numeric filter means "= 0".
+		# That is Frappe's behaviour (db_query does flt(f.value)) and is left at
+		# parity deliberately — see the ledger's D14 note.
 		return _as_number(entry, value)
-	if fieldtype == "Date":
-		try:
-			return str(getdate(value))
-		except Exception:
-			_fail(ERR_INVALID_VALUE, _("{0} needs a valid date.").format(entry["label"]))
-	if fieldtype == "Datetime":
-		try:
-			return str(get_datetime(value))
-		except Exception:
-			_fail(ERR_INVALID_VALUE, _("{0} needs a valid date and time.").format(entry["label"]))
-	if fieldtype == "Time":
-		try:
-			return get_time(value).strftime("%H:%M:%S.%f")
-		except Exception:
-			_fail(ERR_INVALID_VALUE, _("{0} needs a valid time.").format(entry["label"]))
 
 	text = _cap_text(value)
 	options = _select_options(entry)
@@ -695,6 +850,7 @@ def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
 
 	from frappe.utils import get_datetime, getdate, nowdate
 
+	_guard_length(value)
 	if isinstance(value, str):
 		try:
 			parsed = json.loads(value)
@@ -808,6 +964,17 @@ def _column(ref: str, fieldname: str) -> str:
 	return f"{ref}.`{fieldname}`"
 
 
+def _and(parts: list[str]) -> str:
+	"""AND-join, parenthesising EVERY part.
+
+	Structural, not cosmetic: an unparenthesised join means a predicate
+	containing a top-level ``OR`` binds loosely and silently widens the whole
+	WHERE. The skills scope predicate is literally ``a OR (b AND c)``, and any
+	future endpoint author writing one is one keystroke from that bug. Making the
+	joiner defensive removes the footgun from every caller at once."""
+	return " AND ".join(f"({p})" for p in parts if p)
+
+
 def _compile_clause(clause: _Clause, ref: str) -> tuple[str, dict]:
 	"""One clause → (SQL with named placeholders, params). Identifiers come only
 	from the resolved schema entry; every value is a bound parameter."""
@@ -829,9 +996,17 @@ def _compile_clause(clause: _Clause, ref: str) -> tuple[str, dict]:
 
 	if op in (OP_IN, OP_NOT_IN):
 		sql_op = "IN" if op == OP_IN else "NOT IN"
-		# `in` over a nullable column coalesces exactly as db_query does, so an
-		# empty-string member still matches NULL rows.
-		if fieldtype in NON_NULLABLE_FIELDTYPES or fieldname in ("name", "creation", "modified"):
+		# db_query's rule, precisely: for `in` it clears can_be_null unless the
+		# value list is empty or contains a falsy member — and we reject empty
+		# lists (D9) and strip blank members, so `in` NEVER coalesces. Wrapping it
+		# anyway (as this did) defeats index use on every `in` filter for no
+		# semantic gain. `not in` keeps the wrapper, because NULL NOT IN (...) is
+		# NULL and those rows would silently vanish — which IS frappe's rule.
+		if (
+			op == OP_IN
+			or fieldtype in NON_NULLABLE_FIELDTYPES
+			or fieldname in ("name", "creation", "modified")
+		):
 			return (f"{col} {sql_op} %({p0})s", {p0: tuple(clause.value)})
 		return (
 			f"ifnull({col}, {_fallback_sql(fieldtype)}) {sql_op} %({p0})s",
@@ -879,6 +1054,16 @@ class CompiledFilters:
 		return [dim for dim, _sql in self.main] + [dim for dim, _dt, _sql in self.child]
 
 	def fragment(self, exclude_dimension: tuple[str, str] | None = None) -> str:
+		"""One AND-joined SQL string for a caller assembling its own WHERE."""
+		return _and(self.fragments(exclude_dimension))
+
+	def fragments(self, exclude_dimension: tuple[str, str] | None = None) -> list[str]:
+		"""The compiled clauses as SEPARATE parts.
+
+		:class:`ListFilterQuery` consumes this rather than :meth:`fragment` so
+		each user clause is parenthesised exactly once in the final WHERE instead
+		of the whole user block being wrapped again around already-wrapped parts.
+		"""
 		parts = [sql for dim, sql in self.main if dim != exclude_dimension]
 		groups: dict[str, list[str]] = {}
 		for dim, child_dt, sql in self.child:
@@ -887,7 +1072,7 @@ class CompiledFilters:
 			groups.setdefault(child_dt, []).append(sql)
 		for child_dt in sorted(groups):
 			alias = self.child_alias[child_dt]
-			inner = " AND ".join(groups[child_dt])
+			inner = _and(groups[child_dt])
 			# ONE EXISTS per child DocType with every clause on that child ANDed
 			# INSIDE it: that preserves Frappe's single-join meaning, where two
 			# conditions on one child table must be satisfied by the SAME child
@@ -898,7 +1083,7 @@ class CompiledFilters:
 				f"WHERE `{alias}`.`parent` = {self.ref}.`name` "
 				f"AND `{alias}`.`parenttype` = %({alias}_pt)s AND ({inner}))"
 			)
-		return " AND ".join(parts)
+		return parts
 
 
 def compile_validated(root_doctype: str, clauses: list[_Clause], ref: str) -> CompiledFilters:
@@ -930,11 +1115,25 @@ def compile_list_filters(
 	alias: str | None = None,
 	user: str | None = None,
 ) -> CompiledFilters:
-	"""Resolve the view, rebuild THIS caller's schema, validate, compile."""
-	schema = get_schema(view_key, user=user)
-	root = schema["root_doctype"]
+	"""Resolve the view, rebuild THIS caller's schema, validate, compile.
+
+	SHORT-CIRCUIT: the payload is parsed first, and an absent or empty one returns
+	an empty :class:`CompiledFilters` without touching metadata, the schema cache
+	or the database. That is the >99% path — every list load that has no filters
+	on it — and it matters twice over: the migrated endpoints keep exactly their
+	pre-migration cost, and a metadata problem in the filter layer cannot take
+	down an unfiltered list. The view is still resolved (a bad ``view_key`` is a
+	contract error whether or not clauses came with it), but that is a dict
+	lookup.
+	"""
+	items = parse_clauses(clauses)
+	view = resolve_view(view_key)
+	root = _filterable_root(view)
 	ref = f"`{alias}`" if alias else f"`tab{root}`"
-	return compile_validated(root, validate_clauses(schema, clauses), ref)
+	if not items:
+		return CompiledFilters(root_doctype=root, ref=ref)
+	schema = get_schema(view_key, user=user)
+	return compile_validated(root, validate_clauses(schema, items), ref)
 
 
 def compile_filters_v2(
@@ -1024,17 +1223,21 @@ class ListFilterQuery:
 	def where(self, *, exclude_dimension: tuple[str, str] | None = None) -> str:
 		parts = list(self._server_conds)
 		if self._compiled:
-			fragment = self._compiled.fragment(exclude_dimension)
-			if fragment:
-				parts.append(fragment)
-		return " AND ".join(parts) if parts else "1=1"
+			parts.extend(self._compiled.fragments(exclude_dimension))
+		return _and(parts) or "1=1"
 
 	def params(self, extra: dict | None = None) -> dict:
+		"""The merged bind map. ``extra`` carries the endpoint's non-predicate
+		params (``start``, ``page_length``); a collision with an already-bound
+		name is a programming error and raises rather than silently overwriting a
+		predicate's value — which would change what the WHERE means."""
 		out = dict(self._server_params)
 		if self._compiled:
 			out.update(self._compiled.params)
-		if extra:
-			out.update(extra)
+		for name, value in (extra or {}).items():
+			if name in out:
+				raise ValueError(f"parameter {name!r} is already bound by this query")
+			out[name] = value
 		return out
 
 

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -637,11 +637,36 @@ def get_schema(view_key: str, user: str | None = None) -> dict:
 		# Metadata gone, table dropped mid-migrate, a broken child DocType: the
 		# caller gets a stable code and no rows, never a raw 500 whose body the
 		# SPA would render as a mystery toast.
+		#
+		# Logged at most once per view per TTL. A broken DocType breaks EVERY list
+		# load for every user on that surface, so an unguarded log_error turns one
+		# schema fault into an Error Log flood that buries the entry explaining it
+		# (and writes a row per request while the site is already unhealthy).
+		_log_schema_failure(view_key, root)
+		_fail(ERR_SCHEMA_UNAVAILABLE, _("Filters are unavailable for this list right now."))
+
+
+#: How long one view's schema failure stays deduped in the Error Log.
+SCHEMA_FAILURE_LOG_TTL = 900
+
+
+def _log_schema_failure(view_key: str, root: str) -> None:
+	key = f"jarvis:list-filter-schema-fail:{view_key}"
+	try:
+		cache = frappe.cache()
+		if cache.get_value(key):
+			return
+		cache.set_value(key, "1", expires_in_sec=SCHEMA_FAILURE_LOG_TTL)
+	except Exception:
+		# No cache: log anyway. Losing the dedupe is better than losing the fault.
+		pass
+	try:
 		frappe.log_error(
 			title="list filter schema unavailable",
 			message=f"{view_key} / {root}\n{frappe.get_traceback()}",
 		)
-		_fail(ERR_SCHEMA_UNAVAILABLE, _("Filters are unavailable for this list right now."))
+	except Exception:
+		pass
 
 
 def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
@@ -779,6 +804,19 @@ def _select_options(entry: dict) -> list[str] | None:
 _TEMPORAL_FIELDTYPES = frozenset({"Date", "Datetime", "Time"})
 
 
+def _is_blank_temporal(value: Any) -> bool:
+	"""True for anything Frappe's date helpers would silently turn into today/now.
+
+	``getdate()`` / ``get_datetime()`` begin with ``if not string_date:`` and
+	return the current date/time — so falsiness is the ONLY thing they check.
+	``0``, ``False``, ``[]`` and ``{}`` therefore all mean "today" to them, and
+	none of them is a date. This is the single predicate both the scalar path and
+	the ``Between`` bounds use, so the two cannot drift apart again."""
+	if isinstance(value, str):
+		return not value.strip()
+	return not value
+
+
 def _scalar(entry: dict, operator: str, value: Any) -> Any:
 	"""Normalize ONE scalar value by fieldtype, mirroring db_query's per-family
 	conversions. The result is always a bound parameter, never SQL."""
@@ -788,11 +826,11 @@ def _scalar(entry: dict, operator: str, value: Any) -> Any:
 	fieldtype = entry["fieldtype"]
 
 	if fieldtype in _TEMPORAL_FIELDTYPES:
-		# Frappe's getdate(None)/get_datetime(None) return TODAY/NOW, and
-		# getdate("") does the same. Inherited, an omitted or blank date bound
+		# Frappe's getdate(None)/get_datetime(None) return TODAY/NOW, and every
+		# other falsy value does the same. Inherited, an omitted or blank date
 		# would quietly become "today" — a filter that answers a question nobody
 		# asked, and the answer looks plausible. Reject instead.
-		if value is None or (isinstance(value, str) and not value.strip()):
+		if _is_blank_temporal(value):
 			_fail(ERR_INVALID_VALUE, _("{0} needs a value.").format(entry["label"]))
 		try:
 			if fieldtype == "Date":
@@ -843,12 +881,19 @@ def _like_value(value: Any) -> str:
 
 
 def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
-	"""Frappe's get_between_date_filter semantics, as bound values rather than
-	interpolated literals: a bare date on a Datetime field expands to
-	[00:00:00, 23:59:59.999999]; a missing bound falls back to today."""
+	"""Frappe's get_between_date_filter expansion — a bare date on a Datetime
+	field becomes [00:00:00, 23:59:59.999999] — as bound values rather than
+	interpolated literals, but WITHOUT its today-fallback for a missing bound.
+
+	``Between`` is the default operator for Date and Datetime, so it is the first
+	path a client reaches, and Frappe answers a half-empty range by quietly
+	substituting today at both ends. That is the same silent-wrong-answer class
+	the scalar guard rejects, arrived at through the more common door. Both
+	bounds must be present and non-blank. Declared deviation, D14.
+	"""
 	import datetime
 
-	from frappe.utils import get_datetime, getdate, nowdate
+	from frappe.utils import get_datetime, getdate
 
 	_guard_length(value)
 	if isinstance(value, str):
@@ -859,8 +904,13 @@ def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
 			value = [v.strip() for v in value.split(",")]
 	if not isinstance(value, list | tuple):
 		value = [value]
-	frm = value[0] if len(value) >= 1 and value[0] not in (None, "") else nowdate()
-	to = value[1] if len(value) >= 2 and value[1] not in (None, "") else nowdate()
+	# The cap has to be re-applied per element: the raw payload can be a short
+	# JSON string (or a list) whose MEMBERS are megabytes.
+	for element in value:
+		_guard_length(element)
+	if len(value) != 2 or any(_is_blank_temporal(v) for v in value[:2]):
+		_fail(ERR_INVALID_VALUE, _("{0} needs a start and an end.").format(entry["label"]))
+	frm, to = value[0], value[1]
 
 	if entry["fieldtype"] == "Datetime":
 		def _expand(raw, end: bool):

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -67,8 +67,12 @@ from frappe import _
 from jarvis.chat import list_registry
 from jarvis.permissions import require_jarvis_user
 
-#: Bumped when the wire shape of the schema or a clause changes.
-CONTRACT_VERSION = 1
+#: Bumped when the wire shape of the schema or a clause changes. Also bumped to
+#: DISCARD schemas cached by an older build: v1 cached child entries whose
+#: ``parentfields`` list could be empty, which the compiler turned into a
+#: ``parentfield IN ()`` SQL syntax error on a restart-only deploy. v2 rebuilds
+#: the cache cold, and the compiler now fails closed on such an entry regardless.
+CONTRACT_VERSION = 2
 
 # --------------------------------------------------------------------------- #
 # Limits (plan §9). These bound CLIENT input only — a server-authored predicate
@@ -869,17 +873,25 @@ def _disabled_views() -> set[str]:
 	"""View keys rolled back to legacy transport — a KILL SWITCH that fails CLOSED.
 
 	The valid shapes are a list/tuple of view-key strings, a single view-key
-	string, or absent/empty (⇒ nothing disabled, every migrated view ON). ANYTHING
-	else is a misconfiguration, and a kill switch must never fail OPEN on one: the
-	old code did ``{str(v) for v in off}`` inside a ``try``, so
+	string, or absent/empty/off (⇒ nothing disabled, every migrated view ON).
+	``False``/``0`` count as "off": for a key named ``*_off`` they are the most
+	natural spelling of "kill switch not engaged", so they must read as "disable
+	nothing", never fall through to fail-closed. ANYTHING else is a
+	misconfiguration, and a kill switch must never fail OPEN on one: the old code
+	did ``{str(v) for v in off}`` inside a ``try``, so
 	``"jarvis_list_filters_v2_off": true`` (a bool) raised ``TypeError`` and fell
 	through to ``set()`` — silently re-enabling every view the operator meant to
-	turn off. Now a malformed value disables EVERY migrated view and logs once,
-	loudly. Over-disabling is the safe direction for a rollback switch; a typo can
-	never silently re-enable.
+	turn off. Now a malformed value (``True``/``1``, a dict, a mixed list) disables
+	EVERY migrated view and logs once, loudly. Over-disabling is the safe direction
+	for a rollback switch; a typo can never silently re-enable.
 	"""
 	off = frappe.conf.get(CONF_KEY_V2_OFF)
-	if off in (None, "", [], ()):
+	# ``False``/``0`` are listed explicitly: they are NOT equal to any of
+	# ``None``/``""``/``[]``/``()`` under ``==``, so without them a ``false`` or
+	# ``0`` kill switch would fall through to the fail-closed branch and silently
+	# disable every migrated view. ``True``/``1`` deliberately do NOT match here —
+	# they are ambiguous junk and must fail closed.
+	if off in (None, "", [], (), False, 0):
 		return set()
 	if isinstance(off, str):
 		return {off} if off else set()
@@ -1495,8 +1507,17 @@ def compile_validated(root_doctype: str, clauses: list[_Clause], ref: str) -> Co
 			dt = clause.entry["doctype"]
 			parentfields_by_dt[dt] = tuple(sorted(clause.entry.get("parentfields") or ()))
 	for dt, alias in alias_map.items():
+		pf = parentfields_by_dt.get(dt, ())
+		if not pf:
+			# A child clause must carry at least one readable parent container.
+			# Binding an empty tuple would render ``parentfield IN ()`` — a hard
+			# MariaDB syntax error (pymysql prints the empty tuple literally), so a
+			# stale pre-v2 cached schema entry (no ``parentfields``) would otherwise
+			# 500 every child-table filter for up to SCHEMA_CACHE_TTL after a
+			# restart-only deploy. Fail closed with the stable invalid-field code.
+			_fail(ERR_UNKNOWN_FIELD, _("That field cannot be filtered on this list."))
 		compiled.params[f"{alias}_pt"] = root_doctype
-		compiled.params[f"{alias}_pf"] = parentfields_by_dt.get(dt, ())
+		compiled.params[f"{alias}_pf"] = pf
 	for clause in clauses:
 		entry = clause.entry
 		if entry["is_child"]:

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -579,7 +579,10 @@ def build_field_catalog(
 
 def _schema_digest(fields: list[dict]) -> str:
 	payload = json.dumps(
-		[[f["doctype"], f["fieldname"], f["fieldtype"], f["default_operator"], f["operators"]] for f in fields],
+		[
+			[f["doctype"], f["fieldname"], f["fieldtype"], f["default_operator"], f["operators"]]
+			for f in fields
+		],
 		sort_keys=True,
 	)
 	return hashlib.sha256(payload.encode()).hexdigest()[:16]
@@ -618,7 +621,9 @@ def _meta_fingerprint(root_doctype: str, user: str) -> str:
 		for df in m.fields:
 			parts.append(f"{df.fieldname}:{df.fieldtype}:{int(df.permlevel or 0)}:{df.options or ''}")
 		for perm in getattr(m, "permissions", []) or []:
-			parts.append(f"P{perm.get('role')}:{int(perm.get('permlevel') or 0)}:{int(perm.get('read') or 0)}")
+			parts.append(
+				f"P{perm.get('role')}:{int(perm.get('permlevel') or 0)}:{int(perm.get('read') or 0)}"
+			)
 	return hashlib.sha256("|".join(parts).encode()).hexdigest()[:24]
 
 
@@ -762,7 +767,10 @@ def parse_clauses(clauses: Any) -> list[dict]:
 	out: list[dict] = []
 	for item in raw:
 		if not isinstance(item, dict):
-			_fail(ERR_BAD_PAYLOAD, _("Each filter must be an object with doctype, fieldname, operator and value."))
+			_fail(
+				ERR_BAD_PAYLOAD,
+				_("Each filter must be an object with doctype, fieldname, operator and value."),
+			)
 		out.append(item)
 	return out
 
@@ -913,6 +921,7 @@ def _between_bounds(entry: dict, value: Any) -> tuple[str, str]:
 	frm, to = value[0], value[1]
 
 	if entry["fieldtype"] == "Datetime":
+
 		def _expand(raw, end: bool):
 			if isinstance(raw, str) and " " in raw.strip():
 				return get_datetime(raw)
@@ -1257,9 +1266,7 @@ class ListFilterQuery:
 		"""Validate + compile client clauses. Idempotent per query object."""
 		if self._compiled is not None:
 			raise ValueError("filters_v2 already applied to this query")
-		self._compiled = compile_list_filters(
-			self.view_key, clauses, alias=self.alias, user=self.user
-		)
+		self._compiled = compile_list_filters(self.view_key, clauses, alias=self.alias, user=self.user)
 		return self
 
 	@property

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -47,9 +47,7 @@ EXCLUDED_NOT_A_LIST = "excluded_not_a_list"
 # it to DOCUMENT_LIST *and* adopt the contract (plan §7).
 EXCLUDED_DORMANT = "excluded_dormant"
 
-CLASSIFICATIONS = frozenset(
-	{DOCUMENT_LIST, PROJECTION, EXCLUDED_NOT_A_LIST, EXCLUDED_DORMANT}
-)
+CLASSIFICATIONS = frozenset({DOCUMENT_LIST, PROJECTION, EXCLUDED_NOT_A_LIST, EXCLUDED_DORMANT})
 #: Classifications that must carry a ``reason``.
 EXCLUDED_CLASSIFICATIONS = frozenset({EXCLUDED_NOT_A_LIST, EXCLUDED_DORMANT})
 
@@ -179,7 +177,12 @@ _VIEWS: tuple[ListView, ...] = (
 		endpoints=("jarvis.chat.wiki.list_wiki_pages_page",),
 		surface="frontend/src/pages/skills/WikiTab.vue",
 		wave=1,
-		curated_filters={"page_type": "page_type", "scope_filter": None, "attention": None, "archived": "status"},
+		curated_filters={
+			"page_type": "page_type",
+			"scope_filter": None,
+			"attention": None,
+			"archived": "status",
+		},
 		notes="`scope_filter` (all|org|role|mine) and `attention` are view predicates, not single fields; `archived` is a two-valued view switch over `status` (Active vs Archived).",
 	),
 	ListView(
@@ -304,7 +307,11 @@ _VIEWS: tuple[ListView, ...] = (
 		endpoints=("jarvis.chat.approvals_api.list_approvals_page",),
 		surface="frontend/src/pages/approvals/ApprovalsBoard.vue",
 		wave=2,
-		curated_filters={"status": "status", "document_type": "document_type", "conversation": "conversation"},
+		curated_filters={
+			"status": "status",
+			"document_type": "document_type",
+			"conversation": "conversation",
+		},
 		notes="Computed `shared` flag + DocShare/owner visibility. Its document_type facet deliberately drops its own dimension — the C08-3 rule this module implements.",
 	),
 	ListView(

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -513,6 +513,16 @@ NON_LIST_ENDPOINTS: dict[str, str] = {
 		"global command-palette search across entities — a ranked hit list, not a "
 		"single-DocType browsable list view"
 	),
+	# Single-document `*_page` operations. Collection-shaped ONLY by the `_page`
+	# suffix the S7 sweep now recognises; each acts on ONE wiki page by slug and has
+	# no pageable row collection of its own. Registered so the suffix widening does
+	# not let a genuine `get_<thing>_page` list slip past unargued.
+	"jarvis.chat.wiki.get_wiki_page": "reads ONE wiki page by slug — a document getter, not a list",
+	"jarvis.chat.wiki.create_wiki_page": "creates ONE wiki page — a mutation, not a list",
+	"jarvis.chat.wiki.save_wiki_page": "saves ONE wiki page — a mutation, not a list",
+	"jarvis.chat.wiki.archive_wiki_page": "archives ONE wiki page by slug — a mutation, not a list",
+	"jarvis.chat.wiki.delete_wiki_page": "deletes ONE wiki page by slug — a mutation, not a list",
+	"jarvis.chat.wiki.restore_wiki_page": "restores ONE wiki page by slug — a mutation, not a list",
 	# Per-document detail feeds and aggregates: no independent, pageable row
 	# collection of their own.
 	"jarvis.chat.wiki.get_wiki_graph_history": (

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -21,9 +21,12 @@ What lives here
 ever name a key that already exists in this file.
 
 Registering a surface does NOT grant it filters: ``status`` says whether the
-endpoint speaks the ``filters_v2`` contract yet. Phase 1 migrates exactly two
-(Skills, Macros) as the contract's pilots; the rest stay ``PENDING`` and keep
-their curated filters until their wave.
+endpoint speaks the ``filters_v2`` contract yet. Skills and Macros are the
+contract's pilots; each further surface flips to ``MIGRATED`` as it adopts the
+contract, and the rest stay ``PENDING`` on their curated filters until their wave.
+The exact migrated set and its counts are the registry's own data — asserted by
+:mod:`jarvis.tests.test_list_registry`, never restated as a number in prose here
+(which is how the stale "exactly two" crept in and misreported the split).
 """
 
 from __future__ import annotations
@@ -466,12 +469,13 @@ _VIEWS: tuple[ListView, ...] = (
 _BY_KEY: dict[str, ListView] = {v.view_key: v for v in _VIEWS}
 
 
-#: Whitelisted ``list_*`` endpoints under ``jarvis/chat`` that are deliberately
-#: NOT document-list views, each with its classification. The new-surface audit
-#: sweeps every such callable and fails unless it appears in a registered view's
-#: ``endpoints`` or here — so a new list endpoint cannot ship unclassified, which
-#: was the registry's one remaining loophole (it could only prove that what IS
-#: registered is well-formed, never that nothing is missing).
+#: Whitelisted COLLECTION-SHAPED endpoints under ``jarvis/chat`` / ``jarvis/support``
+#: that are deliberately NOT document-list views, each with its classification. The
+#: new-surface audit sweeps every such callable — matched by the whole family of
+#: collection name patterns, not ``list_*`` alone (S7) — and fails unless it appears
+#: in a registered view's ``endpoints`` or here, so a list endpoint cannot ship
+#: unclassified whatever it is named (the round-2 loophole: discovery keyed only on
+#: ``list_*``/``admin_list_*``, so a ``search_*`` or ``*_feed`` collection evaded it).
 NON_LIST_ENDPOINTS: dict[str, str] = {
 	# Unpaginated companions of a registered paginated list. They exist for a
 	# dropdown / autocomplete / first-paint and return a capped slice with no
@@ -492,6 +496,36 @@ NON_LIST_ENDPOINTS: dict[str, str] = {
 	# metadata ABOUT the list views, not a list of documents.
 	"jarvis.chat.list_filters.list_filters_capabilities": (
 		"the filters_v2 per-view capability map (P1-05) — a config probe, not a document list"
+	),
+	"jarvis.chat.list_filters.get_list_filter_schema": (
+		"the filters_v2 field-catalog probe for ONE view — schema metadata about a "
+		"list, not a list of documents (its name carries the 'list' token)"
+	),
+	# Search surfaces: collection-SHAPED (they return matches), but they are search
+	# results over a query, not browsable, paginated, filterable document-list views.
+	# Registered here so the S7 sweep forces the distinction rather than letting a
+	# search endpoint pass unclassified.
+	"jarvis.chat.api.search_conversations": (
+		"full-text search over the caller's conversations — a ranked search-results "
+		"feed for the command palette, not a filterable document-list view"
+	),
+	"jarvis.chat.api.search_workspace": (
+		"global command-palette search across entities — a ranked hit list, not a "
+		"single-DocType browsable list view"
+	),
+	# Per-document detail feeds and aggregates: no independent, pageable row
+	# collection of their own.
+	"jarvis.chat.wiki.get_wiki_graph_history": (
+		"the edit-history feed of ONE wiki page — a per-document timeline, not a "
+		"collection (the chat equivalent of a form's version history)"
+	),
+	"jarvis.chat.triggers_api.activity_stats": (
+		"aggregate counters over Trigger Activity (a stats rollup), not a row "
+		"collection — the browsable feed is the registered trigger_activity view"
+	),
+	"jarvis.chat.api.clear_chat_history": (
+		"a MUTATION that deletes the caller's conversations — collection-shaped by "
+		"name (the 'history' token) but it returns nothing to page, sort or filter"
 	),
 	# Not document collections at all: option/name strings for a control.
 	"jarvis.chat.api.list_tools": "tool NAMES available to the caller — strings, not documents",

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -74,6 +74,16 @@ class ListView:
 	``scope`` field, a genuinely confusable collision). The Phase-0 audit needs
 	that mapping to compare curated width against the metadata catalog without
 	guessing.
+
+	``excluded_fields`` is the view's own withholding list, and it is a SECURITY
+	control, not a taste one. Permlevel (C08-1) stops a field the *DocType* hides;
+	it cannot stop a field the *endpoint* hides. Triggers is the live example: the
+	rows it returns redact ``condition`` / ``script_body`` / ``llm_instruction``
+	for non-managers (``triggers_api._trigger_detail``), so offering those as
+	filters would rebuild the redacted logic one LIKE at a time. Anything a view's
+	projection withholds from its rows MUST appear here before that view is
+	flipped to ``MIGRATED``. Entries are plain fieldnames of ``root_doctype``, or
+	``"Child DocType.fieldname"`` to withhold one child field.
 	"""
 
 	view_key: str
@@ -90,6 +100,7 @@ class ListView:
 	wave: int | None = None
 	status: str = PENDING
 	curated_filters: dict[str, str | None] = field(default_factory=dict)
+	excluded_fields: tuple[str, ...] = ()
 	#: Distinguishes two views served by one endpoint (learning queue/decided).
 	variant: str = ""
 	reason: str = ""
@@ -196,7 +207,15 @@ _VIEWS: tuple[ListView, ...] = (
 			"target_doctype": "target_doctype",
 			"doc_event": "doc_event",
 		},
-		notes="Manager/non-manager row redaction must survive migration.",
+		excluded_fields=("condition", "script_body", "llm_instruction"),
+		notes=(
+			"Manager/non-manager row redaction must survive migration: "
+			"triggers_api._trigger_detail blanks condition/script_body/"
+			"llm_instruction for non-managers, so those three are withheld from "
+			"the filter catalog too — a LIKE oracle would rebuild them. Withheld "
+			"unconditionally (for managers as well): a per-role exclusion needs a "
+			"view-declared predicate, which is deliberately deferred."
+		),
 	),
 	ListView(
 		view_key="trigger_activity",
@@ -438,6 +457,46 @@ _VIEWS: tuple[ListView, ...] = (
 )
 
 _BY_KEY: dict[str, ListView] = {v.view_key: v for v in _VIEWS}
+
+
+#: Whitelisted ``list_*`` endpoints under ``jarvis/chat`` that are deliberately
+#: NOT document-list views, each with its classification. The new-surface audit
+#: sweeps every such callable and fails unless it appears in a registered view's
+#: ``endpoints`` or here — so a new list endpoint cannot ship unclassified, which
+#: was the registry's one remaining loophole (it could only prove that what IS
+#: registered is well-formed, never that nothing is missing).
+NON_LIST_ENDPOINTS: dict[str, str] = {
+	# Unpaginated companions of a registered paginated list. They exist for a
+	# dropdown / autocomplete / first-paint and return a capped slice with no
+	# filter, sort or page contract. The registered *_page endpoint is the
+	# document-list view; these are its accelerators and migrate with it.
+	"jarvis.chat.agents_api.list_agents": "unpaginated companion of agents_catalog (list_agents_page)",
+	"jarvis.chat.agents_api.list_runs": "unpaginated companion of agent_runs (list_runs_page)",
+	"jarvis.chat.approvals_api.list_approvals": "unpaginated companion of approvals (list_approvals_page)",
+	"jarvis.chat.custom_skills_api.list_custom_skills": (
+		"composer '/' autocomplete feed for skills; unpaginated companion of the skills view"
+	),
+	"jarvis.chat.filebox.list_inbound": "unpaginated companion of file_box (list_inbound_page)",
+	"jarvis.chat.macros_api.list_macros": (
+		"Settings macro-runs dropdown feed; unpaginated companion of the macros view"
+	),
+	# Not document collections at all: option/name strings for a control.
+	"jarvis.chat.api.list_tools": "tool NAMES available to the caller — strings, not documents",
+	"jarvis.chat.personalise_api.list_role_options": "role name strings for a picker",
+	"jarvis.chat.custom_skills_api.list_shareable_users": "user picker feed for the share dialog",
+	"jarvis.chat.app_learning_api.list_custom_apps": "installed app names on the bench — not documents",
+	# Configuration, not a browsable collection.
+	"jarvis.chat.personalise_api.list_question_rules": (
+		"the question-bank rule configuration rendered as a settings form, not a list view"
+	),
+	# Transient per-session state, keyed by token and scoped to the caller's own
+	# live turns. It has no identity that survives the turn, no page and no sort.
+	"jarvis.chat.actions_api.list_pending_confirmations": (
+		"re-surfaces the caller's OWN currently-parked confirmation cards after a "
+		"reload; items are live in-flight tokens, not stored documents — they "
+		"vanish when the turn resolves, so there is nothing to page, sort or filter"
+	),
+}
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -487,6 +487,12 @@ NON_LIST_ENDPOINTS: dict[str, str] = {
 	"jarvis.chat.macros_api.list_macros": (
 		"Settings macro-runs dropdown feed; unpaginated companion of the macros view"
 	),
+	# The filters_v2 runtime-capability probe (P1-05): returns the per-view
+	# {view_key: enabled} map so a surface can pick transport at mount. It is
+	# metadata ABOUT the list views, not a list of documents.
+	"jarvis.chat.list_filters.list_filters_capabilities": (
+		"the filters_v2 per-view capability map (P1-05) — a config probe, not a document list"
+	),
 	# Not document collections at all: option/name strings for a control.
 	"jarvis.chat.api.list_tools": "tool NAMES available to the caller — strings, not documents",
 	"jarvis.chat.personalise_api.list_role_options": "role name strings for a picker",
@@ -533,3 +539,28 @@ def filterable_views() -> tuple[ListView, ...]:
 
 def endpoints_by_view() -> dict[str, tuple[str, ...]]:
 	return {v.view_key: v.endpoints for v in _VIEWS}
+
+
+# --------------------------------------------------------------------------- #
+# Discovery annotation (P0-04)
+# --------------------------------------------------------------------------- #
+#: Attribute a whitelisted callable can carry to declare itself a document-list
+#: endpoint for the Phase-0 discovery sweep, REGARDLESS of its name. The sweep
+#: matches the ``list_*`` / ``admin_list_*`` naming families across the customer
+#: API packages, but a differently-named collection endpoint (``search_records``,
+#: a bespoke feed) would otherwise evade discovery — decorate it with
+#: :func:`list_surface_endpoint` and it is caught and must be classified.
+LIST_SURFACE_ATTR = "_jarvis_list_surface"
+
+
+def list_surface_endpoint(fn):
+	"""Mark a whitelisted callable as a document-list endpoint for the registry
+	audit (see :data:`LIST_SURFACE_ATTR`). Purely declarative — it changes no
+	runtime behaviour, it only makes the endpoint visible to the completeness
+	sweep so it cannot ship unclassified."""
+	setattr(fn, LIST_SURFACE_ATTR, True)
+	return fn
+
+
+def is_list_surface_endpoint(fn) -> bool:
+	return bool(getattr(fn, LIST_SURFACE_ATTR, False))

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -1,0 +1,469 @@
+"""Server-owned registry of every active Jarvis document-collection surface.
+
+Plan 08 §10 Phase 0. The universal-filter mandate is only enforceable if the
+set of "document lists" is *data*, not folklore: a page that ships without a
+``view_key`` must fail a test, and a collection that is deliberately NOT a
+document list must say so, in writing, with a reason. This module is that
+registry; :mod:`jarvis.tests.test_list_registry` is the audit that reads it.
+
+What lives here
+---------------
+* the 8 shared-``ListPage`` consumers,
+* every bespoke collection surface (cards / rails / feeds / split panes) named
+  in plan 08 §3.3,
+* the surfaces the SPA's Settings area renders as tables/feeds,
+* explicit EXCLUSIONS (navigation lists, per-document detail feeds, dormant
+  UIs) each carrying a ``reason``.
+
+``view_key`` — never a client-supplied table or doctype — is what
+:func:`jarvis.chat.list_filters.get_list_filter_schema` and
+:func:`jarvis.chat.list_filters.compile_filters_v2` resolve. A caller can only
+ever name a key that already exists in this file.
+
+Registering a surface does NOT grant it filters: ``status`` says whether the
+endpoint speaks the ``filters_v2`` contract yet. Phase 1 migrates exactly two
+(Skills, Macros) as the contract's pilots; the rest stay ``PENDING`` and keep
+their curated filters until their wave.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# --------------------------------------------------------------------------- #
+# Vocabulary
+# --------------------------------------------------------------------------- #
+# A list of rows of ONE local DocType (the fixed visibility predicate may scope
+# it, e.g. owner-only, but every row is a document of ``root_doctype``).
+DOCUMENT_LIST = "document_list"
+# A list whose rows are computed over a root document plus joins/derived state
+# (File Box), or served by a remote authority (Support). Needs a declared
+# projection schema (plan §4.4) before it can offer metadata filters.
+PROJECTION = "projection"
+# Not a document list view: navigation, a single-document detail feed, or a
+# configuration editor. Carries a ``reason``.
+EXCLUDED_NOT_A_LIST = "excluded_not_a_list"
+# A real document list whose UI is not reachable today. Reactivation must flip
+# it to DOCUMENT_LIST *and* adopt the contract (plan §7).
+EXCLUDED_DORMANT = "excluded_dormant"
+
+CLASSIFICATIONS = frozenset(
+	{DOCUMENT_LIST, PROJECTION, EXCLUDED_NOT_A_LIST, EXCLUDED_DORMANT}
+)
+#: Classifications that must carry a ``reason``.
+EXCLUDED_CLASSIFICATIONS = frozenset({EXCLUDED_NOT_A_LIST, EXCLUDED_DORMANT})
+
+#: Speaks ``filters_v2`` today.
+MIGRATED = "migrated"
+#: Registered, still on its curated filter whitelist.
+PENDING = "pending"
+#: Not applicable (excluded surfaces).
+NOT_APPLICABLE = "n/a"
+
+STATUSES = frozenset({MIGRATED, PENDING, NOT_APPLICABLE})
+
+
+@dataclass(frozen=True)
+class ListView:
+	"""One registered surface.
+
+	``curated_filters`` maps the endpoint's CURRENT filter argument/key names to
+	the ``root_doctype`` fieldname each one actually filters, or ``None`` when
+	the key is a view-level pseudo control with no single backing field (e.g.
+	Skills' ``scope``, which means "mine | shared with me" — NOT the doctype's
+	``scope`` field, a genuinely confusable collision). The Phase-0 audit needs
+	that mapping to compare curated width against the metadata catalog without
+	guessing.
+	"""
+
+	view_key: str
+	label: str
+	classification: str
+	endpoints: tuple[str, ...]
+	root_doctype: str | None = None
+	#: For PROJECTION rows: the local root document the projection starts from.
+	projection_root: str | None = None
+	#: For PROJECTION rows served elsewhere: who owns the schema.
+	projection_authority: str = ""
+	clients: tuple[str, ...] = ("spa",)
+	surface: str = ""
+	wave: int | None = None
+	status: str = PENDING
+	curated_filters: dict[str, str | None] = field(default_factory=dict)
+	#: Distinguishes two views served by one endpoint (learning queue/decided).
+	variant: str = ""
+	reason: str = ""
+	notes: str = ""
+
+	@property
+	def is_document_list(self) -> bool:
+		return self.classification == DOCUMENT_LIST
+
+	@property
+	def is_excluded(self) -> bool:
+		return self.classification in EXCLUDED_CLASSIFICATIONS
+
+
+# --------------------------------------------------------------------------- #
+# The registry
+# --------------------------------------------------------------------------- #
+_VIEWS: tuple[ListView, ...] = (
+	# ---------------------------------------------------------------- wave 1 --
+	# The 8 shared-ListPage consumers.
+	ListView(
+		view_key="skills",
+		label="Skills",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Custom Skill",
+		endpoints=("jarvis.chat.custom_skills_api.list_custom_skills_page",),
+		surface="frontend/src/pages/skills/SkillsList.vue",
+		wave=1,
+		status=MIGRATED,
+		curated_filters={"scope": None, "enabled": "enabled", "user_invocable": "user_invocable"},
+		notes="filters_v2 pilot. `scope` is an ownership pseudo-filter (mine|shared), NOT the doctype's scope field.",
+	),
+	ListView(
+		view_key="macros",
+		label="Macros",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Macro",
+		endpoints=("jarvis.chat.macros_api.list_macros_page",),
+		surface="frontend/src/pages/macros/MacrosList.vue",
+		wave=1,
+		status=MIGRATED,
+		curated_filters={
+			"enabled": "enabled",
+			"schedule_enabled": "schedule_enabled",
+			"schedule_frequency": "schedule_frequency",
+		},
+		notes="filters_v2 pilot. Child table Jarvis Macro Step is the EXISTS-compilation case.",
+	),
+	ListView(
+		view_key="file_box",
+		label="File Box",
+		classification=PROJECTION,
+		projection_root="Jarvis Conversation",
+		endpoints=("jarvis.chat.filebox.list_inbound_page",),
+		clients=("spa", "pwa"),
+		surface="frontend/src/pages/files/FilesList.vue",
+		wave=1,
+		curated_filters={"status": None, "from_date": None, "to_date": None},
+		notes="Rows join approvals/messages/File and add a derived status; needs a declared projection schema (plan §4.4). Second client: pwa/src/api.js.",
+	),
+	ListView(
+		view_key="saved_dashboards",
+		label="Saved dashboards",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Dashboard",
+		endpoints=("jarvis.chat.dashboards_api.list_dashboards_page",),
+		surface="frontend/src/pages/dashboards/SavedDashboardsTab.vue",
+		wave=1,
+		curated_filters={"scope": "scope", "dashboard_type": "dashboard_type", "owner": "owner"},
+	),
+	ListView(
+		view_key="wiki_pages",
+		label="Wiki",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Wiki Page",
+		endpoints=("jarvis.chat.wiki.list_wiki_pages_page",),
+		surface="frontend/src/pages/skills/WikiTab.vue",
+		wave=1,
+		curated_filters={"page_type": "page_type", "scope_filter": None, "attention": None, "archived": "status"},
+		notes="`scope_filter` (all|org|role|mine) and `attention` are view predicates, not single fields; `archived` is a two-valued view switch over `status` (Active vs Archived).",
+	),
+	ListView(
+		view_key="support_tickets",
+		label="Support",
+		classification=PROJECTION,
+		projection_authority="remote Helpdesk via jarvis_admin proxy",
+		endpoints=("jarvis.support.api.list_tickets",),
+		surface="frontend/src/pages/support/SupportListPage.vue",
+		wave=1,
+		curated_filters={},
+		notes="C08-4: filtering is client-side over a capped fetch today; server-authoritative filtering needs an admin-repo contract change, so Support is its own cross-repo milestone.",
+	),
+	ListView(
+		view_key="triggers",
+		label="Triggers",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Trigger",
+		endpoints=("jarvis.chat.triggers_api.list_triggers_page",),
+		surface="frontend/src/pages/triggers/TriggersListPane.vue",
+		wave=1,
+		curated_filters={
+			"enabled": "enabled",
+			"action_type": "action_type",
+			"target_doctype": "target_doctype",
+			"doc_event": "doc_event",
+		},
+		notes="Manager/non-manager row redaction must survive migration.",
+	),
+	ListView(
+		view_key="trigger_activity",
+		label="Trigger activity",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Trigger Activity",
+		endpoints=("jarvis.chat.triggers_api.list_activity_page",),
+		surface="frontend/src/pages/triggers/ActivityTab.vue",
+		wave=1,
+		curated_filters={
+			"trigger": "trigger",
+			"status": "status",
+			"action_type": "action_type",
+			"target_doctype": "target_doctype",
+			"doc_event": "doc_event",
+			"from_date": "creation",
+			"to_date": "creation",
+		},
+		notes="C08-6: the per-row target-permission scan caps the count, so totals stay `approximate: True` — a declared exception, surfaced in the UI.",
+	),
+	# ---------------------------------------------------------------- wave 2 --
+	ListView(
+		view_key="agents_catalog",
+		label="Agents catalog",
+		classification=PROJECTION,
+		projection_root="Jarvis Agent Listing",
+		endpoints=("jarvis.chat.agents_api.list_agents_page",),
+		surface="frontend/src/pages/agents/AgentsList.vue",
+		wave=2,
+		curated_filters={"tab": None, "category": "category"},
+		notes="Computed install state / install count ride on the listing; `tab` is a fixed cohort. C08-1's canonical leak target lives here (Jarvis Agent Listing.skill_bundle, permlevel 1).",
+	),
+	ListView(
+		view_key="agent_activity",
+		label="Agent activity",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Agent Activity",
+		endpoints=("jarvis.chat.agents_api.list_agent_activity_page",),
+		surface="frontend/src/pages/agents/AgentActivityTab.vue",
+		wave=2,
+		curated_filters={"agent": "agent", "action": "action"},
+	),
+	ListView(
+		view_key="agent_runs",
+		label="Agent runs",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Agent Run",
+		endpoints=("jarvis.chat.agents_api.list_runs_page",),
+		surface="frontend/src/pages/agents/AgentRunsBoard.vue",
+		wave=2,
+		curated_filters={"agent": "agent", "status": "status"},
+	),
+	ListView(
+		view_key="agent_findings",
+		label="Agent findings",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Agent Finding",
+		endpoints=("jarvis.chat.agents_api.list_findings",),
+		surface="frontend/src/pages/agents/AgentRunsBoard.vue",
+		wave=2,
+		curated_filters={"run": None, "state": "state"},
+		notes="`run` means 'findings this run OBSERVED' (dedupe bumps last_seen_run), a fixed relation — not a plain equality on the run column.",
+	),
+	ListView(
+		view_key="agent_admin_overview",
+		label="Agents admin overview (System Manager)",
+		classification=EXCLUDED_NOT_A_LIST,
+		endpoints=("jarvis.chat.agents_api.get_agent_admin_overview",),
+		surface="frontend/src/pages/agents/AgentsList.vue",
+		status=NOT_APPLICABLE,
+		reason=(
+			"C08-4: not a list surface today. The endpoint returns a configuration "
+			"editor payload — the selectable Role set plus, per listing, its "
+			"allowed_roles and a rollup of every owner's installs. There is no "
+			"independent row collection to page, sort or filter; installs appear as "
+			"an attribute of a listing. Plan §7 wave 2's 'Agent admin installs' row "
+			"anticipates a real Jarvis Agent Installation list; if that is ever built "
+			"it registers as DOCUMENT_LIST before it becomes reachable."
+		),
+	),
+	ListView(
+		view_key="approvals",
+		label="Approvals",
+		classification=PROJECTION,
+		projection_root="Jarvis Approval Request",
+		endpoints=("jarvis.chat.approvals_api.list_approvals_page",),
+		surface="frontend/src/pages/approvals/ApprovalsBoard.vue",
+		wave=2,
+		curated_filters={"status": "status", "document_type": "document_type", "conversation": "conversation"},
+		notes="Computed `shared` flag + DocShare/owner visibility. Its document_type facet deliberately drops its own dimension — the C08-3 rule this module implements.",
+	),
+	ListView(
+		view_key="macro_runs",
+		label="Macro runs",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Macro Run",
+		endpoints=("jarvis.chat.macros_api.list_macro_runs",),
+		surface="frontend/src/pages/macros/RunsTab.vue",
+		wave=2,
+		curated_filters={"status": "status", "macro": "macro"},
+	),
+	# ---------------------------------------------------------------- wave 3 --
+	ListView(
+		view_key="personalise_questions",
+		label="Personalise questions",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Personalise Question",
+		endpoints=("jarvis.chat.personalise_api.list_questions_page",),
+		surface="frontend/src/components/personalise/QuestionsView.vue",
+		wave=3,
+		curated_filters={"status": "status"},
+	),
+	ListView(
+		view_key="personalise_notes",
+		label="Notes",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Voice Note",
+		endpoints=(
+			"jarvis.chat.personalise_api.list_notes_page",
+			"jarvis.chat.voice_notes_api.list_my_voice_notes_page",
+		),
+		clients=("spa", "pwa"),
+		surface="frontend/src/components/personalise/NotesView.vue",
+		wave=3,
+		curated_filters={"kind": "kind", "status": "status"},
+		notes="C08-4: TWO endpoints over one doctype. The SPA Notes pane calls list_notes_page; the PWA calls voice_notes_api.list_my_voice_notes_page. The compatibility window covers both.",
+	),
+	ListView(
+		view_key="learning_queue",
+		label="Learning queues (proposed / stale / approved)",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Learned Pattern",
+		endpoints=("jarvis.chat.learned_api.list_learned_patterns_page",),
+		surface="frontend/src/pages/skills/ReviewTab.vue",
+		wave=3,
+		curated_filters={
+			"status": "status",
+			"domain": "domain",
+			"strength": "strength_band",
+			"surfaced": "surfaced",
+			"disposition": None,
+		},
+		notes="Its domain facet drops the domain filter itself (C08-3). `disposition` is a compound predicate over status + review columns, not a single field.",
+	),
+	ListView(
+		view_key="learning_decided",
+		label="Learning decided log",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Learned Pattern",
+		endpoints=("jarvis.chat.learned_api.list_learned_patterns_page",),
+		variant="view=decided",
+		surface="frontend/src/pages/skills/ReviewTab.vue",
+		wave=3,
+		curated_filters={"domain": "domain", "strength": "strength_band", "disposition": None},
+		notes="Same endpoint, different view predicate: status is overridden with the human-touched terminal states and `surfaced` is ignored.",
+	),
+	ListView(
+		view_key="wiki_promotions",
+		label="Wiki promotion requests",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Wiki Promotion Request",
+		endpoints=("jarvis.chat.learned_api.list_promotion_requests_page",),
+		surface="frontend/src/pages/skills/ReviewTab.vue",
+		wave=3,
+		curated_filters={"status": "status"},
+	),
+	ListView(
+		view_key="skill_promotions",
+		label="Skill promotion requests",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis Skill Promotion Request",
+		endpoints=("jarvis.chat.custom_skills_api.list_skill_promotion_requests",),
+		surface="frontend/src/pages/skills/ReviewTab.vue",
+		wave=3,
+		curated_filters={"status": "status"},
+	),
+	# ------------------------------------------------------- Settings area --
+	ListView(
+		view_key="settings_user_usage_admin",
+		label="Settings → Usage (admin per-user table)",
+		classification=DOCUMENT_LIST,
+		root_doctype="Jarvis User Settings",
+		endpoints=("jarvis.chat.user_settings_api.admin_list_user_usage",),
+		surface="frontend/src/components/settings/UsageAdminPane.vue",
+		wave=3,
+		curated_filters={},
+		notes=(
+			"A real cross-user document collection (one row per Jarvis User Settings "
+			"row, Jarvis-Admin gated) rendered as a table. It has NO pagination, "
+			"search, sort or filter today, so migrating it is a widening, not a "
+			"port: it needs the paginated envelope first. Registered PENDING rather "
+			"than excluded so it cannot quietly stay filter-less."
+		),
+	),
+	ListView(
+		view_key="settings_tool_activity",
+		label="Settings → Activity (tool-run feed)",
+		classification=EXCLUDED_NOT_A_LIST,
+		endpoints=("jarvis.chat.api.get_tool_activity",),
+		surface="frontend/src/components/settings/ActivityPane.vue",
+		status=NOT_APPLICABLE,
+		reason=(
+			"A per-conversation detail feed, not a collection: rows are computed "
+			"groupings of tool calls within the ONE open conversation (turn → "
+			"{tools, ms, names}) and have no document identity, no stable key and "
+			"no existence outside that conversation's detail pane. It is the chat "
+			"equivalent of a form's timeline, which Frappe does not filter either."
+		),
+	),
+	# ------------------------------------------------ explicit non-lists ----
+	ListView(
+		view_key="chat_conversation_sidebar",
+		label="Chat conversation sidebar",
+		classification=EXCLUDED_NOT_A_LIST,
+		endpoints=("jarvis.chat.api.list_conversations",),
+		surface="frontend/src/pages/chat/ChatView.vue",
+		status=NOT_APPLICABLE,
+		reason=(
+			"Navigation, not a document list view (plan §3.3): a fixed-length "
+			"most-recent rail that exists to switch the primary surface. It has no "
+			"columns, no sort control and no page. Recorded here so the "
+			"navigation-vs-list boundary is auditable rather than folklore."
+		),
+	),
+	ListView(
+		view_key="app_learning_runs",
+		label="App learning runs (legacy)",
+		classification=EXCLUDED_DORMANT,
+		root_doctype="Jarvis App Learning Run",
+		endpoints=("jarvis.chat.app_learning_api.list_app_learning_runs_page",),
+		status=NOT_APPLICABLE,
+		reason=(
+			"Plan §7: the legacy App Learning Run UI is not reachable from the "
+			"shipped SPA. The endpoint still exists, so it is registered rather than "
+			"omitted; any reactivation must flip this row to DOCUMENT_LIST and adopt "
+			"the filters_v2 contract before the surface is made reachable."
+		),
+	),
+)
+
+_BY_KEY: dict[str, ListView] = {v.view_key: v for v in _VIEWS}
+
+
+# --------------------------------------------------------------------------- #
+# Accessors
+# --------------------------------------------------------------------------- #
+def all_views() -> tuple[ListView, ...]:
+	"""Every registered surface, in declaration order."""
+	return _VIEWS
+
+
+def get_view(view_key: str) -> ListView | None:
+	"""The registered surface for ``view_key``, or ``None``. Callers that must
+	fail closed use :func:`jarvis.chat.list_filters.resolve_view`."""
+	return _BY_KEY.get(view_key or "")
+
+
+def document_list_views() -> tuple[ListView, ...]:
+	"""Registered surfaces backed directly by one local DocType — the rows the
+	Phase-0 metadata audit and the schema builder can reason about today."""
+	return tuple(v for v in _VIEWS if v.is_document_list and v.root_doctype)
+
+
+def filterable_views() -> tuple[ListView, ...]:
+	"""Surfaces whose endpoints speak ``filters_v2`` today."""
+	return tuple(v for v in _VIEWS if v.status == MIGRATED)
+
+
+def endpoints_by_view() -> dict[str, tuple[str, ...]]:
+	return {v.view_key: v.endpoints for v in _VIEWS}

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -141,6 +141,7 @@ _order_by = list_filters.order_by
 
 @frappe.whitelist()
 @require_jarvis_user
+@list_filters.filter_errors_to_envelope
 def list_macros_page(
 	search: str = "",
 	filters: str | dict | None = None,

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -169,9 +169,7 @@ def list_macros_page(
 	q.server_condition("owner = %(me)s", me=me)
 
 	if search:
-		q.server_condition(
-			"(macro_name LIKE %(q)s OR description LIKE %(q)s)", q=f"%{_lk(search)}%"
-		)
+		q.server_condition("(macro_name LIKE %(q)s OR description LIKE %(q)s)", q=f"%{_lk(search)}%")
 	if "enabled" in f:
 		q.server_condition("enabled = %(enabled)s", enabled=_bool01(f["enabled"]))
 	if "schedule_enabled" in f:

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -11,6 +11,7 @@ import re
 import frappe
 from frappe import _
 
+from jarvis.chat import list_filters
 from jarvis.permissions import require_jarvis_user
 
 MACRO = "Jarvis Macro"
@@ -126,62 +127,16 @@ _MACROS_FILTERS = {"enabled", "schedule_enabled", "schedule_frequency"}
 _FREQUENCIES = {"daily", "weekly", "monthly"}
 
 
-def _lk(s: str) -> str:
-	"""Escape LIKE wildcards in user search input (``\\`` is the default escape)."""
-	return (s or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
-def _clamp_page(start, page_length) -> tuple[int, int]:
-	try:
-		start = max(0, int(start or 0))
-	except (TypeError, ValueError):
-		start = 0
-	try:
-		pl = int(page_length or 20)
-	except (TypeError, ValueError):
-		pl = 20
-	return start, max(1, min(pl, 100))
-
-
-def _bool01(v) -> int:
-	try:
-		iv = int(v)
-	except (TypeError, ValueError):
-		frappe.throw(_("Filter value must be 0 or 1."))
-	if iv not in (0, 1):
-		frappe.throw(_("Filter value must be 0 or 1."))
-	return iv
-
-
-def _load_filters(filters, allowed: set) -> dict:
-	if isinstance(filters, str):
-		if filters.strip():
-			try:
-				raw = frappe.parse_json(filters)
-			except Exception:
-				raw = {}
-		else:
-			raw = {}
-	else:
-		raw = filters or {}
-	if not isinstance(raw, dict):
-		raw = {}
-	out: dict = {}
-	for k, v in raw.items():
-		if k not in allowed:
-			frappe.throw(_("Unknown filter: {0}").format(k))
-		if v in (None, ""):
-			continue
-		out[k] = v
-	return out
-
-
-def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, prefix="") -> str:
-	col = sortable.get(sort_field or "")
-	if not col:
-		return f"{prefix}`{sortable[default_field]}` {default_dir}, {prefix}`name` asc"
-	d = "desc" if (sort_dir or "").lower() == "desc" else "asc"
-	return f"{prefix}`{col}` {d}, {prefix}`name` asc"
+# C08-5: ``_lk`` / ``_clamp_page`` / ``_bool01`` / ``_load_filters`` /
+# ``_order_by`` were copied into six list modules and had begun to drift. The
+# canonical implementations now live in ``jarvis.chat.list_filters``. The private
+# names stay bound here because triggers_api / dashboards_api / app_learning_api
+# import them FROM this module and migrate in their own wave.
+_lk = list_filters.escape_like
+_clamp_page = list_filters.clamp_page
+_bool01 = list_filters.bool01
+_load_filters = list_filters.load_legacy_filters
+_order_by = list_filters.order_by
 
 
 @frappe.whitelist()
@@ -189,6 +144,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 def list_macros_page(
 	search: str = "",
 	filters: str | dict | None = None,
+	filters_v2: str | list | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -196,30 +152,41 @@ def list_macros_page(
 ) -> dict:
 	"""Owner-scoped macros, server-side search/filter/sort/paginate (no step
 	bodies; ``merged_prompt`` body omitted — ``has_summary`` replaces it). Envelope
-	``{rows, total, has_more, start, page_length}``."""
+	``{rows, total, has_more, start, page_length}``.
+
+	``filters_v2`` (plan 08 §6.2) is ADDITIVE: the canonical clause list, validated
+	and compiled against this caller's schema by ``jarvis.chat.list_filters``.
+	Legacy ``filters`` keeps working unchanged for the compatibility window. The
+	owner predicate below is a server-authored condition on the query object, so a
+	user clause can only ever narrow it — never widen it (C08-5).
+	"""
 	me = frappe.session.user
 	start, pl = _clamp_page(start, page_length)
 	f = _load_filters(filters, _MACROS_FILTERS)
 
-	conds = ["owner = %(me)s"]
-	params: dict = {"me": me, "start": start, "page_length": pl}
+	q = list_filters.new_query("macros")
+	q.server_condition("owner = %(me)s", me=me)
 
 	if search:
-		params["q"] = f"%{_lk(search)}%"
-		conds.append("(macro_name LIKE %(q)s OR description LIKE %(q)s)")
+		q.server_condition(
+			"(macro_name LIKE %(q)s OR description LIKE %(q)s)", q=f"%{_lk(search)}%"
+		)
 	if "enabled" in f:
-		params["enabled"] = _bool01(f["enabled"])
-		conds.append("enabled = %(enabled)s")
+		q.server_condition("enabled = %(enabled)s", enabled=_bool01(f["enabled"]))
 	if "schedule_enabled" in f:
-		params["schedule_enabled"] = _bool01(f["schedule_enabled"])
-		conds.append("schedule_enabled = %(schedule_enabled)s")
+		q.server_condition(
+			"schedule_enabled = %(schedule_enabled)s", schedule_enabled=_bool01(f["schedule_enabled"])
+		)
 	if "schedule_frequency" in f:
 		if f["schedule_frequency"] not in _FREQUENCIES:
 			frappe.throw(_("Invalid schedule_frequency filter."))
-		params["schedule_frequency"] = f["schedule_frequency"]
-		conds.append("schedule_frequency = %(schedule_frequency)s")
+		q.server_condition(
+			"schedule_frequency = %(schedule_frequency)s", schedule_frequency=f["schedule_frequency"]
+		)
 
-	where = " AND ".join(conds)
+	q.apply(filters_v2)
+	where = q.where()
+	params = q.params({"start": start, "page_length": pl})
 	order = _order_by(sort_field, sort_dir, _MACROS_SORTABLE, "macro_name", "asc")
 
 	total = frappe.db.sql(f"SELECT COUNT(*) FROM `tabJarvis Macro` WHERE {where}", params)[0][0]

--- a/jarvis/tests/test_list_filters.py
+++ b/jarvis/tests/test_list_filters.py
@@ -1,0 +1,786 @@
+"""The shared list-filter schema + compiler (plan 08 Phase 1, C08-1..C08-5).
+
+The load-bearing tests, in the order they matter:
+
+1. **Permlevel is enforced (C08-1).** Twice: against the real moat field
+   (``Jarvis Agent Listing.skill_bundle``, permlevel 1, System-Manager-only) and
+   end-to-end through a registered view with a Property-Setter-raised permlevel,
+   so both the schema and the compiler are proven at two roles, in both
+   directions — a privileged caller CAN see and filter it, an unprivileged one
+   can do neither.
+2. **Fail closed.** Unknown view / field / operator / value never degrades into
+   a wider result set; nothing is silently stripped.
+3. **Injection stays bound.** Identifiers come from metadata; values are params.
+4. **Child EXISTS.** No parent duplication, and same-child clauses bind to the
+   SAME child row (the C08-2 semantic decision).
+5. **Caps** on client input; server-authored ``IN`` lists exempt (C08-5).
+6. **Facet self-exclusion** (C08-3) and **schema cache user isolation**.
+
+Runs on patterntest.localhost. Uses ``unittest``-style explicit fixtures with
+prefix-based cleanup, matching test_feature_pages_api.py, because the permlevel
+cases need REAL users holding REAL roles.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import unittest
+
+import frappe
+
+from jarvis.chat import list_filters
+from jarvis.chat.list_filters import (
+	ERR_INVALID_OPERATOR,
+	ERR_INVALID_VALUE,
+	ERR_TOO_MANY_CLAUSES,
+	ERR_TOO_MANY_VALUES,
+	ERR_UNKNOWN_FIELD,
+	ERR_UNKNOWN_VIEW,
+	ERR_VALUE_TOO_LONG,
+	ERR_VIEW_NOT_FILTERABLE,
+	ListFilterError,
+	build_field_catalog,
+	compile_list_filters,
+	get_schema,
+	new_query,
+)
+
+SKILL = "Jarvis Custom Skill"
+MACRO = "Jarvis Macro"
+LISTING = "Jarvis Agent Listing"
+
+USER_SM = "lf-user-sm@example.com"
+USER_A = "lf-user-a@example.com"
+USER_B = "lf-user-b@example.com"
+PERMLEVEL_ROLE = "lf-permlevel-reader"
+
+
+# --------------------------------------------------------------------------- #
+# fixtures
+# --------------------------------------------------------------------------- #
+def _ensure_role(name: str) -> None:
+	if not frappe.db.exists("Role", name):
+		frappe.get_doc({"doctype": "Role", "role_name": name, "desk_access": 1}).insert(
+			ignore_permissions=True
+		)
+		frappe.db.commit()
+
+
+def _ensure_user(email: str, roles: tuple[str, ...]) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert()
+		frappe.db.commit()
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+	doc = frappe.get_doc("User", email)
+	have = set(frappe.get_roles(email))
+	want = set(roles)
+	extra = {"System Manager"} - want
+	if extra & have:
+		doc.remove_roles(*(extra & have))
+	missing = want - have
+	if missing:
+		doc.add_roles(*missing)
+	frappe.db.commit()
+	frappe.clear_cache(user=email)
+	return email
+
+
+def setUpModule() -> None:
+	frappe.set_user("Administrator")
+	_ensure_role(PERMLEVEL_ROLE)
+	_ensure_user(USER_SM, ("Jarvis User", "System Manager"))
+	_ensure_user(USER_A, ("Jarvis User", PERMLEVEL_ROLE))
+	_ensure_user(USER_B, ("Jarvis User",))
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _wipe() -> None:
+	for name in frappe.get_all(SKILL, filters={"skill_name": ["like", "lf-%"]}, pluck="name"):
+		frappe.delete_doc(SKILL, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(MACRO, filters={"macro_name": ["like", "lf-%"]}, pluck="name"):
+		frappe.delete_doc(MACRO, name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _mk_skill(owner: str, name: str, **kw) -> str:
+	with _as(owner):
+		doc = frappe.get_doc(
+			{
+				"doctype": SKILL,
+				"skill_name": name,
+				"description": kw.get("description", f"{name} description"),
+				"instructions": kw.get("instructions", "do the thing"),
+				"enabled": kw.get("enabled", 1),
+				"user_invocable": kw.get("user_invocable", 1),
+			}
+		)
+		doc.flags.ignore_validate = True
+		doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+def _mk_macro(owner: str, name: str, steps: list[tuple[str, str]] | None = None, **kw) -> str:
+	with _as(owner):
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": name,
+				"description": kw.get("description", "m"),
+				"enabled": kw.get("enabled", 1),
+				"stop_on_error": 1,
+				"steps": [{"label": lbl, "prompt": prm} for lbl, prm in (steps or [("s0", "p0")])],
+			}
+		)
+		doc.flags.ignore_validate = True
+		doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+def _names(catalog) -> set[str]:
+	return {f["fieldname"] for f in catalog}
+
+
+def _entry(schema, doctype, fieldname):
+	for f in schema["fields"]:
+		if f["doctype"] == doctype and f["fieldname"] == fieldname:
+			return f
+	return None
+
+
+# --------------------------------------------------------------------------- #
+# 1. Permlevel (C08-1)
+# --------------------------------------------------------------------------- #
+class TestPermlevelIsEnforced(unittest.TestCase):
+	"""The agents-IP moat case, on the real DocType, at two real roles."""
+
+	def test_moat_field_is_visible_to_system_manager_only(self):
+		self.assertTrue(frappe.db.exists("DocType", LISTING), "Jarvis Agent Listing must exist")
+		meta = frappe.get_meta(LISTING)
+		bundle = meta.get_field("skill_bundle")
+		# Non-vacuity guard 1: the field is really permlevel 1 and really a
+		# value-bearing type. If someone flattens the permlevel, this test must
+		# fail LOUDLY rather than quietly pass for the wrong reason.
+		self.assertIsNotNone(bundle, "skill_bundle disappeared from Jarvis Agent Listing")
+		self.assertEqual(int(bundle.permlevel or 0), 1)
+		self.assertNotIn(bundle.fieldtype, list_filters.NO_VALUE_FIELDTYPES)
+
+		privileged = _names(build_field_catalog(LISTING, user=USER_SM))
+		ordinary = _names(build_field_catalog(LISTING, user=USER_B))
+
+		# Non-vacuity guard 2: the ordinary catalog is not simply empty.
+		self.assertIn("category", ordinary, "the unprivileged catalog collapsed — test would be vacuous")
+		self.assertIn("skill_bundle", privileged, "System Manager should read permlevel 1")
+		self.assertNotIn(
+			"skill_bundle",
+			ordinary,
+			"a plain Jarvis User can see the agents-IP moat field in the filter schema",
+		)
+
+
+class TestPermlevelEndToEnd(unittest.TestCase):
+	"""Same rule, but through a REGISTERED view: schema + compiler, two roles.
+
+	``Jarvis Custom Skill.instructions`` is pushed to permlevel 1 with a Property
+	Setter (which also proves plan §11.1's 'customizations reflected without a
+	frontend release'), and a Custom DocPerm grants permlevel-1 read to a role
+	only USER_A holds.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		from frappe.permissions import add_permission, update_permission_property
+
+		frappe.make_property_setter(
+			{
+				"doctype": SKILL,
+				"fieldname": "instructions",
+				"property": "permlevel",
+				"value": 1,
+				"property_type": "Int",
+			},
+			is_system_generated=False,
+			validate_fields_for_doctype=False,
+		)
+		add_permission(SKILL, PERMLEVEL_ROLE, 1)
+		update_permission_property(SKILL, PERMLEVEL_ROLE, 1, "read", 1)
+		frappe.db.commit()
+		frappe.clear_cache(doctype=SKILL)
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		from frappe.permissions import reset_perms
+
+		for name in frappe.get_all(
+			"Property Setter",
+			filters={"doc_type": SKILL, "field_name": "instructions", "property": "permlevel"},
+			pluck="name",
+		):
+			frappe.delete_doc("Property Setter", name, force=True, ignore_permissions=True)
+		reset_perms(SKILL)
+		frappe.db.commit()
+		frappe.clear_cache(doctype=SKILL)
+
+	def test_schema_shows_the_field_only_to_the_privileged_role(self):
+		privileged = get_schema("skills", user=USER_A)
+		ordinary = get_schema("skills", user=USER_B)
+		self.assertIsNotNone(
+			_entry(privileged, SKILL, "instructions"),
+			"the permlevel-1 grant did not take effect — fixture broken, test would be vacuous",
+		)
+		self.assertIsNone(_entry(ordinary, SKILL, "instructions"))
+		# Non-vacuity: the ordinary schema is otherwise full.
+		self.assertIsNotNone(_entry(ordinary, SKILL, "skill_name"))
+		self.assertIsNotNone(_entry(ordinary, SKILL, "enabled"))
+
+	def test_compiler_rejects_the_field_for_the_unprivileged_role(self):
+		clause = [{"doctype": SKILL, "fieldname": "instructions", "operator": "like", "value": "secret"}]
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("skills", clause, user=USER_B)
+		self.assertEqual(caught.exception.filter_error_code, ERR_UNKNOWN_FIELD)
+
+	def test_compiler_accepts_the_field_for_the_privileged_role(self):
+		clause = [{"doctype": SKILL, "fieldname": "instructions", "operator": "like", "value": "secret"}]
+		compiled = compile_list_filters("skills", clause, user=USER_A)
+		fragment = compiled.fragment()
+		self.assertIn("`instructions`", fragment)
+		self.assertNotIn("secret", fragment)
+		self.assertIn("%secret%", compiled.params.values())
+
+	def test_schema_cache_never_serves_one_user_to_another(self):
+		# Warm A, then B, then A again: B's build must not evict or overwrite A's.
+		first_a = get_schema("skills", user=USER_A)
+		b = get_schema("skills", user=USER_B)
+		second_a = get_schema("skills", user=USER_A)
+		self.assertIsNotNone(_entry(first_a, SKILL, "instructions"))
+		self.assertIsNone(_entry(b, SKILL, "instructions"))
+		self.assertIsNotNone(_entry(second_a, SKILL, "instructions"))
+		self.assertNotEqual(first_a["schema_revision"], b["schema_revision"])
+
+
+# --------------------------------------------------------------------------- #
+# 2. Catalog shape / Frappe parity
+# --------------------------------------------------------------------------- #
+class TestCatalogShape(unittest.TestCase):
+	def test_standard_fields_present_and_docstatus_absent_for_non_submittable(self):
+		schema = get_schema("skills", user=USER_A)
+		names = {f["fieldname"] for f in schema["fields"] if not f["is_child"]}
+		for std in ("name", "owner", "creation", "modified", "modified_by", "idx"):
+			self.assertIn(std, names)
+		self.assertNotIn("docstatus", names, "Jarvis Custom Skill is not submittable")
+
+	def test_table_containers_are_not_offered_but_their_children_are(self):
+		schema = get_schema("macros", user=USER_A)
+		main = {f["fieldname"] for f in schema["fields"] if not f["is_child"]}
+		self.assertNotIn("steps", main, "a Table field is not itself filterable")
+		child = {(f["doctype"], f["fieldname"]) for f in schema["fields"] if f["is_child"]}
+		self.assertIn(("Jarvis Macro Step", "label"), child)
+		self.assertIn(("Jarvis Macro Step", "prompt"), child)
+
+	def test_child_fields_are_labelled_the_frappe_way(self):
+		schema = get_schema("macros", user=USER_A)
+		entry = _entry(schema, "Jarvis Macro Step", "label")
+		self.assertTrue(entry["label"].endswith("(Jarvis Macro Step)"), entry["label"])
+
+	def test_operator_vocabulary_matches_frappe_per_family(self):
+		schema = get_schema("macros", user=USER_A)
+		check = _entry(schema, MACRO, "enabled")
+		self.assertEqual(check["operators"], ["="], "Check exposes Equals only")
+		self.assertEqual(check["default_operator"], "=")
+
+		data = _entry(schema, MACRO, "macro_name")
+		self.assertEqual(data["default_operator"], "like", "Data defaults to like on a small table")
+		self.assertNotIn("Between", data["operators"])
+		self.assertIn("like", data["operators"])
+
+		dt = _entry(schema, MACRO, "last_run_at")
+		self.assertEqual(dt["default_operator"], "Between")
+		for banned in ("like", "not like", "in", "not in", "=", "!="):
+			self.assertNotIn(banned, dt["operators"], f"Datetime must not offer {banned}")
+
+		select = _entry(schema, MACRO, "schedule_frequency")
+		self.assertEqual(select["default_operator"], "=")
+		self.assertNotIn("like", select["operators"])
+
+		link = _entry(get_schema("skills", user=USER_A), SKILL, "target_role")
+		self.assertEqual(link["default_operator"], "=")
+		for banned in (">", "<", ">=", "<=", "Between", "Timespan"):
+			self.assertNotIn(banned, link["operators"])
+
+		small_text = _entry(schema, MACRO, "description")
+		self.assertEqual(
+			small_text["default_operator"],
+			"=",
+			"deviation D5: Frappe defaults Small Text to '=', not 'like' as plan §5.1 claimed",
+		)
+
+	def test_json_array_standard_fields_are_like_only(self):
+		schema = get_schema("skills", user=USER_A)
+		assign = _entry(schema, SKILL, "_assign")
+		if assign is None:
+			self.skipTest("_assign column not present on this site")
+		self.assertTrue(assign["json_array"])
+		self.assertEqual(assign["default_operator"], "like")
+		self.assertEqual(set(assign["operators"]), {"like", "not like", "is"})
+
+	def test_nested_set_operators_are_not_advertised(self):
+		for view in ("skills", "macros"):
+			for entry in get_schema(view, user=USER_A)["fields"]:
+				self.assertNotIn("descendants of", entry["operators"])
+				self.assertNotIn("ancestors of", entry["operators"])
+
+
+# --------------------------------------------------------------------------- #
+# 3. Fail closed
+# --------------------------------------------------------------------------- #
+class TestFailsClosed(unittest.TestCase):
+	def _code(self, fn, *a, **kw) -> str:
+		with self.assertRaises(ListFilterError) as caught:
+			fn(*a, **kw)
+		return caught.exception.filter_error_code
+
+	def test_unknown_view(self):
+		self.assertEqual(
+			self._code(compile_list_filters, "not-a-view", [], user=USER_A), ERR_UNKNOWN_VIEW
+		)
+
+	def test_projection_view_is_not_filterable_yet(self):
+		# file_box / approvals / agents_catalog have no declared projection schema
+		# yet: answering with the root DocType's catalog would describe rows the
+		# endpoint does not return.
+		for view in ("file_box", "approvals", "agents_catalog", "support_tickets"):
+			with self.subTest(view=view):
+				self.assertEqual(
+					self._code(compile_list_filters, view, [], user=USER_A), ERR_VIEW_NOT_FILTERABLE
+				)
+
+	def test_excluded_view_is_not_filterable(self):
+		self.assertEqual(
+			self._code(compile_list_filters, "chat_conversation_sidebar", [], user=USER_A),
+			ERR_VIEW_NOT_FILTERABLE,
+		)
+
+	def test_unknown_field(self):
+		clause = [{"doctype": SKILL, "fieldname": "no_such_field", "operator": "=", "value": "x"}]
+		self.assertEqual(self._code(compile_list_filters, "skills", clause, user=USER_A), ERR_UNKNOWN_FIELD)
+
+	def test_field_from_another_doctype_is_rejected(self):
+		clause = [{"doctype": "User", "fieldname": "password", "operator": "like", "value": "%"}]
+		self.assertEqual(self._code(compile_list_filters, "skills", clause, user=USER_A), ERR_UNKNOWN_FIELD)
+
+	def test_child_field_of_an_unrelated_doctype_is_rejected(self):
+		clause = [{"doctype": "Jarvis Macro Step", "fieldname": "prompt", "operator": "=", "value": "x"}]
+		self.assertEqual(
+			self._code(compile_list_filters, "skills", clause, user=USER_A),
+			ERR_UNKNOWN_FIELD,
+			"a child of a DIFFERENT root must not be filterable here",
+		)
+
+	def test_invalid_operator_for_family(self):
+		clause = [{"doctype": MACRO, "fieldname": "enabled", "operator": "like", "value": "1"}]
+		self.assertEqual(
+			self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_OPERATOR
+		)
+
+	def test_unknown_operator(self):
+		clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "regexp", "value": "x"}]
+		self.assertEqual(
+			self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_OPERATOR
+		)
+
+	def test_bad_check_value(self):
+		clause = [{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": "maybe"}]
+		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
+
+	def test_select_value_must_be_an_option(self):
+		clause = [
+			{"doctype": MACRO, "fieldname": "schedule_frequency", "operator": "=", "value": "hourly"}
+		]
+		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
+
+	def test_empty_in_list_is_rejected(self):
+		clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "in", "value": []}]
+		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
+
+	def test_is_needs_set_or_not_set(self):
+		clause = [{"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "yes"}]
+		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
+
+	def test_password_fieldtype_is_never_offered(self):
+		# Deviation D2. Proven structurally: no catalog on any registered
+		# doctype-backed view contains a Password field.
+		from jarvis.chat import list_registry
+
+		for view in list_registry.document_list_views():
+			for entry in build_field_catalog(view.root_doctype, user="Administrator"):
+				self.assertNotEqual(entry["fieldtype"], "Password")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Injection
+# --------------------------------------------------------------------------- #
+class TestInjectionStaysBound(unittest.TestCase):
+	PAYLOADS = (
+		"' OR 1=1 -- ",
+		"'; DROP TABLE `tabJarvis Macro`; --",
+		"\\' UNION SELECT name FROM `tabUser` --",
+		"%' AND (SELECT SLEEP(5)) AND '%",
+	)
+
+	def test_values_never_reach_sql(self):
+		for payload in self.PAYLOADS:
+			with self.subTest(payload=payload):
+				clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": payload}]
+				compiled = compile_list_filters("macros", clause, user=USER_A)
+				fragment = compiled.fragment()
+				self.assertNotIn("OR 1=1", fragment)
+				self.assertNotIn("DROP TABLE", fragment)
+				self.assertNotIn("UNION", fragment)
+				self.assertNotIn("SLEEP", fragment)
+				# Exactly one placeholder, and the payload lives in the params.
+				self.assertEqual(fragment.count("%("), 1)
+				self.assertTrue(any(payload.strip("%") in str(v) for v in compiled.params.values()))
+
+	def test_identifier_shaped_payloads_are_rejected_not_interpolated(self):
+		for bad in ("name`; DROP TABLE x; --", "name FROM tabUser", "*"):
+			with self.subTest(bad=bad):
+				clause = [{"doctype": MACRO, "fieldname": bad, "operator": "=", "value": "x"}]
+				with self.assertRaises(ListFilterError) as caught:
+					compile_list_filters("macros", clause, user=USER_A)
+				self.assertEqual(caught.exception.filter_error_code, ERR_UNKNOWN_FIELD)
+
+	def test_a_bound_payload_really_runs_and_matches_nothing(self):
+		"""End to end: the query executes (so the SQL is valid) and the payload is
+		treated as text, not as syntax."""
+		_wipe()
+		_mk_macro(USER_A, "lf-inject-target")
+		try:
+			from jarvis.chat.macros_api import list_macros_page
+
+			with _as(USER_A):
+				res = list_macros_page(
+					filters_v2=[
+						{
+							"doctype": MACRO,
+							"fieldname": "macro_name",
+							"operator": "like",
+							"value": "' OR 1=1 -- ",
+						}
+					]
+				)
+			self.assertEqual(res["total"], 0)
+			self.assertEqual(res["rows"], [])
+			self.assertTrue(frappe.db.exists(MACRO, {"macro_name": "lf-inject-target"}))
+		finally:
+			_wipe()
+
+
+# --------------------------------------------------------------------------- #
+# 5. Child EXISTS semantics (C08-2)
+# --------------------------------------------------------------------------- #
+class TestChildFilters(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		_wipe()
+		# two steps, distinct values -> the same-child grouping case
+		cls.split = _mk_macro(USER_A, "lf-child-split", steps=[("alpha", "p1"), ("beta", "p2")])
+		# two steps that BOTH match one clause -> the duplication case
+		cls.dup = _mk_macro(USER_A, "lf-child-dup", steps=[("gamma", "x"), ("gamma", "y")])
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def _run(self, clauses):
+		from jarvis.chat.macros_api import list_macros_page
+
+		with _as(USER_A):
+			return list_macros_page(filters_v2=clauses, page_length=50)
+
+	def test_matching_children_do_not_duplicate_the_parent(self):
+		res = self._run([{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "gamma"}])
+		self.assertEqual(res["total"], 1, "two matching child rows must not duplicate the parent")
+		self.assertEqual(len(res["rows"]), 1)
+		self.assertEqual(res["rows"][0]["name"], self.dup)
+		self.assertFalse(res["has_more"])
+
+	def test_two_clauses_on_one_child_must_hit_the_same_row(self):
+		same = self._run(
+			[
+				{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "alpha"},
+				{"doctype": "Jarvis Macro Step", "fieldname": "prompt", "operator": "=", "value": "p1"},
+			]
+		)
+		self.assertEqual(same["total"], 1, "alpha/p1 live on the SAME step, so the macro matches")
+
+		cross = self._run(
+			[
+				{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "alpha"},
+				{"doctype": "Jarvis Macro Step", "fieldname": "prompt", "operator": "=", "value": "p2"},
+			]
+		)
+		self.assertEqual(
+			cross["total"],
+			0,
+			"alpha and p2 are on DIFFERENT steps: Frappe's single-join semantics "
+			"require one child row to satisfy both clauses (C08-2)",
+		)
+
+	def test_one_exists_per_child_doctype(self):
+		compiled = compile_list_filters(
+			"macros",
+			[
+				{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "alpha"},
+				{"doctype": "Jarvis Macro Step", "fieldname": "prompt", "operator": "=", "value": "p1"},
+			],
+			user=USER_A,
+		)
+		fragment = compiled.fragment()
+		self.assertEqual(fragment.count("EXISTS ("), 1, "same-child clauses share ONE subquery")
+		self.assertIn("`parenttype`", fragment)
+		self.assertIn("`parent` = `tabJarvis Macro`.`name`", fragment)
+
+	def test_child_and_main_clauses_combine(self):
+		res = self._run(
+			[
+				{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "alpha"},
+				{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lf-child"},
+			]
+		)
+		self.assertEqual(res["total"], 1)
+		self.assertEqual(res["rows"][0]["name"], self.split)
+
+
+# --------------------------------------------------------------------------- #
+# 6. Caps (plan §9 / C08-5)
+# --------------------------------------------------------------------------- #
+class TestCaps(unittest.TestCase):
+	def _code(self, clauses) -> str:
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("macros", clauses, user=USER_A)
+		return caught.exception.filter_error_code
+
+	def test_clause_count_cap(self):
+		clause = {"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "x"}
+		ok = [dict(clause) for _ in range(list_filters.MAX_CLAUSES)]
+		compile_list_filters("macros", ok, user=USER_A)  # at the cap: fine
+		self.assertEqual(self._code(ok + [dict(clause)]), ERR_TOO_MANY_CLAUSES)
+
+	def test_in_value_cap(self):
+		values = [f"v{i}" for i in range(list_filters.MAX_IN_VALUES + 1)]
+		clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "in", "value": values}]
+		self.assertEqual(self._code(clause), ERR_TOO_MANY_VALUES)
+
+	def test_value_length_cap(self):
+		clause = [
+			{
+				"doctype": MACRO,
+				"fieldname": "macro_name",
+				"operator": "like",
+				"value": "x" * (list_filters.MAX_VALUE_CHARS + 1),
+			}
+		]
+		self.assertEqual(self._code(clause), ERR_VALUE_TOO_LONG)
+
+	def test_server_authored_in_lists_are_exempt(self):
+		"""C08-5: 'every skill shared with me' is not attacker input."""
+		big = tuple(f"row-{i}" for i in range(list_filters.MAX_IN_VALUES * 5))
+		q = new_query("skills", user=USER_A)
+		q.server_condition("name IN %(shared)s", shared=big)
+		q.apply([])
+		self.assertIn("name IN %(shared)s", q.where())
+		self.assertEqual(len(q.params()["shared"]), list_filters.MAX_IN_VALUES * 5)
+
+
+# --------------------------------------------------------------------------- #
+# 7. The structural barrier + facet self-exclusion
+# --------------------------------------------------------------------------- #
+class TestQueryBarrierAndFacets(unittest.TestCase):
+	def test_server_predicate_and_user_clauses_are_separate_stores(self):
+		q = new_query("macros", user=USER_A)
+		q.server_condition("owner = %(me)s", me=USER_A)
+		q.apply([{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": 1}])
+		where = q.where()
+		self.assertTrue(where.startswith("owner = %(me)s AND "), where)
+		self.assertIn("`tabJarvis Macro`.`enabled`", where)
+		# The user parameter namespace is disjoint from the server's.
+		user_params = [k for k in q.params() if k.startswith(list_filters.USER_PARAM_PREFIX)]
+		self.assertTrue(user_params)
+		self.assertNotIn("me", user_params)
+
+	def test_server_condition_refuses_the_user_parameter_namespace(self):
+		q = new_query("macros", user=USER_A)
+		with self.assertRaises(ValueError):
+			q.server_condition("x = %(jf0_0)s", jf0_0="spoof")
+
+	def test_server_condition_refuses_positional_placeholders(self):
+		q = new_query("macros", user=USER_A)
+		with self.assertRaises(ValueError):
+			q.server_condition("owner = %s")
+
+	def test_no_clauses_leaves_the_server_predicate_untouched(self):
+		q = new_query("macros", user=USER_A)
+		q.server_condition("owner = %(me)s", me=USER_A)
+		q.apply(None)
+		self.assertEqual(q.where(), "owner = %(me)s")
+		self.assertEqual(q.params(), {"me": USER_A})
+
+	def test_facet_query_drops_only_its_own_dimension(self):
+		q = new_query("macros", user=USER_A)
+		q.server_condition("owner = %(me)s", me=USER_A)
+		q.apply(
+			[
+				{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": 1},
+				{"doctype": MACRO, "fieldname": "schedule_frequency", "operator": "=", "value": "daily"},
+			]
+		)
+		full = q.where()
+		self.assertIn("`enabled`", full)
+		self.assertIn("`schedule_frequency`", full)
+
+		faceted = q.where(exclude_dimension=(MACRO, "schedule_frequency"))
+		self.assertIn("owner = %(me)s", faceted)
+		self.assertIn("`enabled`", faceted)
+		self.assertNotIn("`schedule_frequency`", faceted)
+
+	def test_facet_exclusion_regroups_the_child_exists(self):
+		q = new_query("macros", user=USER_A)
+		q.apply(
+			[
+				{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "a"},
+				{"doctype": "Jarvis Macro Step", "fieldname": "prompt", "operator": "=", "value": "b"},
+			]
+		)
+		self.assertEqual(q.where().count("EXISTS ("), 1)
+		reduced = q.where(exclude_dimension=("Jarvis Macro Step", "prompt"))
+		self.assertEqual(reduced.count("EXISTS ("), 1)
+		self.assertIn("`label`", reduced)
+		self.assertNotIn("`prompt`", reduced)
+
+	def test_excluding_the_only_child_clause_drops_the_exists_entirely(self):
+		q = new_query("macros", user=USER_A)
+		q.server_condition("owner = %(me)s", me=USER_A)
+		q.apply([{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "a"}])
+		self.assertEqual(q.where(exclude_dimension=("Jarvis Macro Step", "label")), "owner = %(me)s")
+
+
+# --------------------------------------------------------------------------- #
+# 8. Typed compilation details
+# --------------------------------------------------------------------------- #
+class TestTypedCompilation(unittest.TestCase):
+	def _fragment(self, view, clause):
+		return compile_list_filters(view, [clause], user=USER_A).fragment()
+
+	def test_is_set_and_is_not_set(self):
+		st = self._fragment("macros", {"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "set"})
+		self.assertIn("ifnull(`tabJarvis Macro`.`description`, '') != ''", st)
+		unset = self._fragment(
+			"macros", {"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "not set"}
+		)
+		self.assertIn("ifnull(`tabJarvis Macro`.`description`, '') = ''", unset)
+
+	def test_between_on_datetime_expands_day_bounds(self):
+		compiled = compile_list_filters(
+			"macros",
+			[
+				{
+					"doctype": MACRO,
+					"fieldname": "last_run_at",
+					"operator": "Between",
+					"value": ["2026-07-01", "2026-07-31"],
+				}
+			],
+			user=USER_A,
+		)
+		values = sorted(str(v) for v in compiled.params.values())
+		self.assertTrue(values[0].startswith("2026-07-01 00:00:00"), values)
+		self.assertTrue(values[1].startswith("2026-07-31 23:59:59"), values)
+		self.assertIn("BETWEEN", compiled.fragment())
+
+	def test_timespan_resolves_to_a_bound_range(self):
+		compiled = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "creation", "operator": "Timespan", "value": "today"}],
+			user=USER_A,
+		)
+		self.assertIn("BETWEEN", compiled.fragment())
+		self.assertEqual(len([v for v in compiled.params.values()]), 2)
+
+	def test_unknown_timespan_fails_closed(self):
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters(
+				"macros",
+				[{"doctype": MACRO, "fieldname": "creation", "operator": "Timespan", "value": "last fortnight"}],
+				user=USER_A,
+			)
+		self.assertEqual(caught.exception.filter_error_code, ERR_INVALID_VALUE)
+
+	def test_like_wraps_wildcards_like_frappes_ui(self):
+		compiled = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "month end"}],
+			user=USER_A,
+		)
+		self.assertIn("%month end%", compiled.params.values())
+
+	def test_like_keeps_a_user_supplied_wildcard(self):
+		compiled = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "month%"}],
+			user=USER_A,
+		)
+		self.assertIn("month%", compiled.params.values())
+		self.assertNotIn("%month%%", compiled.params.values())
+
+	def test_in_binds_a_tuple(self):
+		compiled = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "macro_name", "operator": "in", "value": ["a", "b"]}],
+			user=USER_A,
+		)
+		self.assertIn("IN %(", compiled.fragment())
+		self.assertIn(("a", "b"), compiled.params.values())
+
+	def test_check_normalizes_to_zero_or_one(self):
+		compiled = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": "1"}],
+			user=USER_A,
+		)
+		self.assertIn(1, compiled.params.values())
+
+	def test_operator_defaults_to_the_schema_default_when_omitted(self):
+		compiled = compile_list_filters(
+			"macros", [{"doctype": MACRO, "fieldname": "macro_name", "value": "x"}], user=USER_A
+		)
+		self.assertIn("LIKE", compiled.fragment())
+		self.assertIn("%x%", compiled.params.values())

--- a/jarvis/tests/test_list_filters.py
+++ b/jarvis/tests/test_list_filters.py
@@ -28,7 +28,7 @@ import unittest
 
 import frappe
 
-from jarvis.chat import list_filters
+from jarvis.chat import list_filters, list_registry
 from jarvis.chat.list_filters import (
 	ERR_INVALID_OPERATOR,
 	ERR_INVALID_VALUE,
@@ -217,6 +217,20 @@ class TestPermlevelEndToEnd(unittest.TestCase):
 		frappe.set_user("Administrator")
 		from frappe.permissions import add_permission, update_permission_property
 
+		# Snapshot the Custom DocPerm rows that existed BEFORE we touched
+		# anything. reset_perms() would delete every Custom DocPerm for the
+		# doctype, which on a site that had legitimately customized permissions
+		# is a destructive teardown that silently changes the site.
+		cls._perms_before = {
+			"Jarvis Custom Skill": set(
+				frappe.get_all("Custom DocPerm", filters={"parent": SKILL}, pluck="name")
+			),
+			"Jarvis Macro": set(
+				frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name")
+			),
+		}
+
+		# (a) a MAIN field pushed above the caller's permlevel …
 		frappe.make_property_setter(
 			{
 				"doctype": SKILL,
@@ -228,25 +242,48 @@ class TestPermlevelEndToEnd(unittest.TestCase):
 			is_system_generated=False,
 			validate_fields_for_doctype=False,
 		)
-		add_permission(SKILL, PERMLEVEL_ROLE, 1)
-		update_permission_property(SKILL, PERMLEVEL_ROLE, 1, "read", 1)
+		# (b) … and a CHILD field, whose permlevel access is evaluated against the
+		# PARENT's permissions (Meta.get_permissions with parenttype).
+		frappe.make_property_setter(
+			{
+				"doctype": "Jarvis Macro Step",
+				"fieldname": "prompt",
+				"property": "permlevel",
+				"value": 1,
+				"property_type": "Int",
+			},
+			is_system_generated=False,
+			validate_fields_for_doctype=False,
+		)
+		for dt in (SKILL, MACRO):
+			add_permission(dt, PERMLEVEL_ROLE, 1)
+			update_permission_property(dt, PERMLEVEL_ROLE, 1, "read", 1)
 		frappe.db.commit()
-		frappe.clear_cache(doctype=SKILL)
+		frappe.clear_cache()
 
 	@classmethod
 	def tearDownClass(cls):
 		frappe.set_user("Administrator")
-		from frappe.permissions import reset_perms
-
 		for name in frappe.get_all(
 			"Property Setter",
-			filters={"doc_type": SKILL, "field_name": "instructions", "property": "permlevel"},
+			filters={
+				"doc_type": ["in", [SKILL, "Jarvis Macro Step"]],
+				"property": "permlevel",
+				"field_name": ["in", ["instructions", "prompt"]],
+			},
 			pluck="name",
 		):
 			frappe.delete_doc("Property Setter", name, force=True, ignore_permissions=True)
-		reset_perms(SKILL)
+		# Restore EXACTLY what was there: delete only the Custom DocPerm rows this
+		# fixture caused to exist (add_permission's setup_custom_perms copies the
+		# standard rows in on first use, so on a stock site "before" is empty and
+		# this removes all of them, returning the doctype to its standard perms).
+		for dt, before in cls._perms_before.items():
+			for name in frappe.get_all("Custom DocPerm", filters={"parent": dt}, pluck="name"):
+				if name not in before:
+					frappe.delete_doc("Custom DocPerm", name, force=True, ignore_permissions=True)
 		frappe.db.commit()
-		frappe.clear_cache(doctype=SKILL)
+		frappe.clear_cache()
 
 	def test_schema_shows_the_field_only_to_the_privileged_role(self):
 		privileged = get_schema("skills", user=USER_A)
@@ -274,6 +311,26 @@ class TestPermlevelEndToEnd(unittest.TestCase):
 		self.assertNotIn("secret", fragment)
 		self.assertIn("%secret%", compiled.params.values())
 
+	def test_child_field_above_permlevel_is_withheld_and_rejected(self):
+		"""Child permlevel access is read off the PARENT's permissions, so this
+		path has its own way to be wrong."""
+		privileged = get_schema("macros", user=USER_A)
+		ordinary = get_schema("macros", user=USER_B)
+		self.assertIsNotNone(
+			_entry(privileged, "Jarvis Macro Step", "prompt"),
+			"the child permlevel-1 grant did not take effect — test would be vacuous",
+		)
+		self.assertIsNone(_entry(ordinary, "Jarvis Macro Step", "prompt"))
+		# Non-vacuity: the sibling child field is still there for the ordinary role.
+		self.assertIsNotNone(_entry(ordinary, "Jarvis Macro Step", "label"))
+
+		clause = [{"doctype": "Jarvis Macro Step", "fieldname": "prompt", "operator": "=", "value": "x"}]
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("macros", clause, user=USER_B)
+		self.assertEqual(caught.exception.filter_error_code, ERR_UNKNOWN_FIELD)
+		# …and the privileged role can still use it.
+		self.assertIn("`prompt`", compile_list_filters("macros", clause, user=USER_A).fragment())
+
 	def test_schema_cache_never_serves_one_user_to_another(self):
 		# Warm A, then B, then A again: B's build must not evict or overwrite A's.
 		first_a = get_schema("skills", user=USER_A)
@@ -283,6 +340,70 @@ class TestPermlevelEndToEnd(unittest.TestCase):
 		self.assertIsNone(_entry(b, SKILL, "instructions"))
 		self.assertIsNotNone(_entry(second_a, SKILL, "instructions"))
 		self.assertNotEqual(first_a["schema_revision"], b["schema_revision"])
+
+
+class TestViewExcludedFields(unittest.TestCase):
+	"""P1: permlevel stops what the DOCTYPE hides; ``excluded_fields`` stops what
+	the ENDPOINT hides.
+
+	Triggers is the live case: ``triggers_api._trigger_detail`` blanks
+	``condition`` / ``script_body`` / ``llm_instruction`` for non-managers, so a
+	filter over them would rebuild the redacted automation logic one LIKE at a
+	time — a leak permlevel cannot see, because the DocType marks those fields
+	permlevel 0.
+	"""
+
+	REDACTED = ("condition", "script_body", "llm_instruction")
+
+	def test_registry_declares_the_redacted_trigger_fields(self):
+		view = list_registry.get_view("triggers")
+		self.assertEqual(set(view.excluded_fields), set(self.REDACTED))
+
+	def test_excluded_fields_are_absent_from_the_schema(self):
+		schema = get_schema("triggers", user=USER_SM)
+		names = {f["fieldname"] for f in schema["fields"]}
+		# Non-vacuity: the schema is otherwise populated, and the fields really
+		# exist on the DocType (so their absence is our doing, not the metadata's).
+		self.assertIn("enabled", names)
+		meta = frappe.get_meta("Jarvis Trigger")
+		for fieldname in self.REDACTED:
+			self.assertIsNotNone(meta.get_field(fieldname), f"{fieldname} vanished from Jarvis Trigger")
+			self.assertNotIn(fieldname, names)
+
+	def test_excluded_fields_are_rejected_by_the_compiler(self):
+		for fieldname in self.REDACTED:
+			with self.subTest(field=fieldname):
+				clause = [
+					{
+						"doctype": "Jarvis Trigger",
+						"fieldname": fieldname,
+						"operator": "like",
+						"value": "frappe.db",
+					}
+				]
+				with self.assertRaises(ListFilterError) as caught:
+					compile_list_filters("triggers", clause, user=USER_SM)
+				# Same code as a misspelling: "withheld" must not be a
+				# distinguishable answer, or the rejection is itself the oracle.
+				self.assertEqual(caught.exception.filter_error_code, ERR_UNKNOWN_FIELD)
+
+	def test_a_non_excluded_field_on_the_same_view_still_works(self):
+		"""Non-vacuity for the whole class: the view is otherwise filterable."""
+		compiled = compile_list_filters(
+			"triggers",
+			[{"doctype": "Jarvis Trigger", "fieldname": "enabled", "operator": "=", "value": 1}],
+			user=USER_SM,
+		)
+		self.assertIn("`enabled`", compiled.fragment())
+
+	def test_exclusion_can_name_a_child_field(self):
+		"""The ``Child DocType.fieldname`` form, proven directly on the builder."""
+		catalog = build_field_catalog(
+			MACRO, user=USER_SM, excluded_fields=("Jarvis Macro Step.label",)
+		)
+		pairs = {(f["doctype"], f["fieldname"]) for f in catalog}
+		self.assertNotIn(("Jarvis Macro Step", "label"), pairs)
+		self.assertIn(("Jarvis Macro Step", "model_override"), pairs)
 
 
 # --------------------------------------------------------------------------- #
@@ -337,9 +458,25 @@ class TestCatalogShape(unittest.TestCase):
 		small_text = _entry(schema, MACRO, "description")
 		self.assertEqual(
 			small_text["default_operator"],
-			"=",
-			"deviation D5: Frappe defaults Small Text to '=', not 'like' as plan §5.1 claimed",
+			"like",
+			"deviation D5-a: we diverge from Frappe (which defaults Small Text to "
+			"'=') because a Description filter almost always means 'contains'",
 		)
+		self.assertIn("=", small_text["operators"], "exact match must stay selectable")
+
+	def test_free_text_families_default_to_like_but_code_does_not(self):
+		"""D5-a's boundary: prose bodies get `like`, machine-shaped content does not."""
+		skills = get_schema("skills", user=USER_A)
+		long_text = _entry(skills, SKILL, "instructions")
+		if long_text is not None:  # absent while the permlevel fixture is active
+			self.assertEqual(long_text["default_operator"], "like")
+		self.assertEqual(list_filters.default_operator("body", "Text"), "like")
+		self.assertEqual(list_filters.default_operator("body", "Text Editor"), "like")
+		self.assertEqual(list_filters.default_operator("body", "Code"), "=")
+		self.assertEqual(list_filters.default_operator("body", "HTML Editor"), "=")
+		# Data keeps Frappe's large-table rule.
+		self.assertEqual(list_filters.default_operator("x", "Data", False), "like")
+		self.assertEqual(list_filters.default_operator("x", "Data", True), "=")
 
 	def test_json_array_standard_fields_are_like_only(self):
 		schema = get_schema("skills", user=USER_A)
@@ -432,6 +569,58 @@ class TestFailsClosed(unittest.TestCase):
 	def test_is_needs_set_or_not_set(self):
 		clause = [{"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "yes"}]
 		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
+
+	def test_blank_date_is_rejected_instead_of_meaning_today(self):
+		"""frappe's getdate(None)/getdate("") return TODAY. Inheriting that turns
+		an omitted bound into a filter nobody asked for, whose answer looks
+		plausible."""
+		# NB: Datetime rejects "=" outright (frappe's invalid_condition_map), so the
+		# Datetime leg uses a comparison — otherwise the operator gate would fire
+		# first and this would prove nothing about value normalization.
+		for blank in (None, "", "   "):
+			for field, op in (("last_run_at", ">"), ("schedule_time", "=")):
+				with self.subTest(value=blank, field=field):
+					clause = [{"doctype": MACRO, "fieldname": field, "operator": op, "value": blank}]
+					self.assertEqual(
+						self._code(compile_list_filters, "macros", clause, user=USER_A),
+						ERR_INVALID_VALUE,
+					)
+
+	def test_unparseable_date_is_rejected(self):
+		clause = [{"doctype": MACRO, "fieldname": "last_run_at", "operator": ">", "value": "not-a-date"}]
+		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
+
+	def test_a_valid_date_still_compiles(self):
+		"""Non-vacuity for the two tests above."""
+		compiled = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "last_run_at", "operator": ">", "value": "2026-07-01"}],
+			user=USER_A,
+		)
+		self.assertIn("2026-07-01 00:00:00", [str(v) for v in compiled.params.values()])
+
+	def test_length_cap_applies_to_non_text_fieldtypes_too(self):
+		"""The cap used to live only on the text branch, so a megabyte aimed at a
+		date or a number was parsed first and capped never."""
+		huge = "9" * (list_filters.MAX_VALUE_CHARS + 1)
+		for field, op in (("last_run_at", ">"), ("schedule_frequency", "=")):
+			with self.subTest(field=field):
+				clause = [{"doctype": MACRO, "fieldname": field, "operator": op, "value": huge}]
+				self.assertEqual(
+					self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_VALUE_TOO_LONG
+				)
+
+	def test_schema_endpoint_refuses_a_registered_but_unmigrated_view(self):
+		from jarvis.chat.list_filters import get_list_filter_schema
+
+		orig = frappe.session.user
+		frappe.set_user(USER_SM)
+		try:
+			res = get_list_filter_schema("triggers")
+		finally:
+			frappe.set_user(orig)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], ERR_VIEW_NOT_FILTERABLE)
 
 	def test_password_fieldtype_is_never_offered(self):
 		# Deviation D2. Proven structurally: no catalog on any registered
@@ -630,7 +819,7 @@ class TestQueryBarrierAndFacets(unittest.TestCase):
 		q.server_condition("owner = %(me)s", me=USER_A)
 		q.apply([{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": 1}])
 		where = q.where()
-		self.assertTrue(where.startswith("owner = %(me)s AND "), where)
+		self.assertTrue(where.startswith("(owner = %(me)s) AND "), where)
 		self.assertIn("`tabJarvis Macro`.`enabled`", where)
 		# The user parameter namespace is disjoint from the server's.
 		user_params = [k for k in q.params() if k.startswith(list_filters.USER_PARAM_PREFIX)]
@@ -651,8 +840,31 @@ class TestQueryBarrierAndFacets(unittest.TestCase):
 		q = new_query("macros", user=USER_A)
 		q.server_condition("owner = %(me)s", me=USER_A)
 		q.apply(None)
-		self.assertEqual(q.where(), "owner = %(me)s")
+		self.assertEqual(q.where(), "(owner = %(me)s)")
 		self.assertEqual(q.params(), {"me": USER_A})
+
+	def test_every_where_part_is_parenthesised(self):
+		"""Structural: an unparenthesised join lets a top-level OR in one
+		predicate bind loosely and silently widen the whole WHERE. The skills
+		scope predicate IS such an OR."""
+		q = new_query("skills", user=USER_A)
+		q.server_condition("(owner = %(me)s OR name IN %(shared)s)", me=USER_A, shared=("a",))
+		q.server_condition("enabled = %(enabled)s", enabled=1)
+		q.apply([{"doctype": SKILL, "fieldname": "user_invocable", "operator": "=", "value": 1}])
+		where = q.where()
+		self.assertEqual(
+			where,
+			"((owner = %(me)s OR name IN %(shared)s)) AND (enabled = %(enabled)s) "
+			"AND (`tabJarvis Custom Skill`.`user_invocable` = %(jf0_0)s)",
+		)
+
+	def test_params_refuses_to_overwrite_a_bound_predicate_value(self):
+		q = new_query("macros", user=USER_A)
+		q.server_condition("owner = %(me)s", me=USER_A)
+		q.apply([])
+		self.assertEqual(q.params({"start": 0, "page_length": 20})["start"], 0)
+		with self.assertRaises(ValueError):
+			q.params({"me": "someone-else@example.com"})
 
 	def test_facet_query_drops_only_its_own_dimension(self):
 		q = new_query("macros", user=USER_A)
@@ -690,7 +902,33 @@ class TestQueryBarrierAndFacets(unittest.TestCase):
 		q = new_query("macros", user=USER_A)
 		q.server_condition("owner = %(me)s", me=USER_A)
 		q.apply([{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "a"}])
-		self.assertEqual(q.where(exclude_dimension=("Jarvis Macro Step", "label")), "owner = %(me)s")
+		self.assertEqual(q.where(exclude_dimension=("Jarvis Macro Step", "label")), "(owner = %(me)s)")
+
+	def test_empty_payload_never_touches_metadata_or_the_schema_cache(self):
+		"""The >99% path. A list with no filters on it must cost what it cost
+		before the migration, and must not be able to fail because of the filter
+		layer at all."""
+		import unittest.mock as mock
+
+		with mock.patch.object(list_filters, "get_schema", side_effect=AssertionError("schema built")):
+			for empty in (None, "", "   ", [], "[]"):
+				with self.subTest(payload=empty):
+					q = new_query("macros", user=USER_A)
+					q.server_condition("owner = %(me)s", me=USER_A)
+					q.apply(empty)
+					self.assertEqual(q.where(), "(owner = %(me)s)")
+			# …and a NON-empty payload does build the schema (non-vacuity).
+			with self.assertRaises(AssertionError):
+				new_query("macros", user=USER_A).apply(
+					[{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": 1}]
+				)
+
+	def test_unknown_view_still_fails_closed_on_the_empty_path(self):
+		"""The short-circuit must not become a way to smuggle a bad view_key past
+		the contract check."""
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("not-a-view", [], user=USER_A)
+		self.assertEqual(caught.exception.filter_error_code, ERR_UNKNOWN_VIEW)
 
 
 # --------------------------------------------------------------------------- #
@@ -769,6 +1007,26 @@ class TestTypedCompilation(unittest.TestCase):
 		)
 		self.assertIn("IN %(", compiled.fragment())
 		self.assertIn(("a", "b"), compiled.params.values())
+
+	def test_in_does_not_coalesce_but_not_in_does(self):
+		"""db_query's actual rule: `in` clears can_be_null when the value list is
+		non-empty and has no falsy member (which ours always is — D9 rejects the
+		empty list), so wrapping it in ifnull() only costs the index. `not in`
+		keeps the wrapper, because NULL NOT IN (...) is NULL and those rows would
+		silently vanish."""
+		inc = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "macro_name", "operator": "in", "value": ["a"]}],
+			user=USER_A,
+		).fragment()
+		exc = compile_list_filters(
+			"macros",
+			[{"doctype": MACRO, "fieldname": "macro_name", "operator": "not in", "value": ["a"]}],
+			user=USER_A,
+		).fragment()
+		self.assertNotIn("ifnull", inc)
+		self.assertIn("`tabJarvis Macro`.`macro_name` IN %(", inc)
+		self.assertIn("ifnull", exc)
 
 	def test_check_normalizes_to_zero_or_one(self):
 		compiled = compile_list_filters(

--- a/jarvis/tests/test_list_filters.py
+++ b/jarvis/tests/test_list_filters.py
@@ -586,6 +586,104 @@ class TestFailsClosed(unittest.TestCase):
 						ERR_INVALID_VALUE,
 					)
 
+	# `Jarvis Learned Pattern.snoozed_until` is the only Date field on a registered
+	# doctype-backed view, and the view is reviewer-gated — so the Date legs below
+	# run as the System Manager fixture rather than the ordinary one.
+	LEARNED = "Jarvis Learned Pattern"
+	DATE_FIELD = "snoozed_until"
+
+	def test_falsy_non_string_date_values_are_rejected(self):
+		"""R-1: ``getdate()`` only checks falsiness, so 0 / False / [] / {} all
+		return TODAY. Datetime and Time already rejected these; Date did not."""
+		meta_field = frappe.get_meta(self.LEARNED).get_field(self.DATE_FIELD)
+		self.assertEqual(meta_field.fieldtype, "Date", "fixture drifted — test would not cover Date")
+		for bad in (0, False, [], {}):
+			with self.subTest(value=bad):
+				clause = [
+					{"doctype": self.LEARNED, "fieldname": self.DATE_FIELD, "operator": "=", "value": bad}
+				]
+				self.assertEqual(
+					self._code(compile_list_filters, "learning_queue", clause, user=USER_SM),
+					ERR_INVALID_VALUE,
+				)
+
+	def test_a_valid_date_equality_still_compiles(self):
+		"""Non-vacuity for R-1."""
+		compiled = compile_list_filters(
+			"learning_queue",
+			[{"doctype": self.LEARNED, "fieldname": self.DATE_FIELD, "operator": "=", "value": "2026-07-01"}],
+			user=USER_SM,
+		)
+		self.assertIn("2026-07-01", [str(v) for v in compiled.params.values()])
+
+	def test_blank_between_bounds_are_rejected(self):
+		"""R-2: ``Between`` is the DEFAULT operator for Date/Datetime, so it is the
+		first path a client hits — and frappe's get_between_date_filter falls back
+		to *today* for any missing bound. A range nobody chose, silently answered.
+		"""
+		blanks = (None, "", "   ", [], ["", ""], [None, None], {}, ["2026-07-01"], [None, "2026-07-01"])
+		cases = ((MACRO, "last_run_at", "macros", USER_A), (self.LEARNED, self.DATE_FIELD, "learning_queue", USER_SM))
+		for doctype, fieldname, view, user in cases:
+			for payload in blanks:
+				with self.subTest(field=fieldname, value=payload):
+					clause = [
+						{"doctype": doctype, "fieldname": fieldname, "operator": "Between", "value": payload}
+					]
+					self.assertEqual(
+						self._code(compile_list_filters, view, clause, user=user), ERR_INVALID_VALUE
+					)
+
+	def test_a_complete_between_range_still_compiles(self):
+		"""Non-vacuity for R-2, on both families."""
+		dt = compile_list_filters(
+			"macros",
+			[
+				{
+					"doctype": MACRO,
+					"fieldname": "last_run_at",
+					"operator": "Between",
+					"value": ["2026-07-01", "2026-07-31"],
+				}
+			],
+			user=USER_A,
+		)
+		self.assertIn("BETWEEN", dt.fragment())
+		date = compile_list_filters(
+			"learning_queue",
+			[
+				{
+					"doctype": self.LEARNED,
+					"fieldname": self.DATE_FIELD,
+					"operator": "Between",
+					"value": ["2026-07-01", "2026-07-31"],
+				}
+			],
+			user=USER_SM,
+		)
+		self.assertEqual(sorted(str(v) for v in date.params.values()), ["2026-07-01", "2026-07-31"])
+
+	def test_timespan_still_resolves_through_the_between_path(self):
+		"""Non-vacuity: the stricter bound check must not break Timespan, which
+		feeds _between_bounds a server-computed two-element range."""
+		compiled = compile_list_filters(
+			"learning_queue",
+			[{"doctype": self.LEARNED, "fieldname": self.DATE_FIELD, "operator": "Timespan", "value": "this month"}],
+			user=USER_SM,
+		)
+		self.assertIn("BETWEEN", compiled.fragment())
+		self.assertEqual(len(compiled.params), 2)
+
+	def test_between_caps_each_element_not_just_the_payload(self):
+		"""P3: the length guard ran on the raw value, so a list whose MEMBER was
+		80KB slipped past it."""
+		huge = "9" * (list_filters.MAX_VALUE_CHARS + 1)
+		clause = [
+			{"doctype": MACRO, "fieldname": "last_run_at", "operator": "Between", "value": [huge, huge]}
+		]
+		self.assertEqual(
+			self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_VALUE_TOO_LONG
+		)
+
 	def test_unparseable_date_is_rejected(self):
 		clause = [{"doctype": MACRO, "fieldname": "last_run_at", "operator": ">", "value": "not-a-date"}]
 		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)

--- a/jarvis/tests/test_list_filters.py
+++ b/jarvis/tests/test_list_filters.py
@@ -225,9 +225,7 @@ class TestPermlevelEndToEnd(unittest.TestCase):
 			"Jarvis Custom Skill": set(
 				frappe.get_all("Custom DocPerm", filters={"parent": SKILL}, pluck="name")
 			),
-			"Jarvis Macro": set(
-				frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name")
-			),
+			"Jarvis Macro": set(frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name")),
 		}
 
 		# (a) a MAIN field pushed above the caller's permlevel …
@@ -398,9 +396,7 @@ class TestViewExcludedFields(unittest.TestCase):
 
 	def test_exclusion_can_name_a_child_field(self):
 		"""The ``Child DocType.fieldname`` form, proven directly on the builder."""
-		catalog = build_field_catalog(
-			MACRO, user=USER_SM, excluded_fields=("Jarvis Macro Step.label",)
-		)
+		catalog = build_field_catalog(MACRO, user=USER_SM, excluded_fields=("Jarvis Macro Step.label",))
 		pairs = {(f["doctype"], f["fieldname"]) for f in catalog}
 		self.assertNotIn(("Jarvis Macro Step", "label"), pairs)
 		self.assertIn(("Jarvis Macro Step", "model_override"), pairs)
@@ -504,9 +500,7 @@ class TestFailsClosed(unittest.TestCase):
 		return caught.exception.filter_error_code
 
 	def test_unknown_view(self):
-		self.assertEqual(
-			self._code(compile_list_filters, "not-a-view", [], user=USER_A), ERR_UNKNOWN_VIEW
-		)
+		self.assertEqual(self._code(compile_list_filters, "not-a-view", [], user=USER_A), ERR_UNKNOWN_VIEW)
 
 	def test_projection_view_is_not_filterable_yet(self):
 		# file_box / approvals / agents_catalog have no declared projection schema
@@ -557,9 +551,7 @@ class TestFailsClosed(unittest.TestCase):
 		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
 
 	def test_select_value_must_be_an_option(self):
-		clause = [
-			{"doctype": MACRO, "fieldname": "schedule_frequency", "operator": "=", "value": "hourly"}
-		]
+		clause = [{"doctype": MACRO, "fieldname": "schedule_frequency", "operator": "=", "value": "hourly"}]
 		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_INVALID_VALUE)
 
 	def test_empty_in_list_is_rejected(self):
@@ -622,7 +614,10 @@ class TestFailsClosed(unittest.TestCase):
 		to *today* for any missing bound. A range nobody chose, silently answered.
 		"""
 		blanks = (None, "", "   ", [], ["", ""], [None, None], {}, ["2026-07-01"], [None, "2026-07-01"])
-		cases = ((MACRO, "last_run_at", "macros", USER_A), (self.LEARNED, self.DATE_FIELD, "learning_queue", USER_SM))
+		cases = (
+			(MACRO, "last_run_at", "macros", USER_A),
+			(self.LEARNED, self.DATE_FIELD, "learning_queue", USER_SM),
+		)
 		for doctype, fieldname, view, user in cases:
 			for payload in blanks:
 				with self.subTest(field=fieldname, value=payload):
@@ -667,7 +662,14 @@ class TestFailsClosed(unittest.TestCase):
 		feeds _between_bounds a server-computed two-element range."""
 		compiled = compile_list_filters(
 			"learning_queue",
-			[{"doctype": self.LEARNED, "fieldname": self.DATE_FIELD, "operator": "Timespan", "value": "this month"}],
+			[
+				{
+					"doctype": self.LEARNED,
+					"fieldname": self.DATE_FIELD,
+					"operator": "Timespan",
+					"value": "this month",
+				}
+			],
 			user=USER_SM,
 		)
 		self.assertIn("BETWEEN", compiled.fragment())
@@ -680,9 +682,7 @@ class TestFailsClosed(unittest.TestCase):
 		clause = [
 			{"doctype": MACRO, "fieldname": "last_run_at", "operator": "Between", "value": [huge, huge]}
 		]
-		self.assertEqual(
-			self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_VALUE_TOO_LONG
-		)
+		self.assertEqual(self._code(compile_list_filters, "macros", clause, user=USER_A), ERR_VALUE_TOO_LONG)
 
 	def test_unparseable_date_is_rejected(self):
 		clause = [{"doctype": MACRO, "fieldname": "last_run_at", "operator": ">", "value": "not-a-date"}]
@@ -814,7 +814,9 @@ class TestChildFilters(unittest.TestCase):
 			return list_macros_page(filters_v2=clauses, page_length=50)
 
 	def test_matching_children_do_not_duplicate_the_parent(self):
-		res = self._run([{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "gamma"}])
+		res = self._run(
+			[{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "gamma"}]
+		)
 		self.assertEqual(res["total"], 1, "two matching child rows must not duplicate the parent")
 		self.assertEqual(len(res["rows"]), 1)
 		self.assertEqual(res["rows"][0]["name"], self.dup)
@@ -1037,7 +1039,9 @@ class TestTypedCompilation(unittest.TestCase):
 		return compile_list_filters(view, [clause], user=USER_A).fragment()
 
 	def test_is_set_and_is_not_set(self):
-		st = self._fragment("macros", {"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "set"})
+		st = self._fragment(
+			"macros", {"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "set"}
+		)
 		self.assertIn("ifnull(`tabJarvis Macro`.`description`, '') != ''", st)
 		unset = self._fragment(
 			"macros", {"doctype": MACRO, "fieldname": "description", "operator": "is", "value": "not set"}
@@ -1075,7 +1079,14 @@ class TestTypedCompilation(unittest.TestCase):
 		with self.assertRaises(ListFilterError) as caught:
 			compile_list_filters(
 				"macros",
-				[{"doctype": MACRO, "fieldname": "creation", "operator": "Timespan", "value": "last fortnight"}],
+				[
+					{
+						"doctype": MACRO,
+						"fieldname": "creation",
+						"operator": "Timespan",
+						"value": "last fortnight",
+					}
+				],
 				user=USER_A,
 			)
 		self.assertEqual(caught.exception.filter_error_code, ERR_INVALID_VALUE)

--- a/jarvis/tests/test_list_filters_f8.py
+++ b/jarvis/tests/test_list_filters_f8.py
@@ -31,7 +31,9 @@ from jarvis.chat.list_filters import (
 	ERR_INVALID_OPERATOR,
 	ERR_INVALID_VALUE,
 	ERR_VIEW_NOT_FILTERABLE,
+	ERR_VIEW_ROLLED_BACK,
 	ListFilterError,
+	_Clause,
 	allowed_operators,
 	build_field_catalog,
 	compile_list_filters,
@@ -154,13 +156,35 @@ class TestContainerPermlevel(unittest.TestCase):
 		self.assertTrue(any(f["fieldname"] == "macro_name" for f in catalog))
 
 
+def _mk_macro_with(owner: str, name: str, rows_by_field: dict[str, list[tuple[str, str]]]) -> str:
+	"""A macro whose child steps are distributed across named Table containers, so a
+	step can live under ``steps`` OR a second container (M2 leak fixture). ``steps``
+	is a mandatory child table, so a filler row is added when the caller only put
+	rows under the second container."""
+	frappe.set_user("Administrator")
+	doc = frappe.get_doc(
+		{"doctype": MACRO, "macro_name": name, "description": "m", "enabled": 1, "stop_on_error": 1}
+	)
+	rows_by_field = dict(rows_by_field)
+	rows_by_field.setdefault("steps", [("filler", "f")])
+	for field_name, rows in rows_by_field.items():
+		for lbl, prm in rows:
+			doc.append(field_name, {"label": lbl, "prompt": prm})
+	doc.flags.ignore_validate = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(MACRO, doc.name, "owner", owner)
+	frappe.db.commit()
+	return doc.name
+
+
 class TestTwoTableFieldsSameChild(unittest.TestCase):
-	"""Documented explicit behaviour (LIST-FILTERS-DEVIATIONS D16): when a parent
-	reaches ONE child DocType through TWO Table fields, the catalog lists each
-	child field ONCE (deduped by (child DocType, fieldname)), and a clause on that
-	child compiles to ONE ``EXISTS`` keyed by the child DocType — so it matches a
-	row in EITHER container. That is the known ``parentfield`` ambiguity, made
-	explicit rather than left to chance."""
+	"""When a parent reaches ONE child DocType through TWO Table fields the catalog
+	lists each child field ONCE (deduped by (child DocType, fieldname)), and a
+	clause on it compiles to ONE ``EXISTS`` per child DocType. The EXISTS now binds
+	``parentfield IN (<containers the caller may read>)`` (M2 / ledger D16), so it
+	matches a row under EITHER readable container for a caller who reads both — the
+	behaviour verified here — while a caller who can read only one container is
+	scoped to that one (see :class:`TestContainerParentfieldLeak`)."""
 
 	@classmethod
 	def setUpClass(cls):
@@ -197,6 +221,215 @@ class TestTwoTableFieldsSameChild(unittest.TestCase):
 		clause = [{"doctype": STEP, "fieldname": "label", "operator": "=", "value": "x"}]
 		fragment = compile_list_filters("macros", clause, user=USER_SM).fragment()
 		self.assertEqual(fragment.count("EXISTS"), 1, "same-child clause must be one EXISTS")
+
+	def test_both_readable_binds_every_container(self):
+		# SM reads both containers, so the child entry carries both parentfields and
+		# the compiled EXISTS binds both — the both-readable case keeps working.
+		entry = next(
+			f
+			for f in build_field_catalog(MACRO, user=USER_SM)
+			if f["doctype"] == STEP and f["fieldname"] == "label"
+		)
+		self.assertEqual(sorted(entry["parentfields"]), ["steps", "steps_alt"])
+		clause = [{"doctype": STEP, "fieldname": "label", "operator": "=", "value": "x"}]
+		compiled = compile_list_filters("macros", clause, user=USER_SM)
+		self.assertIn("`parentfield` IN", compiled.fragment())
+		self.assertEqual(
+			{v for v in compiled.params.values() if isinstance(v, tuple)},
+			{("steps", "steps_alt")},
+		)
+
+
+class TestContainerParentfieldLeak(unittest.TestCase):
+	"""M2: the container permission bypass. Two Table fields reach ONE child
+	DocType; the second is above the floor caller's permlevel. A clause via the
+	READABLE container must never match rows attached to the hidden one — same child
+	DocType, same parent+parenttype, told apart only by ``parentfield``."""
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		from frappe.permissions import add_permission, update_permission_property
+
+		cls._perms_before = set(frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name"))
+		if not frappe.db.exists("Custom Field", {"dt": MACRO, "fieldname": "steps_hidden"}):
+			frappe.get_doc(
+				{
+					"doctype": "Custom Field",
+					"dt": MACRO,
+					"fieldname": "steps_hidden",
+					"label": "Steps Alt",
+					"fieldtype": "Table",
+					"options": STEP,
+				}
+			).insert(ignore_permissions=True)
+		# Raise the SECOND container to permlevel 1 and grant that level only to the
+		# role USER_A holds — so USER_A/USER_SM read both containers, USER_B reads
+		# only `steps`.
+		frappe.make_property_setter(
+			{
+				"doctype": MACRO,
+				"fieldname": "steps_hidden",
+				"property": "permlevel",
+				"value": 1,
+				"property_type": "Int",
+			},
+			is_system_generated=False,
+			validate_fields_for_doctype=False,
+		)
+		add_permission(MACRO, PERMLEVEL_ROLE, 1)
+		update_permission_property(MACRO, PERMLEVEL_ROLE, 1, "read", 1)
+		frappe.db.commit()
+		frappe.clear_cache()
+		# leakp under the HIDDEN container only, and under the readable one only.
+		cls.hidden = _mk_macro_with(USER_B, "lf-leak-hidden", {"steps_hidden": [("leakp", "p")]})
+		cls.readable = _mk_macro_with(USER_B, "lf-leak-readable", {"steps": [("leakp", "p")]})
+		cls.priv = _mk_macro_with(USER_A, "lf-leak-priv", {"steps_hidden": [("leakp", "p")]})
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in (cls.hidden, cls.readable, cls.priv):
+			if frappe.db.exists(MACRO, name):
+				frappe.delete_doc(MACRO, name, force=True, ignore_permissions=True)
+		for name in frappe.get_all(
+			"Property Setter",
+			filters={"doc_type": MACRO, "property": "permlevel", "field_name": "steps_hidden"},
+			pluck="name",
+		):
+			frappe.delete_doc("Property Setter", name, force=True, ignore_permissions=True)
+		for name in frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name"):
+			if name not in cls._perms_before:
+				frappe.delete_doc("Custom DocPerm", name, force=True, ignore_permissions=True)
+		cf = frappe.db.get_value("Custom Field", {"dt": MACRO, "fieldname": "steps_hidden"})
+		if cf:
+			frappe.delete_doc("Custom Field", cf, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		frappe.clear_cache()
+
+	def _run(self, user, clauses):
+		from jarvis.chat.macros_api import list_macros_page
+
+		with _as(user):
+			return list_macros_page(filters_v2=clauses, page_length=50)
+
+	_LEAKP = [{"doctype": STEP, "fieldname": "label", "operator": "=", "value": "leakp"}]
+
+	def test_floor_user_does_not_match_rows_under_the_hidden_container(self):
+		# The security assertion: USER_B owns BOTH lf-leak-hidden and
+		# lf-leak-readable, but filtering leakp returns ONLY the readable one.
+		res = self._run(USER_B, self._LEAKP)
+		names = {r["name"] for r in res["rows"]}
+		self.assertIn(self.readable, names)
+		self.assertNotIn(self.hidden, names, "a hidden container's child row leaked through EXISTS")
+
+	def test_floor_user_binds_only_the_readable_parentfield(self):
+		compiled = compile_list_filters("macros", self._LEAKP, user=USER_B)
+		self.assertEqual(
+			{v for v in compiled.params.values() if isinstance(v, tuple)},
+			{("steps",)},
+			"the floor caller's EXISTS must bind only the container it can read",
+		)
+
+	def test_privileged_user_still_matches_the_other_container(self):
+		# USER_A reads permlevel 1, so its clause spans both containers — the
+		# both-readable case is not narrowed by the fix.
+		res = self._run(USER_A, self._LEAKP)
+		self.assertIn(self.priv, {r["name"] for r in res["rows"]})
+
+	def test_view_excluded_container_scopes_the_parentfield(self):
+		# An endpoint that withholds the second container via excluded_fields must
+		# scope the child EXISTS the same way permlevel does. USER_A CAN read
+		# steps_hidden (permlevel 1), so the exclusion — not the permlevel — is what
+		# narrows the bound parentfield set here.
+		entry = next(
+			f
+			for f in build_field_catalog(MACRO, user=USER_A, excluded_fields=("steps_hidden",))
+			if f["doctype"] == STEP and f["fieldname"] == "label"
+		)
+		self.assertEqual(entry["parentfields"], ["steps"], "view-excluded container still bound")
+
+
+class TestMultiSelectContainerParentfieldScoping(unittest.TestCase):
+	"""The Table MultiSelect equivalent of the leak: the parentfield binding is
+	keyed on the container fieldname regardless of Table vs Table MultiSelect, so a
+	hidden MultiSelect container is scoped out the same way."""
+
+	CHILD = "Has Role"
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		from frappe.permissions import add_permission, update_permission_property
+
+		cls._perms_before = set(frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name"))
+		for fn, label in (("roles_a", "Roles A"), ("roles_b", "Roles B")):
+			if not frappe.db.exists("Custom Field", {"dt": MACRO, "fieldname": fn}):
+				frappe.get_doc(
+					{
+						"doctype": "Custom Field",
+						"dt": MACRO,
+						"fieldname": fn,
+						"label": label,
+						"fieldtype": "Table MultiSelect",
+						"options": cls.CHILD,
+					}
+				).insert(ignore_permissions=True)
+		frappe.make_property_setter(
+			{
+				"doctype": MACRO,
+				"fieldname": "roles_b",
+				"property": "permlevel",
+				"value": 1,
+				"property_type": "Int",
+			},
+			is_system_generated=False,
+			validate_fields_for_doctype=False,
+		)
+		add_permission(MACRO, PERMLEVEL_ROLE, 1)
+		update_permission_property(MACRO, PERMLEVEL_ROLE, 1, "read", 1)
+		frappe.db.commit()
+		frappe.clear_cache()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all(
+			"Property Setter",
+			filters={"doc_type": MACRO, "property": "permlevel", "field_name": "roles_b"},
+			pluck="name",
+		):
+			frappe.delete_doc("Property Setter", name, force=True, ignore_permissions=True)
+		for name in frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name"):
+			if name not in cls._perms_before:
+				frappe.delete_doc("Custom DocPerm", name, force=True, ignore_permissions=True)
+		for fn in ("roles_a", "roles_b"):
+			cf = frappe.db.get_value("Custom Field", {"dt": MACRO, "fieldname": fn})
+			if cf:
+				frappe.delete_doc("Custom Field", cf, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		frappe.clear_cache()
+
+	def test_floor_user_scopes_multiselect_to_readable_container(self):
+		entry = next(
+			(
+				f
+				for f in build_field_catalog(MACRO, user=USER_B)
+				if f["doctype"] == self.CHILD and f["fieldname"] == "role"
+			),
+			None,
+		)
+		self.assertIsNotNone(entry, "the MultiSelect Link value field was not catalogued")
+		self.assertEqual(entry["parentfields"], ["roles_a"], "hidden MultiSelect container leaked")
+
+	def test_privileged_user_sees_both_multiselect_containers(self):
+		# USER_A holds the permlevel-1 role granted below, so it reads roles_b.
+		entry = next(
+			f
+			for f in build_field_catalog(MACRO, user=USER_A)
+			if f["doctype"] == self.CHILD and f["fieldname"] == "role"
+		)
+		self.assertEqual(sorted(entry["parentfields"]), ["roles_a", "roles_b"])
 
 
 # --------------------------------------------------------------------------- #
@@ -270,6 +503,93 @@ class TestOperatorMatrixEffectiveData(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------- #
+# S5 — Between/Timespan are temporal-only, asserted as a COMPLEMENT
+# --------------------------------------------------------------------------- #
+class TestRangeOperatorsAreTemporalOnly(unittest.TestCase):
+	"""The golden rule stated in the positive: NO catalogable fieldtype advertises
+	(or compiles) ``Between``/``Timespan`` unless it is explicitly temporal — the
+	COMPLEMENT of a fixed allow-list, so a NEW or currently-unmapped type (Duration,
+	Autocomplete, a future control) is caught automatically rather than inheriting
+	the empty invalid set and silently offering a date range."""
+
+	#: A range operator, IF advertised at all, may only be on an explicitly temporal
+	#: family. Time is temporal but Frappe's own invalid_condition_map still withholds
+	#: Between/Timespan from it (a time-of-day range is not a date range), so the
+	#: complement is one-directional — "Between ⟹ temporal", never "temporal ⟹
+	#: Between". Only Date/Datetime actually carry it.
+	TEMPORAL = frozenset({"Date", "Datetime", "Time"})
+	CARRIES_RANGE = frozenset({"Date", "Datetime"})
+
+	#: A broad sweep of value-bearing fieldtypes — including the ones with NO
+	#: invalid_condition_map row and no effective-Data conversion (Duration,
+	#: Autocomplete, Geolocation, Rating), which are the whole point of S5.
+	CATALOGABLE = (
+		"Data",
+		"Text",
+		"Small Text",
+		"Long Text",
+		"Text Editor",
+		"Code",
+		"HTML Editor",
+		"Markdown Editor",
+		"Int",
+		"Float",
+		"Currency",
+		"Percent",
+		"Check",
+		"Select",
+		"Link",
+		"Dynamic Link",
+		"Duration",
+		"Rating",
+		"Color",
+		"Phone",
+		"JSON",
+		"Barcode",
+		"Autocomplete",
+		"Geolocation",
+		"Read Only",
+		"Attach",
+		"Attach Image",
+		"Date",
+		"Datetime",
+		"Time",
+	)
+
+	def test_between_or_timespan_implies_temporal(self):
+		# The complement: whatever family advertises a range MUST be temporal. A
+		# non-temporal type — mapped or not (Duration/Autocomplete/Geolocation are
+		# unmapped) — advertises neither.
+		for ft in self.CATALOGABLE:
+			ops = allowed_operators("x", ft)
+			with self.subTest(fieldtype=ft):
+				if "Between" in ops:
+					self.assertIn(ft, self.TEMPORAL, f"{ft} advertises Between but is not temporal")
+				if "Timespan" in ops:
+					self.assertIn(ft, self.TEMPORAL, f"{ft} advertises Timespan but is not temporal")
+				if ft not in self.TEMPORAL:
+					self.assertNotIn("Between", ops, f"{ft} (non-temporal) must not advertise Between")
+					self.assertNotIn("Timespan", ops, f"{ft} (non-temporal) must not advertise Timespan")
+
+	def test_date_families_do_advertise_a_range(self):
+		# Non-vacuity: Date/Datetime really do keep Between.
+		for ft in self.CARRIES_RANGE:
+			with self.subTest(fieldtype=ft):
+				self.assertIn("Between", allowed_operators("when", ft))
+
+	def test_compiler_guard_rejects_between_on_an_unmapped_numeric(self):
+		# Belt to the schema's suspenders: _between_bounds itself rejects a
+		# non-temporal type even if a clause reaches it bypassing the schema.
+		entry = {"fieldtype": "Duration", "label": "Elapsed"}
+		with self.assertRaises(ListFilterError) as caught:
+			list_filters._between_bounds(entry, ["1", "2"])
+		self.assertEqual(caught.exception.filter_error_code, ERR_INVALID_OPERATOR)
+		with self.assertRaises(ListFilterError) as caught:
+			list_filters._timespan_bounds(entry, "last 7 days")
+		self.assertEqual(caught.exception.filter_error_code, ERR_INVALID_OPERATOR)
+
+
+# --------------------------------------------------------------------------- #
 # P1-01 — strict numeric parsing
 # --------------------------------------------------------------------------- #
 class TestNumericStrictParse(unittest.TestCase):
@@ -304,6 +624,23 @@ class TestNumericStrictParse(unittest.TestCase):
 		entry = {"fieldtype": "Float", "label": "Amount"}
 		self.assertEqual(list_filters._as_number(entry, "3.5"), 3.5)
 
+	def test_thousands_separators_are_stripped_like_frappe_flt(self):
+		# S10: frappe.utils.flt runs s.replace(",", "") before float(), so a
+		# human-shaped "10,500.50" is a valid number, not a rejected one. The
+		# stripped value is what we bind, too (one parser for validate + bind).
+		entry = {"fieldtype": "Currency", "label": "Amount"}
+		self.assertEqual(list_filters._as_number(entry, "10,500.50"), 10500.50)
+		int_entry = {"fieldtype": "Int", "label": "Count"}
+		self.assertEqual(list_filters._as_number(int_entry, "1,000"), 1000)
+
+	def test_garbage_still_rejected_after_comma_strip(self):
+		# Stripping commas must not open a hole: non-numeric and non-finite still
+		# fail with the stable code.
+		entry = {"fieldtype": "Float", "label": "Amount"}
+		for bad in ("abc", "1,2,a", "inf", "nan"):
+			with self.subTest(value=bad), self.assertRaises(ListFilterError):
+				list_filters._as_number(entry, bad)
+
 
 # --------------------------------------------------------------------------- #
 # P1-10 — schema_revision hashes the full contract
@@ -321,6 +658,7 @@ class TestSchemaRevisionContract(unittest.TestCase):
 			"is_standard": False,
 			"is_child": False,
 			"json_array": False,
+			"parentfields": [],
 		}
 		base.update(over)
 		return base
@@ -351,6 +689,39 @@ class TestSchemaRevisionContract(unittest.TestCase):
 		b = list_filters._schema_digest([self._field()], {"max_clauses": 10})
 		self.assertNotEqual(a, b)
 
+	def test_a_new_wire_key_changes_revision(self):
+		# S8: the digest serializes the WHOLE field dict, so any wire key — the live
+		# example is `parentfields` — is covered without hand-listing it. A change
+		# to it must move the revision, or a caching consumer serves a stale panel.
+		a = list_filters._schema_digest([self._field(parentfields=["steps"])])
+		b = list_filters._schema_digest([self._field(parentfields=["steps", "steps_alt"])])
+		self.assertNotEqual(a, b, "a change to a wire key (parentfields) must change the revision")
+
+	def test_header_keys_change_revision(self):
+		# S8: schema-LEVEL keys the client renders (root_doctype, is_large_table,
+		# contract_version, label) live in the header, not on a field. Each must
+		# move the revision.
+		base = [self._field()]
+		for key, alt in (
+			("root_doctype", "Jarvis Skill"),
+			("is_large_table", True),
+			("contract_version", 999),
+			("label", "Renamed"),
+		):
+			with self.subTest(header_key=key):
+				h1 = {
+					"root_doctype": MACRO,
+					"is_large_table": False,
+					"contract_version": 1,
+					"label": "Macros",
+				}
+				h2 = dict(h1, **{key: alt})
+				self.assertNotEqual(
+					list_filters._schema_digest(base, {}, h1),
+					list_filters._schema_digest(base, {}, h2),
+					f"a change to header {key!r} must change schema_revision",
+				)
+
 
 # --------------------------------------------------------------------------- #
 # P1-05 — runtime capability flag + structural telemetry
@@ -378,9 +749,20 @@ class TestCapabilityFlag(unittest.TestCase):
 			self.assertFalse(view_filters_enabled("macros"))
 			self.assertTrue(view_filters_enabled("skills"))
 
-	def test_disabled_view_schema_endpoint_declines(self):
+	def test_rolled_back_view_declines_with_its_own_code(self):
+		# M1.2: a MIGRATED view rolled back by the flag is distinct from one that
+		# was never migrated, so the client can be honest ("turned off", no retry).
 		with _conf("jarvis_list_filters_v2_off", ["macros"]), _as(USER_SM):
 			res = list_filters.get_list_filter_schema("macros")
+		self.assertFalse(res.get("ok", True))
+		self.assertEqual(res["error"]["code"], ERR_VIEW_ROLLED_BACK)
+
+	def test_unmigrated_view_declines_with_not_filterable(self):
+		# The other side of the M1.2 distinction: a registered-but-PENDING view
+		# (never migrated) still declines with ERR_VIEW_NOT_FILTERABLE, NOT the
+		# rolled-back code — the two truths must never collapse into one message.
+		with _as(USER_SM):
+			res = list_filters.get_list_filter_schema("approvals")
 		self.assertFalse(res.get("ok", True))
 		self.assertEqual(res["error"]["code"], ERR_VIEW_NOT_FILTERABLE)
 
@@ -397,6 +779,27 @@ class TestCapabilityFlag(unittest.TestCase):
 		with _conf("jarvis_list_filters_v2_off", ["macros"]):
 			compiled = compile_list_filters("macros", clause, user=USER_SM)
 		self.assertIn("`macro_name`", compiled.fragment())
+
+	def test_malformed_flag_fails_closed_disabling_every_view(self):
+		# M1.1: the kill switch must NEVER fail open. A bool (the classic
+		# `"...v2_off": true` typo) used to raise inside the parse and silently
+		# re-enable everything; now it disables every migrated view.
+		for bad in (True, 1, {"macros": True}, ["macros", 123]):
+			with self.subTest(value=bad), _conf("jarvis_list_filters_v2_off", bad):
+				self.assertFalse(view_filters_enabled("macros"), f"{bad!r} failed OPEN")
+				self.assertFalse(view_filters_enabled("skills"), f"{bad!r} failed OPEN")
+
+	def test_malformed_flag_logs_once(self):
+		# One loud Error Log, deduped so a broken switch cannot flood it.
+		frappe.cache().delete_value("jarvis:list-filter-flag-misconfig")
+		flt = {"method": ("like", "%kill-switch misconfigured%")}
+		before = frappe.db.count("Error Log", flt)
+		with _conf("jarvis_list_filters_v2_off", True):
+			view_filters_enabled("macros")
+			view_filters_enabled("skills")  # second call must NOT log again
+		frappe.db.commit()
+		after = frappe.db.count("Error Log", flt)
+		self.assertEqual(after - before, 1, "a malformed kill switch must log exactly once per TTL")
 
 
 class _CaptureHandler(logging.Handler):
@@ -430,5 +833,9 @@ class TestFilterTelemetry(unittest.TestCase):
 		self.assertNotIn("SECRET-VALUE", joined)
 
 	def test_emit_never_raises(self):
-		# A broken clause entry must not let telemetry break a query.
-		emit_filter_telemetry("macros", [], duration_ms=1.0)
+		# S9: a GENUINELY broken clause (its schema entry is missing `fieldtype`)
+		# must not let telemetry break a query. An empty list never entered the
+		# except-guard, so the old test passed even with the guard removed — this
+		# one turns red the moment the try/except comes off `emit_filter_telemetry`.
+		broken = _Clause(index=0, entry={"is_child": False}, operator="=", value="x")
+		emit_filter_telemetry("macros", [broken], duration_ms=1.0)

--- a/jarvis/tests/test_list_filters_f8.py
+++ b/jarvis/tests/test_list_filters_f8.py
@@ -25,6 +25,7 @@ import logging
 import unittest
 
 import frappe
+from frappe.model import data_fieldtypes
 
 from jarvis.chat import list_filters
 from jarvis.chat.list_filters import (
@@ -520,40 +521,16 @@ class TestRangeOperatorsAreTemporalOnly(unittest.TestCase):
 	TEMPORAL = frozenset({"Date", "Datetime", "Time"})
 	CARRIES_RANGE = frozenset({"Date", "Datetime"})
 
-	#: A broad sweep of value-bearing fieldtypes — including the ones with NO
-	#: invalid_condition_map row and no effective-Data conversion (Duration,
-	#: Autocomplete, Geolocation, Rating), which are the whole point of S5.
-	CATALOGABLE = (
-		"Data",
-		"Text",
-		"Small Text",
-		"Long Text",
-		"Text Editor",
-		"Code",
-		"HTML Editor",
-		"Markdown Editor",
-		"Int",
-		"Float",
-		"Currency",
-		"Percent",
-		"Check",
-		"Select",
-		"Link",
-		"Dynamic Link",
-		"Duration",
-		"Rating",
-		"Color",
-		"Phone",
-		"JSON",
-		"Barcode",
-		"Autocomplete",
-		"Geolocation",
-		"Read Only",
-		"Attach",
-		"Attach Image",
-		"Date",
-		"Datetime",
-		"Time",
+	#: EVERY value-bearing fieldtype the schema builder can emit into a catalog,
+	#: enumerated from Frappe's canonical ``data_fieldtypes`` (so a fieldtype Frappe
+	#: adds later is swept the day it lands) minus the two families the builder never
+	#: catalogs: the Table containers and the secret types (Password, deviation D2),
+	#: which is exactly the ``NO_VALUE_FIELDTYPES | SECRET_FIELDTYPES`` gate in
+	#: ``build_field_catalog``. Deriving from the source is the whole point of S5: a
+	#: hand-kept tuple silently omitted Signature/Icon (and Long Int), so promoting
+	#: any of them into ``_TEMPORAL_FIELDTYPES`` by mistake stayed green.
+	CATALOGABLE = tuple(
+		sorted(frozenset(data_fieldtypes) - list_filters.NO_VALUE_FIELDTYPES - list_filters.SECRET_FIELDTYPES)
 	)
 
 	def test_between_or_timespan_implies_temporal(self):
@@ -643,6 +620,43 @@ class TestNumericStrictParse(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------- #
+# D8 — a child clause with no readable container must NEVER compile to `IN ()`
+# --------------------------------------------------------------------------- #
+class TestEmptyParentfieldsFailClosed(unittest.TestCase):
+	"""A child clause carries the readable parent containers as ``parentfields``
+	(M2). An empty set would bind ``parentfield IN ()`` — a hard MariaDB syntax
+	error (pymysql renders the empty tuple literally) that 500s every child-table
+	filter for up to SCHEMA_CACHE_TTL after a restart-only deploy served a stale
+	pre-v2 cached schema. The compiler must fail closed with the stable
+	invalid-field code instead, independently of the CONTRACT_VERSION bump that
+	discards such caches on deploy."""
+
+	def test_empty_parentfields_raise_unknown_field_not_empty_in(self):
+		clause = _Clause(
+			index=0,
+			entry={"is_child": True, "doctype": STEP, "parentfields": []},
+			operator="=",
+			value="x",
+		)
+		with self.assertRaises(ListFilterError) as caught:
+			list_filters.compile_validated(MACRO, [clause], ref="`m`")
+		self.assertEqual(caught.exception.filter_error_code, list_filters.ERR_UNKNOWN_FIELD)
+
+	def test_missing_parentfields_key_also_fails_closed(self):
+		# A pre-M2 cached entry has no `parentfields` key at all, not just an empty
+		# list — `.get(...) or ()` must land it on the same closed failure.
+		clause = _Clause(
+			index=0,
+			entry={"is_child": True, "doctype": STEP},
+			operator="=",
+			value="x",
+		)
+		with self.assertRaises(ListFilterError) as caught:
+			list_filters.compile_validated(MACRO, [clause], ref="`m`")
+		self.assertEqual(caught.exception.filter_error_code, list_filters.ERR_UNKNOWN_FIELD)
+
+
+# --------------------------------------------------------------------------- #
 # P1-10 — schema_revision hashes the full contract
 # --------------------------------------------------------------------------- #
 class TestSchemaRevisionContract(unittest.TestCase):
@@ -696,6 +710,16 @@ class TestSchemaRevisionContract(unittest.TestCase):
 		a = list_filters._schema_digest([self._field(parentfields=["steps"])])
 		b = list_filters._schema_digest([self._field(parentfields=["steps", "steps_alt"])])
 		self.assertNotEqual(a, b, "a change to a wire key (parentfields) must change the revision")
+
+	def test_group_change_changes_revision(self):
+		# S8: the field-picker GROUP the client renders is not a wire key of its own —
+		# it is derived from `is_child`+`doctype` (filterModel `fieldOptions`). A field
+		# that moves group (a different doctype, or parent→child) must therefore move
+		# the revision, or the picker regroups against a stale ETag. Guards the digest
+		# against a future "hash only some keys" change that dropped either input.
+		a = list_filters._schema_digest([self._field(doctype=MACRO, is_child=False)])
+		b = list_filters._schema_digest([self._field(doctype=STEP, is_child=True)])
+		self.assertNotEqual(a, b, "a change to a field's group (doctype/is_child) must change the revision")
 
 	def test_header_keys_change_revision(self):
 		# S8: schema-LEVEL keys the client renders (root_doctype, is_large_table,
@@ -780,11 +804,24 @@ class TestCapabilityFlag(unittest.TestCase):
 			compiled = compile_list_filters("macros", clause, user=USER_SM)
 		self.assertIn("`macro_name`", compiled.fragment())
 
+	def test_off_false_or_zero_disables_nothing(self):
+		# D4: `false`/`0` is the most natural spelling of "kill switch not engaged"
+		# for a key named `*_off`. Neither equals any of None/""/[]/() under `==`, so
+		# without an explicit allow they fell THROUGH to the fail-closed branch and
+		# silently disabled EVERY migrated view, fleet-wide. They must read as
+		# "disable nothing". `0.0` is included as the JSON-number sibling of `0`.
+		for off in (False, 0, 0.0):
+			with self.subTest(value=off), _conf("jarvis_list_filters_v2_off", off):
+				self.assertTrue(view_filters_enabled("macros"), f"{off!r} disabled macros")
+				self.assertTrue(view_filters_enabled("skills"), f"{off!r} disabled skills")
+
 	def test_malformed_flag_fails_closed_disabling_every_view(self):
 		# M1.1: the kill switch must NEVER fail open. A bool (the classic
 		# `"...v2_off": true` typo) used to raise inside the parse and silently
-		# re-enable everything; now it disables every migrated view.
-		for bad in (True, 1, {"macros": True}, ["macros", 123]):
+		# re-enable everything; now it disables every migrated view. `True`/`1` are
+		# ambiguous junk (distinct from the `false`/`0` = "off" case above) and, with
+		# a dict or a mixed list, must all fail CLOSED.
+		for bad in (True, 1, {"macros": True}, ["macros", 2]):
 			with self.subTest(value=bad), _conf("jarvis_list_filters_v2_off", bad):
 				self.assertFalse(view_filters_enabled("macros"), f"{bad!r} failed OPEN")
 				self.assertFalse(view_filters_enabled("skills"), f"{bad!r} failed OPEN")

--- a/jarvis/tests/test_list_filters_f8.py
+++ b/jarvis/tests/test_list_filters_f8.py
@@ -1,0 +1,434 @@
+"""Wave F8 foundation repairs to the shared list-filter contract.
+
+Round-two review (plan 08) blocking + high-priority findings, each proven here:
+
+* **P0-02** — a Table container the caller cannot read (its own permlevel, or a
+  view-level exclusion) must hide EVERY child field, at schema and compiler, for
+  both an ordinary and a privileged role.
+* **P0-03** — Frappe's ``original → effective Data`` operator fallback: a
+  string-like control with no invalid_condition_map row inherits Data's, so it
+  never advertises ``Between``/``Timespan``. Golden per-type, schema + compiler.
+* **P1-01** — malformed / non-finite numeric values fail with the stable code
+  instead of silently becoming ``0`` or reaching the DB binder.
+* **P1-10** — ``schema_revision`` hashes the FULL response contract.
+* **P1-05** — the runtime per-view capability flag (default ON) and the bounded,
+  value-free structural telemetry.
+
+Runs on patterntest.localhost. Reuses ``test_list_filters``'s real-user
+fixtures.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import unittest
+
+import frappe
+
+from jarvis.chat import list_filters
+from jarvis.chat.list_filters import (
+	ERR_INVALID_OPERATOR,
+	ERR_INVALID_VALUE,
+	ERR_VIEW_NOT_FILTERABLE,
+	ListFilterError,
+	allowed_operators,
+	build_field_catalog,
+	compile_list_filters,
+	emit_filter_telemetry,
+	get_schema,
+	invalid_conditions,
+	list_filters_capabilities,
+	view_filters_enabled,
+)
+from jarvis.tests.test_list_filters import (
+	MACRO,
+	PERMLEVEL_ROLE,
+	USER_A,
+	USER_B,
+	USER_SM,
+	_as,
+	_ensure_role,
+	_ensure_user,
+	_entry,
+)
+
+STEP = "Jarvis Macro Step"
+
+
+def setUpModule() -> None:
+	frappe.set_user("Administrator")
+	_ensure_role(PERMLEVEL_ROLE)
+	_ensure_user(USER_SM, ("Jarvis User", "System Manager"))
+	_ensure_user(USER_A, ("Jarvis User", PERMLEVEL_ROLE))
+	_ensure_user(USER_B, ("Jarvis User",))
+
+
+def _child_pairs(catalog) -> set[tuple[str, str]]:
+	return {(f["doctype"], f["fieldname"]) for f in catalog if f.get("is_child")}
+
+
+# --------------------------------------------------------------------------- #
+# P0-02 — the Table-container permission boundary
+# --------------------------------------------------------------------------- #
+class TestContainerPermlevel(unittest.TestCase):
+	"""A readable child field under an UNreadable Table field is an oracle over
+	data the container hides. The container's own permlevel gates discovery."""
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		from frappe.permissions import add_permission, update_permission_property
+
+		cls._perms_before = set(frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name"))
+		# Raise the `steps` TABLE CONTAINER (not a child field) to permlevel 1.
+		frappe.make_property_setter(
+			{
+				"doctype": MACRO,
+				"fieldname": "steps",
+				"property": "permlevel",
+				"value": 1,
+				"property_type": "Int",
+			},
+			is_system_generated=False,
+			validate_fields_for_doctype=False,
+		)
+		# Grant permlevel-1 read on the parent to the role only USER_A holds.
+		add_permission(MACRO, PERMLEVEL_ROLE, 1)
+		update_permission_property(MACRO, PERMLEVEL_ROLE, 1, "read", 1)
+		frappe.db.commit()
+		frappe.clear_cache()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all(
+			"Property Setter",
+			filters={"doc_type": MACRO, "property": "permlevel", "field_name": "steps"},
+			pluck="name",
+		):
+			frappe.delete_doc("Property Setter", name, force=True, ignore_permissions=True)
+		for name in frappe.get_all("Custom DocPerm", filters={"parent": MACRO}, pluck="name"):
+			if name not in cls._perms_before:
+				frappe.delete_doc("Custom DocPerm", name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		frappe.clear_cache()
+
+	def test_unreadable_container_hides_every_child_from_the_schema(self):
+		privileged = get_schema("macros", user=USER_A)
+		ordinary = get_schema("macros", user=USER_B)
+		# Non-vacuity: the privileged role (reads permlevel 1 → reads the container)
+		# still sees the child fields.
+		self.assertIsNotNone(
+			_entry(privileged, STEP, "label"),
+			"the container permlevel-1 grant did not take effect — test would be vacuous",
+		)
+		# The ordinary role cannot read the `steps` container, so NONE of its child
+		# fields are catalogued.
+		self.assertEqual(
+			_child_pairs(ordinary["fields"]),
+			set(),
+			"an unreadable Table container leaked its children",
+		)
+		# Non-vacuity: the ordinary schema is otherwise full (main fields present).
+		self.assertIsNotNone(_entry(ordinary, MACRO, "macro_name"))
+
+	def test_compiler_rejects_a_child_of_an_unreadable_container(self):
+		clause = [{"doctype": STEP, "fieldname": "label", "operator": "=", "value": "x"}]
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("macros", clause, user=USER_B)
+		self.assertEqual(caught.exception.filter_error_code, list_filters.ERR_UNKNOWN_FIELD)
+		# …and the privileged role still can.
+		self.assertIn("`label`", compile_list_filters("macros", clause, user=USER_A).fragment())
+
+	def test_view_excluded_container_suppresses_its_whole_subtree(self):
+		"""The `excluded_fields` check used to sit AFTER the Table `continue`, so an
+		endpoint-withheld container still leaked its children (P0-02, second half)."""
+		catalog = build_field_catalog(MACRO, user=USER_SM, excluded_fields=("steps",))
+		self.assertEqual(
+			_child_pairs(catalog),
+			set(),
+			"an excluded Table container leaked its children",
+		)
+		# The withholding is scoped: siblings survive.
+		self.assertTrue(any(f["fieldname"] == "macro_name" for f in catalog))
+
+
+class TestTwoTableFieldsSameChild(unittest.TestCase):
+	"""Documented explicit behaviour (LIST-FILTERS-DEVIATIONS D16): when a parent
+	reaches ONE child DocType through TWO Table fields, the catalog lists each
+	child field ONCE (deduped by (child DocType, fieldname)), and a clause on that
+	child compiles to ONE ``EXISTS`` keyed by the child DocType — so it matches a
+	row in EITHER container. That is the known ``parentfield`` ambiguity, made
+	explicit rather than left to chance."""
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		if not frappe.db.exists("Custom Field", {"dt": MACRO, "fieldname": "steps_alt"}):
+			frappe.get_doc(
+				{
+					"doctype": "Custom Field",
+					"dt": MACRO,
+					"fieldname": "steps_alt",
+					"label": "Steps Alt",
+					"fieldtype": "Table",
+					"options": STEP,
+				}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+			frappe.clear_cache()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		name = frappe.db.get_value("Custom Field", {"dt": MACRO, "fieldname": "steps_alt"})
+		if name:
+			frappe.delete_doc("Custom Field", name, force=True, ignore_permissions=True)
+			frappe.db.commit()
+			frappe.clear_cache()
+
+	def test_child_fields_are_deduplicated_across_two_containers(self):
+		catalog = build_field_catalog(MACRO, user=USER_SM)
+		labels = [f for f in catalog if f["doctype"] == STEP and f["fieldname"] == "label"]
+		self.assertEqual(len(labels), 1, "a child field reached via two Table fields was duplicated")
+
+	def test_same_child_clause_compiles_to_one_exists(self):
+		clause = [{"doctype": STEP, "fieldname": "label", "operator": "=", "value": "x"}]
+		fragment = compile_list_filters("macros", clause, user=USER_SM).fragment()
+		self.assertEqual(fragment.count("EXISTS"), 1, "same-child clause must be one EXISTS")
+
+
+# --------------------------------------------------------------------------- #
+# P0-03 — original → effective Data operator fallback
+# --------------------------------------------------------------------------- #
+class TestOperatorMatrixEffectiveData(unittest.TestCase):
+	#: Every string-like control Frappe scrubs to effective Data (filter.js) that
+	#: has NO invalid_condition_map row of its own, plus Long Text (Jarvis D15).
+	CONVERTED = (
+		"Text",
+		"Small Text",
+		"Text Editor",
+		"Attach",
+		"Attach Image",
+		"Tag",
+		"Phone",
+		"JSON",
+		"Comments",
+		"Barcode",
+		"Dynamic Link",
+		"Read Only",
+		"Assign",
+		"Long Text",
+	)
+
+	def test_converted_types_inherit_datas_invalid_conditions(self):
+		for ft in self.CONVERTED:
+			invalid = invalid_conditions(ft)
+			self.assertIn("Between", invalid, f"{ft} must inherit Data's invalid Between")
+			self.assertIn("Timespan", invalid, f"{ft} must inherit Data's invalid Timespan")
+			ops = allowed_operators("body", ft)
+			self.assertNotIn("Between", ops, f"{ft} must not advertise Between")
+			self.assertNotIn("Timespan", ops, f"{ft} must not advertise Timespan")
+			# non-vacuity: it is still a usable text control
+			self.assertIn("like", ops)
+			self.assertIn("=", ops)
+
+	def test_types_with_their_own_row_keep_it(self):
+		# original_type wins: these are converted to Data by set_fieldtype but keep
+		# their own map row in hide_invalid_conditions.
+		self.assertNotIn(">", allowed_operators("x", "Code"))
+		self.assertNotIn("Between", allowed_operators("x", "Code"))
+		self.assertNotIn("Between", allowed_operators("x", "Color"))
+		# Data itself is unchanged.
+		self.assertNotIn("Between", allowed_operators("x", "Data"))
+
+	def test_comments_standard_text_field_excludes_between(self):
+		"""``_comments`` is a standard Text field, so it must inherit the Data set."""
+		self.assertNotIn("Between", allowed_operators("_comments", "Text"))
+		self.assertNotIn("Timespan", allowed_operators("_comments", "Text"))
+
+	def test_schema_never_offers_between_on_a_small_text_field(self):
+		schema = get_schema("macros", user=USER_SM)
+		desc = _entry(schema, MACRO, "description")  # Small Text
+		self.assertIsNotNone(desc)
+		self.assertNotIn("Between", desc["operators"])
+		self.assertNotIn("Timespan", desc["operators"])
+
+	def test_compiler_rejects_between_on_a_small_text_field(self):
+		clause = [
+			{
+				"doctype": MACRO,
+				"fieldname": "description",
+				"operator": "Between",
+				"value": ["2026-01-01", "2026-12-31"],
+			}
+		]
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("macros", clause, user=USER_SM)
+		self.assertEqual(caught.exception.filter_error_code, ERR_INVALID_OPERATOR)
+
+
+# --------------------------------------------------------------------------- #
+# P1-01 — strict numeric parsing
+# --------------------------------------------------------------------------- #
+class TestNumericStrictParse(unittest.TestCase):
+	def _reject(self, value) -> str:
+		clause = [{"doctype": MACRO, "fieldname": "idx", "operator": "=", "value": value}]
+		with self.assertRaises(ListFilterError) as caught:
+			compile_list_filters("macros", clause, user=USER_SM)
+		return caught.exception.filter_error_code
+
+	def test_nonnumeric_string_is_rejected_not_zeroed(self):
+		self.assertEqual(self._reject("abc"), ERR_INVALID_VALUE)
+
+	def test_blank_numeric_stays_zero_at_parity(self):
+		# D14: a blank numeric compiles to `= 0` (Frappe parity), no error.
+		clause = [{"doctype": MACRO, "fieldname": "idx", "operator": "=", "value": ""}]
+		compiled = compile_list_filters("macros", clause, user=USER_SM)
+		self.assertIn(0, compiled.params.values())
+
+	def test_int_truncates_a_fractional_value(self):
+		clause = [{"doctype": MACRO, "fieldname": "idx", "operator": "=", "value": "3.7"}]
+		compiled = compile_list_filters("macros", clause, user=USER_SM)
+		self.assertIn(3, compiled.params.values())
+
+	def test_float_family_rejects_non_finite(self):
+		# No Float field on a migrated view, so exercise the parser directly.
+		entry = {"fieldtype": "Float", "label": "Amount"}
+		for bad in ("inf", "-inf", "nan", "Infinity"):
+			with self.assertRaises(ListFilterError):
+				list_filters._as_number(entry, bad)
+
+	def test_float_family_accepts_a_real_number(self):
+		entry = {"fieldtype": "Float", "label": "Amount"}
+		self.assertEqual(list_filters._as_number(entry, "3.5"), 3.5)
+
+
+# --------------------------------------------------------------------------- #
+# P1-10 — schema_revision hashes the full contract
+# --------------------------------------------------------------------------- #
+class TestSchemaRevisionContract(unittest.TestCase):
+	def _field(self, **over) -> dict:
+		base = {
+			"doctype": MACRO,
+			"fieldname": "status",
+			"label": "Status",
+			"fieldtype": "Select",
+			"options": "Open\nClosed",
+			"default_operator": "=",
+			"operators": ["=", "!="],
+			"is_standard": False,
+			"is_child": False,
+			"json_array": False,
+		}
+		base.update(over)
+		return base
+
+	def test_identical_contract_same_revision(self):
+		self.assertEqual(
+			list_filters._schema_digest([self._field()], {"max_clauses": 20}),
+			list_filters._schema_digest([self._field()], {"max_clauses": 20}),
+		)
+
+	def test_label_change_changes_revision(self):
+		a = list_filters._schema_digest([self._field(label="Status")])
+		b = list_filters._schema_digest([self._field(label="State")])
+		self.assertNotEqual(a, b, "a relabel must change schema_revision (P1-10)")
+
+	def test_select_options_change_changes_revision(self):
+		a = list_filters._schema_digest([self._field(options="Open\nClosed")])
+		b = list_filters._schema_digest([self._field(options="Open\nClosed\nHeld")])
+		self.assertNotEqual(a, b, "a Select-option change must change schema_revision")
+
+	def test_link_target_change_changes_revision(self):
+		a = list_filters._schema_digest([self._field(fieldtype="Link", options="User")])
+		b = list_filters._schema_digest([self._field(fieldtype="Link", options="Role")])
+		self.assertNotEqual(a, b, "a Link-target change must change schema_revision")
+
+	def test_limits_change_changes_revision(self):
+		a = list_filters._schema_digest([self._field()], {"max_clauses": 20})
+		b = list_filters._schema_digest([self._field()], {"max_clauses": 10})
+		self.assertNotEqual(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# P1-05 — runtime capability flag + structural telemetry
+# --------------------------------------------------------------------------- #
+@contextlib.contextmanager
+def _conf(key, value):
+	orig = frappe.conf.get(key)
+	frappe.conf[key] = value
+	try:
+		yield
+	finally:
+		if orig is None:
+			frappe.conf.pop(key, None)
+		else:
+			frappe.conf[key] = orig
+
+
+class TestCapabilityFlag(unittest.TestCase):
+	def test_default_on(self):
+		self.assertTrue(view_filters_enabled("skills"))
+		self.assertTrue(view_filters_enabled("macros"))
+
+	def test_flag_rolls_a_view_back(self):
+		with _conf("jarvis_list_filters_v2_off", ["macros"]):
+			self.assertFalse(view_filters_enabled("macros"))
+			self.assertTrue(view_filters_enabled("skills"))
+
+	def test_disabled_view_schema_endpoint_declines(self):
+		with _conf("jarvis_list_filters_v2_off", ["macros"]), _as(USER_SM):
+			res = list_filters.get_list_filter_schema("macros")
+		self.assertFalse(res.get("ok", True))
+		self.assertEqual(res["error"]["code"], ERR_VIEW_NOT_FILTERABLE)
+
+	def test_capabilities_map_lists_migrated_views(self):
+		with _as(USER_SM):
+			caps = list_filters_capabilities()
+		self.assertIn("skills", caps)
+		self.assertIn("macros", caps)
+		self.assertTrue(caps["skills"])
+
+	def test_compile_still_honours_v2_when_flag_off(self):
+		# do-not-regress rule 8: a stale client's clause is answered, never dropped.
+		clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "=", "value": "x"}]
+		with _conf("jarvis_list_filters_v2_off", ["macros"]):
+			compiled = compile_list_filters("macros", clause, user=USER_SM)
+		self.assertIn("`macro_name`", compiled.fragment())
+
+
+class _CaptureHandler(logging.Handler):
+	def __init__(self):
+		super().__init__()
+		self.records = []
+
+	def emit(self, record):
+		self.records.append(record.getMessage())
+
+
+class TestFilterTelemetry(unittest.TestCase):
+	def _capture(self, fn):
+		logger = list_filters._filter_logger()
+		handler = _CaptureHandler()
+		logger.addHandler(handler)
+		try:
+			fn()
+		finally:
+			logger.removeHandler(handler)
+		return handler.records
+
+	def test_compile_emits_structural_line_without_values(self):
+		clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "SECRET-VALUE"}]
+		records = self._capture(lambda: compile_list_filters("macros", clause, user=USER_SM))
+		joined = "\n".join(records)
+		self.assertIn("list_filter", joined)
+		self.assertIn('"op": "like"', joined)
+		self.assertIn("macros", joined)
+		# The load-bearing invariant: no filter VALUE is ever logged.
+		self.assertNotIn("SECRET-VALUE", joined)
+
+	def test_emit_never_raises(self):
+		# A broken clause entry must not let telemetry break a query.
+		emit_filter_telemetry("macros", [], duration_ms=1.0)

--- a/jarvis/tests/test_list_filters_pilots.py
+++ b/jarvis/tests/test_list_filters_pilots.py
@@ -130,12 +130,20 @@ def _mk_macro(owner: str, name: str, enabled=1, steps=None) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Structural proof: the emitted WHERE is byte-identical to the legacy one.
+# Structural check on the ASSEMBLER (not on the pilots).
 # --------------------------------------------------------------------------- #
-class TestScopePredicateUnchanged(unittest.TestCase):
-	"""The pre-migration endpoints built ``" AND ".join(conds)`` by hand. These
-	are those exact strings, per branch, compared against what the shared query
-	object emits with no user clauses."""
+class TestQueryObjectReproducesTheLegacyPredicates(unittest.TestCase):
+	"""What this proves, precisely: :class:`ListFilterQuery`, fed the same
+	server-authored predicates the pre-migration endpoints built by hand, emits
+	the same WHERE — modulo the defensive parenthesisation the joiner now adds
+	around every part, which is semantically inert.
+
+	What it does NOT prove: that the pilots feed it the right predicates. That is
+	:class:`TestPilotEqualityOfScope` below, which exercises the real endpoints
+	and compares real result envelopes. This class would still pass if someone
+	deleted a ``server_condition`` call from ``list_custom_skills_page``; that
+	one would not.
+	"""
 
 	def _skills_query(self, scope, shared, search=None, legacy=None):
 		q = list_filters.new_query("skills", user=USER_A)
@@ -162,12 +170,15 @@ class TestScopePredicateUnchanged(unittest.TestCase):
 		return q
 
 	def test_skills_scope_branches(self):
+		# Right-hand side = the exact pre-migration string, wrapped by the
+		# joiner's defensive parentheses (see _and(): a predicate with a
+		# top-level OR must not bind loosely into the AND-chain).
 		cases = [
-			((None, ()), "owner = %(me)s"),
-			((None, ("s1",)), "(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))"),
-			(("mine", ("s1",)), "owner = %(me)s"),
-			(("shared", ()), "1=0"),
-			(("shared", ("s1",)), "(name IN %(shared)s AND enabled = 1)"),
+			((None, ()), "(owner = %(me)s)"),
+			((None, ("s1",)), "((owner = %(me)s OR (name IN %(shared)s AND enabled = 1)))"),
+			(("mine", ("s1",)), "(owner = %(me)s)"),
+			(("shared", ()), "(1=0)"),
+			(("shared", ("s1",)), "((name IN %(shared)s AND enabled = 1))"),
 		]
 		for (scope, shared), expected in cases:
 			with self.subTest(scope=scope, shared=bool(shared)):
@@ -182,8 +193,8 @@ class TestScopePredicateUnchanged(unittest.TestCase):
 		)
 		self.assertEqual(
 			q.where(),
-			"owner = %(me)s AND (skill_name LIKE %(q)s OR description LIKE %(q)s) "
-			"AND enabled = %(enabled)s AND user_invocable = %(user_invocable)s",
+			"(owner = %(me)s) AND ((skill_name LIKE %(q)s OR description LIKE %(q)s)) "
+			"AND (enabled = %(enabled)s) AND (user_invocable = %(user_invocable)s)",
 		)
 		self.assertEqual(q.params(), {"me": USER_A, "q": "%x%", "enabled": 1, "user_invocable": 0})
 
@@ -197,9 +208,9 @@ class TestScopePredicateUnchanged(unittest.TestCase):
 		q.apply([])
 		self.assertEqual(
 			q.where(),
-			"owner = %(me)s AND (macro_name LIKE %(q)s OR description LIKE %(q)s) "
-			"AND enabled = %(enabled)s AND schedule_enabled = %(schedule_enabled)s "
-			"AND schedule_frequency = %(schedule_frequency)s",
+			"(owner = %(me)s) AND ((macro_name LIKE %(q)s OR description LIKE %(q)s)) "
+			"AND (enabled = %(enabled)s) AND (schedule_enabled = %(schedule_enabled)s) "
+			"AND (schedule_frequency = %(schedule_frequency)s)",
 		)
 
 
@@ -333,6 +344,20 @@ class TestPilotEqualityOfScope(unittest.TestCase):
 		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-a"})
 		self.assertEqual(res["total"], 1)
 
+	def test_a_rejected_filter_is_an_envelope_not_an_empty_list(self):
+		"""The failure mode a filtered list must never have: the SPA's list
+		composable reads ``res.rows`` and falls back to ``[]``, so a rejection
+		returned as a bare 200 would render as 'no results' — a wrong answer that
+		looks like a right one."""
+		res = self._macros(
+			USER_A,
+			filters_v2=[{"doctype": MACRO, "fieldname": "no_such_field", "operator": "=", "value": "x"}],
+		)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], "list_filter_unknown_field")
+		self.assertTrue(res["error"]["message"])
+		self.assertNotIn("rows", res)
+
 	def test_schema_endpoint_is_jarvis_user_gated_and_view_scoped(self):
 		from jarvis.chat.list_filters import get_list_filter_schema
 
@@ -342,3 +367,96 @@ class TestPilotEqualityOfScope(unittest.TestCase):
 		self.assertEqual(schema["contract_version"], list_filters.CONTRACT_VERSION)
 		self.assertTrue(schema["schema_revision"])
 		self.assertEqual(schema["limits"]["max_clauses"], list_filters.MAX_CLAUSES)
+
+
+# --------------------------------------------------------------------------- #
+# U1-1: the stable codes reach THE WIRE.
+# --------------------------------------------------------------------------- #
+class TestErrorCodesOnTheWire(unittest.TestCase):
+	"""Asserts on the serialized HTTP response — status line and JSON body — not
+	on the Python object the endpoint returned.
+
+	A code that only exists as an attribute on an exception inside the worker is
+	not a contract. This drives the request through Frappe's real dispatch
+	(``execute_cmd``) and its real serializer (``build_response('json')``), which
+	is what a browser would receive.
+	"""
+
+	@staticmethod
+	def _request(cmd: str, **params) -> tuple[int, dict]:
+		import json as _json
+
+		from frappe.handler import execute_cmd
+		from frappe.utils.response import build_response
+		from werkzeug.test import EnvironBuilder
+		from werkzeug.wrappers import Request
+
+		saved = (
+			getattr(frappe.local, "response", None),
+			getattr(frappe.local, "form_dict", None),
+			getattr(frappe.local, "request", None),
+			getattr(frappe.local, "message_log", None),
+		)
+		try:
+			# A REAL request object on the real /api/method path: execute_cmd
+			# checks the verb against the whitelist's allowed set, and the JSON
+			# serializer reads the path to pick its response version.
+			frappe.local.request = Request(
+				EnvironBuilder(path=f"/api/method/{cmd}", method="GET").get_environ()
+			)
+			frappe.local.response = frappe._dict({"type": "json"})
+			frappe.local.form_dict = frappe._dict({"cmd": cmd, **params})
+			frappe.local.message_log = []
+			data = execute_cmd(cmd)
+			if data is not None:
+				frappe.local.response["message"] = data
+			response = build_response("json")
+			return response.status_code, _json.loads(response.get_data(as_text=True))
+		finally:
+			frappe.local.response, frappe.local.form_dict, frappe.local.request, frappe.local.message_log = (
+				saved
+			)
+
+	def test_unknown_field_serializes_as_a_coded_4xx(self):
+		with _as(USER_A):
+			status, body = self._request(
+				"jarvis.chat.macros_api.list_macros_page",
+				filters_v2='[{"doctype": "Jarvis Macro", "fieldname": "nope", "operator": "=", "value": "x"}]',
+			)
+		self.assertEqual(status, 417)
+		self.assertEqual(body["message"]["ok"], False)
+		self.assertEqual(body["message"]["error"]["code"], "list_filter_unknown_field")
+		# The human-readable half rides along too, in Frappe's own channel, so an
+		# existing client that only knows _server_messages still shows something.
+		self.assertTrue(body.get("_server_messages"))
+
+	def test_malformed_payload_serializes_as_400(self):
+		with _as(USER_A):
+			status, body = self._request(
+				"jarvis.chat.custom_skills_api.list_custom_skills_page", filters_v2="{not json"
+			)
+		self.assertEqual(status, 400)
+		self.assertEqual(body["message"]["error"]["code"], "list_filter_bad_payload")
+
+	def test_schema_endpoint_serializes_its_code_too(self):
+		with _as(USER_A):
+			status, body = self._request(
+				"jarvis.chat.list_filters.get_list_filter_schema", view_key="not-a-view"
+			)
+		self.assertEqual(status, 417)
+		self.assertEqual(body["message"]["error"]["code"], "list_filter_unknown_view")
+
+	def test_a_successful_call_keeps_status_200_and_the_bare_envelope(self):
+		"""Non-vacuity: the boundary must not have turned every response into an
+		envelope — the success shape is frozen and the SPA reads it directly."""
+		with _as(USER_A):
+			status, body = self._request("jarvis.chat.macros_api.list_macros_page")
+		self.assertEqual(status, 200)
+		self.assertIn("rows", body["message"])
+		self.assertNotIn("ok", body["message"])
+
+	def test_a_legacy_filter_error_is_left_alone(self):
+		"""The boundary catches ListFilterError only. The legacy ``filters``
+		contract still throws, which is what its existing callers expect."""
+		with _as(USER_A), self.assertRaises(frappe.ValidationError):
+			self._request("jarvis.chat.macros_api.list_macros_page", filters='{"bogus_key": 1}')

--- a/jarvis/tests/test_list_filters_pilots.py
+++ b/jarvis/tests/test_list_filters_pilots.py
@@ -189,7 +189,10 @@ class TestQueryObjectReproducesTheLegacyPredicates(unittest.TestCase):
 			None,
 			(),
 			search="%x%",
-			legacy=[("enabled = %(enabled)s", {"enabled": 1}), ("user_invocable = %(user_invocable)s", {"user_invocable": 0})],
+			legacy=[
+				("enabled = %(enabled)s", {"enabled": 1}),
+				("user_invocable = %(user_invocable)s", {"user_invocable": 0}),
+			],
 		)
 		self.assertEqual(
 			q.where(),
@@ -294,7 +297,9 @@ class TestPilotEqualityOfScope(unittest.TestCase):
 
 		res = self._macros(
 			USER_A,
-			filters_v2=[{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}],
+			filters_v2=[
+				{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}
+			],
 		)
 		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-a", "lfp-macro-a2"})
 
@@ -303,7 +308,9 @@ class TestPilotEqualityOfScope(unittest.TestCase):
 		the migration must not have loosened that."""
 		res = self._macros(
 			USER_SM,
-			filters_v2=[{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}],
+			filters_v2=[
+				{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}
+			],
 		)
 		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-sm"})
 
@@ -339,7 +346,9 @@ class TestPilotEqualityOfScope(unittest.TestCase):
 	def test_child_filter_through_the_macros_endpoint(self):
 		res = self._macros(
 			USER_A,
-			filters_v2=[{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "build"}],
+			filters_v2=[
+				{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "build"}
+			],
 		)
 		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-a"})
 		self.assertEqual(res["total"], 1)

--- a/jarvis/tests/test_list_filters_pilots.py
+++ b/jarvis/tests/test_list_filters_pilots.py
@@ -1,0 +1,344 @@
+"""The two Phase-1 pilots: Skills and Macros on the ``filters_v2`` contract.
+
+The point of this module is the EQUALITY-OF-SCOPE regression. ``filters_v2`` is
+additive: with no clauses, both endpoints must behave exactly as they did before
+the migration, for every role. Two independent proofs:
+
+* **Structural** — the WHERE the shared query object emits for each scope branch
+  is compared against the literal string the pre-migration code built.
+* **Functional** — legacy-only, ``filters_v2=None``, ``filters_v2=[]`` and
+  ``filters_v2="[]"`` return identical envelopes, at two roles.
+
+Then: a user clause can only ever NARROW the fixed scope (a filter naming another
+user's rows returns nothing rather than widening), legacy and v2 filters AND
+together, and rows / total / has_more agree under a v2 filter.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import unittest
+
+import frappe
+
+from jarvis.chat import list_filters
+from jarvis.chat.custom_skills_api import list_custom_skills_page
+from jarvis.chat.macros_api import list_macros_page
+
+SKILL = "Jarvis Custom Skill"
+MACRO = "Jarvis Macro"
+SHARE = "Jarvis Custom Skill Share"
+
+USER_A = "lfp-user-a@example.com"
+USER_B = "lfp-user-b@example.com"
+USER_SM = "lfp-user-sm@example.com"
+
+
+def _ensure_user(email: str, system_manager: bool = False) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert()
+		frappe.db.commit()
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+	doc = frappe.get_doc("User", email)
+	roles = set(frappe.get_roles(email))
+	if "Jarvis User" not in roles:
+		doc.add_roles("Jarvis User")
+	if system_manager and "System Manager" not in roles:
+		doc.add_roles("System Manager")
+	if not system_manager and "System Manager" in roles:
+		doc.remove_roles("System Manager")
+	frappe.db.commit()
+	frappe.clear_cache(user=email)
+	return email
+
+
+def setUpModule() -> None:
+	frappe.set_user("Administrator")
+	_ensure_user(USER_A)
+	_ensure_user(USER_B)
+	_ensure_user(USER_SM, system_manager=True)
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _wipe() -> None:
+	for name in frappe.get_all(SKILL, filters={"skill_name": ["like", "lfp-%"]}, pluck="name"):
+		frappe.delete_doc(SKILL, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(MACRO, filters={"macro_name": ["like", "lfp-%"]}, pluck="name"):
+		frappe.delete_doc(MACRO, name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _mk_skill(owner: str, name: str, enabled=1, user_invocable=1, shared_with=None) -> str:
+	with _as(owner):
+		doc = frappe.get_doc(
+			{
+				"doctype": SKILL,
+				"skill_name": name,
+				"description": f"{name} description",
+				"instructions": "do the thing",
+				"enabled": enabled,
+				"user_invocable": user_invocable,
+				"shared_with": [{"user": u} for u in (shared_with or [])],
+			}
+		)
+		doc.flags.ignore_validate = True
+		doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+def _mk_macro(owner: str, name: str, enabled=1, steps=None) -> str:
+	with _as(owner):
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": name,
+				"description": "m",
+				"enabled": enabled,
+				"stop_on_error": 1,
+				"steps": [{"label": lbl, "prompt": prm} for lbl, prm in (steps or [("s0", "p0")])],
+			}
+		)
+		doc.flags.ignore_validate = True
+		doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+# --------------------------------------------------------------------------- #
+# Structural proof: the emitted WHERE is byte-identical to the legacy one.
+# --------------------------------------------------------------------------- #
+class TestScopePredicateUnchanged(unittest.TestCase):
+	"""The pre-migration endpoints built ``" AND ".join(conds)`` by hand. These
+	are those exact strings, per branch, compared against what the shared query
+	object emits with no user clauses."""
+
+	def _skills_query(self, scope, shared, search=None, legacy=None):
+		q = list_filters.new_query("skills", user=USER_A)
+		if scope == "mine":
+			q.server_condition("owner = %(me)s", me=USER_A)
+		elif scope == "shared":
+			if not shared:
+				q.server_condition("1=0")
+			else:
+				q.server_condition("(name IN %(shared)s AND enabled = 1)", shared=shared)
+		else:
+			if shared:
+				q.server_condition(
+					"(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))", me=USER_A, shared=shared
+				)
+			else:
+				q.server_condition("owner = %(me)s", me=USER_A)
+		if search:
+			q.server_condition("(skill_name LIKE %(q)s OR description LIKE %(q)s)", q=search)
+		if legacy:
+			for sql, params in legacy:
+				q.server_condition(sql, **params)
+		q.apply(None)
+		return q
+
+	def test_skills_scope_branches(self):
+		cases = [
+			((None, ()), "owner = %(me)s"),
+			((None, ("s1",)), "(owner = %(me)s OR (name IN %(shared)s AND enabled = 1))"),
+			(("mine", ("s1",)), "owner = %(me)s"),
+			(("shared", ()), "1=0"),
+			(("shared", ("s1",)), "(name IN %(shared)s AND enabled = 1)"),
+		]
+		for (scope, shared), expected in cases:
+			with self.subTest(scope=scope, shared=bool(shared)):
+				self.assertEqual(self._skills_query(scope, shared).where(), expected)
+
+	def test_skills_full_legacy_chain(self):
+		q = self._skills_query(
+			None,
+			(),
+			search="%x%",
+			legacy=[("enabled = %(enabled)s", {"enabled": 1}), ("user_invocable = %(user_invocable)s", {"user_invocable": 0})],
+		)
+		self.assertEqual(
+			q.where(),
+			"owner = %(me)s AND (skill_name LIKE %(q)s OR description LIKE %(q)s) "
+			"AND enabled = %(enabled)s AND user_invocable = %(user_invocable)s",
+		)
+		self.assertEqual(q.params(), {"me": USER_A, "q": "%x%", "enabled": 1, "user_invocable": 0})
+
+	def test_macros_full_legacy_chain(self):
+		q = list_filters.new_query("macros", user=USER_A)
+		q.server_condition("owner = %(me)s", me=USER_A)
+		q.server_condition("(macro_name LIKE %(q)s OR description LIKE %(q)s)", q="%x%")
+		q.server_condition("enabled = %(enabled)s", enabled=1)
+		q.server_condition("schedule_enabled = %(schedule_enabled)s", schedule_enabled=0)
+		q.server_condition("schedule_frequency = %(schedule_frequency)s", schedule_frequency="daily")
+		q.apply([])
+		self.assertEqual(
+			q.where(),
+			"owner = %(me)s AND (macro_name LIKE %(q)s OR description LIKE %(q)s) "
+			"AND enabled = %(enabled)s AND schedule_enabled = %(schedule_enabled)s "
+			"AND schedule_frequency = %(schedule_frequency)s",
+		)
+
+
+# --------------------------------------------------------------------------- #
+# Functional proof: identical envelopes at two roles.
+# --------------------------------------------------------------------------- #
+class TestPilotEqualityOfScope(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		_wipe()
+		cls.a_on = _mk_skill(USER_A, "lfp-a-on", enabled=1)
+		cls.a_off = _mk_skill(USER_A, "lfp-a-off", enabled=0)
+		cls.b_shared = _mk_skill(USER_B, "lfp-b-shared", enabled=1, shared_with=[USER_A])
+		cls.b_private = _mk_skill(USER_B, "lfp-b-private", enabled=1)
+		cls.sm_own = _mk_skill(USER_SM, "lfp-sm-own", enabled=1)
+		cls.ma = _mk_macro(USER_A, "lfp-macro-a", enabled=1, steps=[("build", "do it")])
+		cls.ma2 = _mk_macro(USER_A, "lfp-macro-a2", enabled=0)
+		cls.mb = _mk_macro(USER_B, "lfp-macro-b", enabled=1)
+		cls.msm = _mk_macro(USER_SM, "lfp-macro-sm", enabled=1)
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def _skills(self, user, **kw):
+		kw.setdefault("page_length", 100)
+		with _as(user):
+			return list_custom_skills_page(**kw)
+
+	def _macros(self, user, **kw):
+		kw.setdefault("page_length", 100)
+		with _as(user):
+			return list_macros_page(**kw)
+
+	def test_skills_empty_filters_v2_is_identical_to_legacy_at_both_roles(self):
+		for user in (USER_A, USER_SM):
+			with self.subTest(user=user):
+				baseline = self._skills(user)
+				for empty in (None, [], "[]", ""):
+					self.assertEqual(
+						self._skills(user, filters_v2=empty),
+						baseline,
+						f"filters_v2={empty!r} changed the result envelope",
+					)
+
+	def test_macros_empty_filters_v2_is_identical_to_legacy_at_both_roles(self):
+		for user in (USER_A, USER_SM):
+			with self.subTest(user=user):
+				baseline = self._macros(user)
+				for empty in (None, [], "[]", ""):
+					self.assertEqual(self._macros(user, filters_v2=empty), baseline)
+
+	def test_skills_scope_is_still_own_plus_shared_enabled(self):
+		names = {r["skill_name"] for r in self._skills(USER_A)["rows"]}
+		self.assertEqual(names, {"lfp-a-on", "lfp-a-off", "lfp-b-shared"})
+
+	def test_legacy_filters_still_work_unchanged(self):
+		res = self._skills(USER_A, filters={"enabled": 1})
+		self.assertEqual({r["skill_name"] for r in res["rows"]}, {"lfp-a-on", "lfp-b-shared"})
+		res = self._skills(USER_A, filters={"scope": "mine"})
+		self.assertEqual({r["skill_name"] for r in res["rows"]}, {"lfp-a-on", "lfp-a-off"})
+
+	def test_filters_v2_narrows_within_scope(self):
+		res = self._skills(
+			USER_A, filters_v2=[{"doctype": SKILL, "fieldname": "enabled", "operator": "=", "value": 0}]
+		)
+		self.assertEqual({r["skill_name"] for r in res["rows"]}, {"lfp-a-off"})
+		self.assertEqual(res["total"], 1)
+		self.assertFalse(res["has_more"])
+
+	def test_filters_v2_can_never_widen_the_fixed_scope(self):
+		"""Filtering ON another user's identity returns nothing — it does not
+		reach outside the server-authored predicate."""
+		res = self._macros(
+			USER_A, filters_v2=[{"doctype": MACRO, "fieldname": "owner", "operator": "=", "value": USER_B}]
+		)
+		self.assertEqual(res["rows"], [])
+		self.assertEqual(res["total"], 0)
+
+		res = self._macros(
+			USER_A,
+			filters_v2=[{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}],
+		)
+		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-a", "lfp-macro-a2"})
+
+	def test_system_manager_gets_no_extra_rows_from_the_v2_path(self):
+		"""These lists are owner-scoped for everyone, System Manager included;
+		the migration must not have loosened that."""
+		res = self._macros(
+			USER_SM,
+			filters_v2=[{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}],
+		)
+		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-sm"})
+
+	def test_legacy_and_v2_filters_and_together(self):
+		res = self._skills(
+			USER_A,
+			filters={"scope": "mine"},
+			filters_v2=[{"doctype": SKILL, "fieldname": "enabled", "operator": "=", "value": 1}],
+		)
+		self.assertEqual({r["skill_name"] for r in res["rows"]}, {"lfp-a-on"})
+
+	def test_rows_total_and_has_more_share_the_compiled_where(self):
+		"""total counts the FILTERED set (not the scope), and has_more is derived
+		from the same WHERE the row page used."""
+		clause = [{"doctype": MACRO, "fieldname": "macro_name", "operator": "like", "value": "lfp-macro"}]
+		page = self._macros(USER_A, filters_v2=clause, page_length=1)
+		self.assertEqual(page["total"], 2, "the count query must use the compiled WHERE too")
+		self.assertEqual(len(page["rows"]), 1)
+		self.assertTrue(page["has_more"])
+
+		rest = self._macros(USER_A, filters_v2=clause, page_length=1, start=1)
+		self.assertEqual(len(rest["rows"]), 1)
+		self.assertFalse(rest["has_more"])
+		self.assertNotEqual(rest["rows"][0]["name"], page["rows"][0]["name"])
+
+		narrowed = self._macros(
+			USER_A,
+			filters_v2=clause + [{"doctype": MACRO, "fieldname": "enabled", "operator": "=", "value": 1}],
+		)
+		self.assertEqual(narrowed["total"], 1)
+		self.assertEqual({r["macro_name"] for r in narrowed["rows"]}, {"lfp-macro-a"})
+
+	def test_child_filter_through_the_macros_endpoint(self):
+		res = self._macros(
+			USER_A,
+			filters_v2=[{"doctype": "Jarvis Macro Step", "fieldname": "label", "operator": "=", "value": "build"}],
+		)
+		self.assertEqual({r["macro_name"] for r in res["rows"]}, {"lfp-macro-a"})
+		self.assertEqual(res["total"], 1)
+
+	def test_schema_endpoint_is_jarvis_user_gated_and_view_scoped(self):
+		from jarvis.chat.list_filters import get_list_filter_schema
+
+		with _as(USER_A):
+			schema = get_list_filter_schema("skills")
+		self.assertEqual(schema["root_doctype"], SKILL)
+		self.assertEqual(schema["contract_version"], list_filters.CONTRACT_VERSION)
+		self.assertTrue(schema["schema_revision"])
+		self.assertEqual(schema["limits"]["max_clauses"], list_filters.MAX_CLAUSES)

--- a/jarvis/tests/test_list_registry.py
+++ b/jarvis/tests/test_list_registry.py
@@ -21,12 +21,18 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import pkgutil
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import list_registry
 from jarvis.chat.list_filters import build_field_catalog
+
+#: A user holding ONLY the app-access role — the floor every Jarvis customer's
+#: ordinary staff sits on. Administrator's catalog is the ceiling; this is the
+#: number that actually reaches most people.
+FLOOR_USER = "lfr-floor@example.com"
 
 #: Every surface that must be registered. A rename is fine; a disappearance is
 #: not. Mirrors plan 08 §3.3 + the 8 ListPage consumers + the Settings surfaces,
@@ -68,6 +74,56 @@ def _resolve(dotted: str):
 	module_path, _, attr = dotted.rpartition(".")
 	module = importlib.import_module(module_path)
 	return getattr(module, attr)
+
+
+def _ensure_floor_user() -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", FLOOR_USER):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": FLOOR_USER,
+				"first_name": "lfr-floor",
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert()
+		frappe.db.commit()
+	doc = frappe.get_doc("User", FLOOR_USER)
+	roles = set(frappe.get_roles(FLOOR_USER))
+	if "Jarvis User" not in roles:
+		doc.add_roles("Jarvis User")
+	extra = roles & {"System Manager", "Jarvis Admin", "Jarvis Skill Reviewer"}
+	if extra:
+		doc.remove_roles(*extra)
+	frappe.db.commit()
+	frappe.clear_cache(user=FLOOR_USER)
+	return FLOOR_USER
+
+
+def _whitelisted_list_callables() -> dict[str, object]:
+	"""Every whitelisted ``list_*`` callable under ``jarvis/chat``.
+
+	Import errors are NOT swallowed: a module that fails to import would silently
+	shrink the sweep, which is exactly the loophole this audit closes."""
+	import jarvis.chat
+
+	found: dict[str, object] = {}
+	for info in pkgutil.walk_packages(jarvis.chat.__path__, prefix="jarvis.chat."):
+		module = importlib.import_module(info.name)
+		for name, fn in vars(module).items():
+			if not name.startswith("list_") or not callable(fn):
+				continue
+			if getattr(fn, "__module__", None) != module.__name__:
+				continue  # re-export
+			if fn in frappe.whitelisted:
+				found[f"{module.__name__}.{name}"] = fn
+	return found
 
 
 class TestListRegistryIntegrity(FrappeTestCase):
@@ -128,6 +184,56 @@ class TestListRegistryIntegrity(FrappeTestCase):
 					"a projection must say what it projects from",
 				)
 
+	def test_no_unclassified_list_endpoint_exists(self):
+		"""The audit's one remaining hole, closed.
+
+		Everything above proves that what IS registered is well-formed; nothing
+		proved that nothing is MISSING. This sweeps every whitelisted ``list_*``
+		callable under jarvis/chat and requires each to be either a registered
+		view's endpoint or an explicitly classified non-list. A new list endpoint
+		therefore cannot ship without someone writing down what it is.
+		"""
+		registered = {e for v in list_registry.all_views() for e in v.endpoints}
+		unclassified = sorted(
+			set(_whitelisted_list_callables()) - registered - set(list_registry.NON_LIST_ENDPOINTS)
+		)
+		self.assertFalse(
+			unclassified,
+			"whitelisted list endpoints with no classification — register them as a "
+			"ListView or add them to list_registry.NON_LIST_ENDPOINTS with a written "
+			f"reason: {unclassified}",
+		)
+
+	def test_non_list_allowlist_is_argued_and_live(self):
+		live = _whitelisted_list_callables()
+		for dotted, reason in list_registry.NON_LIST_ENDPOINTS.items():
+			with self.subTest(endpoint=dotted):
+				self.assertTrue(len(reason) > 20, "an allowlisted endpoint needs a real reason")
+				self.assertIn(
+					dotted,
+					live,
+					"stale allowlist entry: this endpoint no longer exists (or is no "
+					"longer whitelisted), so the entry is now hiding nothing",
+				)
+
+	def test_excluded_fields_name_real_fields(self):
+		"""A typo in ``excluded_fields`` protects nothing, silently."""
+		for view in list_registry.all_views():
+			if not view.excluded_fields or not view.root_doctype:
+				continue
+			meta = frappe.get_meta(view.root_doctype)
+			for spec in view.excluded_fields:
+				with self.subTest(view=view.view_key, field=spec):
+					if "." in spec:
+						child_dt, fieldname = spec.split(".", 1)
+						self.assertTrue(frappe.get_meta(child_dt).get_field(fieldname))
+					else:
+						self.assertTrue(
+							meta.get_field(spec),
+							f"{view.view_key} excludes {spec!r}, which is not a field of "
+							f"{view.root_doctype}",
+						)
+
 	def test_migrated_views_actually_accept_filters_v2(self):
 		"""'migrated' is a claim; this checks the wiring behind it."""
 		migrated = list_registry.filterable_views()
@@ -157,7 +263,7 @@ class TestCuratedFilterWidthGap(FrappeTestCase):
 		report: list[str] = []
 		for view in list_registry.document_list_views():
 			with self.subTest(view=view.view_key):
-				catalog = build_field_catalog(view.root_doctype, user="Administrator")
+				catalog = build_field_catalog(view.root_doctype, user="Administrator", view=view)
 				self.assertTrue(catalog, f"{view.root_doctype} produced an empty catalog")
 				main = {f["fieldname"] for f in catalog if not f["is_child"]}
 				child = {(f["doctype"], f["fieldname"]) for f in catalog if f["is_child"]}
@@ -182,6 +288,58 @@ class TestCuratedFilterWidthGap(FrappeTestCase):
 					f"gap={len(main) - len(curated):>3}"
 				)
 		print("\nPhase-0 filter width gap (curated vs metadata):\n" + "\n".join(report))
+
+	def test_floor_role_catalog(self):
+		"""U1-2: the same comparison at the FLOOR role, not just Administrator.
+
+		Administrator holds every role, so its catalog is the ceiling — a width
+		claim measured there can be wildly wrong for the person actually using
+		the list. This runs the audit as a user holding only ``Jarvis User`` and
+		reports the real per-surface number, including the surfaces where that
+		user sees NOTHING (reviewer/admin-gated queues), which is itself the
+		answer to 'what does filtering look like for ordinary staff'.
+		"""
+		floor = _ensure_floor_user()
+		report: list[str] = []
+		for view in list_registry.document_list_views():
+			with self.subTest(view=view.view_key):
+				catalog = build_field_catalog(view.root_doctype, user=floor, view=view)
+				main = {f["fieldname"] for f in catalog if not f["is_child"]}
+				if not main:
+					# No level-0 read for the floor role: the surface is gated to
+					# reviewers/admins. Correct, and worth reporting.
+					report.append(f"  {view.view_key:<28} floor_main=  0  (no access at the floor role)")
+					continue
+				curated = {v for v in view.curated_filters.values() if v}
+				missing = curated - main
+				self.assertFalse(
+					missing,
+					f"{view.view_key} curates {sorted(missing)}, which the floor role "
+					f"cannot read — the CURRENT endpoint filters on a field the "
+					f"migrated schema would have to withhold, so migrating it would "
+					f"silently change behaviour for ordinary users",
+				)
+				report.append(
+					f"  {view.view_key:<28} floor_main={len(main):>3}  "
+					f"curated={len(curated):>2}  gap={len(main) - len(curated):>3}"
+				)
+		print("\nFloor-role (Jarvis User only) filter width:\n" + "\n".join(report))
+
+	def test_view_excluded_fields_are_withheld_from_the_catalog(self):
+		"""P1: a view's own withholding list actually removes fields."""
+		for view in list_registry.document_list_views():
+			if not view.excluded_fields:
+				continue
+			with self.subTest(view=view.view_key):
+				withheld = build_field_catalog(view.root_doctype, user="Administrator", view=view)
+				unfiltered = build_field_catalog(view.root_doctype, user="Administrator")
+				names = {(f["doctype"], f["fieldname"]) for f in withheld}
+				all_names = {(f["doctype"], f["fieldname"]) for f in unfiltered}
+				for spec in view.excluded_fields:
+					key = tuple(spec.split(".", 1)) if "." in spec else (view.root_doctype, spec)
+					# Non-vacuity: the field IS otherwise catalogable.
+					self.assertIn(key, all_names, f"{spec} was never in the catalog — test is vacuous")
+					self.assertNotIn(key, names, f"{view.view_key} failed to withhold {spec}")
 
 	def test_catalog_never_leaks_structural_or_secret_fields(self):
 		from jarvis.chat.list_filters import NO_VALUE_FIELDTYPES, SECRET_FIELDTYPES

--- a/jarvis/tests/test_list_registry.py
+++ b/jarvis/tests/test_list_registry.py
@@ -131,6 +131,13 @@ _LIST_NAME_SUFFIXES = (
 	"_records",
 	"_entries",
 	"_results",
+	# The house convention for a paginated list getter is `list_<thing>_page`; the
+	# `list_` prefix already catches those, but a collection endpoint spelled
+	# `get_<thing>_page` (or any `*_page` that is NOT list-prefixed) would slip the
+	# net, so the suffix is swept too. This also pulls in the single-document
+	# `*_page` CRUD verbs (e.g. `get_wiki_page`), which are then argued as non-lists
+	# in `NON_LIST_ENDPOINTS` — exactly the "write down what it is" the audit wants.
+	"_page",
 )
 #: Whole-word tokens (split on `_`) that mark a collection: `search_records`,
 #: `get_activity_feed`, `fetch_rows`.

--- a/jarvis/tests/test_list_registry.py
+++ b/jarvis/tests/test_list_registry.py
@@ -106,23 +106,45 @@ def _ensure_floor_user() -> str:
 	return FLOOR_USER
 
 
+#: Customer-facing API packages the discovery sweep walks. `jarvis.chat` was the
+#: only one before (P0-04): `jarvis.support.api.list_tickets` lived outside it and
+#: could never be discovered. A collection endpoint added to any of these — or
+#: annotated anywhere via `list_registry.list_surface_endpoint` — must be
+#: classified.
+_SWEPT_PACKAGES = ("jarvis.chat", "jarvis.support")
+
+#: Naming families that mark a whitelisted callable as a candidate list endpoint.
+#: `list_*` misses `admin_list_user_usage`; `admin_list_*` catches it. Anything
+#: outside these families declares itself with the annotation instead.
+_LIST_NAME_PREFIXES = ("list_", "admin_list_")
+
+
+def _looks_like_list_endpoint(name: str, fn) -> bool:
+	if list_registry.is_list_surface_endpoint(fn):
+		return True
+	return any(name.startswith(p) for p in _LIST_NAME_PREFIXES)
+
+
 def _whitelisted_list_callables() -> dict[str, object]:
-	"""Every whitelisted ``list_*`` callable under ``jarvis/chat``.
+	"""Every whitelisted list-endpoint candidate across the customer API packages.
 
-	Import errors are NOT swallowed: a module that fails to import would silently
-	shrink the sweep, which is exactly the loophole this audit closes."""
-	import jarvis.chat
-
+	Widened for P0-04: it walks `jarvis.chat` AND `jarvis.support`, matches the
+	`list_*`/`admin_list_*` naming families (not `list_*` alone), and honours the
+	`list_surface_endpoint` annotation for anything named differently. Import
+	errors are NOT swallowed: a module that fails to import would silently shrink
+	the sweep, which is exactly the loophole this audit closes."""
 	found: dict[str, object] = {}
-	for info in pkgutil.walk_packages(jarvis.chat.__path__, prefix="jarvis.chat."):
-		module = importlib.import_module(info.name)
-		for name, fn in vars(module).items():
-			if not name.startswith("list_") or not callable(fn):
-				continue
-			if getattr(fn, "__module__", None) != module.__name__:
-				continue  # re-export
-			if fn in frappe.whitelisted:
-				found[f"{module.__name__}.{name}"] = fn
+	for package in _SWEPT_PACKAGES:
+		root = importlib.import_module(package)
+		for info in pkgutil.walk_packages(root.__path__, prefix=f"{package}."):
+			module = importlib.import_module(info.name)
+			for name, fn in vars(module).items():
+				if not callable(fn) or not _looks_like_list_endpoint(name, fn):
+					continue
+				if getattr(fn, "__module__", None) != module.__name__:
+					continue  # re-export
+				if fn in frappe.whitelisted:
+					found[f"{module.__name__}.{name}"] = fn
 	return found
 
 
@@ -232,6 +254,34 @@ class TestListRegistryIntegrity(FrappeTestCase):
 							meta.get_field(spec),
 							f"{view.view_key} excludes {spec!r}, which is not a field of {view.root_doctype}",
 						)
+
+	def test_active_views_are_classified_and_migration_status_is_reported(self):
+		"""Migration completeness, SEPARATE from inventory and wiring (P0-04).
+
+		Waves 2-3 are deferred, so this round does NOT enforce 'no pending active
+		view' — that is the FINAL-round gate. What it enforces now is that every
+		ACTIVE (non-excluded) collection is CLASSIFIED (migrated or pending, never
+		an unknown status), and it prints the truthful migrated-vs-pending split so
+		the handoff cannot claim more than is built.
+		"""
+		active = [v for v in list_registry.all_views() if not v.is_excluded]
+		migrated = [v for v in active if v.status == list_registry.MIGRATED]
+		pending = [v for v in active if v.status == list_registry.PENDING]
+		for view in active:
+			with self.subTest(view=view.view_key):
+				self.assertIn(
+					view.status,
+					{list_registry.MIGRATED, list_registry.PENDING},
+					f"{view.view_key} is active but has no migration classification",
+				)
+		# Every active view is exactly one of the two — nothing unclassified.
+		self.assertEqual(len(migrated) + len(pending), len(active))
+		print(
+			f"\nPlan-08 migration status: {len(migrated)} migrated, {len(pending)} pending, "
+			f"of {len(active)} active views."
+			f"\n  migrated: {sorted(v.view_key for v in migrated)}"
+			f"\n  pending:  {sorted(v.view_key for v in pending)}"
+		)
 
 	def test_migrated_views_actually_accept_filters_v2(self):
 		"""'migrated' is a claim; this checks the wiring behind it."""

--- a/jarvis/tests/test_list_registry.py
+++ b/jarvis/tests/test_list_registry.py
@@ -1,0 +1,200 @@
+"""Phase-0 audit of the document-collection registry (plan 08 §10, C08-7).
+
+Two jobs.
+
+**Integrity.** Every registered surface is well-formed: a known classification, a
+resolvable whitelisted endpoint, a real root DocType, and — for anything
+classified as NOT a document list — a written reason. Plus a fixed expected-key
+sweep, so deleting a surface from the registry to silence the audit is itself a
+failure.
+
+**The width gap.** Codex's Phase 0 asked for failing evidence that the curated,
+page-authored filter definitions are incomplete. C08-7 reformulates that as a
+SUBSET assertion rather than a red test: for every doctype-backed view, derive
+the filterable field set independently from live metadata and assert the CURRENT
+curated whitelist is a strict subset of it. The audit therefore passes today and
+documents the gap deterministically (it prints the per-surface counts); the
+equality assertion arrives per surface, as each one migrates.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import list_registry
+from jarvis.chat.list_filters import build_field_catalog
+
+#: Every surface that must be registered. A rename is fine; a disappearance is
+#: not. Mirrors plan 08 §3.3 + the 8 ListPage consumers + the Settings surfaces,
+#: minus nothing.
+EXPECTED_VIEW_KEYS = {
+	# 8 shared-ListPage consumers
+	"skills",
+	"macros",
+	"file_box",
+	"saved_dashboards",
+	"wiki_pages",
+	"support_tickets",
+	"triggers",
+	"trigger_activity",
+	# bespoke collection surfaces (§3.3)
+	"agents_catalog",
+	"agent_activity",
+	"agent_runs",
+	"agent_findings",
+	"agent_admin_overview",
+	"approvals",
+	"macro_runs",
+	"personalise_questions",
+	"personalise_notes",
+	"learning_queue",
+	"learning_decided",
+	"wiki_promotions",
+	"skill_promotions",
+	# Settings area
+	"settings_user_usage_admin",
+	"settings_tool_activity",
+	# explicit non-lists / dormant
+	"chat_conversation_sidebar",
+	"app_learning_runs",
+}
+
+
+def _resolve(dotted: str):
+	module_path, _, attr = dotted.rpartition(".")
+	module = importlib.import_module(module_path)
+	return getattr(module, attr)
+
+
+class TestListRegistryIntegrity(FrappeTestCase):
+	def test_expected_surfaces_are_registered(self):
+		registered = {v.view_key for v in list_registry.all_views()}
+		missing = EXPECTED_VIEW_KEYS - registered
+		self.assertFalse(missing, f"surfaces dropped from the registry: {sorted(missing)}")
+
+	def test_view_keys_are_unique(self):
+		keys = [v.view_key for v in list_registry.all_views()]
+		self.assertEqual(len(keys), len(set(keys)), "duplicate view_key in the registry")
+
+	def test_every_view_is_well_formed(self):
+		for view in list_registry.all_views():
+			with self.subTest(view=view.view_key):
+				self.assertTrue(view.view_key and view.label)
+				self.assertIn(view.classification, list_registry.CLASSIFICATIONS)
+				self.assertIn(view.status, list_registry.STATUSES)
+				self.assertTrue(view.endpoints, "a surface with no endpoint cannot be audited")
+				if view.is_excluded:
+					# C08-7 / plan §3.3: the semantic boundary is only defensible
+					# if every exclusion is argued in writing.
+					self.assertTrue(
+						len(view.reason) > 40,
+						"an excluded surface needs a real reason, not a label",
+					)
+					self.assertEqual(view.status, list_registry.NOT_APPLICABLE)
+				else:
+					self.assertIn(view.status, {list_registry.MIGRATED, list_registry.PENDING})
+
+	def test_every_endpoint_resolves_and_is_whitelisted(self):
+		for view in list_registry.all_views():
+			for dotted in view.endpoints:
+				with self.subTest(view=view.view_key, endpoint=dotted):
+					fn = _resolve(dotted)
+					self.assertTrue(callable(fn), f"{dotted} is not callable")
+					self.assertIn(
+						fn,
+						frappe.whitelisted,
+						f"{dotted} is registered as a list endpoint but is not whitelisted",
+					)
+
+	def test_document_list_views_have_a_real_root_doctype(self):
+		for view in list_registry.document_list_views():
+			with self.subTest(view=view.view_key):
+				self.assertTrue(
+					frappe.db.exists("DocType", view.root_doctype),
+					f"{view.view_key} points at a DocType that does not exist",
+				)
+
+	def test_projection_views_declare_their_authority(self):
+		for view in list_registry.all_views():
+			if view.classification != list_registry.PROJECTION:
+				continue
+			with self.subTest(view=view.view_key):
+				self.assertTrue(
+					view.projection_root or view.projection_authority,
+					"a projection must say what it projects from",
+				)
+
+	def test_migrated_views_actually_accept_filters_v2(self):
+		"""'migrated' is a claim; this checks the wiring behind it."""
+		migrated = list_registry.filterable_views()
+		self.assertTrue(migrated, "no surface speaks filters_v2 — the pilots regressed")
+		for view in migrated:
+			for dotted in view.endpoints:
+				with self.subTest(view=view.view_key, endpoint=dotted):
+					params = inspect.signature(_resolve(dotted)).parameters
+					self.assertIn("filters_v2", params, f"{dotted} claims filters_v2 but has no such parameter")
+					self.assertIn(
+						"filters",
+						params,
+						f"{dotted} dropped the legacy argument — the compatibility window is not over",
+					)
+
+
+class TestCuratedFilterWidthGap(FrappeTestCase):
+	"""C08-7: schema COMPLETENESS, not button presence.
+
+	The Filter action is already universally present; what is missing is width.
+	For each doctype-backed surface we rebuild the metadata catalog from scratch
+	(as Administrator, so the comparison is against the widest possible set) and
+	assert the page-curated whitelist is a strict subset of it.
+	"""
+
+	def test_curated_filters_are_a_strict_subset_of_the_metadata_catalog(self):
+		report: list[str] = []
+		for view in list_registry.document_list_views():
+			with self.subTest(view=view.view_key):
+				catalog = build_field_catalog(view.root_doctype, user="Administrator")
+				self.assertTrue(catalog, f"{view.root_doctype} produced an empty catalog")
+				main = {f["fieldname"] for f in catalog if not f["is_child"]}
+				child = {(f["doctype"], f["fieldname"]) for f in catalog if f["is_child"]}
+
+				curated = {v for v in view.curated_filters.values() if v}
+				unknown = curated - main
+				self.assertFalse(
+					unknown,
+					f"{view.view_key} curates filter keys that are not metadata fields "
+					f"of {view.root_doctype}: {sorted(unknown)} — either the mapping in "
+					f"list_registry is wrong or the field was renamed",
+				)
+				self.assertLess(
+					len(curated),
+					len(main),
+					f"{view.view_key} is no longer a strict subset — if it genuinely "
+					f"reached parity, move it to the equality assertion",
+				)
+				report.append(
+					f"  {view.view_key:<28} curated={len(curated):>2}  "
+					f"metadata_main={len(main):>3}  child={len(child):>3}  "
+					f"gap={len(main) - len(curated):>3}"
+				)
+		print("\nPhase-0 filter width gap (curated vs metadata):\n" + "\n".join(report))
+
+	def test_catalog_never_leaks_structural_or_secret_fields(self):
+		from jarvis.chat.list_filters import NO_VALUE_FIELDTYPES, SECRET_FIELDTYPES
+
+		for view in list_registry.document_list_views():
+			with self.subTest(view=view.view_key):
+				for entry in build_field_catalog(view.root_doctype, user="Administrator"):
+					self.assertNotIn(entry["fieldtype"], NO_VALUE_FIELDTYPES)
+					self.assertNotIn(entry["fieldtype"], SECRET_FIELDTYPES)
+
+	def test_docstatus_only_for_submittable_doctypes(self):
+		for view in list_registry.document_list_views():
+			with self.subTest(view=view.view_key):
+				names = {f["fieldname"] for f in build_field_catalog(view.root_doctype, user="Administrator")}
+				submittable = bool(frappe.get_meta(view.root_doctype).is_submittable)
+				self.assertEqual("docstatus" in names, submittable)

--- a/jarvis/tests/test_list_registry.py
+++ b/jarvis/tests/test_list_registry.py
@@ -230,8 +230,7 @@ class TestListRegistryIntegrity(FrappeTestCase):
 					else:
 						self.assertTrue(
 							meta.get_field(spec),
-							f"{view.view_key} excludes {spec!r}, which is not a field of "
-							f"{view.root_doctype}",
+							f"{view.view_key} excludes {spec!r}, which is not a field of {view.root_doctype}",
 						)
 
 	def test_migrated_views_actually_accept_filters_v2(self):
@@ -242,7 +241,9 @@ class TestListRegistryIntegrity(FrappeTestCase):
 			for dotted in view.endpoints:
 				with self.subTest(view=view.view_key, endpoint=dotted):
 					params = inspect.signature(_resolve(dotted)).parameters
-					self.assertIn("filters_v2", params, f"{dotted} claims filters_v2 but has no such parameter")
+					self.assertIn(
+						"filters_v2", params, f"{dotted} claims filters_v2 but has no such parameter"
+					)
 					self.assertIn(
 						"filters",
 						params,

--- a/jarvis/tests/test_list_registry.py
+++ b/jarvis/tests/test_list_registry.py
@@ -113,26 +113,53 @@ def _ensure_floor_user() -> str:
 #: classified.
 _SWEPT_PACKAGES = ("jarvis.chat", "jarvis.support")
 
-#: Naming families that mark a whitelisted callable as a candidate list endpoint.
-#: `list_*` misses `admin_list_user_usage`; `admin_list_*` catches it. Anything
-#: outside these families declares itself with the annotation instead.
-_LIST_NAME_PREFIXES = ("list_", "admin_list_")
+#: Collection-SHAPED name families (S7). The audit used to key ONLY on
+#: `list_*`/`admin_list_*`, so a collection endpoint named anything else — a
+#: `search_*`, a `*_feed`, a `browse_*`, a `get_*_rows` — evaded discovery
+#: entirely and could ship unclassified. Discovery now recognises the whole family
+#: of collection verbs/suffixes (a prefix, a suffix, or a whole-word token), so a
+#: list endpoint can no longer hide behind its name; the `list_surface_endpoint`
+#: annotation remains the escape hatch for a genuinely oddly-named one.
+_LIST_NAME_PREFIXES = ("list_", "admin_list_", "search_", "browse_", "recent_", "all_")
+_LIST_NAME_SUFFIXES = (
+	"_list",
+	"_feed",
+	"_history",
+	"_activity",
+	"_runs",
+	"_rows",
+	"_records",
+	"_entries",
+	"_results",
+)
+#: Whole-word tokens (split on `_`) that mark a collection: `search_records`,
+#: `get_activity_feed`, `fetch_rows`.
+_LIST_NAME_TOKENS = frozenset({"list", "search", "browse", "feed", "history", "activity", "roster"})
 
 
 def _looks_like_list_endpoint(name: str, fn) -> bool:
 	if list_registry.is_list_surface_endpoint(fn):
 		return True
-	return any(name.startswith(p) for p in _LIST_NAME_PREFIXES)
+	if any(name.startswith(p) for p in _LIST_NAME_PREFIXES):
+		return True
+	if any(name.endswith(s) for s in _LIST_NAME_SUFFIXES):
+		return True
+	return bool(set(name.split("_")) & _LIST_NAME_TOKENS)
 
 
 def _whitelisted_list_callables() -> dict[str, object]:
 	"""Every whitelisted list-endpoint candidate across the customer API packages.
 
-	Widened for P0-04: it walks `jarvis.chat` AND `jarvis.support`, matches the
-	`list_*`/`admin_list_*` naming families (not `list_*` alone), and honours the
-	`list_surface_endpoint` annotation for anything named differently. Import
-	errors are NOT swallowed: a module that fails to import would silently shrink
-	the sweep, which is exactly the loophole this audit closes."""
+	Widened for P0-04 and again for S7: it walks `jarvis.chat` AND `jarvis.support`
+	and matches the WHOLE family of collection-shaped names — `list_*`/`admin_list_*`
+	plus `search_*`/`browse_*`/`recent_*`/`all_*` prefixes, `_feed`/`_history`/
+	`_activity`/`_runs`/`_rows`/`_records`/`_results`/`_entries`/`_list` suffixes, and
+	the `list`/`search`/`browse`/`feed`/`history`/`activity`/`roster` whole-word
+	tokens — so a collection endpoint can no longer evade discovery by being named
+	something other than `list_*` (the round-2 hole). `list_surface_endpoint` remains
+	the annotation escape hatch for a genuinely oddly-named one. Import errors are NOT
+	swallowed: a module that fails to import would silently shrink the sweep, which is
+	exactly the loophole this audit closes."""
 	found: dict[str, object] = {}
 	for package in _SWEPT_PACKAGES:
 		root = importlib.import_module(package)
@@ -210,10 +237,13 @@ class TestListRegistryIntegrity(FrappeTestCase):
 		"""The audit's one remaining hole, closed.
 
 		Everything above proves that what IS registered is well-formed; nothing
-		proved that nothing is MISSING. This sweeps every whitelisted ``list_*``
-		callable under jarvis/chat and requires each to be either a registered
-		view's endpoint or an explicitly classified non-list. A new list endpoint
-		therefore cannot ship without someone writing down what it is.
+		proved that nothing is MISSING. This sweeps every whitelisted
+		COLLECTION-SHAPED callable under jarvis/chat and jarvis/support — the full
+		name family, not `list_*` alone (S7) — and requires each to be either a
+		registered view's endpoint or an explicitly classified non-list. A new list
+		endpoint therefore cannot ship without someone writing down what it is, and
+		it can no longer slip past by being named `search_*`, `*_feed`, `*_history`
+		or the like.
 		"""
 		registered = {e for v in list_registry.all_views() for e in v.endpoints}
 		unclassified = sorted(


### PR DESCRIPTION
## What this is

The server foundation for universal Frappe-style list filters (plan 08 in `/home/vignesh/jarvis-ux-fixes`, per `FABLE-JUDGMENT.md` C08-1..7): one registry of every list surface, one caller-specific filter-schema endpoint, and one shared, security-critical filter compiler — piloted end-to-end on **Skills** and **Macros**. The FilterGroup UI (Phase 2) and the remaining surface migrations (waves 1–3) build on this.

## What ships

- **`chat/list_registry.py`** — 25 view_keys with honest classifications (document lists, projections, non-lists with written reasons), per-view `excluded_fields` (Triggers pre-declares its three redacted rule fields so the guard exists before that surface ever migrates), and a Phase-0 audit that documents the curated-vs-metadata width gap (14–48 missing fields per surface) plus a sweep that fails on any new unclassified `list_*` endpoint.
- **`chat/list_filters.py`** — the schema builder (standard + main + child + declared-computed fields, **permlevel enforced per caller** — frappe does not enforce permlevel on filter fields; ours does, closing a filtering-as-oracle leak that reaches the agents-IP `skill_bundle` moat) and the compiler (metadata-resolved identifiers only, every value bound, per-child-doctype grouped EXISTS, facet self-exclusion, caps with server-authored-IN exemption, structural barrier between server predicates and user clauses, fail-closed everywhere — unknown fields, optional columns, blank dates, missing metadata).
- **Wire contract:** stable error codes reach the browser as `{ok:false, error:{code}}` envelopes (400/417/503) via one boundary decorator; success stays the bare legacy shape. Schema answers only for MIGRATED views.
- **`LIST-FILTERS-DEVIATIONS.md` + MIGRATION-CHECKLIST** — every deliberate divergence from Frappe argued in writing (EXISTS child semantics, Password exclusion, `_assign`/`_liked_by` like-semantics, fail-closed vs frappe's silent strips, blank-Between rejection where frappe falls back to "today", **D5-a: free-text families default to `like`**), plus the 8-step per-surface migration recipe (per-role catalog diff, the Approvals permlevel-1 DocPerm trap, scope invariant).
- **Pilots:** Skills + Macros accept additive `filters_v2`; legacy args untouched; `filters_v2` empty is functionally identical to today for both roles (proven), and the five drifting private helper copies are consolidated.

**Reviewer-flagged for explicit attention:** D5-a (Small/Long Text, Text, Text Editor default to `like` instead of Frappe's `=`) is a deliberate Fable product ruling that landed inside the remediation commit — user expectation over strict parity, `=` stays selectable, recorded in the ledger.

## Review trail (doctrine)

Opus adversarial (REQUEST-CHANGES: 1 P1 + 3 P2s; injection/permission/cache-isolation attacks all CLEARED, Frappe parity verified line-by-line against pinned v16) + Sonnet UX (APPROVE-WITH-NOTES) → consolidated fix round → re-probe (**APPROVE**, five mutations each caught by a named test) → final ride-along (23 red → 74 green). Totals: `test_list_filters` 74, pilots 20, registry 15, plus the pre-existing feature/security sweeps — all green on patterntest.

## Deploy

No schema change; no migrate needed. Backend-only — zero user-visible change until Phase 2 ships the UI. Safe to land independently of the onboarding PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxn1qvS9817vFv6gmLYEoN