### PR TITLE
feat(onboarding): ERP company billing defaults + billing passthrough (Plan 01 WS-B)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -176,6 +176,7 @@ def signup(
 	plan: str,
 	coupon: str | None = None,
 	provider: str | None = None,
+	billing: dict | None = None,
 ) -> dict:
 	"""Guest signup against admin. Returns admin's data dict, which carries a
 	``payment_provider`` discriminator plus that gateway's checkout handles:
@@ -197,6 +198,11 @@ def signup(
 
 	``provider`` (optional) requests a specific gateway; admin defaults to
 	razorpay when omitted or unsupported.
+
+	``billing`` (optional, Plan 01) is a typed snapshot admin normalizes and
+	stores on the Customer in the signup transaction; the response echoes
+	``billing_saved: true`` only when a NEW admin persisted it (an older admin
+	drops the unknown kwarg and never echoes it).
 	"""
 	body = {
 		"email": email,
@@ -209,10 +215,12 @@ def signup(
 		body["coupon"] = coupon
 	if provider:
 		body["provider"] = provider
+	if billing:
+		body["billing"] = billing
 	return _post_guest(path=_m("billing.signup.signup"), body=body)
 
 
-def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
+def resume_pending_signup(plan: str, provider: str | None = None, billing: dict | None = None) -> dict:
 	"""Authenticated failed-payment resume: re-issues checkout handles for the
 	caller's own Pending Payment signup, optionally on a different plan/provider.
 	Returns the same checkout-fields shape as signup's sync path (no credentials
@@ -221,7 +229,18 @@ def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
 	body: dict = {"plan": plan}
 	if provider:
 		body["provider"] = provider
+	if billing:
+		body["billing"] = billing
 	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)
+
+
+def update_pending_billing(billing: dict) -> dict:
+	"""Authenticated billing-only edit: update the caller's owned Pending Payment
+	Customer WITHOUT re-issuing a payment intent (the post-intent Review & Pay
+	"Edit" path). Returns admin's data (``billing_saved`` + normalized ``billing``
+	summary). Raises AdminValidationError on a rejected payload or a non-resumable
+	status."""
+	return _post(path=_m("billing.signup.update_pending_billing"), body={"billing": billing})
 
 
 def reconnect_eligibility(email: str, company_name: str = "") -> dict:

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -505,7 +505,9 @@ def _clear_llm_secrets(settings) -> None:
 
 
 @frappe.whitelist()
-def start_signup(email: str, company: str, plan: str, provider: str | None = None) -> dict:
+def start_signup(
+	email: str, company: str, plan: str, provider: str | None = None, billing: dict | None = None
+) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.
 
 	Gated on System Manager (Sprint-1 Important from the 2026-06-16 code
@@ -532,9 +534,9 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	require_jarvis_admin()
 	_require_admin_url()
 	try:
-		data = _surface(admin_client.signup, email, company, plan, provider=provider)
+		data = _surface(admin_client.signup, email, company, plan, provider=provider, billing=billing)
 	except frappe.ValidationError as e:
-		resumed = _try_resume_pending_signup(e, email, plan, provider)
+		resumed = _try_resume_pending_signup(e, email, plan, provider, billing)
 		if resumed is None:
 			raise
 		data = resumed
@@ -562,7 +564,9 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	return data
 
 
-def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None) -> dict | None:
+def _try_resume_pending_signup(
+	err, email: str, plan: str, provider: str | None, billing: dict | None = None
+) -> dict | None:
 	"""Failed-payment retry: when guest signup is rejected as a duplicate and
 	this bench already holds credentials for THAT email (persisted by the first
 	attempt), resume the pending signup through admin's authenticated
@@ -582,7 +586,7 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 	if not has_creds or stored_email != (email or "").strip().lower():
 		return None
 	try:
-		return admin_client.resume_pending_signup(plan, provider=provider)
+		return admin_client.resume_pending_signup(plan, provider=provider, billing=billing)
 	except Exception:
 		# Deliberate fallthrough to the original duplicate error (a rejected
 		# resume usually means a REAL duplicate), but leave a trace so a broken
@@ -592,6 +596,19 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 			message=frappe.get_traceback(),
 		)
 		return None
+
+
+@frappe.whitelist()
+def update_billing(billing: dict) -> dict:
+	"""Authenticated billing-only edit facade (Plan 01, post-intent Review & Pay
+	"Edit"): forwards to admin's ``update_pending_billing`` on the owned pending
+	Customer. Does NOT create or replace a payment intent and never calls guest
+	signup. Gated on Jarvis Admin like the rest of onboarding; admin re-checks
+	ownership + Pending Payment status. Returns admin's data
+	(``billing_saved`` + normalized ``billing`` summary) un-flattened."""
+	require_jarvis_admin()
+	_require_admin_url()
+	return _surface(admin_client.update_pending_billing, billing)
 
 
 @frappe.whitelist()
