### PR TITLE
test(admin_client): stop the fixtures destroying a real site's admin credentials

### DIFF
--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -20,17 +20,115 @@ from jarvis.admin_client import (
 	post_update_llm_creds,
 )
 
+# jarvis #566. These fixtures used to configure the REAL Jarvis Settings Single
+# and then, on teardown, call remove_encrypted_password() on three of its
+# Password fields. Both halves committed, so the whole thing escaped
+# FrappeTestCase's rollback, and running this module against a real site
+# permanently destroyed that site's control-plane credentials. That is not
+# theoretical: it took site.jarvis's jarvis_admin_api_key, api_secret and
+# customer_password on 2026-07-30 and they had to be restored by hand.
+#
+# The teardown's deletion was load-bearing GIVEN the setup: db_set on a Password
+# field writes the plaintext straight to tabSingles and never touches __Auth
+# (jarvis/_password_utils.py documents this), and BaseDocument.get_password
+# prefers that column but FALLS BACK to __Auth once it is blanked. So on a real
+# doc, "cleared" could not be made to read as cleared without dropping the
+# site's own rows. The fix is therefore not to soften the teardown but to stop
+# using a real doc.
+#
+# Nothing here needs one. Everything admin_client reads off Jarvis Settings is
+# three things - jarvis_admin_url, jarvis_admin_customer_email and
+# get_password() - so a plain object serves the whole surface while writing no
+# tabSingles row, no __Auth row and no commit. Same seam
+# TestPermanentRejectionClassification already uses; #542 proved it there and
+# this generalises it to the module.
+
+
+class _FakeSettings:
+	"""Stand-in for the Jarvis Settings Single, for admin_client's readers only.
+
+	``get_password`` mirrors ``BaseDocument.get_password``'s contract minus the
+	``__Auth`` fallback, which is the entire point: there is no encrypted store
+	behind this, so a field that was cleared reads as cleared and cannot serve a
+	real credential left over from the site.
+	"""
+
+	_FIELDS = (
+		"jarvis_admin_url",
+		"jarvis_admin_customer_email",
+		"jarvis_admin_api_key",
+		"jarvis_admin_api_secret",
+		"jarvis_admin_customer_password",
+	)
+
+	def __init__(self):
+		self.reset()
+
+	def reset(self):
+		for field in self._FIELDS:
+			setattr(self, field, "")
+
+	def get(self, fieldname, default=None):
+		return getattr(self, fieldname, default)
+
+	def get_password(self, fieldname="password", raise_exception=True):
+		value = getattr(self, fieldname, "") or ""
+		if not value and raise_exception:
+			frappe.throw(f"Password not found for Jarvis Settings {fieldname}")
+		return value
+
+	def db_set(self, fieldname, value=None, **kwargs):
+		"""Accepts both call shapes the real Document.db_set does. Writes to this
+		object alone - the tests that reach for it are configuring the fixture,
+		not asserting on persistence."""
+		for field, val in (fieldname if isinstance(fieldname, dict) else {fieldname: value}).items():
+			setattr(self, field, val)
+
+
+_ADMIN_SETTINGS = _FakeSettings()
+_REAL_GET_SINGLE = frappe.get_single
+_get_single_patcher = None
+
+
+def _fake_get_single(doctype, *args, **kwargs):
+	"""Serve the fake for Jarvis Settings ONLY; every other doctype still
+	resolves normally, so this cannot quietly change unrelated behaviour."""
+	if doctype == "Jarvis Settings":
+		return _ADMIN_SETTINGS
+	return _REAL_GET_SINGLE(doctype, *args, **kwargs)
+
+
+def setUpModule():
+	global _get_single_patcher
+	_get_single_patcher = patch("frappe.get_single", side_effect=_fake_get_single)
+	_get_single_patcher.start()
+
+
+def tearDownModule():
+	if _get_single_patcher is not None:
+		_get_single_patcher.stop()
+
+
+def _require_fake_settings():
+	"""Refuse to run against a real Single. Without this, a runner that skipped
+	the module fixture would send every helper below straight back at the site's
+	own Jarvis Settings - silently, which is exactly how #566 went unnoticed."""
+	if frappe.get_single("Jarvis Settings") is not _ADMIN_SETTINGS:
+		raise RuntimeError(
+			"test_admin_client fixtures require the module-level frappe.get_single patch; "
+			"refusing to touch the real Jarvis Settings (see jarvis #566)"
+		)
+
 
 def _settings_for_admin(
 	admin_url="https://admin.example.com", api_key="customer-key-123", api_secret="customer-secret-456"
 ):
