### PR TITLE
fix(settings): give a member a real connection verdict instead of green

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -469,6 +469,12 @@ export const disconnectSubscription = () => call("jarvis.oauth.api.disconnect");
 // --- LLM Monitor (System-Manager gated server-side). Real Bifrost usage, NOT the getUsage estimate. ---
 export const getLlmUsage = () => call("jarvis.account.get_llm_usage");
 export const getLlmConnectionStatus = () => call("jarvis.account.get_llm_connection_status");
+// The member-tier half of the same badge (jarvis#711). Returns ONLY { state },
+// one of ok / applying / attention / down - no shape, no model or provider
+// names, no profile ids, and no reason for "attention". Any workspace user may
+// call it; an admin uses getLlmConnectionStatus above instead, which is a
+// superset of this verdict.
+export const getLlmConnectionHealth = () => call("jarvis.account.get_llm_connection_health");
 export const getAccount = () => call("jarvis.account.get_account");
 // BILLING plan lifecycle. Not to be confused with disconnectSubscription
 // above, which drops the LLM PROVIDER subscription (ChatGPT/Claude OAuth).

--- a/frontend/src/components/settings/GeneralPane.spec.js
+++ b/frontend/src/components/settings/GeneralPane.spec.js
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * The Settings Status badge, from a MEMBER's seat (jarvis#711).
+ *
+ * The badge used to be a hardcoded green "Connected" for anyone who was not an
+ * admin, whatever the workspace was doing. These tests pin the replacement, and
+ * the one that matters most is the first: a member with no verdict yet - which
+ * is EVERY member for the whole first paint, before any fetch resolves - must
+ * render the neutral state, not green. A future refactor that reintroduces a
+ * green default has to fail here.
+ */
+
+// @/stores/shell reads matchMedia at MODULE level, which runs on import, before
+// any beforeEach could install a stub. Same hoisted shim the other component
+// specs use.
+vi.hoisted(() => {
+	window.matchMedia = (q) => ({
+		matches: false,
+		media: q,
+		onchange: null,
+		addEventListener() {},
+		removeEventListener() {},
+		addListener() {},
+		removeListener() {},
+		dispatchEvent: () => false,
+	});
+});
+
+// frappe-ui's ESM entry does not resolve under vitest. The stubs keep the two
+// props these tests read (Badge's label + theme, Button's label) observable in
+// the DOM instead of only in component internals - the assertions below are
+// about what a member SEES.
+vi.mock("frappe-ui", () => {
+	const passthrough = (name, tag) => ({
+		name,
+		props: ["label", "theme", "variant", "iconLeft", "loading", "disabled", "modelValue"],
+		template: `<${tag} class="stub-${name.toLowerCase()}" :data-theme="theme" :data-label="label"><slot /></${tag}>`,
+	});
+	return {
+		Badge: passthrough("Badge", "span"),
+		Button: passthrough("Button", "button"),
+		Switch: passthrough("Switch", "span"),
+		ErrorMessage: passthrough("ErrorMessage", "span"),
+		toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+		call: vi.fn(),
+	};
+});
+
+const openSettings = vi.fn();
+vi.mock("@/stores/shell", () => ({
+	useShellStore: () => ({
+		chatContext: null,
+		openSettings,
+		activityDetail: false,
+		notifyEnabled: false,
+		notifySupported: false,
+		settingsActions: {},
+		setActivityDetail: vi.fn(),
+		toggleNotify: vi.fn(),
+		syncSettingsFromServer: vi.fn(),
+	}),
+}));
+
+vi.mock("@/composables/useConfirm", () => ({
+	useConfirm: () => ({ confirm: vi.fn() }),
+}));
+
+// Every network call the pane makes on mount. getUsage / getMySettings /
+// workspaceResetState are best-effort in the component and irrelevant here, so
+// they resolve empty; the two connection calls are what each test drives.
+vi.mock("@/api", () => ({
+	getUsage: vi.fn(() => Promise.resolve(null)),
+	getMySettings: vi.fn(() => Promise.resolve({ ok: false })),
+	workspaceResetState: vi.fn(() => Promise.resolve({})),
+	requestWorkspaceReset: vi.fn(() => Promise.resolve({})),
+	clearAllHistory: vi.fn(() => Promise.resolve({})),
+	getLlmConnectionStatus: vi.fn(() => new Promise(() => {})),
+	getLlmConnectionHealth: vi.fn(() => new Promise(() => {})),
+}));
+
+import * as api from "@/api";
+import GeneralPane from "./GeneralPane.vue";
+
+/** The Status row's badge: its label and its theme, as rendered. */
+function badge(w) {
+	const el = w.find(".stub-badge");
+	if (!el.exists()) return { label: "", theme: "" };
+	return { label: el.attributes("data-label") || "", theme: el.attributes("data-theme") || "" };
+}
+
+/** Labels of every Button the pane rendered. */
+function buttonLabels(w) {
+	return w.findAll(".stub-button").map((b) => b.attributes("data-label") || "");
+}
+
+async function mountAs({ admin }) {
+	window.is_system_manager = admin;
+	window.is_jarvis_admin = false;
+	const w = mount(GeneralPane);
+	await flushPromises();
+	return w;
+}
+
+/** A member health fetch that never settles: the real first-paint condition. */
+const PENDING = () => new Promise(() => {});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	api.getUsage.mockImplementation(() => Promise.resolve(null));
+	api.getMySettings.mockImplementation(() => Promise.resolve({ ok: false }));
+	api.workspaceResetState.mockImplementation(() => Promise.resolve({}));
+	api.getLlmConnectionStatus.mockImplementation(PENDING);
+	api.getLlmConnectionHealth.mockImplementation(PENDING);
+});
+
+afterEach(() => {
+	delete window.is_system_manager;
+	delete window.is_jarvis_admin;
+});
+
+describe("GeneralPane Status badge, member seat", () => {
+	// THE regression test for #711. Not "a member with a bad verdict sees red" -
+	// this is the degenerate case production actually starts from: the verdict is
+	// simply not here yet. The old code answered it with green.
+	it("is neutral, never green, before any verdict has arrived", async () => {
+		api.getLlmConnectionHealth.mockImplementation(PENDING);
+		const w = await mountAs({ admin: false });
+		const b = badge(w);
+		expect(b.theme).not.toBe("green");
+		expect(b.label).not.toBe("Connected");
+		expect(b.theme).toBe("gray");
+		expect(b.label).toBe("—");
+	});
+
+	// The other half of "fail closed": a state the SPA has no mapping for must
+	// not fall through to the healthy branch either. A server that grows a fifth
+	// verdict, or a truncated payload, both land here.
+	it.each([
+		["a payload with no state at all", {}],
+		["a null payload", null],
+		["an unrecognised state", { state: "quiescent" }],
+		["an empty state", { state: "" }],
+	])("is neutral, never green, for %s", async (_name, payload) => {
+		api.getLlmConnectionHealth.mockImplementation(() => Promise.resolve(payload));
+		const w = await mountAs({ admin: false });
+		const b = badge(w);
+		expect(b.theme).not.toBe("green");
+		expect(b.label).not.toBe("Connected");
+		expect(b.theme).toBe("gray");
+	});
+
+	it("shows red Needs attention when the workspace is unwell", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() =>
+			Promise.resolve({ state: "attention" })
+		);
+		const w = await mountAs({ admin: false });
+		expect(badge(w)).toEqual({ label: "Needs attention", theme: "red" });
+	});
+
+	it("shows red Not connected when the assistant is not serving", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() => Promise.resolve({ state: "down" }));
+		const w = await mountAs({ admin: false });
+		expect(badge(w)).toEqual({ label: "Not connected", theme: "red" });
+	});
+
+	it("shows blue Applying changes while a save is in flight", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() =>
+			Promise.resolve({ state: "applying" })
+		);
+		const w = await mountAs({ admin: false });
+		expect(badge(w)).toEqual({ label: "Applying changes", theme: "blue" });
+	});
+
+	it("shows green Connected only when the server says ok", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() => Promise.resolve({ state: "ok" }));
+		const w = await mountAs({ admin: false });
+		expect(badge(w)).toEqual({ label: "Connected", theme: "green" });
+	});
+
+	// A failed fetch is not a healthy workspace either, and a member has to be
+	// able to retry it - the same affordance an admin already had.
+	it("falls back to neutral and offers a retry when the fetch fails", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() => Promise.reject(new Error("403")));
+		const w = await mountAs({ admin: false });
+		expect(badge(w).theme).not.toBe("green");
+		expect(w.text()).toContain("Connection status is unavailable right now.");
+		expect(buttonLabels(w)).toContain("Retry");
+	});
+
+	// The member endpoint is the smallest thing that renders the badge; the admin
+	// one returns pool shape, model names and profile ids, so a member must never
+	// reach it. This also pins that the pane does not simply try both.
+	it("never calls the admin connection endpoint", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() => Promise.resolve({ state: "ok" }));
+		await mountAs({ admin: false });
+		expect(api.getLlmConnectionStatus).not.toHaveBeenCalled();
+		expect(api.getLlmConnectionHealth).toHaveBeenCalledTimes(1);
+	});
+
+	// A member has no attention_reason (the server does not send one) and cannot
+	// open the AI models pane: a gated section falls back to General silently, so
+	// the button would look like a dead end. The hint has to stand alone.
+	it("gives an attention hint with no AI models button and no cause", async () => {
+		api.getLlmConnectionHealth.mockImplementation(() =>
+			Promise.resolve({ state: "attention" })
+		);
+		const w = await mountAs({ admin: false });
+		expect(buttonLabels(w)).not.toContain("Open AI models");
+		const text = w.text();
+		expect(text).toContain("Your workspace needs attention.");
+		expect(text).not.toContain("Open AI models");
+		expect(text).not.toContain("subscription");
+	});
+
+	// The disclosure decision, enforced at the surface: whatever is behind
+	// "attention", a member sees one sentence. The server sends no reason, so a
+	// pane that started rendering one would be inventing it.
+	it("renders the same attention copy whatever the server reason would be", async () => {
+		const texts = [];
+		for (const payload of [
+			{ state: "attention" },
+			{ state: "attention", attention_reason: "subscription_unverified" },
+			{ state: "attention", attention_reason: "turn_error" },
+			{ state: "attention", attention_reason: "sync_failed" },
+		]) {
+			api.getLlmConnectionHealth.mockImplementation(() => Promise.resolve(payload));
+			const w = await mountAs({ admin: false });
+			texts.push(w.text());
+		}
+		expect(new Set(texts).size).toBe(1);
+	});
+});
+
+describe("GeneralPane Status badge, admin seat", () => {
+	it("still uses the admin endpoint and its full payload", async () => {
+		api.getLlmConnectionStatus.mockImplementation(() =>
+			Promise.resolve({
+				pool_mode: true,
+				model_count: 3,
+				routing_mode: "failover",
+				sync_status: "ok (pool_update via admin)",
+				proxy_active: true,
+				disconnected: false,
+				health: "ok",
+				attention_reason: "",
+			})
+		);
+		const w = await mountAs({ admin: true });
+		expect(api.getLlmConnectionHealth).not.toHaveBeenCalled();
+		expect(badge(w)).toEqual({ label: "Connected", theme: "green" });
+		expect(w.text()).toContain("3 models");
+	});
+
+	// An admin keeps the cause-specific hint and the button that acts on it -
+	// #710/#714's work is untouched by the member split.
+	it("keeps the per-cause attention hint", async () => {
+		api.getLlmConnectionStatus.mockImplementation(() =>
+			Promise.resolve({ health: "attention", attention_reason: "sync_failed" })
+		);
+		const w = await mountAs({ admin: true });
+		expect(badge(w)).toEqual({ label: "Needs attention", theme: "red" });
+		expect(w.text()).toContain("did not reach your agent");
+		expect(buttonLabels(w)).toContain("Open AI models");
+	});
+
+	// The admin's own not-yet-known state, which the member state now mirrors.
+	it("is neutral before its verdict arrives", async () => {
+		api.getLlmConnectionStatus.mockImplementation(PENDING);
+		const w = await mountAs({ admin: true });
+		expect(badge(w).theme).not.toBe("green");
+		expect(badge(w)).toEqual({ label: "—", theme: "gray" });
+	});
+
+	// disconnected stays an admin-only distinction: a member gets "down" for the
+	// same workspace, so credential presence is never disclosed to them.
+	it("keeps Disconnected as its own orange state", async () => {
+		api.getLlmConnectionStatus.mockImplementation(() =>
+			Promise.resolve({ disconnected: true, health: "down" })
+		);
+		const w = await mountAs({ admin: true });
+		expect(badge(w)).toEqual({ label: "Disconnected", theme: "orange" });
+	});
+});

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -39,9 +39,15 @@
 				     instead - so every one of them but that gets the button that
 				     actually takes them there. Review round 1 caught sync_failed
 				     alone getting the button while subscription_unverified's
