### PR TITLE
fix(readiness): the chat gate stops failing open for never-ready workspaces (plan 05, step D1)

### DIFF
--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -13,12 +13,21 @@ import { isOnboardComplete } from "@/onboarding/steps.js";
 // model from the settings dialog changes this verdict without leaving the page.
 let readyPromise = null;
 
-// Fail-open: if the backend check THROWS, treat the workspace as ready so a
-// flaky/500 check never strands a real user. (Note this only covers thrown
-// errors — a returned {ready:false} is a real verdict, handled below.)
+// Fail-CLOSED-retryable: if the readiness call itself THROWS (the customer's own
+// bench erroring, not admin - the server already resolves an admin outage by
+// cohort and returns a real verdict), do NOT declare the workspace ready. The old
+// thrown->{ready:true} shortcut sent a never-onboarded workspace straight into a
+// chat that cannot answer (review P0-05). Return the same retryable verdict the
+// server uses for "nobody could confirm this", which needsOnboarding() gates on:
+// an established workspace's outage is already handled server-side, so a thrown
+// call here is the severe case and must fail closed with a retry, not open.
 export function checkReady() {
 	if (!readyPromise) {
-		readyPromise = isReadyForChat().catch(() => ({ ready: true }));
+		readyPromise = isReadyForChat().catch(() => ({
+			ready: false,
+			reason: "readiness_unconfirmed",
+			retryable: true,
+		}));
 	}
 	return readyPromise;
 }
