### PR TITLE
feat(onboarding): say how long the pay link lasts, while it still works (#669)

### DIFF
--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -428,3 +428,33 @@ export const ACTION_LABELS = {
 	[ACTIONS.SUPPORT]: "Contact support",
 	[ACTIONS.RESTART]: "Start again",
 };
+
+/**
+ * What to tell the customer about how long their checkout link lasts (#669).
+ *
+ * The link dies about 45 minutes after it is minted, and until now that was
+ * disclosed ONLY by the failure message after it had already aged out. Stepping
+ * away to fetch a card is a normal thing to do mid-payment, so the limit belongs
+ * on screen while the link still works.
+ *
+ * Takes SECONDS REMAINING (admin sends a duration, not a deadline, so a customer
+ * whose clock is wrong is still told the truth) and returns "" when there is
+ * nothing honest to say: no live token, or a value that is missing, unparseable
+ * or not positive.
+ *
+ * Rounds DOWN, deliberately. Some seconds always pass between admin computing
+ * this and the customer reading it, so rounding up would be the one direction
+ * that can promise time the link does not have.
+ */
+export function payLinkDeadlineNote(expiresInS) {
+	const secs = Number(expiresInS);
+	if (!Number.isFinite(secs) || secs <= 0) return "";
+	const mins = Math.floor(secs / 60);
+	// Under a minute there is no honest number to give: by the time it is read it
+	// may already be gone, so say that instead of counting down to zero.
+	if (mins < 1) {
+		return "This payment link is about to expire. If it stops working, start the payment again to get a fresh one.";
+	}
+	const unit = mins === 1 ? "minute" : "minutes";
+	return `This payment link works for about ${mins} more ${unit}. If it expires, start the payment again to get a fresh one.`;
+}

--- a/frontend/src/onboarding/paymentCodes.test.js
+++ b/frontend/src/onboarding/paymentCodes.test.js
@@ -14,6 +14,7 @@ import {
 	ACTIONS,
 	actionLabelFor,
 	copyFor,
+	payLinkDeadlineNote,
 	UNKNOWN_COPY,
 } from "./paymentCodes.js";
 
@@ -189,4 +190,47 @@ test("rows that warn about money already moving ask for CHECK first", () => {
 	// The declined row carries the same warning and the same ordering.
 	const declined = copyFor(CODES.PAYMENT_DECLINED);
 	assert.equal(declined.actions[0], ACTIONS.CHECK);
+});
+
+// --------------------------------------------------------------------------- //
+// #669: how long the pay link lasts, said while it still works
+// --------------------------------------------------------------------------- //
+
+test("the deadline note states the remaining minutes", () => {
+	assert.match(payLinkDeadlineNote(45 * 60), /about 45 more minutes/);
+	// Singular, because "1 more minutes" on a payment screen reads as a bug in
+	// exactly the moment the customer is being asked to trust us with a card.
+	assert.match(payLinkDeadlineNote(90), /about 1 more minute\b/);
+});
+
+test("the deadline note rounds DOWN, never promising time the link lacks", () => {
+	// 119s is nearly two minutes, but saying "2" would overstate it, and seconds
+	// keep passing between admin computing this and the customer reading it. The
+	// only safe rounding direction is down.
+	assert.match(payLinkDeadlineNote(119), /about 1 more minute\b/);
+	assert.match(payLinkDeadlineNote(59 * 60 + 59), /about 59 more minutes/);
+});
+
+test("under a minute it warns instead of counting to zero", () => {
+	const note = payLinkDeadlineNote(30);
+	assert.match(note, /about to expire/i);
+	// No number at all: whatever we printed could be wrong by the time it is read.
+	assert.doesNotMatch(note, /\d/);
+});
+
+test("every note says how to recover, not just that time is passing", () => {
+	// A deadline with no way out is just a nicer dead end, which is the failure
+	// mode this issue is about in the first place.
+	for (const secs of [45 * 60, 90, 30]) {
+		assert.match(payLinkDeadlineNote(secs), /start the payment again/i);
+	}
+});
+
+test("nothing is claimed when there is no honest number to give", () => {
+	// null/undefined = no live token on the answer. 0 and negatives = expired.
+	// Junk = an older admin that never sent the field. All render nothing rather
+	// than a "0 minutes" scare over a link that still works.
+	for (const bad of [null, undefined, 0, -1, "", "soon", NaN, {}]) {
+		assert.equal(payLinkDeadlineNote(bad), "", `expected "" for ${String(bad)}`);
+	}
 });

--- a/frontend/src/onboarding/paymentMachine.js
+++ b/frontend/src/onboarding/paymentMachine.js
@@ -157,6 +157,11 @@ export function initialState() {
 		payPageToken: "",
 		payOrigin: "",
 		payOriginAttested: false,
+		// #669: seconds of life left on payPageToken as of the answer that set it.
+		// A DURATION, never a deadline timestamp - the customer's clock is not the
+		// admin host's, and a wall-clock deadline rendered against a skewed clock
+		// would tell some customers they had an hour left on an already dead link.
+		payTokenExpiresInS: null,
 		summary: null,
 		lastCheckedAt: null,
 		verificationExpiresAt: null,
@@ -498,10 +503,11 @@ function applyContract(state, decoded, opts) {
 			message: decoded.message || state.message,
 			code,
 			// A parked-money refusal is not a navigate answer: drop any stale token so
-			// nothing can navigate off it.
+			// nothing can navigate off it, and its countdown with it (#669).
 			payPageToken: "",
 			payOrigin: "",
 			payOriginAttested: false,
+			payTokenExpiresInS: null,
 		};
 		next.canCheck = recomputeCanCheck(next, null);
 		return next;
@@ -554,10 +560,12 @@ function applyContract(state, decoded, opts) {
 			transportError: true,
 			busy: null,
 			code,
-			// A transport failure carries no token: never leave a stale one navigable.
+			// A transport failure carries no token: never leave a stale one navigable,
+			// nor a countdown implying the link it belonged to is still alive (#669).
 			payPageToken: "",
 			payOrigin: "",
 			payOriginAttested: false,
+			payTokenExpiresInS: null,
 		});
 	}
 
