### PR TITLE
fix(skills): make Role-promoted skills discoverable, not just invocable

### DIFF
--- a/jarvis/chat/custom_skills.py
+++ b/jarvis/chat/custom_skills.py
@@ -297,15 +297,23 @@ def invoked_skill_clause(message: str) -> str:
 	return clause
 
 
-def _role_scoped_invocable_names(user: str) -> set[str]:
-	"""Bare slugs of enabled, non-managed skills whose (non-empty) allowed_roles
-	intersect ``user``'s roles. One cached role lookup + two indexed queries; no
-	per-skill N+1 (plan section 6.6)."""
+def role_scoped_skill_rows(user: str, fields: list[str]) -> list:
+	"""Enabled, non-managed skills whose (non-empty) allowed_roles intersect ``user``'s
+	roles, projected onto ``fields``.
+
+	The ONE definition of the Role-scope match. Invocation
+	(:func:`_role_scoped_invocable_names`) and discovery
+	(``custom_skills_api.list_custom_skills``) both read it, because #628 was precisely
+	those two disagreeing: ``/slug`` fired for a Role-promoted skill while the composer
+	dropdown never listed it, so the feature only worked for someone who already knew
+	the slug existed.
+
+	One cached role lookup + two indexed queries; no per-skill N+1 (plan section 6.6)."""
 	from jarvis.learning.roles import roles_for_user
 
 	user_roles = roles_for_user(user)
 	if not user_roles:
-		return set()
+		return []
 	parents = {
 		r.parent
 		for r in frappe.get_all(
@@ -315,15 +323,17 @@ def _role_scoped_invocable_names(user: str) -> set[str]:
 		)
 	}
 	if not parents:
-		return set()
-	return {
-		r.skill_name
-		for r in frappe.get_all(
-			"Jarvis Custom Skill",
-			filters={"name": ["in", list(parents)], "enabled": 1, "managed_by_learning": 0},
-			fields=["skill_name"],
-		)
-	}
+		return []
+	return frappe.get_all(
+		"Jarvis Custom Skill",
+		filters={"name": ["in", list(parents)], "enabled": 1, "managed_by_learning": 0},
+		fields=fields,
+	)
+
+
+def _role_scoped_invocable_names(user: str) -> set[str]:
+	"""Bare slugs of the skills :func:`role_scoped_skill_rows` matches."""
+	return {r.skill_name for r in role_scoped_skill_rows(user, ["skill_name"])}
 
 
 def learned_skill_clause(user: str | None = None) -> str:

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -126,23 +126,8 @@ def list_custom_skills() -> list[dict]:
 			fields=["name", "skill_name", "description", "user_invocable", "enabled", "owner", "modified"],
 			order_by="skill_name asc",
 		)
-		# One query for the owners' display names (was a per-row lookup).
-		full_names = (
-			{
-				u.name: u.full_name
-				for u in frappe.get_all(
-					"User",
-					filters={"name": ["in", list({r.owner for r in rows})]},
-					fields=["name", "full_name"],
-				)
-			}
-			if rows
-			else {}
-		)
 		for s in rows:
 			s["mine"] = 0
-			owner = s.pop("owner")
-			s["shared_by"] = full_names.get(owner) or owner
 			shared.append(s)
 
 	# #628: Role-promoted skills. Invocation already accepted these (#477 / #478 via
@@ -161,26 +146,44 @@ def list_custom_skills() -> list[dict]:
 		if r["name"] not in seen
 	]
 	via_role = []
