### PR TITLE
fix(learning): retrieval-gate role-restricted learned skills instead of pushing them

### DIFF
--- a/jarvis/chat/custom_skills.py
+++ b/jarvis/chat/custom_skills.py
@@ -368,9 +368,7 @@ def learned_skill_clause(user: str | None = None) -> str:
 		matched = list(managed)
 	else:
 		matched = [
-			m
-			for m in managed
-			if m.name not in roles_by_skill or (roles_by_skill[m.name] & user_roles)
+			m for m in managed if m.name not in roles_by_skill or (roles_by_skill[m.name] & user_roles)
 		]
 	if not matched:
 		return ""

--- a/jarvis/chat/custom_skills.py
+++ b/jarvis/chat/custom_skills.py
@@ -152,6 +152,71 @@ def render_learned_skill_md(slug: str, description: str, instructions: str) -> s
 	return "\n".join(lines)
 
 
+def allowed_roles_by_skill(row_names) -> dict[str, set[str]]:
+	"""``{docname: {role, ...}}`` for the rows among ``row_names`` narrowed by an
+	``allowed_roles`` child table. Rows carrying NO child row are absent from the
+	mapping, so ``name in mapping`` is the definition of "role-restricted" and the
+	value is the set to intersect a chat user's roles with.
+
+	Presence, not a non-empty role set: ``user_can_use_skill`` narrows an Org row
+	the moment ANY child row exists, so a child carrying a blank role restricts
+	the row to nobody. Answering both questions from ONE query is what stops the
+	push filter and the context clause from drifting apart - issue #479 is
+	exactly that drift, between the custom push and the learned push.
+	"""
+	names = [n for n in (row_names or []) if n]
+	if not names:
+		return {}
+	out: dict[str, set[str]] = {}
+	for row in frappe.get_all(
+		"Jarvis Custom Skill Allowed Role",
+		filters={"parenttype": "Jarvis Custom Skill", "parent": ["in", names]},
+		fields=["parent", "role"],
+	):
+		bucket = out.setdefault(row.parent, set())
+		if row.role:
+			bucket.add(row.role)
+	return out
+
+
+def role_restricted_names(row_names) -> set[str]:
+	"""Docnames among ``row_names`` that carry at least one ``allowed_roles`` row:
+	the ONE definition of "role-restricted" every container push agrees on
+	(security review PART 2 TASK 11 / issue #479).
+
+	A role-restricted body may never be written into the shared, role-BLIND
+	container, so BOTH pushes drop these rows and let the role-gated
+	``jarvis__get_skill`` serve the body instead: the custom push via
+	:func:`_pushable_org_rows`, the learned push via
+	``jarvis.learning.compiler.build_learned_push_payload``. #479 exists because
+	the learned push never had a copy of this filter at all; one shared
+	definition means a third push cannot re-introduce the divergence.
+	"""
+	return set(allowed_roles_by_skill(row_names))
+
+
+def fetch_required_clause(lead_in: str, names) -> str:
+	"""The context-line clause for skills that apply to this user but are NOT
+	installed in the container, because their bodies are deliberately kept off
+	the shared, role-blind blob. The agent's only way to read one is the bench
+	tool named here, which re-derives the caller's roles at fetch time.
+
+	``lead_in`` is the caller's half-sentence (what these skills ARE); the tail is
+	fixed so every caller issues the same instruction. Shared by
+	:func:`invoked_skill_clause` (issue #477) and :func:`learned_skill_clause`
+	(issue #479). Deliberately says nothing about the workspace or a skill
+	directory: there is no directory to point at.
+	"""
+	names = list(names or [])
+	if not names:
+		return ""
+	return (
+		f"; {lead_in}: {', '.join(names)} "
+		"- call the jarvis__get_skill tool with each of those names to read its "
+		"instructions, then follow them"
+	)
+
+
 def invoked_skill_clause(message: str) -> str:
 	"""Return the context-line clause(s) for any enabled custom skills the user
 	invoked via ``/slug`` in ``message``, or ``""`` if none match.
@@ -225,16 +290,10 @@ def invoked_skill_clause(message: str) -> str:
 	if on_disk:
 		names = ", ".join(prefixed_slug(s) for s in on_disk)
 		clause += f"; the user invoked these skills, apply them: {names}"
-	if off_disk:
-		names = ", ".join(prefixed_slug(s) for s in off_disk)
-		# Deliberately says nothing about the workspace or a skill directory: the
-		# agent has no container-side access to these bodies, and the ONLY way it
-		# can read them is the bench tool call named here.
-		clause += (
-			f"; the user invoked these skills, which are not loaded in this session: {names} "
-			"- call the jarvis__get_skill tool with each of those names to read its "
-			"instructions, then follow them"
-		)
+	clause += fetch_required_clause(
+		"the user invoked these skills, which are not loaded in this session",
+		[prefixed_slug(s) for s in off_disk],
+	)
 	return clause
 
 
@@ -274,14 +333,21 @@ def learned_skill_clause(user: str | None = None) -> str:
 	Enabled ``managed_by_learning`` skills whose ``allowed_roles`` the chat user
 	satisfies (empty = everyone; System Manager / Administrator always pass) are
 	folded into the leading ``[Context: ...]`` line as ``learned-<domain>`` — the
-	dedicated learned-namespace wire slug (Phase 2; the persona interplay clause
-	names both the old ``custom-learned-`` and the new ``learned-`` prefixes, so
-	agent-side behaviour is unchanged across the cutover). Portal users
-	(desk_access=0 roles) never intersect desk-role allowed_roles, so learned
-	skills self-suppress for them at this layer.
+	dedicated learned-namespace wire slug (Phase 2). Portal users (desk_access=0
+	roles) never intersect desk-role allowed_roles, so learned skills
+	self-suppress for them at this layer.
+
+	TWO clause shapes, for the same reason :func:`invoked_skill_clause` has two
+	(issue #479): a role-restricted managed row is NOT pushed into the shared,
+	role-blind container, so naming it as installed points the agent at a
+	directory that does not exist. The split predicate is exactly the push
+	filter's - a row is installed iff it carries no ``allowed_roles`` - so
+	discovery and delivery can never disagree about which bodies are on disk.
 
 	Hot path: ONE cached role lookup + two indexed queries, capped at the <=6
-	managed rows - no per-skill N+1.
+	managed rows - no per-skill N+1. The privileged branch pays the child-row
+	query too: a System Manager skips the role INTERSECTION, never the emptiness
+	test, or they alone would be told a role-restricted skill is on disk.
 	"""
 	from jarvis.learning.roles import roles_for_user
 
@@ -296,31 +362,30 @@ def learned_skill_clause(user: str | None = None) -> str:
 
 	user_roles = roles_for_user(user)
 	privileged = user == "Administrator" or "System Manager" in user_roles
+	roles_by_skill = allowed_roles_by_skill([m.name for m in managed])
 
 	if privileged:
-		matched = [m.skill_name for m in managed]
+		matched = list(managed)
 	else:
-		names = [m.name for m in managed]
-		roles_by_skill: dict[str, set] = {m.name: set() for m in managed}
-		for row in frappe.get_all(
-			"Jarvis Custom Skill Allowed Role",
-			filters={"parent": ["in", names], "parenttype": "Jarvis Custom Skill"},
-			fields=["parent", "role"],
-		):
-			if row.role:
-				roles_by_skill[row.parent].add(row.role)
 		matched = [
-			m.skill_name
+			m
 			for m in managed
-			if not roles_by_skill[m.name] or (roles_by_skill[m.name] & user_roles)
+			if m.name not in roles_by_skill or (roles_by_skill[m.name] & user_roles)
 		]
 	if not matched:
 		return ""
 	# skill_name on a managed row IS the wire slug ("learned-<domain>"): learned
 	# skills ship through the dedicated learned_skills namespace, NOT the custom-
 	# prefixed custom-skills push, so no RESERVED_PREFIX here.
-	slugs = ", ".join(sorted(matched))
-	return f"; apply these learned skills: {slugs}"
+	installed = sorted(m.skill_name for m in matched if m.name not in roles_by_skill)
+	off_disk = sorted(m.skill_name for m in matched if m.name in roles_by_skill)
+	clause = ""
+	if installed:
+		clause += f"; apply these learned skills: {', '.join(installed)}"
+	clause += fetch_required_clause(
+		"these learned skills apply to you but are not loaded in this session", off_disk
+	)
+	return clause
 
 
 PERSONAL_CLAUSE_TTL_S = 300
