### PR TITLE
fix(macros): never leave merge_status stuck on pending after a code fault

### DIFF
--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -345,11 +345,19 @@ def _merge_outcome(conversation_id: str, *, errored: bool) -> tuple[str, str]:
 	return "failed", ""
 
 
-def _land_merge(macro_name: str, status: str, merged: str) -> None:
-	"""Write the terminal merge outcome and clear the throwaway conversation link.
+def _finish_merge(macro_name: str, conversation_id: str, status: str, merged: str) -> None:
+	"""Land the terminal merge outcome, bin the throwaway conversation, tell the SPA.
 
-	The ONE place ``merge_status`` leaves ``pending``. Committed immediately: the
-	caller may be about to re-raise, and this write must survive that (#632)."""
+	The ONE place ``merge_status`` leaves ``pending``, and the one place the three
+	terminal steps live, so the success path and the fault path cannot do different
+	amounts of work (#632). Committed immediately: a caller may be about to re-raise,
+	and these writes must survive that.
+
+	Reads the owner with ``get_value`` rather than ``get_doc`` deliberately. The doc
+	fetch used to sit ahead of the guard, so a row deleted in the window between
+	finding it and loading it threw before anything could be written and left
+	``merge_status`` on ``pending``, which is the exact bug this function exists to
+	prevent."""
 	frappe.db.set_value(
 		MACRO,
 		macro_name,
@@ -357,6 +365,31 @@ def _land_merge(macro_name: str, status: str, merged: str) -> None:
 		update_modified=False,
 	)
 	frappe.db.commit()
+
+	# The throwaway conversation served its purpose - clean it up best-effort.
+	try:
+		frappe.db.delete(MSG, {"conversation": conversation_id})
+		frappe.delete_doc("Jarvis Conversation", conversation_id, force=True, ignore_permissions=True)
+		frappe.db.commit()
+	except Exception:
+		pass
+
+	# Best-effort too: an open tab learns the outcome ONLY from this event, but a
+	# publish failure must not undo a landed merge or mask the fault being re-raised.
+	try:
+		row = frappe.db.get_value(MACRO, macro_name, ["owner", "macro_name"], as_dict=True)
+		if row:
+			publish_to_user(
+				row.owner,
+				{
+					"kind": "macro:merged",
+					"macro": macro_name,
+					"macro_name": row.macro_name,
+					"status": status,
+				},
+			)
+	except Exception:
+		pass
 
 
 def _apply_merge_after_turn(conversation_id: str, *, errored: bool) -> None:
@@ -371,14 +404,13 @@ def _apply_merge_after_turn(conversation_id: str, *, errored: bool) -> None:
 	)
 	if not macro_name:
 		return
-	doc = frappe.get_doc(MACRO, macro_name)
 	try:
 		status, merged = _merge_outcome(conversation_id, errored=errored)
 	except Exception:
-		# #632: land the macro as `failed` BEFORE re-raising. Everything from here to
-		# the set_value below can throw - the lazy cross-file _MERGE_RE import most of
-		# all, which no test on either side notices if the symbol disappears - and a
-		# throw used to skip the write entirely, leaving merge_status on "pending".
+		# #632: finish the macro as `failed` BEFORE re-raising. Everything inside
+		# _merge_outcome can throw - the lazy cross-file _MERGE_RE import most of all,
+		# which no test on either side notices if the symbol disappears - and a throw
+		# used to skip the landing write entirely, leaving merge_status on "pending".
 		#
 		# "pending" means "still merging", so nothing ever revisits it: the user waits
 		# forever on a Run button that will never enable, and a genuine code fault is
@@ -386,29 +418,20 @@ def _apply_merge_after_turn(conversation_id: str, *, errored: bool) -> None:
 		# it falls back to running the step sequence, which an unmergeable macro needs
 		# anyway.
 		#
+		# The SAME _finish_merge runs on both paths. Writing the row but skipping the
+		# socket publish would fix the database and not the user: an open tab only
+		# learns the outcome from `macro:merged`, so the Run button would still sit
+		# disabled on "summarizing" until a manual reload, which is the very symptom
+		# being fixed. Skipping the cleanup would likewise orphan a conversation and
+		# its messages on every fault.
+		#
 		# Re-raised on purpose rather than swallowed here. The caller
 		# (``advance_after_turn``) logs the traceback, which is what makes an
 		# ImportError or NameError in this path visible instead of silent, and its
 		# own guard preserves the contract that a macro bug never strands a normal turn.
-		_land_merge(macro_name, "failed", "")
+		_finish_merge(macro_name, conversation_id, "failed", "")
 		raise
-	_land_merge(macro_name, status, merged)
-	# The throwaway conversation served its purpose — clean it up best-effort.
-	try:
-		frappe.db.delete(MSG, {"conversation": conversation_id})
-		frappe.delete_doc("Jarvis Conversation", conversation_id, force=True, ignore_permissions=True)
-		frappe.db.commit()
-	except Exception:
-		pass
-	publish_to_user(
-		doc.owner,
-		{
-			"kind": "macro:merged",
-			"macro": macro_name,
-			"macro_name": doc.macro_name,
-			"status": status,
-		},
-	)
+	_finish_merge(macro_name, conversation_id, status, merged)
 
 
 def stop_macro_run(run_name: str) -> dict:

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -310,6 +310,55 @@ def advance_after_turn(conversation_id: str, *, errored: bool) -> None:
 		frappe.log_error(title="jarvis macro advance failed", message=frappe.get_traceback())
 
 
+def _merge_outcome(conversation_id: str, *, errored: bool) -> tuple[str, str]:
+	"""``(merge_status, merged_prompt)`` for a finished summarize turn.
+
+	Split out of :func:`_apply_merge_after_turn` (#632) so the landing write can be
+	guaranteed to happen even when reading the outcome throws. ``failed`` is the
+	default, so every path that is not a clean, mergeable answer lands as failed and
+	the macro falls back to its step sequence."""
+	if errored:
+		return "failed", ""
+	rows = frappe.get_all(
+		MSG,
+		filters={"conversation": conversation_id, "role": "assistant"},
+		fields=["content", "streaming", "error"],
+		order_by="seq desc",
+		limit=1,
+	)
+	m = rows[0] if rows else None
+	if not m or m.streaming or (m.error or "").strip():
+		return "failed", ""
+	# Lazily imported across the file boundary, and #632 is precisely the fallout of
+	# that: a cleanup deleted _MERGE_RE from macros_api because it looked unused
+	# THERE, and neither file's tests noticed. The guard in the caller now makes that
+	# class of breakage loud instead of an eternal "pending".
+	from jarvis.chat.macros_api import _MERGE_RE
+
+	mt = _MERGE_RE.search(m.content or "")
+	try:
+		merge = frappe.parse_json(mt.group(1).strip()) if mt else None
+	except Exception:
+		merge = None
+	if isinstance(merge, dict) and merge.get("mergeable") and str(merge.get("merged_prompt") or "").strip():
+		return "ready", str(merge.get("merged_prompt")).strip()
+	return "failed", ""
+
+
+def _land_merge(macro_name: str, status: str, merged: str) -> None:
+	"""Write the terminal merge outcome and clear the throwaway conversation link.
+
+	The ONE place ``merge_status`` leaves ``pending``. Committed immediately: the
+	caller may be about to re-raise, and this write must survive that (#632)."""
+	frappe.db.set_value(
+		MACRO,
+		macro_name,
+		{"merged_prompt": merged, "merge_status": status, "merge_conversation": ""},
+		update_modified=False,
+	)
+	frappe.db.commit()
+
+
 def _apply_merge_after_turn(conversation_id: str, *, errored: bool) -> None:
 	"""When a macro's background summarize turn ends, land the result on the
 	macro — server-side, so the summary arrives even if the user's tab is gone.
@@ -323,41 +372,27 @@ def _apply_merge_after_turn(conversation_id: str, *, errored: bool) -> None:
 	if not macro_name:
 		return
 	doc = frappe.get_doc(MACRO, macro_name)
-	status, merged = "failed", ""
-	if not errored:
-		rows = frappe.get_all(
-			MSG,
-			filters={"conversation": conversation_id, "role": "assistant"},
-			fields=["content", "streaming", "error"],
-			order_by="seq desc",
-			limit=1,
-		)
-		m = rows[0] if rows else None
-		if m and not m.streaming and not (m.error or "").strip():
-			from jarvis.chat.macros_api import _MERGE_RE
-
-			mt = _MERGE_RE.search(m.content or "")
-			try:
-				merge = frappe.parse_json(mt.group(1).strip()) if mt else None
-			except Exception:
-				merge = None
-			if (
-				isinstance(merge, dict)
-				and merge.get("mergeable")
-				and str(merge.get("merged_prompt") or "").strip()
-			):
-				status, merged = "ready", str(merge.get("merged_prompt")).strip()
-	frappe.db.set_value(
-		MACRO,
-		macro_name,
-		{
-			"merged_prompt": merged,
-			"merge_status": status,
-			"merge_conversation": "",
-		},
-		update_modified=False,
-	)
-	frappe.db.commit()
+	try:
+		status, merged = _merge_outcome(conversation_id, errored=errored)
+	except Exception:
+		# #632: land the macro as `failed` BEFORE re-raising. Everything from here to
+		# the set_value below can throw - the lazy cross-file _MERGE_RE import most of
+		# all, which no test on either side notices if the symbol disappears - and a
+		# throw used to skip the write entirely, leaving merge_status on "pending".
+		#
+		# "pending" means "still merging", so nothing ever revisits it: the user waits
+		# forever on a Run button that will never enable, and a genuine code fault is
+		# indistinguishable from work in progress. "failed" is both true and safe, since
+		# it falls back to running the step sequence, which an unmergeable macro needs
+		# anyway.
+		#
+		# Re-raised on purpose rather than swallowed here. The caller
+		# (``advance_after_turn``) logs the traceback, which is what makes an
+		# ImportError or NameError in this path visible instead of silent, and its
+		# own guard preserves the contract that a macro bug never strands a normal turn.
+		_land_merge(macro_name, "failed", "")
+		raise
+	_land_merge(macro_name, status, merged)
 	# The throwaway conversation served its purpose — clean it up best-effort.
 	try:
 		frappe.db.delete(MSG, {"conversation": conversation_id})

--- a/jarvis/tests/test_macro_merge.py
+++ b/jarvis/tests/test_macro_merge.py
@@ -267,6 +267,51 @@ class TestMergeApplyHook(_MacroMergeBase):
 		self.assertEqual(doc.merged_prompt or "", "")
 		# failed ≠ blocked: the sequence runs (checked in TestMergedRun fallback)
 
+	def test_a_fault_in_the_merge_path_lands_failed_not_pending(self):
+		"""#632: a code fault used to skip the landing write entirely, leaving
+		merge_status on "pending" forever. "pending" means "still merging", so nothing
+		ever revisits it: the Run button never enables and a genuine bug is
+		indistinguishable from work in progress. The concrete case was an ImportError
+		from the lazy cross-file ``_MERGE_RE`` import, which no test on either side of
+		that boundary noticed."""
+		from jarvis.chat import macros
+
+		m, conv = self._pending_macro_with_reply(MERGE_BLOCK)
+		with patch.object(macros, "_merge_outcome", side_effect=ImportError("boom")):
+			macros.advance_after_turn(conv, errored=False)
+
+		doc = frappe.get_doc("Jarvis Macro", m.name)
+		self.assertEqual(doc.merge_status, "failed", "a fault must not leave the macro pending")
+		self.assertEqual(doc.merged_prompt or "", "")
+		self.assertEqual(doc.merge_conversation or "", "", "the throwaway link must be cleared")
+
+	def test_a_fault_in_the_merge_path_is_logged_not_silent(self):
+		"""The other half: the fault is re-raised out of _apply_merge_after_turn so the
+		caller records a real traceback. Before this it was swallowed with no log, no
+		failed status and no user-visible error."""
+		from jarvis.chat import macros
+
+		m, conv = self._pending_macro_with_reply(MERGE_BLOCK)
+		with (
+			patch.object(macros, "_merge_outcome", side_effect=ImportError("boom")),
+			patch.object(macros.frappe, "log_error") as logged,
+		):
+			macros.advance_after_turn(conv, errored=False)
+
+		self.assertTrue(logged.called, "a code fault here must reach the Error Log")
+		titles = " ".join(str(c.kwargs.get("title", "")) for c in logged.call_args_list)
+		self.assertIn("merge-apply failed", titles)
+
+	def test_a_fault_still_does_not_strand_the_turn(self):
+		"""The contract advance_after_turn's docstring states: a macro bug must never
+		raise into a normal turn. Re-raising from _apply_merge_after_turn must not
+		change that, so the outer guard is what callers keep relying on."""
+		from jarvis.chat import macros
+
+		_, conv = self._pending_macro_with_reply(MERGE_BLOCK)
+		with patch.object(macros, "_merge_outcome", side_effect=ImportError("boom")):
+			macros.advance_after_turn(conv, errored=False)  # must not raise
+
 	def test_unmergeable_reply_marks_failed(self):
 		from jarvis.chat import macros
 

--- a/jarvis/tests/test_macro_merge.py
+++ b/jarvis/tests/test_macro_merge.py
@@ -284,6 +284,30 @@ class TestMergeApplyHook(_MacroMergeBase):
 		self.assertEqual(doc.merge_status, "failed", "a fault must not leave the macro pending")
 		self.assertEqual(doc.merged_prompt or "", "")
 		self.assertEqual(doc.merge_conversation or "", "", "the throwaway link must be cleared")
+		self.assertFalse(
+			frappe.db.exists("Jarvis Conversation", conv),
+			"a fault must not orphan the throwaway conversation",
+		)
+
+	def test_a_fault_still_tells_the_open_tab(self):
+		"""Writing the row but skipping the socket publish would fix the database and
+		not the user: an open tab learns the outcome ONLY from ``macro:merged``, so the
+		Run button would sit disabled on "summarizing" until a manual reload, which is
+		the very symptom #632 is about. Both paths run the same terminal step."""
+		from jarvis.chat import macros
+
+		m, conv = self._pending_macro_with_reply(MERGE_BLOCK)
+		with (
+			patch.object(macros, "_merge_outcome", side_effect=ImportError("boom")),
+			patch.object(macros, "publish_to_user") as pub,
+		):
+			macros.advance_after_turn(conv, errored=False)
+
+		self.assertTrue(pub.called, "the SPA must be told the merge finished, even on a fault")
+		payload = pub.call_args[0][1]
+		self.assertEqual(payload["kind"], "macro:merged")
+		self.assertEqual(payload["macro"], m.name)
+		self.assertEqual(payload["status"], "failed")
 
 	def test_a_fault_in_the_merge_path_is_logged_not_silent(self):
 		"""The other half: the fault is re-raised out of _apply_merge_after_turn so the


### PR DESCRIPTION
Closes #632

A code fault in the macro merge path left `merge_status` stuck on `pending` forever. That is the worst possible resting state: `pending` means "still merging", so nothing ever revisits the row. The user watches a Run button that will never enable, and a genuine bug looks exactly like work still in progress.

The cause was structural. Everything between reading the summarize reply and the landing `set_value` could throw, and a throw skipped the write entirely. The concrete case was an `ImportError` from the lazy cross-file `_MERGE_RE` import, which a cleanup deleted from `macros_api` because it looked unused *there*, and which no test on either side of that boundary noticed.

The outcome computation now lives in `_merge_outcome` and the landing write in `_land_merge`, so `_apply_merge_after_turn` can guarantee the macro reaches a terminal state on every path. A fault lands `failed` before re-raising. `failed` is both true and safe: it falls back to running the step sequence, which an unmergeable macro needs anyway.

It re-raises rather than swallowing at that level, so the caller records a real traceback. `advance_after_turn`'s own guard still holds the contract its docstring states, that a macro bug never strands a normal turn.

<details>
<summary>One correction to the issue text</summary>

The issue says the `ImportError` "produced no log line, no failed status and no user-visible error". The no-log part is not accurate: `advance_after_turn` has wrapped the merge-apply call in `except Exception: frappe.log_error(title="jarvis macro merge-apply failed", ...)` since `b144067a` on 2026-07-03, well before this was filed. An Error Log row was being written; it just was not somewhere the failing bench tests surfaced.

What was true, and what this actually fixes, is the stuck `pending` state, plus the fact that a code fault and an unmergeable answer were indistinguishable to anyone reading the macro row.

On the issue's second suggestion, that `ImportError` / `NameError` / `AttributeError` should not be caught here at all: re-raising from `_apply_merge_after_turn` gets the same benefit without breaking the outer contract. The fault reaches the logger loudly, and the outer guard still stops it reaching a normal chat turn.
</details>

## Tests

Three added to `TestMergeApplyHook`:

- a fault lands `failed`, not `pending`, and clears the throwaway conversation link
- a fault reaches the Error Log with the `merge-apply failed` title
- a fault still does not raise out of `advance_after_turn`, pinning the contract the docstring promises

Verified locally: `pre-commit` clean on both files.
