### PR TITLE
fix(macros): identity guard, usage caps and honest failures for scheduled runs

### DIFF
--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -39,6 +39,7 @@ from frappe.utils import now_datetime
 from jarvis._session import authenticated_user
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.macro_scheduler import compute_next_run
+from jarvis.permissions import is_valid_unattended_owner
 from jarvis.tools import _delegate_capability
 
 INSTALLATION = "Jarvis Agent Installation"
@@ -846,9 +847,11 @@ def _is_app_learning(agent: str) -> bool:
 
 
 def _valid_owner(owner: str) -> bool:
-	if not owner or owner in ("Administrator", "Guest"):
-		return False
-	return bool(frappe.db.get_value("User", owner, "enabled"))
+	"""S1 fail-closed identity guard. The rule itself now lives in
+	``jarvis.permissions.is_valid_unattended_owner`` so the macro scheduler shares
+	one definition with this one instead of re-deriving it (jarvis #469); this
+	wrapper keeps the local name every call site here already uses."""
+	return is_valid_unattended_owner(owner)
 
 
 def _agent_run_budget_monthly() -> int:

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -29,26 +29,28 @@ def run_due_macros() -> None:
 	if not due:
 		return
 
-	from jarvis.permissions import has_jarvis_access
+	from jarvis.permissions import has_jarvis_access, is_valid_unattended_owner
 
 	original_user = frappe.session.user
 	for m in due:
 		# MAC-1 (security review PART 3, TASK 23): never run a macro whose owner
 		# has lost Jarvis access (demoted System User, or a Website/portal owner) —
 		# the scheduled turn would otherwise execute jarvis__* tools as an identity
-		# categorically barred from Jarvis. Advance the schedule so it does not busy
-		# re-fire, but skip the run.
-		if not has_jarvis_access(m.owner):
-			frappe.db.set_value(
-				MACRO,
-				m.name,
-				{
-					"last_run_at": now,
-					"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now),
-				},
-				update_modified=False,
-			)
-			frappe.db.commit()
+		# categorically barred from Jarvis.
+		#
+		# #469: has_jarvis_access alone is NOT that guarantee. It returns True for
+		# Administrator before any other check, and NOTHING in permissions.py (nor
+		# frappe.get_roles) reads User.enabled — so on its own it admitted an
+		# unattended, fully perm-bypassing Administrator turn, and kept an
+		# offboarded employee's macros firing with live ERP access forever. Add the
+		# fail-closed identity guard the sibling agent scheduler has always applied
+		# (agent_scheduler._valid_owner). Both checks are required: this one refuses
+		# Administrator/Guest/disabled, has_jarvis_access refuses portal users and
+		# role-less System Users.
+		#
+		# Advance the schedule so it does not busy re-fire, but skip the run.
+		if not is_valid_unattended_owner(m.owner) or not has_jarvis_access(m.owner):
+			_consume_slot(m, now)
 			continue
 		try:
 			frappe.set_user(m.owner)
@@ -62,18 +64,24 @@ def run_due_macros() -> None:
 			)
 		finally:
 			frappe.set_user(original_user)
-		# Advance the schedule with a raw set_value (no re-validate, which would
-		# otherwise recompute next_run_at itself).
-		frappe.db.set_value(
-			MACRO,
-			m.name,
-			{
-				"last_run_at": now,
-				"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now),
-			},
-			update_modified=False,
-		)
-		frappe.db.commit()
+		_consume_slot(m, now)
+
+
+def _consume_slot(m, now) -> None:
+	"""Consume this macro's schedule slot: stamp ``last_run_at`` and compute the
+	next occurrence with a raw set_value (no re-validate, which would otherwise
+	recompute ``next_run_at`` itself). ``compute_next_run`` is taken from *now*, so
+	even a long outage yields ONE next slot rather than a backfill storm."""
+	frappe.db.set_value(
+		MACRO,
+		m.name,
+		{
+			"last_run_at": now,
+			"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now),
+		},
+		update_modified=False,
+	)
+	frappe.db.commit()
 
 
 def compute_next_run(frequency: str, schedule_time, from_dt=None) -> datetime.datetime:

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -37,6 +37,41 @@ _BARRED_OWNER = (
 )
 _DISPATCH_FAILED = "Scheduled run could not be started. It will retry on the next hourly tick."
 
+# #468: what the owner is told when the entitlement / budget gate refused the run.
+# Keyed on the machine codes `policy.validate_can_send` and `macros.entitlement_block`
+# report, so the macro and the chat composer never disagree about why a send is barred.
+_BLOCK_SENTENCE = {
+	"usage_limit": (
+		"Scheduled run skipped: this user's monthly usage limit is reached. Runs resume "
+		"when the limit resets, or when an admin raises it."
+	),
+	"subscription_suspended": (
+		"Scheduled run skipped: the subscription does not currently include chat. Runs "
+		"resume once billing is settled."
+	),
+	"llm_not_configured": (
+		"Scheduled run skipped: no AI model connection is configured. Connect a model and "
+		"runs resume on the next scheduled slot."
+	),
+	"release_update_required": (
+		"Scheduled run deferred: a Jarvis update is rolling out on this workspace. It will "
+		"retry on the next hourly tick."
+	),
+	"workspace_resetting": (
+		"Scheduled run deferred: the workspace is being rebuilt. It will retry on the next hourly tick."
+	),
+	"scheduled_step_budget": (
+		"Scheduled run skipped: this month's budget for scheduled macro runs is used up. "
+		"Runs resume next month, or ask an admin to raise the budget in Jarvis Settings."
+	),
+}
+
+# #468: a refusal that CLEARS ON ITS OWN within minutes leaves the slot due, so the
+# next hourly tick retries it (the sibling's O4 shape). Everything else is an
+# entitlement decision that cannot clear inside the hour — consume the slot, or the
+# cadence relogs the same dead end 24 times a day.
+_TRANSIENT_BLOCKS = {"release_update_required", "workspace_resetting"}
+
 
 def run_due_macros() -> None:
 	"""Run every enabled macro whose next_run_at is due. Runs as Administrator
@@ -120,9 +155,11 @@ def _settle(m, now, out: dict) -> None:
 		# the pre-dispatch branch — no failure, nothing ran.
 		_consume_slot(m, now, stamp_last_run=False)
 		return
-	sentence = reason or "Scheduled run was refused."
+	sentence = _BLOCK_SENTENCE.get(reason) or f"Scheduled run was refused: {reason or 'unknown'}."
 	_record_failed(m, sentence)
 	_notify_owner(m, sentence)
+	if reason in _TRANSIENT_BLOCKS:
+		return  # leave next_run_at in the past: the next tick retries the slot
 	_consume_slot(m, now)
 
 

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -4,17 +4,38 @@ An hourly cron (``jarvis.hooks.scheduler_events``) calls :func:`run_due_macros`,
 which fires every enabled macro whose ``next_run_at`` has passed — running it as
 the macro's owner (so the result conversation is theirs) and advancing
 ``next_run_at`` for the next occurrence. Modeled on
-``jarvis.chat.stale_scan.scan_and_mark_errored``.
+``jarvis.chat.stale_scan.scan_and_mark_errored``, hardened to match
+``jarvis.chat.agent_scheduler``:
+
+* **#469** — a fail-closed identity guard: an unattended turn never binds to
+  ``Administrator``, ``Guest`` or a disabled user.
+* **#471** — every outcome is DURABLE and honest. A slot that did not produce a
+  run writes a ``failed`` ``Jarvis Macro Run`` the owner can see (and, when the
+  owner can act on it, a Notification Log), instead of an Error Log only a System
+  Manager can read; ``last_run_at`` is stamped only when the slot was actually
+  consumed; and a dispatch that RAISED does not advance the schedule, so the
+  missed slot retries on the next tick rather than looking like a success.
 """
 
 import datetime
 
 import frappe
-from frappe.utils import add_to_date, get_datetime, now_datetime
+from frappe.utils import add_to_date, cint, get_datetime, now_datetime
 
 MACRO = "Jarvis Macro"
+RUN = "Jarvis Macro Run"
 
 _DEFAULT_SECONDS = 9 * 3600  # 09:00 when no schedule_time set
+
+# #471: the owner cannot act on any of these — Administrator and disabled users
+# are refused by notify_owner anyway, and a role-less owner can no longer reach
+# the SPA — so the failed run row is the whole record. Notifying would relog the
+# same dead end every cadence forever.
+_BARRED_OWNER = (
+	"Scheduled run skipped: this macro's owner may not run unattended work "
+	"(Administrator, a disabled account, or no Jarvis access)."
+)
+_DISPATCH_FAILED = "Scheduled run could not be started. It will retry on the next hourly tick."
 
 
 def run_due_macros() -> None:
@@ -24,15 +45,26 @@ def run_due_macros() -> None:
 	due = frappe.get_all(
 		MACRO,
 		filters={"schedule_enabled": 1, "next_run_at": ["<=", now]},
-		fields=["name", "owner", "schedule_frequency", "schedule_time"],
+		fields=["name", "macro_name", "owner", "enabled", "schedule_frequency", "schedule_time"],
 	)
 	if not due:
 		return
 
+	from jarvis.chat import macros
 	from jarvis.permissions import has_jarvis_access, is_valid_unattended_owner
 
 	original_user = frappe.session.user
 	for m in due:
+		# #471: a macro its owner switched OFF is not a failure, it is the state
+		# they asked for. run_macro's own `enabled` early return was never inspected
+		# here, so the slot was consumed AND last_run_at stamped — leaving the UI
+		# reading "last run: today" for a macro that has not run in months. Move the
+		# schedule on so it does not busy re-fire, write no failed row, and leave
+		# last_run_at alone: nothing ran.
+		if not cint(m.enabled):
+			_consume_slot(m, now, stamp_last_run=False)
+			continue
+
 		# MAC-1 (security review PART 3, TASK 23): never run a macro whose owner
 		# has lost Jarvis access (demoted System User, or a Website/portal owner) —
 		# the scheduled turn would otherwise execute jarvis__* tools as an identity
@@ -48,40 +80,114 @@ def run_due_macros() -> None:
 		# Administrator/Guest/disabled, has_jarvis_access refuses portal users and
 		# role-less System Users.
 		#
-		# Advance the schedule so it does not busy re-fire, but skip the run.
+		# Consume the slot so it does not busy re-fire, but skip the run.
 		if not is_valid_unattended_owner(m.owner) or not has_jarvis_access(m.owner):
+			_record_failed(m, _BARRED_OWNER)
 			_consume_slot(m, now)
 			continue
 		try:
 			frappe.set_user(m.owner)
