### PR TITLE
fix(settings): stop the connection badge reading green while turns fail

### DIFF
--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -365,36 +365,56 @@ const disconnected = computed(() => !!(connStatus.value && connStatus.value.disc
 // now derives health from the same evidence is_ready_for_chat gates chat on, so
 // a workspace chat let you into cannot show a failure here.
 const health = computed(() => (connStatus.value && connStatus.value.health) || "");
-const statusLabel = computed(() => {
-	if (!isSM) return "Connected";
-	if (!connStatus.value) return "—";
-	if (disconnected.value) return "Disconnected";
-	if (health.value === "down") return "Not connected";
-	if (health.value === "applying") return "Applying changes";
-	if (health.value === "attention") return "Needs attention";
-	return "Connected";
+// The badge's label, its colour and its hint line all answer the same question,
+// so they resolve it ONCE here. Three copies of this precedence drifted apart
+// easily: adding a health value or moving the disconnected check had to be got
+// right in three places, and a miss would render a colour that disagreed with
+// the line under it.
+const statusState = computed(() => {
+	if (!isSM) return "member";
+	if (!connStatus.value) return "unknown";
+	if (disconnected.value) return "disconnected";
+	return health.value || "ok";
 });
+const statusLabel = computed(
+	() =>
+		({
+			member: "Connected",
+			unknown: "—",
+			disconnected: "Disconnected",
+			down: "Not connected",
+			applying: "Applying changes",
+			attention: "Needs attention",
+		}[statusState.value] || "Connected")
+);
 // One line under the badge, for the two states where "what now" is not obvious.
-// "Connected" gets none: a healthy workspace needs no instructions. The attention
-// copy names the evidence (a turn failed) without naming a cause, since the same
-// wording has come from problems that were not the provider at all (#702).
-const statusHint = computed(() => {
-	if (!isSM || !connStatus.value || disconnected.value) return "";
-	if (health.value === "attention")
-		return "A recent chat message failed. Check the model's key and base URL in AI models.";
-	if (health.value === "down")
-		return "This workspace's model settings have not reached your assistant yet.";
-	return "";
-});
+// "Connected" gets none: a healthy workspace needs no instructions.
+//
+// It names NO cause on purpose. The badge turns red off the bare fact that a
+// turn errored, and turn_handler's #702 comment records that the agent's wording
+// does not identify why - "LLM request failed: network connection error." came
+// from a paired-device file mid-rewrite, nothing to do with the network or the
+// key. Telling an admin to check a key that is fine is the same wasted trip this
+// issue was filed about, so it points at the failed message, whose own inline
+// error is the only first-hand account of what went wrong.
+const statusHint = computed(
+	() =>
+		({
+			attention:
+				"A recent chat message failed. Open that chat to see the error it reported.",
+			down: "This workspace's model settings have not reached your assistant yet.",
+		}[statusState.value] || "")
+);
 // design.md §3.6 status map: Success is green, Attention required and Broken are
 // red, Processing is blue. Disconnected is orange (warning), not red: nothing is
 // broken, the customer chose this and can undo it in AI models.
 const statusTheme = computed(() => {
-	if (!isSM) return "green";
-	if (!connStatus.value) return "gray";
-	if (disconnected.value) return "orange";
-	if (health.value === "down" || health.value === "attention") return "red";
-	if (health.value === "applying") return "blue";
+	const s = statusState.value;
+	if (s === "member") return "green";
+	if (s === "unknown") return "gray";
+	if (s === "disconnected") return "orange";
+	if (s === "down" || s === "attention") return "red";
+	if (s === "applying") return "blue";
 	return "green";
 });
 

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -24,6 +24,11 @@
 			<KvRow label="Status">
 				<Badge :label="statusLabel" :theme="statusTheme" variant="subtle" />
 			</KvRow>
+			<!-- The badge alone sent people looking in the wrong place (#678): it
+			     names a state but not what to do about it. This says what the
+			     workspace can actually tell, and deliberately does not guess a
+			     cause, because the turn error's own wording is unreliable (#702). -->
+			<p v-if="statusHint" class="pb-2 text-p-sm text-ink-gray-5">{{ statusHint }}</p>
 			<KvRow
 				v-if="isProxy && connStatus && connStatus.oauth_expires_at"
 				label="Expires"
@@ -368,6 +373,18 @@ const statusLabel = computed(() => {
 	if (health.value === "applying") return "Applying changes";
 	if (health.value === "attention") return "Needs attention";
 	return "Connected";
+});
+// One line under the badge, for the two states where "what now" is not obvious.
+// "Connected" gets none: a healthy workspace needs no instructions. The attention
+// copy names the evidence (a turn failed) without naming a cause, since the same
+// wording has come from problems that were not the provider at all (#702).
+const statusHint = computed(() => {
+	if (!isSM || !connStatus.value || disconnected.value) return "";
+	if (health.value === "attention")
+		return "A recent chat message failed. Check the model's key and base URL in AI models.";
+	if (health.value === "down")
+		return "This workspace's model settings have not reached your assistant yet.";
+	return "";
 });
 // design.md §3.6 status map: Success is green, Attention required and Broken are
 // red, Processing is blue. Disconnected is orange (warning), not red: nothing is

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -1090,7 +1090,8 @@ def _last_turn_errored() -> bool:
 	failed because a paired-device file was mid-rewrite, nothing to do with the
 	network. So this reads the FACT that a turn errored, which is reliable, and
 	makes no claim about why - "attention", never "down", and the card's copy
-	sends the reader to the logs rather than naming a cause.
+	sends the reader to the failed message itself, whose own inline error is the
+	only first-hand account, rather than naming a cause we cannot know.
 
 	Completed means not still streaming and not parked for snapshot recovery; a
 	recovering turn has not failed yet. Cancellation is excluded for free:

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -1040,12 +1040,21 @@ def _llm_health(settings, pool_mode: bool) -> str:
 	              is not serving it. This is the same evidence is_ready_for_chat
 	              gates chat on, which is what keeps the badge and the gate from
 	              contradicting each other.
-	  attention - the container IS serving, but the last apply failed or the
+	  attention - the container IS serving, but something downstream is wrong:
+	              the last apply failed, the latest completed turn errored, or the
 	              fleet's own probe reports the chat subscription rejecting
-	              requests. Both are workspace-level verdicts. Per-MODEL verdicts
-	              deliberately stay out: AI models shows them per row, and one dead
-	              member of a healthy failover chain is what failover is for.
-	  ok        - serving, and the last apply came back clean.
+	              requests. All three are workspace-level verdicts. Per-MODEL
+	              verdicts deliberately stay out: AI models shows them per row, and
+	              one dead member of a healthy failover chain is what failover is
+	              for.
+	  ok        - serving, the last apply came back clean, and the last turn that
+	              finished did not error.
+
+	``ok`` still does NOT mean the provider was reached just now. Nothing here
+	probes an endpoint, and it should not pretend to: the two open defects about
+	the existing test path (#679, #680) are what a real reachability verdict has
+	to be built on. What changed for #678 is only that a workspace whose turns are
+	visibly failing can no longer read green.
 
 	The status prefixes match @/lib/syncStatus's, which is the SPA's one
 	translator for the same field, so the badge and the sync line cannot disagree
@@ -1058,10 +1067,50 @@ def _llm_health(settings, pool_mode: bool) -> str:
 		return "down"
 	if status.startswith("failed"):
 		return "attention"
+	# A confirmed apply says the config REACHED the container, never that the
+	# provider answers. An api-key model pointed at a base URL nothing serves
+	# applies perfectly and then fails every turn, which is how a green badge
+	# came to sit over a dead endpoint (#678). The turns themselves are the only
+	# local evidence that anything actually responded.
+	if _last_turn_errored():
+		return "attention"
 	# The fleet's own pool-wide subscription probe. Only an explicit rejection
 	# counts: "unchecked" (and a no-op apply, which runs no probe at all) means
 	# nobody looked, which is not evidence of a problem.
 	return "attention" if (settings.get("last_subscription_status") or "") == "unverified" else "ok"
+
+
+def _last_turn_errored() -> bool:
+	"""Did the most recent COMPLETED assistant turn in this workspace fail?
+
+	Deliberately kind-agnostic. `turn_handler._classify` sorts failures into
+	unreachable / timeout / provider / gateway, but its own #702 comment records
+	that the agent's wording is not trustworthy for that split: "LLM request
+	failed: network connection error." was the verbatim text of a turn that
+	failed because a paired-device file was mid-rewrite, nothing to do with the
+	network. So this reads the FACT that a turn errored, which is reliable, and
+	makes no claim about why - "attention", never "down", and the card's copy
+	sends the reader to the logs rather than naming a cause.
+
+	Completed means not still streaming and not parked for snapshot recovery; a
+	recovering turn has not failed yet. Cancellation is excluded for free:
+	stopping a turn writes `stopped`, not `error` (turn_handler:1183), so hitting
+	stop cannot paint the badge - that false-alarm shape is exactly what #561 was
+	about.
+
+	Self-clearing: only the LATEST completed turn is read, so the next turn that
+	succeeds takes the badge back to green with no stamp to reset. Workspace-wide
+	on purpose (this card is admin-only and describes the workspace), and
+	`get_all` is the right call for that since it does not filter by owner.
+	"""
+	rows = frappe.get_all(
+		"Jarvis Chat Message",
+		filters={"role": "assistant", "streaming": 0, "recovering": 0},
+		fields=["error"],
+		order_by="creation desc",
+		limit=1,
+	)
+	return bool(rows and (rows[0].get("error") or "").strip())
 
 
 def _llm_apply_confirmed(settings, pool_mode: bool) -> bool:

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -78,6 +78,16 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		# (the stale-Single flake this suite has hit before).
 		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 		self._saved = {f: frappe.db.get_single_value("Jarvis Settings", f) for f in self._FIELDS}
+		# health now also reads the latest completed turn (#678), which is real
+		# table data on a SHARED test site: one stray errored assistant row would
+		# flip every "ok" case in this class. Pinned false by default so each test
+		# exercises only the signal it names; the cases that care about turn
+		# history override it, and _last_turn_errored has its own class below.
+		# Neutralised by PATCH, not by deleting rows: wiping a shared site's data
+		# from a test is how live tenants were destroyed here before.
+		self._turn_patch = patch.object(account, "_last_turn_errored", return_value=False)
+		self._turn_patch.start()
+		self.addCleanup(self._turn_patch.stop)
 
 	def tearDown(self):
 		for field, value in self._saved.items():
@@ -203,6 +213,55 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 				out = account.get_llm_connection_status()
 		self.assertEqual(out["health"], "attention")
 
+	def test_a_failing_turn_stops_a_clean_apply_reading_green(self):
+		"""#678. Every input a confirmed apply gives us was clean - the config
+		reached the container and the probe saw nothing wrong - while every chat
+		turn failed against a base URL nothing served. A green badge there sent
+		people looking in the wrong place, so the turns themselves have to count.
+		"""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="ok (pool_update via admin)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+			last_subscription_status="unchecked",
+		)
+		with patch.object(account, "_last_turn_errored", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+					out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "attention")
+
+	def test_a_failing_turn_never_downgrades_past_attention(self):
+		"""It is evidence that something downstream is wrong, never that the
+		config failed to arrive. "down" is reserved for an unconfirmed apply,
+		because that is the value is_ready_for_chat also refuses chat on, and the
+		two must not disagree."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="ok (pool_update via admin)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+		)
+		with patch.object(account, "_last_turn_errored", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+					out = account.get_llm_connection_status()
+		self.assertNotEqual(out["health"], "down")
+
+	def test_a_save_in_flight_still_wins_over_a_failing_turn(self):
+		"""Ordering guard: while a save is in flight the container is still on its
+		previous config, so the turn that just failed says nothing about the
+		config being applied now. "applying" has to keep precedence."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="pending: admin applying config",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+		)
+		with patch.object(account, "_last_turn_errored", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+					out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "applying")
+
 	def test_an_unchecked_subscription_is_not_treated_as_a_failure(self):
 		"""An "unchecked" verdict means nobody looked (a no-op apply runs no probe
 		at all), which must not read as evidence of a problem."""
@@ -287,6 +346,56 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		m.assert_not_called()
 		self.assertEqual(out["disconnected"], True)
 		self.assertEqual(out["default_model"], "")
+
+
+class TestLastTurnErrored(FrappeTestCase):
+	"""The query itself. Driven through frappe.get_all rather than by writing
+	rows: this suite runs against a SHARED site, and the filters are the part
+	that silently rots (a renamed field would make the call return nothing and
+	the badge go permanently green, which is the bug this was written to fix)."""
+
+	def _call(self, rows):
+		with patch.object(frappe, "get_all", return_value=rows) as m:
+			out = account._last_turn_errored()
+		return out, m.call_args
+
+	def test_an_errored_latest_turn_reports_true(self):
+		out, _ = self._call([{"error": "LLM request failed: network connection error."}])
+		self.assertTrue(out)
+
+	def test_a_clean_latest_turn_reports_false(self):
+		out, _ = self._call([{"error": ""}])
+		self.assertFalse(out)
+
+	def test_a_workspace_with_no_turns_yet_reports_false(self):
+		"""A brand new workspace has never run a turn. That is an absence of
+		evidence, not a failure, and must not paint the badge."""
+		out, _ = self._call([])
+		self.assertFalse(out)
+
+	def test_whitespace_is_not_an_error(self):
+		out, _ = self._call([{"error": "   "}])
+		self.assertFalse(out)
+
+	def test_it_reads_only_the_latest_completed_assistant_turn(self):
+		"""Pins the filters. Assistant rows only (a user message has no error), and
+		neither a streaming nor a recovering row has finished failing yet - a
+		recovering turn is parked for snapshot recovery and may still succeed."""
+		_, call = self._call([])
+		self.assertEqual(call.args[0], "Jarvis Chat Message")
+		self.assertEqual(
+			call.kwargs["filters"],
+			{"role": "assistant", "streaming": 0, "recovering": 0},
+		)
+		self.assertEqual(call.kwargs["order_by"], "creation desc")
+		self.assertEqual(call.kwargs["limit"], 1)
+
+	def test_a_stopped_turn_carries_no_error_so_it_cannot_flag(self):
+		"""Cancelling writes `stopped`, never `error` (turn_handler), so a user
+		hitting stop leaves the badge alone. Painting red on a deliberate stop is
+		the #561 false-alarm shape, and this is the guard against it returning."""
+		out, _ = self._call([{"error": None}])
+		self.assertFalse(out)
 
 
 class TestHasLlmConfig(FrappeTestCase):


### PR DESCRIPTION
## Summary

Settings > General showed a green "Connected" while every chat turn was failing against a base URL nothing served. The badge's green meant "the config reached the container", which is a different claim from "the provider answers", and only the second is worth green.

Health now also reads whether the **latest completed turn errored**. It maps to `attention`, never `down`, so the badge and the chat gate keep reading the same evidence about whether the config arrived. It self-clears, because only the latest completed turn is read.

**Deliberately kind-agnostic.** `turn_handler._classify` sorts failures into unreachable / timeout / provider / gateway, but its own #702 comment records that the agent's wording cannot be trusted for that split: "LLM request failed: network connection error." was the verbatim text of a turn that failed because a paired-device file was mid-rewrite. So this reports the fact that a turn failed and makes no claim about why, and the new hint line under the badge points at the settings to check rather than naming a cause.

**Scope, stated so it can be vetoed:** this does not make green mean "the provider was reached just now". Nothing here probes an endpoint. The issue's "Expected: status reflects whether the endpoint answers" asks for a real probe, and the existing test path already has two open defects against it, #679 (cannot retest a base URL without re-entering the key) and #680 (probes run from the bench network, so a container-only endpoint looks wrong). A reachability verdict should be designed on top of those, after the fleet-side changes land. What changes here is only that a workspace whose turns are visibly failing can no longer read green.

**Not fixed, worth its own issue:** `GeneralPane.vue` returns a hardcoded `"Connected"` for non System Managers, who cannot fetch the status endpoint at all. That is the same overclaim for members, and changing it needs a decision about what a member should see instead.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (branched from `upstream/develop` at fb59219c)
- [x] New/changed behavior has tests (3 in `TestGetLlmConnectionStatus`, 6 in the new `TestLastTurnErrored`)
- [x] I self-reviewed the diff

<details><summary>Local verification</summary>

Python tests must run with `PYTHONPATH=<worktree>` or bench loads the installed app from `apps/jarvis` and silently tests the OLD code. A bare `--module` run also skips whole TestCases, so each class was run with `--case`.

- `TestGetLlmConnectionStatus`: **15 passed** (12 before, plus the 3 new)
- `TestLastTurnErrored`: **6 passed**
- `test_disconnect_llm`: 23 passed · `test_role_gates`: 6 passed
- frontend `vitest run`: **854 passed, 61 files** · `npm run build`: ok
- `pre-commit`: ruff (ast/imports/lint/format) + prettier all Passed

The new class drives `frappe.get_all` rather than writing rows: this suite runs against a shared site, and the filters are the part that silently rots. A renamed field would make the query return nothing and the badge go permanently green, which is the bug being fixed. `TestGetLlmConnectionStatus.setUp` pins the new signal false by patch, not by deleting rows, so one stray errored row on a shared site cannot flip every other case.

</details>

https://claude.ai/code/session_01MFFvM6mVvwJ5RG1kqmnq1q