@@ -59,16 +68,26 @@ export async function isWorkspaceReady() {
 // half-finished signup (e.g. failed payment), not an established workspace.
 // The soft/hard split lives server-side (_llm_missing_verdict) because only
 // admin knows the subscription state.
+// "readiness_unconfirmed" is COHORT-AWARE by construction: the server returns it
+// ONLY for a workspace nothing has ever confirmed chat-ready (an established one
+// gets ready:true through the same outage - account._admin_unreachable_verdict).
+// So when the SPA sees it, it is the never-ready cohort and must gate closed with
+// a retry, exactly the case the full-screen poster is for (review P0-05). The
+// thrown-call catch above resolves to this same reason for the severe own-bench
+// failure, which also fails closed. It differs from llm_credentials, which fires
+// on an ESTABLISHED workspace's later credential rotation and must stay degraded.
 const NOT_ONBOARDED_REASONS = new Set([
 	"signup",
 	"llm_pool_provisioning",
 	"llm_provisioning",
 	"llm_setup",
+	"readiness_unconfirmed",
 ]);
 
 // True only when the workspace has NOT completed onboarding at all — the single
-// case the full-screen gate poster is for. A ready workspace, a fail-open
-// (thrown) result, or a merely-degraded one (llm_credentials) all return false.
+// case the full-screen gate poster is for. A ready workspace or a merely-degraded
+// one (llm_credentials) returns false; a never-ready workspace the server could
+// not confirm (readiness_unconfirmed) returns true, and the poster offers a retry.
 export async function needsOnboarding() {
 	const resp = await checkReady();
 	if (isOnboardComplete(resp)) return false;

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -698,10 +698,11 @@
 								</div>
 								<div v-show="!state.finishing">
 									<div class="ob-head">
-										<h1>Give {{ agentName }} a brain</h1>
+										<h1>Connect an AI model</h1>
 										<p>
-											Pick which AI powers {{ agentName }}. You can change
-											this anytime in Settings → AI models.
+											Choose which AI powers {{ agentName }} — a chat
+											subscription or your own API key. You can change this
+											anytime in Settings → AI models.
 										</p>
 									</div>
 									<div class="mx-auto max-w-[640px]">
@@ -822,7 +823,7 @@ const FRAME_SUBS = {
 	details: "Your details",
 	pay: "Review & pay",
 	reconnect: "Reconnect your subscription",
-	connect: `Give ${agentName} a brain`,
+	connect: "Connect an AI model",
 };
 
 // ---- step machine -----------------------------------------------------------

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -66,6 +66,13 @@ _GATE_REVISION_FIELDS = (
 	"llm_pool_synced_at",
 	"llm_direct_synced_at",
 	"llm_oauth_connected_at",
+	# The tenant authority this bench is bound to (Plan 04 generation contract).
+	# A move/repair that changes it must not keep serving the verdict the
+	# PREVIOUS authority earned (P1-09). Read raw: the column may not exist yet
+	# on a bench that predates the generation consumer, in which case _settings_raw
+	# simply omits it and the digest is unchanged - forward-compatible by
+	# construction.
+	"tenant_authority_generation",
 )
 
 # Durable "admin has said Ready about this workspace at least once" marker. It is
@@ -78,7 +85,21 @@ _READY_MARKER_FIELD = "chat_was_ready_at"
 # DB write on every uncached page load for no gate value.
 _READY_MARKER_REFRESH_S = 86400
 
-_GATE_STATE_FIELDS = (*_GATE_REVISION_FIELDS, _READY_MARKER_FIELD, "jarvis_admin_api_key")
+# The authority the established claim is BOUND to (P0-06 / review §8.6). A digest
+# of (admin principal, container URL, tenant authority generation) captured when
+# the marker was last stamped. _has_been_chat_ready requires it to still match the
+# CURRENT authority before failing open, so a reset / reconnect / principal or
+# container replacement / generation change ends the claim mechanically - the
+# explicit clears in _disconnect_agent_transport and write_connection are belt to
+# this suspenders, not the only fence.
+_READY_ANCHOR_FIELD = "chat_ready_authority"
+
+_GATE_STATE_FIELDS = (
+	*_GATE_REVISION_FIELDS,
+	_READY_MARKER_FIELD,
+	_READY_ANCHOR_FIELD,
+	"jarvis_admin_api_key",
+)
 
 # Not-ready code for "we could not confirm this workspace is ready" - as opposed
 # to container_provisioning / subscription_suspended, which are verdicts admin
@@ -93,16 +114,35 @@ _UNCONFIRMED_DETAIL = (
 # Applies to THIS code alone: a real not-ready verdict is never cached.
 _UNCONFIRMED_CACHE_TTL_S = 5
 
-# Admin's own words for a customer that has NEVER paid, from
-# jarvis_admin_v2.api._auth.current_customer. Matched on the message because the
-# wire carries nothing better: every refusal that function makes is a 403, and
-# only the sentence separates a half-finished signup from a lapsed customer whose
-# renew banner must keep working.
+# A customer that has NEVER paid, as named by admin's structured refusal code
+# (jarvis_admin_v2 auth contract). This is the machine signal the never-paid gate
+# reads: a stable code on the 403 envelope, propagated onto AdminAuthError.code by
+# admin_client, so the decision no longer depends on parsing a human sentence that
+# a hardened control plane may omit entirely (P0-05 / review §8.4).
 #
-# An ALLOWLIST: "customer status: Cancelled", an empty body, a proxy's own 403 and
-# anything unrecognised all fall through to the soft verdict. Being wrong in the
-# hard direction locks a customer out of chat AND /billing; being wrong in the
-# soft direction shows a banner one step too late.
+# An ALLOWLIST: Cancelled, an empty body, a proxy's own 403 and anything
+# unrecognised all fall through to the soft verdict. Being wrong in the hard
+# direction locks a customer out of chat AND /billing; being wrong in the soft
+# direction shows a banner one step too late. FROZEN-CONTRACT NOTE: wire-verify
+# these codes against jarvis_admin_v2's actual auth-refusal codes when the admin
+# half merges; the set is deliberately generous across the plausible spellings.
+_NEVER_PAID_CODES = frozenset(
+	{
+		"NEVER_PAID",
+		"NOT_A_CUSTOMER",
+		"CUSTOMER_NOT_FOUND",
+		"PENDING_PAYMENT",
+		"PENDING_VERIFICATION",
+		"CUSTOMER_PENDING_PAYMENT",
+		"CUSTOMER_PENDING_VERIFICATION",
+	}
+)
+
+# TEMPORARY prose fallback for an OLD admin that answers the never-paid 403 with a
+# human sentence and no structured code. REMOVE once every control plane in the
+# fleet emits _NEVER_PAID_CODES (tracked with the Plan 04/05 admin cutover): a
+# hardened admin already sends exc_type alone with no sentence, so this branch is
+# best-effort compatibility, not the mechanism.
 _NEVER_PAID_403_MARKERS = (
 	"customer status: pending payment",
 	"customer status: pending verification",
@@ -141,16 +181,21 @@ def _settings_raw(fields: tuple[str, ...]) -> dict:
 
 def _is_never_paid_403(err) -> bool:
 	"""Does this admin rejection carry admin's OWN evidence that the customer has
-	never paid? Anything less is not evidence - see _NEVER_PAID_403_MARKERS.
+	never paid? Anything less is not evidence.
 
-	Note what a production admin actually puts on the wire: Frappe only includes
-	the exception sentence when tracebacks are allowed (frappe/utils/response.py
-	``report_error`` / ``is_traceback_allowed``), so a hardened control plane sends
-	back ``exc_type`` alone and this correctly returns False. The hard gate is the
-	exception, not the rule.
+	Reads the STRUCTURED code first (admin_client tags AdminAuthError.code from the
+	403 envelope's ``error.code``): a machine signal survives a hardened control
+	plane that returns ``exc_type`` alone with no human sentence, which is exactly
+	the shape the old prose match missed (P0-05). The prose markers remain only as
+	a temporary fallback for an admin that predates the code contract - see
+	_NEVER_PAID_403_MARKERS.
 	"""
 	if getattr(err, "status_code", None) != 403:
 		return False
+	code = (getattr(err, "code", "") or "").strip().upper()
+	if code:
+		return code in _NEVER_PAID_CODES
+	# Old-admin compatibility: no structured code, fall back to the sentence.
 	message = str(err or "").strip().lower()
 	return any(marker in message for marker in _NEVER_PAID_403_MARKERS)
 
@@ -166,24 +211,67 @@ def _gate_revision(raw: dict) -> str:
 	return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
 
 
-def _has_been_chat_ready(raw: dict) -> bool:
-	"""Is this an ESTABLISHED workspace - a stored control-plane connection AND a
-	Ready verdict at some point in its life?
+def _authority_anchor(raw: dict) -> str:
+	"""Digest of the AUTHORITY the established claim is bound to (review §8.6).
 
-	Both halves matter. The marker alone would keep a workspace whose credentials
-	were torn down (reconnected on another site, reset) in the cohort whose chat
-	is protected during an outage, and it is precisely that workspace whose chat
-	cannot work. The admin key alone is just "signup happened", which every
-	half-onboarded customer also has. settings_reset.CONNECTION clears the marker
-	with the rest of the tenancy, so a reset site must earn a new Ready.
+	Every input is a LOCAL, offline-readable field, because this is recomputed on
+	the fail-open path when admin cannot be asked at all:
+
+	  - jarvis_admin_api_key: the admin principal. A reconnect to a different
+	    customer replaces it.
+	  - agent_url: the container. A workspace reset clears it; a container
+	    replacement changes it.
+	  - tenant_authority_generation: the Plan 04 generation. A move/repair bumps
+	    it (empty on a bench that predates the consumer - the digest is then
+	    stable across the two remaining inputs, which is correct).
+
+	A change to any of them means the workspace admin confirmed Ready is no longer
+	the one in front of us, so the claim must not carry across it.
 	"""
-	if not frappe.get_meta(SETTINGS).get_field(_READY_MARKER_FIELD):
-		# Code running ahead of its migration: the field does not exist, so NO
-		# workspace can be established and every established customer would fail
-		# closed together. Insurance for a hand-rolled deploy that restarts before
-		# it migrates; self-disarming the moment `bench migrate` adds the field.
-		return True
-	return bool(raw.get(_READY_MARKER_FIELD)) and bool((raw.get("jarvis_admin_api_key") or "").strip())
+	joined = "|".join(
+		(
+			(raw.get("jarvis_admin_api_key") or "").strip(),
+			(raw.get("agent_url") or "").strip(),
+			str(raw.get("tenant_authority_generation") or ""),
+		)
+	)
+	return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def _has_been_chat_ready(raw: dict) -> bool:
+	"""Is this an ESTABLISHED workspace - a stored control-plane connection AND an
+	explicit Ready verdict, for the SAME authority we are looking at now?
+
+	Three halves matter. The marker + admin key say "admin confirmed this
+	workspace Ready once and signup is still in place". The authority anchor is the
+	fence the marker alone was missing (review P0-06): a bare timestamp kept a
+	workspace whose transport was torn down (reset), or whose account was
+	reconnected elsewhere, in the protected cohort - precisely the workspace whose
+	chat cannot work. Binding the claim to (principal, container, generation) ends
+	it the moment any of those move, whether or not the writer that moved them also
+	remembered to clear the marker.
+	"""
+	meta = frappe.get_meta(SETTINGS)
+	if not meta.get_field(_READY_MARKER_FIELD):
+		# Code running ahead of its migration: without the marker field NO
+		# workspace can prove it was ever Ready, so fail CLOSED rather than promote
+		# every site by default (P0-07 - a missing field must not manufacture
+		# established status). The documented deploy order (migrate before restart)
+		# makes this window nil; it self-heals the moment `bench migrate` runs.
+		return False
+	if not (bool(raw.get(_READY_MARKER_FIELD)) and bool((raw.get("jarvis_admin_api_key") or "").strip())):
+		return False
+	if meta.get_field(_READY_ANCHOR_FIELD):
+		stored = (raw.get(_READY_ANCHOR_FIELD) or "").strip()
+		if stored:
+			# The mechanical fence: the claim survives only while its bound
+			# authority is still the current one.
+			return stored == _authority_anchor(raw)
+		# A marker with no stored anchor is a legacy/backfilled claim from before
+		# the fence existed. Honour the presence rule for it - the explicit clears
+		# on reset/reconnect still end it - so a pre-fence established site is not
+		# ejected wholesale on upgrade.
+	return True
 
 
 def _marker_is_fresh(current) -> bool:
@@ -214,26 +302,54 @@ def _write_is_durable() -> bool:
 
 
 def _mark_chat_ready(raw: dict) -> None:
-	"""Record that admin has confirmed this workspace Ready.
+	"""Record that admin has EXPLICITLY confirmed this workspace Ready, bound to the
+	authority that confirmation was about.
 
-	Best-effort and quiet, mirroring release_notice.persist: readiness is a read
-	path and must not fail because a marker could not be written.
+	Called only on an explicit ``chat_readiness == "Ready"`` (never on the
+	v1-tolerant missing-key path - review P0-07): the marker means "admin said
+	Ready", and a response that never said it must not mint that proof.
 
-	``update_modified=False`` for the same reason the sync markers use it - the
-	Settings form's own timestamp is operator state, and the gate's revision must
-	not churn on its own bookkeeping.
+	Two writes, both best-effort and quiet (readiness is a read path and must not
+	fail because a marker could not be written), both ``update_modified=False`` so
+	the gate's revision does not churn on its own bookkeeping:
+
+	  - the timestamp, refreshed at most daily (the gate only reads "is it set");
+	  - the authority anchor, so the claim is bound to this (principal, container,
+	    generation) and ends when any of them move. Re-stamped whenever the
+	    timestamp is - a rebind onto the current authority is exactly what an
+	    established-through-a-generation-change workspace needs.
 	"""
 	try:
-		if _marker_is_fresh(raw.get(_READY_MARKER_FIELD)) or not _write_is_durable():
+		if not _write_is_durable():
+			return
+		if _marker_is_fresh(raw.get(_READY_MARKER_FIELD)):
+			# The timestamp is current, but the authority may have moved since it
+			# was stamped (a legacy marker carries no anchor, or a rebind is due).
+			# Keep the anchor in step without rewriting the timestamp.
+			_rebind_anchor(raw)
 			return
 		frappe.db.set_value(
 			SETTINGS, SETTINGS, _READY_MARKER_FIELD, frappe.utils.now(), update_modified=False
 		)
+		_rebind_anchor(raw)
 	except Exception:
 		pass
 
 
-def _admin_unreachable_verdict(raw: dict) -> dict:
+def _rebind_anchor(raw: dict) -> None:
+	"""Point the stored authority anchor at the CURRENT authority. Its own
+	try/except so a missing column (bench mid-migration) never breaks the gate."""
+	try:
+		if not frappe.get_meta(SETTINGS).get_field(_READY_ANCHOR_FIELD):
+			return
+		anchor = _authority_anchor(raw)
+		if (raw.get(_READY_ANCHOR_FIELD) or "").strip() != anchor:
+			frappe.db.set_value(SETTINGS, SETTINGS, _READY_ANCHOR_FIELD, anchor, update_modified=False)
+	except Exception:
+		pass
+
+
+def _admin_unreachable_verdict(raw: dict, diag_code: str = "", retryable: bool | None = None) -> dict:
 	"""Admin could not be asked. Which way is failing WRONG?
 
 	For an ESTABLISHED workspace (see _has_been_chat_ready) the container is
@@ -256,13 +372,53 @@ def _admin_unreachable_verdict(raw: dict) -> dict:
 	"""
 	if _has_been_chat_ready(raw):
 		return {"ready": True, "reason": None, "billing_notice": {}}
-	return {
+	verdict = {
 		"ready": False,
 		"reason": _UNCONFIRMED_REASON,
-		"retryable": True,
+		"retryable": True if retryable is None else retryable,
 		"detail": _UNCONFIRMED_DETAIL,
 		"billing_notice": {},
 	}
+	if diag_code:
+		# P1-08: keep the diagnostic CLASS the broad catch would otherwise flatten,
+		# so the SPA's recovery copy can tell an admin transport outage (retry) from
+		# an authorization denial (needs the customer to act) from an unexpected
+		# contract shape (support). The code is a fixed, safe token - never admin's
+		# raw exception text. It is carried on the cached entry too, so a polling
+		# wizard gets the same verdict on every beat, not one shape then another.
+		verdict["diag_code"] = diag_code
+	return verdict
+
+
+# Fixed, customer-safe diagnostic tokens for a readiness_unconfirmed verdict, and
+# whether the customer's own action could change the answer (retryable) or not.
+# The token is what the SPA branches its recovery copy on; the raw exception text
+# never crosses this boundary (it can carry admin internals). An unrecognised
+# failure stays retryable - the same optimistic default the rest of this module
+# uses for a control plane it has not classified.
+def _diagnostic_class(err) -> tuple[str, bool]:
+	from jarvis.exceptions import (
+		AdminAuthError,
+		AdminRateLimitedError,
+		AdminUnreachableError,
+		AdminValidationError,
+	)
+
+	if isinstance(err, AdminAuthError):
+		# 401 is a token problem (re-mintable, retryable); 403 is an authorization
+		# denial the same principal will keep hitting until the account changes.
+		if getattr(err, "status_code", None) == 403:
+			return "admin_forbidden", False
+		return "admin_auth", True
+	if isinstance(err, AdminRateLimitedError):
+		return "admin_rate_limited", True
+	if isinstance(err, AdminValidationError):
+		# A structured 4xx business/contract error - not a transient outage. An old
+		# admin whose contract this bench no longer speaks lands here.
+		return "admin_contract", False
+	if isinstance(err, AdminUnreachableError):
+		return "admin_unreachable", True
+	return "admin_error", True
 
 
 def _admin_chat_gate() -> dict:
@@ -294,7 +450,9 @@ def _admin_chat_gate() -> dict:
 	cached = cache.get_value(cache_key)
 	if cached:
 		if isinstance(cached, dict) and cached.get("unconfirmed"):
-			return _admin_unreachable_verdict(raw)
+			return _admin_unreachable_verdict(
+				raw, diag_code=cached.get("diag_code") or "", retryable=cached.get("retryable")
+			)
 		# The billing banner rides the cached verdict. Caching a bare flag would
 		# hide an expiring/grace notice for the whole TTL on every ready load.
 		# Tolerate the pre-upgrade shape (a bare 1) rather than re-asking admin.
@@ -302,20 +460,26 @@ def _admin_chat_gate() -> dict:
 		return {"ready": True, "reason": None, "billing_notice": notice or {}}
 	try:
 		conn = admin_client.get_connection(timeout_s=8) or {}
-	except Exception:
+	except Exception as err:
 		# A site whose account was reconnected elsewhere fails auth here forever, so
 		# failing open sends it into a chat that cannot work. Ask the one question it
 		# can still ask before deciding.
 		moved = _site_replacement()
 		if moved.get("replaced"):
 			return {"ready": False, "reason": "site_replaced", "replaced_notice": moved, "billing_notice": {}}
-		verdict = _admin_unreachable_verdict(raw)
+		diag_code, retryable = _diagnostic_class(err)
+		verdict = _admin_unreachable_verdict(raw, diag_code=diag_code, retryable=retryable)
 		if verdict.get("reason") == _UNCONFIRMED_REASON:
 			# Same revision key as the positive verdict, so a save drops this too -
 			# a customer who fixes their config is never held behind an outage's
-			# leftovers. Re-derived on read rather than stored, so the cohort is
-			# re-evaluated even inside the window.
-			cache.set_value(cache_key, {"unconfirmed": True}, expires_in_sec=_UNCONFIRMED_CACHE_TTL_S)
+			# leftovers. Only the outage FACT + its diagnostic class are cached (never
+			# the cohort decision), so the cohort is re-evaluated even inside the
+			# window and a polling wizard gets a stable verdict shape.
+			cache.set_value(
+				cache_key,
+				{"unconfirmed": True, "diag_code": diag_code, "retryable": retryable},
+				expires_in_sec=_UNCONFIRMED_CACHE_TTL_S,
+			)
 		return verdict
 	# Refresh the locally-mirrored release notice on this gate's cadence so an
 	# active user sees an activate/clear without waiting for the daily sync.
@@ -334,9 +498,13 @@ def _admin_chat_gate() -> dict:
 			# sends no reason; the SPA falls back to its own copy.
 			"detail": conn.get("chat_readiness_reason") or "",
 		}
-	# Reachable + (Ready, or v1-absent) → allow, remember that this workspace has
-	# been confirmed once, and cache the positive verdict against this revision.
-	_mark_chat_ready(raw)
+	# Reachable + (Ready, or v1-absent) → allow and cache the positive verdict.
+	# But only an EXPLICIT Ready earns the established marker (review P0-07): the
+	# v1-tolerant missing-key path allows this page load without minting proof admin
+	# never supplied - a workspace whose control plane has never once said "Ready"
+	# must not be promoted into the cohort whose chat survives an outage.
+	if conn.get("chat_readiness") == "Ready":
+		_mark_chat_ready(raw)
 	cache.set_value(cache_key, {"notice": notice}, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
 	return {"ready": True, "reason": None, "billing_notice": notice}
 

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -212,8 +212,14 @@ def _authority_anchor(raw: dict) -> str:
 	Every input is a LOCAL, offline-readable field, because this is recomputed on
 	the fail-open path when admin cannot be asked at all:
 
-	  - jarvis_admin_api_key: the admin principal. A reconnect to a different
-	    customer replaces it.
+	  - the admin principal: a DIGEST of the REAL jarvis_admin_api_key (review F6).
+	    The raw ``tabSingles`` value the caller passes carries only this Password
+	    field's MASK ("**********"), which is a CONSTANT - joining it made the
+	    principal term inert, so a reconnect to a different principal on the same
+	    container + generation produced an IDENTICAL anchor (a fence that did not
+	    fence). We fetch and hash the decrypted credential from __Auth instead (a
+	    local read, so still offline-safe on the fail-open path); the real key is
+	    never stored - only its one-way digest rides into the anchor.
 	  - agent_url: the container. A workspace reset clears it; a container
 	    replacement changes it.
 	  - tenant_authority_generation: the Plan 04 generation. A move/repair bumps
@@ -223,9 +229,18 @@ def _authority_anchor(raw: dict) -> str:
 	A change to any of them means the workspace admin confirmed Ready is no longer
 	the one in front of us, so the claim must not carry across it.
 	"""
+	from frappe.utils.password import get_decrypted_password
+
+	# The REAL admin credential (from __Auth), digested - NOT the masked column value
+	# the raw tabSingles read carries. get_decrypted_password is a local DB read, so
+	# it is safe on the fail-open path. Empty (un-onboarded) -> empty principal term.
+	real_key = (
+		get_decrypted_password(SETTINGS, SETTINGS, "jarvis_admin_api_key", raise_exception=False) or ""
+	).strip()
+	principal = hashlib.sha256(real_key.encode("utf-8")).hexdigest() if real_key else ""
 	joined = "|".join(
 		(
-			(raw.get("jarvis_admin_api_key") or "").strip(),
+			principal,
 			(raw.get("agent_url") or "").strip(),
 			str(raw.get("tenant_authority_generation") or ""),
 		)

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -17,23 +17,195 @@ their published names - no duplicates:
   - jarvis.onboarding.finish_payment  (post-Razorpay confirm)
 """
 
+import hashlib
+
 import frappe
 
 from jarvis import admin_client, release_notice
+from jarvis.exceptions import AdminAuthError
 from jarvis.jarvis.pool_serialize import compute_pool_mode, pool_primary_model
 from jarvis.onboarding import _surface
 from jarvis.permissions import require_jarvis_admin
 
+SETTINGS = "Jarvis Settings"
+
 # R2-H4 chat-readiness gate, shared by boot, is_ready_for_chat and the send
 # entitlement check. Only "Ready" is cached, so suspension/renewal is still seen
-# promptly; 2 min keeps active-chat admin calls to ~1 per burst.
+# promptly.
+#
+# The cache is keyed by a CONFIG REVISION (see _gate_revision) and the TTL is a
+# belt, not the mechanism. A flat site-wide key with a 2-minute TTL meant a
+# customer who had just saved a broken LLM config could be told "Ready" for two
+# more minutes on the strength of the verdict their PREVIOUS config earned - the
+# save itself busted nothing. 30s bounds how long an ADMIN-side change (a
+# suspension, a container restart) can stay hidden; the revision covers every
+# change this bench makes itself, immediately.
 _CHAT_GATE_CACHE_KEY = "jarvis:chat_readiness_gate"
-_CHAT_GATE_CACHE_TTL_S = 120
+_CHAT_GATE_CACHE_TTL_S = 30
+
+# Every LOCAL input that can change what admin answers about readiness. A change
+# to any of them invalidates the cached verdict outright, because the verdict was
+# about the previous configuration. Kept as raw stored values (see _settings_raw)
+# so the hash is stable and cheap.
+#
+# These are the same fields is_ready_for_chat and _llm_apply_confirmed gate on,
+# plus the ones that decide WHICH container answers (agent_url) and what the last
+# apply did (last_sync_status / last_subscription_status) - a save flips the
+# status to "pending:" before anything else moves, so the revision changes on the
+# save itself rather than only when the async apply lands.
+_GATE_REVISION_FIELDS = (
+	"agent_url",
+	"llm_auth_mode",
+	"llm_provider",
+	"llm_model",
+	"proxy_active",
+	"routing_mode",
+	"preset",
+	"last_sync_status",
+	"last_subscription_status",
+	"llm_pool_synced_at",
+	"llm_direct_synced_at",
+	"llm_oauth_connected_at",
+)
+
+# Durable "admin has said Ready about this workspace at least once" marker. It is
+# what separates an ESTABLISHED workspace (whose chat must survive a control-plane
+# outage) from an onboarding-stage one (which must not be told it is ready when
+# nobody could confirm it). See _admin_unreachable_verdict.
+_READY_MARKER_FIELD = "chat_was_ready_at"
+# Re-stamped at most this often. The gate only ever asks "is it set", so the
+# freshness is for operators reading the field; writing on every Ready would put a
+# DB write on every uncached page load for no gate value.
+_READY_MARKER_REFRESH_S = 86400
+
+_GATE_STATE_FIELDS = (*_GATE_REVISION_FIELDS, _READY_MARKER_FIELD, "jarvis_admin_api_key")
+
+# Not-ready code for "we could not confirm this workspace is ready" - as opposed
+# to container_provisioning / subscription_suspended, which are verdicts admin
+# actually rendered. Callers may retry it; nothing about it is permanent.
+_UNCONFIRMED_REASON = "readiness_unconfirmed"
+_UNCONFIRMED_DETAIL = (
+	"We couldn't confirm your workspace is ready yet. This usually clears in a moment - please retry."
+)
+
+
+def _settings_raw(fields: tuple[str, ...]) -> dict:
+	"""Raw ``tabSingles`` values for ``fields`` - exactly as stored, uncast.
+
+	Deliberately NOT ``frappe.db.get_value`` / ``get_single_value`` on the Single:
+	both cast by fieldtype, and casting an EMPTY Datetime single runs it through
+	``get_datetime``, which returns ``now_datetime()`` for None. Every Datetime
+	this function reads is used either as "has this ever been stamped" or as "has
+	this changed since the cached verdict", and that coercion breaks both: an
+	unstamped marker would read as truthy, and a never-applied config would hash
+	differently on every single call. Same trap the v1_10 / v2_00 backfill
+	patches document from the other direction (``datetime(1, 1, 1)``).
+
+	Uncached on purpose: this decides whether a cached readiness verdict may still
+	be served, so it must see a write the moment it lands.
+
+	``jarvis_admin_api_key`` is among the fields callers ask for; the column holds
+	only the mask (jarvis/_password_utils.py), and it is tested for PRESENCE here
+	and never returned to a caller or logged.
+	"""
+	try:
+		rows = frappe.db.sql(
+			"""select `field`, `value` from `tabSingles` where doctype = %s and `field` in %s""",
+			(SETTINGS, tuple(fields)),
+		)
+	except Exception:
+		return {}
+	return {f: v for f, v in rows}
+
+
+def _gate_revision(raw: dict) -> str:
+	"""Short digest of the local readiness inputs - the cached verdict's identity.
+
+	A miss costs one admin round-trip, so the digest may be conservative (an
+	unrelated re-save that rewrites the same values keeps the entry) but must
+	never be stale: any changed value must produce a different key.
+	"""
+	joined = "|".join(f"{f}={raw.get(f) or ''}" for f in _GATE_REVISION_FIELDS)
+	return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def _has_been_chat_ready(raw: dict) -> bool:
+	"""Is this an ESTABLISHED workspace - a stored control-plane connection AND a
+	Ready verdict at some point in its life?
+
+	Both halves matter. The marker alone would keep a workspace whose credentials
+	were torn down (reconnected on another site, reset) in the cohort whose chat
+	is protected during an outage, and it is precisely that workspace whose chat
+	cannot work. The admin key alone is just "signup happened", which every
+	half-onboarded customer also has.
+	"""
+	return bool(raw.get(_READY_MARKER_FIELD)) and bool((raw.get("jarvis_admin_api_key") or "").strip())
+
+
+def _marker_is_fresh(current) -> bool:
+	"""Is the stored marker recent enough to leave alone? An unset or unreadable
+	stamp is NOT fresh - rewriting it is how a corrupted value heals."""
+	if not current:
+		return False
+	try:
+		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), current) < _READY_MARKER_REFRESH_S
+	except Exception:
+		return False
+
+
+def _mark_chat_ready(raw: dict) -> None:
+	"""Record that admin has confirmed this workspace Ready.
+
+	Best-effort and quiet, mirroring release_notice.persist: readiness is a read
+	path and must not fail because a marker could not be written.
+
+	``update_modified=False`` for the same reason the sync markers use it - the
+	Settings form's own timestamp is operator state, and the gate's revision must
+	not churn on its own bookkeeping.
+	"""
+	try:
+		if _marker_is_fresh(raw.get(_READY_MARKER_FIELD)):
+			return
+		frappe.db.set_value(
+			SETTINGS, SETTINGS, _READY_MARKER_FIELD, frappe.utils.now(), update_modified=False
+		)
+	except Exception:
+		pass
+
+
+def _admin_unreachable_verdict(raw: dict) -> dict:
+	"""Admin could not be asked. Which way is failing WRONG?
+
+	For an ESTABLISHED workspace (see _has_been_chat_ready) the container is
+	almost certainly still serving the config it was already serving, and the
+	control plane is not in the chat path at all - blocking there would take chat
+	away from a working customer over an outage they are not even affected by.
+	Fail OPEN, as this gate always has.
+
+	For a workspace that has NEVER been confirmed ready, the same shrug is what
+	sends a half-onboarded customer into a chat that cannot answer: nothing has
+	ever proven a container is serving them, and "probably fine" is not a thing
+	anybody knows. Fail CLOSED with a RETRYABLE code - not a verdict admin
+	rendered, just an admission that nobody could confirm one - so the wizard
+	keeps polling instead of declaring setup finished.
+
+	Never negative-cached, on either branch: a recovered control plane is re-asked
+	on the very next call.
+	"""
+	if _has_been_chat_ready(raw):
+		return {"ready": True, "reason": None, "billing_notice": {}}
+	return {
+		"ready": False,
+		"reason": _UNCONFIRMED_REASON,
+		"retryable": True,
+		"detail": _UNCONFIRMED_DETAIL,
+		"billing_notice": {},
+	}
 
 
 def _admin_chat_gate() -> dict:
 	"""Last managed ready-gate: ask admin whether the customer's container is
-	actually provisioned enough to serve chat. Fail-open and v1-tolerant.
+	actually provisioned enough to serve chat. v1-tolerant.
 
 	Called only AFTER the local signup + LLM-credential checks have passed, at
 	the managed ready-exits of ``is_ready_for_chat`` — it is the final gate.
@@ -47,13 +219,17 @@ def _admin_chat_gate() -> dict:
 
 	- v1-tolerance: an ABSENT ``chat_readiness`` key (v1 admin, or a v2 that
 	  doesn't surface it) means the control plane has no opinion → allow.
-	- Resilience: ANY ``get_connection`` failure (unreachable / auth / timeout)
-	  → allow. A control-plane hiccup must never bounce an already-provisioned
-	  customer out of chat. We do NOT negative-cache, so a transient block or
-	  error clears on the very next load rather than sticking for the TTL.
+	- Resilience: a ``get_connection`` failure (unreachable / auth / timeout) is
+	  answered by cohort - fail open for an established workspace, fail closed
+	  with a retryable code for one that has never been confirmed ready. See
+	  ``_admin_unreachable_verdict``. Neither is negative-cached, so a transient
+	  block or error clears on the very next load rather than sticking for the
+	  TTL.
 	"""
+	raw = _settings_raw(_GATE_STATE_FIELDS)
 	cache = frappe.cache()
-	cached = cache.get_value(_CHAT_GATE_CACHE_KEY)
+	cache_key = f"{_CHAT_GATE_CACHE_KEY}:{_gate_revision(raw)}"
+	cached = cache.get_value(cache_key)
 	if cached:
 		# The billing banner rides the cached verdict. Caching a bare flag would
 		# hide an expiring/grace notice for the whole TTL on every ready load.
@@ -65,14 +241,13 @@ def _admin_chat_gate() -> dict:
 	except Exception:
 		# A site whose account was reconnected elsewhere fails auth here forever, so
 		# failing open sends it into a chat that cannot work. Ask the one question it
-		# can still ask before shrugging.
+		# can still ask before deciding.
 		moved = _site_replacement()
 		if moved.get("replaced"):
 			return {"ready": False, "reason": "site_replaced", "replaced_notice": moved, "billing_notice": {}}
-		# Fail open on ANY other admin error; deliberately no negative cache.
-		return {"ready": True, "reason": None, "billing_notice": {}}
-	# Refresh the locally-mirrored release notice on this gate's ~120s cadence so
-	# an active user sees an activate/clear without waiting for the daily sync.
+		return _admin_unreachable_verdict(raw)
+	# Refresh the locally-mirrored release notice on this gate's cadence so an
+	# active user sees an activate/clear without waiting for the daily sync.
 	release_notice.persist(conn.get("release_notice") or {})
 	notice = conn.get("billing_notice") or {}
 	if "chat_readiness" in conn and conn["chat_readiness"] != "Ready":
@@ -88,8 +263,10 @@ def _admin_chat_gate() -> dict:
 			# sends no reason; the SPA falls back to its own copy.
 			"detail": conn.get("chat_readiness_reason") or "",
 		}
-	# Reachable + (Ready, or v1-absent) → allow and cache the positive verdict.
-	cache.set_value(_CHAT_GATE_CACHE_KEY, {"notice": notice}, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
+	# Reachable + (Ready, or v1-absent) → allow, remember that this workspace has
+	# been confirmed once, and cache the positive verdict against this revision.
+	_mark_chat_ready(raw)
+	cache.set_value(cache_key, {"notice": notice}, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
 	return {"ready": True, "reason": None, "billing_notice": notice}
 
 
@@ -166,8 +343,13 @@ def is_ready_for_chat() -> dict:
 	  failed).
 	- ``"container_provisioning"`` - all local checks passed, but admin reports
 	  the container isn't chat-ready yet (chat_readiness != "Ready"). Set only by
-	  the final ``_admin_chat_gate`` at the managed ready-exits; fail-open and
-	  v1-tolerant (see ``_admin_chat_gate``).
+	  the final ``_admin_chat_gate`` at the managed ready-exits; v1-tolerant (see
+	  ``_admin_chat_gate``).
+	- ``"readiness_unconfirmed"`` - admin could not be asked AND this workspace
+	  has never been confirmed ready, so nothing knows whether a container is
+	  serving it. Carries ``retryable: True``: it is the absence of a verdict,
+	  not one. An ESTABLISHED workspace does not get this - the same failure
+	  leaves it ready (see ``_admin_unreachable_verdict``).
 	- ``None`` when ``ready`` is True.
 	"""
 	settings = frappe.get_single("Jarvis Settings")
@@ -262,7 +444,8 @@ def _llm_missing_verdict(settings) -> dict:
 	``llm_setup`` hard-gates back to the wizard — chat cannot work there, and
 	the half-created signup resumes via start_signup's authenticated fallback.
 	Subscription state comes from admin; fail OPEN to the soft banner when it
-	is unknown/unreachable."""
+	is unknown/unreachable — EXCEPT when admin was reached and refused this site
+	outright (see the 403 branch)."""
 	never_synced = not (
 		getattr(settings, "llm_direct_synced_at", None)
 		or getattr(settings, "llm_pool_synced_at", None)
@@ -274,6 +457,25 @@ def _llm_missing_verdict(settings) -> dict:
 		from jarvis import admin_client
 
 		sub_status = (admin_client.get_connection(timeout_s=8) or {}).get("subscription_status") or ""
+	except AdminAuthError as e:
+		# 403 is admin REACHED and refusing this site's principal, and the endpoint
+		# that decides it (jarvis_admin_v2.api._auth.current_customer, allow_pending
+		# False) refuses exactly the customer states that mean "not paid up": Pending
+		# Payment, Pending Verification, Suspended, Cancelled. Reading that as
+		# "subscription state unknown" is what made the llm_setup gate below
+		# UNREACHABLE for the cohort it was written for — a Pending Payment customer
+		# 403s here, fell through to the soft banner, and landed in the chat app with
+		# a "no AI connected" note instead of back in the wizard that can finish
+		# their payment.
+		#
+		# Safe only because never_synced has already excluded every workspace that
+		# ever had a working LLM: what is left is a customer admin refuses AND who
+		# has never had an AI connection at all, i.e. chat cannot work for them by
+		# either measure. A lapsed customer who DID connect one keeps the soft
+		# renew-banner path above, untouched.
+		if getattr(e, "status_code", None) == 403:
+			return {"ready": False, "reason": "llm_setup"}
+		sub_status = ""
 	except Exception:
 		sub_status = ""
 	# Hard-gate ONLY the never-paid shapes. Active is established (the revoke
@@ -609,12 +811,21 @@ def cancel_scheduled_downgrade() -> dict:
 
 
 def _bust_chat_gate() -> None:
-	"""Drop the chat-readiness cache after a billing state change.
+	"""Drop EVERY cached chat-readiness verdict for this site.
 
-	Belt-and-braces: cancelling does not itself change readiness (entitlement
-	runs to period end), but the pane re-reads immediately afterwards and a
-	stale positive verdict would be confusing. Costs one Redis DEL."""
+	Two kinds of caller. A billing state change (cancel / resume) moves nothing
+	the revision covers, so this is the only thing that can drop its entry -
+	cancelling does not itself change readiness (entitlement runs to period end),
+	but the pane re-reads immediately afterwards and a stale positive verdict
+	would be confusing. An LLM save DOES move the revision, so its entry is
+	already unreachable; this still runs there because the revision can return to
+	a previous value within the TTL (a save that is reverted, an apply that lands
+	back on the same status), and a resurrected verdict about a configuration that
+	was replaced in between is exactly what the revision exists to prevent.
+
+	Prefix delete, not a single key: the entry to drop is whichever revision is
+	live, and after a save that is no longer the one this call would compute."""
 	try:
-		frappe.cache().delete_value(_CHAT_GATE_CACHE_KEY)
+		frappe.cache().delete_keys(_CHAT_GATE_CACHE_KEY)
 	except Exception:
 		pass

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -123,20 +123,15 @@ _UNCONFIRMED_CACHE_TTL_S = 5
 # An ALLOWLIST: Cancelled, an empty body, a proxy's own 403 and anything
 # unrecognised all fall through to the soft verdict. Being wrong in the hard
 # direction locks a customer out of chat AND /billing; being wrong in the soft
-# direction shows a banner one step too late. FROZEN-CONTRACT NOTE: wire-verify
-# these codes against jarvis_admin_v2's actual auth-refusal codes when the admin
-# half merges; the set is deliberately generous across the plausible spellings.
-_NEVER_PAID_CODES = frozenset(
-	{
-		"NEVER_PAID",
-		"NOT_A_CUSTOMER",
-		"CUSTOMER_NOT_FOUND",
-		"PENDING_PAYMENT",
-		"PENDING_VERIFICATION",
-		"CUSTOMER_PENDING_PAYMENT",
-		"CUSTOMER_PENDING_VERIFICATION",
-	}
-)
+# direction shows a banner one step too late.
+#
+# CUSTOMER_NOT_PAID is admin's concrete structured code
+# (jarvis_admin_v2.api._responses.CustomerNotPaidError, status 403), raised for a
+# Pending Payment / Pending Verification / any non-Active-non-Suspended customer on
+# the wrapped endpoints and get_connection. Distinct from
+# TENANT_AUTHORITY_REPAIR_REQUIRED, which is NOT never-paid (it is a repair state)
+# and is deliberately absent here.
+_NEVER_PAID_CODES = frozenset({"CUSTOMER_NOT_PAID"})
 
 # TEMPORARY prose fallback for an OLD admin that answers the never-paid 403 with a
 # human sentence and no structured code. REMOVE once every control plane in the

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -87,6 +87,27 @@ _UNCONFIRMED_REASON = "readiness_unconfirmed"
 _UNCONFIRMED_DETAIL = (
 	"We couldn't confirm your workspace is ready yet. This usually clears in a moment - please retry."
 )
+# Short enough that "retryable" stays true in practice (the wizard's poll is 2.5s
+# and a recovered control plane must be seen within a beat or two), long enough
+# that an outage does not turn one wizard into 30 admin round-trips a minute.
+# Applies to THIS code alone: a real not-ready verdict is never cached.
+_UNCONFIRMED_CACHE_TTL_S = 5
+
+# Admin's own words for a customer that has NEVER paid, from
+# jarvis_admin_v2.api._auth.current_customer. Matched on the message because the
+# wire carries nothing better: every refusal that function makes is a 403, and
+# only the sentence separates a half-finished signup from a lapsed customer whose
+# renew banner must keep working.
+#
+# An ALLOWLIST: "customer status: Cancelled", an empty body, a proxy's own 403 and
+# anything unrecognised all fall through to the soft verdict. Being wrong in the
+# hard direction locks a customer out of chat AND /billing; being wrong in the
+# soft direction shows a banner one step too late.
+_NEVER_PAID_403_MARKERS = (
+	"customer status: pending payment",
+	"customer status: pending verification",
+	"not a jarvis customer",
+)
 
 
 def _settings_raw(fields: tuple[str, ...]) -> dict:
@@ -118,6 +139,22 @@ def _settings_raw(fields: tuple[str, ...]) -> dict:
 	return {f: v for f, v in rows}
 
 
+def _is_never_paid_403(err) -> bool:
+	"""Does this admin rejection carry admin's OWN evidence that the customer has
+	never paid? Anything less is not evidence - see _NEVER_PAID_403_MARKERS.
+
+	Note what a production admin actually puts on the wire: Frappe only includes
+	the exception sentence when tracebacks are allowed (frappe/utils/response.py
+	``report_error`` / ``is_traceback_allowed``), so a hardened control plane sends
+	back ``exc_type`` alone and this correctly returns False. The hard gate is the
+	exception, not the rule.
+	"""
+	if getattr(err, "status_code", None) != 403:
+		return False
+	message = str(err or "").strip().lower()
+	return any(marker in message for marker in _NEVER_PAID_403_MARKERS)
+
+
 def _gate_revision(raw: dict) -> str:
 	"""Short digest of the local readiness inputs - the cached verdict's identity.
 
@@ -137,8 +174,15 @@ def _has_been_chat_ready(raw: dict) -> bool:
 	were torn down (reconnected on another site, reset) in the cohort whose chat
 	is protected during an outage, and it is precisely that workspace whose chat
 	cannot work. The admin key alone is just "signup happened", which every
-	half-onboarded customer also has.
+	half-onboarded customer also has. settings_reset.CONNECTION clears the marker
+	with the rest of the tenancy, so a reset site must earn a new Ready.
 	"""
+	if not frappe.get_meta(SETTINGS).get_field(_READY_MARKER_FIELD):
+		# Code running ahead of its migration: the field does not exist, so NO
+		# workspace can be established and every established customer would fail
+		# closed together. Insurance for a hand-rolled deploy that restarts before
+		# it migrates; self-disarming the moment `bench migrate` adds the field.
+		return True
 	return bool(raw.get(_READY_MARKER_FIELD)) and bool((raw.get("jarvis_admin_api_key") or "").strip())
 
 
@@ -153,6 +197,22 @@ def _marker_is_fresh(current) -> bool:
 		return False
 
 
+def _write_is_durable() -> bool:
+	"""Would a write made right now survive the end of this request?
+
+	Frappe commits only for an UNSAFE method and rolls everything else back
+	(frappe/app.py ``sync_database``, frappe/auth.py ``UNSAFE_HTTP_METHODS``), so a
+	marker written during the desk's boot GET is discarded anyway - and writing it
+	regardless would burn a row-lock on Singles on every page load of every user
+	for nothing. The paths that matter are POSTs (the SPA's readiness call, a chat
+	send) and background jobs, which is where the marker actually becomes durable.
+	"""
+	request = getattr(frappe.local, "request", None)
+	if request is None:
+		return True  # background job, CLI, test: no request to be rolled back
+	return (getattr(request, "method", "") or "").upper() in ("POST", "PUT", "DELETE", "PATCH")
+
+
 def _mark_chat_ready(raw: dict) -> None:
 	"""Record that admin has confirmed this workspace Ready.
 
@@ -164,7 +224,7 @@ def _mark_chat_ready(raw: dict) -> None:
 	not churn on its own bookkeeping.
 	"""
 	try:
-		if _marker_is_fresh(raw.get(_READY_MARKER_FIELD)):
+		if _marker_is_fresh(raw.get(_READY_MARKER_FIELD)) or not _write_is_durable():
 			return
 		frappe.db.set_value(
 			SETTINGS, SETTINGS, _READY_MARKER_FIELD, frappe.utils.now(), update_modified=False
@@ -189,8 +249,10 @@ def _admin_unreachable_verdict(raw: dict) -> dict:
 	rendered, just an admission that nobody could confirm one - so the wizard
 	keeps polling instead of declaring setup finished.
 
-	Never negative-cached, on either branch: a recovered control plane is re-asked
-	on the very next call.
+	The closed branch is cached for _UNCONFIRMED_CACHE_TTL_S (the gate does the
+	caching, since it owns the key) - long enough to stop a 2.5s poll turning one
+	outage into an admin round-trip per beat, short enough that "retryable" is not
+	a lie. A verdict admin actually RENDERED is still never cached.
 	"""
 	if _has_been_chat_ready(raw):
 		return {"ready": True, "reason": None, "billing_notice": {}}
@@ -222,15 +284,17 @@ def _admin_chat_gate() -> dict:
 	- Resilience: a ``get_connection`` failure (unreachable / auth / timeout) is
 	  answered by cohort - fail open for an established workspace, fail closed
 	  with a retryable code for one that has never been confirmed ready. See
-	  ``_admin_unreachable_verdict``. Neither is negative-cached, so a transient
-	  block or error clears on the very next load rather than sticking for the
-	  TTL.
+	  ``_admin_unreachable_verdict``. A verdict admin RENDERED is never cached, so
+	  a transient block clears on the very next load; the unconfirmed verdict gets
+	  a few seconds so a polling wizard cannot amplify an outage.
 	"""
 	raw = _settings_raw(_GATE_STATE_FIELDS)
 	cache = frappe.cache()
 	cache_key = f"{_CHAT_GATE_CACHE_KEY}:{_gate_revision(raw)}"
 	cached = cache.get_value(cache_key)
 	if cached:
+		if isinstance(cached, dict) and cached.get("unconfirmed"):
+			return _admin_unreachable_verdict(raw)
 		# The billing banner rides the cached verdict. Caching a bare flag would
 		# hide an expiring/grace notice for the whole TTL on every ready load.
 		# Tolerate the pre-upgrade shape (a bare 1) rather than re-asking admin.
@@ -245,7 +309,14 @@ def _admin_chat_gate() -> dict:
 		moved = _site_replacement()
 		if moved.get("replaced"):
 			return {"ready": False, "reason": "site_replaced", "replaced_notice": moved, "billing_notice": {}}
-		return _admin_unreachable_verdict(raw)
+		verdict = _admin_unreachable_verdict(raw)
+		if verdict.get("reason") == _UNCONFIRMED_REASON:
+			# Same revision key as the positive verdict, so a save drops this too -
+			# a customer who fixes their config is never held behind an outage's
+			# leftovers. Re-derived on read rather than stored, so the cohort is
+			# re-evaluated even inside the window.
+			cache.set_value(cache_key, {"unconfirmed": True}, expires_in_sec=_UNCONFIRMED_CACHE_TTL_S)
+		return verdict
 	# Refresh the locally-mirrored release notice on this gate's cadence so an
 	# active user sees an activate/clear without waiting for the daily sync.
 	release_notice.persist(conn.get("release_notice") or {})
@@ -458,22 +529,23 @@ def _llm_missing_verdict(settings) -> dict:
 
 		sub_status = (admin_client.get_connection(timeout_s=8) or {}).get("subscription_status") or ""
 	except AdminAuthError as e:
-		# 403 is admin REACHED and refusing this site's principal, and the endpoint
-		# that decides it (jarvis_admin_v2.api._auth.current_customer, allow_pending
-		# False) refuses exactly the customer states that mean "not paid up": Pending
-		# Payment, Pending Verification, Suspended, Cancelled. Reading that as
-		# "subscription state unknown" is what made the llm_setup gate below
-		# UNREACHABLE for the cohort it was written for — a Pending Payment customer
-		# 403s here, fell through to the soft banner, and landed in the chat app with
-		# a "no AI connected" note instead of back in the wizard that can finish
-		# their payment.
+		# A 403 is admin REACHED and refusing this site's principal. That refusal is
+		# how the llm_setup gate below came to be UNREACHABLE for the cohort it was
+		# written for: a Pending Payment customer 403s at
+		# jarvis_admin_v2.api._auth.current_customer (allow_pending False) instead of
+		# answering with a subscription_status, so they fell through to the soft
+		# banner and landed in the chat app with a "no AI connected" note rather than
+		# back in the wizard that can finish their payment.
 		#
-		# Safe only because never_synced has already excluded every workspace that
-		# ever had a working LLM: what is left is a customer admin refuses AND who
-		# has never had an AI connection at all, i.e. chat cannot work for them by
-		# either measure. A lapsed customer who DID connect one keeps the soft
-		# renew-banner path above, untouched.
-		if getattr(e, "status_code", None) == 403:
+		# ONLY the never-paid shapes hard-gate, and only when admin's own words say
+		# so - see _is_never_paid_403. Every other 403 (Cancelled, a bodyless
+		# proxy/WAF rejection, anything unrecognised) stays SOFT, because the
+		# renew/suspension banner owns those states and the wizard would dead-end
+		# them at signup's duplicate guard. Suspended cannot arrive here at all:
+		# Jarvis Customer propagates Suspended to User.enabled=0
+		# (jarvis_admin_v2/.../jarvis_customer.py:81), so that customer's bench is
+		# rejected by Frappe auth with a 401 long before current_customer runs.
+		if _is_never_paid_403(e):
 			return {"ready": False, "reason": "llm_setup"}
 		sub_status = ""
 	except Exception:
@@ -824,7 +896,14 @@ def _bust_chat_gate() -> None:
 	was replaced in between is exactly what the revision exists to prevent.
 
 	Prefix delete, not a single key: the entry to drop is whichever revision is
-	live, and after a save that is no longer the one this call would compute."""
+	live, and after a save that is no longer the one this call would compute.
+
+	DO NOT call this from a hot path. ``delete_keys`` is a Redis KEYS scan of the
+	whole keyspace, which is fine for the handful of rare, human-triggered actions
+	that call it (a billing change, an LLM save, a disconnect, a reconnect) and is
+	not fine per request or per chat turn. A caller that needs invalidation on a
+	hot path wants the config revision instead - it costs nothing and is already
+	how every routine change is picked up."""
 	try:
 		frappe.cache().delete_keys(_CHAT_GATE_CACHE_KEY)
 	except Exception:

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1612,9 +1612,14 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	# fell through to AdminUnreachableError - losing the rate-limit
 	# category entirely. 401/403/429 always win.
 	if resp.status_code in (401, 403):
+		# Carry admin's structured ``error.code`` when the refusal envelope has one,
+		# so callers branch on a stable token rather than the human sentence a
+		# hardened control plane may omit (jarvis.account._is_never_paid_403).
+		err_obj = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
 		raise AdminAuthError(
 			_envelope_message() or f"admin returned {resp.status_code}",
 			status_code=resp.status_code,
+			code=(err_obj.get("code") or "") if isinstance(err_obj, dict) else "",
 		)
 	if resp.status_code == 429:
 		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -150,11 +150,17 @@ class AdminAuthError(JarvisError):
 	*authorization* denial (403 - the same customer principal backs both the
 	bearer and the legacy api_key:api_secret, so re-minting and the legacy
 	fallback would just replay into the same 403 while storming the token
-	endpoint). None when the status isn't known."""
+	endpoint). None when the status isn't known.
 
-	def __init__(self, message: str, *, status_code: int | None = None):
+	``code`` carries admin's structured ``error.code`` from the refusal envelope
+	when present (e.g. ``PENDING_PAYMENT``), so a caller can branch on a stable
+	machine token instead of parsing the human sentence a hardened control plane
+	may omit - see jarvis.account._is_never_paid_403. Empty when admin sent none."""
+
+	def __init__(self, message: str, *, status_code: int | None = None, code: str = ""):
 		super().__init__(message)
 		self.status_code = status_code
+		self.code = code
 
 
 class AdminValidationError(JarvisError):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -94,6 +94,7 @@
   "llm_pool_synced_at",
   "llm_direct_synced_at",
   "chat_was_ready_at",
+  "chat_ready_authority",
   "installed_apps_synced",
   "last_subscription_status",
   "last_sync_warnings",
@@ -702,6 +703,13 @@
    "fieldname": "chat_was_ready_at",
    "fieldtype": "Datetime",
    "label": "Chat Was Ready At",
+   "read_only": 1
+  },
+  {
+   "description": "Authority the established chat-Ready claim is bound to: a digest of (admin principal, container URL, tenant authority generation) captured the last time admin confirmed this workspace Ready. The claim only survives a control-plane outage while this still matches the current authority - a workspace reset, a reconnect to a different principal/container, or an authority-generation change moves it and ends the claim mechanically, without depending on every writer remembering to clear the marker. See account._authority_anchor.",
+   "fieldname": "chat_ready_authority",
+   "fieldtype": "Small Text",
+   "label": "Chat Ready Authority",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -93,6 +93,7 @@
   "last_sync_status",
   "llm_pool_synced_at",
   "llm_direct_synced_at",
+  "chat_was_ready_at",
   "installed_apps_synced",
   "last_subscription_status",
   "last_sync_warnings",
@@ -694,6 +695,13 @@
    "fieldname": "llm_direct_synced_at",
    "fieldtype": "Datetime",
    "label": "LLM Direct Synced At",
+   "read_only": 1
+  },
+  {
+   "description": "Set the first time admin confirmed this workspace chat-Ready (refreshed at most daily). Marks the workspace as ESTABLISHED: an unreachable control plane leaves its chat open, while a workspace that has never been confirmed fails closed with a retryable verdict instead of being told it is ready - see _admin_chat_gate in jarvis/account.py.",
+   "fieldname": "chat_was_ready_at",
+   "fieldtype": "Datetime",
+   "label": "Chat Was Ready At",
    "read_only": 1
   },
   {

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -95,6 +95,10 @@ def write_connection(data: dict) -> None:
 	from jarvis._password_utils import set_settings_password
 
 	s = frappe.get_single("Jarvis Settings")
+	# Capture the container this workspace pointed at BEFORE this write, so a
+	# reconnect that repoints it can be told apart from a daily sync that rewrites
+	# the same URL (which must not disturb an established claim).
+	_old_agent_url = (s.get("agent_url") or "").strip()
 	if data.get("api_key"):
 		set_settings_password(s, "jarvis_admin_api_key", data["api_key"])
 	if data.get("api_secret"):
@@ -114,8 +118,20 @@ def write_connection(data: dict) -> None:
 		set_settings_password(s, "agent_token", data["agent_token"])
 	# Credentials just changed (fresh signup, or a reconnect rotating onto another
 	# account): a bearer minted from the old ones would outlive them.
-	if any(data.get(k) for k in ("api_key", "api_secret", "customer", "customer_password")):
+	principal_change = any(data.get(k) for k in ("api_key", "api_secret", "customer", "customer_password"))
+	if principal_change:
 		admin_client.clear_cached_token()
+	# End the established chat-Ready claim when this write repoints the workspace at
+	# a DIFFERENT admin principal or a DIFFERENT container (review P0-06): the
+	# workspace admin confirmed Ready is no longer the one we are about to serve, so
+	# the marker must not carry a fail-open verdict across the boundary. A daily
+	# sync that rewrites the SAME agent_url with no new principal is left alone -
+	# clearing there would eject every established customer once a day. The
+	# authority anchor is the mechanical backstop; this is the explicit intent.
+	container_change = bool(data.get("agent_url")) and data["agent_url"].strip() != _old_agent_url
+	if principal_change or container_change:
+		s.db_set("chat_was_ready_at", None)
+		s.db_set("chat_ready_authority", "")
 	# This is the write that can point the workspace at a DIFFERENT container or a
 	# different admin principal, so any cached readiness verdict describes a
 	# connection that is no longer the current one.
@@ -865,6 +881,13 @@ def _disconnect_agent_transport(settings, reconnect_llm: bool = False) -> None:
 	settings.db_set("agent_url", "")
 	clear_settings_password(settings, "agent_token")
 	clear_credentials()
+	# End the established chat-Ready claim BEFORE the fail-open policy can see it
+	# (review P0-06). This is the self-serve rebuild path: the container is being
+	# torn down and replaced, so the workspace admin confirmed Ready no longer
+	# exists. Clearing agent_url above already moves the authority anchor, but the
+	# marker is cleared explicitly too so the intent is not left to a side effect.
+	settings.db_set("chat_was_ready_at", None)
+	settings.db_set("chat_ready_authority", "")
 	settings.db_set(
 		"last_sync_status", _RESETTING_RECONNECT_LLM_STATUS if reconnect_llm else _RESETTING_STATUS
 	)

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -116,6 +116,12 @@ def write_connection(data: dict) -> None:
 	# account): a bearer minted from the old ones would outlive them.
 	if any(data.get(k) for k in ("api_key", "api_secret", "customer", "customer_password")):
 		admin_client.clear_cached_token()
+	# This is the write that can point the workspace at a DIFFERENT container or a
+	# different admin principal, so any cached readiness verdict describes a
+	# connection that is no longer the current one.
+	from jarvis.account import _bust_chat_gate
+
+	_bust_chat_gate()
 	# NB: the release notice is deliberately NOT mirrored here. Several callers
 	# pass a partial payload (a password, a customer email), and an absent notice
 	# key means "cleared" - which would drop a live notice. It is persisted only
@@ -383,6 +389,14 @@ def save_llm_pool(models: str | list, preset: str | None = None, routing_mode: s
 	# compute_pool_mode/compute_proxy_active, mirror models[0], enqueue pool/creds sync.
 	s.save(ignore_permissions=True)
 	frappe.db.commit()
+	# The pool this workspace runs on just changed, so the readiness verdict admin
+	# gave about the PREVIOUS one is finished. account._admin_chat_gate keys its
+	# cache by config revision and this save moves it, so the old entry is already
+	# unreachable; the explicit drop covers the revision returning to a previous
+	# value inside the TTL (see _bust_chat_gate).
+	from jarvis.account import _bust_chat_gate
+
+	_bust_chat_gate()
 
 	row = (
 		frappe.db.get_value(
@@ -465,6 +479,10 @@ def disconnect_llm() -> dict:
 	for field, value in _DISCONNECTED_LLM_FIELDS.items():
 		settings.db_set(field, value, update_modified=False)
 	frappe.db.commit()
+	# There is no connection left for a cached "Ready" to be about.
+	from jarvis.account import _bust_chat_gate
+
+	_bust_chat_gate()
 	return {"disconnected": True, "last_sync_status": "disconnected"}
 
 
@@ -1019,6 +1037,11 @@ def save_llm_creds(
 		s.flags.force_admin_sync = True
 	s.save(ignore_permissions=True)
 	frappe.db.commit()
+	# Same reason as save_llm_pool's: the cached readiness verdict was about the
+	# credential this save replaced.
+	from jarvis.account import _bust_chat_gate
+
+	_bust_chat_gate()
 	# on_update writes last_sync_* via frappe.db.set_value so the
 	# in-memory ``s`` doc is stale. Fetch JUST the two fields we
 	# need rather than reloading the entire Singles doc (the previous

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -38,3 +38,4 @@ jarvis.patches.v2_06_skill_promotion_marker_and_shared_slug
 jarvis.patches.v2_07_agent_run_capability_snapshot
 jarvis.patches.v2_08_drop_jarvis_account_page
 jarvis.patches.v2_09_backfill_persona_enabled
+jarvis.patches.v2_10_backfill_chat_was_ready_at

--- a/jarvis/patches/v2_10_backfill_chat_was_ready_at.py
+++ b/jarvis/patches/v2_10_backfill_chat_was_ready_at.py
@@ -19,18 +19,26 @@ account._llm_apply_confirmed - was chat-ready before this deploy and must stay
 so. The marker is stamped from that leg's own timestamp, not from now(): it is a
 claim about the past, and back-dating it keeps the daily refresh honest.
 
-Those three markers are not equally strong, and the difference is inherited
-rather than introduced here: llm_pool_synced_at and llm_direct_synced_at are
-stamped on a CONFIRMED apply, while llm_oauth_connected_at is stamped when the
-grant completes and the auth-profile blob is PUSHED (jarvis/oauth/api.py) - a
-push, not a confirmation. It is used anyway because it is exactly the evidence
-the live gate already accepts for that leg; grandfathering must reproduce the
-pre-deploy verdict, not a stricter one it was never held to.
+Grandfather ONLY from evidence of a CONFIRMED apply (review P0-07). Two of the
+three sync markers qualify: llm_pool_synced_at and llm_direct_synced_at are
+stamped on an admin-confirmed apply. The third, llm_oauth_connected_at, is
+DELIBERATELY EXCLUDED: it is stamped when the OAuth grant completes and the
+auth-profile blob is PUSHED (jarvis/oauth/api.py) - a push, not a confirmation
+that the container ever served the workspace. A workspace whose only evidence is
+an OAuth push may never have become usable, and manufacturing an established
+claim for it would let it fail OPEN through an outage it should fail closed on.
+Such a workspace stays unconfirmed until its next live Ready earns the marker
+honestly.
 
-NOT stamped: a workspace with no admin key (never signed up) or no applied marker
-on any leg (nothing has ever been pushed to its container). Those are the
-onboarding-stage cohort by definition, and this patch must not manufacture
-history for them - their marker sets on their first real Ready.
+NOT stamped: a workspace with no admin key (never signed up), or one with no
+CONFIRMED apply marker (nothing an admin ever verified reached its container).
+Those are the onboarding-stage cohort by definition, and this patch must not
+manufacture history for them - their marker sets on their first real Ready.
+
+The backfilled marker is bound to the workspace's CURRENT authority (admin
+principal + container + generation) via the same anchor the live gate stamps, so
+a later reset/reconnect/generation change ends the grandfathered claim exactly as
+it would a freshly-earned one.
 
 Reads go through the document API, NOT frappe.db.get_single_value, for the same
 empty-Datetime coercion reason documented in v1_10.
@@ -45,16 +53,25 @@ def execute():
 		return
 	if not (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
 		return  # never signed up: nothing to grandfather
-	# Whichever leg this workspace syncs through - pool marker for a pool (incl. a
-	# BYO api-key pool), the OAuth connect stamp for a direct subscription/oauth
-	# tenant, the direct apply marker otherwise. Read permissively rather than
-	# re-deriving the leg: any ONE of these is what the live gate would have
-	# accepted for this workspace, which is the bar for grandfathering.
-	confirmed = (
-		settings.get("llm_pool_synced_at")
-		or settings.get("llm_direct_synced_at")
-		or settings.get("llm_oauth_connected_at")
-	)
+	# Confirmed-apply evidence ONLY: the pool marker for a pool (incl. a BYO
+	# api-key pool) or the direct apply marker otherwise. llm_oauth_connected_at is
+	# intentionally NOT consulted (see the module docstring): a push is not a
+	# confirmation.
+	confirmed = settings.get("llm_pool_synced_at") or settings.get("llm_direct_synced_at")
 	if not confirmed:
 		return
 	frappe.db.set_single_value("Jarvis Settings", "chat_was_ready_at", confirmed)
+	# Bind the grandfathered claim to the current authority so it is fenced the same
+	# way a live-earned one is (account._has_been_chat_ready). Best-effort: an
+	# unbound legacy marker still honours the presence rule, so a failure here only
+	# forgoes the mechanical fence, never the grandfather itself.
+	try:
+		from jarvis import account
+
+		if frappe.get_meta("Jarvis Settings").get_field(account._READY_ANCHOR_FIELD):
+			raw = account._settings_raw(account._GATE_STATE_FIELDS)
+			frappe.db.set_single_value(
+				"Jarvis Settings", account._READY_ANCHOR_FIELD, account._authority_anchor(raw)
+			)
+	except Exception:
+		pass

--- a/jarvis/patches/v2_10_backfill_chat_was_ready_at.py
+++ b/jarvis/patches/v2_10_backfill_chat_was_ready_at.py
@@ -1,0 +1,52 @@
+"""Backfill Jarvis Settings.chat_was_ready_at for workspaces that predate it.
+
+The marker ("admin has confirmed this workspace chat-Ready at least once") is
+what tells the readiness gate which way to fail when the control plane cannot be
+asked: an ESTABLISHED workspace keeps its chat (the container is still serving
+whatever it was already serving), a never-confirmed one fails closed with a
+retryable verdict rather than being told it is ready by a shrug.
+
+Every workspace running before this deploy has it empty, and it is only ever
+stamped by a live Ready verdict. Without this backfill, a control-plane outage in
+the window between migrating and the next successful gate call would fail CLOSED
+on working customers - the exact regression the established cohort exists to
+prevent.
+
+Grandfather rule (mirrors v1_10 / v2_00): a workspace that is onboarded
+(jarvis_admin_api_key present) AND whose LLM config has been CONFIRMED applied at
+least once - the same evidence is_ready_for_chat itself gates on, per
+account._llm_apply_confirmed - was chat-ready before this deploy and must stay
+so. The marker is stamped from that apply's own timestamp, not from now(): it is
+a claim about the past, and back-dating it keeps the daily refresh honest.
+
+NOT stamped: a workspace with no admin key (never signed up) or no confirmed
+apply on any leg (its container has demonstrably never been serving its config).
+Those are the onboarding-stage cohort by definition, and this patch must not
+manufacture history for them - their marker sets on their first real Ready.
+
+Reads go through the document API, NOT frappe.db.get_single_value, for the same
+empty-Datetime coercion reason documented in v1_10.
+"""
+
+import frappe
+
+
+def execute():
+	settings = frappe.get_single("Jarvis Settings")
+	if settings.get("chat_was_ready_at"):
+		return
+	if not (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
+		return  # never signed up: nothing to grandfather
+	# Whichever leg this workspace syncs through - pool marker for a pool (incl. a
+	# BYO api-key pool), the OAuth connect stamp for a direct subscription/oauth
+	# tenant, the direct apply marker otherwise. Read permissively rather than
+	# re-deriving the leg: any ONE confirmed apply is evidence enough that a
+	# container was serving this workspace.
+	confirmed = (
+		settings.get("llm_pool_synced_at")
+		or settings.get("llm_direct_synced_at")
+		or settings.get("llm_oauth_connected_at")
+	)
+	if not confirmed:
+		return
+	frappe.db.set_single_value("Jarvis Settings", "chat_was_ready_at", confirmed)

--- a/jarvis/patches/v2_10_backfill_chat_was_ready_at.py
+++ b/jarvis/patches/v2_10_backfill_chat_was_ready_at.py
@@ -13,16 +13,24 @@ on working customers - the exact regression the established cohort exists to
 prevent.
 
 Grandfather rule (mirrors v1_10 / v2_00): a workspace that is onboarded
-(jarvis_admin_api_key present) AND whose LLM config has been CONFIRMED applied at
-least once - the same evidence is_ready_for_chat itself gates on, per
+(jarvis_admin_api_key present) AND carries the marker its own leg is gated on -
+the same evidence is_ready_for_chat itself opens chat with, per
 account._llm_apply_confirmed - was chat-ready before this deploy and must stay
-so. The marker is stamped from that apply's own timestamp, not from now(): it is
-a claim about the past, and back-dating it keeps the daily refresh honest.
+so. The marker is stamped from that leg's own timestamp, not from now(): it is a
+claim about the past, and back-dating it keeps the daily refresh honest.
 
-NOT stamped: a workspace with no admin key (never signed up) or no confirmed
-apply on any leg (its container has demonstrably never been serving its config).
-Those are the onboarding-stage cohort by definition, and this patch must not
-manufacture history for them - their marker sets on their first real Ready.
+Those three markers are not equally strong, and the difference is inherited
+rather than introduced here: llm_pool_synced_at and llm_direct_synced_at are
+stamped on a CONFIRMED apply, while llm_oauth_connected_at is stamped when the
+grant completes and the auth-profile blob is PUSHED (jarvis/oauth/api.py) - a
+push, not a confirmation. It is used anyway because it is exactly the evidence
+the live gate already accepts for that leg; grandfathering must reproduce the
+pre-deploy verdict, not a stricter one it was never held to.
+
+NOT stamped: a workspace with no admin key (never signed up) or no applied marker
+on any leg (nothing has ever been pushed to its container). Those are the
+onboarding-stage cohort by definition, and this patch must not manufacture
+history for them - their marker sets on their first real Ready.
 
 Reads go through the document API, NOT frappe.db.get_single_value, for the same
 empty-Datetime coercion reason documented in v1_10.
@@ -40,8 +48,8 @@ def execute():
 	# Whichever leg this workspace syncs through - pool marker for a pool (incl. a
 	# BYO api-key pool), the OAuth connect stamp for a direct subscription/oauth
 	# tenant, the direct apply marker otherwise. Read permissively rather than
-	# re-deriving the leg: any ONE confirmed apply is evidence enough that a
-	# container was serving this workspace.
+	# re-deriving the leg: any ONE of these is what the live gate would have
+	# accepted for this workspace, which is the bar for grandfathering.
 	confirmed = (
 		settings.get("llm_pool_synced_at")
 		or settings.get("llm_direct_synced_at")

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1002,7 +1002,8 @@ onMounted(() => {
 	isReadyForChat()
 		.then((r) => {
 			readiness.value = classifyReadiness(r);
-			readinessNotice.value = readiness.value === "degraded" ? degradedMessage(r) : "";
+			readinessNotice.value =
+				readiness.value === "degraded" ? degradedMessage(r, brandName) : "";
 		})
 		.catch(() => {
 			// Fail OPEN, same as classifyReadiness(null): a flaky/unreachable check

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -63,6 +63,16 @@ export const SUSPENDED_FALLBACK =
 const GENERIC_DEGRADED =
   "Jarvis isn't fully set up, so replies may fail. Ask your administrator to finish reconnecting it.";
 
+// account.py could not reach its control plane AND this workspace has never been
+// confirmed chat-ready, so nobody knows whether a container is serving it
+// (jarvis/account.py::_admin_unreachable_verdict). Retryable by construction:
+// this is the absence of a verdict, not one. Without a case of its own it fell
+// to GENERIC_DEGRADED, which tells the customer to ask an administrator to
+// finish reconnecting - wrong twice over, since nothing is misconfigured and no
+// administrator can shorten an outage.
+const UNCONFIRMED_DEGRADED =
+  "We couldn't confirm Jarvis is ready, so replies may fail. This usually clears in a moment - try again shortly.";
+
 // Copy for the degraded banner, structured to match steps.js's suspensionNotice
 // so the two surfaces cannot drift apart on the same verdict.
 //
@@ -75,6 +85,11 @@ const GENERIC_DEGRADED =
 //   container_provisioning  admin's sentence when it has one (this is the path
 //                           that carries the quota and cooldown wording), else
 //                           the generic line.
+//   readiness_unconfirmed   the "try again shortly" line. account.py always
+//                           attaches a detail here, but the fallback is the
+//                           retryable one either way - never the generic
+//                           "ask your administrator", which names a person who
+//                           cannot help with a control-plane outage.
 //   anything else           the generic line. Do NOT print a raw `detail` for
 //                           an unrecognised reason: the reason set is owned by
 //                           account.py and a future addition would leak
@@ -84,5 +99,6 @@ export function degradedMessage(resp) {
   const detail = (resp && resp.detail) || "";
   if (reason === "subscription_suspended") return detail || SUSPENDED_FALLBACK;
   if (reason === "container_provisioning") return detail || GENERIC_DEGRADED;
+  if (reason === "readiness_unconfirmed") return detail || UNCONFIRMED_DEGRADED;
   return GENERIC_DEGRADED;
 }

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -70,8 +70,13 @@ const GENERIC_DEGRADED =
 // to GENERIC_DEGRADED, which tells the customer to ask an administrator to
 // finish reconnecting - wrong twice over, since nothing is misconfigured and no
 // administrator can shorten an outage.
-const UNCONFIRMED_DEGRADED =
-  "We couldn't confirm Jarvis is ready, so replies may fail. This usually clears in a moment - try again shortly.";
+//
+// Named for the configured agent (P2-02): this surface is white-labelled, so a
+// hardcoded "Jarvis" leaks our brand onto a customer who renamed the assistant.
+// The caller passes window.frappe.boot.jarvis_agent_name; "Jarvis" is the
+// fallback for a workspace that set none.
+const unconfirmedDegraded = (agentName) =>
+  `We couldn't confirm ${agentName} is ready, so replies may fail. This usually clears in a moment - try again shortly.`;
 
 // Copy for the degraded banner, structured to match steps.js's suspensionNotice
 // so the two surfaces cannot drift apart on the same verdict.
@@ -94,11 +99,13 @@ const UNCONFIRMED_DEGRADED =
 //                           an unrecognised reason: the reason set is owned by
 //                           account.py and a future addition would leak
 //                           whatever wording it happens to carry.
-export function degradedMessage(resp) {
+export function degradedMessage(resp, agentName = "Jarvis") {
   const reason = (resp && resp.reason) || "";
   const detail = (resp && resp.detail) || "";
+  const brand = (agentName || "").trim() || "Jarvis";
   if (reason === "subscription_suspended") return detail || SUSPENDED_FALLBACK;
   if (reason === "container_provisioning") return detail || GENERIC_DEGRADED;
-  if (reason === "readiness_unconfirmed") return detail || UNCONFIRMED_DEGRADED;
+  if (reason === "readiness_unconfirmed")
+    return detail || unconfirmedDegraded(brand);
   return GENERIC_DEGRADED;
 }

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -115,6 +115,27 @@ test("degradedMessage: an unconfirmed readiness verdict says retry, not 'ask you
   );
 });
 
+// P2-02: this widget is white-labelled, so the unconfirmed sentence must name the
+// configured agent, not a hardcoded "Jarvis". The caller passes the boot name;
+// "Jarvis" is only the fallback for a workspace that set none.
+test("degradedMessage: the unconfirmed sentence uses the configured agent name", () => {
+  const named = degradedMessage(
+    { ready: false, reason: "readiness_unconfirmed" },
+    "Aria"
+  );
+  assert.match(named, /Aria/);
+  assert.doesNotMatch(named, /Jarvis/);
+  // No name configured -> the fallback brand.
+  assert.match(
+    degradedMessage({ ready: false, reason: "readiness_unconfirmed" }, ""),
+    /Jarvis/
+  );
+  assert.match(
+    degradedMessage({ ready: false, reason: "readiness_unconfirmed" }),
+    /Jarvis/
+  );
+});
+
 // The reason set belongs to account.py. Printing a raw detail for a reason this
 // module does not recognise would leak whatever wording a future backend change
 // happens to attach, into a banner written for a different situation.

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -93,6 +93,25 @@ test("degradedMessage: a suspended subscription gets the renewal line, not the g
   );
 });
 
+// A control-plane outage on a workspace nothing has confirmed yet
+// (account.py::_admin_unreachable_verdict). It used to fall to the generic line,
+// which tells the customer to ask an administrator to finish reconnecting - there
+// is nothing to reconnect and no administrator can help.
+test("degradedMessage: an unconfirmed readiness verdict says retry, not 'ask your administrator'", () => {
+  const generic = degradedMessage({ ready: false, reason: "llm_credentials" });
+  const msg = degradedMessage({ ready: false, reason: "readiness_unconfirmed" });
+  assert.notEqual(msg, generic);
+  assert.match(msg, /try again/i);
+  assert.equal(
+    degradedMessage({
+      ready: false,
+      reason: "readiness_unconfirmed",
+      detail: "We couldn't confirm your workspace is ready yet.",
+    }),
+    "We couldn't confirm your workspace is ready yet."
+  );
+});
+
 // The reason set belongs to account.py. Printing a raw detail for a reason this
 // module does not recognise would leak whatever wording a future backend change
 // happens to attach, into a banner written for a different situation.

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -99,7 +99,10 @@ test("degradedMessage: a suspended subscription gets the renewal line, not the g
 // is nothing to reconnect and no administrator can help.
 test("degradedMessage: an unconfirmed readiness verdict says retry, not 'ask your administrator'", () => {
   const generic = degradedMessage({ ready: false, reason: "llm_credentials" });
-  const msg = degradedMessage({ ready: false, reason: "readiness_unconfirmed" });
+  const msg = degradedMessage({
+    ready: false,
+    reason: "readiness_unconfirmed",
+  });
   assert.notEqual(msg, generic);
   assert.match(msg, /try again/i);
   assert.equal(

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -84,6 +84,13 @@ CONNECTION = ResetSpec(
 	),
 	null=(
 		"last_sync_at",
+		# "this workspace has been chat-Ready" is a claim about the TENANCY that
+		# earned it, and a reset ends that tenancy. Left set, the readiness gate
+		# would keep failing OPEN through the new tenancy's provisioning
+		# (account._has_been_chat_ready) - i.e. the reset site, whose container is
+		# the one thing that definitely is not serving yet, would be the one told
+		# its chat is fine. It re-earns the marker on its first real Ready.
+		"chat_was_ready_at",
 		"agent_token_issued_at",
 		"custom_skills_synced_at",
 		"agent_skills_synced_at",

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -89,8 +89,10 @@ CONNECTION = ResetSpec(
 		# would keep failing OPEN through the new tenancy's provisioning
 		# (account._has_been_chat_ready) - i.e. the reset site, whose container is
 		# the one thing that definitely is not serving yet, would be the one told
-		# its chat is fine. It re-earns the marker on its first real Ready.
+		# its chat is fine. It re-earns the marker on its first real Ready. The
+		# authority the claim was bound to goes with it.
 		"chat_was_ready_at",
+		"chat_ready_authority",
 		"agent_token_issued_at",
 		"custom_skills_synced_at",
 		"agent_skills_synced_at",

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -819,7 +819,12 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		self.assertEqual(out["reason"], "readiness_unconfirmed")
 
 	def test_an_established_workspace_is_unaffected(self):
-		self._write({"chat_was_ready_at": "2026-01-01 00:00:00"})
+		# A genuinely established workspace: the marker AND a matching authority anchor
+		# for the current (real principal, container, generation). setUp already wrote a
+		# REAL admin credential, so the anchor's principal term (F6) is meaningful and
+		# the recomputed anchor on the fail-open path matches the stamped one.
+		anchor = account._authority_anchor(account._settings_raw(account._GATE_STATE_FIELDS))
+		self._write({"chat_was_ready_at": "2026-01-01 00:00:00", "chat_ready_authority": anchor})
 		with patch.object(admin_client, "get_connection", side_effect=Exception("admin 500")):
 			out = account.is_ready_for_chat()
 		self.assertTrue(out["ready"])
@@ -894,7 +899,13 @@ class TestAuthorityAnchorFence(FrappeTestCase):
 		self._snap = account._settings_raw(self._FIELDS)
 
 	def tearDown(self):
+		from jarvis._password_utils import clear_settings_password
+
 		account._bust_chat_gate()
+		# A test may have written a REAL admin credential to __Auth (the F6 principal
+		# fence): drop it so it cannot leak into another test. The column value is
+		# restored from the snapshot below.
+		clear_settings_password(frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key")
 		for f in self._FIELDS:
 			frappe.db.set_value(
 				"Jarvis Settings", "Jarvis Settings", f, self._snap.get(f), update_modified=False
@@ -927,10 +938,23 @@ class TestAuthorityAnchorFence(FrappeTestCase):
 		)
 
 	def test_a_changed_principal_ends_the_claim(self):
-		self._write(agent_url="ws://container-1", jarvis_admin_api_key="key-A-mask")
+		# Production-shaped: the anchor's principal term binds to the REAL admin
+		# credential (F6), so a reconnect that swaps it must end the established claim.
+		# Uses set_settings_password (encrypts into __Auth, masks the column) - NOT a
+		# db_set of a literal, which only ever writes the constant mask production
+		# emits for every principal, so a db_set-based test could not exercise a real
+		# principal change at all.
+		from jarvis._password_utils import set_settings_password
+
+		s = frappe.get_single("Jarvis Settings")
+		set_settings_password(s, "jarvis_admin_api_key", "real-principal-A")
+		self._write(agent_url="ws://container-1")
 		anchor = account._authority_anchor(account._settings_raw(self._FIELDS))
 		self._write(chat_was_ready_at="2026-01-01 00:00:00", chat_ready_authority=anchor)
-		self._write(jarvis_admin_api_key="key-B-mask")  # reconnected to another account
+		# Reconnected to another account: the REAL admin principal changes (same
+		# container, same generation) - the fence must end the claim on this alone.
+		set_settings_password(s, "jarvis_admin_api_key", "real-principal-B")
+		frappe.db.commit()
 		raw = account._settings_raw(account._GATE_STATE_FIELDS)
 		self.assertFalse(account._has_been_chat_ready(raw))
 

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -958,12 +958,15 @@ class TestStructuredNeverPaidCode(FrappeTestCase):
 		return AdminAuthError(message, status_code=status_code, code=code)
 
 	def test_structured_never_paid_code_hard_gates(self):
-		self.assertTrue(account._is_never_paid_403(self._err(code="PENDING_PAYMENT")))
-		self.assertTrue(account._is_never_paid_403(self._err(code="pending_payment")))  # case-insensitive
+		# admin's concrete contract code (jarvis_admin_v2 CustomerNotPaidError).
+		self.assertTrue(account._is_never_paid_403(self._err(code="CUSTOMER_NOT_PAID")))
+		self.assertTrue(account._is_never_paid_403(self._err(code="customer_not_paid")))  # case-insensitive
 
 	def test_an_unrecognised_code_does_not_hard_gate(self):
-		# Cancelled / a proxy code / anything else stays SOFT even on a 403.
+		# Cancelled / a proxy code / the authority-repair refusal / anything else
+		# stays SOFT even on a 403 - only the never-paid code hard-gates.
 		self.assertFalse(account._is_never_paid_403(self._err(code="CANCELLED")))
+		self.assertFalse(account._is_never_paid_403(self._err(code="TENANT_AUTHORITY_REPAIR_REQUIRED")))
 		self.assertFalse(account._is_never_paid_403(self._err(code="SOME_OTHER")))
 
 	def test_prose_fallback_only_when_no_code(self):

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -140,14 +140,28 @@ class TestAccountGatesFailClosed(FrappeTestCase):
 		prev.assert_not_called()
 
 
+def _set_ready_marker(value) -> None:
+	"""Put this site in the ESTABLISHED cohort (a timestamp) or the never-ready
+	one (None). Written raw + update_modified=False, exactly as the gate writes
+	it, so the gate's own revision is unaffected."""
+	frappe.db.set_value(
+		"Jarvis Settings", "Jarvis Settings", "chat_was_ready_at", value, update_modified=False
+	)
+
+
 class TestAdminChatGate(FrappeTestCase):
 	"""jarvis.account._admin_chat_gate — the final managed ready-gate for
-	is_ready_for_chat. Fail-open, v1-tolerant, positive verdict cached ~2 min.
-	admin_client.get_connection is mocked."""
+	is_ready_for_chat. v1-tolerant; positive verdict cached against the config
+	revision. admin_client.get_connection is mocked.
+
+	Every test here pins the ESTABLISHED cohort (chat_was_ready_at set) unless it
+	is specifically about the never-ready one, so a verdict never depends on
+	whatever state the site happens to carry."""
 
 	# The gate now mirrors the release notice onto Jarvis Settings as a side
-	# effect (persist({}) when the mock carries none), so snapshot/restore those
-	# fields to avoid clobbering a real site's operator state.
+	# effect (persist({}) when the mock carries none), and stamps the ready
+	# marker, so snapshot/restore those fields to avoid clobbering a real site's
+	# operator state.
 	_RELEASE_FIELDS = (
 		"release_notice_active",
 		"latest_jarvis_version",
@@ -155,16 +169,24 @@ class TestAdminChatGate(FrappeTestCase):
 	)
 
 	def setUp(self):
-		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+		account._bust_chat_gate()
 		s = frappe.get_single("Jarvis Settings")
 		self._rn_snap = {f: s.get(f) for f in self._RELEASE_FIELDS}
+		self._marker_snap = account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at")
+		_set_ready_marker("2026-01-01 00:00:00")
 
 	def tearDown(self):
-		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+		account._bust_chat_gate()
+		_set_ready_marker(self._marker_snap)
 		s = frappe.get_single("Jarvis Settings")
 		for f, v in self._rn_snap.items():
 			s.db_set(f, v)
 		frappe.db.commit()
+
+	def _cached_verdict(self):
+		"""The live revision's cached entry, or None."""
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		return frappe.cache().get_value(f"{account._CHAT_GATE_CACHE_KEY}:{account._gate_revision(raw)}")
 
 	def test_release_notice_persisted_on_gate(self):
 		# The gate mirrors an active notice so boot can read it; the returned
@@ -253,7 +275,9 @@ class TestAdminChatGate(FrappeTestCase):
 				account._admin_chat_gate(), {"ready": True, "reason": None, "billing_notice": {}}
 			)
 
-	def test_fails_open_on_admin_error(self):
+	def test_established_workspace_fails_open_on_admin_error(self):
+		"""An outage of the control plane is not an outage of the container. A
+		workspace admin has already confirmed Ready keeps its chat."""
 		from jarvis.exceptions import AdminUnreachableError
 
 		with patch.object(
@@ -262,9 +286,63 @@ class TestAdminChatGate(FrappeTestCase):
 			self.assertEqual(
 				account._admin_chat_gate(), {"ready": True, "reason": None, "billing_notice": {}}
 			)
-		# Fail-open verdict must NOT be negative-cached: a recovered admin is
-		# re-probed on the next call rather than being blocked for the TTL.
-		self.assertIsNone(frappe.cache().get_value(account._CHAT_GATE_CACHE_KEY))
+		# Fail-open verdict must NOT be cached: a recovered admin is re-probed on
+		# the next call rather than this shrug standing in for a verdict.
+		self.assertIsNone(self._cached_verdict())
+
+	def test_never_ready_workspace_fails_closed_on_admin_error(self):
+		"""The inversion of the old blanket fail-open. Nothing has ever confirmed a
+		container is serving this workspace, so "probably fine" is a guess - and
+		acting on it is what drops a half-onboarded customer into a chat that
+		cannot answer. Retryable: it is the absence of a verdict, not one."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		_set_ready_marker(None)
+		with patch.object(
+			admin_client, "get_connection", side_effect=AdminUnreachableError("admin is unreachable")
+		):
+			out = account._admin_chat_gate()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "readiness_unconfirmed")
+		self.assertTrue(out["retryable"])
+		self.assertTrue(out["detail"], "the customer must be told something they can act on")
+		# Still never negative-cached: the very next call re-asks.
+		self.assertIsNone(self._cached_verdict())
+
+	def test_pending_payment_403_is_not_a_blind_ready(self):
+		"""jarvis_admin_v2.api._auth.current_customer answers a Pending Payment
+		customer with 403, so this gate NEVER hears "not ready" for them - it hears
+		an exception. The old code shrugged that off as ready."""
+		from jarvis.exceptions import AdminAuthError
+
+		_set_ready_marker(None)
+		with patch.object(
+			admin_client, "get_connection", side_effect=AdminAuthError("admin returned 403", status_code=403)
+		):
+			out = account._admin_chat_gate()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "readiness_unconfirmed")
+
+	def test_ready_stamps_the_established_marker(self):
+		_set_ready_marker(None)
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
+			account._admin_chat_gate()
+		self.assertTrue(account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at"))
+
+	def test_a_fresh_marker_is_not_rewritten_on_every_pass(self):
+		"""The gate runs on every uncached page load; the marker is only ever read
+		as "is it set", so re-stamping it would be a DB write per load for nothing."""
+		fresh = frappe.utils.now()
+		_set_ready_marker(fresh)
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
+			account._admin_chat_gate()
+		self.assertEqual(account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at"), fresh)
+
+	def test_a_blocking_verdict_still_wins_over_the_cohort(self):
+		"""Cohort only decides what to do when admin cannot be ASKED. An answer of
+		"Suspended" is an answer, and an established workspace gets it."""
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}):
+			self.assertEqual(account._admin_chat_gate()["reason"], "subscription_suspended")
 
 	def test_billing_notice_is_passed_through(self):
 		# The expiry banner rides this verdict; admin owns the wording, the gate
@@ -276,7 +354,7 @@ class TestAdminChatGate(FrappeTestCase):
 			return_value={"chat_readiness": "Ready", "billing_notice": notice},
 		):
 			self.assertEqual(account._admin_chat_gate()["billing_notice"], notice)
-		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+		account._bust_chat_gate()
 		with patch.object(
 			admin_client,
 			"get_connection",
@@ -295,7 +373,93 @@ class TestAdminChatGate(FrappeTestCase):
 		# A transient block must clear on the next call, not stick for the TTL.
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Provisioning"}):
 			account._admin_chat_gate()
-		self.assertIsNone(frappe.cache().get_value(account._CHAT_GATE_CACHE_KEY))
+		self.assertIsNone(self._cached_verdict())
+
+	def test_a_config_change_drops_the_cached_verdict(self):
+		"""The C05-1 stale window: a save changed what the container is being asked
+		to run, so the verdict admin gave about the PREVIOUS config is finished -
+		it must not be served for the rest of the TTL.
+
+		The new status is unique per run rather than a literal: this site may
+		already be sitting on any given status string, and an unchanged value is
+		correctly NOT a new revision."""
+		status_snap = account._settings_raw(("last_sync_status",)).get("last_sync_status")
+		try:
+			with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}) as gc:
+				account._admin_chat_gate()
+				frappe.db.set_value(
+					"Jarvis Settings",
+					"Jarvis Settings",
+					"last_sync_status",
+					f"pending: admin applying config ({frappe.generate_hash(length=8)})",
+					update_modified=False,
+				)
+				account._admin_chat_gate()
+			self.assertEqual(gc.call_count, 2, "a config change must force a fresh admin verdict")
+		finally:
+			frappe.db.set_value(
+				"Jarvis Settings", "Jarvis Settings", "last_sync_status", status_snap, update_modified=False
+			)
+
+	def test_an_unchanged_config_keeps_serving_the_cached_verdict(self):
+		"""The other half: rewriting the same values is not a new configuration, and
+		must not cost an admin round-trip per page load."""
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}) as gc:
+			account._admin_chat_gate()
+			raw = account._settings_raw(account._GATE_STATE_FIELDS)
+			frappe.db.set_value(
+				"Jarvis Settings",
+				"Jarvis Settings",
+				"last_sync_status",
+				raw.get("last_sync_status"),
+				update_modified=False,
+			)
+			account._admin_chat_gate()
+		gc.assert_called_once()
+
+	def test_every_revision_is_dropped_by_a_bust(self):
+		"""_bust_chat_gate is called after a save has ALREADY moved the revision, so
+		deleting only the revision it can compute would miss the live entry."""
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}) as gc:
+			account._admin_chat_gate()
+			account._bust_chat_gate()
+			account._admin_chat_gate()
+		self.assertEqual(gc.call_count, 2)
+
+	def test_the_revision_reads_an_empty_datetime_marker_as_unset(self):
+		"""Regression pin for the read itself. frappe.db.get_value /
+		get_single_value cast an empty Datetime single to datetime(1, 1, 1) —
+		TRUTHY — which would have put every workspace that has merely SAVED its
+		settings into the established cohort and quietly restored the fail-open the
+		gate exists to remove."""
+		frappe.db.sql(
+			"""delete from `tabSingles` where doctype=%s and `field`=%s""",
+			("Jarvis Settings", "chat_was_ready_at"),
+		)
+		frappe.db.sql(
+			"""insert into `tabSingles` (doctype, `field`, `value`) values (%s,%s,%s)""",
+			("Jarvis Settings", "chat_was_ready_at", None),
+		)
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		self.assertIsNone(raw.get("chat_was_ready_at"))
+		self.assertFalse(account._has_been_chat_ready(raw))
+		self.assertTrue(
+			frappe.db.get_value("Jarvis Settings", "Jarvis Settings", ["chat_was_ready_at"], as_dict=True)[
+				"chat_was_ready_at"
+			],
+			"if this ever reads falsy the cast changed and the raw read can be simplified",
+		)
+
+	def test_an_established_workspace_needs_its_admin_credentials_too(self):
+		"""The marker on its own would protect a workspace whose connection was torn
+		down - the one workspace whose chat provably cannot work."""
+		self.assertFalse(account._has_been_chat_ready({"chat_was_ready_at": "2026-01-01 00:00:00"}))
+		self.assertFalse(account._has_been_chat_ready({"jarvis_admin_api_key": "**********"}))
+		self.assertTrue(
+			account._has_been_chat_ready(
+				{"chat_was_ready_at": "2026-01-01 00:00:00", "jarvis_admin_api_key": "**********"}
+			)
+		)
 
 
 class TestLlmMissingVerdict(FrappeTestCase):
@@ -346,6 +510,33 @@ class TestLlmMissingVerdict(FrappeTestCase):
 		out, _ = self._verdict(self._S(), conn={})
 		self.assertEqual(out["reason"], "llm_credentials")
 
+	def test_a_403_hard_gates_the_never_synced_workspace(self):
+		"""The dead-code fix. get_connection 403s every un-paid customer state
+		(jarvis_admin_v2.api._auth.current_customer, allow_pending False), so the
+		Pending Payment customer this hard gate was written for never reached it -
+		they took the generic "admin unknown" path and landed in the chat app.
+
+		Reachable only past never_synced, so no established workspace can hit it."""
+		from jarvis.exceptions import AdminAuthError
+
+		out, _ = self._verdict(self._S(), raises=AdminAuthError("admin returned 403", status_code=403))
+		self.assertEqual(out["reason"], "llm_setup")
+
+	def test_a_401_is_still_treated_as_unknown(self):
+		"""401 is a stale/rotated token - a bench problem, not a statement about the
+		customer's subscription. It must not hard-gate anyone to the wizard."""
+		from jarvis.exceptions import AdminAuthError
+
+		out, _ = self._verdict(self._S(), raises=AdminAuthError("admin returned 401", status_code=401))
+		self.assertEqual(out["reason"], "llm_credentials")
+
+	def test_an_established_workspace_never_reaches_the_403_branch(self):
+		s = self._S()
+		s.llm_direct_synced_at = "2026-01-01 00:00:00"
+		out, gc = self._verdict(s, raises=AdminValidationError("should not be called"))
+		self.assertEqual(out["reason"], "llm_credentials")
+		gc.assert_not_called()
+
 
 class TestReplacedSiteIsExplained(FrappeTestCase):
 	"""A site whose account was reconnected elsewhere can no longer authenticate.
@@ -354,11 +545,16 @@ class TestReplacedSiteIsExplained(FrappeTestCase):
 
 	def setUp(self):
 		frappe.cache().delete_value(account._REPLACED_CACHE_KEY)
-		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+		account._bust_chat_gate()
+		# The two "still fails open" cases below are about the ESTABLISHED cohort -
+		# pin it rather than inherit whatever this site happens to be.
+		self._marker_snap = account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at")
+		_set_ready_marker("2026-01-01 00:00:00")
 
 	def tearDown(self):
 		frappe.cache().delete_value(account._REPLACED_CACHE_KEY)
-		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+		account._bust_chat_gate()
+		_set_ready_marker(self._marker_snap)
 
 	def test_an_auth_failure_on_a_replaced_site_explains_itself(self):
 		with (
@@ -388,7 +584,7 @@ class TestReplacedSiteIsExplained(FrappeTestCase):
 			patch.object(account.admin_client, "site_replacement", return_value={"replaced": True}) as probe,
 		):
 			account._admin_chat_gate()
-			frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+			account._bust_chat_gate()
 			account._admin_chat_gate()
 		self.assertEqual(probe.call_count, 1)
 
@@ -399,3 +595,67 @@ class TestReplacedSiteIsExplained(FrappeTestCase):
 		):
 			out = account._admin_chat_gate()
 		self.assertTrue(out["ready"], "cannot prove a replacement, so do not invent one")
+
+	def test_a_replacement_probe_still_wins_on_a_never_ready_site(self):
+		"""site_replaced names a specific, actionable state. The onboarding-stage
+		fallback must not swallow it - it is checked first for both cohorts."""
+		_set_ready_marker(None)
+		with (
+			patch.object(account.admin_client, "get_connection", side_effect=Exception("401")),
+			patch.object(
+				account.admin_client, "site_replacement", return_value={"replaced": True, "moved_to": "x"}
+			),
+		):
+			out = account._admin_chat_gate()
+		self.assertEqual(out["reason"], "site_replaced")
+
+
+class TestIsReadyForChatCohorts(FrappeTestCase):
+	"""is_ready_for_chat end to end (its managed ready-exit), not just the gate:
+	the reason the customer's browser actually receives when the control plane
+	cannot be asked.
+
+	The workspace is pinned onto the subscription/oauth leg (connected marker set,
+	pool mode off) so the run reaches _admin_chat_gate deterministically instead of
+	depending on whatever this site's LLM config happens to be."""
+
+	_FIELDS = ("llm_auth_mode", "llm_oauth_connected_at", "chat_was_ready_at")
+
+	def setUp(self):
+		account._bust_chat_gate()
+		self._snap = account._settings_raw(self._FIELDS)
+		self._write(
+			{
+				"llm_auth_mode": "subscription",
+				"llm_oauth_connected_at": "2026-01-01 00:00:00",
+				"chat_was_ready_at": None,
+			}
+		)
+		self._pool_off = patch.object(account, "compute_pool_mode", return_value=False)
+		self._pool_off.start()
+
+	def tearDown(self):
+		self._pool_off.stop()
+		self._write({f: self._snap.get(f) for f in self._FIELDS})
+		account._bust_chat_gate()
+
+	def _write(self, values: dict) -> None:
+		for f, v in values.items():
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v, update_modified=False)
+
+	def test_a_never_ready_workspace_is_not_told_it_is_ready(self):
+		with patch.object(admin_client, "get_connection", side_effect=Exception("admin 500")):
+			out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"], "plan 05's whole premise: this cannot be labelled ready")
+		self.assertEqual(out["reason"], "readiness_unconfirmed")
+
+	def test_an_established_workspace_is_unaffected(self):
+		self._write({"chat_was_ready_at": "2026-01-01 00:00:00"})
+		with patch.object(admin_client, "get_connection", side_effect=Exception("admin 500")):
+			out = account.is_ready_for_chat()
+		self.assertTrue(out["ready"])
+
+	def test_the_happy_path_is_unchanged(self):
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
+			out = account.is_ready_for_chat()
+		self.assertEqual(out, {"ready": True, "reason": None, "billing_notice": {}})

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -828,3 +828,279 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
 			out = account.is_ready_for_chat()
 		self.assertEqual(out, {"ready": True, "reason": None, "billing_notice": {}})
+
+
+class TestExplicitReadyOnlyMarker(FrappeTestCase):
+	"""Review P0-07: only an EXPLICIT admin `Ready` may mint the established marker.
+	A reachable response that never mentions chat_readiness (v1 tolerance) still
+	ALLOWS this page load, but must not promote the workspace into the cohort whose
+	chat survives an outage."""
+
+	def setUp(self):
+		account._bust_chat_gate()
+		self._key_snap = _set_stored_connection(True)
+		self._marker_snap = account._settings_raw((account._READY_MARKER_FIELD,)).get(
+			account._READY_MARKER_FIELD
+		)
+		_set_ready_marker(None)
+
+	def tearDown(self):
+		account._bust_chat_gate()
+		_set_ready_marker(self._marker_snap)
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	def test_missing_chat_readiness_allows_but_does_not_mint_the_marker(self):
+		with patch.object(
+			admin_client, "get_connection", return_value={"agent_url": "ws://x", "tenant_status": "running"}
+		):
+			out = account._admin_chat_gate()
+		self.assertTrue(out["ready"], "v1-tolerance still allows the page load")
+		self.assertFalse(
+			account._settings_raw((account._READY_MARKER_FIELD,)).get(account._READY_MARKER_FIELD),
+			"a response that never said Ready must not earn the established marker (P0-07)",
+		)
+
+	def test_explicit_ready_mints_the_marker(self):
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
+			account._admin_chat_gate()
+		self.assertTrue(
+			account._settings_raw((account._READY_MARKER_FIELD,)).get(account._READY_MARKER_FIELD),
+			"an explicit Ready earns the marker",
+		)
+
+
+class TestAuthorityAnchorFence(FrappeTestCase):
+	"""Review P0-06 / §8.6: the established claim is bound to (principal, container,
+	generation). It survives an outage only while that authority is still current;
+	when it moves, the claim ends mechanically - no writer has to remember to clear
+	the marker."""
+
+	_FIELDS = (
+		account._READY_MARKER_FIELD,
+		account._READY_ANCHOR_FIELD,
+		"agent_url",
+		"jarvis_admin_api_key",
+	)
+
+	def setUp(self):
+		account._bust_chat_gate()
+		self._snap = account._settings_raw(self._FIELDS)
+
+	def tearDown(self):
+		account._bust_chat_gate()
+		for f in self._FIELDS:
+			frappe.db.set_value(
+				"Jarvis Settings", "Jarvis Settings", f, self._snap.get(f), update_modified=False
+			)
+		frappe.db.commit()
+
+	def _write(self, **vals):
+		for f, v in vals.items():
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v, update_modified=False)
+		frappe.db.commit()
+
+	def test_a_matching_anchor_keeps_the_workspace_established(self):
+		self._write(agent_url="ws://container-1", jarvis_admin_api_key="**********")
+		raw = account._settings_raw(self._FIELDS)
+		anchor = account._authority_anchor(raw)
+		self._write(chat_was_ready_at="2026-01-01 00:00:00", chat_ready_authority=anchor)
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		self.assertTrue(account._has_been_chat_ready(raw), "an unchanged authority keeps the claim")
+
+	def test_a_moved_container_ends_the_claim(self):
+		self._write(agent_url="ws://container-1", jarvis_admin_api_key="**********")
+		anchor = account._authority_anchor(account._settings_raw(self._FIELDS))
+		self._write(chat_was_ready_at="2026-01-01 00:00:00", chat_ready_authority=anchor)
+		# The container is replaced: same marker + admin key, different agent_url.
+		self._write(agent_url="ws://container-2")
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		self.assertFalse(
+			account._has_been_chat_ready(raw),
+			"a marker bound to the old container must not carry to a new one",
+		)
+
+	def test_a_changed_principal_ends_the_claim(self):
+		self._write(agent_url="ws://container-1", jarvis_admin_api_key="key-A-mask")
+		anchor = account._authority_anchor(account._settings_raw(self._FIELDS))
+		self._write(chat_was_ready_at="2026-01-01 00:00:00", chat_ready_authority=anchor)
+		self._write(jarvis_admin_api_key="key-B-mask")  # reconnected to another account
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		self.assertFalse(account._has_been_chat_ready(raw))
+
+	def test_a_legacy_marker_with_no_anchor_honours_the_presence_rule(self):
+		# A pre-fence / backfilled claim carries no anchor; it must not be ejected
+		# wholesale on upgrade - the explicit reset/reconnect clears still end it.
+		self._write(
+			agent_url="ws://container-1",
+			jarvis_admin_api_key="**********",
+			chat_was_ready_at="2026-01-01 00:00:00",
+			chat_ready_authority="",
+		)
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		self.assertTrue(account._has_been_chat_ready(raw))
+
+
+class TestStructuredNeverPaidCode(FrappeTestCase):
+	"""Review P0-05: the never-paid gate reads admin's STRUCTURED code first, so a
+	hardened control plane that omits the human sentence is still classified. The
+	prose markers remain only as old-admin fallback."""
+
+	def _err(self, *, status_code=403, code="", message=""):
+		from jarvis.exceptions import AdminAuthError
+
+		return AdminAuthError(message, status_code=status_code, code=code)
+
+	def test_structured_never_paid_code_hard_gates(self):
+		self.assertTrue(account._is_never_paid_403(self._err(code="PENDING_PAYMENT")))
+		self.assertTrue(account._is_never_paid_403(self._err(code="pending_payment")))  # case-insensitive
+
+	def test_an_unrecognised_code_does_not_hard_gate(self):
+		# Cancelled / a proxy code / anything else stays SOFT even on a 403.
+		self.assertFalse(account._is_never_paid_403(self._err(code="CANCELLED")))
+		self.assertFalse(account._is_never_paid_403(self._err(code="SOME_OTHER")))
+
+	def test_prose_fallback_only_when_no_code(self):
+		self.assertTrue(
+			account._is_never_paid_403(self._err(message="Customer status: Pending Payment")),
+			"old admin with no code still matches on the sentence",
+		)
+		# A structured code that is NOT never-paid must WIN over never-paid-looking
+		# prose: the code is the authority once present.
+		self.assertFalse(
+			account._is_never_paid_403(
+				self._err(code="CANCELLED", message="customer status: pending payment")
+			)
+		)
+
+	def test_a_non_403_is_never_a_never_paid(self):
+		self.assertFalse(account._is_never_paid_403(self._err(status_code=401, code="PENDING_PAYMENT")))
+
+
+class TestDiagnosticClass(FrappeTestCase):
+	"""Review P1-08: a readiness_unconfirmed verdict carries a safe structured
+	diagnostic code + retryability, so the SPA can tell a transient outage (retry)
+	from an authorization denial (act) without seeing admin's raw exception text."""
+
+	def setUp(self):
+		account._bust_chat_gate()
+		self._key_snap = _set_stored_connection(True)
+		self._marker_snap = account._settings_raw((account._READY_MARKER_FIELD,)).get(
+			account._READY_MARKER_FIELD
+		)
+		_set_ready_marker(None)  # never-ready cohort, so the outage fails closed
+
+	def tearDown(self):
+		account._bust_chat_gate()
+		_set_ready_marker(self._marker_snap)
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	def test_transport_outage_is_retryable(self):
+		from jarvis.exceptions import AdminUnreachableError
+
+		with patch.object(admin_client, "get_connection", side_effect=AdminUnreachableError("down")):
+			out = account._admin_chat_gate()
+		self.assertEqual(out["diag_code"], "admin_unreachable")
+		self.assertTrue(out["retryable"])
+
+	def test_a_403_denial_is_not_retryable(self):
+		from jarvis.exceptions import AdminAuthError
+
+		with patch.object(
+			admin_client, "get_connection", side_effect=AdminAuthError("denied", status_code=403)
+		):
+			out = account._admin_chat_gate()
+		self.assertEqual(out["diag_code"], "admin_forbidden")
+		self.assertFalse(out["retryable"])
+
+	def test_the_cached_verdict_carries_the_same_diagnostic(self):
+		from jarvis.exceptions import AdminUnreachableError
+
+		with patch.object(admin_client, "get_connection", side_effect=AdminUnreachableError("down")) as gc:
+			first = account._admin_chat_gate()
+			second = account._admin_chat_gate()
+		gc.assert_called_once()  # second served from the short unconfirmed cache
+		self.assertEqual(first, second, "a polling wizard must get an identical verdict each beat")
+
+
+class TestBackfillExcludesOauthPushOnly(FrappeTestCase):
+	"""Review P0-07: the v2_10 backfill grandfathers ONLY confirmed-apply evidence.
+	llm_oauth_connected_at is a push, not a confirmation, so a workspace whose only
+	evidence is an OAuth push must NOT be manufactured into the established cohort."""
+
+	_FIELDS = (
+		"chat_was_ready_at",
+		"chat_ready_authority",
+		"llm_pool_synced_at",
+		"llm_direct_synced_at",
+		"llm_oauth_connected_at",
+		"agent_url",
+		"jarvis_admin_api_key",
+	)
+
+	def setUp(self):
+		self._snap = account._settings_raw(self._FIELDS)
+		self._key_snap = frappe.get_single("Jarvis Settings").get_password(
+			"jarvis_admin_api_key", raise_exception=False
+		)
+
+	def tearDown(self):
+		for f in self._FIELDS:
+			frappe.db.set_value(
+				"Jarvis Settings", "Jarvis Settings", f, self._snap.get(f), update_modified=False
+			)
+		from jarvis._password_utils import clear_settings_password, set_settings_password
+
+		s = frappe.get_single("Jarvis Settings")
+		# _reset writes a real encrypted key; restore the ORIGINAL (or clear it, so a
+		# site that had none is left with none - otherwise the leaked __Auth row makes
+		# get_password read onboarded for the next test).
+		if self._key_snap:
+			set_settings_password(s, "jarvis_admin_api_key", self._key_snap)
+		else:
+			clear_settings_password(s, "jarvis_admin_api_key")
+		frappe.db.commit()
+
+	def _reset(self, **vals):
+		base = dict.fromkeys(self._FIELDS[:-1], None)
+		base.update(vals)
+		for f, v in base.items():
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v, update_modified=False)
+		from jarvis._password_utils import set_settings_password
+
+		set_settings_password(
+			frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key", "backfill-test-key"
+		)
+		frappe.db.commit()
+
+	def test_oauth_push_only_is_not_grandfathered(self):
+		from jarvis.patches.v2_10_backfill_chat_was_ready_at import execute
+
+		self._reset(llm_oauth_connected_at="2026-01-01 00:00:00")
+		execute()
+		self.assertFalse(
+			account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at"),
+			"an OAuth push alone is not a confirmed apply and must not mint the marker",
+		)
+
+	def test_confirmed_apply_is_grandfathered_and_anchor_bound(self):
+		from jarvis.patches.v2_10_backfill_chat_was_ready_at import execute
+
+		self._reset(llm_direct_synced_at="2026-01-01 00:00:00", agent_url="ws://c1")
+		execute()
+		raw = account._settings_raw(("chat_was_ready_at", account._READY_ANCHOR_FIELD))
+		self.assertTrue(raw.get("chat_was_ready_at"), "a confirmed direct apply is grandfathered")
+		self.assertTrue(raw.get(account._READY_ANCHOR_FIELD), "the grandfathered claim is anchor-bound")

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -149,6 +149,24 @@ def _set_ready_marker(value) -> None:
 	)
 
 
