### PR TITLE
feat(onboarding): give the verify-email screen a way out

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -419,6 +419,13 @@ export const onboardingPaymentApi = {
 	confirmSignupPayment: (payload, opts) =>
 		rawOnboardingCall("jarvis.onboarding.finish_payment", { payload }, opts),
 	syncConnection: () => call("jarvis.onboarding.sync_connection"),
+	// jarvis#297 P0-2a: "Resend the link". This bench method does not exist yet -
+	// the wizard only ever calls it when the machine's canResendVerification is
+	// true, and admin never sends that flag today, so this stays unreachable in
+	// production. Wired against the endpoint name the fix's report specifies, so
+	// wiring it up is the only step left once both planes ship their half.
+	resendVerification: (opts) =>
+		rawOnboardingCall("jarvis.onboarding.resend_verification_email", {}, opts),
 };
 export const isOnboarded = () => call("jarvis.account.is_onboarded");
 // args: {provider, model, api_key, base_url, auth_mode, force}

--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -137,6 +137,14 @@ export const ACTIONS = {
 	RECONNECT: "reconnect",
 	/** Re-poll after the customer clicks the magic link. */
 	VERIFY: "verify",
+	/**
+	 * Send a fresh verification email to the SAME address (jarvis#297 P0-2a). Never
+	 * listed on a row's static `actions` - like RESUME, its availability is a
+	 * property of the LIVE answer (paymentMachine's `canResendVerification`,
+	 * server-granted and fail-closed), not of the code that happens to be showing.
+	 * See OnboardingView's `verifyActions` for where it is spliced in.
+	 */
+	RESEND: "resend",
 	/** A human. Offered on terminal states and after the client-local check ceiling. */
 	SUPPORT: "support",
 	/** Back to the top of the wizard - nothing exists to recover. */
@@ -172,7 +180,15 @@ const TABLE = {
 		headline: "Verify your email to continue.",
 		body: "Click the link we sent you, then come back here. Nothing is charged until you do.",
 		tone: TONE.STATUS,
-		actions: [ACTIONS.VERIFY],
+		// jarvis#297 P0-2a: a wrong address is a real case (Verify alone dead-ends a
+		// typo) and RESEND, the mail-amplifier risk, is capability-gated at the view
+		// instead of listed here (see ACTIONS.RESEND). RESTART is safe on this code
+		// by construction - see paymentMachine's RESTART_SAFE_CODES comment - and
+		// walks the customer back to Details with their typed values still in
+		// place, so "Start again" would undersell it: nothing is being restarted,
+		// one field needs correcting.
+		actions: [ACTIONS.VERIFY, ACTIONS.RESTART],
+		actionLabels: { [ACTIONS.RESTART]: "Use a different email" },
 	},
 	[CODES.PAYMENT_CONFIRMATION_PENDING]: {
 		// A WAIT state, same treatment as PAYMENT_AUTHORIZED_PENDING_CONFIRM below
@@ -437,6 +453,10 @@ export const ACTION_LABELS = {
 	[ACTIONS.CONTINUE]: "Continue",
 	[ACTIONS.RECONNECT]: "Reconnect this site",
 	[ACTIONS.VERIFY]: "I've verified my email",
+	// The countdown variant ("Resend in Ns") is rendered separately in
+	// OnboardingView's resendLabel, the same way checkLabel overrides this one
+	// for ACTIONS.CHECK.
+	[ACTIONS.RESEND]: "Resend the link",
 	[ACTIONS.SUPPORT]: "Contact support",
 	[ACTIONS.RESTART]: "Start again",
 };

--- a/frontend/src/onboarding/paymentCodes.test.js
+++ b/frontend/src/onboarding/paymentCodes.test.js
@@ -256,3 +256,24 @@ test("nothing is claimed when there is no honest number to give", () => {
 		assert.equal(payLinkDeadlineNote(bad), "", `expected "" for ${String(bad)}`);
 	}
 });
+
+// ---------------------------------------------------------------------------
+// jarvis#297 P0-2a: the email-verification dead end.
+// ---------------------------------------------------------------------------
+test("verification offers a way past a mistyped address, not just VERIFY", () => {
+	const entry = copyFor(CODES.SIGNUP_VERIFICATION_REQUIRED);
+	assert.ok(entry.actions.includes(ACTIONS.VERIFY));
+	assert.ok(entry.actions.includes(ACTIONS.RESTART));
+	assert.equal(actionLabelFor(entry, ACTIONS.RESTART), "Use a different email");
+	// "Start again" would undersell it - nothing else about the signup is being
+	// restarted, only the address.
+	assert.notEqual(actionLabelFor(entry, ACTIONS.RESTART), "Start again");
+});
+
+test("RESEND is never baked into the verification row either: it is a granted capability", () => {
+	// Same reasoning paymentCodes.test.js already asserts for RESUME (above): the
+	// view splices it in only once paymentMachine's canResendVerification says
+	// the server actually granted it, never listed statically here.
+	assert.ok(!copyFor(CODES.SIGNUP_VERIFICATION_REQUIRED).actions.includes(ACTIONS.RESEND));
+	assert.equal(actionLabelFor({}, ACTIONS.RESEND), "Resend the link");
+});

--- a/frontend/src/onboarding/paymentMachine.js
+++ b/frontend/src/onboarding/paymentMachine.js
@@ -81,6 +81,13 @@ export const EVENTS = {
 };
 
 const DEFAULT_COOLDOWN_MS = 30_000;
+// jarvis#297 P0-2a: the client-side cooldown after a successful "Resend the
+// link" send. Self-imposed, not server-driven - unlike DEFAULT_COOLDOWN_MS
+// (which only ever fires from a coded 429), this starts on every send that
+// actually went out, so an impatient customer cannot fire a burst of mail
+// while the first one is still landing. A future server-side rate limit is
+// additive, not a replacement for this.
+const RESEND_COOLDOWN_MS = 30_000;
 
 // States the page must never show a payment action in, because payment is
 // either done or cannot be driven forward from here.
@@ -123,6 +130,15 @@ const RESTART_SAFE_CODES = new Set([
 	// behind it, so walking the customer back to the Details step to correct the
 	// offending field is provably safe and is the ONLY useful recovery.
 	CODES.BENCH_SIGNUP_DETAILS_REJECTED,
+	// jarvis#297 P0-2a: verification precedes payment by construction - admin's
+	// signup() mints no order/mandate on this path ("No Razorpay order yet - that
+	// gets created at confirm time"), so nothing recoverable can be sitting behind
+	// it either. "Start again" (labelled "Use a different email" for this code,
+	// see paymentCodes.js) walks the customer back to Details with their typed
+	// values still in place, so a mistyped address is one field-edit and a fresh
+	// signup away instead of a dead end. The abandoned Pending Verification row is
+	// reclaimed server-side by reap_stale_pending_signups after the token TTL.
+	CODES.SIGNUP_VERIFICATION_REQUIRED,
 ]);
 
 export function isTerminalForPayment(value) {
@@ -165,6 +181,17 @@ export function initialState() {
 		summary: null,
 		lastCheckedAt: null,
 		verificationExpiresAt: null,
+		// jarvis#297 P0-2a: "Resend the link" is a mutating mail-send, not a read
+		// like Check, so unlike _backendCanCheck it fails CLOSED - the button never
+		// renders until an answer explicitly grants it. Admin does not send this
+		// flag today (see usePaymentFlow.resendVerification), so it stays false and
+		// the affordance stays hidden until the control plane ships its half.
+		canResendVerification: false,
+		// The self-imposed post-send cooldown (see RESEND_COOLDOWN_MS). Set by
+		// noteVerificationResent, read live against the clock - no reducer event
+		// is needed to lift it, the same way the countdown label itself just reads
+		// the clock.
+		resendCooldownUntil: 0,
 		canInitiate: false,
 		canCheck: false,
 		canReconnect: false,
@@ -668,6 +695,12 @@ function applyContract(state, decoded, opts) {
 	next.canInitiate =
 		backendCanInitiate && !next.awaitingReconciliation && !isTerminalForPayment(next.value);
 	next.canCheck = recomputeCanCheck(next, opts.nowMs);
+	// jarvis#297 P0-2a: fail CLOSED, unlike _backendCanCheck's fail-open default -
+	// resend is a mutating mail-send, not a read, so an admin that says nothing
+	// must not be read as permission. Recomputed fresh from THIS answer every
+	// time (not sticky like canReconnect): a capability that stops being repeated
+	// is a capability that stopped being true.
+	next.canResendVerification = !!data.can_resend_verification;
 
 	return next;
 }
@@ -675,6 +708,14 @@ function applyContract(state, decoded, opts) {
 /** Seconds left on the check cooldown, rounded UP, never negative. */
 export function remainingCooldownSeconds(state, nowMs) {
 	const left = (state.checkCooldownUntil || 0) - nowMs;
+	if (left <= 0) return 0;
+	return Math.ceil(left / 1000);
+}
+
+/** Seconds left on the post-resend cooldown (jarvis#297 P0-2a), same shape as
+ * remainingCooldownSeconds - rounded UP, never negative. */
+export function remainingResendCooldownSeconds(state, nowMs) {
+	const left = (state.resendCooldownUntil || 0) - nowMs;
 	if (left <= 0) return 0;
 	return Math.ceil(left / 1000);
 }
@@ -690,4 +731,16 @@ export function noteStatusCheck(state) {
 		generation: state.generation,
 	});
 	return { ...state, supportChecks: counter, supportOffered: shouldOfferSupport(counter) };
+}
+
+/**
+ * Record that "Resend the link" actually sent one (jarvis#297 P0-2a): starts
+ * the client-side cooldown so a second click cannot fire before the first
+ * mail has had a chance to land. Called only when the answer that came back
+ * from the resend round trip was itself a fresh SIGNUP_VERIFICATION_REQUIRED
+ * - usePaymentFlow.resendVerification decides that, this just records it, the
+ * same division of labour as noteStatusCheck/checkStatus.
+ */
+export function noteVerificationResent(state, nowMs) {
+	return { ...state, resendCooldownUntil: nowMs + RESEND_COOLDOWN_MS };
 }

--- a/frontend/src/onboarding/paymentMachine.test.js
+++ b/frontend/src/onboarding/paymentMachine.test.js
@@ -27,6 +27,8 @@ import {
 	isTerminalForPayment,
 	provisioningOwner,
 	remainingCooldownSeconds,
+	remainingResendCooldownSeconds,
+	noteVerificationResent,
 } from "./paymentMachine.js";
 
 const ORIGIN = "https://fleet.klerk.in";
@@ -746,4 +748,65 @@ test("a later answer without a token clears the earlier countdown", () => {
 	const after = reduce(live, at(CODES.PAYMENT_CONFIRMATION_PENDING, {}));
 	assert.equal(after.payPageToken, "");
 	assert.equal(after.payTokenExpiresInS, null);
+});
+
+// ---------------------------------------------------------------------------
+// jarvis#297 P0-2a: the email-verification dead end - restart-to-change-email
+// and the resend capability flag/cooldown.
+// ---------------------------------------------------------------------------
+test("SIGNUP_VERIFICATION_REQUIRED is restart-safe (no gateway object exists yet)", () => {
+	const s = reduce(
+		initialState(),
+		at(CODES.SIGNUP_VERIFICATION_REQUIRED, { pending_verification: true })
+	);
+	assert.equal(s.value, STATES.VERIFICATION_REQUIRED);
+	assert.equal(canSafelyRestart(s), true);
+	const after = reduce(s, { type: EVENTS.RESTART });
+	assert.equal(after.value, STATES.REVIEW);
+	assert.equal(after.code, "");
+});
+
+test("canResendVerification defaults closed and only opens when the answer grants it", () => {
+	const closed = reduce(
+		initialState(),
+		at(CODES.SIGNUP_VERIFICATION_REQUIRED, { pending_verification: true })
+	);
+	assert.equal(closed.canResendVerification, false);
+	const open = reduce(
+		initialState(),
+		at(CODES.SIGNUP_VERIFICATION_REQUIRED, {
+			pending_verification: true,
+			can_resend_verification: true,
+		})
+	);
+	assert.equal(open.canResendVerification, true);
+});
+
+test("canResendVerification is re-read fresh, never sticky", () => {
+	// Unlike canReconnect (which latches once true), a capability that stops
+	// being repeated must read as false again - the fail-closed default binds on
+	// every answer, not just the first.
+	const first = reduce(
+		initialState(),
+		at(CODES.SIGNUP_VERIFICATION_REQUIRED, {
+			pending_verification: true,
+			can_resend_verification: true,
+		})
+	);
+	assert.equal(first.canResendVerification, true);
+	const second = reduce(
+		first,
+		at(CODES.SIGNUP_VERIFICATION_REQUIRED, { pending_verification: true })
+	);
+	assert.equal(second.canResendVerification, false);
+});
+
+test("noteVerificationResent starts a client-side cooldown read by remainingResendCooldownSeconds", () => {
+	const s = initialState();
+	assert.equal(remainingResendCooldownSeconds(s, 1_000_000), 0);
+	const resent = noteVerificationResent(s, 1_000_000);
+	assert.equal(remainingResendCooldownSeconds(resent, 1_000_000), 30);
+	assert.equal(remainingResendCooldownSeconds(resent, 1_015_000), 15);
+	assert.equal(remainingResendCooldownSeconds(resent, 1_030_000), 0);
+	assert.equal(remainingResendCooldownSeconds(resent, 1_999_999), 0);
 });

--- a/frontend/src/onboarding/usePaymentFlow.js
+++ b/frontend/src/onboarding/usePaymentFlow.js
@@ -50,6 +50,7 @@ import {
 	payPageUrl,
 	reduce,
 	noteStatusCheck,
+	noteVerificationResent,
 	isTerminalForPayment,
 } from "./paymentMachine.js";
 import { counterKey, shouldOfferSupport } from "./supportHandoff.js";
@@ -368,6 +369,50 @@ export function createPaymentFlow(deps) {
 		}
 	}
 
+	// ---- "Resend the link" (jarvis#297 P0-2a) -------------------------------
+	// Currently unreachable in production: the view only renders the button when
+	// the machine's canResendVerification is true, and admin never sends
+	// can_resend_verification today (see paymentCodes.js / paymentMachine.js
+	// comments). Built against the endpoint the control plane still needs to
+	// ship - see api.js's onboardingPaymentApi.resendVerification - so the wiring
+	// is already correct the day it exists and does nothing but time out
+	// (routed through the SAME offline/failure handling as every other call)
+	// until then. Takes the ONE action lock like its siblings, so a resend
+	// cannot race a verify/check/initiate.
+	async function resendVerification() {
+		const my = beginAction("resending");
+		if (!my) return { sent: false }; // an incompatible action already holds the lock
+		try {
+			let decoded;
+			try {
+				decoded = ingest(
+					await deadlined(
+						(signal) => api.resendVerification({ signal }),
+						fetchDeadlineMs,
+						"resend"
+					)
+				);
+			} catch (e) {
+				if (my !== token) return { sent: false };
+				absorb(offlineDecoded());
+				return { sent: false };
+			}
+			if (my !== token) return { sent: false };
+			const code = absorb(decoded);
+			// Only a genuine re-arm of THIS screen counts as a send: a failure, a
+			// rate limit, or an answer that moved the machine elsewhere (verified
+			// out from under the resend, a terminal code) starts no cooldown and
+			// claims nothing sent.
+			if (decoded.ok && code === CODES.SIGNUP_VERIFICATION_REQUIRED) {
+				state.value = noteVerificationResent(state.value, now());
+				return { sent: true };
+			}
+			return { sent: false };
+		} finally {
+			endAction(my);
+		}
+	}
+
 	// ---- submit review: start the signup exactly once ----------------------
 	async function submitReview({ email, company, plan, provider, billing } = {}) {
 		const my = beginAction(null); // SUBMIT_REVIEW sets the busy flag itself
@@ -626,6 +671,7 @@ export function createPaymentFlow(deps) {
 		state,
 		hydrate,
 		verifyAndContinue,
+		resendVerification,
 		submitReview,
 		initiatePayment,
 		checkStatus,

--- a/frontend/src/onboarding/usePaymentFlow.spec.js
+++ b/frontend/src/onboarding/usePaymentFlow.spec.js
@@ -274,6 +274,118 @@ describe("verification continues in one round trip", () => {
 });
 
 // ---------------------------------------------------------------------------
+// jarvis#297 P0-2a: the email-verification dead end - resend + change email.
+// ---------------------------------------------------------------------------
+describe("resend the verification link", () => {
+	test("a successful resend reports {sent:true} and starts the cooldown", async () => {
+		const api = makeApi({
+			resendVerification: vi.fn(async () =>
+				ENVELOPE({
+					code: CODES.SIGNUP_VERIFICATION_REQUIRED,
+					pending_verification: true,
+					attempt_id: "att_1",
+					generation: 0,
+					can_resend_verification: true,
+				})
+			),
+		});
+		const { flow } = makeFlow({ api, now: () => 1_000_000 });
+		const out = await flow.resendVerification();
+		expect(out).toEqual({ sent: true });
+		expect(flow.state.value.resendCooldownUntil).toBe(1_030_000);
+		expect(flow.state.value.value).toBe(STATES.VERIFICATION_REQUIRED);
+	});
+
+	test("a failed resend reports {sent:false} and starts no cooldown", async () => {
+		const api = makeApi({
+			resendVerification: vi.fn(async () => ({ status: 0, body: null, networkError: true })),
+		});
+		const { flow } = makeFlow({ api });
+		const out = await flow.resendVerification();
+		expect(out).toEqual({ sent: false });
+		expect(flow.state.value.resendCooldownUntil).toBe(0);
+	});
+
+	test("the resend button guards its own round trip (a triple-click is one call)", async () => {
+		const api = makeApi({
+			resendVerification: vi.fn(async () =>
+				ENVELOPE({ code: CODES.SIGNUP_VERIFICATION_REQUIRED, pending_verification: true })
+			),
+		});
+		const { flow } = makeFlow({ api });
+		await Promise.all([
+			flow.resendVerification(),
+			flow.resendVerification(),
+			flow.resendVerification(),
+		]);
+		expect(api.resendVerification).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+describe("change the email address and restart verification (jarvis#297 P0-2a)", () => {
+	test("restart from VERIFICATION_REQUIRED, then a fresh submit with the corrected address re-requests verification", async () => {
+		const api = makeApi({
+			startSignup: vi.fn(async () =>
+				ENVELOPE({
+					code: CODES.SIGNUP_VERIFICATION_REQUIRED,
+					pending_verification: true,
+					attempt_id: "att_typo",
+					generation: 0,
+					email: "typo@exmaple.com",
+				})
+			),
+		});
+		const { flow } = makeFlow({ api });
+		await flow.submitReview({ email: "typo@exmaple.com", company: "Acme", plan: "pro" });
+		expect(flow.state.value.value).toBe(STATES.VERIFICATION_REQUIRED);
+
+		// "Use a different email": restart is safe here (canSafelyRestart) because
+		// no gateway object exists yet on this code - the reset lands back on a
+		// fresh review, exactly like any other restart-safe code.
+		const { reset } = flow.restart();
+		expect(reset).toBe(true);
+		expect(flow.state.value.value).toBe(STATES.REVIEW);
+
+		// The corrected address is a DIFFERENT (email, company) pair from admin's
+		// point of view, so it is a fresh signup, not the duplicate-resume path -
+		// it lands on its own new VERIFICATION_REQUIRED, not a re-serve of the
+		// old attempt.
+		api.startSignup.mockResolvedValueOnce(
+			ENVELOPE({
+				code: CODES.SIGNUP_VERIFICATION_REQUIRED,
+				pending_verification: true,
+				attempt_id: "att_fixed",
+				generation: 0,
+				email: "real@example.com",
+			})
+		);
+		await flow.submitReview({ email: "real@example.com", company: "Acme", plan: "pro" });
+		expect(flow.state.value.value).toBe(STATES.VERIFICATION_REQUIRED);
+		expect(flow.state.value.summary.email).toBe("real@example.com");
+		expect(api.startSignup).toHaveBeenCalledTimes(2);
+	});
+
+	test("restart is refused while a real payment could still be behind the code", async () => {
+		const api = makeApi({
+			checkSignupPaymentStatus: vi.fn(async () =>
+				ENVELOPE({
+					code: CODES.PAYMENT_CONFIRMATION_PENDING,
+					attempt_id: "att_1",
+					generation: 1,
+				})
+			),
+		});
+		const { flow } = makeFlow({ api });
+		await flow.checkStatus();
+		expect(flow.state.value.value).toBe(STATES.UNKNOWN);
+		const { reset } = flow.restart();
+		expect(reset).toBe(false);
+		expect(flow.state.value.value).toBe(STATES.UNKNOWN);
+	});
+});
+
+// ---------------------------------------------------------------------------
 describe("the machine decides what navigates", () => {
 	test("a GENERATION-FENCED answer navigates nothing (the reducer refused it)", async () => {
 		// Seed a live intent at generation 5.

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -39,6 +39,7 @@ const api = vi.hoisted(() => ({
 		),
 		confirmSignupPayment: vi.fn(),
 		syncConnection: vi.fn(async () => ({ synced: false })),
+		resendVerification: vi.fn(),
 	},
 }));
 vi.mock("@/api", () => api);
@@ -232,5 +233,122 @@ describe("X8: a refused restart explains itself instead of a silent no-op", () =
 		await wrapper.vm.flow.checkStatus();
 		await flushPromises();
 		expect(wrapper.vm.restartHeldNote).toBe("");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// jarvis#297 P0-2a: the email-verification dead end - resend + change email.
+// ---------------------------------------------------------------------------
+describe("jarvis#297 P0-2a: verification is no longer a dead end", () => {
+	async function mountOnVerify(overrides = {}) {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_1",
+				generation: 0,
+				email: "typo@exmaple.com",
+				...overrides,
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
+		return wrapper;
+	}
+
+	it("RESEND is absent until the server grants can_resend_verification", async () => {
+		const wrapper = await mountOnVerify();
+		expect(wrapper.vm.verifyActions).toEqual([ACTIONS.VERIFY, ACTIONS.RESTART]);
+		expect(wrapper.vm.pay.canResendVerification).toBe(false);
+	});
+
+	it("RESEND appears once granted, sends, then disables itself for the cooldown", async () => {
+		const wrapper = await mountOnVerify({ can_resend_verification: true });
+		expect(wrapper.vm.verifyActions).toEqual([
+			ACTIONS.VERIFY,
+			ACTIONS.RESEND,
+			ACTIONS.RESTART,
+		]);
+		expect(wrapper.vm.payActionDisabled(ACTIONS.RESEND)).toBe(false);
+
+		api.onboardingPaymentApi.resendVerification.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_1",
+				generation: 0,
+				can_resend_verification: true,
+			})
+		);
+		await wrapper.vm.onPayAction(ACTIONS.RESEND);
+		await flushPromises();
+
+		expect(api.onboardingPaymentApi.resendVerification).toHaveBeenCalledTimes(1);
+		// Truthful confirmation, and the button cannot be spammed while it cools.
+		expect(wrapper.vm.resendNote).toBe("We sent a new link to typo@exmaple.com.");
+		expect(wrapper.vm.payActionDisabled(ACTIONS.RESEND)).toBe(true);
+	});
+
+	it("a failed resend claims nothing sent and starts no cooldown", async () => {
+		const wrapper = await mountOnVerify({ can_resend_verification: true });
+		api.onboardingPaymentApi.resendVerification.mockResolvedValue({
+			status: 0,
+			body: null,
+			networkError: true,
+		});
+		await wrapper.vm.onPayAction(ACTIONS.RESEND);
+		await flushPromises();
+
+		expect(wrapper.vm.resendNote).toBe("");
+		expect(wrapper.vm.payActionDisabled(ACTIONS.RESEND)).toBe(false);
+	});
+
+	it("'Use a different email' walks back to Details, ready to re-request verification", async () => {
+		const wrapper = await mountOnVerify();
+		expect(wrapper.vm.payActionLabel(ACTIONS.RESTART)).toBe("Use a different email");
+		await wrapper.vm.onPayAction(ACTIONS.RESTART);
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.state.step).toBe("details");
+		// The mistyped address the customer typed is still there to correct, not
+		// wiped along with the machine.
+		expect(wrapper.vm.state.email).toBe("typo@exmaple.com");
+
+		// Re-submitting a corrected address re-requests verification exactly like
+		// the first attempt did - the existing signup path, unchanged.
+		api.onboardingPaymentApi.startSignup.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_fixed",
+				generation: 0,
+				email: "real@example.com",
+			})
+		);
+		wrapper.vm.state.email = "real@example.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.planName = "pro";
+		await wrapper.vm.flow.submitReview({
+			email: "real@example.com",
+			company: "Acme",
+			plan: "pro",
+		});
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
+	});
+
+	it("VERIFY still works unchanged", async () => {
+		const wrapper = await mountOnVerify();
+		expect(wrapper.vm.payActionLabel(ACTIONS.VERIFY)).toBe("I've verified my email");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "SIGNUP_VERIFICATION_REQUIRED", pending_verification: true })
+		);
+		await wrapper.vm.onPayAction(ACTIONS.VERIFY);
+		await flushPromises();
+		// verifyAndContinue re-reads state exactly as it did before this change.
+		expect(api.onboardingPaymentApi.getOnboardingState).toHaveBeenCalled();
+		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
 	});
 });

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -711,16 +711,29 @@
 										><template v-else>The link expires in 24 hours. </template
 										>Check your spam folder if it doesn't arrive.
 									</p>
