### PR TITLE
fix: remove fail-open FDR default in _read_and_persist

### DIFF
--- a/jarvis/learning/engine.py
+++ b/jarvis/learning/engine.py
@@ -484,8 +484,16 @@ def _execute(run_name: str) -> tuple[str, str]:
 # --------------------------------------------------------------------------- #
 # per-unit read (fenced) + persist (unfenced)
 # --------------------------------------------------------------------------- #
-def _read_and_persist(spec, company, run, fdr_buffer=None, mined=None, watch=None) -> dict:
+def _read_and_persist(spec, company, run, fdr_buffer, mined=None, watch=None) -> dict:
+	"""``fdr_buffer`` has no default (jarvis#483): pass a live ``DetectorFamilyBuffer``
+	to apply the per-family BH-FDR pass (fdr.py), or the ``fdr.NO_FDR`` sentinel to
+	deliberately skip it. Omitting the argument, or passing ``None`` out of habit,
+	used to silently persist every raw candidate with zero multiple-testing
+	correction - that fail-open default is gone; both now fail loudly instead
+	(a ``TypeError`` on omission, an ``AttributeError`` on a stray ``None``).
+	"""
 	from jarvis.learning.executor import PER_DETECTOR_CANDIDATE_CAP, run_detector
+	from jarvis.learning.fdr import NO_FDR
 
 	frappe.db.commit()  # no pending writes before opening the READ ONLY fence
 	with read_only_transaction() as pdb:
@@ -524,7 +532,7 @@ def _read_and_persist(spec, company, run, fdr_buffer=None, mined=None, watch=Non
 	# persisted survivors; the delta is explained in the run's coverage note.
 	to_persist = norm["candidates"]
 	persist_detector_id = _spec_id(spec)
-	if fdr_buffer is not None:
+	if fdr_buffer is not NO_FDR:
 		released = fdr_buffer.add(_spec_id(spec), norm["candidates"])
 		to_persist = list(released.survivors) if released else []
 		if released is not None:

--- a/jarvis/learning/fdr.py
+++ b/jarvis/learning/fdr.py
@@ -43,6 +43,16 @@ from dataclasses import dataclass, field
 # family's surviving proposals are flukes.
 FDR_Q = 0.05
 
+# jarvis#483: the ONLY way ``engine._read_and_persist`` may skip this module's BH
+# pass and persist a unit's raw candidates uncorrected. ``fdr_buffer`` there has no
+# default and is not optional, precisely so a caller cannot skip correction by
+# omitting the argument or by passing ``None`` out of habit (Python's usual "nothing
+# here" value) - both used to silently persist every raw candidate with zero
+# multiple-testing correction, letting a detector that tests hundreds of suppliers
+# take hundreds of shots at a fluke. A caller that genuinely wants that (there is
+# currently none) must say so with this exact sentinel.
+NO_FDR = object()
+
 # Defensive soft cap on a family's buffered candidates: a many-company tenant
 # can concentrate one detector's whole family in RAM before the first persist
 # (the run's memory high-water mark). Crossing the cap releases the buffered

--- a/jarvis/tests/learning/test_orchestrator.py
+++ b/jarvis/tests/learning/test_orchestrator.py
@@ -326,6 +326,73 @@ class TestDriftStash(FrappeTestCase):
 		self.assertEqual(unit["skipped"], "missing field X.y")
 
 
+class TestReadAndPersistRequiresFdrDecision(FrappeTestCase):
+	"""jarvis#483: ``fdr_buffer`` has no default. Omitting it, or passing a
+	stray ``None``, used to silently persist every raw candidate with zero
+	multiple-testing correction - a detector testing hundreds of suppliers got
+	hundreds of shots at a fluke. Both must now fail loudly, and the ONLY way
+	to deliberately skip the BH pass is the ``fdr.NO_FDR`` sentinel."""
+
+	def _spec(self):
+		return {"id": "det-483", "doctype": "Sales Invoice"}
+
+	def _run_with(self, fdr_buffer, candidates, company="CoA"):
+		from jarvis.learning.executor import DetectorResult
+
+		with mock.patch(
+			"jarvis.learning.executor.run_detector",
+			return_value=DetectorResult(candidates, None, rows_scanned=len(candidates)),
+		):
+			return engine._read_and_persist(self._spec(), company, None, fdr_buffer=fdr_buffer)
+
+	def test_omitting_fdr_buffer_raises(self):
+		"""No default: leaving the argument out is a loud TypeError, never a
+		silent skip of the correction pass (the jarvis#483 bug)."""
+		with self.assertRaises(TypeError):
+			engine._read_and_persist(self._spec(), "CoA", None)
+
+	def test_none_is_not_a_valid_skip(self):
+		"""A stray ``fdr_buffer=None`` (Python's habitual "nothing here" value)
+		must fail loudly too, never quietly persist every raw candidate."""
+		with self.assertRaises(AttributeError):
+			self._run_with(None, [{"pattern_key": "k1", "p_value": 0.9}])
+
+	def test_no_fdr_sentinel_persists_raw_candidates_immediately(self):
+		"""The deliberate, explicit opt-out still works and takes effect right
+		away - no buffering, no correction, exactly as a caller who typed
+		``fdr.NO_FDR`` asked for."""
+		from jarvis.learning.fdr import NO_FDR
+
+		with mock.patch.object(engine, "_persist_candidate", return_value="created"):
+			unit = self._run_with(NO_FDR, [{"pattern_key": "k1", "p_value": 0.9}])
+		self.assertEqual(unit["created"], 1, "NO_FDR persists the raw candidate with no correction")
+
+	def test_a_real_buffer_withholds_the_only_unit_until_a_family_releases(self):
+		"""Proof the correction cannot be silently skipped by ACCIDENT either:
+		passing a real buffer defers persistence until its family releases (a
+		later detector's first unit, or an explicit flush) - the opposite of
+		NO_FDR's immediate persist above, for the exact same input."""
+		from jarvis.learning.fdr import DetectorFamilyBuffer
+
+		fdr_buffer = DetectorFamilyBuffer()
+		with mock.patch.object(engine, "_persist_candidate", return_value="created"):
+			unit = self._run_with(fdr_buffer, [{"pattern_key": "k1", "p_value": 0.9}])
+		self.assertEqual(
+			unit["created"],
+			0,
+			"a real buffer withholds the family's only unit pending release - the BH "
+			"pass is actually gating persistence here, not a no-op",
+		)
+		self.assertEqual(fdr_buffer.pending_n, 1, "the candidate is buffered, not lost")
+
+		# Flushing releases it: a family of one candidate whose only test has
+		# p=0.9 fails BH at q=0.05 and is rejected, not persisted either -
+		# confirming the buffered candidate was really subject to correction.
+		released = fdr_buffer.flush()
+		self.assertEqual(released.survivors, [], "p=0.9 does not survive BH at q=0.05")
+		self.assertEqual(len(released.rejected), 1)
+
+
 class TestRowBudget(FrappeTestCase):
 	"""fix 6: the nightly row budget can actually trip once detectors report a
 	real scanned-row count."""


### PR DESCRIPTION
## Summary

`_read_and_persist`'s `fdr_buffer` argument defaulted to `None`, and the per-family Benjamini-Hochberg FDR pass only ran when a buffer was actually supplied. Omitting the argument silently persisted every raw candidate with zero multiple-testing correction, so a detector testing hundreds of suppliers got hundreds of shots at a fluke instead of the intended per-family q=0.05 false-discovery-rate control that runs after the hard per-candidate gates.

`fdr_buffer` now has no default. A caller must pass a live `DetectorFamilyBuffer` to apply the correction, or the new `fdr.NO_FDR` sentinel to deliberately skip it. Omitting the argument is now a `TypeError`, and a stray `fdr_buffer=None` (instead of the sentinel) now raises `AttributeError` on `fdr_buffer.add(...)` rather than silently skipping correction. This is currently inert in production: the sole caller (`engine.py apply()`) already builds and passes a real buffer unconditionally, and the one test caller already passes one too, so neither call site changes.

Adds `TestReadAndPersistRequiresFdrDecision` proving omission raises `TypeError`, a stray `None` raises `AttributeError`, `NO_FDR` persists raw candidates immediately as the only deliberate opt-out, and a real buffer withholds a family's only unit until it releases.

## Pre-merge checklist

- [ ] CI is green
- [ ] Branch is up to date with `develop`
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi

Closes #483
