### PR TITLE
fix(onboarding): clear stale tenant authority on a new admin login

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -112,6 +112,43 @@ def write_connection(data: dict) -> None:
 	# reconnect that repoints it can be told apart from a daily sync that rewrites
 	# the same URL (which must not disturb an established claim).
 	_old_agent_url = (s.get("agent_url") or "").strip()
+	# Credentials just changed (fresh signup, or a reconnect rotating onto another
+	# account): a bearer minted from the old ones would outlive them, and, the part
+	# that used to be missing, the accepted tenant-authority (generation, handle)
+	# must not outlive them either. The generation is a PER-CUSTOMER namespace
+	# (admin-v2 fleet/_tenant_lookup.py: "the generation is an ASSIGNMENT generation,
+	# per customer"), so a stored value left over from a PREVIOUS principal is not a
+	# stale version of the new principal's count, it is a count from an unrelated
+	# series - every fresh customer's first claim is generation 1, so a leftover
+	# stored 1 (or higher) collides with the new customer's own first claim at the
+	# SAME number but a DIFFERENT container handle. guard() cannot tell that apart
+	# from the real invariant breach it exists to catch, so it HOLDS the stale
+	# connection and re-polls forever: every retry carries the same new-customer
+	# generation 1, which can never numerically exceed the stale leftover (jarvis
+	# #693, reproduced end to end on a dev bench re-signed-up after an admin-side
+	# customer purge without a matching bench-side reset). check_account_reconnect
+	# and _disconnect_agent_transport already clear for exactly this reason on their
+	# own paths; plain signup (and anywhere else a fresh principal's credentials
+	# land here) needs the same guard, cleared BEFORE the connection block below so
+	# a payload carrying both new credentials AND a connection in one call is
+	# covered too.
+	#
+	# Deliberately narrower than the ``principal_change`` used below for the
+	# cached-bearer/chat-ready resets: api_key/api_secret/customer are the strong
+	# signal that this IS a different admin login, but a lone ``customer_password``
+	# is not. admin re-serves that field on every poll while its 60-minute cache
+	# entry lives (billing/signup.py ``_serve_signup_password``, "kept until TTL
+	# rather than deleted on read"), including a poll a fully-connected bench could
+	# still make within that window - and a lone customer_password never arrives
+	# for a GENUINELY new principal either: every real new-principal call also
+	# carries api_key/customer, which already trips this clear. Widening the
+	# trigger to customer_password would drop the P0-5 protection for one window on
+	# an otherwise healthy, unrelated connection for no gain.
+	new_admin_login = any(data.get(k) for k in ("api_key", "api_secret", "customer"))
+	if new_admin_login:
+		from jarvis import tenant_authority
+
+		tenant_authority.clear(s)
 	if data.get("api_key"):
 		set_settings_password(s, "jarvis_admin_api_key", data["api_key"])
 	if data.get("api_secret"):
@@ -160,7 +197,11 @@ def write_connection(data: dict) -> None:
 			if data.get("agent_token"):
 				set_settings_password(s, "agent_token", data["agent_token"])
 	# Credentials just changed (fresh signup, or a reconnect rotating onto another
-	# account): a bearer minted from the old ones would outlive them.
+	# account): a bearer minted from the old ones would outlive them. Wider than
+	# ``new_admin_login`` above on purpose - a standalone customer_password (the
+	# verified-poll delivery, no api_key/customer alongside it) still means the
+	# bearer cache key's underlying password rotated, even though it is not by
+	# itself proof of a DIFFERENT admin login.
 	principal_change = any(data.get(k) for k in ("api_key", "api_secret", "customer", "customer_password"))
 	if principal_change:
 		admin_client.clear_cached_token()

--- a/jarvis/tests/test_tenant_authority.py
+++ b/jarvis/tests/test_tenant_authority.py
@@ -65,7 +65,18 @@ class TestAuthorityDecide(FrappeTestCase):
 
 # Fields the integration tests mutate; snapshot/restore so a run against a real
 # site (Frappe Singles are not rolled back between tests) is left untouched.
-_FIELDS = ("agent_url", GEN, HANDLE, "last_sync_status")
+_FIELDS = ("agent_url", GEN, HANDLE, "last_sync_status", "jarvis_admin_customer_email")
+
+# Password fields the principal-change tests exercise (write_connection's
+# api_key/api_secret path) alongside agent_token, which the pre-existing tests
+# already wrote. Snapshotted/restored the same way: get_password before, drop
+# the __Auth row and re-set it (or clear it) after.
+_PASSWORD_FIELDS = (
+	"agent_token",
+	"jarvis_admin_api_key",
+	"jarvis_admin_api_secret",
+	"jarvis_admin_customer_password",
+)
 
 
 class _SettingsSnapshotCase(FrappeTestCase):
