### PR TITLE
plan-09 WS8 (bench): billing checkout cutover + tenant-origin SDK purge

### DIFF
--- a/frontend/src/onboarding/noSdkImports.test.js
+++ b/frontend/src/onboarding/noSdkImports.test.js
@@ -106,7 +106,12 @@ test("the import detector flags a real import but not a comment mention", () => 
 // Every .vue/.js under src/pages/billing - BillingPage and its components.
 function billingFiles() {
 	return readdirSync(BILLING)
-		.filter((f) => (f.endsWith(".vue") || f.endsWith(".js")) && !f.endsWith(".test.js") && !f.endsWith(".spec.js"))
+		.filter(
+			(f) =>
+				(f.endsWith(".vue") || f.endsWith(".js")) &&
+				!f.endsWith(".test.js") &&
+				!f.endsWith(".spec.js")
+		)
 		.map((f) => join(BILLING, f));
 }
 


### PR DESCRIPTION
Stacked on `feat/plan09-bench-cutover` (WS7). Bench half of plan-09 WS8 — BillingPage moves to the admin-hosted checkout and the tenant-origin gateway SDK code is deleted.

Pairs with admin PR **Aerele-RnD/jarvis-admin-v2#196** (the token-emitting side).

## What changed
- **`pages/billing/BillingPage.vue`** — a payable action's response is read with onboarding's own `effectiveCode`. `PAYMENT_PAGE_REDIRECT` builds the URL via **`payPageUrl`** (imported from `@/onboarding/paymentMachine`, gated on the bench's OWN attested origin) and **top-level navigates same-tab** (`window.location.assign`) — the exact mechanism `usePaymentFlow.navigateToPay` uses. **No fallback**: a token with no attested origin, or a pre-cutover admin's raw handles (`CLIENT_UPGRADE_REQUIRED`), fails the action **closed** with honest copy — never a gateway SDK on this origin. `pageshow`/bfcache return clears the copy-moment overlay and re-reads server truth.
- **`account.py`** (`start_upgrade`/`reauthorize_autopay`/`start_downgrade`/`cancel_scheduled_downgrade`) + **`onboarding.py`** (`renew`) — wrap the admin response in `onboarding_contract.augment_pay_page` so a token answer carries the bench's own `pay_origin` + `pay_origin_attested` (behaviour-neutral on a non-token answer).
- **DELETED** `lib/useRazorpay.js`, `lib/useCashfree.js`, `lib/billingCheckout.js` (+ their specs). `onboardingCheckout.js` was already removed by WS7. Repo-wide grep proves no live importer of any loader remains (only a prose comment in OnboardingView mentions the old names).
- **`onboarding/noSdkImports.test.js`** — extended to cover billing: no billing module imports a gateway SDK opener; the three loaders no longer exist; no source module loads a gateway SDK by URL. This is the no-fallback guarantee **by construction** for the whole app. Mutation-checked (inject a forbidden import / recreate a loader → RED).

## Preserved (necessity rule)
`www/jarvis_pay_return.py` + the `/jarvis-pay-return` route — pre-cutover Cashfree mandates POST there for their mandate lifetime (immutable `return_url`); WS7 already commented it. Untouched.

## Tests (local)
- `node --test src/onboarding/noSdkImports.test.js` — **6/6 pass** (3 WS7 + 3 new billing), mutation-checked RED-then-GREEN.
- `npx vitest run` — **348/349 pass**; the one failure (`tests/support-extraction/support-thread.test.js`) fails **identically on the base** `c23d6476` (pre-existing, unrelated to payments). `ruff` (pinned 0.14.10) clean; pre-commit passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)