### PR TITLE
fix(settings): one-line AI model rows, self-clearing status, Resync

### DIFF
--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -584,3 +584,39 @@ describe("api-key model defaults survive a failed catalog fetch", () => {
 		expect(w.vm.providerDefaultModel("Groq")).toBe("openai/gpt-oss-120b");
 	});
 });
+
+// jarvis#714: the "Last sync failed" pill had no retry. resync() re-pushes the
+// unchanged pool through the same save_llm_pool round trip applyOrder already
+// uses for an order-only change - jarvis_settings.py's _pool_sync_is_redundant
+// treats an unchanged re-save after a failed sync as the retry lever, so this
+// is wiring to an existing endpoint, not new backend behaviour.
+describe("resync retries a failed sync (jarvis#714)", () => {
+	it("re-sends the unchanged pool and clears the failed pill on success", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		syncStatus = { ...syncStatus, last_sync_status: "failed: fleet returned 502" };
+		const w = await mountEditor();
+
+		expect(w.vm.statusLine.kind).toBe("failed");
+
+		syncStatus = { ...syncStatus, last_sync_status: "ok (restart via admin)" };
+		await w.vm.resync();
+		await idle();
+
+		expect(api.saveLlmPool).toHaveBeenCalledTimes(1);
+		expect(savedModels().map((m) => m.model)).toEqual(["gpt-4o"]);
+		expect(w.vm.statusLine.kind).toBe("ok");
+	});
+
+	it("does nothing while a reorder is still unapplied", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0), keyModel("anthropic", "claude-sonnet-4", 1)]);
+		syncStatus = { ...syncStatus, last_sync_status: "failed: fleet returned 502" };
+		const w = await mountEditor();
+
+		w.vm.move(0, 1);
+		expect(w.vm.orderDirty).toBe(true);
+		await w.vm.resync();
+		await idle();
+
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -619,4 +619,20 @@ describe("resync retries a failed sync (jarvis#714)", () => {
 
 		expect(api.saveLlmPool).not.toHaveBeenCalled();
 	});
+
+	it("does nothing while the add/edit panel is open", async () => {
+		// A resync mid-edit would submit whatever is half-typed in the open panel
+		// instead of leaving it for the customer to finish (review round 1: the
+		// orderDirty guard above had a test, this sibling guard did not).
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		syncStatus = { ...syncStatus, last_sync_status: "failed: fleet returned 502" };
+		const w = await mountEditor();
+
+		w.vm.openAdd();
+		expect(w.vm.panel.open).toBe(true);
+		await w.vm.resync();
+		await idle();
+
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
+	});
 });

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -1723,6 +1723,21 @@
 			>
 				<span class="jv-pool-syncpill-ic" aria-hidden="true"></span>{{ statusLine.text }}
 			</span>
+			<!-- jarvis#714: the failed pill had no retry. Hidden while a reorder is
+			     still unapplied (orderDirty) - its own "Apply order" bar above already
+			     owns committing THAT change, and resync() would otherwise apply it as
+			     a side effect with no order-specific confirmation. Hidden while the
+			     add/edit panel is open for the same reason "+ Add a model" is
+			     (line 249 above): a resync mid-edit would submit whatever is
+			     half-typed there instead of leaving it for the customer to finish. -->
+			<button
+				v-if="canEdit && statusLine.kind === 'failed' && !orderDirty && !panel.open"
+				:disabled="!editable"
+				@click="resync"
+				class="jv-btn jv-btn--sm jv-btn--primary"
+			>
+				Resync
+			</button>
 		</div>
 	</div>
 </template>
@@ -2961,6 +2976,21 @@ async function applyOrder() {
 	// Only clear the baseline on a write that landed. If it failed, runApply has
 	// already put the old order back, and the baseline must stay valid for the retry.
 	if (persisted) orderBaseline.value = null;
+}
+
+// jarvis#714: the status strip's "Last sync failed" pill had no way to retry.
+// This re-runs runApply() over the CURRENT rows.value unchanged - the exact
+// re-push applyOrder above already does for an order-only change, and the
+// mechanism jarvis_settings.py's _pool_sync_is_redundant docstring names as the
+// sanctioned lever: "a prior failed/pending/skipped sync means the container
+// may not hold the current pool, so an unchanged re-save is the operator's
+// retry lever and must enqueue." No new endpoint - save_llm_pool already
+// treats a same-content re-save after a failed sync as retryable, not a no-op.
+// If #713 later exposes a dedicated retry endpoint, this call is the one place
+// to point at it instead.
+async function resync() {
+	if (busy.value.active || orderDirty.value || panel.value.open) return;
+	await runApply();
 }
 // The models that actually count as a connection. An open "+ Add a model" panel has
 // already put a placeholder in the list and it must not read as a second model - not
