### PR TITLE
fix(wiki): serialise mirror syncs so a full prune cannot delete a live file

### DIFF
--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -54,9 +54,20 @@ JOB_TIMEOUT_S = 120
 _LOCK_NAME = "jarvis_wiki_mirror"
 # Longer than the RQ deadline, so a crashed holder's key always expires on its own.
 _LOCK_TTL_S = JOB_TIMEOUT_S + 30
-# Willing to WAIT rather than skip: dropping the work is what strands a change, since
-# there is no periodic sweep to pick it up later (see ``sync``).
-_LOCK_WAIT_S = 15.0
+# WAITING is the primary resolution, not a fallback. A job that waits and then acquires
+# re-reads the page table itself, so its own change is in the snapshot and nothing is
+# lost. Sized to leave headroom inside JOB_TIMEOUT_S for the sync that follows, so
+# contention almost always resolves here rather than on the re-queue path below.
+_LOCK_WAIT_S = 75.0
+# Re-queue ids, DISTINCT from JOB_ID / JOB_ID_FULL on purpose. frappe.enqueue's
+# deduplicate=True declines a job whose id is already QUEUED or STARTED
+# (background_jobs.py: "Not queueing job ... because it is in queue already"), and a
+# contended worker is itself STARTED under its own id - so re-queueing under that id is
+# silently declined and the work is dropped, which is the failure this whole change
+# exists to prevent. A separate id is a different dedup slot, so the retry is really
+# queued while still being deduped against other retries.
+JOB_ID_RETRY = "wiki-mirror-sync-retry"
+JOB_ID_FULL_RETRY = "wiki-mirror-sync-full-retry"
 
 # fleet-agent hard-caps request bodies at 256KB; keep each push call's b64
 # file payload comfortably under it.
@@ -309,32 +320,51 @@ def sync(full: bool = False) -> dict:
 	current, which surfaces as a wiki file silently vanishing from the container with
 	no error anywhere.
 
-	A contended call RE-QUEUES rather than skipping. Skipping looks safe because a FULL
-	sync pushes every file anyway, but an incremental skipped while another INCREMENTAL
-	holds the lock has its page change stranded: the holder's snapshot may predate that
-	change and there is no periodic sweep to pick it up (see ``enqueue_sync``). The
-	re-queue cannot pile up because ``enqueue_sync`` dedupes on the two job ids."""
+	Contention is resolved by WAITING, which is the important part: a job that waits and
+	then acquires re-reads the page table itself, so its own change is in the snapshot
+	and nothing is lost. Only a wait that times out falls back to a re-queue, and that
+	re-queue uses a DISTINCT job id (see ``JOB_ID_RETRY``) because Frappe declines a
+	dedup-enqueue under an id that is already STARTED, which a contended worker's own id
+	always is. Dropping the work is not an option: there is no periodic sweep to pick a
+	stranded change up later (see ``enqueue_sync``).
+
+	A real Redis fault is re-queued too, not just logged. ``redis_lock`` propagates those
+	rather than yielding False, and treating one as a plain crash would strand the page
+	edit that triggered the job for exactly the same reason."""
 	from jarvis._redis_lock import redis_lock
 
 	try:
 		with redis_lock(_LOCK_NAME, timeout_s=_LOCK_TTL_S, blocking_timeout_s=_LOCK_WAIT_S) as acquired:
-			if not acquired:
-				enqueue_sync(full=bool(full))
-				# "skipped" keeps _stamp_sync_status from overwriting the Wiki tab's
-				# "last synced" line with a failure that did not happen.
-				result = {
-					"ok": False,
-					"skipped": True,
-					"requeued": True,
-					"reason": "another sync in flight; re-queued",
-				}
-			else:
+			if acquired:
 				result = _sync(full=bool(full))
+			else:
+				result = _requeue_contended(full=bool(full), why="another sync still in flight")
 	except Exception:
 		frappe.log_error(title="wiki mirror: sync crashed", message=frappe.get_traceback())
-		result = {"ok": False, "reason": "sync crashed; see Error Log"}
+		# A fault reaching here may be the lock itself (redis_lock propagates real Redis
+		# errors by design), in which case _sync never ran and the change is unpushed.
+		# Re-queue rather than let it strand; the retry id makes this safe to repeat.
+		result = _requeue_contended(full=bool(full), why="sync crashed; see Error Log")
 	_stamp_sync_status(result)
 	return result
