### PR TITLE
Scope the #713 write replay to transactions we own, and stop Resync restarting a healthy container

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -178,20 +178,36 @@ def _is_write_conflict(e: BaseException) -> bool:
 def _owns_transaction() -> bool:
 	"""May this code END the current transaction (commit or roll back)?
 
-	True only in a context that STARTED one and has no caller with uncommitted work
-	riding on it: a background job (``frappe.local.job`` is set exclusively by
+	True only where this process started one and nothing upstream is depending on
+	it: a background job (``frappe.local.job`` is set exclusively by
 	``execute_job``) or a migrate patch, where committing between units is normal.
 
-	False inside a web request and inside a document save, and that distinction is
-	load-bearing rather than cosmetic. A request's transaction belongs to the
-	request: frappe commits it on success and rolls it back on any exception, which
-	is what makes a save all-or-nothing. Code that ends it halfway breaks that
-	contract, and the dangerous shape is not the rollback itself - a genuine 1020 or
-	1213 already destroyed the transaction server-side - but what comes after it. A
-	retry that then re-persists only ITS OWN field leaves the caller's save half
-	written while every caller up the stack carries on and reports success. Raising
-	instead keeps the failure whole and the request's rollback authoritative."""
+	False in a web request, whose transaction belongs to the request: frappe commits
+	it on success and rolls it back on any exception, and code that ends it halfway
+	takes that decision away. False from ``bench execute`` and the CLI too, which is
+	imprecise (they do own their transaction) but harmless: the only thing withheld
+	there is a retry, and every caller treats a skipped retry as a lost race it will
+	re-attempt."""
 	return bool(getattr(frappe.local, "job", None) or frappe.flags.in_migrate)
+
+
+def _inside_a_save() -> bool:
+	"""Is a ``Jarvis Settings`` ``.save()`` in flight further up this stack?
+
+	The precise question ``_owns_transaction`` cannot answer. ``frappe.flags.
+	currently_saving`` holds ``(doctype, name)`` from ``set_user_and_timestamp``
+	until the end of ``run_post_save_methods``, so it spans ``on_update`` - which is
+	exactly where ``_enqueue_pool_sync`` and ``_on_update_single_model_legacy``
+	write their pending status from.
+
+	It matters because that caller has uncommitted field writes of its own in this
+	transaction. A conflict there must be RE-RAISED so the whole save fails as one:
+	rolling back and re-persisting only ``last_sync_status`` would leave the rest of
+	the save discarded while every frame up the stack carries on and reports
+	success. That hazard is about NESTING, not about being in a job, so it is asked
+	separately - a job that ever calls ``settings.save()`` inherits the same
+	protection without anyone having to remember."""
+	return ("Jarvis Settings", "Jarvis Settings") in (frappe.flags.currently_saving or [])
 
 
 def _refresh_db_snapshot() -> None:
@@ -258,15 +274,19 @@ def _write_settings_fields(settings, fields: dict) -> bool:
 	regardless.)
 
 	AND THE REPLAY ONLY RUNS WHERE THE TRANSACTION IS OURS TO END
-	(``_owns_transaction``), which is the whole of the safety argument. In a request
-	or mid-save the conflict is RE-RAISED, exactly as it propagated before this
-	change, so the request's own rollback stays authoritative and an all-or-nothing
-	save stays all-or-nothing. Retrying there would be the genuinely dangerous
-	shape: a 1020 or 1213 has already destroyed the caller's uncommitted work
-	server-side, and quietly re-persisting our one field on a fresh transaction
-	would let a half-written save be reported as a success. #713 happened in a
-	background job, which owns its transaction outright, so the fix loses nothing by
-	scoping the replay to that.
+	(``_owns_transaction``). Elsewhere the conflict is reported, not replayed: a
+	1020 or 1213 has already destroyed the transaction server-side, so rolling back
+	and quietly re-persisting our one field would publish OUR write while the
+	caller's is gone. #713 happened in a background job, which owns its transaction
+	outright, so scoping the replay there costs the fix nothing.
+
+	Reported rather than RAISED, though, and the distinction is the point. Returning
+	False lets a poller or a Resync click carry on and say "still applying", which is
+	true and self-correcting; raising would put a transient race back in front of a
+	customer, which is the entire complaint in #713 and would hit hardest in
+	``_reconcile_pending_applying``, the highest-frequency caller of all. The one
+	place a raise IS correct is nested inside a save (``_inside_a_save``), where the
+	caller's other field writes have to fail with it.
 
 	ALWAYS ``update_modified=False``, which is a real trade-off and not an
 	oversight. Several of these writes previously took ``db_set``'s default and
@@ -288,8 +308,15 @@ def _write_settings_fields(settings, fields: dict) -> bool:
 			settings.update(dict(fields))
 			return True
 		except Exception as e:
-			if not _is_write_conflict(e) or not _owns_transaction():
+			# Three outcomes, and only the first is a raise. Nested in a save, the
+			# caller's uncommitted work makes the failure theirs to own. Otherwise the
+			# lost race is REPORTED, never raised - a poller or a Resync click has no
+			# business turning it into a customer-visible error, which was the whole
+			# of #713 - and the replay is added only where the transaction is ours.
+			if not _is_write_conflict(e) or _inside_a_save():
 				raise
+			if not _owns_transaction():
+				return False
 			last_error = e
 			if attempt < _SETTINGS_WRITE_ATTEMPTS - 1:
 				frappe.db.rollback()

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -147,6 +147,13 @@ _SETTINGS_WRITE_ATTEMPTS = 3
 _SETTINGS_WRITE_BACKOFF_S = 0.05
 
 
+#: The exception classes that mean "another connection got there first". ONE
+#: definition, shared by ``_is_write_conflict`` and by the ``except`` clauses in
+#: both sync workers, so a later widening cannot reach the retry loop while
+#: silently missing the handlers, or the reverse.
+_WRITE_CONFLICT_ERRORS: tuple[type[BaseException], ...] = (frappe.QueryDeadlockError,)
+
+
 def _is_write_conflict(e: BaseException) -> bool:
 	"""Did MariaDB refuse this statement because another connection moved the row
 	after our transaction's snapshot opened (#713)?
