### PR TITLE
fix(wiki): stop the Sync-now dialog promising a daily sync that does not exist

### DIFF
--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -699,9 +699,15 @@ async function changeLanguage(v) {
 function confirmSync() {
 	confirmDialog({
 		title: "Sync wiki to agent now?",
+		// #621: this used to promise "the daily sync". There is no daily sync: wiki_mirror
+		// is wired only as doc events, with no scheduler entry at all. Promising a
+		// fallback that does not exist is worse than promising nothing, because a user
+		// who reads it reasonably decides NOT to press the button, believing the mirror
+		// catches up within a day. It never does.
 		message:
-			"Pushes every active org-scope page into the agent's workspace mirror now, " +
-			"instead of waiting for the next change or the daily sync.",
+			"Pushes every active org-scope page into the agent's workspace mirror now. " +
+			"The mirror is otherwise updated only when a page changes, so use this if it " +
+			"looks out of date.",
 		onConfirm: async ({ hideDialog }) => {
 			syncing.value = true;
 			try {


### PR DESCRIPTION
Closes #621

The Sync-now dialog told users the mirror would otherwise update "instead of waiting for the next change or the daily sync". There is no daily sync.

Verified against `hooks.py`: `wiki_mirror` is wired only as `doc_events` on `Jarvis Wiki Page` (lines 497-501) and appears **zero** times in `scheduler_events`. The daily wiki entries are `wiki_graph.sync`, `wiki_graph.record_history_snapshot` and `wiki_lint.scheduled_lint`, none of which touch the mirror.

Promising a fallback that does not exist is worse than promising nothing. A user who reads that copy reasonably decides **not** to press the button, believing the mirror catches up within a day. It never does, so the mirror they were worried about stays stale.

## Why the copy, and not the daily sync

The issue offers both, and notes the sync has independent value: with no periodic sweep, a mirror prune missed for any reason is never recovered, which is what made #491 permanent rather than self-healing. I agree, and it should be added.

**But it has to land after the mirror serialisation in #622 / PR #661.** A full sync is the one that sends `known_paths` and prunes, so scheduling one daily today would widen exactly the concurrency window PR #661 closes: a full sync running against a concurrent incremental is the race, and adding a guaranteed daily full sync makes it a guaranteed daily opportunity for it.

So this PR makes the copy honest now, at zero risk, and the sync becomes a clean follow-up once #661 is in. I have noted that ordering on the issue rather than leaving it implicit.

## Testing

No test asserts this string, and nothing else in the SPA references a "daily sync". `pre-commit` clean (prettier).

Worth a glance in the UI rather than a test: open the Wiki tab, press **Sync now**, and check the dialog no longer mentions a daily sync and reads sensibly.
