### PR TITLE
Plan 01 WS-C: SPA billing provenance, Review & Pay card, recovery

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -253,9 +253,18 @@ export const listPlans = () => call("jarvis.onboarding.list_plans");
 // operator enabled AND this bench build can render.
 export const listPaymentProviders = () => call("jarvis.onboarding.list_payment_providers");
 export const getAccountDefaults = () => call("jarvis.onboarding.get_account_defaults");
+// ERP-derived billing defaults for the selected Company (Plan 01): its primary
+// Contact phone + primary billing Address (+ optional GSTIN), or a coded error
+// ({ok:false, error:{code}}). Behind the same onboarding-admin gate.
+export const getCompanyOnboardingDefaults = (company) =>
+	call("jarvis.onboarding.get_company_onboarding_defaults", { company });
 export const syncConnection = () => call("jarvis.onboarding.sync_connection");
-export const startSignup = (email, company, plan, provider) =>
-	call("jarvis.onboarding.start_signup", { email, company, plan, provider });
+export const startSignup = (email, company, plan, provider, billing) =>
+	call("jarvis.onboarding.start_signup", { email, company, plan, provider, billing });
+// Authenticated billing-only edit (Plan 01, post-intent Review & Pay "Edit"):
+// updates the owned Pending Payment customer WITHOUT creating/replacing an
+// intent. NEVER guest signup. Returns {billing_saved, billing} (normalized).
+export const updateBilling = (billing) => call("jarvis.onboarding.update_billing", { billing });
 export const checkSignupPaymentState = () => call("jarvis.onboarding.check_signup_payment_state");
 export const finishPayment = (payload) => call("jarvis.onboarding.finish_payment", { payload });
 export const isOnboarded = () => call("jarvis.account.is_onboarded");

--- a/frontend/src/onboarding/TourIntro.vue
+++ b/frontend/src/onboarding/TourIntro.vue
@@ -71,7 +71,7 @@
 								stroke-linejoin="round"
 							>
 								<path d="M20 6 9 17l-5-5" /></svg
-							>Asks before it changes anything
+							>{{ PERMISSION_TOUR_COPY }}
 						</li>
 					</ul>
 				</div>
@@ -514,6 +514,7 @@
 <script setup>
 import { ref, computed } from "vue";
 import { agentName } from "@/branding";
+import { PERMISSION_TOUR_COPY } from "@/onboarding/permissionCopy";
 
 // 'finish' = the final-slide CTA (or advancing past the last slide);
 // 'skip' = the footer "Skip tour" link. Both land the wizard on the Plan step.

--- a/frontend/src/onboarding/permissionCopy.js
+++ b/frontend/src/onboarding/permissionCopy.js
@@ -1,0 +1,34 @@
+// Onboarding permission/confirmation promise (Plan 01, review round-2 P1-05).
+//
+// The tour used to promise "Asks before it changes anything" — false the moment
+// a conversation has auto_apply on, and misleading even by default because it
+// omits the destructive-op carve-out. The approved wording below is DERIVED from
+// the real default policy (Jarvis Conversation.auto_apply default 0 = confirm
+// every write; destructive ops park regardless), and permissionCopy.spec.js
+// binds the two together so a future policy flip can't silently leave the tour
+// over-promising again.
+
+// Jarvis Conversation.auto_apply default, from the DocType JSON:
+//   {"fieldname":"auto_apply","fieldtype":"Check","default":"0", ...
+//    "Default 0 (confirm every write)."}
+export const DEFAULT_AUTO_APPLY = 0;
+// Destructive ops (delete/cancel/amend/send_email) ALWAYS park, even when
+// auto_apply is on — see the same field's description.
+export const DESTRUCTIVE_ALWAYS_CONFIRMS = true;
+
+export const PERMISSION_TOUR_COPY =
+	"By default, shows proposed changes and asks you to confirm before writing; " +
+	"destructive actions always require confirmation.";
+
+// The copy the tour must show for a given default policy. Only the shipped
+// default (confirm-first + destructive-always-confirm) may claim the approved
+// promise; any weaker default has to describe itself honestly instead.
+export function permissionCopyFor(policy = {}) {
+	const autoApply = Number(policy.autoApply || 0);
+	const destructiveAlwaysConfirms = policy.destructiveAlwaysConfirms !== false;
+	if (autoApply === 0 && destructiveAlwaysConfirms) return PERMISSION_TOUR_COPY;
+	if (destructiveAlwaysConfirms) {
+		return "Applies changes automatically; destructive actions always require confirmation.";
+	}
+	return "May change things automatically — review your automation settings.";
+}

