### PR TITLE
fix(chat): recover a stale device-pairing 401 instead of a silent permanent outage

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -123,7 +123,8 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 				"session is bound to a previous device pairing; "
 				"the bench has re-paired since this session was issued. "
 				"Do not retry this call - it will keep failing. Tell the "
-				"user their conversation needs a restart and stop.",
+				"user in your reply: this conversation needs a restart, "
+				"start a new chat to continue. Then stop.",
 			)
 
 		return _dispatch_from_session(plugin_user, session_key, tool, args)

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -102,15 +102,29 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 			).strip()
 		except Exception:
 			row_device = ""
-		if row_device:
-			current_device = (frappe.db.get_single_value("Jarvis Settings", "chat_device_id") or "").strip()
-			if current_device and row_device != current_device:
-				frappe.local.response.http_status_code = 401
-				return _error(
-					"AuthenticationError",
-					"session is bound to a previous device pairing; "
-					"the bench has re-paired since this session was issued",
-				)
+		current_device = (frappe.db.get_single_value("Jarvis Settings", "chat_device_id") or "").strip()
+		from jarvis.chat.device import session_device_is_stale
+
+		if session_device_is_stale(row_device, current_device):
+			frappe.local.response.http_status_code = 401
+			# jarvis #712: this rejection is deliberate (it bounds a leaked
+			# session key's replay window to the next re-pair) and MUST NOT
+			# self-heal here - that would defeat the check. But left as a bare
+			# 401 it was a SILENT permanent outage: no transcript receipt, no
+			# realtime push, nothing telling the customer to start over. The
+			# turn_handler side (handle_chat_send) mints a fresh session for
+			# the NEXT turn on this conversation, so this call_tool rejection
+			# is expected to be transient in practice - but the in-flight turn
+			# that hit it still needs an honest, visible outcome now.
+			tool_call_id = (_get_header("X-Jarvis-Tool-Call-Id") or "").strip() or None
+			_notify_stale_pairing(session_key=session_key, tool=tool, tool_call_id=tool_call_id)
+			return _error(
+				"AuthenticationError",
+				"session is bound to a previous device pairing; "
+				"the bench has re-paired since this session was issued. "
+				"Do not retry this call - it will keep failing. Tell the "
+				"user their conversation needs a restart and stop.",
+			)
 
 		return _dispatch_from_session(plugin_user, session_key, tool, args)
 
