### PR TITLE
plan-05 D2: LLM-apply operation follower + read-side seam (stacked on #584)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -54,6 +54,11 @@ export const checkAccountReconnect = (requestId, code) =>
 	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId, code: code || "" });
 
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat");
+// Read-only poll of a durable LLM-apply operation (plan-05 D2). The single
+// Start-chatting controller (frontend/src/lib/llmOperation.js) follows exactly one
+// operation id to a terminal state through this; it never spends the apply bucket.
+export const getLlmApplyOperation = (operationId) =>
+	call("jarvis.account.get_llm_apply_operation", { operation_id: operationId });
 
 // ---- workspace reset (customer self-serve, admin-gated) --------------------
 export const requestWorkspaceReset = (reason, opts = {}) =>

--- a/frontend/src/lib/__fixtures__/llmOperation.fixtures.js
+++ b/frontend/src/lib/__fixtures__/llmOperation.fixtures.js
@@ -1,0 +1,125 @@
+// Vendored copies of the admin LLM-apply-operation contract shapes, taken VERBATIM
+// from the landed admin half (jarvis_admin_v2 @ feat/plan05-apply-operation,
+// fleet/apply_operation.py::status + api/tenant.py). These are the exact shapes the
+// bench receives, so the client seam in llmOperation.js is exercised against them
+// and the pair is diffed at integration.
+//
+// FROZEN CONTRACT (jarvis_admin_v2.fleet.apply_operation):
+//
+//   save_llm_pool(...) returns result["apply_operation"];
+//   get_llm_apply_operation(operation_id) returns .data — the SAME 12-key shape.
+//   Even while pending, every key is present:
+//
+//     { operation_id, state, code, message, tenant (OPAQUE 32-hex, never TEN-*),
+//       tenant_authority_generation, desired_version, applied_version,
+//       chat_readiness, chat_readiness_reason, retryable, retry_after_seconds }
+//
+//   state  ∈ { pending, applying, applied_waiting_readiness, ready, failed, superseded }
+//   code   ∈ { LLM_APPLY_PENDING, LLM_APPLYING, LLM_APPLIED_READINESS_PENDING,
+//              LLM_READY, LLM_APPLY_REJECTED (permanent), LLM_APPLY_FAILED (transient),
+//              LLM_APPLY_BLOCKED_OAUTH, SUPERSEDED_NEWER_SAVE, SUPERSEDED_AUTHORITY_CHANGED }
+//   retryable = (code !== "LLM_APPLY_REJECTED")   [admin _retryable]
+//
+//   Wire refusals (thrown, not operation states):
+//     CUSTOMER_NOT_PAID (403), TENANT_AUTHORITY_REPAIR_REQUIRED (safe envelope),
+//     IdempotencyKeyConflict (409), RateLimitExceeded (429 + retry_after_seconds),
+//     UnknownOperation (404).
+
+// A 32-hex opaque tenant handle (admin: sha256(...)[:32]) — never a raw TEN-* name.
+const TENANT = "7f3a9c1e4b2d8a6f0e5c3b1a9d7e2f40";
+const GEN = 7;
+const OP_ID = "llmapply_a1b2c3d4e5";
+
+/**
+ * Build a status/descriptor in the exact 12-key shape.
+ * @param {string} state
+ * @param {object} over - per-field overrides
+ */
+export function statusOf(state, over = {}) {
+	const base = {
+		operation_id: OP_ID,
+		state,
+		code: "",
+		message: "",
+		tenant: TENANT,
+		tenant_authority_generation: GEN,
+		desired_version: 12,
+		applied_version: 0,
+		chat_readiness: null,
+		chat_readiness_reason: "",
+		retryable: true,
+		retry_after_seconds: 0,
+	};
+	const byState = {
+		pending: {
+			code: "LLM_APPLY_PENDING",
+			message: "Your AI connection is saved. Starting setup.",
+			chat_readiness: "Provisioning",
+		},
+		applying: {
+			code: "LLM_APPLYING",
+			message: "Applying your AI connection.",
+			chat_readiness: "Configuring",
+		},
+		applied_waiting_readiness: {
+			code: "LLM_APPLIED_READINESS_PENDING",
+			message: "Your AI connection is saved. Jarvis is finishing setup.",
+			applied_version: 12,
+			chat_readiness: "Configuring",
+			chat_readiness_reason: "Applying the ERP plugin environment.",
+		},
+		ready: {
+			code: "LLM_READY",
+			message: "Ready.",
+			applied_version: 12,
+			chat_readiness: "Ready",
+			retryable: false, // _retryable is code!==REJECTED, but ready is terminal-success
+		},
+		failed: {
+			// Transient failure — the admin projects this as RETRYABLE.
+			code: "LLM_APPLY_FAILED",
+			message: "We couldn't apply your AI connection.",
+			chat_readiness: "Provisioning",
+			retryable: true,
+		},
+		rejected: {
+			// Permanent — the request itself is invalid (bad key / rejected spec).
+			state: "failed",
+			code: "LLM_APPLY_REJECTED",
+			message: "That AI configuration was rejected. Check the key and try again.",
+			retryable: false,
+		},
+		blocked_oauth: {
+			state: "failed",
+			code: "LLM_APPLY_BLOCKED_OAUTH",
+			message:
+				"We couldn't finish connecting your subscription. Please reconnect the account.",
+			retryable: true,
+		},
+		superseded: {
+			code: "SUPERSEDED_NEWER_SAVE",
+			message: "A newer AI connection change replaced this one.",
+		},
+		superseded_authority: {
+			state: "superseded",
+			code: "SUPERSEDED_AUTHORITY_CHANGED",
+			message: "Your workspace assignment changed; please retry from the current setup.",
+		},
+	};
+	return { ...base, ...(byState[state] || {}), ...over };
+}
+
+/** What save_llm_pool returns the instant the desired intent is persisted. */
+export const saveDescriptor = statusOf("pending", { operation_id: OP_ID });
+
+/** A RateLimitExceeded refusal on save (429): thrown, carries retry_after_seconds. */
+export function rateLimitRefusal(retryAfterSeconds = 30) {
+	return {
+		code: "RateLimitExceeded",
+		status: 429,
+		retry_after_seconds: retryAfterSeconds,
+		message: "Too many changes. Try again shortly.",
+	};
+}
+
+export const OP_IDS = { OP_ID, TENANT, GEN };

