### PR TITLE
onboarding(pay): behavior-neutral admin_pay_page_v1 capability advert (plan-09 WS2)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -170,6 +170,25 @@ def _admin_url(settings) -> str:
 # (an older bench omits this, and admin falls back to razorpay).
 SUPPORTED_PROVIDERS = ("razorpay", "cashfree")
 
+# Plan-09 WS2 capability advert (frozen contract). Tells admin, in the
+# signup-payment envelope, that this bench understands the admin-hosted pay page
+# (``admin_pay_page_v1``) and which provider checkout SHAPES it can render. This
+# is BEHAVIOR-NEUTRAL predeployment: today's admin ignores keys it does not
+# declare as arguments (Frappe drops unknown form_dict entries — the same
+# mechanism that lets ``supported_providers``/``jarvis_version`` ride an old
+# admin), so nothing changes now. A later admin negotiates a token-only response
+# for capable benches off this advert and hard-fails incapable ones
+# pre-provider-object (plan-09 §R P0-4). The names here are the frozen contract —
+# keep them in lockstep with the admin side; do NOT rename without a coordinated
+# admin change. ``_client_capabilities()`` hands each caller a fresh dict so a
+# body mutation can never corrupt the shared template.
+PAY_PAGE_CAPABILITY = "admin_pay_page_v1"
+PROVIDER_SHAPES = ("razorpay_order", "razorpay_mandate", "cashfree_order", "cashfree_mandate")
+
+
+def _client_capabilities() -> dict:
+	return {"pay_page": PAY_PAGE_CAPABILITY, "provider_shapes": list(PROVIDER_SHAPES)}
+
 
 def signup(
 	email: str,
@@ -205,6 +224,7 @@ def signup(
 		"plan": plan,
 		"frappe_site_url": frappe.utils.get_url(),
 		"supported_providers": list(SUPPORTED_PROVIDERS),
+		"client_capabilities": _client_capabilities(),
 	}
 	if coupon:
 		body["coupon"] = coupon
@@ -231,7 +251,7 @@ def resume_pending_signup(plan: str, provider: str | None = None, idempotency_ke
 	Raises AdminContractError carrying admin's ``code`` on a coded conflict
 	(PAYMENT_ALREADY_ACTIVE, SIGNUP_TERMINAL, ...); a plain AdminValidationError
 	from an admin too old to send one."""
-	body: dict = {"plan": plan}
+	body: dict = {"plan": plan, "client_capabilities": _client_capabilities()}
 	if provider:
 		body["provider"] = provider
 	if idempotency_key:

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -865,6 +865,93 @@ class TestOnboardingClient(FrappeTestCase):
 		self.assertEqual(out, BUNDLED_PRESET_CATALOG)
 
 
+_EXPECTED_ADVERT = {
+	"pay_page": "admin_pay_page_v1",
+	"provider_shapes": [
+		"razorpay_order",
+		"razorpay_mandate",
+		"cashfree_order",
+		"cashfree_mandate",
+	],
+}
+
+
+class TestClientCapabilityAdvert(FrappeTestCase):
+	"""Plan-09 WS2: behavior-neutral pay-page capability advert.
+
+	The bench advertises ``admin_pay_page_v1`` + the provider checkout shapes it
+	understands on every signup-payment initiation/resume call. Today's admin
+	ignores the field (Frappe drops unknown form_dict keys), so this is purely
+	outbound predeployment — these tests pin (a) the advert rides both seams,
+	(b) the frozen contract names are exact, (c) a reply carrying no new keys
+	decodes byte-for-byte as it did before the advert existed.
+	"""
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def test_advert_constant_matches_frozen_contract(self):
+		self.assertEqual(admin_client.PAY_PAGE_CAPABILITY, "admin_pay_page_v1")
+		self.assertEqual(
+			list(admin_client.PROVIDER_SHAPES),
+			["razorpay_order", "razorpay_mandate", "cashfree_order", "cashfree_mandate"],
+		)
+		self.assertEqual(admin_client._client_capabilities(), _EXPECTED_ADVERT)
+
+	def test_helper_returns_a_fresh_copy(self):
+		# A caller mutating the returned advert (it becomes a request body) must
+		# not corrupt the next call's advert.
+		first = admin_client._client_capabilities()
+		first["pay_page"] = "tampered"
+		first["provider_shapes"].append("tampered")
+		self.assertEqual(admin_client._client_capabilities(), _EXPECTED_ADVERT)
+
+	def test_signup_carries_capability_advert(self):
+		_settings_clear_admin()  # guest signup path
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.signup("e@x.com", "Co", "Annual Plan")
+		self.assertEqual(captured["json"]["client_capabilities"], _EXPECTED_ADVERT)
+
+	def test_resume_pending_signup_carries_capability_advert(self):
+		_settings_for_admin()  # authenticated resume path
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.resume_pending_signup("Annual Plan")
+		self.assertEqual(captured["json"]["client_capabilities"], _EXPECTED_ADVERT)
+
+	def test_response_without_new_keys_decodes_unchanged(self):
+		# Behavior neutrality: an admin that ignores the advert replies exactly as
+		# before, and the decoded result is the same dict the bench saw pre-WS2.
+		# The advert is outbound-only; it never touches the reply path.
+		_settings_clear_admin()
+		legacy_data = {
+			"api_key": "k",
+			"api_secret": "s",
+			"payment_provider": "razorpay",
+			"razorpay_order_id": "order_R",
+			"razorpay_key_id": "rzp",
+			"amount_inr": 1500,
+		}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			return _mock_response(200, json_body={"message": {"ok": True, "data": dict(legacy_data)}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			out = admin_client.signup("e@x.com", "Co", "Annual Plan")
+		self.assertEqual(out, legacy_data)
+
+
 class TestPostUpdateLlmCredsAuthMode(FrappeTestCase):
 	def setUp(self):
 		_settings_for_admin()


### PR DESCRIPTION
## Plan-09 WS2 — behavior-neutral bench capability advertisement

Stacks on `feat/onboarding-payment-ui` (#588).

The bench now advertises, in its existing bench→admin signup/payment envelope, that it supports the admin-hosted pay page (`admin_pay_page_v1`) plus the provider checkout shapes it understands. This ships **first**, before any admin negotiation logic, so a later admin can serve token-only responses to capable benches and hard-fail incapable ones pre-provider-object (plan-09 §R P0-4).

### Strictly behavior-neutral
- Outbound-only: a `client_capabilities` field is added to the two signup-payment seams — `signup()` (initiate) and `resume_pending_signup()` (resume/initiate). No response handling, no UI, no other change.
- Today's admin **ignores** the field: Frappe drops unknown `form_dict` keys that a whitelisted function doesn't declare as arguments — the same mechanism that already lets `supported_providers` / `jarvis_version` / `installed_apps` ride an old admin.

### Shape
One frozen constant (`PAY_PAGE_CAPABILITY` + `PROVIDER_SHAPES`) and one helper (`_client_capabilities()` — returns a fresh dict per call). Attached uniformly as a flat top-level body key with a structured value, matching the existing `supported_providers` convention:

```json
{"pay_page": "admin_pay_page_v1",
 "provider_shapes": ["razorpay_order", "razorpay_mandate", "cashfree_order", "cashfree_mandate"]}
```

### Tests (`jarvis/tests/test_admin_client.py::TestClientCapabilityAdvert`)
- advert rides `signup` and `resume_pending_signup` outgoing calls;
- frozen contract names are exact;
- helper hands out a fresh copy (body mutation can't corrupt the template);
- a reply carrying no new keys decodes byte-for-byte as before.

`test_admin_client` 69/69 green, `test_admin_contract` 31/31 green (patterntest.localhost, PYTHONPATH shadow). `pre-commit` clean.

WS7 (response handling of `pay_page_token`/`pay_url`) is out of scope by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)