### PR TITLE
fix(learning): freeze the approved pattern draft so re-detection cannot ship unreviewed text

### DIFF
--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -43,6 +43,7 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, now_datetime, today
 
+from jarvis.learning.lifecycle import REDRAFT_STALE_PREFIX
 from jarvis.permissions import JARVIS_REVIEWER_ROLES, require_jarvis_admin
 
 JLP = "Jarvis Learned Pattern"
@@ -566,6 +567,10 @@ def get_learned_pattern(name: str) -> dict:
 		"roles": [r.role for r in (doc.roles or [])],
 		"pattern_statement": doc.pattern_statement or "",
 		"skill_draft": doc.skill_draft or "",
+		"approved_draft": doc.get("approved_draft") or "",
+		# What re-detection has changed since the approval, so a reviewer looking
+		# at a redraft-staled row sees exactly which words moved (#482).
+		"approved_draft_diff": _approved_draft_diff(doc),
 		"draft_edited": int(doc.draft_edited or 0),
 		"draft_polished": int(doc.get("draft_polished") or 0),
 		"compiled_preview": _compiled_preview(doc),
@@ -608,6 +613,16 @@ def get_learned_pattern(name: str) -> dict:
 	}
 
 
+def _approved_draft_diff(doc) -> str:
+	"""Unified diff of the frozen approved text vs the latest detected draft.
+	Empty when the row was never approved or nothing moved - reuses the shared
+	``_unified_diff`` the go-to-chat bundle already renders."""
+	approved = (doc.get("approved_draft") or "").strip()
+	if not approved:
+		return ""
+	return _unified_diff(approved, (doc.skill_draft or "").strip(), "approved text", "latest detected draft")
+
+
 def _compiled_preview(doc) -> str:
 	"""The exact bullet THIS pattern would compile into (drill-down preview).
 	Uses ``compiler.preview_bullet(pattern_name)`` - the single-bullet renderer;
@@ -643,7 +658,14 @@ def _load_for_transition(name: str, allowed_sources: tuple, action: str):
 def approve_learned_pattern(name: str, edited_skill_draft: str | None = None) -> dict:
 	"""Proposed->Approved (or Stale->Approved). Optional edit freezes the
 	evidence line (section 6.5): ``draft_edited=1`` and the frozen label is shown
-	on the board. Stamps reviewed_by / approved_by / reviewed_at."""
+	on the board. Stamps reviewed_by / approved_by / reviewed_at.
+
+	Approval also FREEZES the reviewed text into ``approved_draft`` (#482). The
+	compiler ships that snapshot, never the live ``skill_draft`` - nightly
+	re-detection rewrites ``skill_draft`` in place on any row that is not
+	SM-edited or LLM-polished, so without the snapshot a plain "looks good"
+	approve could be silently reworded (e.g. "mostly supplies" -> "supplies
+	only") and pushed org-wide unreviewed."""
 	_guard()
 	doc = _load_for_transition(name, ("Proposed", "Stale"), "approve")
 
@@ -668,11 +690,13 @@ def approve_learned_pattern(name: str, edited_skill_draft: str | None = None) ->
 	# writes clamp to it) and a flag-origin stale_reason; drift-origin reasons
 	# are left for the drift pass to manage.
 	doc.flag_band_cap = ""
-	if (doc.stale_reason or "").startswith(_FLAG_STALE_PREFIX):
+	if (doc.stale_reason or "").startswith((_FLAG_STALE_PREFIX, REDRAFT_STALE_PREFIX)):
 		doc.stale_reason = None
 
 	now = now_datetime()
 	doc.status = "Approved"
+	# Freeze what this reviewer actually read: the compiler reads approved_draft.
+	doc.approved_draft = (doc.skill_draft or "").strip()
 	doc.reviewed_by = frappe.session.user
 	doc.approved_by = frappe.session.user
 	doc.reviewed_at = now
@@ -740,6 +764,8 @@ def unapprove_learned_pattern(name: str) -> dict:
 	doc = _load_for_transition(name, ("Approved",), "un-approve")
 	doc.status = "Proposed"
 	doc.approved_by = None
+	# The approval is withdrawn, so the frozen reviewed text goes with it.
+	doc.approved_draft = None
 	doc.save()
 	frappe.db.commit()
 	return {"ok": True, "status": doc.status}

--- a/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
+++ b/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
@@ -14,6 +14,7 @@
     "company",
     "pattern_statement",
     "skill_draft",
+    "approved_draft",
     "draft_edited",
     "draft_polished",
     "support_n",
@@ -99,6 +100,13 @@
       "fieldtype": "Long Text",
       "label": "Skill Draft",
       "reqd": 1
