### PR TITLE
feat(onboarding): banknote confirming art, staged waits, honest headlines

### DIFF
--- a/design.md
+++ b/design.md
@@ -137,8 +137,11 @@ this is the mapping (use it when porting, never when writing new UI):
 > **Brand-asset exception:** the gradient/purple ban applies to chrome and controls, not to
 > brand-identity assets. The Jarvis mark, and the two sanctioned illustrations of a long
 > onboarding wait, may keep the brand gradient, provided they honor
-> `prefers-reduced-motion` with a calm static frame and read every colour from tokens, never
-> hard-coded rgba. The two, and they are a closed set:
+> `prefers-reduced-motion` with a calm static frame and read their colours from tokens rather
+> than hard-coded rgba. The one carve-out is the white foreground drawn *on* the brand fill
+> (the spark, the rupee glyph): white on the brand gradient is theme-invariant for the same
+> reason `ink-white` is, and there is no token for it. Everything else comes from a var. The
+> two illustrations, and they are a closed set:
 >
 > | Illustration | Renders during | Subject |
 > |---|---|---|

--- a/design.md
+++ b/design.md
@@ -143,7 +143,7 @@ this is the mapping (use it when porting, never when writing new UI):
 > | Illustration | Renders during | Subject |
 > |---|---|---|
 > | `SetupNeuralNet` | the long provisioning/readiness wait | ERP modules connecting to the mark |
-> | `PaymentConfirmingArt` | the payment-confirming wait only | coins and notes arriving at the mark |
+> | `PaymentConfirmingArt` | the payment-confirming wait only | banknotes arriving at the mark along a rail |
 >
 > Rules that come with the second one (product owner authorized it on 2026-08-07, overruling
 > the previous single-illustration wording):
