### PR TITLE
feat(chat): minimal new chat + Desk widget confirmations and full-chat handoff

### DIFF
--- a/frontend/src/components/ConnectPhoneDialog.vue
+++ b/frontend/src/components/ConnectPhoneDialog.vue
@@ -28,15 +28,6 @@
 					<div class="rounded-xl border border-outline-gray-2 bg-white p-3">
 						<img :src="qrSrc" alt="Mobile app QR code" class="size-52" />
 					</div>
-					<a
-						v-if="url"
-						:href="url"
-						target="_blank"
-						rel="noopener"
-						class="mt-3 break-all text-center text-sm text-ink-blue-link"
-					>
-						{{ url }}
-					</a>
 				</template>
 			</div>
 		</template>

--- a/frontend/src/components/chat/PersonaOptions.vue
+++ b/frontend/src/components/chat/PersonaOptions.vue
@@ -21,8 +21,8 @@
 			<CheckMark v-if="persona === opt.value" />
 		</button>
 		<div class="pop-note">
-			Persona is voice only. It applies to every chat and device, and takes effect from the
-			next message.
+			Persona only changes the assistant's tone, not its tools or answers. It applies to
+			every chat and device, and takes effect from the next message.
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -201,10 +201,12 @@ describe("ChatView wiring (source tripwires, not behaviour)", () => {
 		expect(src).toContain('v-if="bizGreeting.show && !showHomeIntro"');
 	});
 
