### PR TITLE
fix(agents): validate schedule_time and fault-isolate the hourly agent sweep

### DIFF
--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -87,155 +87,181 @@ def run_due_agent_audits() -> None:
 	if not due:
 		return
 
-	from jarvis.chat.agents_api import _user_allowed_for_agent
-
 	original_user = frappe.session.user
 	seen: set = set()  # O7: dedupe identical (owner, agent, cadence, time)
 	for row in due:
-		key = (row.owner, row.agent, row.schedule_frequency, str(row.schedule_time))
-		if key in seen:
-			_advance(row, now)
-			continue
-		seen.add(key)
-
-		# R5-J8: never dispatch a scheduled run for a non-installable capability. A
-		# reconcile marks an install installable=0 when a min_apps dependency
-		# disappeared after install (the row is kept, not deleted); its run has no
-		# data. Record why + consume the slot so the cadence does not busy-retry.
-		if not frappe.utils.cint(row.installable):
-			_record_failed(
-				row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)"
-			)
-			_advance(row, now)
-			continue
-
-		# Only auditor + scribe agents run scheduled scans; an operator install
-		# with a schedule set just consumes its slot (it drafts through the board,
-		# not on a cron). A scribe's schedule is optional (manual run-now is the
-		# primary path) but honoured here when set, so periodic re-learning works.
-		listing = (
-			frappe.db.get_value(LISTING, row.agent, ["nature", "status"], as_dict=True) or frappe._dict()
-		)
-		nature = listing.get("nature")
-		if nature not in ("Auditor", "Scribe"):
-			_advance(row, now)
-			continue
-
-		# #457: an admin who deprecates a listing must stop its schedules. The push
-		# already drops an unpublished agent from the roster, so the container has no
-		# such delegate and a dispatched run can only fail three hours later as a
-		# mislabelled timeout. ``_launch_audit`` is the authoritative gate, but refuse
-		# HERE too and consume the slot: a throw out of _launch_audit lands in the
-		# generic except below, which does NOT advance, so the cadence would retry
-		# hourly and write an Error Log every time for a state only a human can fix.
-		if (listing.get("status") or "") != "Published":
-			_record_failed(
-				row,
-				"scheduled run skipped: this agent is no longer published "
-				f"({listing.get('status') or 'unknown'}); uninstall it or ask an admin to republish it",
-			)
-			_advance(row, now)
-			continue
-
-		# CX5-5: a scribe writes the LIVE Org wiki with no confirmation gate, so there is
-		# no such thing as a shadow scribe run — refuse it here exactly as the manual path
-		# does, and consume the slot so the cadence does not busy-retry.
-		if nature == "Scribe" and (row.get("activation_state") or "shadow") == "shadow":
-			_record_failed(
-				row,
-				"scheduled run skipped: this agent writes the wiki directly; promote the "
-				"installation to live to run it",
-			)
-			_advance(row, now)
-			continue
-
-		# CX5-2: a Custom App Learning run may only read the apps an ADMIN authorized.
-		# The cron has no human to ask, so it REUSES the durable selection the last
-		# manual launch persisted on the installation (``source_apps_json``) — and when
-		# there is none (or the selected apps have since been uninstalled) it SKIPS with
-		# a recorded reason rather than launching a run that could read the whole bench.
-		source_apps = None
-		if _is_app_learning(row.agent):
-			from jarvis.learning import app_source
-
-			try:
-				source_apps = app_source.validate_source_apps(row.get("source_apps_json") or [])
-			except ValueError as e:
-				_record_failed(
-					row,
-					f"scheduled app-learning skipped: no valid authorized app selection ({e})",
-				)
-				_advance(row, now)
-				continue
-
-		# Phase 1 identity: the audit executes AS the install's run_as_user (its
-		# jarvis__* reads are permission-bounded to that user).
-		#
-		# R1-F3: there is deliberately NO ``or row.owner`` fallback. A blank
-		# run_as_user means the install is MISCONFIGURED, not that it should run as
-		# the row owner: the owner is an identity ``_validate_run_as_escalation``
-		# never litigated, so binding an unattended run to it would execute ERP
-		# reads under rights nobody vetted. Refuse, record WHY, and CONSUME the slot
-		# — retrying hourly would just relog the same failure 24x/day and can never
-		# fix itself; a human has to set a run-as user or disable the install.
-		run_as = (row.run_as_user or "").strip()
-		if not run_as:
-			_record_failed(
-				row, "scheduled audit skipped: no run-as user on this install (set one, or disable it)"
-			)
-			_advance(row, now)
-			continue
-
-		# S1 fail-closed identity guard — never bind a scheduled audit turn to
-		# Administrator / Guest / a disabled RUN-AS user.
-		if not _valid_owner(run_as):
-			_record_failed(row, "scheduled audit skipped: invalid run-as user (fail-closed guard)")
-			_advance(row, now)
-			continue
-
-		# RBAC: the listing may have been restricted (or the run-as user's roles
-		# revoked) AFTER install. Skip, record WHY, and consume the slot — never
-		# dispatch a turn for a run-as identity the agent no longer permits
-		# (gotcha #8 — the EXECUTING identity is gated, not the triggerer).
-		if not _user_allowed_for_agent(row.agent, run_as):
-			_record_failed(row, "run-as user's roles no longer permit this agent")
-			_advance(row, now)
-			continue
-
-		# A14 cost cap — per installation + per-tenant aggregate (the subscription is
-		# the tenant's). Manual + scheduled counted together; failed rows excluded, so
-		# the _record_failed row we write below can never self-perpetuate the cap.
-		over, why = _over_run_budget(row.name)
-		if over:
-			_record_failed(row, why)
-			_notify_owner(row.owner, row, reason=why)
-			_advance(row, now)
-			continue
-
-		# S1 hinge: mint the run session + create conv/run INSIDE set_user(run_as).
-		# Row ownership is reassigned to the human owner inside _launch_audit; only
-		# the ERP-read identity is the run-as user.
+		# #648: fault-isolate each installation, the agent twin of #472's macro sweep.
+		# The per-row try below covers only the DISPATCH; the dedupe, the schedule
+		# arithmetic, the identity guards and every _record_failed / _notify_owner sat
+		# OUTSIDE it, so anything they raised propagated out of the whole sweep and every
+		# installation behind this one silently missed its slot, for good, since the next
+		# hourly tick re-reads the same due set and dies on the same row again. The
+		# concrete case was a schedule_time the arithmetic could not use, but the
+		# guarantee wanted here is structural: no single poisoned row can starve a
+		# tenant's agents. The slot is left DUE on this path (a failure never advances
+		# the schedule), so the next tick retries it.
 		try:
