### PR TITLE
fix(disconnect): converge the local clear from admin's own state (#534)

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1886,6 +1886,84 @@ def _enqueued_sync_via_admin(action: str, retry_left: int = ADMIN_SYNC_LOCK_RETR
 		settings._sync_via_admin(action)
 
 
+#: The clause admin puts in ``chat_readiness_reason`` when its OWN tenant row
+#: holds no LLM credential of any kind.
+#:
+#: Source of truth: ``jarvis_admin_v2/fleet/pool.py``. ``compute_chat_readiness``
+#: appends exactly this sentence to ``missing`` when ``_llm_creds_ready(row)`` is
+#: False, i.e. no api key, no pool config and no oauth blob. ``disconnect_llm``
+#: blanks all three as a committed desired generation BEFORE it touches the
+#: container, so this clause appears the moment admin has processed a disconnect
+#: and stays until the customer reconnects.
+#:
+#: Matching a SENTENCE is not something to do lightly (the resume guard that
+#: prose-matched a message admin had stopped sending is the cautionary tale), so
+#: note which way this one fails. If admin rewords it, the clause stops matching,
+#: the branch below never fires, and the bench is back to exactly today's
+#: behaviour - the split persists until someone reconnects. It can never start
+#: firing on a workspace admin is happy with. A drift here loses the fix; it
+#: cannot cost a customer their keys.
+_ADMIN_NO_LLM_CREDS_CLAUSE = "waiting for an llm key or subscription"
+
+
+def _admin_says_llm_gone(state, reason) -> bool:
+	"""Does admin's OWN state say this workspace has no LLM credentials left?
+
+	Not "is the workspace unhealthy" - specifically "admin's tenant row holds
+	nothing". Every other Configuring reason (applying your LLM configuration, ERP
+	tools not connected, a rejected pool spec, an unverified route) describes a
+	tenant whose credentials admin still HAS, and must never reach the clear.
+
+	``state`` is required to be exactly ``Configuring`` on top of the clause:
+	  * ``None``   - the probe failed. Unknown is not disconnected.
+	  * ``Ready``  - contradicts the clause outright.
+	  * ``Provisioning`` / ``Suspended`` / ``SupportRequired`` - admin is answering
+	    about a container, a subscription or an authority incident, and says
+	    nothing about credentials either way. A suspended tenant in particular
+	    still owns its keys and gets them back on renewal.
+	"""
+	if state != "Configuring":
+		return False
+	return _ADMIN_NO_LLM_CREDS_CLAUSE in (reason or "").strip().lower()
+
+
+def _local_llm_survived_an_admin_disconnect(settings, pool_mode: bool) -> bool:
+	"""Could this workspace be the losing half of a split disconnect? Local-only.
+
+	Two conditions, and the second is the one that keeps a working customer's
+	credentials safe:
+
+	1. The bench still HOLDS a credential (``_has_llm_config``). Nothing to clear
+	   otherwise, which is also what makes the clear idempotent - a converged
+	   workspace fails here on every later tick.
+
+	2. The fleet has CONFIRMED an apply of the leg this workspace syncs through
+	   (``_llm_apply_confirmed``: llm_pool_synced_at / llm_oauth_connected_at /
+	   llm_direct_synced_at). This is the discriminator between the two ways admin
+	   can be holding no credentials:
+
+	     * admin HAD them and deleted them -> the marker is set, because it was
+	       stamped when admin confirmed the apply and only a completed disconnect
+	       clears it. Converge.
+	     * admin NEVER RECEIVED them -> a customer who just typed a key into a
+	       bench that could not reach admin, or whose first push failed. No marker
+	       was ever stamped. Their key is real, wanted, and MUST NOT be destroyed;
+	       the pending-sync machinery is what carries that case.
+
+	   Without (2) the reconcile would read "admin has no creds" identically in
+	   both and wipe the second, which is the one failure mode strictly worse than
+	   the bug being fixed.
+
+	Deliberately reuses ``account``'s predicates rather than restating them: they
+	are the same evidence ``is_ready_for_chat`` opens chat on and the Connection
+	badge colours itself from, so this branch cannot come to a different
+	conclusion about "connected" than the rest of the app.
+	"""
+	from jarvis.account import _has_llm_config, _llm_apply_confirmed
+
+	return _has_llm_config(settings) and _llm_apply_confirmed(settings, pool_mode)
+
+
 def reconcile_pending_llm_sync() -> None:
 	"""Scheduled safety net (*/5, hooks.py): finish a sync the in-band job left
 	PENDING because the admin apply was still converging (F2).
@@ -1897,13 +1975,28 @@ def reconcile_pending_llm_sync() -> None:
 	  resolved since the bench last looked: either the explicit
 	  ``pending: admin applying config`` marker, OR a pool whose FIRST apply is
 	  still unproven (pool mode + no llm_pool_synced_at) sitting at a
-	  pending/failed status (the onboarding livelock class).
+	  pending/failed status (the onboarding livelock class), OR a workspace whose
+	  credentials admin has already destroyed (see ``_admin_says_llm_gone``).
 	- Probes admin get_connection EXACTLY ONCE (chat_readiness); stamps the
 	  terminal success markers only on "Ready" (admin gates Ready on
 	  applied_version >= desired_version, so it never reports Ready from intent).
 	- Never flips a status to a new "failed:" and never touches a healthy /
 	  already-"ok" tenant. Swallows every error - a scheduled task must not
 	  raise. Un-onboarded sites short-circuit.
+
+	THE DISCONNECT LEG (#534). ``onboarding.disconnect_llm`` calls admin inside a
+	whitelisted request and clears local secrets only after it answers, so a
+	worker killed at gunicorn's ``-t`` AFTER admin committed its blanked row left
+	admin and the container disconnected while this bench kept advertising a live
+	model. Nothing converged that: the branches above only look at pending/failed
+	states, and a half-disconnected workspace reads perfectly healthy locally.
+
+	This leg closes it WITHOUT a bench-side intent flag - admin deliberately owns
+	that state (jarvis-admin-v2 #136), and a local flag would only reintroduce the
+	same "did the worker survive long enough to write it" question one field
+	earlier. It converges from what admin already publishes instead, so a killed
+	worker, a dropped connection and a customer who closed the tab all land in the
+	same place on the next tick.
 	"""
 	try:
 		settings = frappe.get_single("Jarvis Settings")
@@ -1942,15 +2035,29 @@ def reconcile_pending_llm_sync() -> None:
 			and (settings.get("llm_auth_mode") or "api_key") == "api_key"
 			and bool((settings.get("llm_provider") or "").strip())
 		)
