### PR TITLE
feat(chat): offer catalog models for providers the tenant already configured

### DIFF
--- a/frontend/src/components/chat/ModelEffortPicker.vue
+++ b/frontend/src/components/chat/ModelEffortPicker.vue
@@ -75,7 +75,16 @@
 				>
 					<span class="mep-item-body">
 						<span class="mep-name">{{ r.model }}</span>
+						<!-- `tier` belongs to a configured pool row. An `extra` row is another
+						     model on a provider the customer ALREADY configured, offered so they
+						     can switch without re-saving Settings; its catalog label is the more
+						     useful subtitle, skipped when it merely repeats the id. -->
 						<span v-if="r.tier" class="mep-desc">{{ r.tier }}</span>
+						<span
+							v-else-if="r.extra && r.label && r.label !== r.model"
+							class="mep-desc"
+							>{{ r.label }}</span
+						>
 					</span>
 					<CheckMark v-if="r.model === modelOverride" />
 				</button>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4501,7 +4501,7 @@ const thinkingLabel = computed(() => thinkingOverride.value || "auto");
 // The pool rows come FIRST and keep their order, because row 0 is the primary
 // the container actually defaults to and the rest are its failover chain. The
 // catalog rows appended after them are other models on a provider the customer
-// has ALREADY configured: openclaw serves a model id the pool spec never named,
+// has ALREADY configured: the agent serves a model id the pool spec never named,
 // so switching within a provider needs no re-save (`catalog_models`, keyed by the
 // same provider id these rows carry). They are marked `extra` so the menu can
 // separate "your models" from "also available".

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4497,6 +4497,18 @@ const thinkingLabel = computed(() => thinkingOverride.value || "auto");
 // The pickable models: the configured LLM pool when present, else the
 // provider's subscription allowlist. Deduped on provider+model because a
 // subscription pool legitimately holds one row per ACCOUNT, not per model.