-			frappe.set_user(run_as)
-			inst = frappe.get_doc(INSTALLATION, row.name)
-			# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
-			# it has no initiating human — the scheduler user (Administrator) is not one.
-			_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
-			frappe.set_user(original_user)
-			_advance(row, now)  # O4: advance ONLY after a successful enqueue
+			_sweep_one(row, now, original_user, seen)
 		except Exception:
-			frappe.set_user(original_user)
-			frappe.log_error(
-				title=f"jarvis scheduled audit failed: {row.name}",
-				message=frappe.get_traceback(),
-			)
-			_record_failed(row, "scheduled audit enqueue failed; see Error Log")
-			_notify_owner(row.owner, row)
-			# Do NOT advance -> retry next hour. compute_next_run(from=now) means
-			# even a long outage yields ONE next slot, never a backfill storm.
-		finally:
 			if frappe.session.user != original_user:
 				frappe.set_user(original_user)
+			frappe.db.rollback()
+			frappe.log_error(
+				title=f"jarvis scheduled agent sweep failed: {row.name}",
+				message=frappe.get_traceback(),
+			)
+
+
+def _sweep_one(row, now, original_user: str, seen: set) -> None:
+	"""Handle ONE due installation. Extracted from the loop so ``run_due_agent_audits``
+	can wrap it whole (#648); every ``return`` here was a ``continue`` in the loop it
+	came from. ``seen`` is the caller's dedupe set and is mutated in place."""
+	from jarvis.chat.agents_api import _user_allowed_for_agent
+
+	key = (row.owner, row.agent, row.schedule_frequency, str(row.schedule_time))
+	if key in seen:
+		_advance(row, now)
+		return
+	seen.add(key)
+
+	# R5-J8: never dispatch a scheduled run for a non-installable capability. A
+	# reconcile marks an install installable=0 when a min_apps dependency
+	# disappeared after install (the row is kept, not deleted); its run has no
+	# data. Record why + consume the slot so the cadence does not busy-retry.
+	if not frappe.utils.cint(row.installable):
+		_record_failed(
+			row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)"
+		)
+		_advance(row, now)
+		return
+
+	# Only auditor + scribe agents run scheduled scans; an operator install
+	# with a schedule set just consumes its slot (it drafts through the board,
+	# not on a cron). A scribe's schedule is optional (manual run-now is the
+	# primary path) but honoured here when set, so periodic re-learning works.
+	listing = (
+		frappe.db.get_value(LISTING, row.agent, ["nature", "status"], as_dict=True) or frappe._dict()
+	)
+	nature = listing.get("nature")
+	if nature not in ("Auditor", "Scribe"):
+		_advance(row, now)
+		return
+
+	# #457: an admin who deprecates a listing must stop its schedules. The push
+	# already drops an unpublished agent from the roster, so the container has no
+	# such delegate and a dispatched run can only fail three hours later as a
+	# mislabelled timeout. ``_launch_audit`` is the authoritative gate, but refuse
+	# HERE too and consume the slot: a throw out of _launch_audit lands in the
+	# generic except below, which does NOT advance, so the cadence would retry
+	# hourly and write an Error Log every time for a state only a human can fix.
+	if (listing.get("status") or "") != "Published":
+		_record_failed(
+			row,
+			"scheduled run skipped: this agent is no longer published "
+			f"({listing.get('status') or 'unknown'}); uninstall it or ask an admin to republish it",
+		)
+		_advance(row, now)
+		return
+
+	# CX5-5: a scribe writes the LIVE Org wiki with no confirmation gate, so there is
+	# no such thing as a shadow scribe run — refuse it here exactly as the manual path
+	# does, and consume the slot so the cadence does not busy-retry.
+	if nature == "Scribe" and (row.get("activation_state") or "shadow") == "shadow":
+		_record_failed(
+			row,
+			"scheduled run skipped: this agent writes the wiki directly; promote the "
+			"installation to live to run it",
+		)
+		_advance(row, now)
+		return
+
+	# CX5-2: a Custom App Learning run may only read the apps an ADMIN authorized.
+	# The cron has no human to ask, so it REUSES the durable selection the last
+	# manual launch persisted on the installation (``source_apps_json``) — and when
+	# there is none (or the selected apps have since been uninstalled) it SKIPS with
+	# a recorded reason rather than launching a run that could read the whole bench.
+	source_apps = None
+	if _is_app_learning(row.agent):
+		from jarvis.learning import app_source
+
+		try:
+			source_apps = app_source.validate_source_apps(row.get("source_apps_json") or [])
+		except ValueError as e:
+			_record_failed(
+				row,
+				f"scheduled app-learning skipped: no valid authorized app selection ({e})",
+			)
+			_advance(row, now)
+			return
+
+	# Phase 1 identity: the audit executes AS the install's run_as_user (its
+	# jarvis__* reads are permission-bounded to that user).
+	#
+	# R1-F3: there is deliberately NO ``or row.owner`` fallback. A blank
+	# run_as_user means the install is MISCONFIGURED, not that it should run as
+	# the row owner: the owner is an identity ``_validate_run_as_escalation``
+	# never litigated, so binding an unattended run to it would execute ERP
+	# reads under rights nobody vetted. Refuse, record WHY, and CONSUME the slot
+	# — retrying hourly would just relog the same failure 24x/day and can never
+	# fix itself; a human has to set a run-as user or disable the install.
+	run_as = (row.run_as_user or "").strip()
+	if not run_as:
+		_record_failed(
+			row, "scheduled audit skipped: no run-as user on this install (set one, or disable it)"
+		)
+		_advance(row, now)
+		return
+
+	# S1 fail-closed identity guard — never bind a scheduled audit turn to
+	# Administrator / Guest / a disabled RUN-AS user.
+	if not _valid_owner(run_as):
+		_record_failed(row, "scheduled audit skipped: invalid run-as user (fail-closed guard)")
+		_advance(row, now)
+		return
+
+	# RBAC: the listing may have been restricted (or the run-as user's roles
+	# revoked) AFTER install. Skip, record WHY, and consume the slot — never
+	# dispatch a turn for a run-as identity the agent no longer permits
+	# (gotcha #8 — the EXECUTING identity is gated, not the triggerer).
+	if not _user_allowed_for_agent(row.agent, run_as):
+		_record_failed(row, "run-as user's roles no longer permit this agent")
+		_advance(row, now)
+		return
+
+	# A14 cost cap — per installation + per-tenant aggregate (the subscription is
+	# the tenant's). Manual + scheduled counted together; failed rows excluded, so
+	# the _record_failed row we write below can never self-perpetuate the cap.
+	over, why = _over_run_budget(row.name)
+	if over:
+		_record_failed(row, why)
+		_notify_owner(row.owner, row, reason=why)
+		_advance(row, now)
+		return
+
+	# S1 hinge: mint the run session + create conv/run INSIDE set_user(run_as).
+	# Row ownership is reassigned to the human owner inside _launch_audit; only
+	# the ERP-read identity is the run-as user.
+	try:
+		frappe.set_user(run_as)
+		inst = frappe.get_doc(INSTALLATION, row.name)
+		# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
+		# it has no initiating human — the scheduler user (Administrator) is not one.
+		_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
+		frappe.set_user(original_user)
+		_advance(row, now)  # O4: advance ONLY after a successful enqueue
+	except Exception:
+		frappe.set_user(original_user)
+		frappe.log_error(
+			title=f"jarvis scheduled audit failed: {row.name}",
+			message=frappe.get_traceback(),
+		)
+		_record_failed(row, "scheduled audit enqueue failed; see Error Log")
+		_notify_owner(row.owner, row)
+		# Do NOT advance -> retry next hour. compute_next_run(from=now) means
+		# even a long outage yields ONE next slot, never a backfill storm.
+	finally:
+		if frappe.session.user != original_user:
+			frappe.set_user(original_user)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -129,9 +129,7 @@ def _sweep_one(row, now, original_user: str, seen: set) -> None:
 	# disappeared after install (the row is kept, not deleted); its run has no
 	# data. Record why + consume the slot so the cadence does not busy-retry.
 	if not frappe.utils.cint(row.installable):
