### PR TITLE
test: pin the v2_12 index reload patches and the learned-miss audit throttle

### DIFF
--- a/jarvis/tests/test_index_reload_patches.py
+++ b/jarvis/tests/test_index_reload_patches.py
@@ -1,0 +1,205 @@
+"""The two v2_12 index-reload patches, pinned to the thing they actually promise.
+
+The trap they exist for: ``on_doctype_update()`` runs only when the DocType
+DOCUMENT is saved (doctype.py calls ``run_module_method("on_doctype_update")``
+from ``on_update``), and ``bench migrate`` re-imports a DocType only when its
+``.json`` changes. Both index PRs edited ``.py`` controllers only, so on a real
+bench the hook never fired, ``migrate`` exited 0, and the indexes silently never
+existed. That is why "the patch runs without error" is NOT the contract worth
+testing. The contract is:
+
+    after the patch runs, the indexes EXIST -- and if they were absent, the
+    patch is what created them.
+
+So each test DROPS the real index, proves from ``information_schema`` that it is
+gone, runs ``execute()``, and proves it is back. Anything weaker would pass
+against a patch body of ``pass`` on a site whose indexes already existed, which
+is precisely the false green these patches were written to end.
+
+``information_schema.STATISTICS`` rather than ``SHOW INDEX``: Frappe table names
+contain spaces, so column-position parsing of ``SHOW INDEX`` output silently
+reads the wrong field.
+
+Isolation: dropping an index is DDL on a shared table, and DDL implicitly
+commits in MariaDB, so the framework's end-of-class rollback cannot undo it.
+Every index this module touches is therefore restored in ``tearDown``, which
+runs whether or not the test body raised, and again in ``tearDownClass`` as a
+backstop against a crash between the drop and the restore.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.patches import v2_12_reload_agent_doctypes_for_indexes as agent_patch
+from jarvis.patches import v2_12_reload_macro_doctypes_for_indexes as macro_patch
+
+# (doctype, index name, columns in SEQ_IN_INDEX order). Verified against a real
+# bench with:
+#   SELECT TABLE_NAME, INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX)
+#   FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() ...
+AGENT_INDEXES = (
+	("Jarvis Agent Finding", "owner_agent_fingerprint_index", ["owner", "agent", "fingerprint"]),
+	("Jarvis Agent Finding", "owner_severity_state_index", ["owner", "severity", "state"]),
+	("Jarvis Agent Run", "owner_started_creation_index", ["owner", "started_at", "creation"]),
+)
+MACRO_INDEXES = (
+	("Jarvis Macro Run", "owner_creation_index", ["owner", "creation"]),
+	("Jarvis Macro", "owner_macro_name_index", ["owner", "macro_name"]),
+)
+
+
+def _index_columns(doctype: str, index_name: str) -> list[str]:
+	"""The index's columns as the DATABASE reports them, in index order.
+
+	Empty list means the index does not exist.
+	"""
+	return frappe.db.sql(
+		"""
+		SELECT COLUMN_NAME
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = %s
+		  AND INDEX_NAME = %s
+		ORDER BY SEQ_IN_INDEX
+		""",
+		(f"tab{doctype}", index_name),
+		pluck=True,
+	)
+
+
+def _index_names(doctype: str) -> set[str]:
+	return set(
+		frappe.db.sql(
+			"""
+			SELECT DISTINCT INDEX_NAME
+			FROM information_schema.STATISTICS
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s
+			""",
+			(f"tab{doctype}",),
+			pluck=True,
+		)
+	)
+
+
+def _drop_index(doctype: str, index_name: str) -> None:
+	if _index_columns(doctype, index_name):
+		frappe.db.sql_ddl(f"ALTER TABLE `tab{doctype}` DROP INDEX `{index_name}`")
+
+
+def _restore_index(doctype: str, index_name: str, columns: list[str]) -> None:
+	if not _index_columns(doctype, index_name):
+		frappe.db.add_index(doctype, columns, index_name=index_name)
+
+
+class _ReloadPatchChecks:
+	"""Shared body, deliberately NOT a TestCase.
+
+	Mixed into the two concrete cases below rather than subclassed from
+	FrappeTestCase, because a TestCase base is itself collected and would run
+	every test a second time against an unbound patch.
+	"""
+
+	PATCH = None
+	INDEXES = ()
+
+	@classmethod
+	def _restore_all(cls):
+		for doctype, index_name, columns in cls.INDEXES:
+			_restore_index(doctype, index_name, columns)
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		# Baseline for the whole class: whatever a previous crash left behind, the
+		# indexes are present before the first test drops anything.
+		cls._restore_all()
+
+	@classmethod
+	def tearDownClass(cls):
+		cls._restore_all()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		# Unconditional: a failing assertion between the DROP and the patch call
+		# must not leave the shared table without its index.
+		self._restore_all()
+
+	def test_patch_recreates_every_dropped_index(self):
+		"""Drop them all, prove they are gone, run the patch, prove they are back.
+
+		This is the whole point: ``reload_doc`` re-saves the DocType document,
+		which is what fires ``on_doctype_update`` and therefore what creates the
+		indexes on an EXISTING site.
+		"""
+		for doctype, index_name, _columns in self.INDEXES:
+			_drop_index(doctype, index_name)
+		for doctype, index_name, _columns in self.INDEXES:
+			self.assertEqual(
+				_index_columns(doctype, index_name),
+				[],
+				f"{index_name} on {doctype} should have been dropped before the patch runs",
+			)
+
+		self.PATCH.execute()
+
+		for doctype, index_name, columns in self.INDEXES:
+			self.assertEqual(
+				_index_columns(doctype, index_name),
+				columns,
+				f"{index_name} on {doctype} was not recreated by the patch",
+			)
+
+	def test_running_twice_neither_errors_nor_duplicates(self):
+		"""Patches re-run: ``bench migrate`` on a site that already applied this one
+		still executes it after a reinstall, and a failed migrate is resumed. Two
+		back-to-back runs must leave the table with exactly the indexes it had,
+		with no second copy under a generated name.
+		"""
+		before = {doctype: _index_names(doctype) for doctype, _n, _c in self.INDEXES}
+
+		self.PATCH.execute()
+		self.PATCH.execute()
+
+		for doctype, index_name, columns in self.INDEXES:
+			self.assertEqual(_index_columns(doctype, index_name), columns)
+			self.assertEqual(
+				_index_names(doctype),
+				before[doctype],
+				f"a second run of the patch changed the index set on {doctype}",
+			)
+
+	def test_patch_is_registered_in_patches_txt(self):
+		"""An unregistered patch never runs, which reproduces the exact silent
+		failure it was written to fix."""
+		entries = {
+			line.strip()
+			for line in frappe.get_file_items(frappe.get_app_path("jarvis", "patches.txt"))
+			if line.strip()
+		}
+		self.assertIn(f"jarvis.patches.{self.PATCH.__name__.rsplit('.', 1)[-1]}", entries)
+
+	def test_every_named_doctype_actually_defines_the_hook(self):
+		"""``reload_doc`` on a doctype with no ``on_doctype_update`` is a no-op that
+		still looks like a successful patch. Pin the patch's DOCTYPES list to
+		modules that really carry the hook, so a rename cannot quietly empty it."""
+		for scrubbed in self.PATCH.DOCTYPES:
+			module = frappe.get_module(f"jarvis.jarvis.doctype.{scrubbed}.{scrubbed}")
+			self.assertTrue(
+				callable(getattr(module, "on_doctype_update", None)),
+				f"{scrubbed} is named by the patch but defines no on_doctype_update",
+			)
+
+
+class TestReloadAgentDoctypesForIndexes(_ReloadPatchChecks, FrappeTestCase):
+	PATCH = agent_patch
+	INDEXES = AGENT_INDEXES
+
+
+class TestReloadMacroDoctypesForIndexes(_ReloadPatchChecks, FrappeTestCase):
+	PATCH = macro_patch
+	INDEXES = MACRO_INDEXES

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -508,6 +508,10 @@ class TestLearnedMissAudit(SkillToolsTestCase):
 		halves can fail independently on a real bench (redis down, Error Log
 		table full), so break each one separately."""
 		slug = self._slug("never-raises")