@@ -399,17 +464,8 @@ def _pushable_org_rows(owner: str | None = None, fields: tuple = _PUSHABLE_FIELD
 	)
 	# TASK 11: drop role-restricted Org rows (any with allowed_roles) so a
 	# role-scoped body is never written to the shared, role-blind container.
-	restricted = {
-		r.parent
-		for r in frappe.get_all(
-			"Jarvis Custom Skill Allowed Role",
-			filters={
-				"parenttype": "Jarvis Custom Skill",
-				"parent": ["in", [r.name for r in rows] or [""]],
-			},
-			fields=["parent"],
-		)
-	}
+	# Shared with the learned push through :func:`role_restricted_names` (#479).
+	restricted = role_restricted_names([r.name for r in rows])
 	kept = [r for r in rows if r.name not in restricted]
 	# One explicit deterministic comparator AFTER filtering (R2-SP-4): the DB
 	# ``order_by`` above is only a stable baseline — the authoritative rank both

--- a/jarvis/chat/learned_skills_api.py
+++ b/jarvis/chat/learned_skills_api.py
@@ -91,9 +91,9 @@ def enqueue_learned_skills_push(chain_custom_reconcile: bool = False) -> dict:
 	skipped - the next custom apply / restart resync's full reconcile
 	self-heals; no status is left pending.
 	"""
-	from jarvis.learning.compiler import build_learned_push_payload
+	from jarvis.learning.compiler import learned_push_split
 
-	payload = build_learned_push_payload()
+	payload, held_back = learned_push_split()
 	frappe.db.set_single_value(
 		_SETTINGS, "learned_skills_sync_status", _PENDING_STATUS, update_modified=False
 	)
@@ -112,7 +112,11 @@ def enqueue_learned_skills_push(chain_custom_reconcile: bool = False) -> dict:
 	return {
 		"ok": True,
 		"learned_skills_sync_status": _PENDING_STATUS,
+		# ``count`` is what actually reaches the container. ``role_restricted`` is
+		# the rest: compiled, live, and served on demand by jarvis__get_skill
+		# instead of written to the shared blob (#479).
 		"count": len(payload),
+		"role_restricted": held_back,
 	}
 
 
@@ -132,7 +136,7 @@ def _enqueued_push_learned_skills(chain_custom_reconcile: bool = False) -> None:
 	resync self-heals)."""
 	from jarvis import admin_client
 	from jarvis._redis_lock import redis_lock
-	from jarvis.learning.compiler import build_learned_push_payload
+	from jarvis.learning.compiler import learned_push_split
 
 	with redis_lock(_LOCK_NAME, timeout_s=180, blocking_timeout_s=60.0) as acquired:
 		if not acquired:
@@ -148,14 +152,14 @@ def _enqueued_push_learned_skills(chain_custom_reconcile: bool = False) -> None:
 		terminal_written = False
 		push_ok = False
 		try:
-			payload = build_learned_push_payload()
+			payload, held_back = learned_push_split()
 			admin_client.post_push_learned_skills(learned_skills=payload)
 			frappe.db.set_value(
 				_SETTINGS,
 				_SETTINGS,
 				{
 					"learned_skills_synced_at": frappe.utils.now(),
-					"learned_skills_sync_status": f"ok (applied {len(payload)} via admin)",
+					"learned_skills_sync_status": _ok_status(len(payload), held_back),
 				},
 				update_modified=False,
 			)
@@ -226,6 +230,24 @@ def _enqueue_cutover_custom_reconcile() -> None:
 			title="Jarvis: cutover custom reconcile enqueue failed",
 			message=frappe.get_traceback(),
 		)
+
+
+def _ok_status(installed: int, role_restricted: int) -> str:
+	"""The reviewer-facing terminal status, which has to distinguish two very
+	different outcomes that the old "ok (applied N via admin)" wording merged.
+
+	Since #479 a role-restricted learned skill is deliberately NOT written into
+	the container: it is live, it still applies to its role-holders, and its body
+	is served on demand by ``jarvis__get_skill``. Every compiled row carries
+	``allowed_roles``, so a reviewer who approves four domains and then reads
+	"applied 1" would reasonably file that as a bug. Naming the held-back count
+	is the whole fix - it says the other three are working, not missing."""
+	if role_restricted:
+		return (
+			f"ok ({installed} installed via admin, "
+			f"{role_restricted} role-restricted and fetched on demand)"
+		)
+	return f"ok ({installed} installed via admin)"
 
 
 def _fail(status: str) -> None:

--- a/jarvis/chat/learned_skills_api.py
+++ b/jarvis/chat/learned_skills_api.py
@@ -244,8 +244,7 @@ def _ok_status(installed: int, role_restricted: int) -> str:
 	is the whole fix - it says the other three are working, not missing."""
 	if role_restricted:
 		return (
-			f"ok ({installed} installed via admin, "
-			f"{role_restricted} role-restricted and fetched on demand)"
+			f"ok ({installed} installed via admin, {role_restricted} role-restricted and fetched on demand)"
 		)
 	return f"ok ({installed} installed via admin)"
 

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.json
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.json
@@ -17,6 +17,7 @@
     "shared_with",
     "allowed_roles",
     "managed_by_learning",
+    "roles_derived",
     "source_skill"
   ],
   "fields": [
@@ -96,6 +97,15 @@
       "default": "0",
       "hidden": 1,
       "description": "Marker only: this row is a consolidated learned-<domain> skill compiled from approved learned patterns; the learning board is its management surface."
+    },
+    {
+      "fieldname": "roles_derived",
+      "fieldtype": "Check",
+      "label": "Roles Derived",
+      "default": "0",
+      "read_only": 1,
+      "hidden": 1,
+      "description": "Provenance for allowed_roles on a compiler-managed row (issue #479): 1 means the role derivation ran to a conclusion for every source doctype, so an EMPTY allowed_roles genuinely means no desk role narrows this skill. 0 means the derivation could not be completed and the empty set is a fallback, not a finding. Recorded only - no code reads it, and an empty allowed_roles still means everyone."
     },
     {
       "fieldname": "source_skill",

--- a/jarvis/learning/compiler.py
+++ b/jarvis/learning/compiler.py
@@ -189,10 +189,43 @@ def compile_domain_skills() -> dict:
 			"description": _description(domain, included),
 			"body": _render_body(domain, included, run_label),
 			"allowed_roles": sorted(allowed),
+			"roles_derived": _roles_derived(included),
 			"pattern_names": [p["name"] for p in included],
 			"deferred": [p["name"] for p in deferred],
 		}
 	return result
+
+
+def _roles_derived(patterns: list) -> bool:
+	"""True iff the role derivation ran to a conclusion for EVERY source doctype
+	behind ``patterns``.
+
+	Recorded on the managed row as ``roles_derived`` and read by NOTHING (issue
+	#479 keeps today's "empty allowed_roles means everyone" reading exactly as it
+	is). It exists so a later, stricter policy can tell "we determined this skill
+	is universal" from "we could not determine anything" - the two produce an
+	identical empty ``allowed_roles`` today (design Q3 cases 1 and 3), and no
+	backfill could ever reconstruct which one a given row was. Capturing it now
+	makes that policy a one-line change instead of a migration with no data.
+
+	Conservative on every doubt: an unknown detector, a spec with no doctype, or
+	any exception all read as NOT derived."""
+	try:
+		from jarvis.learning.registry import get_detector
+		from jarvis.learning.roles import derive_roles_for_doctype
+
+		doctypes = set()
+		for p in patterns:
+			spec = get_detector(p.get("detector_id") or "") or {}
+			doctype = spec.get("doctype")
+			if not doctype:
+				return False
+			doctypes.add(doctype)
+		if not doctypes:
+			return False
+		return all(derive_roles_for_doctype(dt)[1] for dt in sorted(doctypes))
+	except Exception:
+		return False
 
 
 def compile_preview(domain: str) -> str:
@@ -416,30 +449,53 @@ def _precheck_learned_cap(compiled: dict) -> None:
 
 
 def build_learned_push_payload() -> list[dict]:
-	"""Collect the enabled managed learned rows into the fleet push payload: a
-	list of ``{slug, description, body}`` (the agent- item shape) where ``slug``
-	is the row's ``skill_name`` verbatim (``learned-<domain>`` - NO ``custom-``
-	prefix: learned skills reconcile into the fleet's separate learned_skills
-	namespace) and ``body`` is the rendered SKILL.md whose frontmatter ``name``
-	matches the slug.
+	"""The fleet push payload alone; see :func:`learned_push_split` for the
+	payload PLUS the count of rows deliberately held back."""
+	return learned_push_split()[0]
+
+
+def learned_push_split() -> tuple[list[dict], int]:
+	"""``(payload, held_back)``. ``payload`` is the fleet push payload: a list of
+	``{slug, description, body}`` (the agent- item shape) where ``slug`` is the
+	row's ``skill_name`` verbatim (``learned-<domain>`` - NO ``custom-`` prefix:
+	learned skills reconcile into the fleet's separate learned_skills namespace)
+	and ``body`` is the rendered SKILL.md whose frontmatter ``name`` matches the
+	slug. ``held_back`` counts the managed rows kept OFF that payload because
+	they are role-restricted.
+
+	Role-restricted bodies are kept off the shared blob (issue #479), on exactly
+	the rule the sibling custom push has applied since security review PART 2
+	TASK 11 and through exactly the same helper: a managed row narrowed by
+	``allowed_roles`` would otherwise be physically written into the shared,
+	role-BLIND container, where any user's agent can ``cat`` it regardless of
+	roles. ``_upsert_managed_skill`` writes ``allowed_roles`` on every row it
+	compiles, so a tenant whose learned skills all come from role-gated doctypes
+	now pushes ZERO files, and that is the normal case rather than an edge one.
+	Those rows stay reachable: ``learned_skill_clause`` still announces them to
+	role-matched users, and ``jarvis__get_skill`` serves the body after
+	re-deriving the caller's roles at fetch time.
 
 	Reads the MANAGED ROWS (not a fresh compile): the rows are the bench-side
 	storage the last Apply committed, so a restart resync re-pushes exactly what
 	was applied without re-flipping any pattern statuses. Pinned to the
 	Administrator owner (same defense-in-depth as ``learned_skill_clause``).
-	An empty list is a valid "remove all learned skills" reconcile. Truncated at
-	``LEARNED_SKILL_CAP`` so a stale over-cap state can never be pushed (the
-	apply pre-check is the real gate)."""
-	from jarvis.chat.custom_skills import render_learned_skill_md
+	An empty list is a valid "remove all learned skills" reconcile - which is
+	what removes an already-pushed restricted body from a live container.
+	Truncated at ``LEARNED_SKILL_CAP`` so a stale over-cap state can never be
+	pushed (the apply pre-check is the real gate)."""
+	from jarvis.chat.custom_skills import render_learned_skill_md, role_restricted_names
 
 	rows = frappe.get_all(
 		SKILL,
 		filters={"enabled": 1, "managed_by_learning": 1, "owner": MANAGED_OWNER},
-		fields=["skill_name", "description", "instructions"],
+		# ``name`` feeds the role filter; it is not in the payload.
+		fields=["name", "skill_name", "description", "instructions"],
 		order_by="skill_name asc",
 	)
+	restricted = role_restricted_names([r.name for r in rows])
+	pushable = [r for r in rows if r.name not in restricted]
 	payload = []
-	for r in rows[:LEARNED_SKILL_CAP]:
+	for r in pushable[:LEARNED_SKILL_CAP]:
 		slug = (r.skill_name or "").strip().lower()
 		payload.append(
 			{
@@ -448,7 +504,7 @@ def build_learned_push_payload() -> list[dict]:
 				"body": render_learned_skill_md(slug, r.description or "", r.instructions or ""),
 			}
 		)
-	return payload
+	return payload, len(restricted)
 
 
 def _upsert_managed_skill(spec: dict) -> str:
@@ -474,6 +530,10 @@ def _upsert_managed_skill(spec: dict) -> str:
 	# them. The engine flag is set here, so the scope guard admits the write.
 	doc.scope = "Org"
 	doc.set("allowed_roles", [{"role": r} for r in spec["allowed_roles"]])
+	# Provenance only, deliberately INERT: nothing reads this field, and an empty
+	# allowed_roles still means "everyone" exactly as it did before (#479). See
+	# :func:`_roles_derived` for why it is captured at write time regardless.
+	doc.roles_derived = 1 if spec.get("roles_derived") else 0
 	if existing:
 		doc.save(ignore_permissions=True)
 	else:

--- a/jarvis/learning/roles.py
+++ b/jarvis/learning/roles.py
@@ -33,7 +33,9 @@ from jarvis.permissions import (
 	ensure_support_roles,
 )
 
-_DT_CACHE_KEY = "jarvis_learning_roles_for_doctype"
+# _v2: the cached value is now {"roles": [...], "derived": bool}, not a bare
+# list, so the key changes rather than teaching the reader both shapes.
+_DT_CACHE_KEY = "jarvis_learning_roles_for_doctype_v2"
 _CACHE_TTL_S = 300
 
 
@@ -44,31 +46,45 @@ def roles_for_doctype(doctype: str) -> list[str]:
 	data), and if_owner-only grants (a per-owner read is not org-wide, so it is
 	not a delivery signal for a bench-global learned skill). Deterministic,
 	sorted. Empty on any failure (the caller falls back to declared priors)."""
+	return derive_roles_for_doctype(doctype)[0]
+
+
+def derive_roles_for_doctype(doctype: str) -> tuple[list[str], bool]:
+	"""``(roles, derived)`` - :func:`roles_for_doctype` plus its provenance.
+
+	``derived`` says whether the permission scan actually RAN to a conclusion.
+	True means the answer is a real finding even when it is empty ("no desk role
+	holds an org-wide read here"); False means we determined nothing and the
+	empty list is a fallback. The two are indistinguishable from the return value
+	alone, which is what makes an empty ``allowed_roles`` ambiguous downstream
+	(issue #479, design Q3). Callers recording provenance want this one; everyone
+	else keeps calling :func:`roles_for_doctype`.
+	"""
 	if not doctype:
-		return []
+		return [], False
 
 	use_cache = not frappe.flags.in_test
 	if use_cache:
 		try:
 			cached = frappe.cache().hget(_DT_CACHE_KEY, doctype)
-			if cached is not None:
-				return list(cached)
+			if isinstance(cached, dict):
+				return list(cached.get("roles") or []), bool(cached.get("derived"))
 		except Exception:
 			pass
 
-	result = _compute_roles_for_doctype(doctype)
+	roles, derived = _compute_roles_for_doctype(doctype)
 
 	if use_cache:
 		try:
-			frappe.cache().hset(_DT_CACHE_KEY, doctype, result)
+			frappe.cache().hset(_DT_CACHE_KEY, doctype, {"roles": roles, "derived": derived})
 			# Bound staleness even if the hash is never explicitly cleared.
 			frappe.cache().expire(_make_key(_DT_CACHE_KEY), _CACHE_TTL_S)
 		except Exception:
 			pass
-	return result
+	return roles, derived
 
 
-def _compute_roles_for_doctype(doctype: str) -> list[str]:
+def _compute_roles_for_doctype(doctype: str) -> tuple[list[str], bool]:
 	from frappe.permissions import get_all_perms
 
 	try:
@@ -78,9 +94,10 @@ def _compute_roles_for_doctype(doctype: str) -> list[str]:
 			fields=["name", "desk_access"],
 		)
 	except Exception:
-		return []
+		return [], False
 
 	out: set[str] = set()
+	scanned = 0
 	for role in roles:
 		name = role.get("name")
 		if not name:
@@ -93,9 +110,12 @@ def _compute_roles_for_doctype(doctype: str) -> list[str]:
 			perms = get_all_perms(name) or []
 		except Exception:
 			continue
+		scanned += 1
 		if _grants_orgwide_read(perms, doctype):
 			out.add(name)