-	if role_rows:
-		role_full_names = {
+	for s in role_rows:
+		s["mine"] = 0
+		# ``via_role`` lets the composer label these differently from a person-to-person
+		# share: nobody shared it with this user, their ROLE grants it, and revoking the
+		# role removes it. ``shared_by`` is still populated so a client that does not know
+		# the flag renders an author rather than a blank.
+		s["via_role"] = 1
+		via_role.append(s)
+
+	# ONE display-name query for every not-mine row, shared and role-granted alike.
+	# These were two near-identical User lookups; a third source of borrowed rows would
+	# have been a third copy, and nothing enforced looking names up the same way.
+	_attach_shared_by(shared + via_role)
+	return own + shared + via_role
+
+
+def _attach_shared_by(rows: list) -> None:
+	"""Replace each row's ``owner`` with a human ``shared_by`` label, in place.
+
+	One query for all of them. Falls back to the raw owner id, then to a literal, so a
+	row whose owner is empty (a legacy row minted by a script) still renders something
+	identifiable instead of a blank author."""
+	if not rows:
+		return
+	owners = {r.get("owner") for r in rows if r.get("owner")}
+	full_names = (
+		{
 			u.name: u.full_name
 			for u in frappe.get_all(
-				"User",
-				filters={"name": ["in", list({r.owner for r in role_rows})]},
-				fields=["name", "full_name"],
+				"User", filters={"name": ["in", list(owners)]}, fields=["name", "full_name"]
 			)
 		}
-		for s in role_rows:
-			s["mine"] = 0
-			# ``via_role`` lets the composer label these differently from a person-to-person
-			# share: nobody shared it with this user, their ROLE grants it, and revoking the
-			# role removes it. The existing ``shared_by`` is still populated so a client that
-			# does not know the flag renders an author rather than a blank.
-			s["via_role"] = 1
-			owner = s.pop("owner")
-			s["shared_by"] = role_full_names.get(owner) or owner
-			via_role.append(s)
-	return own + shared + via_role
+		if owners
+		else {}
+	)
+	for r in rows:
+		owner = r.pop("owner", None)
+		r["shared_by"] = full_names.get(owner) or owner or _("Unknown")
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -24,6 +24,7 @@ from jarvis.chat.custom_skills import (
 	build_push_payload,
 	project_org_promotion_push,
 	pushable_org_skill_count,
+	role_scoped_skill_rows,
 )
 from jarvis.permissions import require_jarvis_user
 
@@ -143,7 +144,43 @@ def list_custom_skills() -> list[dict]:
 			owner = s.pop("owner")
 			s["shared_by"] = full_names.get(owner) or owner
 			shared.append(s)
-	return own + shared
+
+	# #628: Role-promoted skills. Invocation already accepted these (#477 / #478 via
+	# PR #619) but discovery did not, so `/slug` fired while the composer dropdown
+	# never listed it. The feature therefore only worked for someone who already knew
+	# the slug existed, which is the opposite of what promoting a skill to a Role is
+	# for. Same match the invocation path uses, read from one shared helper so the two
+	# cannot drift apart again.
+	seen = {s["name"] for s in own} | {s["name"] for s in shared}
+	role_rows = [
+		r
+		for r in role_scoped_skill_rows(
+			me,
+			["name", "skill_name", "description", "user_invocable", "enabled", "owner", "modified"],
+		)
+		if r["name"] not in seen
+	]
+	via_role = []
+	if role_rows:
+		role_full_names = {
+			u.name: u.full_name
+			for u in frappe.get_all(
+				"User",
+				filters={"name": ["in", list({r.owner for r in role_rows})]},
+				fields=["name", "full_name"],
+			)
+		}
+		for s in role_rows:
+			s["mine"] = 0
+			# ``via_role`` lets the composer label these differently from a person-to-person
+			# share: nobody shared it with this user, their ROLE grants it, and revoking the
+			# role removes it. The existing ``shared_by`` is still populated so a client that
+			# does not know the flag renders an author rather than a blank.
+			s["via_role"] = 1
+			owner = s.pop("owner")
+			s["shared_by"] = role_full_names.get(owner) or owner
+			via_role.append(s)
+	return own + shared + via_role
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1619,6 +1619,55 @@ class TestRoleScopedSkillInvocation(Part2Base):
 		with _as(USER_B):  # Jarvis User only, no Sales User
 			self.assertEqual(invoked_skill_clause(f"/{PFX}-rolepriv go"), "")
 
+	# ── #628: invocation without discovery is only useful if you already know ────
+	def test_role_promoted_skill_is_listed_for_a_role_holder(self):
+		"""#628: ``/slug`` fired (above) but ``list_custom_skills`` never matched on
+		allowed_roles, so the composer dropdown did not show it. The feature therefore
+		only worked for someone who already knew the slug existed, which is the opposite
+		of what promoting a skill to a Role is for."""
+		from jarvis.chat.custom_skills_api import list_custom_skills
+
+		self._promote_to_role(f"{PFX}-rolelist")
+		with _as(self.ROLE_HOLDER):
+			rows = list_custom_skills()
+		match = [r for r in rows if r["skill_name"] == f"{PFX}-rolelist"]
+		self.assertEqual(len(match), 1, "a Role-promoted skill must be discoverable by a role holder")
+		self.assertEqual(match[0]["mine"], 0)
+		self.assertEqual(match[0].get("via_role"), 1, "the composer needs to tell this apart from a share")
+
+	def test_role_promoted_skill_is_not_listed_for_a_non_role_holder(self):
+		"""Discovery must not widen visibility beyond what invocation already allows."""
+		from jarvis.chat.custom_skills_api import list_custom_skills
+
+		self._promote_to_role(f"{PFX}-rolenolist")
+		with _as(USER_B):  # Jarvis User only, no Sales User
+			rows = list_custom_skills()
+		self.assertEqual([r for r in rows if r["skill_name"] == f"{PFX}-rolenolist"], [])
+
+	def test_a_role_skill_the_user_also_owns_is_not_listed_twice(self):
+		"""The role rows are unioned onto own + shared, so an overlap would otherwise
+		render the same skill twice in the dropdown."""
+		from jarvis.chat.custom_skills_api import list_custom_skills
+
+		_mk_skill(self.ROLE_HOLDER, f"{PFX}-roledup", scope="Role", target_role=self.AUD_ROLE)
+		with _as(self.ROLE_HOLDER):
+			rows = list_custom_skills()
+		match = [r for r in rows if r["skill_name"] == f"{PFX}-roledup"]
+		self.assertEqual(len(match), 1, "own + role must not duplicate the row")
+		self.assertEqual(match[0]["mine"], 1, "ownership wins over the role grant")
+
+	def test_a_disabled_role_skill_is_not_listed(self):
+		"""Same enabled gate the invocation path applies, so a draft promotion does not
+		surface in anyone's dropdown."""
+		from jarvis.chat.custom_skills_api import list_custom_skills
+
+		shared = self._promote_to_role(f"{PFX}-roledisabled")
+		frappe.db.set_value(SKILL, shared, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		with _as(self.ROLE_HOLDER):
+			rows = list_custom_skills()
+		self.assertEqual([r for r in rows if r["skill_name"] == f"{PFX}-roledisabled"], [])
+
 	def test_patch_backfills_allowed_roles_on_a_pre_fix_role_skill(self):
 		# The code fix only helps promotions made AFTER deploy. Rows promoted under the
 		# old code carry target_role with an EMPTY allowed_roles, which is exactly the

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1668,6 +1668,23 @@ class TestRoleScopedSkillInvocation(Part2Base):
 			rows = list_custom_skills()
 		self.assertEqual([r for r in rows if r["skill_name"] == f"{PFX}-roledisabled"], [])
 
+	def test_shared_by_never_renders_blank(self):
+		"""Shared and role-granted rows go through one display-name lookup. A row whose
+		owner is empty (a legacy row minted by a script) must still render something
+		identifiable rather than a blank author."""
+		from jarvis.chat.custom_skills_api import _attach_shared_by
+
+		rows = [
+			{"name": "x", "owner": self.ROLE_HOLDER},
+			{"name": "y", "owner": ""},
+			{"name": "z", "owner": "nobody@example.invalid"},
+		]
+		_attach_shared_by(rows)
+		self.assertTrue(all(r["shared_by"] for r in rows), "no row may carry a blank shared_by")
+		self.assertNotIn("owner", rows[0], "owner is replaced, not duplicated")
+		# An unknown-but-present owner falls back to the raw id, which is still useful.
+		self.assertEqual(rows[2]["shared_by"], "nobody@example.invalid")
+
 	def test_patch_backfills_allowed_roles_on_a_pre_fix_role_skill(self):
 		# The code fix only helps promotions made AFTER deploy. Rows promoted under the
 		# old code carry target_role with an EMPTY allowed_roles, which is exactly the


### PR DESCRIPTION
Closes #628

A Role-promoted skill could be invoked but never found. PR #619 (#477 / #478) made `/slug` fire for role holders, but `list_custom_skills` still returned only rows the caller owns or that appear in `shared_with`. It never matched on `allowed_roles`, so the composer's `/` dropdown did not list the skill.

The result is a feature that works only for someone who already knows the slug exists, which is the opposite of what promoting a skill to a Role is for. Anyone discovering skills through the UI, which is most people, could not find it.

The role match now lives in one function, `custom_skills.role_scoped_skill_rows`, projected onto whatever fields the caller needs. Invocation reads it through `_role_scoped_invocable_names`, unchanged in behaviour and now a one-line wrapper, and discovery reads it directly. The two cannot drift apart again, which is exactly how they came to disagree.

Role rows are unioned onto `own + shared` with a name-based dedupe, so a skill the user also owns, or that was shared with them directly, appears once and keeps its stronger relationship.

<details>
<summary>On the issue's open question about distinguishing these in the dropdown</summary>

The issue asked whether the dropdown should tell apart skills whose body is on disk from ones the agent has to fetch, since #619 made that a real distinction.

Role rows carry `via_role=1` rather than being folded into the existing share shape, because the relationship genuinely differs: nobody shared it with this user, their **role** grants it, and revoking the role removes it. `shared_by` is still populated, so a client that does not know the new flag renders an author rather than a blank.

Whether the composer surfaces that distinction, and how, is a UI decision I have left to the frontend. This PR makes the data available to make it.
</details>

## Tests

Four added to `TestRoleScopedSkillInvocation`, which already covers the invocation half:

- a Role-promoted skill is listed for a role holder, with `mine=0` and `via_role=1`
- it is **not** listed for a non-role-holder, so discovery does not widen visibility past what invocation already allows
- a skill the user also owns appears once, with ownership winning over the role grant
- a disabled role skill is not listed, matching the `enabled` gate the invocation path applies

Verified locally: `pre-commit` clean on all three files.