-				     identical "Open AI models" sentence had no way to act on it. -->
+				     identical "Open AI models" sentence had no way to act on it.
+
+				     isSM-only (jarvis#711): a member has no attention_reason, so
+				     they would pass the turn_error test and get the button, and
+				     AI models is a gated section that falls back to General
+				     silently - the button would look like a dead control. Their
+				     copy names no destination for the same reason. -->
 				<Button
-					v-if="statusState === 'attention' && attentionReason !== 'turn_error'"
+					v-if="isSM && statusState === 'attention' && attentionReason !== 'turn_error'"
 					variant="subtle"
 					label="Open AI models"
 					iconLeft="cpu"
@@ -63,8 +69,10 @@
 			</div>
 			<!-- A failed status fetch must not look like a healthy workspace. Without
 			     this the catch below leaves Status on its placeholder, which reads as
-			     an answer rather than as "we could not ask". Admin-only, because only
-			     an admin can query the endpoint or act on the result. -->
+			     an answer rather than as "we could not ask". Shown to members too
+			     since jarvis#711: they now query a status endpoint of their own, so
+			     the fetch they make can fail the same way, and the badge beside this
+			     stays on its neutral placeholder until a retry lands. -->
 			<div v-if="connErr" class="mt-2 flex items-center gap-2">
 				<span class="text-p-sm text-ink-gray-6">
 					Connection status is unavailable right now.
@@ -306,25 +314,41 @@ const ui = computed(() => (ctx.value && ctx.value.ui) || {});
 const convAutoApply = computed(() => !!(ctx.value && ctx.value.convAutoApply));
 const autoApplyNote = computed(() => (ctx.value && ctx.value.autoApplyNote) || "");
 
-// Real connection status. getLlmConnectionStatus is admin-tier on the server
-// (require_jarvis_admin) and General is an all-user pane, so only tenant-admin
-// users get the live verdict; regular users (who cannot query it and cannot fix
-// it anyway) keep the benign "Connected" the surface implied before, never a
-// 403 rendered as an error.
+// Real connection status, in two tiers. getLlmConnectionStatus is admin-tier on
+// the server (require_jarvis_admin) and returns the whole topology; General is
+// an all-user pane, so a member asks getLlmConnectionHealth instead, which is
+// gated on plain workspace access and answers with { state } and nothing else.
+//
+// Members used to get NEITHER: they could not query the admin endpoint, so the
+// badge was hardcoded to a green "Connected" for them (jarvis#711). That read as
+// a verdict while chat was failing, while a save was applying, and while the
+// workspace was disconnected. It was not stale, it was a constant.
 const isSM = !!(window.is_system_manager || window.is_jarvis_admin);
+// Admin only. Deliberately NOT reused for the member verdict: modeLabel, isPool,
+// disconnected and modelLabel all read this object, so pouring a one-field
+// member payload into it would silently rewrite rows that have nothing to do
+// with the badge.
 const connStatus = ref(null);
+// Member only. "" means no verdict yet, which is the state of EVERY member for
+// the whole first paint - see statusState, which must not read that as health.
+const memberState = ref("");
 const connErr = ref(false);
 const connLoading = ref(false);
 
 // Also ported from the removed ConnectionPane.vue: a fetch failure has to be
 // visible and recoverable. Swallowing it left Status showing its placeholder,
 // which an admin reads as "fine" rather than "we could not ask", and there was
-// no way to retry without reloading the whole app.
+// no way to retry without reloading the whole app. A member's fetch can fail the
+// same way, so both tiers land in the same catch.
 async function loadConnStatus() {
-	if (!isSM) return;
 	connLoading.value = true;
 	try {
-		connStatus.value = await api.getLlmConnectionStatus();
+		if (isSM) {
+			connStatus.value = await api.getLlmConnectionStatus();
+		} else {
+			const res = await api.getLlmConnectionHealth();
+			memberState.value = (res && res.state) || "";
+		}
 		connErr.value = false;
 	} catch (e) {
 		connErr.value = true;
@@ -350,8 +374,9 @@ const expiresLabel = computed(() => {
 });
 // Shared with Billing and metering so the two panes cannot name the same state
 // differently again: that pane called a 2-model api-key pool "Pool (direct
-// failover)" while this one called it "Direct". Blank without a verdict (a
-// non-admin never fetches one), which hides the row rather than guessing.
+// failover)" while this one called it "Direct". Blank without a verdict, which
+// hides the row rather than guessing - and a member never has one: their
+// endpoint answers health only, and topology is precisely what it withholds.
 const modeLabel = computed(() =>
 	connStatus.value
 		? connectionModeLabel(connStatus.value.proxy_active, connStatus.value.model_count)
@@ -389,22 +414,38 @@ const health = computed(() => (connStatus.value && connStatus.value.health) || "
 // easily: adding a health value or moving the disconnected check had to be got
 // right in three places, and a miss would render a colour that disagreed with
 // the line under it.
+//
+// A member resolves to the server's one-field verdict, and to "unknown" until it
+// lands (jarvis#711). There is deliberately no member-only value: the member and
+// admin vocabularies are the same words, so nothing about the badge tells a
+// member's screen apart from an admin's except what the workspace is doing.
+// "disconnected" is simply never reached from the member branch - the member
+// endpoint reports that workspace as "down", so credential presence stays
+// undisclosed.
 const statusState = computed(() => {
-	if (!isSM) return "member";
+	if (!isSM) return memberState.value || "unknown";
 	if (!connStatus.value) return "unknown";
 	if (disconnected.value) return "disconnected";
-	return health.value || "ok";
+	// "unknown", not "ok": the server sends health on every branch, so this only
+	// fires on a truncated payload, and a payload we could not read is not
+	// evidence of a healthy workspace. Same fail-closed rule as the maps below.
+	return health.value || "unknown";
 });
+// Both maps below fall through to the NEUTRAL state, never to green. They used
+// to default to "Connected"/green, which is what made an unmapped or missing
+// verdict indistinguishable from a working workspace - the #711 defect in its
+// general form. "ok" is now an explicit case in each, so a state the server
+// grows later reads as "we do not know" until this pane learns it.
 const statusLabel = computed(
 	() =>
 		({
-			member: "Connected",
+			ok: "Connected",
 			unknown: "—",
 			disconnected: "Disconnected",
 			down: "Not connected",
 			applying: "Applying changes",
 			attention: "Needs attention",
-		}[statusState.value] || "Connected")
+		}[statusState.value] || "—")
 );
 // The server's reason for "attention" (jarvis#714) - see account._llm_health.
 // One of sync_failed / turn_error / subscription_unverified, or "" for every
@@ -424,6 +465,19 @@ const attentionReason = computed(
 // that the agent's own wording is not reliable, so this points at the failed
 // message, whose own inline error is the only first-hand account.
 const statusHint = computed(() => {
+	// A member's two sentences. They are cause-blind by design: the member
+	// endpoint sends no attention_reason at all, because one of its values
+	// (subscription_unverified) can only arise on a workspace running a chat
+	// subscription and so names the credential kind - see
+	// account.get_llm_connection_health. Both point at the one action a member
+	// actually has, and neither names AI models, which they cannot open.
+	if (!isSM) {
+		if (statusState.value === "attention")
+			return "Your workspace needs attention. Ask whoever manages your workspace to check it.";
+		if (statusState.value === "down")
+			return "Your assistant is not ready yet. Ask whoever manages your workspace to set it up.";
+		return "";
+	}
 	if (statusState.value === "attention") {
 		return (
 			{
@@ -446,12 +500,13 @@ const statusHint = computed(() => {
 // broken, the customer chose this and can undo it in AI models.
 const statusTheme = computed(() => {
 	const s = statusState.value;
-	if (s === "member") return "green";
-	if (s === "unknown") return "gray";
+	if (s === "ok") return "green";
 	if (s === "disconnected") return "orange";
 	if (s === "down" || s === "attention") return "red";
 	if (s === "applying") return "blue";
-	return "green";
+	// "unknown" and anything this pane does not recognise. Green is reachable
+	// from exactly one branch above, on purpose.
+	return "gray";
 });
 
 // Estimated token usage — the dialog fetches its own data on open.

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -25,7 +25,7 @@ from jarvis import admin_client, onboarding_contract, release_notice
 from jarvis.exceptions import AdminAuthError
 from jarvis.jarvis.pool_serialize import compute_pool_mode, pool_primary_model
 from jarvis.onboarding import _surface
-from jarvis.permissions import require_jarvis_admin
+from jarvis.permissions import require_jarvis_access, require_jarvis_admin
 
 SETTINGS = "Jarvis Settings"
 
@@ -1029,6 +1029,119 @@ def get_llm_connection_status() -> dict:
 		# the fallback for a shape pool_primary_model cannot read.
 		"default_model": pool_primary_model(settings) or data.get("default_model", ""),
 	}
+
+
+# The complete set of values ``get_llm_connection_health`` may ever return. It
+# is the SPA's badge vocabulary minus "disconnected" (see below), and it is
+# named here so the member contract is one readable list rather than something a
+# reader has to reconstruct from branches.
+MEMBER_HEALTH_STATES = ("ok", "applying", "attention", "down")
+
+
+@frappe.whitelist()
+def get_llm_connection_health() -> dict:
+	"""The Settings Status badge for a workspace MEMBER: is this workspace's
+	assistant working right now? Returns exactly one field, ``state``, one of
+	:data:`MEMBER_HEALTH_STATES`. Nothing else, ever.
+
+	This exists because the badge used to be a hardcoded green "Connected" for
+	anyone who was not an admin (jarvis#711). ``get_llm_connection_status`` above
+	is ``require_jarvis_admin``, so a member could not fetch a verdict at all and
+	the SPA rendered a placeholder that read as an answer: a member saw green
+	while chat was failing, while a save was still applying, and while the
+	workspace was disconnected. It was not stale, it was a constant.
+
+	WHAT A MEMBER MAY AND MAY NOT LEARN
+	-----------------------------------
+	A member gets a HEALTH verdict and no description of the workspace. Not the
+	pool shape, model count or routing mode; not model names, provider names or
+	base URLs; not profile or account ids; not whether a key or subscription is
+	present; not billing state; and no error text from a provider or from a
+	failed turn. The admin payload's every other field is deliberately absent
+	rather than blanked, so a future field added there cannot ride along here.
+
+	No branch calls admin. ``get_llm_connection_status`` round-trips to
+	``post_llm_auth_status`` for a proxied tenant, and doing that here would put
+	``proxy_active`` - a topology fact - into the response LATENCY even though it
+	is absent from the body. Every input below is a local read, so the work is
+	the same shape whatever the workspace runs.
+
+	THE DISCLOSURE DECISION (jarvis#711, settled)
+	---------------------------------------------
+	``_llm_health`` returns ``(health, attention_reason)``, and folds three
+	distinct causes into ``attention``: a failed apply (``sync_failed``), a
+	failed chat turn (``turn_error``, added for #678) and a chat subscription the
+	fleet's probe rejected (``subscription_unverified``, split out for #714).
+
+	``health`` on its own carries no shape. It says whether the assistant is
+	serving, which is a workspace-level statement true of an api-key tenant and a
+	subscription tenant alike. ``attention_reason`` is different:
+	``subscription_unverified`` can only ever arise on a workspace that
+	authenticates with a CHAT SUBSCRIPTION rather than an api key, so handing it
+	to a member tells them which kind of credential this workspace runs on. That
+	is pool shape, and shape is exactly what a member may not have.
+
+	The decision: the member gets ``health`` and no cause. ``attention_reason``
+	is dropped here, not upstream, and it is OMITTED rather than mapped:
+
+	* Mapping is the trap. Any member-visible value reachable only from
+	  ``subscription_unverified`` recovers it exactly, and even a lossy mapping
+	  narrows the credential kind by elimination. Omission is the only version
+	  with nothing left to recover.
+	* All three causes therefore produce the byte-identical response ``{"state":
+	  "attention"}``. There is no cause-specific label, no extra state and no
+	  extra field on any branch, so the response cannot be decomposed.
+	* The alternative - dropping the subscription cause from the member verdict
+	  so that workspace reads ``ok`` - was rejected twice over. It reintroduces
+	  the false green #711 is about, and "this workspace never reports attention
+	  from that cause" is itself a shape oracle for anyone who can compare a
+	  broken workspace against a working one.
+
+	Timing cannot recover the cause either. The only variance inside
+	``_llm_health`` is one versus two ``limit 1`` reads of the newest completed
+	chat message (``sync_failed`` returns before either; ``turn_error`` does one;
+	``subscription_unverified`` does two), on the same local table, with no
+	network call on any branch. That is well under the noise floor of an HTTP
+	round trip, and it is the same code path the admin endpoint already runs.
+
+	Nothing above changes ``_llm_health`` itself, the values of
+	``attention_reason``, or what an admin sees (jarvis#713/#714 own that area).
+	This function is a member-visibility filter placed in front of it.
+
+	WHY ``disconnected`` IS NOT A MEMBER STATE
+	------------------------------------------
+	A workspace with no credential at all reports ``down`` here, exactly like a
+	workspace whose config never reached its container. The admin payload keeps
+	them apart because an admin can act on the difference. For a member,
+	``disconnected`` would say "this workspace currently holds no AI credential",
+	which is credential-presence disclosure, and a member can do nothing with it
+	that ``down`` does not already tell them: the assistant is not going to
+	answer, ask an admin. Collapsing the two also keeps the member vocabulary at
+	four values, so no state is unique to one cause.
+
+	GATE
+	----
+	``require_jarvis_access``, not ``require_jarvis_admin``: any authenticated
+	System User of this workspace holding a Jarvis access role. That gate refuses
+	Guest twice over - ``is_system_user`` rejects Guest by name before roles are
+	consulted, and ``frappe.whitelist()`` without ``allow_guest`` refuses an
+	anonymous session before the body runs. Website/portal users are refused for
+	the same reason chat refuses them.
+
+	``get_llm_connection_status`` is untouched by this: its guard is unchanged
+	and so is every field it returns to an admin.
+	"""
+	require_jarvis_access()
+	settings = frappe.get_single("Jarvis Settings")
+	if not _has_llm_config(settings):
+		return {"state": "down"}
+	state, _reason = _llm_health(settings, compute_pool_mode(settings))
+	# Belt and braces: _llm_health's contract is the same four values, so this
+	# only fires if that function grows a fifth. A member must get a known state
+	# or the most conservative one, never a value the SPA has no mapping for -
+	# an unmapped state is how a badge falls back to its default, and that
+	# default was the green this issue is about.
+	return {"state": state if state in MEMBER_HEALTH_STATES else "down"}
 
 
 def _llm_health(settings, pool_mode: bool) -> tuple:

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -1122,11 +1122,19 @@ def get_llm_connection_health() -> dict:
 	GATE
 	----
 	``require_jarvis_access``, not ``require_jarvis_admin``: any authenticated
-	System User of this workspace holding a Jarvis access role. That gate refuses
-	Guest twice over - ``is_system_user`` rejects Guest by name before roles are
-	consulted, and ``frappe.whitelist()`` without ``allow_guest`` refuses an
-	anonymous session before the body runs. Website/portal users are refused for
-	the same reason chat refuses them.
+	System User of this workspace holding a Jarvis access role. It refuses Guest
+	directly, because ``is_system_user`` rejects Guest by name before roles are
+	even consulted, and refuses Website/portal users for the same reason chat
+	refuses them.
+
+	That in-body call is THE guard, and it is deliberately not left to the
+	framework. ``@frappe.whitelist()`` does NOT wrap the function - the decorator
+	only adds it to Frappe's ``whitelisted`` set - so nothing refuses a Guest
+	until the request dispatcher separately calls ``frappe.is_whitelisted``,
+	which throws for a Guest invoking a method not registered ``allow_guest``.
+	That check therefore exists only on the HTTP path: a direct Python call
+	reaches this body with no framework gate at all. Anyone tempted to drop the
+	line below as redundant should read those two functions first.
 
 	``get_llm_connection_status`` is untouched by this: its guard is unchanged
 	and so is every field it returns to an admin.

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -435,6 +435,14 @@ def _ensure_member_user() -> None:
 			doc.remove_roles(*stale)
 		if "Jarvis User" not in roles:
 			doc.add_roles("Jarvis User")
+		# Re-assert the two fields has_jarvis_access reads besides roles. Another
+		# suite on this shared site disabling the row, or flipping it to a Website
+		# User, would otherwise fail every test in this class on the guard rather
+		# than on the behaviour each one names.
+		if doc.enabled != 1 or doc.user_type != "System User":
+			doc.enabled = 1
+			doc.user_type = "System User"
+			doc.save(ignore_permissions=True)
 		frappe.db.commit()
 		return
 	doc = frappe.get_doc(
@@ -550,9 +558,15 @@ class TestGetLlmConnectionHealth(FrappeTestCase):
 			self._as_member(account.get_llm_connection_status)
 
 	def test_guest_is_refused(self):
-		"""require_jarvis_access rejects Guest before roles are even consulted
-		(is_system_user names it), and @frappe.whitelist() without allow_guest
-		refuses an anonymous session in front of that."""
+		"""require_jarvis_access rejects Guest before roles are even consulted -
+		is_system_user names Guest explicitly.
+
+		This drives the Python function directly, so it exercises THAT in-body
+		guard and nothing else. Frappe refuses a Guest on the HTTP path too, but
+		the decorator does not wrap the function: that check lives in the request
+		dispatcher (frappe.is_whitelisted), which no direct call reaches. The
+		in-body guard is the one that has to hold, so it is the one under test.
+		"""
 		frappe.set_user("Guest")
 		try:
 			with self.assertRaises(frappe.PermissionError):
@@ -677,6 +691,9 @@ class TestGetLlmConnectionHealth(FrappeTestCase):
 		would have been silently undone - so assert here that the distinction
 		still exists on the admin side, and is only dropped on the way to a
 		member."""
+		# No inline try/finally, unlike _as_member: this switches TO the identity
+		# tearDown restores anyway, and tearDown's first statement is the restore,
+		# so an assertion failing below cannot strand the shared site.
 		frappe.set_user("Administrator")
 		reasons = []
 

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -1,8 +1,10 @@
 """TDD tests for customer-side LLM monitor wrappers (Plan 3 Phase F).
 
 Tests: account.get_llm_usage (short-circuit for direct tenants; passthrough
-for proxy tenants; admin error surfaces as frappe.ValidationError) and
-account.get_llm_connection_status (field remapping; no token material).
+for proxy tenants; admin error surfaces as frappe.ValidationError),
+account.get_llm_connection_status (field remapping; no token material) and
+account.get_llm_connection_health (the member-tier verdict, jarvis#711: what a
+non-admin may learn about the workspace, and what the payload must never carry).
 """
 
 from unittest.mock import patch
@@ -13,6 +15,7 @@ from frappe.tests.utils import FrappeTestCase
 from jarvis import account, admin_client
 from jarvis.account import _has_llm_config
 from jarvis.exceptions import AdminValidationError
+from jarvis.permissions import ensure_jarvis_user_role
 
 
 class TestGetLlmUsage(FrappeTestCase):
@@ -393,6 +396,339 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		m.assert_not_called()
 		self.assertEqual(out["disconnected"], True)
 		self.assertEqual(out["default_model"], "")
+
+
+MEMBER_USER = "jarvis-connhealth-member@example.com"
+
+# Every field get_llm_connection_status hands an admin. The member endpoint must
+# return NONE of them, and the assertion is written against this list rather than
+# against a handful of names so a field added to the admin payload is covered the
+# day it lands.
+ADMIN_ONLY_FIELDS = (
+	"pool_mode",
+	"model_count",
+	"routing_mode",
+	"sync_status",
+	"proxy_active",
+	"disconnected",
+	"health",
+	"attention_reason",
+	"auth_present",
+	"oauth_expires_at",
+	"profile_ids",
+	"default_model",
+)
+
+
+def _ensure_member_user() -> None:
+	"""A plain workspace MEMBER: a System User holding "Jarvis User" (as every
+	real chat user does) and NOT System Manager or Jarvis Admin. Idempotent, and
+	it strips the admin roles if a previous run or another suite granted them -
+	this site is shared, and a member who quietly became an admin would turn the
+	whole class into a tautology."""
+	ensure_jarvis_user_role()  # the test site may not have run after_migrate
+	if frappe.db.exists("User", MEMBER_USER):
+		doc = frappe.get_doc("User", MEMBER_USER)
+		roles = set(frappe.get_roles(MEMBER_USER))
+		stale = {"System Manager", "Jarvis Admin"} & roles
+		if stale:
+			doc.remove_roles(*stale)
+		if "Jarvis User" not in roles:
+			doc.add_roles("Jarvis User")
+		frappe.db.commit()
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": MEMBER_USER,
+			"first_name": "Conn",
+			"last_name": "Member",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	doc.add_roles("Jarvis User")
+	frappe.db.commit()
+
+
+class TestGetLlmConnectionHealth(FrappeTestCase):
+	"""The member-tier Status badge (jarvis#711).
+
+	The badge used to be a hardcoded green "Connected" for anyone who was not an
+	admin, because get_llm_connection_status is require_jarvis_admin and a member
+	could not fetch a verdict at all. get_llm_connection_health is the member's
+	own endpoint, and these tests pin the two halves of its contract: it tells a
+	member the truth about whether chat works, and it tells them nothing else.
+
+	Driven as a REAL non-admin session (frappe.set_user) through the whitelisted
+	function, never by patching the guard and inspecting the body. The guard is
+	half of what is being tested, so stubbing it would assert nothing.
+	"""
+
+	_FIELDS = (
+		"proxy_active",
+		"llm_model",
+		"routing_mode",
+		"last_sync_status",
+		"last_subscription_status",
+		"llm_pool_synced_at",
+	)
+
+	def setUp(self):
+		_ensure_member_user()
+		self._orig_user = frappe.session.user
+		# frappe.get_single serves a CACHED doc, so a db.set_single_value written
+		# here is invisible to the endpoint unless the cache is dropped first
+		# (the stale-Single flake this suite has hit before).
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		self._saved = {f: frappe.db.get_single_value("Jarvis Settings", f) for f in self._FIELDS}
+		# Same shared-site hazard the sibling class documents: health reads the
+		# latest completed turn, which is real table data here, so one stray
+		# errored assistant row would flip every "ok" case in this class. Pinned
+		# by PATCH, never by deleting rows - wiping a shared site's data from a
+		# test is how live tenants were destroyed here before. The cases that care
+		# about turn history override these.
+		for attr in ("_last_turn_errored", "_last_turn_succeeded"):
+			p = patch.object(account, attr, return_value=False)
+			p.start()
+			self.addCleanup(p.stop)
+
+	def tearDown(self):
+		# Restore the session FIRST: everything below writes.
+		frappe.set_user(self._orig_user)
+		for field, value in self._saved.items():
+			frappe.db.set_single_value("Jarvis Settings", field, value)
+		frappe.db.commit()
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+
+	def _seed(self, **values):
+		"""Write Single fields and make them visible to frappe.get_single."""
+		for field, value in values.items():
+			frappe.db.set_single_value("Jarvis Settings", field, value)
+		frappe.db.commit()
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+
+	def _as_member(self, fn=None):
+		"""Run ``fn`` (default: the member endpoint) in a real MEMBER_USER
+		session and restore the caller's identity whatever happens."""
+		fn = fn or account.get_llm_connection_health
+		frappe.set_user(MEMBER_USER)
+		try:
+			return fn()
+		finally:
+			frappe.set_user(self._orig_user)
+
+	def _seed_serving_pool(self, **overrides):
+		"""A pool the container has confirmed and is serving. The base state every
+		health case below perturbs by exactly one field."""
+		values = {
+			"proxy_active": 1,
+			"last_sync_status": "ok (pool_update via admin)",
+			"llm_pool_synced_at": "2026-07-30 10:00:00",
+			"last_subscription_status": "",
+		}
+		values.update(overrides)
+		self._seed(**values)
+
+	# ---- the gate -------------------------------------------------------- #
+
+	def test_a_member_may_call_it(self):
+		"""The premise of the whole fix. A member could not reach any verdict
+		before, which is why the badge was a constant."""
+		self._seed_serving_pool()
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		self.assertEqual(out["state"], "ok")
+
+	def test_a_member_still_cannot_reach_the_admin_endpoint(self):
+		"""The new endpoint is ADDITIVE. get_llm_connection_status's guard is
+		untouched, so the payload with the pool shape, model names and profile
+		ids stays admin-only."""
+		with self.assertRaises(frappe.PermissionError):
+			self._as_member(account.get_llm_connection_status)
+
+	def test_guest_is_refused(self):
+		"""require_jarvis_access rejects Guest before roles are even consulted
+		(is_system_user names it), and @frappe.whitelist() without allow_guest
+		refuses an anonymous session in front of that."""
+		frappe.set_user("Guest")
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				account.get_llm_connection_health()
+		finally:
+			frappe.set_user(self._orig_user)
+
+	# ---- what the payload may contain ------------------------------------ #
+
+	def test_the_payload_is_exactly_one_field(self):
+		"""Key-set equality, not a spot check of a few names: a field added here
+		later has to be a deliberate edit to this assertion."""
+		self._seed_serving_pool()
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		self.assertEqual(set(out.keys()), {"state"})
+
+	def test_no_admin_field_appears_in_the_member_payload(self):
+		"""Named forbidden fields, so a failure says WHICH one leaked. Shape
+		(pool_mode / model_count / routing_mode / sync_status / proxy_active),
+		credential presence (disconnected / auth_present / profile_ids), model
+		names (default_model), OAuth timing (oauth_expires_at) and the reason
+		behind "attention" are all absent."""
+		self._seed_serving_pool()
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		for field in ADMIN_ONLY_FIELDS:
+			self.assertNotIn(field, out, f"member payload leaked {field}")
+
+	def test_the_state_is_always_from_the_member_vocabulary(self):
+		self._seed_serving_pool()
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		self.assertIn(out["state"], account.MEMBER_HEALTH_STATES)
+		self.assertNotIn("disconnected", account.MEMBER_HEALTH_STATES)
+
+	def test_it_never_round_trips_to_admin(self):
+		"""A proxied tenant is where get_llm_connection_status calls
+		post_llm_auth_status. Doing that here would put proxy_active - a topology
+		fact absent from the body - into the response LATENCY."""
+		self._seed_serving_pool()
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status") as m:
+				self._as_member()
+		m.assert_not_called()
+
+	# ---- the verdict itself ---------------------------------------------- #
+
+	def test_a_member_sees_attention_not_green_when_a_save_failed(self):
+		"""The defect, from the member's seat: a workspace whose last apply
+		failed used to render green for them."""
+		self._seed_serving_pool(last_sync_status="failed: fleet returned 502")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		self.assertEqual(out["state"], "attention")
+
+	def test_a_member_sees_applying_while_a_save_is_in_flight(self):
+		self._seed_serving_pool(last_sync_status="pending: admin applying config")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		self.assertEqual(out["state"], "applying")
+
+	def test_a_member_sees_down_when_the_container_never_got_the_config(self):
+		self._seed_serving_pool(llm_pool_synced_at="")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			out = self._as_member()
+		self.assertEqual(out["state"], "down")
+
+	def test_a_disconnected_workspace_is_down_with_no_state_of_its_own(self):
+		""" "disconnected" is an admin-only distinction. Telling a member their
+		workspace holds no credential is credential-presence disclosure, and it
+		buys them nothing "down" does not already say. So the two workspaces are
+		indistinguishable here - asserted as payload equality, not as two separate
+		expectations that could drift apart."""
+		with patch.object(account, "_has_llm_config", return_value=False):
+			no_credential = self._as_member()
+		self._seed_serving_pool(llm_pool_synced_at="")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			never_applied = self._as_member()
+		self.assertEqual(no_credential, {"state": "down"})
+		self.assertEqual(no_credential, never_applied)
+
+	# ---- the disclosure decision ----------------------------------------- #
+
+	def test_every_attention_cause_gives_the_member_one_identical_payload(self):
+		"""The settled disclosure question (jarvis#711).
+
+		_llm_health splits "attention" three ways for an admin, and one of those
+		values - subscription_unverified - can only arise on a workspace that
+		authenticates with a CHAT SUBSCRIPTION rather than an api key, so it names
+		the credential kind. That is pool shape. A member therefore gets the
+		verdict and no cause, and the cause is OMITTED rather than mapped: any
+		member-visible value reachable only from subscription_unverified would
+		recover it exactly.
+
+		The three payloads are compared to each other, so this fails if a future
+		change makes ANY of them distinguishable, not merely if a named field
+		reappears.
+		"""
+		payloads = {}
+
+		self._seed_serving_pool(last_sync_status="failed: fleet returned 502")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			payloads["sync_failed"] = self._as_member()
+
+		self._seed_serving_pool()
+		with patch.object(account, "_last_turn_errored", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				payloads["turn_error"] = self._as_member()
+
+		self._seed_serving_pool(last_subscription_status="unverified")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			payloads["subscription_unverified"] = self._as_member()
+
+		for cause, out in payloads.items():
+			self.assertEqual(out, {"state": "attention"}, f"{cause} was not collapsed")
+		self.assertEqual(len({tuple(sorted(p.items())) for p in payloads.values()}), 1)
+
+	def test_the_admin_can_still_tell_those_three_apart(self):
+		"""The control for the test above. If _llm_health stopped distinguishing
+		the causes, the collapse assertion would pass vacuously and #714's work
+		would have been silently undone - so assert here that the distinction
+		still exists on the admin side, and is only dropped on the way to a
+		member."""
+		frappe.set_user("Administrator")
+		reasons = []
+
+		self._seed_serving_pool(last_sync_status="failed: fleet returned 502")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				reasons.append(account.get_llm_connection_status()["attention_reason"])
+
+		self._seed_serving_pool()
+		with patch.object(account, "_last_turn_errored", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+					reasons.append(account.get_llm_connection_status()["attention_reason"])
+
+		self._seed_serving_pool(last_subscription_status="unverified")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				reasons.append(account.get_llm_connection_status()["attention_reason"])
+
+		self.assertEqual(reasons, ["sync_failed", "turn_error", "subscription_unverified"])
+
+	# ---- fail closed ------------------------------------------------------ #
+
+	def test_an_unrecognised_health_value_degrades_to_down(self):
+		"""The clamp. _llm_health is stubbed here BECAUSE the subject is what
+		happens when it grows a fifth value the member vocabulary has no word
+		for - there is no way to reach that branch through real settings. A state
+		the SPA cannot map is how a badge falls back to its default, and the
+		default this issue is about was green."""
+		self._seed_serving_pool()
+		with patch.object(account, "_llm_health", return_value=("quiescent", "")):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				out = self._as_member()
+		self.assertEqual(out, {"state": "down"})
+
+
+class TestGetLlmConnectionStatusIsUnchanged(FrappeTestCase):
+	"""jarvis#711 added a member endpoint alongside the admin one and must not
+	have touched the admin one. This pins the admin payload's exact key set, so
+	a member-tier change that trimmed a field an admin still needs fails here."""
+
+	def test_an_admin_still_gets_every_field(self):
+		frappe.set_user("Administrator")
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		with patch.object(account, "_has_llm_config", return_value=True):
+			with patch.object(account, "compute_pool_mode", return_value=True):
+				with patch.object(account, "_last_turn_errored", return_value=False):
+					with patch.object(account, "_last_turn_succeeded", return_value=False):
+						with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+							out = account.get_llm_connection_status()
+		self.assertEqual(set(out.keys()), set(ADMIN_ONLY_FIELDS))
+		self.assertNotIn("state", out)
 
 
 class TestLastTurnErrored(FrappeTestCase):

--- a/jarvis/tests/test_role_gates.py
+++ b/jarvis/tests/test_role_gates.py
@@ -41,6 +41,13 @@ GATED_ENDPOINTS = [
 	("jarvis.account", "preview_upgrade", {"target_plan": "team_monthly"}),
 	("jarvis.account", "get_llm_usage", {}),
 	("jarvis.account", "get_llm_connection_status", {}),
+	# MEMBER-tier, unlike every other entry in this list: gated by
+	# require_jarvis_access, so an ordinary workspace user is MEANT to pass it.
+	# It is listed for the other half of that gate - Guest must still be refused,
+	# and the Guest case below is what proves it. That a real non-admin can call
+	# it, and gets back a verdict carrying no shape, is asserted separately in
+	# test_llm_monitor.TestGetLlmConnectionHealth (jarvis#711).
+	("jarvis.account", "get_llm_connection_health", {}),
 	("jarvis.oauth.api", "begin_paste_signin", {"provider": "OpenAI", "model": "gpt-5.5"}),
 	(
 		"jarvis.oauth.api",


### PR DESCRIPTION
## Summary

The Settings Status badge showed a hardcoded green "Connected" to every non-admin, whatever the workspace was doing. A member read green while chat was failing, while a save was still applying, and while the workspace was disconnected. Members now see the real verdict; admins see exactly what they saw before.

`account.get_llm_connection_health` is a new member-tier endpoint gated on `require_jarvis_access`. It returns one field, `state`, one of ok/applying/attention/down. No branch of it calls admin, so topology stays out of the body and out of the response latency.

What a member deliberately does not get, and why:

- **`attention_reason`** is omitted, not mapped. One of its values, `subscription_unverified`, can only arise on a workspace authenticating with a chat subscription rather than an api key, so it names the credential kind. All three causes produce the byte-identical `{"state": "attention"}`. The rejected alternative, dropping that cause so the workspace reads ok, reintroduces the false green this issue is about and is itself a shape oracle.
- **`disconnected`** is not a member state. A workspace with no credential reports `down`, indistinguishable from one whose config never reached its container, so credential presence is never disclosed.
- The pool shape, model count, routing mode, model names, provider, profile ids and OAuth expiry stay admin-only.

On the SPA both badge fallbacks now fail closed: an unknown, missing or unrecognised verdict is gray, and green is reachable from exactly one branch. `_llm_health`, `attention_reason`'s values, the sync path and the admin payload are untouched (#713/#714 own that area).

Fixes #711

<details>
<summary>Root cause</summary>

`statusState` had `if (!isSM) return "member"`, which mapped to the label "Connected" and theme green before any data existed. It was a constant, not a stale value, and it was written that way because `get_llm_connection_status` calls `require_jarvis_admin()`: a member could not fetch a verdict at all, so the label stood in for data the caller was not allowed to have. Both maps behind the badge also defaulted to green, so an unmapped or missing verdict was indistinguishable from a healthy workspace even for an admin.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on :x:)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff