### PR TITLE
fix: preserve plain-text newlines in agent-composed HTML (email + comments)

### DIFF
--- a/jarvis/_text.py
+++ b/jarvis/_text.py
@@ -1,0 +1,32 @@
+"""Shared text helpers for turning the agent's composed text into the format a
+destination expects.
+
+The agent composes bodies as PLAIN TEXT with ``\\n`` newlines (persona contract:
+"plain text, \\n newlines, no Markdown"). Several destinations - an email
+Communication's ``content``, a Comment's ``content`` - are HTML fields rendered
+by a mail/timeline client, where whitespace collapses. Written raw, a multi-line
+body arrives as one run-on paragraph. Convert at that boundary with
+``plaintext_to_html``.
+
+Use it ONLY for an HTML-rendered surface. Do NOT run it over a value bound for a
+plain-text storage field (Data / Small Text / a doc field the user edits on a
+card) - there a literal ``<br>`` would be wrong.
+"""
+
+from __future__ import annotations
+
+from frappe.utils import escape_html
+
+
+def plaintext_to_html(text: str | None) -> str:
+	"""Escape ``text`` and turn its ``\\n`` newlines into ``<br>`` so paragraphs
+	and blank lines survive delivery to an HTML surface instead of collapsing
+	into one run-on block.
+
+	Escaping is not optional: a stray ``<`` / ``&`` in plain text - an email
+	address like ``<a@b.com>``, a DocType name like ``<Sales Order>``, an
+	``a < b`` comparison - would otherwise be swallowed by the client as an
+	unknown tag. The ``<br>`` round-trips back to a newline in the plain-text
+	alternative a mail client generates from the HTML.
+	"""
+	return escape_html(text or "").replace("\n", "<br>\n")

--- a/jarvis/tests/test_text.py
+++ b/jarvis/tests/test_text.py
@@ -1,0 +1,36 @@
+"""Unit tests for jarvis._text.plaintext_to_html - the shared plain-text ->
+newline-preserving-HTML conversion applied wherever the agent's composed text
+lands in an HTML-rendered field (email Communication content, Comment content).
+"""
+
+from __future__ import annotations
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis._text import plaintext_to_html
+
+
+class TestPlaintextToHtml(FrappeTestCase):
+	def test_newline_becomes_br(self):
+		self.assertEqual(plaintext_to_html("a\nb"), "a<br>\nb")
+
+	def test_blank_line_survives_as_two_breaks(self):
+		out = plaintext_to_html("Para one.\n\nPara two.")
+		self.assertEqual(out.count("<br>"), 2)
+		self.assertIn("Para one.", out)
+		self.assertIn("Para two.", out)
+
+	def test_html_special_chars_are_escaped(self):
+		# a stray < / & / an <email> must render literally, never as markup
+		out = plaintext_to_html("a < b & c <x@y.com>")
+		self.assertIn("&lt;", out)
+		self.assertIn("&amp;", out)
+		self.assertIn("&lt;x@y.com&gt;", out)
+		self.assertNotIn("<x@y.com>", out)
+
+	def test_empty_and_none_are_safe(self):
+		self.assertEqual(plaintext_to_html(""), "")
+		self.assertEqual(plaintext_to_html(None), "")
+
+	def test_plain_single_line_unchanged(self):
+		self.assertEqual(plaintext_to_html("hello world"), "hello world")

--- a/jarvis/tests/test_tier3_desk_actions.py
+++ b/jarvis/tests/test_tier3_desk_actions.py
@@ -217,6 +217,22 @@ class TestAddComment(FrappeTestCase):
 		)
 		self.assertEqual(out["comment_name"], "Comment-001")
 