-	"""Configure Jarvis Settings for the admin path. Uses db_set to bypass
-	read_only on the fields."""
-	settings = frappe.get_single("Jarvis Settings")
-	settings.db_set("jarvis_admin_url", admin_url)
-	settings.db_set("jarvis_admin_api_key", api_key)
-	settings.db_set("jarvis_admin_api_secret", api_secret)
-	frappe.db.commit()
+	"""Configure the fake Jarvis Settings for the api_key:api_secret path."""
+	_require_fake_settings()
+	_ADMIN_SETTINGS.reset()
+	_ADMIN_SETTINGS.jarvis_admin_url = admin_url
+	_ADMIN_SETTINGS.jarvis_admin_api_key = api_key
+	_ADMIN_SETTINGS.jarvis_admin_api_secret = api_secret
 
 
 def _settings_for_oauth(
@@ -40,30 +138,24 @@ def _settings_for_oauth(
 	api_key="",
 	api_secret="",
 ):
-	"""Configure Jarvis Settings for the OAuth bearer path. By default no
+	"""Configure the fake Jarvis Settings for the OAuth bearer path. By default no
 	api_key/secret so the bearer path is exercised in isolation; pass them to
 	test the 401 -> legacy fallback."""
-	settings = frappe.get_single("Jarvis Settings")
-	settings.db_set("jarvis_admin_url", admin_url)
-	settings.db_set("jarvis_admin_customer_email", email)
-	settings.db_set("jarvis_admin_customer_password", password)
-	settings.db_set("jarvis_admin_api_key", api_key)
-	settings.db_set("jarvis_admin_api_secret", api_secret)
-	frappe.db.commit()
+	_require_fake_settings()
+	_ADMIN_SETTINGS.reset()
+	_ADMIN_SETTINGS.jarvis_admin_url = admin_url
+	_ADMIN_SETTINGS.jarvis_admin_customer_email = email
+	_ADMIN_SETTINGS.jarvis_admin_customer_password = password
+	_ADMIN_SETTINGS.jarvis_admin_api_key = api_key
+	_ADMIN_SETTINGS.jarvis_admin_api_secret = api_secret
 	frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
 
 
 def _settings_clear_admin():
-	from frappe.utils.password import remove_encrypted_password
-
-	settings = frappe.get_single("Jarvis Settings")
-	settings.db_set("jarvis_admin_url", "")
-	settings.db_set("jarvis_admin_customer_email", "")
-	# Password fields need __Auth cleared too, not just the column.
-	for f in ("jarvis_admin_api_key", "jarvis_admin_api_secret", "jarvis_admin_customer_password"):
-		remove_encrypted_password("Jarvis Settings", "Jarvis Settings", f)
-		settings.db_set(f, "")
-	frappe.db.commit()
+	"""Blank every admin field. No __Auth row exists behind the fake, so this is
+	the whole of "not onboarded" - nothing is deleted and nothing to restore."""
+	_require_fake_settings()
+	_ADMIN_SETTINGS.reset()
 	frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
 
 
@@ -713,7 +805,6 @@ class TestMissingConfig(FrappeTestCase):
 		settings.db_set("jarvis_admin_url", "https://admin.example.com")
 		settings.db_set("jarvis_admin_api_key", "")
 		settings.db_set("jarvis_admin_api_secret", "")
-		frappe.db.commit()
 		try:
 			with self.assertRaises(AdminAuthError):
 				post_update_llm_creds("p", "m", "b", "k")
@@ -727,7 +818,6 @@ class TestMissingConfig(FrappeTestCase):
 		settings.db_set("jarvis_admin_url", "https://admin.example.com")
 		settings.db_set("jarvis_admin_api_key", "some-key")
 		settings.db_set("jarvis_admin_api_secret", "")
-		frappe.db.commit()
 		try:
 			with self.assertRaises(AdminAuthError):
 				post_update_llm_creds("p", "m", "b", "k")
@@ -1426,3 +1516,55 @@ class TestAdminAppNamespace(FrappeTestCase):
 		)
 		with patch.dict(frappe.local.conf, {"jarvis_admin_app": "jarvis_admin_v2"}):
 			self.assertNotIn("jarvis_admin", admin_client._OAUTH_TOKEN_PATH)
+
+
+class TestFixturesCannotDestroySiteCredentials(FrappeTestCase):
+	"""jarvis #566: pins the safety property of this module's own fixtures.
+
+	They previously committed writes to the real Jarvis Settings Single and
+	dropped three of its Password fields from __Auth on teardown, which took
+	site.jarvis's control-plane credentials on 2026-07-30. The damage was silent
+	- the teardown restored nothing and the failures surfaced much later, in
+	admin calls with no visible link back to a test run - so the guard against
+	it needs to be an assertion rather than a comment.
+	"""
+
+	def tearDown(self):
+		_ADMIN_SETTINGS.reset()
+
+	def test_no_fixture_removes_an_encrypted_password(self):
+		"""The exact operation from the incident. Patched at its definition site
+		so a lazy `from frappe.utils.password import ...` inside a helper is
+		caught too."""
+		with patch("frappe.utils.password.remove_encrypted_password") as removed:
+			_settings_for_admin()
+			_settings_for_oauth()
+			_settings_clear_admin()
+		removed.assert_not_called()
+
+	def test_the_module_resolves_jarvis_settings_to_the_fake(self):
+		self.assertIs(frappe.get_single("Jarvis Settings"), _ADMIN_SETTINGS)
+
+	def test_other_doctypes_still_resolve_normally(self):
+		"""The patch is scoped by doctype, so it cannot quietly change behaviour
+		for anything this module did not intend to fake."""
+		self.assertIsNot(frappe.get_single("System Settings"), _ADMIN_SETTINGS)
+
+	def test_a_cleared_credential_reads_as_cleared(self):
+		"""What the destructive teardown was actually FOR. On the real doc,
+		blanking the column made get_password fall through to __Auth and hand
+		back the site's own secret, so "not onboarded" tests could only be made
+		honest by deleting it. With no encrypted store behind the fake, blank is
+		simply blank."""
+		_settings_for_admin(api_key="fixture-key", api_secret="fixture-secret")
+		_settings_clear_admin()
+		settings = frappe.get_single("Jarvis Settings")
+		for field in ("jarvis_admin_api_key", "jarvis_admin_api_secret", "jarvis_admin_customer_password"):
+			self.assertEqual(settings.get_password(field, raise_exception=False), "")
+
+	def test_a_fixture_refuses_to_run_against_the_real_single(self):
+		"""A runner that skipped setUpModule would otherwise send every helper
+		straight back at the site's own settings, silently."""
+		with patch("frappe.get_single", _REAL_GET_SINGLE):
+			with self.assertRaises(RuntimeError):
+				_settings_clear_admin()

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -68,9 +68,6 @@ class _FakeSettings:
 		for field in self._FIELDS:
 			setattr(self, field, "")
 
-	def get(self, fieldname, default=None):
-		return getattr(self, fieldname, default)
-
 	def get_password(self, fieldname="password", raise_exception=True):
 		value = getattr(self, fieldname, "") or ""
 		if not value and raise_exception:
@@ -118,6 +115,19 @@ def _require_fake_settings():
 			"test_admin_client fixtures require the module-level frappe.get_single patch; "
 			"refusing to touch the real Jarvis Settings (see jarvis #566)"
 		)