@@ -682,6 +699,150 @@ def get_account_defaults() -> dict:
 		# its placeholder, exactly like the desk auto-fetch's silent no-op.
 		company, companies = "", []
 	return {"email": email, "company": company, "companies": companies}
+
+
+def _company_defaults_error(code: str, message: str, http_status: int) -> dict:
+	"""Coded error envelope for get_company_onboarding_defaults, mirroring admin
+	signup.py's {"ok": False, "error": {"code": ...}} shape so the SPA keys on a
+	stable code, never a prose message. ``message`` never carries billing PII."""
+	frappe.local.response.http_status_code = http_status
+	return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def _resolve_company_contact(company: str) -> dict | None:
+	"""Primary Contact for the Company + a phone number.
+
+	``frappe.contacts...get_default_contact`` is raw SQL that checks NO permission
+	(C01-3), so we re-check Contact read permission ourselves and leak nothing if
+	it is not readable. Phone falls back mobile_no -> phone -> child ``phone_nos``
+	rows (C01-4: the denormalized fields are blank unless a child row carries the
+	primary flag)."""
+	from frappe.contacts.doctype.contact.contact import get_default_contact
+
+	try:
+		contact_name = get_default_contact("Company", company)
+	except Exception:
+		contact_name = None
+	if not contact_name or not frappe.has_permission("Contact", "read", doc=contact_name):
+		return None
+	c = frappe.db.get_value(
+		"Contact",
+		contact_name,
+		["name", "first_name", "last_name", "company_name", "mobile_no", "phone"],
+		as_dict=True,
+	)
+	if not c:
+		return None
+	phone = (c.mobile_no or "").strip() or (c.phone or "").strip() or _contact_child_phone(contact_name)
+	display = " ".join(p for p in (c.first_name, c.last_name) if p).strip() or (c.company_name or "")
+	out = {"name": c.name}
+	if display:
+		out["display_name"] = display
+	if phone:
+		out["phone"] = phone
+	return out
+
+
+def _contact_child_phone(contact_name: str) -> str:
+	"""Deterministic phone from a Contact's child ``phone_nos`` rows (C01-4):
+	primary mobile, then primary phone, then the first non-empty row by idx."""
+	rows = frappe.get_all(
+		"Contact Phone",
+		filters={"parent": contact_name, "parenttype": "Contact"},
+		fields=["phone", "is_primary_phone", "is_primary_mobile_no"],
+		order_by="idx asc",
+	)
+	for want in ("is_primary_mobile_no", "is_primary_phone"):
+		for r in rows:
+			if r.get(want) and (r.phone or "").strip():
+				return r.phone.strip()
+	for r in rows:
+		if (r.phone or "").strip():
+			return r.phone.strip()
+	return ""
+
+
+def _resolve_company_billing_address(company: str) -> dict | None:
+	"""Primary billing Address for the Company, as an allowlisted presentation dict.
+
+	ERPNext is OPTIONAL (C01-1): this deliberately does NOT call
+	``erpnext...get_default_company_address`` \u2014 that helper both requires ERPNext
+	(jarvis is a frappe-only app) AND does not select a primary address (its
+	``max()`` over unset ``is_primary_address`` flags returns an arbitrary
+	SQL-order row \u2014 C01-2). Instead we run the frappe-only Dynamic Link query that
+	works on every bench and filter EXPLICITLY on ``is_primary_address = 1``,
+	excluding disabled rows. Nothing flagged primary -> return NOTHING, never a
+	warehouse/shipping address dressed up as billing. Own read-permission check
+	(C01-3). GSTIN is read only when the field exists in Address metadata (India
+	Compliance not installed on frappe-only benches)."""
+	linked = frappe.get_all(
+		"Dynamic Link",
+		filters={"link_doctype": "Company", "link_name": company, "parenttype": "Address"},
+		pluck="parent",
+	)
+	if not linked:
+		return None
+	primary = frappe.get_all(
+		"Address",
+		filters={"name": ["in", linked], "is_primary_address": 1, "disabled": 0},
+		pluck="name",
+		order_by="modified desc",
+		limit=1,
+	)
+	if not primary or not frappe.has_permission("Address", "read", doc=primary[0]):
+		return None
+	has_gstin = frappe.get_meta("Address").has_field("gstin")
+	fields = ["name", "address_line1", "address_line2", "city", "state", "pincode", "country"]
+	if has_gstin:
+		fields.append("gstin")
+	a = frappe.db.get_value("Address", primary[0], fields, as_dict=True)
+	if not a:
+		return None
+	out = {"name": a.name}
+	for k in ("address_line1", "address_line2", "city", "state", "pincode", "country"):
+		if a.get(k):
+			out[k] = a.get(k)
+	if has_gstin and a.get("gstin"):
+		out["gstin"] = a.get("gstin")
+	return out
+
+
+@frappe.whitelist()
+def get_company_onboarding_defaults(company: str) -> dict:
+	"""ERP-derived billing defaults for ONE selected Company (Plan 01): its primary
+	Contact's phone and its primary billing Address (+ optional India Compliance
+	GSTIN). Behind the same onboarding-admin gate as the rest of onboarding.
+
+	Returns an allowlisted PRESENTATION dict \u2014 never whole Contact/Address
+	documents, never unrelated fields:
+
+	    {"ok": True, "data": {"company": "...",
+	        "contact": {"name","display_name","phone"},
+	        "billing_address": {"name","address_line1","address_line2","city",
+	                            "state","pincode","country","gstin"}}}
+
+	``contact`` / ``billing_address`` are omitted when nothing resolves (so a site
+	without linked Contact/Address still onboards). Failures carry a stable code:
+	COMPANY_DEFAULTS_NOT_FOUND (blank/unknown company) or COMPANY_DEFAULTS_FORBIDDEN
+	(company not readable). Neither the Frappe contact helper nor the Dynamic Link
+	query checks permission, so every read gate here is ours (C01-3)."""
+	require_jarvis_admin()
+	company = (company or "").strip()
+	if not company:
+		return _company_defaults_error("COMPANY_DEFAULTS_NOT_FOUND", "company is required", 400)
+	if not frappe.db.exists("Company", company):
+		return _company_defaults_error("COMPANY_DEFAULTS_NOT_FOUND", "unknown company", 404)
+	if not frappe.has_permission("Company", "read", doc=company):
+		return _company_defaults_error("COMPANY_DEFAULTS_FORBIDDEN", "not permitted to read this company", 403)
+
+	data: dict = {"company": company}
+	contact = _resolve_company_contact(company)
+	if contact:
+		data["contact"] = contact
+	address = _resolve_company_billing_address(company)
+	if address:
+		data["billing_address"] = address
+	return {"ok": True, "data": data}
 
 
 @frappe.whitelist()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -830,10 +830,16 @@ def get_company_onboarding_defaults(company: str) -> dict:
 	company = (company or "").strip()
 	if not company:
 		return _company_defaults_error("COMPANY_DEFAULTS_NOT_FOUND", "company is required", 400)
