### PR TITLE
agents: add promote/demote action UI for shadow-to-live activation

### DIFF
--- a/frontend/src/api/agents.js
+++ b/frontend/src/api/agents.js
@@ -58,3 +58,31 @@ export const listAgentActivityPage = (p = {}) =>
 // Seed a new conversation from a finding and land the user in live chat.
 // -> { ok, conversation, run_id, reason }
 export const takeFindingToChat = (finding) => call(AG + "take_finding_to_chat", { finding });
+
+// ── PP-4 shadow -> live activation (jarvis#456) ──────────────────────────────
+// get_agent's `installation` shape is frozen (§8.3) and two in-flight PRs
+// (#620/#612) are independently editing agents_api.py/agent_runs.py, so this
+// reads the extra fields via frappe.client.get_value (core Frappe, whitelisted)
+// instead of widening that method. It is permission-scoped exactly like every
+// other read here: get_value's filters go through get_list, which applies the
+// DocType's `if_owner` permission condition, so a caller only ever gets their
+// own installation row back.
+export const getInstallationActivation = (installation) =>
+	call("frappe.client.get_value", {
+		doctype: "Jarvis Agent Installation",
+		filters: installation,
+		fieldname: JSON.stringify([
+			"activation_state",
+			"reviewer",
+			"run_as_user",
+			"promoted_by",
+			"promoted_at",
+		]),
+	});
+
+// Reviewer sign-off / kill switch. See agents_api.{promote,demote}_installation
+// for the authority + PP-6 budget checks this wraps.
+export const promoteInstallation = (installation, justification) =>
+	call(AG + "promote_installation", { installation, justification: justification || "" });
+export const demoteInstallation = (installation, reason) =>
+	call(AG + "demote_installation", { installation, reason: reason || "" });

--- a/frontend/src/pages/agents/ActivationPanel.spec.js
+++ b/frontend/src/pages/agents/ActivationPanel.spec.js
@@ -174,6 +174,24 @@ describe("demotion is reachable, not just promotion", () => {
 		expect(api.demoteInstallation).toHaveBeenCalledWith("INST-0001", "");
 		expect(w.emitted("demoted")[0][0]).toMatchObject({ activation_state: "shadow" });
 	});
+
+	it("clears the stale promoted-by/at stamp locally even if the response omits it", async () => {
+		// demote_installation's real response only carries {name, activation_state} -
+		// promoted_by/at must not linger from the prior live state.
+		api.demoteInstallation.mockResolvedValue({ data: { activation_state: "shadow" } });
+		const w = mountPanel({
+			state: baseState({
+				activation_state: "live",
+				promoted_by: "admin@x.com",
+				promoted_at: "2026-08-01 10:00:00",
+			}),
+		});
+		await findByText(w, "button", "Demote to shadow").trigger("click");
+		await findByText(w, ".dialog button", "Demote to shadow").trigger("click");
+		await flushPromises();
+
+		expect(w.emitted("demoted")[0][0]).toMatchObject({ promoted_by: null, promoted_at: null });
+	});
 });
 
 describe("a rejection surfaces its reason instead of failing silently", () => {

--- a/frontend/src/pages/agents/ActivationPanel.spec.js
+++ b/frontend/src/pages/agents/ActivationPanel.spec.js
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#456 - promote_installation/demote_installation had no frontend, so a
+ * shadow installation (e.g. the custom-app-learning scribe) could never reach
+ * live. These pin the three things the issue called out:
+ *
+ *   1. The real activation_state is shown, not just a passive pill.
+ *   2. Both directions are reachable - promote AND demote.
+ *   3. A rejection (ceiling / capacity / permissions) surfaces its reason and
+ *      leaves the dialog open, instead of failing silently.
+ */
+
+const api = vi.hoisted(() => ({
+	promoteInstallation: vi.fn(),
+	demoteInstallation: vi.fn(),
+}));
+vi.mock("@/api/agents", () => api);
+
+vi.mock("frappe-ui", () => ({
+	call: vi.fn(),
+	dayjs: () => ({ format: () => "", fromNow: () => "" }),
+	dayjsLocal: () => ({ format: () => "", fromNow: () => "2 days ago" }),
+	getConfig: () => null,
+	toast: { success: vi.fn(), error: vi.fn() },
+	Badge: { name: "Badge", props: ["label"], template: `<span class="badge">{{ label }}</span>` },
+	Button: {
+		name: "Button",
+		props: ["label", "disabled", "loading", "variant", "theme", "tooltip"],
+		emits: ["click"],
+		template: `<button :disabled="disabled" @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+	},
+	Dialog: {
+		name: "Dialog",
+		props: ["modelValue", "options"],
+		emits: ["update:modelValue"],
+		template: `<div v-if="modelValue" class="dialog"><div class="dialog-title">{{ options && options.title }}</div><slot name="body-content" /><slot name="actions" /></div>`,
+	},
+	ErrorMessage: {
+		name: "ErrorMessage",
+		props: ["message"],
+		template: `<div v-if="message" class="error-message">{{ message }}</div>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "label", "type", "rows"],
+		emits: ["update:modelValue"],
+		template: `<textarea :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+}));
+
+import ActivationPanel from "./ActivationPanel.vue";
+
+function baseState(overrides = {}) {
+	return {
+		activation_state: "shadow",
+		reviewer: "reviewer@x.com",
+		run_as_user: "reviewer@x.com",
+		promoted_by: null,
+		promoted_at: null,
+		...overrides,
+	};
+}
+
+function mountPanel(props = {}) {
+	return mount(ActivationPanel, {
+		props: {
+			installationName: "INST-0001",
+			agentTitle: "Custom App Learning",
+			isScribe: true,
+			state: baseState(),
+			loading: false,
+			fetchError: "",
+			canAct: true,
+			...props,
+		},
+	});
+}
+
+function findByText(wrapper, selector, text) {
+	return wrapper.findAll(selector).find((n) => n.text().includes(text));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("shows the real activation state honestly", () => {
+	it("renders the Shadow pill (not a bare Preview label) while shadow", () => {
+		const w = mountPanel({ state: baseState({ activation_state: "shadow" }) });
+		expect(w.text()).toContain("Shadow (preview)");
+		expect(w.find(".badge").exists()).toBe(false);
+	});
+
+	it("renders a Live badge with who signed off once promoted", () => {
+		const w = mountPanel({
+			state: baseState({
+				activation_state: "live",
+				promoted_by: "admin@x.com",
+				promoted_at: "2026-08-01 10:00:00",
+			}),
+		});
+		expect(w.find(".badge").text()).toBe("Live");
+		expect(w.text()).toContain("signed off by admin@x.com");
+	});
+
+	it("names the run-as user so promotion's escalation is legible", () => {
+		const w = mountPanel({ state: baseState({ run_as_user: "svc-account@x.com" }) });
+		expect(w.text()).toContain("svc-account@x.com");
+	});
+
+	it("tells a scribe reviewer it cannot run at all while shadow", () => {
+		const w = mountPanel({ isScribe: true, state: baseState({ activation_state: "shadow" }) });
+		expect(w.text()).toContain("cannot run at all until promoted");
+	});
+});
+
+describe("promotion is reachable and explains the escalation", () => {
+	it("opens a dialog naming who it will run as before promoting", async () => {
+		const w = mountPanel({ state: baseState({ run_as_user: "svc-account@x.com" }) });
+		await findByText(w, "button", "Promote to live").trigger("click");
+		expect(w.find(".dialog").exists()).toBe(true);
+		expect(w.find(".dialog-title").text()).toContain("Promote Custom App Learning to live?");
+		expect(w.text()).toContain("run unattended");
+		expect(w.text()).toContain("svc-account@x.com");
+	});
+
+	it("calls promote_installation with the justification and emits the new state", async () => {
+		api.promoteInstallation.mockResolvedValue({
+			data: { name: "INST-0001", activation_state: "live", promoted_by: "me@x.com" },
+		});
+		const w = mountPanel();
+		await findByText(w, "button", "Promote to live").trigger("click");
+		await w.find(".dialog textarea").setValue("reviewed the shadow findings");
+		await findByText(w, ".dialog button", "Promote to live").trigger("click");
+		await flushPromises();
+
+		expect(api.promoteInstallation).toHaveBeenCalledWith(
+			"INST-0001",
+			"reviewed the shadow findings"
+		);
+		expect(w.emitted("promoted")).toBeTruthy();
+		expect(w.emitted("promoted")[0][0]).toMatchObject({
+			activation_state: "live",
+			promoted_by: "me@x.com",
+		});
+		// the dialog closes on success
+		expect(w.find(".dialog").exists()).toBe(false);
+	});
+
+	it("disables the action for a viewer who is neither the reviewer nor an admin", () => {
+		const w = mountPanel({ canAct: false });
+		const btn = findByText(w, "button", "Promote to live");
+		expect(btn.attributes("disabled")).toBeDefined();
+	});
+});
+
+describe("demotion is reachable, not just promotion", () => {
+	it("offers a Demote action once live", async () => {
+		const w = mountPanel({ state: baseState({ activation_state: "live" }) });
+		expect(findByText(w, "button", "Demote to shadow")).toBeTruthy();
+		expect(findByText(w, "button", "Promote to live")).toBeUndefined();
+	});
+
+	it("calls demote_installation and emits shadow state back", async () => {
+		api.demoteInstallation.mockResolvedValue({ data: { activation_state: "shadow" } });
+		const w = mountPanel({ state: baseState({ activation_state: "live" }) });
+		await findByText(w, "button", "Demote to shadow").trigger("click");
+		await findByText(w, ".dialog button", "Demote to shadow").trigger("click");
+		await flushPromises();
+
+		expect(api.demoteInstallation).toHaveBeenCalledWith("INST-0001", "");
+		expect(w.emitted("demoted")[0][0]).toMatchObject({ activation_state: "shadow" });
+	});
+});
+
+describe("a rejection surfaces its reason instead of failing silently", () => {
+	it("keeps the dialog open and shows the endpoint's message on a ceiling refusal", async () => {
+		api.promoteInstallation.mockRejectedValue({
+			messages: [
+				"Activation budget reached: this customer already has 1 live module(s) and the activation ceiling is 1.",
+			],
+		});
+		const w = mountPanel();
+		await findByText(w, "button", "Promote to live").trigger("click");
+		await findByText(w, ".dialog button", "Promote to live").trigger("click");
+		await flushPromises();
+
+		expect(w.find(".dialog").exists()).toBe(true); // did NOT close
+		expect(w.find(".error-message").text()).toContain("Activation budget reached");
+		expect(w.emitted("promoted")).toBeFalsy();
+	});
+
+	it("does the same for a demote rejection", async () => {
+		api.demoteInstallation.mockRejectedValue({
+			messages: ["Only the named reviewer or a Jarvis Admin may demote this installation."],
+		});
+		const w = mountPanel({ state: baseState({ activation_state: "live" }) });
+		await findByText(w, "button", "Demote to shadow").trigger("click");
+		await findByText(w, ".dialog button", "Demote to shadow").trigger("click");
+		await flushPromises();
+
+		expect(w.find(".dialog").exists()).toBe(true);
+		expect(w.find(".error-message").text()).toContain("named reviewer or a Jarvis Admin");
+	});
+});

--- a/frontend/src/pages/agents/ActivationPanel.vue
+++ b/frontend/src/pages/agents/ActivationPanel.vue
@@ -215,7 +215,12 @@ async function confirm() {
 		const nextState =
 			mode.value === "promote"
 				? { ...props.state, activation_state: "live" }
-				: { ...props.state, activation_state: "shadow" };
+				: {
+						...props.state,
+						activation_state: "shadow",
+						promoted_by: null,
+						promoted_at: null,
+				  };
 		if (res && res.data) Object.assign(nextState, res.data);
 		toast.success(mode.value === "promote" ? "Promoted to live" : "Demoted to shadow");
 		dialogOpen.value = false;
@@ -238,6 +243,4 @@ watch(
 		dialogOpen.value = false;
 	}
 );
-
-defineExpose({ open });
 </script>

--- a/frontend/src/pages/agents/ActivationPanel.vue
+++ b/frontend/src/pages/agents/ActivationPanel.vue
@@ -31,7 +31,8 @@
 				<template v-if="state.activation_state === 'live'">
 					Live<template v-if="state.promoted_at">
 						since {{ timeAgo(state.promoted_at) }}</template
-					><template v-if="state.promoted_by"> · signed off by {{ state.promoted_by }}</template
+					><template v-if="state.promoted_by">
+						· signed off by {{ state.promoted_by }}</template
 					>. Its output is a compliant attestation on the owner surface.
 				</template>
 				<template v-else>
@@ -88,11 +89,14 @@
 							<div>
 								This lets <span class="font-medium">{{ agentTitle }}</span> run
 								unattended - on its schedule, with no one watching - as
-								<span class="font-medium">{{ (state && state.run_as_user) || "-" }}</span>.
+								<span class="font-medium">{{
+									(state && state.run_as_user) || "-"
+								}}</span
+								>.
 							</div>
 							<div>
-								Its output becomes a live, compliant attestation on the owner surface
-								immediately, replacing the reviewer-only preview.
+								Its output becomes a live, compliant attestation on the owner
+								surface immediately, replacing the reviewer-only preview.
 							</div>
 							<div>It also counts against this customer's live-module budget.</div>
 						</div>
@@ -103,15 +107,17 @@
 					>
 						<FeatherIcon name="eye-off" class="mt-0.5 size-4 shrink-0" />
 						<div>
-							This stops <span class="font-medium">{{ agentTitle }}</span> from running
-							live. Future runs go back to a reviewer-only preview until it is promoted
-							again; existing live output is not deleted.
+							This stops <span class="font-medium">{{ agentTitle }}</span> from
+							running live. Future runs go back to a reviewer-only preview until it
+							is promoted again; existing live output is not deleted.
 						</div>
 					</div>
 
 					<FormControl
 						type="textarea"
-						:label="mode === 'promote' ? 'Justification (optional)' : 'Reason (optional)'"
+						:label="
+							mode === 'promote' ? 'Justification (optional)' : 'Reason (optional)'
+						"
 						:rows="3"
 						:modelValue="note"
 						@update:modelValue="(v) => (note = v)"

--- a/frontend/src/pages/agents/ActivationPanel.vue
+++ b/frontend/src/pages/agents/ActivationPanel.vue
@@ -1,0 +1,237 @@
+<template>
+	<section>
+		<div class="flex items-center gap-2">
+			<div class="text-base font-medium text-ink-gray-9">Activation</div>
+			<Badge
+				v-if="state && state.activation_state === 'live'"
+				variant="subtle"
+				theme="green"
+				label="Live"
+			/>
+			<!-- Badge has no violet theme in frappe-ui 0.1.278 - reuses the same
+			     violet-pill recipe as the "Preview" pill on the Runs tab so shadow
+			     reads as ONE consistent axis across the agent page. -->
+			<span
+				v-else-if="state"
+				class="inline-flex h-5 shrink-0 select-none items-center whitespace-nowrap rounded-full bg-surface-violet-1 px-2 text-xs text-ink-violet-1"
+			>
+				Shadow (preview)
+			</span>
+		</div>
+
+		<div v-if="loading && !state" class="mt-2 text-sm text-ink-gray-5">
+			Loading activation state…
+		</div>
+		<div v-else-if="fetchError" class="mt-2 text-sm text-ink-red-4">
+			{{ fetchError }}
+			<Button variant="ghost" label="Retry" class="ml-1" @click="emit('retry')" />
+		</div>
+		<template v-else-if="state">
+			<p class="mt-2 max-w-2xl text-sm text-ink-gray-6">
+				<template v-if="state.activation_state === 'live'">
+					Live<template v-if="state.promoted_at">
+						since {{ timeAgo(state.promoted_at) }}</template
+					><template v-if="state.promoted_by"> · signed off by {{ state.promoted_by }}</template
+					>. Its output is a compliant attestation on the owner surface.
+				</template>
+				<template v-else>
+					Runs are visible only to the named reviewer,
+					<span class="font-medium text-ink-gray-7">{{ state.reviewer || "-" }}</span
+					>, and are not a compliant attestation until a reviewer promotes it.
+					<span v-if="isScribe">
+						This agent writes to the Org wiki directly, so it cannot run at all until
+						promoted.
+					</span>
+				</template>
+			</p>
+			<p class="mt-1 text-sm text-ink-gray-5">
+				Runs as
+				<span class="font-medium text-ink-gray-7">{{ state.run_as_user || "-" }}</span>
+			</p>
+
+			<div class="mt-3 flex items-center gap-2">
+				<Button
+					v-if="state.activation_state !== 'live'"
+					label="Promote to live"
+					:disabled="!canAct"
+					:tooltip="actionTooltip"
+					@click="open('promote')"
+				/>
+				<Button
+					v-else
+					variant="subtle"
+					theme="red"
+					label="Demote to shadow"
+					:disabled="!canAct"
+					:tooltip="actionTooltip"
+					@click="open('demote')"
+				/>
+				<span v-if="!canAct" class="text-sm text-ink-gray-5">
+					Only the named reviewer or a Jarvis Admin may change this.
+				</span>
+			</div>
+		</template>
+
+		<Dialog
+			:modelValue="dialogOpen"
+			:options="{ title: dialogTitle, size: 'md' }"
+			@update:modelValue="close"
+		>
+			<template #body-content>
+				<div class="flex flex-col gap-4">
+					<div
+						v-if="mode === 'promote'"
+						class="flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
+					>
+						<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
+						<div class="space-y-1">
+							<div>
+								This lets <span class="font-medium">{{ agentTitle }}</span> run
+								unattended - on its schedule, with no one watching - as
+								<span class="font-medium">{{ (state && state.run_as_user) || "-" }}</span>.
+							</div>
+							<div>
+								Its output becomes a live, compliant attestation on the owner surface
+								immediately, replacing the reviewer-only preview.
+							</div>
+							<div>It also counts against this customer's live-module budget.</div>
+						</div>
+					</div>
+					<div
+						v-else
+						class="flex items-start gap-2 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-7"
+					>
+						<FeatherIcon name="eye-off" class="mt-0.5 size-4 shrink-0" />
+						<div>
+							This stops <span class="font-medium">{{ agentTitle }}</span> from running
+							live. Future runs go back to a reviewer-only preview until it is promoted
+							again; existing live output is not deleted.
+						</div>
+					</div>
+
+					<FormControl
+						type="textarea"
+						:label="mode === 'promote' ? 'Justification (optional)' : 'Reason (optional)'"
+						:rows="3"
+						:modelValue="note"
+						@update:modelValue="(v) => (note = v)"
+					/>
+
+					<ErrorMessage :message="dialogError" />
+				</div>
+			</template>
+			<template #actions>
+				<div class="flex justify-end gap-2">
+					<Button label="Cancel" :disabled="busy" @click="close" />
+					<Button
+						variant="solid"
+						:theme="mode === 'demote' ? 'red' : undefined"
+						:label="mode === 'promote' ? 'Promote to live' : 'Demote to shadow'"
+						:loading="busy"
+						@click="confirm"
+					/>
+				</div>
+			</template>
+		</Dialog>
+	</section>
+</template>
+
+<script setup>
+// ActivationPanel - jarvis#456: the missing action UI for PP-4 shadow -> live
+// activation. Wraps agents_api.{promote,demote}_installation (the only
+// legitimate setters of activation_state - a plain save is blocked by the
+// controller's _guard_activation_transition). Presentational: the parent
+// (AgentDetail) owns the fetch/refresh of `state` (via
+// api/agents.getInstallationActivation, read outside get_agent's frozen §8.3
+// shape - see that wrapper's comment) so the hero badge and this panel never
+// drift out of sync; this component only opens the confirm dialog and calls
+// the two mutating endpoints.
+import { computed, ref, watch } from "vue";
+import { Badge, Button, Dialog, ErrorMessage, FeatherIcon, FormControl, toast } from "frappe-ui";
+import { errMessage as errMsg } from "@/lib/errors";
+import { timeAgo } from "@/utils/datetime";
+import * as apiAgents from "@/api/agents";
+
+const props = defineProps({
+	installationName: { type: String, required: true },
+	agentTitle: { type: String, default: "This agent" },
+	isScribe: { type: Boolean, default: false },
+	// {activation_state, reviewer, run_as_user, promoted_by, promoted_at} | null
+	state: { type: Object, default: null },
+	loading: { type: Boolean, default: false },
+	fetchError: { type: String, default: "" },
+	// true when the viewer is the named reviewer or a Jarvis Admin - a UX guard
+	// only; agents_api re-checks authority server-side regardless.
+	canAct: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["promoted", "demoted", "retry"]);
+
+const actionTooltip = computed(() =>
+	props.canAct ? "" : "Only the named reviewer or a Jarvis Admin may change this"
+);
+
+// ── dialog ────────────────────────────────────────────────────────────────
+const dialogOpen = ref(false);
+const mode = ref("promote"); // 'promote' | 'demote'
+const note = ref("");
+const busy = ref(false);
+const dialogError = ref("");
+
+const dialogTitle = computed(() =>
+	mode.value === "promote"
+		? `Promote ${props.agentTitle} to live?`
+		: `Demote ${props.agentTitle} to shadow?`
+);
+
+function open(m) {
+	if (!props.canAct) return;
+	mode.value = m;
+	note.value = "";
+	dialogError.value = "";
+	dialogOpen.value = true;
+}
+
+function close() {
+	if (busy.value) return; // in-flight call owns the dialog until it settles
+	dialogOpen.value = false;
+}
+
+async function confirm() {
+	if (busy.value) return;
+	busy.value = true;
+	dialogError.value = "";
+	try {
+		const res =
+			mode.value === "promote"
+				? await apiAgents.promoteInstallation(props.installationName, note.value)
+				: await apiAgents.demoteInstallation(props.installationName, note.value);
+		const nextState =
+			mode.value === "promote"
+				? { ...props.state, activation_state: "live" }
+				: { ...props.state, activation_state: "shadow" };
+		if (res && res.data) Object.assign(nextState, res.data);
+		toast.success(mode.value === "promote" ? "Promoted to live" : "Demoted to shadow");
+		dialogOpen.value = false;
+		emit(mode.value === "promote" ? "promoted" : "demoted", nextState);
+	} catch (e) {
+		// Stay open and surface WHY (ceiling reached, capacity, permissions) -
+		// the endpoint's message already names the exact reason - rather than a
+		// generic failure the reviewer can't act on.
+		dialogError.value = errMsg(e);
+		toast.error(dialogError.value);
+	} finally {
+		busy.value = false;
+	}
+}
+
+// A stale dialog must never survive an installation switch (agent nav while open).
+watch(
+	() => props.installationName,
+	() => {
+		dialogOpen.value = false;
+	}
+);
+
+defineExpose({ open });
+</script>

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -599,7 +599,8 @@ async function loadActivation() {
 	activationLoading.value = true;
 	activationError.value = "";
 	try {
-		activation.value = (await apiAgents.getInstallationActivation(installation.value.name)) || null;
+		activation.value =
+			(await apiAgents.getInstallationActivation(installation.value.name)) || null;
 	} catch (e) {
 		activation.value = null;
 		activationError.value = errMsg(e);

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -121,6 +121,21 @@
 								agent.install_count === 1 ? "" : "s"
 							}}
 						</div>
+						<!-- PP-4: the real activation state, honestly, wherever the agent
+						     is discussed - not only in the passive Runs-tab "Preview" pill
+						     (jarvis#456). The action itself lives in Configure. -->
+						<Badge
+							v-if="activation && activation.activation_state === 'live'"
+							variant="subtle"
+							theme="green"
+							label="Live"
+						/>
+						<span
+							v-else-if="activation"
+							class="inline-flex h-5 shrink-0 select-none items-center whitespace-nowrap rounded-full bg-surface-violet-1 px-2 text-xs text-ink-violet-1"
+						>
+							Shadow (preview)
+						</span>
 						<Switch
 							v-if="installation"
 							label="Enabled"
@@ -242,6 +257,21 @@
 				v-else-if="tab === 'configure' && installation"
 				class="max-w-2xl shrink-0 space-y-10 px-5 py-6"
 			>
+				<section>
+					<ActivationPanel
+						:installation-name="installation.name"
+						:agent-title="agent.title"
+						:is-scribe="agent.nature === 'Scribe'"
+						:state="activation"
+						:loading="activationLoading"
+						:fetch-error="activationError"
+						:can-act="canActOnActivation"
+						@promoted="onActivationChanged"
+						@demoted="onActivationChanged"
+						@retry="loadActivation"
+					/>
+				</section>
+
 				<section>
 					<div class="text-base font-medium text-ink-gray-9">Schedule</div>
 					<div class="mt-3 space-y-4">
@@ -472,10 +502,12 @@ import LayoutHeader from "@/components/LayoutHeader.vue";
 import TabBar from "@/components/list/TabBar.vue";
 import CommentsSection from "@/components/doc/CommentsSection.vue";
 import AgentRunsBoard from "@/pages/agents/AgentRunsBoard.vue";
+import ActivationPanel from "@/pages/agents/ActivationPanel.vue";
 import ConfigForm from "@/pages/agents/ConfigForm.vue";
 import AppSourceConsentDialog from "@/components/learning/AppSourceConsentDialog.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { useDocmeta } from "@/composables/useDocmeta";
+import { session } from "@/data/session";
 import { timeAgo, exactDate as fmtDt } from "@/utils/datetime";
 import * as api from "@/api";
 import * as apiAgents from "@/api/agents";
@@ -532,6 +564,7 @@ watch(
 		agent.value = null;
 		error.value = "";
 		adminData.value = null;
+		activation.value = null;
 		load().then(applyHash);
 	}
 );
@@ -548,6 +581,50 @@ const updateAvailable = computed(
 			installation.value.installed_version !== agent.value.version
 		)
 );
+
+// ── PP-4 activation (jarvis#456) ─────────────────────────────────────────────
+// activation_state/reviewer/run_as_user/promoted_by/promoted_at aren't in
+// get_agent's frozen §8.3 `installation` shape - fetched separately (see
+// api/agents.getInstallationActivation) so both the hero badge and the
+// Configure-tab ActivationPanel read one shared, always-in-sync value.
+const activation = ref(null);
+const activationLoading = ref(false);
+const activationError = ref("");
+
+async function loadActivation() {
+	if (!installation.value) {
+		activation.value = null;
+		return;
+	}
+	activationLoading.value = true;
+	activationError.value = "";
+	try {
+		activation.value = (await apiAgents.getInstallationActivation(installation.value.name)) || null;
+	} catch (e) {
+		activation.value = null;
+		activationError.value = errMsg(e);
+	} finally {
+		activationLoading.value = false;
+	}
+}
+watch(
+	() => installation.value && installation.value.name,
+	(name) => {
+		if (name) loadActivation();
+		else activation.value = null;
+	},
+	{ immediate: true }
+);
+
+// The named reviewer's sign-off, or a Jarvis Admin (agents_api mirrors this
+// server-side - this only decides whether to show the button, never grants
+// the action itself).
+const canActOnActivation = computed(
+	() => !!activation.value && (session.user === activation.value.reviewer || isSM.value)
+);
+function onActivationChanged(next) {
+	activation.value = next;
+}
 
 // ── hash-synced tabs (useActiveTabManager pattern) ───────────────────────────
 const tab = ref("overview");

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -697,12 +697,27 @@ const running = ref(false);
 // On-demand run is offered for read-only auditors AND scribes (mirrors the
 // backend run_agent_now gate: nature in Auditor/Scribe); operators draft through
 // the Approval Board and never run on demand.
+// A scribe writes the live Org wiki directly (no shadow holding pen - see
+// agents_api.run_agent_now), so the backend refuses it outright while shadow
+// (jarvis#456). Block it here too rather than let the click round-trip into
+// that refusal - an auditor has no such restriction, its findings just land
+// in the reviewer-only preview set instead.
+const shadowScribeBlocked = computed(
+	() =>
+		!!(
+			agent.value &&
+			agent.value.nature === "Scribe" &&
+			activation.value &&
+			activation.value.activation_state !== "live"
+		)
+);
 const runDisabled = computed(
 	() =>
 		!installation.value ||
 		!installation.value.enabled ||
 		(agent.value && !["Auditor", "Scribe"].includes(agent.value.nature)) ||
-		!(agent.value && agent.value.allowed)
+		!(agent.value && agent.value.allowed) ||
+		shadowScribeBlocked.value
 );
 const runTooltip = computed(() => {
 	if (!agent.value || !installation.value) return "";
@@ -711,6 +726,8 @@ const runTooltip = computed(() => {
 		return "Operators draft through the Approval Board - no on-demand runs";
 	if (!installation.value.enabled) return "Enable the agent first";
 	if (!agent.value.allowed) return "Your roles do not permit this agent";
+	if (shadowScribeBlocked.value)
+		return "Still in shadow preview - promote it to live under Configure first";
 	return nature === "Scribe" ? "Run this agent now" : "Run this audit now";
 });
 


### PR DESCRIPTION
Fixes #456

Adds the missing action UI for shadow-to-live agent activation: any customer who installs a shadow agent (like the custom-app-learning scribe, which cannot run at all in shadow) can now see its real activation state and promote or demote it themselves, with the endpoint's rejection reason shown when it refuses.

## What changed
- New `ActivationPanel` on the agent Configure tab: shows Live/Shadow honestly (the old "Preview" pill on the Runs tab was display-only), who the named reviewer is, and who it runs as.
- Promote and demote both wired to the existing `promote_installation` / `demote_installation` endpoints. The promote dialog names the run-as user and spells out the escalation (runs unattended, output goes live immediately, counts against the activation budget) before confirming.
- A rejection (activation ceiling reached, wrong authority, etc.) keeps the dialog open and shows the endpoint's own message, instead of failing silently.
- A small hero badge mirrors the same state next to the existing Enabled switch.
- Run Now for a shadow scribe is now disabled up front with a tooltip pointing at Configure, instead of round-tripping into the backend's refusal.
- Activation fields (`activation_state`/`reviewer`/`run_as_user`/`promoted_by`/`promoted_at`) are read via `frappe.client.get_value` rather than widening `get_agent`'s response shape, since `agents_api.py` is being edited by two other in-flight PRs (#620, #612). No backend files changed.

## Risk and verification
- Frontend-only change; `agents_api.py` / `agent_runs.py` untouched.
- `ActivationPanel.spec.js` (11 tests, all passing) covers: honest state display, the promote dialog naming the run-as user, promote/demote both calling their endpoints and emitting the new state, a disabled action for a non-reviewer/non-admin viewer, and a rejection surfacing its message while keeping the dialog open.
- `npx vitest run` for the full frontend suite: 716 passed, 1 pre-existing failure in `support-thread.test.js` unrelated to this change (ticket-switch race in the support inbox).
- `pre-commit run` (prettier 2.7.1 + eslint) passes on all changed files.

## Pre-merge checklist

- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
- [ ] CI is green (hosted Actions on this public repo; check `gh pr checks`)
