### PR TITLE
fix(tests): unbreak develop, create_capture takes agent_provider not openclaw_provider

### DIFF
--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -319,7 +319,7 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 		return pending_capture.create_capture(
 			provider="openai",
 			upstream="openai",
-			openclaw_provider="openai",
+			agent_provider="openai",
 			oauth_blob=blob,
 			account_email="orphan@acme.com",
 			account_ref=account_ref,


### PR DESCRIPTION
`develop` is red. This unbreaks it. One kwarg, in one test.

`create_capture`'s `openclaw_provider` parameter was renamed to `agent_provider` by the white-label work in #563. #625 was written against the pre-rename signature and its `TestOrphanCaptureAdoption` helper still passes the old name, so all six tests in that class error with `TypeError: create_capture() got an unexpected keyword argument 'openclaw_provider'` on shard 3.

Both PRs were green on their own. The break only exists in the merge.

Verified: `--case TestOrphanCaptureAdoption` gives 6 passed with this change, against the same failure CI reported without it.

<details>
<summary>Why neither PR's CI caught it</summary>

This is the same semantic-conflict shape #563 hit before: a rename in one PR and a call site added in another, where each branch is individually consistent and only their merge is not. Nothing in either PR's diff overlaps, so git reports no conflict and both merge cleanly.

The three other files on `develop` that mention `openclaw_provider` are all correct and deliberately left alone: `v2_12_rename_capture_agent_provider.py` performs the rename, `test_capture_agent_provider_migration.py` tests it, and `test_no_openclaw_leak.py` asserts the old name is gone from the surfaces that matter.

Worth considering as a follow-up: a guard that trial-merges an open PR against current `develop` and runs the suite, since a green PR against a green base is not evidence the merge is green.
</details>

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