--- a/frontend/src/onboarding/permissionCopy.spec.js
+++ b/frontend/src/onboarding/permissionCopy.spec.js
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import {
+	DEFAULT_AUTO_APPLY,
+	DESTRUCTIVE_ALWAYS_CONFIRMS,
+	PERMISSION_TOUR_COPY,
+	permissionCopyFor,
+} from "./permissionCopy.js";
+
+// P1-05: the tour's permission promise is bound to the real default policy so a
+// future auto_apply-default change cannot silently make the onboarding promise
+// false again (as "Asks before it changes anything" was).
+describe("permission tour copy ⇄ default policy contract", () => {
+	it("uses the approved wording", () => {
+		expect(PERMISSION_TOUR_COPY).toBe(
+			"By default, shows proposed changes and asks you to confirm before writing; " +
+				"destructive actions always require confirmation."
+		);
+	});
+
+	it("the shipped default policy is confirm-first with destructive carve-out", () => {
+		// Mirrors Jarvis Conversation.auto_apply default 0 (confirm every write)
+		// + destructive ops always park.
+		expect(DEFAULT_AUTO_APPLY).toBe(0);
+		expect(DESTRUCTIVE_ALWAYS_CONFIRMS).toBe(true);
+	});
+
+	it("derives the approved copy from the default policy", () => {
+		expect(
+			permissionCopyFor({
+				autoApply: DEFAULT_AUTO_APPLY,
+				destructiveAlwaysConfirms: DESTRUCTIVE_ALWAYS_CONFIRMS,
+			})
+		).toBe(PERMISSION_TOUR_COPY);
+	});
+
+	it("a weaker (auto-apply-on) default no longer claims 'asks before it changes anything'", () => {
+		const copy = permissionCopyFor({ autoApply: 1, destructiveAlwaysConfirms: true });
+		expect(copy).not.toBe(PERMISSION_TOUR_COPY);
+		expect(copy).not.toMatch(/asks you to confirm before writing/i);
+	});
+});
+
+// TourIntro must render the copy from this module, never a hardcoded string, so
+// the contract above actually governs what the customer sees.
+describe("TourIntro binds to permissionCopy.js", () => {
+	const HERE = path.dirname(fileURLToPath(import.meta.url));
+	const src = fs.readFileSync(path.join(HERE, "TourIntro.vue"), "utf8");
+
+	it("imports and renders PERMISSION_TOUR_COPY", () => {
+		expect(src).toMatch(/permissionCopy/);
+		expect(src).toMatch(/PERMISSION_TOUR_COPY/);
+	});
+
+	it("no longer ships the old over-promise", () => {
+		expect(src).not.toMatch(/Asks before it changes anything/);
+	});
+});

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -1,0 +1,346 @@
+// Provenance-aware billing state for the onboarding Details step (Plan 01,
+// FABLE-JUDGMENT C01-5/C01-6 + review round-2 P0-01/P0-02/P1-01/P1-03).
+//
+// The four billing inputs (contact phone, billing address, city, GSTIN) can't
+// be plain strings: a Company change fetches ERP-derived defaults, and a late
+// response for a Company the customer already switched away from must never
+// clobber what they typed. Each field therefore carries provenance:
+//
+//     value            the current string
+//     source           empty | erp_default | local_restore | user
+//     source_company   the Company an erp_default came from (fence + switch)
+//     last_auto_value   the last value an ERP default wrote (audit / diffing)
+//
+// Ownership rule, everywhere: `user` and `local_restore` are USER-OWNED and are
+// never overwritten by a default. `empty` and `erp_default` are auto-owned and
+// a matching default may fill/replace them. A stale-response fence (monotonic
+// generation + Company match) is the second guard so out-of-order responses
+// can't win.
+//
+// This module imports ONLY vue (no @/api, no frappe-ui) so the whole lineage is
+// unit-testable without mounting the 12k-line OnboardingView — see
+// useBillingDetails.spec.js.
+
+import { reactive, ref, computed } from "vue";
+
+// The four Details-step inputs.
+export const BILLING_FIELDS = ["contact", "address", "city", "gstin"];
+
+// SPA field -> key in the shared billing-object contract
+// (jarvis/tests/fixtures/billing_contract/billing_snapshot.json). The bench
+// forwards this object to admin UNMODIFIED; admin owns the normalizer.
+export const REQUEST_KEY = {
+	contact: "contact_number",
+	address: "address_line1",
+	city: "city",
+	gstin: "gstin",
+};
+
+// User-owned sources are never overwritten by a default.
+const USER_OWNED = new Set(["user", "local_restore"]);
+
+// Storage-promise copy (P0-01): the "kept with your account" wording renders
+// ONLY once admin acknowledges the durable write (billing_saved: true). Until
+// then the honest local copy shows and the local snapshot is kept.
+export const STORAGE_PROMISE_SAVED =
+	"Billing details are kept with your account for upcoming invoicing.";
+export const STORAGE_PROMISE_LOCAL =
+	"Saved in this browser for now — kept with your account once your signup is confirmed.";
+
+// Transitional-storage key scheme (P0-02/C01-6): namespaced by site identity and
+// user so one site's or user's billing PII can never prefill another's on a
+// shared browser. The bare "jarvis-onboarding-billing" key this replaces was
+// browser-global and never expired.
+export const BILLING_LS_PREFIX = "jarvis-onboarding-billing";
+export function billingStorageKey(site, user) {
+	return `${BILLING_LS_PREFIX}::${site || "_"}::${user || "_"}`;
+}
+
+// ERP-defaults response (get_company_onboarding_defaults data) -> field values.
+function fieldValuesFromDefaults(data) {
+	const contact = (data && data.contact) || {};
+	const addr = (data && data.billing_address) || {};
+	return {
+		contact: (contact.phone || "").trim(),
+		address: (addr.address_line1 || "").trim(),
+		city: (addr.city || "").trim(),
+		gstin: (addr.gstin || "").trim(),
+	};
+}
+
+// Admin's normalized summary (get_signup_payment_state.data.billing /
+// update_pending_billing.data.billing) -> field values.
+function fieldValuesFromSummary(s) {
+	s = s || {};
+	return {
+		contact: (s.contact_number || "").trim(),
+		address: (s.address_line1 || "").trim(),
+		city: (s.city || "").trim(),
+		gstin: (s.gstin || "").trim(),
+	};
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.site  canonical site identity (window.location.host)
+ * @param {string} opts.user  logged-in user id (namespaces the transitional key)
+ * @param {Storage} [opts.storage]  defaults to window.localStorage
+ */
+export function useBillingDetails(opts = {}) {
+	const site = opts.site || "";
+	const user = opts.user || "";
+	const storage =
+		opts.storage || (typeof window !== "undefined" ? window.localStorage : undefined);
+	const key = billingStorageKey(site, user);
+
+	const fields = reactive({
+		contact: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		address: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		city: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		gstin: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+	});
+
+	// C01-5 version-skew acknowledgement: false until admin echoes billing_saved.
+	const billingSaved = ref(false);
+	// Provenance of the last-applied ERP defaults, forwarded to admin so it can
+	// record where the snapshot originated. Never rendered on Review & Pay.
+	const sourceCompany = ref("");
+	const sourceAddress = ref("");
+
+	// Stale-response fence state. `generation` is monotonic; `activeCompany` is
+	// the Company a fetch is currently in flight for. A response applies only
+	// when BOTH still match (P1-01).
+	let generation = 0;
+	let activeCompany = "";
+
+	function _resetToEmpty(name) {
+		const f = fields[name];
+		f.value = "";
+		f.source = "empty";
+		f.source_company = "";
+		f.last_auto_value = "";
+	}
+
+	function isUserOwned(name) {
+		return USER_OWNED.has(fields[name].source);
+	}
+
+	// The Details inputs call this on every edit: the value becomes user-owned
+	// and a default can no longer touch it.
+	function setUserValue(name, value) {
+		const f = fields[name];
+		f.value = value == null ? "" : String(value);
+		f.source = "user";
+		f.source_company = "";
+		persist();
+	}
+
+	// Begin an ERP-defaults fetch for `company`: bump the generation, record the
+	// active Company, and clear any erp_default value that belonged to a DIFFERENT
+	// Company so stale ERP data doesn't linger while the new fetch is in flight
+	// (this is also the "custom Company clears only ERP-owned values" path — a
+	// custom name resolves nothing, so the cleared auto fields simply stay empty).
+	// User-owned values survive untouched. Returns the generation to echo back on
+	// applyDefaults.
+	function beginCompanyFetch(company) {
+		company = (company || "").trim();
+		activeCompany = company;
+		generation += 1;
+		for (const name of BILLING_FIELDS) {
+			const f = fields[name];
+			if (f.source === "erp_default" && f.source_company !== company) {
+				_resetToEmpty(name);
+			}
+		}
+		// Provenance is only meaningful once the new company's defaults resolve.
+		sourceCompany.value = "";
+		sourceAddress.value = "";
+		return generation;
+	}
+
+	// Apply an ERP-defaults response. Fenced: ignored unless it is the newest
+	// in-flight request (generation match) AND still for the selected Company
+	// (company match). Fills only empty / erp_default-owned fields; user-owned
+	// values are never overwritten. Returns "applied" or a rejection reason so
+	// the fence is observable in tests.
+	function applyDefaults(resp, gen, company) {
+		company = (company || "").trim();
+		if (gen !== generation) return "stale-generation";
+		if (company !== activeCompany) return "stale-company";
+		const data = (resp && resp.data) || resp || {};
+		const incoming = fieldValuesFromDefaults(data);
+		for (const name of BILLING_FIELDS) {
+			if (isUserOwned(name)) continue; // never overwrite a user edit
+			const v = incoming[name];
+			if (!v) continue; // a blank default doesn't wipe an existing erp_default
+			const f = fields[name];
+			f.value = v;
+			f.source = "erp_default";
+			f.source_company = company;
+			f.last_auto_value = v;
+		}
+		sourceCompany.value = (data.company || company || "").trim();
+		sourceAddress.value = ((data.billing_address && data.billing_address.name) || "").trim();
+		persist();
+		return "applied";
+	}
+
+	// --- transitional localStorage (namespaced, ack-gated) --------------------
+
+	function persist() {
+		if (!storage) return;
+		try {
+			storage.setItem(
+				key,
+				JSON.stringify({
+					contact: fields.contact.value,
+					address: fields.address.value,
+					city: fields.city.value,
+					gstin: fields.gstin.value,
+				})
+			);
+		} catch (e) {
+			/* storage full/blocked — purely best-effort */
+		}
+	}
+
+	// Restore the namespaced snapshot into any still-empty field. Restored values
+	// are USER-OWNED (local_restore) so a later ERP default cannot overwrite what
+	// the customer had already entered. Only this site+user's key is read, so a
+	// different site/user namespace is invisible. Returns true if anything was
+	// restored.
+	function restore() {
+		if (!storage) return false;
+		let d;
+		try {
+			d = JSON.parse(storage.getItem(key) || "{}");
+		} catch (e) {
+			return false; // corrupt entry — ignore
+		}
+		let any = false;
+		for (const name of BILLING_FIELDS) {
+			const v = (d && d[name]) || "";
+			if (v && fields[name].source === "empty") {
+				fields[name].value = v;
+				fields[name].source = "local_restore";
+				any = true;
+			}
+		}
+		return any;
+	}
+
+	function clearStorage() {
+		if (!storage) return;
+		try {
+			storage.removeItem(key);
+		} catch (e) {
+			/* ignore */
+		}
+	}
+
+	// Record admin's version-skew acknowledgement. Only a literal `true` flips the
+	// promise to "kept with your account" (an older admin drops the kwarg and never
+	// echoes it → stays honest). A durable ack retires the local snapshot.
+	function markBillingSaved(ack) {
+		const saved = ack === true;
+		billingSaved.value = saved;
+		if (saved) clearStorage();
+		return saved;
+	}
+
+	// Cross-device recovery (P1-03 / brief §6): admin's authenticated state
+	// response carries the normalized snapshot. Server truth WINS over local —
+	// hydrated fields become user-owned, and the local remnant is cleared. Only a
+	// present, non-empty summary hydrates.
+	function hydrateServerSnapshot(summary) {
+		if (!summary || typeof summary !== "object") return false;
+		const incoming = fieldValuesFromSummary(summary);
+		let any = false;
+		for (const name of BILLING_FIELDS) {
+			const v = incoming[name];
+			if (v) {
+				fields[name].value = v;
+				fields[name].source = "user"; // authoritative, non-overwritable
+				fields[name].source_company = "";
+				any = true;
+			}
+		}
+		if (summary.source_company) sourceCompany.value = String(summary.source_company);
+		if (summary.source_address) sourceAddress.value = String(summary.source_address);
+		if (any) {
+			markBillingSaved(true); // a stored snapshot is by definition persisted
+			clearStorage();
+		}
+		return any;
+	}
+
+	// The single normalized billing object sent to admin AND rendered on Review &
+	// Pay (P1-03: the card reads THIS object, never re-joined form strings). Only
+	// non-empty keys are included; blank optional fields are simply omitted. GSTIN
+	// is upper-cased to match admin's normalizer so the card shows what is stored.
+	function buildBilling() {
+		const out = {};
+		for (const name of BILLING_FIELDS) {
+			let v = (fields[name].value || "").trim();
+			if (name === "gstin") v = v.toUpperCase();
+			if (v) out[REQUEST_KEY[name]] = v;
+		}
+		if (Object.keys(out).length) {
+			if (sourceCompany.value) out.source_company = sourceCompany.value;
+			if (sourceAddress.value) out.source_address = sourceAddress.value;
+		}
+		return out;
+	}
+
+	// Display rows for the Review & Pay card, derived from buildBilling() (so the
+	// card can never drift from the payload). Provenance keys are dropped.
+	const reviewRows = computed(() => {
+		const b = buildBilling();
+		const labels = {
+			contact_number: "Contact",
+			address_line1: "Billing address",
+			city: "City",
+			gstin: "GSTIN",
+		};
+		return Object.keys(labels)
+			.filter((k) => b[k])
+			.map((k) => ({ key: k, label: labels[k], value: b[k] }));
+	});
+
+	const promiseCopy = computed(() =>
+		billingSaved.value ? STORAGE_PROMISE_SAVED : STORAGE_PROMISE_LOCAL
+	);
+
+	return {
+		fields,
+		billingSaved,
+		sourceCompany,
+		sourceAddress,
+		promiseCopy,
+		reviewRows,
+		storageKey: key,
+		// generation is internal; expose readers for tests / telemetry.
+		currentGeneration: () => generation,
+		activeCompany: () => activeCompany,
+		isUserOwned,
+		setUserValue,
+		beginCompanyFetch,
+		applyDefaults,
+		persist,
+		restore,
+		clearStorage,
+		markBillingSaved,
+		hydrateServerSnapshot,
+		buildBilling,
+	};
+}
+
+// Pure decision for the post-Details "Continue" action when the customer is
+// EDITING billing after returning from Review & Pay (brief §5 / P1-03): once a
+// payment intent exists, edits save through the authenticated update_billing
+// facade — NEVER guest signup, which would create/replace an intent. Before an
+// intent exists there is nothing to persist yet (the snapshot rides the first
+// signup call), so the action is a no-op return to review.
+export function billingEditAction(intentExists) {
+	return intentExists ? "update_billing" : "none";
+}

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	useBillingDetails,
+	billingEditAction,
+	billingStorageKey,
+	STORAGE_PROMISE_SAVED,
+	STORAGE_PROMISE_LOCAL,
+} from "./useBillingDetails.js";
+
+// A default ERP-defaults response for "Aerele" (company A) and one for "Beta".
+const DEF_A = {
+	ok: true,
+	data: {
+		company: "Aerele",
+		contact: { name: "C-A", display_name: "A Contact", phone: "+91 90000 00001" },
+		billing_address: {
+			name: "Aerele-Billing",
+			address_line1: "12 MG Road",
+			city: "Chennai",
+			gstin: "33ABCDE1234F1Z5",
+		},
+	},
+};
+const DEF_B = {
+	ok: true,
+	data: {
+		company: "Beta",
+		contact: { name: "C-B", phone: "+91 90000 00002" },
+		billing_address: {
+			name: "Beta-Billing",
+			address_line1: "9 Ring Road",
+			city: "Delhi",
+			gstin: "07ABCDE1234F1Z5",
+		},
+	},
+};
+
+// Fetch + apply defaults for `company` in one shot, at the CURRENT generation.
+function fetchAndApply(b, company, resp) {
+	const gen = b.beginCompanyFetch(company);
+	return b.applyDefaults(resp, gen, company);
+}
+
+beforeEach(() => {
+	window.localStorage.clear();
+});
+
+describe("blank fields receive defaults", () => {
+	it("fills every empty field from the ERP defaults, marked erp_default", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(fetchAndApply(b, "Aerele", DEF_A)).toBe("applied");
+		expect(b.fields.contact.value).toBe("+91 90000 00001");
+		expect(b.fields.address.value).toBe("12 MG Road");
+		expect(b.fields.city.value).toBe("Chennai");
+		expect(b.fields.gstin.value).toBe("33ABCDE1234F1Z5");
+		for (const k of ["contact", "address", "city", "gstin"]) {
+			expect(b.fields[k].source).toBe("erp_default");
+			expect(b.fields[k].source_company).toBe("Aerele");
+		}
+	});
+});
+
+describe("user edits are never overwritten by a default", () => {
+	it("a value typed BEFORE the response survives it", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		const gen = b.beginCompanyFetch("Aerele");
+		b.setUserValue("city", "Mumbai"); // user types while the fetch is in flight
+		expect(b.applyDefaults(DEF_A, gen, "Aerele")).toBe("applied");
+		expect(b.fields.city.value).toBe("Mumbai"); // user wins
+		expect(b.fields.city.source).toBe("user");
+		expect(b.fields.contact.value).toBe("+91 90000 00001"); // empty one still filled
+	});
+});
+
+describe("stale-response fence (P1-01)", () => {
+	it("A→B with responses arriving B→A keeps B", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		const genA = b.beginCompanyFetch("Aerele");
+		const genB = b.beginCompanyFetch("Beta");
+		// B resolves first (it is the current selection)…
+		expect(b.applyDefaults(DEF_B, genB, "Beta")).toBe("applied");
+		// …then A's late response arrives and MUST be dropped.
+		expect(b.applyDefaults(DEF_A, genA, "Aerele")).toBe("stale-generation");
+		expect(b.fields.city.value).toBe("Delhi");
+		expect(b.fields.contact.value).toBe("+91 90000 00002");
+	});
+
+	// Mutation guard for the fence: if the generation check were removed the
+	// stale A response above would apply. Assert both fence dimensions reject.
+	it("rejects a wrong-generation response without mutating state", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		const gen = b.beginCompanyFetch("Aerele");
+		b.applyDefaults(DEF_A, gen, "Aerele");
+		const before = b.fields.city.value;
+		expect(b.applyDefaults(DEF_B, gen - 1, "Aerele")).toBe("stale-generation");
+		expect(b.fields.city.value).toBe(before);
+	});
+
+	it("rejects a right-generation but wrong-company response", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		const gen = b.beginCompanyFetch("Aerele");
+		expect(b.applyDefaults(DEF_B, gen, "Beta")).toBe("stale-company");
+		expect(b.fields.city.value).toBe("");
+	});
+});
+
+describe("company switch ownership", () => {
+	it("previous ERP-owned values change to the new company's defaults", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		fetchAndApply(b, "Aerele", DEF_A);
+		expect(b.fields.city.value).toBe("Chennai");
+		fetchAndApply(b, "Beta", DEF_B);
+		expect(b.fields.city.value).toBe("Delhi");
+		expect(b.fields.city.source_company).toBe("Beta");
+	});
+
+	it("user-owned values survive a company change", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		fetchAndApply(b, "Aerele", DEF_A);
+		b.setUserValue("contact", "+91 99999 12345");
+		fetchAndApply(b, "Beta", DEF_B);
+		expect(b.fields.contact.value).toBe("+91 99999 12345"); // kept
+		expect(b.fields.contact.source).toBe("user");
+		expect(b.fields.city.value).toBe("Delhi"); // erp_default still swapped
+	});
+
+	it("custom Company clears only ERP-owned values, keeps user edits", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		fetchAndApply(b, "Aerele", DEF_A);
+		b.setUserValue("gstin", "29ABCDE1234F1Z5"); // user override
+		// A custom company resolves nothing: beginCompanyFetch clears prior
+		// erp_default values; no applyDefaults follows (server returns NOT_FOUND).
+		b.beginCompanyFetch("Totally New Pvt Ltd");
+		expect(b.fields.city.value).toBe(""); // erp_default cleared
+		expect(b.fields.city.source).toBe("empty");
+		expect(b.fields.gstin.value).toBe("29ABCDE1234F1Z5"); // user kept
+		expect(b.fields.gstin.source).toBe("user");
+	});
+});
+
+describe("local restore is user-owned", () => {
+	it("restores into empty fields and marks them local_restore (non-overwritable)", () => {
+		const seed = useBillingDetails({ site: "s1", user: "u1" });
+		seed.setUserValue("city", "Pune");
+		seed.setUserValue("gstin", "27ABCDE1234F1Z5");
+		// New instance, same site+user, simulates a reload.
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.restore()).toBe(true);
+		expect(b.fields.city.value).toBe("Pune");
+		expect(b.fields.city.source).toBe("local_restore");
+		// A subsequent ERP default must NOT overwrite the restored value.
+		fetchAndApply(b, "Aerele", DEF_A);
+		expect(b.fields.city.value).toBe("Pune");
+	});
+});
+
+describe("transitional-storage namespace isolation (P0-02/C01-6)", () => {
+	it("a different site or user cannot read the snapshot", () => {
+		const a = useBillingDetails({ site: "siteA", user: "userA" });
+		a.setUserValue("gstin", "33SECRET1234F1Z5");
+		// Different user, same site.
+		const b1 = useBillingDetails({ site: "siteA", user: "userB" });
+		expect(b1.restore()).toBe(false);
+		expect(b1.fields.gstin.value).toBe("");
+		// Different site, same user.
+		const b2 = useBillingDetails({ site: "siteB", user: "userA" });
+		expect(b2.restore()).toBe(false);
+		expect(b2.fields.gstin.value).toBe("");
+		// Same site+user CAN.
+		const b3 = useBillingDetails({ site: "siteA", user: "userA" });
+		expect(b3.restore()).toBe(true);
+		expect(b3.fields.gstin.value).toBe("33SECRET1234F1Z5");
+	});
+
+	it("the storage key encodes site and user", () => {
+		expect(billingStorageKey("siteA", "userA")).not.toBe(billingStorageKey("siteA", "userB"));
+		expect(billingStorageKey("siteA", "userA")).not.toBe(billingStorageKey("siteB", "userA"));
+	});
+});
+
+describe("re-fetch discipline (back/continue does not lose edits)", () => {
+	it("re-selecting the SAME company keeps its erp_default values", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		fetchAndApply(b, "Aerele", DEF_A);
+		// Navigating back to details and re-entering re-runs beginCompanyFetch on
+		// the same company: erp_default from the SAME company must not be cleared.
+		b.beginCompanyFetch("Aerele");
+		expect(b.fields.city.value).toBe("Chennai");
+		expect(b.fields.city.source).toBe("erp_default");
+	});
+
+	it("a fresh generation is minted per fetch (fence stays monotonic)", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		const g1 = b.beginCompanyFetch("Aerele");
+		const g2 = b.beginCompanyFetch("Beta");
+		expect(g2).toBeGreaterThan(g1);
+		expect(b.currentGeneration()).toBe(g2);
+	});
+});
+
+describe("ack-gated storage promise (P0-01)", () => {
+	it("shows the honest local copy until billing_saved: true is observed", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
+		b.markBillingSaved(true);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
+	});
+
+	// Mutation guard for the ack gate: only a literal boolean true may flip it.
+	// A truthy-but-not-true ack (older admin echoing 1, or a "true" string) must
+	// NOT claim persistence.
+	it("only a literal true ack flips the promise", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.markBillingSaved(1)).toBe(false);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
+		expect(b.markBillingSaved("true")).toBe(false);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
+		expect(b.markBillingSaved(undefined)).toBe(false);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
+		expect(b.markBillingSaved(true)).toBe(true);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
+	});
+
+	it("clears the local snapshot only after a durable ack", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("city", "Chennai");
+		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy();
+		b.markBillingSaved(false);
+		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy(); // kept
+		b.markBillingSaved(true);
+		expect(window.localStorage.getItem(b.storageKey)).toBeNull(); // retired
+	});
+});
+
+describe("Review & Pay card equals the normalized payload (P1-03)", () => {
+	it("card rows are derived from buildBilling(), never from separate strings", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		fetchAndApply(b, "Aerele", DEF_A);
+		b.setUserValue("gstin", "27abcde1234f1z5"); // lower-case user entry
+		const payload = b.buildBilling();
+		// GSTIN normalized (upper) in the SAME object the card reads.
+		expect(payload.gstin).toBe("27ABCDE1234F1Z5");
+		const rowByKey = Object.fromEntries(b.reviewRows.value.map((r) => [r.key, r.value]));
+		for (const k of Object.keys(rowByKey)) {
+			expect(rowByKey[k]).toBe(payload[k]);
+		}
+		// Provenance rides the payload but is NOT shown on the card.
+		expect(payload.source_company).toBe("Aerele");
+		expect(payload.source_address).toBe("Aerele-Billing");
+		expect(b.reviewRows.value.some((r) => r.key === "source_company")).toBe(false);
+	});
+
+	it("omits blank optional fields from both payload and card", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("contact", "+91 90000 00000");
+		const payload = b.buildBilling();
+		expect(payload).toEqual({ contact_number: "+91 90000 00000" });
+		expect(b.reviewRows.value).toEqual([
+			{ key: "contact_number", label: "Contact", value: "+91 90000 00000" },
+		]);
+	});
+});
+
+describe("cross-device recovery — server snapshot wins (brief §6)", () => {
+	it("hydrates from admin's normalized summary, overriding local, and clears the remnant", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("city", "LocalCity"); // stale local value
+		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy();
+		const applied = b.hydrateServerSnapshot({
+			contact_number: "+91 88888 00000",
+			address_line1: "Server Address",
+			city: "ServerCity",
+			gstin: "33ABCDE1234F1Z5",
+			source_company: "Aerele",
+		});
+		expect(applied).toBe(true);
+		expect(b.fields.city.value).toBe("ServerCity"); // server wins
+		expect(b.fields.city.source).toBe("user"); // authoritative, non-overwritable
+		expect(b.billingSaved.value).toBe(true); // stored ⇒ saved
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
+		expect(window.localStorage.getItem(b.storageKey)).toBeNull(); // remnant cleared
+		// A later ERP default cannot clobber the recovered snapshot.
+		fetchAndApply(b, "Aerele", DEF_A);
+		expect(b.fields.city.value).toBe("ServerCity");
+	});
+
+	it("does nothing for an empty/absent summary", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.hydrateServerSnapshot(null)).toBe(false);
+		expect(b.hydrateServerSnapshot({})).toBe(false);
+		expect(b.billingSaved.value).toBe(false);
+	});
+});
+
+describe("edit-after-intent uses the authenticated facade, never guest signup (P1-03)", () => {
+	it("returns update_billing once an intent exists, no-op before", () => {
+		expect(billingEditAction(false)).toBe("none");
+		expect(billingEditAction(true)).toBe("update_billing");
+		// The action vocabulary never includes a guest-signup verb.
+		expect(billingEditAction(true)).not.toBe("signup");
+	});
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -230,7 +230,10 @@
 										type="tel"
 										variant="outline"
 										label="Contact number (optional)"
-										v-model="state.contact"
+										:model-value="billing.fields.contact.value"
+										@update:model-value="
+											(v) => billing.setUserValue('contact', v)
+										"
 										placeholder="+91 98765 43210"
 										autocomplete="tel"
 										@keydown.enter="onDetailsSubmit"
@@ -257,15 +260,17 @@
 										Billing
 									</div>
 									<div class="col-span-2 -mt-1 text-p-xs text-ink-gray-5">
-										Billing details are kept with your account for upcoming
-										invoicing.
+										{{ billing.promiseCopy.value }}
 									</div>
 									<FormControl
 										class="col-span-2"
 										type="text"
 										variant="outline"
 										label="Billing address (optional)"
-										v-model="state.billingAddress"
+										:model-value="billing.fields.address.value"
+										@update:model-value="
+											(v) => billing.setUserValue('address', v)
+										"
 										placeholder="Street, area"
 										autocomplete="street-address"
 										@keydown.enter="onDetailsSubmit"
@@ -274,7 +279,10 @@
 										type="text"
 										variant="outline"
 										label="City (optional)"
-										v-model="state.city"
+										:model-value="billing.fields.city.value"
+										@update:model-value="
+											(v) => billing.setUserValue('city', v)
+										"
 										placeholder="Chennai"
 										autocomplete="address-level2"
 										@keydown.enter="onDetailsSubmit"
@@ -283,7 +291,10 @@
 										type="text"
 										variant="outline"
 										label="GSTIN (optional)"
-										v-model="state.gstin"
+										:model-value="billing.fields.gstin.value"
+										@update:model-value="
+											(v) => billing.setUserValue('gstin', v)
+										"
 										placeholder="33ABCDE1234F1Z5"
 										@keydown.enter="onDetailsSubmit"
 									/>
@@ -463,6 +474,16 @@
 											}}</b>
 										</div>
 										<div
