### PR TITLE
fix(llm): let Test use a saved key, and stop calling an unreachable endpoint a failure

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -309,8 +309,16 @@ export const saveLlmPool = (
 export const disconnectLlm = () => call("jarvis.onboarding.disconnect_llm");
 // Pre-save "Test" probe for ONE api-key model row (never persists, never
 // touches the fleet/container - see jarvis/llm_key_probe.py). args:
-// {provider, model, api_key, base_url}. Returns
-// {ok, checks:[{check,ok,detail}], provider, local_endpoint, caveat}.
+// {provider, model, api_key, base_url, use_stored_key}. Returns
+// {ok, verdict, checks:[{check,ok,detail}], provider, local_endpoint, caveat}.
+// `verdict` is "pass" | "fail" | "unverified" and is what decides how the result
+// renders: "unverified" means the bench never reached the endpoint, which is a
+// statement about this network and not a failure the customer caused, so it must
+// not show in red (#680). `ok` stays strictly verdict === "pass", so anything
+// gating on it keeps today's strictness.
+// `use_stored_key` asks the server to load the saved key for this provider
+// rather than a typed one (#679). The key is never sent to the browser in either
+// direction, so this flag is the only way to test an already-saved credential.
 export const testLlmApiKey = (args) => call("jarvis.llm_key_probe.test_llm_api_key", args);
 
 // --- Onboarding wizard (managed signup) ---

--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -795,3 +795,106 @@ describe("Test button: an unreachable endpoint is not a failure (#680)", () => {
 		expect(w.vm.singleModeCanStart).toBe(false);
 	});
 });
