### PR TITLE
fix(chat): attachment uploads, stranded draft cards, and confirmation-card reliability

### DIFF
--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -66,11 +66,45 @@
 			style="display: flex; flex-wrap: wrap; gap: 8px; padding: 6px 4px 2px"
 		>
 			<template v-for="(a, i) in attachments" :key="a.key ?? i">
+				<!-- In-flight: the product's one loading mark, not a bare word. A
+				     recorded clip or a large PDF can take seconds, and a static
+				     "Uploading…" gives no sign anything is still alive. -->
+				<span v-if="a.uploading" class="jv-att-uploading" role="status" aria-live="polite">
+					<JvSpinner :size="20" />
+					<span>{{ a.file_name ? `Uploading ${a.file_name}…` : "Uploading…" }}</span>
+				</span>
+				<!-- Failed: an upload that dies must SAY so. It used to be swallowed,
+				     so the file simply never appeared and the user was left thinking
+				     the picker was broken. -->
 				<span
-					v-if="a.uploading"
-					style="font-size: 11.5px; color: var(--text-3); padding: 3px 6px"
-					>Uploading…</span
+					v-else-if="a.failed"
+					class="jv-att-failed"
+					role="alert"
+					:title="a.error || ''"
 				>
+					<svg
+						width="13"
+						height="13"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+					>
+						<circle cx="12" cy="12" r="9" />
+						<path d="M12 8v4M12 16h.01" />
+					</svg>
+					<span>{{ a.file_name }} failed</span>
+					<button
+						v-if="a.removable"
+						type="button"
+						class="jv-att-failed-x"
+						title="Dismiss"
+						@click="$emit('remove-attachment', i)"
+					>
+						×
+					</button>
+				</span>
 				<span
 					v-else-if="a.preview_url"
 					:title="a.file_name"
@@ -303,6 +337,7 @@
 
 <script setup>
 import { computed, ref, watch } from "vue";
+import JvSpinner from "@/components/JvSpinner.vue";
 
 const props = defineProps({
 	// The composed text. Use with v-model on the host.
@@ -571,5 +606,51 @@ defineExpose({ el: inputEl, focusInput });
 }
 .jv-dark .jv-sendbtn:hover:not(:disabled) svg {
 	stroke: var(--cta-fg) !important;
+}
+
+/* Attachment status pills. Both sit in the same row as the thumbnails/chips, so
+   they match their height and radius rather than introducing a third shape. */
+.jv-att-uploading {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 4px 9px;
+	font-size: 11.5px;
+	color: var(--text-3);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--surface);
+	max-width: 260px;
+}
+.jv-att-uploading > span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-att-failed {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 9px;
+	font-size: 11.5px;
+	color: var(--red);
+	border: 1px solid var(--red);
+	border-radius: 8px;
+	background: var(--red-bg, transparent);
+	max-width: 260px;
+}
+.jv-att-failed > span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-att-failed-x {
+	border: none;
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	font-size: 14px;
+	line-height: 1;
+	padding: 0 0 0 2px;
 }
 </style>

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -201,22 +201,52 @@ describe("ChatView wiring (source tripwires, not behaviour)", () => {
 		expect(src).toContain('v-if="bizGreeting.show && !showHomeIntro"');
 	});
 
