### PR TITLE
fix(onboarding): confirming screen gets a spinner, not a flash

### DIFF
--- a/design.md
+++ b/design.md
@@ -146,7 +146,13 @@ this is the mapping (use it when porting, never when writing new UI):
 > | Illustration | Renders during | Subject |
 > |---|---|---|
 > | `SetupNeuralNet` | the long provisioning/readiness wait | ERP modules connecting to the mark |
-> | `PaymentConfirmingArt` | the payment-confirming wait only | banknotes arriving at the mark along a rail |
+> | `PaymentConfirmingArt` | not currently rendered anywhere; see the note below | banknotes arriving at the mark along a rail |
+>
+> jarvis#728 measured the bench's payment-confirming screen against a real payment: the wait
+> behind it is a single reconcile round trip, not a poll, so it resolves well under the
+> tens-of-seconds bar this carve-out sets and now uses JvSpinner instead. The component, its
+> tokens and this table row are kept rather than deleted: retiring or repurposing the asset for
+> a screen whose wait actually earns it is a design-owner call, not a bugfix-PR call.
 >
 > Rules that come with the second one (product owner authorized it on 2026-08-07, overruling
 > the previous single-illustration wording):

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -68,8 +68,6 @@ vi.mock("@/lib/errorReporter", () => ({ report: vi.fn() }));
 
 // Heavy / canvas children the connect step would otherwise mount.
 vi.mock("@/onboarding/SetupNeuralNet.vue", () => ({ default: { template: "<div/>" } }));
-// Canvas illustration: jsdom has no 2d context, and neither spec is about the art.
-vi.mock("@/onboarding/PaymentConfirmingArt.vue", () => ({ default: { template: "<div/>" } }));
 vi.mock("@/onboarding/TourIntro.vue", () => ({ default: { template: "<div/>" } }));
 
 // The editor is stubbed: it exposes exactly the seam the host reads (save/canStart/
