### PR TITLE
Give chat turn errors a customer-facing cause and a retry hint

### DIFF
--- a/frontend/src/components/ActionError.vue
+++ b/frontend/src/components/ActionError.vue
@@ -29,8 +29,9 @@ const props = defineProps({
 });
 
 // Plain-language headline keyed by the wire `code`. This is the ACTION-failure
-// axis - distinct from ChatView's run/transport ERROR_HEADLINES, kept separate
-// on purpose.
+// axis - distinct from ChatView's run/transport taxonomy (lib/errors.js
+// turnErrorInfo, formerly ChatView's own ERROR_HEADLINES before #702), kept
+// separate on purpose.
 const HEADLINES = {
 	PermissionDeniedError: "You don't have permission to do this",
 	InvalidArgumentError: "Some values need attention",

--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -93,8 +93,8 @@ export function errHtml(e, fallback) {
 // ---------------------------------------------------------------------------
 // Chat TURN failures (#702): the counterpart to errMessage() above, for a
 // chat turn's `error` column instead of a Frappe API exception. That text is
-// raw prose relayed from openclaw over the realtime channel, sometimes
-// verbatim - #702 was openclaw reporting "LLM request failed: network
+// raw prose relayed from the agent gateway over the realtime channel, sometimes
+// verbatim - #702 was the agent reporting "LLM request failed: network
 // connection error." for a turn that failed for an entirely different reason
 // (a device-pairing file caught mid-rewrite), which the SPA had no way to
 // tell apart from a real network failure. Mirrors the operator-facing
@@ -165,6 +165,7 @@ function classifyTurnErrorCode(raw) {
 		[
 			"quota",
 			"rate limit",
+			"rate-limit",
 			"cooldown",
 			"overloaded",
 			"insufficient",
@@ -173,7 +174,7 @@ function classifyTurnErrorCode(raw) {
 		].some((k) => low.includes(k))
 	)
 		return "provider";
-	// #702: openclaw's own mid-run failure text (e.g. "LLM request failed:
+	// #702: the agent's own mid-run failure text (e.g. "LLM request failed:
 	// network connection error.", relayed verbatim) is not a reliable signal
 	// that the network was actually the problem - see the module comment
 	// above. A run that got far enough to be accepted and start is

--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -89,3 +89,115 @@ export function escapeHtml(v) {
 export function errHtml(e, fallback) {
 	return escapeHtml(errMessage(e, fallback));
 }
+
+// ---------------------------------------------------------------------------
+// Chat TURN failures (#702): the counterpart to errMessage() above, for a
+// chat turn's `error` column instead of a Frappe API exception. That text is
+// raw prose relayed from openclaw over the realtime channel, sometimes
+// verbatim - #702 was openclaw reporting "LLM request failed: network
+// connection error." for a turn that failed for an entirely different reason
+// (a device-pairing file caught mid-rewrite), which the SPA had no way to
+// tell apart from a real network failure. Mirrors the operator-facing
+// taxonomy in jarvis/chat/turn_handler.py::_classify_error - keep both in
+// sync when either changes.
+//
+// A live run:error event carries its own `code` (server-classified, richer
+// context available there - e.g. the raised exception's type). A reloaded
+// conversation only has the persisted error STRING (errorMeta in
+// ChatView.vue is not persisted), so it falls back to classifying that text
+// here. turnErrorInfo() is the single entry point for both cases.
+//
+// MUST be total, same contract as errMessage above: given ANY shape of
+// input, this never throws.
+const TURN_ERROR_HEADLINES = {
+	unreachable: "I couldn't reach the assistant",
+	timeout: "That took too long",
+	provider: "The model is busy right now",
+	"recovery-expired": "This took too long, so I stopped waiting",
+	gateway: "A temporary problem interrupted this",
+	internal: "Something went wrong",
+	cancelled: "This message was cancelled",
+};
+
+// The "what you can do" line (ActionError.vue's `hint` slot; the turn-error
+// card in ChatView.vue mirrors that shape). No entry for `cancelled` - a
+// cancelled turn renders as a muted status note, never the red error card.
+const TURN_ERROR_HINTS = {
+	unreachable: "Check your connection, then try again.",
+	timeout: "This can happen on a large request. Try again, or ask for less at once.",
+	provider:
+		"This looks like a provider limit or billing issue. Check your plan, then try again.",
+	"recovery-expired": "Send your message again to start a fresh run.",
+	gateway: "This is usually a brief hiccup on our side. Try sending your message again.",
+	internal: "Try again. If it keeps happening, contact support.",
+};
+
+function classifyTurnErrorCode(raw) {
+	// String(raw ?? "") rather than `raw || ""`: a truthy non-string (a number,
+	// an object) would otherwise reach .toLowerCase() below and throw, which
+	// classifyErrorCode (the function this replaced) did not guard against.
+	const low = String(raw ?? "").toLowerCase();
+	// Phase-0 admission cancel markers: a queued turn cancelled by the user or
+	// aged out by the system leaves a durable transcript marker so a later
+	// reload shows WHY there's no reply (not a silent drop). Classified as
+	// "cancelled" so it renders as a muted note, not a red "something went
+	// wrong".
+	if (
+		low.startsWith("you cancelled this message") ||
+		low.startsWith("waited too long in the queue")
+	)
+		return "cancelled";
+	// Mirrors the worker's own explicit code="internal" backstop
+	// (turn_handler.py's last-resort `except Exception`) so a reload, which
+	// only has the persisted string, classifies it the same way the live
+	// event did - not as the new "gateway" default below.
+	if (low.startsWith("unexpected worker error")) return "internal";
+	if (
+		low.includes("ws open failed") ||
+		low.includes("unreachable") ||
+		low.includes("connection timed out")
+	)
+		return "unreachable";
+	if (low.includes("recovery window")) return "recovery-expired";
+	if (low.includes("timed out") || low.includes("timeout") || low.includes("deadline"))
+		return "timeout";
+	if (
+		[
+			"quota",
+			"rate limit",
+			"cooldown",
+			"overloaded",
+			"insufficient",
+			"credit",
+			"billing",
+		].some((k) => low.includes(k))
+	)
+		return "provider";
+	// #702: openclaw's own mid-run failure text (e.g. "LLM request failed:
+	// network connection error.", relayed verbatim) is not a reliable signal
+	// that the network was actually the problem - see the module comment
+	// above. A run that got far enough to be accepted and start is
+	// presumptively a transient fault on the gateway/container side, not the
+	// unreachable/provider cases already matched above, and not a bug in our
+	// own code (that path stamps "internal" explicitly and never reaches this
+	// fallback). Defaulting here tells the customer to retry instead of the
+	// unhelpful "something went wrong".
+	return "gateway";
+}
+
+// Combined, TOTAL turn-error envelope: {code, headline, hint}. `explicitCode`
+// is the live run:error event's own `code` field when present, and always
+// wins over re-classifying `raw`; pass "" (or omit it) for a reloaded
+// conversation, which only has the persisted string.
+export function turnErrorInfo(raw, explicitCode) {
+	try {
+		const code = explicitCode || classifyTurnErrorCode(raw);
+		return {
+			code,
+			headline: TURN_ERROR_HEADLINES[code] || TURN_ERROR_HEADLINES.internal,
+			hint: TURN_ERROR_HINTS[code] || "",
+		};
+	} catch {
+		return { code: "internal", headline: TURN_ERROR_HEADLINES.internal, hint: "" };
+	}
+}

--- a/frontend/src/lib/errors.test.js
+++ b/frontend/src/lib/errors.test.js
@@ -6,7 +6,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { errMessage } from "./errors.js";
+import { errMessage, turnErrorInfo } from "./errors.js";
 
 test("extracts the first server message when present", () => {
 	assert.equal(errMessage({ messages: ["Settings -> Developer"] }), "Settings -> Developer");
@@ -121,4 +121,99 @@ test("a non-auth status keeps its own message", () => {
 		errMessage({ status: 500, message: "Internal Server Error" }),
 		"Internal Server Error"
 	);
+});
+
+// -----------------------------------------------------------------------
+// turnErrorInfo (#702): the counterpart to errMessage() above, for a chat
+// TURN's raw `error` string instead of a Frappe API exception.
+// -----------------------------------------------------------------------
+
+// The exact wire text from #702: openclaw's own generic wording for a
+// mid-run failure that was actually a device-pairing file caught mid-
+// rewrite, nothing to do with the network. Must land on "gateway" (retry),
+// not "unreachable" (we never lost the connection) and not "internal" (the
+// old behavior - a dead-end headline with no next step).
+test("#702: the observed string classifies as gateway, not unreachable or internal", () => {
+	const info = turnErrorInfo("LLM request failed: network connection error.");
+	assert.equal(info.code, "gateway");
+	assert.notEqual(info.code, "unreachable");
+	assert.notEqual(info.code, "internal");
+	assert.match(info.hint, /try/i);
+});
+
+test("a genuine transport failure stays unreachable", () => {
+	assert.equal(turnErrorInfo("ws open failed: connect ECONNREFUSED").code, "unreachable");
+	assert.equal(turnErrorInfo("agent unreachable after 3 attempts").code, "unreachable");
+});
+
+test("a provider rejection (quota/billing) stays provider", () => {
+	const info = turnErrorInfo(
+		"Google Generative AI API error (429): You exceeded your current quota."
+	);
+	assert.equal(info.code, "provider");
+});
+
+test("a recovery-window expiry and a timeout keep their own codes", () => {
+	assert.equal(
+		turnErrorInfo("Run did not finish within the recovery window.").code,
+		"recovery-expired"
+	);
+	assert.equal(turnErrorInfo("request timed out after 30s").code, "timeout");
+});
+
+// The worker's own explicit code="internal" backstop text - a page refresh
+// only has this persisted string and must reclassify it the same way the
+// live event did, not fall into the new "gateway" default.
+test("the worker backstop's own text stays internal on a reload", () => {
+	assert.equal(turnErrorInfo("unexpected worker error: TypeError").code, "internal");
+});
+
+// The live run:error event's own `code` always wins over reclassifying the
+// text - this is what lets the backend's richer classification (it has the
+// raised exception, not just its stringified message) override the text
+// heuristic.
+test("an explicit live code wins over reclassifying the text", () => {
+	const info = turnErrorInfo("some unrelated message", "provider");
+	assert.equal(info.code, "provider");
+});
+
+// #702 requirement: three failures that need different customer action must
+// not collapse into the same headline+hint.
+test("unreachable, provider and gateway are three distinct headline+hint pairs", () => {
+	const unreachable = turnErrorInfo("ws open failed");
+	const provider = turnErrorInfo("insufficient credit");
+	const gateway = turnErrorInfo("LLM request failed: network connection error.");
+	const pairs = [unreachable, provider, gateway].map((i) => `${i.headline}|${i.hint}`);
+	assert.equal(new Set(pairs).size, 3);
+	// The transient/gateway case is the one #702 asks to specifically tell the
+	// customer to retry.
+	assert.match(gateway.hint, /try/i);
+});
+
+test("cancelled has no hint - it renders as a muted note, never the error card", () => {
+	const info = turnErrorInfo("You cancelled this message.");
+	assert.equal(info.code, "cancelled");
+	assert.equal(info.hint, "");
+});
+
+// MUST be total (same contract as errMessage above): any shape of input
+// returns a usable envelope and never throws, including a truthy non-string
+// that would otherwise crash a naive `.toLowerCase()` call.
+test("turnErrorInfo is total: null, undefined, a number and an object never throw", () => {
+	for (const raw of [null, undefined, 42, { message: "boom" }, []]) {
+		const info = turnErrorInfo(raw);
+		assert.equal(typeof info.code, "string");
+		assert.equal(typeof info.headline, "string");
+		assert.ok(info.headline.length > 0);
+	}
+});
+
+// An unrecognized wire code (e.g. a future server-side taxonomy value this
+// build doesn't know about yet) must degrade to the generic headline with no
+// hint, never crash and never render a blank headline.
+test("an unrecognized explicit code falls back to the generic headline", () => {
+	const info = turnErrorInfo("does not matter", "some-future-code-v2");
+	assert.equal(info.code, "some-future-code-v2");
+	assert.equal(info.headline, "Something went wrong");
+	assert.equal(info.hint, "");
 });

--- a/frontend/src/lib/errors.test.js
+++ b/frontend/src/lib/errors.test.js
@@ -128,7 +128,7 @@ test("a non-auth status keeps its own message", () => {
 // TURN's raw `error` string instead of a Frappe API exception.
 // -----------------------------------------------------------------------
 
-// The exact wire text from #702: openclaw's own generic wording for a
+// The exact wire text from #702: the agent's own generic wording for a
 // mid-run failure that was actually a device-pairing file caught mid-
 // rewrite, nothing to do with the network. Must land on "gateway" (retry),
 // not "unreachable" (we never lost the connection) and not "internal" (the
@@ -151,6 +151,20 @@ test("a provider rejection (quota/billing) stays provider", () => {
 		"Google Generative AI API error (429): You exceeded your current quota."
 	);
 	assert.equal(info.code, "provider");
+});
+
+// The Python mirror (turn_handler._classify_error) matches on both "rate
+// limit" and the hyphenated "rate-limit". Must agree here too, or the same
+// text classifies as provider live and gateway on a reload.
+test("a hyphenated rate-limit reads as provider, matching the Python mirror", () => {
+	assert.equal(turnErrorInfo("upstream rate-limit exceeded").code, "provider");
+});
+
+// classifyTurnErrorCode's "connection timed out" belongs to the unreachable
+// bucket (a transport failure), not the generic timeout bucket - the Python
+// mirror agrees (see test_connection_timed_out_is_unreachable_not_timeout).
+test("connection timed out is unreachable, not a generic timeout", () => {
+	assert.equal(turnErrorInfo("connection timed out").code, "unreachable");
 });
 
 test("a recovery-window expiry and a timeout keep their own codes", () => {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4358,8 +4358,9 @@ const recoveringLabel = computed(() =>
 // Phase-0 WIRES `queued` (the chip) and `cancelled` (cancelQueued toast + the
 // turn:cancelled fallback). `dispatching`/`errored`/`done` are defined for the
 // full state set but are NOT reached in Phase 0 (run:start jumps straight to the
-// pre-existing "Thinking…" UI; reply errors flow through ERROR_HEADLINES; a done
-// reply renders normally) — kept so the mapping is complete for WP-1 (SUXI-7).
+// pre-existing "Thinking…" UI; reply errors flow through turnErrorInfo
+// (lib/errors.js); a done reply renders normally), kept so the mapping is
+// complete for WP-1 (SUXI-7).
 const TURN_STATE_COPY = {
 	queued: (pos) => (pos && pos > 0 ? `Queued — ~${pos} ahead` : "Queued"),
 	// SUXF-3: the pump introduces a queued->preparing->ready window (prompt assembly

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -871,9 +871,11 @@
 											No changes were made to your data.
 										</div>
 										<!-- #702: the "what you can do" line - mirrors ActionError.vue's
-										     `.jv-ae-hint`, so a turn failure carries the same enriched
-										     {code, headline, hint, detail} shape an ACTION-card failure
-										     already does, instead of a bare message with no next step. -->
+										     `.jv-ae-hint`, so a turn failure gets the same headline + hint +
+										     expandable-raw-detail treatment an ACTION-card failure already
+										     does (headline/hint from errorInfo(m); the raw detail is m.error,
+										     shown in the "Show details" block below), instead of a bare
+										     message with no next step. -->
 										<div
 											v-if="errorInfo(m).hint"
 											style="

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -870,6 +870,21 @@
 										>
 											No changes were made to your data.
 										</div>
+										<!-- #702: the "what you can do" line - mirrors ActionError.vue's
+										     `.jv-ae-hint`, so a turn failure carries the same enriched
+										     {code, headline, hint, detail} shape an ACTION-card failure
+										     already does, instead of a bare message with no next step. -->
+										<div
+											v-if="errorInfo(m).hint"
+											style="
+												font-size: 12.5px;
+												color: var(--text-2);
+												line-height: 1.5;
+												margin-top: 6px;
+											"
+										>
+											{{ errorInfo(m).hint }}
+										</div>
 										<details style="margin-top: 4px">
 											<summary
 												style="
@@ -3636,7 +3651,7 @@ import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.v
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { normaliseAction } from "@/lib/chatAction";
-import { errMessage } from "@/lib/errors";
+import { errMessage, turnErrorInfo } from "@/lib/errors";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { pickGreeting } from "@/lib/greeting";
 import { dashboardForConversation } from "@/api/dashboards";
@@ -4331,17 +4346,11 @@ const recoveringLabel = computed(() =>
 		? "That was a big one — reorganizing the conversation and retrying…"
 		: "Reconnecting — your answer will appear here when it's ready."
 );
-// Failure taxonomy → a plain-language headline. The raw string still shows
-// behind "Show details". `code` comes from the live run:error event; a refresh
-// (which only has the persisted string) classifies it here.
-const ERROR_HEADLINES = {
-	unreachable: "I couldn't reach the assistant",
-	timeout: "That took too long",
-	provider: "The model is busy right now",
-	"recovery-expired": "This took too long, so I stopped waiting",
-	internal: "Something went wrong",
-	cancelled: "This message was cancelled",
-};
+// Failure taxonomy → a plain-language headline + "what you can do" hint. The
+// raw string still shows behind "Show details". `code` comes from the live
+// run:error event; a refresh (which only has the persisted string)
+// reclassifies it. See lib/errors.js turnErrorInfo (#702) - the single,
+// tested source for this mapping, shared with errorInfo() below.
 // Phase-0 admission (chat concurrency): the ONLY place a Turn's internal state
 // name maps to user-facing copy (SUX-8). No raw internal state name
 // ("dispatching", "queued", …) ever renders in the UI. `queued` takes a
@@ -4370,48 +4379,12 @@ function queuedChipLabel(pos, state) {
 	if (state && TURN_STATE_COPY[state] && state !== "queued") return TURN_STATE_COPY[state]();
 	return TURN_STATE_COPY.queued(pos);
 }
-function classifyErrorCode(raw) {
-	const low = (raw || "").toLowerCase();
-	// Phase-0 admission cancel markers (SUXI-4): a queued turn cancelled by the
-	// user or aged out by the system leaves a durable transcript marker so a
-	// later reload shows WHY there's no reply (not a silent drop). Classified as
-	// "cancelled" so it renders as a muted note, NOT a red "something went wrong".
-	if (
-		low.startsWith("you cancelled this message") ||
-		low.startsWith("waited too long in the queue")
-	)
-		return "cancelled";
-	if (
-		low.includes("ws open failed") ||
-		low.includes("unreachable") ||
-		low.includes("connection timed out")
-	)
-		return "unreachable";
-	if (low.includes("recovery window")) return "recovery-expired";
-	if (low.includes("timed out") || low.includes("timeout") || low.includes("deadline"))
-		return "timeout";
-	if (
-		[
-			"quota",
-			"rate limit",
-			"cooldown",
-			"overloaded",
-			"insufficient",
-			"credit",
-			"billing",
-		].some((k) => low.includes(k))
-	)
-		return "provider";
-	return "internal";
-}
+// #702: {code, headline, hint} for one message's turn error - `turnErrorInfo`
+// (lib/errors.js) is the single, tested classifier; this only adds the
+// `noChange` flag, which is per-event metadata, not part of the taxonomy.
 function errorInfo(m) {
 	const meta = errorMeta.value[m.name] || {};
-	const code = meta.code || classifyErrorCode(m.error);
-	return {
-		code,
-		headline: ERROR_HEADLINES[code] || "Something went wrong",
-		noChange: meta.changed_data === false,
-	};
+	return { ...turnErrorInfo(m.error, meta.code), noChange: meta.changed_data === false };
 }
 // Live elapsed timer shown next to the status line so a long turn reads as
 // "still working" (time ticking) rather than a frozen spinner. Hidden for the

--- a/jarvis/chat/prepare.py
+++ b/jarvis/chat/prepare.py
@@ -119,7 +119,18 @@ def run_prepare(run_id: str, relay_target_id: str | None = None) -> dict:
 		# Assembly is all best-effort reads; a hard failure here is unexpected. Error
 		# the turn (release credit) rather than dispatch a broken prompt.
 		frappe.log_error(title="prepare.assemble", message=frappe.get_traceback())
-		_prepare_error(run_id, version, assistant_msg, conversation, owner, "Could not prepare the message.")
+		# #702 review: an explicit "internal" - this is a bug in our own code
+		# (assemble_prompt raised), never a gateway/relay signal, so it must
+		# not fall through _classify_error's text guess into "gateway".
+		_prepare_error(
+			run_id,
+			version,
+			assistant_msg,
+			conversation,
+			owner,
+			"Could not prepare the message.",
+			code="internal",
+		)
 		return {"ok": False, "reason": "assemble_failed"}
 
 	# (#22/#23/#24) session bootstrap + model patch + watermark on a SHORT-LIVED
@@ -286,10 +297,21 @@ def _discard_orphan_placeholder(assistant_msg: str | None) -> None:
 			frappe.log_error(title="prepare.discard_orphan", message=frappe.get_traceback())
 
 
-def _prepare_error(run_id, version, assistant_msg, conversation, owner, error, *, exc=None) -> None:
+def _prepare_error(
+	run_id, version, assistant_msg, conversation, owner, error, *, exc=None, code=None
+) -> None:
 	"""preparing -> errored (release credit) + mark the placeholder errored + fenced
 	run:error. Best-effort; mirrors legacy's pre-ack error surface (changed_data=False
-	— the run never started)."""
+	- the run never started).
+
+	`code` lets a caller that already knows the cause skip the text/exc-based
+	guess entirely (#702 review): _classify_error's taxonomy is aimed at
+	gateway/relay failures, and a local bug in our own prompt-assembly code
+	(caught by a bare `except Exception`, no AgentUnreachableError in hand) has
+	no gateway/relay signal to classify - guessing from generic text like
+	"Could not prepare the message." would otherwise fall into the mid-run
+	"gateway" default and tell the customer to just retry a bug that a retry
+	will most likely reproduce."""
 	try:
 		if assistant_msg:
 			frappe.db.set_value(MSG, assistant_msg, {"streaming": 0, "error": (error or "")[:1000]})
@@ -300,12 +322,13 @@ def _prepare_error(run_id, version, assistant_msg, conversation, owner, error, *
 			frappe.db.rollback()
 		except Exception:
 			pass
-	try:
-		from jarvis.chat.turn_handler import _classify_error
+	if not code:
+		try:
+			from jarvis.chat.turn_handler import _classify_error
 
-		code = _classify_error(error, exc)
-	except Exception:
-		code = "internal"
+			code = _classify_error(error, exc)
+		except Exception:
+			code = "internal"
 	if owner:
 		try:
 			ts.publish_fenced(

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -2051,7 +2051,14 @@ def _handle_ack_failure(ctx: PumpContext, rs: _RunState, exc: AgentUnreachableEr
 				run_id=run_id,
 				message_id=rs.assistant_message,
 				error=err,
-				code=_classify_error(err),
+				# #702 review: pass `exc` through so this classifies the same way
+				# turn_handler's own pre-ack AgentUnreachableError path does
+				# ("unreachable", via isinstance) instead of guessing from `err`'s
+				# text alone - a rejection code like "policy_denied" matches no
+				# keyword and would otherwise fall into the mid-run "gateway"
+				# default, telling the customer a pre-ack rejection is a brief
+				# hiccup worth retrying, which it is not.
+				code=_classify_error(err, exc),
 				changed_data=False,
 				pump_epoch=ctx.epoch,
 				relay_target_id=ctx.relay_target_id,
@@ -3504,13 +3511,16 @@ def _telemetry(event: str, **fields) -> None:
 		pass
 
 
-def _classify_error(err_text: str) -> str:
+def _classify_error(err_text: str, exc=None) -> str:
 	"""Preserve today's Message.error headline classification (SUX-11) for the
-	pump's own error publishes (definite pre-ack rejection)."""
+	pump's own error publishes (definite pre-ack rejection). `exc` is forwarded
+	so a caller holding the raised AgentUnreachableError (e.g. a definite
+	pre-ack rejection) classifies the same way turn_handler's own equivalent
+	path does, rather than only ever guessing from `err_text` (#702 review)."""
 	try:
 		from jarvis.chat.turn_handler import _classify_error as _ce
 
-		return _ce(err_text)
+		return _ce(err_text, exc)
 	except Exception:
 		return "internal"
 

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1937,12 +1937,22 @@ def _create_assistant_placeholder(conv) -> "frappe.model.document.Document":
 
 def _classify_error(err_text: str, exc=None) -> str:
 	"""Map a raw error into a small operator-facing taxonomy code the SPA turns
-	into a plain-language headline. The raw text still travels as ``error`` and
-	shows behind a "Show details" disclosure - this only picks the headline."""
+	into a plain-language headline + hint. The raw text still travels as
+	``error`` and shows behind a "Show details" disclosure - this only picks
+	the headline/hint. Mirrored in frontend/src/lib/errors.js
+	(classifyTurnErrorCode) for the no-``code`` refresh path - errorMeta in
+	ChatView.vue is not persisted, so a reload reclassifies from the stored
+	error string alone. Keep both in sync when either changes (#702)."""
 	code = getattr(exc, "code", None)
 	if code == "turn-timeout":
 		return "timeout"
 	low = (err_text or "").lower()
+	# The worker's own last-resort backstop (this module's outer
+	# ``except Exception`` around handle_chat_send) stamps code="internal"
+	# explicitly and never calls this function, but a page refresh only has
+	# the persisted string - match its wording here so the two agree.
+	if low.startswith("unexpected worker error"):
+		return "internal"
 	if isinstance(exc, AgentUnreachableError) or "ws open failed" in low or "unreachable" in low:
 		return "unreachable"
 	if "recovery window" in low:
@@ -1963,7 +1973,17 @@ def _classify_error(err_text: str, exc=None) -> str:
 		)
 	):
 		return "provider"
-	return "internal"
+	# #702: a run that reached this branch already got an ack and started -
+	# it is a mid-run failure openclaw reported for itself (relay:error), not
+	# a case where WE failed to reach the gateway (that is "unreachable",
+	# above) or a specific provider rejection (that is "provider", above).
+	# openclaw's own wording here is not reliable: "LLM request failed:
+	# network connection error." was the verbatim text for a turn that
+	# actually failed because openclaw's paired-device file was mid-rewrite,
+	# nothing to do with the network. Defaulting to "gateway" instead of the
+	# old "internal" tells the customer this is likely transient and worth a
+	# retry, rather than the unhelpful "something went wrong".
+	return "gateway"
 
 
 def _mark_errored(assistant_msg_name: str, error: str) -> None:

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1953,7 +1953,17 @@ def _classify_error(err_text: str, exc=None) -> str:
 	# the persisted string - match its wording here so the two agree.
 	if low.startswith("unexpected worker error"):
 		return "internal"
-	if isinstance(exc, AgentUnreachableError) or "ws open failed" in low or "unreachable" in low:
+	# "connection timed out" is a transport failure (we could not reach the
+	# gateway), not a generic timeout (the model took too long to answer) -
+	# keep it in this branch, matching classifyTurnErrorCode in
+	# frontend/src/lib/errors.js, so the same text does not classify as
+	# "unreachable" live and "timeout" on a reload.
+	if (
+		isinstance(exc, AgentUnreachableError)
+		or "ws open failed" in low
+		or "unreachable" in low
+		or "connection timed out" in low
+	):
 		return "unreachable"
 	if "recovery window" in low:
 		return "recovery-expired"
@@ -1974,12 +1984,12 @@ def _classify_error(err_text: str, exc=None) -> str:
 	):
 		return "provider"
 	# #702: a run that reached this branch already got an ack and started -
-	# it is a mid-run failure openclaw reported for itself (relay:error), not
+	# it is a mid-run failure the agent reported for itself (relay:error), not
 	# a case where WE failed to reach the gateway (that is "unreachable",
 	# above) or a specific provider rejection (that is "provider", above).
-	# openclaw's own wording here is not reliable: "LLM request failed:
+	# The agent's own wording here is not reliable: "LLM request failed:
 	# network connection error." was the verbatim text for a turn that
-	# actually failed because openclaw's paired-device file was mid-rewrite,
+	# actually failed because the agent's paired-device file was mid-rewrite,
 	# nothing to do with the network. Defaulting to "gateway" instead of the
 	# old "internal" tells the customer this is likely transient and worth a
 	# retry, rather than the unhelpful "something went wrong".

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -328,6 +328,9 @@
 						     cannot swamp a 400px panel. -->
 						<div v-if="turnError" class="jvp-turn-err" role="alert">
 							<div class="jvp-turn-err-h">{{ turnErrorHeadline }}</div>
+							<div v-if="turnErrorHint" class="jvp-turn-err-hint">
+								{{ turnErrorHint }}
+							</div>
 							<pre v-if="turnErrorOpen" class="jvp-turn-err-raw">{{
 								turnError
 							}}</pre>
@@ -699,25 +702,43 @@ const loadError = ref("");
 // (auth_permanent) looked exactly like a reply that never came.
 const turnError = ref("");
 const turnErrorOpen = ref(false); // "Show details" disclosure
-// Mirrors the full chat's ERROR_HEADLINES / classifyErrorCode (ChatView.vue) so
-// both surfaces name the same failure the same way. Raw provider errors are
-// unreadable here — an OAuth 401 arrives as a multi-line JSON blob — so the
-// headline is what shows and the raw text hides behind "Show details".
+// Mirrors the full chat's turnErrorInfo / classifyTurnErrorCode
+// (frontend/src/lib/errors.js, formerly ChatView.vue's own ERROR_HEADLINES /
+// classifyErrorCode before #702) so both surfaces name the same failure the
+// same way. This widget is a separate Desk-bundled build with no import path
+// into frontend/src/lib, so the mapping is kept here as its own copy - keep
+// this in sync by hand whenever errors.js's taxonomy changes (#702 review:
+// this copy had silently drifted once already, still showing the old
+// generic "Something went wrong" for the exact failure #702 was filed on).
+// Raw provider errors are unreadable here - an OAuth 401 arrives as a
+// multi-line JSON blob - so the headline is what shows and the raw text
+// hides behind "Show details".
 const _ERROR_HEADLINES = {
 	unreachable: "I couldn't reach the assistant",
 	timeout: "That took too long",
 	provider: "The model is busy right now",
 	"recovery-expired": "This took too long, so I stopped waiting",
+	gateway: "A temporary problem interrupted this",
 	internal: "Something went wrong",
 	cancelled: "This message was cancelled",
 };
+const _ERROR_HINTS = {
+	unreachable: "Check your connection, then try again.",
+	timeout: "This can happen on a large request. Try again, or ask for less at once.",
+	provider:
+		"This looks like a provider limit or billing issue. Check your plan, then try again.",
+	"recovery-expired": "Send your message again to start a fresh run.",
+	gateway: "This is usually a brief hiccup on our side. Try sending your message again.",
+	internal: "Try again. If it keeps happening, contact support.",
+};
 function classifyErrorCode(raw) {
-	const low = (raw || "").toLowerCase();
+	const low = String(raw ?? "").toLowerCase();
 	if (
 		low.startsWith("you cancelled this message") ||
 		low.startsWith("waited too long in the queue")
 	)
 		return "cancelled";
+	if (low.startsWith("unexpected worker error")) return "internal";
 	if (
 		low.includes("ws open failed") ||
 		low.includes("unreachable") ||
@@ -731,6 +752,7 @@ function classifyErrorCode(raw) {
 		[
 			"quota",
 			"rate limit",
+			"rate-limit",
 			"cooldown",
 			"overloaded",
 			"insufficient",
@@ -739,12 +761,16 @@ function classifyErrorCode(raw) {
 		].some((k) => low.includes(k))
 	)
 		return "provider";
-	return "internal";
+	// #702: a run that reached here already started - a mid-run gateway/relay
+	// hiccup, not "internal". See errors.js's classifyTurnErrorCode for the
+	// full reasoning (this is the fallback that regressed once already).
+	return "gateway";
 }
 const turnErrorCode = computed(() => classifyErrorCode(turnError.value));
 const turnErrorHeadline = computed(
 	() => _ERROR_HEADLINES[turnErrorCode.value] || "Something went wrong"
 );
+const turnErrorHint = computed(() => _ERROR_HINTS[turnErrorCode.value] || "");
 // Only offer the raw text when it says more than the headline already does.
 const turnErrorHasDetail = computed(() => {
 	const t = (turnError.value || "").trim();
@@ -1953,6 +1979,12 @@ defineExpose({ load, startNewChat, convId });
 	font-size: 13px;
 	font-weight: 600;
 	color: var(--jv-danger);
+}
+.jvp-turn-err-hint {
+	font-size: 11.5px;
+	line-height: 1.4;
+	color: var(--jv-text-2, inherit);
+	opacity: 0.85;
 }
 .jvp-turn-err-raw {
 	margin: 0;

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -1047,6 +1047,11 @@ class TestSuxf2AckFailureContract(_PipelineCase):
 		self.assertEqual(self._state(rid), "errored")
 		err = next(p for p in self._pubs if p.get("kind") == "run:error")
 		self.assertIs(err.get("changed_data"), False, "SUXF-2: pre-ack rejection => changed_data False")
+		# #702 review: a definite pre-ack rejection ("policy_denied", no keyword
+		# match) must classify like turn_handler's own equivalent pre-ack path
+		# ("unreachable"), not fall into the mid-run "gateway" default and tell
+		# the customer a rejection is a brief hiccup worth retrying.
+		self.assertEqual(err.get("code"), "unreachable")
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -319,3 +319,66 @@ class TestClassifyError(unittest.TestCase):
 	def test_empty_and_none_degrade_to_gateway_not_a_crash(self):
 		self.assertEqual(turn_handler._classify_error(""), "gateway")
 		self.assertEqual(turn_handler._classify_error(None), "gateway")
+
+	def test_a_definite_pre_ack_rejection_stays_unreachable_when_exc_is_passed(self):
+		# #702 review: pump._handle_ack_failure holds an AgentUnreachableError for
+		# a definite pre-ack rejection (e.g. "policy_denied", no keyword match in
+		# the text). Passing that exc through (as turn_handler's own equivalent
+		# pre-ack path already does) must classify it "unreachable", not fall
+		# into the new mid-run "gateway" default meant for a run that already
+		# started.
+		exc = AgentUnreachableError("chat.send rejected: policy_denied: nope")
+		code = turn_handler._classify_error("chat.send rejected: policy_denied: nope", exc=exc)
+		self.assertEqual(code, "unreachable")
+
+
+class TestPumpClassifyErrorForwardsExc(unittest.TestCase):
+	"""pump._classify_error (#702 review): must forward `exc` to
+	turn_handler._classify_error rather than only ever guessing from text, or
+	a definite pre-ack rejection it holds an AgentUnreachableError for
+	silently drops that signal and falls into the "gateway" default."""
+
+	def test_exc_is_forwarded_and_changes_the_result(self):
+		from jarvis.chat import pump
+		from jarvis.exceptions import AgentUnreachableError as AUE
+
+		text = "chat.send rejected: policy_denied: nope"
+		self.assertEqual(pump._classify_error(text), "gateway", "text alone has no keyword match")
+		self.assertEqual(
+			pump._classify_error(text, AUE(text)),
+			"unreachable",
+			"the same text with `exc` passed must match turn_handler's own pre-ack path",
+		)
+
+
+class TestPrepareErrorCodeOverride(FrappeTestCase):
+	"""prepare._prepare_error's `code` param (#702 review): a caller that
+	already knows the cause (a local bug, not a gateway/relay signal) must be
+	able to skip _classify_error's guess entirely - otherwise a generic
+	message like "Could not prepare the message." falls into the "gateway"
+	default and tells the customer a bug in our own code is a brief hiccup
+	worth retrying."""
+
+	def _run(self, *, code=None, error="boom"):
+		from jarvis.chat import prepare
+
+		published = {}
+		with (
+			patch("jarvis.chat.turn_state.prepare_errored", return_value=True),
+			patch(
+				"jarvis.chat.turn_state.publish_fenced",
+				side_effect=lambda *a, **kw: published.update(kw),
+			),
+			patch("frappe.db.set_value"),
+			patch("frappe.db.commit"),
+		):
+			prepare._prepare_error("run1", 1, "msg1", "conv1", "user1", error, code=code)
+		return published
+
+	def test_explicit_code_bypasses_classification(self):
+		published = self._run(code="internal", error="Could not prepare the message.")
+		self.assertEqual(published.get("code"), "internal")
+
+	def test_no_explicit_code_falls_back_to_classify_error(self):
+		published = self._run(error="insufficient credit")
+		self.assertEqual(published.get("code"), "provider")

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -17,6 +17,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import agent_session_pool, turn_handler, worker
+from jarvis.exceptions import AgentUnreachableError
 from jarvis.tests.test_chat_api import (
 	TEST_USER,
 	_cleanup_user_conversations,
@@ -241,3 +242,73 @@ class TestOrgLocaleClause(unittest.TestCase):
 
 	def test_empty_site_yields_empty_clause(self):
 		self.assertEqual(self._run(company=None, default=None), "")
+
+
+class TestClassifyError(unittest.TestCase):
+	"""_classify_error is the single, shared source for a turn error's `code`
+	(#702) - settlement.py, pump.py and prepare.py all delegate to it, and
+	frontend/src/lib/errors.js mirrors it for the no-`code` reload path. Pure
+	string classification, no DB/site access, mirroring TestOrgLocaleClause
+	above."""
+
+	def test_the_702_string_is_gateway_not_internal(self):
+		# The exact wire text observed in #702: openclaw's own generic wording
+		# for a mid-run failure that was actually a device-pairing file caught
+		# mid-rewrite, nothing to do with the network. Must NOT fall into
+		# "unreachable" (that is reserved for OUR OWN failure to reach the
+		# gateway) and must NOT fall into "internal" (that headline offers no
+		# next step; "gateway" tells the customer to retry).
+		code = turn_handler._classify_error("LLM request failed: network connection error.")
+		self.assertEqual(code, "gateway")
+		self.assertNotEqual(code, "unreachable")
+		self.assertNotEqual(code, "internal")
+
+	def test_our_own_unreachable_gateway_stays_unreachable(self):
+		# A genuine pre-ack transport failure (WE couldn't reach openclaw) is a
+		# DIFFERENT failure surface than #702's mid-run gateway hiccup and must
+		# keep its own code - retrying the same way won't help either, but the
+		# customer-facing story ("I couldn't reach the assistant") is honest
+		# about what actually happened.
+		self.assertEqual(turn_handler._classify_error("ws open failed: connect ECONNREFUSED"), "unreachable")
+		exc = AgentUnreachableError("agent WS closed: 1006")
+		self.assertEqual(turn_handler._classify_error("agent WS closed: 1006", exc=exc), "unreachable")
+
+	def test_provider_rejection_stays_provider(self):
+		# An upstream LLM provider's own decline (quota/billing/rate limit) is
+		# actionable in a way a retry is not - must not collapse into "gateway".
+		code = turn_handler._classify_error(
+			"Google Generative AI API error (429): You exceeded your current quota."
+		)
+		self.assertEqual(code, "provider")
+
+	def test_worker_backstop_text_stays_internal_on_a_reload(self):
+		# turn_handler's outer `except Exception` backstop stamps code="internal"
+		# directly (bypassing this function) on the LIVE event; a reloaded
+		# conversation only has the persisted string and must reclassify it the
+		# same way, not fall into the new "gateway" default.
+		code = turn_handler._classify_error("unexpected worker error: TypeError")
+		self.assertEqual(code, "internal")
+
+	def test_recovery_and_timeout_unaffected_by_the_new_default(self):
+		self.assertEqual(
+			turn_handler._classify_error("Run did not finish within the recovery window."),
+			"recovery-expired",
+		)
+		self.assertEqual(turn_handler._classify_error("request timed out after 30s"), "timeout")
+		exc = AgentUnreachableError("chat.send timed out", code="turn-timeout")
+		self.assertEqual(turn_handler._classify_error("chat.send timed out", exc=exc), "timeout")
+
+	def test_three_distinct_customer_actions_are_actually_distinct(self):
+		# #702 requirement: a genuine network/timeout failure, a provider
+		# rejection, and a transient gateway fault must not collapse into the
+		# same code (which is what drives the headline+hint in errors.js).
+		codes = {
+			turn_handler._classify_error("ws open failed"),
+			turn_handler._classify_error("insufficient credit"),
+			turn_handler._classify_error("LLM request failed: network connection error."),
+		}
+		self.assertEqual(codes, {"unreachable", "provider", "gateway"})
+
+	def test_empty_and_none_degrade_to_gateway_not_a_crash(self):
+		self.assertEqual(turn_handler._classify_error(""), "gateway")
+		self.assertEqual(turn_handler._classify_error(None), "gateway")

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -252,7 +252,7 @@ class TestClassifyError(unittest.TestCase):
 	above."""
 
 	def test_the_702_string_is_gateway_not_internal(self):
-		# The exact wire text observed in #702: openclaw's own generic wording
+		# The exact wire text observed in #702: the agent's own generic wording
 		# for a mid-run failure that was actually a device-pairing file caught
 		# mid-rewrite, nothing to do with the network. Must NOT fall into
 		# "unreachable" (that is reserved for OUR OWN failure to reach the
@@ -264,7 +264,7 @@ class TestClassifyError(unittest.TestCase):
 		self.assertNotEqual(code, "internal")
 
 	def test_our_own_unreachable_gateway_stays_unreachable(self):
-		# A genuine pre-ack transport failure (WE couldn't reach openclaw) is a
+		# A genuine pre-ack transport failure (WE couldn't reach the agent) is a
 		# DIFFERENT failure surface than #702's mid-run gateway hiccup and must
 		# keep its own code - retrying the same way won't help either, but the
 		# customer-facing story ("I couldn't reach the assistant") is honest
@@ -280,6 +280,13 @@ class TestClassifyError(unittest.TestCase):
 			"Google Generative AI API error (429): You exceeded your current quota."
 		)
 		self.assertEqual(code, "provider")
+
+	def test_connection_timed_out_is_unreachable_not_timeout(self):
+		# "connection timed out" names a transport failure (we could not reach
+		# the gateway), not a generic timeout (the model took too long). Must
+		# agree with classifyTurnErrorCode in frontend/src/lib/errors.js, which
+		# already put this phrase under "unreachable".
+		self.assertEqual(turn_handler._classify_error("connection timed out"), "unreachable")
 
 	def test_worker_backstop_text_stays_internal_on_a_reload(self):
 		# turn_handler's outer `except Exception` backstop stamps code="internal"


### PR DESCRIPTION
## Summary

A failed chat turn now shows a headline naming what happened plus a retry hint, instead of openclaw's raw wire text ("LLM request failed: network connection error.") shown as an unexplained "Something went wrong", in both the main chat and the Desk mini-chat widget.

## What changed

- `turn_handler.py`: `_classify_error` gets a `gateway` code for a mid-run failure matching no unreachable/timeout/provider marker, plus an `internal` marker so a reload matches the live event.
- `frontend/src/lib/errors.js`: `turnErrorInfo()`, the counterpart to `errMessage()` for a turn's raw error text. Total, mirrors the Python taxonomy, adds a hint per code.
- `ChatView.vue`: renders the hint; classifier moves into `errors.js`, one source instead of two.
- `pump.py` / `prepare.py`: a pre-ack rejection and a local prompt-assembly bug keep an honest code, not `gateway`.
- Desk mini-chat widget (`Panel.vue`): its own separate copy of this taxonomy, synced.

## Risk and verification

- New tests pin the #702 string to `gateway`, the backstop text to `internal`, and the pre-ack/local-bug cases above.
- Frontend suite green under Node 24, pre-commit clean, hosted CI green.
- `_STALLED_ERROR` / `_ORPHAN_ERR` (pre-existing, unmatched text) also classify `gateway` now, deliberately: a lost run is best answered with a fresh message.

<details>
<summary>Error-path map and root cause</summary>

```
ChatView.vue / Panel.vue (composer send)
  -> jarvis/chat/api.py chat_send -> frappe.enqueue(jarvis.chat.worker.run_agent_turn)
  -> jarvis.chat.worker.run_agent_turn (thin shim)
  -> jarvis/chat/turn_handler.py handle_chat_send
       - AgentSession.chat_send (agent_client.py) -> WS RPC to openclaw
       - AgentSession.relay_turn_events consumes broadcast frames until a
         terminal `chat` event (state final|error|aborted)
       - a state=="error"/"aborted" chat event yields
         {"kind": "relay:error", "error": payload.get("errorMessage") or state}
         - openclaw's own errorMessage text, passed through VERBATIM. This is
           where "LLM request failed: network connection error." came from:
           openclaw's own generic wording for a mid-run failure, observed live
           to be a JSON parse race on paired.json, nothing to do with the
           network.
  -> turn_handler._publish_run_error(err_text) -> _classify_error(err_text)
       - before this PR: no keyword matched "network connection error", so it
         fell through to "internal", giving the SPA headline "Something went
         wrong" with no hint.
  -> realtime `run:error` event {error, code} -> ChatView.vue / Panel.vue
     socket handler -> headline + (new) hint; raw text stays behind
     "Show details"
```

The newer Relay-Pump path (`jarvis/chat/pump.py` -> `settlement.py`) and the
prepare-stage path (`jarvis/chat/prepare.py`) are additional callers into the
same turn, all delegating to `turn_handler._classify_error` too
(`settlement._classify`, `pump._classify_error`, `prepare._prepare_error`).
Two of them are pre-ack (the run never started: a definite gateway rejection,
or a local bug in our own prompt assembly) and needed an explicit code rather
than the new mid-run `gateway` default, since neither is "a run that started
and then hit a brief hiccup".

`ActionError.vue` (the `{ok:false, error:{code, message, detail, hint}}`
envelope named in the issue) renders a different failure surface: gated
write/tool confirmations (`jarvis/api.py _translate_write_error`). Its own
code comment says that headline vocabulary is kept separate from turn or
transport errors on purpose. Turn failures never reach that component; they
render via a hand-rolled card in `ChatView.vue` (around line 825, and its own
copy in the Desk widget's `Panel.vue`) that already mirrors its layout
(headline, details expander, retry button) but was missing the hint. This PR
gives that card the same enriched treatment `ActionError.vue` documents,
headline plus hint plus expandable raw detail, without merging the two
components, since the retry button and "no changes made" line have no
`ActionError.vue` equivalent yet.
</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is up to date with `develop`
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
