### PR TITLE
refactor(onboarding): fall back to the bench's admin URL for pay origin

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -553,8 +553,7 @@
    "fieldtype": "Data",
    "permlevel": 1,
    "label": "Pay origin",
-   "default": "https://fleet.klerk.in",
-   "description": "Where the browser is sent for the admin-hosted checkout. Defaults to the production host; override per deployment. site_config 'jarvis_pay_origin' still overrides. Operator-set only — the signup/connect flow never writes it (it anchors the origin-digest cross-check); must match the admin's pay origin. In test mode a plain-http origin is fine for local/staging."
+   "description": "Where the browser is sent for the admin-hosted checkout. Leave blank to follow the bench's admin URL (jarvis_admin_url) — checkout is hosted on the control plane; set it only when the checkout host differs. site_config 'jarvis_pay_origin' still overrides. Operator-set only — the signup/connect flow never writes it (it anchors the origin-digest cross-check); must match the admin's pay origin. In test mode a plain-http origin is fine for local/staging."
   },
   {
    "fieldname": "jarvis_admin_api_key",

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -291,11 +291,8 @@ def strip_credentials(data: dict | None) -> dict:
 # cross-checks against its own configured origin before the frontend navigates.
 # --------------------------------------------------------------------------- #
 #: The origin the bench navigates to for checkout. Resolves site_config ->
-#: ``Jarvis Settings.jarvis_pay_origin`` -> a production default; a bad value fails closed.
+#: ``Jarvis Settings.jarvis_pay_origin`` -> the bench's admin URL; a bad value fails closed.
 CONF_PAY_ORIGIN = "jarvis_pay_origin"
-#: Production default (owner decision 2026-08-05), like admin_client._admin_url. A code
-#: constant, not a wire value, so the origin-digest cross-check stays sound.
-_DEFAULT_PAY_ORIGIN = "https://fleet.klerk.in"
 #: The frozen envelope key admin uses for the pay-page token (brief §Frozen
 #: contract). Its presence is what turns a response into a navigate-to-pay one.
 PAY_PAGE_TOKEN_KEY = "pay_page_token"
@@ -332,15 +329,18 @@ def _normalize_pay_origin(raw: str | None) -> str:
 
 def _resolved_pay_origin() -> str:
 	"""The bench's pay origin, normalized: site_config -> ``Jarvis Settings`` field ->
-	production default. Read fresh; never raises. The field is operator-only and MUST
-	NOT be written by the connect/sync flow - it anchors the digest cross-check."""
+	the bench's admin URL (checkout is hosted on the control plane). Read fresh; never
+	raises. The field is operator-only and MUST NOT be written by the connect/sync flow
+	- it anchors the digest cross-check."""
+	from jarvis.hooks import get_default_admin_url
+
 	raw = (frappe.conf.get(CONF_PAY_ORIGIN) or "").strip()
 	if not raw:
 		try:
 			raw = (frappe.db.get_single_value("Jarvis Settings", "jarvis_pay_origin") or "").strip()
 		except Exception:
 			raw = ""
-	return _normalize_pay_origin(raw or _DEFAULT_PAY_ORIGIN)
+	return _normalize_pay_origin(raw or get_default_admin_url())
 
 
 def pay_origin_digest(origin: str) -> str:

--- a/jarvis/tests/test_pay_page_cutover.py
+++ b/jarvis/tests/test_pay_page_cutover.py
@@ -54,6 +54,7 @@ class TestAugmentPayPage(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.conf.pop("jarvis_pay_origin", None)
+		frappe.conf.pop("jarvis_admin_url", None)
 
 	def test_no_token_answer_is_returned_untouched(self):
 		data = {"code": "PAYMENT_CONFIRMATION_PENDING", "amount_inr": 1500}
@@ -74,15 +75,17 @@ class TestAugmentPayPage(FrappeTestCase):
 		self.assertEqual(out["pay_origin"], self.ORIGIN)
 		self.assertFalse(out["pay_origin_attested"])
 
-	def test_token_with_NO_explicit_config_uses_the_production_default(self):
+	def test_token_with_NO_explicit_config_falls_back_to_the_admin_url(self):
 		# New contract (2026-08-05): with nothing in site_config OR the Settings field,
-		# the origin falls back to the shipped production default instead of failing
-		# closed. self.ORIGIN IS that default and admin minted a token for it, so it
-		# attests. (site_config still overrides; a mismatched default would not attest.)
+		# the origin follows the bench's admin URL instead of failing closed - checkout is
+		# hosted on the control plane. Here the admin URL IS self.ORIGIN and admin minted a
+		# token for it, so it attests. (site_config still overrides; a mismatched admin URL
+		# would not attest.)
 		frappe.conf.pop("jarvis_pay_origin", None)
+		frappe.conf["jarvis_admin_url"] = self.ORIGIN
 		with patch("frappe.db.get_single_value", return_value=""):
 			out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": self.digest})
-		self.assertEqual(out["pay_origin"], oc._DEFAULT_PAY_ORIGIN)
+		self.assertEqual(out["pay_origin"], self.ORIGIN)
 		self.assertTrue(out["pay_origin_attested"])
 
 	def test_token_with_no_admin_digest_cannot_be_attested(self):
@@ -105,10 +108,11 @@ class TestAugmentPayPage(FrappeTestCase):
 
 
 class TestResolvedPayOrigin(FrappeTestCase):
-	"""_resolved_pay_origin precedence: site_config -> Jarvis Settings field -> default."""
+	"""_resolved_pay_origin precedence: site_config -> Jarvis Settings field -> admin URL."""
 
 	def tearDown(self):
 		frappe.conf.pop("jarvis_pay_origin", None)
+		frappe.conf.pop("jarvis_admin_url", None)
 
 	def test_site_config_wins_over_settings_field(self):
 		frappe.conf["jarvis_pay_origin"] = "https://vignesh-staging.klerk.in"
@@ -120,10 +124,20 @@ class TestResolvedPayOrigin(FrappeTestCase):
 		with patch("frappe.db.get_single_value", return_value="https://vignesh-staging.klerk.in"):
 			self.assertEqual(oc._resolved_pay_origin(), "https://vignesh-staging.klerk.in")
 
-	def test_production_default_when_both_empty(self):
+	def test_admin_url_used_when_both_empty(self):
 		frappe.conf.pop("jarvis_pay_origin", None)
+		frappe.conf["jarvis_admin_url"] = "https://fleet.klerk.in"
 		with patch("frappe.db.get_single_value", return_value=""):
-			self.assertEqual(oc._resolved_pay_origin(), oc._DEFAULT_PAY_ORIGIN)
+			self.assertEqual(oc._resolved_pay_origin(), "https://fleet.klerk.in")
+
+	def test_follows_a_local_http_admin_url_with_no_explicit_pay_origin(self):
+		# The point of the fallback: a bench whose admin URL is a local/staging http host
+		# gets that as its checkout origin with no separate pay-origin config - scheme and
+		# port preserved (test-mode form).
+		frappe.conf.pop("jarvis_pay_origin", None)
+		frappe.conf["jarvis_admin_url"] = "http://jarvis_admin_v2.local:8002"
+		with patch("frappe.db.get_single_value", return_value=""):
+			self.assertEqual(oc._resolved_pay_origin(), "http://jarvis_admin_v2.local:8002")
 
 
 class TestPaymentUiV2Flag(FrappeTestCase):


### PR DESCRIPTION
## What

When `jarvis_pay_origin` is set in neither `site_config` nor the Jarvis Settings field, the bench now resolves its checkout origin from its own **admin URL** (`hooks.get_default_admin_url`) instead of a second hardcoded production constant.

Precedence: `site_config.jarvis_pay_origin` → `Jarvis Settings.jarvis_pay_origin` field → **bench's admin URL** (was `_DEFAULT_PAY_ORIGIN = "https://fleet.klerk.in"`).

## Why

Checkout is hosted on the control plane, so the admin URL the bench already knows (`jarvis_admin_url`) *is* the right default. This collapses two hardcoded copies of the same host into one source of truth:

- **Local / staging** benches follow their `jarvis_admin_url` with no separate pay-origin config — a plain-http origin (`http://…:8002`) just works in test mode, which previously required setting `jarvis_pay_origin` by hand.
- **Production** still lands on `fleet.klerk.in` via the admin-URL fallback (`get_default_admin_url` → `jarvis_admin_url` → its own hardcoded fallback).

## Changes

- `onboarding_contract.py`: drop `_DEFAULT_PAY_ORIGIN`; `_resolved_pay_origin()` falls back to `get_default_admin_url()`.
- `jarvis_settings.json`: remove the field's `default` (so it can be genuinely empty and fall through) and reword the description.
- `tests/test_pay_page_cutover.py`: update the two `_DEFAULT_PAY_ORIGIN` assertions; add `test_follows_a_local_http_admin_url_with_no_explicit_pay_origin`.

The origin-digest cross-check and normalization (scheme + port preserved) are unchanged.

## Testing

`bench --site test_jarvis run-tests --module jarvis.tests.test_pay_page_cutover` → **21/21 pass**. ruff (import-sort + lint + format) clean.

## Note

The admin side keeps its hardcoded default deliberately — its production default is already correct, and staging/local set it explicitly. Admin checkout PR unchanged.