+	def test_plain_text_newlines_become_html_breaks(self):
+		# Comment.content is an HTML field, so the agent's \n newlines must
+		# become <br> or a multi-line note collapses to one line - and a stray
+		# <a@b.com> must be escaped, not eaten by the timeline as a tag.
+		fake_comment = MagicMock()
+		fake_comment.name = "Comment-002"
+		with (
+			_all_exist(),
+			patch("frappe.desk.form.utils.add_comment", return_value=fake_comment) as ac,
+			patch("frappe.db.get_value", return_value="Admin User"),
+		):
+			add_comment("User", "test@example.com", "Line one.\n\nLine two. <a@b.com>")
+		sent = ac.call_args.kwargs["content"]
+		self.assertIn("<br>", sent)
+		self.assertIn("&lt;a@b.com&gt;", sent)
+
 
 class TestUpdateComment(FrappeTestCase):
 	def test_rejects_empty(self):
@@ -239,6 +255,17 @@ class TestUpdateComment(FrappeTestCase):
 			out = update_comment("Comment-001", "new body")
 		uc.assert_called_once()
 		self.assertEqual(out, {"comment_name": "Comment-001", "content": "new body"})
+
+	def test_plain_text_newlines_become_html_breaks(self):
+		# Same HTML-field conversion as add_comment; the returned envelope keeps
+		# the raw text, only the value written to the Comment is converted.
+		with (
+			_all_exist(),
+			patch("frappe.desk.form.utils.update_comment") as uc,
+		):
+			out = update_comment("Comment-001", "Line one.\n\nLine two.")
+		self.assertIn("<br>", uc.call_args.kwargs["content"])
+		self.assertEqual(out["content"], "Line one.\n\nLine two.")
 
 
 # ---------------------------------------------------------------------

--- a/jarvis/tests/test_tier3_desk_actions.py
+++ b/jarvis/tests/test_tier3_desk_actions.py
@@ -92,6 +92,90 @@ class TestSendEmail(FrappeTestCase):
 		self.assertEqual(out["communication_name"], "COMM-X-001")
 		self.assertEqual(out["subject"], "Hello")
 
+	def test_plain_text_body_becomes_newline_preserving_html(self):
+		# The agent composes a plain-text body with \n newlines (persona:
+		# "plain text, \n newlines, no Markdown"), but Communication.content is
+		# HTML - so without conversion every paragraph collapses into one
+		# run-on block on delivery. The tool must turn newlines into <br>.
+		with (
+			_all_exist(),
+			patch(
+				"frappe.core.doctype.communication.email.make",
+				return_value={"name": "C"},
+			) as mk,
+		):
+			send_email("to@x.com", "Subj", "Para one.\n\nPara two.", "User", "x")
+		sent = mk.call_args.kwargs["content"]
+		self.assertIn("<br>", sent)
+		self.assertIn("Para one.", sent)
+		self.assertIn("Para two.", sent)
+		# the blank line between paragraphs survives as two breaks
+		self.assertGreaterEqual(sent.count("<br>"), 2)
+
+	def test_plain_text_html_special_chars_are_escaped(self):
+		# Plain text is escaped before newline->br so a stray < or & can't
+		# break the HTML body or inject markup.
+		with (
+			_all_exist(),
+			patch(
+				"frappe.core.doctype.communication.email.make",
+				return_value={"name": "C"},
+			) as mk,
+		):
+			send_email("to@x.com", "Subj", "a < b & c", "User", "x")
+		sent = mk.call_args.kwargs["content"]
+		self.assertIn("&lt;", sent)
+		self.assertIn("&amp;", sent)
+
+	def test_html_like_content_is_escaped_not_rendered(self):
+		# The contract is plain text: anything tag-shaped is escaped so it shows
+		# literally rather than being interpreted (or eaten) as HTML.
+		with (
+			_all_exist(),
+			patch(
+				"frappe.core.doctype.communication.email.make",
+				return_value={"name": "C"},
+			) as mk,
+		):
+			send_email("to@x.com", "Subj", "<p>Hi</p>", "User", "x")
+		self.assertEqual(mk.call_args.kwargs["content"], "&lt;p&gt;Hi&lt;/p&gt;")
+
+	def test_angle_bracketed_text_survives(self):
+		# The regression that pushed us off an is_html guard: an email address
+		# or doctype name in angle brackets must NOT vanish as an unknown tag.
+		with (
+			_all_exist(),
+			patch(
+				"frappe.core.doctype.communication.email.make",
+				return_value={"name": "C"},
+			) as mk,
+		):
+			send_email("to@x.com", "Subj", "Reach me at <a@b.com>", "User", "x")
+		self.assertIn("&lt;a@b.com&gt;", mk.call_args.kwargs["content"])
+
+	def test_batch_messages_also_convert_newlines(self):
+		# The batch path routes through _send_one, so it gets the same
+		# conversion - lock it so a refactor can't skip it.
+		with (
+			_all_exist(),
+			patch(
+				"frappe.core.doctype.communication.email.make",
+				return_value={"name": "C"},
+			) as mk,
+		):
+			send_email(
+				messages=[
+					{
+						"recipients": "to@x.com",
+						"subject": "S",
+						"content": "Line one.\n\nLine two.",
+						"doctype": "User",
+						"name": "x",
+					}
+				]
+			)
+		self.assertIn("<br>", mk.call_args.kwargs["content"])
+
 
 # ---------------------------------------------------------------------
 # add_comment / update_comment

