### PR TITLE
fix(onboarding): honest copy + a support exit on a stuck readiness wait

### DIFF
--- a/frontend/src/onboarding/readinessWait.js
+++ b/frontend/src/onboarding/readinessWait.js
@@ -1,0 +1,42 @@
+/**
+ * Copy for the moment a bounded chat-readiness poll (waitForChatReadiness /
+ * followLegacyReadiness in OnboardingView.vue) runs out with no Ready verdict
+ * (jarvis#708).
+ *
+ * The poll's job is only ever to ask admin "is chat_readiness Ready" - it is
+ * never proof that a stalled workspace is quietly correcting itself. The copy
+ * that used to render here ("It's still finishing on its own, so you can keep
+ * waiting or retry") asserted exactly that, unconditionally, even when every
+ * poll came back with the SAME not-ready verdict for the whole wait, or with
+ * chat_readiness reasons that never advance if nobody ever acts on them (a
+ * stuck provisioning row is the case this was written against). A customer in
+ * that state had no way to tell the two apart and no way out but to keep
+ * clicking Retry forever.
+ *
+ * This module only ever says what the wait loop actually observed: whether
+ * admin answered at all (`sawVerdict` - the readiness-poll analogue of
+ * `neverConfirmed` on the LLM-apply-operation timeout a few lines up in
+ * OnboardingView.vue, jarvis#690), and admin's own last-known explanation
+ * (`detail` - jarvis.account.is_ready_for_chat's `detail`, e.g. "applying your
+ * LLM configuration"), if it ever sent one. It never says "still finishing on
+ * its own" - that is a claim about what admin is DOING, which the wait loop
+ * cannot see.
+ *
+ * Pure so `node --test` runs it without a bundler.
+ *
+ * @param {{sawVerdict?: boolean, detail?: string}} [last] - what the wait loop
+ *   observed. sawVerdict is true iff at least one poll returned a real
+ *   (non-thrown) answer, regardless of what that answer was. detail is the
+ *   most recent non-empty `detail` string across every poll of this wait.
+ * @returns {string}
+ */
+export function readinessWaitExhaustedMessage({ sawVerdict = false, detail = "" } = {}) {
+	if (!sawVerdict) {
+		return "We couldn't reach your workspace to check, so we don't know whether it's finished coming online. You're welcome to keep waiting and retry, or get a person to look into it.";
+	}
+	const trimmed = (detail || "").trim();
+	if (trimmed) {
+		return `Your workspace's last status: ${trimmed} We haven't been able to confirm that's finished, and we can't promise it's still progressing on its own. You're welcome to keep waiting and retry, or get a person to look into it.`;
+	}
+	return "Your AI connection saved, but we haven't been able to confirm your workspace has finished coming online. We can't promise it's still progressing on its own. You're welcome to keep waiting and retry, or get a person to look into it.";
+}

