### PR TITLE
fix(wiki): make the enable toggle a real kill switch, and stop private page titles reaching admin

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -8,7 +8,12 @@ from jarvis import audit, telemetry
 from jarvis._http import validate_bearer as _validate_bearer
 from jarvis._plugin_auth import PluginAuthError, validate_plugin_request
 from jarvis._session import impersonate
-from jarvis.exceptions import CapabilityDeniedError, InvalidArgumentError, JarvisError
+from jarvis.exceptions import (
+	CapabilityDeniedError,
+	FeatureDisabledError,
+	InvalidArgumentError,
+	JarvisError,
+)
 from jarvis.permissions import has_jarvis_access
 from jarvis.tools.registry import dispatch
 
@@ -658,6 +663,11 @@ _GATED_WRITES = frozenset(
 		"assign_to",
 	}
 )
+# #493: the agent-facing wiki surface, refused wholesale when the operator has
+# switched "Enable Business Wiki" off. Deliberately just the two tools the issue
+# names - record_app_wiki (the app-learning scribe's audited-not-gated writeback)
+# is a different feature's pipeline and is out of scope here.
+_WIKI_TOOLS = frozenset({"read_wiki", "update_wiki"})
 # Irreversible/consequential subset - gated even when a user has auto-apply
 # on (Task 4 uses this; define it here so the sets live together).
 _DESTRUCTIVE = frozenset({"delete_doc", "cancel_doc", "amend_doc", "send_email", "apply_workflow_action"})
@@ -889,6 +899,12 @@ _ERROR_HINTS = {
 		"This agent can only use the tools it was published with. Ask your "
 		"administrator to review the agent's bundle if it needs another one."
 	),
+	# #493. A settings checkbox, not a role, so pointing at permissions would send
+	# the user looking in the wrong place entirely.
+	"FeatureDisabledError": (
+		"This feature is switched off for your workspace. Ask your administrator to "
+		"turn it back on in Jarvis Settings if you need it."
+	),
 }
 # Frappe's User-Permission link denial reads "...not allowed to access this X
 # record because it is linked to Y '...' in field Z" - a more specific hint than