-	it("keeps the suggestion cards below the introduction", () => {
-		expect(src.indexOf("<WelcomeAssistantMessage")).toBeLessThan(
-			src.indexOf('class="jv-welcome-grid"')
-		);
+	it("renders the minimal new-chat greeting and no suggestion cards", () => {
+		// Claude-style empty state: the brand mark inline with the greeting, and NO
+		// suggestion grid. A regression that re-adds the cards trips here.
+		expect(src).toContain("<span>{{ greeting }}, {{ firstName }}</span>");
+		expect(src).not.toContain('class="jv-welcome-grid"');
+		expect(src).not.toContain("onWelcomeSuggestion");
 	});
 
 	it("moves the welcome viewport off inline styles onto overflow-safe classes", () => {
@@ -215,15 +217,5 @@ describe("ChatView wiring (source tripwires, not behaviour)", () => {
 		expect(src).toContain('class="jv-welcome-col"');
 		expect(src).toContain("justify-content: flex-start;");
 		expect(src).toContain("margin-block: auto;");
-	});
-
-	it("routes suggestion clicks through the fill+telemetry wrapper and still fills, never sends", () => {
-		expect(src).toContain('@click="onWelcomeSuggestion(s)"');
-		// The wrapper records the category then FILLS the composer — it must not send.
-		const fn = src.slice(src.indexOf("function onWelcomeSuggestion"));
-		const body = fn.slice(0, fn.indexOf("}") + 1);
-		expect(body).toContain("noteWelcomeSuggestion(");
-		expect(body).toContain("fillInput(s.prompt)");
-		expect(body).not.toContain("sendMessage");
 	});
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -405,7 +405,8 @@
 				</div>
 			</div>
 
-			<!-- centre the empty-state greeting + composer (top/bottom flex spacers) -->
+			<!-- Lift the empty-state greeting + composer into the upper third: the bottom
+			     spacer grows more than the top (Claude-style new chat), so it is not dead-centre. -->
 			<div v-if="showWelcome" style="flex: 1"></div>
 			<!-- initial load: a quiet spinner so the welcome screen doesn't flash
 			     before the open conversation finishes loading on refresh -->
@@ -434,8 +435,7 @@
 			<div v-else-if="showWelcome" class="jv-welcome-scroll">
 				<div class="jv-welcome-col">
 					<!-- First empty chat home (per user, versioned): the assistant-styled
-					     introduction REPLACES the compact hero, then never lectures
-					     again. Static presentation only — see WelcomeAssistantMessage. -->
+					     introduction shows once, then never again. Static presentation only. -->
 					<WelcomeAssistantMessage
 						v-if="showHomeIntro"
 						:speaker="homeIntroSpeakerName"
@@ -443,103 +443,26 @@
 						:firstName="firstName"
 						@seen="ackHomeIntro"
 					/>
-					<template v-else>
-						<!-- The brand mark, from its single source of truth. This was a
-						     hand-pasted copy whose gradient read `var(--cta)` as its first
-						     stop; when #294 repointed --cta from indigo to near-black, this
-						     mark silently became near-black->purple while the sidebar mark
-						     (UserMenu) stayed blue->purple — two different logos on one
-						     screen. The purple glow shadow is dropped (design.md §5 #4). -->
-						<JarvisMark :size="54" :radius="14" style="margin: 0 auto 18px" />
-						<h1
-							class="jv-welcome-h1"
-							style="
-								font-size: 30px;
-								font-weight: 640;
-								letter-spacing: -0.03em;
-								margin: 0 0 8px;
-								overflow-wrap: anywhere;
-							"
-						>
-							{{ greeting }}, {{ firstName }}
-						</h1>
-						<p
-							style="
-								font-size: 14.5px;
-								color: var(--text-2);
-								margin: 0 0 26px;
-								line-height: 1.5;
-							"
-						>
-							Ask about your ERP data, run a workflow, or draft something.
-							{{ agentName }}
-							is connected to your
-							<strong style="color: var(--text); font-weight: 600">ERPNext</strong>
-							instance.
-						</p>
-					</template>
-					<div
-						class="jv-welcome-grid"
+					<!-- Claude-style minimal new chat: the brand mark inline with the
+					     greeting, no hero copy or suggestion cards. -->
+					<h1
+						v-else
+						class="jv-welcome-h1"
 						style="
-							display: grid;
-							grid-template-columns: 1fr 1fr;
-							gap: 11px;
-							text-align: left;
+							display: flex;
+							align-items: center;
+							justify-content: center;
+							gap: 14px;
+							font-size: 32px;
+							font-weight: 640;
+							letter-spacing: -0.03em;
+							margin: 0;
+							overflow-wrap: anywhere;
 						"
 					>
-						<button
-							v-for="s in suggestions"
-							:key="s.title"
-							type="button"
-							class="jv-suggest"
-							@click="onWelcomeSuggestion(s)"
-							style="
-								display: flex;
-								gap: 11px;
-								padding: 14px;
-								background: var(--surface);
-								border: 1px solid var(--border);
-								border-radius: 10px;
-								cursor: pointer;
-								transition: border-color 0.12s, background 0.12s;
-								text-align: left;
-								font-family: inherit;
-								color: inherit;
-								width: 100%;
-							"
-						>
-							<div
-								:style="{
-									width: '30px',
-									height: '30px',
-									flex: 'none',
-									borderRadius: '8px',
-									background: s.bg,
-									color: s.fg,
-									display: 'flex',
-									alignItems: 'center',
-									justifyContent: 'center',
-								}"
-								v-html="s.icon"
-							></div>
-							<div>
-								<div
-									style="font-size: 13.5px; font-weight: 550; margin-bottom: 2px"
-								>
-									{{ s.title }}
-								</div>
-								<div
-									style="
-										font-size: 12.5px;
-										color: var(--text-3);
-										line-height: 1.4;
-									"
-								>
-									{{ s.prompt }}
-								</div>
-							</div>
-						</button>
-					</div>
+						<JarvisMark :size="34" :radius="10" style="flex: none" />
+						<span>{{ greeting }}, {{ firstName }}</span>
+					</h1>
 				</div>
 			</div>
 
@@ -1941,7 +1864,7 @@
 								paddingRight: '16px',
 								background: 'transparent',
 						  }
-						: { borderTop: '1px solid var(--border)' }
+						: { borderTop: 'none' }
 				"
 				style="
 					position: relative;
@@ -2867,7 +2790,7 @@
 					</Composer>
 				</div>
 			</div>
-			<div v-if="showWelcome" style="flex: 1"></div>
+			<div v-if="showWelcome" style="flex: 2"></div>
 		</main>
 
 		<!-- ============ PROACTIVE MESSAGE TOAST (Jarvis started a chat) ============ -->
@@ -4443,7 +4366,11 @@ const fullName = displayName(session.user);
 const firstName = computed(() => fullName.split(/\s+/)[0]);
 const greeting = computed(() => {
 	const h = new Date().getHours();
-	return h < 12 ? "Good morning" : h < 17 ? "Good afternoon" : "Good evening";
+	if (h < 5) return "Night";
+	if (h < 12) return "Morning";
+	if (h < 17) return "Afternoon";
+	if (h < 21) return "Evening";
+	return "Night";
 });
 // Empty override = "Auto": the backend falls back to Jarvis Settings.llm_model.
 const modelLabel = computed(() => modelOverride.value || "Auto");
@@ -4757,7 +4684,6 @@ const {
 	homeIntroSpeakerName,
 	initFromBoot: initHomeIntro,
 	ackHomeIntro,
-	noteSuggestionSelected: noteWelcomeSuggestion,
 } = useHomeIntro({
 	showWelcome,
 	booting,
@@ -4828,50 +4754,6 @@ const busy = computed(() => sending.value || waiting.value);
 // the whole run (unlike `waiting`, which clears at the first streamed token);
 // the button re-enables the instant the parent turn ends. #223 review.
 const convStreaming = computed(() => store.streamingConvId === currentId.value);
-
-const suggestions = [
-	{
-		category: "analyse",
-		title: "Analyse data",
-		prompt: "Which sales orders are overdue this month?",
-		bg: "var(--cta-bg)",
-		fg: "var(--cta)",
-		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M18 9l-5 5-3-3-4 4"/></svg>',
-	},
-	{
-		category: "action",
-		title: "Take an action",
-		prompt: "Draft a document for me to review",
-		bg: "var(--green-bg)",
-		fg: "var(--green)",
-		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>',
-	},
-	{
-		category: "search",
-		title: "Search records",
-		prompt: "Search for a customer or contact",
-		bg: "var(--amber-bg)",
-		fg: "var(--amber)",
-		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>',
-	},
-	{
-		category: "draft",
-		title: "Draft content",
-		prompt: "Write a follow-up email to a lead",
-		bg: "rgba(139,92,246,.12)",
-		fg: "#8b5cf6",
-		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>',
-	},
-];
-
-// A welcome suggestion card was chosen: record its category (a stable token,
-// never the prompt text) for the intro telemetry, then fill the composer. It
-// fills, never sends — the do-not-regress rule that a suggestion must not
-// auto-send is unchanged.
-function onWelcomeSuggestion(s) {
-	noteWelcomeSuggestion(s.category || s.title);
-	fillInput(s.prompt);
-}
 
 // Inline action blocks the agent emits: a rich ```jarvis-action JSON card (a doc
 // create/update confirm, or an email draft), or a simple ```confirm label as a
@@ -9090,10 +8972,6 @@ onUnmounted(() => {
 .jv-menuitem-danger:hover {
 	background: var(--red-bg);
 }
-.jv-suggest:hover {
-	border-color: var(--border-2);
-	background: var(--surface-1);
-}
 /* buttons invert to black/white on hover (theme-adaptive: black on light,
    white on dark) — var(--text)/var(--surface) flip, with an svg-stroke
    override so the icon stays visible on the inverted background.
@@ -9732,7 +9610,6 @@ onUnmounted(() => {
 	white-space: nowrap;
 }
 /* visible keyboard focus (UX #15) */
-.jv-suggest:focus-visible,
 .jv-iconbtn:focus-visible,
 .jv-retry:focus-visible,
 .jv-modelpill:focus-visible {
@@ -9769,13 +9646,17 @@ onUnmounted(() => {
    Named classes because inline styles cannot be overridden and the responsive tests
    need a stable target. */
 .jv-welcome-scroll {
-	flex: 1;
+	/* Hug the greeting (flex-grow 0) so the composer sits right under it instead
+	   of a tall centred region opening a big gap; still shrink + scroll if the
+	   first-run home intro is taller than the space between the spacers. */
+	flex: 0 1 auto;
+	min-height: 0;
 	overflow-y: auto;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: flex-start;
-	padding: 32px;
+	padding: 32px 32px 16px;
 }
 .jv-welcome-col {
 	width: 100%;
@@ -9800,9 +9681,6 @@ onUnmounted(() => {
 	   matching the 16px the thread/composer use. */
 	.jv-welcome-scroll {
 		padding: 24px 16px;
-	}
-	.jv-welcome-grid {
-		grid-template-columns: 1fr !important;
 	}
 	.jv-welcome-h1 {
 		font-size: 24px !important;

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -96,20 +96,21 @@
 						</svg>
 					</button>
 					<button
-						class="jvp-ib"
+						class="jvp-fullchat"
 						type="button"
-						aria-label="Open full chat"
+						aria-label="Open in full chat"
 						@click="$emit('open-full')"
 					>
+						<span>Full chat</span>
 						<svg
 							viewBox="0 0 24 24"
 							fill="none"
 							stroke="currentColor"
-							stroke-width="1.6"
+							stroke-width="1.7"
 							stroke-linecap="round"
 							stroke-linejoin="round"
 						>
-							<path d="M15 3h6v6M21 3l-7 7M10 21H4v-6M4 21l7-7" />
+							<path d="M7 17 17 7M8 7h9v9" />
 						</svg>
 					</button>
 					<button
@@ -542,6 +543,7 @@ import {
 	sendMessage,
 	stopRun,
 	confirmTool,
+	listPendingConfirmations,
 	uploadFile,
 	transcribeAudio,
 	getChatUiSettings,
@@ -803,6 +805,23 @@ async function load() {
 		}
 		const conv = await getConversation(convId.value);
 		messages.value = Array.isArray(conv?.messages) ? conv.messages : [];
+		// Resync open write confirmations. Without this a card raised while the
+		// panel was closed (or a dropped realtime frame) never shows here, even
+		// though the full chat has it. Best-effort: chat must work without it.
+		try {
+			const pc = await listPendingConfirmations(convId.value);
+			const rows = (pc && pc.data && pc.data.pending) || [];
+			stream.value = {
+				...stream.value,
+				pending: rows.map((r) => ({
+					token: r.token,
+					tool: r.tool || "",
+					summary: r.summary || r.preview || "",
+				})),
+			};
+		} catch (e) {
+			/* leave whatever the live stream captured */
+		}
 		pinnedToBottom.value = true;
 		await scrollToBottom();
 	} catch (e) {
@@ -1450,6 +1469,38 @@ defineExpose({ load, startNewChat, convId });
 .jvp-ib svg {
 	width: 16px;
 	height: 16px;
+}
+/* Highlighted "go to the full web chat" affordance. Replaces the old bare
+   maximize icon, which people did not notice: a labelled accent pill that fills
+   on hover, so the way out to the big chat reads at a glance. */
+.jvp-fullchat {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	height: 29px;
+	padding: 0 10px;
+	border: 1px solid var(--jv-accent);
+	border-radius: 8px;
+	background: transparent;
+	color: var(--jv-accent);
+	font: inherit;
+	font-size: 12.5px;
+	font-weight: 600;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: background-color 0.12s ease, color 0.12s ease;
+}
+.jvp-fullchat svg {
+	width: 14px;
+	height: 14px;
+}
+.jvp-fullchat:hover {
+	background: var(--jv-accent);
+	color: #fff;
+}
+.jvp-fullchat:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 2px;
 }
 .jvp-ib--sm {
 	width: 24px;

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -3,7 +3,7 @@
 	     page. Tapping it opens the side chat panel in place; on a narrow
 	     viewport (where a 400px panel would be most of the screen) it falls
 	     back to navigating to the chat SPA. -->
-	<div class="jvw-root" :class="{ 'jvw-root--dark': isDark }">
+	<div class="jvw-root" :class="{ 'jvw-root--dark': isDark, 'jvw-leaving': leaving }">
 		<button
 			type="button"
 			ref="fabEl"
@@ -99,6 +99,9 @@ const viewportTick = ref(0);
 // localStorage synchronously below so the first render already has it, and fed
 // to panelLayout, which floors it at the default and caps it to the viewport.
 const prefSize = ref(null);
+// Set true while the panel fades out just before we hand off to the full web
+// chat (resized-to-fullscreen), so the transition reads as one motion.
+const leaving = ref(false);
 const panelBox = computed(() => {
 	viewportTick.value; // re-run on resize / orientation change
 	const topInset = readCssPx(document.documentElement, "--navbar-height", 48);
@@ -118,6 +121,17 @@ function onPanelResize(size) {
 // Drag released: persist the choice per browser, mirroring the FAB position.
 function onPanelResizeCommit() {
 	if (!prefSize.value) return;
+	// Resized to (near) the whole screen: the mini panel is the wrong tool at
+	// that size, so hand off to the full web chat instead of persisting a panel
+	// that blankets the Desk. Fade the widget out first so it reads as one smooth
+	// motion into the SPA, and do NOT persist the fullscreen size (the panel
+	// should reopen at its normal size next time).
+	const box = panelBox.value;
+	if (box && box.width >= window.innerWidth * 0.9 && box.height >= window.innerHeight * 0.85) {
+		leaving.value = true;
+		setTimeout(openFull, 240);
+		return;
+	}
 	try {
 		localStorage.setItem(panelSize.STORAGE_KEY, panelSize.serializeSize(prefSize.value));
 	} catch (e) {
@@ -394,6 +408,18 @@ onBeforeUnmount(() => {
 	--accent-grad: linear-gradient(140deg, #8b7cf7, #6a56e8);
 	--jvw-safe-bottom: env(safe-area-inset-bottom, 0px);
 	font-family: "Inter", system-ui, -apple-system, sans-serif;
+}
+/* Fade the whole widget out as it hands off to the full web chat (resized to
+   fullscreen). Opacity cascades to the panel + FAB (neither is teleported). */
+.jvw-leaving {
+	opacity: 0;
+	transition: opacity 0.24s ease;
+	pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+	.jvw-leaving {
+		transition: none;
+	}
 }
 
 /* Follow the Desk theme. Frappe's theme switcher stamps data-theme="dark" on

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -94,6 +94,15 @@ export const stopRun = (conversation, runId) =>
 export const confirmTool = (token, conversation) =>
   call(ACTIONS + "confirm_tool", { token, conversation: conversation || "" });
 
+// Resync the still-open write confirmations for a conversation. The panel gets
+// live cards from the `action:pending` realtime frame, but a card raised while
+// the panel was CLOSED (or a dropped realtime tail) would otherwise never show —
+// so load() calls this to restore them. Returns {ok, data:{pending:[...]}}.
+export const listPendingConfirmations = (conversation) =>
+  call(ACTIONS + "list_pending_confirmations", {
+    conversation: conversation || "",
+  });
+
 // Chat-readiness verdict ({ready, reason, detail, billing_notice}) - see
 // panel_readiness.mjs for how the panel classifies it into gate/degraded/ready.
 export const isReadyForChat = () => call(ACCOUNT + "is_ready_for_chat");


### PR DESCRIPTION
## What
Post-merge UI polish across the customer chat surfaces: the full-SPA new chat, the Desk chat widget (the small chat), the persona picker, and the connect-phone QR.

## Changes
- **New chat (SPA):** restored the minimal, Claude-style empty state - the brand mark inline with the greeting, no hero copy and no suggestion cards. The first-run home intro stays as an invisible `v-if`, so brand-new users still get it once. Greeting reads Morning/Afternoon/Evening/Night; greeting + composer sit in the upper third with a tight gap; the separator line above the composer is gone. Dead suggestion code + CSS removed; source tripwires updated.
- **Persona picker:** copy no longer says "voice" (it changes tone, not tools or answers).
- **Desk chat widget:** confirmations resync on load (`list_pending_confirmations`), so a Confirm card raised while the panel was closed (or a dropped realtime tail) reappears instead of being lost. The unnoticed maximize icon is replaced with a highlighted "Full chat" pill. Resizing the panel to (near) the whole screen fades it out and hands off to the full web chat.
- **Mobile QR:** dropped the raw URL printed under the connect-phone QR (the QR already encodes it).

## Tests
- Frontend vitest: **749 passing** (incl. the updated new-chat source tripwires).
- Desk widget node:test: **123 passing**.

## Deploy note
Rebuild before serving:
- SPA: `cd frontend && npm run build`
- Desk widget bundle: `bench build --app jarvis`