@@ -165,7 +172,26 @@ def _is_write_conflict(e: BaseException) -> bool:
 	reachable without unwrapping ``QueryDeadlockError``'s argument, and an older
 	MariaDB that reports the same lost race as a plain 1213 has to take this branch
 	too or the customer-facing half of the fix only works on 11.6+."""
-	return isinstance(e, frappe.QueryDeadlockError)
+	return isinstance(e, _WRITE_CONFLICT_ERRORS)
+
+
+def _owns_transaction() -> bool:
+	"""May this code END the current transaction (commit or roll back)?
+
+	True only in a context that STARTED one and has no caller with uncommitted work
+	riding on it: a background job (``frappe.local.job`` is set exclusively by
+	``execute_job``) or a migrate patch, where committing between units is normal.
+
+	False inside a web request and inside a document save, and that distinction is
+	load-bearing rather than cosmetic. A request's transaction belongs to the
+	request: frappe commits it on success and rolls it back on any exception, which
+	is what makes a save all-or-nothing. Code that ends it halfway breaks that
+	contract, and the dangerous shape is not the rollback itself - a genuine 1020 or
+	1213 already destroyed the transaction server-side - but what comes after it. A
+	retry that then re-persists only ITS OWN field leaves the caller's save half
+	written while every caller up the stack carries on and reports success. Raising
+	instead keeps the failure whole and the request's rollback authoritative."""
+	return bool(getattr(frappe.local, "job", None) or frappe.flags.in_migrate)
 
 
 def _refresh_db_snapshot() -> None:
@@ -182,11 +208,11 @@ def _refresh_db_snapshot() -> None:
 	worker's own terminal write fail. Calling this before each probe shrinks the
 	exposure from "the whole job" to "one HTTP round trip".
 