@@ -4663,6 +4693,19 @@ defineExpose({ save, busy, canStart: singleModeCanStart, startBlockedReason });
 	white-space: nowrap;
 }
 .jv-flist-model {
+	/* flex: 1 1 0% (not the flex:none every neighbour on this row uses) so its
+	   HYPOTHETICAL size for the wrap-fitting algorithm is 0, not its full
+	   un-ellipsized text width. Without this, the row's flex-wrap safety net
+	   (meant for genuinely narrow viewports) fired even at this pane's own
+	   MAXIMUM possible width - see the jarvis#714 PR body for the measurement.
+	   max-width: max-content caps the grow side at the same width: with plain
+	   flex:1 the span consumed every pixel of the row's free space, dragging
+	   "key set" / the health dot / the health label away from the model name
+	   they describe. Capped, that free space now sinks into
+	   .jv-flist-acts's own margin-left:auto instead, which is exactly where it
+	   went before this row ever grew a fifth action button. */
+	flex: 1 1 0%;
+	max-width: max-content;
 	font-size: 13.5px;
 	color: var(--text);
 	min-width: 0;

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -26,9 +26,22 @@
 			</KvRow>
 			<!-- The badge alone sent people looking in the wrong place (#678): it
 			     names a state but not what to do about it. This says what the
-			     workspace can actually tell, and deliberately does not guess a
-			     cause, because the turn error's own wording is unreliable (#702). -->
-			<p v-if="statusHint" class="pb-2 text-p-sm text-ink-gray-5">{{ statusHint }}</p>
+			     workspace can actually tell. It deliberately does not guess WHY a
+			     turn failed (the turn's own wording is unreliable, #702), but it
+			     does now say WHICH of the three attention causes applies (#714) -
+			     one hint that claimed every cause was a failed chat message kept
+			     reading as current even once the true cause (a stale sync or
+			     subscription snapshot) had nothing left to do with a chat at all. -->
+			<div v-if="statusHint" class="flex items-center gap-2 pb-2">
+				<p class="text-p-sm text-ink-gray-5">{{ statusHint }}</p>
+				<Button
+					v-if="statusState === 'attention' && attentionReason === 'sync_failed'"
+					variant="subtle"
+					label="Open AI models"
+					iconLeft="cpu"
+					@click="store.openSettings('aimodels')"
+				/>
+			</div>
 			<KvRow
 				v-if="isProxy && connStatus && connStatus.oauth_expires_at"
 				label="Expires"
@@ -387,24 +400,41 @@ const statusLabel = computed(
 			attention: "Needs attention",
 		}[statusState.value] || "Connected")
 );
+// The server's reason for "attention" (jarvis#714) - see account._llm_health.
+// One of sync_failed / turn_error / subscription_unverified, or "" for every
+// other state. Empty until connStatus loads, same fallback shape as health.
+const attentionReason = computed(
+	() => (connStatus.value && connStatus.value.attention_reason) || ""
+);
 // One line under the badge, for the two states where "what now" is not obvious.
 // "Connected" gets none: a healthy workspace needs no instructions.
 //
-// It names NO cause on purpose. The badge turns red off the bare fact that a
-// turn errored, and turn_handler's #702 comment records that the agent's wording
-// does not identify why - "LLM request failed: network connection error." came
-// from a paired-device file mid-rewrite, nothing to do with the network or the
-// key. Telling an admin to check a key that is fine is the same wasted trip this
-// issue was filed about, so it points at the failed message, whose own inline
-// error is the only first-hand account of what went wrong.
-const statusHint = computed(
-	() =>
-		({
-			attention:
-				"A recent chat message failed. Open that chat to see the error it reported.",
-			down: "This workspace's model settings have not reached your assistant yet.",
-		}[statusState.value] || "")
-);
+// attention now branches on WHICH signal is behind it (jarvis#714): a single
+// sentence claiming every cause was "a recent chat message failed" kept
+// reading as current even once the true cause had stopped being about a chat
+// at all - a stale sync failure or a stale subscription probe, neither of
+// which names a message to open. The turn_error branch still names NO cause
+// beyond "a message failed" on purpose: turn_handler's #702 comment records
+// that the agent's own wording is not reliable, so this points at the failed
+// message, whose own inline error is the only first-hand account.
+const statusHint = computed(() => {
+	if (statusState.value === "attention") {
+		return (
+			{
+				sync_failed:
+					"Your last change to AI models did not reach your agent. Open AI models to check it.",
+				turn_error:
+					"A recent chat message failed. Open that chat to see the error it reported.",
+				subscription_unverified:
+					"Your chat subscription was last flagged as unverified, and no chat has completed since. Open AI models to check it.",
+			}[attentionReason.value] ||
+			"This workspace needs attention. Open AI models to check it."
+		);
+	}
+	if (statusState.value === "down")
+		return "This workspace's model settings have not reached your assistant yet.";
+	return "";
+});
 // design.md §3.6 status map: Success is green, Attention required and Broken are
 // red, Processing is blue. Disconnected is orange (warning), not red: nothing is
 // broken, the customer chose this and can undo it in AI models.

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -34,8 +34,14 @@
 			     subscription snapshot) had nothing left to do with a chat at all. -->
 			<div v-if="statusHint" class="flex items-center gap-2 pb-2">
 				<p class="text-p-sm text-ink-gray-5">{{ statusHint }}</p>
+				<!-- Every attention cause's copy below points the reader at AI
+				     models EXCEPT turn_error, which names a specific chat to open
+				     instead - so every one of them but that gets the button that
+				     actually takes them there. Review round 1 caught sync_failed
+				     alone getting the button while subscription_unverified's
+				     identical "Open AI models" sentence had no way to act on it. -->
 				<Button
-					v-if="statusState === 'attention' && attentionReason === 'sync_failed'"
+					v-if="statusState === 'attention' && attentionReason !== 'turn_error'"
 					variant="subtle"
 					label="Open AI models"
 					iconLeft="cpu"

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -991,17 +991,20 @@ def get_llm_connection_status() -> dict:
 			"proxy_active": False,
 			"disconnected": True,
 			"health": "down",
+			"attention_reason": "",
 			"auth_present": False,
 			"oauth_expires_at": None,
 			"profile_ids": [],
 			"default_model": "",
 		}
 	if not getattr(settings, "proxy_active", 0):
