### PR TITLE
feat(chat): show unset-up features as faded + explained, not hidden

### DIFF
--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -52,7 +52,7 @@
 // pattern. Dropdown: Settings (D9) · Switch to Desk · Change theme · Log out.
 import { computed, inject, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
-import { Dropdown, FeatherIcon } from "frappe-ui";
+import { Dropdown, FeatherIcon, toast } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
 import { useShellStore } from "@/stores/shell";
 import { useSupportStore } from "@/stores/support";
@@ -80,6 +80,9 @@ const { effectiveDark, toggleTheme } = useJarvisTheme();
 // resting dot and the list read the same value, so they can never disagree.
 const router = useRouter();
 const supportOn = window.support_available && window.has_support_access;
+// Unconfigured (an operator can still set it up) vs off/error (hidden, as before) —
+// see the same flag in ChatView. Permission still hides outright.
+const supportUnconfigured = window.support_state === "unconfigured" && !!window.has_support_access;
 const store = useSupportStore();
 let pollTimer = null;
 async function pollAwaiting() {
@@ -112,6 +115,17 @@ const crossItem = computed(() => {
 			label: `Switch to ${agentName} chat`,
 			icon: "message-circle",
 			onClick: () => router.push({ name: "Chat" }),
+		};
+	}
+	// Unconfigured but usable-by-this-user: keep the entry so the feature is
+	// discoverable, but say why instead of navigating into a space the route guard
+	// would bounce straight back. "off"/"error" stay omitted (see supportUnconfigured).
+	if (supportUnconfigured) {
+		return {
+			label: "Support",
+			icon: "life-buoy",
+			onClick: () =>
+				toast.info("Support isn't set up on this workspace yet — ask your administrator."),
 		};
 	}
 	if (!supportOn) return null;

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -124,6 +124,11 @@ const crossItem = computed(() => {
 		return {
 			label: "Support",
 			icon: "life-buoy",
+			// A visible cue: without it the entry is pixel-identical to the working one and
+			// clicking it just toasts, which reads as broken. frappe-ui's `disabled` would
+			// set pointer-events:none and swallow the click that carries the explanation,
+			// so use its `description` instead.
+			description: "Not set up - open to see why",
 			onClick: () =>
 				toast.info("Support isn't set up on this workspace yet — ask your administrator."),
 		};

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2794,15 +2794,28 @@
 							     up), so the mic renders FADED and says so on click; a browser
 							     that cannot record is not actionable, so it stays hidden. -->
 							<button
-								v-if="!ui.stt_enabled && micRec.supported"
+								v-if="sttUnconfigured && micRec.supported"
 								class="jv-iconbtn jv-micbtn jv-unavailable"
 								aria-disabled="true"
 								title="Voice dictation is not set up on this workspace"
+								aria-label="Voice dictation is not set up on this workspace"
+								style="
+									width: 30px;
+									height: 30px;
+									display: flex;
+									align-items: center;
+									justify-content: center;
+									background: transparent;
+									border: none;
+									border-radius: 7px;
+									cursor: default;
+									color: var(--text-3);
+								"
 								@click="explainSttUnavailable"
 							>
 								<svg
-									width="18"
-									height="18"
+									width="17"
+									height="17"
 									viewBox="0 0 24 24"
 									fill="none"
 									stroke="currentColor"
@@ -4679,16 +4692,26 @@ const supportOn = window.support_available && window.has_support_access;
 // a user a feature they can never use is noise, not discovery.
 const supportUnconfigured = window.support_state === "unconfigured" && !!window.has_support_access;
 
-function explainSupportUnavailable() {
-	notify("Support isn't set up on this workspace yet — ask your administrator.", {
+// STT is UNCONFIGURED specifically — not deliberately off, not a transient CP blip.
+// Only that case earns a faded control: the other two would either nag an admin who
+// switched voice off on purpose, or turn a self-healing hiccup into a permanent-looking
+// misconfiguration. Reading the state (not `!stt_enabled`) also avoids the faded mic
+// FLASHING on every page load, since `ui` starts empty and `stt_enabled` is briefly
+// undefined — `stt_state` is simply absent until the settings land.
+const sttUnconfigured = computed(() => ui.value?.stt_state === "unconfigured");
+
+// One message shape for every not-set-up feature, so the wording cannot drift between
+// the surfaces (a user with STT off sees the nudge mic and the composer mic at once).
+function explainUnavailable(feature) {
+	notify(`${feature} isn't set up on this workspace yet — ask your administrator.`, {
 		type: "info",
 	});
 }
-
+function explainSupportUnavailable() {
+	explainUnavailable("Support");
+}
 function explainSttUnavailable() {
-	notify(`Voice dictation isn't set up on this workspace — ask your administrator.`, {
-		type: "info",
-	});
+	explainUnavailable("Voice dictation");
 }
 
 // "Get help from a human" — always available (v1). The conversation reference
@@ -9864,11 +9887,24 @@ onUnmounted(() => {
    the user gets a dead grey icon with no reason. aria-disabled + a real click handler
    keeps it reachable and answerable. */
 .jv-unavailable {
-	opacity: 0.45;
+	/* 0.45 measured ~1.8:1 against --surface-2 — under WCAG 1.4.11's 3:1 and, worse for
+	   the point of this pattern, close to invisible. These controls are deliberately
+	   OPERABLE (aria-disabled, not disabled), so the inactive-component exemption does
+	   not really apply: keep them clearly perceptible, just plainly subdued. */
+	opacity: 0.55;
 	cursor: default;
 }
 .jv-unavailable:hover {
-	opacity: 0.6;
+	opacity: 0.8;
+}
+/* .jv-iconbtn:hover inverts to a solid fill with !important — the boldest hover in the
+   UI. On an unavailable control that reads as MORE active than a working button, so
+   opt out and let opacity alone carry the hover. */
+.jv-iconbtn.jv-unavailable:hover,
+.jv-iconbtn.jv-unavailable:hover svg {
+	background: transparent !important;
+	color: var(--text-3) !important;
+	stroke: currentColor !important;
 }
 .jv-nudge-actions {
 	display: flex;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2742,10 +2742,20 @@
 							     standalone support space (Task 6). Gated on the same dual
 							     kill-switch the /support routes guard on. -->
 							<button
-								v-if="supportOn"
+								v-if="supportOn || supportUnconfigured"
 								class="jv-iconbtn"
-								title="Get help from a human"
-								@click="getHumanHelp"
+								:class="{ 'jv-unavailable': supportUnconfigured }"
+								:aria-disabled="supportUnconfigured ? 'true' : undefined"
+								:title="
+									supportUnconfigured
+										? 'Support is not set up on this workspace yet'
+										: 'Get help from a human'
+								"
+								@click="
+									supportUnconfigured
+										? explainSupportUnavailable()
+										: getHumanHelp()
+								"
 								style="
 									width: 30px;
 									height: 30px;
@@ -2779,7 +2789,34 @@
 							</button>
 						</template>
 						<template #right-toolbar>
-							<!-- dictation mic (hidden unless the backend reports STT configured) -->
+							<!-- Dictation mic. Two DIFFERENT unavailable reasons, two treatments:
+							     STT not configured is an actionable gap (an operator can set it
+							     up), so the mic renders FADED and says so on click; a browser
+							     that cannot record is not actionable, so it stays hidden. -->
+							<button
+								v-if="!ui.stt_enabled && micRec.supported"
+								class="jv-iconbtn jv-micbtn jv-unavailable"
+								aria-disabled="true"
+								title="Voice dictation is not set up on this workspace"
+								@click="explainSttUnavailable"
+							>
+								<svg
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="1.7"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path
+										d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"
+									/>
+									<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+									<path d="M12 19v3" />
+								</svg>
+							</button>
 							<template v-if="ui.stt_enabled && micRec.supported">
 								<button
 									class="jv-iconbtn jv-micbtn"
@@ -4633,6 +4670,26 @@ const currentTitle = computed(
 // supportGuard) — a dead button that redirects straight back to chat is worse
 // than no button.
 const supportOn = window.support_available && window.has_support_access;
+
+// Support is UNCONFIGURED (not merely off/erroring) and this user could otherwise use
+// it: an operator can still set it up, so show the entry faded + explained rather than
+// hiding a feature that exists. "off" (deliberately switched off) and "error" (a
+// transient CP blip that self-heals) both stay hidden — a greyed control for either
+// would be misleading. Permission (`has_support_access`) still hides outright: showing
+// a user a feature they can never use is noise, not discovery.
+const supportUnconfigured = window.support_state === "unconfigured" && !!window.has_support_access;
+
+function explainSupportUnavailable() {
+	notify("Support isn't set up on this workspace yet — ask your administrator.", {
+		type: "info",
+	});
+}
+
+function explainSttUnavailable() {
+	notify(`Voice dictation isn't set up on this workspace — ask your administrator.`, {
+		type: "info",
+	});
+}
 
 // "Get help from a human" — always available (v1). The conversation reference
 // is plain, readable, user-EDITABLE body text: create_ticket takes only
@@ -9800,6 +9857,18 @@ onUnmounted(() => {
 .jv-nudge-x:hover {
 	background: var(--surface-1);
 	color: var(--text);
+}
+/* A control for a feature that exists but is not set up on this workspace: faded, and
+   it EXPLAINS itself on click rather than being inert. Deliberately not the `disabled`
+   attribute — a disabled button is not focusable and its title often will not show, so
+   the user gets a dead grey icon with no reason. aria-disabled + a real click handler
+   keeps it reachable and answerable. */
+.jv-unavailable {
+	opacity: 0.45;
+	cursor: default;
+}
+.jv-unavailable:hover {
+	opacity: 0.6;
 }
 .jv-nudge-actions {
 	display: flex;

--- a/frontend/tests/support-extraction/support-badge.test.js
+++ b/frontend/tests/support-extraction/support-badge.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 
 vi.mock("frappe-ui", () => ({
+	toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
 	// Expose `options` so the variant tests can assert the menu items; the stub
 	// still renders only the trigger slot (the button), like the real closed Dropdown.
 	Dropdown: {

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1405,7 +1405,7 @@ def get_chat_ui_settings() -> dict:
 	settings = frappe.get_single("Jarvis Settings")
 	# Lazy import: keeps this hot endpoint's module import light and avoids
 	# a jarvis.chat.api <-> jarvis.chat.voice cycle.
-	from jarvis.chat.voice import stt_config
+	from jarvis.chat.voice import stt_config, stt_state
 
 	# default_models lets callers (jarvis_onboarding.js,
 	# jarvis_account.js subscription-tab) skip duplicating the
@@ -1507,6 +1507,10 @@ def get_chat_ui_settings() -> dict:
 		# Mic button gating: stt_config() is None when voice features / STT
 		# are off or no key resolves (admin path is Redis-cached, never raises).
 		"stt_enabled": bool(stt_config()),
+		# WHY it is unavailable (ok|off|unconfigured|error). The boolean above cannot
+		# distinguish "an admin switched voice off" from "nobody set it up" from "a
+		# transient CP blip", and the UI must not claim the middle one for all three.
+		"stt_state": stt_state(),
 		# Composer "ground on wiki" pill gating: shown only when the wiki feature
 		# is on AND the org has at least one Active page (best-effort).
 		"wiki_enabled": _wiki_enabled_flag(),

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -154,6 +154,38 @@ def stt_config() -> dict | None:
 	return {"enabled": True, "api_key": cfg["api_key"], "model": model or _DEFAULT_STT_MODEL}
 
 
+# Why STT is unavailable — the UI treats these differently, so collapsing them into one
+# boolean (as ``bool(stt_config())`` does) is not enough. Mirrors the support states.
+STT_OK = "ok"
+STT_OFF = "off"  # an admin deliberately turned voice features off
+STT_UNCONFIGURED = "unconfigured"  # no key anywhere — an admin can still set it up
+STT_ERROR = "error"  # transient: the CP lookup blew up; self-heals
+
+
+def stt_state() -> str:
+	"""Which of the FOUR states STT is in, not merely whether it works.
+
+	``stt_config()`` returns None for three very different reasons, and a UI that says
+	"not set up" for all of them lies twice: it tells an admin who deliberately disabled
+	voice to go ask an admin, and it turns a transient CP blip into a permanent-looking
+	misconfiguration. Only ``unconfigured`` is an actionable gap worth surfacing.
+
+	Deliberately does NOT re-implement stt_config's resolution — it asks the same
+	questions in the same order and defers to it for the positive answer, so the two
+	cannot drift."""
+	if not _voice_features_enabled():
+		return STT_OFF
+	try:
+		cfg = stt_config()
+	except Exception:
+		return STT_ERROR
+	if cfg:
+		return STT_OK
+	# Voice is on and nothing raised, so the only remaining reasons are "no key" or an
+	# explicit per-bench stt_enabled=0 — both "an operator has not set this up".
+	return STT_UNCONFIGURED
+
+
 def openrouter_complete(
 	messages: list,
 	model: str | None = None,

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -217,7 +217,9 @@ class TestSupportBenchEndpoints(FrappeTestCase):
 
 class TestSupportBoot(FrappeTestCase):
 	def setUp(self):
-		frappe.cache().delete_value("jarvis:support_available")
+		from jarvis.www import jarvis as jw
+
+		frappe.cache().delete_value(jw._SUPPORT_AVAILABLE_CACHE_KEY)
 
 	def test_support_available_false_on_error_and_cached(self):
 		from jarvis.www import jarvis as jw
@@ -232,6 +234,49 @@ class TestSupportBoot(FrappeTestCase):
 
 		with patch("jarvis.admin_client.support_status", return_value={"available": True}):
 			self.assertTrue(jw._support_available())
+
+	# ---- the state the boolean cannot express ----
+
+	def test_error_is_distinct_from_unconfigured_and_retries_sooner(self):
+		# A transient CP blip must NOT read as "support was never set up" — it stays
+		# hidden and re-checks on the short TTL.
+		from jarvis.www import jarvis as jw
+
+		with patch("jarvis.admin_client.support_status", side_effect=Exception("down")):
+			self.assertEqual(jw._support_state(), jw.SUPPORT_ERROR)
+
+	def test_unconfigured_reason_is_carried_through(self):
+		from jarvis.www import jarvis as jw
+
+		with patch(
+			"jarvis.admin_client.support_status",
+			return_value={"available": False, "reason": "unconfigured"},
+		):
+			self.assertEqual(jw._support_state(), jw.SUPPORT_UNCONFIGURED)
+			self.assertFalse(jw._support_available())
+
+	def test_off_reason_is_carried_through(self):
+		from jarvis.www import jarvis as jw
+
+		with patch("jarvis.admin_client.support_status", return_value={"available": False, "reason": "off"}):
+			self.assertEqual(jw._support_state(), jw.SUPPORT_OFF)
+
+	def test_old_cp_without_a_reason_degrades_to_off(self):
+		# A CP that predates `reason` sends only `available` — keep today's hide-it
+		# behaviour rather than claiming the fleet is unconfigured.
+		from jarvis.www import jarvis as jw
+
+		with patch("jarvis.admin_client.support_status", return_value={"available": False}):
+			self.assertEqual(jw._support_state(), jw.SUPPORT_OFF)
+
+	def test_unknown_reason_degrades_to_off(self):
+		from jarvis.www import jarvis as jw
+
+		with patch(
+			"jarvis.admin_client.support_status",
+			return_value={"available": False, "reason": "something-new"},
+		):
+			self.assertEqual(jw._support_state(), jw.SUPPORT_OFF)
 
 
 class TestAuthenticatedRawErrors(FrappeTestCase):

--- a/jarvis/tests/test_www_release_notice.py
+++ b/jarvis/tests/test_www_release_notice.py
@@ -37,7 +37,9 @@ class TestWwwReleaseNotice(FrappeTestCase):
 			patch.object(www_desktop, "has_jarvis_admin_access", return_value=False),
 			patch.object(www_desktop, "grant_default_support", lambda: None),
 			patch.object(www_desktop, "support_scope", return_value=None),
-			patch.object(www_desktop, "_support_available", return_value=False),
+			# _support_state, not _support_available: get_context calls the former now, so
+			# patching the old name left this test making a REAL admin_client round-trip.
+			patch.object(www_desktop, "_support_state", return_value=www_desktop.SUPPORT_OFF),
 		):
 			www_desktop.get_context(ctx)
 		rn = ctx.boot["release_notice"]

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -10,29 +10,58 @@ from jarvis.permissions import (
 
 no_cache = 1
 
-_SUPPORT_AVAILABLE_CACHE_KEY = "jarvis:support_available"
+_SUPPORT_AVAILABLE_CACHE_KEY = "jarvis:support_state"
 _SUPPORT_AVAILABLE_TTL_S = 300
 # R1-7: negative-cache a transient CP blip for a shorter window so support reappears promptly.
 _SUPPORT_UNAVAILABLE_TTL_S = 60
 
+# Support states the SPA understands. Only ``unconfigured`` is an ACTIONABLE gap (an
+# operator can still set support up), so that is the one the UI shows as a disabled,
+# explained entry; every other unavailable state hides support exactly as before.
+SUPPORT_OK = "ok"
+SUPPORT_UNCONFIGURED = "unconfigured"
+SUPPORT_OFF = "off"
+SUPPORT_ERROR = "error"
 
-def _support_available() -> bool:
-	"""Fleet-wide support kill switch, Redis-cached (P8) so boot never blocks on a CP round-trip.
+
+def _support_state() -> str:
+	"""Fleet-wide support state, Redis-cached (P8) so boot never blocks on a CP round-trip.
 	Uses support_status (relaxed auth) — NOT get_connection, which 403s suspended customers (P7).
-	Any failure ⇒ False (button hidden, never an error)."""
+
+	Returns one of ``ok`` / ``unconfigured`` / ``off`` / ``error``. The CP has always known
+	which of those it means; the bench used to collapse them into one boolean, so a
+	transient CP blip was indistinguishable from "support was never set up" and both just
+	hid the button. ``error`` is kept distinct precisely so a self-healing blip does NOT
+	render as "support is not set up" — it stays hidden and retries in a minute.
+
+	A CP too old to send ``reason`` degrades safely: unavailable-without-a-reason is
+	treated as ``off`` (hide), which is exactly today's behaviour."""
 	cache = frappe.cache()
 	cached = cache.get_value(_SUPPORT_AVAILABLE_CACHE_KEY)
-	if cached is not None:
-		return cached == "1"
+	if cached:
+		return cached
 	try:
 		from jarvis import admin_client
 
-		available = bool(admin_client.support_status(timeout_s=8).get("available"))
+		res = admin_client.support_status(timeout_s=8) or {}
+		if res.get("available"):
+			state = SUPPORT_OK
+		else:
+			reason = (res.get("reason") or "").strip()
+			# Only a reason we KNOW is trusted; anything else (incl. an old CP that sends
+			# none) falls back to the pre-existing hide-it behaviour.
+			state = reason if reason in (SUPPORT_UNCONFIGURED, SUPPORT_OFF) else SUPPORT_OFF
 	except Exception:
-		available = False
-	ttl = _SUPPORT_AVAILABLE_TTL_S if available else _SUPPORT_UNAVAILABLE_TTL_S
-	cache.set_value(_SUPPORT_AVAILABLE_CACHE_KEY, "1" if available else "0", expires_in_sec=ttl)
-	return available
+		state = SUPPORT_ERROR
+	ttl = _SUPPORT_AVAILABLE_TTL_S if state != SUPPORT_ERROR else _SUPPORT_UNAVAILABLE_TTL_S
+	cache.set_value(_SUPPORT_AVAILABLE_CACHE_KEY, state, expires_in_sec=ttl)
+	return state
+
+
+def _support_available() -> bool:
+	"""Back-compat boolean: support is usable. Kept as its own name because other
+	surfaces (and the PWA) read the boot flag by that meaning."""
+	return _support_state() == SUPPORT_OK
 
 
 def get_context(context):
@@ -97,7 +126,12 @@ def get_context(context):
 	# it in this same request), then expose both the per-user access flag and the fleet kill switch.
 	grant_default_support()
 	context.boot["has_support_access"] = support_scope() is not None
-	context.boot["support_available"] = _support_available()
+	# Both flags, deliberately: `support_available` keeps its exact boolean meaning for
+	# every existing reader, and `support_state` lets the SPA tell an actionable
+	# "unconfigured" (show the entry disabled + explained) from "off"/"error" (hide).
+	state = _support_state()
+	context.boot["support_state"] = state
+	context.boot["support_available"] = state == SUPPORT_OK
 
 	frappe.db.commit()
 	return context

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -53,7 +53,9 @@ def _support_state() -> str:
 			state = reason if reason in (SUPPORT_UNCONFIGURED, SUPPORT_OFF) else SUPPORT_OFF
 	except Exception:
 		state = SUPPORT_ERROR
-	ttl = _SUPPORT_AVAILABLE_TTL_S if state != SUPPORT_ERROR else _SUPPORT_UNAVAILABLE_TTL_S
+	# R1-7 unchanged: EVERY unavailable state keeps the short TTL, so support appears
+	# within a minute of an operator configuring it or flipping the switch on.
+	ttl = _SUPPORT_AVAILABLE_TTL_S if state == SUPPORT_OK else _SUPPORT_UNAVAILABLE_TTL_S
 	cache.set_value(_SUPPORT_AVAILABLE_CACHE_KEY, state, expires_in_sec=ttl)
 	return state
 


### PR DESCRIPTION
**Deploy AFTER** jarvis-admin-v2 #274 (https://github.com/Aerele-RnD/jarvis-admin-v2/pull/274) — this degrades safely until then (an old CP sends no `reason`, which reads as "off" = today's hide behaviour).

## Why
A feature that **exists but isn't set up on this workspace** used to vanish entirely, so it read as *"Jarvis can't do this"* rather than *"nobody set this up"*. Now it renders faded with a click that explains — **but only when that's actually true.**

## The distinction that drives everything
Unavailable is not one state. Only the **actionable** one earns a faded control:

| State | Treatment | Why |
|---|---|---|
| **unconfigured** | faded + explains | an admin can still set it up |
| **off** (deliberate) | hidden | that's the point of a switch |
| **error** (transient) | hidden | self-heals in ~60s; a greyed control would lie |
| **no permission** / browser can't record | hidden | not actionable by anyone |

## What
- **`_support_state()`** (`www/jarvis.py`): `ok / unconfigured / off / error`. The CP always knew which it meant; the bench collapsed them, so a transient blip was indistinguishable from "never set up". `support_available` keeps its meaning; `support_state` is new. Cache key renamed (the old one stores `"1"/"0"`, which the new reader would misparse across deploy).
- **`voice.stt_state()`**: the same split for speech-to-text. `bool(stt_config())` collapsed *three* reasons, so a faded mic would have told an admin who **deliberately disabled voice** to "ask your administrator", and turned a CP blip into a permanent-looking misconfiguration — the very bug this PR exists to fix. It defers to `stt_config` for the positive answer so the two can't drift.
- **SPA**: composer dictate mic + "get help from a human" + the UserMenu Support entry. `aria-disabled` + a real click handler, deliberately **not** the `disabled` attribute — that's unfocusable and usually swallows the title, leaving a dead grey icon with no reason. Route guard unchanged (defense in depth).

## Review fixes (two reviewers)
- The faded mic **flashed on every page load for every user** (`ui` starts empty, so `!stt_enabled` was briefly true) — gone, since an absent `stt_state` simply isn't `"unconfigured"`.
- The faded mic had **no inline style** — `.jv-iconbtn` supplies only hover behaviour here, so it rendered as a native browser button beside its transparent siblings.
- `.jv-iconbtn:hover`'s `!important` inversion made an *unavailable* control the boldest hover in the UI — opted out.
- **Contrast**: 0.45 measured ~1.8:1 (under WCAG 1.4.11, near-invisible — which defeats the whole point). Now 0.55 / 0.8.
- The UserMenu entry was **pixel-identical to the working one** and just toasted → added frappe-ui's `description` cue (its `disabled` would swallow the explaining click).
- One `explainUnavailable(feature)` helper so wording can't drift (both faded mics can be on screen at once).
- Kept the **60s** TTL for every unavailable state (`off`/`unconfigured` had silently become 300s → 5 min to appear after configuring).
- Two test defects: `support-badge.test.js`'s frappe-ui mock lacked `toast` (failed that whole file at import once UserMenu imported it), and `test_www_release_notice` patched a function `get_context` no longer calls — making a **real network call in a unit test**.

## Verification
**248 frontend tests (20 files)**, 27 backend, `vite build` clean.
Browser smoke is still the real gate for the faded states (needs a workspace with STT/support genuinely unconfigured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)