-	Same real-worker gate as ``_commit_terminal_sync_status``, and for the same
-	reason: outside ``execute_job`` there is no rollback to defeat and committing
-	would break FrappeTestCase isolation. A single-connection context has no
+	Gated on ``_owns_transaction`` for the reason that predicate exists: ending a
+	transaction we did not start is not ours to do. It also happens to keep
+	FrappeTestCase isolation intact, and a single-connection context has no
 	competing writer to lose to, so skipping the refresh there costs nothing."""
-	if getattr(frappe.local, "job", None) or frappe.flags.in_migrate:
+	if _owns_transaction():
 		frappe.db.commit()
 
 
@@ -225,15 +251,34 @@ def _write_settings_fields(settings, fields: dict) -> bool:
 	the present. It discards nothing: MariaDB aborts the transaction itself on
 	1020/1213, which is directly visible in the #713 trace - the try/finally
 	backstop's own db_set ran 2ms after the failure and SUCCEEDED, which is only
-	possible on a read view the server had already replaced. (jarvis-admin-v2 #264
-	reasoned the other way, that ER_CHECKREAD is statement-level and leaves the
-	transaction usable, and deliberately did not roll back; its recovery path
-	commits first, so it gets a fresh snapshot regardless.)
+	possible on a read view the server had already replaced. (jarvis-admin-v2 PR
+	#264, for its issue #263, reasoned the other way - that ER_CHECKREAD is
+	statement-level and leaves the transaction usable - and deliberately did not
+	roll back; its recovery path commits first, so it gets a fresh snapshot
+	regardless.)
 
-	The one caller that reaches here holding work worth protecting does not: the
-	request path is ``save_llm_pool``, which COMMITS the customer's saved config
-	before it calls ``sync_pool_now`` at all, so no rollback here can cost anyone
-	the credential they just typed."""
+	AND THE REPLAY ONLY RUNS WHERE THE TRANSACTION IS OURS TO END
+	(``_owns_transaction``), which is the whole of the safety argument. In a request
+	or mid-save the conflict is RE-RAISED, exactly as it propagated before this
+	change, so the request's own rollback stays authoritative and an all-or-nothing
+	save stays all-or-nothing. Retrying there would be the genuinely dangerous
+	shape: a 1020 or 1213 has already destroyed the caller's uncommitted work
+	server-side, and quietly re-persisting our one field on a fresh transaction
+	would let a half-written save be reported as a success. #713 happened in a
+	background job, which owns its transaction outright, so the fix loses nothing by
+	scoping the replay to that.
+
+	ALWAYS ``update_modified=False``, which is a real trade-off and not an
+	oversight. Several of these writes previously took ``db_set``'s default and
+	bumped ``modified``, so a Desk save of Jarvis Settings that straddled one of
+	them was caught by ``check_if_latest`` and refused. That protection is given up
+	deliberately: ``modified`` is the single most contended row in this doctype
+	(every ``db_set`` in the app that does not opt out writes it), so stamping it
+	from four writers already racing each other would reintroduce a good share of
+	the conflict this function exists to remove. It also matches what the rest of
+	the app already does for Jarvis Settings bookkeeping - the oauth, chat-device,
+	suggestions, wiki-mirror and skills writers all pass
+	``update_modified=False``."""
 	import time as _time
 
 	last_error: BaseException | None = None
@@ -243,7 +288,7 @@ def _write_settings_fields(settings, fields: dict) -> bool:
 			settings.update(dict(fields))
 			return True
 		except Exception as e:
-			if not _is_write_conflict(e):
+			if not _is_write_conflict(e) or not _owns_transaction():
 				raise
 			last_error = e
 			if attempt < _SETTINGS_WRITE_ATTEMPTS - 1:
@@ -270,11 +315,12 @@ def _stamp_converged_ok(settings, *, is_pool: bool) -> bool:
 	direct apply that converged via reconcile would flip "ok" yet strand the
 	tenant at llm_provisioning forever (an "ok" status stops every reconcile).
 
-	Returns whether the stamp landed. FOUR callers race on these same three rows -
+	Returns whether the stamp landed. FIVE callers race on these same three rows -
 	the in-band sync worker's convergence poll, the pool worker's, the */5
-	``reconcile_pending_llm_sync`` and the SPA's own ``get_llm_sync_status`` poller
-	via ``onboarding._reconcile_pending_applying`` - all of them driven by the same
-	event, admin flipping chat_readiness to Ready. Losing that race is ordinary and
+	``reconcile_pending_llm_sync``, the SPA's own ``get_llm_sync_status`` poller via
+	``onboarding._reconcile_pending_applying``, and a customer's ``resync_llm``
+	click - nearly all of them driven by the same event, admin flipping
+	chat_readiness to Ready. Losing that race is ordinary and
 	self-correcting (whoever won wrote the identical outcome, and every one of the
 	four re-probes), so a lost stamp is reported as False and never raised: it is
 	the caller's cue to leave the reconcile-owned pending state behind rather than
@@ -920,7 +966,10 @@ class JarvisSettings(Document):
 		pending_label = (
 			"pending: provisioning container" if action == "restart" else "pending: rotating credentials"
 		)
-		self.db_set("last_sync_status", pending_label, update_modified=False)
+		# Through the guarded writer like every other status write, so the rule is
+		# uniform: a status write on THIS doctype never uses db_set, whether or not
+		# the caller happens to be inside a save (#713).
+		_write_settings_fields(self, {"last_sync_status": pending_label})
 		# In tests, run inline so existing assertions on the final status
 		# don't have to poll. Set ``frappe.flags.run_admin_sync_inline``
 		# from app code that needs the synchronous behavior (rare).
@@ -1139,9 +1188,13 @@ class JarvisSettings(Document):
 			_commit_terminal_sync_status()
 			terminal_written = True
 			frappe.logger().info(f"admin_client: rate-limited; retry_after={retry}s")
-		except frappe.QueryDeadlockError:
-			# #713. A lost write-conflict race is NOT a failed sync, and it must
-			# never read like one: the admin call succeeded, the container has the
+		except _WRITE_CONFLICT_ERRORS:
+			# #713, a BACKSTOP rather than the primary path: the status writes above
+			# all go through _write_settings_fields, which reports a lost race instead
+			# of raising, so what reaches here is a conflict from some OTHER statement
+			# in this body. Handled the same way, because the reasoning does not depend
+			# on which statement lost. A lost write-conflict race is NOT a failed sync,
+			# and it must never read like one: the admin call succeeded, the container has the
 			# config, and the only thing that did not happen is this bench writing
 			# down that it did. The customer's workspace was reported broken for a
 			# race between two writers that had both just been told everything was
@@ -1805,8 +1858,11 @@ def _enqueued_sync_via_admin_pool(
 				title="Jarvis: admin validation failed (pool sync)",
 				message=_frappe.get_traceback(),
 			)
-		except _frappe.QueryDeadlockError:
-			# #713, the pool twin of the branch in _sync_via_admin. Same reasoning:
+		except _WRITE_CONFLICT_ERRORS:
+			# #713, the pool twin of the branch in _sync_via_admin, and a backstop for
+			# the same reason: the guarded writer already absorbs the status writes, so
+			# this catches a conflict raised by anything else in this body. Same
+			# reasoning either way:
 			# admin already has the config, only the bookkeeping lost a race, and the
 			# pending marker is the state three converging paths act on.
 			_write_settings_fields(settings, {"last_sync_status": _PENDING_APPLYING_STATUS})
@@ -2107,7 +2163,15 @@ def request_resync(settings) -> str:
 	to "Applying your changes" on the same round trip, then enqueues under the SAME
 	job ids and the SAME redis lock as an ordinary save - so a Resync during an
 	in-flight sync coalesces into it instead of racing it or restarting the
-	container twice."""
+	container twice. (Only while that sync is still queued or running; the caller
+	owns the longer-term throttle.)
+
+	The direct leg is always ``"restart"``, never ``_classify_llm_change``'s lighter
+	``"reload"``. Two reasons, and they agree: the classifier needs
+	``get_doc_before_save()``, which is None outside an actual save, and its own
+	rule for a re-push of UNCHANGED creds after a non-ok status is "restart" anyway,
+	because a hot secret rotation cannot repair a container that never took the
+	config."""
 	from jarvis.jarvis.pool_serialize import compute_pool_mode
 
 	if compute_pool_mode(settings):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -349,7 +349,7 @@ def _stamp_converged_ok(settings, *, is_pool: bool) -> bool:
 	click - nearly all of them driven by the same event, admin flipping
 	chat_readiness to Ready. Losing that race is ordinary and
 	self-correcting (whoever won wrote the identical outcome, and every one of the
-	four re-probes), so a lost stamp is reported as False and never raised: it is
+	five re-probes), so a lost stamp is reported as False and never raised: it is
 	the caller's cue to leave the reconcile-owned pending state behind rather than
 	a failure to put in front of a customer (#713)."""
 	import frappe as _frappe

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -2169,9 +2169,15 @@ def resync_llm() -> dict:
 	cache = frappe.cache()
 	if cache.get_value(_RESYNC_COOLDOWN_KEY):
 		return {**get_llm_sync_status(), "outcome": "throttled", "leg": ""}