+
+
+def _requeue_contended(full: bool, why: str) -> dict:
+	"""Re-queue a sync that could not run, under the RETRY job id.
+
+	Returns the result dict the caller reports. ``requeued`` reflects what actually
+	happened rather than what was attempted: ``enqueue_sync`` swallows enqueue failures
+	(Redis down), and a result that claims a re-queue which never occurred is worse than
+	one that admits it, because nothing else will come back for this change."""
+	queued = enqueue_sync(full=full, retry=True)
+	# "skipped" keeps _stamp_sync_status from overwriting the Wiki tab's "last synced"
+	# line with a failure that did not happen, but only when the retry is really pending.
+	return {
+		"ok": False,
+		"skipped": bool(queued),
+		"requeued": bool(queued),
+		"reason": f"{why}; {'re-queued' if queued else 'RE-QUEUE FAILED, change may be unpushed'}",
+	}
 
 
 def _stamp_sync_status(result: dict) -> None:
@@ -472,11 +502,14 @@ def _chunk_files(files: list[dict]) -> list[list[dict]]:
 # --------------------------------------------------------------------------- #
 # triggers
 # --------------------------------------------------------------------------- #
-def enqueue_sync(full: bool = False, after_commit: bool = False) -> None:
+def enqueue_sync(full: bool = False, after_commit: bool = False, retry: bool = False) -> bool:
 	"""Queue the deduped mirror sync (short queue, 120s deadline). Suppressed
 	under tests unless ``frappe.flags.jarvis_test_wiki_mirror_enqueue`` is set
 	— fixture inserts must not spray RQ jobs. Enqueue failures (Redis down)
 	are swallowed: this runs inside user save paths via doc_events.
+
+	Returns whether a job was really queued, so a caller that depends on the retry
+	actually existing can say so honestly instead of assuming.
 
 	``after_commit`` is what the doc_events trigger needs and what the manual
 	endpoint must not use. The worker opens its own DB connection, so a job
@@ -484,21 +517,34 @@ def enqueue_sync(full: bool = False, after_commit: bool = False) -> None:
 	and report success — and with no periodic sweep, a prune lost that way is
 	lost for good. Deferring to the save's commit closes that window. The
 	manual "Sync now" endpoint writes nothing, so its request may never commit
-	and deferring there would drop the job entirely."""
+	and deferring there would drop the job entirely.
+
+	``retry=True`` uses the RETRY job ids. A contended worker re-queueing itself must
+	NOT reuse its own id: ``frappe.enqueue`` with ``deduplicate=True`` declines a job
+	whose id is already QUEUED or STARTED (background_jobs.py:119-125), and the caller
+	is itself STARTED under that id, so the enqueue is silently skipped and the work is
+	dropped. A separate id is a separate dedup slot, so the retry is really queued while
+	still being deduped against other retries."""
 	if frappe.flags.in_test and not frappe.flags.jarvis_test_wiki_mirror_enqueue:
-		return
+		return False
+	if retry:
+		job_id = JOB_ID_FULL_RETRY if full else JOB_ID_RETRY
+	else:
+		job_id = JOB_ID_FULL if full else JOB_ID
 	try:
 		frappe.enqueue(
 			JOB_METHOD,
 			queue=QUEUE,
 			timeout=JOB_TIMEOUT_S,
-			job_id=JOB_ID_FULL if full else JOB_ID,
+			job_id=job_id,
 			deduplicate=True,
 			enqueue_after_commit=bool(after_commit),
 			full=bool(full),
 		)
+		return True
 	except Exception:
 		frappe.log_error(title="wiki mirror: enqueue failed", message=frappe.get_traceback())
+		return False
 
 
 def on_wiki_page_change(doc, method: str | None = None) -> None:

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -46,6 +46,18 @@ JOB_ID_FULL = "wiki-mirror-sync-full"
 QUEUE = "short"
 JOB_TIMEOUT_S = 120
 
+# #622: one mirror sync at a time per bench. The two JOB_IDs above deliberately let an
+# incremental and a FULL sync be QUEUED at once; this serialises their EXECUTION, which
+# is the part that matters. ``_sync`` derives ``known_paths`` from a snapshot taken at
+# its top but the prune only executes on the LAST push, so a file an incremental writes
+# in between is missing from that list and gets pruned even though it is current.
+_LOCK_NAME = "jarvis_wiki_mirror"
+# Longer than the RQ deadline, so a crashed holder's key always expires on its own.
+_LOCK_TTL_S = JOB_TIMEOUT_S + 30
+# Willing to WAIT rather than skip: dropping the work is what strands a change, since
+# there is no periodic sweep to pick it up later (see ``sync``).
+_LOCK_WAIT_S = 15.0
+
 # fleet-agent hard-caps request bodies at 256KB; keep each push call's b64
 # file payload comfortably under it.
 MAX_CALL_PAYLOAD_BYTES = 200 * 1024
@@ -288,9 +300,36 @@ def sync(full: bool = False) -> dict:
 	sha256 diff; ``full`` bypasses the diff so a wiped container rebuilds),
 	delete archived pages' files, always re-send index.md + log.md, and on
 	``full`` send ``known_paths`` so the fleet prunes strays (trashed pages,
-	type/dir moves). Returns a summary dict; NEVER raises into callers."""
+	type/dir moves). Returns a summary dict; NEVER raises into callers.
+
+	#622: serialised per bench. ``_sync`` reads the page table once at its top and
+	derives ``known_paths`` from that snapshot, but the prune only runs on the final
+	push, after every render, hash and earlier batch. A page an incremental sync wrote
+	inside that window is absent from the list and gets pruned even though it is
+	current, which surfaces as a wiki file silently vanishing from the container with
+	no error anywhere.
+
+	A contended call RE-QUEUES rather than skipping. Skipping looks safe because a FULL
+	sync pushes every file anyway, but an incremental skipped while another INCREMENTAL
+	holds the lock has its page change stranded: the holder's snapshot may predate that
+	change and there is no periodic sweep to pick it up (see ``enqueue_sync``). The
+	re-queue cannot pile up because ``enqueue_sync`` dedupes on the two job ids."""
+	from jarvis._redis_lock import redis_lock
+
 	try:
-		result = _sync(full=bool(full))
+		with redis_lock(_LOCK_NAME, timeout_s=_LOCK_TTL_S, blocking_timeout_s=_LOCK_WAIT_S) as acquired:
+			if not acquired:
+				enqueue_sync(full=bool(full))
+				# "skipped" keeps _stamp_sync_status from overwriting the Wiki tab's
+				# "last synced" line with a failure that did not happen.
+				result = {
+					"ok": False,
+					"skipped": True,
+					"requeued": True,
+					"reason": "another sync in flight; re-queued",
+				}
+			else:
+				result = _sync(full=bool(full))
 	except Exception:
 		frappe.log_error(title="wiki mirror: sync crashed", message=frappe.get_traceback())
 		result = {"ok": False, "reason": "sync crashed; see Error Log"}

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -604,11 +604,87 @@ class TestSyncSerialisation(WikiMirrorTestCase):
 		with (
 			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
 			mock.patch.object(wiki_mirror, "_sync"),
-			mock.patch.object(wiki_mirror, "enqueue_sync"),
+			mock.patch.object(wiki_mirror, "enqueue_sync", return_value=True),
 			mock.patch.object(wiki_mirror, "_stamp_sync_status", wraps=wiki_mirror._stamp_sync_status),
 		):
 			out = wiki_mirror.sync()
 		self.assertTrue(out.get("skipped"), "the skipped flag is what silences the status stamp")
+
+	# ---- the retry must use a DIFFERENT job id, or it is silently declined -------- #
+
+	@contextlib.contextmanager
+	def _real_enqueue(self):
+		"""Patch frappe.enqueue itself, NOT enqueue_sync, so the job_id is exercised."""
+		frappe.flags.jarvis_test_wiki_mirror_enqueue = True
+		try:
+			with mock.patch.object(frappe, "enqueue") as enq:
+				yield enq
+		finally:
+			frappe.flags.jarvis_test_wiki_mirror_enqueue = False
+
+	def test_the_retry_does_not_reuse_the_running_jobs_id(self):
+		"""THE bug the first cut of this fix shipped with. ``frappe.enqueue`` with
+		``deduplicate=True`` declines a job whose id is already QUEUED or STARTED
+		(background_jobs.py: "Not queueing job ... because it is in queue already"), and a
+		contended worker is itself STARTED under its own id. Re-queueing under that id was
+		therefore silently skipped and the work dropped, while the result still claimed
+		``requeued: True``.
+
+		Patched at ``frappe.enqueue`` on purpose: mocking ``enqueue_sync``, as the earlier
+		tests here do, cannot see the job id at all, which is exactly why this shipped
+		green."""
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync"),
+			self._real_enqueue() as enq,
+		):
+			wiki_mirror.sync()
+		job_id = enq.call_args.kwargs["job_id"]
+		self.assertEqual(job_id, wiki_mirror.JOB_ID_RETRY)
+		self.assertNotEqual(job_id, wiki_mirror.JOB_ID, "the retry must not collide with the running job")
+
+	def test_the_full_retry_uses_the_full_retry_id(self):
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync"),
+			self._real_enqueue() as enq,
+		):
+			wiki_mirror.sync(full=True)
+		self.assertEqual(enq.call_args.kwargs["job_id"], wiki_mirror.JOB_ID_FULL_RETRY)
+		self.assertTrue(enq.call_args.kwargs["full"], "a prune request must not downgrade")
+
+	def test_a_redis_fault_is_requeued_not_just_logged(self):
+		"""``redis_lock`` propagates real Redis errors rather than yielding False, so a
+		cache blip used to land in the generic handler and be reported as "sync crashed"
+		with no re-queue, stranding the page edit for the same reason as #622 itself."""
+
+		@contextlib.contextmanager
+		def _lock_explodes(*a, **k):
+			raise RuntimeError("redis gone")
+			yield  # pragma: no cover
+
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", _lock_explodes),
+			mock.patch.object(wiki_mirror, "_sync"),
+			mock.patch.object(wiki_mirror, "enqueue_sync", return_value=True) as enq,
+		):
+			out = wiki_mirror.sync()
+		self.assertTrue(enq.called, "a lock fault must still re-queue the work")
+		self.assertTrue(out.get("requeued"))
+
+	def test_a_failed_requeue_is_reported_honestly(self):
+		"""``enqueue_sync`` swallows enqueue failures (Redis down). Claiming a re-queue
+		that never happened is worse than admitting it: nothing else comes back for this
+		change."""
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync"),
+			mock.patch.object(wiki_mirror, "enqueue_sync", return_value=False),
+		):
+			out = wiki_mirror.sync()
+		self.assertFalse(out.get("requeued"))
+		self.assertFalse(out.get("skipped"), "a lost change must reach the status line")
+		self.assertIn("RE-QUEUE FAILED", out["reason"])
 
 	def test_an_uncontended_sync_still_syncs(self):
 		"""Control: the lock must not change the ordinary path."""

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -548,6 +548,77 @@ class TestSync(WikiMirrorTestCase):
 # --------------------------------------------------------------------------- #
 # triggers
 # --------------------------------------------------------------------------- #