--- a/frontend/src/onboarding/readinessWait.test.js
+++ b/frontend/src/onboarding/readinessWait.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { readinessWaitExhaustedMessage } from "./readinessWait.js";
+
+test("no verdict ever landed: says so, never claims progress", () => {
+	const msg = readinessWaitExhaustedMessage({ sawVerdict: false, detail: "" });
+	assert.match(msg, /couldn't reach your workspace/i);
+	assert.doesNotMatch(msg, /still finishing on its own/i);
+});
+
+test("a verdict landed and carried a detail: quotes it, still no self-healing claim", () => {
+	const msg = readinessWaitExhaustedMessage({
+		sawVerdict: true,
+		detail: "applying your LLM configuration",
+	});
+	assert.match(msg, /applying your LLM configuration/);
+	assert.doesNotMatch(msg, /still finishing on its own/i);
+});
+
+test("a verdict landed with no detail: honest fallback, still no self-healing claim", () => {
+	const msg = readinessWaitExhaustedMessage({ sawVerdict: true, detail: "" });
+	assert.match(msg, /haven't been able to confirm/i);
+	assert.doesNotMatch(msg, /still finishing on its own/i);
+});
+
+test("missing input defaults to the never-heard-from-admin case", () => {
+	const msg = readinessWaitExhaustedMessage();
+	assert.match(msg, /couldn't reach your workspace/i);
+});
+
+test("a whitespace-only detail is treated as no detail", () => {
+	const msg = readinessWaitExhaustedMessage({ sawVerdict: true, detail: "   " });
+	assert.match(msg, /haven't been able to confirm/i);
+});
+
+test("never asserts anything is still finishing on its own, in any branch", () => {
+	const cases = [
+		{ sawVerdict: false, detail: "" },
+		{ sawVerdict: false, detail: "applying your LLM configuration" },
+		{ sawVerdict: true, detail: "" },
+		{ sawVerdict: true, detail: "applying your LLM configuration" },
+	];
+	for (const c of cases) {
+		assert.doesNotMatch(readinessWaitExhaustedMessage(c), /finishing on its own/i);
+	}
+});

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -581,4 +581,44 @@ describe("jarvis#708 chat-readiness wait exhaustion: honest copy + a real exit",
 		expect(w.vm.state.connectSupportOffered).toBe(false);
 		w.unmount();
 	});
+
+	it("a SUPERSEDED terminal reached AFTER a prior exhaustion withdraws the stale offer", async () => {
+		// Retry re-follows the SAME operation (no fresh saveConnect), so the flag a
+		// prior readiness-wait exhaustion set is still sitting on state when a later
+		// poll of that operation comes back superseded - a different situation
+		// ("reload and retry") that must not inherit an unrelated stale offer.
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "signup" });
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+
+		w.vm.onOpUpdate({ phase: "superseded", message: "Your workspace assignment changed." });
+
+		expect(w.vm.state.connectPhase).toBe("superseded");
+		expect(w.vm.state.connectSupportOffered).toBe(false);
+		w.unmount();
+	});
+
+	it("the generic support dead-end reached AFTER a prior exhaustion withdraws the stale offer", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "signup" });
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+
+		w.vm.onTerminal(null); // onTerminal's own dead-end: no status at all
+
+		expect(w.vm.state.connectPhase).toBe("support");
+		expect(w.vm.state.connectSupportOffered).toBe(false);
+		w.unmount();
+	});
 });

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -133,6 +133,15 @@ const readyStatus = {
 	code: "LLM_READY",
 	retry_after_seconds: 0,
 };
+// READY, but admin says the workspace itself is not chat-ready yet (chat_readiness
+// === false) - the classifyOperation branch that starts waitForChatReadiness.
+const readyChatBlockedStatus = {
+	operation_id: "op1",
+	state: "ready",
+	code: "LLM_READY",
+	chat_readiness: false,
+	retry_after_seconds: 0,
+};
 const rejectedStatus = {
 	operation_id: "op1",
 	state: "failed",
@@ -469,5 +478,107 @@ describe("§10.4 mode:legacy fallback (no durable operation)", () => {
 		expect(api.isReadyForChat).toHaveBeenCalledTimes(30);
 		expect(routerReplace).not.toHaveBeenCalled();
 		expect(w.vm.state.connectPhase).toBe("retry");
+	});
+});
+
+// jarvis#708: the chat-readiness wait (waitForChatReadiness for the durable-operation
+// path, followLegacyReadiness for mode:"legacy") used to hit its bound and render
+// "It's still finishing on its own, so you can keep waiting or retry" unconditionally
+// - a claim about admin still working the problem that the wait loop cannot see is
+// true, observed false on a tenant admin could never advance. These pin the fix: the
+// message says only what was actually observed, and the SAME poll ceiling that used to
+// offer nothing but another blind wait now also hands off to a person (mirrors
+// jarvis_admin_v2#259's checkout-shell poll ceiling: support offered at the FIRST
+// exhaustion, not after N retries).
+describe("jarvis#708 chat-readiness wait exhaustion: honest copy + a real exit", () => {
+	it("waitForChatReadiness: quotes admin's own detail, offers support, never claims self-healing", async () => {
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "container_provisioning",
+			detail: "applying your LLM configuration",
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear(); // ignore the one mount-time readiness probe
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000); // CHAT_READY_ATTEMPTS * CHAT_READY_INTERVAL_MS
+		await flushPromises();
+
+		expect(api.isReadyForChat).toHaveBeenCalledTimes(40); // exactly CHAT_READY_ATTEMPTS
+		expect(routerReplace).not.toHaveBeenCalled();
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.state.connectMessage).toMatch(/applying your LLM configuration/);
+		expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+		w.unmount();
+	});
+
+	it("waitForChatReadiness: never hearing from admin says so, not 'still finishing'", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear();
+		api.isReadyForChat.mockRejectedValue(new Error("bench hiccup"));
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(api.isReadyForChat).toHaveBeenCalledTimes(40);
+		expect(w.vm.state.connectMessage).toMatch(/couldn't reach your workspace/i);
+		expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+		w.unmount();
+	});
+
+	it("followLegacyReadiness: quotes admin's own detail and offers support at the existing ceiling", async () => {
+		saveMock.mockResolvedValue({
+			ok: true,
+			result: opResult({ apply_operation: null, resumable: false, mode: "legacy" }),
+		});
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "container_provisioning",
+			detail: "applying your LLM configuration",
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear(); // ignore the one mount-time readiness probe
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(30 * 2500); // LEGACY_READY_ATTEMPTS * LEGACY_READY_INTERVAL_MS
+		await p;
+
+		expect(api.isReadyForChat).toHaveBeenCalledTimes(30);
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.state.connectMessage).toMatch(/applying your LLM configuration/);
+		expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+	});
+
+	it("a fresh Start withdraws a previous attempt's support offer until this one exhausts too", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "signup" });
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+
+		// A genuinely new attempt: canStart still true, save parks pending (never
+		// terminal) so this test never has to reach a second exhaustion to prove the
+		// reset happened - saveConnect clears the flag synchronously, before its own
+		// first await.
+		api.getLlmApplyOperation.mockResolvedValue(pending);
+		w.vm.saveConnect();
+		await flushPromises();
+
+		expect(w.vm.state.connectSupportOffered).toBe(false);
+		w.unmount();
 	});
 });

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -70,10 +70,88 @@
 					<div
 						class="w-full overflow-hidden rounded-2xl border border-outline-gray-1 bg-surface-white shadow-2xl"
 					>
