### PR TITLE
wiki: curated links reach every consumer, and the Knowledge Graph can finally create one

### DIFF
--- a/frontend/src/pages/wiki/KnowledgeGraph.spec.js
+++ b/frontend/src/pages/wiki/KnowledgeGraph.spec.js
@@ -1,0 +1,236 @@
+// #492: the tenant Knowledge Graph shipped with its whole action layer switched
+// off. The page passed :show-actions / :can-act / :show-priority /
+// :show-actions-tab as false (three of them overriding a package default of
+// true), so the "+ link" button, the Actions tab and the priority strip never
+// rendered, and `addWikiLink` was exported by src/api/wiki.js and imported by
+// nothing. This covers the loop the page's own header comment describes: accept
+// a suggested connection -> add_wiki_link -> refetch -> the edge appears.
+//
+// wiki-graph-core is mocked wholesale. It is a `file:` sibling whose own runtime
+// deps (graphology, 3d-force-graph) are NOT installed by `npm ci` in frontend/,
+// and its 3D renderer needs WebGL, so the real package cannot load under vitest.
+// The stubs keep the package's real prop defaults, which is what makes "the page
+// stopped forcing these off" an assertion about observable behaviour.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { h, ref } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const A_ID = "page:customer--acme";
+const B_ID = "page:process--billing";
+const A_SLUG = "customer--acme";
+const B_SLUG = "process--billing";
+const SUGGESTION = { a: A_ID, b: B_ID, aLabel: "Acme Corp", bLabel: "Billing", score: 0.8 };
+
+const nodes = [
+	{ id: A_ID, kind: "page", slug: A_SLUG, label: "Acme Corp", page_type: "Customer" },
+	{ id: B_ID, kind: "page", slug: B_SLUG, label: "Billing", page_type: "Process" },
+];
+const UNLINKED = { nodes, edges: [] };
+const LINKED = { nodes, edges: [{ source: A_ID, target: B_ID, kind: "links-to" }] };
+
+const api = vi.hoisted(() => ({
+	addWikiLink: vi.fn(async () => ({ ok: true, manual_links: ["process--billing"] })),
+	getWikiGraph: vi.fn(),
+	getWikiGraphHistory: vi.fn(async () => []),
+}));
+vi.mock("@/api/wiki", () => api);
+
+vi.mock("@/theme", () => ({ useJarvisTheme: () => ({ effectiveDark: ref(false) }) }));
+
+vi.mock("@/components/LayoutHeader.vue", () => ({
+	default: {
+		name: "LayoutHeader",
+		setup:
+			(_p, { slots }) =>
+			() =>
+				h("div", null, slots),
+	},
+}));
+
+vi.mock("frappe-ui", () => {
+	const passthrough = (name, tag) => ({
+		name,
+		inheritAttrs: false,
+		setup:
+			(_p, { slots, attrs }) =>
+			() =>
+				h(
+					tag,
+					{ onClick: attrs.onClick },
+					slots.default ? slots.default() : attrs.label || ""
+				),
+	});
+	return {
+		Badge: passthrough("Badge", "span"),
+		Breadcrumbs: passthrough("Breadcrumbs", "nav"),
+		Button: passthrough("Button", "button"),
+	};
+});
+
+// Captured live prop objects (reactive), plus a handle on AnalysisTabs' emit.
+const seen = vi.hoisted(() => ({ detail: null, tabs: null, graph: null, fireAddLink: null }));
+
+vi.mock("wiki-graph-core", () => {
+	const stub = (name, props, slot, emits = []) => ({
+		name,
+		props,
+		emits,
+		setup(componentProps, { emit }) {
+			seen[slot] = componentProps;
+			if (name === "AnalysisTabs") seen.fireAddLink = (s) => emit("add-link", s);
+			return () => h("div", { class: name });
+		},
+	});
+	return {
+		// Prop defaults copied from the real package: DetailPanel.vue showActions,
+		// AnalysisTabs.vue canAct / showPriority / showActionsTab.
+		DetailPanel: stub(
+			"DetailPanel",
+			{ showActions: { type: Boolean, default: true } },
+			"detail"
+		),
+		AnalysisTabs: stub(
+			"AnalysisTabs",
+			{
+				analysis: Object,
+				nodes: Array,
+				actions: Object,
+				history: Array,
+				canAct: { type: Boolean, default: false },
+				showPriority: { type: Boolean, default: true },
+				showActionsTab: { type: Boolean, default: true },
+			},
+			"tabs",
+			["pick", "add-link"]
+		),
+		Graph3D: stub(
+			"Graph3D",
+			{ data: Object, metrics: Object, mode: String, dark: Boolean },
+			"graph"
+		),
+		FilterBar: { name: "FilterBar", setup: () => () => h("div") },
+		ExclusionRules: { name: "ExclusionRules", setup: () => () => h("div") },
+		runAnalysis: async () => ({
+			metrics: {},
+			lists: { suggestedLinks: [SUGGESTION], coRead: [], brokers: [] },
+			communities: {},
+		}),
+		computeActions: () => ({
+			stale: [],
+			orphans: [],
+			busFactor: [],
+			duplicates: [],
+			suggest: [SUGGESTION],
+		}),
+		overlayFilter: (g) => g,
+		egoGraph: (g) => g,
+		searchGraph: (g) => g,
+	};
+});
+
+import KnowledgeGraph from "@/pages/wiki/KnowledgeGraph.vue";
+
+async function mountGraph() {
+	const wrapper = mount(KnowledgeGraph);
+	await flushPromises();
+	await flushPromises();
+	return wrapper;
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	api.addWikiLink.mockClear();
+	api.addWikiLink.mockResolvedValue({ ok: true, manual_links: [B_SLUG] });
+	api.getWikiGraphHistory.mockClear();
+	api.getWikiGraph.mockReset();
+	api.getWikiGraph.mockResolvedValue(UNLINKED);
+});
+
+describe("KnowledgeGraph action layer (#492)", () => {
+	it("no longer forces the action layer off", async () => {
+		await mountGraph();
+		expect(seen.detail.showActions).toBe(true);
+		expect(seen.tabs.canAct).toBe(true);
+		expect(seen.tabs.showPriority).toBe(true);
+		expect(seen.tabs.showActionsTab).toBe(true);
+	});
+
+	it("adds the curated link and the edge appears after the refetch", async () => {
+		const wrapper = await mountGraph();
+		expect(seen.graph.data.edges).toHaveLength(0);
+		expect(wrapper.text()).toContain("0 links");
+
+		// the server now knows about the link the click is about to create
+		api.getWikiGraph.mockResolvedValue(LINKED);
+		seen.fireAddLink(seen.tabs.actions.suggest[0]);
+		await flushPromises();
+		await flushPromises();
+
+		// node ids are "page:<slug>"; the endpoint takes bare slugs
+		expect(api.addWikiLink).toHaveBeenCalledWith(A_SLUG, B_SLUG);
+		expect(api.getWikiGraph).toHaveBeenCalledTimes(2);
+		expect(seen.graph.data.edges).toEqual([{ source: A_ID, target: B_ID, kind: "links-to" }]);
+		expect(wrapper.text()).toContain("1 links");
+		expect(wrapper.text()).toContain("Linked Acme Corp to Billing");
+	});
+
+	it("keeps the graph mounted while refetching, rather than blanking to the skeleton", async () => {
+		const wrapper = await mountGraph();
+		let release;
+		api.getWikiGraph.mockReturnValueOnce(new Promise((r) => (release = () => r(LINKED))));
+
+		seen.fireAddLink(SUGGESTION);
+		await flushPromises();
+		expect(wrapper.find(".kg-skel").exists()).toBe(false);
+		expect(wrapper.find(".Graph3D").exists()).toBe(true);
+
+		release();
+		await flushPromises();
+	});
+
+	it("still reports success when only the refetch fails, because the link is stored", async () => {
+		const wrapper = await mountGraph();
+		api.getWikiGraph.mockRejectedValueOnce(new Error("Network error"));
+
+		seen.fireAddLink(SUGGESTION);
+		await flushPromises();
+		await flushPromises();
+
+		expect(api.addWikiLink).toHaveBeenCalledTimes(1);
+		expect(wrapper.text()).toContain("Linked Acme Corp to Billing");
+		expect(wrapper.text()).not.toContain("Network error");
+		expect(wrapper.find(".kg-err").exists()).toBe(false);
+	});
+
+	it("surfaces a server denial and leaves the graph as it was", async () => {
+		const wrapper = await mountGraph();
+		api.addWikiLink.mockRejectedValueOnce(new Error("Not permitted."));
+
+		seen.fireAddLink(SUGGESTION);
+		await flushPromises();
+		await flushPromises();
+
+		expect(wrapper.text()).toContain("Not permitted.");
+		expect(api.getWikiGraph).toHaveBeenCalledTimes(1);
+		expect(seen.graph.data.edges).toHaveLength(0);
+	});
+
+	it("ignores a second click while one curation is in flight", async () => {
+		const wrapper = await mountGraph();
+		let release;
+		api.addWikiLink.mockReturnValueOnce(new Promise((r) => (release = () => r({ ok: true }))));
+
+		seen.fireAddLink(SUGGESTION);
+		await flushPromises();
+		expect(seen.tabs.canAct).toBe(false);
+
+		seen.fireAddLink(SUGGESTION);
+		await flushPromises();
+		expect(api.addWikiLink).toHaveBeenCalledTimes(1);
+
+		release();
+		await flushPromises();
+		expect(seen.tabs.canAct).toBe(true);
+		expect(wrapper.exists()).toBe(true);
+	});
+});