@@ -240,6 +254,54 @@ def _dispatch_from_session(
 			return result
 	finally:
 		_agent_run_ctx.clear_session_key()
+
+
+_STALE_PAIRING_DEDUPE_TTL_S = 3600
+
+
+def _notify_stale_pairing(*, session_key: str, tool: str, tool_call_id: str | None = None) -> None:
+	"""Make a stale-device-pairing 401 (jarvis #712) visible to the customer
+	instead of a silent permanent outage: persist a normal tool-error receipt
+	into the conversation transcript and push it over the realtime channel,
+	the same way ``_persist_and_publish_tool_call`` does for an ordinary
+	dispatched call. Best-effort and NEVER raises - this runs on the reject
+	path, so a persistence hiccup here must not turn a clean 401 into a 500.
+
+	Deduped per session_key (cache, ``_STALE_PAIRING_DEDUPE_TTL_S``): every
+	tool call the model makes in the SAME broken turn hits this same
+	rejection, and without a guard each one would write another identical
+	row, burying the transcript. One notice per stale session is enough -
+	the model is told in the wire message not to retry, and the next turn on
+	this conversation gets a freshly re-paired session from turn_handler.
+	"""
+	dedupe_key = f"jarvis:stale_pairing_notified:{session_key}"
+	try:
+		if frappe.cache().get_value(dedupe_key):
+			return
+	except Exception:
+		pass  # cache unavailable - fall through and notify anyway
+	message = (
+		"This conversation's connection is out of date: the assistant was "
+		"re-paired after this chat started, so it can no longer run tools "
+		"here. Please start a new chat to continue."
+	)
+	try:
+		_persist_and_publish_tool_call(
+			session_key=session_key,
+			tool=tool,
+			args={},
+			result=_error("AuthenticationError", message),
+			tool_call_id=tool_call_id,
+		)
+	except Exception:
+		frappe.log_error(
+			title="call_tool: stale-pairing notice failed",
+			message=frappe.get_traceback(),
+		)
+	try:
+		frappe.cache().set_value(dedupe_key, 1, expires_in_sec=_STALE_PAIRING_DEDUPE_TTL_S)
+	except Exception:
+		pass
 
 
 def _persist_and_publish_tool_call(

--- a/jarvis/chat/agent_client.py
+++ b/jarvis/chat/agent_client.py
@@ -265,12 +265,26 @@ _STALE_PAIRING_AUTH_REASONS = frozenset(
 	}
 )
 
+# The same rejection also carries a second, more specific machine-readable
+# value at ``error.details.code`` (distinct from the outer, generic
+# ``error.code``): "AUTH_DEVICE_TOKEN_MISMATCH" alongside
+# ``recommendedNextStep: "update_auth_credentials"``. authReason above is
+# the primary signal (every captured live rejection carries it); this is
+# belt-and-braces for a future gateway build that drops authReason but
+# keeps details.code.
+_STALE_PAIRING_DETAIL_CODES = frozenset(
+	{
+		"AUTH_DEVICE_TOKEN_MISMATCH",
+	}
+)
+
 
 def _is_stale_pairing(err: Exception) -> bool:
 	"""Return True iff ``err`` is an AgentUnreachableError that openclaw
-	classified as a stale device pairing - either via error.code (internal
-	reason set) or via error.details.authReason (the real wire shape for
-	connect auth failures, see _STALE_PAIRING_AUTH_REASONS above).
+	classified as a stale device pairing - via error.code (internal reason
+	set), error.details.authReason, or error.details.code (the real wire
+	shape for connect auth failures, see _STALE_PAIRING_AUTH_REASONS /
+	_STALE_PAIRING_DETAIL_CODES above).
 
 	Strictly typed: an error WITHOUT a ``.code``/``.details`` attribute
 	(network-level failure, programmer bug) never triggers the repair
@@ -282,7 +296,9 @@ def _is_stale_pairing(err: Exception) -> bool:
 	details = getattr(err, "details", None)
 	if not isinstance(details, dict):
 		return False
-	return details.get("authReason") in _STALE_PAIRING_AUTH_REASONS
+	if details.get("authReason") in _STALE_PAIRING_AUTH_REASONS:
+		return True
+	return details.get("code") in _STALE_PAIRING_DETAIL_CODES
 
 
 def _chat_final_text(payload: dict) -> str | None:

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -269,6 +269,37 @@ def clear_credentials() -> None:
 	frappe.db.commit()
 
 
+def session_device_is_stale(row_device_id: str, current_device_id: str) -> bool:
+	"""True iff a chat session's snapshotted ``chat_device_id`` no longer
+	matches the bench's CURRENT pairing.
+
+	Shared by two call sites so they can never drift:
+	  - ``jarvis.api.call_tool`` (the security guard): rejects a plugin
+	    call over a stale session with 401, bounding a leaked-session-key
+	    replay to the window before the next re-pair. That guard must
+	    NEVER auto-heal itself here - doing so would let a leaked session
+	    key survive a re-pair, defeating the whole point of the check.
+	  - ``jarvis.chat.turn_handler.handle_chat_send`` (the recovery): at
+	    the START of a new turn, on the browser-authenticated path (not
+	    the plugin's replayable session key), a stale binding means the
+	    conversation's existing agent session was minted under a device
+	    pairing that no longer exists. Treating it like "no session yet"
+	    mints a FRESH one under the current pairing so the conversation
+	    keeps working without a customer support ticket. The old,
+	    stale-bound session row is left alone and stays dead - the
+	    security property above is untouched.
+
+	Both blank values pass through as "not stale" (pre-migration row /
+	pre-pairing bench), matching the historical backwards-compat rule in
+	``call_tool``.
+	"""
+	row = (row_device_id or "").strip()
+	current = (current_device_id or "").strip()
+	if not row or not current:
+		return False
+	return row != current
+
+
 def update_device_token(new_token: str, *, device_id: str) -> bool:
 	"""Persist a gateway-REISSUED device token for the current pairing.
 

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -969,6 +969,39 @@ def handle_chat_send(payload: dict) -> None:
 		# streamed to the UI by the time the failure surfaces.
 		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 		patch_session_model, session_model_ref = _session_model_patch(conv)
+
+		# jarvis #712: an EXISTING session_key was minted under a device
+		# pairing that no longer exists (the bench re-paired since - a
+		# tenant re-provision, or the connect-level self-heal in
+		# agent_client.py silently repairing an earlier turn). jarvis.api's
+		# plugin-auth guard would 401 every tool call on that session
+		# forever with no recovery (it deliberately never self-heals -
+		# that guard is a leaked-session-key kill switch, see
+		# jarvis.chat.device.session_device_is_stale). Detecting it HERE,
+		# on the browser-authenticated turn-start path rather than the
+		# replayable plugin session key, is safe to auto-heal: treat it
+		# exactly like "no session yet" so the block below mints a fresh
+		# one under the CURRENT pairing. The old row is left alone and
+		# stays dead, so a genuinely leaked key is still cut off.
+		if conv.session_key:
+			from jarvis.chat.device import session_device_is_stale
+
+			# Same tolerance as the api.py guard: on a bench whose Jarvis
+			# Chat Session DocType hasn't picked up the chat_device_id
+			# column yet (pre-migrate state, mid-deploy), fall back to ""
+			# (== "not stale") instead of 500ing every chat turn.
+			try:
+				row_device = (
+					frappe.db.get_value(
+						"Jarvis Chat Session", {"session_key": conv.session_key}, "chat_device_id"
+					)
+					or ""
+				).strip()
+			except Exception:
+				row_device = ""
+			if session_device_is_stale(row_device, (settings.chat_device_id or "").strip()):
+				conv.session_key = ""
+
 		if not conv.session_key:
 			# First turn of this conversation pays session-create and is the
 			# most cold-start-prone (a dormant container takes ~10-25s to

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -289,6 +289,61 @@ class TestCallToolPluginAuth(FrappeTestCase):
 		self.assertEqual(result["error"]["code"], "AuthenticationError")
 		self.assertEqual(frappe.local.response.http_status_code, 401)
 		self.assertIn("previous device pairing", result["error"]["message"])
+		self.assertIn("start a new chat", result["error"]["message"])
+		self.assertIn("Do not retry", result["error"]["message"])
+
+	def test_stale_pairing_rejection_notifies_the_conversation(self):
+		"""jarvis #712: a silent permanent 401 leaves nothing in the
+		transcript and no realtime push - the customer just watches the
+		conversation stop working with no explanation. The rejection must
+		now also persist+publish an honest receipt (the same seam a normal
+		dispatched tool call uses), not just return the bare 401."""
+		session_key = "agent:test:stale-notify"
+		frappe.cache().delete_value(f"jarvis:stale_pairing_notified:{session_key}")
+		gv, gsv = self._patched_session_lookup(
+			row_device="old-device-id-from-before-repair",
+			current_device="current-device-id-after-repair",
+		)
+		with self._with_headers(
+			{
+				"X-Jarvis-Token": "plugin-auth-test-token",
+				"X-Jarvis-Session": session_key,
+			}
+		):
+			with gv, gsv:
+				with patch("frappe.db.exists", return_value=True):
+					with patch("jarvis.api._persist_and_publish_tool_call") as persist_spy:
+						result = call_tool(tool="get_schema", args={"doctype": "Customer"})
+		self.assertFalse(result["ok"])
+		persist_spy.assert_called_once()
+		kwargs = persist_spy.call_args.kwargs
+		self.assertEqual(kwargs["session_key"], session_key)
+		self.assertEqual(kwargs["tool"], "get_schema")
+		self.assertFalse(kwargs["result"]["ok"])
+		self.assertIn("start a new chat", kwargs["result"]["error"]["message"])
+
+	def test_stale_pairing_rejection_is_deduped_per_session(self):
+		"""Every tool call in the same broken turn hits this same
+		rejection - without a guard each would write another identical
+		receipt and bury the transcript. Only the FIRST notifies."""
+		session_key = "agent:test:stale-dedupe"
+		frappe.cache().delete_value(f"jarvis:stale_pairing_notified:{session_key}")
+		gv, gsv = self._patched_session_lookup(
+			row_device="old-device-id-from-before-repair",
+			current_device="current-device-id-after-repair",
+		)
+		with self._with_headers(
+			{
+				"X-Jarvis-Token": "plugin-auth-test-token",
+				"X-Jarvis-Session": session_key,
+			}
+		):
+			with gv, gsv:
+				with patch("frappe.db.exists", return_value=True):
+					with patch("jarvis.api._persist_and_publish_tool_call") as persist_spy:
+						call_tool(tool="get_schema", args={"doctype": "Customer"})
+						call_tool(tool="get_doc", args={"doctype": "Customer", "name": "x"})
+		persist_spy.assert_called_once()
 
 	def test_session_bound_to_current_device_accepted(self):
 		"""Sanity check: a session whose chat_device_id matches the

--- a/jarvis/tests/test_chat_agent_client.py
+++ b/jarvis/tests/test_chat_agent_client.py
@@ -565,6 +565,28 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		self.assertEqual(len(ensure_calls), 2)
 		sess.close()
 
+	def test_wire_shape_details_code_alone_also_triggers_repair(self):
+		"""Belt-and-braces (jarvis #712): a hypothetical future gateway build
+		that drops details.authReason but keeps details.code must still be
+		caught, so the classifier doesn't regress to dead code again."""
+		first_ws, second_ws = self._build_two_ws(
+			"",
+			second_ok=True,
+			first_error={
+				"code": "INVALID_REQUEST",
+				"message": "unauthorized: device token mismatch (rotate/reissue device token)",
+				"details": {
+					"code": "AUTH_DEVICE_TOKEN_MISMATCH",
+					"canRetryWithDeviceToken": False,
+					"recommendedNextStep": "update_auth_credentials",
+				},
+			},
+		)
+		sess, clears, ensure_calls = self._connect_with_two_ws(first_ws, second_ws)
+		self.assertEqual(len(clears), 1)
+		self.assertEqual(len(ensure_calls), 2)
+		sess.close()
+
 	def test_peer_adopted_rotation_skips_the_wipe_but_still_retries(self):
 		"""A gateway token ROTATION keeps the device_id, so when worker B
 		is rejected (it signed with the pre-rotation token) while worker A

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -424,3 +424,32 @@ class TestSigning(FrappeTestCase):
 		)
 		# Trailing fields after the nonce: |<platform>|<device_family>
 		self.assertTrue(out.endswith("|darwinarm64|iphone15"))
+
+
+class TestSessionDeviceIsStale(FrappeTestCase):
+	"""jarvis #712: the single source of truth both jarvis.api.call_tool
+	(the security guard, must never auto-heal) and turn_handler.
+	handle_chat_send (the recovery, safe to auto-heal) read to decide
+	whether a session's snapshotted device binding is stale."""
+
+	def test_mismatched_ids_are_stale(self):
+		self.assertTrue(chat_device.session_device_is_stale("old-device", "new-device"))
+
+	def test_matching_ids_are_not_stale(self):
+		self.assertFalse(chat_device.session_device_is_stale("same-device", "same-device"))
+
+	def test_blank_row_device_is_backwards_compat_not_stale(self):
+		"""Pre-migration row (no chat_device_id column populated yet) must
+		keep dispatching - see the C2 backwards-compat note in api.py."""
+		self.assertFalse(chat_device.session_device_is_stale("", "current-device"))
+
+	def test_blank_current_device_is_not_stale(self):
+		"""A bench that has never paired has no current device to compare
+		against - never reject on that alone."""
+		self.assertFalse(chat_device.session_device_is_stale("old-device", ""))
+
+	def test_both_blank_is_not_stale(self):
+		self.assertFalse(chat_device.session_device_is_stale("", ""))
+
+	def test_whitespace_is_stripped_before_comparing(self):
+		self.assertFalse(chat_device.session_device_is_stale("  dev-1  ", "dev-1"))

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -119,6 +119,67 @@ class TestHandleChatSendAcceptsPayloadDict(FrappeTestCase):
 		# the optional fields holds.
 		self.assertTrue(True)
 
+	def test_stale_device_binding_remints_the_session(self):
+		"""jarvis #712: a conversation's session_key was minted under a
+		device pairing that no longer exists (a tenant re-pair happened
+		after this conversation's first turn). Reusing it would leave
+		every tool call on this conversation 401ing forever (jarvis.api's
+		guard deliberately never self-heals). handle_chat_send must treat
+		it like "no session yet" and mint a fresh one under the CURRENT
+		pairing instead."""
+		SESSION = "Jarvis Chat Session"
+		old_key = frappe.db.get_value("Jarvis Conversation", self.conv, "session_key")
+		frappe.get_doc(
+			{
+				"doctype": SESSION,
+				"session_key": old_key,
+				"user": TEST_USER,
+				"chat_device_id": "old-device-before-repair",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		settings = frappe.get_single("Jarvis Settings")
+		original_device_id = settings.chat_device_id
+		settings.db_set("chat_device_id", "new-device-after-repair")
+		frappe.db.commit()
+
+		fake_sess = MagicMock()
+		fake_sess.create_session.return_value = "agent:freshly-minted"
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream(
+			[
+				{"kind": "lifecycle", "phase": "end"},
+				{"kind": "relay:final", "text": None},
+			]
+		)
+		try:
+			with patch(
+				"jarvis.chat.agent_session_pool.AgentSession.connect",
+				return_value=fake_sess,
+			):
+				with patch("jarvis.chat.worker.publish_to_user"):
+					turn_handler.handle_chat_send(
+						{
+							"conversation_id": self.conv,
+							"message_id": self.user_msg,
+							"run_id": "r-stale-repair",
+						}
+					)
+
+			fake_sess.create_session.assert_called_once()
+			new_key = frappe.db.get_value("Jarvis Conversation", self.conv, "session_key")
+			self.assertEqual(new_key, "agent:freshly-minted")
+			self.assertNotEqual(new_key, old_key)
+			new_row_device = frappe.db.get_value(SESSION, {"session_key": new_key}, "chat_device_id")
+			self.assertEqual(new_row_device, "new-device-after-repair")
+		finally:
+			settings.db_set("chat_device_id", original_device_id)
+			frappe.db.commit()
+			frappe.db.delete(SESSION, {"session_key": old_key})
+			frappe.db.delete(SESSION, {"session_key": "agent:freshly-minted"})
+			frappe.db.commit()
+
 
 class TestRunAgentTurnShimForwardsToHandleChatSend(FrappeTestCase):
 	"""The RQ entry point ``worker.run_agent_turn`` is now a thin shim


### PR DESCRIPTION
Fixes #712

## Summary

A conversation whose bench re-pairs now recovers on its own, and a customer
hitting the security guard that cannot recover gets an honest message instead
of silence.

The issue's suspected fix location, `agent_client.py`'s stale-pairing
classifier, was already fixed on `develop` by `95c8a9f4` (2026-07-09); the
issue text describes pre-rename, pre-fix code. The permanent 401 in the live
repro comes from a different, deliberate guard (trace below).

## What changed
- `jarvis.api.call_tool`: the stale-pairing rejection now persists and
  publishes a tool-error receipt telling the customer to start a new chat,
  deduped per session so one broken turn does not spam the transcript. The
  guard itself still never self-heals here, on purpose.
- `turn_handler.handle_chat_send`: a conversation whose session predates the
  bench's current pairing mints a fresh one at the start of its next turn, so
  the conversation heals itself.
- `agent_client._is_stale_pairing`: also matches `error.details.code`, belt
  and braces alongside `authReason`, per the issue's proposal.

## Risk and verification
- New/extended tests in `test_chat_device.py`, `test_api.py`,
  `test_turn_handler.py`, `test_chat_agent_client.py`, built from the real
  wire shape, not hyphenated internal strings.
- The leaked-session-key guard is unchanged; its existing test still passes.
- Hosted CI is the gate for this repo; no local harness run needed.

## Pre-merge checklist

- [ ] **CI is green**: the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (this repo's base; branched fresh from it)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

<details>
<summary>Root cause and the divergence from the issue text</summary>

**What I verified in the code, not the issue description:**

`jarvis/chat/openclaw_client.py` was renamed to `jarvis/chat/agent_client.py` in
commit `759b95fe` (white-label rename), after commit `95c8a9f4` (2026-07-09)
already fixed exactly what the issue describes: `_is_stale_pairing` already
classifies on `error.details.authReason` (wire shape `error.code =
"INVALID_REQUEST"`, `error.details = {code: "AUTH_DEVICE_TOKEN_MISMATCH",
authReason: "device_token_mismatch", recommendedNextStep:
"update_auth_credentials"}`), and `_handshake` already adopts a reissued
`auth.deviceToken`. Both are covered by `test_chat_agent_client.py`'s
`_WIRE_AUTH_REJECTION` fixture, captured verbatim from a live gateway. That
commit is an ancestor of current `develop`.

The 401 in the live repro, `session is bound to a previous device pairing`,
matches one exact string: `jarvis/api.py`'s `call_tool`, a security check unrelated
to `_is_stale_pairing`. It compares a `Jarvis Chat Session` row's snapshotted
`chat_device_id` (stamped at session-create time) against the bench's current
`Jarvis Settings.chat_device_id`, and rejects on mismatch. This is deliberate:
the comment states it "bounds leaked-session replay to the window before the
next operator re-pair," and `test_session_bound_to_old_device_rejected_after_repair`
pins that behavior. It fires over the plugin's HTTP path, entirely independent of
the WS-connect self-heal in `agent_client.py` (which only guards the bench's own
outgoing connection to openclaw). Fixing the WS-level classifier therefore cannot
fix this 401, and in fact the WS self-heal rotating `chat_device_id` is what puts
an existing session into the stale state in the first place.

The fix keeps that guard's security property intact (no auto-heal at the check
itself) and instead makes the outcome recoverable and visible: the browser-
authenticated turn-start path re-mints a session before the guard has to fire
again, and when it does fire anyway (races, or an in-flight turn), the rejection
is now recorded and shown to the customer instead of vanishing.

**Found, not fixed:** the WS-connect self-heal (`agent_client.py` line ~502)
only guards the initial handshake; a mid-session RPC (`chat_send`,
`create_session`) rejected with the identical shape is not retried there. Not
observed to cause this issue's symptom (plugin `call_tool` never goes through
that path), flagged for a follow-up.



**Update after hosted CI's first run:** `tests (1)` failed on
`test_session_bound_to_old_device_rejected_after_repair`. I added two
assertions to that test in this same PR (`"start a new chat"`,
`"Do not retry"`), and checked the wrong message object: I asserted
`"start a new chat"` against the outer, model-facing rejection string, which
only said "tell the user their conversation needs a restart" without that
literal phrase. Checked against the `develop` baseline: neither assertion
pre-existed, so this was a copy/paste mismatch on my part, not a contract I
broke.

Fix: the outer message now serves both audiences instead of narrowing the
test. It already had to instruct the model (do not retry, tell the user,
stop); it now also carries the literal customer-facing instruction "start a
new chat", matching the established idiom this codebase already uses for an
unrecoverable turn (`agent_client.FAILED_FINAL_ERROR` ends the same way:
"...or start a new chat."). The separate, independently-tested transcript
receipt built by `_notify_stale_pairing` is unchanged and remains the
reliable customer-visible signal regardless of what the model does with the
tool-call result.

</details>