+		health, attention_reason = _llm_health(settings, pool_mode)
 		return {
 			**shape,
 			"proxy_active": False,
 			"disconnected": False,
-			"health": _llm_health(settings, pool_mode),
+			"health": health,
+			"attention_reason": attention_reason,
 			"auth_present": False,
 			"oauth_expires_at": None,
 			"profile_ids": [],
@@ -1009,11 +1012,13 @@ def get_llm_connection_status() -> dict:
 		}
 	raw = _surface(admin_client.post_llm_auth_status) or {}
 	data = raw.get("data", raw) or {}
+	health, attention_reason = _llm_health(settings, pool_mode)
 	return {
 		**shape,
 		"proxy_active": True,
 		"disconnected": False,
-		"health": _llm_health(settings, pool_mode),
+		"health": health,
+		"attention_reason": attention_reason,
 		"auth_present": bool(data.get("auth_profile_present")),
 		"oauth_expires_at": data.get("openai_profile_expires_ms"),
 		"profile_ids": data.get("profile_ids", []),
@@ -1026,9 +1031,14 @@ def get_llm_connection_status() -> dict:
 	}
 
 
-def _llm_health(settings, pool_mode: bool) -> str:
-	"""``ok`` / ``applying`` / ``attention`` / ``down`` for a workspace that HAS a
-	credential (``_has_llm_config`` has already said so).
+def _llm_health(settings, pool_mode: bool) -> tuple:
+	"""``(health, attention_reason)`` for a workspace that HAS a credential
+	(``_has_llm_config`` has already said so). ``health`` is one of ``ok`` /
+	``applying`` / ``attention`` / ``down``. ``attention_reason`` is one of
+	``sync_failed`` / ``turn_error`` / ``subscription_unverified`` when
+	``health`` is ``attention``, else ``""`` - the SPA's Status hint (#714)
+	picks its copy off this instead of a single sentence that claimed every
+	cause was a failed chat message, which was not always true.
 
 	Every input is local. Nothing here asks admin, because the one thing admin was
 	asked - "does a cliproxy auth profile exist" - turned out not to describe a
@@ -1043,10 +1053,10 @@ def _llm_health(settings, pool_mode: bool) -> str:
 	  attention - the container IS serving, but something downstream is wrong:
 	              the last apply failed, the latest completed turn errored, or the
 	              fleet's own probe reports the chat subscription rejecting