-	cache.set_value(_RESYNC_COOLDOWN_KEY, 1, expires_in_sec=_RESYNC_COOLDOWN_S)
 
+	# Armed only once a push is actually queued. Arming it first would let a call
+	# that queued NOTHING still lock the customer out for three minutes - the same
+	# "click it again and nothing happens" dead end this endpoint exists to remove.
+	# Fails open when redis is down (RedisWrapper swallows connection errors): that
+	# loses the throttle, never the retry, and admin's own rate limiter is the
+	# backstop that actually protects the rotate-ops budget.
 	leg = request_resync(settings)
+	cache.set_value(_RESYNC_COOLDOWN_KEY, 1, expires_in_sec=_RESYNC_COOLDOWN_S)
 	return {**get_llm_sync_status(), "outcome": "queued", "leg": leg}
 
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -2045,6 +2045,21 @@ def get_llm_sync_status() -> dict:
 	if status.startswith(_pending_applying_status()):
 		status = _reconcile_pending_applying(s) or status
 
+	return _sync_status_payload(s, status)
+
+
+def _sync_status_payload(s, status: str) -> dict:
+	"""Project Jarvis Settings into the poller's response shape. PURE: it reads and
+	formats, and unlike ``get_llm_sync_status`` it never probes admin and never
+	writes.
+
+	Split out so a caller that has already decided what the workspace's state is can
+	report it without the lazy reconcile running underneath and committing a
+	different answer (#713 review). ``resync_llm``'s not-configured branch is the
+	case that needs it: it has just established there is nothing to re-drive, so a
+	status projection that could stamp "ok (converged ...)" on the way out would
+	contradict the very answer it is returning."""
+
 	def _json_list(raw):
 		"""Stored JSON text -> list, degrading a corrupt/empty value to [] rather than
 		ever 500ing this poller."""
@@ -2066,6 +2081,14 @@ def get_llm_sync_status() -> dict:
 		# contract 1.11. The AI-models list keys each api-key row's health off this.
 		"model_statuses": _json_list(s.get("last_model_statuses")),
 	}
+
+
+#: Minimum gap between two Resync PUSHES. Sized to outlast a normal apply so the
+#: second click of an impatient pair is throttled rather than doubling the work,
+#: and to stay well inside the customer's shared 20/hour rotate-ops budget even if
+#: someone clicks steadily for an hour.
+_RESYNC_COOLDOWN_S = 180
+_RESYNC_COOLDOWN_KEY = "jarvis:resync_llm_cooldown"
 
 
 @frappe.whitelist()
@@ -2091,15 +2114,26 @@ def resync_llm() -> dict:
 	The push is only for a workspace admin says is NOT converged.
 
 	Gated on ``require_jarvis_admin`` (it drives a container mutation, like every
-	other write on this module) and safe to click repeatedly: the queued work
-	carries the same job ids and takes the same redis lock as an ordinary save, so
-	a second click coalesces into the first rather than racing it.
+	other write on this module).
+
+	THROTTLED, because "click it again" is what a customer does to a status that has
+	not moved. Frappe's ``deduplicate=True`` only collapses a second click while the
+	first job is still queued or running; once a worker exits without converging -
+	routine, since the in-job poll gives up after ``_POOL_CONVERGE_DEADLINE_S`` - the
+	job id frees and the next click drives a WHOLE new push: another container
+	re-render and another unit of the customer's shared 20/hour rotate-ops budget,
+	until admin starts refusing with a rate-limit the SPA renders as a failure. So a
+	push is allowed at most once per ``_RESYNC_COOLDOWN_S``; inside that window the
+	call reports ``throttled`` with the live status and queues nothing. The Ready
+	probe is NOT throttled - it neither pushes nor restarts, and answering "your
+	config is already live" instantly is the best outcome a Resync click can have.
 
 	Returns ``get_llm_sync_status()``'s shape, so a caller can render the response
 	directly with no second round trip, plus ``outcome``:
 
 	  * ``converged``      - admin already serves this config; markers stamped.
 	  * ``queued``         - a re-push was enqueued; ``leg`` is "pool" or "direct".