+											v-for="row in billing.reviewRows.value"
+											:key="row.key"
+											class="flex items-center justify-between gap-3 border-b border-outline-gray-1 px-4 py-3 text-p-sm"
+										>
+											<span class="text-ink-gray-5">{{ row.label }}</span
+											><b class="font-medium text-ink-gray-9">{{
+												row.value
+											}}</b>
+										</div>
+										<div
 											class="flex items-center justify-between gap-3 bg-surface-gray-1 px-4 py-3 text-p-sm"
 										>
 											<span class="text-ink-gray-5">Due today</span
@@ -470,6 +491,19 @@
 												dueTodayLabel
 											}}</b>
 										</div>
+									</div>
+									<div
+										v-if="billing.reviewRows.value.length"
+										class="mx-auto mt-2 flex max-w-[560px] items-center justify-between gap-3 text-p-xs text-ink-gray-5"
+									>
+										<span>{{ billing.promiseCopy.value }}</span>
+										<button
+											class="ob-link shrink-0"
+											:disabled="state.payBusy"
+											@click="editBilling"
+										>
+											Edit
+										</button>
 									</div>
 									<div
 										class="mx-auto mt-3.5 flex max-w-[560px] items-center justify-center gap-1.5 text-center text-xs text-ink-gray-5"
