### PR TITLE
fix(oauth): adopt a live capture the client failed to cite

### DIFF
--- a/jarvis/oauth/pending_capture.py
+++ b/jarvis/oauth/pending_capture.py
@@ -214,14 +214,7 @@ def list_active(user: str | None = None) -> list[dict]:
 	rows = frappe.get_all(
 		DT,
 		ignore_permissions=True,
-		filters={
-			"owner_user": user,
-			"consumed_at": ["is", "not set"],
-			"expires_at": [">", now_datetime()],
-			# Only a still-live capture rehydrates - a cancelled/revoked one (its
-			# ciphertext already erased) must never reappear as resumable.
-			"revocation_state": "pending",
-		},
+		filters=_live_filters(user),
 		fields=[
 			"capture_id",
 			"account_ref",
@@ -235,6 +228,42 @@ def list_active(user: str | None = None) -> list[dict]:
 		order_by="creation desc",
 	)
 	return [_safe_view(r) for r in rows]
+
+
+def _live_filters(user: str) -> dict:
+	"""What makes a capture LIVE. One definition, shared by list_active and
+	find_live_capture_id - a second copy elsewhere would drift the day an
+	intermediate revocation_state is added."""
+	return {
+		"owner_user": user,
+		"consumed_at": ["is", "not set"],
+		"expires_at": [">", now_datetime()],
+		# A cancelled/revoked capture (ciphertext already erased) must never
+		# resurface as resumable.
+		"revocation_state": "pending",
+	}
+
+
+def find_live_capture_id(account_ref: str, user: str | None = None) -> str:
+	"""The id of this user's live capture for ``account_ref``, or "".
+
+	For the save path's fallback when the client did not cite a capture_id.
+	Owner-scoped like list_active, so an account_ref arriving in a request body
+	can never resolve to somebody else's capture. Returns the id only - the
+	claim itself must still go through consume_capture, which owns the owner
+	gate, expiry, anchor fence and once-only lock.
+	"""
+	account_ref = (account_ref or "").strip()
+	if not account_ref:
+		return ""
+	return (
+		frappe.db.get_value(
+			DT,
+			{**_live_filters(user or frappe.session.user), "account_ref": account_ref},
+			"capture_id",
+		)
+		or ""
+	)
 
 
 def consume_capture(capture_id: str) -> str:

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -371,25 +371,27 @@ def _adopt_orphan_capture(account_ref: str, consumed_capture_ids: list) -> str:
 	F10 anchor fence and once-only row lock all still apply; every ``CaptureError``
 	returns "" and the caller refuses exactly as it did before.
 	"""
-	from frappe.utils import now_datetime
-
 	from jarvis.oauth import pending_capture
 
-	cap_id = frappe.db.get_value(
-		pending_capture.DT,
-		{
-			"owner_user": frappe.session.user,
-			"account_ref": account_ref,
-			"consumed_at": ["is", "not set"],
-			"expires_at": [">", now_datetime()],
-			"revocation_state": "pending",
-		},
-		"capture_id",
-	)
+	cap_id = pending_capture.find_live_capture_id(account_ref)
 	if not cap_id:
 		return ""
 	try:
 		blob = pending_capture.consume_capture(cap_id)
+	except pending_capture.CaptureAlreadyConsumed:
+		# A concurrent save (a double-clicked Save, or a retry racing its own
+		# in-flight request) claimed this capture between our lookup and our
+		# consume. Its ciphertext is erased, so THIS save genuinely cannot
+		# complete - but the account did get connected, by the winner. Falling
+		# through to "no OAuth credential stored — reconnect this account" would
+		# tell the customer to sign in again and mint a SECOND live provider
+		# token for an account that is already linked, which is the hazard this
+		# whole module exists to avoid. Say what actually happened instead.
+		frappe.throw(
+			"This account was just connected by another save. Reload the page - "
+			"it is already linked, so there is no need to sign in again.",
+			frappe.ValidationError,
+		)
 	except pending_capture.CaptureError:
 		return ""
 	consumed_capture_ids.append(cap_id)

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -356,6 +356,48 @@ def _coalesce_subscription_models(models: list) -> list:
 	return out
 
 
+def _adopt_orphan_capture(account_ref: str, consumed_capture_ids: list) -> str:
+	"""Blob of this user's live capture for ``account_ref``, or "" if there isn't one.
+
+	The client normally cites the capture by its own id. This is the fallback for
+	when it cannot: ``LlmPoolEditor.load()`` blanks ``capture_id`` on every stored
+	account and ``rehydratePendingCaptures`` only re-attaches an orphan one in
+	singleMode, so a settings-pane reload after a failed save leaves a valid,
+	unconsumed capture that no retry can ever cite.
+
+	Scoped to the session user, mirroring ``pending_capture.list_active`` - an
+	``account_ref`` from the request body must never reach another user's row.
+	The claim itself goes through ``consume_capture``, so the owner gate, expiry,
+	F10 anchor fence and once-only row lock all still apply; every ``CaptureError``
+	returns "" and the caller refuses exactly as it did before.
+	"""
+	from frappe.utils import now_datetime
+
+	from jarvis.oauth import pending_capture
+
+	cap_id = frappe.db.get_value(
+		pending_capture.DT,
+		{
+			"owner_user": frappe.session.user,
+			"account_ref": account_ref,
+			"consumed_at": ["is", "not set"],
+			"expires_at": [">", now_datetime()],
+			"revocation_state": "pending",
+		},
+		"capture_id",
+	)
+	if not cap_id:
+		return ""
+	try:
+		blob = pending_capture.consume_capture(cap_id)
+	except pending_capture.CaptureError:
+		return ""
+	consumed_capture_ids.append(cap_id)
+	# Non-secret breadcrumb: an implicit adoption is worth being able to find later.
+	frappe.logger("jarvis.oauth").info(f"adopted orphan capture for account_ref {account_ref}")
+	return blob
+
+
 @frappe.whitelist()
 def save_llm_pool(
 	models: str | list,
@@ -495,6 +537,32 @@ def save_llm_pool(
 					# re-saved account.
 					if ref and prior_blobs.get(ref):
 						a["oauth_blob"] = prior_blobs[ref]
+					elif ref:
+						# Nothing stored either, so this account is heading straight for
+						# validate_models' "no OAuth credential stored" refusal. Before
+						# that, look for a live capture of THIS account the client failed
+						# to cite: the editor blanks capture_id on every load and only
+						# re-attaches an orphan one in singleMode, so a settings-pane
+						# reload after a failed save drops it and no retry can ever
+						# succeed (the capture sits valid and unconsumed server-side).
+						#
+						# Safe because the lookup is owner-scoped exactly like
+						# list_active, and account_ref is no more privileged than
+						# capture_id - both are server-minted and handed to the same
+						# client in the same sign-in response, so this can only adopt a
+						# capture the caller could already have cited explicitly.
+						# consume_capture still applies the owner gate, the expiry, the
+						# F10 anchor fence and the once-only row lock; any CaptureError
+						# falls through to the same refusal as before.
+						#
+						# Fallback ONLY: a stored blob still wins above, so no
+						# currently-succeeding save changes behaviour.
+						#
+						# Refusing is not the safer choice here - it forces a re-sign-in,
+						# which mints a SECOND live provider token while the first stays
+						# unrevoked (openai/xai/kimi have no entry in _REVOKE_ENDPOINTS),
+						# the duplicate-live-token hazard this module exists to avoid.
+						a["oauth_blob"] = _adopt_orphan_capture(ref, consumed_capture_ids)
 				merged_accounts.append(a)
 			row["subscription_accounts"] = json.dumps(merged_accounts)
 		s.append("models", row)

--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -407,3 +407,20 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 		with self.assertRaises(frappe.ValidationError) as cm:
 			self._save(self._payload("SUB_nothing_here"))
 		self.assertIn("no OAuth credential stored", str(cm.exception))
+
+	def test_race_with_a_concurrent_adopter_says_what_happened(self):
+		"""A double-submitted save loses the race to consume. Its ciphertext is
+		gone, so this save cannot finish - but it must NOT tell the customer to
+		reconnect, which would mint a second live token for an account that is
+		now linked."""
+		from jarvis.oauth import pending_capture
+
+		self._mint("SUB_orphan5")
+		with patch.object(
+			pending_capture, "consume_capture", side_effect=pending_capture.CaptureAlreadyConsumed("x")
+		):
+			with self.assertRaises(frappe.ValidationError) as cm:
+				self._save(self._payload("SUB_orphan5"))
+		msg = str(cm.exception)
+		self.assertIn("just connected by another save", msg)
+		self.assertNotIn("reconnect this account", msg)

--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -295,3 +295,115 @@ class TestSubscriptionAccountsRoundTrip(_RT3SettingsTestCase):
 			onboarding.save_llm_pool(frappe.as_json(payload), preset=None, routing_mode="failover")
 		providers = {m.get("provider") for m in pool_calls[0]["spec"]["models"]}
 		self.assertEqual(providers, {"openai", "gemini"})
+
+
+class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
+	"""save_llm_pool adopts a live capture the client failed to cite.
+
+	The editor blanks capture_id on every load and only re-attaches an ORPHAN one
+	in singleMode, so a settings-pane reload after a failed save leaves a valid,
+	unconsumed capture that no retry can cite. Without the fallback the account is
+	permanently unsavable even though its credential is sitting on the server.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		_reset_settings()
+		frappe.db.delete("Jarvis Pending OAuth Capture")
+		frappe.db.commit()
+
+	def _mint(self, account_ref, blob='{"refresh_token":"fake-rt-ORPHAN"}'):
+		from jarvis.oauth import pending_capture
+
+		return pending_capture.create_capture(
+			provider="openai",
+			upstream="openai",
+			openclaw_provider="openai",
+			oauth_blob=blob,
+			account_email="orphan@acme.com",
+			account_ref=account_ref,
+			safe_label="orphan@acme.com",
+			provider_subject="orphan-subject",
+		)
+
+	def _payload(self, account_ref, **extra):
+		acct = {"upstream": "openai", "account_ref": account_ref, "label": "orphan@acme.com"}
+		acct.update(extra)
+		return [
+			{
+				"model": "gpt-5.5",
+				"tier": "strong",
+				"order": 0,
+				"subscription": {"rotation": "sticky", "accounts": [acct]},
+			}
+		]
+
+	def _save(self, payload):
+		with (
+			patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
+			patch("jarvis.admin_client.post_update_llm_creds"),
+		):
+			return onboarding.save_llm_pool(frappe.as_json(payload), preset=None, routing_mode="failover")
+
+	def _stored_blob(self):
+		s = frappe.get_single("Jarvis Settings")
+		row = (s.get("models") or [])[0]
+		accounts = json.loads(row.get_password("subscription_accounts", raise_exception=False) or "[]")
+		return (accounts[0] or {}).get("oauth_blob") or ""
+
+	def test_orphan_capture_is_adopted_without_capture_id(self):
+		"""The regression: account_ref only, no capture_id, nothing stored."""
+		view = self._mint("SUB_orphan1")
+		self._save(self._payload("SUB_orphan1"))
+
+		self.assertIn("fake-rt-ORPHAN", self._stored_blob())
+		row = frappe.db.get_value(
+			"Jarvis Pending OAuth Capture",
+			{"capture_id": view["capture_id"]},
+			["consumed_at", "revocation_state"],
+			as_dict=True,
+		)
+		self.assertTrue(row.consumed_at, "the adopted capture must be burned")
+		self.assertEqual(row.revocation_state, "consumed")
+
+	def test_adopted_account_survives_a_resave(self):
+		"""Second save cites nothing either; the now-STORED blob carries it."""
+		self._mint("SUB_orphan2")
+		self._save(self._payload("SUB_orphan2"))
+		self._save(self._payload("SUB_orphan2"))
+		self.assertIn("fake-rt-ORPHAN", self._stored_blob())
+
+	def test_capture_bound_to_another_connection_is_refused(self):
+		"""The F10 anchor fence still bites - the fallback must not bypass it."""
+		self._mint("SUB_orphan3")
+		frappe.db.set_value(
+			"Jarvis Pending OAuth Capture",
+			{"account_ref": "SUB_orphan3"},
+			"bound_agent_url",
+			"ws://some-other-workspace:1",
+		)
+		frappe.db.commit()
+		with self.assertRaises(frappe.ValidationError) as cm:
+			self._save(self._payload("SUB_orphan3"))
+		self.assertIn("no OAuth credential stored", str(cm.exception))
+
+	def test_another_users_capture_is_never_adopted(self):
+		"""Owner scoping: an account_ref from the request body must not reach a
+		capture belonging to somebody else."""
+		self._mint("SUB_orphan4")
+		frappe.db.set_value(
+			"Jarvis Pending OAuth Capture",
+			{"account_ref": "SUB_orphan4"},
+			"owner_user",
+			"Guest",
+		)
+		frappe.db.commit()
+		with self.assertRaises(frappe.ValidationError) as cm:
+			self._save(self._payload("SUB_orphan4"))
+		self.assertIn("no OAuth credential stored", str(cm.exception))
+
+	def test_no_capture_at_all_still_refuses(self):
+		with self.assertRaises(frappe.ValidationError) as cm:
+			self._save(self._payload("SUB_nothing_here"))
+		self.assertIn("no OAuth credential stored", str(cm.exception))


### PR DESCRIPTION
## Regression

A chat-subscription account can become **permanently unsavable** while its OAuth credential sits valid and unconsumed on the server.

Reproduced on a live site — identical payload, only difference is the field:

```
WITHOUT capture_id → "Model[0] (gpt-5.5) account[0] (SUB_949e245f381aa367):
                      no OAuth credential stored — reconnect this account to authorize"
WITH capture_id    → save OK
```

The capture row was fine throughout: unconsumed, unexpired, `bound_agent_url` matching the anchor.

## Mechanism

1. `LlmPoolEditor.load()` blanks `capture_id` on every stored account (~3608) — correct, stored accounts keep their blob server-side.
2. `rehydratePendingCaptures()` (~3627) re-attaches live captures, but has only two branches: a row already holding that `account_ref`, or — **`if (singleMode.value)` only** — `rows.value[0]`. Otherwise the capture is silently dropped.
3. The settings **AI models** pane renders with `singleMode === false`. On a site with no saved model rows the capture matches nothing, falls off the end, and every later save posts `account_ref` with `capture_id: ""`.
4. `validate_models` (`pool_serialize.py:430`) then refuses, correctly — a blobless account would enter the pool spec and 502 every turn.

No retry can recover: only a fresh sign-in that auto-saves without an intervening reload. Normally "Connect IS the save" consumes the capture in the same action, which is why this stayed hidden — it surfaced when a first save failed for an unrelated reason.

## Fix: server-side, not in the editor

`save_llm_pool` already owns adoption. Fixing it there covers **every** client — SPA, desk, raw API — instead of one code path in one of them.

Matching an orphan capture *in the editor* would need an identity key it doesn't have: `upstream`/provider is shared by two accounts of the same vendor, so it would attach credential material to the **wrong row**. `account_ref` is the only correct key, and the server is where it can be resolved safely.

`_adopt_orphan_capture` runs **only** in the branch with no `capture_id`, no posted blob and no stored blob — a path that today ends in the refusal **100% of the time**. It is structurally incapable of changing a save that currently succeeds.

## Security

`account_ref` is no more privileged than `capture_id`. Both are server-minted (`oauth/api.py:674`) and returned to the same client in the same sign-in response, so this can only adopt a capture the caller could already have cited explicitly.

- Lookup is **owner-scoped** to `frappe.session.user`, mirroring `pending_capture.list_active` — a request-body `account_ref` can never reach another user's row.
- The claim still goes through `consume_capture`, so the owner gate, expiry, **F10 anchor fence** and once-only `FOR UPDATE` row lock all still apply.
- Every `CaptureError` returns `""` and the caller refuses exactly as before — fail-closed.
- Fallback only: a stored blob still wins, so no currently-working save changes behaviour.

**Refusing was not the safer default.** It forces a re-sign-in that mints a *second* live provider token while the first stays unrevoked — `_REVOKE_ENDPOINTS` has no entry for openai/xai/kimi — which is the duplicate-live-token hazard this module exists to prevent.

## Tests

New `TestOrphanCaptureAdoption` in `test_subscription_accounts_roundtrip.py`:

| test | asserts |
|---|---|
| `test_orphan_capture_is_adopted_without_capture_id` | the regression: blob persisted, capture burned + `revocation_state=consumed` |
| `test_adopted_account_survives_a_resave` | second save carries via `prior_blobs` |
| `test_capture_bound_to_another_connection_is_refused` | F10 anchor fence still bites |
| `test_another_users_capture_is_never_adopted` | owner scoping |
| `test_no_capture_at_all_still_refuses` | unchanged refusal |

Also verified against the live site: valid orphan adopted; anchor-mismatched and absent captures still refused with the original message.

## Follow-up, deliberately not bundled

The pane still gives no sign that a connected account is waiting server-side, so a customer will re-sign-in anyway (harmless now — it folds onto the same capture row). Surfacing it needs its own plan: `savedSnapshot` is taken *before* `rehydratePendingCaptures`, so seeding a row would make an empty pool permanently dirty on every load.