--- a/frontend/src/pages/wiki/KnowledgeGraph.vue
+++ b/frontend/src/pages/wiki/KnowledgeGraph.vue
@@ -77,7 +77,6 @@
 					:node="state.selected"
 					:metrics="state.analysis.metrics"
 					:communities="state.analysis.communities"
-					:show-actions="false"
 					@focus="(id) => (state.focus = id)"
 				/>
 				<AnalysisTabs
@@ -85,10 +84,9 @@
 					:nodes="baseData.nodes"
 					:actions="state.actions"
 					:history="state.history"
-					:can-act="false"
-					:show-priority="false"
-					:show-actions-tab="false"
+					:can-act="!state.linking"
 					@pick="pickId"
+					@add-link="onAddLink"
 				/>
 			</div>
 		</div>
@@ -102,7 +100,18 @@
 // exclusion → worker analysis (structure + TF-IDF similarity) → 3D graph + the
 // four analysis tabs. Productive loop: accept a suggested connection → add_wiki_link
 // (durable, out-of-body) → refetch → the edge appears.
-import { reactive, computed, watch, onMounted } from "vue";
+//
+// That loop used to be described here and switched off in the template: the page
+// passed :show-actions / :can-act / :show-priority / :show-actions-tab as false,
+// three of them overriding a package default of true, so the "+ link" button, the
+// Actions tab and the priority strip never rendered and `addWikiLink` had no
+// caller anywhere in the SPA. The props are gone and `add-link` is wired.
+//
+// `canAct` is not a permission claim. add_wiki_link re-checks edit rights on the
+// source and read rights on the target server-side, and per-page rights vary by
+// scope, so the button is offered to everyone and a denial comes back as a toast
+// (same contract the wiki save/archive buttons already follow).
+import { reactive, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { Badge, Breadcrumbs, Button } from "frappe-ui";
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import {
@@ -117,7 +126,7 @@ import {
 	egoGraph,
 	searchGraph,
 } from "wiki-graph-core";
-import { getWikiGraph, getWikiGraphHistory } from "@/api/wiki";
+import { addWikiLink, getWikiGraph, getWikiGraphHistory } from "@/api/wiki";
 import { useJarvisTheme } from "@/theme";
 
 // Same breadcrumb + persistent "Open ERPNext Desk" top bar the other Skills
@@ -143,7 +152,9 @@ const PAGE_TYPES = [
 const state = reactive({
 	data: { nodes: [], edges: [] },
 	analysis: { metrics: {}, lists: {}, communities: {} },
-	actions: {},
+	// Full empty shape, not {}: ActionsTab reads actions.stale.length directly
+	// (no per-key guard), and it is reachable now that the Actions tab renders.
+	actions: { stale: [], orphans: [], busFactor: [], duplicates: [], suggest: [] },
 	history: [],
 	loaded: false,
 	error: null,
@@ -153,6 +164,10 @@ const state = reactive({
 	search: "",
 	focus: null,
 	toast: "",
+	// One curation in flight at a time: the "+ link" buttons are plain package
+	// buttons with no disabled state, so this is what stops a double-click from
+	// firing two writes against a row add_wiki_link locks anyway.
+	linking: false,
 	excluded: readExcluded(),
 });
 // Reactive theme so the 3D graph re-colours on a live light/dark toggle. Reading
@@ -212,12 +227,19 @@ async function recompute() {
 	state.actions = computeActions(data, analysis);
 }
 
+// Refetch + re-analyse in place. Kept separate from `load` so a curation can
+// refresh the graph WITHOUT dropping the page back to its skeleton: the point of
+// the loop is watching the new edge appear, not watching the view blank out.
+async function refetchGraph() {
+	const d = await getWikiGraph();
+	state.data = d || { nodes: [], edges: [] };
+	await recompute();
+}
+
 async function load() {
 	state.loaded = false;
 	state.error = null;
 	try {
-		const d = await getWikiGraph();
-		state.data = d || { nodes: [], edges: [] };
 		// Measured evolution history (best-effort; empty until the daily job runs
 		// or the doctype is migrated in — the Evolution tab reconstructs meanwhile).
 		getWikiGraphHistory()
@@ -225,12 +247,54 @@ async function load() {
 				state.history = Array.isArray(h) ? h : [];
 			})
 			.catch(() => {});
-		await recompute();
+		await refetchGraph();
 	} catch (e) {
 		state.error = (e && e.message) || String(e);
 	} finally {
 		state.loaded = true;
 	}
+}
+
+let _toastTimer = null;
+function toast(message) {
+	state.toast = message;
+	clearTimeout(_toastTimer);
+	_toastTimer = setTimeout(() => (state.toast = ""), 4000);
+}
+
+// Node ids are "page:<slug>"; the node itself carries the real slug, so prefer it
+// and fall back to stripping the prefix.
+function slugOf(id) {
+	const node = (state.data.nodes || []).find((n) => n.id === id);
+	return (node && node.slug) || String(id || "").replace(/^page:/, "");
+}
+
+// The productive loop: a suggested pair from SuggestPanel/ActionsTab -> the
+// curated link -> a refetch that shows the edge. add_wiki_link is idempotent and
+// row-locked, so a repeat is a no-op rather than a duplicate.
+async function onAddLink(suggestion) {
+	if (state.linking || !suggestion) return;
+	const from = slugOf(suggestion.a);
+	const to = slugOf(suggestion.b);
+	if (!from || !to || from === to) return;
+
+	state.linking = true;
+	try {
+		await addWikiLink(from, to);
+	} catch (e) {
+		toast((e && e.message) || "Could not add that link.");
+		return;
+	} finally {
+		state.linking = false;
+	}
+
+	// Past here the link IS stored, so a failing refetch only leaves the view
+	// stale. Reporting that as "could not add that link" would be a lie the user
+	// acts on; the header Refresh button recovers the view.
+	toast(`Linked ${suggestion.aLabel || from} to ${suggestion.bLabel || to}`);
+	try {
+		await refetchGraph();
+	} catch (_) {}
 }
 
 function onNode(node) {
@@ -242,6 +306,7 @@ function pickId(id) {
 }
 watch(() => state.excluded, recompute);
 onMounted(load);
+onBeforeUnmount(() => clearTimeout(_toastTimer));
 </script>
 
 <style scoped>

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -70,6 +70,9 @@ INDEX_PATH = "wiki/index.md"
 LOG_PATH = "wiki/log.md"
 _INDEX_SUMMARY_CHARS = 100
 _LOG_MAX_EVENTS = 150
+# Curated links are appended one at a time and never pruned, so the "## Related"
+# tail gets the same defensive cap wiki_graph puts on a page's link set.
+_MAX_RELATED = 50
 
 _PAGE_FIELDS = [
 	"name",
@@ -80,6 +83,9 @@ _PAGE_FIELDS = [
 	"status",
 	"summary",
 	"body_md",
+	# Curated [[links]], kept out of body_md by add_wiki_link; rendered as the
+	# "## Related" tail so they reach the container at all.
+	"manual_links",
 	"sources",
 	"last_confirmed_at",
 	"contradiction_flag",
@@ -115,12 +121,20 @@ def page_path(page) -> str:
 # --------------------------------------------------------------------------- #
 # renders (pure functions of page data; deterministic modulo the stale clock)
 # --------------------------------------------------------------------------- #
-def render_page(doc) -> tuple[str, str]:
+def render_page(doc, mirrored_slugs: set[str] | None = None) -> tuple[str, str]:
 	"""Render one page as Obsidian-style markdown. Returns ``(path, content)``
 	with path ``wiki/<typedir>/<slug>.md``. Frontmatter carries the metadata
 	the agent needs to trust-or-verify (stale/contradiction flags); the body's
-	existing ``[[slug]]`` links pass through untouched; the provenance trail
-	renders as a ``## Sources`` tail."""
+	existing ``[[slug]]`` links pass through untouched; curated out-of-body
+	links render as a ``## Related`` section and the provenance trail as a
+	``## Sources`` tail.
+
+	``mirrored_slugs`` is the set of slugs that actually have a file on the
+	container. ``_sync`` always passes it, because scope discipline runs
+	through Related too: a curated link may point at a Role/User or archived
+	page, and neither its slug nor a dangling ``[[link]]`` belongs in the
+	org-shared mirror. ``None`` (direct/test calls) renders every curated
+	target unfiltered."""
 	from jarvis.chat.wiki import is_stale
 
 	stale = is_stale(doc.get("last_confirmed_at"), doc.get("modified"))
@@ -142,11 +156,37 @@ def render_page(doc) -> tuple[str, str]:
 	body = str(doc.get("body_md") or "").strip("\n")
 	if body:
 		lines += [body, ""]
+	related = _related_lines(doc, mirrored_slugs)
+	if related:
+		lines += ["## Related", ""] + related + [""]
 	source_lines = _source_lines(doc.get("sources"))
 	if source_lines:
 		lines += ["## Sources", ""] + source_lines + [""]
 	content = "\n".join(lines).rstrip("\n") + "\n"
 	return page_path(doc), content
+
+
+def _related_lines(doc, mirrored_slugs: set[str] | None) -> list[str]:
+	"""``manual_links`` -> ``- [[slug]]`` bullets, in curation order.
+
+	Curated links are stored OUT of ``body_md`` so LLM re-ingest can't clobber
+	them, which also meant they never reached the container at all: the agent's
+	two channels are this mirror and ``jarvis__read_wiki``, and neither read the
+	field. Rendering them as real ``[[slug]]`` links keeps every body-based
+	consumer (Obsidian, a grep, the agent itself) working unchanged."""
+	from jarvis.chat.wiki import _parse_manual_links
+
+	self_slug = doc.get("slug") or doc.get("name")
+	out = []
+	for target in _parse_manual_links(doc.get("manual_links")):
+		if target == self_slug:
+			continue
+		if mirrored_slugs is not None and target not in mirrored_slugs:
+			continue
+		out.append(f"- [[{target}]]")
+		if len(out) >= _MAX_RELATED:
+			break
+	return out
 
 
 def _source_lines(raw) -> list[str]:
@@ -285,9 +325,14 @@ def _sync(full: bool) -> dict:
 	rows = frappe.get_all(WIKI, fields=_PAGE_FIELDS, limit_page_length=0)
 	active = [r for r in rows if _is_mirrorable(r)]
 
+	# Only these slugs have a file on the container, so only these may appear in
+	# a "## Related" tail (a curated link out to a Role/User or archived page
+	# would otherwise leak its slug into the org-shared mirror and dangle).
+	mirrored_slugs = {r.name for r in active}
+
 	files: list[dict] = []
 	for r in active:
-		path, content = render_page(r)
+		path, content = render_page(r, mirrored_slugs)
 		digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
 		if full or digest != (r.mirror_hash or ""):
 			files.append(_file_entry(path, content, page=r.name, digest=digest))

--- a/jarvis/learning/wiki_lint.py
+++ b/jarvis/learning/wiki_lint.py
@@ -8,8 +8,10 @@ wiki pages first:
 	those; a manual save clears the flag but may leave the section);
   * stale pages — >90 days since ``last_confirmed_at`` (``modified``
 	fallback), via ``jarvis.chat.wiki.is_stale``;
-  * orphan pages — no inbound ``[[slug]]`` reference from any OTHER Active
-	Org page body;
+  * orphan pages — no inbound reference from any OTHER Active Org page,
+	counting body ``[[slug]]`` links ∪ the page's curated ``manual_links``
+	(``add_wiki_link`` stores those OUT of ``body_md`` on purpose, so a
+	body-only scan calls a curated-only target an orphan forever);
   * near-duplicate titles — normalized-title collisions (failure mode #1 of
 	LLM-maintained wikis: the same entity re-created under a slightly
 	different name).
@@ -78,6 +80,9 @@ def _load_pages() -> list:
 			"last_confirmed_at",
 			"modified",
 			"scope",
+			# curated [[links]] live here, never in body_md (add_wiki_link's R1
+			# durability rule), so the orphan check has to read both halves.
+			"manual_links",
 		],
 		order_by="name asc",
 		limit_page_length=0,
@@ -98,9 +103,25 @@ def _stale_pages(pages: list) -> list:
 	return [p for p in pages if is_stale(p.last_confirmed_at, p.modified)]
 
 
+def _outbound_targets(page) -> set[str]:
+	"""One page's outbound link targets: body ``[[slug]]`` wikilinks ∪ its
+	curated ``manual_links``, minus self-references.
+
+	The union is what ``wiki_graph._build_graph_from_pages`` already applies;
+	reading only ``body_md`` here is what made the health summary contradict
+	the Evolution tab (a curated inbound link left the target an orphan).
+	"""
+	from jarvis.chat.wiki import _parse_manual_links
+
+	targets = set(_WIKILINK_RE.findall(page.body_md or ""))
+	targets |= set(_parse_manual_links(page.get("manual_links")))
+	targets.discard(page.name)
+	return targets
+
+
 def _find_orphans(pages: list) -> list:
-	"""Pages no OTHER Active Org page links to via [[slug]] (self-references
-	don't count; the generated index.md is not a page and never counts).
+	"""Pages no OTHER Active Org page links to (self-references don't count;
+	the generated index.md is not a page and never counts).
 
 	Young wikis have few cross-links, so "orphan" is only a signal once
 	linking is actually practiced: with fewer than 2 linking pages the check
@@ -109,7 +130,7 @@ def _find_orphans(pages: list) -> list:
 	linking_pages = 0
 	inbound: set[str] = set()
 	for p in pages:
-		targets = [t for t in _WIKILINK_RE.findall(p.body_md or "") if t != p.name]
+		targets = _outbound_targets(p)
 		if targets:
 			linking_pages += 1
 		inbound.update(targets)

--- a/jarvis/tests/test_wiki.py
+++ b/jarvis/tests/test_wiki.py
@@ -875,7 +875,10 @@ class TestWikiTools(FrappeTestCase):
 
 		rows = read_wiki(query="Wikitest Tool Page")
 		self.assertTrue(any(r["slug"] == "org--wikitest-tool-page" for r in rows))
-		self.assertEqual(set(rows[0]), {"slug", "title", "page_type", "summary", "stale"})
+		self.assertEqual(
+			set(rows[0]),
+			{"slug", "title", "page_type", "summary", "stale", "manual_links"},
+		)
 
 	def test_search_matches_ref_name_exactly(self):
 		_make_page(

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -8,6 +8,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import wiki as wiki_mod
 from jarvis.chat import wiki_graph
+from jarvis.tools.read_wiki import read_wiki
 
 WIKI = "Jarvis Wiki Page"
 _PREFIX = "graphtest"
@@ -21,7 +22,10 @@ def _delete_pages():
 		frappe.delete_doc(WIKI, name, force=True, ignore_permissions=True)
 
 
-class TestWikiGraphCompute(FrappeTestCase):
+class WikiGraphTestCase(FrappeTestCase):
+	"""Page fixtures swept by slug prefix, shared by the compute tests and the
+	reader-tool tests below."""
+
 	def setUp(self):
 		frappe.set_user("Administrator")
 		_delete_pages()
@@ -66,6 +70,8 @@ class TestWikiGraphCompute(FrappeTestCase):
 			frappe.db.set_value(WIKI, doc.name, vals, update_modified=False)
 		return doc
 
+
+class TestWikiGraphCompute(WikiGraphTestCase):
 	def _graph(self):
 		return wiki_graph.compute_graph()
 
@@ -378,6 +384,52 @@ class TestWikiGraphCompute(FrappeTestCase):
 		frappe.db.set_value(WIKI, doc.name, "status", "Archived", update_modified=False)
 		g = self._graph()
 		self.assertIsNone(self._node(g, f"page:{doc.name}"))
+
+
+class TestCuratedLinksReachReaders(WikiGraphTestCase):
+	"""#494: ``add_wiki_link`` stores curated links in ``manual_links``, never in
+	``body_md``, and for a long time only ``wiki_graph`` read that field. The
+	agent's only two channels into the wiki are ``jarvis__read_wiki`` and the
+	container mirror, so a curated relation reached it through neither.
+
+	The mirror and orphan halves live beside their own modules
+	(``test_wiki_mirror`` / ``test_wiki_lint``); this covers the reader tool,
+	next to the writer it pairs with."""
+
+	def test_read_wiki_surfaces_curated_links_on_both_paths(self):
+		target = self._page(f"{_PREFIX}-crl-target", "Curated Target")
+		source = self._page(
+			f"{_PREFIX}-crl-source",
+			"Curated Source",
+			body_md="Nothing in this body links anywhere.",
+			manual_links=[target.name],
+		)
+
+		page = read_wiki(slug=source.name)
+		self.assertEqual(page["manual_links"], [target.name])
+
+		rows = read_wiki(query=f"{_PREFIX}-crl-source", limit=10)
+		row = next(r for r in rows if r["slug"] == source.name)
+		self.assertEqual(row["manual_links"], [target.name])
+
+	def test_read_wiki_drops_targets_the_caller_cannot_read(self):
+		"""Curated links are bare slugs written once and never re-checked, so
+		echoing them raw would disclose a page whose scope narrowed since the
+		write, and would hand the agent links it cannot follow."""
+		archived = self._page(f"{_PREFIX}-crl-gone", "Curated Archived")
+		frappe.db.set_value(WIKI, archived.name, "status", "Archived", update_modified=False)
+		source = self._page(
+			f"{_PREFIX}-crl-src2",
+			"Curated Source 2",
+			manual_links=[archived.name, f"{_PREFIX}-crl-never-existed"],
+		)
+
+		page = read_wiki(slug=source.name)
+		self.assertEqual(page["manual_links"], [])
+
+	def test_read_wiki_reports_no_curated_links_when_there_are_none(self):
+		source = self._page(f"{_PREFIX}-crl-plain", "Curated Plain")
+		self.assertEqual(read_wiki(slug=source.name)["manual_links"], [])
 
 
 class TestWikiGraphSync(FrappeTestCase):

--- a/jarvis/tests/test_wiki_lint.py
+++ b/jarvis/tests/test_wiki_lint.py
@@ -12,6 +12,7 @@ tearDown (the lint stamps settings with a commit, so rollback isn't enough).
 from __future__ import annotations
 
 import contextlib
+import json
 from unittest import mock
 
 import frappe
@@ -65,6 +66,7 @@ class WikiLintTestCase(FrappeTestCase):
 		status="Active",
 		contradiction_flag=0,
 		last_confirmed_at=None,
+		manual_links=None,
 	):
 		doc = frappe.get_doc(
 			{
@@ -78,6 +80,8 @@ class WikiLintTestCase(FrappeTestCase):
 				"contradiction_flag": contradiction_flag,
 			}
 		)
+		if manual_links is not None:
+			doc.manual_links = json.dumps(manual_links)
 		doc.insert(ignore_permissions=True)
 		if last_confirmed_at:
 			frappe.db.set_value(
@@ -177,6 +181,44 @@ class TestDeterministicChecks(WikiLintTestCase):
 		with _mock_llm(key=""):
 			out = wiki_lint.run_lint()
 		self.assertEqual(out["orphans"], [])
+
+	def test_curated_inbound_link_rescues_an_orphan(self):
+		"""#494: add_wiki_link stores curated links in manual_links, never in
+		body_md. A body-only orphan scan therefore kept reporting the target as
+		an orphan while the Evolution tab (which unions both) showed it linked."""
+		adopted = self._page("adopted")
+		# body_md says nothing about `adopted`; only the curated store does.
+		self._page("curator", body="No wikilinks here at all.", manual_links=[adopted.name])
+		# second linking page so the young-wiki orphan gate is open
+		self._page("linker-a", body=f"See [[{SLUG_PREFIX}--linker-b]].")
+		self._page("linker-b", body=f"Back to [[{SLUG_PREFIX}--linker-a]].")
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		self.assertNotIn(adopted.name, out["orphans"])
+
+	def test_curated_links_alone_open_the_young_wiki_orphan_gate(self):
+		"""A wiki linked entirely by curation still counts as "linking is
+		practiced" — otherwise the gate silently disables the whole check."""
+		a = self._page("gate-a")
+		b = self._page("gate-b")
+		lonely = self._page("gate-lonely")
+		self._page("gate-c", manual_links=[a.name])
+		self._page("gate-d", manual_links=[b.name])
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		self.assertIn(lonely.name, out["orphans"])
+		self.assertNotIn(a.name, out["orphans"])
+		self.assertNotIn(b.name, out["orphans"])
+
+	def test_curated_self_link_does_not_rescue_an_orphan(self):
+		selfie = self._page("curated-selfie")
+		frappe.db.set_value(WIKI, selfie.name, "manual_links", json.dumps([selfie.name]))
+		frappe.db.commit()
+		self._page("linker-a", body=f"See [[{SLUG_PREFIX}--linker-b]].")
+		self._page("linker-b", body=f"Back to [[{SLUG_PREFIX}--linker-a]].")
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		self.assertIn(selfie.name, out["orphans"])
 
 	def test_settings_fields_are_stamped(self):
 		self._seed()

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -11,8 +11,10 @@ sync commits mid-run (FrappeTestCase rollback can't undo it).
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import hashlib
+import json
 from unittest import mock
 
 import frappe
@@ -47,7 +49,16 @@ class WikiMirrorTestCase(FrappeTestCase):
 		frappe.db.commit()
 		super().tearDown()
 
-	def _page(self, slug, page_type="Customer", body="Body.", summary="", scope=None, status="Active"):
+	def _page(
+		self,
+		slug,
+		page_type="Customer",
+		body="Body.",
+		summary="",
+		scope=None,
+		status="Active",
+		manual_links=None,
+	):
 		doc = frappe.get_doc(
 			{
 				"doctype": WIKI,
@@ -60,6 +71,8 @@ class WikiMirrorTestCase(FrappeTestCase):
 				"status": status,
 			}
 		)
+		if manual_links is not None:
+			doc.manual_links = json.dumps(manual_links)
 		doc.insert(ignore_permissions=True)
 		frappe.db.commit()
 		return doc
@@ -79,6 +92,16 @@ class WikiMirrorTestCase(FrappeTestCase):
 		for call in push_mock.call_args_list:
 			paths += [f["path"] for f in call.kwargs["files"]]
 		return paths
+
+	@staticmethod
+	def _pushed_content(push_mock, wire_path: str) -> str:
+		"""The decoded markdown actually sent for one wire path (the file that
+		lands in the container workspace), or "" when it was never pushed."""
+		for call in push_mock.call_args_list:
+			for f in call.kwargs["files"]:
+				if f["path"] == wire_path:
+					return base64.b64decode(f["content_b64"]).decode("utf-8")
+		return ""
 
 
 # --------------------------------------------------------------------------- #
@@ -118,6 +141,40 @@ class TestRenders(WikiMirrorTestCase):
 		self.assertIn("## Sources", content)
 		self.assertIn("- 2026-07-01 · voice · VN-1 · a@x.com", content)
 		self.assertTrue(content.endswith("\n"))
+
+	def test_render_page_emits_curated_links_as_a_related_section(self):
+		"""#494: curated links live in manual_links, out of body_md, so the
+		mirror never carried them and the agent could not see one at all."""
+		row = self._row(manual_links=json.dumps(["item--widget", "process--billing"]))
+		_path, content = wiki_mirror.render_page(row)
+		self.assertIn("## Related", content)
+		self.assertIn("- [[item--widget]]", content)
+		self.assertIn("- [[process--billing]]", content)
+		# curation order is preserved, and Related sits between body and Sources
+		self.assertLess(content.index("- [[item--widget]]"), content.index("- [[process--billing]]"))
+		self.assertLess(content.index("## Related"), content.index("## Sources"))
+		self.assertLess(content.index("Acme buys monthly."), content.index("## Related"))
+
+	def test_render_page_has_no_related_section_without_curated_links(self):
+		for raw in (None, "", "[]", "not json", '{"not": "a list"}'):
+			_path, content = wiki_mirror.render_page(self._row(manual_links=raw))
+			self.assertNotIn("## Related", content)
+
+	def test_render_page_related_is_filtered_to_mirrored_pages(self):
+		"""Scope discipline runs through Related: a curated link out to a
+		Role/User or archived page must not put its slug on the org-shared
+		container, nor leave a dangling [[link]] there."""
+		row = self._row(manual_links=json.dumps(["item--widget", "secret--u-bob"]))
+		_path, content = wiki_mirror.render_page(row, {"item--widget"})
+		self.assertIn("- [[item--widget]]", content)
+		self.assertNotIn("secret--u-bob", content)
+
+	def test_render_page_related_skips_self_and_caps(self):
+		me = f"{SLUG_PREFIX}--acme"
+		targets = [me] + [f"item--w{i}" for i in range(wiki_mirror._MAX_RELATED + 5)]
+		_path, content = wiki_mirror.render_page(self._row(manual_links=json.dumps(targets)))
+		self.assertNotIn(f"- [[{me}]]", content)
+		self.assertEqual(content.count("- [[item--w"), wiki_mirror._MAX_RELATED)
 
 	def test_render_page_stale_and_contradiction_flags(self):
 		row = self._row(last_confirmed_at="2020-01-01 00:00:00", contradiction_flag=1)
@@ -214,6 +271,35 @@ class TestRenders(WikiMirrorTestCase):
 # sync
 # --------------------------------------------------------------------------- #
 class TestSync(WikiMirrorTestCase):
+	def test_sync_pushes_a_file_carrying_the_curated_links(self):
+		"""#494 end to end: the file that reaches the container workspace has
+		the curated links in it, so a native read/grep by the agent finds them."""
+		target = self._page("target")
+		curator = self._page("curator", body="No wikilinks in this body.", manual_links=[target.name])
+
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		content = self._pushed_content(push, f"customers/{curator.name}.md")
+		self.assertIn("## Related", content)
+		self.assertIn(f"- [[{target.name}]]", content)
+
+	def test_sync_keeps_non_org_curated_targets_off_the_org_container(self):
+		private = self._page("private", scope="User")
+		archived = self._page("bygone", status="Archived")
+		visible = self._page("visible")
+		curator = self._page(
+			"curator",
+			manual_links=[private.name, archived.name, visible.name],
+		)
+
+		with self._mock_push() as push:
+			wiki_mirror.sync()
+		content = self._pushed_content(push, f"customers/{curator.name}.md")
+		self.assertIn(f"- [[{visible.name}]]", content)
+		self.assertNotIn(private.name, content)
+		self.assertNotIn(archived.name, content)
+
 	def test_sync_pushes_new_page_then_hash_diff_skips_it(self):
 		doc = self._page("acme", summary="Acme summary.")
 		wire_path = f"customers/{doc.name}.md"

--- a/jarvis/tools/read_wiki.py
+++ b/jarvis/tools/read_wiki.py
@@ -7,6 +7,13 @@ name) and returns compact rows. Desk (System User) sessions only. Both paths
 filter by the session user's scope visibility (Org pages for everyone, Role
 pages for holders of the target role, User pages for their target user only;
 System Manager sees all) via ``jarvis.chat.wiki_permissions``.
+
+Both paths also carry ``manual_links``: human-curated ``[[link]]`` targets that
+``add_wiki_link`` deliberately stores OUT of ``body_md`` so LLM re-ingest can't
+clobber them. Without them here the agent stays blind to curation, because this
+tool and the container mirror are its only two channels into the wiki. Targets
+are resolved against the CALLER's own visibility, so a curated link never
+discloses a page they may not read and never dangles.
 """
 
 import json
@@ -34,7 +41,8 @@ def _require_system_user() -> None:
 
 def read_wiki(query: str | None = None, slug: str | None = None, limit: int = 5):
 	"""Read the org wiki: pass ``slug`` for one full page dict, or ``query``
-	for a search returning ``[{slug, title, page_type, summary, stale}]``."""
+	for a search returning ``[{slug, title, page_type, summary, stale,
+	manual_links}]``."""
 	_require_system_user()
 	if slug:
 		return _get_by_slug(str(slug))
@@ -73,7 +81,36 @@ def _get_by_slug(slug: str) -> dict:
 		"last_confirmed_at": str(doc.last_confirmed_at) if doc.last_confirmed_at else None,
 		"contradiction_flag": cint(doc.contradiction_flag),
 		"stale": is_stale(doc.last_confirmed_at, doc.modified),
+		"manual_links": _visible_links({doc.name: doc.manual_links})[doc.name],
 	}
+
+
+def _visible_links(by_page: dict) -> dict[str, list[str]]:
+	"""``{page_name: manual_links JSON}`` -> ``{page_name: [target slug]}``,
+	keeping only targets that exist as Active pages the session user may read.
+
+	ONE query for the whole batch, using the same visibility fragment ``_search``
+	splices in. Curated links are stored as bare slugs with no re-check after the
+	write, so echoing them unfiltered would disclose a page whose scope has since
+	narrowed — and would hand the agent links it cannot follow."""
+	from jarvis.chat.wiki import _parse_manual_links
+
+	parsed = {name: _parse_manual_links(raw) for name, raw in by_page.items()}
+	wanted = sorted({t for targets in parsed.values() for t in targets})
+	if not wanted:
+		return {name: [] for name in parsed}
+
+	where = "status = 'Active'"
+	vis = (wiki_permissions.visible_scope_condition(frappe.session.user) or "").strip()
+	if vis:
+		where += f" and ({vis})"
+	rows = frappe.db.sql(
+		f"select slug from `tabJarvis Wiki Page` where {where} and slug in %(slugs)s",
+		{"slugs": wanted},
+		as_dict=True,
+	)
+	allowed = {r.slug for r in rows}
+	return {name: [t for t in targets if t in allowed] for name, targets in parsed.items()}
 
 
 def _search(query: str, limit: int) -> list[dict]:
@@ -90,7 +127,8 @@ def _search(query: str, limit: int) -> list[dict]:
 	if vis:
 		where += f" and ({vis})"
 	rows = frappe.db.sql(
-		f"""select slug, title, page_type, summary, last_confirmed_at, modified
+		f"""select name, slug, title, page_type, summary, manual_links,
+			last_confirmed_at, modified
 		from `tabJarvis Wiki Page`
 		where {where}
 			and (slug like %(like)s or title like %(like)s
@@ -100,6 +138,7 @@ def _search(query: str, limit: int) -> list[dict]:
 		{"like": f"%{query[:140]}%", "query": query, "limit": limit},
 		as_dict=True,
 	)
+	links = _visible_links({r.name: r.manual_links for r in rows})
 	return [
 		{
 			"slug": r.slug,
@@ -107,6 +146,7 @@ def _search(query: str, limit: int) -> list[dict]:
 			"page_type": r.page_type,
 			"summary": r.summary,
 			"stale": is_stale(r.get("last_confirmed_at"), r.get("modified")),
+			"manual_links": links[r.name],
 		}
 		for r in rows
 	]


### PR DESCRIPTION
## Summary

Curated wiki links now work end to end: the "+ link" button on the Knowledge Graph is reachable for the first time, and the link it writes reaches the health check, the container mirror and `read_wiki` instead of only the graph.

Two issues, two commits, in that order. #494 lands the plumbing first so the health summary and the Evolution tab agree the moment #492 starts producing curated links; ship them the other way round and a page with curated inbound links reports as an orphan in one surface while showing as connected in the other.

**Who notices.** Anyone on the Knowledge Graph page: the Actions tab, the priority strip, the per-node actions and the "+ link" button all render now. And the agent, which could not see a curated link through either of its two channels, so curating a relation for its benefit did nothing at all.

`add_wiki_link` itself is unchanged. It was already correct.

Closes #494
Closes #492

<details>
<summary>Root cause</summary>

**#494.** `add_wiki_link` deliberately stores curated links in `manual_links` rather than in `body_md`, so LLM re-ingest (which full-replaces the body) cannot clobber them. Exactly one consumer ever read that field: `wiki_graph`, which unions it into `links-to` edges. The other three read `body_md` only.

- `wiki_lint._load_pages` did not even fetch the column, and `_find_orphans` built its inbound set from `_WIKILINK_RE.findall(p.body_md)`. A page whose only inbound links were curated stayed an orphan to the health summary forever, while the Evolution tab, built on the union graph, showed it linked.
- `wiki_mirror.render_page` emitted frontmatter, summary, body and a Sources tail. `manual_links` appeared nowhere in the module.
- `read_wiki` returned no such key on the slug path and did not select the column on the query path.

The mirror and `read_wiki` are the agent's only two channels into the wiki, so between them the agent was blind to curation.

Fixes:

- `_find_orphans` unions body wikilinks with `manual_links` (self-references still excluded), which is the same union `wiki_graph._build_graph_from_pages` already applies. Curated links also count toward the "linking is practiced" gate, otherwise a wiki linked entirely by curation silently disables the whole orphan check.
- `render_page` emits a `## Related` section of `- [[slug]]` bullets between the body and the Sources tail, matching how the Sources tail is built. Real `[[links]]`, so Obsidian, a grep and the agent all pick them up with no new parsing. `_sync` passes the set of slugs that actually have a file on the container, because scope discipline runs through Related too: a curated link out to a Role/User or archived page must not put its slug on the org-shared mirror or leave a dangling link there. Capped at 50 per page, matching `wiki_graph._MAX_LINKS_PER_PAGE`, since curated links are appended one at a time and never pruned.
- `read_wiki` returns `manual_links` on both paths, resolved against the caller's own visibility in one batched query. Curated links are bare slugs written once and never re-checked, so echoing them raw would disclose a page whose scope has since narrowed and would hand the agent links it cannot follow.

**#492.** `KnowledgeGraph.vue` passed `:show-actions="false"`, `:can-act="false"`, `:show-priority="false"` and `:show-actions-tab="false"`. Three of those override a package default of `true` (`DetailPanel.vue:72`, `AnalysisTabs.vue:90`, `AnalysisTabs.vue:92`), so the package was built with the action layer on and the tenant page opted out of every part of it. `addWikiLink` was exported from `src/api/wiki.js` and imported by nothing, in front of a permission-checked, `for_update`-locked, six-test endpoint. The page's own header comment described the loop as working.

The four props are gone and `@add-link` is wired. Three details fell out of turning the layer on:

- the refetch does not go through `load()`, so the page keeps the graph mounted rather than dropping to its skeleton. Watching the edge appear is the point of the loop.
- `canAct` is not a permission claim. Per-page edit rights vary by scope and the endpoint re-checks both ends, so the button is offered to everyone and a denial comes back as a toast. `state.toast` had a style rule and a template slot but no writer until now.
- `state.actions` was initialised to `{}` while `ActionsTab` reads `actions.stale.length` with no per-key guard. Harmless while the tab could not render. It can now, so the initial value carries the full empty shape.

There is no `remove_wiki_link` endpoint, so a curated link is not undoable from the SPA. Out of scope here; worth a follow-up if curation gets used in anger.

</details>

## What #492 means for #495

Once #492 ships, tenant-curated links start flowing to the ADMIN control plane through the daily graph push. `wiki_graph._build_graph_from_pages` is shared by `compute_graph` (the admin push) and `get_wiki_graph` (the tenant UI), and it already unions `manual_links` into `links-to` edges. Today `manual_links` is empty in practice because nothing writes it, so this is genuinely new data crossing a trust boundary.

Concretely, the delta is one extra `links-to` edge per curated link, `{source: "page:<slug>", target: "page:<slug>", kind: "links-to"}`. No new fields and no page content: both endpoints of every such edge are page nodes already in the payload. But `compute_graph` pushes ALL scopes, and `add_wiki_link` allows any target the caller can read, so a curated edge can assert a relationship involving a Role or User scope page. Per-page manual links are uncapped in `wiki_graph` (unlike body links, capped at 50), bounded only by `MAX_EDGES`.

This is #495's territory, and #495 is not addressed here. The push already sends private page titles and owner emails; this note is so whoever scopes #495 knows the surface just grew.

## Testing

Backend, `bench --site site.jarvis run-tests --app jarvis` per case:

- `test_wiki_lint.TestDeterministicChecks` 8 tests, including a page rescued from orphanhood by a curated-only inbound link, curated links opening the young-wiki gate, and a curated self-link still not rescuing.
- `test_wiki_mirror.TestRenders` 11 and `TestSync` 13, including the `## Related` shape and ordering, the mirrorable-slug filter, the self/cap guards, and the decoded file actually pushed to the container carrying the links.
- `test_wiki_graph.TestCuratedLinksReachReaders` 3, covering `read_wiki` on both paths plus the visibility filter.
- `test_wiki.TestWikiTools` 10, `test_wiki_scopes_api` 38, `test_wiki_graph.TestWikiGraphCompute` 23 and the rest of `test_wiki` all green. The one failure locally is `test_add_link_concurrency_no_lost_update`, the known MariaDB 1020 lock-contention flake that passes on hosted CI.

Frontend, Node 24: 678 vitest tests across 49 files and 557 `node:test` tests, all passing, including 5 new ones in `frontend/src/pages/wiki/KnowledgeGraph.spec.js`.

Each fix was reverted individually and the new tests were confirmed to fail: dropping the lint union fails 2, dropping the `## Related` section fails 5 across renders and sync, dropping the `read_wiki` key fails 4, and restoring the four `false` props fails 4 of the 5 frontend tests.

## Pre-merge checklist

- [ ] **CI is green** on this PR
- [x] Branch is up to date with `develop` (rebased onto `726ac15e`)
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
