### PR TITLE
feat(chat): history-aware new chat page, plus dialog-picker and mini-chat fixes

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -97,6 +97,10 @@ export const recordHomeIntroEvent = (event, payload) =>
 // Persist the sidebar nav order (drag-to-reorder). order = {top:[labels], more:[labels]}.
 export const setSidebarOrder = (order) =>
 	call(US + "set_sidebar_order", { order: JSON.stringify(order || {}) });
+// New-chat prompt suggestions, synthesised from the caller's own recent chat
+// titles. Returns the server-side CACHE (and quietly queues a refresh when it is
+// stale) — never generates inline, so this is a cheap read. {ok, data:{suggestions:[]}}.
+export const getPromptSuggestions = () => call(US + "get_prompt_suggestions");
 // Jarvis Admin (or System Manager) only — server re-checks independently of
 // the client's window.is_jarvis_admin gate.
 export const adminListUserUsage = () => call(US + "admin_list_user_usage");

--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -231,9 +231,12 @@
 				<!-- Host buttons on the RIGHT (chat: dictation mic + model picker),
 				     between the left cluster and the Enter hint + send button. -->
 				<slot name="right-toolbar" />
-				<span style="font-size: 11px; color: var(--text-3); margin-right: 2px">{{
-					busy ? "Stop" : "Enter ↵"
-				}}</span>
+				<!-- Only the "Stop" label survives here: it labels a real action the
+				     user can take mid-reply. The idle "Enter" hint was noise next to a
+				     send button that already says what it does. -->
+				<span v-if="busy" style="font-size: 11px; color: var(--text-3); margin-right: 2px"
+					>Stop</span
+				>
 				<button
 					v-if="busy"
 					@click="emit('stop')"

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -201,12 +201,22 @@ describe("ChatView wiring (source tripwires, not behaviour)", () => {
 		expect(src).toContain('v-if="bizGreeting.show && !showHomeIntro"');
 	});
 