@@ -1066,6 +1082,20 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 	into one to match the reviewer's "native handler" pattern note
 	from the 2026-06-16 punch list.
 	"""
+	# #493: "Enable Business Wiki" is the operator's only wiki kill switch, so it
+	# must refuse the agent-facing wiki tools too, not only the automatic
+	# behaviours. Checked HERE, ahead of everything, because update_wiki is a
+	# _GATED_WRITES tool: without this it parks a confirmation card on a workspace
+	# whose wiki UI is hidden, and the card's only possible outcome is the very
+	# refusal below. The tools carry the same gate themselves, so no dispatch path
+	# is left open; this one exists to stop the card, not to be the only guard.
+	if tool in _WIKI_TOOLS:
+		from jarvis.chat.wiki import WIKI_DISABLED_MESSAGE, wiki_enabled
+
+		if not wiki_enabled():
+			code = FeatureDisabledError.__name__
+			return _error(code, WIKI_DISABLED_MESSAGE, hint=_hint_for(code, ""))
+
 	is_write = tool in _WRITE_TOOLS
 	try:
 		args = _parse_args(raw_args)

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -171,6 +171,29 @@ _EXCERPT_LINE_SNAP_CHARS = 200
 # --------------------------------------------------------------------------- #
 # shared helpers
 # --------------------------------------------------------------------------- #
+# #493: the single refusal every agent-facing wiki surface hands back when the
+# operator has switched "Enable Business Wiki" off. Defined beside the toggle it
+# reports so the two tools and the dispatch gate cannot drift into wording the
+# others do not use.
+#
+# The no-retry instruction is IN the message on purpose: the agent plugin relays a
+# failed tool call to the model as "<code>: <message>" and drops every other field,
+# so a hint the model must act on arrives no other way (the same reason
+# _delegate_capability puts it there). The envelope's ``hint`` keeps its usual
+# human-facing "what you can do" role.
+WIKI_DISABLED_MESSAGE = (
+	"The business wiki is turned off for this workspace, so wiki pages cannot be "
+	"read or written. This is an operator setting rather than a permission problem, "
+	"so retrying, changing the arguments or calling the other wiki tool will not "
+	"help. Answer from what you already know, and if the user needs the wiki, tell "
+	'them an administrator can switch it back on with "Enable Business Wiki" in '
+	"Jarvis Settings."
+)
+# What a short-circuited background job (mirror push, graph push, history snapshot)
+# reports instead. Read by an operator in a job result, never by the model.
+WIKI_DISABLED_REASON = "the business wiki is turned off for this workspace"
+
+
 def wiki_enabled() -> bool:
 	"""Operator toggle; NULL=ON (the vision_attachments_enabled idiom — Single
 	defaults are not backfilled on migrate, so a pre-existing Settings row has

--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -9,17 +9,39 @@ activity from agent telemetry it already reads; this push carries only the
 DB-only tiers (roles, scope, page metadata) that never otherwise leave the site
 — Role/User pages are never mirrored to the container. Derived + rebuildable;
 NEVER raises into the save/sync path.
+
+What actually travels to admin, stated plainly (#495: "page metadata" glossed
+over the fact that a title is authored content):
+
+* Org pages: real title and real slug. They are org-wide by definition, and they
+  are what make the vendor console legible.
+* Role pages: real title and real slug, deliberately. A Role page is authored for
+  a named group audience whose role name already travels as its own node, and the
+  console joins its READ/WRITE activity overlay on the slug, so minimising here
+  would go beyond what #495 asked and blind a working view. Widening is one line:
+  add "Role" to ``_MINIMISED_SCOPES``.
+* User pages: NEITHER title nor slug. Both are replaced by a stable opaque ref
+  (``_opaque_page_ref``) because a personal page titled "salary dispute with
+  manager X" is authored free text and the slug derives from the title.
+* Owning + authoring user EMAILS still travel, as ``user:`` node labels. #495
+  rules that out of scope on the ground that the usage rollup ingest already
+  sends them.
+* Page bodies and summaries never travel (``include_content``), and never have.
+
+The whole push is short-circuited when the "Enable Business Wiki" toggle is off
+(#493), before any of the above is computed.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 
 import frappe
 from frappe.utils import cint
 
-from jarvis.chat.wiki import PAGE_TYPES, is_stale
+from jarvis.chat.wiki import PAGE_TYPES, WIKI_DISABLED_REASON, is_stale, wiki_enabled
 
 # Obsidian-style wikilink in a page body: [[slug]], [[slug|alias]], [[slug#h]].
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
@@ -62,6 +84,12 @@ _PAGE_FIELDS = [
 
 # Scope value → the node an Org/Role/User page is "covered by".
 _ORG_ID = "org"
+
+# #495: scopes whose page title AND slug are replaced by an opaque ref in the
+# ADMIN push. See the module docstring for why Role is not in here; adding it is
+# the one-line lever if that judgement is ever overruled.
+_MINIMISED_SCOPES = frozenset({"User"})
+_OPAQUE_REF_CHARS = 10
 
 
 def _norm_scope(scope) -> str:
@@ -128,6 +156,51 @@ def _manual_link_targets(raw, known: set[str]) -> list[str]:
 	return out[-_MAX_LINKS_PER_PAGE:]
 
 
+def _opaque_page_ref(p, scope: str) -> tuple[str, str]:
+	"""``(slug, label)`` a scope-minimised page travels to admin under (#495).
+
+	BOTH fields are replaced, because a slug derives from the title
+	(``jarvis_wiki_page._apply_scope_slug_suffix``): minimising the label while
+	still sending the slug would carry the same authored text one field over and
+	defeat the whole change.
+
+	STABLE across pushes by construction. The digest is taken over the docname,
+	which ``autoname: field:slug`` freezes at create time, so the console's graph
+	shows the same node every day and its history stays worth keeping. Nothing here
+	is a counter, a timestamp or an iteration order.
+
+	The audience part (``--u-<localpart>`` / ``--r-<role>``) derives from the
+	target, never from the title, and is kept for legibility: it lets a vendor
+	operator still see WHOSE tier a node sits in, which is what the admin view is
+	for. Both are already on the graph anyway as ``user:``/``role:`` node labels.
+	Two pages of the same owner therefore share a LABEL and differ only by id,
+	which is the intended reading: "this person has four personal pages" without
+	what they are about.
+
+	``SLUG_RE`` forbids a leading dash, so a synthetic ref beginning with ``--``
+	can never collide with a real page's slug and steal its activity overlay."""
+	digest = hashlib.sha256(str(p.name or "").encode("utf-8")).hexdigest()[:_OPAQUE_REF_CHARS]
+	if scope == "Role":
+		role = str(p.target_role or "").strip()
+		return (f"--r-{digest}", f"Role page ({role})" if role else "Role page")
+	local = str(p.target_user or "").split("@", 1)[0].strip().lower()
+	if not local:
+		return f"--u-{digest}", "User page"
+	return f"--u-{local}-{digest}", f"User page (--u-{local})"
+
+
+def _emitted_ref(p, minimise_scopes: bool) -> tuple[str, str]:
+	"""``(slug, label)`` this page is emitted under.
+
+	The real slug and real title unless the CALLER asked for minimisation and the
+	page's scope is in ``_MINIMISED_SCOPES``. The tenant SPA path never asks, so it
+	is byte-identical to before #495."""
+	slug = p.name
+	if minimise_scopes and _norm_scope(p.scope) in _MINIMISED_SCOPES:
+		return _opaque_page_ref(p, _norm_scope(p.scope))
+	return slug, (p.title or slug)
+
+
 def _sources_authors(raw) -> dict[str, int]:
 	"""``sources`` JSON ([{date, kind, ref, user}]) → {user: authored_count}.
 	Corrupt JSON contributes nothing rather than failing the compute."""
@@ -157,10 +230,12 @@ def compute_graph() -> dict:
 		order_by="modified desc",
 		limit=MAX_PAGES,
 	)
-	return _build_graph_from_pages(pages)
+	# minimise_scopes: this is the ADMIN-bound graph (#495). The tenant SPA builds
+	# its own through _build_graph_from_pages and keeps real titles.
+	return _build_graph_from_pages(pages, minimise_scopes=True)
 
 
-def _build_graph_from_pages(pages, include_content: bool = False) -> dict:
+def _build_graph_from_pages(pages, include_content: bool = False, minimise_scopes: bool = False) -> dict:
 	"""Bounded ``{nodes, edges, counts}`` from an already-fetched page list.
 
 	Shared by ``compute_graph`` (org-wide → admin push) and ``get_wiki_graph``
@@ -171,12 +246,20 @@ def _build_graph_from_pages(pages, include_content: bool = False) -> dict:
 	weighted), ``member-of`` (user→role via live ``frappe.get_roles``),
 	``links-to`` (body ``[[links]]`` ∪ durable ``manual_links``). Callers pass a
 	page set already filtered to what they may emit, so edges to pages outside
-	the set are dropped by construction (the isolation invariant, R3)."""
+	the set are dropped by construction (the isolation invariant, R3).
+
+	``minimise_scopes`` (#495, admin push only) replaces the title AND slug of a
+	``_MINIMISED_SCOPES`` page with a stable opaque ref. Left False every node is
+	exactly what it was before #495."""
 	nodes: list[dict] = [{"id": _ORG_ID, "kind": "org", "label": _org_label()}]
 	edges: list[dict] = []
 	role_ids: set[str] = set()
 	user_ids: set[str] = set()
 	known_slugs = {p.name for p in pages}
+	# Resolved for EVERY page UP FRONT (#495): links-to edges address other pages by
+	# id, so a per-page substitution decided inside the loop would leave every
+	# inbound edge still pointing at the authored slug.
+	emitted = {p.name: _emitted_ref(p, minimise_scopes) for p in pages}
 	link_edges = 0
 
 	def _role_node(role: str) -> str:
@@ -195,13 +278,14 @@ def _build_graph_from_pages(pages, include_content: bool = False) -> dict:
 
 	for p in pages:
 		slug = p.name
-		pid = f"page:{slug}"
+		emit_slug, emit_label = emitted[slug]
+		pid = f"page:{emit_slug}"
 		scope = _norm_scope(p.scope)
 		node = {
 			"id": pid,
 			"kind": "page",
-			"label": p.title or slug,
-			"slug": slug,
+			"label": emit_label,
+			"slug": emit_slug,
 			"page_type": p.page_type if p.page_type in PAGE_TYPES else "Org",
 			"scope": scope,
 			"stale": is_stale(p.last_confirmed_at, p.modified),
@@ -247,7 +331,10 @@ def _build_graph_from_pages(pages, include_content: bool = False) -> dict:
 				targets.append(t)
 		for target in targets:
 			if target != slug:
-				edges.append({"source": pid, "target": f"page:{target}", "kind": "links-to"})
+				# Through ``emitted`` (#495), never the raw target: an inbound edge to a
+				# minimised page would otherwise re-publish the slug this change hides.
+				# Every target came from ``known_slugs``, so the lookup always resolves.
+				edges.append({"source": pid, "target": f"page:{emitted[target][0]}", "kind": "links-to"})
 				link_edges += 1
 
 	# member-of: connect each user to the role nodes they actually hold (roles
@@ -288,6 +375,11 @@ def record_history_snapshot() -> dict:
 	— real link growth + orphan decline over time — which the Evolution tab prefers
 	over the reconstructed-from-creation-dates fallback. Derived + rebuildable;
 	never raises into the scheduler."""
+	# #493: a disabled wiki records nothing. Tenant-side only, so no data leaves the
+	# site either way, but the toggle is meant to stop the wiki DOING things and the
+	# issue names this job explicitly.
+	if not wiki_enabled():
+		return {"ok": False, "reason": WIKI_DISABLED_REASON}
 	try:
 		return _record_history_snapshot()
 	except Exception:
@@ -326,6 +418,11 @@ def _record_history_snapshot() -> dict:
 
 def sync() -> dict:
 	"""Compute + push the graph. Swallows + logs; never raises into callers."""
+	# #493: no page metadata leaves a workspace whose wiki is switched off. Checked
+	# BEFORE _sync, so a disabled workspace does no graph computation at all rather
+	# than building a payload (minimisation included) and then discarding it.
+	if not wiki_enabled():
+		return {"ok": False, "reason": WIKI_DISABLED_REASON}
 	try:
 		return _sync()
 	except Exception:
@@ -346,6 +443,10 @@ def _sync() -> dict:
 def enqueue_sync() -> None:
 	"""Queue the deduped graph sync (short queue). Suppressed under tests;
 	enqueue failures (Redis down) are swallowed."""
+	# #493: checked BEFORE the in_test suppression so a test that opts into real
+	# enqueues still sees the kill switch.
+	if not wiki_enabled():
+		return
 	if frappe.flags.in_test and not frappe.flags.get("jarvis_test_wiki_graph_enqueue"):
 		return
 	try:

--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -172,10 +172,18 @@ def _opaque_page_ref(p, scope: str) -> tuple[str, str]:
 	The audience part (``--u-<localpart>`` / ``--r-<role>``) derives from the
 	target, never from the title, and is kept for legibility: it lets a vendor
 	operator still see WHOSE tier a node sits in, which is what the admin view is
-	for. Both are already on the graph anyway as ``user:``/``role:`` node labels.
-	Two pages of the same owner therefore share a LABEL and differ only by id,
+	for. Two pages of the same owner therefore share a LABEL and differ only by id,
 	which is the intended reading: "this person has four personal pages" without
 	what they are about.
+
+	That audience part is normally redundant, since the same person is already on
+	the graph as a ``user:`` node labelled with their full email. ONE case where it
+	is not: past ``MAX_USERS`` distinct authors ``_user_node`` stops minting nodes
+	and the scope edge falls back to org, so a capped-out owner's local part rides
+	here with no ``user:`` node beside it. Accepted rather than fixed. Suppressing
+	it conditionally would make the ref depend on how many OTHER pages were in the
+	push, which breaks the stability this whole helper exists to provide, and a
+	local part is strictly less than the title that used to travel in its place.
 
 	``SLUG_RE`` forbids a leading dash, so a synthetic ref beginning with ``--``
 	can never collide with a real page's slug and steal its activity overlay."""

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -35,6 +35,7 @@ import json
 import frappe
 from frappe.utils import cint
 
+from jarvis.chat.wiki import WIKI_DISABLED_REASON, wiki_enabled
 from jarvis.chat.wiki_graph import _MAX_LINKS_PER_PAGE
 
 WIKI = "Jarvis Wiki Page"
@@ -341,6 +342,13 @@ def sync(full: bool = False) -> dict:
 	A real Redis fault is re-queued too, not just logged. ``redis_lock`` propagates those
 	rather than yielding False, and treating one as a plain crash would strand the page
 	edit that triggered the job for exactly the same reason."""
+	# #493: a disabled wiki pushes nothing into the container. First statement in the
+	# function, so a short-circuited sync takes no lock, renders no page and makes no
+	# admin call. ``wiki_mirror_last_sync_status`` is deliberately NOT stamped: it
+	# reports the last real reconciliation, and overwriting it here would erase the
+	# operator's record of it.
+	if not wiki_enabled():
+		return {"ok": False, "reason": WIKI_DISABLED_REASON}
 	from jarvis._redis_lock import redis_lock
 
 	try:
@@ -535,6 +543,11 @@ def enqueue_sync(full: bool = False, after_commit: bool = False, retry: bool = F
 	is itself STARTED under that id, so the enqueue is silently skipped and the work is
 	dropped. A separate id is a separate dedup slot, so the retry is really queued while
 	still being deduped against other retries."""
+	# #493: checked BEFORE the in_test suppression so a test that opts into real
+	# enqueues still sees the kill switch. The doc_events trigger reaches the mirror
+	# through here, so this is where "every save re-pushes markdown" stops.
+	if not wiki_enabled():
+		return False
 	if frappe.flags.in_test and not frappe.flags.jarvis_test_wiki_mirror_enqueue:
 		return False
 	if retry:

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -23,6 +23,20 @@ class CapabilityDeniedError(JarvisError):
 	"""
 
 
+class FeatureDisabledError(JarvisError):
+	"""#493 - a tool for a feature the OPERATOR has switched off for this workspace.
+
+	Deliberately NOT a ``PermissionDeniedError``: nothing about the caller's Frappe
+	rights is wrong, and that hint ("ask your administrator to review your
+	permissions") would send them hunting through roles for what is a settings
+	checkbox. Like ``CapabilityDeniedError`` the answer is FIXED while the toggle is
+	off, so retrying, changing the arguments or reaching for a sibling tool can never
+	turn it into a yes. That instruction rides in the MESSAGE, because the plugin
+	relays only code + message to the model; the ``_ERROR_HINTS`` entry carries the
+	human-facing "what you can do" line.
+	"""
+
+
 class InvalidArgumentError(JarvisError):
 	"""Raised when tool arguments fail validation."""
 

--- a/jarvis/tests/test_wiki.py
+++ b/jarvis/tests/test_wiki.py
@@ -14,9 +14,10 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis import api
 from jarvis.chat import entities as entities_mod
 from jarvis.chat import wiki
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError, PermissionDeniedError
 from jarvis.tools.read_wiki import read_wiki
 from jarvis.tools.update_wiki import update_wiki
 
@@ -989,3 +990,123 @@ class TestWikiEnabledDefault(FrappeTestCase):
 			frappe.db.delete("Singles", {"doctype": "Jarvis Settings", "field": "wiki_enabled"})
 			if original is not None:
 				frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", original, update_modified=False)
+
+
+class TestWikiKillSwitchTools(FrappeTestCase):
+	"""#493: "Enable Business Wiki" is the operator's ONLY wiki kill switch, and it
+	used to gate every automatic behaviour and none of the agent-facing ones. With
+	the wiki off the agent still read every Org page and still created pages on
+	request.
+
+	Nothing removes the two tools from the agent's surface (``registry._TOOL_NAMES``
+	is a static tuple built at import; the plugin declares them statically in
+	another repo), so the refusal has to happen at dispatch. These tests therefore
+	drive the REAL entry point, ``jarvis.api._run_tool``, rather than calling the
+	tool functions and asserting the gate returns what the gate returns."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+		self.page = _make_page("customer--wikitest-killswitch", ALPHA, summary="terms are 60 days")
+
+	def tearDown(self):
+		# both fixture slugs carry "wikitest", so the shared sweeper covers them.
+		_delete_test_pages()
+
+	# --- read_wiki ---------------------------------------------------------
+	def test_read_wiki_is_refused_through_dispatch_when_the_wiki_is_off(self):
+		with _wiki_disabled():
+			r = api._run_tool("read_wiki", {"slug": self.page.name})
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "FeatureDisabledError")
+		self.assertEqual(r["error"]["message"], wiki.WIKI_DISABLED_MESSAGE)
+		# The whole envelope, not just the field we remembered to check: a refusal
+		# that still leaked the page's title or summary would defeat the point.
+		self.assertNotIn(ALPHA, json.dumps(r))
+		self.assertNotIn("terms are 60 days", json.dumps(r))
+
+	def test_read_wiki_search_is_refused_too_not_just_the_slug_path(self):
+		with _wiki_disabled():
+			r = api._run_tool("read_wiki", {"query": "wikitest"})
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "FeatureDisabledError")
+
+	def test_read_wiki_is_unchanged_when_the_wiki_is_on(self):
+		"""The normal state. Behaviour here must be indistinguishable from before."""
+		r = api._run_tool("read_wiki", {"slug": self.page.name})
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["title"], ALPHA)
+		self.assertEqual(r["data"]["summary"], "terms are 60 days")
+
+	def test_the_direct_call_is_gated_as_well_as_the_dispatch(self):
+		"""``api._run_tool`` is not the only way in, so the tool carries the gate
+		itself. A dispatch-only guard would leave every other caller open."""
+		with _wiki_disabled():
+			with self.assertRaises(FeatureDisabledError):
+				read_wiki(slug=self.page.name)
+
+	# --- update_wiki -------------------------------------------------------
+	def test_update_wiki_is_refused_and_parks_no_card_when_the_wiki_is_off(self):
+		"""``update_wiki`` is a _GATED_WRITES tool, so before this change a
+		disabled workspace still raised a confirmation card whose only possible
+		outcome was a refusal, on a workspace where the wiki UI is hidden. The card
+		IS the bug, so the assertion is that no card was parked, not merely that
+		the write did not land."""
+		with _wiki_disabled():
+			with patch("jarvis.chat.events.publish_to_user") as pub:
+				r = api._run_tool(
+					"update_wiki",
+					{
+						"slug": "org--wikitest-ks-new",
+						"title": "Killswitch New Page",
+						"page_type": "Org",
+						"append_md": "written with the wiki switched off",
+					},
+				)
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "FeatureDisabledError")
+		self.assertNotEqual((r.get("data") or {}).get("status"), "pending_confirmation")
+		pub.assert_not_called()
+		self.assertFalse(frappe.db.exists(WIKI_DT, "org--wikitest-ks-new"))
+
+	def test_update_wiki_still_parks_a_confirmation_card_when_the_wiki_is_on(self):
+		"""The regression direction: with the toggle ON the gated-write park is
+		exactly what it always was."""
+		with patch("jarvis.chat.events.publish_to_user") as pub:
+			r = api._run_tool(
+				"update_wiki",
+				{
+					"slug": "org--wikitest-ks-new",
+					"title": "Killswitch New Page",
+					"page_type": "Org",
+					"append_md": "written with the wiki switched on",
+				},
+			)
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		pub.assert_called_once()
+		self.assertEqual(pub.call_args[0][1]["kind"], "action:pending")
+
+	def test_update_wiki_direct_call_is_gated(self):
+		"""Covers confirming a card that was parked BEFORE the operator flipped
+		the toggle: ``dispatch_confirmed`` runs the tool function, not the
+		pre-park gate."""
+		with _wiki_disabled():
+			with self.assertRaises(FeatureDisabledError):
+				update_wiki(slug="org--wikitest-ks-new", title="X", page_type="Org", append_md="x")
+		self.assertFalse(frappe.db.exists(WIKI_DT, "org--wikitest-ks-new"))
+
+	# --- the shape of the refusal -----------------------------------------
+	def test_the_refusal_is_not_a_permission_error_and_tells_the_model_not_to_retry(self):
+		"""A bare permission error reads to the agent like a bug worth retrying and
+		sends the user hunting through roles for what is a settings checkbox."""
+		self.assertFalse(issubclass(FeatureDisabledError, PermissionDeniedError))
+		msg = wiki.WIKI_DISABLED_MESSAGE.lower()
+		self.assertIn("turned off", msg)
+		self.assertIn("will not help", msg)
+		self.assertIn("enable business wiki", msg)
+		# The plugin relays only code + message to the model, so the no-retry
+		# instruction has to be in the MESSAGE, not the hint.
+		hint = api._ERROR_HINTS.get("FeatureDisabledError", "")
+		self.assertTrue(hint)
+		self.assertNotIn("permission", hint.lower())

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -578,6 +578,21 @@ class TestWikiGraphMinimisation(WikiGraphTestCase):
 			},
 		)
 
