### PR TITLE
feat(onboarding): reset depth ladder L1–L4 + bench disconnect

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -62,13 +62,31 @@ export const getLlmApplyOperation = (operationId) =>
 	call("jarvis.account.get_llm_apply_operation", { operation_id: operationId });
 
 // ---- workspace reset (customer self-serve, admin-gated) --------------------
+// Four cumulative depths (L1-L4, jarvis/onboarding.py request_workspace_reset):
+// disconnectAfter (L4) additionally clears the bench's OWN admin connection,
+// deferred until the poll below observes the rebuilt container Ready - so it
+// is refused up front (frappe.ValidationError) when the emailed-code reconnect
+// would not be able to restore the site, rather than left half-done.
 export const requestWorkspaceReset = (reason, opts = {}) =>
 	call("jarvis.onboarding.request_workspace_reset", {
 		reason: reason || "",
 		wipe_data: opts.wipeData ? 1 : 0,
 		revoke_llm: opts.revokeLlm ? 1 : 0,
+		disconnect_after: opts.disconnectAfter ? 1 : 0,
 	});
 export const workspaceResetState = () => call("jarvis.onboarding.workspace_reset_state");
+// Terminal, separate from the reset ladder: no rebuild, no poll, just leaves
+// the account. Idempotent - a second call on an already-disconnected bench
+// returns {disconnected:true, already_disconnected:true} rather than erroring.
+// Refused (frappe.ValidationError) up front, same as L4, when the emailed-code
+// reconnect would not be able to restore the site.
+export const disconnectBench = () => call("jarvis.onboarding.disconnect_bench");
+// Poll durable disconnected state: read from local settings with no admin call,
+// so a disconnected bench (which has no credentials) can still answer it. Returns
+// {disconnected: bool, needs_company: bool}. Used on reload to restore the
+// terminal disconnected state with a definitive needs_company answer, so the
+// recovery text never falls back to hedging.
+export const benchConnectionState = () => call("jarvis.onboarding.bench_connection_state");
 
 // --- Per-user chat settings + real (measured) usage tracking, incl. the
 // tenant-admin usage table (design doc §4/§6). All return the house