+
+
+def _admin_settings():
+	"""The ONLY sanctioned way for a test in this module to hold the settings doc.
+
+	A bare frappe.get_single here would be correct while the module patch is up and
+	catastrophic if it ever is not, and it reads identically in both cases - so the
+	guard has to sit in front of every reach for the doc, not just the three fixture
+	helpers. Checking first also keeps the failure ordered: a test that grabbed the
+	real Single and then wrote to it would blow up in its own `finally` cleanup,
+	AFTER the write it was supposed to prevent."""
+	_require_fake_settings()
+	return frappe.get_single("Jarvis Settings")
 
 
 def _settings_for_admin(
@@ -801,7 +811,7 @@ class TestMissingConfig(FrappeTestCase):
 		"""api_key + api_secret are required; missing either raises early."""
 		from jarvis.exceptions import AdminAuthError
 
-		settings = frappe.get_single("Jarvis Settings")
+		settings = _admin_settings()
 		settings.db_set("jarvis_admin_url", "https://admin.example.com")
 		settings.db_set("jarvis_admin_api_key", "")
 		settings.db_set("jarvis_admin_api_secret", "")
@@ -814,7 +824,7 @@ class TestMissingConfig(FrappeTestCase):
 	def test_no_secret_raises_auth_error(self):
 		from jarvis.exceptions import AdminAuthError
 
-		settings = frappe.get_single("Jarvis Settings")
+		settings = _admin_settings()
 		settings.db_set("jarvis_admin_url", "https://admin.example.com")
 		settings.db_set("jarvis_admin_api_key", "some-key")
 		settings.db_set("jarvis_admin_api_secret", "")
@@ -1558,7 +1568,7 @@ class TestFixturesCannotDestroySiteCredentials(FrappeTestCase):
 		simply blank."""
 		_settings_for_admin(api_key="fixture-key", api_secret="fixture-secret")
 		_settings_clear_admin()
-		settings = frappe.get_single("Jarvis Settings")
+		settings = _admin_settings()
 		for field in ("jarvis_admin_api_key", "jarvis_admin_api_secret", "jarvis_admin_customer_password"):
 			self.assertEqual(settings.get_password(field, raise_exception=False), "")
 


### PR DESCRIPTION
Fixes #566

`_settings_for_admin` / `_settings_clear_admin` configured the **real** Jarvis
Settings Single and, on teardown, called `remove_encrypted_password()` on three
of its Password fields. Both halves committed, so the whole thing escaped
`FrappeTestCase`'s rollback: running this module against a real site
permanently destroyed that site's control-plane credentials.

Not theoretical. It took `site.jarvis`'s `jarvis_admin_api_key`,
`jarvis_admin_api_secret` and `jarvis_admin_customer_password` on 2026-07-30,
during the work on #542, and they had to be restored by hand.

## Why the destructive line was there

It was load-bearing **given the setup**, which is worth spelling out because it
rules out the obvious smaller fix.

`db_set` on a Password field writes the plaintext straight into `tabSingles`
and never touches `__Auth` (`jarvis/_password_utils.py` documents exactly
this). `BaseDocument.get_password` prefers that column, but **falls back to
`__Auth` once it is blanked**. So on a real doc, `_settings_clear_admin` could
not make a field read as cleared without dropping the site's own rows: blank
the column alone and the "not onboarded" tests would quietly authenticate with
the bench's real credentials.

Simply deleting the `remove_encrypted_password` call would therefore have
turned a loud problem into a quiet one. The fix is not to soften the teardown.
It is to stop using a real doc.

## The change

Everything `admin_client` reads off Jarvis Settings is three things:
`jarvis_admin_url`, `jarvis_admin_customer_email` and `get_password()`. A plain
`_FakeSettings` object serves all of it while writing no `tabSingles` row, no
`__Auth` row and no commit. `get_password` deliberately has no `__Auth`
fallback, which is the whole point: a cleared field is simply clear and cannot
serve a leftover real credential.

This is the same seam `TestPermanentRejectionClassification` already uses. #542
introduced it there for this exact reason and left the old fixture in place for
the pre-existing tests; this generalises it to the module and retires the old
one.

Scoping choices:

- **The helpers keep their names and signatures**, so all ~40 call sites across
  15 test classes are unchanged. The diff is three helper bodies plus the
  fixture, not a rewrite of the suite.
- **`frappe.get_single` is patched for `"Jarvis Settings"` only** and delegates
  every other doctype to the real function, so this cannot quietly change
  behaviour for anything the module did not intend to fake.
- **The helpers refuse to run when that patch is not active.** A runner that
  skipped `setUpModule` would otherwise send them straight back at the site's
  own settings. The original failure was silent, so the guard is an assertion,
  not a comment.
- Two now-meaningless `frappe.db.commit()` calls in `TestMissingConfig` were
  dropped; nothing is written for them to commit.

## Tests

`TestFixturesCannotDestroySiteCredentials`, 5 cases pinning the safety property
itself rather than trusting the comment:

- no fixture calls `remove_encrypted_password` (patched at its definition site,
  so a lazy import inside a helper is caught) — the exact operation from the
  incident
- the module resolves Jarvis Settings to the fake
- other doctypes still resolve normally, pinning the scoping
- a cleared credential reads as cleared, which is what the destructive teardown
  was actually for
- a fixture raises rather than running against the real Single

## Verification

Static, not executed. Running this module is precisely the thing that was
unsafe before this change, and `bench run-tests` would execute the installed
app path rather than this worktree, so a local run would have used the old
destructive code against a live site. CI is the gate.

What was checked instead: every `settings.<attr>` reachable from
`admin_client.py` (`get_password`, `jarvis_admin_customer_email`,
`jarvis_admin_url`) and every route it uses to obtain the doc (three
`frappe.get_single` calls, no `get_cached_doc`, no `get_single_value`) against
what the fake provides; plus the same sweep over the test module itself
(`db_set`, `get_password`, `jarvis_admin_api_key`, `jarvis_admin_url` — the
last two on a test's own local MagicMock). `get_default_admin_url` reads
`frappe.conf`, not the Single.

One consequence worth naming: after this lands, this module is safe to run
against a real site, which it has not been.
