### PR TITLE
fix(onboarding): kill the payment dead-end — stable contract, no credentials on the wire, no double-charge

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -21,6 +21,7 @@ import requests
 
 from jarvis.exceptions import (
 	AdminAuthError,
+	AdminContractError,
 	AdminRateLimitedError,
 	AdminRejectedError,
 	AdminUnreachableError,
@@ -212,15 +213,29 @@ def signup(
 	return _post_guest(path=_m("billing.signup.signup"), body=body)
 
 
-def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
+def resume_pending_signup(plan: str, provider: str | None = None, idempotency_key: str | None = None) -> dict:
 	"""Authenticated failed-payment resume: re-issues checkout handles for the
 	caller's own Pending Payment signup, optionally on a different plan/provider.
 	Returns the same checkout-fields shape as signup's sync path (no credentials
 	— the bench already holds them; that's how this call authenticates).
-	Raises AdminValidationError when there is nothing to resume (409)."""
+
+	``idempotency_key`` makes the retry safe to repeat: admin hashes it onto the
+	subscription with the handles it mints, so a replay of the SAME key returns
+	the intent that key already created instead of opening a second gateway
+	object. A double-submitted wizard, a retried POST and a refreshed pay screen
+	converge on one order. A key admin has not seen is a NEW intent, which is
+	what a genuine second attempt after a decline needs - so the bench mints per
+	attempt, not per lifetime (jarvis.onboarding_contract.next_idempotency_key).
+	Omitted when None, exactly as an older bench sends nothing.
+
+	Raises AdminContractError carrying admin's ``code`` on a coded conflict
+	(PAYMENT_ALREADY_ACTIVE, SIGNUP_TERMINAL, ...); a plain AdminValidationError
+	from an admin too old to send one."""
 	body: dict = {"plan": plan}
 	if provider:
 		body["provider"] = provider
+	if idempotency_key:
+		body["idempotency_key"] = idempotency_key
 	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)
 
 
@@ -289,6 +304,42 @@ def get_signup_payment_state() -> dict:
 	"""
 	return _post(
 		path=_m("billing.signup.get_signup_payment_state"),
+		body={},
+	)
+
+
+def check_signup_payment_status() -> dict:
+	"""Authenticated PROVIDER-TRUTH check on this signup's payment.
+
+	The authoritative half of the payment surface, and the difference from
+	``get_signup_payment_state`` is where the answer comes from: the poll reads
+	admin's own subscription row and never asks a gateway whether money moved,
+	while this asks the GATEWAY and converges a verified payment through the
+	same activation seam a callback or a webhook would have used. It is what a
+	customer whose checkout redirect died and whose webhook was lost can click -
+	their money is captured at the gateway and nothing else in the flow will
+	ever notice.
+
+	Takes no arguments by contract: admin resolves the customer from the
+	authentication this call carries and every remote identifier off their own
+	row, so there is nothing a caller can substitute to aim a check at somebody
+	else's payment.
+
+	Same envelope as the poll (``code`` + the ``can_*`` capability flags), plus
+	two facts only a check can state: ``gateway_consulted`` (whether a provider
+	was really reached in THIS call - false when it failed and false when the
+	answer came from the short cache) and ``awaiting_manual_reconciliation``
+	(present only when true: the gateway holds money we could not credit to this
+	exact subscription and generation, an operator is placing it, and a Pay
+	affordance must be suppressed - the code stays the ordinary pending one
+	because a decline here would invite a SECOND payment).
+
+	Never creates or replaces an intent. A decline or a dead handle is a REPORT;
+	opening the replacement is ``resume_pending_signup``'s job, on an explicit
+	customer action. Rate-limited per customer: a 429 carrying
+	``PAYMENT_CHECK_RATE_LIMITED`` is "wait and ask again", NOT a decline."""
+	return _post(
+		path=_m("billing.signup.check_signup_payment_status"),
 		body={},
 	)
 
@@ -1521,6 +1572,71 @@ def _envelope_error_message(envelope) -> str:
 	return _scrub_secrets(err.get("message") or "")
 
 
+def _contract_error(payload) -> dict:
+	"""The onboarding contract's machine-readable ``error`` object, or ``{}``.
+
+	ONE reader for the contract's TWO wire shapes. A whitelisted method's RETURN
+	value and a RAISED exception do not serialize the same way, so the identical
+	``error`` object sits at two different depths::
+
+	    returned   {"message": {"ok": false, "error": {"code": ...}}}
+	    thrown     {"exc_type": "DuplicateEntryError", "error": {"code": ...}}
+
+	Unifying them admin-side is a coordinated release against benches already in
+	the field, so the contract's answer is a reader that accepts both: top level
+	first, then under ``message``. (See the admin repo's
+	``tests/billing/fixtures/README.md``; the vendored copy of that corpus in
+	``jarvis/tests/fixtures/admin_contract/`` is what pins this function.)
+
+	FAIL CLOSED on anything else. An admin older than the contract emits no
+	``error`` object at all - only Frappe's ``exc_type`` and a sentence - and the
+	answer to that is the generic path plus ``exc_type``, NEVER a prose parse.
+	Requiring ``code`` is what makes "unknown shape" and "no contract" the same
+	branch, so a future shape cannot be half-read.
+
+	The message is scrubbed here (the single bottleneck every upstream-controlled
+	string crosses); the rest of the object is admin's, verbatim - contract rule
+	3 keeps internal document names out of it, and a facade needs the extras
+	(``retry_after_seconds``, ``subscription_status``, ``attempt_id``) intact."""
+	if not isinstance(payload, dict):
+		return {}
+	err = payload.get("error")
+	if not isinstance(err, dict):
+		inner = payload.get("message")
+		err = inner.get("error") if isinstance(inner, dict) else None
+	if not isinstance(err, dict) or not err.get("code"):
+		return {}
+	out = dict(err)
+	out["message"] = _scrub_secrets(str(err.get("message") or ""))
+	return out
+
+
+def _rejection(message: str, *, payload, status: int, exc_type: str = "") -> AdminValidationError:
+	"""Build the known-4xx rejection, preserving admin's contract when it sent
+	one (returned for the caller to ``raise``).
+
+	AdminContractError is a SUBCLASS of AdminValidationError, so this is a strict
+	widening: every caller that only knows the parent - the whole non-onboarding
+	surface - sees the same class and the same ``str(e)`` it saw before, and only
+	a caller that asks for ``code`` notices the difference."""
+	err = _contract_error(payload)
+	if not err:
+		return AdminValidationError(message, exc_type=exc_type or None)
+	# The contract's own display copy wins over Frappe's generic extraction: on
+	# the THROWN shape the latter degrades to the bare exception class name when
+	# the body carries no _server_messages, and "DuplicateEntryError" is not a
+	# sentence to put in front of a customer.
+	return AdminContractError(
+		err.get("message") or message or f"admin returned {status}",
+		code=str(err.get("code") or ""),
+		contract_code=str(err.get("contract_code") or ""),
+		recovery=str(err.get("recovery") or ""),
+		error=err,
+		exc_type=exc_type or None,
+		http_status=status,
+	)
+
+
 # Admin ``error.code`` values that name a PERMANENT rejection: the admin was
 # reached, validated the request and refused it, so re-sending the SAME payload
 # can never converge. jarvis_admin_v2's @fleet_endpoint answers a FleetError
@@ -1618,9 +1734,16 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 		)
 	if resp.status_code == 429:
 		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
+		# A CODED 429 (PAYMENT_CHECK_RATE_LIMITED) is "wait and ask again" and
+		# must never be rendered as a decline; carry its code so a caller can
+		# tell it from the stock per-IP limiter's bare status.
+		contract = _contract_error(payload)
 		raise AdminRateLimitedError(
 			_envelope_error_message(envelope) or clean or "rate_limited",
 			retry_after_seconds=int(err.get("retry_after_seconds") or 0),
+			code=str(contract.get("code") or ""),
+			recovery=str(contract.get("recovery") or ""),
+			error=contract,
 		)
 
 	# Frappe-wrapped raised exception with no unambiguous status. Route
@@ -1628,7 +1751,11 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	# class isn't recognised.
 	if exc_type:
 		if exc_type in ("ValidationError", "DuplicateEntryError", "DoesNotExistError"):
-			raise AdminValidationError(clean)
+			# The THROWN wire shape: admin's contract ``error`` object rides at
+			# the top level next to exc_type. Both survive here - the code for a
+			# reader that has one, exc_type for the pre-contract admin that
+			# sends nothing else.
+			raise _rejection(clean, payload=payload, status=resp.status_code, exc_type=exc_type)
 		# AuthenticationError ~ a token/credential failure (retry-eligible, 401);
 		# PermissionError ~ an authorization denial (terminal, 403). Tag the
 		# status so _post re-mints on the former but surfaces the latter as-is.
@@ -1650,7 +1777,12 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 		# allowlist above) and must surface its clean message; only a 5xx is a
 		# genuine admin fault.
 		if 400 <= resp.status_code < 500:
-			raise AdminValidationError(clean or f"admin returned {resp.status_code}")
+			raise _rejection(
+				clean or f"admin returned {resp.status_code}",
+				payload=payload,
+				status=resp.status_code,
+				exc_type=exc_type,
+			)
 		raise AdminUnreachableError(clean or f"admin returned an unrecognised error: {exc_type}")
 	# Sprint-3 PR-8 (2026-06-16 review): a 4xx response with the
 	# structured envelope ({"ok": false, "error": {...}}) is a
@@ -1683,7 +1815,10 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 			)
 			msg = f"admin returned {resp.status_code}"
 		if 400 <= resp.status_code < 500:
-			raise AdminValidationError(msg)
+			# The RETURNED wire shape: {"message": {"ok": false, "error": {...}}}
+			# under a deliberate 4xx. Same error object as the thrown form, one
+			# depth lower, and the same class comes out of here.
+			raise _rejection(msg, payload=payload, status=resp.status_code)
 		rejected = _permanent_rejection_code(envelope)
 		if rejected:
 			raise AdminRejectedError(

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1601,7 +1601,13 @@ def _contract_error(payload) -> dict:
 	if not isinstance(payload, dict):
 		return {}
 	err = payload.get("error")
-	if not isinstance(err, dict):
+	if not (isinstance(err, dict) and err.get("code")):
+		# Fall THROUGH rather than give up: a top-level ``error`` that carries no
+		# code does not mean there is no contract, only that this depth is not
+		# where it is. A response can legitimately hold both (a framework-shaped
+		# hint at the top, admin's coded envelope under ``message``), and the
+		# earlier shape - which stopped at the first ``error`` object it saw -
+		# would have read the codeless one and reported "no contract".
 		inner = payload.get("message")
 		err = inner.get("error") if isinstance(inner, dict) else None
 	if not isinstance(err, dict) or not err.get("code"):

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -160,15 +160,98 @@ class AdminAuthError(JarvisError):
 class AdminValidationError(JarvisError):
 	"""jarvis_admin raised a Frappe ValidationError (or similar user-input
 	error) inside a whitelisted endpoint. Carries the clean operator-facing
-	message - never the traceback dump."""
+	message - never the traceback dump.
+
+	``exc_type`` is admin's own exception CLASS name ("DuplicateEntryError",
+	"ValidationError", ...) when the response declared one, else None. A caller
+	that needs to know WHICH rejection this is branches on that - or, better, on
+	the ``code`` an AdminContractError carries. Never on the message: the
+	failed-payment resume matched the substring "already registered or pending",
+	admin reworded the sentence on 2026-07-26, and the resume was unreachable
+	for every declined-card customer while both repositories stayed green."""
+
+	def __init__(self, message: str, *, exc_type: str | None = None):
+		super().__init__(message)
+		self.exc_type = exc_type
+
+
+class AdminContractError(AdminValidationError):
+	"""jarvis_admin refused the request with a MACHINE-READABLE error from the
+	onboarding/payment contract (``jarvis_admin_v2/billing/codes.py``).
+
+	The contract's whole point is that the caller branches on ``code`` and only
+	*renders* ``message``. This class is what carries the code across
+	admin_client's boundary, which used to flatten every known 4xx into a bare
+	AdminValidationError holding nothing but prose.
+
+	- ``code``          - admin's ``error.code`` (ACCOUNT_ALREADY_EXISTS, ...).
+	- ``contract_code`` - the stable code where a path already shipped a legacy
+	  identifier in ``code`` (Razorpay's "BadPaymentSignature", Cashfree's
+	  "PaymentNotConfirmed"); the legacy string stays where deployed benches
+	  look for it and the contract value rides beside it. Prefer
+	  ``stable_code``, which picks it when present.
+	- ``recovery``      - the advisory next action ("retry", "continue_setup",
+	  "authenticate_or_reconnect", ...). Advisory: the code alone decides, and
+	  an unknown hint is ignored.
+	- ``error``         - the whole ``error`` object, so a facade can hand the
+	  contract onward without re-deriving it (extras like
+	  ``retry_after_seconds``, ``subscription_status``, ``attempt_id`` live
+	  here). Contract rule 3 keeps internal document names out of it.
+	- ``http_status``   - the deliberate 4xx admin chose.
+
+	A SUBCLASS of AdminValidationError on purpose: every existing catch site
+	already handles that class and keeps working unchanged, and ``str(e)`` is
+	still the same clean message. An admin too old to send a code raises the
+	plain parent instead - that is the fail-closed path, never a prose parse."""
+
+	def __init__(
+		self,
+		message: str,
+		*,
+		code: str = "",
+		contract_code: str = "",
+		recovery: str = "",
+		error: dict | None = None,
+		exc_type: str | None = None,
+		http_status: int = 0,
+	):
+		super().__init__(message, exc_type=exc_type)
+		self.code = code
+		self.contract_code = contract_code
+		self.recovery = recovery
+		self.error = error or {}
+		self.http_status = http_status
+
+	@property
+	def stable_code(self) -> str:
+		"""``contract_code`` when admin sent one, else ``code``."""
+		return self.contract_code or self.code
 
 
 class AdminRateLimitedError(JarvisError):
 	"""jarvis_admin returned HTTP 429 - caller should back off and retry later.
 
 	``retry_after_seconds`` carries the body's hint when the admin provides
-	one (0 if absent)."""
+	one (0 if absent).
 
-	def __init__(self, message: str = "rate_limited", retry_after_seconds: int = 0):
+	``code`` / ``recovery`` / ``error`` carry the contract payload when the 429
+	is a CODED one (today: ``PAYMENT_CHECK_RATE_LIMITED``, the per-customer cap
+	on provider-truth checks) rather than the stock per-IP limiter's bare
+	status. They matter because "back off" and "your payment failed" are
+	opposite instructions to a wizard, and a caller that can only read the
+	status has to guess which one it got."""
+
+	def __init__(
+		self,
+		message: str = "rate_limited",
+		retry_after_seconds: int = 0,
+		*,
+		code: str = "",
+		recovery: str = "",
+		error: dict | None = None,
+	):
 		super().__init__(message)
 		self.retry_after_seconds = retry_after_seconds
+		self.code = code
+		self.recovery = recovery
+		self.error = error or {}

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -605,7 +605,7 @@
    "fieldtype": "Long Text",
    "label": "Signup Context",
    "read_only": 1,
-   "description": "Non-secret JSON snapshot of the in-flight signup: attempt id, the customer's real email + company as admin holds them, plan/provider, the amount and what is due today, the last contract code, and the contract version. Written by jarvis.onboarding_contract so a reloaded payment page renders whose signup it is showing instead of the site admin's prefill. Credentials never go here - jarvis_admin_customer_email above holds admin's SYNTHETIC login (cust-<hash>@jarvis.invalid), which is not an address and must never be shown to anyone."
+   "description": "Non-secret JSON snapshot of the in-flight signup: attempt id, the customer's real email + company as admin holds them, plan/provider, the amount and what is due today, the last contract code, and the contract version. Written by jarvis.onboarding_contract so a reloaded payment page renders whose signup it is showing instead of the site admin's prefill. NO SECRETS EVER GO IN THIS FIELD - permlevel is not a container for one: a Single's value is reachable through frappe.client.get_value / get_single_value by anyone who can read the doctype, and the permlevel only governs the form. Secrets belong in the Password fields above, which encrypt into __Auth. jarvis_admin_customer_email above holds admin's SYNTHETIC login (cust-<hash>@jarvis.invalid), which is not an address and must never be shown to anyone."
   },
   {
    "fieldname": "operator_section",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -79,6 +79,7 @@
   "jarvis_admin_api_secret",
   "jarvis_admin_customer_email",
   "jarvis_admin_customer_password",
+  "signup_context",
   "operator_section",
   "agent_url",
   "agent_token",
@@ -597,6 +598,14 @@
    "label": "Jarvis Admin Customer Password",
    "read_only": 1,
    "description": "The customer's password on the admin site, exchanged for short-lived OAuth bearer tokens (client_id `jarvis-bench`). Set automatically once the email is verified. Empty for pre-OAuth customers, which fall back to api_key:api_secret."
+  },
+  {
+   "fieldname": "signup_context",
+   "permlevel": 1,
+   "fieldtype": "Long Text",
+   "label": "Signup Context",
+   "read_only": 1,
+   "description": "Non-secret JSON snapshot of the in-flight signup: attempt id, the customer's real email + company as admin holds them, plan/provider, the amount and what is due today, the last contract code, and the contract version. Written by jarvis.onboarding_contract so a reloaded payment page renders whose signup it is showing instead of the site admin's prefill. Credentials never go here - jarvis_admin_customer_email above holds admin's SYNTHETIC login (cust-<hash>@jarvis.invalid), which is not an address and must never be shown to anyone."
   },
   {
    "fieldname": "operator_section",

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -548,6 +548,15 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	"""
 	require_jarvis_admin()
 	_require_admin_url()
+	# Money the gateway is holding that an operator has not been able to place
+	# stops the WHOLE endpoint, not just the resume half below. The context is
+	# bench-level, so a raised flag means THIS bench's money is parked — and
+	# letting a fresh signup through while it is would be strictly worse than
+	# letting a retry through: a second account, on top of a payment nobody has
+	# managed to credit to the first. A status check is the documented way out
+	# and clears the flag on any answer.
+	if onboarding_contract.awaiting_reconciliation():
+		_refuse_while_money_is_parked()  # always raises
 	# The identity the customer TYPED, before admin is asked anything. Two
 	# reasons it is written first: a response lost in transit still leaves the
 	# bench knowing whose signup this was (plan 03's "bench response lost after
@@ -602,7 +611,14 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	# above: admin's envelope carries the account's real email and company, the
 	# plan label, and what is actually due today.
 	onboarding_contract.absorb(data)
-	return data
+	# Credentials do not go back to the browser. This response is the one that
+	# CARRIES them — api_key, api_secret and (on the flag-off path) the OAuth
+	# login password — and write_connection above has already stored every one.
+	# Both paths return through here, so the resumed retry is covered with the
+	# fresh signup. The wizard reads ``pending_verification`` and the checkout
+	# handles and nothing else (OnboardingView runStartPay → launchCheckout);
+	# no key stripped here is read anywhere in frontend/src.
+	return onboarding_contract.strip_credentials(data)
 
 
 def _try_resume_pending_signup(err, plan: str, provider: str | None) -> dict | None:
@@ -693,6 +709,24 @@ def _absorb_signup_state(data: dict, *, from_check: bool = False) -> dict:
 	if from_check:
 		return onboarding_contract.absorb_check(data)
 	return onboarding_contract.absorb(data)
+
+
+def _refuse_while_money_is_parked() -> None:
+	"""Refuse an onboarding action while a payment is awaiting manual
+	reconciliation. Always raises.
+
+	Used by the surfaces that THROW (start_signup) rather than return an
+	envelope; ``initiate_signup_payment`` expresses the same refusal as an
+	``ok: false`` body. Both carry the same code, the same recovery hint and the
+	same 409 — the status coming off the exception class, because a throw's
+	status is a property of its type and nothing else."""
+	error = {
+		"code": onboarding_contract.BENCH_AWAITING_RECONCILIATION,
+		"message": "we're still confirming a payment on this signup; no new payment is needed",
+		"recovery": onboarding_contract.RECOVERY_CHECK_STATUS,
+	}
+	onboarding_contract.stamp_error(error)
+	frappe.throw(error["message"], onboarding_contract.SignupConflictError)
 
 
 def _no_signup_here() -> dict:
@@ -791,6 +825,13 @@ def initiate_signup_payment(
 	Gated on Jarvis Admin (``JARVIS_ADMIN_ROLES``), like the rest of onboarding."""
 	require_jarvis_admin()
 	_require_admin_url()
+	if not _has_admin_credentials(frappe.get_single("Jarvis Settings")):
+		# The one endpoint that could still reach admin unauthenticated: a bench
+		# whose credentials were cleared (reset, reconnect onto another account)
+		# but whose signup context survived would sail past the plan check below
+		# on a remembered plan and earn the guaranteed 401 the day-one guard
+		# exists to kill.
+		return _no_signup_here()
 	context = onboarding_contract.load()
 	key_error = onboarding_contract.supplied_key_error(idempotency_key)
 	if key_error:
@@ -1040,12 +1081,18 @@ def finish_payment(payload: dict | str) -> dict:
 	# is written. Idempotent with the start_signup grant.
 	grant_onboarding_admin()
 	onboarding_contract.absorb(data)
-	# NOT stripped, deliberately and for now: this response carries ``agent_token``
-	# and the SPA parks the whole dict in ``state.successData``. It is the same
-	# family of leak as the poll's ``customer_password`` and it wants the same
-	# treatment, but the blast radius is the checkout completion path rather than
-	# a poll, so it is raised for judgment instead of changed here.
-	return data
+	# ``agent_token`` does not go back to the browser either, and the reason this
+	# is not merely tidiness: admin's confirm_payment has a REPLAY branch that
+	# re-serves the connection payload for a payment id it has already recorded
+	# (api/tenant.py, the Cashfree arm keyed on a caller-supplied order id with no
+	# signature). That makes this endpoint a repeatable token read rather than a
+	# one-shot checkout completion — and its gate is require_jarvis_admin, which
+	# grant_onboarding_admin hands to every user who finishes an onboarding.
+	# The bench still consumes the token internally: write_connection above stored
+	# it. The SPA parks this dict in ``state.successData`` and reads exactly two
+	# fields from it, ``agent_url`` and ``tenant_status`` (proceedAfterPay), both
+	# of which survive.
+	return onboarding_contract.strip_credentials(data)
 
 
 @frappe.whitelist()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe.utils import cint
 
-from jarvis import admin_client, release_notice
+from jarvis import admin_client, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
@@ -16,6 +16,10 @@ from jarvis.exceptions import (
 )
 from jarvis.hooks import get_default_admin_url
 from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
+
+# Every admin-side failure admin_client raises. One tuple so the onboarding
+# facade's catch sites cannot drift apart from _surface's.
+_ADMIN_ERRORS = (AdminValidationError, AdminAuthError, AdminUnreachableError, AdminRateLimitedError)
 
 
 def _require_admin_url() -> None:
@@ -39,7 +43,16 @@ def _throw_admin_error(e) -> None:
 	"""Map one already-raised admin_client exception to the clean frappe.throw
 	the onboarding page renders. Extracted from _surface so a caller can inspect
 	the raised error first, then fall back to the identical mapping for every
-	other admin-side failure. Always raises."""
+	other admin-side failure. Always raises.
+
+	The machine-readable half of admin's rejection is parked on the response
+	first, so a THROWN failure still delivers the contract: the page keeps
+	rendering the same sentence it always did, and a caller that wants to branch
+	gets ``error.code`` next to Frappe's ``exc_type`` instead of a sentence to
+	parse. Stamped here rather than at one call site because every onboarding
+	surface throws through this function."""
+	error, _status = onboarding_contract.error_object(e)
+	onboarding_contract.stamp_error(error)
 	if isinstance(e, AdminValidationError):
 		frappe.throw(str(e))
 	if isinstance(e, AdminAuthError):
@@ -74,7 +87,7 @@ def _surface(fn, *args, **kwargs):
 	"""
 	try:
 		return fn(*args, **kwargs)
-	except (AdminValidationError, AdminAuthError, AdminUnreachableError, AdminRateLimitedError) as e:
+	except _ADMIN_ERRORS as e:
 		_throw_admin_error(e)
 
 
@@ -531,12 +544,29 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	"""
 	require_jarvis_admin()
 	_require_admin_url()
+	# The identity the customer TYPED, before admin is asked anything. Two
+	# reasons it is written first: a response lost in transit still leaves the
+	# bench knowing whose signup this was (plan 03's "bench response lost after
+	# credentials saved" race), and the resumed wizard has a real address to
+	# render instead of prefilling the site admin's. Server truth from admin
+	# overwrites it below.
+	onboarding_contract.update(
+		email=(email or "").strip(),
+		company=(company or "").strip(),
+		plan=plan,
+		payment_provider=(provider or "").strip().lower(),
+		contract_version=onboarding_contract.CONTRACT_VERSION,
+	)
 	try:
-		data = _surface(admin_client.signup, email, company, plan, provider=provider)
-	except frappe.ValidationError as e:
-		resumed = _try_resume_pending_signup(e, email, plan, provider)
+		# NOT through _surface: that converts the admin error into a bare
+		# frappe.throw, and the duplicate check below needs the class and the
+		# contract code that conversion discards. Anything non-resumable then
+		# goes through the identical mapping _surface would have applied.
+		data = admin_client.signup(email, company, plan, provider=provider)
+	except _ADMIN_ERRORS as e:
+		resumed = _try_resume_pending_signup(e, plan, provider)
 		if resumed is None:
-			raise
+			_throw_admin_error(e)  # always raises
 		data = resumed
 	# Persist whatever credentials the response carries. The guard also fires
 	# on ``customer`` so the OAuth grant username is stored even if a future
@@ -559,30 +589,55 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	# so the require_jarvis_admin gate above still requires the first onboarder to
 	# be the SM site owner — a plain Jarvis User is rejected before reaching here.
 	grant_onboarding_admin()
+	# Server truth for the identity and the money, over the prefill written
+	# above: admin's envelope carries the account's real email and company, the
+	# plan label, and what is actually due today.
+	onboarding_contract.absorb(data)
 	return data
 
 
-def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None) -> dict | None:
+def _try_resume_pending_signup(err, plan: str, provider: str | None) -> dict | None:
 	"""Failed-payment retry: when guest signup is rejected as a duplicate and
-	this bench already holds credentials for THAT email (persisted by the first
-	attempt), resume the pending signup through admin's authenticated
-	``resume_pending_signup`` — same plan or a newly chosen one — instead of
-	dead-ending the wizard on "already registered or pending".
+	this bench holds admin credentials, resume the pending signup through admin's
+	authenticated ``resume_pending_signup`` — same plan or a newly chosen one —
+	instead of dead-ending the wizard on the duplicate error.
 
-	Returns admin's checkout payload, or None when the fallback doesn't apply
-	(different email, no stored creds, or a non-duplicate error) so the caller
-	re-raises the original error. A resume that itself fails (e.g. the customer
-	is Active — a real duplicate) also returns None: the original duplicate
-	error is the honest message for that case."""
-	if "already registered or pending" not in str(err):
+	Two things decide it, and NEITHER is a message:
+
+	**Is this a duplicate?** ``error.code == ACCOUNT_ALREADY_EXISTS``, or
+	Frappe's ``exc_type == "DuplicateEntryError"`` from an admin older than the
+	contract. The substring test this replaces ("already registered or pending")
+	stopped matching when admin reworded the sentence on 2026-07-26, and the
+	resume was unreachable for every declined-card customer from that day on.
+
+	**Is it ours?** Possession of the credentials the first signup minted. That
+	IS the ownership proof: they authenticate the resume, and admin resolves the
+	customer from the authentication — no caller-supplied identifier chooses the
+	record. The email comparison that used to stand here is DELETED, not
+	repaired: it tested the typed address against ``jarvis_admin_customer_email``,
+	which holds admin's synthetic OAuth login ``cust-<hash>@jarvis.invalid``
+	(signup.py ``_synthetic_login``; the bench stores ``data["customer"]``
+	verbatim in write_connection). A real address and that login are never equal,
+	so the gate could only ever return None — the second, independent kill of
+	this dead end, and the one that survived fixing the wording.
+
+	Returns admin's checkout payload, or None when the fallback doesn't apply (no
+	stored creds, or a non-duplicate error) so the caller surfaces the original
+	error. A resume that itself fails (e.g. a genuinely different account's
+	duplicate) also returns None: the original duplicate error is the honest
+	message for that case."""
+	if not onboarding_contract.is_duplicate_signup(err):
 		return None
 	settings = frappe.get_single("Jarvis Settings")
-	stored_email = (settings.get("jarvis_admin_customer_email") or "").strip().lower()
-	has_creds = bool(settings.get_password("jarvis_admin_api_key", raise_exception=False))
-	if not has_creds or stored_email != (email or "").strip().lower():
+	if not _has_admin_credentials(settings):
 		return None
 	try:
-		return admin_client.resume_pending_signup(plan, provider=provider)
+		context = onboarding_contract.load()
+		return admin_client.resume_pending_signup(
+			plan,
+			provider=provider,
+			idempotency_key=_reserve_idempotency_key(context=context),
+		)
 	except Exception:
 		# Deliberate fallthrough to the original duplicate error (a rejected
 		# resume usually means a REAL duplicate), but leave a trace so a broken
@@ -592,6 +647,170 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 			message=frappe.get_traceback(),
 		)
 		return None