+def _set_stored_connection(present: bool):
+	"""The other half of "established": _has_been_chat_ready reads the RAW
+	jarvis_admin_api_key column (a mask, never the secret - see
+	jarvis/_password_utils.py), so a test that wants a cohort must say which,
+	rather than inherit whatever this site's onboarding state happens to be.
+
+	Returns the previous raw value so the caller can put it back."""
+	prior = account._settings_raw(("jarvis_admin_api_key",)).get("jarvis_admin_api_key")
+	frappe.db.set_value(
+		"Jarvis Settings",
+		"Jarvis Settings",
+		"jarvis_admin_api_key",
+		"*" * 10 if present else "",
+		update_modified=False,
+	)
+	return prior
+
+
 class TestAdminChatGate(FrappeTestCase):
 	"""jarvis.account._admin_chat_gate — the final managed ready-gate for
 	is_ready_for_chat. v1-tolerant; positive verdict cached against the config
@@ -173,11 +191,19 @@ class TestAdminChatGate(FrappeTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		self._rn_snap = {f: s.get(f) for f in self._RELEASE_FIELDS}
 		self._marker_snap = account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at")
+		self._key_snap = _set_stored_connection(True)
 		_set_ready_marker("2026-01-01 00:00:00")
 
 	def tearDown(self):
 		account._bust_chat_gate()
 		_set_ready_marker(self._marker_snap)
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
 		s = frappe.get_single("Jarvis Settings")
 		for f, v in self._rn_snap.items():
 			s.db_set(f, v)
@@ -306,7 +332,46 @@ class TestAdminChatGate(FrappeTestCase):
 		self.assertEqual(out["reason"], "readiness_unconfirmed")
 		self.assertTrue(out["retryable"])
 		self.assertTrue(out["detail"], "the customer must be told something they can act on")
-		# Still never negative-cached: the very next call re-asks.
+
+	def test_the_unconfirmed_verdict_is_briefly_cached(self):
+		"""The wizard polls this every 2.5s. Re-asking a control plane that is
+		already failing, once per beat per open tab, is how a bench turns an outage
+		into a second one - so the UNCONFIRMED code (and only it) gets a few
+		seconds. The verdict served from that entry is identical."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		_set_ready_marker(None)
+		with patch.object(
+			admin_client, "get_connection", side_effect=AdminUnreachableError("admin is unreachable")
+		) as gc:
+			first = account._admin_chat_gate()
+			second = account._admin_chat_gate()
+		gc.assert_called_once()
+		self.assertEqual(first, second)
+		self.assertLessEqual(account._UNCONFIRMED_CACHE_TTL_S, 10, "'retryable' has to stay true")
+
+	def test_the_cached_unconfirmed_entry_re_derives_the_cohort(self):
+		"""Only the FACT of the outage is cached, never the cohort decision: a
+		workspace that becomes established inside the window is answered as one."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		_set_ready_marker(None)
+		with patch.object(
+			admin_client, "get_connection", side_effect=AdminUnreachableError("admin is unreachable")
+		):
+			self.assertFalse(account._admin_chat_gate()["ready"])
+			_set_ready_marker("2026-01-01 00:00:00")
+			self.assertTrue(account._admin_chat_gate()["ready"])
+
+	def test_a_rendered_not_ready_verdict_is_still_never_cached(self):
+		"""The short cache is for "nobody answered", not for an answer. A container
+		that finishes provisioning must be seen on the next call, not in 5s."""
+		with patch.object(
+			admin_client, "get_connection", return_value={"chat_readiness": "Provisioning"}
+		) as gc:
+			account._admin_chat_gate()
+			account._admin_chat_gate()
+		self.assertEqual(gc.call_count, 2)
 		self.assertIsNone(self._cached_verdict())
 
 	def test_pending_payment_403_is_not_a_blind_ready(self):
@@ -510,24 +575,53 @@ class TestLlmMissingVerdict(FrappeTestCase):
 		out, _ = self._verdict(self._S(), conn={})
 		self.assertEqual(out["reason"], "llm_credentials")
 
-	def test_a_403_hard_gates_the_never_synced_workspace(self):
-		"""The dead-code fix. get_connection 403s every un-paid customer state
-		(jarvis_admin_v2.api._auth.current_customer, allow_pending False), so the
-		Pending Payment customer this hard gate was written for never reached it -
-		they took the generic "admin unknown" path and landed in the chat app.
-
-		Reachable only past never_synced, so no established workspace can hit it."""
+	def _auth_error(self, message, status_code=403):
 		from jarvis.exceptions import AdminAuthError
 
-		out, _ = self._verdict(self._S(), raises=AdminAuthError("admin returned 403", status_code=403))
-		self.assertEqual(out["reason"], "llm_setup")
+		return AdminAuthError(message, status_code=status_code)
+
+	def test_a_403_naming_a_never_paid_state_hard_gates(self):
+		"""The dead-code fix. get_connection 403s an unpaid customer at
+		jarvis_admin_v2.api._auth.current_customer (allow_pending False) instead of
+		answering with a subscription_status, so the Pending Payment customer this
+		hard gate was written for never reached it - they took the generic "admin
+		unknown" path and landed in the chat app.
+
+		Reachable only past never_synced, so no established workspace can hit it."""
+		for message in (
+			"customer status: Pending Payment",
+			"customer status: Pending Verification",
+			"not a Jarvis Customer",
+		):
+			with self.subTest(message=message):
+				out, _ = self._verdict(self._S(), raises=self._auth_error(message))
+				self.assertEqual(out["reason"], "llm_setup")
+
+	def test_a_cancelled_customer_stays_soft(self):
+		"""Cancelled is an ENDED account, not a half-finished signup: the renew
+		banner owns it, and the wizard would dead-end it at signup's duplicate
+		guard. Hard-gating would also take /billing - the one page that can fix
+		it - away from them."""
+		out, _ = self._verdict(self._S(), raises=self._auth_error("customer status: Cancelled"))
+		self.assertEqual(out["reason"], "llm_credentials")
+
+	def test_an_anonymous_403_stays_soft(self):
+		"""A 403 with no body of admin's - a proxy, a WAF, a hardened control plane
+		that ships exc_type without the sentence - is not evidence of anything about
+		this customer. Guessing "never paid" from it would lock an Active customer
+		out of chat on an infrastructure hiccup."""
+		for message in ("admin returned 403", "PermissionError", "", "<html>403 Forbidden</html>"):
+			with self.subTest(message=message):
+				out, _ = self._verdict(self._S(), raises=self._auth_error(message))
+				self.assertEqual(out["reason"], "llm_credentials")
 
 	def test_a_401_is_still_treated_as_unknown(self):
 		"""401 is a stale/rotated token - a bench problem, not a statement about the
