### PR TITLE
fix: fill id-only jarvis-cards with record fields (B — deterministic backend floor)

### DIFF
--- a/jarvis/chat/cards_enrich.py
+++ b/jarvis/chat/cards_enrich.py
@@ -1,0 +1,138 @@
+"""Backend enrichment for ``jarvis-cards`` blocks: guarantee a browsable record
+card never renders as a bare id.
+
+The ``jarvis-cards`` block is authored by the agent. The SPA renders every field a
+card supplies and, when a card's ``fields`` array is empty, falls back to the record
+id as the card's only visible value (``frontend/src/views/ChatView.vue`` card parse).
+The persona (skill A) tells the agent to fill ``fields`` dynamically, but that is model
+guidance; this module is the deterministic floor: any card that arrives with a
+``doctype`` + ``name`` but no ``fields`` is filled server-side from the record's own
+schema, so a card CANNOT render id-only regardless of what the model emitted.
+
+Two invariants:
+  - IDEMPOTENT + non-destructive. A card that already carries ``fields`` is left
+    exactly as the agent wrote it (skill A's dynamic choice wins); a re-run over
+    already-enriched content is a no-op. Only EMPTY cards are touched.
+  - PERMISSION-SAFE by delegation. Every value comes from
+    ``_record_summary.summary_rows``, which does its own read + field-level
+    permission check and secret masking under the CURRENT user. So the enrichment
+    runs impersonating the message OWNER, never the ambient finalize/worker user.
+
+Best-effort throughout: a parse error, a missing record, or a record the user cannot
+read leaves the card untouched. Nothing here raises into the turn.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import frappe
+
+from jarvis._session import impersonate
+from jarvis.chat import _record_summary
+
+MSG = "Jarvis Chat Message"
+
+# Mirrors ``ChatView.vue`` ``_CARDS_RE`` byte-for-byte (the fence the SPA parses):
+# a ```jarvis-cards fence, optional trailing spaces/tabs, a newline, the JSON body,
+# then the closing fence. Non-greedy so each block matches to its own close.
+_CARDS_RE = re.compile(r"```jarvis-cards[ \t]*\n([\s\S]*?)```")
+
+# Bound the per-message doc reads: a card strip is for browsing a handful of records,
+# not a report. Cards beyond this cap keep whatever the agent gave them.
+_MAX_CARDS = 20
+
+
+def _enrich_card(card: dict) -> bool:
+	"""Fill one id-only card's ``fields`` from the record's schema. Returns True iff
+	the card was changed.
+
+	Left untouched (returns False) when: it is not a dict; it already has ``fields``
+	(the agent's own choice is authoritative); it lacks a ``doctype`` + ``name`` to
+	identify the record; or the record is missing / unreadable by this user
+	(``summary_rows`` returns None or no rows)."""
+	if not isinstance(card, dict):
+		return False
+	if card.get("fields"):
+		return False
+	doctype = str(card.get("doctype") or "").strip()
+	name = str(card.get("name") or "").strip()
+	if not doctype or not name:
+		return False
+	summary = _record_summary.summary_rows(doctype, name)
+	if not summary or not summary.get("rows"):
+		return False
+	card["fields"] = summary["rows"]
+	# Promote the record's human title when the card is titled by its id (or blank),
+	# so the header reads as a name, not a code. summary_rows' title is the
+	# permission-checked title-field value.
+	title = str(card.get("title") or "").strip()
+	if summary.get("title") and (not title or title == name):
+		card["title"] = summary["title"]
+	return True
+
+
+def _enrich_block(raw: str) -> tuple[str, bool]:
+	"""Enrich one block's JSON body. Returns ``(new_raw, changed)``. Malformed JSON,
+	or a body that is not ``{cards: [...]}``, is returned unchanged."""
+	try:
+		data = json.loads(raw)
+	except (ValueError, TypeError):
+		return raw, False
+	if not isinstance(data, dict):
+		return raw, False
+	cards = data.get("cards")
+	if not isinstance(cards, list):
+		return raw, False
+	changed = False
+	for card in cards[:_MAX_CARDS]:
+		if _enrich_card(card):
+			changed = True
+	if not changed:
+		return raw, False
+	return json.dumps(data, ensure_ascii=False), True
+
+
+def enrich_text(content: str, *, owner: str | None = None) -> str:
+	"""Enrich every ``jarvis-cards`` block in ``content`` and return the (possibly
+	unchanged) text. Reads run under ``owner``'s permissions. Best-effort: any failure
+	returns the original content verbatim."""
+	if not content or "jarvis-cards" not in content:
+		return content
+
+	def _run() -> str:
+		def _sub(m: re.Match) -> str:
+			new_raw, changed = _enrich_block(m.group(1))
+			if not changed:
+				return m.group(0)
+			return f"```jarvis-cards\n{new_raw}\n```"
+
+		return _CARDS_RE.sub(_sub, content)
+
+	try:
+		if owner and owner != frappe.session.user:
+			with impersonate(owner):
+				return _run()
+		return _run()
+	except Exception:
+		# A card is a convenience, never worth risking the turn. Clear any message
+		# a failed read queued so it cannot leak into the reply, and degrade to the
+		# original content (an id-only card, not a broken turn).
+		frappe.clear_messages()
+		return content
+
+
+def enrich_message(message_name: str, owner: str | None = None) -> None:
+	"""Read a ``Jarvis Chat Message``'s content, enrich its cards, and write the result
+	back when it changed. Idempotent (re-run is a no-op once cards carry fields) and
+	best-effort (never raises)."""
+	try:
+		row = frappe.db.get_value(MSG, message_name, ["content", "owner"], as_dict=True)
+		if not row or not row.get("content"):
+			return
+		new = enrich_text(row["content"], owner=owner or row.get("owner"))
+		if new != row["content"]:
+			frappe.db.set_value(MSG, message_name, "content", new)
+	except Exception:
+		frappe.clear_messages()

--- a/jarvis/chat/cards_enrich.py
+++ b/jarvis/chat/cards_enrich.py
@@ -54,7 +54,12 @@ def _enrich_card(card: dict) -> bool:
 	(``summary_rows`` returns None or no rows)."""
 	if not isinstance(card, dict):
 		return False
-	if card.get("fields"):
+	# Match the SPA/PWA, which render a card's fields only when they are a NON-EMPTY
+	# LIST (``Array.isArray``). A truthy non-list (a dict, a string) reads as empty on
+	# the client, so treat it as empty here too and fill it - otherwise the floor
+	# silently fails to apply to exactly the cards that render id-only.
+	fields = card.get("fields")
+	if isinstance(fields, list) and fields:
 		return False
 	doctype = str(card.get("doctype") or "").strip()
 	name = str(card.get("name") or "").strip()
@@ -80,9 +85,14 @@ def _enrich_block(raw: str) -> tuple[str, bool]:
 		data = json.loads(raw)
 	except (ValueError, TypeError):
 		return raw, False
-	if not isinstance(data, dict):
+	# The SPA/PWA accept BOTH shapes: an object ``{cards: [...]}`` and a bare list
+	# ``[...]``. Enrich either; anything else is not a card payload.
+	if isinstance(data, dict):
+		cards = data.get("cards")
+	elif isinstance(data, list):
+		cards = data
+	else:
 		return raw, False
-	cards = data.get("cards")
 	if not isinstance(cards, list):
 		return raw, False
 	changed = False
@@ -91,7 +101,16 @@ def _enrich_block(raw: str) -> tuple[str, bool]:
 			changed = True
 	if not changed:
 		return raw, False
-	return json.dumps(data, ensure_ascii=False), True
+	new_raw = json.dumps(data, ensure_ascii=False)
+	# A picked field value can legitimately contain a literal ``` (someone pasted a
+	# code block into a Notes/Description field). Injected into the fence it would
+	# truncate the block at the client's non-greedy parser - the card would vanish AND
+	# the JSON tail would leak into the prose. This hazard arrives only with the DB
+	# values we inject, so refuse the rewrite and leave the id-only card intact rather
+	# than corrupt the message.
+	if "```" in new_raw:
+		return raw, False
+	return new_raw, True
 
 
 def enrich_text(content: str, *, owner: str | None = None) -> str:
@@ -131,8 +150,17 @@ def enrich_message(message_name: str, owner: str | None = None) -> None:
 		row = frappe.db.get_value(MSG, message_name, ["content", "owner"], as_dict=True)
 		if not row or not row.get("content"):
 			return
-		new = enrich_text(row["content"], owner=owner or row.get("owner"))
+		# Fail CLOSED: a permission-scoped read must run under a concrete human. With no
+		# owner the finalize worker's ambient identity is Administrator, whose reads
+		# bypass every permission and field-level check - so skip rather than degrade open.
+		read_as = owner or row.get("owner")
+		if not read_as:
+			return
+		new = enrich_text(row["content"], owner=read_as)
 		if new != row["content"]:
-			frappe.db.set_value(MSG, message_name, "content", new)
+			# update_modified=False: a background touch-up, not a real edit. Bumping
+			# modified here would flip modified_by to the worker and reintroduce the
+			# reply-duration inflation the finalize stamps deliberately avoid.
+			frappe.db.set_value(MSG, message_name, "content", new, update_modified=False)
 	except Exception:
 		frappe.clear_messages()

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -199,7 +199,7 @@ def _effect_enrich_cards(ctx: _Ctx) -> None:
 	# when the agent emitted an empty ``fields`` array. Skipped on an errored/
 	# cancelled turn (a partial reply has no real cards). Idempotent + best-effort;
 	# the ``message:enriched`` publish after all effects refreshes the client with
-	# the filled content. Reads run under the message owner's permissions.
+	# the filled content.
 	if ctx.errored:
 		return
 	am = ctx.turn.get("assistant_message")
@@ -207,7 +207,11 @@ def _effect_enrich_cards(ctx: _Ctx) -> None:
 		return
 	from jarvis.chat import cards_enrich
 
-	cards_enrich.enrich_message(am, owner=ctx.owner)
+	# Read as the turn's SENDER (chat_user), not the conversation owner: the whole turn
+	# pipeline scopes permission reads to the sender (prepare.py, _effect_wiki_nudge),
+	# and in a shared conversation the owner may see fields the sender must not.
+	read_as = ctx.payload.get("chat_user") or ctx.owner
+	cards_enrich.enrich_message(am, owner=read_as)
 
 
 def _effect_chat_asks(ctx: _Ctx) -> None:

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -193,6 +193,23 @@ def _effect_rich_outputs(ctx: _Ctx) -> None:
 	turn_handler.persist_rich_outputs(am, ctx.conversation, ctx.owner, ctx.run_id, _turn_start_ms(ctx))
 
 
+def _effect_enrich_cards(ctx: _Ctx) -> None:
+	# Fill any id-only ``jarvis-cards`` in the final reply with the record's own
+	# schema fields (B), so a browse-cards block can never render as a bare id even
+	# when the agent emitted an empty ``fields`` array. Skipped on an errored/
+	# cancelled turn (a partial reply has no real cards). Idempotent + best-effort;
+	# the ``message:enriched`` publish after all effects refreshes the client with
+	# the filled content. Reads run under the message owner's permissions.
+	if ctx.errored:
+		return
+	am = ctx.turn.get("assistant_message")
+	if not am:
+		return
+	from jarvis.chat import cards_enrich
+
+	cards_enrich.enrich_message(am, owner=ctx.owner)
+
+
 def _effect_chat_asks(ctx: _Ctx) -> None:
 	# A final reply carrying a ```jarvis-ask fence surfaces on the Approval Board.
 	# Skipped for an errored/cancelled turn (a partial fence is not a real ask).
@@ -433,6 +450,7 @@ def _effect_telemetry(ctx: _Ctx) -> None:
 _RUNNERS = {
 	"terminal_publish": _effect_terminal_publish,
 	"rich_outputs": _effect_rich_outputs,
+	"enrich_cards": _effect_enrich_cards,
 	"chat_asks": _effect_chat_asks,
 	"macro_advance": _effect_macro_advance,
 	"auto_title": _effect_auto_title,

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -98,6 +98,7 @@ QUEUED_MAX_AGE_S = 15 * 60
 EFFECT_NAMES = (
 	"terminal_publish",
 	"rich_outputs",
+	"enrich_cards",
 	"chat_asks",
 	"macro_advance",
 	"auto_title",

--- a/jarvis/jarvis/doctype/jarvis_turn_effect/jarvis_turn_effect.json
+++ b/jarvis/jarvis/doctype/jarvis_turn_effect/jarvis_turn_effect.json
@@ -32,7 +32,7 @@
    "length": 64,
    "reqd": 1,
    "in_list_view": 1,
-   "description": "One of the canonical turn-effect vocabulary jarvis.chat.turn_state.EFFECT_NAMES = [terminal_publish, rich_outputs, chat_asks, macro_advance, auto_title, wiki_nudge, usage, telemetry_flush] (that tuple is the single authority; any other name is rejected at insert by turn_state.insert_required_effects). Part of the UNIQUE (turn, effect_name) enforced via the composite doc name (D2 §1a)."
+   "description": "One of the canonical turn-effect vocabulary jarvis.chat.turn_state.EFFECT_NAMES = [terminal_publish, rich_outputs, enrich_cards, chat_asks, macro_advance, auto_title, wiki_nudge, usage, telemetry_flush] (that tuple is the single authority; any other name is rejected at insert by turn_state.insert_required_effects). Part of the UNIQUE (turn, effect_name) enforced via the composite doc name (D2 §1a)."
   },
   {
    "fieldname": "status",

--- a/jarvis/tests/test_cards_enrich.py
+++ b/jarvis/tests/test_cards_enrich.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import cards_enrich
@@ -144,16 +145,104 @@ class TestEnrichText(FrappeTestCase):
 			cards_enrich.enrich_text(_block(cards))
 		self.assertLessEqual(sr.call_count, cards_enrich._MAX_CARDS)
 
-	def test_owner_is_impersonated_for_the_read(self):
+	def test_read_happens_inside_owner_impersonation(self):
+		# Prove the read runs INSIDE impersonate(owner), not merely that impersonate was
+		# called - a read moved outside the `with` must fail this test.
 		content = _block([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+		state = {"active": False, "user": None, "read_while_active": None}
+
+		class _Imp:
+			def __init__(self, user):
+				state["user"] = user
+
+			def __enter__(self):
+				state["active"] = True
+
+			def __exit__(self, *a):
+				state["active"] = False
+
+		def _sr(doctype, name):
+			state["read_while_active"] = state["active"]
+			return {"title": "n", "rows": [{"label": "D", "value": "E"}]}
+
 		with (
-			patch("jarvis.chat.cards_enrich.impersonate") as imp,
-			patch(_SUMMARY, return_value={"title": "n", "rows": [{"label": "D", "value": "E"}]}),
+			patch("jarvis.chat.cards_enrich.impersonate", _Imp),
+			patch(_SUMMARY, _sr),
 			patch("jarvis.chat.cards_enrich.frappe.session") as sess,
 		):
 			sess.user = "administrator@example.com"
 			cards_enrich.enrich_text(content, owner="tenant@example.com")
-		imp.assert_called_once_with("tenant@example.com")
+		self.assertEqual(state["user"], "tenant@example.com")
+		self.assertTrue(state["read_while_active"], "summary_rows must run inside impersonate(owner)")
+		self.assertFalse(state["active"], "impersonation must be exited afterwards")
+
+	def test_non_list_fields_is_treated_as_empty_and_filled(self):
+		# The SPA renders fields only when Array.isArray; a truthy non-list reads as empty
+		# there, so the backend must fill it rather than treat it as the agent's choice.
+		rows = [{"label": "D", "value": "E"}]
+		for bad in ("see profile", {"a": "b"}, 7):
+			content = _block([{"doctype": "Employee", "name": "E1", "title": "E1", "fields": bad}])
+			with patch(_SUMMARY, return_value={"title": "Nm", "rows": rows}):
+				out = cards_enrich.enrich_text(content)
+			self.assertEqual(_first_card(out)["fields"], rows, f"fields={bad!r} should have been filled")
+
+	def test_value_with_fence_delimiter_is_not_written_back(self):
+		# A field value carrying ``` would truncate the fence at the client (both parsers
+		# are non-greedy to the first ```), breaking the card AND leaking the JSON tail
+		# into the prose. Refuse the rewrite: leave the id-only card intact.
+		content = _block([{"doctype": "Note", "name": "N1", "title": "N1"}])
+		rows = [{"label": "Body", "value": "run ```pip install x``` first"}]
+		with patch(_SUMMARY, return_value={"title": "Nm", "rows": rows}):
+			out = cards_enrich.enrich_text(content)
+		self.assertEqual(out, content)  # unchanged - no fence-break introduced
+		self.assertNotIn("fields", _first_card(out))
+
+	def test_bare_array_payload_is_enriched(self):
+		# The SPA/PWA accept a bare-list payload as well as {cards:[...]}; enrich it too.
+		payload = json.dumps([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+		content = f"```jarvis-cards\n{payload}\n```"
+		with patch(_SUMMARY, return_value={"title": "Nm", "rows": [{"label": "D", "value": "E"}]}):
+			out = cards_enrich.enrich_text(content)
+		data = json.loads(cards_enrich._CARDS_RE.search(out).group(1))
+		self.assertIsInstance(data, list)  # shape preserved
+		self.assertEqual(data[0]["fields"], [{"label": "D", "value": "E"}])
+
+	def test_mixed_block_fills_only_the_empty_card(self):
+		agent_fields = [{"label": "Sales", "value": "1.20L"}]
+		content = _block(
+			[
+				{"doctype": "Customer", "name": "C1", "title": "Acme", "fields": agent_fields},
+				{"doctype": "Employee", "name": "E1", "title": "E1"},
+			]
+		)
+		with patch(_SUMMARY, return_value={"title": "Nm", "rows": [{"label": "D", "value": "E"}]}) as sr:
+			out = cards_enrich.enrich_text(content)
+		cards = json.loads(cards_enrich._CARDS_RE.search(out).group(1))["cards"]
+		self.assertEqual(cards[0]["fields"], agent_fields)  # the agent's populated card is preserved
+		self.assertEqual(cards[1]["fields"], [{"label": "D", "value": "E"}])  # only the empty card is filled
+		sr.assert_called_once_with("Employee", "E1")  # only the empty card is read
+
+
+class TestEnrichIntegration(FrappeTestCase):
+	def test_real_record_fields_are_filled_end_to_end(self):
+		# No mocks on the read path: real _record_summary.summary_rows over a real DB
+		# record, real json round-trip, real regex. Proves the composition, not just the
+		# parsing. ToDo is a frappe-core doctype (no erpnext/hrms needed on the test site).
+		todo = frappe.get_doc(
+			{"doctype": "ToDo", "description": "Ship the cards fix", "priority": "High", "status": "Open"}
+		).insert()
+		try:
+			content = _block([{"doctype": "ToDo", "name": todo.name, "title": todo.name}])
+			out = cards_enrich.enrich_text(content)  # runs as the test's Administrator
+			card = _first_card(out)
+			self.assertTrue(card.get("fields"), "a real record must yield real fields")
+			values = {f["value"] for f in card["fields"]}
+			self.assertTrue(
+				any(v in values for v in ("Open", "High", "Ship the cards fix")),
+				f"expected a real ToDo value among the filled fields, got {values}",
+			)
+		finally:
+			frappe.delete_doc("ToDo", todo.name, force=True)
 
 
 class TestEnrichMessageAndEffect(FrappeTestCase):
@@ -166,7 +255,20 @@ class TestEnrichMessageAndEffect(FrappeTestCase):
 			patch("jarvis.chat.cards_enrich.frappe.db.set_value") as sv,
 		):
 			cards_enrich.enrich_message("MSG-1")
-		sv.assert_called_once_with(cards_enrich.MSG, "MSG-1", "content", enriched)
+		# update_modified=False: a background touch-up must not bump modified/modified_by.
+		sv.assert_called_once_with(cards_enrich.MSG, "MSG-1", "content", enriched, update_modified=False)
+
+	def test_enrich_message_fails_closed_without_a_concrete_owner(self):
+		# No owner anywhere -> skip (reading as the Administrator worker would bypass perms).
+		row = {"content": _block([{"doctype": "Employee", "name": "E1", "title": "E1"}]), "owner": ""}
+		with (
+			patch("jarvis.chat.cards_enrich.frappe.db.get_value", return_value=row),
+			patch("jarvis.chat.cards_enrich.enrich_text") as et,
+			patch("jarvis.chat.cards_enrich.frappe.db.set_value") as sv,
+		):
+			cards_enrich.enrich_message("MSG-1", owner=None)
+		et.assert_not_called()
+		sv.assert_not_called()
 
 	def test_enrich_message_no_write_when_unchanged(self):
 		row = {"content": "same", "owner": "u@x"}
@@ -186,10 +288,32 @@ class TestEnrichMessageAndEffect(FrappeTestCase):
 			finalize._effect_enrich_cards(ctx)
 		em.assert_not_called()
 
-	def test_finalize_effect_enriches_success_turn(self):
+	def test_finalize_effect_reads_as_the_sender_chat_user(self):
 		from jarvis.chat import finalize
 
-		ctx = MagicMock(errored=False, turn={"assistant_message": "MSG-1"}, owner="u@x")
+		ctx = MagicMock(
+			errored=False,
+			turn={"assistant_message": "MSG-1"},
+			owner="owner@x",
+			payload={"chat_user": "sender@x"},
+		)
 		with patch("jarvis.chat.cards_enrich.enrich_message") as em:
 			finalize._effect_enrich_cards(ctx)
-		em.assert_called_once_with("MSG-1", owner="u@x")
+		# the SENDER, not the conversation owner (shared-conversation permission scope)
+		em.assert_called_once_with("MSG-1", owner="sender@x")
+
+	def test_finalize_effect_falls_back_to_owner_without_chat_user(self):
+		from jarvis.chat import finalize
+
+		ctx = MagicMock(errored=False, turn={"assistant_message": "MSG-1"}, owner="owner@x", payload={})
+		with patch("jarvis.chat.cards_enrich.enrich_message") as em:
+			finalize._effect_enrich_cards(ctx)
+		em.assert_called_once_with("MSG-1", owner="owner@x")
+
+	def test_finalize_effect_no_assistant_message(self):
+		from jarvis.chat import finalize
+
+		ctx = MagicMock(errored=False, turn={}, owner="owner@x", payload={"chat_user": "s@x"})
+		with patch("jarvis.chat.cards_enrich.enrich_message") as em:
+			finalize._effect_enrich_cards(ctx)
+		em.assert_not_called()

--- a/jarvis/tests/test_cards_enrich.py
+++ b/jarvis/tests/test_cards_enrich.py
@@ -1,0 +1,195 @@
+"""Tests for jarvis.chat.cards_enrich - the deterministic backend floor that fills an
+id-only ``jarvis-cards`` block with the record's own fields (B).
+
+The logic tests patch ``_record_summary.summary_rows`` so they exercise the parsing,
+the only-fill-empty rule, idempotency, and the fence handling without needing seeded
+records - the permission-checked read itself is covered by test_record_summary.py. A
+few wiring tests cover the owner impersonation, the finalize effect's errored-skip, and
+the write-back.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import cards_enrich
+
+_SUMMARY = "jarvis.chat._record_summary.summary_rows"
+
+
+def _block(cards: list[dict], title: str = "Records") -> str:
+	"""A ```jarvis-cards fence carrying ``cards``, as the agent would emit it."""
+	payload = json.dumps({"title": title, "cards": cards})
+	return f"Here you go:\n\n```jarvis-cards\n{payload}\n```"
+
+
+def _first_card(content: str) -> dict:
+	"""Parse the first jarvis-cards block out of ``content`` and return card[0]."""
+	m = cards_enrich._CARDS_RE.search(content)
+	return json.loads(m.group(1))["cards"][0]
+
+
+class TestEnrichCard(FrappeTestCase):
+	def test_id_only_card_is_filled_and_title_promoted(self):
+		rows = [{"label": "Department", "value": "Engineering"}, {"label": "Status", "value": "Active"}]
+		content = _block([{"doctype": "Employee", "name": "HR-EMP-0001", "title": "HR-EMP-0001"}])
+		with patch(_SUMMARY, return_value={"title": "Priya Nair", "rows": rows}) as sr:
+			out = cards_enrich.enrich_text(content)
+		sr.assert_called_once_with("Employee", "HR-EMP-0001")
+		card = _first_card(out)
+		self.assertEqual(card["fields"], rows)
+		# the title was the id, so it is promoted to the record's human name
+		self.assertEqual(card["title"], "Priya Nair")
+
+	def test_card_with_fields_is_left_untouched(self):
+		# The agent's own dynamic choice (skill A) wins: never override a populated card.
+		agent_fields = [{"label": "Sales", "value": "1.20L"}]
+		content = _block(
+			[{"doctype": "Customer", "name": "Acme", "title": "Acme Ltd", "fields": agent_fields}]
+		)
+		with patch(_SUMMARY) as sr:
+			out = cards_enrich.enrich_text(content)
+		sr.assert_not_called()
+		self.assertEqual(out, content)
+
+	def test_card_without_doctype_or_name_is_skipped(self):
+		content = _block([{"title": "Mystery"}])  # nothing to look the record up by
+		with patch(_SUMMARY) as sr:
+			out = cards_enrich.enrich_text(content)
+		sr.assert_not_called()
+		self.assertEqual(out, content)
+
+	def test_unreadable_or_missing_record_is_left_as_id(self):
+		# summary_rows returns None when the record is gone or the user cannot read it.
+		# Never fabricate - the card stays id-only rather than inventing values.
+		content = _block([{"doctype": "Employee", "name": "HR-EMP-9999", "title": "HR-EMP-9999"}])
+		with patch(_SUMMARY, return_value=None):
+			out = cards_enrich.enrich_text(content)
+		self.assertEqual(out, content)
+		self.assertNotIn("fields", _first_card(out))
+
+	def test_summary_with_no_rows_is_left(self):
+		content = _block([{"doctype": "Employee", "name": "HR-EMP-1", "title": "HR-EMP-1"}])
+		with patch(_SUMMARY, return_value={"title": "x", "rows": []}):
+			out = cards_enrich.enrich_text(content)
+		self.assertEqual(out, content)
+
+	def test_title_kept_when_agent_set_a_real_one(self):
+		content = _block([{"doctype": "Employee", "name": "HR-EMP-1", "title": "Priya Nair"}])
+		with patch(
+			_SUMMARY, return_value={"title": "Something Else", "rows": [{"label": "S", "value": "A"}]}
+		):
+			out = cards_enrich.enrich_text(content)
+		self.assertEqual(_first_card(out)["title"], "Priya Nair")  # not overwritten
+
+
+class TestEnrichText(FrappeTestCase):
+	def test_no_cards_block_returns_verbatim(self):
+		content = "Just a plain reply with no card fence."
+		with patch(_SUMMARY) as sr:
+			self.assertEqual(cards_enrich.enrich_text(content), content)
+		sr.assert_not_called()
+
+	def test_malformed_block_is_left_verbatim(self):
+		content = "```jarvis-cards\n{ this is not json\n```"
+		with patch(_SUMMARY) as sr:
+			out = cards_enrich.enrich_text(content)
+		sr.assert_not_called()
+		self.assertEqual(out, content)
+
+	def test_multiple_blocks_all_enriched(self):
+		rows = [{"label": "Dept", "value": "Eng"}]
+		content = (
+			_block([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+			+ "\n"
+			+ _block([{"doctype": "Employee", "name": "E2", "title": "E2"}])
+		)
+		with patch(_SUMMARY, return_value={"title": "n", "rows": rows}):
+			out = cards_enrich.enrich_text(content)
+		blocks = cards_enrich._CARDS_RE.findall(out)
+		self.assertEqual(len(blocks), 2)
+		for raw in blocks:
+			self.assertEqual(json.loads(raw)["cards"][0]["fields"], rows)
+
+	def test_other_fences_are_untouched(self):
+		ask = '```jarvis-ask\n[{"q":"Which?","type":"yesno"}]\n```'
+		content = ask + "\n" + _block([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+		with patch(_SUMMARY, return_value={"title": "n", "rows": [{"label": "D", "value": "E"}]}):
+			out = cards_enrich.enrich_text(content)
+		self.assertIn(ask, out)  # the ask fence survives byte-for-byte
+
+	def test_idempotent(self):
+		content = _block([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+		with patch(_SUMMARY, return_value={"title": "Nm", "rows": [{"label": "D", "value": "E"}]}) as sr:
+			once = cards_enrich.enrich_text(content)
+			twice = cards_enrich.enrich_text(once)
+		self.assertEqual(once, twice)  # second pass is a no-op
+		sr.assert_called_once()  # the now-filled card is not re-read
+
+	def test_exception_returns_original(self):
+		content = _block([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+		with patch(_SUMMARY, side_effect=RuntimeError("boom")):
+			out = cards_enrich.enrich_text(content)
+		self.assertEqual(out, content)  # degrades to the original, never raises
+
+	def test_reads_are_bounded_by_max_cards(self):
+		cards = [
+			{"doctype": "Employee", "name": f"E{i}", "title": f"E{i}"}
+			for i in range(cards_enrich._MAX_CARDS + 5)
+		]
+		with patch(_SUMMARY, return_value={"title": "n", "rows": [{"label": "D", "value": "E"}]}) as sr:
+			cards_enrich.enrich_text(_block(cards))
+		self.assertLessEqual(sr.call_count, cards_enrich._MAX_CARDS)
+
+	def test_owner_is_impersonated_for_the_read(self):
+		content = _block([{"doctype": "Employee", "name": "E1", "title": "E1"}])
+		with (
+			patch("jarvis.chat.cards_enrich.impersonate") as imp,
+			patch(_SUMMARY, return_value={"title": "n", "rows": [{"label": "D", "value": "E"}]}),
+			patch("jarvis.chat.cards_enrich.frappe.session") as sess,
+		):
+			sess.user = "administrator@example.com"
+			cards_enrich.enrich_text(content, owner="tenant@example.com")
+		imp.assert_called_once_with("tenant@example.com")
+
+
+class TestEnrichMessageAndEffect(FrappeTestCase):
+	def test_enrich_message_writes_back_only_when_changed(self):
+		row = {"content": _block([{"doctype": "Employee", "name": "E1", "title": "E1"}]), "owner": "u@x"}
+		enriched = "ENRICHED"
+		with (
+			patch("jarvis.chat.cards_enrich.frappe.db.get_value", return_value=row),
+			patch("jarvis.chat.cards_enrich.enrich_text", return_value=enriched),
+			patch("jarvis.chat.cards_enrich.frappe.db.set_value") as sv,
+		):
+			cards_enrich.enrich_message("MSG-1")
+		sv.assert_called_once_with(cards_enrich.MSG, "MSG-1", "content", enriched)
+
+	def test_enrich_message_no_write_when_unchanged(self):
+		row = {"content": "same", "owner": "u@x"}
+		with (
+			patch("jarvis.chat.cards_enrich.frappe.db.get_value", return_value=row),
+			patch("jarvis.chat.cards_enrich.enrich_text", return_value="same"),
+			patch("jarvis.chat.cards_enrich.frappe.db.set_value") as sv,
+		):
+			cards_enrich.enrich_message("MSG-1")
+		sv.assert_not_called()
+
+	def test_finalize_effect_skips_errored_turn(self):
+		from jarvis.chat import finalize
+
+		ctx = MagicMock(errored=True, turn={"assistant_message": "MSG-1"}, owner="u@x")
+		with patch("jarvis.chat.cards_enrich.enrich_message") as em:
+			finalize._effect_enrich_cards(ctx)
+		em.assert_not_called()
+
+	def test_finalize_effect_enriches_success_turn(self):
+		from jarvis.chat import finalize
+
+		ctx = MagicMock(errored=False, turn={"assistant_message": "MSG-1"}, owner="u@x")
+		with patch("jarvis.chat.cards_enrich.enrich_message") as em:
+			finalize._effect_enrich_cards(ctx)
+		em.assert_called_once_with("MSG-1", owner="u@x")


### PR DESCRIPTION
## Problem
When Jarvis lists records ("fetch 5 employees"), each result card sometimes rendered showing **only the record id** — the agent-authored `jarvis-cards` block left `fields` empty and the SPA falls back to `name`.

Persona guidance (**A**, jarvis-persona #183) tells the agent to fill fields dynamically, but that's model-dependent. **This is the deterministic floor (B):** any card with a `doctype`+`name` but no fields is filled server-side from the record's own schema, so a browse-cards block can never render id-only regardless of what the model emitted.

## How
- **`jarvis/chat/cards_enrich.py`** (new): parse `jarvis-cards` blocks (regex mirrors the SPA), fill **only empty** cards (the agent's own choice always wins) via `_record_summary.summary_rows` — which already does the permission-checked read, field-level masking, secret masking, and schema-driven field pick. Runs under `impersonate(chat_user)` so reads use the **sender's** permissions. Best-effort, idempotent, bounded (`_MAX_CARDS`).
- **`finalize.py`**: new `enrich_cards` finalize effect — runs for every settled success turn, every transport; the existing `message:enriched` publish refreshes the client. Ordered after `terminal_publish` so the answer still lands first.
- **`turn_state.EFFECT_NAMES`** + the `Jarvis Turn Effect` doctype description: add to the canonical effect vocabulary (JF-002).

## Safety (verified by a 3-lane review + fix wave)
- **Cannot stuck a turn** — best-effort (swallows all, incl. the write), import-error path force-dones after 3 attempts, work bounded, off the user's critical path (settlement releases the slot + publishes `run:end` before finalize).
- **Permission-safe** — reads as `chat_user` (the sender, matching the rest of the turn pipeline), **fails closed** if no concrete identity resolves (never the Administrator worker).
- **Never corrupts the message** — refuses to write back a block whose serialized body contains the fence delimiter (a DB value with ``` would truncate the fence client-side); matches the SPA's `Array.isArray` empty-check and its bare-array payload shape.
- `update_modified=False` on the write-back (no `modified`/`modified_by` churn).
- XSS-safe (values render through escaped Vue interpolation).

## Tests
`test_cards_enrich.py` — **26 tests, all green** on `jarvis.test`: fill / skip-filled / no-doctype / unreadable(no-fabricate) / idempotent / malformed / other-fences-untouched / multiple-blocks / bounded / fence-delimiter-refused / non-list-fields / bare-array / mixed-block / fail-closed / update_modified / reads-inside-impersonation / chat_user identity / and a **real-record end-to-end** through `summary_rows` + DB. JF-002 vocab invariants stay green (66 tests).

Pairs with jarvis-persona #183 (A). A is the request-tailored choice when the model complies; B is the schema-driven floor when it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)