+	  * ``throttled``      - a re-push went out moments ago; nothing was queued.
 	  * ``not_configured`` - nothing saved to re-drive; nothing was queued.
 	"""
 	from jarvis.account import _has_llm_config
@@ -2113,15 +2147,29 @@ def resync_llm() -> dict:
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
 	# Both halves matter: a credential with no control-plane tenancy has nowhere to
-	# be pushed, and a tenancy with no credential has nothing to push.
+	# be pushed, and a tenancy with no credential has nothing to push. Projected
+	# WITHOUT get_llm_sync_status's lazy reconcile, which could otherwise stamp an
+	# "ok (converged ...)" on its way out and contradict this very answer.
 	if not _has_llm_config(settings) or not _has_admin_credentials(settings):
-		return {**get_llm_sync_status(), "outcome": "not_configured", "leg": ""}
+		status = settings.get("last_sync_status") or ""
+		return {**_sync_status_payload(settings, status), "outcome": "not_configured", "leg": ""}
 
 	state, _reason = _admin_chat_readiness()
-	if state == "Ready" and _stamp_converged_ok(settings, is_pool=compute_pool_mode(settings)):
-		# The stamp's own commit gate only fires in a worker; this is a request.
-		frappe.db.commit()
+	if state == "Ready":
+		# READY MEANS NEVER PUSH, whether or not our own stamp lands. Making the push
+		# conditional on the stamp succeeding would restart a healthy container in
+		# precisely the situation this endpoint exists to handle gently: five writers
+		# race to record this same Ready, so losing that race is ordinary, and it
+		# means SOMEONE recorded it. The status below carries whatever landed.
+		if _stamp_converged_ok(settings, is_pool=compute_pool_mode(settings)):
+			# The stamp's own commit gate only fires in a worker; this is a request.
+			frappe.db.commit()
 		return {**get_llm_sync_status(), "outcome": "converged", "leg": ""}
+
+	cache = frappe.cache()
+	if cache.get_value(_RESYNC_COOLDOWN_KEY):
+		return {**get_llm_sync_status(), "outcome": "throttled", "leg": ""}
+	cache.set_value(_RESYNC_COOLDOWN_KEY, 1, expires_in_sec=_RESYNC_COOLDOWN_S)
 
 	leg = request_resync(settings)
 	return {**get_llm_sync_status(), "outcome": "queued", "leg": leg}

--- a/jarvis/tests/test_settings_sync_conflict.py
+++ b/jarvis/tests/test_settings_sync_conflict.py
@@ -37,7 +37,7 @@ inside ``frappe.db.sql`` at the statement that can still conflict after the fix
 the statement, so no test here exercises a genuine engine-produced ER_CHECKREAD,
 and nothing here would catch a divergence between the real error and this
 reconstruction. That is the same limitation the admin-plane fix
-(jarvis-admin-v2 #264) recorded, and it is not fixable in this repo's CI: CI runs
+(jarvis-admin-v2 PR #264) recorded, and it is not fixable in this repo's CI: CI runs
 MariaDB 10.11, which has no ``innodb_snapshot_isolation`` at all and cannot raise
 1020 for this reason under any query. Reproducing the real error needs MariaDB
 11.6+ and two connections:
@@ -66,6 +66,7 @@ from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
 )
 
 SETTINGS = "Jarvis Settings"
+POOL_MODEL_DT = "Jarvis LLM Pool Model"
 _READINESS = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._admin_chat_readiness"
 _UNEXPECTED = "failed: unexpected error; see Error Log"
 
@@ -83,6 +84,11 @@ _TOUCHED = (
 	"llm_base_url",
 	"proxy_active",
 	"chat_was_ready_at",
+	"preset",
+	# _sync_via_admin's restart leg calls installed_apps_sync.record_synced_snapshot,
+	# which writes this. Snapshotted so a test run leaves the operator's real record
+	# exactly as it found it.
+	"installed_apps_synced",
 )
 _SECRETS = ("llm_api_key", "jarvis_admin_api_key", "jarvis_admin_api_secret")
 
@@ -143,6 +149,13 @@ class _Base(FrappeTestCase):
 		s = frappe.get_single(SETTINGS)
 		self._snap = {f: s.get(f) for f in _TOUCHED}
 		self._snap_secrets = {f: (s.get_password(f, raise_exception=False) or "") for f in _SECRETS}
+		# A leftover pool row - from the v1_seed_llm_models migration on a configured
+		# site, or from another module's pool tests against this same shared Single -
+		# flips compute_pool_mode and _has_llm_config, which would route these
+		# single-model assertions down the pool leg and fail them ORDER-DEPENDENTLY.
+		# The sibling suites (test_settings_on_update, test_save_llm_pool_operation)
+		# clear the same state for the same reason.
+		frappe.db.delete(POOL_MODEL_DT, {"parenttype": SETTINGS, "parent": SETTINGS})
 		# A connected SINGLE-MODEL workspace mid-apply: exactly #713's shape.
 		frappe.db.set_single_value(
 			SETTINGS,
@@ -151,6 +164,7 @@ class _Base(FrappeTestCase):
 				"llm_model": "deepseek-v4-flash",
 				"llm_auth_mode": "api_key",
 				"llm_base_url": "",
+				"preset": "",
 				"proxy_active": 0,
 				"last_sync_status": "pending: provisioning container",
 				"llm_direct_synced_at": None,
@@ -165,6 +179,7 @@ class _Base(FrappeTestCase):
 		s.db_set("jarvis_admin_api_key", "adminkey")
 		s.db_set("jarvis_admin_api_secret", "adminsecret")
 		frappe.db.commit()
+		self._clear_cooldown()
 
 	def tearDown(self):
 		from frappe.utils.password import remove_encrypted_password
@@ -174,6 +189,32 @@ class _Base(FrappeTestCase):
 			remove_encrypted_password(SETTINGS, SETTINGS, f)
 			frappe.db.set_single_value(SETTINGS, f, v, update_modified=False)
 		frappe.db.commit()
+		self._clear_cooldown()
+
+	@staticmethod
+	@contextlib.contextmanager
+	def _as_worker():
+		"""Run the body as a background job, which is where #713 happened and the
+		only context that owns its transaction outright.
+
+		Not a convenience: ``_write_settings_fields`` replays a conflict ONLY when
+		``_owns_transaction()`` is true, precisely so a request or a mid-save never
+		has its transaction ended underneath it. ``frappe.local.job`` is what
+		``execute_job`` sets, so setting it is what makes these tests exercise the
+		real worker path rather than a shape production never takes."""
+		previous = getattr(frappe.local, "job", None)
+		frappe.local.job = frappe._dict(method="test", job_name="test", after_job=None)
+		try:
+			yield
+		finally:
+			frappe.local.job = previous
+
+	@staticmethod
+	def _clear_cooldown():
+		"""The Resync push cooldown lives in redis, which no test transaction rolls
+		back. Left behind, one test's push throttles the next test's for three
+		minutes - and which tests those are depends on execution order."""
+		frappe.cache().delete_value(onboarding._RESYNC_COOLDOWN_KEY)
 
 	def _settings(self):
 		return frappe.get_single(SETTINGS)
@@ -188,7 +229,7 @@ class TestSettingsWriteSurvivesAConflict(_Base):
 	def test_it_does_not_take_the_doctype_wide_for_update_that_failed_in_713(self):
 		"""The load-bearing structural fix. ``db_set``'s pre-read locks EVERY
 		Jarvis Settings row, so a write of one status field conflicted with a
