### PR TITLE
fix(agents): never re-dispatch a slot whose launch already succeeded

### DIFF
--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -234,6 +234,26 @@ def _sweep_one(row, now, original_user: str, seen: set) -> None:
 		_advance(row, now)
 		return
 
+	# #652: idempotency at DISPATCH, which is the only place it actually holds.
+	# ``_launch_audit`` commits its ``running`` Jarvis Agent Run before returning, so
+	# anything that goes wrong between that commit and ``_advance`` below - a failed
+	# set_value, an RQ worker killed mid-sweep, an OOM - leaves the row still DUE with a
+	# live run already going. The next tick then dispatches the SAME slot a second time:
+	# a duplicate audit, billed twice against the A14 budget, for a customer who was
+	# told nothing ran.
+	#
+	# Guarding on the run itself covers every one of those causes, where guarding only
+	# the advance covers one. A legitimately long audit spanning the next tick is
+	# skipped too, which is correct - two concurrent audits of one installation is not a
+	# thing anyone wants - and ``reap_stale_agent_runs`` terminalizes a genuinely stuck
+	# run at 3h, so this can never wedge a schedule permanently.
+	#
+	# The slot IS advanced here: it was really consumed by the launch that is still
+	# running, so this also repairs the ``next_run_at`` that never got written.
+	if frappe.db.exists(RUN, {"installation": row.name, "status": "running"}):
+		_advance(row, now)
+		return
+
 	# S1 hinge: mint the run session + create conv/run INSIDE set_user(run_as).
 	# Row ownership is reassigned to the human owner inside _launch_audit; only
 	# the ERP-read identity is the run-as user.
@@ -243,10 +263,8 @@ def _sweep_one(row, now, original_user: str, seen: set) -> None:
 		# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
 		# it has no initiating human — the scheduler user (Administrator) is not one.
 		_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
-		frappe.set_user(original_user)
-		_advance(row, now)  # O4: advance ONLY after a successful enqueue
 	except Exception:
-		frappe.set_user(original_user)
+		# Nothing durable was created, so this slot really can be retried.
 		frappe.log_error(
 			title=f"jarvis scheduled audit failed: {row.name}",
 			message=frappe.get_traceback(),
@@ -255,9 +273,28 @@ def _sweep_one(row, now, original_user: str, seen: set) -> None:
 		_notify_owner(row.owner, row)
 		# Do NOT advance -> retry next hour. compute_next_run(from=now) means
 		# even a long outage yields ONE next slot, never a backfill storm.
+		return
 	finally:
 		if frappe.session.user != original_user:
 			frappe.set_user(original_user)
+
+	# #652: everything below is PAST the enqueue boundary. ``_launch_audit`` commits
+	# before it returns, so the conversation and the ``running`` Jarvis Agent Run are
+	# durable and this slot is spent. A failure here is therefore NOT a launch failure,
+	# and the handler above would be wrong three times over: it writes a ``failed`` run
+	# for an audit that is actually running, tells the owner it could not be started,
+	# and leaves the row due so the next tick dispatches the SAME slot again. That
+	# duplicate is unrecoverable and is billed a second time against the A14 budget.
+	#
+	# Leaving next_run_at stale is the lesser evil: the row is re-advanced by the next
+	# successful pass, and the stale-run reaper terminalizes anything that hangs.
+	try:
+		_advance(row, now)  # O4: advance ONLY after a successful enqueue
+	except Exception:
+		frappe.log_error(
+			title=f"jarvis advance failed AFTER a successful launch: {row.name}",
+			message=frappe.get_traceback(),
+		)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1589,3 +1589,163 @@ class TestRehomeMembershipScope(FrappeTestCase):
 
 		self.assertEqual(frappe.db.get_value(FINDING, theirs, "owner"), self.reviewer)
 		self.assertEqual(frappe.db.get_value(RUN, self.run_b, "owner"), self.reviewer)
+
+
+# --------------------------------------------------------------------------- #
+# #652 - a failure AFTER a successful launch must not re-dispatch the slot
+# --------------------------------------------------------------------------- #
+class TestDispatchIdempotency(FrappeTestCase):
+	"""``_launch_audit`` commits its ``running`` run before returning, so anything that
+	goes wrong between that commit and ``_advance`` leaves the row still DUE with a live
+	run going. The next tick then dispatched the SAME slot again: a duplicate audit,
+	billed twice against the A14 budget, for a customer whose only notification said the
+	run could not be started."""
+
+	SLUG = PREFIX + "dispidem"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-dispidem@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.set_value(
+			LISTING, cls.SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False
+		)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.set_value(
+			LISTING, self.SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False
+		)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def _due_install(self) -> str:
+		from frappe.utils import add_days, now_datetime
+
+		name = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.set_value(
+			INSTALLATION,
+			name,
+			{
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"next_run_at": add_days(now_datetime(), -1),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		return name
+
+	def _live_run(self, inst: str) -> str:
+		run = _mk_run(inst, self.SLUG, self.owner)
+		frappe.db.set_value(RUN, run, "status", "running", update_modified=False)
+		frappe.db.commit()
+		return run
+
+	def _run_cron(self, launch_side_effect=None):
+		from frappe.utils import add_days, now_datetime
+
+		now = now_datetime()
+		parked = {
+			r.name: r.next_run_at
+			for r in frappe.get_all(
+				INSTALLATION,
+				filters={
+					"enabled": 1,
+					"schedule_enabled": 1,
+					"next_run_at": ["<=", now],
+					"agent": ["!=", self.SLUG],
+				},
+				fields=["name", "next_run_at"],
+				ignore_permissions=True,
+			)
+		}
+		for n in parked:
+			frappe.db.set_value(INSTALLATION, n, "next_run_at", add_days(now, 2), update_modified=False)
+		frappe.db.commit()
+		calls = []
+
+		def _default(inst, **kw):
+			calls.append(inst.name)
+
+		try:
+			with patch.object(agent_scheduler, "_launch_audit", side_effect=launch_side_effect or _default):
+				agent_scheduler.run_due_agent_audits()
+		finally:
+			for n, ts in parked.items():
+				frappe.db.set_value(INSTALLATION, n, "next_run_at", ts, update_modified=False)
+			frappe.db.commit()
+		return calls
+
+	def test_an_installation_with_a_live_run_is_not_dispatched_again(self):
+		"""THE regression. A live ``running`` row means the launch already happened, so
+		re-dispatching double-charges the customer for one slot."""
+		inst = self._due_install()
+		self._live_run(inst)
+		self.assertEqual(self._run_cron(), [], "a live run must block a second dispatch")
+
+	def test_the_skipped_slot_is_advanced_so_it_self_repairs(self):
+		"""The slot really was consumed by the launch still running, so advancing here
+		repairs the next_run_at a failed _advance never wrote. Without it the row stays
+		due and re-enters this path every hour."""
+		from frappe.utils import now_datetime
+
+		now = now_datetime()
+		inst = self._due_install()
+		self._live_run(inst)
+
+		self._run_cron()
+		nxt = frappe.db.get_value(INSTALLATION, inst, "next_run_at")
+		self.assertGreater(nxt, now, "the stale next_run_at must be repaired, not left due")
+
+	def test_an_advance_failure_after_launch_is_not_reported_as_a_launch_failure(self):
+		"""The handler used to write a `failed` run and tell the owner nothing started,
+		for an audit that was in fact running."""
+		inst = self._due_install()
+		with patch.object(agent_scheduler, "_advance", side_effect=RuntimeError("db blip")):
+			self._run_cron()
+
+		runs = frappe.get_all(
+			RUN, filters={"installation": inst, "status": "failed"}, pluck="name", ignore_permissions=True
+		)
+		self.assertEqual(runs, [], "a post-launch failure must not be recorded as a failed run")
+
+	def test_a_genuine_launch_failure_still_reports_and_retries(self):
+		"""Control: nothing durable was created, so the customer must still be told and
+		the slot must stay due."""
+		from frappe.utils import now_datetime
+
+		now = now_datetime()
+		inst = self._due_install()
+
+		def _boom(inst_doc, **kw):
+			raise RuntimeError("enqueue exploded")
+
+		self._run_cron(launch_side_effect=_boom)
+
+		runs = frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": "failed"},
+			fields=["error"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(len(runs), 1, "a real launch failure is still recorded")
+		self.assertIn("enqueue failed", runs[0]["error"])
+		self.assertLess(
+			frappe.db.get_value(INSTALLATION, inst, "next_run_at"),
+			now,
+			"a real launch failure leaves the slot due for a retry",
+		)
+
+	def test_a_clean_installation_still_dispatches(self):
+		"""Control: no live run, so the ordinary path is untouched."""
+		inst = self._due_install()
+		self.assertEqual(self._run_cron(), [inst])


### PR DESCRIPTION
Closes #652

A scheduled audit could run twice for one slot, be billed twice, and the customer would be told it never started.

`_launch_audit` commits its `running` Jarvis Agent Run before it returns. Anything that goes wrong between that commit and `_advance` therefore leaves the row still **due** with a live run already going, and the next hourly tick dispatches the same slot again.

The old handler was wrong three times over on that path: it wrote a `failed` run for an audit that was actually running, notified the owner that it could not be started, and deliberately did not advance, which is what set up the duplicate.

## Two changes, and the second is the one that closes it

**1. The `try` is split at the enqueue boundary.** A failure after a successful launch no longer records a failure or notifies, because both statements are false. It logs under a distinct title.

**2. Dispatch is now idempotent on the run itself.** An installation that already has a `running` row is skipped.

That second part is load-bearing and I want to flag it, because the issue (which I filed) proposed only the first. **Splitting the `try` alone does not fix the duplicate.** The row stays due either way, so the next tick re-dispatches regardless. I only caught this while writing the tests, after checking whether any dispatch guard already existed. None did.

Guarding on the run also covers every cause rather than one: an RQ worker killed mid-sweep, or an OOM between the two statements, produce exactly the same stale-due-with-live-run state as a failed `_advance`.

<details>
<summary>Why the skipped slot is advanced rather than left alone</summary>

The slot really was consumed, by the launch that is still running. Advancing repairs the `next_run_at` that never got written, instead of leaving the row re-entering this path every hour for the life of the run.

A legitimately long audit that spans the next tick is skipped too. That is correct: two concurrent audits of one installation is not something anyone wants. And `reap_stale_agent_runs` terminalizes a genuinely stuck run at 3h, so this can never wedge a schedule permanently.
</details>

## Tests

`TestDispatchIdempotency`, six cases:

- an installation with a live run is not dispatched again (the regression)
- the skipped slot is advanced, so a stale `next_run_at` self-repairs
- an `_advance` failure after a launch is not recorded as a launch failure
- a genuine launch failure still records, still names the reason, and still leaves the slot due for a retry
- a clean installation dispatches normally

Verified locally: `pre-commit` clean on both files.