+		# A separate slug for the caller-level check below: the broken-log call
+		# above still WROTE the throttle key (the cache succeeded, the log did
+		# not), so reusing that slug would take the early return and prove nothing.
+		caller_slug = self._slug("broken-log")
 
 		with patch.object(frappe, "cache", side_effect=RuntimeError("redis is down")):
 			_audit_learned_miss(slug, OWNER, "unknown")
@@ -519,8 +523,7 @@ class TestLearnedMissAudit(SkillToolsTestCase):
 		with patch.object(frappe, "log_error", side_effect=RuntimeError("error log is full")):
 			with _as(OWNER):
 				with self.assertRaises(InvalidArgumentError):
-					get_skill(f"{_LEARNED_PREFIX}{PFX}-broken-log")
-		self._forget(f"{_LEARNED_PREFIX}{PFX}-broken-log")
+					get_skill(caller_slug)
 
 	def test_get_skill_audits_a_learned_miss_and_only_a_learned_miss(self):
 		"""Wire check: the audit fires from the real tool path, on the branch that

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -10,6 +10,9 @@ feature — at load time.
 """
 
 import contextlib
+import os
+import shutil
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -24,7 +27,13 @@ from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
 from jarvis.tools.create_custom_skill import create_custom_skill
 from jarvis.tools.find_skills import find_skills