-	if not frappe.db.exists("Company", company):
+	# Company is an ERPNext doctype and jarvis runs on frappe-only benches too
+	# (C01-1). Guard the doctype's existence first so frappe.db.exists("Company", …)
+	# can't 500 on a missing table — a frappe-only site simply has no company to
+	# resolve.
+	if not frappe.db.exists("DocType", "Company") or not frappe.db.exists("Company", company):
 		return _company_defaults_error("COMPANY_DEFAULTS_NOT_FOUND", "unknown company", 404)
 	if not frappe.has_permission("Company", "read", doc=company):
-		return _company_defaults_error("COMPANY_DEFAULTS_FORBIDDEN", "not permitted to read this company", 403)
+		return _company_defaults_error(
+			"COMPANY_DEFAULTS_FORBIDDEN", "not permitted to read this company", 403
+		)
 
 	data: dict = {"company": company}
 	contact = _resolve_company_contact(company)

--- a/jarvis/tests/fixtures/billing_contract/PROVENANCE.md
+++ b/jarvis/tests/fixtures/billing_contract/PROVENANCE.md
@@ -1,0 +1,24 @@
+# Billing-object contract fixture (Plan 01)
+
+`billing_snapshot.json` is the shared billing-object contract for the customer
+onboarding flow. It is **byte-for-byte identical** to its twin in the admin repo:
+
+| | |
+|---|---|
+| twin repo | `git@github.com:Aerele-RnD/jarvis-admin-v2.git` |
+| twin path | `jarvis_admin_v2/tests/billing/fixtures/billing_contract/billing_snapshot.json` |
+| sha256 | `612aa11a918ea4f789e2b44d51d4b46d35551e3ec06cdebf9a4cb0848b38f6e9` |
+
+Both sides load the same file and assert against it, so the wire shape cannot
+drift between the bench (which forwards the object and consumes the normalized
+summary + `billing_saved` ack) and admin (which owns the normalizer that stores
+and re-reads it). `test_billing_contract.py` recomputes the sha above and fails
+on a mismatch.
+
+NOTE (coordination): the broader admin-contract corpus
+(`jarvis/tests/fixtures/admin_contract/`, WS-B) is not on `develop` at the time
+this landed; this Plan-01 billing fixture is deliberately in its own
+`billing_contract/` subdir so it neither depends on nor collides with that corpus
+when WS-B merges. The paired-head CI job that diffs the two repos' copies is
+deferred with the rest of combined-head CI (FABLE-JUDGMENT §2.6); the sha assertion
+here is the standing in-repo guard until then.