+									<!-- jarvis#297 P0-2a: a truthful confirmation for "Resend the
+										 link" - stays up until the customer leaves this screen. -->
+									<p
+										v-if="resendNote"
+										class="mt-1.5 text-center text-p-sm text-ink-gray-5"
+										role="status"
+									>
+										{{ resendNote }}
+									</p>
 								</div>
 								<div class="ob-foot justify-end">
-									<Button
-										variant="solid"
-										:disabled="verifying"
-										:loading="verifying || payBusyView"
-										loading-text="Working…"
-										label="I've verified my email"
-										@click="onPayAction(A.VERIFY)"
-									/>
+									<div class="flex items-center gap-2">
+										<Button
+											v-for="a in verifyActions"
+											:key="a"
+											:variant="payActionVariant(a, verifyActions)"
+											:disabled="payActionDisabled(a)"
+											:loading="payActionLoading(a)"
+											loading-text="Working…"
+											:label="payActionLabel(a)"
+											@click="onPayAction(a)"
+										/>
+									</div>
 								</div>
 							</template>
 							<!-- Confirming: the customer paid on the admin-hosted page and came
@@ -1609,6 +1622,7 @@ import {
 	STATES as PAY_STATES,
 	canNavigateToPay,
 	remainingCooldownSeconds,
+	remainingResendCooldownSeconds,
 	isTerminalForPayment,
 } from "@/onboarding/paymentMachine";
 import {
@@ -2550,6 +2564,10 @@ const initiating = computed(() => pay.value.busy === "initiating");
 // triple-click stacked three gateway sheets. The flow holds the same in-flight
 // guard its siblings do; this is the half the customer can see.
 const verifying = computed(() => pay.value.busy === "verifying");
+// jarvis#297 P0-2a: "Resend the link" takes the SAME one-action lock as verify/
+// check/initiate, so this and verifying can never both be true at once - see
+// payActionDisabled, which disables every button on the card while either is.
+const resending = computed(() => pay.value.busy === "resending");
 // The payment-confirming window: the customer paid on the admin-hosted page,
 // came back, and the bench is asking the control plane whether that payment
 // landed. It is the one moment where money has genuinely left them and no
@@ -2635,6 +2653,17 @@ const checkLabel = computed(() =>
 		: ACTION_LABELS[ACTIONS.CHECK]
 );
 
+// jarvis#297 P0-2a: the post-resend cooldown, same live-clock shape as
+// checkCountdown/checkLabel above - no reducer round trip needed to lift it,
+// the SAME 1s ticker (active whenever state.step === "pay", which covers the
+// verify screen) already recomputes this every tick.
+const resendCountdown = computed(() => remainingResendCooldownSeconds(pay.value, nowMs.value));
+const resendLabel = computed(() =>
+	resendCountdown.value > 0
+		? `Resend in ${resendCountdown.value}s`
+		: ACTION_LABELS[ACTIONS.RESEND]
+);
+
 // The action buttons for the recovery card, in the table's order (status-first).
 // The support affordance is appended when the client-local check ceiling is hit
 // even if the code's own actions don't list it (a pending payment the customer
@@ -2674,6 +2703,21 @@ const recoveryActions = computed(() => {
 		else acts.unshift(ACTIONS.RESUME);
 	}
 	if (pay.value.supportOffered && !acts.includes(ACTIONS.SUPPORT)) acts.push(ACTIONS.SUPPORT);
+	return acts;
+});
+
+// jarvis#297 P0-2a: the verify screen's own action row. VERIFY (from the TABLE
+// row) stays first/solid, unchanged. RESEND is spliced in - never listed
+// statically, same reasoning as RESUME above - only once the machine's
+// canResendVerification says the server actually granted it (fail-closed;
+// see paymentMachine.js). RESTART (labelled "Use a different email" for this
+// code) is always last: it is the one action VERIFY and RESEND can never
+// substitute for.
+const verifyActions = computed(() => {
+	const acts = [...payCopy.value.actions]; // [VERIFY, RESTART]
+	if (pay.value.canResendVerification && !acts.includes(ACTIONS.RESEND)) {
+		acts.splice(1, 0, ACTIONS.RESEND);
+	}
 	return acts;
 });
 