+						<!-- ===== Contact support: a real ticket, filed from here. Hoisted
+							 above every step (not just Pay, where it started) so ANY screen
+							 that offers the support action - the payment recovery/terminal/
+							 maintenance-hold cards, and now the Connect step's stuck-waiting
+							 card - reaches the SAME panel, and so it needs no portal: a
+							 teleported dialog would lose the jv-* palette vars this view
+							 binds on its own root. The action it replaces was a bare
+							 mailto:, which did nothing at all on a machine with no mail
+							 client. ===== -->
+						<section v-if="supportOpen" class="ob-screen">
+							<div class="ob-body">
+								<div class="ob-head">
+									<h1>Get help with this</h1>
+									<p v-if="!supportTicket">
+										Tell us what happened and we'll pick it up. We'll attach
+										the technical details of this screen automatically, so you
+										don't have to describe them.
+									</p>
+									<p v-else role="status">
+										Thanks. We have your request and we'll reply to
+										{{ payEmail }}.
+									</p>
+								</div>
+								<div v-if="!supportTicket" class="mx-auto w-full max-w-[560px]">
+									<FormControl
+										v-model="supportBody"
+										type="textarea"
+										variant="outline"
+										label="What happened?"
+										:rows="4"
+										placeholder="I tried to pay and..."
+									/>
+									<details class="mt-3 text-p-xs text-ink-gray-5">
+										<summary class="cursor-pointer">
+											Details we'll attach
+										</summary>
+										<pre
+											class="mt-1.5 whitespace-pre-wrap break-words rounded-md bg-surface-gray-2 p-2.5"
+											>{{ supportContext }}</pre
+										>
+									</details>
+									<!-- Filing failed. Never leave the customer with a dead
+										 button: show the address so there is always a way
+										 through. -->
+									<Banner
+										v-if="supportErr"
+										class="mt-3"
+										type="error"
+										:message="`We couldn't file that for you (${supportErr}). Please email ${SUPPORT_EMAIL} and include the details above.`"
+									/>
+								</div>
+								<div
+									v-else
+									class="mx-auto w-full max-w-[560px] text-center text-p-sm text-ink-gray-5"
+								>
+									Reference
+									<b class="font-medium text-ink-gray-9">{{ supportTicket }}</b
+									>. Please don't pay again while we look at it.
+								</div>
+							</div>
+							<div class="ob-foot">
+								<button class="ob-back" @click="closeSupport">
+									<FeatherIcon
+										name="chevron-left"
+										class="h-3.5 w-3.5 text-ink-gray-5"
+									/>Back
+								</button>
+								<Button
+									v-if="!supportTicket"
+									variant="solid"
+									:disabled="supportBusy || !supportBody.trim()"
+									:loading="supportBusy"
+									loading-text="Sending…"
+									label="Send to support"
+									@click="sendSupport"
+								/>
+							</div>
+						</section>
 						<!-- ===== Intro tour (fresh starts only; reconcile routes mid-flight
 							 signups straight to the right step, past the tour) ===== -->
 						<TourIntro
