### PR TITLE
fix(onboarding): the replaced-site banner must land on reconnect, not a dead end

### DIFF
--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -236,9 +236,12 @@ const TABLE = {
 	},
 	[CODES.BENCH_ADMIN_AUTH_FAILED]: {
 		headline: "This site could not sign in to your account.",
-		body: "Your payment is not affected. We need to look at this with you.",
+		// Reconnect FIRST: the usual cause is the account being reconnected on
+		// another site, which rotates the key this one holds. Reconnect is a guest
+		// call, so it still works from a bench that cannot sign in.
+		body: "Your payment is not affected. If you reconnected your account on another site, reconnect this one to bring it back.",
 		tone: TONE.ALERT,
-		actions: [ACTIONS.SUPPORT],
+		actions: [ACTIONS.RECONNECT, ACTIONS.SUPPORT],
 	},
 	[CODES.BENCH_ADMIN_REJECTED]: {
 		headline: "The payment service refused this request.",

--- a/frontend/src/onboarding/paymentCodes.test.js
+++ b/frontend/src/onboarding/paymentCodes.test.js
@@ -128,3 +128,12 @@ test("an unheard-of code falls back to the honest unknown row", () => {
 	assert.equal(entry, UNKNOWN_COPY);
 	assert.ok(entry.actions.includes(ACTIONS.CHECK));
 });
+
+test("a bench that cannot sign in is offered the reconnect that fixes it", () => {
+	// Reconnecting the account on another site rotates the key THIS one holds, so
+	// the remedy is a reconnect - and it is a guest call, reachable without the
+	// credentials that just stopped working. Support stays as the fallback.
+	const entry = copyFor(CODES.BENCH_ADMIN_AUTH_FAILED);
+	assert.equal(entry.actions[0], ACTIONS.RECONNECT, "reconnect is the primary action");
+	assert.ok(entry.actions.includes(ACTIONS.SUPPORT));
+});

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -110,6 +110,13 @@ export async function replacedNoticeOf() {
 // and a site whose key was rotated away dead-ends at "could not sign in".
 export const RECONNECT_INTENT_URL = "/jarvis/onboarding?reconnect=1";
 
+// Which step the wizard opens on. Explicit reconnect intent beats a resumed
+// step, but never a paid/provisioning one - somebody already set up is not
+// reconnecting.
+export function landingStep({ intent, resumedStep, terminal }) {
+	return intent && !terminal ? "details" : resumedStep;
+}
+
 export function hasReconnectIntent(search) {
 	try {
 		return new URLSearchParams(search || "").get("reconnect") === "1";

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -105,6 +105,19 @@ export async function replacedNoticeOf() {
 	return r.replaced_notice || { replaced: true };
 }
 
+// Where that banner's action sends the customer, and how the wizard recognises it.
+// One constant for both ends: without the flag the wizard resumes its own path,
+// and a site whose key was rotated away dead-ends at "could not sign in".
+export const RECONNECT_INTENT_URL = "/jarvis/onboarding?reconnect=1";
+
+export function hasReconnectIntent(search) {
+	try {
+		return new URLSearchParams(search || "").get("reconnect") === "1";
+	} catch {
+		return false;
+	}
+}
+
 // Copy for that banner. `moved_to` is the site now holding the account - both
 // belong to the same account holder, so naming it is what makes this actionable.
 export function replacedBanner(notice) {

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -9,9 +9,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const isReadyForChat = vi.fn();
 vi.mock("@/api.js", () => ({ isReadyForChat: (...a) => isReadyForChat(...a) }));
 
-const { readinessDetailOf, needsLlmConnection, forgetReady, replacedBanner } = await import(
-	"./readiness.js"
-);
+const {
+	readinessDetailOf,
+	needsLlmConnection,
+	forgetReady,
+	replacedBanner,
+	hasReconnectIntent,
+	RECONNECT_INTENT_URL,
+} = await import("./readiness.js");
 
 // The verdict is memoized for the page load, so every case has to start clean.
 beforeEach(() => {
@@ -151,5 +156,20 @@ describe("replaced-site banner", () => {
 		expect(replacedBanner({})).toBeNull();
 		expect(replacedBanner(null)).toBeNull();
 		expect(replacedBanner({ replaced: false })).toBeNull();
+	});
+});
+
+describe("reconnect intent", () => {
+	it("recognises only the flag the banner actually sends", () => {
+		expect(hasReconnectIntent(new URL(RECONNECT_INTENT_URL, "http://x").search)).toBe(true);
+		expect(hasReconnectIntent("?reconnect=1&foo=bar")).toBe(true);
+		expect(hasReconnectIntent("?reconnect=0")).toBe(false);
+		expect(hasReconnectIntent("?other=1")).toBe(false);
+	});
+
+	it("treats missing or unparseable input as no intent", () => {
+		expect(hasReconnectIntent("")).toBe(false);
+		expect(hasReconnectIntent(null)).toBe(false);
+		expect(hasReconnectIntent(undefined)).toBe(false);
 	});
 });

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -15,6 +15,7 @@ const {
 	forgetReady,
 	replacedBanner,
 	hasReconnectIntent,
+	landingStep,
 	RECONNECT_INTENT_URL,
 } = await import("./readiness.js");
 
@@ -171,5 +172,27 @@ describe("reconnect intent", () => {
 		expect(hasReconnectIntent("")).toBe(false);
 		expect(hasReconnectIntent(null)).toBe(false);
 		expect(hasReconnectIntent(undefined)).toBe(false);
+	});
+});
+
+describe("landing step", () => {
+	it("sends a reconnect intent to the step that carries the offer", () => {
+		expect(landingStep({ intent: true, resumedStep: "pay", terminal: false })).toBe("details");
+		expect(landingStep({ intent: true, resumedStep: "intro", terminal: false })).toBe(
+			"details"
+		);
+	});
+
+	it("leaves the resumed step alone without the intent", () => {
+		expect(landingStep({ intent: false, resumedStep: "pay", terminal: false })).toBe("pay");
+		expect(landingStep({ intent: false, resumedStep: "intro", terminal: false })).toBe(
+			"intro"
+		);
+	});
+
+	it("never drags a paid or provisioning signup into reconnect", () => {
+		expect(landingStep({ intent: true, resumedStep: "connect", terminal: true })).toBe(
+			"connect"
+		);
 	});
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3569,7 +3569,12 @@ import {
 } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
-import { billingNoticeOf, replacedNoticeOf, replacedBanner } from "@/onboarding/readiness.js";
+import {
+	billingNoticeOf,
+	replacedNoticeOf,
+	replacedBanner,
+	RECONNECT_INTENT_URL,
+} from "@/onboarding/readiness.js";
 import { useShellStore } from "@/stores/shell";
 import { useJarvisTheme } from "@/theme";
 import { displayName } from "@/lib/user";
@@ -3669,8 +3674,10 @@ const replacedNotice = ref({});
 const replacedAlert = computed(() => replacedBanner(replacedNotice.value));
 function goReconnect() {
 	// The wizard owns the reconnect flow; land on it rather than duplicating the
-	// code-entry screen here.
-	window.location.assign("/jarvis/onboarding");
+	// code-entry screen here. The flag matters: without it the wizard resumes down
+	// its own path, and a site whose key was rotated away fails to sign in and
+	// lands on a support-only card instead of the reconnect it was sent for.
+	window.location.assign(RECONNECT_INTENT_URL);
 }
 const billingDismissedPhase = ref("");
 // Renewing is gated on require_jarvis_admin(), which accepts Jarvis Admin OR

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -51,7 +51,15 @@ const routerReplace = vi.hoisted(() => vi.fn());
 vi.mock("vue-router", () => ({ useRouter: () => ({ replace: routerReplace }) }));
 
 const forgetReadySpy = vi.hoisted(() => vi.fn());
-vi.mock("@/onboarding/readiness.js", () => ({ forgetReady: forgetReadySpy }));
+// These specs assert the CONNECT step, so there is never a reconnect intent here:
+// the landing helpers are stubbed to "no intent, keep the resumed step". Mocked
+// explicitly rather than via importOriginal so the real module's graph (api.js ->
+// frappe-ui) stays out of this file.
+vi.mock("@/onboarding/readiness.js", () => ({
+	forgetReady: forgetReadySpy,
+	hasReconnectIntent: () => false,
+	landingStep: ({ resumedStep }) => resumedStep,
+}));
 
 vi.mock("@/theme", () => ({
 	useJarvisTheme: () => ({ effectiveDark: false, paletteVars: {} }),

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1088,7 +1088,7 @@ import {
 	operationStore,
 	OP_PHASE,
 } from "@/lib/llmOperation.js";
-import { forgetReady, hasReconnectIntent } from "@/onboarding/readiness.js";
+import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
@@ -2753,10 +2753,14 @@ onMounted(async () => {
 	// AFTER the resumes: they set state.step from persisted signup state, and the
 	// customer's explicit intent has to win over that. Never overrides a finished
 	// signup - somebody already paid and provisioned is not reconnecting.
-	if (hasReconnectIntent(window.location.search) && !isTerminalForPayment(pay.value.value)) {
-		state.reconnectIntent = true;
-		state.step = "details";
-	}
+	const intent = hasReconnectIntent(window.location.search);
+	const landing = landingStep({
+		intent,
+		resumedStep: state.step,
+		terminal: isTerminalForPayment(pay.value.value),
+	});
+	state.reconnectIntent = intent && landing === "details";
+	state.step = landing;
 	// Prefetch the plan catalog behind the intro tour so the Plan step rarely
 	// first-paints in its loading state. Reconciled resumes land past "plan"
 	// and skip it (the step-entry watch still covers every other path).

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -320,6 +320,13 @@
 								/>
 							</div>
 							<p
+								v-if="state.reconnectIntent && !canReconnect"
+								class="mx-auto mt-5 max-w-[620px] text-center text-p-sm text-ink-gray-5"
+							>
+								Enter the email and company this account was registered with, and
+								the reconnect option will appear here.
+							</p>
+							<p
 								v-if="canReconnect"
 								class="mx-auto mt-5 max-w-[620px] text-center text-p-sm text-ink-gray-5"
 							>
@@ -1081,12 +1088,16 @@ import {
 	operationStore,
 	OP_PHASE,
 } from "@/lib/llmOperation.js";
-import { forgetReady } from "@/onboarding/readiness.js";
+import { forgetReady, hasReconnectIntent } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
 import { createPaymentFlow } from "@/onboarding/usePaymentFlow";
-import { STATES as PAY_STATES, remainingCooldownSeconds } from "@/onboarding/paymentMachine";
+import {
+	STATES as PAY_STATES,
+	remainingCooldownSeconds,
+	isTerminalForPayment,
+} from "@/onboarding/paymentMachine";
 import { ACTIONS, ACTION_LABELS, TONE, copyFor } from "@/onboarding/paymentCodes";
 import { CHECKOUT_NAV_KEY, shouldHonorCheckoutReturn } from "@/onboarding/checkoutNav";
 import { makeTelemetryReporter } from "@/onboarding/paymentTelemetry";
@@ -1151,6 +1162,9 @@ const state = reactive({
 	// card's local choices only.
 	reconnectRequestId: "",
 	reconnectFrom: "",
+	// Arrived from the chat banner: the fields are prefilled from the SITE, which
+	// need not be the account, so say what to type when the offer stays hidden.
+	reconnectIntent: false,
 	reconnectEligible: false,
 	reconnectNeedsCompany: false,
 	reconnectCode: "",
@@ -2736,6 +2750,13 @@ onMounted(async () => {
 	// Resume an apply that was in flight when the page was last closed/reloaded: follow
 	// the SAME operation rather than showing an editable form over a running one (P1-05).
 	await maybeResumeConnect();
+	// AFTER the resumes: they set state.step from persisted signup state, and the
+	// customer's explicit intent has to win over that. Never overrides a finished
+	// signup - somebody already paid and provisioned is not reconnecting.
+	if (hasReconnectIntent(window.location.search) && !isTerminalForPayment(pay.value.value)) {
+		state.reconnectIntent = true;
+		state.step = "details";
+	}
 	// Prefetch the plan catalog behind the intro tour so the Plan step rarely
 	// first-paints in its loading state. Reconciled resumes land past "plan"
 	// and skip it (the step-entry watch still covers every other path).


### PR DESCRIPTION
## Reported

> I used the reconnect option on my new site to connect it with the same user and company. But the older site shows an option to "reconnect to this site" — it takes me to the onboarding page where it says *This site could not sign in to your account.* There should be an option to reconnect, right?

Yes. Right now that path cannot reach reconnect at all.

## Why

Reconnecting on the new site rotates the credentials the OLD site holds — that's deliberate, it's how the dead bench gets signed out. The old site correctly detects this and shows the banner *"This site no longer has access to your workspace → Reconnect this site instead"*.

But the button did:

```js
window.location.assign("/jarvis/onboarding");
```

No intent. So the wizard resumed its own path, tried to sign in with the rotated key, and rendered `BENCH_ADMIN_AUTH_FAILED` — whose only action is **Contact support**. The one screen that promised a reconnect was the one screen that couldn't offer it.

## Fix

**1. The banner deep-links the intent.** `?reconnect=1`, and the wizard lands on **Details** — the step carrying the reconnect offer. Applied *after* the resume calls so explicit intent beats persisted signup state, and never over a paid/provisioning state (somebody already set up is not reconnecting).

**2. `BENCH_ADMIN_AUTH_FAILED` offers reconnect first, support second.** Reconnect is a guest call, so it works from a bench that cannot sign in — which is exactly what this code means. The body now names the cause instead of "we need to look at this with you".

**3. Details says which identity to type.** The replacement receipt deliberately stores no account data (guest endpoint keyed by a URL hash — `check_site_replaced`), so the wizard cannot prefill the account's email; the fields come from the SITE and may differ. When the eligibility probe therefore keeps the offer hidden, the step now says what to enter rather than showing an unexplained form.

The URL and its reader live together in `readiness.js` so the two ends can't drift.

## Tests

- `readiness.spec.js` — intent parsing, including the exact URL the banner sends and the near-misses (`?reconnect=0`, absent, unparseable).
- `paymentCodes.test.js` — the auth-failed row offers RECONNECT first and keeps SUPPORT.

72 vitest + 131 node tests green.

## Not verified in a browser

The Chrome extension wasn't connected on this machine today, so I could not click the banner through to the wizard. The parsing and the copy table are unit-tested; the landing itself (`state.step = "details"` on mount) is verified by reading, not by observation. Worth one manual pass on the replaced site before merge.