### PR TITLE
fix(agents): derive rehome membership from origin, not the bumped run pointer

### DIFF
--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -1176,23 +1176,31 @@ def _rehome_installation_outputs(inst, to_owner: str) -> None:
 	re-homing is how promotion OPENS the owner surface (and demotion re-closes it).
 	Raw ``db.set_value`` bypasses the finding/run immutability controllers. Rows are
 	located precisely by installation membership (never a broad owner+agent match
-	that could sweep a different install of the same agent)."""
+	that could sweep a different install of the same agent).
+
+	#615: findings come from :func:`_installation_finding_names`, the SAME membership
+	rule the uninstall cascade uses since #455/#612, rather than a local variant that
+	also accepted ``last_seen_run``. That extra pointer is not a membership signal: it
+	is the only run pointer the engine re-points, and the recurrence bump that
+	re-points it matches on ``(owner, agent, fingerprint)``, so under PP-4 shadow
+	re-homing it can attach ANOTHER owner's finding to one of our runs. A row reachable
+	only through it was, by construction, created by somebody else's installation.
+
+	The consequence here differs from #455 and is why this needed its own fix: the
+	cascade DELETED such a row, while this path rewrites its visibility ``owner``. So
+	the failure was a foreign customer's finding silently appearing under the wrong
+	owner rather than disappearing."""
 	run_names = frappe.get_all(
 		RUN, filters={"installation": inst.name}, pluck="name", ignore_permissions=True
 	)
-	dash_names, finding_names = set(), set()
+	dash_names = set()
+	finding_names = _installation_finding_names(run_names)
 	if run_names:
 		for r in frappe.get_all(
 			RUN, filters={"name": ["in", run_names]}, fields=["dashboard"], ignore_permissions=True
 		):
 			if r.dashboard:
 				dash_names.add(r.dashboard)
-		for field in ("run", "first_seen_run", "last_seen_run"):
-			finding_names.update(
-				frappe.get_all(
-					FINDING, filters={field: ["in", run_names]}, pluck="name", ignore_permissions=True
-				)
-			)
 	for rn in run_names:
 		frappe.db.set_value(RUN, rn, "owner", to_owner, update_modified=False)
 	for fn in finding_names:

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1475,3 +1475,117 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 		dispatched = self._run_cron()
 
 		self.assertIn(good, dispatched, "a bad persisted time aborted the sweep for every other row")