-		if not (is_applying_pending or is_unproven_pool or is_unproven_direct):
+		# The disconnect leg's LOCAL precondition (see the docstring). Cheap and
+		# purely local, so the probe below is still skipped on every tenant that
+		# cannot possibly be in the split state.
+		may_be_disconnected = _local_llm_survived_an_admin_disconnect(settings, pool_mode)
+		if not (is_applying_pending or is_unproven_pool or is_unproven_direct or may_be_disconnected):
 			return
 
-		state, _reason = _admin_chat_readiness()
+		state, reason = _admin_chat_readiness()
 		if state == "Ready":
-			# Stamps the evidence marker for whichever mode is active:
-			# llm_pool_synced_at for pool tenants, llm_direct_synced_at for
-			# single-model tenants (is_ready_for_chat's first-activation gates).
-			_stamp_converged_ok(settings, is_pool=pool_mode)
+			if is_applying_pending or is_unproven_pool or is_unproven_direct:
+				# Stamps the evidence marker for whichever mode is active:
+				# llm_pool_synced_at for pool tenants, llm_direct_synced_at for
+				# single-model tenants (is_ready_for_chat's first-activation gates).
+				_stamp_converged_ok(settings, is_pool=pool_mode)
+			return
+		if may_be_disconnected and _admin_says_llm_gone(state, reason):
+			from jarvis.onboarding import apply_local_disconnect
+
+			frappe.logger().warning(
+				"jarvis_settings: admin reports this workspace's LLM credentials are gone "
+				"while the bench still holds them; completing the local disconnect"
+			)
+			apply_local_disconnect(settings)
 	except Exception:
 		frappe.log_error(
 			title="Jarvis: reconcile_pending_llm_sync failed",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1930,8 +1930,9 @@ def _admin_says_llm_gone(state, reason) -> bool:
 def _local_llm_survived_an_admin_disconnect(settings, pool_mode: bool) -> bool:
 	"""Could this workspace be the losing half of a split disconnect? Local-only.
 
-	Two conditions, and the second is the one that keeps a working customer's
-	credentials safe:
+	Three conditions. The second and third both exist to keep a working customer's
+	credentials safe, and they cover two different ways admin can legitimately be
+	holding none.
 
 	1. The bench still HOLDS a credential (``_has_llm_config``). Nothing to clear
 	   otherwise, which is also what makes the clear idempotent - a converged
@@ -1940,7 +1941,7 @@ def _local_llm_survived_an_admin_disconnect(settings, pool_mode: bool) -> bool:
 	2. The fleet has CONFIRMED an apply of the leg this workspace syncs through
 	   (``_llm_apply_confirmed``: llm_pool_synced_at / llm_oauth_connected_at /
 	   llm_direct_synced_at). This is the discriminator between the two ways admin
-	   can be holding no credentials:
+	   can be holding no credentials for a container we ARE serving:
 
 	     * admin HAD them and deleted them -> the marker is set, because it was
 	       stamped when admin confirmed the apply and only a completed disconnect
@@ -1954,13 +1955,27 @@ def _local_llm_survived_an_admin_disconnect(settings, pool_mode: bool) -> bool:
 	   both and wipe the second, which is the one failure mode strictly worse than
 	   the bug being fixed.
 
+	3. NO WORKSPACE RESET IS IN FLIGHT. (2) is not sufficient alone, because a reset
+	   points the customer at a BRAND NEW container while deliberately keeping the
+	   pool and the ``*_synced_at`` markers - the control plane carries them across,
+	   and ``_prepare_for_reset`` says in as many words that clearing them would
+	   eject the customer into the setup wizard. So between "new container Running"
+	   and "re-pushed spec applied", admin truthfully reports no credentials about a
+	   workspace whose markers are set, and (1) and (2) both pass. Firing there
+	   would destroy a pool nobody asked to disconnect, mid-reset. The reset owns
+	   its own convergence (``reconcile_pending_workspace_reset``); this leg stands
+	   aside until that has finished.
+
 	Deliberately reuses ``account``'s predicates rather than restating them: they
 	are the same evidence ``is_ready_for_chat`` opens chat on and the Connection
 	badge colours itself from, so this branch cannot come to a different
 	conclusion about "connected" than the rest of the app.
 	"""
 	from jarvis.account import _has_llm_config, _llm_apply_confirmed
+	from jarvis.onboarding import _RESETTING_STATUS
 
+	if (settings.get("last_sync_status") or "").startswith(_RESETTING_STATUS):
+		return False
 	return _has_llm_config(settings) and _llm_apply_confirmed(settings, pool_mode)
 
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1964,6 +1964,29 @@ def _local_llm_survived_an_admin_disconnect(settings, pool_mode: bool) -> bool:
 	return _has_llm_config(settings) and _llm_apply_confirmed(settings, pool_mode)
 
 
+def _llm_config_revision() -> str:
+	"""Digest of this bench's LOCAL LLM configuration, read uncached.
+
+	The reconcile decides whether to destroy credentials from an answer admin gave
+	up to a probe-timeout ago, holding a ``settings`` doc it loaded before asking.
+	A customer who RECONNECTS inside that window - types a new key, saves, has it
+	pushed - would otherwise have the credential they just entered deleted by a
+	verdict about the connection they replaced. Snapshot this before the probe,
+	compare after, skip the tick if anything moved; the next tick re-reads a
+	consistent pair. A narrow window, but it is the exact failure mode this whole
+	branch exists to avoid, so it does not get to survive as a race.
+
+	Reuses ``account``'s gate-revision digest rather than a bespoke field list: it
+	already covers every field a save or a reconnect moves (provider, model, auth
+	mode, preset, routing, sync status, the three apply markers), it is uncached by
+	construction, and one definition means a field added for the chat gate is
+	respected here for free.
+	"""
+	from jarvis.account import _GATE_REVISION_FIELDS, _gate_revision, _settings_raw
+
+	return _gate_revision(_settings_raw(_GATE_REVISION_FIELDS))
+
+
 def reconcile_pending_llm_sync() -> None:
 	"""Scheduled safety net (*/5, hooks.py): finish a sync the in-band job left
 	PENDING because the admin apply was still converging (F2).
@@ -2035,13 +2058,17 @@ def reconcile_pending_llm_sync() -> None:
 			and (settings.get("llm_auth_mode") or "api_key") == "api_key"
 			and bool((settings.get("llm_provider") or "").strip())
 		)
-		# The disconnect leg's LOCAL precondition (see the docstring). Cheap and
-		# purely local, so the probe below is still skipped on every tenant that
-		# cannot possibly be in the split state.
+		# The disconnect leg's LOCAL precondition (see the docstring). It is true of
+		# every healthy CONNECTED workspace, so this leg does cost one extra
+		# get_connection per tick on those - unavoidable, because a bench that lost
+		# the disconnect looks identical to a working one from the inside, which is
+		# the whole defect. The probe is the same cheap read the SPA already makes
+		# far more often, and every tenant that holds no credential still skips it.
 		may_be_disconnected = _local_llm_survived_an_admin_disconnect(settings, pool_mode)
 		if not (is_applying_pending or is_unproven_pool or is_unproven_direct or may_be_disconnected):
 			return
 
+		revision_before = _llm_config_revision() if may_be_disconnected else ""
 		state, reason = _admin_chat_readiness()
 		if state == "Ready":
 			if is_applying_pending or is_unproven_pool or is_unproven_direct:
@@ -2050,14 +2077,29 @@ def reconcile_pending_llm_sync() -> None:
 				# single-model tenants (is_ready_for_chat's first-activation gates).
 				_stamp_converged_ok(settings, is_pool=pool_mode)
 			return
-		if may_be_disconnected and _admin_says_llm_gone(state, reason):
-			from jarvis.onboarding import apply_local_disconnect
-
-			frappe.logger().warning(
-				"jarvis_settings: admin reports this workspace's LLM credentials are gone "
-				"while the bench still holds them; completing the local disconnect"
+		if not (may_be_disconnected and _admin_says_llm_gone(state, reason)):
+			return
+		if _llm_config_revision() != revision_before:
+			# The customer reconnected while we were asking. Admin's answer is about
+			# the connection they just replaced, and acting on it would delete the
+			# credential they just entered. Drop the tick; the next one re-reads both.
+			frappe.logger().info(
+				"jarvis_settings: local LLM config changed during the disconnect probe; "
+				"discarding a stale admin verdict"
 			)
-			apply_local_disconnect(settings)
+			return
+
+		from jarvis.onboarding import apply_local_disconnect
+
+		frappe.logger().warning(
+			"jarvis_settings: admin reports this workspace's LLM credentials are gone "
+			"while the bench still holds them; completing the local disconnect"
+		)
+		# Safe to write through the doc loaded before the probe: the revision check
+		# above just proved nothing moved, and every write it makes is absolute
+		# (delete the rows, write _DISCONNECTED_LLM_FIELDS' constants) rather than
+		# derived from a field this doc is holding.
+		apply_local_disconnect(settings)
 	except Exception:
 		frappe.log_error(
 			title="Jarvis: reconcile_pending_llm_sync failed",

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -631,6 +631,20 @@ def disconnect_llm() -> dict:
 	credentials were deleted when they were not, which is the one outcome this
 	feature cannot have.
 
+	That abort is NOT the whole story, and it cannot be. The admin call happens
+	synchronously inside a whitelisted request, so the chain is bounded by
+	gunicorn's ``-t`` on top of every client budget below it. A worker killed at
+	that ceiling AFTER admin already committed its blanked row leaves the planes
+	split the other way: admin (and the container) disconnected, this bench still
+	holding live keys and still advertising a model. Widening timeouts only moves
+	which layer does the killing.
+
+	So the abort is the FAST path, not the only one. The durable half is
+	``reconcile_pending_llm_sync``, which converges from admin's own state on a
+	later pass and finishes the local clear through ``apply_local_disconnect``
+	below. Nothing here records an intent for it to read - admin's state is the
+	authority, and asking it is what makes a killed worker survivable.
+
 	Idempotent: a tenant with nothing configured clears nothing and still succeeds
 	(admin's endpoint is idempotent for the same reason).
 	"""
@@ -643,6 +657,29 @@ def disconnect_llm() -> dict:
 	if _has_admin_credentials(settings):
 		_surface(admin_client.post_disconnect_llm)
 
+	apply_local_disconnect(settings)
+	return {"disconnected": True, "last_sync_status": "disconnected"}
+
+
+def apply_local_disconnect(settings) -> None:
+	"""The LOCAL half of a disconnect: destroy every stored credential, blank the
+	mirrored connection fields, drop the cached readiness verdict.
+
+	Split out of ``disconnect_llm`` because the scheduled reconcile needs the
+	IDENTICAL terminal state when it finds admin already disconnected and this
+	bench still holding secrets. Sharing one implementation is the point: a second,
+	hand-rolled clear would drift from ``_DISCONNECTED_LLM_FIELDS`` and leave a
+	half-cleared row that looks converged to everything downstream.
+
+	Deliberately does NOT call admin. Its only two callers have already established
+	that admin is done: one just got a success back, the other just read admin's
+	state saying so. Re-driving the deletion from here would spend the customer's
+	shared 20/hour rotate-ops bucket on a container admin's own reconcile is
+	already converging.
+
+	Idempotent: on an already-cleared tenant it deletes nothing and rewrites the
+	same values.
+	"""
 	_clear_llm_secrets(settings)
 	for field, value in _DISCONNECTED_LLM_FIELDS.items():
 		settings.db_set(field, value, update_modified=False)
@@ -651,7 +688,6 @@ def disconnect_llm() -> dict:
 	from jarvis.account import _bust_chat_gate
 
 	_bust_chat_gate()
-	return {"disconnected": True, "last_sync_status": "disconnected"}
 
 
 def _has_admin_credentials(settings) -> bool:

--- a/jarvis/tests/test_disconnect_llm.py
+++ b/jarvis/tests/test_disconnect_llm.py
@@ -7,6 +7,10 @@ __Auth row is not cleared at all. Frappe cleans __Auth in frappe.delete_doc,
 which never runs for child rows of a Single (Document.update_child_table deletes
 them with a bare SQL DELETE), so these tests read the table directly rather than
 trusting get_password to tell the truth about it.
+
+TestDisconnectReconcile below covers the other half of the feature: the scheduled
+convergence that finishes a disconnect whose synchronous admin call died after
+admin had already processed it (#534).
 """
 
 from unittest.mock import patch
@@ -16,6 +20,10 @@ from frappe.utils.password import get_decrypted_password
 
 from jarvis import account, admin_client, onboarding
 from jarvis.exceptions import AdminUnreachableError
+from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+	_admin_says_llm_gone,
+	reconcile_pending_llm_sync,
+)
 from jarvis.tests.test_settings_on_update import _reset_settings
 from jarvis.tests.test_unified_llm_config import _RT3SettingsTestCase
 
@@ -279,3 +287,219 @@ class TestDisconnectLlm(_RT3SettingsTestCase):
 		m.assert_not_called()
 		self.assertFalse(out["disconnected"])
 		self.assertEqual(out["default_model"], "gpt-4o")
+
+
+# What admin's chat_readiness_reason really looks like the moment it has processed
+# a disconnect: its own no-credentials clause, plus the stale-generation clause the
+# stub re-render is still working through. Composed, not a bare sentence, because
+# that is the shape the reconcile has to survive - see compute_chat_readiness in
+# jarvis-admin-v2 (fleet/pool.py).
+_ADMIN_DISCONNECTED_REASON = "waiting for an LLM key or subscription; applying your LLM configuration"
+
+
+class TestDisconnectReconcile(_RT3SettingsTestCase):
+	"""#534: the disconnect must survive a worker that dies mid-call.
+
+	``disconnect_llm`` asks admin synchronously and clears local secrets only if it
+	answers. Admin commits its blanked row BEFORE it touches the container, so a
+	worker killed anywhere after that commit - by gunicorn's -t, a dropped
+	connection, a restart - leaves admin and the container disconnected while this
+	bench still holds live keys and still advertises a model.
+
+	Every test here drives ``reconcile_pending_llm_sync`` directly. The scheduler is
+	paused on the dev bench and the cron cadence is not what is under test.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		_reset_settings()
+		frappe.db.commit()
+
+	def _seed_connected_pool(self):
+		"""A pool the fleet CONFIRMED it applied - i.e. an ordinary working customer.
+
+		The confirmed-apply marker is not decoration here: it is the discriminator
+		the reconcile uses to tell "admin deleted these" from "admin never received
+		these", so seeding it is what makes this a connected workspace rather than a
+		half-onboarded one.
+		"""
+		with (
+			patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
+			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
+		):
+			onboarding.save_llm_pool(frappe.as_json(_POOL), preset=None, routing_mode="failover")
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("llm_pool_synced_at", frappe.utils.now(), update_modified=False)
+		settings.db_set("last_sync_status", "ok", update_modified=False)
+		frappe.db.commit()
+
+	def _assert_pool_intact(self, why: str):
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(len(settings.get("models") or []), 2, why)
+		self.assertEqual(settings.models[0].get_password("api_key"), "sk-first", why)
+		self.assertGreaterEqual(_pool_auth_rows(), 2, why)
+		self.assertNotEqual(settings.get("last_sync_status") or "", "disconnected", why)
+
+	def _assert_fully_disconnected(self):
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.get("models") or [], [])
+		self.assertEqual(_pool_auth_rows(), 0, "the ciphertext has to go too, not just the rows")
+		self.assertFalse(
+			get_decrypted_password("Jarvis Settings", "Jarvis Settings", "llm_api_key", False),
+			"the legacy flat key must not survive in __Auth",
+		)
+		self.assertEqual(settings.get("llm_provider") or "", "")
+		self.assertEqual(settings.get("llm_model") or "", "")
+		self.assertEqual(settings.get("last_sync_status") or "", "disconnected")
+		self.assertIsNone(settings.get("llm_pool_synced_at"))
+		self.assertIsNone(settings.get("llm_direct_synced_at"))
+
+	def _split_the_planes(self):
+		"""Reproduce the defect: admin processed the disconnect, the bench never
+		learned. AdminUnreachableError is what a killed read looks like from here,
+		and disconnect_llm aborts on it BEFORE clearing anything locally."""
+		self._seed_connected_pool()
+		with patch(
+			"jarvis.admin_client.post_disconnect_llm",
+			side_effect=AdminUnreachableError("read timeout"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_llm()
+		self._assert_pool_intact("the split state is the premise of these tests")
+
+	# ---- it converges ----------------------------------------------------- #
+
+	def test_reconcile_finishes_a_disconnect_the_worker_did_not_survive(self):
+		self._split_the_planes()
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "Configuring",
+				"chat_readiness_reason": _ADMIN_DISCONNECTED_REASON,
+			},
+		):
+			reconcile_pending_llm_sync()
+		self._assert_fully_disconnected()
+
+	def test_reconcile_converges_without_re_driving_the_admin_disconnect(self):
+		"""Admin is already done - it said so. Calling its disconnect again would
+		spend the customer's shared 20/hour rotate-ops bucket on a container admin's
+		own reconcile is converging."""
+		self._split_the_planes()
+		with (
+			patch.object(
+				admin_client,
+				"get_connection",
+				return_value={
+					"chat_readiness": "Configuring",
+					"chat_readiness_reason": _ADMIN_DISCONNECTED_REASON,
+				},
+			),
+			patch.object(admin_client, "post_disconnect_llm") as post,
+		):
+			reconcile_pending_llm_sync()
+		post.assert_not_called()
+		self._assert_fully_disconnected()
+
+	def test_reconcile_is_idempotent(self):
+		self._split_the_planes()
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "Configuring",
+				"chat_readiness_reason": _ADMIN_DISCONNECTED_REASON,
+			},
+		) as conn:
+			reconcile_pending_llm_sync()
+			reconcile_pending_llm_sync()
+			reconcile_pending_llm_sync()
+		self._assert_fully_disconnected()
+		self.assertEqual(
+			conn.call_count,
+			1,
+			"a converged workspace holds no credential, so later ticks must not even probe admin",
+		)
+
+	# ---- and it does NOT clobber a working customer ------------------------ #
+
+	def test_a_connected_workspace_admin_reports_ready_is_untouched(self):
+		self._seed_connected_pool()
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={"chat_readiness": "Ready", "chat_readiness_reason": ""},
+		):
+			reconcile_pending_llm_sync()
+		self._assert_pool_intact("admin says Ready; there is nothing to converge")
+
+	def test_credentials_admin_never_received_are_not_destroyed(self):
+		"""THE clobber case, and the reason the confirmed-apply marker is required.
+
+		A customer types a key into a bench that cannot reach admin. Admin holds no
+		credential and says so in exactly the same words it uses after a disconnect -
+		but here that means "never received", not "deleted", and the key is real and
+		wanted. Without the marker gate the reconcile reads the two states
+		identically and wipes this one.
+		"""
+		self._seed_connected_pool()
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("llm_pool_synced_at", None, update_modified=False)
+		settings.db_set("last_sync_status", "failed: admin unreachable", update_modified=False)
+		frappe.db.commit()
+
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "Configuring",
+				"chat_readiness_reason": _ADMIN_DISCONNECTED_REASON,
+			},
+		):
+			reconcile_pending_llm_sync()
+		self._assert_pool_intact("an unproven first apply is not a disconnect")
+
+	def test_other_configuring_reasons_are_not_a_disconnect(self):
+		"""Every other Configuring reason describes a tenant whose credentials admin
+		still HAS. Reading any of them as "gone" would delete a working key."""
+		for reason in (
+			"applying your LLM configuration",
+			"ERP tools not connected",
+			"pool spec rejected: invalid_spec",
+			"still verifying your subscription route",
+			"",
+		):
+			with self.subTest(reason=reason):
+				self._clear_models()
+				_reset_settings()
+				self._seed_connected_pool()
+				with patch.object(
+					admin_client,
+					"get_connection",
+					return_value={"chat_readiness": "Configuring", "chat_readiness_reason": reason},
+				):
+					reconcile_pending_llm_sync()
+				self._assert_pool_intact(f"reason {reason!r} says nothing about credentials")
+
+	def test_a_probe_failure_is_never_read_as_disconnected(self):
+		self._seed_connected_pool()
+		with patch.object(admin_client, "get_connection", side_effect=AdminUnreachableError("boom")):
+			reconcile_pending_llm_sync()
+		self._assert_pool_intact("unknown is not disconnected")
+
+	# ---- the predicate itself --------------------------------------------- #
+
+	def test_admin_says_llm_gone_requires_the_configuring_state(self):
+		clause = _ADMIN_DISCONNECTED_REASON
+		self.assertTrue(_admin_says_llm_gone("Configuring", clause))
+		# Case-insensitive: the clause is admin's prose, not a protocol token.
+		self.assertTrue(_admin_says_llm_gone("Configuring", clause.upper()))
+		# A state that says nothing about credentials must never qualify - a
+		# suspended tenant in particular still owns its keys and gets them back.
+		for state in ("Ready", "Provisioning", "Suspended", "SupportRequired", "", None):
+			with self.subTest(state=state):
+				self.assertFalse(_admin_says_llm_gone(state, clause))
+		self.assertFalse(_admin_says_llm_gone("Configuring", None))
+		self.assertFalse(_admin_says_llm_gone("Configuring", "ERP tools not connected"))