--- a/jarvis/tests/fixtures/billing_contract/billing_snapshot.json
+++ b/jarvis/tests/fixtures/billing_contract/billing_snapshot.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 1,
+  "name": "billing_snapshot",
+  "description": "Plan 01 billing-object contract, shared byte-for-byte by jarvis and jarvis-admin-v2. request_billing is the typed object the bench sends admin (start_signup -> admin_client.signup / resume_pending_signup / update_pending_billing). normalized_summary is the allowlisted snapshot admin returns (get_signup_payment_state.data.billing and update_pending_billing.data.billing) and keys are IDENTICAL to the request (admin stores each key on a Jarvis Customer field and reads it back out under the same key). ack is the C01-5 version-skew acknowledgement echoed only after a durable write.",
+  "request_billing": {
+    "contact_number": "+91 98765 43210",
+    "address_line1": "12 MG Road",
+    "address_line2": "Suite 4",
+    "city": "Chennai",
+    "state": "Tamil Nadu",
+    "pincode": "600001",
+    "country": "India",
+    "gstin": "33ABCDE1234F1Z5",
+    "source_company": "Aerele",
+    "source_address": "Aerele-Billing"
+  },
+  "normalized_summary": {
+    "contact_number": "+91 98765 43210",
+    "address_line1": "12 MG Road",
+    "address_line2": "Suite 4",
+    "city": "Chennai",
+    "state": "Tamil Nadu",
+    "pincode": "600001",
+    "country": "India",
+    "gstin": "33ABCDE1234F1Z5",
+    "source_company": "Aerele",
+    "source_address": "Aerele-Billing"
+  },
+  "ack": {
+    "billing_saved": true
+  }
+}

