### PR TITLE
fix(onboarding): drop email from get_account_defaults

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -655,19 +655,22 @@ def check_account_reconnect(request_id: str, code: str = "") -> dict:
 
 @frappe.whitelist()
 def get_account_defaults() -> dict:
-	"""Prefill for the onboarding Account step so the customer doesn't retype what
-	the site already knows: the caller's email + a default company. Company is the
-	user/global default when set, else the site's sole Company; ``companies`` lists
-	options for a client datalist when several exist. Silent no-op (blank / empty
-	list) on sites without the Company doctype or read permission.
+	"""Company prefill for the onboarding Account step, so the customer doesn't
+	retype what the site already knows. Company is the user/global default when
+	set, else the site's sole Company; ``companies`` lists options for a client
+	datalist when several exist. Silent no-op (blank / empty list) on sites
+	without the Company doctype or read permission.
+
+	Deliberately does NOT return the caller's email. It used to, and the SPA wrote
+	it into the Work email field — which on a fresh site is admin@example.com, sat
+	in the field as a real value, on the step that says receipts go there. Email is
+	the customer's to type. Do not add it back.
 
 	Ports the desk auto-fetch (jarvis_onboarding.js, commit 1507495) to the server
 	because the SPA has no ``frappe.defaults``. System-Manager only (the onboarding
 	route is SM-gated).
 	"""
 	require_jarvis_admin()
-	user = frappe.session.user
-	email = (frappe.db.get_value("User", user, "email") or user) if user and user != "Guest" else ""
 
 	company, companies = "", []
 	try:
@@ -681,7 +684,7 @@ def get_account_defaults() -> dict:
 		# No Company doctype / no read permission — leave blank so the client keeps
 		# its placeholder, exactly like the desk auto-fetch's silent no-op.
 		company, companies = "", []
-	return {"email": email, "company": company, "companies": companies}
+	return {"company": company, "companies": companies}
 
 
 @frappe.whitelist()

--- a/jarvis/tests/test_onboarding_account_defaults.py
+++ b/jarvis/tests/test_onboarding_account_defaults.py
@@ -1,9 +1,11 @@
-"""onboarding.get_account_defaults — prefill for the SPA Account step.
+"""onboarding.get_account_defaults — company prefill for the SPA Account step.
 
 Ports the desk auto-fetch (commit 1507495) to a backend endpoint: the SPA has no
-`frappe.defaults`, so the server resolves the caller's email + a default company
-(user/global default → sole Company, with a datalist list for several). Silent
-no-op on sites without the Company doctype / read permission.
+`frappe.defaults`, so the server resolves a default company (user/global default
+→ sole Company, with a datalist list for several). Silent no-op on sites without
+the Company doctype / read permission.
+
+Email is not part of the payload — see the endpoint's docstring for why.
 """
 
 from unittest.mock import patch
@@ -15,10 +17,10 @@ from jarvis import onboarding
 
 
 class TestAccountDefaults(FrappeTestCase):
-	def test_email_is_the_caller(self):
-		out = onboarding.get_account_defaults()
-		expected = frappe.db.get_value("User", frappe.session.user, "email") or frappe.session.user
-		self.assertEqual(out["email"], expected)
+	def test_email_is_never_returned(self):
+		"""Regression guard: the caller's email used to be prefilled into Work
+		email, which on a fresh site is admin@example.com."""
+		self.assertNotIn("email", onboarding.get_account_defaults())
 
 	def test_user_default_company_wins(self):
 		with (


### PR DESCRIPTION
Follow-up to #602, addressing the review finding raised there.

## Why this is needed

#602 stopped the SPA writing the caller's email into the **Work email** field. It did not remove the field from the endpoint — and, more importantly, it left the documentation describing that prefill as the endpoint's purpose:

| where | what it said |
|---|---|
| `onboarding.py` docstring | *"the caller's email + a default company"* |
| test module docstring | *"the server resolves the caller's email + …"* |
| `test_email_is_the_caller` | asserted `out["email"]`, and passed |

So the bug was patched at one call site while the code still told the next reader that prefilling the caller's email is what this endpoint is *for*. A passing test named `test_email_is_the_caller` is a standing invitation to re-add `state.email = d.email` — reintroducing `admin@example.com` in the field that routes billing receipts.

## Change

- Remove `email` from the return.
- Retitle both docstrings to company-only.
- Record the reasoning in the endpoint itself, so it outlives this diff.
- `test_email_is_the_caller` → `test_email_is_never_returned`: same location, opposite assertion. It now guards the regression instead of documenting it.

```diff
-	return {"email": email, "company": company, "companies": companies}
+	return {"company": company, "companies": companies}
```

The `user` / `email` lookup above it goes too, so the endpoint no longer touches `frappe.session.user` at all.

## Contract note

`get_account_defaults` is `@frappe.whitelist()`, so this narrows a public response shape. Readers, exhaustively:

- `frontend/src/api.js` → `OnboardingView.vue` — stopped reading `email` in #602
- `tests/test_role_gates.py:35` — only exercises the permission gate

No caller loses anything it still uses. This had to land after #602, not alongside it: removing the field while `develop`'s frontend still read it would have broken the Details step.

## Verification

Called on a running bench after the change:

```json
{"company": "Aerele", "companies": ["Aerele"]}
```

Company prefill intact, `email` gone. `ruff check` clean on both files (`import frappe` is still needed — `frappe._dict` at line 44).