--- a/jarvis/tests/test_disconnect_llm.py
+++ b/jarvis/tests/test_disconnect_llm.py
@@ -503,3 +503,24 @@ class TestDisconnectReconcile(_RT3SettingsTestCase):
 				self.assertFalse(_admin_says_llm_gone(state, clause))
 		self.assertFalse(_admin_says_llm_gone("Configuring", None))
 		self.assertFalse(_admin_says_llm_gone("Configuring", "ERP tools not connected"))
+
+	def test_a_reconnect_during_the_probe_discards_the_stale_verdict(self):
+		"""The narrow race the revision snapshot closes. Admin's answer is about the
+		connection the customer just replaced; acting on it would delete the
+		credential they entered while we were asking."""
+		self._split_the_planes()
+
+		def _reconnect_then_answer(*args, **kwargs):
+			# Stands in for the customer saving a new key between the probe leaving
+			# and its answer arriving. Any of the gate-revision fields will do.
+			settings = frappe.get_single("Jarvis Settings")
+			settings.db_set("last_sync_status", "pending: admin applying config", update_modified=False)
+			frappe.db.commit()
+			return {
+				"chat_readiness": "Configuring",
+				"chat_readiness_reason": _ADMIN_DISCONNECTED_REASON,
+			}
+
+		with patch.object(admin_client, "get_connection", side_effect=_reconnect_then_answer):
+			reconcile_pending_llm_sync()
+		self._assert_pool_intact("a verdict about a replaced connection must not be acted on")

