### PR TITLE
feat(onboarding): UI-managed pay origin + layered resolver + dev relaxation

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -554,7 +554,7 @@
    "permlevel": 1,
    "label": "Pay origin",
    "default": "https://fleet.klerk.in",
-   "description": "Where the browser is sent for the admin-hosted checkout. Defaults to the production host; override per deployment. site_config 'jarvis_pay_origin' still overrides. Operator-set only — the signup/connect flow never writes it (it anchors the origin-digest cross-check); must match the admin's pay origin. A dev bench also accepts a plain-http .local origin."
+   "description": "Where the browser is sent for the admin-hosted checkout. Defaults to the production host; override per deployment. site_config 'jarvis_pay_origin' still overrides. Operator-set only — the signup/connect flow never writes it (it anchors the origin-digest cross-check); must match the admin's pay origin. In test mode a plain-http origin is fine for local/staging."
   },
   {
    "fieldname": "jarvis_admin_api_key",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -77,6 +77,8 @@
   "jarvis_admin_customer_email",
   "jarvis_admin_customer_password",
   "signup_context",
+  "checkout_section",
+  "jarvis_pay_origin",
   "operator_section",
   "agent_url",
   "agent_token",
@@ -540,6 +542,19 @@
    "label": "Jarvis Admin URL",
    "read_only": 1,
    "description": "HTTPS URL of the Jarvis admin host. Used for signup, billing, subscription state."
+  },
+  {
+   "fieldname": "checkout_section",
+   "fieldtype": "Section Break",
+   "label": "Checkout"
+  },
+  {
+   "fieldname": "jarvis_pay_origin",
+   "fieldtype": "Data",
+   "permlevel": 1,
+   "label": "Pay origin",
+   "default": "https://fleet.klerk.in",
+   "description": "Where the browser is sent for the admin-hosted checkout. Defaults to the production host; override per deployment. site_config 'jarvis_pay_origin' still overrides. Operator-set only — the signup/connect flow never writes it (it anchors the origin-digest cross-check); must match the admin's pay origin. A dev bench also accepts a plain-http .local origin."
   },
   {
    "fieldname": "jarvis_admin_api_key",

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -306,59 +306,28 @@ PAY_PAGE_TOKEN_KEY = "pay_page_token"
 PAY_ORIGIN_DIGEST_KEY = "pay_origin_digest"
 
 
-def _is_production_bench() -> bool:
-	"""True on a production-mode bench (supervisor/systemd). Mirrors the admin-side gate
-	so the dev-origin relaxation is gated identically on both sides."""
-	return bool(
-		frappe.conf.get("restart_supervisor_on_update") or frappe.conf.get("restart_systemd_on_update")
-	)
-
-
-def _dev_origin(parts) -> str:
-	"""LOCAL-DEV ONLY (gated by _is_production_bench): canonicalize a plain-http .local
-	origin, preserving scheme + port, else "". In lockstep with the admin-side
-	origin._dev_origin so the digests agree over http."""
-	scheme = (parts.scheme or "").lower()
-	if scheme not in ("http", "https"):
-		return ""
-	host = (parts.hostname or "").lower()
-	if not host.endswith(".local"):
-		return ""
-	if parts.username or parts.password or parts.path not in ("", "/") or parts.query or parts.fragment:
-		return ""
-	port = f":{parts.port}" if parts.port else ""
-	return f"{scheme}://{host}{port}"
-
-
 def _normalize_pay_origin(raw: str | None) -> str:
-	"""Normalize a configured pay origin to ``https://<host>`` (lowercased host, no
-	path/query/fragment/credentials), or "" when unusable.
+	"""Normalize a configured pay origin, preserving scheme + port, or "" when unusable.
 
-	Kept in lockstep with the admin-side ``canonical_pay_origin`` normalization
-	(jarvis_admin_v2 ``billing/checkout/origin.py``) so the two sha256 digests
-	agree byte-for-byte. Deliberately does NOT enforce the registered-host
-	allowlist — that is admin's authority; the bench only needs a canonical string
-	to digest and to build its own URL from."""
+	Byte-identical to the admin-side origin._preserve_origin (its test-mode form) so the
+	two sha256 digests agree; a live origin (https, no port) yields the same
+	``https://<host>`` the admin's strict validator produces. Does NOT enforce the
+	registered-host allowlist — that is admin's authority; the bench only needs a
+	canonical string to digest and to build its own URL from."""
 	raw = (raw or "").strip()
 	if not raw:
 		return ""
 	parts = urlsplit(raw)
-	# LOCAL-DEV ONLY (gated by _is_production_bench): accept a plain-http .local origin
-	# so onboarding runs over http; matches the admin-side _dev_origin so digests agree.
-	if not _is_production_bench():
-		dev = _dev_origin(parts)
-		if dev:
-			return dev
-	if parts.scheme != "https":
+	scheme = (parts.scheme or "").lower()
+	if scheme not in ("http", "https"):
 		return ""
-	if parts.username or parts.password:
-		return ""
-	if parts.path not in ("", "/") or parts.query or parts.fragment:
+	if parts.username or parts.password or parts.path not in ("", "/") or parts.query or parts.fragment:
 		return ""
 	host = (parts.hostname or "").lower()
 	if not host or "." not in host:
 		return ""
-	return f"https://{host}"
+	port = f":{parts.port}" if parts.port else ""
+	return f"{scheme}://{host}{port}"
 
 
 def _resolved_pay_origin() -> str:

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -290,10 +290,12 @@ def strip_credentials(data: dict | None) -> dict:
 # response instead carries a NON-NAVIGABLE origin digest (§R P0-3) the bench
 # cross-checks against its own configured origin before the frontend navigates.
 # --------------------------------------------------------------------------- #
-#: Site-config-only, NO code default (owner decision 3): the fleet origin the
-#: bench top-level-navigates to for checkout. Missing/mismatched = fail closed
-#: with honest copy, never a fallback (owner decision 4).
+#: The origin the bench navigates to for checkout. Resolves site_config ->
+#: ``Jarvis Settings.jarvis_pay_origin`` -> a production default; a bad value fails closed.
 CONF_PAY_ORIGIN = "jarvis_pay_origin"
+#: Production default (owner decision 2026-08-05), like admin_client._admin_url. A code
+#: constant, not a wire value, so the origin-digest cross-check stays sound.
+_DEFAULT_PAY_ORIGIN = "https://fleet.klerk.in"
 #: The frozen envelope key admin uses for the pay-page token (brief §Frozen
 #: contract). Its presence is what turns a response into a navigate-to-pay one.
 PAY_PAGE_TOKEN_KEY = "pay_page_token"
@@ -302,6 +304,30 @@ PAY_PAGE_TOKEN_KEY = "pay_page_token"
 #: origin and compares — agreement proves both sides mean the same origin without
 #: admin handing the bench anything navigable.
 PAY_ORIGIN_DIGEST_KEY = "pay_origin_digest"
+
+
+def _is_production_bench() -> bool:
+	"""True on a production-mode bench (supervisor/systemd). Mirrors the admin-side gate
+	so the dev-origin relaxation is gated identically on both sides."""
+	return bool(
+		frappe.conf.get("restart_supervisor_on_update") or frappe.conf.get("restart_systemd_on_update")
+	)
+
+
+def _dev_origin(parts) -> str:
+	"""LOCAL-DEV ONLY (gated by _is_production_bench): canonicalize a plain-http .local
+	origin, preserving scheme + port, else "". In lockstep with the admin-side
+	origin._dev_origin so the digests agree over http."""
+	scheme = (parts.scheme or "").lower()
+	if scheme not in ("http", "https"):
+		return ""
+	host = (parts.hostname or "").lower()
+	if not host.endswith(".local"):
+		return ""
+	if parts.username or parts.password or parts.path not in ("", "/") or parts.query or parts.fragment:
+		return ""
+	port = f":{parts.port}" if parts.port else ""
+	return f"{scheme}://{host}{port}"
 
 
 def _normalize_pay_origin(raw: str | None) -> str:
@@ -317,6 +343,12 @@ def _normalize_pay_origin(raw: str | None) -> str:
 	if not raw:
 		return ""
 	parts = urlsplit(raw)
+	# LOCAL-DEV ONLY (gated by _is_production_bench): accept a plain-http .local origin
+	# so onboarding runs over http; matches the admin-side _dev_origin so digests agree.
+	if not _is_production_bench():
+		dev = _dev_origin(parts)
+		if dev:
+			return dev
 	if parts.scheme != "https":
 		return ""
 	if parts.username or parts.password:
@@ -327,6 +359,19 @@ def _normalize_pay_origin(raw: str | None) -> str:
 	if not host or "." not in host:
 		return ""
 	return f"https://{host}"
+
+
+def _resolved_pay_origin() -> str:
+	"""The bench's pay origin, normalized: site_config -> ``Jarvis Settings`` field ->
+	production default. Read fresh; never raises. The field is operator-only and MUST
+	NOT be written by the connect/sync flow - it anchors the digest cross-check."""
+	raw = (frappe.conf.get(CONF_PAY_ORIGIN) or "").strip()
+	if not raw:
+		try:
+			raw = (frappe.db.get_single_value("Jarvis Settings", "jarvis_pay_origin") or "").strip()
+		except Exception:
+			raw = ""
+	return _normalize_pay_origin(raw or _DEFAULT_PAY_ORIGIN)
 
 
 def pay_origin_digest(origin: str) -> str:
@@ -341,11 +386,9 @@ def augment_pay_page(data: dict) -> dict:
 	non-token answer (a coded state, a paid connection payload), is returned
 	untouched. On a token answer it injects two frontend-read fields:
 
-	  * ``pay_origin`` — the bench's configured, normalized ``jarvis_pay_origin``
-	    (``https://<host>``), or "" when unset/invalid. The frontend builds
-	    ``{pay_origin}/jarvis-checkout#t=<token>`` from this; an empty value fails
-	    the pay step CLOSED with honest copy (owner decisions 3/4 — NO default,
-	    NO fallback).
+	  * ``pay_origin`` — the bench's resolved, normalized pay origin (site_config ->
+	    ``Jarvis Settings`` -> production default), or "" when invalid. The frontend
+	    builds ``{pay_origin}/jarvis-checkout#t=<token>`` from it; empty fails closed.
 	  * ``pay_origin_attested`` — True iff ``pay_origin`` is set AND its sha256
 	    digest equals admin's non-navigable ``pay_origin_digest`` (§R P0-3). The
 	    frontend refuses to navigate unless this is True, so a config split-brain
@@ -356,7 +399,7 @@ def augment_pay_page(data: dict) -> dict:
 	its own config, and this is only the cross-check that admin agrees."""
 	if not isinstance(data, dict) or not data.get(PAY_PAGE_TOKEN_KEY):
 		return data
-	origin = _normalize_pay_origin(frappe.conf.get(CONF_PAY_ORIGIN))
+	origin = _resolved_pay_origin()
 	admin_digest = (data.get(PAY_ORIGIN_DIGEST_KEY) or "").strip().lower()
 	attested = (
 		bool(origin) and bool(admin_digest) and hmac.compare_digest(pay_origin_digest(origin), admin_digest)

--- a/jarvis/tests/test_pay_page_cutover.py
+++ b/jarvis/tests/test_pay_page_cutover.py
@@ -23,8 +23,14 @@ class TestNormalizePayOrigin(FrappeTestCase):
 	def test_host_is_lowercased_and_a_trailing_slash_is_dropped(self):
 		self.assertEqual(oc._normalize_pay_origin("https://Fleet.Klerk.IN/"), "https://fleet.klerk.in")
 
-	def test_non_https_is_rejected(self):
-		self.assertEqual(oc._normalize_pay_origin("http://fleet.klerk.in"), "")
+	def test_http_and_port_are_preserved(self):
+		# The bench preserves scheme + port (its test-mode form); the admin enforces
+		# https/allowlist in live mode. Byte-identical to admin origin._preserve_origin.
+		self.assertEqual(oc._normalize_pay_origin("http://fleet.klerk.in"), "http://fleet.klerk.in")
+		self.assertEqual(
+			oc._normalize_pay_origin("http://jarvis_admin_v2.local:8002"),
+			"http://jarvis_admin_v2.local:8002",
+		)
 
 	def test_a_path_query_or_fragment_is_rejected(self):
 		self.assertEqual(oc._normalize_pay_origin("https://fleet.klerk.in/jarvis-checkout"), "")
@@ -38,24 +44,6 @@ class TestNormalizePayOrigin(FrappeTestCase):
 	def test_the_digest_is_sha256_of_the_normalized_origin(self):
 		origin = "https://fleet.klerk.in"
 		self.assertEqual(oc.pay_origin_digest(origin), hashlib.sha256(origin.encode("utf-8")).hexdigest())
-
-	def test_dev_http_local_origin_is_accepted_on_a_dev_bench(self):
-		# LOCAL-DEV relaxation: a non-production bench accepts a plain-http .local origin,
-		# preserving scheme + port, so it matches the admin-side _dev_origin byte-for-byte.
-		with patch.object(oc, "_is_production_bench", return_value=False):
-			self.assertEqual(
-				oc._normalize_pay_origin("http://jarvis_admin_v2.local:8002"),
-				"http://jarvis_admin_v2.local:8002",
-			)
-
-	def test_dev_http_local_is_rejected_on_a_production_bench(self):
-		with patch.object(oc, "_is_production_bench", return_value=True):
-			self.assertEqual(oc._normalize_pay_origin("http://jarvis_admin_v2.local:8002"), "")
-
-	def test_dev_relaxation_does_not_apply_to_non_local_http(self):
-		# Only .local hosts are relaxed; a plain-http public host is still rejected on dev.
-		with patch.object(oc, "_is_production_bench", return_value=False):
-			self.assertEqual(oc._normalize_pay_origin("http://fleet.klerk.in"), "")
 
 
 class TestAugmentPayPage(FrappeTestCase):

--- a/jarvis/tests/test_pay_page_cutover.py
+++ b/jarvis/tests/test_pay_page_cutover.py
@@ -39,6 +39,24 @@ class TestNormalizePayOrigin(FrappeTestCase):
 		origin = "https://fleet.klerk.in"
 		self.assertEqual(oc.pay_origin_digest(origin), hashlib.sha256(origin.encode("utf-8")).hexdigest())
 
+	def test_dev_http_local_origin_is_accepted_on_a_dev_bench(self):
+		# LOCAL-DEV relaxation: a non-production bench accepts a plain-http .local origin,
+		# preserving scheme + port, so it matches the admin-side _dev_origin byte-for-byte.
+		with patch.object(oc, "_is_production_bench", return_value=False):
+			self.assertEqual(
+				oc._normalize_pay_origin("http://jarvis_admin_v2.local:8002"),
+				"http://jarvis_admin_v2.local:8002",
+			)
+
+	def test_dev_http_local_is_rejected_on_a_production_bench(self):
+		with patch.object(oc, "_is_production_bench", return_value=True):
+			self.assertEqual(oc._normalize_pay_origin("http://jarvis_admin_v2.local:8002"), "")
+
+	def test_dev_relaxation_does_not_apply_to_non_local_http(self):
+		# Only .local hosts are relaxed; a plain-http public host is still rejected on dev.
+		with patch.object(oc, "_is_production_bench", return_value=False):
+			self.assertEqual(oc._normalize_pay_origin("http://fleet.klerk.in"), "")
+
 
 class TestAugmentPayPage(FrappeTestCase):
 	ORIGIN = "https://fleet.klerk.in"
@@ -68,11 +86,16 @@ class TestAugmentPayPage(FrappeTestCase):
 		self.assertEqual(out["pay_origin"], self.ORIGIN)
 		self.assertFalse(out["pay_origin_attested"])
 
-	def test_token_with_NO_configured_origin_fails_closed(self):
+	def test_token_with_NO_explicit_config_uses_the_production_default(self):
+		# New contract (2026-08-05): with nothing in site_config OR the Settings field,
+		# the origin falls back to the shipped production default instead of failing
+		# closed. self.ORIGIN IS that default and admin minted a token for it, so it
+		# attests. (site_config still overrides; a mismatched default would not attest.)
 		frappe.conf.pop("jarvis_pay_origin", None)
-		out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": self.digest})
-		self.assertEqual(out["pay_origin"], "")
-		self.assertFalse(out["pay_origin_attested"])
+		with patch("frappe.db.get_single_value", return_value=""):
+			out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": self.digest})
+		self.assertEqual(out["pay_origin"], oc._DEFAULT_PAY_ORIGIN)
+		self.assertTrue(out["pay_origin_attested"])
 
 	def test_token_with_no_admin_digest_cannot_be_attested(self):
 		frappe.conf["jarvis_pay_origin"] = self.ORIGIN
@@ -91,6 +114,28 @@ class TestAugmentPayPage(FrappeTestCase):
 		env = oc.success({"pay_page_token": "tok", "pay_origin_digest": self.digest, "api_secret": "s"})
 		self.assertNotIn("api_secret", env["data"])
 		self.assertTrue(env["data"]["pay_origin_attested"])
+
+
+class TestResolvedPayOrigin(FrappeTestCase):
+	"""_resolved_pay_origin precedence: site_config -> Jarvis Settings field -> default."""
+
+	def tearDown(self):
+		frappe.conf.pop("jarvis_pay_origin", None)
+
+	def test_site_config_wins_over_settings_field(self):
+		frappe.conf["jarvis_pay_origin"] = "https://vignesh-staging.klerk.in"
+		with patch("frappe.db.get_single_value", return_value="https://other.example.com"):
+			self.assertEqual(oc._resolved_pay_origin(), "https://vignesh-staging.klerk.in")
+
+	def test_settings_field_used_when_site_config_empty(self):
+		frappe.conf.pop("jarvis_pay_origin", None)
+		with patch("frappe.db.get_single_value", return_value="https://vignesh-staging.klerk.in"):
+			self.assertEqual(oc._resolved_pay_origin(), "https://vignesh-staging.klerk.in")
+
+	def test_production_default_when_both_empty(self):
+		frappe.conf.pop("jarvis_pay_origin", None)
+		with patch("frappe.db.get_single_value", return_value=""):
+			self.assertEqual(oc._resolved_pay_origin(), oc._DEFAULT_PAY_ORIGIN)
 
 
 class TestPaymentUiV2Flag(FrappeTestCase):


### PR DESCRIPTION
## What
Resolves `jarvis_pay_origin` as `site_config → Jarvis Settings field → production default` (mirroring the admin resolver), and adds an operator-only (permlevel 1) Settings field.

- The field is kept **out of the connect/sync write path** — it anchors the anti-injection origin digest, so a wire-set value must never define it.
- Adds a **dev-gated** (`_is_production_bench()`) plain-`http` `.local` relaxation, **byte-identical** to the admin `_dev_origin` so the origin digests agree over http.
- Declares the production default (`fleet.klerk.in`) on the field.

## Why
Operators manage the pay origin in the UI; local benches point at their own `.local` origin for testing while production defaults to `fleet.klerk.in`.

## Tests
`test_pay_page_cutover` extended (resolution precedence, dev relaxation on/off, production-default fallback) — 23/23 green locally.

Pairs with `jarvis-admin-v2` `feat/pay-origin-in-settings`.
