### PR TITLE
fix(wiki): voice-note ingest appends instead of replacing, so long pages survive

### DIFF
--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -149,6 +149,8 @@ _BODY_EXCERPT_MARKER = (
 	"\n\n[EXCERPT ONLY: {n} further characters of this page are not shown. "
 	'Reply with "append_md" for this page, never a full body.]'
 )
+# How far back an excerpt may snap to end on a whole line.
+_EXCERPT_LINE_SNAP_CHARS = 200
 
 
 # --------------------------------------------------------------------------- #
@@ -811,8 +813,14 @@ def _body_for_prompt(body) -> str:
 	if len(body) <= _MAX_EXISTING_BODY_PROMPT_CHARS:
 		return body
 	head = body[:_MAX_EXISTING_BODY_PROMPT_CHARS]
+	# Snap back to a line boundary, but only a NEARBY one (the _clip_body idiom):
+	# rfind scans the WHOLE window, so a body whose only early newline is followed
+	# by one long unbroken run would otherwise be trimmed to almost nothing,
+	# spending the budget on the marker instead of on context.
 	nl = head.rfind("\n")
-	head = (head[:nl] if nl > 0 else head).rstrip()
+	if nl > len(head) - _EXCERPT_LINE_SNAP_CHARS:
+		head = head[:nl]
+	head = head.rstrip()
 	return head + _BODY_EXCERPT_MARKER.format(n=len(body) - len(head))
 
 
@@ -1160,24 +1168,33 @@ def _merge_update_into_page(
 	if not (doc.ref_name or "").strip() and update.get("ref_name"):
 		doc.ref_name = str(update["ref_name"]).strip()
 
+	# ``append_md`` still wins over ``body_md``, but which key carried the content
+	# no longer decides how a CONTRADICTION lands: a contradicting append used to
+	# slip past the flagged-section path and store contested knowledge as ordinary
+	# prose, leaving neither ``contradiction_flag`` nor the marker text that
+	# jarvis.learning.wiki_lint sweeps for. Only ``body_md`` may replace, and only
+	# when the caller is allowed to.
 	existing = (doc.body_md or "").strip()
+	incoming = ""
+	replaces = False
 	if isinstance(append_md, str) and append_md.strip():
-		doc.body_md = _clip_body(f"{existing}\n\n{append_md.strip()}".strip())
+		incoming = append_md.strip()
 	elif isinstance(body_md, str) and body_md.strip():
 		incoming = body_md.strip()
+		replaces = allow_body_replace
+	if incoming:
 		if contradiction and existing:
 			stamp = now_datetime().strftime("%Y-%m-%d")
 			doc.body_md = _clip_body(f"{existing}\n\n## Contradiction flagged ({stamp})\n\n{incoming}")
 			doc.contradiction_flag = 1
-		elif existing and not allow_body_replace:
-			# An append-only caller sent a body_md anyway (the ingest prompt asks
-			# for append_md, but the model is not bound by it). It only ever saw
-			# an EXCERPT of this page, so swapping the field would delete the
-			# rest. Append instead: a duplicated section is recoverable by a
-			# human editor, a deleted one is not (issue #488).
-			doc.body_md = _clip_body(f"{existing}\n\n{incoming}")
-		else:
+		elif replaces or not existing:
 			doc.body_md = _clip_body(incoming)
+		else:
+			# Either an append, or an append-only caller that sent a body_md
+			# anyway. The ingest only ever saw an EXCERPT of this page, so
+			# swapping the field would delete the rest; a duplicated section is
+			# recoverable by a human editor, a deleted one is not (issue #488).
+			doc.body_md = _clip_body(f"{existing}\n\n{incoming}")
 	append_source(doc, source, ref, user)
 	doc.last_confirmed_at = now_datetime()
 	doc.save(ignore_permissions=True)

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -30,9 +30,10 @@ writes behind explicit channel checks + the controller sanitizer).
 Merge discipline (``apply_extracted_page_updates``): ``append_md`` appends,
 ``body_md`` replaces only when the update carries no contradiction; a flagged
 contradiction APPENDS a ``## Contradiction flagged (<date>)`` section and sets