+
+/**
+ * Two states that only became reachable once #679 made a stored key testable and
+ * #680 added a third verdict. Both are places where the screen would contradict
+ * itself: an amber "nothing is broken" note next to a save that silently refuses,
+ * and a red hard failure next to an enabled Start chatting.
+ */
+describe("the verdict and the surrounding controls agree", () => {
+	it("an unreachable endpoint does not silently cancel Connect", async () => {
+		// The probe result says "saving is still the way to apply it". If Connect
+		// then returns without saving and without a message, the customer is stuck
+		// with no path forward at all.
+		setPool([]);
+		const w = await mountEditor();
+		w.vm.openAdd();
+		const row = w.vm.rows[w.vm.rows.length - 1];
+		w.vm.setCredType(row, "api_key");
+		row.provider = "OpenAI-Compatible";
+		row.model = "gpt-4o";
+		row.apiKey = "sk-typed";
+		row.baseUrl = "https://vpn-only.example.com/v1"; // not container-only by shape
+		await idle();
+		api.testLlmApiKey.mockResolvedValue({
+			ok: false,
+			verdict: "unverified",
+			checks: [{ check: "probe_request", ok: false, detail: "could not resolve" }],
+			caveat: "",
+		});
+
+		await w.vm.connectApiKeyRow(row);
+		await idle();
+
+		expect(api.saveLlmPool).toHaveBeenCalled();
+	});
+
+	it("a real rejection still cancels Connect", async () => {
+		setPool([]);
+		const w = await mountEditor();
+		w.vm.openAdd();
+		const row = w.vm.rows[w.vm.rows.length - 1];
+		w.vm.setCredType(row, "api_key");
+		row.provider = "OpenAI";
+		row.model = "gpt-4o";
+		row.apiKey = "sk-bad";
+		row.baseUrl = "https://api.openai.com/v1";
+		await idle();
+		api.testLlmApiKey.mockResolvedValue({
+			ok: false,
+			verdict: "fail",
+			checks: [{ check: "probe_request", ok: false, detail: "HTTP 401" }],
+			caveat: "",
+		});
+
+		await w.vm.connectApiKeyRow(row);
+		await idle();
+
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
+	});
+
+	it("a failed test on a saved key blocks Start chatting", async () => {
+		// The returning customer whose stored key was revoked. Before #679 this row
+		// could not be tested at all, so a red result next to an enabled Start was
+		// impossible; now it has to be handled.
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor({ modes: ["quick"] });
+		const row = w.vm.rows[0];
+		expect(row.hasKey).toBe(true);
+		expect(row.apiKey).toBe("");
+		expect(w.vm.singleModeCanStart).toBe(true); // stored key, nothing probed yet
+
+		api.testLlmApiKey.mockResolvedValue({
+			ok: false,
+			verdict: "fail",
+			checks: [{ check: "probe_request", ok: false, detail: "HTTP 401: revoked" }],
+			caveat: "",
+		});
+		await w.vm.testSingleModeRow();
+		await idle();
+
+		expect(w.vm.singleModeCanStart).toBe(false);
+		expect(w.vm.startBlockedReason).toBe(
+			"That test failed. Update the settings above to continue."
+		);
+	});
+
+	it("an unreachable endpoint does not block Start chatting on a saved key", async () => {
+		// The guard on the above: "unverified" is not a rejection, so it must not
+		// take away a path that a stored key already earned.
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor({ modes: ["quick"] });
+		api.testLlmApiKey.mockResolvedValue({
+			ok: false,
+			verdict: "unverified",
+			checks: [{ check: "probe_request", ok: false, detail: "could not resolve" }],
+			caveat: "",
+		});
+		await w.vm.testSingleModeRow();
+		await idle();
+
+		expect(w.vm.singleModeCanStart).toBe(true);
+		expect(w.vm.startBlockedReason).toBe("");
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -636,3 +636,162 @@ describe("resync retries a failed sync (jarvis#714)", () => {
 		expect(api.saveLlmPool).not.toHaveBeenCalled();
 	});
 });
+
+/**
+ * The Test button on an API-key row: which credential it may use (#679) and
+ * what it is allowed to call a failure (#680).
+ *
+ * Both are driven through the real component - mount, open the real edit panel,
+ * call the real click handler - because both defects are about what the editor
+ * decides, not about what the probe endpoint returns. keyModel() already builds
+ * the exact production state #679 lives in: has_key true from the server, and
+ * therefore apiKey "" in the row, since get_llm_config never returns a secret.
+ */
+describe("Test button: stored key (#679)", () => {
+	async function openEditOnKeyRow() {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor();
+		w.vm.openEdit(0);
+		await idle();
+		return w;
+	}
+
+	it("is enabled on a saved row whose key was never re-typed", async () => {
+		const w = await openEditOnKeyRow();
+		const row = w.vm.rows[0];
+		// The production state: the server said has_key, so nothing is typed.
+		expect(row.hasKey).toBe(true);
+		expect(row.apiKey).toBe("");
+
+		expect(w.vm.testBlockedReason(row)).toBe("");
+	});
+
+	it("tests a changed base URL against the stored key, without it in the request", async () => {
+		const w = await openEditOnKeyRow();
+		const row = w.vm.rows[0];
+		row.baseUrl = "https://gateway.example.com/v1"; // the only edit, per #679
+		await idle();
+		api.testLlmApiKey.mockResolvedValue({ ok: true, verdict: "pass", checks: [], caveat: "" });
+
+		await w.vm.testApiKeyRow(row);
+		await idle();
+
+		const sent = api.testLlmApiKey.mock.calls[0][0];
+		expect(sent.base_url).toBe("https://gateway.example.com/v1");
+		// The server loads the key itself; the browser never holds or sends it.
+		expect(sent.use_stored_key).toBeTruthy();
+		expect(sent.api_key).toBe("");
+	});
+
+	it("still blocks a brand new row, and says why", async () => {
+		setPool([]);
+		const w = await mountEditor();
+		w.vm.openAdd();
+		const row = w.vm.rows[w.vm.rows.length - 1];
+		row.credentialType = "api_key";
+		row.provider = "OpenAI";
+		row.model = "gpt-4o";
+		await idle();
+
+		expect(row.hasKey).toBe(false);
+		expect(w.vm.testBlockedReason(row)).toBe("Enter an API key to test");
+	});
+
+	it("stops using the stored key once the provider is switched", async () => {
+		// The stored key belongs to the OLD provider's credential, so it is not a
+		// usable credential for the new one and the button must go back to asking.
+		const w = await openEditOnKeyRow();
+		const row = w.vm.rows[0];
+		w.vm.onProviderChange(row, "Anthropic");
+		await idle();
+
+		expect(row.hasKey).toBe(false);
+		expect(w.vm.usesStoredKey(row)).toBe(false);
+		expect(w.vm.testBlockedReason(row)).toBe("Enter an API key to test");
+	});
+});
+
+describe("Test button: an unreachable endpoint is not a failure (#680)", () => {
+	async function runTestWith(res) {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor();
+		w.vm.openEdit(0);
+		await idle();
+		api.testLlmApiKey.mockResolvedValue(res);
+		await w.vm.testApiKeyRow(w.vm.rows[0]);
+		await idle();
+		return w;
+	}
+
+	it("renders a container-only endpoint neutrally, not in red", async () => {
+		// The #680 repro: host.docker.internal answers 200 inside the container and
+		// does not resolve from the bench. The customer must not see a blocker.
+		const w = await runTestWith({
+			ok: false,
+			verdict: "unverified",
+			checks: [
+				{
+					check: "probe_request",
+					ok: false,
+					detail: "This bench could not resolve that hostname.",
+				},
+			],
+			caveat: "Nothing reached the provider, so this is not a verdict on your key.",
+		});
+
+		const status = w.find(".jv-status");
+		expect(status.exists()).toBe(true);
+		expect(status.classes()).toContain("jv-status-warn");
+		expect(status.classes()).not.toContain("jv-status-bad");
+		expect(status.text()).toContain("Could not test from here.");
+		expect(status.text()).not.toContain("Test failed.");
+	});
+
+	it("still renders a real provider rejection in red", async () => {
+		// The guard on the above: a provider that ANSWERED and said no is a real
+		// failure, and softening that would trade one lie for another.
+		const w = await runTestWith({
+			ok: false,
+			verdict: "fail",
+			checks: [
+				{
+					check: "probe_request",
+					ok: false,
+					detail: "HTTP 401: Incorrect API key provided.",
+				},
+			],
+			caveat: "",
+		});
+
+		const status = w.find(".jv-status");
+		expect(status.classes()).toContain("jv-status-bad");
+		expect(status.text()).toContain("Test failed.");
+		expect(status.text()).toContain("Incorrect API key provided.");
+	});
+
+	it("does not let an unreachable endpoint unlock the onboarding gate", async () => {
+		// singleModeCanStart requires a PASS for a typed key. "unverified" is not one:
+		// a typo'd public host fails DNS exactly like a container-only host does.
+		setPool([]);
+		const w = await mountEditor({ modes: ["quick"] });
+		const row = w.vm.rows[0];
+		row.credentialType = "api_key";
+		row.provider = "OpenAI";
+		row.model = "gpt-4o";
+		row.apiKey = "sk-typed";
+		row.baseUrl = "https://api.openai.com/v1";
+		await idle();
+		api.testLlmApiKey.mockResolvedValue({
+			ok: false,
+			verdict: "unverified",
+			checks: [{ check: "probe_request", ok: false, detail: "could not resolve" }],
+			caveat: "",
+		});
+
+		await w.vm.testSingleModeRow();
+		await idle();
+
+		expect(w.vm.smTest.passIdentity).toBe("");
+		expect(w.vm.singleModeCanStart).toBe(false);
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -432,11 +432,16 @@
 					</div>
 
 					<!-- Pre-save "Test": a live, side-effect-free 1-token request straight from this
-               bench to the provider using whatever is typed above - never saved, never
+               bench to the provider using what is typed above - never saved, never
                touches the fleet/container (jarvis.llm_key_probe.test_llm_api_key). Motivated
                by a real GLM/Z.ai case: a valid key on a zero-balance account saved cleanly and
                only failed AFTER save with a bare "Not working" - this lets the customer catch
-               that (and see the provider's OWN error) before they ever click Save. -->
+               that (and see the provider's OWN error) before they ever click Save.
+               A row with a saved key sends no key at all and asks the server to load its
+               own (#679), so a base URL can be changed and tested without re-pasting a
+               credential. The result has THREE states, not two: an endpoint this bench
+               could not reach is reported neutrally, because chat runs from inside the
+               container and reaches addresses the bench cannot (#680). -->
 					<div
 						style="
 							display: flex;
@@ -472,7 +477,7 @@
 					<div
 						v-if="panel.testResult"
 						class="jv-status"
-						:class="panel.testResult.ok ? 'jv-status-ok' : 'jv-status-bad'"
+						:class="testStatusClass(panel.testResult)"
 						style="margin-top: 10px"
 					>
 						<span class="jv-status-ic">
@@ -490,6 +495,20 @@
 								<path d="M20 6 9 17l-5-5" />
 							</svg>
 							<svg
+								v-else-if="panel.testResult.verdict === 'unverified'"
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2.4"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<circle cx="12" cy="12" r="9" />
+								<path d="M12 11v5M12 8h.01" />
+							</svg>
+							<svg
 								v-else
 								width="14"
 								height="14"
@@ -504,7 +523,7 @@
 							</svg>
 						</span>
 						<span class="jv-status-tx"
-							><b>{{ panel.testResult.ok ? "Key works." : "Test failed." }}</b>
+							><b>{{ testStatusHeadline(panel.testResult) }}</b>
 							{{ panel.testResult.message }}</span
 						>
 					</div>
@@ -1319,7 +1338,7 @@
 					<div
 						v-if="singleMode && smTest.result"
 						class="jv-status"
-						:class="smTest.result.ok ? 'jv-status-ok' : 'jv-status-bad'"
+						:class="testStatusClass(smTest.result)"
 						style="margin-top: 10px"
 					>
 						<span class="jv-status-ic">
@@ -1337,6 +1356,20 @@
 								<path d="M20 6 9 17l-5-5" />
 							</svg>
 							<svg
+								v-else-if="smTest.result.verdict === 'unverified'"
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2.4"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<circle cx="12" cy="12" r="9" />
+								<path d="M12 11v5M12 8h.01" />
+							</svg>
+							<svg
 								v-else
 								width="14"
 								height="14"
@@ -1351,7 +1384,7 @@
 							</svg>
 						</span>
 						<span class="jv-status-tx"
-							><b>{{ smTest.result.ok ? "Key works." : "Test failed." }}</b>
+							><b>{{ testStatusHeadline(smTest.result) }}</b>
 							{{ smTest.result.message }}</span
 						>
 					</div>
@@ -1949,21 +1982,17 @@ async function testSingleModeRow() {
 			model: row.model || "",
 			api_key: row.apiKey || "",
 			base_url: effectiveTestBaseUrl(row),
+			use_stored_key: usesStoredKey(row) ? 1 : 0,
 		});
 		if (stale()) return;
-		const checks = Array.isArray(res && res.checks) ? res.checks : [];
-		const last = checks[checks.length - 1];
-		smTest.value.result = {
-			ok: !!(res && res.ok),
-			message:
-				(last && last.detail) ||
-				(res && res.ok ? "The provider accepted the request." : "The test failed."),
-			caveat: (res && res.caveat) || "",
-		};
+		smTest.value.result = testResultOf(res);
+		// Only a real pass binds. An "unverified" probe reached nothing, so it must
+		// not unlock "Start chatting" the way a pass does (#680) - a typo'd public
+		// host fails DNS exactly like a container-only one does.
 		smTest.value.passIdentity = res && res.ok ? boundIdentity : "";
 	} catch (e) {
 		if (stale()) return;
-		smTest.value.result = { ok: false, message: _err(e), caveat: "" };
+		smTest.value.result = { ok: false, verdict: "fail", message: _err(e), caveat: "" };
 		smTest.value.passIdentity = "";
 	} finally {
 		if (!stale()) smTest.value.testing = false;
@@ -2496,17 +2525,31 @@ function openEdit(i) {
 function isLocalProviderRow(row) {
 	return !!(row && LOCAL_PROVIDER_IDS.has(providerId(row.provider)));
 }
-// Why the Test button is disabled right now, or "" when it's enabled. hasKey +
-// a blank apiKey means an already-saved key that hasn't been re-typed - the
-// probe only ever sees what's in the panel (it never reads the stored,
-// encrypted secret), so it has nothing to send yet.
+// Whether this probe has to ask the server for the row's SAVED key because the
+// customer has not typed one. Only true for a row that really has one stored
+// (hasKey), which onProviderChange resets the moment the provider is switched -
+// a stored key belongs to the old provider's credential, not this one.
+function usesStoredKey(row) {
+	return !!(row && !(row.apiKey || "").trim() && row.hasKey === true);
+}
+// Why the Test button is disabled right now, or "" when it's enabled.
+//
+// hasKey + a blank apiKey used to be blocked with "Re-enter the key to test it",
+// because the probe only ever saw what was in the panel. That made the one edit
+// where a test matters most - changing a base URL on a working model - the one
+// edit that could not be tested, unless the customer still had a key they pasted
+// months ago (#679). The server can resolve that key itself now, so this case is
+// allowed and the reason strings below are each true of a DIFFERENT state rather
+// than one string covering them all.
 function testBlockedReason(row) {
 	if (!row) return "Nothing to test";
 	if (!(row.provider || "").trim()) return "Choose a provider to test";
 	if (!(row.model || "").trim()) return "Enter a model id to test";
 	// Local providers (Ollama, vLLM) take no key - nothing blocks the probe.
-	if (!(row.apiKey || "").trim() && !isLocalProviderRow(row))
-		return row.hasKey ? "Re-enter the key to test it" : "Enter an API key to test";
+	if (isLocalProviderRow(row)) return "";
+	// A saved key the server can load on our behalf. Nothing to re-enter.
+	if (usesStoredKey(row)) return "";
+	if (!(row.apiKey || "").trim()) return "Enter an API key to test";
 	return "";
 }
 function testButtonHint(row) {
@@ -2517,7 +2560,27 @@ function testButtonHint(row) {
 			"doesn't guarantee the container can reach it too."
 		);
 	}
+	if (usesStoredKey(row)) {
+		return (
+			"Sends a minimal live request using your saved key and the settings above. " +
+			"The key stays on the server and nothing is saved."
+		);
+	}
 	return "Sends a minimal live request to this provider using what's typed above. Nothing is saved.";
+}
+// The three ways a probe can come back (jarvis.llm_key_probe's `verdict`).
+// "unverified" means the bench never reached the endpoint, which is a fact about
+// this network and not about the key, so it must not render as a red failure -
+// a container-only base URL hits this every time and is perfectly valid (#680).
+function testStatusClass(result) {
+	if (!result) return "";
+	if (result.ok) return "jv-status-ok";
+	return result.verdict === "unverified" ? "jv-status-warn" : "jv-status-bad";
+}
+function testStatusHeadline(result) {
+	if (!result) return "";
+	if (result.ok) return "Key works.";
+	return result.verdict === "unverified" ? "Could not test from here." : "Test failed.";
 }
 // Effective base_url to send: the row's own value, falling back to the provider's
 // known default. A row a customer saved on a STANDARD provider (OpenAI/Anthropic/...)
@@ -2561,23 +2624,33 @@ async function testApiKeyRow(row) {
 			model: row.model || "",
 			api_key: row.apiKey || "",
 			base_url: effectiveTestBaseUrl(row),
+			// The key itself is never sent back to the browser, so an untyped row
+			// asks the server to load its own saved one (#679).
+			use_stored_key: usesStoredKey(row) ? 1 : 0,
 		});
 		if (stale()) return;
-		const checks = Array.isArray(res && res.checks) ? res.checks : [];
-		const last = checks[checks.length - 1];
-		myPanel.testResult = {
-			ok: !!(res && res.ok),
-			message:
-				(last && last.detail) ||
-				(res && res.ok ? "The provider accepted the request." : "The test failed."),
-			caveat: (res && res.caveat) || "",
-		};
+		myPanel.testResult = testResultOf(res);
 	} catch (e) {
 		if (stale()) return;
-		myPanel.testResult = { ok: false, message: _err(e), caveat: "" };
+		myPanel.testResult = { ok: false, verdict: "fail", message: _err(e), caveat: "" };
 	} finally {
 		if (!stale()) myPanel.testing = false;
 	}
+}
+// Flatten a probe response into what the status block renders. `verdict` is what
+// decides the colour (testStatusClass); `ok` alone cannot, because a failure and
+// an un-run probe are both "not ok" and only one of them is the customer's problem.
+function testResultOf(res) {
+	const checks = Array.isArray(res && res.checks) ? res.checks : [];
+	const last = checks[checks.length - 1];
+	return {
+		ok: !!(res && res.ok),
+		verdict: (res && res.verdict) || (res && res.ok ? "pass" : "fail"),
+		message:
+			(last && last.detail) ||
+			(res && res.ok ? "The provider accepted the request." : "The test failed."),
+		caveat: (res && res.caveat) || "",
+	};
 }
 
 // Resilient-by-default (API KEYS ONLY - no subscription presets exist and
@@ -5208,19 +5281,34 @@ defineExpose({ save, busy, canStart: singleModeCanStart, startBlockedReason });
 	border: 1px solid var(--red-bd);
 	background: var(--red-bg);
 }
+/* "Could not test from here": the probe never reached the endpoint, so this is
+   not a verdict on the customer's key and must not wear the failure colour
+   (#680). Amber is the same "look at this, nothing is broken yet" the sync pill
+   and the account-health dot already use in this editor. */
+.jv-status-warn {
+	border: 1px solid var(--amber-bd);
+	background: var(--amber-bg);
+}
 .jv-status-ic {
 	flex: none;
 	display: flex;
+	align-self: flex-start;
+	margin-top: 2px;
 	color: var(--green);
 }
 .jv-status-bad .jv-status-ic {
 	color: var(--red);
 }
+.jv-status-warn .jv-status-ic {
+	color: var(--amber);
+}
+/* Wraps rather than ellipsing. This block used to be one nowrap line, which was
+   survivable while it only ever said "Key works."/"Test failed.", but the text
+   that now matters most is the explanation of an unreachable endpoint - and a
+   truncated explanation is the same dead end #680 is about. Provider errors
+   (the GLM balance message) stop being clipped for the same reason. */
 .jv-status-tx {
 	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 	color: var(--text);
 }
 .jv-status-tx b {
@@ -5229,6 +5317,9 @@ defineExpose({ save, busy, canStart: singleModeCanStart, startBlockedReason });
 }
 .jv-status-bad .jv-status-tx b {
 	color: var(--red);
+}
+.jv-status-warn .jv-status-tx b {
+	color: var(--amber);
 }
 .jv-status-acts {
 	margin-left: auto;

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -2022,6 +2022,18 @@ watch(
 // container-only endpoint can't be probed from the bench, so provider+model is
 // enough; a stored (un-retyped) remote key can't be re-probed either. A remote row
 // with a freshly-typed key MUST carry a pass bound to its current fields.
+// A visible, definitive rejection on the row as it stands. The two exempt
+// branches below (a container-only endpoint, and a stored key) skip the
+// pass requirement on the grounds that no useful probe is possible - which
+// stopped being true for a stored key once #679 made it testable. Without
+// this, a returning customer whose saved key has since been revoked can see
+// a red "Test failed. HTTP 401" sitting next to an enabled Start chatting.
+// Any edit to the row clears smTest.result, so this only ever reflects the
+// fields on screen right now.
+function smHardFailure() {
+	const res = smTest.value.result;
+	return !!(res && !res.ok && res.verdict !== "unverified");
+}
 const singleModeCanStart = computed(() => {
 	if (!singleMode.value) return false;
 	const r = rows.value[0];
@@ -2029,6 +2041,7 @@ const singleModeCanStart = computed(() => {
 	if (r.credentialType === "subscription")
 		return (r.accounts || []).some((a) => a && (a.capture_id || a.account_ref));
 	if (!(r.provider || "").trim() || !(r.model || "").trim()) return false;
+	if (smHardFailure()) return false;
 	if (isContainerOnlyRow(r)) return true; // local / private endpoint: no bench probe
 	const typed = (r.apiKey || "").trim();
 	if (!typed) return r.hasKey === true; // stored key: nothing to re-probe
@@ -2046,6 +2059,7 @@ const startBlockedReason = computed(() => {
 			: "Connect your account to continue.";
 	if (!(r.provider || "").trim()) return "Choose a provider to continue.";
 	if (!(r.model || "").trim()) return "Enter a model id to continue.";
+	if (smHardFailure()) return "That test failed. Update the settings above to continue.";
 	if (isContainerOnlyRow(r)) return "";
 	const typed = (r.apiKey || "").trim();
 	if (!typed) return r.hasKey ? "" : "Enter an API key to continue.";
@@ -2848,11 +2862,12 @@ async function connectApiKeyRow(row) {
 			setBusy("");
 		}
 		const probe = panel.value.testResult;
-		// A probe that produced a RESULT needs nothing more from us: the red Test
-		// result block above the button is already showing the provider's own words
-		// for why it refused. A probe that produced NO result at all is different -
-		// the request itself failed, the block stays empty, and returning here left
-		// the customer pressing Connect against total silence (jarvis#556).
+		// A probe that produced a definitive REJECTION needs nothing more from us:
+		// the red Test result block above the button is already showing the
+		// provider's own words for why it refused. A probe that produced NO result
+		// at all is different - the request itself failed, the block stays empty,
+		// and returning here left the customer pressing Connect against total
+		// silence (jarvis#556).
 		if (!probe) {
 			setApplyResult({
 				kind: "failed",
@@ -2863,7 +2878,13 @@ async function connectApiKeyRow(row) {
 			});
 			return;
 		}
-		if (!probe.ok) return;
+		// "unverified" must NOT block the save. It means the bench could not reach
+		// the endpoint, which is the same condition isContainerOnlyRow above skips
+		// the probe entirely for - it just was not predictable from the URL. The
+		// amber block the customer is looking at says saving is how to apply it, so
+		// silently refusing to save here would contradict the screen and leave no
+		// way forward at all (#680).
+		if (!probe.ok && probe.verdict !== "unverified") return;
 	}
 	// The "add backup models automatically" switch used to be honoured on Close,
 	// which only worked because a Save came afterwards. Expand before the payload is

--- a/jarvis/chat/link_fetch.py
+++ b/jarvis/chat/link_fetch.py
@@ -97,10 +97,38 @@ _METADATA_IPS = {"169.254.169.254"}
 _USER_AGENT = "JarvisLinkFetch/1.0 (+personalise-note-capture)"
 
 
+# Failure classes carried on LinkFetchError.kind. The distinction that matters
+# to a caller is WHETHER THE REMOTE END EVER SPOKE: the first three kinds mean
+# this bench never got a byte back, which says nothing about the endpoint
+# itself, only about what this network can reach. jarvis.llm_key_probe turns
+# exactly that split into its "could not verify from here" verdict instead of
+# calling a container-only endpoint a failure (#680), so classify at the raise
+# site - matching on the message text would break the day one is reworded.
+ERR_INVALID_URL = "invalid_url"  # caller's URL is unusable (scheme/host/empty)
+ERR_UNRESOLVED = "unresolved"  # DNS gave us nothing
+ERR_BLOCKED_ADDRESS = "blocked_address"  # SSRF guard refused the resolved address
+ERR_CONNECT_FAILED = "connect_failed"  # socket/TLS/timeout before any response
+ERR_RESPONSE = "response"  # the remote DID answer; we rejected what it said
+
+# The three kinds that mean "this bench could not reach the endpoint at all".
+UNREACHABLE_KINDS = frozenset({ERR_UNRESOLVED, ERR_BLOCKED_ADDRESS, ERR_CONNECT_FAILED})
+
+
 class LinkFetchError(Exception):
 	"""Raised for any guard rejection or fetch failure. Callers treat this
 	(and any other exception this module might let through, defensively) as
-	"skip extraction, keep the note" - see the module docstring."""
+	"skip extraction, keep the note" - see the module docstring.
+
+	``kind`` is one of the ``ERR_*`` constants above. It defaults to
+	``ERR_RESPONSE`` rather than to an unreachable kind so that anything
+	constructed without an explicit class is treated as a definitive answer,
+	never silently softened into "we could not check" - a caller that grants
+	leniency on the unreachable kinds must only do so where this module really
+	said the network failed."""
+
+	def __init__(self, message: str, *, kind: str = ERR_RESPONSE):
+		super().__init__(message)
+		self.kind = kind
 
 
 # --------------------------------------------------------------------------- #
@@ -139,18 +167,21 @@ def _validate_host(hostname: str) -> list[str]:
 	extract`` connect to an address it already checked instead of letting the
 	HTTP client resolve the name a second, unchecked time."""
 	if not hostname:
-		raise LinkFetchError("URL has no host to validate.")
+		raise LinkFetchError("URL has no host to validate.", kind=ERR_INVALID_URL)
 	try:
 		infos = socket.getaddrinfo(hostname, None)
 	except Exception as exc:
-		raise LinkFetchError(f"Could not resolve host: {hostname}") from exc
+		raise LinkFetchError(f"Could not resolve host: {hostname}", kind=ERR_UNRESOLVED) from exc
 	if not infos:
-		raise LinkFetchError(f"Could not resolve host: {hostname}")
+		raise LinkFetchError(f"Could not resolve host: {hostname}", kind=ERR_UNRESOLVED)
 	addrs: list[str] = []
 	for info in infos:
 		addr = info[4][0]
 		if _is_blocked_ip(addr):
-			raise LinkFetchError(f"Host {hostname} resolves to a disallowed address ({addr}).")
+			raise LinkFetchError(
+				f"Host {hostname} resolves to a disallowed address ({addr}).",
+				kind=ERR_BLOCKED_ADDRESS,
+			)
 		addrs.append(addr)
 	return addrs
 
@@ -162,9 +193,11 @@ def _validate_url(url: str):
 	safe as any)."""
 	parsed = urlparse(url)
 	if parsed.scheme not in _ALLOWED_SCHEMES:
-		raise LinkFetchError(f"URL scheme must be http or https (got {parsed.scheme!r}).")
+		raise LinkFetchError(
+			f"URL scheme must be http or https (got {parsed.scheme!r}).", kind=ERR_INVALID_URL
+		)
 	if not parsed.hostname:
-		raise LinkFetchError("URL has no host.")
+		raise LinkFetchError("URL has no host.", kind=ERR_INVALID_URL)
 	vetted = _validate_host(parsed.hostname)
 	return parsed, vetted[0]
 
@@ -352,7 +385,7 @@ def fetch_and_extract(
 	docstring for why this raises instead of returning ``""``."""
 	current = (url or "").strip()
 	if not current:
-		raise LinkFetchError("No URL given.")
+		raise LinkFetchError("No URL given.", kind=ERR_INVALID_URL)
 
 	redirects = 0
 	while True:
@@ -360,7 +393,7 @@ def fetch_and_extract(
 		try:
 			resp, pool = _open_pinned(parsed, ip, timeout)
 		except (urllib3.exceptions.HTTPError, OSError) as exc:
-			raise LinkFetchError(f"Fetch failed: {exc}") from exc
+			raise LinkFetchError(f"Fetch failed: {exc}", kind=ERR_CONNECT_FAILED) from exc
 
 		try:
 			if resp.status in _REDIRECT_STATUSES:
@@ -430,7 +463,7 @@ def request_pinned(
 	"""
 	current = (url or "").strip()
 	if not current:
-		raise LinkFetchError("No URL given.")
+		raise LinkFetchError("No URL given.", kind=ERR_INVALID_URL)
 
 	parsed, ip = _validate_url(current)
 
@@ -443,7 +476,7 @@ def request_pinned(
 	try:
 		resp, pool = _open_pinned(parsed, ip, timeout, method=method, body=body, extra_headers=hdrs)
 	except (urllib3.exceptions.HTTPError, OSError) as exc:
-		raise LinkFetchError(f"Request failed: {exc}") from exc
+		raise LinkFetchError(f"Request failed: {exc}", kind=ERR_CONNECT_FAILED) from exc
 
 	try:
 		data = _read_capped(resp, max_bytes)

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -107,6 +107,42 @@ def normalize_provider(value: str) -> str:
 	return _PROVIDER_ALIASES.get(v.lower(), v.lower())
 
 
+def stored_api_keys_by_provider(models) -> dict:
+	"""Decrypt every api-key row's stored key, keyed by canonical provider.
+
+	This is the app's ONE answer to "which stored key belongs to provider X".
+	``jarvis.onboarding.save_llm_pool`` uses it to merge a secret back into a
+	row the reloaded editor posted blank (get_llm_config never returns a key,
+	so an untouched row always comes back with ``api_key: ""``), and
+	``jarvis.llm_key_probe.test_llm_api_key`` uses it to probe a stored
+	credential the customer did not retype (#679).
+
+	Both callers MUST agree: if Test probed one key and Save then shipped a
+	different one, a green Test would be a lie. Sharing this function is what
+	makes that impossible, so resist giving either caller its own lookup.
+
+	Keyed by provider ALONE, deliberately - api keys are per-vendor here, and
+	rows carry no durable per-row identity (the child rows are rebuilt, and
+	renamed, on every save, and nothing row-scoped survives on the wire). Two
+	rows on one provider therefore collapse to a single key, LAST non-empty
+	one winning, which is exactly the key both of them will hold after the
+	next save. Blank keys never enter the map, so a half-filled row cannot
+	mask a working credential.
+	"""
+	keys: dict = {}
+	for m in models or []:
+		cred = (
+			m.credential_type if hasattr(m, "credential_type") else m.get("credential_type", "")
+		) or "api_key"
+		if cred != "api_key":
+			continue
+		val = _get_password(m, "api_key")
+		if val:
+			provider = (m.provider if hasattr(m, "provider") else m.get("provider", "")) or ""
+			keys[normalize_provider(provider)] = val
+	return keys
+
+
 # ---------------------------------------------------------------------------
 # Wire-time-only provider collapsing (build_pool_payload). Distinct from
 # normalize_provider(): a provider id can be first-class in STORAGE (so the

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -128,6 +128,15 @@ def stored_api_keys_by_provider(models) -> dict:
 	one winning, which is exactly the key both of them will hold after the
 	next save. Blank keys never enter the map, so a half-filled row cannot
 	mask a working credential.
+
+	The local holding a decrypted key is called ``secret`` ON PURPOSE. Frappe's
+	``get_traceback(with_context=True)`` dumps every frame's locals into the
+	Error Log and redacts them by NAME against a fixed blocklist (password,
+	passwd, secret, token, key, pwd). ``_get_password`` re-raises a genuine
+	decryption failure, so if one row's ciphertext is corrupt this frame is on
+	the traceback while the local still holds the PREVIOUS row's working key.
+	Named ``val`` that key is written to the log in cleartext; named ``secret``
+	it is redacted. ``keys`` is already covered by "key". Do not rename either.
 	"""
 	keys: dict = {}
 	for m in models or []:
@@ -136,10 +145,10 @@ def stored_api_keys_by_provider(models) -> dict:
 		) or "api_key"
 		if cred != "api_key":
 			continue
-		val = _get_password(m, "api_key")
-		if val:
+		secret = _get_password(m, "api_key")
+		if secret:
 			provider = (m.provider if hasattr(m, "provider") else m.get("provider", "")) or ""
-			keys[normalize_provider(provider)] = val
+			keys[normalize_provider(provider)] = secret
 	return keys
 
 

--- a/jarvis/llm_key_probe.py
+++ b/jarvis/llm_key_probe.py
@@ -13,7 +13,7 @@ This probe surfaces exactly that message instead of swallowing it.
 
 Shape: synchronous, no persistence, gated, does live HTTP, and NEVER raises
 for a failed check - it always returns a structured
-``{"ok": bool, "checks": [{"check", "ok", "detail"}, ...]}``.
+``{"ok": bool, "verdict": str, "checks": [{"check", "ok", "detail"}, ...]}``.
 
 NOT the same thing as ``PUT /v1/containers/{name}/llm-pool``
 (``jarvis.admin_client.post_update_llm_pool``): that is a MUTATING apply on
@@ -21,10 +21,18 @@ the fleet-agent that rotates secrets, rewrites the tenant's openclaw.json and
 can restart the container (10-30s chat outage). This probe never writes
 Jarvis Settings, never calls admin_client, and never touches the fleet or a
 container - it is a single side-effect-free HTTP round-trip straight from
-THIS bench to the provider's own API, using whatever
-provider/base_url/model/api_key the customer has typed into the panel so far
-(nothing here is persisted, and nothing here may call the mutating pool
-apply).
+THIS bench to the provider's own API, using the provider/base_url/model the
+customer has typed into the panel so far (nothing here is persisted, and
+nothing here may call the mutating pool apply).
+
+STORED KEYS (#679): the key is the one exception to "only what is typed".
+``test_llm_api_key`` will, on explicit request, resolve the saved key for the
+row's provider server-side and probe with it, so that changing ONLY a base
+URL can be tested by a customer who does not have the key to hand - which is
+precisely when a test is worth most. The key is read through
+``pool_serialize.stored_api_keys_by_provider``, the same helper
+``save_llm_pool`` merges with, so Test can never attest to a credential Save
+would not send. It is used in-process and never returned to the browser.
 
 CAVEAT - read before trusting a green check: live tenant chat is actually
 served from INSIDE the tenant's bifrost container, not from this bench. For
@@ -36,6 +44,41 @@ network), this probe cannot confirm reachability from here - see
 render as a disclaimer, never a guarantee. ``test_llm_api_key`` always
 attaches a ``caveat`` string for this reason, whether or not the provider is
 tagged local.
+
+THREE VERDICTS, NOT TWO (#680). That caveat used to be the only hedge, it sat
+underneath a red "Test failed.", and it was routinely disbelieved: a base_url
+only the container can resolve (``http://host.docker.internal:9000/openai/v1``)
+answers HTTP 200 from inside the container and "Could not resolve host" from
+here, so the customer read the red banner and did not click Save. A bench that
+never got a byte back has learned NOTHING about the credential or the endpoint,
+only about its own network, so calling that "failed" was false. ``verdict``
+therefore carries three values::
+
+    pass       - the provider answered 2xx. Real signal.
+    fail       - a definitive rejection: the provider answered non-2xx, or the
+                 input/URL is unusable. The customer must fix something.
+    unverified - this bench could not reach the endpoint at all (DNS, an
+                 address the SSRF guard refuses, or a dead socket). Says
+                 nothing either way; render neutrally, never as a failure.
+
+``ok`` stays strictly ``verdict == "pass"``, so every existing consumer gating
+on it keeps today's strictness - notably the SPA's onboarding "Start chatting"
+gate, which requires a passing probe before it lets a freshly typed key
+through. An endpoint this bench merely could not reach must not unlock a gate
+that a real pass unlocks. The classification comes from
+``LinkFetchError.kind``, set at the raise site, never from matching message
+text.
+
+The honest alternative - probing from inside the container, the network chat
+really uses - was investigated and rejected for now, because no such path
+exists from this plane. ``jarvis_fleet_agent.proxy_probe`` already does the
+right thing (it execs a request inside the tenant's container and even
+distinguishes an inconclusive result from a definitive one), but it runs only
+inside the MUTATING ``PUT /v1/containers/{name}/llm-pool`` apply: after
+secrets are written and the container restarted, which is exactly what a
+pre-save Test must not do. Exposing it standalone needs a new fleet-agent
+route, an admin relay (this bench holds no fleet credentials), and wiring
+here. Three repos, worth doing, but not as a side effect of fixing a banner.
 
 SECURITY: ``base_url`` is customer-supplied, so this is an SSRF vector
 exactly like ``jarvis.chat.link_fetch``'s Personalise link fetch (a prior
@@ -54,7 +97,7 @@ import json
 import frappe
 
 from jarvis.chat import link_fetch
-from jarvis.jarvis.pool_serialize import normalize_provider
+from jarvis.jarvis.pool_serialize import normalize_provider, stored_api_keys_by_provider
 from jarvis.permissions import require_jarvis_admin
 
 _TIMEOUT_S = 15
@@ -77,6 +120,34 @@ LOCAL_PROVIDER_IDS = {"ollama", "vllm"}
 # motivating case.
 _ANTHROPIC_IDS = {"anthropic"}
 _GEMINI_IDS = {"gemini"}
+
+# The three values of the result's `verdict` - see the module docstring.
+VERDICT_PASS = "pass"
+VERDICT_FAIL = "fail"
+VERDICT_UNVERIFIED = "unverified"
+
+# What to tell the customer for each way the bench can fail to reach an
+# endpoint. Each one is a statement about THIS network, never about the key:
+# the same endpoint may well answer from inside the container. Keyed by
+# link_fetch's raise-site classification, so a reworded exception message
+# cannot silently reclassify a result.
+_UNREACHABLE_DETAIL = {
+	link_fetch.ERR_UNRESOLVED: (
+		"This bench could not resolve that hostname, so nothing was sent. "
+		"An endpoint only your Jarvis container can resolve looks exactly like "
+		"this from here, and so does a typo in the base URL."
+	),
+	link_fetch.ERR_BLOCKED_ADDRESS: (
+		"That address is private, and this bench does not connect to private "
+		"addresses. Your Jarvis container can, so an endpoint on your own "
+		"network can only be confirmed from inside it."
+	),
+	link_fetch.ERR_CONNECT_FAILED: (
+		"This bench could not open a connection to that endpoint, so nothing "
+		"was sent. It may still be reachable from inside your Jarvis container, "
+		"which is where chat runs."
+	),
+}
 
 
 def _check(name: str, ok: bool, detail: str) -> dict:
@@ -182,10 +253,12 @@ def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -
 	SSRF-blocked endpoint, a network error, a provider rejection) comes back
 	as a failed check with a human-readable, key-scrubbed detail.
 
-	Returns ``{"ok": bool, "checks": [...], "provider": <canonical id>,
-	"local_endpoint": bool}``. See the module docstring for the CAVEAT
-	(probed from the bench, not the tenant's container) and the SECURITY
-	notes (SSRF guard via link_fetch, key scrubbing)."""
+	Returns ``{"ok": bool, "verdict": str, "checks": [...], "provider":
+	<canonical id>, "local_endpoint": bool}``, where ``ok`` is exactly
+	``verdict == "pass"``. See the module docstring for the three verdicts and
+	why an unreachable endpoint is NOT a failure (#680), for the CAVEAT (probed
+	from the bench, not the tenant's container) and for the SECURITY notes (SSRF
+	guard via link_fetch, key scrubbing)."""
 	checks: list[dict] = []
 	provider_id = normalize_provider(provider)
 	is_local = provider_id in LOCAL_PROVIDER_IDS
@@ -194,18 +267,26 @@ def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -
 	api_key = (api_key or "").strip()
 	base = (base_url or "").strip()
 
-	def _done(ok: bool) -> dict:
-		return {"ok": ok, "checks": checks, "provider": provider_id, "local_endpoint": is_local}
+	def _done(verdict: str) -> dict:
+		return {
+			"ok": verdict == VERDICT_PASS,
+			"verdict": verdict,
+			"checks": checks,
+			"provider": provider_id,
+			"local_endpoint": is_local,
+		}
 
+	# Missing input is a genuine fail, not "unverified": there is something
+	# concrete for the customer to fix, and nothing was left uncertain.
 	if not model:
 		checks.append(_check("input", False, "Enter a model id before testing."))
-		return _done(False)
+		return _done(VERDICT_FAIL)
 	if not api_key:
 		checks.append(_check("input", False, "Enter an API key before testing."))
-		return _done(False)
+		return _done(VERDICT_FAIL)
 	if not base:
 		checks.append(_check("input", False, "Enter a base URL before testing."))
-		return _done(False)
+		return _done(VERDICT_FAIL)
 
 	kind = _provider_kind(provider_id)
 	req = _build_request(kind, base, model, api_key)
@@ -220,15 +301,16 @@ def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -
 			max_bytes=_MAX_BODY_BYTES,
 		)
 	except link_fetch.LinkFetchError as exc:
-		detail = _scrub(str(exc), api_key)
-		if is_local:
-			detail = (
-				f"Can't reach this endpoint from the bench ({detail}). Local/private "
-				"endpoints are only reachable from inside your Jarvis container, so "
-				"this can't be verified from here."
-			)
-		checks.append(_check("probe_request", False, detail))
-		return _done(False)
+		reason = _scrub(str(exc), api_key)
+		kind = getattr(exc, "kind", link_fetch.ERR_RESPONSE)
+		# Never got a byte back. That is a fact about this bench's network and
+		# nothing else, so it must not be dressed up as a verdict on the key or
+		# the endpoint - see #680 and the module docstring's three verdicts.
+		if kind in link_fetch.UNREACHABLE_KINDS:
+			checks.append(_check("probe_request", False, _UNREACHABLE_DETAIL[kind]))
+			return _done(VERDICT_UNVERIFIED)
+		checks.append(_check("probe_request", False, reason))
+		return _done(VERDICT_FAIL)
 
 	if 200 <= status < 300:
 		checks.append(
@@ -238,7 +320,7 @@ def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -
 				f"{provider_id or 'The provider'} accepted a 1-token test request (HTTP {status}).",
 			)
 		)
-		return _done(True)
+		return _done(VERDICT_PASS)
 
 	# `body` came back from whatever the customer-supplied base_url points to - a
 	# hostile or merely malformed response must never turn "the test failed" into
@@ -258,11 +340,35 @@ def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -
 			f"HTTP {status}: {message}" if message else f"HTTP {status} with no error detail.",
 		)
 	)
-	return _done(False)
+	return _done(VERDICT_FAIL)
+
+
+def _stored_api_key(provider: str) -> str:
+	"""The saved key ``save_llm_pool`` would merge into a row on this provider,
+	decrypted, or "" when there is none.
+
+	Deliberately keyed on provider alone and deliberately NOT a lookup of its
+	own: it is the same ``stored_api_keys_by_provider`` snapshot the save path
+	merges from (see that helper for why per-row identity is not available and
+	would not help). Probing anything else would let a green Test attest to a
+	credential Save then declines to send.
+
+	Never raises. ``_get_password`` propagates a genuine decryption failure,
+	which on the save path is right (better to fail than to wipe a credential
+	with a blank), but here it would turn a Test click into a 500. Degrading to
+	"" instead lands the customer on the honest "no saved key" check below."""
+	try:
+		settings = frappe.get_single("Jarvis Settings")
+		return stored_api_keys_by_provider(settings.get("models")).get(normalize_provider(provider), "")
+	except Exception:
+		frappe.log_error(title="llm_key_probe: stored key lookup failed")
+		return ""
 
 
 @frappe.whitelist()
-def test_llm_api_key(provider: str, model: str, api_key: str = "", base_url: str = "") -> dict:
+def test_llm_api_key(
+	provider: str, model: str, api_key: str = "", base_url: str = "", use_stored_key=0
+) -> dict:
 	"""UI 'Test' button on an API-key LLM pool model row, run BEFORE save.
 
 	Jarvis Admin / System Manager - the same gate ``jarvis.onboarding.
@@ -270,18 +376,62 @@ def test_llm_api_key(provider: str, model: str, api_key: str = "", base_url: str
 	``editable`` prop is ``isSM || is_jarvis_admin``), so anyone who can edit
 	a row can also test it.
 
-	Operates ONLY on the values passed in (whatever is currently typed into
-	the panel) - it never reads or writes the stored, encrypted key on an
-	existing row, and never persists anything or touches the fleet/container.
-	See the module docstring for why this must never call the mutating
-	``/llm-pool`` apply."""
+	Persists nothing and never touches the fleet/container; see the module
+	docstring for why this must never call the mutating ``/llm-pool`` apply.
+
+	``use_stored_key`` opts into probing the SAVED key for ``provider`` instead
+	of a typed one (#679), so that a customer who changes only the base URL can
+	test it without digging out a credential they pasted months ago - the case
+	where testing before saving is worth the most. A typed ``api_key`` always
+	wins, matching the save-path merge, so a stale flag from an old client
+	cannot override what the customer just entered. This grants no new reach:
+	the same role can already Save, which sends that same stored key to any
+	base URL it likes. The resolved key stays server-side, is scrubbed out of
+	provider error bodies like any other, and is never part of the response."""
 	require_jarvis_admin()
+	api_key = (api_key or "").strip()
+	if not api_key and frappe.utils.cint(use_stored_key):
+		api_key = _stored_api_key(provider)
+		if not api_key:
+			# The row claimed a saved key and there is none under this provider:
+			# it was removed, or the provider was switched since the panel loaded.
+			# Say which, rather than the generic "enter an API key".
+			return {
+				"ok": False,
+				"verdict": VERDICT_FAIL,
+				"checks": [
+					_check(
+						"input",
+						False,
+						"No saved key found for this provider. Enter the API key to test it.",
+					)
+				],
+				"provider": normalize_provider(provider),
+				"local_endpoint": normalize_provider(provider) in LOCAL_PROVIDER_IDS,
+				"caveat": "",
+			}
 	result = probe_api_key(provider, model, api_key, base_url)
-	result["caveat"] = (
-		"Tested from the bench, not from your Jarvis container. Local/private "
-		"endpoints (ollama, vllm) can only be confirmed from inside the container."
-		if result.get("local_endpoint")
-		else "Tested from the bench's network. Live chat runs from inside your Jarvis "
+	result["caveat"] = _caveat_for(result)
+	return result
+
+
+def _caveat_for(result: dict) -> str:
+	"""The small print under the Test result. It has to say something different
+	once the verdict is ``unverified``: the old text ("tested from the bench's
+	network") describes a test that in that case never actually happened."""
+	if result.get("verdict") == VERDICT_UNVERIFIED:
+		return (
+			"Nothing reached the provider, so this is not a verdict on your key. "
+			"Live chat runs from inside your Jarvis container, which reaches "
+			"private and container-only endpoints that this bench cannot. If the "
+			"URL is right for the container, saving is still the way to apply it."
+		)
+	if result.get("local_endpoint"):
+		return (
+			"Tested from the bench, not from your Jarvis container. Local/private "
+			"endpoints (ollama, vllm) can only be confirmed from inside the container."
+		)
+	return (
+		"Tested from the bench's network. Live chat runs from inside your Jarvis "
 		"container - for a public provider these agree."
 	)
-	return result

--- a/jarvis/llm_key_probe.py
+++ b/jarvis/llm_key_probe.py
@@ -361,7 +361,16 @@ def _stored_api_key(provider: str) -> str:
 		settings = frappe.get_single("Jarvis Settings")
 		return stored_api_keys_by_provider(settings.get("models")).get(normalize_provider(provider), "")
 	except Exception:
-		frappe.log_error(title="llm_key_probe: stored key lookup failed")
+		# An explicit message is load-bearing, not tidiness. frappe.log_error with
+		# only a title falls back to get_traceback(with_context=True), which dumps
+		# every frame's LOCALS into the Error Log - and the frame that raised here
+		# is the one holding a decrypted key. Passing a message keeps the whole
+		# variable dump out of the log, which is what this module's "never in
+		# frappe.log_error" promise actually requires.
+		frappe.log_error(
+			title="llm_key_probe: stored key lookup failed",
+			message="Could not read the stored API key for this provider. Details omitted on purpose.",
+		)
 		return ""
 
 

--- a/jarvis/llm_key_probe.py
+++ b/jarvis/llm_key_probe.py
@@ -367,7 +367,7 @@ def _stored_api_key(provider: str) -> str:
 
 @frappe.whitelist()
 def test_llm_api_key(
-	provider: str, model: str, api_key: str = "", base_url: str = "", use_stored_key=0
+	provider: str, model: str, api_key: str = "", base_url: str = "", use_stored_key: int = 0
 ) -> dict:
 	"""UI 'Test' button on an API-key LLM pool model row, run BEFORE save.
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -452,9 +452,9 @@ def save_llm_pool(
 			raise frappe.ValidationError(f"unknown preset '{preset}'")
 
 	from jarvis.jarvis.pool_serialize import (
-		_get_password,
 		_model_accounts,
 		normalize_provider,
+		stored_api_keys_by_provider,
 	)
 	from jarvis.oauth import pending_capture
 
@@ -471,14 +471,16 @@ def save_llm_pool(
 	# model id or reordering) does not silently wipe a previously-working
 	# credential. Keyed by canonical provider (api keys are per-vendor) and by
 	# account_ref (server-stable) respectively.
-	prior_api_keys = {}
+	#
+	# The api-key half is stored_api_keys_by_provider() rather than a loop local
+	# to this function because jarvis.llm_key_probe's Test button now resolves a
+	# stored key through the SAME helper (#679). Test has to probe the credential
+	# this merge would ship, or a green Test would be attesting to a key Save
+	# never sends.
+	prior_api_keys = stored_api_keys_by_provider(s.get("models"))
 	prior_blobs = {}
 	for pm in s.get("models") or []:
-		if (pm.credential_type or "api_key") == "api_key":
-			pk = _get_password(pm, "api_key")
-			if pk:
-				prior_api_keys[normalize_provider(pm.provider)] = pk
-		else:
+		if (pm.credential_type or "api_key") != "api_key":
 			for a in _model_accounts(pm):
 				ref = (a.get("account_ref") if hasattr(a, "get") else "") or ""
 				blob = (a.get("oauth_blob") if hasattr(a, "get") else "") or ""

--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -8,11 +8,20 @@ socket.getaddrinfo - never the guard itself), api_key scrubbing out of a
 provider error body, the local-provider (ollama/vllm) disclaimer, and the
 System-Manager/Jarvis-Admin gate on the whitelisted endpoint.
 
+Plus the two defects the "Test" button shipped with:
+
+  #680 - an endpoint this bench cannot reach is "unverified", not "failed".
+         Driven through the real guard, because the claim is about which
+         failures the network layer actually produces.
+  #679 - a saved key can be probed without retyping it. Driven through a real
+         encrypted doc save, because the claim is that the SERVER reads it.
+
 Run: bench --site <site> run-tests --module jarvis.tests.test_llm_key_probe
 """
 
 from __future__ import annotations
 
+import json
 from unittest import mock
 
 import frappe
@@ -20,6 +29,8 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis import llm_key_probe
 from jarvis.chat import link_fetch
+from jarvis.jarvis.pool_serialize import stored_api_keys_by_provider
+from jarvis.tests.test_unified_llm_config import _RT3SettingsTestCase
 
 
 def _addrinfo(ip: str):
@@ -187,33 +198,44 @@ class TestProbeApiKey(FrappeTestCase):
 		self.assertNotIn("sk-super-secret-999", detail)
 		self.assertIn("***", detail)
 
-	def test_ssrf_blocked_endpoint_gets_a_locality_aware_message_for_local_providers(self):
+	def test_ssrf_blocked_endpoint_is_unverified_for_local_providers(self):
+		# Was asserted as a plain failure. An address the guard refuses is one the
+		# bench declined to dial, so it is "we could not check", not "your key is
+		# bad" - and the wording has to point at the container, which CAN dial it.
 		with mock.patch.object(
 			link_fetch,
 			"request_pinned",
-			side_effect=link_fetch.LinkFetchError("Host resolves to a disallowed address"),
+			side_effect=link_fetch.LinkFetchError(
+				"Host resolves to a disallowed address", kind=link_fetch.ERR_BLOCKED_ADDRESS
+			),
 		):
 			result = llm_key_probe.probe_api_key(
 				"Ollama (local)", "llama3", "unused", "http://127.0.0.1:11434/v1"
 			)
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_UNVERIFIED)
 		self.assertFalse(result["ok"])
 		self.assertTrue(result["local_endpoint"])
-		detail = result["checks"][-1]["detail"]
-		self.assertIn("container", detail)
+		self.assertIn("container", result["checks"][-1]["detail"])
 
-	def test_ssrf_blocked_endpoint_for_a_non_local_provider_still_fails_cleanly(self):
+	def test_ssrf_blocked_endpoint_is_unverified_for_a_non_local_provider_too(self):
+		# The old assertion here was assertNotIn("container", ...): the container
+		# hedge used to be reserved for ollama/vllm. That was the bug - the network
+		# gap is a property of the ADDRESS, not of the provider id, and a customer
+		# pointing OpenAI-Compatible at their own LAN hits exactly the same wall.
 		with mock.patch.object(
 			link_fetch,
 			"request_pinned",
-			side_effect=link_fetch.LinkFetchError("Host resolves to a disallowed address"),
+			side_effect=link_fetch.LinkFetchError(
+				"Host resolves to a disallowed address", kind=link_fetch.ERR_BLOCKED_ADDRESS
+			),
 		):
 			result = llm_key_probe.probe_api_key(
 				"OpenAI-Compatible", "x", "sk-x", "http://169.254.169.254/v1"
 			)
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_UNVERIFIED)
 		self.assertFalse(result["ok"])
 		self.assertFalse(result["local_endpoint"])
-		# Non-local providers don't get the ollama/vllm-specific container wording.
-		self.assertNotIn("container", result["checks"][-1]["detail"])
+		self.assertIn("container", result["checks"][-1]["detail"])
 
 
 class TestProbeApiKeySsrfEndToEnd(FrappeTestCase):
@@ -277,3 +299,259 @@ class TestTestLlmApiKeyGating(FrappeTestCase):
 				"Ollama (local)", "llama3", "unused", "http://host.docker.internal:11434/v1"
 			)
 		self.assertIn("container", result["caveat"])
+
+
+class TestUnreachableIsNotAFailure(FrappeTestCase):
+	"""#680: a base_url only the tenant's container can reach answers HTTP 200
+	from inside the container and nothing at all from this bench. Reporting that
+	as "Test failed." told the customer their working configuration was broken,
+	and they did not click Save.
+
+	Every case here drives the REAL jarvis.chat.link_fetch guard, mocking only
+	socket.getaddrinfo / the socket open - never probe_api_key's own classifier,
+	and never request_pinned. That matters: the whole claim is about WHICH
+	failures the network layer really produces, so a test that hands the probe a
+	pre-canned kind would be asserting its own fixture.
+	"""
+
+	def test_a_host_this_bench_cannot_resolve_is_unverified(self):
+		# The literal #680 repro: host.docker.internal has no answer out here.
+		with mock.patch("socket.getaddrinfo", side_effect=OSError("nxdomain")):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "gpt-4o", "sk-x", "http://host.docker.internal:9000/openai/v1"
+			)
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_UNVERIFIED)
+		self.assertFalse(result["ok"])
+		self.assertIn("container", result["checks"][-1]["detail"])
+
+	def test_a_private_address_is_unverified(self):
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PRIVATE_IP)):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "gpt-4o", "sk-x", "http://llm.internal/v1"
+			)
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_UNVERIFIED)
+		self.assertIn("container", result["checks"][-1]["detail"])
+
+	def test_a_dead_socket_is_unverified(self):
+		# Resolves fine and publicly, but nothing is listening. Still no answer,
+		# so still nothing learned about the credential.
+		with (
+			mock.patch("socket.getaddrinfo", return_value=_addrinfo(PUBLIC_IP)),
+			mock.patch.object(link_fetch, "_open_pinned", side_effect=OSError("connection refused")),
+		):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "gpt-4o", "sk-x", "https://api.example.com/v1"
+			)
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_UNVERIFIED)
+
+	def test_a_provider_that_answered_and_said_no_is_still_a_real_failure(self):
+		"""The guard on all of the above. Softening a genuine 401 into "could not
+		check" would trade one lie for a worse one - the customer would never be
+		told their key is wrong."""
+		body = b'{"error":{"message":"Incorrect API key provided."}}'
+		with mock.patch.object(link_fetch, "request_pinned", return_value=(401, {}, body)):
+			result = llm_key_probe.probe_api_key("OpenAI", "gpt-4o", "sk-bad", "https://api.openai.com/v1")
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_FAIL)
+		self.assertFalse(result["ok"])
+		self.assertIn("Incorrect API key", result["checks"][-1]["detail"])
+
+	def test_an_unusable_url_is_a_real_failure_not_a_network_excuse(self):
+		# There IS something concrete for the customer to fix here, so it stays red.
+		result = llm_key_probe.probe_api_key("OpenAI-Compatible", "gpt-4o", "sk-x", "file:///etc/passwd")
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_FAIL)
+
+	def test_a_pass_is_still_a_pass(self):
+		with mock.patch.object(link_fetch, "request_pinned", return_value=(200, {}, b"{}")):
+			result = llm_key_probe.probe_api_key("OpenAI", "gpt-4o", "sk-x", "https://api.openai.com/v1")
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_PASS)
+		self.assertTrue(result["ok"])
+
+	def test_the_caveat_stops_claiming_a_test_that_never_ran(self):
+		"""The old caveat said "Tested from the bench's network". When nothing was
+		reachable, no test happened at all, and that sentence was the only thing
+		under a red banner trying to explain it."""
+		frappe.set_user("Administrator")
+		with mock.patch("socket.getaddrinfo", side_effect=OSError("nxdomain")):
+			result = llm_key_probe.test_llm_api_key(
+				"OpenAI-Compatible", "gpt-4o", "sk-x", "http://host.docker.internal:9000/openai/v1"
+			)
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_UNVERIFIED)
+		self.assertNotIn("Tested from", result["caveat"])
+		self.assertIn("not a verdict on your key", result["caveat"])
+
+
+class TestLinkFetchErrorKinds(FrappeTestCase):
+	"""The classification llm_key_probe branches on is set at link_fetch's raise
+	sites. Asserted here directly so a reworded message can never silently move a
+	failure between "definitive" and "could not reach"."""
+
+	def test_unresolvable_host_raises_the_unresolved_kind(self):
+		with mock.patch("socket.getaddrinfo", side_effect=OSError("nxdomain")):
+			with self.assertRaises(link_fetch.LinkFetchError) as cm:
+				link_fetch.request_pinned("http://nope.invalid/v1", method="POST")
+		self.assertEqual(cm.exception.kind, link_fetch.ERR_UNRESOLVED)
+
+	def test_private_address_raises_the_blocked_kind(self):
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PRIVATE_IP)):
+			with self.assertRaises(link_fetch.LinkFetchError) as cm:
+				link_fetch.request_pinned("http://internal.example.com/v1", method="POST")
+		self.assertEqual(cm.exception.kind, link_fetch.ERR_BLOCKED_ADDRESS)
+
+	def test_bad_scheme_raises_the_invalid_url_kind(self):
+		with self.assertRaises(link_fetch.LinkFetchError) as cm:
+			link_fetch.request_pinned("file:///etc/passwd")
+		self.assertEqual(cm.exception.kind, link_fetch.ERR_INVALID_URL)
+
+	def test_an_unclassified_error_is_treated_as_definitive(self):
+		# Fail closed: anything raised without an explicit kind must NOT be
+		# softened into "we could not check".
+		self.assertEqual(link_fetch.LinkFetchError("boom").kind, link_fetch.ERR_RESPONSE)
+		self.assertNotIn(link_fetch.ERR_RESPONSE, link_fetch.UNREACHABLE_KINDS)
+
+
+class TestStoredApiKeysByProvider(FrappeTestCase):
+	"""The single lookup shared by save_llm_pool's secret merge and the Test
+	button (#679). Pure, so exercised on plain rows."""
+
+	def _row(self, provider, api_key, credential_type="api_key"):
+		return frappe._dict({"provider": provider, "api_key": api_key, "credential_type": credential_type})
+
+	def test_keys_are_canonicalised_by_provider(self):
+		keys = stored_api_keys_by_provider([self._row("OpenAI", "sk-1")])
+		self.assertEqual(keys, {"openai": "sk-1"})
+
+	def test_a_blank_key_never_masks_a_real_one(self):
+		# A half-filled second row on the same vendor must not erase the credential.
+		keys = stored_api_keys_by_provider([self._row("openai", "sk-1"), self._row("openai", "")])
+		self.assertEqual(keys["openai"], "sk-1")
+
+	def test_two_rows_on_one_provider_collapse_last_non_empty_wins(self):
+		# Exactly what save_llm_pool's merge does, so Test cannot probe a key the
+		# row will not hold after the next save.
+		keys = stored_api_keys_by_provider([self._row("openai", "sk-1"), self._row("openai", "sk-2")])
+		self.assertEqual(keys["openai"], "sk-2")
+
+	def test_subscription_rows_carry_no_api_key(self):
+		keys = stored_api_keys_by_provider(
+			[self._row("openai", "should-be-ignored", credential_type="subscription")]
+		)
+		self.assertEqual(keys, {})
+
+
+class TestProbeWithAStoredKey(_RT3SettingsTestCase):
+	"""#679: with a key already saved, the Test button was disabled and read
+	"Re-enter the key to test it", so changing ONLY a base URL - the edit where a
+	test is worth the most - could not be validated at all unless the customer
+	still had a credential they may have pasted months ago.
+
+	The key here is written through a real doc save, so it is genuinely encrypted
+	into __Auth and genuinely masked in memory afterwards: the point of the fix is
+	that the SERVER can read it, and a fixture that just held the plaintext on the
+	row would prove nothing about that.
+	"""
+
+	STORED = "sk-stored-abcdef123456"
+
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		# Frappe caches a Single; a stale one here would serve the previous test's
+		# models table and quietly decide what this probe finds.
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		settings = frappe.get_single("Jarvis Settings")
+		row = frappe.new_doc("Jarvis LLM Pool Model")
+		row.provider = "openai"
+		row.model = "gpt-4o"
+		row.tier = "strong"
+		row.order = 0
+		row.enabled = 1
+		row.credential_type = "api_key"
+		row.api_key = self.STORED
+		row.base_url = "https://api.openai.com/v1"
+		settings.append("models", row)
+		with (
+			mock.patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
+			mock.patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "creds_update"}),
+		):
+			settings.save()
+		frappe.db.commit()
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def _probe(self, **kw):
+		"""Run the real whitelisted endpoint, capturing the request the probe
+		would have put on the wire."""
+		captured = {}
+
+		def _fake(url, **rq):
+			captured["url"] = url
+			captured["headers"] = rq.get("headers") or {}
+			return (200, {}, b"{}")
+
+		args = {
+			"provider": "OpenAI",
+			"model": "gpt-4o",
+			"api_key": "",
+			"base_url": "https://gateway.example.com/v1",
+		}
+		args.update(kw)
+		with mock.patch.object(link_fetch, "request_pinned", side_effect=_fake):
+			result = llm_key_probe.test_llm_api_key(**args)
+		return result, captured
+
+	def test_the_stored_key_is_really_encrypted_at_rest(self):
+		# Guards the fixture itself: if the row still held plaintext in memory,
+		# every assertion below would pass without the server decrypting anything.
+		reloaded = frappe.get_single("Jarvis Settings")
+		self.assertNotEqual(reloaded.models[0].api_key, self.STORED)
+		self.assertEqual(reloaded.models[0].get_password("api_key"), self.STORED)
+
+	def test_a_new_base_url_is_probed_with_the_saved_key(self):
+		"""The #679 scenario end to end: nothing typed into the key field, a new
+		base URL, and the request still carries the real credential."""
+		result, captured = self._probe(use_stored_key=1)
+		self.assertTrue(result["ok"])
+		self.assertEqual(captured["headers"]["Authorization"], f"Bearer {self.STORED}")
+		self.assertTrue(captured["url"].startswith("https://gateway.example.com/v1"))
+
+	def test_the_key_never_travels_back_to_the_browser(self):
+		result, _ = self._probe(use_stored_key=1)
+		self.assertNotIn(self.STORED, json.dumps(result))
+
+	def test_the_probe_uses_the_same_key_the_save_merge_would(self):
+		"""If these two ever diverge, a green Test attests to a credential Save
+		does not send. They share one helper precisely so they cannot."""
+		_, captured = self._probe(use_stored_key=1)
+		merged = stored_api_keys_by_provider(frappe.get_single("Jarvis Settings").get("models"))
+		self.assertEqual(captured["headers"]["Authorization"], f"Bearer {merged['openai']}")
+
+	def test_a_typed_key_beats_the_stored_one(self):
+		# A stale flag from an old client must never override what was just typed.
+		_, captured = self._probe(api_key="sk-freshly-typed", use_stored_key=1)
+		self.assertEqual(captured["headers"]["Authorization"], "Bearer sk-freshly-typed")
+
+	def test_the_stored_key_is_opt_in(self):
+		# Without the flag the endpoint behaves exactly as before: a blank key is
+		# a blank key. The stored credential is never reached for implicitly.
+		result, captured = self._probe()
+		self.assertFalse(result["ok"])
+		self.assertEqual(captured, {})
+		self.assertIn("Enter an API key", result["checks"][-1]["detail"])
+
+	def test_a_provider_with_no_saved_key_says_exactly_that(self):
+		"""The degenerate case: the row claimed a saved key and there is none under
+		this provider - it was removed, or the provider was switched since the panel
+		loaded. "Enter an API key" would be true but would not explain anything."""
+		result, captured = self._probe(provider="Anthropic", use_stored_key=1)
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["verdict"], llm_key_probe.VERDICT_FAIL)
+		self.assertEqual(captured, {})
+		self.assertIn("No saved key found", result["checks"][-1]["detail"])
+
+	def test_guest_cannot_reach_a_stored_key(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			llm_key_probe.test_llm_api_key("OpenAI", "gpt-4o", "", "https://x.example.com/v1", 1)

--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -555,3 +555,64 @@ class TestProbeWithAStoredKey(_RT3SettingsTestCase):
 		frappe.set_user("Guest")
 		with self.assertRaises(frappe.PermissionError):
 			llm_key_probe.test_llm_api_key("OpenAI", "gpt-4o", "", "https://x.example.com/v1", 1)
+
+
+class TestStoredKeyNeverReachesTheErrorLog(FrappeTestCase):
+	"""A decryption failure on one row must not write ANOTHER row's working key
+	into the Error Log in cleartext.
+
+	frappe.log_error with only a title falls back to get_traceback(with_context=
+	True), which dumps every frame's locals and redacts them by NAME against a
+	fixed blocklist (password, passwd, secret, token, key, pwd). Both halves of
+	the fix are asserted here because either one alone leaves the hole open: the
+	local in stored_api_keys_by_provider must be named to match that blocklist,
+	and _stored_api_key must pass a message so no variable dump is captured at
+	all. This is the module's documented "never in frappe.log_error" invariant.
+	"""
+
+	def test_a_decrypt_failure_logs_no_variable_dump_and_no_key(self):
+		leaked = "sk-other-row-still-working-999"
+		good = frappe._dict({"provider": "openai", "api_key": leaked, "credential_type": "api_key"})
+		boom = frappe._dict({"provider": "anthropic", "api_key": "x", "credential_type": "api_key"})
+
+		def _explode(doc, fieldname, raise_exception=False):
+			# First row decrypts (so the loop local holds a real key), second blows
+			# up - the exact ordering that put a working credential on the traceback.
+			if doc is boom:
+				raise ValueError("decryption failed")
+			return leaked
+
+		class _Settings:
+			def get(self, _f):
+				return [good, boom]
+
+		calls = []
+		with (
+			mock.patch("jarvis.jarvis.pool_serialize._get_password", side_effect=_explode),
+			mock.patch.object(frappe, "get_single", return_value=_Settings()),
+			mock.patch.object(frappe, "log_error", side_effect=lambda **kw: calls.append(kw)),
+		):
+			self.assertEqual(llm_key_probe._stored_api_key("Anthropic"), "")
+
+		self.assertEqual(len(calls), 1)
+		# A message must be supplied, or Frappe captures the locals-bearing traceback.
+		self.assertTrue(calls[0].get("message"))
+		self.assertNotIn(leaked, json.dumps(calls[0]))
+
+	def test_the_decrypted_local_is_named_to_match_frappes_blocklist(self):
+		"""Belt and braces on the above: even if some other caller lets this frame
+		reach Frappe's global unhandled-exception logger, the local must redact."""
+		import inspect
+
+		from jarvis.jarvis import pool_serialize
+
+		src = inspect.getsource(pool_serialize.stored_api_keys_by_provider)
+		blocklist = ("password", "passwd", "secret", "token", "key", "pwd")
+		assigned = [ln.strip().split("=")[0].strip() for ln in src.splitlines() if "_get_password(" in ln]
+		self.assertTrue(assigned, "could not find the decrypt assignment")
+		for name in assigned:
+			self.assertTrue(
+				any(b in name for b in blocklist),
+				f"local {name!r} holding a decrypted key does not match Frappe's "
+				f"traceback blocklist {blocklist}, so it would log in cleartext",
+			)


### PR DESCRIPTION
## Summary

Test on Settings > AI models now works on a saved model without retyping the key, and stops showing a red failure for an endpoint only your Jarvis container can reach. Same code path, so one PR.

**#679** Changing just a base URL was untestable: the button read "Re-enter the key to test it". The server resolves the saved key itself now, through `save_llm_pool`'s own secret merge, extracted and shared so Test cannot attest to a credential Save would not send. The key never reaches the browser in either direction, and a typed key still wins. No new reach: this role can already Save, which sends that same stored key to any URL it likes.

**#680** Results carry `pass` / `fail` / `unverified`. A DNS failure, a guard-refused address or a dead socket all mean the bench never got a byte back and learned nothing about the key, so they render amber as "Could not test from here." A provider that answered 401 is still red. `ok` stays `verdict == "pass"`, so the onboarding gate keeps today's strictness.

Probing from inside the container would be the stronger fix, but no path exists from this plane, so that is follow-up work rather than something smuggled in here.

Fixes #679
Fixes #680

<details>
<summary>Root cause, the #680 design decision, and test evidence</summary>

### #680: why advisory rather than a container-side probe

`probe_api_key` returned a bare ok/not-ok, so the three ways `link_fetch` can fail to reach an endpoint rendered identically to a provider answering 401. `http://host.docker.internal:9000/openai/v1` answers HTTP 200 from inside the container and fails to resolve from the bench, so a working configuration read as broken and customers did not click Save.

Probing from the network chat actually uses was investigated first and rejected on evidence:

- `AgentSession` exposes only session/chat/agent RPCs. Expressing a probe as an agent turn is circular, since the probe exists precisely for when the LLM config may be broken.
- `admin_client` has no non-mutating call that makes the container issue an outbound request.
- `jarvis_fleet_agent.proxy_probe` already does exactly the right thing, and already distinguishes an inconclusive result from a definitive one, which is the in-house precedent for the tri-state here. But it runs only inside the MUTATING `PUT /v1/containers/{name}/llm-pool` apply: after secrets are written and the container restarted, which a pre-save Test must never do.
- Exposing it standalone needs a fleet-agent route, an admin relay (this bench holds no fleet credentials) and wiring here. Three repos.

So the classification is structural, not cosmetic: a new `LinkFetchError.kind` set at each raise site, never matched from message text. `unresolved`, `blocked_address` and `connect_failed` become `unverified`; everything else stays a definitive verdict, and an unclassified error fails closed as definitive.

Also widens the container hedge from ollama/vllm to any unreachable address, because the network gap belongs to the address and not the provider id, and lets the status line wrap, since a truncated explanation is the same dead end #680 is about.

### #679: which key, and why keyed on provider

`testBlockedReason` returned "Re-enter the key to test it" whenever a row had a stored key and no typed one. `test_llm_api_key` takes `use_stored_key` now and resolves the credential server side.

The lookup is `stored_api_keys_by_provider`, extracted from `save_llm_pool`'s secret merge and now shared by both callers. That sharing is the point: if Test probed one key and Save shipped another, a green Test would attest to a credential the tenant never receives. It is keyed on provider alone because that is what the merge already does and what the data model holds. Api-key rows have no durable per-row identity on the wire, and a `(provider, model)` lookup would invent a failure mode Save itself does not have.

`testBlockedReason` now says something true per state instead of one string: a new row still says "Enter an API key to test", and switching provider resets `hasKey`, so a stored key belonging to the old provider stops counting.

### Tests, each confirmed failing first

- Frontend, 7 new specs driving the mounted component. 5 fail on the pre-fix component, including `expected 'Re-enter the key to test it' to be ''` and the missing `jv-status-warn`. Full suite 870/870 green.
- Backend `#680` classification, 7 assertions driven through the real `link_fetch` guard with only `socket.getaddrinfo` mocked: 0/7 before, 7/7 after.
- Backend `#679` wiring, 6 assertions: 5 fail before (the endpoint has no such parameter), 6/6 after. The one that passes both ways is the regression guard that a blank key with no flag is still blank.
- Two existing probe tests asserted the old two-state shape and are updated rather than deleted, with the reasoning recorded in place.
- The DB-backed test that the stored key is genuinely encrypted at rest and genuinely decrypted by the server needs a site, so it runs on CI rather than locally.

</details>

## Pre-merge checklist

- [ ] **CI is green**: the `tests` check on this PR passes (never merge on a red check)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