--- a/jarvis/tests/test_disconnect_llm.py
+++ b/jarvis/tests/test_disconnect_llm.py
@@ -524,3 +524,34 @@ class TestDisconnectReconcile(_RT3SettingsTestCase):
 		with patch.object(admin_client, "get_connection", side_effect=_reconnect_then_answer):
 			reconcile_pending_llm_sync()
 		self._assert_pool_intact("a verdict about a replaced connection must not be acted on")
+
+	def test_a_workspace_reset_in_flight_is_not_a_disconnect(self):
+		"""A reset points the customer at a BRAND NEW container and deliberately
+		keeps the pool and the apply markers - _prepare_for_reset says clearing them
+		would eject the customer into the setup wizard. So between "new container
+		Running" and "re-pushed spec applied", admin truthfully reports no
+		credentials about a workspace whose markers are set. Firing there would
+		destroy a pool nobody asked to disconnect.
+		"""
+		from jarvis.onboarding import _RESETTING_RECONNECT_LLM_STATUS, _RESETTING_STATUS
+
+		for status in (_RESETTING_STATUS, _RESETTING_RECONNECT_LLM_STATUS):
+			with self.subTest(status=status):
+				self._clear_models()
+				_reset_settings()
+				self._seed_connected_pool()
+				settings = frappe.get_single("Jarvis Settings")
+				settings.db_set("last_sync_status", status, update_modified=False)
+				frappe.db.commit()
+
+				with patch.object(
+					admin_client,
+					"get_connection",
+					return_value={
+						"chat_readiness": "Configuring",
+						"chat_readiness_reason": _ADMIN_DISCONNECTED_REASON,
+					},
+				) as conn:
+					reconcile_pending_llm_sync()
+				self._assert_pool_intact("a reset must not be read as a disconnect")
+				conn.assert_not_called()

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -4219,16 +4219,52 @@ class TestConvergenceReconcile(_RT3SettingsTestCase):
 		)
 		self.assertTrue((settings.last_sync_status or "").startswith("ok"))
 
