### PR TITLE
fix(onboarding): mark Company required the same way Work email is (#668)

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -280,9 +280,23 @@
 												: undefined
 										"
 									>
-										<label for="jv-ob-company" class="text-xs text-ink-gray-5"
-											>Company *</label
-										>
+										<!-- #668: hand-rolled because JvCombo has no label prop, so this
+										     mirrors FormLabel's required recipe (red asterisk + sr-only
+										     text), the same way TriggerDetail.vue does for Autocomplete.
+										     A literal "Company *" gave this field a grey asterisk while
+										     Work email, a plain FormControl, got FormLabel's red one - the
+										     two required fields on one form marked themselves differently.
+										     It also read aloud as "Company star" with nothing saying the
+										     field was required. -->
+										<label for="jv-ob-company" class="text-xs text-ink-gray-5">
+											Company
+											<span
+												class="select-none text-ink-red-3"
+												aria-hidden="true"
+												>*</span
+											>
+											<span class="sr-only">(required)</span>
+										</label>
 										<JvCombo
 											id="jv-ob-company"
 											:model-value="state.company"


### PR DESCRIPTION
Closes #668

The Details step has exactly two required fields, and they marked themselves differently.

**Work email** is a plain `FormControl`, so frappe-ui's `FormLabel` rendered its marker for it: a **red** asterisk that is `aria-hidden`, followed by an `sr-only` "(required)".

**Company** is a `JvCombo`, which has no label prop, so its label was hand-written as the literal text `Company *`. That asterisk inherited the label's own `text-ink-gray-5`, so one required field was flagged in red and the other in grey on the same form. A screen reader also read it out as "Company star", and was told nothing about the field being required, while Work email announced "(required)" properly.

It now mirrors `FormLabel`'s recipe exactly. That is the pattern `TriggerDetail.vue` already established for the same reason, `Autocomplete` having no label prop either, so this follows the codebase rather than inventing a third convention.

## Already done, not touched here

The other half of the issue, field-level error association, is already on develop: both fields carry `aria-invalid` and `aria-describedby` pointing at their `ErrorMessage`.

I also checked the `aria-required` on `JvCombo` and left it alone. It looked wrong (a bare attribute with no value) but is not: `ariaRequired` is a declared `Boolean` prop, so Vue casts the bare attribute to `true`, and the component maps it onto the real inner `<input>`. Only the visible marker was ever broken.

## Verification

Markup only, no logic changed, so there is no unit test to add that would not just be asserting the template back to itself.

What I did check: this commit adds **no** test failures. The suite reports 4 files / 38 tests failing and 725 passing **both with and without it** on this machine (ambient Node 26; CI pins 24, per the known version issue). The pre-existing failures are in `useBillingDetails.spec.js`, `WikiTab.spec.js` and `KnowledgeGraph.spec.js`. `useBillingDetails` is onboarding code and so looks related, but it fails identically on the untouched baseline.

`pre-commit` clean (prettier + eslint).

A grep for literal-asterisk labels now returns nothing app-wide, so these two were the only required fields and they are consistent.

## Worth a look in the UI

Onboarding step "Your details": the asterisks on **Work email** and **Company** should now be the same red, same size, same position.