--- a/frontend/src/lib/llmOperation.js
+++ b/frontend/src/lib/llmOperation.js
@@ -1,0 +1,346 @@
+// The ONE client-side follower of a durable LLM-apply operation (plan-05 D2,
+// review §8.4/§8.5). This is the integration seam the "one awaited controller"
+// (saveConnect) is built on: it owns the single poll loop for exactly one
+// operation, projects each admin status into a UI phase, and enforces the
+// exactly-once terminal handoff. Kept framework-agnostic (timers, visibility,
+// storage and the poll call are all injected) so it is unit-testable without
+// mounting a component, and so the OnboardingView wiring stays a thin shell over
+// it - see the header of createOperationController.
+//
+// The admin half (jarvis_admin_v2.fleet.apply_operation) owns the operation's
+// truth; this module never invents state. The frozen 12-key status shape it reads
+// is documented in ./__fixtures__/llmOperation.fixtures.js.
+
+// -- contract vocabulary (verbatim from the admin half) -----------------------
+
+export const OP_STATE = Object.freeze({
+	PENDING: "pending",
+	APPLYING: "applying",
+	APPLIED_WAITING_READINESS: "applied_waiting_readiness",
+	READY: "ready",
+	FAILED: "failed",
+	SUPERSEDED: "superseded",
+});
+
+const TERMINAL = new Set([OP_STATE.READY, OP_STATE.FAILED, OP_STATE.SUPERSEDED]);
+
+export const OP_CODE = Object.freeze({
+	PENDING: "LLM_APPLY_PENDING",
+	APPLYING: "LLM_APPLYING",
+	APPLIED_READINESS_PENDING: "LLM_APPLIED_READINESS_PENDING",
+	READY: "LLM_READY",
+	REJECTED: "LLM_APPLY_REJECTED", // permanent
+	FAILED: "LLM_APPLY_FAILED", // transient
+	BLOCKED_OAUTH: "LLM_APPLY_BLOCKED_OAUTH",
+	SUPERSEDED_NEWER: "SUPERSEDED_NEWER_SAVE",
+	SUPERSEDED_AUTHORITY: "SUPERSEDED_AUTHORITY_CHANGED",
+});
+
+/** True once the operation has reached a durable terminal state. */
+export function isTerminal(state) {
+	return TERMINAL.has(state);
+}
+
+// -- UI projection ------------------------------------------------------------
+//
+// The phases the CTA/copy render around. Distinct from the raw admin state so the
+// view never branches on wire strings and `applied_waiting_readiness` is a
+// first-class honest state ("saved, finishing setup"), not a generic spinner
+// (review P1-03). "failed" splits by retryability: a transient failure or a
+// rate-limit offers a bounded retry OF THE SAME OPERATION; a permanent rejection
+// (LLM_APPLY_REJECTED) sends the customer back to fix their input. `superseded`
+// means a newer save / an authority change replaced this operation, so the answer
+// is to re-follow the current one, never to keep polling this dead id.
+
+export const OP_PHASE = Object.freeze({
+	WORKING: "working", // pending / applying — keep polling, show progress
+	FINISHING: "finishing", // applied_waiting_readiness — saved, readiness converging
+	READY: "ready", // terminal success — navigate exactly once
+	RETRY: "retry", // transient failure / rate-limit — bounded retry of this op
+	REJECTED: "rejected", // permanent — the input is the problem, edit & re-save
+	SUPERSEDED: "superseded", // a newer save / authority change owns the truth now
+});
+
+/**
+ * Pure projection of an admin status into a UI descriptor. Never navigates, never
+ * mutates. The controller and the view both read this so they cannot disagree.
+ *
+ * @param {object} op - a §8.4 status object (12 keys), or a falsy value.
+ * @returns {{phase:string, terminal:boolean, canNavigate:boolean, retryable:boolean,
+ *            retryAfterSeconds:number, message:string, chatReadiness:(string|null),
+ *            chatReadinessReason:string, code:string, state:string}}
+ */
+export function classifyOperation(op) {
+	const state = (op && op.state) || "";
+	const code = (op && op.code) || "";
+	const message = (op && op.message) || "";
+	const chatReadiness = op ? op.chat_readiness ?? null : null;
+	const chatReadinessReason = (op && op.chat_readiness_reason) || "";
+	const retryAfterSeconds = Math.max(0, Number((op && op.retry_after_seconds) || 0));
+
+	let phase = OP_PHASE.WORKING;
+	if (state === OP_STATE.READY) phase = OP_PHASE.READY;
+	else if (state === OP_STATE.APPLIED_WAITING_READINESS) phase = OP_PHASE.FINISHING;
+	else if (state === OP_STATE.SUPERSEDED) phase = OP_PHASE.SUPERSEDED;
+	else if (state === OP_STATE.FAILED) {
+		// The admin marks a permanent rejection non-retryable (code === REJECTED);
+		// everything else failed transiently and may be retried as the SAME op.
+		phase = code === OP_CODE.REJECTED ? OP_PHASE.REJECTED : OP_PHASE.RETRY;
+	}
+
+	return {
+		phase,
+		state,
+		code,
+		terminal: isTerminal(state),
+		// Exactly-once navigation is only ever offered on a genuine READY.
+		canNavigate: state === OP_STATE.READY,
+		// Whether the customer can recover by retrying THIS operation (no new desired
+		// version). A permanent rejection and a superseded op are not retryable here.
+		retryable:
+			phase === OP_PHASE.RETRY || phase === OP_PHASE.FINISHING || phase === OP_PHASE.WORKING,
+		retryAfterSeconds,
+		message,
+		chatReadiness,
+		chatReadinessReason,
+	};
+}
+
+// -- active-operation persistence (reload resume) -----------------------------
+//
+// So a reload mid-apply resumes the SAME operation instead of showing an editable
+// form over a running apply (review P1-05) or starting a second poller. Only the
+// opaque operation id is persisted - never a credential, never a token.
+
+const STORE_KEY = "jarvis.llm_apply.operation_id";
+
+/** Wrap a Storage (sessionStorage by default; injectable for tests/SSR-safety). */
+export function operationStore(storage) {
+	const s = storage || (typeof sessionStorage !== "undefined" ? sessionStorage : null);
+	return {
+		remember(operationId) {
+			try {
+				if (operationId) s && s.setItem(STORE_KEY, String(operationId));
+			} catch {
+				/* private-mode / quota: resume is best-effort, never fatal */
+			}
+		},
+		recall() {
+			try {
+				return (s && s.getItem(STORE_KEY)) || "";
+			} catch {
+				return "";
+			}
+		},
+		forget() {
+			try {
+				s && s.removeItem(STORE_KEY);
+			} catch {
+				/* ignore */
+			}
+		},
+	};
+}
+
+// -- the single operation controller ------------------------------------------
+
+const DEFAULTS = {
+	baseDelayMs: 1500,
+	maxDelayMs: 8000,
+	jitterMs: 400,
+	// Hard ceiling so a stuck operation cannot poll forever. On expiry the last
+	// status is returned with a synthetic `timedOut` flag; the caller renders a
+	// support state and never silently declares ready.
+	deadlineMs: 5 * 60 * 1000,
+};
+
+/**
+ * Create the ONE observer for LLM-apply operations. A second follow() supersedes
+ * the first (its timers are cancelled and its promise rejects with {aborted:true})
+ * so there is never more than one live poll loop or more than one terminal handler
+ * - the C05-4 three-poller problem and the duplicate-navigation problem both close
+ * here rather than in the view.
+ *
+ * Injected seams (all optional except poll):
+ *   poll(operationId)  -> Promise<status>   (get_llm_apply_operation)
+ *   onUpdate(uiDescriptor, rawStatus)       side-effect-free render hook
+ *   now()              -> ms                 (Date.now)
+ *   setTimer/clearTimer                       (setTimeout/clearTimeout)
+ *   isVisible()        -> bool               document visibility (pause when hidden)
+ *   onVisible(cb)      -> unsubscribe         visibility-change subscription
+ *   store                                     operationStore() (reload resume)
+ *   random()           -> [0,1)              jitter source (seedable for tests)
+ */
+export function createOperationController(opts) {
+	const {
+		poll,
+		onUpdate = () => {},
+		now = () => Date.now(),
+		setTimer = (fn, ms) => setTimeout(fn, ms),
+		clearTimer = (h) => clearTimeout(h),
+		isVisible = () => true,
+		onVisible = () => () => {},
+		store = operationStore(),
+		random = Math.random,
+		config = {},
+	} = opts || {};
+	if (typeof poll !== "function") throw new Error("createOperationController requires a poll()");
+	const cfg = { ...DEFAULTS, ...config };
+
+	// Monotonic generation: every follow()/abort() bumps it, so a timer or an
+	// in-flight poll that resolves after supersession can detect it is stale and
+	// refuse to touch the newer run's state (review R5 unmount-abort requirement).
+	let generation = 0;
+	let timer = null;
+	let unsubscribeVisible = null;
+	let deadlineAt = 0;
+	// The active run's reject, so a supersede/abort ends its promise with
+	// {aborted:true} rather than leaving the caller's finishing state hanging.
+	let activeReject = null;
+
+	function _clear() {
+		if (timer) {
+			clearTimer(timer);
+			timer = null;
+		}
+		if (unsubscribeVisible) {
+			unsubscribeVisible();
+			unsubscribeVisible = null;
+		}
+	}
+
+	function abort() {
+		generation += 1; // invalidate any in-flight poll/timer
+		_clear();
+		if (activeReject) {
+			const rej = activeReject;
+			activeReject = null;
+			rej({ aborted: true });
+		}
+	}
+
+	/**
+	 * Follow exactly one operation to a terminal state.
+	 * @param {object|string} descriptorOrId - the save descriptor (§8.4) or a bare
+	 *   operation id (used on reload resume). A descriptor is rendered immediately
+	 *   so the UI never flashes empty before the first poll.
+	 * @returns {Promise<object>} resolves with the terminal status (a `timedOut`
+	 *   flag is set if the deadline was hit); rejects {aborted:true} if superseded.
+	 */
+	function follow(descriptorOrId) {
+		abort(); // supersede any prior run - ONE observer
+		const myGen = generation;
+		const descriptor = typeof descriptorOrId === "string" ? null : descriptorOrId || null;
+		const operationId = descriptor ? descriptor.operation_id : String(descriptorOrId || "");
+		if (!operationId) return Promise.reject(new Error("follow() needs an operation id"));
+
+		store.remember(operationId);
+		deadlineAt = now() + cfg.deadlineMs;
+		let attempt = 0;
+
+		// Seed the UI from the save descriptor before the first network poll.
+		if (descriptor) onUpdate(classifyOperation(descriptor), descriptor);
+
+		return new Promise((resolve, reject) => {
+			activeReject = reject;
+			const stale = () => myGen !== generation;
+
+			const settleTerminal = (status) => {
+				_clear();
+				store.forget();
+				if (myGen === generation) activeReject = null;
+				resolve(status);
+			};
+
+			const scheduleNext = (delayMs) => {
+				if (stale()) return;
+				timer = setTimer(tick, Math.max(0, delayMs));
+			};
+
+			const backoff = () => {
+				const capped = Math.min(cfg.baseDelayMs * 2 ** attempt, cfg.maxDelayMs);
+				return capped + Math.floor(random() * cfg.jitterMs);
+			};
+
+			const tick = async () => {
+				if (stale()) return;
+				if (!isVisible()) {
+					// Paused: resume on the next visibility change rather than burning polls
+					// against a backgrounded tab. Exactly one resume subscription at a time.
+					if (!unsubscribeVisible) {
+						unsubscribeVisible = onVisible(() => {
+							if (stale()) return;
+							if (unsubscribeVisible) {
+								unsubscribeVisible();
+								unsubscribeVisible = null;
+							}
+							scheduleNext(0);
+						});
+					}
+					return;
+				}
+				if (now() >= deadlineAt) {
+					if (stale()) return;
+					const timedOut = {
+						operation_id: operationId,
+						state: "",
+						code: "",
+						timedOut: true,
+					};
+					onUpdate(
+						{ ...classifyOperation(null), phase: OP_PHASE.RETRY, timedOut: true },
+						timedOut
+					);
+					settleTerminal(timedOut);
+					return;
+				}
+
+				let status;
+				try {
+					status = await poll(operationId);
+				} catch (err) {
+					if (stale()) return;
+					// A transport error on the READ is not a verdict: keep polling with
+					// backoff until the deadline. The status read never spends the mutation
+					// bucket, so re-reading is safe.
+					attempt += 1;
+					scheduleNext(backoff());
+					onUpdate(
+						{ ...classifyOperation(null), phase: OP_PHASE.WORKING, pollError: true },
+						null
+					);
+					void err;
+					return;
+				}
+				if (stale()) return;
+
+				const ui = classifyOperation(status);
+				onUpdate(ui, status);
+
+				if (ui.terminal) {
+					settleTerminal(status);
+					return;
+				}
+				// Honour a per-operation cooldown (rate-limit bound to THIS op): wait the
+				// server's retry_after before the next read, never resubmit, never mint a
+				// new desired version.
+				attempt += 1;
+				const wait = ui.retryAfterSeconds > 0 ? ui.retryAfterSeconds * 1000 : backoff();
+				scheduleNext(wait);
+			};
+
+			// First poll immediately. Supersession/abort ends this promise via
+			// abort()'s stored-reject path ({aborted:true}); the stale() guard keeps a
+			// late timer or in-flight poll from touching the newer run's state.
+			scheduleNext(0);
+		});
+	}
+
+	return {
+		follow,
+		abort,
+		get generation() {
+			return generation;
+		},
+	};
+}