-	return sorted(out)
+	# A scan that read NO role's permissions concluded nothing, even though it
+	# returns the same empty list as a scan that read every role and found none.
+	return sorted(out), scanned > 0
 
 
 def _grants_orgwide_read(perms, doctype: str) -> bool:

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -48,3 +48,4 @@ jarvis.patches.v2_12_backfill_role_skill_allowed_roles
 jarvis.patches.v2_12_backfill_approved_draft
 jarvis.patches.v2_12_reload_agent_doctypes_for_indexes
 jarvis.patches.v2_12_reload_macro_doctypes_for_indexes
+jarvis.patches.v2_13_repush_learned_skills_role_gated

--- a/jarvis/patches/v2_13_repush_learned_skills_role_gated.py
+++ b/jarvis/patches/v2_13_repush_learned_skills_role_gated.py
@@ -5,8 +5,8 @@ Before this deploy, ``build_learned_push_payload`` wrote EVERY managed
 ``learned-<domain>`` row into the container's ``learned_skills`` dir, including the
 role-restricted ones. The code fix stops NEW pushes from doing that; it cannot
 remove what is already on disk, and a body on disk is readable by every user of
-that tenant's single, role-blind container (openclaw's entrypoint copies it into
-``workspace/skills/`` and ``bash cat`` needs no permission). Shipping the filter
+that tenant's single, role-blind agent container (its entrypoint copies the file
+into ``workspace/skills/`` and ``bash cat`` needs no permission). Shipping the filter
 without this patch closes the tap and leaves the puddle.
 
 The removal mechanism already exists and needs no fleet change: ``PUT

--- a/jarvis/patches/v2_13_repush_learned_skills_role_gated.py
+++ b/jarvis/patches/v2_13_repush_learned_skills_role_gated.py
@@ -1,0 +1,83 @@
+"""Re-push learned skills once, to evict role-restricted bodies already sitting in
+live tenant containers (issue #479).
+
+Before this deploy, ``build_learned_push_payload`` wrote EVERY managed
+``learned-<domain>`` row into the container's ``learned_skills`` dir, including the
+role-restricted ones. The code fix stops NEW pushes from doing that; it cannot
+remove what is already on disk, and a body on disk is readable by every user of
+that tenant's single, role-blind container (openclaw's entrypoint copies it into
+``workspace/skills/`` and ``bash cat`` needs no permission). Shipping the filter
+without this patch closes the tap and leaves the puddle.
+
+The removal mechanism already exists and needs no fleet change: ``PUT
+/v1/containers/{name}/learned-skills`` is a FULL reconcile. It rmtree's every
+learned dir absent from the pushed set, drops the slug from the agent skill
+allowlist, and restarts the container, which is the load-bearing step - the
+restart is what rebuilds ``workspace/skills/`` from the (now smaller) source dir.
+An empty payload is a valid "remove all learned skills" reconcile. So exactly one
+push per affected tenant finishes the job.
+
+Deliberately narrow, because the push costs that tenant a container restart:
+
+* ``learned_skills_sync_status`` empty means this bench has never pushed through
+  the learned namespace, so nothing of ours is in its container. Skip.
+* no managed row carrying ``allowed_roles`` means nothing restricted was ever
+  pushed. Skip.
+
+What is left is precisely the exposed set, so the restart wave is bounded by the
+tenants that actually have a body to evict rather than by the fleet size. The
+alternative (wait for each tenant's next reviewer Apply) is unbounded: a tenant
+that never applies keeps the exposure forever, which is not a close-out for a
+security issue.
+
+``JarvisSettings._resync_learned_skills_after_restart`` is NOT this path. It fires
+only when an LLM-config change restarted the container; a deploy never triggers
+it. It is a backstop, not a migration.
+
+The "patches never run on fresh installs" trap (``install_app`` marks patches done
+without running them) does not bite: a fresh install has no container to clean.
+"""
+
+import frappe
+
+SKILL = "Jarvis Custom Skill"
+ALLOWED_ROLE = "Jarvis Custom Skill Allowed Role"
+SETTINGS = "Jarvis Settings"
+MANAGED_OWNER = "Administrator"
+
+
+def execute():
+	if not frappe.db.table_exists(SKILL) or not frappe.db.table_exists(ALLOWED_ROLE):
+		return
+	# Never pushed through the learned namespace -> no learned dir in the container.
+	if not (frappe.db.get_single_value(SETTINGS, "learned_skills_sync_status") or "").strip():
+		return
+
+	managed = frappe.get_all(
+		SKILL,
+		filters={"managed_by_learning": 1, "enabled": 1, "owner": MANAGED_OWNER},
+		pluck="name",
+	)
+	if not managed:
+		return
+	restricted = frappe.get_all(
+		ALLOWED_ROLE,
+		filters={"parenttype": SKILL, "parent": ("in", managed)},
+		fields=["parent"],
+		limit=1,
+	)
+	if not restricted:
+		return
+
+	# Best-effort: a tenant whose push cannot be enqueued must not fail the whole
+	# migrate. The row stays as it was and the next Apply re-pushes it correctly,
+	# with the fix already in place.
+	try:
+		from jarvis.chat.learned_skills_api import enqueue_learned_skills_push
+
+		enqueue_learned_skills_push()
+	except Exception:
+		frappe.log_error(
+			title="Jarvis: learned-skills role-gating re-push failed to enqueue",
+			message=frappe.get_traceback(),
+		)

--- a/jarvis/tests/learning/test_compiler.py
+++ b/jarvis/tests/learning/test_compiler.py
@@ -297,7 +297,7 @@ class TestApplyLearnedSkills(FrappeTestCase):
 		frappe.db.set_value(
 			"Jarvis Settings",
 			"Jarvis Settings",
-			{"learned_skills_sync_status": "ok (applied 0 via admin)"},
+			{"learned_skills_sync_status": "ok (0 installed via admin)"},
 			update_modified=False,
 		)
 		frappe.db.commit()
@@ -517,7 +517,10 @@ class TestApplyLearnedSkills(FrappeTestCase):
 
 	# --- dedicated learned push payload (Phase-2 namespace) ------------------ #
 	def test_learned_push_payload_matches_fleet_contract(self):
-		_mk("selling", "A", roles=("Sales User",))
+		# roles=() is what makes this row PUSHABLE: an unrestricted managed row is
+		# the only shape that still reaches the container after #479, and its item
+		# shape must be byte-for-byte what the fleet contract always took.
+		_mk("selling", "A", roles=())
 		with _patched_pushes():
 			compiler.apply_learned_skills()
 		payload = compiler.build_learned_push_payload()
@@ -537,6 +540,96 @@ class TestApplyLearnedSkills(FrappeTestCase):
 		self.assertIn("user-invocable: false", item["body"])
 		# the compiled instructions ride verbatim in the body.
 		self.assertIn("# Learned selling habits", item["body"])
