### PR TITLE
fix(onboarding): stop the wizard stranding, blanking and misinforming customers

### DIFF
--- a/frontend/src/lib/llmOperation.js
+++ b/frontend/src/lib/llmOperation.js
@@ -88,13 +88,32 @@ export function classifyOperation(op) {
 		phase = code === OP_CODE.REJECTED ? OP_PHASE.REJECTED : OP_PHASE.RETRY;
 	}
 
+	// The operation being READY means "your AI connection applied". It does NOT mean
+	// "chat works": admin reports the workspace's own verdict separately, on
+	// `chat_readiness`, and this projection was reading that field and then ignoring
+	// it. So a customer whose model saved cleanly while their container was still
+	// coming up was navigated into a chat that could not answer, with no error and
+	// no way to tell what had gone wrong. That is the "it went to chat but chat
+	// didn't work" report, and it closes here.
+	//
+	// `false` is the ONLY blocking value. `null`/undefined means admin did not say
+	// (an older control plane, or a path that does not compute it), and refusing to
+	// navigate on silence would strand every customer on that build. Absent
+	// information keeps the old behaviour; a definite "not ready" is now believed.
+	const chatBlocked = chatReadiness === false;
+
 	return {
 		phase,
 		state,
 		code,
 		terminal: isTerminal(state),
-		// Exactly-once navigation is only ever offered on a genuine READY.
-		canNavigate: state === OP_STATE.READY,
+		// Exactly-once navigation is only ever offered on a genuine READY that admin
+		// has not explicitly told us is un-chattable yet.
+		canNavigate: state === OP_STATE.READY && !chatBlocked,
+		// READY, but chat is not up yet. The caller must stay on the setup step and
+		// keep waiting rather than treat this as a failure: nothing is wrong, the
+		// workspace is simply still coming online.
+		awaitingChatReadiness: state === OP_STATE.READY && chatBlocked,
 		// Whether the customer can recover by retrying THIS operation (no new desired
 		// version). A permanent rejection and a superseded op are not retryable here.
 		retryable:

--- a/frontend/src/onboarding/TourIntro.vue
+++ b/frontend/src/onboarding/TourIntro.vue
@@ -1,13 +1,128 @@
 <template>
 	<!-- Intro product tour (onboarding step 1, chromeless: no step rail).
-		 6 slides in SIDEBAR ORDER: Welcome, Chat, Skills, Macros, File Box,
-		 Agents. Translated from the approved preview
-		 (docs/superpowers/specs/onboarding-preview-v6.html); self-contained,
-		 only depends on the app palette vars OnboardingView already applies. -->
+		 6 slides, TOUR order: Chat, Welcome, Skills, Macros, File Box, Agents
+		 (Chat leads with the animated conversation; the mock sidebar nav
+		 rendered inside each slide keeps its own SIDEBAR order: Chat, Skills,
+		 Macros, File Box, Agents - see NAV_ORDER). Translated from the
+		 approved preview (docs/superpowers/specs/onboarding-preview-v6.html);
+		 self-contained, only depends on the app palette vars OnboardingView
+		 already applies. -->
 	<div class="tour">
 		<div class="tour-stage">
-			<!-- slide 1 · welcome -->
+			<!-- slide 1 · chat -->
 			<div v-if="cur === 0" class="slide">
+				<div class="slide-copy">
+					<span class="eyebrow">Chat</span>
+					<h2>Ask anything about your business.</h2>
+					<p>
+						“Which sales orders are overdue?” “Draft a follow-up to this lead.”
+						{{ agentName }}
+						pulls the answer straight from ERPNext and shows its work.
+					</p>
+				</div>
+				<div class="mock">
+					<div class="mock-bar">
+						<i></i><i></i><i></i><span>Chat · Stock &amp; dispatch</span>
+					</div>
+					<div class="mock-body">
+						<div class="m-side" v-html="sideHtml('Chat')"></div>
+						<div class="m-main">
+							<!-- looping animated conversation: chatStep (script) is a tiny
+								 phase clock that toggles which bubbles exist via v-if; the
+								 motion itself (typing reveal, caret blink, tool-dot pulse,
+								 loop fade) is CSS. .chat-flow is pinned to the mock's fixed
+								 content box and bottom-aligned, so new bubbles push older
+								 ones past the top edge where overflow:hidden clips them -
+								 same as a real scrolled-to-bottom chat - and the mock never
+								 grows or jumps. -->
+							<div class="chat-anim" :class="{ fading: chatFading }">
+								<div class="chat-flow">
+									<div class="cb tool" v-if="chatStep === 'tool'">
+										<span class="g"></span>run_report · Sales Order + Bin
+									</div>
+									<div class="cb u" v-if="chatAtLeast('bubble1')">
+										For the available stock, which customer orders can I
+										dispatch now, who pays me on time, to keep up my
+										cashflow in a good state? Analyse and list.
+									</div>
+									<div class="cb a cb-reply" v-if="chatAtLeast('reply1')">
+										<p class="tbl-lead">
+											3 orders can ship today, ₹2.4L total. Ranked by how
+											fast each customer pays.
+										</p>
+										<div class="tbl">
+											<div class="tbl-row">
+												<b>Acme Industries · SO-0142</b>
+												<span>₹1.1L · 120/120 ready · pays in 12d avg</span>
+											</div>
+											<div class="tbl-row">
+												<b>Vertex Traders · SO-0138</b>
+												<span>₹84,000 · 60/60 ready · pays in 18d avg</span>
+											</div>
+											<div class="tbl-row">
+												<b>Sunrise Mills · SO-0151</b>
+												<span>₹47,500 · 200/200 ready · pays in 9d avg</span>
+											</div>
+										</div>
+									</div>
+									<div class="cb u" v-if="chatAtLeast('bubble2')">
+										Create pick list for first order.
+									</div>
+									<div
+										class="cb a confirm-card"
+										v-if="chatStep === 'confirm' || chatStep === 'approve'"
+									>
+										<div class="confirm-t">
+											About to create a Pick List for SO-0142, Acme
+											Industries.
+										</div>
+										<div class="confirm-btns">
+											<span
+												class="confirm-btn confirm-btn--ok"
+												:class="{ pressed: chatStep === 'approve' }"
+												>Approve</span
+											>
+											<span class="confirm-btn">Cancel</span>
+										</div>
+									</div>
+									<div class="cb a cb-done" v-if="chatAtLeast('done')">
+										<svg
+											width="11"
+											height="11"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="2.6"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+										>
+											<path d="M20 6 9 17l-5-5" />
+										</svg>
+										Pick List PICK-0091 created in draft mode.
+									</div>
+								</div>
+								<div class="composer">
+									<template
+										v-if="chatStep === 'type1' || chatStep === 'type2'"
+									>
+										<span
+											class="type-line"
+											:class="chatStep === 'type1' ? 'type-q1' : 'type-q2'"
+											>{{
+												chatStep === "type1" ? chatQ1 : chatQ2
+											}}</span
+										><span class="type-caret" aria-hidden="true"></span>
+									</template>
+									<template v-else>Ask a follow-up…</template>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- slide 2 · welcome -->
+			<div v-else-if="cur === 1" class="slide">
 				<div class="slide-copy">
 					<span class="eyebrow">Welcome</span>
 					<h2>Harness AI agents inside your ERPNext.</h2>
@@ -174,38 +289,6 @@
 							<div class="composer">
 								Ask {{ agentName }}… @ to mention a user, / for a doctype or tool
 							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-
-			<!-- slide 2 · chat -->
-			<div v-else-if="cur === 1" class="slide">
-				<div class="slide-copy">
-					<span class="eyebrow">Chat</span>
-					<h2>Ask anything about your business.</h2>
-					<p>
-						“Which sales orders are overdue?” “Draft a follow-up to this lead.”
-						{{ agentName }}
-						pulls the answer straight from ERPNext and shows its work.
-					</p>
-				</div>
-				<div class="mock">
-					<div class="mock-bar">
-						<i></i><i></i><i></i><span>Chat · Overdue orders</span>
-					</div>
-					<div class="mock-body">
-						<div class="m-side" v-html="sideHtml('Chat')"></div>
-						<div class="m-main">
-							<div class="cb u">Which sales orders are overdue this month?</div>
-							<div class="cb tool">
-								<span class="g"></span>run_report · Sales Order
-							</div>
-							<div class="cb a">
-								7 orders are overdue, totalling ₹4.2L. The largest is SO-0142
-								(Acme, ₹1.1L, 9 days late).
-							</div>
-							<div class="composer">Ask a follow-up…</div>
 						</div>
 					</div>
 				</div>
@@ -512,7 +595,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch, onUnmounted } from "vue";
 import { agentName } from "@/branding";
 import { PERMISSION_TOUR_COPY } from "@/onboarding/permissionCopy";
 
@@ -535,6 +618,104 @@ function step(d) {
 	}
 	go(cur.value + d);
 }
+
+// ---- chat slide (cur === 0): looping animated conversation ----
+// A tiny phase clock steps through the exchange; every visual (typing
+// reveal, caret blink, tool-dot pulse, bubble/card presence) is driven off
+// the current step name and rendered as CSS, so this is a state machine,
+// not a frame-by-frame animator. It only runs while the Chat slide is
+// mounted, and is skipped entirely under prefers-reduced-motion, which
+// instead shows the loop's settled last frame with no motion at all.
+const CHAT_SEQUENCE = [
+	"type1", // composer types the stock/dispatch question
+	"bubble1", // question becomes a user bubble
+	"tool", // brief tool-running chip
+	"reply1", // assistant's ranked customer table
+	"type2", // composer types the pick-list follow-up
+	"bubble2", // follow-up becomes a user bubble
+	"confirm", // confirm card offered
+	"approve", // Approve shows a pressed state
+	"done", // confirmation line
+	"hold", // pause before the loop fades and restarts
+];
+const CHAT_DURATION_MS = {
+	type1: 3200,
+	bubble1: 450,
+	tool: 900,
+	reply1: 2600,
+	type2: 1200,
+	bubble2: 450,
+	confirm: 1100,
+	approve: 450,
+	done: 2600,
+	hold: 2400,
+};
+const CHAT_INDEX = Object.fromEntries(CHAT_SEQUENCE.map((s, i) => [s, i]));
+const chatQ1 =
+	"For the available stock, which customer orders can I dispatch now, who pays me on time, to keep up my cashflow in a good state? Analyse and list.";
+const chatQ2 = "Create pick list for first order.";
+const chatStep = ref(CHAT_SEQUENCE[CHAT_SEQUENCE.length - 1]);
+const chatFading = ref(false);
+function chatAtLeast(step) {
+	return CHAT_INDEX[chatStep.value] >= CHAT_INDEX[step];
+}
+
+let chatTimer = null;
+let chatIdx = 0;
+function clearChatTimer() {
+	if (chatTimer) {
+		clearTimeout(chatTimer);
+		chatTimer = null;
+	}
+}
+function runChatStep() {
+	const stepName = CHAT_SEQUENCE[chatIdx];
+	chatStep.value = stepName;
+	chatTimer = setTimeout(() => {
+		chatIdx += 1;
+		if (chatIdx >= CHAT_SEQUENCE.length) {
+			// loop boundary: fade the whole exchange out, then reset to blank
+			chatFading.value = true;
+			chatTimer = setTimeout(() => {
+				chatIdx = 0;
+				chatFading.value = false;
+				runChatStep();
+			}, 500);
+			return;
+		}
+		runChatStep();
+	}, CHAT_DURATION_MS[stepName]);
+}
+function startChatAnim() {
+	clearChatTimer();
+	chatIdx = 0;
+	chatFading.value = false;
+	runChatStep();
+}
+function prefersReducedMotion() {
+	return (
+		typeof window !== "undefined" &&
+		typeof window.matchMedia === "function" &&
+		window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	);
+}
+// Slides use v-if, so leaving the Chat slide destroys its DOM - but the
+// timer above is JS state on this component, not the DOM, so it needs its
+// own stop here too, on every slide change and again on unmount.
+watch(
+	cur,
+	(slide) => {
+		if (slide === 0 && !prefersReducedMotion()) {
+			startChatAnim();
+		} else {
+			clearChatTimer();
+			chatStep.value = CHAT_SEQUENCE[CHAT_SEQUENCE.length - 1];
+			chatFading.value = false;
+		}
+	},
+	{ immediate: true }
+);
+onUnmounted(clearChatTimer);
 
 // ---- mock sidebar: mirrors the REAL app sidebar (brand + user, New Chat,
 // Search Chat, feather-icon nav, Recent chats), rendered from data exactly
@@ -611,6 +792,22 @@ function sideHtml(active) {
 		transition: none;
 	}
 	.btn {
+		transition: none;
+	}
+	/* belt-and-braces: the chatStep clock in <script setup> already never
+	   starts under this preference, so these never actually mount, but they
+	   stay off here too in case that ever changes. */
+	.chat-anim {
+		transition: none;
+	}
+	.type-caret {
+		animation: none;
+		opacity: 1;
+	}
+	.cb.tool .g {
+		animation: none;
+	}
+	.confirm-btn--ok {
 		transition: none;
 	}
 }