-	def test_reconcile_noop_on_healthy_tenant(self):
-		"""Inert on a healthy fleet: an 'ok' tenant is never probed or re-stamped."""
+	def test_reconcile_leaves_a_healthy_tenant_alone(self):
+		"""Inert on a healthy fleet: an 'ok' tenant is never re-stamped.
+
+		It IS probed, which this used to assert it was not. The disconnect leg
+		(#534) has to ask admin about a connected-looking workspace, because a bench
+		that lost a disconnect mid-flight looks exactly like a working one from the
+		inside - that indistinguishability is the whole defect. What must stay true
+		is that the answer changes nothing here, which is what this now pins.
+		"""
 		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
 			reconcile_pending_llm_sync,
 		)
 
 		self._seed_pool()
 		settings = frappe.get_single("Jarvis Settings")
-		settings.db_set("llm_pool_synced_at", frappe.utils.now(), update_modified=False)
+		synced_at = frappe.utils.now()
+		settings.db_set("llm_pool_synced_at", synced_at, update_modified=False)
 		settings.db_set("last_sync_status", "ok (pool_update via admin)", update_modified=False)
+		frappe.db.commit()
+		self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
+		with patch(
+			"jarvis.admin_client.get_connection",
+			return_value={"chat_readiness": "Ready", "chat_readiness_reason": ""},
+		):
+			reconcile_pending_llm_sync()
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.last_sync_status, "ok (pool_update via admin)")
+		self.assertEqual(str(settings.llm_pool_synced_at), str(synced_at))
+		self.assertEqual(len(settings.get("models") or []), 2)
+
+	def test_reconcile_never_probes_a_tenant_with_nothing_to_converge(self):
+		"""The cost gate on the disconnect leg. A workspace holding no credential
+		cannot be the losing half of a split disconnect and has no pending apply, so
+		the */5 tick must cost admin nothing at all for it."""
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+			reconcile_pending_llm_sync,
+		)
+
+		self._clear_models()
+		settings = frappe.get_single("Jarvis Settings")
+		for field in ("llm_provider", "llm_model", "llm_api_key"):
+			settings.db_set(field, "", update_modified=False)
+		settings.db_set("proxy_active", 0, update_modified=False)
+		settings.db_set("llm_pool_synced_at", None, update_modified=False)
+		settings.db_set("llm_direct_synced_at", None, update_modified=False)
+		settings.db_set("last_sync_status", "disconnected", update_modified=False)
 		frappe.db.commit()
 		self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
 		with patch("jarvis.admin_client.get_connection") as m:


### PR DESCRIPTION
## Summary

Closes #534.

`disconnect_llm` asks admin synchronously inside a whitelisted request and clears local
secrets only if it answers. Admin commits its blanked row before it touches the container,
so a worker killed anywhere after that commit left admin and the container disconnected
while the bench still held live keys and still advertised a model. Nothing converged it:
`reconcile_pending_llm_sync` only looked at pending/failed states, and a half-disconnected
workspace reads perfectly healthy locally.

This adds a disconnect leg to that `*/5` reconcile. It fires only when the bench still holds
a credential, the fleet **confirmed** an apply of that credential's leg, and admin reports
`Configuring` carrying its own no-credentials clause. Then it runs the same local clear the
endpoint runs, now shared as `onboarding.apply_local_disconnect`.

No bench-side intent flag: admin owns that state (jarvis-admin-v2 #136), and a local flag
would only move "did the worker survive long enough to write it" one field earlier.

Two further guards keep it off workspaces that are not disconnected at all: a revision
snapshot around the probe, so a customer who reconnects while we are waiting does not lose
the key they just entered, and a stand-aside while a workspace reset is in flight.

Who notices: a customer whose Disconnect appeared to fail now stops advertising a dead
model within five minutes instead of forever. Nobody else, by construction.

<details>
<summary>Root cause, and how the clobber risk is bounded</summary>

**Root cause.** The whole chain is bounded by gunicorn's `-t` (bench's `http_timeout`, unset
and so defaulting under supervisor), which sits *above* every client budget. PR #532 widened
`_DISCONNECT_TIMEOUT_S` to 240s so the bench stops giving up before admin can answer, but a
client budget cannot fix a ceiling above it. If the worker dies after admin's desired-first
commit, the bench never reaches `_clear_llm_secrets`. `admin_client.py` already prescribed
the fix in its own comment: converge from admin's own state on a later pass.