+
+	# --- #479: role-restricted learned bodies never reach the container ------ #
+	def _managed(self, slug="learned-selling"):
+		return frappe.db.get_value(SKILL, {"managed_by_learning": 1, "skill_name": slug}, "name")
+
+	def _roles_on(self, docname):
+		return sorted(
+			frappe.get_all(
+				"Jarvis Custom Skill Allowed Role",
+				filters={"parent": docname, "parenttype": SKILL},
+				pluck="role",
+			)
+		)
+
+	def test_role_restricted_learned_row_is_not_pushed(self):
+		# The #479 bug itself: every compiled row carries allowed_roles, and the
+		# learned push wrote all of them into the single role-BLIND container, so a
+		# body only Sales User may read landed where every user's agent can cat it.
+		_mk("selling", "A", roles=("Sales User",))
+		with _patched_pushes():
+			compiler.apply_learned_skills()
+		row = self._managed()
+		self.assertTrue(row, "the managed row must exist - it is held, not dropped")
+		self.assertEqual(self._roles_on(row), ["Sales User"])
+		payload, held_back = compiler.learned_push_split()
+		self.assertEqual(payload, [])
+		self.assertEqual(held_back, 1)
+		self.assertEqual(compiler.build_learned_push_payload(), [])
+
+	def test_unrestricted_learned_row_is_still_pushed_unchanged(self):
+		# The other half of the rule: nothing changes for a row that no role
+		# narrows. Same bytes as before the fix, or this became a regression.
+		from jarvis.chat.custom_skills import render_learned_skill_md
+
+		_mk("selling", "A", roles=())
+		with _patched_pushes():
+			compiler.apply_learned_skills()
+		row = self._managed()
+		self.assertEqual(self._roles_on(row), [])
+		desc, instructions = frappe.db.get_value(SKILL, row, ["description", "instructions"])
+		payload, held_back = compiler.learned_push_split()
+		self.assertEqual(held_back, 0)
+		self.assertEqual(
+			payload,
+			[
+				{
+					"slug": "learned-selling",
+					"description": desc,
+					"body": render_learned_skill_md("learned-selling", desc, instructions),
+				}
+			],
+		)
+
+	def test_mixed_bench_pushes_only_the_unrestricted_rows(self):
+		_mk("selling", "A", roles=("Sales User",))
+		_mk("buying", "A", roles=(), detector_id="buy-supplier-payment-terms-realized")
+		with _patched_pushes():
+			compiler.apply_learned_skills()
+		payload, held_back = compiler.learned_push_split()
+		self.assertEqual([i["slug"] for i in payload], ["learned-buying"])
+		self.assertEqual(held_back, 1)
+
+	def test_roles_derived_is_stamped_and_changes_nothing_about_the_push(self):
+		# The marker is DATA CAPTURE ONLY (#479 decision 4). It must record what the
+		# role derivation concluded, and it must not move a single row between the
+		# pushed and the held-back set - otherwise it is a behaviour change wearing
+		# a marker's clothes.
+		_mk("selling", "A", roles=())
+		with _patched_pushes():
+			compiler.apply_learned_skills()
+		row = self._managed()
+		self.assertEqual(frappe.db.get_value(SKILL, row, "roles_derived"), 1)
+		before = compiler.learned_push_split()
+
+		# Flip the marker to the "we could not determine anything" value. An empty
+		# allowed_roles still means everyone, so the row stays pushed.
+		frappe.db.set_value(SKILL, row, "roles_derived", 0, update_modified=False)
+		self.assertEqual(compiler.learned_push_split(), before)
+		self.assertEqual([i["slug"] for i in before[0]], ["learned-selling"])
+
+	def test_roles_derived_is_zero_when_the_derivation_cannot_conclude(self):
+		# An empty allowed_roles has three causes (design Q3) and only this marker
+		# tells "no desk role narrows this" from "the scan never ran".
+		_mk("selling", "A", roles=())
+		with patch("jarvis.learning.roles.derive_roles_for_doctype", return_value=([], False)):
+			compiled = compiler.compile_domain_skills()
+		self.assertFalse(compiled["selling"]["roles_derived"])
+		with patch("jarvis.learning.roles.derive_roles_for_doctype", return_value=(["x"], True)):
+			compiled = compiler.compile_domain_skills()
+		self.assertTrue(compiled["selling"]["roles_derived"])
 
 	def test_managed_rows_excluded_from_custom_push(self):
 		from jarvis.chat.custom_skills import build_push_payload
@@ -613,7 +706,12 @@ class TestApplyLearnedSkills(FrappeTestCase):
 		# ...the confirmed-ok learned push chained the GRACEFUL custom worker.
 		custom_wire.assert_called_once()
 		st = self._sync_pair()
-		self.assertTrue(st.learned_skills_sync_status.startswith("ok (applied"))
+		# The Sales-User fixture is role-restricted, so NOTHING was installed and
+		# the status has to say so without reading as a failure (#479).
+		self.assertEqual(
+			st.learned_skills_sync_status,
+			"ok (0 installed via admin, 1 role-restricted and fetched on demand)",
+		)
 		self.assertTrue(st.custom_skills_sync_status.startswith("ok (applied"))
 
 		# once the learned sync pair is stamped, later applies push learned ONLY.
@@ -672,7 +770,10 @@ class TestApplyLearnedSkills(FrappeTestCase):
 		learned_wire.assert_called_once()
 		custom_wire.assert_not_called()
 		st = self._sync_pair()
-		self.assertTrue(st.learned_skills_sync_status.startswith("ok (applied"))
+		self.assertEqual(
+			st.learned_skills_sync_status,
+			"ok (0 installed via admin, 1 role-restricted and fetched on demand)",
+		)
 		self.assertEqual(st.custom_skills_sync_status, before.custom_skills_sync_status)
 
 	def test_cutover_reconcile_not_chained_when_learned_push_fails(self):

--- a/jarvis/tests/learning/test_e2e_flow.py
+++ b/jarvis/tests/learning/test_e2e_flow.py
@@ -156,6 +156,17 @@ class TestPatternLearningE2E(FrappeTestCase):
 			sales_clause = clause_fn(_user_with_role("Sales User"))
 			self.assertIn("learned-selling", sales_clause)
 			self.assertNotIn("custom-learned-selling", sales_clause)
+			# ...and in the FETCH sub-clause, not the installed one (#479). The row
+			# carries allowed_roles, so it is deliberately never written into the
+			# shared container; asserting only "the slug appears somewhere" passed
+			# either way and would not have caught the move.
+			self.assertIn(
+				"; these learned skills apply to you but are not loaded in this session: "
+				"learned-selling",
+				sales_clause,
+			)
+			self.assertNotIn("; apply these learned skills:", sales_clause)
+			self.assertIn("jarvis__get_skill", sales_clause)
 			# a user without it does not
 			acct_clause = clause_fn(_user_with_role("Accounts User"))
 			self.assertNotIn("learned-selling", acct_clause)

--- a/jarvis/tests/learning/test_e2e_flow.py
+++ b/jarvis/tests/learning/test_e2e_flow.py
@@ -161,8 +161,7 @@ class TestPatternLearningE2E(FrappeTestCase):
 			# shared container; asserting only "the slug appears somewhere" passed
 			# either way and would not have caught the move.
 			self.assertIn(
-				"; these learned skills apply to you but are not loaded in this session: "
-				"learned-selling",
+				"; these learned skills apply to you but are not loaded in this session: learned-selling",
 				sales_clause,
 			)
 			self.assertNotIn("; apply these learned skills:", sales_clause)

--- a/jarvis/tests/test_custom_skill_visibility.py
+++ b/jarvis/tests/test_custom_skill_visibility.py
@@ -281,9 +281,7 @@ class TestLearnedRetrievalGating(FrappeTestCase):
 			doc.insert(ignore_permissions=True)
 		# insert() forces owner=session.user; the clause query is pinned to
 		# Administrator, exactly as the compiler pins its managed rows.
-		frappe.db.set_value(
-			"Jarvis Custom Skill", doc.name, "owner", "Administrator", update_modified=False
-		)
+		frappe.db.set_value("Jarvis Custom Skill", doc.name, "owner", "Administrator", update_modified=False)
 		return doc.name
 
 	@staticmethod
@@ -379,3 +377,40 @@ class TestLearnedRetrievalGating(FrappeTestCase):
 		slugs = {i["slug"] for i in build_learned_push_payload()}
 		self.assertIn("learned-479open", slugs)
 		self.assertNotIn("learned-479restricted", slugs)
+
+	# --- migration: evict bodies already sitting in live containers ---------- #
+	def _run_patch(self, sync_status):
+		from unittest import mock
+
+		from jarvis.patches.v2_13_repush_learned_skills_role_gated import execute
+
+		before = frappe.db.get_single_value("Jarvis Settings", "learned_skills_sync_status")
+		frappe.db.set_single_value(
+			"Jarvis Settings", "learned_skills_sync_status", sync_status, update_modified=False
+		)
+		try:
+			with mock.patch("jarvis.chat.learned_skills_api.enqueue_learned_skills_push") as enqueue:
+				execute()
+			return enqueue
+		finally:
+			frappe.db.set_single_value(
+				"Jarvis Settings", "learned_skills_sync_status", before, update_modified=False
+			)
+
+	def test_patch_repushes_when_a_restricted_body_is_already_in_the_container(self):
+		# The code fix closes the tap; it cannot remove what is already on disk.
+		# One full-reconcile push per affected tenant deletes the dir, drops the
+		# slug from the agent allowlist and restarts the container (the restart is
+		# what rebuilds workspace/skills/ from the now-smaller source dir).
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		self._run_patch("ok (1 installed via admin)").assert_called_once()
+
+	def test_patch_skips_a_bench_that_never_pushed(self):
+		# Empty sync status: nothing of ours is in that container, so a restart
+		# would be pure cost.
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		self._run_patch("").assert_not_called()
+
+	def test_patch_skips_a_bench_with_nothing_restricted(self):
+		self._managed("learned-479open", roles=())
+		self._run_patch("ok (1 installed via admin)").assert_not_called()