-		customer's subscription. It must not hard-gate anyone to the wizard."""
-		from jarvis.exceptions import AdminAuthError
-
-		out, _ = self._verdict(self._S(), raises=AdminAuthError("admin returned 401", status_code=401))
+		customer's subscription. It must not hard-gate anyone to the wizard, even
+		carrying words that would qualify on a 403."""
+		out, _ = self._verdict(
+			self._S(), raises=self._auth_error("customer status: Pending Payment", status_code=401)
+		)
 		self.assertEqual(out["reason"], "llm_credentials")
 
 	def test_an_established_workspace_never_reaches_the_403_branch(self):
@@ -549,12 +643,20 @@ class TestReplacedSiteIsExplained(FrappeTestCase):
 		# The two "still fails open" cases below are about the ESTABLISHED cohort -
 		# pin it rather than inherit whatever this site happens to be.
 		self._marker_snap = account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at")
+		self._key_snap = _set_stored_connection(True)
 		_set_ready_marker("2026-01-01 00:00:00")
 
 	def tearDown(self):
 		frappe.cache().delete_value(account._REPLACED_CACHE_KEY)
 		account._bust_chat_gate()
 		_set_ready_marker(self._marker_snap)
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
 
 	def test_an_auth_failure_on_a_replaced_site_explains_itself(self):
 		with (
@@ -610,6 +712,54 @@ class TestReplacedSiteIsExplained(FrappeTestCase):
 		self.assertEqual(out["reason"], "site_replaced")
 
 
+class TestResetEndsTheEstablishedClaim(FrappeTestCase):
+	"""chat_was_ready_at is a claim about the TENANCY that earned it. A reset ends
+	that tenancy, so the marker has to go with it - otherwise the site whose
+	container is most certainly not serving yet is the one whose chat is held open
+	through an outage."""
+
+	def setUp(self):
+		account._bust_chat_gate()
+		self._marker_snap = account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at")
+		self._key_snap = _set_stored_connection(True)
+
+	def tearDown(self):
+		_set_ready_marker(self._marker_snap)
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
+		account._bust_chat_gate()
+
+	def test_the_marker_is_in_the_connection_reset_spec(self):
+		"""That settings_reset.apply actually NULLs every field in ``null`` is
+		covered generically by test_dev's reset harness, which plants a value in
+		each and asserts it comes back NULL. Running a real CONNECTION reset from
+		here instead would tear this site's credentials down for whatever runs
+		next - the reset is deliberately not transactional about __Auth."""
+		from jarvis import settings_reset
+
+		self.assertIn("chat_was_ready_at", settings_reset.CONNECTION.null)
+		self.assertIn("chat_was_ready_at", settings_reset.FULL.null)
+
+	def test_a_reconnected_site_fails_closed_until_it_earns_a_new_ready(self):
+		"""Why the marker has to be in that spec: the reconnect writes a fresh admin
+		key within seconds, so the "stored connection" half of _has_been_chat_ready
+		is satisfied again immediately. Only clearing the marker keeps the NEW
+		tenancy - whose container is the one thing definitely not serving yet - in
+		the onboarding-stage cohort."""
+		_set_ready_marker(None)  # what the reset leaves behind
+		_set_stored_connection(True)  # what the reconnect writes back
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		self.assertFalse(account._has_been_chat_ready(raw))
+		with patch.object(admin_client, "get_connection", side_effect=Exception("admin 500")):
+			out = account._admin_chat_gate()
+		self.assertEqual(out["reason"], "readiness_unconfirmed")
+
+
 class TestIsReadyForChatCohorts(FrappeTestCase):
 	"""is_ready_for_chat end to end (its managed ready-exit), not just the gate:
 	the reason the customer's browser actually receives when the control plane