@@ -992,6 +1189,16 @@ button:focus-visible {
 	height: 6px;
 	border-radius: 50%;
 	background: var(--green);
+	animation: jvDotPulse 1.1s ease-in-out infinite;
+}
+@keyframes jvDotPulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.35;
+	}
 }
 .composer {
 	position: absolute;
@@ -1009,6 +1216,133 @@ button:focus-visible {
 	color: var(--text-3);
 	white-space: nowrap;
 	overflow: hidden;
+}
+
+/* ---- chat mock: looping animated conversation ----
+   .chat-anim fades the whole exchange out at the loop boundary (script
+   toggles chatFading). .chat-flow is pinned to the mock's fixed content
+   box (top 0, bottom above the composer) and bottom-aligned, so as bubbles
+   accumulate the oldest ones get pushed past the top edge, where
+   overflow: hidden clips them - the same way a real scrolled-to-bottom chat
+   behaves. Nothing here changes the mock's total height. */
+.chat-anim {
+	height: 100%;
+	transition: opacity 0.45s ease;
+	opacity: 1;
+}
+.chat-anim.fading {
+	opacity: 0;
+}
+.chat-flow {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 50px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	overflow: hidden;
+}
+.cb-reply .tbl-lead {
+	margin: 0 0 7px;
+	font-weight: 600;
+	color: var(--text);
+}
+.tbl {
+	display: grid;
+	gap: 6px;
+}
+.tbl-row b {
+	display: block;
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--text);
+}
+.tbl-row span {
+	display: block;
+	font-size: 9px;
+	color: var(--text-3);
+	margin-top: 1px;
+}
+.confirm-t {
+	margin-bottom: 8px;
+}
+.confirm-btns {
+	display: flex;
+	gap: 8px;
+}
+.confirm-btn {
+	display: inline-flex;
+	align-items: center;
+	padding: 4px 10px;
+	border-radius: 6px;
+	font-size: 9.5px;
+	font-weight: 600;
+	border: 1px solid var(--border-2);
+	color: var(--text-2);
+	background: var(--surface);
+}
+.confirm-btn--ok {
+	border-color: var(--cta);
+	background: var(--cta);
+	color: var(--cta-fg);
+	transition: transform 0.15s ease, filter 0.15s ease;
+}
+.confirm-btn--ok.pressed {
+	transform: scale(0.93);
+	filter: brightness(0.88);
+}
+.cb-done {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+.cb-done svg {
+	color: var(--green);
+	flex: none;
+}
+
+/* typing composer: a clip-path reveal reads as characters appearing
+   without depending on font metrics (a ch-width reveal would, since ch is
+   only exact for monospace); the caret just blinks alongside it rather
+   than tracking the reveal edge pixel-for-pixel. */
+.type-line {
+	display: inline-block;
+	max-width: 100%;
+	overflow: hidden;
+	white-space: nowrap;
+	vertical-align: bottom;
+	clip-path: inset(0 100% 0 0);
+	animation-name: jvTypeReveal;
+	animation-fill-mode: forwards;
+}
+.type-q1 {
+	animation-duration: 3.2s;
+	animation-timing-function: steps(46, end);
+}
+.type-q2 {
+	animation-duration: 1.1s;
+	animation-timing-function: steps(20, end);
+}
+@keyframes jvTypeReveal {
+	to {
+		clip-path: inset(0 0 0 0);
+	}
+}
+.type-caret {
+	display: inline-block;
+	width: 1.5px;
+	height: 10px;
+	margin-left: 2px;
+	background: var(--text-2);
+	vertical-align: -1px;
+	animation: jvCaretBlink 0.9s steps(1, end) infinite;
+}
+@keyframes jvCaretBlink {
+	50% {
+		opacity: 0;
+	}
 }
 
 /* ---- rows mock (skills / macros / file box) ---- */

--- a/frontend/src/onboarding/TourIntro.vue
+++ b/frontend/src/onboarding/TourIntro.vue
@@ -42,8 +42,8 @@
 									</div>
 									<div class="cb u" v-if="chatAtLeast('bubble1')">
 										For the available stock, which customer orders can I
-										dispatch now, who pays me on time, to keep up my
-										cashflow in a good state? Analyse and list.
+										dispatch now, who pays me on time, to keep up my cashflow
+										in a good state? Analyse and list.
 									</div>
 									<div class="cb a cb-reply" v-if="chatAtLeast('reply1')">
 										<p class="tbl-lead">
@@ -53,15 +53,21 @@
 										<div class="tbl">
 											<div class="tbl-row">
 												<b>Acme Industries · SO-0142</b>
-												<span>₹1.1L · 120/120 ready · pays in 12d avg</span>
+												<span
+													>₹1.1L · 120/120 ready · pays in 12d avg</span
+												>
 											</div>
 											<div class="tbl-row">
 												<b>Vertex Traders · SO-0138</b>
-												<span>₹84,000 · 60/60 ready · pays in 18d avg</span>
+												<span
+													>₹84,000 · 60/60 ready · pays in 18d avg</span
+												>
 											</div>
 											<div class="tbl-row">
 												<b>Sunrise Mills · SO-0151</b>
-												<span>₹47,500 · 200/200 ready · pays in 9d avg</span>
+												<span
+													>₹47,500 · 200/200 ready · pays in 9d avg</span
+												>
 											</div>
 										</div>
 									</div>
@@ -102,15 +108,11 @@
 									</div>
 								</div>
 								<div class="composer">
-									<template
-										v-if="chatStep === 'type1' || chatStep === 'type2'"
-									>
+									<template v-if="chatStep === 'type1' || chatStep === 'type2'">
 										<span
 											class="type-line"
 											:class="chatStep === 'type1' ? 'type-q1' : 'type-q2'"
-											>{{
-												chatStep === "type1" ? chatQ1 : chatQ2
-											}}</span
+											>{{ chatStep === "type1" ? chatQ1 : chatQ2 }}</span
 										><span class="type-caret" aria-hidden="true"></span>
 									</template>
 									<template v-else>Ask a follow-up…</template>

--- a/frontend/src/onboarding/gstin.js
+++ b/frontend/src/onboarding/gstin.js
@@ -1,0 +1,72 @@
+// GSTIN (Indian GST identification number) validation: shape + state code +
+// mod-36 checksum. Pure module - no Vue, no `@/` alias, no imports at all - so
+// `node --test` runs it standalone and the admin control plane's own GSTIN
+// rules (billing.gstin) never drift from what this SPA checks client-side.
+// GSTIN is OPTIONAL on the Details step: a blank value is never an error here,
+// only a malformed non-blank one is.
+
+const ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+// 2-digit state code, 5-letter PAN prefix, 4-digit PAN sequence, 1-letter PAN
+// check char, 1 entity code (1-9 or A-Z, never 0), literal "Z", 1 checksum char.
+const SHAPE_RE = /^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z][1-9A-Z]Z[0-9A-Z]$/;
+
+// GST state/UT codes run 01-38; 97 (Other Territory) and 99 (Centre jurisdiction
+// / foreign) are also issued. Mirrors the admin plane's own list so the two
+// never disagree about what "unrecognized state code" means.
+function isKnownStateCode(code) {
+	const n = Number(code);
+	return (n >= 1 && n <= 38) || n === 97 || n === 99;
+}
+
+// GSTIN check-digit algorithm (mod 36). Each of the first 14 characters is
+// weighted 1 or 2 by its 0-based position (even -> 1, odd -> 2); each weighted
+// product is folded into base-36 range (quotient + remainder) and summed; the
+// check digit is (36 - sum % 36) % 36, read back through the same alphabet.
+function computeChecksum(first14) {
+	let sum = 0;
+	for (let i = 0; i < first14.length; i++) {
+		const value = ALPHABET.indexOf(first14[i]);
+		const weight = i % 2 === 0 ? 1 : 2;
+		const product = value * weight;
+		sum += Math.floor(product / 36) + (product % 36);
+	}
+	const check = (36 - (sum % 36)) % 36;
+	return ALPHABET[check];
+}
+
+/**
+ * Full validation: length, shape, state code, and checksum, all at once. A
+ * blank value is NOT a valid GSTIN (it is simply absent) - callers that treat
+ * the field as optional should check for blank separately, or use gstinError.
+ */
+export function isValidGstin(value) {
+	const v = (value || "").trim().toUpperCase();
+	if (v.length !== 15) return false;
+	if (!SHAPE_RE.test(v)) return false;
+	if (!isKnownStateCode(v.slice(0, 2))) return false;
+	return computeChecksum(v.slice(0, 14)) === v[14];
+}
+
+/**
+ * The customer-facing sentence for what is wrong with `value`, or "" when it
+ * is either valid or blank (GSTIN is optional on the Details step). Names the
+ * specific defect so the wizard never disagrees with the admin plane's own
+ * "billing.gstin is not a valid GSTIN" / "has an unrecognized state code" /
+ * "failed its checksum check" rejections - it catches the same three classes,
+ * just before checkout instead of after it.
+ */
+export function gstinError(value) {
+	const v = (value || "").trim().toUpperCase();
+	if (!v) return "";
+	if (v.length !== 15) return "GSTIN must be 15 characters.";
+	if (!SHAPE_RE.test(v)) return "That doesn't look like a GSTIN, check the letters and numbers.";
+	if (!isKnownStateCode(v.slice(0, 2))) return "GSTIN has an unrecognized state code.";
+	if (computeChecksum(v.slice(0, 14)) !== v[14])
+		return "GSTIN doesn't check out, please look for a typo.";
+	return "";
+}
+
+// A checksum-VALID example, computed (not guessed) from the same algorithm
+// above, so the placeholder never shows the customer an invalid GSTIN as a
+// model to copy. See gstin.test.js for the check against a hand run.
+export const GSTIN_PLACEHOLDER = "33ABCDE1234F1Z" + computeChecksum("33ABCDE1234F1Z");

--- a/frontend/src/onboarding/gstin.test.js
+++ b/frontend/src/onboarding/gstin.test.js
@@ -1,0 +1,61 @@
+// GSTIN validation: shape + state code + mod-36 checksum. Pure, node --test.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isValidGstin, gstinError, GSTIN_PLACEHOLDER } from "./gstin.js";
+
+test("GSTIN is optional: a blank value is never an error", () => {
+	assert.equal(gstinError(""), "");
+	assert.equal(gstinError("   "), "");
+	assert.equal(gstinError(undefined), "");
+	assert.equal(gstinError(null), "");
+	// isValidGstin is the strict "is this literally a GSTIN" check, so blank is
+	// not a valid GSTIN even though gstinError treats it as no error.
+	assert.equal(isValidGstin(""), false);
+});
+
+test("GSTIN_PLACEHOLDER is checksum-valid and case/whitespace-tolerant", () => {
+	assert.equal(isValidGstin(GSTIN_PLACEHOLDER), true);
+	assert.equal(gstinError(GSTIN_PLACEHOLDER), "");
+	// isValidGstin trims + uppercases before checking, per spec.
+	assert.equal(isValidGstin(`  ${GSTIN_PLACEHOLDER.toLowerCase()}  `), true);
+});
+
+test("a 23-character junk string fails on length, not shape or checksum", () => {
+	const junk = "12345678901234567890123";
+	assert.equal(junk.length, 23);
+	assert.equal(isValidGstin(junk), false);
+	assert.equal(gstinError(junk), "GSTIN must be 15 characters.");
+});
+
+test("a 15-character string with the wrong shape is rejected", () => {
+	// Right length, but digits where the PAN letters/checksum letter must be.
+	const wrongShape = "123456789012345";
+	assert.equal(wrongShape.length, 15);
+	assert.equal(isValidGstin(wrongShape), false);
+	assert.equal(
+		gstinError(wrongShape),
+		"That doesn't look like a GSTIN, check the letters and numbers."
+	);
+});
+
+test("an unrecognized state code is rejected even with a well-shaped GSTIN", () => {
+	// "00" is not an issued state/UT code (valid range is 01-38, plus 97 and 99).
+	const badState = "00ABCDE1234F1Z5";
+	assert.equal(isValidGstin(badState), false);
+	assert.equal(gstinError(badState), "GSTIN has an unrecognized state code.");
+});
+
+// The admin control plane rejects this exact value with "billing.gstin failed
+// its checksum check" - the current onboarding placeholder used to be this
+// string, so a customer copying the placeholder verbatim always failed at
+// checkout. The correct check char for "33ABCDE1234F1Z" is "7", not "5".
+test("33ABCDE1234F1Z5 fails the checksum specifically", () => {
+	const badChecksum = "33ABCDE1234F1Z5";
+	assert.equal(isValidGstin(badChecksum), false);
+	assert.equal(gstinError(badChecksum), "GSTIN doesn't check out, please look for a typo.");
+	// Swapping in the correct check char makes it pass, and matches the placeholder.
+	assert.equal(isValidGstin("33ABCDE1234F1Z7"), true);
+	assert.equal(GSTIN_PLACEHOLDER, "33ABCDE1234F1Z7");
+});

