### PR TITLE
feat: retire the collapsed-capability pattern (wiki pill + the last two STT recorders)

### DIFF
--- a/frontend/src/components/personalise/ChatComposer.vue
+++ b/frontend/src/components/personalise/ChatComposer.vue
@@ -82,6 +82,23 @@
 				<div class="flex flex-wrap items-center gap-1.5">
 					<!-- voice first + prominent (design-language §7) -->
 					<VoiceRecorder v-if="sttEnabled" compact @transcript="onTranscript" />
+					<!-- not set up is an ACTIONABLE gap: fade + say so instead of vanishing
+					     (deliberately off / a transient error stay hidden) -->
+					<button
+						v-else-if="sttUnconfigured"
+						class="flex size-7 items-center justify-center rounded text-ink-gray-4 opacity-55"
+						style="cursor: default"
+						aria-disabled="true"
+						title="Voice input is not set up on this workspace"
+						aria-label="Voice input is not set up on this workspace"
+						@click="
+							toast.info(
+								`Voice input isn't set up on this workspace yet — ask your administrator.`
+							)
+						"
+					>
+						<FeatherIcon name="mic" class="size-4" />
+					</button>
 					<FileUploader
 						:upload-args="{ private: 1 }"
 						@success="onUpload"
@@ -152,6 +169,9 @@ import { agentName } from "@/branding";
 const props = defineProps({
 	// STT availability (pass caps.stt_enabled) - hides the recorder when off.
 	sttEnabled: { type: Boolean, default: false },
+	// STT is unconfigured specifically (pass caps.stt_state === "unconfigured") —
+	// renders the recorder faded + explained rather than hiding it.
+	sttUnconfigured: { type: Boolean, default: false },
 	// the selected question ({name, question, …}) or null for free capture.
 	question: { type: Object, default: null },
 	// true while the parent's answer/save call is in flight (Send loading).

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -153,6 +153,24 @@
 			<div class="mt-2 flex items-center justify-between gap-2">
 				<div class="flex items-center gap-1.5">
 					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
+					<!-- Voice not set up is an ACTIONABLE gap, so show it faded and say so
+					     rather than vanishing; deliberately off / a transient error stay
+					     hidden (see voice.stt_state). -->
+					<button
+						v-else-if="caps.stt_state === 'unconfigured'"
+						class="flex size-7 items-center justify-center rounded text-ink-gray-4 opacity-55"
+						style="cursor: default"
+						aria-disabled="true"
+						title="Voice input is not set up on this workspace"
+						aria-label="Voice input is not set up on this workspace"
+						@click="
+							toast.info(
+								`Voice input isn't set up on this workspace yet — ask your administrator.`
+							)
+						"
+					>
+						<FeatherIcon name="mic" class="size-4" />
+					</button>
 					<!-- explicit data-mode: Auto leaves it to the opening interview
 					     (the agent asks before the first build); Static bakes the
 					     numbers in (one-time report); Live declares view-time sources.

--- a/frontend/src/pages/skills/PersonaliseTab.vue
+++ b/frontend/src/pages/skills/PersonaliseTab.vue
@@ -265,6 +265,7 @@
 			<ChatComposer
 				ref="composer"
 				:stt-enabled="!!caps.stt_enabled"
+				:stt-unconfigured="caps.stt_state === 'unconfigured'"
 				:question="selected"
 				:saving="submitting"
 				@submit="onSubmit"

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2718,6 +2718,51 @@
 									/>
 								</svg>
 							</button>
+							<!-- Empty wiki is the one unavailable state the USER can fix (write a
+							     page, or answer the "worth remembering?" nudge), so it fades with
+							     a self-serve hint instead of "ask your administrator". Feature
+							     switched off / error stay hidden. -->
+							<button
+								v-if="wikiEmpty"
+								class="jv-iconbtn jv-unavailable"
+								aria-disabled="true"
+								title="No wiki pages yet"
+								aria-label="No wiki pages yet"
+								style="
+									width: 30px;
+									height: 30px;
+									display: flex;
+									align-items: center;
+									justify-content: center;
+									background: transparent;
+									border: none;
+									border-radius: 7px;
+									cursor: default;
+									color: var(--text-3);
+								"
+								@click="
+									notify(
+										`No wiki pages yet — I'll ask when something's worth remembering, or add one in Wiki.`,
+										{ type: 'info' }
+									)
+								"
+							>
+								<svg
+									width="16"
+									height="16"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="1.7"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+									<path
+										d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"
+									/>
+								</svg>
+							</button>
 							<button
 								v-if="ui.wiki_enabled"
 								class="jv-iconbtn"
@@ -4709,6 +4754,9 @@ const supportUnconfigured = window.support_state === "unconfigured" && !!window.
 // FLASHING on every page load, since `ui` starts empty and `stt_enabled` is briefly
 // undefined — `stt_state` is simply absent until the settings land.
 const sttUnconfigured = computed(() => ui.value?.stt_state === "unconfigured");
+// The wiki feature is ON but nobody has written a page yet — the one unavailable
+// state the user can resolve themselves, so it earns a faded pill + a nudge.
+const wikiEmpty = computed(() => ui.value?.wiki_state === "empty");
 
 // One message shape for every not-set-up feature, so the wording cannot drift between
 // the surfaces (a user with STT off sees the nudge mic and the composer mic at once).

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1514,6 +1514,9 @@ def get_chat_ui_settings() -> dict:
 		# Composer "ground on wiki" pill gating: shown only when the wiki feature
 		# is on AND the org has at least one Active page (best-effort).
 		"wiki_enabled": _wiki_enabled_flag(),
+		# WHY it is unavailable (ok|off|empty|error) — `empty` is user-fixable, so the
+		# pill fades with a nudge instead of disappearing. See _wiki_state_flag.
+		"wiki_state": _wiki_state_flag(),
 		# Persona pill gating: a real kill switch (Jarvis Settings.persona_enabled,
 		# default on), read here AND in _persona_clause so flipping it off both hides
 		# the pill and stops the clause - never a client-only half-switch (N7).
@@ -1582,12 +1585,25 @@ def _wiki_enabled_flag() -> bool:
 	feature is on AND the org actually has at least one Active page (so the pill
 	can never be a guaranteed-silent no-op on an empty wiki). Best-effort — a
 	bootstrap must never fail on this."""
+	return _wiki_state_flag() == "ok"
+
+
+def _wiki_state_flag() -> str:
+	"""WHY the wiki pill is unavailable: ok | off | empty | error.
+
+	The boolean above collapses two very different things. ``off`` is an operator
+	kill switch (hide it — that is the point of a switch), but ``empty`` just means
+	nobody has written a page yet, and that is fixable BY THE USER — so the pill can
+	be shown faded with a "no pages yet" nudge instead of vanishing. Best-effort: a
+	bootstrap must never fail on this, and an error hides exactly as before."""
 	try:
 		from jarvis.chat.wiki import _has_active_pages, wiki_enabled
 
-		return bool(wiki_enabled() and _has_active_pages())
+		if not wiki_enabled():
+			return "off"
+		return "ok" if _has_active_pages() else "empty"
 	except Exception:
-		return False
+		return "error"
 
 
 def _current_user_persona() -> str | None:

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -166,12 +166,17 @@ def get_dashboards_caps() -> dict:
 	"""Single gating probe for the Dashboards page: which scopes the caller
 	may create in, which roles they may target, and the size caps."""
 	stt_enabled = False
+	# WHY it is off (ok|off|unconfigured|error): only `unconfigured` is an actionable
+	# gap worth showing the user as a faded recorder; the rest stay hidden.
+	stt_state = "error"
 	try:
 		from jarvis.chat import voice
 
 		stt_enabled = bool(voice.stt_config())
+		stt_state = voice.stt_state()
 	except Exception:
 		stt_enabled = False
+		stt_state = "error"
 	return {
 		"ok": True,
 		"data": {
@@ -181,6 +186,7 @@ def get_dashboards_caps() -> dict:
 			"max_html_chars": _MAX_HTML_CHARS,
 			"max_rows": DASHBOARD_MAX_ROWS,
 			"stt_enabled": stt_enabled,
+			"stt_state": stt_state,
 		},
 	}
 

--- a/jarvis/chat/personalise_api.py
+++ b/jarvis/chat/personalise_api.py
@@ -244,12 +244,17 @@ def get_skills_area_caps() -> dict:
 	me = frappe.session.user
 
 	stt_enabled = False
+	# WHY it is off (ok|off|unconfigured|error): only `unconfigured` is an actionable
+	# gap worth showing the user as a faded recorder; the rest stay hidden.
+	stt_state = "error"
 	try:
 		from jarvis.chat import voice
 
 		stt_enabled = bool(voice.stt_config())
+		stt_state = voice.stt_state()
 	except Exception:
 		stt_enabled = False
+		stt_state = "error"
 
 	unanswered_count = frappe.db.count(QUESTION, {"user": me, "status": "Unanswered"})
 	# Any non-Deleted question, any status - the SPA uses this to tell a
@@ -263,6 +268,7 @@ def get_skills_area_caps() -> dict:
 		"analysis": has_jarvis_admin_access(),
 		"review": is_skill_reviewer(),
 		"stt_enabled": stt_enabled,
+		"stt_state": stt_state,
 		"unanswered_count": unanswered_count,
 		"questions_total": questions_total,
 		"personalise_enabled": _single_bool("personalise_enabled", True),


### PR DESCRIPTION
**This is the tail of #739.** That PR merged at head `b6df6368`; this final commit landed on the branch just after GitHub captured the merge, so it was never included. Same work, rebased onto current `develop`, re-verified. Nothing else changed.

## What it does
Finishes the sweep #739 started — the same capability signal was duplicated across the app, so #739 fixed the mic in **one of three** places while two others still vanished silently.

- **`wiki_state`** (`ok|off|empty|error`) beside `wiki_enabled`. The old flag collapsed *"an operator switched the wiki off"* with *"nobody has written a page yet"* — and the second is **the one unavailable state the user can fix themselves**. So the composer's wiki pill now fades with a self-serve nudge (*"I'll ask when something's worth remembering, or add one in Wiki"*) instead of disappearing. Feature-off and error still hide.
- **`stt_state`** added to the two caps endpoints whose recorders actually gate on it (`get_dashboards_caps`, `get_skills_area_caps`), consumed by the **dashboard-builder recorder** and the **Personalise composer**.

## Scope was narrowed deliberately
Six backend sites compute `bool(stt_config())`, but only the ones that gate a real affordance were touched:
- `greeting.py` — a behavioural decision, not a UI gate → left alone
- `triggers_api`, `voice_notes_api` — carried in caps defaults with no `v-if` rendering on them → left alone

## The principle this encodes
The copy differs by **who can act**: *"ask your administrator"* for an admin-side gap, a teaching nudge for an empty wiki. An unavailable control should say **why** — and to whom it's actionable.

## Verification
**929 frontend tests (62 files)**, `test_wiki` + `test_voice` green, `vite build` clean — all on the post-merge `develop` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)