-			from jarvis.chat import macros
-
-			macros.run_macro(m.name, trigger="scheduled")
+			out = macros.run_macro(m.name, trigger="scheduled") or {}
 		except Exception:
+			frappe.set_user(original_user)
 			frappe.log_error(
 				title=f"jarvis scheduled macro failed: {m.name}",
 				message=frappe.get_traceback(),
 			)
+			# #471: record the failure where the OWNER can see it, and do NOT consume
+			# the slot — next_run_at stays in the past so the next hourly tick retries
+			# it. Previously the schedule advanced regardless, so a run that never
+			# happened was indistinguishable from one that did.
+			_record_failed(m, _DISPATCH_FAILED)
+			_notify_owner(m, _DISPATCH_FAILED)
+			continue
 		finally:
-			frappe.set_user(original_user)
+			if frappe.session.user != original_user:
+				frappe.set_user(original_user)
+		_settle(m, now, out)
+
+
+def _settle(m, now, out: dict) -> None:
+	"""Apply the outcome ``run_macro`` reported. A refusal it returns rather than
+	raises (``{"ok": False, "reason": ...}``) used to be dropped on the floor here,
+	so the slot was consumed and stamped as if the macro had run."""
+	if out.get("ok"):
 		_consume_slot(m, now)
+		return
+	reason = str(out.get("reason") or "").strip()
+	if reason == "macro disabled":
+		# Raced: disabled between the due query and the dispatch. Same handling as
+		# the pre-dispatch branch — no failure, nothing ran.
+		_consume_slot(m, now, stamp_last_run=False)
+		return
+	sentence = reason or "Scheduled run was refused."
+	_record_failed(m, sentence)
+	_notify_owner(m, sentence)
+	_consume_slot(m, now)
 
 
-def _consume_slot(m, now) -> None:
-	"""Consume this macro's schedule slot: stamp ``last_run_at`` and compute the
-	next occurrence with a raw set_value (no re-validate, which would otherwise
-	recompute ``next_run_at`` itself). ``compute_next_run`` is taken from *now*, so
-	even a long outage yields ONE next slot rather than a backfill storm."""
-	frappe.db.set_value(
-		MACRO,
-		m.name,
-		{
-			"last_run_at": now,
-			"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now),
-		},
-		update_modified=False,
-	)
+def _consume_slot(m, now, *, stamp_last_run: bool = True) -> None:
+	"""Consume this macro's schedule slot: compute the next occurrence with a raw
+	set_value (no re-validate, which would otherwise recompute ``next_run_at``
+	itself). ``compute_next_run`` is taken from *now*, so even a long outage yields
+	ONE next slot rather than a backfill storm.
+
+	``stamp_last_run=False`` moves the schedule on WITHOUT claiming a run happened:
+	``last_run_at`` is what the SPA renders as "last run", so stamping it for a slot
+	nothing executed is the #471 "the UI reports success" limb."""
+	values = {"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now)}
+	if stamp_last_run:
+		values["last_run_at"] = now
+	frappe.db.set_value(MACRO, m.name, values, update_modified=False)
 	frappe.db.commit()
+
+
+def _record_failed(m, reason: str) -> None:
+	"""Write a ``failed`` Jarvis Macro Run owned by the macro's owner, so a slot
+	that did not run is VISIBLE — in the run-history list and the dashboard tiles —
+	rather than only in an Error Log the owner cannot read (#471). Mirrors
+	``agent_scheduler._record_failed``.
+
+	Never raises: a bookkeeping failure must not abort the sweep for every other
+	due macro."""
+	try:
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"macro": m.name,
+				"status": "failed",
+				"trigger": "scheduled",
+				"current_step": 0,
+				"total_steps": 0,
+				"started_at": frappe.utils.now(),
+				"finished_at": frappe.utils.now(),
+				"error": (reason or "")[:500],
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		if m.owner and m.owner != frappe.session.user:
+			frappe.db.set_value(RUN, run.name, "owner", m.owner, update_modified=False)
+		frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(
+			title="jarvis macro scheduler: could not record a failed run",
+			message=frappe.get_traceback(),
+		)
+
+
+def _notify_owner(m, reason: str) -> None:
+	"""Tell the owner their scheduled macro did not run. A 03:00 failure reaches
+	nobody through the realtime channel (no socket is open), which is why #471 calls
+	the current behaviour silent."""
+	from jarvis.chat import macros
+
+	macros.notify_owner(
+		m.owner,
+		subject=f"Scheduled macro did not run: {m.get('macro_name') or m.name}",
+		body=reason,
+	)
 
 
 def compute_next_run(frequency: str, schedule_time, from_dt=None) -> datetime.datetime:

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -22,6 +22,8 @@ import datetime
 import frappe
 from frappe.utils import add_to_date, cint, get_datetime, now_datetime
 
+from jarvis.chat.macros import BLOCK_DISPATCH_FAILED, BLOCK_STEP_BUDGET
+
 MACRO = "Jarvis Macro"
 RUN = "Jarvis Macro Run"
 
@@ -60,9 +62,13 @@ _BLOCK_SENTENCE = {
 	"workspace_resetting": (
 		"Scheduled run deferred: the workspace is being rebuilt. It will retry on the next hourly tick."
 	),
-	"scheduled_step_budget": (
+	BLOCK_STEP_BUDGET: (
 		"Scheduled run skipped: this month's budget for scheduled macro runs is used up. "
 		"Runs resume next month, or ask an admin to raise the budget in Jarvis Settings."
+	),
+	BLOCK_DISPATCH_FAILED: (
+		"Scheduled run could not be started: the agent turn was not dispatched. It will "
+		"retry on the next hourly tick."
 	),
 }
 
@@ -70,7 +76,7 @@ _BLOCK_SENTENCE = {
 # next hourly tick retries it (the sibling's O4 shape). Everything else is an
 # entitlement decision that cannot clear inside the hour — consume the slot, or the
 # cadence relogs the same dead end 24 times a day.
-_TRANSIENT_BLOCKS = {"release_update_required", "workspace_resetting"}
+_TRANSIENT_BLOCKS = {"release_update_required", "workspace_resetting", BLOCK_DISPATCH_FAILED}
 
 
 def run_due_macros() -> None:
@@ -156,6 +162,12 @@ def _settle(m, now, out: dict) -> None:
 		_consume_slot(m, now, stamp_last_run=False)
 		return
 	sentence = _BLOCK_SENTENCE.get(reason) or f"Scheduled run was refused: {reason or 'unknown'}."
+	if reason == BLOCK_DISPATCH_FAILED:
+		# run_macro already terminalized the run row it had created — the one that
+		# carries the conversation link — so recording a second one here would show the
+		# customer two failures for one missed slot. Notify, and leave the slot due.
+		_notify_owner(m, sentence)
+		return
 	_record_failed(m, sentence)
 	_notify_owner(m, sentence)
 	if reason in _TRANSIENT_BLOCKS:

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -43,9 +43,37 @@ _STOP_LOCK_BLOCK_S = 10.0
 # 2-minute turn-recovery sweep, so 3 h is a ~12x margin over the longest legitimate gap
 # between two step advances. Module-level so tests can shorten it.
 STALE_RUN_AFTER_SECONDS = 3 * 3600
-_STALE_RUN_ERROR = (
-	"The run stopped making progress and was closed by the stale-run sweep. Run it again."
-)
+_STALE_RUN_ERROR = "The run stopped making progress and was closed by the stale-run sweep. Run it again."
+
+# #468: the monthly budget for UNATTENDED macro work, per owner. Counted in STEPS,
+# not runs: one run is up to MAX_STEPS (25) agent turns, so a run count would
+# under-bound the real spend by 25x. Read from Jarvis Settings at run time (not a
+# constant) so a bench admin can raise it without a code change, and floored at
+# MIN_ so a misconfigured 0/blank can never wedge every schedule for a month.
+#
+# The uncapped ceiling this replaces: MAX_MACROS_PER_OWNER (25) x MAX_STEPS (25) at
+# the shortest cadence = 625 turns/day/owner, ~19k/month, times the number of users
+# on the bench. The default leaves room for a couple of daily multi-step macros
+# plus headroom; the floor is a full daily schedule of a single-step macro.
+DEFAULT_SCHEDULED_STEP_BUDGET_MONTHLY = 500
+MIN_SCHEDULED_STEP_BUDGET_MONTHLY = 31
+
+# The machine reason ``run_macro`` reports when the budget is spent. The rest come
+# straight from ``policy.validate_can_send`` so a macro and a typed message speak
+# the same vocabulary.
+BLOCK_STEP_BUDGET = "scheduled_step_budget"
+
+# Human sentences for the MANUAL path (thrown, so the SPA's existing toast renders
+# them). The scheduled path reports the machine code instead and the scheduler
+# writes its own owner-facing sentence onto the failed run row.
+_BLOCK_MESSAGE = {
+	"usage_limit": "You have reached your monthly usage limit, so this macro cannot run.",
+	"subscription_suspended": "Your subscription does not currently include chat, so this macro cannot run.",
+	"release_update_required": "A Jarvis update is rolling out. Try this macro again in a few minutes.",
+	"workspace_resetting": "Your workspace is being rebuilt. Try this macro again in a few minutes.",
+	"llm_not_configured": "Connect an AI model before running a macro.",
+	BLOCK_STEP_BUDGET: "This month's budget for scheduled macro runs is used up.",
+}
 
 
 def _run_cas(sql: str, params: dict) -> int:
@@ -106,6 +134,16 @@ def run_macro(macro_name: str, *, trigger: str = "manual") -> dict:
 	# to the sequence (an unmergeable sequence NEEDS its checkpoints).
 	merged = (doc.merged_prompt or "").strip()
 	total = 1 if merged else len(steps)
+
+	# #468: the entitlement + unattended-spend gate, BEFORE anything is created —
+	# a refused run must leave no conversation, no intro message and no run row.
+	blocked = entitlement_block(owner, steps=total, trigger=trigger)
+	if blocked:
+		if trigger == "scheduled":
+			# The scheduler decides what a refusal costs: it records the failure
+			# against the owner and works out whether the slot is consumed.
+			return {"ok": False, "reason": blocked}
+		frappe.throw(_(_BLOCK_MESSAGE.get(blocked, "This macro cannot run right now.")))
 
 	# Fresh conversation titled after the macro, seeded with an intro so the
 	# transcript reads as a self-contained run.
@@ -576,6 +614,80 @@ def _compensate_resume_enqueue_failure(run, macro_doc, attempts: int) -> None:
 	except Exception:
 		frappe.db.rollback()
 		frappe.log_error(title="jarvis macro capacity-resume compensate", message=frappe.get_traceback())
+
+
+# --------------------------------------------------------------------------- #
+# #468 entitlement + unattended-spend gate
+# --------------------------------------------------------------------------- #
+def entitlement_block(owner: str, *, steps: int, trigger: str) -> str | None:
+	"""The machine reason a macro run for ``owner`` must NOT dispatch, or None.
+
+	Two layers, both missing before #468:
+
+	1. **The same entitlement gate a typed message passes.**
+	   ``policy.validate_can_send`` had exactly three call sites — ``send_message``
+	   (x2) and ``retry_message`` — all human paths. ``api._enqueue_turn``, the SOLE
+	   dispatch path for macro steps, had none, and neither did ``dispatch``,
+	   ``admission``, ``turn_handler`` or ``worker``. So a macro step bypassed the
+	   per-user monthly token cap, the per-model cap and ``subscription_suspended``
+	   while ``turn_handler.record_turn_usage`` metered it anyway. The inversion was
+	   complete: the macro drained the owner's quota and the quota then rejected the
+	   owner's own interactive chat while the macro kept running.
+
+	   The gate is applied at the RUN, not per step, and no model is passed: a
+	   macro's model is resolved per conversation at dispatch time, and the
+	   aggregate monthly cap is the outer gate anyway (policy already documents the
+	   Auto/per-model skip as an accepted gap).
+
+	2. **A monthly step budget, for SCHEDULED runs only.** This is the path with no
+	   human in it and no other bound. A manual run is an explicit, attended click
+	   that the token caps above already price; refusing one on a monthly *run*
+	   quota would break a legitimate workflow with no cost story to justify it.
+	   Manual runs are not counted either, so a heavy interactive month cannot
+	   silently starve the schedule.
+
+	Mirrors ``agent_scheduler._over_run_budget`` in shape, and differs in key: an
+	agent budget is keyed on the INSTALLATION because ``run_as_user`` decouples the
+	executing identity from the owner. A macro has no such split, so the owner is
+	both the executing identity and the metered one."""
+	from jarvis.chat.policy import validate_can_send
+
+	ok, reason = validate_can_send(owner)
+	if not ok:
+		return reason
+	if trigger == "scheduled" and _over_step_budget(owner, steps):
+		return BLOCK_STEP_BUDGET
+	return None
+
+
+def _scheduled_step_budget_monthly() -> int:
+	try:
+		v = frappe.utils.cint(frappe.db.get_single_value("Jarvis Settings", "macro_step_budget_monthly"))
+	except Exception:
+		v = 0
+	return v if v >= MIN_SCHEDULED_STEP_BUDGET_MONTHLY else DEFAULT_SCHEDULED_STEP_BUDGET_MONTHLY
+
+
+def _scheduled_steps_this_month(owner: str) -> int:
+	"""Agent turns this owner's SCHEDULED macro runs have dispatched this month.
+
+	``current_step`` is the count of steps a run has actually dispatched, so an
+	in-flight run contributes honestly rather than all-or-nothing. ``failed`` rows
+	are EXCLUDED for the same reason the sibling excludes them: every refusal writes
+	one, so counting them would make the cap self-perpetuating the moment it is
+	first hit."""
+	row = frappe.db.sql(
+		f"""SELECT COALESCE(SUM(current_step), 0) FROM `tab{RUN}`
+		    WHERE owner = %(owner)s AND `trigger` = 'scheduled'
+		      AND status != 'failed' AND creation >= %(since)s""",
+		{"owner": owner, "since": frappe.utils.get_first_day(frappe.utils.today())},
+	)
+	return int(row[0][0] or 0) if row else 0
+
+
+def _over_step_budget(owner: str, steps: int) -> bool:
+	"""True iff dispatching ``steps`` more scheduled steps would breach the budget."""
+	return (_scheduled_steps_this_month(owner) + max(int(steps or 1), 1)) > _scheduled_step_budget_monthly()
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -13,8 +13,11 @@ last started; ``status`` in queued/running/completed/failed/stopped). Progress i
 pushed to the owner's realtime channel as ``macro:progress`` / ``macro:done``.
 """
 
+from datetime import timedelta
+
 import frappe
 from frappe import _
+from frappe.utils import get_datetime, now_datetime
 
 from jarvis.chat.events import publish_to_user
 
@@ -33,6 +36,16 @@ _MAX_CAPACITY_ATTEMPTS = 20
 # ample headroom; on the pathological miss the state-fenced CAS in the resume path is the hard
 # backstop. Module-level so tests can shorten it.
 _STOP_LOCK_BLOCK_S = 10.0
+
+# #471: how long a run may sit ``running`` WITHOUT FORWARD PROGRESS before the sweep
+# terminalizes it. Sized against the RQ turn envelope, not the run: a chat turn is capped
+# at ``api._AGENT_TURN_WORKER_TIMEOUT`` (720 s) and a dead one is picked up by the
+# 2-minute turn-recovery sweep, so 3 h is a ~12x margin over the longest legitimate gap
+# between two step advances. Module-level so tests can shorten it.
+STALE_RUN_AFTER_SECONDS = 3 * 3600
+_STALE_RUN_ERROR = (
+	"The run stopped making progress and was closed by the stale-run sweep. Run it again."
+)
 
 
 def _run_cas(sql: str, params: dict) -> int:
@@ -563,6 +576,121 @@ def _compensate_resume_enqueue_failure(run, macro_doc, attempts: int) -> None:
 	except Exception:
 		frappe.db.rollback()
 		frappe.log_error(title="jarvis macro capacity-resume compensate", message=frappe.get_traceback())
+
+
+# --------------------------------------------------------------------------- #
+# #471 stale-run reaper (backstop) — hooks cron
+# --------------------------------------------------------------------------- #
+def reap_stale_macro_runs() -> int:
+	"""Terminalize macro runs stuck ``running`` with no forward progress, and return
+	how many were reaped. Runs as Administrator (scheduler); never raises out.
+
+	Without this a run orphaned before its first turn sat ``running`` FOREVER with an
+	empty ``error`` (#471): ``run_macro`` dispatches through ``api._enqueue_turn``,
+	whose ``_ensure_session_key`` throws when the gateway is down, and with no turn
+	dispatched the chaining hook that terminalizes a run never fires for it.
+
+	**Parked is not stranded.** Two independent discriminators keep a legitimately
+	slow or deliberately parked run safe:
+
+	* **Status is an ALLOWLIST of exactly ``running``.** ``waiting_capacity`` is a
+	  live, deliberately parked state (CDX-19): a step that could not be admitted
+	  waits there for ``resume_waiting_capacity_runs``, legitimately for up to
+	  ``_MAX_CAPACITY_ATTEMPTS`` x 5 min (~100 min), and that path has its OWN bound
+	  after which it fails honestly. It is never a candidate here — and because the
+	  filter is an allowlist rather than "not terminal", any future non-terminal
+	  status is excluded by construction too.
+	* **Staleness is measured on ``modified`` (last forward progress), never on
+	  ``started_at``.** A 25-step macro legitimately stays ``running`` for hours;
+	  what it never does is stop making progress, because every step dispatch,
+	  capacity park and capacity resume writes the row.
+
+	Then, before acting, each candidate is re-read UNDER the same per-run redis lock
+	the chaining hook and the capacity resume take, plus a row lock, and transitioned
+	with a compare-and-set on ``status='running'`` — so a run that advanced between
+	the scan and here is left alone rather than having a live step killed under it."""
+	cutoff = now_datetime() - timedelta(seconds=STALE_RUN_AFTER_SECONDS)
+	candidates = _stale_run_candidates(cutoff)
+	if not candidates:
+		return 0
+	from jarvis._redis_lock import redis_lock
+
+	reaped = 0
+	for run_name in candidates:
+		try:
+			with redis_lock(f"jarvis_macro_run:{run_name}", timeout_s=60, blocking_timeout_s=0.0) as acquired:
+				if not acquired:
+					# A chaining advance / capacity resume is INSIDE its critical section for
+					# this run right now, which is proof of life. Leave it for the next sweep.
+					continue
+				cur = frappe.db.get_value(
+					RUN, run_name, ["status", "modified"], as_dict=True, for_update=True
+				)
+				if not cur or cur.status != "running" or get_datetime(cur.modified) >= cutoff:
+					frappe.db.commit()  # release the row lock; the snapshot was stale
+					continue
+				if not _cas_run_status(
+					run_name, "running", "failed", finished_at=frappe.utils.now(), error=_STALE_RUN_ERROR
+				):
+					frappe.db.commit()
+					continue
+				frappe.db.commit()
+				reaped += 1
+				_announce_reaped(run_name)
+		except Exception:
+			frappe.log_error(title="jarvis macro stale-run sweep failed", message=frappe.get_traceback())
+	return reaped
+
+
+def _stale_run_candidates(cutoff) -> list[str]:
+	"""Runs stuck ``running`` with no forward progress since ``cutoff``. Its own
+	function so the re-read-under-lock compare-and-set can be exercised against a
+	deliberately STALE candidate snapshot in tests."""
+	return frappe.get_all(RUN, filters={"status": "running", "modified": ["<", cutoff]}, pluck="name")
+
+
+def _announce_reaped(run_name: str) -> None:
+	"""Surface a reaped run the two ways a live failure is surfaced: the realtime
+	``macro:done`` an open SPA listens for, and a Notification Log for the (likely
+	absent) owner. Best-effort — the durable ``failed`` row is the real record."""
+	try:
+		run = frappe.get_doc(RUN, run_name)
+		macro_doc = frappe.get_doc(MACRO, run.macro)
+		_publish_done(run, macro_doc, "failed")
+		notify_owner(
+			macro_doc.owner,
+			subject=f"Macro run did not finish: {macro_doc.macro_name}",
+			body=_STALE_RUN_ERROR,
+		)
+	except Exception:
+		pass
+
+
+def notify_owner(owner: str, *, subject: str, body: str) -> None:
+	"""Best-effort Notification Log for a macro owner (#471). A scheduled macro that
+	fails at 03:00 reaches nobody through the realtime channel — ``publish_to_user``
+	is delivered only to an open socket, and there is none — and ``frappe.log_error``
+	writes an Error Log only a System Manager can read.
+
+	Skipped for identities that cannot act on one (Administrator / Guest / disabled).
+	Never raises: notification is a courtesy on top of the durable failed run row."""
+	from jarvis.permissions import is_valid_unattended_owner
+
+	if not is_valid_unattended_owner(owner):
+		return
+	try:
+		frappe.get_doc(
+			{
+				"doctype": "Notification Log",
+				"for_user": owner,
+				"type": "Alert",
+				"subject": subject[:140],
+				"email_content": body,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+	except Exception:
+		pass
 
 
 def _finish(run, status: str, error: str | None = None) -> None:

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -38,10 +38,19 @@ _MAX_CAPACITY_ATTEMPTS = 20
 _STOP_LOCK_BLOCK_S = 10.0
 
 # #471: how long a run may sit ``running`` WITHOUT FORWARD PROGRESS before the sweep
-# terminalizes it. Sized against the RQ turn envelope, not the run: a chat turn is capped
-# at ``api._AGENT_TURN_WORKER_TIMEOUT`` (720 s) and a dead one is picked up by the
-# 2-minute turn-recovery sweep, so 3 h is a ~12x margin over the longest legitimate gap
-# between two step advances. Module-level so tests can shorten it.
+# terminalizes it. Sized against the longest a SINGLE step can legitimately take without
+# writing the run row, which is NOT just the RQ turn cap. Worst legitimate case, traced
+# end to end:
+#     api._AGENT_TURN_WORKER_TIMEOUT   720 s   RQ worker envelope for one turn
+#   + stale_scan promotion             720 s   MANAGED_RECOVER_AFTER_SECONDS, on a */5 cron
+#   + turn_recovery._RECOVERY_CEILING_MINUTES  60 min a turn may sit `recovering`
+#   + the next */2 recovery tick
+#   ~= 70-80 min with ZERO writes to Jarvis Macro Run, because recovery works on the chat
+#      MESSAGE and only touches the run when it finalizes into advance_after_turn.
+# 3 h is therefore roughly a 2.5x margin, not the 12x you get by counting the turn cap
+# alone. Do NOT tighten this below ~2 h without re-tracing those four numbers; the
+# recovery ceiling, not the worker timeout, is the binding constraint. Module-level so
+# tests can shorten it.
 STALE_RUN_AFTER_SECONDS = 3 * 3600
 _STALE_RUN_ERROR = "The run stopped making progress and was closed by the stale-run sweep. Run it again."
 
@@ -63,6 +72,12 @@ MIN_SCHEDULED_STEP_BUDGET_MONTHLY = 31
 # the same vocabulary.
 BLOCK_STEP_BUDGET = "scheduled_step_budget"
 
+# #471: reported when the first turn's dispatch RAISED after the conversation and run
+# row were already committed. Distinct from the codes above because the run row exists
+# and has already been terminalized, so the scheduler must not record a second one.
+BLOCK_DISPATCH_FAILED = "dispatch_failed"
+_DISPATCH_FAILED_ERROR = "The agent turn could not be dispatched, so this run never started."
+
 # Human sentences for the MANUAL path (thrown, so the SPA's existing toast renders
 # them). The scheduled path reports the machine code instead and the scheduler
 # writes its own owner-facing sentence onto the failed run row.
@@ -73,6 +88,7 @@ _BLOCK_MESSAGE = {
 	"workspace_resetting": "Your workspace is being rebuilt. Try this macro again in a few minutes.",
 	"llm_not_configured": "Connect an AI model before running a macro.",
 	BLOCK_STEP_BUDGET: "This month's budget for scheduled macro runs is used up.",
+	BLOCK_DISPATCH_FAILED: "This macro could not be started. Please try again in a few minutes.",
 }
 
 
@@ -202,10 +218,29 @@ def run_macro(macro_name: str, *, trigger: str = "manual") -> dict:
 			},
 		)
 
-	if merged:
-		_run_merged(run, doc, merged)
-	else:
-		_run_step(run, doc, 0)
+	try:
+		if merged:
+			_run_merged(run, doc, merged)
+		else:
+			_run_step(run, doc, 0)
+	except Exception:
+		# #471: the conversation and the run row are already COMMITTED above, but the
+		# first turn never dispatched (``_ensure_session_key`` throws when the gateway
+		# is down). No turn means the chaining hook that terminalizes a run never fires
+		# for it, so without this the row sits `running` until the stale sweep picks it
+		# up three hours later — and the scheduler, seeing the raise, would record a
+		# SECOND failed row, showing the customer two failures for one missed slot.
+		# Terminalize the row that actually carries the conversation, and report the
+		# refusal in the normal return shape instead of raising.
+		frappe.log_error(title=f"jarvis macro dispatch failed: {doc.name}", message=frappe.get_traceback())
+		_finish(run, "failed", error=_DISPATCH_FAILED_ERROR)
+		try:
+			_publish_done(run, doc, "failed")
+		except Exception:
+			pass
+		if trigger == "scheduled":
+			return {"ok": False, "reason": BLOCK_DISPATCH_FAILED}
+		frappe.throw(_(_BLOCK_MESSAGE[BLOCK_DISPATCH_FAILED]))
 	return {"ok": True, "data": {"macro_run": run.name, "conversation": conv.name}}
 
 
@@ -661,25 +696,44 @@ def entitlement_block(owner: str, *, steps: int, trigger: str) -> str | None:
 
 
 def _scheduled_step_budget_monthly() -> int:
+	"""The configured budget, or the default when it is unset.
+
+	A configured value is CLAMPED UP to ``MIN_SCHEDULED_STEP_BUDGET_MONTHLY`` rather
+	than replaced by the default, so an admin who deliberately sets a tight cap gets
+	the tightest cap that still permits a daily single-step schedule, not a silent
+	16x widening to the default. Unset/blank/unreadable means "no opinion" and takes
+	the default."""
 	try:
 		v = frappe.utils.cint(frappe.db.get_single_value("Jarvis Settings", "macro_step_budget_monthly"))
 	except Exception:
 		v = 0
-	return v if v >= MIN_SCHEDULED_STEP_BUDGET_MONTHLY else DEFAULT_SCHEDULED_STEP_BUDGET_MONTHLY
+	if v <= 0:
+		return DEFAULT_SCHEDULED_STEP_BUDGET_MONTHLY
+	return max(v, MIN_SCHEDULED_STEP_BUDGET_MONTHLY)
 
 
 def _scheduled_steps_this_month(owner: str) -> int:
 	"""Agent turns this owner's SCHEDULED macro runs have dispatched this month.
 
-	``current_step`` is the count of steps a run has actually dispatched, so an
-	in-flight run contributes honestly rather than all-or-nothing. ``failed`` rows
-	are EXCLUDED for the same reason the sibling excludes them: every refusal writes
-	one, so counting them would make the cap self-perpetuating the moment it is
-	first hit."""
+	EVERY status counts, because ``current_step`` (how many steps a run actually
+	dispatched) is already the honest measure of spend on its own:
+
+	* a refusal recorded by ``macro_scheduler._record_failed`` carries
+	  ``current_step = 0``, so it contributes nothing and the cap can never become
+	  self-perpetuating. That is what the sibling's ``status != 'failed'`` filter
+	  buys, obtained here structurally instead.
+	* a run that failed PART WAY THROUGH really did dispatch and bill its completed
+	  steps, and three paths produce exactly that (``stop_on_error``, the
+	  capacity-attempt cap, and the stale-run sweep). Filtering on status would erase
+	  those turns from the tally, so an owner whose macros keep failing halfway could
+	  spend past the budget indefinitely — reopening the very "spends without ever
+	  being refused by it" inversion #468 exists to close.
+	* a ``stopped`` run likewise billed the steps it ran before the user stopped it.
+
+	So an in-flight or part-failed run contributes honestly, not all-or-nothing."""
 	row = frappe.db.sql(
 		f"""SELECT COALESCE(SUM(current_step), 0) FROM `tab{RUN}`
-		    WHERE owner = %(owner)s AND `trigger` = 'scheduled'
-		      AND status != 'failed' AND creation >= %(since)s""",
+		    WHERE owner = %(owner)s AND `trigger` = 'scheduled' AND creation >= %(since)s""",
 		{"owner": owner, "since": frappe.utils.get_first_day(frappe.utils.today())},
 	)
 	return int(row[0][0] or 0) if row else 0
@@ -735,6 +789,10 @@ def reap_stale_macro_runs() -> int:
 					# A chaining advance / capacity resume is INSIDE its critical section for
 					# this run right now, which is proof of life. Leave it for the next sweep.
 					continue
+				# REPEATABLE-READ discipline, matching agent_scheduler.fail_run: commit to
+				# close the current snapshot so the FOR UPDATE read below sees the row as it
+				# is NOW, not as this connection's transaction first saw it.
+				frappe.db.commit()
 				cur = frappe.db.get_value(
 					RUN, run_name, ["status", "modified"], as_dict=True, for_update=True
 				)
@@ -750,6 +808,10 @@ def reap_stale_macro_runs() -> int:
 				reaped += 1
 				_announce_reaped(run_name)
 		except Exception:
+			# Roll back explicitly: an exception between the FOR UPDATE read and its
+			# balancing commit would otherwise leave the row lock and any half-applied
+			# state open, to be resolved as a side effect of the NEXT candidate's commit.
+			frappe.db.rollback()
 			frappe.log_error(title="jarvis macro stale-run sweep failed", message=frappe.get_traceback())
 	return reaped
 
@@ -785,12 +847,15 @@ def notify_owner(owner: str, *, subject: str, body: str) -> None:
 	writes an Error Log only a System Manager can read.
 
 	Skipped for identities that cannot act on one (Administrator / Guest / disabled).
-	Never raises: notification is a courtesy on top of the durable failed run row."""
-	from jarvis.permissions import is_valid_unattended_owner
-
-	if not is_valid_unattended_owner(owner):
-		return
+	Never raises: notification is a courtesy on top of the durable failed run row, and
+	the scheduler's per-macro loop has no outer guard, so an escape here would abort
+	the sweep for every REMAINING due macro. The eligibility check is therefore inside
+	the try too: it reads ``User.enabled`` from the DB and can fail like any query."""
 	try:
+		from jarvis.permissions import is_valid_unattended_owner
+
+		if not is_valid_unattended_owner(owner):
+			return
 		frappe.get_doc(
 			{
 				"doctype": "Notification Log",

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -370,8 +370,17 @@ scheduler_events = {
 		# render a "reconnect" banner instead of "Connected" until the
 		# user hits a ProviderAuthError mid-chat.
 		"jarvis.oauth.cron.poll_oauth_refresh_status",
-		# Fire any scheduled macros whose next_run_at has passed.
+		# Fire any scheduled macros whose next_run_at has passed. Identity-safe
+		# (never binds an unattended turn to Administrator or a disabled owner),
+		# entitlement- and budget-gated, and it advances the schedule only when
+		# the slot was really consumed. See jarvis/chat/macro_scheduler.py.
 		"jarvis.chat.macro_scheduler.run_due_macros",
+		# #471 backstop: fail macro runs stuck `running` with no forward progress.
+		# A dispatch that raised leaves no turn behind, so the turn-end chaining
+		# hook that terminalizes a run never fires for it. Deliberately parked
+		# `waiting_capacity` runs are NOT candidates — they have their own bounded
+		# resume cron (`resume_waiting_capacity_runs`, above).
+		"jarvis.chat.macros.reap_stale_macro_runs",
 		# Fire any due scheduled auditor agents. Identity-safe (runs each audit
 		# as its owner, never Administrator); budget-capped; advances only on a
 		# successful enqueue. See jarvis/chat/agent_scheduler.py.

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -110,6 +110,7 @@
   "agent_catalog_dirty",
   "agent_catalog_version",
   "agent_run_budget_monthly",
+  "macro_step_budget_monthly",
   "activation_module_ceiling",
   "learned_skills_synced_at",
   "learned_skills_sync_status",
@@ -827,6 +828,13 @@
    "fieldname": "agent_run_budget_monthly",
    "fieldtype": "Int",
    "label": "Agent Run Budget (monthly, per installation)"
+  },
+  {
+   "default": "500",
+   "description": "#468: monthly budget for UNATTENDED macro work, per macro owner, counted in STEPS (one run is up to 25 agent turns, so a run count would under-bound the real spend by 25x). Scheduled runs only: a manual run is an attended click already priced by the per-user token caps, and manual runs are not counted here either, so a heavy interactive month cannot silently starve the schedule. Failed rows are excluded so a refusal can never self-perpetuate the cap. Floored at 31 (a full daily schedule of a single-step macro) when set below it. Raise it to allow more frequent or longer scheduled macros before runs are skipped.",
+   "fieldname": "macro_step_budget_monthly",
+   "fieldtype": "Int",
+   "label": "Scheduled Macro Step Budget (monthly, per owner)"
   },
   {
    "default": "1",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -831,7 +831,7 @@
   },
   {
    "default": "500",
-   "description": "#468: monthly budget for UNATTENDED macro work, per macro owner, counted in STEPS (one run is up to 25 agent turns, so a run count would under-bound the real spend by 25x). Scheduled runs only: a manual run is an attended click already priced by the per-user token caps, and manual runs are not counted here either, so a heavy interactive month cannot silently starve the schedule. Failed rows are excluded so a refusal can never self-perpetuate the cap. Floored at 31 (a full daily schedule of a single-step macro) when set below it. Raise it to allow more frequent or longer scheduled macros before runs are skipped.",
+   "description": "#468: monthly budget for UNATTENDED macro work, per macro owner, counted in STEPS (one run is up to 25 agent turns, so a run count would under-bound the real spend by 25x). Scheduled runs only: a manual run is an attended click already priced by the per-user token caps, and manual runs are not counted here either, so a heavy interactive month cannot silently starve the schedule. A refusal records a run with 0 steps, so it contributes nothing and the cap can never self-perpetuate; a run that failed part way through DOES count the steps it really dispatched. Leave blank or 0 to use the default of 500. A configured value below 31 is clamped UP to 31 (a full daily schedule of a single-step macro), so a low value can never wedge every schedule for a month. Raise it to allow more frequent or longer scheduled macros before runs are skipped.",
    "fieldname": "macro_step_budget_monthly",
    "fieldtype": "Int",
    "label": "Scheduled Macro Step Budget (monthly, per owner)"

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -135,6 +135,31 @@ def is_system_user(user: str | None = None) -> bool:
 	return frappe.db.get_value("User", user, "user_type") == "System User"
 
 
+def is_valid_unattended_owner(user: str | None) -> bool:
+	"""True iff ``user`` may be bound as the identity of an UNATTENDED (cron) turn.
+
+	Strictly narrower than :func:`has_jarvis_access`, which answers "may this
+	identity reach Jarvis at all" and deliberately waves ``Administrator``
+	through. A scheduled turn has no human watching it, so it must never bind to:
+
+	* ``Administrator`` - every DocPerm and User Permission is bypassed, silently,
+	  on a cron.
+	* ``Guest`` - not a real identity.
+	* a **disabled** user - disabling is how an offboarded employee's access is
+	  revoked, but Frappe only clears their browser sessions: their roles survive,
+	  ``frappe.get_roles`` does not filter on ``enabled``, and nothing else in this
+	  module reads ``User.enabled``. Without this check their scheduled work keeps
+	  reaching the ERP forever.
+
+	This is the guard ``agent_scheduler._valid_owner`` has enforced since the agent
+	scheduler shipped; it lives here so every unattended dispatcher shares ONE
+	definition instead of each re-deriving it (jarvis #469: the macro scheduler had
+	not, and admitted exactly the two identities the sibling refuses)."""
+	if not user or user in ("Administrator", "Guest"):
+		return False
+	return bool(frappe.db.get_value("User", user, "enabled"))
+
+
 def require_jarvis_access(user: str | None = None) -> None:
 	"""Raise ``frappe.PermissionError`` (with a clear message) if the user lacks
 	access. Defaults to the current session user.

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -11,10 +11,12 @@ Covers the three defects the hourly ``run_due_macros`` cron shipped with:
 * **#471** — a failed run advanced its schedule anyway, recorded nothing the owner
   could see, and could strand a run in ``running`` forever (no reaper).
 
-``jarvis.chat.macros.run_macro`` is patched in every dispatch test: this suite is
-about the SCHEDULER's decisions, and a real dispatch would need a live gateway.
-``run_due_macros`` sweeps every due macro on the site, so assertions are always
-scoped to this suite's own rows by name.
+Nothing here reaches a live gateway. Tests about the SCHEDULER's own decisions stub
+``macros.run_macro`` wholesale and assert on which macros it dispatched; tests about
+the #468 gate, which lives INSIDE ``run_macro``, stub only the turn dispatch
+(``api._enqueue_turn``) so the real gate executes, and assert on the run rows it
+did or did not leave behind. ``run_due_macros`` sweeps every due macro on the site,
+so assertions are always scoped to this suite's own rows.
 """
 
 from __future__ import annotations
@@ -90,9 +92,7 @@ def _purge() -> None:
 		for run in frappe.get_all(RUN, filters={"macro": n}, pluck="name"):
 			frappe.delete_doc(RUN, run, force=True, ignore_permissions=True)
 		frappe.delete_doc(MACRO, n, force=True, ignore_permissions=True)
-	for n in frappe.get_all(
-		"Notification Log", filters={"subject": ["like", f"%{PFX}-%"]}, pluck="name"
-	):
+	for n in frappe.get_all("Notification Log", filters={"subject": ["like", f"%{PFX}-%"]}, pluck="name"):
 		frappe.delete_doc("Notification Log", n, force=True, ignore_permissions=True)
 	frappe.db.commit()
 
@@ -195,7 +195,7 @@ class TestScheduledMacroFailures(MacroSchedulerBase):
 		)
 
 	def test_dispatch_failure_notifies_the_owner(self):
-		m = _mk_macro(OWNER_OK, "raises-notify")
+		_mk_macro(OWNER_OK, "raises-notify")
 		with patch("jarvis.chat.macros.run_macro", side_effect=RuntimeError("gateway down")):
 			macro_scheduler.run_due_macros()
 		notes = frappe.get_all(
@@ -221,6 +221,133 @@ class TestScheduledMacroFailures(MacroSchedulerBase):
 			"a disabled macro stamped last_run_at, so the UI claims it ran",
 		)
 		self.assertEqual(_runs_for(m.name), [], "a deliberately disabled macro is not a failure")
+
+
+# --------------------------------------------------------------------------- #
+# #468 — the entitlement gate and the unattended step budget
+# --------------------------------------------------------------------------- #
+class TestScheduledMacroCaps(MacroSchedulerBase):
+	def _run_due_gated(self):
+		"""Run the cron with only the TURN dispatch stubbed, so ``run_macro``'s own
+		gate really executes. A refused run leaves exactly one ``failed`` row and no
+		conversation; a dispatched one leaves a ``running`` row."""
+		with patch("jarvis.chat.api._enqueue_turn", return_value={"run_id": "r", "message_id": "m"}):
+			macro_scheduler.run_due_macros()
+
+	def _mk_consumed_run(self, macro_name: str, steps: int, *, trigger="scheduled", status="completed"):
+		"""A prior run that already spent ``steps`` turns this month."""
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"macro": macro_name,
+				"status": status,
+				"current_step": steps,
+				"total_steps": steps,
+				"trigger": trigger,
+				"started_at": frappe.utils.now(),
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		frappe.db.set_value(RUN, run.name, "owner", OWNER_OK, update_modified=False)
+		frappe.db.commit()
+		return run.name
+
+	def test_over_cap_run_is_refused_recorded_and_consumes_the_slot(self):
+		m = _mk_macro(OWNER_OK, "over-cap")
+		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "usage_limit")):
+			self._run_due_gated()
+		runs = _runs_for(m.name)
+		self.assertEqual([r.status for r in runs], ["failed"], "a macro ran straight through the cap")
+		self.assertIn("usage limit", runs[0].error)
+		self.assertEqual(runs[0].owner, OWNER_OK)
+		# usage_limit does not clear inside the hour, so the slot is consumed rather
+		# than relogging the same refusal 24 times a day.
+		nxt = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertGreater(nxt, now_datetime())
+
+	def test_ungated_run_still_dispatches(self):
+		m = _mk_macro(OWNER_OK, "under-cap")
+		self._run_due_gated()
+		self.assertEqual([r.status for r in _runs_for(m.name)], ["running"], "the gate over-reached")
+
+	def test_suspended_subscription_refuses_the_run(self):
+		m = _mk_macro(OWNER_OK, "suspended")
+		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "subscription_suspended")):
+			self._run_due_gated()
+		runs = _runs_for(m.name)
+		self.assertEqual([r.status for r in runs], ["failed"])
+		self.assertIn("subscription", runs[0].error)
+
+	def test_transient_block_leaves_the_slot_due_for_a_retry(self):
+		m = _mk_macro(OWNER_OK, "rolling-out")
+		before = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "release_update_required")):
+			self._run_due_gated()
+		self.assertEqual([r.status for r in _runs_for(m.name)], ["failed"])
+		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertEqual(after, before, "a rollout that clears in minutes cost the macro its slot")
+
+	def test_the_gate_creates_nothing_before_refusing(self):
+		# A refused run must leave no conversation and no intro message behind —
+		# only the scheduler's own failed record.
+		m = _mk_macro(OWNER_OK, "no-residue")
+		convs_before = frappe.db.count("Jarvis Conversation")
+		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "usage_limit")):
+			self._run_due_gated()
+		self.assertEqual(frappe.db.count("Jarvis Conversation"), convs_before)
+		self.assertFalse(_runs_for(m.name)[0].get("conversation"))
+
+	def test_step_budget_refuses_once_the_month_is_spent(self):
+		m = _mk_macro(OWNER_OK, "budget", steps=3)
+		frappe.db.set_single_value("Jarvis Settings", "macro_step_budget_monthly", 40)
+		self.addCleanup(frappe.db.set_single_value, "Jarvis Settings", "macro_step_budget_monthly", None)
+		spent = self._mk_consumed_run(m.name, 40 - macros._scheduled_steps_this_month(OWNER_OK) - 1)
+		self.addCleanup(frappe.delete_doc, RUN, spent, force=True, ignore_permissions=True)
+		# One step of headroom left, and this macro wants three.
+		self.assertFalse(macros._over_step_budget(OWNER_OK, 1))
+		self.assertTrue(macros._over_step_budget(OWNER_OK, 3))
+		self._run_due_gated()
+		runs = _runs_for(m.name)
+		failed = [r for r in runs if r.status == "failed"]
+		self.assertTrue(failed, "the unattended step budget did not bind")
+		self.assertNotIn("running", [r.status for r in runs])
+		self.assertIn("budget", failed[0].error)
+
+	def test_meter_counts_steps_not_runs_and_excludes_refusals(self):
+		m = _mk_macro(OWNER_OK, "meter", steps=3)
+		base = macros._scheduled_steps_this_month(OWNER_OK)
+		spent = self._mk_consumed_run(m.name, 7)
+		self.addCleanup(frappe.delete_doc, RUN, spent, force=True, ignore_permissions=True)
+		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 7)
+		# A manual run is not unattended work, so it does not spend the budget.
+		manual = self._mk_consumed_run(m.name, 5, trigger="manual")
+		self.addCleanup(frappe.delete_doc, RUN, manual, force=True, ignore_permissions=True)
+		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 7)
+		# And a refusal must never make the cap self-perpetuating.
+		refused = self._mk_consumed_run(m.name, 4, status="failed")
+		self.addCleanup(frappe.delete_doc, RUN, refused, force=True, ignore_permissions=True)
+		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 7)
+
+	def test_budget_floor_survives_a_misconfigured_zero(self):
+		frappe.db.set_single_value("Jarvis Settings", "macro_step_budget_monthly", 0)
+		self.addCleanup(frappe.db.set_single_value, "Jarvis Settings", "macro_step_budget_monthly", None)
+		self.assertEqual(
+			macros._scheduled_step_budget_monthly(), macros.DEFAULT_SCHEDULED_STEP_BUDGET_MONTHLY
+		)
+
+	def test_manual_run_is_entitlement_gated_but_not_budget_gated(self):
+		m = _mk_macro(OWNER_OK, "manual-gate", due=False)
+		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "usage_limit")):
+			with self.assertRaises(frappe.ValidationError):
+				macros.run_macro(m.name, trigger="manual")
+		# The budget is scheduled-only: an attended click is never refused by it.
+		with patch.object(macros, "_over_step_budget", return_value=True):
+			self.assertIsNone(macros.entitlement_block(OWNER_OK, steps=3, trigger="manual"))
+			self.assertEqual(
+				macros.entitlement_block(OWNER_OK, steps=3, trigger="scheduled"),
+				macros.BLOCK_STEP_BUDGET,
+			)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -205,6 +205,32 @@ class TestScheduledMacroFailures(MacroSchedulerBase):
 		)
 		self.assertTrue(notes, "the owner got no signal at all")
 
+	def test_dispatch_raising_after_the_run_row_exists_leaves_no_orphan(self):
+		# run_macro COMMITS the conversation and the run row, then dispatches. When the
+		# dispatch raises (gateway down, _ensure_session_key throws) no turn exists, so
+		# the chaining hook that terminalizes a run never fires. Without the fix that
+		# row sat `running` for three hours until the sweep, AND the scheduler recorded
+		# a second failed row, showing two failures for one missed slot.
+		m = _mk_macro(OWNER_OK, "orphan", steps=1)
+		before = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=RuntimeError("gateway down")):
+			macro_scheduler.run_due_macros()
+		runs = _runs_for(m.name)
+		self.assertEqual(len(runs), 1, f"expected exactly one run row for one slot, got {runs}")
+		self.assertEqual(runs[0].status, "failed", "the run row was left stranded in `running`")
+		self.assertIn("dispatch", runs[0].error.lower())
+		# It is the row that carries the conversation, not a bare scheduler record.
+		self.assertTrue(frappe.db.get_value(RUN, runs[0].name, "conversation"))
+		# Transient: the slot stays due so the next tick retries it.
+		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertEqual(after, before, "a dispatch failure cost the macro its slot")
+
+	def test_notify_owner_never_escapes_and_aborts_the_sweep(self):
+		# The scheduler's per-macro loop has no outer guard, so an escape from
+		# notify_owner would abort the sweep for every REMAINING due macro.
+		with patch("jarvis.permissions.is_valid_unattended_owner", side_effect=RuntimeError("db blip")):
+			macros.notify_owner(OWNER_OK, subject="x", body="y")  # must not raise
+
 	def test_successful_run_stamps_last_run_at(self):
 		m = _mk_macro(OWNER_OK, "success")
 		self._run_due()
@@ -324,17 +350,44 @@ class TestScheduledMacroCaps(MacroSchedulerBase):
 		manual = self._mk_consumed_run(m.name, 5, trigger="manual")
 		self.addCleanup(frappe.delete_doc, RUN, manual, force=True, ignore_permissions=True)
 		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 7)
-		# And a refusal must never make the cap self-perpetuating.
-		refused = self._mk_consumed_run(m.name, 4, status="failed")
+		# And a refusal must never make the cap self-perpetuating. It carries
+		# current_step=0, so it contributes nothing WITHOUT filtering on status.
+		refused = self._mk_consumed_run(m.name, 0, status="failed")
 		self.addCleanup(frappe.delete_doc, RUN, refused, force=True, ignore_permissions=True)
 		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 7)
 
-	def test_budget_floor_survives_a_misconfigured_zero(self):
-		frappe.db.set_single_value("Jarvis Settings", "macro_step_budget_monthly", 0)
+	def test_partly_failed_run_still_counts_the_steps_it_billed(self):
+		# A run that failed HALFWAY really dispatched and billed its completed steps
+		# (stop_on_error, the capacity-attempt cap, and the stale sweep all produce
+		# exactly that). Excluding failed rows wholesale would erase those turns, so an
+		# owner whose macros keep failing could spend past the budget indefinitely.
+		m = _mk_macro(OWNER_OK, "part-failed", due=False, steps=3)
+		base = macros._scheduled_steps_this_month(OWNER_OK)
+		partial = self._mk_consumed_run(m.name, 2, status="failed")
+		self.addCleanup(frappe.delete_doc, RUN, partial, force=True, ignore_permissions=True)
+		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 2)
+
+	def test_stopped_run_still_counts_the_steps_it_billed(self):
+		m = _mk_macro(OWNER_OK, "stopped-run", due=False, steps=3)
+		base = macros._scheduled_steps_this_month(OWNER_OK)
+		stopped = self._mk_consumed_run(m.name, 2, status="stopped")
+		self.addCleanup(frappe.delete_doc, RUN, stopped, force=True, ignore_permissions=True)
+		self.assertEqual(macros._scheduled_steps_this_month(OWNER_OK), base + 2)
+
+	def test_budget_floor_clamps_up_and_never_widens(self):
 		self.addCleanup(frappe.db.set_single_value, "Jarvis Settings", "macro_step_budget_monthly", None)
+		# Unset/blank means "no opinion" and takes the default.
+		frappe.db.set_single_value("Jarvis Settings", "macro_step_budget_monthly", 0)
 		self.assertEqual(
 			macros._scheduled_step_budget_monthly(), macros.DEFAULT_SCHEDULED_STEP_BUDGET_MONTHLY
 		)
+		# A deliberately tight cap is clamped UP to the floor, never widened to the
+		# default: an admin who configures 10 must not silently get 500.
+		frappe.db.set_single_value("Jarvis Settings", "macro_step_budget_monthly", 10)
+		self.assertEqual(macros._scheduled_step_budget_monthly(), macros.MIN_SCHEDULED_STEP_BUDGET_MONTHLY)
+		# A value above the floor is honoured exactly.
+		frappe.db.set_single_value("Jarvis Settings", "macro_step_budget_monthly", 77)
+		self.assertEqual(macros._scheduled_step_budget_monthly(), 77)
 
 	def test_manual_run_is_entitlement_gated_but_not_budget_gated(self):
 		m = _mk_macro(OWNER_OK, "manual-gate", due=False)

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -25,7 +25,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, get_datetime, now_datetime
 
-from jarvis.chat import macro_scheduler
+from jarvis.chat import macro_scheduler, macros
 
 MACRO = "Jarvis Macro"
 RUN = "Jarvis Macro Run"
@@ -90,6 +90,10 @@ def _purge() -> None:
 		for run in frappe.get_all(RUN, filters={"macro": n}, pluck="name"):
 			frappe.delete_doc(RUN, run, force=True, ignore_permissions=True)
 		frappe.delete_doc(MACRO, n, force=True, ignore_permissions=True)
+	for n in frappe.get_all(
+		"Notification Log", filters={"subject": ["like", f"%{PFX}-%"]}, pluck="name"
+	):
+		frappe.delete_doc("Notification Log", n, force=True, ignore_permissions=True)
 	frappe.db.commit()
 
 
@@ -152,3 +156,130 @@ class TestScheduledMacroIdentity(MacroSchedulerBase):
 		self._run_due()
 		nxt = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
 		self.assertGreater(nxt, now_datetime(), "a refused macro stayed due and would re-fire hourly")
+
+	def test_refusal_is_recorded_as_a_failed_run(self):
+		m = _mk_macro(OWNER_OFF, "disabled-recorded")
+		self._run_due()
+		runs = _runs_for(m.name)
+		self.assertEqual([r.status for r in runs], ["failed"])
+		self.assertEqual(runs[0].owner, OWNER_OFF, "the failed row is not visible to the owner")
+		self.assertIn("unattended", runs[0].error)
+
+
+# --------------------------------------------------------------------------- #
+# #471 — failures are durable, honest, and terminalized
+# --------------------------------------------------------------------------- #
+class TestScheduledMacroFailures(MacroSchedulerBase):
+	def test_dispatch_failure_does_not_advance_the_schedule(self):
+		m = _mk_macro(OWNER_OK, "raises")
+		before = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		with patch("jarvis.chat.macros.run_macro", side_effect=RuntimeError("gateway down")):
+			macro_scheduler.run_due_macros()
+		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertEqual(after, before, "a failed run advanced its schedule and lost the slot")
+		self.assertGreater(now_datetime(), after, "the missed slot is no longer due, so it cannot retry")
+
+	def test_dispatch_failure_is_visible_as_failed_not_successful(self):
+		m = _mk_macro(OWNER_OK, "raises-visible")
+		with patch("jarvis.chat.macros.run_macro", side_effect=RuntimeError("gateway down")):
+			macro_scheduler.run_due_macros()
+		runs = _runs_for(m.name)
+		self.assertEqual([r.status for r in runs], ["failed"], "the failure left no owner-visible trace")
+		self.assertEqual(runs[0].trigger, "scheduled")
+		self.assertEqual(runs[0].owner, OWNER_OK)
+		# The UI reads last_run_at as "last run"; a run that never happened must not
+		# stamp it (the "actively misleading" limb of #471).
+		self.assertFalse(
+			frappe.db.get_value(MACRO, m.name, "last_run_at"),
+			"last_run_at was stamped for a run that never executed",
+		)
+
+	def test_dispatch_failure_notifies_the_owner(self):
+		m = _mk_macro(OWNER_OK, "raises-notify")
+		with patch("jarvis.chat.macros.run_macro", side_effect=RuntimeError("gateway down")):
+			macro_scheduler.run_due_macros()
+		notes = frappe.get_all(
+			"Notification Log",
+			filters={"for_user": OWNER_OK, "subject": ["like", f"%{PFX}-raises-notify%"]},
+			pluck="name",
+		)
+		self.assertTrue(notes, "the owner got no signal at all")
+
+	def test_successful_run_stamps_last_run_at(self):
+		m = _mk_macro(OWNER_OK, "success")
+		self._run_due()
+		self.assertTrue(frappe.db.get_value(MACRO, m.name, "last_run_at"))
+		self.assertEqual(_runs_for(m.name), [], "a successful dispatch wrote a spurious failed row")
+
+	def test_disabled_macro_consumes_the_slot_without_claiming_a_run(self):
+		m = _mk_macro(OWNER_OK, "switched-off", enabled=0)
+		self.assertNotIn(m.name, self._run_due(), "a disabled macro was dispatched")
+		nxt = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertGreater(nxt, now_datetime(), "a disabled macro stayed due and re-fires hourly forever")
+		self.assertFalse(
+			frappe.db.get_value(MACRO, m.name, "last_run_at"),
+			"a disabled macro stamped last_run_at, so the UI claims it ran",
+		)
+		self.assertEqual(_runs_for(m.name), [], "a deliberately disabled macro is not a failure")
+
+
+# --------------------------------------------------------------------------- #
+# #471 — the stale-run reaper, and what it must NOT reap
+# --------------------------------------------------------------------------- #
+class TestStaleMacroRunReaper(MacroSchedulerBase):
+	def _mk_run(self, tag: str, status: str, *, age_s: int):
+		m = _mk_macro(OWNER_OK, tag, due=False)
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"macro": m.name,
+				"status": status,
+				"current_step": 0,
+				"total_steps": 1,
+				"trigger": "scheduled",
+				"started_at": frappe.utils.now(),
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		stamp = add_to_date(now_datetime(), seconds=-age_s)
+		frappe.db.sql(
+			"UPDATE `tabJarvis Macro Run` SET modified=%(t)s, owner=%(o)s WHERE name=%(n)s",
+			{"t": stamp, "o": OWNER_OK, "n": run.name},
+		)
+		frappe.db.commit()
+		return run.name
+
+	def test_stranded_running_run_is_terminalized(self):
+		name = self._mk_run("stranded", "running", age_s=macros.STALE_RUN_AFTER_SECONDS + 600)
+		self.assertEqual(macros.reap_stale_macro_runs(), 1)
+		row = frappe.db.get_value(RUN, name, ["status", "error", "finished_at"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertTrue(row.error, "a reaped run must say WHY, not carry an empty error")
+		self.assertTrue(row.finished_at)
+
+	def test_parked_waiting_capacity_run_is_never_reaped(self):
+		# #470 lets a run sit in waiting_capacity for ~100 min legitimately; the
+		# reaper must not confuse deliberately parked with stranded. Aged far past
+		# the cutoff so only the STATUS allowlist can be saving it.
+		name = self._mk_run("parked", "waiting_capacity", age_s=macros.STALE_RUN_AFTER_SECONDS * 4)
+		self.assertEqual(macros.reap_stale_macro_runs(), 0)
+		self.assertEqual(frappe.db.get_value(RUN, name, "status"), "waiting_capacity")
+
+	def test_recently_progressing_run_is_never_reaped(self):
+		name = self._mk_run("progressing", "running", age_s=macros.STALE_RUN_AFTER_SECONDS // 2)
+		self.assertEqual(macros.reap_stale_macro_runs(), 0)
+		self.assertEqual(frappe.db.get_value(RUN, name, "status"), "running")
+
+	def test_run_that_advanced_after_the_scan_is_left_alone(self):
+		# The candidate snapshot is inherently stale: a step can advance between the
+		# scan and the transition. The re-read under the lock must catch that.
+		name = self._mk_run("raced", "running", age_s=macros.STALE_RUN_AFTER_SECONDS + 600)
+		with patch.object(macros, "_stale_run_candidates", return_value=[name]):
+			frappe.db.sql(
+				"UPDATE `tabJarvis Macro Run` SET modified=%(t)s WHERE name=%(n)s",
+				{"t": now_datetime(), "n": name},
+			)
+			frappe.db.commit()
+			self.assertEqual(macros.reap_stale_macro_runs(), 0)
+		self.assertEqual(frappe.db.get_value(RUN, name, "status"), "running")

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -1,0 +1,154 @@
+"""Scheduled-macro dispatch: identity, caps and failure handling.
+
+Covers the three defects the hourly ``run_due_macros`` cron shipped with:
+
+* **#469** — it gated only on ``has_jarvis_access``, which returns True for
+  ``Administrator`` and never reads ``User.enabled``, so an unattended turn could
+  bind to a fully perm-bypassing identity or to an offboarded employee.
+* **#468** — macro steps never passed the entitlement gate (``validate_can_send``)
+  and had no run budget of any kind, so they drained the owner's quota without
+  ever being refused by it.
+* **#471** — a failed run advanced its schedule anyway, recorded nothing the owner
+  could see, and could strand a run in ``running`` forever (no reaper).
+
+``jarvis.chat.macros.run_macro`` is patched in every dispatch test: this suite is
+about the SCHEDULER's decisions, and a real dispatch would need a live gateway.
+``run_due_macros`` sweeps every due macro on the site, so assertions are always
+scoped to this suite's own rows by name.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, get_datetime, now_datetime
+
+from jarvis.chat import macro_scheduler
+
+MACRO = "Jarvis Macro"
+RUN = "Jarvis Macro Run"
+
+PFX = "msched"
+OWNER_OK = "msched-owner@example.com"
+OWNER_OFF = "msched-disabled@example.com"
+
+
+def _ensure_user(email: str, *, enabled: int = 1) -> str:
+	from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": PFX,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	if JARVIS_USER_ROLE not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles(JARVIS_USER_ROLE)
+	# enabled is set LAST and with a raw write: User.validate refuses some edits on
+	# a disabled row, and add_roles on a disabled user is a no-op.
+	frappe.db.set_value("User", email, {"enabled": enabled, "user_type": "System User"})
+	return email
+
+
+def _mk_macro(owner: str, tag: str, *, due: bool = True, enabled: int = 1, steps: int = 1):
+	doc = frappe.get_doc(
+		{
+			"doctype": MACRO,
+			"macro_name": f"{PFX}-{tag}",
+			"enabled": enabled,
+			"schedule_enabled": 1,
+			"schedule_frequency": "daily",
+			"steps": [{"prompt": f"step {i}"} for i in range(1, steps + 1)],
+		}
+	)
+	doc.flags.ignore_permissions = True
+	doc.insert()
+	frappe.db.set_value(MACRO, doc.name, "owner", owner, update_modified=False)
+	frappe.db.set_value(
+		MACRO,
+		doc.name,
+		"next_run_at",
+		add_to_date(now_datetime(), hours=-1) if due else add_to_date(now_datetime(), days=1),
+		update_modified=False,
+	)
+	frappe.db.commit()
+	return doc
+
+
+def _purge() -> None:
+	"""Drop this suite's macros + their runs. Several paths under test COMMIT, so
+	the per-test rollback does not clean up after them, and leaked macros count
+	against ``MAX_MACROS_PER_OWNER`` (25) until every later insert throws."""
+	for n in frappe.get_all(MACRO, filters={"macro_name": ["like", f"{PFX}-%"]}, pluck="name"):
+		for run in frappe.get_all(RUN, filters={"macro": n}, pluck="name"):
+			frappe.delete_doc(RUN, run, force=True, ignore_permissions=True)
+		frappe.delete_doc(MACRO, n, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _runs_for(macro_name: str) -> list:
+	return frappe.get_all(
+		RUN,
+		filters={"macro": macro_name},
+		fields=["name", "status", "error", "owner", "trigger"],
+		order_by="creation asc",
+	)
+
+
+class MacroSchedulerBase(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(OWNER_OK, enabled=1)
+		_ensure_user(OWNER_OFF, enabled=0)
+		frappe.db.commit()
+
+	def setUp(self):
+		super().setUp()
+		_purge()
+
+	def tearDown(self):
+		frappe.db.rollback()
+		_purge()
+		super().tearDown()
+
+	def _run_due(self):
+		"""Run the cron with dispatch stubbed; returns the macro names it dispatched."""
+		with patch("jarvis.chat.macros.run_macro", return_value={"ok": True}) as mock_run:
+			macro_scheduler.run_due_macros()
+		return [c.args[0] for c in mock_run.call_args_list]
+
+
+# --------------------------------------------------------------------------- #
+# #469 — the unattended-identity guard
+# --------------------------------------------------------------------------- #
+class TestScheduledMacroIdentity(MacroSchedulerBase):
+	def test_administrator_owned_macro_is_refused(self):
+		m = _mk_macro("Administrator", "admin-owned")
+		self.assertNotIn(m.name, self._run_due(), "scheduler bound an unattended turn to Administrator")
+
+	def test_disabled_owner_macro_is_refused(self):
+		m = _mk_macro(OWNER_OFF, "disabled-owner")
+		# The premise of the defect: the OLD gate still says this identity is fine.
+		from jarvis.permissions import has_jarvis_access, is_valid_unattended_owner
+
+		self.assertTrue(has_jarvis_access(OWNER_OFF), "premise changed: has_jarvis_access now filters")
+		self.assertFalse(is_valid_unattended_owner(OWNER_OFF))
+		self.assertNotIn(m.name, self._run_due(), "offboarding did not revoke scheduled ERP access")
+
+	def test_enabled_jarvis_owner_still_runs(self):
+		m = _mk_macro(OWNER_OK, "good-owner")
+		self.assertIn(m.name, self._run_due(), "the guard over-reached and refused a legitimate owner")
+
+	def test_refused_macro_does_not_busy_refire(self):
+		m = _mk_macro("Administrator", "admin-advance")
+		self._run_due()
+		nxt = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertGreater(nxt, now_datetime(), "a refused macro stayed due and would re-fire hourly")

--- a/jarvis/tests/test_part3_security.py
+++ b/jarvis/tests/test_part3_security.py
@@ -231,6 +231,11 @@ class Part3Base(FrappeTestCase):
 			(MACRO, {"macro_name": ["like", f"{PFX}%"]}),
 		):
 			for n in frappe.get_all(dt, filters=filt, pluck="name"):
+				if dt == MACRO:
+					# The scheduler now COMMITS a failed Macro Run for a slot it refused
+					# (#471), so that row outlives the rollback above too.
+					for r in frappe.get_all(MACRO_RUN, filters={"macro": n}, pluck="name"):
+						frappe.delete_doc(MACRO_RUN, r, force=True, ignore_permissions=True)
 				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
 		frappe.db.set_single_value("Jarvis Settings", "agent_skills_sync_status", "")
 		frappe.db.commit()


### PR DESCRIPTION
## Summary

Scheduled macros stop running as Administrator or as offboarded users, stop bypassing every usage cap, and stop reporting success when they failed; customers with scheduled macros notice their runs being refused, recorded and surfaced instead of silently drained or silently lost.

Closes #469, closes #468, closes #471. They could not be split: all three rewrite the same ~30 lines of `macro_scheduler.run_due_macros` and its handshake with `macros.run_macro`, so three PRs would conflict on every hunk. They are three separate commits so each can be reviewed and reverted alone.

Two decisions worth a reviewer's attention.

**A refused scheduled run is REJECTED, not skipped.** It writes a `failed` Jarvis Macro Run with the reason, owned by the macro owner, so it appears in the run-history list and the dashboard tiles, plus a Notification Log when the owner can act on it. A silent skip is exactly the failure mode #471 describes: the customer's month-end audit quietly never happens and the UI says it did. Whether the slot is CONSUMED is a separate axis, decided by whether the block can clear on its own. A release rollout or workspace reset is over in minutes, so the slot stays due and the next hourly tick retries it. A usage cap, suspended subscription, missing model connection or spent budget cannot clear inside the hour, so the slot is consumed rather than relogging the same dead end 24 times a day.

**The reaper tells parked from stranded on two independent axes.** Status is an allowlist of exactly `running`, so `waiting_capacity` (legitimately up to ~100 min under CDX-19, with its own bounded resume cron) is never a candidate, and neither is any future non-terminal status. Staleness is measured on `modified`, meaning last forward progress, never on `started_at`, so a 25-step macro that legitimately runs for hours is safe.

<details>
<summary>Root cause, per issue</summary>

**#469 - the scheduler admitted the two identities its sibling refuses.** The only gate was `has_jarvis_access(m.owner)` before `frappe.set_user(m.owner)`. That helper returns `True` for `Administrator` before any other check, and nothing in `permissions.py` reads `User.enabled` (nor does `frappe.get_roles`). So an Administrator-owned macro ran unattended with every DocPerm and User Permission bypassed, and disabling an offboarded employee never revoked their macros' ERP access: Frappe clears browser sessions only, and the roles, the macro row and `schedule_enabled` all survive.

Fixed by lifting `agent_scheduler._valid_owner` into `permissions.is_valid_unattended_owner` so both unattended dispatchers share one definition, and applying it alongside the existing access check. Both are needed: the new one refuses Administrator, Guest and disabled; `has_jarvis_access` refuses portal users and role-less System Users.

**#468 - macro steps met no entitlement gate at all.** `validate_can_send` had exactly three call sites, all human paths (`send_message` twice, `retry_message`). `_enqueue_turn`, the sole dispatch path for macro steps, had none, and neither did `dispatch`, `admission`, `turn_handler` or `worker`. Usage was still recorded by `record_turn_usage`, so the meter ran and nothing read it: the macro drained the owner's quota and the quota then rejected the owner's own interactive chat while the macro kept running.

There was also no run budget of any kind. The effective ceiling was 25 macros x 25 steps at the shortest cadence, about 625 turns per owner per day and 19k per month, times the number of users on the bench.

The gate now runs in `macros.run_macro` before anything is created, so a refused run leaves no conversation, no intro message and no run row. It covers the manual path too, where it throws so the SPA's existing toast renders it. The new budget is counted in STEPS, not runs, because one run is up to `MAX_STEPS` (25) turns, so a run count would under-bound the real spend by 25x. `Jarvis Settings.macro_step_budget_monthly` (default 500, floored at 31) mirrors `agent_run_budget_monthly`, and failed rows are excluded so a refusal can never self-perpetuate the cap.

The budget binds on scheduled runs only, and counts only scheduled steps. A manual run is an attended click already priced by the per-user token caps, so refusing one on a monthly run quota would break a real workflow with no cost story behind it, and counting manual runs would let a busy interactive month silently starve the schedule. It is keyed on the owner, where the sibling keys on the installation, because a macro has no `run_as_user` split: the owner is both the executing identity and the metered one.

**#471 - failures were silent, misleading and could strand a run forever.** `run_due_macros` caught the exception, wrote an Error Log only a System Manager can read, then advanced `last_run_at` and `next_run_at` UNCONDITIONALLY, so the missed slot was gone and the UI read "last run: today" for a run that never executed. `run_macro`'s own `{"ok": False, "reason": "macro disabled"}` return was never inspected, so a disabled-but-scheduled macro burned its slot every day forever with zero signal. And there was no reaper for `Jarvis Macro Run`, unlike `reap_stale_agent_runs`: `_enqueue_turn` can throw in `_ensure_session_key` when the gateway is down, and with no turn dispatched the chaining hook that terminalizes a run never fires, so the row sat `running` permanently with an empty `error`.

Now every outcome is durable. `last_run_at` is stamped only when the slot really produced a run, a dispatch that raised does not advance the schedule, and a disabled macro moves its schedule on without claiming a run and without writing a failed row (it is the state the owner asked for, not a failure). `reap_stale_macro_runs` is registered hourly in `hooks.py`; candidates are re-read under the same per-run redis lock the chaining hook takes, plus a row lock, and transitioned with a compare-and-set on `running`, so a run that advanced between the scan and the sweep is left alone rather than having a live step killed under it.

</details>

<details>
<summary>Test evidence</summary>

Local runs are DB-polluting and `site.jarvis` is role-polluted, so hosted CI is the authority. Local:

```
$ bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_macro_scheduler

Running 23 unspecified-category tests for jarvis

jarvis.tests.test_macro_scheduler.TestScheduledMacroCaps
    ok  test_budget_floor_survives_a_misconfigured_zero
    ok  test_manual_run_is_entitlement_gated_but_not_budget_gated
    ok  test_meter_counts_steps_not_runs_and_excludes_refusals
    ok  test_over_cap_run_is_refused_recorded_and_consumes_the_slot
    ok  test_step_budget_refuses_once_the_month_is_spent
    ok  test_suspended_subscription_refuses_the_run
    ok  test_the_gate_creates_nothing_before_refusing
    ok  test_transient_block_leaves_the_slot_due_for_a_retry
    ok  test_ungated_run_still_dispatches

jarvis.tests.test_macro_scheduler.TestScheduledMacroFailures
    ok  test_disabled_macro_consumes_the_slot_without_claiming_a_run
    ok  test_dispatch_failure_does_not_advance_the_schedule
    ok  test_dispatch_failure_is_visible_as_failed_not_successful
    ok  test_dispatch_failure_notifies_the_owner
    ok  test_successful_run_stamps_last_run_at

jarvis.tests.test_macro_scheduler.TestScheduledMacroIdentity
    ok  test_administrator_owned_macro_is_refused
    ok  test_disabled_owner_macro_is_refused
    ok  test_enabled_jarvis_owner_still_runs
    ok  test_refusal_is_recorded_as_a_failed_run
    ok  test_refused_macro_does_not_busy_refire

jarvis.tests.test_macro_scheduler.TestStaleMacroRunReaper
    ok  test_parked_waiting_capacity_run_is_never_reaped
    ok  test_recently_progressing_run_is_never_reaped
    ok  test_run_that_advanced_after_the_scan_is_left_alone
    ok  test_stranded_running_run_is_terminalized

----------------------------------------------------------------------
Ran 23 tests in 0.877s

OK
```

Regression sweep over the neighbouring suites, all green:

```
test_macro_scheduler         Ran 23 tests in 0.877s | OK
test_macro_merge             Ran 25 tests in 0.764s | OK | Ran 1 test | OK
test_part3_security          Ran 19 tests in 0.626s | OK
test_chat_policy             Ran 16 tests in 0.268s | OK
test_chat_admission          Ran 59 tests in 1.263s | OK | Ran 11 tests | OK
test_agents_marketplace      Ran 36 tests in 1.561s | OK
test_agent_identity          Ran  7 tests in 1.007s | OK
test_chat_api                Ran 61 tests in 1.812s | OK | Ran 6 tests | OK
test_turn_recovery           Ran 35 tests in 0.461s | OK
test_chat_stale_scan         Ran  6 tests in 0.428s | OK
```

</details>

## Notes for the follow-up on #470

Out of scope here, but this PR constrains how it should be fixed. #470 (merged-vs-stepped re-decided per dispatch) means a run can sit in `waiting_capacity` for up to ~100 minutes legitimately. The reaper allowlists `running` only, so any new non-terminal status a #470 fix introduces is excluded from reaping by construction, no reaper change required. The one thing a #470 fix must not do is leave a run in `running` for more than three hours without writing the row: staleness is measured on `modified`, so a design that parks a run in `running` without touching it would be reaped as stranded.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on a red check)
- [x] Branch is **up to date with `develop`** (branched from `upstream/develop`)
- [x] New/changed behavior has tests (23 new, in `jarvis/tests/test_macro_scheduler.py`)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
