### PR TITLE
fix(wiki): a personal page belongs to one user, and the voice scribe may not overwrite a human edit

### DIFF
--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -43,6 +43,15 @@ replacing with it deleted everything past the excerpt. The prompt now asks for
 ``append_md`` on an existing page, and the merge appends a stray ``body_md``
 instead of swapping it in.
 
+Two fences protect text the machine does not own, and they answer different
+questions. ``provenance_prefix`` (Custom App Learning scribe) asks "is this page
+MINE?" and REFUSES anything else outright. ``preserve_curated`` (every voice
+caller) asks "did a PERSON write this?" and, when the answer is yes, downgrades
+the write to add-only: a dated attribution heading, no summary overwrite, and a
+refusal rather than a head-truncating clip. The voice ingest cannot use the first
+one, because its own writes are stamped ``voice`` and ``voice`` counts as a human
+kind, so the fence would lock it out of the pages it created itself.
+
 Personal (User-scope) pages are resolved by ``resolve_user_scope_page``, never by
 a bare slug lookup: the ``--u-<localpart>`` audience suffix is NOT unique across
 users, so an unfiltered lookup could hand one colleague's private page to
@@ -804,6 +813,9 @@ def _ingest_note(note_name: str) -> None:
 		# path may never replace one: a "full merged body" reply would delete
 		# everything past the excerpt (issue #488).
 		allow_body_replace=False,
+		# ... and on a page a person edited by hand, this write may only ADD:
+		# no summary overwrite, no head-truncating clip (issue #489).
+		preserve_curated=True,
 	)
 	if failed:
 		# A page write failed (already logged per-update): leave the note New
@@ -956,6 +968,21 @@ def _parse_updates(raw: str) -> list | None:
 # clobber a person's edit.
 _HUMAN_SOURCE_KINDS = frozenset({"manual", "chat", "voice", "edit", "promotion", "tool"})
 