-	it("renders the minimal new-chat greeting and no suggestion cards", () => {
-		// Claude-style empty state: the brand mark inline with the greeting, and NO
-		// suggestion grid. A regression that re-adds the cards trips here.
+	it("renders the minimal greeting over SYNTHESISED starter cards", () => {
+		// The empty state is the brand mark inline with the greeting, then starter
+		// cards whose copy comes from the user's own history — never the old
+		// hard-coded four. A regression that reintroduces a static list trips here.
 		expect(src).toContain("<span>{{ greeting }}, {{ firstName }}</span>");
-		expect(src).not.toContain('class="jv-welcome-grid"');
-		expect(src).not.toContain("onWelcomeSuggestion");
+		expect(src).toContain('class="jv-welcome-grid"');
+		expect(src).toContain('v-for="(s, i) in promptSuggestions"');
+		expect(src).not.toContain("const suggestions = [");
+	});
+
+	it("a starter card fills the composer and never sends", () => {
+		// The do-not-regress rule the original cards carried: clicking a suggestion
+		// puts it in the box for the user to edit, it does not fire a turn.
+		expect(src).toContain('@click="fillInput(s.prompt)"');
+		const card = src.slice(src.indexOf('v-for="(s, i) in promptSuggestions"'));
+		expect(card.slice(0, card.indexOf("</button>"))).not.toContain("sendMessage");
 	});
 
 	it("moves the welcome viewport off inline styles onto overflow-safe classes", () => {

--- a/frontend/src/components/skills/PromotionRequestDialog.spec.js
+++ b/frontend/src/components/skills/PromotionRequestDialog.spec.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * The "Request promotion" dialog's role picker.
+ *
+ * Two failure modes are pinned here, because the bug that prompted them was
+ * invisible to a normal unit test: the picker RENDERED fine and was simply
+ * painted over. So the behaviour half is mounted, and the stacking half is
+ * asserted against the stylesheet — the only place it can be checked without a
+ * real browser.
+ */
+
+const rolesMock = vi.fn(async () => ({ roles: ["Sales Manager", "Accounts"] }));
+vi.mock("@/api/skills", () => ({ promotableTargetRoles: () => rolesMock() }));
+
+// frappe-ui's ESM entry does not resolve under vitest (every other spec here
+// stubs it the same way). The stubs keep the contracts this dialog relies on:
+// FormControl emits update:modelValue, Autocomplete emits an {label,value}.
+vi.mock("frappe-ui", () => ({
+	Dialog: {
+		name: "Dialog",
+		props: ["modelValue", "options"],
+		template: "<div class='dialog'><slot name='body-content'/><slot name='actions'/></div>",
+	},
+	FormControl: {
+		name: "FormControl",
+		props: ["type", "label", "options", "modelValue", "rows", "placeholder"],
+		emits: ["update:modelValue"],
+		template: `<select v-if="type === 'select'" class="fc-select" @change="$emit('update:modelValue', $event.target.value)">
+			<option v-for="o in options || []" :key="o.value" :value="o.value">{{ o.label }}</option>
+		</select><textarea v-else class="fc-textarea" />`,
+	},
+	Autocomplete: {
+		name: "Autocomplete",
+		props: ["options", "modelValue", "placeholder"],
+		emits: ["update:modelValue"],
+		template: "<div class='autocomplete' />",
+	},
+	Button: { name: "Button", props: ["label", "loading", "disabled"], template: "<button />" },
+	toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import PromotionRequestDialog from "./PromotionRequestDialog.vue";
+
+const openDialog = async () => {
+	const w = mount(PromotionRequestDialog, { props: { modelValue: false, noun: "skill" } });
+	await w.setProps({ modelValue: true }); // the watcher resets + loads on open
+	await flushPromises();
+	return w;
+};
+
+// Drive the "Promote to" select the way a user does.
+const chooseScope = async (w, value) => {
+	const select = w.find("select.fc-select");
+	select.element.value = value;
+	await select.trigger("change");
+	await flushPromises();
+};
+
+beforeEach(() => rolesMock.mockClear());
+
+describe("PromotionRequestDialog role picker", () => {
+	it("hides the role picker on the default Org scope", async () => {
+		const w = await openDialog();
+		expect(w.findComponent({ name: "Autocomplete" }).exists()).toBe(false);
+	});
+
+	it("reveals the role picker when the scope becomes Role", async () => {
+		const w = await openDialog();
+		await chooseScope(w, "Role");
+		expect(w.findComponent({ name: "Autocomplete" }).exists()).toBe(true);
+	});
+
+	it("offers the requester's own targetable roles", async () => {
+		const w = await openDialog();
+		await chooseScope(w, "Role");
+		expect(w.findComponent({ name: "Autocomplete" }).props("options")).toEqual([
+			{ label: "Sales Manager", value: "Sales Manager" },
+			{ label: "Accounts", value: "Accounts" },
+		]);
+	});
+
+	it("explains itself instead of showing an empty picker when the user holds no roles", async () => {
+		rolesMock.mockResolvedValueOnce({ roles: [] });
+		const w = await openDialog();
+		await chooseScope(w, "Role");
+		expect(w.text()).toContain("You hold no roles that can be targeted");
+	});
+
+	it("cannot submit a Role promotion until a role is chosen", async () => {
+		const w = await openDialog();
+		await chooseScope(w, "Role");
+		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(true);
+		w.findComponent({ name: "Autocomplete" }).vm.$emit("update:modelValue", {
+			label: "Accounts",
+			value: "Accounts",
+		});
+		await flushPromises();
+		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(false);
+	});
+});
+
+describe("portalled pickers stack above dialogs (source guard)", () => {
+	// frappe-ui portals Popover content to <body> with no z-index of its own, so a
+	// picker opened inside a dialog is painted over by the dialog's own overlay.
+	// jsdom computes no stacking, so this is asserted against the stylesheet.
+	const css = fs.readFileSync(path.resolve(process.cwd(), "src/main.css"), "utf8");
+	const zOf = (selector) => {
+		const rule = new RegExp(`\\${selector}\\s*\\{[^}]*z-index:\\s*(\\d+)`, "m").exec(css);
+		return rule ? Number(rule[1]) : null;
+	};
+
+	it("gives .PopoverContent a z-index above .dialog-overlay", () => {
+		const popover = zOf(".PopoverContent");
+		const dialog = zOf(".dialog-overlay");
+		expect(popover, ".PopoverContent needs an explicit z-index").not.toBeNull();
+		expect(dialog).not.toBeNull();
+		expect(popover).toBeGreaterThan(dialog);
+	});
+
+	it("keeps it below the confirm dialog, so a confirm still wins", () => {
+		expect(zOf(".PopoverContent")).toBeLessThan(200);
+	});
+});

--- a/frontend/src/lib/greeting.js
+++ b/frontend/src/lib/greeting.js
@@ -1,0 +1,100 @@
+// The empty-chat greeting line ("Up late", "Welcome back", "Afternoon"), chosen
+// from signals the SPA already holds. Pure and dependency-free so it can be unit
+// tested without mounting ChatView, which is the whole reason it lives here
+// rather than inline in the view.
+//
+// Two rules only (deliberately — the same-day and milestone signals were cut):
+//   - time of day, including the late-night and early-morning edges that give the
+//     empty state its charm;
+//   - returning after a gap, read from the newest conversation's timestamp.
+//
+// Nothing leaves the browser: the gap rule reads a TIMESTAMP, never a chat title,
+// and there is no backend call. Lines carry no product name, so a whitelabeled
+// tenant and a Jara user both get sensible text.
+
+// Kept mild on purpose: this is a tool people use at work, so the personality is
+// a light touch at the edges of the day rather than a joke on every load.
+const TIME_LINES = {
+	night: ["Up late", "Burning the midnight oil", "Night owl hours"],
+	early: ["Early start", "Up with the sun"],
+	morning: ["Morning", "Good morning"],
+	afternoon: ["Afternoon", "Good afternoon"],
+	evening: ["Evening", "Good evening"],
+};
+
+const GAP_LINES = {
+	long: ["Long time no see", "Welcome back"],
+	short: ["Welcome back"],
+};
+
+// Days away that count as "returning". Below SHORT_GAP_DAYS the time-of-day line
+// stands — someone who chatted yesterday has not been away.
+const SHORT_GAP_DAYS = 3;
+const LONG_GAP_DAYS = 14;
+
+/** Bucket for a local-clock hour (0-23). Night wraps midnight, so it is checked first. */
+export function timeBucket(hour) {
+	const h = Number(hour);
+	if (!Number.isFinite(h)) return "morning";
+	if (h >= 23 || h < 5) return "night";
+	if (h < 8) return "early";
+	if (h < 12) return "morning";
+	if (h < 17) return "afternoon";
+	return "evening";
+}
+
+/** "long" | "short" | null — how long since the last real conversation. */
+export function gapBucket(nowMs, lastChatAt) {
+	const last = toMs(lastChatAt);
+	if (!Number.isFinite(last)) return null;
+	const days = (Number(nowMs) - last) / 86400000;
+	// A clock skew (last chat in the "future") is not a gap.
+	if (!Number.isFinite(days) || days < 0) return null;
+	if (days >= LONG_GAP_DAYS) return "long";
+	if (days >= SHORT_GAP_DAYS) return "short";
+	return null;
+}
+
+/**
+ * The greeting phrase. Rendered as `<phrase>, <firstName>`, so it never contains
+ * the name itself.
+ *
+ * A gap WINS over the time of day: coming back after two weeks is the rarer and
+ * more personal thing to acknowledge, and "Welcome back" at 2am still reads fine.
+ *
+ * The choice is seeded by (local day + which rule fired) rather than random, so
+ * it is stable while the user sits on the screen — a line that reshuffled on every
+ * re-render would read as a glitch — while still varying day to day.
+ */
+export function pickGreeting({ now = Date.now(), lastChatAt = null } = {}) {
+	const nowMs = Number(now) || Date.now();
+	const d = new Date(nowMs);
+	const gap = gapBucket(nowMs, lastChatAt);
+	const key = gap ? `gap:${gap}` : `time:${timeBucket(d.getHours())}`;
+	const pool = gap ? GAP_LINES[gap] : TIME_LINES[timeBucket(d.getHours())];
+	// Defensive: an unknown key must never render an empty greeting.
+	if (!pool || !pool.length) return "Hello";
+	return pool[(localDaySeed(d) + hash(key)) % pool.length];
+}
+
+// A stable day number in LOCAL time. Not a UTC day count: the greeting follows
+// the user's clock, so the day has to turn over at their midnight.
+function localDaySeed(d) {
+	return d.getFullYear() * 400 + (d.getMonth() + 1) * 31 + d.getDate();
+}
+
+function hash(s) {
+	let h = 0;
+	for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+	return h;
+}
+
+// Frappe hands back naive "YYYY-MM-DD HH:MM:SS" strings in the site's timezone.
+// The space form is not valid ISO, so normalise it before parsing; day-granularity
+// is all the gap rule needs, which is why no timezone maths is attempted here.
+function toMs(v) {
+	if (v == null || v === "") return NaN;
+	if (typeof v === "number") return v;
+	if (v instanceof Date) return v.getTime();
+	return Date.parse(String(v).trim().replace(" ", "T"));
+}

--- a/frontend/src/lib/greeting.spec.js
+++ b/frontend/src/lib/greeting.spec.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { pickGreeting, timeBucket, gapBucket } from "./greeting.js";
+
+// Build a local-time instant, so these assertions do not drift with the runner's
+// timezone (the greeting follows the user's own clock by design).
+const at = (y, m, d, h) => new Date(y, m - 1, d, h, 0, 0).getTime();
+const DAY = 86400000;
+
+describe("timeBucket", () => {
+	it("maps the day into its buckets", () => {
+		expect(timeBucket(9)).toBe("morning");
+		expect(timeBucket(14)).toBe("afternoon");
+		expect(timeBucket(19)).toBe("evening");
+		expect(timeBucket(6)).toBe("early");
+	});
+
+	it("wraps night across midnight", () => {
+		// The charming edge: 23:00 through 04:59 is one bucket, not two.
+		expect(timeBucket(23)).toBe("night");
+		expect(timeBucket(0)).toBe("night");
+		expect(timeBucket(2)).toBe("night");
+		expect(timeBucket(4)).toBe("night");
+	});
+
+	it("pins the bucket boundaries", () => {
+		expect(timeBucket(22)).toBe("evening"); // still evening
+		expect(timeBucket(5)).toBe("early"); // night has ended
+		expect(timeBucket(8)).toBe("morning");
+		expect(timeBucket(12)).toBe("afternoon");
+		expect(timeBucket(17)).toBe("evening");
+	});
+
+	it("falls back rather than throwing on junk", () => {
+		expect(timeBucket(undefined)).toBe("morning");
+		expect(timeBucket("nope")).toBe("morning");
+	});
+});
+
+describe("gapBucket", () => {
+	const now = at(2026, 8, 20, 10);
+
+	it("is null for a recent chat", () => {
+		expect(gapBucket(now, new Date(now - 2 * DAY))).toBe(null);
+	});
+
+	it("pins the thresholds", () => {
+		expect(gapBucket(now, new Date(now - 3 * DAY))).toBe("short");
+		expect(gapBucket(now, new Date(now - 13 * DAY))).toBe("short");
+		expect(gapBucket(now, new Date(now - 14 * DAY))).toBe("long");
+	});
+
+	it("is null when there is no history at all", () => {
+		expect(gapBucket(now, null)).toBe(null);
+		expect(gapBucket(now, "")).toBe(null);
+		expect(gapBucket(now, "not a date")).toBe(null);
+	});
+
+	it("treats a future timestamp as no gap, not a huge one", () => {
+		// Clock skew between the bench and the browser must not produce
+		// "Long time no see" for someone who just chatted.
+		expect(gapBucket(now, new Date(now + 2 * DAY))).toBe(null);
+	});
+
+	it("parses Frappe's naive 'YYYY-MM-DD HH:MM:SS' form", () => {
+		expect(gapBucket(at(2026, 8, 20, 10), "2026-08-01 09:30:00")).toBe("long");
+	});
+});
+
+describe("pickGreeting", () => {
+	it("greets by time of day when there is no gap", () => {
+		const line = pickGreeting({ now: at(2026, 8, 20, 14), lastChatAt: at(2026, 8, 20, 9) });
+		expect(["Afternoon", "Good afternoon"]).toContain(line);
+	});
+
+	it("uses a late-night line after 11pm", () => {
+		const line = pickGreeting({ now: at(2026, 8, 20, 23), lastChatAt: at(2026, 8, 20, 9) });
+		expect(["Up late", "Burning the midnight oil", "Night owl hours"]).toContain(line);
+	});
+
+	it("welcomes back after a gap, and the gap wins over the clock", () => {
+		const now = at(2026, 8, 20, 14);
+		const line = pickGreeting({ now, lastChatAt: now - 20 * DAY });
+		expect(["Long time no see", "Welcome back"]).toContain(line);
+		expect(["Afternoon", "Good afternoon"]).not.toContain(line);
+	});
+
+	it("is stable for the same inputs (no reshuffle on re-render)", () => {
+		const args = { now: at(2026, 8, 20, 23), lastChatAt: at(2026, 8, 20, 9) };
+		const first = pickGreeting(args);
+		for (let i = 0; i < 5; i++) expect(pickGreeting(args)).toBe(first);
+	});
+
+	it("varies across days rather than showing one line forever", () => {
+		const seen = new Set();
+		for (let day = 1; day <= 14; day++) {
+			seen.add(pickGreeting({ now: at(2026, 9, day, 23), lastChatAt: at(2026, 9, day, 9) }));
+		}
+		expect(seen.size).toBeGreaterThan(1);
+	});
+
+	it("still greets a brand-new user with no history", () => {
+		const line = pickGreeting({ now: at(2026, 8, 20, 9), lastChatAt: null });
+		expect(["Morning", "Good morning"]).toContain(line);
+	});
+
+	it("never returns an empty string, even with no arguments", () => {
+		expect(pickGreeting()).toBeTruthy();
+		expect(pickGreeting({}).length).toBeGreaterThan(0);
+	});
+
+	it("carries no product name, so whitelabel and Jara are safe", () => {
+		for (let h = 0; h < 24; h++) {
+			const line = pickGreeting({ now: at(2026, 8, 20, h), lastChatAt: null });
+			expect(line.toLowerCase()).not.toContain("jarvis");
+			expect(line.toLowerCase()).not.toContain("jara");
+		}
+	});
+});

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -109,3 +109,18 @@ body {
 .dialog-overlay {
 	z-index: 60;
 }
+
+/* …and the other half of that story. frappe-ui's Popover renders its content
+   through reka-ui's PopoverPortal into <body> as well, but carries NO z-index at
+   all (.PopoverContent is unstyled for stacking). So once the floor above lifted
+   dialogs to 60, every picker OPENED FROM INSIDE a dialog was painted over by the
+   dialog it belongs to — the role Autocomplete in "Request promotion" looked like
+   a dead control: clicking it opened a list nobody could see.
+
+   120 clears every overlay in the app (dialog 60, DraftPreview 61, skills 62, and
+   ChatView's 70/90 chat layers) while staying below ConfirmDialog's 200, so a
+   confirm still opens over an open picker. App-wide for the same reason the rule
+   above is: every Autocomplete/Dropdown/Select portals identically. */
+.PopoverContent {
+	z-index: 120;
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -405,9 +405,6 @@
 				</div>
 			</div>
 
-			<!-- Lift the empty-state greeting + composer into the upper third: the bottom
-			     spacer grows more than the top (Claude-style new chat), so it is not dead-centre. -->
-			<div v-if="showWelcome" style="flex: 1"></div>
 			<!-- initial load: a quiet spinner so the welcome screen doesn't flash
 			     before the open conversation finishes loading on refresh -->
 			<div
@@ -452,17 +449,86 @@
 							display: flex;
 							align-items: center;
 							justify-content: center;
-							gap: 14px;
-							font-size: 32px;
+							gap: 16px;
+							font-size: 40px;
 							font-weight: 640;
 							letter-spacing: -0.03em;
 							margin: 0;
 							overflow-wrap: anywhere;
 						"
 					>
-						<JarvisMark :size="34" :radius="10" style="flex: none" />
+						<JarvisMark :size="38" :radius="11" style="flex: none" />
 						<span>{{ greeting }}, {{ firstName }}</span>
 					</h1>
+					<!-- Starter cards, same shape as the original static ones (tinted icon
+					     tile + label over the prompt) — only the CONTENT is now synthesised
+					     from this user's own recent chat titles. They FILL the composer,
+					     never send: the do-not-regress rule the old cards had. -->
+					<div
+						v-if="!showHomeIntro && promptSuggestions.length"
+						class="jv-welcome-grid"
+						style="
+							display: grid;
+							grid-template-columns: 1fr 1fr;
+							gap: 11px;
+							text-align: left;
+							margin-top: 22px;
+						"
+					>
+						<button
+							v-for="(s, i) in promptSuggestions"
+							:key="s.prompt"
+							type="button"
+							class="jv-suggest"
+							@click="fillInput(s.prompt)"
+							style="
+								display: flex;
+								gap: 11px;
+								padding: 14px;
+								background: var(--surface);
+								border: 1px solid var(--border);
+								border-radius: 10px;
+								cursor: pointer;
+								transition: border-color 0.12s, background 0.12s;
+								text-align: left;
+								font-family: inherit;
+								color: inherit;
+								width: 100%;
+							"
+						>
+							<div
+								:style="{
+									width: '30px',
+									height: '30px',
+									flex: 'none',
+									borderRadius: '8px',
+									background: starterTint(i).bg,
+									color: starterTint(i).fg,
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'center',
+								}"
+								v-html="starterTint(i).icon"
+							></div>
+							<div style="min-width: 0">
+								<div
+									v-if="s.title"
+									style="font-size: 13.5px; font-weight: 550; margin-bottom: 2px"
+								>
+									{{ s.title }}
+								</div>
+								<div
+									style="
+										font-size: 12.5px;
+										color: var(--text-3);
+										line-height: 1.4;
+									"
+								>
+									{{ s.prompt }}
+								</div>
+							</div>
+						</button>
+					</div>
 				</div>
 			</div>
 
@@ -1853,24 +1919,12 @@
 			<!-- ===== COMPOSER ===== -->
 			<div
 				class="jv-composer-wrap"
-				:style="
-					showWelcome
-						? {
-								borderTop: 'none',
-								alignSelf: 'center',
-								width: '100%',
-								maxWidth: '720px',
-								paddingLeft: '16px',
-								paddingRight: '16px',
-								background: 'transparent',
-						  }
-						: { borderTop: 'none' }
-				"
 				style="
 					position: relative;
 					flex: none;
 					padding: 12px 40px 16px;
 					background: var(--surface);
+					border-top: none;
 				"
 			>
 				<!-- Billing lifecycle: before expiry, during grace, and after.
@@ -2790,7 +2844,6 @@
 					</Composer>
 				</div>
 			</div>
-			<div v-if="showWelcome" style="flex: 2"></div>
 		</main>
 
 		<!-- ============ PROACTIVE MESSAGE TOAST (Jarvis started a chat) ============ -->
@@ -3560,6 +3613,7 @@ import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.v
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
+import { pickGreeting } from "@/lib/greeting";
 import { dashboardForConversation } from "@/api/dashboards";
 import {
 	checkReady,
@@ -4371,14 +4425,63 @@ const jarvisTools = ref([
 // Shared with the shell via @/lib/user (see the cookie double-decode note there).
 const fullName = displayName(session.user);
 const firstName = computed(() => fullName.split(/\s+/)[0]);
-const greeting = computed(() => {
-	const h = new Date().getHours();
-	if (h < 5) return "Night";
-	if (h < 12) return "Morning";
-	if (h < 17) return "Afternoon";
-	if (h < 21) return "Evening";
-	return "Night";
+// The empty-chat greeting. `now` is captured ONCE per mount, not read per render:
+// the phrase must not change under the user while they sit on the screen (and a
+// session left open past midnight keeping its line is the calmer behaviour).
+// lastChatAt is the newest EXISTING conversation's activity — list_conversations
+// only returns conversations that already have a message, so the empty one being
+// started right now cannot mask a real gap. See lib/greeting.js for the rules.
+const _greetingNow = Date.now();
+const lastChatAt = computed(() => {
+	let newest = null;
+	for (const c of store.conversations || []) {
+		const t = c && c.last_active_at;
+		if (t && (!newest || t > newest)) newest = t;
+	}
+	return newest;
 });
+const greeting = computed(() => pickGreeting({ now: _greetingNow, lastChatAt: lastChatAt.value }));
+
+// ---- empty-state history: resume card + synthesised prompt suggestions ----
+
+// Server-cached, model-synthesised starters (jarvis.chat.suggestions). Fetched
+// once per mount and best-effort: an empty list simply renders no strip, which is
+// the correct look for a workspace with no history yet.
+const promptSuggestions = ref([]);
+// The starter cards' icon tiles. The old cards had a fixed category per card;
+// these are synthesised, so the tint cycles by POSITION instead — same visual
+// rhythm, no pretence of knowing the category. Deterministic, so a card keeps
+// its colour across re-renders.
+const _STARTER_TINTS = [
+	{
+		bg: "var(--cta-bg)",
+		fg: "var(--cta)",
+		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M18 9l-5 5-3-3-4 4"/></svg>',
+	},
+	{
+		bg: "var(--green-bg)",
+		fg: "var(--green)",
+		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>',
+	},
+	{
+		bg: "var(--amber-bg)",
+		fg: "var(--amber)",
+		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>',
+	},
+	{
+		bg: "rgba(139,92,246,.12)",
+		fg: "#8b5cf6",
+		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>',
+	},
+];
+const starterTint = (i) => _STARTER_TINTS[i % _STARTER_TINTS.length];
+api.getPromptSuggestions()
+	.then((r) => {
+		const list = (r && r.data && r.data.suggestions) || [];
+		if (Array.isArray(list))
+			promptSuggestions.value = list.filter((s) => s && typeof s.prompt === "string");
+	})
+	.catch(() => {});
 // Empty override = "Auto": the backend falls back to Jarvis Settings.llm_model.
 const modelLabel = computed(() => modelOverride.value || "Auto");
 const availableModels = computed(
@@ -6369,13 +6472,33 @@ async function ensureCanvas(m) {
 			/* leave it in the loading state; a reload retries */
 		}
 	}
-	nextTick(scrollBottom);
+	nextTick(scrollBottomIfPinned);
 }
 function scrollBottom(smooth = false) {
 	const el = threadEl.value;
 	if (!el) return;
 	if (smooth && "scrollTo" in el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
 	else el.scrollTop = el.scrollHeight;
+}
+// Content-driven scroll: only follow the newest text while the reader is already
+// parked at the bottom. Streaming a long reply used to call scrollBottom() on
+// every chunk, which dragged the view down mid-sentence and made a big answer
+// unreadable until the turn ended. When the reader HAS scrolled up we leave the
+// viewport alone and let onThreadScroll reveal the jump-to-latest arrow instead.
+// Only user-initiated moments (opening a chat, sending a message) scroll
+// unconditionally.
+function scrollBottomIfPinned() {
+	if (pinnedToBottom.value) {
+		scrollBottom();
+		// While following, we are at the newest text by definition — clear any arrow
+		// a mid-growth scroll event flipped on, or it lingers pointing nowhere.
+		showScrollDown.value = false;
+		return;
+	}
+	// Same rule as the ResizeObserver: streamed text arriving must never RE-PIN a
+	// reader who scrolled up. Only their own scroll does that. Just keep the
+	// jump-to-latest arrow's visibility honest as the thread grows.
+	else showScrollDown.value = distanceFromBottom() > 140;
 }
 // Distance in px from the very bottom of the thread. 0 == pinned to newest.
 function distanceFromBottom() {
@@ -6386,6 +6509,9 @@ function distanceFromBottom() {
 // Runs on every user scroll: decide whether we're "at the bottom" (keep pinning
 // as new content arrives) and whether to reveal the jump-to-latest arrow.
 function onThreadScroll() {
+	// A deliberate scroll always wins over a position being held across a
+	// re-render: stop re-applying it the moment the reader moves themselves.
+	_restoreTop = null;
 	const d = distanceFromBottom();
 	pinnedToBottom.value = d <= 80;
 	showScrollDown.value = d > 140;
@@ -6410,8 +6536,27 @@ watch(threadInnerEl, (el) => {
 	}
 	if (el && typeof ResizeObserver !== "undefined") {
 		threadRO = new ResizeObserver(() => {
-			if (pinnedToBottom.value) scrollBottom();
-			else onThreadScroll();
+			// Re-apply a held position until the thread's real height has arrived, so
+			// a re-render cannot strand the reader at the top by clamping.
+			if (_restoreTop !== null && threadEl.value) {
+				if (performance.now() > _restoreUntil) _restoreTop = null;
+				else if (Math.abs(threadEl.value.scrollTop - _restoreTop) > 2) {
+					threadEl.value.scrollTop = _restoreTop;
+					showScrollDown.value = distanceFromBottom() > 140;
+					return;
+				}
+			}
+			if (pinnedToBottom.value) {
+				scrollBottom();
+				showScrollDown.value = false;
+				return;
+			}
+			// Growing content must never RE-PIN: only a real user scroll may do
+			// that (onThreadScroll, on the @scroll listener). Calling it here let a
+			// mid-render measurement — scrollHeight momentarily short — read as "at
+			// the bottom" and silently re-attach a reader who had scrolled up.
+			// Update only the arrow's visibility from geometry.
+			else showScrollDown.value = distanceFromBottom() > 140;
 		});
 		threadRO.observe(el);
 	}
@@ -6496,7 +6641,24 @@ function onKey(e) {
 	}
 }
 
+// The conversation the thread is currently showing. loadConversation re-runs
+// IN PLACE on the same conversation (after a turn settles, after applying or
+// discarding a card), and those re-runs must not fling a reader who has scrolled
+// up back down to the newest message. Comparing against this tells a genuine
+// chat switch apart from an in-place resync.
+let _shownConvId = null;
+// A scroll position being held across a re-render, and the deadline after which
+// we stop re-applying it. Set by loadConversation, honoured by the thread's
+// ResizeObserver, cancelled by any deliberate scroll.
+let _restoreTop = null;
+let _restoreUntil = 0;
+
 async function loadConversation(id) {
+	// Preserve the reader's position across an in-place resync. Captured BEFORE
+	// the message array is swapped, restored after the re-render.
+	const _sameConv = _shownConvId === id;
+	const _keepScrollTop =
+		_sameConv && !pinnedToBottom.value && threadEl.value ? threadEl.value.scrollTop : null;
 	// One-shot wiki grounding is per-turn: never carry an armed pill into a
 	// different conversation (matches how modelOverride/auto-apply reload here).
 	groundNextTurn.value = false;
@@ -6615,12 +6777,37 @@ async function loadConversation(id) {
 	// to the current run/message, so navigating away from a STILL-streaming chat never
 	// clears its live state.
 	if (!_resumed) tearDownActivityIfSettled();
-	// A freshly opened/refreshed chat should land on the newest message and stay
-	// pinned there while late content settles; the ResizeObserver takes over.
-	pinnedToBottom.value = true;
-	showScrollDown.value = false;
+	// A freshly opened chat should land on the newest message and stay pinned
+	// there while late content settles; the ResizeObserver takes over. But an
+	// in-place resync of the chat already on screen must NOT do that: reloading
+	// after a turn settles (or after a card is applied/discarded) used to fling a
+	// reader who had scrolled up back to the bottom, which is exactly what makes a
+	// long reply unreadable. Restore where they were and let the arrow stand.
+	_shownConvId = id;
 	await nextTick();
-	scrollBottom();
+	if (_keepScrollTop !== null && threadEl.value) {
+		// Hold the position while the thread finishes laying out. The message array
+		// was just replaced, so on this tick the content is still short and a single
+		// assignment CLAMPS against a small scrollHeight — which is what threw the
+		// reader up to the top of the conversation. The ResizeObserver re-applies
+		// this target as the real height arrives, and any deliberate scroll cancels
+		// it (see onThreadScroll).
+		_restoreTop = _keepScrollTop;
+		_restoreUntil = performance.now() + 1500;
+		threadEl.value.scrollTop = _keepScrollTop;
+		// Deliberately NOT onThreadScroll() here: the thread is still re-rendering,
+		// so scrollHeight is briefly too small and the derived distance reads as
+		// "at the bottom", which flipped pinnedToBottom back to true — and the next
+		// growth then flung the reader to the newest text. Their intent is already
+		// known (they scrolled up), so state it instead of re-deriving it.
+		pinnedToBottom.value = false;
+		showScrollDown.value = true;
+	} else {
+		// A genuinely fresh open: land on the newest message.
+		pinnedToBottom.value = true;
+		showScrollDown.value = false;
+		scrollBottom();
+	}
 	processMermaid();
 }
 
@@ -6737,7 +6924,7 @@ async function _renderMermaid() {
 			else el.setAttribute("data-try", String(t));
 		}
 	}
-	nextTick(scrollBottom);
+	nextTick(scrollBottomIfPinned);
 }
 // Drop a hover "download PNG" button onto a rendered chart. The chart is raw
 // (markdown-rendered) HTML, not a Vue node, so we wire the button imperatively.
@@ -7098,7 +7285,17 @@ async function send(textArg, resendAck) {
 	};
 	messages.value = [...messages.value, _optBubble];
 	await nextTick();
+	// Two things, in this order, and both matter:
+	//   1. land on the new turn, so you see your question and the answer start
+	//      without reaching for the jump-to-latest arrow;
+	//   2. then STOP following, so the answer grows downward from there instead of
+	//      sliding its own opening up past the top of the viewport as it is
+	//      written. Staying pinned is what made a long reply unreadable.
+	// The arrow appears once the text runs past the bottom; only a scroll back to
+	// the bottom (or that arrow) resumes following.
 	scrollBottom();
+	pinnedToBottom.value = false;
+	showScrollDown.value = false;
 	try {
 		// The conversation we're sending FROM. The user may switch to another chat
 		// while this POST is in flight, so all post-send reconciliation gates on
@@ -7452,7 +7649,7 @@ function onEvent(p) {
 			}
 			m.content = p.text;
 			m.streaming = true;
-			nextTick(scrollBottom);
+			nextTick(scrollBottomIfPinned);
 			break;
 		}
 		case "tool:start": {
@@ -7465,7 +7662,7 @@ function onEvent(p) {
 			];
 			waiting.value = false;
 			statusPhase.value = null;
-			nextTick(scrollBottom);
+			nextTick(scrollBottomIfPinned);
 			break;
 		}
 		case "tool:end": {
@@ -9653,23 +9850,33 @@ onUnmounted(() => {
    Named classes because inline styles cannot be overridden and the responsive tests
    need a stable target. */
 .jv-welcome-scroll {
-	/* Hug the greeting (flex-grow 0) so the composer sits right under it instead
-	   of a tall centred region opening a big gap; still shrink + scroll if the
-	   first-run home intro is taller than the space between the spacers. */
-	flex: 0 1 auto;
+	/* Fill the thread area so the composer keeps its normal place at the BOTTOM
+	   (it is the next flex child); the greeting then centres in the space above
+	   via .jv-welcome-col's margin-block:auto. justify-content stays flex-start so
+	   a tall first-run intro scrolls from its top instead of being clipped. */
+	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: flex-start;
-	padding: 32px 32px 16px;
+	padding: 32px;
 }
 .jv-welcome-col {
 	width: 100%;
 	max-width: 680px;
 	text-align: center;
 	margin-block: auto;
+}
+/* Starter cards (the original card treatment, now carrying synthesised copy). */
+.jv-suggest:hover {
+	border-color: var(--border-2);
+	background: var(--surface-1);
+}
+.jv-suggest:focus-visible {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
 }
 /* mobile layout (UX #12): the chat had fixed 40px desktop paddings + a 2-col
    welcome grid; inline styles win over class rules, so these override with
@@ -9690,7 +9897,14 @@ onUnmounted(() => {
 		padding: 24px 16px;
 	}
 	.jv-welcome-h1 {
-		font-size: 24px !important;
+		/* Scaled with the desktop bump (32 -> 40), kept a step smaller so a long
+		   "Long time no see, <name>" still fits a phone without wrapping oddly. */
+		font-size: 28px !important;
+	}
+	/* Starter cards stack: two 14px-padded cards side by side are unreadable at
+	   phone width. Inline styles set the grid, so this has to win with !important. */
+	.jv-welcome-grid {
+		grid-template-columns: 1fr !important;
 	}
 }
 /* Phone mode (< 768px, matches the shell store `mobile` flag that swaps the

--- a/frontend/tests/support-extraction/__snapshots__/composer.test.js.snap
+++ b/frontend/tests/support-extraction/__snapshots__/composer.test.js.snap
@@ -31,7 +31,11 @@ exports[`composer renders identically (light) 1`] = `
         </svg></button>
       <div data-v-680708eb="" style="margin-left: auto; display: flex; align-items: center; gap: 6px;">
         <!-- Host buttons on the RIGHT (chat: dictation mic + model picker),
-				     between the left cluster and the Enter hint + send button. --><span data-v-680708eb="" style="font-size: 11px; color: var(--text-3); margin-right: 2px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+				     between the left cluster and the Enter hint + send button. -->
+        <!-- Only the "Stop" label survives here: it labels a real action the
+				     user can take mid-reply. The idle "Enter" hint was noise next to a
+				     send button that already says what it does. -->
+        <!--v-if--><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
             <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
           </svg></button>
       </div>
@@ -72,7 +76,11 @@ exports[`dark render 1`] = `
         </svg></button>
       <div data-v-680708eb="" style="margin-left: auto; display: flex; align-items: center; gap: 6px;">
         <!-- Host buttons on the RIGHT (chat: dictation mic + model picker),
-				     between the left cluster and the Enter hint + send button. --><span data-v-680708eb="" style="font-size: 11px; color: var(--text-3); margin-right: 2px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+				     between the left cluster and the Enter hint + send button. -->
+        <!-- Only the "Stop" label survives here: it labels a real action the
+				     user can take mid-reply. The idle "Enter" hint was noise next to a
+				     send button that already says what it does. -->
+        <!--v-if--><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
             <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
           </svg></button>
       </div>

--- a/jarvis/chat/suggestions.py
+++ b/jarvis/chat/suggestions.py
@@ -1,0 +1,335 @@
+"""Dynamic new-chat prompt suggestions, synthesised from the user's own chat titles.
+
+The empty chat screen used to show four hard-coded starter cards, which said the
+same thing to a brand-new workspace and to someone six months in. These are
+generated from what the person actually works on.
+
+Shape of the feature, and why each part is the way it is:
+
+  - **Titles only.** The model sees conversation TITLES, never message bodies.
+    Titles are already short summaries (jarvis.chat.title writes them), so they
+    are both the cheapest and the least sensitive thing that still carries what
+    the user does.
+  - **One cheap oneshot turn**, on the same throwaway-session path auto-titling
+    uses (``jarvis.chat.title._generate_via_gateway``): managed mode has no
+    separate completion surface, so a silent agent turn on its own session key is
+    the cheap call. ~25 titles in, three lines out.
+  - **Never on the request path.** The endpoint returns the cached value and
+    enqueues a refresh; the page renders instantly whether or not a job runs.
+  - **Refresh is gated on ACTIVITY, not just a clock** (``needs_refresh``): an
+    idle user costs nothing at all, and an active one is refreshed at most once
+    every ``REFRESH_AFTER_DAYS``. A bare timer would have been the worst of both.
+
+Best-effort throughout: every failure path leaves the previous suggestions in
+place and returns quietly. An empty-state decoration must never break the chat.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import frappe
+
+from jarvis.chat.title import _clean, _is_greeting
+
+CONV = "Jarvis Conversation"
+MSG_DT = "Jarvis Chat Message"
+USETT = "Jarvis User Settings"
+
+#: How far back to look for material. Older work is not what the user is doing now.
+LOOKBACK_DAYS = 30
+#: Most titles ever sent to the model (newest first) - the token bound.
+MAX_TITLES = 25
+#: A conversation with fewer USER/ASSISTANT messages than this is a one-off
+#: ("Simple Addition Answer"), not a piece of work worth suggesting more of.
+#: Tool rows are excluded from the count on purpose - they outnumber prose in a
+#: real conversation, so counting them let a single question that happened to
+#: call two tools pass as a substantive thread.
+MIN_MESSAGES = 3
+#: Floor between two syntheses for one user. With the activity gate below, this
+#: caps an active user at ~10 cheap calls a month and an idle one at zero.
+REFRESH_AFTER_DAYS = 3
+#: How many suggestions to ask for (and to keep). Four fills the two-column card
+#: grid exactly, which is why it is not three.
+WANT = 4
+#: Bounds on what we store / hand back, so a chatty model cannot bloat the row.
+MAX_SUGGESTION_CHARS = 90
+MAX_TITLE_CHARS = 32
+
+_PROMPT = (
+	"Below are the titles of recent chats a user had with an ERP assistant.\n"
+	"Suggest exactly {n} things they would plausibly want to do next.\n"
+	"Format each as:  Label | prompt\n"
+	"  Label  = 2 or 3 words naming the area, e.g. Timesheet report\n"
+	"  prompt = a natural first-person request under 10 words\n"
+	"Base them on the themes in these titles. One per line. No numbering, no "
+	"quotes, no markdown, no preamble; do not call any tools.\n\n"
+	"Recent chat titles:\n{titles}"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Material: which titles are worth feeding the model
+# --------------------------------------------------------------------------- #
+def eligible_titles(user: str, *, limit: int = MAX_TITLES) -> list[str]:
+	"""The user's recent, substantive, de-duplicated chat titles (newest first).
+
+	Filters out exactly the noise the feature must not learn from: still-unnamed
+	chats, greeting chats, one-off questions, and the same title repeated (a
+	sidebar full of "System Behaviour Overview" should count once, not five
+	times, or it drowns out everything else in the prompt).
+	"""
+	cutoff = frappe.utils.add_days(frappe.utils.now_datetime(), -LOOKBACK_DAYS)
+	rows = frappe.db.sql(
+		f"""
+		SELECT c.title,
+		       (SELECT COUNT(*) FROM `tab{MSG_DT}` m
+		         WHERE m.conversation = c.name AND m.role IN ('user', 'assistant'))
+		           AS message_count
+		FROM `tab{CONV}` c
+		WHERE c.owner = %s AND c.status = 'Active' AND c.last_active_at >= %s
+		ORDER BY c.last_active_at DESC
+		""",
+		(user, cutoff),
+		as_dict=True,
+	)
+	out: list[str] = []
+	seen: set[str] = set()
+	for r in rows:
+		title = _clean(r.get("title"))
+		if not _is_usable_title(title):
+			continue
+		if int(r.get("message_count") or 0) < MIN_MESSAGES:
+			continue
+		key = title.lower()
+		if key in seen:
+			continue
+		seen.add(key)
+		out.append(title)
+		if len(out) >= limit:
+			break
+	return out
+
+
+def _is_usable_title(title: str) -> bool:
+	"""A title worth learning from: named, not a greeting, not trivially short."""
+	if not title or title == "New chat":
+		return False
+	if _is_greeting(title):
+		return False
+	# A one-word title carries no theme ("Greeting", "Test").
+	return len(title.split()) >= 2
+
+
+# --------------------------------------------------------------------------- #
+# Refresh policy
+# --------------------------------------------------------------------------- #
+def needs_refresh(user: str) -> bool:
+	"""Is it worth spending a model call on this user right now?
+
+	True only when the cache is stale AND the user has actually chatted since it
+	was written. The activity half is what makes an idle workspace free: without
+	it, a plain timer would re-synthesise the same titles forever.
+	"""
+	stamp = frappe.db.get_value(USETT, {"user": user}, "prompt_suggestions_at")
+	if not stamp:
+		return True  # never attempted
+	# The STAMP alone gates, never the stored value: an attempt that produced
+	# nothing (no eligible titles yet, or a gateway blip) still stamps, so a user
+	# with no history cannot spawn a job on every single page load.
+	stamped = frappe.utils.get_datetime(stamp)
+	age_days = frappe.utils.time_diff(frappe.utils.now_datetime(), stamped).total_seconds() / 86400
+	if age_days < REFRESH_AFTER_DAYS:
+		return False
+	return _has_chatted_since(user, stamped)
+
+
+def _has_chatted_since(user: str, stamped) -> bool:
+	return bool(frappe.db.exists(CONV, {"owner": user, "status": "Active", "last_active_at": (">", stamped)}))
+
+
+# --------------------------------------------------------------------------- #
+# Generation
+# --------------------------------------------------------------------------- #
+def enqueue_refresh(user: str) -> None:
+	"""Queue a synthesis on the SHORT lane (same lane auto-titling uses) so the
+	caller's request returns immediately. Gate first so a hot empty screen cannot
+	spawn a job per page load."""
+	if not needs_refresh(user):
+		return
+	frappe.enqueue("jarvis.chat.suggestions.refresh_job", queue="short", user=user)
+
+
+def refresh_job(user: str) -> None:
+	"""Short-queue body. Re-resolves everything itself; never raises."""
+	try:
+		if not needs_refresh(user):
+			return  # another job won the race
+		titles = eligible_titles(user)
+		if not titles:
+			# Nothing to learn from yet. STAMP anyway so the gate backs off for a
+			# few days: without this, a workspace with no named history would queue
+			# a job every time its empty chat screen opened.
+			touch(user)
+			return
+		settings = frappe.get_single("Jarvis Settings")
+		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
+		if not gateway_url:
+			touch(user)
+			return
+		model, provider = _resolve_model_provider(user)
+		lines = _generate_via_gateway(gateway_url, titles, model=model, provider=provider)
+		if lines:
+			store(user, lines)
+		else:
+			# Generation failed or parsed to nothing. Keep whatever the user already
+			# had (a transient gateway blip must not blank a good strip) but stamp,
+			# so a broken gateway is retried in days rather than hammered.
+			touch(user)
+	except Exception:
+		frappe.log_error(title="prompt suggestions: refresh failed", message=frappe.get_traceback())
+
+
+def _resolve_model_provider(user: str):
+	"""Reuse the turn handler's resolution against the user's newest conversation.
+	There is always one here: eligible_titles() already proved it."""
+	from jarvis.chat.turn_handler import _resolve_model_and_provider
+
+	name = frappe.db.get_value(
+		CONV, {"owner": user, "status": "Active"}, "name", order_by="last_active_at desc"
+	)
+	return _resolve_model_and_provider(frappe.get_doc(CONV, name))
+
+
+def _generate_via_gateway(gateway_url, titles: list[str], *, model, provider) -> list[str]:
+	"""One silent throwaway turn -> up to WANT suggestion lines. [] on any failure.
+
+	Mirrors jarvis.chat.title._generate_via_gateway, including the unique session
+	label and the reclaim-on-the-same-connection cleanup - see that function for
+	why the throwaway session must be reclaimed rather than deleted outright.
+	"""
+	from jarvis.chat import agent_session_pool
+	from jarvis.chat.agent_client import oneshot_run_id
+	from jarvis.chat.session_lifecycle import reclaim_throwaway_session
+
+	prompt = _PROMPT.format(n=WANT, titles="\n".join(titles))
+	text = ""
+	label = f"jarvis-suggest-{frappe.generate_hash(length=10)}"
+	try:
+		with agent_session_pool.checkout(gateway_url) as sess:
+			skey = sess.create_session(label=label)
+			fired_at = time.time()
+			run_ended = False
+			try:
+				for ev in sess.stream_agent_turn(
+					skey,
+					prompt,
+					oneshot_run_id("suggest", skey, model=model, provider=provider),
+					model=model,
+					provider=provider,
+				):
+					if ev.get("kind") == "assistant" and ev.get("text"):
+						text = ev["text"]
+				run_ended = True
+			finally:
+				reclaim_throwaway_session(
+					sess,
+					skey,
+					logger_name="jarvis.chat.suggestions",
+					fired_at=None if run_ended else fired_at,
+				)
+	except Exception:
+		frappe.log_error(
+			title="prompt suggestions: gateway generation failed",
+			message=frappe.get_traceback(),
+		)
+		return []
+	return parse_lines(text)
+
+
+def parse_lines(text: str | None) -> list[dict]:
+	"""Model reply -> ``[{"title", "prompt"}]``.
+
+	Tolerates the shapes a model reaches for anyway (numbering, bullets, quotes)
+	rather than trusting the instruction, and tolerates a MISSING label: a line
+	with no ``|`` becomes a prompt with an empty title, which the card renders as
+	a single line rather than dropping a usable suggestion.
+	"""
+	out: list[dict] = []
+	for raw in (text or "").splitlines():
+		line = _strip_ornament(_clean(raw))
+		if not line:
+			continue
+		title, _, prompt = line.partition("|")
+		if not prompt:
+			title, prompt = "", line
+		title = _strip_ornament(title)[:MAX_TITLE_CHARS]
+		prompt = _strip_ornament(prompt)[:MAX_SUGGESTION_CHARS]
+		# A one-word "prompt" is a stray heading, not something to send.
+		if len(prompt.split()) < 2:
+			continue
+		out.append({"title": title, "prompt": prompt})
+		if len(out) >= WANT:
+			break
+	return out
+
+
+def _strip_ornament(s: str) -> str:
+	"""Drop bullets, "1." / "1)" numbering and wrapping quotes."""
+	line = (s or "").strip().lstrip("-*•").strip()
+	while line[:1].isdigit():
+		rest = line.lstrip("0123456789")
+		if rest[:1] not in (".", ")"):
+			break  # a genuine leading number ("2026 revenue"), not numbering
+		line = rest[1:].strip()
+	return line.strip().strip('"').strip("'").strip()
+
+
+def touch(user: str) -> None:
+	"""Record an ATTEMPT without changing the suggestions. This is what makes the
+	refresh gate back off after a run that had nothing to say."""
+	from jarvis.chat import usage
+
+	doc = usage.get_or_create_user_settings(user)
+	doc.db_set("prompt_suggestions_at", frappe.utils.now_datetime(), update_modified=False)
+	frappe.db.commit()
+
+
+def store(user: str, items: list[dict]) -> None:
+	"""Persist the cache + its stamp. db_set-style writes so the settings row's
+	modified time (and the gate revision that keys off it) does not churn.
+	Accepts plain strings too, so a caller (or a test) can pass either shape."""
+	from jarvis.chat import usage
+
+	rows = [{"title": "", "prompt": i} if isinstance(i, str) else i for i in items]
+	doc = usage.get_or_create_user_settings(user)
+	doc.db_set("prompt_suggestions", json.dumps(rows[:WANT]), update_modified=False)
+	doc.db_set("prompt_suggestions_at", frappe.utils.now_datetime(), update_modified=False)
+	frappe.db.commit()
+
+
+def read(user: str) -> list[dict]:
+	"""Cached suggestions as ``[{"title", "prompt"}]``, or [] - never raises.
+
+	Normalises on the way out so a cache written by the earlier plain-string
+	version still renders (as a prompt with no label) instead of blanking the
+	strip until the next refresh.
+	"""
+	try:
+		parsed = json.loads(frappe.db.get_value(USETT, {"user": user}, "prompt_suggestions") or "[]")
+		if not isinstance(parsed, list):
+			return []
+		out: list[dict] = []
+		for item in parsed:
+			if isinstance(item, str):
+				item = {"title": "", "prompt": item}
+			if not isinstance(item, dict):
+				continue
+			prompt = str(item.get("prompt") or "")[:MAX_SUGGESTION_CHARS]
+			if not prompt:
+				continue
+			out.append({"title": str(item.get("title") or "")[:MAX_TITLE_CHARS], "prompt": prompt})
+		return out[:WANT]
+	except Exception:
+		return []

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -471,3 +471,27 @@ def set_sidebar_order(order: str) -> dict:
 	doc = usage.get_or_create_user_settings(frappe.session.user)
 	doc.db_set("sidebar_order", json.dumps(clean), update_modified=False)
 	return {"ok": True, "data": {"sidebar_order": clean}}
+
+
+@frappe.whitelist()
+def get_prompt_suggestions() -> dict:
+	"""New-chat prompt suggestions for the calling user, synthesised from their own
+	recent chat titles (see ``jarvis.chat.suggestions``).
+
+	Returns the CACHE and, if it is stale and the user has chatted since it was
+	written, queues a background refresh. It never generates inline: the empty chat
+	screen must paint instantly, and a suggestion strip is not worth a model call in
+	the request path. A user with no history yet simply gets an empty list, which
+	the SPA renders as no strip at all.
+	"""
+	require_jarvis_access()
+	user = frappe.session.user
+	from jarvis.chat import suggestions
+
+	try:
+		suggestions.enqueue_refresh(user)
+	except Exception:
+		# Decoration must never break the page - a queue hiccup just means the
+		# cache stays as it is until the next visit.
+		frappe.logger("jarvis.chat.suggestions").debug("refresh enqueue failed", exc_info=True)
+	return {"ok": True, "data": {"suggestions": suggestions.read(user)}}

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -18,6 +18,8 @@
     "business_greeting_chat_count",
     "business_greeting_hidden_at_count",
     "sidebar_order",
+    "prompt_suggestions",
+    "prompt_suggestions_at",
     "home_intro_seen_version",
     "home_intro_seen_at",
     "usage_limits_tab",
@@ -108,6 +110,22 @@
       "label": "Sidebar Order",
       "no_copy": 1,
       "description": "Per-user sidebar nav order as JSON {\"top\":[labels],\"more\":[labels]}. UI state only; the client reconciles against its defaults."
+    },
+    {
+      "fieldname": "prompt_suggestions",
+      "fieldtype": "Small Text",
+      "label": "Prompt Suggestions",
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Cached new-chat prompt suggestions, a JSON array of strings synthesised from this user's own recent chat TITLES by jarvis.chat.suggestions. Server-owned cache, refreshed at most every few days and only when the user has chatted since. Safe to clear - it regenerates."
+    },
+    {
+      "fieldname": "prompt_suggestions_at",
+      "fieldtype": "Datetime",
+      "label": "Prompt Suggestions At",
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "When prompt_suggestions was last synthesised; drives the refresh gate."
     },
     {
       "fieldname": "home_intro_seen_version",

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -307,15 +307,11 @@
 									/>
 								</svg>
 							</div>
-							<div
-								class="jvp-think"
-								role="status"
-								aria-live="polite"
-								aria-label="Jarvis is typing"
-							>
+							<div class="jvp-think" role="status" aria-live="polite">
 								<span class="jvp-think-dots" aria-hidden="true"
 									><i></i><i></i><i></i
 								></span>
+								<span class="jvp-think-tx">{{ thinkingLabel }}</span>
 							</div>
 						</div>
 
@@ -744,6 +740,15 @@ const thinking = computed(() => {
 	const s = stream.value;
 	return sending.value || (s.busy && !s.live) || (!!s.live && !s.live.text);
 });
+// Caption beside the typing dots. The full web chat labels this wait ("Waking up
+// your assistant…" / "Working on it…"); the mini panel showed bare dots, which
+// read as hung on a slow turn. Same wording as the SPA's liveStatus so the two
+// surfaces say the same thing. (The SPA also names the running tool; the panel
+// is deliberately text-only and does not track tool frames, so it stays generic
+// rather than inventing a phrase it cannot back up.)
+const thinkingLabel = computed(() =>
+	stream.value.status === "waking" ? "Waking up your assistant…" : "Working on it…"
+);
 const canSend = computed(
 	() =>
 		(draft.value.trim().length > 0 || attachments.value.length > 0) &&
@@ -1984,6 +1989,13 @@ defineExpose({ load, startNewChat, convId });
 	border-radius: 5px 15px 15px 15px;
 	padding: 11px 13px;
 	color: var(--jv-ink-2);
+}
+/* The caption beside the dots ("Working on it…"), matching the web chat. */
+.jvp-think-tx {
+	font-size: 13px;
+	line-height: 1.2;
+	color: var(--jv-ink-2);
+	white-space: nowrap;
 }
 .jvp-think-dots {
 	display: inline-flex;

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -7,6 +7,7 @@
 	<div
 		v-show="open"
 		class="jvp-root"
+		:class="{ 'jvp-root--expanding': leaving }"
 		:style="rootStyle"
 		role="dialog"
 		:aria-label="`${brandName} chat`"
@@ -556,6 +557,10 @@ const props = defineProps({
 	// Computed by panel_anchor.panelLayout from wherever the user dragged the
 	// FAB. The panel is a floating mini window, so it has no fixed home.
 	layout: { type: Object, default: null },
+	// True while handing off to the full web chat: the root animates open to
+	// fullscreen (see .jvp-root--expanding) so the transition reads as the panel
+	// growing INTO the big chat rather than a hard cut.
+	leaving: { type: Boolean, default: false },
 });
 const emit = defineEmits(["close", "open-full", "dismiss-context", "resize", "resize-commit"]);
 
@@ -1268,6 +1273,25 @@ defineExpose({ load, startNewChat, convId });
 	z-index: 1029; /* under Frappe modals (1050), over page content */
 	display: flex;
 	pointer-events: none;
+}
+/* Handoff to the full web chat: the window grows to fill the screen, its
+   corners flatten and its shadow deepens, so it reads as the panel opening INTO
+   the big chat. Widget.vue drives the fullscreen size + a dimming backdrop; this
+   just animates the box. Only during the handoff, so live resizing stays snappy. */
+.jvp-root--expanding {
+	transition: left 0.32s cubic-bezier(0.4, 0, 0.2, 1), top 0.32s cubic-bezier(0.4, 0, 0.2, 1),
+		width 0.32s cubic-bezier(0.4, 0, 0.2, 1), height 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.jvp-root--expanding .jvp-panel {
+	transition: border-radius 0.32s ease, box-shadow 0.32s ease;
+	border-radius: 6px;
+	box-shadow: 0 40px 120px -20px rgba(24, 20, 50, 0.5), 0 12px 40px -8px rgba(24, 20, 50, 0.3);
+}
+@media (prefers-reduced-motion: reduce) {
+	.jvp-root--expanding,
+	.jvp-root--expanding .jvp-panel {
+		transition: none;
+	}
 }
 .jvp-panel {
 	pointer-events: auto;

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -368,6 +368,30 @@
 				</div>
 			</div>
 
+			<!-- Jump to latest. stickToBottom already refuses to drag a reader who
+			     has scrolled up back down mid-reply, so without this arrow a long
+			     streamed answer left them stranded with no way back to the newest
+			     text but a manual scroll. Sits above the composer, over the body. -->
+			<button
+				v-if="showScrollDown && readinessResolved && readiness !== 'gate'"
+				class="jvp-jump"
+				type="button"
+				title="Jump to latest"
+				aria-label="Jump to latest"
+				@click="jumpToBottom"
+			>
+				<svg viewBox="0 0 24 24" aria-hidden="true">
+					<path
+						d="M6 9.5 L12 15.5 L18 9.5"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					/>
+				</svg>
+			</button>
+
 			<!-- Hidden entirely in the gate state, not merely disabled: there is
 			     nothing to send to yet, and a live-but-disabled composer would
 			     imply chat almost works. The "degraded" state keeps this, on
@@ -452,7 +476,8 @@
 						v-model="draft"
 						@focus="composerFocused = true"
 						@blur="composerFocused = false"
-						@input="autoGrow"
+						@input="onComposerInput"
+						@keydown="onComposerKey"
 						@keydown.enter.exact.prevent="send"
 					></textarea>
 					<button
@@ -647,6 +672,61 @@ const sending = ref(false);
 const composerFocused = ref(false);
 const resolving = ref("");
 const lastSent = ref("");
+// Prompt recall, matching the full chat: Up walks back through prompts sent from
+// this panel, Down walks forward and finally restores whatever was being typed.
+// Guarded on caret position so it never fights normal multi-line editing.
+const promptHistory = ref([]);
+const histIdx = ref(null);
+const histDraft = ref("");
+function onComposerInput() {
+	// Typing leaves history navigation. Without this, recalling a prompt, editing
+	// it, then pressing Down would throw the edit away for the next entry.
+	histIdx.value = null;
+	autoGrow();
+}
+function onComposerKey(e) {
+	const el = e.target;
+	if (
+		e.key === "ArrowUp" &&
+		(draft.value === "" || el.selectionStart === 0) &&
+		promptHistory.value.length
+	) {
+		e.preventDefault();
+		if (histIdx.value === null) {
+			histDraft.value = draft.value;
+			histIdx.value = promptHistory.value.length;
+		}
+		if (histIdx.value > 0) {
+			histIdx.value -= 1;
+			draft.value = promptHistory.value[histIdx.value];
+			nextTick(() => {
+				const p = draft.value.length;
+				el.setSelectionRange(p, p);
+				autoGrow();
+			});
+		}
+		return;
+	}
+	if (
+		e.key === "ArrowDown" &&
+		histIdx.value !== null &&
+		el.selectionStart === draft.value.length
+	) {
+		e.preventDefault();
+		if (histIdx.value < promptHistory.value.length - 1) {
+			histIdx.value += 1;
+			draft.value = promptHistory.value[histIdx.value];
+		} else {
+			histIdx.value = null;
+			draft.value = histDraft.value;
+		}
+		nextTick(() => {
+			const p = draft.value.length;
+			el.setSelectionRange(p, p);
+			autoGrow();
+		});
+	}
+}
 const isDark = ref(false);
 let unwatchTheme = null;
 const fileEl = ref(null);
@@ -777,16 +857,36 @@ async function scrollToBottom() {
 // way via pinnedToBottom). A user scroll updates the flag; a send / load / new
 // chat re-pins so a fresh turn always snaps to the bottom.
 const pinnedToBottom = ref(true);
+// Reveals the jump-to-latest arrow. Deliberately a wider gap than the pin
+// threshold: between the two the panel has stopped following the reply but the
+// reader is still close enough that an arrow would be noise.
+const showScrollDown = ref(false);
 function distanceFromBottom() {
 	const el = bodyEl.value;
 	if (!el) return 0;
 	return el.scrollHeight - el.scrollTop - el.clientHeight;
 }
 function onBodyScroll() {
-	pinnedToBottom.value = distanceFromBottom() <= 80;
+	const d = distanceFromBottom();
+	pinnedToBottom.value = d <= 80;
+	showScrollDown.value = d > 140;
 }
 function stickToBottom() {
-	if (pinnedToBottom.value) scrollToBottom();
+	// Growing content must never RE-PIN a reader who scrolled up: only their own
+	// scroll does that (onBodyScroll, on the @scroll listener). Just keep the
+	// jump-to-latest arrow's visibility honest as the panel grows.
+	if (pinnedToBottom.value) {
+		scrollToBottom();
+		// Following means we are at the newest text: clear any arrow a mid-growth
+		// scroll event flipped on, or it lingers pointing nowhere.
+		showScrollDown.value = false;
+	} else showScrollDown.value = distanceFromBottom() > 140;
+}
+// Arrow click: re-pin so the panel follows the rest of the reply again.
+function jumpToBottom() {
+	pinnedToBottom.value = true;
+	showScrollDown.value = false;
+	scrollToBottom();
 }
 
 function autoGrow() {
@@ -804,6 +904,13 @@ async function load() {
 	// an existing thread should be invisible.
 	loading.value = messages.value.length === 0;
 	loadError.value = "";
+	// ...and "invisible" has to include the scroll position. load() re-runs in
+	// place when a turn settles, and forcing the panel back to the newest message
+	// there is what yanked a reader away from the answer they were reading.
+	const _convAtEntry = convId.value;
+	const _hadThread = messages.value.length > 0;
+	const _keepScrollTop =
+		_hadThread && !pinnedToBottom.value && bodyEl.value ? bodyEl.value.scrollTop : null;
 	try {
 		if (!convId.value) {
 			const list = await listConversations();
@@ -815,6 +922,14 @@ async function load() {
 		}
 		const conv = await getConversation(convId.value);
 		messages.value = Array.isArray(conv?.messages) ? conv.messages : [];
+		// Seed recall from what was actually asked in this conversation. The panel
+		// is usually opened fresh on a Desk page, so without this Up would do
+		// nothing until you had already sent something in this page load.
+		promptHistory.value = messages.value
+			.filter((m) => m.role === "user" && typeof m.content === "string" && m.content.trim())
+			.map((m) => m.content);
+		histIdx.value = null;
+		histDraft.value = "";
 		// Resync open write confirmations. Without this a card raised while the
 		// panel was closed (or a dropped realtime frame) never shows here, even
 		// though the full chat has it. Best-effort: chat must work without it.
@@ -832,8 +947,32 @@ async function load() {
 		} catch (e) {
 			/* leave whatever the live stream captured */
 		}
-		pinnedToBottom.value = true;
-		await scrollToBottom();
+		if (_keepScrollTop !== null && bodyEl.value && convId.value === _convAtEntry) {
+			// In-place refresh of the thread already on screen, with the reader
+			// parked somewhere in it. Put them back exactly where they were and
+			// leave the blank run alone so it keeps trimming as the answer grows.
+			await nextTick();
+			// Re-apply for a moment: the message list was just replaced, so on this
+			// tick the panel is still short and a single assignment clamps against a
+			// small scrollHeight, which would strand the reader near the top.
+			bodyEl.value.scrollTop = _keepScrollTop;
+			const deadline = Date.now() + 900;
+			const hold = () => {
+				if (!bodyEl.value || pinnedToBottom.value || Date.now() > deadline) return;
+				if (Math.abs(bodyEl.value.scrollTop - _keepScrollTop) > 2) {
+					bodyEl.value.scrollTop = _keepScrollTop;
+				}
+				requestAnimationFrame(hold);
+			};
+			requestAnimationFrame(hold);
+			pinnedToBottom.value = false;
+			showScrollDown.value = true;
+		} else {
+			// A genuinely fresh open: land on the newest message.
+			pinnedToBottom.value = true;
+			showScrollDown.value = false;
+			await scrollToBottom();
+		}
 	} catch (e) {
 		loadError.value = "Could not load your conversation.";
 	} finally {
@@ -851,7 +990,12 @@ function startNewChat() {
 	stream.value = { ...emptyStream(), fence: stream.value.fence };
 	loadError.value = "";
 	draft.value = "";
+	// Recall belongs to the conversation you are in, not to the panel.
+	promptHistory.value = [];
+	histIdx.value = null;
+	histDraft.value = "";
 	pinnedToBottom.value = true;
+	showScrollDown.value = false;
 	nextTick(() => textareaEl.value?.focus());
 }
 
@@ -973,12 +1117,23 @@ async function send() {
 	// Optimistic echo so the panel feels immediate. run:end reloads from the
 	// durable record, which replaces this.
 	messages.value.push({ name: `local-${Date.now()}`, role: "user", content: text });
+	// Recall history: skip an immediate repeat so holding Up isn't a wall of the
+	// same line, and reset the cursor so the next Up starts from the newest.
+	if (promptHistory.value[promptHistory.value.length - 1] !== text)
+		promptHistory.value.push(text);
+	histIdx.value = null;
+	histDraft.value = "";
 	draft.value = "";
 	attachments.value = [];
 	await nextTick();
 	autoGrow();
-	pinnedToBottom.value = true; // a fresh turn always snaps to the newest
+	// Land on the new turn first, so you see your question and the answer start
+	// without reaching for the arrow — then STOP following, so the answer grows
+	// downward instead of sliding its own opening up out of the panel as it is
+	// written. Staying pinned is what made a long reply unreadable here too.
 	await scrollToBottom();
+	pinnedToBottom.value = false;
+	showScrollDown.value = false;
 
 	try {
 		// Context is read at SEND time, not at open time: a conversation outlives
@@ -1084,9 +1239,21 @@ watch(
 	async (isOpen) => {
 		if (!isOpen) return;
 		await nextTick();
-		panelEl.value?.focus();
+		// Focus the box, not the panel shell: opening the widget is always a
+		// prelude to typing, and focusing the shell cost a click every time.
+		// Escape still closes, since the keydown bubbles to the root handler.
+		(textareaEl.value || panelEl.value)?.focus();
 		ensureRealtime();
-		load();
+		await load();
+		// The composer only renders once readiness resolves, so on a cold open the
+		// textarea did not exist for the focus above. Claim it now that it does,
+		// unless the reader has already put focus somewhere else in the panel.
+		await nextTick();
+		const ae = document.activeElement;
+		// Claim focus only when nothing else has meaningfully taken it: a bare
+		// <body> (the usual cold-open state) or somewhere inside the panel.
+		const focusIsLoose = !ae || ae === document.body || !!panelEl.value?.contains(ae);
+		if (props.open && textareaEl.value && focusIsLoose) textareaEl.value.focus();
 	}
 );
 
@@ -1579,6 +1746,41 @@ defineExpose({ load, startNewChat, convId });
 	overflow-y: auto;
 	overflow-x: hidden; /* long tokens wrap; the panel never scrolls sideways */
 	padding: 16px 15px;
+}
+/* Jump-to-latest arrow. The panel is a flex column, so align-self parks it at
+   the right edge and the negative top margin floats it over the last lines of
+   the body. The margins cancel out (-44 + 36 + 8 = 0), so showing or hiding it
+   never shifts the composer below. */
+.jvp-jump {
+	position: relative;
+	z-index: 3;
+	align-self: flex-end;
+	margin: -44px 14px 8px 0;
+	width: 36px;
+	height: 36px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 50%;
+	background: var(--jv-surface);
+	color: var(--jv-ink-2);
+	cursor: pointer;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.16);
+}
+.jvp-jump:hover {
+	color: var(--jv-ink);
+	border-color: var(--jv-ink-3);
+}
+.jvp-jump:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 2px;
+}
+.jvp-jump svg {
+	width: 18px;
+	height: 18px;
+	display: block;
 }
 .jvp-center {
 	height: 100%;

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -3,7 +3,7 @@
 	     page. Tapping it opens the side chat panel in place; on a narrow
 	     viewport (where a 400px panel would be most of the screen) it falls
 	     back to navigating to the chat SPA. -->
-	<div class="jvw-root" :class="{ 'jvw-root--dark': isDark, 'jvw-leaving': leaving }">
+	<div class="jvw-root" :class="{ 'jvw-root--dark': isDark }">
 		<button
 			type="button"
 			ref="fabEl"
@@ -33,11 +33,20 @@
 			</svg>
 		</button>
 
+		<!-- Dimming backdrop for the expand-into-the-big-chat handoff: fades the
+		     Desk behind the panel as it grows to fullscreen, so the motion reads
+		     as going full. Inert otherwise. -->
+		<div
+			class="jvw-backdrop"
+			:class="{ 'jvw-backdrop--show': leaving }"
+			aria-hidden="true"
+		></div>
 		<Panel
 			ref="panelRef"
 			:open="panelOpen"
 			:context="effectiveContext"
 			:layout="panelBox"
+			:leaving="leaving"
 			@close="closePanel"
 			@open-full="openFull"
 			@dismiss-context="contextDismissed = true"
@@ -99,12 +108,24 @@ const viewportTick = ref(0);
 // localStorage synchronously below so the first render already has it, and fed
 // to panelLayout, which floors it at the default and caps it to the viewport.
 const prefSize = ref(null);
-// Set true while the panel fades out just before we hand off to the full web
-// chat (resized-to-fullscreen), so the transition reads as one motion.
+// Set true while the panel expands to fullscreen just before we hand off to the
+// full web chat (resized-to-fullscreen), so the handoff reads as the panel
+// growing INTO the big chat rather than a hard cut.
 const leaving = ref(false);
 const panelBox = computed(() => {
 	viewportTick.value; // re-run on resize / orientation change
 	const topInset = readCssPx(document.documentElement, "--navbar-height", 48);
+	// Handoff to the big chat: aim the panel at the full content area so the root
+	// animates open to fullscreen (Panel's .jvp-root--expanding does the easing).
+	if (leaving.value) {
+		return {
+			left: 0,
+			top: topInset,
+			width: window.innerWidth,
+			height: Math.max(0, window.innerHeight - topInset),
+			side: side.value,
+		};
+	}
 	return panelLayout(
 		{ x: fabXY.value.x, y: fabXY.value.y, size: fabPos.FAB_SIZE },
 		{ vw: window.innerWidth, vh: window.innerHeight, top: topInset },
@@ -123,13 +144,15 @@ function onPanelResizeCommit() {
 	if (!prefSize.value) return;
 	// Resized to (near) the whole screen: the mini panel is the wrong tool at
 	// that size, so hand off to the full web chat instead of persisting a panel
-	// that blankets the Desk. Fade the widget out first so it reads as one smooth
-	// motion into the SPA, and do NOT persist the fullscreen size (the panel
-	// should reopen at its normal size next time).
+	// that blankets the Desk. Expand the panel to fullscreen first (with a
+	// dimming backdrop) so it reads as growing INTO the full chat, and do NOT
+	// persist the fullscreen size (the panel should reopen at its normal size).
 	const box = panelBox.value;
 	if (box && box.width >= window.innerWidth * 0.9 && box.height >= window.innerHeight * 0.85) {
 		leaving.value = true;
-		setTimeout(openFull, 240);
+		// Navigate just after the 0.32s expand finishes, so the panel has visibly
+		// grown into the full chat before the page swaps.
+		setTimeout(openFull, 360);
 		return;
 	}
 	try {
@@ -409,15 +432,26 @@ onBeforeUnmount(() => {
 	--jvw-safe-bottom: env(safe-area-inset-bottom, 0px);
 	font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
-/* Fade the whole widget out as it hands off to the full web chat (resized to
-   fullscreen). Opacity cascades to the panel + FAB (neither is teleported). */
-.jvw-leaving {
+/* Dimming backdrop behind the panel during the expand-into-the-big-chat handoff.
+   Covers the Desk (under the panel, over the page) and fades in as the panel
+   grows to fullscreen, so the motion reads as going full. */
+.jvw-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 1028; /* just under the panel's 1029 */
+	background: rgba(18, 15, 40, 0.34);
 	opacity: 0;
-	transition: opacity 0.24s ease;
 	pointer-events: none;
+	transition: opacity 0.32s ease;
+}
+.jvw-root--dark .jvw-backdrop {
+	background: rgba(0, 0, 0, 0.5);
+}
+.jvw-backdrop--show {
+	opacity: 1;
 }
 @media (prefers-reduced-motion: reduce) {
-	.jvw-leaving {
+	.jvw-backdrop {
 		transition: none;
 	}
 }

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -16,6 +16,11 @@ export function emptyStream() {
     error: "",
     pending: [],
     reload: false,
+    // Coarse turn phase, mirroring the full SPA's status line: "waking" while a
+    // cold container starts, null otherwise. Panel.vue turns this into the
+    // visible caption ("Waking up your assistant…" / "Working on it…") so the
+    // mini panel says the same thing the web chat does instead of bare dots.
+    status: null,
     fence: {},
   };
 }
@@ -58,6 +63,7 @@ export function applyEventEx(state, payload) {
     error: state.error,
     pending: state.pending.slice(),
     reload: state.reload,
+    status: state.status || null,
     // Shallow copy is enough: admitEvent REPLACES a run's entry, never mutates it.
     fence: { ...(state.fence || {}) },
   };
@@ -76,8 +82,18 @@ export function applyEventEx(state, payload) {
 // `s` is already a safe copy the caller owns.
 function applyAdmitted(s, p) {
   switch (p.kind) {
+    // Pre-flight phase (the container is cold and being woken). Arrives BEFORE
+    // run:start, which is why it gets its own caption: this is the slowest wait
+    // in a turn and bare dots make it look hung.
+    case "run:status":
+      if (p.status === "waking") s.status = "waking";
+      return s;
+
     case "run:start":
       s.busy = false;
+      // Woken: the model is working now, so the caption drops back to the
+      // generic "Working on it…".
+      s.status = null;
       s.live = {
         runId: p.run_id || "",
         messageId: p.message_id || "",
@@ -96,6 +112,7 @@ function applyAdmitted(s, p) {
     case "run:end":
       s.busy = false;
       s.live = null;
+      s.status = null;
       // The reply is durable now; re-fetch rather than trusting the streamed
       // copy, which lacks the final formatting.
       s.reload = true;
@@ -104,6 +121,7 @@ function applyAdmitted(s, p) {
     case "run:error":
       s.busy = false;
       s.live = null;
+      s.status = null;
       s.error = p.error || "That turn failed.";
       s.reload = true;
       return s;

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -406,3 +406,29 @@ test("fence survives startNewChat's state reset (dead-banner resurrection guard)
   assert.equal(r.state.error, "");
   assert.equal(r.state.reload, false);
 });
+
+// The mini panel used to show bare typing dots for the whole wait, which reads
+// as hung on a cold start. It now mirrors the web chat's caption, so the coarse
+// phase has to survive the reducer: waking is set pre-flight and cleared the
+// moment the turn actually starts (or ends / fails).
+test("run:status waking sets the phase, run:start clears it", () => {
+  let s = applyEvent(emptyStream(), { kind: "run:status", status: "waking" });
+  assert.equal(s.status, "waking");
+  s = applyEvent(s, { kind: "run:start", run_id: "r1" });
+  assert.equal(s.status, null, "a started turn is no longer waking");
+});
+
+test("run:status ignores any status other than waking", () => {
+  const s = applyEvent(emptyStream(), { kind: "run:status", status: "queued" });
+  assert.equal(s.status, null);
+});
+
+test("a terminal frame clears the waking phase", () => {
+  for (const kind of ["run:end", "run:error"]) {
+    const woke = applyEvent(emptyStream(), {
+      kind: "run:status",
+      status: "waking",
+    });
+    assert.equal(applyEvent(woke, { kind, run_id: "r1" }).status, null, kind);
+  }
+});

--- a/jarvis/tests/test_prompt_suggestions.py
+++ b/jarvis/tests/test_prompt_suggestions.py
@@ -1,0 +1,340 @@
+"""New-chat prompt suggestions synthesised from the user's own chat titles.
+
+Three things have to hold, and each has a test here:
+
+1. The MATERIAL is clean. The model must never be fed the noise a real sidebar is
+   full of — still-unnamed chats, greeting chats, one-off questions, and the same
+   title five times over — or the suggestions describe nothing the user does.
+2. The REFRESH is gated on activity, not just a clock, so an idle workspace costs
+   zero model calls and an active one is capped.
+3. The ENDPOINT is a cheap read: it returns the cache and never generates inline,
+   and it cannot break the empty screen no matter what the queue does.
+
+The gateway turn itself is never exercised — that path is
+jarvis.chat.title._generate_via_gateway's, already covered there, and a test that
+opened a real agent session would be a live-container test.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import suggestions, user_settings_api
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+USETT = "Jarvis User Settings"
+
+USER = "sugg-user@example.test"
+OTHER = "sugg-other@example.test"
+
+
+def _ensure_user(email: str) -> None:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Sugg",
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	frappe.get_doc("User", email).add_roles("Jarvis User")
+
+
+def _conv(owner: str, title: str, *, messages: int = 4, days_ago: int = 1) -> str:
+	"""A conversation owned by `owner`, with `messages` real messages on it."""
+	when = frappe.utils.add_days(frappe.utils.now_datetime(), -days_ago)
+	doc = frappe.get_doc({"doctype": CONV, "title": title, "status": "Active"}).insert(
+		ignore_permissions=True
+	)
+	frappe.db.set_value(CONV, doc.name, {"owner": owner, "last_active_at": when}, update_modified=False)
+	for i in range(messages):
+		m = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": doc.name,
+				"seq": i + 1,
+				"role": "user" if i % 2 == 0 else "assistant",
+				"content": "x",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(MSG, m.name, "owner", owner, update_modified=False)
+	return doc.name
+
+
+class SuggestionsBase(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(USER)
+		_ensure_user(OTHER)
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		for u in (USER, OTHER):
+			for name in frappe.get_all(CONV, filters={"owner": u}, pluck="name"):
+				frappe.db.delete(MSG, {"conversation": name})
+				frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+			for name in frappe.get_all(USETT, filters={"user": u}, pluck="name"):
+				frappe.delete_doc(USETT, name, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+
+# --------------------------------------------------------------------------- #
+# 1. Material
+# --------------------------------------------------------------------------- #
+class TestEligibleTitles(SuggestionsBase):
+	def test_keeps_substantive_titles_newest_first(self):
+		_conv(USER, "Sales Invoice Submission Alert", days_ago=5)
+		_conv(USER, "Timesheet Report Date Range", days_ago=1)
+		self.assertEqual(
+			suggestions.eligible_titles(USER),
+			["Timesheet Report Date Range", "Sales Invoice Submission Alert"],
+		)
+
+	def test_drops_unnamed_greeting_and_one_word_titles(self):
+		_conv(USER, "New chat")
+		_conv(USER, "hello")
+		_conv(USER, "Greeting")
+		_conv(USER, "Purchase Order Approval Flow")
+		self.assertEqual(suggestions.eligible_titles(USER), ["Purchase Order Approval Flow"])
+
+	def test_drops_one_off_conversations(self):
+		# "Simple Addition Answer" style: a titled chat that was a single question.
+		_conv(USER, "Simple Addition Answer", messages=2)
+		_conv(USER, "Stock Reconciliation Draft", messages=4)
+		self.assertEqual(suggestions.eligible_titles(USER), ["Stock Reconciliation Draft"])
+
+	def test_tool_rows_do_not_make_a_one_off_look_substantive(self):
+		# Tool rows outnumber prose in a real conversation, so counting them let a
+		# single question that happened to call two tools pass the MIN_MESSAGES bar.
+		name = _conv(USER, "One Question With Tools", messages=2)
+		for i in range(6):
+			m = frappe.get_doc(
+				{
+					"doctype": MSG,
+					"conversation": name,
+					"seq": 100 + i,
+					"role": "tool",
+					"content": "get_doc -> completed",
+				}
+			).insert(ignore_permissions=True)
+			frappe.db.set_value(MSG, m.name, "owner", USER, update_modified=False)
+		frappe.db.commit()
+		self.assertEqual(suggestions.eligible_titles(USER), [])
+
+	def test_dedupes_repeated_titles(self):
+		# A sidebar with five "System Behaviour Overview" must not spend five of the
+		# 25 prompt slots saying the same thing.
+		for d in range(1, 6):
+			_conv(USER, "System Behaviour Overview", days_ago=d)
+		_conv(USER, "Lead Conversion Report", days_ago=6)
+		self.assertEqual(
+			suggestions.eligible_titles(USER),
+			["System Behaviour Overview", "Lead Conversion Report"],
+		)
+
+	def test_ignores_conversations_outside_the_window(self):
+		_conv(USER, "Ancient Migration Notes", days_ago=suggestions.LOOKBACK_DAYS + 5)
+		_conv(USER, "Recent Payroll Question", days_ago=2)
+		self.assertEqual(suggestions.eligible_titles(USER), ["Recent Payroll Question"])
+
+	def test_never_leaks_another_users_titles(self):
+		_conv(OTHER, "Other Persons Secret Project")
+		_conv(USER, "My Own Report")
+		self.assertEqual(suggestions.eligible_titles(USER), ["My Own Report"])
+
+	def test_caps_the_number_of_titles(self):
+		for i in range(suggestions.MAX_TITLES + 6):
+			_conv(USER, f"Distinct Report Number {i}", days_ago=1)
+		self.assertEqual(len(suggestions.eligible_titles(USER)), suggestions.MAX_TITLES)
+
+	def test_empty_for_a_user_with_no_history(self):
+		self.assertEqual(suggestions.eligible_titles(USER), [])
+
+
+# --------------------------------------------------------------------------- #
+# 2. Refresh policy
+# --------------------------------------------------------------------------- #
+class TestRefreshGate(SuggestionsBase):
+	def _stamp(self, days_ago: float, lines=({"title": "A", "prompt": "a b"},)) -> None:
+		suggestions.store(USER, list(lines))
+		frappe.db.set_value(
+			USETT,
+			{"user": USER},
+			"prompt_suggestions_at",
+			frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-days_ago),
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	def test_refreshes_when_never_synthesised(self):
+		self.assertTrue(suggestions.needs_refresh(USER))
+
+	def test_does_not_refresh_while_fresh(self):
+		self._stamp(days_ago=1)
+		_conv(USER, "Brand New Work", days_ago=0)
+		self.assertFalse(suggestions.needs_refresh(USER), "a fresh cache must not be regenerated")
+
+	def test_idle_user_never_costs_a_call(self):
+		# Stale by the clock, but the user has not chatted since - the whole point
+		# of the activity gate.
+		_conv(USER, "Old Work", days_ago=40)
+		self._stamp(days_ago=suggestions.REFRESH_AFTER_DAYS + 10)
+		self.assertFalse(suggestions.needs_refresh(USER))
+
+	def test_refreshes_when_stale_and_active(self):
+		self._stamp(days_ago=suggestions.REFRESH_AFTER_DAYS + 1)
+		_conv(USER, "Work Done Since The Stamp", days_ago=0)
+		self.assertTrue(suggestions.needs_refresh(USER))
+
+	def test_an_attempt_that_found_nothing_still_backs_off(self):
+		# The gate reads the STAMP, not the stored value. Without this, a workspace
+		# with no named history would queue a job on every empty-screen load.
+		suggestions.touch(USER)
+		self.assertEqual(suggestions.read(USER), [])
+		self.assertFalse(suggestions.needs_refresh(USER))
+
+	def test_a_user_with_no_history_is_stamped_not_retried(self):
+		with patch.object(suggestions, "_generate_via_gateway") as gen:
+			suggestions.refresh_job(USER)
+		gen.assert_not_called()  # nothing to synthesise from
+		self.assertFalse(suggestions.needs_refresh(USER), "must back off, not retry every load")
+
+	def test_a_failed_generation_keeps_the_previous_strip(self):
+		# A transient gateway blip must not blank a good strip - it stamps (so the
+		# gateway is not hammered) and leaves the old suggestions in place.
+		suggestions.store(USER, [{"title": "Invoices", "prompt": "Show overdue invoices"}])
+		frappe.db.set_value(
+			USETT,
+			{"user": USER},
+			"prompt_suggestions_at",
+			frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-(suggestions.REFRESH_AFTER_DAYS + 1)),
+			update_modified=False,
+		)
+		_conv(USER, "Fresh Work Since Then", days_ago=0)
+		frappe.db.commit()
+		with patch.object(suggestions, "_generate_via_gateway", return_value=[]):
+			suggestions.refresh_job(USER)
+		self.assertEqual(suggestions.read(USER), [{"title": "Invoices", "prompt": "Show overdue invoices"}])
+		self.assertFalse(suggestions.needs_refresh(USER))
+
+	def test_enqueue_is_a_no_op_when_not_needed(self):
+		self._stamp(days_ago=0)
+		with patch("frappe.enqueue") as mock_enqueue:
+			suggestions.enqueue_refresh(USER)
+		mock_enqueue.assert_not_called()
+
+	def test_enqueue_queues_when_needed(self):
+		with patch("frappe.enqueue") as mock_enqueue:
+			suggestions.enqueue_refresh(USER)
+		mock_enqueue.assert_called_once()
+		self.assertEqual(mock_enqueue.call_args.kwargs.get("queue"), "short")
+
+
+# --------------------------------------------------------------------------- #
+# 3. Parsing, storage, endpoint
+# --------------------------------------------------------------------------- #
+class TestParseAndStore(SuggestionsBase):
+	def test_parses_label_and_prompt_pairs(self):
+		out = suggestions.parse_lines(
+			"Invoices | Show overdue invoices\n"
+			"- Payroll | Draft a payroll summary\n"
+			'1. Stock | "Reconcile stock counts"'
+		)
+		self.assertEqual(
+			out,
+			[
+				{"title": "Invoices", "prompt": "Show overdue invoices"},
+				{"title": "Payroll", "prompt": "Draft a payroll summary"},
+				{"title": "Stock", "prompt": "Reconcile stock counts"},
+			],
+		)
+
+	def test_keeps_a_line_that_forgot_its_label(self):
+		# A missing label must not cost us a usable suggestion - the card just
+		# renders the prompt on its own.
+		self.assertEqual(
+			suggestions.parse_lines("Show my open leads"),
+			[{"title": "", "prompt": "Show my open leads"}],
+		)
+
+	def test_drops_blank_and_single_word_lines(self):
+		self.assertEqual(
+			suggestions.parse_lines("\n\nOk\nShow my open leads\n"),
+			[{"title": "", "prompt": "Show my open leads"}],
+		)
+
+	def test_caps_the_count(self):
+		many = "\n".join(f"Area {i} | Do the thing number {i}" for i in range(10))
+		self.assertEqual(len(suggestions.parse_lines(many)), suggestions.WANT)
+
+	def test_tolerates_junk(self):
+		self.assertEqual(suggestions.parse_lines(None), [])
+		self.assertEqual(suggestions.parse_lines(""), [])
+
+	def test_store_and_read_round_trip(self):
+		items = [{"title": "Invoices", "prompt": "Show overdue invoices"}]
+		suggestions.store(USER, items)
+		self.assertEqual(suggestions.read(USER), items)
+
+	def test_read_upgrades_a_legacy_plain_string_cache(self):
+		# A cache written by the first version of this feature must still render
+		# rather than blanking the strip until the next refresh.
+		suggestions.touch(USER)  # ensure the settings row exists to overwrite
+		frappe.db.set_value(
+			USETT,
+			{"user": USER},
+			"prompt_suggestions",
+			json.dumps(["Show overdue invoices"]),
+			update_modified=False,
+		)
+		frappe.db.commit()
+		self.assertEqual(suggestions.read(USER), [{"title": "", "prompt": "Show overdue invoices"}])
+
+	def test_read_is_empty_and_quiet_for_a_fresh_user(self):
+		self.assertEqual(suggestions.read(USER), [])
+
+	def test_read_survives_a_corrupt_cache(self):
+		suggestions.store(USER, ["ok line"])
+		frappe.db.set_value(USETT, {"user": USER}, "prompt_suggestions", "{not json", update_modified=False)
+		frappe.db.commit()
+		self.assertEqual(suggestions.read(USER), [])
+
+
+class TestEndpoint(SuggestionsBase):
+	def test_returns_the_cache_and_never_generates_inline(self):
+		suggestions.store(USER, [{"title": "Invoices", "prompt": "Show overdue invoices"}])
+		frappe.set_user(USER)
+		with patch.object(suggestions, "_generate_via_gateway") as gen, patch("frappe.enqueue"):
+			out = user_settings_api.get_prompt_suggestions()
+		frappe.set_user("Administrator")
+		self.assertTrue(out["ok"])
+		self.assertEqual(
+			out["data"]["suggestions"], [{"title": "Invoices", "prompt": "Show overdue invoices"}]
+		)
+		gen.assert_not_called()
+
+	def test_survives_a_broken_queue(self):
+		# A queue outage must not take the empty chat screen down with it.
+		frappe.set_user(USER)
+		with patch("frappe.enqueue", side_effect=RuntimeError("redis down")):
+			out = user_settings_api.get_prompt_suggestions()
+		frappe.set_user("Administrator")
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["data"]["suggestions"], [])


### PR DESCRIPTION
## What

The new chat page, rebuilt around the user's own history, plus the mini-chat and dialog fixes found alongside it.

Carries two commits orphaned when #659 merged (`f82d4a14`, `28f8e19c` - the panel expand transition and the "Working on it..." caption), so nothing is stranded.

## Changes

**New chat page** (`feat(chat): rebuild the new chat page...`)
- **Greeting is synthesised locally** (`lib/greeting.js`): time of day incl. the late-night ("Up late") and early edges, plus a returning-after-a-gap line ("Welcome back" / "Long time no see") read from the newest conversation's timestamp. Seeded by day, so it holds steady on screen but varies day to day. **No backend call; no history leaves the browser.**
- **Starter cards keep their original design** but their copy is synthesised from the user's own recent chat titles (`chat/suggestions.py`). Titles only - never message bodies. One cheap oneshot turn on the same throwaway-session path auto-titling already uses (~5s, ~25 titles in). Cached per user; refreshed at most every 3 days **and only when the user has chatted since**, so an idle workspace costs zero model calls.
- Layout: composer sits at the bottom like a normal chat, greeting centred above it at display size.
- Filtering is deliberate: drops `New chat`, greeting chats and one-offs, dedupes repeated titles, and counts only user/assistant rows (tool rows outnumber prose and made single questions look substantive).
- Every attempt stamps - including failures - so a workspace with no history cannot queue a job on every page load, and a gateway blip keeps the previous cards rather than blanking them.

**Dialog pickers** (`fix(ui): lift portalled pickers above dialogs`)
frappe-ui portals Popover content to `<body>` with no z-index, so once `.dialog-overlay` was raised to 60, any picker opened *inside* a dialog was painted over by that dialog. The role Autocomplete in **Request promotion** looked like a dead control. `.PopoverContent` now sits at 120 - above every overlay, below `ConfirmDialog`'s 200. App-wide, since every Autocomplete/Dropdown/Select portals identically.

**Mini chat** - jump-to-latest button (a reader scrolled up mid-reply had no way back), and the two carried-over commits above.

**Composer** - the idle "Enter" hint is gone; only "Stop" survives, and only while a reply runs.

## Tests

- `jarvis/tests/test_prompt_suggestions.py` - **29 tests**: title filtering (dummy/greeting/one-off/tool-rows/dupes/window/cap/other-users), the activity-gated refresh, backoff on empty and failed runs, parsing, and that the endpoint never generates inline or breaks on a dead queue.
- `frontend/src/lib/greeting.spec.js` - **17 tests**: bucket boundaries, midnight wrap, gap thresholds, stability, day-to-day variation, clock skew, no brand names.
- `frontend/src/components/skills/PromotionRequestDialog.spec.js` - **7 tests**: picker appears on Role scope, offers the requester's own roles, explains itself when they hold none, gates Send, plus a stylesheet guard on the stacking order (jsdom cannot compute it).

```
bench --site <site> run-tests --app jarvis --module jarvis.tests.test_prompt_suggestions
cd frontend && npx vitest run     # 788 passing / 56 files
```

## Deploy note

Run `bench --site <site> migrate` - adds `prompt_suggestions` / `prompt_suggestions_at` to **Jarvis User Settings**. Then rebuild the SPA (`cd frontend && npm run build`); the Desk widget change needs `bench build --app jarvis`.
