### PR TITLE
fix(agents): inert TOCTOU guard, check-then-act install uniqueness, and push/run gate disagreement

### DIFF
--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -185,12 +185,15 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	enabled installs on the site are pushed; ``owner`` is accepted only to scope
 	tests. An empty list is a valid "remove all agent skills" reconcile.
 
-	RBAC (defense in depth): an enabled install whose OWNER's roles no longer
+	RBAC (defense in depth): an enabled install whose RUN-AS user's roles no longer
 	permit the agent is EXCLUDED from the push — the scheduler / run-now gates
 	already refuse to run it, but its enablement signal must not reach the
-	container either. Identity (CX1-1, the same reasoning): an enabled install with
-	a BLANK run-as user is EXCLUDED too — R1-F3 refuses it at every dispatch path,
-	so pushing it would advertise an agent this bench can never run.
+	container either. The run-as user, not the owner, is the identity that decides
+	(#457): it is the one every dispatch gate applies, so gating the push on
+	anything else advertises a roster the bench will not honour. Identity (CX1-1,
+	the same reasoning): an enabled install with a BLANK run-as user is EXCLUDED
+	too — R1-F3 refuses it at every dispatch path, so pushing it would advertise an
+	agent this bench can never run.
 
 	Installs are per-(owner, agent) but the payload is bench-global and keyed by
 	SLUG, so two users each enabling the SAME agent are ONE entry, not two —
@@ -290,7 +293,17 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		)
 		if not listing or listing.status != "Published":
 			continue
-		if not _user_allowed_for_agent(row.agent, row.owner):
+		# #457: gated on the RUN-AS user, not the row owner. The push and the two
+		# dispatch gates (``agent_scheduler.run_due_agent_audits`` and
+		# ``agents_api.run_agent_now``) must agree on WHICH identity decides, or the
+		# roster describes a bench that does not exist. Gotcha #8 settles which one:
+		# the EXECUTING identity is gated, not the triggerer, and the run-as user is
+		# the identity whose permissions every ``jarvis__*`` read is bounded by.
+		# Owner-gating produced both errors — an install whose owner lost the role
+		# while the run-as user kept it was dropped from the roster yet still
+		# dispatched (the reported phantom run), and the mirror case advertised a
+		# delegate the bench would refuse to run at every cadence.
+		if not _user_allowed_for_agent(row.agent, row.run_as_user):
 			continue
 
 		# Every gate has passed, so this agent is emitted and no later row for it can

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -113,8 +113,27 @@ def run_due_agent_audits() -> None:
 		# with a schedule set just consumes its slot (it drafts through the board,
 		# not on a cron). A scribe's schedule is optional (manual run-now is the
 		# primary path) but honoured here when set, so periodic re-learning works.
-		nature = frappe.db.get_value(LISTING, row.agent, "nature")
+		listing = (
+			frappe.db.get_value(LISTING, row.agent, ["nature", "status"], as_dict=True) or frappe._dict()
+		)
+		nature = listing.get("nature")
 		if nature not in ("Auditor", "Scribe"):
+			_advance(row, now)
+			continue
+
+		# #457: an admin who deprecates a listing must stop its schedules. The push
+		# already drops an unpublished agent from the roster, so the container has no
+		# such delegate and a dispatched run can only fail three hours later as a
+		# mislabelled timeout. ``_launch_audit`` is the authoritative gate, but refuse
+		# HERE too and consume the slot: a throw out of _launch_audit lands in the
+		# generic except below, which does NOT advance, so the cadence would retry
+		# hourly and write an Error Log every time for a state only a human can fix.
+		if (listing.get("status") or "") != "Published":
+			_record_failed(
+				row,
+				"scheduled run skipped: this agent is no longer published "
+				f"({listing.get('status') or 'unknown'}); uninstall it or ask an admin to republish it",
+			)
 			_advance(row, now)
 			continue
 
@@ -533,6 +552,27 @@ def _launch_audit(
 	# refusal, never with a bundle-configuration diagnosis (merge ruling, 2026-07-26
 	# composition review).
 	initiating_human = _resolve_initiating_human(trigger, initiating_human)
+
+	# #457: the listing must still be Published. This is the AUTHORITATIVE status
+	# gate — both dispatch paths funnel through here, so no caller can dispatch a
+	# delegate the push has stopped advertising. ``listing.status`` used to be
+	# checked only at INSTALL time, so an admin flipping a live installed agent to
+	# Deprecated changed nothing about its schedule: the next Apply reconciled the
+	# roster without that slug, then every cadence dispatched to a container that
+	# had no such delegate, the container rejected the unknown agent id, the bench
+	# never learned (the completion writeback never fires because the delegate never
+	# starts), and the run sat ``running`` for three hours until the stale-run sweep
+	# terminalized it as a duration timeout it never hit. Refuse at launch instead,
+	# with the real reason and no orphan conversation/run — same discipline as the
+	# run-as guard above, and ORDERED AFTER the authorization check for the same
+	# reason it precedes the bundle-configuration check below.
+	if (listing.status or "") != "Published":
+		frappe.throw(
+			_(
+				"This agent is no longer published ({0}), so it is not deployed to run. "
+				"Uninstall it, or ask an admin to publish it again — nothing was started."
+			).format(listing.status or "unknown")
+		)
 
 	# JF-017: the run's CAPABILITY CONTRACT. Resolved HERE, before any row exists,
 	# because an empty declared surface is not a runnable state: the bench would

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -636,7 +636,18 @@ def install_agent(agent_slug: str) -> dict:
 			"schedule_frequency": freq,
 		}
 	)
