### PR TITLE
refactor(billing): drop the tenant Pay origin field; follow the admin URL

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -77,8 +77,6 @@
   "jarvis_admin_customer_email",
   "jarvis_admin_customer_password",
   "signup_context",
-  "checkout_section",
-  "jarvis_pay_origin",
   "operator_section",
   "agent_url",
   "agent_token",
@@ -542,18 +540,6 @@
    "label": "Jarvis Admin URL",
    "read_only": 1,
    "description": "HTTPS URL of the Jarvis admin host. Used for signup, billing, subscription state."
-  },
-  {
-   "fieldname": "checkout_section",
-   "fieldtype": "Section Break",
-   "label": "Checkout"
-  },
-  {
-   "fieldname": "jarvis_pay_origin",
-   "fieldtype": "Data",
-   "permlevel": 1,
-   "label": "Pay origin",
-   "description": "Where the browser is sent for the admin-hosted checkout. Leave blank to follow the bench's admin URL (jarvis_admin_url) — checkout is hosted on the control plane; set it only when the checkout host differs. site_config 'jarvis_pay_origin' still overrides. Operator-set only — the signup/connect flow never writes it (it anchors the origin-digest cross-check); must match the admin's pay origin. In test mode a plain-http origin is fine for local/staging."
   },
   {
    "fieldname": "jarvis_admin_api_key",

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -329,9 +329,6 @@ def strip_credentials(data: dict | None) -> dict:
 # response instead carries a NON-NAVIGABLE origin digest (§R P0-3) the bench
 # cross-checks against its own configured origin before the frontend navigates.
 # --------------------------------------------------------------------------- #
-#: The origin the bench navigates to for checkout. Resolves site_config ->
-#: ``Jarvis Settings.jarvis_pay_origin`` -> the bench's admin URL; a bad value fails closed.
-CONF_PAY_ORIGIN = "jarvis_pay_origin"
 #: The frozen envelope key admin uses for the pay-page token (brief §Frozen
 #: contract). Its presence is what turns a response into a navigate-to-pay one.
 PAY_PAGE_TOKEN_KEY = "pay_page_token"
@@ -367,19 +364,12 @@ def _normalize_pay_origin(raw: str | None) -> str:
 
 
 def _resolved_pay_origin() -> str:
-	"""The bench's pay origin, normalized: site_config -> ``Jarvis Settings`` field ->
-	the bench's admin URL (checkout is hosted on the control plane). Read fresh; never
-	raises. The field is operator-only and MUST NOT be written by the connect/sync flow
-	- it anchors the digest cross-check."""
+	"""The bench's pay origin, normalized: the bench's admin URL (checkout is hosted on
+	the control plane, so the admin URL the bench already knows IS the checkout origin).
+	Read fresh; never raises. This anchors the digest cross-check against admin."""
 	from jarvis.hooks import get_default_admin_url
 
-	raw = (frappe.conf.get(CONF_PAY_ORIGIN) or "").strip()
-	if not raw:
-		try:
-			raw = (frappe.db.get_single_value("Jarvis Settings", "jarvis_pay_origin") or "").strip()
-		except Exception:
-			raw = ""
-	return _normalize_pay_origin(raw or get_default_admin_url())
+	return _normalize_pay_origin(get_default_admin_url())
 
 
 def pay_origin_digest(origin: str) -> str:
@@ -394,9 +384,9 @@ def augment_pay_page(data: dict) -> dict:
 	non-token answer (a coded state, a paid connection payload), is returned
 	untouched. On a token answer it injects two frontend-read fields:
 
-	  * ``pay_origin`` — the bench's resolved, normalized pay origin (site_config ->
-	    ``Jarvis Settings`` -> production default), or "" when invalid. The frontend
-	    builds ``{pay_origin}/jarvis-checkout#t=<token>`` from it; empty fails closed.
+	  * ``pay_origin`` — the bench's resolved, normalized pay origin (its admin URL),
+	    or "" when invalid. The frontend builds ``{pay_origin}/jarvis-checkout#t=<token>``
+	    from it; empty fails closed.
 	  * ``pay_origin_attested`` — True iff ``pay_origin`` is set AND its sha256
 	    digest equals admin's non-navigable ``pay_origin_digest`` (§R P0-3). The
 	    frontend refuses to navigate unless this is True, so a config split-brain

--- a/jarvis/tests/test_pay_page_cutover.py
+++ b/jarvis/tests/test_pay_page_cutover.py
@@ -51,9 +51,10 @@ class TestAugmentPayPage(FrappeTestCase):
 
 	def setUp(self):
 		self.digest = hashlib.sha256(self.ORIGIN.encode("utf-8")).hexdigest()
+		# The checkout origin now follows the bench's admin URL alone.
+		frappe.conf["jarvis_admin_url"] = self.ORIGIN
 
 	def tearDown(self):