-		concurrent write of any of the ~200 - which is how a readiness marker
+		concurrent write of any of the 100 a live workspace has - which is how a readiness marker
 		killed a sync stamp. Asserted against ``db_set`` in the same test so the
 		difference is the claim, not a snapshot of one implementation."""
 		guarded, direct = [], []
@@ -221,7 +262,7 @@ class TestSettingsWriteSurvivesAConflict(_Base):
 		"""The ordinary case. The competing writer has committed and moved on, so
 		the replay - which runs on a FRESH snapshot, because the rollback is what
 		ends the doomed transaction - simply succeeds."""
-		with _conflict_on("last_sync_status", times=1) as state:
+		with self._as_worker(), _conflict_on("last_sync_status", times=1) as state:
 			landed = _write_settings_fields(self._settings(), {"last_sync_status": "ok (replayed)"})
 		self.assertTrue(landed)
 		self.assertEqual(state["raised"], 1)
@@ -231,11 +272,21 @@ class TestSettingsWriteSurvivesAConflict(_Base):
 		"""Bounded, and it does not raise: the caller decides what a lost race
 		means for the customer, and for every caller here the answer is a
 		recoverable state, never an exception on its way to an Error Log."""
-		with _conflict_on("last_sync_status") as state:
+		with self._as_worker(), _conflict_on("last_sync_status") as state:
 			landed = _write_settings_fields(self._settings(), {"last_sync_status": "ok (never)"})
 		self.assertFalse(landed)
 		self.assertGreaterEqual(state["raised"], 2, "the write is replayed, not attempted once")
 		self.assertEqual(_status(), "pending: provisioning container", "the old value stands")
+
+	def test_a_request_re_raises_instead_of_ending_a_transaction_it_does_not_own(self):
+		"""The safety rule behind the replay. In a request or mid-save the caller's
+		transaction is not ours to end, and a 1020/1213 has already destroyed its
+		uncommitted work server-side. Rolling back and re-persisting only OUR field
+		would leave a half-written save that every caller up the stack reports as a
+		success, so the conflict propagates and frappe's own request rollback stays
+		authoritative."""
+		with _conflict_on("last_sync_status"), self.assertRaises(frappe.QueryDeadlockError):
+			_write_settings_fields(self._settings(), {"last_sync_status": "ok (request)"})
 
 	def test_it_swallows_nothing_but_a_write_conflict(self):
 		"""A programmer error or a schema fault must not be absorbed into a
@@ -277,7 +328,7 @@ class TestSyncRecoversFromAConflict(_Base):
 		"""The customer-visible defect. "unexpected error" is what
 		``humaniseSyncStatus`` renders as "Last sync failed", on a workspace whose
 		container was serving the new config the whole time."""
-		with self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
+		with self._as_worker(), self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
 			self._settings()._sync_via_admin("restart")
 		self.assertNotIn(_UNEXPECTED, _status())
 		self.assertEqual(_status(), _PENDING_APPLYING_STATUS)
@@ -285,7 +336,7 @@ class TestSyncRecoversFromAConflict(_Base):
 	def test_the_stamp_still_lands_when_the_conflict_clears(self):
 		"""The fix must not make the happy path pessimistic: one lost race is
 		replayed into a normal, fully stamped success."""
-		with self._applying_then_ready(), _conflict_on("llm_direct_synced_at", times=1):
+		with self._as_worker(), self._applying_then_ready(), _conflict_on("llm_direct_synced_at", times=1):
 			self._settings()._sync_via_admin("restart")
 		self.assertTrue(_status().startswith("ok"))
 		self.assertTrue(_direct_marker())
@@ -294,7 +345,7 @@ class TestSyncRecoversFromAConflict(_Base):
 		"""Why the pending marker rather than softer failure wording: it is the
 		state ``reconcile_pending_llm_sync`` (and the SPA's own poller) converges.
 		The apply is real, so recording it is the only thing outstanding."""
-		with self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
+		with self._as_worker(), self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
 			self._settings()._sync_via_admin("restart")
 		self.assertEqual(_status(), _PENDING_APPLYING_STATUS)
 
@@ -381,6 +432,30 @@ class TestResyncLlm(_Base):
 			out = onboarding.resync_llm()
 		self.assertEqual(out["leg"], "pool")
 		self.assertEqual([c.kwargs.get("job_id") for c in enq.call_args_list], ["jarvis_settings_sync:pool"])