--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -45,6 +45,15 @@ export const CODES = {
 	BENCH_RATE_LIMITED: "BENCH_RATE_LIMITED",
 	BENCH_NO_SIGNUP_CONTEXT: "BENCH_NO_SIGNUP_CONTEXT",
 	BENCH_AWAITING_RECONCILIATION: "BENCH_AWAITING_RECONCILIATION",
+	// BENCH_SIGNUP_DETAILS_REJECTED - admin refused the customer's OWN submitted
+	// details (a malformed GSTIN, an unusable phone number) BEFORE any gateway was
+	// contacted. It used to collapse into BENCH_ADMIN_REJECTED, whose copy says "the
+	// payment service refused this request" and offers Check status / Initiate
+	// again. Every word of that was wrong: no payment service was involved, nothing
+	// existed to check, and retrying with the same data failed identically forever.
+	// The customer was left in an unrecoverable dead end, three screens past the
+	// field that actually caused it.
+	BENCH_SIGNUP_DETAILS_REJECTED: "BENCH_SIGNUP_DETAILS_REJECTED",
 	// plan-09 WS7 (bench-local): the admin-hosted pay-page cutover.
 	//
 	// PAYMENT_PAGE_REDIRECT — a token-bearing answer that is navigable (the bench's
@@ -85,6 +94,7 @@ export const BENCH_CODES = [
 	CODES.BENCH_RATE_LIMITED,
 	CODES.BENCH_NO_SIGNUP_CONTEXT,
 	CODES.BENCH_AWAITING_RECONCILIATION,
+	CODES.BENCH_SIGNUP_DETAILS_REJECTED,
 	// plan-09 WS7 cutover codes
 	CODES.PAYMENT_PAGE_REDIRECT,
 	CODES.BENCH_PAY_ORIGIN_UNCONFIGURED,
@@ -275,6 +285,24 @@ const TABLE = {
 		tone: TONE.STATUS,
 		actions: [ACTIONS.CHECK],
 	},
+	[CODES.BENCH_SIGNUP_DETAILS_REJECTED]: {
+		// A rejection of what the CUSTOMER typed, raised before any gateway existed.
+		// The headline therefore names the details, not a payment service, and the
+		// only sensible action is to go back and fix the field. `message` carries
+		// admin's own specific sentence ("billing.gstin failed its checksum check"),
+		// which the page renders underneath as the detail line, so two different
+		// causes no longer read as one identical failure.
+		headline: "We could not accept some of your details.",
+		body: "Nothing has been charged. Check the highlighted field and continue again.",
+		tone: TONE.ALERT,
+		// RESTART walks back to the Details step. It is safe here by construction:
+		// admin refuses this before it creates any provider object, so there is never
+		// a payment sitting behind it (see RESTART_SAFE_CODES in paymentMachine).
+		actions: [ACTIONS.RESTART, ACTIONS.SUPPORT],
+		// Per-row label override: "Start again" undersells this to the point of being
+		// misleading. Nothing is being started again - one field needs correcting.
+		actionLabels: { [ACTIONS.RESTART]: "Fix your details" },
+	},
 	// ---- plan-09 WS7: the admin-hosted pay-page cutover -----------------
 	[CODES.PAYMENT_PAGE_REDIRECT]: {
 		// The orchestrator top-level-navigates away the instant this lands, so this
@@ -342,6 +370,20 @@ export function copyFor(code, flags = {}) {
 		return PENDING_AWAITING_RECONCILIATION;
 	}
 	return TABLE[code] || UNKNOWN_COPY;
+}
+
+/**
+ * The label to render for one action on one row.
+ *
+ * Defaults to the shared vocabulary below, so two screens still cannot disagree,
+ * but lets a row override a label whose generic wording would mislead in its own
+ * context (see BENCH_SIGNUP_DETAILS_REJECTED, where "Start again" means "correct
+ * one field" and saying the former would send the customer looking for a way to
+ * abandon a signup that is fine).
+ */
+export function actionLabelFor(copy, action) {
+	const override = copy && copy.actionLabels && copy.actionLabels[action];
+	return override || ACTION_LABELS[action] || "";
 }
 
 /** Human labels for the affordances. One place, so two screens cannot disagree. */

--- a/frontend/src/onboarding/paymentCodes.test.js
+++ b/frontend/src/onboarding/paymentCodes.test.js
@@ -16,13 +16,17 @@ import {
 	UNKNOWN_COPY,
 } from "./paymentCodes.js";
 
-test("the vocabulary is 12 admin codes + 9 bench codes = 21", () => {
+test("the vocabulary is 12 admin codes + 10 bench codes = 22", () => {
 	// +3 bench codes from the plan-09 WS7 cutover: PAYMENT_PAGE_REDIRECT (the
 	// navigate-to-pay signal), BENCH_PAY_ORIGIN_UNCONFIGURED (a token we cannot
 	// navigate with) and CLIENT_UPGRADE_REQUIRED (a pre-cutover admin's raw handles).
+	// +1 for BENCH_SIGNUP_DETAILS_REJECTED: admin refusing the customer's own
+	// submitted details used to collapse into BENCH_ADMIN_REJECTED, whose copy blames
+	// a payment service that was never contacted and offers a retry that can only
+	// fail identically forever.
 	assert.equal(ADMIN_CODES.length, 12);
-	assert.equal(BENCH_CODES.length, 9);
-	assert.equal(new Set([...ADMIN_CODES, ...BENCH_CODES]).size, 21);
+	assert.equal(BENCH_CODES.length, 10);
+	assert.equal(new Set([...ADMIN_CODES, ...BENCH_CODES]).size, 22);
 });
 
 test("every code in the vocabulary has its own copy row", () => {

--- a/frontend/src/onboarding/paymentMachine.js
+++ b/frontend/src/onboarding/paymentMachine.js
@@ -118,6 +118,11 @@ const RESTART_SAFE_CODES = new Set([
 	// The capability/upgrade refusal precedes any provider object, so nothing
 	// recoverable sits behind it - "Start again" is safe (U4).
 	CODES.CLIENT_UPGRADE_REQUIRED,
+	// A details rejection is raised by admin BEFORE it creates any provider object,
+	// on exactly the same grounds as the refusal above: nothing recoverable can sit
+	// behind it, so walking the customer back to the Details step to correct the
+	// offending field is provably safe and is the ONLY useful recovery.
+	CODES.BENCH_SIGNUP_DETAILS_REJECTED,
 ]);
 
 export function isTerminalForPayment(value) {
@@ -240,6 +245,12 @@ function stateForCode(code, data) {
 			return STATES.UNKNOWN;
 		case CODES.INVALID_REQUEST:
 			return STATES.FAILED_RETRYABLE;
+		// The customer's own details were refused before any gateway existed. It is
+		// retryable in the only sense that matters here: correct the field and the
+		// same submission succeeds. Deliberately NOT terminal - a terminal state
+		// offers no way forward, and this one has an obvious one.
+		case CODES.BENCH_SIGNUP_DETAILS_REJECTED:
+			return STATES.FAILED_RETRYABLE;
 		default:
 			return null;
 	}
@@ -258,6 +269,7 @@ const PAYMENT_STATE_CODES = new Set([
 	CODES.PAYMENT_PAGE_REDIRECT,
 	CODES.CLIENT_UPGRADE_REQUIRED,
 	CODES.BENCH_PAY_ORIGIN_UNCONFIGURED,
+	CODES.BENCH_SIGNUP_DETAILS_REJECTED,
 ]);
 
 function recomputeCanCheck(next, nowMs) {

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -39,12 +39,20 @@ export function planSubtitleFor(plans) {
 	// coerce to NaN here, which fails both comparisons, so the honest paid-only
 	// wording wins whenever the catalog is not explicit about being free.
 	const amount = (v) => (v === null || v === undefined || v === "" ? NaN : Number(v));
-	const hasFreeOrTrial = list.some(
-		(p) => !!p && (amount(p.price_inr) === 0 || amount(p.trial_days) > 0)
-	);
-	return hasFreeOrTrial
-		? "Start free. Upgrade or extend anytime, with no auto-renewal."
-		: "Pick a plan to get started. No auto-renewal.";
+	// A genuinely FREE plan (price zero) and a TRIAL plan are not the same promise,
+	// and collapsing them is how this line came to say the opposite of what happens.
+	// A trial is gated behind a Razorpay RECURRING MANDATE: the card is rejected
+	// unless it is recurring-eligible, and when the trial ends the plan bills
+	// monthly until cancelled. So "no auto-renewal" was, for a trial-only catalog,
+	// billing consent copy that contradicted the instrument being authorized three
+	// screens later. Only a zero-price plan can honestly claim nothing renews.
+	const hasFree = list.some((p) => !!p && amount(p.price_inr) === 0);
+	const hasTrial = list.some((p) => !!p && amount(p.trial_days) > 0);
+	if (hasFree) return "Start free. Upgrade whenever you're ready.";
+	if (hasTrial) {
+		return "Start with a free trial. When it ends, billing continues automatically until you cancel.";
+	}
+	return "Pick a plan to get started. Billing continues automatically until you cancel.";
 }
 
 // jarvis.account.is_ready_for_chat (jarvis/account.py) returns

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -53,7 +53,8 @@ test("planSubtitleFor: no free or trial plan drops the free-tier promise", () =>
 // is 0, so the naive coercion reported the free-tier wording for a catalog
 // that charges for everything, which is the bug jarvis#536 was filed about.
 test("planSubtitleFor: an absent, null or blank price is not treated as free", () => {
-	const paidOnly = "Pick a plan to get started. Billing continues automatically until you cancel.";
+	const paidOnly =
+		"Pick a plan to get started. Billing continues automatically until you cancel.";
 	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: null }]), paidOnly);
 	assert.equal(planSubtitleFor([{ name: "ob-plan" }]), paidOnly);
 	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: "" }]), paidOnly);
@@ -87,15 +88,27 @@ test("planSubtitleFor: a trial-gated plan does NOT promise that nothing renews",
 	);
 	// A genuinely free plan still may, because nothing renews on a zero price.
 	assert.equal(
-		planSubtitleFor([{ name: "Free", price_inr: 0 }, { name: "Pro", trial_days: 7 }]),
+		planSubtitleFor([
+			{ name: "Free", price_inr: 0 },
+			{ name: "Pro", trial_days: 7 },
+		]),
 		"Start free. Upgrade whenever you're ready."
 	);
 });
 
 test("planSubtitleFor: an empty or missing plan list is not a false promise", () => {
-	assert.equal(planSubtitleFor([]), "Pick a plan to get started. Billing continues automatically until you cancel.");
-	assert.equal(planSubtitleFor(null), "Pick a plan to get started. Billing continues automatically until you cancel.");
-	assert.equal(planSubtitleFor(undefined), "Pick a plan to get started. Billing continues automatically until you cancel.");
+	assert.equal(
+		planSubtitleFor([]),
+		"Pick a plan to get started. Billing continues automatically until you cancel."
+	);
+	assert.equal(
+		planSubtitleFor(null),
+		"Pick a plan to get started. Billing continues automatically until you cancel."
+	);
+	assert.equal(
+		planSubtitleFor(undefined),
+		"Pick a plan to get started. Billing continues automatically until you cancel."
+	);
 });
 
 // jarvis.account.is_ready_for_chat returns {ready: bool, reason: str|None}

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -45,7 +45,7 @@ test("planSubtitleFor: no free or trial plan drops the free-tier promise", () =>
 			{ name: "ob-plan", price_inr: 1000, trial_days: 0 },
 			{ name: "Pro (Annual)", price_inr: 3000, trial_days: 0 },
 		]),
-		"Pick a plan to get started. No auto-renewal."
+		"Pick a plan to get started. Billing continues automatically until you cancel."
 	);
 });
 
@@ -53,7 +53,7 @@ test("planSubtitleFor: no free or trial plan drops the free-tier promise", () =>
 // is 0, so the naive coercion reported the free-tier wording for a catalog
 // that charges for everything, which is the bug jarvis#536 was filed about.
 test("planSubtitleFor: an absent, null or blank price is not treated as free", () => {
-	const paidOnly = "Pick a plan to get started. No auto-renewal.";
+	const paidOnly = "Pick a plan to get started. Billing continues automatically until you cancel.";
 	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: null }]), paidOnly);
 	assert.equal(planSubtitleFor([{ name: "ob-plan" }]), paidOnly);
 	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: "" }]), paidOnly);