-	              requests. All three are workspace-level verdicts. Per-MODEL
-	              verdicts deliberately stay out: AI models shows them per row, and
-	              one dead member of a healthy failover chain is what failover is
-	              for.
+	              requests with no completed turn since to contradict it. All
+	              three are workspace-level verdicts. Per-MODEL verdicts
+	              deliberately stay out: AI models shows them per row, and one
+	              dead member of a healthy failover chain is what failover is for.
 	  ok        - serving, the last apply came back clean, and the last turn that
 	              finished did not error.
 
@@ -1059,25 +1069,72 @@ def _llm_health(settings, pool_mode: bool) -> str:
 	The status prefixes match @/lib/syncStatus's, which is the SPA's one
 	translator for the same field, so the badge and the sync line cannot disagree
 	about which of the three an audit string means.
+
+	sync_failed does not self-clear on a later successful turn (jarvis#714), and
+	that is deliberate, not a gap this function leaves open: a turn succeeding
+	proves the container is still serving whatever it applied LAST, never that a
+	failed apply since landed. Clearing "sync_failed" off local chat evidence
+	would be the badge lying about the one thing #713's sync path is the actual
+	fix for - see jarvis_settings.py's sync path, which this function does not
+	touch. subscription_unverified is different: that probe result is a
+	workspace-wide snapshot with no causal link to which config is currently
+	applied, so a completed turn succeeding since is first-hand proof the
+	subscription that turn used is fine now, and is allowed to demote it - the
+	same "fresh local evidence over a stale remote snapshot" reasoning #678
+	already established for turn_error below.
 	"""
 	status = (settings.get("last_sync_status") or "").strip().lower()
 	if status.startswith("pending"):
-		return "applying"
+		return "applying", ""
 	if not _llm_apply_confirmed(settings, pool_mode):
-		return "down"
+		return "down", ""
 	if status.startswith("failed"):
-		return "attention"
+		return "attention", "sync_failed"
 	# A confirmed apply says the config REACHED the container, never that the
 	# provider answers. An api-key model pointed at a base URL nothing serves
 	# applies perfectly and then fails every turn, which is how a green badge
 	# came to sit over a dead endpoint (#678). The turns themselves are the only
 	# local evidence that anything actually responded.
 	if _last_turn_errored():
-		return "attention"
+		return "attention", "turn_error"
 	# The fleet's own pool-wide subscription probe. Only an explicit rejection
 	# counts: "unchecked" (and a no-op apply, which runs no probe at all) means
-	# nobody looked, which is not evidence of a problem.
-	return "attention" if (settings.get("last_subscription_status") or "") == "unverified" else "ok"
+	# nobody looked, which is not evidence of a problem. A completed turn that
+	# succeeded SINCE that probe ran is fresher, stronger evidence than a
+	# snapshot only a future apply would otherwise refresh (jarvis#714) - see
+	# _last_turn_succeeded.
+	if (settings.get("last_subscription_status") or "") == "unverified" and not _last_turn_succeeded():
+		return "attention", "subscription_unverified"
+	return "ok", ""
+
+
+def _latest_completed_turn_error():
+	"""``None`` when this workspace has no completed assistant turn yet, else
+	that turn's ``error`` field (``""`` for a clean finish). The one query
+	``_last_turn_errored`` and ``_last_turn_succeeded`` both read, so the
+	filters - the part TestLastTurnErrored's docstring warns silently rots -
+	can only drift in one place.
+
+	Completed means not still streaming and not parked for snapshot recovery; a
+	recovering turn has not failed yet. Cancellation is excluded for free:
+	stopping a turn writes `stopped`, not `error` (turn_handler:1183), so hitting
+	stop cannot paint the badge - that false-alarm shape is exactly what #561 was
+	about.
+
+	Workspace-wide on purpose (this card is admin-only and describes the
+	workspace), and `get_all` is the right call for that since it does not
+	filter by owner.
+	"""
+	rows = frappe.get_all(
+		"Jarvis Chat Message",
+		filters={"role": "assistant", "streaming": 0, "recovering": 0},
+		fields=["error"],
+		order_by="creation desc",
+		limit=1,
+	)
+	if not rows:
+		return None
+	return (rows[0].get("error") or "").strip()
 
 
 def _last_turn_errored() -> bool:
@@ -1093,25 +1150,27 @@ def _last_turn_errored() -> bool:
 	sends the reader to the failed message itself, whose own inline error is the
 	only first-hand account, rather than naming a cause we cannot know.
 
-	Completed means not still streaming and not parked for snapshot recovery; a
-	recovering turn has not failed yet. Cancellation is excluded for free:
-	stopping a turn writes `stopped`, not `error` (turn_handler:1183), so hitting
-	stop cannot paint the badge - that false-alarm shape is exactly what #561 was
-	about.
-
 	Self-clearing: only the LATEST completed turn is read, so the next turn that
-	succeeds takes the badge back to green with no stamp to reset. Workspace-wide
-	on purpose (this card is admin-only and describes the workspace), and
-	`get_all` is the right call for that since it does not filter by owner.
+	succeeds takes the badge back to green with no stamp to reset.
 	"""
-	rows = frappe.get_all(
-		"Jarvis Chat Message",
-		filters={"role": "assistant", "streaming": 0, "recovering": 0},
-		fields=["error"],
-		order_by="creation desc",
-		limit=1,
-	)
-	return bool(rows and (rows[0].get("error") or "").strip())
+	return bool(_latest_completed_turn_error())
+
+
+def _last_turn_succeeded() -> bool:
+	"""Did the most recent COMPLETED assistant turn in this workspace finish
+	clean? The positive counterpart of ``_last_turn_errored`` - a workspace with
+	no completed turn yet reports False here too, same as it does there: absence
+	of evidence must not read as proof of success any more than it reads as proof
+	of failure.
+
+	Used only to demote a stale ``last_subscription_status`` (see _llm_health):
+	that probe is a snapshot from the last APPLY, refreshed only by a future
+	apply (jarvis_settings.py's sync path), never by ordinary chat traffic, so
+	without this a single old rejection kept the badge on "attention" forever
+	regardless of how much chat had worked since (jarvis#714).
+	"""
+	err = _latest_completed_turn_error()
+	return err is not None and err == ""
 
 
 def _llm_apply_confirmed(settings, pool_mode: bool) -> bool:

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -88,6 +88,14 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		self._turn_patch = patch.object(account, "_last_turn_errored", return_value=False)
 		self._turn_patch.start()
 		self.addCleanup(self._turn_patch.stop)
+		# Same shared-site hazard for the positive counterpart (jarvis#714): a
+		# real completed turn elsewhere on the site would silently demote a
+		# stale "unverified" case to "ok". Pinned false by default too, so the
+		# existing "needs attention" expectations stay deterministic; only the
+		# test that names the demotion overrides it.
+		self._turn_ok_patch = patch.object(account, "_last_turn_succeeded", return_value=False)
+		self._turn_ok_patch.start()
+		self.addCleanup(self._turn_ok_patch.stop)
 
 	def tearDown(self):
 		for field, value in self._saved.items():
@@ -197,11 +205,13 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
 				out = account.get_llm_connection_status()
 		self.assertEqual(out["health"], "attention")
+		self.assertEqual(out["attention_reason"], "sync_failed")
 
 	def test_a_rejected_subscription_needs_attention(self):
 		"""The fleet's own pool-wide probe said the account rejected a test
-		request. That is a real verdict about the workspace, unlike the auth
-		profile count."""
+		request, and no completed turn has succeeded since to contradict it.
+		That is a real verdict about the workspace, unlike the auth profile
+		count."""
 		self._seed(
 			proxy_active=1,
 			last_sync_status="ok (pool_update via admin)",
@@ -212,6 +222,42 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
 				out = account.get_llm_connection_status()
 		self.assertEqual(out["health"], "attention")
+		self.assertEqual(out["attention_reason"], "subscription_unverified")
+
+	def test_a_later_success_clears_a_stale_unverified_subscription(self):
+		"""jarvis#714: "Needs attention" never cleared after the workspace
+		recovered, because the only signal behind it was a snapshot only a
+		future apply refreshes. A completed turn that succeeded since is
+		first-hand proof the subscription that turn used is fine now."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="ok (pool_update via admin)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+			last_subscription_status="unverified",
+		)
+		with patch.object(account, "_last_turn_succeeded", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+					out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "ok")
+		self.assertEqual(out["attention_reason"], "")
+
+	def test_a_failed_sync_does_not_self_clear_on_a_success(self):
+		"""The counterweight to the test above: a later success only proves the
+		container still serves whatever it last applied, never that a FAILED
+		apply since landed. Clearing this off local chat evidence would make the
+		badge lie about the one thing #713's sync-race fix actually repairs."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="failed: fleet returned 502",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+		)
+		with patch.object(account, "_last_turn_succeeded", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+					out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "attention")
+		self.assertEqual(out["attention_reason"], "sync_failed")
 
 	def test_a_failing_turn_stops_a_clean_apply_reading_green(self):
 		"""#678. Every input a confirmed apply gives us was clean - the config