+
+
+def _reserve_idempotency_key(*, supplied: str | None = None, context: dict | None = None) -> str:
+	"""Pick the key for the initiation about to be made and persist it BEFORE
+	the call.
+
+	The order is the whole point. A key written only after a successful response
+	is no protection against the case the key exists for — the response that
+	never arrives — because the retry would then mint a second key and admin
+	would open a second gateway object beside the one the first call already
+	created."""
+	key = onboarding_contract.next_idempotency_key(supplied=supplied, context=context)
+	onboarding_contract.update(idempotency_key=key)
+	return key
+
+
+def _absorb_signup_state(data: dict) -> dict:
+	"""Fold an authenticated state/check envelope into local state.
+
+	Admin delivers the customer's OAuth password on whichever poll first runs
+	after the email is confirmed (kept until TTL rather than deleted on read, so
+	a dropped response is recoverable) — both the passive poll and the
+	provider-truth check can carry it, and whichever one the wizard happens to
+	call must persist it or the bench never gets bearer auth."""
+	if not isinstance(data, dict):
+		return onboarding_contract.load()
+	if data.get("customer_password"):
+		write_connection({"customer_password": data["customer_password"]})
+	return onboarding_contract.absorb(data)
+
+
+@frappe.whitelist()
+def get_onboarding_state() -> dict:
+	"""Where this site's signup actually stands, from admin, plus what this
+	bench knows locally.
+
+	The PASSIVE half of the payment surface: admin reads its own subscription
+	row and never asks a gateway whether money moved, so this is what a wizard
+	polls. ``check_signup_payment_status`` below is the half that asks the
+	provider.
+
+	Returns ``{ok, contract_version, data, context}``. ``data`` is admin's
+	envelope verbatim — its ``code``, its ``can_initiate_payment`` /
+	``can_check_status`` / ``can_reconnect`` capability flags, its billing
+	disclosure — passed through unfiltered so an additive admin release needs no
+	bench change to reach the page. Gate a Pay button on ``can_initiate_payment``
+	and a reconnect offer on ``can_reconnect``; never re-derive either from a
+	status string, and never from a message.
+
+	A failure answers with the same envelope under a DELIBERATE 4xx/5xx and
+	``ok: false`` — never a success-shaped body under a success status.
+
+	Same System-Manager gating as the rest of onboarding."""
+	require_jarvis_admin()
+	_require_admin_url()
+	try:
+		data = admin_client.get_signup_payment_state()
+	except _ADMIN_ERRORS as e:
+		error, status = onboarding_contract.error_object(e)
+		return onboarding_contract.failure(error, status)
+	context = _absorb_signup_state(data)
+	return onboarding_contract.success(data, context=context)
+
+
+@frappe.whitelist()
+def initiate_signup_payment(
+	plan: str | None = None,
+	provider: str | None = None,
+	idempotency_key: str | None = None,
+) -> dict:
+	"""Open (or re-open) checkout for THIS site's own pending signup.
+
+	The authenticated retry, and the reason the failed-payment dead end had a way
+	out at all: the bench holds the credentials admin minted at signup, so it
+	proves ownership by authenticating rather than by naming an email. No
+	caller-supplied identifier chooses the record.
+
+	``plan``/``provider`` default to the ones the signup was started with (from
+	the local context); passing them switches plan or gateway on the retry,
+	exactly as admin's resume allows.
+
+	``idempotency_key`` is honoured verbatim when given. When it is not, the
+	bench supplies one itself: the stored key is reused while the intent it
+	bought is still payable — so a double-clicked Pay button, a retried POST and
+	a refreshed page converge on ONE gateway object — and a fresh key is minted
+	once the last known code says the recovery is a new intent. It is persisted
+	before the call, because the case it exists for is the response that never
+	arrives.
+
+	Returns the same ``{ok, contract_version, data, context}`` envelope as
+	``get_onboarding_state``. A coded conflict (already paid, terminal,
+	verification still pending) comes back as ``ok: false`` with admin's code
+	under its deliberate 4xx — ``PAYMENT_ALREADY_ACTIVE`` in particular means
+	continue setup and MUST NOT be retried into a second charge."""
+	require_jarvis_admin()
+	_require_admin_url()
+	context = onboarding_contract.load()
+	plan = (plan or context.get("plan") or "").strip()
+	if not plan:
+		# Nothing local to resume with and nothing named. A coded refusal rather
+		# than a guess: initiating on the wrong plan is a wrong charge.
+		return onboarding_contract.failure(
+			{
+				"code": onboarding_contract.BENCH_NO_SIGNUP_CONTEXT,
+				"message": "no signup in progress on this site; start one before paying",
+				"recovery": onboarding_contract.RECOVERY_RETRY,
+			},
+			409,
+			context=context,
+		)
+	provider = (provider or context.get("payment_provider") or "").strip().lower()
+	try:
+		data = admin_client.resume_pending_signup(
+			plan,
+			provider=provider or None,
+			idempotency_key=_reserve_idempotency_key(supplied=idempotency_key, context=context),
+		)
+	except _ADMIN_ERRORS as e:
+		error, status = onboarding_contract.error_object(e)
+		# The codes on a refusal carry state too (which attempt, which
+		# subscription status), and a wizard that reloads after one has to render
+		# it. Absorbing the error object is how the page shows "already paid"
+		# rather than the plan it was about to charge for.
+		return onboarding_contract.failure(error, status, context=onboarding_contract.absorb(error))
+	context = _absorb_signup_state(data)
+	return onboarding_contract.success(data, context=context)
+
+
+@frappe.whitelist()
+def check_signup_payment_status() -> dict:
+	"""Ask the PROVIDER what happened to this signup's payment, and converge.
+
+	What a customer whose checkout redirect died and whose webhook was lost can
+	click. Everything else in the flow learns that money moved from something the
+	browser brings back or something the gateway pushes; this endpoint goes and
+	asks, and a verified payment is activated through the same seam a callback or
+	a webhook would have used — so the callback that turns up late is a no-op
+	rather than a second activation.
+
+	Never creates or replaces an intent: a decline or a dead handle is a REPORT,
+	and opening the replacement is ``initiate_signup_payment``'s job on an
+	explicit customer action.
+
+	Two fields only this surface adds, and both change what may be rendered:
+	``gateway_consulted`` (false when the call failed AND when the answer came
+	from the short cache — so "checked just now" can never be shown as "and the
+	gateway confirmed it") and ``awaiting_manual_reconciliation`` (the gateway
+	holds money we could not credit to this exact attempt and an operator is
+	placing it — the code stays the ordinary pending one, because a decline here
+	would invite a SECOND payment, so it is THIS FLAG that suppresses a Pay
+	affordance).
+
+	Rate-limited per customer: ``PAYMENT_CHECK_RATE_LIMITED`` means wait
+	``retry_after_seconds`` and ask again. It asserts nothing about the payment
+	and must never be rendered as a decline."""
+	require_jarvis_admin()
+	_require_admin_url()
+	try:
+		data = admin_client.check_signup_payment_status()
+	except _ADMIN_ERRORS as e:
+		error, status = onboarding_contract.error_object(e)
+		return onboarding_contract.failure(error, status)
+	context = _absorb_signup_state(data)
+	return onboarding_contract.success(data, context=context)
 
 
 @frappe.whitelist()
@@ -703,8 +922,10 @@ def check_signup_payment_state() -> dict:
 	# On the verified poll (email confirmed) admin delivers the customer's
 	# OAuth password once. Persist it so subsequent admin calls use bearer
 	# auth. Absent on the not-yet-verified poll and on the flag-off path.
-	if isinstance(data, dict) and data.get("customer_password"):
-		write_connection({"customer_password": data["customer_password"]})
+	# Shared with get_onboarding_state so the two surfaces cannot disagree about
+	# what a poll persists; the flat return shape this endpoint's caller expects
+	# is unchanged.
+	_absorb_signup_state(data)
 	return data
 
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -521,11 +521,15 @@ def _clear_llm_secrets(settings) -> None:
 def start_signup(email: str, company: str, plan: str, provider: str | None = None) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.
 
-	Gated on System Manager (Sprint-1 Important from the 2026-06-16 code
-	review): the customer signing up is configuring Jarvis for their entire
-	site, which is a System Manager operation on Frappe by convention.
-	Without this, a non-admin staff user could initiate a paid signup using
-	a different email/company under the site's admin contract.
+	Gated on ``require_jarvis_admin`` (Sprint-1 Important from the 2026-06-16
+	code review): the customer signing up is configuring Jarvis for their entire
+	site. Note what that gate actually is — ``JARVIS_ADMIN_ROLES``, i.e. System
+	Manager OR the ``Jarvis Admin`` role, plus Administrator — NOT System Manager
+	alone, which this docstring claimed for a year. It matters here because
+	``grant_onboarding_admin`` below hands out ``Jarvis Admin``, so every user
+	who completes an onboarding can reach this endpoint afterwards. Without the
+	gate, any staff user could initiate a paid signup using a different
+	email/company under the site's admin contract.
 
 	Requires ``Jarvis Settings.jarvis_admin_url`` to be set first. Otherwise
 	admin_client falls back to the DEFAULT_ADMIN_URL, which on a multi-site
@@ -550,11 +554,16 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	# credentials saved" race), and the resumed wizard has a real address to
 	# render instead of prefilling the site admin's. Server truth from admin
 	# overwrites it below.
+	#
+	# Identity ONLY. The plan and the provider are deliberately NOT written here:
+	# they are what a later initiate charges on, and a REQUESTED plan is not a
+	# confirmed one. Writing them pre-call meant a plan admin rejected (disabled,
+	# zero-priced, a gateway the operator switched off) became this site's sticky
+	# default, and the next Pay click charged on it. They land in absorb(), from
+	# a response admin actually agreed to.
 	onboarding_contract.update(
 		email=(email or "").strip(),
 		company=(company or "").strip(),
-		plan=plan,
-		payment_provider=(provider or "").strip().lower(),
 		contract_version=onboarding_contract.CONTRACT_VERSION,
 	)
 	try:
@@ -663,19 +672,45 @@ def _reserve_idempotency_key(*, supplied: str | None = None, context: dict | Non
 	return key
 
 
-def _absorb_signup_state(data: dict) -> dict:
+def _absorb_signup_state(data: dict, *, from_check: bool = False) -> dict:
 	"""Fold an authenticated state/check envelope into local state.
 
 	Admin delivers the customer's OAuth password on whichever poll first runs
 	after the email is confirmed (kept until TTL rather than deleted on read, so
 	a dropped response is recoverable) — both the passive poll and the
 	provider-truth check can carry it, and whichever one the wizard happens to
-	call must persist it or the bench never gets bearer auth."""
+	call must persist it or the bench never gets bearer auth. It is persisted
+	HERE, from the original envelope, and stripped from the copy that goes back
+	to the browser.
+
+	``from_check`` marks a provider-truth answer, which is additionally
+	authoritative about the reconciliation flag — see
+	``onboarding_contract.absorb_check``."""
 	if not isinstance(data, dict):
 		return onboarding_contract.load()
 	if data.get("customer_password"):
 		write_connection({"customer_password": data["customer_password"]})
+	if from_check:
+		return onboarding_contract.absorb_check(data)
 	return onboarding_contract.absorb(data)
+
+
+def _no_signup_here() -> dict:
+	"""The day-one answer: this site has never started a signup.
+
+	A bench with no admin credentials cannot authenticate anything, so asking the
+	control plane is a guaranteed 401 - which the facade would then dress up as
+	"admin authentication failed; contact support" and show to somebody whose only
+	mistake was opening the page before signing up. Answered locally, with no
+	network call and copy that describes the actual situation."""
+	return onboarding_contract.failure(
+		{
+			"code": onboarding_contract.BENCH_NO_SIGNUP_CONTEXT,
+			"message": "no signup has been started on this site yet",
+			"recovery": onboarding_contract.RECOVERY_RETRY,
+		},
+		409,
+	)
 
 
 @frappe.whitelist()
@@ -689,19 +724,23 @@ def get_onboarding_state() -> dict:
 	provider.
 
 	Returns ``{ok, contract_version, data, context}``. ``data`` is admin's
-	envelope verbatim — its ``code``, its ``can_initiate_payment`` /
-	``can_check_status`` / ``can_reconnect`` capability flags, its billing
-	disclosure — passed through unfiltered so an additive admin release needs no
-	bench change to reach the page. Gate a Pay button on ``can_initiate_payment``
-	and a reconnect offer on ``can_reconnect``; never re-derive either from a
-	status string, and never from a message.
+	envelope — its ``code``, its ``can_initiate_payment`` / ``can_check_status`` /
+	``can_reconnect`` capability flags, its billing disclosure — passed through
+	unfiltered except for credential-shaped keys, so an additive admin release
+	needs no bench change to reach the page. Gate a Pay button on
+	``can_initiate_payment`` and a reconnect offer on ``can_reconnect``; never
+	re-derive either from a status string, and never from a message.
 
 	A failure answers with the same envelope under a DELIBERATE 4xx/5xx and
-	``ok: false`` — never a success-shaped body under a success status.
+	``ok: false`` — never a success-shaped body under a success status. A site
+	that has not signed up yet is answered locally, without a doomed call.
 
-	Same System-Manager gating as the rest of onboarding."""
+	Gated on Jarvis Admin (``JARVIS_ADMIN_ROLES`` — System Manager OR the Jarvis
+	Admin role, plus Administrator), like the rest of onboarding."""
 	require_jarvis_admin()
 	_require_admin_url()
+	if not _has_admin_credentials(frappe.get_single("Jarvis Settings")):
+		return _no_signup_here()
 	try:
 		data = admin_client.get_signup_payment_state()
 	except _ADMIN_ERRORS as e:
@@ -728,22 +767,49 @@ def initiate_signup_payment(
 	the local context); passing them switches plan or gateway on the retry,
 	exactly as admin's resume allows.
 
-	``idempotency_key`` is honoured verbatim when given. When it is not, the
-	bench supplies one itself: the stored key is reused while the intent it
-	bought is still payable — so a double-clicked Pay button, a retried POST and
-	a refreshed page converge on ONE gateway object — and a fresh key is minted
-	once the last known code says the recovery is a new intent. It is persisted
-	before the call, because the case it exists for is the response that never
-	arrives.
+	``idempotency_key`` is honoured verbatim when given, and REFUSED locally when
+	it cannot work — an over-long key is answered here, with nothing persisted,
+	because the stored key is what the next attempt reuses and storing one admin
+	rejects is a brick the customer cannot clear. When none is given the bench
+	supplies its own: the stored key is reused while the intent it bought is still
+	payable — so a double-clicked Pay button, a retried POST and a refreshed page
+	converge on ONE gateway object — and a fresh key is minted once the last known
+	code says the recovery is a new intent. It is persisted before the call,
+	because the case it exists for is the response that never arrives.
+
+	Refused locally, before any network call, while the last provider-truth check
+	says money is awaiting manual reconciliation: the gateway is holding a payment
+	an operator has not been able to place, and a second intent would take a
+	second one for it.
 
 	Returns the same ``{ok, contract_version, data, context}`` envelope as
 	``get_onboarding_state``. A coded conflict (already paid, terminal,
 	verification still pending) comes back as ``ok: false`` with admin's code
 	under its deliberate 4xx — ``PAYMENT_ALREADY_ACTIVE`` in particular means
-	continue setup and MUST NOT be retried into a second charge."""
+	continue setup and MUST NOT be retried into a second charge.
+
+	Gated on Jarvis Admin (``JARVIS_ADMIN_ROLES``), like the rest of onboarding."""
 	require_jarvis_admin()
 	_require_admin_url()
 	context = onboarding_contract.load()
+	key_error = onboarding_contract.supplied_key_error(idempotency_key)
+	if key_error:
+		return onboarding_contract.failure(key_error, 400, context=context)
+	if onboarding_contract.awaiting_reconciliation(context):
+		# The customer has already paid something the gateway is holding, and the
+		# code that came with it is the ordinary PENDING one - deliberately, so a
+		# wizard does not invite a second payment - which means nothing in the code
+		# alone stops this call. The flag does. It clears when a later check says
+		# the operator placed the money.
+		return onboarding_contract.failure(
+			{
+				"code": onboarding_contract.BENCH_AWAITING_RECONCILIATION,
+				"message": "we're still confirming a payment on this signup; no new payment is needed",
+				"recovery": onboarding_contract.RECOVERY_CHECK_STATUS,
+			},
+			409,
+			context=context,
+		)
 	plan = (plan or context.get("plan") or "").strip()
 	if not plan:
 		# Nothing local to resume with and nothing named. A coded refusal rather
@@ -766,11 +832,13 @@ def initiate_signup_payment(
 		)
 	except _ADMIN_ERRORS as e:
 		error, status = onboarding_contract.error_object(e)
-		# The codes on a refusal carry state too (which attempt, which
-		# subscription status), and a wizard that reloads after one has to render
-		# it. Absorbing the error object is how the page shows "already paid"
-		# rather than the plan it was about to charge for.
-		return onboarding_contract.failure(error, status, context=onboarding_contract.absorb(error))
+		# Only a PAYMENT-STATE code updates what the page renders and what the next
+		# key does. A rate-limit backoff and a transport failure describe this CALL,
+		# not the money: absorbing "you are asking too often" as the payment's state
+		# would mint a fresh intent on the next click.
+		return onboarding_contract.failure(
+			error, status, context=onboarding_contract.absorb_payment_outcome(e)
+		)
 	context = _absorb_signup_state(data)
 	return onboarding_contract.success(data, context=context)
 
@@ -801,15 +869,24 @@ def check_signup_payment_status() -> dict:
 
 	Rate-limited per customer: ``PAYMENT_CHECK_RATE_LIMITED`` means wait
 	``retry_after_seconds`` and ask again. It asserts nothing about the payment
-	and must never be rendered as a decline."""
+	and must never be rendered as a decline.
+
+	This is also the ONLY surface that may lower the reconciliation flag, because
+	admin sends it only when it is true — so an ordinary poll can raise it and
+	nothing could ever clear it. Running a check is how a customer refused a retry
+	gets out of that state once the operator has placed the money.
+
+	Gated on Jarvis Admin (``JARVIS_ADMIN_ROLES``), like the rest of onboarding."""
 	require_jarvis_admin()
 	_require_admin_url()
+	if not _has_admin_credentials(frappe.get_single("Jarvis Settings")):
+		return _no_signup_here()
 	try:
 		data = admin_client.check_signup_payment_status()
 	except _ADMIN_ERRORS as e:
 		error, status = onboarding_contract.error_object(e)
 		return onboarding_contract.failure(error, status)
-	context = _absorb_signup_state(data)
+	context = _absorb_signup_state(data, from_check=True)
 	return onboarding_contract.success(data, context=context)
 
 
@@ -913,8 +990,10 @@ def check_signup_payment_state() -> dict:
 	``pending_verification`` to decide whether to keep showing the
 	"check your email" screen or to open Razorpay Checkout.
 
-	Gated on System Manager for the same reason as start_signup: this is
-	part of the same paid-signup flow on the customer's bench.
+	Gated on ``require_jarvis_admin`` (``JARVIS_ADMIN_ROLES``: System Manager or
+	the Jarvis Admin role, plus Administrator) for the same reason as
+	start_signup: this is part of the same paid-signup flow on the customer's
+	bench.
 	"""
 	require_jarvis_admin()
 	_require_admin_url()
@@ -926,25 +1005,46 @@ def check_signup_payment_state() -> dict:
 	# what a poll persists; the flat return shape this endpoint's caller expects
 	# is unchanged.
 	_absorb_signup_state(data)
-	return data
+	# ...and the password does NOT go on to the browser. It was persisted above
+	# and the page has no use for it (verifyPollAction never reads it); returning
+	# admin's dict verbatim put a plaintext login secret in an HTTP response body
+	# on every verified poll.
+	return onboarding_contract.strip_credentials(data)
 
 
 @frappe.whitelist()
 def finish_payment(payload: dict | str) -> dict:
 	"""Confirm Checkout success → store the returned container connection.
 
-	Gated on System Manager: writes container connection (agent_url,
-	agent_token) into Jarvis Settings.
+	Gated on ``require_jarvis_admin`` (``JARVIS_ADMIN_ROLES``: System Manager or
+	the Jarvis Admin role, plus Administrator): writes container connection
+	(agent_url, agent_token) into Jarvis Settings.
+
+	A FAILED confirm is where the wizard learns a payment was refused, and that
+	verdict has to reach the local context or the next Pay click reuses the
+	idempotency key that bought the refused intent — and admin hands back the
+	dead order. Only a payment-state code is absorbed; a transport failure here
+	says nothing about the money.
 	"""
 	require_jarvis_admin()
 	if isinstance(payload, str):
 		payload = json.loads(payload)
-	data = _surface(admin_client.confirm_payment, payload)
+	try:
+		data = admin_client.confirm_payment(payload)
+	except _ADMIN_ERRORS as e:
+		onboarding_contract.absorb_payment_outcome(e)
+		_throw_admin_error(e)  # always raises
 	write_connection(data)
 	# PART 4 REVISED, TASK 48: the AUTHORITATIVE "onboarding AND paying" grant —
 	# make the paying user a Jarvis Admin once payment confirms and the connection
 	# is written. Idempotent with the start_signup grant.
 	grant_onboarding_admin()
+	onboarding_contract.absorb(data)
+	# NOT stripped, deliberately and for now: this response carries ``agent_token``
+	# and the SPA parks the whole dict in ``state.successData``. It is the same
+	# family of leak as the poll's ``customer_password`` and it wants the same
+	# treatment, but the blast radius is the checkout completion path rather than
+	# a poll, so it is raised for judgment instead of changed here.
 	return data
 
 

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -1,0 +1,382 @@
+"""The bench half of the onboarding / payment-recovery contract with admin.
+
+Admin publishes a machine vocabulary (``jarvis_admin_v2/billing/codes.py``) and
+a corpus of wire fixtures; this module is what the bench reads it WITH. Three
+jobs, all of them consequences of one incident:
+
+  1. **Codes, never prose.** Admin reworded its duplicate-signup message on
+     2026-07-26. The bench's failed-payment resume string-matched the old
+     sentence, so from that day every customer whose card was declined hit a
+     dead end - and both repositories' suites stayed green, because each side
+     kept its own copy of the sentence. Nothing here branches on a message.
+  2. **Identity is proven by CREDENTIALS, never by an email comparison.** The
+     resume gate also compared the user's typed address against the stored
+     ``jarvis_admin_customer_email``, which holds admin's SYNTHETIC OAuth login
+     (``cust-<hash>@jarvis.invalid``, signup.py ``_synthetic_login``) - never
+     equal to a real address, so the gate was structurally dead even with the
+     wording fixed. Possession of the credentials the first signup minted IS
+     the ownership proof; admin resolves the customer from authentication.
+  3. **Local display context.** A reloaded wizard used to render the SITE
+     admin's email as the address a verification link was sent to. The bench
+     keeps a small non-secret snapshot of whose signup this is, and server
+     truth from admin overwrites it whenever a response carries any.
+
+The vendored fixture corpus in ``jarvis/tests/fixtures/admin_contract/`` is the
+executable half of this file's claims - see its PROVENANCE.md.
+"""
+
+import json
+import secrets
+
+import frappe
+
+# The contract vocabulary version this bench is written against
+# (``codes.CONTRACT_VERSION`` on the admin side). Bumped only on a BREAKING
+# shape change; a new CODE is additive and does not move it. Recorded in the
+# local context so a support conversation can tell which vocabulary a stuck
+# wizard was answered in.
+CONTRACT_VERSION = 2
+
+# --------------------------------------------------------------------------- #
+# admin's codes (append-only vocabulary; a shipped code's meaning never changes)
+# --------------------------------------------------------------------------- #
+#: Guest signup refused: this (email, company) already has an account. Says
+#: NOTHING about that account's status - deliberately, so the endpoint cannot be
+#: used to enumerate. This is the code the failed-payment resume keys off.
+ACCOUNT_ALREADY_EXISTS = "ACCOUNT_ALREADY_EXISTS"
+#: The signup exists but the address is unproven; nothing happens until the
+#: magic link is clicked.
+SIGNUP_VERIFICATION_REQUIRED = "SIGNUP_VERIFICATION_REQUIRED"
+#: An intent exists and the gateway has not said money moved. Poll; do not
+#: re-initiate.
+PAYMENT_CONFIRMATION_PENDING = "PAYMENT_CONFIRMATION_PENDING"
+#: The gateway says this attempt will not complete. A NEW intent is the recovery.
+PAYMENT_DECLINED = "PAYMENT_DECLINED"
+#: Already paid. Terminal for the payment step - continue setup, never a second
+#: intent.
+PAYMENT_ALREADY_ACTIVE = "PAYMENT_ALREADY_ACTIVE"
+#: Awaiting payment with no usable checkout handle. Only an explicit initiate
+#: may create one.
+NO_CURRENT_INTENT = "NO_CURRENT_INTENT"
+#: Paid, live and already running: the recovery is the emailed reconnect code,
+#: never a new signup and never another payment.
+ACCOUNT_RECONNECT_REQUIRED = "ACCOUNT_RECONNECT_REQUIRED"
+#: A mandate the gateway has already AUTHORIZED. Money moved; the recovery is
+#: confirm, and a second intent would authorize a second mandate.
+PAYMENT_AUTHORIZED_PENDING_CONFIRM = "PAYMENT_AUTHORIZED_PENDING_CONFIRM"
+#: A handle exists but the gateway would not hand back the session token it has
+#: to be opened with. Retryable, and NOT a decline.
+INTENT_HANDLE_UNAVAILABLE = "INTENT_HANDLE_UNAVAILABLE"
+#: Past the signup stage: renewal, reconnect or support, not a checkout.
+SIGNUP_TERMINAL = "SIGNUP_TERMINAL"
+#: A request field violated a documented bound (today: an over-long
+#: idempotency_key).
+INVALID_REQUEST = "INVALID_REQUEST"
+#: Too many provider-truth checks for this account. Asserts NOTHING about the
+#: payment - wait ``retry_after_seconds`` and ask again.
+PAYMENT_CHECK_RATE_LIMITED = "PAYMENT_CHECK_RATE_LIMITED"
+
+# --------------------------------------------------------------------------- #
+# bench-local codes
+# --------------------------------------------------------------------------- #
+# Failures that never reached admin's contract at all: transport, authentication,
+# an admin too old to send a code. Prefixed so they can never be confused with -
+# or collide with a future addition to - admin's append-only vocabulary.
+BENCH_ADMIN_UNREACHABLE = "BENCH_ADMIN_UNREACHABLE"
+BENCH_ADMIN_AUTH_FAILED = "BENCH_ADMIN_AUTH_FAILED"
+BENCH_ADMIN_REJECTED = "BENCH_ADMIN_REJECTED"
+BENCH_RATE_LIMITED = "BENCH_RATE_LIMITED"
+#: No plan is known for an initiate: the local context is empty (a bench that
+#: never ran a signup, or one whose settings were reset) and the caller named
+#: none.
+BENCH_NO_SIGNUP_CONTEXT = "BENCH_NO_SIGNUP_CONTEXT"
+
+RECOVERY_RETRY = "retry"
+RECOVERY_CONTINUE_SETUP = "continue_setup"
+RECOVERY_CONTACT_SUPPORT = "contact_support"
+RECOVERY_AUTHENTICATE_OR_RECONNECT = "authenticate_or_reconnect"
+
+# The codes whose recovery IS a new intent: whatever the stored idempotency key
+# bought can no longer be paid. Reusing the key there would be actively wrong -
+# admin returns the intent a key it has already seen created, so a customer
+# retrying after a decline would be handed the dead order back and could never
+# escape it. Everything else reuses the key, which is what makes a double-click
+# (or a retried POST, or a refreshed pay screen) converge on ONE gateway object.
+_SPENT_INTENT_CODES = frozenset(
+	{
+		PAYMENT_DECLINED,
+		NO_CURRENT_INTENT,
+		INTENT_HANDLE_UNAVAILABLE,
+	}
+)
+
+
+def is_duplicate_signup(err) -> bool:
+	"""Is this admin rejection "that (email, company) already has an account"?
+
+	Two machine signals, both stable, NEITHER of them prose:
+
+	- ``error.code == ACCOUNT_ALREADY_EXISTS`` - the contract's own answer;
+	- ``exc_type == "DuplicateEntryError"`` - what an admin older than the
+	  contract sends, and still sends. Every version of admin's
+	  ``_reject_duplicate_email`` back to the v2 fork throws
+	  ``frappe.DuplicateEntryError``, whose ``http_status_code`` puts the 409 on
+	  the wire, so this branch covers a mid-upgrade fleet with no prose fallback
+	  needed anywhere.
+
+	The substring match this replaces (``"already registered or pending" in
+	str(err)``) is what made the failed-payment resume unreachable for every
+	real customer the day admin improved its wording."""
+	if getattr(err, "code", "") == ACCOUNT_ALREADY_EXISTS:
+		return True
+	return getattr(err, "exc_type", None) == "DuplicateEntryError"
+
+
+# --------------------------------------------------------------------------- #
+# local display context
+# --------------------------------------------------------------------------- #
+#: Jarvis Settings field holding the JSON snapshot. Non-secret by construction -
+#: see _ADMIN_KEYS, an allowlist rather than a copy of admin's payload, so a
+#: response carrying api_key / api_secret / customer_password can never leak
+#: into it.
+CONTEXT_FIELD = "signup_context"
+
+# What the bench keeps out of an admin envelope. Display facts and machine codes
+# only: identity as the customer typed it, what they are buying, where the
+# attempt got to.
+_ADMIN_KEYS = (
+	# opaque per-attempt handle - the one identifier support and the bench may
+	# both quote (contract rule 3 keeps document names on admin's side)
+	"attempt_id",
+	"generation",
+	"contract_version",
+	# server-side identity truth; overwrites whatever the wizard prefilled
+	"email",
+	"company",
+	# what is being bought, and what is actually due today
+	"payment_provider",
+	"amount_inr",
+	"signup_fee_inr",
+	"due_today_inr",
+	"trial_days",
+	"effective_trial_days",
+	"effective_first_charge_at",
+	# where the attempt got to
+	"code",
+	"recovery",
+	"subscription_status",
+	"pending_verification",
+	"verification_expires_at",
+	"payment_last_checked_at",
+)
+
+# Never persisted, and asserted on: the signup response carries the account's
+# credentials in the same dict as its display fields.
+_NEVER_PERSIST = ("api_key", "api_secret", "customer", "customer_password", "agent_token")
+
+# Held locally, never sent to the browser. The key is the bench's receipt for an
+# initiation; handing it to the SPA would invite it to echo the same key back on
+# a genuine second attempt, which is exactly the replay that returns the dead
+# intent.
+_LOCAL_ONLY_KEYS = ("idempotency_key",)
+
+
+def load() -> dict:
+	"""The stored context, or ``{}``. Never raises on a malformed value - a
+	wizard must not be bricked by its own bookkeeping."""
+	raw = frappe.db.get_single_value("Jarvis Settings", CONTEXT_FIELD) or ""
+	if not raw:
+		return {}
+	try:
+		out = json.loads(raw)
+	except (ValueError, TypeError):
+		return {}
+	return out if isinstance(out, dict) else {}
+
+
+def save(context: dict) -> None:
+	"""Persist the context. ``db_set`` for the same reason write_connection uses
+	it - Jarvis Settings' ``on_update`` pushes credentials to the container, and
+	onboarding must not trigger that. ``update_modified=False`` keeps a 2-second
+	wizard poll from churning the Single's timestamp.
+
+	The secret sweep is the last line of defence, not the first: ``absorb``'s
+	allowlist is what keeps credentials out of here, and this makes a future
+	caller that hands the field a raw admin payload fail safe instead of parking
+	an api_secret in a plain-text Settings column."""
+	clean = {k: v for k, v in (context or {}).items() if k not in _NEVER_PERSIST}
+	settings = frappe.get_single("Jarvis Settings")
+	settings.db_set(CONTEXT_FIELD, json.dumps(clean, sort_keys=True), update_modified=False)
+
+
+def update(**fields) -> dict:
+	"""Merge non-empty fields into the stored context and return the result.
+
+	Empty values are dropped rather than written: a poll that answers with no
+	``amount_inr`` (a verification-stage response, say) must not erase the amount
+	a later screen still has to render. Writes only on a real change, so the
+	wizard's polling costs no DB writes once the state is steady."""
+	context = load()
+	merged = dict(context)
+	for key, value in fields.items():
+		if value in (None, "", {}, []):
+			continue
+		merged[key] = value
+	if merged != context:
+		merged["updated_at"] = frappe.utils.now()
+		save(merged)
+	return merged
+
+
+def absorb(payload: dict | None) -> dict:
+	"""Fold an admin envelope's DISPLAY facts into the local context.
+
+	An allowlist, never a copy: the signup response carries the account's
+	credentials beside its display fields, and a blanket merge would park them in
+	a plain-text Settings field. ``plan`` arrives as ``{"name", "label"}`` from
+	the state/resume surfaces and as a bare string from the bench's own signup
+	call, so both are folded to ``plan`` + ``plan_label``."""
+	if not isinstance(payload, dict):
+		return load()
+	fields = {key: payload.get(key) for key in _ADMIN_KEYS if key in payload}
+	plan = payload.get("plan")
+	if isinstance(plan, dict):
+		fields["plan"] = plan.get("name") or ""
+		fields["plan_label"] = plan.get("label") or ""
+	elif isinstance(plan, str):
+		fields["plan"] = plan
+	return update(**fields)
+
+
+def wire(context: dict | None = None) -> dict:
+	"""The context block a facade response carries, minus anything local-only."""
+	context = load() if context is None else context
+	return {k: v for k, v in context.items() if k not in _LOCAL_ONLY_KEYS}
+
+
+def clear() -> None:
+	"""Drop the context (bench reset / disconnect)."""
+	save({})
+
+
+# --------------------------------------------------------------------------- #
+# idempotency
+# --------------------------------------------------------------------------- #
+def next_idempotency_key(*, supplied: str | None = None, context: dict | None = None) -> str:
+	"""The key for the payment initiation about to be made.
+
+	``supplied`` (from the caller) wins verbatim - including an over-long one,
+	which admin answers with a coded ``INVALID_REQUEST`` it can fix. Silently
+	truncating would hand it a DIFFERENT key than the one it thinks it sent, and
+	an idempotency key that is not the caller's is worse than none.
+
+	Otherwise: reuse the stored key while the intent it bought is still payable
+	(so a double-click, a retried POST and a refreshed pay screen all converge on
+	one gateway object), and mint a fresh one once the last code says the
+	recovery IS a new intent - because admin answers a key it has already seen
+	with the intent that key created, and after a decline that is precisely the
+	order the customer cannot pay.
+
+	The key carries no identity: it is a receipt, admin stores only its SHA-256,
+	and anything derived from the customer would put an identifier in a field
+	operators read."""
+	if supplied and supplied.strip():
+		return supplied.strip()
+	context = load() if context is None else context
+	stored = (context.get("idempotency_key") or "").strip()
+	if stored and context.get("code") not in _SPENT_INTENT_CODES:
+		return stored
+	return f"bench-{secrets.token_urlsafe(24)}"
+
+
+# --------------------------------------------------------------------------- #
+# wire shaping
+# --------------------------------------------------------------------------- #
+def error_object(err) -> tuple[dict, int]:
+	"""One admin_client exception -> (wire error object, HTTP status).
+
+	A contract error passes through as ITSELF: admin's code, its recovery hint
+	and every extra it carried (``retry_after_seconds``, ``subscription_status``,
+	``attempt_id``) reach the caller unaltered, because re-deriving them here is
+	how one side's vocabulary becomes two. Everything else - transport,
+	authentication, an admin too old to speak the contract - gets a BENCH_* code
+	so its provenance is unambiguous."""
+	from jarvis.exceptions import (
+		AdminAuthError,
+		AdminContractError,
+		AdminRateLimitedError,
+		AdminUnreachableError,
+		AdminValidationError,
+	)
+
+	if isinstance(err, AdminContractError):
+		out = dict(err.error)
+		out.setdefault("code", err.code)
+		out.setdefault("message", str(err))
+		return out, (err.http_status or 409)
+	if isinstance(err, AdminRateLimitedError):
+		out = dict(err.error) if err.error else {}
+		out.setdefault("code", err.code or BENCH_RATE_LIMITED)
+		out.setdefault("message", str(err))
+		out.setdefault("recovery", err.recovery or RECOVERY_RETRY)
+		if err.retry_after_seconds:
+			out.setdefault("retry_after_seconds", err.retry_after_seconds)
+		return out, 429
+	if isinstance(err, AdminAuthError):
+		return {
+			"code": BENCH_ADMIN_AUTH_FAILED,
+			"message": str(err),
+			"recovery": RECOVERY_CONTACT_SUPPORT,
+		}, (err.status_code or 401)
+	if isinstance(err, AdminValidationError):
+		# An admin older than the contract: a real rejection with a real
+		# message, and no machine code anywhere in it. Fail closed onto the
+		# generic branch rather than reading the sentence.
+		out = {"code": BENCH_ADMIN_REJECTED, "message": str(err), "recovery": RECOVERY_RETRY}
+		if getattr(err, "exc_type", None):
+			out["exc_type"] = err.exc_type
+		return out, 409
+	if isinstance(err, AdminUnreachableError):
+		return {
+			"code": BENCH_ADMIN_UNREACHABLE,
+			"message": str(err),
+			"recovery": RECOVERY_RETRY,
+		}, 502
+	return {"code": BENCH_ADMIN_REJECTED, "message": str(err), "recovery": RECOVERY_RETRY}, 500
+
+
+def stamp_error(error: dict) -> None:
+	"""Park the machine-readable error on a response that is about to carry a
+	RAISED exception, so a throw still delivers the contract.
+
+	``frappe.utils.response.build_response`` serializes ``frappe.local.response``
+	verbatim, which is what puts the object on the wire next to Frappe's own
+	``exc_type`` - the same mechanism admin's ``codes.stamp_error`` uses, read
+	from the other end. Call it immediately before the throw: it mutates the
+	response, so a caller that CATCHES the throw would otherwise leave a stale
+	error on an eventually-successful reply."""
+	frappe.local.response["error"] = error
+
+
+def success(data: dict, *, context: dict | None = None) -> dict:
+	"""A facade success: admin's envelope verbatim, plus the local context.
+
+	``data`` is NOT filtered. Every capability flag, disclosure field and code
+	admin added - including ones this bench build has never heard of - reaches
+	the caller, which is what makes an additive admin release a no-op here."""
+	return {
+		"ok": True,
+		"contract_version": int((data or {}).get("contract_version") or CONTRACT_VERSION),
+		"data": data or {},
+		"context": wire(context),
+	}
+
+
+def failure(error: dict, status: int, *, context: dict | None = None) -> dict:
+	"""A facade failure: the contract error, under a DELIBERATE 4xx/5xx.
+
+	Never ``{"ok": false}`` on a 200 - the same rule that governs admin's half of
+	this contract, for the same reason: a success-shaped body under a success
+	status is a failure every reader has to be told about out of band."""
+	frappe.local.response.http_status_code = status
+	return {"ok": False, "error": error, "context": wire(context)}

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -182,9 +182,17 @@ _LOCAL_ONLY_KEYS = ("idempotency_key",)
 
 
 def load() -> dict:
-	"""The stored context, or ``{}``. Never raises on a malformed value - a
-	wizard must not be bricked by its own bookkeeping."""
-	raw = frappe.db.get_single_value("Jarvis Settings", CONTEXT_FIELD) or ""
+	"""The stored context, or ``{}``.
+
+	Never raises. Two ways it can find nothing and both are survivable: a
+	malformed value (hand-edited, half-written), and a bench between a code
+	deploy and its ``bench migrate``, where ``get_single_value`` throws on a
+	field the installed doctype does not have yet. A wizard must not be bricked
+	by its own bookkeeping."""
+	try:
+		raw = frappe.db.get_single_value("Jarvis Settings", CONTEXT_FIELD) or ""
+	except Exception:
+		return {}
 	if not raw:
 		return {}
 	try:
@@ -203,10 +211,25 @@ def save(context: dict) -> None:
 	The secret sweep is the last line of defence, not the first: ``absorb``'s
 	allowlist is what keeps credentials out of here, and this makes a future
 	caller that hands the field a raw admin payload fail safe instead of parking
-	an api_secret in a plain-text Settings column."""
+	an api_secret in a plain-text Settings column.
+
+	Best-effort, and deliberately so. ``db_set`` REJECTS a field the installed
+	doctype does not have ("Field ... does not exist"), which is precisely the
+	state of a bench between a code deploy and its ``bench migrate``. Letting
+	that abort the call would take signup itself down in that window - a strictly
+	worse failure than the one this snapshot exists to prevent - so a wizard is
+	never bricked by its own bookkeeping, on the write side as much as the read
+	side. The cost of the degraded window is a display block the page falls back
+	from, and an idempotency key that is not remembered across a double-click."""
 	clean = {k: v for k, v in (context or {}).items() if k not in _NEVER_PERSIST}
 	settings = frappe.get_single("Jarvis Settings")
-	settings.db_set(CONTEXT_FIELD, json.dumps(clean, sort_keys=True), update_modified=False)
+	try:
+		settings.db_set(CONTEXT_FIELD, json.dumps(clean, sort_keys=True), update_modified=False)
+	except Exception:
+		frappe.log_error(
+			title="signup context not persisted (run bench migrate?)",
+			message=frappe.get_traceback(),
+		)
 
 
 def update(**fields) -> dict:

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -86,15 +86,35 @@ BENCH_ADMIN_UNREACHABLE = "BENCH_ADMIN_UNREACHABLE"
 BENCH_ADMIN_AUTH_FAILED = "BENCH_ADMIN_AUTH_FAILED"
 BENCH_ADMIN_REJECTED = "BENCH_ADMIN_REJECTED"
 BENCH_RATE_LIMITED = "BENCH_RATE_LIMITED"
-#: No plan is known for an initiate: the local context is empty (a bench that
-#: never ran a signup, or one whose settings were reset) and the caller named
-#: none.
+#: No signup is known on this site: no admin credentials at all (a bench on day
+#: one, or one whose settings were reset), or nothing local to name a plan with
+#: and the caller named none.
+#:
+#: Deliberately ONE code for both rather than a separate BENCH_NOT_STARTED. The
+#: caller's decision is identical - show the signup form - and a wizard with two
+#: codes for one decision grows a branch that can only ever disagree with itself.
 BENCH_NO_SIGNUP_CONTEXT = "BENCH_NO_SIGNUP_CONTEXT"
+#: A provider-truth check found money the control plane could not credit to this
+#: exact attempt, and an operator is placing it. Refused HERE, before the network:
+#: the customer has already paid, and the one thing that must not happen next is
+#: a second intent. Bench-local because the refusal is this facade's - admin's
+#: own durable guard is a separate, ledgered piece of work.
+BENCH_AWAITING_RECONCILIATION = "BENCH_AWAITING_RECONCILIATION"
 
 RECOVERY_RETRY = "retry"
 RECOVERY_CONTINUE_SETUP = "continue_setup"
 RECOVERY_CONTACT_SUPPORT = "contact_support"
 RECOVERY_AUTHENTICATE_OR_RECONNECT = "authenticate_or_reconnect"
+#: Bench-local hint, not one of admin's five: "ask the gateway again, and I will
+#: know more". Advisory like every recovery hint, so an admin that later adopts
+#: the name loses nothing and a consumer that does not know it ignores it.
+RECOVERY_CHECK_STATUS = "check_status"
+
+#: Admin's cap on an idempotency key (``billing/signup.py _MAX_IDEMPOTENCY_KEY_LEN``).
+#: Mirrored rather than discovered: a key admin refuses must never be PERSISTED
+#: here, because the stored key is what the next attempt reuses - see
+#: next_idempotency_key.
+MAX_IDEMPOTENCY_KEY_LEN = 128
 
 # The codes whose recovery IS a new intent: whatever the stored idempotency key
 # bought can no longer be paid. Reusing the key there would be actively wrong -
@@ -102,11 +122,38 @@ RECOVERY_AUTHENTICATE_OR_RECONNECT = "authenticate_or_reconnect"
 # retrying after a decline would be handed the dead order back and could never
 # escape it. Everything else reuses the key, which is what makes a double-click
 # (or a retried POST, or a refreshed pay screen) converge on ONE gateway object.
+#
+# INVALID_REQUEST is in the set for the opposite reason and it is load-bearing: a
+# key admin REFUSED bought nothing at all, so a bench that kept reusing it would
+# replay the same refusal forever with no way out but a settings reset. Validation
+# below is what stops such a key being stored; this is what frees a bench that
+# stored one anyway (an older build, or a bound admin tightens later).
 _SPENT_INTENT_CODES = frozenset(
 	{
 		PAYMENT_DECLINED,
 		NO_CURRENT_INTENT,
 		INTENT_HANDLE_UNAVAILABLE,
+		INVALID_REQUEST,
+	}
+)
+
+# Admin's PAYMENT-STATE vocabulary: the codes that describe where this signup's
+# money actually is. Only these may be folded into the local context, because the
+# context drives the idempotency decision and a rendered stage - and a transport
+# failure, a rate-limit backoff or a bench-local refusal says NOTHING about
+# either. Absorbing "you are asking too often" as the payment's state is how a
+# backoff would come to mint a fresh intent.
+_PAYMENT_STATE_CODES = frozenset(
+	{
+		SIGNUP_VERIFICATION_REQUIRED,
+		PAYMENT_CONFIRMATION_PENDING,
+		PAYMENT_DECLINED,
+		PAYMENT_ALREADY_ACTIVE,
+		NO_CURRENT_INTENT,
+		ACCOUNT_RECONNECT_REQUIRED,
+		PAYMENT_AUTHORIZED_PENDING_CONFIRM,
+		INTENT_HANDLE_UNAVAILABLE,
+		SIGNUP_TERMINAL,
 	}
 )
 
@@ -168,6 +215,11 @@ _ADMIN_KEYS = (
 	"pending_verification",
 	"verification_expires_at",
 	"payment_last_checked_at",
+	# Money the gateway holds that could not be credited to this attempt. Kept
+	# because it OUTLIVES the response that reported it: an operator is placing
+	# that payment, and until a later check says otherwise this bench must refuse
+	# to open a second intent. See awaiting_reconciliation().
+	"awaiting_manual_reconciliation",
 )
 
 # Never persisted, and asserted on: the signup response carries the account's
@@ -180,15 +232,80 @@ _NEVER_PERSIST = ("api_key", "api_secret", "customer", "customer_password", "age
 # intent.
 _LOCAL_ONLY_KEYS = ("idempotency_key",)
 
+# Fields whose value changes on every single poll and means nothing on its own.
+# They are excluded from change DETECTION only - they still ride along in a write
+# that something real triggered. Without this a wizard polling every 2 seconds
+# rewrites the Single forever, because the timestamp is different every time.
+_VOLATILE_KEYS = ("payment_last_checked_at", "gateway_consulted", "updated_at")
+
+# Credential-shaped keys that must never reach the browser, wherever in an admin
+# envelope they appear. The bench persists them (write_connection) and then hands
+# the SAME dict onward, so "we only return what admin sent" was, on the verified
+# poll, a plaintext password in an HTTP response body the page had no use for.
+# Stripping is by KEY, on the way out, so a future admin field named like a
+# credential is caught without a bench release.
+_WIRE_STRIP = ("api_key", "api_secret", "customer_password", "agent_token")
+
+
+def strip_credentials(data: dict | None) -> dict:
+	"""A copy of ``data`` with every credential-shaped key removed.
+
+	The persist path reads the ORIGINAL before this runs; only the wire copy is
+	stripped. ``customer`` is deliberately NOT here - it is the synthetic OAuth
+	login, useless without the password, and the legacy verify flow's JS reads it
+	off the signup response. It has no business being RENDERED, which is what the
+	context block's real email is for."""
+	if not isinstance(data, dict):
+		return {}
+	return {k: v for k, v in data.items() if k not in _WIRE_STRIP}
+
+
+#: One Error Log per hour, not one per poll, for the deploy window below.
+_MISSING_FIELD_LOG_KEY = "jarvis:signup_context:missing_field_logged"
+
+
+def _field_installed() -> bool:
+	"""Does the INSTALLED doctype have the context field?
+
+	``frappe.get_meta().has_field`` and not ``frappe.db.has_column``: Jarvis
+	Settings is a Single, so it has no table of its own and ``has_column`` raises
+	``ProgrammingError('DocType', 'Jarvis Settings')`` when asked. Verified on
+	this bench rather than assumed."""
+	try:
+		return bool(frappe.get_meta("Jarvis Settings").has_field(CONTEXT_FIELD))
+	except Exception:
+		return False
+
+
+def _note_missing_field() -> None:
+	"""Say ONCE an hour that the field is missing. A wizard polls every couple of
+	seconds; an un-throttled log here would bury the Error Log it is trying to
+	warn through."""
+	cache = frappe.cache()
+	if cache.get_value(_MISSING_FIELD_LOG_KEY):
+		return
+	cache.set_value(_MISSING_FIELD_LOG_KEY, 1, expires_in_sec=3600)
+	frappe.log_error(
+		title="signup context field missing - run bench migrate",
+		message=(
+			f"Jarvis Settings.{CONTEXT_FIELD} is not on the installed doctype, so the onboarding "
+			"display context and the payment idempotency key are not being kept. Signup still "
+			"works; a double-click may open two checkouts. Run `bench --site <site> migrate`."
+		),
+	)
+
 
 def load() -> dict:
 	"""The stored context, or ``{}``.
 
-	Never raises. Two ways it can find nothing and both are survivable: a
-	malformed value (hand-edited, half-written), and a bench between a code
-	deploy and its ``bench migrate``, where ``get_single_value`` throws on a
-	field the installed doctype does not have yet. A wizard must not be bricked
-	by its own bookkeeping."""
+	Never raises. Three ways it can find nothing and all are survivable: nothing
+	stored yet, a malformed value (hand-edited, half-written), and a bench between
+	a code deploy and its ``bench migrate`` - where ``get_single_value`` THROWS on
+	a field the installed doctype does not have. A wizard must not be bricked by
+	its own bookkeeping."""
+	if not _field_installed():
+		_note_missing_field()
+		return {}
 	try:
 		raw = frappe.db.get_single_value("Jarvis Settings", CONTEXT_FIELD) or ""
 	except Exception:
@@ -213,23 +330,31 @@ def save(context: dict) -> None:
 	caller that hands the field a raw admin payload fail safe instead of parking
 	an api_secret in a plain-text Settings column.
 
-	Best-effort, and deliberately so. ``db_set`` REJECTS a field the installed
-	doctype does not have ("Field ... does not exist"), which is precisely the
-	state of a bench between a code deploy and its ``bench migrate``. Letting
-	that abort the call would take signup itself down in that window - a strictly
-	worse failure than the one this snapshot exists to prevent - so a wizard is
-	never bricked by its own bookkeeping, on the write side as much as the read
-	side. The cost of the degraded window is a display block the page falls back
-	from, and an idempotency key that is not remembered across a double-click."""
+	SKIPPED entirely when the installed doctype has no such field - the state of a
+	bench between a code deploy and its ``bench migrate``. Checking rather than
+	catching, because the two write layers disagree about what happens then and
+	both answers are bad: ``Document.db_set`` raises (it reads the value back, and
+	the read is what throws), while ``frappe.db.set_single_value`` validates
+	NOTHING and silently writes an orphan ``tabSingles`` row that the next migrate
+	does not clean up. Losing a display snapshot for one deploy window is a bad
+	day; taking signup down, or leaving rows behind, is worse."""
+	if not _field_installed():
+		_note_missing_field()
+		return
 	clean = {k: v for k, v in (context or {}).items() if k not in _NEVER_PERSIST}
 	settings = frappe.get_single("Jarvis Settings")
 	try:
 		settings.db_set(CONTEXT_FIELD, json.dumps(clean, sort_keys=True), update_modified=False)
 	except Exception:
 		frappe.log_error(
-			title="signup context not persisted (run bench migrate?)",
+			title="signup context not persisted",
 			message=frappe.get_traceback(),
 		)
+
+
+def _material(context: dict) -> dict:
+	"""The part of a context that a write would be ABOUT."""
+	return {k: v for k, v in context.items() if k not in _VOLATILE_KEYS}
 
 
 def update(**fields) -> dict:
@@ -237,18 +362,26 @@ def update(**fields) -> dict:
 
 	Empty values are dropped rather than written: a poll that answers with no
 	``amount_inr`` (a verification-stage response, say) must not erase the amount
-	a later screen still has to render. Writes only on a real change, so the
-	wizard's polling costs no DB writes once the state is steady."""
+	a later screen still has to render. ``False`` and ``0`` are NOT empty and are
+	written - ``awaiting_manual_reconciliation: False`` is how a cleared incident
+	is recorded, and dropping it would leave the refusal it drives stuck on
+	forever.
+
+	A write happens only when something MATERIAL changed. The wizard polls every
+	couple of seconds and every answer carries a fresh ``payment_last_checked_at``,
+	so comparing whole dicts made a steady state write the Single on every tick -
+	each write clearing the document cache for every other request on the site."""
 	context = load()
 	merged = dict(context)
 	for key, value in fields.items():
 		if value in (None, "", {}, []):
 			continue
 		merged[key] = value
-	if merged != context:
+	if _material(merged) != _material(context):
 		merged["updated_at"] = frappe.utils.now()
 		save(merged)
-	return merged
+		return merged
+	return context
 
 
 def absorb(payload: dict | None) -> dict:
@@ -271,6 +404,59 @@ def absorb(payload: dict | None) -> dict:
 	return update(**fields)
 
 
+def absorb_check(payload: dict | None) -> dict:
+	"""``absorb`` for a PROVIDER-TRUTH check, which is additionally authoritative
+	about the reconciliation flag.
+
+	Admin sends ``awaiting_manual_reconciliation`` only when it is TRUE, so an
+	ordinary absorb can raise the flag and nothing can ever lower it: the customer
+	would be refused a retry forever, on an incident an operator closed weeks ago.
+	A check is the one surface entitled to say the flag is FALSE, so it says so
+	explicitly."""
+	context = absorb(payload)
+	if not isinstance(payload, dict):
+		return context
+	return update(awaiting_manual_reconciliation=bool(payload.get("awaiting_manual_reconciliation")))
+
+
+def absorb_payment_outcome(err) -> dict:
+	"""Fold a FAILED admin call into the context - but only when it actually
+	reported the payment's state.
+
+	The context drives two decisions (what the page renders, and whether the next
+	initiation reuses its idempotency key), so what may enter it is admin's
+	payment-state vocabulary and nothing else. A rate-limit backoff, a transport
+	failure or a bench-local refusal describes THIS CALL, not the money: absorbing
+	"you are asking too often" as the payment's state would let a backoff mint a
+	fresh intent, and absorbing a network blip would overwrite a real decline.
+
+	Narrow on purpose - the code, its recovery hint and the check stamp. A refusal
+	is not a state read, and the fields it happens to carry are not a substitute
+	for one."""
+	code = getattr(err, "stable_code", "") or getattr(err, "code", "")
+	if code not in _PAYMENT_STATE_CODES:
+		return load()
+	error = getattr(err, "error", None) or {}
+	return update(
+		code=code,
+		recovery=error.get("recovery") or "",
+		payment_last_checked_at=error.get("payment_last_checked_at") or "",
+	)
+
+
+def awaiting_reconciliation(context: dict | None = None) -> bool:
+	"""Did the last provider-truth check find money an operator still has to
+	place?
+
+	While it did, this bench refuses to open another intent. The customer has
+	already paid something the gateway is holding, and the code that comes with it
+	is the ordinary pending one - deliberately, because a decline would invite a
+	second payment - so nothing in the code alone stops a retry. The flag is what
+	stops it."""
+	context = load() if context is None else context
+	return bool(context.get("awaiting_manual_reconciliation"))
+
+
 def wire(context: dict | None = None) -> dict:
 	"""The context block a facade response carries, minus anything local-only."""
 	context = load() if context is None else context
@@ -285,13 +471,41 @@ def clear() -> None:
 # --------------------------------------------------------------------------- #
 # idempotency
 # --------------------------------------------------------------------------- #
+def supplied_key_error(supplied: str | None) -> dict | None:
+	"""Why a caller-supplied idempotency key is unusable, or None.
+
+	Checked HERE, before the key is persisted, and that order is the whole point.
+	The stored key is what the NEXT attempt reuses, so a key admin will refuse
+	must never be written: the previous shape stored it, admin answered
+	``INVALID_REQUEST``, and every subsequent attempt replayed the same refusal
+	from the same stored key - a self-inflicted brick with no way out but a
+	settings reset.
+
+	The bound mirrors admin's ``_MAX_IDEMPOTENCY_KEY_LEN``. Duplicating a remote
+	constant is a drift risk taken deliberately: a local refusal costs one HTTP
+	round trip and leaves nothing behind, and the wrong direction of drift (ours
+	stricter) is a caller told to shorten a key, while the other (ours looser) is
+	the exact 400 admin already answers - which the INVALID_REQUEST entry in
+	_SPENT_INTENT_CODES then clears rather than sticks on."""
+	supplied = (supplied or "").strip()
+	if not supplied:
+		return None
+	if len(supplied) > MAX_IDEMPOTENCY_KEY_LEN:
+		return {
+			"code": INVALID_REQUEST,
+			"message": f"idempotency_key must be at most {MAX_IDEMPOTENCY_KEY_LEN} characters",
+			"recovery": RECOVERY_RETRY,
+		}
+	return None
+
+
 def next_idempotency_key(*, supplied: str | None = None, context: dict | None = None) -> str:
 	"""The key for the payment initiation about to be made.
 
-	``supplied`` (from the caller) wins verbatim - including an over-long one,
-	which admin answers with a coded ``INVALID_REQUEST`` it can fix. Silently
-	truncating would hand it a DIFFERENT key than the one it thinks it sent, and
-	an idempotency key that is not the caller's is worse than none.
+	``supplied`` (from the caller) wins verbatim. Never truncated: a key that is
+	not the one the caller thinks it sent is worse than no key at all, so an
+	unusable one is REFUSED by the endpoint (see supplied_key_error) instead of
+	being quietly rewritten into a different request.
 
 	Otherwise: reuse the stored key while the intent it bought is still payable
 	(so a double-click, a retried POST and a refreshed pay screen all converge on
@@ -328,6 +542,7 @@ def error_object(err) -> tuple[dict, int]:
 		AdminAuthError,
 		AdminContractError,
 		AdminRateLimitedError,
+		AdminRejectedError,
 		AdminUnreachableError,
 		AdminValidationError,
 	)
@@ -359,6 +574,18 @@ def error_object(err) -> tuple[dict, int]:
 		if getattr(err, "exc_type", None):
 			out["exc_type"] = err.exc_type
 		return out, 409
+	if isinstance(err, AdminRejectedError):
+		# Admin was REACHED and permanently refused (its fleet layer answers a
+		# config it can never accept with a 502 carrying its own error.code). It
+		# is a subclass of AdminUnreachableError, so it must be answered before
+		# that branch - collapsing it into "unreachable" is the exact mistake
+		# jarvis #542 was about: a deterministic refusal recorded as "still
+		# landing", which a caller then waits out forever.
+		return {
+			"code": err.code or BENCH_ADMIN_REJECTED,
+			"message": err.detail or str(err),
+			"recovery": RECOVERY_CONTACT_SUPPORT,
+		}, 502
 	if isinstance(err, AdminUnreachableError):
 		return {
 			"code": BENCH_ADMIN_UNREACHABLE,
@@ -382,17 +609,33 @@ def stamp_error(error: dict) -> None:
 
 
 def success(data: dict, *, context: dict | None = None) -> dict:
-	"""A facade success: admin's envelope verbatim, plus the local context.
+	"""A facade success: admin's envelope plus the local context.
 
-	``data`` is NOT filtered. Every capability flag, disclosure field and code
-	admin added - including ones this bench build has never heard of - reaches
-	the caller, which is what makes an additive admin release a no-op here."""
+	Additive by default and subtractive only for credentials. Every capability
+	flag, disclosure field and code admin added - including ones this bench build
+	has never heard of - reaches the caller, which is what makes an additive admin
+	release a no-op here; the ONE exception is the credential-shaped keys
+	``strip_credentials`` removes, because "return exactly what admin sent" put
+	the customer's OAuth password in an HTTP response body on the verified poll.
+	The bench has already persisted it by the time this runs; the page never
+	wanted it."""
+	data = data or {}
 	return {
 		"ok": True,
-		"contract_version": int((data or {}).get("contract_version") or CONTRACT_VERSION),
-		"data": data or {},
+		"contract_version": _int_or(data.get("contract_version"), CONTRACT_VERSION),
+		"data": strip_credentials(data),
 		"context": wire(context),
 	}
+
+
+def _int_or(value, fallback: int) -> int:
+	"""``int(value)``, or ``fallback`` when it is not a number. A malformed
+	``contract_version`` from a proxy or a half-upgraded admin is a bad field, not
+	a reason to 500 the payment page."""
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		return fallback
 
 
 def failure(error: dict, status: int, *, context: dict | None = None) -> dict:

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -137,12 +137,18 @@ _SPENT_INTENT_CODES = frozenset(
 	}
 )
 
-# Admin's PAYMENT-STATE vocabulary: the codes that describe where this signup's
-# money actually is. Only these may be folded into the local context, because the
-# context drives the idempotency decision and a rendered stage - and a transport
-# failure, a rate-limit backoff or a bench-local refusal says NOTHING about
-# either. Absorbing "you are asking too often" as the payment's state is how a
-# backoff would come to mint a fresh intent.
+# The codes a FAILED call may write into the local context. Almost all of them
+# are admin's payment-state vocabulary - what this signup's money is actually
+# doing - because the context drives both what the page renders and whether the
+# next initiation reuses its key, and a transport failure or a rate-limit backoff
+# says nothing about either. Absorbing "you are asking too often" as the
+# payment's state is how a backoff would come to mint a fresh intent.
+#
+# INVALID_REQUEST is the one member that is NOT a payment state, and it is here
+# on purpose: it is the verdict on the KEY. Without it the self-heal below is
+# unreachable - a stored key admin refuses can never be recorded as refused, so
+# _SPENT_INTENT_CODES never sees it and every later attempt replays the same
+# refusal. Its presence is what makes that brick clear itself on the next click.
 _PAYMENT_STATE_CODES = frozenset(
 	{
 		SIGNUP_VERIFICATION_REQUIRED,
@@ -154,8 +160,23 @@ _PAYMENT_STATE_CODES = frozenset(
 		PAYMENT_AUTHORIZED_PENDING_CONFIRM,
 		INTENT_HANDLE_UNAVAILABLE,
 		SIGNUP_TERMINAL,
+		INVALID_REQUEST,
 	}
 )
+
+
+class SignupConflictError(frappe.ValidationError):
+	"""A bench-side refusal that reaches the wire as 409, not 417.
+
+	``handle_exception`` reads the status off the exception CLASS
+	(``getattr(e, "http_status_code", 500)``), so hand-setting
+	``frappe.local.response.http_status_code`` before a throw is overwritten by
+	``report_error`` - the status is a property of the type and nothing else.
+	Plain ``frappe.ValidationError`` is 417, which no HTTP client reads as "this
+	conflicts with the state you are already in". Mirrors admin's own
+	``codes.InvalidRequestError``, from the other end of the same contract."""
+
+	http_status_code = 409
 
 
 def is_duplicate_signup(err) -> bool:
@@ -331,13 +352,15 @@ def save(context: dict) -> None:
 	an api_secret in a plain-text Settings column.
 
 	SKIPPED entirely when the installed doctype has no such field - the state of a
-	bench between a code deploy and its ``bench migrate``. Checking rather than
-	catching, because the two write layers disagree about what happens then and
-	both answers are bad: ``Document.db_set`` raises (it reads the value back, and
-	the read is what throws), while ``frappe.db.set_single_value`` validates
-	NOTHING and silently writes an orphan ``tabSingles`` row that the next migrate
-	does not clean up. Losing a display snapshot for one deploy window is a bad
-	day; taking signup down, or leaving rows behind, is worse."""
+	bench between a code deploy and its ``bench migrate``. CHECKING rather than
+	catching, and the difference is the whole reason this guard exists: writing a
+	Single validates NOTHING against meta. ``Document.db_set`` does not raise on a
+	field the doctype has never heard of - verified on frappe 16.25.0 against a
+	field with no prior row - it silently inserts an orphan ``tabSingles`` row
+	that no migrate cleans up and no read can ever get back (``get_single_value``
+	looks the field up in meta and THROWS, which is the asymmetry). A guard
+	written as try/except would therefore have caught nothing and littered every
+	bench deployed ahead of its migrate."""
 	if not _field_installed():
 		_note_missing_field()
 		return

--- a/jarvis/tests/fixtures/admin_contract/PROVENANCE.md
+++ b/jarvis/tests/fixtures/admin_contract/PROVENANCE.md
@@ -1,0 +1,77 @@
+# Vendored admin contract fixtures
+
+These JSON files are **not ours**. They are a byte-for-byte copy of the wire
+contract the control plane publishes for the signup / payment-recovery flow, and
+they are here so this repository's tests replay the *other* side's published
+truth instead of a local re-statement of it.
+
+## Source
+
+| | |
+|---|---|
+| repo | `git@github.com:Aerele-RnD/jarvis-admin-v2.git` |
+| branch | `feat/onboarding-reconcile` |
+| commit | `99740f2` ("fix(billing): review round - lock lifetime, parked rows, and the pay button") |
+| path | `jarvis_admin_v2/tests/billing/fixtures/*.json` |
+| copied | 2026-08-02 |
+
+`README.md` in that directory is the contract's prose (the two wire shapes, the
+capability flags, the codes-not-messages rule). It is deliberately NOT copied:
+one authoritative copy, on the side that owns the vocabulary. Read it there.
+
+Checksums of what was copied, so drift is visible rather than argued about:
+
+```
+061aabf5b44131ae639fd3cc493697f9843ca6b49fb85cfe12b3f2de43f195f5  account_reconnect_required.json
+a647f72beebfae8e43870fdbba2d669b862890e76a150ff3916ca00d6478362c  duplicate_409.json
+389e75957ddc715c0760b10324617b87546438f144c369a2a6aa11f7256fae76  legacy_v1_duplicate_409.json
+2a3ced8920d84712c45976276ae6a041293e068acaf05aed18b105914a346e82  payment_already_active.json
+86d39fd6297d46e2c98d23096e27688e004a88f1df93f5a164340d9feb35aea0  payment_check_rate_limited.json
+42ae064fb6407c1ded2d705a785c4e285b9359bde7c27cb764bb2d16cfccfc77  payment_declined_mandate.json
+75bead5d397ee8661d17d5cfdf4553bf7c848f372a2912482722e6ed4408c7e2  reconcile_authorized_pending_confirm.json
+70549805007c7c22584d73b6ba9ac4bbff50d2e17811a0d24d406897418af7a0  reconcile_declined.json
+bca211819996fe51afca89aeda5774a6dd787ecd98be33b14eb82b5597f6b7a3  reconcile_paid_active.json
+93bf1ae29ff36e4f0abefbe6472573675cc275a0f864b402ed405d6445dac104  reconcile_pending.json
+df5596bc4925ef05b13a861f3676b38b7684deb219417ba6806e4a743a8ac971  reconcile_unmatched_payment.json
+41dfbd2bac688c7d25a5189a43c28dbcc27a3b20ea104f7f66c41ac5442732bf  resume_intent.json
+c7a7237c2a4d95c0acd70be22de4b70a0ef317f49ab0af77099ed791d42e5e68  signup_terminal.json
+fd508b91a430f688a42bec006b0741c2ecf9ab30c05b19c37f57b16931ef9045  state_mandate_pending.json
+e6353a18b9b9ab9ad2d0cf344517defb5b162cc893078637810f7a25a5376b24  state_mandate_pending_razorpay.json
+43dc1fb4574e760455601ee5428ee7fbc6b20d89ea2a5c5c4d415b0d5822db41  state_no_current_intent.json
+bdd79f8c19879c4cfe9b5871e10f9334c83678951e247fb90a9eab1cb73cecc6  verification_required.json
+```
+
+## Why a copy exists at all
+
+Because the last time each side kept its own statement of this contract, both
+repositories stayed green while every real declined-card customer hit a dead
+end. Admin reworded its duplicate-signup message on 2026-07-26; the bench's
+failed-payment resume string-matched the old sentence; the only surviving copy
+of that sentence in this tree was **this suite's own fixture**, so nothing here
+could notice. `test_admin_contract.py` replays these files through the real
+`admin_client` parser, which is what makes a rewording harmless and a contract
+change loud.
+
+## Editing rule
+
+**Never edit a file in this directory to make a test pass.** They describe what
+the control plane sends. If a fixture and this bench disagree, either the bench
+is wrong or the contract genuinely changed — and a contract change is a change
+*over there*, landed first, then re-copied here.
+
+## Re-syncing
+
+Manual today, deliberately: the combined-head CI that would make it automatic is
+blocked behind the llm-proxy PAT pin in admin's `pyproject` (admin #119/#122 +
+fleet #161). Until that lands:
+
+```bash
+cp <admin-checkout>/jarvis_admin_v2/tests/billing/fixtures/*.json \
+   jarvis/tests/fixtures/admin_contract/
+sha256sum jarvis/tests/fixtures/admin_contract/*.json   # update the table above
+```
+
+and run `jarvis.tests.test_admin_contract`. A fixture whose `contract_version`
+is higher than `jarvis.onboarding_contract.CONTRACT_VERSION` means a BREAKING
+shape change shipped and the facade has to be read again, not re-pinned; the
+suite asserts that and fails on it.

--- a/jarvis/tests/fixtures/admin_contract/PROVENANCE.md
+++ b/jarvis/tests/fixtures/admin_contract/PROVENANCE.md
@@ -1,11 +1,20 @@
-# Vendored admin contract fixtures
+# Admin contract fixtures
 
-These JSON files are **not ours**. They are a byte-for-byte copy of the wire
-contract the control plane publishes for the signup / payment-recovery flow, and
-they are here so this repository's tests replay the *other* side's published
-truth instead of a local re-statement of it.
+Two kinds of file live here and the difference is load-bearing.
 
-## Source
+**Vendored** (the table below): byte-for-byte copies of the wire contract the
+control plane publishes. They are **not ours** — they are here so this
+repository's tests replay the *other* side's published truth instead of a local
+re-statement of it.
+
+**Bench-authored** (listed at the bottom): cases this bench must survive that the
+admin corpus does not yet contain. They carry a `produced_by` field saying so.
+They are not checksummed against admin, they are not evidence of what admin
+sends, and each one has an admin-side twin ledgered for the next admin round.
+Keeping them in the same directory is deliberate — the reader under test is the
+same, and the alternative is a second loader nobody runs.
+
+## Source (vendored files only)
 
 | | |
 |---|---|
@@ -40,6 +49,16 @@ e6353a18b9b9ab9ad2d0cf344517defb5b162cc893078637810f7a25a5376b24  state_mandate_
 43dc1fb4574e760455601ee5428ee7fbc6b20d89ea2a5c5c4d415b0d5822db41  state_no_current_intent.json
 bdd79f8c19879c4cfe9b5871e10f9334c83678951e247fb90a9eab1cb73cecc6  verification_required.json
 ```
+
+`test_admin_contract.py` recomputes that table and fails on a mismatch, so a
+vendored file edited in place is caught rather than argued about.
+
+## Bench-authored files (NOT vendored, NOT checksummed)
+
+| file | why it exists | admin-side twin |
+|---|---|---|
+| `duplicate_409_code_only.json` | Every vendored duplicate fixture carries `exc_type`, so the bench's `error.code` branch was never actually exercised — delete it and the suite stayed green. This is the returned-envelope form (`codes.error_response`, no `exc_type`), which is what the contract says a coded rejection is. | **LEDGERED**: admin adds the same case, or states that the guest duplicate will always be a raise. |
+| `state_verification_required.json` | The passive poll's answer while the magic link is unclicked — the state a wizard sits in longest and had no fixture for. `verification_required.json` is the *resume* endpoint's version of the same cohort; the capability flags differ. | **LEDGERED**: admin adds the poll-side case beside its resume-side one. |
 
 ## Why a copy exists at all
 

--- a/jarvis/tests/fixtures/admin_contract/PROVENANCE.md
+++ b/jarvis/tests/fixtures/admin_contract/PROVENANCE.md
@@ -60,6 +60,29 @@ vendored file edited in place is caught rather than argued about.
 | `duplicate_409_code_only.json` | Every vendored duplicate fixture carries `exc_type`, so the bench's `error.code` branch was never actually exercised — delete it and the suite stayed green. This is the returned-envelope form (`codes.error_response`, no `exc_type`), which is what the contract says a coded rejection is. | **LEDGERED**: admin adds the same case, or states that the guest duplicate will always be a raise. |
 | `state_verification_required.json` | The passive poll's answer while the magic link is unclicked — the state a wizard sits in longest and had no fixture for. `verification_required.json` is the *resume* endpoint's version of the same cohort; the capability flags differ. | **LEDGERED**: admin adds the poll-side case beside its resume-side one. |
 
+## Ledger — known gaps, deliberately not closed here
+
+Recorded rather than fixed, each because closing it here would be worse than
+carrying it:
+
+1. **Admin has no durable parked-money marker.** The bench refuses to open a new
+   intent while the last provider-truth check reported
+   `awaiting_manual_reconciliation` (`onboarding_contract.awaiting_reconciliation`),
+   and that refusal now covers `start_signup` as well as
+   `initiate_signup_payment`. But it is bench-local state: a settings reset, a
+   rebuilt site, or a second bench pointed at the same account does not have it.
+   The durable guard belongs on admin's own `resume_pending_signup`, beside a
+   parked marker on the subscription row. **Next admin round.**
+2. **`onboarding_contract.clear()` has no callers.** The signup context — plan,
+   idempotency key, and the reconciliation flag — survives
+   `request_workspace_reset`, so a reset workspace keeps a stale plan as its
+   sticky default. Not wired in here for two reasons: the natural call site sits
+   inside the hunk zone another in-flight branch is editing, and clearing the
+   context also clears the parked-money flag, which would silently drop the
+   refusal in (1) for exactly the customer most likely to be resetting. It lands
+   with the admin-side durable marker, which makes the flag survivable.
+3. **Both bench-authored fixtures need admin-side twins** — see the table above.
+
 ## Why a copy exists at all
 
 Because the last time each side kept its own statement of this contract, both

--- a/jarvis/tests/fixtures/admin_contract/account_reconnect_required.json
+++ b/jarvis/tests/fixtures/admin_contract/account_reconnect_required.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 2,
+  "name": "account_reconnect_required",
+  "description": "An authenticated state/check call for an account that is genuinely paid and has been running long enough to be an EXISTING setup rather than the signup anybody is finishing. 'Continue setup' would point this caller at a container it holds no credentials for; the emailed reconnect code is the path, and no payment is owed. Emitted by the authenticated surfaces ONLY - the guest duplicate rejection stays generic (ACCOUNT_ALREADY_EXISTS), because saying 'reconnect' to an unauthenticated caller would disclose that the account is live. A caller decides whether to OFFER reconnect from can_reconnect, which every envelope carries.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "ACCOUNT_RECONNECT_REQUIRED",
+        "pending_verification": false,
+        "subscription_status": "Active",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "can_initiate_payment": false,
+        "can_check_status": false,
+        "can_reconnect": true,
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1,
+        "gateway_consulted": false,
+        "recovery": "authenticate_or_reconnect"
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/duplicate_409.json
+++ b/jarvis/tests/fixtures/admin_contract/duplicate_409.json
@@ -1,0 +1,18 @@
+{
+  "contract_version": 2,
+  "name": "duplicate_409",
+  "description": "Guest signup for an (email, company) that already has an account. A deliberate 409 carrying BOTH Frappe's exc_type and the stable code; the bench keys its failed-payment resume off one of those, never off the message prose. This is the THROWN wire shape: the error object sits at the top level next to exc_type, with no `message` wrapper and no `ok` key.",
+  "endpoint": "jarvis_admin_v2.billing.signup.signup",
+  "http_status": 409,
+  "volatile": [
+    "body.error.message"
+  ],
+  "body": {
+    "exc_type": "DuplicateEntryError",
+    "error": {
+      "code": "ACCOUNT_ALREADY_EXISTS",
+      "message": "An account for this email and company already exists.",
+      "recovery": "authenticate_or_reconnect"
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/duplicate_409_code_only.json
+++ b/jarvis/tests/fixtures/admin_contract/duplicate_409_code_only.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 2,
+  "name": "duplicate_409_code_only",
+  "description": "The duplicate rejection in its RETURNED form: admin's codes.error_response envelope, nested under Frappe's `message` key, with the stable code and NO exc_type anywhere. Admin does not emit this today - the guest rejection is a raised DuplicateEntryError - but the contract says codes are the machine-readable part and exc_type is Frappe's incidental framing, so a reader that only works when BOTH are present is one refactor away from the original dead end. Every other duplicate fixture carries exc_type, which means the bench's code branch was never the thing being tested. This is the fixture that tests it.",
+  "produced_by": "BENCH-AUTHORED forward-compatibility case (not vendored; see PROVENANCE.md). The admin-side twin is ledgered for the next admin round.",
+  "endpoint": "jarvis_admin_v2.billing.signup.signup",
+  "http_status": 409,
+  "volatile": [
+    "body.message.error.message"
+  ],
+  "body": {
+    "message": {
+      "ok": false,
+      "error": {
+        "code": "ACCOUNT_ALREADY_EXISTS",
+        "message": "An account for this email and company already exists.",
+        "recovery": "authenticate_or_reconnect"
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/legacy_v1_duplicate_409.json
+++ b/jarvis/tests/fixtures/admin_contract/legacy_v1_duplicate_409.json
@@ -1,0 +1,17 @@
+{
+  "contract_version": 1,
+  "name": "legacy_v1_duplicate_409",
+  "description": "HISTORICAL, and NOT produced by this admin any more. The duplicate rejection as every admin before this contract shipped it: a 409 whose only machine-readable part is Frappe's exc_type, with the reason carried in prose that was reworded on 2026-07-26 and killed the bench's failed-payment resume. A reader that has to work against a fleet mid-upgrade will meet this shape from an older control plane, so it must fall back to (http_status, exc_type) when `error.code` is absent - and must NEVER branch on the sentence, which is exactly what broke.",
+  "produced_by": "pre-contract admin (historical; asserted for shape only, not against this serializer)",
+  "endpoint": "jarvis_admin_v2.billing.signup.signup",
+  "http_status": 409,
+  "volatile": [
+    "body.exception",
+    "body._server_messages"
+  ],
+  "body": {
+    "exc_type": "DuplicateEntryError",
+    "exception": "frappe.exceptions.DuplicateEntryError: An account for this email already exists.",
+    "_server_messages": "[\"{\\\"message\\\": \\\"An account for this email already exists.\\\"}\"]"
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/payment_already_active.json
+++ b/jarvis/tests/fixtures/admin_contract/payment_already_active.json
@@ -1,0 +1,23 @@
+{
+  "contract_version": 2,
+  "name": "payment_already_active",
+  "description": "Retry against a signup that is already paid - most often the webhook activated between the failed checkout and the retry. A distinct, actionable answer instead of the old blanket NotResumable, and never a second payment intent.",
+  "endpoint": "jarvis_admin_v2.billing.signup.resume_pending_signup",
+  "http_status": 409,
+  "volatile": [
+    "body.message.error.attempt_id",
+    "body.message.error.message"
+  ],
+  "body": {
+    "message": {
+      "ok": false,
+      "error": {
+        "code": "PAYMENT_ALREADY_ACTIVE",
+        "message": "This signup is already paid. Continue setup.",
+        "recovery": "continue_setup",
+        "subscription_status": "Active",
+        "attempt_id": "att_placeholder"
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/payment_check_rate_limited.json
+++ b/jarvis/tests/fixtures/admin_contract/payment_check_rate_limited.json
@@ -1,0 +1,22 @@
+{
+  "contract_version": 2,
+  "name": "payment_check_rate_limited",
+  "description": "This account has asked for provider truth too often. Every uncached check spends a gateway call, so the cap is per CUSTOMER (the stock per-IP limiter is either one bench behind a NAT or a hundred behind a proxy). NOTHING is asserted about the payment - the caller waits `retry_after_seconds` and asks again, and MUST NOT treat this as a decline or offer to pay again. It carries a code rather than a bare 429 because 'back off' and 'your payment failed' are opposite instructions and a caller that can only read the status has to guess which one it got.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 429,
+  "volatile": [
+    "body.message.error.message",
+    "body.message.error.retry_after_seconds"
+  ],
+  "body": {
+    "message": {
+      "ok": false,
+      "error": {
+        "code": "PAYMENT_CHECK_RATE_LIMITED",
+        "message": "We're still checking with your payment provider. Please try again in a moment.",
+        "recovery": "retry",
+        "retry_after_seconds": 1234
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/payment_declined_mandate.json
+++ b/jarvis/tests/fixtures/admin_contract/payment_declined_mandate.json
@@ -1,0 +1,19 @@
+{
+  "contract_version": 2,
+  "name": "payment_declined_mandate",
+  "description": "A Cashfree AUTOPAY confirm where the mandate is NOT authorized at the gateway (the customer abandoned the redirect, or the authorization failed). Distinct from PAYMENT_CONFIRMATION_PENDING, which is what an e-NACH still awaiting the customer's bank returns: a decline means a NEW intent is the recovery, pending means poll again.",
+  "endpoint": "jarvis_admin_v2.api.tenant.confirm_payment",
+  "http_status": 402,
+  "volatile": [
+    "body.message.error.message"
+  ],
+  "body": {
+    "message": {
+      "ok": false,
+      "error": {
+        "code": "PAYMENT_DECLINED",
+        "message": "This Cashfree mandate is not authorized."
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/reconcile_authorized_pending_confirm.json
+++ b/jarvis/tests/fixtures/admin_contract/reconcile_authorized_pending_confirm.json
@@ -1,0 +1,34 @@
+{
+  "contract_version": 2,
+  "name": "reconcile_authorized_pending_confirm",
+  "description": "A provider-truth check on a Razorpay AUTOPAY signup whose mandate the gateway says is authorized. The customer has already parted with the authorization amount, but Razorpay publishes no route from a subscription id to its authorization PAYMENT id - so there is no idempotency key to activate under, and activating without one is the double activation this contract exists to prevent. The honest answer is CONFIRM, never a new intent: a second intent authorizes a second mandate and charges the signup fee twice. `can_initiate_payment` is FALSE to match (the retry path refuses this state outright), and `recovery` carries the same instruction the 409 form of this code carries, so one reader handles both.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at",
+    "body.message.data.razorpay_key_id",
+    "body.message.data.razorpay_subscription_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+        "recovery": "confirm_payment",
+        "pending_verification": false,
+        "payment_provider": "razorpay",
+        "razorpay_subscription_id": "sub_placeholder",
+        "razorpay_key_id": "placeholder",
+        "can_initiate_payment": false,
+        "can_check_status": true,
+        "can_reconnect": false,
+        "gateway_consulted": true,
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/reconcile_declined.json
+++ b/jarvis/tests/fixtures/admin_contract/reconcile_declined.json
@@ -1,0 +1,37 @@
+{
+  "contract_version": 2,
+  "name": "reconcile_declined",
+  "description": "A provider-truth check whose gateway says every payment on this intent was refused. Distinct from PAYMENT_CONFIRMATION_PENDING in exactly one way that matters to the caller: a NEW intent is the recovery here, and polling is not. The dead handle is still reported - the check never replaces an intent, only an explicit retry does - so the caller branches on the code and not on the presence of a handle.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at",
+    "body.message.data.razorpay_key_id",
+    "body.message.data.razorpay_order_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_DECLINED",
+        "pending_verification": false,
+        "payment_provider": "razorpay",
+        "amount_inr": 12000.0,
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "razorpay_key_id": "placeholder",
+        "razorpay_order_id": "order_placeholder",
+        "can_initiate_payment": true,
+        "can_check_status": true,
+        "can_reconnect": false,
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1,
+        "gateway_consulted": true,
+        "recovery": "retry"
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/reconcile_paid_active.json
+++ b/jarvis/tests/fixtures/admin_contract/reconcile_paid_active.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 2,
+  "name": "reconcile_paid_active",
+  "description": "The recovery this endpoint exists for: the customer paid, the checkout callback died and the webhook never arrived, so the row still said Pending Payment. A provider-truth check found the captured payment at the gateway and converged through the ordinary activation seam under the gateway's own payment id - so the callback that later turns up, and the late webhook, are no-ops rather than second activations. The answer is the ordinary PAYMENT_ALREADY_ACTIVE the wizard already knows: continue setup.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_ALREADY_ACTIVE",
+        "pending_verification": false,
+        "subscription_status": "Active",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "can_initiate_payment": false,
+        "can_check_status": false,
+        "can_reconnect": false,
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1,
+        "gateway_consulted": true,
+        "recovery": "continue_setup"
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/reconcile_pending.json
+++ b/jarvis/tests/fixtures/admin_contract/reconcile_pending.json
@@ -1,0 +1,42 @@
+{
+  "contract_version": 2,
+  "name": "reconcile_pending",
+  "description": "A provider-truth check whose gateway says the intent is alive and undecided - an unopened checkout, a payment still in flight, an e-NACH the bank is still approving. Same code the passive poll returns, deliberately: the caller polls or re-checks, and it must NOT be routed at a retry, which would open a second gateway object alongside a live one. The checkout handle is still served so the customer can simply finish paying.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at",
+    "body.message.data.razorpay_key_id",
+    "body.message.data.razorpay_order_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_CONFIRMATION_PENDING",
+        "pending_verification": false,
+        "payment_provider": "razorpay",
+        "amount_inr": 12000.0,
+        "plan": {
+          "name": "oc-test-annual",
+          "label": "oc-test-annual"
+        },
+        "signup_fee_inr": 0.0,
+        "due_today_inr": 12000.0,
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "razorpay_key_id": "placeholder",
+        "razorpay_order_id": "order_placeholder",
+        "can_initiate_payment": true,
+        "can_check_status": true,
+        "can_reconnect": false,
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1,
+        "gateway_consulted": true
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/reconcile_unmatched_payment.json
+++ b/jarvis/tests/fixtures/admin_contract/reconcile_unmatched_payment.json
@@ -1,0 +1,36 @@
+{
+  "contract_version": 2,
+  "name": "reconcile_unmatched_payment",
+  "description": "A provider-truth check that found money at the gateway which cannot be tied to this exact subscription and generation (the amount, currency or receipt/notes linkage disagrees; a retry superseded the intent mid-check; the row was parked by an operator). NOTHING is activated and ops is paged - either a customer has paid into an intent we cannot credit, or this row points at an order that is not theirs, and both are money questions no automatic rule may answer. The customer is told we are still confirming, on purpose: reporting a decline here invites a SECOND payment on top of the one already unplaceable. The CODE is the ordinary pending one - the incident is an operator's, not the customer's - and `awaiting_manual_reconciliation` is what distinguishes it: while it is true a human is placing money the gateway is holding, so `can_initiate_payment` is FALSE and a surface must suppress its Pay affordance. The alert body tells the operator not to ask the customer to pay again; this is the API saying the same thing.",
+  "endpoint": "jarvis_admin_v2.billing.signup.check_signup_payment_status",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at",
+    "body.message.data.razorpay_key_id",
+    "body.message.data.razorpay_order_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_CONFIRMATION_PENDING",
+        "pending_verification": false,
+        "payment_provider": "razorpay",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "razorpay_key_id": "placeholder",
+        "razorpay_order_id": "order_placeholder",
+        "can_initiate_payment": false,
+        "can_check_status": true,
+        "can_reconnect": false,
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1,
+        "gateway_consulted": true,
+        "awaiting_manual_reconciliation": true
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/resume_intent.json
+++ b/jarvis/tests/fixtures/admin_contract/resume_intent.json
@@ -1,0 +1,35 @@
+{
+  "contract_version": 2,
+  "name": "resume_intent",
+  "description": "Authenticated failed-payment retry on a Pending Payment signup: a fresh checkout handle on a NEW intent generation, on the same subscription. Never a second account, never a second subscription. Carries the billing disclosure (plan, signup fee, what is actually due today) and the account identity a reloaded wizard renders.",
+  "endpoint": "jarvis_admin_v2.billing.signup.resume_pending_signup",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.razorpay_key_id",
+    "body.message.data.razorpay_order_id",
+    "body.message.data.attempt_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_CONFIRMATION_PENDING",
+        "payment_provider": "razorpay",
+        "amount_inr": 12000.0,
+        "plan": {
+          "name": "oc-test-annual",
+          "label": "oc-test-annual"
+        },
+        "signup_fee_inr": 0.0,
+        "due_today_inr": 12000.0,
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "razorpay_key_id": "rzp_test_placeholder",
+        "razorpay_order_id": "order_placeholder",
+        "attempt_id": "att_placeholder",
+        "generation": 2
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/signup_terminal.json
+++ b/jarvis/tests/fixtures/admin_contract/signup_terminal.json
@@ -1,0 +1,27 @@
+{
+  "contract_version": 2,
+  "name": "signup_terminal",
+  "description": "The signup cohort that is past the checkout stage and cannot be driven further by the onboarding flow: cancelled, expired, lapsed into Past Due, or belonging to a suspended account. ONE code for all of them because the caller's decision is the same - this is renewal, reconnect or support, not a payment - and because a wizard with no code for a state renders whatever state it happens to have been left in.",
+  "endpoint": "jarvis_admin_v2.billing.signup.get_signup_payment_state",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "SIGNUP_TERMINAL",
+        "pending_verification": false,
+        "subscription_status": "Cancelled",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "payment_last_checked_at": "2026-08-01 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/state_mandate_pending.json
+++ b/jarvis/tests/fixtures/admin_contract/state_mandate_pending.json
@@ -1,0 +1,43 @@
+{
+  "contract_version": 2,
+  "name": "state_mandate_pending",
+  "description": "Authenticated state poll for a Cashfree AUTOPAY signup awaiting mandate authorization. The mandate id is a checkout handle exactly like an order id; before this contract the state endpoint did not look at it and told every mandate customer to start over. The mandate id and the browser session token are GATEWAY-minted per attempt, so only their presence is pinned.",
+  "endpoint": "jarvis_admin_v2.billing.signup.get_signup_payment_state",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.cashfree_app_id",
+    "body.message.data.cashfree_env",
+    "body.message.data.cashfree_subscription_id",
+    "body.message.data.subscription_session_id",
+    "body.message.data.payment_last_checked_at",
+    "body.message.data.attempt_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_CONFIRMATION_PENDING",
+        "pending_verification": false,
+        "payment_provider": "cashfree",
+        "amount_inr": 999.0,
+        "plan": {
+          "name": "oc-test-cf-monthly",
+          "label": "oc-test-cf-monthly"
+        },
+        "signup_fee_inr": 0.0,
+        "due_today_inr": 999.0,
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "cashfree_app_id": "placeholder",
+        "cashfree_env": "sandbox",
+        "cashfree_subscription_id": "jrvs_placeholder",
+        "subscription_session_id": "sub_session_placeholder",
+        "trial_days": 0,
+        "payment_last_checked_at": "2026-08-01 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/state_mandate_pending_razorpay.json
+++ b/jarvis/tests/fixtures/admin_contract/state_mandate_pending_razorpay.json
@@ -1,0 +1,42 @@
+{
+  "contract_version": 2,
+  "name": "state_mandate_pending_razorpay",
+  "description": "Authenticated state poll for a RAZORPAY autopay signup awaiting mandate authorization. Kept beside state_mandate_pending because the two gateways' mandate handles are NOT the same shape and a reader must cope with both: Razorpay Checkout opens straight against the subscription id, so there is no browser session token here at all (and therefore INTENT_HANDLE_UNAVAILABLE can never arise on this path), while Cashfree's handle is useless without subscription_session_id. The trial disclosure fields are the same on both.",
+  "endpoint": "jarvis_admin_v2.billing.signup.get_signup_payment_state",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.razorpay_key_id",
+    "body.message.data.razorpay_subscription_id",
+    "body.message.data.effective_first_charge_at",
+    "body.message.data.payment_last_checked_at",
+    "body.message.data.attempt_id"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "PAYMENT_CONFIRMATION_PENDING",
+        "pending_verification": false,
+        "payment_provider": "razorpay",
+        "amount_inr": 999.0,
+        "plan": {
+          "name": "oc-test-rzp-monthly",
+          "label": "oc-test-rzp-monthly"
+        },
+        "signup_fee_inr": 0.0,
+        "due_today_inr": 0.0,
+        "effective_first_charge_at": 0,
+        "effective_trial_days": 14,
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "razorpay_key_id": "rzp_test_placeholder",
+        "razorpay_subscription_id": "sub_placeholder",
+        "trial_days": 14,
+        "payment_last_checked_at": "2026-08-01 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/state_no_current_intent.json
+++ b/jarvis/tests/fixtures/admin_contract/state_no_current_intent.json
@@ -1,0 +1,27 @@
+{
+  "contract_version": 2,
+  "name": "state_no_current_intent",
+  "description": "Authenticated state poll for a signup that is awaiting payment but holds no usable checkout handle - the commonest way is a retry whose replacement intent failed to create at the gateway, which now leaves the handles CLEARED rather than pointing at a released mandate. A status check REPORTS this and never repairs it; creating an intent is resume_pending_signup's job and only on an explicit customer action.",
+  "endpoint": "jarvis_admin_v2.billing.signup.get_signup_payment_state",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.payment_last_checked_at"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "NO_CURRENT_INTENT",
+        "pending_verification": false,
+        "subscription_status": "Pending Payment",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "payment_last_checked_at": "2026-08-01 00:00:00.000000",
+        "attempt_id": "att_placeholder",
+        "generation": 1
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/state_verification_required.json
+++ b/jarvis/tests/fixtures/admin_contract/state_verification_required.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 2,
+  "name": "state_verification_required",
+  "description": "The PASSIVE poll's answer while the magic link is still unclicked - the state a wizard sits in longest, and the one it had no fixture for. verification_required.json is the RESUME endpoint's version of this cohort; this is what the poll the page actually runs every couple of seconds returns, and the two differ in what a caller may do next: the capability flags say a payment cannot be initiated and a status check would tell it nothing, because nothing has been charged and no gateway has been asked. Carries the link's expiry so the page can say how long is left instead of 'check your email' forever.",
+  "produced_by": "BENCH-AUTHORED coverage case (not vendored; see PROVENANCE.md). The admin-side twin is ledgered for the next admin round.",
+  "endpoint": "jarvis_admin_v2.billing.signup.get_signup_payment_state",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.verification_expires_at",
+    "body.message.data.payment_last_checked_at"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "SIGNUP_VERIFICATION_REQUIRED",
+        "pending_verification": true,
+        "verification_expires_at": "2026-08-03 00:00:00.000000",
+        "payment_last_checked_at": "2026-08-02 00:00:00.000000",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "can_initiate_payment": false,
+        "can_check_status": false,
+        "can_reconnect": false,
+        "attempt_id": "att_placeholder",
+        "generation": 0
+      }
+    }
+  }
+}

--- a/jarvis/tests/fixtures/admin_contract/verification_required.json
+++ b/jarvis/tests/fixtures/admin_contract/verification_required.json
@@ -1,0 +1,28 @@
+{
+  "contract_version": 2,
+  "name": "verification_required",
+  "description": "Retry against a signup still awaiting email verification. The same dead end as Pending Payment and the same ownership proof, so resume re-serves the state instead of throwing; it does NOT re-send the verification mail (that would make the retry button a mail amplifier). Carries the link's expiry so the wizard can say how long is left instead of 'check your email' forever. NOTE: there is deliberately no resend endpoint yet - a customer whose link expires must start a fresh signup.",
+  "endpoint": "jarvis_admin_v2.billing.signup.resume_pending_signup",
+  "http_status": 200,
+  "volatile": [
+    "body.message.data.attempt_id",
+    "body.message.data.verification_expires_at",
+    "body.message.data.payment_last_checked_at"
+  ],
+  "body": {
+    "message": {
+      "ok": true,
+      "data": {
+        "contract_version": 2,
+        "code": "SIGNUP_VERIFICATION_REQUIRED",
+        "pending_verification": true,
+        "verification_expires_at": "2026-08-02 00:00:00.000000",
+        "payment_last_checked_at": "2026-08-01 00:00:00.000000",
+        "email": "oc-test-a@example.com",
+        "company": "Acme",
+        "attempt_id": "att_placeholder",
+        "generation": 0
+      }
+    }
+  }
+}

--- a/jarvis/tests/test_admin_contract.py
+++ b/jarvis/tests/test_admin_contract.py
@@ -23,6 +23,7 @@ Three properties these tests exist to hold:
     never falls back to reading the sentence.
 """
 
+import hashlib
 import json
 import os
 from unittest.mock import MagicMock, patch
@@ -346,6 +347,118 @@ class TestDeclineCodes(_ContractCase):
 	def test_terminal_signup_is_not_a_checkout(self):
 		data = self.replay("signup_terminal")
 		self.assertEqual(data["code"], onboarding_contract.SIGNUP_TERMINAL)
+
+
+class TestTheCorpusIsWhatItClaims(_ContractCase):
+	"""PROVENANCE.md carries a checksum table. A table nobody recomputes is a
+	comment, and a vendored file edited in place to make a test pass is exactly
+	the drift this directory exists to prevent."""
+
+	def _provenance(self) -> str:
+		with open(os.path.join(FIXTURE_DIR, "PROVENANCE.md")) as fh:
+			return fh.read()
+
+	def _declared(self) -> dict:
+		out = {}
+		for line in self._provenance().splitlines():
+			parts = line.split()
+			if len(parts) == 2 and len(parts[0]) == 64 and parts[1].endswith(".json"):
+				out[parts[1]] = parts[0]
+		return out
+
+	def test_every_vendored_file_matches_its_recorded_checksum(self):
+		declared = self._declared()
+		self.assertTrue(declared, "PROVENANCE.md must carry the vendored checksum table")
+		for name, want in declared.items():
+			with self.subTest(fixture=name):
+				with open(os.path.join(FIXTURE_DIR, name), "rb") as fh:
+					got = hashlib.sha256(fh.read()).hexdigest()
+				self.assertEqual(got, want, f"{name} differs from the vendored copy - re-sync, do not re-pin")
+
+	def test_every_file_is_either_vendored_or_declares_itself_bench_authored(self):
+		"""No third category. A file that is neither a checksummed copy of
+		admin's nor an explicit bench-authored case is a local invention wearing
+		the authority of a contract."""
+		declared = self._declared()
+		for name in sorted(os.listdir(FIXTURE_DIR)):
+			if not name.endswith(".json"):
+				continue
+			with self.subTest(fixture=name):
+				if name in declared:
+					continue
+				produced_by = _load(name[: -len(".json")]).get("produced_by", "")
+				self.assertTrue(
+					produced_by.startswith("BENCH-AUTHORED"),
+					f"{name} is not in the vendored table and does not declare itself bench-authored",
+				)
+
+
+class TestTheDuplicateCodeBranchIsReal(_ContractCase):
+	"""Every VENDORED duplicate fixture carries ``exc_type``, so the bench's
+	``error.code`` branch was never the thing under test - delete it and the
+	suite stayed green. The code-only fixture is what tests it."""
+
+	def test_a_coded_duplicate_with_no_exc_type_is_still_a_duplicate(self):
+		err = self.replay_error("duplicate_409_code_only")
+		self.assertEqual(err.code, onboarding_contract.ACCOUNT_ALREADY_EXISTS)
+		self.assertIsNone(err.exc_type, "the fixture must carry no exc_type, or it tests nothing")
+		self.assertTrue(
+			onboarding_contract.is_duplicate_signup(err),
+			"the code alone must reach the resume; exc_type is Frappe's framing, not the contract",
+		)
+
+	def test_the_poll_has_a_verification_state_of_its_own(self):
+		"""The state a wizard sits in longest. Its capability flags differ from
+		the resume endpoint's answer for the same cohort: nothing has been
+		charged, so there is nothing to initiate and nothing to check."""
+		data = self.replay("state_verification_required")
+		self.assertEqual(data["code"], onboarding_contract.SIGNUP_VERIFICATION_REQUIRED)
+		self.assertTrue(data["pending_verification"])
+		self.assertFalse(data["can_initiate_payment"])
+		self.assertFalse(data["can_check_status"])
+		self.assertIn("verification_expires_at", data)
+
+
+class TestReaderEdges(_ContractCase):
+	def test_a_codeless_top_level_error_does_not_hide_the_coded_one(self):
+		"""Two ``error`` objects, only one of them the contract's. Stopping at
+		the first one seen reported "no contract" for a response that carried
+		one, which fails closed into the generic branch and loses the code."""
+		body = {
+			"error": {"message": "gateway says something went wrong"},
+			"message": {
+				"ok": False,
+				"error": {"code": "PAYMENT_ALREADY_ACTIVE", "recovery": "continue_setup"},
+			},
+		}
+		with (
+			patch("requests.post", MagicMock(return_value=_mock_response(409, body))),
+			self.assertRaises(AdminContractError) as ctx,
+		):
+			admin_client.resume_pending_signup("some-plan")
+		self.assertEqual(ctx.exception.code, onboarding_contract.PAYMENT_ALREADY_ACTIVE)
+
+	def test_a_permanent_refusal_is_not_reported_as_an_outage(self):
+		"""AdminRejectedError is a SUBCLASS of AdminUnreachableError, so a facade
+		that checks the parent first turns a deterministic refusal into "admin is
+		unwell, keep waiting" - jarvis #542, in a new place."""
+		from jarvis.exceptions import AdminRejectedError
+
+		error, status = onboarding_contract.error_object(
+			AdminRejectedError(
+				"admin returned a 502 error: bad provider slug",
+				code="FleetConfigError",
+				detail="bad provider slug",
+			)
+		)
+		self.assertEqual(error["code"], "FleetConfigError")
+		self.assertEqual(error["message"], "bad provider slug")
+		self.assertNotEqual(error["code"], onboarding_contract.BENCH_ADMIN_UNREACHABLE)
+		self.assertEqual(status, 502)
+
+	def test_a_malformed_contract_version_does_not_break_the_page(self):
+		out = onboarding_contract.success({"code": "X", "contract_version": "not-a-number"})
+		self.assertEqual(out["contract_version"], onboarding_contract.CONTRACT_VERSION)
 
 
 class TestFacadeErrorObjects(_ContractCase):

--- a/jarvis/tests/test_admin_contract.py
+++ b/jarvis/tests/test_admin_contract.py
@@ -1,0 +1,371 @@
+"""Replay the control plane's PUBLISHED wire fixtures through this bench's reader.
+
+The fixtures in ``jarvis/tests/fixtures/admin_contract/`` are a copy of what
+jarvis-admin-v2 asserts its own serializer produces (see PROVENANCE.md). Every
+test here feeds one of them to ``requests.post`` and lets the real
+``admin_client`` parse it, so what is under test is the actual boundary and not
+a local restatement of it.
+
+That is the whole point. The last time each side kept its own statement of this
+contract, admin reworded its duplicate-signup message, the bench's
+failed-payment resume string-matched the old sentence, and BOTH suites stayed
+green while every declined-card customer hit a dead end - because the only copy
+of that sentence left in this tree was the bench suite's own fixture.
+
+Three properties these tests exist to hold:
+
+  - the reader handles the contract's TWO wire shapes (a returned envelope nests
+    the error under Frappe's ``message`` key; a raised exception parks the same
+    object at the top level next to ``exc_type``);
+  - a code, a capability flag and a recovery hint survive the crossing intact,
+    including ones this build has never heard of;
+  - an admin too old to send a code FAILS CLOSED onto the generic path - it
+    never falls back to reading the sentence.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import frappe
+import requests
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import admin_client, onboarding_contract
+from jarvis.exceptions import (
+	AdminContractError,
+	AdminRateLimitedError,
+	AdminValidationError,
+)
+from jarvis.tests.test_onboarding_sync import _restore_settings, _snapshot_settings
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "admin_contract")
+
+
+def _load(name: str) -> dict:
+	with open(os.path.join(FIXTURE_DIR, f"{name}.json")) as fh:
+		return json.load(fh)
+
+
+def _all_fixtures() -> list[dict]:
+	return [_load(f[: -len(".json")]) for f in sorted(os.listdir(FIXTURE_DIR)) if f.endswith(".json")]
+
+
+def _mock_response(status_code: int, body: dict):
+	resp = MagicMock(spec=requests.Response)
+	resp.status_code = status_code
+	resp.json.return_value = body
+	resp.text = json.dumps(body)
+	return resp
+
+
+# Which admin_client call answers each fixture's endpoint. The client function is
+# the unit under test; the arguments are whatever gets it as far as the wire.
+_CALLERS = {
+	"jarvis_admin_v2.billing.signup.signup": lambda: admin_client.signup(
+		"someone@example.com", "Acme", "some-plan"
+	),
+	"jarvis_admin_v2.billing.signup.resume_pending_signup": lambda: admin_client.resume_pending_signup(
+		"some-plan"
+	),
+	"jarvis_admin_v2.billing.signup.get_signup_payment_state": admin_client.get_signup_payment_state,
+	"jarvis_admin_v2.billing.signup.check_signup_payment_status": admin_client.check_signup_payment_status,
+	"jarvis_admin_v2.api.tenant.confirm_payment": lambda: admin_client.confirm_payment({}),
+}
+
+
+class _ContractCase(FrappeTestCase):
+	"""Credentials + admin URL for the authenticated fixtures, and a stubbed
+	site URL so the guest signup call's pre-flight doesn't reach for one.
+
+	Settings are snapshotted with the onboarding suite's own helpers: Frappe
+	Singles are not rolled back between tests, so a run against a real site must
+	put the operator's onboarded state back exactly as it found it."""
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("jarvis_admin_url", "https://admin.example.com")
+		settings.db_set("jarvis_admin_api_key", "contract-key")
+		settings.db_set("jarvis_admin_api_secret", "contract-secret")
+		# No OAuth password: the legacy api_key path reaches _do_post in one hop,
+		# which is the parser these tests are about.
+		settings.db_set("jarvis_admin_customer_email", "")
+		settings.db_set("jarvis_admin_customer_password", "")
+		settings.db_set(onboarding_contract.CONTEXT_FIELD, "")
+		frappe.db.commit()
+		frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
+		self._get_url = patch("frappe.utils.get_url", return_value="https://erp.example.com")
+		self._get_url.start()
+
+	def tearDown(self):
+		self._get_url.stop()
+		_restore_settings(self._snap)
+		frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
+
+	def replay(self, name: str):
+		"""Run the fixture through the real client. Returns admin's data on a
+		success fixture; raises exactly what the bench would raise otherwise."""
+		fixture = _load(name)
+		caller = _CALLERS[fixture["endpoint"]]
+		with patch(
+			"requests.post",
+			MagicMock(return_value=_mock_response(fixture["http_status"], fixture["body"])),
+		):
+			return caller()
+
+	def replay_error(self, name: str, expected=AdminContractError):
+		with self.assertRaises(expected) as ctx:
+			self.replay(name)
+		return ctx.exception
+
+
+class TestEveryFixtureCrossesTheBoundary(_ContractCase):
+	"""The sweep: every published fixture, through the real parser, with its
+	machine-readable half intact on the other side. A new fixture copied from
+	admin joins this test by existing."""
+
+	def test_every_fixture_keeps_its_code(self):
+		for fixture in _all_fixtures():
+			name = fixture["name"]
+			body = fixture["body"]
+			with self.subTest(fixture=name):
+				if fixture["http_status"] == 200:
+					data = self.replay(name)
+					expected = body["message"]["data"]
+					self.assertEqual(
+						data.get("code"),
+						expected.get("code"),
+						"the state code must reach the facade unaltered",
+					)
+					for flag in ("can_initiate_payment", "can_check_status", "can_reconnect"):
+						if flag in expected:
+							self.assertEqual(
+								data.get(flag),
+								expected[flag],
+								f"{flag} decides whether a button may be rendered",
+							)
+					continue
+				err = self.replay_error(name, expected=Exception)
+				coded = body.get("error") or body.get("message", {}).get("error") or {}
+				if not coded.get("code"):
+					# legacy_v1: no machine code anywhere. Fail closed - the
+					# generic class, never a coded one built out of prose.
+					self.assertNotIsInstance(err, AdminContractError)
+					continue
+				self.assertEqual(
+					getattr(err, "code", ""),
+					coded["code"],
+					"a coded refusal must arrive as a code, not as a sentence",
+				)
+
+	def test_no_fixture_speaks_a_newer_contract_than_this_bench(self):
+		"""A fixture from a BREAKING admin release must fail the suite rather
+		than be quietly re-pinned: the facade has to be read again first."""
+		for fixture in _all_fixtures():
+			with self.subTest(fixture=fixture["name"]):
+				self.assertLessEqual(
+					int(fixture["contract_version"]),
+					onboarding_contract.CONTRACT_VERSION,
+					"admin shipped a breaking contract version; read the facade, don't re-pin",
+				)
+
+
+class TestTheTwoWireShapes(_ContractCase):
+	"""One reader, two depths. A whitelisted method's RETURN value and a RAISED
+	exception do not serialize the same way, and a consumer that only knows one
+	of them silently loses the contract on the other."""
+
+	def test_thrown_shape_error_at_the_top_level(self):
+		fixture = _load("duplicate_409")
+		self.assertIn("error", fixture["body"], "fixture must be the THROWN shape")
+		self.assertNotIn("message", fixture["body"])
+		err = self.replay_error("duplicate_409")
+		self.assertEqual(err.code, onboarding_contract.ACCOUNT_ALREADY_EXISTS)
+		self.assertEqual(err.exc_type, "DuplicateEntryError")
+		self.assertEqual(err.recovery, "authenticate_or_reconnect")
+		self.assertEqual(err.http_status, 409)
+
+	def test_returned_shape_error_under_the_message_key(self):
+		fixture = _load("payment_already_active")
+		self.assertIn("error", fixture["body"]["message"], "fixture must be the RETURNED shape")
+		self.assertNotIn("error", fixture["body"])
+		err = self.replay_error("payment_already_active")
+		self.assertEqual(err.code, onboarding_contract.PAYMENT_ALREADY_ACTIVE)
+		self.assertEqual(err.recovery, "continue_setup")
+		self.assertEqual(err.http_status, 409)
+		# The extras ride along: a wizard reloading onto this answer renders the
+		# subscription status without a second call.
+		self.assertEqual(err.error.get("subscription_status"), "Active")
+
+	def test_both_shapes_are_the_same_class_to_a_caller(self):
+		self.assertIsInstance(self.replay_error("duplicate_409"), AdminValidationError)
+		self.assertIsInstance(self.replay_error("payment_already_active"), AdminValidationError)
+
+
+class TestOldAdminFailsClosed(_ContractCase):
+	"""A fleet mid-upgrade still has control planes that predate the contract.
+	Their duplicate rejection carries Frappe's exc_type and a SENTENCE, and the
+	sentence is exactly what must not be read."""
+
+	def test_legacy_duplicate_has_no_code_and_is_not_a_contract_error(self):
+		err = self.replay_error("legacy_v1_duplicate_409", expected=AdminValidationError)
+		self.assertNotIsInstance(err, AdminContractError)
+		self.assertEqual(getattr(err, "code", ""), "")
+		self.assertEqual(err.exc_type, "DuplicateEntryError")
+
+	def test_legacy_duplicate_still_reaches_the_resume(self):
+		"""exc_type is the signal that spans every admin ever deployed: every
+		version of _reject_duplicate_email back to the v2 fork throws
+		frappe.DuplicateEntryError. That is why no prose fallback is needed."""
+		err = self.replay_error("legacy_v1_duplicate_409", expected=AdminValidationError)
+		self.assertTrue(onboarding_contract.is_duplicate_signup(err))
+
+	def test_an_unknown_shape_is_not_half_read(self):
+		"""Fail closed on anything that isn't the published contract: a body with
+		an ``error`` object but no code is treated as "no contract", not as a
+		coded refusal with an empty code."""
+		body = {"exc_type": "ValidationError", "error": {"message": "something went wrong"}}
+		with (
+			patch("requests.post", MagicMock(return_value=_mock_response(409, body))),
+			self.assertRaises(AdminValidationError) as ctx,
+		):
+			admin_client.resume_pending_signup("some-plan")
+		self.assertNotIsInstance(ctx.exception, AdminContractError)
+
+
+class TestCapabilityFlagsAndDisclosure(_ContractCase):
+	"""The fields a payment surface must render FROM rather than re-derive."""
+
+	def test_awaiting_manual_reconciliation_survives_with_its_pay_gate(self):
+		"""Money the gateway holds that we could not credit. The CODE is the
+		ordinary pending one on purpose - a decline would invite a second
+		payment - so it is the flag, and can_initiate_payment, that suppress the
+		Pay affordance. Losing either in transit re-charges a customer."""
+		data = self.replay("reconcile_unmatched_payment")
+		self.assertEqual(data["code"], onboarding_contract.PAYMENT_CONFIRMATION_PENDING)
+		self.assertTrue(data["awaiting_manual_reconciliation"])
+		self.assertFalse(data["can_initiate_payment"])
+		self.assertTrue(data["gateway_consulted"])
+
+	def test_gateway_consulted_is_carried_not_inferred(self):
+		"""False on the passive poll's answers and true only when a provider was
+		really reached IN THIS CALL, so "checked just now" can never be rendered
+		as "and the gateway confirmed it"."""
+		self.assertTrue(self.replay("reconcile_paid_active")["gateway_consulted"])
+		self.assertFalse(self.replay("account_reconnect_required")["gateway_consulted"])
+
+	def test_reconnect_is_offered_from_the_flag(self):
+		data = self.replay("account_reconnect_required")
+		self.assertEqual(data["code"], onboarding_contract.ACCOUNT_RECONNECT_REQUIRED)
+		self.assertTrue(data["can_reconnect"])
+		self.assertFalse(data["can_initiate_payment"])
+
+	def test_authorized_mandate_refuses_a_second_intent(self):
+		"""Money has already moved on an authorized mandate; a new intent would
+		authorize a second one and charge the signup fee twice."""
+		data = self.replay("reconcile_authorized_pending_confirm")
+		self.assertEqual(data["code"], onboarding_contract.PAYMENT_AUTHORIZED_PENDING_CONFIRM)
+		self.assertFalse(data["can_initiate_payment"])
+		self.assertEqual(data["recovery"], "confirm_payment")
+
+	def test_due_today_disclosure_crosses_intact(self):
+		"""What the customer is actually charged today, which the wizard used to
+		compute from price_inr and get wrong whenever a signup fee or an anchored
+		trial was involved."""
+		data = self.replay("reconcile_pending")
+		self.assertEqual(data["due_today_inr"], 12000.0)
+		self.assertEqual(data["signup_fee_inr"], 0.0)
+		self.assertEqual(data["plan"], {"name": "oc-test-annual", "label": "oc-test-annual"})
+
+	def test_effective_trial_crosses_intact(self):
+		"""The trial as anchored on THIS attempt, not the plan's advertised
+		length - the number a resumed wizard has to render."""
+		data = self.replay("state_mandate_pending_razorpay")
+		self.assertEqual(data["effective_trial_days"], 14)
+		self.assertEqual(data["due_today_inr"], 0.0)
+		self.assertIn("effective_first_charge_at", data)
+
+	def test_verification_expiry_crosses_intact(self):
+		data = self.replay("verification_required")
+		self.assertEqual(data["code"], onboarding_contract.SIGNUP_VERIFICATION_REQUIRED)
+		self.assertTrue(data["pending_verification"])
+		self.assertIn("verification_expires_at", data)
+
+	def test_attempt_id_and_generation_cross_intact(self):
+		"""The opaque handle a support conversation may quote, and the fence a
+		late callback is checked against. Neither is derivable locally."""
+		data = self.replay("resume_intent")
+		self.assertEqual(data["attempt_id"], "att_placeholder")
+		self.assertEqual(data["generation"], 2)
+
+	def test_a_field_this_build_never_heard_of_still_arrives(self):
+		"""Additive-only is admin's rule; passing everything through unfiltered
+		is what makes it true on this side. A bench that dropped unknown keys
+		would turn every additive release into a coordinated one."""
+		fixture = _load("reconcile_pending")
+		body = json.loads(json.dumps(fixture["body"]))
+		body["message"]["data"]["some_future_field"] = {"nested": 1}
+		with patch("requests.post", MagicMock(return_value=_mock_response(200, body))):
+			data = admin_client.check_signup_payment_status()
+		self.assertEqual(data["some_future_field"], {"nested": 1})
+
+
+class TestRateLimitIsNotADecline(_ContractCase):
+	"""Back off, and your payment failed, are opposite instructions - and a
+	caller that can only read the status has to guess which one it got."""
+
+	def test_coded_429_carries_its_code_and_backoff(self):
+		err = self.replay_error("payment_check_rate_limited", expected=AdminRateLimitedError)
+		self.assertEqual(err.code, onboarding_contract.PAYMENT_CHECK_RATE_LIMITED)
+		self.assertEqual(err.retry_after_seconds, 1234)
+		self.assertEqual(err.recovery, "retry")
+
+	def test_the_facade_does_not_turn_it_into_a_decline(self):
+		err = self.replay_error("payment_check_rate_limited", expected=AdminRateLimitedError)
+		error, status = onboarding_contract.error_object(err)
+		self.assertEqual(status, 429)
+		self.assertEqual(error["code"], onboarding_contract.PAYMENT_CHECK_RATE_LIMITED)
+		self.assertNotEqual(error["code"], onboarding_contract.PAYMENT_DECLINED)
+
+
+class TestDeclineCodes(_ContractCase):
+	def test_mandate_decline_carries_the_code(self):
+		err = self.replay_error("payment_declined_mandate")
+		self.assertEqual(err.code, onboarding_contract.PAYMENT_DECLINED)
+
+	def test_a_declined_check_is_a_report_not_a_refusal(self):
+		"""A check never creates or replaces an intent, so a decline comes back
+		as an ordinary 200 answer with a code - the caller decides whether to
+		open a replacement."""
+		data = self.replay("reconcile_declined")
+		self.assertEqual(data["code"], onboarding_contract.PAYMENT_DECLINED)
+		self.assertTrue(data["can_initiate_payment"])
+		self.assertEqual(data["recovery"], "retry")
+
+	def test_terminal_signup_is_not_a_checkout(self):
+		data = self.replay("signup_terminal")
+		self.assertEqual(data["code"], onboarding_contract.SIGNUP_TERMINAL)
+
+
+class TestFacadeErrorObjects(_ContractCase):
+	"""What the SPA is handed when a call fails: admin's own error object, not a
+	re-derivation of it."""
+
+	def test_contract_error_passes_through_verbatim(self):
+		err = self.replay_error("payment_already_active")
+		error, status = onboarding_contract.error_object(err)
+		self.assertEqual(status, 409)
+		self.assertEqual(error["code"], onboarding_contract.PAYMENT_ALREADY_ACTIVE)
+		self.assertEqual(error["recovery"], "continue_setup")
+		self.assertEqual(error["subscription_status"], "Active")
+
+	def test_uncoded_rejection_gets_a_bench_code_not_an_invented_admin_one(self):
+		"""An admin too old to speak the contract must not have a code invented
+		for it: a BENCH_* code says where the answer came from, and cannot
+		collide with admin's append-only vocabulary."""
+		err = self.replay_error("legacy_v1_duplicate_409", expected=AdminValidationError)
+		error, status = onboarding_contract.error_object(err)
+		self.assertEqual(error["code"], onboarding_contract.BENCH_ADMIN_REJECTED)
+		self.assertEqual(error["exc_type"], "DuplicateEntryError")
+		self.assertEqual(status, 409)

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1128,6 +1128,116 @@ class TestSignupResumeFallback(FrappeTestCase):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
 		self.assertIn("already exists", str(ctx.exception))
 
+	def test_the_fresh_signup_response_carries_no_credentials(self):
+		"""start_signup's response is the one that CARRIES the account's
+		credentials — api_key, api_secret and, on the flag-off path, the OAuth
+		login password. write_connection stores every one of them before this
+		returns; none of them belongs in an HTTP response body."""
+		with patch(
+			"jarvis.onboarding.admin_client.signup",
+			return_value={
+				"api_key": "k",
+				"api_secret": "s",
+				"customer": "cust-abc@jarvis.invalid",
+				"customer_password": "pw",
+				"agent_token": "tok",
+				"razorpay_order_id": "order_FRESH",
+				"email": "owner@acme.example",
+			},
+		):
+			out = onboarding.start_signup("owner@acme.example", "Acme", "annual")
+		for leaked in ("api_key", "api_secret", "customer_password", "agent_token"):
+			self.assertNotIn(leaked, out, f"{leaked} must not reach the browser")
+		self.assertEqual(out["razorpay_order_id"], "order_FRESH", "the checkout handles survive")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False), "k")
+		self.assertEqual(s.get_password("jarvis_admin_customer_password", raise_exception=False), "pw")
+
+	def test_the_resumed_signup_response_carries_no_credentials_either(self):
+		"""Both paths return through the same statement, and the retry is the one
+		a real customer hits."""
+		with (
+			self._signup_raises(self._duplicate_coded()),
+			patch(
+				"jarvis.onboarding.admin_client.resume_pending_signup",
+				return_value={
+					"api_key": "k2",
+					"api_secret": "s2",
+					"customer_password": "pw2",
+					"razorpay_order_id": "order_RESUMED",
+				},
+			),
+		):
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		for leaked in ("api_key", "api_secret", "customer_password", "agent_token"):
+			self.assertNotIn(leaked, out)
+		self.assertEqual(out["razorpay_order_id"], "order_RESUMED")
+
+	def test_finish_payment_never_hands_back_the_agent_token(self):
+		"""Not tidiness: admin's confirm_payment re-serves the connection payload
+		for a payment id it has already recorded, so this endpoint is a REPEATABLE
+		token read — behind a gate (require_jarvis_admin) that
+		grant_onboarding_admin hands to every user who finishes an onboarding."""
+		with patch(
+			"jarvis.onboarding.admin_client.confirm_payment",
+			return_value={
+				"agent_url": "ws://container.example",
+				"agent_token": "the-container-token",
+				"tenant_status": "running",
+			},
+		):
+			out = onboarding.finish_payment({"razorpay_payment_id": "pay_1"})
+		self.assertNotIn("agent_token", out)
+		# The two fields the SPA actually reads off this response survive.
+		self.assertEqual(out["agent_url"], "ws://container.example")
+		self.assertEqual(out["tenant_status"], "running")
+		# ...and the bench still consumed the token internally.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("agent_token", raise_exception=False), "the-container-token")
+
+	def test_parked_money_stops_the_whole_signup_not_just_the_resume(self):
+		"""Refusing only the resume would let a FRESH signup through while a
+		payment sits unplaceable — a second account on top of money nobody has
+		managed to credit to the first, which is strictly worse than the retry it
+		was meant to prevent."""
+		onboarding_contract.update(awaiting_manual_reconciliation=True)
+		with (
+			patch("jarvis.onboarding.admin_client.signup") as signup,
+			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
+			self.assertRaises(frappe.ValidationError) as ctx,
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		signup.assert_not_called()
+		resume.assert_not_called()
+		self.assertEqual(
+			frappe.local.response.get("error", {}).get("code"),
+			onboarding_contract.BENCH_AWAITING_RECONCILIATION,
+		)
+		self.assertEqual(
+			frappe.local.response.get("error", {}).get("recovery"),
+			onboarding_contract.RECOVERY_CHECK_STATUS,
+		)
+		self.assertEqual(
+			getattr(type(ctx.exception), "http_status_code", None),
+			409,
+			"a conflict must reach the wire as 409, which comes off the exception CLASS",
+		)
+
+	def test_a_check_clears_the_parked_refusal_for_signup_too(self):
+		onboarding_contract.update(awaiting_manual_reconciliation=True)
+		with patch(
+			"jarvis.onboarding.admin_client.check_signup_payment_status",
+			return_value={"code": "PAYMENT_CONFIRMATION_PENDING", "gateway_consulted": True},
+		):
+			onboarding.check_signup_payment_status()
+		with (
+			self._signup_raises(self._duplicate_coded()),
+			self._resume_ok("order_AFTER") as resume,
+		):
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_called_once()
+		self.assertEqual(out["razorpay_order_id"], "order_AFTER")
+
 	def test_a_thrown_duplicate_still_delivers_its_code(self):
 		"""A throw is how this endpoint reports failure, and the SPA still has to
 		branch. The machine-readable error rides on the response next to Frappe's
@@ -1439,21 +1549,47 @@ class TestOnboardingFacadeEndpoints(FrappeTestCase):
 		self.assertTrue(out["ok"])
 		self.assertTrue(onboarding_contract.load()["idempotency_key"])
 
-	def test_a_refused_key_that_did_get_stored_still_frees_itself(self):
-		"""Belt and braces for a key an older build stored, or one a bound admin
-		tightens the bound on later: INVALID_REQUEST is a SPENT key, so the next
-		attempt mints rather than replaying the refusal."""
-		onboarding_contract.update(
-			plan="annual",
-			idempotency_key="stale-refused-key",
-			code=onboarding_contract.INVALID_REQUEST,
+	def test_a_stored_bad_key_heals_itself_end_to_end(self):
+		"""The brick as an older build would leave it: a key admin refuses, ALREADY
+		in the context, with no code planted beside it. Nothing here hand-writes
+		the verdict — it has to come back from admin, through
+		absorb_payment_outcome, and free the next attempt on its own.
+
+		This is the test that failed to be a test the first time: it asserted the
+		self-heal from a context state (``code: INVALID_REQUEST``) that no code
+		path could actually produce, because INVALID_REQUEST was not absorbable.
+		The brick survived underneath a green test."""
+		from jarvis.exceptions import AdminContractError
+
+		onboarding_contract.update(plan="annual", idempotency_key="x" * 400)
+		self.assertNotIn("code", onboarding_contract.load(), "no verdict may be pre-planted")
+
+		refusal = AdminContractError(
+			"idempotency_key must be at most 128 characters",
+			code="INVALID_REQUEST",
+			recovery="retry",
+			error={"code": "INVALID_REQUEST", "message": "idempotency_key must be at most 128 characters"},
+			http_status=400,
 		)
+		with patch("jarvis.onboarding.admin_client.resume_pending_signup", side_effect=refusal) as resume:
+			first = onboarding.initiate_signup_payment()
+		self.assertEqual(resume.call_args.kwargs["idempotency_key"], "x" * 400, "the stored key was sent")
+		self.assertEqual(first["error"]["code"], onboarding_contract.INVALID_REQUEST)
+		self.assertEqual(
+			onboarding_contract.load()["code"],
+			onboarding_contract.INVALID_REQUEST,
+			"admin's verdict on the key must be recorded, or the next attempt replays it",
+		)
+
 		with patch(
 			"jarvis.onboarding.admin_client.resume_pending_signup",
 			return_value=self._STATE,
 		) as resume:
-			onboarding.initiate_signup_payment()
-		self.assertNotEqual(resume.call_args.kwargs["idempotency_key"], "stale-refused-key")
+			second = onboarding.initiate_signup_payment()
+		self.assertNotEqual(
+			resume.call_args.kwargs["idempotency_key"], "x" * 400, "the refused key must not be replayed"
+		)
+		self.assertTrue(second["ok"])
 
 	# ---- P1-2: money an operator is still placing ----
 
@@ -1591,6 +1727,18 @@ class TestOnboardingFacadeEndpoints(FrappeTestCase):
 			out = onboarding.check_signup_payment_status()
 		check.assert_not_called()
 		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_NO_SIGNUP_CONTEXT)
+
+	def test_initiate_guards_cleared_credentials_with_a_surviving_context(self):
+		"""The one endpoint that could still reach admin unauthenticated: the plan
+		check would pass on a remembered plan, and the call would earn the exact
+		401 the day-one guard exists to stop being shown as "contact support"."""
+		onboarding_contract.update(plan="annual")
+		_set_token("")
+		with patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume:
+			out = onboarding.initiate_signup_payment()
+		resume.assert_not_called()
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_NO_SIGNUP_CONTEXT)
+		self.assertNotEqual(out["error"]["code"], onboarding_contract.BENCH_ADMIN_AUTH_FAILED)
 
 	# ---- P2: the bookkeeping must not cost more than it is worth ----
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1036,6 +1036,37 @@ class TestSignupResumeFallback(FrappeTestCase):
 			second = resume.call_args.kwargs["idempotency_key"]
 		self.assertNotEqual(first, second)
 
+	def test_an_unmigrated_bench_degrades_instead_of_breaking(self):
+		"""Between a code deploy and its ``bench migrate`` the context field does
+		not exist yet, and Frappe REFUSES both reads and writes of a field its
+		installed doctype has never heard of. Signup must survive that window:
+		losing a display snapshot is a bad day, taking signup down is a worse
+		one."""
+		import frappe.model.document as document_module
+
+		real_get = frappe.db.get_single_value
+		real_db_set = document_module.Document.db_set
+
+		def unmigrated_get(doctype, fieldname, *a, **kw):
+			if doctype == "Jarvis Settings" and fieldname == onboarding_contract.CONTEXT_FIELD:
+				frappe.throw("Field signup_context does not exist on Jarvis Settings")
+			return real_get(doctype, fieldname, *a, **kw)
+
+		def unmigrated_db_set(self, fieldname, value=None, *a, **kw):
+			if fieldname == onboarding_contract.CONTEXT_FIELD:
+				frappe.throw("Field signup_context does not exist on Jarvis Settings")
+			return real_db_set(self, fieldname, value, *a, **kw)
+
+		with (
+			patch.object(frappe.db, "get_single_value", unmigrated_get),
+			patch.object(document_module.Document, "db_set", unmigrated_db_set),
+			self._signup_raises(self._duplicate_coded()),
+			self._resume_ok("order_RM") as resume,
+		):
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_called_once()
+		self.assertEqual(out["razorpay_order_id"], "order_RM")
+
 	def test_non_dedup_error_reraises(self):
 		from jarvis.exceptions import AdminValidationError
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1036,36 +1036,72 @@ class TestSignupResumeFallback(FrappeTestCase):
 			second = resume.call_args.kwargs["idempotency_key"]
 		self.assertNotEqual(first, second)
 
-	def test_an_unmigrated_bench_degrades_instead_of_breaking(self):
-		"""Between a code deploy and its ``bench migrate`` the context field does
-		not exist yet, and Frappe REFUSES both reads and writes of a field its
-		installed doctype has never heard of. Signup must survive that window:
-		losing a display snapshot is a bad day, taking signup down is a worse
-		one."""
-		import frappe.model.document as document_module
+	def test_frappe_really_does_refuse_a_field_the_doctype_lacks(self):
+		"""The premise of the guard, asserted against REAL frappe rather than a
+		mock — and the two write layers do not agree, which is why the guard
+		checks instead of catching:
 
-		real_get = frappe.db.get_single_value
-		real_db_set = document_module.Document.db_set
+		  - a READ of a field the installed doctype lacks THROWS
+		    (``get_single_value`` looks the field up in meta and refuses);
+		  - ``frappe.db.set_single_value`` validates NOTHING and silently writes
+		    an orphan ``tabSingles`` row that no migrate cleans up.
 
-		def unmigrated_get(doctype, fieldname, *a, **kw):
-			if doctype == "Jarvis Settings" and fieldname == onboarding_contract.CONTEXT_FIELD:
-				frappe.throw("Field signup_context does not exist on Jarvis Settings")
-			return real_get(doctype, fieldname, *a, **kw)
+		So "just catch the exception" would have left orphan rows behind on every
+		bench deployed ahead of its migrate."""
+		scratch = "zz_signup_context_probe"
+		try:
+			with self.assertRaises(Exception):
+				frappe.db.get_single_value("Jarvis Settings", scratch)
+			frappe.db.set_single_value("Jarvis Settings", scratch, "written-anyway")
+			rows = frappe.db.sql(
+				"select value from tabSingles where doctype=%s and field=%s", ("Jarvis Settings", scratch)
+			)
+			self.assertTrue(rows, "set_single_value writes without validating - that is the hazard")
+		finally:
+			frappe.db.delete("Singles", {"doctype": "Jarvis Settings", "field": scratch})
+			frappe.db.commit()
 
-		def unmigrated_db_set(self, fieldname, value=None, *a, **kw):
-			if fieldname == onboarding_contract.CONTEXT_FIELD:
-				frappe.throw("Field signup_context does not exist on Jarvis Settings")
-			return real_db_set(self, fieldname, value, *a, **kw)
+	def test_an_unmigrated_bench_degrades_and_leaves_no_orphan_row(self):
+		"""The deploy window itself: code is live, ``bench migrate`` has not run,
+		so the installed doctype has no such field. Everything below is real
+		frappe except the one fact that differs in that window.
 
+		Signup must survive it — losing a display snapshot is a bad day, taking
+		signup down is a worse one — and it must not write the row it cannot
+		legitimately write."""
+		before = frappe.db.get_single_value("Jarvis Settings", onboarding_contract.CONTEXT_FIELD)
+		real_get_meta = frappe.get_meta
+
+		class _MetaMissingTheField:
+			def __init__(self, meta):
+				self._meta = meta
+
+			def has_field(self, fieldname):
+				if fieldname == onboarding_contract.CONTEXT_FIELD:
+					return False
+				return self._meta.has_field(fieldname)
+
+			def __getattr__(self, name):
+				return getattr(self._meta, name)
+
+		def unmigrated_meta(doctype, *a, **kw):
+			meta = real_get_meta(doctype, *a, **kw)
+			return _MetaMissingTheField(meta) if doctype == "Jarvis Settings" else meta
+
+		frappe.cache().delete_value(onboarding_contract._MISSING_FIELD_LOG_KEY)
 		with (
-			patch.object(frappe.db, "get_single_value", unmigrated_get),
-			patch.object(document_module.Document, "db_set", unmigrated_db_set),
+			patch.object(frappe, "get_meta", unmigrated_meta),
 			self._signup_raises(self._duplicate_coded()),
 			self._resume_ok("order_RM") as resume,
 		):
 			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
 		resume.assert_called_once()
 		self.assertEqual(out["razorpay_order_id"], "order_RM")
+		self.assertEqual(
+			frappe.db.get_single_value("Jarvis Settings", onboarding_contract.CONTEXT_FIELD),
+			before,
+			"nothing may be written to a field the installed doctype does not have",
+		)
 
 	def test_non_dedup_error_reraises(self):
 		from jarvis.exceptions import AdminValidationError
@@ -1300,7 +1336,12 @@ class TestOnboardingFacadeEndpoints(FrappeTestCase):
 
 	def test_a_refused_initiate_still_updates_what_the_page_renders(self):
 		"""A wizard reloading onto "already paid" has to render that, not the
-		plan it was about to charge for."""
+		plan it was about to charge for.
+
+		The CODE and its recovery hint, and nothing else: a refusal is not a state
+		read. The fields it happens to carry describe why this call was refused,
+		not where the money is, and treating them as a state read is how a
+		rate-limit answer would come to overwrite a real decline."""
 		from jarvis.exceptions import AdminContractError
 
 		onboarding_contract.update(plan="annual")
@@ -1312,6 +1353,7 @@ class TestOnboardingFacadeEndpoints(FrappeTestCase):
 				error={
 					"code": "PAYMENT_ALREADY_ACTIVE",
 					"message": "This signup is already paid. Continue setup.",
+					"recovery": "continue_setup",
 					"subscription_status": "Active",
 					"attempt_id": "att_7c2",
 				},
@@ -1320,7 +1362,302 @@ class TestOnboardingFacadeEndpoints(FrappeTestCase):
 		):
 			out = onboarding.initiate_signup_payment()
 		self.assertEqual(out["context"]["code"], "PAYMENT_ALREADY_ACTIVE")
-		self.assertEqual(out["context"]["subscription_status"], "Active")
+		self.assertEqual(out["context"]["recovery"], "continue_setup")
+		# The full error object still reaches the page - it just does not become
+		# the persisted state.
+		self.assertEqual(out["error"]["subscription_status"], "Active")
+
+	# ---- P0-1: credentials must not ride the response back to the browser ----
+
+	def test_the_state_poll_never_returns_the_login_password(self):
+		"""Admin delivers the OAuth password on the first poll after the email is
+		confirmed. The bench PERSISTS it; the page has no use for it; returning
+		admin's dict verbatim put a plaintext login secret in an HTTP response
+		body on every verified poll, where it lands in browser caches, devtools
+		and any proxy log on the way."""
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			return_value=dict(self._STATE, customer_password="pw-once", api_key="k", api_secret="s"),
+		):
+			out = onboarding.get_onboarding_state()
+		for leaked in ("customer_password", "api_key", "api_secret"):
+			self.assertNotIn(leaked, out["data"], f"{leaked} must never reach the browser")
+		# ...and it was still persisted, which is the point of receiving it.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_customer_password", raise_exception=False), "pw-once")
+
+	def test_the_provider_check_never_returns_the_login_password(self):
+		with patch(
+			"jarvis.onboarding.admin_client.check_signup_payment_status",
+			return_value=dict(self._STATE, customer_password="pw-once"),
+		):
+			out = onboarding.check_signup_payment_status()
+		self.assertNotIn("customer_password", out["data"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_customer_password", raise_exception=False), "pw-once")
+
+	def test_the_legacy_poll_never_returns_the_login_password(self):
+		"""Same leak, older endpoint, still live: this is the one the shipped
+		wizard actually calls."""
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			return_value=dict(self._STATE, customer_password="pw-once"),
+		):
+			out = onboarding.check_signup_payment_state()
+		self.assertNotIn("customer_password", out)
+		self.assertEqual(out["code"], "PAYMENT_CONFIRMATION_PENDING", "the rest of the payload is untouched")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_customer_password", raise_exception=False), "pw-once")
+
+	# ---- P0-2: a key that cannot work must not be stored ----
+
+	def test_an_unusable_key_is_refused_locally_and_never_persisted(self):
+		onboarding_contract.update(plan="annual")
+		with patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume:
+			out = onboarding.initiate_signup_payment(idempotency_key="x" * 400)
+		resume.assert_not_called()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], onboarding_contract.INVALID_REQUEST)
+		self.assertEqual(frappe.local.response.http_status_code, 400)
+		self.assertNotIn("idempotency_key", onboarding_contract.load())
+
+	def test_an_unusable_key_does_not_brick_the_next_attempt(self):
+		"""The self-inflicted brick: the over-long key used to be PERSISTED, admin
+		answered INVALID_REQUEST, and every later attempt replayed the same stored
+		key into the same refusal with no way out but a settings reset. Three
+		identical sends, then a normal one."""
+		onboarding_contract.update(plan="annual")
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			for _ in range(3):
+				refused = onboarding.initiate_signup_payment(idempotency_key="x" * 400)
+				self.assertEqual(refused["error"]["code"], onboarding_contract.INVALID_REQUEST)
+			resume.assert_not_called()
+			out = onboarding.initiate_signup_payment()
+		self.assertTrue(out["ok"])
+		self.assertTrue(onboarding_contract.load()["idempotency_key"])
+
+	def test_a_refused_key_that_did_get_stored_still_frees_itself(self):
+		"""Belt and braces for a key an older build stored, or one a bound admin
+		tightens the bound on later: INVALID_REQUEST is a SPENT key, so the next
+		attempt mints rather than replaying the refusal."""
+		onboarding_contract.update(
+			plan="annual",
+			idempotency_key="stale-refused-key",
+			code=onboarding_contract.INVALID_REQUEST,
+		)
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			onboarding.initiate_signup_payment()
+		self.assertNotEqual(resume.call_args.kwargs["idempotency_key"], "stale-refused-key")
+
+	# ---- P1-2: money an operator is still placing ----
+
+	def test_a_parked_payment_refuses_a_new_intent_without_a_network_call(self):
+		"""The gateway holds a payment that could not be credited to this attempt
+		and an operator is placing it. The CODE stays the ordinary pending one -
+		deliberately, so a wizard does not invite a second payment - which means
+		nothing in the code alone stops a retry. The flag does."""
+		onboarding_contract.update(plan="annual")
+		with patch(
+			"jarvis.onboarding.admin_client.check_signup_payment_status",
+			return_value=dict(
+				self._STATE,
+				gateway_consulted=True,
+				awaiting_manual_reconciliation=True,
+				can_initiate_payment=False,
+			),
+		):
+			onboarding.check_signup_payment_status()
+		with patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume:
+			out = onboarding.initiate_signup_payment()
+		resume.assert_not_called()
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_AWAITING_RECONCILIATION)
+		self.assertEqual(out["error"]["recovery"], onboarding_contract.RECOVERY_CHECK_STATUS)
+		self.assertEqual(frappe.local.response.http_status_code, 409)
+
+	def test_a_later_check_clears_the_refusal(self):
+		"""Admin sends the flag only when it is TRUE, so an ordinary absorb can
+		raise it and nothing could ever lower it - the customer would be refused
+		forever over an incident closed weeks ago. The check is the one surface
+		entitled to say it is false, and it says so explicitly."""
+		onboarding_contract.update(plan="annual", awaiting_manual_reconciliation=True)
+		with patch(
+			"jarvis.onboarding.admin_client.check_signup_payment_status",
+			return_value=dict(self._STATE, gateway_consulted=True),
+		):
+			onboarding.check_signup_payment_status()
+		self.assertFalse(onboarding_contract.awaiting_reconciliation())
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			out = onboarding.initiate_signup_payment()
+		resume.assert_called_once()
+		self.assertTrue(out["ok"])
+
+	# ---- P1-3 / U1-2: only a payment-state code may become the payment's state ----
+
+	def test_a_decline_confirmed_through_finish_payment_mints_a_fresh_key(self):
+		"""Where a refusal is actually LEARNED: the browser comes back from
+		checkout and confirm says the gateway refused it. If that verdict does not
+		reach the context, the next Pay click reuses the key that bought the
+		refused intent - and admin, correctly, hands the dead order back."""
+		from jarvis.exceptions import AdminContractError
+
+		onboarding_contract.update(plan="annual", idempotency_key="key-of-the-dead-intent")
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.confirm_payment",
+				side_effect=AdminContractError(
+					"This Cashfree mandate is not authorized.",
+					code="PAYMENT_DECLINED",
+					error={"code": "PAYMENT_DECLINED", "message": "This Cashfree mandate is not authorized."},
+					http_status=402,
+				),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.finish_payment({"provider": "cashfree"})
+		self.assertEqual(onboarding_contract.load()["code"], onboarding_contract.PAYMENT_DECLINED)
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			onboarding.initiate_signup_payment()
+		self.assertNotEqual(resume.call_args.kwargs["idempotency_key"], "key-of-the-dead-intent")
+
+	def test_a_backoff_is_not_absorbed_as_the_payments_state(self):
+		"""Being told you are asking too often says nothing about the money.
+		Absorbing it as the payment's state would overwrite a real decline and,
+		worse, let a backoff decide whether the next click opens a gateway
+		object."""
+		from jarvis.exceptions import AdminRateLimitedError
+
+		onboarding_contract.update(plan="annual", code=onboarding_contract.PAYMENT_DECLINED)
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			side_effect=AdminRateLimitedError(
+				"try again shortly",
+				retry_after_seconds=30,
+				code="PAYMENT_CHECK_RATE_LIMITED",
+				error={"code": "PAYMENT_CHECK_RATE_LIMITED"},
+			),
+		):
+			out = onboarding.initiate_signup_payment()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "PAYMENT_CHECK_RATE_LIMITED")
+		self.assertEqual(
+			onboarding_contract.load()["code"],
+			onboarding_contract.PAYMENT_DECLINED,
+			"the real payment verdict must survive a rate-limit answer",
+		)
+
+	def test_an_unreachable_admin_is_not_absorbed_either(self):
+		from jarvis.exceptions import AdminUnreachableError
+
+		onboarding_contract.update(plan="annual", code=onboarding_contract.PAYMENT_CONFIRMATION_PENDING)
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			side_effect=AdminUnreachableError("admin is unreachable"),
+		):
+			out = onboarding.initiate_signup_payment()
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_ADMIN_UNREACHABLE)
+		self.assertEqual(onboarding_contract.load()["code"], onboarding_contract.PAYMENT_CONFIRMATION_PENDING)
+
+	# ---- U0: day one ----
+
+	def test_a_site_that_never_signed_up_is_answered_locally(self):
+		"""A bench with no credentials cannot authenticate anything, so the call
+		is a guaranteed 401 that the facade would dress up as "admin
+		authentication failed; contact support" - shown to somebody whose only
+		mistake was opening the page early."""
+		_set_token("")
+		with patch("jarvis.onboarding.admin_client.get_signup_payment_state") as poll:
+			out = onboarding.get_onboarding_state()
+		poll.assert_not_called()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_NO_SIGNUP_CONTEXT)
+		self.assertNotIn("support", out["error"]["message"].lower())
+		self.assertNotEqual(out["error"]["code"], onboarding_contract.BENCH_ADMIN_AUTH_FAILED)
+
+	def test_the_provider_check_guards_day_one_the_same_way(self):
+		_set_token("")
+		with patch("jarvis.onboarding.admin_client.check_signup_payment_status") as check:
+			out = onboarding.check_signup_payment_status()
+		check.assert_not_called()
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_NO_SIGNUP_CONTEXT)
+
+	# ---- P2: the bookkeeping must not cost more than it is worth ----
+
+	def test_a_steady_poll_writes_nothing(self):
+		"""Every answer carries a fresh payment_last_checked_at, so comparing
+		whole dicts made a wizard polling every two seconds rewrite the Single on
+		every tick - and every write clears the document cache for every other
+		request on the site."""
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			return_value=dict(self._STATE, payment_last_checked_at="2026-08-02 00:00:00.000000"),
+		):
+			onboarding.get_onboarding_state()
+		with patch.object(onboarding_contract, "save", wraps=onboarding_contract.save) as save:
+			for i in range(5):
+				with patch(
+					"jarvis.onboarding.admin_client.get_signup_payment_state",
+					return_value=dict(self._STATE, payment_last_checked_at=f"2026-08-02 00:00:0{i}.000000"),
+				):
+					onboarding.get_onboarding_state()
+			self.assertEqual(save.call_count, 0, "a steady state must cost no writes")
+			# ...and something real still writes.
+			with patch(
+				"jarvis.onboarding.admin_client.get_signup_payment_state",
+				return_value=dict(self._STATE, code="PAYMENT_DECLINED"),
+			):
+				onboarding.get_onboarding_state()
+			self.assertEqual(save.call_count, 1)
+
+	def test_save_sweeps_credentials_out_of_a_raw_payload(self):
+		"""The allowlist in absorb() is the first line; this is the last. A future
+		caller that hands the store a raw admin payload must fail safe, not park
+		an api_secret in a plain-text Settings column."""
+		onboarding_contract.save(
+			{
+				"email": "owner@acme.example",
+				"api_key": "k",
+				"api_secret": "s",
+				"customer_password": "pw",
+				"agent_token": "t",
+				"customer": "cust-abc@jarvis.invalid",
+			}
+		)
+		raw = frappe.db.get_single_value("Jarvis Settings", onboarding_contract.CONTEXT_FIELD) or ""
+		for leaked in ("api_key", "api_secret", "customer_password", "agent_token", "cust-abc"):
+			self.assertNotIn(leaked, raw)
+		self.assertIn("owner@acme.example", raw)
+
+	def test_a_rejected_plan_does_not_become_the_sticky_default(self):
+		"""A REQUESTED plan is not a confirmed one. Writing it before the call
+		meant a plan admin refused (disabled, zero-priced, a gateway switched off)
+		became this site's default, and the next Pay click charged on it."""
+		from jarvis.exceptions import AdminValidationError
+
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.signup",
+				side_effect=AdminValidationError("This plan has no payable amount."),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.start_signup("owner@acme.example", "Acme", "a-plan-admin-refuses")
+		self.assertNotIn("plan", onboarding_contract.load())
+		with patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume:
+			out = onboarding.initiate_signup_payment()
+		resume.assert_not_called()
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_NO_SIGNUP_CONTEXT)
 
 	def test_the_context_never_leaves_the_idempotency_key_on_the_wire(self):
 		onboarding_contract.update(plan="annual")

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis import onboarding
+from jarvis import onboarding, onboarding_contract
 
 
 def _set_token(value, secret="secret"):
@@ -38,6 +38,7 @@ _SNAPSHOTTED_FIELDS = (
 	"jarvis_admin_api_secret",
 	"jarvis_admin_customer_email",
 	"jarvis_admin_customer_password",
+	"signup_context",
 	"agent_url",
 	"agent_token",
 	"release_notice_active",
@@ -315,7 +316,12 @@ class TestSignupEmailVerification(FrappeTestCase):
 				"ok": True,
 				"api_key": "verify-key",
 				"api_secret": "verify-secret",
-				"customer": "alice@example.com",
+				# Contract truth: ``customer`` is admin's SYNTHETIC OAuth login
+				# (_synthetic_login), not a deliverable address. The bench stores
+				# it as the grant username and must never render it.
+				"customer": "cust-3a91f0c2b7de@jarvis.invalid",
+				"email": "alice@example.com",
+				"company": "Acme",
 				"pending_verification": True,
 			},
 		):
@@ -334,11 +340,17 @@ class TestSignupEmailVerification(FrappeTestCase):
 			s.get_password("jarvis_admin_api_secret", raise_exception=False),
 			"verify-secret",
 		)
-		# The customer email (OAuth grant username) is persisted now; the
-		# password is deliberately absent on the verify-on response (admin
-		# defers it to the verified poll).
-		self.assertEqual(s.get("jarvis_admin_customer_email"), "alice@example.com")
+		# The OAuth grant username is persisted now; the password is deliberately
+		# absent on the verify-on response (admin defers it to the verified
+		# poll). What is stored is the synthetic login — which is exactly why no
+		# code may treat this field as the customer's address.
+		self.assertEqual(s.get("jarvis_admin_customer_email"), "cust-3a91f0c2b7de@jarvis.invalid")
 		self.assertFalse(s.get_password("jarvis_admin_customer_password", raise_exception=False) or "")
+		# The address a resumed wizard renders lives in the signup context, from
+		# admin's server truth.
+		context = onboarding_contract.load()
+		self.assertEqual(context["email"], "alice@example.com")
+		self.assertEqual(context["company"], "Acme")
 
 	def test_start_signup_legacy_response_still_persists_key_secret(self):
 		# Regression pin: the flag-off (legacy) response shape must keep
@@ -351,8 +363,10 @@ class TestSignupEmailVerification(FrappeTestCase):
 				"ok": True,
 				"api_key": "legacy-key",
 				"api_secret": "legacy-secret",
-				"customer": "bob@example.com",
+				"customer": "cust-b0b7e1d2c3f4@jarvis.invalid",
 				"customer_password": "bob-pw",
+				"email": "bob@example.com",
+				"company": "Bob Inc",
 				"razorpay_key_id": "rzp_test_X",
 				"razorpay_order_id": "order_LEGACY",
 				"amount_inr": 12000,
@@ -370,12 +384,20 @@ class TestSignupEmailVerification(FrappeTestCase):
 			"legacy-key",
 		)
 		# Flag-off path carries the OAuth password in the signup response; the
-		# bench persists it (+ the email) for bearer auth on subsequent calls.
-		self.assertEqual(s.get("jarvis_admin_customer_email"), "bob@example.com")
+		# bench persists it (+ the synthetic grant username) for bearer auth on
+		# subsequent calls.
+		self.assertEqual(s.get("jarvis_admin_customer_email"), "cust-b0b7e1d2c3f4@jarvis.invalid")
 		self.assertEqual(
 			s.get_password("jarvis_admin_customer_password", raise_exception=False),
 			"bob-pw",
 		)
+		# No credential ever reaches the plain-text context field.
+		context = onboarding_contract.load()
+		self.assertEqual(context["email"], "bob@example.com")
+		self.assertNotIn("api_key", context)
+		self.assertNotIn("api_secret", context)
+		self.assertNotIn("customer", context)
+		self.assertNotIn("customer_password", context)
 
 	def test_check_signup_payment_state_returns_pending(self):
 		# Customer hasn't clicked the link yet - admin returns
@@ -833,62 +855,203 @@ class TestWorkspaceReset(FrappeTestCase):
 
 
 class TestSignupResumeFallback(FrappeTestCase):
-	"""Failed-payment retry: the dedup rejection falls back to the authenticated
-	resume only when this bench holds creds for that same email."""
+	"""Failed-payment retry against CONTRACT-TRUE mocks.
 
-	_DUP = "An account with this email is already registered or pending."
+	The dead end had two independent kills and this class used to encode both:
+
+	1. the resume gate string-matched "already registered or pending"; admin
+	   reworded that sentence on 2026-07-26 and the gate stopped matching. The
+	   only surviving copy of the old wording in this tree was THIS suite's
+	   ``_DUP`` fixture, which is why all four tests stayed green while the
+	   feature was dead;
+	2. the gate then compared the typed email against
+	   ``jarvis_admin_customer_email`` — which holds admin's SYNTHETIC OAuth
+	   login ``cust-<hash>@jarvis.invalid``, never a real address. The old mocks
+	   returned a real email there, so the fiction that hid this kill lived in
+	   the fixtures too.
+
+	These mocks now say what admin says: the duplicate arrives as a CODE (or as
+	Frappe's exception class), and ``customer`` is the synthetic login with the
+	real address nowhere in Settings."""
+
+	# What admin's _synthetic_login actually mints, and what write_connection
+	# stores verbatim as jarvis_admin_customer_email.
+	_SYNTHETIC_LOGIN = "cust-9f2b1c4d5e6a@jarvis.invalid"
+	# Admin's current duplicate copy. Pinned ONLY to prove nothing branches on
+	# it: every test below passes a code or an exc_type, and the one that passes
+	# neither must NOT resume.
+	_DUP_COPY = "An account for this email and company already exists."
 
 	def setUp(self):
 		self._snap = _snapshot_settings()
 		s = frappe.get_single("Jarvis Settings")
 		_set_token("tok")
 		s.db_set("jarvis_admin_url", "https://fleet.example.test")
-		s.db_set("jarvis_admin_customer_email", "resume-me@example.com")
+		# Contract truth: the stored "customer email" is admin's synthetic OAuth
+		# login. Comparing a typed address against it can only ever be False.
+		s.db_set("jarvis_admin_customer_email", self._SYNTHETIC_LOGIN)
+		s.db_set("signup_context", "")
 		frappe.db.commit()
 
 	def tearDown(self):
 		_restore_settings(self._snap)
 
-	def _signup_raises(self, msg):
+	def _signup_raises(self, err):
+		return patch("jarvis.onboarding.admin_client.signup", side_effect=err)
+
+	def _duplicate_coded(self):
+		"""The RETURNED/THROWN contract shape: a stable code beside exc_type."""
+		from jarvis.exceptions import AdminContractError
+
+		return AdminContractError(
+			self._DUP_COPY,
+			code="ACCOUNT_ALREADY_EXISTS",
+			recovery="authenticate_or_reconnect",
+			error={
+				"code": "ACCOUNT_ALREADY_EXISTS",
+				"message": self._DUP_COPY,
+				"recovery": "authenticate_or_reconnect",
+			},
+			exc_type="DuplicateEntryError",
+			http_status=409,
+		)
+
+	def _duplicate_legacy(self):
+		"""A control plane older than the contract: Frappe's exception class and
+		a sentence, and no code anywhere."""
 		from jarvis.exceptions import AdminValidationError
 
-		return patch("jarvis.onboarding.admin_client.signup", side_effect=AdminValidationError(msg))
+		return AdminValidationError(
+			"An account with this email is already registered or pending.",
+			exc_type="DuplicateEntryError",
+		)
 
-	def test_dedup_with_matching_creds_resumes(self):
-		with (
-			self._signup_raises(self._DUP),
-			patch(
-				"jarvis.onboarding.admin_client.resume_pending_signup",
-				return_value={"payment_provider": "razorpay", "razorpay_order_id": "order_R2"},
-			) as resume,
-		):
+	def _resume_ok(self, order="order_R2"):
+		return patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value={
+				"payment_provider": "razorpay",
+				"razorpay_order_id": order,
+				"code": "PAYMENT_CONFIRMATION_PENDING",
+				"attempt_id": "att_7c2",
+				"generation": 2,
+				# Server truth for the identity: admin's real contact email, NOT
+				# the synthetic login and NOT what the wizard typed.
+				"email": "owner@acme.example",
+				"company": "Acme",
+			},
+		)
+
+	def test_coded_duplicate_resumes(self):
+		"""The headline. A coded duplicate reaches the resume with no prose read
+		and no email compared — the retry a declined card needs."""
+		with self._signup_raises(self._duplicate_coded()), self._resume_ok() as resume:
 			out = onboarding.start_signup("Resume-Me@example.com ", "Co", "some-plan")
-		resume.assert_called_once_with("some-plan", provider=None)
+		self.assertEqual(resume.call_count, 1)
+		self.assertEqual(resume.call_args.args[0], "some-plan")
 		self.assertEqual(out["razorpay_order_id"], "order_R2")
 
-	def test_dedup_with_different_email_reraises(self):
-		with (
-			self._signup_raises(self._DUP),
-			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
-			self.assertRaises(frappe.ValidationError),
-		):
-			onboarding.start_signup("someone-else@example.com", "Co", "some-plan")
-		resume.assert_not_called()
+	def test_duplicate_resumes_though_the_stored_login_can_never_match(self):
+		"""Kill #2, pinned. Settings hold the synthetic login; the customer types
+		a real address; the two are structurally never equal. Possession of the
+		credentials is the ownership proof, so the retry still succeeds."""
+		stored = frappe.db.get_single_value("Jarvis Settings", "jarvis_admin_customer_email")
+		self.assertEqual(stored, self._SYNTHETIC_LOGIN)
+		self.assertNotEqual(stored, "resume-me@example.com")
+		with self._signup_raises(self._duplicate_coded()), self._resume_ok("order_R9") as resume:
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_called_once()
+		self.assertEqual(out["razorpay_order_id"], "order_R9")
 
-	def test_non_dedup_error_reraises(self):
+	def test_any_typed_address_resumes_this_benchs_own_attempt(self):
+		"""No caller-supplied identifier chooses the record. Whatever was typed,
+		the resume authenticates as THIS bench and admin answers about the
+		account those credentials belong to — whose identity the response then
+		reports."""
+		with self._signup_raises(self._duplicate_coded()), self._resume_ok("order_RX") as resume:
+			out = onboarding.start_signup("somebody-completely-else@example.com", "Co", "some-plan")
+		resume.assert_called_once()
+		self.assertEqual(out["email"], "owner@acme.example")
+
+	def test_legacy_admin_duplicate_still_resumes_on_exc_type(self):
+		"""A fleet mid-upgrade: no contract code, only Frappe's exception class.
+		Every admin ever deployed throws DuplicateEntryError here, which is why
+		the prose fallback could be deleted rather than widened."""
+		with self._signup_raises(self._duplicate_legacy()), self._resume_ok("order_R4") as resume:
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_called_once()
+		self.assertEqual(out["razorpay_order_id"], "order_R4")
+
+	def test_the_duplicate_sentence_alone_never_resumes(self):
+		"""The regression that started all of this, inverted: prose is not a
+		signal. An error carrying admin's exact duplicate copy but NO machine
+		marker must not divert into the resume — that is the branch that rotted
+		the moment somebody improved the wording."""
+		from jarvis.exceptions import AdminValidationError
+
 		with (
-			self._signup_raises("Unsupported payment provider."),
+			self._signup_raises(AdminValidationError(self._DUP_COPY)),
 			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
 			self.assertRaises(frappe.ValidationError),
 		):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
 		resume.assert_not_called()
 
-	def test_failed_resume_reraises_original_duplicate(self):
+	def test_no_credentials_no_resume(self):
+		"""Ownership is proven by credentials, so a bench holding none has
+		nothing to prove it with — a wiped site's path is reconnect, not resume."""
+		_set_token("")
+		with (
+			self._signup_raises(self._duplicate_coded()),
+			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_not_called()
+
+	def test_a_double_submit_reuses_one_idempotency_key(self):
+		"""Two clicks, one gateway object: admin returns the intent a key it has
+		already seen created, so the second submit must arrive under the SAME
+		key. The key is persisted before the call, which is what covers the case
+		it exists for — the response that never comes back."""
+		with self._signup_raises(self._duplicate_coded()), self._resume_ok() as resume:
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		self.assertEqual(resume.call_count, 2)
+		first = resume.call_args_list[0].kwargs["idempotency_key"]
+		second = resume.call_args_list[1].kwargs["idempotency_key"]
+		self.assertTrue(first)
+		self.assertEqual(first, second)
+
+	def test_a_retry_after_a_decline_mints_a_new_key(self):
+		"""...and the opposite, because reusing it there is worse than not
+		having one: admin would hand back the very intent the gateway refused,
+		and the customer could never escape it."""
+		with self._signup_raises(self._duplicate_coded()), self._resume_ok() as resume:
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+			first = resume.call_args.kwargs["idempotency_key"]
+			# The gateway refuses that intent; the wizard's status check records it.
+			onboarding_contract.update(code=onboarding_contract.PAYMENT_DECLINED)
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+			second = resume.call_args.kwargs["idempotency_key"]
+		self.assertNotEqual(first, second)
+
+	def test_non_dedup_error_reraises(self):
 		from jarvis.exceptions import AdminValidationError
 
 		with (
-			self._signup_raises(self._DUP),
+			self._signup_raises(AdminValidationError("Unsupported payment provider.")),
+			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_not_called()
+
+	def test_failed_resume_surfaces_the_original_duplicate(self):
+		from jarvis.exceptions import AdminValidationError
+
+		with (
+			self._signup_raises(self._duplicate_coded()),
 			patch(
 				"jarvis.onboarding.admin_client.resume_pending_signup",
 				side_effect=AdminValidationError("signup is not awaiting payment; nothing to resume"),
@@ -896,7 +1059,247 @@ class TestSignupResumeFallback(FrappeTestCase):
 			self.assertRaises(frappe.ValidationError) as ctx,
 		):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
-		self.assertIn("already registered", str(ctx.exception))
+		self.assertIn("already exists", str(ctx.exception))
+
+	def test_a_thrown_duplicate_still_delivers_its_code(self):
+		"""A throw is how this endpoint reports failure, and the SPA still has to
+		branch. The machine-readable error rides on the response next to Frappe's
+		exc_type — the same mechanism admin uses, read from the other end."""
+		from jarvis.exceptions import AdminValidationError
+
+		with (
+			self._signup_raises(self._duplicate_coded()),
+			patch(
+				"jarvis.onboarding.admin_client.resume_pending_signup",
+				side_effect=AdminValidationError("nothing to resume"),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		self.assertEqual(frappe.local.response.get("error", {}).get("code"), "ACCOUNT_ALREADY_EXISTS")
+		self.assertEqual(frappe.local.response.get("error", {}).get("recovery"), "authenticate_or_reconnect")
+
+
+class TestOnboardingFacadeEndpoints(FrappeTestCase):
+	"""The three surfaces the payment page calls, and the local context they
+	keep. Each returns admin's envelope UNFILTERED plus a non-secret context
+	block; a failure comes back under a deliberate 4xx/5xx, never as an
+	``ok: false`` body wearing a 200."""
+
+	# One realistic passive-poll envelope, shaped exactly like admin's
+	# reconcile_pending / state fixtures.
+	_STATE = {
+		"contract_version": 2,
+		"code": "PAYMENT_CONFIRMATION_PENDING",
+		"pending_verification": False,
+		"payment_provider": "razorpay",
+		"amount_inr": 12000.0,
+		"plan": {"name": "annual", "label": "Annual"},
+		"signup_fee_inr": 0.0,
+		"due_today_inr": 12000.0,
+		"email": "owner@acme.example",
+		"company": "Acme",
+		"razorpay_key_id": "rzp_test_X",
+		"razorpay_order_id": "order_A1",
+		"can_initiate_payment": True,
+		"can_check_status": True,
+		"can_reconnect": False,
+		"attempt_id": "att_7c2",
+		"generation": 1,
+	}
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		s = frappe.get_single("Jarvis Settings")
+		_set_token("tok")
+		s.db_set("jarvis_admin_url", "https://fleet.example.test")
+		s.db_set("signup_context", "")
+		frappe.db.commit()
+		frappe.local.response.pop("http_status_code", None)
+
+	def tearDown(self):
+		frappe.local.response.pop("http_status_code", None)
+		_restore_settings(self._snap)
+
+	def test_state_passes_the_envelope_through_untouched(self):
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			return_value=dict(self._STATE, some_future_field="from a newer admin"),
+		):
+			out = onboarding.get_onboarding_state()
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["contract_version"], 2)
+		self.assertEqual(out["data"]["code"], "PAYMENT_CONFIRMATION_PENDING")
+		self.assertTrue(out["data"]["can_initiate_payment"])
+		self.assertFalse(out["data"]["can_reconnect"])
+		# Additive-only is admin's rule; not filtering is what makes it true here.
+		self.assertEqual(out["data"]["some_future_field"], "from a newer admin")
+
+	def test_state_records_the_display_context(self):
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			return_value=self._STATE,
+		):
+			out = onboarding.get_onboarding_state()
+		context = out["context"]
+		self.assertEqual(context["email"], "owner@acme.example")
+		self.assertEqual(context["company"], "Acme")
+		self.assertEqual(context["plan"], "annual")
+		self.assertEqual(context["plan_label"], "Annual")
+		self.assertEqual(context["attempt_id"], "att_7c2")
+		self.assertEqual(context["due_today_inr"], 12000.0)
+		self.assertEqual(context["code"], "PAYMENT_CONFIRMATION_PENDING")
+		# Survives a restart: it is persisted, not assembled per request.
+		self.assertEqual(onboarding_contract.load()["attempt_id"], "att_7c2")
+
+	def test_state_persists_the_oauth_password_it_is_handed(self):
+		"""Admin delivers the login password on whichever poll first runs after
+		the email is confirmed. Whichever surface receives it must persist it or
+		the bench never gets bearer auth."""
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			return_value=dict(self._STATE, customer_password="pw-once"),
+		):
+			onboarding.get_onboarding_state()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_customer_password", raise_exception=False), "pw-once")
+		self.assertNotIn("customer_password", onboarding_contract.load())
+
+	def test_a_failure_is_a_deliberate_4xx_not_an_ok_false_200(self):
+		from jarvis.exceptions import AdminContractError
+
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+			side_effect=AdminContractError(
+				"This signup is already paid. Continue setup.",
+				code="PAYMENT_ALREADY_ACTIVE",
+				recovery="continue_setup",
+				error={
+					"code": "PAYMENT_ALREADY_ACTIVE",
+					"message": "This signup is already paid. Continue setup.",
+					"recovery": "continue_setup",
+					"subscription_status": "Active",
+				},
+				http_status=409,
+			),
+		):
+			out = onboarding.get_onboarding_state()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "PAYMENT_ALREADY_ACTIVE")
+		self.assertEqual(out["error"]["recovery"], "continue_setup")
+		self.assertEqual(out["error"]["subscription_status"], "Active")
+		self.assertEqual(frappe.local.response.http_status_code, 409)
+
+	def test_a_rate_limit_is_not_reported_as_a_decline(self):
+		from jarvis.exceptions import AdminRateLimitedError
+
+		with patch(
+			"jarvis.onboarding.admin_client.check_signup_payment_status",
+			side_effect=AdminRateLimitedError(
+				"We're still checking with your payment provider.",
+				retry_after_seconds=30,
+				code="PAYMENT_CHECK_RATE_LIMITED",
+				recovery="retry",
+				error={"code": "PAYMENT_CHECK_RATE_LIMITED", "retry_after_seconds": 30},
+			),
+		):
+			out = onboarding.check_signup_payment_status()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "PAYMENT_CHECK_RATE_LIMITED")
+		self.assertEqual(out["error"]["retry_after_seconds"], 30)
+		self.assertEqual(frappe.local.response.http_status_code, 429)
+
+	def test_the_check_carries_its_two_extra_facts(self):
+		with patch(
+			"jarvis.onboarding.admin_client.check_signup_payment_status",
+			return_value=dict(
+				self._STATE,
+				gateway_consulted=True,
+				awaiting_manual_reconciliation=True,
+				can_initiate_payment=False,
+			),
+		):
+			out = onboarding.check_signup_payment_status()
+		self.assertTrue(out["data"]["gateway_consulted"])
+		self.assertTrue(out["data"]["awaiting_manual_reconciliation"])
+		self.assertFalse(out["data"]["can_initiate_payment"])
+
+	def test_initiate_uses_the_plan_the_signup_was_started_with(self):
+		onboarding_contract.update(plan="annual", payment_provider="cashfree")
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			out = onboarding.initiate_signup_payment()
+		self.assertTrue(out["ok"])
+		self.assertEqual(resume.call_args.args[0], "annual")
+		self.assertEqual(resume.call_args.kwargs["provider"], "cashfree")
+
+	def test_initiate_double_click_reuses_one_key(self):
+		onboarding_contract.update(plan="annual")
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			onboarding.initiate_signup_payment()
+			first = resume.call_args.kwargs["idempotency_key"]
+			onboarding.initiate_signup_payment()
+			second = resume.call_args.kwargs["idempotency_key"]
+		self.assertTrue(first)
+		self.assertEqual(first, second)
+
+	def test_initiate_honours_a_supplied_key_verbatim(self):
+		onboarding_contract.update(plan="annual")
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		) as resume:
+			onboarding.initiate_signup_payment(idempotency_key="caller-chose-this")
+		self.assertEqual(resume.call_args.kwargs["idempotency_key"], "caller-chose-this")
+
+	def test_initiate_with_no_signup_refuses_with_a_code(self):
+		"""Nothing local and nothing named: a coded refusal, never a guess.
+		Initiating on the wrong plan is a wrong charge."""
+		with patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume:
+			out = onboarding.initiate_signup_payment()
+		resume.assert_not_called()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], onboarding_contract.BENCH_NO_SIGNUP_CONTEXT)
+		self.assertEqual(frappe.local.response.http_status_code, 409)
+
+	def test_a_refused_initiate_still_updates_what_the_page_renders(self):
+		"""A wizard reloading onto "already paid" has to render that, not the
+		plan it was about to charge for."""
+		from jarvis.exceptions import AdminContractError
+
+		onboarding_contract.update(plan="annual")
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			side_effect=AdminContractError(
+				"This signup is already paid. Continue setup.",
+				code="PAYMENT_ALREADY_ACTIVE",
+				error={
+					"code": "PAYMENT_ALREADY_ACTIVE",
+					"message": "This signup is already paid. Continue setup.",
+					"subscription_status": "Active",
+					"attempt_id": "att_7c2",
+				},
+				http_status=409,
+			),
+		):
+			out = onboarding.initiate_signup_payment()
+		self.assertEqual(out["context"]["code"], "PAYMENT_ALREADY_ACTIVE")
+		self.assertEqual(out["context"]["subscription_status"], "Active")
+
+	def test_the_context_never_leaves_the_idempotency_key_on_the_wire(self):
+		onboarding_contract.update(plan="annual")
+		with patch(
+			"jarvis.onboarding.admin_client.resume_pending_signup",
+			return_value=self._STATE,
+		):
+			out = onboarding.initiate_signup_payment()
+		self.assertNotIn("idempotency_key", out["context"])
+		self.assertTrue(onboarding_contract.load()["idempotency_key"])
 
 
 class TestAccountReconnect(FrappeTestCase):


### PR DESCRIPTION
## What this does

Kills the onboarding **payment dead-end** at the bench end and gives the SPA a stable,
machine-readable contract to drive the pay page from (plan 03 / WS-B B2, built as
corrected by `FABLE-JUDGMENT.md`).

### The dead-end had TWO kills — both are dead here

1. **Prose matching.** `onboarding.py` matched admin's *message text*
   ("already registered or pending") against a string admin no longer sends
   ("An account for this email and company already exists."). Retries fell through to a
   terminal error instead of resuming. Now keyed on stable machine codes + `exc_type`,
   never prose.
2. **The synthetic-login identity check.** Admin returns `customer.user` as
   `cust-<hash>@jarvis.invalid`; the bench stored that as `jarvis_admin_customer_email`
   and compared it against the user's *real* email — a comparison that is structurally
   never equal, so the resume path could never fire. Removed.

(Supersedes draft #581, which fixes kill 1 only.)

### Also in here

- **Contract layer** (`onboarding_contract.py`): stable code vocabulary, a persisted
  context store, and 18 vendored/bench-authored fixtures with sha256 provenance, so the
  bench and admin sides can't silently drift.
- **Credentials no longer travel on the wire.** `api_key` / `api_secret` /
  `customer_password` / `agent_token` are stripped from every response
  (`get_onboarding_state`, `check_signup_payment_status`, the legacy poll, `start_signup`
  both paths, `finish_payment`) while still being persisted server-side.
  `finish_payment` mattered most: it is gated on **Jarvis Admin** (a role every
  onboarding completer receives), and admin's `confirm_payment` has a replay branch that
  re-serves the connection for an already-recorded payment id — the Cashfree path on a
  caller-supplied order id with no signature. That made it a **repeatable container
  bearer-token read**. It is now replay-safe and returns nothing secret.
- **Parked money can't be double-charged.** When a payment is awaiting manual
  reconciliation, `start_signup` (fresh create *and* resume) and `initiate_signup_payment`
  refuse locally with `BENCH_AWAITING_RECONCILIATION` (409, `recovery: check_status`) —
  no network call, no second intent.
- **Idempotency keys can't brick a signup.** An oversized/invalid key is refused before
  anything persists, and a key admin has rejected now self-heals to a fresh one on the
  next attempt.
- **Day-one visitors** get the signup form, not "contact support": the no-credentials
  case is answered locally instead of via a guaranteed 401.
- Steady-state polling costs **zero writes** (it was writing `tabSingles` on every poll
  and busting the settings cache site-wide).

## Verification

Full doctrine: build → Sonnet UX + Opus adversarial panels → fix round → **targeted
adversarial re-probe** → fix round 2 → **final re-probe** → Fable judgment.

- **220 tests green**: `test_onboarding_sync` 96, `test_admin_client` 64,
  `test_admin_contract` 31, `test_account` 29 (patterntest.localhost).
- Every fix landed **red-first** (failing test replayed against the pre-fix source, with
  the failure text recorded), then green.
- **Mutation-pinned**: reverting the duplicate-detection code branch, the persisted-context
  credential sweep, or either `strip_credentials` call turns the suite red.
- The final re-probe drove the credential strips with keys admin *doesn't currently send*
  (so coverage doesn't depend on today's admin shape), replayed `finish_payment` through
  the replay branch, ran the bad-key brick end-to-end through the real absorb path, and
  swept every route into a signup intent. Verdict: **clear for closure**.

## Deploy notes

No migration needed. Bench-side only; pairs with admin-v2 #169 (contract) and #171
(reconcile) — this branch tolerates an admin that predates them.

## Follow-ups (ledgered, not in this PR)

- Admin-side **durable** parked-money marker + a guard on admin's own
  `resume_pending_signup` (the bench refusal is defence-in-depth over bench-local state).
- `onboarding_contract.clear()` has no callers — the context survives
  `request_workspace_reset`. Deferred: its call site sits inside WS-D1's hunk zone, and
  clearing the context also drops the parked-money flag, so it lands with the admin marker.
- Admin-side twins of the two bench-authored fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