-							v-if="state.step === 'intro'"
+							v-else-if="state.step === 'intro'"
 							@finish="startWizard"
 							@skip="startWizard"
 						/>
@@ -461,92 +539,11 @@
 							 Sub-screens are driven by the machine state (pay.value), never by
 							 an HTTP status or an error message. ===== -->
 						<section v-else-if="state.step === 'pay'" class="ob-screen">
-							<!-- Contact support: a real ticket, filed from here. It sits at the
-								 HEAD of this v-if chain so every screen that offers the support
-								 action (recovery, terminal, maintenance hold) reaches the same
-								 panel, and so it needs no portal - a teleported dialog would lose
-								 the jv-* palette vars this view binds on its own root. The action
-								 it replaces was a bare mailto:, which did nothing at all on a
-								 machine with no mail client. -->
-							<template v-if="supportOpen">
-								<div class="ob-body">
-									<div class="ob-head">
-										<h1>Get help with this</h1>
-										<p v-if="!supportTicket">
-											Tell us what happened and we'll pick it up. We'll
-											attach the technical details of this screen
-											automatically, so you don't have to describe them.
-										</p>
-										<p v-else role="status">
-											Thanks. We have your request and we'll reply to
-											{{ payEmail }}.
-										</p>
-									</div>
-									<div
-										v-if="!supportTicket"
-										class="mx-auto w-full max-w-[560px]"
-									>
-										<FormControl
-											v-model="supportBody"
-											type="textarea"
-											variant="outline"
-											label="What happened?"
-											:rows="4"
-											placeholder="I tried to pay and..."
-										/>
-										<details class="mt-3 text-p-xs text-ink-gray-5">
-											<summary class="cursor-pointer">
-												Details we'll attach
-											</summary>
-											<pre
-												class="mt-1.5 whitespace-pre-wrap break-words rounded-md bg-surface-gray-2 p-2.5"
-												>{{ supportContext }}</pre
-											>
-										</details>
-										<!-- Filing failed. Never leave the customer with a dead
-											 button: show the address so there is always a way
-											 through. -->
-										<Banner
-											v-if="supportErr"
-											class="mt-3"
-											type="error"
-											:message="`We couldn't file that for you (${supportErr}). Please email ${SUPPORT_EMAIL} and include the details above.`"
-										/>
-									</div>
-									<div
-										v-else
-										class="mx-auto w-full max-w-[560px] text-center text-p-sm text-ink-gray-5"
-									>
-										Reference
-										<b class="font-medium text-ink-gray-9">{{
-											supportTicket
-										}}</b
-										>. Please don't pay again while we look at it.
-									</div>
-								</div>
-								<div class="ob-foot">
-									<button class="ob-back" @click="closeSupport">
-										<FeatherIcon
-											name="chevron-left"
-											class="h-3.5 w-3.5 text-ink-gray-5"
-										/>Back
-									</button>
-									<Button
-										v-if="!supportTicket"
-										variant="solid"
-										:disabled="supportBusy || !supportBody.trim()"
-										:loading="supportBusy"
-										loading-text="Sending…"
-										label="Send to support"
-										@click="sendSupport"
-									/>
-								</div>
-							</template>
 							<!-- Paid: the payment step is over. Receipt + workspace-setup
 								 projection, rendered separately (plan 02 §Paid/provisioning).
 								 Provisioning belongs to the readiness gate, so this shows status
 								 only and never a payment action. -->
-							<template v-else-if="showPaidFlash || showProvisioning">
+							<template v-if="showPaidFlash || showProvisioning">
 								<div class="ob-body">
 									<div class="ob-head">
 										<h1>
@@ -1206,6 +1203,21 @@
 													@click="retryConnect"
 												/>
 											</div>