@@ -230,6 +276,7 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
 					out = account.get_llm_connection_status()
 		self.assertEqual(out["health"], "attention")
+		self.assertEqual(out["attention_reason"], "turn_error")
 
 	def test_a_failing_turn_never_downgrades_past_attention(self):
 		"""It is evidence that something downstream is wrong, never that the
@@ -396,6 +443,27 @@ class TestLastTurnErrored(FrappeTestCase):
 		the #561 false-alarm shape, and this is the guard against it returning."""
 		out, _ = self._call([{"error": None}])
 		self.assertFalse(out)
+
+
+class TestLastTurnSucceeded(FrappeTestCase):
+	"""The positive counterpart (jarvis#714). Shares _latest_completed_turn_error
+	with TestLastTurnErrored above, so the filters are asserted there once rather
+	than a second time here."""
+
+	def _call(self, rows):
+		with patch.object(frappe, "get_all", return_value=rows):
+			return account._last_turn_succeeded()
+
+	def test_a_clean_latest_turn_reports_true(self):
+		self.assertTrue(self._call([{"error": ""}]))
+
+	def test_an_errored_latest_turn_reports_false(self):
+		self.assertFalse(self._call([{"error": "gateway error"}]))
+
+	def test_a_workspace_with_no_turns_yet_reports_false(self):
+		"""Absence of evidence must not read as proof of success any more than
+		TestLastTurnErrored lets it read as proof of failure."""
+		self.assertFalse(self._call([]))
 
 
 class TestHasLlmConfig(FrappeTestCase):


