### PR TITLE
chore(macros): remove dead macro-merge poll/apply/discard endpoints

### DIFF
--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -16,7 +16,6 @@ from jarvis.permissions import require_jarvis_user
 
 MACRO = "Jarvis Macro"
 RUN = "Jarvis Macro Run"
-MSG = "Jarvis Chat Message"
 
 
 def _parse_steps(steps) -> list[dict]:
@@ -519,8 +518,14 @@ def macro_run_stats() -> dict:
 # Macro merge — summarize a 2+ step sequence into one prompt (spec:
 # docs/superpowers/specs/2026-07-03-macro-merge-design.md). The LLM does the
 # merging via the persona /macro-merge skill in a throwaway archived
-# conversation; these endpoints are the deterministic plumbing around it.
+# conversation; this endpoint kicks it off. The SPA reads the result straight
+# off the Macro doc (merge_status/merged_prompt) once the worker's advance
+# hook applies it — there is no separate poll/apply/discard surface.
 # --------------------------------------------------------------------------- #
+# NOTE: _MERGE_RE has no caller in THIS module — jarvis.chat.macros
+# (_apply_merge_after_turn, off-limits here) lazily imports it to parse the
+# assistant reply's ```jarvis-macro-merge``` block. Keep it even though it
+# looks locally dead.
 _MERGE_RE = re.compile(r"```jarvis-macro-merge[ \t]*\n([\s\S]*?)```")
 
 _MERGE_INSTRUCTION = (
@@ -535,14 +540,6 @@ _MERGE_INSTRUCTION = (
 	"mergeable=false when merging would lose a user review checkpoint before "
 	"a data change. Steps:\n\n"
 )
-
-
-def _own_conversation(conversation: str) -> None:
-	owner = frappe.db.get_value("Jarvis Conversation", conversation, "owner")
-	if not owner:
-		frappe.throw(_("Unknown conversation."))
-	if owner != frappe.session.user:
-		frappe.throw(_("Not your conversation."), frappe.PermissionError)
 
 
 @frappe.whitelist()
@@ -601,95 +598,3 @@ def summarize_macro(name: str) -> dict:
 	)
 	frappe.db.commit()
 	return {"ok": True, "conversation": conv.name}
-
-
-@frappe.whitelist()
-@require_jarvis_user
-def get_macro_merge(conversation: str) -> dict:
-	"""Poll target for the merge turn: pending → ready(merge)/error."""
-	_own_conversation(conversation)
-	rows = frappe.get_all(
-		MSG,
-		filters={"conversation": conversation, "role": "assistant"},
-		fields=["content", "streaming", "error"],
-		order_by="seq desc",
-		limit=1,
-	)
-	m = rows[0] if rows else None
-	if m and (m.error or "").strip():
-		return {"status": "error", "error": m.error}
-	if not m or m.streaming or not (m.content or "").strip():
-		return {"status": "pending"}
-	mt = _MERGE_RE.search(m.content)
-	if not mt:
-		return {"status": "error", "error": "no merge block in the reply"}
-	try:
-		merge = frappe.parse_json(mt.group(1).strip())
-	except Exception:
-		merge = None
-	if not isinstance(merge, dict):
-		return {"status": "error", "error": "unparsable merge block"}
-	return {
-		"status": "ready",
-		"merge": {
-			"mergeable": bool(merge.get("mergeable")),
-			"reason": str(merge.get("reason") or ""),
-			"merged_prompt": str(merge.get("merged_prompt") or ""),
-			"dependencies": merge.get("dependencies") if isinstance(merge.get("dependencies"), list) else [],
-		},
-	}
-
-
-@frappe.whitelist()
-@require_jarvis_user
-def apply_macro_merge(name: str, merged_prompt: str, conversation: str = "") -> dict:
-	"""Store ``merged_prompt`` (possibly user-edited) on the macro. The step
-	sequence STAYS as the editable source of truth — but when a merged prompt
-	is set, ``run_macro`` runs IT as a single turn instead of chaining the
-	steps. Cleans up the merge conversation best-effort."""
-	doc = frappe.get_doc(MACRO, name)
-	doc.check_permission("write")
-	merged_prompt = (merged_prompt or "").strip()
-	if not merged_prompt:
-		frappe.throw(_("Merged prompt is empty."))
-	doc.merged_prompt = merged_prompt
-	doc.merge_status = "ready"
-	doc.merge_conversation = ""
-	doc.save()
-	frappe.db.commit()
-	if conversation:
-		try:
-			discard_macro_merge(conversation)
-		except Exception:
-			pass  # best-effort cleanup; the conversation is archived anyway
-	return {"ok": True, "merged": True, "step_count": len(doc.steps or [])}
-
-
-@frappe.whitelist()
-@require_jarvis_user
-def clear_macro_merge(name: str) -> dict:
-	"""Remove the stored merged prompt so the step sequence runs again."""
-	doc = frappe.get_doc(MACRO, name)
-	doc.check_permission("write")
-	doc.merged_prompt = ""
-	doc.merge_status = ""
-	doc.merge_conversation = ""
-	doc.save()
-	frappe.db.commit()
-	return {"ok": True}
-
-
-@frappe.whitelist()
-@require_jarvis_user
-def discard_macro_merge(conversation: str) -> dict:
-	"""Delete the throwaway merge conversation + its messages (Keep sequence /
-	unmergeable / error paths). Best-effort: if a link blocks the delete the
-	conversation stays archived, which is invisible anyway."""
-	_own_conversation(conversation)
-	frappe.db.delete(MSG, {"conversation": conversation})
-	try:
-		frappe.delete_doc("Jarvis Conversation", conversation, force=True, ignore_permissions=True)
-	except Exception:
-		pass
-	frappe.db.commit()
-	return {"ok": True}

