### PR TITLE
fix(macros): validate schedule_time, fault-isolate the sweep, and snapshot the run's dispatch mode

### DIFF
--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -305,6 +305,14 @@ def parse_schedule_seconds(t) -> int | None:
 
 	MariaDB's TIME column accepts up to 838:59:59, which is why an out-of-range value
 	could be persisted at all: the storage layer is not the guard here.
+
+	``compute_next_run`` is shared with the AGENT scheduler (``agent_scheduler._advance``,
+	``agents_api.set_schedule``, ``agent_runs``), which has the same unguarded shape: the
+	agent sweep calls ``_advance`` from ten sites and only one of them sits inside a try.
+	Making the arithmetic total therefore closes that cron-wide abort too. The trade is
+	that ``agents_api.set_schedule`` no longer 500s on a hand-crafted out-of-range value,
+	it saves it and schedules 09:00; the durable fix there is this same check applied in
+	the Jarvis Agent Installation controller, which is out of scope for #472.
 	"""
 	if t is None or t == "":
 		return None

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -15,6 +15,10 @@ the macro's owner (so the result conversation is theirs) and advancing
   Manager can read; ``last_run_at`` is stamped only when the slot was actually
   consumed; and a dispatch that RAISED does not advance the schedule, so the
   missed slot retries on the next tick rather than looking like a success.
+* **#472** — the sweep is per-macro fault-isolated, and ``compute_next_run`` is
+  TOTAL: no ``schedule_time`` value, however malformed, can make it raise. Both
+  limbs matter because the schedule arithmetic used to run OUTSIDE the per-macro
+  try/except, so one bad row aborted the sweep for every other macro on the bench.
 """
 
 import datetime
@@ -28,6 +32,7 @@ MACRO = "Jarvis Macro"
 RUN = "Jarvis Macro Run"
 
 _DEFAULT_SECONDS = 9 * 3600  # 09:00 when no schedule_time set
+_MAX_SECONDS = 24 * 3600 - 1  # 23:59:59, the last representable time of day
 
 # #471: the owner cannot act on any of these — Administrator and disabled users
 # are refused by notify_owner anyway, and a role-less owner can no longer reach
@@ -91,61 +96,84 @@ def run_due_macros() -> None:
 	if not due:
 		return
 
+	original_user = frappe.session.user
+	for m in due:
+		# #472: fault-isolate each macro. The per-macro try below covers only the
+		# DISPATCH; the schedule arithmetic, the identity guard and the bookkeeping all
+		# sat outside it, so anything they raised propagated out of the whole sweep and
+		# every macro after this one silently missed its slot. The concrete case was a
+		# `schedule_time` the arithmetic could not use, but the guarantee wanted here is
+		# structural and not specific to that value: no single row can take the sweep
+		# down. The slot is left DUE on this path (#471's rule: a failure never advances
+		# the schedule), so the next hourly tick retries it.
+		try:
+			_sweep_one(m, now, original_user)
+		except Exception:
+			if frappe.session.user != original_user:
+				frappe.set_user(original_user)
+			frappe.db.rollback()
+			frappe.log_error(
+				title=f"jarvis scheduled macro sweep failed: {m.name}",
+				message=frappe.get_traceback(),
+			)
+
+
+def _sweep_one(m, now, original_user: str) -> None:
+	"""Handle ONE due macro. Extracted from the loop so ``run_due_macros`` can wrap it
+	whole (#472); every ``return`` here was a ``continue`` in the loop it came from."""
 	from jarvis.chat import macros
 	from jarvis.permissions import has_jarvis_access, is_valid_unattended_owner
 
-	original_user = frappe.session.user
-	for m in due:
-		# #471: a macro its owner switched OFF is not a failure, it is the state
-		# they asked for. run_macro's own `enabled` early return was never inspected
-		# here, so the slot was consumed AND last_run_at stamped — leaving the UI
-		# reading "last run: today" for a macro that has not run in months. Move the
-		# schedule on so it does not busy re-fire, write no failed row, and leave
-		# last_run_at alone: nothing ran.
-		if not cint(m.enabled):
-			_consume_slot(m, now, stamp_last_run=False)
-			continue
+	# #471: a macro its owner switched OFF is not a failure, it is the state
+	# they asked for. run_macro's own `enabled` early return was never inspected
+	# here, so the slot was consumed AND last_run_at stamped — leaving the UI
+	# reading "last run: today" for a macro that has not run in months. Move the
+	# schedule on so it does not busy re-fire, write no failed row, and leave
+	# last_run_at alone: nothing ran.
+	if not cint(m.enabled):
+		_consume_slot(m, now, stamp_last_run=False)
+		return
 