@@ -76,7 +87,7 @@ class _SettingsSnapshotCase(FrappeTestCase):
 		frappe.cache().delete_keys("jarvis:tenant_authority_invariant")
 		s = frappe.get_single("Jarvis Settings")
 		self._snap = {f: s.get(f) for f in _FIELDS}
-		self._token = s.get_password("agent_token", raise_exception=False) or ""
+		self._passwords = {f: s.get_password(f, raise_exception=False) or "" for f in _PASSWORD_FIELDS}
 
 	def tearDown(self):
 		from jarvis._password_utils import clear_settings_password, set_settings_password
@@ -84,10 +95,11 @@ class _SettingsSnapshotCase(FrappeTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		for f, v in self._snap.items():
 			s.db_set(f, v)
-		if self._token:
-			set_settings_password(s, "agent_token", self._token)
-		else:
-			clear_settings_password(s, "agent_token")
+		for f, v in self._passwords.items():
+			if v:
+				set_settings_password(s, f, v)
+			else:
+				clear_settings_password(s, f)
 		frappe.db.commit()
 
 	def _store(self, agent_url, gen, handle):
@@ -149,6 +161,92 @@ class TestWriteConnectionGuard(_SettingsSnapshotCase):
 		self._store("", 0, "")
 		onboarding.write_connection({"agent_url": "ws://A", "agent_token": "tokA", GEN: 3, HANDLE: "A"})
 		self.assertEqual(self._read(), ("ws://A", 3, "A"))
+
+	def test_new_principal_at_the_old_generation_is_accepted_not_held(self):
+		"""jarvis#693: a stale (generation, handle) left over from a PREVIOUS admin
+		principal must not be compared against a fresh principal's own count. The
+		generation is a per-customer namespace, so a brand-new customer's first
+		claim is always generation 1 - identical to whatever the old customer last
+		held if the bench never got past 1 either. Without clearing on principal
+		change, this lands on the equal-generation/different-handle branch and is
+		HELD forever (the exact bug: pinned to a dead pool container forever,
+		reproduced end to end on 2026-08-05/06). A payload carrying new admin
+		credentials AND a connection in the SAME call (the shape a signup response
+		can take) must still land the new container."""
+		# The OLD principal's accepted connection: generation 1, container A.
+		self._store("ws://A", 1, "A")
+		onboarding.write_connection(
+			{
+				"api_key": "new-key",
+				"api_secret": "new-secret",
+				"customer": "cust-new@jarvis.invalid",
+				"agent_url": "ws://B",
+				"agent_token": "tokB",
+				GEN: 1,  # the NEW customer's own first claim - also generation 1
+				HANDLE: "B",  # a different container than the old principal's
+			}
+		)
+		# Accepted: new principal, new container, new generation namespace - not
+		# held as a divergence against the old principal's leftover state.
+		self.assertEqual(self._read(), ("ws://B", 1, "B"))
+
+	def test_principal_change_alone_clears_the_stored_authority(self):
+		"""Isolate the mechanism: credentials for a new principal arriving WITHOUT
+		a connection in the same call (the plain jarvis.onboarding.signup shape -
+		agent_url is not part of a signup response) must still forget the old
+		principal's (generation, handle), so the connection that follows in a
+		LATER call is judged on its own terms."""
+		self._store("ws://A", 6, "A")
+		onboarding.write_connection({"api_key": "new-key", "api_secret": "new-secret"})
+		_url, gen, handle = self._read()
+		self.assertEqual((gen, handle), (0, ""))
+		# The old connection itself is untouched by a credentials-only call - only
+		# the accepted-authority receipt is forgotten, exactly like tenant_authority
+		# .clear()'s documented contract.
+		self.assertEqual(_url, "ws://A")
+
+	def test_plain_agent_url_sync_does_not_clear_authority(self):
+		"""Regression guard: a call with no new principal (a daily sync_connection
+		poll, or a slow/duplicate connection payload) must NOT clear the accepted
+		authority - only credentials arriving trigger the reset."""
+		self._store("ws://A", 6, "A")
+		onboarding.write_connection({"agent_url": "ws://A", "agent_token": "tokA", GEN: 6, HANDLE: "A"})
+		self.assertEqual(self._read(), ("ws://A", 6, "A"))
+
+	def test_standalone_customer_password_does_not_clear_authority(self):
+		"""A lone customer_password is not proof of a new admin login: admin
+		re-serves it on every poll for up to an hour after minting it
+		(billing/signup.py ``_serve_signup_password``, kept-until-TTL not
+		deleted-on-read), and a fully-connected bench can still hit that poll
+		within the window. Clearing on this field alone would drop the P0-5
+		protection on an otherwise healthy connection for no reason - the real
+		new-principal signal is api_key/api_secret/customer, which always
+		accompanies a GENUINE new login and already trips the clear above."""
+		self._store("ws://A", 6, "A")
+		onboarding.write_connection({"customer_password": "rotated-secret"})
+		self.assertEqual(self._read(), ("ws://A", 6, "A"))
+
+	def test_signup_then_confirm_payment_across_two_calls_lands_the_new_container(self):
+		"""The real shape jarvis#693 reproduced in: credentials and the connection
+		arrive in TWO SEPARATE write_connection calls, not one. ``onboarding.signup``
+		persists the new principal's api_key/customer with no agent_url yet (nothing
+		to connect to before payment); ``finish_payment`` writes agent_url later, in
+		its own call, once admin's confirm_payment returns the container. Between
+		them this bench still held a PREVIOUS principal's (generation, handle) from
+		a prior tenancy that was never reset (an admin-side purge_customer with no
+		matching bench-side reset_onboarding, the documented two-step dev recipe run
+		as one step). The new customer's own first claim is generation 1 - the same
+		number the old principal was already sitting at - so without the clear on
+		the credentials-only call, the confirm_payment call's guard() sees an
+		equal-generation/different-handle divergence and holds forever."""
+		self._store("ws://A", 1, "A")
+		# signup(): new principal, no container yet.
+		onboarding.write_connection(
+			{"api_key": "new-key", "api_secret": "new-secret", "customer": "cust-new@jarvis.invalid"}
+		)
+		# finish_payment(): the connection arrives in its OWN call, later.
+		onboarding.write_connection({"agent_url": "ws://B", "agent_token": "tokB", GEN: 1, HANDLE: "B"})
+		self.assertEqual(self._read(), ("ws://B", 1, "B"))
 
 
 class TestResetClearsAuthority(_SettingsSnapshotCase):


### PR DESCRIPTION
Fixes #693

## Summary

A bench pointed at a different admin customer no longer gets stuck serving the previous
customer's container. Chat stopped queueing forever with nothing shown to the user.

The reported symptom was real and current. The cause was not where the issue placed it:
admin-v2 bumps the authority generation on every write, without exception. The defect is
bench side.

## What changed

- `write_connection` clears the stored tenant-authority receipt when a new admin
  principal's credentials arrive, alongside the bearer cache and chat-ready markers it
  already reset for the same reason.
- Deliberately narrower than the existing `principal_change`: a standalone
  `customer_password` is re-served on every poll and is not proof of a new login, so
  treating it as one would drop the guard on a healthy connection for no gain.

## Risk and verification

- Five tests. Three fail without the fix, including the realistic two-call shape of
  signup followed by finish payment. Two are regression guards that a plain agent URL
  sync and a standalone password do not clear authority.
- Not run locally: the bench serves the main checkout rather than this worktree, and CI
  is the authority for this repo.

<details><summary>Root cause</summary>

The authority generation is a PER CUSTOMER counter, so every fresh customer's first claim
is generation 1.

A bench that held a real connection (generation 1, handle of container A) and is then
pointed at a different admin customer receives generation 1 again, with the handle of
container B. The guard compares two unrelated customers' counters, sees equal generation
with a different handle, and raises `AuthorityInvariantError`. It can never clear,
because a fresh customer's generation cannot numerically exceed the stale leftover.

Verified against the live admin plane: all three writers of `authoritative_tenant` bump
the generation atomically in the same statement, and every promotion path calls one of
them in the same transaction. There is no missing bump.

The known trigger is a one-sided dev reset, an admin-side customer purge without the
matching bench-side reset, which is exactly the recipe `jarvis/dev.py:reset_onboarding`
documents as two steps. The invariant was wrong for any path that hands a bench a new
principal without a reset, not only that one.

Not implemented here, deliberately: the issue also asks to escalate a persistent
equal-generation hold and surface it in the UI instead of showing Queued forever. This
fix removes the only identified trigger for a permanent hold; the escalation work belongs
with the #690 and #691 silent-failure family.

Two admin-v2 hardening items were found and are NOT fixed here, both latent with no known
trigger: `drain.py:_cutover_under_fence` reads `customer` before the fence and can skip
the authority stamp while the promotion writes above it are unconditional, and
`api/tenant.py:_connection_payload` pairs a generation and a handle that are not
guaranteed to describe the same row.

</details>