@@ -617,13 +767,22 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 
 	The workspace is pinned onto the subscription/oauth leg (connected marker set,
 	pool mode off) so the run reaches _admin_chat_gate deterministically instead of
-	depending on whatever this site's LLM config happens to be."""
+	depending on whatever this site's LLM config happens to be. is_ready_for_chat
+	reads the admin key through get_password, so this class provisions a real
+	encrypted one for the duration rather than the raw mask the gate-level tests
+	use."""
 
 	_FIELDS = ("llm_auth_mode", "llm_oauth_connected_at", "chat_was_ready_at")
 
 	def setUp(self):
+		from jarvis._password_utils import set_settings_password
+
 		account._bust_chat_gate()
 		self._snap = account._settings_raw(self._FIELDS)
+		self._key_snap = account._settings_raw(("jarvis_admin_api_key",)).get("jarvis_admin_api_key")
+		set_settings_password(
+			frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key", "test-only-readiness-key"
+		)
 		self._write(
 			{
 				"llm_auth_mode": "subscription",
@@ -635,8 +794,18 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		self._pool_off.start()
 
 	def tearDown(self):
+		from jarvis._password_utils import clear_settings_password
+
 		self._pool_off.stop()
+		clear_settings_password(frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key")
 		self._write({f: self._snap.get(f) for f in self._FIELDS})
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
 		account._bust_chat_gate()
 
 	def _write(self, values: dict) -> None:

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1593,8 +1593,15 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
 
 	def test_api_key_onboarding_leaves_is_ready_for_chat_passing(self):
 		"""is_ready_for_chat must return ready=True after a successful (confirmed,
-		status=applied) api_key onboarding via save_llm_creds."""
+		status=applied) api_key onboarding via save_llm_creds AND an explicit admin
+		Ready verdict. A first-onboarding workspace has no established history, so
+		the final managed gate really does ask admin - the test supplies the
+		explicit Ready it needs and then proves that Ready earned the marker (D1
+		cohort proof), rather than leaning on a fail-open the never-ready cohort no
+		longer gets."""
 		from unittest.mock import patch