@@ -777,6 +775,11 @@ describe("the payment-confirming wait", () => {
 		// Mid-reconcile: the round trip has not answered yet.
 		expect(w.vm.showConfirming).toBe(true);
 		expect(w.vm.state.step).toBe("pay");
+		// jarvis#728: the confirming screen is a single round trip, not a
+		// tens-of-seconds wait, so it gets the short-wait spinner, not the
+		// PaymentConfirmingArt canvas illustration (which no longer mounts here).
+		expect(w.find('[aria-label="Loading"]').exists()).toBe(true);
+		expect(w.find("canvas").exists()).toBe(false);
 
 		release({
 			status: 200,

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -725,12 +725,19 @@
 							</template>
 							<!-- Confirming: the customer paid on the admin-hosted page and came
 								 back, and we are asking the control plane whether it landed. Money
-								 has left them and no verdict exists yet, so this is the one screen
-								 the payment illustration belongs on (design.md §2.2). It replaces
-								 the recovery card, whose disabled "Working…" button is what a
-								 customer used to stare at in the seconds right after paying. -->
+								 has left them and no verdict exists yet.
+								 jarvis#728: this used to render PaymentConfirmingArt here, but the
+								 round trip behind this screen is a single one-shot reconcile
+								 (usePaymentFlow's hydrate/reconcileAfterFailure), never a poll -
+								 it resolves in well under a second on the common path and hands
+								 off to the recovery card on the slow one, so the screen can never
+								 reliably reach the "tens of seconds" bar design.md §2.2 sets for
+								 using an illustration instead of JvSpinner. A short, honest wait
+								 gets the short-wait treatment; a flashed or half-drawn frame is
+								 worse than a plain spinner. PaymentConfirmingArt.vue is unchanged
+								 and kept for a screen whose wait actually earns it. -->
 							<template v-else-if="showConfirming">
-								<div class="ob-body">
+								<div class="ob-body ob-body--center">
 									<div class="ob-head">
 										<h1 role="status">Confirming your payment</h1>
 										<p>
@@ -738,14 +745,11 @@
 											that it came through.
 										</p>
 									</div>
-									<!-- min-height (not h-full): the canvas fills via absolute +
-										 inset-0 and percentage heights don't resolve against a
-										 min-height parent. Same constraint as SetupNeuralNet. -->
-									<div class="relative mt-2 min-h-[300px] flex-1">
-										<PaymentConfirmingArt :dark="dark" />
+									<div class="mt-2.5 flex justify-center">
+										<JvSpinner :size="56" />
 									</div>
 									<p
-										class="mx-auto max-w-[420px] text-center text-p-sm text-ink-gray-5"
+										class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
 									>
 										This usually takes a few seconds. Please don't close this
 										page or pay again.
@@ -1536,7 +1540,6 @@ import JarvisMark from "@/components/JarvisMark.vue";
 import Banner from "@/components/Banner.vue";
 import TourIntro from "@/onboarding/TourIntro.vue";
 import SetupNeuralNet from "@/onboarding/SetupNeuralNet.vue";
-import PaymentConfirmingArt from "@/onboarding/PaymentConfirmingArt.vue";
 import cashfreeLogo from "@/assets/cashfree.png";
 import {
 	STEPS_MANAGED,


### PR DESCRIPTION
Fixes #728

## Summary

The payment-confirming screen showed a banknote illustration for however long a single
reconcile check took, which on a real payment can be well under a second, so the picture
either flashed or never painted a frame. It now shows the same JvSpinner every other
short in-flight state in this flow already uses.

**What changed**
- `OnboardingView.vue`: confirming block renders `JvSpinner` instead of
  `PaymentConfirmingArt` (import removed, headline and copy unchanged).
- `OnboardingView.connect.spec.js`: drops the now-unused illustration mock, asserts the
  spinner renders and no canvas mounts.
- `design.md`: illustration table now says `PaymentConfirmingArt` renders nowhere, with
  a pointer to this issue.

**Why a spinner, not a shorter animation or a minimum display time.** The confirming
screen is a single one-shot reconcile call, never a poll. Fast and slow payment paths
both end the screen after the same short round trip; a slow webhook just routes the
customer to the pending recovery card sooner. A minimum display time was rejected: on
the slow path it would delay an actionable card just to decorate a wait. Numbers below.

**Admin-plane checkout** (`jarvis_admin_v2`, not edited): its illustration is already
gated on a genuine polling signal with a live elapsed-time counter, so it does not share
this bug.

<details><summary>Measured / code-derived timing</summary>

**Redirect-return path** (`?pay=done|failed|pending`, the reported case): `onMounted`
sets `confirmingReturn=true`, then awaits `prefillAccount()` (one local call,
`get_account_defaults`) and `reconcileMidFlightSignup()` to `hydrate()` to one call to
`get_onboarding_state`, a PASSIVE read of admin's own subscription row that never asks
the gateway (`admin_client.get_signup_payment_state`). A paid answer adds one more local
call, `isReadyForChat`. So 2-3 sequential round trips, each bounded by the client's own
`fetchDeadlineMs = 30_000` abort, typically tens to a few hundred ms in practice.

**bfcache / tab-refocus path**: `returnFromCheckout` to `reconcileAfterFailure` to one
call to `check_signup_payment_status`, the ACTIVE check that does ask the gateway. Same
30s client ceiling, realistically 1-5s.

**Both paths are one-shot.** `whileConfirmingReturn` wraps exactly one `run()` and
clears the flag in its `finally`, so the confirming screen never becomes a poll loop no
matter which branch resolves. A slow webhook does not lengthen the illustration's
window, it just means `get_onboarding_state` answers "still pending" and the screen
hands off to the recovery card (manual "Check status") after the same short call.

**The animation's own numbers** (`PaymentConfirmingArt.vue`): `LOOP_SECONDS = 2.8`,
`STAGGER_SECONDS = 0.6`. At 200ms elapsed the first note is at progress 0.071, alpha
around 0.5, still sitting at the faded rail end; the first core pulse does not happen
until a note completes its loop near 2.8s. A confirming window under about 1s (the
common case above) shows dim, barely visible notes at best; under about 200ms,
effectively nothing.

**design.md 2.2** already draws the line this bug crosses: illustrations are for waits
"measured in tens of seconds", short waits get `JvSpinner`. This screen structurally
cannot reach that bar, so the fix brings the code into line with the doc's own rule.

</details>

## Pre-merge checklist

- [ ] CI is green (hosted Actions runs on this repo; check the `tests` job)
- [x] Branch is up to date with `develop` (branched fresh from `upstream/develop`)
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