-	doc.insert()  # owner = me; validate() runs the cap/uniqueness/run-as checks
+	try:
+		doc.insert()  # owner = me; validate() runs the cap/uniqueness/run-as checks
+	except frappe.UniqueValidationError:
+		# #460: the (owner, agent) unique index is the authority — the two
+		# ``frappe.db.exists`` checks above it (here and in the controller) cannot
+		# serialize a double-submit, so the LOSER of that race arrives here. Frappe
+		# has already queued its generic "owner_agent must be unique" msgprint from
+		# ``show_unique_validation_message``; drop it and re-raise the same friendly
+		# message the non-racing path gives, so a double click reads as an ordinary
+		# "already installed" rather than a 500.
+		frappe.clear_last_message()
+		frappe.throw(_("You have already installed this agent."))
 	# No _mark_catalog_dirty(): installs start enabled=0, so the container's
 	# ENABLED set is unchanged — only enable/disable (and uninstalling an
 	# ENABLED install) make an Apply pending.

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -536,13 +536,44 @@ def _mark_catalog_dirty() -> None:
 	mutation it annotates."""
 	try:
 		frappe.db.set_single_value(_SETTINGS, "agent_catalog_dirty", 1)
-		frappe.db.set_single_value(
-			_SETTINGS,
-			"agent_catalog_version",
-			frappe.utils.cint(frappe.db.get_single_value(_SETTINGS, "agent_catalog_version")) + 1,
-		)
+		_bump_catalog_version()
 	except Exception:
 		frappe.log_error(title="Jarvis: agent catalog dirty flag failed", message=frappe.get_traceback())
+
+
+def _bump_catalog_version() -> None:
+	"""Increment ``agent_catalog_version`` in ONE statement (#458).
+
+	The obvious read-modify-write (``get_single_value`` + ``set_single_value``)
+	loses updates: two mutations racing both read V and both write V+1, so the
+	second mutation leaves the version looking untouched. The push worker's TOCTOU
+	recheck compares against that version, so a lost increment is exactly the case
+	where the worker clears the dirty flag for a change that never made the
+	payload.
+
+	Frappe stores one Single field as one ``tabSingles`` row, so a single
+	``UPDATE ... SET value = value + 1`` runs under that row's write lock and
+	cannot lose an increment however the two writers interleave.
+	``set_single_value`` survives only as the SEED path: a Single field that was
+	never written has no ``tabSingles`` row at all, and the UPDATE above would
+	silently match nothing.
+	"""
+	params = {"dt": _SETTINGS, "field": "agent_catalog_version"}
+	frappe.db.sql(
+		"""UPDATE `tabSingles`
+		SET `value` = CAST(COALESCE(NULLIF(`value`, ''), '0') AS UNSIGNED) + 1
+		WHERE `doctype` = %(dt)s AND `field` = %(field)s""",
+		params,
+	)
+	if not frappe.db.sql(
+		"""SELECT 1 FROM `tabSingles` WHERE `doctype` = %(dt)s AND `field` = %(field)s LIMIT 1""",
+		params,
+	):
+		frappe.db.set_single_value(_SETTINGS, "agent_catalog_version", 1)
+	# Raw SQL bypasses both the Single's redis document cache and
+	# ``frappe.db.value_cache``, which would otherwise keep serving the
+	# pre-increment value for the rest of this request.
+	frappe.clear_document_cache(_SETTINGS, _SETTINGS)
 
 
 @frappe.whitelist()
@@ -1821,9 +1852,29 @@ def _enqueued_push_agent_skills() -> None:
 			# (``_mark_catalog_dirty``), and we then refuse to clear the dirty
 			# flag below — the change missed this payload; a later Apply
 			# reconciles it.
-			version = frappe.utils.cint(frappe.db.get_single_value(_SETTINGS, "agent_catalog_version"))
+			version = frappe.utils.cint(
+				frappe.db.get_single_value(_SETTINGS, "agent_catalog_version", cache=False)
+			)
 			payload = build_agent_push_payload()
 			admin_client.post_push_agent_skills(agent_skills=payload)
+			# #458: END THIS WORKER'S TRANSACTION before the recheck, or the recheck
+			# cannot see a mutation at all and the guard above is inert. Two layers
+			# hid it: ``get_single_value`` defaults to ``cache=True`` and serves
+			# ``frappe.db.value_cache``, which is invalidated ONLY by commit/rollback;
+			# and under REPEATABLE READ every plain SELECT in this transaction reads
+			# the snapshot taken before the push, so even ``cache=False`` would
+			# re-read the snapshot value. Committing clears both. Exactly the reason
+			# ``promote_installation`` commits before ITS re-read.
+			#
+			# SAFE HERE and nowhere earlier: at this point the worker has written
+			# NOTHING (the version read and ``build_agent_push_payload`` are pure
+			# reads, and ``admin_client`` is pure HTTP), so this commits an empty
+			# transaction and can leave no half-written state. It also sits AFTER the
+			# push, so it can never commit a status implying a push that did not
+			# happen. The terminal write below is a single ``set_value`` in the fresh
+			# transaction, still covered by the try/except/finally and the trailing
+			# commit, so the "status is never left pending" invariant is unchanged.
+			frappe.db.commit()
 			values = {
 				"agent_skills_synced_at": frappe.utils.now(),
 				"agent_skills_sync_status": f"ok (applied {len(payload)} via admin)",
@@ -1831,7 +1882,10 @@ def _enqueued_push_agent_skills() -> None:
 			# The container now matches the DB — clear the dirty flag ONLY on a
 			# successful push whose payload saw every mutation (version
 			# unchanged); failures and mid-push mutations leave it set.
-			if frappe.utils.cint(frappe.db.get_single_value(_SETTINGS, "agent_catalog_version")) == version:
+			fresh = frappe.utils.cint(
+				frappe.db.get_single_value(_SETTINGS, "agent_catalog_version", cache=False)
+			)
+			if fresh == version:
 				values["agent_catalog_dirty"] = 0
 			frappe.db.set_value(_SETTINGS, _SETTINGS, values)
 			terminal_written = True

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -439,8 +439,18 @@ def set_listing_status(agent_slug: str, status: str) -> dict:
 		frappe.throw(_("Status must be one of: {0}.").format(", ".join(_ADMIN_STATUSES)))
 	doc = frappe.get_doc(LISTING, agent_slug)
 	doc.check_permission("write")
+	before = doc.status
 	doc.status = status
 	doc.save()
+	# #457: status is a PUSH-VISIBLE property — ``build_agent_push_payload`` emits
+	# only Published listings — so changing it changes the container's roster just
+	# as install/enable does. Without this the SPA showed no "Apply pending" after a
+	# deprecate, so the roster and the DB silently disagreed until some unrelated
+	# mutation re-dirtied the flag. Only on an actual change, and only when some
+	# install would have carried the slug: a status flip on an agent nobody enabled
+	# pushes exactly the same payload.
+	if before != doc.status and frappe.db.exists(INSTALLATION, {"agent": doc.name, "enabled": 1}):
+		_mark_catalog_dirty()
 	frappe.db.commit()
 	return {"ok": True, "status": doc.status}
 
@@ -969,10 +979,24 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 	from jarvis.chat.agent_installability import assert_installable
 
 	assert_installable(doc.agent)
-	nature = frappe.db.get_value(LISTING, doc.agent, "nature")
+	listing = frappe.db.get_value(LISTING, doc.agent, ["nature", "status"], as_dict=True) or frappe._dict()
+	nature = listing.get("nature")
 	if nature not in ("Auditor", "Scribe"):
 		frappe.throw(
 			_("Only auditor and scribe agents run on demand; operators draft through the Approval Board.")
+		)
+	# #457: an unpublished listing is not deployed — the push drops it from the
+	# container roster, so a manual run would reach a delegate that does not exist
+	# and only fail three hours later as a mislabelled timeout. ``_launch_audit``
+	# refuses it authoritatively; refuse here too, before the budget check and the
+	# source-app persistence, so the operator gets the real reason and no side
+	# effects.
+	if (listing.get("status") or "") != "Published":
+		frappe.throw(
+			_(
+				"This agent is no longer published ({0}), so it is not deployed to run. "
+				"Uninstall it, or ask an admin to publish it again."
+			).format(listing.get("status") or "unknown")
 		)
 	# CX5-5: a SHADOW installation means "run it, but its output is not live yet" —
 	# an auditor's findings sit in a shadow set for a reviewer. A scribe has no such

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -188,9 +188,12 @@ class JarvisAgentInstallation(Document):
 		)
 
 	def _validate_unique_per_owner(self):
-		# One install of a given agent per owner. Frappe has no composite-unique
-		# on (owner, agent), so enforce it here (an owner re-installing the same
-		# agent must reuse / re-enable the existing row).
+		# One install of a given agent per owner. This is the FRIENDLY path only:
+		# check-then-act cannot serialize two concurrent inserts (both see no clash
+		# under REPEATABLE READ and both commit under distinct hash names — #460),
+		# so the real guarantee is the composite unique index created in
+		# ``on_doctype_update`` below. Keep this check first so the ordinary
+		# double-install gets a readable message instead of a constraint error.
 		owner = self.owner or frappe.session.user
 		clash = frappe.db.exists(
 			"Jarvis Agent Installation",
@@ -330,3 +333,37 @@ class JarvisAgentInstallation(Document):
 		except Exception:
 			return False
 		return any(dt in perms for dt in _GL_SCOPED_DIMENSIONS)
+
+
+def on_doctype_update():
+	"""Create the composite unique index on (owner, agent) — #460.
+
+	``_validate_unique_per_owner`` is check-then-act: ``frappe.db.exists`` then
+	``frappe.throw``. The doctype is ``autoname: hash`` / ``naming_rule: Random``
+	and declares no ``unique`` field, so nothing at the DB level serialized two
+	concurrent installs of the same agent by one owner — both saw no clash under
+	REPEATABLE READ and both committed under distinct names. The duplicate
+	inflated ``install_count`` and made a single uninstall leave a phantom row, so
+	the agent still rendered as installed.
+
+	The constraint lives HERE and not only in the patch because
+	``install_app`` runs with ``set_as_patched=True``, which marks every entry in
+	patches.txt executed WITHOUT running it: on any fresh install (CI, a new
+	customer bench, a rebuilt site) the patch is skipped, and a patch-only
+	constraint would silently never exist. Frappe calls ``on_doctype_update()``
+	whenever the DocType document is saved, fresh installs included.
+
+	The converse gap is why ``v2_13_unique_agent_installation`` also exists:
+	``bench migrate`` re-imports a DocType only when its ``.json`` changes, so a
+	``.py``-only change like this one never fires the hook on an EXISTING site.
+	That patch reloads the doctype (and de-dupes first, since ALTER TABLE would
+	fail on live duplicates).
+
+	``add_unique`` no-ops when the index is already present, so a site running
+	both paths is harmless.
+	"""
+	frappe.db.add_unique(
+		"Jarvis Agent Installation",
+		["owner", "agent"],
+		constraint_name="owner_agent",
+	)

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -49,3 +49,4 @@ jarvis.patches.v2_12_backfill_approved_draft
 jarvis.patches.v2_12_reload_agent_doctypes_for_indexes
 jarvis.patches.v2_12_reload_macro_doctypes_for_indexes
 jarvis.patches.v2_13_repush_learned_skills_role_gated
+jarvis.patches.v2_13_unique_agent_installation

--- a/jarvis/patches/v2_13_unique_agent_installation.py
+++ b/jarvis/patches/v2_13_unique_agent_installation.py
@@ -1,0 +1,140 @@
+"""Add the composite unique index on (owner, agent) to
+`tabJarvis Agent Installation`, backing the check-then-act uniqueness in
+jarvis_agent_installation._validate_unique_per_owner (#460).
+
+Root cause this closes: uniqueness of (owner, agent) was enforced ONLY by
+`frappe.db.exists` + `frappe.throw`, in the controller and again in
+`agents_api.install_agent`. The doctype is `autoname: hash` /
+`naming_rule: Random` and declares no `unique` field, so nothing at the DB
+level backstopped it: two concurrent installs (a double click, or two
+gunicorn workers) both saw no clash under REPEATABLE READ and both committed
+under distinct hash names. The duplicate inflated `install_count` and made a
+single uninstall leave a phantom row behind, so the agent still rendered as
+installed.
+
+Existing duplicates are MERGED, not destroyed, before the constraint is added
+(ALTER TABLE would otherwise hard-fail on any bench already carrying rows from
+exactly the race this closes). See `_merge_duplicate_installs` for which row
+survives and why.
+
+The index also lives in `on_doctype_update()`, which is what gives it to a
+FRESH install: `install_app` runs with `set_as_patched=True`, so every patch in
+patches.txt is marked done without running. Conversely `bench migrate`
+re-imports a DocType only when its `.json` changes, and #460 is a `.py`-only
+change, so on an EXISTING site the hook never fires by itself -- hence the
+explicit `reload_doc` here.
+"""
+
+import frappe
+
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+PROVENANCE = "Jarvis Agent Provenance Event"
+ACTIVITY = "Jarvis Agent Activity"
+
+
+def _keeper_rank(row: dict) -> tuple:
+	"""Sort key for picking which duplicate SURVIVES (lowest tuple wins).
+
+	Ordered by how expensive the state is to reconstruct, not by age:
+
+	1. ``activation_state == "live"`` -- reaching live costs a named reviewer's
+	   PP-4 sign-off and a slot under the PP-6 activation ceiling. Silently
+	   demoting a live capability is the single worst outcome here.
+	2. ``enabled`` -- a running agent must not silently stop running.
+	3. ``schedule_enabled`` -- likewise for its cadence.
+	4. run count -- a pure tiebreak. History is NOT what decides the winner,
+	   because history is preserved either way: every loser's runs, provenance
+	   events and activity rows are re-pointed at the keeper below.
+	5. oldest ``creation`` -- of two otherwise identical rows the first is the
+	   real install and the second is the racer.
+	6. ``name`` -- so the choice is deterministic and the patch is idempotent.
+	"""
+	return (
+		0 if (row.get("activation_state") or "shadow") == "live" else 1,
+		0 if frappe.utils.cint(row.get("enabled")) else 1,
+		0 if frappe.utils.cint(row.get("schedule_enabled")) else 1,
+		-int(row.get("run_count") or 0),
+		str(row.get("creation") or ""),
+		str(row.get("name") or ""),
+	)
+
+
+def _merge_duplicate_installs() -> int:
+	"""Collapse every duplicate (owner, agent) group onto one keeper row.
+
+	Nothing is destroyed except the redundant installation row itself: runs,
+	provenance events and activity rows belonging to a loser are re-pointed at
+	the keeper first, so the customer's installation history survives the merge
+	intact and the findings hanging off those runs stay reachable.
+
+	Idempotent: a second execution finds no group with COUNT(*) > 1 and returns 0.
+	"""
+	dupes = frappe.db.sql(
+		"""
+		SELECT `owner`, `agent`
+		FROM `tabJarvis Agent Installation`
+		GROUP BY `owner`, `agent`
+		HAVING COUNT(*) > 1
+		""",
+		as_dict=True,
+	)
+	merged = 0
+	for d in dupes:
+		rows = frappe.get_all(
+			INSTALLATION,
+			filters={"owner": d.owner, "agent": d.agent},
+			fields=[
+				"name",
+				"creation",
+				"enabled",
+				"schedule_enabled",
+				"activation_state",
+			],
+			ignore_permissions=True,
+		)
+		if len(rows) < 2:
+			continue
+		for r in rows:
+			r["run_count"] = frappe.db.count(RUN, {"installation": r["name"]})
+		rows.sort(key=_keeper_rank)
+		keep, extras = rows[0], rows[1:]
+		for extra in extras:
+			frappe.db.set_value(
+				RUN, {"installation": extra["name"]}, "installation", keep["name"], update_modified=False
+			)
+			frappe.db.set_value(
+				PROVENANCE,
+				{"installation": extra["name"]},
+				"installation",
+				keep["name"],
+				update_modified=False,
+			)
+			# ``installation`` on the activity log is a Data field (Link-free by
+			# design, so the row survives the uninstall cascade), but it is still the
+			# join the agent activity feed uses.
+			frappe.db.set_value(
+				ACTIVITY,
+				{"installation": extra["name"]},
+				"installation",
+				keep["name"],
+				update_modified=False,
+			)
+			frappe.db.delete(INSTALLATION, {"name": extra["name"]})
+			merged += 1
+	return merged
+
+
+def execute():
+	if not frappe.db.table_exists(INSTALLATION):
+		return
+	_merge_duplicate_installs()
+	frappe.db.commit()
+	# Re-saving the DocType is what actually fires on_doctype_update(), which owns
+	# the index. A .py-only change never triggers it on an existing site, so
+	# without this migrate exits 0 and the index silently never exists.
+	frappe.reload_doc("jarvis", "doctype", "jarvis_agent_installation", force=True)
+	# Belt and braces: reload_doc is the canonical path, but the constraint must
+	# not depend on it. add_unique no-ops when the index is already present.
+	frappe.db.add_unique(INSTALLATION, ["owner", "agent"], constraint_name="owner_agent")
+	frappe.db.commit()

--- a/jarvis/tests/test_app_learning_agent.py
+++ b/jarvis/tests/test_app_learning_agent.py
@@ -84,7 +84,11 @@ def _mk_user(email: str, roles: list[str]) -> str:
 
 def _mk_listing(slug: str, nature: str) -> str:
 	if frappe.db.exists(LISTING, slug):
-		frappe.db.set_value(LISTING, slug, "nature", nature)
+		# ``status`` is re-asserted, not just ``nature``: this slug is synthetic, so
+		# any module that runs ``agent_catalog.sync_agent_listings`` retires it to
+		# Deprecated (it is not in the bundled registry), and the fixture means a
+		# PUBLISHED scribe — which the #457 dispatch gate now requires.
+		frappe.db.set_value(LISTING, slug, {"nature": nature, "status": "Published"})
 	else:
 		frappe.get_doc(
 			{

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.chat import agents_api
+from jarvis.chat import agent_scheduler, agents_api
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
@@ -890,3 +890,359 @@ class TestAgentInstallDuplicateMerge(FrappeTestCase):
 		frappe.db.commit()
 		_add_owner_agent_index()
 		self.assertTrue(_owner_agent_index())
+
+
+# --------------------------------------------------------------------------- #
+# #457 — push gate and dispatch gate agree on identity and status
+# --------------------------------------------------------------------------- #
+GATE_ROLE = "Jarvis Hardening Gate Role"
+
+
+def _mk_role(name: str) -> str:
+	if not frappe.db.exists("Role", name):
+		doc = frappe.get_doc({"doctype": "Role", "role_name": name, "desk_access": 1})
+		doc.flags.ignore_permissions = True
+		doc.insert()
+	return name
+
+
+def _set_roles(email: str, role: str, *, held: bool) -> None:
+	user = frappe.get_doc("User", email)
+	has = any(r.role == role for r in user.roles)
+	if held and not has:
+		user.append("roles", {"role": role})
+	elif not held and has:
+		user.set("roles", [r for r in user.roles if r.role != role])
+	else:
+		return
+	user.flags.ignore_permissions = True
+	user.save()
+	frappe.clear_cache(user=email)
+
+
+def _restrict(slug: str, roles: list[str]) -> None:
+	doc = frappe.get_doc(LISTING, slug)
+	doc.set("allowed_roles", [{"role": r} for r in roles])
+	doc.flags.ignore_permissions = True
+	doc.save()
+
+
+def _mk_gate_install(owner: str, slug: str, run_as: str) -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": slug,
+			"run_as_user": run_as,
+			"reviewer": owner,
+			"enabled": 1,
+		}
+	)
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	return doc.name
+
+
+class TestAgentPushGateIdentity(FrappeTestCase):
+	"""#457: the push must advertise exactly the set the dispatch gates will run.
+	Gotcha #8 settles which identity decides — the EXECUTING one — so the push now
+	gates on ``run_as_user``, matching ``agent_scheduler.run_due_agent_audits`` and
+	``agents_api.run_agent_now``."""
+
+	SLUG = PREFIX + "pushid"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-pushid-owner@example.com")
+		cls.runner = _mk_user("h-pushid-runner@example.com")
+		_mk_role(GATE_ROLE)
+		_mk_listing(cls.SLUG)
+		frappe.db.set_value(LISTING, cls.SLUG, "status", "Published", update_modified=False)
+		_restrict(cls.SLUG, [GATE_ROLE])
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Published", update_modified=False)
+		_restrict(self.SLUG, [GATE_ROLE])
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		for u in (self.owner, self.runner):
+			_set_roles(u, GATE_ROLE, held=False)
+		frappe.db.commit()
+
+	def _slugs(self):
+		from jarvis.chat.agent_catalog import build_agent_push_payload
+
+		return [e["slug"] for e in build_agent_push_payload(owner=self.owner)]
+
+	def test_pushed_when_the_run_as_user_holds_the_role_and_the_owner_does_not(self):
+		"""D1 in the issue: the owner lost the restricting role while the run-as
+		user kept it. Dispatch has always allowed this; the push used to drop it, so
+		the bench ran an agent its own roster did not list."""
+		_set_roles(self.owner, GATE_ROLE, held=False)
+		_set_roles(self.runner, GATE_ROLE, held=True)
+		_mk_gate_install(self.owner, self.SLUG, self.runner)
+		frappe.db.commit()
+		self.assertIn(f"agent-{self.SLUG}", self._slugs())
+
+	def test_not_pushed_when_the_owner_holds_the_role_and_the_run_as_user_does_not(self):
+		"""The mirror case: dispatch refuses this install at every cadence, so
+		advertising it would seat a delegate the bench will never run."""
+		_set_roles(self.owner, GATE_ROLE, held=True)
+		_set_roles(self.runner, GATE_ROLE, held=False)
+		_mk_gate_install(self.owner, self.SLUG, self.runner)
+		frappe.db.commit()
+		self.assertNotIn(f"agent-{self.SLUG}", self._slugs())
+
+	def test_self_mapped_install_is_unaffected(self):
+		"""Control: run_as_user defaults to the installer, so for every ordinary
+		install owner == run-as user and the change is a no-op."""
+		_set_roles(self.owner, GATE_ROLE, held=True)
+		_mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.commit()
+		self.assertIn(f"agent-{self.SLUG}", self._slugs())
+
+	def test_unpublished_listing_is_never_pushed(self):
+		"""Unchanged, and the reason the dispatch gate had to learn the same rule."""
+		_set_roles(self.owner, GATE_ROLE, held=True)
+		_mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Deprecated", update_modified=False)
+		frappe.db.commit()
+		self.assertNotIn(f"agent-{self.SLUG}", self._slugs())
+
+
+class TestAgentDispatchStatusGate(FrappeTestCase):
+	"""#457: an unpublished listing must not dispatch. Before this, ``status`` was
+	read only by ``install_agent``, so deprecating a live installed agent left its
+	schedule firing into a container that no longer had the delegate — three hours
+	of ``running`` per cadence, terminalized by the stale-run sweep as a duration
+	timeout it never hit."""
+
+	SLUG = PREFIX + "gate"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-gate-owner@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.set_value(
+			LISTING, cls.SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False
+		)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.set_value(
+			LISTING, self.SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False
+		)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def _due_install(self) -> str:
+		from frappe.utils import add_days, now_datetime
+
+		name = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.set_value(
+			INSTALLATION,
+			name,
+			{
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"next_run_at": add_days(now_datetime(), -1),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		return name
+
+	def _run_cron(self):
+		"""Run the hourly cron with only OUR install due (this is a shared dev site,
+		and other modules leave due rows behind), and with the launch stubbed."""
+		from frappe.utils import add_days, now_datetime
+
+		now = now_datetime()
+		parked = {
+			r.name: r.next_run_at
+			for r in frappe.get_all(
+				INSTALLATION,
+				filters={
+					"enabled": 1,
+					"schedule_enabled": 1,
+					"next_run_at": ["<=", now],
+					"agent": ["!=", self.SLUG],
+				},
+				fields=["name", "next_run_at"],
+				ignore_permissions=True,
+			)
+		}
+		for n in parked:
+			frappe.db.set_value(INSTALLATION, n, "next_run_at", add_days(now, 2), update_modified=False)
+		frappe.db.commit()
+		calls = []
+		try:
+			with patch.object(
+				agent_scheduler,
+				"_launch_audit",
+				side_effect=lambda inst, **kw: calls.append((inst.name, frappe.session.user)),
+			):
+				agent_scheduler.run_due_agent_audits()
+		finally:
+			for n, ts in parked.items():
+				frappe.db.set_value(INSTALLATION, n, "next_run_at", ts, update_modified=False)
+			frappe.db.commit()
+		return calls
+
+	def test_deprecated_listing_does_not_dispatch_on_the_cron(self):
+		"""The reported phantom-run path (D2): an admin deprecates an installed,
+		enabled, scheduled auditor. No turn is dispatched, the reason is recorded on
+		a ``failed`` run the customer can see, and the slot is CONSUMED so the
+		cadence does not busy-retry hourly."""
+		from frappe.utils import now_datetime
+
+		now = now_datetime()
+		inst = self._due_install()
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Deprecated", update_modified=False)
+		frappe.db.commit()
+
+		self.assertEqual(self._run_cron(), [])
+		runs = frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": "failed"},
+			fields=["owner", "error"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(len(runs), 1)
+		self.assertEqual(runs[0]["owner"], self.owner)
+		self.assertIn("no longer published", runs[0]["error"])
+		row = frappe.db.get_value(INSTALLATION, inst, ["next_run_at", "last_run_at"], as_dict=True)
+		self.assertIsNotNone(row.last_run_at)
+		self.assertGreater(row.next_run_at, now)
+
+	def test_published_listing_still_dispatches_as_the_run_as_user(self):
+		"""Control: the legitimate case is untouched, and still launches under the
+		RUN-AS identity (the S1 hinge), not the scheduler's Administrator."""
+		inst = self._due_install()
+		calls = self._run_cron()
+		self.assertEqual(calls, [(inst, self.owner)])
+		self.assertEqual(
+			frappe.get_all(RUN, filters={"installation": inst, "status": "failed"}, ignore_permissions=True),
+			[],
+		)
+
+	def test_launch_audit_refuses_a_deprecated_listing_and_creates_no_rows(self):
+		"""The choke point both dispatch paths funnel through: no caller can get a
+		run started for an unpublished agent, and a refused launch leaves no orphan
+		conversation or run behind."""
+		inst = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Deprecated", update_modified=False)
+		frappe.db.commit()
+		doc = frappe.get_doc(INSTALLATION, inst)
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agent_scheduler._launch_audit(doc, trigger="scheduled")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn("no longer published", str(ctx.exception))
+		self.assertEqual(frappe.get_all(RUN, filters={"installation": inst}, ignore_permissions=True), [])
+
+	def test_launch_audit_lets_a_published_listing_past_the_status_gate(self):
+		"""Control + ordering: with the listing Published the launch proceeds to the
+		JF-017 bundle check, proving the new gate is not refusing everything and
+		that it sits BEFORE the bundle-configuration diagnosis."""
+		inst = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.commit()
+		doc = frappe.get_doc(INSTALLATION, inst)
+		frappe.set_user(self.owner)
+		try:
+			with (
+				patch("jarvis.chat.agent_catalog.registry_tools_allow", return_value=[]),
+				self.assertRaises(frappe.ValidationError) as ctx,
+			):
+				agent_scheduler._launch_audit(doc, trigger="scheduled")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn("declares no tools", str(ctx.exception))
+
+	def test_run_agent_now_refuses_a_deprecated_listing(self):
+		"""The manual path answers with the availability reason too, before it
+		spends a budget slot or persists anything."""
+		inst = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Deprecated", update_modified=False)
+		frappe.db.commit()
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agents_api.run_agent_now(inst)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn("no longer published", str(ctx.exception))
+
+
+class TestSetListingStatusMarksCatalogDirty(FrappeTestCase):
+	"""#457: ``set_listing_status`` changes what the push emits, so it must mark an
+	Apply pending like every other push-visible mutation. Without this the SPA
+	showed "synced" while the container roster still carried the deprecated slug."""
+
+	SLUG = PREFIX + "statusdirty"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-statusdirty-owner@example.com")
+		_mk_listing(cls.SLUG)
+		cls._saved = {k: _single(k) for k in ("agent_catalog_dirty", "agent_catalog_version")}
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for k, v in cls._saved.items():
+			frappe.db.set_single_value(SETTINGS, k, v)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Published", update_modified=False)
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_dirty", 0)
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_version", 3)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def test_deprecating_an_enabled_agent_marks_an_apply_pending(self):
+		_mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.commit()
+		agents_api.set_listing_status(self.SLUG, "Deprecated")
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 1)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 4)
+
+	def test_status_change_with_no_enabled_install_is_not_dirty(self):
+		"""The payload is identical either way, so do not manufacture a pending
+		Apply (and a container restart) out of nothing."""
+		agents_api.set_listing_status(self.SLUG, "Deprecated")
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 3)
+
+	def test_setting_the_same_status_is_not_dirty(self):
+		_mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.commit()
+		agents_api.set_listing_status(self.SLUG, "Published")
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -497,3 +497,163 @@ class TestUninstallCascadeScope(FrappeTestCase):
 		"""No cascade flag, no guard — an ordinary admin/Desk delete is unaffected."""
 		frappe.delete_doc(FINDING, self.f_b, ignore_permissions=True, force=True)
 		self.assertFalse(frappe.db.exists(FINDING, self.f_b))