--- a/jarvis/tests/test_custom_skill_visibility.py
+++ b/jarvis/tests/test_custom_skill_visibility.py
@@ -203,3 +203,179 @@ class TestManagedFlagSecurity(FrappeTestCase):
 		clause = learned_skill_clause("Administrator")
 		self.assertIn("learned-clausecheck", clause)
 		self.assertNotIn("custom-learned-clausecheck", clause)
+
+
+# --------------------------------------------------------------------------- #
+# issue #479: retrieval-gated learned skills
+# --------------------------------------------------------------------------- #
+FETCH_LEAD = "; these learned skills apply to you but are not loaded in this session:"
+INSTALLED_LEAD = "; apply these learned skills:"
+
+HOLDER = "jcs-479-holder@example.com"
+OUTSIDER = "jcs-479-outsider@example.com"
+HOLDER_ROLE = "Sales User"
+
+
+def _ensure_role_user(email: str, role: str | None) -> str:
+	"""An enabled System User holding ``role`` (or no extra role) and explicitly
+	NOT System Manager, which auto-passes every visibility check and would make
+	each assertion below pass for the wrong reason."""
+	if not frappe.db.exists("User", email):
+		doc = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "jcs-479",
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+	doc = frappe.get_doc("User", email)
+	held = set(frappe.get_roles(email))
+	if "System Manager" in held:
+		doc.remove_roles("System Manager")
+	if role and role not in held:
+		doc.add_roles(role)
+	return email
+
+
+class TestLearnedRetrievalGating(FrappeTestCase):
+	"""Issue #479: a role-restricted learned body is never written into the
+	shared, role-BLIND container. Its EXISTENCE is announced by
+	``learned_skill_clause`` (already role-matched per chat user) and its BODY is
+	served by ``jarvis__get_skill``, which re-derives the caller's roles at fetch
+	time. The two role checks are the same predicate on the same identity, which
+	is the property the pushed-file model could not offer at all.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.holder = _ensure_role_user(HOLDER, HOLDER_ROLE)
+		cls.outsider = _ensure_role_user(OUTSIDER, None)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete("Jarvis Custom Skill", {"skill_name": ["like", "learned-479%"]})
+		super().tearDown()
+
+	def _managed(self, slug, roles=(), enabled=1):
+		doc = frappe.new_doc("Jarvis Custom Skill")
+		doc.update(
+			{
+				"skill_name": slug,
+				"description": f"desc for {slug}",
+				"instructions": f"# body of {slug}\n- the restricted rule",
+				"enabled": enabled,
+				"user_invocable": 0,
+				"scope": "Org",
+				"managed_by_learning": 1,
+				"allowed_roles": [{"role": r} for r in roles],
+			}
+		)
+		with _engine_flag():
+			doc.insert(ignore_permissions=True)
+		# insert() forces owner=session.user; the clause query is pinned to
+		# Administrator, exactly as the compiler pins its managed rows.
+		frappe.db.set_value(
+			"Jarvis Custom Skill", doc.name, "owner", "Administrator", update_modified=False
+		)
+		return doc.name
+
+	@staticmethod
+	def _halves(clause):
+		"""``(installed_half, fetch_half)`` of a rendered clause."""
+		head, _, tail = clause.partition(FETCH_LEAD)
+		return head, tail
+
+	# --- discovery ----------------------------------------------------------- #
+	def test_restricted_learned_skill_lands_in_the_fetch_half_for_a_role_holder(self):
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		clause = learned_skill_clause(self.holder)
+		installed, fetch = self._halves(clause)
+		self.assertIn("learned-479restricted", fetch)
+		self.assertNotIn("learned-479restricted", installed)
+		self.assertIn("jarvis__get_skill", clause)
+		# It must not imply container-side access to a body that is not there.
+		self.assertNotIn("workspace", clause)
+
+	def test_unrestricted_learned_skill_keeps_the_installed_clause(self):
+		self._managed("learned-479open", roles=())
+		installed, fetch = self._halves(learned_skill_clause(self.holder))
+		self.assertIn(f"{INSTALLED_LEAD} ", installed)
+		self.assertIn("learned-479open", installed)
+		self.assertNotIn("learned-479open", fetch)
+
+	def test_non_holder_is_told_about_neither(self):
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		self.assertNotIn("learned-479restricted", learned_skill_clause(self.outsider))
+
+	def test_system_manager_is_not_told_a_restricted_row_is_on_disk(self):
+		# The privileged branch used to short-circuit the child-row lookup, so
+		# Administrator / System Manager alone were told a role-restricted skill
+		# was installed. They skip the role INTERSECTION, never the emptiness test.
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		installed, fetch = self._halves(learned_skill_clause("Administrator"))
+		self.assertIn("learned-479restricted", fetch)
+		self.assertNotIn("learned-479restricted", installed)
+
+	def test_one_turn_can_carry_both_learned_clause_shapes(self):
+		self._managed("learned-479open", roles=())
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		installed, fetch = self._halves(learned_skill_clause(self.holder))
+		self.assertIn("learned-479open", installed)
+		self.assertNotIn("learned-479open", fetch)
+		self.assertIn("learned-479restricted", fetch)
+		self.assertNotIn("learned-479restricted", installed)
+
+	# --- retrieval ----------------------------------------------------------- #
+	def test_role_holder_can_fetch_the_restricted_body(self):
+		# The whole design rests on this: discovery names it, retrieval serves it,
+		# and the same predicate gates both.
+		from jarvis.tools.get_skill import get_skill
+
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		with _as(self.holder):
+			out = get_skill("learned-479restricted")
+		self.assertEqual(out["skill_name"], "learned-479restricted")
+		self.assertIn("the restricted rule", out["instructions"])
+
+	def test_non_holder_is_refused_the_restricted_body(self):
+		from jarvis.exceptions import PermissionDeniedError
+		from jarvis.tools.get_skill import get_skill
+
+		self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		with _as(self.outsider):
+			with self.assertRaises(PermissionDeniedError):
+				get_skill("learned-479restricted")
+
+	def test_disabled_learned_row_is_not_fetchable(self):
+		# find_skills filters enabled=1 and get_skill did not, so a disabled row
+		# still served its body. Harmless until this tool became the ONLY delivery
+		# path for a role-restricted body.
+		from jarvis.exceptions import InvalidArgumentError
+		from jarvis.tools.get_skill import get_skill
+
+		self._managed("learned-479off", roles=(HOLDER_ROLE,), enabled=0)
+		with _as(self.holder):
+			with self.assertRaises(InvalidArgumentError):
+				get_skill("learned-479off")
+
+	# --- the push, from the clause's side ------------------------------------ #
+	def test_the_clause_split_predicate_is_the_push_filter(self):
+		# The property #479 says the old design lacked: discovery and delivery
+		# cannot disagree about which bodies are on disk, because one helper
+		# answers both.
+		from jarvis.chat.custom_skills import role_restricted_names
+		from jarvis.learning.compiler import build_learned_push_payload
+
+		restricted = self._managed("learned-479restricted", roles=(HOLDER_ROLE,))
+		open_row = self._managed("learned-479open", roles=())
+		self.assertEqual(role_restricted_names([restricted, open_row]), {restricted})
+		slugs = {i["slug"] for i in build_learned_push_payload()}
+		self.assertIn("learned-479open", slugs)
+		self.assertNotIn("learned-479restricted", slugs)

--- a/jarvis/tests/test_learned_api.py
+++ b/jarvis/tests/test_learned_api.py
@@ -1057,7 +1057,7 @@ class TestLearnedSkillsPush(unittest.TestCase):
 			learned_skills_api.enqueue_learned_skills_push()
 		st = learned_skills_api.get_learned_skills_sync_status()
 		self.assertFalse(st["pending"])
-		self.assertTrue(st["last_sync_status"].startswith("ok (applied 1 via admin)"))
+		self.assertEqual(st["last_sync_status"], "ok (1 installed via admin)")
 		self.assertTrue(st["last_sync_at"])
 		post.assert_called_once()
 		# the wire body key + item shape match the admin/fleet contract.
@@ -1106,7 +1106,7 @@ class TestLearnedSkillsPush(unittest.TestCase):
 			SETTINGS,
 			SETTINGS,
 			{
-				"learned_skills_sync_status": "ok (applied 1 via admin)",
+				"learned_skills_sync_status": "ok (1 installed via admin)",
 				"learned_skills_synced_at": now_datetime(),
 			},
 			update_modified=False,

--- a/jarvis/tests/test_learned_skills_api.py
+++ b/jarvis/tests/test_learned_skills_api.py
@@ -81,7 +81,8 @@ class TestLearnedSkillsCutoverChain(unittest.TestCase):
 			mock.patch("frappe.enqueue") as enq,
 		):
 			learned_skills_api._enqueued_push_learned_skills(chain_custom_reconcile=True)
-		self.assertTrue(self._learned_status().startswith("ok (applied"))
+		self.assertTrue(self._learned_status().startswith("ok ("))
+		self.assertIn("installed via admin", self._learned_status())
 		# the custom pair is stamped pending BEFORE the reconcile is enqueued
 		# (the same stamps the SPA custom apply uses - the board polls them).
 		self.assertEqual(self._custom_status(), "pending: applying skills")
@@ -119,9 +120,28 @@ class TestLearnedSkillsCutoverChain(unittest.TestCase):
 			mock.patch("frappe.enqueue") as enq,
 		):
 			learned_skills_api._enqueued_push_learned_skills()
-		self.assertTrue(self._learned_status().startswith("ok (applied"))
+		self.assertTrue(self._learned_status().startswith("ok ("))
 		self.assertEqual(self._custom_status(), before)
 		enq.assert_not_called()
+
+	# ------------------------------------------------------------------ #
+	# reviewer-facing terminal wording (#479)
+	# ------------------------------------------------------------------ #
+	def test_ok_status_names_the_role_restricted_count(self):
+		# Every compiled managed row carries allowed_roles, so "applied 1" after a
+		# four-domain Apply was the normal reading of a healthy bench and reviewers
+		# would file it as a bug. The status now separates what reached the
+		# container from what is held bench-side and fetched on demand.
+		self.assertEqual(
+			learned_skills_api._ok_status(1, 3),
+			"ok (1 installed via admin, 3 role-restricted and fetched on demand)",
+		)
+		self.assertEqual(
+			learned_skills_api._ok_status(0, 4),
+			"ok (0 installed via admin, 4 role-restricted and fetched on demand)",
+		)
+		# nothing held back -> no clause about it, so the common case stays terse.
+		self.assertEqual(learned_skills_api._ok_status(2, 0), "ok (2 installed via admin)")
 
 
 if __name__ == "__main__":

--- a/jarvis/tools/get_skill.py
+++ b/jarvis/tools/get_skill.py
@@ -15,11 +15,24 @@ from jarvis.tools.find_skills import _require_system_user, _visible
 
 SKILL = "Jarvis Custom Skill"
 _CUSTOM_PREFIX = "custom-"
+_LEARNED_PREFIX = "learned-"
+# One Error Log row per slug per 10 minutes (the throttle idiom of
+# _plugin_auth._should_audit_unsigned_reject): a tenant whose clause and whose
+# fetch check disagree would otherwise fill the log from every turn.
+_MISS_AUDIT_TTL_S = 600
+_MISS_AUDIT_PREFIX = "jarvis:learned_get_skill_miss:"
 
 
 def get_skill(skill_name: str) -> dict:
 	"""Return one skill the calling user may use: ``{skill_name, description,
-	instructions, scope, enabled, user_invocable}``."""
+	instructions, scope, enabled, user_invocable}``.
+
+	This is the ONLY delivery path for a role-restricted body, custom or learned
+	(issues #477 / #479): those are never written into the shared, role-blind
+	container, so the role check here is enforcement on the bytes rather than
+	advice on a context line. It re-derives the caller's roles at fetch time and
+	runs them through ``user_can_use_skill``, the same predicate that decided
+	whether to name the slug in the first place."""
 	user = _require_system_user()
 	raw = (skill_name or "").strip().lower()
 	if not raw:
@@ -33,7 +46,10 @@ def get_skill(skill_name: str) -> dict:
 
 	rows = frappe.get_all(
 		SKILL,
-		filters={"skill_name": ["in", sorted(candidates)]},
+		# enabled=1 mirrors find_skills: a disabled row is not discoverable, so it
+		# must not be fetchable either. Load-bearing since #479 made this tool the
+		# only way a role-restricted body reaches the agent.
+		filters={"skill_name": ["in", sorted(candidates)], "enabled": 1},
 		fields=[
 			"name",
 			"owner",
@@ -49,11 +65,13 @@ def get_skill(skill_name: str) -> dict:
 		],
 	)
 	if not rows:
+		_audit_learned_miss(raw, user, "unknown")
 		raise InvalidArgumentError(f"unknown skill: {skill_name}")
 
 	user_roles = frappe.get_roles(user)
 	usable = [r for r in rows if _visible(r, user, user_roles)]
 	if not usable:
+		_audit_learned_miss(raw, user, "denied")
 		raise PermissionDeniedError(f"no access to skill: {skill_name}")
 
 	row = next((r for r in usable if r.owner == user), usable[0])
@@ -65,3 +83,36 @@ def get_skill(skill_name: str) -> dict:
 		"enabled": int(row.enabled or 0),
 		"user_invocable": int(row.user_invocable or 0),
 	}
+
+
+def _audit_learned_miss(slug: str, user: str, reason: str) -> None:
+	"""Log one throttled Error Log row when a ``learned-`` fetch misses.
+
+	``learned_skill_clause`` names a slug only after ``user_can_use_skill``
+	admitted this user, so a deny here means discovery and retrieval disagreed:
+	roles changed mid-turn, or one of the two read a stale ``frappe.get_roles``
+	cache. An ``unknown`` means the managed row was deleted between the two (a
+	concurrent Apply drops emptied domains). Both are invisible otherwise, and a
+	steady stream of either is the ONLY signal that the two role checks #479
+	deliberately made agree have drifted apart again.
+
+	Narrow on purpose: only ``learned-`` slugs, where the clause is the sole
+	discovery channel. A missed ``custom-`` slug is usually just the model
+	guessing a name. Never raises - an audit row must not fail a tool call."""
+	try:
+		if not (slug or "").startswith(_LEARNED_PREFIX):
+			return
+		cache = frappe.cache()
+		if not cache.set(_MISS_AUDIT_PREFIX + slug, b"1", nx=True, ex=_MISS_AUDIT_TTL_S):
+			return
+		frappe.log_error(
+			title="Jarvis: learned skill fetch missed",
+			message=(
+				f"jarvis__get_skill({slug!r}) {reason} for user {user!r}. The learned "
+				"context clause and the fetch-time role check disagreed, or the managed "
+				"row was deleted between them; the agent answered without this domain's "
+				"learned defaults."
+			),
+		)
+	except Exception:
+		pass

--- a/jarvis/tools/get_skill.py
+++ b/jarvis/tools/get_skill.py
@@ -103,7 +103,12 @@ def _audit_learned_miss(slug: str, user: str, reason: str) -> None:
 		if not (slug or "").startswith(_LEARNED_PREFIX):
 			return
 		cache = frappe.cache()
