### PR TITLE
onboarding: route a recovered checkout to Pay instead of a container that does not exist

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2109,6 +2109,21 @@ async function submitReconnectCode() {
 			state.step = "connect";
 			return;
 		}
+		if (d && d.status === "resume_payment") {
+			// Recovered an UNFINISHED checkout, not a live workspace (admin-v2 #162):
+			// there is no container, so the Connect shortcut above would strand this
+			// customer on a workspace that never appears. What the code bought them is
+			// the ability to AUTHENTICATE, which is the one thing the resume path was
+			// missing - so hand off to the same mount reconciliation a reload runs and
+			// let server truth place the step.
+			state.payBusy = false;
+			await reconcileMidFlightSignup();
+			// Reconciliation lands a mid-signup customer on Pay from real state. If it
+			// established none (a control-plane blip), Details is still forward progress
+			// and never a spinner - the credentials are persisted either way.
+			if (state.step === "reconnect") state.step = "details";
+			return;
+		}
 		state.payErr =
 			d && d.status === "expired"
 				? "The reconnect request expired. Start it again."

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -1241,16 +1241,25 @@ def reconnect_available(email: str, company: str = "") -> dict:
 	CLOSED: any admin-side error answers "not available" rather than raising, because
 	this only decides whether to show a hint - a wizard that breaks because the
 	control plane blipped would be a worse trade than a hint that stays hidden.
-	Same System-Manager gating as the rest of onboarding."""
+	Same System-Manager gating as the rest of onboarding.
+
+	``company_account_exists`` is the separate, weaker answer to a separate
+	question (admin-v2 #166): somebody ELSE at this company already has an account.
+	It is not a reconnect offer and must not be rendered as one - this caller
+	cannot recover a colleague's account, and admin will not tell them whose it is.
+	False on an older admin that does not send the key, which is the safe default.
+	"""
 	require_jarvis_admin()
+	blank = {"eligible": False, "needs_company": False, "company_account_exists": False}
 	try:
 		_require_admin_url()
 		d = admin_client.reconnect_eligibility(email, company) or {}
 	except Exception:
-		return {"eligible": False, "needs_company": False}
+		return blank
 	return {
 		"eligible": bool(d.get("eligible")),
 		"needs_company": bool(d.get("needs_company")),
+		"company_account_exists": bool(d.get("company_account_exists")),
 	}
 
 