-from jarvis.tools.get_skill import get_skill
+from jarvis.tools.get_skill import (
+	_LEARNED_PREFIX,
+	_MISS_AUDIT_PREFIX,
+	_MISS_AUDIT_TTL_S,
+	_audit_learned_miss,
+	get_skill,
+)
 
 SKILL = "Jarvis Custom Skill"
 # All fixture slugs share this prefix so leftovers from committed runs are
@@ -36,6 +45,13 @@ PEER = "sttool-peer@example.com"
 THIRD = "sttool-third@example.com"
 WEB = "sttool-web@example.com"
 
+ERROR_LOG = "Error Log"
+AUDIT_TITLE = "Jarvis: learned skill fetch missed"
+# Two stand-ins for "two tenant benches sharing one redis". Never real sites:
+# the point is only that ``frappe.local.site`` differs between the two calls.
+AUDIT_SITE_A = "sttool-tenant-a.test"
+AUDIT_SITE_B = "sttool-tenant-b.test"
+
 
 @contextlib.contextmanager
 def _as(user: str):
@@ -45,6 +61,23 @@ def _as(user: str):
 		yield
 	finally:
 		frappe.set_user(orig)
+
+
+@contextlib.contextmanager
+def _site(name: str):
+	"""Run a block as if this process were serving another tenant's site.
+
+	Safe to do mid-test: Frappe's own cache namespacing keys off
+	``frappe.local.conf.db_name`` (RedisWrapper.make_key), not off
+	``frappe.local.site``, so swapping the site name moves nothing except the
+	hand-built key under test.
+	"""
+	orig = frappe.local.site
+	frappe.local.site = name
+	try:
+		yield
+	finally:
+		frappe.local.site = orig
 
 
 @contextlib.contextmanager
@@ -342,6 +375,168 @@ class TestGetSkill(SkillToolsTestCase):
 		_make_skill(PEER, f"{PFX}-dup-name", "sttool dup peer copy", scope="User")
 		with _as(PEER):
 			self.assertEqual(get_skill(f"{PFX}-dup-name")["description"], "sttool dup peer copy")
