### PR TITLE
fix(readiness): the chat gate confirms an unrecorded apply with admin before blocking chat

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -202,8 +202,15 @@ def is_ready_for_chat() -> dict:
 	# Keyed on pool MODE, not the narrower proxy_active: a BYO api-key pool has
 	# no sidecar but still syncs through /llm-pool and stamps llm_pool_synced_at,
 	# so gating it on the direct marker would strand it forever.
+	#
+	# An unstamped marker means "this bench never RECORDED an apply", which is not
+	# the same as "no apply happened" - the sync job can hand off to the scheduled
+	# reconcile without stamping. So both provisioning exits below ask admin once
+	# before declaring the workspace not ready (_confirm_apply_via_admin, #576);
+	# the reason strings still mean exactly what they say, they are now just also
+	# backed by the control plane declining to confirm.
 	if compute_pool_mode(settings):
-		if getattr(settings, "llm_pool_synced_at", None):
+		if getattr(settings, "llm_pool_synced_at", None) or _confirm_apply_via_admin(settings, is_pool=True):
 			return _admin_chat_gate()
 		return {"ready": False, "reason": "llm_pool_provisioning"}
 
@@ -231,7 +238,9 @@ def is_ready_for_chat() -> dict:
 		# pending/failed is NOT ready — opening chat there guarantees failing turns
 		# while onboarding still shows "applying". Legacy direct tenants are
 		# backfilled by patch v2_00_backfill_llm_direct_synced_at.
-		if not getattr(settings, "llm_direct_synced_at", None):
+		if not getattr(settings, "llm_direct_synced_at", None) and not _confirm_apply_via_admin(
+			settings, is_pool=False
+		):
 			return {"ready": False, "reason": "llm_provisioning"}
 	elif auth_mode in ("subscription", "oauth"):
 		# Both modes use the same local signal: llm_oauth_connected_at is
@@ -244,6 +253,73 @@ def is_ready_for_chat() -> dict:
 		return {"ready": False, "reason": "llm_credentials"}
 
 	return _admin_chat_gate()
+
+
+# Damping for _confirm_apply_via_admin. Only a NEGATIVE outcome is cached: a
+# confirmation stamps the durable marker, which ends the question for good.
+#
+# Needed because the two not-ready exits below are polled hard. OnboardingView's
+# waitUntilReady runs 30 probes at 2.5s (75s) after a Connect, and the desk
+# banner + widget probe on their own schedules — so an unproven tenant would put
+# one admin round-trip on every one of those ticks. 10s costs at most one extra
+# poll before a convergence is noticed against that 75s budget, and cuts the
+# round-trips it can generate by roughly two thirds.
+_APPLY_CONFIRM_MISS_KEY = "jarvis:apply_confirm_miss"
+_APPLY_CONFIRM_MISS_TTL_S = 10
+
+
+def _confirm_apply_via_admin(settings, *, is_pool: bool) -> bool:
+	"""Last chance to confirm an apply this bench never recorded: ask admin.
+
+	The two callers sit at ``is_ready_for_chat``'s provisioning exits, reached
+	when the durable evidence-of-apply marker is unstamped. Those exits are what
+	renders "Chat may not work yet / applying your LLM configuration", and until
+	now they returned that verdict WITHOUT ever asking the control plane — while
+	the neighbouring proven-tenant branch asks it directly via
+	``_admin_chat_gate``. So a tenant whose apply converged after the sync job's
+	in-band poll gave up was told chat would not work while the container was
+	demonstrably serving turns, and nothing could correct it but the ``*/5``
+	``reconcile_pending_llm_sync`` tick (jarvis #576). The surface that reports
+	the problem can now also clear it.
+
+	No new way to become ready: this reuses ``_admin_chat_readiness`` and
+	``_stamp_converged_ok``, the exact pair the scheduled reconcile and the
+	onboarding poller's ``_reconcile_pending_applying`` already use. Admin gates
+	``chat_readiness`` "Ready" on ``applied_version >= desired_version``, so it
+	never reports Ready from intent — the evidentiary bar is unchanged.
+
+	Deliberately does NOT commit, unlike ``_reconcile_pending_applying``. That
+	one runs only from the onboarding poller; this runs from ``boot.py`` too, on
+	a desk-boot GET, and injecting a commit into boot would make this gate commit
+	whatever else that request happens to be carrying. The SPA, the desk widget
+	and the banner all reach ``is_ready_for_chat`` through frappe-ui's ``call``,
+	which POSTs, so the stamp lands durably where it matters; on a GET it rolls
+	back and the next probe simply re-confirms. Correct either way — persistence
+	is the optimisation, not the mechanism.
+
+	Fails closed and never raises: an unreachable admin, a non-Ready verdict or a
+	failed write all leave the provisioning verdict standing.
+	"""
+	try:
+		cache = frappe.cache()
+		if cache.get_value(_APPLY_CONFIRM_MISS_KEY):
+			return False
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+			_admin_chat_readiness,
+			_stamp_converged_ok,
+		)
+
+		state, _reason = _admin_chat_readiness()
+		if state != "Ready":
+			cache.set_value(_APPLY_CONFIRM_MISS_KEY, 1, expires_in_sec=_APPLY_CONFIRM_MISS_TTL_S)
+			return False
+		# Stamps the marker for this leg AND clears last_sync_status to a
+		# converged "ok" — which is the second face of #576, the Settings pane
+		# still showing "Applying to your agent" off that same field.
+		_stamp_converged_ok(settings, is_pool=is_pool)
+		return True
+	except Exception:
+		return False
 
 
 def _llm_missing_verdict(settings) -> dict:

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -3309,11 +3309,13 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 			},
 			update_modified=False,
 		)