-		# MAC-1 (security review PART 3, TASK 23): never run a macro whose owner
-		# has lost Jarvis access (demoted System User, or a Website/portal owner) —
-		# the scheduled turn would otherwise execute jarvis__* tools as an identity
-		# categorically barred from Jarvis.
-		#
-		# #469: has_jarvis_access alone is NOT that guarantee. It returns True for
-		# Administrator before any other check, and NOTHING in permissions.py (nor
-		# frappe.get_roles) reads User.enabled — so on its own it admitted an
-		# unattended, fully perm-bypassing Administrator turn, and kept an
-		# offboarded employee's macros firing with live ERP access forever. Add the
-		# fail-closed identity guard the sibling agent scheduler has always applied
-		# (agent_scheduler._valid_owner). Both checks are required: this one refuses
-		# Administrator/Guest/disabled, has_jarvis_access refuses portal users and
-		# role-less System Users.
-		#
-		# Consume the slot so it does not busy re-fire, but skip the run.
-		if not is_valid_unattended_owner(m.owner) or not has_jarvis_access(m.owner):
-			_record_failed(m, _BARRED_OWNER)
-			_consume_slot(m, now)
-			continue
-		try:
-			frappe.set_user(m.owner)
-			out = macros.run_macro(m.name, trigger="scheduled") or {}
-		except Exception:
+	# MAC-1 (security review PART 3, TASK 23): never run a macro whose owner
+	# has lost Jarvis access (demoted System User, or a Website/portal owner) —
+	# the scheduled turn would otherwise execute jarvis__* tools as an identity
+	# categorically barred from Jarvis.
+	#
+	# #469: has_jarvis_access alone is NOT that guarantee. It returns True for
+	# Administrator before any other check, and NOTHING in permissions.py (nor
+	# frappe.get_roles) reads User.enabled — so on its own it admitted an
+	# unattended, fully perm-bypassing Administrator turn, and kept an
+	# offboarded employee's macros firing with live ERP access forever. Add the
+	# fail-closed identity guard the sibling agent scheduler has always applied
+	# (agent_scheduler._valid_owner). Both checks are required: this one refuses
+	# Administrator/Guest/disabled, has_jarvis_access refuses portal users and
+	# role-less System Users.
+	#
+	# Consume the slot so it does not busy re-fire, but skip the run.
+	if not is_valid_unattended_owner(m.owner) or not has_jarvis_access(m.owner):
+		_record_failed(m, _BARRED_OWNER)
+		_consume_slot(m, now)
+		return
+	try:
+		frappe.set_user(m.owner)
+		out = macros.run_macro(m.name, trigger="scheduled") or {}
+	except Exception:
+		frappe.set_user(original_user)
+		frappe.log_error(
+			title=f"jarvis scheduled macro failed: {m.name}",
+			message=frappe.get_traceback(),
+		)
+		# #471: record the failure where the OWNER can see it, and do NOT consume
+		# the slot — next_run_at stays in the past so the next hourly tick retries
+		# it. Previously the schedule advanced regardless, so a run that never
+		# happened was indistinguishable from one that did.
+		_record_failed(m, _DISPATCH_FAILED)
+		_notify_owner(m, _DISPATCH_FAILED)
+		return
+	finally:
+		if frappe.session.user != original_user:
 			frappe.set_user(original_user)
-			frappe.log_error(
-				title=f"jarvis scheduled macro failed: {m.name}",
-				message=frappe.get_traceback(),
-			)
-			# #471: record the failure where the OWNER can see it, and do NOT consume
-			# the slot — next_run_at stays in the past so the next hourly tick retries
-			# it. Previously the schedule advanced regardless, so a run that never
-			# happened was indistinguishable from one that did.
-			_record_failed(m, _DISPATCH_FAILED)
-			_notify_owner(m, _DISPATCH_FAILED)
-			continue
-		finally:
-			if frappe.session.user != original_user:
-				frappe.set_user(original_user)
-		_settle(m, now, out)
+	_settle(m, now, out)
 
 
 def _settle(m, now, out: dict) -> None:
@@ -241,7 +269,13 @@ def _notify_owner(m, reason: str) -> None:
 
 def compute_next_run(frequency: str, schedule_time, from_dt=None) -> datetime.datetime:
 	"""Next fire time strictly after ``from_dt`` (default now) at ``schedule_time``
-	on the given ``frequency`` (daily/weekly/monthly)."""
+	on the given ``frequency`` (daily/weekly/monthly).
+
+	TOTAL by construction (#472): ``_time_to_seconds`` can only return a real time of
+	day, so ``base.replace(hour=...)`` can no longer raise ``ValueError`` on a value
+	that reached the row before this validation existed. That matters because the
+	function is called from the cron's bookkeeping, where a raise skipped every macro
+	after the offending one."""
 	base = get_datetime(from_dt) if from_dt else now_datetime()
 	secs = _time_to_seconds(schedule_time)
 	cand = base.replace(hour=secs // 3600, minute=(secs % 3600) // 60, second=0, microsecond=0)
@@ -258,16 +292,45 @@ def _advance(dt: datetime.datetime, frequency: str) -> datetime.datetime:
 	return add_to_date(dt, days=1)
 
 
-def _time_to_seconds(t) -> int:
-	if not t:
-		return _DEFAULT_SECONDS
+def parse_schedule_seconds(t) -> int | None:
+	"""Seconds since midnight for a ``schedule_time``, or None when it is not a real
+	time of day (#472).
+
+	STRICT on purpose: this is the reader ``JarvisMacro.validate`` uses to REFUSE a
+	bad value at save with a field error. It has to be strict because Frappe's own
+	Time-field validation runs AFTER the controller (``Document.insert`` calls
+	``run_before_save_methods`` and only then ``_validate``), so by the time the
+	framework would object the controller has already fed the value to the schedule
+	arithmetic.
+
+	MariaDB's TIME column accepts up to 838:59:59, which is why an out-of-range value
+	could be persisted at all: the storage layer is not the guard here.
+	"""
+	if t is None or t == "":
+		return None
 	if isinstance(t, datetime.timedelta):
-		return int(t.total_seconds())
-	parts = str(t).split(":")
-	try:
-		h = int(parts[0])
-		m = int(parts[1]) if len(parts) > 1 else 0
-		s = int(parts[2]) if len(parts) > 2 else 0
-		return h * 3600 + m * 60 + s
-	except (ValueError, IndexError):
-		return _DEFAULT_SECONDS
+		secs = int(t.total_seconds())
+	elif isinstance(t, datetime.time):
+		secs = t.hour * 3600 + t.minute * 60 + t.second
+	else:
+		parts = str(t).strip().split(":")
+		if len(parts) > 3:
+			return None
+		try:
+			nums = [int(p) for p in parts]
+		except ValueError:
+			return None
+		nums += [0] * (3 - len(nums))
+		h, m, s = nums
+		if not (0 <= m <= 59 and 0 <= s <= 59):
+			return None
+		secs = h * 3600 + m * 60 + s
+	return secs if 0 <= secs <= _MAX_SECONDS else None
+
+
+def _time_to_seconds(t) -> int:
+	"""TOLERANT reader, for the cron. A value the strict parser rejects has already
+	been persisted, so refusing it here would only take the schedule arithmetic down
+	with it; fall back to the same 09:00 an unset time gets and let the sweep finish."""
+	secs = parse_schedule_seconds(t)
+	return _DEFAULT_SECONDS if secs is None else secs

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -11,6 +11,10 @@ a closed browser tab (unlike a frontend-driven loop).
 State lives in ``Jarvis Macro Run`` (``current_step`` = 1-based index of the step
 last started; ``status`` in queued/running/completed/failed/stopped). Progress is
 pushed to the owner's realtime channel as ``macro:progress`` / ``macro:done``.
+
+A run also records the SHAPE it was dispatched in (``run_mode``, #470). Everything
+that re-enters a live run reads that snapshot rather than re-deriving the shape from
+the macro, because the macro is editable while the run is in flight.
 """
 
 from datetime import timedelta
@@ -77,6 +81,18 @@ BLOCK_STEP_BUDGET = "scheduled_step_budget"
 # and has already been terminalized, so the scheduler must not record a second one.
 BLOCK_DISPATCH_FAILED = "dispatch_failed"
 _DISPATCH_FAILED_ERROR = "The agent turn could not be dispatched, so this run never started."
+
+# #470: the two shapes a run can be dispatched in, snapshotted on the run row at insert.
+MODE_STEPPED = "stepped"
+MODE_MERGED = "merged"
+
+# #470: what the owner is told when a mid-park macro edit made the run's dispatch-time
+# shape unrunnable. Ending the run is the honest outcome: the alternatives are executing
+# the OLD summary the user just replaced, or silently switching shape mid-flight.
+_MACRO_CHANGED_ERROR = (
+	"The macro was edited while this run was waiting for capacity, so the run could no "
+	"longer continue the way it started. Run it again."
+)
 
 # Human sentences for the MANUAL path (thrown, so the SPA's existing toast renders
 # them). The scheduled path reports the machine code instead and the scheduler
@@ -190,6 +206,11 @@ def run_macro(macro_name: str, *, trigger: str = "manual") -> dict:
 			"status": "running",
 			"current_step": 0,
 			"total_steps": total,
+			# #470: the shape is decided HERE, once, and every later re-entry into this
+			# run reads it back off the row. It used to be re-derived from the live macro
+			# on each dispatch, so a macro edited while the run sat parked for capacity
+			# flipped the run's shape mid-flight.
+			"run_mode": MODE_MERGED if merged else MODE_STEPPED,
 			"trigger": trigger,
 			"started_at": frappe.utils.now(),
 		}
@@ -551,7 +572,13 @@ def resume_waiting_capacity_runs() -> None:
 	Bounded: ``capacity_attempts`` is incremented each cycle; once it exceeds
 	``_MAX_CAPACITY_ATTEMPTS`` the run takes its NORMAL failure path with an honest reason
 	rather than retrying forever. Serialized + idempotent via the same per-run redis lock
-	the chaining hook uses, so a resume can never race a late step advance. Never raises."""
+	the chaining hook uses, so a resume can never race a late step advance. Never raises.
+
+	#470: the macro is re-read fresh here, but only for its CONTENT. Which shape to
+	dispatch comes from the run's own ``run_mode`` snapshot, never from live macro state.
+	The park window is long (``_MAX_CAPACITY_ATTEMPTS`` x the 5 min cron, ~100 min) and
+	macro edits do not take this lock, so re-deriving the shape let an edit land mid-park
+	and change what a live run executed."""
 	rows = frappe.get_all(RUN, filters={"status": "waiting_capacity"}, pluck="name")
 	if not rows:
 		return
@@ -575,6 +602,22 @@ def resume_waiting_capacity_runs() -> None:
 					)
 					_publish_done(run, macro_doc, "failed")
 					continue
+				# #470: end the run before spending an attempt on work its snapshot can no
+				# longer describe. State-fenced off waiting_capacity so a stop that landed
+				# first is never clobbered.
+				if _resume_incompatible(run, macro_doc):
+					if _cas_run_status(
+						run.name,
+						"waiting_capacity",
+						"failed",
+						finished_at=frappe.utils.now(),
+						error=_MACRO_CHANGED_ERROR,
+					):
+						frappe.db.commit()
+						_publish_done(run, macro_doc, "failed")
+					else:
+						frappe.db.commit()
+					continue
 				# CDX-22: flip waiting_capacity -> running with a STATE-FENCED CAS (not a blind set),
 				# recording the attempt BEFORE re-enqueue so a re-overload keeps the bounded count. The
 				# fence closes the stop-before-resume-write race: a stop that already set ``stopped``
@@ -591,10 +634,15 @@ def resume_waiting_capacity_runs() -> None:
 				# ``stopped``, so no restore is owed.
 				if _run_status_now(run.name) != "running":
 					continue
-				merged = (macro_doc.merged_prompt or "").strip()
 				try:
-					if merged:
-						_run_merged(run, macro_doc, merged)
+					# #470: the run's OWN snapshot decides the shape. This branch used to read
+					# ``macro_doc.merged_prompt`` live, so a summary that landed during the park
+					# turned a part-executed stepped run merged (re-running steps 2..N after the
+					# merged turn), and a step edit that cleared the summary turned a merged run
+					# stepped (one step ran, then ``advance_after_turn`` computed
+					# total=min(1,N)=1 and reported the run COMPLETED).
+					if _run_mode(run, macro_doc) == MODE_MERGED:
+						_run_merged(run, macro_doc, (macro_doc.merged_prompt or "").strip())
 					else:
 						_run_step(run, macro_doc, int(run.current_step or 0))
 				except Exception:
@@ -609,6 +657,49 @@ def resume_waiting_capacity_runs() -> None:
 					_compensate_resume_enqueue_failure(run, macro_doc, attempts)
 		except Exception:
 			frappe.log_error(title="jarvis macro capacity-resume failed", message=frappe.get_traceback())
+
+
+def _run_mode(run, macro_doc) -> str:
+	"""The shape this run was DISPATCHED in (#470).
+
+	An explicit column rather than reusing ``total_steps == 1`` as the merged marker.
+	``total_steps`` is already the loop bound ``advance_after_turn`` reads
+	(``min(run.total_steps or len(steps), len(steps))``), so overloading it would make one
+	column mean two things and tie any future change to either meaning to the other. It is
+	also ambiguous on its own: a genuine ONE-STEP macro run as a sequence has
+	``total_steps == 1`` too.
+
+	A blank value means a row written before the column existed. It can only be a run that
+	was live across the deploy, so the window is at most one park (~100 min), and
+	``total_steps`` is the only dispatch-time record such a row carries. Resolve its
+	one-step ambiguity toward ``stepped``: for a one-step macro the two shapes dispatch
+	near-identical prompts, and ``stepped`` is the branch that can neither re-run a
+	completed step nor complete early."""
+	mode = (run.get("run_mode") or "").strip()
+	if mode in (MODE_MERGED, MODE_STEPPED):
+		return mode
+	steps = macro_doc.steps or []
+	return MODE_MERGED if int(run.total_steps or 0) == 1 and len(steps) > 1 else MODE_STEPPED
+
+
+def _resume_incompatible(run, macro_doc) -> bool:
+	"""#470: True when the macro was edited during the park in a way that leaves the run's
+	dispatch-time shape unrunnable. Macro edits take no per-run lock, so the resume path is
+	where that is noticed.
+
+	* **merged, summary gone.** ``update_macro`` clears ``merged_prompt`` the moment the
+	  steps change, precisely because the summary describes the OLD steps. Running it
+	  anyway would execute the intent the user just replaced. A merged run parks BEFORE its
+	  only turn (``_run_merged`` defers ahead of the ``current_step`` write, and
+	  ``advance_after_turn`` never re-enters merged), so nothing has executed and ending
+	  the run costs no work.
+	* **stepped, step list shrank past the cursor.** ``macro_doc.steps[index]`` would
+	  IndexError, and the CDX-23 compensation would then restore ``waiting_capacity`` and
+	  retry that certain IndexError once per cron cycle until the attempt cap ~100 min
+	  later."""
+	if _run_mode(run, macro_doc) == MODE_MERGED:
+		return not (macro_doc.merged_prompt or "").strip()
+	return int(run.current_step or 0) >= len(macro_doc.steps or [])
 
 
 def _compensate_resume_enqueue_failure(run, macro_doc, attempts: int) -> None:

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
@@ -27,6 +27,7 @@ class JarvisMacro(Document):
 		self._validate_steps()
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
+		self._validate_schedule_time()
 		self._recompute_next_run()
 
 	def _validate_name(self):
@@ -71,6 +72,29 @@ class JarvisMacro(Document):
 		owner = self.owner or frappe.session.user
 		if frappe.db.count("Jarvis Macro", {"owner": owner}) >= MAX_MACROS_PER_OWNER:
 			frappe.throw(_("You can have at most {0} macros.").format(MAX_MACROS_PER_OWNER))