@@ -584,6 +592,17 @@ function applyContract(state, decoded, opts) {
 	const payPageToken = data.pay_page_token || "";
 	const payOrigin = payPageToken ? data.pay_origin || "" : "";
 	const payOriginAttested = payPageToken ? !!data.pay_origin_attested : false;
+	// #669: gated on the token for the SAME fail-closed reason as the two lines
+	// above. A countdown that outlived its token would paint a live-looking
+	// deadline over a dead link, which is worse than showing no deadline at all.
+	// Only a finite POSITIVE number counts: admin omits the key rather than
+	// sending 0 for an expired token, and a 0 or negative here would render as
+	// "expires in 0 minutes" on a link that still works.
+	const rawExpiresIn = Number(data.pay_token_expires_in_s);
+	const payTokenExpiresInS =
+		payPageToken && Number.isFinite(rawExpiresIn) && rawExpiresIn > 0
+			? Math.floor(rawExpiresIn)
+			: null;
 
 	const next = {
 		...state,
@@ -603,6 +622,7 @@ function applyContract(state, decoded, opts) {
 		payPageToken,
 		payOrigin,
 		payOriginAttested,
+		payTokenExpiresInS,
 		lastCheckedAt: data.payment_last_checked_at || state.lastCheckedAt,
 		verificationExpiresAt: data.verification_expires_at || state.verificationExpiresAt,
 		awaitingReconciliation: !!data.awaiting_manual_reconciliation,

--- a/frontend/src/onboarding/paymentMachine.test.js
+++ b/frontend/src/onboarding/paymentMachine.test.js
@@ -702,3 +702,48 @@ test("'last checked' is read from data, never invented", () => {
 	);
 	assert.equal(s.lastCheckedAt, "2026-08-03 01:02:03");
 });
+
+// ---------------------------------------------------------------------------
+// #669: the pay link's remaining life travels WITH its token
+// ---------------------------------------------------------------------------
+test("a token answer carries how long that token is good for", () => {
+	const s = reduce(initialState(), token({ pay_token_expires_in_s: 2700 }));
+	assert.equal(s.payTokenExpiresInS, 2700);
+});
+
+test("a fresh page claims no deadline", () => {
+	assert.equal(initialState().payTokenExpiresInS, null);
+});
+
+test("the countdown is gated on the token, exactly like the origin is", () => {
+	// An answer with a duration but NO token must not leave a deadline behind: it
+	// would paint a live-looking countdown over a link that cannot be opened.
+	const s = reduce(
+		initialState(),
+		at(CODES.PAYMENT_CONFIRMATION_PENDING, { pay_token_expires_in_s: 2700 })
+	);
+	assert.equal(s.payPageToken, "");
+	assert.equal(s.payTokenExpiresInS, null);
+});
+
+test("only a positive finite duration is kept", () => {
+	// Admin omits the key rather than sending 0 for a dead token, so a 0 or a
+	// negative here is a bug or an older sender. Either way "expires in 0 minutes"
+	// must never appear over a link that still works.
+	for (const bad of [0, -30, "soon", null]) {
+		const s = reduce(initialState(), token({ pay_token_expires_in_s: bad }));
+		assert.equal(s.payPageToken, "tok_1", "the token itself is still honoured");
+		assert.equal(s.payTokenExpiresInS, null, `expected null for ${String(bad)}`);
+	}
+});
+
+test("a later answer without a token clears the earlier countdown", () => {
+	// The regression this pins: a customer sits on the pay step, a later answer
+	// drops the token, and a stale "43 more minutes" keeps reassuring them while
+	// nothing behind it works any more.
+	const live = reduce(initialState(), token({ pay_token_expires_in_s: 2580 }));
+	assert.equal(live.payTokenExpiresInS, 2580);
+	const after = reduce(live, at(CODES.PAYMENT_CONFIRMATION_PENDING, {}));
+	assert.equal(after.payPageToken, "");
+	assert.equal(after.payTokenExpiresInS, null);
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1043,6 +1043,18 @@
 											Nothing to pay again.
 										</p>
 									</div>
+									<!-- #669: how long this link lasts, said while it STILL works.
+									     Directly above the pay button because that is where the
+									     customer is looking before they step away to fetch a card,
+									     and stepping away is the whole scenario: the 45 minute limit
+									     used to be disclosed only by the failure message, after the
+									     link had already died. -->
+									<p
+										v-if="payLinkDeadline"
+										class="mx-auto mt-3 max-w-[560px] text-center text-p-sm text-ink-gray-5"
+									>
+										{{ payLinkDeadline }}
+									</p>
 								</div>
 								<div class="ob-foot">
 									<button
@@ -1323,6 +1335,7 @@ import {
 	TONE,
 	actionLabelFor,
 	copyFor,
+	payLinkDeadlineNote,
 } from "@/onboarding/paymentCodes";
 import { CHECKOUT_NAV_KEY, shouldHonorCheckoutReturn } from "@/onboarding/checkoutNav";
 import { makeTelemetryReporter } from "@/onboarding/paymentTelemetry";
@@ -1628,6 +1641,12 @@ const payCta = computed(() => {
 // paid plan and an autopay trial need one (the trial authorizes a mandate), so
 // the CTA is disabled until then and the unavailable/retry note stands in for it.
 const payProviderReady = computed(() => !!state.paymentProvider);
+// #669: how long the checkout link is good for. Reads the machine's own
+// payTokenExpiresInS, which is cleared with the token it belongs to, so this
+// renders nothing the moment the link stops being openable rather than leaving a
+// reassuring countdown over a dead link. Empty string when there is no honest
+// number to give, and the v-if means no empty paragraph is left behind.
+const payLinkDeadline = computed(() => payLinkDeadlineNote(pay.value.payTokenExpiresInS));
 
 // Review-card labels (preview .rev): "Pro · Monthly" plan row and a plain
 // amount in the emphasized total row.


### PR DESCRIPTION
Closes #669. Part 2 of 2 — **needs Aerele-RnD/jarvis-admin-v2#249 merged first**, which adds the field this reads.

The checkout token dies about 45 minutes after it is minted. The customer was told that only by the failure message *after* the link had already aged out, and that message is the same generic sentence used for every other checkout failure, so expiry was indistinguishable from a bug. Stepping away to fetch a card is a normal thing to do mid-payment.

The pay step now states the remaining life directly above the pay button, which is where the customer is looking right before they step away.

## The countdown cannot outlive its token

`payTokenExpiresInS` is gated on `payPageToken` and cleared everywhere the token is cleared, for the same fail-closed reason `payOrigin` and `payOriginAttested` already are. A countdown that outlived its token would be worse than none: it would paint a reassuring "43 more minutes" over a link that no longer opens. There is a test for exactly that regression.

Only a finite positive value is kept. Admin omits the key rather than sending `0` for a dead token, so a `0` or a negative here means a bug or an older sender, and either way "expires in 0 minutes" must never appear over a link that still works.

## The copy rounds down

Seconds pass between admin computing the value and the customer reading it, so rounding up is the one direction that can promise time the link does not have. Under a minute it gives no number at all, because whatever we printed could already be wrong. Every variant says how to recover: a deadline with no way out is just a nicer dead end, which is the failure this issue is about.

## Not done, on purpose

Distinguishing "expired" from "never existed" on the checkout shell. That would confirm to the holder of a stolen token that it was once real. admin-v2 #242 already made the single generic message name the 45 minute cause and the way out, which was the half that made an expired link read as a bug.

<details>
<summary>The middle hop, checked rather than assumed</summary>

Cross-repo contract drift is the top source of breakage here, and this field crosses two boundaries: admin to bench, then bench to SPA. Traced the whole chain rather than assuming pass-through:

- `strip_credentials` is a **denylist** (`_WIRE_STRIP` = `api_key`, `api_secret`, `customer_password`, `agent_token`), exact-match, so an unknown key survives.
- `augment_pay_page` does `out = dict(data)` and adds two fields, so it is pass-through.
- The wire key is byte-identical on both sides: `pay_token_expires_in_s` in admin's `ALLOWED_KEYS` and `signup.py`, and in `paymentMachine.js`.
</details>

## Tests

10 new, all pure so they run under `node --test`:

- **copy (5):** rounds down (`119s` reads as 1 minute, not 2), singular "1 more minute", sub-minute warns with no digits at all, every variant names the recovery, and nothing is claimed for `null`/`0`/negative/`NaN`/junk
- **machine (5):** a token answer carries its duration, a fresh page claims none, a duration with no token is dropped, only positive finite values are kept, and a later tokenless answer clears an earlier countdown

579/579 `node --test` pass. `pre-commit` clean (prettier + eslint). vitest is 38 failed / 730 passed, **identical to develop's baseline** on this machine (ambient Node 26; CI pins 24) — those are the known pre-existing failures in `useBillingDetails.spec.js`, `WikiTab.spec.js` and `KnowledgeGraph.spec.js`.

## Worth a look in the UI

Reach the pay step with a live intent: a line reading "This payment link works for about 44 more minutes. If it expires, start the payment again to get a fresh one." should sit just above the pay button. Until admin-v2#249 merges, the field is absent and the line correctly renders nothing.