@@ -1273,9 +1282,24 @@ def check_account_reconnect(request_id: str, code: str = "") -> dict:
 	"""Redeem the reconnect code the customer received by email (or from
 	support). Only a correct code releases anything: admin then rotates and
 	delivers the credentials — persist them and
-	grant the onboarding admin role, exactly like a fresh signup would. The
-	wizard then rides the normal sync_connection path to the customer's
-	EXISTING container; only the LLM step needs re-doing on this fresh site."""
+	grant the onboarding admin role, exactly like a fresh signup would.
+
+	Two outcomes, because there are two things a reconnect can recover
+	(admin-v2 #162):
+
+	- ``connected`` - a PAID account whose container is already running. The
+	  wizard rides the normal sync_connection path to it; only the LLM step
+	  needs re-doing on this fresh site.
+	- ``resume_payment`` - an UNFINISHED checkout (declined card, interrupted
+	  payment). There is no container, so sync_connection has nothing to reach
+	  and the wizard would sit on "setting up your workspace" forever. What was
+	  recovered is the ability to authenticate, which is precisely what
+	  ``resume_pending_signup`` needs, so the wizard goes back to Pay.
+
+	Read off admin's ``subscription_status``. An admin that predates that key
+	sends nothing and this answers ``connected``, which is exactly what it
+	answered before and is right for the only population that admin can
+	reconnect."""
 	require_jarvis_admin()
 	data = _surface(admin_client.get_reconnect_state, request_id, code) or {}
 	if data.get("status") != "ready":
@@ -1298,6 +1322,8 @@ def check_account_reconnect(request_id: str, code: str = "") -> dict:
 		}
 	)
 	grant_onboarding_admin()
+	if (data.get("subscription_status") or "").strip() == "Pending Payment":
+		return {"status": "resume_payment"}
 	return {"status": "connected"}
 
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1968,9 +1968,7 @@ class TestAccountReconnect(FrappeTestCase):
 			side_effect=RuntimeError("control plane down"),
 		):
 			out = onboarding.reconnect_available("a@b.example")
-		self.assertEqual(
-			out, {"eligible": False, "needs_company": False, "company_account_exists": False}
-		)
+		self.assertEqual(out, {"eligible": False, "needs_company": False, "company_account_exists": False})
 
 	def test_check_expired_passthrough(self):
 		with patch(

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1891,6 +1891,87 @@ class TestAccountReconnect(FrappeTestCase):
 			onboarding.check_account_reconnect("rid-1", "ABCD2345")
 		poll.assert_called_once_with("rid-1", "ABCD2345")
 
+	def test_check_ready_on_a_pending_payment_account_routes_to_the_payment_resume(self):
+		"""admin-v2 #162. There is no container behind a recovered checkout, so
+		answering "connected" sends the wizard to sync_connection and it waits on a
+		workspace that never appears. Credentials are persisted either way - what
+		changes is only where the customer is put down."""
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={
+				"status": "ready",
+				"api_key": "pp-key",
+				"api_secret": "pp-secret",
+				"customer": "cust-abc@jarvis.invalid",
+				"customer_password": "pp-pass",
+				"subscription_status": "Pending Payment",
+			},
+		):
+			out = onboarding.check_account_reconnect("rid-1")
+		self.assertEqual(out["status"], "resume_payment")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False), "pp-key")
+
+	def test_an_active_subscription_status_still_connects(self):
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={
+				"status": "ready",
+				"api_key": "a-key",
+				"api_secret": "a-secret",
+				"customer": "cust-def@jarvis.invalid",
+				"customer_password": "a-pass",
+				"subscription_status": "Active",
+			},
+		):
+			out = onboarding.check_account_reconnect("rid-1")
+		self.assertEqual(out["status"], "connected")
+
+	def test_an_admin_that_never_sends_the_key_still_connects(self):
+		"""Forward compatibility runs one way only: this bench may talk to an admin
+		older than the key. Absent must mean the behaviour that shipped before it."""
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={
+				"status": "ready",
+				"api_key": "o-key",
+				"api_secret": "o-secret",
+				"customer": "cust-ghi@jarvis.invalid",
+				"customer_password": "o-pass",
+			},
+		):
+			out = onboarding.check_account_reconnect("rid-1")
+		self.assertEqual(out["status"], "connected")
+
+	def test_eligibility_forwards_the_same_company_hint(self):
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility",
+			return_value={"eligible": False, "needs_company": False, "company_account_exists": True},
+		):
+			out = onboarding.reconnect_available("someone@acme.example", "Acme")
+		self.assertTrue(out["company_account_exists"])
+		self.assertFalse(out["eligible"], "a colleague's account is NOT this caller's to reconnect")
+
+	def test_eligibility_defaults_the_company_hint_to_false(self):
+		# An older admin sends no such key, and a control-plane failure sends nothing
+		# at all. Both must read as "say nothing", never as "yes".
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility",
+			return_value={"eligible": True, "needs_company": False},
+		):
+			self.assertFalse(onboarding.reconnect_available("a@b.example")["company_account_exists"])
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility",
+			side_effect=RuntimeError("control plane down"),
+		):
+			out = onboarding.reconnect_available("a@b.example")
+		self.assertEqual(
+			out, {"eligible": False, "needs_company": False, "company_account_exists": False}
+		)
+
 	def test_check_expired_passthrough(self):
 		with patch(
 			"jarvis.onboarding.admin_client.get_reconnect_state",


### PR DESCRIPTION
## Summary

Customer-plane half of Aerele-RnD/jarvis-admin-v2#162 and #166. A customer whose card was declined and who then rebuilt their bench can now be reconnected by admin, and this bench has to put them down in the right place: a recovered checkout has no container, so the old "connected" answer sent the wizard down `sync_connection` and it waited on a workspace that never appears.

`check_account_reconnect` reads admin's new `subscription_status` and answers `resume_payment` for a `Pending Payment` account. The wizard hands that to the same mount reconciliation a reload runs and lets server truth place the step, which is Pay: the credentials the code just restored are exactly what `resume_pending_signup` was missing.

`reconnect_available` also forwards `company_account_exists` (#166), so the wizard can say "somebody else at this company already has an account". That is not a reconnect offer and must not be rendered as one: this caller cannot recover a colleague's account, and admin will not say whose it is.

**Merge order: this PR merges BEFORE admin-v2 #225.** Both new keys default to the behaviour that shipped before them, so this bench is safe against an older admin. The reverse order is not safe: it lets an older bench redeem a `Pending Payment` account and strand it.

<details>
<summary>Root cause</summary>

`check_account_reconnect` had exactly one success answer, `connected`, because admin's `_ELIGIBLE_STATUSES` was `("Active", "Suspended")` and every reconnectable account therefore had a live tenant. admin-v2 #225 widens that to `Pending Payment` for the failed-payment population, whose whole problem is that `resume_pending_signup` authenticates with the api_key/api_secret the first signup response wrote into a bench that no longer exists. Those accounts have no container by definition, so the single answer stopped being sufficient the moment admin could hand one back.

The SPA branch is placed after the `connected` branch rather than instead of it, and falls through to Details if reconciliation could not establish any server state. Credentials are persisted before either branch runs, so no path here can leave the site unauthenticated, and none of them is a spinner.

The `company_account_exists` forward is deliberately a plain boolean with no identity attached. Admin gates the disclosure on a shared non-consumer mail domain and never names the other account; this wrapper adds nothing and defaults it to false on an older admin or any control-plane failure.
</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on a failure)
- [x] Branch is up to date with `develop` (based on `e887aeb9`, current head)
- [x] New/changed behavior has tests (`TestAccountReconnect`, 11 passing, revert-proofed)
- [x] I self-reviewed the diff

Blocks Aerele-RnD/jarvis-admin-v2#225, which must merge after this.

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
