### PR TITLE
fix(errors): replace 42 inline copies of the pre-#696 error formatter

### DIFF
--- a/frontend/src/components/ConnectPhoneDialog.vue
+++ b/frontend/src/components/ConnectPhoneDialog.vue
@@ -53,6 +53,7 @@ import { ref, computed, watch } from "vue";
 import { Dialog, Button, FeatherIcon } from "frappe-ui";
 import * as api from "@/api";
 import { agentName } from "@/branding";
+import { errMessage } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -67,7 +68,10 @@ const url = ref("");
 const qrSrc = computed(() => (svg.value ? `data:image/svg+xml;base64,${svg.value}` : ""));
 
 function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Could not generate the code.";
+	const msg = errMessage(e);
+	return msg === "Something went wrong. Please try again."
+		? "Could not generate the code."
+		: msg;
 }
 
 async function load() {

--- a/frontend/src/components/ConnectPhoneDialog.vue
+++ b/frontend/src/components/ConnectPhoneDialog.vue
@@ -67,11 +67,9 @@ const url = ref("");
 
 const qrSrc = computed(() => (svg.value ? `data:image/svg+xml;base64,${svg.value}` : ""));
 
+// Feeds `{{ error }}`, a text sink, so the plain-text form is the right one here.
 function errMsg(e) {
-	const msg = errMessage(e);
-	return msg === "Something went wrong. Please try again."
-		? "Could not generate the code."
-		: msg;
+	return errMessage(e, "Could not generate the code.");
 }
 
 async function load() {

--- a/frontend/src/components/VoiceRecorder.vue
+++ b/frontend/src/components/VoiceRecorder.vue
@@ -73,6 +73,7 @@ import { ref, computed, onBeforeUnmount } from "vue";
 import { Button, toast } from "frappe-ui";
 import { useAudioRecorder } from "@/composables/useAudioRecorder";
 import { transcribeAudio } from "@/api/voice";
+import { errMessage as errMsg } from "@/lib/errors";
 
 defineProps({
 	// Compact/embedded mode for the Personalise ChatComposer toolbar: icon-only
@@ -84,10 +85,6 @@ defineProps({
 });
 
 const emit = defineEmits(["transcript"]);
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 const rec = useAudioRecorder({
 	onAutoStop: (r) => {

--- a/frontend/src/components/VoiceRecorder.vue
+++ b/frontend/src/components/VoiceRecorder.vue
@@ -73,7 +73,7 @@ import { ref, computed, onBeforeUnmount } from "vue";
 import { Button, toast } from "frappe-ui";
 import { useAudioRecorder } from "@/composables/useAudioRecorder";
 import { transcribeAudio } from "@/api/voice";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 defineProps({
 	// Compact/embedded mode for the Personalise ChatComposer toolbar: icon-only
@@ -134,7 +134,7 @@ async function transcribe(r) {
 		if (text) emit("transcript", text, r.durationS || 0);
 		else toast.error("Nothing was transcribed - try again closer to the microphone.");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		phase.value = "idle";
 	}

--- a/frontend/src/components/doc/DocMetaPanel.vue
+++ b/frontend/src/components/doc/DocMetaPanel.vue
@@ -232,6 +232,7 @@ import {
 } from "frappe-ui";
 import { listShareableUsers } from "@/api";
 import { timeAgo } from "@/utils/datetime";
+import { errMessage } from "@/lib/errors";
 
 const props = defineProps({
 	docmeta: { type: Object, required: true }, // useDocmeta() object
@@ -313,7 +314,6 @@ function onUploadError(e) {
 		"Portal accounts can attach JPG, PNG, GIF, PDF, TXT, CSV and MS Office files only.";
 }
 function uploadErrMsg(e) {
-	if (e && e.messages && e.messages[0]) return e.messages[0];
 	if (e && e._server_messages) {
 		try {
 			return JSON.parse(JSON.parse(e._server_messages)[0]).message;
@@ -321,7 +321,8 @@ function uploadErrMsg(e) {
 			/* fall through */
 		}
 	}
-	return (e && e.message) || "Upload failed";
+	const msg = errMessage(e);
+	return msg === "Something went wrong. Please try again." ? "Upload failed" : msg;
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/frontend/src/components/doc/DocMetaPanel.vue
+++ b/frontend/src/components/doc/DocMetaPanel.vue
@@ -232,7 +232,7 @@ import {
 } from "frappe-ui";
 import { listShareableUsers } from "@/api";
 import { timeAgo } from "@/utils/datetime";
-import { errMessage } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	docmeta: { type: Object, required: true }, // useDocmeta() object
@@ -313,6 +313,11 @@ function onUploadError(e) {
 	uploadHint.value =
 		"Portal accounts can attach JPG, PNG, GIF, PDF, TXT, CSV and MS Office files only.";
 }
+// Result goes to toast.error(), which binds `message` with v-html, so this
+// returns ESCAPED html rather than plain text. The _server_messages branch is
+// left as-is on purpose: Frappe has already escaped that payload once, so it
+// renders correctly (and inertly) in that sink, and escaping it a second time
+// would show the entities literally.
 function uploadErrMsg(e) {
 	if (e && e._server_messages) {
 		try {
@@ -321,8 +326,7 @@ function uploadErrMsg(e) {
 			/* fall through */
 		}
 	}
-	const msg = errMessage(e);
-	return msg === "Something went wrong. Please try again." ? "Upload failed" : msg;
+	return errHtml(e, "Upload failed");
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/frontend/src/components/learning/AppLearningCard.vue
+++ b/frontend/src/components/learning/AppLearningCard.vue
@@ -80,7 +80,7 @@ import { onMounted, ref } from "vue";
 import { Button, FeatherIcon, toast } from "frappe-ui";
 import { useRouter } from "vue-router";
 import * as api from "@/api";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 import AppSourceConsentDialog from "@/components/learning/AppSourceConsentDialog.vue";
 
 const router = useRouter();
@@ -115,7 +115,7 @@ async function run(apps) {
 		pickerOpen.value = false;
 		toast.success(`Learning ${apps.length} app(s) — follow it on the agent's Runs tab`);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		running.value = false;
 	}

--- a/frontend/src/components/learning/AppSourceConsentDialog.vue
+++ b/frontend/src/components/learning/AppSourceConsentDialog.vue
@@ -108,7 +108,7 @@ import { ref, watch } from "vue";
 import { Button, Checkbox, Dialog, FeatherIcon, toast } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { listCustomApps } from "@/api/appLearning";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -134,7 +134,7 @@ async function load() {
 		apps.value = (await listCustomApps()) || [];
 	} catch (e) {
 		apps.value = [];
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		loading.value = false;
 	}

--- a/frontend/src/components/learning/InsightApplyDialog.vue
+++ b/frontend/src/components/learning/InsightApplyDialog.vue
@@ -155,7 +155,7 @@ import {
 	acknowledgeLearnedPattern,
 } from "@/api/learning";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -222,7 +222,7 @@ async function load() {
 				: "update";
 	} catch (e) {
 		if (seq !== loadSeq) return;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		emit("update:modelValue", false);
 	}
 }
@@ -292,7 +292,7 @@ async function confirmApply() {
 		emit("applied", { skill_name: skill });
 		emit("update:modelValue", false);
 	} catch (e) {
-		toast.error(errMsg(e)); // dialog stays open for retry / cancel
+		toast.error(errHtml(e)); // dialog stays open for retry / cancel
 	} finally {
 		applying.value = false;
 	}
@@ -309,7 +309,7 @@ async function acknowledgeInstead() {
 		emit("applied", { acknowledged: true });
 		emit("update:modelValue", false);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acknowledging.value = false;
 	}

--- a/frontend/src/components/learning/InsightApplyDialog.vue
+++ b/frontend/src/components/learning/InsightApplyDialog.vue
@@ -155,10 +155,7 @@ import {
 	acknowledgeLearnedPattern,
 } from "@/api/learning";
 import { agentName } from "@/branding";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },

--- a/frontend/src/components/personalise/NoteDetailModal.vue
+++ b/frontend/src/components/personalise/NoteDetailModal.vue
@@ -129,7 +129,7 @@ import JvSpinner from "@/components/JvSpinner.vue";
 import { exactDate } from "@/utils/datetime";
 import { getNote, deleteNote } from "@/api/personalise";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const router = useRouter();
 
@@ -194,7 +194,7 @@ async function load() {
 		note.value = await getNote(props.name);
 	} catch (e) {
 		show.value = false;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		loading.value = false;
 	}
@@ -216,7 +216,7 @@ function confirmDelete() {
 				toast.success("Note deleted");
 				emit("changed");
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			} finally {
 				deleting.value = false;
 			}

--- a/frontend/src/components/personalise/NoteDetailModal.vue
+++ b/frontend/src/components/personalise/NoteDetailModal.vue
@@ -129,6 +129,7 @@ import JvSpinner from "@/components/JvSpinner.vue";
 import { exactDate } from "@/utils/datetime";
 import { getNote, deleteNote } from "@/api/personalise";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const router = useRouter();
 
@@ -137,10 +138,6 @@ const props = defineProps({
 	name: { type: String, default: "" },
 });
 const emit = defineEmits(["update:modelValue", "changed", "reanswer"]);
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // Same theme map as NotesView's row badges - kept as a local copy (not a
 // shared import) because NotesView's is inline too; both are small enough

--- a/frontend/src/components/personalise/NotesView.vue
+++ b/frontend/src/components/personalise/NotesView.vue
@@ -142,12 +142,9 @@ import { listNotesPage } from "@/api/personalise";
 import JvSpinner from "@/components/JvSpinner.vue";
 import NoteDetailModal from "./NoteDetailModal.vue";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const emit = defineEmits(["reanswer"]);
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 const KIND_OPTIONS = [
 	{ label: "All", value: "" },

--- a/frontend/src/components/personalise/NotesView.vue
+++ b/frontend/src/components/personalise/NotesView.vue
@@ -142,7 +142,7 @@ import { listNotesPage } from "@/api/personalise";
 import JvSpinner from "@/components/JvSpinner.vue";
 import NoteDetailModal from "./NoteDetailModal.vue";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const emit = defineEmits(["reanswer"]);
 
@@ -216,7 +216,7 @@ async function fetchNotes(mode = "reset") {
 		notes.hasMore = !!res.has_more;
 	} catch (e) {
 		if (id !== reqId) return;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (id === reqId) notes.loading = false;
 	}

--- a/frontend/src/components/personalise/PersonalisationSettings.vue
+++ b/frontend/src/components/personalise/PersonalisationSettings.vue
@@ -348,7 +348,7 @@ import {
 } from "@/api/personalise";
 import { timeAgo } from "@/utils/datetime";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	open: { type: Boolean, default: false },
@@ -405,7 +405,7 @@ async function loadRules() {
 	try {
 		rules.value = (await listQuestionRules()) || [];
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		rulesLoading.value = false;
 	}
@@ -440,7 +440,7 @@ async function toggleActive(rule, value) {
 		toast.success(value ? "Question enabled" : "Question paused");
 	} catch (e) {
 		rule.active = prev;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		rowActing.value = "";
 	}
@@ -508,7 +508,7 @@ async function saveEditor() {
 		closeEditor();
 		await loadRules();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		editor.saving = false;
 	}
@@ -525,7 +525,7 @@ function confirmDeleteRule(rule) {
 				toast.success("Question removed");
 				loadRules();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});
@@ -557,7 +557,7 @@ async function loadSettings() {
 		settings.chat_mining_last_run_at = s.chat_mining_last_run_at || null;
 		settings.chat_mining_last_run_status = s.chat_mining_last_run_status || "";
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		settingsLoading.value = false;
 	}
@@ -578,7 +578,7 @@ async function saveSettings() {
 		settings.chat_mining_last_run_status = res.chat_mining_last_run_status || "";
 		toast.success("Settings saved");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		savingSettings.value = false;
 	}
@@ -598,7 +598,7 @@ async function generateNow() {
 			toast.info((res && res.reason) || "Already running.");
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		generatingNow.value = false;
 	}

--- a/frontend/src/components/personalise/PersonalisationSettings.vue
+++ b/frontend/src/components/personalise/PersonalisationSettings.vue
@@ -348,15 +348,12 @@ import {
 } from "@/api/personalise";
 import { timeAgo } from "@/utils/datetime";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	open: { type: Boolean, default: false },
 });
 const emit = defineEmits(["update:open"]);
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 function intOr(v, d) {
 	if (v === null || v === undefined || v === "") return d;
 	const n = Number(v);

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -252,6 +252,7 @@ import { connectionModeLabel } from "@/llm/pool";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
 import * as api from "@/api";
+import { errMessage } from "@/lib/errors";
 
 const store = useShellStore();
 
@@ -526,7 +527,12 @@ async function doReset() {
 		toast.success("Resetting your workspace.");
 		startPoll();
 	} catch (e) {
-		toast.error((e && e.messages && e.messages[0]) || "Could not reset the workspace.");
+		const msg = errMessage(e);
+		toast.error(
+			msg === "Something went wrong. Please try again."
+				? "Could not reset the workspace."
+				: msg
+		);
 	} finally {
 		resetBusy.value = false;
 	}

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -252,7 +252,7 @@ import { connectionModeLabel } from "@/llm/pool";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
 import * as api from "@/api";
-import { errMessage } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const store = useShellStore();
 
@@ -527,12 +527,7 @@ async function doReset() {
 		toast.success("Resetting your workspace.");
 		startPoll();
 	} catch (e) {
-		const msg = errMessage(e);
-		toast.error(
-			msg === "Something went wrong. Please try again."
-				? "Could not reset the workspace."
-				: msg
-		);
+		toast.error(errHtml(e, "Could not reset the workspace."));
 	} finally {
 		resetBusy.value = false;
 	}

--- a/frontend/src/components/settings/UsageAdminPane.vue
+++ b/frontend/src/components/settings/UsageAdminPane.vue
@@ -192,7 +192,7 @@ import { timeAgo } from "@/utils/datetime";
 import { modelDisplayLabel } from "@/utils/usageModel";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import * as api from "@/api";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const users = ref([]);
 const loading = ref(false);
@@ -265,7 +265,7 @@ async function saveLimit(u) {
 		u._limitDraft = u.monthly_token_limit;
 		toast.success("Limit updated");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		u._saving = false;
 	}
@@ -285,7 +285,7 @@ async function saveModelLimit(u, m) {
 		m._limitDraft = m.monthly_token_limit;
 		toast.success(`Limit updated for ${modelDisplayLabel(m.model)}`);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		m._saving = false;
 	}

--- a/frontend/src/components/settings/UsageAdminPane.vue
+++ b/frontend/src/components/settings/UsageAdminPane.vue
@@ -192,10 +192,7 @@ import { timeAgo } from "@/utils/datetime";
 import { modelDisplayLabel } from "@/utils/usageModel";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import * as api from "@/api";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
+import { errMessage as errMsg } from "@/lib/errors";
 
 const users = ref([]);
 const loading = ref(false);

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -207,16 +207,13 @@ import {
 import JvSpinner from "@/components/JvSpinner.vue";
 import PromotionRequestDialog from "@/components/skills/PromotionRequestDialog.vue";
 import PromotionStatusChip from "@/components/skills/PromotionStatusChip.vue";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
 	slug: { type: String, default: "" },
 });
 const emit = defineEmits(["update:modelValue", "refresh"]);
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 const SCOPE_THEME = { Org: "gray", Role: "blue", User: "green" };
 

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -207,7 +207,7 @@ import {
 import JvSpinner from "@/components/JvSpinner.vue";
 import PromotionRequestDialog from "@/components/skills/PromotionRequestDialog.vue";
 import PromotionStatusChip from "@/components/skills/PromotionStatusChip.vue";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -264,7 +264,7 @@ async function submitPromotion({ to_scope, target_role, note }) {
 		toast.success("Promotion requested — a reviewer will decide.");
 		await loadMyPromo();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		promoBusy.value = false;
 	}
@@ -325,7 +325,7 @@ async function load() {
 		loadMyPromo();
 	} catch (e) {
 		show.value = false;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		loading.value = false;
 	}
@@ -359,7 +359,7 @@ async function save() {
 		toast.success("Page saved");
 		emit("refresh");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		saving.value = false;
 	}
@@ -373,7 +373,7 @@ async function restore() {
 		toast.success("Page restored");
 		emit("refresh");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		archiving.value = false;
 	}
@@ -393,7 +393,7 @@ function confirmArchive() {
 				toast.success("Page archived");
 				emit("refresh");
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			} finally {
 				archiving.value = false;
 			}
@@ -414,7 +414,7 @@ function confirmDelete() {
 				toast.success("Page deleted");
 				emit("refresh");
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			} finally {
 				deleting.value = false;
 			}

--- a/frontend/src/composables/useDocmeta.js
+++ b/frontend/src/composables/useDocmeta.js
@@ -11,7 +11,7 @@ import { reactive, ref, isRef, watch } from "vue";
 import { toast } from "frappe-ui";
 import { session } from "@/data/session";
 import * as apiDocmeta from "@/api/docmeta";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 export function useDocmeta(doctype, name) {
 	// plain string (B4/B5 contract) or a ref (detail pages whose route param
@@ -42,7 +42,7 @@ export function useDocmeta(doctype, name) {
 			if (meta.value && row) meta.value.comments = [...(meta.value.comments || []), row];
 			return row || null;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return null;
 		}
 	}
@@ -57,7 +57,7 @@ export function useDocmeta(doctype, name) {
 			}
 			return true;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return false;
 		}
 	}
@@ -69,7 +69,7 @@ export function useDocmeta(doctype, name) {
 				meta.value.comments = (meta.value.comments || []).filter((c) => c.name !== id);
 			return true;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return false;
 		}
 	}
@@ -85,7 +85,7 @@ export function useDocmeta(doctype, name) {
 			meta.value.liked = likedBy.includes(session.user);
 		} catch (e) {
 			meta.value.liked = !next;
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 		}
 	}
 
@@ -101,7 +101,7 @@ export function useDocmeta(doctype, name) {
 			if (meta.value && Array.isArray(assignees)) meta.value.assignees = assignees;
 			return true;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return false;
 		}
 	}
@@ -117,7 +117,7 @@ export function useDocmeta(doctype, name) {
 			if (meta.value && Array.isArray(assignees)) meta.value.assignees = assignees;
 			return true;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return false;
 		}
 	}
@@ -133,7 +133,7 @@ export function useDocmeta(doctype, name) {
 			}
 			return true;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return false;
 		}
 	}
@@ -149,7 +149,7 @@ export function useDocmeta(doctype, name) {
 			}
 			return true;
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 			return false;
 		}
 	}

--- a/frontend/src/composables/useDocmeta.js
+++ b/frontend/src/composables/useDocmeta.js
@@ -11,10 +11,7 @@ import { reactive, ref, isRef, watch } from "vue";
 import { toast } from "frappe-ui";
 import { session } from "@/data/session";
 import * as apiDocmeta from "@/api/docmeta";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
+import { errMessage as errMsg } from "@/lib/errors";
 
 export function useDocmeta(doctype, name) {
 	// plain string (B4/B5 contract) or a ref (detail pages whose route param

--- a/frontend/src/composables/useListPage.js
+++ b/frontend/src/composables/useListPage.js
@@ -17,6 +17,7 @@ import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from "vue"
 import { useStorage } from "@vueuse/core";
 import { toast } from "frappe-ui";
 import * as api from "@/api";
+import { errMessage as errMsg } from "@/lib/errors";
 import {
 	URL_PARAM,
 	schemaIndex,
@@ -42,10 +43,6 @@ import {
 	ERR_VIEW_NOT_FILTERABLE,
 	ERR_VIEW_ROLLED_BACK,
 } from "@/components/list/filterModel";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 export function useListPage({
 	fetchFn,

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -803,7 +803,7 @@ test("the promotion is validated against the transcript, not the link", () => {
 	// a message that is gone, or never drew html, says so and leaves the builder
 	// as it was
 	assert.match(promote, /if \(!frame\) \{\n\t\tgiveUp\(/);
-	assert.match(promote, /giveUp\(errMsg\(e\)\);/);
+	assert.match(promote, /giveUp\(errHtml\(e\)\);/);
 	const giveUp = promote.slice(promote.indexOf("const giveUp = "));
 	assert.match(giveUp, /stripPromotionQuery\(\);/);
 	assert.match(giveUp, /if \(fallback\) fallback\(\);/);
@@ -1073,7 +1073,7 @@ test("an adoption whose artifact is gone falls back to the row it adopted", () =
 	assert.match(edit, /canvasMsg\.value = "";/);
 	// a live frame's failure is untouched — it toasts, and there is no stale
 	// identity to fall back from
-	assert.match(onCanvas, /else toast\.error\(errMsg\(e\)\);/);
+	assert.match(onCanvas, /else toast\.error\(errHtml\(e\)\);/);
 });
 
 test("a promotion that would cost the user something confirms first", () => {

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -127,7 +127,7 @@ test("a restore never overwrites a live canvas, an ?edit target or a promotion",
 	// re-checked AFTER the get_canvas round trip, not just before it
 	assert.equal((onCanvas.match(new RegExp(guard.source, "g")) || []).length, 2);
 	// a failed replay is silent; only a live frame's failure is surfaced
-	assert.match(onCanvas, /else toast\.error\(errMsg\(e\)\);/);
+	assert.match(onCanvas, /else toast\.error\(errHtml\(e\)\);/);
 });
 
 test("an unreadable artifact is retried never, not on every transcript load", () => {

--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -32,7 +32,16 @@ function isInternalCrash(e) {
 // wrapping tags via a detached element (never inserted into the live DOM, so
 // nothing in the message - script/img/etc. - ever executes) before handing
 // the string to a caller.
-export function errMessage(e) {
+// The sentence shown when the error carries nothing specific. Exported so a
+// caller never has to spell it out to detect it: an earlier pass at #699 gave
+// each site a custom fallback by comparing errMessage()'s RESULT against this
+// literal, which put 6 fresh copies of the string into components - the exact
+// duplication #699 exists to remove, and one that would have failed silently
+// (falling back to the generic sentence) the day the wording changed. Pass the
+// custom sentence in as `fallback` instead.
+export const GENERIC_ERROR_MESSAGE = "Something went wrong. Please try again.";
+
+export function errMessage(e, fallback = GENERIC_ERROR_MESSAGE) {
 	// The server's OWN explicit message always wins, even on a 401/403 (round-4
 	// review F1): frappe.throw("You do not have permission to disconnect this
 	// model") is a real, actionable remedy, and burying it under a blanket
@@ -43,13 +52,40 @@ export function errMessage(e) {
 	// Only once there is nothing specific to show does a 401/403 get named
 	// plainly, since an expired session / logged-out tab / permission change is
 	// still the single most likely cause of an error this formatter otherwise
-	// cannot explain.
+	// cannot explain. This outranks `fallback` deliberately: "sign in again" is
+	// an actionable remedy, a caller's "Could not save." is not.
 	if (!specific && e && (e.status === 401 || e.status === 403)) {
 		return "Your session has expired. Please sign in again.";
 	}
-	const raw = specific || "Something went wrong. Please try again.";
+	const raw = specific || fallback;
 	if (typeof document === "undefined") return raw;
 	const d = document.createElement("div");
 	d.innerHTML = raw; // decodes &gt; &amp; &#39; etc; detached, so no script/img runs
 	return (d.textContent || d.innerText || raw).trim();
+}
+
+// errMessage() returns PLAIN TEXT: it decodes entities so a text sink renders
+// "Settings -> Developer" rather than "Settings -&gt; Developer". That decode is
+// unsafe in an HTML sink, and frappe-ui's Toast is one - Toast.vue binds its
+// `message` prop with `v-html`. So the round trip through a toast is:
+//
+//   frappe.throw(user_value)  ->  server escapes once  ->  "&lt;img onerror=...&gt;"
+//   errMessage()              ->  decodes              ->  "<img onerror=...>"
+//   toast.error(...)          ->  v-html re-parses     ->  a LIVE <img> element
+//
+// The escaping that made the value safe is exactly what errMessage() removes,
+// so the plain text has to be re-escaped on its way into an HTML sink. Use this
+// for toast.*() and any other v-html binding; use errMessage() for `{{ }}`,
+// textContent, and ChatView's own notify(), which interpolate as text.
+// The single escape implementation in the frontend. pages/skills/escapeHtml.js
+// re-exports this as `esc`, which is the name the skills review flow already
+// imports at its own v-html sink (frappe-ui's ConfirmDialog).
+const HTML_ESCAPES = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+export function escapeHtml(v) {
+	// One pass over the string, so the "&" rewritten for "<" is never re-escaped.
+	return String(v ?? "").replace(/[&<>"']/g, (c) => HTML_ESCAPES[c]);
+}
+
+export function errHtml(e, fallback) {
+	return escapeHtml(errMessage(e, fallback));
 }

--- a/frontend/src/lib/noInlineErrorFormatter.test.js
+++ b/frontend/src/lib/noInlineErrorFormatter.test.js
@@ -5,12 +5,20 @@
 // reproduction command used and fails the moment a new copy appears anywhere
 // outside lib/errors.js itself.
 //
-// One exception is intentional and pinned to an exact file+line below:
+// One exception is intentional and pinned by its exact source line below:
 // SaveDashboardDialog.vue's isThemeError() reads the first entry of the
 // server's message array to pattern-match its text for CONTROL FLOW (deciding
 // whether to offer a "fix in chat" hand-off), not to display it - flattening
 // that into errMessage() would be the exact mistake #699 warned against, so
 // it is left alone on purpose.
+//
+// The second test here guards the OTHER half of the same lesson. errMessage()
+// returns plain text: it decodes the entities Frappe escaped, which is right
+// for a `{{ }}` sink and wrong for an HTML one. frappe-ui's Toast binds its
+// `message` prop with v-html, so a message routed there has to go through
+// errHtml() instead, or the decode hands the sink live markup that the server
+// had already made safe. Both rules exist because the safe call is invisible
+// at the call site - only a test makes the wrong one loud.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -24,8 +32,23 @@ const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 // zero-index array access - regardless of what wraps it.
 const BANNED_PATTERN = /\.messages\s*(\?\.)?\s*(&&)?\s*\[0\]/;
 
-// file (relative to src/) -> allowed line numbers (1-based) for the pattern.
-const ALLOWED = new Map([["pages/dashboards/SaveDashboardDialog.vue", new Set([122])]]);
+// A toast whose text comes from the plain-text formatter rather than the
+// escaping one. Matched on a single line, which covers every shape in the tree
+// today (the direct `toast.error(errMsg(e))` and the one template-literal
+// case); a call split across lines would slip past, so this is a ratchet
+// against regrowth, not a proof of absence.
+const TOAST_CALL = /toast\.[a-zA-Z]+\(/;
+const PLAIN_FORMATTER_CALL = /\b(errMessage|errMsg|_err)\s*\(/;
+
+// file (relative to src/) -> the exact trimmed source lines allowed to carry
+// the pattern. Pinned by TEXT, not line number, so an edit elsewhere in the
+// file cannot turn this guard red for no reason.
+const ALLOWED = new Map([
+	[
+		"pages/dashboards/SaveDashboardDialog.vue",
+		new Set(['const m = (e.messages && e.messages[0]) || e.message || "";']),
+	],
+]);
 
 function walk(dir, out) {
 	for (const entry of readdirSync(dir)) {
@@ -51,8 +74,12 @@ test("no inline duplicate of the pre-#696 error formatter exists outside lib/err
 		lines.forEach((line, i) => {
 			if (!BANNED_PATTERN.test(line)) return;
 			if (rel === "lib/errors.js") return; // the canonical implementation
-			const allowedLines = ALLOWED.get(rel);
-			if (allowedLines && allowedLines.has(i + 1)) return; // pinned exception
+			// This file quotes the banned shape twice on purpose: once in the
+			// ALLOWED pin above and once in the regex. Skipping it keeps the
+			// guard from matching its own definition.
+			if (rel === "lib/noInlineErrorFormatter.test.js") return;
+			const allowed = ALLOWED.get(rel);
+			if (allowed && allowed.has(line.trim())) return; // pinned exception
 			offenders.push(`${rel}:${i + 1}: ${line.trim()}`);
 		});
 	}
@@ -63,5 +90,31 @@ test("no inline duplicate of the pre-#696 error formatter exists outside lib/err
 		"Found a copy of the pre-#696 error formatter outside lib/errors.js. Import " +
 			'errMessage from "@/lib/errors" instead of re-deriving a display message ' +
 			"from the server's error shape inline (jarvis#699)."
+	);
+});
+
+test("no toast is fed by the plain-text formatter (Toast renders `message` via v-html)", () => {
+	const offenders = [];
+
+	for (const file of walk(SRC_DIR, [])) {
+		const rel = path.relative(SRC_DIR, file).split(path.sep).join("/");
+		if (rel === "lib/errors.js" || rel.endsWith(".test.js")) continue;
+		readFileSync(file, "utf8")
+			.split("\n")
+			.forEach((line, i) => {
+				if (!TOAST_CALL.test(line)) return;
+				if (!PLAIN_FORMATTER_CALL.test(line)) return;
+				offenders.push(`${rel}:${i + 1}: ${line.trim()}`);
+			});
+	}
+
+	assert.deepEqual(
+		offenders,
+		[],
+		"A toast is being given text from errMessage(), which DECODES the entities " +
+			"Frappe escaped. frappe-ui's Toast binds `message` with v-html, so that " +
+			"decoded text is re-parsed as markup and the server's escaping is undone. " +
+			'Use errHtml() from "@/lib/errors" for toasts; errMessage() is for text ' +
+			"sinks only (jarvis#699)."
 	);
 });

--- a/frontend/src/lib/noInlineErrorFormatter.test.js
+++ b/frontend/src/lib/noInlineErrorFormatter.test.js
@@ -1,0 +1,67 @@
+// Guard for #699: 42 inline copies of the pre-#696 error formatter, spread
+// across 38 files, never called the shared errMessage() fix from #696 and
+// could still paint frappe-ui's raw internal-crash TypeError text straight at
+// a customer. This test greps the whole src tree for the SAME shape the #699
+// reproduction command used and fails the moment a new copy appears anywhere
+// outside lib/errors.js itself.
+//
+// One exception is intentional and pinned to an exact file+line below:
+// SaveDashboardDialog.vue's isThemeError() reads the first entry of the
+// server's message array to pattern-match its text for CONTROL FLOW (deciding
+// whether to offer a "fix in chat" hand-off), not to display it - flattening
+// that into errMessage() would be the exact mistake #699 warned against, so
+// it is left alone on purpose.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The reproduction command from jarvis#699, unchanged: a property read of
+// `messages` immediately followed by an optional `?.` or `&&`, then a
+// zero-index array access - regardless of what wraps it.
+const BANNED_PATTERN = /\.messages\s*(\?\.)?\s*(&&)?\s*\[0\]/;
+
+// file (relative to src/) -> allowed line numbers (1-based) for the pattern.
+const ALLOWED = new Map([["pages/dashboards/SaveDashboardDialog.vue", new Set([122])]]);
+
+function walk(dir, out) {
+	for (const entry of readdirSync(dir)) {
+		if (entry === "node_modules") continue;
+		const full = path.join(dir, entry);
+		const st = statSync(full);
+		if (st.isDirectory()) {
+			walk(full, out);
+		} else if (/\.(js|vue)$/.test(entry)) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+test("no inline duplicate of the pre-#696 error formatter exists outside lib/errors.js", () => {
+	const files = walk(SRC_DIR, []);
+	const offenders = [];
+
+	for (const file of files) {
+		const rel = path.relative(SRC_DIR, file).split(path.sep).join("/");
+		const lines = readFileSync(file, "utf8").split("\n");
+		lines.forEach((line, i) => {
+			if (!BANNED_PATTERN.test(line)) return;
+			if (rel === "lib/errors.js") return; // the canonical implementation
+			const allowedLines = ALLOWED.get(rel);
+			if (allowedLines && allowedLines.has(i + 1)) return; // pinned exception
+			offenders.push(`${rel}:${i + 1}: ${line.trim()}`);
+		});
+	}
+
+	assert.deepEqual(
+		offenders,
+		[],
+		"Found a copy of the pre-#696 error formatter outside lib/errors.js. Import " +
+			'errMessage from "@/lib/errors" instead of re-deriving a display message ' +
+			"from the server's error shape inline (jarvis#699)."
+	);
+});

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -512,7 +512,7 @@ import { timeAgo, exactDate as fmtDt } from "@/utils/datetime";
 import * as api from "@/api";
 import * as apiAgents from "@/api/agents";
 import { renderMarkdown } from "@/markdown";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	slug: { type: String, required: true },
@@ -763,7 +763,7 @@ async function startRun(sourceApps) {
 		if (runsBoard.value) runsBoard.value.reload({ selectNewest: true });
 		load(); // refresh last_run_at etc. in the background
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		running.value = false;
 	}
@@ -784,7 +784,7 @@ function confirmUninstall() {
 				toast.success(`${agent.value.title} uninstalled`);
 				router.push({ name: "AgentsList" });
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});
@@ -798,7 +798,7 @@ async function setEnabled(v) {
 		await api.setAgentEnabled(installation.value.name, v ? 1 : 0);
 		await load();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		togglingEnabled.value = false;
 	}
@@ -895,7 +895,7 @@ async function saveSchedule() {
 		toast.success("Schedule saved");
 		await load();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		savingSchedule.value = false;
 	}
@@ -925,7 +925,7 @@ async function saveConfig(merged) {
 		toast.success("Configuration saved");
 		await load();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		savingConfig.value = false;
 	}
@@ -945,7 +945,7 @@ async function loadAdmin() {
 	try {
 		adminData.value = (await api.getAgentAdminOverview()) || null;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		adminLoading.value = false;
 	}
@@ -1007,7 +1007,7 @@ async function saveRoles() {
 		);
 		load(); // refresh allowed/lock state
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		savingRoles.value = false;
 	}

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -512,6 +512,7 @@ import { timeAgo, exactDate as fmtDt } from "@/utils/datetime";
 import * as api from "@/api";
 import * as apiAgents from "@/api/agents";
 import { renderMarkdown } from "@/markdown";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	slug: { type: String, required: true },
@@ -519,10 +520,6 @@ const props = defineProps({
 
 const route = useRoute();
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // display metadata (mirrors AgentsList / registry.json domains)
 const DOMAINS = [

--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -279,13 +279,10 @@ import { useListPage } from "@/composables/useListPage";
 import * as api from "@/api";
 import * as agentsApi from "@/api/agents";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // Display metadata mirroring jarvis/agents/registry.json domains (unknown slugs
 // fall back to a prettified slug).

--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -279,7 +279,7 @@ import { useListPage } from "@/composables/useListPage";
 import * as api from "@/api";
 import * as agentsApi from "@/api/agents";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
@@ -504,7 +504,7 @@ async function applyCatalog() {
 		startSyncPoll();
 		return true;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		return false;
 	} finally {
 		applying.value = false;

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -299,6 +299,7 @@ import { timeAgo, exactDate, formatDate } from "@/utils/datetime";
 import { renderMarkdown } from "@/markdown";
 import * as api from "@/api";
 import { takeFindingToChat } from "@/api/agents";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	// full row from list_runs_page: {name, status, trigger, started_at,
@@ -313,10 +314,6 @@ const props = defineProps({
 });
 
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 const STATUS_THEME = { running: "blue", completed: "green", partial: "orange", failed: "red" };
 const SEVERITY_THEME = { blocker: "red", warning: "orange", note: "gray" };

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -299,7 +299,7 @@ import { timeAgo, exactDate, formatDate } from "@/utils/datetime";
 import { renderMarkdown } from "@/markdown";
 import * as api from "@/api";
 import { takeFindingToChat } from "@/api/agents";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	// full row from list_runs_page: {name, status, trigger, started_at,
@@ -528,7 +528,7 @@ async function moveFinding(f, state) {
 		}
 	} catch (e) {
 		f.state = prev;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		busy.value = "";
 	}
@@ -545,7 +545,7 @@ async function discussInChat(f) {
 		}
 		router.push("/c/" + res.conversation);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		chatBusy.value = "";
 	}

--- a/frontend/src/pages/approvals/ApprovalsBoard.vue
+++ b/frontend/src/pages/approvals/ApprovalsBoard.vue
@@ -511,14 +511,11 @@ import { timeAgo, exactDate } from "@/utils/datetime";
 import { getApproval } from "@/api/approvals";
 import * as api from "@/api";
 import { renderMarkdown } from "@/markdown";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
 const store = useShellStore();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── rail config ──────────────────────────────────────────────────────────────
 // "Answered" = a chat ask the user resolved IN CHAT (chat_asks.resolve_on_

--- a/frontend/src/pages/approvals/ApprovalsBoard.vue
+++ b/frontend/src/pages/approvals/ApprovalsBoard.vue
@@ -511,7 +511,7 @@ import { timeAgo, exactDate } from "@/utils/datetime";
 import { getApproval } from "@/api/approvals";
 import * as api from "@/api";
 import { renderMarkdown } from "@/markdown";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
@@ -872,7 +872,7 @@ async function submitDecide(approve) {
 			docmeta.reload();
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		deciding.value = null;
 	}
@@ -908,7 +908,7 @@ async function submitDismiss() {
 		if ((filters.status || "Pending") === "Pending") advanceAfterDecide(id);
 		else loadRecord(id, { keep: true });
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		dismissing.value = false;
 	}
@@ -928,7 +928,7 @@ async function submitRestore() {
 		if ((filters.status || "Pending") === "Dismissed") advanceAfterDecide(id);
 		else loadRecord(id, { keep: true });
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		restoring.value = false;
 	}

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -73,6 +73,7 @@ import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc";
 import { THEMES, DEFAULT_THEME, themeKey } from "@/lib/dashboardThemes";
 import { loadCaptureLib, downloadPng, downloadPdf } from "@/lib/dashboardExport";
 import { runDashboardSource, callDashboardTool } from "@/api/dashboards";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	mode: { type: String, default: "builder" }, // "builder" | "view"
@@ -95,10 +96,6 @@ const loading = ref(false);
 const building = ref(false);
 const buildError = ref("");
 const frameH = ref(480); // view mode: grown by the iframe's height frames
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 function postToFrame(msg) {
 	const fw = frame.value && frame.value.contentWindow;

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -217,7 +217,7 @@ import { session } from "@/data/session";
 import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards";
 import { listPendingConfirmations, confirmTool, dismissTool } from "@/api";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 // get_dashboards_caps payload (creatable_scopes/manageable_roles feed the save
 // dialog; stt_enabled - when the backend sends it - gates the mic)
@@ -454,7 +454,7 @@ async function approve(pa) {
 		}
 	} catch (e) {
 		keepCard = true;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (keepCard) pa.busy = false;
 		else removeCard(pa.token);
@@ -476,7 +476,7 @@ async function dismiss(pa) {
 		}
 	} catch (e) {
 		keepCard = true;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (keepCard) pa.busy = false;
 		else removeCard(pa.token);
@@ -575,7 +575,7 @@ async function send() {
 	} catch (e) {
 		messages.value = messages.value.filter((m) => m.name !== tmpName);
 		if (!draft.value) draft.value = text;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		sending.value = false;
 	}

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -217,6 +217,7 @@ import { session } from "@/data/session";
 import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards";
 import { listPendingConfirmations, confirmTool, dismissTool } from "@/api";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 // get_dashboards_caps payload (creatable_scopes/manageable_roles feed the save
 // dialog; stt_enabled - when the backend sends it - gates the mic)
@@ -239,10 +240,6 @@ const router = useRouter();
 const socket = inject("$socket", null);
 // AskCard styles with the jv-* tokens, which this frappe-ui page does not bind.
 const { paletteVars } = useJarvisTheme();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── conversation persistence (per user, ChatComposer's namespacing idiom) ────
 const conversation = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "");

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -181,16 +181,13 @@ import { getDashboard, getDashboardsCaps, deleteDashboard, saveDashboard } from 
 import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes";
 import DashboardCanvas from "./DashboardCanvas.vue";
 import SaveDashboardDialog from "./SaveDashboardDialog.vue";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, required: true },
 });
 
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 const detail = ref(null);
 const loading = ref(true);

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -181,7 +181,7 @@ import { getDashboard, getDashboardsCaps, deleteDashboard, saveDashboard } from 
 import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes";
 import DashboardCanvas from "./DashboardCanvas.vue";
 import SaveDashboardDialog from "./SaveDashboardDialog.vue";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, required: true },
@@ -216,7 +216,7 @@ async function pickTheme(key) {
 		await saveDashboard({ name: detail.value.name, theme: themeLabel(key) });
 		detail.value.theme = themeLabel(key);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -274,7 +274,7 @@ async function doExport(format) {
 	try {
 		await canvas.value.exportAs(format, detail.value && detail.value.dashboard_title);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		exporting.value = false;
 	}
@@ -301,7 +301,7 @@ const deleteDialogOptions = computed(() => {
 						toast.success("Dashboard deleted");
 						goBack();
 					} catch (e) {
-						toast.error(errMsg(e));
+						toast.error(errHtml(e));
 					}
 				},
 			},

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -223,7 +223,7 @@ import DashboardCanvas from "./DashboardCanvas.vue";
 import DashboardChatPane from "./DashboardChatPane.vue";
 import SavedDashboardsTab from "./SavedDashboardsTab.vue";
 import SaveDashboardDialog from "./SaveDashboardDialog.vue";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
@@ -427,7 +427,7 @@ async function onCanvas({ message_id, items, restore }) {
 		// A restore is best-effort background work the user did not ask for -
 		// a deleted/expired artifact must not raise a toast on page load.
 		if (restore) restoreFailed(message_id);
-		else toast.error(errMsg(e));
+		else toast.error(errHtml(e));
 		return false;
 	}
 }
@@ -665,7 +665,7 @@ async function loadEdit(name, { deepLink = true } = {}) {
 	} catch (e) {
 		// A restored target that has since been deleted is not the user's doing -
 		// forget it silently instead of toasting on every page load.
-		if (deepLink) toast.error(errMsg(e));
+		if (deepLink) toast.error(errHtml(e));
 		else editingSticky.value = "";
 		settle();
 	}

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -223,13 +223,10 @@ import DashboardCanvas from "./DashboardCanvas.vue";
 import DashboardChatPane from "./DashboardChatPane.vue";
 import SavedDashboardsTab from "./SavedDashboardsTab.vue";
 import SaveDashboardDialog from "./SaveDashboardDialog.vue";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 const TABS = [
 	{ label: "Builder", value: "builder" },

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -813,6 +813,8 @@ async function promoteFromChat(conversation, messageId, { fallback = null, dash 
 	// restore would stay blocked for the life of the page. Still synchronous,
 	// nothing awaits above it, so the pane's restore cannot slip in first.
 	promotionPending.value = true;
+	// `msg` lands in a toast, which binds `message` with v-html, so anything
+	// derived from a server error must arrive here already escaped (errHtml).
 	const giveUp = (msg) => {
 		if (msg) toast.error(msg);
 		promotionPending.value = false;
@@ -831,7 +833,7 @@ async function promoteFromChat(conversation, messageId, { fallback = null, dash 
 		const d = (await getDashboardConversation(conversation)) || {};
 		frame = builderCanvasFrame(d.messages || [], messageId);
 	} catch (e) {
-		giveUp(errMsg(e));
+		giveUp(errHtml(e));
 		return;
 	}
 	if (!frame) {

--- a/frontend/src/pages/dashboards/SaveDashboardDialog.vue
+++ b/frontend/src/pages/dashboards/SaveDashboardDialog.vue
@@ -96,6 +96,7 @@ import { reactive, ref, computed, watch } from "vue";
 import { Badge, Button, Dialog, ErrorMessage, FormControl } from "frappe-ui";
 import { saveDashboard } from "@/api/dashboards";
 import { themeLabel } from "@/lib/dashboardThemes";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -112,10 +113,6 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["update:modelValue", "saved", "fix-in-chat"]);
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // A theme-standard rejection (ThemeStandardError) is recoverable via the model:
 // surface the human messages AND offer a one-click hand-off to the builder chat.

--- a/frontend/src/pages/files/FilesList.vue
+++ b/frontend/src/pages/files/FilesList.vue
@@ -194,7 +194,7 @@ import { useShellStore } from "@/stores/shell";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as api from "@/api";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
@@ -403,7 +403,7 @@ function bulkDelete(selections, unselectAll) {
 				resetLoad();
 				store.refreshApprovalsCount();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});
@@ -423,7 +423,7 @@ function clearProcessed() {
 				hideDialog();
 				resetLoad();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/files/FilesList.vue
+++ b/frontend/src/pages/files/FilesList.vue
@@ -194,14 +194,11 @@ import { useShellStore } from "@/stores/shell";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as api from "@/api";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const route = useRoute();
 const router = useRouter();
 const store = useShellStore();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── list config ──────────────────────────────────────────────────────────────
 const STATUS_BADGE = {

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -198,6 +198,7 @@ import { takeMacroPrefill } from "@/composables/macroPrefill";
 import { exactDate } from "@/utils/datetime";
 import * as api from "@/api";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, default: "" },
@@ -213,10 +214,6 @@ const FREQUENCY_OPTIONS = [
 	{ label: "Weekly", value: "weekly" },
 	{ label: "Monthly", value: "monthly" },
 ];
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── state ────────────────────────────────────────────────────────────────────
 const macro = ref(null); // last server copy (null while new)

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -198,7 +198,7 @@ import { takeMacroPrefill } from "@/composables/macroPrefill";
 import { exactDate } from "@/utils/datetime";
 import * as api from "@/api";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, default: "" },
@@ -452,7 +452,7 @@ async function save() {
 			await reloadMacro(); // picks up merge_status / cleared summary / next_run_at
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		saving.value = false;
 	}
@@ -469,7 +469,7 @@ async function run() {
 		// hand off to the chat - the live macro banner is ChatView's machinery
 		if (data.conversation) router.push("/c/" + data.conversation);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		running.value = false;
 	}
@@ -484,7 +484,7 @@ async function resummarize() {
 			type: "info",
 		});
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -502,7 +502,7 @@ function confirmDelete() {
 				toast.success("Macro deleted");
 				router.push({ name: "MacrosList" });
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -143,6 +143,7 @@ import RunsTab from "./RunsTab.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as api from "@/api";
 import * as apiMacros from "@/api/macros";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	tab: { type: String, default: "macros" }, // 'runs' on /macros/runs (§9)
@@ -154,10 +155,6 @@ const router = useRouter();
 // Macros tab's filters (judgment C08-7).
 const route = useRoute();
 const socket = inject("$socket");
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── tabs (synced to the route, D32-friendly: real URLs per tab) ──────────────
 const TABS = [

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -143,7 +143,7 @@ import RunsTab from "./RunsTab.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as api from "@/api";
 import * as apiMacros from "@/api/macros";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	tab: { type: String, default: "macros" }, // 'runs' on /macros/runs (§9)
@@ -270,7 +270,7 @@ async function runRow(row) {
 		// hand off to the chat - the live macro banner is ChatView's machinery
 		if (data.conversation) router.push("/c/" + data.conversation);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		runningRow.value = "";
 	}
@@ -303,7 +303,7 @@ function bulkDelete(selections, unselectAll) {
 				hideDialog();
 				resetLoad();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/macros/RunsTab.vue
+++ b/frontend/src/pages/macros/RunsTab.vue
@@ -166,7 +166,7 @@ import {
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as api from "@/api";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const router = useRouter();
 const socket = inject("$socket");
@@ -264,7 +264,7 @@ async function fetchRuns(mode = "reset") {
 		total.value = res.total != null ? res.total : null;
 	} catch (e) {
 		if (id !== reqId) return;
-		toast.error(errMsg(e)); // keep last-good rows visible
+		toast.error(errHtml(e)); // keep last-good rows visible
 	} finally {
 		if (id === reqId && mode !== "keep") loading.value = false;
 	}
@@ -321,7 +321,7 @@ async function stopRun(row) {
 		fetchRuns("keep");
 		loadStats();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 

--- a/frontend/src/pages/macros/RunsTab.vue
+++ b/frontend/src/pages/macros/RunsTab.vue
@@ -166,13 +166,10 @@ import {
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as api from "@/api";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const router = useRouter();
 const socket = inject("$socket");
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── list config ──────────────────────────────────────────────────────────────
 const STATUS_OPTIONS = [

--- a/frontend/src/pages/skills/AnalysisTab.vue
+++ b/frontend/src/pages/skills/AnalysisTab.vue
@@ -303,13 +303,10 @@ import {
 	getLearningStatus,
 } from "@/api/learning";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const emit = defineEmits(["changed"]);
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── state ────────────────────────────────────────────────────────────────────
 const savingSettings = ref(false);

--- a/frontend/src/pages/skills/AnalysisTab.vue
+++ b/frontend/src/pages/skills/AnalysisTab.vue
@@ -303,7 +303,7 @@ import {
 	getLearningStatus,
 } from "@/api/learning";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const emit = defineEmits(["changed"]);
 const router = useRouter();
@@ -382,7 +382,7 @@ async function loadStatus() {
 		status.latestRun = st.latest_run || null;
 	} catch (e) {
 		// parent mounts this only for SMs; a failure here means no access
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -396,7 +396,7 @@ async function loadSettings() {
 		settings.pattern_max_proposals_per_run = intOr(s.pattern_max_proposals_per_run, 10);
 		settings.pattern_row_budget_per_night = intOr(s.pattern_row_budget_per_night, 500000);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -445,7 +445,7 @@ async function saveSettings() {
 		toast.success("Settings saved");
 		loadStatus();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		savingSettings.value = false;
 	}
@@ -469,7 +469,7 @@ function runNow() {
 				loadStatus();
 				emit("changed");
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			} finally {
 				runningNow.value = false;
 			}

--- a/frontend/src/pages/skills/PersonaliseTab.vue
+++ b/frontend/src/pages/skills/PersonaliseTab.vue
@@ -330,7 +330,7 @@ import {
 import { renderMarkdown } from "@/markdown";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const PAGE = 20;
 
@@ -430,7 +430,7 @@ async function fetchQuestions(mode = "reset") {
 		board.total = r.total || 0;
 		board.hasMore = !!r.has_more;
 	} catch (e) {
-		if (my === reqId) toast.error(errMsg(e));
+		if (my === reqId) toast.error(errHtml(e));
 	} finally {
 		if (my === reqId) board.loading = false;
 	}
@@ -474,7 +474,7 @@ async function ignore(row) {
 		fetchQuestions("reset");
 		loadCaps();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -493,7 +493,7 @@ function confirmDelete(row) {
 				fetchQuestions("reset");
 				loadCaps();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});
@@ -516,7 +516,7 @@ async function onSubmit(payload) {
 		if (wasQuestion) fetchQuestions("reset");
 		loadCaps();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		submitting.value = false;
 	}
@@ -540,7 +540,7 @@ async function onReanswer(payload) {
 		full = await getQuestion(name);
 	} catch (e) {
 		if (isDoesNotExist(e)) toast.error("This question is no longer available");
-		else toast.error(errMsg(e));
+		else toast.error(errHtml(e));
 		return; // stay on the Notes view
 	}
 	subTab.value = "questions";

--- a/frontend/src/pages/skills/PersonaliseTab.vue
+++ b/frontend/src/pages/skills/PersonaliseTab.vue
@@ -330,6 +330,7 @@ import {
 import { renderMarkdown } from "@/markdown";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const PAGE = 20;
 
@@ -354,10 +355,6 @@ const props = defineProps({
 	// optional seed from SkillsPage (F1); the tab refetches caps on mount too.
 	caps: { type: Object, default: () => ({}) },
 });
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── caps ─────────────────────────────────────────────────────────────────────
 const caps = reactive({

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -1820,7 +1820,7 @@ import { humaniseSyncStatus } from "@/lib/syncStatus";
 // Session user: a reviewer who is ALSO the requester can't decide their own
 // request (four-eyes); we disable + explain up front (SAR-4 / SPX-4).
 import { session } from "@/data/session";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const emit = defineEmits(["changed"]);
 const router = useRouter();
@@ -2117,7 +2117,7 @@ async function loadStatus() {
 		pendingCandidates.value = st.pending_patterns || 0;
 	} catch (e) {
 		// parent mounts this only for the reviewer set; a failure here = no access
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 	// Best-effort Analysis niceties for reviewers who ALSO hold the admin role:
 	// the empty-state "enable learning" copy + the Apply dialog's quiet-window
@@ -2157,7 +2157,7 @@ async function fetchPromotions(mode = "reset") {
 		promoLoaded.value = true;
 	} catch (e) {
 		if (id !== promoReq) return;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (id === promoReq) promo.loading = false;
 	}
@@ -2233,7 +2233,7 @@ async function decidePromo(p, approve, note) {
 		emit("changed");
 		return true;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		return false;
 	} finally {
 		promoActing.value = "";
@@ -2264,7 +2264,7 @@ async function fetchSkillPromotions(mode = "reset") {
 		skillPromoLoaded.value = true;
 	} catch (e) {
 		if (id !== skillPromoReq) return;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (id === skillPromoReq) skillPromo.loading = false;
 	}
@@ -2373,7 +2373,7 @@ async function decideSkillPromo(p, approve, note, ackProjection = null) {
 	} catch (e) {
 		// Four-eyes (a reviewer cannot approve their OWN request) + reviewer-gate
 		// come back as a PermissionError - surface the honest server message.
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		return false;
 	} finally {
 		skillPromoActing.value = "";
@@ -2401,7 +2401,7 @@ async function submitAsk() {
 		toast.success("Added to their questions");
 		askDialog.show = false;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		askDialog.sending = false;
 	}
@@ -2453,7 +2453,7 @@ async function fetchBoard(mode = "reset") {
 		reviewActivity.value = res.review_activity || { decided: 0, total: 0, last_by_name: "" };
 	} catch (e) {
 		if (id !== boardReq) return;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (id === boardReq) board.loading = false;
 	}
@@ -2482,7 +2482,7 @@ async function fetchDecided(mode = "reset") {
 		decided.hasMore = !!res.has_more;
 	} catch (e) {
 		if (id !== decidedReq) return;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		if (id === decidedReq) decided.loading = false;
 	}
@@ -2541,7 +2541,7 @@ async function toggleExpand(name) {
 		expanded[name] = await getLearnedPattern(name);
 	} catch (e) {
 		delete expanded[name];
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 async function toggleDecidedExpand(name) {
@@ -2554,7 +2554,7 @@ async function toggleDecidedExpand(name) {
 		dExpanded[name] = await getLearnedPattern(name);
 	} catch (e) {
 		delete dExpanded[name];
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -2628,7 +2628,7 @@ async function goToChat(kind, name, patternRow) {
 			router.push("/");
 			return;
 		}
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -2648,7 +2648,7 @@ async function doBatchApprove() {
 		toast.success(`Approved ${r.count || selectedNames.value.length}`);
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2668,7 +2668,7 @@ async function doApprove(row) {
 		toast.success("Approved");
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2680,7 +2680,7 @@ async function doUnapprove(row) {
 		toast.success("Un-approved");
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2692,7 +2692,7 @@ async function doAcknowledge(row) {
 		toast.success("Acknowledged");
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2704,7 +2704,7 @@ async function doRestore(row) {
 		toast.success("Restored");
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2719,7 +2719,7 @@ async function doSnooze(row, days) {
 		toast.success(`Snoozed ${days} days`);
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2744,7 +2744,7 @@ async function submitReject() {
 		rejectDialog.show = false;
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2772,7 +2772,7 @@ async function submitEdit() {
 		editDialog.show = false;
 		afterAction();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		acting.value = "";
 	}
@@ -2798,7 +2798,7 @@ async function confirmApply() {
 		fetchBoard("reset");
 		emit("changed");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -1820,13 +1820,10 @@ import { humaniseSyncStatus } from "@/lib/syncStatus";
 // Session user: a reviewer who is ALSO the requester can't decide their own
 // request (four-eyes); we disable + explain up front (SAR-4 / SPX-4).
 import { session } from "@/data/session";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const emit = defineEmits(["changed"]);
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── static config ────────────────────────────────────────────────────────────
 const STATUS_OPTIONS = [

--- a/frontend/src/pages/skills/ShareDialog.vue
+++ b/frontend/src/pages/skills/ShareDialog.vue
@@ -97,7 +97,7 @@
 import { ref, computed, watch } from "vue";
 import { Dialog, Button, FormControl, Avatar, FeatherIcon, toast } from "frappe-ui";
 import * as api from "@/api";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -143,7 +143,7 @@ async function load() {
 			}
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		emit("update:modelValue", false);
 	} finally {
 		loading.value = false;
@@ -181,7 +181,7 @@ async function save() {
 		emit("saved");
 		emit("update:modelValue", false);
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		saving.value = false;
 	}

--- a/frontend/src/pages/skills/ShareDialog.vue
+++ b/frontend/src/pages/skills/ShareDialog.vue
@@ -97,10 +97,7 @@
 import { ref, computed, watch } from "vue";
 import { Dialog, Button, FormControl, Avatar, FeatherIcon, toast } from "frappe-ui";
 import * as api from "@/api";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },

--- a/frontend/src/pages/skills/SkillDetail.vue
+++ b/frontend/src/pages/skills/SkillDetail.vue
@@ -283,7 +283,7 @@ import { timeAgo } from "@/utils/datetime";
 import { useJarvisTheme } from "@/theme";
 import "@/assets/settings.css"; // shared jv-* primitives (overlay, jv-btn) for the discard dialog
 import * as api from "@/api";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, default: "" },
@@ -372,7 +372,7 @@ async function submitPromotion({ to_scope, target_role, note }) {
 		toast.success("Promotion requested — a reviewer will decide.");
 		await loadMyPromo();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		promoBusy.value = false;
 	}
@@ -519,7 +519,7 @@ async function save() {
 			toast.success("Saved");
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		saving.value = false;
 	}
@@ -542,7 +542,7 @@ function confirmDelete() {
 				toast.success("Skill deleted");
 				router.push({ name: "SkillsList" });
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/skills/SkillDetail.vue
+++ b/frontend/src/pages/skills/SkillDetail.vue
@@ -283,6 +283,7 @@ import { timeAgo } from "@/utils/datetime";
 import { useJarvisTheme } from "@/theme";
 import "@/assets/settings.css"; // shared jv-* primitives (overlay, jv-btn) for the discard dialog
 import * as api from "@/api";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, default: "" },
@@ -295,10 +296,6 @@ const router = useRouter();
 const { effectiveDark: dark, paletteVars } = useJarvisTheme();
 const DOCTYPE = "Jarvis Custom Skill";
 const FIELDS = ["skill_name", "description", "instructions", "user_invocable", "enabled"];
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── state ────────────────────────────────────────────────────────────────────
 const skill = ref(null); // last server copy (null while new)

--- a/frontend/src/pages/skills/SkillsList.vue
+++ b/frontend/src/pages/skills/SkillsList.vue
@@ -124,16 +124,13 @@ import SyncPill from "./SyncPill.vue";
 import { session } from "@/data/session";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as apiSkills from "@/api/skills";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const router = useRouter();
 // /skills is a TABBED shell (Skills | Learning), so the `fv2` query param is
 // shared with a sibling tab; the payload carries its view key and a foreign one
 // is ignored rather than half-applied (judgment C08-7).
 const route = useRoute();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── list config ──────────────────────────────────────────────────────────────
 // "Ownership", not "Scope": scope is the Org/Personal skill field (shown as a

--- a/frontend/src/pages/skills/SkillsList.vue
+++ b/frontend/src/pages/skills/SkillsList.vue
@@ -124,7 +124,7 @@ import SyncPill from "./SyncPill.vue";
 import { session } from "@/data/session";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as apiSkills from "@/api/skills";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const router = useRouter();
 // /skills is a TABBED shell (Skills | Learning), so the `fv2` query param is
@@ -251,7 +251,7 @@ function bulkDelete(selections, unselectAll) {
 				// the server enqueued one skills-apply at the end (§8.3) - show it
 				syncPill.value && syncPill.value.checkNow();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/skills/SyncPill.vue
+++ b/frontend/src/pages/skills/SyncPill.vue
@@ -41,7 +41,7 @@ import { Badge, Button, Tooltip, toast } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import * as api from "@/api";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const status = ref(""); // last_sync_status: "", "pending: …", "ok …", "failed: …"
 const pending = ref(false);
@@ -94,7 +94,7 @@ async function apply() {
 		pending.value = true;
 		startPoll();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		applying.value = false;
 	}

--- a/frontend/src/pages/skills/SyncPill.vue
+++ b/frontend/src/pages/skills/SyncPill.vue
@@ -41,10 +41,7 @@ import { Badge, Button, Tooltip, toast } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import * as api from "@/api";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
+import { errMessage as errMsg } from "@/lib/errors";
 
 const status = ref(""); // last_sync_status: "", "pending: …", "ok …", "failed: …"
 const pending = ref(false);

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -323,7 +323,7 @@ import {
 	runWikiLintNow,
 } from "@/api/wiki";
 import { agentName } from "@/branding";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 // /skills is a TABBED shell; the `fv2` payload carries its view key so a sibling
 // tab's filters are never half-applied here (judgment C08-7).
@@ -554,7 +554,7 @@ async function runRowAction(row, fn, successMsg) {
 		toast.success(successMsg);
 		resetLoad();
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		rowBusy.value = "";
 	}
@@ -670,7 +670,7 @@ async function doCreate() {
 			openPage(res.slug);
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		createDialog.saving = false;
 	}
@@ -689,7 +689,7 @@ async function changeLanguage(v) {
 		toast.success(`Knowledge language set to ${v}`);
 	} catch (e) {
 		caps.knowledge_language = previous;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -713,7 +713,7 @@ function confirmSync() {
 				if (r && r.ok === false) toast.error(r.reason || "Could not queue the sync.");
 				else toast.success("Sync queued");
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			} finally {
 				syncing.value = false;
 			}
@@ -738,7 +738,7 @@ function confirmLint() {
 				loadCaps();
 				refreshKeep();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			} finally {
 				linting.value = false;
 			}

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -323,15 +323,12 @@ import {
 	runWikiLintNow,
 } from "@/api/wiki";
 import { agentName } from "@/branding";
+import { errMessage as errMsg } from "@/lib/errors";
 
 // /skills is a TABBED shell; the `fv2` payload carries its view key so a sibling
 // tab's filters are never half-applied here (judgment C08-7).
 const route = useRoute();
 const router = useRouter();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── static config ────────────────────────────────────────────────────────────
 const WIKI_TYPES = [

--- a/frontend/src/pages/skills/escapeHtml.js
+++ b/frontend/src/pages/skills/escapeHtml.js
@@ -6,11 +6,12 @@
 // the reviewer's privileged session on Approve. Pure + importable so it is
 // node-tested (the promotionBudget.js precedent) and reused verbatim at every
 // call site. Server-side neutralization of the wiki title is the second belt.
-export function esc(v) {
-	return String(v ?? "")
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#39;");
-}
+// The implementation moved to lib/errors.js (#699), which needs the very same
+// escape for the OTHER v-html sink in the app: frappe-ui's Toast binds its
+// `message` prop with v-html too, so an error message decoded back to plain
+// text has to be re-escaped on the way into it. Re-exported here under the
+// original name so every existing call site and this module's own test keep
+// working against ONE implementation instead of two that can drift apart.
+// Relative path, not the "@/" alias: this test is run by plain `node --test`,
+// which does not resolve Vite's aliases.
+export { escapeHtml as esc } from "../../lib/errors.js";

--- a/frontend/src/pages/triggers/TriggerDetail.vue
+++ b/frontend/src/pages/triggers/TriggerDetail.vue
@@ -356,6 +356,7 @@ import ActivityDetailDialog from "./ActivityDetailDialog.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { searchLink } from "@/api";
 import * as apiTriggers from "@/api/triggers";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, default: "" },
@@ -366,10 +367,6 @@ const router = useRouter();
 
 const ACTION_TYPES = ["Script", "LLM"];
 const STATUS_THEME = { Success: "green", Failed: "red", Blocked: "orange", Skipped: "gray" };
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── caps (deep-linkable page → its own probe) ────────────────────────────────
 const caps = ref({

--- a/frontend/src/pages/triggers/TriggerDetail.vue
+++ b/frontend/src/pages/triggers/TriggerDetail.vue
@@ -356,7 +356,7 @@ import ActivityDetailDialog from "./ActivityDetailDialog.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { searchLink } from "@/api";
 import * as apiTriggers from "@/api/triggers";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	id: { type: String, default: "" },
@@ -623,7 +623,7 @@ async function save() {
 			toast.success("Saved");
 		}
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		saving.value = false;
 	}
@@ -638,7 +638,7 @@ async function toggleEnabled() {
 		if (snapshot.value) snapshot.value.enabled = next;
 		toast.success(next ? "Trigger enabled" : "Trigger disabled");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -654,7 +654,7 @@ function confirmDelete() {
 				toast.success("Trigger deleted");
 				router.push({ name: "TriggersPage" });
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/triggers/TriggersListPane.vue
+++ b/frontend/src/pages/triggers/TriggersListPane.vue
@@ -138,7 +138,7 @@ import { useListPage } from "@/composables/useListPage";
 import { triggersListFetch } from "@/pages/list/listFetchers";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as apiTriggers from "@/api/triggers";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 const props = defineProps({
 	caps: { type: Object, default: () => ({}) }, // get_triggers_caps payload
@@ -265,7 +265,7 @@ async function toggleEnabled(row, value) {
 		await apiTriggers.setTriggerEnabled(row.name, value ? 1 : 0);
 	} catch (e) {
 		row.enabled = prev;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	} finally {
 		togglingRow.value = "";
 	}
@@ -304,7 +304,7 @@ function bulkDelete(selections, unselectAll) {
 				hideDialog();
 				resetLoad();
 			} catch (e) {
-				toast.error(errMsg(e));
+				toast.error(errHtml(e));
 			}
 		},
 	});

--- a/frontend/src/pages/triggers/TriggersListPane.vue
+++ b/frontend/src/pages/triggers/TriggersListPane.vue
@@ -138,6 +138,7 @@ import { useListPage } from "@/composables/useListPage";
 import { triggersListFetch } from "@/pages/list/listFetchers";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as apiTriggers from "@/api/triggers";
+import { errMessage as errMsg } from "@/lib/errors";
 
 const props = defineProps({
 	caps: { type: Object, default: () => ({}) }, // get_triggers_caps payload
@@ -147,10 +148,6 @@ const router = useRouter();
 // /triggers is a TABBED route (Triggers | Activity); the payload carries its view
 // key so the Activity tab never applies this list's filters (judgment C08-7).
 const route = useRoute();
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // ── list config ──────────────────────────────────────────────────────────────
 const ENABLED_OPTIONS = [

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -12,10 +12,7 @@ import { reactive, ref, computed } from "vue";
 import { useStorage } from "@vueuse/core";
 import { toast } from "frappe-ui";
 import * as api from "@/api";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
+import { errMessage as errMsg } from "@/lib/errors";
 
 // ---- state ------------------------------------------------------------------
 const conversations = ref([]); // [{name,title,last_active_at,starred,message_count}]

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -12,7 +12,7 @@ import { reactive, ref, computed } from "vue";
 import { useStorage } from "@vueuse/core";
 import { toast } from "frappe-ui";
 import * as api from "@/api";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errHtml } from "@/lib/errors";
 
 // ---- state ------------------------------------------------------------------
 const conversations = ref([]); // [{name,title,last_active_at,starred,message_count}]
@@ -89,7 +89,7 @@ function setActivityDetail(v, { persist = true } = {}) {
 		// toast (same as renameConversation/toggleStar below) but the local
 		// (localStorage-cached) value already stuck, so the UI stays correct.
 		api.updateMySettings({ activity_detail: activityDetail.value ? 1 : 0 }).catch((e) =>
-			toast.error(errMsg(e))
+			toast.error(errHtml(e))
 		);
 	}
 }
@@ -204,7 +204,7 @@ async function toggleNotify() {
 			// localStorage throws in private mode and when the quota is full.
 			// The preference is a nicety; losing it must never break the toggle.
 		}
-		api.updateMySettings({ notify_enabled: 0 }).catch((e) => toast.error(errMsg(e)));
+		api.updateMySettings({ notify_enabled: 0 }).catch((e) => toast.error(errHtml(e)));
 		return;
 	}
 	let perm = Notification.permission;
@@ -223,7 +223,7 @@ async function toggleNotify() {
 			// localStorage throws in private mode and when the quota is full.
 			// The preference is a nicety; losing it must never break the toggle.
 		}
-		api.updateMySettings({ notify_enabled: 1 }).catch((e) => toast.error(errMsg(e)));
+		api.updateMySettings({ notify_enabled: 1 }).catch((e) => toast.error(errHtml(e)));
 	}
 }
 // Called by GeneralPane's onMounted (get_my_settings) once the server row is
@@ -322,7 +322,7 @@ async function loadConversations() {
 			conversations.value = (await api.listConversations()) || [];
 			refreshApprovalsCount(); // poll-on-activity parity (D12)
 		} catch (e) {
-			toast.error(errMsg(e));
+			toast.error(errHtml(e));
 		} finally {
 			conversationsLoading.value = false;
 			_convsInflight = null;
@@ -359,7 +359,7 @@ async function renameConversation(name, title) {
 		await api.renameConversation(name, title);
 	} catch (e) {
 		if (conv) conv.title = prev;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -372,7 +372,7 @@ async function toggleStar(name) {
 		await api.setStar(name, next);
 	} catch (e) {
 		conv.starred = next ? 0 : 1;
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 
@@ -384,7 +384,7 @@ async function archiveConversation(name) {
 		conversations.value = conversations.value.filter((c) => c.name !== name);
 		toast.success("Chat deleted");
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 	}
 }
 

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -6,6 +6,7 @@
 // so a failed call showed the user nothing at all — that is the defect being fixed.
 import { reactive, ref } from "vue";
 import { toast } from "frappe-ui";
+import { errMessage as errMsg } from "@/lib/errors";
 import {
 	supportListTickets,
 	supportGetThread,
@@ -15,10 +16,6 @@ import {
 	supportAwaitingCount,
 	supportUpload,
 } from "@/api";
-
-function errMsg(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 
 // Mirrors jarvis_helpdesk/setup/install.py:39 AWAITING_STATUSES and
 // jarvis_admin_v2/support/awaiting.py:10 AWAITING — both ("Replied", "Resolved").

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -6,7 +6,7 @@
 // so a failed call showed the user nothing at all — that is the defect being fixed.
 import { reactive, ref } from "vue";
 import { toast } from "frappe-ui";
-import { errMessage as errMsg } from "@/lib/errors";
+import { errMessage as errMsg, errHtml, escapeHtml } from "@/lib/errors";
 import {
 	supportListTickets,
 	supportGetThread,
@@ -149,7 +149,7 @@ async function createTicket(subject, body) {
 		}
 		return name;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		return null;
 	}
 }
@@ -163,7 +163,7 @@ async function reply(name, body) {
 		// callers (the `if (!ok) return` guard in send()) still read this as success.
 		return (r && r.data && r.data.comm) || true;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		return false;
 	}
 }
@@ -173,7 +173,7 @@ async function closeTicket(name) {
 		await supportCloseTicket(name);
 		return true;
 	} catch (e) {
-		toast.error(errMsg(e));
+		toast.error(errHtml(e));
 		return false;
 	}
 }
@@ -191,7 +191,9 @@ async function uploadTo(name, files, comm) {
 			await supportUpload(name, f, comm);
 			succeeded.push(f);
 		} catch (e) {
-			toast.error(`Couldn't attach ${f.name}: ${errMsg(e)}`);
+			// Toast binds `message` with v-html, so the FILENAME is a sink here
+			// too: it is user-chosen and reaches this string unescaped (#699).
+			toast.error(`Couldn't attach ${escapeHtml(f.name)}: ${errHtml(e)}`);
 		}
 	}
 	return succeeded;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3956,9 +3956,6 @@ watch(
 // --- Custom skills (Skills settings tab + "/" composer menu) ---
 const customSkills = ref([]);
 
-function _skillErr(e) {
-	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
-}
 async function loadCustomSkills() {
 	try {
 		customSkills.value = (await api.listCustomSkills()) || [];
@@ -4070,7 +4067,7 @@ async function rerunFromHistory(run) {
 			status: "running",
 		};
 	} catch (e) {
-		notify(_skillErr(e), { type: "error" });
+		notify(errMessage(e), { type: "error" });
 	}
 }
 async function stopRunFromHistory(run) {
@@ -4079,7 +4076,7 @@ async function stopRunFromHistory(run) {
 		run.status = "stopped"; // optimistic patch
 		loadMacroRunStats();
 	} catch (e) {
-		notify(_skillErr(e), { type: "error" });
+		notify(errMessage(e), { type: "error" });
 	}
 }
 
@@ -4764,7 +4761,7 @@ async function clearAllHistory() {
 		settingsOpen.value = false;
 		newChat(); // also reloads store.conversations
 	} catch (e) {
-		notify(_skillErr(e) || "Could not delete history", { type: "error" });
+		notify(errMessage(e) || "Could not delete history", { type: "error" });
 	} finally {
 		clearingHistory.value = false;
 	}
@@ -6013,11 +6010,12 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 		}
 	} catch (e) {
 		p.applying = false;
+		const msg = errMessage(e);
 		p.error = {
 			message:
-				(e && e.messages && e.messages[0]) ||
-				(e && e.message) ||
-				"Could not save — check the values.",
+				msg === "Something went wrong. Please try again."
+					? "Could not save — check the values."
+					: msg,
 		};
 	}
 }
@@ -6196,11 +6194,13 @@ async function confirmPending(pa) {
 		}
 	} catch (e) {
 		const card = cardById();
-		if (card)
+		if (card) {
+			const msg = errMessage(e);
 			card.error = {
 				message:
-					(e && e.messages && e.messages[0]) || (e && e.message) || "Could not confirm.",
+					msg === "Something went wrong. Please try again." ? "Could not confirm." : msg,
 			};
+		}
 	} finally {
 		const card = cardById();
 		if (card) card.busy = false;
@@ -6224,9 +6224,10 @@ async function discardPending(pa) {
 			return;
 		}
 	} catch (e) {
+		const msg = errMessage(e);
 		pa.error = {
 			message:
-				(e && e.messages && e.messages[0]) || (e && e.message) || "Could not discard.",
+				msg === "Something went wrong. Please try again." ? "Could not discard." : msg,
 		};
 		return;
 	} finally {
@@ -7125,7 +7126,7 @@ async function selectConversation(id) {
 // the extracted reason so a non-string Frappe error payload can't throw inside the
 // caller's catch and re-swallow the very failure we're trying to report.
 function notifyActionError(prefix, e) {
-	notify(`${prefix} — ${String(_skillErr(e)).replace(/\.$/, "")}. Try again.`, {
+	notify(`${prefix} — ${String(errMessage(e)).replace(/\.$/, "")}. Try again.`, {
 		type: "error",
 	});
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6010,13 +6010,7 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 		}
 	} catch (e) {
 		p.applying = false;
-		const msg = errMessage(e);
-		p.error = {
-			message:
-				msg === "Something went wrong. Please try again."
-					? "Could not save — check the values."
-					: msg,
-		};
+		p.error = { message: errMessage(e, "Could not save. Check the values.") };
 	}
 }
 
@@ -6194,13 +6188,7 @@ async function confirmPending(pa) {
 		}
 	} catch (e) {
 		const card = cardById();
-		if (card) {
-			const msg = errMessage(e);
-			card.error = {
-				message:
-					msg === "Something went wrong. Please try again." ? "Could not confirm." : msg,
-			};
-		}
+		if (card) card.error = { message: errMessage(e, "Could not confirm.") };
 	} finally {
 		const card = cardById();
 		if (card) card.busy = false;
@@ -6224,11 +6212,7 @@ async function discardPending(pa) {
 			return;
 		}
 	} catch (e) {
-		const msg = errMessage(e);
-		pa.error = {
-			message:
-				msg === "Something went wrong. Please try again." ? "Could not discard." : msg,
-		};
+		pa.error = { message: errMessage(e, "Could not discard.") };
 		return;
 	} finally {
 		pa.busy = false;


### PR DESCRIPTION
Replaces 42 inline copies of the pre-#696 error formatter across 38 files with the shared `errMessage()` helper, so a frappe-ui internal crash can no longer leak `Cannot read properties of undefined (reading 'exc_type')` to a customer through any of these screens.

Consolidating those sites onto one helper exposed a second problem that this PR also fixes. `errMessage()` returns **plain text**: it decodes the HTML entities Frappe escaped, which is what a `{{ }}` sink needs to render "Settings -> Developer" instead of "Settings -&gt; Developer". frappe-ui's `Toast` binds its `message` prop with `v-html`, so error text routed there was having the server's escaping undone before it reached an HTML parser. This adds `errHtml()` for HTML sinks, keeps `errMessage()` for text sinks, and moves every toast call site onto it.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop` (branched fresh)
- [x] New/changed behavior has tests (two source-scanning guard tests)
- [x] I self-reviewed the diff

<details>
<summary>Root cause</summary>

#696 fixed `errMessage()` in `frontend/src/lib/errors.js` to recognise frappe-ui's own internal crash (a `TypeError` from an unguarded `error.exc_type` read after a failed `JSON.parse`) and stop echoing its raw message. 42 other call sites across 38 files carried a byte-identical copy of the pre-fix logic and never called the shared helper, so each one could still surface that crash text.

Each site was read individually, not swept blindly. Sites that use `e.messages[0]` for control flow rather than display were left alone; `SaveDashboardDialog.vue`'s `isThemeError()` is the one such case, pattern-matching the message text to decide whether to offer a "fix in chat" hand-off, and is called out with a comment.

</details>

<details>
<summary>Text sinks vs HTML sinks</summary>

The two helpers now have distinct contracts, because the app has both kinds of sink and the correct string differs between them:

| Helper | Returns | Use at |
|---|---|---|
| `errMessage(e, fallback)` | plain text (entities decoded) | `{{ }}`, `textContent`, ChatView's own `notify()` |
| `errHtml(e, fallback)` | escaped HTML | `toast.*()`, and any other `v-html` binding |

Audited while making the change: the **only** `v-html` sink reached by error text is frappe-ui's `Toast`. Every other `v-html` binding in `frontend/src` renders markdown or sanitized document HTML, no error value flows into `confirm()` (whose `ConfirmDialog` is also a `v-html` sink), and ChatView's local `notify()` renders `{{ n.message }}`. The 53 non-toast call sites were left on `errMessage()` deliberately.

`escapeHtml()` is now the single escape implementation in the frontend; `pages/skills/escapeHtml.js` re-exports it as `esc` so the existing SAR-1 call sites and their test keep working against one copy rather than two that can drift apart.

</details>

<details>
<summary>Custom fallbacks</summary>

A handful of sites want their own sentence ("Upload failed", "Could not confirm.", "Could not reset the workspace.") rather than the generic default. The first pass did that by comparing `errMessage()`'s **result** against the generic sentence, which put 6 fresh copies of that string into components and would have failed silently the day its wording changed. Both helpers now take an explicit `fallback` parameter instead. A 401/403 with no specific message still outranks `fallback`, since "sign in again" is an actionable remedy and "Could not save." is not.

</details>

## Guard tests

`frontend/src/lib/noInlineErrorFormatter.test.js` scans the whole `src` tree and fails on either regression: a new inline copy of the formatter, or a toast fed by the plain-text helper. Both call the safe and unsafe forms indistinguishable at the call site, so only a test makes the wrong one loud. The first guard pins its one intentional exception by source text rather than line number, so unrelated edits in that file cannot turn it red.

Fixes #699