--- a/jarvis/tests/test_billing_contract.py
+++ b/jarvis/tests/test_billing_contract.py
@@ -1,0 +1,38 @@
+"""Plan 01 billing-object contract (bench side).
+
+Pins the shared fixture sha (byte-identical twin in the admin repo) and asserts
+the bench forwards the typed billing object to admin UNMODIFIED — the bench never
+reshapes or flattens it; admin owns the normalizer.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import admin_client
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "billing_contract" / "billing_snapshot.json"
+# sha256 of the shared billing_snapshot.json; the admin twin pins the same value.
+_FIXTURE_SHA = "612aa11a918ea4f789e2b44d51d4b46d35551e3ec06cdebf9a4cb0848b38f6e9"
+
+
+class TestBillingContract(FrappeTestCase):
+	def setUp(self):
+		self.fx = json.loads(_FIXTURE.read_text())
+
+	def test_fixture_sha_pinned(self):
+		self.assertEqual(hashlib.sha256(_FIXTURE.read_bytes()).hexdigest(), _FIXTURE_SHA)
+
+	def test_admin_client_forwards_billing_object_unmodified(self):
+		captured = {}
+
+		def _fake_post_guest(path, body):
+			captured["body"] = body
+			return {}
+
+		with patch("jarvis.admin_client._post_guest", side_effect=_fake_post_guest):
+			admin_client.signup("a@b.com", "Acme", "some-plan", billing=self.fx["request_billing"])
+		self.assertEqual(captured["body"]["billing"], self.fx["request_billing"])

--- a/jarvis/tests/test_onboarding_company_defaults.py
+++ b/jarvis/tests/test_onboarding_company_defaults.py
@@ -1,0 +1,286 @@
+"""onboarding.get_company_onboarding_defaults — ERP-derived billing defaults for
+one selected Company (Plan 01, WS-A).
+
+Mock-based on purpose: jarvis is a frappe-only app (ERPNext/India-Compliance are
+OPTIONAL — C01-1), so these tests must pass on a frappe-only CI bench where the
+Company doctype does not exist and no ERPNext helper is importable. Each test
+still exercises the REAL resolution logic — the primary-address filter, the phone
+fallback order, the permission short-circuits, the gstin-metadata branch — by
+mocking only the frappe data-access boundary underneath it.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import onboarding
+
+
+def _dispatch_get_all(mapping):
+	"""Return a frappe.get_all side_effect dispatching on the doctype (1st arg)."""
+
+	def _inner(doctype, *args, **kwargs):
+		val = mapping.get(doctype, [])
+		return list(val)
+
+	return _inner
+
+
+class TestCompanyDefaultsEndpoint(FrappeTestCase):
+	"""Gates + assembly + allowlist. The two resolvers are patched so this class
+	isolates the endpoint's own behavior."""
+
+	def test_non_admin_caller_rejected(self):
+		frappe.set_user("Guest")
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				onboarding.get_company_onboarding_defaults("Aerele")
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_blank_company_not_found(self):
+		out = onboarding.get_company_onboarding_defaults("   ")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "COMPANY_DEFAULTS_NOT_FOUND")
+
+	def test_unknown_company_not_found(self):
+		with patch("frappe.db.exists", return_value=False):
+			out = onboarding.get_company_onboarding_defaults("Ghost Co")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "COMPANY_DEFAULTS_NOT_FOUND")
+
+	def test_unreadable_company_forbidden(self):
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=False),
+		):
+			out = onboarding.get_company_onboarding_defaults("Aerele")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "COMPANY_DEFAULTS_FORBIDDEN")
+
+	def test_assembles_and_allowlists(self):
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch.object(
+				onboarding,
+				"_resolve_company_contact",
+				return_value={"name": "CNT-1", "display_name": "V", "phone": "+91"},
+			),
+			patch.object(
+				onboarding,
+				"_resolve_company_billing_address",
+				return_value={"name": "ADD-1", "city": "Chennai", "gstin": "33ABCDE1234F1Z5"},
+			),
+		):
+			out = onboarding.get_company_onboarding_defaults("Aerele")
+		self.assertTrue(out["ok"])
+		self.assertEqual(set(out["data"].keys()), {"company", "contact", "billing_address"})
+		self.assertEqual(out["data"]["company"], "Aerele")
+
+	def test_missing_links_are_omitted_not_faked(self):
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch.object(onboarding, "_resolve_company_contact", return_value=None),
+			patch.object(onboarding, "_resolve_company_billing_address", return_value=None),
+		):
+			out = onboarding.get_company_onboarding_defaults("Aerele")
+		self.assertTrue(out["ok"])
+		self.assertEqual(set(out["data"].keys()), {"company"})
+
+
+class TestResolveContact(FrappeTestCase):
+	_C = "frappe.contacts.doctype.contact.contact.get_default_contact"
+
+	def _contact_row(self, mobile="", phone=""):
+		return frappe._dict(
+			name="CNT-1", first_name="Vignesh", last_name="S", company_name="Aerele",
+			mobile_no=mobile, phone=phone,
+		)
+
+	def test_no_default_contact_returns_none(self):
+		with patch(self._C, return_value=None):
+			self.assertIsNone(onboarding._resolve_company_contact("Aerele"))
+
+	def test_unreadable_contact_leaks_nothing(self):
+		with (
+			patch(self._C, return_value="CNT-1"),
+			patch("frappe.has_permission", return_value=False),
+		):
+			self.assertIsNone(onboarding._resolve_company_contact("Aerele"))
+
+	def test_mobile_no_wins(self):
+		with (
+			patch(self._C, return_value="CNT-1"),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.db.get_value", return_value=self._contact_row(mobile="+91-MOBILE", phone="+91-PHONE")),
+		):
+			out = onboarding._resolve_company_contact("Aerele")
+		self.assertEqual(out["phone"], "+91-MOBILE")
+		self.assertEqual(out["display_name"], "Vignesh S")
+
+	def test_phone_fallback_when_no_mobile(self):
+		with (
+			patch(self._C, return_value="CNT-1"),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.db.get_value", return_value=self._contact_row(mobile="", phone="+91-PHONE")),
+		):
+			out = onboarding._resolve_company_contact("Aerele")
+		self.assertEqual(out["phone"], "+91-PHONE")
+
+	def test_child_phone_fallback_when_denormalized_blank(self):
+		child_rows = [frappe._dict(phone="+91-CHILD", is_primary_phone=1, is_primary_mobile_no=0)]
+		with (
+			patch(self._C, return_value="CNT-1"),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.db.get_value", return_value=self._contact_row(mobile="", phone="")),
+			patch("frappe.get_all", return_value=child_rows),
+		):
+			out = onboarding._resolve_company_contact("Aerele")
+		self.assertEqual(out["phone"], "+91-CHILD")
+
+	def test_no_phone_anywhere_omits_phone(self):
+		with (
+			patch(self._C, return_value="CNT-1"),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.db.get_value", return_value=self._contact_row(mobile="", phone="")),
+			patch("frappe.get_all", return_value=[]),
+		):
+			out = onboarding._resolve_company_contact("Aerele")
+		self.assertNotIn("phone", out)
+		self.assertEqual(out["name"], "CNT-1")
+
+
+class TestChildPhone(FrappeTestCase):
+	"""_contact_child_phone deterministic order: primary mobile > primary phone >
+	first non-empty by idx (C01-4)."""
+
+	def _run(self, rows):
+		with patch("frappe.get_all", return_value=[frappe._dict(r) for r in rows]):
+			return onboarding._contact_child_phone("CNT-1")
+
+	def test_primary_mobile_wins(self):
+		phone = self._run([
+			{"phone": "A", "is_primary_phone": 1, "is_primary_mobile_no": 0},
+			{"phone": "B", "is_primary_phone": 0, "is_primary_mobile_no": 1},
+		])
+		self.assertEqual(phone, "B")
+
+	def test_primary_phone_over_first(self):
+		phone = self._run([
+			{"phone": "A", "is_primary_phone": 0, "is_primary_mobile_no": 0},
+			{"phone": "B", "is_primary_phone": 1, "is_primary_mobile_no": 0},
+		])
+		self.assertEqual(phone, "B")
+
+	def test_first_non_empty_fallback(self):
+		phone = self._run([
+			{"phone": "", "is_primary_phone": 0, "is_primary_mobile_no": 0},
+			{"phone": "C", "is_primary_phone": 0, "is_primary_mobile_no": 0},
+		])
+		self.assertEqual(phone, "C")
+
+	def test_no_rows(self):
+		self.assertEqual(self._run([]), "")
+
+
+class TestResolveAddress(FrappeTestCase):
+	def _address_row(self, gstin=None):
+		row = frappe._dict(
+			name="ADD-1", address_line1="12 MG Road", address_line2="", city="Chennai",
+			state="Tamil Nadu", pincode="600001", country="India",
+		)
+		if gstin is not None:
+			row.gstin = gstin
+		return row
+
+	def test_primary_filter_is_explicit(self):
+		"""C01-2: the Address query MUST filter is_primary_address=1 and exclude
+		disabled — never rely on an arbitrary max()/SQL-order row."""
+		captured = {}
+
+		def _get_all(doctype, *args, **kwargs):
+			if doctype == "Dynamic Link":
+				return ["ADD-1", "ADD-2"]
+			if doctype == "Address":
+				captured["filters"] = kwargs.get("filters")
+				return ["ADD-1"]
+			return []
+
+		meta = MagicMock()
+		meta.has_field.return_value = False
+		with (
+			patch("frappe.get_all", side_effect=_get_all),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.get_meta", return_value=meta),
+			patch("frappe.db.get_value", return_value=self._address_row()),
+		):
+			onboarding._resolve_company_billing_address("Aerele")
+		self.assertEqual(captured["filters"]["is_primary_address"], 1)
+		self.assertEqual(captured["filters"]["disabled"], 0)
+
+	def test_no_linked_address_returns_none(self):
+		with patch("frappe.get_all", side_effect=_dispatch_get_all({"Dynamic Link": []})):
+			self.assertIsNone(onboarding._resolve_company_billing_address("Aerele"))
+
+	def test_no_primary_flagged_returns_none(self):
+		"""Linked addresses exist but none is primary -> return NOTHING (never a
+		warehouse/shipping address dressed up as billing)."""
+		with patch(
+			"frappe.get_all",
+			side_effect=_dispatch_get_all({"Dynamic Link": ["ADD-1"], "Address": []}),
+		):
+			self.assertIsNone(onboarding._resolve_company_billing_address("Aerele"))
+
+	def test_unreadable_address_leaks_nothing(self):
+		with (
+			patch(
+				"frappe.get_all",
+				side_effect=_dispatch_get_all({"Dynamic Link": ["ADD-1"], "Address": ["ADD-1"]}),
+			),
+			patch("frappe.has_permission", return_value=False),
+		):
+			self.assertIsNone(onboarding._resolve_company_billing_address("Aerele"))
+
+	def _resolve_with_meta(self, has_gstin, address_row):
+		meta = MagicMock()
+		meta.has_field.return_value = has_gstin
+		with (
+			patch(
+				"frappe.get_all",
+				side_effect=_dispatch_get_all({"Dynamic Link": ["ADD-1"], "Address": ["ADD-1"]}),
+			),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.get_meta", return_value=meta),
+			patch("frappe.db.get_value", return_value=address_row),
+		):
+			return onboarding._resolve_company_billing_address("Aerele")
+
+	def test_gstin_absent_from_metadata(self):
+		out = self._resolve_with_meta(has_gstin=False, address_row=self._address_row())
+		self.assertNotIn("gstin", out)
+		self.assertEqual(out["city"], "Chennai")
+
+	def test_gstin_blank_is_omitted(self):
+		out = self._resolve_with_meta(has_gstin=True, address_row=self._address_row(gstin=""))
+		self.assertNotIn("gstin", out)
+
+	def test_gstin_present_returned(self):
+		out = self._resolve_with_meta(has_gstin=True, address_row=self._address_row(gstin="33ABCDE1234F1Z5"))
+		self.assertEqual(out["gstin"], "33ABCDE1234F1Z5")
+
+	def test_response_allowlist_only(self):
+		out = self._resolve_with_meta(has_gstin=True, address_row=self._address_row(gstin="33ABCDE1234F1Z5"))
+		allowed = {"name", "address_line1", "address_line2", "city", "state", "pincode", "country", "gstin"}
+		self.assertTrue(set(out.keys()).issubset(allowed))
+
+	def test_resolves_without_erpnext(self):
+		"""C01-1 no-ERPNext leg: even with the ERPNext company helper unimportable,
+		address resolution succeeds — proof the frappe-only Dynamic Link path is the
+		mechanism, not erpnext.get_default_company_address."""
+		with patch.dict(sys.modules, {"erpnext.setup.doctype.company.company": None}):
+			out = self._resolve_with_meta(has_gstin=True, address_row=self._address_row(gstin="33ABCDE1234F1Z5"))
+		self.assertEqual(out["city"], "Chennai")

