### PR TITLE
fix(wiki): cap curated manual_links per page in the graph

### DIFF
--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -107,7 +107,13 @@ def _manual_link_targets(raw, known: set[str]) -> list[str]:
 	Capped separately rather than sharing one budget with the body links, so a page with
 	many ``[[wikilinks]]`` in its body cannot silently swallow a human's deliberate
 	curation. A page therefore contributes at most ``2 * _MAX_LINKS_PER_PAGE`` link
-	edges."""
+	edges.
+
+	Keeps the NEWEST, not the oldest. ``add_wiki_link`` APPENDS, so truncating the head
+	would mean that past the cap a user clicks "+ link", is told it succeeded, the link
+	is durably stored, and it never appears in the graph. Dropping the oldest edge is a
+	bounded, understandable loss; silently discarding the one the user just made is
+	not."""
 	try:
 		arr = json.loads(raw) if isinstance(raw, str) else (raw or [])
 	except Exception:
@@ -119,9 +125,7 @@ def _manual_link_targets(raw, known: set[str]) -> list[str]:
 		s = str(t or "").strip().lower()
 		if s and s in known and s not in out:
 			out.append(s)
-			if len(out) >= _MAX_LINKS_PER_PAGE:
-				break
-	return out
+	return out[-_MAX_LINKS_PER_PAGE:]
 
 
 def _sources_authors(raw) -> dict[str, int]:

--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -93,8 +93,21 @@ def _extract_link_targets(body, known: set[str]) -> list[str]:
 
 
 def _manual_link_targets(raw, known: set[str]) -> list[str]:
-	"""``manual_links`` (JSON list of target slugs) → the ones that exist. The
-	durable, out-of-body half of the link set (R1)."""
+	"""``manual_links`` (JSON list of target slugs) → the ones that exist, capped
+	per page. The durable, out-of-body half of the link set (R1).
+
+	#645: capped at the same ``_MAX_LINKS_PER_PAGE`` the body links already use, which
+	is also what the mirror caps its ``## Related`` tail at (``wiki_mirror._MAX_RELATED``).
+	The asymmetry was harmless while nothing wrote ``manual_links``; PR #642 wired the
+	add-link loop, so they now accumulate one click at a time and are never pruned. Left
+	uncapped, one heavily curated page can take a large share of the global ``MAX_EDGES``
+	budget and crowd every other page out of the graph, and the daily push to the control
+	plane grows with no per-page bound.
+
+	Capped separately rather than sharing one budget with the body links, so a page with
+	many ``[[wikilinks]]`` in its body cannot silently swallow a human's deliberate
+	curation. A page therefore contributes at most ``2 * _MAX_LINKS_PER_PAGE`` link
+	edges."""
 	try:
 		arr = json.loads(raw) if isinstance(raw, str) else (raw or [])
 	except Exception:
@@ -106,6 +119,8 @@ def _manual_link_targets(raw, known: set[str]) -> list[str]:
 		s = str(t or "").strip().lower()
 		if s and s in known and s not in out:
 			out.append(s)
+			if len(out) >= _MAX_LINKS_PER_PAGE:
+				break
 	return out
 
 

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -35,6 +35,8 @@ import json
 import frappe
 from frappe.utils import cint
 
+from jarvis.chat.wiki_graph import _MAX_LINKS_PER_PAGE
+
 WIKI = "Jarvis Wiki Page"
 SETTINGS = "Jarvis Settings"
 
@@ -70,9 +72,13 @@ INDEX_PATH = "wiki/index.md"
 LOG_PATH = "wiki/log.md"
 _INDEX_SUMMARY_CHARS = 100
 _LOG_MAX_EVENTS = 150
