### PR TITLE
fix(onboarding): stop prefilling Work email with the logged-in user

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1843,14 +1843,13 @@ watch(
 	}
 );
 
-// Prefill the Details step from what the site already knows (caller's email +
-// default/sole company; options list for several) so the customer doesn't
-// retype it. Backend-sourced because the SPA has no frappe.defaults. Never
-// overwrites a value the user already typed; silent on any failure.
+// Prefill the Details step's company so the customer doesn't retype it. Never
+// overwrites a typed value; silent on failure.
+// Email is deliberately not prefilled: it resolved to the logged-in user —
+// admin@example.com on a fresh site — and this step routes billing receipts.
 async function prefillAccount() {
 	try {
 		const d = (await getAccountDefaults()) || {};
-		if (d.email && !state.email.trim()) state.email = d.email;
 		if (d.company && !state.company.trim()) state.company = d.company;
 		if (Array.isArray(d.companies)) state.companies = d.companies;
 	} catch (e) {


### PR DESCRIPTION
## Problem

The onboarding **Your details** step opened with `admin@example.com` already filled into **Work email** — not as a placeholder, as a real, submittable value.

`prefillAccount()` wrote the backend's answer straight into the bound state:

```js
const d = (await getAccountDefaults()) || {};
if (d.email && !state.email.trim()) state.email = d.email;   // ← removed
```

and `get_account_defaults` (`jarvis/onboarding.py:670`) resolves that from `frappe.session.user`:

```python
email = (frappe.db.get_value("User", user, "email") or user) if user and user != "Guest" else ""
```

Confirmed on a real site:

```json
{"email": "admin@example.com", "company": "Aerele", "companies": ["Aerele"]}
```

The field's markup was never wrong — `placeholder="you@company.com"` is right there. The placeholder simply never got a chance to render, because the mount-time prefill overwrote it before first paint. The existing catch block gave it away: `/* no-op: keep the placeholders */` — placeholders survived only when the prefill *failed*.

## Why this matters

That step reads *"We'll set Jarvis up for this workspace and send receipts here."* A customer who doesn't notice routes their billing mail to a mailbox nobody reads, and nothing flags it — a prefilled value renders identically to a typed one. `admin@example.com` is Frappe's default and extremely common on a fresh site, so this is the normal case, not an edge one.

## Fix

Drop the email line. The field now shows its placeholder and requires a deliberate answer.

**Company prefill is untouched** — that comes from the site's own Company record, which is the right answer far more often than `session.user` is the right billing address.

## Scope

`get_account_defaults` still returns `email`; no other caller reads it. Left alone deliberately rather than cleaned up here — it's whitelisted, and `test_onboarding_account_defaults.py:21` asserts the key. Worth a follow-up.

## Verification

Rebuilt and checked on a running bench, at `/jarvis/onboarding` → Your details:

| field | before | after |
|---|---|---|
| Work email | `admin@example.com` | `""` + placeholder `you@company.com` |
| Company | `Aerele` | `Aerele` (unchanged) |

Also confirmed the built bundle no longer contains the email-prefill pattern while retaining the company one.