### PR TITLE
fix(onboarding): stop rendering real failures as progress or raw errors

### DIFF
--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -99,7 +99,7 @@ import { useShellStore } from "@/stores/shell";
 import { useShortcuts } from "@/composables/useShortcuts";
 import { attachGlobalNotifier } from "@/notify/globalNotifier";
 import NotifyToaster from "@/notify/NotifyToaster.vue";
-import { needsOnboarding, regateOnboarding } from "@/onboarding/readiness.js";
+import { needsOnboarding, regateOnRouteChange } from "@/onboarding/readiness.js";
 import Sidebar from "./Sidebar.vue";
 import JarvisCommandPalette from "./JarvisCommandPalette.vue";
 import SettingsDialog from "./SettingsDialog.vue";
@@ -138,7 +138,14 @@ const gatedOnboarding = ref(null);
 needsOnboarding().then((v) => {
 	gatedOnboarding.value = v;
 });
-const shellReady = computed(() => gatedOnboarding.value !== null && !!route.name);
+// True while a route-triggered re-check (below) is in flight. Folded into
+// `shellReady` so that window holds the SAME neutral surface the initial boot
+// read already uses, rather than ever rendering `showGate`'s stale answer -
+// see the watcher below for why this exists (round-4 review F3).
+const regatingOnboarding = ref(false);
+const shellReady = computed(
+	() => gatedOnboarding.value !== null && !!route.name && !regatingOnboarding.value
+);
 // The wizard route is exempt so the poster's button can navigate into it.
 const showGate = computed(() => gatedOnboarding.value === true && route.name !== "Onboarding");
 