+class TestSyncSerialisation(WikiMirrorTestCase):
+	"""#622: ``_sync`` derives ``known_paths`` from a snapshot taken at its top, but the
+	prune only executes on the final push, after every render, hash and earlier batch. A
+	page an incremental sync wrote inside that window is absent from the list and is
+	pruned even though it is current, which shows up as a wiki file silently vanishing
+	from the container with no error anywhere.
+
+	The two JOB_IDs deliberately let an incremental and a FULL sync be QUEUED at once, so
+	nothing serialised their EXECUTION before this."""
+
+	@contextlib.contextmanager
+	def _lock_denied(self, *a, **k):
+		"""Stand-in for redis_lock that never grants (another sync is in flight)."""
+		yield False
+
+	def test_a_contended_sync_does_not_run(self):
+		self._page("acme")
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync") as inner,
+			mock.patch.object(wiki_mirror, "enqueue_sync"),
+		):
+			out = wiki_mirror.sync()
+		self.assertFalse(inner.called, "a second sync must not walk the pages concurrently")
+		self.assertFalse(out["ok"])
+		self.assertTrue(out.get("requeued"))
+
+	def test_a_contended_sync_requeues_instead_of_dropping(self):
+		"""Skipping looks safe because a FULL sync pushes everything anyway, but an
+		incremental skipped while another INCREMENTAL holds the lock has its page change
+		stranded: the holder's snapshot may predate it and there is no periodic sweep."""
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync"),
+			mock.patch.object(wiki_mirror, "enqueue_sync") as enq,
+		):
+			wiki_mirror.sync()
+		self.assertTrue(enq.called, "contended work must be re-queued, never dropped")
+
+	def test_a_contended_full_sync_requeues_as_full(self):
+		"""A prune request must not be downgraded to an incremental: only a FULL sync
+		sends known_paths, so a downgrade would silently lose the prune."""
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync"),
+			mock.patch.object(wiki_mirror, "enqueue_sync") as enq,
+		):
+			wiki_mirror.sync(full=True)
+		self.assertTrue(enq.call_args.kwargs.get("full"), "the FULL flag must survive the re-queue")
+
+	def test_a_contended_sync_does_not_overwrite_the_last_synced_line(self):
+		"""``skipped`` keeps _stamp_sync_status quiet, so the Wiki tab does not report a
+		failure that did not happen."""
+		with (
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_sync"),
+			mock.patch.object(wiki_mirror, "enqueue_sync"),
+			mock.patch.object(wiki_mirror, "_stamp_sync_status", wraps=wiki_mirror._stamp_sync_status),
+		):
+			out = wiki_mirror.sync()
+		self.assertTrue(out.get("skipped"), "the skipped flag is what silences the status stamp")
+
+	def test_an_uncontended_sync_still_syncs(self):
+		"""Control: the lock must not change the ordinary path."""
+		doc = self._page("acme")
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		self.assertIn(f"customers/{doc.name}.md", self._pushed_paths(push))
+
+
 class TestTriggers(WikiMirrorTestCase):
 	def test_doc_event_triggers_only_for_org_scope(self):
 		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:


### PR DESCRIPTION
Closes #622

A full sync could delete a wiki file that was current, silently.

`_sync` reads the page table once at its top and derives `known_paths` from that snapshot, but the prune only executes on the **last** push, after every render, every sha256, the chunking, and each earlier batch's round trip. On a large wiki that window is seconds to tens of seconds. Any page an incremental sync writes inside it is absent from `known_paths`, so the fleet endpoint deletes it.

The symptom is nasty to trace: a file vanishes from the tenant's container with no error anywhere, and the next edit to that page restores it. So it presents as "the agent could not see a page it should have known about".

<details>
<summary>Why it was reachable at all</summary>

Two properties combine.

The two job ids are separate **on purpose**, "so a queued incremental sync can't swallow a requested FULL sync". That is the right call for enqueueing, but it means nothing serialised their **execution**.

And there is no periodic sweep. The module says so twice, in the class docstring and again in `enqueue_sync`: "with no periodic sweep, a prune lost that way is lost for good". So a wrongly pruned file stays gone until that page happens to be edited again.

#491's fix widened the window rather than causing it, by enqueuing full syncs in cases that previously enqueued none.
</details>

## Approach

`sync()` now holds a bench-wide advisory lock for both job kinds, using the `_redis_lock` primitive two other call sites already use.

I chose this over the issue's other suggestion, re-reading `known_paths` immediately before the push. That shrinks the window but does not close it: a gap remains between the re-read and the server-side prune.

**The contended path re-queues rather than skipping**, and that distinction is the subtle part. Skipping looks safe, because a FULL sync pushes every file regardless of hash. But an incremental skipped while another **incremental** holds the lock has its page change stranded: the holder's snapshot may predate that change, and nothing sweeps later to catch it. `enqueue_sync` dedupes on the two job ids, so re-queueing cannot pile up.

The result carries `skipped=True`, which keeps `_stamp_sync_status` from overwriting the Wiki tab's "last synced" line with a failure that did not happen.

## Tests

`TestSyncSerialisation`, five cases:

- a contended sync does not walk the pages concurrently
- it re-queues instead of dropping the work
- a contended **full** sync re-queues as full, since only a full sync sends `known_paths` and a downgrade would silently lose the prune
- it does not stamp the status line
- control: the uncontended path is unchanged

Verified locally: `pre-commit` clean on both files.

## Not addressed here

The issue's second note, that nothing alarms if the RQ worker is down so a queued sync that never runs looks identical to one that succeeded, is a separate observability gap. It wants its own issue rather than being folded into a concurrency fix.