--- a/jarvis/tests/test_macro_merge.py
+++ b/jarvis/tests/test_macro_merge.py
@@ -1,10 +1,10 @@
 """Tests for the macro-merge surface (summarize a step sequence into one prompt).
 
 The LLM summarize turn itself is exercised by the live smoke; these tests
-cover the deterministic plumbing: enqueue + throwaway conversation, the poll
-state machine parsing the jarvis-macro-merge block, and the apply that
-collapses the steps (skills union, first non-empty overrides), all
-owner-gated.
+cover the deterministic plumbing: enqueue + throwaway conversation, the
+worker-side apply that lands the summary on the macro doc, and running the
+merged prompt as a single turn (skills union, first non-empty overrides),
+all owner-gated.
 """
 
 from __future__ import annotations
@@ -14,12 +14,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.chat.macros_api import (
-	apply_macro_merge,
-	discard_macro_merge,
-	get_macro_merge,
-	summarize_macro,
-)
+from jarvis.chat.macros_api import summarize_macro, update_macro
 
 MERGE_BLOCK = (
 	"Here you go:\n\n```jarvis-macro-merge\n"
@@ -122,58 +117,13 @@ class TestSummarizeMacro(_MacroMergeBase):
 			summarize_macro(m.name)
 
 
-class TestGetMacroMerge(_MacroMergeBase):
-	def _cleanup_conv(self, conv):
-		self.addCleanup(
-			lambda: (
-				frappe.db.delete("Jarvis Chat Message", {"conversation": conv}),
-				frappe.delete_doc("Jarvis Conversation", conv, force=True, ignore_permissions=True),
-			)
-		)
+class TestUpdateMacroSummary(_MacroMergeBase):
+	"""update_macro is the sole surviving surface that writes merged_prompt from
+	the SPA (the poll/apply/clear/discard merge endpoints were removed as dead
+	REST surface - jarvis#474 - once the UI moved to reading merge_status /
+	merged_prompt straight off get_macro and editing the summary as a plain
+	form field)."""
 
-	def test_pending_when_no_reply(self):
-		conv = _mk_conv(assistant=None)
-		self._cleanup_conv(conv)
-		self.assertEqual(get_macro_merge(conv)["status"], "pending")
-
-	def test_pending_while_streaming(self):
-		conv = _mk_conv(assistant="partial", streaming=1)
-		self._cleanup_conv(conv)
-		self.assertEqual(get_macro_merge(conv)["status"], "pending")
-
-	def test_error_from_turn_error(self):
-		conv = _mk_conv(assistant="", error="quota exceeded")
-		self._cleanup_conv(conv)
-		r = get_macro_merge(conv)
-		self.assertEqual(r["status"], "error")
-		self.assertIn("quota", r["error"])
-
-	def test_error_when_no_block(self):
-		conv = _mk_conv(assistant="I could not do that.")
-		self._cleanup_conv(conv)
-		self.assertEqual(get_macro_merge(conv)["status"], "error")
-
-	def test_ready_parses_block(self):
-		conv = _mk_conv(assistant=MERGE_BLOCK)
-		self._cleanup_conv(conv)
-		r = get_macro_merge(conv)
-		self.assertEqual(r["status"], "ready")
-		self.assertTrue(r["merge"]["mergeable"])
-		self.assertIn("Using the results of (1)", r["merge"]["merged_prompt"])
-		self.assertEqual(r["merge"]["dependencies"], [{"step": 2, "uses": [1]}])
-
-	def test_ownership_enforced(self):
-		conv = _mk_conv(assistant=MERGE_BLOCK)
-		self._cleanup_conv(conv)
-		frappe.set_user("Guest")
-		try:
-			with self.assertRaises(frappe.PermissionError):
-				get_macro_merge(conv)
-		finally:
-			frappe.set_user("Administrator")
-
-
-class TestApplyMacroMerge(_MacroMergeBase):
 	def test_stores_summary_and_keeps_steps(self):
 		# The sequence stays as the editable source; the summary rides alongside
 		# and (see TestMergedRun) is what run_macro executes.
@@ -187,40 +137,31 @@ class TestApplyMacroMerge(_MacroMergeBase):
 		self.addCleanup(
 			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
 		)
-		r = apply_macro_merge(m.name, "Do p1, and from those results p2, then p3.")
-		self.assertEqual(r["step_count"], 3)  # steps untouched
+		update_macro(m.name, merged_prompt="Do p1, and from those results p2, then p3.")
 		doc = frappe.get_doc("Jarvis Macro", m.name)
-		self.assertEqual(len(doc.steps), 3)
+		self.assertEqual(len(doc.steps), 3)  # steps untouched
 		self.assertEqual([s.prompt for s in doc.steps], ["p1", "p2", "p3"])
 		self.assertIn("from those results", doc.merged_prompt)
+		self.assertEqual(doc.merge_status, "ready")
 
-	def test_empty_prompt_refused(self):
+	def test_clearing_merged_prompt_clears_merge_status(self):
 		m = _mk_macro([{"prompt": "p1"}, {"prompt": "p2"}])
 		self.addCleanup(
 			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
 		)
-		with self.assertRaises(frappe.ValidationError):
-			apply_macro_merge(m.name, "   ")
-
-	def test_clear_macro_merge(self):
-		m = _mk_macro([{"prompt": "p1"}, {"prompt": "p2"}])
-		self.addCleanup(
-			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
-		)
-		apply_macro_merge(m.name, "the summary")
-		from jarvis.chat.macros_api import clear_macro_merge
-
-		clear_macro_merge(m.name)
+		update_macro(m.name, merged_prompt="the summary")
+		update_macro(m.name, merged_prompt="")
 		self.assertEqual(frappe.db.get_value("Jarvis Macro", m.name, "merged_prompt") or "", "")
+		self.assertEqual(frappe.db.get_value("Jarvis Macro", m.name, "merge_status") or "", "")
 
 	def test_update_steps_clears_stale_summary(self):
-		from jarvis.chat.macros_api import get_macro, update_macro
+		from jarvis.chat.macros_api import get_macro
 
 		m = _mk_macro([{"prompt": "p1"}, {"prompt": "p2"}])
 		self.addCleanup(
 			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
 		)
-		apply_macro_merge(m.name, "the summary")
+		update_macro(m.name, merged_prompt="the summary")
 		# steps replaced without a merged_prompt in the same call → summary is stale → cleared
 		update_macro(m.name, steps=frappe.as_json([{"prompt": "p1 changed"}, {"prompt": "p2"}]))
 		self.assertEqual(get_macro(m.name)["merged_prompt"], "")
@@ -307,7 +248,7 @@ class TestMergedRun(_MacroMergeBase):
 		self.addCleanup(
 			lambda: frappe.delete_doc("Jarvis Macro", m.name, force=True, ignore_permissions=True)
 		)
-		apply_macro_merge(m.name, "One prompt to rule them all.")
+		update_macro(m.name, merged_prompt="One prompt to rule them all.")
 		with patch("jarvis.chat.api._enqueue_turn") as enq:
 			r = macros.run_macro(m.name)
 		run_name = r["data"]["macro_run"]
@@ -346,14 +287,6 @@ class TestMergedRun(_MacroMergeBase):
 		enq.assert_called_once()  # step 1 enqueued; the chain advances per turn
 		self.assertTrue(enq.call_args[0][1].startswith("p1"))
 		self.assertEqual(frappe.get_doc("Jarvis Macro Run", run_name).total_steps, 2)
-
-
-class TestDiscardMacroMerge(FrappeTestCase):
-	def test_deletes_conversation_and_messages(self):
-		conv = _mk_conv(assistant=MERGE_BLOCK)
-		discard_macro_merge(conv)
-		self.assertFalse(frappe.db.exists("Jarvis Conversation", conv))
-		self.assertEqual(frappe.db.count("Jarvis Chat Message", {"conversation": conv}), 0)
 
 
 class TestMacroCapacityDefer(_MacroMergeBase):


### PR DESCRIPTION
## Summary

Removes four whitelisted `macros_api.py` endpoints (`get_macro_merge`, `apply_macro_merge`,
`clear_macro_merge`, `discard_macro_merge`) that have had zero callers since the macro
merge UI switched to reading `merge_status`/`merged_prompt` straight off `get_macro`,
editing the summary as a plain form field, and using `update_macro` to save it - there is
no code path left, in this app or any other Aerele-RnD/jarvis plane, that hits any of the
four. `get_macro_run` is kept (see PR body below). Nobody outside this repo notices;
inside it, the SPA's macro merge flow is unchanged because it never used these four.

## Search performed (proving dead-ness)

Grepped for each of the five names literally, repo-wide:

- `frontend/src`, `pwa`, `jarvis/public`, `jarvis/www`, `jarvis/templates` - zero hits
  outside the definitions themselves and `frontend/src/api.js`'s `MC` wrapper block
  (which only exports list/get/create/update/delete/run/stop/list_runs/stats/summarize).
- `jarvis-openclaw-plugin/src` and `jarvis-persona` (separate repos) - zero hits. The
  persona `/macro-merge` skill referenced by `summarize_macro`'s prompt is the LLM-side
  instruction that *produces* the merge block; it never calls back into these REST
  endpoints.
- `jarvis_admin` (admin-v2) and `jarvis-fleet-agent` - zero hits (checked as a sanity
  extra, not required by the issue).
- Read `frontend/src/pages/macros/MacroDetail.vue`: the current UI edits
  `form.merged_prompt` directly and saves it via `updateMacro`, and refreshes state via
  `getMacro` on a `macro:merged` socket event - never via `get_macro_merge` polling or
  `apply_macro_merge`/`clear_macro_merge`.
- One near-miss: `discard_macro_merge` DID have an internal Python caller -
  `apply_macro_merge` called it directly (not through the whitelist boundary). Since
  `apply_macro_merge` is itself dead, that call site goes with it.
- A second, more dangerous near-miss: `_MERGE_RE` (a module-level regex, not one of the
  five endpoints) looked locally unused after deleting `get_macro_merge`, but
  `jarvis/chat/macros.py` (`_apply_merge_after_turn`, off-limits for this PR) lazily
  imports it to parse the summarize turn's reply. Deleting it broke that worker-side
  apply silently (caught by a broad `except Exception` there) - caught by the bench
  tests, not by grepping macros.py's imports alone; **kept `_MERGE_RE`** with a comment
  explaining the cross-file dependency.

## `get_macro_run` - kept

Also whitelisted with zero current callers, but unlike the four merge endpoints it is
not superseded by a different, already-shipped design - it is a plain "current run
state" read mirroring exactly what `ChatView.vue`'s live macro banner gets from socket
events, framed in its own docstring as a socketio-fallback poll. The same repo already
has that exact pattern shipped and wired up for a different resource (queued turns:
`getQueuePosition` / `refreshQueuePositionOnFocus`, SUX-2), so this reads as a
plausible, cheap (owner-gated, single doc read), not-yet-wired resilience seam rather
than vestigial code from a superseded flow. Left in place.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on FAIL)
- [x] Branch is up to date with `develop` (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi

Closes #474
