### PR TITLE
fix(settings): clear the row on disconnect, drop the blue focus ring

### DIFF
--- a/frontend/src/components/JvCombo.vue
+++ b/frontend/src/components/JvCombo.vue
@@ -213,6 +213,23 @@ onBeforeUnmount(() => document.removeEventListener("mousedown", onDocClick));
 	font: inherit;
 	padding: 0;
 }
+/* The inner input is not the control the customer sees - .jvc-field is, and it
+   carries the border. Any ring on the input would therefore be drawn INSIDE that
+   border, which is the "box inside a box" look. Focus is signalled on the wrapper
+   instead: a tinted border while anything inside has focus, and for keyboard users
+   a real ring OUTSIDE the border (positive outline-offset), matching the
+   outline: 2px solid var(--cta) / offset 2px idiom used elsewhere in the app. */
+.jvc-input:focus,
+.jvc-input:focus-visible {
+	outline: none;
+}
+.jvc-field:focus-within {
+	border-color: var(--cta-bd);
+}
+.jvc-field:focus-visible {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
+}
 .jvc-val {
 	flex: 1;
 	min-width: 0;

--- a/frontend/src/components/JvCombo.vue
+++ b/frontend/src/components/JvCombo.vue
@@ -9,7 +9,7 @@
 			class="jvc-field"
 			:class="{ 'jvc-open': open, 'jvc-dis': !editable }"
 			role="button"
-			tabindex="0"
+			:tabindex="allowCustom ? -1 : 0"
 			:aria-expanded="open"
 			@click="onFieldClick"
 			@keydown.down.prevent="openAnd(0)"
@@ -226,7 +226,16 @@ onBeforeUnmount(() => document.removeEventListener("mousedown", onDocClick));
 .jvc-field:focus-within {
 	border-color: var(--cta-bd);
 }
-.jvc-field:focus-visible {
+/* Two selectors, because there are two ways this control can hold focus. A plain
+   picker has no inner input, so the wrapper itself is the tab stop and matches
+   :focus-visible directly. An allowCustom combo puts a real <input> inside, and
+   THAT is the element the customer tabs to and types into - the wrapper never
+   matches :focus-visible in that case, so keying the ring off it alone left the
+   editable combos (model id, base URL) with no keyboard focus indicator at all.
+   :has keeps the ring on the wrapper, outside its border, rather than drawing a
+   second box inside it. */
+.jvc-field:focus-visible,
+.jvc-field:has(.jvc-input:focus-visible) {
 	outline: 2px solid var(--cta);
 	outline-offset: 2px;
 }

--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -346,6 +346,39 @@ describe("removing the last model disconnects the workspace", () => {
 		expect(w.vm.applyResult.text).toMatch(/^Disconnected/);
 	});
 
+	it("clears the list instead of leaving the deleted model on screen", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor();
+
+		await w.vm.remove(0);
+		await idle();
+
+		// The whole point of Disconnect: the model is gone, so the list is empty and
+		// the template's "No models yet. Add one below." empty state takes over. A
+		// blank placeholder row here would render as a row numbered "1" carrying no
+		// provider and no model, which reads as though something were still connected.
+		expect(w.vm.rows).toHaveLength(0);
+		// An empty pool is the SAVED state, not unsaved work. While it read as dirty,
+		// accountHealth flipped every pill to "Pending re-check" on an empty pool.
+		expect(w.vm.dirty).toBe(false);
+	});
+
+	it("still clears the list when the reload after the disconnect fails", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor();
+		// The disconnect itself succeeds; only the refetch that follows it falls over.
+		// This is the exact shape of the original defect: load() aborts inside its
+		// catch before reassigning rows, so the just-deleted model survived on screen
+		// underneath the "Disconnected" banner, pill reading "Pending re-check".
+		api.getLlmConfig.mockRejectedValueOnce(new Error("network"));
+
+		await w.vm.remove(0);
+		await idle();
+
+		expect(api.disconnectLlm).toHaveBeenCalledTimes(1);
+		expect(w.vm.rows).toHaveLength(0);
+	});
+
 	it("keeps Remove as an ordinary edit while another model is left", async () => {
 		setPool([keyModel("openai", "gpt-4o", 0), keyModel("anthropic", "claude-sonnet-4", 1)]);
 		const w = await mountEditor();

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -3061,6 +3061,26 @@ async function disconnect() {
 		text: "Disconnected. Your keys and connected accounts have been deleted.",
 		detail: "",
 	});
+	// Assert the disconnected state LOCALLY instead of trusting the reseed below to
+	// observe it. load() rebuilds rows from a fresh getLlmConfig(); when that call
+	// throws, its catch sets err and leaves rows UNTOUCHED, so the model that was just
+	// deleted stayed on screen underneath a "Disconnected" banner - and rendered as
+	// "Pending re-check", because a snapshot that was never reconciled reads as dirty.
+	// The server half is already final by this line (see the note above), so stating it
+	// here is not optimism, and it makes the stale row impossible on every path rather
+	// than only on the one where the refetch happens to succeed.
+	//
+	// Success path only: the catch above returns early, so a disconnect that failed
+	// still leaves the row exactly where it was for the customer to retry.
+	cfg.value = { ...(cfg.value || {}), models: [], preset: "", proxy_active: false };
+	rows.value = [];
+	selectedPreset.value = "";
+	keysByVendor.value = {};
+	// An open Edit panel is pointing at a row that no longer exists.
+	panel.value = { ...panel.value, open: false, uid: null, testResult: null };
+	// An empty pool is the SAVED state now, not unsaved work. Without this the editor
+	// reads dirty, which is what flips every health pill to "Pending re-check".
+	savedSnapshot.value = poolSnapshot([]);
 	await load();
 	// Same signal an apply emits, so the host pane re-reads its own state (the DIRECT
 	// subscription probe in particular, which a disconnect also clears).
@@ -3679,7 +3699,12 @@ async function load(opts = {}) {
 			llmMode.value = "custom";
 		else {
 			llmMode.value = "quick";
-			if (!rows.value.length) rows.value = [newRow()];
+			// Deliberately no blank placeholder row here. For an EMPTY pool - no preset,
+			// no rows, which is exactly what a disconnect leaves - this branch is the one
+			// that runs, so this was the line that put a placeholder back no matter which
+			// editor came after it. Onboarding still gets its row from the singleMode
+			// branch immediately below, which is the only place that actually needs one
+			// (its whole UI is rows[0]); the settings list wants its real empty state.
 		}
 		// Onboarding is quick-only (singleMode): the editor shows a single editable
 		// row (editorRows renders rows[0]) but we KEEP any seeded tail rows so a
@@ -3710,7 +3735,12 @@ async function load(opts = {}) {
 			// needs to be "preset" or "quick" here.
 			llmMode.value = "custom";
 			selectedPreset.value = "";
-			if (!rows.value.length) rows.value = [newRow()];
+			// No blank placeholder row here, deliberately. Onboarding (above) needs one
+			// because its whole UI IS rows[0], but this list renders an explicit empty
+			// state ("No models yet. Add one below.") plus an always-present "Add a
+			// model" button. Seeding a blank row instead meant an empty pool - the state
+			// a disconnect leaves behind - showed a half-rendered row numbered "1" with
+			// no provider and no model, which reads as "something is still connected".
 		}
 		// Baseline for the unsaved-changes notice - the pool as just loaded is clean.
 		// The carried row is deliberately NOT in the baseline: it is unsaved work, and

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,9 +78,24 @@
    `outline: none` does not suppress it. */
 .jv-root :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus,
 .jv-ob-root :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus {
-	outline: revert;
+	outline: none;
 	box-shadow: none;
 	border-color: revert;
+}
+/* `outline: revert` used to sit above, which was the wrong tool: revert rolls the
+   property back to the USER-AGENT sheet, and the UA's rule for a focused input is
+   the browser's own blue focus ring. So the line meant to suppress a blue ring was
+   the thing painting one - a blue rectangle drawn tight around the inner input,
+   which inside a bordered wrapper (JvCombo) reads as a box inside a box.
+   Suppressing it outright would cost keyboard users their focus indicator, so the
+   ring is re-drawn here in the app's own accent, and only for :focus-visible, so a
+   mouse click leaves the field clean while Tab still shows where you are. */
+.jv-root
+	:where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible,
+.jv-ob-root
+	:where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible {
+	outline: 2px solid var(--cta, currentColor);
+	outline-offset: 1px;
 }
 
 /* ===== §2.5 theme bridge: dark value overrides =============================


### PR DESCRIPTION
## Summary

Disconnecting your last AI model now clears the list instead of leaving the deleted model on screen, and focused inputs no longer draw a blue box inside their own border. Both were reported from a live workspace, where a successful Disconnect left the old provider and model showing with a "Pending re-check" pill, under a banner saying the keys were deleted.

## What changed

- A successful Disconnect empties the list, so the "No models yet" empty state shows. A failed one still leaves the row there to retry.
- An empty pool no longer renders a blank placeholder row numbered "1" with no provider. Onboarding keeps its row.
- Focused inputs stop painting the browser's blue focus ring. Keyboard users get a ring in the app accent on `:focus-visible` only.
- In the provider and model combobox, that ring sits outside the field border rather than inside it.

## Risk and verification

- Both `LlmPoolEditor` suites pass, 31 of 31, including two new tests covering the row list after a successful disconnect and after the reload that follows it fails.
- Full frontend suite against this branch's base: 719 passed before, 721 after, same 31 pre-existing failures both times. Those are the known `localStorage` failures from Node 26 locally versus the Node 24 CI pins, not this change.
- The focus rule is global, so it touches every input. That is intended: the blue ring appeared app wide.

<details><summary>Root cause</summary>

**The surviving row.** `disconnect()` never mutated the row list. It called `api.disconnectLlm()`, set the success banner, then called `load()`, delegating the actual removal to a fresh `getLlmConfig()` refetch. `load()` wraps that refetch in a try block whose catch only sets an error string, so when the fetch throws, `rows` is never reassigned and the deleted model survives on screen. The pill read "Pending re-check" because `accountHealth()` degrades every row when the editor reads dirty, and the snapshot was never reconciled to the now empty pool.

The server half was verified correct and final before this line runs: `disconnect_llm` calls admin first, aborts the whole operation if admin fails, and only then clears the bench. On the live site the settings row already showed `models: []` and `last_sync_status: "disconnected"`, confirming the defect was entirely client side.

The fix asserts the empty state locally on the success path, so a failed refetch can no longer resurrect the row. The failure path is untouched, which the existing "reports a failed disconnect instead of claiming the keys are gone" test still pins.

**The placeholder row.** `load()` had two separate `if (!rows.value.length) rows.value = [newRow()]` guards. For an empty pool with no preset, the first one runs, so removing only the later one had no effect. Onboarding gets its row from the `singleMode` branch, which is the only place that needs one.

**The blue ring.** `index.css` used `outline: revert` in a rule whose own comment says it exists to suppress the forms plugin's blue focus ring. `revert` rolls the property back to the user-agent stylesheet, and the UA rule for a focused input is the browser's blue focus ring, so the declaration reinstated exactly what the rule was written to remove. The neighbouring `box-shadow: none` and `border-color: revert` were correct.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (branched from `dabeba01`, the current head)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01KDsRq5555BfFv15X6gBQbc