-		# Deliberately NOT committed. set_password writes an __Auth row, and a
-		# committed one outlives the rollback that makes these tests safe to run
-		# against a real site - the exact hazard filed as #566. The write is
-		# visible to this connection uncommitted, which is all the gate needs.
-		settings.set_password("llm_api_key", "sk-test-direct")
+		# db_set, not the password store, and deliberately NOT committed. db_set on
+		# a Password field writes the plaintext column and never touches __Auth
+		# (jarvis/_password_utils.py), and get_password prefers that column, so this
+		# is all the gate reads. It also leaves no __Auth row to outlive the rollback
+		# that makes these tests safe to run against a real site - the exact hazard
+		# filed as #566.
+		settings.db_set("llm_api_key", "sk-test-direct", update_modified=False)
 		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
 		with patch(self._READINESS_PROBE, return_value=("Ready", "")):

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2943,6 +2943,8 @@ class TestFT4bValidateModelsNeverRaises(_RT3SettingsTestCase):
 
 from unittest.mock import patch
 
+from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import _PENDING_APPLYING_STATUS
+
 
 class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 	"""Pins the incident-class behaviors:
@@ -2959,7 +2961,21 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 	   later re-save's transient pending/failed.
 	4. The sync jobs' RQ envelopes (300s) exceed the admin HTTP budgets they
 	   wrap (120s pool / 90s single-model + lock waits + retries).
+	5. The provisioning exits confirm an unrecorded apply with admin before
+	   declaring the workspace not chat-ready (#576), and damp the probe.
 	"""
+
+	def setUp(self):
+		super().setUp()
+		# _confirm_apply_via_admin caches a MISS for 10s, and this whole class runs
+		# well inside that window. A leftover entry would suppress the probe the
+		# next case is trying to exercise, so a real regression could pass.
+		from jarvis.account import _APPLY_CONFIRM_MISS_KEY
+
+		frappe.cache().delete_value(_APPLY_CONFIRM_MISS_KEY)
+		# Sibling cases here db_set the Single directly; without this a later read
+		# can be served a stale cached doc and the gate judges the wrong state.
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
 	def _seed_pool(self):
 		"""Two api_key models -> proxy_active=1, sync job enqueued (mocked ok)."""
