### PR TITLE
fix(chat): confirmation cards break on Frappe v15 / Redis < 6.2 (RedisWrapper.expire_key + GETDEL)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -157,15 +157,16 @@ export const applyAction = (action) =>
 // Write-safety gate (issue #186): confirm a parked ERP write by its one-time
 // token. Pass the conversation the click came from so the server enforces the
 // real conversation guard (#11). Returns the tool result envelope {ok, ...} on
-// success, or {ok:False, error:{type:"InvalidConfirmation", ...}} if the token
-// is gone.
+// success. A gone token returns InvalidConfirmation; a Redis outage returns a
+// ConfirmationUnavailableError/ConfirmationOutcomeUnknownError that the UI must
+// keep on screen because the business action did not run in that request.
 export const confirmTool = (token, conversation) =>
 	call(AC + "confirm_tool", { token, conversation: conversation || "" });
 // Discard a parked ERP write by its one-time token: consumes the token (so it
 // can't replay or re-surface on reload), leaves a durable "discarded" receipt
 // chip in the transcript, and queues a note so the agent's next turn learns it
 // was vetoed. Returns {ok, data:{status:"discarded"|"already_handled"}}; the SPA
-// drops the card either way.
+// drops the card for those success states; storage-error envelopes retain it.
 export const dismissTool = (token, conversation) =>
 	call(AC + "dismiss_tool", { token, conversation: conversation || "" });
 // Resync (issue #186, R3 fix for #3): re-surface the caller's own currently

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -365,6 +365,7 @@ async function refreshPending() {
 	}
 	try {
 		const env = await listPendingConfirmations(conversation.value);
+		if (env && env.ok === false) return;
 		const items = (env && env.data && env.data.pending) || [];
 		// keep in-flight busy flags across refreshes
 		const busy = new Set(pendingCards.value.filter((c) => c.busy).map((c) => c.token));
@@ -376,6 +377,11 @@ async function refreshPending() {
 
 function removeCard(token) {
 	pendingCards.value = pendingCards.value.filter((c) => c.token !== token);
+}
+
+function confirmationStorageUnavailable(response) {
+	const type = response && response.error && response.error.type;
+	return type === "ConfirmationUnavailableError" || type === "ConfirmationOutcomeUnknownError";
 }
 
 // ── pending-card copy ─────────────────────────────────────────────────────────
@@ -436,15 +442,23 @@ function cardMeta(pa) {
 
 async function approve(pa) {
 	pa.busy = true;
+	let keepCard = false;
 	try {
 		const r = await confirmTool(pa.token, conversation.value);
 		if (r && r.ok === false) {
-			toast.error("Couldn't confirm — it may have expired. Ask again in the chat.");
+			keepCard = confirmationStorageUnavailable(r);
+			toast.error(
+				keepCard
+					? r.error.message
+					: "Couldn't confirm — it may have expired. Ask again in the chat."
+			);
 		}
 	} catch (e) {
+		keepCard = true;
 		toast.error(errMsg(e));
 	} finally {
-		removeCard(pa.token);
+		if (keepCard) pa.busy = false;
+		else removeCard(pa.token);
 		// the parked run resumes server-side after a confirm: refresh both the
 		// transcript (receipt chip) and anything list-shaped upstream
 		scheduleRefetch();
@@ -454,12 +468,19 @@ async function approve(pa) {
 
 async function dismiss(pa) {
 	pa.busy = true;
+	let keepCard = false;
 	try {
-		await dismissTool(pa.token, conversation.value);
+		const r = await dismissTool(pa.token, conversation.value);
+		if (r && r.ok === false) {
+			keepCard = confirmationStorageUnavailable(r);
+			toast.error((r.error && r.error.message) || "Could not discard this confirmation.");
+		}
 	} catch (e) {
+		keepCard = true;
 		toast.error(errMsg(e));
 	} finally {
-		removeCard(pa.token);
+		if (keepCard) pa.busy = false;
+		else removeCard(pa.token);
 		scheduleRefetch();
 	}
 }

--- a/frontend/src/pages/triggers/TriggerChatPane.vue
+++ b/frontend/src/pages/triggers/TriggerChatPane.vue
@@ -347,6 +347,7 @@ async function refreshPending() {
 	}
 	try {
 		const env = await listPendingConfirmations(conversation.value);
+		if (env && env.ok === false) return;
 		const items = (env && env.data && env.data.pending) || [];
 		// keep in-flight busy flags across refreshes
 		const busy = new Set(pendingCards.value.filter((c) => c.busy).map((c) => c.token));
@@ -358,6 +359,11 @@ async function refreshPending() {
 
 function removeCard(token) {
 	pendingCards.value = pendingCards.value.filter((c) => c.token !== token);
+}
+
+function confirmationStorageUnavailable(response) {
+	const type = response && response.error && response.error.type;
+	return type === "ConfirmationUnavailableError" || type === "ConfirmationOutcomeUnknownError";
 }
 
 // ── pending-card copy ─────────────────────────────────────────────────────────
@@ -424,15 +430,23 @@ function cardMeta(pa) {
 
 async function approve(pa) {
 	pa.busy = true;
+	let keepCard = false;
 	try {
 		const r = await confirmTool(pa.token, conversation.value);
 		if (r && r.ok === false) {
-			toast.error("Couldn't confirm — it may have expired. Ask again in the chat.");
+			keepCard = confirmationStorageUnavailable(r);
+			toast.error(
+				keepCard
+					? r.error.message
+					: "Couldn't confirm — it may have expired. Ask again in the chat."
+			);
 		}
 	} catch (e) {
+		keepCard = true;
 		toast.error(errMsg(e));
 	} finally {
-		removeCard(pa.token);
+		if (keepCard) pa.busy = false;
+		else removeCard(pa.token);
 		// the parked run resumes server-side after a confirm: refresh both the
 		// transcript (receipt chip) and the triggers list (a row may now exist)
 		scheduleRefetch();
@@ -442,12 +456,19 @@ async function approve(pa) {
 
 async function dismiss(pa) {
 	pa.busy = true;
+	let keepCard = false;
 	try {
-		await dismissTool(pa.token, conversation.value);
+		const r = await dismissTool(pa.token, conversation.value);
+		if (r && r.ok === false) {
+			keepCard = confirmationStorageUnavailable(r);
+			toast.error((r.error && r.error.message) || "Could not discard this confirmation.");
+		}
 	} catch (e) {
+		keepCard = true;
 		toast.error(errMsg(e));
 	} finally {
-		removeCard(pa.token);
+		if (keepCard) pa.busy = false;
+		else removeCard(pa.token);
 		scheduleRefetch();
 	}
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -5732,6 +5732,10 @@ function removePending(token) {
 	if (!token) return;
 	pendingActions.value = pendingActions.value.filter((x) => x.token !== token);
 }
+function confirmationStorageUnavailable(response) {
+	const type = response && response.error && response.error.type;
+	return type === "ConfirmationUnavailableError" || type === "ConfirmationOutcomeUnknownError";
+}
 // Enqueue a parked confirmation, deduped by token (a resync + a live event can
 // both carry the same card).
 function enqueuePending(card) {
@@ -5767,6 +5771,12 @@ async function confirmPending(pa) {
 	try {
 		const r = await api.confirmTool(token, pa.conversation || currentId.value || "");
 		if (r && r.ok === false) {
+			if (confirmationStorageUnavailable(r)) {
+				const card = cardById();
+				if (card) card.error = r.error;
+				notify(r.error.message, { type: "error" });
+				return;
+			}
 			// Token gone/expired/used, or the executed tool reported failure. Either
 			// way the card is spent - surface a brief note and dismiss.
 			if (r.error && r.error.type === "InvalidConfirmation") {
@@ -5822,17 +5832,28 @@ async function confirmPending(pa) {
 // Dismiss: consume the token server-side (closes the 15-min replay window and
 // stops the card re-surfacing on reload), leave a durable "discarded" receipt
 // chip, and queue a note so the agent's next turn learns it was vetoed. Fires NO
-// agent turn. Best-effort: even if the call fails, the card drops locally (the
-// token TTL-expires) - only the chip would be missing.
+// agent turn. Storage/transport failures keep the card visible so an outage is
+// not mistaken for a successful discard; the server-side token still self-expires.
 async function discardPending(pa) {
 	if (!pa || pa.busy) return;
 	const token = pa.token;
 	const conv = pa.conversation || currentId.value || "";
 	pa.busy = true;
 	try {
-		await api.dismissTool(token, conv);
+		const r = await api.dismissTool(token, conv);
+		if (r && r.ok === false && confirmationStorageUnavailable(r)) {
+			pa.error = r.error;
+			notify(r.error.message, { type: "error" });
+			return;
+		}
 	} catch (e) {
-		// Swallow - drop the card regardless (the token self-expires server-side).
+		pa.error = {
+			message:
+				(e && e.messages && e.messages[0]) || (e && e.message) || "Could not discard.",
+		};
+		return;
+	} finally {
+		pa.busy = false;
 	}
 	removePending(token);
 	// Re-fetch so the durable "discarded" chip shows in the thread.
@@ -5850,6 +5871,7 @@ async function resyncPendingConfirmations(id) {
 	let items = [];
 	try {
 		const r = await api.listPendingConfirmations(id);
+		if (r && r.ok === false) return;
 		items = (r && r.data && r.data.pending) || [];
 	} catch (e) {
 		return;

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -1146,10 +1146,19 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 		#   tokens under any filter (F1), so re-filter to record.conversation == conv
 		#   - an unrelated conv-less token (a rare session-resolution miss) must not
 		#   block a legitimate new card here.
-		if conv and any(
-			t.get("conversation") == conv
-			for t in pending_confirm.list_for_owner(owner_user, conversation=conv)
-		):
+		try:
+			conversation_pending = conv and any(
+				t.get("conversation") == conv
+				for t in pending_confirm.list_for_owner(owner_user, conversation=conv, strict=True)
+			)
+		except pending_confirm.PendingConfirmStorageError:
+			return _error(
+				"ConfirmationUnavailableError",
+				"could not check whether another confirmation is already pending "
+				"(a storage error). Nothing was changed. You may retry this exact "
+				"call once; if it still fails, tell the user and stop - do not loop.",
+			)
+		if conversation_pending:
 			return _error(
 				"ConfirmationPendingError",
 				"a confirmation card for a previous action is still awaiting the "

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -343,6 +343,41 @@ _INVALID_CONFIRM = {
 	},
 }
 
+_CONFIRMATION_UNAVAILABLE = {
+	"ok": False,
+	"error": {
+		"type": "ConfirmationUnavailableError",
+		"message": (
+			"Confirmation storage is temporarily unavailable. Nothing was changed "
+			"by this request. Keep this card and try again shortly."
+		),
+	},
+}
+
+_CONFIRMATION_OUTCOME_UNKNOWN = {
+	"ok": False,
+	"error": {
+		"type": "ConfirmationOutcomeUnknownError",
+		"message": (
+			"The confirmation token's storage outcome could not be verified. The "
+			"business action was not run by this request. Refresh the confirmations "
+			"before trying again."
+		),
+	},
+}
+
+
+def _confirmation_storage_error(exc) -> dict:
+	"""Stable user envelope for a Redis failure; never mislabel it as expiry."""
+	from jarvis.chat import pending_confirm
+
+	frappe.logger("jarvis.pending_confirm").error(
+		"confirmation endpoint stopped before the business action: %s", type(exc).__name__
+	)
+	if isinstance(exc, pending_confirm.PendingConfirmOutcomeUnknown):
+		return _CONFIRMATION_OUTCOME_UNKNOWN
+	return _CONFIRMATION_UNAVAILABLE
+
 
 @frappe.whitelist()
 @require_jarvis_user
@@ -384,16 +419,19 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 	from jarvis.chat import pending_confirm
 
 	token = (token or "").strip()
-	record = pending_confirm.peek(token)
-	if not record:
-		return _INVALID_CONFIRM
+	try:
+		record = pending_confirm.peek(token, strict=True)
+		if not record:
+			return _INVALID_CONFIRM
 
-	# Real conversation guard (#11): if the caller passed the conversation the
-	# click came from, enforce it; otherwise fall back to the record's own
-	# conversation (owner + single-use remain the guarantees).
-	passed_conv = (conversation or "").strip()
-	guard_conv = passed_conv if passed_conv else record.get("conversation")
-	record = pending_confirm.consume(token, owner=frappe.session.user, conversation=guard_conv)
+		# Real conversation guard (#11): if the caller passed the conversation the
+		# click came from, enforce it; otherwise fall back to the record's own
+		# conversation (owner + single-use remain the guarantees).
+		passed_conv = (conversation or "").strip()
+		guard_conv = passed_conv if passed_conv else record.get("conversation")
+		record = pending_confirm.consume(token, owner=frappe.session.user, conversation=guard_conv)
+	except pending_confirm.PendingConfirmStorageError as exc:
+		return _confirmation_storage_error(exc)
 	if not record:
 		return _INVALID_CONFIRM
 
@@ -536,15 +574,18 @@ def dismiss_tool(token: str, conversation: str | None = None) -> dict:
 	from jarvis.chat import pending_confirm
 
 	token = (token or "").strip()
-	record = pending_confirm.peek(token)
-	if not record:
-		return {"ok": True, "data": {"status": "already_handled"}}
+	try:
+		record = pending_confirm.peek(token, strict=True)
+		if not record:
+			return {"ok": True, "data": {"status": "already_handled"}}
 
-	# Same owner + conversation binding as confirm_tool: consume atomically so a
-	# concurrent Confirm and Discard cannot both win.
-	passed_conv = (conversation or "").strip()
-	guard_conv = passed_conv if passed_conv else record.get("conversation")
-	record = pending_confirm.consume(token, owner=frappe.session.user, conversation=guard_conv)
+		# Same owner + conversation binding as confirm_tool: consume atomically so a
+		# concurrent Confirm and Discard cannot both win.
+		passed_conv = (conversation or "").strip()
+		guard_conv = passed_conv if passed_conv else record.get("conversation")
+		record = pending_confirm.consume(token, owner=frappe.session.user, conversation=guard_conv)
+	except pending_confirm.PendingConfirmStorageError as exc:
+		return _confirmation_storage_error(exc)
 	if not record:
 		return {"ok": True, "data": {"status": "already_handled"}}
 
@@ -595,5 +636,8 @@ def list_pending_confirmations(conversation: str | None = None) -> dict:
 	# terminal use (pending_confirm.list_items_for_owner) so the three cannot drift
 	# and no internal field leaks. The park-time preview is returned verbatim (F2 -
 	# never a re-run dry-run) and the per-record F3 guard both live in the helper.
-	items = pending_confirm.list_items_for_owner(frappe.session.user, conversation=conv)
+	try:
+		items = pending_confirm.list_items_for_owner(frappe.session.user, conversation=conv, strict=True)
+	except pending_confirm.PendingConfirmStorageError as exc:
+		return _confirmation_storage_error(exc)
 	return {"ok": True, "data": {"pending": items}}

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -195,8 +195,18 @@ def mint(
 		cache.sadd(_owner_key(owner), token)
 		# set_value swallows a redis blip, so confirm the record is really readable
 		# before we let a card be published against this token. A strict read keeps
-		# an outage distinct from a genuine persist miss; both fail closed here.
-		if peek(token, strict=True) is None:
+		# an outage distinct from a genuine persist miss. Retry one transient read
+		# once so a good park is not immediately torn down because its first verify
+		# reply was lost; a second failure still fails closed through the outer block.
+		try:
+			persisted = peek(token, strict=True)
+		except PendingConfirmStorageError as exc:
+			frappe.logger("jarvis.pending_confirm").error(
+				"park verification read failed; retrying once before rollback: %s",
+				type(exc.__cause__).__name__ if exc.__cause__ else type(exc).__name__,
+			)
+			persisted = peek(token, strict=True)
+		if persisted is None:
 			raise RuntimeError("pending-confirm record did not persist")
 	except Exception:
 		frappe.log_error(

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -173,7 +173,6 @@ def mint(
 	try:
 		cache.set_value(_key(token), record, expires_in_sec=_TTL_S)
 		cache.sadd(_owner_key(owner), token)
-		cache.expire_key(_owner_key(owner), _TTL_S)
 		# set_value swallows a redis blip, so confirm the record is really readable
 		# before we let a card be published against this token.
 		if peek(token) is None:
@@ -192,6 +191,18 @@ def mint(
 			except Exception:
 				pass
 		return None
+	# Refresh the owner-index set's TTL so an emptied set self-expires (see the module
+	# docstring). PURE HYGIENE - dead members are pruned on read regardless - so it must
+	# NEVER fail the park: a record that already persisted + verified is live and
+	# confirmable whether or not this TTL lands, which is why it sits OUTSIDE the try
+	# above. Uses the raw redis ``expire`` on the make_key'd set key (present on every
+	# Frappe version) rather than ``RedisWrapper.expire_key`` - Frappe >= 17 only, whose
+	# AttributeError on a v15 bench was caught by the park's try/except and rolled back a
+	# good record, taking down every gated confirmation card.
+	try:
+		cache.expire(cache.make_key(_owner_key(owner)), _TTL_S)
+	except Exception:
+		pass
 	# cards_open gauge +1 (self-healing on expiry via the ZSET score). Bumped only
 	# after a successful persist+index+verify so the gauge never over-counts a
 	# rolled-back park.
@@ -210,6 +221,24 @@ def peek(token: str) -> dict | None:
 	return frappe.cache().get_value(_key(token), use_local_cache=False)
 
 
+def _get_and_delete(full_key):
+	"""Atomically read-and-remove a raw cache key, returning its pickled bytes (or
+	None if absent). Uses a MULTI/EXEC transaction (GET then DEL) rather than the
+	one-shot GETDEL command: GETDEL is redis-server >= 6.2 only, and a customer
+	bench may run older (a v6.0 server rejects it), whereas GET/DEL under MULTI/EXEC
+	run as one indivisible unit on EVERY redis version. That keeps the single-winner
+	consume guarantee - the server serializes the two transactions, so of two racing
+	confirms exactly one sees the value before DEL removes it - without the version
+	floor. ``full_key`` is the already-make_key'd key (raw redis, no re-namespacing),
+	matching what the previous getdel operated on.
+	"""
+	pipe = frappe.cache().pipeline(transaction=True)
+	pipe.get(full_key)
+	pipe.delete(full_key)
+	raw, _deleted = pipe.execute()
+	return raw
+
+
 def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	"""Validate AND atomically single-use-consume. Returns the stored record
 	ONLY when: token exists, record.owner == owner, and (when the record has a
@@ -222,13 +251,14 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 
 	Atomicity: ownership is checked first with a plain (non-destructive)
 	read, so a mismatched call never touches the stored key. Only once
-	ownership matches do we delete - and that delete uses Redis' GETDEL,
-	a single atomic server-side command (get-and-delete in one round trip,
-	no separate check-then-delete on our side). If two confirmed consumes
-	race each other here, the server serializes the two GETDELs: exactly
-	one gets the pickled record back, the other gets None. That is the
-	single-use guarantee - it does not depend on Python-level locking,
-	which would not help anyway across separate worker processes.
+	ownership matches do we delete - and that delete is an atomic
+	get-and-delete (``_get_and_delete``: GET then DEL inside one MULTI/EXEC
+	transaction, portable to redis < 6.2 which lacks GETDEL). If two
+	confirmed consumes race each other here, the server serializes the two
+	transactions: exactly one gets the pickled record back, the other gets
+	None. That is the single-use guarantee - it does not depend on
+	Python-level locking, which would not help anyway across separate
+	worker processes.
 	"""
 	if not token:
 		return None
@@ -251,20 +281,21 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 		return None
 
 	full_key = frappe.cache().make_key(_key(token))
-	# GETDEL is a raw redis-py command, not one of RedisWrapper's own wrapped
-	# methods (get_value/set_value/...), so unlike those it is NOT wrapped in
-	# RedisWrapper's usual suppress(redis.exceptions.ConnectionError) - a
-	# transient redis blip here would otherwise propagate as an uncaught 500
-	# instead of the graceful None the caller expects (treated as
-	# not-consumable -> InvalidConfirmation; the token is not burned, the user
-	# can retry). Also defensively catch ResponseError: GETDEL requires
-	# redis-server >= 6.2, and an older/misconfigured server rejects the
-	# command outright. Either error returns None here WITHOUT falling back to
-	# a non-atomic get-then-delete, which would reintroduce the very race
-	# GETDEL exists to close - only the same atomic getdel is retried on a
-	# later call.
+	# Atomic get-and-delete. GETDEL would be the one-command way but it is
+	# redis-server >= 6.2 ONLY, and a customer bench may run older (a v6.0 server
+	# rejects it outright) - so _get_and_delete uses a MULTI/EXEC transaction
+	# (GET then DEL as one indivisible unit) instead. That keeps the single-winner
+	# guarantee (of two concurrent confirms exactly one sees the value before DEL
+	# removes it) while working on every redis version; a plain get-then-delete
+	# would reopen the very race the atomicity exists to close. Catch both a
+	# transient blip (ConnectionError) AND a degraded-write state (ResponseError -
+	# e.g. -MISCONF stop-writes-on-bgsave-error, or a read-only replica, under which
+	# the write DEL inside the transaction errors) and turn either into a graceful
+	# None (treated as not-consumable -> InvalidConfirmation; the token is NOT
+	# burned, so a retry against a healthy cache still succeeds) rather than an
+	# uncaught 500 on the whitelisted Confirm endpoint.
 	try:
-		raw = frappe.cache().getdel(full_key)
+		raw = _get_and_delete(full_key)
 	except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
 		return None
 	frappe.local.cache.pop(full_key, None)

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -15,8 +15,8 @@ TTL so a token that nobody clicks self-expires instead of leaking forever.
 
 Portability floor: this module runs on the CUSTOMER bench, whose Frappe/Redis
 versions vary. It must stay compatible down to **Frappe 15** and **Redis 6.0**.
-Do NOT reach for a Frappe >= 16/17-only RedisWrapper method (``expire_key``, the
-``use_local_cache`` get_value kwarg) or a Redis >= 6.2-only command (``GETDEL``,
+Do NOT reach for a RedisWrapper method missing from Frappe 15 (``expire_key``,
+the ``use_local_cache`` get_value kwarg) or a Redis >= 6.2-only command (``GETDEL``,
 ``GETEX``, ``COPY``, ``SINTERCARD``, ...) - use an inherited ``redis.Redis``
 builtin or a MULTI/EXEC transaction instead.
 """
@@ -34,6 +34,7 @@ import redis.exceptions
 
 _TTL_S = 900  # 15 min; a confirmation token the user must click within
 _PREFIX = "jarvis:pending_confirm:"
+_CLAIM_PREFIX = "jarvis:pending_confirm:claim:"
 # Per-owner index: a Redis set of the owner's currently-live token ids, so the
 # resync endpoint can enumerate a user's own parked confirmations after a reload
 # or reconnect. TTL discipline: dead members
@@ -48,6 +49,18 @@ def _key(token: str) -> str:
 
 def _owner_key(owner: str) -> str:
 	return _OWNER_PREFIX + owner
+
+
+def _claim_key(token: str) -> str:
+	return _CLAIM_PREFIX + token
+
+
+class PendingConfirmStorageError(RuntimeError):
+	"""Redis could not provide a definite pending-confirmation result."""
+
+
+class PendingConfirmOutcomeUnknown(PendingConfirmStorageError):
+	"""Redis may have committed a consume, but its durable claim is unreadable."""
 
 
 # --------------------------------------------------------------------------- #
@@ -181,8 +194,9 @@ def mint(
 		cache.set_value(_key(token), record, expires_in_sec=_TTL_S)
 		cache.sadd(_owner_key(owner), token)
 		# set_value swallows a redis blip, so confirm the record is really readable
-		# before we let a card be published against this token.
-		if peek(token) is None:
+		# before we let a card be published against this token. A strict read keeps
+		# an outage distinct from a genuine persist miss; both fail closed here.
+		if peek(token, strict=True) is None:
 			raise RuntimeError("pending-confirm record did not persist")
 	except Exception:
 		frappe.log_error(
@@ -203,9 +217,9 @@ def mint(
 	# NEVER fail the park: a record that already persisted + verified is live and
 	# confirmable whether or not this TTL lands, which is why it sits OUTSIDE the try
 	# above. Uses the raw redis ``expire`` on the make_key'd set key (present on every
-	# Frappe version) rather than ``RedisWrapper.expire_key`` - Frappe >= 17 only, whose
-	# AttributeError on a v15 bench was caught by the park's try/except and rolled back a
-	# good record, taking down every gated confirmation card.
+	# supported Frappe version) rather than ``RedisWrapper.expire_key``. That wrapper
+	# is absent on Frappe 15; its AttributeError was caught by the park's old broad
+	# exception handler and rolled back a good record, taking down every gated card.
 	try:
 		cache.expire(cache.make_key(_owner_key(owner)), _TTL_S)
 	except Exception as exc:
@@ -225,60 +239,113 @@ def mint(
 
 
 def _read_record(token: str, *, swallow: bool = True) -> dict | None:
-	"""Read the parked record straight from Redis, bypassing the worker-local
-	cache. Bypassing local is load-bearing: mint()'s post-persist verify must catch
-	the case where set_value swallowed a ConnectionError and the record never landed
-	in Redis (a local copy would falsely read as success), and consume() must never
-	act on a stale local snapshot. Version-portable: Frappe < 16's get_value has no
-	``use_local_cache`` kwarg (passing it TypeErrors on a v15 bench), so instead pop
-	any local entry (forces the read to miss local and hit Redis) and pass
-	``expires=True`` (the token key has a TTL) so the read does not repopulate local -
-	together equivalent to the v17-only ``use_local_cache=False``.
+	"""Read the parked record directly from Redis, bypassing local cache.
 
-	``swallow`` (default True): a RedisError on the read becomes None - the safe,
-	retryable outcome for peek/consume/mint-verify (not-consumable / not-found /
-	persist-miss->rollback), because get_value itself only suppresses ConnectionError,
-	not its TimeoutError sibling or ResponseError, so an uncaught one would be a 500.
-	``list_for_owner`` passes ``swallow=False`` so it can tell a TRANSIENT read blip
-	(skip, leave the member) apart from a genuinely-absent token (prune) - swallowing
-	there would orphan a still-live token from the index (the invisible-card class).
+	The raw inherited ``GET`` is intentional. ``RedisWrapper.get_value`` suppresses
+	``ConnectionError`` and returns ``None``, which makes an outage indistinguishable
+	from an expired token. It can also read a worker-local value. Reading the
+	make_key'd key directly and unpickling it keeps Frappe 15 compatibility while
+	preserving the distinction between "absent" and "storage unavailable".
+
+	When ``swallow`` is false, Redis failures become
+	``PendingConfirmStorageError``. Best-effort background callers may keep the
+	default; user-facing confirm and resync paths use strict reads.
 	"""
 	cache = frappe.cache()
-	frappe.local.cache.pop(cache.make_key(_key(token)), None)
+	full_key = cache.make_key(_key(token))
+	frappe.local.cache.pop(full_key, None)
 	try:
-		return cache.get_value(_key(token), expires=True)
-	except redis.exceptions.RedisError:
+		raw = cache.get(full_key)
+	except redis.exceptions.RedisError as exc:
 		if not swallow:
-			raise
+			raise PendingConfirmStorageError("pending-confirm record read failed") from exc
 		return None
+	return pickle.loads(raw) if raw is not None else None
 
 
-def peek(token: str) -> dict | None:
+def peek(token: str, *, strict: bool = False) -> dict | None:
 	"""Return the stored record (dict) without consuming it, or None if the
 	token is unknown/expired. Used to build the preview/UI event. Does NOT
-	validate ownership - callers that act on it must.
+	validate ownership - callers that act on it must. ``strict=True`` preserves
+	storage failures instead of presenting them as an unknown token.
 	"""
 	if not token:
 		return None
-	return _read_record(token)
+	return _read_record(token, swallow=not strict)
 
 
-def _get_and_delete(full_key) -> bytes | None:
-	"""Atomically read-and-remove a raw cache key, returning its pickled bytes (or
-	None if absent). Uses a MULTI/EXEC transaction (GET then DEL) rather than the
-	one-shot GETDEL command: GETDEL is redis-server >= 6.2 only, and a customer
-	bench may run older (a v6.0 server rejects it), whereas GET/DEL under MULTI/EXEC
-	run as one indivisible unit on EVERY redis version. That keeps the single-winner
-	consume guarantee - the server serializes the two transactions, so of two racing
-	confirms exactly one sees the value before DEL removes it - without the version
-	floor. ``full_key`` is the already-make_key'd key (raw redis, no re-namespacing),
-	matching what the previous getdel operated on.
+def _claim_matches(cache, full_claim_key, claim_id: str) -> tuple[bool, bytes | None]:
+	"""Return whether a durable consume claim belongs to this request."""
+	stored_claim, stored_record = cache.hmget(full_claim_key, "claim", "record")
+	if isinstance(stored_claim, bytes):
+		stored_claim = stored_claim.decode()
+	return stored_claim == claim_id, stored_record
+
+
+def _get_and_delete(full_key, full_claim_key, claim_id: str) -> bytes | None:
+	"""Atomically claim and remove a raw token key, returning its pickled record.
+
+	``WATCH`` + ``MULTI/EXEC`` is supported by the Redis 6.0 floor and preserves a
+	single winner without ``GETDEL`` (Redis 6.2+). The transaction also writes a
+	short-lived claim containing the record. That claim is load-bearing when the
+	server commits ``EXEC`` but the client loses its reply: the same request can
+	recover its result, while a racing request has a different claim id and cannot
+	dispatch the write a second time.
 	"""
-	pipe = frappe.cache().pipeline(transaction=True)
-	pipe.get(full_key)
-	pipe.delete(full_key)
-	raw, _deleted = pipe.execute()
-	return raw
+	cache = frappe.cache()
+	pipe = cache.pipeline(transaction=True)
+	exec_attempted = False
+	try:
+		pipe.watch(full_key, full_claim_key)
+		raw = pipe.get(full_key)
+		if raw is None or pipe.exists(full_claim_key):
+			pipe.unwatch()
+			return None
+		pipe.multi()
+		pipe.hset(full_claim_key, mapping={"claim": claim_id, "record": raw})
+		pipe.expire(full_claim_key, _TTL_S)
+		pipe.delete(full_key)
+		exec_attempted = True
+		pipe.execute()
+		return raw
+	except redis.exceptions.WatchError:
+		return None
+	except redis.exceptions.RedisError as exc:
+		if not exec_attempted:
+			raise PendingConfirmStorageError("pending-confirm consume failed before commit") from exc
+		# EXEC may have committed even though its response never reached this
+		# process. Recover only our own durable claim; never infer success merely
+		# because the token disappeared, since a concurrent request may have won.
+		try:
+			ours, claimed_raw = _claim_matches(cache, full_claim_key, claim_id)
+		except redis.exceptions.RedisError as recovery_exc:
+			raise PendingConfirmOutcomeUnknown(
+				"pending-confirm consume outcome could not be recovered"
+			) from recovery_exc
+		if ours and claimed_raw is not None:
+			frappe.logger("jarvis.pending_confirm").error(
+				"consume transaction reply was lost; recovered this request's durable claim: %s",
+				type(exc).__name__,
+			)
+			return claimed_raw
+		if claimed_raw is not None:
+			return None  # another request's durable claim won
+		try:
+			pending_raw = cache.get(full_key)
+		except redis.exceptions.RedisError as recovery_exc:
+			raise PendingConfirmOutcomeUnknown(
+				"pending-confirm consume outcome could not be recovered"
+			) from recovery_exc
+		if pending_raw is not None:
+			raise PendingConfirmStorageError("pending-confirm consume was not committed") from exc
+		# No token and no durable claim is an indeterminate partial transaction.
+		# Never dispatch from the earlier snapshot and never call it ordinary expiry.
+		raise PendingConfirmOutcomeUnknown("pending-confirm consume outcome is unknown") from exc
+	finally:
+		try:
+			pipe.reset()
+		except redis.exceptions.RedisError:
+			pass
 
 
 def consume(token: str, *, owner: str, conversation: str) -> dict | None:
@@ -294,8 +361,8 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	Atomicity: ownership is checked first with a plain (non-destructive)
 	read, so a mismatched call never touches the stored key. Only once
 	ownership matches do we delete - and that delete is an atomic
-	get-and-delete (``_get_and_delete``: GET then DEL inside one MULTI/EXEC
-	transaction, portable to redis < 6.2 which lacks GETDEL). If two
+	claim-and-delete (``_get_and_delete``: WATCH plus a claim + DEL inside one
+	MULTI/EXEC transaction, portable to Redis < 6.2 which lacks GETDEL). If two
 	confirmed consumes race each other here, the server serializes the two
 	transactions: exactly one gets the pickled record back, the other gets
 	None. That is the single-use guarantee - it does not depend on
@@ -304,7 +371,7 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	"""
 	if not token:
 		return None
-	record = _read_record(token)
+	record = _read_record(token, swallow=False)
 	if not record:
 		return None
 	# Owner is the real security boundary and is always enforced.
@@ -322,35 +389,17 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	if stored_conv and stored_conv != conversation:
 		return None
 
-	full_key = frappe.cache().make_key(_key(token))
+	cache = frappe.cache()
+	full_key = cache.make_key(_key(token))
+	full_claim_key = cache.make_key(_claim_key(token))
 	# Atomic get-and-delete. GETDEL would be the one-command way but it is
 	# redis-server >= 6.2 ONLY, and a customer bench may run older (a v6.0 server
-	# rejects it outright) - so _get_and_delete uses a MULTI/EXEC transaction
-	# (GET then DEL as one indivisible unit) instead. That keeps the single-winner
-	# guarantee (of two concurrent confirms exactly one sees the value before DEL
-	# removes it) while working on every redis version; a plain get-then-delete
-	# would reopen the very race the atomicity exists to close.
-	try:
-		raw = _get_and_delete(full_key)
-	except redis.exceptions.RedisError as exc:
-		# ANY redis-level failure on the burn must degrade to a graceful None, NOT a
-		# 500 on the whitelisted Confirm endpoint: a transient blip (ConnectionError),
-		# a socket timeout (TimeoutError - a SIBLING of ConnectionError, not a
-		# subclass, so the old narrow tuple missed it), or a degraded-write state
-		# (ResponseError - -MISCONF stop-writes-on-bgsave-error, a read-only replica)
-		# under which the DEL inside the transaction errors. None => not-consumable
-		# => retryable InvalidConfirmation, and the token is NOT burned (the DEL never
-		# applied), so a retry against a healthy cache still succeeds. Breadcrumb at
-		# .error (NOT frappe.log_error - that floods the DB Error Log under a sustained
-		# outage; and NOT .warning - a PROD bench's default log level is ERROR, so a
-		# warning is filtered out and never written) so a tenant-wide "Confirm does
-		# nothing" incident is greppable in the log file and distinguishable from
-		# ordinary token expiry.
-		frappe.logger("jarvis.pending_confirm").error(
-			"consume burn failed; treating as not-consumable (retryable): %s",
-			type(exc).__name__,
-		)
-		return None
+	# rejects it outright) - so _get_and_delete uses WATCH + a MULTI/EXEC transaction
+	# (durable claim then DEL as one indivisible unit) instead. That keeps the
+	# single-winner guarantee (of two concurrent confirms exactly one claims the
+	# record before DEL removes it) while working on every supported Redis version;
+	# a plain get-then-delete would reopen the very race the atomicity exists to close.
+	raw = _get_and_delete(full_key, full_claim_key, secrets.token_urlsafe(18))
 	frappe.local.cache.pop(full_key, None)
 	if raw is None:
 		return None
@@ -366,7 +415,7 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	return pickle.loads(raw)
 
 
-def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
+def list_for_owner(owner: str, conversation: str | None = None, *, strict: bool = False) -> list[dict]:
 	"""Return the owner's currently-live parked records (each with its ``token``
 	attached), newest-first is NOT guaranteed. Reads the per-owner index, peeks
 	each token, and:
@@ -377,7 +426,9 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 	    records ("") which carry no binding and surface under any filter (F1).
 
 	Never returns another user's tokens. Used by the resync endpoint so the SPA
-	can re-surface confirmation cards after a reload/reconnect.
+	can re-surface confirmation cards after a reload/reconnect. ``strict=True``
+	raises on any index/record read failure so a user-facing resync cannot mistake
+	an outage for an authoritative empty or partial list.
 	"""
 	if not owner:
 		return []
@@ -386,7 +437,12 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 			m.decode() if isinstance(m, bytes) else m
 			for m in (frappe.cache().smembers(_owner_key(owner)) or set())
 		}
-	except Exception:
+	except redis.exceptions.RedisError as exc:
+		frappe.logger("jarvis.pending_confirm").error(
+			"owner confirmation index read failed: %s", type(exc).__name__
+		)
+		if strict:
+			raise PendingConfirmStorageError("pending-confirm owner index read failed") from exc
 		return []
 	if not members:
 		return []
@@ -395,11 +451,17 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 	for token in members:
 		try:
 			record = _read_record(token, swallow=False)
-		except redis.exceptions.RedisError:
+		except PendingConfirmStorageError as exc:
 			# TRANSIENT read blip on this token (Redis reachable enough for smembers,
 			# but this GET failed). Do NOT prune - the record may still be live, and
 			# pruning would orphan it from the index (invisible to every future resync
 			# for its full TTL). Skip it this round; a later clean resync re-surfaces it.
+			frappe.logger("jarvis.pending_confirm").error(
+				"owner confirmation record read failed; card was retained for retry: %s",
+				type(exc.__cause__).__name__ if exc.__cause__ else type(exc).__name__,
+			)
+			if strict:
+				raise
 			continue
 		if not record:
 			dead.append(token)
@@ -463,7 +525,7 @@ def _pending_item(
 	}
 
 
-def list_items_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
+def list_items_for_owner(owner: str, conversation: str | None = None, *, strict: bool = False) -> list[dict]:
 	"""Client-facing pending-confirmation items for ``owner`` (optionally filtered to
 	``conversation``), each built through the shared ``_pending_item`` shape so the
 	resync endpoint and the ``run:end`` terminal cannot drift: a card missed on the
@@ -480,7 +542,7 @@ def list_items_for_owner(owner: str, conversation: str | None = None) -> list[di
 			run_id=r.get("run_id"),
 			expires_at=r.get("expires_at"),
 		)
-		for r in list_for_owner(owner, conversation=conversation)
+		for r in list_for_owner(owner, conversation=conversation, strict=strict)
 	]
 
 
@@ -504,6 +566,12 @@ def clear_for_conversation(owner: str, conversation: str, run_id: str | None = N
 			continue  # list_for_owner surfaces conv-less tokens under any filter
 		if run_id and rec.get("run_id") and rec.get("run_id") != run_id:
 			continue  # a sibling run's card (run_id is "" today, so this no-ops)
-		if consume(rec["token"], owner=owner, conversation=conversation) is not None:
-			n += 1
+		try:
+			if consume(rec["token"], owner=owner, conversation=conversation) is not None:
+				n += 1
+		except PendingConfirmStorageError as exc:
+			frappe.logger("jarvis.pending_confirm").error(
+				"conversation confirmation cleanup failed; token retained when possible: %s",
+				type(exc).__name__,
+			)
 	return n

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -12,6 +12,13 @@ confirmation and does not run anything.
 
 Storage: ``frappe.cache()`` (Redis), one key per token, single round trip
 TTL so a token that nobody clicks self-expires instead of leaking forever.
+
+Portability floor: this module runs on the CUSTOMER bench, whose Frappe/Redis
+versions vary. It must stay compatible down to **Frappe 15** and **Redis 6.0**.
+Do NOT reach for a Frappe >= 16/17-only RedisWrapper method (``expire_key``, the
+``use_local_cache`` get_value kwarg) or a Redis >= 6.2-only command (``GETDEL``,
+``GETEX``, ``COPY``, ``SINTERCARD``, ...) - use an inherited ``redis.Redis``
+builtin or a MULTI/EXEC transaction instead.
 """
 
 from __future__ import annotations
@@ -201,14 +208,49 @@ def mint(
 	# good record, taking down every gated confirmation card.
 	try:
 		cache.expire(cache.make_key(_owner_key(owner)), _TTL_S)
-	except Exception:
-		pass
+	except Exception as exc:
+		# Best-effort hygiene (see above): must never fail the park. DEBUG (not a
+		# loud log - it is non-fatal and could be frequent) so a DURABLE failure
+		# (e.g. a Redis ACL that permits SADD but denies EXPIRE) is discoverable
+		# when the log level is raised, rather than silent forever.
+		frappe.logger("jarvis.pending_confirm").debug(
+			"owner-index TTL refresh failed (non-fatal): %s", type(exc).__name__
+		)
 	# cards_open gauge +1 (self-healing on expiry via the ZSET score). Bumped only
 	# after a successful persist+index+verify so the gauge never over-counts a
 	# rolled-back park.
 	_gauge_add(token, record["expires_at"])
 	_emit_cards_open("mint")
 	return token
+
+
+def _read_record(token: str, *, swallow: bool = True) -> dict | None:
+	"""Read the parked record straight from Redis, bypassing the worker-local
+	cache. Bypassing local is load-bearing: mint()'s post-persist verify must catch
+	the case where set_value swallowed a ConnectionError and the record never landed
+	in Redis (a local copy would falsely read as success), and consume() must never
+	act on a stale local snapshot. Version-portable: Frappe < 16's get_value has no
+	``use_local_cache`` kwarg (passing it TypeErrors on a v15 bench), so instead pop
+	any local entry (forces the read to miss local and hit Redis) and pass
+	``expires=True`` (the token key has a TTL) so the read does not repopulate local -
+	together equivalent to the v17-only ``use_local_cache=False``.
+
+	``swallow`` (default True): a RedisError on the read becomes None - the safe,
+	retryable outcome for peek/consume/mint-verify (not-consumable / not-found /
+	persist-miss->rollback), because get_value itself only suppresses ConnectionError,
+	not its TimeoutError sibling or ResponseError, so an uncaught one would be a 500.
+	``list_for_owner`` passes ``swallow=False`` so it can tell a TRANSIENT read blip
+	(skip, leave the member) apart from a genuinely-absent token (prune) - swallowing
+	there would orphan a still-live token from the index (the invisible-card class).
+	"""
+	cache = frappe.cache()
+	frappe.local.cache.pop(cache.make_key(_key(token)), None)
+	try:
+		return cache.get_value(_key(token), expires=True)
+	except redis.exceptions.RedisError:
+		if not swallow:
+			raise
+		return None
 
 
 def peek(token: str) -> dict | None:
@@ -218,10 +260,10 @@ def peek(token: str) -> dict | None:
 	"""
 	if not token:
 		return None
-	return frappe.cache().get_value(_key(token), use_local_cache=False)
+	return _read_record(token)
 
 
-def _get_and_delete(full_key):
+def _get_and_delete(full_key) -> bytes | None:
 	"""Atomically read-and-remove a raw cache key, returning its pickled bytes (or
 	None if absent). Uses a MULTI/EXEC transaction (GET then DEL) rather than the
 	one-shot GETDEL command: GETDEL is redis-server >= 6.2 only, and a customer
@@ -262,7 +304,7 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	"""
 	if not token:
 		return None
-	record = frappe.cache().get_value(_key(token), use_local_cache=False)
+	record = _read_record(token)
 	if not record:
 		return None
 	# Owner is the real security boundary and is always enforced.
@@ -287,16 +329,27 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	# (GET then DEL as one indivisible unit) instead. That keeps the single-winner
 	# guarantee (of two concurrent confirms exactly one sees the value before DEL
 	# removes it) while working on every redis version; a plain get-then-delete
-	# would reopen the very race the atomicity exists to close. Catch both a
-	# transient blip (ConnectionError) AND a degraded-write state (ResponseError -
-	# e.g. -MISCONF stop-writes-on-bgsave-error, or a read-only replica, under which
-	# the write DEL inside the transaction errors) and turn either into a graceful
-	# None (treated as not-consumable -> InvalidConfirmation; the token is NOT
-	# burned, so a retry against a healthy cache still succeeds) rather than an
-	# uncaught 500 on the whitelisted Confirm endpoint.
+	# would reopen the very race the atomicity exists to close.
 	try:
 		raw = _get_and_delete(full_key)
-	except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
+	except redis.exceptions.RedisError as exc:
+		# ANY redis-level failure on the burn must degrade to a graceful None, NOT a
+		# 500 on the whitelisted Confirm endpoint: a transient blip (ConnectionError),
+		# a socket timeout (TimeoutError - a SIBLING of ConnectionError, not a
+		# subclass, so the old narrow tuple missed it), or a degraded-write state
+		# (ResponseError - -MISCONF stop-writes-on-bgsave-error, a read-only replica)
+		# under which the DEL inside the transaction errors. None => not-consumable
+		# => retryable InvalidConfirmation, and the token is NOT burned (the DEL never
+		# applied), so a retry against a healthy cache still succeeds. Breadcrumb at
+		# .error (NOT frappe.log_error - that floods the DB Error Log under a sustained
+		# outage; and NOT .warning - a PROD bench's default log level is ERROR, so a
+		# warning is filtered out and never written) so a tenant-wide "Confirm does
+		# nothing" incident is greppable in the log file and distinguishable from
+		# ordinary token expiry.
+		frappe.logger("jarvis.pending_confirm").error(
+			"consume burn failed; treating as not-consumable (retryable): %s",
+			type(exc).__name__,
+		)
 		return None
 	frappe.local.cache.pop(full_key, None)
 	if raw is None:
@@ -340,7 +393,14 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 	out: list[dict] = []
 	dead: list[str] = []
 	for token in members:
-		record = peek(token)
+		try:
+			record = _read_record(token, swallow=False)
+		except redis.exceptions.RedisError:
+			# TRANSIENT read blip on this token (Redis reachable enough for smembers,
+			# but this GET failed). Do NOT prune - the record may still be live, and
+			# pruning would orphan it from the index (invisible to every future resync
+			# for its full TTL). Skip it this round; a later clean resync re-surfaces it.
+			continue
 		if not record:
 			dead.append(token)
 			continue

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -389,6 +389,56 @@ class TestConfirmTool(FrappeTestCase):
 		self.assertFalse(res["ok"])
 		self.assertEqual(res["error"]["type"], "InvalidConfirmation")
 
+	def test_confirm_storage_failure_is_not_reported_as_expiry_and_executes_nothing(self):
+		desc = "jarvis-test-confirm-storage-unavailable"
+		token = self._park(
+			"create_doc",
+			{"doctype": "ToDo", "values": {"description": desc}},
+		)
+		failure = pending_confirm.PendingConfirmStorageError("read unavailable")
+		with patch.object(pending_confirm, "peek", side_effect=failure):
+			with patch("jarvis.api.dispatch_confirmed") as dispatch:
+				with patch.object(frappe, "logger"):
+					res = confirm_tool(token)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["type"], "ConfirmationUnavailableError")
+		self.assertIn("Nothing was changed", res["error"]["message"])
+		dispatch.assert_not_called()
+		self.assertFalse(frappe.db.exists("ToDo", {"description": desc}))
+		self.assertIsNotNone(pending_confirm.peek(token))
+
+	def test_confirm_unknown_consume_outcome_has_distinct_error_and_executes_nothing(self):
+		desc = "jarvis-test-confirm-outcome-unknown"
+		token = self._park(
+			"create_doc",
+			{"doctype": "ToDo", "values": {"description": desc}},
+		)
+		failure = pending_confirm.PendingConfirmOutcomeUnknown("recovery unavailable")
+		with patch.object(pending_confirm, "consume", side_effect=failure):
+			with patch("jarvis.api.dispatch_confirmed") as dispatch:
+				with patch.object(frappe, "logger"):
+					res = confirm_tool(token)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["type"], "ConfirmationOutcomeUnknownError")
+		self.assertIn("business action was not run", res["error"]["message"])
+		dispatch.assert_not_called()
+		self.assertFalse(frappe.db.exists("ToDo", {"description": desc}))
+
+	def test_dismiss_storage_failure_keeps_token_and_reports_unavailable(self):
+		from jarvis.chat.actions_api import dismiss_tool
+
+		token = self._park(
+			"create_doc",
+			{"doctype": "ToDo", "values": {"description": "dismiss-storage"}},
+		)
+		failure = pending_confirm.PendingConfirmStorageError("read unavailable")
+		with patch.object(pending_confirm, "peek", side_effect=failure):
+			with patch.object(frappe, "logger"):
+				res = dismiss_tool(token)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["type"], "ConfirmationUnavailableError")
+		self.assertIsNotNone(pending_confirm.peek(token))
+
 
 class TestGatedToolRefusesModelPreview(FrappeTestCase):
 	"""Fix #14: a gated write called with ``preview=True`` must NOT take the
@@ -825,6 +875,17 @@ class TestListPendingConfirmations(FrappeTestCase):
 		finally:
 			frappe.set_user(original)
 
+	def test_storage_failure_returns_error_instead_of_authoritative_empty_list(self):
+		from jarvis.chat.actions_api import list_pending_confirmations
+
+		failure = pending_confirm.PendingConfirmStorageError("index unavailable")
+		with patch.object(pending_confirm, "list_items_for_owner", side_effect=failure):
+			with patch.object(frappe, "logger"):
+				res = list_pending_confirmations()
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["type"], "ConfirmationUnavailableError")
+		self.assertNotIn("data", res)
+
 
 class TestCreateDocsGate(FrappeTestCase):
 	def test_create_docs_parks_one_card_and_dry_runs_batch(self):
@@ -988,6 +1049,19 @@ class TestSequentialConfirmationGuard(FrappeTestCase):
 		self.assertFalse(r2["ok"])
 		self.assertEqual(r2["error"]["code"], "ConfirmationPendingError")
 		self.assertIsNone(cap2.get("token"))  # no second token minted
+
+	def test_single_flight_storage_failure_fails_closed_without_parking(self):
+		failure = pending_confirm.PendingConfirmStorageError("index unavailable")
+		with patch.object(pending_confirm, "list_for_owner", side_effect=failure):
+			with patch.object(pending_confirm, "mint") as mint:
+				r = api._run_tool(
+					"create_doc",
+					{"doctype": "ToDo", "values": {"description": "seq-storage"}},
+					conversation="seq-guard-storage",
+				)
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "ConfirmationUnavailableError")
+		mint.assert_not_called()
 
 	def test_pending_card_does_not_block_a_different_conversation(self):
 		with _spy_mint()[0]:

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -156,6 +156,36 @@ class TestMintReliableIndex(FrappeTestCase):
 				self._mint()
 		self.assertEqual(pending_confirm.cards_open_gauge(), before)
 
+	def test_mint_survives_missing_expire_key_on_frappe_v15(self):
+		"""Frappe < 17 (e.g. v15) has no ``RedisWrapper.expire_key``. The owner-index
+		TTL refresh must not depend on it: when it is unavailable the park still
+		succeeds (record persisted + peekable + indexed) instead of the AttributeError
+		being caught by the park's try/except and rolling back a good record - which
+		took down EVERY gated confirmation card on v15 benches."""
+		with patch.object(
+			frappe.cache(),
+			"expire_key",
+			create=True,
+			side_effect=AttributeError("'RedisWrapper' object has no attribute 'expire_key'"),
+		):
+			with patch.object(frappe, "log_error") as mock_log:
+				token = self._mint()
+		self.assertIsNotNone(token, "park must not depend on the Frappe>=17-only expire_key")
+		self.assertFalse(mock_log.called, "a missing expire_key must not trip the error/rollback path")
+		self.assertIsNotNone(pending_confirm.peek(token))
+		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
+
+	def test_mint_refreshes_owner_index_ttl_via_portable_path(self):
+		"""The owner-index set gets a fresh TTL on every mint (so an emptied set
+		self-expires) via the version-portable raw ``expire`` on the make_key'd key -
+		the SAME key ``sadd`` wrote to. Guards the hygiene from silently regressing to
+		a no-op (e.g. targeting an un-namespaced or otherwise wrong key)."""
+		self._mint()
+		cache = frappe.cache()
+		ttl = cache.ttl(cache.make_key(pending_confirm._owner_key(self._A)))
+		self.assertGreater(ttl, 0, "owner-index set must carry a positive TTL after mint")
+		self.assertLessEqual(ttl, pending_confirm._TTL_S)
+
 
 class TestExecUser(FrappeTestCase):
 	def test_exec_user_stored_and_returned(self):
@@ -474,16 +504,16 @@ class TestConsume(FrappeTestCase):
 		self.assertIsNone(pending_confirm.consume(token, owner=OWNER, conversation=CONV))
 
 	def test_concurrent_consumes_exactly_one_wins(self):
-		"""Two threads race to consume the same legitimate token. Redis GETDEL
-		is atomic server-side, so exactly one of the two concurrent consumes
-		must get the record back; the other must get None - never both, never
-		neither.
+		"""Two threads race to consume the same legitimate token. The atomic
+		get-and-delete (_get_and_delete's MULTI/EXEC) is serialized server-side,
+		so exactly one of the two concurrent consumes must get the record back;
+		the other must get None - never both, never neither.
 
 		Without a barrier, nothing forces the two threads to actually overlap:
 		the OS could just run them back-to-back, in which case a naive
 		non-atomic get-then-delete would also pass this test by accident. A
-		threading.Barrier(2) is spliced in front of the real getdel call (the
-		only place consume() mutates the store) so neither thread's getdel can
+		threading.Barrier(2) is spliced in front of the real _get_and_delete call
+		(the only place consume() mutates the store) so neither thread's burn can
 		return until BOTH threads have completed their ownership-check read
 		(the plain get_value earlier in consume()) and are standing right at
 		the delete. That is the actual race window consume()'s docstring
@@ -493,14 +523,14 @@ class TestConsume(FrappeTestCase):
 		token = self._mint()
 		results = [None, None]
 		barrier = threading.Barrier(2)
-		real_getdel = frappe.cache().getdel
+		real_get_and_delete = pending_confirm._get_and_delete
 
-		def _synced_getdel(*args, **kwargs):
+		def _synced_get_and_delete(*args, **kwargs):
 			# Both threads land here only after their own ownership-check
 			# read already matched, so this rendezvous pins both threads
 			# past that read before either delete is allowed to fire.
 			barrier.wait(timeout=5)
-			return real_getdel(*args, **kwargs)
+			return real_get_and_delete(*args, **kwargs)
 
 		def _consume(i):
 			results[i] = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
@@ -513,10 +543,9 @@ class TestConsume(FrappeTestCase):
 		t1 = threading.Thread(target=ctx1.run, args=(_consume, 0))
 		t2 = threading.Thread(target=ctx2.run, args=(_consume, 1))
 
-		# frappe.cache is a process-wide singleton (frappe/__init__.py sets
-		# it via `global cache`, not a thread local), so patching the bound
-		# method on the one instance affects both threads.
-		with patch.object(frappe.cache(), "getdel", side_effect=_synced_getdel):
+		# _get_and_delete is a module-level function, so patching it on the
+		# pending_confirm module affects both threads (they call the same one).
+		with patch.object(pending_confirm, "_get_and_delete", side_effect=_synced_get_and_delete):
 			t1.start()
 			t2.start()
 			t1.join(timeout=5)
@@ -529,24 +558,22 @@ class TestConsume(FrappeTestCase):
 		self.assertEqual(len(winners), 1)
 		self.assertIsNone(pending_confirm.peek(token))
 
-	def test_getdel_connection_error_returns_none_without_burning_token(self):
-		"""Finding #8 (max-effort review of issue #186): the raw
-		``frappe.cache().getdel`` call in consume() is not wrapped in the
-		RedisWrapper's usual ``suppress(redis.exceptions.ConnectionError)``
-		(unlike get_value, used by peek), so a transient redis blip during a
-		Confirm click propagated as an uncaught 500 instead of a graceful
-		None. consume() must itself catch the error and return None - the
-		token must not be burned, so a later consume against a healthy cache
-		still succeeds. This must NOT fall back to a non-atomic
-		get-then-delete: only the same getdel is retried later."""
-		import redis.exceptions
-
+	def test_atomic_burn_connection_error_returns_none_without_burning_token(self):
+		"""Finding #8 (max-effort review of issue #186): the atomic get-and-delete
+		in consume() is a raw redis operation, not one of RedisWrapper's own wrapped
+		methods, so unlike get_value (used by peek) it is NOT auto-suppressed - a
+		transient redis blip during a Confirm click would otherwise propagate as an
+		uncaught 500 instead of a graceful None. consume() must itself catch the
+		error and return None - the token must NOT be burned, so a later consume
+		against a healthy cache still succeeds. It must NOT fall back to a non-atomic
+		get-then-delete (which would reopen the consume race): only the same atomic
+		burn is retried later."""
 		token = self._mint()
 
 		def _raise_once(*args, **kwargs):
 			raise redis.exceptions.ConnectionError("simulated redis blip")
 
-		with patch.object(frappe.cache(), "getdel", side_effect=_raise_once):
+		with patch.object(pending_confirm, "_get_and_delete", side_effect=_raise_once):
 			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		self.assertIsNone(result)
 		# Token was not burned: still peekable, and a later consume against a
@@ -555,3 +582,43 @@ class TestConsume(FrappeTestCase):
 		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		self.assertIsNotNone(record)
 		self.assertEqual(record["tool"], TOOL)
+
+	def test_atomic_burn_response_error_returns_none_without_burning_token(self):
+		"""A degraded-write Redis state (e.g. -MISCONF stop-writes-on-bgsave-error,
+		or a read-only replica) makes the DEL inside the MULTI/EXEC raise
+		ResponseError. The whitelisted Confirm endpoint relies on consume()
+		returning None (-> graceful retry toast), so this must NOT propagate as an
+		uncaught 500 - and the token must not be burned, so a later consume against a
+		healthy cache still succeeds."""
+		token = self._mint()
+
+		def _raise_once(*args, **kwargs):
+			raise redis.exceptions.ResponseError("MISCONF Redis is configured to save RDB snapshots")
+
+		with patch.object(pending_confirm, "_get_and_delete", side_effect=_raise_once):
+			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNone(result)
+		self.assertIsNotNone(pending_confirm.peek(token))
+		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNotNone(record)
+		self.assertEqual(record["tool"], TOOL)
+
+	def test_consume_does_not_require_getdel_redis_62(self):
+		"""GETDEL is a redis-server >= 6.2 command; an older bench (e.g. v6.0)
+		rejects it with ResponseError. A Confirm click must still succeed there, so
+		consume() must NOT depend on GETDEL. Simulate the old server by making the
+		cache's getdel raise ResponseError; the consume must still burn the token and
+		return the record via the portable MULTI/EXEC path (which never calls
+		GETDEL)."""
+		token = self._mint()
+		with patch.object(
+			frappe.cache(),
+			"getdel",
+			create=True,
+			side_effect=redis.exceptions.ResponseError("ERR unknown command 'GETDEL'"),
+		):
+			record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNotNone(record, "consume must not depend on the redis>=6.2 GETDEL command")
+		self.assertEqual(record["tool"], TOOL)
+		# Really burned (single-use) via the portable path, not left dangling.
+		self.assertIsNone(pending_confirm.peek(token))

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -186,6 +186,52 @@ class TestMintReliableIndex(FrappeTestCase):
 		self.assertGreater(ttl, 0, "owner-index set must carry a positive TTL after mint")
 		self.assertLessEqual(ttl, pending_confirm._TTL_S)
 
+	def test_mint_rolls_back_when_set_value_swallows_a_write_error(self):
+		"""_read_record's local-cache pop is LOAD-BEARING: set_value writes
+		frappe.local.cache BEFORE its ConnectionError-suppressed Redis SET, so a
+		swallowed write leaves a stale LOCAL copy while Redis holds nothing. mint()'s
+		post-persist verify must still detect the miss - _read_record's pop forces a
+		fresh Redis read - and roll back rather than publish a card whose record never
+		landed. Guards the pop from being dropped (without it the verify reads the
+		stale local copy and falsely passes). Simulate by making the raw redis SET
+		raise ConnectionError, which set_value suppresses."""
+		with patch.object(frappe.cache(), "set", side_effect=redis.exceptions.ConnectionError("write blip")):
+			with patch.object(frappe, "log_error") as mock_log:
+				token = self._mint()
+		self.assertIsNone(token, "a swallowed set_value write must be caught by the verify -> rollback")
+		self.assertTrue(mock_log.called, "a persist-verify miss must be logged, not swallowed")
+
+	def test_list_for_owner_does_not_prune_a_live_token_on_transient_read_blip(self):
+		"""A transient read blip (TimeoutError/ResponseError) on one token during the
+		resync loop must NOT prune it from the owner index: the record is still live,
+		so pruning orphans it (invisible to every future resync for its TTL = the
+		invisible-card class this module guards). The member is skipped this round and
+		re-surfaces on a later clean resync."""
+		token = self._mint()
+		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
+
+		def _timeout(*a, **k):
+			raise redis.exceptions.TimeoutError("read blip")
+
+		with patch.object(frappe.cache(), "get_value", side_effect=_timeout):
+			blipped = pending_confirm.list_for_owner(self._A)
+		self.assertNotIn(token, {r["token"] for r in blipped}, "blipped token is skipped this round")
+		# NOT orphaned: a later clean resync still finds it (proves it was not pruned).
+		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
+
+	def test_mint_survives_ttl_refresh_failure(self):
+		"""The owner-index TTL refresh is best-effort and sits OUTSIDE the fatal park
+		try; if cache.expire() itself fails (a blip, or a Redis ACL that permits SADD
+		but denies EXPIRE) the park must still succeed and must NOT hit the
+		error/rollback path. Guards against a future edit folding the TTL refresh back
+		into the fatal try (the regression class this PR fixes)."""
+		with patch.object(frappe.cache(), "expire", side_effect=redis.exceptions.ConnectionError("blip")):
+			with patch.object(frappe, "log_error") as mock_log:
+				token = self._mint()
+		self.assertIsNotNone(token, "a TTL-refresh failure must not roll back a good park")
+		self.assertFalse(mock_log.called, "TTL-refresh failure must not trip the park error/rollback path")
+		self.assertIsNotNone(pending_confirm.peek(token))
+
 
 class TestExecUser(FrappeTestCase):
 	def test_exec_user_stored_and_returned(self):
@@ -622,3 +668,62 @@ class TestConsume(FrappeTestCase):
 		self.assertEqual(record["tool"], TOOL)
 		# Really burned (single-use) via the portable path, not left dangling.
 		self.assertIsNone(pending_confirm.peek(token))
+
+	def test_atomic_burn_timeout_error_returns_none_without_burning_token(self):
+		"""redis TimeoutError is a SIBLING of ConnectionError (both subclass
+		RedisError directly, TimeoutError is NOT a subclass), so a socket timeout on
+		the burn must also degrade to a graceful None - not an uncaught 500 - with the
+		token left un-burned for retry."""
+		token = self._mint()
+
+		def _raise_once(*args, **kwargs):
+			raise redis.exceptions.TimeoutError("timed out")
+
+		with patch.object(pending_confirm, "_get_and_delete", side_effect=_raise_once):
+			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNone(result)
+		self.assertIsNotNone(pending_confirm.peek(token))
+		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNotNone(record)
+		self.assertEqual(record["tool"], TOOL)
+
+	def test_consume_read_timeout_error_returns_none_without_500(self):
+		"""The ownership read (via _read_record -> get_value) must degrade gracefully
+		too: frappe's get_value suppresses only ConnectionError internally, so a
+		TimeoutError (sibling, not subclass) from the read would otherwise propagate
+		as an uncaught 500 on the whitelisted Confirm endpoint. _read_record catches
+		RedisError -> None -> not-consumable, and the token is left un-burned."""
+		token = self._mint()
+
+		def _timeout(*args, **kwargs):
+			raise redis.exceptions.TimeoutError("read timed out")
+
+		with patch.object(frappe.cache(), "get_value", side_effect=_timeout):
+			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNone(result)
+		# Not burned - a later consume against a healthy cache still succeeds.
+		self.assertIsNotNone(pending_confirm.peek(token))
+		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNotNone(record)
+		self.assertEqual(record["tool"], TOOL)
+
+	def test_confirm_flow_works_without_get_value_use_local_cache_kwarg(self):
+		"""Frappe < 16's RedisWrapper.get_value has NO ``use_local_cache`` kwarg;
+		passing it raises TypeError on a real v15 bench. In mint() that TypeError is
+		caught by the park try/except -> rollback -> None (no card renders - the exact
+		v15 symptom this module exists to fix); in consume() the ownership read is
+		unguarded -> an uncaught 500. Simulate the v15 signature and assert the whole
+		mint+consume flow still works (i.e. the code never passes use_local_cache)."""
+		real_get_value = frappe.cache().get_value
+
+		def v15_get_value(key, *args, **kwargs):
+			if "use_local_cache" in kwargs:
+				raise TypeError("get_value() got an unexpected keyword argument 'use_local_cache'")
+			return real_get_value(key, *args, **kwargs)
+
+		with patch.object(frappe.cache(), "get_value", side_effect=v15_get_value):
+			token = self._mint()
+			self.assertIsNotNone(token, "mint must not pass use_local_cache (TypeErrors on Frappe v15)")
+			record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNotNone(record, "consume must not pass use_local_cache (500s on Frappe v15)")
+		self.assertEqual(record["tool"], TOOL)

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -157,7 +157,7 @@ class TestMintReliableIndex(FrappeTestCase):
 		self.assertEqual(pending_confirm.cards_open_gauge(), before)
 
 	def test_mint_survives_missing_expire_key_on_frappe_v15(self):
-		"""Frappe < 17 (e.g. v15) has no ``RedisWrapper.expire_key``. The owner-index
+		"""Frappe 15 has no ``RedisWrapper.expire_key``. The owner-index
 		TTL refresh must not depend on it: when it is unavailable the park still
 		succeeds (record persisted + peekable + indexed) instead of the AttributeError
 		being caught by the park's try/except and rolling back a good record - which
@@ -170,7 +170,7 @@ class TestMintReliableIndex(FrappeTestCase):
 		):
 			with patch.object(frappe, "log_error") as mock_log:
 				token = self._mint()
-		self.assertIsNotNone(token, "park must not depend on the Frappe>=17-only expire_key")
+		self.assertIsNotNone(token, "park must not depend on expire_key, which is absent on Frappe 15")
 		self.assertFalse(mock_log.called, "a missing expire_key must not trip the error/rollback path")
 		self.assertIsNotNone(pending_confirm.peek(token))
 		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
@@ -213,11 +213,33 @@ class TestMintReliableIndex(FrappeTestCase):
 		def _timeout(*a, **k):
 			raise redis.exceptions.TimeoutError("read blip")
 
-		with patch.object(frappe.cache(), "get_value", side_effect=_timeout):
-			blipped = pending_confirm.list_for_owner(self._A)
+		with patch.object(frappe.cache(), "get", side_effect=_timeout):
+			with patch.object(frappe, "logger") as mock_logger:
+				blipped = pending_confirm.list_for_owner(self._A)
 		self.assertNotIn(token, {r["token"] for r in blipped}, "blipped token is skipped this round")
+		self.assertTrue(mock_logger.return_value.error.called, "the skipped card must be observable")
 		# NOT orphaned: a later clean resync still finds it (proves it was not pruned).
 		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
+
+	def test_strict_list_reports_read_failure_without_pruning_or_returning_empty_success(self):
+		"""User-facing resync is strict: a cache outage is not an authoritative
+		empty list, because replacing the UI from that result clears a live card."""
+		token = self._mint()
+		with patch.object(frappe.cache(), "get", side_effect=redis.exceptions.TimeoutError("read blip")):
+			with patch.object(frappe, "logger"):
+				with self.assertRaises(pending_confirm.PendingConfirmStorageError):
+					pending_confirm.list_for_owner(self._A, strict=True)
+		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
+
+	def test_strict_list_reports_owner_index_failure(self):
+		"""A failed SMEMBERS cannot masquerade as 'this user has no cards'."""
+		self._mint()
+		with patch.object(
+			frappe.cache(), "smembers", side_effect=redis.exceptions.ConnectionError("index blip")
+		):
+			with patch.object(frappe, "logger"):
+				with self.assertRaises(pending_confirm.PendingConfirmStorageError):
+					pending_confirm.list_for_owner(self._A, strict=True)
 
 	def test_mint_survives_ttl_refresh_failure(self):
 		"""The owner-index TTL refresh is best-effort and sits OUTSIDE the fatal park
@@ -604,50 +626,65 @@ class TestConsume(FrappeTestCase):
 		self.assertEqual(len(winners), 1)
 		self.assertIsNone(pending_confirm.peek(token))
 
-	def test_atomic_burn_connection_error_returns_none_without_burning_token(self):
-		"""Finding #8 (max-effort review of issue #186): the atomic get-and-delete
-		in consume() is a raw redis operation, not one of RedisWrapper's own wrapped
-		methods, so unlike get_value (used by peek) it is NOT auto-suppressed - a
-		transient redis blip during a Confirm click would otherwise propagate as an
-		uncaught 500 instead of a graceful None. consume() must itself catch the
-		error and return None - the token must NOT be burned, so a later consume
-		against a healthy cache still succeeds. It must NOT fall back to a non-atomic
-		get-then-delete (which would reopen the consume race): only the same atomic
-		burn is retried later."""
+	def test_atomic_burn_precommit_error_is_typed_and_does_not_burn_token(self):
+		"""A definite pre-commit storage failure remains retryable, but is not
+		misreported to the endpoint as an expired/invalid token."""
 		token = self._mint()
-
-		def _raise_once(*args, **kwargs):
-			raise redis.exceptions.ConnectionError("simulated redis blip")
-
-		with patch.object(pending_confirm, "_get_and_delete", side_effect=_raise_once):
-			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
-		self.assertIsNone(result)
-		# Token was not burned: still peekable, and a later consume against a
-		# healthy cache still succeeds.
+		cache = frappe.cache()
+		pipe = cache.pipeline(transaction=True)
+		with patch.object(
+			pipe, "watch", side_effect=redis.exceptions.ConnectionError("failed before commit")
+		):
+			with patch.object(cache, "pipeline", return_value=pipe):
+				with self.assertRaises(pending_confirm.PendingConfirmStorageError):
+					pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		self.assertIsNotNone(pending_confirm.peek(token))
 		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		self.assertIsNotNone(record)
 		self.assertEqual(record["tool"], TOOL)
 
-	def test_atomic_burn_response_error_returns_none_without_burning_token(self):
-		"""A degraded-write Redis state (e.g. -MISCONF stop-writes-on-bgsave-error,
-		or a read-only replica) makes the DEL inside the MULTI/EXEC raise
-		ResponseError. The whitelisted Confirm endpoint relies on consume()
-		returning None (-> graceful retry toast), so this must NOT propagate as an
-		uncaught 500 - and the token must not be burned, so a later consume against a
-		healthy cache still succeeds."""
+	def test_atomic_burn_recovers_when_exec_commits_but_reply_is_lost(self):
+		"""The request that durably claimed the token may execute after losing the
+		EXEC reply; a second request must still lose. This is the ambiguity the old
+		GET+DEL transaction incorrectly classified as 'token was not burned'."""
 		token = self._mint()
+		cache = frappe.cache()
+		pipe = cache.pipeline(transaction=True)
+		real_execute = pipe.execute
 
-		def _raise_once(*args, **kwargs):
-			raise redis.exceptions.ResponseError("MISCONF Redis is configured to save RDB snapshots")
+		def _commit_then_lose_reply(*args, **kwargs):
+			real_execute(*args, **kwargs)
+			raise redis.exceptions.TimeoutError("reply lost after EXEC")
 
-		with patch.object(pending_confirm, "_get_and_delete", side_effect=_raise_once):
-			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
-		self.assertIsNone(result)
-		self.assertIsNotNone(pending_confirm.peek(token))
-		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		with patch.object(pipe, "execute", side_effect=_commit_then_lose_reply):
+			with patch.object(cache, "pipeline", return_value=pipe):
+				with patch.object(frappe, "logger"):
+					record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		self.assertIsNotNone(record)
 		self.assertEqual(record["tool"], TOOL)
+		self.assertIsNone(pending_confirm.peek(token))
+		self.assertIsNone(pending_confirm.consume(token, owner=OWNER, conversation=CONV))
+
+	def test_atomic_burn_reports_unknown_when_committed_claim_cannot_be_read(self):
+		"""If EXEC's reply and the recovery read are both lost, never dispatch from
+		the pre-read snapshot and never call the token merely expired."""
+		token = self._mint()
+		cache = frappe.cache()
+		pipe = cache.pipeline(transaction=True)
+		real_execute = pipe.execute
+
+		def _commit_then_lose_reply(*args, **kwargs):
+			real_execute(*args, **kwargs)
+			raise redis.exceptions.TimeoutError("reply lost after EXEC")
+
+		with patch.object(pipe, "execute", side_effect=_commit_then_lose_reply):
+			with patch.object(cache, "pipeline", return_value=pipe):
+				with patch.object(
+					cache, "hmget", side_effect=redis.exceptions.TimeoutError("recovery read lost")
+				):
+					with self.assertRaises(pending_confirm.PendingConfirmOutcomeUnknown):
+						pending_confirm.consume(token, owner=OWNER, conversation=CONV)
+		self.assertIsNone(pending_confirm.peek(token))
 
 	def test_consume_does_not_require_getdel_redis_62(self):
 		"""GETDEL is a redis-server >= 6.2 command; an older bench (e.g. v6.0)
@@ -669,38 +706,17 @@ class TestConsume(FrappeTestCase):
 		# Really burned (single-use) via the portable path, not left dangling.
 		self.assertIsNone(pending_confirm.peek(token))
 
-	def test_atomic_burn_timeout_error_returns_none_without_burning_token(self):
-		"""redis TimeoutError is a SIBLING of ConnectionError (both subclass
-		RedisError directly, TimeoutError is NOT a subclass), so a socket timeout on
-		the burn must also degrade to a graceful None - not an uncaught 500 - with the
-		token left un-burned for retry."""
-		token = self._mint()
-
-		def _raise_once(*args, **kwargs):
-			raise redis.exceptions.TimeoutError("timed out")
-
-		with patch.object(pending_confirm, "_get_and_delete", side_effect=_raise_once):
-			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
-		self.assertIsNone(result)
-		self.assertIsNotNone(pending_confirm.peek(token))
-		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
-		self.assertIsNotNone(record)
-		self.assertEqual(record["tool"], TOOL)
-
-	def test_consume_read_timeout_error_returns_none_without_500(self):
-		"""The ownership read (via _read_record -> get_value) must degrade gracefully
-		too: frappe's get_value suppresses only ConnectionError internally, so a
-		TimeoutError (sibling, not subclass) from the read would otherwise propagate
-		as an uncaught 500 on the whitelisted Confirm endpoint. _read_record catches
-		RedisError -> None -> not-consumable, and the token is left un-burned."""
+	def test_consume_read_timeout_is_typed_and_does_not_burn_token(self):
+		"""The endpoint must distinguish a failed ownership read from expiry and
+		keep the still-live confirmation available for retry."""
 		token = self._mint()
 
 		def _timeout(*args, **kwargs):
 			raise redis.exceptions.TimeoutError("read timed out")
 
-		with patch.object(frappe.cache(), "get_value", side_effect=_timeout):
-			result = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
-		self.assertIsNone(result)
+		with patch.object(frappe.cache(), "get", side_effect=_timeout):
+			with self.assertRaises(pending_confirm.PendingConfirmStorageError):
+				pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		# Not burned - a later consume against a healthy cache still succeeds.
 		self.assertIsNotNone(pending_confirm.peek(token))
 		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
@@ -708,7 +724,7 @@ class TestConsume(FrappeTestCase):
 		self.assertEqual(record["tool"], TOOL)
 
 	def test_confirm_flow_works_without_get_value_use_local_cache_kwarg(self):
-		"""Frappe < 16's RedisWrapper.get_value has NO ``use_local_cache`` kwarg;
+		"""Frappe 15's RedisWrapper.get_value has NO ``use_local_cache`` kwarg;
 		passing it raises TypeError on a real v15 bench. In mint() that TypeError is
 		caught by the park try/except -> rollback -> None (no card renders - the exact
 		v15 symptom this module exists to fix); in consume() the ownership read is

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -201,6 +201,31 @@ class TestMintReliableIndex(FrappeTestCase):
 		self.assertIsNone(token, "a swallowed set_value write must be caught by the verify -> rollback")
 		self.assertTrue(mock_log.called, "a persist-verify miss must be logged, not swallowed")
 
+	def test_mint_retries_a_transient_verification_read_before_rollback(self):
+		"""A one-off GET timeout must not destroy a record and owner index that
+		both persisted successfully. The strict retry recovers the good park; a
+		sustained failure still follows the fail-closed rollback path."""
+		cache = frappe.cache()
+		real_get = cache.get
+		calls = 0
+
+		def _first_read_times_out(*args, **kwargs):
+			nonlocal calls
+			calls += 1
+			if calls == 1:
+				raise redis.exceptions.TimeoutError("first verify reply lost")
+			return real_get(*args, **kwargs)
+
+		with patch.object(cache, "get", side_effect=_first_read_times_out):
+			with patch.object(frappe, "logger") as mock_logger:
+				with patch.object(frappe, "log_error") as mock_log_error:
+					token = self._mint()
+		self.assertIsNotNone(token)
+		self.assertEqual(calls, 2)
+		self.assertTrue(mock_logger.return_value.error.called)
+		self.assertFalse(mock_log_error.called, "a recovered verification read must not roll back")
+		self.assertIsNotNone(pending_confirm.peek(token))
+
 	def test_list_for_owner_does_not_prune_a_live_token_on_transient_read_blip(self):
 		"""A transient read blip (TimeoutError/ResponseError) on one token during the
 		resync loop must NOT prune it from the owner index: the record is still live,


### PR DESCRIPTION
## Symptom

On a customer bench running **Frappe v15** with **Redis 6.0.16**, every gated write failed before its confirmation card could render:

```text
AttributeError: 'RedisWrapper' object has no attribute 'expire_key'
  File "apps/jarvis/jarvis/chat/pending_confirm.py", line 176, in mint
```

The same stack would also reject Redis `GETDEL`, which was introduced in Redis 6.2.

## Root causes

1. `RedisWrapper.expire_key` is absent on Frappe v15. Because the call was inside the fatal park block, its `AttributeError` rolled back an otherwise valid confirmation.
2. `GETDEL` is unavailable on Redis 6.0.
3. The first compatibility patch treated every Redis read/consume error as an absent or expired token. It also assumed that an `EXEC` timeout meant the transaction did not commit; Redis can commit the transaction and lose only the reply.
4. Pending-card resync returned an authoritative empty/partial list during Redis read failures, which could clear live cards from the UI.

## Fix

- Refresh the owner-index TTL through the inherited, version-portable `expire(make_key(...))` path. This hygiene operation cannot roll back a valid park.
- Read token records directly through the inherited Redis `GET`, bypassing Frappe's worker-local cache and its suppression of `ConnectionError`.
- Retry one failed strict mint-verification read before rollback, so a one-off lost GET reply does not destroy an otherwise valid park. A sustained failure still fails closed.
- Consume with Redis 6.0-compatible `WATCH` + `MULTI/EXEC`. The transaction writes a short-lived request-specific claim and deletes the token atomically.
  - Exactly one concurrent request can claim the token.
  - If `EXEC` commits but its reply is lost, that request recovers only its own durable claim.
  - If recovery is also unavailable, the endpoint returns `ConfirmationOutcomeUnknownError` before dispatching any business write.
- Preserve storage failures as typed errors instead of presenting them as expiry:
  - confirm/discard execute no business action and keep the card available;
  - resync does not replace live cards with an empty result;
  - the single-flight gate fails closed rather than staging a second card;
  - Redis failures are logged without logging bearer tokens.
- Keep confirmation cards visible in the main chat, dashboard chat, and trigger chat on storage/transport failures.

## Compatibility

- Customer floor remains **Frappe 15 / Redis 6.0**.
- No `expire_key`, `get_value(use_local_cache=...)`, `GETDEL`, or other Redis 6.2+ command is used.
- The code relies only on inherited Redis commands and transactions available on Redis 6.0 and redis-py used by Frappe 15.
- No migration.

## Validation

- `jarvis.tests.test_pending_confirm`: **49/49 passed**
- `jarvis.tests.test_confirm_gate`: **48/48 passed**
- receipt-chip suite: **13/13 passed**
- realtime pending-event suite: **4/4 passed**
- affected action endpoint cases: **12/12 passed**
- fault injection covers transient mint verification, pre-commit failure, post-`EXEC` reply loss, failed recovery, concurrent confirms, strict resync, and fail-closed single-flight behavior
- all selected pre-commit lint/format hooks passed
- all three changed Vue SFCs compile successfully
- merged cleanly and repeated the core suites against current `develop` at `26c4c0e2`

The local runtime validation bench is Frappe 16 / Redis 7; Frappe 15 / Redis 6 compatibility is covered by source/API verification and explicit old-stack regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and hardened after review.