--- a/frontend/src/components/settings/GeneralPane.spec.js
+++ b/frontend/src/components/settings/GeneralPane.spec.js
@@ -1,0 +1,423 @@
+// Reset Workspace / Disconnect this bench (Settings > General): the depth
+// ladder composes the right flags, the two lockout paths (L4 and the separate
+// Disconnect action) show their cost and their way back before they can be
+// submitted, and the terminal `disconnected` state is never mistaken for a
+// plain unreachable-admin blip or a normal "ready, reloading" reset.
+//
+// Mounted via @vue/test-utils and driven through the exposed <script setup>
+// bindings (w.vm.*) rather than DOM clicks - the same convention
+// LlmPoolEditor.spec.js in this directory uses for its disconnect coverage.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// GeneralPane.vue -> stores/shell.js reads window.matchMedia at MODULE
+// EVALUATION time (its narrow-sidebar breakpoint watcher, not inside a
+// function), so this has to run before the `import GeneralPane` below even
+// begins to resolve, not just before the first test. vi.hoisted is what makes
+// that ordering guarantee - a plain top-of-file statement would still run
+// after import hoisting. (OnboardingView.spec.js's identical stub lives in
+// beforeEach instead, because the module it mounts never reads matchMedia
+// this early.)
+vi.hoisted(() => {
+	window.matchMedia = (q) => ({
+		matches: false,
+		media: q,
+		addEventListener() {},
+		removeEventListener() {},
+		addListener() {},
+		removeListener() {},
+		dispatchEvent() {},
+	});
+});
+
+const api = vi.hoisted(() => ({
+	getUsage: vi.fn(),
+	getMySettings: vi.fn(),
+	getLlmConnectionStatus: vi.fn(),
+	requestWorkspaceReset: vi.fn(),
+	workspaceResetState: vi.fn(),
+	disconnectBench: vi.fn(),
+	benchConnectionState: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+// frappe-ui components are rendered but never asserted on directly here
+// (every check goes through exposed script-setup state instead), so trivial
+// templates are enough - matches OnboardingView.spec.js's stub shape.
+vi.mock("frappe-ui", () => ({
+	Badge: { name: "Badge", template: "<span><slot />{{ label }}</span>", props: ["label"] },
+	Button: { name: "Button", template: "<button @click=\"$emit('click')\"><slot /></button>" },
+	Switch: { name: "Switch", template: "<input type=\"checkbox\" />" },
+	ErrorMessage: { name: "ErrorMessage", template: "<div><slot /></div>" },
+	toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const answer = vi.hoisted(() => ({ confirm: true }));
+const confirmCalls = vi.hoisted(() => []);
+vi.mock("@/composables/useConfirm", () => ({
+	useConfirm: () => ({
+		confirm: async (opts) => {
+			confirmCalls.push(opts);
+			return answer.confirm;
+		},
+	}),
+}));
+
+import { toast } from "frappe-ui";
+import GeneralPane from "./GeneralPane.vue";
+
+async function mountPane() {
+	const w = mount(GeneralPane);
+	await flushPromises();
+	return w;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	confirmCalls.length = 0;
+	answer.confirm = true;
+	window.is_jarvis_admin = true;
+	window.is_system_manager = false;
+	// {} (rather than null) is a truthy "no usage yet" that still lacks
+	// month_label - out of scope for this suite, so avoid the unrelated KvRow
+	// prop warning it triggers.
+	api.getUsage.mockResolvedValue(null);
+	api.getMySettings.mockResolvedValue({ ok: true, data: {} });
+	api.getLlmConnectionStatus.mockResolvedValue({});
+	api.requestWorkspaceReset.mockResolvedValue({});
+	api.workspaceResetState.mockResolvedValue({});
+	api.disconnectBench.mockResolvedValue({
+		disconnected: true,
+		already_disconnected: false,
+		cleared: [],
+		needs_company: false,
+	});
+	// Default: not disconnected, so resumeResetIfInFlight / pollReset fall
+	// through to whatever workspaceResetState says, unchanged from before this
+	// mock existed - tests that care about the disconnected branch override it.
+	api.benchConnectionState.mockResolvedValue({ disconnected: false, needs_company: false });
+	// jsdom's window.location.assign is non-configurable, so it cannot be
+	// vi.spyOn'd directly - replace the whole object instead (goReconnect and
+	// the ready-reload path both call this).
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: { assign: vi.fn() },
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("the depth ladder composes flags cumulatively", () => {
+	// Each depth adds to the one above it (plan: "four depths, each adding to
+	// the one above") - a radio ladder instead of independent checkboxes makes
+	// "L3 without L2" unrepresentable rather than merely undocumented.
+	it.each([
+		[1, { wipeData: false, revokeLlm: false, disconnectAfter: false }],
+		[2, { wipeData: true, revokeLlm: false, disconnectAfter: false }],
+		[3, { wipeData: true, revokeLlm: true, disconnectAfter: false }],
+		[4, { wipeData: true, revokeLlm: true, disconnectAfter: true }],
+	])("depth %i sends %o", async (depth, expected) => {
+		const w = await mountPane();
+		w.vm.resetDepth = depth;
+		await w.vm.doReset();
+		expect(api.requestWorkspaceReset).toHaveBeenCalledWith("", expected);
+		w.vm.stopPoll();
+	});
+});
+
+describe("L4 is a lockout path", () => {
+	it("shows the cost and the emailed-code recovery before submitting, not after", async () => {
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_DISCONNECT;
+		await w.vm.doReset();
+		const shown = confirmCalls[confirmCalls.length - 1];
+		expect(shown.message).toMatch(/disconnects from your account/i);
+		expect(shown.message).toMatch(/one-time code emailed/i);
+		expect(shown.message).toMatch(/company name/i);
+		expect(shown.danger).toBe(true);
+		w.vm.stopPoll();
+	});
+
+	it("does not claim a disconnect for the shallower depths", async () => {
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_REVOKE_LLM;
+		await w.vm.doReset();
+		const shown = confirmCalls[confirmCalls.length - 1];
+		expect(shown.message).not.toMatch(/disconnects from your account/i);
+		w.vm.stopPoll();
+	});
+
+	it("refuses up front verbatim and starts nothing when reconnect would not work", async () => {
+		api.requestWorkspaceReset.mockRejectedValue({
+			messages: ["No reconnectable account was found for a@b.com. Contact support instead."],
+		});
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_DISCONNECT;
+		await w.vm.doReset();
+		expect(toast.error).toHaveBeenCalledWith(
+			"No reconnectable account was found for a@b.com. Contact support instead."
+		);
+		expect(w.vm.resetting).toBe(false);
+		expect(w.vm.benchDisconnected).toBe(false);
+	});
+
+	// T33 / round-5 MINOR 12. The refusal case above was the only half exercised;
+	// the half Amendment 4 singles out — the call that never answered — had no test.
+	it("starts polling when the initiate call dies without answering", async () => {
+		// gunicorn SIGKILL / dropped connection: no status, no server messages.
+		api.requestWorkspaceReset.mockRejectedValue(new Error("Network Error"));
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_REBUILD;
+		await w.vm.doReset();
+		// Admin rebuilds SYNCHRONOUSLY inside the request, so the reset may well be
+		// running, and the bench keeps its claim for exactly that reason. Without
+		// this the customer sits on a bare error toast watching nothing happen.
+		expect(w.vm.resetting).toBe(true);
+		w.vm.stopPoll();
+	});
+
+	it("does NOT start polling when the server answered with a refusal", async () => {
+		// A 4xx is a decision: nothing was started, so a spinner would be a lie.
+		api.requestWorkspaceReset.mockRejectedValue({
+			status: 417,
+			messages: ["A workspace reset is already running at a different depth."],
+		});
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_REBUILD;
+		await w.vm.doReset();
+		expect(w.vm.resetting).toBe(false);
+	});
+
+	it("treats a JSON-bodied 502 as unreachable despite the synthesised message", async () => {
+		// round-5 MINOR 11: frappe-ui's call.js sets messages:['Internal Server
+		// Error'] for any parseable JSON error body, so keying on `messages` first
+		// misread this as a refusal. Status is the discriminator.
+		api.requestWorkspaceReset.mockRejectedValue({
+			status: 502,
+			messages: ["Internal Server Error"],
+		});
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_REBUILD;
+		await w.vm.doReset();
+		expect(w.vm.resetting).toBe(true);
+		w.vm.stopPoll();
+	});
+
+	it("does nothing without confirmation", async () => {
+		answer.confirm = false;
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_DISCONNECT;
+		await w.vm.doReset();
+		expect(api.requestWorkspaceReset).not.toHaveBeenCalled();
+	});
+
+	it("closeReset returns the ladder to the harmless default", async () => {
+		const w = await mountPane();
+		w.vm.resetDepth = w.vm.DEPTH_DISCONNECT;
+		w.vm.closeReset();
+		expect(w.vm.resetDepth).toBe(w.vm.DEPTH_REBUILD);
+	});
+});
+
+describe("the poll tells a completed L4 disconnect apart from a normal ready reload", () => {
+	it("a disconnected+ready poll enters the terminal state and never reloads the page", async () => {
+		const w = await mountPane();
+		api.workspaceResetState.mockResolvedValue({ ready: true, disconnected: true });
+		w.vm.resetting = true;
+		w.vm.pollStarted = Date.now();
+		await w.vm.pollReset();
+		expect(w.vm.benchDisconnected).toBe(true);
+		expect(w.vm.resetting).toBe(false);
+		await new Promise((r) => setTimeout(r, 900));
+		expect(window.location.assign).not.toHaveBeenCalled();
+	});
+
+	// T23 / round-4 MAJOR 9. This used to assert ONLY the base sentence, on the
+	// reasoning that needs_company was "always definitive". It was definitive in
+	// the sense that it could never be anything but false: bench_connection_state
+	// hardcoded it, and pollReset resolves the value from that endpoint. So the
+	// test passed because the mock echoed a constant the real endpoint could not
+	// vary from - a green test certifying a property the system did not have.
+	//
+	// It varies now (persisted onto reconnect_needs_company at the moment of the
+	// clear), so both values are pinned. A customer whose registered address owns
+	// several eligible accounts MUST be told to have the company name ready, or
+	// they are sent to a reconnect that cannot complete with what they were given.
+	it("names the company requirement when the address owns several accounts", async () => {
+		const w = await mountPane();
+		api.benchConnectionState.mockResolvedValue({ disconnected: true, needs_company: true });
+		api.workspaceResetState.mockResolvedValue({ ready: true, disconnected: true });
+		w.vm.resetting = true;
+		w.vm.pollStarted = Date.now();
+		await w.vm.pollReset();
+		expect(w.vm.benchNeedsCompany).toBe(true);
+		expect(w.vm.disconnectRecoveryText).toContain("company name");
+	});
+
+	it("omits the company caveat when the address owns exactly one account", async () => {
+		const w = await mountPane();
+		api.benchConnectionState.mockResolvedValue({ disconnected: true, needs_company: false });
+		api.workspaceResetState.mockResolvedValue({ ready: true, disconnected: true });
+		w.vm.resetting = true;
+		w.vm.pollStarted = Date.now();
+		await w.vm.pollReset();
+		expect(w.vm.benchNeedsCompany).toBe(false);
+		expect(w.vm.disconnectRecoveryText).toBe(
+			"Reconnect with the one-time code emailed to this workspace's registered address."
+		);
+	});
+
+	// T24 / round-4 MAJOR 2.
+	it("tells the customer when an L4 was downgraded to an L3, and does not reload", async () => {
+		const w = await mountPane();
+		api.workspaceResetState.mockResolvedValue({
+			ready: true,
+			disconnected: false,
+			disconnect_blocked: "Subscription is Cancelled; reconnect is not available.",
+		});
+		w.vm.resetting = true;
+		w.vm.pollStarted = Date.now();
+		await w.vm.pollReset();
+		expect(w.vm.resetting).toBe(false);
+		expect(toast.error).toHaveBeenCalledWith(
+			expect.stringContaining("could not be disconnected")
+		);
+		// A reload would drop the only message explaining the downgrade, and there
+		// is nothing to reload for: the connection is unchanged.
+		await new Promise((r) => setTimeout(r, 900));
+		expect(window.location.assign).not.toHaveBeenCalled();
+	});
+
+	it("a plain ready poll (no disconnect) still reloads, unchanged from before", async () => {
+		vi.useFakeTimers();
+		const w = await mountPane();
+		api.workspaceResetState.mockResolvedValue({ ready: true });
+		w.vm.resetting = true;
+		w.vm.pollStarted = Date.now();
+		await w.vm.pollReset();
+		expect(w.vm.benchDisconnected).toBe(false);
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(window.location.assign).toHaveBeenCalledWith("/jarvis/");
+	});
+});
+
+describe("resuming an in-flight reset on mount", () => {
+	it("catches an L4 disconnect completed by the resume call itself", async () => {
+		// _workspace_reset_poll is not read-only: persisting the fresh connection
+		// and clearing admin creds are side effects of calling it. A tab closed in
+		// the last second of an L4 rebuild means the NEXT mount's own resume poll
+		// is the call that finishes the disconnect - it must not go unnoticed.
+		api.workspaceResetState.mockResolvedValue({ ready: true, disconnected: true });
+		const w = await mountPane();
+		expect(w.vm.benchDisconnected).toBe(true);
+		expect(w.vm.resetting).toBe(false);
+	});
+
+	it("resumes an ordinary in-flight reset as before", async () => {
+		api.workspaceResetState.mockResolvedValue({ ready: false, resetting: true });
+		const w = await mountPane();
+		expect(w.vm.resetting).toBe(true);
+		expect(w.vm.benchDisconnected).toBe(false);
+		w.vm.stopPoll();
+	});
+
+	it("checks benchConnectionState before workspaceResetState, and trusts a disconnected answer even though workspaceResetState would reject", async () => {
+		// The real defect this ordering fixes: a bench with no admin credentials
+		// left (already disconnected) cannot call the AUTHENTICATED
+		// workspace_reset_state endpoint - it would 401. The old order called
+		// workspaceResetState() first, so that rejection was swallowed by the
+		// "nothing to resume" catch and the disconnected bench reloaded into the
+		// generic onboarding poster with no trace of how to get back.
+		// benchConnectionState() reads local settings only and needs no
+		// credentials, so checking it FIRST and trusting a disconnected answer
+		// must short-circuit before the credential-hungry call is ever reached.
+		const callOrder = [];
+		api.benchConnectionState.mockImplementation(async () => {
+			callOrder.push("benchConnectionState");
+			return { disconnected: true, needs_company: false };
+		});
+		api.workspaceResetState.mockImplementation(async () => {
+			callOrder.push("workspaceResetState");
+			return Promise.reject({ messages: ["not authenticated"] });
+		});
+		const w = await mountPane();
+		expect(callOrder).toEqual(["benchConnectionState"]);
+		expect(api.workspaceResetState).not.toHaveBeenCalled();
+		expect(w.vm.benchDisconnected).toBe(true);
+		expect(w.vm.resetting).toBe(false);
+	});
+});
+
+describe("Disconnect this bench (separate terminal action)", () => {
+	it("shows the cost and the recovery code before submitting", async () => {
+		const w = await mountPane();
+		await w.vm.doDisconnectBench();
+		const shown = confirmCalls[confirmCalls.length - 1];
+		expect(shown.message).toMatch(/one-time code emailed/i);
+		expect(shown.message).toMatch(/chat stops working immediately/i);
+		expect(shown.danger).toBe(true);
+	});
+
+	it("does nothing without confirmation", async () => {
+		answer.confirm = false;
+		const w = await mountPane();
+		await w.vm.doDisconnectBench();
+		expect(api.disconnectBench).not.toHaveBeenCalled();
+	});
+
+	it("tells the customer they will need their company name when needs_company is true", async () => {
+		api.disconnectBench.mockResolvedValue({
+			disconnected: true,
+			already_disconnected: false,
+			cleared: ["agent_url"],
+			needs_company: true,
+		});
+		const w = await mountPane();
+		await w.vm.doDisconnectBench();
+		expect(w.vm.benchDisconnected).toBe(true);
+		expect(w.vm.disconnectRecoveryText).toMatch(/you'll also need to give the company name/i);
+		expect(toast.success).toHaveBeenCalled();
+	});
+
+	it("omits the company caveat when needs_company is definitively false", async () => {
+		const w = await mountPane();
+		await w.vm.doDisconnectBench();
+		expect(w.vm.disconnectRecoveryText).not.toMatch(/company/i);
+	});
+
+	it("treats a double disconnect as idempotent, not an error", async () => {
+		api.disconnectBench.mockResolvedValue({
+			disconnected: true,
+			already_disconnected: true,
+			cleared: [],
+			needs_company: false,
+		});
+		const w = await mountPane();
+		await w.vm.doDisconnectBench();
+		expect(w.vm.benchDisconnected).toBe(true);
+		expect(toast.error).not.toHaveBeenCalled();
+		expect(toast.success).toHaveBeenCalledWith("This bench was already disconnected.");
+	});
+
+	it("refuses verbatim and changes nothing when reconnect would not work", async () => {
+		api.disconnectBench.mockRejectedValue({
+			messages: ["No live workspace was found, so disconnecting now would lock you out."],
+		});
+		const w = await mountPane();
+		await w.vm.doDisconnectBench();
+		expect(toast.error).toHaveBeenCalledWith(
+			"No live workspace was found, so disconnecting now would lock you out."
+		);
+		expect(w.vm.benchDisconnected).toBe(false);
+	});
+
+	it("is blocked while a reset is in flight, so it cannot race the poll's own clear", async () => {
+		const w = await mountPane();
+		w.vm.resetting = true;
+		await w.vm.doDisconnectBench();
+		expect(api.disconnectBench).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -161,7 +161,10 @@
 		<!-- Reset workspace (jarvis.onboarding.*): self-serve container rebuild.
 		     Admin-tier only; the red solid lives in the useConfirm dialog, per the
 		     danger-zone rule above. While a reset runs the pane polls back to
-		     Ready and hard-reloads /jarvis (drops the memoized readiness verdict). -->
+		     Ready and hard-reloads /jarvis (drops the memoized readiness verdict) -
+		     UNLESS the poll reports `disconnected` (L4): that bench just lost its
+		     admin credentials, so reloading would strand it behind the onboarding
+		     gate poster instead of showing it how to get back. See benchDisconnected. -->
 		<template v-if="isSM">
 			<div class="mt-6 flex items-start justify-between gap-4">
 				<div class="flex flex-col gap-0.5">
@@ -169,13 +172,12 @@
 					<span class="max-w-lg text-p-sm text-ink-gray-6">
 						Destroys this workspace's container and attaches a fresh one, then
 						reconnects automatically — use it when the workspace is stuck or won't
-						connect. Chat is unavailable while it runs (usually a few minutes). Your
-						subscription, chat history and AI connections are kept unless you tick the
-						options.
+						connect. Chat is unavailable while it runs (usually a few minutes). Pick
+						how deep to go below; each level keeps everything the one above it kept.
 					</span>
 				</div>
 				<Button
-					v-if="!resetting && !resetOpen"
+					v-if="!resetting && !resetOpen && !benchDisconnected"
 					variant="subtle"
 					theme="red"
 					label="Reset workspace"
@@ -183,7 +185,24 @@
 				/>
 			</div>
 
-			<div v-if="resetting" class="mt-3">
+			<div v-if="benchDisconnected" class="mt-3 max-w-lg">
+				<div
+					class="rounded-lg border border-outline-red-2 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
+				>
+					<p class="font-medium">This bench is disconnected.</p>
+					<p class="mt-1">{{ disconnectRecoveryText }}</p>
+				</div>
+				<Button
+					class="mt-3"
+					variant="subtle"
+					theme="red"
+					label="Reconnect this bench"
+					iconLeft="external-link"
+					@click="goReconnect"
+				/>
+			</div>
+
+			<div v-else-if="resetting" class="mt-3">
 				<Badge :label="resetStatusLabel" theme="blue" variant="subtle" />
 				<p class="mt-2 text-p-sm text-ink-gray-6">{{ resetNote }}</p>
 			</div>
@@ -195,35 +214,52 @@
 					class="w-full rounded-md border bg-surface-white p-2 text-p-sm text-ink-gray-8"
 					placeholder="What's wrong? (optional)"
 				/>
-				<label class="mt-3 flex cursor-pointer items-start gap-2.5">
-					<input v-model="wipeData" type="checkbox" class="mt-0.5" />
-					<span>
-						<span class="block text-p-sm font-medium text-ink-gray-8">
-							Also delete workspace content
+				<!-- One escalating choice, not four independent checkboxes: the depths
+				     are cumulative (L2 implies L1's rebuild, L4 implies L1-L3), so
+				     separate toggles could combine into a depth request_workspace_reset
+				     has no name for. A radio ladder makes "L3 without L2" unrepresentable
+				     instead of merely undocumented. -->
+				<fieldset class="mt-3">
+					<legend class="text-p-sm font-medium text-ink-gray-8">How deep?</legend>
+					<label
+						v-for="d in RESET_DEPTHS"
+						:key="d.value"
+						class="mt-2 flex cursor-pointer items-start gap-2.5"
+					>
+						<input
+							v-model="resetDepth"
+							type="radio"
+							name="reset-depth"
+							:value="d.value"
+							class="mt-0.5"
+						/>
+						<span>
+							<span class="block text-p-sm font-medium text-ink-gray-8">{{ d.title }}</span>
+							<span class="block text-p-sm text-ink-gray-6">{{ d.description }}</span>
 						</span>
-						<span class="block text-p-sm text-ink-gray-6">
-							Permanently deletes chats, skills, macros, triggers, learned patterns,
-							wiki pages and dashboards. Cannot be undone.
-						</span>
-					</span>
-				</label>
-				<label class="mt-2 flex cursor-pointer items-start gap-2.5">
-					<input v-model="revokeLlm" type="checkbox" class="mt-0.5" />
-					<span>
-						<span class="block text-p-sm font-medium text-ink-gray-8">
-							Also disconnect AI model connections
-						</span>
-						<span class="block text-p-sm text-ink-gray-6">
-							Removes every connected model and key; you'll set them up again after
-							the reset.
-						</span>
-					</span>
-				</label>
+					</label>
+				</fieldset>
+				<!-- L4 is a lockout path (it ends with no admin credentials on this
+				     bench): shown the moment it is SELECTED, not just inside the confirm
+				     dialog at submit time - the plan requires the cost and the way back
+				     to be visible before the choice can be made, not just before it's
+				     final. -->
+				<div
+					v-if="resetDepth === DEPTH_DISCONNECT"
+					class="mt-3 rounded-lg border border-outline-red-2 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
+				>
+					This is the deepest reset: once the rebuild finishes, this bench also
+					disconnects from your account. Reconnect with the one-time code emailed
+					to this workspace's registered address (plus its company name, if that
+					address covers more than one). Refused up front — before anything is
+					touched — if your subscription would not be eligible to reconnect
+					afterwards.
+				</div>
 				<div ref="resetFormEl" class="mt-4 flex items-center gap-2">
 					<Button
 						variant="subtle"
 						theme="red"
-						label="Reset workspace"
+						:label="resetDepth === DEPTH_DISCONNECT ? 'Reset and disconnect' : 'Reset workspace'"
 						iconLeft="refresh-cw"
 						:loading="resetBusy"
 						@click="doReset"
@@ -235,6 +271,37 @@
 						@click="closeReset"
 					/>
 				</div>
+			</div>
+
+			<!-- Disconnect this bench: the SEPARATE terminal action (T3,
+			     disconnect_bench). Deliberately not a fifth reset depth in the
+			     ladder above - no rebuild, no poll, and it is worded for what it
+			     is (leaving), not folded into "reset". Always a lockout path, so
+			     the cost + recovery text is in the static description, not gated
+			     behind opening a form first. -->
+			<div v-if="!benchDisconnected" class="mt-8 flex items-start justify-between gap-4">
+				<div class="flex flex-col gap-0.5">
+					<span class="text-base font-medium text-ink-gray-8">Disconnect this bench</span>
+					<span class="max-w-lg text-p-sm text-ink-gray-6">
+						Leaves your account rather than resetting anything — no rebuild, no
+						polling. Clears this bench's connection to your subscription; chat stops
+						working immediately. The only way back is a one-time code emailed to
+						this workspace's registered address (plus its company name, if that
+						address covers more than one).
+					</span>
+					<span v-if="resetting" class="max-w-lg text-p-sm text-ink-gray-5">
+						A reset is in progress — wait for it to finish before disconnecting.
+					</span>
+				</div>
+				<Button
+					variant="subtle"
+					theme="red"
+					label="Disconnect"
+					iconLeft="log-out"
+					:loading="disconnectBusy"
+					:disabled="resetting"
+					@click="doDisconnectBench"
+				/>
 			</div>
 		</template>
 	</SettingsPane>
@@ -456,8 +523,66 @@ const resetReason = ref("");
 const resetBusy = ref(false);
 const resetting = ref(false);
 const resetState = ref({});
-const wipeData = ref(false);
-const revokeLlm = ref(false);
+
+// The four depths (jarvis/onboarding.py request_workspace_reset), each adding
+// to the one above — see RESET_DEPTHS below for the ladder itself.
+const DEPTH_REBUILD = 1;
+const DEPTH_WIPE_DATA = 2;
+const DEPTH_REVOKE_LLM = 3;
+const DEPTH_DISCONNECT = 4;
+const resetDepth = ref(DEPTH_REBUILD);
+const wipeData = computed(() => resetDepth.value >= DEPTH_WIPE_DATA);
+const revokeLlm = computed(() => resetDepth.value >= DEPTH_REVOKE_LLM);
+const disconnectAfter = computed(() => resetDepth.value >= DEPTH_DISCONNECT);
+
+const RESET_DEPTHS = [
+	{
+		value: DEPTH_REBUILD,
+		title: "Rebuild the container",
+		description:
+			"Destroys and rebuilds the container, then reconnects automatically. Your subscription, chat history and AI connections are kept.",
+	},
+	{
+		value: DEPTH_WIPE_DATA,
+		title: "+ Delete workspace content",
+		description:
+			"Also permanently deletes chats, skills, macros, triggers, learned patterns, wiki pages and dashboards. Cannot be undone.",
+	},
+	{
+		value: DEPTH_REVOKE_LLM,
+		title: "+ Disconnect AI model connections",
+		description:
+			"Also removes every connected model and key; you'll set them up again after the reset.",
+	},
+	{
+		value: DEPTH_DISCONNECT,
+		title: "+ Disconnect this bench",
+		description:
+			"Also clears this bench's connection to your account once the rebuild finishes. Refused up front if your subscription would not be eligible to reconnect afterwards.",
+	},
+];
+
+// Terminal state shared by L4 (via the poll, see pollReset) and the separate
+// Disconnect action below: this bench has no admin credentials left.
+// benchNeedsCompany is always definitive (true/false), never null — L4's own
+// request/poll fetches it from bench_connection_state() on the poll response,
+// and disconnect_bench() reports it directly (see disconnectRecoveryText).
+const benchDisconnected = ref(false);
+const benchNeedsCompany = ref(false);
+const disconnectRecoveryText = computed(() => {
+	const base =
+		"Reconnect with the one-time code emailed to this workspace's registered address.";
+	if (benchNeedsCompany.value === true) {
+		return `${base} That address is linked to more than one company, so you'll also need to give the company name.`;
+	}
+	return base;
+});
+// The wizard owns the reconnect flow (code entry, company disambiguation);
+// land on it rather than duplicating that screen here — same convention as
+// ChatView.vue's goReconnect for the site_replaced billing notice.
+function goReconnect() {
+	window.location.assign("/jarvis/onboarding");
+}
 
 // Poll every 3s while resetting, up to 15 min; the tenant-side */5 cron backstop
 // converges a closed tab, so timing out here just stops the spinner.
@@ -486,8 +611,7 @@ function openReset() {
 function closeReset() {
 	resetOpen.value = false;
 	resetReason.value = "";
-	wipeData.value = false;
-	revokeLlm.value = false;
+	resetDepth.value = DEPTH_REBUILD;
 }
 
 async function doReset() {
@@ -506,10 +630,15 @@ async function doReset() {
 			"Your AI model connections will be disconnected — you'll set them up again after the reset."
 		);
 	}
+	if (disconnectAfter.value) {
+		parts.push(
+			"Once the rebuild finishes, this bench also disconnects from your account — chat stays unavailable until you reconnect with a one-time code emailed to this workspace's registered address (plus its company name, if that address covers more than one). Refused up front, before anything changes, if your subscription would not be eligible to reconnect."
+		);
+	}
 	const ok = await confirm({
-		title: "Reset workspace?",
+		title: disconnectAfter.value ? "Reset and disconnect this bench?" : "Reset workspace?",
 		message: parts.join(" "),
-		confirmLabel: "Reset workspace",
+		confirmLabel: disconnectAfter.value ? "Reset and disconnect" : "Reset workspace",
 		danger: true,
 	});
 	if (!ok) return;
@@ -519,6 +648,7 @@ async function doReset() {
 			(await api.requestWorkspaceReset(resetReason.value, {
 				wipeData: wipeData.value,
 				revokeLlm: revokeLlm.value,
+				disconnectAfter: disconnectAfter.value,
 			})) || {};
 		closeReset();
 		resetState.value = out;
@@ -526,10 +656,88 @@ async function doReset() {
 		toast.success("Resetting your workspace.");
 		startPoll();
 	} catch (e) {
+		// L4's refusal (ineligible to reconnect) throws BEFORE anything is
+		// rebuilt or cleared (onboarding.py request_workspace_reset) — the
+		// server's message explains why, so it is shown verbatim rather than
+		// replaced with a generic one.
 		toast.error((e && e.messages && e.messages[0]) || "Could not reset the workspace.");
+		// ...but a refusal is not the only way this call fails. Admin rebuilds
+		// SYNCHRONOUSLY inside the request, so a slow reset can outlive the web
+		// worker's own ceiling (gunicorn http_timeout, ~120s by default) and this
+		// call dies while the reset it started proceeds. The bench keeps its claim
+		// on purpose for exactly that case (onboarding.py: a timeout is not
+		// evidence the rebuild did not start), and reconcile_pending_workspace_reset
+		// converges it — but the customer would sit on a bare error toast watching
+		// nothing happen, and reload into a workspace mid-rebuild with no
+		// explanation. Start polling instead: workspace_reset_state is read-only
+		// and reports `resetting: false` almost immediately if there is in fact no
+		// reset, which just stops the spinner.
+		if (isServerUnreachable(e)) {
+			resetting.value = true;
+			startPoll();
+		}
 	} finally {
 		resetBusy.value = false;
 	}
+}
+
+// Disconnect this bench (danger zone, separate from the ladder above) -------
+const disconnectBusy = ref(false);
+
+async function doDisconnectBench() {
+	if (resetting.value) return; // also guarded by the button's :disabled — defensive against a stray click racing the poll
+	const ok = await confirm({
+		title: "Disconnect this bench?",
+		message:
+			"This clears this bench's connection to your account — chat stops working immediately and nothing rebuilds automatically. The only way back is a one-time code emailed to this workspace's registered address (plus its company name, if that address covers more than one). Refused up front, before anything changes, if your subscription would not be eligible to reconnect.",
+		confirmLabel: "Disconnect",
+		danger: true,
+	});
+	if (!ok) return;
+	disconnectBusy.value = true;
+	try {
+		const res = (await api.disconnectBench()) || {};
+		benchNeedsCompany.value = res.needs_company === true;
+		benchDisconnected.value = true;
+		toast.success(
+			res.already_disconnected
+				? "This bench was already disconnected."
+				: "This bench is now disconnected."
+		);
+	} catch (e) {
+		toast.error((e && e.messages && e.messages[0]) || "Could not disconnect this bench.");
+	} finally {
+		disconnectBusy.value = false;
+	}
+}
+
+// Did the call fail because the server never answered, rather than because it
+// answered "no"? Only the former means the reset may be running regardless.
+//
+// A server-side REFUSAL arrives with Frappe's `messages` (from _server_messages,
+// which frappe.throw populates) or an explicit 4xx: request_workspace_reset
+// refuses that way for an ineligible L4, a different-depth reset and a
+// mid-disconnect reset, and in every one of those nothing was started. A dead
+// worker, a proxy timeout or a dropped connection has no message and no 4xx.
+// Defaults to FALSE for anything ambiguous: spuriously polling would leave a
+// spinner over a workspace that is not resetting.
+function isServerUnreachable(e) {
+	const status = (e && (e.status || (e.response && e.response.status))) || 0;
+	// STATUS first, because `messages` is not the reliable discriminator the first
+	// draft assumed: frappe-ui's call.js synthesises `messages: ['Internal Server
+	// Error']` for ANY parseable JSON error body with no _server_messages, so a
+	// JSON-bodied 502/504 carries a message and would have been misread as a
+	// refusal. A 5xx is the server failing regardless of what it says.
+	if (status >= 500) return true;
+	// A 4xx is a decision: request_workspace_reset refuses this way for an
+	// ineligible L4, a different-depth reset, a non-cumulative depth and a
+	// mid-disconnect reset, and in every one of those nothing was started.
+	if (status >= 400) return false;
+	// No status at all: a dead worker, a dropped connection, a proxy that never
+	// answered. Server-side messages here mean the request WAS served, so they
+	// still rule it out.
+	if (e && e.messages && e.messages.length) return false;
+	return status === 0;
 }
 
 function startPoll() {
@@ -557,8 +765,50 @@ async function pollReset() {
 		return; // transient — the container is mid-rebuild; keep polling
 	}
 	resetState.value = s;
+	// L4's admin-connection clear only runs once this same poll has observed
+	// the rebuilt container Ready and persisted the fresh connection
+	// (onboarding.py _workspace_reset_poll), so `disconnected` and `ready` land
+	// on the SAME response. Check `disconnected` FIRST and return: this bench
+	// has no admin credentials on every later poll, and the `ready` reload
+	// below would bounce it behind the onboarding gate poster instead of
+	// showing it the way back — an unreachable-admin blip must never look like
+	// this deliberate, permanent state, and vice versa.
+	if (s.disconnected) {
+		stopPoll();
+		resetting.value = false;
+		// Fetch the definitive needs_company from local settings so the recovery
+		// text is never hedged (bench_connection_state returns {disconnected,
+		// needs_company} read from local settings with no admin call).
+		try {
+			const state = (await api.benchConnectionState()) || {};
+			benchNeedsCompany.value = state.needs_company === true;
+		} catch (e) {
+			// If the endpoint fails, default to false (no company name needed)
+			// rather than hedging. A disconnected bench with no local settings
+			// answer is rare, and "no company needed" is the less disruptive guess.
+			benchNeedsCompany.value = false;
+		}
+		benchDisconnected.value = true;
+		toast.success("Workspace reset — this bench is now disconnected.");
+		return;
+	}
 	if (s.ready) {
 		stopPoll();
+		// The customer asked for L4, confirmed an irreversibility warning, and got
+		// L3: the workspace WAS rebuilt, but this bench is still connected. Say so
+		// rather than toasting plain success, and do NOT reload — the reload would
+		// drop the only message explaining it, and there is nothing to reload for
+		// because the connection is unchanged. Server side: _workspace_reset_poll's
+		// `disconnect_blocked`, set when the eligibility re-check refused (the
+		// subscription went ineligible mid-rebuild) or the container teardown could
+		// not complete.
+		if (s.disconnect_blocked) {
+			resetting.value = false;
+			toast.error(
+				`Your workspace was reset, but this bench could not be disconnected: ${s.disconnect_blocked}`
+			);
+			return;
+		}
 		toast.success("Workspace is back — reloading.");
 		// Full reload drops the memoized readiness verdict (same ending as the
 		// onboarding wizard).
@@ -568,8 +818,54 @@ async function pollReset() {
 
 async function resumeResetIfInFlight() {
 	if (!isSM) return;
+	// The credential-free check comes FIRST, and the ORDER is the fix — but not for
+	// the reason this comment used to give (round-5 MINOR 10). It claimed
+	// workspaceResetState() throws for a disconnected bench. It does not:
+	// require_jarvis_admin is a role check independent of connection state, and the
+	// get_connection failure is caught inside _workspace_reset_poll, which returns a
+	// normal 200 with ready:false.
+	//
+	// The real reason: that 200 says "not resetting, not ready", which is
+	// indistinguishable from "nothing to resume" — so a disconnected bench fell
+	// through to the generic onboarding poster with no way back shown.
+	// bench_connection_state answers the question that actually distinguishes them,
+	// from local settings, with no admin call.
+	try {
+		const local = (await api.benchConnectionState()) || {};
+		if (local.disconnected) {
+			benchNeedsCompany.value = local.needs_company === true;
+			benchDisconnected.value = true;
+			return;
+		}
+	} catch (e) {
+		// Local endpoint unavailable: fall through to the reset poll below rather
+		// than assuming either state.
+	}
 	try {
 		const s = (await api.workspaceResetState()) || {};
+		if (s.disconnected) {
+			// _workspace_reset_poll is not read-only — persisting the fresh
+			// connection and clearing admin creds are side effects of calling it,
+			// not just facts it reports. So THIS mount's own resume call can be
+			// the one that finishes an L4 left mid-poll by a closed tab. Without
+			// this check that leaves the bench disconnected server-side with the
+			// pane showing no trace of it — same distinct-terminal-state
+			// requirement as pollReset below, just reached from a fresh mount
+			// instead of an in-progress poll.
+			resetState.value = s;
+			// Fetch the definitive needs_company from local settings so the
+			// recovery text on reload is never hedged.
+			try {
+				const state = (await api.benchConnectionState()) || {};
+				benchNeedsCompany.value = state.needs_company === true;
+			} catch (e) {
+				// If the endpoint fails, default to false (no company name needed)
+				// rather than hedging.
+				benchNeedsCompany.value = false;
+			}
+			benchDisconnected.value = true;
+			return;
+		}
 		if (s.resetting && !s.ready) {
 			resetState.value = s;
 			resetting.value = true;

--- a/frontend/src/components/shell/OnboardingGate.spec.js
+++ b/frontend/src/components/shell/OnboardingGate.spec.js
@@ -1,0 +1,131 @@
+// T16 (MAJOR 1 fix, Amendment 2): AppShell renders OnboardingGate IN PLACE OF
+// the sidebar + router-view for a disconnected bench (is_ready_for_chat
+// returns "signup", same as a first-time workspace), so this gate is the only
+// screen a reloaded disconnected bench actually lands on. It must name the
+// emailed-code reconnect there instead of the generic first-time-setup
+// poster - and a first-time bench must never be told it was disconnected.
+//
+// Mounted via @vue/test-utils and driven through the exposed <script setup>
+// bindings (w.vm.*) rather than DOM clicks - same convention as
+// GeneralPane.spec.js in the settings directory.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const api = vi.hoisted(() => ({
+	benchConnectionState: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+const push = vi.hoisted(() => vi.fn());
+vi.mock("vue-router", () => ({ useRouter: () => ({ push }) }));
+
+vi.mock("frappe-ui", () => ({
+	// label rendered as text (not a slot) so tests can assert on the CTA copy,
+	// matching how OnboardingGate.vue actually invokes <Button :label="...">.
+	Button: {
+		name: "Button",
+		props: ["label"],
+		template: '<button @click="$emit(\'click\')">{{ label }}</button>',
+	},
+}));
+
+import OnboardingGate from "./OnboardingGate.vue";
+
+const STUBS = { JarvisMark: true };
+
+async function mountGate() {
+	const w = mount(OnboardingGate, { global: { stubs: STUBS } });
+	await flushPromises();
+	return w;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	window.is_system_manager = false;
+	window.is_jarvis_admin = true;
+	api.benchConnectionState.mockResolvedValue({ disconnected: false, needs_company: false });
+});
+
+describe("not disconnected: unchanged generic first-time-setup copy", () => {
+	it("renders the original poster untouched when bench_connection_state reports false", async () => {
+		api.benchConnectionState.mockResolvedValue({ disconnected: false, needs_company: false });
+		const w = await mountGate();
+
+		expect(w.vm.disconnected).toBe(false);
+		expect(w.text()).toContain("Finish setting up Jarvis");
+		expect(w.text()).toContain(
+			"This workspace isn't connected to an AI agent yet. Complete a short setup to start chatting with Jarvis about your ERPNext data."
+		);
+		expect(w.text()).toContain("Complete setup");
+		expect(w.text()).not.toContain("disconnected");
+		expect(w.text()).not.toContain("Reconnect");
+	});
+});
+
+describe("endpoint throws: unchanged generic copy, never a false disconnected claim", () => {
+	it("falls through to the same poster a genuine first-time bench sees", async () => {
+		api.benchConnectionState.mockRejectedValue(new Error("network error"));
+		const w = await mountGate();
+
+		expect(w.vm.disconnected).toBe(false);
+		expect(w.text()).toContain("Finish setting up Jarvis");
+		expect(w.text()).toContain("This workspace isn't connected to an AI agent yet.");
+		expect(w.text()).not.toContain("disconnected");
+		expect(w.text()).not.toContain("Reconnect");
+	});
+});
+
+describe("disconnected: true names the emailed-code reconnect (admin)", () => {
+	it("shows the recovery route instead of the generic poster, with a working CTA", async () => {
+		window.is_system_manager = true;
+		api.benchConnectionState.mockResolvedValue({ disconnected: true, needs_company: false });
+		const w = await mountGate();
+
+		expect(w.vm.disconnected).toBe(true);
+		expect(w.text()).toContain("Reconnect Jarvis");
+		expect(w.text()).toContain("This workspace still exists");
+		expect(w.text()).toContain(
+			"Reconnect with the one-time code emailed to this workspace's registered address."
+		);
+		// The generic first-time copy must not also be present.
+		expect(w.text()).not.toContain("isn't connected to an AI agent yet");
+		// needs_company is false here, so no company clause.
+		expect(w.text()).not.toContain("company name");
+
+		expect(w.text()).toContain("Reconnect");
+		// Same route the "Complete setup" CTA already used - the wizard owns
+		// the reconnect flow (code entry, company disambiguation).
+		await w.findComponent({ name: "Button" }).trigger("click");
+		expect(push).toHaveBeenCalledWith({ name: "Onboarding" });
+	});
+});
+
+describe("needs_company: true adds the company-name clause", () => {
+	it("tells the admin they'll also need the company name", async () => {
+		window.is_system_manager = true;
+		api.benchConnectionState.mockResolvedValue({ disconnected: true, needs_company: true });
+		const w = await mountGate();
+
+		expect(w.vm.needsCompany).toBe(true);
+		expect(w.text()).toContain(
+			"That address is linked to more than one company, so you'll also need to give the company name."
+		);
+	});
+
+	it("tells a non-admin teammate the same, phrased for relaying it", async () => {
+		window.is_system_manager = false;
+		window.is_jarvis_admin = false;
+		api.benchConnectionState.mockResolvedValue({ disconnected: true, needs_company: true });
+		const w = await mountGate();
+
+		expect(w.text()).toContain("Ask your administrator (a System Manager) to reconnect it");
+		expect(w.text()).toContain(
+			"That address is linked to more than one company, so they'll also need to give the company name."
+		);
+		// Non-admins never get the CTA button (matches the pre-existing
+		// "Complete setup" gating this branch reuses) - only the unconditional
+		// "Switch to Desk" plain button remains.
+		expect(w.findComponent({ name: "Button" }).exists()).toBe(false);
+	});
+});

--- a/frontend/src/components/shell/OnboardingGate.vue
+++ b/frontend/src/components/shell/OnboardingGate.vue
@@ -14,23 +14,31 @@
 			<JarvisMark :size="56" :radius="14" class="mb-6" />
 
 			<h1 class="mb-2.5 text-2xl font-semibold leading-tight text-ink-gray-9">
-				Finish setting up {{ agentName }}
+				{{ disconnected ? `Reconnect ${agentName}` : `Finish setting up ${agentName}` }}
 			</h1>
 
-			<p v-if="isSystemManager" class="mb-7 text-p-base text-ink-gray-6">
+			<!-- MAJOR 1 fix: showGate covers a disconnected bench too - a cleared
+			     admin connection makes is_ready_for_chat return "signup", same as
+			     a first-time bench - and this gate is the only screen it lands on;
+			     every openSettings() call site (GeneralPane included) lives in the
+			     unrendered subtree behind showGate. The two branches below are
+			     byte-identical to the pre-T16 copy so a not-disconnected (or
+			     failed-call) bench renders exactly as it did before. -->
+			<p v-if="!disconnected && isSystemManager" class="mb-7 text-p-base text-ink-gray-6">
 				This workspace isn't connected to an AI agent yet. Complete a short setup to start
 				chatting with {{ agentName }} about your ERPNext data.
 			</p>
-			<p v-else class="mb-7 text-p-base text-ink-gray-6">
+			<p v-else-if="!disconnected" class="mb-7 text-p-base text-ink-gray-6">
 				{{ agentName }} isn't set up for this workspace yet. Please ask your administrator
 				(a System Manager) to complete onboarding.
 			</p>
+			<p v-else class="mb-7 text-p-base text-ink-gray-6">{{ recoveryMessage }}</p>
 
 			<Button
 				v-if="isSystemManager"
 				variant="solid"
 				size="lg"
-				label="Complete setup"
+				:label="disconnected ? 'Reconnect' : 'Complete setup'"
 				iconRight="arrow-right"
 				@click="goOnboard"
 			/>
@@ -49,10 +57,12 @@
 </template>
 
 <script setup>
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { Button } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
 import { agentName } from "@/branding";
+import { benchConnectionState } from "@/api";
 
 const router = useRouter();
 
@@ -65,6 +75,45 @@ const router = useRouter();
 // gets the "ask your administrator" copy instead. PART 4 REVISED TASK 49(c):
 // widened to the Jarvis Admin tenant-admin tier.
 const isSystemManager = !!(window.is_system_manager || window.is_jarvis_admin);
+
+// MAJOR 1: a disconnected bench (L4 reset, or the separate "Disconnect this
+// bench" action) also lands here — is_ready_for_chat returns "signup" for it,
+// same as a workspace that never onboarded, and this gate replaces the whole
+// app for both. Defaults below keep the poster generic until proven otherwise.
+const disconnected = ref(false);
+const needsCompany = ref(false);
+
+onMounted(async () => {
+	// bench_connection_state() reads local settings only and makes no admin
+	// call, so it still answers on a disconnected bench even though that bench
+	// holds no admin credentials — the same property GeneralPane.vue's
+	// resumeResetIfInFlight relies on. A thrown error must leave `disconnected`
+	// at its false default: a first-time bench must never be told it was
+	// disconnected.
+	try {
+		const state = (await benchConnectionState()) || {};
+		disconnected.value = state.disconnected === true;
+		needsCompany.value = state.needs_company === true;
+	} catch (e) {
+		// Local endpoint unavailable — fall through to the generic poster
+		// rather than guessing at a disconnected state.
+	}
+});
+
+// Mirrors GeneralPane.vue's disconnectRecoveryText: same emailed-code
+// reconnect, same "needs_company" clause, worded for whichever role is
+// looking at this gate — the admin who can act on it via the Button below,
+// or the teammate who can only relay it to one.
+const recoveryMessage = computed(() => {
+	const base = isSystemManager
+		? "This workspace still exists — it's just disconnected from your account. Reconnect with the one-time code emailed to this workspace's registered address."
+		: "This workspace still exists — it's just disconnected from your account. Ask your administrator (a System Manager) to reconnect it with the one-time code emailed to this workspace's registered address.";
+	if (!needsCompany.value) return base;
+	const companyClause = isSystemManager
+		? " That address is linked to more than one company, so you'll also need to give the company name."
+		: " That address is linked to more than one company, so they'll also need to give the company name.";
+	return base + companyClause;
+});
 
 function goOnboard() {
 	router.push({ name: "Onboarding" });

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -344,6 +344,21 @@ def reconnect_eligibility(email: str, company_name: str = "") -> dict:
 	)
 
 
+def reconnect_eligibility_me() -> dict:
+	"""Authenticated: would the emailed-code reconnect restore THIS bench's account?
+
+	Sends no identity. What this site stores as ``jarvis_admin_customer_email`` is
+	admin's synthetic OAuth login (``cust-<hash>@jarvis.invalid``), not the contact
+	address ``can_reconnect`` resolves on — so passing it, as the guest variant
+	above requires, matches nothing and echoes back a value that must never be
+	shown. Admin derives the customer from these credentials instead.
+
+	Unlike ``reconnect_eligibility``, the caller must NOT treat a failure as a soft
+	"don't offer": this gates an irreversible credential clear, so a failure has to
+	mean "refuse". Returns {recoverable, needs_company, reason}."""
+	return _post(path=_m("billing.reconnect.can_reconnect_me"), body={}, timeout_s=8)
+
+
 def site_replacement() -> dict:
 	"""Guest: was THIS site's account reconnected somewhere else?
 
@@ -1220,6 +1235,52 @@ def unpair_chat_devices() -> dict:
 	"""Drop the container's paired devices. Idempotent; a file op on the agent,
 	so it needs none of the disconnect budget above."""
 	return _post(path=_m("api.tenant.unpair_chat_devices"), body={}, timeout_s=60)
+
+
+def prepare_bench_disconnect() -> dict:
+	"""Ask admin to tear the container down on this bench's behalf, BEFORE the
+	bench destroys the credentials that could ever reach it again.
+
+	One authenticated call replacing ``post_subscription_disconnect`` +
+	``unpair_chat_devices`` on the disconnect path. Those two gate on admin's
+	``current_customer``, which 403s a SUSPENDED account — a cohort that is
+	allowed to disconnect — so for exactly that cohort both teardowns were
+	refused and the refusal was swallowed as if the container were unreachable.
+	admin performs both legs itself, where the caller's status is already known.
+
+	Returns ``{"profile_cleared": bool, "devices_unpaired": bool,
+	"removed": int, "detail": str}``. The two legs are reported separately
+	because they fail independently: see admin's
+	``api.tenant.prepare_bench_disconnect``. The caller gates its credential
+	clear on ``devices_unpaired``.
+
+	Rides ``_DISCONNECT_TIMEOUT_S`` rather than the shared 150s, and this one is
+	not a judgement call — admin's own worst case is arithmetic: up to 30s
+	acquiring ``named_lock`` (``url_alloc._PORT_LOCK_TIMEOUT_S``), 15s for
+	``agent_client.unpair_devices``, then 150s for ``agent_client.
+	delete_auth_profile`` (which runs doctor + restart inside its own budget).
+	That is ~195s before admin's handler overhead and the HTTPS round trip.
+	DEFAULT_TIMEOUT_S = 150 would therefore hang up on a slow teardown while
+	admin was still holding the lock and still working — and the caller would
+	read that ``requests.Timeout`` as AdminUnreachableError, the ONE signal it
+	is entitled to treat as "proceed and clear the credentials". It would then
+	destroy them against a teardown whose outcome was genuinely unknown.
+
+	INVARIANT: keep this strictly above admin's worst case above. The same
+	gunicorn ``http_timeout`` ceiling documented on _DISCONNECT_TIMEOUT_S
+	applies here and is not enforceable from this file.
+
+	Raises:
+		AdminAuthError, AdminUnreachableError, AdminValidationError,
+		AdminRateLimitedError — the caller MUST tell a refusal (4xx / a
+		permanent rejection) apart from genuine unreachability. Only the
+		latter authorizes proceeding without a confirmed teardown.
+	"""
+	return _post(
+		path=_m("api.tenant.prepare_bench_disconnect"),
+		body={},
+		timeout_s=_DISCONNECT_TIMEOUT_S,
+	)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -4,6 +4,19 @@ Gated by the System Manager role. Exposed as the ``bench reset-onboarding``
 command (``jarvis.commands``) to wipe local state so the operator can run the
 onboarding wizard fresh without manual DB surgery.
 
+This is one of THREE callers that compose from ``jarvis.settings_reset`` -
+``dev.reset_onboarding`` (FULL), ``onboarding._revoke_llm_connections`` (LLM) and
+``onboarding._clear_admin_connection`` (CONNECTION | OAUTH_MARKERS). That module's
+docstring enumerates FIVE reset PATHS, which is a different count and both are
+right: the self-serve ladder is four user-facing depths served by two call sites,
+because L1 and L2 clear no settings field at all. Do not "correct" either number
+to match the other.
+
+Here, ``reset_onboarding`` applies ``settings_reset.FULL`` (the entire
+CONNECTION + LLM spec). The self-serve ladder in
+``onboarding.request_workspace_reset`` offers granular depths; this CLI command is
+the operator's blunt tool.
+
 Companion to ``jarvis_admin_v2.api.dev.purge_customer`` on the admin side -
 the admin button wipes admin-side records; this clears the customer bench.
 
@@ -33,12 +46,18 @@ _RESET_LITERAL_DEFAULTS = dict(_FULL.literals)
 
 
 def reset_onboarding(wipe_data: bool = False) -> dict:
-	"""Wipe local Jarvis Settings connection + LLM credentials so the
-	customer bench can run the onboarding wizard from step 1 again.
+	"""Wipe local Jarvis Settings connection + LLM credentials (apply ``FULL``)
+	so the customer bench can run the onboarding wizard from step 1 again.
+
+	The CLI command ``bench reset-onboarding`` is the operator's blunt tool;
+	``onboarding.request_workspace_reset`` offers customers a four-level ladder
+	(rebuild only → + wipe data → + revoke LLM → + disconnect) so they can
+	choose their reset depth. This function applies the deepest level (equivalent
+	to the ladder's L4 + no rebuild polling).
 
 	``wipe_data`` additionally deletes all workspace content (chats, skills,
 	macros, triggers, learning artifacts, wiki, dashboards — the same
-	``onboarding._WIPE_DOCTYPES`` set the self-serve reset offers) for a true
+	``onboarding._WIPE_DOCTYPES`` set the ladder offers in its L2) for a true
 	factory reset. The ``bench reset-onboarding`` CLI passes it by default;
 	programmatic callers must opt in.
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -95,6 +95,8 @@
   "last_sync_section",
   "last_sync_at",
   "last_sync_status",
+  "workspace_reset_claimed_at",
+  "reconnect_needs_company",
   "llm_pool_synced_at",
   "llm_direct_synced_at",
   "chat_was_ready_at",
@@ -719,6 +721,23 @@
    "fieldtype": "Long Text",
    "label": "Last Sync Status",
    "read_only": 1
+  },
+  {
+   "fieldname": "workspace_reset_claimed_at",
+   "fieldtype": "Datetime",
+   "label": "Workspace Reset Claimed At",
+   "hidden": 1,
+   "read_only": 1,
+   "description": "When request_workspace_reset (or disconnect_bench) CLAIMED last_sync_status, before its long admin calls. Reset bookkeeping, not tenancy state, so it is in NO settings_reset ResetSpec - a disconnect that cleared it would destroy the only thing able to resolve its own orphaned claim. reconcile_pending_workspace_reset needs it to tell admin's fresh request row from an older one, and to know when an unresolvable claim has waited long enough to expire. Cleared on release and on expiry; kept while the operation is genuinely in flight."
+  },
+  {
+   "fieldname": "reconnect_needs_company",
+   "fieldtype": "Check",
+   "label": "Reconnect Needs Company",
+   "default": "0",
+   "hidden": 1,
+   "read_only": 1,
+   "description": "Whether the emailed-code reconnect will ALSO require the company name, because this workspace's registered address owns more than one eligible account. Written by _clear_admin_connection at the moment of the clear, AFTER the CONNECTION sweep, and in NO settings_reset ResetSpec - it describes the aftermath of a disconnect, not the tenancy that was disconnected. It cannot be recomputed later: once the admin credentials are gone there is nothing left to ask, which is why bench_connection_state used to hardcode False and send customers to a reconnect they could not complete."
   },
   {
    "description": "Set when a pool (proxy) config was last APPLIED to the container via admin. Distinguishes a provisioned pool from one whose first sync is still pending/failed - is_ready_for_chat gates on it.",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -545,6 +545,9 @@ class JarvisSettings(Document):
 					# Mask in-memory so nothing downstream re-writes plaintext.
 					self.llm_api_key = "*" * 10
 
+		if self._workspace_op_holds_status():
+			return
+
 		# Step 4: Route to pool or single-model path. Keyed on pool_mode, NOT
 		# proxy_active: an openclaw-direct pool still has to be pushed as a whole
 		# spec through /llm-pool, and pushing its models[0] through /llm-creds
@@ -765,8 +768,46 @@ class JarvisSettings(Document):
 			idempotency_key=idempotency_key,
 		)
 
+	def _workspace_op_holds_status(self) -> bool:
+		"""True when a workspace reset or bench disconnect owns ``last_sync_status``,
+		so the admin SYNC must be skipped.
+
+		The post-lock design in ``jarvis.onboarding`` rests on that claim being
+		durable once the redis lock is released. Every status the sync legs write
+		would overwrite it, and the diff gate that might have saved us
+		(``_should_skip_admin_sync``) requires ``last_sync_status.startswith("ok")``
+		— which a claim never satisfies — so the skip can never apply while one is
+		held. A single save from a second tab destroyed it: a pre-flight claim was
+		left with nothing to resolve it, a converging one left the rebuild
+		unconverged with ``agent_url`` blank and chat dead until the daily sync.
+
+		Skipping the sync is right on its own terms too. During a reset the container
+		is being replaced and during a disconnect it is being torn down, so there is
+		nothing the push could usefully reach; ``onboarding._workspace_reset_poll``
+		re-enqueues the pool sync once the rebuilt container is reachable.
+
+		ONE definition, consulted at the two places that actually push — the unified
+		path's Step 4 and the legacy path — never at the top of ``on_update``. The
+		first cut of this guard returned early from ``on_update`` itself and thereby
+		also skipped ``validate_models`` (the app's ONLY call site), the derived
+		flags, the legacy mirror and the encrypted ``llm_api_key`` write, so
+		``save_llm_creds`` returned SUCCESS while the credential was never stored and
+		an invalid config was never rejected. Local bookkeeping must always run; only
+		the push is conditional.
+		"""
+		from jarvis.onboarding import _workspace_op_in_flight
+
+		if not _workspace_op_in_flight(self):
+			return False
+		frappe.logger().info(
+			"jarvis settings: admin sync skipped — a workspace operation holds the status claim"
+		)
+		return True
+
 	def _on_update_single_model_legacy(self):
 		"""The existing single-model on_update logic, extracted for reuse."""
+		if self._workspace_op_holds_status():
+			return
 		action = self._classify_llm_change()
 		if action is None:
 			return

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -3,19 +3,22 @@ Settings, and thin server wrappers the onboarding page calls (so the browser
 never holds admin creds). admin_client returns already-unwrapped admin data."""
 
 import json
+from typing import NamedTuple
 
 import frappe
+from frappe.rate_limiter import rate_limit
 from frappe.utils import cint
 
 from jarvis import admin_client, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
+	AdminRejectedError,
 	AdminUnreachableError,
 	AdminValidationError,
 )
 from jarvis.hooks import get_default_admin_url
-from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
+from jarvis.permissions import grant_onboarding_admin, require_jarvis_access, require_jarvis_admin
 
 # Every admin-side failure admin_client raises. One tuple so the onboarding
 # facade's catch sites cannot drift apart from _surface's.
@@ -91,7 +94,7 @@ def _surface(fn, *args, **kwargs):
 		_throw_admin_error(e)
 
 
-def write_connection(data: dict) -> None:
+def write_connection(data: dict) -> bool:
 	"""Persist native admin credentials + container connection into Jarvis
 	Settings via db_set (no on_update creds-push retrigger during onboarding).
 
@@ -104,9 +107,16 @@ def write_connection(data: dict) -> None:
 	encrypts into __Auth first, then db_sets only the mask - preserving the
 	"no on_update retrigger" property this function exists for."""
 	if not isinstance(data, dict):
-		return
+		return False
 	from jarvis._password_utils import set_settings_password
 
+	# Whether the CONNECTION block (agent_url + agent_token) was actually
+	# persisted. False when the payload carried no agent_url, and — the case that
+	# matters — when tenant_authority.guard HELD the write. Callers that go on to
+	# act as if the connection had landed must gate on this; see the L4 poll, which
+	# used to record a reset complete and then destroy the credentials on the
+	# strength of a write that never happened.
+	connection_written = False
 	s = frappe.get_single("Jarvis Settings")
 	# Capture the container this workspace pointed at BEFORE this write, so a
 	# reconnect that repoints it can be told apart from a daily sync that rewrites
@@ -159,6 +169,7 @@ def write_connection(data: dict) -> None:
 			s.db_set("agent_url", data["agent_url"])
 			if data.get("agent_token"):
 				set_settings_password(s, "agent_token", data["agent_token"])
+		connection_written = write_conn
 	# Credentials just changed (fresh signup, or a reconnect rotating onto another
 	# account): a bearer minted from the old ones would outlive them.
 	principal_change = any(data.get(k) for k in ("api_key", "api_secret", "customer", "customer_password"))
@@ -186,6 +197,7 @@ def write_connection(data: dict) -> None:
 	# key means "cleared" - which would drop a live notice. It is persisted only
 	# where a full get_connection payload is in hand: sync_connection and the
 	# chat gate.
+	return connection_written
 
 
 @frappe.whitelist()
@@ -1470,6 +1482,280 @@ _RESETTING_STATUS = "pending: resetting workspace"
 # then completes on "container reachable" (readiness can never reach Ready with
 # no LLM configured) and the wizard gate owns the rest.
 _RESETTING_RECONNECT_LLM_STATUS = _RESETTING_STATUS + " (reconnect llm)"
+# L4 ("reset and start fresh"): the customer asked for the admin connection to go
+# too. It cannot go now — the poll below still has to authenticate to admin to
+# watch the rebuild — so the intent rides the marker and the clear happens once
+# the poll has seen the new container Ready. Suffix, not a third variant, so a
+# reset that is BOTH llm-revoking and disconnecting still satisfies the
+# ``startswith`` in _reconnect_llm.
+_DISCONNECT_SUFFIX = " (disconnect)"
+# Durable "no admin connection" marker: _clear_admin_connection writes this
+# AFTER settings_reset.CONNECTION blanks last_sync_status (CONNECTION.blank
+# includes it), so a reload can tell a bench that lost its admin credentials
+# apart from one that simply never finished onboarding (last_sync_status stays
+# "" for that case). Deliberately does NOT start with _RESETTING_STATUS, so
+# _reset_in_flight() and reconcile_pending_workspace_reset() both correctly
+# treat a disconnected bench as having no reset to converge.
+#
+# WRITE-ONLY BY DESIGN, and round-4 MINOR 2 is right that this is unusual enough
+# to state outright rather than leave as an oddity.
+#
+# Nothing reads it back to ANSWER "is this bench disconnected" — ``_admin_connection_absent``
+# does that, from the two credential fields — because the literal "disconnected"
+# already means something ELSE on this same field: ``jarvis.oauth.api.disconnect``
+# and ``onboarding.disconnect_llm`` both write it for a chat-subscription / LLM
+# disconnect that leaves admin credentials fully intact (account.py's
+# ``_has_llm_config`` docstring documents the same collision). Testing equality
+# against it would tell a customer who merely unplugged their AI model that they
+# need the emailed-code reconnect.
+#
+# It is kept because ``settings_reset.CONNECTION`` blanks ``last_sync_status``, and
+# an empty field is indistinguishable from "never onboarded" for an operator
+# reading the row — which is precisely the question they ask when a customer says
+# chat stopped. Diagnostic value, not control flow. Do not build a predicate on it.
+_DISCONNECTED_STATUS = "disconnected"
+
+
+# A reset has TWO in-flight states, and conflating them is what let a transient
+# failure destroy a customer's credentials.
+#
+# PRE-FLIGHT (this suffix): claimed, but the rebuild has NOT been requested yet —
+# or was attempted and we do not know whether it started. The old container is
+# still up and still Ready.
+# CONVERGING (no suffix): admin accepted the request, so a rebuild really is
+# happening and the poll's job is to watch for it.
+#
+# Why they must differ. The claim is written BEFORE the long calls (Amendment 2
+# BLOCKER 2), so between claim and rebuild the marker says "resetting" while the
+# OLD container still answers Ready. ``_workspace_reset_poll`` converges on
+# ``ready and _resetting()``. With ONE state, a ``*/5``
+# ``reconcile_pending_workspace_reset`` landing in that window declares the reset
+# complete against a container that was never replaced — and for an L4 tears it
+# down and clears the credentials.
+#
+# That window is not just the happy-path gap. When ``reset_workspace`` fails with
+# a timeout or a 5xx the claim is deliberately KEPT (see _release_reset_claim: a
+# bench timeout is the ordinary shape of a rebuild that IS running), the raise
+# unwinds ``with redis_lock(...)`` and its ``finally`` RELEASES the lock. So a
+# single transient network fault used to leave a convergeable marker, a free
+# lock, and an un-rebuilt container — and reconcile would then converge on it five
+# minutes later. No lock scope or TTL closes that; the lock is not even held when
+# it happens. Only positive evidence that admin accepted the request does, which
+# is what promotion is.
+_PREFLIGHT_SUFFIX = " (requested)"
+
+# The disconnect's own claim. Same role the pre-flight reset marker plays, for the
+# same reason: ``disconnect_bench``'s critical section spans a teardown that can
+# run to 240s, so holding the lock across it would freeze every convergence for
+# the whole TTL when the worker is SIGKILLed at ``http_timeout``. The lock now
+# covers only check-and-claim, and THIS carries in-flight-ness afterwards.
+#
+# Deliberately does NOT start with _RESETTING_STATUS: a disconnect is not a reset,
+# nothing polls it, and ``reconcile_pending_workspace_reset`` must not try to
+# converge one. It is matched by ``_workspace_op_in_flight`` instead.
+_DISCONNECTING_STATUS = "pending: disconnecting bench"
+
+
+def _reset_marker(
+	reconnect_llm: bool = False, disconnect_after: bool = False, preflight: bool = False
+) -> str:
+	"""The ``last_sync_status`` marker for a reset at this depth.
+
+	One definition, because the marker is not just display state — it is where a
+	reset's DEPTH lives between the request and the poll that completes it. Two
+	call sites deriving it separately is how an L4 gets silently downgraded.
+
+	``preflight`` appends ``_PREFLIGHT_SUFFIX``: claimed, rebuild not yet known to
+	have started. Guards treat it as in flight; the poll refuses to converge on it.
+	"""
+	marker = _RESETTING_RECONNECT_LLM_STATUS if reconnect_llm else _RESETTING_STATUS
+	if disconnect_after:
+		marker += _DISCONNECT_SUFFIX
+	return marker + _PREFLIGHT_SUFFIX if preflight else marker
+
+
+def _strip_preflight(status: str) -> str:
+	"""The converging marker a pre-flight claim will be promoted to.
+
+	Depth comparisons must go through this. A same-depth resubmission during the
+	pre-flight window is idempotent, not "a reset at a different depth" — comparing
+	the raw strings would refuse it with a message that is simply untrue."""
+	status = status or ""
+	return status[: -len(_PREFLIGHT_SUFFIX)] if status.endswith(_PREFLIGHT_SUFFIX) else status
+
+
+def _is_preflight(settings) -> bool:
+	"""Claimed, but not yet known to be rebuilding. See ``_PREFLIGHT_SUFFIX``."""
+	return (settings.get("last_sync_status") or "").endswith(_PREFLIGHT_SUFFIX)
+
+
+def _reset_in_flight(settings) -> str:
+	"""The marker of a reset this bench has CLAIMED, or "" if none.
+
+	The GUARD predicate — ``disconnect_bench``'s refusal, the depth check, and the
+	poll's ``resetting`` display field. It matches pre-flight AND converging,
+	because from the point of view of "may another workspace operation start", a
+	claimed reset counts whether or not the rebuild has been confirmed.
+
+	Deliberately NOT the same predicate the poll converges on
+	(``_workspace_reset_poll_locked``'s ``_resetting()``), which excludes
+	pre-flight. Guarding and converging are different questions and answering them
+	with one predicate is what made a transient failure destructive — see
+	``_PREFLIGHT_SUFFIX``.
+
+	The bench, not the browser, is the authority on this. An in-flight reset was
+	previously guarded only by a disabled button in the SPA, which two open Settings
+	tabs defeat: the tab that did not start the reset never learns it is running.
+	That matters because the marker lives in ``settings_reset.CONNECTION`` — a
+	concurrent disconnect blanks it, and ``reconcile_pending_workspace_reset`` then
+	has nothing left to converge, stranding the rebuild permanently."""
+	status = settings.get("last_sync_status") or ""
+	return status if status.startswith(_RESETTING_STATUS) else ""
+
+
+def _workspace_op_in_flight(settings) -> str:
+	"""Any claimed workspace operation — a reset at either state, OR a disconnect.
+
+	The reset and the disconnect are mutually exclusive and each must refuse while
+	the other is claimed, so both guards ask THIS rather than only about their own
+	kind. ``_reset_in_flight`` on its own would let a reset start on top of a
+	disconnect that is mid-teardown, and then clear ``CONNECTION`` under it."""
+	status = settings.get("last_sync_status") or ""
+	return _reset_in_flight(settings) or (status if status == _DISCONNECTING_STATUS else "")
+
+
+# The critical section both entry points serialise on: read the marker, decide,
+# and CLAIM it, as one indivisible step.
+#
+# A guard that reads state it has not yet claimed is not a guard.
+# ``request_workspace_reset`` used to read the marker first and write it LAST,
+# inside ``_disconnect_agent_transport``, after ``_recovery_outlook`` (8s),
+# ``post_subscription_disconnect`` (180s budget), ``admin_client.reset_workspace``
+# (180s, and it STARTS the rebuild) and the content wipe. For that whole
+# multi-minute window ``disconnect_bench``'s ``_reset_in_flight`` guard saw no
+# marker and let the disconnect through — blanking ``last_sync_status`` (it is in
+# ``settings_reset.CONNECTION``) and leaving ``reconcile_pending_workspace_reset``
+# nothing to converge, with the rebuilt container stranded and no bench able to
+# reach it.
+#
+# One lock name, not one per action: all three ARE mutually exclusive.
+# Serialising a reset only against other resets would leave exactly the
+# reset-vs-disconnect race this exists to close.
+#
+# THREE holders, and the poll is not an afterthought. Claiming the marker early
+# creates a state the old ordering never had: marker set, rebuild NOT yet
+# requested, OLD container still up and Ready. ``_workspace_reset_poll``'s
+# convergence test is ``ready and _resetting()``, and admin still reports the old
+# container as Ready — so a ``*/5`` ``reconcile_pending_workspace_reset`` landing
+# in that window would declare the reset complete against the container that was
+# never replaced, and for an L4 go on to clear the credentials. The poll takes
+# this lock too, non-blocking: while a request holds it there is by definition
+# nothing to converge.
+_RESET_LOCK = "workspace-reset"
+# TTL: the backstop for a worker that dies holding it.
+#
+# 60s, because the guarded section is now only re-read -> guards -> claim-commit.
+# It was 600s when the lock was held across the whole multi-minute request, and
+# that was the wrong shape: redis_lock's release is a ``finally``, which a
+# SIGKILLed worker never runs, and under a ~120s gunicorn ``http_timeout`` a
+# SIGKILL mid-reset is the ORDINARY end of a slow reset rather than an
+# exceptional one. Every convergence — including the ``*/5`` reconcile — then
+# froze for the full ten minutes, and an L4's credential clear with it.
+#
+# What the lock stopped protecting when it shrank is carried by the marker
+# instead, which is what a durable claim is for: see _PREFLIGHT_SUFFIX.
+_RESET_LOCK_TTL_S = 60
+# Wait: a contender is a second Settings tab clicking a moment later, not a
+# convoy. Long enough that an ordinary overlap queues rather than erroring,
+# short enough that a genuinely stuck holder surfaces as a message the customer
+# can act on instead of a hung request.
+_RESET_LOCK_WAIT_S = 5.0
+
+
+def _reread_inside_lock():
+	"""Re-read Jarvis Settings so a guard sees what ANOTHER worker committed.
+
+	``settings.reload()`` alone does NOT do this, and three call sites used to say
+	it did. Frappe holds ONE MariaDB transaction per request — pymysql's
+	``autocommit`` default is False and ``get_connection_settings`` never
+	overrides it, while ``Database.commit()`` immediately re-opens a transaction
+	with ``START TRANSACTION``. Frappe also never overrides the isolation level
+	for MariaDB, and this deployment reports ``REPEATABLE-READ``. Under InnoDB
+	that means every consistent nonlocking read in a transaction returns the
+	snapshot pinned by the FIRST read in it. ``Document.reload()`` is
+	``load_from_db()`` -> ``get_singles_dict(..., for_update=False)``, a plain
+	consistent read, so it re-issues the identical SELECT and gets the identical
+	rows. Measured, not reasoned: a second connection's committed INSERT is
+	invisible to a re-read and visible immediately after ``frappe.db.commit()``.
+
+	So the snapshot has to END first. ``commit()`` rather than a ``for_update``
+	locking read: the alternative would hold InnoDB row locks on ``tabSingles``
+	for the whole guarded section, which here spans multi-minute admin calls and
+	would block every unrelated writer to Jarvis Settings.
+
+	Safe to commit at these three call sites specifically: each runs at the TOP of
+	its locked section, before the function has written anything, so there is no
+	half-finished work to make durable. Do not move a call to this below a write.
+
+	Returns a freshly-read doc; callers must use the returned object.
+	"""
+	frappe.db.commit()
+	return frappe.get_single("Jarvis Settings")
+
+
+def _claim_reset(settings, marker: str) -> None:
+	"""Write the resetting marker and commit it, so every other request sees it.
+
+	Committed immediately and deliberately: the whole point is that a concurrent
+	``disconnect_bench`` in another worker reads it, and an uncommitted write in
+	this transaction is invisible to that worker.
+
+	Stamps ``workspace_reset_claimed_at`` alongside. A claim with no timestamp
+	cannot be resolved later: ``reconcile_pending_workspace_reset`` needs it both
+	to tell admin's fresh request row from last week's (the customer who runs an L1
+	at 10:00 and an L4 at 10:05 defeats any "is there a recent row" heuristic) and
+	to know when an unresolvable claim has waited long enough to expire."""
+	settings.db_set("last_sync_status", marker)
+	settings.db_set("workspace_reset_claimed_at", frappe.utils.now_datetime())
+	frappe.db.commit()
+
+
+def _promote_reset_claim(settings, marker: str) -> None:
+	"""Turn a PRE-FLIGHT claim into a converging one. Admin accepted the request.
+
+	The single place a marker becomes something ``_workspace_reset_poll`` may
+	converge on, and it is reached only after ``admin_client.reset_workspace``
+	RETURNED — i.e. on positive evidence that a rebuild is actually happening.
+	Everything else leaves the claim pre-flight for reconcile to resolve.
+
+	``workspace_reset_claimed_at`` is kept, not cleared: the reset is still in
+	flight, and a converging marker can still be orphaned by a crash before the
+	poll finishes."""
+	settings.db_set("last_sync_status", marker)
+	frappe.db.commit()
+
+
+def _release_reset_claim(settings, prior: str) -> None:
+	"""Undo a claim whose reset PROVABLY never started.
+
+	Called only when admin was reached and REFUSED — a 4xx/401/403/429 — so nothing
+	was torn down and no rebuild is running, and restoring the previous status is
+	honest. Without it, a refused request would leave the bench displaying
+	"resetting" forever, with ``reconcile_pending_workspace_reset`` polling a reset
+	that does not exist and ``disconnect_bench`` refused by a guard protecting
+	nothing.
+
+	NOT called on a timeout or a 5xx, and that distinction is load-bearing rather
+	than cautious. Admin's ``reset_workspace`` runs the destroy + reprovision
+	synchronously inside the HTTP request and commits its request row before
+	starting, while this bench gives up at ``timeout_s=180``. A bench-side timeout
+	is therefore the ORDINARY shape of a slow rebuild that is running, not evidence
+	of one that is not. Releasing there blanks the marker mid-rebuild and strands
+	the container — the same outcome the claim exists to prevent."""
+	settings.db_set("last_sync_status", prior)
+	settings.db_set("workspace_reset_claimed_at", None)
+	frappe.db.commit()
+
 
 # Customer content wiped by the "also delete my data" reset option. Raw table
 # deletes (single-tenant DB, no hooks) — the dev.reset_onboarding precedent.
@@ -1515,34 +1801,211 @@ _WIPE_DOCTYPES = (
 
 
 @frappe.whitelist()
-def request_workspace_reset(reason: str = "", wipe_data: bool = False, revoke_llm: bool = False) -> dict:
+def request_workspace_reset(
+	reason: str = "",
+	wipe_data: bool = False,
+	revoke_llm: bool = False,
+	disconnect_after: bool = False,
+) -> dict:
 	"""Self-serve workspace reset: the control plane rebuilds the container NOW
 	(subscription kept), then this site disconnects its agent transport and polls
 	``workspace_reset_state`` back to Ready.
 
-	``wipe_data`` also deletes workspace content (chats, skills, macros,
-	triggers, learning artifacts, wiki, dashboards). ``revoke_llm`` also clears
-	every LLM connection (pool models, subscription accounts, keys, synced
-	markers) so the customer sets up their AI model fresh after the reset.
-	Both run only AFTER the control plane accepted the reset.
+	Four depths, each adding to the one above:
+
+	  L1  (no flags)         rebuild the container
+	  L2  wipe_data          + delete workspace content (chats, skills, macros,
+	                           triggers, learning artifacts, wiki, dashboards)
+	  L3  revoke_llm         + clear every LLM connection (pool models,
+	                           subscription accounts, keys, synced markers) so the
+	                           customer sets their AI model up fresh
+	  L4  disconnect_after   + clear the admin connection itself — full
+	                           ``bench reset-onboarding`` parity
+
+	L2/L3 run only AFTER the control plane accepted the reset. L4 is different: it
+	CANNOT run here, because the poll that watches the rebuild authenticates with
+	the very credentials it clears. Doing it now would leave the reset initiated
+	on the control plane and unobservable from this bench. The intent is recorded
+	on the marker instead and ``_workspace_reset_poll`` performs the clear once
+	the new container reports Ready — see ``_DISCONNECT_SUFFIX``.
+
+	L4 leaves this bench with no credentials; the way back is the emailed-code
+	reconnect. So it is refused up front when that recovery would not work, before
+	anything is rebuilt or cleared — ``_recovery_outlook``.
 
 	Gated on System Manager, like the rest of onboarding."""
+	from jarvis._redis_lock import redis_lock
+
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
+	disconnect_after = bool(cint(disconnect_after))
+	reconnect_llm = bool(cint(revoke_llm))
+	wipe_data = bool(cint(wipe_data))
+	# The ladder is CUMULATIVE — each level adds to the one above — and until now
+	# only the SPA's radio group enforced that. The server took three independent
+	# booleans, so ``disconnect_after=1, revoke_llm=0, wipe_data=0`` was accepted
+	# and produced a depth with no name: the marker is
+	# ``"pending: resetting workspace (disconnect)"``, for which ``_reconnect_llm()``
+	# is false, so the poll requires full chat-Ready before it will converge — while
+	# the customer has asked for the connection to be destroyed at the end. Nothing
+	# in the ladder describes that combination, and no test covers it.
+	#
+	# Enforced here rather than fixed in the poll, because the poll is not what is
+	# wrong: the request is. Round-4 MINOR 4.
+	if disconnect_after and not (wipe_data and reconnect_llm):
+		frappe.throw(
+			"Reset depth is cumulative: disconnecting this bench (L4) includes wiping "
+			"workspace content and revoking LLM connections. Send those too, or choose a "
+			"shallower reset.",
+			frappe.ValidationError,
+		)
+	if reconnect_llm and not wipe_data:
+		frappe.throw(
+			"Reset depth is cumulative: revoking LLM connections (L3) includes wiping "
+			"workspace content. Send wipe_data too, or choose a shallower reset.",
+			frappe.ValidationError,
+		)
+	marker = _reset_marker(reconnect_llm, disconnect_after)
+	prior_status = settings.get("last_sync_status") or ""
+
+	# The lock is held for the WHOLE request, not just the check-and-claim. Two
+	# separate windows need covering and one lock covers both:
+	#
+	#   check -> claim   a concurrent disconnect must not slip between reading the
+	#                    marker and writing it (Amendment 2 BLOCKER 2).
+	#   claim -> rebuild the marker is now set while the OLD container is still up
+	#                    and Ready, so a concurrent poll would "converge" the reset
+	#                    against a container that was never replaced. See _RESET_LOCK.
+	#
+	# The marker claim is still what makes the guard DURABLE — the lock dies with
+	# the worker, the marker does not, and a crash between here and
+	# ``admin_client.reset_workspace`` returning would otherwise leave admin
+	# rebuilding a container this bench has no record of resetting.
+	with redis_lock(
+		_RESET_LOCK, timeout_s=_RESET_LOCK_TTL_S, blocking_timeout_s=_RESET_LOCK_WAIT_S
+	) as acquired:
+		if not acquired:
+			frappe.throw(
+				"Another workspace operation is already running on this site. Wait for it to "
+				"finish, then try again.",
+				frappe.ValidationError,
+			)
+		settings = _reread_inside_lock()
+		prior_status = settings.get("last_sync_status") or ""
+		# A reset already running at a DIFFERENT depth must not be silently
+		# re-labelled. Admin is idempotent (named_lock + return the in-flight
+		# request), so a repeat submission does not start a second rebuild — but
+		# this bench would still overwrite the marker, and the marker is where the
+		# depth lives. Re-submitting the SAME depth stays idempotent; changing it is
+		# refused rather than applied to a rebuild the customer did not choose it for.
+		in_flight = _workspace_op_in_flight(settings)
+		if in_flight == _DISCONNECTING_STATUS:
+			# A disconnect is mid-teardown. Its lock is already released (it only
+			# covers check-and-claim), so this marker is the only thing standing
+			# between a reset and a bench that is about to lose its credentials.
+			frappe.throw(
+				"This bench is being disconnected. Wait for that to finish before resetting.",
+				frappe.ValidationError,
+			)
+		# Compared with the pre-flight suffix STRIPPED. A same-depth resubmission
+		# while the first attempt is still pre-flight is idempotent, not "a reset at
+		# a different depth" — comparing raw strings would refuse it with a message
+		# that is simply untrue.
+		if in_flight and _strip_preflight(in_flight) != marker:
+			frappe.throw(
+				"A workspace reset is already running at a different depth. Wait for it to finish, "
+				"then start the deeper one.",
+				frappe.ValidationError,
+			)
+		if disconnect_after:
+			# Before the rebuild, not after: a customer who cannot reconnect must not
+			# reach a state where the only thing standing between them and a lost
+			# workspace is a code that will never be issued.
+			outlook = _recovery_outlook()
+			if not outlook.recoverable:
+				frappe.throw(outlook.reason, frappe.ValidationError)
+		# CLAIM, before any long call, as PRE-FLIGHT. Committed, so another worker's
+		# ``disconnect_bench`` reads it even though this transaction is still open.
+		# Pre-flight, so no poll can converge on it until admin has actually
+		# accepted the request — see _PREFLIGHT_SUFFIX.
+		_claim_reset(settings, _reset_marker(reconnect_llm, disconnect_after, preflight=True))
+
+	# The lock ends HERE, not after the long calls. It only ever had to make
+	# check-and-claim atomic; the marker carries in-flight-ness from now on, and it
+	# is durable where the lock is not (redis_lock's release is a `finally`, which
+	# a SIGKILLed worker never runs — and under a ~120s gunicorn http_timeout that
+	# is the ORDINARY end of a slow reset, not an exceptional one). Holding it
+	# across the calls below froze every convergence for the whole TTL.
 	# Tear down the container-side OAuth auth-profile while the old container is
 	# still reachable (same ordering as dev.reset_onboarding). Best-effort — a
-	# dead container is often the very reason for the reset.
+	# dead container is often the very reason for the reset, and unlike the L4
+	# disconnect, nothing irreversible follows here: the container is being
+	# replaced wholesale and the bench keeps its credentials either way.
 	if settings.get("agent_url"):
 		try:
 			admin_client.post_subscription_disconnect()
 		except Exception:
 			pass
-	out = _surface(admin_client.reset_workspace, reason)
-	if cint(wipe_data):
+	# NOT via _surface: it maps every admin error onto a bare
+	# frappe.ValidationError, and the CLASS is precisely what decides whether the
+	# claim may be given back. Mapped by hand below through the same
+	# _throw_admin_error, so the customer-facing sentence is unchanged.
+	try:
+		out = admin_client.reset_workspace(reason)
+	except (
+		AdminRejectedError,
+		AdminValidationError,
+		AdminAuthError,
+		AdminRateLimitedError,
+	) as exc:
+		# Admin was REACHED, validated the request and declined it (4xx / 401 / 403 /
+		# 429, or a 5xx carrying a permanent rejection code). Nothing was started, so
+		# the claim must not linger.
+		#
+		# AdminRejectedError is listed FIRST and explicitly: it subclasses
+		# AdminUnreachableError, so without it a permanent refusal fell through to the
+		# generic handler and blocked the customer for 15 minutes on a request admin
+		# had provably declined.
+		_release_reset_claim(settings, prior_status)
+		_throw_admin_error(exc)
+	except Exception as exc:
+		# Everything else — a timeout, a 5xx, a network fault — is NOT evidence that
+		# nothing is running, so the claim STAYS, and stays PRE-FLIGHT.
+		#
+		# Admin runs the destroy + reprovision SYNCHRONOUSLY inside the HTTP request,
+		# committing its "Applying" row before it starts, while this bench gives up at
+		# timeout_s=180. So a bench-side timeout is the ordinary shape of a rebuild
+		# that IS running, and releasing here would blank the marker mid-rebuild and
+		# strand the container.
+		#
+		# But it is equally NOT evidence that one IS running. Leaving a CONVERGING
+		# marker here was the defect: the raise unwinds the lock (redis_lock's
+		# `finally` DOES run on an exception), and five minutes later reconcile would
+		# converge against a container that was never rebuilt — clearing the
+		# credentials on an L4. Pre-flight is the honest state, and
+		# reconcile_pending_workspace_reset resolves it by asking admin whether the
+		# request actually exists.
+		frappe.logger().info(
+			"workspace reset: admin call failed without proving the rebuild did or did not "
+			f"start; leaving the claim PRE-FLIGHT for reconcile to resolve "
+			f"({type(exc).__name__}: {exc})"
+		)
+		if isinstance(exc, _ADMIN_ERRORS):
+			_throw_admin_error(exc)
+		raise
+	# PROMOTE. Admin accepted the request, so a rebuild really is happening and the
+	# poll's job is now to watch for it. This is the positive evidence, and it is the
+	# only thing that turns a claim into something a poll may converge on.
+	_promote_reset_claim(settings, marker)
+	if wipe_data:
 		_wipe_workspace_content()
-	if cint(revoke_llm):
+	if reconnect_llm:
 		_revoke_llm_connections(settings)
-	_disconnect_agent_transport(settings, reconnect_llm=bool(cint(revoke_llm)))
+	_disconnect_agent_transport(
+		settings,
+		reconnect_llm=reconnect_llm,
+		disconnect_after=disconnect_after,
+	)
 	return out
 
 
@@ -1560,7 +2023,9 @@ def _revoke_llm_connections(settings) -> None:
 	settings_reset.apply(settings, settings_reset.LLM)
 
 
-def _disconnect_agent_transport(settings, reconnect_llm: bool = False) -> None:
+def _disconnect_agent_transport(
+	settings, reconnect_llm: bool = False, disconnect_after: bool = False
+) -> None:
 	"""Clear the agent transport so chat gates on admin's chat_readiness while
 	the container is rebuilt. Keeps admin creds and (unless the customer revoked
 	them) the LLM config + ``*_synced_at`` markers — the control plane carries
@@ -1585,11 +2050,492 @@ def _disconnect_agent_transport(settings, reconnect_llm: bool = False) -> None:
 	# marker is cleared explicitly too so the intent is not left to a side effect.
 	settings.db_set("chat_was_ready_at", None)
 	settings.db_set("chat_ready_authority", "")
-	settings.db_set(
-		"last_sync_status", _RESETTING_RECONNECT_LLM_STATUS if reconnect_llm else _RESETTING_STATUS
-	)
+	settings.db_set("last_sync_status", _reset_marker(reconnect_llm, disconnect_after))
 	_bust_chat_gate()
 	frappe.db.commit()
+
+
+class _RecoveryOutlook(NamedTuple):
+	"""Whether this bench could get back after its admin connection is cleared.
+
+	``needs_company`` is not a refusal — see ``_recovery_outlook``."""
+
+	recoverable: bool
+	needs_company: bool
+	reason: str
+
+
+def _recovery_outlook() -> _RecoveryOutlook:
+	"""Would the emailed-code reconnect return this bench to its account?
+
+	Asks admin's ``billing.reconnect.can_reconnect_me`` (via
+	``admin_client.reconnect_eligibility_me``) rather than re-deriving eligibility
+	here, so the rules — subscription in Active/Suspended, and a live tenant — stay
+	on the side that owns them and are free to change without this bench knowing.
+
+	It is NOT ``_resolve_customer``, and an earlier version of this docstring said
+	it was. ``can_reconnect_me`` applies the same predicates (``_ELIGIBLE_STATUSES``,
+	``_has_live_tenant``) to the SESSION's customer, and shares
+	``_eligible_accounts`` with ``_resolve_customer`` for the ambiguity half — but
+	it is a separate function answering "could the caller reconnect", not
+	"which account does this code reconnect". Those are different questions and
+	only the shared helper keeps their answers aligned; there is no single call
+	that makes drift impossible by construction.
+
+	Fails CLOSED, and for a different reason than ``reconnect_available`` above:
+	that one hides a hint when admin blips, this one refuses an IRREVERSIBLE
+	clear. Refusing costs the customer a retry; clearing on a wrong "yes" costs
+	them their workspace with no self-serve way back.
+
+	``needs_company`` is reconnectable, not refused. It means the customer's contact
+	address owns several accounts reconnect would also accept, so they must name one
+	when they redeem the code. Admin computes it; treating it as "not recoverable"
+	would block a customer who can in fact recover.
+
+	Sends NO identity, deliberately. The obvious-looking
+	``jarvis_admin_customer_email`` holds admin's synthetic OAuth login
+	(``cust-<hash>@jarvis.invalid`` from ``signup._synthetic_login``), never a
+	contact address. An earlier version of this function passed it to the guest
+	``can_reconnect``, which resolves on the real address — so the precheck matched
+	nothing, refused every genuine bench, and rendered a value the Jarvis Settings
+	field documents as never-to-be-shown into a customer toast. Admin derives the
+	customer from this bench's credentials instead, which cannot be got wrong here.
+
+	Takes no arguments. It used to accept ``settings`` and never read it — every
+	fact it needs is derived by admin from this bench's credentials, which is the
+	entire point of the redesign above.
+	"""
+	try:
+		_require_admin_url()
+		data = admin_client.reconnect_eligibility_me() or {}
+	except Exception as exc:
+		# Deliberate degrade: an unverified recovery path is treated as no recovery
+		# path. Same shape as reconnect_available's catch, opposite purpose — that
+		# one hides a hint, this one refuses an irreversible clear.
+		#
+		# Logged WITH the exception, to Error Log rather than the info log. This is
+		# the branch that refuses an irreversible action, and a fixed sentence with
+		# no detail left an operator unable to tell a 403 (this account genuinely
+		# cannot reconnect) from a DNS failure (nothing is known at all) — two very
+		# different things to tell a customer who cannot disconnect.
+		frappe.log_error(
+			title="disconnect precheck: could not confirm reconnect eligibility; refusing",
+			message=f"{type(exc).__name__}: {exc}\n\n{frappe.get_traceback()}",
+		)
+		return _RecoveryOutlook(
+			False,
+			False,
+			"Jarvis Admin could not be reached to confirm this site can be reconnected afterwards. "
+			"Nothing was changed — try again shortly.",
+		)
+	if data.get("recoverable"):
+		return _RecoveryOutlook(True, bool(data.get("needs_company")), "")
+	# Admin owns the refusal wording: it knows the account state, and it is the side
+	# that can phrase one without naming an address this bench holds no legitimate
+	# copy of. Fall back only if it sent none.
+	return _RecoveryOutlook(
+		False,
+		False,
+		data.get("reason")
+		or "This account cannot be reconnected afterwards, so disconnecting now would leave no "
+		"self-serve way back. Contact support.",
+	)
+
+
+class BenchTeardownRefused(frappe.ValidationError):
+	"""admin was REACHED and the container teardown did not complete.
+
+	Distinct from ``AdminUnreachableError`` on purpose, and the distinction is
+	the whole of T14: unreachable is the ONLY condition that authorizes clearing
+	the credentials without a confirmed teardown. Everything else — a refusal, a
+	rate limit, an auth failure, a device unpair that was attempted and failed —
+	means a retry can still succeed, so the clear must abort instead.
+
+	A ``frappe.ValidationError`` subclass so ``disconnect_bench`` surfaces it the
+	same way it surfaces its other two refusals, while ``_workspace_reset_poll``
+	can still catch this class specifically without swallowing unrelated errors.
+	"""
+
+
+def _teardown_container_via_admin() -> dict:
+	"""Have admin tear the container down, and decide whether this bench may
+	proceed to destroy its credentials.
+
+	Replaces the pair of calls this used to make (``post_subscription_disconnect``
+	+ ``unpair_chat_devices``). Both gate on admin's ``current_customer``, which
+	403s a Suspended account — a cohort deliberately admitted to the disconnect —
+	so for exactly that cohort both were refused, and both refusals were caught by
+	a bare ``except`` and logged in the same sentence as a dead container. The
+	container kept its OAuth auth-profile and every paired chat-device token, and
+	this bench then destroyed the only credentials that could ever revoke them.
+
+	Returns admin's report when the clear may proceed. Raises
+	``BenchTeardownRefused`` when it may not.
+
+	The decision, and why each way:
+
+	* ``AdminRejectedError`` — admin was reached and permanently refused. ABORT.
+	  Checked BEFORE AdminUnreachableError because it is a SUBCLASS of it
+	  (``jarvis.exceptions``); ordering these the other way silently turns every
+	  permanent rejection into a proceed.
+	* ``AdminUnreachableError`` — network fault, timeout, or a 5xx with no
+	  recognised code. PROCEED. This is the only escape hatch, and it has to
+	  exist: without it a bench whose control plane is gone can never leave its
+	  tenancy, which is worse than the risk it accepts.
+	* ``AdminValidationError`` (4xx: ResetLocked, MoveInFlight, UnknownProvider),
+	  ``AdminAuthError``, ``AdminRateLimitedError`` — admin answered and said no.
+	  ABORT; the customer retries.
+	* ``devices_unpaired`` false — the unpair was ATTEMPTED and failed. ABORT.
+	  This is the leg that must not be skipped: a surviving auth profile costs
+	  the customer their own LLM credential, a surviving device token gives a
+	  third party chat access to the workspace, and after the clear nothing can
+	  revoke it. NOTE this gate applies only when admin ANSWERED — the
+	  ``AdminUnreachableError`` branch above returns before reaching it, and must,
+	  because nothing is known there and the escape hatch has to exist. So the
+	  device leg is guaranteed against a reachable admin, not unconditionally.
+	* ``profile_cleared`` false with devices unpaired — PROCEED, logged. This is
+	  the ordinary dead-container disconnect: unpair is a file operation that
+	  works on a stopped container, the auth-profile clear runs doctor + restart
+	  and does not. Refusing here would block the case the disconnect exists for
+	  (plan edge case 6), and the cost is bounded to the customer's own credential.
+	* anything else — ABORT. Fail-safe: an unclassified failure is not evidence
+	  that the teardown happened, and the action on the other side is irreversible.
+	"""
+	try:
+		report = admin_client.prepare_bench_disconnect() or {}
+	except AdminRejectedError as exc:
+		raise BenchTeardownRefused(
+			f"Jarvis Admin refused to release this bench ({exc}). Nothing was changed."
+		) from exc
+	except AdminUnreachableError as exc:
+		frappe.logger().info(f"disconnect: admin unreachable during container teardown; proceeding ({exc})")
+		return {"profile_cleared": False, "devices_unpaired": False, "removed": 0, "detail": str(exc)}
+	except (AdminValidationError, AdminAuthError, AdminRateLimitedError) as exc:
+		raise BenchTeardownRefused(
+			f"Jarvis Admin could not release this bench yet: {exc} Nothing was changed — try again shortly."
+		) from exc
+	except Exception as exc:
+		frappe.log_error(
+			title="disconnect: unclassified failure preparing the container teardown",
+			message=frappe.get_traceback(),
+		)
+		raise BenchTeardownRefused(
+			f"Could not confirm this workspace's container was released ({type(exc).__name__}). "
+			"Nothing was changed — try again shortly."
+		) from exc
+
+	if not report.get("devices_unpaired"):
+		raise BenchTeardownRefused(
+			"This workspace's paired chat devices could not be unpaired, so they would keep "
+			"access after this bench loses its credentials. Nothing was changed — try again "
+			f"shortly. ({report.get('detail') or 'no detail'})"
+		)
+	if not report.get("profile_cleared"):
+		# Proceeding deliberately: see the docstring. Logged as an error, not an
+		# info, because it leaves the customer's own LLM credential live on a
+		# container no bench can reach again.
+		frappe.log_error(
+			title="disconnect: container auth-profile survived the teardown",
+			message=f"devices unpaired ({report.get('removed')}); "
+			f"auth profile NOT cleared: {report.get('detail')}",
+		)
+	return report
+
+
+def _clear_admin_connection(settings, *, needs_company: bool = False) -> list:
+	"""Tear this bench off its tenancy: the ``CONNECTION`` field set, plus the
+	container-side state that does not live in Jarvis Settings.
+
+	Ordering is load-bearing and matches ``dev.reset_onboarding``: after the field
+	loop this bench can no longer authenticate to admin, so everything needing
+	admin runs first.
+
+	The teardown is NO LONGER best-effort. It was, and that was the defect: a
+	refusal and a dead container were caught by the same bare ``except`` and
+	logged in the same sentence, so the one case where the teardown was possible
+	and got skipped was indistinguishable from the one where it was impossible.
+	``_teardown_container_via_admin`` makes that distinction and raises
+	``BenchTeardownRefused`` when the clear must not proceed — callers handle it.
+
+	``settings_reset.apply`` covers more than it looks: the chat-device quartet
+	(the same four fields ``chat.device.clear_credentials`` drops, via the same
+	``clear_settings_password`` so the ``__Auth`` rows go too), the authority
+	generation + handle (``tenant_authority.clear``'s pair), and the cached
+	bearer, which it drops itself because ``CONNECTION`` carries passwords. The
+	chat-readiness verdict cache is NOT a settings field, so it is busted here —
+	without it a stale positive verdict outlives the connection it described.
+
+	``needs_company`` is admin's answer from the caller's OWN eligibility check, and
+	both callers have just made one. It is persisted here because this is the last
+	moment it is knowable: after the sweep there are no credentials left to ask
+	with. See ``bench_connection_state``.
+
+	Returns the cleared field list for the caller's report.
+
+	Raises:
+		BenchTeardownRefused: nothing was cleared.
+	"""
+	from jarvis.account import _bust_chat_gate
+
+	# UNCONDITIONAL, and that is the fix. This used to be gated on the bench's own
+	# ``agent_url`` being non-empty — a leftover from the design where the BENCH
+	# called the container-affecting endpoints itself. It is now admin that tears
+	# the container down: it resolves the tenant with _any_tenant_for(customer) and
+	# already answers profile_cleared/devices_unpaired true when there is nothing
+	# to tear down. This bench's agent_url has no bearing on whether a container
+	# exists or must be torn down, so the guard tested the wrong fact — and when it
+	# was false it skipped the teardown with no raise, no log and no report, then
+	# destroyed the credentials anyway, leaving every paired chat-device token live
+	# on a workspace nothing could ever revoke them from.
+	#
+	# Reachable, not theoretical: on the L4 poll, write_connection declines to write
+	# agent_url whenever tenant_authority.guard holds (REJECT, or an
+	# AuthorityInvariantError from an equal generation with a different serving
+	# container — what a reprovision onto a warm-pool container can produce). The
+	# poll then re-read a Single still holding the "" committed at request time.
+	_teardown_container_via_admin()
+
+	from jarvis import settings_reset
+
+	# CONNECTION plus the OAuth markers, because the teardown above just destroyed
+	# the credential those markers describe. Left set, a bench that reconnects with
+	# the emailed code SKIPS the LLM step and lands in a chat whose container holds
+	# no auth profile - see settings_reset.OAUTH_MARKERS, plan edge case 21.
+	spec = settings_reset.CONNECTION | settings_reset.OAUTH_MARKERS
+	settings_reset.apply(settings, spec)
+	# CONNECTION.blank clears last_sync_status to "" as part of the field sweep
+	# above; write the durable disconnected marker AFTER that clear so it
+	# survives it instead of leaving the field blank - see _DISCONNECTED_STATUS.
+	settings.db_set("last_sync_status", _DISCONNECTED_STATUS)
+	# The operation this claim was for is over. Not in any ResetSpec (it is
+	# bookkeeping, not tenancy state), so it has to be cleared explicitly or a
+	# resolved claim keeps a timestamp that reads as a live one.
+	settings.db_set("workspace_reset_claimed_at", None)
+	# T22: persist the ONE fact about recovery that cannot be recomputed once the
+	# credentials are gone. Written here, after the sweep, for the same reason
+	# _DISCONNECTED_STATUS is: CONNECTION.blank would otherwise wipe it. Both
+	# callers have just asked admin, so both can supply it.
+	settings.db_set("reconnect_needs_company", 1 if needs_company else 0)
+	_bust_chat_gate()
+	frappe.db.commit()
+	return settings_reset.cleared_fields(spec)
+
+
+def _admin_connection_absent(settings) -> bool:
+	"""True when this bench holds neither signal a connected admin tenancy
+	always has: the customer identity and the container address. Both are in
+	``settings_reset.CONNECTION`` and both are blanked together by
+	``_clear_admin_connection`` - checking BOTH (not either alone) is what keeps
+	this from firing mid-reset, when ``_disconnect_agent_transport`` blanks
+	``agent_url`` alone for EVERY depth (L1-L4) while ``jarvis_admin_customer_email``
+	stays in place until a reset that actually reaches the CONNECTION clear.
+
+	One definition, shared by ``disconnect_bench``'s idempotency check and
+	``bench_connection_state``, so the two cannot disagree about what "no admin
+	connection" means - same reasoning as ``_reset_marker``."""
+	return (
+		not (settings.get("jarvis_admin_customer_email") or "").strip()
+		and not (settings.get("agent_url") or "").strip()
+	)
+
+
+@frappe.whitelist()
+@rate_limit(limit=5, seconds=3600, ip_based=True)
+def disconnect_bench() -> dict:
+	"""Terminal, no-rebuild counterpart to L4: tear down the container-side OAuth
+	auth-profile + chat devices while still reachable, then clear the admin
+	connection. No rebuild, no poll, no resetting marker - this bench is LEAVING
+	its tenancy, not resetting itself, so it must never be described as one.
+
+	Idempotency comes before the recovery precheck, deliberately: a bench with no
+	``jarvis_admin_customer_email`` and no ``agent_url`` (both in
+	``settings_reset.CONNECTION``) is already disconnected, and letting that fall
+	through to ``_recovery_outlook`` would throw "no registered customer email" -
+	turning a harmless repeat click into an error that hides the real state
+	instead of confirming it.
+
+	Otherwise the same reconnect-eligibility precheck L4 uses runs first, and
+	nothing is torn down or cleared unless it passes: a customer who could not
+	get back in would be permanently locked out. ``needs_company`` is carried
+	through rather than refused - it means the emailed-code reconnect works but
+	needs the customer's company name to disambiguate, which the caller can
+	surface as a heads-up.
+
+	The container teardown then has its own veto: ``_teardown_container_via_admin``
+	aborts the clear unless the paired chat devices were provably unpaired, or
+	admin was genuinely unreachable. A dead CONTAINER still disconnects (the
+	unpair is a file operation that survives it); a dead ADMIN still disconnects
+	(otherwise a lost control plane traps this bench forever); an admin that
+	answers and refuses does not.
+
+	Rate-limited on top of ``require_jarvis_admin``: unlike L1-L4, this action
+	never calls admin's ``reset_workspace``, so it never benefits from that
+	endpoint's own 5/hr/IP budget."""
+	from jarvis._redis_lock import redis_lock
+
+	require_jarvis_admin()
+	# The lock covers CHECK-AND-CLAIM only, exactly as request_workspace_reset's
+	# does, and for the same reason: the teardown below can run to 240s
+	# (admin_client.prepare_bench_disconnect's budget), and redis_lock's release is
+	# a ``finally`` that a SIGKILLed worker never runs. Holding it across the
+	# teardown froze every convergence — including the */5 reconcile — for the whole
+	# TTL whenever gunicorn's http_timeout killed the request, which under a ~120s
+	# ceiling is the ordinary end of a slow teardown, not an exceptional one.
+	#
+	# Taken BEFORE Jarvis Settings is read, not after. A doc fetched outside the
+	# lock is a stale read: a reset could claim its marker and release the lock in
+	# that gap, and this call would then see no marker, proceed, and clear
+	# CONNECTION out from under a rebuild that is already running.
+	with redis_lock(
+		_RESET_LOCK, timeout_s=_RESET_LOCK_TTL_S, blocking_timeout_s=_RESET_LOCK_WAIT_S
+	) as acquired:
+		if not acquired:
+			frappe.throw(
+				"A workspace operation is already running on this site. Wait for it to finish, "
+				"then disconnect.",
+				frappe.ValidationError,
+			)
+		settings = _reread_inside_lock()
+		if _admin_connection_absent(settings):
+			return {
+				"disconnected": True,
+				"already_disconnected": True,
+				"cleared": [],
+				"needs_company": False,
+			}
+		# Refuse while ANY workspace operation is claimed, server-side. A reset in
+		# flight has already blanked ``agent_url`` while the email survives, so the
+		# idempotency test above does not fire and the clear would otherwise proceed
+		# — blanking the marker with it (it is in CONNECTION) and leaving
+		# reconcile_pending_workspace_reset nothing to converge, with the rebuilt
+		# container stranded. The SPA disables the button, but a second Settings tab
+		# never learns the reset started, so the browser cannot enforce this.
+		#
+		# _workspace_op_in_flight, not _reset_in_flight: a second disconnect landing
+		# mid-teardown must be refused too, now that the lock no longer spans it.
+		in_flight = _workspace_op_in_flight(settings)
+		if in_flight == _DISCONNECTING_STATUS:
+			frappe.throw(
+				"This bench is already being disconnected. Wait for that to finish.",
+				frappe.ValidationError,
+			)
+		if in_flight:
+			frappe.throw(
+				"A workspace reset is in progress. Wait for it to finish before disconnecting this bench.",
+				frappe.ValidationError,
+			)
+		prior_status = settings.get("last_sync_status") or ""
+		outlook = _recovery_outlook()
+		if not outlook.recoverable:
+			frappe.throw(outlook.reason, frappe.ValidationError)
+		# CLAIM before the long calls, same as the reset. Nothing destructive has
+		# happened yet, so an orphaned claim is always safe to expire and retry.
+		_claim_reset(settings, _DISCONNECTING_STATUS)
+
+	# Lock released. The claim carries in-flight-ness from here.
+	try:
+		cleared = _clear_admin_connection(settings, needs_company=outlook.needs_company)
+	except BenchTeardownRefused as exc:
+		# Nothing was torn down or cleared, so give the claim back rather than
+		# leaving a marker that blocks the customer's next attempt.
+		_release_reset_claim(settings, prior_status)
+		# Re-thrown rather than raised straight through, so the reason reaches the
+		# customer: the SPA renders ``e.messages[0]``, which comes from
+		# ``_server_messages``, which only ``frappe.throw``'s msgprint populates. A
+		# bare raise of the same class would degrade this to the generic "Could not
+		# disconnect this bench." — the third refusal in this function to be
+		# silently unexplained would be a poor place to end up.
+		frappe.throw(str(exc), BenchTeardownRefused)
+	except Exception:
+		# Any other failure may have died PART WAY through the field sweep.
+		# ROLL BACK FIRST. settings_reset.apply is a sequence of db_sets with no
+		# commit until the end, so a partial clear is uncommitted and would be
+		# discarded — but _release_reset_claim commits, which would make that
+		# half-applied state durable. That is the property "no intermediate commit,
+		# so a partial failure rolls back" depends on, and releasing without a
+		# rollback silently broke it.
+		frappe.db.rollback()
+		# Then release: the bench is still connected and the claim is pointless.
+		# reconcile would otherwise expire it on a 15-minute timer for a request
+		# that already knows it failed.
+		_release_reset_claim(settings, prior_status)
+		raise
+	return {
+		"disconnected": True,
+		"already_disconnected": False,
+		"cleared": cleared,
+		"needs_company": outlook.needs_company,
+	}
+
+
+@frappe.whitelist()
+def bench_connection_state() -> dict:
+	"""Durable answer to "is this bench disconnected from its admin tenancy",
+	read from Jarvis Settings alone - no admin round-trip.
+
+	Exists because both ``disconnect_bench()``'s response and the L4 poll's
+	``disconnected: true`` (``_workspace_reset_poll``) are ONE-SHOT: only the
+	caller that receives them ever sees that answer. Every later page load - a
+	reload, a second tab, a tab that was closed mid-poll and converged later by
+	``reconcile_pending_workspace_reset`` - has nothing to go on and falls
+	through to the generic "isn't connected yet" onboarding poster, which never
+	mentions the emailed-code reconnect: the ONLY way back once credentials are
+	gone. This endpoint gives every later load the same durable answer.
+
+	Making no admin call is not an optimisation here, it is required: a
+	genuinely disconnected bench holds no admin credentials, so any
+	authenticated admin call would simply fail.
+
+	``disconnected`` reuses ``_admin_connection_absent`` - the exact predicate
+	``disconnect_bench``'s own idempotency check uses - rather than testing
+	``last_sync_status == _DISCONNECTED_STATUS``. See that constant's comment:
+	the literal "disconnected" is already written to this same field by
+	``jarvis.oauth.api.disconnect`` and ``onboarding.disconnect_llm`` for a
+	chat-subscription / LLM disconnect that leaves admin credentials fully
+	intact, so equality against it cannot tell that case apart from this one.
+
+	``needs_company`` is admin's answer (``billing.reconnect``'s ambiguity
+	branch, surfaced via ``reconnect_eligibility_me``) and cannot be recomputed
+	here: once admin credentials are gone there is nothing left to ask. So it is
+	PERSISTED at the moment of the clear by ``_clear_admin_connection``, onto
+	``reconnect_needs_company`` — a field of its own, in no ``ResetSpec``,
+	precisely because repurposing one ``settings_reset.CONNECTION`` already
+	clears for an unrelated tenancy concern (release notice, catalog version,
+	authority generation) would corrupt whichever feature owns it next.
+
+	It used to be hardcoded ``False``, with this docstring deferring to "the
+	one-shot ``disconnect_bench()`` / poll response". That deferral was wrong:
+	``_workspace_reset_poll``'s return carried no ``needs_company`` either, and
+	``GeneralPane.pollReset`` resolves the value by calling THIS endpoint — so
+	after an L4 it was always false, and a customer whose registered address owns
+	several eligible accounts was sent to a reconnect that could not complete
+	with what they had been told.
+
+	Gated on ``require_jarvis_access()``, NOT ``require_jarvis_admin()`` like its
+	neighbours, and that difference is deliberate (round-4 MINOR 6).
+
+	``OnboardingGate`` is the screen a disconnected bench actually lands on, for
+	EVERY user — and it has copy for a non-admin teammate telling them to ask their
+	workspace admin. Behind the admin gate that call 403s for exactly the person the
+	copy is written for, so the ``catch`` left ``disconnected`` false and the
+	generic first-time-setup poster rendered instead. The branch could never fire
+	in production, and ``OnboardingGate.spec.js``'s test for it passed only because
+	it mocks the API. Plan edge case 20 was unmet for non-admins.
+
+	Safe to widen: this returns two booleans derived from local settings and makes
+	no admin call. It carries no credential, no address and no tenancy identifier —
+	``disconnected`` is already obvious to any user (chat has stopped working), and
+	``needs_company`` only says a recovery step will ask for a name the user's own
+	organisation owns. Anything that ACTS on this state is gated separately:
+	``disconnect_bench`` and ``request_workspace_reset`` both keep
+	``require_jarvis_admin``.
+	"""
+	require_jarvis_access()
+	settings = frappe.get_single("Jarvis Settings")
+	return {
+		"disconnected": _admin_connection_absent(settings),
+		"needs_company": bool(settings.get("reconnect_needs_company")),
+	}
 
 
 @frappe.whitelist()
@@ -1602,7 +2548,31 @@ def workspace_reset_state() -> dict:
 
 
 def _workspace_reset_poll() -> dict:
-	settings = frappe.get_single("Jarvis Settings")
+	"""Read the reset's state and, when the rebuild is done, finish it.
+
+	Takes ``_RESET_LOCK`` NON-BLOCKING and converges only if it gets it. While
+	``request_workspace_reset`` holds it there is by definition nothing to
+	converge — the marker is claimed but the rebuild has not been requested yet,
+	and admin still reports the OLD container as Ready. Converging there would
+	declare the reset complete against the container that was never replaced, and
+	for an L4 go on to clear the credentials.
+
+	Non-blocking rather than waiting, because both callers are pollers: the SPA
+	re-asks every few seconds and ``reconcile_pending_workspace_reset`` every 5
+	minutes. Reporting "still resetting" for one tick is free; queueing a request
+	worker behind a multi-minute holder is not.
+	"""
+	from jarvis._redis_lock import redis_lock
+
+	with redis_lock(_RESET_LOCK, timeout_s=_RESET_LOCK_TTL_S) as acquired:
+		return _workspace_reset_poll_locked(may_converge=acquired)
+
+
+def _workspace_reset_poll_locked(*, may_converge: bool) -> dict:
+	# reconcile_pending_workspace_reset reads the Single itself before calling
+	# here, so this request's read snapshot is already pinned and predates the
+	# lock. _reread_inside_lock ends it; a plain reload() cannot.
+	settings = _reread_inside_lock()
 	req: dict = {}
 	try:
 		req = admin_client.reset_workspace_state() or {}
@@ -1610,10 +2580,27 @@ def _workspace_reset_poll() -> dict:
 		pass  # audit-row state is advisory; readiness below is the real signal
 
 	def _resetting() -> bool:
-		return (settings.get("last_sync_status") or "").startswith(_RESETTING_STATUS)
+		"""DISPLAY: is a reset claimed? Pre-flight counts — the customer's card
+		should say "resetting" from the moment they click, not from the moment
+		admin confirms."""
+		return bool(_reset_in_flight(settings))
+
+	def _may_converge_marker() -> bool:
+		"""CONVERGENCE: is a rebuild known to be happening? Pre-flight does NOT
+		count. Converging on a claim admin never accepted means declaring the reset
+		complete against the container that was never replaced — and for an L4,
+		tearing it down and clearing the credentials. See ``_PREFLIGHT_SUFFIX``."""
+		return bool(_reset_in_flight(settings)) and not _is_preflight(settings)
 
 	def _reconnect_llm() -> bool:
 		return (settings.get("last_sync_status") or "").startswith(_RESETTING_RECONNECT_LLM_STATUS)
+
+	def _disconnect_after() -> bool:
+		# Stripped, like the depth check in request_workspace_reset. On a pre-flight
+		# L4 marker the raw endswith() is False, because " (requested)" is the last
+		# suffix - correct only by accident today, since this is called past the
+		# pre-flight gate.
+		return _strip_preflight(settings.get("last_sync_status") or "").endswith(_DISCONNECT_SUFFIX)
 
 	try:
 		data = admin_client.get_connection(timeout_s=8) or {}
@@ -1627,14 +2614,177 @@ def _workspace_reset_poll() -> dict:
 	# With the LLM revoked, readiness can never reach Ready (nothing configured);
 	# "container reachable" completes the reset and the wizard gate owns the rest.
 	ready = bool(data.get("agent_url")) and (data.get("chat_readiness") == "Ready" or _reconnect_llm())
-	if ready and _resetting():
+	disconnected = False
+	# T24 / round-4 MAJOR 2. Non-empty when the customer explicitly chose "reset and
+	# disconnect", was shown the irreversibility warning, confirmed it — and then got
+	# a SHALLOWER reset than they asked for. Degrading rather than clearing is the
+	# right safety call; degrading rather than TELLING is not, and an Error Log entry
+	# is not telling. The SPA renders this instead of the plain "Workspace is back"
+	# toast, so the one poll that can answer actually does.
+	disconnect_blocked = ""
+	# Round-4 MINOR 7. ``ready`` used to be reported even when this pass could not
+	# converge, and ``GeneralPane.pollReset`` ACTS on it: stopPoll() plus a hard
+	# reload announcing "Workspace is back". So during a long L4 clear (up to 240s
+	# in the teardown) a concurrent poll reloaded the page mid-clear, and the
+	# terminal ``disconnected: true`` response was never seen by that tab.
+	#
+	# "Ready" is a claim about the customer's WORKSPACE being back, not about what
+	# admin's container currently reports. While a reset is claimed and this pass
+	# has not finished it, that claim is not yet true. Narrowed rather than
+	# suppressed: a bench with no reset in flight is unaffected, so this cannot make
+	# the card flicker on the ordinary path.
+	#
+	# PRE-FLIGHT is the second half of this condition, and gating on
+	# ``not may_converge`` ALONE was wrong — round 5. ``may_converge`` is just "did
+	# this pass get the lock", which is almost always true, so the narrowing hardly
+	# ever fired. Meanwhile ``ready`` for an L3/L4 is
+	# ``agent_url and (Ready or _reconnect_llm())``, and ``_reconnect_llm()`` matches
+	# straight through the pre-flight suffix — so during pre-flight ``ready``
+	# collapsed to "the OLD container is up", which is unconditionally true. With
+	# T33 now starting the poll after a timed-out initiate, the very first tick
+	# would have told the customer "Workspace is back — reloading" for a reset that
+	# never started.
+	if ready and _reset_in_flight(settings) and (not may_converge or _is_preflight(settings)):
+		ready = False
+	if may_converge and ready and _may_converge_marker():
 		from jarvis.account import _bust_chat_gate
 
-		write_connection(data)
-		settings.db_set("last_sync_status", "ok (workspace reset)")
+		disconnect_after = _disconnect_after()
+		# GATED on the connection actually landing. write_connection returns False
+		# when tenant_authority.guard HELD the write (a stale generation, or an equal
+		# generation naming a different serving container). The guard's whole design
+		# is "hold and re-poll" — so retiring the marker here would remove the very
+		# retry it is waiting for, leaving a bench with agent_url still blank, no
+		# marker, dead chat and nothing to converge it. For L4 it was worse: the same
+		# branch went on to destroy the credentials.
+		if not write_connection(data):
+			frappe.logger().info(
+				"workspace reset: connection write held by the authority guard; leaving the "
+				"marker set so the next poll can converge"
+			)
+			return {
+				"ready": ready,
+				"resetting": _resetting(),
+				"status": req.get("status") or "",
+				"message": req.get("message") or "",
+				"tenant_status": data.get("tenant_status") or "",
+				"disconnected": False,
+			}
+		# The reset itself is done. For an L4 the marker does NOT go back to a
+		# resting value here: it becomes the DISCONNECT claim, because the clear
+		# below runs for up to ~264s (prepare_bench_disconnect's 240s budget plus
+		# the eligibility re-check) and this poll's _RESET_LOCK expires at
+		# _RESET_LOCK_TTL_S = 60.
+		#
+		# Retiring the marker first was a real hole: from t=60s there was neither
+		# lock NOR marker, so a second tab's Reset passed every guard, called admin
+		# and started a genuine rebuild — while the clear still in flight here
+		# blanked CONNECTION underneath it. That is exactly the stranding the guards
+		# exist to prevent, reached through the one long section that got the short
+		# lock without a durable claim. T29 gave disconnect_bench this same shape;
+		# the poll needed it too.
 		_bust_chat_gate()
-		frappe.db.commit()
-	elif _resetting() and data.get("agent_url") and not (settings.get("agent_url") or ""):
+		# What the marker rests at once the disconnect half is over, one way or the
+		# other. The RESET succeeded regardless of what the clear does next.
+		reset_done_status = "ok (workspace reset)"
+		if not disconnect_after:
+			settings.db_set("last_sync_status", reset_done_status)
+			frappe.db.commit()
+		else:
+			_claim_reset(settings, _DISCONNECTING_STATUS)
+		if disconnect_after:
+			# _clear_admin_connection overwrites the claim above with
+			# _DISCONNECTED_STATUS on success, which is what stops
+			# reconcile_pending_workspace_reset from picking this site up again —
+			# there is no reset still pending. On either failure path below the
+			# claim is given back to reset_done_status, so an L4-degraded-to-L3
+			# leaves no marker behind; and if this worker dies mid-clear,
+			# _expire_orphaned_disconnect_claim gives it back instead.
+			#
+			# write_connection() above took its OWN uncached frappe.get_single()
+			# doc, so this ``settings`` object never observed that write. Re-read
+			# it, now that the write is committed, before handing it to the clear.
+			#
+			# The round-1 fix here was to make _clear_admin_connection's
+			# ``if agent_url:`` guard see a fresh value. That guard is GONE — it was
+			# testing the wrong fact and skipping the teardown outright — so this
+			# re-read no longer decides whether the container is torn down. It is
+			# kept because settings_reset.apply is about to db_set this doc, and it
+			# should not be a stale one.
+			#
+			# A NEW NAME, not a rebind of ``settings`` (round-4 MINOR 3). The
+			# _resetting() / _reconnect_llm() / _disconnect_after() closures above
+			# all read ``settings``, so rebinding it silently changed what they
+			# returned from this line onward. That was correct only by accident —
+			# ``disconnect_after`` is captured before it — and the next person to
+			# call one of those closures below would have got a different answer for
+			# no visible reason.
+			fresh = frappe.get_single("Jarvis Settings")
+			# T21 / round-4 MAJOR 8: RE-VALIDATE, minutes after the request-time
+			# precheck and on the far side of a container rebuild.
+			#
+			# request_workspace_reset refused up front if the customer could not
+			# reconnect, which satisfies plan edge case 2 AT REQUEST TIME. But for L4
+			# the clear happens here, minutes later. A subscription that moved to
+			# Cancelled during the rebuild — not Suspended; Cancelled is outside
+			# billing.reconnect._ELIGIBLE_STATUSES — would have its credentials
+			# destroyed with no emailed-code reconnect able to restore them. That is
+			# the permanent lockout the plan calls "mandatory, not advisory" to
+			# prevent, and one precheck "before clearing anything" cannot cover a gap
+			# it sits minutes before.
+			outlook = _recovery_outlook()
+			if not outlook.recoverable:
+				disconnect_blocked = outlook.reason
+				# Give the disconnect claim back: the reset is done and nothing is
+				# going to clear anything, so leaving the claim would block the
+				# customer's next reset for the full expiry window.
+				_release_reset_claim(settings, reset_done_status)
+				frappe.log_error(
+					title="workspace reset: L4 downgraded to L3, reconnect no longer available",
+					message=f"the rebuild completed; the clear was abandoned: {outlook.reason}",
+				)
+			else:
+				try:
+					_clear_admin_connection(fresh, needs_company=outlook.needs_company)
+					disconnected = True
+				except BenchTeardownRefused as exc:
+					# The RESET is complete; only the disconnect half could not be
+					# done. Degrade to the L3 outcome — rebuilt container, bench still
+					# connected — rather than 500ing a poll for a reset that succeeded,
+					# and rather than clearing the credentials anyway.
+					#
+					# Raised by _teardown_container_via_admin, which runs BEFORE
+					# settings_reset.apply, so nothing was cleared and the claim can be
+					# given back safely.
+					# Not str(exc) verbatim: those messages end "Nothing was changed",
+					# which is true of the disconnect half and false of the reset half.
+					disconnect_blocked = f"{exc} The workspace reset itself completed."
+					_release_reset_claim(settings, reset_done_status)
+					frappe.log_error(
+						title="workspace reset: L4 completed the rebuild but could not disconnect",
+						message=frappe.get_traceback(),
+					)
+				except Exception:
+					# Anything else may have failed PART WAY through the field sweep.
+					# Roll back first: settings_reset.apply is a sequence of db_sets
+					# with no commit until the end, so an uncommitted partial clear
+					# must not be made durable by the claim release that follows.
+					frappe.db.rollback()
+					disconnect_blocked = (
+						"This bench could not be disconnected. The workspace reset itself "
+						"completed. Nothing was changed — try again shortly."
+					)
+					_release_reset_claim(settings, reset_done_status)
+					frappe.log_error(
+						title="workspace reset: L4 clear failed unexpectedly",
+						message=frappe.get_traceback(),
+					)
+	elif (
+		may_converge
+		and _may_converge_marker()
+		and data.get("agent_url")
+		and not (settings.get("agent_url") or "")
+	):
 		# New container reachable but not Ready yet: reconnect the transport and,
 		# for a pool tenant, re-push the stored spec + subscription blobs — OAuth
 		# creds never ride a rebuild, so without this a subscription pool stays
@@ -1650,14 +2800,231 @@ def _workspace_reset_poll() -> dict:
 		"status": req.get("status") or "",
 		"message": req.get("message") or "",
 		"tenant_status": data.get("tenant_status") or "",
+		# Terminal for L4: this bench just lost its credentials, so this is the
+		# last poll that can answer. Every later one falls into the unreachable
+		# branch above. The UI needs the distinction — "you are disconnected, here
+		# is how to come back" is not the same screen as "admin is down".
+		"disconnected": disconnected,
+		# The L4 the customer asked for became an L3. Reset done, bench still
+		# connected, and this says why. One-shot by nature: the tab that started
+		# the reset is polling at this exact moment, and a customer converged by
+		# the */5 backstop instead sees a completed reset and a connected bench —
+		# true, just unexplained. Persisting it durably is a second schema change
+		# for a strictly rarer case; named in Amendment 3 OQ1 as a decision, not
+		# an oversight.
+		"disconnect_blocked": disconnect_blocked,
 	}
 
 
+# How long a PRE-FLIGHT claim may stay unresolved before it is given up on.
+#
+# Must exceed the worst case for a request that is genuinely still on its way to
+# admin: _recovery_outlook (8s) + post_subscription_disconnect (180s) +
+# reset_workspace (180s) + lock wait, i.e. ~6.5 min. 15 gives comfortable margin
+# while still bounding how long a customer can be stuck behind a claim whose
+# worker was SIGKILLed. Beyond it, a request worker would have to have outlived
+# gunicorn's http_timeout many times over — which is the same premise that makes
+# the SIGKILL ordinary in the first place.
+_PREFLIGHT_EXPIRY_MINUTES = 15
+
+# How long a PROMOTED (converging) claim may go unconverged before the bench gives
+# up on it. Promotion proved a rebuild STARTED; it never promised one would finish,
+# and a request admin abandoned — or a container that never comes back — would
+# otherwise leave the marker outliving everything able to clear it.
+#
+# Deliberately generous: the poll converges the instant the container reports
+# Ready, so this only fires when it never does. A warm-pool claim is seconds and a
+# cold provision minutes, so 60 is far past any real rebuild while still bounded.
+_RECONCILE_GIVE_UP_MINUTES = 60
+
+# Slack on the AGE comparison in _resolve_preflight_claim. Admin's row is created
+# moments after this bench stamps its claim, so a genuine row's age is slightly
+# SMALLER; the slack covers the round trip and any clock rate difference without
+# admitting a row from an earlier reset. Deliberately not a wall-clock tolerance —
+# the comparison is between two durations, each measured on its own host's clock,
+# so a timezone difference cannot enter it at all.
+_CLAIM_CLOCK_SLACK_SECONDS = 120
+
+
+def _resolve_preflight_claim(settings) -> None:
+	"""Decide what a PRE-FLIGHT claim actually was, and leave no claim unresolved.
+
+	A pre-flight marker means "this bench claimed a reset and does not know whether
+	admin accepted it" — the state left by a timeout, a 5xx, or a worker killed
+	between the claim and the promote. Nothing converges on it, deliberately, so
+	without this resolver it would sit forever: exactly the *"no path may leave
+	``last_sync_status`` on a resetting marker nothing can clear"* invariant the
+	plan is built on, violated from the other side.
+
+	Three outcomes:
+
+	* Admin has a request row for THIS claim (``requested_at`` at or after the
+	  claim, within clock slack) -> PROMOTE. The rebuild is real; the poll takes
+	  over from here. This is the case where the bench's HTTP call died but admin
+	  went on rebuilding regardless, which is the common one.
+	* No such row, and the claim is younger than ``_PREFLIGHT_EXPIRY_MINUTES`` ->
+	  leave it. The request may still be in flight; deciding now would be guessing.
+	* No such row past the deadline -> give up honestly. Restore a status the
+	  customer can act on, and clear the stamp. Nothing was torn down (the claim is
+	  written before any destructive step), so this is safe to retry.
+
+	Admin unreachable is NOT a verdict: leave the claim and try again next tick.
+	Treating "cannot ask" as "no row" would expire a live rebuild's claim.
+	"""
+	claimed_at = settings.get("workspace_reset_claimed_at")
+	try:
+		req = admin_client.reset_workspace_state() or {}
+	except Exception as exc:
+		frappe.logger().info(f"reset claim: cannot reach admin to resolve a pre-flight claim ({exc})")
+		return
+
+	status = (req.get("status") or "").strip()
+	# AGES, not wall clocks. Admin stamps ``requested_at`` in the ADMIN site's
+	# timezone and this bench stamps its claim in its OWN, both naive local
+	# datetimes — so comparing them directly makes a timezone difference a CONSTANT
+	# BIAS of hours rather than skew of milliseconds. Bench ahead of admin would
+	# expire every live rebuild's claim; bench behind admin would promote any row of
+	# any age, permanently, which for an L4 is a credential clear against a
+	# container that was never rebuilt. Both sites happen to be Asia/Kolkata today,
+	# which is precisely why nothing caught it.
+	#
+	# ``requested_age_seconds`` is measured by admin on admin's clock; the claim's
+	# age is measured here on ours. Two durations compare correctly across any pair
+	# of timezones and any clock offset.
+	admin_age = req.get("requested_age_seconds")
+	claim_age = None
+	if claimed_at:
+		claim_age = frappe.utils.time_diff_in_seconds(
+			frappe.utils.now_datetime(), frappe.utils.get_datetime(claimed_at)
+		)
+	# STATUS matters as much as the age. Promoting means "a rebuild is happening, go
+	# converge it" — and a row that already reached a terminal FAILURE proves the
+	# opposite. Promoting on one hands the poll a reset that can never complete and,
+	# for an L4, a marker that eventually authorises clearing the credentials.
+	_LIVE = ("Applying", "Pending Capacity", "Applied")
+	if admin_age is not None and claim_age is not None and status in _LIVE:
+		# The row is THIS claim's iff it is no OLDER than the claim, within slack:
+		# admin's row is created moments AFTER the bench claims, so a genuine one has
+		# a SMALLER age. A stale row from an earlier reset has a much larger one.
+		if float(admin_age) <= float(claim_age) + _CLAIM_CLOCK_SLACK_SECONDS:
+			promoted = _strip_preflight(settings.get("last_sync_status") or "")
+			frappe.logger().info(
+				f"reset claim: admin has a {status} request {admin_age}s old against a claim "
+				f"{claim_age}s old; promoting"
+			)
+			_promote_reset_claim(settings, promoted)
+			return
+		frappe.logger().info(
+			f"reset claim: admin's latest request is {admin_age}s old but this claim is only "
+			f"{claim_age}s old — that row predates this claim, so it is not evidence for it"
+		)
+	elif status:
+		frappe.logger().info(
+			f"reset claim: admin's latest request is {status!r}; not evidence of a live rebuild"
+		)
+
+	if claimed_at:
+		deadline = frappe.utils.add_to_date(
+			frappe.utils.get_datetime(claimed_at), minutes=_PREFLIGHT_EXPIRY_MINUTES
+		)
+		if frappe.utils.now_datetime() < deadline:
+			return
+
+	# Past the deadline with no matching request: the reset never started. Say so
+	# in a way the customer can act on rather than leaving a marker that means
+	# "resetting" forever.
+	frappe.log_error(
+		title="workspace reset: claim expired without admin ever accepting the request",
+		message=f"claimed_at={claimed_at!r} admin_request={req!r}",
+	)
+	_release_reset_claim(settings, "workspace reset did not start — try again")
+
+
+def _expire_orphaned_disconnect_claim(settings) -> None:
+	"""Give back a disconnect claim whose worker died before it finished.
+
+	``disconnect_bench`` releases its lock after claiming, so the claim is all that
+	blocks a concurrent reset — and if the worker is SIGKILLed mid-teardown nothing
+	else will ever clear it. Without this the customer is locked out of BOTH
+	actions permanently, which is the plan's clear-the-marker invariant violated by
+	the disconnect path instead of the reset one.
+
+	Safe to expire and retry: the claim is written before anything destructive, and
+	both legs are idempotent — admin's teardown answers vacuous-true when there is
+	nothing left to tear down, and a completed clear would have overwritten this
+	marker with ``_DISCONNECTED_STATUS`` already. Seeing the claim still here means
+	the clear did NOT complete, so the bench still holds its credentials.
+
+	Waits the same ``_PREFLIGHT_EXPIRY_MINUTES`` as a reset claim, which is far
+	longer than the 240s teardown budget — expiring a claim whose worker is merely
+	slow would let a reset start on top of a live teardown."""
+	claimed_at = settings.get("workspace_reset_claimed_at")
+	if claimed_at:
+		deadline = frappe.utils.add_to_date(
+			frappe.utils.get_datetime(claimed_at), minutes=_PREFLIGHT_EXPIRY_MINUTES
+		)
+		if frappe.utils.now_datetime() < deadline:
+			return
+	frappe.log_error(
+		title="bench disconnect: claim expired without completing",
+		message=f"claimed_at={claimed_at!r}; the clear did not complete, credentials survive",
+	)
+	_release_reset_claim(settings, "disconnect did not complete — try again")
+
+
 def reconcile_pending_workspace_reset() -> None:
-	"""*/5 backstop: converge a reset whose tab was closed mid-poll."""
+	"""*/5 backstop: converge a reset whose tab was closed mid-poll, and resolve a
+	claim whose request worker died before it could promote or release."""
 	s = frappe.get_single("Jarvis Settings")
+	# A disconnect claim is not a reset and nothing converges it, but it does block
+	# both entry points, so an orphan has to be given back here or nowhere.
+	if (s.get("last_sync_status") or "") == _DISCONNECTING_STATUS:
+		_expire_orphaned_disconnect_claim(s)
+		return
 	if not (s.get("last_sync_status") or "").startswith(_RESETTING_STATUS):
 		return
+	# A pre-flight claim is not convergeable — polling it would do nothing forever.
+	# Resolve it first; if that promotes, the poll below runs on the promoted
+	# marker in the same tick rather than waiting another five minutes.
+	if _is_preflight(s):
+		# Under the lock: every OTHER writer of this marker takes it, and this one
+		# runs from the */5 cron where a request worker may be promoting or releasing
+		# the same field concurrently. Non-blocking — if a request holds it, that
+		# request is itself resolving the claim and this tick has nothing to add.
+		from jarvis._redis_lock import redis_lock
+
+		with redis_lock(_RESET_LOCK, timeout_s=_RESET_LOCK_TTL_S) as acquired:
+			if not acquired:
+				return
+			s = _reread_inside_lock()
+			if not _is_preflight(s):
+				return
+			_resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		if not _reset_in_flight(s) or _is_preflight(s):
+			return
+	else:
+		# A CONVERGING claim needs a deadline too (round-5 MAJOR 2). Promotion
+		# proved a rebuild had started; it did not promise one would finish. A
+		# request that admin abandoned, or a rebuild whose container never comes
+		# back, would otherwise poll forever — the marker outliving everything that
+		# could clear it, which is the plan's own invariant broken from the far end.
+		#
+		# Generous, because the poll converges the moment the container reports
+		# Ready and this only fires when it never does: _RECONCILE_GIVE_UP_MINUTES
+		# is far past any real rebuild.
+		claimed_at = s.get("workspace_reset_claimed_at")
+		if claimed_at:
+			deadline = frappe.utils.add_to_date(
+				frappe.utils.get_datetime(claimed_at), minutes=_RECONCILE_GIVE_UP_MINUTES
+			)
+			if frappe.utils.now_datetime() >= deadline:
+				frappe.log_error(
+					title="workspace reset: rebuild never converged; giving up on the marker",
+					message=f"claimed_at={claimed_at!r} status={s.get('last_sync_status')!r}",
+				)
+				_release_reset_claim(s, "workspace reset did not finish — check your workspace, or try again")
+				return
 	_workspace_reset_poll()
 
 

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -1,9 +1,30 @@
 """One definition of what a reset clears on Jarvis Settings.
 
-Two paths reset this site: the ``bench reset-onboarding`` CLI clears everything,
-the self-serve workspace reset clears only the LLM subset. They kept separate
-field lists that drifted - the CLI missed the credential the bench authenticates
-with, the self-serve path blanked a ``reqd`` field. Both now compose from here.
+Five reset paths exist. Every settings field any of them clears comes from the
+specs below — L1 and L2 clear none of their own (a container rebuild and a
+workspace-content wipe touch nothing on this Single), which is why a spec is
+named only from L3 down:
+
+  1. ``dev.reset_onboarding`` (CLI ``bench reset-onboarding``) applies ``FULL``
+  2-4. ``onboarding.request_workspace_reset`` offers a four-level ladder, each
+       level optionally deeper:
+
+       L1  (no flags)         rebuild the container only
+       L2  wipe_data          + workspace content
+       L3  revoke_llm         + LLM connections  (applies ``LLM``)
+       L4  disconnect_after   + admin connection (applies ``CONNECTION |
+                                OAUTH_MARKERS``, deferred until the rebuilt
+                                container reports Ready)
+
+  5. ``onboarding.disconnect_bench`` terminal action applies ``CONNECTION |
+     OAUTH_MARKERS`` with no rebuild or poll
+
+They kept separate field lists that drifted - the CLI missed the credential the
+bench authenticates with (now ``CONNECTION``), the self-serve path blanked a
+``reqd`` field (``llm_auth_mode``, now in ``LLM.defaults``). All now compose from
+here, so the field lists cannot drift apart. The composition is load-bearing: L1
+rebuilds but clears nothing; L2 adds workspace wipe; L3 adds ``LLM``; L4 and the
+terminal action each add ``CONNECTION``.
 """
 
 from typing import NamedTuple
@@ -112,6 +133,37 @@ CONNECTION = ResetSpec(
 		# the previous tenancy's generation (review plan 04 P0-5).
 		"tenant_authority_generation",
 	),
+)
+
+# The OAuth markers whose backing credential a DISCONNECT itself destroys, and
+# nothing wider.
+#
+# Both paths that clear ``CONNECTION`` first have admin tear the container's OAuth
+# auth-profile down (``api.tenant.prepare_bench_disconnect``), and an L4 rebuild
+# would drop it regardless - OAuth creds never ride a rebuild. So after either,
+# the container can no longer answer a turn on an OAuth grant, while these two
+# fields on this Single still say it can.
+#
+# That is not cosmetic. ``account.is_ready_for_chat`` gates the whole LLM step on
+# ``llm_oauth_connected_at`` for auth_mode oauth/subscription, and
+# ``account._has_llm_config`` reads either field - so a bench that disconnected and
+# then reconnected with the emailed code would SKIP LLM setup and land the customer
+# in a chat whose container holds no credential. Plan edge case 21.
+#
+# Deliberately NOT the whole ``LLM`` spec: a disconnect is not a revoke. An api-key
+# tenant's ``/secrets/llm.key`` and a pool's own keys survive the disconnect, so
+# ``llm_api_key``, the models[] pool and ``llm_direct_synced_at`` /
+# ``llm_pool_synced_at`` must stay - clearing them would make every disconnect a
+# silent L3. ``llm_auth_mode`` stays too, and stays reqd: the workspace WAS set up
+# for OAuth, and leaving it set is what routes readiness back through LLM setup
+# rather than into the "unknown auth_mode" verdict.
+#
+# A strict subset of ``LLM`` (``llm_oauth_account_email`` is in its blank list,
+# ``llm_oauth_connected_at`` in its null list), so ``FULL`` already covers it and
+# the CLI cannot drift from the self-serve paths here.
+OAUTH_MARKERS = ResetSpec(
+	blank=("llm_oauth_account_email",),
+	null=("llm_oauth_connected_at",),
 )
 
 FULL = CONNECTION | LLM

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1,5 +1,6 @@
 """Tests for jarvis.onboarding sync + wrappers (admin_client mocked)."""
 
+import contextlib
 from unittest.mock import patch
 
 import frappe
@@ -45,6 +46,17 @@ _SNAPSHOTTED_FIELDS = (
 	"latest_jarvis_version",
 	"release_notice_message",
 )
+
+# admin's prepare_bench_disconnect report for a teardown that fully succeeded.
+# Spelled out as a literal rather than a MagicMock's truthy default, because the
+# bench BRANCHES on these keys: a bare Mock() would make every key truthy and
+# every abort path silently untestable. See onboarding._teardown_container_via_admin.
+_TEARDOWN_OK = {
+	"profile_cleared": True,
+	"devices_unpaired": True,
+	"removed": 1,
+	"detail": "",
+}
 
 
 def _snapshot_settings() -> dict:
@@ -622,6 +634,10 @@ class TestWorkspaceReset(FrappeTestCase):
 		"preset",
 		"proxy_active",
 		"proxy_recommended",
+		# Only the L4-completion test reaches _clear_admin_connection (CONNECTION
+		# spec), which touches these too - matches TestDisconnectBench's list.
+		"tenant_authority_handle",
+		"tenant_authority_generation",
 	)
 
 	def setUp(self):
@@ -812,13 +828,18 @@ class TestWorkspaceReset(FrappeTestCase):
 		frappe.db.commit()
 		with (
 			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			# L3 includes L2. The ladder is cumulative and the server now enforces
+			# what only the SPA's radio group used to (round-4 MINOR 4). The wipe is
+			# patched out because this test is about the LLM revoke, and
+			# test_reset_wipe_data_deletes_content already owns the wipe.
+			patch("jarvis.onboarding._wipe_workspace_content"),
 			patch(
 				"jarvis.onboarding.admin_client.reset_workspace",
 				return_value={"status": "Applied", "tenant": "t-new"},
 			),
 			patch("jarvis.account._bust_chat_gate"),
 		):
-			onboarding.request_workspace_reset(revoke_llm=True)
+			onboarding.request_workspace_reset(wipe_data=True, revoke_llm=True)
 		s = frappe.get_single("Jarvis Settings")
 		self.assertFalse(s.llm_model)
 		self.assertFalse(s.proxy_active)
@@ -852,6 +873,1999 @@ class TestWorkspaceReset(FrappeTestCase):
 			out = onboarding.workspace_reset_state()
 		self.assertTrue(out["ready"])
 		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, "ok (workspace reset)")
+
+	def test_poll_tears_down_container_before_clearing_connection_on_l4(self):
+		"""BLOCKER 2 regression. _workspace_reset_poll used to bind ``settings``
+		before ``write_connection`` persisted the rebuilt container's agent_url -
+		write_connection takes its OWN uncached frappe.get_single() doc, so the
+		poll's copy kept the "" that _disconnect_agent_transport committed at
+		request time. That made _clear_admin_connection's
+		``if (settings.get("agent_url") or "").strip():`` guard deterministically
+		false, so the container teardown was silently skipped on every L4 and the
+		rebuilt container kept its OAuth auth-profile forever, unreachable once the
+		bench destroyed the credentials that could have torn it down.
+
+		Assert the teardown call actually HAPPENS - not that the guard's inputs
+		look right, which is what let this ship undetected.
+
+		T14 replaced the two current_customer-gated calls with the single
+		authenticated prepare_bench_disconnect, so that is what must fire here."""
+		s = frappe.get_single("Jarvis Settings")
+		# Simulate the state _disconnect_agent_transport leaves behind: agent_url
+		# already cleared, marker carrying the L4 (disconnect_after) suffix.
+		s.db_set("agent_url", "")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS + onboarding._DISCONNECT_SUFFIX)
+		frappe.db.commit()
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Applied"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+					"tenant_status": "running",
+				},
+			),
+			# T21 re-validates eligibility immediately before the deferred clear -
+			# minutes after the request-time precheck, on the far side of a rebuild.
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={"recoverable": True, "needs_company": False, "reason": ""},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value=_TEARDOWN_OK,
+			) as teardown,
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.workspace_reset_state()
+		teardown.assert_called_once()
+		self.assertTrue(out["ready"])
+		self.assertFalse(out["resetting"])
+		s = frappe.get_single("Jarvis Settings")
+		# CONNECTION cleared afterwards: the agent_url the poll just wrote is gone
+		# again, along with the rest of the admin connection.
+		self.assertFalse(s.agent_url)
+		self.assertFalse(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+
+class TestDisconnectBench(FrappeTestCase):
+	"""'Disconnect this bench': the terminal, no-rebuild counterpart to L4.
+	No poll, no resetting marker — leaving, not resetting."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + (
+		"chat_device_id",
+		"chat_device_public_key",
+		"chat_device_private_key",
+		"chat_device_token",
+		"tenant_authority_handle",
+		"tenant_authority_generation",
+		"last_sync_status",
+	)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			v = (
+				s.get_password(f, raise_exception=False)
+				if f.endswith(("_key", "_secret", "_token", "_password"))
+				else s.get(f)
+			)
+			self._snap[f] = v or ""
+		_set_token("tok")
+		s.db_set("agent_url", "ws://localhost:19000")
+		s.db_set("jarvis_admin_customer_email", "cust@example.com")
+		s.db_set("chat_device_id", "dev-1")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_disconnects_tears_down_and_clears_connection(self):
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value=_TEARDOWN_OK,
+			) as teardown,
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={"recoverable": True, "needs_company": False, "reason": ""},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.disconnect_bench()
+		teardown.assert_called_once()
+		self.assertTrue(out["disconnected"])
+		self.assertFalse(out["already_disconnected"])
+		self.assertFalse(out["needs_company"])
+		self.assertIn("jarvis_admin_customer_email", out["cleared"])
+		self.assertIn("agent_url", out["cleared"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.agent_url)
+		self.assertFalse(s.jarvis_admin_customer_email)
+		self.assertFalse(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	def test_already_disconnected_is_idempotent_and_harmless(self):
+		"""No email, no agent_url: this bench already left. Must succeed WITHOUT
+		reaching _recovery_outlook - that predicate needs a registered email and
+		would throw "no registered customer email" on a bench that already has
+		none, turning a harmless repeat click into an error."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_customer_email", "")
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		with patch("jarvis.onboarding._recovery_outlook") as outlook:
+			out = onboarding.disconnect_bench()
+		outlook.assert_not_called()
+		self.assertTrue(out["disconnected"])
+		self.assertTrue(out["already_disconnected"])
+		self.assertEqual(out["cleared"], [])
+		self.assertFalse(out["needs_company"])
+
+	def test_refuses_when_not_recoverable_and_clears_nothing(self):
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={
+					"recoverable": False,
+					"needs_company": False,
+					"reason": "Subscription is Cancelled; reconnect is not available.",
+				},
+			),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect") as teardown,
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				onboarding.disconnect_bench()
+		self.assertEqual(str(ctx.exception), "Subscription is Cancelled; reconnect is not available.")
+		teardown.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.agent_url, "ws://localhost:19000")
+		self.assertEqual(s.jarvis_admin_customer_email, "cust@example.com")
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	def test_needs_company_is_recoverable_not_refused(self):
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={"recoverable": True, "needs_company": True, "reason": ""},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value=_TEARDOWN_OK,
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.disconnect_bench()
+		self.assertTrue(out["disconnected"])
+		self.assertFalse(out["already_disconnected"])
+		self.assertTrue(out["needs_company"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.agent_url)
+
+	def _recoverable(self):
+		return patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": True, "needs_company": False, "reason": ""},
+		)
+
+	def _assert_nothing_cleared(self):
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.agent_url, "ws://localhost:19000")
+		self.assertEqual(s.jarvis_admin_customer_email, "cust@example.com")
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	# -- T14: refusal vs unreachability -------------------------------------
+	#
+	# Round-2 BLOCKER 1 / round-3 BLOCKER 3, and plan edge case 18. The old code
+	# caught BOTH in one bare ``except Exception`` and logged them in the same
+	# sentence, so the case where the teardown was POSSIBLE and got skipped was
+	# indistinguishable from the case where it was impossible - and the bench
+	# went on to destroy the credentials either way. These four pin the split.
+
+	def test_dead_admin_still_completes_the_clear(self):
+		"""Genuine unreachability - the ONLY thing that authorizes proceeding
+		without a confirmed teardown. Without this escape hatch a bench whose
+		control plane is gone could never leave its tenancy."""
+		from jarvis.admin_client import AdminUnreachableError
+
+		with (
+			self._recoverable(),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				side_effect=AdminUnreachableError("down"),
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.disconnect_bench()
+		self.assertTrue(out["disconnected"])
+		self.assertFalse(out["already_disconnected"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.agent_url)
+		self.assertFalse(s.jarvis_admin_customer_email)
+
+	def test_admin_refusal_aborts_the_clear(self):
+		"""T14's acceptance criterion. admin ANSWERED and said no (a 4xx -
+		ResetLocked, MoveInFlight, UnknownProvider all arrive as this class).
+		A retry can still succeed, so nothing may be destroyed."""
+		from jarvis.admin_client import AdminValidationError
+
+		with (
+			self._recoverable(),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				side_effect=AdminValidationError("another workspace operation is in progress"),
+			),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_bench()
+		self._assert_nothing_cleared()
+
+	def test_permanent_rejection_aborts_even_though_it_subclasses_unreachable(self):
+		"""AdminRejectedError IS an AdminUnreachableError subclass
+		(jarvis.exceptions), so an except-clause ordered the other way would
+		turn every permanent rejection into a proceed. It is a refusal: admin
+		was reached and said no."""
+		from jarvis.admin_client import AdminRejectedError
+
+		with (
+			self._recoverable(),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				side_effect=AdminRejectedError("refused", code="FleetConfigError", detail="refused"),
+			),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_bench()
+		self._assert_nothing_cleared()
+
+	def test_failed_device_unpair_aborts_the_clear(self):
+		"""admin was reached and reported the teardown honestly: the auth
+		profile went, the DEVICE unpair did not. Every paired chat-device token
+		is still live, and clearing CONNECTION now destroys the only credentials
+		that could ever revoke them. Round-3 BLOCKER 1's consequence, reached
+		through a reported failure instead of skipped control flow."""
+		with (
+			self._recoverable(),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value={
+					"profile_cleared": True,
+					"devices_unpaired": False,
+					"removed": 0,
+					"detail": "unpair: TimeoutError: agent unreachable",
+				},
+			),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_bench()
+		self._assert_nothing_cleared()
+
+	def test_dead_container_still_completes_the_clear(self):
+		"""The inverse, and the case the disconnect exists for (plan edge case
+		6, T3's acceptance criterion). The container is dead: the auth-profile
+		clear runs doctor + restart and cannot finish, but the device unpair is
+		a file operation that survives a stopped container. Devices provably
+		unpaired, so no third party keeps chat access - proceed. Refusing here
+		would block exactly the customer most likely to be disconnecting."""
+		with (
+			self._recoverable(),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value={
+					"profile_cleared": False,
+					"devices_unpaired": True,
+					"removed": 2,
+					"detail": "auth_profile: TimeoutError: container stopped",
+				},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.disconnect_bench()
+		self.assertTrue(out["disconnected"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.agent_url)
+		self.assertFalse(s.jarvis_admin_customer_email)
+
+
+class TestRecoveryOutlookPrecheck(FrappeTestCase):
+	"""Amendment 1 BLOCKER 1: the disconnect precheck must resolve identity
+	SERVER-SIDE via ``admin_client.reconnect_eligibility_me()`` - never by
+	sending ``jarvis_admin_customer_email``, which holds admin's synthetic
+	OAuth login (``cust-<hash>@jarvis.invalid`` from ``signup._synthetic_login``),
+	not a contact address. The earlier version passed it to the guest
+	``can_reconnect``, which resolves on the real address, so the lookup could
+	never match: L4 and disconnect_bench() refused for 100% of real benches and
+	rendered a value the field is documented as never-to-be-shown into a
+	customer-facing toast."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + ("last_sync_status",)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+		_set_token("tok")
+		# The synthetic OAuth login this field really holds, modelled exactly -
+		# if the precheck ever leaked it, this is the shape that would appear.
+		s.db_set("jarvis_admin_customer_email", "cust-deadbeef@jarvis.invalid")
+		s.db_set("agent_url", "ws://localhost:19000")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_sends_no_identity_argument(self):
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": True, "needs_company": False, "reason": ""},
+		) as elig:
+			onboarding._recovery_outlook()
+		# Zero args, zero kwargs - not even jarvis_admin_customer_email.
+		elig.assert_called_once_with()
+
+	def test_recoverable_true_yields_a_recoverable_outlook(self):
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": True, "needs_company": False, "reason": ""},
+		):
+			outlook = onboarding._recovery_outlook()
+		self.assertEqual(outlook, onboarding._RecoveryOutlook(True, False, ""))
+
+	def test_needs_company_true_is_recoverable_not_a_refusal(self):
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": True, "needs_company": True, "reason": ""},
+		):
+			outlook = onboarding._recovery_outlook()
+		self.assertTrue(outlook.recoverable)
+		self.assertTrue(outlook.needs_company)
+
+	def test_recoverable_false_refuses_with_admins_own_reason(self):
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={
+				"recoverable": False,
+				"needs_company": False,
+				"reason": "Subscription is Cancelled; reconnect is not available.",
+			},
+		):
+			outlook = onboarding._recovery_outlook()
+		self.assertFalse(outlook.recoverable)
+		self.assertEqual(outlook.reason, "Subscription is Cancelled; reconnect is not available.")
+
+	def test_no_customer_facing_string_contains_the_synthetic_login(self):
+		"""Plan edge case 13 - asserted by test, not by inspection."""
+		# Sanity: the fixture really does model the never-to-be-shown shape.
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertIn("@jarvis.invalid", settings.jarvis_admin_customer_email)
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": False, "needs_company": False, "reason": ""},
+		):
+			outlook = onboarding._recovery_outlook()
+		self.assertNotIn("@jarvis.invalid", outlook.reason)
+		# The disconnect endpoint's thrown message is what actually reaches the
+		# customer's toast - assert the same on that surface, not just the
+		# helper's return value.
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": False, "needs_company": False, "reason": ""},
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				onboarding.disconnect_bench()
+		self.assertNotIn("@jarvis.invalid", str(ctx.exception))
+
+	def test_admin_unreachable_fails_closed(self):
+		"""Fails CLOSED, deliberately: an unverified recovery path is treated as
+		no recovery path, and disconnect_bench() must refuse rather than clear
+		on a blip it could not confirm."""
+		from jarvis.admin_client import AdminUnreachableError
+
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			side_effect=AdminUnreachableError("down"),
+		):
+			outlook = onboarding._recovery_outlook()
+		self.assertFalse(outlook.recoverable)
+		self.assertNotIn("@jarvis.invalid", outlook.reason)
+		with patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			side_effect=AdminUnreachableError("down"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_bench()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.agent_url, "ws://localhost:19000")
+		self.assertTrue(s.jarvis_admin_customer_email)
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+
+class TestDisconnectBenchInFlightGuard(FrappeTestCase):
+	"""Amendment 1 BLOCKER 3 / MAJOR-1 (T8): disconnect_bench() must refuse
+	SERVER-SIDE while a reset is in flight. The SPA's :disabled button is not
+	enforcement - a second Settings tab never learns a reset started, and once
+	CONNECTION is cleared the resetting marker is blanked with it, leaving
+	reconcile_pending_workspace_reset nothing to converge and the rebuilt
+	container stranded."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + ("last_sync_status",)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+		_set_token("tok")
+		s.db_set("jarvis_admin_customer_email", "cust-deadbeef@jarvis.invalid")
+		# The state _disconnect_agent_transport leaves mid-reset: agent_url
+		# blanked but the email still present - this is what DEFEATS
+		# _admin_connection_absent's AND (it requires BOTH empty), so the
+		# idempotency short-circuit does not fire here and the in-flight guard
+		# is the only thing standing between this call and a stranding clear.
+		s.db_set("agent_url", "")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_disconnect_mid_reset_is_refused_and_clears_nothing(self):
+		# Patches the endpoint the disconnect path ACTUALLY calls. It used to
+		# patch post_subscription_disconnect / unpair_chat_devices, which T14
+		# removed from this path entirely - assert_not_called() on a target the
+		# code can no longer reach passes whatever the guard does.
+		with (
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect") as teardown,
+			patch("jarvis.onboarding.admin_client.reconnect_eligibility_me") as elig,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_bench()
+		teardown.assert_not_called()
+		# Refused by the in-flight guard, before the recovery precheck even runs.
+		elig.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, onboarding._RESETTING_STATUS)
+		self.assertTrue(s.jarvis_admin_customer_email)
+
+
+class TestRequestWorkspaceResetInFlightGuard(FrappeTestCase):
+	"""Amendment 1 BLOCKER 3 / MAJOR-1 (T8), plan edge case 15: a second
+	request_workspace_reset submission while a reset is already in flight must
+	not silently change its depth. Admin's own named_lock makes the ADMIN-side
+	request idempotent, but the DEPTH lives on this bench's marker, so this
+	bench has to guard it separately."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + ("last_sync_status",)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+		_set_token("tok")
+		# Transport already cleared by the in-flight reset's own request.
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_different_depth_while_in_flight_throws_and_does_not_relabel(self):
+		s = frappe.get_single("Jarvis Settings")
+		in_flight_marker = onboarding._reset_marker(reconnect_llm=False, disconnect_after=False)  # L1
+		s.db_set("last_sync_status", in_flight_marker)
+		frappe.db.commit()
+		with patch("jarvis.onboarding.admin_client.reset_workspace") as rw:
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.request_workspace_reset(revoke_llm=True)  # L3 - a different depth
+		rw.assert_not_called()
+		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, in_flight_marker)
+
+	def test_a_non_cumulative_depth_is_refused_server_side(self):
+		"""Round-4 MINOR 4. The ladder is cumulative — each level ADDS to the one
+		above — but the server took three independent booleans, so
+		``disconnect_after=1, revoke_llm=0`` was accepted and produced a depth the
+		ladder has no name for: the marker is "pending: resetting workspace
+		(disconnect)", for which ``_reconnect_llm()`` is false, so the poll demands
+		full chat-Ready before converging while the customer has asked for the
+		connection to be destroyed at the end.
+
+		Only the SPA's radio group enforced this, and a radio group is not
+		enforcement — it computes ``depth >= N`` for each flag, which is exactly the
+		rule now applied here. Nothing that reaches this endpoint by any other route
+		can pick a rung that does not exist."""
+		with patch("jarvis.onboarding.admin_client.reset_workspace") as rw:
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.request_workspace_reset(disconnect_after=True)  # L4 without L2/L3
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.request_workspace_reset(revoke_llm=True)  # L3 without L2
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.request_workspace_reset(wipe_data=True, disconnect_after=True)  # L4 without L3
+		rw.assert_not_called()
+
+	def test_same_depth_resubmission_stays_idempotent(self):
+		# L1 vs L1 (no flags) - deliberately avoids revoke_llm/wipe_data here, so
+		# this stays a guard-only test and does not also exercise (and need to
+		# snapshot/restore) settings_reset.LLM's field list and pool-model wipe,
+		# which TestWorkspaceReset already covers on its own terms.
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._reset_marker(reconnect_llm=False, disconnect_after=False))
+		frappe.db.commit()
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				return_value={"status": "Applied", "tenant": "t-new"},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.request_workspace_reset()  # same L1 depth: not refused
+		self.assertEqual(out["status"], "Applied")
+
+
+class TestL4RevalidatesBeforeTheDeferredClear(FrappeTestCase):
+	"""T21 + T24 / round-4 MAJOR 8 and MAJOR 2, Amendment 3.
+
+	request_workspace_reset refuses up front if the customer could not reconnect,
+	which satisfies plan edge case 2 AT REQUEST TIME. But for L4 the clear happens
+	minutes later in the poll, on the far side of a container rebuild - and a
+	subscription that moved to Cancelled in between (NOT Suspended; Cancelled is
+	outside billing.reconnect._ELIGIBLE_STATUSES) would have its credentials
+	destroyed with no emailed-code reconnect able to restore them. One precheck
+	"before clearing anything" cannot cover a gap it sits minutes before."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + (
+		"last_sync_status",
+		"workspace_reset_claimed_at",
+		"reconnect_needs_company",
+		"chat_device_id",
+		"chat_device_public_key",
+		"chat_device_private_key",
+		"chat_device_token",
+		"tenant_authority_handle",
+		"tenant_authority_generation",
+		"llm_oauth_connected_at",
+		"llm_oauth_account_email",
+	)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			v = (
+				s.get_password(f, raise_exception=False)
+				if f.endswith(("_key", "_secret", "_token", "_password"))
+				else s.get(f)
+			)
+			self._snap[f] = v or ""
+		_set_token("tok")
+		s.db_set("jarvis_admin_customer_email", "cust@example.com")
+		s.db_set("agent_url", "")
+		s.db_set("reconnect_needs_company", 0)
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS + onboarding._DISCONNECT_SUFFIX)
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("workspace_reset_claimed_at", None)
+		s.db_set("reconnect_needs_company", 0)
+		frappe.db.commit()
+
+	def _poll(self, *, eligibility, teardown=None):
+		return (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Applied"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+					"tenant_status": "running",
+				},
+			),
+			patch("jarvis.onboarding.admin_client.reconnect_eligibility_me", return_value=eligibility),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value=teardown if teardown is not None else _TEARDOWN_OK,
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		)
+
+	def test_a_subscription_cancelled_mid_rebuild_does_not_lose_its_credentials(self):
+		"""The permanent lockout the plan calls "mandatory, not advisory" to
+		prevent. Eligible at request time, Cancelled by the time the rebuild
+		finishes - the clear must be abandoned, not completed.
+
+		Fails against pre-T21 code, which cleared unconditionally."""
+		reason = "This account cannot be reconnected afterwards. Contact support."
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(
+				eligibility={"recoverable": False, "needs_company": False, "reason": reason}
+			):
+				stack.enter_context(cm)
+			out = onboarding.workspace_reset_state()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(out["disconnected"], "the clear must be abandoned")
+		self.assertTrue(s.jarvis_admin_customer_email, "credentials must survive")
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+		# The RESET still completed - this is the L3 outcome, not a failed reset.
+		self.assertEqual(s.last_sync_status, "ok (workspace reset)")
+		self.assertEqual(s.agent_url, "ws://localhost:19100")
+
+	def test_the_downgrade_is_reported_not_just_logged(self):
+		"""T24 / round-4 MAJOR 2. The customer chose "reset and disconnect", was
+		shown an irreversibility warning and confirmed it. Silently giving them a
+		shallower reset and toasting "Workspace is back" is not acceptable; an
+		Error Log entry is not telling them."""
+		reason = "This account cannot be reconnected afterwards. Contact support."
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(
+				eligibility={"recoverable": False, "needs_company": False, "reason": reason}
+			):
+				stack.enter_context(cm)
+			out = onboarding.workspace_reset_state()
+		self.assertEqual(out["disconnect_blocked"], reason)
+
+	def test_a_refused_teardown_is_reported_on_the_same_field(self):
+		"""The other way an L4 becomes an L3. One field, so the SPA has one branch
+		rather than two ways to say the same thing."""
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(
+				eligibility={"recoverable": True, "needs_company": False, "reason": ""},
+				teardown={
+					"profile_cleared": True,
+					"devices_unpaired": False,
+					"removed": 0,
+					"detail": "unpair: TimeoutError",
+				},
+			):
+				stack.enter_context(cm)
+			out = onboarding.workspace_reset_state()
+		self.assertFalse(out["disconnected"])
+		self.assertTrue(out["disconnect_blocked"])
+		self.assertTrue(frappe.get_single("Jarvis Settings").jarvis_admin_customer_email)
+
+	def test_a_successful_l4_reports_no_blockage(self):
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(eligibility={"recoverable": True, "needs_company": False, "reason": ""}):
+				stack.enter_context(cm)
+			out = onboarding.workspace_reset_state()
+		self.assertTrue(out["disconnected"])
+		self.assertEqual(out["disconnect_blocked"], "")
+
+	def test_the_l4_clear_holds_a_durable_claim_while_it_runs(self):
+		"""Round-5 BLOCKER. The poll used to retire the marker to
+		"ok (workspace reset)" and commit BEFORE starting the clear - which runs up
+		to ~264s (prepare_bench_disconnect's 240s budget plus the eligibility
+		re-check) while this poll's _RESET_LOCK expires at 60s.
+
+		So from t=60s there was neither lock NOR marker: a second tab's Reset passed
+		every guard, called admin and started a genuine rebuild, and the clear still
+		in flight here then blanked CONNECTION underneath it. That is round-4
+		BLOCKER 1's stranding, reached through the one long section that got the
+		short lock without a durable claim.
+
+		Read from INSIDE the teardown, which is the window that was unguarded."""
+		seen = {}
+
+		def _capture():
+			seen["status"] = frappe.db.get_single_value("Jarvis Settings", "last_sync_status")
+			seen["claimed_at"] = frappe.db.get_single_value("Jarvis Settings", "workspace_reset_claimed_at")
+			seen["blocks_a_reset"] = bool(
+				onboarding._workspace_op_in_flight(frappe.get_single("Jarvis Settings"))
+			)
+			return _TEARDOWN_OK
+
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(eligibility={"recoverable": True, "needs_company": False, "reason": ""}):
+				stack.enter_context(cm)
+			stack.enter_context(
+				patch("jarvis.onboarding.admin_client.prepare_bench_disconnect", side_effect=_capture)
+			)
+			onboarding.workspace_reset_state()
+		self.assertEqual(seen["status"], onboarding._DISCONNECTING_STATUS)
+		self.assertTrue(seen["claimed_at"], "an unstamped claim cannot be expired later")
+		self.assertTrue(
+			seen["blocks_a_reset"],
+			"a concurrent reset would have passed every guard and stranded this clear",
+		)
+		# ...and the completed clear leaves the terminal state, not the claim.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, onboarding._DISCONNECTED_STATUS)
+		self.assertFalse(s.workspace_reset_claimed_at)
+
+	def test_a_downgraded_l4_gives_the_claim_back(self):
+		"""Nothing is going to clear anything, so the claim must not sit there
+		blocking the customer's next reset for the whole expiry window."""
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(
+				eligibility={
+					"recoverable": False,
+					"needs_company": False,
+					"reason": "Subscription is Cancelled.",
+				}
+			):
+				stack.enter_context(cm)
+			onboarding.workspace_reset_state()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, "ok (workspace reset)")
+		self.assertFalse(onboarding._workspace_op_in_flight(s))
+		self.assertFalse(s.workspace_reset_claimed_at)
+
+	def test_needs_company_is_persisted_through_the_l4_clear(self):
+		"""T22 / round-4 MAJOR 9. The value is knowable ONLY at this moment - after
+		the sweep there are no credentials left to ask with. bench_connection_state
+		hardcoded False before, so an L4 customer whose address owns several
+		eligible accounts was sent to a reconnect they could not complete."""
+		with contextlib.ExitStack() as stack:
+			for cm in self._poll(eligibility={"recoverable": True, "needs_company": True, "reason": ""}):
+				stack.enter_context(cm)
+			onboarding.workspace_reset_state()
+		# Survives the CONNECTION sweep, like _DISCONNECTED_STATUS does...
+		self.assertTrue(frappe.get_single("Jarvis Settings").reconnect_needs_company)
+		# ...and every later page load can now read it back, with no admin call.
+		self.assertTrue(onboarding.bench_connection_state()["needs_company"])
+
+
+class TestDisconnectClaimsBeforeItTearsDown(FrappeTestCase):
+	"""T29 / Amendment 4. disconnect_bench used to hold _RESET_LOCK across its whole
+	critical section - including a teardown budgeted at 240s. redis_lock's release
+	is a `finally` a SIGKILLed worker never runs, so under a ~120s gunicorn
+	http_timeout the ordinary end of a slow teardown left the lock held for the full
+	TTL, freezing every convergence including the */5 reconcile.
+
+	The lock now covers check-and-claim only, and a durable claim
+	(_DISCONNECTING_STATUS) carries in-flight-ness afterwards, exactly as the
+	reset's pre-flight marker does. That gives the claim three new jobs: block a
+	concurrent reset, block a second disconnect, and be recoverable when its own
+	worker dies."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + (
+		"last_sync_status",
+		"workspace_reset_claimed_at",
+		"chat_device_id",
+		"chat_device_public_key",
+		"chat_device_private_key",
+		"chat_device_token",
+		"tenant_authority_handle",
+		"tenant_authority_generation",
+		"llm_oauth_connected_at",
+		"llm_oauth_account_email",
+	)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			v = (
+				s.get_password(f, raise_exception=False)
+				if f.endswith(("_key", "_secret", "_token", "_password"))
+				else s.get(f)
+			)
+			self._snap[f] = v or ""
+		_set_token("tok")
+		s.db_set("agent_url", "ws://localhost:19000")
+		s.db_set("jarvis_admin_customer_email", "cust@example.com")
+		s.db_set("last_sync_status", "ok")
+		s.db_set("workspace_reset_claimed_at", None)
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.get_single("Jarvis Settings").db_set("workspace_reset_claimed_at", None)
+		frappe.db.commit()
+
+	def _recoverable(self):
+		return patch(
+			"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+			return_value={"recoverable": True, "needs_company": False, "reason": ""},
+		)
+
+	def test_the_claim_is_written_before_the_teardown_runs(self):
+		"""Read from INSIDE the teardown call - the exact window the lock no longer
+		covers. With no claim there, a concurrent reset would sail past its guard
+		while this bench was mid-teardown."""
+		seen = {}
+
+		def _capture():
+			seen["status"] = frappe.db.get_single_value("Jarvis Settings", "last_sync_status")
+			seen["claimed_at"] = frappe.db.get_single_value("Jarvis Settings", "workspace_reset_claimed_at")
+			return _TEARDOWN_OK
+
+		with (
+			self._recoverable(),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect", side_effect=_capture),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.disconnect_bench()
+		self.assertEqual(seen["status"], onboarding._DISCONNECTING_STATUS)
+		self.assertTrue(seen["claimed_at"], "an unstamped claim cannot be expired later")
+		# ...and the completed clear overwrites it, leaving no stale claim behind.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, onboarding._DISCONNECTED_STATUS)
+		self.assertFalse(s.workspace_reset_claimed_at)
+
+	def test_a_reset_is_refused_while_a_disconnect_is_mid_teardown(self):
+		"""The race the shortened lock opens. The disconnect's lock is already
+		released by the time its teardown runs, so this marker is the only thing
+		stopping a reset from starting on a bench about to lose its credentials."""
+		outcome = {}
+
+		def _reentrant():
+			try:
+				onboarding.request_workspace_reset()
+				outcome["refused"] = False
+			except frappe.ValidationError as exc:
+				outcome["refused"] = True
+				outcome["why"] = str(exc)
+			return _TEARDOWN_OK
+
+		with (
+			self._recoverable(),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect", side_effect=_reentrant),
+			patch("jarvis.onboarding.admin_client.reset_workspace") as rw,
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.disconnect_bench()
+		self.assertTrue(outcome.get("refused"), outcome)
+		self.assertIn("being disconnected", outcome.get("why", ""))
+		rw.assert_not_called()
+
+	def test_a_second_disconnect_is_refused_while_one_is_mid_teardown(self):
+		outcome = {}
+
+		def _reentrant():
+			try:
+				onboarding.disconnect_bench()
+				outcome["refused"] = False
+			except frappe.ValidationError as exc:
+				outcome["refused"] = True
+				outcome["why"] = str(exc)
+			return _TEARDOWN_OK
+
+		with (
+			self._recoverable(),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect", side_effect=_reentrant),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.disconnect_bench()
+		self.assertTrue(outcome.get("refused"), outcome)
+		self.assertIn("already being disconnected", outcome.get("why", ""))
+
+	def test_a_refused_teardown_gives_the_claim_back(self):
+		"""Nothing was torn down or cleared, so the claim must not linger and block
+		the customer's next attempt."""
+		with (
+			self._recoverable(),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value={
+					"profile_cleared": True,
+					"devices_unpaired": False,
+					"removed": 0,
+					"detail": "unpair: TimeoutError",
+				},
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.disconnect_bench()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, "ok")
+		self.assertFalse(onboarding._workspace_op_in_flight(s))
+		self.assertFalse(s.workspace_reset_claimed_at)
+		self.assertTrue(s.jarvis_admin_customer_email)
+
+	def test_reconcile_expires_an_orphaned_disconnect_claim(self):
+		"""The SIGKILL case. Nothing else can ever clear this marker and it blocks
+		BOTH entry points, so without the expiry the customer is locked out of
+		resetting AND disconnecting, permanently. Safe to retry: the claim precedes
+		anything destructive, and a completed clear would have overwritten it with
+		_DISCONNECTED_STATUS."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._DISCONNECTING_STATUS)
+		s.db_set(
+			"workspace_reset_claimed_at",
+			frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), minutes=-(onboarding._PREFLIGHT_EXPIRY_MINUTES + 1)
+			),
+		)
+		frappe.db.commit()
+		with patch("jarvis.onboarding._workspace_reset_poll") as poll:
+			onboarding.reconcile_pending_workspace_reset()
+		# Never polled: a disconnect is not a reset and nothing converges it.
+		poll.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(onboarding._workspace_op_in_flight(s))
+		self.assertIn("did not complete", s.last_sync_status)
+		self.assertTrue(s.jarvis_admin_customer_email, "credentials must be intact")
+
+	def test_reconcile_leaves_a_young_disconnect_claim_alone(self):
+		"""The teardown is budgeted at 240s. Expiring a claim whose worker is merely
+		slow would let a reset start on top of a live teardown."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._DISCONNECTING_STATUS)
+		s.db_set("workspace_reset_claimed_at", frappe.utils.now_datetime())
+		frappe.db.commit()
+		onboarding.reconcile_pending_workspace_reset()
+		self.assertEqual(
+			frappe.get_single("Jarvis Settings").last_sync_status, onboarding._DISCONNECTING_STATUS
+		)
+
+
+class TestDisconnectClearsTheOAuthMarkers(FrappeTestCase):
+	"""T17 / plan edge case 21: a reconnected bench must be routed back through
+	LLM setup, not skip it on a marker whose credential the disconnect destroyed.
+
+	prepare_bench_disconnect tears the container's OAuth auth-profile down, and an
+	L4 rebuild would drop it regardless (OAuth creds never ride a rebuild). Either
+	way the container can no longer answer a turn on an OAuth grant. Left set,
+	llm_oauth_connected_at makes account.is_ready_for_chat skip the whole LLM step
+	for auth_mode oauth/subscription - so the customer reconnects with the emailed
+	code and lands in a chat whose container holds no credential."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + (
+		"last_sync_status",
+		"llm_auth_mode",
+		"llm_oauth_connected_at",
+		"llm_oauth_account_email",
+		"llm_direct_synced_at",
+		"chat_device_id",
+		"chat_device_public_key",
+		"chat_device_private_key",
+		"chat_device_token",
+		"tenant_authority_handle",
+		"tenant_authority_generation",
+	)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			v = (
+				s.get_password(f, raise_exception=False)
+				if f.endswith(("_key", "_secret", "_token", "_password"))
+				else s.get(f)
+			)
+			self._snap[f] = v or ""
+		_set_token("tok")
+		s.db_set("agent_url", "ws://localhost:19000")
+		s.db_set("jarvis_admin_customer_email", "cust@example.com")
+		s.db_set("llm_auth_mode", "oauth")
+		s.db_set("llm_oauth_connected_at", "2026-01-01 00:00:00")
+		s.db_set("llm_oauth_account_email", "person@example.com")
+		s.db_set("llm_direct_synced_at", "2026-01-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def _disconnect(self):
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={"recoverable": True, "needs_company": False, "reason": ""},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value=_TEARDOWN_OK,
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			return onboarding.disconnect_bench()
+
+	def test_the_oauth_markers_are_cleared(self):
+		out = self._disconnect()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.llm_oauth_connected_at)
+		self.assertFalse(s.llm_oauth_account_email)
+		# Reported, so the caller's "what was cleared" list is not a lie.
+		self.assertIn("llm_oauth_connected_at", out["cleared"])
+		self.assertIn("llm_oauth_account_email", out["cleared"])
+
+	def test_readiness_no_longer_reports_a_usable_credential(self):
+		"""The property edge case 21 actually asks for, asserted through the real
+		predicate rather than by re-reading the field the test just cleared."""
+		from jarvis import account
+
+		self._disconnect()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(account._has_llm_config(s))
+
+	def test_a_disconnect_is_not_a_silent_llm_revoke(self):
+		"""OAUTH_MARKERS is deliberately narrower than the LLM spec. The disconnect
+		destroys the container's auth PROFILE; it does not touch an api-key
+		tenant's /secrets/llm.key or a pool's own keys. Clearing llm_api_key,
+		models[] or the direct/pool sync markers here would turn every disconnect
+		into an L3 the customer never asked for."""
+		self._disconnect()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(s.llm_direct_synced_at)
+		# llm_auth_mode is reqd AND load-bearing: it is what routes readiness to
+		# the LLM step rather than to the "unknown auth_mode" verdict.
+		self.assertEqual(s.llm_auth_mode, "oauth")
+
+	def test_the_spec_is_a_strict_subset_of_the_llm_spec(self):
+		"""So the reset-onboarding CLI (which applies FULL = CONNECTION | LLM)
+		cannot drift from the self-serve disconnect. If a marker were ever added
+		to OAUTH_MARKERS without also being in LLM, FULL would stop clearing it
+		and the two paths would silently diverge - the exact class of bug
+		settings_reset exists to prevent."""
+		from jarvis import settings_reset
+
+		full = set(settings_reset.cleared_fields(settings_reset.FULL))
+		for field in settings_reset.cleared_fields(settings_reset.OAUTH_MARKERS):
+			self.assertIn(field, full)
+
+
+class TestResetClaimIsAtomicAndEarly(FrappeTestCase):
+	"""T15 / Amendment 2 BLOCKER 2: the in-flight guard was defeated by ordering.
+
+	``request_workspace_reset`` READ the marker first and WROTE it LAST, inside
+	``_disconnect_agent_transport``, after ``_recovery_outlook`` (8s),
+	``post_subscription_disconnect`` (180s budget), ``admin_client.reset_workspace``
+	(180s, and it STARTS the rebuild) and the content wipe. For that entire
+	multi-minute window ``disconnect_bench``'s guard saw no marker and let the
+	disconnect through - blanking ``last_sync_status`` (it is in
+	``settings_reset.CONNECTION``), leaving ``reconcile_pending_workspace_reset``
+	nothing to converge, and stranding the rebuilt container with no bench able to
+	reach it.
+
+	A guard that reads state it has not yet claimed is not a guard.
+	"""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + ("last_sync_status", "workspace_reset_claimed_at")
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+		_set_token("tok")
+		s.db_set("agent_url", "ws://localhost:19000")
+		s.db_set("jarvis_admin_customer_email", "cust@example.com")
+		s.db_set("last_sync_status", "ok")
+		frappe.db.commit()
+		self.addCleanup(self._release_lock)
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	@staticmethod
+	def _release_lock():
+		"""Belt and braces: a test that fails mid-lock must not leave the key set
+		for the rest of the suite.
+
+		Deletes through the RAW redis client, not ``frappe.cache().delete_value``.
+		That was round-4 MINOR 5: ``delete_value`` routes through
+		``RedisWrapper.make_key``, which prefixes the site's db name, while
+		redis-py's ``cache.lock(key)`` uses the key VERBATIM. So the old cleanup
+		deleted a key that never existed, and this safety net caught nothing.
+		Pinned by a test below rather than left to inspection — a no-op cleanup
+		looks exactly like a working one until the day it matters."""
+		from jarvis._redis_lock import LOCK_PREFIX
+
+		try:
+			frappe.cache().delete(LOCK_PREFIX + onboarding._RESET_LOCK)
+		except Exception:
+			pass
+
+	def test_the_release_lock_helper_deletes_the_key_the_lock_actually_uses(self):
+		"""Round-4 MINOR 5. Takes the real lock, runs the cleanup, and asserts the
+		lock can then be re-acquired. Fails against the delete_value version, which
+		deleted a db-name-prefixed key redis-py never wrote."""
+		from jarvis._redis_lock import redis_lock
+
+		lock = frappe.cache().lock(f"jarvis:lock:{onboarding._RESET_LOCK}", timeout=60, blocking_timeout=None)
+		self.assertTrue(lock.acquire(blocking=False), "could not take the lock under test")
+		self._release_lock()
+		with redis_lock(onboarding._RESET_LOCK, timeout_s=10) as reacquired:
+			self.assertTrue(reacquired, "the cleanup did not actually free the lock")
+
+	def test_marker_is_claimed_before_the_rebuild_is_requested(self):
+		"""Reads ``last_sync_status`` from INSIDE the reset_workspace call - the
+		exact moment the old code had already started the rebuild with no marker
+		set. Fails against pre-T15 code, where the marker was written afterwards."""
+		seen = {}
+
+		def _capture(reason=""):
+			seen["status"] = frappe.db.get_single_value("Jarvis Settings", "last_sync_status")
+			return {"status": "Applied", "tenant": "t-new"}
+
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch("jarvis.onboarding.admin_client.reset_workspace", side_effect=_capture),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.request_workspace_reset()
+		# PRE-FLIGHT at this point: claimed, but admin has not yet accepted the
+		# request, so no poll may converge on it. Promotion happens after
+		# reset_workspace returns.
+		self.assertEqual(seen["status"], onboarding._reset_marker(preflight=True))
+
+	def test_the_l4_depth_is_on_the_claim_not_just_the_final_write(self):
+		"""The marker is where a reset's DEPTH lives. Claiming a bare L1 marker
+		early and only labelling it L4 at the end would leave the whole window
+		looking like a shallower reset to anything that read it."""
+		seen = {}
+
+		def _capture(reason=""):
+			seen["status"] = frappe.db.get_single_value("Jarvis Settings", "last_sync_status")
+			return {"status": "Applied", "tenant": "t-new"}
+
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={"recoverable": True, "needs_company": False, "reason": ""},
+			),
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			# Patched for the same reason as above: the assertion is the marker.
+			patch("jarvis.onboarding._wipe_workspace_content"),
+			patch("jarvis.onboarding._revoke_llm_connections"),
+			patch("jarvis.onboarding.admin_client.reset_workspace", side_effect=_capture),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.request_workspace_reset(wipe_data=True, revoke_llm=True, disconnect_after=True)
+		# A real L4 necessarily carries L3 as well (the ladder is cumulative and the
+		# server enforces it), so the marker carries BOTH suffixes - which is the
+		# combined "(reconnect llm) (disconnect)" case _reset_marker's docstring
+		# calls out by name.
+		l4 = onboarding._reset_marker(reconnect_llm=True, disconnect_after=True)
+		self.assertEqual(
+			seen["status"],
+			onboarding._reset_marker(reconnect_llm=True, disconnect_after=True, preflight=True),
+		)
+		# The depth survives the pre-flight suffix: stripping it must give back
+		# exactly the L4 marker the poll will later converge on.
+		self.assertEqual(onboarding._strip_preflight(seen["status"]), l4)
+		self.assertTrue(onboarding._strip_preflight(seen["status"]).endswith(onboarding._DISCONNECT_SUFFIX))
+		# ...and it is promoted once admin accepts, or the poll could never finish.
+		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, l4)
+
+	def test_a_refused_request_gives_the_claim_back(self):
+		"""admin was REACHED and declined (a 4xx), so nothing was started and the
+		claim must not survive. Left set, it shows a reset that does not exist,
+		blocks disconnect_bench on a guard protecting nothing, and hands the */5
+		reconcile a reset it can never converge."""
+		from jarvis.admin_client import AdminValidationError
+
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				side_effect=AdminValidationError("no subscription found"),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.request_workspace_reset()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, "ok")
+		self.assertFalse(onboarding._reset_in_flight(s))
+		# And the transport is untouched, as it was before T15.
+		self.assertEqual(s.agent_url, "ws://localhost:19000")
+
+	def test_a_timeout_KEEPS_the_claim_because_the_rebuild_may_be_running(self):
+		"""Round-4 MAJOR 5. Admin runs the destroy + reprovision SYNCHRONOUSLY
+		inside the HTTP request, committing its request row before it starts, while
+		this bench gives up at timeout_s=180. So AdminUnreachableError here is the
+		ordinary shape of a slow rebuild that IS running - not evidence that none
+		is.
+
+		Releasing the claim there would blank the marker mid-rebuild, leaving
+		reconcile_pending_workspace_reset nothing to converge and disconnect_bench
+		unguarded: the exact stranding the claim exists to prevent, reached through
+		the release path instead of the claim path.
+
+		Fails against the pre-fix code, which released on every exception."""
+		from jarvis.admin_client import AdminUnreachableError
+
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				side_effect=AdminUnreachableError("read timeout"),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.request_workspace_reset()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, onboarding._reset_marker(preflight=True))
+		self.assertTrue(
+			onboarding._reset_in_flight(s),
+			"the marker must survive so reconcile can resolve a rebuild that may be running",
+		)
+
+	def test_a_transient_failure_leaves_a_claim_no_poll_will_converge_on(self):
+		"""The defect the two-state marker exists for, and it was INTRODUCED by the
+		round-4 MAJOR 5 fix.
+
+		Keeping the claim on a timeout is right (admin rebuilds synchronously, so a
+		bench timeout is the ordinary shape of a rebuild that IS running). But the
+		raise unwinds `with redis_lock(...)`, whose `finally` DOES release - so if
+		the rebuild never actually started, reconcile arrives five minutes later to
+		a free lock, an old container still answering Ready, and a marker saying
+		"resetting". It converged: a silent no-op for L1-L3, and for L4 a container
+		teardown plus a credential clear against a container that was never rebuilt.
+
+		Pre-flight is what closes it. The claim survives (so the guards hold and
+		reconcile can resolve it), but no poll may converge on it until admin has
+		positively accepted the request.
+
+		Fails against the pre-fix code, where the kept marker was convergeable."""
+		from jarvis.admin_client import AdminUnreachableError
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "ok")
+		frappe.db.commit()
+
+		with (
+			# L4, so the recovery precheck runs FIRST and has to pass - otherwise the
+			# request is refused before it ever claims and this test proves nothing.
+			patch(
+				"jarvis.onboarding.admin_client.reconnect_eligibility_me",
+				return_value={"recoverable": True, "needs_company": False, "reason": ""},
+			),
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			# The two destructive legs are patched out: this test is about the
+			# CLAIM. Cumulativity (round-4 MINOR 4) means an L4 must send them, but
+			# actually running them here would delete workspace content and revoke
+			# LLM config on the real site for no assertion's benefit.
+			patch("jarvis.onboarding._wipe_workspace_content"),
+			patch("jarvis.onboarding._revoke_llm_connections"),
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				side_effect=AdminUnreachableError("connection reset by peer"),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.request_workspace_reset(wipe_data=True, revoke_llm=True, disconnect_after=True)
+
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(onboarding._is_preflight(s), "the claim must be left PRE-FLIGHT")
+		self.assertTrue(onboarding._reset_in_flight(s), "guards must still see a claim")
+		self.assertTrue(s.workspace_reset_claimed_at, "reconcile needs the claim timestamp")
+
+		# Now the reconcile that used to destroy the credentials: the OLD container
+		# is up and Ready, because it was never rebuilt.
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Applied"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19000",
+					"agent_token": "t",
+					"tenant_status": "running",
+				},
+			),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect") as teardown,
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.workspace_reset_state()
+
+		teardown.assert_not_called()
+		self.assertFalse(out["disconnected"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(s.jarvis_admin_customer_email, "credentials must survive")
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+		self.assertTrue(onboarding._is_preflight(s), "still unresolved, not silently completed")
+
+	# -- T27: no claim may be left unresolvable --------------------------------
+	#
+	# The plan's invariant is "no path may leave last_sync_status on a resetting
+	# marker nothing can clear". Pre-flight satisfies the safety half (nothing
+	# converges on it) but would violate that invariant outright without a
+	# resolver: a worker SIGKILLed between the claim and the promote leaves a
+	# marker no poll acts on and nothing clears. These three cover every branch.
+
+	def _preflight_claim(self, *, age_minutes=0):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._reset_marker(preflight=True))
+		s.db_set(
+			"workspace_reset_claimed_at",
+			frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-age_minutes),
+		)
+		frappe.db.commit()
+		return frappe.get_single("Jarvis Settings")
+
+	def test_a_claim_admin_really_accepted_is_promoted(self):
+		"""The common case: the bench's HTTP call died but admin went on
+		rebuilding. The claim must become convergeable, or the customer's rebuild
+		completes on the control plane and this bench never notices."""
+		s = self._preflight_claim(age_minutes=1)
+		with patch(
+			"jarvis.onboarding.admin_client.reset_workspace_state",
+			return_value={
+				"request": "REQ-1",
+				"status": "Applying",
+				"requested_at": str(frappe.utils.now_datetime()),
+				# Admin measures this on ADMIN's clock; the bench compares it against
+				# its own claim's age. Two durations, so no timezone can enter it.
+				"requested_age_seconds": 5,
+			},
+		):
+			onboarding._resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(onboarding._is_preflight(s), "must be promoted")
+		self.assertEqual(s.last_sync_status, onboarding._reset_marker())
+
+	def test_a_settings_save_cannot_clobber_a_claim(self):
+		"""Round-5 MAJOR 6. The whole post-lock design rests on the claim being
+		durable, but Jarvis Settings.on_update writes its own status to the SAME
+		field on every save while pool_mode - and _should_skip_admin_sync requires
+		last_sync_status.startswith("ok"), which a claim never satisfies, so the
+		skip could never apply while one was held.
+
+		One save from a second tab (save_llm_creds, save_llm_pool, or a System
+		Manager on the desk form) destroyed it: a pre-flight claim left
+		workspace_reset_claimed_at with nothing to resolve it; a converging one left
+		the rebuild unconverged, agent_url blank and chat dead until the daily
+		sync_connection.
+
+		All three claim states, because they are written by different code paths and
+		only one of them starts with the resetting prefix."""
+		for claim in (
+			onboarding._reset_marker(preflight=True),
+			onboarding._reset_marker(),
+			onboarding._DISCONNECTING_STATUS,
+		):
+			with self.subTest(claim=claim):
+				frappe.get_single("Jarvis Settings").db_set("last_sync_status", claim)
+				frappe.db.commit()
+				s = frappe.get_single("Jarvis Settings")
+				s.flags.ignore_mandatory = True
+				s.save(ignore_permissions=True)
+				frappe.db.commit()
+				self.assertEqual(
+					frappe.db.get_single_value("Jarvis Settings", "last_sync_status"),
+					claim,
+					"a Jarvis Settings save destroyed the workspace-operation claim",
+				)
+
+	def test_a_claim_does_not_disable_llm_validation_or_the_key_write(self):
+		"""Round-6 MAJOR 2, a regression the round-5 MAJOR 6 fix INTRODUCED.
+
+		That guard returned early from on_update itself, which skipped far more than
+		the admin sync it was aimed at: validate_models (the app's ONLY call site),
+		the derived proxy flags, the legacy models[0] mirror, and the encrypted
+		llm_api_key write. save_llm_creds then returned SUCCESS while the credential
+		was never stored and an invalid config was never rejected.
+
+		The guard now sits at the two PUSH sites instead. This asserts the local
+		bookkeeping still runs while a claim is held - which is what none of the 164
+		tests noticed, because they all assert on the sync, never on validation."""
+		from jarvis.jarvis.pool_serialize import validate_models
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._reset_marker(preflight=True))
+		frappe.db.commit()
+
+		# validate_models must still REFUSE a bad config while a claim is held.
+		s = frappe.get_single("Jarvis Settings")
+		s.set(
+			"models",
+			[{"provider": "OpenAI", "model": "gpt-5.5", "credential_type": "api_key", "enabled": 1}],
+		)
+		self.assertTrue(
+			validate_models(s),
+			"an api_key model with no key must not validate - if this passes, the "
+			"fixture stopped modelling the case the regression was about",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			s.save(ignore_permissions=True)
+		frappe.db.rollback()
+
+		# ...and the claim is still standing afterwards.
+		self.assertEqual(
+			frappe.db.get_single_value("Jarvis Settings", "last_sync_status"),
+			onboarding._reset_marker(preflight=True),
+		)
+
+	def test_a_failed_request_does_not_promote_a_claim(self):
+		"""Round-5. Promotion means "a rebuild is happening, go converge it", and a
+		row that already reached a terminal FAILURE proves the opposite. Promoting
+		on one hands the poll a reset that can never complete and, for an L4, a
+		marker that eventually authorises clearing the credentials.
+
+		The timestamp alone was the whole test before, so a Failed row promoted."""
+		s = self._preflight_claim(age_minutes=1)
+		with patch(
+			"jarvis.onboarding.admin_client.reset_workspace_state",
+			return_value={
+				"request": "REQ-1",
+				"status": "Failed",
+				"requested_at": str(frappe.utils.now_datetime()),
+			},
+		):
+			onboarding._resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(onboarding._is_preflight(s), "a Failed request is not evidence of a rebuild")
+
+	def test_the_card_is_not_ready_while_the_claim_is_pre_flight(self):
+		"""Round-5. `ready` for an L3/L4 is `agent_url and (Ready or
+		_reconnect_llm())`, and _reconnect_llm() matches straight THROUGH the
+		pre-flight suffix - so during pre-flight `ready` collapsed to "the OLD
+		container is up", which is unconditionally true. GeneralPane.pollReset acts
+		on it with a hard reload announcing "Workspace is back", and T33 now starts
+		that poll after a timed-out initiate: the very first tick would announce a
+		completed reset for one that never started."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._reset_marker(reconnect_llm=True, preflight=True))
+		frappe.db.commit()
+		with (
+			patch("jarvis.onboarding.admin_client.reset_workspace_state", return_value={}),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={"chat_readiness": "Configuring", "agent_url": "ws://old:19000"},
+			),
+		):
+			out = onboarding.workspace_reset_state()
+		self.assertFalse(out["ready"], "a pre-flight claim must never read as a finished reset")
+		self.assertTrue(out["resetting"], "but the card still shows progress")
+
+	def test_a_young_claim_with_no_request_is_left_alone(self):
+		"""The call may still be in flight. Deciding now would be guessing, and
+		guessing wrong expires a live rebuild's claim."""
+		s = self._preflight_claim(age_minutes=1)
+		with patch(
+			"jarvis.onboarding.admin_client.reset_workspace_state",
+			return_value={"request": None, "status": None, "requested_at": None},
+		):
+			onboarding._resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(onboarding._is_preflight(s), "a young claim must not be expired")
+
+	def test_an_expired_claim_with_no_request_is_given_up_honestly(self):
+		"""Past the deadline with no matching request the reset never started.
+		The marker must not mean "resetting" forever - this is the plan's
+		clear-the-marker invariant, and the claim is written before any
+		destructive step, so retrying is safe."""
+		s = self._preflight_claim(age_minutes=onboarding._PREFLIGHT_EXPIRY_MINUTES + 1)
+		with patch(
+			"jarvis.onboarding.admin_client.reset_workspace_state",
+			return_value={"request": None, "status": None, "requested_at": None},
+		):
+			onboarding._resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(onboarding._reset_in_flight(s), "no marker may outlive its claim")
+		self.assertFalse(s.workspace_reset_claimed_at)
+		self.assertIn("did not start", s.last_sync_status)
+
+	def test_an_old_request_does_not_promote_a_new_claim(self):
+		"""The customer who ran an L1 at 10:00 and an L4 at 10:05. A bare "is
+		there a request row" check would promote the new claim on the OLD row and
+		converge against a container this reset never rebuilt - which is the
+		defect pre-flight exists to stop, re-entered through the resolver."""
+		s = self._preflight_claim(age_minutes=onboarding._PREFLIGHT_EXPIRY_MINUTES + 1)
+		stale = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-3)
+		with patch(
+			"jarvis.onboarding.admin_client.reset_workspace_state",
+			return_value={
+				"request": "REQ-OLD",
+				"status": "Applied",
+				"requested_at": str(stale),
+				# THREE HOURS old against a claim of ~16 minutes: admin's row is
+				# created moments AFTER a genuine claim, so a row far older than the
+				# claim provably predates it.
+				"requested_age_seconds": 3 * 60 * 60,
+			},
+		):
+			onboarding._resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(onboarding._reset_in_flight(s))
+		self.assertIn("did not start", s.last_sync_status)
+
+	def test_admin_unreachable_is_not_a_verdict(self):
+		""" "Cannot ask" must never be read as "no row" - that would expire a live
+		rebuild's claim on a network blip. Leave it; the next tick retries."""
+		from jarvis.admin_client import AdminUnreachableError
+
+		s = self._preflight_claim(age_minutes=onboarding._PREFLIGHT_EXPIRY_MINUTES + 1)
+		with patch(
+			"jarvis.onboarding.admin_client.reset_workspace_state",
+			side_effect=AdminUnreachableError("down"),
+		):
+			onboarding._resolve_preflight_claim(s)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(onboarding._is_preflight(s), "an unanswerable question resolves nothing")
+
+	def test_reconcile_does_not_poll_a_preflight_claim(self):
+		"""The */5 backstop must resolve first and only poll a promoted claim.
+		Polling a pre-flight marker converges nothing, forever."""
+		self._preflight_claim(age_minutes=1)
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"request": None, "status": None, "requested_at": None},
+			),
+			patch("jarvis.onboarding._workspace_reset_poll") as poll,
+		):
+			onboarding.reconcile_pending_workspace_reset()
+		poll.assert_not_called()
+
+	def test_reconcile_polls_in_the_same_tick_it_promotes(self):
+		"""Promotion and convergence in one pass, or every recovered reset waits
+		another five minutes for no reason."""
+		self._preflight_claim(age_minutes=1)
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={
+					"request": "REQ-1",
+					"status": "Applying",
+					"requested_at": str(frappe.utils.now_datetime()),
+					"requested_age_seconds": 5,
+				},
+			),
+			patch("jarvis.onboarding._workspace_reset_poll") as poll,
+		):
+			onboarding.reconcile_pending_workspace_reset()
+		poll.assert_called_once()
+
+	def test_the_card_still_says_resetting_while_pre_flight(self):
+		"""Display and convergence are different questions. The customer's card
+		must say "resetting" from the moment they click - not from the moment admin
+		confirms - or a slow initiate looks like nothing happened."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._reset_marker(preflight=True))
+		frappe.db.commit()
+		with (
+			patch("jarvis.onboarding.admin_client.reset_workspace_state", return_value={}),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={"chat_readiness": "Configuring", "agent_url": "ws://x:1"},
+			),
+		):
+			out = onboarding.workspace_reset_state()
+		self.assertTrue(out["resetting"])
+
+	def test_a_disconnect_landing_in_the_pre_rebuild_window_is_refused(self):
+		"""The race itself, end to end: disconnect_bench is called from INSIDE
+		reset_workspace - i.e. after the reset was authorised but before the
+		transport teardown that used to be the first thing to write the marker.
+
+		Against pre-T15 code this window let the disconnect straight through.
+		Both guards close it here: the redis lock (held by the request) and the
+		marker (already claimed)."""
+		outcome = {}
+
+		def _reentrant(reason=""):
+			try:
+				onboarding.disconnect_bench()
+				outcome["refused"] = False
+			except frappe.ValidationError as exc:
+				outcome["refused"] = True
+				outcome["why"] = str(exc)
+			return {"status": "Applied", "tenant": "t-new"}
+
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch("jarvis.onboarding.admin_client.reset_workspace", side_effect=_reentrant),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect") as teardown,
+			patch("jarvis.onboarding.admin_client.reconnect_eligibility_me") as elig,
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.request_workspace_reset()
+		self.assertTrue(outcome.get("refused"), outcome)
+		# Refused before it could reach either the eligibility precheck or the
+		# container teardown, so nothing about the tenancy was touched.
+		elig.assert_not_called()
+		teardown.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(s.jarvis_admin_customer_email)
+
+	def test_the_guard_sees_a_marker_committed_by_another_connection(self):
+		"""Round-4 BLOCKER 1, and the only test here that is not single-transaction.
+
+		Frappe holds ONE MariaDB transaction per request at REPEATABLE READ, so
+		every consistent read returns the snapshot pinned by the FIRST read in it.
+		``settings.reload()`` is a plain consistent read and therefore CANNOT see
+		another worker's commit - which is what the guard has to see. Verified on
+		this bench: a second connection's committed write is invisible to a
+		re-read, and visible immediately after frappe.db.commit().
+
+		Every other T15 test writes the marker itself, in its own transaction, so
+		the guard always sees it and none of them can catch this. This one uses a
+		SECOND CONNECTION to model the other worker, which is the whole point.
+
+		Fails against the pre-fix code (`settings.reload()`), passes with
+		`_reread_inside_lock`'s commit."""
+		from frappe.database import get_db
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "ok")
+		frappe.db.commit()
+
+		# Pin THIS request's read snapshot before the marker exists, exactly as
+		# disconnect_bench's pre-lock read does.
+		frappe.get_single("Jarvis Settings")
+
+		marker = onboarding._reset_marker()
+		other = get_db(
+			socket=frappe.conf.db_socket,
+			host=frappe.conf.db_host,
+			port=frappe.conf.db_port,
+			user=frappe.conf.db_name,
+			password=frappe.conf.db_password,
+			cur_db_name=frappe.conf.db_name,
+		)
+		try:
+			other.connect()
+			other.sql(
+				"UPDATE `tabSingles` SET `value`=%s WHERE `doctype`='Jarvis Settings' "
+				"AND `field`='last_sync_status'",
+				(marker,),
+			)
+			other.commit()
+		finally:
+			try:
+				other.close()
+			except Exception:
+				pass
+
+		# A plain re-read still cannot see it - this is the defect, asserted so the
+		# test fails loudly if someone "simplifies" _reread_inside_lock back to a
+		# reload().
+		stale = frappe.get_single("Jarvis Settings")
+		stale.reload()
+		self.assertEqual(
+			stale.get("last_sync_status"),
+			"ok",
+			"reload() unexpectedly saw the other connection - the isolation "
+			"assumption this fix rests on no longer holds; re-derive it",
+		)
+
+		fresh = onboarding._reread_inside_lock()
+		self.assertEqual(fresh.get("last_sync_status"), marker)
+		self.assertTrue(
+			onboarding._reset_in_flight(fresh),
+			"the in-flight guard must see a marker another worker committed",
+		)
+
+	def test_the_poll_will_not_converge_while_a_request_holds_the_lock(self):
+		"""The hazard the early claim CREATES, and the reason the poll takes the
+		lock too. Between the claim and the rebuild the marker is set while the
+		OLD container is still up and Ready - so a */5
+		reconcile_pending_workspace_reset landing there would declare the reset
+		complete against a container that was never replaced, and for an L4 go on
+		to clear the credentials."""
+		from jarvis._redis_lock import redis_lock
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS + onboarding._DISCONNECT_SUFFIX)
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		with (
+			redis_lock(onboarding._RESET_LOCK, timeout_s=30) as held,
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Applied"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+					"tenant_status": "running",
+				},
+			),
+			patch("jarvis.onboarding.admin_client.prepare_bench_disconnect") as teardown,
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			self.assertTrue(held, "test could not take the lock it is asserting about")
+			out = onboarding.workspace_reset_state()
+		# Round-4 MINOR 7: NOT reported ready. This assertion used to read "readiness
+		# is still REPORTED - it is an observation, not a mutation", which was the
+		# defect: GeneralPane.pollReset ACTS on `ready` with stopPoll() and a hard
+		# reload announcing "Workspace is back", so a poll landing during a long L4
+		# clear reloaded the page mid-clear and that tab never saw the terminal
+		# `disconnected: true`. "Ready" is a claim about the workspace being back,
+		# and while a claimed reset has not been finished it is not yet true.
+		self.assertFalse(out["ready"])
+		# The card still says "resetting", so the customer sees progress, not a stall.
+		self.assertTrue(out["resetting"])
+		# And nothing converged - above all, nothing was cleared.
+		self.assertFalse(out["disconnected"])
+		teardown.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(onboarding._reset_in_flight(s))
+		self.assertTrue(s.jarvis_admin_customer_email)
+
+
+class TestResetMarkerRoundTrip(FrappeTestCase):
+	"""``_reset_marker`` / ``_reset_in_flight``: one definition each, so a
+	reset's depth cannot be silently downgraded by two call sites deriving it
+	separately. All four (reconnect_llm, disconnect_after) combinations,
+	including the combined "(reconnect llm) (disconnect)" case the docstring
+	calls out by name."""
+
+	def setUp(self):
+		self._snap_status = frappe.get_single("Jarvis Settings").get("last_sync_status") or ""
+
+	def tearDown(self):
+		frappe.get_single("Jarvis Settings").db_set("last_sync_status", self._snap_status)
+		frappe.db.commit()
+
+	def test_all_four_depth_combinations_round_trip(self):
+		s = frappe.get_single("Jarvis Settings")
+		cases = (
+			(False, False, onboarding._RESETTING_STATUS),
+			(True, False, onboarding._RESETTING_RECONNECT_LLM_STATUS),
+			(False, True, onboarding._RESETTING_STATUS + onboarding._DISCONNECT_SUFFIX),
+			(True, True, onboarding._RESETTING_RECONNECT_LLM_STATUS + onboarding._DISCONNECT_SUFFIX),
+		)
+		for reconnect_llm, disconnect_after, expected in cases:
+			with self.subTest(reconnect_llm=reconnect_llm, disconnect_after=disconnect_after):
+				marker = onboarding._reset_marker(reconnect_llm, disconnect_after)
+				self.assertEqual(marker, expected)
+				s.db_set("last_sync_status", marker)
+				frappe.db.commit()
+				self.assertEqual(onboarding._reset_in_flight(s), marker)
+
+
+class TestDeferredConnectionClear(FrappeTestCase):
+	"""T2 (plan edge case 1, the central risk the whole L4 design exists to
+	avoid): the CONNECTION clear must be deferred until the poll has observed
+	Ready. Nothing in the suite referenced ``disconnect_after``,
+	``_DISCONNECT_SUFFIX`` or ``_clear_admin_connection`` before this task.
+	The Ready-completes-the-clear half is already covered by
+	``test_poll_tears_down_container_before_clearing_connection_on_l4`` above
+	(BLOCKER 2's regression test); this covers the other half the "ONLY"
+	requires - that a not-ready poll must not clear early."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + ("last_sync_status",)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+		_set_token("tok")
+		s.db_set("agent_url", "")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS + onboarding._DISCONNECT_SUFFIX)
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_marker_survives_and_clear_does_not_fire_while_not_ready(self):
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Pending Capacity"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={"chat_readiness": "Configuring"},  # no agent_url yet: not ready
+			),
+			patch("jarvis.onboarding._clear_admin_connection") as clear,
+		):
+			out = onboarding.workspace_reset_state()
+		clear.assert_not_called()
+		self.assertFalse(out["ready"])
+		self.assertFalse(out["disconnected"])
+		self.assertTrue(out["resetting"])
+		s = frappe.get_single("Jarvis Settings")
+		# The disconnect intent is still recorded on the marker - the clear has
+		# not consumed it, so a later poll can still finish the job.
+		self.assertEqual(s.last_sync_status, onboarding._RESETTING_STATUS + onboarding._DISCONNECT_SUFFIX)
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+
+class TestDisconnectedMarkerIsNotAResetToConverge(FrappeTestCase):
+	"""T11 item 1-3: ``_clear_admin_connection`` writes a DURABLE
+	``"disconnected"`` marker (not a blank field) so a reload can tell "lost
+	admin credentials" apart from "never onboarded" - and that marker must
+	never be mistaken for a reset still in flight, or the */5
+	``reconcile_pending_workspace_reset`` backstop would try to poll a bench
+	holding no admin credentials to poll with."""
+
+	# Matches TestDisconnectBench's list: test_clear_admin_connection_leaves_the_
+	# disconnected_marker below calls the real _clear_admin_connection (CONNECTION
+	# spec), which touches all of these on the SAME Jarvis Settings singleton
+	# TestDisconnectBench exercises - not just last_sync_status.
+	_FIELDS = _SNAPSHOTTED_FIELDS + (
+		"chat_device_id",
+		"chat_device_public_key",
+		"chat_device_private_key",
+		"chat_device_token",
+		"tenant_authority_handle",
+		"tenant_authority_generation",
+		"last_sync_status",
+	)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_clear_admin_connection_leaves_the_disconnected_marker(self):
+		settings = frappe.get_single("Jarvis Settings")
+		frappe.db.commit()
+		# The teardown is patched, not skipped. Blanking agent_url used to skip it,
+		# which is exactly the guard round-4 BLOCKER 2 removed: admin resolves the
+		# tenant itself, so the bench's agent_url never had any bearing on whether
+		# a container needed tearing down.
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.prepare_bench_disconnect",
+				return_value=_TEARDOWN_OK,
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding._clear_admin_connection(settings)
+		self.assertEqual(
+			frappe.get_single("Jarvis Settings").last_sync_status, onboarding._DISCONNECTED_STATUS
+		)
+
+	def test_reset_in_flight_returns_empty_for_the_disconnected_marker(self):
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("last_sync_status", onboarding._DISCONNECTED_STATUS)
+		frappe.db.commit()
+		self.assertEqual(onboarding._reset_in_flight(settings), "")
+
+	def test_reconcile_does_not_poll_a_disconnected_bench(self):
+		frappe.get_single("Jarvis Settings").db_set("last_sync_status", onboarding._DISCONNECTED_STATUS)
+		frappe.db.commit()
+		with patch("jarvis.onboarding._workspace_reset_poll") as poll:
+			onboarding.reconcile_pending_workspace_reset()
+		poll.assert_not_called()
+
+
+class TestBenchConnectionState(FrappeTestCase):
+	"""T11 item 4: ``bench_connection_state()`` is the durable,
+	admin-round-trip-free answer a reload / second tab / tab reconciled later
+	by the */5 backstop falls back to. Its predicate is
+	``_admin_connection_absent`` - deliberately NOT
+	``last_sync_status == "disconnected"``. That literal string is ALSO
+	written by ``jarvis.oauth.api.disconnect`` / ``onboarding.disconnect_llm``
+	for an LLM-only disconnect that leaves admin credentials fully intact, so
+	testing equality against it would tell a customer who merely unplugged
+	their AI model that they need the emailed-code reconnect."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + ("last_sync_status",)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			self._snap[f] = s.get(f) or ""
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+		frappe.db.commit()
+
+	def test_disconnected_true_when_both_email_and_agent_url_are_empty(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_customer_email", "")
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		self.assertEqual(onboarding.bench_connection_state(), {"disconnected": True, "needs_company": False})
+
+	def test_disconnected_false_when_marker_says_so_but_credentials_survive(self):
+		"""Regression: oauth.api.disconnect() / onboarding.disconnect_llm()
+		write the literal "disconnected" to last_sync_status for an LLM-only
+		disconnect that leaves admin credentials intact. Without this, a
+		customer who merely unplugged their LLM would be told to use the
+		emailed-code reconnect - this is the collision T11 found."""
+		_set_token("tok")
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_customer_email", "cust-deadbeef@jarvis.invalid")
+		s.db_set("agent_url", "ws://localhost:19000")
+		s.db_set("last_sync_status", onboarding._DISCONNECTED_STATUS)
+		frappe.db.commit()
+		self.assertFalse(onboarding.bench_connection_state()["disconnected"])
+
+	def test_disconnected_false_mid_reset(self):
+		_set_token("tok")
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_customer_email", "cust-deadbeef@jarvis.invalid")
+		s.db_set("agent_url", "")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		frappe.db.commit()
+		self.assertFalse(onboarding.bench_connection_state()["disconnected"])
+
+	def test_makes_no_admin_call(self):
+		"""Must work with ZERO credentials - a genuinely disconnected bench
+		holds none, so any authenticated admin call would simply fail."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_customer_email", "")
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		with patch("jarvis.onboarding.admin_client.reconnect_eligibility_me") as elig:
+			onboarding.bench_connection_state()
+		elig.assert_not_called()
+
+	def test_a_caller_without_jarvis_access_is_refused(self):
+		frappe.set_user("Guest")
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				onboarding.bench_connection_state()
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_a_non_admin_jarvis_user_gets_an_answer(self):
+		"""Round-5 MINOR 4, and the POINT of moving this off require_jarvis_admin.
+
+		OnboardingGate is the screen a disconnected bench lands on for EVERY user,
+		and it carries copy telling a non-admin teammate to ask their workspace
+		admin. Behind the admin gate this call 403s for exactly that person, the
+		catch left `disconnected` false, and the generic first-time-setup poster
+		rendered instead — so the branch could never fire in production and its spec
+		test passed only by mocking the API.
+
+		The Guest test above cannot show this: Guest is refused under
+		require_jarvis_access too, so it passes either way. This one needs a real
+		user WITH Jarvis access and WITHOUT System Manager."""
+		email = "minor4-jarvis-user@example.com"
+		if not frappe.db.exists("User", email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": "Minor4",
+					"send_welcome_email": 0,
+					"roles": [{"role": "Jarvis User"}],
+				}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+		self.addCleanup(frappe.db.commit)
+		self.addCleanup(frappe.delete_doc, "User", email, force=True, ignore_permissions=True)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+		frappe.set_user(email)
+		self.assertFalse(
+			"System Manager" in frappe.get_roles(), "fixture must not be an admin, or it proves nothing"
+		)
+		out = onboarding.bench_connection_state()
+		self.assertIn("disconnected", out)
+		self.assertIn("needs_company", out)
 
 
 class TestSignupResumeFallback(FrappeTestCase):


### PR DESCRIPTION
## ⚠️ Draft — NOT ready to merge

Code review **round 6 is RED** (1 BLOCKER / 7 MAJOR / 16 MINOR) and **no flow review has ever run**. This is opened as a draft to bank the work and make it reviewable, not to merge. The project's review gate was bypassed deliberately, at the repo owner's direction, to get it pushed.

Pairs with `Aerele-RnD/jarvis-admin-v2` branch `feat/reset-depth-ladder` — **neither half works without the other.**

---

## What this adds

A customer-facing **reset depth ladder** in Settings → Reset Workspace, plus a separate **"Disconnect this bench"** action. Levels 1–3 already existed and are re-presented as one coherent choice; L4 and the disconnect are new, and both end with the bench holding no admin credentials.

| Level | Adds | Ends |
|---|---|---|
| L1 | rebuild the container | connected, chat works |
| L2 | + wipe workspace content | connected |
| L3 | + revoke LLM connections | connected, wizard owns LLM setup |
| L4 | + clear the admin connection | **disconnected** → emailed-code reconnect |

L4's ordering is the whole point: the `CONNECTION` clear is deferred until the poll has seen the new container Ready and persisted the fresh connection. There is no window where a reset is in flight and unpollable.

Plan: `.claude/workflow/plans/2026-08-04-reset-workspace-cli-option.md` (+ Amendments 1–4).

## The parts that took six review rounds to get right

**A claim must be atomic, durable, and distinguishable from a rebuild.** `request_workspace_reset` now claims `last_sync_status` *before* its long admin calls, under `jarvis/_redis_lock`, and **promotes** that claim to a convergeable marker only once admin has accepted the request.

That two-state split exists because of a specific defect: `redis_lock`'s release is a `finally`, which **does** run on an exception. So a single transient failure of the one `reset_workspace` call left a convergeable marker *and* a released lock — and the `*/5` reconcile then converged against a container that was never rebuilt, tearing it down and clearing the credentials on an L4.

**Guards must not read stale snapshots.** Frappe holds one MariaDB transaction per request at `REPEATABLE-READ` with `autocommit=False`, so `settings.reload()` **cannot** see another worker's commit — verified with a two-process probe. All three entry points now commit before the guarded read.

**A refusal is not unreachability.** `_clear_admin_connection` makes one authenticated admin call and **aborts** unless the paired chat devices were provably unpaired. Only genuine unreachability proceeds. A dead *container* still disconnects (the unpair is a file op that survives it); a dead *admin* still disconnects (otherwise a lost control plane traps the bench forever); an admin that answers and refuses does not.

**No marker may outlive what can clear it.** `reconcile_pending_workspace_reset` resolves or expires every claim — promote on evidence, leave a young one alone, give up honestly past the deadline.

Also: reset depth is now cumulative **server-side** (only the SPA's radio group enforced it, so `disconnect_after=1, revoke_llm=0` produced a rung the ladder has no name for), and two new Jarvis Settings fields — `workspace_reset_claimed_at`, `reconnect_needs_company` — deliberately in **no** `ResetSpec`, because they describe the aftermath of an operation rather than the tenancy it acted on.

## Frontend

The four depths as one explicit radio choice with per-level consequences, the disconnect as a separate danger-zone action, `OnboardingGate` showing the emailed-code recovery route on the screen a disconnected bench actually lands on, and an L4 that degraded to L3 surfaced to the customer rather than only logged.

## Tests

`jarvis.tests.test_onboarding_sync` **121 → 165** · `GeneralPane.spec.js` **21 → 27** · `test_dev` 10 · `test_account` 74 · `test_settings_on_update` 39 · `test_part4_security` 19 · frontend 737/738 (the one failure is `tests/support-extraction/support-thread.test.js`, pre-existing and outside this change set) · `ruff check` + `format --check` clean at the repo-pinned v0.14.10.

## Known open — read before reviewing

Full detail in `.claude/workflow/reviews/code-feat-reset-depth-ladder.md` and `.claude/workflow/HANDOVER-reset-ladder-2026-08-05.md`.

- **BLOCKER** — `bench_connection_state` returns `disconnected: true` for a bench that has **never onboarded** (both credential fields are blank pre-signup), so every first-time customer sees "Reconnect Jarvis" instead of "Finish setting up".
- **MAJOR** — the `on_update` guard covers 1 of **27** `last_sync_status` writers; `_enqueued_sync_via_admin` writes past it from the worker.
- **MAJOR** — the promote comparison is algebraically unchanged from the form it replaced, and `_LIVE` admits `Applied`, which admin's own `OPEN_STATES` does not.
- **MAJOR** — `_RECONCILE_GIVE_UP_MINUTES = 60` abandons a `Pending Capacity` reset admin will still fulfil.
- **MAJOR** — the two `frappe.db.rollback()` calls and the give-up timer have **zero coverage**.
- **MAJOR** — the new test classes mutate the site they run against; they cascade blanks through Jarvis Settings and must be run against a scratch site. This destroyed a working local bench during development.
- 16 MINORs.

## Review history

Six adversarial rounds. From round 3 onward **every round found defects in work the previous round had signed off**, and three times the defect was introduced *by a fix for another finding in the same session*. Round 6 verified three findings by execution rather than by reading. Weight your review accordingly — reading the code was repeatedly not enough here.
