### PR TITLE
fix(macros): write merge_status pending before dispatching the turn

### DIFF
--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -569,27 +569,11 @@ def summarize_macro(name: str) -> dict:
 	from jarvis.chat import api as chat_api
 
 	prompt = _MERGE_INSTRUCTION + frappe.as_json(payload) + "\n\nApply these skills: /macro-merge"
-	out = chat_api._enqueue_turn(conv.name, prompt)
-	# CDX-19: the site's turn queue was momentarily full, so the merge turn was NOT dispatched
-	# (its seed was cleaned up). Do NOT mark the macro merge "pending" — that would strand it
-	# waiting on a summary turn that never runs (get_macro_merge would poll pending forever).
-	# The merge is a one-shot user action (not a chained run), so the honest disposition is a
-	# retryable rejection: tear down the throwaway conversation and let the user re-click.
-	if isinstance(out, dict) and out.get("overloaded"):
-		try:
-			frappe.delete_doc("Jarvis Conversation", conv.name, ignore_permissions=True, force=True)
-			frappe.db.commit()
-		except Exception:
-			frappe.db.rollback()
-		return {
-			"ok": False,
-			"reason": out.get("reason") or _("The site is busy — please try again in a moment."),
-		}
-	# Hide from the sidebar (list_conversations skips Archived).
-	frappe.db.set_value("Jarvis Conversation", conv.name, "status", "Archived", update_modified=False)
-	# Mark the macro "summarizing": run_macro refuses while pending, and the
-	# worker's advance hook applies the summary when this turn finishes — so
-	# the flow completes even if the browser tab is gone.
+	# Mark the macro "summarizing" BEFORE dispatch: run_macro refuses while pending, and
+	# the worker's advance hook applies the summary when this turn finishes. Dispatch can
+	# complete the turn inline (before _enqueue_turn even returns), so writing "pending"
+	# after dispatch loses the race — the advance hook's lookup misses and silently no-ops.
+	# Writing it first guarantees a completed turn always finds the macro already waiting.
 	frappe.db.set_value(
 		MACRO,
 		name,
@@ -599,6 +583,35 @@ def summarize_macro(name: str) -> dict:
 		},
 		update_modified=False,
 	)
+	frappe.db.commit()
+	out = chat_api._enqueue_turn(conv.name, prompt)
+	# CDX-19: the site's turn queue was momentarily full, so the merge turn was NOT dispatched
+	# (its seed was cleaned up). Roll back the "pending" mark set above — there is no summary
+	# turn coming for it to wait on (get_macro_merge would poll pending forever otherwise).
+	# The merge is a one-shot user action (not a chained run), so the honest disposition is a
+	# retryable rejection: tear down the throwaway conversation, clear the mark, and let the
+	# user re-click.
+	if isinstance(out, dict) and out.get("overloaded"):
+		try:
+			frappe.delete_doc("Jarvis Conversation", conv.name, ignore_permissions=True, force=True)
+			frappe.db.set_value(
+				MACRO,
+				name,
+				{
+					"merge_status": "",
+					"merge_conversation": "",
+				},
+				update_modified=False,
+			)
+			frappe.db.commit()
+		except Exception:
+			frappe.db.rollback()
+		return {
+			"ok": False,
+			"reason": out.get("reason") or _("The site is busy — please try again in a moment."),
+		}
+	# Hide from the sidebar (list_conversations skips Archived).
+	frappe.db.set_value("Jarvis Conversation", conv.name, "status", "Archived", update_modified=False)
 	frappe.db.commit()
 	return {"ok": True, "conversation": conv.name}
 

--- a/jarvis/tests/test_macro_merge.py
+++ b/jarvis/tests/test_macro_merge.py
@@ -121,6 +121,57 @@ class TestSummarizeMacro(_MacroMergeBase):
 		with self.assertRaises(frappe.ValidationError):
 			summarize_macro(m.name)
 
+	def test_pending_written_before_dispatch(self):
+		"""Regression: dispatch can complete the turn inline before _enqueue_turn
+		returns, so the advance hook's lookup for {merge_conversation, merge_status
+		== "pending"} must never miss. Assert "pending" is already on the macro
+		at the moment _enqueue_turn is invoked, not after."""
+		m = _mk_macro(
+			[
+				{"label": "a", "prompt": "Sales analytics for last quarter"},
+				{"label": "b", "prompt": "Find the highest outstanding customer"},
+			]
+		)
+		self.addCleanup(
+			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
+		)
+		seen = {}
+
+		def _capture(conversation, prompt):
+			seen["merge_status"] = frappe.db.get_value("Jarvis Macro", m.name, "merge_status")
+			seen["merge_conversation"] = frappe.db.get_value("Jarvis Macro", m.name, "merge_conversation")
+			return {"run_id": "r1", "message_id": "m1"}
+
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=_capture):
+			r = summarize_macro(m.name)
+		self.addCleanup(
+			lambda: frappe.delete_doc(
+				"Jarvis Conversation", r["conversation"], force=True, ignore_permissions=True
+			)
+		)
+		self.assertEqual(seen["merge_status"], "pending")
+		self.assertEqual(seen["merge_conversation"], r["conversation"])
+
+	def test_overloaded_dispatch_clears_pending_mark(self):
+		"""When dispatch reports overloaded, the pending mark written up front
+		must be rolled back — otherwise Run stays gated forever on a summary
+		turn that never ran (get_macro_merge would poll pending forever)."""
+		m = _mk_macro(
+			[
+				{"label": "a", "prompt": "Sales analytics for last quarter"},
+				{"label": "b", "prompt": "Find the highest outstanding customer"},
+			]
+		)
+		self.addCleanup(
+			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
+		)
+		overload = {"ok": False, "overloaded": True, "reason": "busy"}
+		with patch("jarvis.chat.api._enqueue_turn", return_value=overload):
+			r = summarize_macro(m.name)
+		self.assertFalse(r["ok"])
+		self.assertEqual(frappe.db.get_value("Jarvis Macro", m.name, "merge_status"), "")
+		self.assertEqual(frappe.db.get_value("Jarvis Macro", m.name, "merge_conversation"), "")
+
 
 class TestGetMacroMerge(_MacroMergeBase):
 	def _cleanup_conv(self, conv):


### PR DESCRIPTION
## Summary

`summarize_macro` now writes the `merge_status="pending"` marker before dispatching the
merge turn instead of after, so a turn that completes inline (before `_enqueue_turn`
returns) is never missed by the advance hook; the overloaded-dispatch path rolls the
marker back so a rejected dispatch does not strand the macro pending forever. Anyone
who uses the "Merge steps" action on a macro with 2+ steps notices: the merge no
longer silently vanishes on a fast turn.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on FAIL)
- [x] Branch is up to date with `develop` (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi

Closes #473