@@ -798,11 +832,15 @@ import {
 	startSignup,
 	finishPayment,
 	getAccountDefaults,
+	getCompanyOnboardingDefaults,
+	updateBilling,
 	syncConnection,
 } from "@/api";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
+import { readCookie } from "@/lib/user";
+import { useBillingDetails, billingEditAction } from "@/onboarding/useBillingDetails";
 
 const { effectiveDark: dark, paletteVars } = useJarvisTheme();
 
@@ -834,17 +872,16 @@ const state = reactive({
 	company: "",
 	companies: [],
 	detailsErr: "",
-	// Collected by the redesign but NOT submitted yet:
-	// jarvis.onboarding.start_signup(email, company, plan) and
-	// admin_client.signup(email, company_name, plan, coupon=None) accept no
-	// contact/billing kwargs, and the admin-side signup contract is external
-	// to this repo. Threading them through would break the API contract.
-	// TODO(backend): pass contact + billingAddress/city/gstin through
-	// start_signup → admin signup once those endpoints accept them.
-	contact: "",
-	billingAddress: "",
-	city: "",
-	gstin: "",
+	// The four billing inputs (contact phone, address, city, GSTIN) live in the
+	// `billing` composable below (provenance-aware, fenced, namespaced) — Plan 01.
+	// True once a payment intent exists (a signup call created checkout handles,
+	// or reconcile found a live mid-flight order): billing edits then save through
+	// the authenticated update_billing facade, never a fresh guest signup.
+	intentExists: false,
+	// True while the customer is editing billing after returning from Review & Pay
+	// (the card's "Edit" button), so onDetailsSubmit returns to Pay instead of
+	// walking forward through Plan.
+	billingEditReturn: false,
 	// plan (Choose Your Plan step)
 	plans: [],
 	planName: null,
@@ -884,6 +921,15 @@ const state = reactive({
 	finishing: false,
 	finishNote: "",
 	finishSubtitle: "",
+});
+
+// Plan 01 billing state. Namespaced by site identity + logged-in user so one
+// site's / user's transitional billing PII can never prefill another's on a
+// shared browser (P0-02/C01-6). Owns provenance, the stale-response fence, the
+// ack-gated storage promise, and the Review & Pay ↔ payload single source.
+const billing = useBillingDetails({
+	site: (typeof window !== "undefined" && window.location && window.location.host) || "",
+	user: readCookie("user_id") || "",
 });
 
 const steps = computed(() => STEPS_MANAGED);
@@ -939,6 +985,15 @@ watch(
 		eligibilityTimer = setTimeout(refreshReconnectEligibility, 500);
 	},
 	{ immediate: true }
+);
+// Plan 01: a Company change re-fetches ERP-derived billing defaults (debounced +
+// fenced inside fetchCompanyDefaults). Fires on the prefilled default Company too
+// (harmless: it only fills empty/erp_default fields, never user edits). immediate
+// is off so it doesn't race prefillAccount/restore on mount — onMounted kicks the
+// first fetch explicitly after both have run.
+watch(
+	() => state.company,
+	() => scheduleCompanyDefaults()
 );
 const frameSub = computed(() => FRAME_SUBS[state.step] || "Set up your workspace");
 
@@ -1098,9 +1153,18 @@ async function reconcileMidFlightSignup() {
 		// signed up, moments after they authorised. verifyPollAction is the one
 		// place that knows every gateway/shape, so the two cannot drift again.
 		const pay = await checkSignupPaymentState();
+		// Cross-device recovery (Plan 01 §6): admin's authenticated state response
+		// carries the normalized billing snapshot for the owned Pending Payment
+		// customer. Server truth wins over any local remnant, and hydrating retires
+		// the local snapshot. Presence of this row also proves an intent exists, so
+		// later edits route through update_billing rather than a fresh signup.
+		if (pay && billing.hydrateServerSnapshot(pay.billing)) {
+			state.intentExists = true;
+		}
 		if (pay && (pay.pending_verification || verifyPollAction(pay).kind === "checkout")) {
 			state.step = "pay";
 			state.payPhase = "verify";
+			state.intentExists = true;
 		}
 		// else: nothing in flight - leave the default "intro" step (fresh start).
 	} catch (e) {
@@ -1151,38 +1215,40 @@ function onPlanContinue() {
 
 // ---- Details (Your Details) -------------------------------------------------
 // Validation matches the old Account step verbatim: email regex + non-empty
-// company. The contact/billing fields are collected but not (yet) submitted -
-// see the TODO(backend) note on `state` above. Until the backend accepts
-// them, they're persisted to localStorage on submit so they survive reloads
-// and can be backfilled once the signup contract carries them.
-const BILLING_LS_KEY = "jarvis-onboarding-billing";
-function persistBillingDetails() {
+// company. The four billing inputs are provenance-aware state owned by the
+// `billing` composable (Plan 01): edits are user-owned, the transitional
+// localStorage snapshot is namespaced by site+user and cleared only after
+// admin's billing_saved ack, and a Company change fetches ERP-derived defaults
+// behind a stale-response fence (fetchCompanyDefaults below).
+
+// ERP-derived billing defaults for the selected Company. Debounced (the Company
+// combo emits on every keystroke), fenced (beginCompanyFetch mints a monotonic
+// generation; applyDefaults drops anything that isn't the newest request for the
+// still-selected Company), and fail-closed (any error just leaves the fields as
+// beginCompanyFetch left them — prior-Company ERP values cleared, user edits kept).
+// Telemetry is presence-only: a stable code, never a billing value.
+let companyDefaultsTimer = null;
+function scheduleCompanyDefaults() {
+	if (companyDefaultsTimer) clearTimeout(companyDefaultsTimer);
+	companyDefaultsTimer = setTimeout(fetchCompanyDefaults, 300);
+}
+async function fetchCompanyDefaults() {
+	const company = (state.company || "").trim();
+	// beginCompanyFetch clears prior-Company erp_default values (and mints the
+	// generation) whether or not a network call follows, so a switch to a custom
+	// Company that resolves nothing still drops the previous Company's ERP data.
+	const gen = billing.beginCompanyFetch(company);
+	if (!company) return;
 	try {
-		window.localStorage.setItem(
-			BILLING_LS_KEY,
-			JSON.stringify({
-				contact: state.contact,
-				billingAddress: state.billingAddress,
-				city: state.city,
-				gstin: state.gstin,
-			})
-		);
+		const resp = await getCompanyOnboardingDefaults(company);
+		if (resp && resp.ok) billing.applyDefaults(resp, gen, company);
 	} catch (e) {
-		/* storage full/blocked - purely best-effort */
+		// COMPANY_DEFAULTS_FORBIDDEN / _NOT_FOUND surface as a 4xx (thrown here);
+		// nothing to apply. Presence-only report, no PII.
+		reportError({ surface: "onboarding", error_code: "company_defaults", message: "" });
 	}
 }
-// Restore on mount; never overwrites something the user already typed.
-function restoreBillingDetails() {
-	try {
-		const d = JSON.parse(window.localStorage.getItem(BILLING_LS_KEY) || "{}");
-		if (d.contact && !state.contact) state.contact = d.contact;
-		if (d.billingAddress && !state.billingAddress) state.billingAddress = d.billingAddress;
-		if (d.city && !state.city) state.city = d.city;
-		if (d.gstin && !state.gstin) state.gstin = d.gstin;
-	} catch (e) {
-		/* corrupt entry - ignore */
-	}
-}
+
 function onDetailsSubmit() {
 	state.detailsErr = "";
 	state.email = (state.email || "").trim();
@@ -1195,7 +1261,16 @@ function onDetailsSubmit() {
 		state.detailsErr = "Company name is required.";
 		return;
 	}
-	persistBillingDetails();
+	billing.persist();
+	// Editing billing after Review & Pay: return straight to Pay, and — once an
+	// intent exists — save the edit through the authenticated update_billing
+	// facade (NEVER a fresh guest signup, which would create/replace the intent).
+	if (state.billingEditReturn) {
+		state.billingEditReturn = false;
+		saveBillingEdit();
+		state.step = "pay";
+		return;
+	}
 	// Entering Review & Pay fresh from Details: reset the pay sub-state. This
 	// includes reconnectOffered, not just payErr - otherwise a reconnect offer
 	// raised by a duplicate email on an earlier attempt survives a Back, an
@@ -1205,6 +1280,28 @@ function onDetailsSubmit() {
 	state.payErr = "";
 	state.reconnectOffered = false;
 	goNext();
+}
+
+// The Review & Pay card's "Edit" affordance: return to Details WITHOUT touching
+// the payment intent. If one already exists the subsequent Continue persists via
+// update_billing; otherwise it just walks back to the card.
+function editBilling() {
+	state.billingEditReturn = true;
+	state.step = "details";
+}
+
+// Persist a post-intent billing edit through the authenticated facade. Best-
+// effort: a failure keeps the local snapshot (promise stays honest) and reports
+// presence-only. billingEditAction is the single source of truth for "which
+// path" so the choice is unit-tested (never guest signup).
+async function saveBillingEdit() {
+	if (billingEditAction(state.intentExists) !== "update_billing") return;
+	try {
+		const d = (await updateBilling(billing.buildBilling())) || {};
+		billing.markBillingSaved(d.billing_saved === true);
+	} catch (e) {
+		reportError({ surface: "onboarding", error_code: "billing_update", message: "" });
+	}
 }
 
 // ---- Pay (renderPay / renderVerifyEmail / startPay / openCheckout,
@@ -1298,12 +1395,20 @@ async function proceedAfterPay() {
 
 async function runStartPay() {
 	try {
+		// Plan 01: the normalized billing snapshot rides the signup call. The bench
+		// forwards it to admin UNMODIFIED and echoes billing_saved only when a new
+		// admin persisted it (an older admin drops the kwarg — promise stays honest).
 		const d = await startSignup(
 			state.email,
 			state.company,
 			state.planName,
-			state.paymentProvider
+			state.paymentProvider,
+			billing.buildBilling()
 		);
+		// A checkout intent now exists: further billing edits go through the
+		// authenticated update_billing facade, not a fresh guest signup.
+		state.intentExists = true;
+		billing.markBillingSaved(d && d.billing_saved === true);
 		if (d && d.pending_verification) {
 			state.payPhase = "verify";
 			state.payBusy = false;
@@ -1859,8 +1964,16 @@ async function prefillAccount() {
 }
 
 onMounted(async () => {
-	prefillAccount();
-	restoreBillingDetails();
+	// Restore the namespaced local billing snapshot FIRST: restored values are
+	// user-owned (local_restore), so the Company-defaults fetch prefillAccount
+	// triggers can only fill fields the customer left blank.
+	billing.restore();
+	await prefillAccount();
+	// prefillAccount may set the default Company synchronously; the watcher fires,
+	// but kick a fetch explicitly too in case the prefilled value equalled the
+	// combo's initial value (no change event) — beginCompanyFetch is idempotent
+	// for the same Company (it never clears same-Company erp_default values).
+	if ((state.company || "").trim()) scheduleCompanyDefaults();
 	loadPaymentProviders();
 	await reconcileMidFlightSignup();
 	// Prefetch the plan catalog behind the intro tour so the Plan step rarely

--- a/jarvis/tests/fixtures/billing_contract/PROVENANCE.md
+++ b/jarvis/tests/fixtures/billing_contract/PROVENANCE.md
@@ -1,24 +1,63 @@
 # Billing-object contract fixture (Plan 01)
 
 `billing_snapshot.json` is the shared billing-object contract for the customer
-onboarding flow. It is **byte-for-byte identical** to its twin in the admin repo:
+onboarding flow.
+
+## Source of truth
+
+The **admin** copy is authoritative — admin owns the normalizer
+(`billing.signup._normalize_billing` / `_billing_summary`) that stores and
+re-reads this object. This file is a **byte-for-byte identical** vendored twin of
+it, so the two repos cannot drift silently:
 
 | | |
 |---|---|
 | twin repo | `git@github.com:Aerele-RnD/jarvis-admin-v2.git` |
+| twin branch | `feat/plan01-billing-persistence` |
 | twin path | `jarvis_admin_v2/tests/billing/fixtures/billing_contract/billing_snapshot.json` |
-| sha256 | `612aa11a918ea4f789e2b44d51d4b46d35551e3ec06cdebf9a4cb0848b38f6e9` |
+| sha256 | `c370ecf920f61212f2f3f2359f28fca375a8e417573daabb6f735d6d222e03a2` |
 
-Both sides load the same file and assert against it, so the wire shape cannot
-drift between the bench (which forwards the object and consumes the normalized
-summary + `billing_saved` ack) and admin (which owns the normalizer that stores
-and re-reads it). `test_billing_contract.py` recomputes the sha above and fails
-on a mismatch.
+The sha pin is what enforces byte-identity: `test_billing_contract.py`
+recomputes the sha of this file and fails on a mismatch, and the admin twin pins
+the identical value. If either side edits its copy, both suites go red — a
+divergence surfaces as a test failure instead of shipping. (The `gstin` in the
+fixture, `33ABCDE1234F1Z7`, is a fully valid GSTIN — real state code 33 and a
+correct checksum digit — so it survives the admin normalizer's validation; the
+earlier `...Z5` value was checksum-invalid.)
 
-NOTE (coordination): the broader admin-contract corpus
-(`jarvis/tests/fixtures/admin_contract/`, WS-B) is not on `develop` at the time
-this landed; this Plan-01 billing fixture is deliberately in its own
-`billing_contract/` subdir so it neither depends on nor collides with that corpus
-when WS-B merges. The paired-head CI job that diffs the two repos' copies is
-deferred with the rest of combined-head CI (FABLE-JUDGMENT §2.6); the sha assertion
-here is the standing in-repo guard until then.
+## What is contractual vs volatile
+
+Stable **codes** and **field names** are the contract — `request_billing`'s field
+set, `normalized_summary`'s keys, and the `billing_saved` ack shape are what both
+sides pin. Human-facing **display messages** are volatile and are NOT part of the
+pinned shape; never string-match against them.
+
+The bench forwards `request_billing` to admin UNMODIFIED (it never reshapes or
+flattens it) and consumes the normalized summary + `billing_saved` ack.
+`test_billing_contract.py` replays the fixture through the real bench consumer
+(`jarvis.admin_client.signup`, with `_post_guest` patched) and asserts the
+forwarded object is byte-for-byte the fixture, so an admin-side shape change
+fails here rather than being discovered in production.
+
+## Re-syncing
+
+Manual today: the paired-head CI job that would diff the two repos' copies
+automatically is deferred with the rest of combined-head CI
+(FABLE-JUDGMENT §2.6); the sha pin above is the standing in-repo guard until
+then. A contract change lands on the admin side first, then is re-copied here —
+never edit this file to make a test pass.
+
+```bash
+cp <admin-checkout>/jarvis_admin_v2/tests/billing/fixtures/billing_contract/billing_snapshot.json \
+   jarvis/tests/fixtures/billing_contract/billing_snapshot.json
+sha256sum jarvis/tests/fixtures/billing_contract/billing_snapshot.json   # update _FIXTURE_SHA in test_billing_contract.py
+```
+
+and run `jarvis.tests.test_billing_contract`.
+
+## Coordination
+
+The broader admin-contract corpus (`jarvis/tests/fixtures/admin_contract/`, WS-B)
+is not on `develop` at the time this landed; this Plan-01 billing fixture is
+deliberately in its own `billing_contract/` subdir so it neither depends on nor
+collides with that corpus when WS-B merges.

--- a/jarvis/tests/fixtures/billing_contract/billing_snapshot.json
+++ b/jarvis/tests/fixtures/billing_contract/billing_snapshot.json
@@ -10,7 +10,7 @@
     "state": "Tamil Nadu",
     "pincode": "600001",
     "country": "India",
-    "gstin": "33ABCDE1234F1Z5",
+    "gstin": "33ABCDE1234F1Z7",
     "source_company": "Aerele",
     "source_address": "Aerele-Billing"
   },
@@ -22,7 +22,7 @@
     "state": "Tamil Nadu",
     "pincode": "600001",
     "country": "India",
-    "gstin": "33ABCDE1234F1Z5",
+    "gstin": "33ABCDE1234F1Z7",
     "source_company": "Aerele",
     "source_address": "Aerele-Billing"
   },

--- a/jarvis/tests/test_billing_contract.py
+++ b/jarvis/tests/test_billing_contract.py
@@ -16,7 +16,7 @@ from jarvis import admin_client
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "billing_contract" / "billing_snapshot.json"
 # sha256 of the shared billing_snapshot.json; the admin twin pins the same value.
-_FIXTURE_SHA = "612aa11a918ea4f789e2b44d51d4b46d35551e3ec06cdebf9a4cb0848b38f6e9"
+_FIXTURE_SHA = "c370ecf920f61212f2f3f2359f28fca375a8e417573daabb6f735d6d222e03a2"
 
 
 class TestBillingContract(FrappeTestCase):


### PR DESCRIPTION
Work unit C of Plan 01 (ERP defaults + billing metadata), stacked on the bench-resolver half **#590 (`feat/plan01-company-defaults`)**. Frontend-only: replaces the four plain billing strings with provenance-aware state, adds the Company request-generation fence, namespaced/ack-gated transitional storage, the Review & Pay billing card, cross-device recovery, and the corrected tour copy.

## What changed
- **`frontend/src/onboarding/useBillingDetails.js`** (new) — vue-only composable so the whole lineage is unit-testable without mounting the 12k-line `OnboardingView`. Per-field `{value, source: empty|erp_default|local_restore|user, source_company, last_auto_value}`; monotonic-generation + Company-match fence; ownership rules; namespaced localStorage; ack-gated storage promise; `buildBilling()` single source for the payload **and** the Review card; `hydrateServerSnapshot()`; `billingEditAction()`.
- **`frontend/src/onboarding/permissionCopy.js`** (new) — approved permission wording derived from the default `Jarvis Conversation.auto_apply` policy (default `0` = confirm every write; destructive ops always park).
- **`frontend/src/views/OnboardingView.vue`** — wires the composable into the Details inputs, the Company watcher (debounced + fenced, fail-closed), the Review & Pay billing card + **Edit** (returns to Details without touching the intent; post-intent edits go through `update_billing`, never guest signup), the `billing_saved` ack gate, and cross-device hydrate on resume.
- **`frontend/src/api.js`** — `getCompanyOnboardingDefaults`, `updateBilling`; `startSignup` now forwards the normalized billing object.
- **`frontend/src/onboarding/TourIntro.vue`** — "Asks before it changes anything" → the approved wording.

## Review findings addressed (codex round-2)
P0-01 (false storage promise → ack-gated), P0-02/C01-6 (browser-global key → site+user namespace, cleared only on ack), P1-01 (no provenance/fence → both), P1-03 (Review & Pay + edit-after-intent path), P1-05 (tour copy + copy-to-policy contract).

## Tests
- `useBillingDetails.spec.js` — the review's full "Frontend lineage" matrix (blank fields defaulted; user-typed-before-response survives; out-of-order B→A keeps B; company-switch ownership; custom company; local restore is user-owned; namespace isolation; no duplicate/lost-edit on re-fetch; ack-gated copy; review card == payload; edit-after-intent → `update_billing`) plus mutation guards on the fence and the ack gate.
- `permissionCopy.spec.js` — copy↔policy contract + TourIntro binds to the module.
- `vitest run` and `test:node` green (the single `support-thread.test.js` failure is **pre-existing on the base branch**, unrelated). Pinned prettier + eslint clean on all changed files.

## Notes for the judge
- Scoped to the Details step, the Review & Pay card, and billing recovery. Does **not** touch `runCheckout`/payment-machine internals beyond one honest `intentExists` flag; expect a merge with plan-09 WS7's PAYMENT-step rework.
- Depends on admin #189's normalized snapshot in the authenticated state response and #590's API shapes (`get_company_onboarding_defaults`, `start_signup` billing passthrough, `update_billing`). Combined-head contract CI is deferred per FABLE-JUDGMENT §2.6; the in-repo billing-fixture sha guard (from #590) stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MAPeM77sD3rpQwX98aLRG