### PR DESCRIPTION
Fixes #714

Fixes the AI models row wrap, makes the connection badge clear itself when
the problem is gone, and adds a Resync control for a failed sync.

## What changed
- **Row wrap was a bug, not a narrow-width choice**: it fired at every
  width the dialog can render, even its own maximum. Fixed with
  `flex: 1 1 0%` + `max-width: max-content` on the model-name span.
- **"Needs attention" now clears on real evidence and names its cause.**
  A stale subscription probe clears once a chat has completed cleanly
  since; a failed sync does not (success only proves the old config still
  serves, not that a later apply landed). The hint now says which cause,
  with an "Open AI models" button for every cause except a named chat.
- **Resync wired to the existing save endpoint**, no new backend code:
  `jarvis_settings.py` already treats an unchanged re-save after a failed
  sync as the retry lever.

## Risk and verification
- CI green: lint, frontend-tests, tests (1-4), coverage all pass.
- 863 frontend tests pass, incl. 3 new Resync tests. `pre-commit` clean.
- Backend tests added for the new reason field; left to hosted CI, not run
  against the shared bench DB.
- Touches only `jarvis/account.py`, not `jarvis_settings.py` (#713) or
  `chat/openclaw_client.py` (#712). If #713 exposes a dedicated retry
  endpoint later, the Resync button's one call site is where to point it.

<details><summary>Wrap-threshold measurement and status-badge reasoning</summary>

Reproduced the row's CSS/markup in a static harness and bisected the wrap
breakpoint: the row needs about 756px to fit one line as shipped, while the
dialog (`max-w-5xl`, 1024px) minus the rail (224px) minus the pane's own
padding (80px) tops out at 720px of content width, always below that
threshold. So there is no width at which the wrap was a deliberate
fallback; it fired unconditionally. The model-name span had no flex-basis,
so its full un-ellipsized text width counted toward the wrap decision even
though it would have shrunk with an ellipsis given the chance. After the
fix the row holds one line down to about 640px and still wraps below that,
so narrow viewports keep a real fallback.

For the badge: three server-local signals can independently produce
"attention" (a failed sync, the latest completed turn erroring, a stale
"subscription unverified" probe). The first two already had, or now have, a
self-clearing story tied to fresh local evidence; the third had none, so a
probe from days ago could hold the badge red forever. `_llm_health` now
returns `(health, attention_reason)` and demotes `subscription_unverified`
once a completed turn has succeeded since, on the same "fresh local
evidence over a stale snapshot" reasoning `_last_turn_errored` already used
for #678. `sync_failed` is left alone on purpose: a later chat success does
not prove a failed apply landed.
</details>

## Pre-merge checklist
- [x] CI is green
- [ ] Branch is up to date with `develop`
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