+
+	def test_a_second_click_inside_the_cooldown_pushes_nothing(self):
+		"""A status that has not moved is exactly what makes someone click again, and
+		frappe's job dedupe stops covering the moment the first worker exits. Without
+		the cooldown each further click is another container re-render against the
+		customer's shared rotate-ops budget."""
+		with patch(_READINESS, return_value=("Configuring", "")), patch("frappe.enqueue") as enq:
+			first = onboarding.resync_llm()
+			second = onboarding.resync_llm()
+		self.assertEqual(first["outcome"], "queued")
+		self.assertEqual(second["outcome"], "throttled")
+		self.assertEqual(second["leg"], "")
+		self.assertEqual(len(enq.call_args_list), 1, "the second click must enqueue nothing")
+
+	def test_the_cooldown_never_blocks_the_probe_that_costs_nothing(self):
+		"""Throttling the Ready path would be the wrong trade: it neither pushes nor
+		restarts, and "your config is already live" is the best answer a Resync can
+		give. It stays available even straight after a throttled click."""
+		with patch(_READINESS, return_value=("Configuring", "")), patch("frappe.enqueue"):
+			onboarding.resync_llm()
+		with patch(_READINESS, return_value=("Ready", "")), patch("frappe.enqueue") as enq:
+			out = onboarding.resync_llm()
+		self.assertEqual(out["outcome"], "converged")
+		enq.assert_not_called()
 
 	def test_it_refuses_a_workspace_with_nothing_to_re_drive(self):
 		"""No credential means no configuration to push; queueing one would spend a

--- a/jarvis/tests/test_settings_sync_conflict.py
+++ b/jarvis/tests/test_settings_sync_conflict.py
@@ -278,15 +278,29 @@ class TestSettingsWriteSurvivesAConflict(_Base):
 		self.assertGreaterEqual(state["raised"], 2, "the write is replayed, not attempted once")
 		self.assertEqual(_status(), "pending: provisioning container", "the old value stands")
 
-	def test_a_request_re_raises_instead_of_ending_a_transaction_it_does_not_own(self):
-		"""The safety rule behind the replay. In a request or mid-save the caller's
-		transaction is not ours to end, and a 1020/1213 has already destroyed its
-		uncommitted work server-side. Rolling back and re-persisting only OUR field
-		would leave a half-written save that every caller up the stack reports as a
-		success, so the conflict propagates and frappe's own request rollback stays
-		authoritative."""
-		with _conflict_on("last_sync_status"), self.assertRaises(frappe.QueryDeadlockError):
-			_write_settings_fields(self._settings(), {"last_sync_status": "ok (request)"})
+	def test_a_request_reports_the_lost_race_without_ending_a_transaction_it_owns_not(self):
+		"""Half of the safety rule. A request's transaction belongs to the request,
+		so the replay is withheld - but the conflict is REPORTED, not raised. Raising
+		would put a transient race back in front of a customer, which is #713 itself,
+		and it would land hardest on _reconcile_pending_applying: the SPA polls it
+		every few seconds and its contract is that it never raises."""
+		with _conflict_on("last_sync_status"), patch.object(frappe.local.db, "rollback") as rb:
+			landed = _write_settings_fields(self._settings(), {"last_sync_status": "ok (request)"})
+		self.assertFalse(landed)
+		rb.assert_not_called()
+
+	def test_a_conflict_nested_in_a_save_is_raised_so_the_whole_save_fails(self):
+		"""The other half, and the reason the nesting question is asked separately
+		from the job question. on_update writes the pending status while the save
+		still holds uncommitted field writes of its own; swallowing a conflict there
+		would let the save be reported as a success with everything except
+		last_sync_status discarded."""
+		frappe.flags.currently_saving.append((SETTINGS, SETTINGS))
+		try:
+			with _conflict_on("last_sync_status"), self.assertRaises(frappe.QueryDeadlockError):
+				_write_settings_fields(self._settings(), {"last_sync_status": "ok (in save)"})
+		finally:
+			frappe.flags.currently_saving.remove((SETTINGS, SETTINGS))
 
 	def test_it_swallows_nothing_but_a_write_conflict(self):
 		"""A programmer error or a schema fault must not be absorbed into a
@@ -445,6 +459,18 @@ class TestResyncLlm(_Base):
 		self.assertEqual(second["outcome"], "throttled")
 		self.assertEqual(second["leg"], "")
 		self.assertEqual(len(enq.call_args_list), 1, "the second click must enqueue nothing")
+
+	def test_a_push_that_queued_nothing_does_not_arm_the_cooldown(self):
+		"""Arming before the push would turn one failed call into a three-minute
+		lockout - the dead end this endpoint exists to remove, self-inflicted."""
+		with patch(_READINESS, return_value=("Configuring", "")):
+			with patch("frappe.enqueue", side_effect=RuntimeError("queue down")):
+				with self.assertRaises(RuntimeError):
+					onboarding.resync_llm()
+			with patch("frappe.enqueue") as enq:
+				out = onboarding.resync_llm()
+		self.assertEqual(out["outcome"], "queued", "the retry must not be throttled by a failed push")
+		self.assertEqual(len(enq.call_args_list), 1)
 
 	def test_the_cooldown_never_blocks_the_probe_that_costs_nothing(self):
 		"""Throttling the Ready path would be the wrong trade: it neither pushes nor

--- a/jarvis/tests/test_settings_sync_conflict.py
+++ b/jarvis/tests/test_settings_sync_conflict.py
@@ -61,6 +61,7 @@ from frappe.tests.utils import FrappeTestCase
 from jarvis import admin_client, onboarding
 from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
 	_PENDING_APPLYING_STATUS,
+	_SETTINGS_WRITE_ATTEMPTS,
 	_write_settings_fields,
 	reconcile_pending_llm_sync,
 )
@@ -229,7 +230,7 @@ class TestSettingsWriteSurvivesAConflict(_Base):
 	def test_it_does_not_take_the_doctype_wide_for_update_that_failed_in_713(self):
 		"""The load-bearing structural fix. ``db_set``'s pre-read locks EVERY
 		Jarvis Settings row, so a write of one status field conflicted with a
-		concurrent write of any of the 100 a live workspace has - which is how a readiness marker
+		concurrent write to any of the 100 rows a live workspace has - which is how a readiness marker
 		killed a sync stamp. Asserted against ``db_set`` in the same test so the
 		difference is the claim, not a snapshot of one implementation."""
 		guarded, direct = [], []
@@ -342,10 +343,17 @@ class TestSyncRecoversFromAConflict(_Base):
 		"""The customer-visible defect. "unexpected error" is what
 		``humaniseSyncStatus`` renders as "Last sync failed", on a workspace whose
 		container was serving the new config the whole time."""
-		with self._as_worker(), self._applying_then_ready(), _conflict_on("llm_direct_synced_at"):
+		with self._as_worker(), self._applying_then_ready(), _conflict_on("llm_direct_synced_at") as state:
 			self._settings()._sync_via_admin("restart")
 		self.assertNotIn(_UNEXPECTED, _status())
 		self.assertEqual(_status(), _PENDING_APPLYING_STATUS)
+		# The status alone does NOT prove the replay ran: _sync_via_admin's
+		# _WRITE_CONFLICT_ERRORS backstop writes the same marker, so a version that
+		# never retried would look identical from outside. The attempt count is what
+		# separates them.
+		self.assertEqual(
+			state["raised"], _SETTINGS_WRITE_ATTEMPTS, "the stamp must exhaust its replays first"
+		)
 
 	def test_the_stamp_still_lands_when_the_conflict_clears(self):
 		"""The fix must not make the happy path pessimistic: one lost race is