+
+	def _validate_schedule_time(self):
+		"""#472: refuse a ``schedule_time`` that is not a time of day.
+
+		Frappe does not coerce or range-check a Time field before the controller runs
+		(``Document.insert`` runs ``validate`` first and ``_validate`` after), so the raw
+		value reached ``_recompute_next_run`` -> ``compute_next_run`` ->
+		``datetime.replace(hour=...)`` and surfaced as an unhandled ``ValueError``, i.e.
+		an HTTP 500 with a traceback instead of a field error.
+
+		Checked whenever a value is PRESENT, not only when ``schedule_enabled`` is on.
+		With the schedule off the bad value used to persist happily (MariaDB TIME holds
+		up to 838:59:59), which is what armed the cron-wide abort: a later flip of
+		``schedule_enabled`` handed the stored garbage straight to the sweep."""
+		if self.schedule_time in (None, ""):
+			return
+		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+
+		if parse_schedule_seconds(self.schedule_time) is None:
+			frappe.throw(
+				_("Schedule time must be a time of day between 00:00:00 and 23:59:59."),
+				title=_("Invalid schedule time"),
+			)
 
 	def _recompute_next_run(self):
 		"""Keep ``next_run_at`` in sync with the schedule fields. The scheduler

--- a/jarvis/jarvis/doctype/jarvis_macro_run/jarvis_macro_run.json
+++ b/jarvis/jarvis/doctype/jarvis_macro_run/jarvis_macro_run.json
@@ -12,6 +12,7 @@
     "status",
     "current_step",
     "total_steps",
+    "run_mode",
     "capacity_attempts",
     "trigger",
     "started_at",
@@ -55,6 +56,13 @@
       "fieldtype": "Int",
       "label": "Total Steps",
       "default": "0"
+    },
+    {
+      "fieldname": "run_mode",
+      "fieldtype": "Select",
+      "label": "Run Mode",
+      "options": "\nstepped\nmerged",
+      "description": "#470: the shape this run was DISPATCHED in - the whole step sequence (stepped) or the macro's summarized single prompt (merged). Snapshotted at insert and never rewritten, so a macro edited while the run is parked in waiting_capacity cannot flip it mid-flight. Deliberately has NO default: the blank a pre-#470 row gets on migrate is what tells the resume path to fall back instead of trusting a value nobody wrote."
     },
     {
       "fieldname": "capacity_attempts",

--- a/jarvis/tests/test_macro_merge.py
+++ b/jarvis/tests/test_macro_merge.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, now_datetime
 
 from jarvis.chat.macros_api import summarize_macro, update_macro
 
@@ -502,3 +503,245 @@ class TestMacroStopResumeSerialization(_MacroMergeBase):
 			macros.resume_waiting_capacity_runs()
 		self.assertEqual(frappe.db.get_value(self.RUN, run_name, "status"), "failed")
 		self.assertIn("busy", (frappe.db.get_value(self.RUN, run_name, "error") or "").lower())
+
+
+class TestMacroRunModeSnapshot(_MacroMergeBase):
+	"""#470 — merged-vs-stepped is fixed when the run is DISPATCHED, never re-decided on
+	a later dispatch.
+
+	A run parked in ``waiting_capacity`` waits up to ``_MAX_CAPACITY_ATTEMPTS`` x the 5 min
+	resume cron (~100 min), and macro edits take no per-run lock, so the macro the resume
+	re-read could easily have changed shape underneath it. Driving the state machine with a
+	stubbed ``api._enqueue_turn`` lets every dispatched prompt be asserted in order, which
+	is what makes "did not re-run a step" and "did not complete early" observable."""
+
+	MACRO = "Jarvis Macro"
+	RUN = "Jarvis Macro Run"
+
+	def _mk(self, n: int):
+		m = _mk_macro([{"label": f"s{i}", "prompt": f"p{i}"} for i in range(1, n + 1)])
+		self.addCleanup(lambda: frappe.delete_doc(self.MACRO, m.name, force=True, ignore_permissions=True))
+		return m
+
+	def _recorder(self):
+		"""A stubbed dispatcher that records the prompts it actually sent, and can be
+		flipped to report the accept gate as overloaded."""
+		state = {"overloaded": False, "sent": []}
+
+		def fake_enqueue(_conversation, prompt, **_kw):
+			if state["overloaded"]:
+				return {"ok": False, "overloaded": True, "reason": "busy"}
+			state["sent"].append(prompt)
+			return {"run_id": "r", "message_id": "m"}
+
+		return state, fake_enqueue
+
+	def _start(self, macro):
+		from jarvis.chat import macros
+
+		res = macros.run_macro(macro.name)
+		run_name, conv = res["data"]["macro_run"], res["data"]["conversation"]
+		self.addCleanup(
+			lambda: (
+				frappe.delete_doc(self.RUN, run_name, force=True, ignore_permissions=True),
+				frappe.db.delete("Jarvis Chat Message", {"conversation": conv}),
+				frappe.delete_doc("Jarvis Conversation", conv, force=True, ignore_permissions=True),
+			)
+		)
+		return run_name, conv
+
+	def _row(self, run_name):
+		return frappe.db.get_value(
+			self.RUN, run_name, ["status", "current_step", "total_steps", "run_mode"], as_dict=True
+		)
+
+	def _land_summary(self, macro_name, text="MERGED"):
+		"""What ``_apply_merge_after_turn`` does when a background summarize lands."""
+		frappe.db.set_value(
+			self.MACRO,
+			macro_name,
+			{"merged_prompt": text, "merge_status": "ready"},
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	# ---- the snapshot itself ---------------------------------------------------- #
+	def test_mode_is_snapshotted_on_the_run_at_dispatch(self):
+		state, fake = self._recorder()
+		stepped = self._mk(3)
+		merged = self._mk(3)
+		update_macro(merged.name, merged_prompt="MERGED")
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			s_run, _ = self._start(stepped)
+			m_run, _ = self._start(merged)
+		self.assertEqual(self._row(s_run).run_mode, "stepped")
+		self.assertEqual(self._row(m_run).run_mode, "merged")
+		self.assertEqual(state["sent"], ["p1", "MERGED"])
+
+	# ---- direction (a): a stepped run that gains a summary mid-park -------------- #
+	def test_stepped_run_that_gains_a_summary_mid_park_stays_stepped(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		state, fake = self._recorder()
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, conv = self._start(m)  # step 1 dispatches
+			state["overloaded"] = True
+			macros.advance_after_turn(conv, errored=False)  # step 2 cannot be admitted
+			self.assertEqual(self._row(run_name).status, "waiting_capacity")
+			self.assertEqual(self._row(run_name).current_step, 1, "a parked step must not advance")
+
+			# A background summarize completes while the run sits parked.
+			self._land_summary(m.name)
+			state["overloaded"] = False
+			macros.resume_waiting_capacity_runs()
+			macros.advance_after_turn(conv, errored=False)
+			macros.advance_after_turn(conv, errored=False)
+
+		# Re-deriving the mode here ran the 3-step summary into the SAME conversation and
+		# reset current_step to 1, so steps 2 and 3 executed a second time afterwards.
+		self.assertEqual(state["sent"], ["p1", "p2", "p3"])
+		self.assertEqual(self._row(run_name).status, "completed")
+
+	# ---- direction (b): a merged run whose summary is cleared mid-park ----------- #
+	def test_merged_run_whose_summary_is_cleared_mid_park_does_not_complete_early(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		update_macro(m.name, merged_prompt="MERGED")
+		state, fake = self._recorder()
+		state["overloaded"] = True
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, conv = self._start(m)
+			self.assertEqual(self._row(run_name).status, "waiting_capacity")
+
+			# The user edits the steps mid-park; update_macro clears the stale summary.
+			update_macro(m.name, steps=[{"prompt": f"q{i}"} for i in range(1, 5)])
+			self.assertFalse(frappe.db.get_value(self.MACRO, m.name, "merged_prompt"))
+
+			state["overloaded"] = False
+			macros.resume_waiting_capacity_runs()
+			macros.advance_after_turn(conv, errored=False)
+
+		# Re-deriving the mode ran q1 as a step and then finished the run "completed" off
+		# total=min(total_steps=1, 4)=1, i.e. 1 of 4 steps with a success in the history.
+		row = self._row(run_name)
+		self.assertNotEqual(row.status, "completed", "1 of 4 steps ran and the run claimed success")
+		self.assertEqual(row.status, "failed")
+		self.assertEqual(state["sent"], [], "nothing may dispatch once the snapshot is unrunnable")
+		self.assertIn("edited", (frappe.db.get_value(self.RUN, run_name, "error") or "").lower())
+
+	def test_stepped_run_whose_steps_shrank_past_the_cursor_fails_honestly(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		state, fake = self._recorder()
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, conv = self._start(m)  # p1 dispatches, current_step = 1
+			state["overloaded"] = True
+			macros.advance_after_turn(conv, errored=False)  # parks at current_step = 1
+			# The macro is cut to a single step, so index 1 no longer exists. Left alone
+			# this is an IndexError re-raised once per cron cycle until the attempt cap.
+			update_macro(m.name, steps=[{"prompt": "only"}])
+			state["overloaded"] = False
+			macros.resume_waiting_capacity_runs()
+
+		self.assertEqual(state["sent"], ["p1"])
+		self.assertEqual(self._row(run_name).status, "failed")
+		self.assertEqual(frappe.db.get_value(self.RUN, run_name, "capacity_attempts"), 0)
+
+	# ---- the unedited paths still work ------------------------------------------ #
+	def test_normal_merged_run_still_works_end_to_end(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		update_macro(m.name, merged_prompt="MERGED")
+		state, fake = self._recorder()
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, conv = self._start(m)
+			macros.advance_after_turn(conv, errored=False)
+		self.assertEqual(state["sent"], ["MERGED"])
+		row = self._row(run_name)
+		self.assertEqual((row.status, row.total_steps, row.current_step), ("completed", 1, 1))
+
+	def test_normal_stepped_run_still_works_end_to_end(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		state, fake = self._recorder()
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, conv = self._start(m)
+			for _ in range(3):
+				macros.advance_after_turn(conv, errored=False)
+		self.assertEqual(state["sent"], ["p1", "p2", "p3"])
+		row = self._row(run_name)
+		self.assertEqual((row.status, row.total_steps, row.current_step), ("completed", 3, 3))
+
+	def test_parked_and_unedited_run_resumes_in_its_own_mode(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		update_macro(m.name, merged_prompt="MERGED")
+		state, fake = self._recorder()
+		state["overloaded"] = True
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, conv = self._start(m)
+			state["overloaded"] = False
+			macros.resume_waiting_capacity_runs()
+			macros.advance_after_turn(conv, errored=False)
+		self.assertEqual(state["sent"], ["MERGED"])
+		self.assertEqual(self._row(run_name).status, "completed")
+
+	# ---- interaction with the #471 reaper ---------------------------------------- #
+	def test_a_parked_run_stays_distinguishable_from_a_stranded_one(self):
+		from jarvis.chat import macros
+
+		m = self._mk(3)
+		state, fake = self._recorder()
+		state["overloaded"] = True
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			run_name, _conv = self._start(m)
+		# Aged far past the stale-run cutoff: only the reaper's `running`-only status
+		# allowlist can be saving it, and the snapshot does not disturb that.
+		frappe.db.sql(
+			"UPDATE `tabJarvis Macro Run` SET modified=%(t)s WHERE name=%(n)s",
+			{"t": add_to_date(now_datetime(), seconds=-macros.STALE_RUN_AFTER_SECONDS * 4), "n": run_name},
+		)
+		frappe.db.commit()
+		macros.reap_stale_macro_runs()
+		self.assertEqual(self._row(run_name).status, "waiting_capacity", "a parked run was reaped")
+		# And it is still resumable afterwards.
+		state["overloaded"] = False
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			macros.resume_waiting_capacity_runs()
+		self.assertEqual(state["sent"], ["p1"])
+		self.assertEqual(self._row(run_name).status, "running")
+
+	# ---- rows written before the column existed ---------------------------------- #
+	def test_legacy_run_without_a_snapshot_falls_back_to_total_steps(self):
+		from jarvis.chat import macros
+
+		# A merged run that was already parked when the column shipped: run_mode is NULL,
+		# and total_steps=1 against a multi-step macro is the only record of its shape.
+		merged_macro = self._mk(3)
+		update_macro(merged_macro.name, merged_prompt="MERGED")
+		stepped_macro = self._mk(3)
+		state, fake = self._recorder()
+		state["overloaded"] = True
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			merged_run, _ = self._start(merged_macro)
+			stepped_run, _ = self._start(stepped_macro)
+		frappe.db.sql(
+			"UPDATE `tabJarvis Macro Run` SET run_mode=NULL WHERE name IN (%(a)s, %(b)s)",
+			{"a": merged_run, "b": stepped_run},
+		)
+		# A summary lands on the stepped macro too, which is exactly what used to flip it.
+		self._land_summary(stepped_macro.name, "WRONG")
+		frappe.db.commit()
+
+		state["overloaded"] = False
+		with patch("jarvis.chat.api._enqueue_turn", side_effect=fake):
+			macros.resume_waiting_capacity_runs()
+		self.assertIn("MERGED", state["sent"])
+		self.assertIn("p1", state["sent"])
+		self.assertNotIn("WRONG", state["sent"])

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -463,3 +463,108 @@ class TestStaleMacroRunReaper(MacroSchedulerBase):
 			frappe.db.commit()
 			self.assertEqual(macros.reap_stale_macro_runs(), 0)
 		self.assertEqual(frappe.db.get_value(RUN, name, "status"), "running")
+
+
+# --------------------------------------------------------------------------- #
+# #472 — schedule_time is validated, and one bad row cannot abort the sweep
+# --------------------------------------------------------------------------- #
+class TestScheduleTimeValidation(MacroSchedulerBase):
+	"""A ``schedule_time`` Frappe never range-checks reached
+	``datetime.replace(hour=...)`` inside ``validate()``, so the save 500'd, and a
+	value already on a row aborted the WHOLE hourly sweep."""
+
+	def _save(self, tag: str, schedule_time):
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": f"{PFX}-{tag}",
+				"enabled": 1,
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"schedule_time": schedule_time,
+				"steps": [{"prompt": "p1"}],
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		return doc
+
+	def test_out_of_range_schedule_time_is_refused_cleanly(self):
+		# frappe.ValidationError is what the SPA renders as a field error; a bare
+		# ValueError from the arithmetic is the 500 this closes.
+		for bad in ("99:00:00", "-01:00:00", "24:00:00", "12:99:00", "not-a-time", "1:2:3:4"):
+			with self.subTest(bad=bad):
+				with self.assertRaises(frappe.ValidationError):
+					self._save(f"bad-{abs(hash(bad))}", bad)
+
+	def test_a_bad_time_is_refused_even_with_the_schedule_off(self):
+		# The latent limb: with schedule_enabled=0 the controller never computed a
+		# next run, so the garbage persisted and armed the sweep for whenever the
+		# schedule was turned on.
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": f"{PFX}-off-but-bad",
+				"enabled": 1,
+				"schedule_enabled": 0,
+				"schedule_time": "99:00:00",
+				"steps": [{"prompt": "p1"}],
+			}
+		)
+		doc.flags.ignore_permissions = True
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert()
+
+	def test_valid_schedule_times_are_accepted_and_scheduled(self):
+		for good in ("00:00:00", "09:30:00", "23:59:59"):
+			with self.subTest(good=good):
+				doc = self._save(f"ok-{good.replace(':', '')}", good)
+				self.assertTrue(doc.next_run_at, "a valid time must still produce a next_run_at")
+
+	def test_bad_persisted_time_does_not_abort_the_sweep(self):
+		# Raw-write past the new validation to recreate a row saved before it existed,
+		# then force it to the FRONT of the sweep (Jarvis Macro sorts modified DESC) so
+		# a sweep that dies on it cannot reach the healthy macro behind it.
+		bad = _mk_macro(OWNER_OK, "poisoned")
+		good = _mk_macro(OWNER_OK, "healthy")
+		frappe.db.sql(
+			"UPDATE `tabJarvis Macro` SET schedule_time='99:00:00', modified=%(t)s WHERE name=%(n)s",
+			{"t": add_to_date(now_datetime(), days=1), "n": bad.name},
+		)
+		frappe.db.commit()
+
+		dispatched = self._run_due()
+
+		self.assertIn(good.name, dispatched, "one bad row aborted the sweep for every other macro")
+		self.assertIn(bad.name, dispatched, "the bad row should fall back, not be skipped")
+		# The poisoned row's slot still advanced, on the 09:00 fallback an unset time gets.
+		nxt = get_datetime(frappe.db.get_value(MACRO, bad.name, "next_run_at"))
+		self.assertEqual((nxt.hour, nxt.minute), (9, 0))
+
+	def test_one_exploding_macro_does_not_abort_the_sweep(self):
+		# The structural guarantee, independent of schedule_time: whatever a single
+		# row raises anywhere in its handling, every OTHER due macro still runs.
+		first = _mk_macro(OWNER_OK, "explodes")
+		second = _mk_macro(OWNER_OK, "survivor")
+		frappe.db.sql(
+			"UPDATE `tabJarvis Macro` SET modified=%(t)s WHERE name=%(n)s",
+			{"t": add_to_date(now_datetime(), days=1), "n": first.name},
+		)
+		frappe.db.commit()
+
+		def boom(m, *a, **kw):
+			if m.name == first.name:
+				raise RuntimeError("bookkeeping blew up")
+
+		with (
+			patch("jarvis.chat.macros.run_macro", return_value={"ok": True}) as mock_run,
+			patch.object(macro_scheduler, "_settle", side_effect=boom),
+		):
+			macro_scheduler.run_due_macros()
+		self.assertIn(second.name, [c.args[0] for c in mock_run.call_args_list])
+
+	def test_compute_next_run_never_raises_on_a_stored_value(self):
+		for bad in ("99:00:00", "-01:00:00", "838:59:59", "garbage"):
+			with self.subTest(bad=bad):
+				nxt = macro_scheduler.compute_next_run("daily", bad)
+				self.assertEqual((nxt.hour, nxt.minute), (9, 0))


### PR DESCRIPTION
## Summary

Two macro fixes. A macro saved with an out-of-range `schedule_time` (say `99:00:00`)
now gets a field error instead of a 500 traceback, and one bad macro row can no longer
abort the hourly scheduled-run sweep for every other macro on the bench. Separately, a
run parked in `waiting_capacity` now resumes in the shape it was DISPATCHED in rather
than re-deriving merged-vs-stepped from the macro on each dispatch, so a macro edited
during the ~100 minute park window can no longer make a run re-execute steps it already
ran, or report itself completed after one step of many.

Who notices: anyone who typed a bad time into the schedule field, and anyone who edits a
macro while one of its runs is waiting for site capacity. Behaviour on the unedited,
valid paths is unchanged.

Commit 1 is #472 and touches only `macro_scheduler.py` plus the macro controller.
Commit 2 is #470 and adds one column to `Jarvis Macro Run`.

<details>
<summary>Root cause</summary>

**#472.** Frappe runs the controller BEFORE its own field-type validation:
`Document.insert` calls `run_before_save_methods()` and only then `_validate()`. So
`JarvisMacro.validate` -> `_recompute_next_run` -> `compute_next_run` saw the raw
string, and `base.replace(hour=secs // 3600, ...)` raised `ValueError: hour must be in
0..23, not 99`. That is not a `frappe.ValidationError`, so it surfaced as a 500.

The latent limb was worse. With `schedule_enabled=0` the controller never computed a
next run, so the bad value persisted happily (a MariaDB TIME column accepts up to
`838:59:59`), and the schedule arithmetic in the cron ran OUTSIDE the per-macro
try/except, which covered only the dispatch. One poisoned row therefore aborted
`run_due_macros` for every macro behind it. The #471 rewrite did NOT close this: it
added failure handling around `macros.run_macro` only, and moved MORE `compute_next_run`
calls into the uncovered region via `_consume_slot`.

Fixed at three levels: the controller refuses a bad value whenever one is present (not
only when the schedule is on, so it can never be stored to arm the sweep later);
`_time_to_seconds` now clamps through a strict parser, making `compute_next_run` total;
and the loop body moved into `_sweep_one` so `run_due_macros` can wrap the whole
per-macro call. The failing row's slot is left due, matching #471's rule that a failure
never advances the schedule.

**#470.** `run.total_steps` is written exactly once, at insert, under whichever shape was
active then. `resume_waiting_capacity_runs` re-read the macro fresh and branched on
`(macro_doc.merged_prompt or "").strip()` live, so the two could disagree. Macro edits
take no per-run lock and `_MAX_CAPACITY_ATTEMPTS` (20) on a `*/5` cron is a real ~100
minute window, so an edit landing mid-park changed what a live run executed.

Stepped -> merged: the whole summary dispatched into the same conversation and
`_run_merged` reset `current_step` to 1, after which `advance_after_turn` computed
`total = min(5, 5) = 5` and `next_index = 1` and re-ran steps 2..5. Merged -> stepped: a
step edit cleared `merged_prompt`, one step ran, and `advance_after_turn` computed
`total = min(1, N) = 1` so the run finished `completed` with a success in the history for
1 of N steps.

`Jarvis Macro Run.run_mode` snapshots the shape at insert; the resume path reads it back.
An explicit column beats reusing `total_steps == 1` because `total_steps` is already the
loop bound in `advance_after_turn` (one column would mean two things) and it cannot
distinguish a merged run from a genuine one-step sequence. The field carries no DocType
default, so a row parked across the deploy reads blank and falls back to `total_steps`,
resolving the one-step ambiguity toward `stepped`. `advance_after_turn` needed no change:
it never re-enters merged, and `total_steps = 1` already caps a merged run at one turn.

When an edit leaves the snapshot unrunnable the run ends `failed` with an honest reason
rather than switching shape. Two cases: a merged run whose summary is gone (running the
old summary would execute the intent the user just replaced, and a merged run parks
BEFORE its only turn, so nothing has executed), and a stepped cursor past a shrunken step
list (otherwise a certain `IndexError`, retried once per cron cycle to the attempt cap).

Interaction with #471: `waiting_capacity` remains a live status, so the reaper's
`running`-only allowlist still tells a parked run from a stranded one. The new terminal
is a state-fenced CAS off `waiting_capacity`, taken under the same per-run redis lock and
before the attempt is spent, so it can neither clobber a concurrent stop nor disturb the
bounded-attempt promise.

</details>

## Tests

`jarvis/tests/test_macro_scheduler.py::TestScheduleTimeValidation` (6) and
`jarvis/tests/test_macro_merge.py::TestMacroRunModeSnapshot` (9). Every fix was reverted
individually and the suite re-run to confirm the tests fail without it. The #470 revert
reproduces both directions exactly: `['p1', 'MERGED', 'p2', 'p3'] != ['p1', 'p2', 'p3']`
for the re-run, and `'completed' == 'completed' : 1 of 4 steps ran and the run claimed
success` for the early finish. The #472 revert reproduces
`ValueError: hour must be in 0..23, not 99` escaping `run_due_macros()`.

All pre-existing classes in both modules were re-run per `--case`, plus
`test_part3_security`, `test_feature_pages_api`, `test_list_filters_f8`,
`test_turn_recovery` and `test_pump_pipeline`. All green.

## Pre-merge checklist

- [ ] **CI is green**: the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (based on `726ac15e`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

Closes #470
Closes #472

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