+	def test_widening_the_lever_to_role_actually_minimises_role_pages(self):
+		"""The module docstring offers "add Role to _MINIMISED_SCOPES" as a one-line
+		lever. Without this, that branch of ``_opaque_page_ref`` is dead code nobody
+		has ever run, and the lever would be a promise rather than a fact.
+
+		Drives the real ``compute_graph`` with the scope set widened, so it exercises
+		the emitted-ref plumbing and not just the helper in isolation."""
+		doc = self._page(f"{_PREFIX}-rolelever", "Approval Limits", scope="Role", target_role=_ROLE)
+		with patch.object(wiki_graph, "_MINIMISED_SCOPES", frozenset({"User", "Role"})):
+			payload = json.dumps(wiki_graph.compute_graph())
+		self.assertNotIn("Approval Limits", payload)
+		self.assertNotIn(doc.name, payload)
+		labels = [n["label"] for n in json.loads(payload)["nodes"] if n.get("scope") == "Role"]
+		self.assertIn(f"Role page ({_ROLE})", labels)
+
 	def test_a_role_page_keeps_its_real_title(self):
 		"""Deliberate, not an oversight (see the module docstring). A Role page is
 		authored for a named group whose role name already travels as its own node,

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -1,5 +1,6 @@
 """Tenant-side wiki-utilization graph compute + push (jarvis.chat.wiki_graph)."""
 
+import contextlib
 import json
 from unittest.mock import patch
 
@@ -15,6 +16,17 @@ _PREFIX = "graphtest"
 # Framework built-ins (never tenant data) used as a real Role/User link target.
 _ROLE = "System Manager"
 _USER = "Administrator"
+
+
+@contextlib.contextmanager
+def _wiki_disabled():
+	"""Drive the real operator toggle (#493), never a patched ``wiki_enabled``:
+	the question these tests ask is whether the production callers consult it."""
+	frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 0, update_modified=False)
+	try:
+		yield
+	finally:
+		frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 1, update_modified=False)
 
 
 def _delete_pages():
@@ -78,6 +90,11 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 	def _node(self, g, node_id):
 		return next((n for n in g["nodes"] if n["id"] == node_id), None)
 
+	def _pid(self, doc):
+		"""The node id this page travels under in the ADMIN push. Identical to
+		``page:<slug>`` for every scope except the minimised ones (#495)."""
+		return f"page:{wiki_graph._emitted_ref(doc, True)[0]}"
+
 	def test_org_page_scope_edge_and_no_body(self):
 		doc = self._page(f"{_PREFIX}-org", "Org Page")
 		g = self._graph()
@@ -106,7 +123,7 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		doc = self._page(f"{_PREFIX}-usercap", "User Page", scope="User", target_user=_USER)
 		with patch.object(wiki_graph, "MAX_USERS", 0):
 			g = self._graph()
-		pid = f"page:{doc.name}"
+		pid = self._pid(doc)
 		self.assertIsNone(self._node(g, f"user:{_USER}"))  # cap hit, no node
 		self.assertIn({"source": pid, "target": "org", "kind": "scope"}, g["edges"])
 
@@ -121,7 +138,7 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 	def test_user_page_makes_user_node_and_scope_edge(self):
 		doc = self._page(f"{_PREFIX}-user", "User Page", scope="User", target_user=_USER)
 		g = self._graph()
-		pid = f"page:{doc.name}"
+		pid = self._pid(doc)
 		uid = f"user:{_USER}"
 		self.assertIsNotNone(self._node(g, uid))
 		self.assertIn({"source": pid, "target": uid, "kind": "scope"}, g["edges"])
@@ -489,3 +506,163 @@ class TestWikiGraphSync(FrappeTestCase):
 			out = wiki_graph.sync()
 		self.assertTrue(out["ok"])
 		self.assertIn("pages", out)
+
+
+# A title a customer would be upset to find in the vendor's console. Deliberately
+# real free text, not "User Page": the production degenerate case is an authored
+# sentence, and a fixture that supplies a bland value proves nothing.
+_PRIVATE_TITLE = "salary dispute with manager Xavier"
+
+
+class TestWikiGraphMinimisation(WikiGraphTestCase):
+	"""#495: the daily push withheld bodies and summaries and then sent the TITLE
+	and SLUG of every scope, including private User pages. Titles are user-authored
+	free text and slugs derive from them.
+
+	Every assertion here runs over the WHOLE serialized payload rather than the one
+	field that was changed, because the slug carrying the title one field over is
+	exactly the way a half-fix passes."""
+
+	def _payload(self):
+		"""What ``sync`` posts, verbatim (``_sync`` pushes ``compute_graph()``)."""
+		return json.dumps(wiki_graph.compute_graph())
+
+	def _node(self, g, node_id):
+		return next((n for n in g["nodes"] if n["id"] == node_id), None)
+
+	def test_a_user_page_title_and_slug_are_both_absent_from_the_pushed_payload(self):
+		doc = self._page(f"{_PREFIX}-priv", _PRIVATE_TITLE, scope="User", target_user=_USER)
+		payload = self._payload()
+		self.assertNotIn(_PRIVATE_TITLE, payload)
+		# The slug is the other half. It derives from the title, so leaving it in
+		# would publish the same words under a different key.
+		self.assertNotIn(doc.name, payload)
+		# ...and the page is still THERE, as an opaque node. Minimisation, not
+		# deletion: the vendor console still needs to see the User tier exists.
+		node = next(n for n in json.loads(payload)["nodes"] if n.get("scope") == "User")
+		self.assertEqual(node["label"], "User page (--u-administrator)")
+		self.assertTrue(node["slug"].startswith("--u-administrator-"))
+
+	def test_an_org_page_node_is_byte_identical_to_before_the_change(self):
+		"""The regression direction. #495 is the one part of this work that changes
+		the ENABLED path, so an Org node is asserted WHOLE, not by its label."""
+		doc = self._page(f"{_PREFIX}-orgkeep", "Acme Corp Payment Terms")
+		node = self._node(json.loads(self._payload()), f"page:{doc.name}")
+		self.assertEqual(
+			node,
+			{
+				"id": f"page:{doc.name}",
+				"kind": "page",
+				"label": "Acme Corp Payment Terms",
+				"slug": doc.name,
+				"page_type": "Org",
+				"scope": "Org",
+				# freshly inserted, so modified is now and the 90-day window is wide open.
+				"stale": False,
+				"contradiction": False,
+				"created": str(doc.creation)[:10],
+			},
+		)
+
+	def test_a_role_page_keeps_its_real_title(self):
+		"""Deliberate, not an oversight (see the module docstring). A Role page is
+		authored for a named group whose role name already travels as its own node,
+		and admin joins its activity overlay on the slug."""
+		doc = self._page(f"{_PREFIX}-rolekeep", "Approval Limits", scope="Role", target_role=_ROLE)
+		payload = self._payload()
+		self.assertIn("Approval Limits", payload)
+		self.assertIn(doc.name, payload)
+
+	def test_the_opaque_ref_is_stable_across_two_consecutive_pushes(self):
+		"""Whatever is substituted has to derive from the page, never from a counter
+		or a timestamp: a node that changes identity daily makes the console's
+		history worthless, which is the opposite of the point."""
+		self._page(f"{_PREFIX}-stable", _PRIVATE_TITLE, scope="User", target_user=_USER)
+		first = [n for n in wiki_graph.compute_graph()["nodes"] if n.get("scope") == "User"]
+		second = [n for n in wiki_graph.compute_graph()["nodes"] if n.get("scope") == "User"]
+		self.assertEqual(len(first), 1)
+		self.assertEqual(first, second)
+
+	def test_a_link_into_a_user_page_does_not_republish_its_slug(self):
+		"""``links-to`` edges address pages by id. A substitution applied only to the
+		node would leave every inbound edge still carrying the authored slug, so the
+		payload assertion is what catches it."""
+		private = self._page(f"{_PREFIX}-linked", _PRIVATE_TITLE, scope="User", target_user=_USER)
+		public = self._page(f"{_PREFIX}-linker", "Public", body_md=f"see [[{private.name}]]")
+		payload = self._payload()
+		self.assertNotIn(private.name, payload)
+		self.assertNotIn(_PRIVATE_TITLE, payload)
+		g = json.loads(payload)
+		edge = next(e for e in g["edges"] if e["kind"] == "links-to" and e["source"] == f"page:{public.name}")
+		self.assertTrue(edge["target"].startswith("page:--u-administrator-"))
+
+	def test_the_tenant_spa_graph_still_gets_real_titles(self):
+		"""Minimisation is for the ADMIN push only. The customer's own Knowledge
+		Graph is inside their trust boundary and would be unusable without titles."""
+		self._page(f"{_PREFIX}-spa", _PRIVATE_TITLE, scope="User", target_user=_USER)
+		g = wiki_mod.get_wiki_graph()
+		self.assertIn(_PRIVATE_TITLE, json.dumps(g))
+
+	def test_user_emails_still_travel_and_that_is_deliberate(self):
+		"""#495 rules this out of scope: the usage rollup ingest in the same admin
+		file already sends per-tenant user emails. Asserted so a later reader can see
+		it was decided rather than missed."""
+		self._page(f"{_PREFIX}-mail", _PRIVATE_TITLE, scope="User", target_user=_USER)
+		self.assertIn(f"user:{_USER}", self._payload())
+
+
+class TestWikiGraphKillSwitch(WikiGraphTestCase):
+	"""#493: with the wiki switched off, page metadata kept leaving the site daily.
+	The gate runs BEFORE the graph is computed, so a disabled workspace does no work
+	rather than building a payload and discarding it."""
+
+	def test_sync_pushes_nothing_when_the_wiki_is_off(self):
+		self._page(f"{_PREFIX}-ks", "Killswitch")
+		with _wiki_disabled():
+			with patch("jarvis.admin_client.push_wiki_graph") as push:
+				out = wiki_graph.sync()
+		push.assert_not_called()
+		self.assertFalse(out["ok"])
+
+	def test_sync_computes_nothing_when_the_wiki_is_off(self):
+		"""Not merely "does not push": the gate is ahead of compute_graph, so a
+		disabled workspace never builds the payload in the first place."""
+		self._page(f"{_PREFIX}-ks2", "Killswitch")
+		with _wiki_disabled():
+			with patch.object(wiki_graph, "compute_graph") as compute:
+				wiki_graph.sync()
+		compute.assert_not_called()
+
+	def test_sync_still_pushes_when_the_wiki_is_on(self):
+		self._page(f"{_PREFIX}-ks3", "Killswitch")
+		with patch("jarvis.admin_client.push_wiki_graph", return_value={"ok": True}) as push:
+			out = wiki_graph.sync()
+		push.assert_called_once()
+		self.assertTrue(out["ok"])
+
+	def test_history_snapshot_is_a_noop_when_the_wiki_is_off(self):
+		with _wiki_disabled():
+			with patch.object(wiki_graph, "_record_history_snapshot") as work:
+				out = wiki_graph.record_history_snapshot()
+		work.assert_not_called()
+		self.assertFalse(out["ok"])
+
+	def test_history_snapshot_still_runs_when_the_wiki_is_on(self):
+		with patch.object(wiki_graph, "_record_history_snapshot", return_value={"ok": True}) as work:
+			wiki_graph.record_history_snapshot()
+		work.assert_called_once()
+
+	def test_enqueue_is_suppressed_when_the_wiki_is_off(self):
+		"""Checked ahead of the in_test suppression, so opting into real enqueues
+		still sees the kill switch."""
+		frappe.flags.jarvis_test_wiki_graph_enqueue = True
+		try:
+			with _wiki_disabled():
+				with patch("frappe.enqueue") as enq:
+					wiki_graph.enqueue_sync()
+			enq.assert_not_called()
+			with patch("frappe.enqueue") as enq:
+				wiki_graph.enqueue_sync()
+			enq.assert_called_once()
+		finally:
+			frappe.flags.jarvis_test_wiki_graph_enqueue = False

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -512,6 +512,10 @@ class TestWikiGraphSync(FrappeTestCase):
 # real free text, not "User Page": the production degenerate case is an authored
 # sentence, and a fixture that supplies a bland value proves nothing.
 _PRIVATE_TITLE = "salary dispute with manager Xavier"
+# What a page owned by _USER is labelled once minimised. Written out literally
+# rather than derived from the production helper, so the test still fails if the
+# helper's shape changes.
+_OPAQUE_LABEL = "User page (--u-administrator)"
 
 
 class TestWikiGraphMinimisation(WikiGraphTestCase):
@@ -530,6 +534,15 @@ class TestWikiGraphMinimisation(WikiGraphTestCase):
 	def _node(self, g, node_id):
 		return next((n for n in g["nodes"] if n["id"] == node_id), None)
 
+	def _minimised_nodes(self, g):
+		"""Every node emitted under Administrator's opaque User ref.
+
+		Selected by LABEL, not by "the one node whose scope is User": compute_graph
+		is org-wide with no scope filter, several sibling test modules create their
+		own User-scope pages, and CI's parallel runner orders files differently from
+		the serial one. A positional selector would pick up a neighbour's fixture."""
+		return [n for n in g["nodes"] if n.get("label") == _OPAQUE_LABEL]
+
 	def test_a_user_page_title_and_slug_are_both_absent_from_the_pushed_payload(self):
 		doc = self._page(f"{_PREFIX}-priv", _PRIVATE_TITLE, scope="User", target_user=_USER)
 		payload = self._payload()
@@ -539,9 +552,10 @@ class TestWikiGraphMinimisation(WikiGraphTestCase):
 		self.assertNotIn(doc.name, payload)
 		# ...and the page is still THERE, as an opaque node. Minimisation, not
 		# deletion: the vendor console still needs to see the User tier exists.
-		node = next(n for n in json.loads(payload)["nodes"] if n.get("scope") == "User")
-		self.assertEqual(node["label"], "User page (--u-administrator)")
-		self.assertTrue(node["slug"].startswith("--u-administrator-"))
+		nodes = self._minimised_nodes(json.loads(payload))
+		self.assertTrue(nodes, f"no node labelled {_OPAQUE_LABEL!r} in the payload")
+		for node in nodes:
+			self.assertTrue(node["slug"].startswith("--u-administrator-"))
 
 	def test_an_org_page_node_is_byte_identical_to_before_the_change(self):
 		"""The regression direction. #495 is the one part of this work that changes
@@ -578,9 +592,9 @@ class TestWikiGraphMinimisation(WikiGraphTestCase):
 		or a timestamp: a node that changes identity daily makes the console's
 		history worthless, which is the opposite of the point."""
 		self._page(f"{_PREFIX}-stable", _PRIVATE_TITLE, scope="User", target_user=_USER)
-		first = [n for n in wiki_graph.compute_graph()["nodes"] if n.get("scope") == "User"]
-		second = [n for n in wiki_graph.compute_graph()["nodes"] if n.get("scope") == "User"]
-		self.assertEqual(len(first), 1)
+		first = self._minimised_nodes(wiki_graph.compute_graph())
+		second = self._minimised_nodes(wiki_graph.compute_graph())
+		self.assertTrue(first, f"no node labelled {_OPAQUE_LABEL!r} in the payload")
 		self.assertEqual(first, second)
 
 	def test_a_link_into_a_user_page_does_not_republish_its_slug(self):

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -845,3 +845,20 @@ class TestMirrorKillSwitch(WikiMirrorTestCase):
 			enq.assert_not_called()
 		finally:
 			frappe.flags.jarvis_test_wiki_mirror_enqueue = False
+
+	def test_a_page_saved_with_the_wiki_on_still_triggers_the_mirror_job(self):
+		"""The paired direction, and the one an operator worries about.
+
+		``TestTriggers`` drives ``on_wiki_page_change`` directly with ``enqueue_sync``
+		mocked, so without this the real save-to-enqueue chain was only proven in the
+		OFF direction and a gate that killed it outright would still have looked
+		green. Asserts the queued METHOD too, so a save routed to some other job
+		could not read as a pass."""
+		frappe.flags.jarvis_test_wiki_mirror_enqueue = True
+		try:
+			with mock.patch("frappe.enqueue") as enq:
+				self._page("killswitch-save-on")
+			enq.assert_called()
+			self.assertEqual(enq.call_args[0][0], wiki_mirror.JOB_METHOD)
+		finally:
+			frappe.flags.jarvis_test_wiki_mirror_enqueue = False

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -772,3 +772,76 @@ class TestTriggers(WikiMirrorTestCase):
 				frappe.flags.jarvis_test_wiki_mirror_enqueue = False
 		finally:
 			frappe.flags.in_test = prev_in_test
+
+
+@contextlib.contextmanager
+def _wiki_disabled():
+	"""Drive the real operator toggle (#493), never a patched ``wiki_enabled``:
+	the question these tests ask is whether the production callers consult it."""
+	frappe.db.set_single_value(SETTINGS, "wiki_enabled", 0, update_modified=False)
+	try:
+		yield
+	finally:
+		frappe.db.set_single_value(SETTINGS, "wiki_enabled", 1, update_modified=False)
+
+
+class TestMirrorKillSwitch(WikiMirrorTestCase):
+	"""#493: the mirror's doc_events fire on every save, tool write and archive,
+	so with the wiki switched off the container kept receiving page markdown. The
+	workspace ``wiki/`` folder is the agent's cheap native read channel, which is
+	precisely what an operator reaching for the kill switch wants stopped."""
+
+	def test_sync_pushes_nothing_when_the_wiki_is_off(self):
+		self._page("killswitch")
+		with _wiki_disabled():
+			with self._mock_push() as push:
+				out = wiki_mirror.sync()
+		push.assert_not_called()
+		self.assertFalse(out["ok"])
+
+	def test_sync_still_pushes_when_the_wiki_is_on(self):
+		"""The regression direction: nothing about the normal state moved."""
+		self._page("killswitch-on")
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		push.assert_called()
+		self.assertTrue(out["ok"])
+		self.assertIn(f"customers/{SLUG_PREFIX}--killswitch-on.md", self._pushed_paths(push))
+
+	def test_a_short_circuited_sync_does_not_overwrite_the_last_sync_status(self):
+		"""It reports the last real reconciliation. Stamping "disabled" over it
+		would erase the operator's record of when the mirror last actually ran."""
+		self._page("killswitch-status")
+		with self._mock_push():
+			wiki_mirror.sync()
+		before = frappe.db.get_single_value(SETTINGS, "wiki_mirror_last_sync_status")
+		with _wiki_disabled():
+			wiki_mirror.sync()
+		self.assertEqual(frappe.db.get_single_value(SETTINGS, "wiki_mirror_last_sync_status"), before)
+
+	def test_enqueue_is_suppressed_when_the_wiki_is_off(self):
+		"""Checked ahead of the in_test suppression, so opting into real enqueues
+		still sees the kill switch. This is the doc_events path: on_wiki_page_change
+		reaches the mirror through enqueue_sync."""
+		frappe.flags.jarvis_test_wiki_mirror_enqueue = True
+		try:
+			with _wiki_disabled():
+				with mock.patch("frappe.enqueue") as enq:
+					self.assertFalse(wiki_mirror.enqueue_sync())
+			enq.assert_not_called()
+			with mock.patch("frappe.enqueue") as enq:
+				self.assertTrue(wiki_mirror.enqueue_sync())
+			enq.assert_called_once()
+		finally:
+			frappe.flags.jarvis_test_wiki_mirror_enqueue = False
+
+	def test_a_page_saved_with_the_wiki_off_triggers_no_mirror_job(self):
+		"""The whole doc_events chain, driven by a real save."""
+		frappe.flags.jarvis_test_wiki_mirror_enqueue = True
+		try:
+			with _wiki_disabled():
+				with mock.patch("frappe.enqueue") as enq:
+					self._page("killswitch-save")
+			enq.assert_not_called()
+		finally:
+			frappe.flags.jarvis_test_wiki_mirror_enqueue = False

--- a/jarvis/tools/read_wiki.py
+++ b/jarvis/tools/read_wiki.py
@@ -22,8 +22,8 @@ import frappe
 from frappe.utils import cint
 
 from jarvis.chat import wiki_permissions
-from jarvis.chat.wiki import is_stale
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.chat.wiki import WIKI_DISABLED_MESSAGE, is_stale, wiki_enabled
+from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError, PermissionDeniedError
 
 WIKI = "Jarvis Wiki Page"
 _MAX_LIMIT = 10
@@ -44,6 +44,14 @@ def read_wiki(query: str | None = None, slug: str | None = None, limit: int = 5)
 	for a search returning ``[{slug, title, page_type, summary, stale,
 	manual_links}]``."""
 	_require_system_user()
+	# #493: "Enable Business Wiki" is the operator's only wiki kill switch, and
+	# nothing removes this tool from the agent's surface (registry.py builds a
+	# static tuple at import; the plugin declares it statically), so the toggle has
+	# to be honoured HERE or the agent keeps reading every Org page with the wiki
+	# switched off. After the identity check on purpose: an unauthorised caller
+	# still gets exactly the answer it got before this change.
+	if not wiki_enabled():
+		raise FeatureDisabledError(WIKI_DISABLED_MESSAGE)
 	if slug:
 		return _get_by_slug(str(slug))
 	if query:

--- a/jarvis/tools/update_wiki.py
+++ b/jarvis/tools/update_wiki.py
@@ -25,8 +25,8 @@ Scopes (wiki v2): optional ``scope`` — "Org" (default) or "User".
 import frappe
 
 from jarvis.chat import wiki_permissions
-from jarvis.chat.wiki import PAGE_TYPES, append_source
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.chat.wiki import PAGE_TYPES, WIKI_DISABLED_MESSAGE, append_source, wiki_enabled
+from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError, PermissionDeniedError
 from jarvis.permissions import JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE
 
 WIKI = "Jarvis Wiki Page"
@@ -90,6 +90,14 @@ def update_wiki(
 	``scope="User"`` writes the caller's personal page instead of the org
 	wiki (any Jarvis User). Returns a compact summary of the saved page."""
 	_require_system_user()
+	# #493: the operator toggle has to refuse the write channel too, or turning the
+	# wiki off leaves the agent still creating pages on request. api._run_tool
+	# carries the same gate BEFORE the confirmation park (so a workspace with the
+	# wiki off never raises a card whose only outcome is this refusal); this one
+	# catches every other dispatch path, including confirming a card that was
+	# parked before the toggle was flipped.
+	if not wiki_enabled():
+		raise FeatureDisabledError(WIKI_DISABLED_MESSAGE)
 	user = frappe.session.user
 
 	slug = (slug or "").strip().lower()


### PR DESCRIPTION
## Summary

Turning off "Enable Business Wiki" now actually turns the wiki off. Before this it hid the SPA pill and stopped the automatic behaviours while the agent kept reading every Org page, kept creating pages on request, the container mirror kept pushing markdown on every save, and page metadata kept leaving the site daily. Whoever reaches for that switch during an incident is who notices.

Separately, the daily graph push no longer sends the titles and slugs of private User pages to the control plane. A personal page titled "salary dispute with manager X" travelled verbatim, and the slug carried it too. Org and Role pages are unchanged.

Both land in `wiki_graph.py`, so they ship together rather than as two PRs fighting over one file.

With the wiki ON every gate is a no-op, so the four gated surfaces behave exactly as before and each has a paired test saying so. The one thing that does move on the enabled path is the User-page minimisation, so an Org node is asserted whole in tests rather than by its label.

Fixes #493
Fixes #495

<details>
<summary>Mechanism</summary>

Nothing removes the two tools from the agent's surface: `registry._TOOL_NAMES` is a static tuple built at import and the plugin declares both statically in another repo. So the tools stay declared and the refusal happens at dispatch, as a new `FeatureDisabledError`. Not a permission error: no role of the caller's is wrong, and the permission hint would send them hunting through roles for a settings checkbox. The message names the setting and tells the model that retrying or switching tools cannot help, because the plugin relays only code + message to the model.

This is the exact text the agent sees:

> The business wiki is turned off for this workspace, so wiki pages cannot be read or written. This is an operator setting rather than a permission problem, so retrying, changing the arguments or calling the other wiki tool will not help. Answer from what you already know, and if the user needs the wiki, tell them an administrator can switch it back on with "Enable Business Wiki" in Jarvis Settings.

`api._run_tool` carries the same gate ahead of everything else. `update_wiki` is a `_GATED_WRITES` tool, so without a pre-park check a disabled workspace still raised a confirmation card whose only possible outcome was that refusal, on a workspace whose wiki UI is hidden. The tools keep their own gate too, so no other dispatch path is open, including confirming a card parked before the toggle was flipped.

The mirror short-circuits in `enqueue_sync` (the doc_events path) and in `sync` itself, before the lock and before any render. `wiki_mirror_last_sync_status` is left alone on purpose: it reports the last real reconciliation. The graph short-circuits in `sync`, `record_history_snapshot` and `enqueue_sync`, ahead of `compute_graph`, so a disabled workspace does no graph work rather than building a payload and discarding it.

For #495, User pages travel under a stable opaque ref, for example `--u-kavin-82c0644921` labelled `User page (--u-kavin)`. The digest is over the docname, which `autoname: field:slug` freezes at create time, so the console shows the same node every day instead of a fresh one whose history is worthless. Both the label and the slug are replaced, since the slug derives from the title. The substitution is resolved for every page up front because `links-to` edges address pages by id, and a node-only fix would leave every inbound edge still carrying the authored slug.

</details>

<details>
<summary>Decisions and what was deliberately not done</summary>

**Role scope keeps its real title and slug.** The issue names Org and User and is silent on Role. A Role page is authored for a named group whose role name already travels as its own node, and admin joins its READ/WRITE activity overlay on the slug (`jarvis_admin_v2/wiki/graph.py:153-162`). Minimising there would go past what the issue asked and blind a working vendor view for a tier nobody raised. `_MINIMISED_SCOPES` is the one-line lever if that judgement is overruled.

**The admin activity overlay goes dark for User pages.** That same slug join is how admin attaches read counts and last-read timestamps to a node, so User-tier nodes will now show no demand. This is the intended cost of minimisation, not a regression.

**User emails still travel** as `user:` node labels. #495 rules this out of scope because the usage rollup ingest already sends them, and I agree: removing them would break the `member-of` and `authored` edges the whole graph exists to show.

**Stale mirrored files remain readable to the agent.** Short-circuiting the push means the workspace `wiki/` folder keeps whatever was last written there, and the persona tells the agent to prefer grepping `wiki/`. So with the wiki off the agent can still read previously mirrored Org page content off disk. The kill switch closes the DB read path, the write path and both pushes, but it does not scrub the container.

**And it is worse than "does not scrub": it blocks revocations.** A page archived, trashed or narrowed to Role/User while the wiki is off would normally enqueue a prune that deletes its container file. That prune is now gated too, and the mirror has no periodic sweep to catch up, so re-enabling fires nothing and the revoked file sits there until something else triggers a real sync. Disabling the wiki therefore makes one specific thing more exposed, not less, which is the opposite of what the toggle is for. **After re-enabling, run a full mirror sync**, which is step 7 of the manual plan.

Not fixed here, and the obvious one-liner does not work: letting prune-motivated calls bypass the gate would not help, because the prune rides a `full=True` sync that re-pushes every Org page, which is exactly the behaviour the kill switch exists to stop. The real fix is a delete-only reconciliation path, which is a feature rather than a patch, so it is disclosed rather than invented mid-PR. Worth its own issue.

**`record_app_wiki` is still ungated.** The app-learning scribe's writeback is a different feature's pipeline than the four surfaces #493 names.

**The field's label and description are unchanged**, per the issue's own first fix option.

</details>

<details>
<summary>Tests, and evidence each one failed first</summary>

I could not run the new tests locally: bench imports `apps/jarvis`, not the worktree, and copying test files into the main checkout would disturb the operator's working state. Instead each assertion was probed against the running bench, which is pre-fix `develop` by construction, and every one behaved as the bug describes. Fixtures were rolled back and the site left with zero wiki pages, as it started.

Pre-fix, with the wiki switched OFF:

| Probe | Pre-fix result |
|---|---|
| `_run_tool("read_wiki", {"slug": ...})` | `ok: True`, returned the page title |
| `_run_tool("update_wiki", ...)` | `ok: True`, `status: pending_confirmation` (the card fired) |
| `wiki_mirror.sync()` | `push_wiki_files` called |
| `wiki_graph.sync()` | `push_wiki_graph` called, `ok: True` |
| `json.dumps(compute_graph())` (wiki on) | contained both the private title and the real User slug |

The new code was then run against the same real database by loading the branch's modules directly, confirming every post-fix assertion: the private title and real slug absent from the payload, Org and Role titles present, the inbound link edge retargeted to the opaque id, the ref identical across two consecutive pushes, the tenant SPA graph still carrying real titles, and each of the four surfaces refusing when off and working when on.

New tests, all paired off/on:

- `test_wiki.py::TestWikiKillSwitchTools` (9): `read_wiki` slug and query paths refused through the real `_run_tool` dispatch and unchanged when on; `update_wiki` refused with **no card parked** and no page created, and still parking a card when on; direct calls gated for both, which is the confirm-an-old-card path; the refusal shape asserted not to be a permission error.
- `test_wiki_graph.py::TestWikiGraphMinimisation` (7): the User title and slug both absent from the whole serialized payload; an Org node asserted as a full literal dict; a Role page keeping its real title; the ref stable across two pushes; an inbound `links-to` edge not republishing the slug; the tenant SPA still getting real titles; emails still travelling, recorded as decided.
- `test_wiki_graph.py::TestWikiGraphKillSwitch` (6) and `test_wiki_mirror.py::TestMirrorKillSwitch` (5): each entry point short-circuits when off and still runs when on, `compute_graph` proven not even called, the last-sync status proven untouched, and a real page save proven to trigger no mirror job.

Two existing tests asserted `page:<slug>` for a User page through `compute_graph()` and now resolve the emitted id instead. Every other existing assertion is untouched.

</details>

<details>
<summary>Manual test plan on the bench</summary>

The branch touches only `jarvis/**.py`. **No `bench migrate` and no SPA rebuild**, so no `www/jarvis.html` copy either.

**1. Get the branch onto the bench**

```bash
git -C ~/frappe/v16/bench-16/apps/jarvis fetch upstream
git -C ~/frappe/v16/bench-16/apps/jarvis checkout fix/493-495-wiki-gate-and-minimise
```

Your working tree survives: the three modified `package-lock.json` files and the untracked `jarvis/_watch.py` are not in this diff, so checkout carries them across untouched. No stash needed. Restart `bench start` so the changed Python is re-imported. Afterwards, `git -C ~/frappe/v16/bench-16/apps/jarvis checkout develop`.

**2. Open a console and seed two pages**

```bash
bench --site site.jarvis console
```

```python
import json, frappe
from jarvis import api
from jarvis.chat import wiki, wiki_graph, wiki_mirror
frappe.get_doc({"doctype":"Jarvis Wiki Page","slug":"mt-org","title":"Acme Corp Payment Terms","page_type":"Org","scope":"Org","status":"Active","body_md":"60 day terms."}).insert(ignore_permissions=True)
frappe.get_doc({"doctype":"Jarvis Wiki Page","slug":"mt-personal","title":"salary dispute with manager Xavier","page_type":"Org","scope":"User","target_user":"Administrator","status":"Active","body_md":"private"}).insert(ignore_permissions=True)
frappe.db.commit()
```

**3. Flip the toggle.** Field `wiki_enabled` on the `Jarvis Settings` Single, labelled "Enable Business Wiki". NULL counts as ON.

```python
frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 0, update_modified=False); frappe.db.commit()   # OFF
frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 1, update_modified=False); frappe.db.commit()   # ON
```

**4. Regression checks first, with the toggle ON.** This is the "did you break my wiki" list.

```python
api._run_tool("read_wiki", {"slug": "mt-org"})["data"]["title"]
```
Expect `'Acme Corp Payment Terms'`.

```python
api._run_tool("update_wiki", {"slug":"mt-new","title":"T","page_type":"Org","append_md":"x"})["data"]["status"]
```
Expect `'pending_confirmation'`, the confirmation card, exactly as today.

```python
wiki_mirror.sync()
```
Expect `{'ok': False, 'reason': 'admin/tenant unreachable; will retry next sync', ...}` on this bench, because it has no onboarded tenant, so the push seam returns None. The point is that it **reached the push**. On a provisioned tenant expect `ok: True` with `pushed_files` above zero, and `docker exec <container> ls wiki/org` shows the file.

In the SPA, the composer wiki pill is visible.

**5. Kill-switch checks, toggle OFF.** Re-run the same four.

```python
api._run_tool("read_wiki", {"slug": "mt-org"})
```
Expect `ok: False`, `error.code == 'FeatureDisabledError'`, and `error.message` exactly:

> The business wiki is turned off for this workspace, so wiki pages cannot be read or written. This is an operator setting rather than a permission problem, so retrying, changing the arguments or calling the other wiki tool will not help. Answer from what you already know, and if the user needs the wiki, tell them an administrator can switch it back on with "Enable Business Wiki" in Jarvis Settings.

```python
api._run_tool("update_wiki", {"slug":"mt-new2","title":"T","page_type":"Org","append_md":"x"})
frappe.db.exists("Jarvis Wiki Page", "mt-new2")
```
Expect the same refusal, **no** `pending_confirmation`, and `None` for the exists check.

```python
wiki_mirror.sync()
wiki_graph.sync()
wiki_graph.record_history_snapshot()
```
All three expect `{'ok': False, 'reason': 'the business wiki is turned off for this workspace'}`. In the SPA the composer pill is gone, as before.

**6. #495, inspect the pushed payload.** The scheduler is paused, so nothing fires on its own. `compute_graph()` is byte-for-byte what `sync()` posts, since `_sync` pushes it unmodified.

```python
frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 1, update_modified=False); frappe.db.commit()
p = json.dumps(wiki_graph.compute_graph())
print("private title travels:", "salary dispute with manager Xavier" in p)   # expect False
print("private slug travels:", "mt-personal--u-administrator" in p)          # expect False
print("org title travels:", "Acme Corp Payment Terms" in p)                  # expect True
print([n for n in json.loads(p)["nodes"] if n.get("scope") == "User"])
```

The last line prints one node whose `label` is `User page (--u-administrator)` and whose `slug` starts `--u-administrator-`. Run the two `compute_graph()` calls again and confirm the id is identical.

Stronger evidence if you have an onboarded tenant: run `wiki_graph.sync()` and read `Jarvis Wiki Graph Snapshot.structure_json` for that tenant on the admin site. That is the control plane's own copy rather than a Python return value, so prefer it when it is reachable.

**7. The stale-mirror caveat, seen rather than read.** With a provisioned tenant: with the wiki ON run `wiki_mirror.sync(full=True)` and confirm `docker exec <container> ls wiki/org` lists `mt-org.md`. Switch the wiki OFF, run `wiki_mirror.sync()` again, and list the folder once more. The file is still there and still greppable by the agent. That is the documented limit of this kill switch. Then re-enable and run `wiki_mirror.sync(full=True)` once, which is the step that reconciles anything archived or narrowed during the disabled window.

**8. Clean up**

```python
for n in frappe.get_all("Jarvis Wiki Page", filters={"name": ["like", "mt-%"]}, pluck="name"):
    frappe.delete_doc("Jarvis Wiki Page", n, force=True, ignore_permissions=True)

frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 1, update_modified=False); frappe.db.commit()
```

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on :x:)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