-		if not cache.set(_MISS_AUDIT_PREFIX + slug, b"1", nx=True, ex=_MISS_AUDIT_TTL_S):
+		# Site-scoped by hand: the raw redis ``set`` is NOT namespaced the way
+		# ``set_value`` is, and every tenant bench shares the same six learned
+		# slugs, so an unqualified key would let one site's throttle silence
+		# another's audit row.
+		key = f"{_MISS_AUDIT_PREFIX}{frappe.local.site}:{slug}"
+		if not cache.set(key, b"1", nx=True, ex=_MISS_AUDIT_TTL_S):
 			return
 		frappe.log_error(
 			title="Jarvis: learned skill fetch missed",


### PR DESCRIPTION
## Summary

Role-restricted learned skills are no longer written into the tenant's shared, role-blind openclaw container; their existence is still announced per turn to role-matched users, and their body is served on demand by the role-gated `jarvis__get_skill`.

Who notices: nearly every tenant. `_upsert_managed_skill` writes `allowed_roles` on every row it compiles, so a bench whose learned skills all come from role-gated doctypes now pushes **zero** files. That is the intended steady state, not a failure, so the audit status stops calling the result "applied N" and names the held-back count instead.

Behaviour for unrestricted rows is byte-identical to today. An empty `allowed_roles` still means "everyone" (design Q3 decision, unchanged here). `roles_derived` is recorded on managed rows and **read by nothing** so a later, stricter policy has data it could never backfill.

Based on `integration/backlog-2026-08-04`, not `develop`: PR #619 landed there and added the two-shape invocation clause plus the `jarvis__get_skill` fetch path this change reuses. Basing on `develop` would mean re-inventing #477's fetch-required clause and conflicting later.

Requires `Aerele-RnD/jarvis-persona#181` to merge FIRST.

Closes #479.

<details>
<summary>Root cause</summary>

`build_learned_push_payload` (`jarvis/learning/compiler.py`) filtered managed rows on `{enabled, managed_by_learning, owner}` and rendered every one of them. The sibling custom push has dropped role-restricted rows since security review PART 2 TASK 11, at `_pushable_org_rows` in `jarvis/chat/custom_skills.py`; the learned push never got a copy of that filter. So a body only Accounts Manager may read was physically written into a container that has exactly one `learned_skills` dir, no per-role mount, and no `bash` denial: `entrypoint.sh` copies it into `workspace/skills/` on every boot and any user's agent can `cat` it.

Narrowing the openclaw skill allowlist would not have fixed it. `<available_skills>` carries name and description only; the body is read by `bash cat` regardless of whether the agent was told the skill exists. The bytes have to leave the disk.

Two filters that were supposed to agree, in two files, with no shared definition, is exactly the shape that produced this. The fix hoists one helper, `custom_skills.role_restricted_names`, and has both pushes call it. `learned_skill_clause` derives its installed / not-installed split from the same helper's data, so discovery and delivery cannot disagree about what is on disk. The privileged branch now pays that lookup too: it may skip the role intersection, never the emptiness test, or a System Manager alone would be told a restricted row is installed.

`get_skill` becomes the only delivery path for these bodies, so it is hardened: `enabled=1` (`find_skills` already filtered it, `get_skill` did not) and a throttled Error Log row on a `learned-` deny or 404, which is the only observable signal that the two role checks have drifted apart again.
</details>

<details>
<summary>How already-pushed bodies get removed</summary>

Patch `jarvis.patches.v2_13_repush_learned_skills_role_gated`. The code fix closes the tap; it cannot remove what is on disk.

The mechanism already exists and needs no fleet change. `PUT /v1/containers/{name}/learned-skills` is a full reconcile: it `rmtree`s every learned dir absent from the pushed set, drops the slug from `agents.defaults.skills`, and restarts the container. The restart is the load-bearing step, because it is what rebuilds `workspace/skills/` from the now-smaller source dir. An empty payload is a valid "remove all" reconcile. One push per tenant finishes it.

Cost is a container restart, so the patch is gated twice: it returns early unless `learned_skills_sync_status` is non-empty (this bench has pushed through the learned namespace, so something of ours is in that container) AND at least one managed row carries `allowed_roles`. What survives both gates is precisely the exposed set, so the restart wave is bounded by tenants that actually have a body to evict rather than by fleet size. I judged that cheap enough for one wave; the staged alternative (wait for each tenant's next reviewer Apply) is unbounded and leaves a tenant that never applies exposed indefinitely, which is not a close-out for a security issue.

`JarvisSettings._resync_learned_skills_after_restart` is not this path: it fires only on an LLM-config-driven container restart, never on a deploy.
</details>

<details>
<summary>Tests, and proof they catch the bug</summary>

New: `TestLearnedRetrievalGating` (`jarvis/tests/test_custom_skill_visibility.py`, 12 tests) and five cases in `TestApplyLearnedSkills`. Existing `test_learned_push_payload_matches_fleet_contract` now uses an unrestricted fixture and keeps every shape assertion, so the fleet contract is still pinned byte for byte. `test_turn_injection_role_scoped` was passing by luck (the slug just moved sub-clause) and now asserts which sub-clause it lands in.

Reverting the two-line filter and the clause split, with tests untouched, fails 9 tests across 3 modules:

```
jarvis.tests.learning.test_compiler :: TestApplyLearnedSkills -> Ran 19 tests FAILED (failures=4)
 FAIL  test_role_restricted_learned_row_is_not_pushed
 FAIL  test_mixed_bench_pushes_only_the_unrestricted_rows
 FAIL  test_cutover_chains_graceful_custom_reconcile_once
 FAIL  test_cutover_skipped_for_fresh_phase2_tenant

jarvis.tests.test_custom_skill_visibility :: TestLearnedRetrievalGating -> Ran 9 tests FAILED (failures=4)
 FAIL  test_restricted_learned_skill_lands_in_the_fetch_half_for_a_role_holder
 FAIL  test_system_manager_is_not_told_a_restricted_row_is_on_disk
 FAIL  test_one_turn_can_carry_both_learned_clause_shapes
 FAIL  test_the_clause_split_predicate_is_the_push_filter

jarvis.tests.learning.test_e2e_flow :: TestPatternLearningE2E -> Ran 2 tests FAILED (failures=1)
 FAIL  test_turn_injection_role_scoped
```

with, for example:

```
AssertionError: Lists differ: [{'slug': 'learned-selling', ...}] != []
First list contains 1 additional elements.
```

Restored, all green:

```
Ran 19 tests OK <- TestApplyLearnedSkills
Ran 10 tests OK <- TestCompileDomainSkills
Ran 12 tests OK <- TestLearnedRetrievalGating
Ran  5 tests OK <- TestManagedFlagSecurity
Ran  2 tests OK <- TestPatternLearningE2E
Ran  5 tests OK <- TestLearnedSkillsCutoverChain
Ran  6 tests OK <- TestLearnedSkillsPush
Ran  7 tests OK <- TestGetSkill
Ran 13 tests OK <- TestRoleScopedSkillInvocation
```
</details>

<details>
<summary>One design claim that did not survive contact</summary>

The design says `learned_skills_sync_status` "surfaces on the reviewer board", so a reviewer reading "ok (applied 1 via admin)" after a four-domain Apply would file a bug. On this branch the SPA does not render it raw: `ReviewTab.vue` passes it through `humaniseSyncStatus` (`frontend/src/lib/syncStatus.js`), which collapses every `ok...` variant to "Up to date" and drops the suffix, deliberately, because the suffix is an audit trail and not customer copy.

So the misleading string was reaching support, Desk, and the `get_learned_apply_status` / `enqueue_learned_skills_push` API responses, not the reviewer's screen. The reword is still right and still required (that audit trail is how anyone reconstructs what a push did), it just is not a UI fix, and no SPA change is needed. `enqueue_learned_skills_push` additionally returns `role_restricted` alongside `count`, so a future surface has the number without re-parsing prose.
</details>

<details>
<summary>Not changed</summary>

- **Fleet-agent and jarvis_admin: zero changes.** The wire contract is still `{slug, description, body}` items; only the set is smaller.
- **Empty `allowed_roles` still means everyone.** It arises from three situations (genuinely universal, nobody holds an org-wide read, the derivation failed) and today's code reads all three the same way one layer up. Closing that is a separable product call, so this PR ships the real fix with zero behaviour change for unrestricted rows and records `roles_derived` so the safer policy later becomes a one-line change rather than a migration with nothing to migrate.
- **No "All" role in `allowed_roles`.** It fights the mechanism: the push filter drops any row that HAS `allowed_roles`, so an "All" row would stop being pushed, the opposite of the intent, and special-casing it in both filters is exactly the divergence that created this issue.
- **Delivery is model-volunteered, not guaranteed.** Nothing forces the agent to call `jarvis__get_skill`. The persona makes it an obligation and requires an honest sentence when the fetch fails. Worth noting the pushed-file model was also lazy: `<available_skills>` carries description only and the body was read by `bash cat`. This changes the channel, not the cost shape.
</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes
- [x] Branch is up to date with its base (`integration/backlog-2026-08-04`)
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