+											<!-- jarvis#708: offered the moment a bounded readiness wait
+												 runs out with no Ready verdict - never after N retries,
+												 same as jarvis_admin_v2#259's checkout-shell poll ceiling.
+												 A real exit alongside Retry, not instead of it. -->
+											<p
+												v-if="state.connectSupportOffered"
+												class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
+												role="status"
+											>
+												Still not resolved?
+												<button class="ob-link" @click="openSupport">
+													Contact support
+												</button>
+												- we'll take a look for you.
+											</p>
 										</div>
 									</template>
 								</div>
@@ -1317,6 +1329,7 @@ import {
 	operationStore,
 	OP_PHASE,
 } from "@/lib/llmOperation.js";
+import { readinessWaitExhaustedMessage } from "@/onboarding/readinessWait.js";
 import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
@@ -1441,11 +1454,18 @@ const state = reactive({
 	// finishSubtitle is the spinner's state-derived line. retryAfter counts down a
 	// per-operation rate-limit cooldown; connectBlockReason is the inline reason the
 	// gate refused (no probe / no account) when the form is still shown.
+	// connectSupportOffered (jarvis#708) is true once a bounded chat-readiness wait
+	// (waitForChatReadiness / followLegacyReadiness) has run out at least once THIS
+	// attempt with no Ready verdict - the same "hand off to a person at the existing
+	// poll ceiling" moment jarvis_admin_v2#259 uses for the checkout shell's own
+	// confirm poll. Reset only in saveConnect (a genuinely new attempt); a Retry that
+	// re-follows the SAME stuck operation must not silently withdraw the offer.
 	finishing: false,
 	finishSubtitle: "",
 	connectPhase: "",
 	connectMessage: "",
 	connectBlockReason: "",
+	connectSupportOffered: false,
 	retryAfter: 0,
 });
 
@@ -2371,7 +2391,20 @@ const supportErr = ref("");
 // What support needs to act without a round trip, and nothing a customer would be
 // alarmed to read: the coded state, the masked attempt reference the recovery card
 // already shows, and admin's own sentence. No token, no gateway id, no payload.