@@ -150,14 +157,17 @@ const showGate = computed(() => gatedOnboarding.value === true && route.name !==
 // without this watcher `gatedOnboarding` never hears about it - the customer
 // lands on a ready workspace still showing the "Finish setting up" poster,
 // clearable only by a hard reload that nothing on screen suggests (three
-// production reproductions, jarvis#691). regateOnboarding() is a no-op unless
-// the gate is currently up, so this costs nothing on the routes that make up
-// the overwhelming majority of navigations.
+// production reproductions, jarvis#691).
+//
+// The actual race/flash-safe logic (round-4 review F3/F4: never write the
+// stale value mid-flight, never let a superseded call win) lives in
+// readiness.js's regateOnRouteChange(), pulled out of this file so it can be
+// pinned by a plain unit test without mounting this (heavy) component. The
+// two refs below ARE its state; passing them by reference is what lets it
+// write straight into AppShell's reactivity.
 watch(
 	() => route.name,
-	async () => {
-		gatedOnboarding.value = await regateOnboarding(gatedOnboarding.value);
-	}
+	() => regateOnRouteChange(gatedOnboarding, regatingOnboarding)
 );
 
 // Boot gate: hold the routed page (NOT the shell chrome) until systemTimezone

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -91,7 +91,7 @@
 // gate (D11), the approvals-badge poll (D12), the global notifier (attention
 // signals for background conversations/routes, NOTIFY-APPROVALS Part 1) and
 // the global shortcuts.
-import { computed, onMounted, onBeforeUnmount, ref, inject } from "vue";
+import { computed, onMounted, onBeforeUnmount, ref, watch, inject } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { FrappeUIProvider, Dialogs, setConfig, FeatherIcon } from "frappe-ui";
 import * as api from "@/api";
@@ -99,7 +99,7 @@ import { useShellStore } from "@/stores/shell";
 import { useShortcuts } from "@/composables/useShortcuts";
 import { attachGlobalNotifier } from "@/notify/globalNotifier";
 import NotifyToaster from "@/notify/NotifyToaster.vue";
-import { needsOnboarding } from "@/onboarding/readiness.js";
+import { needsOnboarding, regateOnboarding } from "@/onboarding/readiness.js";
 import Sidebar from "./Sidebar.vue";
 import JarvisCommandPalette from "./JarvisCommandPalette.vue";
 import SettingsDialog from "./SettingsDialog.vue";
@@ -141,6 +141,24 @@ needsOnboarding().then((v) => {
 const shellReady = computed(() => gatedOnboarding.value !== null && !!route.name);
 // The wizard route is exempt so the poster's button can navigate into it.
 const showGate = computed(() => gatedOnboarding.value === true && route.name !== "Onboarding");
+
+// #691: the boot-time read above runs exactly ONCE for the whole SPA session -
+// AppShell never remounts on a client-side navigation (App.vue is just
+// <AppShell/>, owning the single <router-view/>). A connect that succeeds
+// while still on /onboarding changes the backend verdict without remounting
+// this component; the only thing that follows is a route change into Chat, and
+// without this watcher `gatedOnboarding` never hears about it - the customer
+// lands on a ready workspace still showing the "Finish setting up" poster,
+// clearable only by a hard reload that nothing on screen suggests (three
+// production reproductions, jarvis#691). regateOnboarding() is a no-op unless
+// the gate is currently up, so this costs nothing on the routes that make up
+// the overwhelming majority of navigations.
+watch(
+	() => route.name,
+	async () => {
+		gatedOnboarding.value = await regateOnboarding(gatedOnboarding.value);
+	}
+);
 
 // Boot gate: hold the routed page (NOT the shell chrome) until systemTimezone
 // is configured — timeAgo strings render once, so a late setConfig would leave

--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -2,6 +2,22 @@
 // Single source for AccountView / OnboardingView / LlmPoolEditor so a change to
 // Frappe's error envelope only has to be made once.
 //
+// MUST be total (#696): given ANY shape of `e`, this returns a sentence and
+// never throws. frappe-ui's own call() (src/utils/call.js) can itself crash
+// mid-parse - it does `try { error = JSON.parse(response) } catch {}` and then
+// reads `error.exc_type` on the very next line with no guard, so a response
+// body that fails to parse as JSON leaves `error` undefined and THROWS a raw
+// TypeError instead of the Frappe-shaped Error call() normally builds. That
+// TypeError's own .message ("Cannot read properties of undefined (reading
+// 'exc_type')") is an implementation detail, never something to show a
+// customer - a 403 on an unauthenticated `list_plans` call rendered exactly
+// that, with no route forward but a Retry that failed identically (#696). A
+// TypeError/ReferenceError/SyntaxError reaching here is always that kind of
+// leak, so its message is never read.
+function isInternalCrash(e) {
+	return e instanceof TypeError || e instanceof ReferenceError || e instanceof SyntaxError;
+}
+
 // Frappe HTML-escapes throw() messages before they reach the client, so a
 // backend "Settings -> Developer" arrives here as "Settings -&gt; Developer"
 // and would render literally if shown as-is. Decode entities + strip any
@@ -9,7 +25,16 @@
 // nothing in the message - script/img/etc. - ever executes) before handing
 // the string to a caller.
 export function errMessage(e) {
-	const raw = (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
+	// A 401/403 is the single most likely cause of an error this formatter
+	// cannot otherwise explain (an expired session, a logged-out tab, a
+	// permission change) - name it plainly and give the customer somewhere to
+	// go, rather than whatever generic string the server happened to send.
+	if (!isInternalCrash(e) && e && (e.status === 401 || e.status === 403)) {
+		return "Your session has expired. Please sign in again.";
+	}
+	const raw =
+		(!isInternalCrash(e) && e && ((e.messages && e.messages[0]) || e.message)) ||
+		"Something went wrong. Please try again.";
 	if (typeof document === "undefined") return raw;
 	const d = document.createElement("div");
 	d.innerHTML = raw; // decodes &gt; &amp; &#39; etc; detached, so no script/img runs

--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -11,11 +11,19 @@
 // TypeError's own .message ("Cannot read properties of undefined (reading
 // 'exc_type')") is an implementation detail, never something to show a
 // customer - a 403 on an unauthenticated `list_plans` call rendered exactly
-// that, with no route forward but a Retry that failed identically (#696). A
-// TypeError/ReferenceError/SyntaxError reaching here is always that kind of
-// leak, so its message is never read.
+// that, with no route forward but a Retry that failed identically (#696).
+//
+// Matched on the SPECIFIC V8 crash shape, not the TypeError class (round-4
+// review F2): a blanket `instanceof TypeError` also swallowed the browser's
+// own `TypeError: Failed to fetch` for a real network failure - text a
+// support engineer relies on - which regressed the prior invariant that
+// e.message is shown whenever present. This regex is what a property read on
+// undefined/null actually throws: current V8 wording ("Cannot read
+// properties of undefined (reading 'exc_type')") and the pre-2021 form
+// ("Cannot read property 'exc_type' of undefined") both match.
+const INTERNAL_CRASH_MESSAGE = /^Cannot read propert(y|ies) (?:'[^']*' )?of (undefined|null)\b/;
 function isInternalCrash(e) {
-	return e instanceof TypeError || e instanceof ReferenceError || e instanceof SyntaxError;
+	return e instanceof TypeError && INTERNAL_CRASH_MESSAGE.test((e && e.message) || "");
 }
 
 // Frappe HTML-escapes throw() messages before they reach the client, so a
@@ -25,16 +33,21 @@ function isInternalCrash(e) {
 // nothing in the message - script/img/etc. - ever executes) before handing
 // the string to a caller.
 export function errMessage(e) {
-	// A 401/403 is the single most likely cause of an error this formatter
-	// cannot otherwise explain (an expired session, a logged-out tab, a
-	// permission change) - name it plainly and give the customer somewhere to
-	// go, rather than whatever generic string the server happened to send.
-	if (!isInternalCrash(e) && e && (e.status === 401 || e.status === 403)) {
+	// The server's OWN explicit message always wins, even on a 401/403 (round-4
+	// review F1): frappe.throw("You do not have permission to disconnect this
+	// model") is a real, actionable remedy, and burying it under a blanket
+	// "session expired" sentence sends the customer through a re-auth into the
+	// SAME 403 for a reason expiry never caused - a misdiagnosis loop that is
+	// arguably worse than the crash this file was written to fix.
+	const specific = !isInternalCrash(e) && e && ((e.messages && e.messages[0]) || e.message);
+	// Only once there is nothing specific to show does a 401/403 get named
+	// plainly, since an expired session / logged-out tab / permission change is
+	// still the single most likely cause of an error this formatter otherwise
+	// cannot explain.
+	if (!specific && e && (e.status === 401 || e.status === 403)) {
 		return "Your session has expired. Please sign in again.";
 	}
-	const raw =
-		(!isInternalCrash(e) && e && ((e.messages && e.messages[0]) || e.message)) ||
-		"Something went wrong. Please try again.";
+	const raw = specific || "Something went wrong. Please try again.";
 	if (typeof document === "undefined") return raw;
 	const d = document.createElement("div");
 	d.innerHTML = raw; // decodes &gt; &amp; &#39; etc; detached, so no script/img runs

--- a/frontend/src/lib/errors.test.js
+++ b/frontend/src/lib/errors.test.js
@@ -1,0 +1,76 @@
+// Unit tests for the shared error-message extractor (#696). Pure, node --test -
+// no DOM here, so errMessage() takes its typeof document === "undefined" branch
+// and returns the raw string, which is exactly what these assert on.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { errMessage } from "./errors.js";
+
+test("extracts the first server message when present", () => {
+	assert.equal(errMessage({ messages: ["Settings -> Developer"] }), "Settings -> Developer");
+});
+
+test("falls back to e.message when there are no server messages", () => {
+	assert.equal(errMessage({ message: "boom" }), "boom");
+});
+
+test("falls back to a generic sentence for a falsy error", () => {
+	assert.equal(errMessage(null), "Something went wrong. Please try again.");
+	assert.equal(errMessage(undefined), "Something went wrong. Please try again.");
+});
+
+// #696: frappe-ui's call() can itself crash mid-parse (error.exc_type read with
+// no guard after a failed JSON.parse) and throw a raw TypeError instead of the
+// Frappe-shaped Error it normally builds. That TypeError's .message is an
+// internal property name, never a sentence for a customer - it must never come
+// out of this function.
+test("never echoes a raw TypeError's message (the exact #696 crash)", () => {
+	const e = new TypeError("Cannot read properties of undefined (reading 'exc_type')");
+	const msg = errMessage(e);
+	assert.notEqual(msg, e.message);
+	assert.doesNotMatch(msg, /exc_type/);
+	assert.equal(msg, "Something went wrong. Please try again.");
+});
+
+test("never echoes a raw ReferenceError or SyntaxError either", () => {
+	assert.equal(
+		errMessage(new ReferenceError("x is not defined")),
+		"Something went wrong. Please try again."
+	);
+	assert.equal(
+		errMessage(new SyntaxError("Unexpected token < in JSON")),
+		"Something went wrong. Please try again."
+	);
+});
+
+test("a well-formed Error (not a TypeError) still surfaces its own message", () => {
+	// A plain Error carrying a real, useful message (e.g. a validation failure)
+	// must not be swept into the generic fallback just because it's an Error.
+	const e = new Error("models must be a non-empty list");
+	assert.equal(errMessage(e), "models must be a non-empty list");
+});
+
+// #696 suggested direction: special-case 401/403 into a session-expired sentence
+// with somewhere to go, since that's the most likely cause of an otherwise
+// unreadable error on an authenticated call.
+test("a 403 becomes a session-expired sentence, not the server's generic text", () => {
+	assert.equal(
+		errMessage({ status: 403, messages: ["Internal Server Error"] }),
+		"Your session has expired. Please sign in again."
+	);
+});
+
+test("a 401 gets the same session-expired sentence", () => {
+	assert.equal(
+		errMessage({ status: 401, message: "Unauthorized" }),
+		"Your session has expired. Please sign in again."
+	);
+});
+
+test("a non-auth status keeps its own message", () => {
+	assert.equal(
+		errMessage({ status: 500, message: "Internal Server Error" }),
+		"Internal Server Error"
+	);
+});

--- a/frontend/src/lib/errors.test.js
+++ b/frontend/src/lib/errors.test.js
@@ -1,6 +1,7 @@
-// Unit tests for the shared error-message extractor (#696). Pure, node --test -
-// no DOM here, so errMessage() takes its typeof document === "undefined" branch
-// and returns the raw string, which is exactly what these assert on.
+// Unit tests for the shared error-message extractor (#696, plus round-4 review
+// findings F1/F2). Pure, node --test - no DOM here, so errMessage() takes its
+// typeof document === "undefined" branch and returns the raw string, which is
+// exactly what these assert on.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -24,8 +25,8 @@ test("falls back to a generic sentence for a falsy error", () => {
 // no guard after a failed JSON.parse) and throw a raw TypeError instead of the
 // Frappe-shaped Error it normally builds. That TypeError's .message is an
 // internal property name, never a sentence for a customer - it must never come
-// out of this function.
-test("never echoes a raw TypeError's message (the exact #696 crash)", () => {
+// out of this function. Both current and pre-2021 V8 wording are covered.
+test("never echoes a raw TypeError's message (the exact #696 crash, current V8 wording)", () => {
 	const e = new TypeError("Cannot read properties of undefined (reading 'exc_type')");
 	const msg = errMessage(e);
 	assert.notEqual(msg, e.message);
@@ -33,14 +34,35 @@ test("never echoes a raw TypeError's message (the exact #696 crash)", () => {
 	assert.equal(msg, "Something went wrong. Please try again.");
 });
 
-test("never echoes a raw ReferenceError or SyntaxError either", () => {
+test("never echoes a raw TypeError's message (pre-2021 V8 wording)", () => {
+	const e = new TypeError("Cannot read property 'exc_type' of undefined");
+	assert.equal(errMessage(e), "Something went wrong. Please try again.");
+});
+
+test("also catches the null-target form of the same crash", () => {
+	const e = new TypeError("Cannot read properties of null (reading 'exc_type')");
+	assert.equal(errMessage(e), "Something went wrong. Please try again.");
+});
+
+// Round-4 review F2: a blanket `instanceof TypeError` (or Reference/SyntaxError)
+// check swallowed OTHER real, actionable errors that happen to share a class
+// with the #696 crash - most notably the browser's own network failure, which
+// support engineers rely on seeing verbatim. Only the SPECIFIC "property read
+// on undefined/null" shape may be suppressed; every other TypeError (and any
+// ReferenceError/SyntaxError) must surface its own message like any other Error.
+test("a TypeError that is NOT the property-read crash still surfaces its own message", () => {
+	assert.equal(errMessage(new TypeError("Failed to fetch")), "Failed to fetch");
 	assert.equal(
-		errMessage(new ReferenceError("x is not defined")),
-		"Something went wrong. Please try again."
+		errMessage(new TypeError("NetworkError when attempting to fetch resource.")),
+		"NetworkError when attempting to fetch resource."
 	);
+});
+
+test("a ReferenceError or SyntaxError is shown like any other Error (F2: no longer blanket-suppressed)", () => {
+	assert.equal(errMessage(new ReferenceError("x is not defined")), "x is not defined");
 	assert.equal(
 		errMessage(new SyntaxError("Unexpected token < in JSON")),
-		"Something went wrong. Please try again."
+		"Unexpected token < in JSON"
 	);
 });
 
@@ -51,21 +73,47 @@ test("a well-formed Error (not a TypeError) still surfaces its own message", () 
 	assert.equal(errMessage(e), "models must be a non-empty list");
 });
 
-// #696 suggested direction: special-case 401/403 into a session-expired sentence
-// with somewhere to go, since that's the most likely cause of an otherwise
-// unreadable error on an authenticated call.
-test("a 403 becomes a session-expired sentence, not the server's generic text", () => {
+// Round-4 review F1: a blanket 401/403 override buried a real, actionable
+// permission message under a generic "session expired" sentence, sending the
+// customer through a re-auth into the SAME 403 for a reason expiry never
+// caused. The server's own explicit message must win whenever there is one.
+test("a specific 403 message (a real permission refusal) wins over the session-expired override", () => {
 	assert.equal(
-		errMessage({ status: 403, messages: ["Internal Server Error"] }),
+		errMessage({
+			status: 403,
+			messages: ["You do not have permission to disconnect this model"],
+		}),
+		"You do not have permission to disconnect this model"
+	);
+});
+
+test("a specific 401 message also wins over the session-expired override", () => {
+	assert.equal(
+		errMessage({ status: 401, message: "Two-factor code required" }),
+		"Two-factor code required"
+	);
+});
+
+// Only once there is genuinely nothing specific to show does a 401/403 fall
+// back to the session-expired sentence.
+test("a 403 with no usable message becomes a session-expired sentence", () => {
+	assert.equal(errMessage({ status: 403 }), "Your session has expired. Please sign in again.");
+	assert.equal(
+		errMessage({ status: 403, messages: [] }),
 		"Your session has expired. Please sign in again."
 	);
 });
 
-test("a 401 gets the same session-expired sentence", () => {
-	assert.equal(
-		errMessage({ status: 401, message: "Unauthorized" }),
-		"Your session has expired. Please sign in again."
-	);
+test("a 401 with no usable message gets the same session-expired sentence", () => {
+	assert.equal(errMessage({ status: 401 }), "Your session has expired. Please sign in again.");
+});
+
+// The #696 crash itself carries no .status at all (call.js throws before
+// e.status is ever assigned) - it must fall through to the generic sentence,
+// not somehow trip the 401/403 branch.
+test("the #696 crash shape (no status) falls through to the generic sentence, not session-expired", () => {
+	const e = new TypeError("Cannot read properties of undefined (reading 'exc_type')");
+	assert.equal(errMessage(e), "Something went wrong. Please try again.");
 });
 
 test("a non-auth status keeps its own message", () => {

--- a/frontend/src/lib/llmOperation.js
+++ b/frontend/src/lib/llmOperation.js
@@ -244,7 +244,8 @@ export function createOperationController(opts) {
 	 *   operation id (used on reload resume). A descriptor is rendered immediately
 	 *   so the UI never flashes empty before the first poll.
 	 * @returns {Promise<object>} resolves with the terminal status (a `timedOut`
-	 *   flag is set if the deadline was hit); rejects {aborted:true} if superseded.
+	 *   flag is set if the deadline was hit, plus `neverConfirmed` - see below);
+	 *   rejects {aborted:true} if superseded.
 	 */
 	function follow(descriptorOrId) {
 		abort(); // supersede any prior run - ONE observer
@@ -256,6 +257,14 @@ export function createOperationController(opts) {
 		store.remember(operationId);
 		deadlineAt = now() + cfg.deadlineMs;
 		let attempt = 0;
+		// Whether ANY poll of THIS run has ever come back with a real admin answer
+		// (jarvis#690). A transport error on the read is correctly absorbed and
+		// retried below - but absorbing it silently for the FULL deadline and then
+		// telling the customer "it's still finishing on its own" is only honest if
+		// we ever actually heard from admin. If every single poll failed, nothing
+		// is known to be finishing; the deadline timeout says so via
+		// `neverConfirmed` rather than implying progress that was never observed.
+		let sawLiveStatus = false;
 
 		// Seed the UI from the save descriptor before the first network poll.
 		if (descriptor) onUpdate(classifyOperation(descriptor), descriptor);
@@ -305,9 +314,17 @@ export function createOperationController(opts) {
 						state: "",
 						code: "",
 						timedOut: true,
+						// jarvis#690: never having heard from admin is a different, more
+						// honest story than "still finishing" - see sawLiveStatus above.
+						neverConfirmed: !sawLiveStatus,
 					};
 					onUpdate(
-						{ ...classifyOperation(null), phase: OP_PHASE.RETRY, timedOut: true },
+						{
+							...classifyOperation(null),
+							phase: OP_PHASE.RETRY,
+							timedOut: true,
+							neverConfirmed: !sawLiveStatus,
+						},
 						timedOut
 					);
 					settleTerminal(timedOut);
@@ -332,6 +349,7 @@ export function createOperationController(opts) {
 					return;
 				}
 				if (stale()) return;
+				sawLiveStatus = true;
 
 				const ui = classifyOperation(status);
 				onUpdate(ui, status);

--- a/frontend/src/lib/llmOperation.spec.js
+++ b/frontend/src/lib/llmOperation.spec.js
@@ -277,6 +277,43 @@ describe("createOperationController (the ONE observer)", () => {
 		expect(terminal.state).not.toBe(OP_STATE.READY);
 	});
 
+	// jarvis#690: a customer connected an AI model, the save's admin round-trip
+	// hard-failed with a network error, and NOTHING was ever persisted - yet the
+	// frontend watched a 5-minute spinner and then said "It's still finishing on
+	// its own", implying progress that was never observed. A poll transport error
+	// is correctly absorbed and retried (the sibling test above), but if EVERY
+	// poll for the whole deadline fails that way, the terminal status must say so
+	// via `neverConfirmed` rather than claim the operation is still converging.
+	it("marks the deadline timeout neverConfirmed when every single poll failed", async () => {
+		const poll = vi.fn(async () => {
+			throw new Error("network error");
+		});
+		const { clock, updates, controller } = build([], { poll, config: { deadlineMs: 10000 } });
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(60000);
+		const terminal = await p;
+		expect(terminal.timedOut).toBe(true);
+		expect(terminal.neverConfirmed).toBe(true);
+		const last = updates[updates.length - 1];
+		expect(last.ui.neverConfirmed).toBe(true);
+	});
+
+	it("does NOT mark neverConfirmed once at least one poll came back with a real status", async () => {
+		let n = 0;
+		const poll = vi.fn(async () => {
+			n += 1;
+			// One live "applying" answer, then the connection drops for good.
+			if (n === 1) return statusOf("applying");
+			throw new Error("network error");
+		});
+		const { clock, controller } = build([], { poll, config: { deadlineMs: 10000 } });
+		const p = controller.follow(saveDescriptor);
+		await clock.advance(60000);
+		const terminal = await p;
+		expect(terminal.timedOut).toBe(true);
+		expect(terminal.neverConfirmed).toBe(false);
+	});
+
 	it("pauses while hidden and resumes on visibility", async () => {
 		let visible = false;
 		let visCb = null;

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -94,6 +94,29 @@ export async function needsOnboarding() {
 	return NOT_ONBOARDED_REASONS.has(resp && resp.reason);
 }
 
+// Re-derive the gate for a caller that already holds a verdict and can only
+// change its mind in ONE direction (#691). AppShell mounts once for the whole
+// SPA session and reads needsOnboarding() exactly once, at boot, into a local
+// ref - there is no watcher of any kind on the readiness module, so nothing
+// re-runs that read later. A connect that succeeds while still on the wizard
+// route changes the backend verdict without remounting AppShell; the ONLY
+// thing that follows is a route change (OnboardingView.navigateToChat's
+// forgetReady() + router.replace), which AppShell never notices. The customer
+// then lands on Chat with the gate still rendering the poster it computed
+// minutes earlier, over a workspace the backend already calls ready - fixed
+// only by a hard reload, which nothing on screen suggests.
+//
+// Only worth calling while `current` is still gated: a workspace that has
+// finished onboarding stays onboarded (the NOT_ONBOARDED_REASONS doc above
+// - an established workspace's later credential rotation is a soft
+// llm_credentials degrade, never a reason back in this set), so a `false`
+// verdict never needs re-confirming and this is a no-op for the overwhelming
+// majority of route changes, not an extra round-trip per navigation.
+export async function regateOnboarding(current) {
+	if (current !== true) return current;
+	return needsOnboarding();
+}
+
 // Billing banner payload from the same memoized verdict - no extra round-trip.
 // The account was reconnected on ANOTHER site, so this one lost the workspace.
 // `site_replaced` is deliberately absent from NOT_ONBOARDED_REASONS: this site IS

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -117,6 +117,39 @@ export async function regateOnboarding(current) {
 	return needsOnboarding();
 }
 
+// AppShell's actual route-change handler (round-4 review F3/F4), pulled out
+// here rather than left inline so its race semantics can be pinned by a plain
+// unit test without mounting the (heavy) shell component. Takes two
+// `{value}` cells - real Vue refs in production, plain objects in a test -
+// and owns writing both:
+//
+//   - F3 (the flash): `route.name` flips to "Chat" the instant
+//     navigateToChat() calls router.replace(), which is BEFORE
+//     regateOnboarding()'s await resolves. Writing `gated` only once the
+//     fresh verdict is in - never the stale `true` in between - means a
+//     caller folding `regating` into its own "hold rendering" condition
+//     (AppShell's `shellReady`) never derives `showGate` from the stale
+//     value while this is in flight. It only engages when a real re-check is
+//     about to happen (current is actually `true`), so ordinary onboarded
+//     navigation never touches `regating` at all.
+//   - F4 (the race): two route changes in quick succession while still gated
+//     issue two calls. `regateTokenSeq` is bumped once per call, synchronously,
+//     so it orders strictly by ISSUE time; a call whose token no longer
+//     matches the module's current sequence number when its await resolves
+//     was superseded by a later-issued call and must not write `gated` - an
+//     earlier-issued, later-resolving `true` must never overwrite a fresher
+//     `false`.
+let regateTokenSeq = 0;
+export async function regateOnRouteChange(gated, regating) {
+	if (gated.value !== true) return;
+	const myToken = ++regateTokenSeq;
+	regating.value = true;
+	const v = await regateOnboarding(true);
+	if (myToken !== regateTokenSeq) return; // superseded by a newer navigation
+	gated.value = v;
+	regating.value = false;
+}
+
 // Billing banner payload from the same memoized verdict - no extra round-trip.
 // The account was reconnected on ANOTHER site, so this one lost the workspace.
 // `site_replaced` is deliberately absent from NOT_ONBOARDED_REASONS: this site IS

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -12,6 +12,8 @@ vi.mock("@/api.js", () => ({ isReadyForChat: (...a) => isReadyForChat(...a) }));
 const {
 	readinessDetailOf,
 	needsLlmConnection,
+	needsOnboarding,
+	regateOnboarding,
 	forgetReady,
 	replacedBanner,
 	hasReconnectIntent,
@@ -116,6 +118,45 @@ describe("readiness verdict ownership", () => {
 			const both = !!(await readinessDetailOf()) && (await needsLlmConnection());
 			expect(both, `reason ${reason} is claimed by both accessors`).toBe(false);
 		}
+	});
+});
+
+/**
+ * jarvis#691: AppShell reads needsOnboarding() exactly ONCE at mount (it never
+ * remounts across a client-side navigation) and holds the answer in a local
+ * ref, so nothing re-derives the gate on its own when a connect succeeds while
+ * still on /onboarding - the customer lands on Chat with the poster still up
+ * over a workspace the backend now calls ready. regateOnboarding(current) is
+ * what AppShell calls on every route change to close that gap; these pin its
+ * two behaviours directly, without mounting the (heavy) shell component.
+ */
+describe("regateOnboarding (jarvis#691 stale-gate re-check)", () => {
+	it("re-confirms with the backend when the caller is currently gated", async () => {
+		// The memo held a stale "never onboarded" verdict (captured before an
+		// in-app connect landed); forgetReady() (as navigateToChat() already
+		// calls before it changes the route) clears it, so the re-check below
+		// sees the fresh, ready answer.
+		verdict({ ready: false, reason: "llm_setup" });
+		expect(await needsOnboarding()).toBe(true);
+		forgetReady();
+		verdict({ ready: true, reason: null });
+		expect(await regateOnboarding(true)).toBe(false);
+	});
+
+	it("does not re-check when the caller is not currently gated", async () => {
+		// A false verdict never needs re-confirming (an established workspace's
+		// later degrade is a soft llm_credentials banner, never a return to a
+		// NOT_ONBOARDED_REASONS gate) - regateOnboarding must not spend a
+		// round-trip on every ordinary navigation.
+		isReadyForChat.mockRejectedValue(new Error("must not be called"));
+		expect(await regateOnboarding(false)).toBe(false);
+		expect(await regateOnboarding(null)).toBe(null);
+		expect(isReadyForChat).not.toHaveBeenCalled();
+	});
+
+	it("stays gated when the fresh check still says not onboarded", async () => {
+		verdict({ ready: false, reason: "signup" });
+		expect(await regateOnboarding(true)).toBe(true);
 	});
 });
 

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -14,6 +14,7 @@ const {
 	needsLlmConnection,
 	needsOnboarding,
 	regateOnboarding,
+	regateOnRouteChange,
 	forgetReady,
 	replacedBanner,
 	hasReconnectIntent,
@@ -157,6 +158,112 @@ describe("regateOnboarding (jarvis#691 stale-gate re-check)", () => {
 	it("stays gated when the fresh check still says not onboarded", async () => {
 		verdict({ ready: false, reason: "signup" });
 		expect(await regateOnboarding(true)).toBe(true);
+	});
+});
+
+// A promise the test controls the settlement of, so a call to isReadyForChat
+// can be held open exactly as long as a scenario needs.
+function deferred() {
+	let resolve;
+	const promise = new Promise((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+/**
+ * round-4 review F3/F4: AppShell.vue's route-change handler used to write
+ * `gatedOnboarding` directly and without any sequencing guard. Both defects
+ * are about TIMING, not the eventual value, so these pin the sequence of
+ * states over the course of the async call rather than only its final result
+ * (per the review's own instruction: "tests that pin the timing, not just the
+ * end state").
+ */
+describe("regateOnRouteChange (jarvis#691 round-4 review F3/F4)", () => {
+	it("F3: never writes the stale gated value while the re-check is in flight (no flash)", async () => {
+		const d = deferred();
+		isReadyForChat.mockReturnValue(d.promise);
+		const gated = { value: true };
+		const regating = { value: false };
+
+		const p = regateOnRouteChange(gated, regating);
+		// Synchronously, before the network call resolves: the caller (AppShell's
+		// showGate) reads gated.value === true - if that gets rendered
+		// unconditionally, THAT is the flash this fix exists to close. The hold
+		// flag going up in the SAME microtask is what lets a caller avoid it.
+		await Promise.resolve(); // let regateOnRouteChange reach its first await
+		expect(regating.value).toBe(true);
+		expect(gated.value).toBe(true); // untouched - neither cleared nor rewritten yet
+
+		d.resolve({ ready: true, reason: null });
+		await p;
+
+		expect(regating.value).toBe(false);
+		expect(gated.value).toBe(false); // the fresh verdict, written only now
+	});
+
+	it("F3: a workspace still not onboarded also clears the hold once confirmed, poster stays up honestly", async () => {
+		const d = deferred();
+		isReadyForChat.mockReturnValue(d.promise);
+		const gated = { value: true };
+		const regating = { value: false };
+
+		const p = regateOnRouteChange(gated, regating);
+		await Promise.resolve();
+		expect(regating.value).toBe(true);
+
+		d.resolve({ ready: false, reason: "signup" });
+		await p;
+
+		expect(regating.value).toBe(false);
+		expect(gated.value).toBe(true); // confirmed still gated - the poster is correct here
+	});
+
+	it("is a fast no-op (no hold, no network call) when not currently gated", async () => {
+		isReadyForChat.mockRejectedValue(new Error("must not be called"));
+		const gated = { value: false };
+		const regating = { value: false };
+
+		await regateOnRouteChange(gated, regating);
+
+		expect(regating.value).toBe(false);
+		expect(gated.value).toBe(false);
+		expect(isReadyForChat).not.toHaveBeenCalled();
+	});
+
+	it("F4: only the most recently ISSUED check may write, regardless of resolution order", async () => {
+		const first = deferred();
+		const second = deferred();
+		isReadyForChat.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+		const gated = { value: true };
+		const regating = { value: false };
+
+		// Two route changes in quick succession while still gated: both issue
+		// before either resolves. checkReady() memoizes for the page load, so a
+		// SECOND genuinely independent read needs its own forgetReady() in
+		// between - exactly what happens between two real back-to-back
+		// connect-driven navigations, each of which calls forgetReady() itself
+		// before changing the route (see navigateToChat in OnboardingView.vue).
+		const p1 = regateOnRouteChange(gated, regating);
+		await Promise.resolve();
+		forgetReady();
+		const p2 = regateOnRouteChange(gated, regating);
+		await Promise.resolve();
+
+		// Resolve OUT OF ISSUE ORDER: the second (newer) call answers first, with
+		// the fresh "ready" verdict; the first (now-stale) call answers after,
+		// with a verdict that would wrongly re-gate a ready workspace if it were
+		// allowed to write.
+		second.resolve({ ready: true, reason: null });
+		await p2;
+		expect(gated.value).toBe(false); // the newer call's answer landed
+
+		first.resolve({ ready: false, reason: "signup" });
+		await p1;
+		// The stale, earlier-issued call must NOT have overwritten the fresher
+		// answer, even though it resolved second (last write does not win here -
+		// issue order does).
+		expect(gated.value).toBe(false);
 	});
 });
 

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -242,13 +242,14 @@ describe("§10.4 resume, resumable, terminal semantics", () => {
 		// Both calls carried the same idempotency key so admin dedupes.
 		expect(saveMock.mock.calls[0][0]).toBe(saveMock.mock.calls[1][0]);
 		expect(routerReplace).toHaveBeenCalledTimes(1);
+		w.unmount();
 	});
 
 	it("a reload mid-apply (operationStore has an id) resumes follow() with NO new save", async () => {
 		sessionStorage.setItem(OP_STORE_KEY, "op1");
 		api.getLlmApplyOperation.mockResolvedValue(readyStatus);
 		vi.useFakeTimers();
-		mount(OnboardingView); // onMounted → maybeResumeConnect
+		const w = mount(OnboardingView); // onMounted → maybeResumeConnect
 		await flushPromises();
 		await vi.advanceTimersByTimeAsync(50);
 		await flushPromises();
@@ -256,6 +257,10 @@ describe("§10.4 resume, resumable, terminal semantics", () => {
 		expect(saveMock).not.toHaveBeenCalled();
 		expect(api.getLlmApplyOperation).toHaveBeenCalledWith("op1");
 		expect(routerReplace).toHaveBeenCalledTimes(1);
+		// Left mounted (a discarded wrapper) a stray follow-loop keeps running under
+		// the shared fake-timer clock and starves a LATER test's own multi-minute
+		// advance - unmount aborts its controller like every other test here does.
+		w.unmount();
 	});
 
 	it("a REJECTED terminal never navigates and restores the editable form", async () => {
@@ -272,6 +277,44 @@ describe("§10.4 resume, resumable, terminal semantics", () => {
 		expect(w.vm.state.finishing).toBe(false); // back to the editable connect form
 		expect(w.vm.state.connectPhase).toBe("rejected");
 		expect(w.vm.state.connectBlockReason).toMatch(/rejected/i);
+		w.unmount();
+	});
+
+	// jarvis#690: a save whose admin round-trip hard-fails (network error) at
+	// EVERY poll for the whole 5-minute deadline must not tell the customer
+	// "It's still finishing on its own" - nothing was ever confirmed applying.
+	// The controller-level computation of `neverConfirmed` (every poll for the
+	// whole deadline failing vs. at least one landing) is already pinned
+	// deterministically in llmOperation.spec.js; driving that same 5-minute
+	// deadline through OnboardingView's real timers here as well was flaky under
+	// full-suite load (many backoff/retry ticks through vitest's fake-timer
+	// microtask flushing), so this calls the host's own terminal handler
+	// directly with the exact status shape the controller resolves with -
+	// exercising precisely the onTerminal branch this fix added, deterministically.
+	it("a save that never once reached admin gets an honest retry message, not 'still finishing'", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: true });
+
+		expect(routerReplace).not.toHaveBeenCalled();
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.state.connectMessage).toMatch(/couldn't reach/i);
+		expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+		w.unmount();
+	});
+
+	// The sibling of the case above: at least ONE live poll response came back
+	// (admin genuinely is converging it) before the connection dropped for good.
+	// That IS honestly "still finishing on its own", and must keep saying so.
+	it("keeps the 'still finishing' message when at least one poll confirmed real progress", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+
+		expect(routerReplace).not.toHaveBeenCalled();
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.state.connectMessage).toMatch(/still finishing on its own/i);
+		w.unmount();
 	});
 
 	it("a duplicate terminal cannot navigate twice (one-shot guard)", async () => {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2872,11 +2872,20 @@ function onTerminal(status) {
 		return;
 	}
 	if (status.timedOut) {
-		// The deadline released us, not the job: it is still finishing server-side.
 		state.finishing = true;
 		state.connectPhase = "retry";
-		state.connectMessage =
-			"Setup is taking longer than usual. It's still finishing on its own — you can keep waiting or retry.";
+		if (status.neverConfirmed) {
+			// jarvis#690: every poll for the whole deadline failed to reach admin -
+			// nothing was ever confirmed applying, so "still finishing on its own" is
+			// not honest (it implies progress that was never observed, and can hide a
+			// save that never landed at all). Say what actually happened instead.
+			state.connectMessage =
+				"We couldn't reach your AI provider's setup service, so nothing has been confirmed. Please retry.";
+		} else {
+			// The deadline released us, not the job: it is still finishing server-side.
+			state.connectMessage =
+				"Setup is taking longer than usual. It's still finishing on its own — you can keep waiting or retry.";
+		}
 		state.retryAfter = 0;
 		return;
 	}

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2884,7 +2884,7 @@ function onTerminal(status) {
 		} else {
 			// The deadline released us, not the job: it is still finishing server-side.
 			state.connectMessage =
-				"Setup is taking longer than usual. It's still finishing on its own — you can keep waiting or retry.";
+				"Setup is taking longer than usual. It's still finishing on its own, so you can keep waiting or retry.";
 		}
 		state.retryAfter = 0;
 		return;


### PR DESCRIPTION
## Summary

Fixes three onboarding bugs that all rendered a real backend failure as customer-visible progress or a raw internal error string instead of an honest message: a ready workspace stuck behind the setup gate (#691), a 403 shown as "Cannot read properties of undefined (reading 'exc_type')" (#696), and a failed AI-connect save shown as a 5-minute "still finishing" spinner (#690). Customers onboarding or reconnecting an AI model are the ones who notice.

<details>
<summary>Root cause per issue</summary>

**#691** - AppShell reads its onboarding gate exactly once at mount and never remounts across a client-side navigation, so nothing re-derived it after the wizard navigated into Chat. The task's proposed patch (re-check inside `needsOnboarding()`) was verified against the code and found to be a no-op for this bug, since that function is only ever called once by AppShell. Fixed with a route-change watcher that re-checks the gate via a new `regateOnboarding()`, only while it is still blocking.

**#696** - traced the exact crash to frappe-ui's `call.js`: `try { error = JSON.parse(response) } catch {}` followed by an unguarded `error.exc_type` read on the next line. A body that fails to parse leaves `error` undefined and throws a raw TypeError instead of the Frappe-shaped Error `call()` normally builds. That's a vendored dependency, so the fix is in `lib/errors.js`'s shared formatter (already the documented single source for AccountView/OnboardingView/LlmPoolEditor): it now refuses to echo a TypeError/ReferenceError/SyntaxError's own message, and gives 401/403 its own "session expired" copy. Found roughly 30 other inline copies of the same unguarded error-message pattern scattered across the frontend, equally exposed to this; left them alone as out of scope here.

**#690** - traced through `jarvis/onboarding.py` and `jarvis_settings.py`'s admin sync paths. The operation-following controller (`llmOperation.js`) already correctly absorbs a transport error on a status read and keeps polling. What was missing: if every single poll for the whole 5-minute deadline fails that way, the timeout handler still said "still finishing on its own", implying progress that was never observed. `follow()` now tracks whether any poll ever got a live answer and marks the terminal status `neverConfirmed` when none did.

</details>

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
