### PR TITLE
chore(frontend): prune dead .jv-* selectors from settings.css

### DIFF
--- a/frontend/dump-rules.mjs
+++ b/frontend/dump-rules.mjs
@@ -5,38 +5,41 @@ const css = readFileSync("src/assets/settings.css", "utf8");
 const root = postcss.parse(css, { from: "src/assets/settings.css" });
 
 function splitSelectorList(selector) {
-	const parts = [];
-	let depth = 0;
-	let cur = "";
-	for (const ch of selector) {
-		if (ch === "(") depth++;
-		if (ch === ")") depth--;
-		if (ch === "," && depth === 0) {
-			parts.push(cur);
-			cur = "";
-		} else {
-			cur += ch;
-		}
-	}
-	if (cur.trim()) parts.push(cur);
-	return parts;
+  const parts = [];
+  let depth = 0;
+  let cur = "";
+  for (const ch of selector) {
+    if (ch === "(") depth++;
+    if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.trim()) parts.push(cur);
+  return parts;
 }
 
 root.walkRules((rule) => {
-	const selectors = splitSelectorList(rule.selector);
-	const classesPerSelector = selectors.map((sel) => {
-		const found = sel.match(/\.jv-[a-zA-Z0-9_-]+/g) || [];
-		return found.map((c) => c.slice(1));
-	});
-	const parentType = rule.parent && rule.parent.type === "atrule" ? `@${rule.parent.name} ${rule.parent.params}` : "";
-	console.log(
-		JSON.stringify({
-			line: rule.source.start.line,
-			endLine: rule.source.end.line,
-			selector: rule.selector,
-			selectors,
-			classesPerSelector,
-			parent: parentType,
-		})
-	);
+  const selectors = splitSelectorList(rule.selector);
+  const classesPerSelector = selectors.map((sel) => {
+    const found = sel.match(/\.jv-[a-zA-Z0-9_-]+/g) || [];
+    return found.map((c) => c.slice(1));
+  });
+  const parentType =
+    rule.parent && rule.parent.type === "atrule"
+      ? `@${rule.parent.name} ${rule.parent.params}`
+      : "";
+  console.log(
+    JSON.stringify({
+      line: rule.source.start.line,
+      endLine: rule.source.end.line,
+      selector: rule.selector,
+      selectors,
+      classesPerSelector,
+      parent: parentType,
+    })
+  );
 });

--- a/frontend/dump-rules.mjs
+++ b/frontend/dump-rules.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import postcss from "postcss";
+
+const css = readFileSync("src/assets/settings.css", "utf8");
+const root = postcss.parse(css, { from: "src/assets/settings.css" });
+
+function splitSelectorList(selector) {
+	const parts = [];
+	let depth = 0;
+	let cur = "";
+	for (const ch of selector) {
+		if (ch === "(") depth++;
+		if (ch === ")") depth--;
+		if (ch === "," && depth === 0) {
+			parts.push(cur);
+			cur = "";
+		} else {
+			cur += ch;
+		}
+	}
+	if (cur.trim()) parts.push(cur);
+	return parts;
+}
+
+root.walkRules((rule) => {
+	const selectors = splitSelectorList(rule.selector);
+	const classesPerSelector = selectors.map((sel) => {
+		const found = sel.match(/\.jv-[a-zA-Z0-9_-]+/g) || [];
+		return found.map((c) => c.slice(1));
+	});
+	const parentType = rule.parent && rule.parent.type === "atrule" ? `@${rule.parent.name} ${rule.parent.params}` : "";
+	console.log(
+		JSON.stringify({
+			line: rule.source.start.line,
+			endLine: rule.source.end.line,
+			selector: rule.selector,
+			selectors,
+			classesPerSelector,
+			parent: parentType,
+		})
+	);
+});

--- a/frontend/prune-dead-css.mjs
+++ b/frontend/prune-dead-css.mjs
@@ -3,14 +3,15 @@
 // regex/sed — a prior regex-based attempt corrupted this file when a comment
 // swallowed the following selector).
 //
-// A rule (or one comma-branch of a rule's selector list) is deleted only if
-// EVERY .jv-* class token appearing in that selector is in the dead set
-// read from deadClassesFile. This correctly handles compound/descendant
-// selectors like ".jv-dark .jv-settings-navitem.on": jv-dark is a live,
-// widely-used dark-mode scope class, but the rule as a whole can never
-// match anything because .jv-settings-navitem (the other required part of
-// the compound) never appears in the live DOM, so the whole selector is
-// still dead and the rule is removed.
+// A rule (or one comma-branch of a rule's selector list) is deleted as soon
+// as ANY .jv-* class token appearing in that selector is in the dead set
+// read from deadClassesFile, not only when every class in it is dead. This
+// correctly handles compound/descendant selectors like
+// ".jv-dark .jv-settings-navitem.on": jv-dark is a live, widely-used
+// dark-mode scope class, but the rule as a whole can never match anything
+// because .jv-settings-navitem (the other required part of the compound)
+// never appears in the live DOM, so the whole selector is still dead and
+// the rule is removed even though .jv-dark itself is very much alive.
 //
 // After rule removal, any @media block left with no rules and no comments
 // is dropped too. @keyframes are never touched by class-based removal since
@@ -20,11 +21,28 @@
 // `animation: jv-popin` (confirmed live, see PR description), so it must
 // survive even though every settings.css rule using it is being deleted.
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import postcss from "postcss";
 
 const CSS_FILE = process.argv[2] || "src/assets/settings.css";
-const DEAD_FILE = process.argv[3] || "/tmp/dead-final.txt";
+// No default path ships in the repo on purpose: the dead-class list is a
+// derived artifact of scan-jv-classes.mjs's output, not something to keep in
+// sync by hand. To reproduce: run
+//   node scan-jv-classes.mjs src src/assets/settings.css
+// take everything under "=== DEAD CLASSES ===", strip the trailing
+// "[only matched inside another file's own <style> block]" notes, and drop
+// the four jv-fade-* lines (runtime-derived by <transition name="jv-fade">
+// in ChatView.vue, so they're live despite showing up dead here — see the
+// PR description). Save the remaining class names one per line, then pass
+// that file's path as this script's second argument.
+const DEAD_FILE = process.argv[3];
+if (!DEAD_FILE || !existsSync(DEAD_FILE)) {
+  console.error(
+    "Usage: node prune-dead-css.mjs <settings.css path> <dead-classes.txt path>\n" +
+      "See the comment at the top of this file for how to (re)generate the dead-classes file."
+  );
+  process.exit(1);
+}
 
 const dead = new Set(
   readFileSync(DEAD_FILE, "utf8").trim().split("\n").filter(Boolean)

--- a/frontend/prune-dead-css.mjs
+++ b/frontend/prune-dead-css.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Structurally deletes dead .jv-* rules from settings.css using postcss (not
+// regex/sed — a prior regex-based attempt corrupted this file when a comment
+// swallowed the following selector).
+//
+// A rule (or one comma-branch of a rule's selector list) is deleted only if
+// EVERY .jv-* class token appearing in that selector is in the dead set
+// read from deadClassesFile. This correctly handles compound/descendant
+// selectors like ".jv-dark .jv-settings-navitem.on": jv-dark is a live,
+// widely-used dark-mode scope class, but the rule as a whole can never
+// match anything because .jv-settings-navitem (the other required part of
+// the compound) never appears in the live DOM, so the whole selector is
+// still dead and the rule is removed.
+//
+// After rule removal, any @media block left with no rules and no comments
+// is dropped too. @keyframes are never touched by class-based removal since
+// their step selectors (from/to/N%) contain no .jv-* tokens — this matters
+// because @keyframes jv-popin, though only reached via the (dead) .jv-settings
+// rule from *within* this file, is also consumed by SkillDetail.vue's own
+// `animation: jv-popin` (confirmed live, see PR description), so it must
+// survive even though every settings.css rule using it is being deleted.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import postcss from "postcss";
+
+const CSS_FILE = process.argv[2] || "src/assets/settings.css";
+const DEAD_FILE = process.argv[3] || "/tmp/dead-final.txt";
+
+const dead = new Set(
+  readFileSync(DEAD_FILE, "utf8").trim().split("\n").filter(Boolean)
+);
+
+function splitSelectorList(selector) {
+  const parts = [];
+  let depth = 0;
+  let cur = "";
+  for (const ch of selector) {
+    if (ch === "(") depth++;
+    if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.trim()) parts.push(cur);
+  return parts;
+}
+
+function classesIn(selector) {
+  return (selector.match(/\.jv-[a-zA-Z0-9_-]+/g) || []).map((c) => c.slice(1));
+}
+
+const css = readFileSync(CSS_FILE, "utf8");
+const root = postcss.parse(css, { from: CSS_FILE });
+
+let removedRuleCount = 0;
+let trimmedSelectorCount = 0;
+const removedSelectors = [];
+
+root.walkRules((rule) => {
+  const branches = splitSelectorList(rule.selector);
+  const jvBranches = branches.filter((b) => classesIn(b).length > 0);
+  if (jvBranches.length === 0) return; // not a .jv-* rule (e.g. keyframe steps)
+
+  const keptBranches = branches.filter((b) => {
+    const classes = classesIn(b);
+    if (classes.length === 0) return true; // no jv- class in this branch; leave as-is
+    // A compound/descendant selector needs EVERY one of its classes to
+    // match some real element simultaneously. If even one class token in
+    // this branch has zero real usage anywhere (confirmed dead), the
+    // whole branch can never match — regardless of how live any other
+    // class in the compound is elsewhere (e.g. ".jv-dark .jv-seg button.on"
+    // is unreachable because nothing ever has class="jv-seg", even though
+    // .jv-dark itself is applied all over the app). So "any dead" kills
+    // the branch, not "all dead".
+    return !classes.some((c) => dead.has(c));
+  });
+
+  if (keptBranches.length === branches.length) return; // nothing dead here
+
+  if (keptBranches.length === 0) {
+    removedSelectors.push(rule.selector.trim());
+    rule.remove();
+    removedRuleCount++;
+  } else {
+    trimmedSelectorCount++;
+    removedSelectors.push(
+      `(partial) ${rule.selector.trim()} -> ${keptBranches.join(", ").trim()}`
+    );
+    rule.selector = keptBranches.join(",\n");
+  }
+});
+
+// Drop now-empty @media (or other at-rules) blocks: no child nodes left at all
+// (covers both rules and any comments that were inside).
+let removedAtRules = 0;
+root.walkAtRules((atrule) => {
+  if (atrule.nodes && atrule.nodes.length === 0) {
+    removedAtRules++;
+    atrule.remove();
+  }
+});
+
+writeFileSync(CSS_FILE, root.toString());
+
+console.log(`Removed ${removedRuleCount} whole rules.`);
+console.log(
+  `Trimmed ${trimmedSelectorCount} rules (partial comma-branch removal).`
+);
+console.log(`Removed ${removedAtRules} now-empty at-rule blocks.`);
+console.log("");
+console.log("=== Removed / trimmed selectors ===");
+for (const s of removedSelectors) console.log(s);

--- a/frontend/scan-jv-classes.mjs
+++ b/frontend/scan-jv-classes.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Usage scan for .jv-* selectors defined in frontend/src/assets/settings.css.
+//
+// Strategy:
+// 1. Parse settings.css with postcss to get every top-level and nested rule's
+//    selectors structurally (comments, media queries, @keyframes handled by
+//    the parser, not by regex).
+// 2. Extract every distinct `.jv-xxxx` class token referenced by those
+//    selectors (ignoring combinators, pseudo-classes, attribute selectors).
+// 3. Search the rest of the frontend source tree (excluding settings.css
+//    itself) for any textual reference to each class name: class="...",
+//    :class bindings, template literals, JS string literals. This is a
+//    generic substring search per class name across all source files, plus
+//    a separate check for each file's own <style> blocks so a class that
+//    only appears inside another component's *own* <style> (i.e. redefined
+//    there, not consumed) is not miscounted as "used".
+// 4. Report classes with zero references outside settings.css and outside
+//    any other file's own <style> block.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, extname, relative } from "node:path";
+import postcss from "postcss";
+
+const FRONTEND_SRC = process.argv[2] || "src";
+const CSS_FILE = process.argv[3] || "src/assets/settings.css";
+
+// ---------- Step 1+2: extract selectors from settings.css ----------
+
+function extractClassesFromCss(cssPath) {
+	const css = readFileSync(cssPath, "utf8");
+	const root = postcss.parse(css, { from: cssPath });
+	const classes = new Set();
+	const classToRuleSelectors = new Map(); // class -> Set of full selectors it appeared in
+
+	root.walkRules((rule) => {
+		// rule.selector may be a comma list; postcss gives raw selector string.
+		// Split on top-level commas (postcss selectors don't nest commas inside
+		// parens in our file, but guard simple parens like :not()).
+		const selectors = splitSelectorList(rule.selector);
+		for (const sel of selectors) {
+			const found = sel.match(/\.jv-[a-zA-Z0-9_-]+/g) || [];
+			for (const cls of found) {
+				const name = cls.slice(1); // strip leading dot
+				classes.add(name);
+				if (!classToRuleSelectors.has(name)) classToRuleSelectors.set(name, new Set());
+				classToRuleSelectors.get(name).add(sel.trim());
+			}
+		}
+	});
+
+	// Also catch classes referenced only inside @keyframes-adjacent constructs
+	// or animation-name / transition-name-derived class families is handled
+	// separately below (runtime-derived names), not here.
+
+	return { classes, classToRuleSelectors };
+}
+
+function splitSelectorList(selector) {
+	// naive top-level comma split, respecting parens
+	const parts = [];
+	let depth = 0;
+	let cur = "";
+	for (const ch of selector) {
+		if (ch === "(") depth++;
+		if (ch === ")") depth--;
+		if (ch === "," && depth === 0) {
+			parts.push(cur);
+			cur = "";
+		} else {
+			cur += ch;
+		}
+	}
+	if (cur.trim()) parts.push(cur);
+	return parts;
+}
+
+// ---------- Step 3: walk source files ----------
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "coverage"]);
+const TEXT_EXT = new Set([".vue", ".js", ".jsx", ".ts", ".tsx", ".css", ".html", ".md"]);
+
+function walk(dir, out = []) {
+	for (const entry of readdirSync(dir)) {
+		if (SKIP_DIRS.has(entry)) continue;
+		const full = join(dir, entry);
+		const st = statSync(full);
+		if (st.isDirectory()) {
+			walk(full, out);
+		} else if (TEXT_EXT.has(extname(full))) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+// Extract a file's own <style> block contents (for .vue SFCs) so we can
+// exclude "defined in its own style block elsewhere" matches from counting
+// as usage.
+function ownStyleBlockRanges(content) {
+	const ranges = [];
+	const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+	let m;
+	while ((m = re.exec(content))) {
+		ranges.push([m.index, m.index + m[0].length]);
+	}
+	return ranges;
+}
+
+function isInsideRanges(idx, ranges) {
+	return ranges.some(([a, b]) => idx >= a && idx < b);
+}
+
+function main() {
+	const cssAbsPath = CSS_FILE;
+	const { classes, classToRuleSelectors } = extractClassesFromCss(cssAbsPath);
+
+	const allFiles = walk(FRONTEND_SRC);
+	const otherFiles = allFiles.filter((f) => relative(".", f) !== relative(".", cssAbsPath));
+
+	const fileContents = new Map();
+	for (const f of otherFiles) {
+		fileContents.set(f, readFileSync(f, "utf8"));
+	}
+
+	const results = [];
+	for (const cls of [...classes].sort()) {
+		const usages = []; // {file, line, kind}
+		for (const [f, content] of fileContents) {
+			const isVue = extname(f) === ".vue";
+			const styleRanges = isVue ? ownStyleBlockRanges(content) : [];
+			// find all occurrences of the literal class name as a "word" (not
+			// part of a longer class name), e.g. jv-btn should not match
+			// jv-btn-danger.
+			const re = new RegExp(`(?<![\\w-])${escapeRegex(cls)}(?![\\w-])`, "g");
+			let m;
+			while ((m = re.exec(content))) {
+				const inOwnStyle = isInsideRanges(m.index, styleRanges);
+				const lineNum = content.slice(0, m.index).split("\n").length;
+				usages.push({
+					file: relative(".", f),
+					line: lineNum,
+					inOwnStyle,
+				});
+			}
+		}
+
+		const realUsages = usages.filter((u) => !u.inOwnStyle);
+		const onlyInOtherStyleBlocks = usages.length > 0 && realUsages.length === 0;
+
+		results.push({
+			class: cls,
+			selectors: [...classToRuleSelectors.get(cls)],
+			totalMatches: usages.length,
+			realUsageCount: realUsages.length,
+			realUsages: realUsages.slice(0, 5),
+			onlyInOtherStyleBlocks,
+		});
+	}
+
+	const dead = results.filter((r) => r.realUsageCount === 0);
+	const live = results.filter((r) => r.realUsageCount > 0);
+
+	console.log(`Total unique .jv-* classes defined in ${CSS_FILE}: ${results.length}`);
+	console.log(`Live (referenced outside settings.css, outside other files' own <style>): ${live.length}`);
+	console.log(`Dead (zero genuine reference): ${dead.length}`);
+	console.log("");
+	console.log("=== DEAD CLASSES ===");
+	for (const r of dead) {
+		const note = r.onlyInOtherStyleBlocks ? "  [only matched inside another file's own <style> block]" : "";
+		console.log(`- ${r.class}${note}`);
+	}
+	console.log("");
+	console.log("=== LIVE CLASSES (with first usage) ===");
+	for (const r of live) {
+		const u = r.realUsages[0];
+		console.log(`- ${r.class}  (${r.realUsageCount}x, e.g. ${u.file}:${u.line})`);
+	}
+}
+
+function escapeRegex(s) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+main();

--- a/frontend/scan-jv-classes.mjs
+++ b/frontend/scan-jv-classes.mjs
@@ -13,9 +13,21 @@
 //    generic substring search per class name across all source files, plus
 //    a separate check for each file's own <style> blocks so a class that
 //    only appears inside another component's *own* <style> (i.e. redefined
-//    there, not consumed) is not miscounted as "used".
+//    there, not consumed) is not miscounted as "used". HTML comments
+//    (<!-- ... -->) and JS/CSS block comments (/* ... */) are stripped
+//    (replaced with equal-length whitespace, preserving line numbers)
+//    before searching, so prose that merely *mentions* a class name in a
+//    comment does not count as a usage. A real false positive of this
+//    exact kind was found during this scan: SettingsDialog.vue:9 mentions
+//    ".jv-settings-overlay" inside an HTML template comment.
 // 4. Report classes with zero references outside settings.css and outside
 //    any other file's own <style> block.
+//
+// Known limitation this script does NOT solve automatically: runtime-
+// derived class names. `<transition name="jv-fade">` makes Vue synthesize
+// `jv-fade-enter-active` etc. at runtime with no literal string anywhere
+// for those exact tokens. Such cases are cross-checked by hand; see the PR
+// description for what was checked in this pass.
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, extname, relative } from "node:path";
@@ -27,158 +39,194 @@ const CSS_FILE = process.argv[3] || "src/assets/settings.css";
 // ---------- Step 1+2: extract selectors from settings.css ----------
 
 function extractClassesFromCss(cssPath) {
-	const css = readFileSync(cssPath, "utf8");
-	const root = postcss.parse(css, { from: cssPath });
-	const classes = new Set();
-	const classToRuleSelectors = new Map(); // class -> Set of full selectors it appeared in
+  const css = readFileSync(cssPath, "utf8");
+  const root = postcss.parse(css, { from: cssPath });
+  const classes = new Set();
+  const classToRuleSelectors = new Map(); // class -> Set of full selectors it appeared in
 
-	root.walkRules((rule) => {
-		// rule.selector may be a comma list; postcss gives raw selector string.
-		// Split on top-level commas (postcss selectors don't nest commas inside
-		// parens in our file, but guard simple parens like :not()).
-		const selectors = splitSelectorList(rule.selector);
-		for (const sel of selectors) {
-			const found = sel.match(/\.jv-[a-zA-Z0-9_-]+/g) || [];
-			for (const cls of found) {
-				const name = cls.slice(1); // strip leading dot
-				classes.add(name);
-				if (!classToRuleSelectors.has(name)) classToRuleSelectors.set(name, new Set());
-				classToRuleSelectors.get(name).add(sel.trim());
-			}
-		}
-	});
+  root.walkRules((rule) => {
+    // rule.selector may be a comma list; postcss gives raw selector string.
+    // Split on top-level commas (postcss selectors don't nest commas inside
+    // parens in our file, but guard simple parens like :not()).
+    const selectors = splitSelectorList(rule.selector);
+    for (const sel of selectors) {
+      const found = sel.match(/\.jv-[a-zA-Z0-9_-]+/g) || [];
+      for (const cls of found) {
+        const name = cls.slice(1); // strip leading dot
+        classes.add(name);
+        if (!classToRuleSelectors.has(name))
+          classToRuleSelectors.set(name, new Set());
+        classToRuleSelectors.get(name).add(sel.trim());
+      }
+    }
+  });
 
-	// Also catch classes referenced only inside @keyframes-adjacent constructs
-	// or animation-name / transition-name-derived class families is handled
-	// separately below (runtime-derived names), not here.
+  // Also catch classes referenced only inside @keyframes-adjacent constructs
+  // or animation-name / transition-name-derived class families is handled
+  // separately below (runtime-derived names), not here.
 
-	return { classes, classToRuleSelectors };
+  return { classes, classToRuleSelectors };
 }
 
 function splitSelectorList(selector) {
-	// naive top-level comma split, respecting parens
-	const parts = [];
-	let depth = 0;
-	let cur = "";
-	for (const ch of selector) {
-		if (ch === "(") depth++;
-		if (ch === ")") depth--;
-		if (ch === "," && depth === 0) {
-			parts.push(cur);
-			cur = "";
-		} else {
-			cur += ch;
-		}
-	}
-	if (cur.trim()) parts.push(cur);
-	return parts;
+  // naive top-level comma split, respecting parens
+  const parts = [];
+  let depth = 0;
+  let cur = "";
+  for (const ch of selector) {
+    if (ch === "(") depth++;
+    if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.trim()) parts.push(cur);
+  return parts;
 }
 
 // ---------- Step 3: walk source files ----------
 
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "coverage"]);
-const TEXT_EXT = new Set([".vue", ".js", ".jsx", ".ts", ".tsx", ".css", ".html", ".md"]);
+const TEXT_EXT = new Set([
+  ".vue",
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".css",
+  ".html",
+  ".md",
+]);
 
 function walk(dir, out = []) {
-	for (const entry of readdirSync(dir)) {
-		if (SKIP_DIRS.has(entry)) continue;
-		const full = join(dir, entry);
-		const st = statSync(full);
-		if (st.isDirectory()) {
-			walk(full, out);
-		} else if (TEXT_EXT.has(extname(full))) {
-			out.push(full);
-		}
-	}
-	return out;
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (TEXT_EXT.has(extname(full))) {
+      out.push(full);
+    }
+  }
+  return out;
 }
 
 // Extract a file's own <style> block contents (for .vue SFCs) so we can
 // exclude "defined in its own style block elsewhere" matches from counting
 // as usage.
 function ownStyleBlockRanges(content) {
-	const ranges = [];
-	const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
-	let m;
-	while ((m = re.exec(content))) {
-		ranges.push([m.index, m.index + m[0].length]);
-	}
-	return ranges;
+  const ranges = [];
+  const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+  let m;
+  while ((m = re.exec(content))) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
 }
 
 function isInsideRanges(idx, ranges) {
-	return ranges.some(([a, b]) => idx >= a && idx < b);
+  return ranges.some(([a, b]) => idx >= a && idx < b);
+}
+
+// Blank out HTML comments and JS/CSS block comments, keeping every
+// character's byte offset (and every newline) intact so line-number
+// reporting downstream stays accurate. Line comments (`//`) are
+// deliberately left alone: blanking them risks eating real code that
+// follows "//" inside a string or URL, and this codebase's actual false
+// positives were all block/HTML comments.
+function blankOut(content, re) {
+  return content.replace(re, (m) => m.replace(/[^\n]/g, " "));
+}
+
+function stripComments(content) {
+  let out = blankOut(content, /<!--[\s\S]*?-->/g);
+  out = blankOut(out, /\/\*[\s\S]*?\*\//g);
+  return out;
 }
 
 function main() {
-	const cssAbsPath = CSS_FILE;
-	const { classes, classToRuleSelectors } = extractClassesFromCss(cssAbsPath);
+  const cssAbsPath = CSS_FILE;
+  const { classes, classToRuleSelectors } = extractClassesFromCss(cssAbsPath);
 
-	const allFiles = walk(FRONTEND_SRC);
-	const otherFiles = allFiles.filter((f) => relative(".", f) !== relative(".", cssAbsPath));
+  const allFiles = walk(FRONTEND_SRC);
+  const otherFiles = allFiles.filter(
+    (f) => relative(".", f) !== relative(".", cssAbsPath)
+  );
 
-	const fileContents = new Map();
-	for (const f of otherFiles) {
-		fileContents.set(f, readFileSync(f, "utf8"));
-	}
+  const fileContents = new Map();
+  for (const f of otherFiles) {
+    fileContents.set(f, stripComments(readFileSync(f, "utf8")));
+  }
 
-	const results = [];
-	for (const cls of [...classes].sort()) {
-		const usages = []; // {file, line, kind}
-		for (const [f, content] of fileContents) {
-			const isVue = extname(f) === ".vue";
-			const styleRanges = isVue ? ownStyleBlockRanges(content) : [];
-			// find all occurrences of the literal class name as a "word" (not
-			// part of a longer class name), e.g. jv-btn should not match
-			// jv-btn-danger.
-			const re = new RegExp(`(?<![\\w-])${escapeRegex(cls)}(?![\\w-])`, "g");
-			let m;
-			while ((m = re.exec(content))) {
-				const inOwnStyle = isInsideRanges(m.index, styleRanges);
-				const lineNum = content.slice(0, m.index).split("\n").length;
-				usages.push({
-					file: relative(".", f),
-					line: lineNum,
-					inOwnStyle,
-				});
-			}
-		}
+  const results = [];
+  for (const cls of [...classes].sort()) {
+    const usages = []; // {file, line, kind}
+    for (const [f, content] of fileContents) {
+      const isVue = extname(f) === ".vue";
+      const styleRanges = isVue ? ownStyleBlockRanges(content) : [];
+      // find all occurrences of the literal class name as a "word" (not
+      // part of a longer class name), e.g. jv-btn should not match
+      // jv-btn-danger.
+      const re = new RegExp(`(?<![\\w-])${escapeRegex(cls)}(?![\\w-])`, "g");
+      let m;
+      while ((m = re.exec(content))) {
+        const inOwnStyle = isInsideRanges(m.index, styleRanges);
+        const lineNum = content.slice(0, m.index).split("\n").length;
+        usages.push({
+          file: relative(".", f),
+          line: lineNum,
+          inOwnStyle,
+        });
+      }
+    }
 
-		const realUsages = usages.filter((u) => !u.inOwnStyle);
-		const onlyInOtherStyleBlocks = usages.length > 0 && realUsages.length === 0;
+    const realUsages = usages.filter((u) => !u.inOwnStyle);
+    const onlyInOtherStyleBlocks = usages.length > 0 && realUsages.length === 0;
 
-		results.push({
-			class: cls,
-			selectors: [...classToRuleSelectors.get(cls)],
-			totalMatches: usages.length,
-			realUsageCount: realUsages.length,
-			realUsages: realUsages.slice(0, 5),
-			onlyInOtherStyleBlocks,
-		});
-	}
+    results.push({
+      class: cls,
+      selectors: [...classToRuleSelectors.get(cls)],
+      totalMatches: usages.length,
+      realUsageCount: realUsages.length,
+      realUsages: realUsages.slice(0, 5),
+      onlyInOtherStyleBlocks,
+    });
+  }
 
-	const dead = results.filter((r) => r.realUsageCount === 0);
-	const live = results.filter((r) => r.realUsageCount > 0);
+  const dead = results.filter((r) => r.realUsageCount === 0);
+  const live = results.filter((r) => r.realUsageCount > 0);
 
-	console.log(`Total unique .jv-* classes defined in ${CSS_FILE}: ${results.length}`);
-	console.log(`Live (referenced outside settings.css, outside other files' own <style>): ${live.length}`);
-	console.log(`Dead (zero genuine reference): ${dead.length}`);
-	console.log("");
-	console.log("=== DEAD CLASSES ===");
-	for (const r of dead) {
-		const note = r.onlyInOtherStyleBlocks ? "  [only matched inside another file's own <style> block]" : "";
-		console.log(`- ${r.class}${note}`);
-	}
-	console.log("");
-	console.log("=== LIVE CLASSES (with first usage) ===");
-	for (const r of live) {
-		const u = r.realUsages[0];
-		console.log(`- ${r.class}  (${r.realUsageCount}x, e.g. ${u.file}:${u.line})`);
-	}
+  console.log(
+    `Total unique .jv-* classes defined in ${CSS_FILE}: ${results.length}`
+  );
+  console.log(
+    `Live (referenced outside settings.css, outside other files' own <style>): ${live.length}`
+  );
+  console.log(`Dead (zero genuine reference): ${dead.length}`);
+  console.log("");
+  console.log("=== DEAD CLASSES ===");
+  for (const r of dead) {
+    const note = r.onlyInOtherStyleBlocks
+      ? "  [only matched inside another file's own <style> block]"
+      : "";
+    console.log(`- ${r.class}${note}`);
+  }
+  console.log("");
+  console.log("=== LIVE CLASSES (with first usage) ===");
+  for (const r of live) {
+    const u = r.realUsages[0];
+    console.log(
+      `- ${r.class}  (${r.realUsageCount}x, e.g. ${u.file}:${u.line})`
+    );
+  }
 }
 
 function escapeRegex(s) {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 main();

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -356,10 +356,6 @@
 .jv-settings-overlay.jv-dark {
 	background: rgba(0, 0, 0, 0.55);
 }
-/* Widened dialog + roomier grouped rail. */
-/* NOTE: this block is LAST, so it wins the cascade over the .jv-settings rule at
-   the top of the file. Any width change must be made in BOTH places or it will
-   appear to do nothing. */
 
 /* ===== narrow screens =======================================================
    The rail is `flex: none; width: 230px`, so it never shrinks: at a 390px
@@ -367,7 +363,8 @@
    the dialog — the rail becomes a horizontal, scrollable tab strip above the
    body. Group headings are dropped because they carry no meaning in a single
    row; the items stay in the same order, so the grouping is still implied.
-   Placed at the very end so it outranks BOTH .jv-settings blocks above. */
+   Placed at the very end so it outranks the .jv-settings-overlay padding rule
+   above. */
 @media (max-width: 720px) {
 	.jv-settings-overlay {
 		padding: 12px;

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -43,19 +43,6 @@
    min() guards a short viewport: a bare height/min-height BEATS max-height in the
    cascade, so on a landscape phone the dialog would grow past the screen.
    Below 720px the fixed rail can't fit — see the stacking media query at the end. */
-.jv-settings {
-	width: 1080px;
-	max-width: 100%;
-	height: min(680px, 88vh);
-	max-height: 88vh;
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: 16px;
-	display: flex;
-	overflow: hidden;
-	box-shadow: 0 0 1px rgba(0, 0, 0, 0.2), 0 24px 30px -8px rgba(0, 0, 0, 0.1);
-	animation: jv-popin 0.1s ease-out;
-}
 @keyframes jv-popin {
 	from {
 		transform: scale(0.98);
@@ -66,100 +53,12 @@
 		opacity: 1;
 	}
 }
-.jv-settings-nav {
-	width: 230px;
-	flex: none;
-	background: var(--surface-1);
-	border-right: 1px solid var(--border);
-	padding: 8px;
-	display: flex;
-	flex-direction: column;
-	gap: 3px;
-	overflow-y: auto;
-}
-.jv-settings-nav-title {
-	font-size: 15px;
-	font-weight: 600;
-	color: var(--text);
-	padding: 6px 8px 10px;
-}
-.jv-settings-navitem {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	width: 100%;
-	height: 28px;
-	padding: 0 8px;
-	border: none;
-	background: transparent;
-	border-radius: 8px;
-	font-family: inherit;
-	font-size: 13px;
-	font-weight: 420;
-	color: var(--text-2);
-	cursor: pointer;
-	text-align: left;
-	transition: background-color 0.15s ease, color 0.15s ease;
-}
-.jv-settings-navitem svg {
-	color: var(--text-3);
-	flex: none;
-}
-.jv-settings-navitem:hover {
-	background: var(--surface-2);
-	color: var(--text);
-}
-.jv-settings-navitem.on {
-	background: var(--surface);
-	color: var(--text);
-	box-shadow: 0 0 1px rgba(0, 0, 0, 0.33), 0 1px 3px rgba(0, 0, 0, 0.14);
-}
-.jv-dark .jv-settings-navitem.on {
-	background: var(--surface-3);
-	box-shadow: 0 0 0 1px var(--border-2);
-}
-.jv-settings-navitem.on svg {
-	color: var(--text);
-}
 /* min-height:0 — REQUIRED now that .jv-settings is height:auto/max-height. A flex
    item defaults to min-height:auto, which refuses to shrink below its content, so
    a tall pane would blow past max-height and get clipped by the shell's
    overflow:hidden instead of scrolling in .jv-settings-body. */
-.jv-settings-main {
-	flex: 1;
-	min-width: 0;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
-}
 /* Pane-owned header (design.md §4.1): title + optional description left, ghost
    close right. The dialog renders it once; panes carry no duplicate heading. */
-.jv-settings-head {
-	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 20px 24px 14px;
-	flex: none;
-}
-.jv-settings-head-title {
-	font-size: 16px;
-	font-weight: 600;
-	color: var(--text);
-	line-height: 1.2;
-}
-.jv-settings-head-desc {
-	font-size: 13px;
-	line-height: 1.5;
-	color: var(--text-3);
-	margin-top: 4px;
-}
-.jv-settings-body {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding: 4px 24px 28px;
-}
 
 /* Overlay-style scrollbar for the settings dialog's scroll regions (this
    legacy .jv-settings-body plus SettingsPane.vue's own overflow-y-auto div,
@@ -245,129 +144,7 @@
 	padding-top: 16px;
 	border-top: 1px solid var(--border);
 }
-.jv-set-sec {
-	font-size: 14px;
-	font-weight: 600;
-	color: var(--text);
-	margin: 0 0 6px;
-}
-.jv-set-sub {
-	font-size: 12px;
-	line-height: 1.5;
-	color: var(--text-3);
-	font-weight: 420;
-}
 /* usage stat cards */
-.jv-statgrid {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 10px;
-}
-.jv-stat {
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: 10px;
-	padding: 12px 14px;
-}
-.jv-stat-label {
-	font-size: 12px;
-	font-weight: 420;
-	color: var(--text-3);
-}
-.jv-stat-val {
-	font-size: 20px;
-	font-weight: 500;
-	color: var(--text);
-	margin-top: 6px;
-	line-height: 1.1;
-}
-.jv-stat-sub {
-	font-size: 12px;
-	color: var(--text-3);
-	margin-top: 3px;
-}
-.jv-set-row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 10px 0;
-	border-bottom: 1px solid var(--border);
-	font-size: 13px;
-	color: var(--text-2);
-}
-.jv-set-row:last-child {
-	border-bottom: 0;
-}
-.jv-set-row b {
-	font-weight: 500;
-	color: var(--text);
-	text-align: right;
-}
-.jv-set-empty {
-	font-size: 13px;
-	color: var(--text-3);
-	padding: 14px 0;
-}
-.jv-set-hint {
-	font-size: 12px;
-	color: var(--text-3);
-	margin-top: 8px;
-}
-.jv-kbd-row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 9px 0;
-	border-bottom: 1px solid var(--border);
-	font-size: 13px;
-	color: var(--text-2);
-}
-.jv-kbd-row:last-of-type {
-	border-bottom: 0;
-}
-.jv-kbd {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 22px;
-	height: 22px;
-	padding: 0 6px;
-	background: var(--surface-1);
-	border: 1px solid var(--border-2);
-	border-radius: 6px;
-	font-family: ui-monospace, "SF Mono", Menlo, monospace;
-	font-size: 11.5px;
-	font-weight: 500;
-	color: var(--text);
-}
-.jv-kbd-plus {
-	color: var(--text-3);
-	margin: 0 3px;
-	font-size: 11px;
-}
-.jv-est {
-	font-size: 10px;
-	font-weight: 500;
-	color: var(--text-3);
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	padding: 1px 7px;
-}
-.jv-usage-bar {
-	margin-top: 12px;
-	height: 6px;
-	border-radius: 99px;
-	background: var(--surface-2);
-	overflow: hidden;
-}
-.jv-usage-fill {
-	height: 100%;
-	border-radius: 99px;
-	background: var(--text);
-	transition: width 0.25s ease;
-}
 
 /* toggle switch — on-state is near-black (frappe Switch), not green */
 .jv-switch {
@@ -407,269 +184,10 @@
 /* segmented control — one recipe for Appearance (.jv-seg), macro-run filters
    (.jv-runchips) and the AI-models tabs (.jv-acct-aitabs): gray track, active
    = raised chip (design.md §3.5) */
-.jv-seg,
-.jv-runchips,
-.jv-acct-aitabs {
-	display: inline-flex;
-	align-items: center;
-	background: var(--surface-2);
-	border: 1px solid var(--border);
-	border-radius: 10px;
-	padding: 2px;
-	gap: 2px;
-}
-.jv-seg button,
-.jv-runchips button,
-.jv-acct-aitabs button {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 5px 12px;
-	background: transparent;
-	border: none;
-	border-radius: 8px;
-	font-family: inherit;
-	font-size: 13px;
-	font-weight: 420;
-	color: var(--text-3);
-	cursor: pointer;
-	transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
-}
-.jv-seg button:hover,
-.jv-runchips button:hover,
-.jv-acct-aitabs button:hover {
-	color: var(--text-2);
-	background: var(--surface-3);
-}
-.jv-seg button.on,
-.jv-runchips button.on,
-.jv-acct-aitabs button.on {
-	background: var(--surface);
-	color: var(--text);
-	box-shadow: 0 0 1px rgba(0, 0, 0, 0.33), 0 1px 3px rgba(0, 0, 0, 0.14);
-}
-.jv-dark .jv-seg button.on,
-.jv-dark .jv-runchips button.on,
-.jv-dark .jv-acct-aitabs button.on {
-	background: var(--surface-3);
-	box-shadow: none;
-}
-.jv-seg button svg {
-	color: var(--text-3);
-}
-.jv-seg button.on svg {
-	color: var(--text);
-}
 
 /* activity rows */
-.jv-act {
-	padding: 10px 0;
-	border-bottom: 1px solid var(--border);
-}
-.jv-act:last-child {
-	border-bottom: 0;
-}
-.jv-act-top {
-	display: flex;
-	align-items: center;
-	gap: 7px;
-	font-size: 13px;
-	font-weight: 420;
-	color: var(--text-2);
-}
-.jv-act-ms {
-	margin-left: auto;
-	font-variant-numeric: tabular-nums;
-	color: var(--text-3);
-	font-weight: 420;
-}
-.jv-act-names {
-	font-size: 11.5px;
-	color: var(--text-3);
-	margin-top: 3px;
-	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-	word-break: break-word;
-}
 
 /* macro run history dashboard (Macro runs) */
-.jv-runfilters {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	margin: 12px 0 6px;
-	flex-wrap: wrap;
-}
-.jv-runmacrosel {
-	margin-left: auto;
-	font-family: inherit;
-	font-size: 13px;
-	color: var(--text-2);
-	background: var(--surface-1);
-	border: 1px solid var(--border-2);
-	border-radius: 8px;
-	padding: 5px 10px;
-	cursor: pointer;
-	outline: none;
-	transition: border-color 0.15s ease, background-color 0.15s ease;
-}
-.jv-runmacrosel:focus {
-	background: var(--surface);
-	border-color: var(--text-3);
-}
-.jv-run {
-	display: flex;
-	align-items: flex-start;
-	gap: 11px;
-	padding: 12px 2px;
-	border-bottom: 1px solid var(--surface-2);
-}
-.jv-run:last-of-type {
-	border-bottom: none;
-}
-.jv-run-dot {
-	flex: none;
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	margin-top: 5px;
-}
-.jv-run-dot.d-ok {
-	background: var(--green);
-}
-.jv-run-dot.d-err {
-	background: var(--red);
-}
-.jv-run-dot.d-run {
-	background: var(--cta);
-}
-.jv-run-dot.d-stop {
-	background: var(--text-3);
-}
-.jv-run-main {
-	flex: 1;
-	min-width: 0;
-}
-.jv-run-top {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	flex-wrap: wrap;
-}
-.jv-run-name {
-	font-size: 13px;
-	font-weight: 500;
-	color: var(--text);
-}
-.jv-run-badge {
-	font-size: 11px;
-	font-weight: 420;
-	padding: 2px 8px;
-	border-radius: 999px;
-	text-transform: capitalize;
-}
-.jv-run-badge.b-ok {
-	background: var(--green-bg);
-	color: var(--green);
-}
-.jv-run-badge.b-err {
-	background: var(--red-bg);
-	color: var(--red);
-}
-.jv-run-badge.b-run {
-	background: var(--cta-bg);
-	color: var(--link);
-}
-.jv-run-badge.b-stop {
-	background: var(--surface-2);
-	color: var(--text-3);
-}
-.jv-run-trig {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	font-size: 11px;
-	color: var(--text-3);
-}
-.jv-run-meta {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-size: 12px;
-	color: var(--text-3);
-	margin-top: 4px;
-	flex-wrap: wrap;
-}
-.jv-run-prog {
-	font-family: ui-monospace, Menlo, monospace;
-}
-.jv-run-sep {
-	opacity: 0.5;
-}
-.jv-run-err {
-	display: flex;
-	align-items: center;
-	gap: 5px;
-	margin-top: 5px;
-	font-size: 12px;
-	color: var(--red);
-	word-break: break-word;
-}
-.jv-run-err svg {
-	flex: none;
-}
-.jv-run-act {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	flex: none;
-}
-.jv-run-btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	font-family: inherit;
-	font-size: 12.5px;
-	font-weight: 420;
-	height: 28px;
-	padding: 0 11px;
-	border-radius: 8px;
-	cursor: pointer;
-	background: var(--surface-2);
-	color: var(--text);
-	border: 1px solid transparent;
-	transition: background-color 0.15s ease, color 0.15s ease;
-}
-.jv-run-btn:hover {
-	background: var(--surface-3);
-}
-.jv-run-btn.stop {
-	background: var(--red-bg);
-	color: var(--red);
-}
-.jv-run-btn.stop:hover {
-	background: var(--red-bd);
-}
-.jv-run-loadmore {
-	display: block;
-	margin: 14px auto 2px;
-	font-family: inherit;
-	font-size: 13px;
-	font-weight: 420;
-	color: var(--text);
-	background: var(--surface-2);
-	border: 1px solid transparent;
-	border-radius: 8px;
-	padding: 7px 16px;
-	cursor: pointer;
-	transition: background-color 0.15s ease;
-}
-.jv-run-loadmore:hover {
-	background: var(--surface-3);
-}
-.jv-run-loadmore:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
 
 /* ============ BUTTONS (design.md §3.1 mapped to jv tokens) ============
    Compose a variant with the base:
@@ -743,30 +261,7 @@
 	font-size: 12.5px;
 	border-radius: 8px;
 }
-.jv-btn--icon {
-	width: 28px;
-	height: 28px;
-	padding: 0;
-	border-radius: 8px;
-	color: var(--text-3);
-	background: transparent;
-}
-.jv-btn--icon:hover {
-	background: var(--surface-2);
-	color: var(--text);
-}
 /* legacy single-dash danger modifier (used with jv-btn jv-btn--sm jv-btn-danger) */
-.jv-btn-danger {
-	color: var(--red);
-	background: var(--red-bg);
-	border-color: transparent;
-}
-.jv-btn-danger:hover {
-	background: var(--red-bd);
-}
-.jv-btn-danger:disabled {
-	opacity: 0.6;
-}
 
 /* fade for the overlay (transition name="jv-fade") */
 .jv-fade-enter-active {
@@ -781,49 +276,6 @@
 }
 
 /* ===== Account / billing (design.md §4.2) ===== */
-.jv-acct-card {
-	padding: 2px 0;
-}
-.jv-acct-card h2 {
-	font-size: 14px;
-	font-weight: 600;
-	margin: 0 0 10px;
-	color: var(--text);
-}
-.jv-acct-card-head {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 10px;
-	flex-wrap: wrap;
-	margin-bottom: 4px;
-}
-.jv-acct-card-head h2 {
-	margin-bottom: 0;
-}
-.jv-acct-sub {
-	color: var(--text-3);
-	font-weight: 420;
-	font-size: 12px;
-}
-.jv-acct-muted,
-.jv-acct-err {
-	font-size: 13px;
-	color: var(--text-3);
-}
-.jv-acct-err {
-	color: var(--red);
-}
-.jv-acct-pill {
-	font-size: 12px;
-	font-weight: 420;
-	height: 20px;
-	display: inline-flex;
-	align-items: center;
-	padding: 0 8px;
-	border-radius: 999px;
-	flex: none;
-}
 .jv-pill-ok {
 	color: var(--green);
 	background: var(--green-bg);
@@ -840,248 +292,15 @@
 	color: var(--text-3);
 	background: var(--surface-2);
 }
-.jv-acct-plan-row {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	flex-wrap: wrap;
-}
-.jv-acct-plan-name {
-	font-size: 16px;
-	font-weight: 500;
-	color: var(--text);
-}
-.jv-acct-plan-price {
-	font-size: 13px;
-	color: var(--text-2);
-}
-.jv-acct-renewal {
-	font-size: 13px;
-	color: var(--text-3);
-	margin-top: 6px;
-}
-.jv-acct-features {
-	list-style: none;
-	margin: 12px 0 0;
-	padding: 0;
-	display: grid;
-	gap: 7px;
-	font-size: 13px;
-	color: var(--text-2);
-}
-.jv-acct-features li {
-	display: flex;
-	align-items: flex-start;
-	gap: 8px;
-}
-.jv-acct-features li svg {
-	color: var(--green);
-	flex: none;
-	margin-top: 1px;
-}
-.jv-acct-upgrades {
-	margin-top: 20px;
-	padding-top: 16px;
-	border-top: 1px solid var(--border);
-}
-.jv-acct-upgrades-label {
-	font-size: 14px;
-	font-weight: 600;
-	color: var(--text);
-	margin-bottom: 10px;
-}
-.jv-acct-upgrade-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-	gap: 10px;
-}
-.jv-acct-upgrade-card {
-	display: flex;
-	flex-direction: column;
-	border: 1px solid var(--border);
-	border-radius: 10px;
-	background: var(--surface);
-	overflow: hidden;
-}
-.jv-acct-upgrade-head {
-	padding: 10px 12px;
-	border-bottom: 1px solid var(--border);
-}
-.jv-acct-upgrade-name {
-	font-size: 13px;
-	font-weight: 500;
-	color: var(--text);
-}
-.jv-acct-upgrade-price {
-	font-size: 12.5px;
-	color: var(--text-3);
-	margin-top: 2px;
-}
-.jv-acct-upgrade-act {
-	padding: 10px 12px;
-	margin-top: auto;
-}
 /* the upgrade CTA is an <a> (same Desk href) rendered as a quiet subtle button */
-.jv-acct-btn-sm {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
-	height: 28px;
-	font-size: 12.5px;
-	font-weight: 500;
-	color: var(--text);
-	text-decoration: none;
-	border-radius: 8px;
-	background: var(--surface-2);
-	transition: background-color 0.15s ease;
-}
-.jv-acct-btn-sm:hover {
-	background: var(--surface-3);
-}
 /* scheduled-cancellation banner: warn-toned, above the plan actions */
-.jv-acct-notice {
-	margin-top: 12px;
-	padding: 9px 11px;
-	border-radius: 8px;
-	background: var(--surface-2);
-	font-size: 12.5px;
-	color: var(--text-2);
-}
 /* notice with an inline action (the cancellation notice carries Resume) */
-.jv-acct-notice--row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-}
-.jv-acct-notice--row > span {
-	min-width: 0;
-}
 /* plan lifecycle actions (cancel / resume) sit below the feature list */
-.jv-acct-actions {
-	display: flex;
-	gap: 8px;
-	margin-top: 16px;
-}
-.jv-acct-actions .jv-acct-btn-sm {
-	width: auto;
-	padding: 0 12px;
-}
 /* manage-billing: a plain text link (design.md §4.2) */
-.jv-acct-link {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	margin-top: 18px;
-	font-size: 13px;
-	color: var(--link);
-	text-decoration: none;
-}
-.jv-acct-link:hover {
-	text-decoration: underline;
-}
-.jv-acct-link svg {
-	flex: none;
-}
 /* manage footer: billing link left, quiet cancel action right (same baseline) */
-.jv-acct-footer {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	margin-top: 18px;
-}
-.jv-acct-footer .jv-acct-link {
-	margin-top: 0;
-}
 /* cancel: a quiet text link, red only on hover — confirm dialog owns the red */
-.jv-acct-cancel {
-	flex: none;
-	padding: 0;
-	border: 0;
-	background: none;
-	font: inherit;
-	font-size: 13px;
-	color: var(--text-3);
-	cursor: pointer;
-	transition: color 0.15s ease;
-}
-.jv-acct-cancel:hover:not(:disabled) {
-	color: var(--red);
-	text-decoration: underline;
-}
-.jv-acct-cancel:disabled {
-	opacity: 0.5;
-	cursor: default;
-}
-.jv-acct-savednote {
-	font-size: 12px;
-	color: var(--text-3);
-	font-weight: 420;
-}
-.jv-acct-usage-line {
-	font-size: 13px;
-	color: var(--text-2);
-}
 
 /* ===== Monitor cards (Billing & metering) ===== */
-.jv-mon {
-	display: grid;
-	gap: 12px;
-}
-.jv-mon-card {
-	border: 1px solid var(--border);
-	border-radius: 10px;
-	padding: 14px 16px;
-	background: var(--surface);
-}
-.jv-mon-card h3 {
-	font-size: 14px;
-	font-weight: 600;
-	margin: 0 0 10px;
-	color: var(--text);
-}
-.jv-mon-sub,
-.jv-mon-tag {
-	color: var(--text-3);
-	font-weight: 420;
-	font-size: 12px;
-}
-.jv-mon-kv {
-	display: flex;
-	justify-content: space-between;
-	font-size: 13px;
-	padding: 6px 0;
-}
-.jv-mon-kv span {
-	color: var(--text-3);
-}
-.jv-mon-kv b {
-	font-weight: 500;
-	color: var(--text);
-}
-.jv-mon-models {
-	margin: 6px 0 0;
-	padding-left: 18px;
-	font-size: 13px;
-}
-.jv-mon-stats {
-	display: flex;
-	gap: 20px;
-	margin-bottom: 10px;
-	font-size: 13px;
-}
-.jv-mon-note,
-.jv-mon-empty {
-	font-size: 13px;
-	color: var(--text-3);
-	line-height: 1.5;
-}
-.jv-mon-empty {
-	padding: 40px;
-	text-align: center;
-}
 /* retry — same recipe as jv-btn--ghost --sm (one retry pattern, design.md §3.8) */
 .jv-mon-retry {
 	display: inline-flex;
@@ -1104,20 +323,8 @@
 }
 
 /* AI-models tabs share the segmented recipe above; only the margin is local. */
-.jv-acct-aitabs {
-	margin-bottom: 14px;
-}
 
 /* Rail group headers — 12px medium, sentence case (design.md §2.3; no uppercase). */
-.jv-settings-group {
-	font-size: 12px;
-	font-weight: 500;
-	color: var(--text-3);
-	padding: 14px 8px 5px;
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
 
 /* Header close icon-button — quiet ghost hover (no colour inversion).
    This is the ONLY global `.jv-iconbtn`, and its hover is deliberately NOT the
@@ -1153,12 +360,6 @@
 /* NOTE: this block is LAST, so it wins the cascade over the .jv-settings rule at
    the top of the file. Any width change must be made in BOTH places or it will
    appear to do nothing. */
-.jv-settings {
-	width: 1080px;
-}
-.jv-settings-nav {
-	width: 230px;
-}
 
 /* ===== narrow screens =======================================================
    The rail is `flex: none; width: 230px`, so it never shrinks: at a 390px
@@ -1171,46 +372,12 @@
 	.jv-settings-overlay {
 		padding: 12px;
 	}
-	.jv-settings {
-		width: 100%;
-		flex-direction: column;
-		height: 92vh;
-		max-height: 92vh;
-		border-radius: 14px;
-	}
-	.jv-settings-nav {
-		width: 100%;
-		flex: none;
-		flex-direction: row;
-		align-items: center;
-		gap: 6px;
-		padding: 8px 10px;
-		overflow-x: auto;
-		overflow-y: hidden;
-		border-right: 0;
-		border-bottom: 1px solid var(--border);
-	}
-	.jv-settings-nav-title,
-	.jv-settings-group {
-		display: none;
-	}
-	.jv-settings-navitem {
-		width: auto;
-		flex: none;
-		white-space: nowrap;
-	}
-	.jv-settings-body {
-		padding: 4px 16px 20px;
-	}
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.jv-fade-enter-active,
 	.jv-fade-leave-active {
 		transition: none;
-	}
-	.jv-settings {
-		animation: none;
 	}
 }
 


### PR DESCRIPTION
Closes #407.

## Summary

Prunes 88 dead `.jv-*` selectors from `frontend/src/assets/settings.css` (1234 to 401 lines). Only rules with zero real usage anywhere in the frontend were removed, so nobody using the settings dialog, the skills discard dialog, or the shared button/pill/fade styles should see any visual difference.

Scan output (before pruning; `frontend/scan-jv-classes.mjs`, kept in the diff for reproducibility):

```
Total unique .jv-* classes defined in src/assets/settings.css: 111
Live (referenced outside settings.css, outside other files' own <style>): 19
Dead (zero genuine reference): 92 (88 pruned + 4 jv-fade-* kept, see below)
```

6 classes stay, still gated on #406 (LlmPoolEditor's frappe-ui migration): `jv-mon-retry`, `jv-switch`, `jv-switch-knob`, `jv-llm-editor`, `jv-pool-savebar`, `jv-pane-fill`. Whoever picks up #406 should re-run the scan afterward.

## What changed
- Removed 88 selectors with no real usage anywhere, deleted structurally via postcss (`frontend/prune-dead-css.mjs`), not sed/regex.
- Kept `.jv-fade-*` and `@keyframes jv-popin`: both look dead by string search but are live (details below).
- Left the 6 #406-gated classes above untouched.

## Risk and verification
- `npm run test`: 705/706 passing; the 1 failure is an unrelated pre-existing flake (reproduces with this change stashed out).
- `settings.css` re-parses cleanly with postcss; `npm run build` succeeds and the bundle keeps live classes, drops pruned ones.
- No live screenshot diff: no credentials for the only reachable local site. Relying on build/bundle check and hosted CI. Detail below.

<details><summary>Why 88 not the issue's 86, the jv-fade/jv-popin exceptions, and the deletion rule</summary>

The scan originally didn't exclude comments (HTML `<!-- -->` or JS/CSS `/* */`), so two matches it counted as "live" were only prose mentions: `jv-settings-overlay` at `SettingsDialog.vue:9` sits inside an HTML template comment (it has a real, separate usage elsewhere, so stays live regardless), and `jv-set-row` / `jv-mon-kv` at `KvRow.vue:2-3` are named inside a comment listing the legacy patterns `KvRow` replaces, while the component itself only uses Tailwind utility classes. Stripping comments before searching moved those two from live to dead: 92 raw zero-reference classes, minus the 4 `jv-fade-*` kept deliberately, is 88 pruned.

`.jv-fade-enter-active/-leave-active/-enter-from/-leave-to` have no literal string match anywhere outside settings.css, which would normally read as dead. But `<transition name="jv-fade">` (`ChatView.vue:2691`) makes Vue synthesize exactly these class names at runtime on a real, live element (the proactive-message toast), so the selectors are genuinely matched, not dead code. `ChatView.vue` also carries its own scoped copy of the same rule that currently wins the cascade for timing, so settings.css's copy is redundant-but-matched today rather than dead-and-unreachable; that is a separate cleanup from this issue's scope (dead rules), so it stays.

`@keyframes jv-popin` also stays: the only settings.css rule that used it (`.jv-settings`) is dead and was removed, but `SkillDetail.vue:592` has its own `animation: jv-popin` with no local `@keyframes`, so it depends on this file's global definition.

`frontend/dump-rules.mjs` dumps rule/selector structure for review. The deletion script (`frontend/prune-dead-css.mjs`) removes a rule or comma-branch when at least one of its `.jv-*` classes is confirmed dead: a compound selector like `.jv-dark .jv-seg button.on` can never match once `.jv-seg` never appears on any real element, regardless of how live `.jv-dark` is elsewhere.

Live site check: the only site on the local bench matching an `/etc/hosts` entry (`site.jarvis`) needs login credentials I don't have, and the `jarvis.proxy` site referenced in older notes no longer exists on this bench. Did not attempt to guess credentials.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on a failure)
- [x] Branch is up to date with `develop` (this repo's base branch, not `main`)
- [x] New/changed behavior has tests (n/a: pure CSS deletion; existing suite re-verified, see Risk and verification)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