+//
+// Step-aware since the panel now serves both Pay (jarvis#708 hoisted it out of
+// that step) and Connect: a payment code means nothing on a stuck AI-connect
+// wait, and a connect phase means nothing on a stuck payment.
 const supportContext = computed(() => {
+	if (state.step === "connect") {
+		const rows = [
+			`Step: ${state.step}`,
+			`Connect phase: ${state.connectPhase || "none"}`,
+			`Operation: ${currentOpId.value || "none"}`,
+		];
+		if (state.connectMessage) rows.push(`Detail: ${state.connectMessage}`);
+		return rows.join("\n");
+	}
 	const rows = [
 		`Step: ${state.step}`,
 		`Payment state: ${pay.value.value || "unknown"}`,
@@ -2398,7 +2431,10 @@ async function sendSupport() {
 	supportBusy.value = true;
 	supportErr.value = "";
 	try {
-		const subject = `Onboarding payment help (${pay.value.code || "no code"})`;
+		const subject =
+			state.step === "connect"
+				? "Onboarding setup help"
+				: `Onboarding payment help (${pay.value.code || "no code"})`;
 		const body = `${supportBody.value.trim()}\n\n---\n${supportContext.value}`;
 		const d = (await supportCreateTicket(subject, body)) || {};
 		// The API answers {ok, data}; the ticket name is whatever data carries. Show
@@ -2839,6 +2875,10 @@ function navigateToChat() {
 const CHAT_READY_ATTEMPTS = 40;
 const CHAT_READY_INTERVAL_MS = 3000;
 async function waitForChatReadiness() {
+	// What this run actually observed, so the exhaustion message below can say
+	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
+	let sawVerdict = false;
+	let lastDetail = "";
 	for (let i = 0; i < CHAT_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
 		// The memoized verdict is what the router guard will read moments from now, so
@@ -2850,6 +2890,10 @@ async function waitForChatReadiness() {
 		} catch (e) {
 			// A readiness call that throws is not a verdict. Keep waiting.
 		}
+		if (r) {
+			sawVerdict = true;
+			if (r.detail) lastDetail = r.detail;
+		}
 		if (r && r.ready) {
 			navigateToChat();
 			return;
@@ -2858,8 +2902,8 @@ async function waitForChatReadiness() {
 	}
 	state.finishing = true;
 	state.connectPhase = "retry";
-	state.connectMessage =
-		"Your AI is connected, but your workspace is taking longer than usual to come online. It's still finishing on its own, so you can keep waiting or retry.";
+	state.connectMessage = readinessWaitExhaustedMessage({ sawVerdict, detail: lastDetail });
+	state.connectSupportOffered = true;
 	state.retryAfter = 0;
 }
 
@@ -3001,6 +3045,10 @@ async function followLegacyReadiness() {
 	state.finishing = true;
 	state.connectPhase = "working";
 	state.finishSubtitle = "Bringing your workspace online, taking you to chat…";
+	// What this run actually observed, so the exhaustion message below can say
+	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
+	let sawVerdict = false;
+	let lastDetail = "";
 	for (let i = 0; i < LEGACY_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
 		let r = null;
@@ -3008,6 +3056,10 @@ async function followLegacyReadiness() {
 			r = await isReadyForChat();
 		} catch (e) {
 			// transient: a readiness call that throws is not a verdict - keep polling
+		}
+		if (r) {
+			sawVerdict = true;
+			if (r.detail) lastDetail = r.detail;
 		}
 		if (r && r.ready) {
 			navigateToChat();
@@ -3017,8 +3069,8 @@ async function followLegacyReadiness() {
 	}
 	state.finishing = true;
 	state.connectPhase = "retry";
-	state.connectMessage =
-		"Setup is taking longer than usual. It's still finishing on its own — you can keep waiting or retry.";
+	state.connectMessage = readinessWaitExhaustedMessage({ sawVerdict, detail: lastDetail });
+	state.connectSupportOffered = true;
 	state.retryAfter = 0;
 }
 
@@ -3056,6 +3108,9 @@ async function saveConnect() {
 		return;
 	}
 	state.connectBlockReason = "";
+	// A genuinely fresh attempt: any earlier attempt's "we couldn't confirm this,
+	// get a person to look into it" offer was about THAT attempt, not this one.
+	state.connectSupportOffered = false;
 	savingConnect.value = true;
 	try {
 		let idem = recallIdem();

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2841,6 +2841,10 @@ function onOpUpdate(ui) {
 		state.connectMessage =
 			(ui && ui.message) ||
 			"Your workspace assignment changed. Reload this page and try again.";
+		// A stale offer from an EARLIER readiness wait (jarvis#708) must not survive
+		// into this unrelated terminal - supersession means reload, not "still not
+		// resolved", and this phase already has its own recovery action.
+		state.connectSupportOffered = false;
 	} else {
 		// WORKING (pending / applying), and the descriptor seed.
 		state.connectPhase = "working";
@@ -2969,6 +2973,9 @@ function enterSupport() {
 	// IdempotencyKeyConflict, or an old-admin descriptor-less response) would make
 	// every subsequent Retry re-submit the same conflicting key and dead-end again.
 	forgetIdem();
+	// This dead-end is unrelated to a chat-readiness wait (jarvis#708): don't let a
+	// stale offer from an earlier one show under a different failure's message.
+	state.connectSupportOffered = false;
 }
 
 // Follow a descriptor (or a bare op id on resume) to its terminal state. Supersession


### PR DESCRIPTION
## Summary

The onboarding wizard's Connect step no longer claims a stuck workspace "is still finishing on its own" when nothing confirms that, and now offers a real way out instead of an indefinite retry loop. Customers on a stalled setup notice the difference.

<details>
<summary>Details</summary>

Root cause: `waitForChatReadiness()` / `followLegacyReadiness()` rendered the same "still finishing on its own" text once their bounded poll ran out, whether or not any poll ever confirmed progress. On a tenant admin can never advance (`jarvis-admin-v2#263`), that was false, with no way out but Retry forever.

Fix: a new pure module, `readinessWait.js`, builds the exhaustion message from what the wait loop actually saw - whether admin answered at all, and its last-known `detail` (e.g. "applying your LLM configuration"), which the wizard received but never showed. At that same poll ceiling, `connectSupportOffered` now offers Contact support alongside Retry, mirroring `jarvis_admin_v2#259`'s checkout-shell handoff. The existing ticket panel is hoisted out of the Pay step so both steps share it, and cleared again if a later poll instead comes back superseded or hits the unrelated generic dead-end.

Closes #708.
</details>

## Pre-merge checklist

- [ ] CI is green - the `tests` check on this PR passes (never merge on a failure)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests (`readinessWait.test.js`, 6 cases; `OnboardingView.connect.spec.js`, 6 new cases; full suite re-verified green: 854 vitest + 615 node:test)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