@@ -66,7 +66,7 @@ test("planSubtitleFor: an absent, null or blank price is not treated as free", (
 	// A genuine zero still reads as free, including the string form.
 	assert.equal(
 		planSubtitleFor([{ name: "Free", price_inr: "0" }]),
-		"Start free. Upgrade or extend anytime, with no auto-renewal."
+		"Start free. Upgrade whenever you're ready."
 	);
 });
 
@@ -76,21 +76,26 @@ test("planSubtitleFor: a zero-price plan keeps the free-tier wording", () => {
 			{ name: "Free", price_inr: 0, trial_days: 0 },
 			{ name: "Pro (Annual)", price_inr: 3000, trial_days: 0 },
 		]),
-		"Start free. Upgrade or extend anytime, with no auto-renewal."
+		"Start free. Upgrade whenever you're ready."
 	);
 });
 
-test("planSubtitleFor: a trial-gated plan also keeps the free-tier wording", () => {
+test("planSubtitleFor: a trial-gated plan does NOT promise that nothing renews", () => {
 	assert.equal(
 		planSubtitleFor([{ name: "Pro", price_inr: 3000, trial_days: 7 }]),
-		"Start free. Upgrade or extend anytime, with no auto-renewal."
+		"Start with a free trial. When it ends, billing continues automatically until you cancel."
+	);
+	// A genuinely free plan still may, because nothing renews on a zero price.
+	assert.equal(
+		planSubtitleFor([{ name: "Free", price_inr: 0 }, { name: "Pro", trial_days: 7 }]),
+		"Start free. Upgrade whenever you're ready."
 	);
 });
 
 test("planSubtitleFor: an empty or missing plan list is not a false promise", () => {
-	assert.equal(planSubtitleFor([]), "Pick a plan to get started. No auto-renewal.");
-	assert.equal(planSubtitleFor(null), "Pick a plan to get started. No auto-renewal.");
-	assert.equal(planSubtitleFor(undefined), "Pick a plan to get started. No auto-renewal.");
+	assert.equal(planSubtitleFor([]), "Pick a plan to get started. Billing continues automatically until you cancel.");
+	assert.equal(planSubtitleFor(null), "Pick a plan to get started. Billing continues automatically until you cancel.");
+	assert.equal(planSubtitleFor(undefined), "Pick a plan to get started. Billing continues automatically until you cancel.");
 });
 
 // jarvis.account.is_ready_for_chat returns {ready: bool, reason: str|None}

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -26,6 +26,17 @@ import { reactive, ref, computed } from "vue";
 // The four Details-step inputs.
 export const BILLING_FIELDS = ["contact", "address", "city", "gstin"];
 
+// The two IDENTITY inputs (work email, company). They are not billing fields and
+// they carry no provenance, but they belong in the same snapshot for one blunt
+// reason: paying TOP-LEVEL NAVIGATES the whole tab away to the admin-hosted
+// checkout, so coming back is a fresh page load. Anything held only in the
+// wizard's in-memory `state` is gone by then. Email and company were held only
+// there, so a customer who came back from a failed payment and pressed Back found
+// the Details step blank, or prefilled with the SITE ADMINISTRATOR's email rather
+// than the one they had typed. Restoring them is the difference between resuming
+// and starting over.
+export const IDENTITY_FIELDS = ["email", "company"];
+
 // SPA field -> key in the shared billing-object contract
 // (jarvis/tests/fixtures/billing_contract/billing_snapshot.json). The bench
 // forwards this object to admin UNMODIFIED; admin owns the normalizer.
@@ -102,6 +113,11 @@ export function useBillingDetails(opts = {}) {
 
 	// C01-5 version-skew acknowledgement: false until admin echoes billing_saved.
 	const billingSaved = ref(false);
+	// The identity half of the snapshot (see IDENTITY_FIELDS). Held here rather
+	// than in the wizard's `state` so it survives the checkout round trip, and kept
+	// deliberately dumb: last write wins, no provenance, because unlike the billing
+	// fields nothing auto-fills these behind the customer's back.
+	const identity = reactive({ email: "", company: "" });
 	// Provenance of the last-applied ERP defaults, forwarded to admin so it can
 	// record where the snapshot originated. Never rendered on Review & Pay.
 	const sourceCompany = ref("");
@@ -187,6 +203,15 @@ export function useBillingDetails(opts = {}) {
 
 	// --- transitional localStorage (namespaced, ack-gated) --------------------
 
+	// Record the identity half of the snapshot. Called on every edit of the work
+	// email / company inputs, so a mid-flow reload or a checkout round trip finds
+	// them again.
+	function setIdentity(email, company) {
+		if (email !== undefined) identity.email = email == null ? "" : String(email);
+		if (company !== undefined) identity.company = company == null ? "" : String(company);
+		persist();
+	}
+
 	function persist() {
 		if (!storage) return;
 		try {
@@ -197,6 +222,8 @@ export function useBillingDetails(opts = {}) {
 					address: fields.address.value,
 					city: fields.city.value,
 					gstin: fields.gstin.value,
+					email: identity.email,
+					company: identity.company,
 				})
 			);
 		} catch (e) {
@@ -226,6 +253,17 @@ export function useBillingDetails(opts = {}) {
 				any = true;
 			}
 		}
+		// Identity restores unconditionally into whatever is still blank. There is no
+		// provenance to respect here, and the caller reads `identity` to decide
+		// whether to overwrite its own prefill (a restored value the CUSTOMER typed
+		// must beat getAccountDefaults, which can be the site admin's email).
+		for (const name of IDENTITY_FIELDS) {
+			const v = (d && d[name]) || "";
+			if (v && !identity[name]) {
+				identity[name] = v;
+				any = true;
+			}
+		}
 		return any;
 	}
 
@@ -244,8 +282,30 @@ export function useBillingDetails(opts = {}) {
 	function markBillingSaved(ack) {
 		const saved = ack === true;
 		billingSaved.value = saved;
-		if (saved) clearStorage();
+		// Deliberately does NOT clear the local snapshot any more, and this is the
+		// single most load-bearing change in this file.
+		//
+		// It used to, on the reasoning that once admin holds the data durably there
+		// is no reason to leave PII sitting in localStorage. The reasoning is sound;
+		// the TIMING was wrong. The ack arrives from start_signup, which is the call
+		// made immediately BEFORE the customer is navigated away to the checkout - so
+		// the snapshot was destroyed at the exact moment the only copy that could
+		// survive the round trip was needed. A customer whose payment then failed
+		// pressed Back and found the form empty, with nothing left to restore from
+		// except admin's own state read, which carries no snapshot for a signup that
+		// never completed.
+		//
+		// The privacy intent is preserved by clearing at the END of onboarding
+		// instead (see `finish`), which is where "we no longer need this locally"
+		// actually becomes true.
 		return saved;
+	}
+
+	// Onboarding is over: drop the transitional local copy. This is where the
+	// storage promise is finally kept, rather than at the durable-write ack (see
+	// markBillingSaved for why that was too early).
+	function finish() {
+		clearStorage();
 	}
 
 	// Cross-device recovery (P1-03 / brief §6): admin's authenticated state
@@ -269,7 +329,10 @@ export function useBillingDetails(opts = {}) {
 		if (summary.source_address) sourceAddress.value = String(summary.source_address);
 		if (any) {
 			markBillingSaved(true); // a stored snapshot is by definition persisted
-			clearStorage();
+			// The local copy is kept until onboarding finishes (see markBillingSaved):
+			// server truth having won here says nothing about whether the customer is
+			// about to be navigated away to checkout and back.
+			persist();
 		}
 		return any;
 	}
@@ -313,6 +376,9 @@ export function useBillingDetails(opts = {}) {
 
 	return {
 		fields,
+		identity,
+		setIdentity,
+		finish,
 		billingSaved,
 		sourceCompany,
 		sourceAddress,

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -67,6 +67,22 @@ export function billingStorageKey(site, user) {
 	return `${BILLING_LS_PREFIX}::${site || "_"}::${user || "_"}`;
 }
 
+// How long a transitional snapshot may live before it is treated as absent and
+// deleted on sight.
+//
+// This exists because the snapshot no longer dies at the durable-write ack (see
+// markBillingSaved: dying there is what emptied the Details form after a checkout
+// round trip). Moving the clear to the END of onboarding fixed resuming, but a
+// customer who ABANDONS - closes the tab at the pay screen, never comes back -
+// then never reaches the end, and their address, GSTIN and work email would sit
+// in localStorage on a shared or kiosk browser forever. Neither "clear at the ack"
+// nor "clear at the end" is sufficient on its own; retention has to be bounded by
+// TIME, which holds however the customer leaves.
+//
+// 24 hours matches the verification link's own life, so the window never outlives
+// a signup that could still legitimately be resumed.
+export const BILLING_SNAPSHOT_TTL_MS = 24 * 60 * 60 * 1000;
+
 // ERP-defaults response (get_company_onboarding_defaults data) -> field values.
 function fieldValuesFromDefaults(data) {
 	const contact = (data && data.contact) || {};
@@ -96,8 +112,10 @@ function fieldValuesFromSummary(s) {
  * @param {string} opts.site  canonical site identity (window.location.host)
  * @param {string} opts.user  logged-in user id (namespaces the transitional key)
  * @param {Storage} [opts.storage]  defaults to window.localStorage
+ * @param {Function} [opts.now]  ms clock, injected so the snapshot TTL is testable
  */
 export function useBillingDetails(opts = {}) {
+	const now = opts.now || (() => Date.now());
 	const site = opts.site || "";
 	const user = opts.user || "";
 	const storage =
@@ -224,6 +242,9 @@ export function useBillingDetails(opts = {}) {
 					gstin: fields.gstin.value,
 					email: identity.email,
 					company: identity.company,
+					// Stamped on every write so restore() can bound how long this PII
+					// lives, whatever happens to the session that wrote it.
+					saved_at: now(),
 				})
 			);
 		} catch (e) {
@@ -243,6 +264,21 @@ export function useBillingDetails(opts = {}) {
 			d = JSON.parse(storage.getItem(key) || "{}");
 		} catch (e) {
 			return false; // corrupt entry — ignore
+		}
+		// Past its window: treat as absent AND delete it. This is the retention bound
+		// that "clear when onboarding finishes" cannot provide on its own, because a
+		// customer who abandons at the pay screen never reaches the finish. Deleting
+		// on READ is deliberate: it needs no timer, no lifecycle hook and no
+		// cooperation from the page that abandoned, and the next visit to any
+		// onboarding screen is what collects it.
+		//
+		// A snapshot with NO stamp is one written by a build older than this change.
+		// It is dropped too, on the same reasoning: its age is unknowable, so it
+		// cannot be shown to be within the window.
+		const savedAt = Number(d && d.saved_at);
+		if (!Number.isFinite(savedAt) || now() - savedAt > BILLING_SNAPSHOT_TTL_MS) {
+			clearStorage();
+			return false;
 		}
 		let any = false;
 		for (const name of BILLING_FIELDS) {

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -221,14 +221,72 @@ describe("ack-gated storage promise (P0-01)", () => {
 		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
 	});
 
-	it("clears the local snapshot only after a durable ack", () => {
+	// The durable ack used to ALSO clear the local snapshot. It no longer does, and
+	// that is the fix rather than a regression: the ack arrives from start_signup,
+	// which is the call made immediately before the customer is top-level-navigated
+	// away to the checkout. Clearing there destroyed the only copy that could
+	// survive the round trip, so a customer who came back from a failed payment and
+	// pressed Back found an empty form. The promise is now kept at the END of
+	// onboarding instead, via finish().
+	it("keeps the local snapshot through a durable ack, so a checkout round trip can resume", () => {
 		const b = useBillingDetails({ site: "s1", user: "u1" });
 		b.setUserValue("city", "Chennai");
 		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy();
 		b.markBillingSaved(false);
 		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy(); // kept
 		b.markBillingSaved(true);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED); // the promise still flips
+		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy(); // but the copy stays
+	});
+
+	it("retires the local snapshot when onboarding finishes", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("city", "Chennai");
+		b.markBillingSaved(true);
+		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy();
+		b.finish();
 		expect(window.localStorage.getItem(b.storageKey)).toBeNull(); // retired
+	});
+});
+
+describe("identity survives the checkout round trip", () => {
+	it("persists and restores the work email and company", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setIdentity("payer@acme.test", "Acme Inc.");
+		// A fresh instance is what a return from the pay page actually produces: the
+		// tab navigated away, so nothing in memory survived.
+		const after = useBillingDetails({ site: "s1", user: "u1" });
+		expect(after.identity.email).toBe("");
+		after.restore();
+		expect(after.identity.email).toBe("payer@acme.test");
+		expect(after.identity.company).toBe("Acme Inc.");
+	});
+
+	it("stays namespaced: another site or user cannot see it", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setIdentity("payer@acme.test", "Acme Inc.");
+		const otherUser = useBillingDetails({ site: "s1", user: "u2" });
+		otherUser.restore();
+		expect(otherUser.identity.email).toBe("");
+		const otherSite = useBillingDetails({ site: "s2", user: "u1" });
+		otherSite.restore();
+		expect(otherSite.identity.company).toBe("");
+	});
+
+	// restore() fills BLANKS only. The wizard calls it once on mount, before the
+	// customer can type and before prefillAccount runs, which is what stops the site
+	// administrator's email (a different person) from replacing the payer's.
+	it("restore fills only what is still blank", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setIdentity("stored@acme.test", "Stored Co.");
+		const fresh = useBillingDetails({ site: "s1", user: "u1" });
+		fresh.restore();
+		expect(fresh.identity.email).toBe("stored@acme.test");
+		// A value present at restore time is never clobbered by a second restore.
+		fresh.identity.email = "typed@acme.test";
+		fresh.restore();
+		expect(fresh.identity.email).toBe("typed@acme.test");
+		expect(fresh.identity.company).toBe("Stored Co.");
 	});
 });
 
@@ -262,7 +320,7 @@ describe("Review & Pay card equals the normalized payload (P1-03)", () => {
 });
 
 describe("cross-device recovery — server snapshot wins (brief §6)", () => {
-	it("hydrates from admin's normalized summary, overriding local, and clears the remnant", () => {
+	it("hydrates from admin's normalized summary, overriding local, and rewrites the snapshot", () => {
 		const b = useBillingDetails({ site: "s1", user: "u1" });
 		b.setUserValue("city", "LocalCity"); // stale local value
 		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy();
@@ -278,7 +336,10 @@ describe("cross-device recovery — server snapshot wins (brief §6)", () => {
 		expect(b.fields.city.source).toBe("user"); // authoritative, non-overwritable
 		expect(b.billingSaved.value).toBe(true); // stored ⇒ saved
 		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
-		expect(window.localStorage.getItem(b.storageKey)).toBeNull(); // remnant cleared
+		// The remnant is REWRITTEN with server truth rather than deleted: onboarding
+		// is still in flight here, and the checkout round trip that follows would
+		// otherwise leave nothing to restore from (see markBillingSaved).
+		expect(JSON.parse(window.localStorage.getItem(b.storageKey)).city).toBe("ServerCity");
 		// A later ERP default cannot clobber the recovered snapshot.
 		fetchAndApply(b, "Aerele", DEF_A);
 		expect(b.fields.city.value).toBe("ServerCity");

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -4,6 +4,7 @@ import {
 	billingEditAction,
 	billingStorageKey,
 	STORAGE_PROMISE_SAVED,
+	BILLING_SNAPSHOT_TTL_MS,
 	STORAGE_PROMISE_LOCAL,
 } from "./useBillingDetails.js";
 
@@ -359,5 +360,42 @@ describe("edit-after-intent uses the authenticated facade, never guest signup (P
 		expect(billingEditAction(true)).toBe("update_billing");
 		// The action vocabulary never includes a guest-signup verb.
 		expect(billingEditAction(true)).not.toBe("signup");
+	});
+});
+
+describe("the snapshot has a bounded lifetime (retention)", () => {
+	// Moving the clear from the durable-write ack to the end of onboarding fixed
+	// resuming after a checkout round trip, but on its own it meant a customer who
+	// ABANDONED at the pay screen left billing PII in localStorage forever, since
+	// they never reach the end. Retention is therefore bounded by TIME as well,
+	// which holds however the customer leaves.
+	it("restores a fresh snapshot", () => {
+		const t = 1_000_000_000_000;
+		const a = useBillingDetails({ site: "s1", user: "u1", now: () => t });
+		a.setUserValue("city", "Chennai");
+		const b = useBillingDetails({ site: "s1", user: "u1", now: () => t + 60_000 });
+		expect(b.restore()).toBe(true);
+		expect(b.fields.city.value).toBe("Chennai");
+	});
+
+	it("drops and DELETES a snapshot past its window, even if nothing finished", () => {
+		const t = 1_000_000_000_000;
+		const a = useBillingDetails({ site: "s1", user: "u1", now: () => t });
+		a.setUserValue("gstin", "33ABCDE1234F1Z7");
+		expect(window.localStorage.getItem(a.storageKey)).toBeTruthy();
+		const later = t + BILLING_SNAPSHOT_TTL_MS + 1;
+		const b = useBillingDetails({ site: "s1", user: "u1", now: () => later });
+		expect(b.restore()).toBe(false);
+		expect(b.fields.gstin.value).toBe("");
+		// Collected on read: no timer, no lifecycle hook, no cooperation needed from
+		// the session that abandoned.
+		expect(window.localStorage.getItem(b.storageKey)).toBeNull();
+	});
+
+	it("drops an unstamped snapshot written by an older build", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		window.localStorage.setItem(b.storageKey, JSON.stringify({ city: "Chennai" }));
+		expect(b.restore()).toBe(false);
+		expect(window.localStorage.getItem(b.storageKey)).toBeNull();
 	});
 });

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -106,6 +106,11 @@ vi.mock("frappe-ui", () => {
 		Button: stub("Button"),
 		FormControl: stub("FormControl", "input"),
 		FeatherIcon: stub("FeatherIcon", "span"),
+		ErrorMessage: {
+			name: "ErrorMessage",
+			props: ["message"],
+			template: '<div v-if="message">{{ message }}</div>',
+		},
 		dayjs: () => ({ format: () => "", fromNow: () => "" }),
 		toast: { error: vi.fn(), success: vi.fn() },
 	};

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -48,6 +48,11 @@ vi.mock("vue-router", () => ({ useRouter: () => ({ replace: vi.fn() }) }));
 vi.mock("frappe-ui", () => ({
 	Button: { name: "Button", template: "<button><slot /></button>" },
 	FormControl: { name: "FormControl", template: "<input />" },
+	ErrorMessage: {
+		name: "ErrorMessage",
+		props: ["message"],
+		template: '<div v-if="message">{{ message }}</div>',
+	},
 	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
 	call: vi.fn(),
 	dayjs: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -215,23 +215,33 @@
 									>
 										Account
 									</div>
-									<FormControl
-										type="email"
-										variant="outline"
-										label="Work email"
-										:model-value="state.email"
-										@update:model-value="
-											(v) => {
-												state.email = v;
-												state.identityFromUser = true;
-											}
-										"
-										placeholder="you@company.com"
-										autocomplete="email"
-										required
-										aria-required="true"
-										@keydown.enter="onDetailsSubmit"
-									/>
+									<div class="flex flex-col gap-1">
+										<FormControl
+											type="email"
+											variant="outline"
+											label="Work email"
+											:model-value="state.email"
+											@update:model-value="
+												(v) => {
+													state.email = v;
+													billing.setIdentity(v, undefined);
+													state.identityFromUser = true;
+													clearFieldErrorIfValid('email', emailError, v);
+												}
+											"
+											placeholder="you@company.com"
+											autocomplete="email"
+											required
+											aria-required="true"
+											:aria-invalid="detailsFieldErrors.email ? 'true' : undefined"
+											:aria-describedby="
+												detailsFieldErrors.email ? 'jv-ob-email-err' : undefined
+											"
+											@blur="touchEmailField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage id="jv-ob-email-err" :message="detailsFieldErrors.email" />
+									</div>
 									<FormControl
 										type="tel"
 										variant="outline"
@@ -244,9 +254,23 @@
 										autocomplete="tel"
 										@keydown.enter="onDetailsSubmit"
 									/>
-									<div class="col-span-2 flex flex-col gap-1.5">
+									<!-- JvCombo (shared, out of scope) has no declared aria-invalid /
+										 aria-describedby / blur props, and does not spread $attrs onto
+										 its inner <input>, so those attrs would silently land on its
+										 root <div> instead of the actual control. The error message and
+										 aria therefore go on THIS wrapper, which we do own, rather than
+										 on JvCombo itself. Its error only clears on input (every
+										 keystroke already reaches us via update:model-value) - there is
+										 no reliable blur signal to hook without editing JvCombo. -->
+									<div
+										class="col-span-2 flex flex-col gap-1.5"
+										:aria-invalid="detailsFieldErrors.company ? 'true' : undefined"
+										:aria-describedby="
+											detailsFieldErrors.company ? 'jv-ob-company-err' : undefined
+										"
+									>
 										<label for="jv-ob-company" class="text-xs text-ink-gray-5"
-											>Company</label
+											>Company *</label
 										>
 										<JvCombo
 											id="jv-ob-company"
@@ -254,7 +278,9 @@
 											@update:model-value="
 												(v) => {
 													state.company = v;
+													billing.setIdentity(undefined, v);
 													state.identityFromUser = true;
+													clearFieldErrorIfValid('company', companyError, v);
 												}
 											"
 											allow-custom
@@ -264,6 +290,7 @@
 											placeholder="Acme Inc."
 											@enter="onDetailsSubmit"
 										/>
+										<ErrorMessage id="jv-ob-company-err" :message="detailsFieldErrors.company" />
 									</div>
 									<div
 										class="col-span-2 mt-2 text-base font-semibold text-ink-gray-9"
@@ -298,18 +325,34 @@
 										autocomplete="address-level2"
 										@keydown.enter="onDetailsSubmit"
 									/>
-									<FormControl
-										type="text"
-										variant="outline"
-										label="GSTIN (optional)"
-										:model-value="billing.fields.gstin.value"
-										@update:model-value="
-											(v) => billing.setUserValue('gstin', v)
-										"
-										placeholder="33ABCDE1234F1Z5"
-										@keydown.enter="onDetailsSubmit"
-									/>
+									<div class="flex flex-col gap-1">
+										<FormControl
+											type="text"
+											variant="outline"
+											label="GSTIN (optional)"
+											:model-value="billing.fields.gstin.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('gstin', v);
+													clearFieldErrorIfValid('gstin', gstinError, v);
+												}
+											"
+											:placeholder="GSTIN_PLACEHOLDER"
+											:aria-invalid="detailsFieldErrors.gstin ? 'true' : undefined"
+											:aria-describedby="
+												detailsFieldErrors.gstin ? 'jv-ob-gstin-err' : undefined
+											"
+											@blur="touchGstinField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage id="jv-ob-gstin-err" :message="detailsFieldErrors.gstin" />
+									</div>
 								</div>
+								<!-- state.detailsErr stays for genuinely form-wide messages (e.g.
+									 onPayClick's "your signup details are missing" guard). Per-field
+									 problems render under their own field above instead - a shared
+									 bottom banner with no tie to the field is what let a resolved
+									 error linger and gave no clue which input it meant. -->
 								<Banner
 									v-if="state.detailsErr"
 									type="error"
@@ -366,11 +409,89 @@
 							 Sub-screens are driven by the machine state (pay.value), never by
 							 an HTTP status or an error message. ===== -->
 						<section v-else-if="state.step === 'pay'" class="ob-screen">
+							<!-- Contact support: a real ticket, filed from here. It sits at the
+								 HEAD of this v-if chain so every screen that offers the support
+								 action (recovery, terminal, maintenance hold) reaches the same
+								 panel, and so it needs no portal - a teleported dialog would lose
+								 the jv-* palette vars this view binds on its own root. The action
+								 it replaces was a bare mailto:, which did nothing at all on a
+								 machine with no mail client. -->
+							<template v-if="supportOpen">
+								<div class="ob-body">
+									<div class="ob-head">
+										<h1>Get help with this</h1>
+										<p v-if="!supportTicket">
+											Tell us what happened and we'll pick it up. We'll attach
+											the technical details of this screen automatically, so
+											you don't have to describe them.
+										</p>
+										<p v-else role="status">
+											Thanks. We have your request and we'll reply to
+											{{ payEmail }}.
+										</p>
+									</div>
+									<div v-if="!supportTicket" class="mx-auto w-full max-w-[560px]">
+										<FormControl
+											v-model="supportBody"
+											type="textarea"
+											variant="outline"
+											label="What happened?"
+											:rows="4"
+											placeholder="I tried to pay and..."
+										/>
+										<details class="mt-3 text-p-xs text-ink-gray-5">
+											<summary class="cursor-pointer">
+												Details we'll attach
+											</summary>
+											<pre
+												class="mt-1.5 whitespace-pre-wrap break-words rounded-md bg-surface-gray-2 p-2.5"
+												>{{ supportContext }}</pre
+											>
+										</details>
+										<!-- Filing failed. Never leave the customer with a dead
+											 button: show the address so there is always a way
+											 through. -->
+										<Banner
+											v-if="supportErr"
+											class="mt-3"
+											type="error"
+											:message="`We couldn't file that for you (${supportErr}). Please email ${SUPPORT_EMAIL} and include the details above.`"
+										/>
+									</div>
+									<div
+										v-else
+										class="mx-auto w-full max-w-[560px] text-center text-p-sm text-ink-gray-5"
+									>
+										Reference
+										<b class="font-medium text-ink-gray-9">{{
+											supportTicket
+										}}</b
+										>. Please don't pay again while we look at it.
+									</div>
+								</div>
+								<div class="ob-foot">
+									<button class="ob-back" @click="closeSupport">
+										<FeatherIcon
+											name="chevron-left"
+											class="h-3.5 w-3.5 text-ink-gray-5"
+										/>Back
+									</button>
+									<Button
+										v-if="!supportTicket"
+										variant="solid"
+										:disabled="supportBusy || !supportBody.trim()"
+										:loading="supportBusy"
+										loading-text="Sending…"
+										label="Send to support"
+										@click="sendSupport"
+									/>
+								</div>
+							</template>
 							<!-- Paid: the payment step is over. Receipt + workspace-setup
 								 projection, rendered separately (plan 02 §Paid/provisioning).
 								 Provisioning belongs to the readiness gate, so this shows status
 								 only and never a payment action. -->
-							<template v-if="showPaidFlash || showProvisioning">
+							<template v-else-if="showPaidFlash || showProvisioning">
 								<div class="ob-body">
 									<div class="ob-head">
 										<h1>
@@ -570,6 +691,16 @@
 									>
 										{{ restartHeldNote }}
 									</p>
+									<!-- The outcome of the last "Check payment status". A check that
+										 changes nothing must still say so, or the button reads as
+										 broken. -->
+									<p
+										v-if="statusCheckNote"
+										class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
+										role="status"
+									>
+										{{ statusCheckNote }}
+									</p>
 								</div>
 								<div class="ob-foot">
 									<!-- A way back, always. A recovery screen with only forward
@@ -633,6 +764,18 @@
 											}}
 										</p>
 									</div>
+									<!-- A status check can legitimately land the customer back on
+										 this card (admin answers "no signup here" when the attempt
+										 never created an intent). Silently swapping the screen for a
+										 blank form is what made the check button look broken, so the
+										 outcome is stated here too. -->
+									<Banner
+										v-if="statusCheckNote"
+										type="info"
+										:message="statusCheckNote"
+										class="mx-auto mb-4 max-w-[560px]"
+										role="status"
+									/>
 									<div
 										class="mx-auto max-w-[560px] overflow-hidden rounded-lg border border-outline-gray-1"
 									>
@@ -1057,7 +1200,7 @@
 <script setup>
 import { reactive, ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
 import { useRouter } from "vue-router";
-import { Button, FormControl, FeatherIcon } from "frappe-ui";
+import { Button, FormControl, FeatherIcon, ErrorMessage } from "frappe-ui";
 import { useJarvisTheme } from "@/theme";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
 import JvCombo from "@/components/JvCombo.vue";
@@ -1081,6 +1224,7 @@ import {
 	getCompanyOnboardingDefaults,
 	updateBilling,
 	onboardingPaymentApi,
+	supportCreateTicket,
 } from "@/api";
 import {
 	createOperationController,
@@ -1098,11 +1242,19 @@ import {
 	remainingCooldownSeconds,
 	isTerminalForPayment,
 } from "@/onboarding/paymentMachine";
-import { ACTIONS, ACTION_LABELS, TONE, copyFor } from "@/onboarding/paymentCodes";
+import {
+	ACTIONS,
+	ACTION_LABELS,
+	CODES,
+	TONE,
+	actionLabelFor,
+	copyFor,
+} from "@/onboarding/paymentCodes";
 import { CHECKOUT_NAV_KEY, shouldHonorCheckoutReturn } from "@/onboarding/checkoutNav";
 import { makeTelemetryReporter } from "@/onboarding/paymentTelemetry";
 import { readCookie } from "@/lib/user";
 import { useBillingDetails, billingEditAction } from "@/onboarding/useBillingDetails";
+import { gstinError, GSTIN_PLACEHOLDER } from "@/onboarding/gstin";
 
 const router = useRouter();
 const { effectiveDark: dark, paletteVars } = useJarvisTheme();
@@ -1443,6 +1595,26 @@ function startWizard() {
 // Connect while their payment was never made. So payment truth
 // (get_onboarding_state, via flow.hydrate) is consulted FIRST, and only a paid
 // answer lets the connect shortcut fire. Fails open (default intro) on any error.
+// A PAID customer whose workspace is not chat-ready yet, for a reason that means
+// "the AI model still has to be chosen". Every one of these resumes on Connect,
+// which is the step the customer expects to land on the moment their payment goes
+// through.
+//
+// This used to be an inline two-value check (llm_credentials, llm_pool_provisioning)
+// while readiness.js's own NOT_ONBOARDED_REASONS listed five. The two that were
+// missing are the ones a fresh signup actually hits: `llm_provisioning` is the
+// direct/single-model analogue of llm_pool_provisioning, and `llm_setup` is the
+// half-finished signup whose payment has only just landed. Both fell through to
+// the else-branch below and parked the customer on the Pay step's provisioning
+// spinner instead of taking them to the AI model step, which is the "after payment
+// it did not go to the AI model page" report.
+const PAID_NEEDS_CONNECT_REASONS = new Set([
+	"llm_credentials",
+	"llm_pool_provisioning",
+	"llm_provisioning",
+	"llm_setup",
+]);
+
 async function reconcileMidFlightSignup() {
 	let truth;
 	try {
@@ -1464,10 +1636,7 @@ async function reconcileMidFlightSignup() {
 		} catch (e) {
 			/* readiness is advisory here - fall through to the pay projection */
 		}
-		if (
-			ready &&
-			(ready.reason === "llm_credentials" || ready.reason === "llm_pool_provisioning")
-		) {
+		if (ready && PAID_NEEDS_CONNECT_REASONS.has(ready.reason)) {
 			state.reconciledConnect = true;
 			state.step = "connect";
 			return;
@@ -1537,12 +1706,51 @@ function onPlanContinue() {
 }
 
 // ---- Details (Your Details) -------------------------------------------------
-// Validation matches the old Account step verbatim: email regex + non-empty
-// company. The four billing inputs are provenance-aware state owned by the
-// `billing` composable (Plan 01): edits are user-owned, the transitional
-// localStorage snapshot is namespaced by site+user and cleared only after
-// admin's billing_saved ack, and a Company change fetches ERP-derived defaults
-// behind a stale-response fence (fetchCompanyDefaults below).
+// Email + Company are required; GSTIN is validated (gstin.js) but optional -
+// the four billing inputs are provenance-aware state owned by the `billing`
+// composable (Plan 01): edits are user-owned, the transitional localStorage
+// snapshot is namespaced by site+user and cleared only after admin's
+// billing_saved ack, and a Company change fetches ERP-derived defaults behind
+// a stale-response fence (fetchCompanyDefaults below).
+
+// Per-field validators: each returns "" for a valid (or, where the field is
+// optional, blank) value, else the exact sentence shown under that field. Kept
+// as pure functions of a raw value so onDetailsSubmit's "validate everything
+// at once" and the per-field blur/input handlers below share one source of
+// truth instead of drifting. Email distinguishes EMPTY from MALFORMED - an
+// empty form used to report "Enter a valid email address", which is simply
+// untrue of a field nobody has typed into yet.
+function emailError(value) {
+	const v = (value || "").trim();
+	if (!v) return "Work email is required.";
+	return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(v) ? "" : "Enter a valid email address.";
+}
+function companyError(value) {
+	return (value || "").trim() ? "" : "Company name is required.";
+}
+// gstinError (gstin.js) already treats a blank value as "" (GSTIN is optional).
+
+// Details-step field errors, one bucket per field so each renders under its
+// OWN input via ErrorMessage instead of a single shared bar at the bottom with
+// no tie to what's wrong. Set all at once by onDetailsSubmit (every failure
+// shown together, not one submit per error); state.detailsErr stays reserved
+// for genuinely form-wide messages (see onPayClick's missing-details guard).
+const detailsFieldErrors = reactive({ email: "", company: "", gstin: "" });
+function touchEmailField() {
+	detailsFieldErrors.email = emailError(state.email);
+}
+function touchCompanyField() {
+	detailsFieldErrors.company = companyError(state.company);
+}
+function touchGstinField() {
+	detailsFieldErrors.gstin = gstinError(billing.fields.gstin.value);
+}
+// Called on every keystroke: only ever CLEARS an error that no longer applies
+// - it never shows a NEW one while the customer is still typing. Full
+// (re)validation happens on blur (touch*Field above) and on submit.
+function clearFieldErrorIfValid(name, errorFn, value) {
+	if (detailsFieldErrors[name] && !errorFn(value)) detailsFieldErrors[name] = "";
+}
 
 // ERP-derived billing defaults for the selected Company. Debounced (the Company
 // combo emits on every keystroke), fenced (beginCompanyFetch mints a monotonic
@@ -1576,14 +1784,15 @@ function onDetailsSubmit() {
 	state.detailsErr = "";
 	state.email = (state.email || "").trim();
 	state.company = (state.company || "").trim();
-	if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(state.email)) {
-		state.detailsErr = "Enter a valid email address.";
-		return;
-	}
-	if (!state.company) {
-		state.detailsErr = "Company name is required.";
-		return;
-	}
+	// Validate every field AT ONCE, not one submit per error: each failure lands
+	// under its own field via detailsFieldErrors, so a customer sees everything
+	// wrong in one pass instead of fixing email only to have the next click
+	// reveal Company was empty too. A bad GSTIN blocks here too, on this same
+	// step, instead of dead-ending at the pay button three screens later.
+	touchEmailField();
+	touchCompanyField();
+	touchGstinField();
+	if (detailsFieldErrors.email || detailsFieldErrors.company || detailsFieldErrors.gstin) return;
 	billing.persist();
 	// Editing billing after Review & Pay: return straight to Pay, and — once an
 	// intent exists — save the edit through the authenticated update_billing
@@ -1598,6 +1807,22 @@ function onDetailsSubmit() {
 	// sub-state now, and a fresh review renders from its REVIEW state. Clear the
 	// reconnect-code step's own error surface so a stale one does not linger.
 	state.payErr = "";
+	statusCheckNote.value = "";
+	// The customer just edited the details behind a FAILED attempt. Without this,
+	// walking forward from here landed them straight back on the old failure card
+	// with no new request made at all: the machine was still parked on the failed
+	// code, the pay step renders that card ahead of the review card, and the one
+	// button that names the obvious action ("Initiate payment again") is disabled
+	// on the codes this happens for. The corrected value sat in storage, unused,
+	// and the only escape was a non-obvious detour through "Check payment status".
+	//
+	// flow.restart() is exactly the right instrument and needs no new safety
+	// reasoning: it resets ONLY for codes that definitionally have no recoverable
+	// payment behind them (canSafelyRestart), and preserves the attempt and its
+	// recovery affordances for anything where money might exist. So a corrected
+	// GSTIN gets a clean re-submit, and a declined card still cannot be silently
+	// re-charged.
+	if (pay.value.value !== S.REVIEW) flow.restart();
 	goNext();
 }
 
@@ -1667,6 +1892,32 @@ function clearExternalCheckoutNav() {
 	} catch (e) {
 		/* no-op */
 	}
+}
+
+// The admin-hosted pay page now sends the customer back here when the payment
+// settles, rather than leaving them on a result screen whose only exit was a
+// "Back to your workspace" button running history.back(). It appends
+// `?pay=done|failed|pending`; this reads that hint and STRIPS it from the URL in
+// the same breath, so a later reload cannot replay a verdict that has since moved
+// on. The hint is advisory only - it never overrides server truth, it only stops
+// a returning customer being shown the intro tour while the control plane catches
+// up with the gateway.
+const CHECKOUT_OUTCOME_PARAM = "pay";
+const CHECKOUT_OUTCOMES = new Set(["done", "failed", "pending"]);
+function readCheckoutOutcome() {
+	let outcome = "";
+	try {
+		const url = new URL(window.location.href);
+		const raw = url.searchParams.get(CHECKOUT_OUTCOME_PARAM) || "";
+		if (CHECKOUT_OUTCOMES.has(raw)) outcome = raw;
+		if (url.searchParams.has(CHECKOUT_OUTCOME_PARAM)) {
+			url.searchParams.delete(CHECKOUT_OUTCOME_PARAM);
+			window.history.replaceState(null, "", url.pathname + url.search + url.hash);
+		}
+	} catch (e) {
+		/* no URL/history support: the reconcile below still runs on server truth */
+	}
+	return outcome;
 }
 
 const flow = createPaymentFlow({
@@ -1938,9 +2189,105 @@ function onReconnectIdentityInput() {
 // current state, P1-3), say so instead of leaving a silent no-op button.
 const restartHeldNote = ref("");
 
+// ---- "Check payment status" must always say something ----------------------
+// The button used to call flow.checkStatus() and nothing else. That is fine when
+// the answer is a payment state, because the machine repaints. It is NOT fine for
+// the answer this signup actually gets when its start_signup was rejected before
+// an intent existed: admin answers BENCH_NO_SIGNUP_CONTEXT, whose reducer branch
+// resets the machine to a blank REVIEW card. The customer pressed a button, the
+// screen silently became a fresh form, and nothing anywhere said why. That reads
+// as a broken button, and it is the "check payment status not working" report.
+const statusCheckNote = ref("");
+async function runStatusCheck() {
+	statusCheckNote.value = "";
+	const before = pay.value.value;
+	await flow.checkStatus();
+	const after = pay.value.value;
+	if (after === S.REVIEW && pay.value.notStarted) {
+		statusCheckNote.value =
+			"We checked, and there is no payment on this site to look up yet. Nothing has been charged. Enter your details and start the payment when you're ready.";
+		return;
+	}
+	if (after === before && !pay.value.transportError) {
+		// A real answer that changed nothing is still an answer. Saying so beats a
+		// button that appears to do nothing at all.
+		statusCheckNote.value = "We checked just now, and nothing has changed yet.";
+	}
+}
+
+// ---- Contact support: an actual ticket, not a mailto -----------------------
+// This action used to set window.location.href to a mailto: URL. On any machine
+// with no mail client configured - which is most browsers, and every kiosk and
+// most corporate desktops - clicking it did visibly nothing, which is the
+// "contact support not working" report. It also carried no context, so even when
+// it did open a composer the customer had to describe a failure they cannot see
+// the internals of.
+//
+// The app already has a real ticket API (jarvis.support.api.create_ticket) behind
+// @/api's supportCreateTicket, and the onboarding wizard runs authenticated, so
+// there is nothing stopping us filing the ticket properly. Rendered INLINE rather
+// than in a Dialog on purpose: a portaled dialog loses the jv-* palette vars this
+// view binds on its own root (design.md §2.2), and this panel is not worth that
+// risk.
+const SUPPORT_EMAIL = "support@aerele.in";
+const supportOpen = ref(false);
+const supportBody = ref("");
+const supportBusy = ref(false);
+const supportTicket = ref("");
+const supportErr = ref("");
+
+// What support needs to act without a round trip, and nothing a customer would be
+// alarmed to read: the coded state, the masked attempt reference the recovery card
+// already shows, and admin's own sentence. No token, no gateway id, no payload.
+const supportContext = computed(() => {
+	const rows = [
+		`Step: ${state.step}`,
+		`Payment state: ${pay.value.value || "unknown"}`,
+		`Code: ${pay.value.code || "none"}`,
+	];
+	if (maskedIntentRef.value) rows.push(`Reference: ${maskedIntentRef.value}`);
+	if (pay.value.message) rows.push(`Detail: ${pay.value.message}`);
+	return rows.join("\n");
+});
+
+function openSupport() {
+	supportErr.value = "";
+	supportTicket.value = "";
+	supportBody.value = "";
+	supportOpen.value = true;
+}
+
+function closeSupport() {
+	supportOpen.value = false;
+}
+
+async function sendSupport() {
+	if (supportBusy.value) return;
+	supportBusy.value = true;
+	supportErr.value = "";
+	try {
+		const subject = `Onboarding payment help (${pay.value.code || "no code"})`;
+		const body = `${supportBody.value.trim()}\n\n---\n${supportContext.value}`;
+		const d = (await supportCreateTicket(subject, body)) || {};
+		// The API answers {ok, data}; the ticket name is whatever data carries. Show
+		// it when present, but a successful call with an unfamiliar shape is still a
+		// success - never turn one into an error the customer has to act on.
+		supportTicket.value = (d.data && (d.data.name || d.data.ticket)) || "sent";
+	} catch (e) {
+		// Filing failed. Fall back to the address, visibly, so the customer is never
+		// left with a dead button again - which was the whole point of this change.
+		supportErr.value = errMsg(e);
+	} finally {
+		supportBusy.value = false;
+	}
+}
+
 function payActionLabel(a) {
 	if (a === ACTIONS.CHECK) return checkLabel.value;
-	return ACTION_LABELS[a] || "";
+	// actionLabelFor lets a row override a label whose shared wording would mislead
+	// in its own context - "Start again" on a details rejection, where the only
+	// thing being started again is one corrected field.
+	return actionLabelFor(payCopy.value, a);
 }
 function payActionDisabled(a) {
 	// Any mutating call in flight disables BOTH recovery actions (plan 02: server
@@ -1970,7 +2317,7 @@ function payActionVariant(a) {
 	return recoveryActions.value[0] === a ? "solid" : "subtle";
 }
 async function onPayAction(a) {
-	if (a === ACTIONS.CHECK) return flow.checkStatus();
+	if (a === ACTIONS.CHECK) return runStatusCheck();
 	if (a === ACTIONS.INITIATE) {
 		// Provider from SERVER TRUTH, not the local default. A resumed Cashfree
 		// signup renders "Payment method: Cashfree" one line above this button
@@ -1984,11 +2331,16 @@ async function onPayAction(a) {
 	}
 	if (a === ACTIONS.RECONNECT) return startReconnect();
 	if (a === ACTIONS.VERIFY) return flow.verifyAndContinue();
-	if (a === ACTIONS.SUPPORT) {
-		window.location.href = "mailto:support@aerele.in?subject=Jarvis%20onboarding%20payment";
-		return;
-	}
+	if (a === ACTIONS.SUPPORT) return openSupport();
 	if (a === ACTIONS.RESTART) {
+		// A details rejection is not a restart in any meaningful sense: admin named a
+		// field the customer typed wrongly, and the reset below wipes the machine (and
+		// with it admin's sentence) on the way to the Details step. Carry the sentence
+		// across so the step they land on says WHY they are there, instead of looking
+		// like the wizard threw their progress away for no reason.
+		if (pay.value.code === CODES.BENCH_SIGNUP_DETAILS_REJECTED) {
+			state.detailsErr = pay.value.message || payCopy.value.body;
+		}
 		// Server-truth-gated reset (P1-3): the flow resets the machine only when no
 		// recoverable payment can be behind the current code, otherwise it preserves
 		// the attempt and its recovery affordances. Editing details is offered only
@@ -2323,7 +2675,44 @@ function navigateToChat() {
 	forgetIdem();
 	opStore.forget();
 	forgetReady();
+	// Onboarding is over, so the transitional local billing snapshot has finally
+	// outlived its purpose. This is where the "kept in this browser for now" promise
+	// is honoured - NOT at the durable-write ack, which fires while the customer is
+	// still mid-flow and used to destroy the only copy that could survive the
+	// checkout round trip (see useBillingDetails.markBillingSaved).
+	billing.finish();
 	router.replace({ name: "Chat" });
+}
+
+// The AI applied but the workspace is not chat-ready yet. Poll readiness (a read,
+// cheap, no mutation) and navigate the moment it turns true. Bounded, and on
+// expiry it lands on the SAME honest retry state every other non-ready terminal
+// gets - never a silent navigation into a chat that cannot answer.
+const CHAT_READY_ATTEMPTS = 40;
+const CHAT_READY_INTERVAL_MS = 3000;
+async function waitForChatReadiness() {
+	for (let i = 0; i < CHAT_READY_ATTEMPTS; i++) {
+		if (navigated.value) return;
+		// The memoized verdict is what the router guard will read moments from now, so
+		// it has to be dropped before each probe or this loop polls a cached answer.
+		forgetReady();
+		let r = null;
+		try {
+			r = await isReadyForChat();
+		} catch (e) {
+			// A readiness call that throws is not a verdict. Keep waiting.
+		}
+		if (r && r.ready) {
+			navigateToChat();
+			return;
+		}
+		await _sleep(CHAT_READY_INTERVAL_MS);
+	}
+	state.finishing = true;
+	state.connectPhase = "retry";
+	state.connectMessage =
+		"Your AI is connected, but your workspace is taking longer than usual to come online. It's still finishing on its own, so you can keep waiting or retry.";
+	state.retryAfter = 0;
 }
 
 // The terminal handler for a followed operation. READY → navigate once; every other
@@ -2346,6 +2735,21 @@ function onTerminal(status) {
 	const ui = classifyOperation(status);
 	if (ui.canNavigate) {
 		navigateToChat();
+		return;
+	}
+	// The AI connection applied, but admin says the workspace is not chat-ready yet
+	// (chat_readiness === false - typically the serving container still coming up).
+	// This used to navigate anyway, because canNavigate only looked at the operation
+	// state, and the customer landed in a chat that could not answer with nothing on
+	// screen to explain it. Nothing is wrong here, so it is not a failure state: wait
+	// for readiness and then go, with an honest line about what is happening.
+	if (ui.awaitingChatReadiness) {
+		state.finishing = true;
+		state.connectPhase = "working";
+		state.finishSubtitle =
+			ui.chatReadinessReason ||
+			"Your AI is connected. Waiting for your workspace to come online…";
+		waitForChatReadiness();
 		return;
 	}
 	// A non-navigable terminal. onOpUpdate already rendered the matching phase; a
@@ -2721,10 +3125,29 @@ function onCheckoutVisibility() {
 }
 
 onMounted(async () => {
+	// Did we just come back from the admin-hosted checkout? The pay page appends
+	// `?pay=done|failed|pending` on its way out (jarvis_admin_v2's
+	// billing/checkout/workspace.py owns that vocabulary). Read it BEFORE anything
+	// else touches the URL, and strip it immediately so a later reload does not
+	// re-apply a stale verdict.
+	const checkoutReturn = readCheckoutOutcome();
 	// Restore the namespaced local billing snapshot FIRST: restored values are
 	// user-owned (local_restore), so the Company-defaults fetch prefillAccount
 	// triggers can only fill fields the customer left blank.
 	billing.restore();
+	// The identity half of that snapshot (work email, company). Applied before
+	// prefillAccount so what the CUSTOMER typed beats getAccountDefaults, which can
+	// legitimately answer with the SITE ADMINISTRATOR's email - a different person.
+	// Without this, returning from checkout showed the wrong email on the Details
+	// step, or none at all.
+	if (billing.identity.email) {
+		state.email = billing.identity.email;
+		state.identityFromUser = true;
+	}
+	if (billing.identity.company) {
+		state.company = billing.identity.company;
+		state.identityFromUser = true;
+	}
 	// Fired (not awaited) synchronously so providersLoading flips true on this same
 	// tick, before the awaited prefill below — the discovery loading note must show
 	// from first paint (X4), independent of prefill/company.
@@ -2761,6 +3184,15 @@ onMounted(async () => {
 	});
 	state.reconnectIntent = intent && landing === "details";
 	state.step = landing;
+	// Coming back from checkout must NEVER land on the intro tour. reconcile above
+	// already routes from server truth in the normal case, but there are real races
+	// where it cannot: the control plane may not have absorbed the gateway's answer
+	// yet, so a customer who genuinely paid ten seconds ago can hydrate as "nothing
+	// started" and be shown the marketing tour as though they had never signed up.
+	// The pay page told us where they came from, so honour that.
+	if (checkoutReturn && state.step === "intro") {
+		state.step = "pay";
+	}
 	// Prefetch the plan catalog behind the intro tour so the Plan step rarely
 	// first-paints in its loading state. Reconciled resumes land past "plan"
 	// and skip it (the step-entry watch still covers every other path).

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -233,14 +233,21 @@
 											autocomplete="email"
 											required
 											aria-required="true"
-											:aria-invalid="detailsFieldErrors.email ? 'true' : undefined"
+											:aria-invalid="
+												detailsFieldErrors.email ? 'true' : undefined
+											"
 											:aria-describedby="
-												detailsFieldErrors.email ? 'jv-ob-email-err' : undefined
+												detailsFieldErrors.email
+													? 'jv-ob-email-err'
+													: undefined
 											"
 											@blur="touchEmailField"
 											@keydown.enter="onDetailsSubmit"
 										/>
-										<ErrorMessage id="jv-ob-email-err" :message="detailsFieldErrors.email" />
+										<ErrorMessage
+											id="jv-ob-email-err"
+											:message="detailsFieldErrors.email"
+										/>
 									</div>
 									<FormControl
 										type="tel"
@@ -264,9 +271,13 @@
 										 no reliable blur signal to hook without editing JvCombo. -->
 									<div
 										class="col-span-2 flex flex-col gap-1.5"
-										:aria-invalid="detailsFieldErrors.company ? 'true' : undefined"
+										:aria-invalid="
+											detailsFieldErrors.company ? 'true' : undefined
+										"
 										:aria-describedby="
-											detailsFieldErrors.company ? 'jv-ob-company-err' : undefined
+											detailsFieldErrors.company
+												? 'jv-ob-company-err'
+												: undefined
 										"
 									>
 										<label for="jv-ob-company" class="text-xs text-ink-gray-5"
@@ -280,7 +291,11 @@
 													state.company = v;
 													billing.setIdentity(undefined, v);
 													state.identityFromUser = true;
-													clearFieldErrorIfValid('company', companyError, v);
+													clearFieldErrorIfValid(
+														'company',
+														companyError,
+														v
+													);
 												}
 											"
 											allow-custom
@@ -290,7 +305,10 @@
 											placeholder="Acme Inc."
 											@enter="onDetailsSubmit"
 										/>
-										<ErrorMessage id="jv-ob-company-err" :message="detailsFieldErrors.company" />
+										<ErrorMessage
+											id="jv-ob-company-err"
+											:message="detailsFieldErrors.company"
+										/>
 									</div>
 									<div
 										class="col-span-2 mt-2 text-base font-semibold text-ink-gray-9"
@@ -338,14 +356,21 @@
 												}
 											"
 											:placeholder="GSTIN_PLACEHOLDER"
-											:aria-invalid="detailsFieldErrors.gstin ? 'true' : undefined"
+											:aria-invalid="
+												detailsFieldErrors.gstin ? 'true' : undefined
+											"
 											:aria-describedby="
-												detailsFieldErrors.gstin ? 'jv-ob-gstin-err' : undefined
+												detailsFieldErrors.gstin
+													? 'jv-ob-gstin-err'
+													: undefined
 											"
 											@blur="touchGstinField"
 											@keydown.enter="onDetailsSubmit"
 										/>
-										<ErrorMessage id="jv-ob-gstin-err" :message="detailsFieldErrors.gstin" />
+										<ErrorMessage
+											id="jv-ob-gstin-err"
+											:message="detailsFieldErrors.gstin"
+										/>
 									</div>
 								</div>
 								<!-- state.detailsErr stays for genuinely form-wide messages (e.g.
@@ -421,16 +446,19 @@
 									<div class="ob-head">
 										<h1>Get help with this</h1>
 										<p v-if="!supportTicket">
-											Tell us what happened and we'll pick it up. We'll attach
-											the technical details of this screen automatically, so
-											you don't have to describe them.
+											Tell us what happened and we'll pick it up. We'll
+											attach the technical details of this screen
+											automatically, so you don't have to describe them.
 										</p>
 										<p v-else role="status">
 											Thanks. We have your request and we'll reply to
 											{{ payEmail }}.
 										</p>
 									</div>
-									<div v-if="!supportTicket" class="mx-auto w-full max-w-[560px]">
+									<div
+										v-if="!supportTicket"
+										class="mx-auto w-full max-w-[560px]"
+									>
 										<FormControl
 											v-model="supportBody"
 											type="textarea"

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1923,7 +1923,19 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	# by exc_type allowlist; default to AdminUnreachableError when the
 	# class isn't recognised.
 	if exc_type:
-		if exc_type in ("ValidationError", "DuplicateEntryError", "DoesNotExistError"):
+		if exc_type in (
+			"ValidationError",
+			"DuplicateEntryError",
+			"DoesNotExistError",
+			# A ValidationError SUBCLASS admin raises when the customer's own billing
+			# metadata is unusable. This list matches the exc_type STRING, not the
+			# class hierarchy, so a subclass is invisible here unless it is named:
+			# BillingMetadataRejected was therefore falling through to the unknown-
+			# exc_type branch below and being logged as a surprise on every bad
+			# GSTIN. It is a plain rejection with a precise, customer-safe message,
+			# which is exactly what this allowlist is for.
+			"BillingMetadataRejected",
+		):
 			# The THROWN wire shape: admin's contract ``error`` object rides at
 			# the top level next to exc_type. Both survive here - the code for a
 			# reader that has one, exc_type for the pre-contract admin that

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -103,6 +103,45 @@ BENCH_NO_SIGNUP_CONTEXT = "BENCH_NO_SIGNUP_CONTEXT"
 #: a second intent. Bench-local because the refusal is this facade's - admin's
 #: own durable guard is a separate, ledgered piece of work.
 BENCH_AWAITING_RECONCILIATION = "BENCH_AWAITING_RECONCILIATION"
+#: Admin refused the customer's OWN submitted details (a malformed GSTIN, an
+#: unusable contact number) BEFORE it built any provider object. Its own code
+#: because the generic BENCH_ADMIN_REJECTED it used to collapse into renders as
+#: "the payment service refused this request", which is false in every particular:
+#: no payment service was involved, nothing was created, nothing can be checked,
+#: and retrying the identical data fails identically forever. The customer was left
+#: at an unrecoverable dead end, three screens past the field that caused it, with
+#: the exact server sentence ("billing.gstin is not a valid GSTIN") thrown away.
+#: The recovery for this one is to go back and fix a field, and nothing else.
+BENCH_SIGNUP_DETAILS_REJECTED = "BENCH_SIGNUP_DETAILS_REJECTED"
+
+#: Admin exception classes that mean "what the customer typed is unusable", as
+#: opposed to "the request was refused for a reason the customer cannot see". These
+#: are matched on the wire ``exc_type`` string, so a class admin renames must be
+#: added here too - which is the same append-only discipline every other code in
+#: this module follows.
+_DETAILS_REJECTION_EXC_TYPES = frozenset({"BillingMetadataRejected"})
+
+#: Field prefixes admin uses when it names the offending input. A message starting
+#: with one of these is, by admin's own convention, about a value the customer
+#: entered, so it is safe to route to the details-rejection copy even from an admin
+#: build whose exception class this bench has never heard of.
+_DETAILS_REJECTION_PREFIXES = ("billing.",)
+
+
+def is_details_rejection(message: str, exc_type: str = "") -> bool:
+	"""Did admin refuse the customer's own submitted details?
+
+	Checked on the exception CLASS first (structural, admin's own vocabulary) and
+	only then on the message prefix, which is a documented convention rather than a
+	guess: ``_normalize_billing`` names the offending key and never the value. This
+	is not the prose-matching the contract exists to remove - it is a namespaced
+	field prefix, and getting it wrong degrades to the previous generic copy rather
+	than to a wrong verdict about money."""
+	if exc_type and exc_type in _DETAILS_REJECTION_EXC_TYPES:
+		return True
+	msg = (message or "").strip().lower()
+	return msg.startswith(_DETAILS_REJECTION_PREFIXES)
+
 
 RECOVERY_RETRY = "retry"
 RECOVERY_CONTINUE_SETUP = "continue_setup"
@@ -691,9 +730,19 @@ def error_object(err) -> tuple[dict, int]:
 		# An admin older than the contract: a real rejection with a real
 		# message, and no machine code anywhere in it. Fail closed onto the
 		# generic branch rather than reading the sentence.
-		out = {"code": BENCH_ADMIN_REJECTED, "message": str(err), "recovery": RECOVERY_RETRY}
-		if getattr(err, "exc_type", None):
-			out["exc_type"] = err.exc_type
+		exc_type = getattr(err, "exc_type", None) or ""
+		message = str(err)
+		# ...EXCEPT when the rejection is about a field the customer typed. That is a
+		# different failure with a different recovery (fix the field, not retry the
+		# payment), and answering it with the generic code told the customer their
+		# PAYMENT SERVICE had refused - a service that was never contacted, since
+		# admin refuses this before it builds any provider object.
+		code = (
+			BENCH_SIGNUP_DETAILS_REJECTED if is_details_rejection(message, exc_type) else BENCH_ADMIN_REJECTED
+		)
+		out = {"code": code, "message": message, "recovery": RECOVERY_RETRY}
+		if exc_type:
+			out["exc_type"] = exc_type
 		return out, 409
 	if isinstance(err, AdminRejectedError):
 		# Admin was REACHED and permanently refused (its fleet layer answers a

--- a/jarvis/tests/test_admin_contract.py
+++ b/jarvis/tests/test_admin_contract.py
@@ -482,3 +482,51 @@ class TestFacadeErrorObjects(_ContractCase):
 		self.assertEqual(error["code"], onboarding_contract.BENCH_ADMIN_REJECTED)
 		self.assertEqual(error["exc_type"], "DuplicateEntryError")
 		self.assertEqual(status, 409)
+
+
+class TestDetailsRejectionIsNotAPaymentFailure(_ContractCase):
+	"""Admin refusing what the CUSTOMER typed is a different failure from admin
+	refusing the request, and it used to be answered as the latter.
+
+	`BillingMetadataRejected` is a ValidationError SUBCLASS, and admin_client
+	matches exc_type by exact string, so it fell through the allowlist into the
+	unknown branch and came out as BENCH_ADMIN_REJECTED. That code renders as "the
+	payment service refused this request" over "Check the status, or start a new
+	payment" - and no payment service had been contacted, nothing existed to
+	check, and retrying identical data failed identically forever. The customer
+	dead-ended three screens past the field that caused it."""
+
+	def test_billing_metadata_rejection_gets_its_own_code(self):
+		err = AdminValidationError("billing.gstin is not a valid GSTIN")
+		err.exc_type = "BillingMetadataRejected"
+		error, status = onboarding_contract.error_object(err)
+		self.assertEqual(error["code"], onboarding_contract.BENCH_SIGNUP_DETAILS_REJECTED)
+		self.assertEqual(status, 409)
+		# The precise server sentence is what makes this actionable; it must survive.
+		self.assertEqual(error["message"], "billing.gstin is not a valid GSTIN")
+
+	def test_an_unknown_exc_type_still_routes_on_the_field_prefix(self):
+		"""An admin build whose exception class this bench has never heard of still
+		names the field by admin's own convention, so the customer is not punished
+		for a version skew."""
+		err = AdminValidationError("billing.contact_number is not a valid phone number")
+		err.exc_type = "SomeFutureRejection"
+		error, _status = onboarding_contract.error_object(err)
+		self.assertEqual(error["code"], onboarding_contract.BENCH_SIGNUP_DETAILS_REJECTED)
+
+	def test_an_ordinary_rejection_is_untouched(self):
+		"""The generic path must NOT be widened: a refusal that is not about a field
+		the customer typed still answers BENCH_ADMIN_REJECTED."""
+		err = AdminValidationError("Unsupported payment provider.")
+		err.exc_type = "ValidationError"
+		error, _status = onboarding_contract.error_object(err)
+		self.assertEqual(error["code"], onboarding_contract.BENCH_ADMIN_REJECTED)
+
+	def test_the_predicate_is_not_prose_matching(self):
+		"""It keys on the exception class and on a NAMESPACED field prefix, never on
+		a sentence. A reworded message that still names its field keeps working; a
+		message that merely mentions billing does not qualify."""
+		self.assertTrue(onboarding_contract.is_details_rejection("", "BillingMetadataRejected"))
+		self.assertTrue(onboarding_contract.is_details_rejection("billing.city is too long"))
+		self.assertFalse(onboarding_contract.is_details_rejection("your billing could not be processed"))
+		self.assertFalse(onboarding_contract.is_details_rejection(""))


### PR DESCRIPTION
## Summary

Fixes eight reported onboarding failures plus the P1 blockers found alongside them. A customer who pays is now taken to the AI model step instead of being left on the pay page; a customer who fails no longer finds an empty form when they go back; and the errors along the way say what actually happened.

The load-bearing ones:

- **Fields went blank after paying.** Email and company were never persisted anywhere, and the billing snapshot was deleted on admin's durable-write ack, which is the call made immediately *before* the tab navigates away to checkout. Both now survive the round trip and are retired when onboarding finishes.
- **"The payment service refused this request"** was shown for a bad GSTIN, which never reaches a payment service. `BillingMetadataRejected` is a `ValidationError` subclass and `admin_client` matches `exc_type` by exact string, so it fell through to the generic code. It now has its own code, keeps admin's exact sentence, and sends the customer back to the field.
- **Chat opened before it worked.** `classifyOperation` read `chat_readiness` and ignored it.
- **"Check payment status" and "Contact support" did nothing visible.** The first could silently blank the screen; the second was a bare `mailto:`. Support now files a real ticket with the coded state attached.

Also: GSTIN is validated on the Details step rather than dead-ending three screens later, the placeholder is no longer itself invalid, per-field errors are wired for screen readers, and the plan step no longer promises "no auto-renewal" while setting up a recurring mandate.

The intro tour's chat slide is now first and animated (pure CSS, theme-aware, honours `prefers-reduced-motion`, no image assets).

<details>
<summary>Verification</summary>

- 760 vitest + 137 `node --test`, all passing.
- `ruff check` and `ruff format --check` clean on the Python changes.
- Both changed SFCs compile (`@vue/compiler-sfc`). `vite build` cannot run in a worktree that is not a linked bench site; that failure reproduces on the unmodified base commit.
- Specs that pinned the old clear-on-ack and "no auto-renewal" behaviour were updated, with the reasoning recorded at each assertion.
- Not yet verified end to end against a live signup: needs a paid run through the paired admin-v2 branch.
</details>

Pairs with Aerele-RnD/jarvis-admin-v2 `fix/checkout-return-and-errors`, which supplies the return URL this branch consumes. **Merge that one first.**

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff

https://claude.ai/code/session_0172HQoE7QCUQvEQLK8XQaLz