### PR TITLE
fix(macros): surface waiting_capacity in the Runs tab

### DIFF
--- a/frontend/src/pages/macros/RunsTab.vue
+++ b/frontend/src/pages/macros/RunsTab.vue
@@ -87,7 +87,11 @@
 				<template v-else-if="column.key === '_actions'">
 					<div class="flex w-full items-center justify-end gap-1" @click.stop.prevent>
 						<Button
-							v-if="row.status === 'running' || row.status === 'queued'"
+							v-if="
+								row.status === 'running' ||
+								row.status === 'queued' ||
+								row.status === 'waiting_capacity'
+							"
 							variant="ghost"
 							theme="red"
 							icon="square"
@@ -175,6 +179,7 @@ const STATUS_OPTIONS = [
 	{ label: "All statuses", value: "" },
 	{ label: "Queued", value: "queued" },
 	{ label: "Running", value: "running" },
+	{ label: "Waiting for capacity", value: "waiting_capacity" },
 	{ label: "Completed", value: "completed" },
 	{ label: "Failed", value: "failed" },
 	{ label: "Stopped", value: "stopped" },
@@ -182,9 +187,14 @@ const STATUS_OPTIONS = [
 const RUN_THEMES = {
 	queued: "gray",
 	running: "blue",
+	waiting_capacity: "orange", // parked, not failed - matches the merge_status "pending" badge elsewhere in Macros
 	completed: "green",
 	failed: "red",
 	stopped: "gray",
+};
+// Statuses whose display label isn't just a capitalized value (e.g. waiting_capacity).
+const STATUS_LABELS = {
+	waiting_capacity: "Waiting for capacity",
 };
 
 const columns = [
@@ -339,7 +349,8 @@ onBeforeUnmount(() => {
 
 // ── formatters ───────────────────────────────────────────────────────────────
 function statusLabel(s) {
-	return s ? s.charAt(0).toUpperCase() + s.slice(1) : "";
+	if (!s) return "";
+	return STATUS_LABELS[s] || s.charAt(0).toUpperCase() + s.slice(1);
 }
 function fmtDuration(sec) {
 	if (sec == null) return "";


### PR DESCRIPTION
## Summary

RunsTab.vue now treats `waiting_capacity` as a first-class run status: the Stop button
shows for it, it is filterable in the status dropdown, and its badge reads "Waiting for
capacity" in orange instead of falling back to a gray badge with the raw enum value
"Waiting_capacity". Anyone viewing Macros > Runs while a run is parked on capacity
notices: they can now filter to it, read its state correctly, and stop it.

## Colour choice

Orange, matching `theme="orange"` already used for the macro merge "pending"
(summarizing) badge in `MacrosList.vue` and `MacroDetail.vue` - this codebase's existing
convention for "a background process is holding this up, not an error." Red (failed) and
gray (queued/stopped, neutral) both read wrong for a state that is actively retrying and
will resolve on its own.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on FAIL)
- [x] Branch is up to date with `develop` (so it is tested against the latest code)
- [ ] New/changed behavior has tests - RunsTab.vue has no existing test harness
      (mounting it pulls in LayoutHeader/ListView/router/sockets); ran the full
      frontend suite instead to confirm no regressions (see PR comment)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi

Closes #476
