### PR TITLE
fix(ui): centre alert icons on the first line, add setup-wait progress bar (#725, #726)

### DIFF
--- a/design.md
+++ b/design.md
@@ -397,11 +397,19 @@ is theirs.)
 
 ### 3.7 Banners & notices
 
-- Inline alert (press `AlertBanner` shape): `flex items-center justify-between rounded-md p-2`
-  with typed fill — info `bg-surface-blue-2 text-ink-blue-3`, warning `bg-surface-amber-2
+- Inline alert (press `AlertBanner` shape, `Banner.vue`): `flex items-start gap-2.5 rounded-md
+  p-2.5` with typed fill: info `bg-surface-blue-2 text-ink-blue-3`, warning `bg-surface-amber-2
   text-ink-amber-3`, error `bg-surface-red-2 text-ink-red-3`, success green; icon
-  `lucide-info` / `lucide-alert-triangle` at `size-4`; copy `font-medium text-ink-gray-8`;
-  optional action button + ghost `lucide-x` dismiss.
+  `lucide-info` / `lucide-alert-triangle` at bare `size-4` (no chip, border, or background
+  around it; a wrapped icon box taller than one text line is what jarvis#725 was); copy
+  `font-medium text-ink-gray-8`; optional action button + ghost `lucide-x` dismiss.
+  **Alignment (jarvis#725): `items-start`, not `items-center`.** A bare `size-4` icon (16px)
+  sits close enough to a `text-sm` line (~15px) that `items-start` alone already reads as
+  centered on a single line. Because the icon's own height doesn't grow with the content, it
+  also stays pinned to the FIRST line no matter how many lines follow, which `items-center`
+  does not: on a title+message banner or a message that wraps, `items-center` centers the
+  icon against the whole block and visibly drifts it away from line one. Decide by rendering
+  both, not by picking the property that reads better in the one-line case.
 - Quiet informational note (Helpdesk): bordered box, not colored fill —
   `rounded-md p-2 ring-1 ring-outline-gray-modals` + `size-4` icon + `text-xs text-ink-gray-7`
   (`outline-gray-modals` matches `outline-gray-1` in light but diverges in dark).

--- a/frontend/src/components/Banner.vue
+++ b/frontend/src/components/Banner.vue
@@ -1,21 +1,38 @@
 <!--
   Reusable inline banner (design.md §3.7 "Banners & notices"). Sits in a fixed
   slot on a screen (a form step, a blocked action) instead of loose colored
-  text. Icon tile + title/message body + an optional #action slot for a
+  text. Icon + title/message body + an optional #action slot for a
   Retry-style button. Wired into onboarding's error/notice surfaces (9 spots
   in OnboardingView.vue) and ChatView's billing/paused banners — the
   type/title/message props and the default/#action slots are a stable API
   that every call site depends on; only the internal styling below changed.
+
+  jarvis#725: the icon used to sit in a bordered size-6.5 (26px) chip next to
+  `items-start`. A single text-sm line is only ~15px tall, so the chip's own
+  centered icon landed well below the text's center - visibly top-heavy on
+  the common single-line case. Two fixes were possible: switch to
+  `items-center` (design.md's literal words), or shrink the icon box to the
+  text's own line-height so `items-start` already centers it. items-center
+  was rejected because it centers the icon against the WHOLE flex item - for
+  a title+message banner (two lines) or a long message that wraps, that
+  drifts the icon toward the block's middle instead of staying on the first
+  line (verified in a throwaway visual harness, not shipped: items-center
+  visibly slides the icon down to straddle both lines once a second line is
+  added). Bare `size-4` (16px, design.md's own icon-size spec, no chip) sits
+  so close to a text-sm line (~15px) that `items-start` alone reads as
+  centered, and - because the icon no longer grows with the content - it
+  stays pinned to line one no matter how many lines follow. This also
+  matches the "Test failed" reference the issue called out as already
+  correct (LlmPoolEditor's .jv-status: a bare icon, no chip).
 -->
 <template>
 	<div class="flex items-start gap-2.5 rounded-md p-2.5" :class="variant.fill">
-		<span
-			class="grid size-6.5 shrink-0 place-items-center rounded-lg border bg-surface-white"
-			:class="variant.border"
+		<FeatherIcon
+			:name="variant.icon"
+			class="size-4 shrink-0"
+			:class="variant.ink"
 			aria-hidden="true"
-		>
-			<FeatherIcon :name="variant.icon" class="size-3.5" :class="variant.ink" />
-		</span>
+		/>
 		<div class="min-w-0 flex-1">
 			<template v-if="title">
 				<div class="text-sm font-semibold" :class="variant.ink">{{ title }}</div>
@@ -61,25 +78,21 @@ const props = defineProps({
 const VARIANTS = {
 	error: {
 		fill: "bg-surface-red-2",
-		border: "border-outline-red-2",
 		ink: "text-ink-red-3",
 		icon: "alert-circle",
 	},
 	warning: {
 		fill: "bg-surface-amber-2",
-		border: "border-outline-amber-2",
 		ink: "text-ink-amber-3",
 		icon: "alert-triangle",
 	},
 	success: {
 		fill: "bg-surface-green-2",
-		border: "border-outline-green-2",
 		ink: "text-ink-green-3",
 		icon: "check-circle",
 	},
 	info: {
 		fill: "bg-surface-blue-2",
-		border: "border-outline-blue-1",
 		ink: "text-ink-blue-3",
 		icon: "info",
 	},

--- a/frontend/src/components/learning/AppLearningCard.vue
+++ b/frontend/src/components/learning/AppLearningCard.vue
@@ -12,7 +12,7 @@
 		<div
 			class="mt-3 flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
 		>
-			<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
+			<FeatherIcon name="alert-triangle" class="size-4 shrink-0" />
 			<span>
 				A run reads only the apps you pick, and their source code is sent to the AI model
 				provider configured for this site. Source text — including comments and docstrings

--- a/frontend/src/components/learning/AppSourceConsentDialog.vue
+++ b/frontend/src/components/learning/AppSourceConsentDialog.vue
@@ -13,7 +13,7 @@
 			<div
 				class="mt-3 flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
 			>
-				<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
+				<FeatherIcon name="alert-triangle" class="size-4 shrink-0" />
 				<div class="space-y-1">
 					<div>
 						The <span class="font-medium">source code</span> of every app you select -

--- a/frontend/src/components/learning/InsightApplyDialog.vue
+++ b/frontend/src/components/learning/InsightApplyDialog.vue
@@ -27,7 +27,7 @@
 				v-else-if="phase === 'none'"
 				class="mt-3 flex items-start gap-2 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-7"
 			>
-				<FeatherIcon name="info" class="mt-0.5 size-4 shrink-0" />
+				<FeatherIcon name="info" class="size-4 shrink-0" />
 				<span>{{
 					draft.reason || "This insight is not worth folding into a skill."
 				}}</span>

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -239,3 +239,72 @@ export function connectHeadline(phase, { fromReadinessCeiling = false } = {}) {
 	// a different (and honestly reportable) thing from never getting an answer.
 	return "Setup hit a snag";
 }
+
+/**
+ * Progress-bar reading of a phase (jarvis#726), for the fixed 3-step shape
+ * already drawn as the phase list next to it: a settled prior fact (the save
+ * persisted / the payment cleared), the CURRENT phase (this function's
+ * argument), and a step that resolves only by leaving this screen entirely -
+ * `navigateToChat()` fires the instant `ready` is true, so that step is never
+ * rendered done in place. Reads the SAME phase object the row already
+ * renders (provisioningPhase / readinessPhase / inFlightPhase) - no separate
+ * source of truth, and in particular no ordering inferred across `reason`
+ * codes, which waitPhases.js does not encode and never has: a phase counts
+ * as done ONLY when the model itself says PHASE_STATE.DONE.
+ *
+ * That means the two waits behave differently here, honestly:
+ * provisioningPhase has a DONE branch (tenant_status === "running"), so the
+ * provisioning wait's bar can and does advance to 2 of 3 mid-screen.
+ * readinessPhase has NO done branch at all - every reason it knows about
+ * maps to ACTIVE or UNKNOWN - so the connect wait's bar stays at 1 of 3
+ * until the moment is_ready_for_chat says ready and the screen navigates
+ * away; it never fills to 2 in place. Both waits still get the bar: the
+ * provisioning wait makes the determinate case real and demonstrable, and
+ * the connect wait's honestly-stuck-at-1/3 bar is exactly the indeterminate
+ * case this function has to tell apart from real progress.
+ *
+ * `indeterminate` is true whenever the phase carries nothing to act on -
+ * PHASE_STATE.UNKNOWN, or no phase read yet. It must render differently from
+ * the ACTIVE case: ACTIVE means the last poll told us specifically what's
+ * running (or, for inFlightPhase, that we are genuinely asking right now -
+ * itself known, not guessed, which is why inFlightPhase's state is ACTIVE
+ * and this counts it as determinate, matching the rest of this module's
+ * philosophy). UNKNOWN means the last poll told us nothing. A bar that looks
+ * identical for both would fake the confidence the honest phase label next
+ * to it already refuses to claim.
+ *
+ * The bar's own visible label is deliberately just "Step {current} of
+ * {total}" (built by the caller from `current`/`total`, not from `label`
+ * below) - never the phase's own sentence. The phase row right next to the
+ * bar already renders that sentence (waitPhases.js's whole reason for
+ * existing); repeating it as the bar's label too read as an unintentional
+ * duplicate rather than a deliberate echo. `label` is kept on the return
+ * value for callers that want it (tests, a future non-duplicating layout),
+ * not because OnboardingView.vue's bar renders it directly.
+ *
+ * @param {{state?: string, label?: string}} [phase]
+ * @returns {{done: number, current: number, total: number, percent: number,
+ *   label: string, indeterminate: boolean}} `done` is how many of `total`
+ *   segments fill. `current` is the 1-indexed step the customer is ON
+ *   (done + 1, capped at total) - never `done` itself, because a customer
+ *   watching this is on the step that ISN'T done yet. `percent` is `done` /
+ *   `total` rounded to an integer, for the Progress component's numeric
+ *   `value` prop (frappe-ui's own `filledIntervalCount` re-derives the
+ *   segment count from this by rounding it back against `total`, so the
+ *   rounding here never changes which segments fill) - it exists only so
+ *   the rendered `aria-valuenow` is a clean integer instead of a repeating
+ *   fraction; it is never displayed to the customer as a percentage.
+ */
+export function phaseProgress(phase) {
+	const total = 3;
+	const state = phase && phase.state;
+	const done = state === PHASE_STATE.DONE ? 2 : 1;
+	return {
+		done,
+		current: Math.min(done + 1, total),
+		total,
+		percent: Math.round((done / total) * 100),
+		label: (phase && phase.label) || "",
+		indeterminate: !phase || state === PHASE_STATE.UNKNOWN,
+	};
+}

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -7,6 +7,7 @@ import {
 	readinessPhase,
 	inFlightPhase,
 	connectHeadline,
+	phaseProgress,
 } from "./waitPhases.js";
 
 // ---- provisioning wait ---------------------------------------------------
@@ -214,4 +215,80 @@ test("headline: no branch renders the phrase jarvis#709 removed", () => {
 	for (const [phase, opts] of cases) {
 		assert.doesNotMatch(connectHeadline(phase, opts), /still finishing setup/i);
 	}
+});
+
+// ---- progress bar (jarvis#726) --------------------------------------------
+
+test("progress: an ACTIVE phase is 1 of 3, and determinate", () => {
+	const p = phaseProgress(provisioningPhase({ answered: true, tenantStatus: "pending" }));
+	assert.equal(p.done, 1);
+	assert.equal(p.current, 2);
+	assert.equal(p.total, 3);
+	assert.equal(p.percent, 33);
+	assert.equal(p.indeterminate, false);
+});
+
+test("progress: a DONE phase is 2 of 3, and determinate - the only branch that fills segment two", () => {
+	const p = phaseProgress(provisioningPhase({ answered: true, tenantStatus: "running" }));
+	assert.equal(p.done, 2);
+	assert.equal(p.current, 3);
+	assert.equal(p.percent, 67);
+	assert.equal(p.indeterminate, false);
+});
+
+// frappe-ui's Progress re-derives filledIntervalCount as
+// Math.round((value/100)*intervalCount) - confirm the rounding in `percent`
+// never changes which segment count that produces, for both reachable states.
+test("progress: percent survives frappe-ui's own round-trip back to a segment count", () => {
+	for (const [done, total] of [
+		[1, 3],
+		[2, 3],
+	]) {
+		const percent = phaseProgress({
+			state: done === 2 ? PHASE_STATE.DONE : PHASE_STATE.ACTIVE,
+		}).percent;
+		assert.equal(Math.round((percent / 100) * total), done, `done=${done}`);
+	}
+});
+
+test("progress: readinessPhase has no DONE branch, so it never passes 1 of 3 in place", () => {
+	const reasons = [
+		"llm_pool_provisioning",
+		"llm_provisioning",
+		"container_provisioning",
+		"readiness_unconfirmed",
+		"authority_repair_required",
+		"subscription_suspended",
+		"site_replaced",
+		"unmapped",
+	];
+	for (const reason of reasons) {
+		const p = phaseProgress(readinessPhase({ answered: true, reason }));
+		assert.equal(p.done, 1, reason);
+	}
+});
+
+test("progress: UNKNOWN is indeterminate even though it still fills the settled segment", () => {
+	const p = phaseProgress(readinessPhase({ answered: true, reason: "readiness_unconfirmed" }));
+	assert.equal(p.indeterminate, true);
+	assert.equal(p.done, 1); // segment one is a settled fact, not faked by this state
+});
+
+test("progress: an unanswered poll is indeterminate too", () => {
+	assert.equal(phaseProgress(readinessPhase({ answered: false })).indeterminate, true);
+	assert.equal(phaseProgress(provisioningPhase({ answered: false })).indeterminate, true);
+});
+
+test("progress: inFlightPhase is ACTIVE, not UNKNOWN - determinate per the module's own philosophy", () => {
+	const p = phaseProgress(inFlightPhase("Checking on your workspace"));
+	assert.equal(p.indeterminate, false);
+	assert.equal(p.done, 1);
+	assert.equal(p.current, 2);
+	assert.equal(p.label, "Checking on your workspace");
+});
+
+test("progress: no phase read yet (null/undefined) is indeterminate and never throws", () => {
+	assert.equal(phaseProgress(null).indeterminate, true);
+	assert.equal(phaseProgress(undefined).indeterminate, true);
+	assert.equal(phaseProgress(null).done, 1);
 });

--- a/frontend/src/pages/agents/ActivationPanel.vue
+++ b/frontend/src/pages/agents/ActivationPanel.vue
@@ -84,7 +84,7 @@
 						v-if="mode === 'promote'"
 						class="flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
 					>
-						<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
+						<FeatherIcon name="alert-triangle" class="size-4 shrink-0" />
 						<div class="space-y-1">
 							<div>
 								This lets <span class="font-medium">{{ agentTitle }}</span> run
@@ -105,7 +105,7 @@
 						v-else
 						class="flex items-start gap-2 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-7"
 					>
-						<FeatherIcon name="eye-off" class="mt-0.5 size-4 shrink-0" />
+						<FeatherIcon name="eye-off" class="size-4 shrink-0" />
 						<div>
 							This stops <span class="font-medium">{{ agentTitle }}</span> from
 							running live. Future runs go back to a reviewer-only preview until it

--- a/frontend/src/pages/agents/AgentRunsBoard.vue
+++ b/frontend/src/pages/agents/AgentRunsBoard.vue
@@ -153,7 +153,7 @@
 					v-if="selectedRun && selectedRun.preparation_mode === 'shadow'"
 					class="flex items-start gap-2 border-b bg-surface-violet-1 px-6 py-2.5 text-sm text-ink-violet-1"
 				>
-					<FeatherIcon name="eye" class="mt-0.5 size-4 shrink-0" />
+					<FeatherIcon name="eye" class="size-4 shrink-0" />
 					<span>
 						Preview (shadow) - this run is visible to the named reviewer only and is
 						not a compliant attestation. Promote the capability to live before relying

--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -47,17 +47,15 @@
 		<TabBar class="shrink-0" :tabs="TABS" :model-value="tab" @update:model-value="setTab" />
 
 		<!-- persistent apply-failure banner: the reason must survive the toast and
-		     be reachable without hovering a badge (keyboard/SR access) -->
+		     be reachable without hovering a badge (keyboard/SR access). x-circle, not
+		     Banner's fixed error icon: matches AgentActivityTab's own run_failed
+		     convention, which Banner has no prop to select. -->
 		<div
 			v-if="canApply && syncFailed && !sync.pending"
 			class="mx-5 mt-3 flex shrink-0 items-start gap-2 rounded-lg border border-outline-red-1 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
 		>
-			<FeatherIcon name="x-circle" class="mt-0.5 size-4 shrink-0" />
-			<span>
-				Applying agents to your assistant failed<template v-if="syncFailureReason">
-					- {{ syncFailureReason }}</template
-				>. Use Retry apply to try again.
-			</span>
+			<FeatherIcon name="x-circle" class="size-4 shrink-0" />
+			<span>{{ syncFailureMessage }}</span>
 		</div>
 
 		<!-- Activity: self-contained feed (own search + pagination) -->
@@ -467,6 +465,12 @@ const sync = reactive({ pending: false, dirty: false, status: "" });
 const syncHuman = computed(() => humaniseSyncStatus(sync.status));
 const syncFailed = computed(() => syncHuman.value.kind === "failed");
 const syncFailureReason = computed(() => syncHuman.value.detail);
+const syncFailureMessage = computed(
+	() =>
+		`Applying agents to your assistant failed${
+			syncFailureReason.value ? ` - ${syncFailureReason.value}` : ""
+		}. Use Retry apply to try again.`
+);
 
 let syncTimer = null;
 async function loadSyncStatus() {

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -45,20 +45,22 @@
 		     Show the pages it wrote (with links) instead of a findings list, so a
 		     successful run reads as "N pages written", never a failure / "0 findings". -->
 		<template v-if="isScribe">
+			<!-- x-circle, not Banner's fixed error icon: matches AgentActivityTab's own
+				 run_failed convention (icon: "x-circle"), which Banner has no prop to
+				 select. -->
 			<div
 				v-if="run.status === 'failed'"
 				class="mt-4 flex items-start gap-2 rounded-lg border border-outline-red-1 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
 			>
-				<FeatherIcon name="x-circle" class="mt-0.5 size-4 shrink-0" />
+				<FeatherIcon name="x-circle" class="size-4 shrink-0" />
 				<span>{{ run.error || "This run failed before writing any pages." }}</span>
 			</div>
-			<div
+			<Banner
 				v-else-if="run.coverage_note"
-				class="mt-4 flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
-			>
-				<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
-				<span>{{ coverageNote }}.</span>
-			</div>
+				class="mt-4"
+				type="warning"
+				:message="`${coverageNote}.`"
+			/>
 
 			<div class="mt-5 text-base font-medium text-ink-gray-9">
 				{{ scribePages.length || run.pages_written || 0 }} wiki page{{
@@ -92,22 +94,20 @@
 
 		<template v-else>
 			<!-- coverage-honesty banner: a truncated scan must NEVER read as all-clear -->
-			<div
+			<Banner
 				v-if="coverageWarning"
-				class="mt-4 flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
-			>
-				<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
-				<span>
-					Partial scan - {{ coverageNote }}. Treat gaps as unreviewed, not clean.
-				</span>
-			</div>
+				class="mt-4"
+				type="warning"
+				:message="`Partial scan - ${coverageNote}. Treat gaps as unreviewed, not clean.`"
+			/>
 
-			<!-- failed run: surface the error; no findings snapshot was recorded -->
+			<!-- failed run: surface the error; no findings snapshot was recorded.
+				 x-circle, not Banner's fixed error icon: see the scribe branch above. -->
 			<div
 				v-if="run.status === 'failed'"
 				class="mt-4 flex items-start gap-2 rounded-lg border border-outline-red-1 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
 			>
-				<FeatherIcon name="x-circle" class="mt-0.5 size-4 shrink-0" />
+				<FeatherIcon name="x-circle" class="size-4 shrink-0" />
 				<span>{{ run.error || "This run failed before recording findings." }}</span>
 			</div>
 
@@ -295,6 +295,7 @@ import { ref, computed, watch } from "vue";
 import { useRouter } from "vue-router";
 import { Badge, Button, FeatherIcon, FormControl, Tooltip, toast } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
+import Banner from "@/components/Banner.vue";
 import { timeAgo, exactDate, formatDate } from "@/utils/datetime";
 import { renderMarkdown } from "@/markdown";
 import * as api from "@/api";

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -208,10 +208,7 @@
 								v-if="hasActionableB"
 								class="flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
 							>
-								<FeatherIcon
-									name="alert-triangle"
-									class="mt-0.5 size-4 shrink-0"
-								/>
+								<FeatherIcon name="alert-triangle" class="size-4 shrink-0" />
 								<span>
 									Rows marked <b>B</b> contain exact text every chat user on this
 									site can read once approved - expand a row for its role
@@ -387,7 +384,7 @@
 									>
 										<FeatherIcon
 											name="trending-down"
-											class="mt-0.5 size-4 shrink-0"
+											class="size-4 shrink-0"
 										/>
 										<span>
 											{{
@@ -407,7 +404,7 @@
 									<!-- shown on the EXPANDED decidable card only: repeated verbatim on
 								     every collapsed B row it trains the exact banner blindness it
 								     warns about (a group-level note above the list covers the rest) -->
-									<div
+									<Banner
 										v-if="
 											row.effective_sensitivity === 'B' &&
 											['Proposed', 'Stale', 'Snoozed'].includes(
@@ -415,14 +412,10 @@
 											) &&
 											expanded[row.name]
 										"
-										class="mt-2.5 flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
-									>
-										<FeatherIcon
-											name="alert-triangle"
-											class="mt-0.5 size-4 shrink-0"
-										/>
-										<span>{{ disclosureText(bRoles(row)) }}</span>
-									</div>
+										class="mt-2.5"
+										type="warning"
+										:message="disclosureText(bRoles(row))"
+									/>
 
 									<!-- drill-down toggle -->
 									<button
@@ -1581,15 +1574,10 @@
 		>
 			<template #body-content>
 				<div class="flex flex-col gap-3 text-sm">
-					<div
-						class="flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-ink-amber-3"
-					>
-						<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
-						<span>
-							Applying restarts the assistant for everyone for up to ~3 min. Active
-							chats may be briefly interrupted.
-						</span>
-					</div>
+					<Banner
+						type="warning"
+						message="Applying restarts the assistant for everyone for up to ~3 min. Active chats may be briefly interrupted."
+					/>
 					<p class="text-ink-gray-6">
 						Recompiles approved patterns into the learned-&lt;domain&gt; skills and
 						pushes them to your assistant. Only A-class (aggregate-safe) patterns are
@@ -1776,6 +1764,7 @@ import LayoutHeader from "@/components/LayoutHeader.vue";
 import SyncPill from "./SyncPill.vue";
 import InsightApplyDialog from "@/components/learning/InsightApplyDialog.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
+import Banner from "@/components/Banner.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { setChatPrefill } from "@/composables/chatPrefill";
 import { getSkillsAreaCaps } from "@/api/personalise";

--- a/frontend/src/pages/triggers/TriggerDetail.vue
+++ b/frontend/src/pages/triggers/TriggerDetail.vue
@@ -170,7 +170,7 @@
 						>
 							<FeatherIcon
 								name="alert-triangle"
-								class="mt-0.5 size-4 shrink-0 text-ink-amber-3"
+								class="size-4 shrink-0 text-ink-amber-3"
 							/>
 							<span class="text-sm font-medium text-ink-gray-8">
 								Server scripts are disabled on this bench — deterministic actions
@@ -284,7 +284,7 @@
 						Condition is valid.
 					</div>
 					<div v-else class="flex items-start gap-2 text-sm text-ink-red-4" role="alert">
-						<FeatherIcon name="alert-circle" class="mt-0.5 size-4 shrink-0" />
+						<FeatherIcon name="alert-circle" class="size-4 shrink-0" />
 						<span>{{ testResult.error || "Condition is not valid." }}</span>
 					</div>
 					<div

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -113,6 +113,7 @@ vi.mock("frappe-ui", () => {
 			props: ["message"],
 			template: '<div v-if="message">{{ message }}</div>',
 		},
+		Progress: { name: "Progress", template: '<div><slot name="hint" /></div>' },
 		dayjs: () => ({ format: () => "", fromNow: () => "" }),
 		toast: { error: vi.fn(), success: vi.fn() },
 	};

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -54,6 +54,7 @@ vi.mock("frappe-ui", () => ({
 		template: '<div v-if="message">{{ message }}</div>',
 	},
 	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	Progress: { name: "Progress", template: '<div><slot name="hint" /></div>' },
 	call: vi.fn(),
 	dayjs: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
 	toast: { error: vi.fn(), success: vi.fn() },

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -588,6 +588,26 @@
 											{{ setupRecheckNote }}
 										</p>
 									</div>
+									<!-- jarvis#726: a step-counted Progress bar, reading the SAME
+										 phase object the row below already renders - see
+										 waitPhases.phaseProgress for what it measures and why it
+										 goes indeterminate instead of guessing a percentage. Label is
+										 just "Step N of 3", not the phase's own sentence - that
+										 sentence already renders once, in the row below; repeating it
+										 here read as an accidental duplicate rather than emphasis. -->
+									<Progress
+										v-if="!provisioningDelayed"
+										class="ob-progress"
+										:class="{
+											'ob-progress--indeterminate':
+												provisioningProgress.indeterminate,
+										}"
+										:value="provisioningProgress.percent"
+										intervals
+										:interval-count="provisioningProgress.total"
+										size="md"
+										:label="`Step ${provisioningProgress.current} of ${provisioningProgress.total}`"
+									/>
 									<!-- Phase list. Row 1 is a settled fact. Row 2 renders ONLY what
 										 the last provisioning tick observed (waitPhases.js), so
 										 "Jarvis is getting ready for you" appears when admin itself
@@ -1252,6 +1272,24 @@
 												}}
 											</p>
 										</div>
+										<!-- jarvis#726: same step-counted bar as the provisioning wait,
+											 reading readinessStage. readinessPhase has no DONE branch
+											 (waitPhases.js), so this bar stays at 1 of 3 until the
+											 screen navigates to chat - it never fills segment two in
+											 place. Label is "Step N of 3" only, not the phase's own
+											 sentence - see the provisioning bar's comment above. -->
+										<Progress
+											class="ob-progress"
+											:class="{
+												'ob-progress--indeterminate':
+													readinessProgress.indeterminate,
+											}"
+											:value="readinessProgress.percent"
+											intervals
+											:interval-count="readinessProgress.total"
+											size="md"
+											:label="`Step ${readinessProgress.current} of ${readinessProgress.total}`"
+										/>
 										<!-- Phase list, driven by is_ready_for_chat's `reason` on the
 											 LAST poll (waitPhases.js). Before this the screen showed one
 											 fixed sentence for the whole two-minute wait, so a workspace
@@ -1489,7 +1527,7 @@
 <script setup>
 import { reactive, ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
 import { useRouter } from "vue-router";
-import { Button, FormControl, FeatherIcon, ErrorMessage } from "frappe-ui";
+import { Button, FormControl, FeatherIcon, ErrorMessage, Progress } from "frappe-ui";
 import { useJarvisTheme } from "@/theme";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
 import JvCombo from "@/components/JvCombo.vue";
@@ -1534,6 +1572,7 @@ import {
 	readinessPhase,
 	inFlightPhase,
 	connectHeadline,
+	phaseProgress,
 } from "@/onboarding/waitPhases.js";
 import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
@@ -1697,6 +1736,9 @@ const readinessStage = computed(() =>
 		  // reported that, so naming it is grounded.
 		  inFlightPhase("Applying your AI connection")
 );
+// jarvis#726: the Progress bar next to the phase list above, reading the SAME
+// readinessStage - see waitPhases.phaseProgress.
+const readinessProgress = computed(() => phaseProgress(readinessStage.value));
 
 // Plan 01 billing state. Namespaced by site identity + logged-in user so one
 // site's / user's transitional billing PII can never prefill another's on a
@@ -2464,6 +2506,9 @@ const provisioningStage = computed(() =>
 		? provisioningPhase(provisioningSeen.value)
 		: inFlightPhase("Checking on your workspace")
 );
+// jarvis#726: the Progress bar next to the phase list above, reading the SAME
+// provisioningStage - see waitPhases.phaseProgress.
+const provisioningProgress = computed(() => phaseProgress(provisioningStage.value));
 
 // The FULL-SCREEN busy view is only for the phases where there is genuinely
 // nothing to press: starting the signup, the sheet being open, confirming.
@@ -3959,6 +4004,33 @@ onUnmounted(() => {
 	outline: 2px solid var(--cta);
 	outline-offset: 2px;
 }
+/* ---- staged wait progress bar (jarvis#726, waitPhases.phaseProgress) ----
+   Segment one (the settled fact) is never touched here - it stays the plain
+   frappe-ui Progress fill in every state, determinate or not. Only the
+   CURRENT segment (nth-child(2) of the three fixed intervals) gets the
+   indeterminate treatment, and only when the phase itself is UNKNOWN: a
+   muted pulse reusing --surface-3, the same colour the waiting dot below
+   already uses for "nothing has reported this yet", so "we don't currently
+   know" reads consistently across both the bar and the phase list next to
+   it instead of inventing a second visual vocabulary for the same idea. */
+.ob-progress {
+	margin: 0 auto;
+	max-width: 420px;
+}
+.ob-progress--indeterminate :deep([role="progressbar"] > div:nth-child(2)) {
+	background: var(--surface-3);
+	animation: ob-progress-pulse 1.6s ease-in-out infinite;
+}
+@keyframes ob-progress-pulse {
+	0%,
+	100% {
+		opacity: 0.5;
+	}
+	50% {
+		opacity: 1;
+	}
+}
+
 /* ---- staged wait phases (waitPhases.js) --------------------------------
    One row per phase. The row's MODIFIER is the honesty contract, not
    decoration: `active` is only ever set from an observation, `unknown` means a
@@ -4092,6 +4164,10 @@ onUnmounted(() => {
 	}
 	.ob-details-form :deep(.jvc-field) {
 		transition: none;
+	}
+	.ob-progress--indeterminate :deep([role="progressbar"] > div:nth-child(2)) {
+		animation: none;
+		opacity: 0.75;
 	}
 }
 </style>


### PR DESCRIPTION
## Summary

Two related fixes on the onboarding Connect step.

**#725**: inline alert icons top-aligned instead of centring, worst on the single-line "Test your API key before you continue." warning. Fixed at the root in `Banner.vue` (icon drops its oversized chip, renders bare at `size-4`, `items-start` kept) and applied to every hand-rolled site with the same pattern; 4 of those, where icon and copy genuinely match `Banner`'s API, are migrated onto it. `design.md` 3.7 amended to match.

**#726**: the post-Connect setup wait had only a phase list, no sense of how far along a two-minute wait was. Added a `Progress` bar (design.md 3.8) reading the SAME phase object the rows already render, no new source of truth. It fills a segment only on a real `PHASE_STATE.DONE`; the connect wait's `readinessPhase` has no such branch, so it honestly sits at 1 of 3 until the screen navigates to chat rather than faking a fill. The uncertain case gets a visually distinct muted pulse, and the label is just "Step N of 3", not a repeat of the row's own sentence.

Full reasoning and the per-instance migrate/keep calls are in the commit messages.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on a failure)
- [x] Branch is **up to date with `develop`** (branched from `328d8dbd`, current tip)
- [x] New/changed behavior has tests (`waitPhases.test.js` +8 cases for `phaseProgress`; full suites green on Node 24: 907 vitest, 646 node:test. Production build green.)
- [x] I self-reviewed the diff, plus two independent review passes (see below)

<details>
<summary>#725: why items-start, not items-center</summary>

design.md literally said `items-center`, but a blanket swap is wrong for multi-line content: it centres the icon against the whole flex item, so a title+message banner or a wrapped message drifts the icon toward the block's middle instead of the first line. Verified in a throwaway (unshipped) visual harness: side by side, `items-center` visibly slides the alert-circle icon down to straddle both lines of a title+message banner the moment a second line exists.

The fix that survives both cases: keep `items-start`, drop the icon's bordered `size-6.5` (26px) chip, render it bare at `size-4` (16px, design.md's own icon-size spec). A `text-sm` line is ~15px, close enough to 16px that `items-start` alone reads as centred on one line, and because the icon's own height doesn't grow with the content, it stays pinned to the first line regardless of how many follow, including an unpredictably wrapped single message where there's no discrete "line 2" to key off.

18 sites carry this exact recipe. 17 match design.md's colored-fill alert shape (Banner.vue plus 16 hand-rolled duplicates, matching the issue's own count); an 18th, `TriggerDetail.vue`'s plain-text validation error (no fill, `role="alert"`), gets the same alignment fix even though it falls outside that recipe. Of the 16 duplicates, 4 (single plain-text message, no embedded markup, dash-free, and using the icon `Banner`'s `type` would pick anyway) are migrated onto `Banner.vue`: `FindingsPanel.vue`'s two coverage-note warnings, `ReviewTab.vue`'s two warnings. The other 12 stay hand-rolled with the same alignment mechanism: 3 use `x-circle` (the `run_failed` icon convention `AgentActivityTab.vue` already establishes) which `Banner`'s error type can't express (it hardcodes `alert-circle`, no icon-override prop); the remaining 9 don't fit `Banner`'s props without a behaviour change (multi-paragraph text, inline `<b>`/styled `<span>` mid-sentence, a neutral "quiet note" variant `Banner` has no type for, a full-bleed page banner in a colour outside `Banner`'s four types, or copy with a pre-existing em dash this diff didn't want to move through a prop).

</details>

<details>
<summary>#726: what the bar measures, and how it stays honest</summary>

Both waits already receive a real phase signal per poll (`waitPhases.js`, from jarvis#722) and now also render it as a fixed 3-segment bar: a settled prior fact, the current phase, and a step that only resolves by leaving the screen (never rendered done in place). New pure `phaseProgress()` reads the exact same phase object the row already renders, no parallel source of truth, no ordering inferred across `reason` codes, no elapsed-time branch.

`provisioningPhase` has a `DONE` branch (`tenant_status === "running"`), so the provisioning wait's bar demonstrably reaches 2 of 3. `readinessPhase` has no `DONE` branch at all, by design, so the connect wait's bar honestly never passes 1 of 3 in place. Both waits still get the bar: the provisioning wait makes the determinate case real and testable, and the connect wait's stuck-at-1/3 bar is exactly the indeterminate case that needs telling apart from real progress.

Indeterminate handling: segment one (the settled fact) is never dimmed. Only the current segment gets a muted pulse reusing `--surface-3`, the same color the phase list's own "waiting" dot already uses for "nothing reported yet", when the phase state is `UNKNOWN`. Respects `prefers-reduced-motion` via the existing `@media` block in `OnboardingView.vue`.

</details>

<details>
<summary>Review history on this PR</summary>

Two independent sonnet review passes (one per commit) ran against the first version of this diff and found real issues, since fixed and folded into the commits above (history was force-pushed, not amended-in-place):
- A second `TriggerDetail.vue` instance of the same alignment bug was missed; now fixed.
- 3 of 7 original `Banner.vue` migrations silently swapped a semantically distinct `x-circle` icon for `Banner`'s hardcoded `alert-circle`; reverted to hand-rolled (matching the reasoning already used for `ReviewTab.vue`'s `trending-down` holdout).
- The Progress bar's label duplicated the phase row's own sentence; changed to a plain "Step N of 3".
- `aria-valuenow` carried a long repeating-decimal float; now a rounded integer that round-trips to the same segment count.

</details>