+
+
+# --------------------------------------------------------------------------- #
+# #458 — the agent_catalog_dirty TOCTOU guard
+# --------------------------------------------------------------------------- #
+_TOCTOU_KEYS = (
+	"agent_catalog_dirty",
+	"agent_catalog_version",
+	"agent_skills_sync_status",
+	"agent_skills_synced_at",
+)
+
+
+def _single(field: str):
+	"""Read a Jarvis Settings field bypassing frappe.db.value_cache — the very
+	cache this section is about."""
+	return frappe.db.get_single_value(SETTINGS, field, cache=False)
+
+
+def _second_connection():
+	"""A SEPARATE DB connection, so a write can be committed while the push
+	worker's own transaction is open.
+
+	This is what makes the #458 regression faithful: a same-connection write
+	would be visible to the worker's re-read (read-your-own-writes) and a
+	same-connection commit would clear ``frappe.db.value_cache`` for it, so
+	neither could ever reproduce the bug.
+	"""
+	from frappe.database import get_db
+
+	conf = frappe.conf
+	return get_db(
+		socket=conf.db_socket,
+		host=conf.db_host,
+		port=conf.db_port,
+		user=conf.db_user or conf.db_name,
+		password=conf.db_password,
+		cur_db_name=conf.db_name,
+	)
+
+
+def _concurrent_catalog_mutation() -> None:
+	"""Model a user's ``set_enabled`` landing mid-push: another connection bumps
+	the catalog version and re-marks the catalog dirty, and COMMITS."""
+	conn = _second_connection()
+	try:
+		conn.sql(
+			"""UPDATE `tabSingles`
+			SET `value` = CAST(COALESCE(NULLIF(`value`, ''), '0') AS UNSIGNED) + 1
+			WHERE `doctype` = %(dt)s AND `field` = 'agent_catalog_version'""",
+			{"dt": SETTINGS},
+		)
+		conn.sql(
+			"""UPDATE `tabSingles` SET `value` = '1'
+			WHERE `doctype` = %(dt)s AND `field` = 'agent_catalog_dirty'""",
+			{"dt": SETTINGS},
+		)
+		conn.commit()
+	finally:
+		conn.close()
+
+
+class TestAgentCatalogPushTOCTOU(FrappeTestCase):
+	"""#458: the push worker's version recheck must be able to SEE a mutation that
+	landed after its snapshot. Before the fix it re-read its own
+	``frappe.db.value_cache`` entry (and, under REPEATABLE READ, its own
+	transaction snapshot), so the comparison was tautologically equal and a
+	mid-push mutation was silently marked applied."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls._saved = {k: _single(k) for k in _TOCTOU_KEYS}
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for k, v in cls._saved.items():
+			frappe.db.set_single_value(SETTINGS, k, v)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_version", 7)
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_dirty", 1)
+		frappe.db.set_single_value(SETTINGS, "agent_skills_sync_status", "pending: applying agents")
+		# Commit the seed so the worker below opens a CLEAN transaction holding no
+		# row locks the second connection would block on.
+		frappe.db.commit()
+
+	def _push(self, side_effect=None):
+		from jarvis import admin_client
+
+		def _fake_push(agent_skills):
+			if side_effect:
+				side_effect()
+			return {"ok": True}
+
+		with patch.object(admin_client, "post_push_agent_skills", side_effect=_fake_push):
+			agents_api._enqueued_push_agent_skills()
+
+	def test_mid_push_mutation_is_detected_not_marked_applied(self):
+		"""A mutation committed by another connection WHILE the push is in flight
+		leaves ``agent_catalog_dirty`` set, so the SPA keeps showing "Apply
+		pending" and the change is not silently lost."""
+		self._push(side_effect=_concurrent_catalog_mutation)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 8)
+		self.assertEqual(
+			frappe.utils.cint(_single("agent_catalog_dirty")),
+			1,
+			"a mid-push mutation must NOT have its dirty flag cleared by that push",
+		)
+		self.assertTrue(str(_single("agent_skills_sync_status")).startswith("ok ("))
+
+	def test_clean_push_still_clears_the_dirty_flag(self):
+		"""Control: with no mid-push mutation the version is unchanged, so the push
+		clears the flag exactly as before. The fix must not make the flag sticky."""
+		self._push()
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 7)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
+		self.assertTrue(str(_single("agent_skills_sync_status")).startswith("ok ("))
+
+	def test_failed_push_leaves_the_dirty_flag_set(self):
+		"""Control: a terminal failure never clears the flag, and never leaves the
+		status stuck on ``pending:``."""
+		from jarvis import admin_client
+
+		with patch.object(
+			admin_client,
+			"post_push_agent_skills",
+			side_effect=admin_client.AdminUnreachableError("nope"),
+		):
+			agents_api._enqueued_push_agent_skills()
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 1)
+		self.assertTrue(str(_single("agent_skills_sync_status")).startswith("failed: admin unreachable"))
+
+	def test_version_bump_does_not_depend_on_a_previously_read_value(self):
+		"""#458 lost update: the bump is one statement, so it increments whatever
+		the row currently holds. The old read-modify-write took the value from
+		``get_single_value`` (cached / snapshot) and wrote that + 1, which silently
+		discards a concurrent increment. Poisoning the cache with the stale value
+		reproduces exactly that."""
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_version", 5)
+		frappe.db.commit()
+		# The DB row moves to 9 without touching any cache — stand-in for the
+		# increment a concurrent request already committed.
+		frappe.db.sql(
+			"""UPDATE `tabSingles` SET `value` = '9'
+			WHERE `doctype` = %(dt)s AND `field` = 'agent_catalog_version'""",
+			{"dt": SETTINGS},
+		)
+		frappe.db.value_cache[SETTINGS]["agent_catalog_version"] = 5
+		agents_api._bump_catalog_version()
+		self.assertEqual(
+			frappe.utils.cint(_single("agent_catalog_version")),
+			10,
+			"the increment must be applied to the ROW, never to a stale read",
+		)

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -657,3 +657,236 @@ class TestAgentCatalogPushTOCTOU(FrappeTestCase):
 			10,
 			"the increment must be applied to the ROW, never to a stale read",
 		)