+# Provenance kinds that mean a person AUTHORED OR APPROVED this page's text with
+# their own hands: the SPA editor (``create_wiki_page`` / ``save_wiki_page`` stamp
+# "manual") and the reviewed promotion flow ("promotion"). "edit" is reserved for
+# the same meaning.
+#
+# A STRICT SUBSET of _HUMAN_SOURCE_KINDS, and deliberately so (issue #489). The
+# obvious fix — handing the voice ingest ``provenance_prefix="voice"`` — cannot
+# work, because "voice" is itself a human kind AND is what the ingest stamps on
+# every page it writes, so the fence would refuse the ingest's own pages from the
+# second note onward. "voice" and "chat" name a pipeline that DERIVED text from a
+# human utterance; "tool" names the agent's own update_wiki writes. None of those
+# is a person's typing, and none belongs here. _HUMAN_SOURCE_KINDS keeps its full
+# membership for the Custom App Learning fence, which is unchanged.
+_CURATED_SOURCE_KINDS = frozenset({"manual", "edit", "promotion"})
+
 
 def _is_txn_fatal(e: Exception) -> bool:
 	"""A transaction-FATAL DB error — a deadlock or a lock-wait timeout — aborts the
@@ -997,6 +1024,23 @@ def _sources_agent_updatable(raw, prefix: str) -> bool:
 	return any(k.startswith(prefix) for k in kinds)
 
 
+def _sources_are_curated(raw) -> bool:
+	"""Predicate over a page's raw ``sources`` JSON: has a PERSON authored or
+	approved this page's text (a ``kind`` in ``_CURATED_SOURCE_KINDS``)?
+
+	Unlike ``_sources_agent_updatable`` this never refuses the write outright —
+	it downgrades it to add-only (issue #489), so the machine keeps recording
+	what it learned and the human keeps every word they wrote. A missing/corrupt
+	``sources`` reads as CURATED (fails closed toward preserving text)."""
+	try:
+		sources = json.loads(raw) if raw else []
+	except Exception:
+		return True
+	if not isinstance(sources, list):
+		return True
+	return any(str(s.get("kind") or "") in _CURATED_SOURCE_KINDS for s in sources if isinstance(s, dict))
+
+
 def _page_is_agent_updatable(name: str, prefix: str) -> bool:
 	"""``_sources_agent_updatable`` for a page by name (unlocked read — the cheap
 	early-out; the authoritative check is re-run under a row lock at save time)."""
@@ -1012,6 +1056,7 @@ def apply_extracted_page_updates(
 	target_user: str | None = None,
 	provenance_prefix: str | None = None,
 	allow_body_replace: bool = True,
+	preserve_curated: bool = False,
 	return_outcomes: bool = False,
 ) -> tuple[int, int] | list[dict]:
 	"""Create/update wiki pages from extracted updates (the note ingest above
@@ -1047,6 +1092,17 @@ def apply_extracted_page_updates(
 	recoverable, a deleted one is not. Callers that compose a page from a source
 	they read in full (the app-learning scribe) keep the default True and still
 	replace, so a re-run refreshes its own page in place rather than doubling it.
+
+	``preserve_curated=True`` (every voice caller, issue #489): on a page a
+	PERSON authored or approved (``_sources_are_curated``) this write may only
+	ADD, never SUBTRACT. The body is appended under a dated attribution heading
+	whatever ``allow_body_replace`` says, the summary is only filled when empty,
+	and an append that would push the body past the cap is REFUSED rather than
+	clipped (the clip drops the OLDEST text, which on such a page is the human's
+	own). ``allow_body_replace`` is a property of the CALLER — it says "I only
+	saw an excerpt"; this is a property of the PAGE — it says "someone wrote
+	this by hand". Pages the machine owns are untouched by it, which is what
+	lets the voice ingest keep refreshing the pages it created itself.
 
 	``return_outcomes=True`` (Custom App Learning scribe writeback): returns a
 	PER-UPDATE outcome list ``[{slug, ok, reason}]`` aligned to the accepted
@@ -1099,6 +1155,7 @@ def apply_extracted_page_updates(
 					target_user,
 					provenance_prefix,
 					allow_body_replace,
+					preserve_curated,
 				)
 			)
 			reason = "applied" if ok else "refused"
@@ -1133,6 +1190,7 @@ def _apply_one_update(
 	target_user: str | None = None,
 	provenance_prefix: str | None = None,
 	allow_body_replace: bool = True,
+	preserve_curated: bool = False,
 ) -> bool:
 	slug = _normalize_slug(update.get("slug"))
 	if not slug:
@@ -1208,7 +1266,7 @@ def _apply_one_update(
 	if provenance_prefix and not _page_is_agent_updatable(name, provenance_prefix):
 		return False
 
-	args = (name, update, source, user, ref, provenance_prefix, allow_body_replace, tuser)
+	args = (name, update, source, user, ref, provenance_prefix, allow_body_replace, preserve_curated, tuser)
 	try:
 		return _merge_update_into_page(*args)
 	except frappe.TimestampMismatchError:
@@ -1225,11 +1283,13 @@ def _merge_update_into_page(
 	ref: str | None,
 	provenance_prefix: str | None = None,
 	allow_body_replace: bool = True,
+	preserve_curated: bool = False,
 	expect_target_user: str | None = None,
 ) -> bool:
 	body_md = update.get("body_md")
 	append_md = update.get("append_md")
 	contradiction = bool(update.get("contradiction"))
+	curated = False
 
 	# TOCTOU close: re-check under a ROW LOCK on the page immediately before
 	# mutating it. A save that landed BETWEEN the unlocked resolution above and
@@ -1242,7 +1302,9 @@ def _merge_update_into_page(
 	#    page. Merging into a colleague's personal page both discloses the
 	#    writer's private statement and hides it from the writer, and the page
 	#    could have been re-targeted since we resolved it.
-	if provenance_prefix is not None or expect_target_user is not None:
+	#  * curation (issue #489): a human edit that landed via ``save_wiki_page``
+	#    in the gap must still downgrade this write to add-only.
+	if provenance_prefix is not None or expect_target_user is not None or preserve_curated:
 		locked = (
 			frappe.db.get_value(WIKI, name, ["sources", "target_user"], as_dict=True, for_update=True) or {}
 		)
@@ -1252,9 +1314,13 @@ def _merge_update_into_page(
 			return False
 		if expect_target_user is not None and locked.get("target_user") != expect_target_user:
 			return False
+		curated = bool(preserve_curated) and _sources_are_curated(locked.get("sources"))
 
 	doc = frappe.get_doc(WIKI, name)
-	if update.get("summary"):
+	if update.get("summary") and not (curated and (doc.summary or "").strip()):
+		# A summary REPLACES, so on a curated page it is the one field that could
+		# still destroy a human's words even after issue #488 turned the body into
+		# an append. Fill it only when the human left it empty (issue #489).
 		doc.summary = _clip_summary(update.get("summary"))
 	if not (doc.ref_doctype or "").strip() and update.get("ref_doctype"):
 		doc.ref_doctype = str(update["ref_doctype"]).strip()
@@ -1276,18 +1342,38 @@ def _merge_update_into_page(
 		incoming = body_md.strip()
 		replaces = allow_body_replace
 	if incoming:
+		stamp = now_datetime().strftime("%Y-%m-%d")
 		if contradiction and existing:
-			stamp = now_datetime().strftime("%Y-%m-%d")
-			doc.body_md = _clip_body(f"{existing}\n\n## Contradiction flagged ({stamp})\n\n{incoming}")
+			merged = f"{existing}\n\n## Contradiction flagged ({stamp})\n\n{incoming}"
 			doc.contradiction_flag = 1
-		elif replaces or not existing:
-			doc.body_md = _clip_body(incoming)
+		elif not existing:
+			merged = incoming
+		elif curated:
+			# A person authored or approved this page's text (issue #489). The
+			# machine may ADD to it under its own attributed heading — so the
+			# reader can always tell whose words are whose — but never rewrite
+			# it, whatever ``allow_body_replace`` says.
+			merged = f"{existing}\n\n## Added by Jarvis from a note ({stamp})\n\n{incoming}"
+		elif replaces:
+			merged = incoming
 		else:
 			# Either an append, or an append-only caller that sent a body_md
 			# anyway. The ingest only ever saw an EXCERPT of this page, so
 			# swapping the field would delete the rest; a duplicated section is
 			# recoverable by a human editor, a deleted one is not (issue #488).
-			doc.body_md = _clip_body(f"{existing}\n\n{incoming}")
+			merged = f"{existing}\n\n{incoming}"
+		if curated and existing and len(merged) > MAX_BODY_LEN:
+			# _clip_body keeps the TAIL, so clipping here would silently delete
+			# the human's oldest lines to make room for a machine append. Refuse
+			# the whole update instead and say so: dropping one note's knowledge
+			# is recoverable (the page is still there to edit), deleting a
+			# person's text is not.
+			frappe.log_error(
+				title="wiki: append refused, would truncate a human-edited page",
+				message=f"{name}: {len(existing)} + {len(incoming)} chars exceeds {MAX_BODY_LEN}",
+			)
+			return False
+		doc.body_md = _clip_body(merged)
 	append_source(doc, source, ref, user)
 	doc.last_confirmed_at = now_datetime()
 	doc.save(ignore_permissions=True)

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -42,6 +42,11 @@ tokens, so a "full merged body" reply can never carry a long page back intact �
 replacing with it deleted everything past the excerpt. The prompt now asks for
 ``append_md`` on an existing page, and the merge appends a stray ``body_md``
 instead of swapping it in.
+
+Personal (User-scope) pages are resolved by ``resolve_user_scope_page``, never by
+a bare slug lookup: the ``--u-<localpart>`` audience suffix is NOT unique across
+users, so an unfiltered lookup could hand one colleague's private page to
+another.
 """
 
 from __future__ import annotations
@@ -228,14 +233,77 @@ def _suffix_slug(base_slug, suffix: str) -> str:
 
 
 def user_scope_slug(base_slug, user: str) -> str:
-	"""The audience-suffixed slug a User-scope page for ``user`` gets
-	(``<base>--u-<localpart>``), mirroring the controller exactly."""
+	"""The PREFERRED audience-suffixed slug for ``user``'s User-scope page
+	(``<base>--u-<localpart>``) — what the controller gives them when that slug
+	is free or already theirs. It is NOT unique per user: see
+	``user_scope_slug_candidates``."""
 	from jarvis.chat.entities import scrub
 
 	local = scrub(str(user or "").split("@")[0])
 	if not local:
 		return _normalize_slug(base_slug)
 	return _suffix_slug(base_slug, f"--u-{local}")
+
+
+def _user_slug_digest(user: str) -> str:
+	"""A short stable digest of the WHOLE address, used to break a local-part
+	collision. ``scrub`` is lossy (it folds ``@``, ``.``, ``_`` and every other
+	non-alnum run to one hyphen), so no scrubbed form of an email — local part
+	OR full address — is injective. A digest of the raw address is."""
+	import hashlib
+
+	return hashlib.sha256(str(user or "").strip().lower().encode("utf-8")).hexdigest()[:8]
+
+
+def user_scope_slug_candidates(base_slug, user: str) -> list[str]:
+	"""Every slug ``user``'s User-scope page for ``base_slug`` may carry, most
+	preferred first.
+
+	The audience suffix keys on the email LOCAL PART, so alice@acme.com and
+	alice@contractor.io both derive ``--u-alice`` — and since the slug IS the
+	docname (``autoname: field:slug``, unique), the second user's page collided
+	with the first's, which is issue #490. The preferred form is still offered
+	first, so every page created before that fix keeps its slug and its docname
+	(no rename, no orphan); a genuine cross-user collision falls back to
+	``--u-<localpart>-<digest>``.
+
+	Both forms are PURE functions of the base slug and the address, so the
+	controller (which picks one at create time) and the resolvers (which probe
+	them at read time) agree without a shared lookup table."""
+	from jarvis.chat.entities import scrub
+
+	normalized = _normalize_slug(base_slug)
+	preferred = user_scope_slug(base_slug, user)
+	local = scrub(str(user or "").split("@")[0])
+	if not local:
+		return [preferred]
+	alt = _suffix_slug(base_slug, f"--u-{local}-{_user_slug_digest(user)}")
+	# An already-suffixed slug passed back in must not be suffixed twice. The
+	# disambiguated form is checked first: it ENDS WITH the preferred one, so
+	# testing the preferred form first would mis-classify it.
+	if normalized == alt:
+		return [alt]
+	if normalized == preferred:
+		return [preferred]
+	return [preferred, alt]
+
+
+def resolve_user_scope_page(base_slug, target_user: str) -> tuple[str | None, str]:
+	"""Resolve ``target_user``'s OWN User-scope page for ``base_slug``.
+
+	Returns ``(docname or None, slug)``. EVERY probe filters on
+	``scope``/``target_user``, so a slug this user does not own can never
+	resolve here — that unfiltered lookup was how one colleague's private note
+	landed in another's page (issue #490). Mirrors
+	``jarvis.tools.update_wiki._find_existing``, which always got this right."""
+	candidates = user_scope_slug_candidates(base_slug, target_user)
+	for candidate in candidates:
+		name = frappe.db.get_value(
+			WIKI, {"slug": candidate, "scope": "User", "target_user": target_user}, "name"
+		)
+		if name:
+			return name, candidate
+	return None, candidates[0]
 
 
 def role_scope_slug(base_slug, role: str) -> str:
@@ -1083,10 +1151,14 @@ def _apply_one_update(
 
 	# User pages carry the controller's audience suffix in their docname, so a
 	# scope-aware lookup must probe the SUFFIXED slug (a base-slug lookup would
-	# miss the personal page and mint a duplicate).
-	lookup_slug = user_scope_slug(slug, tuser) if scope == "User" else slug
-
-	name = frappe.db.get_value(WIKI, {"slug": lookup_slug}, "name")
+	# miss the personal page and mint a duplicate) AND filter on the audience (an
+	# unfiltered one resolves to whichever user claimed the local part first,
+	# issue #490).
+	if scope == "User":
+		name, lookup_slug = resolve_user_scope_page(slug, tuser)
+	else:
+		lookup_slug = slug
+		name = frappe.db.get_value(WIKI, {"slug": lookup_slug}, "name")
 	if not name:
 		title = " ".join(str(update.get("title") or "").split())
 		page_type = (update.get("page_type") or "").strip()
@@ -1116,10 +1188,16 @@ def _apply_one_update(
 			return True
 		except frappe.DuplicateEntryError:
 			# The slug appeared concurrently — merge into it instead (the stored
-			# docname is the suffixed slug for User scope).
-			name = frappe.db.get_value(WIKI, {"slug": lookup_slug}, "name") or frappe.db.get_value(
-				WIKI, {"slug": doc.slug}, "name"
-			)
+			# docname is the suffixed slug for User scope). The User re-probe stays
+			# audience-filtered: a slug owned by somebody else is NOT ours to merge
+			# into, so it re-raises and the update is counted failed rather than
+			# cross-written (issue #490).
+			if scope == "User":
+				name, _ = resolve_user_scope_page(slug, tuser)
+			else:
+				name = frappe.db.get_value(WIKI, {"slug": lookup_slug}, "name") or frappe.db.get_value(
+					WIKI, {"slug": doc.slug}, "name"
+				)
 			if not name:
 				raise
 
@@ -1130,12 +1208,13 @@ def _apply_one_update(
 	if provenance_prefix and not _page_is_agent_updatable(name, provenance_prefix):
 		return False
 
+	args = (name, update, source, user, ref, provenance_prefix, allow_body_replace, tuser)
 	try:
-		return _merge_update_into_page(name, update, source, user, ref, provenance_prefix, allow_body_replace)
+		return _merge_update_into_page(*args)
 	except frappe.TimestampMismatchError:
 		# Concurrent save between our load and save: reload + re-merge once
 		# so ordinary concurrency doesn't drop the update.
-		return _merge_update_into_page(name, update, source, user, ref, provenance_prefix, allow_body_replace)
+		return _merge_update_into_page(*args)
 
 
 def _merge_update_into_page(
@@ -1146,19 +1225,32 @@ def _merge_update_into_page(
 	ref: str | None,
 	provenance_prefix: str | None = None,
 	allow_body_replace: bool = True,
+	expect_target_user: str | None = None,
 ) -> bool:
 	body_md = update.get("body_md")
 	append_md = update.get("append_md")
 	contradiction = bool(update.get("contradiction"))
 
-	# TOCTOU close (scribe writeback): re-check ownership under a ROW LOCK on the
-	# page immediately before mutating it. A human edit that landed via
-	# ``save_wiki_page`` BETWEEN the unlocked pre-check above and this save would
-	# otherwise be clobbered; the ``for_update`` read serializes against that save,
-	# so a page that gained a human touch in the gap is refused here.
-	if provenance_prefix is not None:
-		locked_sources = frappe.db.get_value(WIKI, name, "sources", for_update=True)
-		if not _sources_agent_updatable(locked_sources, provenance_prefix):
+	# TOCTOU close: re-check under a ROW LOCK on the page immediately before
+	# mutating it. A save that landed BETWEEN the unlocked resolution above and
+	# this save would otherwise be clobbered; the ``for_update`` read serializes
+	# against it.
+	#
+	#  * provenance (scribe writeback): a page that gained a human touch in the
+	#    gap is refused here.
+	#  * audience (issue #490): a User-scope write must land on ITS OWN user's
+	#    page. Merging into a colleague's personal page both discloses the
+	#    writer's private statement and hides it from the writer, and the page
+	#    could have been re-targeted since we resolved it.
+	if provenance_prefix is not None or expect_target_user is not None:
+		locked = (
+			frappe.db.get_value(WIKI, name, ["sources", "target_user"], as_dict=True, for_update=True) or {}
+		)
+		if provenance_prefix is not None and not _sources_agent_updatable(
+			locked.get("sources"), provenance_prefix
+		):
+			return False
+		if expect_target_user is not None and locked.get("target_user") != expect_target_user:
 			return False
 
 	doc = frappe.get_doc(WIKI, name)

--- a/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.py
+++ b/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.py
@@ -158,11 +158,39 @@ class JarvisWikiPage(Document):
 		caller already suffixed; base is trimmed to keep the total <= 140 and
 		grammar-valid (scrub emits alnum-and-single-hyphen runs only)."""
 		self.slug = (self.slug or "").strip().lower()
+		if self.scope == "User" and self.target_user and self.slug:
+			self.slug = self._pick_user_slug()
+			return
 		suffix = self._scope_slug_suffix()
 		if not self.slug or not suffix or self.slug.endswith(suffix):
 			return
 		base = self.slug[: MAX_SLUG_LEN - len(suffix)].rstrip("-")
 		self.slug = f"{base}{suffix}"
+
+	def _pick_user_slug(self) -> str:
+		"""The audience-suffixed slug this personal page gets.
+
+		``--u-<localpart>`` keys on the email LOCAL PART only, so alice@acme.com
+		and alice@contractor.io derive the SAME slug — and the slug IS the
+		docname (``autoname: field:slug``, unique), so the second user's page
+		collided with the first's (issue #490). The preferred form is kept
+		whenever it is unclaimed or already this user's, so every personal page
+		created before this fix keeps its slug and its docname; only a genuine
+		cross-user collision falls back to ``--u-<localpart>-<digest>``.
+
+		If BOTH forms are taken by someone else the preferred one is returned
+		unchanged and the unique index raises ``DuplicateEntryError``, exactly as
+		before — callers already handle that."""
+		from jarvis.chat.wiki import user_scope_slug_candidates
+
+		candidates = user_scope_slug_candidates(self.slug, self.target_user)
+		for candidate in candidates:
+			row = frappe.db.get_value(
+				self.doctype, {"slug": candidate}, ["name", "target_user"], as_dict=True
+			)
+			if not row or row.target_user == self.target_user:
+				return candidate
+		return candidates[0]
 
 	def _guard_scope_change(self):
 		"""Only a System Manager may re-scope or re-target an existing page —

--- a/jarvis/learning/voice_facts.py
+++ b/jarvis/learning/voice_facts.py
@@ -772,8 +772,12 @@ def _apply_personalise_context(context_facts: list[dict], owner: str, ref: str |
 			)
 			continue
 		if applied:
-			slug = wiki.user_scope_slug(base_slug, owner)
-			title = frappe.db.get_value(WIKI, {"slug": slug}, "title")
+			# Audience-filtered (issue #490): looking the title up by the PREDICTED
+			# suffixed slug alone named a colleague's page whenever two addresses
+			# scrub to the same local part, so the receipt advertised a page this
+			# owner cannot even read.
+			name, slug = wiki.resolve_user_scope_page(base_slug, owner)
+			title = frappe.db.get_value(WIKI, name, "title") if name else None
 			if title:
 				pages.append({"slug": slug, "title": title})
 	return pages

--- a/jarvis/learning/voice_facts.py
+++ b/jarvis/learning/voice_facts.py
@@ -650,7 +650,8 @@ def _apply_context_facts(context_facts: list[dict]) -> int:
 			}
 		]
 		try:
-			wiki.apply_extracted_page_updates(updates, "voice", user)
+			# A page a person edited by hand is add-only from here (issue #489).
+			wiki.apply_extracted_page_updates(updates, "voice", user, preserve_curated=True)
 			applied += len(fs)
 		except Exception:
 			frappe.log_error(
@@ -667,7 +668,14 @@ def _apply_context_facts(context_facts: list[dict]) -> int:
 			}
 		]
 		try:
-			wiki.apply_extracted_page_updates(updates, "voice", user, default_scope="User", target_user=user)
+			wiki.apply_extracted_page_updates(
+				updates,
+				"voice",
+				user,
+				default_scope="User",
+				target_user=user,
+				preserve_curated=True,
+			)
 			applied += len(fs)
 		except Exception:
 			frappe.log_error(
@@ -763,7 +771,13 @@ def _apply_personalise_context(context_facts: list[dict], owner: str, ref: str |
 		]
 		try:
 			applied, _failed = wiki.apply_extracted_page_updates(
-				updates, "voice", owner, ref=ref, default_scope="User", target_user=owner
+				updates,
+				"voice",
+				owner,
+				ref=ref,
+				default_scope="User",
+				target_user=owner,
+				preserve_curated=True,
 			)
 		except Exception:
 			frappe.log_error(

--- a/jarvis/tests/test_wiki_scope_and_edit_fence.py
+++ b/jarvis/tests/test_wiki_scope_and_edit_fence.py
@@ -1,0 +1,209 @@
+"""Regression tests for the two wiki write-site defects that share
+``jarvis.chat.wiki._merge_update_into_page``.
+
+Issue #490 (audience): personal page slugs keyed on the email LOCAL PART only,
+and the extraction resolver did not filter on ``target_user`` — so two
+colleagues whose addresses scrub alike shared one page. One read the other's
+private notes; the other's own notes vanished from every view they had.
+
+Issue #489 (curation): the human-edit fence existed but no voice caller passed
+it, so the machine could rewrite a person's edit. Issue #488 already stopped the
+body REPLACE on the ingest path; what remained was the summary overwrite, the
+head-truncating clip, and nothing marking machine additions on a curated page.
+
+Kept in its own module (not folded into test_wiki.py) so it stays independent of
+the other wiki suites.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import wiki
+from jarvis.permissions import JARVIS_USER_ROLE
+
+WIKI_DT = "Jarvis Wiki Page"
+
+ALPHA = "Wikifence Alpha Pvt"
+ALPHA_SLUG = "customer--wikifence-alpha-pvt"
+
+# Two colleagues whose addresses scrub to the SAME local part. That is the whole
+# of issue #490: the audience suffix keys on that local part alone.
+TWIN_A = "wikifence-twin@alpha.invalid"
+TWIN_B = "wikifence-twin@beta.invalid"
+TWIN_BASE_SLUG = "org-notes--wikifence-selling"
+
+
+def _delete_test_pages():
+	frappe.db.delete(WIKI_DT, {"slug": ["like", "%wikifence%"]})
+	frappe.db.commit()
+
+
+def _ensure_twin_users():
+	for email in (TWIN_A, TWIN_B):
+		if not frappe.db.exists("User", email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": email.split("@")[0],
+					# A role-less user flips to Website User; the Jarvis User role
+					# both keeps user_type sticky and grants personal-page writes.
+					"user_type": "System User",
+					"send_welcome_email": 0,
+					"roles": [{"role": JARVIS_USER_ROLE}],
+				}
+			).insert(ignore_permissions=True)
+
+
+def _make_page(slug, title, page_type="Customer", **kwargs):
+	return frappe.get_doc(
+		{
+			"doctype": WIKI_DT,
+			"slug": slug,
+			"title": title,
+			"page_type": page_type,
+			"status": "Active",
+			**kwargs,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _curated_sources(user="a@test.invalid"):
+	"""``sources`` for a page a person edited by hand (what save_wiki_page leaves)."""
+	return frappe.as_json([{"date": "2026-01-01", "kind": "manual", "ref": None, "user": user}])
+
+
+class TestUserScopePageIsolation(FrappeTestCase):
+	"""Issue #490."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_twin_users()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+
+	def _twin_update(self, statement):
+		return {
+			"slug": TWIN_BASE_SLUG,
+			"page_type": "Org",
+			"title": "Wikifence notes (selling)",
+			"append_md": f"- {statement}",
+		}
+
+	def _ingest_as(self, user, statement):
+		return wiki.apply_extracted_page_updates(
+			[self._twin_update(statement)],
+			"voice",
+			user,
+			default_scope="User",
+			target_user=user,
+		)
+
+	def test_both_users_derive_the_same_preferred_suffix(self):
+		# The precondition the whole issue rests on. Left UNCHANGED on purpose:
+		# the preferred slug is what every page created before the fix carries,
+		# and renaming those would break the docname they are stored under.
+		self.assertEqual(
+			wiki.user_scope_slug(TWIN_BASE_SLUG, TWIN_A),
+			wiki.user_scope_slug(TWIN_BASE_SLUG, TWIN_B),
+		)
+
+	def test_same_local_part_different_domains_get_separate_pages(self):
+		self.assertEqual(self._ingest_as(TWIN_A, "ALPHA-PRIVATE-FACT"), (1, 0))
+		self.assertEqual(self._ingest_as(TWIN_B, "BETA-PRIVATE-FACT"), (1, 0))
+
+		name_a, slug_a = wiki.resolve_user_scope_page(TWIN_BASE_SLUG, TWIN_A)
+		name_b, slug_b = wiki.resolve_user_scope_page(TWIN_BASE_SLUG, TWIN_B)
+		self.assertIsNotNone(name_a)
+		self.assertIsNotNone(name_b)
+		self.assertNotEqual(name_a, name_b)
+		self.assertNotEqual(slug_a, slug_b)
+
+		doc_a = frappe.get_doc(WIKI_DT, name_a)
+		doc_b = frappe.get_doc(WIKI_DT, name_b)
+		self.assertEqual(doc_a.target_user, TWIN_A)
+		self.assertEqual(doc_b.target_user, TWIN_B)
+		# Neither private statement crossed to the other colleague's page.
+		self.assertIn("ALPHA-PRIVATE-FACT", doc_a.body_md)
+		self.assertNotIn("BETA-PRIVATE-FACT", doc_a.body_md)
+		self.assertIn("BETA-PRIVATE-FACT", doc_b.body_md)
+		self.assertNotIn("ALPHA-PRIVATE-FACT", doc_b.body_md)
+
+	def test_user_scope_lookup_never_resolves_another_users_page(self):
+		self.assertEqual(self._ingest_as(TWIN_A, "ALPHA-PRIVATE-FACT"), (1, 0))
+		claimed = wiki.user_scope_slug(TWIN_BASE_SLUG, TWIN_A)
+		self.assertTrue(frappe.db.exists(WIKI_DT, {"slug": claimed, "target_user": TWIN_A}))
+		# The second user derives the SAME preferred slug ...
+		self.assertEqual(wiki.user_scope_slug(TWIN_BASE_SLUG, TWIN_B), claimed)
+		# ... and still resolves to NO page, rather than to the first user's.
+		name, _slug = wiki.resolve_user_scope_page(TWIN_BASE_SLUG, TWIN_B)
+		self.assertIsNone(name)
+		# Writing anyway mints them their own page and leaves the first alone.
+		self.assertEqual(self._ingest_as(TWIN_B, "BETA-PRIVATE-FACT"), (1, 0))
+		name_b, slug_b = wiki.resolve_user_scope_page(TWIN_BASE_SLUG, TWIN_B)
+		self.assertIsNotNone(name_b)
+		self.assertNotEqual(slug_b, claimed)
+		self.assertEqual(frappe.db.get_value(WIKI_DT, name_b, "target_user"), TWIN_B)
+		self.assertNotIn("BETA-PRIVATE-FACT", frappe.db.get_value(WIKI_DT, claimed, "body_md"))
+
+	def test_merge_refuses_a_page_targeted_at_someone_else(self):
+		# Belt and braces under the row lock: even handed the wrong docname
+		# directly, a User-scope write never lands on another audience's page.
+		self.assertEqual(self._ingest_as(TWIN_A, "ALPHA-PRIVATE-FACT"), (1, 0))
+		name_a, _ = wiki.resolve_user_scope_page(TWIN_BASE_SLUG, TWIN_A)
+		applied = wiki._merge_update_into_page(
+			name_a,
+			{"append_md": "- BETA-PRIVATE-FACT"},
+			"voice",
+			TWIN_B,
+			None,
+			None,
+			False,
+			False,
+			TWIN_B,
+		)
+		self.assertFalse(applied)
+		self.assertNotIn("BETA-PRIVATE-FACT", frappe.get_doc(WIKI_DT, name_a).body_md)
+
+	def test_a_pre_fix_page_keeps_its_slug_and_keeps_receiving_updates(self):
+		# The fix renames NOTHING: the slug IS the docname, so a rename would
+		# break every stored reference. A page created before the fix keeps the
+		# plain --u-<localpart> docname and stays the resolver's target.
+		preferred = wiki.user_scope_slug(TWIN_BASE_SLUG, TWIN_A)
+		_make_page(
+			preferred,
+			"Wikifence notes (selling)",
+			page_type="Org",
+			body_md="- OLDER-FACT",
+			scope="User",
+			target_user=TWIN_A,
+		)
+		self.assertEqual(self._ingest_as(TWIN_A, "NEWER-FACT"), (1, 0))
+		self.assertEqual(
+			frappe.db.count(WIKI_DT, {"target_user": TWIN_A, "slug": ["like", "%wikifence%"]}), 1
+		)
+		doc = frappe.get_doc(WIKI_DT, preferred)
+		self.assertIn("OLDER-FACT", doc.body_md)
+		self.assertIn("NEWER-FACT", doc.body_md)
+
+	def test_second_user_is_not_locked_out_of_the_spa_create(self):
+		# Before the fix the second colleague got "A page with this slug already
+		# exists" naming a page they cannot even read: existence disclosure plus
+		# a permanent dead end on that personal base slug.
+		frappe.set_user(TWIN_A)
+		first = wiki.create_wiki_page(title="Wikifence Twin Notes", page_type="Org", scope="User")
+		frappe.set_user(TWIN_B)
+		second = wiki.create_wiki_page(title="Wikifence Twin Notes", page_type="Org", scope="User")
+		frappe.set_user("Administrator")
+		self.assertTrue(first["ok"], first)
+		self.assertTrue(second["ok"], second)
+		self.assertNotEqual(first["slug"], second["slug"])
+		self.assertEqual(frappe.db.get_value(WIKI_DT, first["slug"], "target_user"), TWIN_A)
+		self.assertEqual(frappe.db.get_value(WIKI_DT, second["slug"], "target_user"), TWIN_B)

--- a/jarvis/tests/test_wiki_scope_and_edit_fence.py
+++ b/jarvis/tests/test_wiki_scope_and_edit_fence.py
@@ -15,6 +15,8 @@ Kept in its own module (not folded into test_wiki.py) so it stays independent of
 the other wiki suites.
 """
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -207,3 +209,187 @@ class TestUserScopePageIsolation(FrappeTestCase):
 		self.assertNotEqual(first["slug"], second["slug"])
 		self.assertEqual(frappe.db.get_value(WIKI_DT, first["slug"], "target_user"), TWIN_A)
 		self.assertEqual(frappe.db.get_value(WIKI_DT, second["slug"], "target_user"), TWIN_B)
+
+
+class TestVoiceIngestPreservesHumanEdits(FrappeTestCase):
+	"""Issue #489."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+
+	def _voice(self, update):
+		"""One voice write, shaped exactly like the ingest's own call."""
+		return wiki.apply_extracted_page_updates(
+			[update],
+			"voice",
+			"b@test.invalid",
+			allow_body_replace=False,
+			preserve_curated=True,
+		)
+
+	def test_human_edit_survives_a_later_voice_ingest(self):
+		_make_page(ALPHA_SLUG, ALPHA, body_md="## Payment\n\nMachine guess.")
+		wiki.save_wiki_page(
+			slug=ALPHA_SLUG,
+			body_md="## Payment\n\nHUMAN-AUTHORED net 30, no exceptions.",
+			summary="HUMAN-SUMMARY",
+		)
+		applied, failed = self._voice(
+			{
+				"slug": ALPHA_SLUG,
+				"body_md": "## Payment\n\nMACHINE-PARAPHRASE 45 days.",
+				"summary": "MACHINE-SUMMARY",
+			}
+		)
+		self.assertEqual((applied, failed), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		# The summary REPLACES, so it is the field that still destroyed human
+		# text after issue #488 turned the body into an append. Asserted FIRST
+		# because it is the only surviving data loss, not a presentation detail.
+		self.assertEqual(doc.summary, "HUMAN-SUMMARY")
+		# The human's words survive, the new knowledge still lands, and a reader
+		# can tell which is which.
+		self.assertIn("HUMAN-AUTHORED net 30", doc.body_md)
+		self.assertIn("MACHINE-PARAPHRASE 45 days", doc.body_md)
+		self.assertIn("## Added by Jarvis from a note (", doc.body_md)
+
+	def test_summary_is_still_filled_when_the_human_left_it_empty(self):
+		_make_page(ALPHA_SLUG, ALPHA, body_md="Human body.", sources=_curated_sources())
+		applied, failed = self._voice({"slug": ALPHA_SLUG, "append_md": "- New.", "summary": "Filled in."})
+		self.assertEqual((applied, failed), (1, 0))
+		self.assertEqual(frappe.get_doc(WIKI_DT, ALPHA_SLUG).summary, "Filled in.")
+
+	def test_a_curated_page_is_never_truncated_from_the_head(self):
+		# _clip_body keeps the TAIL, so clipping an over-cap append silently
+		# deletes the human's OLDEST lines. Refuse the update instead: dropping
+		# one note's knowledge is recoverable, deleting a person's text is not.
+		body = "HUMAN-HEAD-SENTINEL\n" + ("h" * (wiki.MAX_BODY_LEN - 200))
+		_make_page(ALPHA_SLUG, ALPHA, body_md=body, sources=_curated_sources())
+		applied, failed = self._voice({"slug": ALPHA_SLUG, "append_md": "m" * 500})
+		self.assertEqual((applied, failed), (0, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertTrue(doc.body_md.startswith("HUMAN-HEAD-SENTINEL"))
+		self.assertEqual(doc.body_md, body)
+
+	def test_the_ingest_still_owns_the_pages_it_created_itself(self):
+		# Why provenance_prefix="voice" cannot be the fix: "voice" is in
+		# _HUMAN_SOURCE_KINDS AND is what the ingest stamps on every page it
+		# writes, so that fence would refuse its own pages from note two onward.
+		created = self._voice(
+			{
+				"slug": ALPHA_SLUG,
+				"page_type": "Customer",
+				"title": ALPHA,
+				"body_md": "- First note.",
+			}
+		)
+		self.assertEqual(created, (1, 0))
+		self.assertEqual(self._voice({"slug": ALPHA_SLUG, "append_md": "- Second note."}), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertIn("- First note.", doc.body_md)
+		self.assertIn("- Second note.", doc.body_md)
+		# No attribution heading: nobody curated this page, it is the scribe's.
+		self.assertNotIn("## Added by Jarvis from a note (", doc.body_md)
+		self.assertFalse(wiki._sources_are_curated(doc.sources))
+
+	def test_the_agents_own_tool_writes_do_not_count_as_curation(self):
+		# "tool" (update_wiki) and "chat" name machine-composed text, so they
+		# stay OUT of the curated set even though _HUMAN_SOURCE_KINDS holds them
+		# for the stricter app-learning fence.
+		self.assertFalse(wiki._sources_are_curated(frappe.as_json([{"kind": "tool"}, {"kind": "chat"}])))
+		self.assertTrue(wiki._sources_are_curated(frappe.as_json([{"kind": "promotion"}])))
+		# Unreadable provenance fails CLOSED, toward preserving text.
+		self.assertTrue(wiki._sources_are_curated("{not json"))
+
+	def test_app_learning_fence_is_unchanged(self):
+		# The scribe's fence keeps BOTH halves: it refreshes its own page in
+		# place, and it refuses outright once a human has touched it.
+		_make_page(
+			ALPHA_SLUG,
+			ALPHA,
+			body_md="SCRIBE-V1",
+			sources=frappe.as_json(
+				[{"date": "2026-01-01", "kind": "app-learning-agent:acme", "ref": None, "user": None}]
+			),
+		)
+		applied, failed = wiki.apply_extracted_page_updates(
+			[{"slug": ALPHA_SLUG, "body_md": "SCRIBE-V2"}],
+			"app-learning-agent:acme",
+			"scribe@test.invalid",
+			provenance_prefix="app-learning",
+		)
+		self.assertEqual((applied, failed), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertEqual(doc.body_md, "SCRIBE-V2")
+		self.assertNotIn("SCRIBE-V1", doc.body_md)
+
+		wiki.save_wiki_page(slug=ALPHA_SLUG, body_md="HUMAN-BODY")
+		applied, failed = wiki.apply_extracted_page_updates(
+			[{"slug": ALPHA_SLUG, "body_md": "SCRIBE-V3"}],
+			"app-learning-agent:acme",
+			"scribe@test.invalid",
+			provenance_prefix="app-learning",
+		)
+		self.assertEqual((applied, failed), (0, 0))
+		self.assertEqual(frappe.get_doc(WIKI_DT, ALPHA_SLUG).body_md, "HUMAN-BODY")
+
+	def test_callers_without_the_flag_are_byte_for_byte_unchanged(self):
+		# preserve_curated defaults off, so no existing caller changes shape.
+		_make_page(
+			ALPHA_SLUG,
+			ALPHA,
+			body_md="HUMAN-BODY",
+			summary="HUMAN-SUMMARY",
+			sources=_curated_sources(),
+		)
+		applied, failed = wiki.apply_extracted_page_updates(
+			[{"slug": ALPHA_SLUG, "body_md": "MACHINE-BODY", "summary": "MACHINE-SUMMARY"}],
+			"voice",
+			"b@test.invalid",
+		)
+		self.assertEqual((applied, failed), (1, 0))
+		doc = frappe.get_doc(WIKI_DT, ALPHA_SLUG)
+		self.assertEqual(doc.body_md, "MACHINE-BODY")
+		self.assertEqual(doc.summary, "MACHINE-SUMMARY")
+
+	def test_the_note_ingest_passes_the_fence(self):
+		# The defect was purely a caller omission, so assert the caller.
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "wikifence"}).insert(
+			ignore_permissions=True
+		)
+		note = frappe.get_doc(
+			{
+				"doctype": "Jarvis Voice Note",
+				"transcript": "Wikifence fence wiring.",
+				"context_type": "Conversation",
+				"conversation": conv.name,
+				"entities": frappe.as_json([]),
+				"source": "Chat Nudge",
+				"status": "New",
+			}
+		).insert(ignore_permissions=True)
+		try:
+			with patch("jarvis.chat.wiki._extract_page_updates", return_value=[]):
+				with patch(
+					"jarvis.chat.wiki.apply_extracted_page_updates", return_value=(0, 0)
+				) as apply_mock:
+					wiki._ingest_note(note.name)
+		finally:
+			frappe.db.delete("Jarvis Voice Note", {"name": note.name})
+			frappe.db.delete("Jarvis Conversation", {"name": conv.name})
+		self.assertTrue(apply_mock.call_args.kwargs["preserve_curated"])
+		self.assertFalse(apply_mock.call_args.kwargs["allow_body_replace"])
+
+	def test_the_personalise_ingest_passes_the_fence(self):
+		from jarvis.learning import voice_facts
+
+		facts = [{"domain": "selling", "statement": "Wikifence personalise fact."}]
+		with patch.object(wiki, "apply_extracted_page_updates", return_value=(0, 0)) as apply_mock:
+			voice_facts._apply_personalise_context(facts, "b@test.invalid", ref="NOTE-1")
+		self.assertTrue(apply_mock.call_args.kwargs["preserve_curated"])
+		self.assertEqual(apply_mock.call_args.kwargs["target_user"], "b@test.invalid")


### PR DESCRIPTION
## Summary

Two defects that share one write site, `jarvis.chat.wiki._merge_update_into_page`.

A personal wiki page was keyed on the email **local part** alone, so
`alice@acme.com` and `alice@contractor.io` derived the same slug, and the slug
is the docname. The extraction resolver then looked pages up with no
`target_user` filter, so one colleague's private note was appended to the
other's page: readable by the wrong person, invisible to its author. Anyone with
an externally invited user on a different domain and a matching local part is
affected. The resolver now filters on the audience at every probe, the
controller disambiguates only a genuine collision, and nothing is renamed.

Separately, the human-edit fence existed but no voice caller passed it, so a
person's wiki edit could be rewritten by the next ingest. Issue #488 already
stopped the wholesale body replace, which left the summary overwrite as the only
live data loss. The voice path is now add-only on any page a person authored or
approved. Users who edit wiki pages by hand notice; nobody else does.

<details>
<summary>Root cause</summary>

### #490, the audience

The suffix comes from `scrub(email.split("@")[0])`, so it is not unique per
user, and `jarvis_wiki_page.json` sets `autoname: field:slug` with `unique: 1`.
Exactly one such page can exist site-wide.

The lookup in `_apply_one_update` carried no `scope` or `target_user` predicate,
so it resolved to whichever user created the page first, and the
`DuplicateEntryError` fallback repeated the same unfiltered read.
`_merge_update_into_page` never compared `target_user` before saving. The
sibling resolver `update_wiki._find_existing` always filtered correctly, so the
tool path never cross-wrote; only the extraction funnel did. That funnel routes
every user into the same six base slugs (`voice_facts.py` domain vocabulary), so
once two local parts collide the page collision is near deterministic.

**On migration, deliberately none.** The slug IS the docname, so changing the
derivation is a `rename_doc` on every existing personal page, and every stored
reference to it. Instead `user_scope_slug` keeps returning the preferred
`--u-<localpart>` form, the controller keeps it whenever it is unclaimed or
already this user's, and only a real cross-user collision falls back to
`--u-<localpart>-<digest>` over the whole address. `resolve_user_scope_page`
probes both forms, both filtered by `target_user`, so a page created before this
change keeps its docname and keeps receiving updates. A digest is used rather
than a scrubbed full address because `scrub` is lossy in both directions:
`alice@ac.me` and `alice-ac@me` scrub alike.

**What this does not repair.** Pages already cross-written stay cross-written.
The two users' content is genuinely interleaved in one body and only
`track_changes` version history can separate it, so no automatic un-merge is
possible. A disclosure that already happened cannot be retracted either. This
stops new cross-writes and stops the second user's permanent lockout; it does
not undo the ones that landed.

Filtering on read alone is not enough, and the revert-proof below shows why: with
the filter but without the controller change, the second user's every write
fails `(0, 1)` forever and the SPA create refuses them by naming a page they
cannot see.

### #489, the curation

The fence is `_sources_agent_updatable`, guarded at both sites by
`if provenance_prefix`. `record_app_wiki` and `app_analysis` pass it; the voice
ingest did not.

**The obvious fix is wrong and the issue says so.** `provenance_prefix="voice"`
fences the ingest out of its own pages: `"voice"` is in `_HUMAN_SOURCE_KINDS`
and `"voice"` is what the ingest stamps on everything it writes, so the fence
refuses from the second note onward. That fence answers "is this page MINE?" and
refuses everything else, which is the right policy for a scribe that owns its
pages and the wrong one for a pipeline appending to shared knowledge.

So this adds a second, narrower predicate instead of widening the first.
`_CURATED_SOURCE_KINDS` is a strict subset: `"manual"` (the SPA editor),
`"promotion"` (a reviewer approving content into place), and the reserved
`"edit"`. `"voice"` and `"chat"` name a pipeline that derived text from an
utterance, `"tool"` names the agent's own `update_wiki` writes, and none of those
is a person's typing. `_HUMAN_SOURCE_KINDS` is untouched, so the app-learning
fence is byte for byte what it was.

On a curated page the write is downgraded, not refused, because refusing would
silently drop the note's knowledge: the body appends under a dated
`## Added by Jarvis from a note` heading whatever `allow_body_replace` says, the
summary is filled only when the human left it empty, and an append that would
exceed the cap is refused and logged rather than clipped (`_clip_body` keeps the
tail, so clipping deletes the human's oldest lines). The check runs under the
same row lock that already guards the provenance fence, closing the same TOCTOU.

**#488 shrank this a lot.** It made the ingest append rather than replace, so the
wholesale body destruction the issue describes is already gone on that path. The
surviving live data loss was the summary, which still replaced unconditionally.
The rest of this change moves the invariant from the CALLER to the PAGE:
`allow_body_replace=False` is the ingest saying "I only saw an excerpt", and two
voice call sites in `voice_facts` still default it to True. It is smaller than
the issue implies, and it is stated that way in the commit.

</details>

## Test plan

New module `jarvis/tests/test_wiki_scope_and_edit_fence.py`, 15 tests, kept out
of `test_wiki.py` so it does not collide with concurrent work on that file.

```
TestUserScopePageIsolation ......... 6 tests  OK
TestVoiceIngestPreservesHumanEdits . 9 tests  OK
```

Each fix was reverted in turn and the suite re-run:

| Reverted | Failures | Evidence |
|---|---|---|
| #490 audience filter | 3 | both users resolve to `--u-wikifence-twin`, and the cross-user merge returns True |
| #490 controller disambiguation | 3 | second user's write is `(0, 1)` forever; SPA create returns `A page with this slug already exists` |
| #489 curated downgrade | 2 | `'MACHINE-SUMMARY' != 'HUMAN-SUMMARY'`; the over-cap append clips the human's head |

No regressions: `test_wiki` (30 across three classes), `test_wiki_scopes_api`
(38), `test_wiki_permissions` (29), `test_personalise_pipeline` (38),
`test_wiki_mirror` (24), `test_wiki_lint` (13), `test_wiki_grounding` (11),
`test_app_learning` (44) all pass.

## Pre-merge checklist

- [ ] **CI is green**: the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (rebased onto `726ac15e`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

Closes #489
Closes #490

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