@@ -3182,6 +3198,133 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 		result = is_ready_for_chat()
 		self.assertFalse(result.get("ready"))
 		self.assertEqual(result.get("reason"), "llm_pool_provisioning")
+
+	# -- jarvis #576: the gate confirms an unrecorded apply with admin ----
+	#
+	# The provisioning exits are what render "Chat may not work yet"; they used
+	# to return that verdict without ever asking the control plane, so an apply
+	# that converged after the sync job's in-band poll gave up left the customer
+	# staring at the banner while the container served turns, until the */5
+	# reconcile happened to tick. These pin the confirm-on-read behaviour AND
+	# its damping.
+
+	_READINESS_PROBE = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._admin_chat_readiness"
+
+	def test_unproven_pool_goes_ready_when_admin_confirms(self):
+		"""admin reporting Ready IS the confirmation the marker wants (it gates
+		Ready on applied_version >= desired_version), so the gate must accept it
+		rather than wait for the scheduled reconcile to notice the same fact."""
+		from jarvis.account import is_ready_for_chat
+
+		self._set_pool_gate_state(synced_at=None, status=_PENDING_APPLYING_STATUS)
+		with patch(self._READINESS_PROBE, return_value=("Ready", "")):
+			result = is_ready_for_chat()
+		self.assertTrue(result.get("ready"), f"admin confirmed the apply; got: {result}")
+
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertTrue(
+			settings.llm_pool_synced_at,
+			"the confirmation must stamp the durable marker, or every load re-probes",
+		)
+		# The second face of #576: Settings reads "Applying to your agent" off
+		# last_sync_status, so a confirmation that only moved the gate would
+		# leave the pane still claiming an apply is in flight.
+		self.assertTrue(
+			(settings.last_sync_status or "").startswith("ok"),
+			f"a converged apply must clear the pending status; got: {settings.last_sync_status!r}",
+		)
+
+	def test_unproven_pool_stays_provisioning_when_admin_says_not_ready(self):
+		"""Fails CLOSED. Admin answering with a non-Ready state is a real
+		verdict, not a confirmation - the banner is correct there."""
+		from jarvis.account import is_ready_for_chat
+
+		self._set_pool_gate_state(synced_at=None, status=_PENDING_APPLYING_STATUS)
+		with patch(self._READINESS_PROBE, return_value=("Provisioning", "container starting")):
+			result = is_ready_for_chat()
+		self.assertFalse(result.get("ready"))
+		self.assertEqual(result.get("reason"), "llm_pool_provisioning")
+		self.assertFalse(
+			frappe.get_single("Jarvis Settings").llm_pool_synced_at,
+			"a non-Ready verdict must never stamp the evidence marker",
+		)
+
+	def test_unproven_pool_stays_provisioning_when_admin_is_unreachable(self):
+		"""_admin_chat_readiness returns (None, err) rather than raising; the
+		gate must treat "no answer" as "no confirmation" and never 500."""
+		from jarvis.account import is_ready_for_chat
+
+		self._set_pool_gate_state(synced_at=None, status="failed: admin unreachable: timeout")
+		with patch(self._READINESS_PROBE, return_value=(None, "timeout")):
+			result = is_ready_for_chat()
+		self.assertFalse(result.get("ready"))
+		self.assertEqual(result.get("reason"), "llm_pool_provisioning")
+		self.assertFalse(frappe.get_single("Jarvis Settings").llm_pool_synced_at)
+
+	def test_a_miss_is_damped_so_the_wizard_poll_cannot_hammer_admin(self):
+		"""OnboardingView polls readiness 30 times at 2.5s after a Connect. Without
+		damping each tick would be an admin round-trip; this pins that a miss is
+		cached, so removing the cache turns this test red rather than turning
+		production into a 30x amplifier."""
+		from jarvis.account import is_ready_for_chat
+
+		self._set_pool_gate_state(synced_at=None, status=_PENDING_APPLYING_STATUS)
+		with patch(self._READINESS_PROBE, return_value=("Provisioning", "")) as probe:
+			is_ready_for_chat()
+			is_ready_for_chat()
+			is_ready_for_chat()
+		self.assertEqual(probe.call_count, 1, "a cached miss must suppress the follow-up probes")
+
+	def test_a_confirmation_is_not_damped_by_an_earlier_miss(self):
+		"""The damping is a rate limit on asking, not a lock on the answer: once
+		the cached miss expires the very next probe must be able to confirm.
+		Pinned by clearing the key, which is what its TTL does in production."""
+		from jarvis.account import _APPLY_CONFIRM_MISS_KEY, is_ready_for_chat
+
+		self._set_pool_gate_state(synced_at=None, status=_PENDING_APPLYING_STATUS)
+		with patch(self._READINESS_PROBE, return_value=("Provisioning", "")):
+			self.assertFalse(is_ready_for_chat().get("ready"))
+		frappe.cache().delete_value(_APPLY_CONFIRM_MISS_KEY)
+		with patch(self._READINESS_PROBE, return_value=("Ready", "")):
+			self.assertTrue(is_ready_for_chat().get("ready"))
+
+	def test_unproven_direct_tenant_goes_ready_when_admin_confirms(self):
+		"""The single-model leg strands the same way and is rescued by the same
+		reconcile, so it must be confirmable from the gate too - the marker it
+		stamps is llm_direct_synced_at, not the pool one."""
+		from jarvis.account import is_ready_for_chat
+
+		self._clear_models()
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			{
+				"llm_pool_synced_at": None,
+				"llm_direct_synced_at": None,
+				"llm_auth_mode": "api_key",
+				"llm_provider": "openai",
+				"llm_model": "gpt-4o-mini",
+				"proxy_active": 0,
+				"preset": "",
+				"last_sync_status": _PENDING_APPLYING_STATUS,
+			},
+			update_modified=False,
+		)
+		# Deliberately NOT committed. set_password writes an __Auth row, and a
+		# committed one outlives the rollback that makes these tests safe to run
+		# against a real site - the exact hazard filed as #566. The write is
+		# visible to this connection uncommitted, which is all the gate needs.
+		settings.set_password("llm_api_key", "sk-test-direct")
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+
+		with patch(self._READINESS_PROBE, return_value=("Ready", "")):
+			result = is_ready_for_chat()
+		self.assertTrue(result.get("ready"), f"admin confirmed the direct apply; got: {result}")
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertTrue(settings.llm_direct_synced_at, "the direct leg's own marker must be stamped")
+		self.assertFalse(
+			settings.llm_pool_synced_at,
+			"a direct tenant must not be stamped as a pool tenant",
+		)
 
 	def test_backfill_patch_grandfathers_pre_marker_tenants(self):
 		"""Tenants provisioned before llm_pool_synced_at existed are


### PR DESCRIPTION
Fixes #576

After reconnecting a model the workspace kept saying it was still applying,
while chat demonstrably worked: the amber "Chat may not work yet / applying
your LLM configuration" banner sat directly above a composer answering
normally, and Settings showed "Applying to your agent".

## Root cause

Not the paused local scheduler. That makes the symptom permanent instead of
five minutes long, but the defect is real on production too.

`is_ready_for_chat` has two provisioning exits, reached when the durable
evidence-of-apply marker (`llm_pool_synced_at` / `llm_direct_synced_at`) is
unstamped. Those exits are what render the banner, and **they returned that
verdict without ever asking the control plane** — while the neighbouring
proven-tenant branch one line up asks it directly via `_admin_chat_gate`.

An unstamped marker means "this bench never RECORDED an apply". That is not
the same as "no apply happened". The sync job stamps only on a confirmed
`status="applied"`; an admin "applying" (busy apply lock, fleet read timeout,
CAS refusal) hands off to `_converge_via_admin`, and when that in-band poll
hits its deadline the job writes the pending status and leaves the marker
unstamped **on purpose**, for someone else to finish.

Three things were supposed to finish it, and none of them covers the chat gate:

| rescuer | trigger | reaches the banner? |
|---|---|---|
| `_converge_via_admin` | in-band, bounded deadline | gave up already |
| `reconcile_pending_llm_sync` | `*/5` cron | eventually, and never with the scheduler paused |
| `_reconcile_pending_applying` | `sync_status`, the onboarding poller only | no |

So the one surface that tells the customer chat will not work was the one
surface that could not check.

## The change

Both provisioning exits now ask admin once before declaring the workspace not
ready. On `chat_readiness == "Ready"`, stamp the marker and fall through to the
normal gate.

**No new way to become ready.** `_confirm_apply_via_admin` reuses
`_admin_chat_readiness` and `_stamp_converged_ok`, the exact pair the scheduled
reconcile and the onboarding poller already use. Admin gates Ready on
`applied_version >= desired_version`, so it never reports Ready from intent.
The evidentiary bar is identical; only who is allowed to ask has changed.

Stamping also clears `last_sync_status` to a converged `ok`, which is the
second face of the report: Settings reads "Applying to your agent" off that
same field, so a fix that only moved the gate would have left the pane still
claiming an apply was in flight.

**Damped.** `OnboardingView.waitUntilReady` polls readiness 30 times at 2.5s
after a Connect, and the desk banner and widget probe on their own schedules.
Undamped, an unproven tenant would put one admin round-trip on every tick. A
miss is cached for 10s: at most one extra poll before a convergence is noticed
against that 75s budget, and roughly a third of the round-trips. Only misses
are cached — a confirmation stamps the marker, which ends the question.

**Does not commit**, unlike `_reconcile_pending_applying`. That one runs only
from the onboarding poller; this runs from `boot.py` too, on a desk-boot GET,
and injecting a commit there would make the gate commit whatever else that
request happens to be carrying. Every browser caller (SPA, desk widget, desk
banner) reaches this through frappe-ui's `call`, which POSTs, so the stamp
lands durably where it matters; on a GET it rolls back and the next probe
re-confirms. Correct either way — persistence is the optimisation, not the
mechanism.

Fails closed throughout: an unreachable admin, a non-Ready verdict or a failed
write all leave the provisioning verdict standing, and the helper never raises.

## Tests

6 added to `TestOnboardingAuditFixes`, beside the existing gate tests:
admin confirming flips an unproven pool to ready and stamps both the marker and
the status; a non-Ready verdict does not; an unreachable admin does not; a miss
is damped to a single probe across three calls; a cleared cache lets the very
next probe confirm; and the direct leg stamps `llm_direct_synced_at` rather
than the pool marker.

The existing `test_never_applied_pool_*` cases now depend on admin's answer, so
they were left as-is deliberately — they pass because `_admin_chat_readiness`
returns `(None, err)` on an unreachable control plane, which is the fail-closed
path this change is built on. The new tests patch the probe explicitly rather
than relying on that ambient behaviour.

A `setUp` was added clearing the miss cache and the Single's document cache;
without the first, a leftover entry from a sibling case would suppress the
probe under test and let a real regression pass.

## Interaction with #584

#584 rewrites the same function's failure handling. Verified: a trial merge of
`fix/chat-readiness-fail-closed` into this branch auto-merges clean. The
docstring's reason list was deliberately left untouched for that reason — the
behaviour note lives in the comment block above the pool branch, outside #584's
hunks. Either can land first.

## Not verified

No live reproduction. The state that produces it is transient by construction
(an apply that converged after the in-band poll's deadline), and `onb.localhost`
has since settled to `ok (pool via admin)` with the marker stamped, so there was
nothing left to observe. The mechanism is read off the code paths and pinned by
the tests; a live check would mean forcing an admin "applying" response, which
means writing to the tenant under test.