-``contradiction_flag`` — extracted content never silently overwrites contested
-knowledge. Every applied update appends a ``{date, kind, ref, user}`` sources
-entry and refreshes ``last_confirmed_at``.
+``contradiction_flag`` WHICHEVER key carried it — extracted content never
+silently overwrites contested knowledge, and never buries it as ordinary prose
+where ``jarvis.learning.wiki_lint`` cannot find it. Every applied update appends
+a ``{date, kind, ref, user}`` sources entry and refreshes ``last_confirmed_at``.
 
 The voice-note ingest is APPEND-ONLY against pages that already exist
 (``allow_body_replace=False``). It shows the model at most

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -33,6 +33,14 @@ contradiction APPENDS a ``## Contradiction flagged (<date>)`` section and sets
 ``contradiction_flag`` — extracted content never silently overwrites contested
 knowledge. Every applied update appends a ``{date, kind, ref, user}`` sources
 entry and refreshes ``last_confirmed_at``.
+
+The voice-note ingest is APPEND-ONLY against pages that already exist
+(``allow_body_replace=False``). It shows the model at most
+``_MAX_EXISTING_BODY_PROMPT_CHARS`` of a stored body and caps the reply at 4000
+tokens, so a "full merged body" reply can never carry a long page back intact —
+replacing with it deleted everything past the excerpt. The prompt now asks for
+``append_md`` on an existing page, and the merge appends a stray ``body_md``
+instead of swapping it in.
 """
 
 from __future__ import annotations
@@ -110,21 +118,36 @@ _INGEST_SYSTEM = (
 	"You maintain an internal business wiki. Given a spoken note transcript, "
 	"the ERP entities in view and the existing wiki pages, output ONLY a JSON "
 	"array of page updates - no prose, no markdown fences. Each item must be "
-	'an object with exactly these keys: "slug" (lowercase-hyphen page id; '
-	'reuse the existing or suggested slug when one is given), "page_type" '
-	'(one of "Customer", "Supplier", "Item", "Process", "Doctype", '
-	'"Exception", "Integration", "People", "Org"), "title", "ref_doctype", '
-	'"ref_name" (the ERP record the page is about, or null), "summary" (one '
-	'paragraph, max 500 characters), "body_md" (markdown) and "contradiction" '
-	'(boolean). When the note does NOT contradict a page, "body_md" must be '
-	"the FULL updated body: the existing body with the new durable knowledge "
-	"merged in - never drop existing content. When the note contradicts what "
-	'a page already says, set "contradiction": true and put ONLY the new '
-	'conflicting information in "body_md" (it is appended as a flagged '
-	"section; the existing body is preserved). Record only durable business "
-	"knowledge - how the org, its customers, suppliers, items and processes "
-	"work; ignore greetings, small talk and one-off tasks. At most "
-	f"{MAX_PAGES_PER_NOTE} pages. Output [] when there is nothing durable."
+	'an object with these keys: "slug" (lowercase-hyphen page id; reuse the '
+	'existing or suggested slug when one is given), "page_type" (one of '
+	'"Customer", "Supplier", "Item", "Process", "Doctype", "Exception", '
+	'"Integration", "People", "Org"), "title", "ref_doctype", "ref_name" (the '
+	'ERP record the page is about, or null), "summary" (one paragraph, max 500 '
+	'characters), "contradiction" (boolean), and EXACTLY ONE body key chosen '
+	"as follows.\n"
+	'The page is NOT in the existing wiki pages: use "body_md" - the full body '
+	"of the new page.\n"
+	'The page IS in the existing wiki pages: use "append_md" - ONLY the new '
+	"durable knowledge, as a short markdown section. It is appended to the "
+	"stored body, so never repeat what the page already says and never send "
+	"the page body back. The body you were shown may be an excerpt, so a "
+	"full-body reply would destroy the part you cannot see.\n"
+	"The note CONTRADICTS what an existing page says: set "
+	'"contradiction": true and put ONLY the new conflicting information in '
+	'"body_md". It is appended as a flagged section for a human to reconcile; '
+	"the existing body is preserved.\n"
+	"Record only durable business knowledge - how the org, its customers, "
+	"suppliers, items and processes work; ignore greetings, small talk and "
+	f"one-off tasks. At most {MAX_PAGES_PER_NOTE} pages. Output [] when there "
+	"is nothing durable."
+)
+
+# Appended to a stored body that did not fit the prompt budget. Without it the
+# model reads a plain slice as the whole page and "merges" against a phantom
+# document (issue #488).
+_BODY_EXCERPT_MARKER = (
+	"\n\n[EXCERPT ONLY: {n} further characters of this page are not shown. "
+	'Reply with "append_md" for this page, never a full body.]'
 )
 
 
@@ -701,7 +724,16 @@ def _ingest_note(note_name: str) -> None:
 	if updates is None:
 		return  # extraction failed (logged); stays New for the sweep
 
-	applied, failed = apply_extracted_page_updates(updates, "voice", note.owner, ref=note.name)
+	applied, failed = apply_extracted_page_updates(
+		updates,
+		"voice",
+		note.owner,
+		ref=note.name,
+		# The prompt showed the model an EXCERPT of any long page body, so this
+		# path may never replace one: a "full merged body" reply would delete
+		# everything past the excerpt (issue #488).
+		allow_body_replace=False,
+	)
 	if failed:
 		# A page write failed (already logged per-update): leave the note New
 		# so the daily voice_facts sweep retries — marking it Processed here
@@ -768,8 +800,20 @@ def _pages_for_prompt(entities: list[dict]) -> tuple[list[dict], list[dict]]:
 		limit_page_length=len(suggested),
 	)
 	for r in rows:
-		r["body_md"] = (r.get("body_md") or "")[:_MAX_EXISTING_BODY_PROMPT_CHARS]
+		r["body_md"] = _body_for_prompt(r.get("body_md"))
 	return suggested, rows
+
+
+def _body_for_prompt(body) -> str:
+	"""The prompt copy of a stored body: whole when it fits the budget, else the
+	head cut on a line boundary plus an explicit excerpt marker."""
+	body = body or ""
+	if len(body) <= _MAX_EXISTING_BODY_PROMPT_CHARS:
+		return body
+	head = body[:_MAX_EXISTING_BODY_PROMPT_CHARS]
+	nl = head.rfind("\n")
+	head = (head[:nl] if nl > 0 else head).rstrip()
+	return head + _BODY_EXCERPT_MARKER.format(n=len(body) - len(head))
 
 
 def _extract_page_updates(note, entities, suggested, existing) -> list | None:
@@ -890,6 +934,7 @@ def apply_extracted_page_updates(
 	default_scope: str | None = None,
 	target_user: str | None = None,
 	provenance_prefix: str | None = None,
+	allow_body_replace: bool = True,
 	return_outcomes: bool = False,
 ) -> tuple[int, int] | list[dict]:
 	"""Create/update wiki pages from extracted updates (the note ingest above
@@ -916,6 +961,15 @@ def apply_extracted_page_updates(
 	human-authored / other-feature page is REFUSED rather than overwritten — a
 	scribe can create/update only its OWN pages. None (every other caller)
 	preserves today's behavior byte-for-byte.
+
+	``allow_body_replace=False`` (voice-note ingest, issue #488): a ``body_md``
+	aimed at an EXISTING page is APPENDED instead of replacing its body. Callers
+	that only saw an EXCERPT of the stored body (``_pages_for_prompt`` clips at
+	``_MAX_EXISTING_BODY_PROMPT_CHARS``) cannot produce a lossless replacement,
+	so a replace there silently deletes the unseen tail; a duplicated section is
+	recoverable, a deleted one is not. Callers that compose a page from a source
+	they read in full (the app-learning scribe) keep the default True and still
+	replace, so a re-run refreshes its own page in place rather than doubling it.
 
 	``return_outcomes=True`` (Custom App Learning scribe writeback): returns a
 	PER-UPDATE outcome list ``[{slug, ok, reason}]`` aligned to the accepted
@@ -959,7 +1013,16 @@ def apply_extracted_page_updates(
 		frappe.db.savepoint(sp)
 		try:
 			ok = bool(
-				_apply_one_update(update, source, user, ref, default_scope, target_user, provenance_prefix)
+				_apply_one_update(
+					update,
+					source,
+					user,
+					ref,
+					default_scope,
+					target_user,
+					provenance_prefix,
+					allow_body_replace,
+				)
 			)
 			reason = "applied" if ok else "refused"
 			if ok:
@@ -992,6 +1055,7 @@ def _apply_one_update(
 	default_scope: str | None = None,
 	target_user: str | None = None,
 	provenance_prefix: str | None = None,
+	allow_body_replace: bool = True,
 ) -> bool:
 	slug = _normalize_slug(update.get("slug"))
 	if not slug:
@@ -1058,11 +1122,11 @@ def _apply_one_update(
 		return False
 
 	try:
-		return _merge_update_into_page(name, update, source, user, ref, provenance_prefix)
+		return _merge_update_into_page(name, update, source, user, ref, provenance_prefix, allow_body_replace)
 	except frappe.TimestampMismatchError:
 		# Concurrent save between our load and save: reload + re-merge once
 		# so ordinary concurrency doesn't drop the update.
-		return _merge_update_into_page(name, update, source, user, ref, provenance_prefix)
+		return _merge_update_into_page(name, update, source, user, ref, provenance_prefix, allow_body_replace)
 
 
 def _merge_update_into_page(
@@ -1072,6 +1136,7 @@ def _merge_update_into_page(
 	user: str | None,
 	ref: str | None,
 	provenance_prefix: str | None = None,
+	allow_body_replace: bool = True,
 ) -> bool:
 	body_md = update.get("body_md")
 	append_md = update.get("append_md")
@@ -1104,6 +1169,13 @@ def _merge_update_into_page(
 			stamp = now_datetime().strftime("%Y-%m-%d")
 			doc.body_md = _clip_body(f"{existing}\n\n## Contradiction flagged ({stamp})\n\n{incoming}")
 			doc.contradiction_flag = 1
+		elif existing and not allow_body_replace:
+			# An append-only caller sent a body_md anyway (the ingest prompt asks
+			# for append_md, but the model is not bound by it). It only ever saw
+			# an EXCERPT of this page, so swapping the field would delete the
+			# rest. Append instead: a duplicated section is recoverable by a
+			# human editor, a deleted one is not (issue #488).
+			doc.body_md = _clip_body(f"{existing}\n\n{incoming}")
 		else:
 			doc.body_md = _clip_body(incoming)
 	append_source(doc, source, ref, user)

--- a/jarvis/tests/test_wiki.py
+++ b/jarvis/tests/test_wiki.py
@@ -294,6 +294,25 @@ class TestApplyPageUpdates(FrappeTestCase):
 		self.assertIn("prepay everything", doc.body_md)
 		self.assertEqual(frappe.utils.cint(doc.contradiction_flag), 1)
 
+	def test_contradicting_append_is_flagged_too(self):
+		# A contradiction must land in the flagged section whichever key carried
+		# it. The ingest now asks for append_md on an existing page, so a
+		# contradicting append is reachable; an unflagged one would be invisible
+		# to the wiki_lint sweep, which keys off the flag or the marker text.
+		wiki.apply_extracted_page_updates([self._alpha_update()], "voice", "a@test.invalid")
+		applied, failed = wiki.apply_extracted_page_updates(
+			[{"slug": ALPHA_SLUG, "append_md": "They now prepay everything.", "contradiction": True}],
+			"voice",
+			"b@test.invalid",
+			allow_body_replace=False,
+		)
+		self.assertEqual((applied, failed), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertIn("60-day terms", doc.body_md)
+		self.assertIn("## Contradiction flagged (", doc.body_md)
+		self.assertIn("prepay everything", doc.body_md)
+		self.assertEqual(frappe.utils.cint(doc.contradiction_flag), 1)
+
 	def test_append_md(self):
 		wiki.apply_extracted_page_updates([self._alpha_update()], "voice", "a@test.invalid")
 		applied, failed = wiki.apply_extracted_page_updates(
@@ -627,6 +646,16 @@ class TestIngestNote(_ConversationFixture):
 		self.assertLess(len(cut), len(_long_wiki_body()))
 		self.assertIn("EXCERPT ONLY", cut)
 		self.assertNotIn("TAIL-SENTINEL-KEEP-ME", cut)
+		self.assertTrue(cut.startswith("## Payment"))
+
+	def test_excerpt_spends_its_budget_on_context(self):
+		# The line-boundary snap only reaches BACK a little. A body whose one
+		# early newline is followed by a long unbroken run must still fill the
+		# budget, not collapse to the marker alone.
+		budget = wiki._MAX_EXISTING_BODY_PROMPT_CHARS
+		cut = wiki._body_for_prompt("intro\n" + "X" * (budget * 2))
+		self.assertGreater(len(cut.split("[EXCERPT ONLY")[0]), budget - 200)
+		self.assertIn("EXCERPT ONLY", cut)
 
 	def test_ingest_page_write_failure_leaves_note_new(self):
 		# A failed page write must NOT mark the note Processed — that would

--- a/jarvis/tests/test_wiki.py
+++ b/jarvis/tests/test_wiki.py
@@ -49,6 +49,13 @@ def _wiki_disabled():
 		frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 1, update_modified=False)
 
 
+def _long_wiki_body():
+	"""A body comfortably past ``_MAX_EXISTING_BODY_PROMPT_CHARS``, ending in a
+	sentinel the ingest prompt can never show the model."""
+	filler = "\n".join(f"- Escalation contact {i}: ops{i}@alpha.invalid" for i in range(80))
+	return f"## Payment\n\nAlways 60-day terms.\n\n{filler}\n\n## SLA\n\nTAIL-SENTINEL-KEEP-ME"
+
+
 def _make_page(slug, title, page_type="Customer", summary=None, body_md=None, **kwargs):
 	doc = frappe.get_doc(
 		{
@@ -206,22 +213,71 @@ class TestApplyPageUpdates(FrappeTestCase):
 		self.assertEqual(sources[0]["ref"], "NOTE-1")
 		self.assertEqual(sources[0]["user"], "a@test.invalid")
 
-		# Non-contradicting update: body_md is the merged replacement.
+		# Non-contradicting update from an append-only caller (the voice-note
+		# ingest): the new knowledge lands, the old knowledge SURVIVES. The
+		# ingest sees only an excerpt of a long body, so it may never swap the
+		# field out (issue #488).
 		applied, failed = wiki.apply_extracted_page_updates(
 			[self._alpha_update(body_md="## Payment\n\nNow 45-day terms.", summary="45 days.")],
 			"voice",
 			"b@test.invalid",
 			ref="NOTE-2",
+			allow_body_replace=False,
 		)
 		self.assertEqual((applied, failed), (1, 0))
 		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
 		self.assertIn("45-day terms", doc.body_md)
-		self.assertNotIn("60-day terms", doc.body_md)
+		self.assertIn("60-day terms", doc.body_md)
 		self.assertEqual(doc.summary, "45 days.")
 		self.assertEqual(frappe.utils.cint(doc.contradiction_flag), 0)
 		sources = json.loads(doc.sources)
 		self.assertEqual(len(sources), 2)
 		self.assertEqual(sources[1]["ref"], "NOTE-2")
+
+	def test_append_only_caller_keeps_everything_past_the_prompt_excerpt(self):
+		# Issue #488: the ingest prompt carries at most
+		# _MAX_EXISTING_BODY_PROMPT_CHARS of a stored body, so a "full merged
+		# body" reply is a rewrite of the excerpt alone. Appending it keeps the
+		# unseen tail; replacing with it deleted the tail outright.
+		body = _long_wiki_body()
+		self.assertGreater(len(body), wiki._MAX_EXISTING_BODY_PROMPT_CHARS)
+		_make_page(ALPHA_SLUG, ALPHA, body_md=body)
+
+		applied, failed = wiki.apply_extracted_page_updates(
+			[self._alpha_update(body_md="## Payment\n\nNow 45-day terms.")],
+			"voice",
+			"b@test.invalid",
+			allow_body_replace=False,
+		)
+		self.assertEqual((applied, failed), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertIn("TAIL-SENTINEL-KEEP-ME", doc.body_md)
+		self.assertIn("Escalation contact 79", doc.body_md)
+		self.assertIn("45-day terms", doc.body_md)
+		self.assertGreaterEqual(len(doc.body_md), len(body))
+
+	def test_full_rewrite_caller_still_replaces(self):
+		# The default is deliberately unchanged: the app-learning scribe
+		# composes a page from a source it read in FULL, so a re-run refreshes
+		# its own page in place instead of doubling it every run.
+		_make_page(
+			ALPHA_SLUG,
+			ALPHA,
+			body_md="## Payment\n\nAlways 60-day terms.",
+			sources=frappe.as_json(
+				[{"date": "2026-01-01", "kind": "app-learning-agent:acme", "ref": None, "user": None}]
+			),
+		)
+		applied, failed = wiki.apply_extracted_page_updates(
+			[self._alpha_update(body_md="## Payment\n\nNow 45-day terms.")],
+			"app-learning-agent:acme",
+			"scribe@test.invalid",
+			provenance_prefix="app-learning",
+		)
+		self.assertEqual((applied, failed), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertIn("45-day terms", doc.body_md)
+		self.assertNotIn("60-day terms", doc.body_md)
 
 	def test_contradiction_appends_flagged_section(self):
 		wiki.apply_extracted_page_updates([self._alpha_update()], "voice", "a@test.invalid", ref="NOTE-1")
@@ -509,6 +565,68 @@ class TestIngestNote(_ConversationFixture):
 		with patch("jarvis.chat.voice.openrouter_complete") as mock_llm:
 			wiki._ingest_note(note.name)
 		mock_llm.assert_not_called()
+
+	def test_ingest_keeps_a_body_longer_than_the_prompt_excerpt(self):
+		# Issue #488 end to end. The stored body is past the prompt budget, so
+		# the model is shown an excerpt and answers with the destructive shape:
+		# contradiction False plus a short "full merged body". Nothing may be
+		# lost, and the model must be told the body it saw was partial.
+		body = _long_wiki_body()
+		self.assertGreater(len(body), wiki._MAX_EXISTING_BODY_PROMPT_CHARS)
+		_make_page(ALPHA_SLUG, ALPHA, body_md=body)
+		note = self._make_note()
+		updates = [
+			{
+				"slug": ALPHA_SLUG,
+				"page_type": "Customer",
+				"title": ALPHA,
+				"summary": "Consolidated monthly invoicing.",
+				"body_md": "## Payment\n\nAlways 60-day terms.\n\n- Consolidated monthly invoices.",
+				"contradiction": False,
+			}
+		]
+		with patch(
+			"jarvis.chat.voice.openrouter_complete",
+			return_value=json.dumps(updates),
+		) as mock_llm:
+			wiki._ingest_note(note.name)
+
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertIn("TAIL-SENTINEL-KEEP-ME", doc.body_md)
+		self.assertIn("Escalation contact 79", doc.body_md)
+		self.assertIn("Consolidated monthly invoices", doc.body_md)
+		self.assertGreaterEqual(len(doc.body_md), len(body))
+		self.assertEqual(frappe.db.get_value(NOTE_DT, note.name, "status"), "Processed")
+
+		system_prompt, user_prompt = (m["content"] for m in mock_llm.call_args.args[0])
+		# The excerpt is marked as such, and the contract asks for append_md on
+		# a page that already exists.
+		self.assertIn("EXCERPT ONLY", user_prompt)
+		self.assertNotIn("TAIL-SENTINEL-KEEP-ME", user_prompt)
+		self.assertIn("append_md", system_prompt)
+
+	def test_ingest_appends_new_knowledge_to_an_existing_page(self):
+		# The shape the prompt now asks for on an existing page.
+		_make_page(ALPHA_SLUG, ALPHA, body_md="## Payment\n\nAlways 60-day terms.")
+		note = self._make_note()
+		updates = [{"slug": ALPHA_SLUG, "append_md": "- Consolidated monthly invoices."}]
+		with patch(
+			"jarvis.chat.voice.openrouter_complete",
+			return_value=json.dumps(updates),
+		):
+			wiki._ingest_note(note.name)
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertIn("60-day terms", doc.body_md)
+		self.assertTrue(doc.body_md.endswith("- Consolidated monthly invoices."))
+
+	def test_short_body_reaches_the_prompt_whole(self):
+		# Only an over-budget body is cut, and the cut lands on a line boundary.
+		short = "## Payment\n\nAlways 60-day terms."
+		self.assertEqual(wiki._body_for_prompt(short), short)
+		cut = wiki._body_for_prompt(_long_wiki_body())
+		self.assertLess(len(cut), len(_long_wiki_body()))
+		self.assertIn("EXCERPT ONLY", cut)
+		self.assertNotIn("TAIL-SENTINEL-KEEP-ME", cut)
 
 	def test_ingest_page_write_failure_leaves_note_new(self):
 		# A failed page write must NOT mark the note Processed — that would


### PR DESCRIPTION
## Summary

The voice-note wiki ingest no longer deletes the part of a page it never showed the model: a page over 3,000 characters now survives an ingest intact. Anyone who records a chat nudge note against an entity that has a long wiki page notices, because that page used to lose everything past 3,000 characters, silently, on every ingest.

I chose to make the ingest APPEND to an existing page rather than to keep the replace behind a "materially shorter" guard. The deciding fact is that the replace contract is not merely truncation-buggy, it is arithmetically impossible: the reply is capped at `max_tokens=4000` (roughly 16,000 characters, shared across up to 5 pages) while `MAX_BODY_LEN` is 20,000, so the model can never hand a long body back intact even if it were shown the whole thing. A shrink guard would then fire on essentially every long page and still have to fall back to append, so it buys a heuristic and no extra safety.

Appending does not break corrections. On this path a correction is already an append: `contradiction: true` appends a `## Contradiction flagged` section and sets `contradiction_flag`, and that branch is untouched. The non-contradiction branch had no correction remit at all, the prompt told it "never drop existing content", so replace only ever served tidiness.

Server side is the enforcement, the prompt is only the request: `allow_body_replace=False` makes a stray `body_md` against an existing page append instead of replace, so a model that ignores the prompt still cannot delete anything.

<details>
<summary>Root cause, the three steps that composed into loss</summary>

1. `wiki.py:98` `_MAX_EXISTING_BODY_PROMPT_CHARS = 3000`, and `_pages_for_prompt` sliced the body with no marker, so the model read a slice as the whole page.
2. `_INGEST_SYSTEM` listed exactly 8 keys with no `append_md` among them, and demanded `body_md` be "the FULL updated body ... never drop existing content". The lossless `append_md` branch at `wiki.py:1099` existed but was unreachable because the model was never told the key existed.
3. `_merge_update_into_page` did `doc.body_md = _clip_body(incoming)`. No length comparison, no minimum-retention check. `_clip_body` and the controller's `_validate_lengths` enforce only the 20,000 upper bound.

Entry path: ChatView nudge card, `voice_notes_api.save_voice_note`, `wiki.enqueue_ingest_note`, `_ingest_note`. `wiki_enabled` defaults ON via the NULL=ON idiom, and `voice_facts.process_daily` re-enqueues New notes as a backstop.

Changes:

- `_INGEST_SYSTEM`: one body key chosen by case. New page: `body_md`. Existing page: `append_md`, only the new knowledge, never the page body back. Contradiction: unchanged.
- `_body_for_prompt`: an over-budget body is cut on a line boundary and carries an explicit `[EXCERPT ONLY: N further characters ...]` marker.
- `apply_extracted_page_updates(allow_body_replace=True)`: new keyword, default True. Every existing caller is byte for byte unchanged, which matters for the app-learning scribe (`record_app_wiki`, `app_analysis`): it composes a page from a source it read in full, so its re-run must still replace its own page rather than double it. Only the ingest passes False.

Verified the regression test fails on unpatched `develop` with the real defect, a 3,979 character body reduced to 63 characters:

```
AssertionError: 'TAIL-SENTINEL-KEEP-ME' not found in
'## Payment\n\nAlways 60-day terms.\n\n- Consolidated monthly invoices.'
```

Local run, `bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_wiki`: 25 + 29 tests, OK. Related modules also green: `test_app_learning` (44), `test_app_learning_agent` (59), `test_voice_facts` (21), `test_personalise_pipeline` (38), `test_wiki_scopes_api` (38), `test_confirm_card` (68). `test_wiki_graph.test_add_link_concurrency_no_lost_update` errors locally with MariaDB 1020 on a threaded `for_update` read, and it errors identically on unpatched `develop`, so it is pre-existing and unrelated.

Not fixed here, worth a follow-up: appends now accumulate, and `_clip_body` drops the OLDEST content once a body passes the hard 20,000 cap. That is the pre-existing policy on every append writer (`voice_facts`, the `update_wiki` tool, the contradiction branch) and 20,000 is enforced on human saves too, so it is a separate discussion, not part of this defect.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on :x:)
- [x] Branch is up to date with `develop` (branched from `upstream/develop` at 19471502)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi

Closes #488