+
+
+class TestLearnedMissAudit(SkillToolsTestCase):
+	"""``_audit_learned_miss``: the throttled Error Log row for a missed
+	``learned-`` fetch, and specifically its SITE SCOPING.
+
+	The throttle key is built by hand as ``<prefix><site>:<slug>`` because the
+	raw redis ``set`` it uses is NOT namespaced the way ``frappe.cache().
+	set_value`` is (RedisWrapper.make_key prefixes with ``conf.db_name``;
+	``redis.Redis.set`` prefixes with nothing). Every tenant bench on a shared
+	redis carries the SAME handful of learned slugs, so without that qualifier
+	the first tenant to miss ``learned-selling`` would silence every other
+	tenant's audit row for ten minutes. That is a cross-tenant observability
+	failure whose only symptom is a row that never appears, so nothing but a
+	test can hold the qualifier in place.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# ``frappe.log_error`` calls the telemetry hook first, and that hook always
+		# fails outside a request (``frappe.request`` is unbound), which sends it
+		# down ``frappe.logger().error(...)`` -- a SITE-scoped rotating file
+		# handler. Under a site name with no ``logs/`` directory that handler
+		# cannot be constructed, the FileNotFoundError escapes log_error, and no
+		# Error Log row is ever written. So give the two stand-in tenants the one
+		# directory frappe insists on, and take it away again afterwards.
+		for site in (AUDIT_SITE_A, AUDIT_SITE_B):
+			os.makedirs(os.path.join(frappe.local.sites_path, site, "logs"), exist_ok=True)
+
+	@classmethod
+	def tearDownClass(cls):
+		for site in (AUDIT_SITE_A, AUDIT_SITE_B):
+			shutil.rmtree(os.path.join(frappe.local.sites_path, site), ignore_errors=True)
+		super().tearDownClass()
+
+	def _key(self, site: str, slug: str) -> str:
+		return f"{_MISS_AUDIT_PREFIX}{site}:{slug}"
+
+	def _forget(self, slug: str) -> None:
+		"""Clear every key shape this slug could occupy.
+
+		Includes the UNQUALIFIED shape a regression would write, so that running
+		this suite against a reverted ``get_skill`` still leaves redis clean.
+		"""
+		cache = frappe.cache()
+		keys = [f"{_MISS_AUDIT_PREFIX}{slug}"]
+		keys += [self._key(s, slug) for s in (frappe.local.site, AUDIT_SITE_A, AUDIT_SITE_B)]
+		for key in keys:
+			cache.delete(key)
+
+	def _audit_rows(self, slug: str) -> list[dict]:
+		return frappe.get_all(
+			ERROR_LOG,
+			filters={"method": AUDIT_TITLE, "error": ["like", f"%{slug}%"]},
+			fields=["name", "error"],
+			ignore_permissions=True,
+		)
+
+	def _drop_audit_rows(self, slug: str) -> None:
+		for row in self._audit_rows(slug):
+			frappe.delete_doc(ERROR_LOG, row["name"], force=True, ignore_permissions=True)
+
+	def _slug(self, suffix: str) -> str:
+		"""A learned slug that starts every test with an empty throttle and an
+		empty audit trail, and leaves both empty afterwards."""
+		slug = f"{_LEARNED_PREFIX}{PFX}-{suffix}"
+		self._forget(slug)
+		self._drop_audit_rows(slug)
+		self.addCleanup(self._drop_audit_rows, slug)
+		self.addCleanup(self._forget, slug)
+		return slug
+
+	def test_two_sites_each_get_their_own_audit_row(self):
+		"""THE regression: the same slug missed on two different sites must log
+		TWICE. Drop ``frappe.local.site`` from the key and site B's row silently
+		disappears into site A's throttle."""
+		slug = self._slug("cross-site")
+
+		with _site(AUDIT_SITE_A):
+			_audit_learned_miss(slug, OWNER, "unknown")
+		with _site(AUDIT_SITE_B):
+			_audit_learned_miss(slug, OWNER, "denied")
+
+		self.assertEqual(
+			len(self._audit_rows(slug)),
+			2,
+			"one tenant's throttle swallowed another tenant's audit row",
+		)
+		# And the keys really are distinct, so neither site is reading the other's.
+		# ``shared=True`` because RedisWrapper.exists() DOES run make_key while the
+		# raw ``set`` under test does not: that asymmetry is the whole reason the
+		# site qualifier has to be written by hand.
+		cache = frappe.cache()
+		self.assertTrue(cache.exists(self._key(AUDIT_SITE_A, slug), shared=True))
+		self.assertTrue(cache.exists(self._key(AUDIT_SITE_B, slug), shared=True))
+
+	def test_second_miss_on_the_same_site_is_throttled(self):
+		"""Within one site the throttle still does its job: a tenant whose two role
+		checks disagree on every turn gets one row, not one per turn."""
+		slug = self._slug("throttled")
+
+		with _site(AUDIT_SITE_A):
+			_audit_learned_miss(slug, OWNER, "unknown")
+			_audit_learned_miss(slug, OWNER, "denied")
+
+		rows = self._audit_rows(slug)
+		self.assertEqual(len(rows), 1)
+		# The surviving row is the FIRST miss (nx=True never overwrites), and it
+		# carries the reason and the caller, which is the whole diagnostic value.
+		self.assertIn("unknown", rows[0]["error"])
+		self.assertIn(OWNER, rows[0]["error"])
+		# A key with no expiry would silence the audit forever, not for a window.
+		ttl = frappe.cache().ttl(self._key(AUDIT_SITE_A, slug))
+		self.assertGreater(ttl, 0)
+		self.assertLessEqual(ttl, _MISS_AUDIT_TTL_S)
+
+	def test_a_non_learned_slug_is_ignored_entirely(self):
+		"""Narrow on purpose. A missed ``custom-`` slug is usually just the model
+		guessing a name, so it must not reach the cache OR the log."""
+		slug = f"custom-{PFX}-never-audited"
+		self.addCleanup(self._drop_audit_rows, slug)
+
+		with patch.object(frappe, "cache") as fake_cache:
+			_audit_learned_miss(slug, OWNER, "unknown")
+			fake_cache.assert_not_called()
+		self.assertEqual(self._audit_rows(slug), [])
+
+	def test_a_broken_cache_or_log_never_reaches_the_caller(self):
+		"""The docstring's promise: an audit row must not fail a tool call. Both
+		halves can fail independently on a real bench (redis down, Error Log
+		table full), so break each one separately."""
+		slug = self._slug("never-raises")
+
+		with patch.object(frappe, "cache", side_effect=RuntimeError("redis is down")):
+			_audit_learned_miss(slug, OWNER, "unknown")
+		with patch.object(frappe, "log_error", side_effect=RuntimeError("error log is full")):
+			_audit_learned_miss(slug, OWNER, "unknown")
+
+		# And through the real caller: the tool still fails the way it is supposed
+		# to, with its own error, not with the audit's.
+		with patch.object(frappe, "log_error", side_effect=RuntimeError("error log is full")):
+			with _as(OWNER):
+				with self.assertRaises(InvalidArgumentError):
+					get_skill(f"{_LEARNED_PREFIX}{PFX}-broken-log")
+		self._forget(f"{_LEARNED_PREFIX}{PFX}-broken-log")
+
+	def test_get_skill_audits_a_learned_miss_and_only_a_learned_miss(self):
+		"""Wire check: the audit fires from the real tool path, on the branch that
+		matters, and stays silent on the branch that does not."""
+		learned = self._slug("wire-learned")
+		custom = f"custom-{PFX}-wire-miss"
+		self.addCleanup(self._drop_audit_rows, custom)
+
+		with _as(OWNER):
+			with self.assertRaises(InvalidArgumentError):
+				get_skill(learned)
+			with self.assertRaises(InvalidArgumentError):
+				get_skill(custom)
+
+		self.assertEqual(len(self._audit_rows(learned)), 1)
+		self.assertEqual(self._audit_rows(custom), [])
 
 
 class TestCreateCustomSkill(SkillToolsTestCase):


