### PR TITLE
fix(wiki): prune a demoted page's file from the org-shared mirror

### DIFF
--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -388,11 +388,19 @@ def _chunk_files(files: list[dict]) -> list[list[dict]]:
 # --------------------------------------------------------------------------- #
 # triggers
 # --------------------------------------------------------------------------- #
-def enqueue_sync(full: bool = False) -> None:
+def enqueue_sync(full: bool = False, after_commit: bool = False) -> None:
 	"""Queue the deduped mirror sync (short queue, 120s deadline). Suppressed
 	under tests unless ``frappe.flags.jarvis_test_wiki_mirror_enqueue`` is set
 	— fixture inserts must not spray RQ jobs. Enqueue failures (Redis down)
-	are swallowed: this runs inside user save paths via doc_events."""
+	are swallowed: this runs inside user save paths via doc_events.
+
+	``after_commit`` is what the doc_events trigger needs and what the manual
+	endpoint must not use. The worker opens its own DB connection, so a job
+	queued mid-save can read the PRE-save row, find nothing to push or prune,
+	and report success — and with no periodic sweep, a prune lost that way is
+	lost for good. Deferring to the save's commit closes that window. The
+	manual "Sync now" endpoint writes nothing, so its request may never commit
+	and deferring there would drop the job entirely."""
 	if frappe.flags.in_test and not frappe.flags.jarvis_test_wiki_mirror_enqueue:
 		return
 	try:
@@ -402,6 +410,7 @@ def enqueue_sync(full: bool = False) -> None:
 			timeout=JOB_TIMEOUT_S,
 			job_id=JOB_ID_FULL if full else JOB_ID,
 			deduplicate=True,
+			enqueue_after_commit=bool(after_commit),
 			full=bool(full),
 		)
 	except Exception:
@@ -420,7 +429,7 @@ def on_wiki_page_change(doc, method: str | None = None) -> None:
 		prune = _needs_mirror_prune(doc)
 		if not prune and not _is_org_scope(doc.get("scope")):
 			return
-		enqueue_sync(full=(prune or method == "on_trash"))
+		enqueue_sync(full=(prune or method == "on_trash"), after_commit=True)
 	except Exception:
 		frappe.log_error(
 			title="wiki mirror: doc-event trigger failed",

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -11,7 +11,9 @@ cheap native file reads/greps; ``jarvis__read_wiki`` stays authoritative.
 
 Scope discipline: only Org pages (scope NULL/'' counts as Org) are ever
 mirrored — the container workspace is org-shared, so Role/User pages must
-never land there. Diffing rides ``mirror_hash`` (sha256 of the rendered
+never land there. That runs both ways: narrowing a mirrored page to Role/User
+is a revocation, so its file is deleted on the next sync (there is no periodic
+sweep to fall back on). Diffing rides ``mirror_hash`` (sha256 of the rendered
 content, stamped per page via ``frappe.db.set_value`` — deliberately NOT
 ``doc.save``, which would re-fire the very doc_events that trigger the sync).
 
@@ -89,6 +91,12 @@ _PAGE_FIELDS = [
 def _is_org_scope(scope) -> bool:
 	"""NULL/'' scope (pre-v2 rows) reads as Org everywhere."""
 	return (scope or "").strip() in ("", "Org")
+
+
+def _is_mirrorable(page) -> bool:
+	"""Only Active Org pages belong on the org-shared container. Everything
+	else (archived, or narrowed to Role/User) must have its file removed."""
+	return _is_org_scope(page.get("scope")) and (page.get("status") or "Active") == "Active"
 
 
 def _wire_path(path: str) -> str:
@@ -171,7 +179,7 @@ def render_index() -> tuple[str, str]:
 		order_by="name asc",
 		limit_page_length=0,
 	)
-	pages = [r for r in rows if _is_org_scope(r.scope) and (r.status or "Active") == "Active"]
+	pages = [r for r in rows if _is_mirrorable(r)]
 	by_type: dict[str, list] = {}
 	for r in pages:
 		by_type.setdefault((r.page_type or "").strip() or "Org", []).append(r)
@@ -275,9 +283,7 @@ def _stamp_sync_status(result: dict) -> None:
 
 def _sync(full: bool) -> dict:
 	rows = frappe.get_all(WIKI, fields=_PAGE_FIELDS, limit_page_length=0)
-	org = [r for r in rows if _is_org_scope(r.scope)]
-	active = [r for r in org if (r.status or "Active") == "Active"]
-	inactive = [r for r in org if (r.status or "Active") != "Active"]
+	active = [r for r in rows if _is_mirrorable(r)]
 
 	files: list[dict] = []
 	for r in active:
@@ -292,9 +298,13 @@ def _sync(full: bool) -> dict:
 	files.append(_file_entry(ipath, icontent))
 	files.append(_file_entry(lpath, lcontent))
 
-	# Archived pages whose file is (still) on the container: delete + clear the
-	# hash stamp after a confirmed push so the delete isn't re-sent forever.
-	deletes = [r for r in inactive if (r.mirror_hash or "")]
+	# Every page whose file is (still) on the container but no longer belongs
+	# there: archived, or narrowed out of Org scope. A stamped mirror_hash is
+	# the standing proof a file was pushed, so it drives the delete list no
+	# matter WHY the page stopped being mirrorable; clearing the stamp after a
+	# confirmed push stops the delete being re-sent forever and lets a later
+	# re-promotion push the same content again.
+	deletes = [r for r in rows if (r.mirror_hash or "") and not _is_mirrorable(r)]
 	delete_paths = [_wire_path(page_path(r)) for r in deletes]
 	known_paths = None
 	if full:
@@ -400,17 +410,48 @@ def enqueue_sync(full: bool = False) -> None:
 
 def on_wiki_page_change(doc, method: str | None = None) -> None:
 	"""doc_events hook (after_insert / on_update / on_trash on Jarvis Wiki
-	Page). Only Org-scope pages trigger a sync — Role/User pages are never
-	mirrored. A trash enqueues a FULL sync: the row is gone before the job
-	runs, so only known_paths pruning can remove its file (archival, by
-	contrast, is a status flip the incremental sync sees as a delete).
-	Never raises into the save/delete path."""
+	Page). Org-scope pages trigger a sync; so does a Role/User page that still
+	has a file on the org-shared container, because narrowing a page's scope is
+	a REVOCATION and the file has to go. A trash enqueues a FULL sync: the row
+	is gone before the job runs, so only known_paths pruning can remove its
+	file (archival, by contrast, is a status flip the incremental sync sees as
+	a delete). Never raises into the save/delete path."""
 	try:
