### PR TITLE
Mini-chat & PWA: resizable window, reliable streaming, and rich-content handling

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -12,35 +12,60 @@
 		:aria-label="`${brandName} chat`"
 		@keydown.esc.stop="$emit('close')"
 	>
-		<div class="jvp-panel" :class="{ 'jvp-panel--dark': isDark }" ref="panelEl" tabindex="-1">
-			<!-- Resize grip. Sits on the corner that faces away from the FAB (the
-			     panel is anchored at its FAB-side bottom corner and grows up/out),
-			     so a drag always enlarges into the page. Widget.vue persists it. -->
-			<div
-				v-if="layout"
-				class="jvp-resize"
-				:class="[
-					layout.side === 'left' ? 'jvp-resize--tl' : 'jvp-resize--tr',
-					{ 'jvp-resize--active': resizing },
-				]"
-				role="button"
-				tabindex="0"
-				aria-label="Resize chat window. Drag, or use arrow keys."
-				title="Drag to resize"
-				@pointerdown="onResizeDown"
-				@keydown="onResizeKey"
-			>
-				<svg
-					viewBox="0 0 14 14"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="1.5"
-					stroke-linecap="round"
+		<div
+			class="jvp-panel"
+			:class="{ 'jvp-panel--dark': isDark, 'jvp-panel--resizing': resizing }"
+			ref="panelEl"
+			tabindex="-1"
+		>
+			<!-- Resize handles on the three open edges (top / left / right) plus the
+			     two top corners. The panel is anchored at its FAB-side bottom corner,
+			     so a drag grows it toward the open page; each edge shows a grabber so
+			     it reads as resizable. Widget.vue persists the size. -->
+			<template v-if="layout">
+				<div
+					class="jvp-rz jvp-rz--top"
 					aria-hidden="true"
+					title="Drag to resize"
+					@pointerdown="onResizeDown($event, 'y')"
 				>
-					<path d="M3 11 L11 3 M6.5 11 L11 6.5" />
-				</svg>
-			</div>
+					<span class="jvp-rz-grip"></span>
+				</div>
+				<div
+					class="jvp-rz jvp-rz--left"
+					aria-hidden="true"
+					title="Drag to resize"
+					@pointerdown="onResizeDown($event, 'x')"
+				>
+					<span class="jvp-rz-grip"></span>
+				</div>
+				<div
+					class="jvp-rz jvp-rz--right"
+					aria-hidden="true"
+					title="Drag to resize"
+					@pointerdown="onResizeDown($event, 'x')"
+				>
+					<span class="jvp-rz-grip"></span>
+				</div>
+				<div
+					class="jvp-rz jvp-rz--tl"
+					role="button"
+					tabindex="0"
+					aria-label="Resize chat window. Drag, or use arrow keys."
+					title="Drag to resize"
+					@pointerdown="onResizeDown($event, 'both')"
+					@keydown="onResizeKey"
+				></div>
+				<div
+					class="jvp-rz jvp-rz--tr"
+					role="button"
+					tabindex="0"
+					aria-label="Resize chat window. Drag, or use arrow keys."
+					title="Drag to resize"
+					@pointerdown="onResizeDown($event, 'both')"
+					@keydown="onResizeKey"
+				></div>
+			</template>
 			<div class="jvp-head">
 				<div class="jvp-avatar">
 					<img v-if="brandLogoUrl" :src="brandLogoUrl" class="jvp-avatar-img" alt="" />
@@ -142,7 +167,7 @@
 				</button>
 			</div>
 
-			<div class="jvp-body" ref="bodyEl">
+			<div class="jvp-body" ref="bodyEl" @scroll.passive="onBodyScroll">
 				<!-- Never onboarded (readiness === "gate"): the panel cannot possibly
 				     chat, so the whole body - welcome, history, composer below - is
 				     replaced by a compact setup nudge instead of a chat box that can
@@ -532,19 +557,20 @@ const props = defineProps({
 });
 const emit = defineEmits(["close", "open-full", "dismiss-context", "resize", "resize-commit"]);
 
-// ---- Resize: drag the top-outer corner to grow the window. Widget.vue owns
-// the localStorage; this only turns a pointer drag into new-size events. The
-// grip sits on the corner facing away from the FAB (top-left when the panel
-// opens leftward, top-right when it opens rightward), so it always drags "out"
-// into the page. resizeFrom (panel_size.mjs) floors the result at the default,
-// and Widget's panelLayout re-clamps to the viewport every frame. ----
+// ---- Resize: drag any of the three open edges (top / left / right) or a top
+// corner to grow the window. The panel is anchored at its FAB-side bottom corner,
+// so a drag enlarges it toward the open page. Each handle passes a mode ('y' =
+// height only, 'x' = width only, 'both' = a corner); resizeFrom (panel_size.mjs)
+// floors the result at the default and Widget's panelLayout re-clamps it to the
+// viewport, and Widget owns the localStorage. ----
 const resizing = ref(false);
 let resizeStart = null;
 
 function onResizeMove(e) {
 	if (!resizeStart) return;
-	const dx = e.clientX - resizeStart.x;
-	const dy = e.clientY - resizeStart.y;
+	const m = resizeStart.mode;
+	const dx = m === "y" ? 0 : e.clientX - resizeStart.x;
+	const dy = m === "x" ? 0 : e.clientY - resizeStart.y;
 	emit("resize", resizeFrom(resizeStart, resizeStart.side, dx, dy));
 }
 
@@ -558,7 +584,7 @@ function endResize() {
 	emit("resize-commit");
 }
 