--- a/jarvis/tests/test_onboarding_company_defaults.py
+++ b/jarvis/tests/test_onboarding_company_defaults.py
@@ -51,6 +51,18 @@ class TestCompanyDefaultsEndpoint(FrappeTestCase):
 		self.assertFalse(out["ok"])
 		self.assertEqual(out["error"]["code"], "COMPANY_DEFAULTS_NOT_FOUND")
 
+	def test_frappe_only_bench_no_company_doctype(self):
+		"""C01-1: on a frappe-only bench the Company doctype is absent; the endpoint
+		returns a clean NOT_FOUND rather than 500-ing on the missing table."""
+
+		def _exists(dt, *a, **k):
+			return False if dt == "DocType" else None
+
+		with patch("frappe.db.exists", side_effect=_exists):
+			out = onboarding.get_company_onboarding_defaults("Aerele")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "COMPANY_DEFAULTS_NOT_FOUND")
+
 	def test_unreadable_company_forbidden(self):
 		with (
 			patch("frappe.db.exists", return_value=True),
@@ -97,8 +109,12 @@ class TestResolveContact(FrappeTestCase):
 
 	def _contact_row(self, mobile="", phone=""):
 		return frappe._dict(
-			name="CNT-1", first_name="Vignesh", last_name="S", company_name="Aerele",
-			mobile_no=mobile, phone=phone,
+			name="CNT-1",
+			first_name="Vignesh",
+			last_name="S",
+			company_name="Aerele",
+			mobile_no=mobile,
+			phone=phone,
 		)
 
 	def test_no_default_contact_returns_none(self):
@@ -116,7 +132,9 @@ class TestResolveContact(FrappeTestCase):
 		with (
 			patch(self._C, return_value="CNT-1"),
 			patch("frappe.has_permission", return_value=True),
-			patch("frappe.db.get_value", return_value=self._contact_row(mobile="+91-MOBILE", phone="+91-PHONE")),
+			patch(
+				"frappe.db.get_value", return_value=self._contact_row(mobile="+91-MOBILE", phone="+91-PHONE")
+			),
 		):
 			out = onboarding._resolve_company_contact("Aerele")
 		self.assertEqual(out["phone"], "+91-MOBILE")
@@ -163,24 +181,30 @@ class TestChildPhone(FrappeTestCase):
 			return onboarding._contact_child_phone("CNT-1")
 
 	def test_primary_mobile_wins(self):
-		phone = self._run([
-			{"phone": "A", "is_primary_phone": 1, "is_primary_mobile_no": 0},
-			{"phone": "B", "is_primary_phone": 0, "is_primary_mobile_no": 1},
-		])
+		phone = self._run(
+			[
+				{"phone": "A", "is_primary_phone": 1, "is_primary_mobile_no": 0},
+				{"phone": "B", "is_primary_phone": 0, "is_primary_mobile_no": 1},
+			]
+		)
 		self.assertEqual(phone, "B")
 
 	def test_primary_phone_over_first(self):
-		phone = self._run([
-			{"phone": "A", "is_primary_phone": 0, "is_primary_mobile_no": 0},
-			{"phone": "B", "is_primary_phone": 1, "is_primary_mobile_no": 0},
-		])
+		phone = self._run(
+			[
+				{"phone": "A", "is_primary_phone": 0, "is_primary_mobile_no": 0},
+				{"phone": "B", "is_primary_phone": 1, "is_primary_mobile_no": 0},
+			]
+		)
 		self.assertEqual(phone, "B")
 
 	def test_first_non_empty_fallback(self):
-		phone = self._run([
-			{"phone": "", "is_primary_phone": 0, "is_primary_mobile_no": 0},
-			{"phone": "C", "is_primary_phone": 0, "is_primary_mobile_no": 0},
-		])
+		phone = self._run(
+			[
+				{"phone": "", "is_primary_phone": 0, "is_primary_mobile_no": 0},
+				{"phone": "C", "is_primary_phone": 0, "is_primary_mobile_no": 0},
+			]
+		)
 		self.assertEqual(phone, "C")
 
 	def test_no_rows(self):
@@ -190,8 +214,13 @@ class TestChildPhone(FrappeTestCase):
 class TestResolveAddress(FrappeTestCase):
 	def _address_row(self, gstin=None):
 		row = frappe._dict(
-			name="ADD-1", address_line1="12 MG Road", address_line2="", city="Chennai",
-			state="Tamil Nadu", pincode="600001", country="India",
+			name="ADD-1",
+			address_line1="12 MG Road",
+			address_line2="",
+			city="Chennai",
+			state="Tamil Nadu",
+			pincode="600001",
+			country="India",
 		)
 		if gstin is not None:
 			row.gstin = gstin
@@ -282,5 +311,7 @@ class TestResolveAddress(FrappeTestCase):
 		address resolution succeeds — proof the frappe-only Dynamic Link path is the
 		mechanism, not erpnext.get_default_company_address."""
 		with patch.dict(sys.modules, {"erpnext.setup.doctype.company.company": None}):
-			out = self._resolve_with_meta(has_gstin=True, address_row=self._address_row(gstin="33ABCDE1234F1Z5"))
+			out = self._resolve_with_meta(
+				has_gstin=True, address_row=self._address_row(gstin="33ABCDE1234F1Z5")
+			)
 		self.assertEqual(out["city"], "Chennai")

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -863,7 +863,7 @@ class TestSignupResumeFallback(FrappeTestCase):
 			) as resume,
 		):
 			out = onboarding.start_signup("Resume-Me@example.com ", "Co", "some-plan")
-		resume.assert_called_once_with("some-plan", provider=None)
+		resume.assert_called_once_with("some-plan", provider=None, billing=None)
 		self.assertEqual(out["razorpay_order_id"], "order_R2")
 
 	def test_dedup_with_different_email_reraises(self):


### PR DESCRIPTION
## Plan 01 WS-B — ERP company billing defaults + billing passthrough

Bench half of Plan 01. Admin half is jarvis-admin-v2
`feat/plan01-billing-persistence` (#189) and **must deploy + migrate first** (an
older admin silently drops the `billing` kwarg — the `billing_saved` ack is how
the bench detects that). The SPA (Work Unit C) is deliberately **not** here.

### What
- **`get_company_onboarding_defaults(company)`** — behind the onboarding-admin
  gate. Resolves a selected Company's:
  - primary **Contact** phone: `mobile_no` → `phone` → child `phone_nos` rows
    (primary mobile → primary phone → first, deterministic — C01-4);
  - primary **billing Address**: frappe-only Dynamic Link query filtered
    **explicitly** on `is_primary_address = 1` (excludes disabled); nothing
    flagged → returns nothing, never a warehouse/shipping address (C01-2);
  - **GSTIN** read only when the field exists in Address metadata (India
    Compliance optional).
  ERPNext is optional (C01-1): it never imports
  `erpnext.get_default_company_address` (which requires ERPNext *and* doesn't
  select primary). Own Company/Contact/Address read-permission checks (C01-3 —
  the Frappe helpers check nothing). Returns an allowlisted **presentation** dict
  (no whole documents); failures carry stable `COMPANY_DEFAULTS_NOT_FOUND` /
  `COMPANY_DEFAULTS_FORBIDDEN` codes.
- **Billing passthrough**: `start_signup(billing=…)` and
  `admin_client.signup/resume_pending_signup` forward the typed object and
  preserve admin's `billing_saved` ack + normalized summary un-flattened.
- **`update_billing` facade** → `admin_client.update_pending_billing` for the
  post-intent edit path (no new payment intent, never guest signup).

### Tests (all green on patterntest.localhost)
`tests/test_onboarding_company_defaults.py` (25 tests: default-contact/permission
gates, mobile→phone→child fallback, primary-only address filter, none→blank,
disabled/unreadable excluded, gstin absent/blank/valid, response allowlist,
no-ERPNext leg, endpoint gates + codes) and `tests/test_billing_contract.py`
(shared fixture sha pin + admin_client forwards the object unmodified).

```
Ran 25 tests in 0.052s  OK      # test_onboarding_company_defaults
Ran 2 tests in 0.003s   OK      # test_billing_contract
```

### Relationships / coordination
- Deploy order: **admin #189 first**, then this.
- **WS-B contract corpus** (`jarvis/tests/fixtures/admin_contract/`) is not on
  `develop`; the Plan-01 fixture is isolated in its own `billing_contract/`
  subdir to avoid collision when that corpus merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