+
+
+# --------------------------------------------------------------------------- #
+# #460 — (owner, agent) uniqueness is a DB constraint, not check-then-act
+# --------------------------------------------------------------------------- #
+def _owner_agent_index() -> list[dict]:
+	"""The (owner, agent) index as the DATABASE reports it.
+
+	Read from ``information_schema`` on purpose: ``bench migrate`` exits 0 whether
+	or not ``on_doctype_update`` ever fired, so its exit code proves nothing about
+	whether the constraint exists.
+	"""
+	return frappe.db.sql(
+		"""
+		SELECT INDEX_NAME, NON_UNIQUE, COLUMN_NAME, SEQ_IN_INDEX
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'tabJarvis Agent Installation'
+		  AND INDEX_NAME = 'owner_agent'
+		ORDER BY SEQ_IN_INDEX
+		""",
+		as_dict=True,
+	)
+
+
+def _drop_owner_agent_index() -> None:
+	if _owner_agent_index():
+		frappe.db.sql_ddl("ALTER TABLE `tabJarvis Agent Installation` DROP INDEX `owner_agent`")
+
+
+def _add_owner_agent_index() -> None:
+	frappe.db.add_unique(INSTALLATION, ["owner", "agent"], constraint_name="owner_agent")
+
+
+class TestAgentInstallUniqueIndex(FrappeTestCase):
+	"""#460: the constraint must EXIST, and the racing install must lose to it
+	with the friendly message rather than a 500."""
+
+	SLUG = PREFIX + "uniq"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-uniq-owner@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.set_value(LISTING, cls.SLUG, "status", "Published", update_modified=False)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+
+	def test_owner_agent_unique_index_exists(self):
+		"""A fresh install gets the index from ``on_doctype_update``; an existing
+		site gets it from the v2_13 patch. Either way the DB must report it."""
+		cols = _owner_agent_index()
+		self.assertEqual([c["COLUMN_NAME"] for c in cols], ["owner", "agent"])
+		self.assertEqual({c["NON_UNIQUE"] for c in cols}, {0})
+
+	def test_racing_install_produces_one_row_and_a_friendly_error(self):
+		"""Two concurrent installs of the same agent by one owner: both
+		``frappe.db.exists`` checks return None (exactly what the race achieves,
+		since neither transaction has committed), so the DB constraint is the only
+		thing left. It must yield ONE row and the ordinary "already installed"
+		ValidationError, not an unhandled IntegrityError."""
+		real_exists = frappe.db.exists
+
+		def blind_to_installs(dt, *a, **kw):
+			# Only the (owner, agent) clash lookup is blinded; every other existence
+			# check the insert makes (link validation, etc.) runs for real.
+			if dt == INSTALLATION:
+				return None
+			return real_exists(dt, *a, **kw)
+
+		frappe.set_user(self.owner)
+		try:
+			agents_api.install_agent(self.SLUG)
+			with patch.object(frappe.db, "exists", side_effect=blind_to_installs):
+				with self.assertRaises(frappe.ValidationError) as ctx:
+					agents_api.install_agent(self.SLUG)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertNotIsInstance(ctx.exception, frappe.UniqueValidationError)
+		self.assertIn("already installed", str(ctx.exception))
+		rows = frappe.get_all(
+			INSTALLATION, filters={"owner": self.owner, "agent": self.SLUG}, ignore_permissions=True
+		)
+		self.assertEqual(len(rows), 1)
+
+	def test_ordinary_double_install_still_gets_the_friendly_message(self):
+		"""Control: the non-racing path is unchanged — the check-then-act guard
+		still answers first, so the constraint is never reached."""
+		frappe.set_user(self.owner)
+		try:
+			agents_api.install_agent(self.SLUG)
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agents_api.install_agent(self.SLUG)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn("already installed", str(ctx.exception))
+
+
+class TestAgentInstallDuplicateMerge(FrappeTestCase):
+	"""#460 migration trap: a bench already carrying duplicate rows from the race
+	would hard-fail the ALTER TABLE, so the patch merges first. What it keeps and
+	what it discards is the part that must not be got wrong."""
+
+	SLUG = PREFIX + "dupe"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-dupe-owner@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		# The duplicates this patch exists to clean up predate the constraint, so
+		# seeding them requires it to be absent.
+		frappe.db.commit()
+		_drop_owner_agent_index()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+		_add_owner_agent_index()
+
+	def _seed(self, *, enabled=0, activation_state="shadow", runs=0):
+		# Deliberately NOT via _mk_install: that reuses an existing row, and the
+		# point here is to produce the SECOND row the race would have produced.
+		# ignore_validate blinds validate(), where the check-then-act guard lives —
+		# which is what the race achieves in production.
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": self.SLUG,
+				"run_as_user": self.owner,
+				"reviewer": self.owner,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.flags.ignore_validate = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(
+			INSTALLATION,
+			doc.name,
+			{"owner": self.owner, "enabled": enabled, "activation_state": activation_state},
+			update_modified=False,
+		)
+		for _ in range(runs):
+			_mk_run(doc.name, self.SLUG, self.owner)
+		return doc.name
+
+	def test_merge_keeps_the_live_enabled_row_and_rehomes_the_history(self):
+		"""The keeper is the row whose state is most expensive to reconstruct (live
+		beats shadow, enabled beats disabled), and the loser's runs are re-pointed
+		at it — so promoting/enabling is never silently undone AND no run history
+		is destroyed."""
+		from jarvis.patches import v2_13_unique_agent_installation as patch_mod
+
+		loser = self._seed(enabled=0, activation_state="shadow", runs=2)
+		keeper = self._seed(enabled=1, activation_state="live", runs=0)
+		frappe.db.commit()
+
+		merged = patch_mod._merge_duplicate_installs()
+		frappe.db.commit()
+
+		self.assertEqual(merged, 1)
+		self.assertFalse(frappe.db.exists(INSTALLATION, loser))
+		self.assertTrue(frappe.db.exists(INSTALLATION, keeper))
+		survivor = frappe.db.get_value(INSTALLATION, keeper, ["enabled", "activation_state"], as_dict=True)
+		self.assertEqual(frappe.utils.cint(survivor.enabled), 1)
+		self.assertEqual(survivor.activation_state, "live")
+		# Both of the loser's runs now hang off the keeper: nothing was destroyed.
+		self.assertEqual(frappe.db.count(RUN, {"installation": keeper}), 2)
+		self.assertEqual(frappe.db.count(RUN, {"installation": loser}), 0)
+
+	def test_merge_is_idempotent(self):
+		"""Re-running the cleanup is a no-op: nothing left to merge, and the
+		surviving row is untouched."""
+		from jarvis.patches import v2_13_unique_agent_installation as patch_mod
+
+		self._seed(enabled=0, activation_state="shadow", runs=1)
+		self._seed(enabled=1, activation_state="shadow", runs=1)
+		frappe.db.commit()
+
+		self.assertEqual(patch_mod._merge_duplicate_installs(), 1)
+		frappe.db.commit()
+		before = frappe.get_all(
+			INSTALLATION,
+			filters={"owner": self.owner, "agent": self.SLUG},
+			fields=["name", "enabled", "activation_state"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(len(before), 1)
+
+		self.assertEqual(patch_mod._merge_duplicate_installs(), 0)
+		frappe.db.commit()
+		after = frappe.get_all(
+			INSTALLATION,
+			filters={"owner": self.owner, "agent": self.SLUG},
+			fields=["name", "enabled", "activation_state"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(after, before)
+		self.assertEqual(frappe.db.count(RUN, {"installation": before[0]["name"]}), 2)
+
+	def test_the_alter_table_would_fail_without_the_merge(self):
+		"""Why the ordering is mandatory: with live duplicates present the unique
+		index cannot be created at all, so a patch that skipped the cleanup would
+		hard-fail migrate on exactly the benches that hit the race."""
+		self._seed()
+		self._seed()
+		frappe.db.commit()
+		with self.assertRaises(Exception):
+			_add_owner_agent_index()
+		frappe.db.rollback()
+
+		from jarvis.patches import v2_13_unique_agent_installation as patch_mod
+
+		patch_mod._merge_duplicate_installs()
+		frappe.db.commit()
+		_add_owner_agent_index()
+		self.assertTrue(_owner_agent_index())


### PR DESCRIPTION
## Summary

Three agent-surface defects where a guard existed but did not hold. A push worker's TOCTOU recheck could never observe a mid-push mutation, so a change landing inside the push window was silently marked applied; install uniqueness was check-then-act with no DB constraint, so a double click could leave two rows for one (owner, agent); and the push gate and the run gates disagreed on both identity and status, so a deprecated agent kept dispatching every cadence and failing three hours later as a mislabelled timeout. Customers notice the third one directly: phantom runs that burn the monthly run budget. Admins notice that deprecating a listing now shows "Apply pending" and actually stops the schedule, and that a cross-user run-as mapping is advertised on the same rule that dispatches it. Three commits, one per issue.

<details>
<summary>Root cause</summary>

**#458.** `_enqueued_push_agent_skills` snapshotted `agent_catalog_version`, pushed, then re-read it. `frappe.db.get_single_value` defaults to `cache=True` and serves `frappe.db.value_cache`, which is invalidated only by commit or rollback, and nothing between the two reads commits (`build_agent_push_payload` is pure reads, `admin_client` is pure HTTP). Under REPEATABLE READ the worker's own transaction snapshot hides a concurrently committed write too, so a cache bypass alone would still re-read the snapshot. The comparison was tautologically equal on every run. `_mark_catalog_dirty` also incremented the version with a read-modify-write, so two racing mutations could both write V+1 and the later one looked invisible.

Fix: `frappe.db.commit()` after the push and before the re-read (which ends the transaction and clears the value cache), plus `cache=False` on both reads so the intent survives a later edit. The commit sits at the one point in the worker where nothing has been written, so it commits an empty transaction and cannot leave a half-written state, and it is after the push so it cannot record a success that did not happen. The `redis_lock` scope, the terminal write and the try/except/finally that guarantees a terminal status are unchanged. The version bump is now a single `UPDATE ... SET value = value + 1` on the `tabSingles` row.

**#460.** `jarvis_agent_installation._validate_unique_per_owner` and `install_agent` both did `frappe.db.exists` then `frappe.throw`. The doctype is `autoname: hash` / `naming_rule: Random` with no `unique` field, so nothing at the DB level serialized two concurrent installs: both saw no clash and both committed under distinct names, inflating `install_count` and leaving a phantom row that kept rendering the agent as installed after one uninstall.

Fix: a composite unique index `owner_agent` in `on_doctype_update()`, following `jarvis_user_model_usage`, so a fresh install gets it at doctype creation (patches are marked done without running under `install_app(set_as_patched=True)`). `install_agent` translates the race-triggered `UniqueValidationError` into the same friendly "already installed" message. Patch `v2_13_unique_agent_installation` covers the existing site, where a `.py`-only change never fires the hook: `bench migrate` re-imports a DocType only when its `.json` changes, so migrate would exit 0 with no index. The patch reloads the doctype with `force=True` and calls `add_unique` directly.

The patch merges duplicates first, because `ALTER TABLE` hard-fails on any bench already carrying rows from this exact race. The keeper is the row whose state is most expensive to reconstruct: live beats shadow (reaching live costs a reviewer sign-off and a slot under the PP-6 ceiling), then enabled, then scheduled, then run count, then oldest, then name for determinism. Nothing is destroyed but the redundant row: every loser's runs, provenance events and activity rows are re-pointed at the keeper first, so findings stay reachable and no installation history is lost.

**#457.** The push emitted a slug when the listing was Published AND the install OWNER's roles permitted it (`agent_catalog.py`). The dispatch gates checked only the RUN-AS user's roles and never looked at status (`agent_scheduler.py`, `agents_api.py`). `listing.status` was read solely by `install_agent`, and `set_listing_status` did not mark the catalog dirty. So an admin deprecating an installed, enabled, scheduled auditor got the slug reconciled out of the roster on the next Apply while every cadence still dispatched: openclaw rejects the unknown agent id, the completion writeback never fires because the delegate never starts, and the run sits `running` for three hours until the stale-run sweep terminalizes it with the wrong error.

Fix: status is checked in `_launch_audit`, the choke point both dispatch paths funnel through, plus an explicit skip in the scheduler loop that records why and CONSUMES the slot (a throw out of `_launch_audit` lands in the generic handler, which does not advance, so the cadence would retry hourly and log an error each time for a state only a human can fix) and an early refusal in `run_agent_now` before any budget slot or source-app write. `set_listing_status` marks the catalog dirty when the change can alter the payload. Identity is settled by gotcha #8, the module's own stated principle that the EXECUTING identity is gated, not the triggerer: the push now gates on `run_as_user`.

For every self-mapped install, which is every install created through `install_agent`, that changes nothing, since `run_as_user` defaults to the installer. It moves only cross-user mappings, which an admin sets deliberately: an install whose owner lost the restricting role while the run-as user kept it is now advertised, and it was already being dispatched; the mirror case is now dropped, and it was never runnable.

Deliberately not in this PR: wiring `admin_client.get_agent_run_status` (zero callers today) into the dispatch path. It would shorten the phantom window, but it is a cross-plane polling contract, not a gate alignment.

</details>

## Tests

22 new tests in `jarvis.tests.test_platform_agents_api_hardening`, across six classes. Each fix was reverted in turn and the tests confirmed failing before being restored: the mid-push mutation is silently marked applied, the racing install leaves two rows with no error (and an unhandled `UniqueValidationError` once the index exists but the translation is removed), the deprecated agent dispatches on the cron, and `set_listing_status` leaves the catalog clean.

The index was verified from `information_schema` on a real bench, not from migrate's exit code, and separately after dropping it and running only `reload_doc(force=True)` to prove `on_doctype_update` is what creates it.

One pre-existing fixture in `test_app_learning_agent` reused an existing synthetic listing without re-asserting `status`. Any module running `sync_agent_listings` retires that slug to Deprecated, so the fixture had silently stopped meaning "a published scribe"; it now re-asserts both fields.

Closes #457
Closes #458
Closes #460

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (based on `726ac15e`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
