### PR TITLE
chore(chat): rename openclaw to agent in #577 prose (unblocks #563)

### DIFF
--- a/frontend/src/utils/modelBadge.js
+++ b/frontend/src/utils/modelBadge.js
@@ -3,7 +3,7 @@
 // all, and a rule that hides too eagerly fails silently.
 //
 // Background. Jarvis lets a user change the model mid-conversation, and an
-// UNPINNED conversation keeps openclaw's failover chain live, so a reply can
+// UNPINNED conversation keeps the agent's failover chain live, so a reply can
 // come from a model the user never chose. The server now stamps `model` and
 // `provider` on the assistant row at finalize, taken from the model the gateway
 // says actually served the turn. Without a rendering rule that surfaces the

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4485,7 +4485,7 @@ function elapsedLabel(m) {
 }
 // Per-reply model attribution (jarvis#560). m.model / m.provider are stamped on
 // the assistant row at finalize and name the model that ACTUALLY answered, which
-// is not always the one the user picked: an unpinned thread keeps openclaw's
+// is not always the one the user picked: an unpinned thread keeps the agent's
 // failover chain live, so a substitution otherwise leaves no trace anywhere. The
 // show/hide rule lives in @/utils/modelBadge (unit-tested there) because a rule
 // that hides too eagerly would suppress the whole signal without failing.

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -312,7 +312,7 @@ def _stamp_reply_model(ctx: _Ctx, row: dict | None) -> None:
 	``role='assistant'`` is in the WHERE clause, not just implied by
 	``turn.assistant_message``: the field is meaningless on a user or tool row and
 	a mislinked turn must not be able to write one. A blank model (no row, or a
-	session the gateway does not name a model for - an openclaw-direct pool that
+	session the gateway does not name a model for - an agent-direct pool that
 	never resolved one) leaves the row untouched rather than writing "" over a
 	value an earlier finalize cycle already got right.
 

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -140,7 +140,7 @@ def resolved_model_identity(row: dict | None) -> tuple[str, str]:
 	override when it has one, else the RUNTIME identity persisted on the session
 	entry after the run (``entry.model`` / ``entry.modelProvider``). The runtime
 	half is why an unpinned conversation reports the model that actually answered
-	rather than the chain's primary: openclaw only keeps its ``model.fallbacks``
+	rather than the chain's primary: the agent only keeps its ``model.fallbacks``
 	chain live for a session with no override (see
 	``turn_handler._session_model_for``), and a failover rewrites the entry.
 

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -195,7 +195,7 @@
       "length": 140,
       "read_only": 1,
       "no_copy": 1,
-      "description": "jarvis#560 - the model that actually PRODUCED this reply, stamped on assistant rows only. Read at finalize from the gateway's sessions.list row for this turn's session (the same row the per-model usage bucket is billed against, so the transcript and the usage pane can never disagree). It names the model that answered, which is not always the one requested: an unpinned conversation keeps openclaw's failover chain live, so a substitution lands here with no other trace. Blank on legacy rows and on turns whose session row never named a model."
+      "description": "jarvis#560 - the model that actually PRODUCED this reply, stamped on assistant rows only. Read at finalize from the gateway's sessions.list row for this turn's session (the same row the per-model usage bucket is billed against, so the transcript and the usage pane can never disagree). It names the model that answered, which is not always the one requested: an unpinned conversation keeps the agent's failover chain live, so a substitution lands here with no other trace. Blank on legacy rows and on turns whose session row never named a model."
     },
     {
       "fieldname": "provider",
@@ -204,7 +204,7 @@
       "length": 140,
       "read_only": 1,
       "no_copy": 1,
-      "description": "jarvis#560 - the openclaw provider id that served this reply (sessions.list `modelProvider`, e.g. `gemini`, `openai_compat`), paired with `model`. Two providers can expose the same model id, so the pair is what identifies the run for an audit or an incident review."
+      "description": "jarvis#560 - the agent provider id that served this reply (sessions.list `modelProvider`, e.g. `gemini`, `openai_compat`), paired with `model`. Two providers can expose the same model id, so the pair is what identifies the run for an audit or an incident review."
     },
     {
       "fieldname": "hidden",

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -1000,7 +1000,7 @@ class TestSessionsListModelIdentity(FrappeTestCase):
 		)
 
 	def test_row_that_names_no_model_decodes_as_blank(self):