**What admin exposes.** No boolean crosses the wire. `get_connection` carries
`chat_readiness` plus `chat_readiness_reason`, and admin's `compute_chat_readiness`
(`jarvis_admin_v2/fleet/pool.py`) appends "waiting for an LLM key or subscription" exactly
when `_llm_creds_ready(row)` is false, i.e. no api key, no pool config, no oauth blob.
`_persist_disconnected` blanks all three as a committed desired generation, so that clause
is present from the moment admin has processed a disconnect. Matching a sentence is not
something to do lightly here, so note the failure direction: if admin rewords it the branch
stops firing and we are back to today's behaviour. It can never start firing on a workspace
admin is happy with.

**The clobber guard.** Admin also reports no credentials when it never *received* any, which
is a customer who typed a key into a bench that could not reach admin. Their key is real and
must not be destroyed. The discriminator is `account._llm_apply_confirmed`, the same
confirmed-apply marker `is_ready_for_chat` opens chat on and the Connection badge colours
itself from: it is stamped only when the fleet confirmed the apply, and only a completed
disconnect clears it. Deleted keys have it, never-received keys do not. Reusing `account`'s
predicates rather than restating them is deliberate, so this branch cannot reach a different
conclusion about "connected" than the rest of the app.

**The reset hazard, found by tracing rather than by a test.** A reset points the customer at
a brand new container and deliberately keeps the pool and the `*_synced_at` markers;
`_prepare_for_reset` says clearing them would eject the customer into the setup wizard. So
between "new container Running" and "re-pushed spec applied", admin truthfully reports no
credentials about a workspace whose markers are set, and both other guards pass. This leg
would have destroyed a pool nobody asked to disconnect, mid-reset. It now stands aside until
`reconcile_pending_workspace_reset` has finished.

Seven of the ten new tests exist for this half. Revert-proof: with only the reconcile wiring
reverted, the two convergence tests fail and every guard stays green; with only the revision
snapshot or the reset guard reverted, their tests destroy both pool models.

**Cost, stated plainly.** The new precondition is true of every healthy connected workspace,
so those now spend one extra `get_connection` per `*/5` tick. That is unavoidable: a bench
that lost the disconnect is indistinguishable from a working one from the inside, which is
the defect. It is the same cheap read the SPA already makes far more often, and the
unconditional `push_bench_heartbeat` on the same tick sets the precedent. A workspace holding
no credential still skips the probe entirely, and there is a test pinning that.

`test_reconcile_noop_on_healthy_tenant` asserted the old "never probed" contract and was
re-pinned onto what must actually stay true (the answer changes nothing). Hosted CI shard 4
caught it; the module's local serial run only executes one test category and skips that class
entirely, so run it with `--case TestConvergenceReconcile`.

</details>

## Pre-merge checklist

- [x] **CI is green** - lint, frontend-tests, coverage and all 4 `tests` shards pass
- [x] Branch is **up to date with `develop`** (based on `upstream/develop` at 1947150)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