-		frappe.conf.pop("jarvis_pay_origin", None)
 		frappe.conf.pop("jarvis_admin_url", None)
 
 	def test_no_token_answer_is_returned_untouched(self):
@@ -62,82 +63,61 @@ class TestAugmentPayPage(FrappeTestCase):
 		self.assertNotIn("pay_origin", oc.augment_pay_page(dict(data)))
 
 	def test_token_with_matching_origin_is_attested(self):
-		frappe.conf["jarvis_pay_origin"] = self.ORIGIN
 		out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": self.digest})
 		self.assertEqual(out["pay_origin"], self.ORIGIN)
 		self.assertTrue(out["pay_origin_attested"])
 
 	def test_token_with_a_MISMATCHED_digest_is_NOT_attested(self):
-		# The digest assertion / mutation: a split-brain (bench pointed at one
-		# origin, admin minted a token for another) fails closed - never navigates.
-		frappe.conf["jarvis_pay_origin"] = self.ORIGIN
+		# The digest assertion: a split-brain (the bench's admin URL is one origin,
+		# admin minted a token for another) fails closed - never navigates.
 		out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": "deadbeef"})
 		self.assertEqual(out["pay_origin"], self.ORIGIN)
 		self.assertFalse(out["pay_origin_attested"])
 
-	def test_token_with_NO_explicit_config_falls_back_to_the_admin_url(self):
-		# New contract (2026-08-05): with nothing in site_config OR the Settings field,
-		# the origin follows the bench's admin URL instead of failing closed - checkout is
-		# hosted on the control plane. Here the admin URL IS self.ORIGIN and admin minted a
-		# token for it, so it attests. (site_config still overrides; a mismatched admin URL
-		# would not attest.)
-		frappe.conf.pop("jarvis_pay_origin", None)
-		frappe.conf["jarvis_admin_url"] = self.ORIGIN
-		with patch("frappe.db.get_single_value", return_value=""):
-			out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": self.digest})
-		self.assertEqual(out["pay_origin"], self.ORIGIN)
-		self.assertTrue(out["pay_origin_attested"])
-
 	def test_token_with_no_admin_digest_cannot_be_attested(self):
-		frappe.conf["jarvis_pay_origin"] = self.ORIGIN
 		out = oc.augment_pay_page({"pay_page_token": "tok"})
 		self.assertFalse(out["pay_origin_attested"])
 
 	def test_success_envelope_carries_the_attestation_through(self):
-		frappe.conf["jarvis_pay_origin"] = self.ORIGIN
 		env = oc.success({"pay_page_token": "tok", "pay_origin_digest": self.digest})
 		self.assertEqual(env["data"]["pay_origin"], self.ORIGIN)
 		self.assertTrue(env["data"]["pay_origin_attested"])
 
 	def test_success_envelope_strips_credentials_before_augmenting(self):
 		# augment must run over the credential-stripped copy, not raw admin data.
-		frappe.conf["jarvis_pay_origin"] = self.ORIGIN
 		env = oc.success({"pay_page_token": "tok", "pay_origin_digest": self.digest, "api_secret": "s"})
 		self.assertNotIn("api_secret", env["data"])
 		self.assertTrue(env["data"]["pay_origin_attested"])
 
 
 class TestResolvedPayOrigin(FrappeTestCase):
-	"""_resolved_pay_origin precedence: site_config -> Jarvis Settings field -> admin URL."""
+	"""_resolved_pay_origin now follows the bench's admin URL alone (the dedicated
+	pay-origin field + site_config knob were dropped 2026-08-06)."""
 
 	def tearDown(self):
-		frappe.conf.pop("jarvis_pay_origin", None)
 		frappe.conf.pop("jarvis_admin_url", None)
-
-	def test_site_config_wins_over_settings_field(self):
-		frappe.conf["jarvis_pay_origin"] = "https://vignesh-staging.klerk.in"
-		with patch("frappe.db.get_single_value", return_value="https://other.example.com"):
-			self.assertEqual(oc._resolved_pay_origin(), "https://vignesh-staging.klerk.in")
-
-	def test_settings_field_used_when_site_config_empty(self):
 		frappe.conf.pop("jarvis_pay_origin", None)
-		with patch("frappe.db.get_single_value", return_value="https://vignesh-staging.klerk.in"):
-			self.assertEqual(oc._resolved_pay_origin(), "https://vignesh-staging.klerk.in")
 
-	def test_admin_url_used_when_both_empty(self):
-		frappe.conf.pop("jarvis_pay_origin", None)
+	def test_follows_the_admin_url(self):
 		frappe.conf["jarvis_admin_url"] = "https://fleet.klerk.in"
-		with patch("frappe.db.get_single_value", return_value=""):
-			self.assertEqual(oc._resolved_pay_origin(), "https://fleet.klerk.in")
+		self.assertEqual(oc._resolved_pay_origin(), "https://fleet.klerk.in")
 
