### PR TITLE
fix: refresh six stale PROVIDER_DEFAULTS to match the model catalog

### DIFF
--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -496,3 +496,91 @@ describe("the status keeps updating past the blocking wait (defect 3)", () => {
 		expect(api.getLlmSyncStatus.mock.calls.length).toBe(before);
 	});
 });
+
+/**
+ * PROVIDER_DEFAULTS is the local fallback for "which api-key model does this
+ * provider preselect", used only while the admin catalog fetch is in flight or
+ * after it fails. It is a hand-maintained mirror of the catalog's api_key
+ * is_default, and nothing enforces the pairing: the 2026-07-26 catalog refresh
+ * moved six ids and left this copy behind, so a customer whose catalog fetch
+ * failed got preselected onto two vendor-DEPRECATED ids (deepseek-chat, retired
+ * 2026-07-24, and llama-3.3-70b-versatile, retired 2026-06-17).
+ *
+ * These lock the fallback to the catalog. If a future refresh moves an id in
+ * jarvis/_model_catalog.py without moving it here, this fails instead of
+ * silently shipping a dead default.
+ */
+describe("api-key model defaults survive a failed catalog fetch", () => {
+	// The six the 2026-07-26 refresh stranded, plus the ones that were already
+	// correct, so the whole table is covered rather than just the regression.
+	const EXPECTED = {
+		OpenAI: "gpt-5.6",
+		Anthropic: "claude-sonnet-5",
+		"Google Gemini": "gemini-3.6-flash",
+		Mistral: "mistral-large-latest",
+		Groq: "openai/gpt-oss-120b",
+		"Together AI": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+		DeepSeek: "deepseek-v4-flash",
+		"Moonshot (Kimi)": "kimi-k2.6",
+		"xAI Grok": "grok-4.5",
+		"GLM / Z.ai": "glm-4.7",
+		"GLM / Z.ai (Coding Plan)": "glm-4.7",
+		OpenRouter: "anthropic/claude-sonnet-4-6",
+		"Ollama (local)": "llama3",
+	};
+
+	it("falls back to the catalog's current api_key default for every provider", async () => {
+		api.getModelCatalogUi.mockRejectedValue(new Error("admin unreachable"));
+		const w = await mountEditor();
+
+		for (const [label, model] of Object.entries(EXPECTED)) {
+			expect(`${label}=${w.vm.providerDefaultModel(label)}`).toBe(`${label}=${model}`);
+		}
+	});
+
+	it("never falls back to a vendor-deprecated id", async () => {
+		api.getModelCatalogUi.mockRejectedValue(new Error("admin unreachable"));
+		const w = await mountEditor();
+
+		expect(w.vm.providerDefaultModel("DeepSeek")).not.toBe("deepseek-chat");
+		expect(w.vm.providerDefaultModel("Groq")).not.toBe("llama-3.3-70b-versatile");
+	});
+
+	it("clears the model for providers that have no default", async () => {
+		api.getModelCatalogUi.mockRejectedValue(new Error("admin unreachable"));
+		const w = await mountEditor();
+
+		expect(w.vm.providerDefaultModel("vLLM (local)")).toBe("");
+		expect(w.vm.providerDefaultModel("OpenAI-Compatible")).toBe("");
+	});
+
+	it("snaps a row's model to the fallback when the provider is switched", async () => {
+		api.getModelCatalogUi.mockRejectedValue(new Error("admin unreachable"));
+		const w = await mountEditor();
+		const row = w.vm.rows[0] || (w.vm.rows.push(w.vm.newRow?.() ?? {}), w.vm.rows[0]);
+
+		w.vm.onProviderChange(row, "DeepSeek");
+		expect(row.model).toBe("deepseek-v4-flash");
+		expect(row.baseUrl).toBe("https://api.deepseek.com");
+
+		w.vm.onProviderChange(row, "Groq");
+		expect(row.model).toBe("openai/gpt-oss-120b");
+	});
+
+	it("prefers the fetched catalog over the local literal", async () => {
+		// The literal is only a stand-in. When admin answers, admin wins - that is
+		// what lets an operator add a model in the desk with no deploy.
+		api.getModelCatalogUi.mockResolvedValue({
+			api_key_models: {
+				DeepSeek: [{ model_id: "deepseek-v9-future", label: "", is_default: true }],
+			},
+			subscription_models: {},
+			default_models: {},
+		});
+		const w = await mountEditor();
+
+		expect(w.vm.providerDefaultModel("DeepSeek")).toBe("deepseek-v9-future");
+		// A provider the catalog did not mention still uses the literal.
+		expect(w.vm.providerDefaultModel("Groq")).toBe("openai/gpt-oss-120b");
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -2070,14 +2070,21 @@ const providerOptions = PROVIDER_LABELS.map((p) => p.label);
 // admin-managed catalog (modelCatalog.value.api_key_models, fetched in load())
 // is now the source, so a model added in the admin desk shows up here with no
 // deploy. See modelSuggestionsForProvider below.
+//
+// Every `model` here MUST mirror that provider's api_key is_default in the admin
+// seed (jarvis_admin_v2/fleet/provider_catalog.py PROVIDER_SEED, whose generated
+// mirror is jarvis/_model_catalog.py). Nothing enforces that, so a catalog refresh
+// silently strands this copy: six of these were left behind by the 2026-07-26
+// refresh and preselected deprecated ids until 2026-08-06. Re-check the pair when
+// bumping either side.
 const PROVIDER_DEFAULTS = {
-	Anthropic: { model: "claude-sonnet-4-6", baseUrl: "https://api.anthropic.com" },
-	// "gpt-5.5" is this literal's FALLBACK value only, used before the catalog
+	Anthropic: { model: "claude-sonnet-5", baseUrl: "https://api.anthropic.com" },
+	// "gpt-5.6" is this literal's FALLBACK value only, used before the catalog
 	// fetch lands or if it fails - providerDefaultModel() below prefers the
 	// catalog's is_default flag. Previously a stale "gpt-4o" here (fixed
 	// alongside the catalog wiring: PROVIDER_DEFAULTS.OpenAI predates the
 	// gpt-5.x rollout and was never updated).
-	OpenAI: { model: "gpt-5.5", baseUrl: "https://api.openai.com/v1" },
+	OpenAI: { model: "gpt-5.6", baseUrl: "https://api.openai.com/v1" },
 	// Flash, not pro: Google grants pro-tier models zero free quota, so a
 	// gemini-2.5-pro fallback 429s on the free key most customers start with.
 	// Matches the catalog's api_key is_default, which this only stands in for.
@@ -2086,21 +2093,25 @@ const PROVIDER_DEFAULTS = {
 		baseUrl: "https://generativelanguage.googleapis.com",
 	},
 	Mistral: { model: "mistral-large-latest", baseUrl: "https://api.mistral.ai/v1" },
-	Groq: { model: "llama-3.3-70b-versatile", baseUrl: "https://api.groq.com/openai/v1" },
+	// gpt-oss, not llama: Groq deprecated llama-3.3-70b-versatile on 2026-06-17
+	// and points migrations at the gpt-oss routes.
+	Groq: { model: "openai/gpt-oss-120b", baseUrl: "https://api.groq.com/openai/v1" },
 	"Together AI": {
 		model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
 		baseUrl: "https://api.together.xyz/v1",
 	},
-	DeepSeek: { model: "deepseek-chat", baseUrl: "https://api.deepseek.com" },
+	// deepseek-chat was deprecated 2026-07-24 and only maps to deepseek-v4-flash
+	// during a compatibility window, so it must not be what a new key preselects.
+	DeepSeek: { model: "deepseek-v4-flash", baseUrl: "https://api.deepseek.com" },
 	"Moonshot (Kimi)": { model: "kimi-k2.6", baseUrl: "https://api.moonshot.ai/v1" },
 	"xAI Grok": { model: "grok-4.5", baseUrl: "https://api.x.ai/v1" },
-	"GLM / Z.ai": { model: "glm-4.6", baseUrl: "https://api.z.ai/api/paas/v4" },
+	"GLM / Z.ai": { model: "glm-4.7", baseUrl: "https://api.z.ai/api/paas/v4" },
 	// GLM Coding Plan is a separate z.ai subscription from pay-as-you-go "GLM / Z.ai"
 	// above - a coding-plan key 402s with "insufficient balance" on the pay-as-you-go
 	// base URL even though it's perfectly valid on this one (see apiKeyModelHealth's
 	// targeted hint in pool.js for the exact trap this option exists to avoid).
 	"GLM / Z.ai (Coding Plan)": {
-		model: "glm-4.6",
+		model: "glm-4.7",
 		baseUrl: "https://api.z.ai/api/coding/paas/v4",
 	},
 	OpenRouter: { model: "anthropic/claude-sonnet-4-6", baseUrl: "https://openrouter.ai/api/v1" },

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -2901,7 +2901,7 @@ function onProviderChange(m, newProvider) {
 	m.provider = newProvider;
 	if (!changed) return;
 	// Snap the model + base URL to the NEW provider's defaults, replacing any
-	// leftover from the previous provider — so picking "GLM / Z.ai" gives glm-4.6,
+	// leftover from the previous provider — so picking "GLM / Z.ai" gives glm-4.7,
 	// not whatever model was there before. Providers with no default model
 	// (OpenAI-Compatible / vLLM) clear the field so the user types their own.
 	const d = PROVIDER_DEFAULTS[m.provider] || {};


### PR DESCRIPTION
## Summary

The pool editor preselected superseded model ids for six providers when the admin model catalog had not loaded. Two of them were vendor-deprecated, so a customer adding a DeepSeek or Groq key in that window started on a retired model.

`PROVIDER_DEFAULTS` is a local fallback used before the catalog fetch lands or if it fails. It is a hand-maintained mirror of the catalog's api_key `is_default`, and the 2026-07-26 catalog refresh updated the seed without updating this copy.

| Provider | Was | Now |
|---|---|---|
| OpenAI | `gpt-5.5` | `gpt-5.6` |
| Anthropic | `claude-sonnet-4-6` | `claude-sonnet-5` |
| Groq | `llama-3.3-70b-versatile` (deprecated 2026-06-17) | `openai/gpt-oss-120b` |
| DeepSeek | `deepseek-chat` (deprecated 2026-07-24) | `deepseek-v4-flash` |
| GLM / Z.ai | `glm-4.6` | `glm-4.7` |
| GLM / Z.ai (Coding Plan) | `glm-4.6` | `glm-4.7` |

All 15 entries now match `jarvis/_model_catalog.py`. No behavior change when the catalog loads normally: `providerDefaultModel()` already prefers the catalog's `is_default`.

Nothing enforced that pairing, which is why the drift lasted eleven days, so the second commit adds tests that do. They mount the editor with `getModelCatalogUi` rejecting (the only state where the literal is reachable) and assert the fallback for all 13 providers that have a default, that neither deprecated id can return, that vLLM and OpenAI-Compatible still clear the field, and that a fetched catalog still wins over the literal.

<details>
<summary>How this was verified</summary>

- The new tests were run against the pre-fix commit: 4 of 5 fail, naming `gpt-5.5`, `deepseek-chat` and `llama-3.3-70b-versatile`.
- Every `PROVIDER_DEFAULTS` entry was diffed against the api_key `is_default` in `jarvis/_model_catalog.py`: 15/15 match, 0 mismatches.
- Browser verification of the live editor was not possible here: it sits behind the onboarding Pay step and this signup has no open checkout.

</details>

## Pre-merge checklist

- [x] **CI is green** - all 7 checks pass on `85a88203`
- [x] Branch is **up to date with `develop`** (branched from `upstream/develop` at `1f3e30e7`)
- [x] New/changed behavior has tests (5 new cases; frontend suite 768 passing, was 763)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01A34AUVP2eMaFFeSXkGdLQy