### PR TITLE
ci: gate PRs on the frontend Vitest + node:test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,57 @@ jobs:
         with:
           extra_args: --all-files --show-diff-on-failure
 
+  # The frontend Vue SPA carries its own two test suites and, until this job, NOTHING ran either of
+  # them on a PR: `frontend/package.json` defines `test` (vitest) and `test:node` (node's built-in
+  # runner), but no workflow invoked them, so a browser-transport regression once shipped green.
+  # This is that gate. It needs only node — no bench, no container — so it reports fast and
+  # independently of the Python shards above.
+  frontend-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Full-repo checkout, not a sparse frontend/ one: frontend/package.json depends on
+      # ../wiki-graph-core via a `file:` link, so its sibling must be on disk for `npm ci`.
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # Node 24 is this repo's canonical dev/bench version and what the suite is validated
+          # against locally. (The lint job runs 20 because it only shells pre-commit hooks.)
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Vitest (*.spec.js + tests/support-extraction/**/*.test.js)
+        working-directory: frontend
+        env:
+          # Belt-and-braces: vitest already fails a non-watch run on an unhandled rejection, but
+          # make node itself throw on one too so nothing rejects silently.
+          NODE_OPTIONS: --unhandled-rejections=strict
+        run: |
+          # `npm test` is `vitest run` (non-watch). Exactly one file is quarantined:
+          #
+          #   tests/support-extraction/support-thread.test.js
+          #
+          # It has a single PRE-EXISTING, unrelated failure (a mid-flight ticket-switch reply is
+          # asserted against a two-arg uploadTo() signature that has since grown extra args). That
+          # is out of scope for the CI change that added this job and must NOT be "fixed" here.
+          # Excluding the one file lets the other 27 files (306 tests) gate PRs today. DELETE this
+          # --exclude — re-including the file — the moment that assertion is repaired upstream.
+          npm test -- --exclude '**/support-thread.test.js'
+
+      - name: node:test (co-located src/**/*.test.js)
+        working-directory: frontend
+        env:
+          NODE_OPTIONS: --unhandled-rejections=strict
+        # node's runner exits non-zero on any failure or unhandled rejection; no watch mode exists
+        # for `node --test`, so this is inherently a one-shot gate.
+        run: npm run test:node
+
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 25


### PR DESCRIPTION
## Why this gate exists

The frontend Vue SPA has shipped two test suites for a while, and until now **no CI job ran either of them**:

- `frontend/package.json` → `test` = `vitest run` (the `*.spec.js` component tests + `tests/support-extraction/**/*.test.js`)
- `frontend/package.json` → `test:node` = `node --test "src/**/*.test.js"` (co-located node:test files)

`.github/workflows/ci.yml` had only three jobs — `lint` (pre-commit), `tests` (4 Frappe Python shards), `coverage` — none of which touch the frontend. A browser-transport P0 shipped **green** through that gap. This PR adds a `frontend-tests` job so those suites actually gate PRs.

## What the job does

- `actions/checkout` (full repo — `frontend` depends on `../wiki-graph-core` via a `file:` link) + `actions/setup-node@v4` on Node 24 (the repo's canonical dev/bench version, and what the suite is validated against) with npm caching keyed on `frontend/package-lock.json`.
- `npm ci` in `frontend/`.
- Vitest in non-watch mode (`npm test -- --exclude …`) and the node:test suite (`npm run test:node`), both with `NODE_OPTIONS=--unhandled-rejections=strict` so nothing rejects silently. No watch mode anywhere.
- Bench-free: no container, no site — reports fast and independently of the Python shards.

## What is excluded and why

Exactly one file is quarantined:

```
tests/support-extraction/support-thread.test.js
```

It has a **single pre-existing, unrelated failure** — a mid-flight ticket-switch reply asserted against a two-arg `uploadTo()` signature that has since grown extra args. That is out of scope for this CI change, so per direction it is **not** "fixed" here; instead the one file is excluded via `--exclude`, with an in-file comment pointing at re-inclusion once the assertion is repaired upstream. The test file itself is untouched.

## Local run counts (Node 24)

- Vitest with the exclude: **27 files / 306 tests passed**, exit 0.
- Full Vitest (no exclude): 28 files, 350 passed / 1 failed (the quarantined file).
- node:test: **451 tests passed**, 0 failed, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)