+
+		from jarvis import account
 
 		with patch(
 			"jarvis.admin_client.post_update_llm_creds",
@@ -1612,7 +1619,15 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
 
 		from jarvis.account import is_ready_for_chat
 
-		result = is_ready_for_chat()
+		# Fresh onboarding: nothing has confirmed this workspace before, so clear any
+		# leftover marker and require admin to say Ready explicitly.
+		frappe.db.set_value(
+			"Jarvis Settings", "Jarvis Settings", "chat_was_ready_at", None, update_modified=False
+		)
+		frappe.db.commit()
+		account._bust_chat_gate()
+		with patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}):
+			result = is_ready_for_chat()
 		self.assertTrue(
 			result.get("ready"),
 			f"is_ready_for_chat must return ready=True after api_key onboarding; got: {result}",
@@ -1620,6 +1635,11 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
 		self.assertIsNone(
 			result.get("reason"), f"reason must be None when ready; got: {result.get('reason')!r}"
 		)
+		self.assertTrue(
+			account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at"),
+			"an explicit admin Ready must earn the established marker",
+		)
+		account._bust_chat_gate()
 
 	def test_api_key_first_apply_still_applying_is_not_ready(self):
 		"""Round-4 review R4-P0-6 / P1-10: a FIRST direct apply that admin returns
@@ -1696,13 +1716,26 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
 			(settings.last_sync_status or "").startswith("ok"),
 			f"a converged apply must read ok; got {settings.last_sync_status!r}",
 		)
+		from jarvis import account
 		from jarvis.account import is_ready_for_chat
 
-		self.assertTrue(is_ready_for_chat().get("ready"), "a converged first direct apply must open chat")
+		# The final managed gate is a fresh admin question (the convergence probe
+		# above was inside the save's own mock scope). This is still first
+		# onboarding, so admin must say Ready explicitly for the gate to open.
+		account._bust_chat_gate()
+		with patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}):
+			self.assertTrue(is_ready_for_chat().get("ready"), "a converged first direct apply must open chat")
+		account._bust_chat_gate()
 
 	def test_established_direct_tenant_stays_ready_through_resave_pending(self):
-		"""An already-confirmed direct tenant (marker set) keeps chatting on its
-		previous key while a re-save is transiently 'applying'."""
+		"""An already-confirmed direct tenant keeps chatting on its previous key
+		while a re-save is transiently 'applying' AND the control plane is briefly
+		unreachable. Establishedness is proven with the explicit chat_was_ready_at
+		marker (D1's cohort proof), not inferred - so the admin-outage fail-open
+		policy is what this exercises, exactly the intended established behaviour."""
+		from unittest.mock import patch
+
+		from jarvis import account
 		from jarvis.account import is_ready_for_chat
 
 		settings = frappe.get_single("Jarvis Settings")
@@ -1718,15 +1751,24 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
 				"proxy_active": 0,
 				"llm_direct_synced_at": frappe.utils.now(),
 				"last_sync_status": _PENDING_APPLYING_STATUS,
+				# The established-cohort proof. Left unbound (anchor cleared, in case a
+				# sibling test earned one) so the presence rule applies; the point here
+				# is the outage policy, not the authority fence, which has its own
+				# dedicated tests in test_account.
+				"chat_was_ready_at": "2026-01-01 00:00:00",
+				"chat_ready_authority": "",
 			},
 			update_modified=False,
 		)
 		settings.db_set("llm_api_key", "sk-established")
 		frappe.db.commit()
-		self.assertTrue(
-			is_ready_for_chat().get("ready"),
-			"an established direct tenant must stay ready during a pending re-save",
-		)
+		account._bust_chat_gate()
+		with patch("jarvis.admin_client.get_connection", side_effect=Exception("admin outage")):
+			self.assertTrue(
+				is_ready_for_chat().get("ready"),
+				"an established direct tenant must stay ready through a pending re-save + admin outage",
+			)
+		account._bust_chat_gate()
 
 	# ------------------------------------------------------------------
 	# (e) OAuth mode leaves the models table untouched
@@ -2257,15 +2299,22 @@ class TestFT2ValidateMirrorTiming(_RT3SettingsTestCase):
 		settings = frappe.get_single("Jarvis Settings")
 		settings.db_set("llm_oauth_connected_at", None, update_modified=False)
 		settings.db_set("llm_pool_synced_at", frappe.utils.now(), update_modified=False)
+		settings.db_set("chat_was_ready_at", None, update_modified=False)
 		frappe.db.commit()
 
+		from jarvis import account
 		from jarvis.account import is_ready_for_chat
 
-		result = is_ready_for_chat()
+		# An applied pool passes the local pool gate and reaches the final managed
+		# gate; with no established history it asks admin, which says Ready here.
+		account._bust_chat_gate()
+		with patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}):
+			result = is_ready_for_chat()
 		self.assertTrue(
 			result.get("ready"),
 			f"an applied pool must make is_ready_for_chat return ready=True; got: {result}",
 		)
+		account._bust_chat_gate()
 
 
 # ---------------------------------------------------------------------------
@@ -3158,19 +3207,41 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 		self.assertEqual(result.get("reason"), "llm_pool_provisioning")
 
 	def test_ever_applied_pool_stays_ready_through_resave_pending(self):
-		"""A tenant whose pool applied once keeps chatting on the container's
-		previous config while a re-save is mid-sync - must NOT be bounced to
-		onboarding over a transient pending/failed."""
+		"""An ESTABLISHED tenant whose pool applied once keeps chatting on the
+		container's previous config while a re-save is mid-sync AND the control
+		plane is briefly unreachable - it must NOT be bounced to onboarding over a
+		transient pending/failed. Establishedness is the explicit chat_was_ready_at
+		proof; the admin outage is what makes this the fail-open cohort test."""
+		from unittest.mock import patch
+
+		from jarvis import account
 		from jarvis.account import is_ready_for_chat
 
-		self._set_pool_gate_state(
-			synced_at=frappe.utils.now(), status="pending: provisioning container (pool)"
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"chat_was_ready_at",
+			"2026-01-01 00:00:00",
+			update_modified=False,
 		)
-		self.assertTrue(is_ready_for_chat().get("ready"))
-		self._set_pool_gate_state(
-			synced_at=frappe.utils.now(), status="failed: rate-limited; retry_after=90s"
+		# Presence-rule established proof: clear any anchor a sibling test earned so
+		# the fence does not reject this artificially-seeded marker (the fence has
+		# dedicated coverage in test_account).
+		frappe.db.set_value(
+			"Jarvis Settings", "Jarvis Settings", "chat_ready_authority", "", update_modified=False
 		)
-		self.assertTrue(is_ready_for_chat().get("ready"))
+		with patch("jarvis.admin_client.get_connection", side_effect=Exception("admin outage")):
+			self._set_pool_gate_state(
+				synced_at=frappe.utils.now(), status="pending: provisioning container (pool)"
+			)
+			account._bust_chat_gate()
+			self.assertTrue(is_ready_for_chat().get("ready"))
+			self._set_pool_gate_state(
+				synced_at=frappe.utils.now(), status="failed: rate-limited; retry_after=90s"
+			)
+			account._bust_chat_gate()
+			self.assertTrue(is_ready_for_chat().get("ready"))
+		account._bust_chat_gate()
 
 	def test_legacy_ok_status_alone_does_not_open_the_gate(self):
 		"""last_sync_status is SHARED with the single-model sync: a stale
@@ -3188,12 +3259,16 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 		grandfathered by patch v1_10 (marker backfilled from last_sync_at
 		when the pool demonstrably applied), NOT by a status heuristic in
 		the gate."""
+		from unittest.mock import patch
+
+		from jarvis import account
 		from jarvis.account import is_ready_for_chat
 		from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
 
 		self._set_pool_gate_state(synced_at=None, status="ok (pool_update via admin)")
 		settings = frappe.get_single("Jarvis Settings")
 		settings.db_set("last_sync_at", frappe.utils.now(), update_modified=False)
+		settings.db_set("chat_was_ready_at", None, update_modified=False)
 		# v1_10 grandfathers PRE-CHANGE tenants, so reproduce the flag the OLD
 		# "any 2+-model pool is proxied" rule persisted. The patch reads the
 		# stored field on purpose - at migrate time on_update has not re-derived it.
@@ -3204,7 +3279,12 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 
 		settings = frappe.get_single("Jarvis Settings")
 		self.assertTrue(settings.llm_pool_synced_at, "patch must backfill the marker for an applied pool")
-		self.assertTrue(is_ready_for_chat().get("ready"))
+		# v1_10 backfills the POOL marker, not the chat-ready one, so this is still a
+		# workspace with no established history: the final managed gate asks admin.
+		account._bust_chat_gate()
+		with patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}):
+			self.assertTrue(is_ready_for_chat().get("ready"))
+		account._bust_chat_gate()
 
 	def test_backfill_patch_stamps_even_non_ok_pool_tenants(self):
 		"""Grandfathering is unconditional for pre-marker pool tenants: an


### PR DESCRIPTION
## What this is

Step D1 of the AI-connect workstream (plan 05 per `FABLE-JUDGMENT.md` C05-1): the chat-readiness gate returned `ready: true` on **any** admin error, with a 120s site-wide positive cache no LLM save ever busted — so a half-onboarded customer could be waved into a dead chat, and the plan's own acceptance criteria were unenforceable. This fixes the gate; the operation-descriptor/UI work is the next step.

## The ruling implemented

- **Cohort-aware failure:** a workspace that has *never* been chat-ready fails **closed** on admin errors (`readiness_unconfirmed`, retryable) — the onboarding wizard no longer reloads into a dead chat (it renders the honest "still preparing" note with manual continue). An **established** workspace (durable `chat_was_ready_at` marker) keeps failing open — availability wins for sites that were provably working.
- **The marker is trap-proof:** frappe's `get_value` casts an empty Datetime Single to `datetime(1,1,1)` — which would have silently marked every site established and neutered the fix with green tests. The marker is read raw, and a regression test pins the cast misbehavior so the workaround can only be removed deliberately. Reset/reconnect clears the marker (`settings_reset.CONNECTION`) — a re-tenanted site must earn Ready again.
- **The 403 branch is evidence-narrowed:** only admin's own never-paid refusal shapes hard-gate into the wizard; a 403 naming Cancelled, a bodyless/proxy/WAF 403, or a hardened-admin `PermissionError` stays **soft** — chat + `/billing` remain reachable (mutation-verified: the panel's Cancelled-blockade and proxy-403 scenarios are red on the previous head, green here). On hardened production admin the hard gate is consequently rare by design; the proper close is a structured refusal code from admin (ledgered follow-up).
- **Cache honesty:** positive verdicts are revision-keyed (LLM save/creds/disconnect/connection-write all bust or move the revision), TTL 120s→30s, plus a 5s negative cache for `readiness_unconfirmed` only — damping the wizard-poll amplification (measured 3→1 admin round-trips) without caching real not-ready verdicts.
- Backfill patch grandfathers genuinely-established sites (confirmed-apply markers); the desk widget prints the retryable copy for the new reason. SPA rendering additions ride with plan-05's frontend step.

## Review trail (doctrine)

Opus adversarial (REQUEST-CHANGES: the Cancelled/proxy 403 over-reach + the reset-inheritance hole + the 30× poll amplification; core mechanism CLEARED under three-way mutation — both cohort directions and the cast pin each fail the right tests when broken) → fix round with red→green on every finding. `test_account` 53 · `test_chat_policy` 16 · `test_onboarding_sync` 53 · `test_dev` 10 · widget node tests 10 — green.

## Deploy

`bench migrate` before restart (marker field + backfill). Pre-migrate window fails soft (retryable banner, self-healing; belt: a missing meta field reads as established). Note for reviewers: the D1 test work surfaced that patterntest's ambient "onboarded" settings were relied on by older tests — the suite now provisions its own preconditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxn1qvS9817vFv6gmLYEoN