@@ -478,6 +486,10 @@ class TestResyncLlm(_Base):
 		give. It stays available even straight after a throttled click."""
 		with patch(_READINESS, return_value=("Configuring", "")), patch("frappe.enqueue"):
 			onboarding.resync_llm()
+		# Without this the test could not tell a bypassed cooldown from no cooldown.
+		self.assertTrue(
+			frappe.cache().get_value(onboarding._RESYNC_COOLDOWN_KEY), "the cooldown must be armed"
+		)
 		with patch(_READINESS, return_value=("Ready", "")), patch("frappe.enqueue") as enq:
 			out = onboarding.resync_llm()
 		self.assertEqual(out["outcome"], "converged")


### PR DESCRIPTION
## Summary

Review follow-ups to #713, which merged while the review was still running. Three
fixes, one of them a correctness bug in that PR.

The conflict replay in `_write_settings_fields` now runs only where the transaction
is ours to end: a 1020 or 1213 has already destroyed the caller's uncommitted work
server-side, so rolling back and re-persisting our one field would publish ours
while theirs is gone. Elsewhere the lost race is REPORTED, not raised, because
raising would put a transient conflict back in front of the customer through the
SPA's own status poller. The one case that must raise is a conflict nested inside a
`.save()`, where the caller's other field writes have to fail with it.

`resync_llm` no longer falls through to a container restart when admin reports
Ready but our own stamp loses its race. That was the single case the endpoint
exists to handle gently. It also throttles pushes: frappe's job dedupe stops
covering once a worker exits, so repeated clicks were each a fresh re-render
against the customer's rotate-ops budget.

The new tests were order-dependent. They now clear leftover pool rows and `preset`
the way the sibling suites do, snapshot `installed_apps_synced`, clear the
throttle key, and run the replay cases as a worker.

No API shape change for #714: `outcome` gains `throttled`.

<details>
<summary>Why each one matters</summary>

**The replay scope (correctness).** `_write_settings_fields` rolled back and
retried unconditionally. Reached from `on_update` (via `_enqueue_pool_sync` or
`_on_update_single_model_legacy`), or inline under
`frappe.flags.run_admin_sync_inline` where `frappe.enqueue(now=True)` runs in the
caller's own transaction, that rollback discards the caller's unflushed field
writes. The retry then re-persists only `last_sync_status`, `on_update` continues,
and the request reports success on a save whose other writes are gone. A genuine
ER_CHECKREAD cannot reach that path (`check_if_latest` takes the doctype-wide
`FOR UPDATE` before `on_update` runs, so staleness trips there first and 500s
safely), but ER_LOCK_DEADLOCK 1213 can, and `_is_write_conflict` matches it too.
`_owns_transaction()` gates the transaction-ending helpers: only a background job or
a migrate patch starts its own transaction and may end it.

Gating on that ALONE was wrong, which a second review round caught. It also made the
conflict raise in every request, and the highest-frequency caller is
`_reconcile_pending_applying`, reached from the `get_llm_sync_status` poller the SPA
hits every few seconds while a workspace is pending-applying, whose stated contract
is that it never raises. That is #713 reintroduced. Nesting is now asked separately
from ownership: `_inside_a_save()` (true throughout `on_update`, via
`frappe.flags.currently_saving`) forces a raise, ownership permits a replay, and
everything else reports False so the caller can say "still applying". Asking about
nesting rather than about jobs also means a worker that ever calls `settings.save()`
inherits the protection with nobody having to remember.

**The Ready fall-through.** `if state == "Ready" and _stamp_converged_ok(...)`
short-circuited to `request_resync` whenever the stamp lost its race. Five writers
race to record that same Ready, so losing is ordinary and means someone else
recorded it. Ready now means never push, regardless of who won.

**The throttle ordering.** The cooldown was armed before `request_resync` ran, so a
call that raised before queueing anything still locked the customer out for three
minutes: the exact dead end this endpoint exists to remove, self-inflicted. It is
armed after a push is queued now, and fails open if redis is down.

**The throttle.** `deduplicate=True` only collapses a click while the first job is
queued or running. Once a worker exits without converging, routine given the
120s in-job poll, the job id frees and the next click drives a whole new push. A
customer watching an unmoved status is exactly the one who clicks again. One push
per 3 minutes; the Ready probe is never throttled, since it neither pushes nor
restarts.

**The test isolation.** `compute_pool_mode` and `_has_llm_config` read `models[]`
and `preset` off the shared Single. A leftover pool row, from the
`v1_seed_llm_models` migration or another module's tests, routes these
single-model assertions down the pool leg and fails five of them depending on
execution order. CI shards by file and the parallel runner orders alphabetically,
so this would have surfaced as an unrelated-looking flake later.
`test_settings_on_update` and `test_save_llm_pool_operation` already clear the
same state for the same reason.

**Test limits are unchanged from #713** and still stated in the module docstring:
the injected conflict is a faithfully constructed `QueryDeadlockError` raised from
Python inside `frappe.db.sql`, not an engine-produced ER_CHECKREAD. CI runs
MariaDB 10.11, which has no `innodb_snapshot_isolation`, so no test in this repo
can produce the real error.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on :x:)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