-	it("renders the minimal greeting over SYNTHESISED starter cards", () => {
-		// The empty state is the brand mark inline with the greeting, then starter
-		// cards whose copy comes from the user's own history — never the old
-		// hard-coded four. A regression that reintroduces a static list trips here.
+	it("renders the greeting, one orienting line, then starter cards", () => {
+		// The empty state is the brand mark inline with the greeting, a single line
+		// saying what the box is for and that the agent is wired to real ERP data,
+		// then the starter grid. The line is load-bearing on an otherwise bare
+		// screen: dropping it leaves a name and a text box with no explanation.
 		expect(src).toContain("<span>{{ greeting }}, {{ firstName }}</span>");
+		expect(src).toContain('class="jv-welcome-sub"');
+		expect(src).toContain("Ask about your ERP data, run a workflow, or draft something.");
 		expect(src).toContain('class="jv-welcome-grid"');
-		expect(src).toContain('v-for="(s, i) in promptSuggestions"');
-		expect(src).not.toContain("const suggestions = [");
+		expect(src).toContain('v-for="(s, i) in starterCards"');
+	});
+
+	it("prefers synthesised starters, falling back to the defaults only when there are none", () => {
+		// Precedence IS the invariant, in both directions: a user with history must
+		// never be shown the generic four, and a brand-new workspace must never be
+		// shown an empty grid. Gating the grid on the synthesised list being
+		// non-empty is what produced the bare screen, so that gate must stay gone.
+		expect(src).toContain(
+			"promptSuggestions.value.length ? promptSuggestions.value : DEFAULT_STARTERS"
+		);
+		expect(src).not.toContain('v-if="!showHomeIntro && promptSuggestions.length"');
+		expect(src).toContain("const DEFAULT_STARTERS = [");
 	});
 
 	it("a starter card fills the composer and never sends", () => {
 		// The do-not-regress rule the original cards carried: clicking a suggestion
 		// puts it in the box for the user to edit, it does not fire a turn.
-		expect(src).toContain('@click="fillInput(s.prompt)"');
-		const card = src.slice(src.indexOf('v-for="(s, i) in promptSuggestions"'));
+		expect(src).toContain('@click="onWelcomeSuggestion(s)"');
+		const handler = src.slice(src.indexOf("function onWelcomeSuggestion(s) {"));
+		const body = handler.slice(0, handler.indexOf("\n}"));
+		expect(body).toContain("fillInput(s.prompt)");
+		expect(body).not.toContain("sendMessage");
+		const card = src.slice(src.indexOf('v-for="(s, i) in starterCards"'));
 		expect(card.slice(0, card.indexOf("</button>"))).not.toContain("sendMessage");
+	});
+
+	it("keeps the suggestion telemetry wired to a category token, never prompt text", () => {
+		// The composable still exports noteSuggestionSelected; an earlier redesign
+		// stopped destructuring it, silently killing the signal. Pin the wiring and
+		// the argument: a stable token, never the prompt the user is about to send.
+		expect(composable).toContain("noteSuggestionSelected");
+		expect(src).toContain("noteSuggestionSelected: noteWelcomeSuggestion");
+		const handler = src.slice(src.indexOf("function onWelcomeSuggestion(s) {"));
+		const body = handler.slice(0, handler.indexOf("\n}"));
+		expect(body).toContain("noteWelcomeSuggestion(s.category || s.title");
+		expect(body).not.toContain("noteWelcomeSuggestion(s.prompt");
 	});
 
 	it("moves the welcome viewport off inline styles onto overflow-safe classes", () => {

--- a/frontend/src/lib/attachUpload.spec.js
+++ b/frontend/src/lib/attachUpload.spec.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Attachment upload: one path, a visible loader, and failures that are SHOWN.
+ *
+ * The reported symptom was "audio files appear in the picker but never upload".
+ * The picker has no `accept` filter and the server has no extension allow-list
+ * (System Settings.allowed_file_extensions is empty), so nothing type-specific
+ * was rejecting audio. What made it look that way was the error handling: the
+ * uploader caught every failure into an empty block, so a refused file simply
+ * never appeared and the UI said nothing at all. Whatever the server's reason
+ * (an oversize recording, an expired session), the user saw a dead button.
+ */
+
+const SRC = path.resolve(__dirname, "../views/ChatView.vue");
+const COMPOSER = path.resolve(__dirname, "../components/chat/Composer.vue");
+const src = fs.readFileSync(SRC, "utf8");
+const composer = fs.readFileSync(COMPOSER, "utf8");
+
+describe("upload failures are surfaced, never swallowed", () => {
+	it("no empty catch remains on an upload path", () => {
+		// THE bug. Both the picker path and the paste path had one.
+		expect(src).not.toContain("/* skip a file that failed to upload */");
+	});
+
+	it("a failed upload records the reason and tells the user", () => {
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("failedUploads.value = [");
+		expect(body).toContain("notify(");
+		expect(body).toContain("errMessage(err)");
+	});
+
+	it("the in-flight pill always clears, even when the upload throws", () => {
+		// Without the finally, one failure would leave a spinner running forever.
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("} finally {");
+		expect(body).toContain("uploadingFiles.value = uploadingFiles.value.filter");
+	});
+
+	it("oversize files fail with a readable sentence rather than a bare 413", () => {
+		expect(src).toContain("const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;");
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		expect(fn.slice(0, fn.indexOf("\n}"))).toContain("MAX_UPLOAD_BYTES");
+	});
+});
+
+describe("every attach type goes through the same uploader", () => {
+	it("picker and drag-drop route through uploadFiles", () => {
+		expect(src).toContain('@files-added="uploadFiles"');
+	});
+
+	it("clipboard paste routes through it too, instead of its own copy", () => {
+		// The paste handler used to inline its own upload loop with its own empty
+		// catch, so a fix to the picker path silently missed pasted images.
+		const fn = src.slice(src.indexOf("async function onPaste(e) {"));
+		const body = fn.slice(0, fn.indexOf("\n}\n"));
+		expect(body).toContain("await uploadFiles(");
+		expect(body).not.toContain("api.uploadFile(");
+	});
+
+	it("uploads run concurrently, so one slow file does not block the batch", () => {
+		const fn = src.slice(src.indexOf("async function uploadFiles(list) {"));
+		expect(fn.slice(0, fn.indexOf("\n}"))).toContain("Promise.all");
+	});
+});
+
+describe("the loader is the product's one spinner", () => {
+	it("the composer renders JvSpinner for an in-flight attachment", () => {
+		// JvSpinner is distilled from the onboarding completion animation and is
+		// documented as the ONE loading indicator; a bare "Uploading…" word was
+		// the odd one out.
+		expect(composer).toContain('import JvSpinner from "@/components/JvSpinner.vue";');
+		const at = composer.indexOf('v-if="a.uploading"');
+		expect(at).toBeGreaterThan(-1);
+		expect(composer.slice(at, at + 400)).toContain("<JvSpinner");
+	});
+
+	it("the pill names the file it belongs to", () => {
+		expect(composer).toContain("Uploading ${a.file_name}…");
+		expect(src).toContain("uploading: true, file_name: u.name");
+	});
+
+	it("a failed attachment renders its own alert chip", () => {
+		expect(composer).toContain('v-else-if="a.failed"');
+		expect(composer).toContain('role="alert"');
+	});
+});
+
+describe("a slow upload stays with the chat it was started in", () => {
+	it("the result is discarded if the user has moved to another conversation", () => {
+		// The reported leak: a 3-minute voice memo attached in one chat resolved
+		// after the user opened a NEW chat and pushed itself into that tray, so a
+		// brand-new conversation silently inherited the previous one's attachment.
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("const forConv = currentId.value;");
+		expect(body).toContain("if (currentId.value !== forConv) return;");
+		// The captured id must be read BEFORE the awaited upload, or it is useless.
+		expect(body.indexOf("const forConv")).toBeLessThan(body.indexOf("await api.uploadFile"));
+	});
+
+	it("a failure toast is suppressed once the user has left that chat", () => {
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("if (currentId.value === forConv) {");
+	});
+
+	it("the in-flight pill is scoped to its own conversation", () => {
+		expect(src).toContain("if (u.conv === currentId.value)");
+	});
+});
+
+describe("re-picking a file mid-upload does not duplicate it", () => {
+	it("an identical in-flight file is refused rather than uploaded again", () => {
+		// A 3-minute recording uploads slowly enough that an impatient re-click is
+		// the normal reaction; each click used to start another full upload, which
+		// is how one recording ended up attached five times.
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("if (_inflightKeys.has(key)) {");
+		expect(body).toContain("is already uploading");
+	});
+
+	it("identity is bytes, not just the name", () => {
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("file && file.size");
+		expect(body).toContain("file && file.lastModified");
+	});
+
+	it("the key is released in finally, so a failed upload can be retried", () => {
+		const fn = src.slice(src.indexOf("async function uploadOne(file) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		const fin = body.indexOf("} finally {");
+		expect(body.indexOf("_inflightKeys.delete(key)")).toBeGreaterThan(fin);
+	});
+});
+
+describe("removing an attachment addresses the right list", () => {
+	it("the composer's flat index is mapped back onto the owning list", () => {
+		// Chips are pendingFiles, then in-flight pills, then failures. Treating
+		// that flat index as a pendingFiles index would remove the wrong file.
+		expect(src).toContain('@remove-attachment="removeAttachment"');
+		const fn = src.slice(src.indexOf("function removeAttachment(i) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("if (i < pendingFiles.value.length) return removeFile(i);");
+		// It must count the pills actually RENDERED. The tray hides uploads owned
+		// by another conversation, so using the full in-flight length would shift
+		// the failure index and remove the wrong chip.
+		expect(body).toContain("u.conv === currentId.value");
+		expect(body).toContain("visibleUploading");
+	});
+
+	it("stale failure pills do not follow the user into a new chat", () => {
+		expect(src).toContain("failedUploads.value = []");
+	});
+});

--- a/frontend/src/lib/chatAction.js
+++ b/frontend/src/lib/chatAction.js
@@ -1,0 +1,57 @@
+/**
+ * Canonicalises a ```jarvis-action block into the one shape the summary card and
+ * the draft-model builder both expect.
+ *
+ * The spec (skills/jarvis-drafting/SKILL.md) is:
+ *
+ *     {kind:"doc", verb, doctype, title, summary?, fields:[{label,value}], tables?}
+ *
+ * Models drift from it in two ways that used to strand the card at
+ * "Preparing summary..." with no error, no timeout and no retry:
+ *
+ *   1. `kind` omitted. The card renders on isEditVerb(), which never inspected
+ *      kind, while the build watcher required kind === "doc". The card drew and
+ *      its model was never built.
+ *   2. `fields` emitted as an object ({fieldname: value}) rather than the
+ *      [{label,value}] array the builder walks with for..of.
+ *   3. `tables` emitted as an object ({items:{rows:[...]}} or {items:[...]})
+ *      rather than the [{fieldname,rows}] array. This one THREW rather than
+ *      hung: `for (const t of a.tables)` on a plain object is a TypeError, so
+ *      the card showed "Could not load this draft. Tell me to try again."
+ *
+ * All are absorbed rather than rejected: the data is unambiguous, and the field
+ * keys resolve either way because the builder matches on fieldname OR label.
+ * Anything still unbuildable is left alone so it reaches the builder and raises
+ * the honest error card, which is the rule that module already states: an action
+ * we cannot render must fail, never render empty.
+ *
+ * Pure and dependency-free so it is unit-testable without mounting the view.
+ */
+
+/**
+ * @param {unknown} a parsed JSON from a jarvis-action fence
+ * @returns {object|null} the same object, canonicalised in place, or null
+ */
+export function normaliseAction(a) {
+	if (!a || typeof a !== "object" || Array.isArray(a)) return null;
+	// `kind` only distinguishes an email block from a doc one. A doc block is the
+	// default, and the card's own render gate has always treated a missing kind as
+	// one, so infer it rather than letting the two gates disagree.
+	if (!a.kind && a.doctype) a.kind = "doc";
+	if (a.fields && !Array.isArray(a.fields) && typeof a.fields === "object") {
+		a.fields = Object.entries(a.fields).map(([label, value]) => ({ label, value }));
+	}
+	// {items:{rows:[...]}} and {items:[...]} both mean the same thing as the
+	// canonical [{fieldname:"items", rows:[...]}]. A table whose rows cannot be
+	// read as a list is dropped rather than guessed at: a half-populated grid the
+	// user confirms believing it is the full set is worse than an empty one.
+	if (a.tables && !Array.isArray(a.tables) && typeof a.tables === "object") {
+		a.tables = Object.entries(a.tables)
+			.map(([fieldname, spec]) => {
+				const rows = Array.isArray(spec) ? spec : spec && spec.rows;
+				return Array.isArray(rows) ? { fieldname, rows } : null;
+			})
+			.filter(Boolean);
+	}
+	return a;
+}

--- a/frontend/src/lib/chatAction.spec.js
+++ b/frontend/src/lib/chatAction.spec.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+import { normaliseAction } from "./chatAction";
+
+/**
+ * The regression this module exists for: a jarvis-action block missing `kind`
+ * rendered a summary card whose model was never built, so the card sat on
+ * "Preparing summary..." forever with no error and no retry. The card's render
+ * gate (isEditVerb) and the build watcher disagreed about whether `kind` was
+ * required, and the disagreement failed silently.
+ */
+
+describe("normaliseAction", () => {
+	it("infers kind:doc for a block that omits it", () => {
+		// THE bug: the model emits verb+doctype+fields and no `kind`.
+		const a = normaliseAction({ verb: "create", doctype: "Supplier" });
+		expect(a.kind).toBe("doc");
+	});
+
+	it("converts a fields OBJECT into the [{label,value}] array the builder walks", () => {
+		const a = normaliseAction({
+			verb: "create",
+			doctype: "Supplier",
+			fields: { supplier_name: "Test", country: "India" },
+		});
+		expect(a.fields).toEqual([
+			{ label: "supplier_name", value: "Test" },
+			{ label: "country", value: "India" },
+		]);
+	});
+
+	it("normalises the exact block that stranded conversation o3fike0mm0", () => {
+		const raw = {
+			verb: "create",
+			doctype: "Supplier",
+			continue: 1,
+			fields: {
+				supplier_name: "Test",
+				supplier_type: "Company",
+				country: "India",
+				supplier_group: "Demo Supplier Group",
+			},
+		};
+		const a = normaliseAction(raw);
+		expect(a.kind).toBe("doc");
+		expect(Array.isArray(a.fields)).toBe(true);
+		expect(a.fields).toHaveLength(4);
+		// buildDraftModel throws "no fields to show" on a create whose fields have
+		// no .length, and an object silently has none. This is what unblocks the card.
+		expect(a.fields.length).toBeGreaterThan(0);
+		expect(a.continue).toBe(1); // chain marker must survive
+	});
+
+	it("converts a tables OBJECT keyed by fieldname into the [{fieldname,rows}] array", () => {
+		// This shape THREW rather than hung: for..of on a plain object is a
+		// TypeError, which surfaced as "Could not load this draft. Tell me to try
+		// again." on the card.
+		const a = normaliseAction({
+			verb: "create",
+			doctype: "Purchase Order",
+			tables: { items: { rows: [{ item_code: "DUMMY-ITEM-002", qty: 1 }] } },
+		});
+		expect(a.tables).toEqual([
+			{ fieldname: "items", rows: [{ item_code: "DUMMY-ITEM-002", qty: 1 }] },
+		]);
+	});
+
+	it("accepts the bare-array table form too ({items: [...]})", () => {
+		const a = normaliseAction({
+			verb: "create",
+			doctype: "Purchase Order",
+			tables: { items: [{ item_code: "X", qty: 2 }] },
+		});
+		expect(a.tables).toEqual([{ fieldname: "items", rows: [{ item_code: "X", qty: 2 }] }]);
+	});
+
+	it("drops a table whose rows cannot be read as a list rather than guessing", () => {
+		// A half-populated grid the user confirms believing it is the full set is
+		// worse than no grid at all.
+		const a = normaliseAction({
+			verb: "create",
+			doctype: "Purchase Order",
+			tables: { items: { nonsense: true }, taxes: { rows: [{ rate: 18 }] } },
+		});
+		expect(a.tables).toEqual([{ fieldname: "taxes", rows: [{ rate: 18 }] }]);
+	});
+
+	it("normalises the second stranded block (Purchase Order, object fields AND tables)", () => {
+		const a = normaliseAction({
+			verb: "create",
+			doctype: "Purchase Order",
+			fields: { supplier: "Test", transaction_date: "2026-07-31" },
+			tables: { items: { rows: [{ item_code: "DUMMY-ITEM-002", qty: 1, rate: 1 }] } },
+		});
+		expect(a.kind).toBe("doc");
+		expect(a.fields).toHaveLength(2);
+		expect(a.tables).toHaveLength(1);
+		expect(a.tables[0].fieldname).toBe("items");
+		// buildDraftModel walks BOTH with for..of; neither may be a plain object.
+		expect(Array.isArray(a.fields)).toBe(true);
+		expect(Array.isArray(a.tables)).toBe(true);
+	});
+
+	it("leaves a spec-shaped block untouched", () => {
+		const good = {
+			kind: "doc",
+			verb: "create",
+			doctype: "Sales Order",
+			fields: [{ label: "customer", value: "Palmer Productions Ltd." }],
+			tables: [{ fieldname: "items", rows: [{ item_code: "Widget", qty: 5 }] }],
+		};
+		expect(normaliseAction({ ...good })).toEqual(good);
+	});
+
+	it("never rewrites an explicit kind, so an email block stays an email block", () => {
+		// The template branches on kind === 'email' BEFORE the summary card, so
+		// inferring 'doc' here would swap the rendered card entirely.
+		const a = normaliseAction({ kind: "email", verb: "create", doctype: "Contact" });
+		expect(a.kind).toBe("email");
+	});
+
+	it("does not invent a kind when there is no doctype to justify one", () => {
+		const a = normaliseAction({ verb: "create" });
+		expect(a.kind).toBeUndefined();
+	});
+
+	it("passes non-objects through as null rather than throwing", () => {
+		expect(normaliseAction(null)).toBeNull();
+		expect(normaliseAction(undefined)).toBeNull();
+		expect(normaliseAction("nope")).toBeNull();
+		expect(normaliseAction(42)).toBeNull();
+		// An array is JSON-valid and typeof "object": it must not be treated as a
+		// block, or Object.entries would turn it into nonsense fields.
+		expect(normaliseAction([{ label: "a", value: 1 }])).toBeNull();
+	});
+
+	it("tolerates a block with no fields at all", () => {
+		// A tables-only create is legal per the spec; it must not crash here.
+		const a = normaliseAction({ verb: "create", doctype: "Sales Order", tables: [] });
+		expect(a.kind).toBe("doc");
+		expect(a.fields).toBeUndefined();
+	});
+});
+
+describe("the two gates that disagreed stay mirrored", () => {
+	const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+	it("the build watcher gates on the same predicate the card renders on", () => {
+		// The card is `v-else-if="isEditVerb(activeAction)"` after an email branch.
+		// The watcher must mirror that, NOT add its own kind === "doc" requirement:
+		// anything that draws a summary card has to attempt its model, so a shape it
+		// cannot build produces the error card instead of a stuck placeholder.
+		expect(src).toContain('v-else-if="isEditVerb(activeAction)"');
+		expect(src).toContain('if (!a || a.kind === "email" || !isEditVerb(a)) return;');
+		expect(src).not.toContain(
+			'if (!(a && a.kind === "doc" && (a.verb === "create" || a.verb === "update" || !a.verb)))'
+		);
+	});
+
+	it("never dumps raw dry-run JSON into a confirmation card body", () => {
+		// PendingCard puts the raw preview behind a "Details" expander. The
+		// no-structured-card FALLBACK used to <pre> the same JSON straight into the
+		// card body, so a confirmation whose preview did not summarise landed as a
+		// wall of JSON above the Confirm button. Both surfaces must collapse it.
+		expect(src).toContain('<details\n\t\t\t\t\t\t\t\t\t\tv-else-if="pendingPreviewOf(pa)"');
+		expect(src).not.toMatch(/<pre\s+v-else-if="pendingPreviewOf\(pa\)"/);
+	});
+
+	it("actions are canonicalised at the single parse point", () => {
+		// If a second _ACTION_RE parser appears without this call, the shapes
+		// diverge again and the stuck card comes back.
+		expect(src).toContain("normaliseAction(a)");
+		expect(src).toContain('import { normaliseAction } from "@/lib/chatAction";');
+	});
+});

--- a/frontend/src/lib/pendingConfirmResync.spec.js
+++ b/frontend/src/lib/pendingConfirmResync.spec.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * A parked confirmation card must never depend on a single event surviving.
+ *
+ * It can reach the screen by three best-effort routes, and each one can miss:
+ *
+ *   1. the live `action:pending` push. Socketio has no replay, so anything
+ *      published during a blip is simply gone.
+ *   2. the `pending` payload folded into a terminal by _extra_with_pending.
+ *      Only settlement/finalize do that; turn_handler's own run:end has no
+ *      `pending` key.
+ *   3. the loadConversation reload (which resyncs as a side effect). On the
+ *      ordinary success path run:end deliberately SKIPS it to avoid a visible
+ *      flash, leaving the card waiting on message:enriched, another event.
+ *
+ * Three independent maybes multiply into the rare miss users describe as "about
+ * one confirmation in ten never showed". The fix is an unconditional resync from
+ * durable server state at every terminal. These tests pin it there.
+ */
+
+const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+const terminalBody = (kind) => {
+	const at = src.indexOf(`case "${kind}":`);
+	expect(at).toBeGreaterThan(-1);
+	// Up to the next `case "` at the same switch level is close enough to scope it.
+	const rest = src.slice(at + 10);
+	const end = rest.indexOf('\t\tcase "');
+	return end === -1 ? rest : rest.slice(0, end);
+};
+
+describe("parked confirmations resync from durable state at every terminal", () => {
+	it("run:end resyncs unconditionally, not only when it carried a pending payload", () => {
+		const body = terminalBody("run:end");
+		expect(body).toContain("resyncPendingConfirmations(currentId.value);");
+		// It must NOT sit inside the `if (Array.isArray(p.pending))` branch: that is
+		// precisely the payload that can be absent.
+		const guard = body.indexOf("if (Array.isArray(p.pending))");
+		const call = body.indexOf("resyncPendingConfirmations(currentId.value);");
+		const guardCloses = body.indexOf("\t\t\t}", guard);
+		expect(call).toBeGreaterThan(guardCloses);
+	});
+
+	it("run:error resyncs too, so a card parked in a turn that then errors recovers", () => {
+		const body = terminalBody("run:error");
+		expect(body).toContain("resyncPendingConfirmations(currentId.value);");
+	});
+
+	it("the resync is token-deduped, so a live push plus a resync cannot double-render", () => {
+		expect(src).toContain("function enqueuePending(card) {");
+		const fn = src.slice(src.indexOf("function enqueuePending(card) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("pendingActions.value.some((x) => x.token === card.token)");
+	});
+
+	it("the resync is freshness-guarded against a mid-flight conversation switch", () => {
+		const fn = src.slice(src.indexOf("async function resyncPendingConfirmations(id) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain("if (currentId.value !== id) return;");
+		// and never throws into the terminal handler that now calls it unawaited
+		expect(body).toContain("catch (e) {");
+	});
+
+	it("loadConversation still resyncs, so a reload/reconnect path keeps working", () => {
+		expect(src).toContain("resyncPendingConfirmations(id);");
+	});
+});

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -2180,7 +2180,17 @@ function toScopeLabel(p) {
 // Four-eyes cue (shared by the wiki + skill queues): the viewing reviewer
 // authored this request, so the server will reject their own decide. Disable
 // Approve/Reject and say so up front rather than letting the doomed click 403.
+// Four-eyes: a reviewer cannot decide their OWN request. This MIRRORS the server
+// rule (wiki.py::_decide_promotion, custom_skills_api.py::decide_skill_promotion)
+// and must mirror its Administrator carve-out too. Both servers read
+// `reviewer == req.owner and reviewer != "Administrator"`, so Administrator may
+// decide its own request; without the same carve-out here the UI was STRICTER
+// than the server and sat Approve/Reject disabled on a request the server would
+// have accepted, leaving an Administrator-owned pending request undecidable from
+// the page. Keep the two in sync: a gate that over-refuses is as broken as one
+// that under-refuses, it just fails silently instead of with an error.
 function isMyPromo(p) {
+	if (session.user === "Administrator") return false;
 	return !!p && !!p.requested_by && p.requested_by === session.user;
 }
 // The decision is irreversible from the user's side, so Approve confirms with

--- a/frontend/src/pages/skills/fourEyesParity.spec.js
+++ b/frontend/src/pages/skills/fourEyesParity.spec.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Four-eyes parity between the Review page and the two server endpoints that
+ * actually enforce it.
+ *
+ * The rule: a reviewer may not decide their own promotion request. Both servers
+ * spell it `reviewer == req.owner and reviewer != "Administrator"`, so the
+ * break-glass account is deliberately exempt.
+ *
+ * The client had the first half and not the carve-out. That is a silent failure
+ * mode rather than a loud one: the page disabled Approve/Reject on a request the
+ * server would have accepted, so an Administrator-owned request could not be
+ * decided from the UI at all and there was no error to explain why. These tests
+ * pin BOTH sides, because a client gate stricter than its server is still a bug.
+ */
+
+const APP = path.resolve(__dirname, "../../../..");
+const read = (p) => fs.readFileSync(path.join(APP, p), "utf8");
+
+const reviewTab = read("frontend/src/pages/skills/ReviewTab.vue");
+const wikiPy = read("jarvis/chat/wiki.py");
+const skillsPy = read("jarvis/chat/custom_skills_api.py");
+
+describe("four-eyes: client gate mirrors the server rule", () => {
+	it("the client exempts Administrator before comparing the requester", () => {
+		const fn = reviewTab.slice(reviewTab.indexOf("function isMyPromo(p) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toContain('session.user === "Administrator"');
+		expect(body).toContain("p.requested_by === session.user");
+	});
+
+	it("both servers carry the same Administrator carve-out", () => {
+		// If either server ever drops the carve-out, the client must drop it too
+		// or it becomes the LENIENT side and users get a 403 on a live button.
+		const rule = 'reviewer == (req.owner or "") and reviewer != "Administrator"';
+		expect(wikiPy).toContain(rule);
+		expect(skillsPy).toContain(rule);
+	});
+
+	it("the gate still refuses a non-Administrator deciding their own request", () => {
+		// The carve-out must not swallow the rule it is an exception to.
+		const fn = reviewTab.slice(reviewTab.indexOf("function isMyPromo(p) {"));
+		const body = fn.slice(0, fn.indexOf("\n}"));
+		expect(body).toMatch(
+			/return\s+!!p\s+&&\s+!!p\.requested_by\s+&&\s+p\.requested_by === session\.user;/
+		);
+	});
+
+	it("Approve, Reject and the explanation all hang off the same gate", () => {
+		// Three call sites per promotion kind. If one drifts, a user sees an
+		// enabled button next to "another reviewer must decide it".
+		const uses = reviewTab.match(/isMyPromo\(p\)/g) || [];
+		expect(uses.length).toBeGreaterThanOrEqual(6);
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -440,47 +440,59 @@
 						:firstName="firstName"
 						@seen="ackHomeIntro"
 					/>
-					<!-- Claude-style minimal new chat: the brand mark inline with the
-					     greeting, no hero copy or suggestion cards. -->
-					<h1
-						v-else
-						class="jv-welcome-h1"
-						style="
-							display: flex;
-							align-items: center;
-							justify-content: center;
-							gap: 16px;
-							font-size: 40px;
-							font-weight: 640;
-							letter-spacing: -0.03em;
-							margin: 0;
-							overflow-wrap: anywhere;
-						"
-					>
-						<JarvisMark :size="38" :radius="11" style="flex: none" />
-						<span>{{ greeting }}, {{ firstName }}</span>
-					</h1>
+					<!-- The brand mark inline with the greeting, then one line of
+					     orienting copy. The copy earns its place on an empty screen: it
+					     is the only thing that says what this box is for and that the
+					     agent is wired to real ERP data. -->
+					<template v-else>
+						<h1
+							class="jv-welcome-h1"
+							style="
+								display: flex;
+								align-items: center;
+								justify-content: center;
+								gap: 16px;
+								font-size: 40px;
+								font-weight: 640;
+								letter-spacing: -0.03em;
+								margin: 0;
+								overflow-wrap: anywhere;
+							"
+						>
+							<JarvisMark :size="38" :radius="11" style="flex: none" />
+							<span>{{ greeting }}, {{ firstName }}</span>
+						</h1>
+						<p class="jv-welcome-sub">
+							Ask about your ERP data, run a workflow, or draft something.
+							{{ agentName }}
+							is connected to your
+							<strong style="color: var(--text); font-weight: 600">ERPNext</strong>
+							instance.
+						</p>
+					</template>
 					<!-- Starter cards, same shape as the original static ones (tinted icon
-					     tile + label over the prompt) — only the CONTENT is now synthesised
-					     from this user's own recent chat titles. They FILL the composer,
-					     never send: the do-not-regress rule the old cards had. -->
+					     tile + label over the prompt). The CONTENT is synthesised from this
+					     user's own recent chat titles when there are any, and falls back to
+					     the original four defaults for a workspace with no history yet.
+					     They FILL the composer, never send: the do-not-regress rule the old
+					     cards had. -->
 					<div
-						v-if="!showHomeIntro && promptSuggestions.length"
+						v-if="!showHomeIntro"
 						class="jv-welcome-grid"
 						style="
 							display: grid;
 							grid-template-columns: 1fr 1fr;
 							gap: 11px;
 							text-align: left;
-							margin-top: 22px;
+							margin-top: 26px;
 						"
 					>
 						<button
-							v-for="(s, i) in promptSuggestions"
+							v-for="(s, i) in starterCards"
 							:key="s.prompt"
 							type="button"
 							class="jv-suggest"
-							@click="fillInput(s.prompt)"
+							@click="onWelcomeSuggestion(s)"
 							style="
 								display: flex;
 								gap: 11px;
@@ -1881,11 +1893,22 @@
 											Create <b>{{ a.doctype }}</b> "{{ a.name }}"
 										</li>
 									</ul>
-									<pre
+									<!-- Raw dry-run JSON belongs BEHIND an expander, exactly as
+									     PendingCard puts it behind its own "Details". This branch
+									     is the fallback for when the server built no structured
+									     card, and it used to dump the JSON straight into the card
+									     body - so a confirmation whose preview did not summarise
+									     landed as a wall of JSON above the Confirm button. Same
+									     information, same click to reach it, no dump. -->
+									<details
 										v-else-if="pendingPreviewOf(pa)"
-										class="jv-pending-preview"
-										>{{ pendingPreviewOf(pa) }}</pre
+										class="jv-pending-details"
 									>
+										<summary>Details</summary>
+										<pre class="jv-pending-preview">{{
+											pendingPreviewOf(pa)
+										}}</pre>
+									</details>
 								</template>
 							</template>
 						</div>
@@ -2072,7 +2095,7 @@
 						@keydown="onKey"
 						@paste="onPaste"
 						@files-added="uploadFiles"
-						@remove-attachment="removeFile"
+						@remove-attachment="removeAttachment"
 					>
 						<template #above>
 							<!-- Create menu "Create a trigger": trigger-build mode. While this marker
@@ -3612,6 +3635,8 @@ import AskCard from "@/components/chat/AskCard.vue";
 import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
+import { normaliseAction } from "@/lib/chatAction";
+import { errMessage } from "@/lib/errors";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { pickGreeting } from "@/lib/greeting";
 import { dashboardForConversation } from "@/api/dashboards";
@@ -4402,7 +4427,20 @@ const liveElapsedLabel = computed(() => {
 const runMeta = ref({}); // { [message_id]: { ms, tools, names } } — survives reloads
 const canvasContent = ref({}); // { `${msgName}::${canvasName}`: srcdoc html (html/svg) | data-url (pdf/image/file) }
 const pendingFiles = ref([]); // [{ file_url, file_name }] attachments to send
-const uploading = ref(false);
+// Per-file upload state. This was a single `uploading` boolean, which could
+// only ever say "something is happening somewhere" - no file name, no way to
+// show more than one at a time, and no place at all to record a FAILURE (the
+// old code caught upload errors and dropped them on the floor).
+const uploadingFiles = ref([]); // [{ id, name }] in flight
+const failedUploads = ref([]); // [{ id, name, error }] shown until dismissed
+let _uploadSeq = 0;
+// Identity keys of uploads currently in flight, so re-picking the same file
+// while it uploads is a no-op instead of a second copy.
+const _inflightKeys = new Set();
+// Frappe's own default ceiling (frappe/core/api/file.py::get_max_file_size).
+// Checked client-side purely so an oversize file fails with a readable sentence
+// instead of a bare 413; the server remains the authority.
+const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
 const mention = ref({ open: false, type: "", query: "", start: 0, items: [], index: 0 });
 // Tool names for the "Tools available" count + the /tool autocomplete. Seeded
 // with the core set as a fallback, then replaced on mount with the live bench
@@ -4475,6 +4513,35 @@ const _STARTER_TINTS = [
 	},
 ];
 const starterTint = (i) => _STARTER_TINTS[i % _STARTER_TINTS.length];
+// The original static cards, kept as the no-history fallback. A brand-new
+// workspace has nothing to synthesise from, and four good defaults are a better
+// first impression than a bare screen, and they teach the four things the
+// agent can do. Only the copy lives here: colour and icon come from position via
+// starterTint, which is exactly where these four cards' own tints came from, so
+// the fallback renders pixel-identical to the pre-synthesis design.
+const DEFAULT_STARTERS = [
+	{
+		category: "analyse",
+		title: "Analyse data",
+		prompt: "Which sales orders are overdue this month?",
+	},
+	{ category: "action", title: "Take an action", prompt: "Draft a document for me to review" },
+	{ category: "search", title: "Search records", prompt: "Search for a customer or contact" },
+	{ category: "draft", title: "Draft content", prompt: "Write a follow-up email to a lead" },
+];
+// What the welcome grid renders: this user's synthesised starters when the
+// backend returned any, else the defaults above. Never empty, so the grid always
+// has something to show.
+const starterCards = computed(() =>
+	promptSuggestions.value.length ? promptSuggestions.value : DEFAULT_STARTERS
+);
+// A card was chosen. Fills the composer, never sends (do-not-regress). The
+// bounded intro telemetry gets a category token for a default card and the short
+// synthesised label otherwise. Never the prompt text, never user content.
+function onWelcomeSuggestion(s) {
+	noteWelcomeSuggestion(s.category || s.title || "synthesised");
+	fillInput(s.prompt);
+}
 api.getPromptSuggestions()
 	.then((r) => {
 		const list = (r && r.data && r.data.suggestions) || [];
@@ -4821,6 +4888,7 @@ const {
 	homeIntroSpeakerName,
 	initFromBoot: initHomeIntro,
 	ackHomeIntro,
+	noteSuggestionSelected: noteWelcomeSuggestion,
 } = useHomeIntro({
 	showWelcome,
 	booting,
@@ -5185,12 +5253,15 @@ function chartsOf(m) {
 function askOf(m) {
 	return parseAsk((m && m.content) || "");
 }
+// Canonicalised at the single _ACTION_RE parse point so every consumer (render
+// gate, build watcher, buildDraftModel, edit panel, apply) sees ONE shape. See
+// lib/chatAction.js for which model slips are absorbed and why.
 function actionOf(m) {
 	const mt = ((m && m.content) || "").match(_ACTION_RE);
 	if (!mt) return null;
 	try {
 		const a = JSON.parse(mt[1].trim());
-		return a && typeof a === "object" ? a : null;
+		return a && typeof a === "object" ? normaliseAction(a) : null;
 	} catch (e) {
 		return null;
 	}
@@ -5840,8 +5911,14 @@ function onPreviewEdit() {
 // draft while mid-edit.
 watch(actionFor, () => {
 	const a = activeAction.value;
-	if (!(a && a.kind === "doc" && (a.verb === "create" || a.verb === "update" || !a.verb)))
-		return;
+	// Gate on EXACTLY what the template renders the summary card on: not an email
+	// block, and isEditVerb(). These two used to disagree: the card drew for any
+	// edit verb while the build additionally required kind === "doc", so a block
+	// missing `kind` rendered a card whose model was never built and sat on
+	// "Preparing summary..." indefinitely. Keep them mirrored: whatever draws a
+	// summary card must also attempt its model, so an unbuildable shape produces
+	// the error card instead of a permanent placeholder.
+	if (!a || a.kind === "email" || !isEditVerb(a)) return;
 	ensureActionSummary(a); // keep the summary card in sync with the latest action
 	if (draftPanel.value) {
 		// panel is open (user is editing) and the action re-emitted -> refresh it too
@@ -7013,6 +7090,7 @@ function resetRunState() {
 	currentRunId.value = null;
 	store.streamingConvId = null;
 	pendingFiles.value = [];
+	failedUploads.value = []; // a stale failure pill must not follow the user into a new chat
 	mention.value = { ...mention.value, open: false };
 	histIdx.value = null;
 	histDraft.value = "";
@@ -7261,6 +7339,7 @@ async function send(textArg, resendAck) {
 	if (fromMain) {
 		input.value = "";
 		pendingFiles.value = [];
+		failedUploads.value = [];
 		mention.value = { ...mention.value, open: false };
 	}
 	// A fromMain send clears the composer, so any transcribed recording in this scope whose text
@@ -7732,6 +7811,26 @@ function onEvent(p) {
 						conversation: card.conversation || p.conversation_id,
 					});
 			}
+			// UNCONDITIONAL backstop: re-read the parked list from durable server
+			// state at every terminal, whether or not this payload carried `pending`.
+			//
+			// Why the C2 self-heal above is not enough. A card reached the screen by
+			// one of three best-effort routes, and EVERY one can miss:
+			//   1. the live action:pending push (best-effort; a socket blip loses it,
+			//      and socketio has no replay);
+			//   2. this `p.pending` payload, which only exists on terminals published
+			//      through settlement/finalize (_extra_with_pending). turn_handler's
+			//      own run:end carries no `pending` key at all;
+			//   3. the loadConversation reload below, which on the ORDINARY success
+			//      path (enrichment_pending, not recovered) is deliberately skipped to
+			//      avoid a visible flash — so the resync inside it never runs, and the
+			//      card then waits on message:enriched, itself just another event.
+			// Three independent maybes multiply into the rare miss that shows up as
+			// "about one confirmation in ten never appeared". This makes the card
+			// depend on durable state instead: one cheap read per turn end, deduped by
+			// token in enqueuePending, freshness-guarded against a conversation switch,
+			// and silent on failure.
+			resyncPendingConfirmations(currentId.value);
 			// Defensive: if a promoted turn's run:start was missed, retire the chip.
 			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			const m = messages.value.find((x) => x.name === p.message_id);
@@ -7845,6 +7944,8 @@ function onEvent(p) {
 						conversation: card.conversation || p.conversation_id,
 					});
 			}
+			// …and the unconditional backstop, for the same reason as run:end below.
+			resyncPendingConfirmations(currentId.value);
 			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			if (p.message_id) {
 				errorMeta.value = {
@@ -8692,7 +8793,26 @@ const composerAttachments = computed(() => {
 		preview_url: isImageFile(f) ? f.file_url : "",
 		removable: true,
 	}));
-	if (uploading.value) chips.push({ key: "uploading", uploading: true });
+	// One in-flight pill PER file being uploaded, named, so a slow attach shows
+	// which file the wait belongs to instead of one anonymous "Uploading…" for a
+	// whole multi-file pick.
+	// Scoped to this conversation for the same reason the upload result is: an
+	// upload still running in the chat the user just left must not show its
+	// spinner in the one they opened.
+	for (const u of uploadingFiles.value)
+		if (u.conv === currentId.value)
+			chips.push({ key: `up:${u.id}`, uploading: true, file_name: u.name });
+	// Failures are shown, never swallowed. Indexed AFTER pendingFiles so the
+	// remove-attachment index the composer emits still addresses the right list
+	// (see removeAttachment).
+	for (const f of failedUploads.value)
+		chips.push({
+			key: `fail:${f.id}`,
+			failed: true,
+			file_name: f.name,
+			error: f.error,
+			removable: true,
+		});
 	return chips;
 });
 // Shared upload path for the file picker, clipboard paste, and drag-and-drop.
@@ -8701,16 +8821,59 @@ const composerAttachments = computed(() => {
 async function uploadFiles(list) {
 	const files = Array.from(list || []);
 	if (!files.length) return;
-	uploading.value = true;
-	for (const f of files) {
-		try {
-			pendingFiles.value = [...pendingFiles.value, await api.uploadFile(f)];
-		} catch (err) {
-			/* skip a file that failed to upload */
-		}
-	}
-	uploading.value = false;
+	// Uploads run CONCURRENTLY now. The old loop awaited each file in turn, so
+	// picking five made the fifth wait on the four before it with a single
+	// anonymous pill for the whole batch.
+	await Promise.all(files.map((f) => uploadOne(f)));
 	composerRef.value?.focusInput();
+}
+// The ONE upload path: file picker, drag-drop and clipboard paste all land here,
+// so a fix (the spinner, the failure pill, the size pre-check) applies to every
+// attach type rather than only the one that was reported. Never throws.
+async function uploadOne(file) {
+	const name = (file && file.name) || "file";
+	// Identity of the actual bytes, not just the name: re-picking the SAME file
+	// while its first upload is still running must not start a second one. A
+	// 3-minute voice memo takes long enough that an impatient re-click is the
+	// normal reaction, and each click used to queue another full upload - which
+	// is how one recording ended up attached five times.
+	const key = `${name}|${file && file.size}|${file && file.lastModified}`;
+	if (_inflightKeys.has(key)) {
+		notify(`${name} is already uploading`, { type: "info" });
+		return;
+	}
+	_inflightKeys.add(key);
+	const id = ++_uploadSeq;
+	// The conversation this attachment BELONGS to, captured before the await.
+	const forConv = currentId.value;
+	uploadingFiles.value = [...uploadingFiles.value, { id, name, conv: forConv }];
+	try {
+		// Pre-flight the size so an oversize file fails with a sentence the user
+		// can act on, rather than a bare HTTP 413 from the server.
+		if (MAX_UPLOAD_BYTES && file && file.size > MAX_UPLOAD_BYTES) {
+			throw new Error(`larger than the ${Math.floor(MAX_UPLOAD_BYTES / 1048576)} MB limit`);
+		}
+		const rec = await api.uploadFile(file);
+		// Freshness guard. Without it a slow upload started in one chat resolves
+		// AFTER the user has opened another and pushes itself into that chat's
+		// tray - so a brand-new chat opened mid-upload silently inherited the
+		// previous conversation's attachment. resetRunState() clears the tray on
+		// leave; an in-flight upload has to respect the same boundary.
+		if (currentId.value !== forConv) return;
+		pendingFiles.value = [...pendingFiles.value, rec];
+	} catch (err) {
+		// Previously an empty catch: the file silently never appeared, which read
+		// as "the picker is broken" for anything the server refused (an oversize
+		// recording, a blocked extension, an expired session). Show it instead.
+		const why = errMessage(err) || "upload failed";
+		if (currentId.value === forConv) {
+			failedUploads.value = [...failedUploads.value, { id, name, error: why }];
+			notify(`Could not attach ${name}: ${why}`, { type: "error" });
+		}
+	} finally {
+		_inflightKeys.delete(key);
+		uploadingFiles.value = uploadingFiles.value.filter((u) => u.id !== id);
+	}
 }
 // Transient hint shown when the clipboard holds only a file PATH, not the image
 // bytes (e.g. copying an image FILE from a file manager - the OS exposes only
@@ -8758,23 +8921,32 @@ async function onPaste(e) {
 		return;
 	}
 	e.preventDefault();
-	uploading.value = true;
-	for (let i = 0; i < imgs.length; i++) {
-		const f = imgs[i];
-		const ext = ((f.type || "image/png").split("/")[1] || "png").split("+")[0];
-		// Clipboard images come in unnamed (or all "image.png"); give each a
-		// unique, descriptive name so the upload + dedup behave.
-		const named = new File([f], `pasted-${Date.now()}-${i}.${ext}`, {
-			type: f.type || "image/png",
-		});
-		try {
-			pendingFiles.value = [...pendingFiles.value, await api.uploadFile(named)];
-		} catch (err) {
-			/* skip a file that failed to upload */
-		}
-	}
-	uploading.value = false;
-	composerRef.value?.focusInput();
+	// Same uploader as the picker and drag-drop, so pasted images get the named
+	// spinner and the failure pill too.
+	await uploadFiles(
+		imgs.map((f, i) => {
+			const ext = ((f.type || "image/png").split("/")[1] || "png").split("+")[0];
+			// Clipboard images come in unnamed (or all "image.png"); give each a
+			// unique, descriptive name so the upload + dedup behave.
+			return new File([f], `pasted-${Date.now()}-${i}.${ext}`, {
+				type: f.type || "image/png",
+			});
+		})
+	);
+}
+// The composer emits ONE index across the whole chip list, which is
+// pendingFiles, then the in-flight pills, then the failures. Only real
+// attachments and failures are removable, so map the index onto whichever list
+// owns it. Getting this wrong silently removed the wrong attachment.
+function removeAttachment(i) {
+	if (i < pendingFiles.value.length) return removeFile(i);
+	// Count the pills actually RENDERED, not every in-flight upload: the tray
+	// hides uploads belonging to another conversation, so using the full length
+	// here would shift the failure index and remove the wrong chip.
+	const visibleUploading = uploadingFiles.value.filter((u) => u.conv === currentId.value).length;
+	const failedAt = i - pendingFiles.value.length - visibleUploading;
+	if (failedAt >= 0 && failedAt < failedUploads.value.length)
+		failedUploads.value = failedUploads.value.filter((_, idx) => idx !== failedAt);
 }
 function removeFile(i) {
 	pendingFiles.value = pendingFiles.value.filter((_, idx) => idx !== i);
@@ -9896,6 +10068,14 @@ onUnmounted(() => {
 	text-align: center;
 	margin-block: auto;
 }
+/* The orienting line under the greeting. A class, not an inline style, so the
+   phone rule below can shrink it; inline styles cannot be overridden. */
+.jv-welcome-sub {
+	font-size: 15px;
+	color: var(--text-2);
+	line-height: 1.5;
+	margin: 12px 0 0;
+}
 /* Starter cards (the original card treatment, now carrying synthesised copy). */
 .jv-suggest:hover {
 	border-color: var(--border-2);
@@ -9927,6 +10107,10 @@ onUnmounted(() => {
 		/* Scaled with the desktop bump (32 -> 40), kept a step smaller so a long
 		   "Long time no see, <name>" still fits a phone without wrapping oddly. */
 		font-size: 28px !important;
+	}
+	.jv-welcome-sub {
+		font-size: 14px;
+		margin-top: 10px;
 	}
 	/* Starter cards stack: two 14px-padded cards side by side are unreadable at
 	   phone width. Inline styles set the grid, so this has to win with !important. */
@@ -12113,6 +12297,25 @@ onUnmounted(() => {
 	color: var(--text-3);
 	font-size: 12.5px;
 	line-height: 1.45;
+}
+/* Collapsed wrapper for the raw dry-run JSON in the no-structured-card fallback.
+   Mirrors PendingCard's own .jv-pcard-details so the two confirmation surfaces
+   hide the same thing the same way. */
+.jv-pending-details {
+	margin: 0 14px 8px;
+}
+.jv-pending-details > summary {
+	cursor: pointer;
+	font-size: 11.5px;
+	color: var(--text-3);
+	user-select: none;
+	padding: 2px 0;
+}
+.jv-pending-details > summary:hover {
+	color: var(--text-2);
+}
+.jv-pending-details[open] > summary {
+	margin-bottom: 6px;
 }
 .jv-pending-preview {
 	margin: 0;

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -321,6 +321,31 @@
 								Retry
 							</button>
 						</div>
+
+						<!-- A turn that failed server-side. Shows the same headline the
+						     full chat uses; the raw provider text (an OAuth 401 arrives
+						     as a JSON blob) stays folded away behind "Show details" so it
+						     cannot swamp a 400px panel. -->
+						<div v-if="turnError" class="jvp-turn-err" role="alert">
+							<div class="jvp-turn-err-h">{{ turnErrorHeadline }}</div>
+							<pre v-if="turnErrorOpen" class="jvp-turn-err-raw">{{
+								turnError
+							}}</pre>
+							<div class="jvp-turn-err-acts">
+								<button class="jvp-btn-subtle" type="button" @click="retryLast">
+									Retry
+								</button>
+								<button
+									v-if="turnErrorHasDetail"
+									class="jvp-btn-subtle"
+									type="button"
+									:aria-expanded="turnErrorOpen ? 'true' : 'false'"
+									@click="turnErrorOpen = !turnErrorOpen"
+								>
+									{{ turnErrorOpen ? "Hide details" : "Show details" }}
+								</button>
+							</div>
+						</div>
 					</div>
 				</template>
 			</div>
@@ -667,6 +692,68 @@ const messages = ref([]);
 const stream = ref(emptyStream());
 const loading = ref(false);
 const loadError = ref("");
+// A turn that FAILED server-side (run:error), kept separate from loadError on
+// purpose. run:error also sets `reload`, and load() clears loadError on entry —
+// so routing a failed turn through loadError meant the message was wiped by the
+// reload it triggers, and the panel showed nothing at all. A dead LLM credential
+// (auth_permanent) looked exactly like a reply that never came.
+const turnError = ref("");
+const turnErrorOpen = ref(false); // "Show details" disclosure
+// Mirrors the full chat's ERROR_HEADLINES / classifyErrorCode (ChatView.vue) so
+// both surfaces name the same failure the same way. Raw provider errors are
+// unreadable here — an OAuth 401 arrives as a multi-line JSON blob — so the
+// headline is what shows and the raw text hides behind "Show details".
+const _ERROR_HEADLINES = {
+	unreachable: "I couldn't reach the assistant",
+	timeout: "That took too long",
+	provider: "The model is busy right now",
+	"recovery-expired": "This took too long, so I stopped waiting",
+	internal: "Something went wrong",
+	cancelled: "This message was cancelled",
+};
+function classifyErrorCode(raw) {
+	const low = (raw || "").toLowerCase();
+	if (
+		low.startsWith("you cancelled this message") ||
+		low.startsWith("waited too long in the queue")
+	)
+		return "cancelled";
+	if (
+		low.includes("ws open failed") ||
+		low.includes("unreachable") ||
+		low.includes("connection timed out")
+	)
+		return "unreachable";
+	if (low.includes("recovery window")) return "recovery-expired";
+	if (low.includes("timed out") || low.includes("timeout") || low.includes("deadline"))
+		return "timeout";
+	if (
+		[
+			"quota",
+			"rate limit",
+			"cooldown",
+			"overloaded",
+			"insufficient",
+			"credit",
+			"billing",
+		].some((k) => low.includes(k))
+	)
+		return "provider";
+	return "internal";
+}
+const turnErrorCode = computed(() => classifyErrorCode(turnError.value));
+const turnErrorHeadline = computed(
+	() => _ERROR_HEADLINES[turnErrorCode.value] || "Something went wrong"
+);
+// Only offer the raw text when it says more than the headline already does.
+const turnErrorHasDetail = computed(() => {
+	const t = (turnError.value || "").trim();
+	return !!t && t !== turnErrorHeadline.value;
+});
+function clearTurnError() {
+	turnError.value = "";
+	turnErrorOpen.value = false;
+}
 const draft = ref("");
 const sending = ref(false);
 const composerFocused = ref(false);
@@ -888,6 +975,36 @@ function jumpToBottom() {
 	showScrollDown.value = false;
 	scrollToBottom();
 }
+// The arrow has to track the CONTENT, not the delivery path. stickToBottom()
+// runs only on live realtime frames (see onRealtime), so when a reply lands via
+// the polling safety net instead, nothing recomputed it: a reader parked at the
+// top of a long answer was stranded with the reply running thousands of pixels
+// past the fold and no arrow to follow it. Watching the thread itself covers
+// every path. MutationObserver, not ResizeObserver: the latter reports the
+// scroll BOX, whose size never changes as the thread inside it grows.
+let bodyMO = null;
+let arrowTick = null;
+function watchBodyGrowth() {
+	if (bodyMO || !bodyEl.value) return;
+	bodyMO = new MutationObserver(() => {
+		// Streaming mutates on nearly every token; one coalesced check per burst
+		// is enough and keeps this off the hot path.
+		if (arrowTick) return;
+		arrowTick = window.setTimeout(() => {
+			arrowTick = null;
+			stickToBottom();
+		}, 120);
+	});
+	bodyMO.observe(bodyEl.value, { subtree: true, childList: true, characterData: true });
+}
+function unwatchBodyGrowth() {
+	bodyMO?.disconnect();
+	bodyMO = null;
+	if (arrowTick) {
+		window.clearTimeout(arrowTick);
+		arrowTick = null;
+	}
+}
 
 function autoGrow() {
 	const el = textareaEl.value;
@@ -989,6 +1106,8 @@ function startNewChat() {
 	// New runs get fresh entries; old entries are three ints per run_id.
 	stream.value = { ...emptyStream(), fence: stream.value.fence };
 	loadError.value = "";
+	// The failure belonged to the conversation being left behind.
+	clearTurnError();
 	draft.value = "";
 	// Recall belongs to the conversation you are in, not to the panel.
 	promptHistory.value = [];
@@ -1112,6 +1231,8 @@ async function send() {
 	if ((!text && !atts.length) || sending.value || stream.value.live) return;
 	sending.value = true;
 	loadError.value = "";
+	// A new attempt supersedes the previous failure's notice.
+	clearTurnError();
 	lastSent.value = text;
 
 	// Optimistic echo so the panel feels immediate. run:end reloads from the
@@ -1154,6 +1275,7 @@ function retryLast() {
 	if (!lastSent.value) return;
 	draft.value = lastSent.value;
 	loadError.value = "";
+	clearTurnError();
 	// Drop the optimistic echo that never made it to the server.
 	const i = messages.value.findIndex((m) => String(m.name).startsWith("local-"));
 	if (i !== -1) messages.value.splice(i, 1);
@@ -1215,7 +1337,10 @@ function onRealtime(payload) {
 		// Clear the flag before reloading so a second frame cannot double-fetch.
 		stream.value = { ...next, reload: false, error: "" };
 		sending.value = false;
-		if (next.error) loadError.value = next.error;
+		// A failed turn has to outlive the reload it just triggered, so it goes to
+		// turnError, which load() leaves alone. Sending it to loadError meant
+		// load()'s own reset erased it before it ever rendered.
+		if (next.error) turnError.value = next.error;
 		load();
 		return;
 	}
@@ -1225,7 +1350,7 @@ function onRealtime(payload) {
 		sending.value = false;
 		stickToBottom();
 	}
-	if (next.error) loadError.value = next.error;
+	if (next.error) turnError.value = next.error;
 }
 
 // Load lazily on first open, not at mount: the FAB is on every Desk page and
@@ -1237,8 +1362,12 @@ function onRealtime(payload) {
 watch(
 	() => props.open,
 	async (isOpen) => {
-		if (!isOpen) return;
+		if (!isOpen) {
+			unwatchBodyGrowth();
+			return;
+		}
 		await nextTick();
+		watchBodyGrowth();
 		// Focus the box, not the panel shell: opening the widget is always a
 		// prelude to typing, and focusing the shell cost a click every time.
 		// Escape still closes, since the keydown bubbles to the root handler.
@@ -1315,9 +1444,13 @@ function startPolling() {
 		pollTicks += 1;
 		// ~2 minutes, then give up rather than hammer the site forever.
 		if (pollTicks > 48) {
-			stopPolling();
-			sending.value = false;
-			if (!stream.value.live) loadError.value = "Jarvis did not reply. Try again.";
+			const gaveUp = !stream.value.live;
+			// settle(), not a bare `sending = false`: giving up has to clear
+			// stream.busy too, or `thinking` stays true and the panel shows the
+			// typing dots and "Jarvis did not reply" at the same time — it claims to
+			// be working on a turn it has just abandoned.
+			settle();
+			if (gaveUp) loadError.value = "Jarvis did not reply. Try again.";
 			return;
 		}
 		if (!convId.value) return;
@@ -1375,6 +1508,7 @@ onBeforeUnmount(() => {
 	// A live recording outlives this component otherwise: the mic stays hot and
 	// the getUserMedia tracks are never released.
 	abortRecording();
+	unwatchBodyGrowth();
 	unwatchTheme?.();
 	if (rtTimer) {
 		window.clearInterval(rtTimer);
@@ -1801,6 +1935,40 @@ defineExpose({ load, startNewChat, convId });
 	display: flex;
 	align-items: center;
 	gap: 10px;
+	flex-wrap: wrap;
+}
+
+/* ---- failed turn ---- */
+.jvp-turn-err {
+	margin: 4px 0 2px;
+	padding: 10px 12px;
+	border: 1px solid var(--jv-danger);
+	border-radius: 10px;
+	background: var(--jv-surface-2, transparent);
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.jvp-turn-err-h {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--jv-danger);
+}
+.jvp-turn-err-raw {
+	margin: 0;
+	max-height: 160px;
+	overflow: auto;
+	font-size: 11px;
+	line-height: 1.45;
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: var(--jv-text-2, inherit);
+	opacity: 0.85;
+}
+.jvp-turn-err-acts {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 	flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## What this fixes

Six issues found while running the stack, each root-caused rather than patched at the symptom.

### The new chat page reads as unfinished
The greeting sat alone above an empty grid. Restores the orienting line under it, and falls back to the original four starter cards when there is no history to synthesise from. Also reconnects the `suggestion_selected` telemetry, which an earlier redesign silently stopped destructuring.

### A draft card stuck on "Preparing summary..."
The card renders on `isEditVerb()`, which never inspected `kind`, while the build watcher required `kind === "doc"`. A block missing `kind` therefore drew a card whose model was never built: no error, no timeout, no retry. A second shape (`fields`/`tables` as objects rather than arrays) threw a `TypeError` instead, surfacing as "try again".

Canonicalised at the single parse point, and the build watcher now gates on exactly what the template renders on. Anything still unbuildable reaches `buildDraftModel` and raises the honest error card.

### "About one confirmation in ten never shows"
A card reached the screen by three best-effort routes and every one can miss: the live `action:pending` push (socketio has no replay), the `pending` payload on a terminal (only settlement/finalize add it, `turn_handler`'s own `run:end` has none), and the `loadConversation` reload (skipped on the ordinary success path to avoid a flash). Three independent maybes multiply into a rare, unreproducible miss.

Now resyncs from durable server state at every terminal, outside the payload branch.

### Attachments
A 3-minute recording looked like nothing happened, was re-picked repeatedly, uploaded five times, and then appeared in a **new** chat. Three causes: failures were caught into empty blocks and never shown; there was no per-file progress; and the upload had no conversation guard, so a slow result appended itself to whatever tray was current when it resolved.

### The role picker in Request promotion
Both servers exempt `Administrator` from four-eyes; the client did not, so it was stricter than the rule it mirrored and an Administrator-owned request could not be decided at all. An over-strict gate fails silently.

### The mini chat swallowed failed turns
`run:error` also sets `reload`, and `load()` clears `loadError` on entry, so a failed turn was wiped by the reload it triggered. A dead LLM credential looked exactly like a reply that never came.

## Verification

- **837 tests / 60 files** green; 40 new, including cases built from the two real stranded action blocks.
- pre-commit clean; SPA builds.
- Rebased on current `develop` (post #695) with no conflicts.

## Deploy

`npm run build` for the SPA, `bench build --app jarvis` for the Desk widget. No migration.

## Not verified end to end

The confirmation-card race is a fix against a confirmed gap in the delivery chain, not an observed before/after; a 1-in-10 race cannot be reproduced on demand. The original audio-attachment failure was never reproduced either: it is not a type restriction (no `accept` filter, no server extension allow-list, `.mp3`/`.webm` insert fine), and it can now no longer fail silently, so the next occurrence will name its reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6sH266hANsUiCMSgdUD7j