### PR TITLE
fix(chat): bound the "Finishing..." affordance so it can never stick (#681)

### DIFF
--- a/frontend/src/lib/enrichmentPending.js
+++ b/frontend/src/lib/enrichmentPending.js
@@ -1,0 +1,120 @@
+// SUX-7 / jarvis#681: the "Finishing…" affordance's bookkeeping, extracted as a
+// PLAIN, importable, unit-tested module (ChatView.vue imports it).
+//
+// What the affordance is. Settlement publishes the turn's terminal `run:end` with
+// `enrichment_pending`, which tells the SPA to keep a subtle "Finishing…" line under
+// an otherwise finished reply while the finalize job is still adding late enrichment
+// (attachments, canvas, auto-title). `message:enriched` clears it.
+//
+// The defect this module closes (jarvis#681, e2e finding F26). `message:enriched` is
+// a single best-effort realtime push at the end of a chain of best-effort enrichment
+// effects, and the affordance had NOTHING else that could ever clear it. So all of
+// these left it up permanently on a reply that was already complete and correct:
+//   * a finalize effect that keeps failing. The usage poll retries BY DESIGN when the
+//     gateway session row is missing or stale, which is exactly what a live credential
+//     apply produces, and the turn then sits in `finalizing` until the 5-minute pump
+//     watchdog has burned the 3-attempt budget. That is 15 minutes at best, and
+//     forever on any bench whose scheduler is not running.
+//   * the push itself lost: a socket blip, a hidden tab, a client that was on another
+//     route when it fired. There is no replay on the socket.
+//   * a reload. `loadConversation` replaces the messages but never the pending set,
+//     so navigating away and back re-rendered the same stuck line.
+//
+// A permanent "Finishing…" asserts the answer is incomplete when it is not, which is
+// strictly worse than saying nothing. So the affordance is BOUNDED: every entry
+// carries a deadline, and on expiry it is dropped and the owner is told, so it can
+// refetch the conversation once and still pull in whatever enrichment did land.
+//
+// The bound is deliberately generous. Enrichment normally completes within a couple
+// of seconds; the slowest healthy path is the usage effect's bounded gateway poll
+// (three reads with 1.5s sleeps) plus short-queue latency. Two minutes is far past
+// any healthy run, and short enough that nobody reads the line as permanent.
+export const ENRICHMENT_PENDING_MAX_MS = 120000;
+
+const noop = () => {};
+
+/**
+ * Track which assistant messages are still awaiting `message:enriched`, with a
+ * deadline on each so the affordance can never outlive its usefulness.
+ *
+ * The tracker owns the timers; the caller owns the rendering. `onChange` is handed a
+ * fresh Set on every mutation (so a Vue ref assignment triggers a re-render, matching
+ * how ChatView already replaced the Set rather than mutating it), and `onExpire` is
+ * called once per message that timed out, AFTER `onChange`, so the owner sees the
+ * cleared state before it decides to resync.
+ *
+ * `setTimer` / `clearTimer` are injectable purely so the deadline behaviour is
+ * testable without real time passing.
+ */
+export function createEnrichmentPending(options = {}) {
+	const maxMs = options.maxMs != null ? options.maxMs : ENRICHMENT_PENDING_MAX_MS;
+	const onChange = options.onChange || noop;
+	const onExpire = options.onExpire || noop;
+	const setTimer = options.setTimer || ((fn, ms) => setTimeout(fn, ms));
+	const clearTimer = options.clearTimer || ((handle) => clearTimeout(handle));
+
+	const timers = new Map(); // messageId -> timer handle
+	let ids = new Set(); // messageIds currently showing "Finishing…"
+
+	function emit() {
+		onChange(new Set(ids));
+	}
+
+	function cancelTimer(messageId) {
+		if (!timers.has(messageId)) return;
+		clearTimer(timers.get(messageId));
+		timers.delete(messageId);
+	}
+
+	function expire(messageId) {
+		timers.delete(messageId);
+		if (!ids.delete(messageId)) return; // already cleared by message:enriched
+		emit();
+		onExpire(messageId);
+	}
+
+	return {
+		/**
+		 * A terminal `run:end` said enrichment is still owed for this reply. Idempotent
+		 * and deliberately NON-extending: a re-delivered terminal (the CDX-12 finalize
+		 * backstop re-publishes one) must not push the deadline out, or a server that
+		 * keeps re-announcing the same stuck turn would keep the line up indefinitely,
+		 * which is the very failure being fixed. The clock runs from the FIRST terminal.
+		 */
+		mark(messageId) {
+			if (!messageId || ids.has(messageId)) return false;
+			ids.add(messageId);
+			timers.set(
+				messageId,
+				setTimer(() => expire(messageId), maxMs)
+			);
+			emit();
+			return true;
+		},
+
+		/** `message:enriched` landed (or the caller otherwise knows enrichment settled). */
+		clear(messageId) {
+			if (!messageId || !ids.has(messageId)) return false;
+			cancelTimer(messageId);
+			ids.delete(messageId);
+			emit();
+			return true;
+		},
+
+		/** Drop everything and cancel every timer (component teardown). */
+		reset() {
+			for (const messageId of [...timers.keys()]) cancelTimer(messageId);
+			if (!ids.size) return;
+			ids = new Set();
+			emit();
+		},
+
+		has(messageId) {
+			return ids.has(messageId);
+		},
+
+		get size() {
+			return ids.size;
+		},
+	};
+}

--- a/frontend/src/lib/enrichmentPending.test.js
+++ b/frontend/src/lib/enrichmentPending.test.js
@@ -1,0 +1,223 @@
+// Real executable tests for the bounded "Finishing…" affordance (enrichmentPending.js),
+// plus source assertions fencing the ONE view that drives it. Plain node built-ins
+// (node:test + node:assert), like eventFence.test.js / chatAsk.test.js. Run directly
+// (`node --test enrichmentPending.test.js`), via `npm run test:node`, or via the python
+// suite (jarvis/tests/test_enrichment_pending_client.py subprocess-runs it every CI run).
+//
+// What is being defended (jarvis#681, e2e finding F26). A chat turn rendered its answer,
+// its tool count and its duration, and then showed "Finishing…" forever. The reply was
+// complete; only the post-turn enrichment had stalled, because a background lane was
+// still holding credentials the operator had just replaced. The affordance had exactly
+// one thing that could ever clear it, the `message:enriched` realtime push, so a stalled
+// or lost enrichment left a permanent claim that the answer was unfinished.
+//
+// The contract these tests pin down: the affordance is BOUNDED. It clears on
+// `message:enriched` as before, and it ALSO clears on its own deadline, whatever the
+// server is doing, so no server-side failure can produce a permanent "Finishing…".
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createEnrichmentPending, ENRICHMENT_PENDING_MAX_MS } from "./enrichmentPending.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const chatViewSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+// A controllable clock, so the deadline is proved rather than waited out.
+function fakeClock() {
+	let nextId = 1;
+	let now = 0;
+	const timers = new Map(); // id -> { at, fn }
+	return {
+		setTimer(fn, ms) {
+			const id = nextId++;
+			timers.set(id, { at: now + ms, fn });
+			return id;
+		},
+		clearTimer(id) {
+			timers.delete(id);
+		},
+		advance(ms) {
+			now += ms;
+			const due = [...timers.entries()]
+				.filter(([, t]) => t.at <= now)
+				.sort((a, b) => a[1].at - b[1].at);
+			for (const [id, t] of due) {
+				timers.delete(id);
+				t.fn();
+			}
+		},
+		get liveTimers() {
+			return timers.size;
+		},
+	};
+}
+
+// Builds a tracker on the fake clock and records everything it emits.
+function harness(maxMs = ENRICHMENT_PENDING_MAX_MS) {
+	const clock = fakeClock();
+	const changes = [];
+	const expired = [];
+	const tracker = createEnrichmentPending({
+		maxMs,
+		setTimer: clock.setTimer,
+		clearTimer: clock.clearTimer,
+		onChange: (set) => changes.push(set),
+		onExpire: (id) => expired.push(id),
+	});
+	return { clock, changes, expired, tracker };
+}
+
+const latest = (changes) => changes[changes.length - 1];
+
+// ---- the ordinary path is unchanged --------------------------------------
+
+test("run:end marks the reply pending and message:enriched clears it", () => {
+	const { tracker, changes, expired, clock } = harness();
+	tracker.mark("msg-1");
+	assert.equal(tracker.has("msg-1"), true);
+	assert.deepEqual([...latest(changes)], ["msg-1"]);
+
+	tracker.clear("msg-1");
+	assert.equal(tracker.has("msg-1"), false, "the affordance goes away when enrichment lands");
+	assert.equal(latest(changes).size, 0);
+	assert.equal(clock.liveTimers, 0, "clearing cancels the deadline, no orphan timer");
+
+	clock.advance(ENRICHMENT_PENDING_MAX_MS * 2);
+	assert.deepEqual(expired, [], "a reply that enriched normally never expires afterwards");
+});
+
+test("onChange is handed a fresh Set every time, never the tracker's own", () => {
+	// ChatView assigns this straight onto a ref; a mutated-in-place Set would not
+	// re-render, which is how the affordance would go stale in the other direction.
+	const { tracker, changes } = harness();
+	tracker.mark("msg-1");
+	tracker.mark("msg-2");
+	assert.equal(changes.length, 2);
+	assert.notEqual(changes[0], changes[1]);
+	assert.equal(changes[0].size, 1, "the earlier snapshot is not mutated by the later mark");
+	assert.equal(changes[1].size, 2);
+});
+
+// ---- the reported failure shape ------------------------------------------
+
+test("a completed turn whose enrichment never lands stops claiming to be unfinished", () => {
+	// jarvis#681 exactly: the turn SUCCEEDED (run:end with enrichment_pending, the answer
+	// is on screen), and then the follow-up work died, so message:enriched never comes.
+	const { tracker, changes, expired, clock } = harness();
+	tracker.mark("msg-stuck");
+
+	clock.advance(ENRICHMENT_PENDING_MAX_MS - 1);
+	assert.equal(tracker.has("msg-stuck"), true, "still within the grace window");
+	assert.deepEqual(expired, [], "nothing given up on yet");
+
+	clock.advance(1);
+	assert.equal(tracker.has("msg-stuck"), false, "the deadline clears it with no server help");
+	assert.equal(latest(changes).size, 0);
+	assert.deepEqual(expired, ["msg-stuck"], "the owner is told once so it can resync");
+	assert.equal(clock.liveTimers, 0);
+});
+
+test("expiry fires once, even if the owner keeps the clock running", () => {
+	const { tracker, expired, clock } = harness();
+	tracker.mark("msg-stuck");
+	clock.advance(ENRICHMENT_PENDING_MAX_MS * 5);
+	assert.deepEqual(
+		expired,
+		["msg-stuck"],
+		"no repeated resync storm on a permanently dead turn"
+	);
+});
+
+test("a re-delivered terminal does not push the deadline out", () => {
+	// The CDX-12 finalize backstop re-publishes run:end for a turn it believes is still
+	// owed enrichment. If mark() restarted the clock, a server stuck in that loop would
+	// hold the affordance up forever, which is the bug this module exists to prevent.
+	const { tracker, expired, clock } = harness();
+	assert.equal(tracker.mark("msg-1"), true);
+	clock.advance(ENRICHMENT_PENDING_MAX_MS - 10);
+	assert.equal(tracker.mark("msg-1"), false, "re-marking an already-pending reply is a no-op");
+	clock.advance(10);
+	assert.deepEqual(expired, ["msg-1"], "the clock still ran from the FIRST terminal");
+});
+
+test("deadlines are per reply and independent", () => {
+	const { tracker, expired, clock } = harness(1000);
+	tracker.mark("msg-early");
+	clock.advance(400);
+	tracker.mark("msg-late");
+
+	clock.advance(600); // msg-early is now 1000ms old, msg-late only 600ms
+	assert.deepEqual(expired, ["msg-early"]);
+	assert.equal(tracker.has("msg-late"), true, "a later reply keeps its own full window");
+
+	clock.advance(400);
+	assert.deepEqual(expired, ["msg-early", "msg-late"]);
+});
+
+test("enrichment landing for one reply leaves another reply's affordance alone", () => {
+	const { tracker, clock, expired } = harness(1000);
+	tracker.mark("msg-1");
+	tracker.mark("msg-2");
+	tracker.clear("msg-1");
+	assert.equal(tracker.size, 1);
+	clock.advance(1000);
+	assert.deepEqual(expired, ["msg-2"]);
+});
+
+// ---- teardown ------------------------------------------------------------
+
+test("reset cancels every deadline so a torn-down view never resyncs", () => {
+	const { tracker, changes, expired, clock } = harness();
+	tracker.mark("msg-1");
+	tracker.mark("msg-2");
+	tracker.reset();
+	assert.equal(tracker.size, 0);
+	assert.equal(latest(changes).size, 0);
+	assert.equal(clock.liveTimers, 0, "no timer survives to fire a reload into a dead component");
+	clock.advance(ENRICHMENT_PENDING_MAX_MS * 2);
+	assert.deepEqual(expired, []);
+});
+
+test("clear and mark ignore a missing message id", () => {
+	const { tracker, changes } = harness();
+	assert.equal(tracker.mark(null), false);
+	assert.equal(tracker.mark(undefined), false);
+	assert.equal(tracker.clear(null), false);
+	assert.equal(tracker.clear("never-marked"), false);
+	assert.equal(changes.length, 0, "a no-op never churns the render");
+});
+
+test("the bound is generous enough for a healthy slow finalize and short enough to be a bound", () => {
+	// The slowest healthy enrichment is the usage effect's own bounded gateway poll
+	// (three reads, 1.5s apart) plus short-queue latency, comfortably inside a minute.
+	assert.ok(ENRICHMENT_PENDING_MAX_MS >= 60000, "must not clip a slow but healthy finalize");
+	assert.ok(ENRICHMENT_PENDING_MAX_MS <= 300000, "must not read as permanent to a human");
+});
+
+// ---- source fences: ChatView must go through this module ------------------
+
+test("ChatView drives the affordance through this module, not a raw Set", () => {
+	assert.match(
+		chatViewSrc,
+		/import \{ createEnrichmentPending \} from "@\/lib\/enrichmentPending"/,
+		"ChatView must import the bounded tracker"
+	);
+	assert.match(
+		chatViewSrc,
+		/enrichmentTracker\.mark\(p\.message_id\)/,
+		"run:end must mark through the tracker so the deadline is armed"
+	);
+	assert.match(
+		chatViewSrc,
+		/enrichmentTracker\.clear\(p\.message_id\)/,
+		"message:enriched must clear through the tracker so the deadline is disarmed"
+	);
+	// The old unbounded bookkeeping wrote the ref directly. If either line comes back,
+	// an entry gets added or removed with no deadline attached and the bug returns.
+	assert.ok(
+		!/enrichmentPending\.value = new Set\(enrichmentPending\.value\)/.test(chatViewSrc),
+		"no direct Set surgery on the ref: every mutation must carry a deadline"
+	);
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4264,8 +4264,12 @@ const enrichmentTracker = createEnrichmentPending({
 	// whose enrichment truly died just loses a label it should never have kept.
 	// Freshness-guarded, since the deadline can fire long after the user moved on.
 	onExpire: (messageId) => {
-		if (currentId.value && messages.value.some((m) => m.name === messageId))
-			loadConversation(currentId.value);
+		if (!currentId.value || !messages.value.some((m) => m.name === messageId)) return;
+		loadConversation(currentId.value);
+		// Same idle re-render pass the other two reload sites do: loadConversation
+		// runs processMermaid once, but a late re-render can swap a freshly-rendered
+		// mermaid node back to raw source, and this catches that race.
+		setTimeout(processMermaid, 300);
 	},
 });
 onUnmounted(() => enrichmentTracker.reset());

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3637,6 +3637,7 @@ import { useConfirm } from "@/composables/useConfirm";
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
 import { formatDate, exactDate, dayLabel } from "@/utils/datetime";
 import { fenceReject, fenceAccept } from "@/utils/eventFence";
+import { createEnrichmentPending } from "@/lib/enrichmentPending";
 import { currentThreadModel, modelBadgeFor, modelBadgeTitleFor } from "@/utils/modelBadge";
 import { renderMarkdown } from "@/markdown";
 import JvChart from "@/charts/JvChart.vue";
@@ -4244,7 +4245,30 @@ function tearDownActivityIfSettled() {
 // SUX-7: a settled reply whose enrichment (canvas/attachments/title) is still running.
 // run:end carries enrichment_pending; message:enriched clears it. Drives a subtle
 // "finishing…" affordance so a late pop-in is signalled, not silent.
+//
+// jarvis#681: that affordance is BOUNDED, because message:enriched is one best-effort
+// push at the end of a chain of best-effort effects. Any of them stalling (the usage
+// poll retries by design, which is exactly what a live credential change produces)
+// held the line up for as long as the pump watchdog took to burn the retry budget, and
+// forever wherever that cron is not running. A permanent "Finishing…" on a finished
+// answer says the reply is incomplete when it is not, so the deadline in
+// @/lib/enrichmentPending drops it and resyncs once instead. The tracker owns the
+// deadlines; this ref is only what the template reads.
 const enrichmentPending = ref(new Set()); // message_ids awaiting message:enriched
+const enrichmentTracker = createEnrichmentPending({
+	onChange: (ids) => {
+		enrichmentPending.value = ids;
+	},
+	// Nothing told us enrichment finished, so pull the conversation once: whatever
+	// late canvas / attachments / title DID land still gets rendered, and a reply
+	// whose enrichment truly died just loses a label it should never have kept.
+	// Freshness-guarded, since the deadline can fire long after the user moved on.
+	onExpire: (messageId) => {
+		if (currentId.value && messages.value.some((m) => m.name === messageId))
+			loadConversation(currentId.value);
+	},
+});
+onUnmounted(() => enrichmentTracker.reset());
 const recovering = ref(null); // { message_id, reason } while a turn is parked for background recovery — the composer stays UNLOCKED so the user isn't trapped
 const retrying = ref(false); // guards the error-card Retry against a double-enqueue while one is in flight
 const srMessage = ref(""); // visually-hidden aria-live text (turn completion / failure) for screen readers
@@ -7805,10 +7829,11 @@ function onEvent(p) {
 			if (p.was_recovered) announceSR("Your answer is ready.");
 			// SUX-7: enrichment (canvas/attachments/title) may still be running after the
 			// authoritative terminal. Keep a subtle "finishing…" affordance until the
-			// message:enriched event clears it (a late pop-in is signalled, not silent).
+			// message:enriched event clears it (a late pop-in is signalled, not silent),
+			// or until its deadline expires (jarvis#681: an enrichment that never lands
+			// must not leave a finished answer looking unfinished forever).
 			if (p.message_id) {
-				if (p.enrichment_pending)
-					enrichmentPending.value = new Set(enrichmentPending.value).add(p.message_id);
+				if (p.enrichment_pending) enrichmentTracker.mark(p.message_id);
 				// NB: the CDX-3 fence entry is deliberately NOT cleared here — the
 				// terminated-epoch marker must persist to permanently block a later
 				// lower-epoch straggler (clearing it re-opened the stale-delta window).
@@ -7857,11 +7882,10 @@ function onEvent(p) {
 			// SUX-7: the Relay-Pump finalize job finished the owed enrichment for a
 			// settled reply — clear the "finishing…" affordance and pull the late
 			// attachments/canvas/title in with one reload.
-			if (p.message_id && enrichmentPending.value.has(p.message_id)) {
-				const next = new Set(enrichmentPending.value);
-				next.delete(p.message_id);
-				enrichmentPending.value = next;
-			}
+			// jarvis#681: the server re-delivers this event for a turn that is already
+			// done, so a client whose original push was lost still gets un-stuck. The
+			// tracker no-ops on a message it is not holding, which makes a repeat inert.
+			enrichmentTracker.clear(p.message_id);
 			loadConversation(currentId.value);
 			setTimeout(processMermaid, 300);
 			break;

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -69,7 +69,6 @@ def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> 
 		return {"ok": False, "reason": "no turn"}
 	state = turn["state"]
 	conversation = turn["conversation"]
-	owner = frappe.db.get_value(CONV, conversation, "owner")
 	if state == "done":
 		# jarvis#681: the enrichment terminal's CDX-12 backstop. ``run:end`` carried
 		# ``enrichment_pending``, which is the SPA's instruction to hold the subtle
@@ -83,13 +82,16 @@ def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> 
 		return {
 			"ok": True,
 			"already_done": True,
-			"republished": _publish_enriched(run_id, conversation, owner, turn.get("assistant_message")),
+			"republished": _publish_enriched(
+				run_id, conversation, _conversation_owner(conversation), turn.get("assistant_message")
+			),
 		}
 	# Only settled turns own an effect ledger. A turn still pre-terminal (queued/
 	# preparing/.../streaming/terminal_observed) has nothing to enrich yet.
 	if state not in ("finalizing", "errored", "cancelled"):
 		return {"ok": False, "reason": f"not settled ({state})"}
 
+	owner = _conversation_owner(conversation)
 	errored = state in ("errored", "cancelled")
 	ctx = _Ctx(
 		run_id=run_id,
@@ -143,6 +145,12 @@ def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> 
 			done = True
 			_publish_enriched(run_id, conversation, owner, turn.get("assistant_message"))
 	return {"ok": True, "ran": ran, "done": done, "state": state}
+
+
+def _conversation_owner(conversation: str) -> str | None:
+	"""Who the turn's realtime events are addressed to. Looked up per branch rather
+	than once up front so the pre-terminal early return below costs no extra read."""
+	return frappe.db.get_value(CONV, conversation, "owner")
 
 
 def _publish_enriched(

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -55,9 +55,10 @@ class _UsageRetry(Exception):
 
 def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> dict:
 	"""Run every pending enrichment effect for ``run_id`` (idempotent, force-done at
-	3), then finalize the turn to ``done`` (success path). Safe to re-run: a done
-	turn is a no-op; a partially-failed run leaves the rest pending for the next
-	cycle. Never raises out (best-effort)."""
+	3), then finalize the turn to ``done`` (success path). Safe to re-run: a done turn
+	runs no effects and only RE-DELIVERS ``message:enriched`` (jarvis#681, see below);
+	a partially-failed run leaves the rest pending for the next cycle. Never raises out
+	(best-effort)."""
 	turn = frappe.db.get_value(
 		TURN,
 		run_id,
@@ -67,15 +68,28 @@ def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> 
 	if not turn:
 		return {"ok": False, "reason": "no turn"}
 	state = turn["state"]
+	conversation = turn["conversation"]
+	owner = frappe.db.get_value(CONV, conversation, "owner")
 	if state == "done":
-		return {"ok": True, "already_done": True}
+		# jarvis#681: the enrichment terminal's CDX-12 backstop. ``run:end`` carried
+		# ``enrichment_pending``, which is the SPA's instruction to hold the subtle
+		# "Finishing..." line until ``message:enriched`` lands. That made the line depend
+		# on ONE best-effort push, so losing it (socket blip, a client on another route,
+		# a hidden tab) left a permanent "Finishing..." on a reply that was already
+		# complete. Any finalize that arrives after the turn is done now re-delivers the
+		# same event from durable truth; the client clears on set membership, so a
+		# duplicate is inert. This heals only when finalize runs again, which is why the
+		# SPA bounds the affordance on its own side too.
+		return {
+			"ok": True,
+			"already_done": True,
+			"republished": _publish_enriched(run_id, conversation, owner, turn.get("assistant_message")),
+		}
 	# Only settled turns own an effect ledger. A turn still pre-terminal (queued/
 	# preparing/.../streaming/terminal_observed) has nothing to enrich yet.
 	if state not in ("finalizing", "errored", "cancelled"):
 		return {"ok": False, "reason": f"not settled ({state})"}
 
-	conversation = turn["conversation"]
-	owner = frappe.db.get_value(CONV, conversation, "owner")
 	errored = state in ("errored", "cancelled")
 	ctx = _Ctx(
 		run_id=run_id,
@@ -127,15 +141,30 @@ def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> 
 		if ts.finalize_done(run_id, v):
 			frappe.db.commit()
 			done = True
-			if owner and turn.get("assistant_message"):
-				ts.publish_fenced(
-					owner,
-					"message:enriched",
-					conversation_id=conversation,
-					run_id=run_id,
-					message_id=turn["assistant_message"],
-				)
+			_publish_enriched(run_id, conversation, owner, turn.get("assistant_message"))
 	return {"ok": True, "ran": ran, "done": done, "state": state}
+
+
+def _publish_enriched(
+	run_id: str, conversation: str, owner: str | None, assistant_message: str | None
+) -> bool:
+	"""SUX-7: tell the client the owed enrichment for this reply is finished, so it
+	drops the "Finishing..." affordance and pulls the late attachments/canvas/title in.
+
+	One publish site for both callers: the finalize that flips ``finalizing -> done``,
+	and the jarvis#681 re-delivery for a turn that was ALREADY done when this finalize
+	ran. Returns whether anything was published (a turn with no assistant row, e.g. a
+	turn that errored before prepare inserted one, has no message to enrich)."""
+	if not (owner and assistant_message):
+		return False
+	ts.publish_fenced(
+		owner,
+		"message:enriched",
+		conversation_id=conversation,
+		run_id=run_id,
+		message_id=assistant_message,
+	)
+	return True
 
 
 class _Ctx:

--- a/jarvis/tests/test_enrichment_pending_client.py
+++ b/jarvis/tests/test_enrichment_pending_client.py
@@ -1,0 +1,62 @@
+"""jarvis#681 - the bounded "Finishing..." affordance, proven by a REAL executable
+node test that lives in the python suite forever.
+
+A completed chat turn kept showing "Finishing..." indefinitely after a background
+enrichment lane died on stale credentials. The affordance was driven by a single
+best-effort ``message:enriched`` realtime push and had nothing else that could ever
+clear it, so one stalled or lost enrichment left a finished answer permanently
+claiming to be unfinished.
+
+The bookkeeping now lives in ``frontend/src/lib/enrichmentPending.js`` (a plain,
+importable module ChatView.vue wires itself to) and every entry carries a deadline.
+``frontend/src/lib/enrichmentPending.test.js`` drives the reported shape on a fake
+clock: a reply marked pending whose ``message:enriched`` never arrives is dropped when
+its deadline passes, the owner is told exactly once so it can resync, a re-delivered
+terminal cannot push the deadline out, and teardown cancels every timer. It also
+source-fences ChatView so the old unbounded Set surgery cannot come back.
+
+This subprocess-runs it with ``node --test`` (non-zero exit on any failed assertion)
+so the client contract is enforced by the backend shards too, not only by the separate
+frontend CI job. Mirrors test_event_fence_client.py.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "lib", "enrichmentPending.test.js")
+
+
+class TestEnrichmentPendingClient(unittest.TestCase):
+	def test_bounded_finishing_affordance_node_walk_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"client enrichment-pending test missing at {test_file} - the jarvis#681 walk "
+			"MUST ship with the module",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"client enrichment-pending node test FAILED (jarvis#681 bounded affordance):\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: a silently-skipped suite (0 tests) must not read as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)

--- a/jarvis/tests/test_enrichment_pending_client.py
+++ b/jarvis/tests/test_enrichment_pending_client.py
@@ -21,11 +21,19 @@ frontend CI job. Mirrors test_event_fence_client.py.
 """
 
 import os
+import re
 import shutil
 import subprocess
 import unittest
 
 import frappe
+
+# The walk this file guards is only meaningful if it actually RAN. `node --test` counts
+# the FILE itself as one passing unit, so an emptied or import-broken test file still
+# prints "pass 1" with a zero exit: asserting merely that a pass line exists, or that the
+# count is at least 1, proves nothing. Hold a floor comfortably above 1 (the file ships
+# 11 tests) so a gutted suite fails loudly instead of reading as green.
+_MIN_EXPECTED_PASSES = 8
 
 
 def _test_path() -> str:
@@ -57,6 +65,14 @@ class TestEnrichmentPendingClient(unittest.TestCase):
 			"client enrichment-pending node test FAILED (jarvis#681 bounded affordance):\n"
 			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
 		)
-		# Belt-and-suspenders: a silently-skipped suite (0 tests) must not read as green.
-		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
-		self.assertNotIn("fail 1", proc.stdout)
+		# Belt-and-suspenders: prove the walk RAN, not just that nothing failed. See
+		# _MIN_EXPECTED_PASSES for why a floor above 1 is what makes this assertion real.
+		passes = re.search(r"\bpass (\d+)\b", proc.stdout)
+		self.assertIsNotNone(passes, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertGreaterEqual(
+			int(passes.group(1)),
+			_MIN_EXPECTED_PASSES,
+			f"the jarvis#681 client walk ran only {passes.group(1)} assertions, expected at least "
+			f"{_MIN_EXPECTED_PASSES}. An emptied or import-broken test file still exits 0 with "
+			f"'pass 1'.\n{proc.stdout}",
+		)

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -950,6 +950,137 @@ class TestFailedFinalSettlesAsError(_PipelineCase):
 
 
 # --------------------------------------------------------------------------- #
+# 7c. jarvis#681: a SUCCESSFUL turn whose follow-up enrichment lane keeps failing
+# --------------------------------------------------------------------------- #
+
+
+class TestStuckFinishingAfterAFailingLane(_PipelineCase):
+	"""jarvis#681 (e2e finding F26). A turn answered, ran its tools and settled. A
+	background lane then died on stale credentials, roughly a minute after an API-key
+	apply the main lane had already picked up. The SPA kept "Finishing..." up forever,
+	which claims the answer is incomplete when it is not.
+
+	The failing shape is driven for real, at the layer that actually breaks: the
+	gateway reports NO row for this turn's session (what a live credential change
+	produces), so the REAL usage effect gets ``USAGE_RETRY`` from the REAL
+	``record_turn_usage`` and raises, exactly as it does in production. Nothing is
+	mocked at the effect boundary, so the test cannot be satisfied by a fixture
+	handing the code a healthy row.
+
+	What that proves, and what the fix adds:
+	  * the turn legitimately stays ``finalizing`` and promises NO ``message:enriched``
+	    while the lane keeps failing. That is by design and is NOT changed here.
+	  * the retry budget eventually force-dones the effect and the turn reaches
+	    ``done``, publishing ``message:enriched`` exactly once. But that ONE publish is
+	    best-effort, and every retry is 5 minutes apart behind the pump watchdog cron.
+	  * so a finalize that arrives AFTER the turn is done now RE-DELIVERS
+	    ``message:enriched`` (the counterpart of the CDX-12 terminal backstop), instead
+	    of returning ``already_done`` in silence and leaving the client stuck.
+	The client-side half of the fix, the deadline that bounds the affordance whatever
+	the server does, is covered by frontend/src/lib/enrichmentPending.test.js.
+	"""
+
+	@contextmanager
+	def _mock_enrichment_except_usage(self):
+		"""``_mock_enrichment`` with the USAGE effect left REAL: this test's whole
+		subject is the real usage retry, and mocking it away would test nothing. The
+		poll's own sleeps are stubbed so the bounded retry costs no wall clock."""
+		recs = {"rich": _Recorder(), "macro": _Recorder(), "applearn": _Recorder(), "title": _Recorder()}
+		with (
+			patch("jarvis.chat.turn_handler.persist_rich_outputs", recs["rich"]),
+			patch("jarvis.chat.macros.advance_after_turn", recs["macro"]),
+			patch("jarvis.learning.app_analysis.on_turn_end", recs["applearn"]),
+			patch("jarvis.chat.title.enqueue_autotitle", recs["title"]),
+			patch("jarvis.chat.wiki.wiki_enabled", return_value=False),
+			patch("jarvis.chat.usage.time.sleep", lambda *a, **k: None),
+		):
+			yield recs
+
+	def _settle_a_successful_turn(self, rid: str) -> str:
+		"""Drive the REAL pipeline to a settled success: prepare -> stream -> terminal
+		-> settlement. Returns the conversation."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, content="how many sales invoices are open?")
+		self._mk_turn(conv, rid, seed, "queued", version=0, reserved=0)
+		double = self._double()
+		deps = self._deps(double=double, prepare=self._prepare_stub(conv, double, "success"))
+		ctx = self._make_ctx(deps)
+		self._pubs.clear()
+		self._pump_until(ctx, lambda: self._state(rid) in ("finalizing", "done"))
+		self.assertEqual(self._state(rid), "finalizing", "the answer settled; only enrichment is owed")
+		return conv
+
+	def test_a_dead_lane_holds_the_turn_then_the_budget_frees_it_and_the_event_redelivers(self):
+		rid = "pmp_681"
+		self._settle_a_successful_turn(rid)
+		# The gateway has no row for this turn's session: the F26 shape.
+		blind = _FakeSess()
+		blind.list_sessions = lambda: []
+
+		# ---- 1. the reported state: a completed answer, a dead lane, no clear ----
+		with self._gateway(blind), self._mock_enrichment_except_usage():
+			out = finalize.run_finalize(rid, self._target)
+		self.assertTrue(out["ok"], "finalize never errors a settled turn")
+		self.assertFalse(out["done"])
+		self.assertEqual(self._state(rid), "finalizing", "the failing lane holds the turn open")
+		self.assertEqual(self._effects(rid)["usage"], "pending", "released for the next cycle")
+		self.assertEqual(int(self._val(rid, "usage_recorded")), 0, "the guard CAS rolled back")
+		self.assertNotIn(
+			"message:enriched",
+			self._pub_kinds(),
+			"nothing tells the client to stop showing Finishing... while enrichment is owed",
+		)
+		# Everything the USER can see did land: the answer is complete, which is why a
+		# permanent "Finishing..." is a lie rather than merely pessimistic.
+		self.assertEqual(self._effects(rid)["rich_outputs"], "done")
+		self.assertEqual(self._effects(rid)["auto_title"], "done")
+
+		# ---- 2. the retry budget frees it, but only after the watchdog cadence ----
+		for _ in range(ts.FINALIZE_MAX_ATTEMPTS):
+			if self._state(rid) == "done":
+				break
+			with self._gateway(blind), self._mock_enrichment_except_usage():
+				finalize.run_finalize(rid, self._target)
+		self.assertEqual(self._state(rid), "done", "a broken lane can never strand a settled turn")
+		self.assertEqual(
+			self._pub_kinds().count("message:enriched"), 1, "the clear is published exactly once"
+		)
+
+		# ---- 3. THE FIX: that single publish is best-effort, so a later finalize
+		#         re-delivers it instead of returning already_done in silence. ----
+		amsg = self._val(rid, "assistant_message")
+		self._pubs.clear()
+		with self._gateway(blind), self._mock_enrichment_except_usage() as recs:
+			again = finalize.run_finalize(rid, self._target)
+		self.assertEqual(
+			self._pub_kinds(),
+			["message:enriched"],
+			"a finalize on a done turn re-delivers the clear the client is waiting on, "
+			"and nothing else. Before jarvis#681 this was silent, so a client that missed "
+			"the one publish above stayed on Finishing... with the answer already complete",
+		)
+		self.assertEqual(self._pubs[0]["message_id"], amsg, "addressed to the reply on screen")
+		self.assertEqual(self._pubs[0]["run_id"], rid)
+		self.assertTrue(again["already_done"])
+		self.assertTrue(again.get("republished"), "the re-delivery is reported to the caller")
+		self.assertEqual(recs["rich"].count, 0, "re-delivery runs NO effects; it is a publish, not a redo")
+
+	def test_a_done_turn_with_no_assistant_row_publishes_nothing(self):
+		# The re-delivery is addressed to a message. A turn that never got an assistant
+		# row (settled before prepare inserted one) has nothing to enrich, and must not
+		# emit a message:enriched carrying a null message_id for the client to index on.
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv)
+		rid = "pmp_681_noamsg"
+		self._mk_turn(conv, rid, seed, "done", version=9)
+		frappe.db.commit()
+		self._pubs.clear()
+		out = finalize.run_finalize(rid, self._target)
+		self.assertEqual(out, {"ok": True, "already_done": True, "republished": False})
+		self.assertEqual(self._pubs, [], "no message:enriched with a null message_id to index on")
+
+
+# --------------------------------------------------------------------------- #
 # 8. Usage (turn_id) idempotency under finalize replay
 # --------------------------------------------------------------------------- #
 

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -1076,8 +1076,11 @@ class TestStuckFinishingAfterAFailingLane(_PipelineCase):
 		frappe.db.commit()
 		self._pubs.clear()
 		out = finalize.run_finalize(rid, self._target)
-		self.assertEqual(out, {"ok": True, "already_done": True, "republished": False})
 		self.assertEqual(self._pubs, [], "no message:enriched with a null message_id to index on")
+		self.assertTrue(out["already_done"])
+		# assertIs, not assertFalse: before jarvis#681 this branch reported no outcome at
+		# all, and a missing key must not read the same as a considered "nothing to send".
+		self.assertIs(out.get("republished"), False, "the skipped re-delivery is reported honestly")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

A finished chat turn could keep showing "Finishing..." forever; now that label always clears, so a complete answer never looks unfinished. Anyone whose post-turn enrichment stalls notices, and the reporter's live case (a background lane dying on credentials that had just been rotated) is one of several ways to trigger it.

The label was driven by a single best-effort `message:enriched` realtime push and had nothing else that could ever clear it. Two changes make it self-limiting:

- **Client (the real fix).** The bookkeeping moves out of `ChatView` into `frontend/src/lib/enrichmentPending.js`, where every entry carries a 120s deadline. On expiry the entry is dropped and the conversation is refetched once, so any enrichment that did land still renders. This holds whatever the server is doing.
- **Server.** A finalize that arrives after the turn is already `done` now re-delivers `message:enriched` instead of returning `already_done` in silence. That is the counterpart of the CDX-12 terminal re-publish backstop, which the enrichment terminal never had.

The turn state machine is deliberately unchanged: a failing effect still holds the turn in `finalizing` and still force-dones at the retry budget.

**No `bench migrate`.** SPA rebuild required (`cd frontend && npm run build`).

<details>
<summary>Root cause</summary>

**The label.** Settlement publishes `run:end` with `enrichment_pending`, and `ChatView` kept the message id in a Set until `message:enriched` arrived (`ChatView.vue:4248`, `:7810`, `:7860` on develop). Nothing else cleared that Set: not `loadConversation`, not a reconnect resync, not any timeout. So every one of these left it up permanently on a reply that was already complete:

1. A finalize effect that keeps failing. `finalize.run_finalize` only flips `finalizing -> done` and publishes `message:enriched` once **every** required effect is done (`finalize.py:125` on develop). The usage effect retries by design when the gateway session row is missing or stale (`finalize.py:315`), which is exactly what a live credential change produces. The only retry driver is the `*/5` pump watchdog cron (`hooks.py:275` -> `pump.py:3240`), and the budget is 3 (`turn_state.py:68`), so the floor is roughly 15 minutes, and forever wherever that cron is not running.
2. The push itself lost to a socket blip, a hidden tab, or a client on another route. There is no replay on the socket.
3. `run_finalize` returning early on an already-`done` turn (`finalize.py:70` on develop) without republishing, so nothing could ever heal case 2.

**The stale-credential lane** is a separate defect and does not live in this repo. Written up in full in a comment on this PR, with the fleet-agent and openclaw file references, so it can be filed against the right repo. It is why the client-side bound is the primary fix here rather than a server-side retry tweak: the label must not depend on that being fixed.

</details>

<details>
<summary>Manual test plan</summary>

Rebuild the SPA first (`cd frontend && npm run build`), then hard-reload the chat page.

1. **Happy path is unchanged.** Send a message on a healthy tenant. The reply renders, "Finishing..." appears briefly under it, then disappears within a second or two once enrichment lands, and any late attachment / canvas / title pops in.
2. **The reported bug.** Stall enrichment so `message:enriched` never fires. Easiest reliable way: stop the openclaw container (`docker stop <tenant-container>`) right after a turn's answer finishes rendering, so the finalize usage poll cannot reach the gateway. Expected: "Finishing..." shows, and clears on its own within about two minutes. Before this change it stayed up indefinitely. Restart the container afterwards.
3. **Navigating away does not strand it.** Trigger case 2, switch to another conversation and back before the deadline. The label should still clear on schedule rather than surviving the reload.
4. **Server re-delivery.** For a turn that is already `done`, run `bench --site <site> execute jarvis.chat.finalize.run_finalize --args '["<run_id>"]'`. It should return `{"ok": true, "already_done": true, "republished": true}` and a chat tab open on that conversation should refresh the reply. This also works as a manual un-stick for any client caught by an older build.

</details>

## Pre-merge checklist

- [x] **CI is green** - the `tests` check on this PR passes (never merge on X)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
