### PR TITLE
fix(agents): dispatch a scheduled agent slot exactly once (#672)

### DIFF
--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -281,10 +281,24 @@ def _dispatch(row, now, *, run_as: str, original_user: str, source_apps: list[st
 	   freshness, never status alone (see ``_live_run``).
 
 	The failure handling then splits on what the launch actually left behind, because
-	"it raised" does not mean "nothing ran": ``_launch_audit`` commits its ``running``
-	run before it dispatches, so a throw after that point is a failure of the
-	bookkeeping, not of the audit. Handing the slot back there is exactly how the
-	duplicate was reached.
+	"it raised" does not mean "nothing ran". ``_launch_audit`` commits its ``running``
+	run before it dispatches, so a throw AFTER that commit that leaves the run alive is
+	a failure of the bookkeeping, not of the audit, and handing the slot back there is
+	exactly how the duplicate was reached. A throw from the dispatch call itself is the
+	other case: ``_launch_audit`` has already stamped its own run ``failed``, nothing is
+	running, and the slot is genuinely unspent. Reading the run rather than the
+	exception is what tells the two apart.
+
+	NOT covered here: a dispatch call that fails AMBIGUOUSLY, a timeout where admin may
+	already have started the turn. ``_launch_audit`` records that as ``failed`` (it
+	cannot know better), so the retry mints a fresh run id and the fleet's run-id
+	idempotency does not engage. That is a different duplicate with a different cause,
+	pre-dating this path, and closing it needs a decision about what an ambiguous
+	dispatch means rather than another guard here.
+
+	A Redis fault propagates out of the lock instead of dispatching, which is
+	deliberate: without the lock there is no exclusivity to be had, and a slot left due
+	is recoverable where a duplicate is not.
 	"""
 	from jarvis._redis_lock import redis_lock
 
@@ -294,7 +308,10 @@ def _dispatch(row, now, *, run_as: str, original_user: str, source_apps: list[st
 		if _live_run(row.name):
 			# Already auditing: a manual Run Now, or an audit that is genuinely still
 			# going. The slot's work is being done, so CONSUME it instead of queueing a
-			# second concurrent audit of the same installation.
+			# second concurrent audit of the same installation. Recorded like every other
+			# skip in this sweep, so the customer is never left with a scheduled audit
+			# that silently did not appear.
+			_record_failed(row, "scheduled run skipped: an audit for this agent was already running")
 			_advance(row, now)
 			return
 		prev = _claim_slot(row, now)
@@ -308,7 +325,7 @@ def _dispatch(row, now, *, run_as: str, original_user: str, source_apps: list[st
 			frappe.set_user(run_as)
 			inst = frappe.get_doc(INSTALLATION, row.name)
 			# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
-			# it has no initiating human — the scheduler user (Administrator) is not one.
+			# it has no initiating human: the scheduler user (Administrator) is not one.
 			_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
 		except Exception:
 			frappe.set_user(original_user)

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -21,9 +21,12 @@ review:
   ``run_as_user`` decouples the executing identity from the owner.
 * **O3:** the turn is dispatched ``background=1`` (unattended), so it never
   jumps ahead of a human's queued question.
-* **O4:** ``next_run_at`` advances ONLY after a successful enqueue; on failure a
-  ``failed`` run is recorded + the owner notified, and the missed slot is NOT
-  backfilled (``compute_next_run`` from *now* yields a single next future slot).
+* **O4 (#672):** the slot is CLAIMED (``next_run_at`` advanced) under a
+  per-installation lock BEFORE the enqueue, so a crash anywhere in the launch
+  leaves the slot spent rather than due; a launch that provably created nothing
+  hands the claim back, records a ``failed`` run and notifies the owner. The
+  missed slot is NOT backfilled (``compute_next_run`` from *now* yields a single
+  next future slot).
 * **O7:** identical ``(owner, agent, cadence, time)`` due rows are deduped.
 
 ``_launch_audit`` is shared with ``agents_api.run_agent_now`` so a manual
@@ -59,7 +62,20 @@ MIN_AGENT_RUN_BUDGET_MONTHLY = 31
 # run worker fails a run on exec/RPC death (A15) and record_agent_run finalizes a
 # live one, so this is a pure BACKSTOP. Sits well above the max bundle
 # ``timeout_s`` (manifest ceiling 5400s) so it can only ever catch orphans.
+#
+# It has a SECOND consumer since #672: ``_live_run`` treats a run older than this as
+# not-in-flight, precisely because this is the age at which the reaper declares it
+# dead. Keep the two answers to "is this run alive?" on one number, or a run becomes
+# too old to count as live and too young to be reaped.
 STALE_RUN_AFTER_SECONDS = 3 * 3600
+
+# #672: TTL on the per-installation DISPATCH lock, which is held across the slot
+# claim AND the whole launch, including the admin call (admin_client.DEFAULT_TIMEOUT_S
+# is 150s). Comfortably above that, because the TTL is a crash backstop and NOT a
+# concurrency budget: expiring it while a launch is still in flight would hand the
+# same installation to a second dispatcher, which is the thing this lock exists to
+# prevent.
+DISPATCH_LOCK_TTL_S = 300
 
 
 # --------------------------------------------------------------------------- #
@@ -234,30 +250,92 @@ def _sweep_one(row, now, original_user: str, seen: set) -> None:
 		_advance(row, now)
 		return
 
-	# S1 hinge: mint the run session + create conv/run INSIDE set_user(run_as).
-	# Row ownership is reassigned to the human owner inside _launch_audit; only
-	# the ERP-read identity is the run-as user.
-	try:
-		frappe.set_user(run_as)
-		inst = frappe.get_doc(INSTALLATION, row.name)
-		# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
-		# it has no initiating human — the scheduler user (Administrator) is not one.
-		_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
-		frappe.set_user(original_user)
-		_advance(row, now)  # O4: advance ONLY after a successful enqueue
-	except Exception:
-		frappe.set_user(original_user)
-		frappe.log_error(
-			title=f"jarvis scheduled audit failed: {row.name}",
-			message=frappe.get_traceback(),
-		)
-		_record_failed(row, "scheduled audit enqueue failed; see Error Log")
-		_notify_owner(row.owner, row)
-		# Do NOT advance -> retry next hour. compute_next_run(from=now) means
-		# even a long outage yields ONE next slot, never a backfill storm.
-	finally:
-		if frappe.session.user != original_user:
+	_dispatch(row, now, run_as=run_as, original_user=original_user, source_apps=source_apps)
+
+
+def _dispatch(row, now, *, run_as: str, original_user: str, source_apps: list[str] | None) -> None:
+	"""Launch this installation's due audit exactly once (#672).
+
+	Dispatch is the one step of the sweep that can be executed twice for a single
+	slot, and the duplicate is unrecoverable: a second real audit, billed a second
+	time against the A14 budget, for a customer whose only notification said the run
+	could not be started. Three things close it and all three are load-bearing.
+
+	1. **The lock.** Dispatch used to be an unlocked check-then-act shared with
+	   ``agents_api.run_agent_now``: a manual Run Now landing in the same tick as the
+	   cron had both pass their checks and both launch. Both paths now take this
+	   per-installation lock, so the check and the act cannot interleave. NOT
+	   acquiring it means another dispatcher owns this installation right now, so
+	   this row is left EXACTLY as it is: the holder's decision is the authoritative
+	   one, and advancing here as well could consume a slot the holder then declines
+	   to run.
+	2. **The claim.** ``_claim_slot`` writes the durable "this slot is spent" marker
+	   BEFORE the launch, so a failed set_value, a killed RQ worker or an OOM leaves
+	   the slot consumed rather than due. That is the safe direction: a lost slot
+	   resumes at the next cadence, a duplicate audit cannot be taken back. Keying
+	   idempotency on the RUN instead does not work: audits finish in minutes and
+	   ticks are hourly, so by the next tick the run is ``completed`` and a liveness
+	   check sees nothing at all.
+	3. **The live-run check**, which stops a SECOND CONCURRENT audit of one
+	   installation rather than a second dispatch of one slot. It is bounded by run
+	   freshness, never status alone (see ``_live_run``).
+
+	The failure handling then splits on what the launch actually left behind, because
+	"it raised" does not mean "nothing ran": ``_launch_audit`` commits its ``running``
+	run before it dispatches, so a throw after that point is a failure of the
+	bookkeeping, not of the audit. Handing the slot back there is exactly how the
+	duplicate was reached.
+	"""
+	from jarvis._redis_lock import redis_lock
+
+	with redis_lock(_dispatch_lock_name(row.name), timeout_s=DISPATCH_LOCK_TTL_S) as acquired:
+		if not acquired:
+			return
+		if _live_run(row.name):
+			# Already auditing: a manual Run Now, or an audit that is genuinely still
+			# going. The slot's work is being done, so CONSUME it instead of queueing a
+			# second concurrent audit of the same installation.
+			_advance(row, now)
+			return
+		prev = _claim_slot(row, now)
+		if prev is None:
+			return
+
+		# S1 hinge: mint the run session + create conv/run INSIDE set_user(run_as).
+		# Row ownership is reassigned to the human owner inside _launch_audit; only
+		# the ERP-read identity is the run-as user.
+		try:
+			frappe.set_user(run_as)
+			inst = frappe.get_doc(INSTALLATION, row.name)
+			# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
+			# it has no initiating human — the scheduler user (Administrator) is not one.
+			_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
+		except Exception:
 			frappe.set_user(original_user)
+			frappe.log_error(
+				title=f"jarvis scheduled audit failed: {row.name}",
+				message=frappe.get_traceback(),
+			)
+			# Did the audit actually start? Only the launch itself can have written a
+			# live run here (the lock is still held and there was none before the
+			# claim), and ``_launch_audit`` is atomic up to its own commit, so this
+			# answers honestly rather than guessing from the exception.
+			if _live_run(row.name):
+				# It is running. Recording a ``failed`` run, telling the owner nothing
+				# started, and handing the slot back would each be untrue, and the last
+				# one is the duplicate dispatch this whole path exists to prevent. Keep
+				# the claim; the Error Log above is the operator's signal.
+				frappe.db.commit()
+				return
+			# Nothing durable was created, so this slot really is unspent: hand it back
+			# and retry next hour. compute_next_run(from=now) means even a long outage
+			# yields ONE next slot, never a backfill storm.
+			_unclaim_slot(row, prev)
+			_record_failed(row, "scheduled audit enqueue failed; see Error Log")
+			_notify_owner(row.owner, row)
+		finally:
+			if frappe.session.user != original_user:
+				frappe.set_user(original_user)
 
 
 # --------------------------------------------------------------------------- #
@@ -616,83 +694,103 @@ def _launch_audit(
 			)
 		)
 
-	# Fresh conversation. ROW ownership is the human owner (reassigned below) so
-	# if_owner visibility works; the ERP-read identity is the run-as user.
-	# ignore_permissions matches the macro engine.
-	conv = frappe.get_doc({"doctype": CONV, "title": f"{listing.title} audit"[:140], "status": "Active"})
-	conv.flags.ignore_permissions = True
-	conv.insert()
+	# #672: everything from here to the commit below is ONE unit. It used to be a
+	# sequence of pending inserts, so a throw anywhere in it (a rejected insert, a
+	# duplicate session key, a DB blip) left a ``running`` Jarvis Agent Run PENDING in
+	# the transaction, and the caller's own error handling (``_record_failed``, which
+	# commits) flushed it. That phantom run counted against the A14 budget, made
+	# every liveness check believe an audit was in flight, and was finally relabelled
+	# by the 3h stale-run reaper as a duration timeout it never hit. With the
+	# savepoint this function either commits a real ``running`` run or leaves nothing
+	# at all, which is what lets the callers ask "did it actually start?" and get a
+	# true answer. The commit is deliberately OUTSIDE the try: a savepoint does not
+	# survive it, so rolling back to one after it could only ever fail.
+	savepoint = "jv_launch_" + frappe.generate_hash(length=8)
+	frappe.db.savepoint(savepoint)
+	try:
+		# Fresh conversation. ROW ownership is the human owner (reassigned below) so
+		# if_owner visibility works; the ERP-read identity is the run-as user.
+		# ignore_permissions matches the macro engine.
+		conv = frappe.get_doc({"doctype": CONV, "title": f"{listing.title} audit"[:140], "status": "Active"})
+		conv.flags.ignore_permissions = True
+		conv.insert()
 
-	# PP-5: the run's IMMUTABLE launch-time provenance, stamped once at insert (the
-	# controller's _IMMUTABLE_LAUNCH_FIELDS guard refuses any later ORM change):
-	#   * bundle_version — a SNAPSHOT of the version this run actually executes, taken
-	#     from the installation's installed_version (falling back to the listing) so it
-	#     is fixed even though the listing/installation versions are mutable.
-	#   * preparation_mode — a snapshot of the installation's activation_state
-	#     (shadow|live) at launch, so a run made in shadow is forever attributable as
-	#     such even after the install is later promoted.
-	#   * initiating_human — the human who triggered a MANUAL run; None for a
-	#     scheduled cron run (no human initiated it). Resolved above from the caller's
-	#     EXPLICIT argument, never from frappe.session.user: the session here is the
-	#     run-as user, which is a different person whenever the triggerer did not run
-	#     their own self-mapped install (JF-021).
-	bundle_version = inst.installed_version or listing.version or None
-	preparation_mode = inst.activation_state or "shadow"
+		# PP-5: the run's IMMUTABLE launch-time provenance, stamped once at insert (the
+		# controller's _IMMUTABLE_LAUNCH_FIELDS guard refuses any later ORM change):
+		#   * bundle_version — a SNAPSHOT of the version this run actually executes, taken
+		#     from the installation's installed_version (falling back to the listing) so it
+		#     is fixed even though the listing/installation versions are mutable.
+		#   * preparation_mode — a snapshot of the installation's activation_state
+		#     (shadow|live) at launch, so a run made in shadow is forever attributable as
+		#     such even after the install is later promoted.
+		#   * initiating_human — the human who triggered a MANUAL run; None for a
+		#     scheduled cron run (no human initiated it). Resolved above from the caller's
+		#     EXPLICIT argument, never from frappe.session.user: the session here is the
+		#     run-as user, which is a different person whenever the triggerer did not run
+		#     their own self-mapped install (JF-021).
+		bundle_version = inst.installed_version or listing.version or None
+		preparation_mode = inst.activation_state or "shadow"
 
-	# Stamped in the same insert and under the same immutability guard — the
-	# declared ``tools_allow`` resolved above plus the listing's ``nature``/
-	# ``writes`` as they stand RIGHT NOW. From here on the bench authorises this
-	# run's tool calls against the snapshot, never against the mutable listing, so
-	# neither a listing edit mid-run nor a compromised container can widen what an
-	# in-flight run may do.
-	capability = _delegate_capability.contract_for_launch(listing, declared_tools)
+		# Stamped in the same insert and under the same immutability guard — the
+		# declared ``tools_allow`` resolved above plus the listing's ``nature``/
+		# ``writes`` as they stand RIGHT NOW. From here on the bench authorises this
+		# run's tool calls against the snapshot, never against the mutable listing, so
+		# neither a listing edit mid-run nor a compromised container can widen what an
+		# in-flight run may do.
+		capability = _delegate_capability.contract_for_launch(listing, declared_tools)
 
-	run = frappe.get_doc(
-		{
-			"doctype": RUN,
-			"agent": inst.agent,
-			"installation": inst.name,
-			"trigger": trigger,
-			"status": "running",
-			"conversation": conv.name,
-			"started_at": frappe.utils.now(),
-			"bundle_version": bundle_version,
-			"preparation_mode": preparation_mode,
-			"initiating_human": initiating_human,
-			**capability,
-		}
-	)
-	run.flags.ignore_permissions = True
-	run.insert()
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": inst.agent,
+				"installation": inst.name,
+				"trigger": trigger,
+				"status": "running",
+				"conversation": conv.name,
+				"started_at": frappe.utils.now(),
+				"bundle_version": bundle_version,
+				"preparation_mode": preparation_mode,
+				"initiating_human": initiating_human,
+				**capability,
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
 
-	# Defensive: hand the row-owned rows to the intended HUMAN owner (mirrors
-	# macros.run_macro). When run_as_user != owner the session user here is the
-	# run-as user, so this reassignment is what keeps row ownership = owner.
-	if owner != frappe.session.user:
-		for dt, name in ((CONV, conv.name), (RUN, run.name)):
-			frappe.db.set_value(dt, name, "owner", owner, update_modified=False)
+		# Defensive: hand the row-owned rows to the intended HUMAN owner (mirrors
+		# macros.run_macro). When run_as_user != owner the session user here is the
+		# run-as user, so this reassignment is what keeps row ownership = owner.
+		if owner != frappe.session.user:
+			for dt, name in ((CONV, conv.name), (RUN, run.name)):
+				frappe.db.set_value(dt, name, "owner", owner, update_modified=False)
 
-	# Phase 1: mint a per-run Jarvis Chat Session bound to the RUN-AS user and
-	# stamp it on the Run. This is the row the delegate's jarvis__* calls resolve
-	# their identity from (api.py:44-141 → impersonate(run_as_user)). The dispatch
-	# itself is stubbed until Phase 2; the session + scope + watermark are the
-	# Phase-1 deliverable.
-	slug = listing.agent_slug
-	# agent session keys are `agent:<agent-id>:<key>` and the gateway resolves
-	# the session under that agent-id. The delegate agent id is `agent-<slug>`
-	# (fleet-agent compose.agent_delegates), so the id component MUST be the full
-	# delegate id, not the bare slug — otherwise the gateway `agent` RPC's
-	# agentId (`agent-<slug>`) and the session key's embedded id (`<slug>`)
-	# disagree. The bench never parses this shape (it matches the Jarvis Chat
-	# Session row verbatim), so aligning it is free on the bench side and correct
-	# on the agent side.
-	session_key = f"agent:agent-{slug}:{run.name}"
-	_mint_run_session(session_key, run_as_user)
-	frappe.db.set_value(RUN, run.name, "session_key", session_key, update_modified=False)
+		# Phase 1: mint a per-run Jarvis Chat Session bound to the RUN-AS user and
+		# stamp it on the Run. This is the row the delegate's jarvis__* calls resolve
+		# their identity from (api.py:44-141 → impersonate(run_as_user)). The dispatch
+		# itself is stubbed until Phase 2; the session + scope + watermark are the
+		# Phase-1 deliverable.
+		slug = listing.agent_slug
+		# agent session keys are `agent:<agent-id>:<key>` and the gateway resolves
+		# the session under that agent-id. The delegate agent id is `agent-<slug>`
+		# (fleet-agent compose.agent_delegates), so the id component MUST be the full
+		# delegate id, not the bare slug — otherwise the gateway `agent` RPC's
+		# agentId (`agent-<slug>`) and the session key's embedded id (`<slug>`)
+		# disagree. The bench never parses this shape (it matches the Jarvis Chat
+		# Session row verbatim), so aligning it is free on the bench side and correct
+		# on the agent side.
+		session_key = f"agent:agent-{slug}:{run.name}"
+		_mint_run_session(session_key, run_as_user)
+		frappe.db.set_value(RUN, run.name, "session_key", session_key, update_modified=False)
 
-	# A6 explicit scope + A17 consistency watermark + A12 permission profile —
-	# all best-effort (never abort the launch) and computed AS the run-as user.
-	scope = _stamp_scope_and_watermark(run.name, inst, run_as_user, source_apps=source_apps)
+		# A6 explicit scope + A17 consistency watermark + A12 permission profile —
+		# all best-effort (never abort the launch) and computed AS the run-as user.
+		scope = _stamp_scope_and_watermark(run.name, inst, run_as_user, source_apps=source_apps)
+
+	except Exception:
+		# Undo every row this launch wrote, so a caller that later commits (and both
+		# of them do, to record the failure) cannot flush a half-built run.
+		frappe.db.rollback(save_point=savepoint)
+		raise
 
 	frappe.db.commit()
 
@@ -964,6 +1062,76 @@ def _over_run_budget(installation: str) -> tuple[bool, str]:
 	if _runs_this_month() >= budget * enabled:
 		return True, "tenant-wide monthly agent run budget exceeded"
 	return False, ""
+
+
+def _dispatch_lock_name(installation: str) -> str:
+	"""The per-installation dispatch lock, shared by the cron sweep and the manual
+	``run_agent_now``. One name in one place: two spellings would serialize each path
+	against itself and neither against the other, which is the race (#672)."""
+	return f"jarvis_agent_dispatch:{installation}"
+
+
+def _live_run(installation: str) -> str | None:
+	"""The name of an IN-FLIGHT run for this installation, or None (#672).
+
+	Liveness is status PLUS freshness, never status alone. A row still ``running``
+	past ``STALE_RUN_AFTER_SECONDS`` is precisely what ``reap_stale_agent_runs``
+	exists to terminalize, so believing it here would let one wedged run suppress
+	every dispatch (and every manual run) until the reaper caught up, silently
+	skipping real slots for up to three hours. The two contracts are deliberately
+	keyed to the SAME cutoff: nothing the reaper would kill counts as in flight, so
+	there is no window where a row is too old to be live and too young to be reaped.
+	The reaper's own behaviour is unchanged.
+
+	``ignore_permissions`` because this is a server-side concurrency guard: runs are
+	owner-scoped by an ``if_owner`` query condition, so a System Manager triggering
+	someone else's install would otherwise be told there is no live run when there
+	is one."""
+	if not installation:
+		return None
+	fresh = now_datetime() - timedelta(seconds=STALE_RUN_AFTER_SECONDS)
+	rows = frappe.get_all(
+		RUN,
+		filters={"installation": installation, "status": "running", "started_at": [">", fresh]},
+		pluck="name",
+		limit=1,
+		ignore_permissions=True,
+	)
+	return rows[0] if rows else None
+
+
+def _claim_slot(row, now) -> dict | None:
+	"""Consume this slot durably BEFORE dispatching it, and return what it held so a
+	launch that provably created nothing can hand it back. None means another
+	dispatcher already claimed it.
+
+	Compare-and-set under a ROW LOCK: the sweep's ``frappe.get_all`` does not lock, so
+	two dispatchers can read the same due row; re-reading ``next_run_at`` for update
+	and confirming it is still due is what makes exactly one of them the dispatcher.
+	``compute_next_run`` returns a time strictly after ``now``, so a slot another
+	dispatcher has claimed reads as not-due here even within the same second."""
+	frappe.db.commit()  # REPEATABLE-READ discipline: FOR UPDATE goes first
+	cur = frappe.db.get_value(
+		INSTALLATION, row.name, ["next_run_at", "last_run_at"], as_dict=True, for_update=True
+	)
+	if not cur or not cur.next_run_at or frappe.utils.get_datetime(cur.next_run_at) > now:
+		frappe.db.commit()  # release the row lock; this slot is not ours to run
+		return None
+	_advance(row, now)  # commits, releasing the row lock
+	return {"next_run_at": cur.next_run_at, "last_run_at": cur.last_run_at}
+
+
+def _unclaim_slot(row, prev: dict) -> None:
+	"""Give a claimed slot back, unchanged, after a launch that created nothing. Only
+	ever called with the dispatch lock held and with a launch that left no live run,
+	so this cannot resurrect a slot some other dispatcher is running."""
+	frappe.db.set_value(
+		INSTALLATION,
+		row.name,
+		{"next_run_at": prev["next_run_at"], "last_run_at": prev["last_run_at"]},
+		update_modified=False,
+	)
+	frappe.db.commit()
 
 
 def _advance(row, now) -> None:

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -53,6 +53,11 @@ _ADMIN_STATUSES = ("Published", "Coming Soon", "Deprecated")
 # are identities, not grantable roles) and never offered in the admin picker.
 _NON_SELECTABLE_ROLES = ("Administrator", "Guest", "All")
 
+# #672: how long a manual "Run now" waits for the per-installation dispatch lock
+# before refusing. Long enough to swallow an ordinary overlap with the hourly sweep,
+# short enough that a human never sits on a spinner.
+DISPATCH_LOCK_WAIT_S = 5.0
+
 
 # --------------------------------------------------------------------------- #
 # role-based access (RBAC)
@@ -1074,17 +1079,44 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 	# (run_agent_now takes no such parameter) and the launch re-derives + verifies it
 	# against the authenticated session user, so it can only confirm, never forge.
 	triggering_human = authenticated_user()
-	# impersonate is session-safe (a bare frappe.set_user in this HTTP path
-	# would gut the caller's cookie session and log them out) and no-ops when
-	# the run-as user IS the caller (self-mapped manual run). get_doc does NOT
-	# enforce read perms, so the re-fetch under the run-as user is safe even when
-	# run_as is not the (if_owner) row owner.
-	with impersonate(run_as if run_as != original_user else None):
-		if run_as != original_user:
-			doc = frappe.get_doc(INSTALLATION, installation)  # re-fetch under run_as
-		result = _launch_audit(
-			doc, trigger="manual", source_apps=source_apps, initiating_human=triggering_human
-		)
+	# #672: the manual path takes the SAME per-installation dispatch lock as the cron
+	# sweep, and refuses to start a second CONCURRENT audit of one installation.
+	# Without the lock the two paths were an unguarded check-then-act on shared state:
+	# a Run Now landing in the same tick as the hourly sweep had both pass every gate
+	# above and both launch, so one customer paid twice out of one A14 budget for two
+	# audits of the same books. A short wait rather than an immediate refusal, because
+	# the common overlap is a launch already in progress that finishes in well under a
+	# second; only a genuinely concurrent dispatch reaches the refusal.
+	from jarvis._redis_lock import redis_lock
+	from jarvis.chat.agent_scheduler import DISPATCH_LOCK_TTL_S, _dispatch_lock_name, _live_run
+
+	with redis_lock(
+		_dispatch_lock_name(installation),
+		timeout_s=DISPATCH_LOCK_TTL_S,
+		blocking_timeout_s=DISPATCH_LOCK_WAIT_S,
+	) as acquired:
+		if not acquired:
+			frappe.throw(_("A run for this agent is already starting. Try again in a moment."))
+		# Freshness-bounded (see agent_scheduler._live_run), so a wedged run cannot
+		# lock the button out until the 3h reaper clears it.
+		if _live_run(installation):
+			frappe.throw(
+				_(
+					"This agent is already running. Wait for the current run to finish "
+					"before starting another one."
+				)
+			)
+		# impersonate is session-safe (a bare frappe.set_user in this HTTP path
+		# would gut the caller's cookie session and log them out) and no-ops when
+		# the run-as user IS the caller (self-mapped manual run). get_doc does NOT
+		# enforce read perms, so the re-fetch under the run-as user is safe even when
+		# run_as is not the (if_owner) row owner.
+		with impersonate(run_as if run_as != original_user else None):
+			if run_as != original_user:
+				doc = frappe.get_doc(INSTALLATION, installation)  # re-fetch under run_as
+			result = _launch_audit(
+				doc, trigger="manual", source_apps=source_apps, initiating_human=triggering_human
+			)
 	return {"ok": True, "data": result}
 
 

--- a/jarvis/tests/test_agent_dispatch_idempotency.py
+++ b/jarvis/tests/test_agent_dispatch_idempotency.py
@@ -304,6 +304,13 @@ class DispatchIdempotencyTestCase(FrappeTestCase):
 			ignore_permissions=True,
 		)
 
+	def _dispatched_for(self, inst: str) -> list:
+		"""Dispatch calls that belong to THIS installation. The sweep is site-wide and
+		CI runs four shards against one site, so a foreign installation falling due
+		mid-test must never read as a second audit of ours."""
+		mine = set(frappe.get_all(RUN, filters={"installation": inst}, pluck="name", ignore_permissions=True))
+		return [kw for kw in self.dispatched if kw.get("run_id") in mine]
+
 	def _next_run_at(self, inst: str):
 		return frappe.db.get_value(INSTALLATION, inst, "next_run_at")
 
@@ -321,7 +328,7 @@ class TestScheduledSlotIsDispatchedOnce(DispatchIdempotencyTestCase):
 		self._sweep(launch=self._launch_then_crash())
 		launched = self._launched(inst)
 		self.assertEqual(len(launched), 1, "the first tick launches exactly one audit")
-		self.assertEqual(len(self.dispatched), 1)
+		self.assertEqual(len(self._dispatched_for(inst)), 1)
 
 		# The writeback lands: the audit is done, minutes into the hour.
 		frappe.db.set_value(RUN, launched[0], "status", "completed", update_modified=False)
@@ -331,7 +338,7 @@ class TestScheduledSlotIsDispatchedOnce(DispatchIdempotencyTestCase):
 		self.assertEqual(
 			self._launched(inst), launched, "the slot was already dispatched; it must not run again"
 		)
-		self.assertEqual(len(self.dispatched), 1, "no second audit reaches the container")
+		self.assertEqual(len(self._dispatched_for(inst)), 1, "no second audit reaches the container")
 
 	def test_a_crash_after_the_launch_is_not_reported_as_a_failure_to_start(self):
 		"""The customer's audit IS running, so a ``failed`` run and a "could not be
@@ -365,7 +372,7 @@ class TestScheduledSlotIsDispatchedOnce(DispatchIdempotencyTestCase):
 			agent_scheduler._sweep_one(stale, now_datetime(), "Administrator", set())
 
 		self.assertEqual(self._launched(inst), launched, "the stale worker must not re-dispatch")
-		self.assertEqual(len(self.dispatched), 1)
+		self.assertEqual(len(self._dispatched_for(inst)), 1)
 
 	def test_a_long_audit_spanning_a_tick_is_not_double_launched(self):
 		"""Control: the ordinary healthy path. The audit is still ``running`` when the
@@ -380,6 +387,42 @@ class TestScheduledSlotIsDispatchedOnce(DispatchIdempotencyTestCase):
 		self._sweep()
 		self.assertEqual(self._launched(inst), launched)
 		self.assertEqual(frappe.db.get_value(RUN, launched[0], "status"), "running")
+
+	def test_a_dispatch_that_fails_for_real_leaves_the_slot_due_and_nothing_running(self):
+		"""The launch reaches the fleet call and THAT fails, which is a different shape
+		from the whole launch failing: the run row is already committed, so
+		``_launch_audit`` stamps it ``failed`` itself and re-raises. Nothing is running,
+		so the slot is genuinely unspent and must go back.
+
+		Known and deliberately not asserted as exactly-one: this attempt leaves TWO
+		``failed`` rows, one from the launch's own writeback and one from the sweep's
+		skip record. That predates the dispatch claim. What matters here is that no run
+		is left alive and the slot returns."""
+		inst = self._due_install()
+		now = now_datetime()
+
+		def _unreachable(**kw):
+			raise RuntimeError("admin unreachable")
+
+		self._sweep(dispatch=_unreachable)
+
+		self.assertEqual(self._runs(inst, "running"), [], "a failed dispatch leaves nothing alive")
+		errors = frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": "failed"},
+			fields=["error"],
+			ignore_permissions=True,
+		)
+		self.assertTrue(errors, "the failure is recorded for the customer")
+		self.assertTrue(
+			any("dispatch failed" in (e["error"] or "") for e in errors),
+			f"the real dispatch failure is named: {errors}",
+		)
+		self.assertTrue(
+			frappe.get_all(NOTIFICATION, filters={"for_user": self.owner}, pluck="name"),
+			"the owner is told",
+		)
+		self.assertLessEqual(self._next_run_at(inst), now, "the slot goes back for a retry")
 
 	def test_a_genuine_launch_failure_records_notifies_and_leaves_the_slot_due(self):
 		"""Control: nothing durable was created, so the customer must still be told and
@@ -405,7 +448,7 @@ class TestScheduledSlotIsDispatchedOnce(DispatchIdempotencyTestCase):
 			"the owner is told the run could not be started",
 		)
 		self.assertLessEqual(self._next_run_at(inst), now, "the slot stays due for a retry")
-		self.assertEqual(self.dispatched, [], "nothing reached the container")
+		self.assertEqual(self._dispatched_for(inst), [], "nothing reached the container")
 
 
 class TestLaunchAtomicity(DispatchIdempotencyTestCase):
@@ -471,7 +514,7 @@ class TestLaunchAtomicity(DispatchIdempotencyTestCase):
 
 		self._sweep()
 
-		self.assertEqual(len(self.dispatched), 1, "today's slot still runs")
+		self.assertEqual(len(self._dispatched_for(inst)), 1, "today's slot still runs")
 		self.assertEqual(len(self._launched(inst)), 2, "the wedged row plus the new audit")
 
 
@@ -510,14 +553,19 @@ class TestManualAndScheduledCannotInterleave(DispatchIdempotencyTestCase):
 				try:
 					self._run_now(inst)
 					outcome[0] = "launched"
+					outcome.append(None)
 				except Exception as e:
 					outcome[0] = f"refused: {e}"
+					outcome.append(type(e))
 			return self._dispatch_stub(**kw)
 
 		self._sweep(dispatch=_dispatch)
 
 		self.assertTrue(outcome and outcome[0] != "pending", "the manual run must have been attempted")
 		self.assertTrue(outcome[0].startswith("refused"), f"the manual run was not refused: {outcome[0]}")
+		# Refused for the RIGHT reason: any old crash would also read as "refused".
+		self.assertEqual(outcome[1], frappe.ValidationError)
+		self.assertIn("already", outcome[0])
 		self.assertEqual(len(self._launched(inst)), 1, "exactly one audit for the two triggers")
 
 	def test_a_manual_run_is_refused_while_its_own_audit_is_still_running(self):
@@ -531,6 +579,33 @@ class TestManualAndScheduledCannotInterleave(DispatchIdempotencyTestCase):
 			self._run_now(inst)
 		self.assertIn("already running", str(cm.exception))
 		self.assertEqual(len(self._launched(inst)), 1)
+
+	def test_a_tick_arriving_during_a_live_manual_audit_consumes_the_slot(self):
+		"""The non-racing overlap, which is the common one: the manual run started a
+		minute ago and is still going when the hourly tick fires. Nothing is contended,
+		the lock is free, and the tick has to decide on its own. It must not queue a
+		second audit of the same books, it must consume the slot rather than busy-retry
+		every hour behind a long audit, and the deferral has to be visible: every other
+		skip in this sweep records its reason, so a customer never finds a scheduled
+		audit that simply did not appear."""
+		inst = self._due_install()
+		self._run_now(inst)
+		self.assertEqual(len(self._launched(inst)), 1)
+		now = now_datetime()
+
+		self._sweep()
+
+		self.assertEqual(len(self._launched(inst)), 1, "no second concurrent audit")
+		self.assertEqual(len(self._dispatched_for(inst)), 1)
+		self.assertGreater(self._next_run_at(inst), now, "the slot is consumed, not left due")
+		skipped = frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": "failed"},
+			fields=["error"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(len(skipped), 1, "the deferral is recorded for the customer")
+		self.assertIn("already running", skipped[0]["error"])
 
 	def test_a_manual_run_is_allowed_again_once_the_audit_finishes(self):
 		"""Control: the refusal is about CONCURRENCY, never a lockout. A finished audit

--- a/jarvis/tests/test_agent_dispatch_idempotency.py
+++ b/jarvis/tests/test_agent_dispatch_idempotency.py
@@ -1,0 +1,544 @@
+"""#672: a scheduled agent slot must be dispatched EXACTLY once.
+
+``_launch_audit`` commits its ``running`` Jarvis Agent Run before it returns, so
+anything that went wrong between that commit and the schedule advance left the row
+still DUE with a live audit going, and the next hourly tick dispatched the SAME slot
+again. The customer was billed twice against the A14 budget and their only
+notification said the run could not be started.
+
+These tests drive the real shapes rather than asserting on a mock at the boundary
+under repair, because the three holes an earlier attempt (PR #662) left open are all
+invisible to a healthy-input test:
+
+  * a crash AFTER a successful launch, followed by the run COMPLETING, which is the
+    common case: audits take minutes and ticks are hourly, so any guard keyed on run
+    liveness has stopped protecting by the time the next tick arrives;
+  * a manual ``run_agent_now`` and the cron sweep genuinely INTERLEAVED (driven here
+    by re-entering one path from inside the other's dispatch call, which is where the
+    two really overlap), not two sequential calls;
+  * a launch that raises MID-WAY, which used to leave an orphaned ``running`` row
+    (the pending inserts were flushed by ``_record_failed``'s own commit) and made
+    every later tick skip a real slot while the failure went unreported.
+
+Run:
+  bench --site test_site run-tests --app jarvis \
+    --module jarvis.tests.test_agent_dispatch_idempotency
+"""
+
+import json
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, add_to_date, now_datetime
+
+from jarvis import admin_client
+from jarvis.chat import agent_catalog, agent_scheduler, agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+CONV = "Jarvis Conversation"
+SESSION = "Jarvis Chat Session"
+ACTIVITY = "Jarvis Agent Activity"
+NOTIFICATION = "Notification Log"
+
+SLUG = "dispatch-idem-auditor"
+OWNER = "dispatch-idem-owner@example.com"
+
+# Any non-empty declared surface: _launch_audit refuses a bundle that declares no
+# tools before it creates a row, and this module is about dispatch, not contracts.
+DECLARED = ["jarvis__get_schema"]
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		user.insert(ignore_permissions=True)
+		user.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Dispatch idempotency auditor",
+				"rule_tokens": json.dumps(["tok"]),
+				"doctypes_required": json.dumps([]),
+				"rule_pack": f"pack-{SLUG}",
+			}
+		).insert(ignore_permissions=True)
+	frappe.db.set_value(LISTING, SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False)
+	return SLUG
+
+
+def _wipe() -> None:
+	"""Everything a launch leaves behind. Launches commit, so FrappeTestCase's own
+	rollback cannot reclaim any of it."""
+	for name in frappe.get_all(RUN, filters={"agent": SLUG}, pluck="name", ignore_permissions=True):
+		frappe.delete_doc(RUN, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(ACTIVITY, filters={"agent": SLUG}, pluck="name", ignore_permissions=True):
+		frappe.delete_doc(ACTIVITY, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(INSTALLATION, filters={"agent": SLUG}, pluck="name", ignore_permissions=True):
+		frappe.delete_doc(INSTALLATION, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(CONV, filters={"owner": OWNER}, pluck="name", ignore_permissions=True):
+		frappe.delete_doc(CONV, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(SESSION, filters={"user": OWNER}, pluck="name", ignore_permissions=True):
+		frappe.delete_doc(SESSION, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(
+		NOTIFICATION, filters={"for_user": OWNER}, pluck="name", ignore_permissions=True
+	):
+		frappe.delete_doc(NOTIFICATION, name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+class DispatchIdempotencyTestCase(FrappeTestCase):
+	"""Shared fixture: one published auditor, installed for one owner, due now, with
+	the fleet dispatch stubbed so ``_launch_audit`` runs for real end to end."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user(OWNER)
+		_mk_listing()
+		# The A14 ceiling counts every non-failed run on the SITE, including rows other
+		# platform-test modules commit and never clean, so it can refuse a legitimate
+		# dispatch here for reasons that have nothing to do with this module.
+		cls._orig_budget = frappe.db.get_single_value("Jarvis Settings", "agent_run_budget_monthly")
+		frappe.db.set_single_value("Jarvis Settings", "agent_run_budget_monthly", 1000000)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("Jarvis Settings", "agent_run_budget_monthly", cls._orig_budget)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		_mk_listing()
+		frappe.db.commit()
+		self.dispatched = []
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	# ------------------------------------------------------------------ #
+	# fixture
+	# ------------------------------------------------------------------ #
+	def _due_install(self) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": SLUG,
+				"run_as_user": self.owner,
+				"reviewer": self.owner,
+				"enabled": 1,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(INSTALLATION, doc.name, "owner", self.owner, update_modified=False)
+		frappe.db.set_value(
+			INSTALLATION,
+			doc.name,
+			{
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"next_run_at": add_days(now_datetime(), -1),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		return doc.name
+
+	def _due_row(self, inst: str):
+		"""The snapshot ``run_due_agent_audits`` hands ``_sweep_one``, so a test can
+		replay a worker that read the row while it was still due."""
+		return frappe.get_all(
+			INSTALLATION,
+			filters={"name": inst},
+			fields=[
+				"name",
+				"owner",
+				"run_as_user",
+				"agent",
+				"schedule_frequency",
+				"schedule_time",
+				"installable",
+				"source_apps_json",
+				"activation_state",
+			],
+			ignore_permissions=True,
+		)[0]
+
+	# ------------------------------------------------------------------ #
+	# harness
+	# ------------------------------------------------------------------ #
+	def _dispatch_stub(self, **kw):
+		self.dispatched.append(kw)
+		return {"run_id": kw.get("run_id"), "status": "queued"}
+
+	@contextmanager
+	def _delegate_stubbed(self, dispatch=None):
+		"""Run the REAL ``_launch_audit`` without a fleet: only the outbound admin call
+		and the bundled registry lookup are stubbed, so the conversation, the run row,
+		the session and every commit boundary are exercised."""
+		with ExitStack() as stack:
+			stack.enter_context(patch.object(admin_client, "post_agent_run", dispatch or self._dispatch_stub))
+			stack.enter_context(patch.object(agent_catalog, "registry_tools_allow", return_value=DECLARED))
+			# Keeps the manual path's lock wait off the clock when a test deliberately
+			# collides with a launch that is still in flight. create=True so the module
+			# without the fix (where nothing reads it) patches cleanly too.
+			stack.enter_context(patch.object(agents_api, "DISPATCH_LOCK_WAIT_S", 0.1, create=True))
+			yield
+
+	@contextmanager
+	def _only_this_install_due(self):
+		"""Park every OTHER due installation. This is a shared site and other modules
+		leave due rows behind; the sweep is site-wide."""
+		now = now_datetime()
+		parked = {
+			r.name: r.next_run_at
+			for r in frappe.get_all(
+				INSTALLATION,
+				filters={
+					"enabled": 1,
+					"schedule_enabled": 1,
+					"next_run_at": ["<=", now],
+					"agent": ["!=", SLUG],
+				},
+				fields=["name", "next_run_at"],
+				ignore_permissions=True,
+			)
+		}
+		for name in parked:
+			frappe.db.set_value(INSTALLATION, name, "next_run_at", add_days(now, 2), update_modified=False)
+		frappe.db.commit()
+		try:
+			yield
+		finally:
+			for name, ts in parked.items():
+				frappe.db.set_value(INSTALLATION, name, "next_run_at", ts, update_modified=False)
+			frappe.db.commit()
+
+	def _sweep(self, *, dispatch=None, launch=None) -> None:
+		"""One hourly tick."""
+		with self._only_this_install_due(), self._delegate_stubbed(dispatch), ExitStack() as stack:
+			if launch is not None:
+				stack.enter_context(patch.object(agent_scheduler, "_launch_audit", launch))
+			agent_scheduler.run_due_agent_audits()
+
+	def _sweep_as_administrator(self) -> None:
+		"""A tick firing on a cron worker while some OTHER dispatch is mid-flight on
+		this thread. The session is restored, so the caller's launch continues under
+		the identity it had."""
+		prev = frappe.session.user
+		frappe.set_user("Administrator")
+		try:
+			with self._only_this_install_due():
+				agent_scheduler.run_due_agent_audits()
+		finally:
+			frappe.set_user(prev)
+
+	def _run_now(self, inst: str, *, dispatch=None):
+		with self._delegate_stubbed(dispatch):
+			prev = frappe.session.user
+			frappe.set_user(self.owner)
+			try:
+				return agents_api.run_agent_now(inst)
+			finally:
+				frappe.set_user(prev)
+
+	@staticmethod
+	def _launch_then_crash():
+		"""The launch gets all the way through, then the worker dies before the sweep
+		can finish its bookkeeping: a killed RQ worker, an OOM, a failed set_value."""
+		real = agent_scheduler._launch_audit
+
+		def _wrapped(inst, **kw):
+			real(inst, **kw)
+			raise RuntimeError("worker killed after a successful launch")
+
+		return _wrapped
+
+	# ------------------------------------------------------------------ #
+	# assertions
+	# ------------------------------------------------------------------ #
+	def _launched(self, inst: str) -> list:
+		"""Runs that actually STARTED an audit. A skip records a ``failed`` row without
+		ever reaching the container, so reaching ``running`` is what makes it a launch,
+		and the row survives the audit completing (which is exactly the case a
+		liveness-only guard misses)."""
+		return frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": ["in", ("running", "completed")]},
+			order_by="creation asc",
+			pluck="name",
+			ignore_permissions=True,
+		)
+
+	def _runs(self, inst: str, status: str) -> list:
+		return frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": status},
+			order_by="creation asc",
+			pluck="name",
+			ignore_permissions=True,
+		)
+
+	def _next_run_at(self, inst: str):
+		return frappe.db.get_value(INSTALLATION, inst, "next_run_at")
+
+
+class TestScheduledSlotIsDispatchedOnce(DispatchIdempotencyTestCase):
+	"""The reported defect and its immediate neighbours."""
+
+	def test_a_crash_after_the_launch_does_not_re_dispatch_the_completed_slot(self):
+		"""THE regression. The launch succeeds, the sweep dies before the schedule can
+		be advanced, the audit finishes normally within the hour, and the next tick
+		finds the slot still due. A guard keyed on a live run cannot see this: by then
+		the run is ``completed``."""
+		inst = self._due_install()
+
+		self._sweep(launch=self._launch_then_crash())
+		launched = self._launched(inst)
+		self.assertEqual(len(launched), 1, "the first tick launches exactly one audit")
+		self.assertEqual(len(self.dispatched), 1)
+
+		# The writeback lands: the audit is done, minutes into the hour.
+		frappe.db.set_value(RUN, launched[0], "status", "completed", update_modified=False)
+		frappe.db.commit()
+
+		self._sweep()  # the next hourly tick
+		self.assertEqual(
+			self._launched(inst), launched, "the slot was already dispatched; it must not run again"
+		)
+		self.assertEqual(len(self.dispatched), 1, "no second audit reaches the container")
+
+	def test_a_crash_after_the_launch_is_not_reported_as_a_failure_to_start(self):
+		"""The customer's audit IS running, so a ``failed`` run and a "could not be
+		started" alert would both be untrue."""
+		inst = self._due_install()
+
+		self._sweep(launch=self._launch_then_crash())
+
+		self.assertEqual(self._runs(inst, "failed"), [], "a live audit is not a failed one")
+		self.assertEqual(
+			frappe.get_all(NOTIFICATION, filters={"for_user": self.owner}, pluck="name"),
+			[],
+			"the owner is not told a run that started could not start",
+		)
+
+	def test_a_second_cron_worker_with_a_stale_due_snapshot_does_not_re_dispatch(self):
+		"""Two workers read the same due row; one dispatches and consumes the slot. The
+		other is still holding its snapshot, and by the time it acts the first audit has
+		finished, so nothing about the RUNS tells it the slot is spent. Only the durable
+		slot claim does."""
+		inst = self._due_install()
+		stale = self._due_row(inst)  # what both workers read
+
+		self._sweep()
+		launched = self._launched(inst)
+		self.assertEqual(len(launched), 1)
+		frappe.db.set_value(RUN, launched[0], "status", "completed", update_modified=False)
+		frappe.db.commit()
+
+		with self._delegate_stubbed():
+			agent_scheduler._sweep_one(stale, now_datetime(), "Administrator", set())
+
+		self.assertEqual(self._launched(inst), launched, "the stale worker must not re-dispatch")
+		self.assertEqual(len(self.dispatched), 1)
+
+	def test_a_long_audit_spanning_a_tick_is_not_double_launched(self):
+		"""Control: the ordinary healthy path. The audit is still ``running`` when the
+		next tick fires, and the slot is not due again until tomorrow."""
+		inst = self._due_install()
+
+		self._sweep()
+		launched = self._launched(inst)
+		self.assertEqual(len(launched), 1)
+		self.assertEqual(frappe.db.get_value(RUN, launched[0], "status"), "running")
+
+		self._sweep()
+		self.assertEqual(self._launched(inst), launched)
+		self.assertEqual(frappe.db.get_value(RUN, launched[0], "status"), "running")
+
+	def test_a_genuine_launch_failure_records_notifies_and_leaves_the_slot_due(self):
+		"""Control: nothing durable was created, so the customer must still be told and
+		the slot must stay due for the next hour."""
+		inst = self._due_install()
+		now = now_datetime()
+
+		def _boom(inst_doc, **kw):
+			raise RuntimeError("enqueue exploded")
+
+		self._sweep(launch=_boom)
+
+		failed = frappe.get_all(
+			RUN,
+			filters={"installation": inst, "status": "failed"},
+			fields=["error"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(len(failed), 1, "a real launch failure is recorded for the customer")
+		self.assertIn("enqueue failed", failed[0]["error"])
+		self.assertTrue(
+			frappe.get_all(NOTIFICATION, filters={"for_user": self.owner}, pluck="name"),
+			"the owner is told the run could not be started",
+		)
+		self.assertLessEqual(self._next_run_at(inst), now, "the slot stays due for a retry")
+		self.assertEqual(self.dispatched, [], "nothing reached the container")
+
+
+class TestLaunchAtomicity(DispatchIdempotencyTestCase):
+	"""A launch that raises mid-way must leave NOTHING behind. Its rows used to sit
+	pending in the transaction until ``_record_failed``'s own commit flushed them,
+	which is how a failed launch produced a phantom in-flight run."""
+
+	@staticmethod
+	def _mid_launch_failure():
+		"""Raises AFTER the conversation and the ``running`` run are inserted and
+		BEFORE the launch commits: the exact window that produced the orphan."""
+		return patch.object(
+			agent_scheduler, "_mint_run_session", side_effect=RuntimeError("session mint blew up")
+		)
+
+	def test_a_mid_launch_failure_leaves_no_orphaned_running_run(self):
+		inst = self._due_install()
+
+		with self._mid_launch_failure():
+			self._sweep()
+
+		self.assertEqual(self._runs(inst, "running"), [], "no phantom in-flight run")
+		self.assertEqual(len(self._runs(inst, "failed")), 1, "the failure is recorded instead")
+		self.assertEqual(
+			frappe.get_all(CONV, filters={"owner": self.owner}, pluck="name"),
+			[],
+			"and no orphan conversation either",
+		)
+
+	def test_the_next_tick_reports_the_failure_again_rather_than_skipping_it(self):
+		"""An orphan would make every later tick believe an audit was in flight, so the
+		slot would be silently skipped and advanced, hiding a real failure until the 3h
+		reaper fired."""
+		inst = self._due_install()
+
+		with self._mid_launch_failure():
+			self._sweep()
+			self._sweep()
+
+		self.assertEqual(len(self._runs(inst, "failed")), 2, "the second tick reports it too")
+		self.assertEqual(self._runs(inst, "running"), [])
+
+	def test_a_wedged_run_does_not_suppress_a_later_due_slot(self):
+		"""A run stuck ``running`` past the stale-run reaper's cutoff is not in flight,
+		it is dead, and treating it as live would skip real slots for up to three hours.
+		This is why dispatch is guarded by a durable slot claim and not by run status."""
+		inst = self._due_install()
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": SLUG,
+				"installation": inst,
+				"trigger": "scheduled",
+				"status": "running",
+				"started_at": add_to_date(
+					now_datetime(), seconds=-(agent_scheduler.STALE_RUN_AFTER_SECONDS + 600)
+				),
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		self._sweep()
+
+		self.assertEqual(len(self.dispatched), 1, "today's slot still runs")
+		self.assertEqual(len(self._launched(inst)), 2, "the wedged row plus the new audit")
+
+
+class TestManualAndScheduledCannotInterleave(DispatchIdempotencyTestCase):
+	"""``run_agent_now`` and the sweep share one installation and one budget. Both used
+	to check "is anything running?" and act on the answer with nothing serializing the
+	two, so a Run Now landing in the same tick as the cron launched a second audit."""
+
+	def test_a_sweep_firing_during_a_manual_launch_does_not_launch_a_second_audit(self):
+		"""The hourly tick arrives while the manual run is still being dispatched: the
+		manual run's row is already committed ``running``, the slot is still due."""
+		inst = self._due_install()
+		reentered = []
+
+		def _dispatch(**kw):
+			if not reentered:
+				reentered.append(True)
+				self._sweep_as_administrator()
+			return self._dispatch_stub(**kw)
+
+		self._run_now(inst, dispatch=_dispatch)
+
+		self.assertTrue(reentered, "the re-entrant tick must actually have run")
+		self.assertEqual(len(self._launched(inst)), 1, "exactly one audit for the two triggers")
+
+	def test_a_manual_run_racing_the_sweep_is_refused_rather_than_launched(self):
+		"""The mirror ordering: the cron is mid-dispatch when the customer clicks Run
+		Now. One of the two has to lose, and it cannot be the scheduled slot, which has
+		already been claimed."""
+		inst = self._due_install()
+		outcome = []
+
+		def _dispatch(**kw):
+			if not outcome:
+				outcome.append("pending")
+				try:
+					self._run_now(inst)
+					outcome[0] = "launched"
+				except Exception as e:
+					outcome[0] = f"refused: {e}"
+			return self._dispatch_stub(**kw)
+
+		self._sweep(dispatch=_dispatch)
+
+		self.assertTrue(outcome and outcome[0] != "pending", "the manual run must have been attempted")
+		self.assertTrue(outcome[0].startswith("refused"), f"the manual run was not refused: {outcome[0]}")
+		self.assertEqual(len(self._launched(inst)), 1, "exactly one audit for the two triggers")
+
+	def test_a_manual_run_is_refused_while_its_own_audit_is_still_running(self):
+		"""Two concurrent audits of one installation are two bills for one answer, so
+		the second trigger is refused whichever surface it came from."""
+		inst = self._due_install()
+		self._run_now(inst)
+		self.assertEqual(len(self._launched(inst)), 1)
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			self._run_now(inst)
+		self.assertIn("already running", str(cm.exception))
+		self.assertEqual(len(self._launched(inst)), 1)
+
+	def test_a_manual_run_is_allowed_again_once_the_audit_finishes(self):
+		"""Control: the refusal is about CONCURRENCY, never a lockout. A finished audit
+		leaves the button working."""
+		inst = self._due_install()
+		self._run_now(inst)
+		frappe.db.set_value(RUN, self._launched(inst)[0], "status", "completed", update_modified=False)
+		frappe.db.commit()
+
+		self._run_now(inst)
+		self.assertEqual(len(self._launched(inst)), 2)


### PR DESCRIPTION
## Summary

A scheduled agent audit is now dispatched exactly once per slot: the slot is claimed before the launch instead of advanced after it, both dispatch paths hold one per-installation lock, and a launch that fails part way through leaves nothing behind. Customers on a schedule stop getting duplicate audits billed twice against one monthly run budget, and stop being told "could not start" about an audit that is running.

Three changes, all needed. `_claim_slot` writes the durable "this slot is spent" marker before `_launch_audit`, as a compare-and-set on `next_run_at` under a row lock, so a crash, an OOM or a killed worker loses the slot rather than duplicating it; a launch that provably created nothing hands the claim back, so a genuine failure still records, notifies and retries next hour. Both the cron sweep and `run_agent_now` take one per-installation redis lock and refuse a second concurrent audit of one installation, with liveness bounded by the stale-run reaper's own cutoff so a wedged run cannot suppress real slots. And `_launch_audit` wraps its row creation in a savepoint, so it either commits a real `running` run or leaves nothing, which is what lets the scheduler ask "did the audit actually start?" and get a true answer.

Supersedes #652 and the closed PR #662, whose running-run guard the review showed does not close this.

**User-visible changes:** "Run now" is refused while that agent's own audit is still in flight, including a double click. And a scheduled slot that defers to an already-running audit now records that reason on the Runs list instead of silently not appearing. **No `bench migrate`, no SPA rebuild** (Python only, no schema change).

<details>
<summary>Root cause, and why the obvious fixes do not work</summary>

`_launch_audit` commits its `running` Jarvis Agent Run before it returns (`agent_scheduler.py:697` on develop). `_sweep_one` advanced `next_run_at` only afterwards, inside the same `try`. So anything failing between that commit and `_advance` left the row still DUE with a live audit going, and took the failure branch: a `failed` run row, an alert saying nothing started, and no advance. The next hourly tick then dispatched the same slot again.

Splitting the `try` at the enqueue boundary stops the false record and the false alert, but the row is left due either way, so the next tick still re-dispatches.

A plain `frappe.db.exists(RUN, {installation, status: "running"})` guard fails three ways:

1. It stops protecting the moment the run finishes. Audits take minutes, ticks are hourly, so by the next tick the run is `completed` and the guard sees nothing. The common case is uncovered.
2. It is an unlocked check-then-act. A manual `run_agent_now` racing the sweep can have both pass before either inserts.
3. An orphaned `running` row makes it mask real failures. `_record_failed`'s own commit flushed the pending rows of a half-finished launch, and the guard then skipped and advanced real slots until the 3h reaper fired.

The fix answers each: idempotency is keyed on the SLOT (`next_run_at`), not on run liveness, and is written in a protected step; one lock spans check and act on both paths; and the savepoint means an orphan cannot exist, so the remaining liveness check is only ever asking about a genuinely concurrent audit.

**Orphan decision and the reaper contract.** `_launch_audit` is now atomic up to its own commit, so a mid-launch failure creates nothing. The reaper's behaviour is unchanged, but `STALE_RUN_AFTER_SECONDS` now has a second consumer: `_live_run` treats a run older than that cutoff as not in flight, exactly because that is the age at which the reaper declares it dead. One number, so no run is ever too old to count as live and too young to be reaped.

**What this does NOT cover.**

* A hard crash between the claim commit and the launch loses one slot silently: no run, no notification, until the next cadence. Deliberate: a lost slot is recoverable and a duplicate audit is not.
* An AMBIGUOUS dispatch failure, a timeout where admin may already have started the turn. `_launch_audit` records it as `failed` because it cannot know better, so the retry mints a fresh run id and the fleet's run-id idempotency never engages. That is a second duplicate route with a different cause, it predates this path, and closing it needs a decision about what an ambiguous dispatch means. Filed as #743.
* A completed manual run does not consume the scheduled slot, so a manual run at 09:00 and a scheduled one at 10:00 still both run. Only concurrency is prevented.
* The per-tenant budget check remains an unlocked check-then-act across installations.
* A Redis fault now stops dispatch instead of racing it. Slots stay due and an Error Log is written per row, but no owner notification is sent for that hour.
</details>

<details>
<summary>Manual test plan</summary>

On a bench with one enabled auditor installation whose schedule is due (`site.jarvis`, scheduler paused, so invoke the cron by hand). Stub the fleet by pointing `admin_client.post_agent_run` at a no-op, or just watch the Runs list.

1. **Happy path.** `bench --site <site> execute jarvis.chat.agent_scheduler.run_due_agent_audits`. One `running` run appears, `next_run_at` moved to tomorrow, `last_run_at` is now.
2. **Crash after the launch.** Set `next_run_at` back to the past, run the sweep with `_launch_audit` wrapped so it raises after returning. Expect: one run only, no `failed` row, no Notification Log, and `next_run_at` ALREADY advanced. Mark the run `completed`, run the sweep again: nothing new is dispatched.
3. **Mid-launch failure.** Set `next_run_at` back to the past, patch `agent_scheduler._mint_run_session` to raise, run the sweep. Expect: zero `running` rows, one `failed` row naming the enqueue failure, one notification, and `next_run_at` still in the past. Run it again: it reports again rather than silently skipping.
4. **Manual vs scheduled.** With a run in flight, click "Run now" in the SPA (Agents, the installation, Run now). Expect the refusal "This agent is already running". Mark the run `completed` and click again: it launches.
5. **Wedged run.** Insert a `running` run with `started_at` four hours ago and make the slot due. The sweep must still dispatch, and the manual button must still work: a dead run is not an in-flight one.
</details>

## Pre-merge checklist

- [x] **CI is green** on this PR
- [x] Branch is up to date with `develop` (this repo merges into `develop`, not `main`)
- [x] New/changed behavior has tests: 14 new tests in `jarvis/tests/test_agent_dispatch_idempotency.py`, 9 of which were confirmed RED against unfixed `develop` before the fix landed ([run 31244756856](https://github.com/Aerele-RnD/jarvis/actions/runs/31244756856), and [run 31245611744](https://github.com/Aerele-RnD/jarvis/actions/runs/31245611744) for the two cases added after review). The other 5 are controls that pass on `develop` and must keep passing.
- [x] I self-reviewed the diff

Fixes #672