--- a/frontend/src/lib/llmOperation.spec.js
+++ b/frontend/src/lib/llmOperation.spec.js
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+	OP_PHASE,
+	OP_STATE,
+	isTerminal,
+	classifyOperation,
+	operationStore,
+	createOperationController,
+} from "./llmOperation.js";
+import { statusOf, saveDescriptor, OP_IDS } from "./__fixtures__/llmOperation.fixtures.js";
+
+// A deterministic virtual clock so the poll loop is fully controllable: setTimer
+// enqueues, advance() fires everything due and flushes the async poll microtasks.
+function fakeClock() {
+	let t = 0;
+	let seq = 0;
+	const q = new Map(); // id -> {due, fn}
+	const api = {
+		now: () => t,
+		setTimer: (fn, ms) => {
+			const id = ++seq;
+			q.set(id, { due: t + Math.max(0, ms || 0), fn });
+			return id;
+		},
+		clearTimer: (id) => q.delete(id),
+		async advance(ms) {
+			const target = t + ms;
+			// Fire due callbacks in time order, flushing promises between each, until
+			// we reach the target time or run out of work.
+			// A generous guard against runaway rescheduling.
+			for (let guard = 0; guard < 10000; guard++) {
+				let next = null;
+				for (const [id, item] of q) {
+					if (item.due <= target && (!next || item.due < next.item.due))
+						next = { id, item };
+				}
+				if (!next) break;
+				q.delete(next.id);
+				t = Math.max(t, next.item.due);
+				next.item.fn();
+				// flush microtasks (the async poll body)
+				await Promise.resolve();
+				await Promise.resolve();
+			}
+			t = target;
+		},
+	};
+	return api;
+}
+
+function memoryStorage() {
+	const m = new Map();
+	return {
+		getItem: (k) => (m.has(k) ? m.get(k) : null),
+		setItem: (k, v) => m.set(k, String(v)),
+		removeItem: (k) => m.delete(k),
+	};
+}
+
+describe("classifyOperation (pure projection)", () => {
+	it("maps working states", () => {
+		expect(classifyOperation(statusOf("pending")).phase).toBe(OP_PHASE.WORKING);
+		expect(classifyOperation(statusOf("applying")).phase).toBe(OP_PHASE.WORKING);
+	});
+
+	it("applied_waiting_readiness is a first-class FINISHING phase, not a spinner", () => {
+		const ui = classifyOperation(statusOf("applied_waiting_readiness"));
+		expect(ui.phase).toBe(OP_PHASE.FINISHING);
+		expect(ui.terminal).toBe(false);
+		expect(ui.canNavigate).toBe(false);
+		expect(ui.chatReadinessReason).toMatch(/plugin/i);
+	});
+
+	it("ready is the only phase that may navigate, and it is terminal", () => {
+		const ui = classifyOperation(statusOf("ready"));
+		expect(ui.phase).toBe(OP_PHASE.READY);
+		expect(ui.terminal).toBe(true);
+		expect(ui.canNavigate).toBe(true);
+	});
+
+	it("a transient failure is RETRY (retryable); a permanent rejection is REJECTED (not)", () => {
+		const transient = classifyOperation(statusOf("failed"));
+		expect(transient.phase).toBe(OP_PHASE.RETRY);
+		expect(transient.retryable).toBe(true);
+		expect(transient.terminal).toBe(true);
+
+		const rejected = classifyOperation(statusOf("rejected"));
+		expect(rejected.phase).toBe(OP_PHASE.REJECTED);
+		expect(rejected.retryable).toBe(false);
+		expect(rejected.canNavigate).toBe(false);
+	});
+
+	it("blocked-oauth is a retryable failure, not a permanent rejection", () => {
+		const ui = classifyOperation(statusOf("blocked_oauth"));
+		expect(ui.phase).toBe(OP_PHASE.RETRY);
+		expect(ui.state).toBe(OP_STATE.FAILED);
+	});
+
+	it("superseded (newer save or authority change) is its own phase, never navigable", () => {
+		expect(classifyOperation(statusOf("superseded")).phase).toBe(OP_PHASE.SUPERSEDED);
+		expect(classifyOperation(statusOf("superseded_authority")).phase).toBe(
+			OP_PHASE.SUPERSEDED
+		);
+		expect(classifyOperation(statusOf("superseded")).canNavigate).toBe(false);
+	});
+
+	it("carries the per-operation retry_after for a rate-limited status", () => {
+		const ui = classifyOperation(statusOf("failed", { retry_after_seconds: 30 }));
+		expect(ui.retryAfterSeconds).toBe(30);
+	});
+
+	it("a null/absent status never navigates", () => {
+		const ui = classifyOperation(null);
+		expect(ui.canNavigate).toBe(false);
+		expect(ui.terminal).toBe(false);
+	});
+});
+
+describe("isTerminal", () => {
+	it("only ready/failed/superseded are terminal", () => {
+		expect(isTerminal(OP_STATE.READY)).toBe(true);
+		expect(isTerminal(OP_STATE.FAILED)).toBe(true);
+		expect(isTerminal(OP_STATE.SUPERSEDED)).toBe(true);
+		expect(isTerminal(OP_STATE.PENDING)).toBe(false);
+		expect(isTerminal(OP_STATE.APPLYING)).toBe(false);
+		expect(isTerminal(OP_STATE.APPLIED_WAITING_READINESS)).toBe(false);
+	});
+});
+
+describe("operationStore (reload resume)", () => {
+	it("remembers, recalls and forgets the opaque operation id", () => {
+		const s = operationStore(memoryStorage());
+		expect(s.recall()).toBe("");
+		s.remember("llmapply_x");
+		expect(s.recall()).toBe("llmapply_x");
+		s.forget();
+		expect(s.recall()).toBe("");
+	});
+
+	it("never throws on a hostile storage (private mode / quota)", () => {
+		const throwing = {
+			getItem: () => {
+				throw new Error("blocked");
+			},
+			setItem: () => {
+				throw new Error("blocked");
+			},
+			removeItem: () => {
+				throw new Error("blocked");
+			},
+		};
+		const s = operationStore(throwing);
+		expect(() => s.remember("x")).not.toThrow();
+		expect(s.recall()).toBe("");
+		expect(() => s.forget()).not.toThrow();
+	});
+});
+
+describe("createOperationController (the ONE observer)", () => {
+	function build(pollSeq, overrides = {}) {
+		const clock = fakeClock();
+		const updates = [];
+		const store = operationStore(memoryStorage());
+		let i = 0;
+		const poll =
+			overrides.poll || vi.fn(async () => pollSeq[Math.min(i++, pollSeq.length - 1)]);
+		const controller = createOperationController({
+			poll,
+			onUpdate: (ui, raw) => updates.push({ ui, raw }),
+			now: clock.now,
+			setTimer: clock.setTimer,
+			clearTimer: clock.clearTimer,
+			isVisible: overrides.isVisible || (() => true),
+			onVisible: overrides.onVisible || (() => () => {}),
+			store,
+			random: () => 0, // no jitter, deterministic delays
+			config: overrides.config,
+		});
+		return { clock, updates, store, poll, controller };
+	}
+
+	it("follows pending -> applying -> ready and resolves the terminal status", async () => {
+		const seq = [statusOf("pending"), statusOf("applying"), statusOf("ready")];
+		const { clock, controller, store } = build(seq);
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(30000);
+		const terminal = await p;
+		expect(terminal.state).toBe(OP_STATE.READY);
+		// The active-operation id is forgotten on terminal (nothing to resume).
+		expect(store.recall()).toBe("");
+	});
+
+	it("seeds the UI from the save descriptor before the first poll", async () => {
+		const { clock, updates, controller } = build([statusOf("ready")]);
+		const p = controller.follow(saveDescriptor);
+		// Synchronously, the descriptor has been projected once already.
+		expect(updates[0].ui.phase).toBe(OP_PHASE.WORKING);
+		await clock.advance(5000);
+		await p;
+	});
+
+	it("remembers the operation id while running (reload resume) and follows a bare id", async () => {
+		const { clock, controller, store, poll } = build([
+			statusOf("applying"),
+			statusOf("ready"),
+		]);
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(0); // first poll
+		expect(store.recall()).toBe(OP_IDS.OP_ID);
+		await clock.advance(30000);
+		await p;
+		// A fresh follow by bare id (as a reload would) polls the same operation.
+		const p2 = controller.follow(OP_IDS.OP_ID);
+		await clock.advance(5000);
+		await p2;
+		expect(poll).toHaveBeenCalledWith(OP_IDS.OP_ID);
+	});
+
+	it("honours a per-operation retry_after cooldown before the next read", async () => {
+		// pending (retry_after=10s) then ready. The next poll must wait ~10s, not the
+		// ~1.5s base backoff.
+		const seq = [statusOf("pending", { retry_after_seconds: 10 }), statusOf("ready")];
+		const { clock, controller, poll } = build(seq);
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(0); // first poll -> pending w/ cooldown
+		expect(poll).toHaveBeenCalledTimes(1);
+		await clock.advance(5000); // less than the 10s cooldown
+		expect(poll).toHaveBeenCalledTimes(1); // still waiting
+		await clock.advance(6000); // now past 10s
+		expect(poll).toHaveBeenCalledTimes(2);
+		await p;
+	});
+
+	it("a second follow() supersedes the first: its promise rejects and its polling stops", async () => {
+		// Op-id-aware poll: the old op is always pending, so it can only END by being
+		// superseded - never by reaching a terminal on its own.
+		const poll = vi.fn(async () => statusOf("pending"));
+		const { clock, controller } = build([], { poll });
+		const p1 = controller.follow(saveDescriptor);
+		await clock.advance(0); // first op polled once
+		const callsBefore = poll.mock.calls.filter((c) => c[0] === OP_IDS.OP_ID).length;
+		expect(callsBefore).toBeGreaterThanOrEqual(1);
+		// Supersede with a new operation.
+		const p2 = controller.follow(statusOf("pending", { operation_id: "llmapply_NEW" }));
+		await expect(p1).rejects.toMatchObject({ aborted: true });
+		// The old operation's loop must never poll again after supersession.
+		await clock.advance(30000);
+		expect(poll.mock.calls.filter((c) => c[0] === OP_IDS.OP_ID).length).toBe(callsBefore);
+		// Only the new operation is polled now.
+		expect(poll.mock.calls.some((c) => c[0] === "llmapply_NEW")).toBe(true);
+		controller.abort();
+		await expect(p2).rejects.toMatchObject({ aborted: true });
+	});
+
+	it("a poll transport error is not a verdict: it keeps polling to the deadline", async () => {
+		let n = 0;
+		const poll = vi.fn(async () => {
+			n += 1;
+			if (n < 3) throw new Error("network");
+			return statusOf("ready");
+		});
+		const { clock, controller } = build([], { poll });
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(60000);
+		const terminal = await p;
+		expect(terminal.state).toBe(OP_STATE.READY);
+		expect(poll.mock.calls.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it("stops at the deadline with a timedOut terminal, never declaring ready", async () => {
+		const poll = vi.fn(async () => statusOf("applying")); // never terminal
+		const { clock, controller } = build([], { poll, config: { deadlineMs: 10000 } });
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(60000);
+		const terminal = await p;
+		expect(terminal.timedOut).toBe(true);
+		expect(terminal.state).not.toBe(OP_STATE.READY);
+	});
+
+	it("pauses while hidden and resumes on visibility", async () => {
+		let visible = false;
+		let visCb = null;
+		const poll = vi.fn(async () => statusOf("ready"));
+		const { clock, controller } = build([], {
+			poll,
+			isVisible: () => visible,
+			onVisible: (cb) => {
+				visCb = cb;
+				return () => {
+					visCb = null;
+				};
+			},
+		});
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(30000);
+		expect(poll).not.toHaveBeenCalled(); // hidden -> no polling
+		visible = true;
+		if (visCb) visCb();
+		await clock.advance(5000);
+		expect(poll).toHaveBeenCalled();
+		await p;
+	});
+
+	it("a terminal reached after supersession cannot resolve the newer run", async () => {
+		// Old op resolves ready AFTER a newer follow started; the stale() guard must
+		// stop it touching state and it must not resolve p1 with ready.
+		let release;
+		const gate = new Promise((r) => (release = r));
+		const poll = vi.fn(async (id) => {
+			if (id === OP_IDS.OP_ID) {
+				await gate; // hangs until we release, simulating a slow in-flight read
+				return statusOf("ready");
+			}
+			return statusOf("pending");
+		});
+		const { clock, controller } = build([], { poll });
+		const p1 = controller.follow(saveDescriptor);
+		await clock.advance(0); // kicks off the (hanging) first poll
+		const p2 = controller.follow(statusOf("pending", { operation_id: "llmapply_NEW" }));
+		await expect(p1).rejects.toMatchObject({ aborted: true });
+		release(); // the stale in-flight read now resolves ready
+		await Promise.resolve();
+		await Promise.resolve();
+		// p1 already rejected; it must NOT have resolved ready. Clean up p2.
+		controller.abort();
+		await expect(p2).rejects.toMatchObject({ aborted: true });
+	});
+});

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -722,6 +722,24 @@ def _llm_missing_verdict(settings) -> dict:
 
 
 @frappe.whitelist()
+def get_llm_apply_operation(operation_id: str) -> dict:
+	"""Read-only status of a durable LLM-apply operation (plan-05 D2), for the SPA's
+	single Start-chatting controller to follow one operation to a terminal state.
+
+	A thin System-Manager-gated shim over admin's read-only endpoint (see
+	admin_client.get_llm_apply_operation): it never mutates and never spends the
+	apply rate bucket, so the controller polls it with backoff. The bench holds no
+	operation state of its own - admin owns the operation's truth - so this
+	forwards the opaque id and surfaces admin's §8.4 status verbatim. Errors arrive
+	as clean frappe.throw toasts via the shared _surface helper; the SPA client
+	seam (frontend/src/lib/llmOperation.js) treats a transport failure as
+	"keep polling", not a verdict.
+	"""
+	require_jarvis_admin()
+	return _surface(admin_client.get_llm_apply_operation, operation_id)
+
+
+@frappe.whitelist()
 def get_llm_usage() -> dict:
 	"""Real, curated Bifrost usage for the Monitor tab (System-Manager only,
 	spec 7). Tenants with no Bifrost (proxy_active=0) short-circuit to the empty

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1122,6 +1122,34 @@ def post_update_llm_pool(*, spec: dict, api_keys: dict, oauth_blobs: dict) -> di
 	)
 
 
+def get_llm_apply_operation(operation_id: str, *, timeout_s: int = 8) -> dict:
+	"""Read-only status of a durable LLM-apply operation (plan-05 D2).
+
+	Wraps admin's ``api.tenant.get_llm_apply_operation``, which never mutates and
+	never spends the 20/hour apply bucket, so the SPA may poll it freely. ``_post``
+	unwraps the admin ``data`` envelope, so this returns the §8.4 status dict
+	directly:
+
+	    {operation_id, state, code, message, tenant (opaque), desired_version,
+	     applied_version, tenant_authority_generation, chat_readiness,
+	     chat_readiness_reason, retryable, retry_after_seconds}
+
+	Short default timeout: this is a hot poll on a converging apply, so a slow
+	admin must not stretch the SPA's follow loop past a beat. UnknownOperation
+	surfaces as AdminValidationError (404); a transport error surfaces as
+	AdminUnreachableError, which the client seam treats as "keep polling", not a
+	verdict.
+
+	Raises:
+		AdminAuthError, AdminUnreachableError, AdminValidationError
+	"""
+	return _post(
+		path=_m("api.tenant.get_llm_apply_operation"),
+		body={"operation_id": operation_id},
+		timeout_s=timeout_s,
+	)
+
+
 def post_llm_auth_status() -> dict:
 	"""Ask admin (and via admin, fleet-agent) whether the customer's
 	container actually holds a usable OAuth profile right now.

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -1107,3 +1107,49 @@ class TestBackfillExcludesOauthPushOnly(FrappeTestCase):
 		raw = account._settings_raw(("chat_was_ready_at", account._READY_ANCHOR_FIELD))
 		self.assertTrue(raw.get("chat_was_ready_at"), "a confirmed direct apply is grandfathered")
 		self.assertTrue(raw.get(account._READY_ANCHOR_FIELD), "the grandfathered claim is anchor-bound")
+
+
+class TestGetLlmApplyOperationShim(FrappeTestCase):
+	"""jarvis.account.get_llm_apply_operation — the read-only bench shim the SPA's
+	single Start-chatting controller polls (plan-05 D2). It forwards the opaque
+	operation id to admin and surfaces the §8.4 status verbatim; it is
+	System-Manager-gated and holds no operation state of its own."""
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_forwards_the_operation_id_and_returns_admin_status(self):
+		status = {
+			"operation_id": "llmapply_abc",
+			"state": "applied_waiting_readiness",
+			"code": "LLM_APPLIED_READINESS_PENDING",
+			"message": "finishing setup",
+			"tenant": "deadbeef" * 4,
+			"tenant_authority_generation": 7,
+			"desired_version": 12,
+			"applied_version": 12,
+			"chat_readiness": "Configuring",
+			"chat_readiness_reason": "Applying the ERP plugin environment.",
+			"retryable": True,
+			"retry_after_seconds": 0,
+		}
+		with patch.object(admin_client, "get_llm_apply_operation", return_value=status) as m:
+			out = account.get_llm_apply_operation("llmapply_abc")
+		m.assert_called_once_with("llmapply_abc")
+		self.assertEqual(out, status)
+
+	def test_admin_validation_error_surfaces_as_frappe_throw(self):
+		# e.g. UnknownOperation (404) -> AdminValidationError -> clean toast.
+		with patch.object(
+			admin_client, "get_llm_apply_operation", side_effect=AdminValidationError("no such operation")
+		):
+			with self.assertRaises(frappe.ValidationError) as cm:
+				account.get_llm_apply_operation("llmapply_missing")
+		self.assertIn("no such operation", str(cm.exception))
+
+	def test_is_system_manager_gated_before_any_admin_round_trip(self):
+		frappe.set_user("Guest")
+		with patch.object(admin_client, "get_llm_apply_operation") as m:
+			with self.assertRaises(frappe.PermissionError):
+				account.get_llm_apply_operation("llmapply_abc")
+		m.assert_not_called()


### PR DESCRIPTION
Stacked on #584 (plan-05 D1). The plan-05 D2 integration seam against the landed admin contract (jarvis_admin_v2 `feat/plan05-apply-operation`, PR #193).

## What this is
The framework-agnostic, fully unit-tested foundation for the "one awaited controller" (saveConnect). It owns the single poll loop and the exactly-once terminal handoff, so wiring it into OnboardingView becomes a thin shell, and it stands green standalone until the save-descriptor threading + UI controller land.

- **`frontend/src/lib/llmOperation.js`** — the ONE observer. `createOperationController` polls exactly one operation id; a second `follow()` supersedes the first and rejects its promise (closes the C05-4 three-poller and duplicate-navigation problems). Backoff+jitter with a hard deadline (a timeout is a support state, never a silent ready), visibility-aware pause/resume, per-operation `retry_after` cooldown (no resubmit, no new desired version), transport-error-tolerant reads, reload resume via an opaque `operationStore` (id only — never a token). `classifyOperation` is a pure state→UI-phase projection: `applied_waiting_readiness` is a first-class FINISHING phase (P1-03); `LLM_APPLY_REJECTED` → REJECTED (edit & re-save) vs transient `LLM_APPLY_FAILED`/rate-limit → bounded RETRY of the same op; only a genuine `ready` may navigate.
- **`__fixtures__/llmOperation.fixtures.js`** — the frozen 12-key contract shapes taken verbatim from the admin half, to diff at integration.
- **`llmOperation.spec.js`** — 20 vitest cases (state machine, backoff, cooldown, deadline, visibility, supersession/abort, reload resume, stale-in-flight guard).
- **`account.get_llm_apply_operation`** + **`admin_client.get_llm_apply_operation`** — read-only, System-Manager-gated bench shim over admin's status endpoint (never spends the apply bucket); + `api.js` `getLlmApplyOperation` binding. 3 backend tests.

## Contract fixtures (checked against admin at integration)
`frontend/src/lib/__fixtures__/llmOperation.fixtures.js` mirrors `jarvis_admin_v2.fleet.apply_operation.status` (the 12-key shape) and the wire refusals (CUSTOMER_NOT_PAID/TENANT_AUTHORITY_REPAIR_REQUIRED/IdempotencyKeyConflict/RateLimitExceeded/UnknownOperation).

## Remaining D2 (scoped, not in this PR — see commit body)
`save_llm_pool` returning the operation descriptor (the bench currently pushes the pool asynchronously via a worker; threading the admin-created operation through the synchronous save is an architectural change); the durable encrypted pending-OAuth-capture store (P0-04); the onboarding `singleMode` API-key Test (P0-09); the OnboardingView `saveConnect` wiring that removes `@saved` orchestration + `forceContinue` and calls `forgetReady()`+`router.replace` (P0-08/P1-06).

## Tests
- vitest: 370 pass (support-thread.test.js pre-existing failure untouched); +20 new llmOperation cases.
- node --test widgets/shared: 117 pass.
- `jarvis.tests.test_account`: 71 pass (incl. 3 new shim tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MAPeM77sD3rpQwX98aLRG