-# Curated links are appended one at a time and never pruned, so the "## Related"
-# tail gets the same defensive cap wiki_graph puts on a page's link set.
-_MAX_RELATED = 50
+# Curated links are appended one at a time and never pruned, so the "## Related" tail
+# gets the same defensive cap wiki_graph puts on a page's link set.
+#
+# #645: IMPORTED rather than restated. These were two independent literals whose
+# equality only a test enforced, so a future change to either one silently broke the
+# coupling. Now the coupling is structural and there is one number to change.
+_MAX_RELATED = _MAX_LINKS_PER_PAGE
 
 _PAGE_FIELDS = [
 	"name",
@@ -173,7 +179,13 @@ def _related_lines(doc, mirrored_slugs: set[str] | None) -> list[str]:
 	them, which also meant they never reached the container at all: the agent's
 	two channels are this mirror and ``jarvis__read_wiki``, and neither read the
 	field. Rendering them as real ``[[slug]]`` links keeps every body-based
-	consumer (Obsidian, a grep, the agent itself) working unchanged."""
+	consumer (Obsidian, a grep, the agent itself) working unchanged.
+
+	#645: keeps the NEWEST ``_MAX_RELATED``, not the oldest. ``add_wiki_link`` APPENDS,
+	so truncating the head meant that past the cap a user clicks "+ link", is told it
+	succeeded, the link is durably stored, and it never reaches the container. Dropping
+	the oldest bullet is a bounded, understandable loss; silently discarding the one the
+	user just made is not. The graph applies the same rule to the same field."""
 	from jarvis.chat.wiki import _parse_manual_links
 
 	self_slug = doc.get("slug") or doc.get("name")
@@ -184,9 +196,7 @@ def _related_lines(doc, mirrored_slugs: set[str] | None) -> list[str]:
 		if mirrored_slugs is not None and target not in mirrored_slugs:
 			continue
 		out.append(f"- [[{target}]]")
-		if len(out) >= _MAX_RELATED:
-			break
-	return out
+	return out[-_MAX_RELATED:]
 
 
 def _source_lines(raw) -> list[str]:

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -214,6 +214,36 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		# dangling manual link (no such page) dropped
 		self.assertFalse(any(e.get("target") == "page:nope-missing-slug" for e in g["edges"]))
 
+	def test_manual_links_are_capped_per_page(self):
+		"""#645: curated links were the only unbounded per-page contributor. PR #642
+		wired the add-link loop, so they accumulate one click at a time and are never
+		pruned; left uncapped, one heavily curated page can take a large share of the
+		global MAX_EDGES budget and crowd every other page out of the graph.
+
+		Exercised against the helper rather than through a real graph, because the
+		interesting input is 60+ existing target pages."""
+		known = {f"slug-{i}" for i in range(60)}
+		raw = json.dumps(sorted(known))
+		out = wiki_graph._manual_link_targets(raw, known)
+		self.assertEqual(len(out), wiki_graph._MAX_LINKS_PER_PAGE)
+
+	def test_the_curated_cap_matches_the_mirrors(self):
+		"""The two must agree, which is the whole point of #645: the mirror already caps
+		its ``## Related`` tail, and the graph is the other consumer of the same field."""
+		from jarvis.chat import wiki_mirror
+
+		self.assertEqual(wiki_graph._MAX_LINKS_PER_PAGE, wiki_mirror._MAX_RELATED)
+
+	def test_body_links_do_not_eat_the_curated_budget(self):
+		"""Capped separately on purpose: a page with many body [[wikilinks]] must not
+		silently swallow a human's deliberate curation."""
+		known = {f"slug-{i}" for i in range(60)}
+		body = " ".join(f"[[slug-{i}]]" for i in range(60))
+		body_out = wiki_graph._extract_link_targets(body, known)
+		manual_out = wiki_graph._manual_link_targets(json.dumps(sorted(known)), known)
+		self.assertEqual(len(body_out), wiki_graph._MAX_LINKS_PER_PAGE)
+		self.assertEqual(len(manual_out), wiki_graph._MAX_LINKS_PER_PAGE)
+
 	def test_get_wiki_graph_scoped_with_content(self):
 		from jarvis.chat import wiki as wiki_mod
 

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -227,12 +227,24 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		out = wiki_graph._manual_link_targets(raw, known)
 		self.assertEqual(len(out), wiki_graph._MAX_LINKS_PER_PAGE)
 
+	def test_the_cap_keeps_the_NEWEST_links(self):
+		"""``add_wiki_link`` APPENDS, so a head-truncating cap means that past 50 links a
+		user clicks "+ link", is told it succeeded, the link is durably stored, and it
+		never appears in the graph. Dropping the oldest is a bounded, understandable
+		loss; silently discarding the one just made is not."""
+		known = {f"slug-{i:03d}" for i in range(60)}
+		ordered = sorted(known)  # oldest first, exactly how add_wiki_link leaves it
+		out = wiki_graph._manual_link_targets(json.dumps(ordered), known)
+		self.assertEqual(len(out), wiki_graph._MAX_LINKS_PER_PAGE)
+		self.assertIn(ordered[-1], out, "the most recently added link must survive the cap")
+		self.assertNotIn(ordered[0], out, "the oldest is the one that falls off")
+
 	def test_the_curated_cap_matches_the_mirrors(self):
-		"""The two must agree, which is the whole point of #645: the mirror already caps
-		its ``## Related`` tail, and the graph is the other consumer of the same field."""
+		"""The two must agree, which is the whole point of #645. Now structural: the
+		mirror IMPORTS this constant rather than restating it, so they cannot drift."""
 		from jarvis.chat import wiki_mirror
 
-		self.assertEqual(wiki_graph._MAX_LINKS_PER_PAGE, wiki_mirror._MAX_RELATED)
+		self.assertIs(wiki_mirror._MAX_RELATED, wiki_graph._MAX_LINKS_PER_PAGE)
 
 	def test_body_links_do_not_eat_the_curated_budget(self):
 		"""Capped separately on purpose: a page with many body [[wikilinks]] must not


### PR DESCRIPTION
Closes #645

`wiki_graph` capped body-derived `[[links]]` at `_MAX_LINKS_PER_PAGE` but applied **no cap at all** to curated `manual_links`, so per-page curated edges were bounded only by the global `MAX_EDGES` of 20000.

That was harmless while nothing wrote the field. PR #642 wired the add-link loop, so curated links now accumulate one click at a time and are never pruned. Left uncapped, a single heavily curated page can take a large share of the global edge budget and crowd every other page out of the graph, and the daily push to the control plane grows with no per-page bound.

Now capped at the same `_MAX_LINKS_PER_PAGE` the body links already use, which is also what the mirror caps its `## Related` tail at (`wiki_mirror._MAX_RELATED`). That is the agreement the issue asks for: both consumers of `manual_links` bound it the same way.

<details>
<summary>Why a separate budget rather than one shared cap</summary>

The alternative reading is to cap the combined body-plus-curated set at 50, which bounds a page harder.

I did not do that, because it means a page with 50 `[[wikilinks]]` in its body silently drops every human-curated link. Curated links are deliberate input from a person and reach further than body links do (the orphan check, the container mirror, `read_wiki`, and the control-plane push), so having auto-extracted body text crowd them out is the wrong trade.

With separate caps a page contributes at most `2 * _MAX_LINKS_PER_PAGE` link edges. Bounded, which is what the issue needed, where before it was not bounded at all.
</details>

## Tests

- the cap holds when 60 candidate targets exist
- **the two modules' caps are asserted equal**, so `wiki_graph` and `wiki_mirror` cannot drift apart again, which is the failure this issue is
- body links are shown not to eat the curated budget

Verified locally: `pre-commit` clean, and the capped helper checked directly to confirm it still drops dangling targets and malformed JSON as before.

## Related, not addressed here

The issue notes this should be settled alongside #495, which covers *what* the graph push sends where this covers *how much*. #495 is a privacy question (private page titles and owner emails crossing to the control plane) and wants its own change; nothing here makes it harder.
