### PR TITLE
fix(onboarding): stop offering a second payment while one is still confirming

### DIFF
--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -175,10 +175,20 @@ const TABLE = {
 		actions: [ACTIONS.VERIFY],
 	},
 	[CODES.PAYMENT_CONFIRMATION_PENDING]: {
+		// A WAIT state, same treatment as PAYMENT_AUTHORIZED_PENDING_CONFIRM below
+		// (jarvis#705). This row cannot tell apart a checkout the customer never
+		// touched from a mandate they already authorized whose webhook has not
+		// landed yet, so it must never offer INITIATE for either: a live e2e run
+		// authorized a second mandate by clicking it 84 seconds after the first,
+		// before admin's own committed-money guard had anything to refuse. Nobody
+		// is stranded by CHECK alone - while the token lives, RESUME (added
+		// dynamically, see OnboardingView.vue) reopens the SAME checkout, and CHECK
+		// itself resolves a genuinely untouched one to NO_CURRENT_INTENT, which
+		// offers INITIATE.
 		headline: "We have not confirmed this payment.",
-		body: "If money was deducted, check the status before starting another payment.",
+		body: "Check the status before doing anything else. If money already moved, please do not pay again, as that would authorize a second one.",
 		tone: TONE.STATUS,
-		actions: [ACTIONS.CHECK, ACTIONS.INITIATE],
+		actions: [ACTIONS.CHECK],
 	},
 	[CODES.PAYMENT_DECLINED]: {
 		headline: "The payment was declined. No payment was confirmed.",

--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -381,8 +381,10 @@ const TABLE = {
  *
  * Deliberately NOT a code of its own: admin answers the ordinary
  * PAYMENT_CONFIRMATION_PENDING when money is parked, because a decline there
- * would invite a second payment. The flag is the only thing that distinguishes
- * the two, and it is the flag - never the code - that suppresses Pay.
+ * would invite a second payment. The flag only changes the SENTENCE now
+ * (jarvis#705 made the plain row check-only too, same as this one); it still
+ * vetoes the backend can_initiate_payment flag one layer down, in
+ * paymentMachine.js.
  */
 const PENDING_AWAITING_RECONCILIATION = Object.freeze({
 	headline: "We are still confirming your payment.",

--- a/frontend/src/onboarding/paymentCodes.test.js
+++ b/frontend/src/onboarding/paymentCodes.test.js
@@ -57,13 +57,35 @@ test("awaiting_manual_reconciliation renders as a FLAG-VARIANT of the pending co
 	const flagged = copyFor(CODES.PAYMENT_CONFIRMATION_PENDING, {
 		awaitingReconciliation: true,
 	});
-	// Same code, different sentence - the flag is what distinguishes them,
-	// because admin deliberately answers the ordinary pending code so no wizard
-	// invites a second payment.
+	// Same code, different sentence - the flag names WHY the wait is happening.
+	// Neither variant offers to pay again (jarvis#705): admin's own contract gives
+	// PAYMENT_CONFIRMATION_PENDING no recovery action at all, and inventing one is
+	// how a waiting customer gets talked into a second mandate.
 	assert.notEqual(flagged.body, plain.body);
-	assert.ok(plain.actions.includes(ACTIONS.INITIATE));
+	assert.ok(!plain.actions.includes(ACTIONS.INITIATE));
 	assert.ok(!flagged.actions.includes(ACTIONS.INITIATE));
 	assert.ok(flagged.actions.includes(ACTIONS.CHECK));
+});
+
+test("PAYMENT_CONFIRMATION_PENDING is a WAIT state: check only, never a second payment", () => {
+	// admin's own contract (signup.py's _RECOVERY_FOR_CODE) gives this code no
+	// recovery action: "there is nothing for the caller to do but wait, and
+	// inventing an action for it is how a waiting customer gets talked into
+	// paying twice." The wizard used to disagree and offer Initiate here, which
+	// is how a live e2e run authorized a second mandate 84 seconds after the
+	// first while the original subscription was still resolving (jarvis#705).
+	//
+	// Nobody is stranded by dropping Initiate: while the token lives, RESUME
+	// reopens the SAME checkout (added dynamically in OnboardingView.vue, not
+	// listed here), and CHECK itself resolves a genuinely untouched checkout to
+	// NO_CURRENT_INTENT, whose own row offers Initiate.
+	const entry = copyFor(CODES.PAYMENT_CONFIRMATION_PENDING);
+	assert.deepEqual(entry.actions, [ACTIONS.CHECK]);
+	assert.ok(
+		!entry.actions.includes(ACTIONS.INITIATE),
+		"a second intent authorizes a second mandate while the first is still resolving"
+	);
+	assert.ok(/not pay again|don't pay again|do not pay again/i.test(entry.body));
 });
 
 // The ONE code exempt from status-first, and it is exempt on the rule's own terms.
@@ -185,7 +207,7 @@ test("rows that warn about money already moving ask for CHECK first", () => {
 	// the row's own body says so out loud.
 	const pending = copyFor(CODES.PAYMENT_CONFIRMATION_PENDING);
 	assert.equal(pending.actions[0], ACTIONS.CHECK);
-	assert.match(pending.body, /check the status before starting another payment/i);
+	assert.match(pending.body, /check the status before doing anything else/i);
 
 	// The declined row carries the same warning and the same ordering.
 	const declined = copyFor(CODES.PAYMENT_DECLINED);

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2287,12 +2287,12 @@ const recoveryActions = computed(() => {
 	//
 	// But it must NOT outrank CHECK, and an earlier version of this that unshifted
 	// unconditionally did. PAYMENT_CONFIRMATION_PENDING can carry a live token AND
-	// mean "money may already have moved" - its own body says "If money was
-	// deducted, check the status before starting another payment." Making RESUME
-	// the primary button there walks the customer back to the payment page ahead of
-	// the read that would tell them they have already paid, which is precisely the
-	// double payment status-first exists to prevent. A row that asks for CHECK
-	// first has a reason; RESUME slots in behind it.
+	// mean "money may already have moved" - its own body says "Check the status
+	// before doing anything else." Making RESUME the primary button there walks
+	// the customer back to the payment page ahead of the read that would tell
+	// them they have already paid, which is precisely the double payment
+	// status-first exists to prevent. A row that asks for CHECK first has a
+	// reason; RESUME slots in behind it.
 	if (canResumeCheckout.value && !acts.includes(ACTIONS.RESUME)) {
 		const check = acts.indexOf(ACTIONS.CHECK);
 		if (check >= 0) acts.splice(check + 1, 0, ACTIONS.RESUME);


### PR DESCRIPTION
Fixes #705

The onboarding wizard no longer offers "Start a new payment" while a payment on the
same signup is still unconfirmed, so a customer can no longer authorize a second
mandate by clicking it.

## What changed
- `PAYMENT_CONFIRMATION_PENDING` now carries `actions: [CHECK]`, matching its sibling
  wait state `PAYMENT_AUTHORIZED_PENDING_CONFIRM` and admin's own contract, which
  gives this code no recovery action on purpose.
- Its body copy now says to check status before doing anything else and warns that
  paying again would authorize a second mandate.
- Extended `paymentCodes.test.js` with the same "check only, never a second payment"
  assertion the sibling state already had, and fixed the one existing test that
  asserted the old (buggy) behavior.

## Risk and verification
- A customer with a genuinely abandoned checkout is not stranded: RESUME (added
  dynamically, unaffected by this change) reopens the same live token, and CHECK
  itself resolves an untouched checkout to `NO_CURRENT_INTENT`, whose row still
  offers Initiate first. Traced in `jarvis_admin_v2/billing/signup.py`.
- `node --test` on the onboarding suite (597 tests) and `vitest run` (848 tests) pass
  under Node 24. `pre-commit` passes on the changed files.

<details><summary>Investigation: does a no-money path reach this code, and does dropping INITIATE strand it?</summary>

Yes, a live pay-page token with no money moved does reach plain
`PAYMENT_CONFIRMATION_PENDING` (`signup.py` `_signup_payment_state`, ~2863-2880: any
Pending Payment subscription with a live token, regardless of whether the customer
ever opened the gateway sheet). It is not stranded by dropping INITIATE, for two
independent reasons:

1. While the token lives, RESUME is injected dynamically by `recoveryActions` in
   `OnboardingView.vue` and reopens the same checkout, no new intent.
2. CHECK converges it: `_RECONCILE_CODES` maps a dead or never-opened intent to
   `NO_CURRENT_INTENT` (`signup.py` 2966-2967), whose row leads with Initiate. A
   Pending Payment subscription whose token has simply expired gets `NO_CURRENT_INTENT`
   directly (`signup.py` 2913-2919), same result.

So the backend already performs the split this code seemed to need, dynamically,
through CHECK and RESUME. No second wizard code was needed.

The incident mechanism: admin's `CommittedMoneyError` guard (`signup.py` 2049) that
would refuse a second intent only fires once the ledger has recorded money as
committed, which needs a webhook or an explicit reconcile. In the reported 84 second
window neither had run, so `can_initiate_payment` was still true and the button was
live and clickable. That is why the frontend must not render Initiate on this
ambiguous code at all, rather than relying on the backend flag alone.

Repo-wide grep confirmed `paymentCodes.js` is the only wizard copy table; no
duplicate exists under `pwa/`.

</details>

## Pre-merge checklist

- [x] **CI is green** - the `tests` check on this PR passes (never merge on X)
- [x] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