-		if not _is_org_scope(doc.get("scope")):
+		prune = _needs_mirror_prune(doc)
+		if not prune and not _is_org_scope(doc.get("scope")):
 			return
-		enqueue_sync(full=(method == "on_trash"))
+		enqueue_sync(full=(prune or method == "on_trash"))
 	except Exception:
 		frappe.log_error(
 			title="wiki mirror: doc-event trigger failed",
 			message=frappe.get_traceback(),
 		)
+
+
+def _needs_mirror_prune(doc) -> bool:
+	"""True when this non-Org page has a mirrored file to revoke.
+
+	Two signals, because each covers the other's blind spot:
+
+	* A stamped ``mirror_hash``. Set only after a confirmed push and cleared
+	  only after a confirmed delete, so it means "a file is out there" without
+	  needing any save history — which is also why it catches pages demoted
+	  BEFORE this guard existed, and why it works in ``on_trash`` (where the
+	  doc is loaded fresh from the DB and there is no pre-save copy).
+	* A pre-save row that was Org scope. ``mirror_hash`` is stamped with
+	  ``update_modified=False``, so a Desk form opened before the last sync
+	  submits a stale empty hash without tripping the timestamp check; the
+	  pre-save row still knows the page was Org. Only ``on_update`` has one.
+
+	The prune rides a FULL sync so the fleet's ``known_paths`` walk removes the
+	file even in that stale-hash case, where no delete path can be derived.
+	"""
+	if _is_org_scope(doc.get("scope")):
+		return False
+	if (doc.get("mirror_hash") or "").strip():
+		return True
+	# callable-checked, not hasattr: frappe._dict answers every attribute with
+	# None, so a plain dict-shaped doc would hasattr-pass and then TypeError.
+	loader = getattr(doc, "get_doc_before_save", None)
+	before = loader() if callable(loader) else None
+	return bool(before and _is_org_scope(before.get("scope")))

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -293,6 +293,105 @@ class TestSync(WikiMirrorTestCase):
 		last = push2.call_args_list[-1].kwargs
 		self.assertNotIn(wire_path, last["delete"] or [])
 
+	def test_demoted_to_user_scope_page_gets_deleted_and_hash_cleared(self):
+		doc = self._page("acme")
+		wire_path = f"customers/{doc.name}.md"
+		with self._mock_push() as push:
+			wiki_mirror.sync()
+		self.assertIn(wire_path, self._pushed_paths(push))
+		self.assertTrue(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+
+		doc.reload()
+		doc.scope = "User"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+		# demotion never re-suffixes the slug, so the orphan sits at the very
+		# path the mirror pushed
+		self.assertEqual(
+			wiki_mirror.page_path(frappe.get_doc(WIKI, doc.name)),
+			f"wiki/{wire_path}",
+		)
+
+		with self._mock_push() as push2:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		self.assertNotIn(wire_path, self._pushed_paths(push2))
+		self.assertIn(wire_path, push2.call_args_list[-1].kwargs["delete"])
+		self.assertFalse(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+
+		# delete confirmed -> not re-sent forever
+		with self._mock_push() as push3:
+			wiki_mirror.sync()
+		self.assertNotIn(wire_path, push3.call_args_list[-1].kwargs["delete"] or [])
+
+	def test_demoted_to_role_scope_page_gets_deleted(self):
+		doc = self._page("shared")
+		wire_path = f"customers/{doc.name}.md"
+		with self._mock_push():
+			wiki_mirror.sync()
+
+		doc.reload()
+		doc.scope = "Role"
+		doc.target_role = "System Manager"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		self.assertNotIn(wire_path, self._pushed_paths(push))
+		self.assertIn(wire_path, push.call_args_list[-1].kwargs["delete"])
+		self.assertFalse(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+		_path, index = wiki_mirror.render_index()
+		self.assertNotIn(doc.name, index)
+
+	def test_demotion_with_a_stale_hash_still_prunes_on_the_full_sync(self):
+		doc = self._page("acme")
+		wire_path = f"customers/{doc.name}.md"
+		with self._mock_push():
+			wiki_mirror.sync()
+		self.assertTrue(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+
+		# `doc` was loaded before the sync stamped mirror_hash, and the stamp
+		# leaves `modified` alone, so this save writes the stale empty hash
+		# back without tripping the timestamp check - exactly what a Desk form
+		# opened before a sync does. The pre-save scope is the only signal left.
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			doc.scope = "User"
+			doc.save(ignore_permissions=True)
+		frappe.db.commit()
+		self.assertFalse(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+		enq.assert_called_once_with(full=True)
+
+		with self._mock_push() as push:
+			wiki_mirror.sync(full=True)
+		known = push.call_args_list[-1].kwargs["known_paths"]
+		self.assertNotIn(wire_path, known)
+
+	def test_repromoted_page_is_pushed_again(self):
+		doc = self._page("acme")
+		wire_path = f"customers/{doc.name}.md"
+		with self._mock_push():
+			wiki_mirror.sync()
+
+		doc.reload()
+		doc.scope = "User"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+		with self._mock_push():
+			wiki_mirror.sync()
+
+		# same content as before the demotion: the re-push only happens because
+		# the delete cleared the stamped hash
+		doc.reload()
+		doc.scope = "Org"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+		with self._mock_push() as push:
+			wiki_mirror.sync()
+		self.assertIn(wire_path, self._pushed_paths(push))
+		self.assertNotIn(wire_path, push.call_args_list[-1].kwargs["delete"] or [])
+
 	def test_sync_chunks_batches_under_payload_cap(self):
 		for i in range(12):
 			self._page(f"big-{i}", body="a" * 19000)
@@ -357,6 +456,28 @@ class TestTriggers(WikiMirrorTestCase):
 		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
 			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Org"), "on_trash")
 		enq.assert_called_once_with(full=True)
+
+	def test_doc_event_prunes_a_mirrored_non_org_page(self):
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="User", mirror_hash="deadbeef"), "on_update")
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Role", mirror_hash="deadbeef"), "on_trash")
+		self.assertEqual(enq.call_count, 2)
+		for call in enq.call_args_list:
+			self.assertTrue(call.kwargs["full"])
+
+	def test_doc_event_falls_back_to_the_pre_save_scope(self):
+		demoted = frappe._dict(scope="User", mirror_hash="")
+		demoted.get_doc_before_save = lambda: frappe._dict(scope="Org")
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			wiki_mirror.on_wiki_page_change(demoted, "on_update")
+		enq.assert_called_once_with(full=True)
+
+		# never mirrored: no hash, and it was already non-Org before the save
+		untouched = frappe._dict(scope="User", mirror_hash="")
+		untouched.get_doc_before_save = lambda: frappe._dict(scope="User")
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq2:
+			wiki_mirror.on_wiki_page_change(untouched, "on_update")
+		enq2.assert_not_called()
 
 	def test_doc_event_swallows_enqueue_errors(self):
 		with mock.patch.object(wiki_mirror, "enqueue_sync", side_effect=Exception("redis down")):

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -361,12 +361,36 @@ class TestSync(WikiMirrorTestCase):
 			doc.save(ignore_permissions=True)
 		frappe.db.commit()
 		self.assertFalse(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
-		enq.assert_called_once_with(full=True)
+		enq.assert_called_once_with(full=True, after_commit=True)
 
 		with self._mock_push() as push:
 			wiki_mirror.sync(full=True)
 		known = push.call_args_list[-1].kwargs["known_paths"]
 		self.assertNotIn(wire_path, known)
+
+	def test_demotion_that_also_moves_page_type_prunes_the_old_path(self):
+		doc = self._page("acme", page_type="Customer")
+		old_path = f"customers/{doc.name}.md"
+		with self._mock_push() as push:
+			wiki_mirror.sync()
+		self.assertIn(old_path, self._pushed_paths(push))
+
+		# page_path() reads the CURRENT page_type, so a demotion that also moves
+		# the page to another type dir derives a delete path that no file sits
+		# at. The full sync the prune asks for is what actually removes it.
+		doc.reload()
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			doc.scope = "User"
+			doc.page_type = "Supplier"
+			doc.save(ignore_permissions=True)
+		frappe.db.commit()
+		enq.assert_called_once_with(full=True, after_commit=True)
+
+		with self._mock_push() as push2:
+			wiki_mirror.sync(full=True)
+		known = push2.call_args_list[-1].kwargs["known_paths"]
+		self.assertNotIn(old_path, known)
+		self.assertNotIn(f"suppliers/{doc.name}.md", known)
 
 	def test_repromoted_page_is_pushed_again(self):
 		doc = self._page("acme")
@@ -445,7 +469,7 @@ class TestTriggers(WikiMirrorTestCase):
 			wiki_mirror.on_wiki_page_change(frappe._dict(scope=None), "after_insert")
 			wiki_mirror.on_wiki_page_change(frappe._dict(scope=""), "on_update")
 		self.assertEqual(enq.call_count, 3)
-		enq.assert_called_with(full=False)
+		enq.assert_called_with(full=False, after_commit=True)
 
 		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
 			wiki_mirror.on_wiki_page_change(frappe._dict(scope="User"), "on_update")
@@ -455,7 +479,7 @@ class TestTriggers(WikiMirrorTestCase):
 	def test_doc_event_trash_requests_full_sync(self):
 		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
 			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Org"), "on_trash")
-		enq.assert_called_once_with(full=True)
+		enq.assert_called_once_with(full=True, after_commit=True)
 
 	def test_doc_event_prunes_a_mirrored_non_org_page(self):
 		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
@@ -470,7 +494,7 @@ class TestTriggers(WikiMirrorTestCase):
 		demoted.get_doc_before_save = lambda: frappe._dict(scope="Org")
 		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
 			wiki_mirror.on_wiki_page_change(demoted, "on_update")
-		enq.assert_called_once_with(full=True)
+		enq.assert_called_once_with(full=True, after_commit=True)
 
 		# never mirrored: no hash, and it was already non-Org before the save
 		untouched = frappe._dict(scope="User", mirror_hash="")
@@ -495,17 +519,22 @@ class TestTriggers(WikiMirrorTestCase):
 			frappe.flags.jarvis_test_wiki_mirror_enqueue = True
 			try:
 				with mock.patch("frappe.enqueue") as enq2:
-					wiki_mirror.enqueue_sync(full=True)
+					wiki_mirror.enqueue_sync(full=True, after_commit=True)
 				enq2.assert_called_once()
 				kwargs = enq2.call_args.kwargs
 				self.assertEqual(kwargs["queue"], "short")
 				self.assertEqual(kwargs["job_id"], wiki_mirror.JOB_ID_FULL)
 				self.assertTrue(kwargs["deduplicate"])
 				self.assertTrue(kwargs["full"])
+				# a job queued mid-save would read the pre-save row
+				self.assertTrue(kwargs["enqueue_after_commit"])
 
 				with mock.patch("frappe.enqueue") as enq3:
 					wiki_mirror.enqueue_sync()
 				self.assertEqual(enq3.call_args.kwargs["job_id"], wiki_mirror.JOB_ID)
+				# the manual endpoint writes nothing, so its request may never
+				# commit; deferring there would drop the job
+				self.assertFalse(enq3.call_args.kwargs["enqueue_after_commit"])
 			finally:
 				frappe.flags.jarvis_test_wiki_mirror_enqueue = False
 		finally:


### PR DESCRIPTION
## Summary

Narrowing a wiki page from Org scope to Role or User now deletes its markdown file from the tenant container, so a System Manager who restricts a sensitive page actually revokes it instead of leaving it readable by every user in the org.

Only Org pages are mirrored into the container workspace, because that workspace is shared by everyone in the tenant. Demotion was invisible to the mirror at both ends: the doc event saw only the new scope and returned before enqueueing anything, and the sync built its delete list from Org rows only, so a demoted page was absent from the computation entirely. The result was a file that outlived its own page's deletion while the index and log looked correctly scrubbed.

The mirror now has one rule, "an Active Org page belongs on the container, nothing else does", and both archival and demotion take the same delete path. The doc event fires for any non-Org page that still carries a `mirror_hash`. That also fixes the follow-on bug where a page demoted, pruned and then re-promoted with unchanged content was never pushed back.

Second commit: the doc event enqueued its job inline, so a worker could run the sync against the pre-save row and silently conclude there was nothing to prune. It now defers to the save commit.

Fixes #491

### Already-leaked files

A demoted page that still has its row and its `mirror_hash` stamp is deleted by the very next sync, whatever triggers it. No one-off pass needed for those.

Two residues need a full sync, whose `known_paths` walk prunes strays by path rather than by stamp: a page demoted and then trashed before this ships (the row is gone, so no delete path can be derived), and a page whose `mirror_hash` was cleared by a stale form save. Both are swept by the manual "Sync now" button in the Wiki tab, or by any Org page trash. Running "Sync now" once per tenant after deploy makes the cleanup deterministic.

<details>
<summary>Root cause</summary>

**Gap 1, the trigger.** `on_wiki_page_change` guarded on `doc.get("scope")`, which is the post-demotion value, so the demoting save enqueued nothing. Trashing the demoted page hit the same early return, so `on_trash` did not prune it either. There is no scheduler entry for `wiki_mirror.sync` (`hooks.py` wires it as doc events only), so nothing periodic would ever catch the miss.

**Gap 2, the delete list.** `_sync` built `org` from Org rows, derived `active` and `inactive` from `org`, then derived `deletes` from `inactive`. A demoted page was in neither list, so it could never appear in `deletes`.

**Why the fix does not lean on scope history.** `doc.get_doc_before_save()` exists in `on_update` (Frappe loads it in `check_if_latest`) but is `None` in `after_insert` and `on_trash`. A stamped `mirror_hash` needs no history at all, works in every hook, and is what catches pages demoted before this ships. It is the primary signal.

**Why there is a second signal.** `mirror_hash` is `read_only` and is stamped with `update_modified=False`. Frappe does not filter read-only fields out of a submitted document, and the stamp does not bump `modified`, so a Desk form opened before the last sync writes the stale empty hash back without raising `TimestampMismatchError`. The test `test_demotion_with_a_stale_hash_still_prunes_on_the_full_sync` reproduces exactly that and asserts the stamp is gone after the save. In that case the pre-save row is the only thing that still knows the page was Org, and the prune rides a FULL sync so the fleet's `known_paths` walk removes the file by path.

`_apply_scope_slug_suffix` runs in `before_insert` only, so a demoted page keeps its slug and docname and `page_path()` still resolves to the path that was pushed. Nothing about slugs or docnames changes here.

**The enqueue race (second commit).** `enqueue_sync` called `frappe.enqueue` without `enqueue_after_commit`, so the job hit Redis while the demoting save was still open. The worker opens its own DB connection, so it could read the pre-save row, see a page that is still Org scope and Active, find nothing to push or prune, and return `ok: True`. Nothing retries after that, because there is no periodic sweep, so a prune lost to that race is lost for good. The doc-event trigger now passes `enqueue_after_commit=True`, which is the pattern this app already uses for doc-event work (`jarvis/learning/questions.py`, `jarvis/triggers/engine.py`). The manual "Sync now" endpoint deliberately does not, because it writes nothing and its request may never commit, which would drop the job.

**A demotion that also moves `page_type`.** `page_path()` reads the current `page_type`, so a save that narrows scope and changes the type in one go derives a delete path pointing at a file that does not exist, while the real file sits in the old type dir. This is why the prune asks for a FULL sync rather than an incremental one: `known_paths` removes the file by walking the directory, not by trusting a derived path. `test_demotion_that_also_moves_page_type_prunes_the_old_path` covers it.

**Scope note.** This PR deliberately does not touch the `wiki_enabled()` gating question (#493). Gating the mirror while this bug is unfixed would make a leaked file permanently uncleanable.

</details>

## Testing

`bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_wiki_mirror` passes, 24 tests. Seven are new:

- `test_demoted_to_user_scope_page_gets_deleted_and_hash_cleared`
- `test_demoted_to_role_scope_page_gets_deleted`
- `test_demotion_with_a_stale_hash_still_prunes_on_the_full_sync`
- `test_demotion_that_also_moves_page_type_prunes_the_old_path`
- `test_repromoted_page_is_pushed_again`
- `test_doc_event_prunes_a_mirrored_non_org_page`
- `test_doc_event_falls_back_to_the_pre_save_scope`

Reverting `wiki_mirror.py` to `develop` and keeping the tests fails 10 of the 24: all seven new ones, plus three existing trigger tests whose assertions were updated for the new `after_commit` argument. The four sync tests drive a real `doc.save()` scope change through the doc event, not a hand-built payload.

`jarvis.tests.test_wiki`, `test_wiki_permissions`, `test_wiki_scopes_api` and `test_wiki_lint` also pass unchanged. `test_wiki_graph` has one local failure, `test_add_link_concurrency_no_lost_update`, which reproduces identically on unmodified `develop` (a `SELECT ... FOR UPDATE` lock wait on the shared local site) and passes on hosted CI.

## Pre-merge checklist

- [ ] **CI is green**: the `tests` check on this PR passes (never merge on :x:)
- [x] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