+
+
+# --------------------------------------------------------------------------- #
+# #615 - promote/demote must not re-home a foreign owner's finding
+# --------------------------------------------------------------------------- #
+class TestRehomeMembershipScope(FrappeTestCase):
+	"""``_rehome_installation_outputs`` built its membership set from ``run``,
+	``first_seen_run`` AND ``last_seen_run``. That third pointer is the only one the
+	engine re-points, and the recurrence bump that re-points it matches on
+	``(owner, agent, fingerprint)``, so under PP-4 shadow re-homing it can attach
+	another owner's finding to one of our runs. Promoting or demoting then rewrote
+	that foreign row's visibility ``owner``.
+
+	Same unsafe signal #455/#612 removed from the uninstall cascade, different
+	consequence: the cascade DELETED such a row, this path makes a foreign customer's
+	finding appear under the wrong owner."""
+
+	SLUG = PREFIX + "rehome"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner_a = _mk_user("h-rehome-a@example.com")
+		cls.owner_b = _mk_user("h-rehome-b@example.com")
+		cls.reviewer = _mk_user("h-rehome-rev@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		# Two installations of the SAME agent sharing one reviewer, so PP-4 re-homing
+		# has already put both owners' findings under that reviewer.
+		self.inst_a = _mk_install(self.owner_a, self.SLUG, self.reviewer)
+		self.inst_b = _mk_install(self.owner_b, self.SLUG, self.reviewer)
+		self.run_a = _mk_run(self.inst_a.name, self.SLUG, self.reviewer)
+		self.run_b = _mk_run(self.inst_b.name, self.SLUG, self.reviewer)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def test_a_foreign_finding_bumped_onto_our_run_is_not_rehomed(self):
+		"""THE regression. B's finding was CREATED by B's installation (run +
+		first_seen_run both point at B's run) but a recurrence bump re-pointed its
+		last_seen_run onto A's run. Re-homing A must leave its owner alone."""
+		foreign = _mk_finding(
+			self.reviewer,
+			self.SLUG,
+			run=self.run_b,
+			first_seen_run=self.run_b,
+			last_seen_run=self.run_a,  # the bump, the only pointer the engine moves
+		).name
+		frappe.db.commit()
+
+		agents_api._rehome_installation_outputs(self.inst_a, self.owner_a)
+
+		self.assertEqual(
+			frappe.db.get_value(FINDING, foreign, "owner"),
+			self.reviewer,
+			"a finding created by another installation must not be re-homed",
+		)
+
+	def test_our_own_findings_are_still_rehomed(self):
+		"""Control: the function must still do its job, or the fix is just a break."""
+		mine = _mk_finding(
+			self.reviewer,
+			self.SLUG,
+			run=self.run_a,
+			first_seen_run=self.run_a,
+			last_seen_run=self.run_a,
+		).name
+		frappe.db.commit()
+
+		agents_api._rehome_installation_outputs(self.inst_a, self.owner_a)
+
+		self.assertEqual(frappe.db.get_value(FINDING, mine, "owner"), self.owner_a)
+		self.assertEqual(frappe.db.get_value(RUN, self.run_a, "owner"), self.owner_a, "runs re-home too")
+
+	def test_a_finding_created_on_our_run_but_bumped_elsewhere_is_rehomed(self):
+		"""The mirror case: origin is what counts, not where the bump currently points.
+		A row A's installation created stays A's even though its last_seen_run has since
+		moved onto B's run."""
+		mine = _mk_finding(
+			self.reviewer,
+			self.SLUG,
+			run=self.run_a,
+			first_seen_run=self.run_a,
+			last_seen_run=self.run_b,
+		).name
+		frappe.db.commit()
+
+		agents_api._rehome_installation_outputs(self.inst_a, self.owner_a)
+
+		self.assertEqual(frappe.db.get_value(FINDING, mine, "owner"), self.owner_a)
+
+	def test_b_findings_are_untouched_when_a_is_rehomed(self):
+		"""Nothing belonging to the co-reviewed installation moves at all."""
+		theirs = _mk_finding(
+			self.reviewer,
+			self.SLUG,
+			run=self.run_b,
+			first_seen_run=self.run_b,
+			last_seen_run=self.run_b,
+		).name
+		frappe.db.commit()
+
+		agents_api._rehome_installation_outputs(self.inst_a, self.owner_a)
+
+		self.assertEqual(frappe.db.get_value(FINDING, theirs, "owner"), self.reviewer)
+		self.assertEqual(frappe.db.get_value(RUN, self.run_b, "owner"), self.reviewer)


### PR DESCRIPTION
Closes #615

Promoting or demoting an installation could silently rewrite the visibility `owner` of a **different customer's** finding, making it appear under the wrong owner.

`_rehome_installation_outputs` built its membership set from `run`, `first_seen_run` **and** `last_seen_run`. That third pointer is not a membership signal. It is the only run pointer the engine ever re-points, and the recurrence bump that re-points it matches on `(owner, agent, fingerprint)`. Under PP-4, a reviewer holds findings from several installations at once, so that bump can attach another owner's finding to one of our runs. A row reachable *only* through `last_seen_run` was, by construction, created by somebody else's installation.

`run` and `first_seen_run` are both stamped once at insert by `agent_runs.record_delegate_run` and frozen by the controller thereafter, which is what makes them a durable statement of origin.

Membership now comes from `_installation_finding_names`, the same helper the uninstall cascade has used since #455/#612, rather than a local variant of the rule. One definition, so the two paths cannot disagree again, which is how this survived #612 in the first place.

Same unsafe signal as #455, different consequence, which is why it needed its own fix and tests: **the cascade deleted such a row, this path silently reassigns it.** A deletion is at least visible; a reassignment shows one customer's finding to another.

## Tests

`TestRehomeMembershipScope` sets up two installations of the same agent sharing one reviewer, so PP-4 has already pulled both owners' findings under that reviewer, which is the shape that makes this reachable:

- a foreign finding bumped onto our run is **not** re-homed (the regression)
- our own findings still are, and so do our runs, so the fix is not just a break
- a finding we created whose bump has since moved onto the other installation's run is still ours, since origin is what counts and not where the pointer currently sits
- the co-reviewed installation's finding and run are untouched throughout

Verified locally: `pre-commit` clean on both files.
