### PR TITLE
fix(tests): green develop CI — mock the final chat gate in the confirm-not-damped test

### DIFF
--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -3356,8 +3356,23 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 		with patch(self._READINESS_PROBE, return_value=("Provisioning", "")):
 			self.assertFalse(is_ready_for_chat().get("ready"))
 		frappe.cache().delete_value(_APPLY_CONFIRM_MISS_KEY)
-		with patch(self._READINESS_PROBE, return_value=("Ready", "")):
+		# The confirm probe is not the only admin call on the ready path: once
+		# _confirm_apply_via_admin stamps the marker, is_ready_for_chat proceeds to the
+		# final _admin_chat_gate, which asks admin again. In production that is the same
+		# control plane that just answered Ready, so present it consistently - otherwise
+		# the gate's unestablished-workspace fail-closed (a workspace with no
+		# chat_was_ready_at marker gets readiness_unconfirmed on an admin outage), not the
+		# damping under test, is what decides. Bust the gate cache so the fresh verdict is
+		# computed rather than a stale one (the idiom in the grandfather test above).
+		from jarvis import account
+
+		account._bust_chat_gate()
+		with (
+			patch(self._READINESS_PROBE, return_value=("Ready", "")),
+			patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}),
+		):
 			self.assertTrue(is_ready_for_chat().get("ready"))
+		account._bust_chat_gate()
 
 	def test_unproven_direct_tenant_goes_ready_when_admin_confirms(self):
 		"""The single-model leg strands the same way and is rescued by the same


### PR DESCRIPTION
## Problem

develop CI (run 30845451622, shard 4/4) had exactly ONE failure out of 1226:
`test_a_confirmation_is_not_damped_by_an_earlier_miss` →
`self.assertTrue(is_ready_for_chat().get("ready"))` → `AssertionError: False is not true`.

## Root cause — a cross-branch semantic collision, green on each side alone

- The failing test + `_confirm_apply_via_admin` came from **#593** (merged first). Its final
  `_admin_chat_gate` call reaches `admin_client.get_connection` **unmocked**; the test only
  mocks the `_admin_chat_readiness` probe that drives `_confirm_apply_via_admin`. On #593's
  branch this was harmless because `_admin_chat_gate` **failed open on ANY admin error**.
- **#603 (F6)** hardened `_admin_chat_gate`'s admin-unreachable branch to fail open **only for
  an established workspace** (one with a `chat_was_ready_at` marker); everything else fails
  closed with `readiness_unconfirmed`.
- Merged on develop: the test's unmocked gate call raises (no admin in CI) → the workspace
  has no marker → fail closed → `{ready: False, reason: readiness_unconfirmed}`. Neither PR's
  own CI could see it (#603's branch didn't contain #593's test).

Reproduced to ground truth on a CI-faithful site (patterntest, `chat_was_ready_at = NULL`),
verdict captured: `{ready: False, reason: 'readiness_unconfirmed', diag_code: 'admin_unreachable'}`.

## Fix — test-only

Present admin consistently at BOTH admin calls on the ready path: keep the `_admin_chat_readiness`
probe mock and additionally mock `admin_client.get_connection → {chat_readiness: Ready}` for the
final gate, plus bust the gate cache — the exact idiom the neighbouring
`test_backfill_patch_grandfathers_pre_marker_tenants` already uses. In production the confirm probe
and the final gate hit the same control plane, so a consistent Ready is the faithful representation.

**No production code touched. The F6 fence and the damping semantics are unchanged.** Removing the
miss-key clear still turns the test red (its teeth remain on the damping it pins).

## Verification (CI-faithful: patterntest, no chat_was_ready_at marker)

- Pre-fix: `test_unified_llm_config` full module → 92 tests, **1 failure** (the target) — matches CI exactly.
- Post-fix: full module → **92 OK**; target test isolated → **OK**.
- Fence intact: with admin left unreachable + no marker, the same seeding still fails closed
  (`readiness_unconfirmed`) — the F6 behaviour is untouched and independently covered in test_account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)