### PR TITLE
Stop a lost write race reporting a working sync as failed, and give the customer a retry

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -138,7 +138,127 @@ def _admin_chat_readiness(*, timeout_s: int = _POOL_CONVERGE_PROBE_TIMEOUT_S):
 	return (data.get("chat_readiness") or ""), (data.get("chat_readiness_reason") or "")
 
 
-def _stamp_converged_ok(settings, *, is_pool: bool) -> None:
+#: How many times a Jarvis Settings status write is replayed through a write
+#: conflict before the caller falls back to the reconcile-owned pending state.
+#: Three is enough for a conflict class whose window is one competing commit: each
+#: replay starts from a FRESH snapshot, so it only loses again if another writer
+#: commits inside the few milliseconds the retry takes.
+_SETTINGS_WRITE_ATTEMPTS = 3
+_SETTINGS_WRITE_BACKOFF_S = 0.05
+
+
+def _is_write_conflict(e: BaseException) -> bool:
+	"""Did MariaDB refuse this statement because another connection moved the row
+	after our transaction's snapshot opened (#713)?
+
+	The bench runs MariaDB 11.6+ with ``innodb_snapshot_isolation=ON``, where a
+	LOCKING read or write that meets a record newer than the transaction's read
+	view fails immediately with ER_CHECKREAD 1020 ("Record has changed since last
+	read") rather than waiting or re-reading. Frappe folds that into
+	``QueryDeadlockError`` alongside a true ER_LOCK_DEADLOCK 1213
+	(``frappe/database/mariadb/database.py``: ``is_deadlocked`` tests for both), so
+	one class covers both and both want the same treatment here: the write did not
+	land, nothing downstream of it ran, and a replay from a fresh snapshot is the
+	whole recovery.
+
+	Matching the frappe class rather than the errno is deliberate. The errno is not
+	reachable without unwrapping ``QueryDeadlockError``'s argument, and an older
+	MariaDB that reports the same lost race as a plain 1213 has to take this branch
+	too or the customer-facing half of the fix only works on 11.6+."""
+	return isinstance(e, frappe.QueryDeadlockError)
+
+
+def _refresh_db_snapshot() -> None:
+	"""End the worker's transaction so the NEXT statement opens a fresh REPEATABLE
+	READ snapshot.
+
+	This is the structural half of #713. A sync worker's read view opens at the
+	``frappe.get_single`` that loads the doc and then stays open across the admin
+	push and up to ``_POOL_CONVERGE_DEADLINE_S`` of convergence polling - minutes,
+	most of it spent in ``time.sleep`` and HTTP. Every Jarvis Settings write that
+	commits anywhere in that window (the SPA's readiness POST stamping
+	``chat_was_ready_at``, its sync poller converging a pending apply, the */5
+	reconcile, the apply-operation poll folding in probe verdicts) makes the
+	worker's own terminal write fail. Calling this before each probe shrinks the
+	exposure from "the whole job" to "one HTTP round trip".
+
+	Same real-worker gate as ``_commit_terminal_sync_status``, and for the same
+	reason: outside ``execute_job`` there is no rollback to defeat and committing
+	would break FrappeTestCase isolation. A single-connection context has no
+	competing writer to lose to, so skipping the refresh there costs nothing."""
+	if getattr(frappe.local, "job", None) or frappe.flags.in_migrate:
+		frappe.db.commit()
+
+
+def _write_settings_fields(settings, fields: dict) -> bool:
+	"""Write status/marker fields onto Jarvis Settings so that a concurrent writer
+	cannot turn the write into a customer-visible failure (#713). Returns whether
+	it landed.
+
+	IT IS THE PRE-READ THAT FAILED LIVE, not the write. On the first ``db_set`` of a
+	freshly loaded doc, ``Document.load_doc_before_save`` runs
+
+	    SELECT field,value FROM tabSingles WHERE doctype='Jarvis Settings' FOR UPDATE
+
+	which locks EVERY Jarvis Settings row - 100 of them on a live workspace - to
+	write three. Under snapshot isolation that makes a status stamp conflict with a
+	concurrent write to any unrelated field, which is exactly what happened: a
+	readiness marker killed a sync. ``frappe.db.set_single_value`` is what ``db_set``
+	delegates the actual write to, so going straight to it drops the pre-read and
+	narrows the conflict surface to the fields actually being written. Nothing is
+	lost by skipping ``db_set``: the only other things it does are ``before_change``
+	/ ``on_change``, and neither this controller nor ``hooks.doc_events`` binds
+	either for this doctype (the Jarvis Triggers wildcard covers ``on_update``, not
+	``on_change``). The in-memory doc is still updated so callers reading it back
+	see their own write.
+
+	The residual same-field conflict is REPLAYED. Safe because every field written
+	through here is an ABSOLUTE value - a status string, a timestamp, an apply
+	marker - computed from an outcome already in hand, never a read-modify-write of
+	what is in the row. Replaying one cannot lose an interleaved update the way a
+	compare-and-set would; the last writer of a given outcome wins, which is what
+	last_sync_status has always meant.
+
+	THE ROLLBACK BEFORE EACH REPLAY IS THE POINT, not tidying up. ER_CHECKREAD
+	fails BECAUSE our snapshot is stale, so a retry on that same snapshot fails
+	identically forever. Ending the transaction is what makes the next attempt read
+	the present. It discards nothing: MariaDB aborts the transaction itself on
+	1020/1213, which is directly visible in the #713 trace - the try/finally
+	backstop's own db_set ran 2ms after the failure and SUCCEEDED, which is only
+	possible on a read view the server had already replaced. (jarvis-admin-v2 #264
+	reasoned the other way, that ER_CHECKREAD is statement-level and leaves the
+	transaction usable, and deliberately did not roll back; its recovery path
+	commits first, so it gets a fresh snapshot regardless.)
+
+	The one caller that reaches here holding work worth protecting does not: the
+	request path is ``save_llm_pool``, which COMMITS the customer's saved config
+	before it calls ``sync_pool_now`` at all, so no rollback here can cost anyone
+	the credential they just typed."""
+	import time as _time
+
+	last_error: BaseException | None = None
+	for attempt in range(_SETTINGS_WRITE_ATTEMPTS):
+		try:
+			frappe.db.set_single_value("Jarvis Settings", dict(fields), update_modified=False)
+			settings.update(dict(fields))
+			return True
+		except Exception as e:
+			if not _is_write_conflict(e):
+				raise
+			last_error = e
+			if attempt < _SETTINGS_WRITE_ATTEMPTS - 1:
+				frappe.db.rollback()
+				_time.sleep(_SETTINGS_WRITE_BACKOFF_S * (attempt + 1))
+	frappe.logger().warning(
+		"jarvis_settings: settings write lost %d write-conflict races on fields %s (%s)",
+		_SETTINGS_WRITE_ATTEMPTS,
+		sorted(fields),
+		last_error,
+	)
+	return False
+
+
+def _stamp_converged_ok(settings, *, is_pool: bool) -> bool:
 	"""Record a converged apply as a terminal success. last_sync_status keeps the
 	literal "ok" prefix (the _pool_sync_is_redundant dedup gate + the onboarding
 	poller both key off it); the durable evidence-of-successful-apply marker
@@ -148,7 +268,17 @@ def _stamp_converged_ok(settings, *, is_pool: bool) -> None:
 	exactly the confirmation it wants: admin gates chat_readiness "Ready" on
 	applied_version >= desired_version. Without the direct marker here, a first
 	direct apply that converged via reconcile would flip "ok" yet strand the
-	tenant at llm_provisioning forever (an "ok" status stops every reconcile)."""
+	tenant at llm_provisioning forever (an "ok" status stops every reconcile).
+
+	Returns whether the stamp landed. FOUR callers race on these same three rows -
+	the in-band sync worker's convergence poll, the pool worker's, the */5
+	``reconcile_pending_llm_sync`` and the SPA's own ``get_llm_sync_status`` poller
+	via ``onboarding._reconcile_pending_applying`` - all of them driven by the same
+	event, admin flipping chat_readiness to Ready. Losing that race is ordinary and
+	self-correcting (whoever won wrote the identical outcome, and every one of the
+	four re-probes), so a lost stamp is reported as False and never raised: it is
+	the caller's cue to leave the reconcile-owned pending state behind rather than
+	a failure to put in front of a customer (#713)."""
 	import frappe as _frappe
 
 	now = _frappe.utils.now()
@@ -160,8 +290,10 @@ def _stamp_converged_ok(settings, *, is_pool: bool) -> None:
 		fields["llm_pool_synced_at"] = now
 	else:
 		fields["llm_direct_synced_at"] = now
-	settings.db_set(fields, update_modified=False)
+	if not _write_settings_fields(settings, fields):
+		return False
 	_commit_terminal_sync_status()
+	return True
 
 
 def _converge_via_admin(
@@ -173,19 +305,28 @@ def _converge_via_admin(
 ) -> bool:
 	"""Poll admin get_connection until chat_readiness == "Ready" (bounded by
 	deadline_s). On Ready: stamp the terminal success markers and return True. On
-	deadline: return False so the caller records the pending state for the
-	scheduled safety net to finish. Under frappe.flags.in_test the loop probes
-	exactly once (no sleep) so tests observe a single deterministic outcome."""
+	deadline - or on a stamp that lost a write-conflict race - return False so the
+	caller records the pending state for the scheduled safety net to finish. Under
+	frappe.flags.in_test the loop probes exactly once (no sleep) so tests observe a
+	single deterministic outcome.
+
+	The snapshot refresh at the top of each pass is what keeps the stamp writable
+	(#713). Everything this loop does between passes is HTTP and sleep, so holding
+	the transaction open across it buys nothing and costs the stamp: it is exactly
+	the window in which the SPA's readiness POST - reacting to the SAME Ready this
+	loop is waiting for - commits its own Jarvis Settings write. Refreshing here
+	means the stamp runs on a read view no older than the probe that decided to
+	stamp."""
 	import time as _time
 
 	import frappe as _frappe
 
 	deadline = _time.monotonic() + deadline_s
 	while True:
+		_refresh_db_snapshot()
 		state, _reason = _admin_chat_readiness()
 		if state == "Ready":
-			_stamp_converged_ok(settings, is_pool=is_pool)
-			return True
+			return _stamp_converged_ok(settings, is_pool=is_pool)
 		if _frappe.flags.in_test or _time.monotonic() + interval_s >= deadline:
 			return False
 		_time.sleep(interval_s)
@@ -243,10 +384,8 @@ def _schedule_sync_lock_retry(*, method: str, job_base: str, retry_left: int, **
 	  redis lock.
 	"""
 	settings = frappe.get_single("Jarvis Settings")
-	settings.db_set(
-		"last_sync_status",
-		"pending: waiting for a concurrent sync to finish (will retry)",
-		update_modified=False,
+	_write_settings_fields(
+		settings, {"last_sync_status": "pending: waiting for a concurrent sync to finish (will retry)"}
 	)
 	frappe.enqueue(
 		method,
@@ -744,7 +883,7 @@ class JarvisSettings(Document):
 		operation already created - it converges + stamps the markers WITHOUT driving
 		a second push.
 		"""
-		self.db_set("last_sync_status", "pending: provisioning container (pool)", update_modified=False)
+		_write_settings_fields(self, {"last_sync_status": "pending: provisioning container (pool)"})
 		run_inline = bool(frappe.flags.in_test or frappe.flags.run_admin_sync_inline)
 		# Budget rationale lives on ADMIN_SYNC_RQ_TIMEOUT_S.
 		frappe.enqueue(
@@ -826,6 +965,12 @@ class JarvisSettings(Document):
 		Additionally a try/finally backstop guarantees last_sync_status
 		never stays at "pending: ..." on an unexpected exception path -
 		the UI poller flips off pending no matter what blew up.
+
+		#713: that backstop was reporting a LOST RACE as "failed: unexpected
+		error; see Error Log". Every status write here goes through
+		``_write_settings_fields`` instead, and a write conflict that survives
+		its replays lands on the reconcile-owned pending marker rather than a
+		terminal failure - see the QueryDeadlockError branch below.
 		"""
 		from jarvis import admin_client
 
@@ -855,6 +1000,11 @@ class JarvisSettings(Document):
 
 				record_synced_snapshot()
 				resolved_action = result.get("action", "restart")
+			# The push is the long part of this job, and until now every status
+			# write below still ran on the snapshot taken before it (#713). Ending
+			# the transaction here makes the apps snapshot above durable and gives
+			# the writes that follow a read view minutes younger than the job.
+			_refresh_db_snapshot()
 			# C5/F2 + round-4 R4-P0-6 — CONVERGENCE, not HTTP success: a sync may
 			# come back accepted-but-still-converging. Admin deliberately returns
 			# 200 with status="applying" on a busy apply lock / fleet read-timeout /
@@ -869,15 +1019,12 @@ class JarvisSettings(Document):
 			# old to thread it predates this contract).
 			if _is_applying_result(result) or (result.get("status") or "applied") != "applied":
 				if not _converge_via_admin(self, is_pool=False):
-					self.db_set(
-						"last_sync_status",
-						_PENDING_APPLYING_STATUS,
-						update_modified=False,
-					)
+					_write_settings_fields(self, {"last_sync_status": _PENDING_APPLYING_STATUS})
 					_commit_terminal_sync_status()
 				terminal_written = True
 				return
-			self.db_set(
+			applied_ok = _write_settings_fields(
+				self,
 				{
 					"last_sync_at": frappe.utils.now(),
 					"last_sync_status": f"ok ({resolved_action} via admin)",
@@ -886,8 +1033,15 @@ class JarvisSettings(Document):
 					# direct activation is gated on this so local key/provider/model
 					# presence alone can no longer open chat on an unconfirmed apply.
 					"llm_direct_synced_at": frappe.utils.now(),
-				}
+				},
 			)
+			if not applied_ok:
+				# The apply is CONFIRMED and only the record of it lost a race, so
+				# the recoverable pending state is the honest thing to leave behind:
+				# it names something outstanding (write down an apply that happened)
+				# that three converging paths can finish, and it never reports the
+				# workspace as broken (#713).
+				_write_settings_fields(self, {"last_sync_status": _PENDING_APPLYING_STATUS})
 			# Commit EVERY terminal status (ok and each failed branch), not
 			# just the finally-backstop: the rq SIGALRM can fire at any
 			# later point in this job (log_error, lock release, skills
@@ -905,11 +1059,12 @@ class JarvisSettings(Document):
 				self._resync_custom_skills_after_restart()
 				self._resync_learned_skills_after_restart()
 		except admin_client.AdminAuthError as e:
-			self.db_set(
+			_write_settings_fields(
+				self,
 				{
 					"last_sync_at": frappe.utils.now(),
 					"last_sync_status": f"failed: auth: {e}",
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
@@ -928,11 +1083,12 @@ class JarvisSettings(Document):
 			# already knew the exact reason. Terminal, carrying that reason, like
 			# the neighbouring auth/rate-limit branches.
 			reason = _admin_rejection_reason(e)
-			self.db_set(
+			_write_settings_fields(
+				self,
 				{
 					"last_sync_at": frappe.utils.now(),
 					"last_sync_status": f"failed: {reason}",
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
@@ -949,11 +1105,7 @@ class JarvisSettings(Document):
 			# reconcile, so an unreachable there stays terminal-failed as before.
 			if action == "restart":
 				if not _converge_via_admin(self, is_pool=False):
-					self.db_set(
-						"last_sync_status",
-						_PENDING_APPLYING_STATUS,
-						update_modified=False,
-					)
+					_write_settings_fields(self, {"last_sync_status": _PENDING_APPLYING_STATUS})
 					_commit_terminal_sync_status()
 					frappe.logger().warning(
 						"jarvis_settings: creds sync admin-unreachable; recorded pending for reconcile (%s)",
@@ -961,11 +1113,12 @@ class JarvisSettings(Document):
 					)
 				terminal_written = True
 			else:
-				self.db_set(
+				_write_settings_fields(
+					self,
 					{
 						"last_sync_at": frappe.utils.now(),
 						"last_sync_status": f"failed: admin unreachable: {e}",
-					}
+					},
 				)
 				_commit_terminal_sync_status()
 				terminal_written = True
@@ -976,15 +1129,39 @@ class JarvisSettings(Document):
 		except admin_client.AdminRateLimitedError as e:
 			retry = e.retry_after_seconds or 0
 			retry_str = f"retry_after={retry}s" if retry > 0 else "retry shortly"
-			self.db_set(
+			_write_settings_fields(
+				self,
 				{
 					"last_sync_at": frappe.utils.now(),
 					"last_sync_status": f"failed: rate-limited; {retry_str}",
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
 			frappe.logger().info(f"admin_client: rate-limited; retry_after={retry}s")
+		except frappe.QueryDeadlockError:
+			# #713. A lost write-conflict race is NOT a failed sync, and it must
+			# never read like one: the admin call succeeded, the container has the
+			# config, and the only thing that did not happen is this bench writing
+			# down that it did. The customer's workspace was reported broken for a
+			# race between two writers that had both just been told everything was
+			# fine.
+			#
+			# The pending marker is the RECOVERY, not a softer wording. It is the one
+			# status three independent converging paths act on - the SPA's own
+			# get_llm_sync_status poller (seconds), the */5 reconcile, and a Resync
+			# click - and a "failed:" here reaches NONE of them once
+			# llm_direct_synced_at is already set, which is exactly how the workspace
+			# in #713 was left with no way forward. Swallowed rather than re-raised
+			# for the same reason: the state is recoverable and self-correcting, and
+			# a raise would only hand execute_job an exception to log and re-log.
+			_write_settings_fields(self, {"last_sync_status": _PENDING_APPLYING_STATUS})
+			_commit_terminal_sync_status()
+			terminal_written = True
+			frappe.log_error(
+				title="Jarvis: LLM sync lost a write-conflict race (recorded pending)",
+				message=frappe.get_traceback(),
+			)
 		finally:
 			# Final backstop: if a non-Admin* exception path blew through
 			# (network exception class admin_client doesn't translate,
@@ -998,13 +1175,22 @@ class JarvisSettings(Document):
 			# UNcommitted status write here is silently undone and the
 			# status sticks at "pending:" forever. Committing makes the
 			# terminal write durable before the rollback runs.
+			#
+			# #713 narrowed what reaches this branch rather than reworking it: a
+			# write conflict now has its own handler above, so "unexpected error"
+			# once again means an error nobody anticipated, which is the only thing
+			# that wording can honestly describe. The write itself goes through
+			# _write_settings_fields because the backstop is the LAST chance to move
+			# the status off "pending:", and losing it to the same conflict class
+			# that brought us here is how a status gets stuck.
 			if not terminal_written:
 				try:
-					self.db_set(
+					_write_settings_fields(
+						self,
 						{
 							"last_sync_at": frappe.utils.now(),
 							"last_sync_status": "failed: unexpected error; see Error Log",
-						}
+						},
 					)
 					_commit_terminal_sync_status()
 				except Exception:
@@ -1265,8 +1451,10 @@ def _pool_spec_pushable(settings, converge_teardown: bool = False) -> bool:
 	return any(m.enabled for m in (settings.models or []))
 
 
-def _stamp_pool_applied_ok(settings, result: dict) -> None:
+def _stamp_pool_applied_ok(settings, result: dict) -> bool:
 	"""Record a CONFIRMED pool apply (status=applied) as a terminal success.
+	Returns whether the stamp landed (#713: a lost write-conflict race leaves the
+	caller to record the reconcile-owned pending state instead).
 
 	Extracted so the async pool-sync worker (``_enqueued_sync_via_admin_pool``)
 	and the synchronous onboarding/settings push (``sync_pool_now``) stamp the
@@ -1297,11 +1485,13 @@ def _stamp_pool_applied_ok(settings, result: dict) -> None:
 		# Per-model verdicts (contract 1.11/1.12) forwarded verbatim - the AI-models
 		# list keys each api-key row's health off this.
 		_synced["last_model_statuses"] = _frappe.as_json(result.get("model_statuses") or [])
-	settings.db_set(_synced)
+	if not _write_settings_fields(settings, _synced):
+		return False
 	# Commit every terminal write (matches _sync_via_admin) so a propagating
 	# JobTimeoutException can't roll the terminal status back to "pending:", and so
 	# llm_pool_synced_at is durable.
 	_commit_terminal_sync_status()
+	return True
 
 
 def _post_pool_with_retry(spec, api_keys, oauth_blobs, idempotency_key=None):
@@ -1433,12 +1623,12 @@ def _enqueued_sync_via_admin_pool(
 			# Terminal "failed:" write - clear any stale warnings/subscription_status
 			# from a prior successful apply alongside it (see
 			# _cleared_subscription_status_fields).
-			settings.db_set(
+			_write_settings_fields(
+				settings,
 				{
 					"last_sync_status": "failed: skipped (concurrent sync did not finish in time)",
 					**_cleared_subscription_status_fields(),
 				},
-				update_modified=False,
 			)
 			return
 
@@ -1454,10 +1644,8 @@ def _enqueued_sync_via_admin_pool(
 		revalidation_errors = validate_models(settings)
 		if revalidation_errors or not _pool_spec_pushable(settings, converge_teardown):
 			reason = "; ".join(revalidation_errors) if revalidation_errors else "no longer a pool"
-			settings.db_set(
-				"last_sync_status",
-				f"skipped: no longer pool-valid after re-read ({reason})",
-				update_modified=False,
+			_write_settings_fields(
+				settings, {"last_sync_status": f"skipped: no longer pool-valid after re-read ({reason})"}
 			)
 			return
 
@@ -1466,6 +1654,9 @@ def _enqueued_sync_via_admin_pool(
 		terminal_written = False
 		try:
 			result = _post_pool_with_retry(spec, api_keys, oauth_blobs, idempotency_key=idempotency_key) or {}
+			# The push is the long part of this job; end the transaction so every
+			# status write below runs on a read view younger than it (#713).
+			_refresh_db_snapshot()
 			# CONVERGENCE STATUS, not HTTP success (C5/F2 + round-4 R4-P0-6).
 			# Admin deliberately returns HTTP 200 with status="applying" when the
 			# apply lock was busy, the fleet read timed out, or the applied-version
@@ -1482,33 +1673,34 @@ def _enqueued_sync_via_admin_pool(
 			# to thread it) defaults to "applied" — its own contract predates this.
 			status = result.get("status") or "applied"
 			if status == "blocked":
-				settings.db_set(
-					"last_sync_status",
-					"failed: subscription needs re-authentication (blocked)",
-					update_modified=False,
+				_write_settings_fields(
+					settings,
+					{"last_sync_status": "failed: subscription needs re-authentication (blocked)"},
 				)
 				_commit_terminal_sync_status()
 				terminal_written = True  # preserve this status past the finally backstop
 				return
 			if _is_applying_result(result) or status != "applied":
 				if not _converge_via_admin(settings, is_pool=True):
-					settings.db_set(
-						"last_sync_status",
-						_PENDING_APPLYING_STATUS,
-						update_modified=False,
-					)
+					_write_settings_fields(settings, {"last_sync_status": _PENDING_APPLYING_STATUS})
 					_commit_terminal_sync_status()
 				terminal_written = True
 				return
-			_stamp_pool_applied_ok(settings, result)
+			# A stamp that lost a write-conflict race falls back to the pending
+			# marker so the SPA poller / the */5 reconcile finish it, exactly as a
+			# non-converged apply does (#713).
+			if not _stamp_pool_applied_ok(settings, result):
+				_write_settings_fields(settings, {"last_sync_status": _PENDING_APPLYING_STATUS})
+				_commit_terminal_sync_status()
 			terminal_written = True
 		except admin_client.AdminAuthError as e:
-			settings.db_set(
+			_write_settings_fields(
+				settings,
 				{
 					"last_sync_at": _frappe.utils.now(),
 					"last_sync_status": f"failed: auth: {e}",
 					**_cleared_subscription_status_fields(),
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
@@ -1523,12 +1715,13 @@ def _enqueued_sync_via_admin_pool(
 			# implying it through a "Your ..." sentence. Nothing was persisted, so
 			# no reconcile can ever finish it - terminal, with admin's reason.
 			reason = _admin_rejection_reason(e)
-			settings.db_set(
+			_write_settings_fields(
+				settings,
 				{
 					"last_sync_at": _frappe.utils.now(),
 					"last_sync_status": f"failed: {reason}",
 					**_cleared_subscription_status_fields(),
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
@@ -1553,12 +1746,13 @@ def _enqueued_sync_via_admin_pool(
 			# validation branches, before falling through to F2's converge.
 			reason = _admin_customer_facing_reason(str(e))
 			if reason:
-				settings.db_set(
+				_write_settings_fields(
+					settings,
 					{
 						"last_sync_at": _frappe.utils.now(),
 						"last_sync_status": f"failed: {reason}",
 						**_cleared_subscription_status_fields(),
-					}
+					},
 				)
 				_commit_terminal_sync_status()
 				terminal_written = True
@@ -1575,11 +1769,7 @@ def _enqueued_sync_via_admin_pool(
 			# otherwise record PENDING (not failed) and let the */5 reconcile
 			# finish it. Only genuine auth/validation/rate-limit stay terminal.
 			if not _converge_via_admin(settings, is_pool=True):
-				settings.db_set(
-					"last_sync_status",
-					_PENDING_APPLYING_STATUS,
-					update_modified=False,
-				)
+				_write_settings_fields(settings, {"last_sync_status": _PENDING_APPLYING_STATUS})
 				_commit_terminal_sync_status()
 				_frappe.logger().warning(
 					"jarvis_settings: pool sync admin-unreachable; recorded pending for reconcile (%s)",
@@ -1589,28 +1779,41 @@ def _enqueued_sync_via_admin_pool(
 		except admin_client.AdminRateLimitedError as e:
 			retry = e.retry_after_seconds or 0
 			retry_str = f"retry_after={retry}s" if retry > 0 else "retry shortly"
-			settings.db_set(
+			_write_settings_fields(
+				settings,
 				{
 					"last_sync_at": _frappe.utils.now(),
 					"last_sync_status": f"failed: rate-limited; {retry_str}",
 					**_cleared_subscription_status_fields(),
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
 			_frappe.logger().info(f"admin_client: pool sync rate-limited; retry_after={retry}s")
 		except admin_client.AdminValidationError as e:
-			settings.db_set(
+			_write_settings_fields(
+				settings,
 				{
 					"last_sync_at": _frappe.utils.now(),
 					"last_sync_status": f"failed: validation: {e}",
 					**_cleared_subscription_status_fields(),
-				}
+				},
 			)
 			_commit_terminal_sync_status()
 			terminal_written = True
 			_frappe.log_error(
 				title="Jarvis: admin validation failed (pool sync)",
+				message=_frappe.get_traceback(),
+			)
+		except _frappe.QueryDeadlockError:
+			# #713, the pool twin of the branch in _sync_via_admin. Same reasoning:
+			# admin already has the config, only the bookkeeping lost a race, and the
+			# pending marker is the state three converging paths act on.
+			_write_settings_fields(settings, {"last_sync_status": _PENDING_APPLYING_STATUS})
+			_commit_terminal_sync_status()
+			terminal_written = True
+			_frappe.log_error(
+				title="Jarvis: LLM pool sync lost a write-conflict race (recorded pending)",
 				message=_frappe.get_traceback(),
 			)
 		finally:
@@ -1623,12 +1826,13 @@ def _enqueued_sync_via_admin_pool(
 			# (JARVIS-2026-07-08, fault c).
 			if not terminal_written:
 				try:
-					settings.db_set(
+					_write_settings_fields(
+						settings,
 						{
 							"last_sync_at": _frappe.utils.now(),
 							"last_sync_status": "failed: unexpected error; see Error Log",
 							**_cleared_subscription_status_fields(),
-						}
+						},
 					)
 					_commit_terminal_sync_status()
 				except Exception:
@@ -1724,12 +1928,13 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 				except admin_client.AdminRateLimitedError as e:
 					retry = int(e.retry_after_seconds or 0)
 					retry_str = f"retry_after={retry}s" if retry > 0 else "retry shortly"
-					settings.db_set(
+					_write_settings_fields(
+						settings,
 						{
 							"last_sync_at": _frappe.utils.now(),
 							"last_sync_status": f"failed: rate-limited; {retry_str}",
 							**_cleared_subscription_status_fields(),
-						}
+						},
 					)
 					_commit_terminal_sync_status()
 					# Enforced BEFORE admin allocates an operation: nothing to resume-follow
@@ -1741,12 +1946,13 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 					# fleet apply and is now marked failed). Terminal status for the settings
 					# strip; stay resumable so the SPA resume-by-key reads the REJECTED
 					# descriptor. No reconcile can fix a permanent rejection, so no handoff.
-					settings.db_set(
+					_write_settings_fields(
+						settings,
 						{
 							"last_sync_at": _frappe.utils.now(),
 							"last_sync_status": f"failed: {_admin_rejection_reason(e)}",
 							**_cleared_subscription_status_fields(),
-						}
+						},
 					)
 					_commit_terminal_sync_status()
 					outcome = {"apply_operation": None, "resumable": True}
@@ -1759,12 +1965,13 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 				except (admin_client.AdminAuthError, admin_client.AdminValidationError) as e:
 					# Fail BEFORE any operation is allocated (auth / spec validation): a
 					# terminal, non-resumable error, nothing to follow or converge.
-					settings.db_set(
+					_write_settings_fields(
+						settings,
 						{
 							"last_sync_at": _frappe.utils.now(),
 							"last_sync_status": f"failed: {e}",
 							**_cleared_subscription_status_fields(),
-						}
+						},
 					)
 					_commit_terminal_sync_status()
 					outcome = {"apply_operation": None, "resumable": False}
@@ -1777,10 +1984,9 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 					status = result.get("status") or "applied"
 					outcome = {"apply_operation": op, "resumable": False, "legacy_capability": legacy}
 					if status == "blocked":
-						settings.db_set(
-							"last_sync_status",
-							"failed: subscription needs re-authentication (blocked)",
-							update_modified=False,
+						_write_settings_fields(
+							settings,
+							{"last_sync_status": "failed: subscription needs re-authentication (blocked)"},
 						)
 						_commit_terminal_sync_status()
 						handoff = False
@@ -1792,8 +1998,10 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 					else:
 						# Confirmed applied within the short bound: stamp inline (a fast db
 						# write, no polling) so is_ready_for_chat's pool marker is prompt.
-						_stamp_pool_applied_ok(settings, result)
-						handoff = False
+						# A stamp that lost a write-conflict race keeps the hand-off (#713):
+						# the worker re-drives the same apply and stamps it, which is the
+						# same recovery a still-converging apply already gets.
+						handoff = not _stamp_pool_applied_ok(settings, result)
 	except Exception:
 		# F3 backstop: any unexpected failure AFTER save_llm_pool committed the desired
 		# state must not strand the config with nothing converging it.
@@ -1876,14 +2084,47 @@ def _enqueued_sync_via_admin(action: str, retry_left: int = ADMIN_SYNC_LOCK_RETR
 				"another worker held the lock past blocking timeout (retries exhausted)",
 				action,
 			)
-			settings.db_set(
-				"last_sync_status",
-				"failed: skipped (concurrent sync did not finish in time)",
-				update_modified=False,
+			_write_settings_fields(
+				settings, {"last_sync_status": "failed: skipped (concurrent sync did not finish in time)"}
 			)
 			return
 		settings = frappe.get_single("Jarvis Settings")
 		settings._sync_via_admin(action)
+
+
+def request_resync(settings) -> str:
+	"""Re-drive the CURRENT LLM configuration through admin and report which leg
+	was queued: ``"pool"`` or ``"direct"``.
+
+	The retry verb behind ``onboarding.resync_llm``. It exists because neither
+	normal path can be re-triggered on demand: ``on_update`` only syncs what
+	``_classify_llm_change`` sees CHANGE, so re-saving an unchanged config is a
+	no-op, and the reconcile only looks at workspaces whose state says something is
+	outstanding. A workspace whose sync failed for a reason that has since passed
+	had nothing left that would ever try again (#713).
+
+	Writes the pending label first so the poller the SPA is already running flips
+	to "Applying your changes" on the same round trip, then enqueues under the SAME
+	job ids and the SAME redis lock as an ordinary save - so a Resync during an
+	in-flight sync coalesces into it instead of racing it or restarting the
+	container twice."""
+	from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+	if compute_pool_mode(settings):
+		settings._enqueue_pool_sync()
+		return "pool"
+	_write_settings_fields(settings, {"last_sync_status": "pending: provisioning container"})
+	frappe.enqueue(
+		"jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._enqueued_sync_via_admin",
+		queue="long",
+		timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
+		enqueue_after_commit=not (frappe.flags.in_test or frappe.flags.run_admin_sync_inline),
+		now=bool(frappe.flags.in_test or frappe.flags.run_admin_sync_inline),
+		job_id="jarvis_settings_sync:restart",
+		deduplicate=True,
+		action="restart",
+	)
+	return "direct"
 
 
 #: The clause admin puts in ``chat_readiness_reason`` when its OWN tenant row
@@ -2084,12 +2325,20 @@ def reconcile_pending_llm_sync() -> None:
 			return
 
 		revision_before = _llm_config_revision() if may_be_disconnected else ""
+		# End the transaction before the probe (#713). Two things depend on it: the
+		# stamp below has to be writable against whatever committed while we were
+		# asking admin, and the reconnect guard further down has to be able to SEE
+		# that commit - a re-read on the snapshot this tick opened with would answer
+		# "nothing moved" no matter what the customer did.
+		_refresh_db_snapshot()
 		state, reason = _admin_chat_readiness()
 		if state == "Ready":
 			if is_applying_pending or is_unproven_pool or is_unproven_direct:
 				# Stamps the evidence marker for whichever mode is active:
 				# llm_pool_synced_at for pool tenants, llm_direct_synced_at for
 				# single-model tenants (is_ready_for_chat's first-activation gates).
+				# A lost race needs no handling here: this tick changes nothing and
+				# the next one (or the SPA's own poller) re-probes and re-stamps.
 				_stamp_converged_ok(settings, is_pool=pool_mode)
 			return
 		if not (may_be_disconnected and _admin_says_llm_gone(state, reason)):

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -2068,6 +2068,65 @@ def get_llm_sync_status() -> dict:
 	}
 
 
+@frappe.whitelist()
+def resync_llm() -> dict:
+	"""Re-drive this workspace's saved AI configuration through admin. The customer
+	half of #713: a way forward from a sync that failed.
+
+	It exists because a failed sync used to be a dead end with no lever anywhere.
+	Nothing retries on its own once the workspace stops looking outstanding:
+	``on_update`` syncs only what CHANGED, so re-saving the same config is a no-op;
+	``reconcile_pending_llm_sync`` acts on a pending-applying marker or on a first
+	apply that never proved itself, and a workspace that HAS a proven apply (the
+	shape in #713: llm_direct_synced_at already set from an earlier good sync)
+	matches no branch it has. The status said "Last sync failed" and nothing in the
+	product was ever going to try again.
+
+	PROBES BEFORE IT PUSHES. Most of what leaves a workspace on a failed status is
+	bookkeeping that lost a race, not a container that missed its config, so the
+	first thing this does is ask admin whether the container is already serving what
+	was saved (chat_readiness == Ready, the same receipt every other convergence
+	path trusts). If it is, this stamps the success markers and returns: no restart,
+	no re-render, no interruption to a workspace that was working the whole time.
+	The push is only for a workspace admin says is NOT converged.
+
+	Gated on ``require_jarvis_admin`` (it drives a container mutation, like every
+	other write on this module) and safe to click repeatedly: the queued work
+	carries the same job ids and takes the same redis lock as an ordinary save, so
+	a second click coalesces into the first rather than racing it.
+
+	Returns ``get_llm_sync_status()``'s shape, so a caller can render the response
+	directly with no second round trip, plus ``outcome``:
+
+	  * ``converged``      - admin already serves this config; markers stamped.
+	  * ``queued``         - a re-push was enqueued; ``leg`` is "pool" or "direct".
+	  * ``not_configured`` - nothing saved to re-drive; nothing was queued.
+	"""
+	from jarvis.account import _has_llm_config
+	from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+		_admin_chat_readiness,
+		_stamp_converged_ok,
+		request_resync,
+	)
+	from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+	require_jarvis_admin()
+	settings = frappe.get_single("Jarvis Settings")
+	# Both halves matter: a credential with no control-plane tenancy has nowhere to
+	# be pushed, and a tenancy with no credential has nothing to push.
+	if not _has_llm_config(settings) or not _has_admin_credentials(settings):
+		return {**get_llm_sync_status(), "outcome": "not_configured", "leg": ""}
+
+	state, _reason = _admin_chat_readiness()
+	if state == "Ready" and _stamp_converged_ok(settings, is_pool=compute_pool_mode(settings)):
+		# The stamp's own commit gate only fires in a worker; this is a request.
+		frappe.db.commit()
+		return {**get_llm_sync_status(), "outcome": "converged", "leg": ""}
+
+	leg = request_resync(settings)
+	return {**get_llm_sync_status(), "outcome": "queued", "leg": leg}
+
+
 def _pending_applying_status() -> str:
 	"""The jarvis_settings pending-applying marker, imported lazily so this
 	module keeps zero import-time coupling to the (heavy) doctype module."""
@@ -2088,8 +2147,15 @@ def _reconcile_pending_applying(settings) -> str | None:
 	opens chat and the poller stops calling admin. Returns the new status string on
 	a flip, else None (stay pending).
 
-	Best-effort: any admin error / non-Ready verdict leaves the pending status
-	untouched; the next poll retries. Never raises out of the poller."""
+	Best-effort: any admin error / non-Ready verdict / lost write-conflict race
+	leaves the pending status untouched; the next poll retries. Never raises out of
+	the poller.
+
+	This poll is one of the FOUR writers that race on the converged-ok markers
+	(#713), and the one that runs most often - every few seconds while a workspace
+	is pending-applying, from the SPA. It is also the fastest way back: the moment a
+	sync worker records the pending marker, this poller is what converges it,
+	seconds later, without waiting for the */5 reconcile."""
 	from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
 		_admin_chat_readiness,
 		_stamp_converged_ok,
@@ -2101,7 +2167,11 @@ def _reconcile_pending_applying(settings) -> str | None:
 		return None
 	# The marker follows the SYNC LEG, so this is pool mode - a BYO api-key pool
 	# has no sidecar (proxy_active=0) but still stamps llm_pool_synced_at.
-	_stamp_converged_ok(settings, is_pool=compute_pool_mode(settings))
+	if not _stamp_converged_ok(settings, is_pool=compute_pool_mode(settings)):
+		# Whoever won the race wrote the same outcome, so there is nothing to
+		# correct and nothing to tell the customer: stay pending and let the next
+		# poll read the winner's value.
+		return None
 	# _stamp_converged_ok's commit gate only fires in a worker/migrate context;
 	# this runs in a web request, where a GET would otherwise roll the terminal
 	# write back at request end.

--- a/jarvis/tests/test_settings_sync_conflict.py
+++ b/jarvis/tests/test_settings_sync_conflict.py
@@ -1,0 +1,406 @@
+"""A sync that loses a write-conflict race stays recoverable, and the customer
+has a lever (#713).
+
+THE BUG THESE PIN. On a workspace whose chat was already working, Settings read
+"Last sync failed. unexpected error; see Error Log". Behind it:
+
+    (1020, "Record has changed since last read in table 'tabsingles'")
+      jarvis_settings.py  _enqueued_sync_via_admin (action='restart')
+      jarvis_settings.py  _sync_via_admin -> _converge_via_admin(is_pool=False)
+
+The statement that failed was not the UPDATE. It was the locking PRE-READ
+``Document.db_set`` issues on the first write to a freshly loaded doc:
+
+    SELECT `field`,`value` FROM `tabSingles` WHERE `doctype`='Jarvis Settings' FOR UPDATE
+
+Under MariaDB 11.6+'s ``innodb_snapshot_isolation=ON`` that read fails outright
+if ANY of the doctype's rows moved since the transaction's snapshot opened, and
+the sync worker's snapshot had been open across the admin push plus two minutes
+of convergence polling. In the live incident the competing writer was
+``account._mark_chat_ready`` stamping ``chat_was_ready_at`` 19.7s earlier, from
+the SPA's readiness POST, reacting to the SAME "Ready" the worker was waiting
+for. So the two writers were not merely concurrent, they were correlated by
+construction.
+
+Three properties are asserted here, in the order the fix delivers them:
+
+  * the write no longer takes a doctype-wide lock it never needed;
+  * a conflict that does happen is replayed, and if the replays lose, the sync
+    lands on the reconcile-owned pending state instead of a terminal failure;
+  * a workspace stuck on a terminal failure has a way back (``resync_llm``),
+    including the exact shape from #713 that no reconcile branch matches.
+
+HONEST LIMIT OF THE INJECTION. ``_conflict_on`` raises a faithfully constructed
+``QueryDeadlockError`` around a real ``pymysql.InternalError(1020, ...)``, from
+inside ``frappe.db.sql`` at the statement that can still conflict after the fix
+(the ``tabSingles`` DELETE). It is still raised from Python: MariaDB never sees
+the statement, so no test here exercises a genuine engine-produced ER_CHECKREAD,
+and nothing here would catch a divergence between the real error and this
+reconstruction. That is the same limitation the admin-plane fix
+(jarvis-admin-v2 #264) recorded, and it is not fixable in this repo's CI: CI runs
+MariaDB 10.11, which has no ``innodb_snapshot_isolation`` at all and cannot raise
+1020 for this reason under any query. Reproducing the real error needs MariaDB
+11.6+ and two connections:
+
+    conn A: START TRANSACTION;
+            SELECT * FROM tabSingles WHERE doctype='Jarvis Settings';
+    conn B: UPDATE tabSingles SET value=NOW() WHERE doctype='Jarvis Settings'
+              AND field='chat_was_ready_at';
+            COMMIT;
+    conn A: SELECT * FROM tabSingles WHERE doctype='Jarvis Settings' FOR UPDATE;
+            -- ERROR 1020: Record has changed since last read
+"""
+
+import contextlib
+from unittest.mock import patch
+
+import frappe
+import pymysql
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import admin_client, onboarding
+from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+	_PENDING_APPLYING_STATUS,
+	_write_settings_fields,
+	reconcile_pending_llm_sync,
+)
+
+SETTINGS = "Jarvis Settings"
+_READINESS = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._admin_chat_readiness"
+_UNEXPECTED = "failed: unexpected error; see Error Log"
+
+# Everything these tests write. Frappe Singles are not rolled back between tests
+# (and these tests commit on purpose - see _conflict_on), so the operator's real
+# state is snapshotted and restored rather than trusted to the test transaction.
+_TOUCHED = (
+	"last_sync_at",
+	"last_sync_status",
+	"llm_direct_synced_at",
+	"llm_pool_synced_at",
+	"llm_provider",
+	"llm_model",
+	"llm_auth_mode",
+	"llm_base_url",
+	"proxy_active",
+	"chat_was_ready_at",
+)
+_SECRETS = ("llm_api_key", "jarvis_admin_api_key", "jarvis_admin_api_secret")
+
+
+def _checkread() -> Exception:
+	"""The exact error MariaDB raises under snapshot isolation, wrapped the way
+	frappe wraps it. ``is_deadlocked`` folds ER.CHECKREAD in with ER.LOCK_DEADLOCK
+	(frappe/database/mariadb/database.py), so ``frappe.db.sql`` turns both into
+	``QueryDeadlockError`` - which is what any handler can actually match on."""
+	return frappe.QueryDeadlockError(
+		pymysql.InternalError(1020, "Record has changed since last read in table 'tabsingles'")
+	)
+
+
+@contextlib.contextmanager
+def _conflict_on(marker: str, *, times: int | None = None):
+	"""Fail every ``tabSingles`` statement that writes ``marker``, at the layer a
+	conflict can still occur after the fix.
+
+	Patching ``_write_settings_fields`` itself would prove nothing: the whole
+	defect is that a raw statement raises mid-transaction, so the injection has to
+	sit UNDER the function, not over it. Every other query in the request runs for
+	real, which is what lets the recovery (the replay, the fallback status write,
+	the reconcile that follows) be asserted honestly rather than mocked.
+
+	Scoped to one field name so the FALLBACK write - itself a ``tabSingles``
+	write - is not swallowed by the same injection and the recovery stays
+	observable. ``times`` bounds how many statements fail, which is how a conflict
+	that CLEARS (the ordinary case: the other writer has committed and moved on) is
+	distinguished from one that never does.
+	"""
+	real = frappe.local.db.sql
+	state = {"raised": 0}
+
+	def fake(query, *args, **kwargs):
+		blob = f"{query} {args} {kwargs}"
+		if "tabSingles" in blob and marker in blob and (times is None or state["raised"] < times):
+			state["raised"] += 1
+			raise _checkread()
+		return real(query, *args, **kwargs)
+
+	with patch.object(frappe.local.db, "sql", side_effect=fake):
+		yield state
+
+
+def _status() -> str:
+	return frappe.db.get_single_value(SETTINGS, "last_sync_status", cache=False) or ""
+
+
+def _direct_marker():
+	return frappe.db.get_single_value(SETTINGS, "llm_direct_synced_at", cache=False)
+
+
+class _Base(FrappeTestCase):
+	def setUp(self):
+		from frappe.utils.password import remove_encrypted_password
+
+		s = frappe.get_single(SETTINGS)
+		self._snap = {f: s.get(f) for f in _TOUCHED}
+		self._snap_secrets = {f: (s.get_password(f, raise_exception=False) or "") for f in _SECRETS}
+		# A connected SINGLE-MODEL workspace mid-apply: exactly #713's shape.
+		frappe.db.set_single_value(
+			SETTINGS,
+			{
+				"llm_provider": "deepseek",
+				"llm_model": "deepseek-v4-flash",
+				"llm_auth_mode": "api_key",
+				"llm_base_url": "",
+				"proxy_active": 0,
+				"last_sync_status": "pending: provisioning container",
+				"llm_direct_synced_at": None,
+				"llm_pool_synced_at": None,
+			},
+			update_modified=False,
+		)
+		for f in _SECRETS:
+			remove_encrypted_password(SETTINGS, SETTINGS, f)
+		s = frappe.get_single(SETTINGS)
+		s.db_set("llm_api_key", "sk-test-713")
+		s.db_set("jarvis_admin_api_key", "adminkey")
+		s.db_set("jarvis_admin_api_secret", "adminsecret")
+		frappe.db.commit()
+
+	def tearDown(self):
+		from frappe.utils.password import remove_encrypted_password
+
+		frappe.db.set_single_value(SETTINGS, dict(self._snap), update_modified=False)
+		for f, v in self._snap_secrets.items():
+			remove_encrypted_password(SETTINGS, SETTINGS, f)
+			frappe.db.set_single_value(SETTINGS, f, v, update_modified=False)
+		frappe.db.commit()
+
+	def _settings(self):
+		return frappe.get_single(SETTINGS)
+
+
+# ---------------------------------------------------------------------------
+# the write itself: a smaller lock, and a replay for what is left
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsWriteSurvivesAConflict(_Base):
+	def test_it_does_not_take_the_doctype_wide_for_update_that_failed_in_713(self):
+		"""The load-bearing structural fix. ``db_set``'s pre-read locks EVERY
+		Jarvis Settings row, so a write of one status field conflicted with a
+		concurrent write of any of the ~200 - which is how a readiness marker
+		killed a sync stamp. Asserted against ``db_set`` in the same test so the
+		difference is the claim, not a snapshot of one implementation."""
+		guarded, direct = [], []
+
+		def _record(into):
+			real = frappe.local.db.sql
+
+			def fake(query, *args, **kwargs):
+				into.append(str(query))
+				return real(query, *args, **kwargs)
+
+			return patch.object(frappe.local.db, "sql", side_effect=fake)
+
+		with _record(guarded):
+			_write_settings_fields(self._settings(), {"last_sync_status": "ok (test)"})
+		with _record(direct):
+			self._settings().db_set("last_sync_status", "ok (test)", update_modified=False)
+
+		def _locking_reads(queries):
+			return [q for q in queries if "FOR UPDATE" in q.upper() and "tabSingles" in q]
+
+		self.assertEqual(_locking_reads(guarded), [], "the guarded write must not lock the whole doctype")
+		self.assertTrue(
+			_locking_reads(direct),
+			"db_set is expected to still take the doctype-wide lock; if it no longer "
+			"does, frappe changed and this fix's premise needs re-checking",
+		)
+
+	def test_a_conflict_that_clears_is_replayed_and_the_value_lands(self):
+		"""The ordinary case. The competing writer has committed and moved on, so
+		the replay - which runs on a FRESH snapshot, because the rollback is what
+		ends the doomed transaction - simply succeeds."""
+		with _conflict_on("last_sync_status", times=1) as state:
+			landed = _write_settings_fields(self._settings(), {"last_sync_status": "ok (replayed)"})
+		self.assertTrue(landed)
+		self.assertEqual(state["raised"], 1)
+		self.assertEqual(_status(), "ok (replayed)")
+
+	def test_a_conflict_that_never_clears_reports_failure_instead_of_raising(self):
+		"""Bounded, and it does not raise: the caller decides what a lost race
+		means for the customer, and for every caller here the answer is a
+		recoverable state, never an exception on its way to an Error Log."""
+		with _conflict_on("last_sync_status") as state:
+			landed = _write_settings_fields(self._settings(), {"last_sync_status": "ok (never)"})
+		self.assertFalse(landed)
+		self.assertGreaterEqual(state["raised"], 2, "the write is replayed, not attempted once")
+		self.assertEqual(_status(), "pending: provisioning container", "the old value stands")
+
+	def test_it_swallows_nothing_but_a_write_conflict(self):
+		"""A programmer error or a schema fault must not be absorbed into a
+		"lost a race" story - that is how a real bug becomes a mystery."""
+		real = frappe.local.db.sql
+
+		def fake(query, *args, **kwargs):
+			if "tabSingles" in str(query) and "last_sync_status" in f"{query} {args}":
+				raise ValueError("not a write conflict")
+			return real(query, *args, **kwargs)
+
+		with patch.object(frappe.local.db, "sql", side_effect=fake), self.assertRaises(ValueError):
+			_write_settings_fields(self._settings(), {"last_sync_status": "ok (boom)"})
+
+
+# ---------------------------------------------------------------------------
+# #713 proper: the sync's own recovery
+# ---------------------------------------------------------------------------
+
+
+class TestSyncRecoversFromAConflict(_Base):
+	"""The live sequence: admin returns 200 status="applying", the convergence
+	poll sees Ready, and the stamp loses a race with a writer reacting to that
+	same Ready."""
+
+	@contextlib.contextmanager
+	def _applying_then_ready(self):
+		with (
+			patch.object(
+				admin_client,
+				"post_update_llm_creds",
+				return_value={"action": "restart", "status": "applying"},
+			),
+			patch(_READINESS, return_value=("Ready", "")),
+		):
+			yield
+
+	def test_a_lost_stamp_is_not_reported_as_an_unexpected_error(self):
+		"""The customer-visible defect. "unexpected error" is what
+		``humaniseSyncStatus`` renders as "Last sync failed", on a workspace whose
+		container was serving the new config the whole time."""
+		with self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
+			self._settings()._sync_via_admin("restart")
+		self.assertNotIn(_UNEXPECTED, _status())
+		self.assertEqual(_status(), _PENDING_APPLYING_STATUS)
+
+	def test_the_stamp_still_lands_when_the_conflict_clears(self):
+		"""The fix must not make the happy path pessimistic: one lost race is
+		replayed into a normal, fully stamped success."""
+		with self._applying_then_ready(), _conflict_on("llm_direct_synced_at", times=1):
+			self._settings()._sync_via_admin("restart")
+		self.assertTrue(_status().startswith("ok"))
+		self.assertTrue(_direct_marker())
+
+	def test_the_recovered_state_is_one_a_converging_path_acts_on(self):
+		"""Why the pending marker rather than softer failure wording: it is the
+		state ``reconcile_pending_llm_sync`` (and the SPA's own poller) converges.
+		The apply is real, so recording it is the only thing outstanding."""
+		with self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
+			self._settings()._sync_via_admin("restart")
+		self.assertEqual(_status(), _PENDING_APPLYING_STATUS)
+
+		with patch(_READINESS, return_value=("Ready", "")):
+			reconcile_pending_llm_sync()
+		self.assertTrue(_status().startswith("ok"), f"reconcile left the status at {_status()!r}")
+		self.assertTrue(_direct_marker())
+
+	def test_a_terminal_failure_after_a_proven_apply_is_a_dead_end(self):
+		"""The other half of #713, and the reason a Resync lever had to exist.
+		``reconcile_pending_llm_sync`` acts on a pending-applying marker or on a
+		FIRST apply that never proved itself. A workspace with a terminal "failed:"
+		AND a proven apply behind it (llm_direct_synced_at set from an earlier good
+		sync) matches neither, so nothing in the product ever tried again.
+
+		This documents the gap rather than closing it: widening the reconcile to
+		re-probe every failed workspace would put every genuinely broken config on
+		a */5 admin call forever.
+
+		Admin is deliberately mocked as Ready, which makes the point sharper. The
+		reconcile does reach the probe (through its disconnect leg, which every
+		connected workspace satisfies), is told the container is serving, and still
+		leaves the status alone: no branch it has repairs a failed status behind a
+		proven apply."""
+		frappe.db.set_single_value(
+			SETTINGS,
+			{"last_sync_status": _UNEXPECTED, "llm_direct_synced_at": frappe.utils.now()},
+			update_modified=False,
+		)
+		with patch(_READINESS, return_value=("Ready", "")):
+			reconcile_pending_llm_sync()
+			self.assertEqual(_status(), _UNEXPECTED, "no reconcile branch repairs this workspace")
+			# The lever that does. Same workspace, same admin verdict, one call.
+			with patch("frappe.enqueue") as enq:
+				out = onboarding.resync_llm()
+		self.assertEqual(out["outcome"], "converged")
+		self.assertTrue(_status().startswith("ok"))
+		enq.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# the way forward: onboarding.resync_llm
+# ---------------------------------------------------------------------------
+
+
+class TestResyncLlm(_Base):
+	def test_it_stamps_and_does_not_touch_the_container_when_admin_already_serves_it(self):
+		"""Probe before push. The state this exists to clear is bookkeeping that
+		lost a race, where the container is fine - restarting it would take chat
+		away from a working customer to fix a status string."""
+		frappe.db.set_single_value(SETTINGS, "last_sync_status", _UNEXPECTED, update_modified=False)
+		with patch(_READINESS, return_value=("Ready", "")), patch("frappe.enqueue") as enq:
+			out = onboarding.resync_llm()
+		self.assertEqual(out["outcome"], "converged")
+		self.assertTrue(out["last_sync_status"].startswith("ok"))
+		self.assertTrue(_direct_marker())
+		enq.assert_not_called()
+
+	def test_it_queues_a_re_push_when_admin_says_the_config_is_not_serving(self):
+		frappe.db.set_single_value(SETTINGS, "last_sync_status", _UNEXPECTED, update_modified=False)
+		with patch(_READINESS, return_value=("Configuring", "applying your LLM configuration")):
+			with patch("frappe.enqueue") as enq:
+				out = onboarding.resync_llm()
+		self.assertEqual(out["outcome"], "queued")
+		self.assertEqual(out["leg"], "direct")
+		self.assertTrue(out["pending"], "the poller the SPA already runs must flip immediately")
+		self.assertEqual(
+			[c.kwargs.get("job_id") for c in enq.call_args_list],
+			["jarvis_settings_sync:restart"],
+			"a Resync must coalesce with an ordinary save, not race it",
+		)
+
+	def test_it_queues_the_pool_leg_for_a_pool_workspace(self):
+		"""A pool is re-driven through the pool worker, not the creds one - the two
+		push different admin endpoints. ``compute_pool_mode`` is stubbed rather than
+		satisfied with real ``models[]`` rows: a genuine pool needs encrypted
+		Password child rows and a full save, which would fire the whole on_update
+		sync machinery this test is not about."""
+		with (
+			patch("jarvis.jarvis.pool_serialize.compute_pool_mode", return_value=True),
+			patch(_READINESS, return_value=("Configuring", "")),
+			patch("frappe.enqueue") as enq,
+		):
+			out = onboarding.resync_llm()
+		self.assertEqual(out["leg"], "pool")
+		self.assertEqual([c.kwargs.get("job_id") for c in enq.call_args_list], ["jarvis_settings_sync:pool"])
+
+	def test_it_refuses_a_workspace_with_nothing_to_re_drive(self):
+		"""No credential means no configuration to push; queueing one would spend a
+		container restart proving that."""
+		from frappe.utils.password import remove_encrypted_password
+
+		remove_encrypted_password(SETTINGS, SETTINGS, "llm_api_key")
+		frappe.db.set_single_value(SETTINGS, "llm_api_key", "", update_modified=False)
+		with patch(_READINESS) as probe, patch("frappe.enqueue") as enq:
+			out = onboarding.resync_llm()
+		self.assertEqual(out["outcome"], "not_configured")
+		enq.assert_not_called()
+		probe.assert_not_called()
+
+	def test_it_is_gated_on_the_workspace_admin_role(self):
+		"""It drives a container mutation, so it carries the same gate every other
+		write endpoint on this module does."""
+		frappe.set_user("Guest")
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				onboarding.resync_llm()
+		finally:
+			frappe.set_user("Administrator")


### PR DESCRIPTION
## Summary

A workspace whose AI connection was working no longer reports "Last sync failed"
because two writers reacted to the same good news at once. The convergence stamp
took a doctype-wide `SELECT ... FOR UPDATE` on a snapshot minutes old, so under
MariaDB's `innodb_snapshot_isolation` any concurrent Jarvis Settings write turned
it into ER_CHECKREAD 1020 and a terminal "unexpected error" (#713).

Status writes now go through one guarded writer: no pre-read, and a bounded replay
from a fresh snapshot where the transaction is ours to end. The sync workers end
their transaction around the admin push and each convergence probe, so the write
runs on a read view one HTTP round trip old instead of one job old. A conflict that
survives the replays lands on the pending marker three converging paths already act
on, not a failure.

Because no reconcile branch repairs a failed status behind a proven apply,
`onboarding.resync_llm` adds a probe-first retry verb: if admin says the container
already serves the config it stamps and returns, restarting nothing. Pushes are
throttled, since frappe's job dedupe stops covering once a worker exits.

No UI here. Settings needs a Resync button wired to that endpoint, which #714 owns.

<details>
<summary>Root cause, the competing writer, and what changed</summary>

**The statement that failed was not the UPDATE.** From the Error Log behind #713
(`6bb6t3acc5` on `e2e.localhost`, 2026-08-07 16:08:53):

```
SELECT `field`,`value` FROM `tabSingles` WHERE `doctype`=%(param1)s FOR UPDATE
  frappe/database/database.py:278   raise frappe.QueryDeadlockError(e)
  frappe/database/database.py:800   get_singles_dict(for_update=True)
  frappe/model/document.py:1430     load_doc_before_save
  frappe/model/document.py:1538     db_set
  jarvis_settings.py:163            _stamp_converged_ok
  jarvis_settings.py:187            _converge_via_admin   (state = 'Ready')
  jarvis_settings.py:871            _sync_via_admin
  jarvis_settings.py:1886           _enqueued_sync_via_admin   (acquired = True)
```

`Document.db_set` locks EVERY row of the Single before writing, 100 of them on
this workspace, to write three. That is what makes an unrelated field's writer
fatal.

**The competing writer.** `tabSingles` for Jarvis Settings held
`chat_was_ready_at = 2026-08-07 16:08:34.132830`, 19.7s before the failure and
one `_POOL_CONVERGE_INTERVAL_S` tick earlier. That is `account._mark_chat_ready`
plus `_rebind_anchor`, written from the SPA's `is_ready_for_chat` POST, which
Frappe commits because the method is unsafe. Both writers fired on the SAME
event: admin flipping `chat_readiness` to Ready. The worker was polling for it;
the SPA was polling for it; the SPA got there first and its commit invalidated
the worker's read view. Correlated by construction, not merely concurrent.

Three more writers are in the same class, all outside the `jarvis_settings_admin_sync`
redis lock (which is why `acquired = True` in the trace and why adding a lock
fixes nothing): `onboarding._reconcile_pending_applying` off the SPA's
`get_llm_sync_status` poll (seconds), `reconcile_pending_llm_sync` (\*/5,
`pause_scheduler: 0` on this bench), and `account._persist_operation_probe_verdicts`
off the apply-operation poll. The first three all write the same three fields.

**Why it was a dead end.** `reconcile_pending_llm_sync` acts on the
pending-applying marker, on an unproven first apply, or on a suspected disconnect.
This workspace had `llm_direct_synced_at` set from an earlier good sync and a
terminal `failed:` status, so it matched none of them, and `on_update` only syncs
what changed. Nothing in the product was ever going to try again. That is what
`resync_llm` exists for, and it is pinned by
`test_a_terminal_failure_after_a_proven_apply_is_a_dead_end`.

**Changed.** `_write_settings_fields` writes through `frappe.db.set_single_value`
(what `db_set` delegates to anyway, minus the pre-read), replays a
`QueryDeadlockError` up to three times, rolls back before each replay so the retry
reads the present, and returns a bool instead of raising. Every `last_sync_status`
write on this doctype now uses it; the `proxy_active` config writes do not.

The replay is scoped to callers that OWN the transaction (`_owns_transaction`: a
background job or a migrate). In a request or mid-save it re-raises, exactly as
today. That is the safety argument, not a convenience: a 1020 or 1213 has already
destroyed the caller's uncommitted work server-side, so rolling back and quietly
re-persisting our one field would let a half-written save be reported as a
success. #713 happened in a background job, which owns its transaction outright,
so nothing is lost by the scoping.

`_write_settings_fields` always writes `update_modified=False`, where about
fifteen of these sites previously took `db_set`'s default and bumped `modified`.
That gives up `check_if_latest`'s protection against a Desk save of Jarvis
Settings straddling a stamp, and it is deliberate: `modified` is the most
contended row in the doctype, so stamping it from writers already racing each
other would reintroduce a good share of the conflict this PR removes. It also
matches what the rest of the app already does for Jarvis Settings bookkeeping.
`_refresh_db_snapshot` (same real-worker gate as `_commit_terminal_sync_status`)
ends the transaction after the admin push and before each convergence probe.
`_stamp_converged_ok` / `_stamp_pool_applied_ok` / `_converge_via_admin` report a
lost stamp, and each caller falls back to `_PENDING_APPLYING_STATUS`; both sync
workers gained a `QueryDeadlockError` branch that records that marker and logs,
rather than letting the `finally` backstop call it an unexpected error.
`_refresh_db_snapshot` in the reconcile also fixes a latent read: its
reconnect guard re-read `_llm_config_revision` on the tick's original snapshot and
so could not see the commit it was looking for.

**Followed jarvis-admin-v2 #264.** Make the lost write visible rather than silent;
leave the drift for reconcile rather than forcing it; end the transaction before
reading what another connection committed.

**Diverged from #264, deliberately.** (1) It rolls back before retrying, which
#264 declined to do on the premise that ER_CHECKREAD is statement-level and leaves
the transaction usable. The #713 trace says otherwise on this plane: the
`finally` backstop's own `db_set` ran 2ms after the 1020 and SUCCEEDED, which is
only possible on a read view the server had already replaced. #264's code is
unaffected either way because `_report_unrecorded_apply` commits first, so this is
a note, not a bug report. (2) #264 could only leave its CAS for reconcile; these
writes are absolute values, so a replay is safe and is tried first. (3) #264
guarded the UPDATE; here the conflict was the pre-read, so the fix removes the
lock footprint as well as handling the error.

**Found, not fixed.** Frappe's background-job deadlock replay is unreachable for
this class, twice over: `execute_job` retries on `except (frappe.db.InternalError,
...)`, but `frappe.db.sql` has already converted the driver error into
`frappe.QueryDeadlockError`, which subclasses plain `Exception`
(`frappe/exceptions.py:258`); and `is_deadlocked(e)` would compare a wrapped
exception object against integer errnos anyway. So the job took the generic
handler, logged, and raised. Framework-level, left alone.

**Test honesty.** `_conflict_on` raises a real
`QueryDeadlockError(pymysql.InternalError(1020, ...))` from inside `frappe.db.sql`
at the statement that can still conflict after this change, but it is still raised
from Python: MariaDB never sees the statement, so no test here exercises a genuine
engine-produced ER_CHECKREAD. That is the same limit #264 recorded, and it cannot
be closed in this repo's CI, which runs MariaDB 10.11 and has no
`innodb_snapshot_isolation` to raise 1020 with. A two-connection reproduction
recipe is in the test module's docstring; a `skipUnless`-gated version of it was
deliberately NOT shipped, because it would never execute in any environment. The
suite was not run locally either: the constraint on this task rules out bench runs
against shared sites, and a worktree is not importable by bench regardless, so
hosted CI on this PR is the only execution these tests get.

</details>

## For #714 (settings panel)

Backend only, no Vue touched. Wire a Resync control to:

- **Method:** `jarvis.onboarding.resync_llm`, no arguments, POST (it writes).
- **Returns:** everything `get_llm_sync_status` returns (`last_sync_at`,
  `last_sync_status`, `pending`, `subscription_status`, `warnings`,
  `model_statuses`) plus `outcome` and `leg`.
- **`outcome`:** `converged` (admin already serves it, markers stamped, nothing
  restarted), `queued` (a re-push was enqueued, `leg` is `pool` or `direct`),
  `throttled` (a push went out within the last 3 minutes, nothing queued), or
  `not_configured` (nothing saved to re-drive, nothing queued).
- Render the response directly, no second poll needed. Safe to click repeatedly:
  the Ready probe is never throttled, and a push is rate-limited server-side, so
  the button needs no client-side guard of its own.

## Pre-merge checklist

- [x] **CI is green** - the `tests` check on this PR passes (never merge on :x:)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