-	def test_follows_a_local_http_admin_url_with_no_explicit_pay_origin(self):
-		# The point of the fallback: a bench whose admin URL is a local/staging http host
-		# gets that as its checkout origin with no separate pay-origin config - scheme and
-		# port preserved (test-mode form).
-		frappe.conf.pop("jarvis_pay_origin", None)
+	def test_follows_a_local_http_admin_url(self):
+		# scheme + port preserved (test-mode form) so a local/staging bench needs no
+		# separate checkout config.
 		frappe.conf["jarvis_admin_url"] = "http://jarvis_admin_v2.local:8002"
-		with patch("frappe.db.get_single_value", return_value=""):
-			self.assertEqual(oc._resolved_pay_origin(), "http://jarvis_admin_v2.local:8002")
+		self.assertEqual(oc._resolved_pay_origin(), "http://jarvis_admin_v2.local:8002")
+
+	def test_a_stale_pay_origin_site_config_is_ignored(self):
+		# The dropped knob is truly dead: an old site_config still carrying
+		# jarvis_pay_origin no longer influences the checkout origin.
+		frappe.conf["jarvis_admin_url"] = "https://fleet.klerk.in"
+		frappe.conf["jarvis_pay_origin"] = "https://stale.example.com"
+		self.assertEqual(oc._resolved_pay_origin(), "https://fleet.klerk.in")
+
+	def test_falls_back_to_the_hardcoded_default_when_admin_url_unset(self):
+		frappe.conf.pop("jarvis_admin_url", None)
+		self.assertEqual(oc._resolved_pay_origin(), "https://fleet.klerk.in")
 
 
 class TestPaymentUiV2Flag(FrappeTestCase):

--- a/jarvis/www/jarvis_pay_return.py
+++ b/jarvis/www/jarvis_pay_return.py
@@ -3,7 +3,7 @@
 HISTORICAL / pre-cutover route (plan-09 §0.7, P0-8). After the WS7 cutover the
 tenant bench no longer initiates any gateway checkout on its own origin: all
 checkout is top-level navigation to the admin-hosted pay page
-(``{jarvis_pay_origin}/jarvis-checkout``), and a Cashfree mandate now returns
+(``{admin_url}/jarvis-checkout``), and a Cashfree mandate now returns
 cross-site to admin's ``/jarvis-checkout/return`` — never here. This page stays
 alive for the lifetime of mandates authorised BEFORE cutover (a rollback must
 keep return routes serving), which is why it is not removed.


### PR DESCRIPTION
## What

Removes the tenant-side **Pay origin** knob entirely. The checkout origin now follows the bench's **admin URL** as its single source of truth.

- `Jarvis Settings.jarvis_pay_origin` field deleted (plus its now-empty "Checkout" section).
- `site_config['jarvis_pay_origin']` override dropped.
- `_resolved_pay_origin()` collapses to `_normalize_pay_origin(get_default_admin_url())`.

## Why

Checkout is hosted on the control plane, so the admin URL the bench already knows (`jarvis_admin_url`) **is** the checkout origin. #675 made the admin URL the fallback but left the field in place; this completes the merge — one value, resolved in one place, no operator-facing knob that's normally blank anyway.

## Blast radius: tiny, and the wire contract is unchanged

The onboarding response still emits `pay_origin` + `pay_origin_attested`, so the frontend (`paymentMachine`, `BillingPage`) and the admin↔bench **origin-digest cross-check** are untouched — only the *source* of `pay_origin` changes.

The digest check keeps working because the tenant's `admin_url` equals the admin's origin in every environment (prod `fleet.klerk.in`, staging `vignesh-staging`, local `:8002`). It becomes admin-authoritative rather than an independent two-party value — an accepted trade for collapsing the duplication.

## Admin side: deliberately left as-is

The control plane has no `admin_url` to merge into — it **is** the origin — and its own `jarvis_pay_origin` conf feeds the checkout security core (digest, origin allowlist, the staging→test / prod→live gate, provider return URLs). Reworking that to a request-derived origin is a separate, security-sensitive change, out of scope here.

## Changes

- `jarvis_settings.json` — remove `jarvis_pay_origin` + `checkout_section`.
- `onboarding_contract.py` — drop `CONF_PAY_ORIGIN` and the field/site_config reads.
- `www/jarvis_pay_return.py` — doc reference `{jarvis_pay_origin}` → `{admin_url}`.
- `tests/test_pay_page_cutover.py` — rewritten to the single-source model; adds a **stale-`site_config`-is-ignored** guard.

## Testing

`bench --site test_jarvis run-tests --module jarvis.tests.test_pay_page_cutover` → **20/20 pass**. ruff (import-sort + lint + format) clean.

## Migration note

Removing a field from a Single doctype leaves the old stored value as an orphan row in `tabSingles` that nothing reads — harmless, no data migration needed.