+    },
+    {
+      "fieldname": "approved_draft",
+      "fieldtype": "Long Text",
+      "label": "Approved Draft",
+      "read_only": 1,
+      "description": "The exact bullet text a reviewer approved, frozen at approve time. The compiler ships THIS, never the live skill_draft (which nightly re-detection rewrites in place), so no unreviewed wording can reach the pushed learned skills. Re-stamped on every approve; cleared on un-approve."
     },
     {
       "default": "0",

--- a/jarvis/learning/compiler.py
+++ b/jarvis/learning/compiler.py
@@ -155,6 +155,7 @@ def compile_domain_skills() -> dict:
 			"company",
 			"pattern_statement",
 			"skill_draft",
+			"approved_draft",
 			"strength_band",
 			"support_n",
 			"detector_id",
@@ -208,7 +209,7 @@ def preview_bullet(pattern_name: str) -> str:
 	row = frappe.db.get_value(
 		JLP,
 		pattern_name,
-		["name", "domain", "skill_draft", "pattern_statement"],
+		["name", "domain", "skill_draft", "approved_draft", "pattern_statement"],
 		as_dict=True,
 	)
 	if not row:
@@ -592,9 +593,16 @@ def _interplay_lines(domain: str) -> list[str]:
 
 def _bullet(row: dict) -> str:
 	"""One compiled bullet: sanitized draft + JLP ref. Injection-shaped drafts
-	are withheld with a board pointer rather than embedded (plan section 6.3)."""
+	are withheld with a board pointer rather than embedded (plan section 6.3).
+
+	Source of truth is ``approved_draft`` - the text frozen when a human
+	approved it (#482). ``skill_draft`` is the LIVE detector render and is
+	rewritten in place by every re-detection, so compiling from it shipped
+	wording no one reviewed. Rows with no snapshot (Proposed previews, and
+	rows approved before the snapshot existed / before the backfill ran) fall
+	back to the live draft, then to the statement."""
 	name = row["name"]
-	draft = (row.get("skill_draft") or "").strip()
+	draft = (row.get("approved_draft") or "").strip() or (row.get("skill_draft") or "").strip()
 	if not draft:
 		draft = "- " + (row.get("pattern_statement") or "").strip()
 

--- a/jarvis/learning/engine.py
+++ b/jarvis/learning/engine.py
@@ -21,12 +21,21 @@ Pattern fields:
 
     {
       "detector_id":          str,   # registry id, e.g. "buy-supplier-stockness"
-      "pattern_key":          str,   # REQUIRED, unique dedupe key (detector + company + antecedent + consequent)
+      # REQUIRED, unique dedupe key: sha1(detector_id | antecedent_value |
+      # company) - see executor._pattern_key. The CONSEQUENT is NOT part of the
+      # key (a detector emits at most one candidate per antecedent, so there is
+      # no duplicate to collide with), which also means a later run can carry a
+      # DIFFERENT consequent into the SAME row. Approved rows are protected
+      # from that by approved_draft + lifecycle's redraft staling (#482).
+      "pattern_key":          str,
       "domain":               str,   # selling|buying|stock|accounts|projects|org
       "company":              str|None,
       "roles":                list[str],   # detected role names -> Jarvis Learned Pattern Role child rows (insert only)
       "pattern_statement":    str,   # REQUIRED, plain-English sentence
       "skill_draft":          str,   # REQUIRED, deterministic template body (never overwritten once draft_edited=1)
+                                     # NOTE: this is the LIVE draft. What an
+                                     # approved pattern COMPILES from is the
+                                     # frozen approved_draft snapshot (#482).
       "support_n":            int,   # n_units (independent units, never child rows)
       "n_rows":               int,   # raw rows (drill-down only)
       "exception_n":          int,
@@ -703,6 +712,10 @@ def _apply_evidence(doc, cand: dict, run, *, is_new: bool) -> None:
 	# Never overwrite an SM-edited draft (draft_edited freezes it, plan 6.5)
 	# or an LLM-polished one (draft_polished - the polished wording must
 	# survive re-detection and approval; evidence below stays un-frozen).
+	# An APPROVED row's draft is still refreshed here on purpose: the reviewed
+	# text lives in the untouched approved_draft snapshot (what the compiler
+	# ships), so skill_draft stays the current detected wording that the board
+	# diffs against, and lifecycle stales the row when the two diverge (#482).
 	if is_new or not (doc.draft_edited or doc.get("draft_polished")):
 		doc.skill_draft = (cand.get("skill_draft") or "").strip() or doc.pattern_statement
 

--- a/jarvis/learning/lifecycle.py
+++ b/jarvis/learning/lifecycle.py
@@ -457,7 +457,16 @@ def revalidate_active(run=None, patterndb=None, mined=None) -> dict:
 		],
 	)
 	out = {"revalidated": 0, "staled": 0, "version_skipped": 0, "unchecked": 0, "cap_deferred": 0}
+	# Rows this run's mining already staled for redraft drift (#482) ride the
+	# SAME summary notification - the mining loop stashes them precisely so they
+	# never become one Notification Log per pattern. Drained BEFORE the
+	# empty-rows return: mining may have staled every Approved/Active row, which
+	# is exactly when `rows` is empty.
+	staled_lines: list[str] = _drain_redraft_stale()
+	out["staled"] += len(staled_lines)
 	if not rows:
+		if staled_lines:
+			_notify_stale(staled_lines)
 		return out
 
 	groups: dict = {}
@@ -465,7 +474,6 @@ def revalidate_active(run=None, patterndb=None, mined=None) -> dict:
 		groups.setdefault((r.detector_id, r.company), []).append(r)
 
 	now = now_datetime()
-	staled_lines: list[str] = []
 	for (detector_id, company), patterns in groups.items():
 		if mined is None and _revalidation_window_closed(run):
 			# Respect the analysis window on the SLOW (checker-re-run) path
@@ -559,13 +567,6 @@ def revalidate_active(run=None, patterndb=None, mined=None) -> dict:
 				out["staled"] += 1
 				staled_lines.append(f"{row.name}: {reason}")
 
-	# Rows this run's mining already staled for redraft drift ride the SAME
-	# summary notification (#482) - the mining loop stashes them precisely so
-	# they do not become one Notification Log per pattern.
-	redraft_lines = _drain_redraft_stale()
-	if redraft_lines:
-		staled_lines.extend(redraft_lines)
-		out["staled"] += len(redraft_lines)
 	if staled_lines:
 		_notify_stale(staled_lines)
 	if out["revalidated"] or out["version_skipped"]:

--- a/jarvis/learning/lifecycle.py
+++ b/jarvis/learning/lifecycle.py
@@ -27,7 +27,15 @@ Rules (plan section 6.5):
     and moves undetectable / below-threshold / recency-diverged rows to Stale
     (+ ONE summary Notification Log to System Managers). Never a silent edit:
     Stale rows drop out of the next compile (the compiler filters Approved/
-    Active) and the board shows the reason.
+    Active) and the board shows the reason;
+  * REDRAFT drift (#482): the evidence refresh above rewrites ``skill_draft``
+    in place, and the detector's own wording can flip meaning while every
+    statistical axis IMPROVES (the strict "-only" template variant swaps in at
+    n>=60 with zero exceptions, so "mostly supplies" becomes "supplies only"),
+    which ``revalidate_active`` can never catch. An approved row therefore
+    carries an ``approved_draft`` snapshot (the compiler ships that, not the
+    live draft), and ``upsert_candidate`` moves the row to Stale the moment
+    the freshly detected RULE sentence stops matching the approved one.
 """
 
 from __future__ import annotations
@@ -50,6 +58,17 @@ REJECTED_TTL_DAYS = 180
 SUPERSEDED_TTL_DAYS = 90
 
 _MAX_NOTE_LEN = 500
+
+# Redraft drift (#482). Statuses whose text a human signed off on, and the
+# stale_reason prefix stamped when re-detection stops matching that text
+# (learned_api.approve_learned_pattern clears reasons with this prefix, since
+# re-approving IS the resolution).
+_APPROVED_STATUSES = frozenset({"Approved", "Active"})
+REDRAFT_STALE_PREFIX = "the detected rule changed after approval"
+# skill_drafts.render_skill_draft joins the rule sentence to its evidence
+# sentence with this marker. Everything after it is measured numbers that move
+# on every run, so only the head is compared.
+_EVIDENCE_MARKER = " Evidence: "
 
 # Overlap check: ignore short/common words so a warning means real shared wording.
 _OVERLAP_MIN_SHARED = 3
@@ -154,10 +173,20 @@ def upsert_candidate(candidate: dict, run) -> str:
 		else:
 			# Proposed / Approved / Active / Snoozed / Stale: refresh evidence in place.
 			doc = frappe.get_doc(JLP, existing)
+			# Read BEFORE the refresh: _apply_evidence overwrites the statement
+			# and clears draft_polished, so the pre-refresh row is the only
+			# place the approved-vs-detected comparison can be made.
+			redraft = _redraft_reason(doc, candidate)
 			with _engine_flag():
 				eng._apply_evidence(doc, candidate, run, is_new=False)
 				_set_overlap(doc)
+				if redraft:
+					doc.status = "Stale"
+					doc.stale_reason = redraft[:_MAX_NOTE_LEN]
+					doc.last_validated_at = now_datetime()
 				doc.save(ignore_permissions=True)
+			if redraft:
+				_record_redraft_stale(f"{doc.name}: {redraft}")
 			result = "updated"
 
 	# Skills-area rework (DESIGN.md section 3): the moment a learned-pattern row
@@ -167,6 +196,63 @@ def upsert_candidate(candidate: dict, run) -> str:
 	if result == "created":
 		_maybe_materialize_question(pattern_key)
 	return result
+
+
+# --------------------------------------------------------------------------- #
+# redraft drift (#482): the approved wording vs what is detected now
+# --------------------------------------------------------------------------- #
+def rule_sentence(draft) -> str:
+	"""The directive half of a skill-draft bullet: the leading "- " and the
+	trailing "Evidence: 96% of 58 Purchase Receipt since 2024-09." tail removed.
+	That tail is measured numbers which legitimately move on every run, so only
+	the head decides whether the org is being told something different."""
+	text = (draft or "").strip()
+	if text.startswith("- "):
+		text = text[2:]
+	return " ".join(text.split(_EVIDENCE_MARKER, 1)[0].split()).strip()
+
+
+def _redraft_reason(doc, candidate: dict) -> str | None:
+	"""Why this approved row must go back to review, or None to leave it alone.
+
+	Applies to rows whose approved text is the DETECTOR's own wording, which is
+	exactly the set the nightly refresh rewrites (``engine._apply_evidence``
+	only overwrites ``skill_draft`` when neither ``draft_edited`` nor
+	``draft_polished`` is set). An SM-edited or LLM-polished draft is already
+	frozen against that refresh and is not a template render, so comparing it
+	against a fresh template render would flag every night; those rows stay
+	governed by the statistical axes in ``revalidate_active``."""
+	if (doc.get("status") or "") not in _APPROVED_STATUSES:
+		return None
+	if doc.get("draft_edited") or doc.get("draft_polished"):
+		return None
+	approved_rule = rule_sentence(doc.get("approved_draft"))
+	if not approved_rule:
+		# Never approved through the snapshotting path (a row approved before
+		# #482 shipped and not yet backfilled): nothing trustworthy to compare.
+		return None
+	fresh_rule = rule_sentence(candidate.get("skill_draft"))
+	if not fresh_rule or fresh_rule.casefold() == approved_rule.casefold():
+		return None
+	return f'{REDRAFT_STALE_PREFIX}: approved "{approved_rule}" but now detects "{fresh_rule}"'
+
+
+def _record_redraft_stale(line: str) -> None:
+	"""Stash one line for the run's single summary notification. Per-request
+	state, drained by ``revalidate_active`` at the end of the same run - the
+	mining loop touches one candidate at a time and must never send one
+	Notification Log per pattern."""
+	lines = getattr(frappe.local, "jarvis_redraft_stale", None)
+	if lines is None:
+		lines = []
+		frappe.local.jarvis_redraft_stale = lines
+	lines.append(line)
+
+
+def _drain_redraft_stale() -> list:
+	lines = list(getattr(frappe.local, "jarvis_redraft_stale", None) or [])
+	frappe.local.jarvis_redraft_stale = []
+	return lines
 
 
 def _maybe_materialize_question(pattern_key: str) -> None:
@@ -473,6 +559,13 @@ def revalidate_active(run=None, patterndb=None, mined=None) -> dict:
 				out["staled"] += 1
 				staled_lines.append(f"{row.name}: {reason}")
 
+	# Rows this run's mining already staled for redraft drift ride the SAME
+	# summary notification (#482) - the mining loop stashes them precisely so
+	# they do not become one Notification Log per pattern.
+	redraft_lines = _drain_redraft_stale()
+	if redraft_lines:
+		staled_lines.extend(redraft_lines)
+		out["staled"] += len(redraft_lines)
 	if staled_lines:
 		_notify_stale(staled_lines)
 	if out["revalidated"] or out["version_skipped"]:

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -44,3 +44,4 @@ jarvis.patches.v2_10_backfill_home_intro_seen
 jarvis.patches.v2_10_backfill_chat_was_ready_at
 jarvis.patches.v2_11_backfill_home_intro_enabled
 jarvis.patches.v2_12_rename_capture_agent_provider
+jarvis.patches.v2_12_backfill_approved_draft

--- a/jarvis/patches/v2_12_backfill_approved_draft.py
+++ b/jarvis/patches/v2_12_backfill_approved_draft.py
@@ -1,0 +1,56 @@
+"""#482: snapshot the reviewed text of already-approved learned patterns.
+
+The compiler now ships ``Jarvis Learned Pattern.approved_draft`` instead of the
+live ``skill_draft`` (nightly re-detection rewrites the live field in place, so
+approved wording could change and be pushed org-wide unreviewed). Rows approved
+before that field existed have an empty snapshot, and would keep compiling from
+the live draft - exactly the behaviour being fixed. Stamp the current draft as
+the snapshot so those rows are protected from the NEXT re-detection onward.
+
+This is the best available baseline, not a perfect one: if a nightly run already
+rewrote such a row, the current draft IS the rewritten text and the original
+wording is unrecoverable from the row (Jarvis Learned Pattern has
+``track_changes``, so the version history still holds it). Freezing what is
+there today stops the drift going forward.
+
+Fresh installs never run patches (``install_app(set_as_patched=True)`` marks
+them done without executing), which is correct here - a fresh site has no
+pre-existing approved rows to backfill.
+
+Idempotent: only rows whose ``approved_draft`` is still NULL/empty are touched,
+raw ``db.set_value`` with ``update_modified=False`` (never ``doc.save()``, which
+would run the status-transition guard mid-migrate), so a re-run is a no-op.
+"""
+
+import frappe
+
+JLP = "Jarvis Learned Pattern"
+BACKFILL_STATUSES = ("Approved", "Active")
+
+
+def execute():
+	if not frappe.db.has_column(JLP, "approved_draft"):
+		return
+
+	rows = frappe.get_all(
+		JLP,
+		filters={"status": ["in", list(BACKFILL_STATUSES)], "approved_draft": ["in", [None, ""]]},
+		fields=["name", "skill_draft", "approved_draft"],
+	)
+	stamped = 0
+	for row in rows:
+		if (row.approved_draft or "").strip():
+			continue  # belt-and-braces against a partial deploy
+		draft = (row.skill_draft or "").strip()
+		if not draft:
+			# No text to freeze; _bullet falls back to pattern_statement.
+			continue
+		frappe.db.set_value(JLP, row.name, "approved_draft", draft, update_modified=False)
+		stamped += 1
+
+	if stamped:
+		frappe.db.commit()
+		frappe.logger("jarvis").info(
+			f"#482 approved_draft backfill: froze the reviewed text of {stamped} "
+			f"learned pattern(s) (of {len(rows)} unsnapshotted Approved/Active rows)"
+		)

--- a/jarvis/tests/learning/test_lifecycle.py
+++ b/jarvis/tests/learning/test_lifecycle.py
@@ -701,3 +701,311 @@ class TestSurfacingSortKey(FrappeTestCase):
 		c = {"effective_sensitivity": "C", "strength_band": "Low", "support_n": 1}
 		a = {"effective_sensitivity": "A", "strength_band": "High", "support_n": 999}
 		self.assertEqual(sorted([a, c], key=lifecycle.surfacing_sort_key), [c, a])
+
+
+# --------------------------------------------------------------------------- #
+# #482: an approved pattern's reviewed text is frozen
+# --------------------------------------------------------------------------- #
+A_KEY = "_lc-482-key"
+
+# The real wording pair skill_drafts ships for buy-supplier-stockness: the
+# executor swaps to the strict "-only" variant purely on evidence thresholds
+# (n >= 60, zero exceptions), which IMPROVES every drift axis, so no staling
+# check based on statistics can ever intervene.
+TENDENCY_DRAFT = (
+	'- Supplier "ThreadCo" mostly supplies non-stock items: default is_stock_item to 0 '
+	"and flag if a stock item appears. Evidence: 96.6% of 58 Purchase Receipt since 2024-09. "
+	"2 known exceptions (see board)."
+)
+STRICT_DRAFT = (
+	'- Supplier "ThreadCo" supplies only non-stock items: default is_stock_item to 0 '
+	"and flag if any stock item appears. Evidence: 100% of 75 Purchase Receipt since 2024-11."
+)
+TENDENCY_STATEMENT = "Supplier ThreadCo usually supplies non-stock items."
+STRICT_STATEMENT = "Supplier ThreadCo supplies only non-stock items."
+
+
+def _a_class(**over):
+	"""An A-class candidate: only A-class rows are approvable AND compilable."""
+	fields = {
+		"pattern_key": A_KEY,
+		"sensitivity": "A",
+		"effective_sensitivity": "A",
+		"pattern_statement": TENDENCY_STATEMENT,
+		"skill_draft": TENDENCY_DRAFT,
+	}
+	fields.update(over)
+	return _candidate(**fields)
+
+
+class TestApprovedDraftFreeze(FrappeTestCase):
+	"""#482. A reviewer approves a pattern; the next nightly run re-detects the
+	same pattern_key and rewrites ``skill_draft`` in place. Before the fix the
+	compiler read that live field, so the org ran wording nobody reviewed."""
+
+	def setUp(self):
+		super().setUp()
+		self.run = frappe.get_doc({"doctype": RUN, "trigger": "manual", "status": "Running"}).insert(
+			ignore_permissions=True
+		)
+		frappe.local._jarvis_overlap_index = None
+		frappe.local.jarvis_redraft_stale = []
+
+	def tearDown(self):
+		frappe.db.delete(JLP_ROLE, {"parenttype": JLP})
+		frappe.db.delete(JLP, {"pattern_key": ["like", "_lc-%"]})
+		frappe.db.delete(RUN, {"name": self.run.name})
+		frappe.local._jarvis_overlap_index = None
+		frappe.local.jarvis_redraft_stale = []
+		frappe.db.commit()
+		super().tearDown()
+
+	def _row(self):
+		name = frappe.db.exists(JLP, {"pattern_key": A_KEY})
+		return frappe.get_doc(JLP, name) if name else None
+
+	def _propose_and_approve(self, edited=None):
+		"""Mine the pattern, then approve it through the real board endpoint."""
+		from jarvis.chat import learned_api
+
+		lifecycle.upsert_candidate(_a_class(), self.run)
+		name = self._row().name
+		learned_api.approve_learned_pattern(name, edited_skill_draft=edited)
+		return name
+
+	def _compiled_body(self):
+		from jarvis.learning import compiler
+
+		return (compiler.compile_domain_skills().get("buying") or {}).get("body", "")
+
+	# --- the reviewed text is what ships ------------------------------------ #
+	def test_plain_approve_then_redetection_still_compiles_the_approved_text(self):
+		# A plain "looks good" approve leaves draft_edited=0, which is exactly
+		# the row whose skill_draft the nightly refresh overwrites.
+		name = self._propose_and_approve()
+		self.assertEqual(self._row().draft_edited, 0)
+		self.assertEqual(self._row().approved_draft, TENDENCY_DRAFT)
+
+		# Re-detection restates the SAME rule with fresher measurements, and a
+		# pattern_statement that moved with them.
+		refreshed = TENDENCY_DRAFT.replace("96.6% of 58", "97.4% of 77")
+		lifecycle.upsert_candidate(
+			_a_class(
+				skill_draft=refreshed,
+				pattern_statement="Supplier ThreadCo usually supplies non-stock items (77 receipts).",
+				support_n=77,
+			),
+			self.run,
+		)
+
+		row = self._row()
+		self.assertEqual(row.status, "Approved", "an evidence refresh must not move the row")
+		self.assertEqual(row.skill_draft, refreshed, "the live draft still tracks what is detected")
+		self.assertEqual(row.approved_draft, TENDENCY_DRAFT, "the reviewed text must not move")
+
+		from jarvis.learning import compiler
+
+		bullet = compiler.preview_bullet(name)
+		self.assertIn("96.6% of 58", bullet)
+		self.assertNotIn("97.4% of 77", bullet)
+		body = self._compiled_body()
+		self.assertIn("96.6% of 58", body)
+		self.assertNotIn("97.4% of 77", body)
+
+	def test_unsnapshotted_row_falls_back_to_the_live_draft(self):
+		# Rows approved before #482 shipped (and before the backfill patch ran)
+		# must still compile - the compiler falls back to skill_draft.
+		name = self._propose_and_approve()
+		frappe.db.set_value(JLP, name, {"approved_draft": ""}, update_modified=False)
+		from jarvis.learning import compiler
+
+		self.assertIn("96.6% of 58", compiler.preview_bullet(name))
+
+	# --- the materially-changed case ---------------------------------------- #
+	def test_material_rule_change_stales_the_row_naming_both_wordings(self):
+		# The airtight case: "mostly supplies" -> "supplies only" while every
+		# statistical drift axis improves. The approved text is not rewritten
+		# AND the new wording is not shipped: the row goes back to the board.
+		name = self._propose_and_approve()
+		out = lifecycle.upsert_candidate(
+			_a_class(
+				skill_draft=STRICT_DRAFT,
+				pattern_statement=STRICT_STATEMENT,
+				support_n=75,
+				exception_n=0,
+				confidence_pct=100.0,
+				wilson_low=0.95,
+			),
+			self.run,
+		)
+		self.assertEqual(out, "updated")
+
+		row = self._row()
+		self.assertEqual(row.status, "Stale")
+		self.assertEqual(row.approved_draft, TENDENCY_DRAFT)
+		self.assertTrue(row.stale_reason.startswith(lifecycle.REDRAFT_STALE_PREFIX))
+		self.assertIn("mostly supplies non-stock items", row.stale_reason)
+		self.assertIn("supplies only non-stock items", row.stale_reason)
+		self.assertNotIn("Evidence:", row.stale_reason, "the reason compares rules, not numbers")
+
+		# Stale drops out of the compile: neither wording ships unreviewed.
+		body = self._compiled_body()
+		self.assertNotIn("ThreadCo", body)
+		self.assertNotIn(name, body)
+
+	def test_active_row_is_staled_too(self):
+		# An Active row is already IN the pushed body, so it must go back to the
+		# board (and out of the next Apply) rather than be silently reworded.
+		name = self._propose_and_approve()
+		frappe.db.set_value(JLP, name, {"status": "Active"}, update_modified=False)
+		lifecycle.upsert_candidate(
+			_a_class(skill_draft=STRICT_DRAFT, pattern_statement=STRICT_STATEMENT), self.run
+		)
+		row = self._row()
+		self.assertEqual(row.status, "Stale")
+		self.assertEqual(row.approved_draft, TENDENCY_DRAFT)
+
+	def test_evidence_only_change_never_stales(self):
+		# The numbers move on EVERY run; only the rule sentence decides.
+		self._propose_and_approve()
+		lifecycle.upsert_candidate(
+			_a_class(
+				skill_draft=TENDENCY_DRAFT.replace("96.6% of 58", "95.1% of 61"),
+				support_n=61,
+			),
+			self.run,
+		)
+		row = self._row()
+		self.assertEqual(row.status, "Approved")
+		self.assertFalse(row.stale_reason)
+
+	def test_sm_edited_approval_is_never_redraft_staled(self):
+		# An SM-edited draft is already frozen against the refresh and is not a
+		# template render, so comparing it to one would stale it every night.
+		name = self._propose_and_approve(edited="- ThreadCo: never default a stock item on this supplier.")
+		self.assertEqual(frappe.db.get_value(JLP, name, "draft_edited"), 1)
+		lifecycle.upsert_candidate(
+			_a_class(skill_draft=STRICT_DRAFT, pattern_statement=STRICT_STATEMENT), self.run
+		)
+		row = self._row()
+		self.assertEqual(row.status, "Approved")
+		self.assertEqual(row.approved_draft, "- ThreadCo: never default a stock item on this supplier.")
+
+	def test_polished_approval_is_never_redraft_staled(self):
+		name = self._propose_and_approve()
+		frappe.db.set_value(JLP, name, {"draft_polished": 1}, update_modified=False)
+		lifecycle.upsert_candidate(
+			_a_class(skill_draft=STRICT_DRAFT, pattern_statement=STRICT_STATEMENT), self.run
+		)
+		self.assertEqual(self._row().status, "Approved")
+
+	def test_proposed_row_is_never_redraft_staled(self):
+		# Nothing was approved yet: the refresh is the whole point of the board.
+		lifecycle.upsert_candidate(_a_class(), self.run)
+		lifecycle.upsert_candidate(
+			_a_class(skill_draft=STRICT_DRAFT, pattern_statement=STRICT_STATEMENT), self.run
+		)
+		row = self._row()
+		self.assertEqual(row.status, "Proposed")
+		self.assertEqual(row.skill_draft, STRICT_DRAFT)
+
+	def test_re_approving_accepts_the_new_wording_and_clears_the_reason(self):
+		# The staled row must be actionable, not a dead end: Stale -> Approved is
+		# a legal transition and re-approval re-freezes the CURRENT text.
+		from jarvis.chat import learned_api
+
+		name = self._propose_and_approve()
+		lifecycle.upsert_candidate(
+			_a_class(skill_draft=STRICT_DRAFT, pattern_statement=STRICT_STATEMENT), self.run
+		)
+		learned_api.approve_learned_pattern(name)
+		row = self._row()
+		self.assertEqual(row.status, "Approved")
+		self.assertEqual(row.approved_draft, STRICT_DRAFT)
+		self.assertFalse(row.stale_reason)
+
+	def test_unapprove_clears_the_snapshot(self):
+		from jarvis.chat import learned_api
+
+		name = self._propose_and_approve()
+		learned_api.unapprove_learned_pattern(name)
+		row = self._row()
+		self.assertEqual(row.status, "Proposed")
+		self.assertFalse(row.approved_draft)
+
+	# --- one notification per run ------------------------------------------- #
+	def test_redraft_stales_ride_the_single_summary_notification(self):
+		self._propose_and_approve()
+		lifecycle.upsert_candidate(
+			_a_class(skill_draft=STRICT_DRAFT, pattern_statement=STRICT_STATEMENT), self.run
+		)
+		with mock.patch("jarvis.learning.lifecycle._notify_stale") as notify:
+			out = lifecycle.revalidate_active(self.run, mined={})
+		self.assertEqual(notify.call_count, 1)
+		lines = notify.call_args[0][0]
+		self.assertEqual(len(lines), 1)
+		self.assertIn(lifecycle.REDRAFT_STALE_PREFIX, lines[0])
+		self.assertGreaterEqual(out["staled"], 1)
+
+	# --- the rule/evidence split -------------------------------------------- #
+	def test_rule_sentence_strips_the_bullet_marker_and_evidence_tail(self):
+		self.assertEqual(
+			lifecycle.rule_sentence("- Do the thing. Evidence: 96% of 10 Sales Invoice since 2024-01."),
+			"Do the thing.",
+		)
+		self.assertEqual(lifecycle.rule_sentence("  - Do   the thing.  "), "Do the thing.")
+		self.assertEqual(lifecycle.rule_sentence(None), "")
+
+
+class TestApprovedDraftBackfill(FrappeTestCase):
+	"""The v2_12 patch freezes the reviewed text of rows approved before the
+	snapshot field existed. Patches can rerun, so it must be idempotent."""
+
+	KEYS = ("_lc-bf-approved", "_lc-bf-active", "_lc-bf-proposed")
+
+	def setUp(self):
+		super().setUp()
+		self.run = frappe.get_doc({"doctype": RUN, "trigger": "manual", "status": "Running"}).insert(
+			ignore_permissions=True
+		)
+		frappe.local._jarvis_overlap_index = None
+
+	def tearDown(self):
+		frappe.db.delete(JLP_ROLE, {"parenttype": JLP})
+		frappe.db.delete(JLP, {"pattern_key": ["like", "_lc-%"]})
+		frappe.db.delete(RUN, {"name": self.run.name})
+		frappe.local._jarvis_overlap_index = None
+		frappe.db.commit()
+		super().tearDown()
+
+	def _legacy_row(self, key, status, draft):
+		lifecycle.upsert_candidate(_candidate(pattern_key=key, skill_draft=draft), self.run)
+		name = frappe.db.exists(JLP, {"pattern_key": key})
+		frappe.db.set_value(JLP, name, {"status": status, "approved_draft": None}, update_modified=False)
+		return name
+
+	def test_backfill_freezes_approved_rows_only_and_is_idempotent(self):
+		from jarvis.patches.v2_12_backfill_approved_draft import execute as backfill
+
+		approved = self._legacy_row(self.KEYS[0], "Approved", "- approved rule. Evidence: 90% of 10 x.")
+		active = self._legacy_row(self.KEYS[1], "Active", "- active rule. Evidence: 91% of 11 x.")
+		proposed = self._legacy_row(self.KEYS[2], "Proposed", "- proposed rule. Evidence: 92% of 12 x.")
+
+		backfill()
+		self.assertEqual(
+			frappe.db.get_value(JLP, approved, "approved_draft"), "- approved rule. Evidence: 90% of 10 x."
+		)
+		self.assertEqual(
+			frappe.db.get_value(JLP, active, "approved_draft"), "- active rule. Evidence: 91% of 11 x."
+		)
+		self.assertFalse(
+			frappe.db.get_value(JLP, proposed, "approved_draft"),
+			"an un-reviewed row has nothing to freeze",
+		)
+
+		# Re-run after the live draft moved on: the frozen text must not follow.
+		frappe.db.set_value(JLP, approved, {"skill_draft": "- REWRITTEN."}, update_modified=False)
+		backfill()
+		self.assertEqual(
+			frappe.db.get_value(JLP, approved, "approved_draft"), "- approved rule. Evidence: 90% of 10 x."
+		)


### PR DESCRIPTION
## Summary

A reviewer who approves a learned pattern with a plain "looks good" now gets the exact text they read frozen into a new `approved_draft` field, and the compiler ships that snapshot instead of the live `skill_draft` that every nightly re-detection rewrites in place. When re-detection produces a materially different rule for an already-approved pattern, the row goes back to the board as Stale (reason naming both wordings) rather than being reworded under the reviewer or quietly kept forever. System Managers running the learning board notice: previously approved wording could change without them, now a changed rule shows up on the Stale tab, in the "will be removed on Apply" count and in the nightly summary notification.

<details>
<summary>Root cause</summary>

Four things lined up:

1. `learned_api.approve_learned_pattern` set `draft_edited=1` only when the reviewer supplied a differing `edited_skill_draft`. A plain approve left both `draft_edited` and `draft_polished` at 0.
2. `engine.TERMINAL_STATUSES` excludes Approved and Active, and `lifecycle._REFRESH_STATUSES` includes both, so re-detection took the "refresh evidence in place" branch on approved rows.
3. `engine._apply_evidence` overwrites `pattern_statement` unconditionally and overwrites `skill_draft` whenever neither freeze flag is set. It also CLEARS `draft_polished` when the statement changed, reopening the overwrite gate in exactly the material-change case.
4. `compiler.compile_domain_skills` / `_bullet` read the live `skill_draft`, not a snapshot.

The drift pass could never catch it. `executor._effective_template` swaps to the strict `-only` template variant purely on `exception_n == 0 and n_units >= N_MIN_ALWAYS`, so "mostly supplies" becomes "supplies only" while confidence, Wilson and recency all IMPROVE and `lifecycle._stale_reason` stays silent. `_refresh_drift_stats` deliberately never touches `skill_draft`, and the per-unit mining upsert commits before `revalidate_active` runs anyway, so the reviewed text was already gone.

`pattern_key` is `sha1(detector_id | antecedent_value | company)`; the consequent is not in it, so a re-detection can carry a different consequent into the same row. The engine docstring claimed the key covered the consequent, which is what made this easy to miss in review. Corrected here.
</details>

### What changed

- `Jarvis Learned Pattern.approved_draft` (Long Text, read only), stamped by `approve_learned_pattern` (so `batch_approve` too), cleared by `unapprove_learned_pattern`.
- `compiler._bullet` prefers `approved_draft`, falling back to `skill_draft` then `pattern_statement`, so `compile_domain_skills` and `preview_bullet` agree and un-snapshotted rows still compile.
- `lifecycle.upsert_candidate` compares the freshly detected RULE sentence against the approved one and moves a diverged Approved/Active row to Stale. The comparison strips the `Evidence: ...` tail, which is measured numbers that legitimately move every run, so only a changed directive counts.
- Redraft stales ride the run's single existing summary Notification Log rather than one per pattern.
- `get_learned_pattern` returns `approved_draft` plus an `approved_draft_diff` built from the existing `_unified_diff` helper.
- Backfill patch `v2_12_backfill_approved_draft`, idempotent, Approved/Active only.

### Why Stale, and not "freeze and walk away"

Silently keeping the approved text forever is also wrong: the reverse flip ("only" back to "mostly", after one exception appears) leaves the org running a strict directive that reality no longer supports, and a consequent reroute changes the meaning entirely. Demoting to Proposed is not available for an Active row (`LEGAL_TRANSITIONS` allows only Stale or Superseded) and would be a second, differently shaped silent change. Stale is this module's existing, surfaced answer to "the approved pattern no longer matches what we measure": it writes a reason, drops out of the next compile, shows on the board, feeds the Apply bar's removal count, notifies System Managers, and Stale to Approved is a legal transition, so re-approving accepts the new wording in one click and re-freezes it.

Scope note: the check runs on machine-drafted approvals, which is exactly the set the refresh rewrites. An SM-edited or LLM-polished draft is already frozen against the refresh and is not a template render, so comparing it against a fresh template render would stale it every night; those rows stay governed by the statistical axes in `revalidate_active`.

The approved bullet's evidence sentence is frozen along with the rule. That matches the contract `draft_edited` already documents on the doctype, and the fresh numbers remain visible in the drill-down.

An Apply-time diff of the whole pushed body is still worth doing and is left as the independent improvement the issue calls it.

Closes #482

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