@@ -154,15 +154,18 @@ this is the mapping (use it when porting, never when writing new UI):
 > - **Neither is a spinner.** §3.8 still stands: `JvSpinner` is the only loading indicator, and
 >   short waits (a sub-second navigation, a button's own `:loading`) get it, not an
 >   illustration. These two are for waits measured in tens of seconds.
-> - **The money tones are `--money-coin` and `--money-note`, not the semantic ramps.** Green
->   (`--green`) means success and amber (`--amber`) means warning. The confirming screen renders
->   while the payment is *unconfirmed*, so it must not be painted in either, and gold leads so
->   the screen never reads as a green "paid" tick before that is true. Status is carried by the
->   copy. These two tokens are for this illustration and nothing else: never text, badges,
->   banners or controls.
-> - **No emoji, here least of all.** §3.9 holds: emoji are platform-drawn, cannot take a token
->   colour, and do not theme, so they can satisfy none of the conditions above. Money is drawn
->   as vectors.
+> - **The money green is `--money-note` / `--money-note-bd`, never the semantic success ramp.**
+>   `--green` means success/paid. The confirming screen renders while the payment is
+>   *unconfirmed*, so painting it in the success colour would assert the outcome the screen
+>   exists to say we do not have yet. These two tokens flip by theme (a fill that works on a
+>   white card disappears on a near-black one) and are for this illustration and nothing else:
+>   never text, badges, banners or controls. Status is carried by the copy, never by the colour.
+> - **Notes, not coins.** Circles read as a slot machine, which is the wrong note to strike on
+>   the screen that appears right after taking someone's money. Rectangles on a rail read as a
+>   transfer.
+> - **No emoji, here least of all.** §3.9 holds: emoji are platform-drawn, so the same screen
+>   would ship a different picture per OS; they cannot take a token colour, so they cannot meet
+>   the condition above; and they ignore theme. The rupee glyph is drawn as canvas text.
 >
 > Adding a third illustration is a change to this table, not a judgement call at the call site.
 

--- a/design.md
+++ b/design.md
@@ -135,9 +135,36 @@ this is the mapping (use it when porting, never when writing new UI):
 | brand purple `#8b5cf6`, gradients, glow rgba | **no equivalent — delete from chrome and controls on rewrite** | untokenized; violates §1.1–1.3 |
 
 > **Brand-asset exception:** the gradient/purple ban applies to chrome and controls, not to
-> brand-identity assets. The Jarvis mark, and a single sanctioned "processing" illustration
-> during a long provisioning wait (SetupNeuralNet), may keep the brand gradient — provided
-> they honor `prefers-reduced-motion` and read their colors from tokens, not hard-coded rgba.
+> brand-identity assets. The Jarvis mark, and the two sanctioned illustrations of a long
+> onboarding wait, may keep the brand gradient, provided they honor
+> `prefers-reduced-motion` with a calm static frame and read every colour from tokens, never
+> hard-coded rgba. The two, and they are a closed set:
+>
+> | Illustration | Renders during | Subject |
+> |---|---|---|
+> | `SetupNeuralNet` | the long provisioning/readiness wait | ERP modules connecting to the mark |
+> | `PaymentConfirmingArt` | the payment-confirming wait only | coins and notes arriving at the mark |
+>
+> Rules that come with the second one (product owner authorized it on 2026-08-07, overruling
+> the previous single-illustration wording):
+>
+> - **One illustration per screen, never both at once.** They mean different things: value
+>   arriving versus a workspace being assembled. A screen that showed both would be claiming
+>   both, and a screen that used the wrong one would be claiming the wrong thing.
+> - **Neither is a spinner.** §3.8 still stands: `JvSpinner` is the only loading indicator, and
+>   short waits (a sub-second navigation, a button's own `:loading`) get it, not an
+>   illustration. These two are for waits measured in tens of seconds.
+> - **The money tones are `--money-coin` and `--money-note`, not the semantic ramps.** Green
+>   (`--green`) means success and amber (`--amber`) means warning. The confirming screen renders
+>   while the payment is *unconfirmed*, so it must not be painted in either, and gold leads so
+>   the screen never reads as a green "paid" tick before that is true. Status is carried by the
+>   copy. These two tokens are for this illustration and nothing else: never text, badges,
+>   banners or controls.
+> - **No emoji, here least of all.** §3.9 holds: emoji are platform-drawn, cannot take a token
+>   colour, and do not theme, so they can satisfy none of the conditions above. Money is drawn
+>   as vectors.
+>
+> Adding a third illustration is a change to this table, not a judgement call at the call site.
 
 Coexistence rules: `theme.js#applyTheme()` already stamps `data-theme` on `<html>`, so
 Tailwind semantic tokens work everywhere, including inside legacy subtrees. The reverse is not

--- a/frontend/src/lib/brand.js
+++ b/frontend/src/lib/brand.js
@@ -7,12 +7,12 @@
  * refresh to land in two of them, so the path lives here once and every surface
  * imports it.
  *
- * Colours are deliberately NOT here. They already have a single source of truth
- * as CSS custom properties (--brand-1 / --brand-2 / --brand-grad in main.css),
- * and duplicating them as JS constants would create exactly the drift this
- * module exists to prevent. The one exception is the canvas in
- * SetupNeuralNet.vue, which cannot read a gradient from CSS and documents its
- * own literals as theme-invariant.
+ * Colour VALUES are deliberately NOT here. They already have a single source of
+ * truth as CSS custom properties (--brand-1 / --brand-2 / --brand-grad in
+ * main.css), and duplicating them as JS constants would create exactly the
+ * drift this module exists to prevent. What does live here is the one helper
+ * the canvases need to USE those tokens, since a canvas cannot apply a CSS
+ * colour at partial opacity the way a stylesheet can.
  */
 
 /**
@@ -20,3 +20,30 @@
  * Consumers set their own fill; the path carries no colour of its own.
  */
 export const BRAND_STAR_PATH = "M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z";
+
+/**
+ * A hex colour at partial opacity, as an rgba() string a canvas can use.
+ *
+ * The canvases read their colours from CSS custom properties (the brand-asset
+ * exception in design.md requires it), but a token is a flat hex and the
+ * illustrations need it at many opacities for edges, halos and trails. This
+ * turns one into the other.
+ *
+ * Lives here for the same reason BRAND_STAR_PATH does: it was written twice,
+ * once in SetupNeuralNet.vue and once in PaymentConfirmingArt.vue, byte for
+ * byte apart from the fallback. Two hand-maintained copies is two chances for a
+ * fix to land in one of them.
+ *
+ * @param {string} hex - "#rgb" or "#rrggbb". Anything else uses `fallback`.
+ * @param {number} a - alpha, 0 to 1.
+ * @param {string} [fallback] - rgb triple to use when `hex` is unparseable.
+ */
+export function alphaHex(hex, a, fallback = "110,139,255") {
+	let h = String(hex || "")
+		.trim()
+		.replace("#", "");
+	if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+	const n = parseInt(h, 16);
+	if (h.length !== 6 || Number.isNaN(n)) return `rgba(${fallback},${a})`;
+	return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -18,21 +18,34 @@
 	--brand-2: #8b5cf6;
 	--brand-grad: linear-gradient(135deg, var(--brand-1), var(--brand-2));
 
-	/* Money tones, for the payment-confirming illustration ONLY
-	   (PaymentConfirmingArt.vue). Deliberately NOT the semantic ramps:
+	/* Money green, for the banknotes in the payment-confirming illustration
+	   ONLY (PaymentConfirmingArt.vue).
 
-	   --green (#16a34a) means success/paid and --amber (#d97706) means
-	   warning. The confirming screen renders while the payment is still
-	   UNCONFIRMED, so painting it in either ramp would state an outcome the
-	   screen exists to say we do not have yet. These are duller and warmer
-	   than both, read as coin metal and banknote at a glance, and carry no
-	   status meaning anywhere else in the product.
+	   Deliberately NOT the semantic success ramp. --green (#16a34a) means
+	   success/paid, and this illustration renders while the payment is still
+	   UNCONFIRMED - the whole point of that screen is that we do not have a
+	   verdict yet. Painting it in the success colour would assert the payment
+	   succeeded before it has, which is the same class of false progress
+	   jarvis#708/#709 were about. It reads as money, it does not read as a
+	   green tick.
 
-	   Theme-invariant for the same reason as the brand tokens above: this is
-	   an illustration, not chrome, and it must not restate itself per theme.
+	   Unlike the brand pair above these DO flip by theme, because a fill dark
+	   enough to sit on a white card disappears on a near-black one. Written as
+	   a :root default plus a [data-theme="dark"] override rather than in
+	   theme.js's paletteVars, so they resolve everywhere - the jv-* vars only
+	   resolve inside a subtree that bound paletteVars, and applyTheme() already
+	   stamps data-theme on <html>.
+
 	   Never use them for text, badges, banners or any control. */
-	--money-coin: #c9922b;
-	--money-note: #5a9e73;
+	--money-note: #1f8a54;
+	--money-note-bd: #34a76a;
+}
+
+[data-theme="dark"] {
+	/* Lifted for legibility on the dark card; the border stays a touch lighter
+	   than the fill so the note keeps its edge. */
+	--money-note: #4fbf85;
+	--money-note-bd: #6fce9a;
 }
 
 /* Native form controls (select dropdowns, date/time pickers, scrollbars)

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -17,6 +17,22 @@
 	--brand-1: #6e8bff;
 	--brand-2: #8b5cf6;
 	--brand-grad: linear-gradient(135deg, var(--brand-1), var(--brand-2));
+
+	/* Money tones, for the payment-confirming illustration ONLY
+	   (PaymentConfirmingArt.vue). Deliberately NOT the semantic ramps:
+
+	   --green (#16a34a) means success/paid and --amber (#d97706) means
+	   warning. The confirming screen renders while the payment is still
+	   UNCONFIRMED, so painting it in either ramp would state an outcome the
+	   screen exists to say we do not have yet. These are duller and warmer
+	   than both, read as coin metal and banknote at a glance, and carry no
+	   status meaning anywhere else in the product.
+
+	   Theme-invariant for the same reason as the brand tokens above: this is
+	   an illustration, not chrome, and it must not restate itself per theme.
+	   Never use them for text, badges, banners or any control. */
+	--money-coin: #c9922b;
+	--money-note: #5a9e73;
 }
 
 /* Native form controls (select dropdowns, date/time pickers, scrollbars)

--- a/frontend/src/onboarding/PaymentConfirmingArt.vue
+++ b/frontend/src/onboarding/PaymentConfirmingArt.vue
@@ -280,7 +280,7 @@ function start() {
 	coreFlash = 0;
 	t0 = null;
 	if (reduced) {
-		requestAnimationFrame((ts) => {
+		raf = requestAnimationFrame((ts) => {
 			t0 = ts;
 			draw(ts);
 			cancelAnimationFrame(raf);

--- a/frontend/src/onboarding/PaymentConfirmingArt.vue
+++ b/frontend/src/onboarding/PaymentConfirmingArt.vue
@@ -18,39 +18,38 @@
 /**
  * PaymentConfirmingArt - the payment-confirming illustration.
  *
- * Coins and banknotes drift inward and are absorbed into the Jarvis mark,
- * which pulses as each one lands. It renders during the window where the
- * customer has paid on the admin-hosted page and the bench is asking the
- * control plane whether that payment actually landed.
+ * Banknotes travel along a hairline rail into the Jarvis mark, which pulses as
+ * each one lands. It renders during the window where the customer has paid on
+ * the admin-hosted page and the bench is asking the control plane whether that
+ * payment actually landed.
  *
  * WHY THIS EXISTS ALONGSIDE SetupNeuralNet, rather than replacing it or being
  * folded into it: the two illustrate different things and never appear at the
- * same time. This one is value arriving (payment confirming). SetupNeuralNet
- * is a workspace being assembled (provisioning). Sharing one asset across both
+ * same time. This one is value arriving (payment confirming). SetupNeuralNet is
+ * a workspace being assembled (provisioning). Sharing one asset across both
  * would mean the same picture claims two different things, which is precisely
  * the class of overstatement jarvis#708/#709 were about. design.md's
- * brand-asset exception was amended to name both, with the one-illustration-
- * per-screen rule written into it.
+ * brand-asset exception was amended to name both, with the
+ * one-illustration-per-screen rule written into it.
  *
- * DELIBERATELY NOT EMOJI. The request floated "money notes emoji". Emoji are
- * rendered by the platform font, so the same screen ships a different picture
- * on macOS, Windows and Android; they cannot take a token colour, so they
- * cannot honour the brand-asset exception's "read colours from tokens" rule;
- * they do not adapt to theme; and at the sizes used here they land as raster
- * blobs beside a vector mark. design.md 3.9 is also explicit that emoji are
- * never UI. These are drawn as vectors instead, which themes correctly, scales
- * to any DPR, and reads as money at a glance.
+ * NOTES, NOT COINS. Circles read as a slot machine, which is the last thing to
+ * put on the screen that appears immediately after taking someone's money.
+ * Rectangular notes on a rail read as a transfer.
  *
- * COLOUR. Coins are --money-coin, notes are --money-note (see main.css). Both
- * are deliberately off the semantic ramps: --green means success and --amber
- * means warning, and this screen renders while the payment is NOT yet
- * confirmed. Gold leads and green is the minority tone, so the screen never
- * reads as a green "paid" tick before it is true. The status is carried by the
- * copy, never by the colour.
+ * NOT EMOJI. Emoji are drawn by the platform font, so the same screen would
+ * ship a different picture on macOS, Windows and Android; they cannot take a
+ * token colour, so they cannot satisfy the brand-asset exception's "read
+ * colours from tokens" condition; and they do not adapt to theme. design.md
+ * 3.9 is also explicit that emoji are never UI. The rupee glyph here is drawn
+ * as canvas text in white on the note, so it themes with everything else.
  *
- * Reduced motion renders one calm static frame: the same composition, fully
- * drawn, with nothing travelling. Same contract as SetupNeuralNet and
- * JvSpinner.
+ * COLOUR. --money-note / --money-note-bd (see main.css), deliberately off the
+ * semantic success ramp: --green means success, and this screen renders while
+ * the payment is NOT yet confirmed. The status is carried by the copy, never by
+ * the colour.
+ *
+ * Reduced motion renders one calm static frame: the notes at rest along the
+ * rail, and no halo. Same contract as SetupNeuralNet and JvSpinner.
  */
 import { ref, onMounted, onBeforeUnmount, watch } from "vue";
 import { BRAND_STAR_PATH } from "@/lib/brand";
@@ -64,24 +63,31 @@ const canvasEl = ref(null);
 
 const STAR = new Path2D(BRAND_STAR_PATH);
 
-/** How many pieces are in flight at once. Small on purpose: this is a calm
- *  confirmation, not a payout animation. */
-const FLIGHT_COUNT = 9;
-/** Seconds a piece takes to travel from the rim to the core, before jitter. */
-const TRAVEL_SECONDS = 3.4;
+/** Note geometry, in CSS px. */
+const NOTE_W = 22;
+const NOTE_H = 13;
+const NOTE_R = 3;
+/** Tilted so a note reads as in-motion even in the static reduced-motion frame. */
+const NOTE_TILT = (-7 * Math.PI) / 180;
+
+/** One note's full journey, and the gap between consecutive departures. Four
+ *  notes at 0.6s spacing over a 2.8s loop keeps roughly three visible at once,
+ *  evenly spread: a steady arrival, not a burst. */
+const LOOP_SECONDS = 2.8;
+const STAGGER_SECONDS = 0.6;
+const NOTE_COUNT = 4;
 
 let ctx = null;
 let W = 0,
 	H = 0,
 	dpr = 1;
 let core = { x: 0, y: 0 };
-let ringRx = 0,
-	ringRy = 0;
+let railHalf = 0;
 let reduced = false;
 let mq = null;
 const C = {};
 
-let pieces = [];
+let notes = [];
 let coreFlash = 0,
 	t0 = null,
 	raf = 0;
@@ -91,11 +97,11 @@ function readColors() {
 	if (!el) return;
 	const cs = getComputedStyle(el);
 	// Tokens, never literals - the brand-asset exception requires it.
-	C.coin = cs.getPropertyValue("--money-coin").trim() || "#c9922b";
-	C.note = cs.getPropertyValue("--money-note").trim() || "#5a9e73";
+	C.note = cs.getPropertyValue("--money-note").trim() || "#1f8a54";
+	C.noteBd = cs.getPropertyValue("--money-note-bd").trim() || "#34a76a";
 	C.brand1 = cs.getPropertyValue("--brand-1").trim() || "#6e8bff";
 	C.brand2 = cs.getPropertyValue("--brand-2").trim() || "#8b5cf6";
-	C.surface = cs.getPropertyValue("--surface").trim() || "#ffffff";
+	C.rail = cs.getPropertyValue("--border-2").trim() || "#dfdfe4";
 }
 
 /** Hex to rgba(). Kept local so the component never needs a colour library. */
@@ -105,7 +111,7 @@ function alpha(hex, a) {
 		.replace("#", "");
 	if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
 	const n = parseInt(h, 16);
-	if (h.length !== 6 || Number.isNaN(n)) return `rgba(201,146,43,${a})`;
+	if (h.length !== 6 || Number.isNaN(n)) return `rgba(31,138,84,${a})`;
 	return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
 }
 
@@ -114,23 +120,16 @@ function clamp(x) {
 }
 
 /**
- * A piece starts at a random point on the rim and travels to the core. `phase`
- * spreads the initial population across the journey so the first frame already
- * looks mid-flight instead of firing all seven from the edge at once.
+ * Notes alternate sides so value visibly converges ON the mark rather than
+ * streaming past it, which is what a single-direction rail looks like once the
+ * mark sits centred. Still one rail.
  */
-function makePiece(i, phase) {
-	const a = Math.random() * Math.PI * 2;
-	return {
-		a,
-		// Alternating with a bias to coins: gold leads, green is the accent.
-		kind: i % 3 === 1 ? "note" : "coin",
-		t: phase,
-		sp: 1 / (TRAVEL_SECONDS * (0.8 + Math.random() * 0.45)),
-		spin: (Math.random() - 0.5) * 1.6,
-		// A gentle tangential bow so pieces arc in rather than falling straight.
-		bow: (Math.random() - 0.5) * 0.5,
-		wob: Math.random() * Math.PI * 2,
-	};
+function buildNotes() {
+	notes = Array.from({ length: NOTE_COUNT }, (_, i) => ({
+		side: i % 2 === 0 ? -1 : 1,
+		// Seconds into the loop at which this note departs.
+		offset: i * STAGGER_SECONDS,
+	}));
 }
 
 function layout() {
@@ -145,66 +144,30 @@ function layout() {
 	cv.height = Math.round(H * dpr);
 	ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 	core = { x: W / 2, y: H / 2 };
-	ringRx = Math.min(W * 0.42, 300);
-	ringRy = Math.min(H * 0.44, 190);
+	railHalf = Math.min(W * 0.42, 320);
 	return true;
 }
 
-function reset() {
-	// Spread the starting population evenly along the path.
-	pieces = Array.from({ length: FLIGHT_COUNT }, (_, i) =>
-		makePiece(i, (i / FLIGHT_COUNT) * 0.92)
-	);
-	coreFlash = 0;
-	t0 = null;
+/** Journey fraction for note `n` at elapsed time `el`: 0 at the rail end, 1 at
+ *  the mark. In reduced motion the notes do not advance; they are parked at
+ *  their departure offsets instead (see draw). */
+function progress(n, el) {
+	const local = (el - n.offset) % LOOP_SECONDS;
+	return local < 0 ? (local + LOOP_SECONDS) / LOOP_SECONDS : local / LOOP_SECONDS;
 }
 
-/** Position of a piece at journey fraction t (0 rim, 1 core). */
-function pieceAt(p) {
-	// Ease-in: pieces accelerate slightly as they are drawn in.
-	const e = p.t * p.t * 0.45 + p.t * 0.55;
-	const rx = ringRx * (1 - e);
-	const ry = ringRy * (1 - e);
-	const bow = p.bow * (1 - e) * 1.1;
-	const wob = reduced ? 0 : Math.sin(p.wob + p.t * 5) * 3 * (1 - e);
-	return {
-		x: core.x + Math.cos(p.a + bow) * rx + wob,
-		y: core.y + Math.sin(p.a + bow) * ry,
-	};
-}
-
-function drawCoin(x, y, r, rot, a) {
+function drawNote(x, y, a) {
+	if (a <= 0.01) return;
 	ctx.save();
 	ctx.translate(x, y);
-	// Squash on rotation so it reads as a disc turning in space, not a ball.
-	ctx.scale(Math.max(0.32, Math.abs(Math.cos(rot))), 1);
+	ctx.rotate(NOTE_TILT);
 	ctx.globalAlpha = a;
-	ctx.beginPath();
-	ctx.arc(0, 0, r, 0, 6.283);
-	ctx.fillStyle = alpha(C.coin, 0.92);
-	ctx.fill();
-	ctx.lineWidth = Math.max(1, r * 0.16);
-	ctx.strokeStyle = alpha(C.coin, 1);
-	ctx.stroke();
-	// Inner rim: enough to read as a coin, not enough to become detail noise.
-	ctx.beginPath();
-	ctx.arc(0, 0, r * 0.54, 0, 6.283);
-	ctx.strokeStyle = alpha(C.surface, 0.55);
-	ctx.lineWidth = Math.max(0.8, r * 0.14);
-	ctx.stroke();
-	ctx.restore();
-}
 
-function drawNote(x, y, r, rot, a) {
-	const w = r * 2.5,
-		h = r * 1.45;
-	ctx.save();
-	ctx.translate(x, y);
-	ctx.rotate(rot * 0.5);
-	ctx.globalAlpha = a;
-	const rr = Math.min(3, h * 0.28);
+	const w = NOTE_W,
+		h = NOTE_H,
+		rr = NOTE_R;
 	ctx.beginPath();
-	// Rounded rect, drawn by hand: roundRect is not in every supported engine.
+	// Rounded rect by hand: roundRect is not in every engine this ships to.
 	ctx.moveTo(-w / 2 + rr, -h / 2);
 	ctx.lineTo(w / 2 - rr, -h / 2);
 	ctx.quadraticCurveTo(w / 2, -h / 2, w / 2, -h / 2 + rr);
@@ -215,14 +178,19 @@ function drawNote(x, y, r, rot, a) {
 	ctx.lineTo(-w / 2, -h / 2 + rr);
 	ctx.quadraticCurveTo(-w / 2, -h / 2, -w / 2 + rr, -h / 2);
 	ctx.closePath();
-	ctx.fillStyle = alpha(C.note, 0.9);
+	ctx.fillStyle = C.note;
 	ctx.fill();
-	// The band across the middle is what makes a green rectangle read as a note.
-	ctx.beginPath();
-	ctx.arc(0, 0, h * 0.26, 0, 6.283);
-	ctx.strokeStyle = alpha(C.surface, 0.6);
-	ctx.lineWidth = Math.max(0.8, h * 0.1);
+	ctx.lineWidth = 1;
+	ctx.strokeStyle = C.noteBd;
 	ctx.stroke();
+
+	// The rupee mark, drawn as text so it inherits nothing from the platform.
+	ctx.fillStyle = "#ffffff";
+	ctx.font = "700 8px Inter, system-ui, sans-serif";
+	ctx.textAlign = "center";
+	ctx.textBaseline = "middle";
+	ctx.fillText("₹", 0, 0.5);
+
 	ctx.restore();
 }
 
@@ -232,49 +200,56 @@ function draw(ts) {
 	const dt = 1 / 60;
 	ctx.clearRect(0, 0, W, H);
 
-	// --- pieces in flight ---
-	pieces.forEach((p, i) => {
-		if (!reduced) {
-			p.t += dt * p.sp;
-			if (p.t >= 1) {
-				coreFlash = 1;
-				pieces[i] = makePiece(i, 0);
-				return;
-			}
+	// --- the rail: one hairline through the mark, faded at both ends so it
+	//     reads as a track that emerges and dissolves rather than a cut line ---
+	const rg = ctx.createLinearGradient(core.x - railHalf, 0, core.x + railHalf, 0);
+	rg.addColorStop(0, alpha(C.rail, 0));
+	rg.addColorStop(0.28, alpha(C.rail, 0.9));
+	rg.addColorStop(0.72, alpha(C.rail, 0.9));
+	rg.addColorStop(1, alpha(C.rail, 0));
+	ctx.strokeStyle = rg;
+	ctx.lineWidth = 1;
+	ctx.beginPath();
+	ctx.moveTo(core.x - railHalf, core.y);
+	ctx.lineTo(core.x + railHalf, core.y);
+	ctx.stroke();
+
+	// --- notes ---
+	notes.forEach((n) => {
+		let t;
+		if (reduced) {
+			// Parked along the rail: a still frame of the same composition, never a
+			// blank stage. Spread across the middle of the journey rather than
+			// mapped straight from the departure offsets, because that put the
+			// first note at t=1 - exactly on the core, hidden behind the mark - so
+			// the static frame showed one note fewer than the animation.
+			t = 0.18 + (n.offset / LOOP_SECONDS) * 0.62;
+		} else {
+			t = progress(n, el);
+			// Arrival: pulse the mark exactly once as the note is absorbed.
+			if (n.last != null && t < n.last) coreFlash = 1;
+			n.last = t;
 		}
-		const pos = pieceAt(p);
-		// Fade in off the rim, fade out as it is absorbed by the core.
-		const fadeIn = clamp(p.t / 0.12);
-		const fadeOut = clamp((1 - p.t) / 0.18);
-		const a = fadeIn * fadeOut;
-		if (a <= 0.01) return;
-		// Shrink as it approaches, so absorption reads as depth not deletion.
-		const r = (8.6 - 2.9 * p.t) * (0.85 + (i % 3) * 0.1);
-		const rot = reduced ? 0.6 : el * p.spin + p.wob;
-		// A soft trail behind each piece: motion without a hard streak.
-		const gl = ctx.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, r * 2.6);
-		gl.addColorStop(0, alpha(p.kind === "coin" ? C.coin : C.note, 0.2 * a));
-		gl.addColorStop(1, alpha(p.kind === "coin" ? C.coin : C.note, 0));
-		ctx.fillStyle = gl;
-		ctx.beginPath();
-		ctx.arc(pos.x, pos.y, r * 2.6, 0, 6.283);
-		ctx.fill();
-		if (p.kind === "coin") drawCoin(pos.x, pos.y, r, rot, a);
-		else drawNote(pos.x, pos.y, r, rot, a);
+		const x = core.x + n.side * railHalf * (1 - t);
+		// Fade in early off the rail end, fade out as the mark takes it.
+		const a = clamp(t / 0.14) * clamp((1 - t) / 0.16);
+		drawNote(x, core.y, reduced ? 1 : a);
 	});
 
 	// --- core: the Jarvis mark, same construction as SetupNeuralNet so the two
 	//     illustrations are visibly the same family ---
-	if (coreFlash > 0) coreFlash = Math.max(0, coreFlash - dt * 2.2);
-	const breathe = reduced ? 0.5 : 0.5 + 0.5 * Math.sin(el * 1.6);
-	const haloR = 32 + breathe * 8 + coreFlash * 15;
-	const hg = ctx.createRadialGradient(core.x, core.y, 8, core.x, core.y, haloR);
-	hg.addColorStop(0, alpha(C.brand2, 0.26 + coreFlash * 0.32));
-	hg.addColorStop(1, alpha(C.brand2, 0));
-	ctx.fillStyle = hg;
-	ctx.beginPath();
-	ctx.arc(core.x, core.y, haloR, 0, 6.283);
-	ctx.fill();
+	if (!reduced) {
+		if (coreFlash > 0) coreFlash = Math.max(0, coreFlash - dt * 2.2);
+		const breathe = 0.5 + 0.5 * Math.sin(el * 1.6);
+		const haloR = 30 + breathe * 7 + coreFlash * 15;
+		const hg = ctx.createRadialGradient(core.x, core.y, 8, core.x, core.y, haloR);
+		hg.addColorStop(0, alpha(C.brand2, 0.24 + coreFlash * 0.32));
+		hg.addColorStop(1, alpha(C.brand2, 0));
+		ctx.fillStyle = hg;
+		ctx.beginPath();
+		ctx.arc(core.x, core.y, haloR, 0, 6.283);
+		ctx.fill();
+	}
 
 	const R = 22;
 	const dg = ctx.createLinearGradient(core.x - R, core.y - R, core.x + R, core.y + R);
@@ -301,9 +276,10 @@ function start() {
 	cancelAnimationFrame(raf);
 	readColors();
 	if (!layout()) return;
-	reset();
+	buildNotes();
+	coreFlash = 0;
+	t0 = null;
 	if (reduced) {
-		// One calm static frame: pieces sit spread along the path, nothing moves.
 		requestAnimationFrame((ts) => {
 			t0 = ts;
 			draw(ts);
@@ -363,12 +339,13 @@ onBeforeUnmount(() => {
 	if (mq) mq.removeEventListener("change", onReducedMotionChange);
 });
 
-// The theme flip changes --surface, which this reads for the coin rim and the
-// note band. Re-read so those stay legible on the dark card.
+// The theme flip changes the money and rail tokens this reads. Re-read them, and
+// redraw immediately when there is no animation loop to do it on the next frame.
 watch(
 	() => props.dark,
 	() => {
 		readColors();
+		if (started && reduced) start();
 	}
 );
 </script>

--- a/frontend/src/onboarding/PaymentConfirmingArt.vue
+++ b/frontend/src/onboarding/PaymentConfirmingArt.vue
@@ -52,7 +52,7 @@
  * rail, and no halo. Same contract as SetupNeuralNet and JvSpinner.
  */
 import { ref, onMounted, onBeforeUnmount, watch } from "vue";
-import { BRAND_STAR_PATH } from "@/lib/brand";
+import { BRAND_STAR_PATH, alphaHex } from "@/lib/brand";
 
 const props = defineProps({
 	dark: { type: Boolean, default: false },
@@ -102,17 +102,6 @@ function readColors() {
 	C.brand1 = cs.getPropertyValue("--brand-1").trim() || "#6e8bff";
 	C.brand2 = cs.getPropertyValue("--brand-2").trim() || "#8b5cf6";
 	C.rail = cs.getPropertyValue("--border-2").trim() || "#dfdfe4";
-}
-
-/** Hex to rgba(). Kept local so the component never needs a colour library. */
-function alpha(hex, a) {
-	let h = String(hex || "")
-		.trim()
-		.replace("#", "");
-	if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
-	const n = parseInt(h, 16);
-	if (h.length !== 6 || Number.isNaN(n)) return `rgba(31,138,84,${a})`;
-	return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
 }
 
 function clamp(x) {
@@ -203,10 +192,10 @@ function draw(ts) {
 	// --- the rail: one hairline through the mark, faded at both ends so it
 	//     reads as a track that emerges and dissolves rather than a cut line ---
 	const rg = ctx.createLinearGradient(core.x - railHalf, 0, core.x + railHalf, 0);
-	rg.addColorStop(0, alpha(C.rail, 0));
-	rg.addColorStop(0.28, alpha(C.rail, 0.9));
-	rg.addColorStop(0.72, alpha(C.rail, 0.9));
-	rg.addColorStop(1, alpha(C.rail, 0));
+	rg.addColorStop(0, alphaHex(C.rail, 0));
+	rg.addColorStop(0.28, alphaHex(C.rail, 0.9));
+	rg.addColorStop(0.72, alphaHex(C.rail, 0.9));
+	rg.addColorStop(1, alphaHex(C.rail, 0));
 	ctx.strokeStyle = rg;
 	ctx.lineWidth = 1;
 	ctx.beginPath();
@@ -243,8 +232,8 @@ function draw(ts) {
 		const breathe = 0.5 + 0.5 * Math.sin(el * 1.6);
 		const haloR = 30 + breathe * 7 + coreFlash * 15;
 		const hg = ctx.createRadialGradient(core.x, core.y, 8, core.x, core.y, haloR);
-		hg.addColorStop(0, alpha(C.brand2, 0.24 + coreFlash * 0.32));
-		hg.addColorStop(1, alpha(C.brand2, 0));
+		hg.addColorStop(0, alphaHex(C.brand2, 0.24 + coreFlash * 0.32));
+		hg.addColorStop(1, alphaHex(C.brand2, 0));
 		ctx.fillStyle = hg;
 		ctx.beginPath();
 		ctx.arc(core.x, core.y, haloR, 0, 6.283);

--- a/frontend/src/onboarding/PaymentConfirmingArt.vue
+++ b/frontend/src/onboarding/PaymentConfirmingArt.vue
@@ -1,0 +1,374 @@
+<template>
+	<!-- Root ref: readColors() reads the money/brand tokens and the jv-* palette
+		 via getComputedStyle on THIS element, not document.documentElement. The
+		 jv-* vars are inline-applied on an ancestor (.jv-ob-root's paletteVars in
+		 OnboardingView.vue), so they only resolve once inherited down to a node
+		 inside that scope - this component's root div.
+
+		 Both this div and the canvas fill via absolute + inset-0 (NOT h-full on
+		 the div): the parent uses min-height, and percentage heights don't
+		 resolve against min-height, so h-full collapses the canvas to 0px and
+		 nothing draws. Same trap as SetupNeuralNet. Do not change this. -->
+	<div ref="rootEl" class="absolute inset-0">
+		<canvas ref="canvasEl" class="absolute inset-0 block h-full w-full"></canvas>
+	</div>
+</template>
+
+<script setup>
+/**
+ * PaymentConfirmingArt - the payment-confirming illustration.
+ *
+ * Coins and banknotes drift inward and are absorbed into the Jarvis mark,
+ * which pulses as each one lands. It renders during the window where the
+ * customer has paid on the admin-hosted page and the bench is asking the
+ * control plane whether that payment actually landed.
+ *
+ * WHY THIS EXISTS ALONGSIDE SetupNeuralNet, rather than replacing it or being
+ * folded into it: the two illustrate different things and never appear at the
+ * same time. This one is value arriving (payment confirming). SetupNeuralNet
+ * is a workspace being assembled (provisioning). Sharing one asset across both
+ * would mean the same picture claims two different things, which is precisely
+ * the class of overstatement jarvis#708/#709 were about. design.md's
+ * brand-asset exception was amended to name both, with the one-illustration-
+ * per-screen rule written into it.
+ *
+ * DELIBERATELY NOT EMOJI. The request floated "money notes emoji". Emoji are
+ * rendered by the platform font, so the same screen ships a different picture
+ * on macOS, Windows and Android; they cannot take a token colour, so they
+ * cannot honour the brand-asset exception's "read colours from tokens" rule;
+ * they do not adapt to theme; and at the sizes used here they land as raster
+ * blobs beside a vector mark. design.md 3.9 is also explicit that emoji are
+ * never UI. These are drawn as vectors instead, which themes correctly, scales
+ * to any DPR, and reads as money at a glance.
+ *
+ * COLOUR. Coins are --money-coin, notes are --money-note (see main.css). Both
+ * are deliberately off the semantic ramps: --green means success and --amber
+ * means warning, and this screen renders while the payment is NOT yet
+ * confirmed. Gold leads and green is the minority tone, so the screen never
+ * reads as a green "paid" tick before it is true. The status is carried by the
+ * copy, never by the colour.
+ *
+ * Reduced motion renders one calm static frame: the same composition, fully
+ * drawn, with nothing travelling. Same contract as SetupNeuralNet and
+ * JvSpinner.
+ */
+import { ref, onMounted, onBeforeUnmount, watch } from "vue";
+import { BRAND_STAR_PATH } from "@/lib/brand";
+
+const props = defineProps({
+	dark: { type: Boolean, default: false },
+});
+
+const rootEl = ref(null);
+const canvasEl = ref(null);
+
+const STAR = new Path2D(BRAND_STAR_PATH);
+
+/** How many pieces are in flight at once. Small on purpose: this is a calm
+ *  confirmation, not a payout animation. */
+const FLIGHT_COUNT = 9;
+/** Seconds a piece takes to travel from the rim to the core, before jitter. */
+const TRAVEL_SECONDS = 3.4;
+
+let ctx = null;
+let W = 0,
+	H = 0,
+	dpr = 1;
+let core = { x: 0, y: 0 };
+let ringRx = 0,
+	ringRy = 0;
+let reduced = false;
+let mq = null;
+const C = {};
+
+let pieces = [];
+let coreFlash = 0,
+	t0 = null,
+	raf = 0;
+
+function readColors() {
+	const el = rootEl.value;
+	if (!el) return;
+	const cs = getComputedStyle(el);
+	// Tokens, never literals - the brand-asset exception requires it.
+	C.coin = cs.getPropertyValue("--money-coin").trim() || "#c9922b";
+	C.note = cs.getPropertyValue("--money-note").trim() || "#5a9e73";
+	C.brand1 = cs.getPropertyValue("--brand-1").trim() || "#6e8bff";
+	C.brand2 = cs.getPropertyValue("--brand-2").trim() || "#8b5cf6";
+	C.surface = cs.getPropertyValue("--surface").trim() || "#ffffff";
+}
+
+/** Hex to rgba(). Kept local so the component never needs a colour library. */
+function alpha(hex, a) {
+	let h = String(hex || "")
+		.trim()
+		.replace("#", "");
+	if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+	const n = parseInt(h, 16);
+	if (h.length !== 6 || Number.isNaN(n)) return `rgba(201,146,43,${a})`;
+	return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}
+
+function clamp(x) {
+	return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+/**
+ * A piece starts at a random point on the rim and travels to the core. `phase`
+ * spreads the initial population across the journey so the first frame already
+ * looks mid-flight instead of firing all seven from the edge at once.
+ */
+function makePiece(i, phase) {
+	const a = Math.random() * Math.PI * 2;
+	return {
+		a,
+		// Alternating with a bias to coins: gold leads, green is the accent.
+		kind: i % 3 === 1 ? "note" : "coin",
+		t: phase,
+		sp: 1 / (TRAVEL_SECONDS * (0.8 + Math.random() * 0.45)),
+		spin: (Math.random() - 0.5) * 1.6,
+		// A gentle tangential bow so pieces arc in rather than falling straight.
+		bow: (Math.random() - 0.5) * 0.5,
+		wob: Math.random() * Math.PI * 2,
+	};
+}
+
+function layout() {
+	const cv = canvasEl.value;
+	if (!cv) return false;
+	const r = cv.getBoundingClientRect();
+	W = r.width;
+	H = r.height;
+	if (W < 2 || H < 2) return false;
+	dpr = Math.min(2, window.devicePixelRatio || 1);
+	cv.width = Math.round(W * dpr);
+	cv.height = Math.round(H * dpr);
+	ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+	core = { x: W / 2, y: H / 2 };
+	ringRx = Math.min(W * 0.42, 300);
+	ringRy = Math.min(H * 0.44, 190);
+	return true;
+}
+
+function reset() {
+	// Spread the starting population evenly along the path.
+	pieces = Array.from({ length: FLIGHT_COUNT }, (_, i) =>
+		makePiece(i, (i / FLIGHT_COUNT) * 0.92)
+	);
+	coreFlash = 0;
+	t0 = null;
+}
+
+/** Position of a piece at journey fraction t (0 rim, 1 core). */
+function pieceAt(p) {
+	// Ease-in: pieces accelerate slightly as they are drawn in.
+	const e = p.t * p.t * 0.45 + p.t * 0.55;
+	const rx = ringRx * (1 - e);
+	const ry = ringRy * (1 - e);
+	const bow = p.bow * (1 - e) * 1.1;
+	const wob = reduced ? 0 : Math.sin(p.wob + p.t * 5) * 3 * (1 - e);
+	return {
+		x: core.x + Math.cos(p.a + bow) * rx + wob,
+		y: core.y + Math.sin(p.a + bow) * ry,
+	};
+}
+
+function drawCoin(x, y, r, rot, a) {
+	ctx.save();
+	ctx.translate(x, y);
+	// Squash on rotation so it reads as a disc turning in space, not a ball.
+	ctx.scale(Math.max(0.32, Math.abs(Math.cos(rot))), 1);
+	ctx.globalAlpha = a;
+	ctx.beginPath();
+	ctx.arc(0, 0, r, 0, 6.283);
+	ctx.fillStyle = alpha(C.coin, 0.92);
+	ctx.fill();
+	ctx.lineWidth = Math.max(1, r * 0.16);
+	ctx.strokeStyle = alpha(C.coin, 1);
+	ctx.stroke();
+	// Inner rim: enough to read as a coin, not enough to become detail noise.
+	ctx.beginPath();
+	ctx.arc(0, 0, r * 0.54, 0, 6.283);
+	ctx.strokeStyle = alpha(C.surface, 0.55);
+	ctx.lineWidth = Math.max(0.8, r * 0.14);
+	ctx.stroke();
+	ctx.restore();
+}
+
+function drawNote(x, y, r, rot, a) {
+	const w = r * 2.5,
+		h = r * 1.45;
+	ctx.save();
+	ctx.translate(x, y);
+	ctx.rotate(rot * 0.5);
+	ctx.globalAlpha = a;
+	const rr = Math.min(3, h * 0.28);
+	ctx.beginPath();
+	// Rounded rect, drawn by hand: roundRect is not in every supported engine.
+	ctx.moveTo(-w / 2 + rr, -h / 2);
+	ctx.lineTo(w / 2 - rr, -h / 2);
+	ctx.quadraticCurveTo(w / 2, -h / 2, w / 2, -h / 2 + rr);
+	ctx.lineTo(w / 2, h / 2 - rr);
+	ctx.quadraticCurveTo(w / 2, h / 2, w / 2 - rr, h / 2);
+	ctx.lineTo(-w / 2 + rr, h / 2);
+	ctx.quadraticCurveTo(-w / 2, h / 2, -w / 2, h / 2 - rr);
+	ctx.lineTo(-w / 2, -h / 2 + rr);
+	ctx.quadraticCurveTo(-w / 2, -h / 2, -w / 2 + rr, -h / 2);
+	ctx.closePath();
+	ctx.fillStyle = alpha(C.note, 0.9);
+	ctx.fill();
+	// The band across the middle is what makes a green rectangle read as a note.
+	ctx.beginPath();
+	ctx.arc(0, 0, h * 0.26, 0, 6.283);
+	ctx.strokeStyle = alpha(C.surface, 0.6);
+	ctx.lineWidth = Math.max(0.8, h * 0.1);
+	ctx.stroke();
+	ctx.restore();
+}
+
+function draw(ts) {
+	if (t0 == null) t0 = ts;
+	const el = (ts - t0) / 1000;
+	const dt = 1 / 60;
+	ctx.clearRect(0, 0, W, H);
+
+	// --- pieces in flight ---
+	pieces.forEach((p, i) => {
+		if (!reduced) {
+			p.t += dt * p.sp;
+			if (p.t >= 1) {
+				coreFlash = 1;
+				pieces[i] = makePiece(i, 0);
+				return;
+			}
+		}
+		const pos = pieceAt(p);
+		// Fade in off the rim, fade out as it is absorbed by the core.
+		const fadeIn = clamp(p.t / 0.12);
+		const fadeOut = clamp((1 - p.t) / 0.18);
+		const a = fadeIn * fadeOut;
+		if (a <= 0.01) return;
+		// Shrink as it approaches, so absorption reads as depth not deletion.
+		const r = (8.6 - 2.9 * p.t) * (0.85 + (i % 3) * 0.1);
+		const rot = reduced ? 0.6 : el * p.spin + p.wob;
+		// A soft trail behind each piece: motion without a hard streak.
+		const gl = ctx.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, r * 2.6);
+		gl.addColorStop(0, alpha(p.kind === "coin" ? C.coin : C.note, 0.2 * a));
+		gl.addColorStop(1, alpha(p.kind === "coin" ? C.coin : C.note, 0));
+		ctx.fillStyle = gl;
+		ctx.beginPath();
+		ctx.arc(pos.x, pos.y, r * 2.6, 0, 6.283);
+		ctx.fill();
+		if (p.kind === "coin") drawCoin(pos.x, pos.y, r, rot, a);
+		else drawNote(pos.x, pos.y, r, rot, a);
+	});
+
+	// --- core: the Jarvis mark, same construction as SetupNeuralNet so the two
+	//     illustrations are visibly the same family ---
+	if (coreFlash > 0) coreFlash = Math.max(0, coreFlash - dt * 2.2);
+	const breathe = reduced ? 0.5 : 0.5 + 0.5 * Math.sin(el * 1.6);
+	const haloR = 32 + breathe * 8 + coreFlash * 15;
+	const hg = ctx.createRadialGradient(core.x, core.y, 8, core.x, core.y, haloR);
+	hg.addColorStop(0, alpha(C.brand2, 0.26 + coreFlash * 0.32));
+	hg.addColorStop(1, alpha(C.brand2, 0));
+	ctx.fillStyle = hg;
+	ctx.beginPath();
+	ctx.arc(core.x, core.y, haloR, 0, 6.283);
+	ctx.fill();
+
+	const R = 22;
+	const dg = ctx.createLinearGradient(core.x - R, core.y - R, core.x + R, core.y + R);
+	dg.addColorStop(0, C.brand1);
+	dg.addColorStop(1, C.brand2);
+	ctx.fillStyle = dg;
+	ctx.beginPath();
+	ctx.arc(core.x, core.y, R, 0, 6.283);
+	ctx.fill();
+
+	ctx.save();
+	const s = (2 * R * 0.82) / 24;
+	ctx.translate(core.x - R * 0.82, core.y - R * 0.82);
+	ctx.scale(s, s);
+	ctx.fillStyle = "#fff";
+	ctx.fill(STAR);
+	ctx.restore();
+
+	raf = requestAnimationFrame(draw);
+}
+
+function start() {
+	if (!canvasEl.value) return;
+	cancelAnimationFrame(raf);
+	readColors();
+	if (!layout()) return;
+	reset();
+	if (reduced) {
+		// One calm static frame: pieces sit spread along the path, nothing moves.
+		requestAnimationFrame((ts) => {
+			t0 = ts;
+			draw(ts);
+			cancelAnimationFrame(raf);
+		});
+	} else {
+		raf = requestAnimationFrame(draw);
+	}
+}
+
+let ro = null;
+let started = false;
+
+// Mirrors SetupNeuralNet: this can mount inside a hidden container, where
+// getBoundingClientRect reads 0 and no window resize ever fires on reveal. A
+// ResizeObserver DOES fire on 0 -> visible, so (re)layout there. Reduced motion
+// has no loop, so it redraws its single frame on any real-size change.
+function measure() {
+	const el = rootEl.value;
+	if (!el) return;
+	const r = el.getBoundingClientRect();
+	if (r.width < 2 || r.height < 2) return;
+	if (!started || reduced) {
+		started = true;
+		start();
+	} else {
+		readColors();
+		layout();
+	}
+}
+
+function onReducedMotionChange(e) {
+	reduced = e.matches;
+	if (started) start();
+}
+
+onMounted(() => {
+	const cv = canvasEl.value;
+	if (!cv) return;
+	ctx = cv.getContext("2d");
+	mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+	reduced = mq.matches;
+	mq.addEventListener("change", onReducedMotionChange);
+	ro = new ResizeObserver(measure);
+	ro.observe(rootEl.value);
+	window.addEventListener("resize", measure);
+	measure();
+});
+
+onBeforeUnmount(() => {
+	cancelAnimationFrame(raf);
+	if (ro) {
+		ro.disconnect();
+		ro = null;
+	}
+	window.removeEventListener("resize", measure);
+	if (mq) mq.removeEventListener("change", onReducedMotionChange);
+});
+
+// The theme flip changes --surface, which this reads for the coin rim and the
+// note band. Re-read so those stay legible on the dark card.
+watch(
+	() => props.dark,
+	() => {
+		readColors();
+	}
+);
+</script>

--- a/frontend/src/onboarding/SetupNeuralNet.vue
+++ b/frontend/src/onboarding/SetupNeuralNet.vue
@@ -301,7 +301,7 @@ function start() {
 	reset();
 	if (reduced) {
 		// one static calm frame
-		requestAnimationFrame((ts) => {
+		raf = requestAnimationFrame((ts) => {
 			t0 = ts - 9999;
 			draw(ts);
 			cancelAnimationFrame(raf);

--- a/frontend/src/onboarding/SetupNeuralNet.vue
+++ b/frontend/src/onboarding/SetupNeuralNet.vue
@@ -16,7 +16,7 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount, watch } from "vue";
-import { BRAND_STAR_PATH } from "@/lib/brand";
+import { BRAND_STAR_PATH, alphaHex } from "@/lib/brand";
 
 const props = defineProps({
 	dark: { type: Boolean, default: false },
@@ -64,18 +64,6 @@ let pulses = [],
 	coreFlash = 0,
 	t0 = null,
 	raf = 0;
-
-/** Hex to rgba(), so the brand tokens can be used at partial opacity for the
- *  edges, node rings and halo without a second hard-coded copy of each colour. */
-function alpha(hex, a) {
-	let h = String(hex || "")
-		.trim()
-		.replace("#", "");
-	if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
-	const n = parseInt(h, 16);
-	if (h.length !== 6 || Number.isNaN(n)) return `rgba(110,139,255,${a})`;
-	return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
-}
 
 function readColors() {
 	const el = rootEl.value;
@@ -159,7 +147,7 @@ function draw(ts) {
 		const p = P[i],
 			ex = core.x + (p.x - core.x) * dp,
 			ey = core.y + (p.y - core.y) * dp;
-		ctx.strokeStyle = alpha(C.brand1, 0.16);
+		ctx.strokeStyle = alphaHex(C.brand1, 0.16);
 		ctx.beginPath();
 		ctx.moveTo(core.x, core.y);
 		ctx.lineTo(ex, ey);
@@ -167,7 +155,7 @@ function draw(ts) {
 	});
 	const ra = reduced ? 1 : clamp((el - 1.4) / 0.8);
 	if (ra > 0) {
-		ctx.strokeStyle = alpha(C.brand1, 0.1 * ra);
+		ctx.strokeStyle = alphaHex(C.brand1, 0.1 * ra);
 		for (let i = 0; i < nodes.length; i++) {
 			const a = P[i],
 				b = P[(i + 1) % nodes.length];
@@ -219,8 +207,8 @@ function draw(ts) {
 				continue;
 			}
 			const g = ctx.createRadialGradient(x, y, 0, x, y, 9);
-			g.addColorStop(0, alpha(C.brand2, 0.9));
-			g.addColorStop(1, alpha(C.brand2, 0));
+			g.addColorStop(0, alphaHex(C.brand2, 0.9));
+			g.addColorStop(1, alphaHex(C.brand2, 0));
 			ctx.fillStyle = g;
 			ctx.beginPath();
 			ctx.arc(x, y, 9, 0, 6.283);
@@ -246,11 +234,11 @@ function draw(ts) {
 		ctx.fillStyle = C.nodeFill;
 		ctx.fill();
 		ctx.lineWidth = 1.6;
-		ctx.strokeStyle = alpha(C.brand1, 0.55);
+		ctx.strokeStyle = alphaHex(C.brand1, 0.55);
 		ctx.stroke();
 		ctx.beginPath();
 		ctx.arc(p.x, p.y, 2.4, 0, 6.283);
-		ctx.fillStyle = alpha(C.brand1, 0.9);
+		ctx.fillStyle = alphaHex(C.brand1, 0.9);
 		ctx.fill();
 		// label radially outward
 		const lx = p.x + Math.cos(n.a) * 17,
@@ -268,8 +256,8 @@ function draw(ts) {
 	const breathe = reduced ? 0.5 : 0.5 + 0.5 * Math.sin(el * 1.6);
 	const haloR = 34 + breathe * 9 + coreFlash * 16;
 	const hg = ctx.createRadialGradient(core.x, core.y, 8, core.x, core.y, haloR);
-	hg.addColorStop(0, alpha(C.brand2, 0.28 + coreFlash * 0.35));
-	hg.addColorStop(1, alpha(C.brand2, 0));
+	hg.addColorStop(0, alphaHex(C.brand2, 0.28 + coreFlash * 0.35));
+	hg.addColorStop(1, alphaHex(C.brand2, 0));
 	ctx.fillStyle = hg;
 	ctx.beginPath();
 	ctx.arc(core.x, core.y, haloR, 0, 6.283);
@@ -363,8 +351,10 @@ onBeforeUnmount(() => {
 });
 
 // Theme toggle changes the CSS vars this component reads (label/node colors);
-// re-read them so labels stay legible. The edge/pulse/core colors are fixed
-// brand rgba values, unaffected by theme.
+// re-read them so labels stay legible. The edge/pulse/core colors now come from
+// the --brand-1/--brand-2 tokens rather than the rgba literals this file used to
+// carry; those tokens are theme-invariant by design, so re-reading them is a
+// no-op for those layers and only the label/node colours actually change.
 watch(
 	() => props.dark,
 	() => {

--- a/frontend/src/onboarding/SetupNeuralNet.vue
+++ b/frontend/src/onboarding/SetupNeuralNet.vue
@@ -65,6 +65,18 @@ let pulses = [],
 	t0 = null,
 	raf = 0;
 
+/** Hex to rgba(), so the brand tokens can be used at partial opacity for the
+ *  edges, node rings and halo without a second hard-coded copy of each colour. */
+function alpha(hex, a) {
+	let h = String(hex || "")
+		.trim()
+		.replace("#", "");
+	if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+	const n = parseInt(h, 16);
+	if (h.length !== 6 || Number.isNaN(n)) return `rgba(110,139,255,${a})`;
+	return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}
+
 function readColors() {
 	const el = rootEl.value;
 	if (!el) return;
@@ -72,6 +84,15 @@ function readColors() {
 	C.label = cs.getPropertyValue("--text-3").trim() || "#83838b";
 	C.nodeFill = cs.getPropertyValue("--surface").trim() || "#fff";
 	C.nodeStroke = cs.getPropertyValue("--surface-3").trim() || "#ececef";
+	// The brand pair comes from the tokens in main.css, never from literals
+	// here. design.md's brand-asset exception allows this illustration to keep
+	// the brand gradient only "provided they honor prefers-reduced-motion and
+	// read their colors from tokens, not hard-coded rgba" - and until now this
+	// file carried its own copies of #6e8bff/#8b5cf6 plus a spread of
+	// rgba(110,139,255,...) literals, so a brand refresh would have landed
+	// everywhere except the one screen that is nothing but brand.
+	C.brand1 = cs.getPropertyValue("--brand-1").trim() || "#6e8bff";
+	C.brand2 = cs.getPropertyValue("--brand-2").trim() || "#8b5cf6";
 }
 
 function layout() {
@@ -138,7 +159,7 @@ function draw(ts) {
 		const p = P[i],
 			ex = core.x + (p.x - core.x) * dp,
 			ey = core.y + (p.y - core.y) * dp;
-		ctx.strokeStyle = "rgba(110,139,255,0.16)";
+		ctx.strokeStyle = alpha(C.brand1, 0.16);
 		ctx.beginPath();
 		ctx.moveTo(core.x, core.y);
 		ctx.lineTo(ex, ey);
@@ -146,7 +167,7 @@ function draw(ts) {
 	});
 	const ra = reduced ? 1 : clamp((el - 1.4) / 0.8);
 	if (ra > 0) {
-		ctx.strokeStyle = "rgba(110,139,255," + 0.1 * ra + ")";
+		ctx.strokeStyle = alpha(C.brand1, 0.1 * ra);
 		for (let i = 0; i < nodes.length; i++) {
 			const a = P[i],
 				b = P[(i + 1) % nodes.length];
@@ -198,8 +219,8 @@ function draw(ts) {
 				continue;
 			}
 			const g = ctx.createRadialGradient(x, y, 0, x, y, 9);
-			g.addColorStop(0, "rgba(139,92,246,0.9)");
-			g.addColorStop(1, "rgba(139,92,246,0)");
+			g.addColorStop(0, alpha(C.brand2, 0.9));
+			g.addColorStop(1, alpha(C.brand2, 0));
 			ctx.fillStyle = g;
 			ctx.beginPath();
 			ctx.arc(x, y, 9, 0, 6.283);
@@ -225,11 +246,11 @@ function draw(ts) {
 		ctx.fillStyle = C.nodeFill;
 		ctx.fill();
 		ctx.lineWidth = 1.6;
-		ctx.strokeStyle = "rgba(110,139,255,0.55)";
+		ctx.strokeStyle = alpha(C.brand1, 0.55);
 		ctx.stroke();
 		ctx.beginPath();
 		ctx.arc(p.x, p.y, 2.4, 0, 6.283);
-		ctx.fillStyle = "rgba(110,139,255,0.9)";
+		ctx.fillStyle = alpha(C.brand1, 0.9);
 		ctx.fill();
 		// label radially outward
 		const lx = p.x + Math.cos(n.a) * 17,
@@ -247,16 +268,16 @@ function draw(ts) {
 	const breathe = reduced ? 0.5 : 0.5 + 0.5 * Math.sin(el * 1.6);
 	const haloR = 34 + breathe * 9 + coreFlash * 16;
 	const hg = ctx.createRadialGradient(core.x, core.y, 8, core.x, core.y, haloR);
-	hg.addColorStop(0, "rgba(139,92,246," + (0.28 + coreFlash * 0.35) + ")");
-	hg.addColorStop(1, "rgba(139,92,246,0)");
+	hg.addColorStop(0, alpha(C.brand2, 0.28 + coreFlash * 0.35));
+	hg.addColorStop(1, alpha(C.brand2, 0));
 	ctx.fillStyle = hg;
 	ctx.beginPath();
 	ctx.arc(core.x, core.y, haloR, 0, 6.283);
 	ctx.fill();
 	const R = 22;
 	const dg = ctx.createLinearGradient(core.x - R, core.y - R, core.x + R, core.y + R);
-	dg.addColorStop(0, "#6e8bff");
-	dg.addColorStop(1, "#8b5cf6");
+	dg.addColorStop(0, C.brand1);
+	dg.addColorStop(1, C.brand2);
 	ctx.fillStyle = dg;
 	ctx.beginPath();
 	ctx.arc(core.x, core.y, R, 0, 6.283);

--- a/frontend/src/onboarding/readinessWait.js
+++ b/frontend/src/onboarding/readinessWait.js
@@ -36,7 +36,13 @@ export function readinessWaitExhaustedMessage({ sawVerdict = false, detail = "" 
 	}
 	const trimmed = (detail || "").trim();
 	if (trimmed) {
-		return `Your workspace's last status: ${trimmed} We haven't been able to confirm that's finished, and we can't promise it's still progressing on its own. You're welcome to keep waiting and retry, or get a person to look into it.`;
+		// admin's details are phrases, not sentences ("applying your LLM
+		// configuration"), so interpolating one raw ran it straight into the next
+		// sentence: "...last status: applying your LLM configuration We haven't
+		// been able to confirm...". Close it when it does not close itself. This
+		// is punctuation only - the detail is still quoted, never reworded.
+		const closed = /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+		return `Your workspace's last status: ${closed} We haven't been able to confirm that's finished, and we can't promise it's still progressing on its own. You're welcome to keep waiting and retry, or get a person to look into it.`;
 	}
 	return "Your AI connection saved, but we haven't been able to confirm your workspace has finished coming online. We can't promise it's still progressing on its own. You're welcome to keep waiting and retry, or get a person to look into it.";
 }

--- a/frontend/src/onboarding/readinessWait.test.js
+++ b/frontend/src/onboarding/readinessWait.test.js
@@ -34,6 +34,22 @@ test("a whitespace-only detail is treated as no detail", () => {
 	assert.match(msg, /haven't been able to confirm/i);
 });
 
+test("an unpunctuated detail is closed so it does not run into the next sentence", () => {
+	const msg = readinessWaitExhaustedMessage({
+		sawVerdict: true,
+		detail: "applying your LLM configuration",
+	});
+	assert.match(msg, /applying your LLM configuration\. We haven't/);
+});
+
+test("a detail that already ends in punctuation is not double-punctuated", () => {
+	for (const d of ["it is applying.", "are you there?", "stop!"]) {
+		const msg = readinessWaitExhaustedMessage({ sawVerdict: true, detail: d });
+		assert.match(msg, new RegExp(`${d.slice(-1).replace(/[.?!]/, "\\$&")} We haven't`));
+		assert.doesNotMatch(msg, /[.!?]\. We haven't/);
+	}
+});
+
 test("never asserts anything is still finishing on its own, in any branch", () => {
 	const cases = [
 		{ sawVerdict: false, detail: "" },

--- a/frontend/src/onboarding/usePaymentFlow.js
+++ b/frontend/src/onboarding/usePaymentFlow.js
@@ -558,18 +558,36 @@ export function createPaymentFlow(deps) {
 	}
 
 	// ---- provisioning: the old proceedAfterPay loop, fenced ----------------
-	async function waitForProvisioning() {
+	/**
+	 * @param {{onObservation?: (o: {answered: boolean, tenantStatus: string}) => void}} [opts]
+	 *   `onObservation` is called once per tick with what that tick actually saw,
+	 *   so the page can render the phase instead of one fixed sentence for the
+	 *   whole 90 seconds. Deliberately a callback rather than a machine event:
+	 *   these are observations, not transitions, and pushing them through apply()
+	 *   would either need new states or trip the strict reducer's
+	 *   illegal-transition telemetry. The poll's own control flow does not read
+	 *   it, so a throwing observer can never break the wait.
+	 */
+	async function waitForProvisioning(opts) {
 		if (provisioningInFlight) return { status: "already_running" };
 		provisioningInFlight = true;
 		try {
-			return await runProvisioningPoll();
+			return await runProvisioningPoll(opts);
 		} finally {
 			provisioningInFlight = false;
 		}
 	}
 
-	async function runProvisioningPoll() {
+	async function runProvisioningPoll({ onObservation } = {}) {
 		const my = token;
+		const observe = (answered, tenantStatus) => {
+			if (typeof onObservation !== "function") return;
+			try {
+				onObservation({ answered, tenantStatus: tenantStatus || "" });
+			} catch (e) {
+				// Rendering must never be able to break the provisioning wait.
+			}
+		};
 		// The transition into provisioning is legal only from paid - the readiness
 		// gate owns this surface, and `unknown -> provisioning` is the illegal move
 		// plan 02 names.
@@ -585,6 +603,7 @@ export function createPaymentFlow(deps) {
 				r = null;
 			}
 			if (my !== token) return { status: "superseded" };
+			observe(!!r, r && r.tenant_status);
 			if (r && (r.synced || r.tenant_status === "running")) {
 				return { status: "ready" };
 			}

--- a/frontend/src/onboarding/usePaymentFlow.spec.js
+++ b/frontend/src/onboarding/usePaymentFlow.spec.js
@@ -491,6 +491,77 @@ describe("the provisioning poll", () => {
 		await p1;
 	});
 
+	// The per-tick observation the page renders its phase from. Before this the
+	// poll swallowed tenant_status on every non-ready tick, so the screen had
+	// nothing to say for 90 seconds.
+	test("reports what each tick observed, including a tick that answered nothing", async () => {
+		const answers = [null, { synced: false, tenant_status: "pending" }, { synced: true }];
+		let i = 0;
+		const api = makeApi({
+			syncConnection: vi.fn(async () => {
+				const a = answers[i++];
+				if (a === null) throw new Error("network");
+				return a;
+			}),
+			getOnboardingState: vi.fn(async () =>
+				ENVELOPE({
+					code: CODES.PAYMENT_ALREADY_ACTIVE,
+					attempt_id: "att_1",
+					generation: 1,
+				})
+			),
+		});
+		const { flow } = makeFlow({ api, sleep: async () => {} });
+		await flow.hydrate();
+		const seen = [];
+		const out = await flow.waitForProvisioning({ onObservation: (o) => seen.push(o) });
+
+		expect(out).toEqual({ status: "ready" });
+		expect(seen).toEqual([
+			{ answered: false, tenantStatus: "" },
+			{ answered: true, tenantStatus: "pending" },
+			{ answered: true, tenantStatus: "" },
+		]);
+	});
+
+	// Rendering must never be able to break the wait.
+	test("an observer that throws does not stop the poll", async () => {
+		const api = makeApi({
+			syncConnection: vi.fn(async () => ({ synced: true })),
+			getOnboardingState: vi.fn(async () =>
+				ENVELOPE({
+					code: CODES.PAYMENT_ALREADY_ACTIVE,
+					attempt_id: "att_1",
+					generation: 1,
+				})
+			),
+		});
+		const { flow } = makeFlow({ api, sleep: async () => {} });
+		await flow.hydrate();
+		const out = await flow.waitForProvisioning({
+			onObservation: () => {
+				throw new Error("render blew up");
+			},
+		});
+		expect(out).toEqual({ status: "ready" });
+	});
+
+	test("no observer at all is still a valid call", async () => {
+		const api = makeApi({
+			syncConnection: vi.fn(async () => ({ synced: true })),
+			getOnboardingState: vi.fn(async () =>
+				ENVELOPE({
+					code: CODES.PAYMENT_ALREADY_ACTIVE,
+					attempt_id: "att_1",
+					generation: 1,
+				})
+			),
+		});
+		const { flow } = makeFlow({ api, sleep: async () => {} });
+		await flow.hydrate();
+		expect(await flow.waitForProvisioning()).toEqual({ status: "ready" });
+	});
+
 	test("stops when its attempt is superseded", async () => {
 		const api = makeApi({
 			syncConnection: vi.fn(async () => ({ synced: false })),

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -40,6 +40,35 @@ export const PHASE_STATE = {
 };
 
 /**
+ * The row to show while a wait is genuinely UNDER WAY but nothing has reported
+ * back yet - the very first poll is still in flight, or (on the Connect step)
+ * the apply operation is running and the readiness wait has not started.
+ *
+ * This exists because the alternative was worse in exactly the way this module
+ * is supposed to prevent. Seeding the "last observation" as `answered: false`
+ * made the row render "We couldn't reach your workspace to check" on the first
+ * frame - announcing a FAILED check before any check had been attempted. That
+ * is a false claim about the system's own state, just inverted from the ones
+ * jarvis#708/#709 were about, and it is a lie the old fixed-sentence screen
+ * never told.
+ *
+ * `observed` is false: nothing has reported. But the STATE is active, not
+ * unknown, because "we are asking right now" is itself true and directly
+ * known - unlike "we asked and got nothing", which is what UNKNOWN means.
+ *
+ * @param {string} label - what is actually being done, in the caller's words.
+ */
+export function inFlightPhase(label) {
+	return {
+		observed: false,
+		state: PHASE_STATE.ACTIVE,
+		label,
+		detail: "",
+		stop: false,
+	};
+}
+
+/**
  * Post-payment provisioning wait.
  *
  * @param {{answered?: boolean, tenantStatus?: string}} [last] - what the most
@@ -97,8 +126,10 @@ export function provisioningPhase({ answered = false, tenantStatus = "" } = {}) 
  *
  * @param {{answered?: boolean, reason?: string, detail?: string}} [last]
  * @returns {{observed: boolean, state: string, label: string, detail: string,
- *   blocked: boolean}} `blocked` marks the state where the customer must be
- *   given no retry affordance at all.
+ *   stop: boolean, paged?: boolean, title?: string}} `stop` means waiting cannot
+ *   resolve this, so the loop must end rather than run to a ceiling whose copy
+ *   invites a retry that cannot help. `paged` distinguishes "support has already
+ *   been notified, do nothing" from "nobody was notified, you must act".
  */
 export function readinessPhase({ answered = false, reason = "", detail = "" } = {}) {
 	const say = String(detail || "").trim();
@@ -108,7 +139,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			state: PHASE_STATE.UNKNOWN,
 			label: "We couldn't reach your workspace to check",
 			detail: "We'll keep trying.",
-			blocked: false,
+			stop: false,
 		};
 	}
 	switch (String(reason || "").trim()) {
@@ -119,7 +150,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				state: PHASE_STATE.ACTIVE,
 				label: "Applying your AI configuration",
 				detail: say,
-				blocked: false,
+				stop: false,
 			};
 		case "container_provisioning":
 			return {
@@ -127,7 +158,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				state: PHASE_STATE.ACTIVE,
 				label: "Your workspace is coming online",
 				detail: say,
-				blocked: false,
+				stop: false,
 			};
 		case "readiness_unconfirmed":
 			return {
@@ -135,7 +166,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				state: PHASE_STATE.UNKNOWN,
 				label: "Nothing has confirmed your workspace yet",
 				detail: "We'll keep checking.",
-				blocked: false,
+				stop: false,
 			};
 		case "authority_repair_required":
 			return {
@@ -145,7 +176,35 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				// Admin's own reassurance, quoted. Never paraphrased, and never
 				// accompanied by an action.
 				detail: say,
-				blocked: true,
+				stop: true,
+				paged: true,
+				title: "We're looking into your workspace",
+			};
+		// The two reasons that no amount of waiting can resolve. Both used to fall
+		// through to the default below and render as active progress, which is the
+		// same false claim this module exists to prevent - and jarvis/account.py is
+		// explicit about why the first one must stay distinct: "kept distinct so a
+		// suspended customer isn't told to wait for a container that won't come
+		// back". Neither is `paged`: nobody was notified, the customer has to act.
+		case "subscription_suspended":
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				label: "Your subscription is paused",
+				detail: say,
+				stop: true,
+				paged: false,
+				title: "Your subscription is paused",
+			};
+		case "site_replaced":
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				label: "Your account is connected to a different site",
+				detail: say,
+				stop: true,
+				paged: false,
+				title: "This site no longer has your workspace",
 			};
 		default:
 			// A reason this build does not know about gets the neutral line. It
@@ -155,7 +214,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				state: PHASE_STATE.ACTIVE,
 				label: "Waiting for your workspace to come online",
 				detail: say,
-				blocked: false,
+				stop: false,
 			};
 	}
 }

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -1,0 +1,182 @@
+/**
+ * Copy for the two long onboarding waits, derived ONLY from what the wait loop
+ * actually observed.
+ *
+ * Both waits already receive a real phase signal on every poll and throw it
+ * away:
+ *
+ *   - the provisioning poll (usePaymentFlow.runProvisioningPoll) gets
+ *     `tenant_status` back from jarvis.onboarding.sync_connection on every one
+ *     of its 45 ticks, and only ever tests it for "running";
+ *   - the readiness wait (OnboardingView.waitForChatReadiness) gets a `reason`
+ *     from jarvis.account.is_ready_for_chat on every one of its 40 polls, and
+ *     only ever keeps the `detail` for the exhaustion message.
+ *
+ * So both screens showed ONE fixed sentence for their whole two-minute wait and
+ * a customer could not tell a workspace being built from one that was stuck.
+ * This module turns those observations into staged copy.
+ *
+ * The rule this module exists to enforce, and the reason it is pure and
+ * separately tested: **a phase is only ever named because something reported
+ * it.** There is no elapsed-time branch anywhere here. If nothing answered, the
+ * caller gets `observed: false` and copy that says exactly that, never a phase.
+ * This is the same discipline readinessWait.js applies at the poll ceiling
+ * (jarvis#708/#709), extended to the middle of the wait rather than only its
+ * end.
+ *
+ * Pure so `node --test` runs it without a bundler.
+ */
+
+/**
+ * The three states a phase row can be in. `unknown` is deliberately distinct
+ * from `waiting`: "we asked and got nothing" is not the same as "not started",
+ * and rendering the first as the second would imply progress.
+ */
+export const PHASE_STATE = {
+	DONE: "done",
+	ACTIVE: "active",
+	UNKNOWN: "unknown",
+	WAITING: "waiting",
+};
+
+/**
+ * Post-payment provisioning wait.
+ *
+ * @param {{answered?: boolean, tenantStatus?: string}} [last] - what the most
+ *   recent poll returned. `answered` is true iff sync_connection returned a
+ *   real payload (it resolves to null on throw or deadline). `tenantStatus` is
+ *   admin's own value, e.g. "pending".
+ * @returns {{observed: boolean, state: string, label: string, detail: string}}
+ */
+export function provisioningPhase({ answered = false, tenantStatus = "" } = {}) {
+	if (!answered) {
+		// A poll that threw or timed out is not a verdict. Say only that, and
+		// restate the one thing that IS settled, because a customer who has just
+		// been charged is asking about their money, not about a container.
+		return {
+			observed: false,
+			state: PHASE_STATE.UNKNOWN,
+			label: "We couldn't reach your workspace to check",
+			detail: "Your payment is complete and nothing more is owed. We'll keep trying.",
+		};
+	}
+	const status = String(tenantStatus || "")
+		.trim()
+		.toLowerCase();
+	if (status === "running") {
+		return {
+			observed: true,
+			state: PHASE_STATE.DONE,
+			label: "Your workspace is ready",
+			detail: "",
+		};
+	}
+	// Admin answered and did not say running. "pending" is the value the bench
+	// defaults to and the only other one it is known to send, but any answered
+	// non-running status means the same thing for the customer: admin has this
+	// and it is not finished. An unrecognised value must not invent a phase of
+	// its own, so it shares this one.
+	return {
+		observed: true,
+		state: PHASE_STATE.ACTIVE,
+		label: "Jarvis is getting ready for you",
+		detail: "Your workspace is being prepared.",
+	};
+}
+
+/**
+ * Connect-step readiness wait. Keyed on is_ready_for_chat's `reason` enum
+ * (jarvis/account.py), which is a fixed server-side vocabulary.
+ *
+ * Two reasons must never render as a phase in progress:
+ *   - `readiness_unconfirmed` is BY DEFINITION the absence of a verdict.
+ *   - `authority_repair_required` means admin found the serving container
+ *     ambiguous and paged a human. readiness.js is explicit that the only safe
+ *     thing this surface can do is show admin's own reassurance, never an
+ *     action, because retrying payment or reconnecting could make it worse.
+ *
+ * @param {{answered?: boolean, reason?: string, detail?: string}} [last]
+ * @returns {{observed: boolean, state: string, label: string, detail: string,
+ *   blocked: boolean}} `blocked` marks the state where the customer must be
+ *   given no retry affordance at all.
+ */
+export function readinessPhase({ answered = false, reason = "", detail = "" } = {}) {
+	const say = String(detail || "").trim();
+	if (!answered) {
+		return {
+			observed: false,
+			state: PHASE_STATE.UNKNOWN,
+			label: "We couldn't reach your workspace to check",
+			detail: "We'll keep trying.",
+			blocked: false,
+		};
+	}
+	switch (String(reason || "").trim()) {
+		case "llm_pool_provisioning":
+		case "llm_provisioning":
+			return {
+				observed: true,
+				state: PHASE_STATE.ACTIVE,
+				label: "Applying your AI configuration",
+				detail: say,
+				blocked: false,
+			};
+		case "container_provisioning":
+			return {
+				observed: true,
+				state: PHASE_STATE.ACTIVE,
+				label: "Your workspace is coming online",
+				detail: say,
+				blocked: false,
+			};
+		case "readiness_unconfirmed":
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				label: "Nothing has confirmed your workspace yet",
+				detail: "We'll keep checking.",
+				blocked: false,
+			};
+		case "authority_repair_required":
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				label: "This needs a person to check it",
+				// Admin's own reassurance, quoted. Never paraphrased, and never
+				// accompanied by an action.
+				detail: say,
+				blocked: true,
+			};
+		default:
+			// A reason this build does not know about gets the neutral line. It
+			// must not be given a phase name invented here.
+			return {
+				observed: true,
+				state: PHASE_STATE.ACTIVE,
+				label: "Waiting for your workspace to come online",
+				detail: say,
+				blocked: false,
+			};
+	}
+}
+
+/**
+ * Headline for a wait that ended without a Ready verdict.
+ *
+ * Split out because the Connect step used to render every one of these under
+ * "Still finishing setup" - which asserts the workspace IS still finishing,
+ * the exact claim readinessWaitExhaustedMessage was written to stop making in
+ * the body copy directly underneath it (jarvis#709). A headline is not exempt
+ * from that just because it is short.
+ *
+ * @param {string} phase - the connect phase this headline sits above.
+ * @param {{fromReadinessCeiling?: boolean}} [opts]
+ */
+export function connectHeadline(phase, { fromReadinessCeiling = false } = {}) {
+	if (phase === "superseded") return "Your workspace changed";
+	if (phase === "support") return "We couldn't finish setting up your AI";
+	if (fromReadinessCeiling) return "We couldn't confirm your setup";
+	// An operation-level retry: something actually failed and said so, which is
+	// a different (and honestly reportable) thing from never getting an answer.
+	return "Setup hit a snag";
+}

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PHASE_STATE, provisioningPhase, readinessPhase, connectHeadline } from "./waitPhases.js";
+
+// ---- provisioning wait ---------------------------------------------------
+
+test("provisioning: an unanswered poll never claims a phase", () => {
+	const p = provisioningPhase({ answered: false });
+	assert.equal(p.observed, false);
+	assert.equal(p.state, PHASE_STATE.UNKNOWN);
+	assert.match(p.label, /couldn't reach your workspace/i);
+	assert.doesNotMatch(p.label, /getting ready/i);
+});
+
+test("provisioning: an unanswered poll still restates the settled payment fact", () => {
+	const p = provisioningPhase({ answered: false });
+	assert.match(p.detail, /payment is complete/i);
+});
+
+test("provisioning: 'Jarvis is getting ready' requires admin to have answered", () => {
+	const answered = provisioningPhase({ answered: true, tenantStatus: "pending" });
+	assert.equal(answered.observed, true);
+	assert.equal(answered.state, PHASE_STATE.ACTIVE);
+	assert.match(answered.label, /getting ready for you/i);
+
+	// The same line must be unreachable without an answer.
+	const silent = provisioningPhase({ answered: false, tenantStatus: "pending" });
+	assert.doesNotMatch(silent.label, /getting ready for you/i);
+});
+
+test("provisioning: running is a completed phase", () => {
+	const p = provisioningPhase({ answered: true, tenantStatus: "running" });
+	assert.equal(p.state, PHASE_STATE.DONE);
+});
+
+test("provisioning: status matching is case and whitespace tolerant", () => {
+	assert.equal(
+		provisioningPhase({ answered: true, tenantStatus: "  RUNNING " }).state,
+		PHASE_STATE.DONE
+	);
+});
+
+test("provisioning: an unrecognised answered status shares the prepared phase, invents nothing", () => {
+	const p = provisioningPhase({ answered: true, tenantStatus: "allocating" });
+	assert.equal(p.state, PHASE_STATE.ACTIVE);
+	assert.doesNotMatch(p.label, /allocating/i);
+});
+
+test("provisioning: an answered poll with no status at all is still not 'running'", () => {
+	const p = provisioningPhase({ answered: true, tenantStatus: "" });
+	assert.equal(p.state, PHASE_STATE.ACTIVE);
+});
+
+// ---- readiness wait ------------------------------------------------------
+
+test("readiness: an unanswered poll never claims a phase", () => {
+	const p = readinessPhase({ answered: false });
+	assert.equal(p.observed, false);
+	assert.equal(p.state, PHASE_STATE.UNKNOWN);
+	assert.equal(p.blocked, false);
+});
+
+test("readiness: pool and direct provisioning both name the apply phase", () => {
+	for (const reason of ["llm_pool_provisioning", "llm_provisioning"]) {
+		const p = readinessPhase({ answered: true, reason });
+		assert.equal(p.state, PHASE_STATE.ACTIVE);
+		assert.match(p.label, /applying your AI configuration/i);
+	}
+});
+
+test("readiness: container_provisioning names the container phase and quotes the detail", () => {
+	const p = readinessPhase({
+		answered: true,
+		reason: "container_provisioning",
+		detail: "applying your LLM configuration",
+	});
+	assert.equal(p.state, PHASE_STATE.ACTIVE);
+	assert.match(p.label, /coming online/i);
+	assert.equal(p.detail, "applying your LLM configuration");
+});
+
+test("readiness: readiness_unconfirmed is the absence of a verdict, never an active phase", () => {
+	const p = readinessPhase({ answered: true, reason: "readiness_unconfirmed" });
+	assert.equal(p.state, PHASE_STATE.UNKNOWN);
+	assert.notEqual(p.state, PHASE_STATE.ACTIVE);
+	assert.doesNotMatch(p.label, /coming online|applying/i);
+});
+
+test("readiness: authority_repair_required is blocked and quotes admin verbatim", () => {
+	const detail = "Your payment is safe. Please don't pay again while we sort this out.";
+	const p = readinessPhase({ answered: true, reason: "authority_repair_required", detail });
+	assert.equal(p.blocked, true);
+	assert.equal(p.detail, detail);
+	assert.notEqual(p.state, PHASE_STATE.ACTIVE);
+});
+
+test("readiness: only authority_repair_required is ever blocked", () => {
+	const reasons = [
+		"llm_pool_provisioning",
+		"llm_provisioning",
+		"container_provisioning",
+		"readiness_unconfirmed",
+		"something_new",
+		"",
+	];
+	for (const reason of reasons) {
+		assert.equal(readinessPhase({ answered: true, reason }).blocked, false, reason);
+	}
+	assert.equal(readinessPhase({ answered: false }).blocked, false);
+});
+
+test("readiness: an unknown reason falls back and never echoes itself as a phase name", () => {
+	const p = readinessPhase({ answered: true, reason: "brand_new_reason" });
+	assert.equal(p.state, PHASE_STATE.ACTIVE);
+	assert.doesNotMatch(p.label, /brand_new_reason/);
+});
+
+test("readiness: no branch ever claims setup is finishing on its own", () => {
+	const reasons = [
+		"llm_pool_provisioning",
+		"container_provisioning",
+		"readiness_unconfirmed",
+		"authority_repair_required",
+		"unmapped",
+	];
+	for (const reason of reasons) {
+		for (const answered of [true, false]) {
+			const p = readinessPhase({ answered, reason });
+			assert.doesNotMatch(p.label + " " + p.detail, /finishing on its own/i);
+		}
+	}
+});
+
+// ---- headline ------------------------------------------------------------
+
+test("headline: the readiness ceiling never says setup is still finishing", () => {
+	const h = connectHeadline("retry", { fromReadinessCeiling: true });
+	assert.match(h, /couldn't confirm/i);
+	assert.doesNotMatch(h, /still finishing/i);
+});
+
+test("headline: an operation failure reads as a failure, not as an unknown", () => {
+	assert.match(connectHeadline("retry", { fromReadinessCeiling: false }), /snag/i);
+});
+
+test("headline: superseded and support keep their own meanings", () => {
+	assert.match(connectHeadline("superseded"), /workspace changed/i);
+	assert.match(connectHeadline("support"), /couldn't finish/i);
+});
+
+test("headline: no branch renders the phrase jarvis#709 removed", () => {
+	const cases = [
+		["retry", { fromReadinessCeiling: true }],
+		["retry", { fromReadinessCeiling: false }],
+		["superseded", {}],
+		["support", {}],
+		["", {}],
+	];
+	for (const [phase, opts] of cases) {
+		assert.doesNotMatch(connectHeadline(phase, opts), /still finishing setup/i);
+	}
+});

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { PHASE_STATE, provisioningPhase, readinessPhase, connectHeadline } from "./waitPhases.js";
+import {
+	PHASE_STATE,
+	provisioningPhase,
+	readinessPhase,
+	inFlightPhase,
+	connectHeadline,
+} from "./waitPhases.js";
 
 // ---- provisioning wait ---------------------------------------------------
 
@@ -58,7 +64,7 @@ test("readiness: an unanswered poll never claims a phase", () => {
 	const p = readinessPhase({ answered: false });
 	assert.equal(p.observed, false);
 	assert.equal(p.state, PHASE_STATE.UNKNOWN);
-	assert.equal(p.blocked, false);
+	assert.equal(p.stop, false);
 });
 
 test("readiness: pool and direct provisioning both name the apply phase", () => {
@@ -87,15 +93,61 @@ test("readiness: readiness_unconfirmed is the absence of a verdict, never an act
 	assert.doesNotMatch(p.label, /coming online|applying/i);
 });
 
-test("readiness: authority_repair_required is blocked and quotes admin verbatim", () => {
+test("readiness: authority_repair_required stops the wait, is paged, quotes admin verbatim", () => {
 	const detail = "Your payment is safe. Please don't pay again while we sort this out.";
 	const p = readinessPhase({ answered: true, reason: "authority_repair_required", detail });
-	assert.equal(p.blocked, true);
+	assert.equal(p.stop, true);
+	assert.equal(p.paged, true);
 	assert.equal(p.detail, detail);
 	assert.notEqual(p.state, PHASE_STATE.ACTIVE);
 });
 
-test("readiness: only authority_repair_required is ever blocked", () => {
+// jarvis/account.py keeps subscription_suspended distinct from
+// container_provisioning precisely "so a suspended customer isn't told to wait
+// for a container that won't come back". site_replaced can never be resolved by
+// waiting either - the account lives on another site now. Both used to fall
+// through to the default and render as active progress.
+test("readiness: reasons that waiting cannot fix never render as progress", () => {
+	for (const reason of ["subscription_suspended", "site_replaced"]) {
+		const p = readinessPhase({ answered: true, reason, detail: "why" });
+		assert.equal(p.stop, true, reason);
+		assert.notEqual(p.state, PHASE_STATE.ACTIVE, reason);
+		assert.doesNotMatch(p.label, /coming online|keep (waiting|checking)/i, reason);
+		// Nobody was paged for these: the CUSTOMER has to act.
+		assert.equal(p.paged, false, reason);
+		assert.ok(p.title, reason);
+	}
+});
+
+test("readiness: only a paged repair claims support was already notified", () => {
+	assert.equal(
+		readinessPhase({ answered: true, reason: "authority_repair_required" }).paged,
+		true
+	);
+	for (const reason of [
+		"subscription_suspended",
+		"site_replaced",
+		"container_provisioning",
+		"readiness_unconfirmed",
+		"unmapped",
+	]) {
+		assert.notEqual(readinessPhase({ answered: true, reason }).paged, true, reason);
+	}
+});
+
+// The row shown while a wait is genuinely running but nothing has reported yet.
+// Seeding "last observation" as answered:false instead made the screen announce
+// a FAILED check before one had been attempted.
+test("inFlight: names the act of checking, and claims no observation", () => {
+	const p = inFlightPhase("Checking on your workspace");
+	assert.equal(p.observed, false);
+	assert.equal(p.state, PHASE_STATE.ACTIVE);
+	assert.equal(p.label, "Checking on your workspace");
+	assert.equal(p.stop, false);
+	assert.doesNotMatch(p.label, /couldn't reach|could not reach/i);
+});
+
+test("readiness: a resolvable wait never stops itself", () => {
 	const reasons = [
 		"llm_pool_provisioning",
 		"llm_provisioning",
@@ -105,9 +157,9 @@ test("readiness: only authority_repair_required is ever blocked", () => {
 		"",
 	];
 	for (const reason of reasons) {
-		assert.equal(readinessPhase({ answered: true, reason }).blocked, false, reason);
+		assert.equal(readinessPhase({ answered: true, reason }).stop, false, reason);
 	}
-	assert.equal(readinessPhase({ answered: false }).blocked, false);
+	assert.equal(readinessPhase({ answered: false }).stop, false);
 });
 
 test("readiness: an unknown reason falls back and never echoes itself as a phase name", () => {
@@ -122,6 +174,8 @@ test("readiness: no branch ever claims setup is finishing on its own", () => {
 		"container_provisioning",
 		"readiness_unconfirmed",
 		"authority_repair_required",
+		"subscription_suspended",
+		"site_replaced",
 		"unmapped",
 	];
 	for (const reason of reasons) {

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -68,6 +68,8 @@ vi.mock("@/lib/errorReporter", () => ({ report: vi.fn() }));
 
 // Heavy / canvas children the connect step would otherwise mount.
 vi.mock("@/onboarding/SetupNeuralNet.vue", () => ({ default: { template: "<div/>" } }));
+// Canvas illustration: jsdom has no 2d context, and neither spec is about the art.
+vi.mock("@/onboarding/PaymentConfirmingArt.vue", () => ({ default: { template: "<div/>" } }));
 vi.mock("@/onboarding/TourIntro.vue", () => ({ default: { template: "<div/>" } }));
 
 // The editor is stubbed: it exposes exactly the seam the host reads (save/canStart/
@@ -313,16 +315,42 @@ describe("§10.4 resume, resumable, terminal semantics", () => {
 	});
 
 	// The sibling of the case above: at least ONE live poll response came back
-	// (admin genuinely is converging it) before the connection dropped for good.
-	// That IS honestly "still finishing on its own", and must keep saying so.
-	it("keeps the 'still finishing' message when at least one poll confirmed real progress", async () => {
+	// (admin genuinely was converging it) before the deadline elapsed. That is a
+	// real observation and the copy still reports it - but it reports it as
+	// something SEEN, anchored to when it was seen, rather than as a promise that
+	// the job is still running now. jarvis#709 removed "it's still finishing on
+	// its own" from the readiness wait for asserting exactly that; this branch was
+	// the last place the phrase survived, and it made the same unverifiable claim
+	// from a past observation.
+	it("reports observed progress in the past tense, never as a self-healing promise", async () => {
 		const w = await mountConnect();
 
 		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
 
 		expect(routerReplace).not.toHaveBeenCalled();
 		expect(w.vm.state.connectPhase).toBe("retry");
-		expect(w.vm.state.connectMessage).toMatch(/still finishing on its own/i);
+		// It still distinguishes this case from the never-confirmed one above.
+		expect(w.vm.state.connectMessage).toMatch(/was still running when we last checked/i);
+		expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+		w.unmount();
+	});
+
+	// The phrase jarvis#709 deleted must not survive anywhere on this screen,
+	// headline included - a short heading asserting progress is the same claim as
+	// a sentence asserting it.
+	it("no connect terminal renders 'still finishing' in its message or its headline", async () => {
+		const w = await mountConnect();
+
+		const terminals = [
+			() => w.vm.onTerminal({ timedOut: true, neverConfirmed: true }),
+			() => w.vm.onTerminal({ timedOut: true, neverConfirmed: false }),
+		];
+		for (const drive of terminals) {
+			drive();
+			expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+			expect(w.vm.state.connectTitle).not.toMatch(/still finishing setup/i);
+			expect(w.vm.state.connectTitle).toBeTruthy();
+		}
 		w.unmount();
 	});
 
@@ -619,6 +647,108 @@ describe("jarvis#708 chat-readiness wait exhaustion: honest copy + a real exit",
 
 		expect(w.vm.state.connectPhase).toBe("support");
 		expect(w.vm.state.connectSupportOffered).toBe(false);
+		w.unmount();
+	});
+});
+
+describe("staged readiness phases: the screen renders what the poll observed", () => {
+	// Every one of these 40 polls used to be discarded except the last detail, so
+	// the wait showed one fixed sentence for two minutes.
+	it("an observed provisioning reason becomes the live phase line", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "container_provisioning",
+			detail: "applying your LLM configuration",
+		});
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.readinessStage.state).toBe("active");
+		expect(w.vm.readinessStage.label).toMatch(/coming online/i);
+		expect(w.vm.readinessStage.detail).toBe("applying your LLM configuration");
+		w.unmount();
+	});
+
+	it("readiness_unconfirmed renders as unknown, never as an active phase", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "readiness_unconfirmed" });
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.readinessStage.state).toBe("unknown");
+		expect(w.vm.readinessStage.label).not.toMatch(/coming online|applying/i);
+		w.unmount();
+	});
+
+	it("a poll that throws never claims a phase", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockRejectedValue(new Error("network"));
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.readinessStage.observed).toBe(false);
+		expect(w.vm.readinessStage.state).toBe("unknown");
+		w.unmount();
+	});
+
+	// admin paged a human. Retrying payment or reconnecting here could make it
+	// worse, so the wait must stop rather than run to a ceiling whose copy invites
+	// exactly that.
+	it("authority_repair_required stops the wait and blocks, quoting admin verbatim", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		const detail = "Your payment is safe. Please don't pay again while we sort this out.";
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "authority_repair_required",
+			detail,
+		});
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("blocked");
+		expect(w.vm.state.connectMessage).toBe(detail);
+
+		// Running out the rest of the ceiling must NOT convert it into a retry.
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+		expect(w.vm.state.connectPhase).toBe("blocked");
+		expect(routerReplace).not.toHaveBeenCalled();
+		w.unmount();
+	});
+
+	// jarvis#709's behaviour, unchanged: the ceiling still offers support beside
+	// Retry, and the message is still built from what the run observed.
+	it("the poll ceiling still offers support and still uses the observed-only message", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "signup" });
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+		expect(w.vm.state.connectMessage).not.toMatch(/still finishing on its own/i);
+		expect(w.vm.state.connectTitle).not.toMatch(/still finishing setup/i);
 		w.unmount();
 	});
 });

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -834,3 +834,69 @@ describe("the payment-confirming wait", () => {
 		w.unmount();
 	});
 });
+
+describe("the phase row never claims a check it has not made", () => {
+	// The regression: readinessSeen was seeded {answered:false}, and the phase row
+	// renders during the whole apply operation - a window strictly larger than the
+	// readiness wait. So the first frame after a successful save announced "We
+	// couldn't reach your workspace to check", a FAILED check, before one had been
+	// attempted. That is the same false-claim class jarvis#708/#709 were about,
+	// only inverted, and the old fixed-sentence screen never told that lie.
+	it("shows the apply phase, not a failed check, before any readiness poll runs", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying" });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("working");
+		expect(w.vm.readinessStage.label).not.toMatch(/couldn't reach|could not reach/i);
+		expect(w.vm.readinessStage.observed).toBe(false);
+		expect(w.vm.readinessStage.state).toBe("active");
+		w.unmount();
+	});
+
+	it("a poll that genuinely answered nothing still reports the failed check", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockRejectedValue(new Error("network"));
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.readinessStage.label).toMatch(/couldn't reach/i);
+		expect(w.vm.readinessStage.state).toBe("unknown");
+		w.unmount();
+	});
+});
+
+describe("every connect terminal carries its own headline", () => {
+	// enterSaveRefusal was the one writer of connectPhase="retry" that never set
+	// connectTitle, so a rate-limited save rendered the generic "We couldn't
+	// confirm your setup" over a rate-limit body - or worse, a STALE headline left
+	// behind by an earlier attempt, since nothing ever clears it.
+	it("a rate-limited save gets a headline that matches its body", async () => {
+		const w = await mountConnect();
+
+		w.vm.enterSaveRefusal(30);
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.state.connectMessage).toMatch(/too many changes/i);
+		expect(w.vm.state.connectTitle).toBeTruthy();
+		expect(w.vm.state.connectTitle).not.toMatch(/couldn't confirm your setup/i);
+		w.unmount();
+	});
+
+	it("a rate limit after an earlier terminal does not inherit the stale headline", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: true });
+		const stale = w.vm.state.connectTitle;
+		expect(stale).toBeTruthy();
+
+		w.vm.enterSaveRefusal(30);
+		expect(w.vm.state.connectTitle).not.toBe(stale);
+		w.unmount();
+	});
+});

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -752,3 +752,85 @@ describe("staged readiness phases: the screen renders what the poll observed", (
 		w.unmount();
 	});
 });
+
+// The payment-confirming screen. This is the moment right after the customer
+// pays: they are sent back to the SPA and the bench asks the control plane
+// whether the payment landed. Before this it rendered the marketing intro tour,
+// because state.step is still the default "intro" until the mount reconcile
+// resolves, and the correction for that ran only AFTER the awaits.
+describe("the payment-confirming wait", () => {
+	function returnFromPayPage() {
+		window.history.replaceState(null, "", "/jarvis/onboarding?pay=done");
+	}
+
+	it("shows the confirming screen, not the intro tour, while the mount reconcile runs", async () => {
+		returnFromPayPage();
+		let release;
+		api.onboardingPaymentApi.getOnboardingState.mockImplementation(
+			() => new Promise((r) => (release = r))
+		);
+
+		const w = mount(OnboardingView);
+		await flushPromises();
+
+		// Mid-reconcile: the round trip has not answered yet.
+		expect(w.vm.showConfirming).toBe(true);
+		expect(w.vm.state.step).toBe("pay");
+
+		release({
+			status: 200,
+			body: {
+				message: {
+					ok: true,
+					contract_version: 2,
+					data: { code: "BENCH_NO_SIGNUP_CONTEXT" },
+					context: {},
+				},
+			},
+		});
+		await flushPromises();
+
+		// Resolved: the confirming screen hands over rather than sticking.
+		expect(w.vm.showConfirming).toBe(false);
+		w.unmount();
+	});
+
+	it("is not shown on an ordinary mount that did not come back from checkout", async () => {
+		window.history.replaceState(null, "", "/jarvis/onboarding");
+		const w = mount(OnboardingView);
+		await flushPromises();
+		expect(w.vm.showConfirming).toBe(false);
+		w.unmount();
+	});
+
+	// The regression this was written against: showConfirming was originally
+	// derived from busy === "checking", which ONLY the explicit "Check payment
+	// status" button sets. The post-checkout reconcile never sets it, so the
+	// screen never appeared on the path it exists for.
+	it("does not depend on the status-check busy flag", async () => {
+		returnFromPayPage();
+		let release;
+		api.onboardingPaymentApi.getOnboardingState.mockImplementation(
+			() => new Promise((r) => (release = r))
+		);
+		const w = mount(OnboardingView);
+		await flushPromises();
+
+		expect(w.vm.pay.busy).not.toBe("checking");
+		expect(w.vm.showConfirming).toBe(true);
+
+		release({
+			status: 200,
+			body: {
+				message: {
+					ok: true,
+					contract_version: 2,
+					data: { code: "BENCH_NO_SIGNUP_CONTEXT" },
+					context: {},
+				},
+			},
+		});
+		await flushPromises();
+		w.unmount();
+	});
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -553,18 +553,20 @@
 													: "Payment confirmed"
 											}}
 										</h1>
+										<!-- The lead states only what the machine reaching PAID
+											 establishes. What is happening to the workspace is left to
+											 the phase list below, which reports observations rather
+											 than asserting preparation is under way. -->
 										<p v-if="!provisioningDelayed" role="status">
 											{{
 												paySummaryTrial
-													? "Auto-pay authorized — nothing charged until your trial ends."
+													? "Auto-pay authorized, and nothing is charged until your trial ends."
 													: "Payment received."
 											}}
-											We're preparing your {{ agentName }} workspace. This
-											usually takes under a minute…
 										</p>
 										<p v-else role="status">
-											Your workspace is taking a little longer than usual to
-											come online. Your payment is complete — nothing more is
+											Your workspace is taking longer than usual to come
+											online. Your payment is complete and nothing more is
 											owed.
 										</p>
 										<!-- admin's OWN sentence when it recorded the payment but the
@@ -586,15 +588,77 @@
 											{{ setupRecheckNote }}
 										</p>
 									</div>
-									<!-- Deliberately NOT aria-hidden: JvSpinner is its own status
-										 region and, while provisioning runs, the only thing on screen
-										 saying the workspace is still being built. -->
+									<!-- Phase list. Row 1 is a settled fact. Row 2 renders ONLY what
+										 the last provisioning tick observed (waitPhases.js), so
+										 "Jarvis is getting ready for you" appears when admin itself
+										 answered, and an honest "we couldn't check" appears when it
+										 did not. Row 3 names a phase that has not started and says
+										 nothing further about it. -->
+									<ul v-if="!provisioningDelayed" class="ob-phases" role="list">
+										<li class="ob-phase ob-phase--done">
+											<span class="ob-phase-ico">
+												<FeatherIcon name="check" class="h-4 w-4" />
+											</span>
+											<span class="ob-phase-txt">
+												<span class="ob-phase-label"
+													>Payment confirmed</span
+												>
+											</span>
+										</li>
+										<li
+											class="ob-phase"
+											:class="`ob-phase--${provisioningStage.state}`"
+											role="status"
+										>
+											<span class="ob-phase-ico">
+												<JvSpinner
+													v-if="provisioningStage.state === 'active'"
+													:size="20"
+												/>
+												<FeatherIcon
+													v-else
+													name="alert-circle"
+													class="h-4 w-4"
+												/>
+											</span>
+											<span class="ob-phase-txt">
+												<span class="ob-phase-label">{{
+													provisioningStage.label
+												}}</span>
+												<span
+													v-if="provisioningStage.detail"
+													class="ob-phase-detail"
+													>{{ provisioningStage.detail }}</span
+												>
+											</span>
+										</li>
+										<li class="ob-phase ob-phase--waiting">
+											<span class="ob-phase-ico"
+												><i class="ob-phase-dot"></i
+											></span>
+											<span class="ob-phase-txt">
+												<span class="ob-phase-label"
+													>Connecting your AI</span
+												>
+											</span>
+										</li>
+									</ul>
+									<!-- The sanctioned provisioning illustration (design.md §2.2).
+										 min-height, never a percentage height - see SetupNeuralNet's
+										 own comment. Dropped at the delayed ceiling, where there is a
+										 decision to make and motion would compete with it. -->
 									<div
 										v-if="!provisioningDelayed"
-										class="mt-2.5 flex justify-center"
+										class="relative mt-2 min-h-[320px] flex-1"
 									>
-										<JvSpinner :size="72" />
+										<SetupNeuralNet :dark="dark" />
 									</div>
+									<p
+										v-if="!provisioningDelayed"
+										class="mx-auto max-w-[420px] text-center text-p-sm text-ink-gray-5"
+									>
+										Most workspaces are ready within a minute.
+									</p>
 								</div>
 								<div v-if="provisioningDelayed" class="ob-foot justify-end">
 									<Button
@@ -637,6 +701,35 @@
 										label="I've verified my email"
 										@click="onPayAction(A.VERIFY)"
 									/>
+								</div>
+							</template>
+							<!-- Confirming: the customer paid on the admin-hosted page and came
+								 back, and we are asking the control plane whether it landed. Money
+								 has left them and no verdict exists yet, so this is the one screen
+								 the payment illustration belongs on (design.md §2.2). It replaces
+								 the recovery card's disabled "Checking…" button, which is what a
+								 customer used to stare at in the seconds right after paying. -->
+							<template v-else-if="showConfirming">
+								<div class="ob-body">
+									<div class="ob-head">
+										<h1 role="status">Confirming your payment</h1>
+										<p>
+											You've paid. We're checking with our payment provider
+											that it came through.
+										</p>
+									</div>
+									<!-- min-height (not h-full): the canvas fills via absolute +
+										 inset-0 and percentage heights don't resolve against a
+										 min-height parent. Same constraint as SetupNeuralNet. -->
+									<div class="relative mt-2 min-h-[300px] flex-1">
+										<PaymentConfirmingArt :dark="dark" />
+									</div>
+									<p
+										class="mx-auto max-w-[420px] text-center text-p-sm text-ink-gray-5"
+									>
+										This usually takes a few seconds. Please don't close this
+										page or pay again.
+									</p>
 								</div>
 							</template>
 							<!-- In flight: starting signup, checkout open, or confirming.
@@ -1159,12 +1252,103 @@
 												}}
 											</p>
 										</div>
+										<!-- Phase list, driven by is_ready_for_chat's `reason` on the
+											 LAST poll (waitPhases.js). Before this the screen showed one
+											 fixed sentence for the whole two-minute wait, so a workspace
+											 being built and one that was stuck looked identical. -->
+										<ul class="ob-phases" role="list">
+											<li class="ob-phase ob-phase--done">
+												<span class="ob-phase-ico">
+													<FeatherIcon name="check" class="h-4 w-4" />
+												</span>
+												<span class="ob-phase-txt">
+													<span class="ob-phase-label"
+														>AI connection saved</span
+													>
+												</span>
+											</li>
+											<li
+												class="ob-phase"
+												:class="`ob-phase--${readinessStage.state}`"
+												role="status"
+											>
+												<span class="ob-phase-ico">
+													<JvSpinner
+														v-if="readinessStage.state === 'active'"
+														:size="20"
+													/>
+													<FeatherIcon
+														v-else
+														name="alert-circle"
+														class="h-4 w-4"
+													/>
+												</span>
+												<span class="ob-phase-txt">
+													<span class="ob-phase-label">{{
+														readinessStage.label
+													}}</span>
+													<span
+														v-if="readinessStage.detail"
+														class="ob-phase-detail"
+														>{{ readinessStage.detail }}</span
+													>
+												</span>
+											</li>
+											<li class="ob-phase ob-phase--waiting">
+												<span class="ob-phase-ico"
+													><i class="ob-phase-dot"></i
+												></span>
+												<span class="ob-phase-txt">
+													<span class="ob-phase-label"
+														>Opening chat</span
+													>
+												</span>
+											</li>
+										</ul>
 										<!-- min-height (not h-full) is load-bearing: SetupNeuralNet's
 											 canvas fills via absolute+inset-0, and percentage heights
 											 don't resolve against a min-height parent - see its own
 											 comment. Don't change this to a fixed h-*. -->
-										<div class="relative mt-2 min-h-[380px] flex-1">
+										<div class="relative mt-2 min-h-[320px] flex-1">
 											<SetupNeuralNet :dark="dark" />
+										</div>
+									</template>
+									<!-- Admin found this workspace ambiguous and paged a human
+										 (authority_repair_required). readiness.js is explicit that the
+										 only safe thing this surface can do is show admin's own
+										 reassurance: no Retry, no Reconnect, and no illustration,
+										 because all three suggest something is in motion when what is
+										 actually happening is that a person has to look. -->
+									<template v-else-if="state.connectPhase === 'blocked'">
+										<div class="ob-head">
+											<h1>We're looking into your workspace</h1>
+											<p>
+												Something about your workspace needs a person to
+												check it, and our team has already been notified.
+											</p>
+										</div>
+										<div class="mx-auto mt-4 max-w-[560px]">
+											<Banner
+												v-if="state.connectMessage"
+												type="warning"
+												:message="state.connectMessage"
+											/>
+											<p
+												class="mt-4 text-center text-p-sm text-ink-gray-5"
+												role="status"
+											>
+												There's nothing for you to do here, and nothing
+												more to pay. We'll email you as soon as it's
+												sorted.
+											</p>
+											<p
+												class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
+											>
+												Want to talk to someone now?
+												<button class="ob-link" @click="openSupport">
+													Contact support
+												</button>
+											</p>
 										</div>
 									</template>
 									<!-- A non-ready terminal (retry / superseded / support) or a
@@ -1173,11 +1357,15 @@
 										 answer (review P0-08). -->
 									<template v-else>
 										<div class="ob-head">
+											<!-- Derived (waitPhases.connectHeadline), not hard-coded.
+												 Every one of these terminals used to render under
+												 "Still finishing setup", which asserts the workspace IS
+												 still finishing - the exact claim the message directly
+												 below it refuses to make (jarvis#709). -->
 											<h1>
 												{{
-													state.connectPhase === "superseded"
-														? "Your workspace changed"
-														: "Still finishing setup"
+													state.connectTitle ||
+													"We couldn't confirm your setup"
 												}}
 											</h1>
 											<p>{{ state.connectMessage }}</p>
@@ -1300,6 +1488,7 @@ import JarvisMark from "@/components/JarvisMark.vue";
 import Banner from "@/components/Banner.vue";
 import TourIntro from "@/onboarding/TourIntro.vue";
 import SetupNeuralNet from "@/onboarding/SetupNeuralNet.vue";
+import PaymentConfirmingArt from "@/onboarding/PaymentConfirmingArt.vue";
 import cashfreeLogo from "@/assets/cashfree.png";
 import {
 	STEPS_MANAGED,
@@ -1330,6 +1519,12 @@ import {
 	OP_PHASE,
 } from "@/lib/llmOperation.js";
 import { readinessWaitExhaustedMessage } from "@/onboarding/readinessWait.js";
+import {
+	PHASE_STATE,
+	provisioningPhase,
+	readinessPhase,
+	connectHeadline,
+} from "@/onboarding/waitPhases.js";
 import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
@@ -1464,10 +1659,20 @@ const state = reactive({
 	finishSubtitle: "",
 	connectPhase: "",
 	connectMessage: "",
+	// The recovery panel's own heading. Derived from the same place as
+	// connectMessage rather than hard-coded in the template, where a single
+	// "Still finishing setup" sat above all of them and claimed progress the
+	// message underneath deliberately refuses to claim (jarvis#709).
+	connectTitle: "",
 	connectBlockReason: "",
 	connectSupportOffered: false,
 	retryAfter: 0,
 });
+
+// What the LAST readiness poll observed, projected into the setup screen's
+// phase. Seeded unanswered so the first frame of a wait claims no phase at all.
+const readinessSeen = ref({ answered: false, reason: "", detail: "" });
+const readinessStage = computed(() => readinessPhase(readinessSeen.value));
 
 // Plan 01 billing state. Namespaced by site identity + logged-in user so one
 // site's / user's transitional billing PII can never prefill another's on a
@@ -2183,21 +2388,32 @@ function relativeSince(ts) {
 // concurrent loop (the flow now refuses re-entry too - this is the visible half).
 const recheckingSetup = ref(false);
 const setupRecheckNote = ref("");
+// One tick's observation from the provisioning poll. Assigning a fresh object
+// (rather than mutating) is what makes the computed phase re-evaluate.
+function noteProvisioning(o) {
+	provisioningSeen.value = {
+		answered: !!(o && o.answered),
+		tenantStatus: (o && o.tenantStatus) || "",
+	};
+}
 async function recheckProvisioning() {
 	if (recheckingSetup.value) return;
 	recheckingSetup.value = true;
 	setupRecheckNote.value = "";
 	try {
-		const out = await flow.waitForProvisioning();
+		const out = await flow.waitForProvisioning({ onObservation: noteProvisioning });
 		if (out.status === "ready") {
 			state.step = "connect";
 			return;
 		}
 		// Do not discard the outcome: a silent 90 seconds followed by the same
-		// screen reads as a broken button.
+		// screen reads as a broken button. It reports what the re-check OBSERVED -
+		// it deliberately no longer says "still preparing your workspace", which
+		// asserted that preparation is ongoing when all the loop established is
+		// that nothing reported ready.
 		setupRecheckNote.value =
 			out.status === "delayed"
-				? "Still preparing your workspace. Your payment is complete — you can leave this page and come back."
+				? "We checked again and your workspace still isn't ready. Your payment is complete, and you can leave this page and come back."
 				: "";
 	} finally {
 		recheckingSetup.value = false;
@@ -2211,6 +2427,13 @@ const showProvisioning = computed(
 	() => pay.value.value === S.PROVISIONING || pay.value.value === S.PROVISIONING_DELAYED
 );
 const showPaidFlash = computed(() => pay.value.value === S.PAID);
+
+// What the LAST provisioning tick actually saw. Seeded unanswered so the first
+// frame of the wait claims nothing: the poll has not reported yet, and "Jarvis
+// is getting ready for you" must never be a default (see waitPhases.js).
+const provisioningSeen = ref({ answered: false, tenantStatus: "" });
+const provisioningStage = computed(() => provisioningPhase(provisioningSeen.value));
+
 // The FULL-SCREEN busy view is only for the phases where there is genuinely
 // nothing to press: starting the signup, the sheet being open, confirming.
 // A status check or a retry deliberately does NOT hide the recovery card -
@@ -2225,9 +2448,25 @@ const initiating = computed(() => pay.value.busy === "initiating");
 // triple-click stacked three gateway sheets. The flow holds the same in-flight
 // guard its siblings do; this is the half the customer can see.
 const verifying = computed(() => pay.value.busy === "verifying");
+// The payment-confirming window: the customer paid on the admin-hosted page,
+// came back, and the bench is now asking the control plane whether that payment
+// landed. The machine models it as UNKNOWN + checkRequired with a check in
+// flight - RETURNED_FROM_CHECKOUT deliberately parks on a checkable UNKNOWN
+// rather than assuming paid or dismissed. It is the one moment where money has
+// genuinely left the customer and no verdict exists yet, so it gets its own
+// screen instead of the recovery card's disabled "Checking..." button, which is
+// what a customer used to stare at immediately after paying.
+const showConfirming = computed(
+	() =>
+		!payBusyView.value &&
+		pay.value.value === S.UNKNOWN &&
+		!!pay.value.checkRequired &&
+		checking.value
+);
 const showRecovery = computed(
 	() =>
 		!payBusyView.value &&
+		!showConfirming.value &&
 		(pay.value.value === S.UNKNOWN ||
 			pay.value.value === S.FAILED_RETRYABLE ||
 			pay.value.value === S.FAILED_TERMINAL ||
@@ -2834,6 +3073,7 @@ function onOpUpdate(ui) {
 	} else if (phase === OP_PHASE.RETRY) {
 		state.connectPhase = "retry";
 		state.connectMessage = (ui && ui.message) || "We hit a snag applying your AI connection.";
+		state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: false });
 		state.retryAfter = (ui && ui.retryAfterSeconds) || 0;
 		startRetryCountdown();
 	} else if (phase === OP_PHASE.SUPERSEDED) {
@@ -2841,6 +3081,7 @@ function onOpUpdate(ui) {
 		state.connectMessage =
 			(ui && ui.message) ||
 			"Your workspace assignment changed. Reload this page and try again.";
+		state.connectTitle = connectHeadline("superseded");
 		// A stale offer from an EARLIER readiness wait (jarvis#708) must not survive
 		// into this unrelated terminal - supersession means reload, not "still not
 		// resolved", and this phase already has its own recovery action.
@@ -2876,6 +3117,27 @@ function navigateToChat() {
 // cheap, no mutation) and navigate the moment it turns true. Bounded, and on
 // expiry it lands on the SAME honest retry state every other non-ready terminal
 // gets - never a silent navigation into a chat that cannot answer.
+// One poll's observation from the readiness wait, projected into the phase the
+// setup screen renders. Same discipline as noteProvisioning: a poll that threw
+// reports answered:false and gets copy that claims nothing.
+function noteReadiness(o) {
+	const seen = {
+		answered: !!(o && o.answered),
+		reason: (o && o.reason) || "",
+		detail: (o && o.detail) || "",
+	};
+	readinessSeen.value = seen;
+	const stage = readinessPhase(seen);
+	// A blocked verdict (admin paged a human) is terminal for this wait: stop
+	// polling and hand the customer a screen with no retry, because retrying
+	// payment or reconnecting is exactly what must not happen here.
+	if (stage.blocked) {
+		state.connectPhase = "blocked";
+		state.connectMessage = stage.detail;
+		state.connectSupportOffered = true;
+	}
+}
+
 const CHAT_READY_ATTEMPTS = 40;
 const CHAT_READY_INTERVAL_MS = 3000;
 async function waitForChatReadiness() {
@@ -2883,8 +3145,15 @@ async function waitForChatReadiness() {
 	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
 	let sawVerdict = false;
 	let lastDetail = "";
+	// A new wait starts from "nothing observed yet", so a stale phase from an
+	// earlier attempt is never the first thing this one renders.
+	readinessSeen.value = { answered: false, reason: "", detail: "" };
 	for (let i = 0; i < CHAT_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
+		// A blocked verdict is terminal for this wait (admin paged a human): stop
+		// polling rather than counting down to a ceiling whose exhaustion copy
+		// would invite the retry this state must not offer.
+		if (state.connectPhase === "blocked") return;
 		// The memoized verdict is what the router guard will read moments from now, so
 		// it has to be dropped before each probe or this loop polls a cached answer.
 		forgetReady();
@@ -2902,11 +3171,23 @@ async function waitForChatReadiness() {
 			navigateToChat();
 			return;
 		}
+		// Render what THIS poll saw. Previously every one of these 40 answers was
+		// discarded except the last detail, so the screen showed one fixed
+		// sentence for two minutes and a customer could not tell a workspace
+		// being built from one that was stuck.
+		noteReadiness({ answered: !!r, reason: r && r.reason, detail: r && r.detail });
+		if (state.connectPhase === "blocked") return;
 		await _sleep(CHAT_READY_INTERVAL_MS);
 	}
 	state.finishing = true;
 	state.connectPhase = "retry";
+	// jarvis#709: built from what this run OBSERVED, never from elapsed time.
+	// Unchanged.
 	state.connectMessage = readinessWaitExhaustedMessage({ sawVerdict, detail: lastDetail });
+	// The headline used to be a hard-coded "Still finishing setup" in the
+	// template, which asserted the very progress the message above refuses to
+	// claim. It is now derived from the same source.
+	state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 	state.connectSupportOffered = true;
 	state.retryAfter = 0;
 }
@@ -2922,6 +3203,8 @@ function onTerminal(status) {
 	if (status.timedOut) {
 		state.finishing = true;
 		state.connectPhase = "retry";
+		// A deadline is the absence of a completion, not a reported failure.
+		state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 		if (status.neverConfirmed) {
 			// jarvis#690: every poll for the whole deadline failed to reach admin -
 			// nothing was ever confirmed applying, so "still finishing on its own" is
@@ -2930,9 +3213,15 @@ function onTerminal(status) {
 			state.connectMessage =
 				"We couldn't reach your AI provider's setup service, so nothing has been confirmed. Please retry.";
 		} else {
-			// The deadline released us, not the job: it is still finishing server-side.
+			// The deadline released us, not the job. jarvis#709 removed the phrase
+			// "it's still finishing on its own" from the readiness wait because it
+			// asserted continuing progress nothing had observed; this branch is the
+			// last place it survived. It is better grounded here (polls DID confirm
+			// the operation in flight before the deadline elapsed) but it is still a
+			// present-tense claim made from a past observation, so it is anchored to
+			// when that observation happened instead of projected forward.
 			state.connectMessage =
-				"Setup is taking longer than usual. It's still finishing on its own, so you can keep waiting or retry.";
+				"Setup was still running when we last checked, and it's taking longer than usual. You can keep waiting and retry.";
 		}
 		state.retryAfter = 0;
 		return;
@@ -2968,6 +3257,7 @@ function enterSupport() {
 	state.connectPhase = "support";
 	state.connectMessage =
 		"We couldn't finish setting up your AI connection. Please try again in a moment.";
+	state.connectTitle = connectHeadline("support");
 	// A support dead-end is terminal for THIS attempt (F1/F8): drop the idempotency
 	// key so the next Start mints a fresh one. Otherwise a poisoned key (e.g. a 409
 	// IdempotencyKeyConflict, or an old-admin descriptor-less response) would make
@@ -3056,8 +3346,10 @@ async function followLegacyReadiness() {
 	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
 	let sawVerdict = false;
 	let lastDetail = "";
+	readinessSeen.value = { answered: false, reason: "", detail: "" };
 	for (let i = 0; i < LEGACY_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
+		if (state.connectPhase === "blocked") return;
 		let r = null;
 		try {
 			r = await isReadyForChat();
@@ -3072,11 +3364,16 @@ async function followLegacyReadiness() {
 			navigateToChat();
 			return;
 		}
+		// Same per-poll phase projection as waitForChatReadiness: this wait is just
+		// as long and was just as silent.
+		noteReadiness({ answered: !!r, reason: r && r.reason, detail: r && r.detail });
+		if (state.connectPhase === "blocked") return;
 		if (i < LEGACY_READY_ATTEMPTS - 1) await _sleep(LEGACY_READY_INTERVAL_MS);
 	}
 	state.finishing = true;
 	state.connectPhase = "retry";
 	state.connectMessage = readinessWaitExhaustedMessage({ sawVerdict, detail: lastDetail });
+	state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 	state.connectSupportOffered = true;
 	state.retryAfter = 0;
 }
@@ -3230,7 +3527,10 @@ watch(
 	async (v) => {
 		if (v === PAY_STATES.PAID && !provisioningRun) {
 			provisioningRun = true;
-			const out = await flow.waitForProvisioning();
+			// A fresh wait starts from "nothing observed yet", so a stale phase from
+			// an earlier run can never be the first thing this one shows.
+			provisioningSeen.value = { answered: false, tenantStatus: "" };
+			const out = await flow.waitForProvisioning({ onObservation: noteProvisioning });
 			if (out.status === "ready") {
 				state.step = "connect";
 			}
@@ -3496,9 +3796,13 @@ onUnmounted(() => {
 	letter-spacing: 6px;
 	font-weight: 500;
 }
+/* `--accent` is defined in NEITHER palette, so both of these fell through to a
+   raw blue that exists nowhere in the token set - and design.md §2.6 asks for a
+   neutral ring, not a coloured glow. Focus is the near-black CTA edge plus a
+   soft neutral ring, which is what every other focusable control here does. */
 .ob-code:focus {
-	border-color: var(--accent, #2563eb);
-	box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+	border-color: var(--cta);
+	box-shadow: 0 0 0 3px var(--surface-2);
 }
 .ob-code-note {
 	margin: 14px 0 0;
@@ -3508,15 +3812,26 @@ onUnmounted(() => {
 	line-height: 1.55;
 	color: var(--text-2);
 }
+/* ONE definition. There were two: this rule and a second, later block that
+   repainted it 12.5px --text-3 gray. The later one won, so every inline link on
+   these steps - including the "Contact support" handoff jarvis#709 added at the
+   readiness ceiling, and the provider "Retry" - rendered as small gray text that
+   did not look clickable. design.md §1.1 reserves --link for links and §3.1 says
+   links look like links; the old `--accent` fallback was also an undefined var
+   resolving to a raw blue outside the token set. */
 .ob-link {
-	color: var(--accent, #2563eb);
 	font: inherit;
+	font-family: inherit;
+	color: var(--link);
 	background: none;
 	border: 0;
 	padding: 0;
 	cursor: pointer;
 	text-decoration: underline;
 	text-underline-offset: 2px;
+}
+.ob-link:hover {
+	text-decoration-thickness: 2px;
 }
 .ob-head h1 {
 	font-size: 20px; /* text-2xl, 0.1.278 */
@@ -3568,21 +3883,84 @@ onUnmounted(() => {
 	outline: 2px solid var(--cta);
 	outline-offset: 2px;
 }
-/* quiet inline links on a step footer — links look like links */
-.ob-link {
-	font-size: 12.5px;
-	color: var(--text-3);
-	background: none;
-	border: none;
-	cursor: pointer;
-	font-family: inherit;
-	text-decoration: underline;
-	text-underline-offset: 3px;
-	padding: 4px 2px;
+/* ---- staged wait phases (waitPhases.js) --------------------------------
+   One row per phase. The row's MODIFIER is the honesty contract, not
+   decoration: `active` is only ever set from an observation, `unknown` means a
+   poll answered with nothing (or with the absence of a verdict) and must never
+   look like progress, and `waiting` says nothing at all about a phase that has
+   not started. Colour carries no status here beyond the completed check - the
+   words do that. */
+.ob-phases {
+	list-style: none;
+	margin: 0 auto;
+	padding: 0;
+	max-width: 420px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
 }
-.ob-link:hover {
+.ob-phase {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 7px 8px;
+	border-radius: 8px;
+}
+.ob-phase-ico {
+	width: 20px;
+	height: 20px;
+	flex: none;
+	display: grid;
+	place-items: center;
+}
+.ob-phase-txt {
+	min-width: 0;
+}
+.ob-phase-label {
+	display: block;
+	font-size: 13px;
+	line-height: 1.5;
+}
+.ob-phase-detail {
+	display: block;
+	font-size: 12px;
+	line-height: 1.5;
+	color: var(--text-3);
+	margin-top: 2px;
+}
+.ob-phase--done .ob-phase-label {
 	color: var(--text-2);
 }
+.ob-phase--done .ob-phase-ico {
+	color: var(--green);
+}
+.ob-phase--active,
+.ob-phase--unknown {
+	background: var(--surface-1);
+}
+.ob-phase--active .ob-phase-label,
+.ob-phase--unknown .ob-phase-label {
+	color: var(--text);
+	font-weight: 500;
+}
+.ob-phase--active .ob-phase-ico {
+	color: var(--text-2);
+}
+.ob-phase--unknown .ob-phase-ico {
+	color: var(--text-3);
+}
+.ob-phase--waiting .ob-phase-label {
+	color: var(--text-3);
+}
+.ob-phase-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--surface-3);
+	border: 1px solid var(--border-2);
+	display: block;
+}
+
 .ob-note {
 	font-size: 12.5px;
 	color: var(--text-3);

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -707,7 +707,7 @@
 								 back, and we are asking the control plane whether it landed. Money
 								 has left them and no verdict exists yet, so this is the one screen
 								 the payment illustration belongs on (design.md §2.2). It replaces
-								 the recovery card's disabled "Checking…" button, which is what a
+								 the recovery card, whose disabled "Working…" button is what a
 								 customer used to stare at in the seconds right after paying. -->
 							<template v-else-if="showConfirming">
 								<div class="ob-body">
@@ -1321,10 +1321,19 @@
 										 actually happening is that a person has to look. -->
 									<template v-else-if="state.connectPhase === 'blocked'">
 										<div class="ob-head">
-											<h1>We're looking into your workspace</h1>
-											<p>
+											<h1>
+												{{
+													state.connectTitle ||
+													"We couldn't continue setting up"
+												}}
+											</h1>
+											<p v-if="state.connectPaged">
 												Something about your workspace needs a person to
 												check it, and our team has already been notified.
+											</p>
+											<p v-else>
+												Waiting won't clear this one, so we've stopped
+												checking rather than leave you watching a spinner.
 											</p>
 										</div>
 										<div class="mx-auto mt-4 max-w-[560px]">
@@ -1334,6 +1343,7 @@
 												:message="state.connectMessage"
 											/>
 											<p
+												v-if="state.connectPaged"
 												class="mt-4 text-center text-p-sm text-ink-gray-5"
 												role="status"
 											>
@@ -1520,9 +1530,9 @@ import {
 } from "@/lib/llmOperation.js";
 import { readinessWaitExhaustedMessage } from "@/onboarding/readinessWait.js";
 import {
-	PHASE_STATE,
 	provisioningPhase,
 	readinessPhase,
+	inFlightPhase,
 	connectHeadline,
 } from "@/onboarding/waitPhases.js";
 import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
@@ -1664,15 +1674,29 @@ const state = reactive({
 	// "Still finishing setup" sat above all of them and claimed progress the
 	// message underneath deliberately refuses to claim (jarvis#709).
 	connectTitle: "",
+	// True only when the STOP came from a verdict where support was already
+	// notified (authority_repair_required). A paused subscription or a moved
+	// account also stop the wait, but nobody was paged and the customer has to
+	// act, so they must not get the "our team is on it" reassurance.
+	connectPaged: false,
 	connectBlockReason: "",
 	connectSupportOffered: false,
 	retryAfter: 0,
 });
 
 // What the LAST readiness poll observed, projected into the setup screen's
-// phase. Seeded unanswered so the first frame of a wait claims no phase at all.
-const readinessSeen = ref({ answered: false, reason: "", detail: "" });
-const readinessStage = computed(() => readinessPhase(readinessSeen.value));
+// phase. NULL means no poll has reported yet - which is NOT the same as a poll
+// that answered nothing. Seeding it as `answered: false` made the row render
+// "We couldn't reach your workspace to check" on the first frame after a
+// successful save, announcing a failed check before one had been attempted.
+const readinessSeen = ref(null);
+const readinessStage = computed(() =>
+	readinessSeen.value
+		? readinessPhase(readinessSeen.value)
+		: // The apply operation is what is running, and the operation controller
+		  // reported that, so naming it is grounded.
+		  inFlightPhase("Applying your AI connection")
+);
 
 // Plan 01 billing state. Namespaced by site identity + logged-in user so one
 // site's / user's transitional billing PII can never prefill another's on a
@@ -2400,6 +2424,9 @@ async function recheckProvisioning() {
 	if (recheckingSetup.value) return;
 	recheckingSetup.value = true;
 	setupRecheckNote.value = "";
+	// A fresh look starts from "nothing observed": the stale phase from the wait
+	// that already exhausted must not be what this one opens on.
+	provisioningSeen.value = null;
 	try {
 		const out = await flow.waitForProvisioning({ onObservation: noteProvisioning });
 		if (out.status === "ready") {
@@ -2428,11 +2455,15 @@ const showProvisioning = computed(
 );
 const showPaidFlash = computed(() => pay.value.value === S.PAID);
 
-// What the LAST provisioning tick actually saw. Seeded unanswered so the first
-// frame of the wait claims nothing: the poll has not reported yet, and "Jarvis
-// is getting ready for you" must never be a default (see waitPhases.js).
-const provisioningSeen = ref({ answered: false, tenantStatus: "" });
-const provisioningStage = computed(() => provisioningPhase(provisioningSeen.value));
+// What the LAST provisioning tick actually saw. NULL means no tick has reported
+// yet; see readinessSeen for why that is deliberately distinct from a tick that
+// answered nothing. "Jarvis is getting ready for you" must never be a default.
+const provisioningSeen = ref(null);
+const provisioningStage = computed(() =>
+	provisioningSeen.value
+		? provisioningPhase(provisioningSeen.value)
+		: inFlightPhase("Checking on your workspace")
+);
 
 // The FULL-SCREEN busy view is only for the phases where there is genuinely
 // nothing to press: starting the signup, the sheet being open, confirming.
@@ -3142,12 +3173,17 @@ function noteReadiness(o) {
 	};
 	readinessSeen.value = seen;
 	const stage = readinessPhase(seen);
-	// A blocked verdict (admin paged a human) is terminal for this wait: stop
-	// polling and hand the customer a screen with no retry, because retrying
-	// payment or reconnecting is exactly what must not happen here.
-	if (stage.blocked) {
+	// A verdict that waiting cannot resolve is terminal for this wait: stop
+	// polling rather than counting down to a ceiling whose copy invites a retry
+	// that cannot help. Covers a paged authority repair (do nothing, we called
+	// someone), a paused subscription, and an account that has moved to another
+	// site - the last two need the CUSTOMER to act, so they must not be dressed
+	// in the "our team has been notified" reassurance.
+	if (stage.stop) {
 		state.connectPhase = "blocked";
+		state.connectTitle = stage.title || "We couldn't continue setting up";
 		state.connectMessage = stage.detail;
+		state.connectPaged = !!stage.paged;
 		state.connectSupportOffered = true;
 	}
 }
@@ -3161,7 +3197,7 @@ async function waitForChatReadiness() {
 	let lastDetail = "";
 	// A new wait starts from "nothing observed yet", so a stale phase from an
 	// earlier attempt is never the first thing this one renders.
-	readinessSeen.value = { answered: false, reason: "", detail: "" };
+	readinessSeen.value = null;
 	for (let i = 0; i < CHAT_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
 		// A blocked verdict is terminal for this wait (admin paged a human): stop
@@ -3360,7 +3396,7 @@ async function followLegacyReadiness() {
 	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
 	let sawVerdict = false;
 	let lastDetail = "";
-	readinessSeen.value = { answered: false, reason: "", detail: "" };
+	readinessSeen.value = null;
 	for (let i = 0; i < LEGACY_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
 		if (state.connectPhase === "blocked") return;
@@ -3402,6 +3438,10 @@ function enterSaveRefusal(retryAfterSeconds) {
 		state.connectPhase = "retry";
 		state.connectMessage =
 			"Too many changes in a short time. Please wait a moment, then retry.";
+		// Every other terminal sets this; without it this one rendered the generic
+		// "We couldn't confirm your setup" over a rate-limit body, or worse, a
+		// STALE title left behind by an earlier attempt.
+		state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: false });
 		state.retryAfter = retryAfterSeconds;
 		startRetryCountdown();
 	} else {
@@ -3543,7 +3583,7 @@ watch(
 			provisioningRun = true;
 			// A fresh wait starts from "nothing observed yet", so a stale phase from
 			// an earlier run can never be the first thing this one shows.
-			provisioningSeen.value = { answered: false, tenantStatus: "" };
+			provisioningSeen.value = null;
 			const out = await flow.waitForProvisioning({ onObservation: noteProvisioning });
 			if (out.status === "ready") {
 				state.step = "connect";
@@ -3664,6 +3704,24 @@ onMounted(async () => {
 	// else touches the URL, and strip it immediately so a later reload does not
 	// re-apply a stale verdict.
 	const checkoutReturn = readCheckoutOutcome();
+	// Returning from the pay page: show the confirming screen from first paint.
+	// Everything below this line that the customer would otherwise be watching is
+	// real work - a providers fetch, an account prefill, then the reconcile round
+	// trip (hydrate, then a readiness read) - and until that lands `state.step` is
+	// still the default "intro". So a customer who paid ten seconds ago sat
+	// watching the marketing tour while we worked out what had happened to their
+	// money. A correction for that already existed at the end of this hook, but it
+	// ran AFTER the awaits: it fixed where they landed, not what they watched.
+	//
+	// Set before the first await deliberately. Routing to "pay" here reaches the
+	// same landing the correction did (landingStep leaves a resumed "pay" alone),
+	// which is why that guard below is now a no-op rather than a repair. The flag
+	// is cleared in the finally around the reconcile; nothing awaited in between
+	// can reject (prefillAccount swallows its own errors), so it cannot strand.
+	if (checkoutReturn) {
+		state.step = "pay";
+		confirmingReturn.value = true;
+	}
 	// Restore the namespaced local billing snapshot FIRST: restored values are
 	// user-owned (local_restore), so the Company-defaults fetch prefillAccount
 	// triggers can only fill fields the customer left blank.
@@ -3701,19 +3759,6 @@ onMounted(async () => {
 	// onMounted, so a live restored checkout is untouched.
 	if (pay.value.value !== S.CHECKOUT_OPEN) {
 		clearExternalCheckoutNav();
-	}
-	// Returning from the pay page, show the confirming screen from FIRST PAINT.
-	// reconcileMidFlightSignup() below is a real round trip (hydrate, then a
-	// readiness read), and until it lands `state.step` is still the default
-	// "intro" - so a customer who paid ten seconds ago was shown the marketing
-	// tour while we worked out what had happened to their money. The correction
-	// for that already existed further down, but it only ran AFTER the awaits, so
-	// it fixed where they ended up and not what they watched. Routing to "pay"
-	// here reaches the same landing (landingStep leaves a resumed "pay" alone,
-	// and the checkoutReturn guard below is now a no-op rather than a repair).
-	if (checkoutReturn) {
-		state.step = "pay";
-		confirmingReturn.value = true;
 	}
 	try {
 		await reconcileMidFlightSignup();

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2449,20 +2449,34 @@ const initiating = computed(() => pay.value.busy === "initiating");
 // guard its siblings do; this is the half the customer can see.
 const verifying = computed(() => pay.value.busy === "verifying");
 // The payment-confirming window: the customer paid on the admin-hosted page,
-// came back, and the bench is now asking the control plane whether that payment
-// landed. The machine models it as UNKNOWN + checkRequired with a check in
-// flight - RETURNED_FROM_CHECKOUT deliberately parks on a checkable UNKNOWN
-// rather than assuming paid or dismissed. It is the one moment where money has
-// genuinely left the customer and no verdict exists yet, so it gets its own
-// screen instead of the recovery card's disabled "Checking..." button, which is
-// what a customer used to stare at immediately after paying.
-const showConfirming = computed(
-	() =>
-		!payBusyView.value &&
-		pay.value.value === S.UNKNOWN &&
-		!!pay.value.checkRequired &&
-		checking.value
-);
+// came back, and the bench is asking the control plane whether that payment
+// landed. It is the one moment where money has genuinely left them and no
+// verdict exists yet.
+//
+// Driven by an explicit view-owned flag rather than derived from the machine,
+// for two reasons that both bite:
+//
+//   - `busy === "checking"` belongs to the "Check payment status" BUTTON
+//     (beginAction("checking") in usePaymentFlow.checkStatus). The post-checkout
+//     reconcile - reconcileAfterFailure, and hydrate's frozen-checkout exit -
+//     never sets it, so keying this off it would have meant the screen
+//     essentially never appeared on the one path it exists for.
+//   - even if it did, plan 02 a11y is explicit that an explicit status check
+//     must NOT have its buttons replaced by a full-screen indefinite spinner;
+//     they are disabled in place on the recovery card instead. So this is the
+//     return reconcile only, never any status check.
+const confirmingReturn = ref(false);
+const showConfirming = computed(() => !payBusyView.value && confirmingReturn.value);
+
+/** Hold the confirming screen for the duration of a post-checkout reconcile. */
+async function whileConfirmingReturn(run) {
+	confirmingReturn.value = true;
+	try {
+		return await run();
+	} finally {
+		confirmingReturn.value = false;
+	}
+}
 const showRecovery = computed(
 	() =>
 		!payBusyView.value &&
@@ -3632,7 +3646,7 @@ function handleCheckoutReturn() {
 		return;
 	}
 	clearExternalCheckoutNav();
-	flow.returnFromCheckout();
+	whileConfirmingReturn(() => flow.returnFromCheckout());
 }
 function onCheckoutPageShow(e) {
 	// Only a bfcache restore needs handling here; a normal load re-mounts fresh
@@ -3688,7 +3702,24 @@ onMounted(async () => {
 	if (pay.value.value !== S.CHECKOUT_OPEN) {
 		clearExternalCheckoutNav();
 	}
-	await reconcileMidFlightSignup();
+	// Returning from the pay page, show the confirming screen from FIRST PAINT.
+	// reconcileMidFlightSignup() below is a real round trip (hydrate, then a
+	// readiness read), and until it lands `state.step` is still the default
+	// "intro" - so a customer who paid ten seconds ago was shown the marketing
+	// tour while we worked out what had happened to their money. The correction
+	// for that already existed further down, but it only ran AFTER the awaits, so
+	// it fixed where they ended up and not what they watched. Routing to "pay"
+	// here reaches the same landing (landingStep leaves a resumed "pay" alone,
+	// and the checkoutReturn guard below is now a no-op rather than a repair).
+	if (checkoutReturn) {
+		state.step = "pay";
+		confirmingReturn.value = true;
+	}
+	try {
+		await reconcileMidFlightSignup();
+	} finally {
+		confirmingReturn.value = false;
+	}
 	// Resume an apply that was in flight when the page was last closed/reloaded: follow
 	// the SAME operation rather than showing an editable form over a running one (P1-05).
 	await maybeResumeConnect();


### PR DESCRIPTION
## Summary

The post-payment screens now show what is actually happening instead of one fixed sentence over a bare spinner. A new banknote illustration runs during the payment-confirming wait, and both long waits render the phase signal they already received and were throwing away. Anyone who pays notices.

`design.md`'s brand-asset exception is amended from one sanctioned illustration to two. **The product owner authorized this**, having seen and overruled the argument for keeping a single asset; the amendment ships here so the contract matches the code rather than contradicting it.

<details>
<summary>The illustration</summary>

`PaymentConfirmingArt` draws four 22x13 banknotes with a white rupee glyph, tilted 7 degrees so they read as in-motion even at rest, travelling into the Jarvis mark along one hairline rail on a 2.8s loop staggered 0.6s apart, with a halo pulse as each lands. Coins were rejected as reading slot-machine. Emoji were rejected because the glyph is OS-drawn, cannot take a token colour and ignores theme. Reduced motion parks the notes along the rail with no halo.

It renders during the post-checkout reconcile only. That window previously rendered the **marketing intro tour**, because `state.step` stays at the default `"intro"` until the reconcile resolves; the existing correction for that ran after the awaits, so it fixed where the customer landed, not what they watched.

Colour is `--money-note` / `--money-note-bd`, theme-flipping, deliberately off the `--green` success ramp: the screen renders while the payment is unconfirmed, and success-green would assert the outcome the screen exists to say we do not have yet.

`SetupNeuralNet` stays on the longer provisioning wait, and now reads `--brand-1` / `--brand-2` instead of carrying its own copies of them. One illustration per screen, never both.

</details>

<details>
<summary>Staged waits, and the rule they follow</summary>

Both waits already received a real phase signal per poll and discarded it: `tenant_status` on each of 45 provisioning ticks, `is_ready_for_chat`'s `reason` on each of 40 readiness polls. New pure module `waitPhases.js` turns those into copy under one rule, with no elapsed-time branch anywhere: **a phase is only ever named because something reported it.**

So "Jarvis is getting ready for you" renders when admin itself answered, and an honest "we couldn't check" renders when it did not. Three states are kept distinct, which is the whole point: *nothing has reported yet*, *we asked and got nothing*, and *we asked and got an answer*. Collapsing the first two is what made an early draft announce a failed check before one had been attempted.

Verdicts that waiting cannot resolve now stop the wait rather than run to a ceiling whose copy invites a retry that cannot help: `authority_repair_required` (support already paged, so the customer is told to do nothing), plus `subscription_suspended` and `site_replaced`, where nobody was paged and the customer has to act.

</details>

<details>
<summary>#709 preserved, and one place it had leaked</summary>

`readinessWaitExhaustedMessage` still builds from `sawVerdict` and the last `detail`; its three message bodies are byte-identical apart from a punctuation fix where an unpunctuated detail ran into the next sentence. Support is still offered at the same ceiling, and the hoisted ticket panel is untouched.

The headline is now derived too. Every terminal used to render under "Still finishing setup", which asserted the progress the message underneath refuses to claim, and that was the last surviving instance of the phrase #709 removed. The operation-deadline branch is now anchored to when it was observed rather than projected forward.

</details>

<details>
<summary>Defects fixed along the way</summary>

- `.ob-link` was defined twice and the later gray block won, so every inline link on these steps rendered as unclickable gray text, including #709's own Contact support.
- `.ob-code`'s focus ring read an undefined `--accent`, falling back to a blue in no token set.
- `enterSaveRefusal` was the one retry terminal that never set a headline, so a rate-limited save showed a mismatched or stale one.
- A one-shot `rAF` id went uncaptured, so unmounting mid-frame left a stray draw against a detached canvas.
- `alpha()` was written twice byte-for-byte; extracted to `lib/brand.js` beside `BRAND_STAR_PATH`, verified identical to both originals across 55 cases.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on a failure)
- [x] Branch is **up to date with `develop`** (branched from `a734ea60`, after #718 and #719)
- [x] New/changed behavior has tests (`waitPhases.test.js` 22 cases; `readinessWait` +2; `usePaymentFlow` +3; `OnboardingView.connect` +13. Suites green on Node 24: **879 vitest, 639 node:test**. Production build green. The confirming-screen and phase-row tests were each verified to fail against the implementation they replaced.)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01CU69MfBfXdyKeTsSZb2QYi