-function onResizeDown(e) {
+function onResizeDown(e, mode = "both") {
 	const l = props.layout;
 	if (!l || (e.button != null && e.button !== 0)) return;
 	resizeStart = {
@@ -567,6 +593,7 @@ function onResizeDown(e) {
 		width: l.width,
 		height: l.height,
 		side: l.side,
+		mode,
 	};
 	resizing.value = true;
 	window.addEventListener("pointermove", onResizeMove);
@@ -715,6 +742,25 @@ async function scrollToBottom() {
 	if (bodyEl.value) bodyEl.value.scrollTop = bodyEl.value.scrollHeight;
 }
 
+// Sticky-bottom guard: auto-scroll ONLY while the reader is already at the newest
+// end. Without it, scrollToBottom on every streamed token yanked a long reply back
+// to its tail, so only the last screenful was ever visible in the small panel and
+// the rest could not be read until the turn ended (the full SPA guards the same
+// way via pinnedToBottom). A user scroll updates the flag; a send / load / new
+// chat re-pins so a fresh turn always snaps to the bottom.
+const pinnedToBottom = ref(true);
+function distanceFromBottom() {
+	const el = bodyEl.value;
+	if (!el) return 0;
+	return el.scrollHeight - el.scrollTop - el.clientHeight;
+}
+function onBodyScroll() {
+	pinnedToBottom.value = distanceFromBottom() <= 80;
+}
+function stickToBottom() {
+	if (pinnedToBottom.value) scrollToBottom();
+}
+
 function autoGrow() {
 	const el = textareaEl.value;
 	if (!el) return;
@@ -741,6 +787,7 @@ async function load() {
 		}
 		const conv = await getConversation(convId.value);
 		messages.value = Array.isArray(conv?.messages) ? conv.messages : [];
+		pinnedToBottom.value = true;
 		await scrollToBottom();
 	} catch (e) {
 		loadError.value = "Could not load your conversation.";
@@ -759,6 +806,7 @@ function startNewChat() {
 	stream.value = { ...emptyStream(), fence: stream.value.fence };
 	loadError.value = "";
 	draft.value = "";
+	pinnedToBottom.value = true;
 	nextTick(() => textareaEl.value?.focus());
 }
 
@@ -884,6 +932,7 @@ async function send() {
 	attachments.value = [];
 	await nextTick();
 	autoGrow();
+	pinnedToBottom.value = true; // a fresh turn always snaps to the newest
 	await scrollToBottom();
 
 	try {
@@ -972,7 +1021,7 @@ function onRealtime(payload) {
 	stream.value = next;
 	if (next.live) {
 		sending.value = false;
-		scrollToBottom();
+		stickToBottom();
 	}
 	if (next.error) loadError.value = next.error;
 }
@@ -1067,7 +1116,7 @@ function startPolling() {
 			if (next.length > before && last && last.role === "assistant") {
 				messages.value = msgs;
 				settle();
-				scrollToBottom();
+				stickToBottom();
 			}
 		} catch (e) {
 			/* transient - keep polling */
@@ -1212,59 +1261,95 @@ defineExpose({ load, startNewChat, convId });
 	}
 }
 
-/* ---- resize grip ----
-   A subtle corner handle, revealed on panel hover / keyboard focus. It sits in
-   the outer-top corner padding so it never covers the header's avatar or the
-   action buttons; the diagonal glyph points the way the panel grows. */
-.jvp-resize {
+/* ---- resize handles ----
+   Thin strips along the three open edges (top / left / right) plus two top
+   corners. Each edge carries an always-present grabber so the panel plainly
+   reads as resizable; the strips sit in the panel's border zone, inset from the
+   corners, clear of the header buttons and the composer. */
+.jvp-rz {
 	position: absolute;
-	top: 3px;
 	z-index: 6;
-	width: 16px;
-	height: 16px;
-	display: grid;
-	place-items: center;
-	color: var(--jv-ink-3);
-	opacity: 0;
 	touch-action: none;
 	user-select: none;
 	-webkit-user-select: none;
-	transition: opacity 0.12s ease, color 0.12s ease;
 }
-/* Inset into the header's outer padding so it clears the avatar (left) and the
-   action buttons (right), which start ~15px in from the edge. */
-.jvp-resize--tl {
-	left: 3px;
+.jvp-rz--top {
+	top: 0;
+	left: 14px;
+	right: 14px;
+	height: 8px;
+	cursor: ns-resize;
+	display: grid;
+	place-items: center;
+}
+.jvp-rz--left {
+	top: 14px;
+	bottom: 14px;
+	left: 0;
+	width: 8px;
+	cursor: ew-resize;
+	display: grid;
+	place-items: center;
+}
+.jvp-rz--right {
+	top: 14px;
+	bottom: 14px;
+	right: 0;
+	width: 8px;
+	cursor: ew-resize;
+	display: grid;
+	place-items: center;
+}
+/* The visible cue: a small grabber bar, always faintly shown, brightening to the
+   accent on hover or while dragging. */
+.jvp-rz-grip {
+	display: block;
+	border-radius: 999px;
+	background: var(--jv-ink-3);
+	opacity: 0.4;
+	transition: opacity 0.12s ease, background-color 0.12s ease;
+}
+.jvp-rz--top .jvp-rz-grip {
+	width: 28px;
+	height: 3px;
+}
+.jvp-rz--left .jvp-rz-grip,
+.jvp-rz--right .jvp-rz-grip {
+	width: 3px;
+	height: 28px;
+}
+.jvp-panel:hover .jvp-rz-grip {
+	opacity: 0.55;
+}
+.jvp-rz:hover .jvp-rz-grip,
+.jvp-panel--resizing .jvp-rz-grip {
+	opacity: 1;
+	background: var(--jv-accent);
+}
+/* Corners sit above the edge strips and resize both axes at once. */
+.jvp-rz--tl,
+.jvp-rz--tr {
+	top: 0;
+	width: 15px;
+	height: 15px;
+	z-index: 7;
+}
+.jvp-rz--tl {
+	left: 0;
 	cursor: nwse-resize;
 }
-.jvp-resize--tr {
-	right: 3px;
+.jvp-rz--tr {
+	right: 0;
 	cursor: nesw-resize;
 }
-.jvp-resize svg {
-	width: 11px;
-	height: 11px;
-}
-/* The glyph is drawn pointing to the top-right; mirror it for the left corner. */
-.jvp-resize--tl svg {
-	transform: scaleX(-1);
-}
-.jvp-panel:hover .jvp-resize {
-	opacity: 0.5;
-}
-.jvp-resize:hover,
-.jvp-resize--active {
-	opacity: 1;
-	color: var(--jv-ink-2);
-}
-.jvp-resize:focus-visible {
-	opacity: 1;
+.jvp-rz--tl:focus-visible,
+.jvp-rz--tr:focus-visible {
 	outline: 2px solid var(--jv-accent);
-	outline-offset: -2px;
-	border-radius: 7px;
+	outline-offset: -3px;
+	border-radius: 8px;
 }
 @media (prefers-reduced-motion: reduce) {
-	.jvp-resize {
+	.jvp-rz-grip {
 		transition: none;
 	}
 }

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -728,7 +728,15 @@ function useSuggestion(prompt) {
 	});
 }
 
-const thinking = computed(() => sending.value || (stream.value.busy && !stream.value.live));
+// Typing dots while a turn is in flight but has no visible text yet. The last
+// clause is what makes the panel show a "typing" state for a turn it did NOT
+// start (the same conversation open in the full web chat or another tab):
+// jarvis:event frames are published to the user, so run:start reaches every
+// session and sets `live` with empty text before the first token arrives.
+const thinking = computed(() => {
+	const s = stream.value;
+	return sending.value || (s.busy && !s.live) || (!!s.live && !s.live.text);
+});
 const canSend = computed(
 	() =>
 		(draft.value.trim().length > 0 || attachments.value.length > 0) &&

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -264,7 +264,7 @@
 						</div>
 					</div>
 
-					<div v-else class="jvp-msgs">
+					<div v-else class="jvp-msgs" @click="onTranscriptClick">
 						<template v-for="m in shownMessages" :key="m.name">
 							<div v-if="m.role === 'user'" class="jvp-row jvp-row--user">
 								<div class="jvp-m-user">{{ m.content }}</div>
@@ -620,6 +620,14 @@ function onResizeKey(e) {
 	e.preventDefault();
 	emit("resize", resizeFrom({ width: l.width, height: l.height }, l.side, d[0], d[1]));
 	emit("resize-commit");
+}
+
+// Delegated click for the in-message "open in full chat" chips that
+// panel_markdown swaps in for content this panel can't draw (diagrams, charts,
+// record cards). The chip lives inside a v-html bubble, so it cannot bind a Vue
+// handler directly.
+function onTranscriptClick(e) {
+	if (e.target?.closest?.(".jvp-view-chip")) emit("open-full");
 }
 
 const panelEl = ref(null);
@@ -1717,6 +1725,68 @@ defineExpose({ load, startNewChat, convId });
 	line-height: 1.5;
 	color: var(--jv-ink);
 	overflow-wrap: anywhere;
+}
+
+/* "Open in full chat" chip: stands in for content this panel can't draw
+   (diagram / chart / record cards). Injected inside a v-html bubble, so it is
+   reached with :deep(). */
+.jvp-m-bot :deep(.jvp-view-chip) {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	margin: 4px 0;
+	padding: 9px 11px;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 11px;
+	background: var(--jv-surface);
+	color: var(--jv-ink);
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+	transition: border-color 0.12s ease, background-color 0.12s ease;
+}
+.jvp-m-bot :deep(.jvp-view-chip:hover) {
+	border-color: var(--jv-accent);
+	background: var(--jv-chip-3);
+}
+.jvp-m-bot :deep(.jvp-view-chip:focus-visible) {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 1px;
+}
+.jvp-m-bot :deep(.jvp-view-chip-ic) {
+	width: 26px;
+	height: 26px;
+	flex: 0 0 auto;
+	padding: 5px;
+	border-radius: 8px;
+	background: var(--jv-chip-3);
+	color: var(--jv-accent);
+	box-sizing: border-box;
+}
+.jvp-m-bot :deep(.jvp-view-chip-tx) {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	line-height: 1.3;
+}
+.jvp-m-bot :deep(.jvp-view-chip-t) {
+	font-size: 13.5px;
+	font-weight: 600;
+}
+.jvp-m-bot :deep(.jvp-view-chip-s) {
+	font-size: 12px;
+	color: var(--jv-ink-2);
+}
+.jvp-m-bot :deep(.jvp-view-chip-go) {
+	width: 15px;
+	height: 15px;
+	flex: 0 0 auto;
+	color: var(--jv-ink-3);
+}
+.jvp-m-bot :deep(.jvp-view-chip:hover .jvp-view-chip-go) {
+	color: var(--jv-accent);
 }
 
 /* ---- rendered markdown inside an assistant bubble ----

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -13,6 +13,34 @@
 		@keydown.esc.stop="$emit('close')"
 	>
 		<div class="jvp-panel" :class="{ 'jvp-panel--dark': isDark }" ref="panelEl" tabindex="-1">
+			<!-- Resize grip. Sits on the corner that faces away from the FAB (the
+			     panel is anchored at its FAB-side bottom corner and grows up/out),
+			     so a drag always enlarges into the page. Widget.vue persists it. -->
+			<div
+				v-if="layout"
+				class="jvp-resize"
+				:class="[
+					layout.side === 'left' ? 'jvp-resize--tl' : 'jvp-resize--tr',
+					{ 'jvp-resize--active': resizing },
+				]"
+				role="button"
+				tabindex="0"
+				aria-label="Resize chat window. Drag, or use arrow keys."
+				title="Drag to resize"
+				@pointerdown="onResizeDown"
+				@keydown="onResizeKey"
+			>
+				<svg
+					viewBox="0 0 14 14"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.5"
+					stroke-linecap="round"
+					aria-hidden="true"
+				>
+					<path d="M3 11 L11 3 M6.5 11 L11 6.5" />
+				</svg>
+			</div>
 			<div class="jvp-head">
 				<div class="jvp-avatar">
 					<img v-if="brandLogoUrl" :src="brandLogoUrl" class="jvp-avatar-img" alt="" />
@@ -478,6 +506,7 @@ import { computed, ref, watch, nextTick, onMounted, onBeforeUnmount } from "vue"
 import { contextLabel } from "./desk_context.mjs";
 import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import { renderReply } from "./panel_markdown.mjs";
+import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
 import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
@@ -501,7 +530,70 @@ const props = defineProps({
 	// FAB. The panel is a floating mini window, so it has no fixed home.
 	layout: { type: Object, default: null },
 });
-defineEmits(["close", "open-full", "dismiss-context"]);
+const emit = defineEmits(["close", "open-full", "dismiss-context", "resize", "resize-commit"]);
+
+// ---- Resize: drag the top-outer corner to grow the window. Widget.vue owns
+// the localStorage; this only turns a pointer drag into new-size events. The
+// grip sits on the corner facing away from the FAB (top-left when the panel
+// opens leftward, top-right when it opens rightward), so it always drags "out"
+// into the page. resizeFrom (panel_size.mjs) floors the result at the default,
+// and Widget's panelLayout re-clamps to the viewport every frame. ----
+const resizing = ref(false);
+let resizeStart = null;
+
+function onResizeMove(e) {
+	if (!resizeStart) return;
+	const dx = e.clientX - resizeStart.x;
+	const dy = e.clientY - resizeStart.y;
+	emit("resize", resizeFrom(resizeStart, resizeStart.side, dx, dy));
+}
+
+function endResize() {
+	if (!resizeStart) return;
+	resizeStart = null;
+	resizing.value = false;
+	window.removeEventListener("pointermove", onResizeMove);
+	window.removeEventListener("pointerup", endResize);
+	window.removeEventListener("pointercancel", endResize);
+	emit("resize-commit");
+}
+
+function onResizeDown(e) {
+	const l = props.layout;
+	if (!l || (e.button != null && e.button !== 0)) return;
+	resizeStart = {
+		x: e.clientX,
+		y: e.clientY,
+		width: l.width,
+		height: l.height,
+		side: l.side,
+	};
+	resizing.value = true;
+	window.addEventListener("pointermove", onResizeMove);
+	window.addEventListener("pointerup", endResize);
+	window.addEventListener("pointercancel", endResize);
+	e.preventDefault();
+}
+
+// Keyboard resize: arrows nudge the size by a step, using the SAME grow/shrink
+// semantics as the drag (up = taller, "outward" = wider), floored at the default
+// by resizeFrom. Each press is its own commit so the choice survives immediately.
+function onResizeKey(e) {
+	const l = props.layout;
+	if (!l) return;
+	const STEP = 24;
+	const map = {
+		ArrowUp: [0, -STEP],
+		ArrowDown: [0, STEP],
+		ArrowLeft: [-STEP, 0],
+		ArrowRight: [STEP, 0],
+	};
+	const d = map[e.key];
+	if (!d) return;
+	e.preventDefault();
+	emit("resize", resizeFrom({ width: l.width, height: l.height }, l.side, d[0], d[1]));
+	emit("resize-commit");
+}
 
 const panelEl = ref(null);
 const bodyEl = ref(null);
@@ -1023,6 +1115,10 @@ onBeforeUnmount(() => {
 	}
 	stopPolling();
 	if (rtBound) window.frappe?.realtime?.off?.("jarvis:event", onRealtime);
+	// Drop any drag listeners if we unmount mid-resize (no commit — nothing to save).
+	window.removeEventListener("pointermove", onResizeMove);
+	window.removeEventListener("pointerup", endResize);
+	window.removeEventListener("pointercancel", endResize);
 });
 
 defineExpose({ load, startNewChat, convId });
@@ -1085,6 +1181,7 @@ defineExpose({ load, startNewChat, convId });
 }
 .jvp-panel {
 	pointer-events: auto;
+	position: relative;
 	max-width: 100%;
 	display: flex;
 	flex-direction: column;
@@ -1112,6 +1209,63 @@ defineExpose({ load, startNewChat, convId });
 	to {
 		opacity: 1;
 		transform: scale(1);
+	}
+}
+
+/* ---- resize grip ----
+   A subtle corner handle, revealed on panel hover / keyboard focus. It sits in
+   the outer-top corner padding so it never covers the header's avatar or the
+   action buttons; the diagonal glyph points the way the panel grows. */
+.jvp-resize {
+	position: absolute;
+	top: 3px;
+	z-index: 6;
+	width: 16px;
+	height: 16px;
+	display: grid;
+	place-items: center;
+	color: var(--jv-ink-3);
+	opacity: 0;
+	touch-action: none;
+	user-select: none;
+	-webkit-user-select: none;
+	transition: opacity 0.12s ease, color 0.12s ease;
+}
+/* Inset into the header's outer padding so it clears the avatar (left) and the
+   action buttons (right), which start ~15px in from the edge. */
+.jvp-resize--tl {
+	left: 3px;
+	cursor: nwse-resize;
+}
+.jvp-resize--tr {
+	right: 3px;
+	cursor: nesw-resize;
+}
+.jvp-resize svg {
+	width: 11px;
+	height: 11px;
+}
+/* The glyph is drawn pointing to the top-right; mirror it for the left corner. */
+.jvp-resize--tl svg {
+	transform: scaleX(-1);
+}
+.jvp-panel:hover .jvp-resize {
+	opacity: 0.5;
+}
+.jvp-resize:hover,
+.jvp-resize--active {
+	opacity: 1;
+	color: var(--jv-ink-2);
+}
+.jvp-resize:focus-visible {
+	opacity: 1;
+	outline: 2px solid var(--jv-accent);
+	outline-offset: -2px;
+	border-radius: 7px;
+}
+@media (prefers-reduced-motion: reduce) {
+	.jvp-resize {
+		transition: none;
 	}
 }
 

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1002,13 +1002,15 @@ function onRealtime(payload) {
 		});
 	}
 
-	const { state: next, admitted } = applyEventEx(stream.value, payload);
+	const { state: next } = applyEventEx(stream.value, payload);
 
-	// Only an ADMITTED frame proves the winning pump's stream is reaching us.
-	// A fenced-out straggler must not stand the HTTP fallback down: after a
-	// handoff, stale frames can be the ONLY thing this socket ever sees, and
-	// polling is then the sole path to the finished reply.
-	if (admitted) stopPolling();
+	// NB: we deliberately do NOT stop polling when a realtime frame arrives.
+	// Realtime gives the smooth live stream, but the relay can drop the TAIL
+	// (the final deltas / run:end) after delivering the first part — which left
+	// the panel frozen on a partial reply ("only the text up to some word shows")
+	// until a manual reload. Polling stays on as the safety net and settles only
+	// once the DURABLE message is complete (streaming=0, see startPolling), so a
+	// dropped tail self-heals within one poll cycle.
 	if (next.reload) {
 		// Clear the flag before reloading so a second frame cannot double-fetch.
 		stream.value = { ...next, reload: false, error: "" };
@@ -1111,9 +1113,12 @@ function startPolling() {
 			const conv = await getConversation(convId.value);
 			const msgs = Array.isArray(conv && conv.messages) ? conv.messages : [];
 			const next = visibleMessages(msgs);
-			// A new assistant turn landed: adopt it and stop.
+			// A COMPLETE assistant turn landed (streaming=0): adopt it and stop.
+			// The streaming guard is what lets polling run alongside realtime as a
+			// safety net without ever settling on a half-written reply, and it is
+			// what recovers a reply whose streamed tail the relay dropped.
 			const last = next[next.length - 1];
-			if (next.length > before && last && last.role === "assistant") {
+			if (next.length > before && last && last.role === "assistant" && !last.streaming) {
 				messages.value = msgs;
 				settle();
 				stickToBottom();

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -41,6 +41,8 @@
 			@close="closePanel"
 			@open-full="openFull"
 			@dismiss-context="contextDismissed = true"
+			@resize="onPanelResize"
+			@resize-commit="onPanelResizeCommit"
 		/>
 	</div>
 </template>
@@ -50,6 +52,7 @@ import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
 import { panelLayout } from "./panel_anchor.mjs";
+import * as panelSize from "./panel_size.mjs";
 import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import * as fabPos from "./fab_position.mjs";
 import Panel from "./Panel.vue";
@@ -92,14 +95,35 @@ const effectiveContext = computed(() => (contextDismissed.value ? null : deskCon
 // resize. fabXY is already reactive, which is what makes the panel travel with
 // the launcher instead of being stranded across the screen from it.
 const viewportTick = ref(0);
+// The user's saved window size (null => the shipped default). Loaded from
+// localStorage synchronously below so the first render already has it, and fed
+// to panelLayout, which floors it at the default and caps it to the viewport.
+const prefSize = ref(null);
 const panelBox = computed(() => {
 	viewportTick.value; // re-run on resize / orientation change
 	const topInset = readCssPx(document.documentElement, "--navbar-height", 48);
 	return panelLayout(
 		{ x: fabXY.value.x, y: fabXY.value.y, size: fabPos.FAB_SIZE },
-		{ vw: window.innerWidth, vh: window.innerHeight, top: topInset }
+		{ vw: window.innerWidth, vh: window.innerHeight, top: topInset },
+		prefSize.value
 	);
 });
+
+// Live drag: adopt the new size so the panel re-lays-out each frame (panelLayout
+// re-clamps, so this can never paint a sub-default or off-screen panel).
+function onPanelResize(size) {
+	prefSize.value = size;
+}
+
+// Drag released: persist the choice per browser, mirroring the FAB position.
+function onPanelResizeCommit() {
+	if (!prefSize.value) return;
+	try {
+		localStorage.setItem(panelSize.STORAGE_KEY, panelSize.serializeSize(prefSize.value));
+	} catch (e) {
+		/* localStorage unavailable */
+	}
+}
 
 function readDeskContext() {
 	const route = (window.frappe && frappe.get_route && frappe.get_route()) || [];
@@ -196,6 +220,18 @@ function applyPosition({ animate = false } = {}) {
 	side.value = resolved.side;
 	yRatio.value = resolved.yRatio;
 	applyPosition({ animate: false });
+}
+
+// Restore the saved panel size the same way — synchronously, before first paint
+// — so a grown panel never flashes at the default size on open.
+{
+	let savedRaw = null;
+	try {
+		savedRaw = localStorage.getItem(panelSize.STORAGE_KEY);
+	} catch (e) {
+		savedRaw = null;
+	}
+	prefSize.value = panelSize.parseSavedSize(savedRaw);
 }
 
 function wake() {

--- a/jarvis/public/js/jarvis_chat/widget/panel_anchor.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_anchor.mjs
@@ -19,10 +19,14 @@ function clamp(n, lo, hi) {
   return Math.min(hi, Math.max(lo, n));
 }
 
-// fab: { x, y, size } — the FAB's top-left in viewport coordinates.
-// vp:  { vw, vh, top } — top is the Desk navbar height the panel must clear.
+// fab:  { x, y, size } — the FAB's top-left in viewport coordinates.
+// vp:   { vw, vh, top } — top is the Desk navbar height the panel must clear.
+// pref: { width, height } | null — the user's saved size. It may only GROW the
+//       panel above the default, never shrink it below (product rule: the mini
+//       chat never gets smaller than its shipped size), and never past the
+//       viewport. Omit for the default 400×624.
 // Returns { left, top, width, height, side }, all in viewport pixels.
-export function panelLayout(fab, vp) {
+export function panelLayout(fab, vp, pref) {
   const v = vp || {};
   const vw = Number.isFinite(v.vw) ? v.vw : 1024;
   const vh = Number.isFinite(v.vh) ? v.vh : 768;
@@ -33,8 +37,20 @@ export function panelLayout(fab, vp) {
   const fx = Number.isFinite(f.x) ? f.x : vw - size - MARGIN;
   const fy = Number.isFinite(f.y) ? f.y : vh - size - MARGIN;
 
-  const width = Math.min(PANEL_W, Math.max(0, vw - MARGIN * 2));
-  const height = Math.min(PANEL_MAX_H, Math.max(0, vh - top - MARGIN * 2));
+  // The viewport ceilings the panel can never exceed, and the default floor
+  // (itself capped to the viewport on a small screen). A saved preference is
+  // clamped into [floor, ceiling]: clamp's lo-wins rule means the floor also
+  // guarantees the panel never shrinks below the default when a preference is
+  // present. No pref → want === floor → identical to the pre-resize behaviour.
+  const maxW = Math.max(0, vw - MARGIN * 2);
+  const maxH = Math.max(0, vh - top - MARGIN * 2);
+  const floorW = Math.min(PANEL_W, maxW);
+  const floorH = Math.min(PANEL_MAX_H, maxH);
+  const p = pref || {};
+  const wantW = Number.isFinite(p.width) ? p.width : floorW;
+  const wantH = Number.isFinite(p.height) ? p.height : floorH;
+  const width = clamp(wantW, floorW, maxW);
+  const height = clamp(wantH, floorH, maxH);
 
   // Prefer the side facing into the page: a right-docked FAB opens leftward.
   const fabCentre = fx + size / 2;

--- a/jarvis/public/js/jarvis_chat/widget/panel_anchor.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_anchor.test.mjs
@@ -90,3 +90,34 @@ test("junk input yields a usable layout rather than NaN", () => {
   assert.ok(Number.isFinite(l.left) && Number.isFinite(l.top));
   assert.ok(Number.isFinite(l.width) && Number.isFinite(l.height));
 });
+
+// ---- user-preferred size (the pref arg) ----
+const RIGHT_FAB = { x: 1440 - 54 - 16, y: 700, size: FAB };
+
+test("pref: a larger saved size grows the panel and stays on-screen", () => {
+  const l = panelLayout(RIGHT_FAB, VP, { width: 560, height: 720 });
+  assert.equal(l.width, 560);
+  assert.equal(l.height, 720);
+  assert.equal(l.side, "left");
+  assert.ok(l.left >= MARGIN, "never off the left edge");
+  assert.ok(l.top >= VP.top + MARGIN, "never under the navbar");
+});
+
+test("pref: a sub-default size is floored to the default (never shrinks)", () => {
+  const l = panelLayout(RIGHT_FAB, VP, { width: 200, height: 200 });
+  assert.equal(l.width, PANEL_W);
+  assert.equal(l.height, PANEL_MAX_H);
+});
+
+test("pref: is capped to the viewport, never past the margins", () => {
+  const l = panelLayout(RIGHT_FAB, VP, { width: 99999, height: 99999 });
+  assert.equal(l.width, VP.vw - MARGIN * 2);
+  assert.equal(l.height, VP.vh - VP.top - MARGIN * 2);
+});
+
+test("pref: absent (or null) is identical to the default layout", () => {
+  const a = panelLayout(RIGHT_FAB, VP);
+  assert.deepEqual(a, panelLayout(RIGHT_FAB, VP, null));
+  assert.equal(a.width, PANEL_W);
+  assert.equal(a.height, PANEL_MAX_H);
+});

--- a/jarvis/public/js/jarvis_chat/widget/panel_markdown.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_markdown.mjs
@@ -6,31 +6,104 @@
 // and it escapes HTML before emitting, which is what makes v-html safe here.
 import { renderMarkdown } from "../../../../../frontend/src/markdown.js";
 
-// Control fences the agent uses to talk to the UI, not to the reader. The full
-// SPA turns several of these into cards; this panel is text-only, so strip them
-// all rather than print their JSON. Mirrors ChatView's _stripControlBlocks.
-const CONTROL_FENCES = [
+// Pure interactive control fences: NOT viewable content. The panel surfaces
+// actions / confirmations through its own event handlers (action:pending etc.),
+// not the transcript, so these are removed outright.
+const STRIP_FENCES = [
   "jarvis-action",
   "confirm",
   "jarvis-ask",
-  "jarvis-cards",
   "jarvis-skill",
   "jarvis-macro",
-  "jarvis-chart",
 ];
+
+// Rich CONTENT this text-only mini panel cannot draw: record cards, data charts,
+// and mermaid diagrams. Rather than drop them silently (or, for mermaid, leak the
+// raw source), each block becomes a sentinel that renderReply turns into a chip
+// linking to the full chat, where the SPA renders it. Private-use chars so the
+// sentinel can never collide with real text and survives markdown rendering.
+const M0 = "\uE000";
+const M1 = "\uE001";
+const sentinel = (kind) => `\n\n${M0}${kind}${M1}\n\n`;
 
 export function stripControlBlocks(src) {
   let t = String(src == null ? "" : src);
-  for (const name of CONTROL_FENCES) {
+  for (const name of STRIP_FENCES) {
     t = t.replace(
       new RegExp("```" + name + "[ \\t]*\\n[\\s\\S]*?```", "g"),
       ""
     );
   }
-  t = t.replace(/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g, "");
+  // Content blocks → "view in full chat" sentinels (kept, not dropped).
+  t = t.replace(/```jarvis-cards[ \t]*\n[\s\S]*?```/g, sentinel("cards"));
+  t = t.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, sentinel("chart"));
+  // Mermaid: xychart-beta is a DATA chart; anything else is a diagram.
+  t = t.replace(
+    /```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g,
+    sentinel("chart")
+  );
+  t = t.replace(/```mermaid[ \t]*\n[\s\S]*?```/g, sentinel("diagram"));
   return t.replace(/\n{3,}/g, "\n\n").trim();
 }
 
+// Per-kind chip: an icon, a label, and a "Open in full chat" affordance. Clicks
+// are caught by delegation in Panel.vue (the chip lives inside a v-html bubble,
+// so it cannot bind a Vue handler directly) and emit "open-full".
+const CHIP = {
+  diagram: {
+    label: "Diagram",
+    icon:
+      '<rect x="3" y="3" width="7" height="6" rx="1"></rect>' +
+      '<rect x="14" y="15" width="7" height="6" rx="1"></rect>' +
+      '<path d="M6.5 9v4a2 2 0 0 0 2 2H14"></path>',
+  },
+  chart: {
+    label: "Chart",
+    icon: '<path d="M4 20V10M10 20V4M16 20v-7M2 20h20"></path>',
+  },
+  cards: {
+    label: "Records",
+    icon:
+      '<rect x="3" y="4" width="18" height="5" rx="1"></rect>' +
+      '<rect x="3" y="13" width="18" height="5" rx="1"></rect>',
+  },
+};
+
+function chip(kind) {
+  const c = CHIP[kind] || {
+    label: "Content",
+    icon: '<circle cx="12" cy="12" r="9"></circle>',
+  };
+  return (
+    '<button type="button" class="jvp-view-chip" data-open-full>' +
+    '<svg class="jvp-view-chip-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    c.icon +
+    "</svg>" +
+    '<span class="jvp-view-chip-tx"><span class="jvp-view-chip-t">' +
+    c.label +
+    "</span>" +
+    '<span class="jvp-view-chip-s">Open in full chat</span></span>' +
+    '<svg class="jvp-view-chip-go" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"></path></svg>' +
+    "</button>"
+  );
+}
+
+const MERMAID_DIV_RE = /<div class="jv-mermaid">[\s\S]*?<\/div>/g;
+// The renderer wraps a lone line in <p class="jv-md-p"> — match any attributes.
+const SENT_P_RE = new RegExp(
+  "<p[^>]*>\\s*" + M0 + "(\\w+)" + M1 + "\\s*</p>",
+  "g"
+);
+const SENT_RE = new RegExp(M0 + "(\\w+)" + M1, "g");
+
 export function renderReply(src) {
-  return renderMarkdown(stripControlBlocks(src));
+  let html = renderMarkdown(stripControlBlocks(src));
+  // Defensive: if any mermaid slipped past stripControlBlocks, renderMarkdown
+  // emits an undrawn `.jv-mermaid` div — treat it as a diagram chip too.
+  html = html.replace(MERMAID_DIV_RE, chip("diagram"));
+  // Sentinels normally come out wrapped in their own <p>; unwrap that first so
+  // the chip is a clean block, then catch any inline stragglers.
+  html = html.replace(SENT_P_RE, (_m, k) => chip(k));
+  html = html.replace(SENT_RE, (_m, k) => chip(k));
+  return html;
 }

--- a/jarvis/public/js/jarvis_chat/widget/panel_markdown.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_markdown.test.mjs
@@ -1,25 +1,24 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { stripControlBlocks } from "./panel_markdown.mjs";
+import { stripControlBlocks, renderReply } from "./panel_markdown.mjs";
 
 test("strips the jarvis-skill fence the agent appends to replies", () => {
   const src = "Here is the summary.\n\n```jarvis-skill\nerpnext-accounts\n```";
   assert.equal(stripControlBlocks(src), "Here is the summary.");
 });
 
-test("strips every control fence, keeping the prose", () => {
+test("removes pure control fences outright, keeping the prose", () => {
   for (const name of [
     "jarvis-action",
     "confirm",
     "jarvis-ask",
-    "jarvis-cards",
     "jarvis-skill",
     "jarvis-macro",
-    "jarvis-chart",
   ]) {
     const src = `Before.\n\n\`\`\`${name}\n{"x":1}\n\`\`\`\n\nAfter.`;
     const out = stripControlBlocks(src);
     assert.ok(!out.includes(name), `${name} leaked`);
+    assert.ok(!out.includes('"x"'), `${name} body leaked`);
     assert.ok(out.includes("Before.") && out.includes("After."));
   }
 });
@@ -38,4 +37,50 @@ test("is safe on empty and non-string input", () => {
   assert.equal(stripControlBlocks(""), "");
   assert.equal(stripControlBlocks(null), "");
   assert.equal(stripControlBlocks(undefined), "");
+});
+
+// ---- content the panel can't draw -> an "open in full chat" chip ----
+
+test("renderReply: a mermaid flowchart becomes a Diagram chip, not raw source", () => {
+  const html = renderReply("The flow:\n\n```mermaid\nflowchart TD\nA-->B\n```");
+  assert.ok(html.includes('class="jvp-view-chip"'), "no chip");
+  assert.ok(html.includes(">Diagram</span>"), "wrong label");
+  assert.ok(!html.includes("flowchart TD"), "raw mermaid leaked");
+  assert.ok(html.includes("The flow:"), "prose dropped");
+});
+
+test("renderReply: jarvis-chart and mermaid xychart both become a Chart chip", () => {
+  for (const src of [
+    'Sales:\n\n```jarvis-chart\n{"type":"bar"}\n```',
+    "Sales:\n\n```mermaid\nxychart-beta\n  bar [1,2,3]\n```",
+  ]) {
+    const html = renderReply(src);
+    assert.ok(html.includes('class="jvp-view-chip"'), "no chip");
+    assert.ok(html.includes(">Chart</span>"), "wrong label");
+    assert.ok(
+      !html.includes("xychart") && !html.includes('"type"'),
+      "raw spec leaked"
+    );
+  }
+});
+
+test("renderReply: jarvis-cards becomes a Records chip", () => {
+  const html = renderReply(
+    'Matches:\n\n```jarvis-cards\n[{"name":"SO-1"}]\n```'
+  );
+  assert.ok(html.includes('class="jvp-view-chip"'), "no chip");
+  assert.ok(html.includes(">Records</span>"), "wrong label");
+  assert.ok(!html.includes("SO-1"), "raw card data leaked");
+});
+
+test("renderReply: every chip carries the open-full hook and the hint", () => {
+  const html = renderReply("```mermaid\nflowchart TD\nA-->B\n```");
+  assert.ok(html.includes("data-open-full"));
+  assert.ok(html.includes("Open in full chat"));
+});
+
+test("renderReply: plain markdown (a table) stays inline, no chip", () => {
+  const html = renderReply("| A | B |\n|---|---|\n| 1 | 2 |");
+  assert.ok(!html.includes("jvp-view-chip"), "spurious chip");
+  assert.ok(html.includes("jv-md-table"), "table not rendered");
 });

--- a/jarvis/public/js/jarvis_chat/widget/panel_size.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_size.mjs
@@ -1,0 +1,70 @@
+// The user-preferred mini-chat window size, persisted per browser.
+//
+// Widget.vue owns the localStorage I/O and the pointer events; this module is
+// the pure parse + corner-drag geometry so every rule (never shrink below the
+// shipped default, which way a drag grows the panel) is a node:test unit rather
+// than a drag session in a browser — same split as fab_position.mjs.
+
+import { PANEL_W, PANEL_MAX_H } from "./panel_anchor.mjs";
+
+export const STORAGE_KEY = "jarvis-panel-size";
+
+// The product rule: the panel can be GROWN but never shrunk below the shipped
+// default. These are the floors resizeFrom enforces; panelLayout additionally
+// caps the result to the viewport at render time, so a preference saved on a
+// large monitor simply clamps down (never below the default) on a small one.
+export const MIN_W = PANEL_W; // 400
+export const MIN_H = PANEL_MAX_H; // 624
+
+function num(x) {
+  return typeof x === "number" && Number.isFinite(x) ? x : NaN;
+}
+
+// Parse the stored payload. Returns { width, height } floored at the default
+// (so a tampered or pre-feature value can never encode a sub-default size), or
+// null when there is nothing valid to restore.
+export function parseSavedSize(raw) {
+  if (!raw) return null;
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const w = num(obj.width);
+  const h = num(obj.height);
+  if (Number.isNaN(w) || Number.isNaN(h)) return null;
+  return { width: Math.max(MIN_W, w), height: Math.max(MIN_H, h) };
+}
+
+// Serialize for localStorage, floored at the default so a bad in-memory value
+// can never be persisted as a sub-default size.
+export function serializeSize(size) {
+  const s = size || {};
+  return JSON.stringify({
+    width: Math.max(MIN_W, num(s.width) || MIN_W),
+    height: Math.max(MIN_H, num(s.height) || MIN_H),
+  });
+}
+
+// The new size from a corner drag. `start` is the size at pointer-down, `side`
+// is which way the panel opens ("left" => grip on the top-left, panel grows
+// leftward; anything else => grip on the top-right, grows rightward), and dx/dy
+// are the pointer deltas since pointer-down. Height always grows by dragging UP
+// (dy negative). Floored at the default so a drag can never shrink past it; the
+// viewport cap is left to panelLayout so the stored preference keeps the user's
+// intended size across viewport changes.
+export function resizeFrom(start, side, dx, dy) {
+  const s = start || {};
+  const w0 = num(s.width) || MIN_W;
+  const h0 = num(s.height) || MIN_H;
+  const ddx = num(dx) || 0;
+  const ddy = num(dy) || 0;
+  const width = side === "left" ? w0 - ddx : w0 + ddx;
+  const height = h0 - ddy;
+  return {
+    width: Math.max(MIN_W, Math.round(width)),
+    height: Math.max(MIN_H, Math.round(height)),
+  };
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_size.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_size.test.mjs
@@ -1,0 +1,122 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  STORAGE_KEY,
+  MIN_W,
+  MIN_H,
+  parseSavedSize,
+  serializeSize,
+  resizeFrom,
+} from "./panel_size.mjs";
+import { PANEL_W, PANEL_MAX_H } from "./panel_anchor.mjs";
+
+test("MIN_* are the shipped default (the never-shrink floor)", () => {
+  assert.equal(MIN_W, PANEL_W);
+  assert.equal(MIN_H, PANEL_MAX_H);
+});
+
+test("STORAGE_KEY is stable", () => {
+  assert.equal(STORAGE_KEY, "jarvis-panel-size");
+});
+
+// ---- parseSavedSize ----
+test("parseSavedSize: a valid larger size round-trips", () => {
+  assert.deepEqual(
+    parseSavedSize(JSON.stringify({ width: 560, height: 720 })),
+    {
+      width: 560,
+      height: 720,
+    }
+  );
+});
+
+test("parseSavedSize: floors a sub-default stored size at the default", () => {
+  assert.deepEqual(
+    parseSavedSize(JSON.stringify({ width: 100, height: 100 })),
+    {
+      width: MIN_W,
+      height: MIN_H,
+    }
+  );
+});
+
+test("parseSavedSize: null / garbage / partial -> null", () => {
+  assert.equal(parseSavedSize(null), null);
+  assert.equal(parseSavedSize(""), null);
+  assert.equal(parseSavedSize("not json"), null);
+  assert.equal(parseSavedSize("[1,2]"), null); // array, no width/height
+  assert.equal(parseSavedSize(JSON.stringify({ width: 500 })), null); // height missing
+  assert.equal(
+    parseSavedSize(JSON.stringify({ width: "x", height: 700 })),
+    null
+  );
+});
+
+// ---- serializeSize ----
+test("serializeSize: floors at the default and round-trips through parse", () => {
+  assert.deepEqual(parseSavedSize(serializeSize({ width: 10, height: 10 })), {
+    width: MIN_W,
+    height: MIN_H,
+  });
+  assert.deepEqual(parseSavedSize(serializeSize({ width: 700, height: 800 })), {
+    width: 700,
+    height: 800,
+  });
+});
+
+// ---- resizeFrom ----
+const START = { width: 400, height: 624 };
+
+test("resizeFrom: left panel grows WIDER when dragged left (dx negative)", () => {
+  assert.deepEqual(resizeFrom(START, "left", -50, 0), {
+    width: 450,
+    height: 624,
+  });
+});
+
+test("resizeFrom: left panel shrink is floored at the default", () => {
+  assert.deepEqual(resizeFrom(START, "left", 80, 0), {
+    width: 400,
+    height: 624,
+  });
+  assert.deepEqual(resizeFrom({ width: 500, height: 624 }, "left", 80, 0), {
+    width: 420,
+    height: 624,
+  });
+});
+
+test("resizeFrom: right panel grows WIDER when dragged right (dx positive)", () => {
+  assert.deepEqual(resizeFrom(START, "right", 60, 0), {
+    width: 460,
+    height: 624,
+  });
+});
+
+test("resizeFrom: dragging UP grows height on both sides (dy negative)", () => {
+  assert.deepEqual(resizeFrom(START, "left", 0, -40), {
+    width: 400,
+    height: 664,
+  });
+  assert.deepEqual(resizeFrom(START, "right", 0, -40), {
+    width: 400,
+    height: 664,
+  });
+});
+
+test("resizeFrom: dragging DOWN shrinks height, floored at the default", () => {
+  assert.deepEqual(resizeFrom(START, "left", 0, 100), {
+    width: 400,
+    height: 624,
+  });
+  assert.deepEqual(resizeFrom({ width: 400, height: 800 }, "left", 0, 100), {
+    width: 400,
+    height: 700,
+  });
+});
+
+test("resizeFrom: rounds fractional pointer deltas", () => {
+  assert.deepEqual(resizeFrom(START, "right", 10.4, -10.6), {
+    width: 410,
+    height: 635,
+  });
+});

--- a/pwa/src/lib/blocks.js
+++ b/pwa/src/lib/blocks.js
@@ -23,13 +23,27 @@ const STRIP_RES = [
 	/```jarvis-macro[ \t]*\n[\s\S]*?```/g,
 	/```jarvis-chart[ \t]*\n[\s\S]*?```/g,
 	/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g,
+	// A mermaid block that is NOT xychart-beta is a DIAGRAM (flowchart etc.) the
+	// PWA can't draw. Strip it so it doesn't leak as a raw code block; the chip
+	// from countDiagrams opens it in the web chat instead.
+	/```mermaid[ \t]*\n(?![ \t]*xychart-beta)[\s\S]*?```/g,
 ];
+
+// Separate object (not shared with STRIP_RES) so its /g lastIndex can't collide.
+const DIAGRAM_RE = /```mermaid[ \t]*\n(?![ \t]*xychart-beta)[\s\S]*?```/g;
 
 /** The agent's prose, with every control block removed. */
 export function stripAgentBlocks(text) {
 	let t = text || "";
 	for (const re of STRIP_RES) t = t.replace(re, "");
 	return t.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/** How many mermaid DIAGRAMS (flowcharts etc., not data charts) the reply holds. */
+export function countDiagrams(text) {
+	if (!text || !text.includes("```mermaid")) return 0;
+	const m = text.match(DIAGRAM_RE);
+	return m ? m.length : 0;
 }
 
 /** ```jarvis-cards``` → {title, cards:[{title, subtitle, doctype, name, fields}]}. */

--- a/pwa/src/lib/blocks.test.js
+++ b/pwa/src/lib/blocks.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseCards, stripAgentBlocks, toolStatus } from "./blocks.js";
+import { countDiagrams, parseCards, stripAgentBlocks, toolStatus } from "./blocks.js";
 
 const fence = (kind, body) => "```" + kind + "\n" + body + "\n```";
 
@@ -21,12 +21,32 @@ test("stripAgentBlocks: removes every control fence from the prose", () => {
 	}
 });
 
-test("stripAgentBlocks: strips an xychart mermaid block but keeps ordinary mermaid", () => {
+test("stripAgentBlocks: strips both xychart charts and ordinary mermaid diagrams", () => {
+	// xychart-beta is a data chart (rendered by ChartCard); it must not leak.
 	const xy = stripAgentBlocks(`Text\n${fence("mermaid", "xychart-beta\n  title x")}\nEnd`);
 	assert.ok(!xy.includes("xychart-beta"));
+	assert.equal(xy, "Text\n\nEnd");
 
+	// An ordinary diagram (flowchart) can't be drawn here, so it is stripped from
+	// the prose too — a chip (countDiagrams) links it to the web chat instead of
+	// leaving raw ``` source on screen.
 	const flow = `Text\n${fence("mermaid", "graph TD;\n  A-->B;")}\nEnd`;
-	assert.ok(stripAgentBlocks(flow).includes("graph TD"), "a normal diagram must survive");
+	const out = stripAgentBlocks(flow);
+	assert.ok(!out.includes("graph TD"), "a diagram must not leak as raw source");
+	assert.equal(out, "Text\n\nEnd");
+});
+
+test("countDiagrams: counts flowchart-style mermaid, ignores xychart data charts", () => {
+	assert.equal(countDiagrams(`a\n${fence("mermaid", "flowchart TD\n A-->B")}\nb`), 1);
+	assert.equal(countDiagrams(fence("mermaid", "xychart-beta\n bar [1,2]")), 0);
+	assert.equal(countDiagrams("no diagrams here"), 0);
+	assert.equal(countDiagrams(""), 0);
+	assert.equal(countDiagrams(null), 0);
+	const two = `${fence("mermaid", "graph TD\n A-->B")}\n\n${fence(
+		"mermaid",
+		"sequenceDiagram\n A->>B: hi"
+	)}`;
+	assert.equal(countDiagrams(two), 2);
 });
 
 test("stripAgentBlocks: leaves a plain code block alone", () => {

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -20,6 +20,7 @@ import { eventFence } from "../lib/pump_fence_state.js";
 import * as api from "../api";
 import { store } from "../store";
 import {
+	countDiagrams,
 	parseAction,
 	parseCards,
 	parseCharts,
@@ -52,6 +53,11 @@ const socket = inject("$socket");
 // its real id.
 const convId = ref(props.id === "new" ? "" : props.id);
 const conversation = ref(null);
+// Deep link to this thread in the desktop web chat (outside the PWA's
+// /jarvis-mobile scope), where the SPA draws diagrams the PWA can't.
+const webChatUrl = computed(() =>
+	convId.value ? `/jarvis/c/${encodeURIComponent(convId.value)}` : "/jarvis/"
+);
 const messages = ref([]);
 const input = ref("");
 const loading = ref(false);
@@ -115,6 +121,8 @@ const view = (m) => {
 		html,
 		cards,
 		charts,
+		// Mermaid diagrams can't be drawn here; surface a chip to the web chat.
+		diagrams: countDiagrams(content),
 		action: parseAction(content),
 		skills: parseSkillsUsed(content),
 		took: spanBetween(m.creation, m.modified),
@@ -654,6 +662,46 @@ onUnmounted(() => {
 					/>
 					<RecordCards v-if="it.view.cards" :data="it.view.cards" />
 					<ChartCard v-for="(c, ci) in it.view.charts" :key="ci" :spec="c" />
+					<a
+						v-if="it.view.diagrams"
+						class="jv-diagram-chip"
+						:href="webChatUrl"
+						target="_blank"
+						rel="noopener"
+					>
+						<svg
+							class="jv-diagram-chip-ic"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<rect x="3" y="3" width="7" height="6" rx="1" />
+							<rect x="14" y="15" width="7" height="6" rx="1" />
+							<path d="M6.5 9v4a2 2 0 0 0 2 2H14" />
+						</svg>
+						<span class="jv-diagram-chip-tx">
+							<span class="jv-diagram-chip-t">{{
+								it.view.diagrams > 1 ? it.view.diagrams + " diagrams" : "Diagram"
+							}}</span>
+							<span class="jv-diagram-chip-s">Open in web chat</span>
+						</span>
+						<svg
+							class="jv-diagram-chip-go"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="M7 17 17 7M8 7h9v9" />
+						</svg>
+					</a>
 					<SkillChips :names="it.view.skills" />
 					<div v-if="it.msg.error" class="jv-msg-error">{{ it.msg.error }}</div>
 					<MessageMedia
@@ -933,6 +981,55 @@ onUnmounted(() => {
 	line-height: 1.6;
 	color: var(--ink7);
 	overflow-wrap: anywhere;
+}
+
+/* "Open in web chat" chip for a mermaid diagram the PWA can't draw. */
+.jv-diagram-chip {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin: 6px 0;
+	padding: 10px 12px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+	color: var(--ink9);
+	text-decoration: none;
+	-webkit-tap-highlight-color: transparent;
+}
+.jv-diagram-chip:active {
+	background: var(--card2);
+}
+.jv-diagram-chip-ic {
+	width: 30px;
+	height: 30px;
+	flex: 0 0 auto;
+	padding: 6px;
+	border-radius: 8px;
+	background: var(--card2);
+	color: var(--accent);
+	box-sizing: border-box;
+}
+.jv-diagram-chip-tx {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	line-height: 1.3;
+}
+.jv-diagram-chip-t {
+	font-size: 14px;
+	font-weight: 600;
+}
+.jv-diagram-chip-s {
+	font-size: 12.5px;
+	color: var(--ink5);
+}
+.jv-diagram-chip-go {
+	width: 16px;
+	height: 16px;
+	flex: 0 0 auto;
+	color: var(--ink4);
 }
 .jv-md :deep(p) {
 	margin: 0 0 8px;


### PR DESCRIPTION
Improvements to the two non-web chat surfaces (the Desk mini-chat widget and the mobile PWA), so agent replies read the same as they do in the full web chat. Five focused commits:

### 1. Resizable mini-chat window
The panel was a fixed 400x624. Now it's draggable from the top / left / right edges and the top corners, with an always-visible grabber so it clearly reads as resizable. The size can only grow (floored at the shipped default), is capped to the viewport, and persists per browser in `localStorage` like the launcher position.

### 2. Sticky-bottom scroll (fixes "only half the reply shows")
The widget auto-scrolled to the newest token on every frame, so a long streamed reply kept getting yanked to its tail and you couldn't scroll up to read it. Now it sticks to the bottom only while you're already there (same `pinnedToBottom` guard as the SPA), and re-pins on send / load / new chat.

### 3. Recover a dropped stream tail (fixes "cuts off at a word, reload shows full")
The relay can deliver the first part of a reply over realtime then drop the tail (final deltas / `run:end`), leaving the panel frozen on a partial reply until a manual reload. Polling now stays on as a safety net and settles only when the durable message is complete (`streaming=0`), so a dropped tail self-heals within one poll cycle. Verified against live data: every finished assistant row is complete with `streaming=0`.

### 4. Rich content -> "open in full chat" chips (mini-chat)
The text-only mini-chat was leaking raw ```mermaid``` source and silently dropping `jarvis-cards` / `jarvis-chart`. Anything it can't draw (diagram / chart / record cards) now renders as a compact chip that opens the full chat, where the SPA draws it. Prose, tables, code and lists render as before.

### 5. PWA: mermaid diagrams -> "open in web chat" chip
The PWA already renders record cards and data charts; only mermaid diagrams (flowcharts etc.) fell through and printed as raw code. They now strip from the prose and surface a chip that deep-links to `/jarvis/c/<id>`, where the SPA draws them.

### Tests / build
121 widget `node:test` units + 33 PWA `node:test` units pass; `bench build --app jarvis` builds the widget, SPA and PWA bundles clean. Built assets under `public/dist|frontend|pwa` are gitignored and regenerated by CI.