+//
+// The pool rows come FIRST and keep their order, because row 0 is the primary
+// the container actually defaults to and the rest are its failover chain. The
+// catalog rows appended after them are other models on a provider the customer
+// has ALREADY configured: openclaw serves a model id the pool spec never named,
+// so switching within a provider needs no re-save (`catalog_models`, keyed by the
+// same provider id these rows carry). They are marked `extra` so the menu can
+// separate "your models" from "also available".
+//
+// Only the server decides what lands in catalog_models. Never widen this to every
+// provider in the catalog: a provider with no credential in the container answers
+// model_not_found, which does not fail over, so the turn dies (#498).
 const pickableModels = computed(() => {
 	const pool = ui.value.pool_models || [];
 	if (pool.length) {
@@ -4507,6 +4519,21 @@ const pickableModels = computed(() => {
 			if (seen.has(key)) continue;
 			seen.add(key);
 			out.push(r);
+		}
+		const catalog = ui.value.catalog_models || {};
+		for (const r of pool) {
+			for (const c of catalog[r.provider] || []) {
+				const key = `${r.provider}/${c.model}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				out.push({
+					provider: r.provider,
+					model: c.model,
+					label: c.label,
+					tier: "",
+					extra: true,
+				});
+			}
 		}
 		return out;
 	}

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -92,6 +92,15 @@ def _allowed_pin_models(settings) -> set[str]:
 	allowed |= {
 		(m.model or "").strip() for m in (settings.models or []) if m.enabled and (m.model or "").strip()
 	}
+	# Catalog models on a provider this tenant already configured. The container
+	# serves a model id the pool spec never named, so the picker offers these and
+	# the pin must accept them or every such choice 417s with "not allowed".
+	#
+	# Deliberately the SAME call the picker is fed from, not a parallel rule:
+	# display and validation drifting apart is what made a pin fail while the menu
+	# still offered it. If it is offered, it is pinnable, by construction.
+	for rows in _catalog_models_for_pool(settings).values():
+		allowed |= {r["model"] for r in rows}
 	return allowed
 
 
@@ -1289,6 +1298,53 @@ def _api_key_models() -> dict[str, list[dict]]:
 	return out
 
 
+def _catalog_models_for_pool(settings) -> dict[str, list[dict]]:
+	"""Provider id -> api-key catalog models the chat picker may offer, for the
+	providers this tenant has ALREADY configured.
+
+	The point is that a customer with one saved model is not stuck with it. The
+	container holds a credential per provider, and openclaw serves a model id the
+	pool spec never named, so switching within a configured provider costs nothing
+	and needs no re-save.
+
+	Keyed on the canonical provider id the ``pool_models`` rows carry, so the UI
+	can join the two without a second lookup. The catalog's ``catalog_id`` IS that
+	id (``google`` the provider is ``gemini`` on the wire); ``provider_id`` is the
+	fallback for a legacy row.
+
+	Only providers already in the pool appear: a provider with no credential in
+	the container answers ``model_not_found``, and being an explicit bad-id
+	rejection rather than an upstream failure it does not fail over, so the turn
+	dies (#498). Adding a NEW provider stays a Settings operation.
+
+	z.ai rows are excluded by ``accepts_any_model`` -- see the note beside it in
+	pool_serialize, and keep this in step with the fleet render's ``any_model``.
+	"""
+	from jarvis import admin_client
+	from jarvis.jarvis.pool_serialize import accepts_any_model, normalize_provider
+
+	wanted = {
+		normalize_provider(getattr(m, "provider", "") or "")
+		for m in settings.models or []
+		if m.enabled and accepts_any_model(m)
+	}
+	wanted.discard("")
+	if not wanted:
+		return {}
+
+	out: dict[str, list[dict]] = {}
+	for provider in admin_client.get_model_catalog() or []:
+		pid = (provider.get("catalog_id") or provider.get("provider_id") or "").strip()
+		if pid not in wanted:
+			continue
+		rows = [m for m in provider.get("models") or [] if m.get("tier") == "api_key"]
+		rows.sort(key=lambda m: (m.get("sort_order") or 0, m.get("model_id") or ""))
+		# Display fields only. The catalog carries no secrets by construction, but
+		# this endpoint is on the hot chat path, so it stays a narrow projection.
+		out[pid] = [{"model": m["model_id"], "label": m.get("label") or m["model_id"]} for m in rows]
+	return out
+
+
 def _subscription_connect_providers() -> list[dict]:
 	"""Providers offering DirectSubscriptionCard's paste-back OAuth connect flow.
 
@@ -1433,6 +1489,10 @@ def get_chat_ui_settings() -> dict:
 		"pool_models": pool,
 		"providers": providers,
 		"multi_provider": len(providers) > 1,
+		# Catalog models the customer may switch to IN CHAT without re-saving
+		# Settings, keyed by the same provider id the ``pool_models`` rows carry.
+		# See _catalog_models_for_pool.
+		"catalog_models": _catalog_models_for_pool(settings),
 		# Effort levels. Deliberately mirrors ``_ALLOWED_THINKING`` minus the
 		# empty "auto" entry, which the UI renders separately. agent itself
 		# accepts more levels (off/minimal/xhigh/adaptive/max), but

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1303,7 +1303,7 @@ def _catalog_models_for_pool(settings) -> dict[str, list[dict]]:
 	providers this tenant has ALREADY configured.
 
 	The point is that a customer with one saved model is not stuck with it. The
-	container holds a credential per provider, and openclaw serves a model id the
+	container holds a credential per provider, and the agent serves a model id the
 	pool spec never named, so switching within a configured provider costs nothing
 	and needs no re-save.
 

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -129,6 +129,62 @@ def _wire_provider(canonical_id: str) -> str:
 	return _WIRE_PROVIDER_OVERRIDES.get(canonical_id, canonical_id)
 
 
+# ---------------------------------------------------------------------------
+# Which providers the chat picker may offer CATALOG models for, beyond the exact
+# rows the customer saved.
+#
+# The container serves a model id its pool spec never named, so a customer does
+# not have to leave chat and re-save Settings to try another model on a provider
+# they already configured. z.ai is the one exception, and it is not cosmetic:
+# measured against openclaw's own resolver, an unnamed model inherits `maxTokens`
+# and `params` from the provider entry but NOT `reasoning` or `compat`, and GLM's
+# thinking suppression is `compat.thinkingFormat === "zai" && model.reasoning`.
+# Offer an unnamed GLM id and the customer gets a blank assistant bubble (#526).
+#
+# This MIRRORS jarvis-fleet-agent `pool_render`'s `any_model` marker, which is
+# what actually gates the container. Keep the two in step: offering a model the
+# fleet render did not admit gives `model_not_found`, and because that is an
+# explicit bad-id rejection rather than an upstream failure, native failover does
+# not engage and the turn dies. That is the #498 shape. The fleet side is the
+# authority; this is only the display half.
+#
+# Keyed on provider id AND resolved host: the tenant in #526 reached z.ai through
+# the generic `openai_compat` row, so a provider-id-only test would miss the very
+# pool that reported the bug. Matched on the registrable domain (host is it, or a
+# dot-subdomain of it) so `evilz.ai` and `api.z.ai.attacker.test` do not match.
+# ---------------------------------------------------------------------------
+_ZAI_PROVIDER_IDS = frozenset({"zai", "zai_coding"})
+_ZAI_DOMAINS = ("z.ai", "bigmodel.cn")
+
+
+def _host_of(base_url: str) -> str:
+	from urllib.parse import urlsplit
+
+	try:
+		return (urlsplit((base_url or "").strip()).hostname or "").lower()
+	except ValueError:
+		return ""
+
+
+def is_zai_backed(provider: str, base_url: str = "") -> bool:
+	"""True when this credential talks to z.ai (GLM), by provider id or by host."""
+	if (provider or "").strip().lower() in _ZAI_PROVIDER_IDS:
+		return True
+	host = _host_of(base_url)
+	return any(host == d or host.endswith("." + d) for d in _ZAI_DOMAINS)
+
+
+def accepts_any_model(m) -> bool:
+	"""True when the chat picker may offer catalog models for this pool row.
+
+	False for a subscription row (its model list belongs to the upstream, not the
+	api-key catalog) and for anything z.ai-backed.
+	"""
+	if _credential_type(m) == "subscription":
+		return False
+	return not is_zai_backed(_field(m, "provider"), _field(m, "base_url"))
+
+
 def _model_accounts(m) -> list:
 	"""Return a subscription model's accounts as a list of dicts.
 

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -136,7 +136,7 @@ def _wire_provider(canonical_id: str) -> str:
 # The container serves a model id its pool spec never named, so a customer does
 # not have to leave chat and re-save Settings to try another model on a provider
 # they already configured. z.ai is the one exception, and it is not cosmetic:
-# measured against openclaw's own resolver, an unnamed model inherits `maxTokens`
+# measured against the agent runtime's own resolver, an unnamed model inherits `maxTokens`
 # and `params` from the provider entry but NOT `reasoning` or `compat`, and GLM's
 # thinking suppression is `compat.thinkingFormat === "zai" && model.reasoning`.
 # Offer an unnamed GLM id and the customer gets a blank assistant bubble (#526).

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -896,6 +896,87 @@ class TestChatUiSettings(FrappeTestCase):
 			self.assertIn(default, SUBSCRIPTION_MODELS[provider])
 
 
+class TestCatalogModelsForPool(FrappeTestCase):
+	"""The chat picker may offer catalog models on a provider the tenant ALREADY
+	configured, because the container serves a model id the pool spec never named.
+	z.ai is excluded: an unnamed model there loses `reasoning`/`compat` and returns
+	a blank bubble (#526). Mirrors jarvis-fleet-agent pool_render's `any_model`."""
+
+	CATALOG = [
+		{
+			"provider_id": "anthropic",
+			"catalog_id": "anthropic",
+			"models": [
+				{"model_id": "claude-opus-4-8", "label": "Opus", "tier": "api_key", "sort_order": 2},
+				{"model_id": "claude-sonnet-4-6", "label": "Sonnet", "tier": "api_key", "sort_order": 1},
+				{"model_id": "claude-sub", "label": "Sub", "tier": "subscription"},
+			],
+		},
+		{
+			"provider_id": "google",
+			"catalog_id": "gemini",
+			"models": [{"model_id": "gemini-3.6-flash", "label": "Flash", "tier": "api_key"}],
+		},
+		{
+			"provider_id": "zai_coding",
+			"catalog_id": "zai_coding",
+			"models": [{"model_id": "glm-4.6", "label": "GLM 4.6", "tier": "api_key"}],
+		},
+	]
+
+	def _settings(self, rows):
+		return frappe._dict(models=[frappe._dict(r) for r in rows])
+
+	def _run(self, rows):
+		from unittest.mock import patch
+
+		from jarvis.chat import api
+
+		with patch("jarvis.admin_client.get_model_catalog", return_value=self.CATALOG):
+			return api._catalog_models_for_pool(self._settings(rows))
+
+	def test_offers_catalog_models_for_a_configured_provider_only(self):
+		out = self._run([{"enabled": 1, "provider": "anthropic", "model": "claude-sonnet-4-6"}])
+		self.assertEqual(list(out), ["anthropic"], "a provider with no credential must not appear")
+		# sort_order wins over id, and subscription-tier rows are excluded
+		self.assertEqual([r["model"] for r in out["anthropic"]], ["claude-sonnet-4-6", "claude-opus-4-8"])
+		self.assertEqual(out["anthropic"][0]["label"], "Sonnet")
+
+	def test_zai_provider_is_excluded(self):
+		out = self._run([{"enabled": 1, "provider": "zai_coding", "model": "glm-4.7"}])
+		self.assertEqual(out, {}, "an unnamed GLM id returns a blank bubble (#526)")
+
+	def test_zai_reached_through_openai_compat_base_url_is_excluded(self):
+		"""The #526 tenant reached z.ai through the generic openai_compat row, so a
+		provider-id-only test would miss the very pool that reported the bug."""
+		out = self._run(
+			[
+				{
+					"enabled": 1,
+					"provider": "openai_compat",
+					"model": "glm-4.7",
+					"base_url": "https://api.z.ai/api/coding/paas/v4",
+				}
+			]
+		)
+		self.assertEqual(out, {})
+
+	def test_disabled_and_subscription_rows_contribute_nothing(self):
+		self.assertEqual(self._run([{"enabled": 0, "provider": "anthropic", "model": "x"}]), {})
+		self.assertEqual(
+			self._run(
+				[{"enabled": 1, "provider": "anthropic", "model": "x", "credential_type": "subscription"}]
+			),
+			{},
+		)
+
+	def test_legacy_google_provider_id_maps_onto_the_gemini_wire_id(self):
+		"""normalize_provider collapses the legacy `google` id onto `gemini`, which is
+		what pool rows and the catalog's catalog_id both use."""
+		out = self._run([{"enabled": 1, "provider": "google", "model": "gemini-3.6-flash"}])
+		self.assertEqual(list(out), ["gemini"])
+
+
 class TestWarmSessionEndpoint(FrappeTestCase):
 	def tearDown(self):
 		from jarvis.chat import prewarm


### PR DESCRIPTION
## Summary

A customer who configured one model can only ever chat with that one model. The container already holds a credential per provider and serves a model id the pool spec never named, so switching within a configured provider costs nothing. The picker just had nothing else to show. Customers now get the rest of that provider's catalog in the chat model menu, with no trip to Settings and no re-sync.

Customer half of #692. **Needs `jarvis-fleet-agent`#188** (renders the anthropic budget at provider scope and re-admits non-z.ai providers when a thinking pin forces allowlist mode). Merging this first is safe but does nothing for an anthropic-primary tenant.

## What changed
- `get_chat_ui_settings` returns `catalog_models`, keyed by the same provider id the pool rows carry, for providers **already in the pool**.
- The picker appends them after the pool rows, which keep their order: row 0 is the primary, the rest are its failover chain.
- `_allowed_pin_models` unions in the same call the picker is fed from, so a model that is offered is pinnable by construction.

## Risk and verification
- **Only configured providers appear.** One with no credential answers `model_not_found`, which does not fail over, so the turn would die (#498). Adding a new provider stays a Settings operation.
- **z.ai excluded**, by provider id and by resolved host, including a GLM reached through a generic `openai_compat` row (the shape that reported #526). Host matching is on the registrable domain, so `evilz.ai` and `api.z.ai.attacker.test` do not match; both are pinned in tests.
- New `TestCatalogModelsForPool` covers ordering, subscription-tier exclusion, disabled rows, the legacy `google` to `gemini` id collapse, and both z.ai paths.
- Lint gate run locally: `pre-commit run --files ...` green (ruff format and the pinned prettier both rewrote files first, so `ruff check` alone would have gone red on CI).

<details><summary>Why z.ai is the one exception</summary>

Measured against openclaw 2026.6.8's own resolver, a model id the pool spec does not name inherits `maxTokens` and `params` from the provider entry but not `reasoning` or `compat`:

```
zai-0/glm-4.7  (named)    reasoning=true   compat="zai"
zai-0/glm-4.6  (unnamed)  reasoning=false  compat=null
```

GLM's thinking suppression is `compat.thinkingFormat === "zai" && model.reasoning`, so an unnamed GLM id loses thinking-off and returns a blank assistant bubble. This mirrors fleet-agent `pool_render`'s `any_model` marker; the fleet side is the authority and this is the display half.

</details>

https://claude.ai/code/session_01MFFvM6mVvwJ5RG1kqmnq1q