-		_record_failed(
-			row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)"
-		)
+		_record_failed(row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)")
 		_advance(row, now)
 		return
 
@@ -139,9 +137,7 @@ def _sweep_one(row, now, original_user: str, seen: set) -> None:
 	# with a schedule set just consumes its slot (it drafts through the board,
 	# not on a cron). A scribe's schedule is optional (manual run-now is the
 	# primary path) but honoured here when set, so periodic re-learning works.
-	listing = (
-		frappe.db.get_value(LISTING, row.agent, ["nature", "status"], as_dict=True) or frappe._dict()
-	)
+	listing = frappe.db.get_value(LISTING, row.agent, ["nature", "status"], as_dict=True) or frappe._dict()
 	nature = listing.get("nature")
 	if nature not in ("Auditor", "Scribe"):
 		_advance(row, now)

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -336,6 +336,27 @@ def parse_schedule_seconds(t) -> int | None:
 	return secs if 0 <= secs <= _MAX_SECONDS else None
 
 
+def validate_schedule_time_or_throw(value) -> None:
+	"""Refuse a ``schedule_time`` that is not a time of day, with the field error the
+	SPA renders.
+
+	ONE definition of the rule, called by ``JarvisMacro`` (#472) and
+	``JarvisAgentInstallation`` (#648). Both controllers previously carried their own
+	copy, so a change to the range, the message or the empty-value exemption had to be
+	made twice, and missing one would let the two DocTypes accept different values,
+	which is the drift #472 and #648 were both filed to close.
+
+	An empty value is exempt on purpose: ``schedule_time`` is optional and the
+	schedulers already treat an unset time as the 09:00 default."""
+	if value in (None, ""):
+		return
+	if parse_schedule_seconds(value) is None:
+		frappe.throw(
+			frappe._("Schedule time must be a time of day between 00:00:00 and 23:59:59."),
+			title=frappe._("Invalid schedule time"),
+		)
+
+
 def _time_to_seconds(t) -> int:
 	"""TOLERANT reader, for the cron. A value the strict parser rejects has already
 	been persisted, so refusing it here would only take the schedule arithmetic down

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -155,17 +155,17 @@ class JarvisAgentInstallation(Document):
 		with the schedule off a bad value persists happily, and a later flip of
 		``schedule_enabled`` would hand the stored garbage straight to the sweep.
 
-		Scoped to inserts and to saves that actually TOUCH ``schedule_time``. The whole
-		premise of this fix is that out-of-range values are already on rows out there,
-		so validating every save would make those rows permanently un-saveable: both
-		``agents_api.set_enabled`` and ``set_config`` go through ``doc.save()``, and a
-		customer would be unable to disable or reconfigure the agent without first
-		repairing a field they were not editing. Same reasoning ``_guard_installability``
-		gives for leaving an already-non-installable row saveable so it can still be
-		repaired. A legacy bad value therefore keeps its 09:00 fallback until someone
-		writes the field, and any write of a bad value is refused."""
-		if not (self.is_new() or self.has_value_changed("schedule_time")):
-			return
+		Runs on EVERY save, exactly like the macro sibling, and deliberately not scoped
+		to "only when schedule_time changed". Review asked whether that strands a row
+		holding a legacy bad value, since ``set_enabled`` and ``set_config`` both go
+		through ``doc.save()``. It cannot, because such a row cannot be saved at all
+		either way: the only values this check rejects that MariaDB will still STORE are
+		``>= 24:00:00``, and those come back from a TIME column as a
+		``datetime.timedelta`` with a days component, which Frappe writes back as
+		``"4 days, 3:00:00"`` and MariaDB then refuses with error 1292. So there is no
+		value that is simultaneously persistable, rejected here, and able to survive a
+		read/write round trip. Scoping the check would add a branch for a state that
+		cannot exist, and would split this rule from the macro one it shares."""
 		from jarvis.chat.macro_scheduler import validate_schedule_time_or_throw
 
 		validate_schedule_time_or_throw(self.schedule_time)

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -46,6 +46,7 @@ class JarvisAgentInstallation(Document):
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
 		self._validate_run_as_user()
+		self._validate_schedule_time()
 		self._validate_schedule_budget()
 		self._guard_activation_transition()
 
@@ -132,6 +133,36 @@ class JarvisAgentInstallation(Document):
 			_("activation_state flips only via the reviewer promotion / demotion path (PP-4)."),
 			frappe.PermissionError,
 		)
+
+	def _validate_schedule_time(self):
+		"""#648: refuse a ``schedule_time`` that is not a time of day.
+
+		The agent twin of ``JarvisMacro._validate_schedule_time`` (#472), and it has to
+		live here for the same reason: Frappe runs the controller BEFORE its own Time
+		field check (``Document.insert`` calls ``run_before_save_methods`` and only then
+		``_validate``), so by the time the framework would object the value has already
+		reached the schedule arithmetic. MariaDB's TIME column accepts up to 838:59:59,
+		so the storage layer is not the guard either.
+
+		``agents_api.set_schedule`` alone is not enough: it is one write surface among
+		several, and a Desk edit, a data import, a bulk edit or a direct ``doc.save()``
+		all bypass it. Since #472 made ``parse_schedule_seconds`` total, an out-of-range
+		value no longer crashes the sweep, it silently schedules 09:00 instead — so
+		without this check a customer who typed 99:00 would see runs at 09:00 with no
+		explanation. Refusing at save is the honest answer.
+
+		Checked whenever a value is PRESENT, not only when ``schedule_enabled`` is on:
+		with the schedule off a bad value persists happily, and a later flip of
+		``schedule_enabled`` would hand the stored garbage straight to the sweep."""
+		if self.schedule_time in (None, ""):
+			return
+		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+
+		if parse_schedule_seconds(self.schedule_time) is None:
+			frappe.throw(
+				_("Schedule time must be a time of day between 00:00:00 and 23:59:59."),
+				title=_("Invalid schedule time"),
+			)
 
 	def _validate_schedule_budget(self):
 		"""A14: warn (do not hard-block) when an enabled schedule's expected monthly

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -153,16 +153,22 @@ class JarvisAgentInstallation(Document):
 
 		Checked whenever a value is PRESENT, not only when ``schedule_enabled`` is on:
 		with the schedule off a bad value persists happily, and a later flip of
-		``schedule_enabled`` would hand the stored garbage straight to the sweep."""
-		if self.schedule_time in (None, ""):
-			return
-		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+		``schedule_enabled`` would hand the stored garbage straight to the sweep.
 
-		if parse_schedule_seconds(self.schedule_time) is None:
-			frappe.throw(
-				_("Schedule time must be a time of day between 00:00:00 and 23:59:59."),
-				title=_("Invalid schedule time"),
-			)
+		Scoped to inserts and to saves that actually TOUCH ``schedule_time``. The whole
+		premise of this fix is that out-of-range values are already on rows out there,
+		so validating every save would make those rows permanently un-saveable: both
+		``agents_api.set_enabled`` and ``set_config`` go through ``doc.save()``, and a
+		customer would be unable to disable or reconfigure the agent without first
+		repairing a field they were not editing. Same reasoning ``_guard_installability``
+		gives for leaving an already-non-installable row saveable so it can still be
+		repaired. A legacy bad value therefore keeps its 09:00 fallback until someone
+		writes the field, and any write of a bad value is refused."""
+		if not (self.is_new() or self.has_value_changed("schedule_time")):
+			return
+		from jarvis.chat.macro_scheduler import validate_schedule_time_or_throw
+
+		validate_schedule_time_or_throw(self.schedule_time)
 
 	def _validate_schedule_budget(self):
 		"""A14: warn (do not hard-block) when an enabled schedule's expected monthly

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
@@ -85,16 +85,13 @@ class JarvisMacro(Document):
 		Checked whenever a value is PRESENT, not only when ``schedule_enabled`` is on.
 		With the schedule off the bad value used to persist happily (MariaDB TIME holds
 		up to 838:59:59), which is what armed the cron-wide abort: a later flip of
-		``schedule_enabled`` handed the stored garbage straight to the sweep."""
-		if self.schedule_time in (None, ""):
-			return
-		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+		``schedule_enabled`` handed the stored garbage straight to the sweep.
 
-		if parse_schedule_seconds(self.schedule_time) is None:
-			frappe.throw(
-				_("Schedule time must be a time of day between 00:00:00 and 23:59:59."),
-				title=_("Invalid schedule time"),
-			)
+		The rule itself lives in ``macro_scheduler.validate_schedule_time_or_throw`` so
+		this controller and ``JarvisAgentInstallation`` (#648) cannot drift apart."""
+		from jarvis.chat.macro_scheduler import validate_schedule_time_or_throw
+
+		validate_schedule_time_or_throw(self.schedule_time)
 
 	def _recompute_next_run(self):
 		"""Keep ``next_run_at`` in sync with the schedule fields. The scheduler

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1381,6 +1381,36 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 				name = self._install(schedule_time=good)
 				self.assertEqual(str(frappe.db.get_value(INSTALLATION, name, "schedule_time")), good)
 
+	def test_a_legacy_bad_time_does_not_block_an_unrelated_save(self):
+		"""The whole premise of this fix is that bad values are ALREADY on rows, so
+		validating every save would make those rows permanently un-saveable:
+		``set_enabled`` and ``set_config`` both go through ``doc.save()``, and the
+		customer would be unable to disable or reconfigure the agent without first
+		repairing a field they never touched. Only inserts and saves that actually
+		change ``schedule_time`` are litigated."""
+		name = self._install()
+		frappe.db.sql(
+			"UPDATE `tabJarvis Agent Installation` SET schedule_time='99:00:00' WHERE name=%(n)s",
+			{"n": name},
+		)
+		frappe.db.commit()
+
+		doc = frappe.get_doc(INSTALLATION, name)
+		doc.enabled = 0
+		doc.flags.ignore_permissions = True
+		doc.save(ignore_permissions=True)  # must NOT raise
+		self.assertEqual(frappe.utils.cint(frappe.db.get_value(INSTALLATION, name, "enabled")), 0)
+
+	def test_writing_a_bad_time_onto_an_existing_row_is_still_refused(self):
+		"""The other half of the same scoping: leaving legacy rows saveable must not
+		open a door for a NEW bad value on an existing row."""
+		name = self._install(schedule_time="09:00:00")
+		doc = frappe.get_doc(INSTALLATION, name)
+		doc.schedule_time = "99:00:00"
+		doc.flags.ignore_permissions = True
+		with self.assertRaises(frappe.ValidationError):
+			doc.save(ignore_permissions=True)
+
 	# ---- sweep fault isolation (gap 2) ---------------------------------------- #
 
 	def test_one_exploding_installation_does_not_abort_the_sweep(self):

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1257,35 +1257,41 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 	edit, a data import or a direct ``doc.save()`` could persist a value the sweep
 	could not honour. Separately, ``run_due_agent_audits`` guarded only the DISPATCH,
 	so anything the dedupe, the arithmetic or the bookkeeping raised took down every
-	installation behind it — permanently, since the next tick died on the same row."""
+	installation behind it, permanently, since the next tick died on the same row.
+
+	Two agent slugs, not two installs of one agent: #460 added a unique index on
+	(owner, agent), so a second install of the same agent for the same owner is a
+	duplicate-key error rather than a second due row."""
 
 	SLUG = PREFIX + "schedtime"
+	SLUG2 = PREFIX + "schedtime2"
 
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		cls.owner = _mk_user("h-schedtime-owner@example.com")
-		_mk_listing(cls.SLUG)
-		frappe.db.set_value(
-			LISTING, cls.SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False
-		)
+		for slug in (cls.SLUG, cls.SLUG2):
+			_mk_listing(slug)
+			frappe.db.set_value(
+				LISTING, slug, {"status": "Published", "nature": "Auditor"}, update_modified=False
+			)
 		frappe.db.commit()
 
 	def setUp(self):
 		frappe.set_user("Administrator")
-		_wipe([self.SLUG])
+		_wipe([self.SLUG, self.SLUG2])
 		frappe.db.commit()
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
-		_wipe([self.SLUG])
+		_wipe([self.SLUG, self.SLUG2])
 		frappe.db.commit()
 
-	def _install(self, **overrides) -> str:
+	def _install(self, slug: str | None = None, **overrides) -> str:
 		from frappe.utils import add_days, now_datetime
 
-		name = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		name = _mk_gate_install(self.owner, slug or self.SLUG, self.owner)
 		values = {
 			"schedule_enabled": 1,
 			"schedule_frequency": "daily",
@@ -1309,7 +1315,7 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 					"enabled": 1,
 					"schedule_enabled": 1,
 					"next_run_at": ["<=", now],
-					"agent": ["!=", self.SLUG],
+					"agent": ["not in", [self.SLUG, self.SLUG2]],
 				},
 				fields=["name", "next_run_at"],
 				ignore_permissions=True,
@@ -1375,19 +1381,32 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 			doc.insert(ignore_permissions=True)
 
 	def test_valid_schedule_times_are_accepted(self):
-		for good in ("00:00:00", "09:30:00", "23:59:59"):
-			with self.subTest(good=good):
-				_wipe([self.SLUG])
-				name = self._install(schedule_time=good)
-				self.assertEqual(str(frappe.db.get_value(INSTALLATION, name, "schedule_time")), good)
+		# Compared as SECONDS, not as strings: MariaDB hands a TIME column back as a
+		# datetime.timedelta, and str(timedelta(0)) is '0:00:00', not '00:00:00'. The
+		# stored value is right either way, so a string compare would only be asserting
+		# timedelta's formatting.
+		from jarvis.chat.macro_scheduler import parse_schedule_seconds
 
-	def test_a_legacy_bad_time_does_not_block_an_unrelated_save(self):
-		"""The whole premise of this fix is that bad values are ALREADY on rows, so
-		validating every save would make those rows permanently un-saveable:
-		``set_enabled`` and ``set_config`` both go through ``doc.save()``, and the
-		customer would be unable to disable or reconfigure the agent without first
-		repairing a field they never touched. Only inserts and saves that actually
-		change ``schedule_time`` are litigated."""
+		for good, secs in (("00:00:00", 0), ("09:30:00", 34200), ("23:59:59", 86399)):
+			with self.subTest(good=good):
+				_wipe([self.SLUG, self.SLUG2])
+				name = self._install(schedule_time=good)
+				stored = frappe.db.get_value(INSTALLATION, name, "schedule_time")
+				self.assertEqual(parse_schedule_seconds(stored), secs)
+
+	def test_a_row_holding_a_legacy_bad_time_cannot_be_saved_by_the_DB_either(self):
+		"""Review asked whether validating on EVERY save strands a row that already
+		holds a bad value, since ``set_enabled`` / ``set_config`` go through
+		``doc.save()``. It cannot, and this pins why, so nobody adds a
+		``has_value_changed`` branch for a state that cannot exist.
+
+		The only values the check rejects that MariaDB will still STORE are
+		``>= 24:00:00``. A TIME column hands those back as a ``timedelta`` carrying a
+		days component, Frappe writes that back as ``"4 days, 3:00:00"``, and MariaDB
+		refuses it with error 1292 before any controller runs. So such a row is
+		un-saveable regardless of this validation."""
+		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+
 		name = self._install()
 		frappe.db.sql(
 			"UPDATE `tabJarvis Agent Installation` SET schedule_time='99:00:00' WHERE name=%(n)s",
@@ -1395,15 +1414,14 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 		)
 		frappe.db.commit()
 
-		doc = frappe.get_doc(INSTALLATION, name)
-		doc.enabled = 0
-		doc.flags.ignore_permissions = True
-		doc.save(ignore_permissions=True)  # must NOT raise
-		self.assertEqual(frappe.utils.cint(frappe.db.get_value(INSTALLATION, name, "enabled")), 0)
+		# Read it back: the value is a timedelta with days, not a time of day.
+		stored = frappe.db.get_value(INSTALLATION, name, "schedule_time")
+		self.assertIsNone(parse_schedule_seconds(stored), "99:00:00 must not read back as a time of day")
+		self.assertIn("day", str(stored), "MariaDB returns an out-of-range TIME as a timedelta")
 
-	def test_writing_a_bad_time_onto_an_existing_row_is_still_refused(self):
-		"""The other half of the same scoping: leaving legacy rows saveable must not
-		open a door for a NEW bad value on an existing row."""
+	def test_writing_a_bad_time_onto_an_existing_row_is_refused(self):
+		"""An existing, healthy row must not be able to take a bad value either: the
+		check runs on every save, not only on insert."""
 		name = self._install(schedule_time="09:00:00")
 		doc = frappe.get_doc(INSTALLATION, name)
 		doc.schedule_time = "99:00:00"
@@ -1420,8 +1438,8 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 		handler then raises are all live ways one row can throw."""
 		from frappe.utils import add_days, now_datetime
 
-		boom = self._install()
-		good = self._install()
+		boom = self._install(self.SLUG)
+		good = self._install(self.SLUG2)
 		# Force the exploding row to the FRONT: get_all has no explicit order_by here, so
 		# pin it by making it the older next_run_at, which is the natural due ordering.
 		frappe.db.set_value(
@@ -1445,8 +1463,8 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 		then confirm the sweep still reaches the healthy installation behind it."""
 		from frappe.utils import add_days, now_datetime
 
-		bad = self._install()
-		good = self._install()
+		bad = self._install(self.SLUG)
+		good = self._install(self.SLUG2)
 		frappe.db.sql(
 			"UPDATE `tabJarvis Agent Installation` SET schedule_time='99:00:00', "
 			"next_run_at=%(t)s WHERE name=%(n)s",

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1246,3 +1246,188 @@ class TestSetListingStatusMarksCatalogDirty(FrappeTestCase):
 		frappe.db.commit()
 		agents_api.set_listing_status(self.SLUG, "Published")
 		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
+
+
+# --------------------------------------------------------------------------- #
+# #648 — schedule_time is validated on every surface, and one bad installation
+# cannot abort the whole hourly agent sweep (the agent twin of #472)
+# --------------------------------------------------------------------------- #
+class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
+	"""``schedule_time`` was litigated only by ``agents_api.set_schedule``, so a Desk
+	edit, a data import or a direct ``doc.save()`` could persist a value the sweep
+	could not honour. Separately, ``run_due_agent_audits`` guarded only the DISPATCH,
+	so anything the dedupe, the arithmetic or the bookkeeping raised took down every
+	installation behind it — permanently, since the next tick died on the same row."""
+
+	SLUG = PREFIX + "schedtime"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-schedtime-owner@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.set_value(
+			LISTING, cls.SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False
+		)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def _install(self, **overrides) -> str:
+		from frappe.utils import add_days, now_datetime
+
+		name = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		values = {
+			"schedule_enabled": 1,
+			"schedule_frequency": "daily",
+			"next_run_at": add_days(now_datetime(), -1),
+		}
+		values.update(overrides)
+		frappe.db.set_value(INSTALLATION, name, values, update_modified=False)
+		frappe.db.commit()
+		return name
+
+	def _run_cron(self, launch_side_effect=None):
+		"""Run the hourly cron with only OUR installs due (shared dev site), launch stubbed."""
+		from frappe.utils import add_days, now_datetime
+
+		now = now_datetime()
+		parked = {
+			r.name: r.next_run_at
+			for r in frappe.get_all(
+				INSTALLATION,
+				filters={
+					"enabled": 1,
+					"schedule_enabled": 1,
+					"next_run_at": ["<=", now],
+					"agent": ["!=", self.SLUG],
+				},
+				fields=["name", "next_run_at"],
+				ignore_permissions=True,
+			)
+		}
+		for n in parked:
+			frappe.db.set_value(INSTALLATION, n, "next_run_at", add_days(now, 2), update_modified=False)
+		frappe.db.commit()
+		calls = []
+
+		def _default(inst, **kw):
+			calls.append(inst.name)
+
+		try:
+			with patch.object(
+				agent_scheduler, "_launch_audit", side_effect=launch_side_effect or _default
+			):
+				agent_scheduler.run_due_agent_audits()
+		finally:
+			for n, ts in parked.items():
+				frappe.db.set_value(INSTALLATION, n, "next_run_at", ts, update_modified=False)
+			frappe.db.commit()
+		return calls
+
+	# ---- controller validation (gap 1) ---------------------------------------- #
+
+	def test_out_of_range_schedule_time_is_refused_on_every_write_surface(self):
+		"""``frappe.ValidationError`` is what the SPA renders as a field error. Before
+		this the value persisted silently and the scheduler quietly used 09:00."""
+		for bad in ("99:00:00", "-01:00:00", "24:00:00", "12:99:00", "not-a-time", "1:2:3:4"):
+			with self.subTest(bad=bad):
+				doc = frappe.get_doc(
+					{
+						"doctype": INSTALLATION,
+						"agent": self.SLUG,
+						"run_as_user": self.owner,
+						"reviewer": self.owner,
+						"enabled": 1,
+						"schedule_enabled": 1,
+						"schedule_frequency": "daily",
+						"schedule_time": bad,
+					}
+				)
+				doc.flags.ignore_permissions = True
+				with self.assertRaises(frappe.ValidationError):
+					doc.insert(ignore_permissions=True)
+
+	def test_a_bad_time_is_refused_even_with_the_schedule_off(self):
+		"""The latent limb: with ``schedule_enabled=0`` nothing consumed the value, so
+		the garbage persisted and armed the sweep for whenever the schedule was flipped
+		on. MariaDB TIME accepts up to 838:59:59, so storage was never the guard."""
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": self.SLUG,
+				"run_as_user": self.owner,
+				"reviewer": self.owner,
+				"enabled": 1,
+				"schedule_enabled": 0,
+				"schedule_time": "99:00:00",
+			}
+		)
+		doc.flags.ignore_permissions = True
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	def test_valid_schedule_times_are_accepted(self):
+		for good in ("00:00:00", "09:30:00", "23:59:59"):
+			with self.subTest(good=good):
+				_wipe([self.SLUG])
+				name = self._install(schedule_time=good)
+				self.assertEqual(
+					str(frappe.db.get_value(INSTALLATION, name, "schedule_time")), good
+				)
+
+	# ---- sweep fault isolation (gap 2) ---------------------------------------- #
+
+	def test_one_exploding_installation_does_not_abort_the_sweep(self):
+		"""The structural guarantee, independent of ``schedule_time``: whatever a single
+		row raises, every row behind it still gets its slot. ``_record_failed``,
+		``_notify_owner``, a deleted run-as user and a failing ``_launch_audit`` whose own
+		handler then raises are all live ways one row can throw."""
+		from frappe.utils import add_days, now_datetime
+
+		boom = self._install()
+		good = self._install()
+		# Force the exploding row to the FRONT: get_all has no explicit order_by here, so
+		# pin it by making it the older next_run_at, which is the natural due ordering.
+		frappe.db.set_value(
+			INSTALLATION, boom, "next_run_at", add_days(now_datetime(), -3), update_modified=False
+		)
+		frappe.db.commit()
+
+		seen = []
+
+		def _explode(inst, **kw):
+			seen.append(inst.name)
+			if inst.name == boom:
+				raise RuntimeError("poisoned installation")
+
+		self._run_cron(launch_side_effect=_explode)
+
+		self.assertIn(good, seen, "one exploding installation aborted the sweep for every other row")
+
+	def test_a_bad_persisted_time_does_not_abort_the_sweep(self):
+		"""Recreate a row saved BEFORE the controller check existed by writing past it,
+		then confirm the sweep still reaches the healthy installation behind it."""
+		from frappe.utils import add_days, now_datetime
+
+		bad = self._install()
+		good = self._install()
+		frappe.db.sql(
+			"UPDATE `tabJarvis Agent Installation` SET schedule_time='99:00:00', "
+			"next_run_at=%(t)s WHERE name=%(n)s",
+			{"t": add_days(now_datetime(), -3), "n": bad},
+		)
+		frappe.db.commit()
+
+		dispatched = self._run_cron()
+
+		self.assertIn(good, dispatched, "a bad persisted time aborted the sweep for every other row")

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1324,9 +1324,7 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 			calls.append(inst.name)
 
 		try:
-			with patch.object(
-				agent_scheduler, "_launch_audit", side_effect=launch_side_effect or _default
-			):
+			with patch.object(agent_scheduler, "_launch_audit", side_effect=launch_side_effect or _default):
 				agent_scheduler.run_due_agent_audits()
 		finally:
 			for n, ts in parked.items():
@@ -1381,9 +1379,7 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 			with self.subTest(good=good):
 				_wipe([self.SLUG])
 				name = self._install(schedule_time=good)
-				self.assertEqual(
-					str(frappe.db.get_value(INSTALLATION, name, "schedule_time")), good
-				)
+				self.assertEqual(str(frappe.db.get_value(INSTALLATION, name, "schedule_time")), good)
 
 	# ---- sweep fault isolation (gap 2) ---------------------------------------- #
 


### PR DESCRIPTION
Closes #648

One installation with an out-of-range `schedule_time` aborted the entire hourly agent sweep, so every healthy installation behind it silently stopped dispatching, permanently. Customers running scheduled auditors notice; nothing surfaced except a single Error Log per hour.

Two independent gaps, closed separately.

**Validation.** `JarvisAgentInstallation._validate_schedule_time` now refuses a value that is not a time of day, on every write surface. `agents_api.set_schedule` litigated it, but a Desk edit, a data import, a bulk edit or a direct `doc.save()` all bypassed that. The controller has to own the check because Frappe runs it before its own Time field check, and MariaDB `TIME` accepts up to `838:59:59`, so neither the framework nor the column is the guard. Checked whenever a value is present, not only when the schedule is enabled, so a later flip cannot hand stored garbage to the sweep.

**Fault isolation.** The per-row body of `run_due_agent_audits` moves into `_sweep_one`, wrapped whole, mirroring `macro_scheduler._sweep_one` from #472. The pre-existing `try` covered only the dispatch; the dedupe, the arithmetic, the identity guards and every `_record_failed` / `_notify_owner` sat outside it. The slot is left due on the failure path, so the next tick retries instead of skipping.

<details>
<summary>Why the crash alone was not the whole bug</summary>

`_advance` calls the shared `macro_scheduler.compute_next_run`, and `datetime.replace(hour=99)` raises `ValueError`. `_advance` is called from eleven sites in `run_due_agent_audits`; exactly one sat inside a `try`, and that handler does not re-advance. So the exception propagated out of the sweep and stopped it at that row, and the scheduler died on the same row every hour after.

#472 made `parse_schedule_seconds` total, which closes the crash for free. But that changes the failure mode rather than removing it: an out-of-range value now saves and silently schedules 09:00, so a customer who typed 99:00 sees runs at 09:00 with no explanation. Hence the controller check, which is the durable half.

Fault isolation is worth having independently of `schedule_time`. `_record_failed` inserts a row, `_notify_owner` writes a Notification, `frappe.set_user` can hit a user deleted mid-sweep, and a `_launch_audit` failure whose own handler then raises would each take down every row behind it.
</details>

## Tests

`TestAgentScheduleTimeAndSweepIsolation` in `test_platform_agents_api_hardening.py`:

- out-of-range values refused on a direct insert, covering `99:00:00`, `-01:00:00`, `24:00:00`, `12:99:00`, `not-a-time`, `1:2:3:4`
- refused with `schedule_enabled=0`, the latent limb that armed the original abort
- valid times still accepted and persisted
- an exploding `_launch_audit` does not stop the installation behind it
- a bad time written past the controller does not stop the installation behind it

Verified locally: both modules compile and `ruff check` passes on all three files. The suite itself is left to CI rather than run against the local bench, which is mid-onboarding-test and would be polluted by a local run.