### PR DESCRIPTION
## Summary

Adds coverage for two previously unpinned contracts and changes no production code.

**The v2_12 index reload patches** (`jarvis/tests/test_index_reload_patches.py`, new).
They exist because `on_doctype_update()` fires only when the DocType *document* is saved,
so a `bench migrate` that sees no `.json` change leaves the indexes missing and still exits
0. "The patch runs without error" would pass against a body of `pass`, so each test instead
DROPs the real index, proves from `information_schema.STATISTICS` that it is gone, runs
`execute()`, and proves it is back with the right columns in order. All five indexes across
the four doctypes are covered, plus idempotency, `patches.txt` registration, and that every
doctype the patch names really defines the hook. Verified to fail (`[] != ['owner', 'agent',
'fingerprint']`) against a no-op `execute()`.

**The learned-miss audit throttle** (`TestLearnedMissAudit` in `test_skill_tools.py`).
`_audit_learned_miss` site-qualifies its cache key by hand because the raw redis `set` is not
namespaced the way `set_value` is, and every tenant bench shares the same learned slugs.
Without the qualifier one tenant's throttle silences another's audit row. The test logs one
slug under two `frappe.local.site` values and requires two Error Log rows; verified to fail
(`1 != 2`) with the qualifier removed. Throttling within one site, the `learned-` narrowness,
and the never-raises guarantee are covered too.

Index DDL is restored in `tearDown` and again in `tearDownClass`, since DDL implicitly commits.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on X)
- [ ] Branch is **up to date with `develop`**
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