@@ -2720,6 +2764,20 @@ async function runStatusCheck() {
 		// button that appears to do nothing at all.
 		statusCheckNote.value = "We checked just now, and nothing has changed yet.";
 	}
+}
+
+// ---- "Resend the link" (jarvis#297 P0-2a) -----------------------------------
+// A truthful confirmation line, not a toast that could be missed off-screen -
+// same reasoning as statusCheckNote above. Only says "sent" when the flow
+// itself judged the answer a real send (flow.resendVerification's {sent}); a
+// failed or rate-limited attempt says nothing rather than claim one, which is
+// the whole point of building this against a real capability flag instead of
+// a button that always claims success.
+const resendNote = ref("");
+async function runResendVerification() {
+	resendNote.value = "";
+	const { sent } = await flow.resendVerification();
+	resendNote.value = sent ? `We sent a new link to ${payEmail.value}.` : "";
 }
 
 // ---- Contact support: an actual ticket, not a mailto -----------------------
@@ -2807,18 +2865,23 @@ async function sendSupport() {
 
 function payActionLabel(a) {
 	if (a === ACTIONS.CHECK) return checkLabel.value;
+	// The countdown wins the same way checkLabel's does above (jarvis#297 P0-2a).
+	if (a === ACTIONS.RESEND) return resendLabel.value;
 	// actionLabelFor lets a row override a label whose shared wording would mislead
 	// in its own context - "Start again" on a details rejection, where the only
-	// thing being started again is one corrected field.
+	// thing being started again is one corrected field; "Use a different email" on
+	// the verify screen, where nothing else is being restarted either.
 	return actionLabelFor(payCopy.value, a);
 }
 function payActionDisabled(a) {
-	// Any mutating call in flight disables BOTH recovery actions (plan 02: server
-	// idempotency, not button state, is what prevents duplicate intents - but a
-	// double-click should still not fire twice). A status check disables itself
-	// and the retry, so an impatient customer cannot stack concurrent
-	// provider-truth calls into the rate limit.
-	if (checking.value || initiating.value) return true;
+	// Any mutating/checking call in flight disables every action on the CURRENT
+	// card (plan 02: server idempotency, not button state, is what prevents
+	// duplicate intents/mails - but a double-click should still not fire twice).
+	// A status check disables itself and the retry, so an impatient customer
+	// cannot stack concurrent provider-truth calls into the rate limit; verify
+	// and resend take the SAME one action lock (usePaymentFlow.beginAction), so
+	// they disable the same way (jarvis#297 P0-2a).
+	if (checking.value || initiating.value || verifying.value || resending.value) return true;
 	if (a === ACTIONS.CHECK) return !pay.value.canCheck;
 	if (a === ACTIONS.INITIATE) return !pay.value.canInitiate;
 	// RESUME is gated on the machine alone, never on a backend capability flag:
@@ -2832,20 +2895,32 @@ function payActionDisabled(a) {
 	if (a === ACTIONS.RECONNECT) {
 		return !reconnectIdentity.value.email || !reconnectIdentity.value.company;
 	}
+	// RESEND is capability-gated (fail closed, so this only matters once the
+	// backend starts granting it - verifyActions already hides the button
+	// otherwise) AND cooled down client-side after a send, so the button cannot
+	// be spammed into a burst of mail while the first one is still landing.
+	if (a === ACTIONS.RESEND) {
+		return !pay.value.canResendVerification || resendCountdown.value > 0;
+	}
 	return false;
 }
 function payActionLoading(a) {
 	if (a === ACTIONS.CHECK) return checking.value;
 	if (a === ACTIONS.INITIATE) return initiating.value;
+	if (a === ACTIONS.VERIFY) return verifying.value;
+	if (a === ACTIONS.RESEND) return resending.value;
 	return false;
 }
-function payActionVariant(a) {
+// `list` defaults to the recovery card's own actions; the verify screen passes
+// its own verifyActions so VERIFY (always first there) is the one rendered
+// solid, the same "whichever appears first is primary" rule (jarvis#297 P0-2a).
+function payActionVariant(a, list = recoveryActions.value) {
 	// Status-first: the primary (solid) action is whichever appears first, which
 	// the copy table already orders as Check where double-payment is possible.
 	// RESUME is unshifted to the front when it applies, so it becomes primary on
 	// exactly the screens where going back to the existing checkout is the cheapest
 	// and safest thing the customer can do.
-	return recoveryActions.value[0] === a ? "solid" : "subtle";
+	return list[0] === a ? "solid" : "subtle";
 }
 async function onPayAction(a) {
 	if (a === ACTIONS.CHECK) return runStatusCheck();
@@ -2870,6 +2945,7 @@ async function onPayAction(a) {
 	}
 	if (a === ACTIONS.RECONNECT) return startReconnect();
 	if (a === ACTIONS.VERIFY) return flow.verifyAndContinue();
+	if (a === ACTIONS.RESEND) return runResendVerification();
 	if (a === ACTIONS.SUPPORT) return openSupport();
 	if (a === ACTIONS.RESTART) {
 		// A details rejection is not a restart in any meaningful sense: admin named a
@@ -2879,6 +2955,21 @@ async function onPayAction(a) {
 		// like the wizard threw their progress away for no reason.
 		if (pay.value.code === CODES.BENCH_SIGNUP_DETAILS_REJECTED) {
 			state.detailsErr = pay.value.message || payCopy.value.body;
+		}
+		// jarvis#297 P0-2a: "Use a different email" on a signup this session TYPED
+		// through Details already has state.email/company live in memory, but a
+		// customer who RELOADED mid-verification (the exact dead end the issue
+		// names) has none - only the machine's summary carries server truth, and
+		// restart() below is about to wipe it. Copy it across first, and only into
+		// a field the customer has not already typed something else into (never
+		// clobber a live edit, same rule prefillAccount uses).
+		if (pay.value.code === CODES.SIGNUP_VERIFICATION_REQUIRED) {
+			const summary = pay.value.summary || {};
+			if (summary.email && !state.email.trim()) {
+				state.email = summary.email;
+				state.identityFromUser = true;
+			}
+			if (summary.company && !state.company.trim()) state.company = summary.company;
 		}
 		// Server-truth-gated reset (P1-3): the flow resets the machine only when no
 		// recoverable payment can be behind the current code, otherwise it preserves
@@ -2917,8 +3008,12 @@ watch(
 	() => pay.value.value,
 	async () => {
 		// A state change means the machine moved on: drop the stale "we're keeping you
-		// here" note so it never lingers past the state it explained (X8).
+		// here" note so it never lingers past the state it explained (X8), and the
+		// same for the resend confirmation (jarvis#297 P0-2a) - it stays up while
+		// the customer remains on THIS verify screen and disappears once they leave
+		// it (verified, or restarted onto a fresh one).
 		restartHeldNote.value = "";
+		resendNote.value = "";
 		if (!showRecovery.value && !showVerify.value) return;
 		await nextTick();
 		const el = recoveryHeading.value;


### PR DESCRIPTION
Part of #297 (the P0-2 email dead end only)

## Summary

A customer who mistypes their signup email can now recover. The verify screen offered a
single "I've verified my email" button and a link that would never arrive, so the only
move was to abandon signup.

## What changed

- **Use a different email** resets the payment machine to REVIEW and routes back to
  Details with the address pre-filled. No backend change needed: a corrected address is a
  new (email, company) pair, so `start_signup` mints a fresh token and sends real mail.
- Pre-fills from the signup summary after a mid-verification reload, which previously
  landed the customer on a blank form.
- **Resend is wired but deliberately unreachable.** It is gated on a new
  `can_resend_verification` flag that fails closed and that admin does not send today, so
  the button never appears rather than claiming to send mail that never went.

## Risk and verification

- 673 node tests and 939 vitest tests pass on Node 24. Ambient Node here is 26, which
  fails with an unrelated localStorage error, so CI's pinned 24 is the real signal.
- The existing verify action is unchanged and covered by a regression test.

## Backend still required for resend

No resend endpoint exists on either plane, and that absence is intentional: see
`_verification_expiry`'s note about not turning the retry button into a mail amplifier.
Three pieces are needed.

1. `jarvis_admin_v2.billing.signup.resend_verification_email`, authenticated with the
   signup-minted key and secret, valid only while the subscription is Pending
   Verification, minting a fresh token and invalidating the old one so a single link is
   live, server-side rate limited.
2. `can_resend_verification` riding every envelope that lands on
   `SIGNUP_VERIFICATION_REQUIRED`. To throttle, answer `false` in the ordinary envelope
   rather than a coded 429: the frontend's rate-limit branch returns early and would
   leave a stale `true` with no visible cooldown.
3. `jarvis.onboarding.resend_verification_email`, a thin pass-through. `api.js` already
   calls this name.

<details><summary>Reviewer note</summary>

Restart safety: `SIGNUP_VERIFICATION_REQUIRED` was added to `RESTART_SAFE_CODES`. Safe by
construction, no gateway object exists on this code.

Worth a second opinion: the restart path marks `identityFromUser = true` when copying
`summary.email` into the local field. P1-7 exists to stop a resumed other account's
screen leaking the site admin's email into an editable identity field.
`SIGNUP_VERIFICATION_REQUIRED` only exists for a signup this browser itself started, so
this reads as safe, but that rule is enforced carefully elsewhere.

</details>
