### PR TITLE
fix(onboarding): a way out of an unverifiable model, and a headline that follows the phase (#727)

### DIFF
--- a/design.md
+++ b/design.md
@@ -574,6 +574,12 @@ Every pane in the Settings dialog owns its own header (there is no global dialog
   pure module and test it there; never branch on phase label text in the template.
 - **Never say "workspace" during onboarding** (product owner, twice). The customer does not
   have one yet. Use "setup" or "onboarding", on headlines, subtitles and button labels alike.
+  **Known outstanding violations, not yet fixed:** the `waitPhases.js` phase-row labels ("Your
+  workspace is coming online", "Checking on your workspace" and siblings), the
+  `readinessWaitExhaustedMessage` bodies, and the connect step's `blocked` panel line
+  ("Something about your workspace needs a person to check it"). Those are jarvis#709/#722
+  copy, and jarvis#726's test asserts one of the strings literally, so they need their own
+  change rather than a drive-by rename. Do not add new ones; the rule binds anything you write.
 - **A dead end gets a second action (jarvis#727)**. When a wait ends in a state that retrying
   cannot resolve, Retry must not be the only button. Offer the action that can actually change
   the outcome, and offer it ONLY where this attempt observed the thing it would change: a

--- a/design.md
+++ b/design.md
@@ -564,6 +564,24 @@ Every pane in the Settings dialog owns its own header (there is no global dialog
   else. No gradients, no glow shadows, no pulse animations, no decorative background orbs
   (brand-asset exception: §2.2 — the Jarvis mark and the provisioning illustration only). The
   wizard proves quality through calm, not sparkle.
+- **Long waits: the headline is a phase, not a label (jarvis#727)**. On a wait screen that
+  already renders an observation-driven phase list (`onboarding/waitPhases.js`), the `h1`
+  reads off the SAME phase instead of repeating the step name: "Giving Jarvis a brain" while
+  the AI connection is being applied, "Bringing your setup online" while the container comes
+  up, "Opening your chat" once a ready verdict has actually fired the navigation. The honesty
+  rule from jarvis#709 binds the headline exactly as it binds body copy, so every unobserved
+  or unrecognised state falls back to the plain "Setting up {agentName}". Derive it in the
+  pure module and test it there; never branch on phase label text in the template.
+- **Never say "workspace" during onboarding** (product owner, twice). The customer does not
+  have one yet. Use "setup" or "onboarding", on headlines, subtitles and button labels alike.
+- **A dead end gets a second action (jarvis#727)**. When a wait ends in a state that retrying
+  cannot resolve, Retry must not be the only button. Offer the action that can actually change
+  the outcome, and offer it ONLY where this attempt observed the thing it would change: a
+  model change belongs on a wait that watched the customer's own configuration stall, and not
+  on one that never reached the control plane at all, where it would blame something nobody
+  examined. Keep it in the wizard, never a link to Settings: `readiness.js`'s
+  `NOT_ONBOARDED_REASONS` puts these states behind AppShell's full-screen gate, so a Settings
+  link is a round trip back to the same screen.
 - **Post-signup activation**: prefer a checklist over a marketing tour — steps registered with
   `useOnboarding(app)`, each step's action **deep-links into the real UI** (opens the settings
   dialog at the right tab, routes to the real form) and is marked complete where the action

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -84,11 +84,22 @@ export const PHASE_KIND = {
  * @param {string} label - what is actually being done, in the caller's words.
  * @param {string} [kind] - PHASE_KIND, when the caller can name the SUBJECT of
  *   this wait from something it already established rather than guessed. The
- *   connect wait passes LLM_APPLY because reaching it means a save returned an
- *   apply-operation descriptor and we are polling that operation - the AI
- *   connection is demonstrably being wired in, which is exactly what the phase
- *   claims. Defaults to NONE so a caller that cannot ground a subject gets no
- *   headline derived from one.
+ *   connect wait passes LLM_APPLY because reaching it means a save for this
+ *   configuration was ACCEPTED and is now being applied - the AI connection is
+ *   demonstrably being wired in, which is exactly what the phase claims.
+ *
+ *   Stated that way on purpose: an earlier draft of this comment justified it by
+ *   "a save returned an apply-operation descriptor and we are polling that
+ *   operation", which is true of the durable-operation path and false of the
+ *   `mode:"legacy"` one, where admin's creds endpoint mints no operation at all
+ *   (OnboardingView.followLegacyReadiness). Both paths do establish the same
+ *   underlying fact - the configuration was accepted and is being applied - and
+ *   that fact, not the existence of a pollable operation, is what grounds the
+ *   phase. The row and the headline say the same thing on both paths, which is
+ *   the behaviour jarvis#722 shipped and jarvis#727 kept.
+ *
+ *   Defaults to NONE so a caller that cannot ground a subject gets no headline
+ *   derived from one.
  */
 export function inFlightPhase(label, kind = PHASE_KIND.NONE) {
 	return {

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -40,6 +40,31 @@ export const PHASE_STATE = {
 };
 
 /**
+ * WHAT a connect-wait phase is waiting on, as opposed to `state`, which is how
+ * that wait is going. Only the connect wait carries a kind: it is the one screen
+ * whose headline is derived from the live phase (`setupHeadline`, jarvis#727),
+ * and a headline needs to know the subject, not the progress.
+ *
+ * `NONE` is a real member of the vocabulary, not an omission. Every phase this
+ * module refuses to name - a poll that never answered, `readiness_unconfirmed`,
+ * an unrecognised reason, and all three stopping verdicts - is explicitly NONE,
+ * so `setupHeadline` falls back to the generic headline instead of borrowing a
+ * neighbouring phase's words. Naming a subject we did not observe is the same
+ * false claim the rest of this module exists to prevent.
+ *
+ * `provisioningPhase` deliberately carries no kind: its screen's headline is a
+ * settled fact ("Payment confirmed"), never a phase, so there is nothing there
+ * to derive.
+ */
+export const PHASE_KIND = {
+	NONE: "",
+	// The customer's chosen AI connection is being wired into the container.
+	LLM_APPLY: "llm_apply",
+	// The serving container itself is still coming up.
+	CONTAINER: "container",
+};
+
+/**
  * The row to show while a wait is genuinely UNDER WAY but nothing has reported
  * back yet - the very first poll is still in flight, or (on the Connect step)
  * the apply operation is running and the readiness wait has not started.
@@ -57,11 +82,19 @@ export const PHASE_STATE = {
  * known - unlike "we asked and got nothing", which is what UNKNOWN means.
  *
  * @param {string} label - what is actually being done, in the caller's words.
+ * @param {string} [kind] - PHASE_KIND, when the caller can name the SUBJECT of
+ *   this wait from something it already established rather than guessed. The
+ *   connect wait passes LLM_APPLY because reaching it means a save returned an
+ *   apply-operation descriptor and we are polling that operation - the AI
+ *   connection is demonstrably being wired in, which is exactly what the phase
+ *   claims. Defaults to NONE so a caller that cannot ground a subject gets no
+ *   headline derived from one.
  */
-export function inFlightPhase(label) {
+export function inFlightPhase(label, kind = PHASE_KIND.NONE) {
 	return {
 		observed: false,
 		state: PHASE_STATE.ACTIVE,
+		kind,
 		label,
 		detail: "",
 		stop: false,
@@ -137,6 +170,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 		return {
 			observed: false,
 			state: PHASE_STATE.UNKNOWN,
+			kind: PHASE_KIND.NONE,
 			label: "We couldn't reach your workspace to check",
 			detail: "We'll keep trying.",
 			stop: false,
@@ -148,6 +182,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			return {
 				observed: true,
 				state: PHASE_STATE.ACTIVE,
+				kind: PHASE_KIND.LLM_APPLY,
 				label: "Applying your AI configuration",
 				detail: say,
 				stop: false,
@@ -156,6 +191,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			return {
 				observed: true,
 				state: PHASE_STATE.ACTIVE,
+				kind: PHASE_KIND.CONTAINER,
 				label: "Your workspace is coming online",
 				detail: say,
 				stop: false,
@@ -164,6 +200,9 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			return {
 				observed: true,
 				state: PHASE_STATE.UNKNOWN,
+				// The absence of a verdict names no subject: admin could not be
+				// asked, so nothing here knows WHAT is outstanding.
+				kind: PHASE_KIND.NONE,
 				label: "Nothing has confirmed your workspace yet",
 				detail: "We'll keep checking.",
 				stop: false,
@@ -172,6 +211,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			return {
 				observed: true,
 				state: PHASE_STATE.UNKNOWN,
+				kind: PHASE_KIND.NONE,
 				label: "This needs a person to check it",
 				// Admin's own reassurance, quoted. Never paraphrased, and never
 				// accompanied by an action.
@@ -190,6 +230,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			return {
 				observed: true,
 				state: PHASE_STATE.UNKNOWN,
+				kind: PHASE_KIND.NONE,
 				label: "Your subscription is paused",
 				detail: say,
 				stop: true,
@@ -200,6 +241,7 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			return {
 				observed: true,
 				state: PHASE_STATE.UNKNOWN,
+				kind: PHASE_KIND.NONE,
 				label: "Your account is connected to a different site",
 				detail: say,
 				stop: true,
@@ -208,14 +250,71 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 			};
 		default:
 			// A reason this build does not know about gets the neutral line. It
-			// must not be given a phase name invented here.
+			// must not be given a phase name invented here - and, for the same
+			// reason, no kind: a headline derived from a subject this build cannot
+			// identify would be pure invention.
 			return {
 				observed: true,
 				state: PHASE_STATE.ACTIVE,
+				kind: PHASE_KIND.NONE,
 				label: "Waiting for your workspace to come online",
 				detail: say,
 				stop: false,
 			};
+	}
+}
+
+/**
+ * The connect wait's HEADLINE, derived from the live phase (jarvis#727).
+ *
+ * The screen used to render a fixed "Setting up {agentName}" over a phase list
+ * that had already become real (jarvis#722), so the largest text on screen was
+ * the only part of it saying nothing. This maps the phase's SUBJECT - its
+ * `kind`, never its `state` and never its label text - onto a headline that
+ * describes what is actually being done.
+ *
+ * The honesty rule is the same one the rest of this module follows, applied to
+ * a bigger font: **a headline may only name a phase that was observed.** Every
+ * phase whose kind is NONE - a poll that never answered, an absent verdict, an
+ * unrecognised reason, a stopping verdict - falls back to the generic setup
+ * headline. "Giving {agentName} a brain" is reachable only from LLM_APPLY,
+ * which requires either a live apply operation we are polling or admin naming
+ * an apply as the outstanding work.
+ *
+ * `navigating` is the one branch that does not come from a phase, and it is the
+ * only honest source for "Opening your chat": readinessPhase has no DONE branch
+ * (jarvis#726 documents why - every reason it knows maps to ACTIVE or UNKNOWN),
+ * so a chat-opening phase can never be OBSERVED on this screen. What can be
+ * observed is that a ready verdict arrived and navigateToChat() ran; the router
+ * guard then re-checks readiness over the network while this screen is still
+ * painted. During that window "Opening your chat" is a statement about what we
+ * are doing, made from the verdict we just received - not a guess about a phase
+ * nobody reported. The DONE mapping is kept too, so the function stays total
+ * over the phase vocabulary for any caller whose phases can reach it.
+ *
+ * @param {{state?: string, kind?: string}} [phase]
+ * @param {string} [agentName] - the white-label brand name; blank falls back to
+ *   Jarvis, exactly as @/branding does.
+ * @param {{navigating?: boolean}} [opts]
+ * @returns {string} sentence case, per design.md.
+ */
+export function setupHeadline(phase, agentName, { navigating = false } = {}) {
+	const name = String(agentName || "").trim() || "Jarvis";
+	if (navigating || (phase && phase.state === PHASE_STATE.DONE)) return "Opening your chat";
+	switch ((phase && phase.kind) || PHASE_KIND.NONE) {
+		case PHASE_KIND.LLM_APPLY:
+			// The literal act of giving the assistant its model. This is the phase
+			// the whole connect step exists for, and the one a customer waits on
+			// longest.
+			return `Giving ${name} a brain`;
+		case PHASE_KIND.CONTAINER:
+			// The model is settled; what is outstanding is the container. Not
+			// "workspace": the customer does not have one to speak of yet.
+			return "Bringing your setup online";
+		default:
+			// Nothing was observed, or nothing this build can name. The generic
+			// headline is the honest one, and it is what this screen said before.
+			return `Setting up ${name}`;
 	}
 }
 

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -3,9 +3,11 @@ import assert from "node:assert/strict";
 
 import {
 	PHASE_STATE,
+	PHASE_KIND,
 	provisioningPhase,
 	readinessPhase,
 	inFlightPhase,
+	setupHeadline,
 	connectHeadline,
 	phaseProgress,
 } from "./waitPhases.js";
@@ -184,6 +186,107 @@ test("readiness: no branch ever claims setup is finishing on its own", () => {
 			const p = readinessPhase({ answered, reason });
 			assert.doesNotMatch(p.label + " " + p.detail, /finishing on its own/i);
 		}
+	}
+});
+
+// ---- setup headline (jarvis#727) -----------------------------------------
+
+test("setup headline: the apply phase is the only thing that earns the brain line", () => {
+	for (const reason of ["llm_pool_provisioning", "llm_provisioning"]) {
+		const p = readinessPhase({ answered: true, reason });
+		assert.equal(p.kind, PHASE_KIND.LLM_APPLY);
+		assert.equal(setupHeadline(p, "Jarvis"), "Giving Jarvis a brain");
+	}
+});
+
+test("setup headline: a live apply operation grounds the brain line before any poll answers", () => {
+	const p = inFlightPhase("Applying your AI connection", PHASE_KIND.LLM_APPLY);
+	assert.equal(setupHeadline(p, "Jarvis"), "Giving Jarvis a brain");
+});
+
+test("setup headline: an inFlight phase with no named subject claims none", () => {
+	assert.equal(
+		setupHeadline(inFlightPhase("Checking on your workspace"), "Jarvis"),
+		"Setting up Jarvis"
+	);
+});
+
+test("setup headline: the container phase names the container, never a workspace", () => {
+	const p = readinessPhase({ answered: true, reason: "container_provisioning" });
+	assert.equal(setupHeadline(p, "Jarvis"), "Bringing your setup online");
+});
+
+// The whole point of jarvis#709/#722: the biggest text on the screen is not
+// exempt from the rule that a phase is named only when something reported it.
+test("setup headline: no unobserved or unnameable phase ever claims a subject", () => {
+	const unnameable = [
+		readinessPhase({ answered: false }),
+		readinessPhase({ answered: true, reason: "readiness_unconfirmed" }),
+		readinessPhase({ answered: true, reason: "authority_repair_required" }),
+		readinessPhase({ answered: true, reason: "subscription_suspended" }),
+		readinessPhase({ answered: true, reason: "site_replaced" }),
+		readinessPhase({ answered: true, reason: "a_reason_this_build_never_heard_of" }),
+		null,
+		undefined,
+	];
+	for (const p of unnameable) {
+		assert.equal(setupHeadline(p, "Jarvis"), "Setting up Jarvis");
+	}
+});
+
+test("setup headline: only navigating (or a DONE phase) opens chat", () => {
+	const applying = readinessPhase({ answered: true, reason: "llm_pool_provisioning" });
+	assert.equal(setupHeadline(applying, "Jarvis", { navigating: true }), "Opening your chat");
+	assert.equal(setupHeadline(null, "Jarvis", { navigating: true }), "Opening your chat");
+	assert.equal(
+		setupHeadline(provisioningPhase({ answered: true, tenantStatus: "running" }), "Jarvis"),
+		"Opening your chat"
+	);
+});
+
+// readinessPhase has no DONE branch (jarvis#726), so the connect wait can never
+// observe a chat-opening phase - `navigating` above is the only route to that
+// headline there. Pinned so a later DONE branch is a deliberate decision.
+test("setup headline: no readiness reason reaches the chat-opening headline on its own", () => {
+	const reasons = [
+		"llm_pool_provisioning",
+		"llm_provisioning",
+		"container_provisioning",
+		"readiness_unconfirmed",
+		"authority_repair_required",
+		"subscription_suspended",
+		"site_replaced",
+		"unmapped",
+	];
+	for (const reason of reasons) {
+		for (const answered of [true, false]) {
+			const h = setupHeadline(readinessPhase({ answered, reason }), "Jarvis");
+			assert.notEqual(h, "Opening your chat", reason);
+		}
+	}
+});
+
+test("setup headline: the brand name is honoured, and a blank one falls back to Jarvis", () => {
+	const p = readinessPhase({ answered: true, reason: "llm_provisioning" });
+	assert.equal(setupHeadline(p, "Aerele AI"), "Giving Aerele AI a brain");
+	assert.equal(setupHeadline(p, "   "), "Giving Jarvis a brain");
+	assert.equal(setupHeadline(p), "Giving Jarvis a brain");
+	assert.equal(setupHeadline(null, ""), "Setting up Jarvis");
+});
+
+// The product owner asked twice to drop "workspace" from onboarding copy: the
+// customer does not have one yet.
+test("setup headline: no headline says workspace", () => {
+	const phases = [
+		inFlightPhase("Applying your AI connection", PHASE_KIND.LLM_APPLY),
+		readinessPhase({ answered: true, reason: "container_provisioning" }),
+		readinessPhase({ answered: true, reason: "readiness_unconfirmed" }),
+		readinessPhase({ answered: false }),
+		null,
+	];
+	for (const p of phases) {
+		assert.doesNotMatch(setupHeadline(p, "Jarvis"), /workspace/i);
+		assert.doesNotMatch(setupHeadline(p, "Jarvis", { navigating: true }), /workspace/i);
 	}
 });
 

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -652,6 +652,278 @@ describe("jarvis#708 chat-readiness wait exhaustion: honest copy + a real exit",
 	});
 });
 
+// jarvis#727: a customer whose only model cannot be verified reached a screen
+// whose single action was Retry, re-running the exact thing that had just been
+// watched fail to converge - and could not reach Settings to add another model,
+// because readiness.js puts llm_pool_provisioning / llm_provisioning /
+// readiness_unconfirmed in NOT_ONBOARDED_REASONS, so AppShell's gate covers
+// every route but this wizard. The exit therefore has to live here. These pin
+// BOTH halves of the rule: it appears where the pipeline was observed to stall
+// on the chosen configuration, and it stays away where nothing was observed at
+// all (offering it there would blame a model nobody examined).
+describe("jarvis#727 an unverifiable model has a way out, not only a Retry", () => {
+	function labels(w) {
+		return w.findAll("button").map((b) => b.attributes("label") || b.text());
+	}
+
+	it("the reproduced dead end (op confirmed in flight, never finished) offers a different model", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		expect(labels(w)).toContain("Use a different model");
+		w.unmount();
+	});
+
+	it("a deadline that never confirmed anything keeps Retry alone: nothing points at the model", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: true });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(false);
+		expect(labels(w)).not.toContain("Use a different model");
+		expect(labels(w)).toContain("Retry"); // still an exit, just an honest one
+		w.unmount();
+	});
+
+	it("a readiness ceiling where admin kept answering offers the model change", async () => {
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "llm_pool_provisioning",
+			detail: "applying your LLM configuration",
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		w.unmount();
+	});
+
+	it("a readiness ceiling that never reached admin does NOT offer it", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockRejectedValue(new Error("bench hiccup"));
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(false);
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+		w.unmount();
+	});
+
+	// The three verdicts waitPhases marks `stop`. A different model resolves none
+	// of them, and authority_repair_required must show no self-service action at
+	// all, so the blocked panel keeps its own shape.
+	it("a stopping verdict never offers a model change", async () => {
+		for (const reason of [
+			"authority_repair_required",
+			"subscription_suspended",
+			"site_replaced",
+		]) {
+			const w = await mountConnect();
+			w.vm.connectModelChangeOffered = true; // a stale offer from an earlier attempt
+			w.vm.noteReadiness({ answered: true, reason, detail: "admin's own sentence" });
+			await flushPromises();
+
+			expect(w.vm.state.connectPhase).toBe("blocked");
+			expect(w.vm.connectModelChangeOffered).toBe(false);
+			expect(labels(w)).not.toContain("Use a different model");
+			w.unmount();
+		}
+	});
+
+	it("an operation-level failure offers the change beside Retry, not instead of it", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "retry", message: "We hit a snag applying your AI connection." });
+		await flushPromises();
+
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		expect(labels(w)).toEqual(expect.arrayContaining(["Retry", "Use a different model"]));
+		w.unmount();
+	});
+
+	// The whole point: the customer lands back on their own choice, and the next
+	// Start is a genuinely NEW attempt. Reusing this attempt's idempotency key
+	// would have admin dedupe the new configuration straight back to the stuck
+	// operation, and a surviving currentOpId would make Retry re-follow it.
+	it("taking the exit returns to the editable form and starts a genuinely fresh attempt", async () => {
+		// A transient apply failure: terminal (so saveConnect resolves) and, unlike
+		// a rejection or a supersession, one that deliberately KEEPS the idempotency
+		// key so a Retry re-follows the same operation. That is exactly the state
+		// the exit has to undo.
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "failed",
+			code: "LLM_APPLY_FAILED",
+			message: "We hit a snag applying your AI connection.",
+			retry_after_seconds: 0,
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(50);
+		await p;
+		const firstKey = saveMock.mock.calls[0][0];
+		expect(firstKey).toBeTruthy();
+		expect(sessionStorage.getItem(IDEM_KEY)).toBe(firstKey);
+		expect(w.vm.currentOpId).toBe("op1");
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		sessionStorage.setItem(OP_STORE_KEY, "op1"); // as a mid-apply reload would leave it
+
+		w.vm.chooseDifferentModel();
+		await flushPromises();
+
+		expect(w.vm.state.finishing).toBe(false); // the editor, with their choice still in it
+		expect(w.vm.state.connectPhase).toBe("");
+		expect(w.vm.state.connectBlockReason).toMatch(/pick a different model/i);
+		expect(w.vm.connectModelChangeOffered).toBe(false);
+		expect(w.vm.currentOpId).toBe("");
+		expect(sessionStorage.getItem(IDEM_KEY)).toBe(null);
+		expect(sessionStorage.getItem(OP_STORE_KEY)).toBe(null);
+
+		const p2 = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(50);
+		await p2;
+		expect(saveMock.mock.calls[1][0]).not.toBe(firstKey);
+		w.unmount();
+	});
+
+	// A live wait must not outlive the exit: without this, the ceiling of the wait
+	// the customer just walked away from fires minutes later and yanks them back
+	// out of the form.
+	it("a wait still in flight stops when the customer takes the exit", async () => {
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_pool_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3 * 3000);
+		await flushPromises();
+		const pollsBefore = api.isReadyForChat.mock.calls.length;
+		expect(pollsBefore).toBeGreaterThan(0);
+
+		w.vm.chooseDifferentModel();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(api.isReadyForChat.mock.calls.length).toBeLessThanOrEqual(pollsBefore + 1);
+		expect(w.vm.state.finishing).toBe(false);
+		expect(w.vm.state.connectPhase).toBe("");
+		w.unmount();
+	});
+
+	it("a genuinely fresh Start withdraws the offer until this attempt earns it too", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+
+		w.vm.saveConnect();
+		await flushPromises();
+
+		expect(w.vm.connectModelChangeOffered).toBe(false);
+		w.unmount();
+	});
+});
+
+// jarvis#727 part 2. The headline used to be a fixed "Setting up Jarvis" above a
+// phase list jarvis#722 had already made real. waitPhases.setupHeadline owns the
+// mapping and its honesty rule; these pin the WIRING - that the view feeds it the
+// live phase, and that the never-observed states still render the generic line.
+describe("jarvis#727 the setup headline follows the live phase", () => {
+	it("names the brain phase while the apply operation is being followed", async () => {
+		const w = await mountConnect();
+
+		w.vm.saveConnect();
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("working");
+		expect(w.vm.setupTitle).toBe("Giving Jarvis a brain");
+		w.unmount();
+	});
+
+	it("follows admin's own reason once the readiness wait starts answering", async () => {
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "container_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.setupTitle).toBe("Bringing your setup online");
+		w.unmount();
+	});
+
+	it("claims nothing when the poll answered nothing", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockRejectedValue(new Error("bench hiccup"));
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.vm.setupTitle).toBe("Setting up Jarvis");
+		w.unmount();
+	});
+
+	it("says it is opening chat only once a ready verdict has actually navigated", async () => {
+		api.getLlmApplyOperation.mockResolvedValue(readyStatus);
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(50);
+		await p;
+
+		expect(routerReplace).toHaveBeenCalledTimes(1);
+		expect(w.vm.setupTitle).toBe("Opening your chat");
+		w.unmount();
+	});
+
+	// The product owner asked twice to drop "workspace" from onboarding copy: at
+	// this point the customer does not have one.
+	it("no wait-screen headline or subtitle says workspace", async () => {
+		const w = await mountConnect();
+
+		w.vm.saveConnect();
+		await flushPromises();
+		expect(w.vm.setupTitle).not.toMatch(/workspace/i);
+		expect(w.vm.state.finishSubtitle).not.toMatch(/workspace/i);
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		expect(w.vm.setupTitle).not.toMatch(/workspace/i);
+		expect(w.vm.state.finishSubtitle).not.toMatch(/workspace/i);
+		w.unmount();
+	});
+});
+
 describe("staged readiness phases: the screen renders what the poll observed", () => {
 	// Every one of these 40 polls used to be discarded except the last detail, so
 	// the wait showed one fixed sentence for two minutes.

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -710,6 +710,77 @@ describe("jarvis#727 an unverifiable model has a way out, not only a Retry", () 
 		w.unmount();
 	});
 
+	// Review round. The offer used to be gated on `sawVerdict`, which means only
+	// "a poll returned JSON". readiness_unconfirmed IS a well-formed 200, and
+	// jarvis/account.py documents it as "admin could not be asked" - so the old
+	// gate told a customer their chosen connection had failed on the strength of a
+	// wait in which nothing about that connection was ever established.
+	it("a ceiling where every poll answered readiness_unconfirmed does NOT offer it", async () => {
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "readiness_unconfirmed",
+			retryable: true,
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(false);
+		expect(labels(w)).not.toContain("Use a different model");
+		expect(w.vm.state.connectSupportOffered).toBe(true);
+		w.unmount();
+	});
+
+	// The judgement call, recorded: container_provisioning is admin saying "not
+	// Ready" for anything that is neither Suspended nor SupportRequired, and in the
+	// reproduced class of failure admin's own detail rides that code ("Still
+	// verifying your OpenAI subscription"). So a named container counts.
+	it("a ceiling that only ever saw container_provisioning DOES offer it", async () => {
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "container_provisioning",
+			detail: "Still verifying your OpenAI subscription.",
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		w.unmount();
+	});
+
+	// "At least once", never "on the last poll": ninety seconds of a named apply
+	// followed by one transient unconfirmed is still a wait that watched this
+	// configuration fail to converge.
+	it("one late unconfirmed poll does not erase a wait that DID name the apply", async () => {
+		let n = 0;
+		api.isReadyForChat.mockImplementation(async () => {
+			n += 1;
+			return n < 40
+				? { ready: false, reason: "llm_pool_provisioning" }
+				: { ready: false, reason: "readiness_unconfirmed", retryable: true };
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		w.unmount();
+	});
+
 	it("a readiness ceiling that never reached admin does NOT offer it", async () => {
 		vi.useFakeTimers();
 		const w = await mountConnect();
@@ -833,6 +904,77 @@ describe("jarvis#727 an unverifiable model has a way out, not only a Retry", () 
 		w.unmount();
 	});
 
+	// The mode:"legacy" twin of the two tests above. Both jarvis#727 edits were
+	// applied to followLegacyReadiness with a comment claiming parity, and the
+	// review round showed BOTH could be reverted with the whole suite still green.
+	function legacySave() {
+		saveMock.mockResolvedValue({
+			ok: true,
+			result: opResult({ apply_operation: null, resumable: false, mode: "legacy" }),
+		});
+	}
+
+	it("legacy: a ceiling that named the apply offers the model change", async () => {
+		legacySave();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(30 * 2500);
+		await p;
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(true);
+		expect(labels(w)).toContain("Use a different model");
+		w.unmount();
+	});
+
+	it("legacy: a ceiling that named nothing does NOT offer the model change", async () => {
+		legacySave();
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "readiness_unconfirmed",
+			retryable: true,
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(30 * 2500);
+		await p;
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.connectModelChangeOffered).toBe(false);
+		w.unmount();
+	});
+
+	it("legacy: a wait still in flight stops when the customer takes the exit", async () => {
+		legacySave();
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear();
+
+		w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(3 * 2500);
+		await flushPromises();
+		const pollsBefore = api.isReadyForChat.mock.calls.length;
+		expect(pollsBefore).toBeGreaterThan(0);
+
+		w.vm.chooseDifferentModel();
+		await vi.advanceTimersByTimeAsync(30 * 2500);
+		await flushPromises();
+
+		expect(api.isReadyForChat.mock.calls.length).toBeLessThanOrEqual(pollsBefore + 1);
+		expect(w.vm.state.finishing).toBe(false);
+		expect(w.vm.state.connectPhase).toBe("");
+		w.unmount();
+	});
+
 	it("a genuinely fresh Start withdraws the offer until this attempt earns it too", async () => {
 		const w = await mountConnect();
 
@@ -874,6 +1016,61 @@ describe("jarvis#727 the setup headline follows the live phase", () => {
 		await flushPromises();
 
 		expect(w.vm.setupTitle).toBe("Bringing your setup online");
+		w.unmount();
+	});
+
+	// Recorded decision, not an accident: mode:"legacy" mints NO durable apply
+	// operation, and still shows the brain headline. What grounds the phase is that
+	// the save for this configuration was accepted and is being applied, which is
+	// equally true on both paths - and the phase ROW beneath the headline has said
+	// exactly this on the legacy path since jarvis#722.
+	it("legacy mode shows the brain headline too, matching the row beneath it", async () => {
+		saveMock.mockResolvedValue({
+			ok: true,
+			result: opResult({ apply_operation: null, resumable: false, mode: "legacy" }),
+		});
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.saveConnect();
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("working");
+		expect(w.vm.setupTitle).toBe("Giving Jarvis a brain");
+		// The row names the same subject as the headline. Which of the two apply
+		// labels is showing depends on whether the first poll has landed yet (the
+		// inFlight fallback before it, readinessPhase's after) - both are LLM_APPLY,
+		// and it is the KIND, not the wording, that the headline is derived from.
+		expect(w.vm.readinessStage.kind).toBe("llm_apply");
+		expect(w.vm.readinessStage.label).toMatch(/applying your AI/i);
+		w.unmount();
+	});
+
+	// Review round: a Retry re-follows the SAME operation via followDescriptor,
+	// which flips back to the working screen. Without clearing the last attempt's
+	// observation there, the ceiling's stale phase was re-rendered as the live one
+	// - and this PR wires that phase into the h1, so the stale reading became the
+	// biggest text on the screen.
+	it("a Retry after a ceiling does not re-render the previous wait's phase", async () => {
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "container_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.setupTitle).toBe("Bringing your setup online"); // the wait that just ended
+
+		// Never terminal, so the re-follow parks on the working screen.
+		api.getLlmApplyOperation.mockResolvedValue(pending);
+		w.vm.retryConnect();
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("working");
+		expect(w.vm.setupTitle).toBe("Giving Jarvis a brain");
 		w.unmount();
 	});
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3353,6 +3353,9 @@ function noteReadiness(o) {
 		// would be a wrong diagnosis dressed as help (jarvis#727).
 		connectModelChangeOffered.value = false;
 	}
+	// Returned so the wait loops can accumulate what their polls NAMED, not just
+	// that the polls answered. See sawNamedSubject in waitForChatReadiness.
+	return stage;
 }
 
 const CHAT_READY_ATTEMPTS = 40;
@@ -3361,6 +3364,20 @@ async function waitForChatReadiness() {
 	// What this run actually observed, so the exhaustion message below can say
 	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
 	let sawVerdict = false;
+	// Whether any poll of THIS wait NAMED what it was waiting on (jarvis#727).
+	// Deliberately not sawVerdict, which the review round showed is far too coarse
+	// to hang a diagnosis on: it means only "a poll returned JSON", and
+	// `readiness_unconfirmed` is a perfectly well-formed 200 whose documented
+	// meaning in jarvis/account.py is that admin COULD NOT BE ASKED. Gating the
+	// model-change offer on sawVerdict therefore told a customer their chosen
+	// connection had failed on the strength of a wait in which nothing about that
+	// connection was ever established - the exact false claim this feature exists
+	// to avoid, and a contradiction of this function's own ceiling comment.
+	// A named subject is `kind !== NONE`, i.e. admin said the outstanding work was
+	// the LLM apply or the container. "At least once", never "on the last poll":
+	// ninety seconds of llm_pool_provisioning followed by one transient unconfirmed
+	// is still a wait that watched this configuration fail to converge.
+	let sawNamedSubject = false;
 	let lastDetail = "";
 	// A new wait starts from "nothing observed yet", so a stale phase from an
 	// earlier attempt is never the first thing this one renders.
@@ -3396,7 +3413,12 @@ async function waitForChatReadiness() {
 		// discarded except the last detail, so the screen showed one fixed
 		// sentence for two minutes and a customer could not tell a workspace
 		// being built from one that was stuck.
-		noteReadiness({ answered: !!r, reason: r && r.reason, detail: r && r.detail });
+		const stage = noteReadiness({
+			answered: !!r,
+			reason: r && r.reason,
+			detail: r && r.detail,
+		});
+		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
 		if (state.connectPhase === "blocked") return;
 		await _sleep(CHAT_READY_INTERVAL_MS);
 	}
@@ -3410,11 +3432,12 @@ async function waitForChatReadiness() {
 	// claim. It is now derived from the same source.
 	state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 	state.connectSupportOffered = true;
-	// jarvis#727: this is the exact state the issue was filed from. Admin kept
-	// answering for the whole wait and never said Ready, so Retry re-runs a thing
-	// this run watched fail to converge. Offer the model change beside it. When
-	// admin was never reached at all, only Retry and support are honest.
-	connectModelChangeOffered.value = sawVerdict;
+	// jarvis#727: this is the exact state the issue was filed from. Admin named the
+	// outstanding work for this configuration and never said Ready, so Retry
+	// re-runs a thing this run watched fail to converge. Offer the model change
+	// beside it. When nothing was ever named - admin unreachable, or reachable but
+	// unable to answer (readiness_unconfirmed) - only Retry and support are honest.
+	connectModelChangeOffered.value = sawNamedSubject;
 	state.retryAfter = 0;
 }
 
@@ -3515,6 +3538,13 @@ async function followDescriptor(descriptorOrId) {
 			? descriptorOrId
 			: (descriptorOrId && descriptorOrId.operation_id) || "";
 	state.finishing = true;
+	// Third entry point into the "working" screen, and the one that was missing the
+	// invariant the two wait loops each state at their own top: a new attempt must
+	// not open on the LAST attempt's observation. Reached by Retry, which re-follows
+	// the same operation - so without this, a Retry taken from a readiness ceiling
+	// re-rendered that ceiling's stale phase as the live one, and jarvis#727 wired
+	// that phase into the h1, making a stale reading the biggest text on the screen.
+	readinessSeen.value = null;
 	state.connectPhase = "working";
 	let terminal;
 	try {
@@ -3584,6 +3614,9 @@ async function followLegacyReadiness() {
 	// What this run actually observed, so the exhaustion message below can say
 	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
 	let sawVerdict = false;
+	// See waitForChatReadiness for why the model-change offer is gated on a NAMED
+	// subject and not on sawVerdict (jarvis#727 review round).
+	let sawNamedSubject = false;
 	let lastDetail = "";
 	readinessSeen.value = null;
 	for (let i = 0; i < LEGACY_READY_ATTEMPTS; i++) {
@@ -3608,7 +3641,12 @@ async function followLegacyReadiness() {
 		}
 		// Same per-poll phase projection as waitForChatReadiness: this wait is just
 		// as long and was just as silent.
-		noteReadiness({ answered: !!r, reason: r && r.reason, detail: r && r.detail });
+		const stage = noteReadiness({
+			answered: !!r,
+			reason: r && r.reason,
+			detail: r && r.detail,
+		});
+		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
 		if (state.connectPhase === "blocked") return;
 		if (i < LEGACY_READY_ATTEMPTS - 1) await _sleep(LEGACY_READY_INTERVAL_MS);
 	}
@@ -3618,7 +3656,7 @@ async function followLegacyReadiness() {
 	state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 	state.connectSupportOffered = true;
 	// Same ceiling, same rule as waitForChatReadiness (jarvis#727).
-	connectModelChangeOffered.value = sawVerdict;
+	connectModelChangeOffered.value = sawNamedSubject;
 	state.retryAfter = 0;
 }
 
@@ -3636,6 +3674,13 @@ function enterSaveRefusal(retryAfterSeconds) {
 		// "We couldn't confirm your setup" over a rate-limit body, or worse, a
 		// STALE title left behind by an earlier attempt.
 		state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: false });
+		// Explicit for the same reason connectTitle is (jarvis#727 review round). A
+		// rate limit is a refusal to accept the save AT ALL, so nothing about the
+		// configuration was observed and no model change is indicated. It happens to
+		// be false already on both live call paths, but only because each caller
+		// resets it first - an invariant held by the callers is not one this panel
+		// can rely on, and every sibling terminal sets it here rather than assume.
+		connectModelChangeOffered.value = false;
 		state.retryAfter = retryAfterSeconds;
 		startRetryCountdown();
 	} else {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1264,11 +1264,18 @@
 										"
 									>
 										<div class="ob-head">
-											<h1>Setting up {{ agentName }}</h1>
+											<!-- Follows the live phase (waitPhases.setupHeadline,
+												 jarvis#727): this used to be a fixed "Setting up
+												 {agentName}" sitting above a phase list that jarvis#722
+												 had already made real, so the largest text on the screen
+												 was the only part saying nothing. It falls back to
+												 exactly that sentence whenever the phase names no
+												 subject - a headline is not exempt from jarvis#709. -->
+											<h1>{{ setupTitle }}</h1>
 											<p>
 												{{
 													state.finishSubtitle ||
-													"Bringing your workspace online, taking you to chat…"
+													"We'll take you to chat as soon as your setup is done."
 												}}
 											</p>
 										</div>
@@ -1424,7 +1431,7 @@
 												type="info"
 												:message="`You can retry in ${state.retryAfter}s.`"
 											/>
-											<div class="mt-4 flex justify-center">
+											<div class="mt-4 flex flex-wrap justify-center gap-2">
 												<Button
 													v-if="state.connectPhase === 'superseded'"
 													variant="solid"
@@ -1437,6 +1444,20 @@
 													:disabled="state.retryAfter > 0"
 													label="Retry"
 													@click="retryConnect"
+												/>
+												<!-- jarvis#727: the way out of a state Retry cannot
+													 resolve. Offered ONLY where this attempt watched the
+													 pipeline stall or fail on the model the customer chose
+													 (see connectModelChangeOffered) - never where nothing
+													 was observed, because that would blame a model no one
+													 examined. Secondary, not primary: Retry can still be
+													 the right answer, it just can no longer be the only
+													 answer. -->
+												<Button
+													v-if="connectModelChangeOffered"
+													variant="subtle"
+													label="Use a different model"
+													@click="chooseDifferentModel"
 												/>
 											</div>
 											<!-- jarvis#708: offered the moment a bounded readiness wait
@@ -1568,9 +1589,11 @@ import {
 } from "@/lib/llmOperation.js";
 import { readinessWaitExhaustedMessage } from "@/onboarding/readinessWait.js";
 import {
+	PHASE_KIND,
 	provisioningPhase,
 	readinessPhase,
 	inFlightPhase,
+	setupHeadline,
 	connectHeadline,
 	phaseProgress,
 } from "@/onboarding/waitPhases.js";
@@ -1734,7 +1757,7 @@ const readinessStage = computed(() =>
 		? readinessPhase(readinessSeen.value)
 		: // The apply operation is what is running, and the operation controller
 		  // reported that, so naming it is grounded.
-		  inFlightPhase("Applying your AI connection")
+		  inFlightPhase("Applying your AI connection", PHASE_KIND.LLM_APPLY)
 );
 // jarvis#726: the Progress bar next to the phase list above, reading the SAME
 // readinessStage - see waitPhases.phaseProgress.
@@ -3106,6 +3129,89 @@ const currentOpId = ref("");
 const navigated = ref(false);
 let retryTimer = null;
 
+// The setup screen's headline, following the live phase (jarvis#727) instead of
+// the fixed "Setting up {agentName}" that used to sit above a phase list which
+// had already become real (jarvis#722). setupHeadline owns every honesty
+// decision; this only supplies what it cannot know: the brand name, and the
+// fact that a ready verdict arrived and we are now navigating.
+const setupTitle = computed(() =>
+	setupHeadline(readinessStage.value, agentName, { navigating: navigated.value })
+);
+
+// jarvis#727. True once THIS attempt has watched the pipeline stall or fail on
+// the AI connection the customer chose, which is the only evidence that makes
+// "use a different model" an honest offer rather than a guess.
+//
+// The bar is deliberately an OBSERVATION, not a reason code, because the reason
+// codes alone cannot carry it: `llm_pool_provisioning` is a perfectly ordinary
+// mid-apply state for the first ninety seconds and a permanent dead end at the
+// hundred and twentieth, and nothing in the code distinguishes those. What does
+// distinguish them is that a bounded wait ran to its ceiling while admin kept
+// answering. So this is set at exactly three places:
+//
+//   - a readiness wait that reached its ceiling having HEARD from admin
+//     (sawVerdict) - admin kept telling us the config was still outstanding and
+//     it never converged;
+//   - an apply-operation deadline that DID confirm the operation in flight
+//     (!neverConfirmed) - the operation to wire this model in existed and never
+//     finished;
+//   - an operation-level RETRY - admin reported a real failure applying it.
+//
+// and deliberately NOT when nothing was observed: a wait that never once
+// reached admin (sawVerdict false), a deadline where no poll ever confirmed
+// anything (neverConfirmed), and the generic support dead-end all know only
+// that we could not ask. Offering a model change there would imply the model is
+// at fault, which is a diagnosis nobody made - the same class of claim
+// jarvis#709 removed. Those states keep Retry, which CAN help them, plus
+// Contact support.
+//
+// Also never on the three stopping verdicts (waitPhases `stop`): a paged
+// authority repair, a paused subscription and a moved account all render the
+// `blocked` panel, and a different model provably cannot resolve any of them.
+const connectModelChangeOffered = ref(false);
+
+// The escape hatch itself: back to the Connect form with the customer's own
+// choice still in it. The editor is v-show'd, never v-if'd, so its state - the
+// provider, the model, a passing key probe - is still mounted and simply
+// becomes visible again; there is nothing to re-fetch or re-fill.
+//
+// It has to be in-wizard. Settings is the obvious home for "add another model",
+// but it is unreachable from here by construction: `llm_pool_provisioning`,
+// `llm_provisioning` and `readiness_unconfirmed` are all in readiness.js's
+// NOT_ONBOARDED_REASONS, so AppShell's `showGate` renders the full-screen
+// onboarding poster over every route except this one. A "go to Settings" link
+// would put the customer back on this wizard by a longer path.
+//
+// The three forgets are load-bearing, not tidying. The customer is about to
+// submit a DIFFERENT configuration, so this attempt's idempotency key must not
+// survive: admin dedupes on it and would hand back the very operation that
+// never converged. currentOpId must go with it, or retryConnect would re-follow
+// that dead operation instead of saving the new config (enterSaveRefusal, the
+// one terminal that can be reached next, never clears it).
+function chooseDifferentModel() {
+	stopRetryCountdown();
+	forgetIdem();
+	opStore.forget();
+	currentOpId.value = "";
+	forgetReady();
+	readinessSeen.value = null;
+	state.connectPhase = "";
+	state.connectTitle = "";
+	state.connectMessage = "";
+	state.connectPaged = false;
+	state.connectSupportOffered = false;
+	state.retryAfter = 0;
+	connectModelChangeOffered.value = false;
+	// Says what was observed - the wait ended without setup finishing - and never
+	// that the chosen model is broken, which nothing here established.
+	state.connectBlockReason =
+		"Setup didn't finish with the AI connection you chose, and waiting hasn't cleared it. Pick a different model and start again.";
+	// Any wait still sleeping between polls stops on its next tick (both loops
+	// re-check this), so a late ceiling cannot yank the customer back out of the
+	// form they were just returned to.
+	state.finishing = false;
+}
+
 function ensureController() {
 	if (opController) return opController;
 	opController = createOperationController({
@@ -3148,8 +3254,11 @@ function onOpUpdate(ui) {
 	const phase = ui && ui.phase;
 	if (phase === OP_PHASE.REJECTED) {
 		// The input is the problem: return to the editable form with the reason.
+		// This IS the jarvis#727 escape, already built, for the one case admin can
+		// name outright - so there is nothing left to offer.
 		state.finishing = false;
 		state.connectPhase = "rejected";
+		connectModelChangeOffered.value = false;
 		state.connectBlockReason =
 			(ui && ui.message) ||
 			"That AI configuration was rejected. Edit your key or connection and try again.";
@@ -3165,6 +3274,10 @@ function onOpUpdate(ui) {
 		state.connectMessage = (ui && ui.message) || "We hit a snag applying your AI connection.";
 		state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: false });
 		state.retryAfter = (ui && ui.retryAfterSeconds) || 0;
+		// Admin reported a real failure applying THIS configuration (jarvis#727).
+		// Retry stays the primary action - the failure is transient by
+		// classification - but it is no longer the only one.
+		connectModelChangeOffered.value = true;
 		startRetryCountdown();
 	} else if (phase === OP_PHASE.SUPERSEDED) {
 		state.connectPhase = "superseded";
@@ -3174,13 +3287,17 @@ function onOpUpdate(ui) {
 		state.connectTitle = connectHeadline("superseded");
 		// A stale offer from an EARLIER readiness wait (jarvis#708) must not survive
 		// into this unrelated terminal - supersession means reload, not "still not
-		// resolved", and this phase already has its own recovery action.
+		// resolved", and this phase already has its own recovery action. The
+		// jarvis#727 offer is withdrawn for the same reason, and one more: a newer
+		// save owns the truth now, so this screen no longer knows which
+		// configuration is even being applied.
 		state.connectSupportOffered = false;
+		connectModelChangeOffered.value = false;
 	} else {
 		// WORKING (pending / applying), and the descriptor seed.
 		state.connectPhase = "working";
 		state.connectMessage = "";
-		state.finishSubtitle = "Bringing your workspace online, taking you to chat…";
+		state.finishSubtitle = "We'll take you to chat as soon as your setup is done.";
 	}
 }
 
@@ -3230,6 +3347,11 @@ function noteReadiness(o) {
 		state.connectMessage = stage.detail;
 		state.connectPaged = !!stage.paged;
 		state.connectSupportOffered = true;
+		// Not one of these three is a model problem: a paged authority repair must
+		// see no self-service action at all, a paused subscription needs a renewal,
+		// and a moved account needs the other site. Offering a different model here
+		// would be a wrong diagnosis dressed as help (jarvis#727).
+		connectModelChangeOffered.value = false;
 	}
 }
 
@@ -3249,6 +3371,10 @@ async function waitForChatReadiness() {
 		// polling rather than counting down to a ceiling whose exhaustion copy
 		// would invite the retry this state must not offer.
 		if (state.connectPhase === "blocked") return;
+		// The customer took the jarvis#727 escape back to the editor. This wait is
+		// about the configuration they just left behind, so its ceiling must not
+		// fire and pull them back out of the form.
+		if (!state.finishing) return;
 		// The memoized verdict is what the router guard will read moments from now, so
 		// it has to be dropped before each probe or this loop polls a cached answer.
 		forgetReady();
@@ -3284,6 +3410,11 @@ async function waitForChatReadiness() {
 	// claim. It is now derived from the same source.
 	state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 	state.connectSupportOffered = true;
+	// jarvis#727: this is the exact state the issue was filed from. Admin kept
+	// answering for the whole wait and never said Ready, so Retry re-runs a thing
+	// this run watched fail to converge. Offer the model change beside it. When
+	// admin was never reached at all, only Retry and support are honest.
+	connectModelChangeOffered.value = sawVerdict;
 	state.retryAfter = 0;
 }
 
@@ -3318,6 +3449,13 @@ function onTerminal(status) {
 			state.connectMessage =
 				"Setup was still running when we last checked, and it's taking longer than usual. You can keep waiting and retry.";
 		}
+		// jarvis#727. The operation that wires the chosen model in was CONFIRMED in
+		// flight and still did not finish inside its deadline, which is the state
+		// tenant e4qdeprp4r sat in (LLM_APPLY_PENDING, applied_version behind
+		// desired_version, forever). A different model is a real way out of that.
+		// neverConfirmed is the opposite case - nothing was ever reached, so nothing
+		// points at the configuration - and keeps Retry alone.
+		connectModelChangeOffered.value = !status.neverConfirmed;
 		state.retryAfter = 0;
 		return;
 	}
@@ -3337,7 +3475,7 @@ function onTerminal(status) {
 		state.connectPhase = "working";
 		state.finishSubtitle =
 			ui.chatReadinessReason ||
-			"Your AI is connected. Waiting for your workspace to come online…";
+			"Your AI is connected. We're waiting on the last of your setup…";
 		waitForChatReadiness();
 		return;
 	}
@@ -3361,6 +3499,12 @@ function enterSupport() {
 	// This dead-end is unrelated to a chat-readiness wait (jarvis#708): don't let a
 	// stale offer from an earlier one show under a different failure's message.
 	state.connectSupportOffered = false;
+	// And no model-change offer (jarvis#727). Everything that lands here - a
+	// controller that threw, a null terminal, a resume that ran out, a
+	// descriptor-less refusal - is a failure to complete the round trip, not an
+	// observation about the configuration. Retry is the honest primary here
+	// because the round trip is exactly what may work next time.
+	connectModelChangeOffered.value = false;
 }
 
 // Follow a descriptor (or a bare op id on resume) to its terminal state. Supersession
@@ -3436,7 +3580,7 @@ const LEGACY_READY_INTERVAL_MS = 2500;
 async function followLegacyReadiness() {
 	state.finishing = true;
 	state.connectPhase = "working";
-	state.finishSubtitle = "Bringing your workspace online, taking you to chat…";
+	state.finishSubtitle = "We'll take you to chat as soon as your setup is done.";
 	// What this run actually observed, so the exhaustion message below can say
 	// exactly that and nothing more (jarvis#708) - see readinessWaitExhaustedMessage.
 	let sawVerdict = false;
@@ -3445,6 +3589,9 @@ async function followLegacyReadiness() {
 	for (let i = 0; i < LEGACY_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
 		if (state.connectPhase === "blocked") return;
+		// The jarvis#727 escape took the customer back to the editor - see
+		// waitForChatReadiness for why this wait must not outlive it.
+		if (!state.finishing) return;
 		let r = null;
 		try {
 			r = await isReadyForChat();
@@ -3470,6 +3617,8 @@ async function followLegacyReadiness() {
 	state.connectMessage = readinessWaitExhaustedMessage({ sawVerdict, detail: lastDetail });
 	state.connectTitle = connectHeadline("retry", { fromReadinessCeiling: true });
 	state.connectSupportOffered = true;
+	// Same ceiling, same rule as waitForChatReadiness (jarvis#727).
+	connectModelChangeOffered.value = sawVerdict;
 	state.retryAfter = 0;
 }
 
@@ -3513,7 +3662,10 @@ async function saveConnect() {
 	state.connectBlockReason = "";
 	// A genuinely fresh attempt: any earlier attempt's "we couldn't confirm this,
 	// get a person to look into it" offer was about THAT attempt, not this one.
+	// Same for the jarvis#727 model-change offer, which is an observation about a
+	// configuration this attempt has not yet tried.
 	state.connectSupportOffered = false;
+	connectModelChangeOffered.value = false;
 	savingConnect.value = true;
 	try {
 		let idem = recallIdem();
@@ -3558,13 +3710,12 @@ function reloadConnect() {
 	window.location.reload();
 }
 
-// Back to the editable form to fix a rejected configuration.
-function editConnect() {
-	stopRetryCountdown();
-	state.finishing = false;
-	state.connectPhase = "";
-	state.connectMessage = "";
-}
+// (An unreferenced `editConnect` lived here: a partial return-to-the-form that
+// nothing ever called, because onOpUpdate's REJECTED branch inlines its own.
+// Removed rather than reused by jarvis#727's escape - it dropped neither the
+// idempotency key nor the operation id, so wiring it to a button would have sent
+// the customer's NEW configuration under the old attempt's key and had admin
+// dedupe it straight back to the stuck operation.)
 
 // Resume an in-flight apply on mount (reload mid-apply): follow the SAME operation
 // rather than showing an editable form over a running one (review P1-05). If only the


### PR DESCRIPTION
## Summary

A customer whose only model cannot be verified can now leave the wizard's dead end by picking a different one, and the setup screen's headline says what is actually happening instead of "Setting up Jarvis".

**The escape.** Where a wait ends in a state Retry cannot resolve, "Use a different model" now sits beside Retry and returns the customer to the Connect step with their choice still filled in. It appears only where this attempt watched the pipeline stall or fail on the configuration they chose, and never where nothing was observed at all, which would blame a model nobody examined. It cannot be a link to Settings: `readiness.js`'s `NOT_ONBOARDED_REASONS` puts these states behind AppShell's full-screen gate, so Settings is a round trip back to this same screen.

**The headline** now reads off the live phase: "Giving Jarvis a brain" while the AI connection is applied, "Bringing your setup online" while the container comes up, "Opening your chat" once a ready verdict has fired the navigation, and the plain "Setting up {agentName}" whenever nothing is observed. The word "workspace" is gone from the wait copy.

Fixes #727.

<details>
<summary>Composing with #730, and the classification behind the escape</summary>

### #730

It was **open** when this started, so the change was written to compose with its diff: new exports go mid-file in `waitPhases.js` and mid-file in its test (both of which #730 appends to at EOF), new import names go before `connectHeadline` in both import blocks (#730 adds `phaseProgress` after it), and the connect template's subtitle expression keeps its exact line shape so the three lines #730's `Progress` hunk uses as context are untouched. A trial merge of `fix/725-726-alert-progress` was clean and green before it landed. #730 then merged mid-work and this branch **rebased on top with zero conflicts**; the progress bar and the phase-driven headline coexist on the same screen.

### Which states are unrecoverable, and on what evidence

The reason codes alone cannot carry this. `llm_pool_provisioning` is an ordinary mid-apply state at ninety seconds and a permanent dead end at a hundred and twenty, and nothing in the vocabulary distinguishes them. What distinguishes them is whether a bounded wait ran to its ceiling while the control plane kept answering. So the offer is gated on an observation, in three places:

| State | Offer | Why |
|---|---|---|
| Readiness ceiling that NAMED a subject | yes | admin said the outstanding work was the LLM apply or the container, for the whole wait, and it never converged. This is the reproduced state: tenant `e4qdeprp4r`, `chat_readiness` Configuring, `desired_version 1 / applied_version 0`, `LLM_APPLY_PENDING`. |
| Readiness ceiling that named NOTHING (`readiness_unconfirmed`) | no | that code means admin could not be asked. See the review round below. |
| Apply deadline, `neverConfirmed` false | yes | the operation that wires the model in was confirmed in flight and never finished. |
| Operation `RETRY` | yes | admin reported a real failure applying this configuration. |
| Readiness ceiling, no poll answered at all | no | admin was never reached. Nothing points at the model; Retry is the thing that can help. |
| Apply deadline, `neverConfirmed` true | no | same, per jarvis#690. |
| Generic support dead end | no | a failed round trip, not an observation about the configuration. |
| `authority_repair_required` | no | `account.py` and `readiness.js` are explicit: support is paged, retrying could make it worse, no self-service action at all. Already renders the blocked panel with no Retry. |
| `subscription_suspended` | no | `account.py` keeps this distinct precisely so a suspended customer is not told to wait. Needs a renewal, not a model. |
| `site_replaced` | no | the account lives on another site. |
| Operation `REJECTED` | n/a | already returns to the editable form with admin's reason. That escape existed; this PR only stops it being the only one. |

The three `stop` verdicts already had no Retry, so the defect #727 names was never in the blocked panel. It was in the retry/timeout terminals, which offered Retry alone.

### Review round (second commit)

A finder caught a real P0 in the first commit: the readiness ceilings gated the offer on `sawVerdict`, which means only "a poll returned JSON". `readiness_unconfirmed` is a well-formed 200 whose documented meaning in `account.py` is that admin **could not be asked**, so a wait that established nothing about the customer's connection still told them it had failed. That is the same class of false claim the feature exists to prevent, and it contradicted the ceiling's own comment. The gate is now "did any poll of this wait NAME what it was waiting on" (`kind !== PHASE_KIND.NONE`), accumulated across the wait rather than read off the last poll.

`container_provisioning` deliberately stays in the offered set: it is admin saying "not Ready" for anything that is neither Suspended nor SupportRequired, and in the reproduced class of failure admin's own detail rides that code ("Still verifying your OpenAI subscription"). That is a judgement call, and it has a test naming it as one.

Three smaller review findings, all fixed in the same commit: `followDescriptor` (the third entry into the working screen, reached by Retry) did not clear the previous wait's observation, so a Retry from a ceiling re-rendered that ceiling's stale phase as the live headline; `enterSaveRefusal` relied on its callers to reset the offer instead of setting it itself; and `inFlightPhase`'s doc justified the brain headline by an apply operation that the `mode:"legacy"` path never mints, when the real grounding is that the save was accepted and is being applied, which holds on both paths.

Every new assertion was mutation-checked: reverting the gate turns two tests red, and removing the stale-phase reset turns a third red.

### Why the exit clears three things

The customer is about to submit a *different* configuration. The idempotency key must not survive or admin dedupes the new config straight back to the stuck operation; `currentOpId` must go with it or `retryConnect` re-follows that dead operation (`enterSaveRefusal`, reachable next, never clears it); and both wait loops now stop on `!state.finishing` so a ceiling cannot fire minutes later and pull the customer back out of the form.

### Honesty (#709, #722)

`setupHeadline` is pure and keys on a new `PHASE_KIND` carried by the phase objects, never on label text. Every phase the module refuses to name is explicitly `NONE` and falls back to the generic headline. "Opening your chat" is reachable only from an actual ready verdict having fired `navigateToChat()`, or a `DONE` phase; a test pins that no readiness reason reaches it on its own, since `readinessPhase` has no DONE branch (#726's own finding).

### Found, not fixed

- **The onboarding editor is single-model** (`modes: ["quick"]`). #727 proposes "add a second one as a fallback"; that is not expressible in the wizard, so the copy says "pick a different model". Adding a fallback during onboarding is a separate change.
- **The phase-row labels still say "workspace"** ("Your workspace is coming online", "Checking on your workspace"), as do `readinessWaitExhaustedMessage` and the `blocked` panel. Left alone: that copy is #709/#722's, and #726 asserts one of the strings literally. The new design.md rule now names these as known outstanding violations rather than pretending the repo already complies.
- **A pre-existing Retry freeze.** If admin returns a FAILED op with `retry_after_seconds > 0`, `onOpUpdate` starts the cooldown and `onTerminal`'s `stopRetryCountdown()` kills the timer in the same tick, so `retryAfter` never reaches zero and Retry stays permanently disabled. Predates this PR; flagged because "Use a different model" is now the only live action if it is ever hit.
- **`subscription_suspended` offers only Contact support**, with no Renew action, though the customer's own action is exactly what it needs.
- **A dead `editConnect()`** was sitting in `OnboardingView.vue`, unreferenced. Removed rather than reused: it dropped neither the idempotency key nor the operation id.

### Verification

Node 24. Full frontend suite 929/929, `node --test` 656/656, `vite build` clean, `pre-commit` (prettier 2.7.1 + eslint) passes. Hosted CI was 7/7 green on the first commit; the review-round commit is running now. Tenant `e4qdeprp4r` was read only and not modified; no bench mutation, no migrate.

</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (rebased onto develop after #730 merged)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
