### PR TITLE
fix(tests): repair the capture helper kwarg that is failing develop

### DIFF
--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -319,7 +319,7 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 		return pending_capture.create_capture(
 			provider="openai",
 			upstream="openai",
-			openclaw_provider="openai",
+			agent_provider="openai",
 			oauth_blob=blob,
 			account_email="orphan@acme.com",
 			account_ref=account_ref,


### PR DESCRIPTION
## Summary

Turns `develop` green again. Shard 3 has been failing since `17576a9f` with `TypeError: create_capture() got an unexpected keyword argument 'openclaw_provider'`, so every test using that helper dies.

#563 renamed the parameter to `agent_provider`. #625 branched before that landed and merged after, so its `_mint` helper still passes the old name. One word.

The two PRs never overlapped textually, so no conflict was raised at merge time and both were green on their own heads.

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (branched from `develop` tip `17576a9f`)
- [x] New/changed behavior has tests (this repairs existing tests; no behavior change)
- [x] I self-reviewed the diff