-		# An openclaw-direct pool that never resolved a model omits both fields;
+		# An agent-direct pool that never resolved a model omits both fields;
 		# the decoder must answer "" rather than invent one, so the assistant row
 		# is left unattributed instead of falsely attributed.
 		sess, ws = _build_session()

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -1855,7 +1855,7 @@ class TestPrepareActorFencing(_PipelineCase):
 class _ModelRowSess(_FakeSess):
 	"""``_FakeSess`` whose ``sessions.list`` returns a caller-supplied row.
 
-	The row is the REAL openclaw payload shape, not a convenience dict: the field
+	The row is the REAL agent payload shape, not a convenience dict: the field
 	names and their casing are what ``buildGatewaySessionRow`` emits in
 	ghcr.io/openclaw/openclaw:2026.6.8 (``key``, ``model``, ``modelProvider``,
 	``totalTokensFresh``, ``inputTokens``, ``outputTokens``, ``totalTokens``), so
@@ -1948,7 +1948,7 @@ class TestReplyModelAttribution(_PipelineCase):
 		)
 
 	def test_row_without_a_model_leaves_the_stamp_blank(self):
-		# An openclaw-direct pool that never resolved a model reports no model at
+		# An agent-direct pool that never resolved a model reports no model at
 		# all. Writing "" over the field would be indistinguishable from a real
 		# answer of "unknown"; leave it blank and let the UI say nothing.
 		rid = "pmp_model_absent"


### PR DESCRIPTION
## Why

#563 white-labels the `openclaw` codename to `agent` across the app, and adds `tests/test_no_openclaw_leak.py` to stop it coming back.

#577 (mine) landed on `develop` after #563 branched, so it reintroduced the codename in nine comments and descriptions that #563 has no way to know about. The guard test passes on #563's branch in isolation and reports **9 offenders** once `develop` is merged in, so merging #563 as-is turns `develop` red.

This renames those nine so #563 can merge clean. The guard test does not exist on `develop` yet, so this is a no-op for `develop` CI and only takes effect when #563 lands.

## The nine

| File | What |
|---|---|
| `jarvis/chat/finalize.py:315` | docstring |
| `jarvis/chat/usage.py:143` | docstring |
| `jarvis/tests/test_chat_openclaw_client.py:1003` | comment |
| `jarvis/tests/test_pump_pipeline.py:1858, :1951` | docstring + comment |
| `jarvis/.../jarvis_chat_message.json:198, :207` | **field descriptions, operator-visible in Desk** |
| `frontend/src/utils/modelBadge.js:6` | comment |
| `frontend/src/views/ChatView.vue:4488` | comment |

The two DocType descriptions are exactly what the white-label exists to catch, so the guard earned its keep here.

## Scope

Deliberately minimal. `develop` carries many other `openclaw` strings (`openclaw-direct`, the session pool, and so on) and **#563 renames all of those itself**. Touching them here would hand #563 textual conflicts. Only the nine that #563 cannot see are changed.

`ghcr.io/openclaw/openclaw:2026.6.8` on the adjacent `usage.py:138` is left alone: the guard's `_ALLOWED_LITERALS` already sanctions it as an image reference.

## Verification

- Trial-merged `refs/pull/563/head` onto this branch: **auto-merged, 0 conflicted paths**, and the edit correctly followed #563's rename of `test_chat_openclaw_client.py` to `test_chat_agent_client.py`.
- Ran the guard's own scan logic against that merged tree: **0 offenders**, down from 9.
- Scan was not vacuous: 712 / 226 / 58 files against floors of 300 / 100 / 10.
- `jarvis_chat_message.json` still parses, 24 fields intact.

No behaviour change. Comments, docstrings and field descriptions only.

## Merge order

This first, then #563 merges `develop` and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