--- a/jarvis/tools/add_comment.py
+++ b/jarvis/tools/add_comment.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import frappe
 
+from jarvis._text import plaintext_to_html
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools import desk_action
 from jarvis.tools._bulk import run_atomic_batch
@@ -60,7 +61,9 @@ def _add_comment_one(doctype: str, name: str, content: str) -> str | None:
 	comment = _ac(
 		reference_doctype=doctype,
 		reference_name=name,
-		content=content,
+		# Comment.content is an HTML field; the agent writes plain text with \n
+		# newlines, so convert or the note collapses to one line (jarvis._text).
+		content=plaintext_to_html(content),
 		comment_email=session_user,
 		comment_by=user_full_name,
 	)

--- a/jarvis/tools/send_email.py
+++ b/jarvis/tools/send_email.py
@@ -28,8 +28,8 @@ Two shapes:
 from __future__ import annotations
 
 import frappe
-from frappe.utils import escape_html
 
+from jarvis._text import plaintext_to_html
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools import require_doctype_and_name
 from jarvis.tools._bulk import run_atomic_batch
@@ -104,20 +104,14 @@ def _send_one(
 
 	from frappe.core.doctype.communication.email import make as _make
 
-	# Communication.content is HTML, but the agent composes a PLAIN-TEXT body
-	# with \n newlines (persona: "plain text, \n newlines, no Markdown"). Escape
-	# it and turn newlines into <br> so paragraphs survive delivery instead of
-	# collapsing into one run-on block - and so a stray `<`/`&` (an email address
-	# like <a@b.com>, a doctype name like <Sales Order>, an "a < b" comparison)
-	# renders literally instead of being swallowed by the mail client as a tag.
-	# Always escape: the contract is plain text, and no caller passes real HTML.
-	body = escape_html(content).replace("\n", "<br>\n")
-
+	# Communication.content is HTML; the agent composes plain text with \n
+	# newlines, so convert or every paragraph collapses into one run-on block on
+	# delivery. Shared with the other HTML surfaces - see jarvis._text.
 	result = _make(
 		doctype=doctype,
 		name=name,
 		subject=subject,
-		content=body,
+		content=plaintext_to_html(content),
 		sent_or_received="Sent",
 		recipients=recipients,
 		cc=cc,

--- a/jarvis/tools/send_email.py
+++ b/jarvis/tools/send_email.py
@@ -28,6 +28,7 @@ Two shapes:
 from __future__ import annotations
 
 import frappe
+from frappe.utils import escape_html
 
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools import require_doctype_and_name
@@ -103,11 +104,20 @@ def _send_one(
 
 	from frappe.core.doctype.communication.email import make as _make
 
+	# Communication.content is HTML, but the agent composes a PLAIN-TEXT body
+	# with \n newlines (persona: "plain text, \n newlines, no Markdown"). Escape
+	# it and turn newlines into <br> so paragraphs survive delivery instead of
+	# collapsing into one run-on block - and so a stray `<`/`&` (an email address
+	# like <a@b.com>, a doctype name like <Sales Order>, an "a < b" comparison)
+	# renders literally instead of being swallowed by the mail client as a tag.
+	# Always escape: the contract is plain text, and no caller passes real HTML.
+	body = escape_html(content).replace("\n", "<br>\n")
+
 	result = _make(
 		doctype=doctype,
 		name=name,
 		subject=subject,
-		content=content,
+		content=body,
 		sent_or_received="Sent",
 		recipients=recipients,
 		cc=cc,

--- a/jarvis/tools/update_comment.py
+++ b/jarvis/tools/update_comment.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import frappe
 
+from jarvis._text import plaintext_to_html
 from jarvis.exceptions import InvalidArgumentError
 
 
@@ -27,5 +28,7 @@ def update_comment(name: str, content: str) -> dict:
 
 	from frappe.desk.form.utils import update_comment as _uc
 
-	_uc(name=name, content=content)
+	# Comment.content is an HTML field; convert the agent's plain text so \n
+	# newlines survive instead of collapsing to one line (jarvis._text).
+	_uc(name=name, content=plaintext_to_html(content))
 	return {"comment_name": name, "content": content}


### PR DESCRIPTION
## Bug

Jarvis emails arrived as one run-on paragraph — the composed layout (blank lines between paragraphs) collapsed on delivery. Same latent bug on document **comments**.

## Root cause

The agent composes bodies as **plain text with `\n` newlines** (persona: "plain text, `\n` newlines, no Markdown"), but several destinations are **HTML** fields where whitespace collapses:
- `send_email` → `Communication.content` (HTML)
- `add_comment` / `update_comment` → `Comment.content` (an "HTML Editor" field, rendered raw in the timeline)

Written raw, a multi-line body renders as one line.

## Fix — one shared helper

Extract the conversion into **`jarvis._text.plaintext_to_html`** and apply it at every surface where the agent's plain text lands in a Frappe HTML field:

```python
def plaintext_to_html(text): return escape_html(text or "").replace("\n", "<br>\n")
```

- `send_email` — now via the helper (was an inline conversion).
- `add_comment` / `update_comment` — same collapse bug, now fixed. Both keep the **raw** text in their returned envelope; only the value written to the HTML field is converted.
- **Always escape** (no `is_html` guard): a stray `<`/`&` in plain text — an email address `<a@b.com>`, a doctype name `<Sales Order>` — would otherwise be silently eaten by the client as an unknown tag. The `<br>` round-trips to a newline in the plain-text alternative.

## Deliberately out of scope
- **Support `create_ticket` / `reply`** — the backend is **shared** with the support SPA, which already sends HTML via its own `plainToHtml`; converting there would **double-escape** the UI's body. Needs its own agent-path insertion point — flagged as a follow-up.
- **Plain-text doc fields** — a literal `<br>` would corrupt stored data.
- **Chat responses** — a separate Markdown pipeline that already formats.

## Tests (TDD, on `jarvis.test`)
- `jarvis._text` unit tests (newline→`<br>`, blank-line, escaping incl. `<email>`, empty/None) — 5/5.
- `send_email`: newline, blank-line, escaping, HTML-like shown literally, **`<a@b.com>` survives**, batch path — 6 cases.
- `add_comment` / `update_comment`: newline+escape converted, envelope keeps raw text.
- Full `test_tier3_desk_actions` 35/35 + `test_text` 5/5 green.

## Companion
Plugin PR (jarvis-openclaw-plugin #65) updates the `send_email` schema wording from "HTML is supported" to "plain text, line breaks preserved."

🤖 Generated with [Claude Code](https://claude.com/claude-code)