### PR TITLE
fix(onboarding): preselect a sole plan and show what is due today on the card

### DIFF
--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -11,6 +11,37 @@
 // plan, so the two are free to swap.
 export const STEPS_MANAGED = ["intro", "details", "plan", "pay", "connect"];
 
+// RELATIVE, not "@/account/format": this file's tests run under `node --test`
+// (package.json test:node), which resolves no bundler alias. format.js is plain ESM
+// with zero imports of its own, so pulling it in here keeps this module cheap to test.
+import { inr, planAmount, planSuffix } from "../account/format.js";
+
+/**
+ * What the customer pays TODAY for one plan, as a sentence (#671).
+ *
+ * ONE definition, used by the Plan cards and the Review row. The customer used to
+ * learn this only on Review, a screen after choosing, so nothing told them the trial
+ * starts at zero while they were still deciding. Two independent renderings of "what
+ * you pay now" is also how the two screens come to disagree.
+ *
+ * ``signup_fee_inr`` is included. admin's own get_plans comment says pricing from
+ * ``price_inr`` alone understates the charge, "most visibly on a trial plan, where the
+ * fee is the entire amount due now", and the Review row this replaces hardcoded a flat
+ * zero for every trial, which is exactly that understatement. The fee is 0 on the
+ * current catalog, so this changes nothing today and stops being wrong the moment a
+ * plan carries one.
+ */
+export function planDueToday(p) {
+	if (!p || !p.plan_name) return "";
+	const fee = Number(p.signup_fee_inr) || 0;
+	const days = Number(p.trial_days) || 0;
+	const suffix = planSuffix(p.price_inr, p.billing_cycle) || "";
+	if (days > 0) {
+		return `${inr(fee)} today · then ${inr(p.price_inr)}${suffix} after ${days} days`;
+	}
+	return fee > 0 ? `${inr(Number(p.price_inr) + fee)} today` : planAmount(p.price_inr);
+}
+
 export function stepIndex(steps, cur) {
 	const i = steps.indexOf(cur);
 	return i < 0 ? 0 : i;

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -11,6 +11,7 @@ import {
 	notReadyNote,
 	GENERIC_NOT_READY_NOTE,
 	syncStatusNote,
+	planDueToday,
 	planSubtitleFor,
 } from "./steps.js";
 
@@ -120,4 +121,62 @@ test("isOnboardComplete reads readiness", () => {
 	assert.equal(isOnboardComplete({ ready: false, reason: "llm_credentials" }), false);
 	assert.equal(isOnboardComplete(null), false);
 	assert.equal(isOnboardComplete(undefined), false);
+});
+
+// --------------------------------------------------------------------------- //
+// #671 - what is due TODAY, shown on the Plan card and the Review row
+// --------------------------------------------------------------------------- //
+test("planDueToday: a trial plan leads with zero due now, then the recurring price", () => {
+	assert.equal(
+		planDueToday({
+			plan_name: "Standard",
+			price_inr: 3500,
+			billing_cycle: "Monthly",
+			trial_days: 7,
+		}),
+		"₹0 today · then ₹3,500/mo after 7 days"
+	);
+});
+
+test("planDueToday: a signup fee is what is due now, not zero", () => {
+	// admin's get_plans comment: pricing from price_inr alone understates the charge,
+	// "most visibly on a trial plan, where the fee is the entire amount due now". The
+	// Review row this replaces hardcoded a flat zero for every trial.
+	assert.equal(
+		planDueToday({
+			plan_name: "Standard",
+			price_inr: 3500,
+			billing_cycle: "Monthly",
+			trial_days: 7,
+			signup_fee_inr: 499,
+		}),
+		"₹499 today · then ₹3,500/mo after 7 days"
+	);
+});
+
+test("planDueToday: a plan with no trial just shows its price", () => {
+	// planAmount deliberately omits the cycle suffix: the card already renders the big
+	// price with its own "/mo" directly above this line, and the Review row did the
+	// same before this change. Repeating it would read as a second, different price.
+	assert.equal(
+		planDueToday({ plan_name: "Pro", price_inr: 3500, billing_cycle: "Monthly" }),
+		"₹3,500"
+	);
+});
+
+test("planDueToday: a no-trial plan with a fee shows the combined amount", () => {
+	assert.equal(
+		planDueToday({
+			plan_name: "Pro",
+			price_inr: 3500,
+			billing_cycle: "Monthly",
+			signup_fee_inr: 500,
+		}),
+		"₹4,000 today"
+	);
+});
+
+test("planDueToday: nothing to say without a plan", () => {
+	assert.equal(planDueToday(null), "");
+	assert.equal(planDueToday({}), "");
 });

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -170,7 +170,16 @@
 										>
 											{{ planDueToday(p) }}
 										</div>
-										<ul class="mt-3.5 grid gap-2">
+										<!-- #671: not rendered at all when a plan has no features. The
+										     old fallback bullet said "Monthly plan", repeating both the
+										     "/mo" on the price and the cycle line directly above it.
+										     Dropping that bullet without this guard would leave a
+										     featureless plan with an empty list and its margin, a blank
+										     gap that reads as a broken card. -->
+										<ul
+											v-if="planFeatures(p).length"
+											class="mt-3.5 grid gap-2"
+										>
 											<li
 												v-for="(f, k) in planFeatures(p)"
 												:key="k"

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -160,6 +160,16 @@
 										<div class="text-xs text-ink-gray-5">
 											{{ planCycleLabel(p) }}
 										</div>
+										<!-- #671: what is due TODAY, on the card. The customer
+										     used to meet this only on Review, a screen after
+										     choosing, so nothing told them the trial starts at
+										     zero while they were deciding. -->
+										<div
+											v-if="planDueToday(p)"
+											class="mt-2 text-p-sm font-medium text-ink-gray-8"
+										>
+											{{ planDueToday(p) }}
+										</div>
 										<ul class="mt-3.5 grid gap-2">
 											<li
 												v-for="(f, k) in planFeatures(p)"
@@ -170,12 +180,6 @@
 													name="check"
 													class="mt-0.5 h-3.5 w-3.5 shrink-0 text-ink-green-3"
 												/>{{ f }}
-											</li>
-											<li
-												v-if="!planFeatures(p).length"
-												class="text-p-sm text-ink-gray-5"
-											>
-												{{ p.billing_cycle }} plan
 											</li>
 										</ul>
 									</div>
@@ -1238,7 +1242,13 @@ import Banner from "@/components/Banner.vue";
 import TourIntro from "@/onboarding/TourIntro.vue";
 import SetupNeuralNet from "@/onboarding/SetupNeuralNet.vue";
 import cashfreeLogo from "@/assets/cashfree.png";
-import { STEPS_MANAGED, nextStep, prevStep, planSubtitleFor } from "@/onboarding/steps";
+import {
+	STEPS_MANAGED,
+	nextStep,
+	prevStep,
+	planDueToday,
+	planSubtitleFor,
+} from "@/onboarding/steps";
 import { inr, planAmount, planSuffix } from "@/account/format";
 import {
 	isReadyForChat,
@@ -1590,13 +1600,9 @@ const planRowLabel = computed(() => {
 	if (!p.plan_name) return "";
 	return p.billing_cycle ? `${p.plan_name} · ${p.billing_cycle}` : p.plan_name;
 });
-const dueTodayLabel = computed(() => {
-	if (isTrialPlan.value)
-		return `₹0 · then ${inr(selectedPlan.value.price_inr)}${
-			planSuffix(selectedPlan.value.price_inr, selectedPlan.value.billing_cycle) || ""
-		} after ${trialDays.value} days`;
-	return planAmount(selectedPlan.value.price_inr);
-});
+// #671: planDueToday lives in onboarding/steps.js so the Plan cards and this Review
+// row read ONE definition, and so it is unit-testable under node --test.
+const dueTodayLabel = computed(() => planDueToday(selectedPlan.value));
 
 function goNext() {
 	state.step = nextStep(steps.value, state.step);
@@ -1698,6 +1704,17 @@ async function loadPlans() {
 	state.plansLoading = true;
 	try {
 		state.plans = (await listPlans()) || [];
+		// #671: a single-choice question must not need a click to answer it. With
+		// exactly one plan on offer the card started unselected and Continue was
+		// disabled until you clicked the only thing on screen, which is a dead click.
+		//
+		// Only ever fills an EMPTY selection, so a customer who came Back to this step
+		// keeps whatever they picked, and a real multi-plan catalog is untouched: with
+		// two or more plans the choice is genuine and preselecting one would be us
+		// answering it for them.
+		if (state.plans.length === 1 && !state.planName) {
+			state.planName = state.plans[0].name;
+		}
 	} finally {
 		state.plansLoading = false;
 	}


### PR DESCRIPTION
Closes #671

Three of the four things the issue names. The fourth needs a decision, and is left on the issue rather than guessed at.

**The sole plan is preselected.** With exactly one plan on offer the card started unselected and Continue was disabled until you clicked the only thing on screen, which is a dead click on a single-choice question. `loadPlans` now fills an empty selection when the catalog has exactly one plan.

It only ever fills an **empty** selection, so a customer who came Back keeps what they picked, and a real multi-plan catalog is untouched: with two or more plans the choice is genuine, and preselecting one would be us answering it for them.

**The redundant "Monthly plan" line is gone.** It rendered only when a plan had no features, and repeated both the `/mo` on the price directly above it and the "Billed monthly" cycle line between them.

**What is due today is on the card**, not only on Review a screen later. That was the substance of the complaint: the customer did not learn the trial starts at zero until after choosing.

<details>
<summary>One real bug fixed while unifying the two screens</summary>

`planDueToday` moves into `onboarding/steps.js` so the Plan cards and the Review row read one definition. Two independent renderings of "what you pay now" is how they come to disagree.

Unifying them surfaced an understatement. The Review row hardcoded a flat `₹0` due today for **every** trial plan, but admin's own `get_plans` comment says pricing from `price_inr` alone understates the charge, *"most visibly on a trial plan, where the fee is the entire amount due now"*. `signup_fee_inr` is now included on both screens.

It is 0 across the current catalog, so nothing changes today. It stops being wrong the moment a plan carries a fee, which is precisely when a customer would notice.

On placement: `steps.js` previously had zero imports, because its tests run under `node --test` (`test:node`), which resolves no bundler alias. The new import is therefore relative (`../account/format.js`), and `format.js` is plain ESM with no imports of its own, so the module stays cheap to test.
</details>

## Not done here

The card still says nothing about included users or container size. The issue notes the plan record carries `cpu_limit` and `memory_limit_mb`, and it does, but **`get_plans` does not put them on the wire**. Adding them means exposing resource limits on a guest, pre-signup endpoint in admin-v2, which is a product decision rather than a tweak. I have left that part on the issue.

## Tests

Five for `planDueToday` in `steps.test.js` (13/13 passing under `node --test`):

- a trial plan leads with zero due now, then the recurring price after N days
- **a signup fee is what is due now, not zero**, the case that was previously wrong
- a no-trial plan shows its price, deliberately without the cycle suffix the card already renders above
- a no-trial plan with a fee shows the combined amount
- nothing to say without a plan

`pre-commit` clean (prettier + eslint).

Local `node --test` also shows pre-existing failures in `usageCharts.test.js` and `theme.test.js`; those are the known ambient-Node-version issue (CI pins 24, this machine is on 26) and are unrelated to this change.

## Worth a look in the UI

Open onboarding step 2 with the single-plan catalog: the card should be selected on arrival, Continue live, no "Monthly plan" line, and a "₹0 today · then ₹3,500/mo after 7 days" line under the price.
