### PR TITLE
fix(chat): streaming render, typed card approval, duplicate notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,18 @@ jobs:
         # for `node --test`, so this is inherently a one-shot gate.
         run: npm run test:node
 
+      - name: node:test (Desk widget + PWA lib)
+        env:
+          NODE_OPTIONS: --unhandled-rejections=strict
+        # These two suites are plain node:test with only sibling-module imports (no npm deps),
+        # so they run from the repo root with bare node - no `npm ci` needed. They were run by
+        # NOTHING in CI before, which is exactly how a Desk-widget confirmation-card ordering
+        # bug (a dropped field that renumbered a typed "confirm N" onto the wrong ERP write)
+        # shipped under a green build. Gate them here.
+        run: |
+          node --test jarvis/public/js/jarvis_chat/widget/*.test.mjs
+          node --test pwa/src/lib/*.test.js
+
   # The frontend-tests job above runs the SPA's *tests* but never *builds* it — so a Vite/build break
   # would slip through green and only surface at Frappe Cloud deploy time as a 404 on /jarvis. This gate
   # builds the SPA (the /jarvis artifact) the way the deploy does. (The PWA build resolves the bench site

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -205,13 +205,19 @@ export const dismissTool = (token, conversation) =>
 export const listPendingConfirmations = (conversation) =>
 	call(AC + "list_pending_confirmations", { conversation: conversation || "" });
 
-export async function sendMessage(conversation, message, modelOverride, attachments, context) {
+export async function sendMessage(conversation, message, modelOverride, attachments, context, approvalTokens) {
 	// Empty conversation is allowed: the backend creates (or focuses) an empty
 	// conversation itself and returns its id as `conversation_id` - saves the
 	// SPA a createOrFocusEmpty round-trip before the first send (latency plan).
 	const args = { conversation: conversation || "", message };
 	if (modelOverride) args.model_override = modelOverride;
 	if (attachments && attachments.length) args.attachments = JSON.stringify(attachments);
+	// The ordered tokens of the confirmation cards on screen. A typed "confirm 2"
+	// selects by the number the user sees, so the server must resolve that number
+	// against THESE tokens (what was displayed) rather than a list it re-fetches -
+	// otherwise a card expiring between glance and send renumbers the rest and the
+	// wrong card runs. Server ignores it unless the message parses as an approval.
+	if (approvalTokens && approvalTokens.length) args.approval_tokens = JSON.stringify(approvalTokens);
 	// Forward context for a viewing-context doc/report, the one-shot "ground on
 	// wiki" flag (which can arrive without a doc), OR a page marker ("triggers" /
 	// "dashboards") that primes the agent for that surface's flow from the main

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -205,7 +205,14 @@ export const dismissTool = (token, conversation) =>
 export const listPendingConfirmations = (conversation) =>
 	call(AC + "list_pending_confirmations", { conversation: conversation || "" });
 
-export async function sendMessage(conversation, message, modelOverride, attachments, context, approvalTokens) {
+export async function sendMessage(
+	conversation,
+	message,
+	modelOverride,
+	attachments,
+	context,
+	approvalTokens
+) {
 	// Empty conversation is allowed: the backend creates (or focuses) an empty
 	// conversation itself and returns its id as `conversation_id` - saves the
 	// SPA a createOrFocusEmpty round-trip before the first send (latency plan).
@@ -217,7 +224,8 @@ export async function sendMessage(conversation, message, modelOverride, attachme
 	// against THESE tokens (what was displayed) rather than a list it re-fetches -
 	// otherwise a card expiring between glance and send renumbers the rest and the
 	// wrong card runs. Server ignores it unless the message parses as an approval.
-	if (approvalTokens && approvalTokens.length) args.approval_tokens = JSON.stringify(approvalTokens);
+	if (approvalTokens && approvalTokens.length)
+		args.approval_tokens = JSON.stringify(approvalTokens);
 	// Forward context for a viewing-context doc/report, the one-shot "ground on
 	// wiki" flag (which can arrive without a doc), OR a page marker ("triggers" /
 	// "dashboards") that primes the agent for that surface's flow from the main

--- a/frontend/src/api.spec.js
+++ b/frontend/src/api.spec.js
@@ -70,6 +70,19 @@ describe("sendMessage context forwarding", () => {
 		expect(args.model_override).toBe("gpt-x");
 		expect(JSON.parse(args.attachments)).toEqual([{ file_url: "/f.png" }]);
 	});
+
+	it("forwards the displayed confirmation-card tokens, in order, for a typed approval", async () => {
+		// The server resolves a typed "confirm 2" against THIS ordered list, so the
+		// wire contract must carry it verbatim - a dropped or reordered token would
+		// renumber the selection and can run the wrong card. Pins the C2 binding.
+		await sendMessage("C1", "confirm 2", undefined, undefined, undefined, ["tokA", "tokB"]);
+		expect(JSON.parse(lastSendArgs().approval_tokens)).toEqual(["tokA", "tokB"]);
+	});
+
+	it("omits approval_tokens when there are no cards on screen", async () => {
+		await sendMessage("C1", "hi", undefined, undefined, undefined, []);
+		expect(lastSendArgs().approval_tokens).toBeUndefined();
+	});
 });
 
 describe("setSidebarOrder", () => {

--- a/frontend/src/lib/chatBlocks.js
+++ b/frontend/src/lib/chatBlocks.js
@@ -1,0 +1,72 @@
+/**
+ * Removes the agent's structured blocks from a reply before the remainder is
+ * rendered as markdown.
+ *
+ * A reply is not only prose. The agent also emits fenced blocks that OTHER
+ * surfaces render as real UI: the draft summary card (```jarvis-action), the
+ * confirmation card (```confirm), the clarifying question (```jarvis-ask), the
+ * suggestion cards, the skill/macro markers and the charts. Every one of them
+ * must be cut out of the markdown body, or the same payload would be drawn
+ * twice: once as its card, once as a raw code block underneath it.
+ *
+ * The subtle part is STREAMING. The closing fence is the last thing to arrive,
+ * so for as long as a block is still being written there is nothing for a
+ * `...```/` pattern to match, and marked treats an unterminated fence as a code
+ * block running to the end of the text. The reader watches a wall of raw JSON
+ * type itself out and then disappear when the block finally closes. That flash
+ * is what makes a structured answer look sloppy next to a plain prose one.
+ *
+ * So a block is held back from the first character of its opener, not from its
+ * closing fence, while `streaming` is true. Once the turn settles the rule is
+ * dropped: a block the agent never closed is then shown as-is rather than
+ * silently swallowed, because at that point the raw text is the only honest
+ * thing left to render.
+ *
+ * Pure and dependency-free so the streaming behaviour is unit-testable without
+ * mounting the view.
+ */
+
+/** Fenced blocks that other surfaces own. Order is irrelevant; all are cut. */
+export const BLOCK_TAGS = [
+	"jarvis-action",
+	"confirm",
+	"jarvis-ask",
+	"jarvis-cards",
+	"jarvis-skill",
+	"jarvis-macro",
+	"jarvis-chart",
+];
+
+// Completed blocks. `mermaid` is special: only the xychart-beta variant is a
+// jarvis chart, every other mermaid block is a diagram the body should keep.
+const COMPLETE = [
+	...BLOCK_TAGS.map((tag) => new RegExp("```" + tag + "[ \\t]*\\n[\\s\\S]*?```", "g")),
+	/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g,
+];
+
+// An opener with no closing fence yet, running to the end of the text. Only the
+// trailing one can be unterminated: any earlier block already closed and was cut
+// by COMPLETE above. `mermaid` is held whole here (not just xychart-beta) because
+// half a diagram source is noise on screen either way, and the completed pass
+// re-renders it correctly one frame later.
+const OPEN = new RegExp(
+	"\\n?```(?:" + [...BLOCK_TAGS, "mermaid"].join("|") + ")[ \\t]*(?:\\n[\\s\\S]*)?$"
+);
+
+// A fence whose language tag is still being typed ("```jarv"). No newline has
+// arrived, so this cannot be a plain code block yet, and rendering it produces an
+// empty grey slab that pops in and out. A real code block ("```js\n...") has its
+// newline and streams normally, which is what a reader wants to watch.
+const OPEN_PARTIAL = /\n?```[a-zA-Z-]*$/;
+
+/**
+ * @param {string} text raw assistant content
+ * @param {boolean} streaming true while the reply is still being written
+ * @returns {string} markdown body with structured blocks removed
+ */
+export function stripBlocks(text, streaming = false) {
+	let out = text || "";
+	for (const re of COMPLETE) out = out.replace(re, "");
+	if (streaming) out = out.replace(OPEN, "").replace(OPEN_PARTIAL, "");
+	return out.replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/frontend/src/lib/chatBlocks.spec.js
+++ b/frontend/src/lib/chatBlocks.spec.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+import { stripBlocks, BLOCK_TAGS } from "./chatBlocks";
+
+/**
+ * The regression this module exists for: while a reply streams, the closing
+ * fence has not arrived, so a half-written ```jarvis-action block did not match
+ * the strip pattern and marked rendered it as a code block. The reader watched a
+ * wall of raw JSON type itself out and then vanish when the block closed.
+ */
+
+describe("stripBlocks, settled reply", () => {
+	it("removes a completed block and keeps the prose around it", () => {
+		const text = 'Here you go.\n\n```jarvis-action\n{"verb":"create"}\n```\n\nAnything else?';
+		expect(stripBlocks(text)).toBe("Here you go.\n\nAnything else?");
+	});
+
+	it("removes every block type the agent can emit", () => {
+		for (const tag of BLOCK_TAGS) {
+			const text = "before\n\n```" + tag + '\n{"a":1}\n```\n\nafter';
+			expect(stripBlocks(text)).toBe("before\n\nafter");
+		}
+	});
+
+	it("removes a jarvis xychart but keeps an ordinary mermaid diagram", () => {
+		const chart = "```mermaid\nxychart-beta\n  title x\n```";
+		const diagram = "```mermaid\ngraph TD;\n  A-->B;\n```";
+		expect(stripBlocks("t\n\n" + chart)).toBe("t");
+		expect(stripBlocks("t\n\n" + diagram)).toContain("graph TD");
+	});
+
+	it("SHOWS an unterminated block once the reply has settled", () => {
+		// A block the agent never closed is a real, if broken, answer. Hiding it
+		// forever would leave the reader with a blank message and no explanation.
+		const text = 'Working on it\n\n```jarvis-action\n{"verb":"create"';
+		expect(stripBlocks(text, false)).toContain("jarvis-action");
+	});
+
+	it("collapses the gap a removed block leaves behind", () => {
+		const text = "one\n\n\n```confirm\nx\n```\n\n\n\ntwo";
+		expect(stripBlocks(text)).toBe("one\n\ntwo");
+	});
+});
+
+describe("stripBlocks, mid-stream", () => {
+	it("HOLDS an unterminated block instead of rendering it as raw JSON", () => {
+		// THE bug. Same text, streaming: the reader sees the prose, not the payload.
+		const text =
+			'Creating that supplier.\n\n```jarvis-action\n{"verb":"create","doctype":"Sup';
+		expect(stripBlocks(text, true)).toBe("Creating that supplier.");
+	});
+
+	it("holds an unterminated block of every type", () => {
+		for (const tag of [...BLOCK_TAGS, "mermaid"]) {
+			const text = "prose\n\n```" + tag + '\n{"half":';
+			expect(stripBlocks(text, true)).toBe("prose");
+		}
+	});
+
+	it("holds a fence whose language tag is still being typed", () => {
+		// "```jarv" has no newline yet, so it cannot be a plain code block. Rendering
+		// it produces an empty grey slab that pops in and straight back out.
+		expect(stripBlocks("prose\n\n```jarv", true)).toBe("prose");
+		expect(stripBlocks("prose\n\n```", true)).toBe("prose");
+	});
+
+	it("still streams an ordinary code block, which the reader wants to watch", () => {
+		// The newline proves the language is complete, so this is real content.
+		const text = "Here:\n\n```js\nconst a = 1;";
+		expect(stripBlocks(text, true)).toContain("const a = 1;");
+	});
+
+	it("holds only the trailing opener, never an earlier completed block's prose", () => {
+		const text =
+			'first\n\n```confirm\n{"ok":1}\n```\n\nsecond\n\n```jarvis-action\n{"partial"';
+		expect(stripBlocks(text, true)).toBe("first\n\nsecond");
+	});
+
+	it("reveals the block's absence identically at every prefix of the stream", () => {
+		// Character-by-character: the body must never flash the payload, at any
+		// point in the stream. This is the property the fix actually promises.
+		const full = 'Done.\n\n```jarvis-action\n{"verb":"create","doctype":"Supplier"}\n```';
+		for (let i = 1; i <= full.length; i++) {
+			const body = stripBlocks(full.slice(0, i), true);
+			expect(body).not.toContain("jarvis-action");
+			expect(body).not.toContain("doctype");
+		}
+	});
+
+	it("does not mangle a reply with no blocks at all", () => {
+		const text = "Just a plain answer with **bold** and a list:\n\n- one\n- two";
+		expect(stripBlocks(text, true)).toBe(text);
+	});
+
+	it("tolerates empty and nullish input", () => {
+		expect(stripBlocks("", true)).toBe("");
+		expect(stripBlocks(null, true)).toBe("");
+		expect(stripBlocks(undefined)).toBe("");
+	});
+});
+
+describe("the view renders through this module", () => {
+	const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+	it("passes the streaming flag, so a settled reply is not held forever", () => {
+		expect(src).toContain('import { stripBlocks } from "@/lib/chatBlocks";');
+		expect(src).toContain("renderMarkdown(stripBlocks(text, streaming))");
+		expect(src).toContain("render(m.content, m.streaming)");
+	});
+
+	it("keeps the streaming flag in the render cache key", () => {
+		// Without this the first (held) render of a text would be replayed for the
+		// settled one, and the block would stay hidden after the turn ended.
+		expect(src).toContain('const key = (streaming ? "S:" : "F:") + text;');
+	});
+
+	it("no longer carries its own copy of the strip patterns", () => {
+		expect(src).not.toContain("```jarvis-action[ \\t]*\\n[\\s\\S]*?```");
+	});
+});

--- a/frontend/src/lib/sortPendingCards.js
+++ b/frontend/src/lib/sortPendingCards.js
@@ -1,0 +1,26 @@
+// One source of truth for the parked confirmation-card order on THIS client.
+//
+// A typed "confirm 2" selects by the number the user sees, and the server
+// resolves that number against the tokens this client sends in this order, so
+// every surface that shows numbered cards MUST order them the way the server
+// does: by (expires_at ascending, then token by CODE UNIT).
+//
+// Code unit, not localeCompare / Intl.Collator: the server tiebreaks with
+// Python's byte order (`sorted(key=(expires_at, token))`), and locale rules
+// disagree on mixed-case tokens - which would number cards one way on screen
+// and another on the server, i.e. run the wrong write.
+//
+// The SPA, PWA and Desk widget are separate builds and cannot import one shared
+// module, so this file is duplicated per client. Each copy is pinned by its own
+// unit test (sortPendingCards.spec.js) so the three cannot silently drift - the
+// forked, untested copies are exactly how the Desk-widget ordering bug shipped.
+export function comparePendingCards(a, b) {
+	return (
+		(a.expires_at || 0) - (b.expires_at || 0) ||
+		(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
+	);
+}
+
+export function sortPendingCards(cards) {
+	return [...(cards || [])].sort(comparePendingCards);
+}

--- a/frontend/src/lib/sortPendingCards.spec.js
+++ b/frontend/src/lib/sortPendingCards.spec.js
@@ -40,8 +40,14 @@ describe("sortPendingCards", () => {
 	});
 
 	it("comparePendingCards is a total order (transitive-safe: distinct tokens never tie)", () => {
-		expect(comparePendingCards({ token: "a", expires_at: 1 }, { token: "b", expires_at: 1 })).toBeLessThan(0);
-		expect(comparePendingCards({ token: "b", expires_at: 1 }, { token: "a", expires_at: 1 })).toBeGreaterThan(0);
-		expect(comparePendingCards({ token: "a", expires_at: 1 }, { token: "a", expires_at: 1 })).toBe(0);
+		expect(
+			comparePendingCards({ token: "a", expires_at: 1 }, { token: "b", expires_at: 1 })
+		).toBeLessThan(0);
+		expect(
+			comparePendingCards({ token: "b", expires_at: 1 }, { token: "a", expires_at: 1 })
+		).toBeGreaterThan(0);
+		expect(
+			comparePendingCards({ token: "a", expires_at: 1 }, { token: "a", expires_at: 1 })
+		).toBe(0);
 	});
 });

--- a/frontend/src/lib/sortPendingCards.spec.js
+++ b/frontend/src/lib/sortPendingCards.spec.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { comparePendingCards, sortPendingCards } from "./sortPendingCards.js";
+
+// Real behavioural tests for the card order a typed "confirm N" indexes into.
+// This replaces a source-grep that passed even when a client dropped expires_at
+// (the Desk-widget wrong-write bug): grepping the comparator text proves nothing
+// if the data it runs on never carries the field.
+describe("sortPendingCards", () => {
+	it("orders by expires_at ascending, so the earliest-minted card is number 1", () => {
+		const out = sortPendingCards([
+			{ token: "z", expires_at: 200 },
+			{ token: "a", expires_at: 100 },
+		]);
+		expect(out.map((c) => c.token)).toEqual(["a", "z"]);
+	});
+
+	it("tie-breaks equal expires_at by token in CODE-UNIT (byte) order, matching the server", () => {
+		// 'A' (0x41) sorts before 'z' (0x7A) by code unit; a locale-aware compare
+		// would disagree (case-folding 'a'/'A' together), which is the divergence
+		// that renumbers a card between screen and server.
+		const out = sortPendingCards([
+			{ token: "z9", expires_at: 100 },
+			{ token: "A0", expires_at: 100 },
+		]);
+		expect(out.map((c) => c.token)).toEqual(["A0", "z9"]);
+	});
+
+	it("treats a missing expires_at as 0 without throwing", () => {
+		const out = sortPendingCards([{ token: "b", expires_at: 5 }, { token: "a" }]);
+		expect(out.map((c) => c.token)).toEqual(["a", "b"]);
+	});
+
+	it("does not mutate its input", () => {
+		const input = [
+			{ token: "z", expires_at: 2 },
+			{ token: "a", expires_at: 1 },
+		];
+		sortPendingCards(input);
+		expect(input.map((c) => c.token)).toEqual(["z", "a"]);
+	});
+
+	it("comparePendingCards is a total order (transitive-safe: distinct tokens never tie)", () => {
+		expect(comparePendingCards({ token: "a", expires_at: 1 }, { token: "b", expires_at: 1 })).toBeLessThan(0);
+		expect(comparePendingCards({ token: "b", expires_at: 1 }, { token: "a", expires_at: 1 })).toBeGreaterThan(0);
+		expect(comparePendingCards({ token: "a", expires_at: 1 }, { token: "a", expires_at: 1 })).toBe(0);
+	});
+});

--- a/frontend/src/lib/streamReveal.js
+++ b/frontend/src/lib/streamReveal.js
@@ -1,0 +1,136 @@
+/**
+ * Paces streamed assistant text onto the screen at a steady rate.
+ *
+ * The server publishes the CUMULATIVE reply on every `assistant:delta`, and the
+ * view used to assign it straight through. That makes the reply move at exactly
+ * the rate the model and the socket happen to deliver it: a few characters, then
+ * a stall, then a whole paragraph in one frame. The content is correct and the
+ * motion is not, which is what reads as sloppy.
+ *
+ * This holds the newest text as a TARGET and walks a reveal cursor toward it a
+ * little each frame, faster when it is further behind, so a burst is absorbed
+ * instead of dumped. Nothing is ever dropped or reordered: the cursor only moves
+ * forward, and every snap path below ends with the full target on screen.
+ *
+ * Snap (skip the animation, show everything now) is required, not optional, in
+ * four cases:
+ *
+ *   1. FIRST delta of a message. Starting from zero would leave the assistant row
+ *      empty for a frame, and the view hides an empty streaming row, so the reply
+ *      would flicker out of existence just as it arrives.
+ *   2. REWRITE. A recovered run republishes text that is not an extension of what
+ *      was shown. Animating a rewrite would play the difference as a typo.
+ *   3. TERMINAL (run end, error, stop, conversation switch). The final text is
+ *      authoritative the moment it lands; a cursor still mid-walk would truncate
+ *      the answer.
+ *   4. HIDDEN TAB. requestAnimationFrame stops while the tab is in the
+ *      background, so an animating message would freeze there indefinitely.
+ *
+ * The caller owns the frame loop and the DOM; this module owns only the cursor
+ * arithmetic and the snap rules, so both are testable without mounting the view.
+ */
+
+/** Never crawl slower than this, or a long tail takes visibly too long. */
+export const MIN_STEP = 2;
+/** Never move more than this per frame, or a burst is a jump cut again. */
+export const MAX_STEP = 180;
+/** Frames-ish to absorb a backlog. Lower is snappier, higher is smoother. */
+export const CATCH_UP = 7;
+
+/**
+ * Where the cursor lands next frame.
+ * @param {number} shown characters currently on screen
+ * @param {number} targetLen characters available
+ * @returns {number} the new cursor position, never past targetLen
+ */
+export function nextRevealed(shown, targetLen) {
+	if (shown >= targetLen) return targetLen;
+	const backlog = targetLen - shown;
+	const step = Math.min(MAX_STEP, Math.max(MIN_STEP, Math.ceil(backlog / CATCH_UP)));
+	return Math.min(targetLen, shown + step);
+}
+
+/**
+ * A per-conversation revealer. Keyed by message id, so two messages streaming at
+ * once (a recovery landing beside a live turn) each keep their own cursor.
+ */
+export function createRevealer() {
+	const states = new Map();
+
+	return {
+		/**
+		 * Take a cumulative delta. Returns the text to show RIGHT NOW, which is
+		 * the full text on a first delta or a rewrite and a prefix otherwise.
+		 */
+		receive(id, text) {
+			const next = text || "";
+			const st = states.get(id);
+			if (!st) {
+				states.set(id, { target: next, shown: next.length });
+				return next;
+			}
+			// Not an extension of what we were revealing: the reply was rewritten,
+			// so there is no animation to continue.
+			if (!next.startsWith(st.target)) {
+				st.target = next;
+				st.shown = next.length;
+				return next;
+			}
+			st.target = next;
+			return st.target.slice(0, st.shown);
+		},
+
+		/**
+		 * Advance the cursor. Returns null when this id has nothing left to reveal.
+		 *
+		 * ``frames`` is how many frames' worth of catch-up to apply in one go. It
+		 * exists because each returned text costs the caller a FULL markdown re-parse
+		 * and a v-html rewrite of the whole message, so painting on every one of 60
+		 * frames a second is many times the work the old socket-rate rendering did,
+		 * and a long reply starts dropping frames. The caller paints less often and
+		 * passes the frames it skipped, which keeps the reveal SPEED identical while
+		 * cutting the render cost. Same arithmetic, applied N times, so pacing stays
+		 * exactly what the tests pin.
+		 */
+		tick(id, frames = 1) {
+			const st = states.get(id);
+			if (!st) return null;
+			if (st.shown >= st.target.length) return null;
+			for (let i = 0; i < Math.max(1, frames) && st.shown < st.target.length; i++)
+				st.shown = nextRevealed(st.shown, st.target.length);
+			return { text: st.target.slice(0, st.shown), done: st.shown >= st.target.length };
+		},
+
+		/** Ids still mid-reveal, so the caller knows whether to keep the loop alive. */
+		pending() {
+			const out = [];
+			for (const [id, st] of states) if (st.shown < st.target.length) out.push(id);
+			return out;
+		},
+
+		/** Snap one message to its full text and forget it. Returns that text. */
+		flush(id) {
+			const st = states.get(id);
+			if (!st) return null;
+			states.delete(id);
+			return st.target;
+		},
+
+		/** Snap everything. Returns [id, fullText] pairs for the caller to apply. */
+		flushAll() {
+			const out = [];
+			for (const [id, st] of states) out.push([id, st.target]);
+			states.clear();
+			return out;
+		},
+
+		/** Forget a message without applying anything (its row is gone). */
+		drop(id) {
+			states.delete(id);
+		},
+
+		get size() {
+			return states.size;
+		},
+	};
+}

--- a/frontend/src/lib/streamReveal.spec.js
+++ b/frontend/src/lib/streamReveal.spec.js
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+import { createRevealer, nextRevealed, MIN_STEP, MAX_STEP } from "./streamReveal";
+
+/**
+ * assistant:delta carries the CUMULATIVE reply and the view used to assign it
+ * straight to the row, so the text moved at whatever rate the socket delivered
+ * it: a word, a stall, then a paragraph in one frame. The revealer paces it.
+ *
+ * The correctness bar is that pacing NEVER loses or reorders text: every path
+ * below has to end with the full target on screen.
+ */
+
+describe("nextRevealed", () => {
+	it("never moves past the target", () => {
+		expect(nextRevealed(10, 10)).toBe(10);
+		expect(nextRevealed(12, 10)).toBe(10);
+		expect(nextRevealed(9, 10)).toBe(10);
+	});
+
+	it("moves at least MIN_STEP so a long tail still finishes", () => {
+		expect(nextRevealed(0, 1000) - 0).toBeGreaterThanOrEqual(MIN_STEP);
+	});
+
+	it("caps at MAX_STEP so a huge burst is absorbed, not jump-cut", () => {
+		expect(nextRevealed(0, 1_000_000)).toBe(MAX_STEP);
+	});
+
+	it("goes faster the further behind it is", () => {
+		const small = nextRevealed(0, 50);
+		const big = nextRevealed(0, 5000);
+		expect(big).toBeGreaterThan(small);
+	});
+
+	it("always converges", () => {
+		let shown = 0;
+		const target = 4321;
+		for (let i = 0; i < 10000 && shown < target; i++) shown = nextRevealed(shown, target);
+		expect(shown).toBe(target);
+	});
+});
+
+describe("createRevealer", () => {
+	it("shows the FIRST delta whole, so the row never renders empty", () => {
+		// The view hides an empty streaming row, so starting the cursor at zero
+		// would flicker the reply out of existence just as it arrived.
+		const r = createRevealer();
+		expect(r.receive("m1", "Hello")).toBe("Hello");
+		expect(r.pending()).toEqual([]);
+	});
+
+	it("paces a later delta instead of assigning it", () => {
+		const r = createRevealer();
+		r.receive("m1", "Hi");
+		const shown = r.receive("m1", "Hi there, this is a much longer continuation of the reply");
+		expect(shown).toBe("Hi");
+		expect(r.pending()).toEqual(["m1"]);
+	});
+
+	it("walks forward one frame at a time and finishes on the exact target", () => {
+		const r = createRevealer();
+		const full = "a".repeat(500);
+		r.receive("m1", "a");
+		r.receive("m1", full);
+		let last = null;
+		for (let i = 0; i < 500; i++) {
+			const step = r.tick("m1");
+			if (!step) break;
+			// Monotonic: the cursor only ever moves forward.
+			if (last) expect(step.text.startsWith(last)).toBe(true);
+			last = step.text;
+			if (step.done) break;
+		}
+		expect(last).toBe(full);
+		expect(r.pending()).toEqual([]);
+	});
+
+	it("SNAPS on a rewrite rather than animating the difference", () => {
+		// A recovered run republishes text that is not an extension of what was
+		// shown. Animating that would play the correction as if it were a typo.
+		const r = createRevealer();
+		r.receive("m1", "The answer is 41");
+		r.receive("m1", "The answer is 41 and more text to leave a backlog behind");
+		const rewritten = r.receive("m1", "Completely different recovered answer");
+		expect(rewritten).toBe("Completely different recovered answer");
+		expect(r.pending()).toEqual([]);
+	});
+
+	it("flush snaps to the full text and forgets the message", () => {
+		const r = createRevealer();
+		r.receive("m1", "x");
+		r.receive("m1", "x".repeat(400));
+		expect(r.flush("m1")).toBe("x".repeat(400));
+		expect(r.pending()).toEqual([]);
+		expect(r.flush("m1")).toBeNull();
+	});
+
+	it("flushAll returns every mid-reveal message so a terminal loses nothing", () => {
+		const r = createRevealer();
+		r.receive("a", "1");
+		r.receive("a", "1".repeat(300));
+		r.receive("b", "2");
+		r.receive("b", "2".repeat(300));
+		const out = r.flushAll();
+		expect(out).toHaveLength(2);
+		expect(Object.fromEntries(out)).toEqual({
+			a: "1".repeat(300),
+			b: "2".repeat(300),
+		});
+		expect(r.size).toBe(0);
+	});
+
+	it("keeps two messages independent", () => {
+		// A recovery landing beside a live turn must not share a cursor with it.
+		const r = createRevealer();
+		r.receive("a", "aaa");
+		r.receive("b", "bbb");
+		r.receive("a", "aaa" + "a".repeat(200));
+		expect(r.pending()).toEqual(["a"]);
+		expect(r.flush("b")).toBe("bbb");
+	});
+
+	it("drop forgets a message without applying anything", () => {
+		const r = createRevealer();
+		r.receive("m1", "x");
+		r.receive("m1", "x".repeat(300));
+		r.drop("m1");
+		expect(r.pending()).toEqual([]);
+		expect(r.size).toBe(0);
+	});
+
+	it("applies N frames of catch-up in one tick, at the same speed", () => {
+		// The caller paints ~25 times a second instead of 60 because each paint costs
+		// a full markdown re-parse. Passing the skipped frames keeps the reveal SPEED
+		// identical: three single ticks and one tick(3) must land on the same cursor.
+		const a = createRevealer();
+		const b = createRevealer();
+		const full = "z".repeat(600);
+		for (const r of [a, b]) {
+			r.receive("m", "z");
+			r.receive("m", full);
+		}
+		a.tick("m");
+		a.tick("m");
+		a.tick("m");
+		const stepped = b.tick("m", 3);
+		expect(stepped.text).toBe(a.flush("m").slice(0, stepped.text.length));
+		expect(stepped.text.length).toBe(b.flush("m").length ? stepped.text.length : 0);
+	});
+
+	it("treats a zero or negative frame count as one frame", () => {
+		const r = createRevealer();
+		r.receive("m", "q");
+		r.receive("m", "q".repeat(400));
+		expect(r.tick("m", 0).text.length).toBeGreaterThan(1);
+	});
+
+	it("tick on an unknown or finished message is a no-op", () => {
+		const r = createRevealer();
+		expect(r.tick("nope")).toBeNull();
+		r.receive("m1", "done");
+		expect(r.tick("m1")).toBeNull();
+	});
+
+	it("handles an empty delta without stalling", () => {
+		const r = createRevealer();
+		expect(r.receive("m1", "")).toBe("");
+		expect(r.receive("m1", undefined)).toBe("");
+		expect(r.pending()).toEqual([]);
+	});
+});
+
+describe("every terminal in the view snaps the reveal", () => {
+	const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+	it("wires the revealer into assistant:delta", () => {
+		expect(src).toContain('import { createRevealer } from "@/lib/streamReveal";');
+		expect(src).toContain("m.content = revealer.receive(p.message_id, p.text);");
+		// The old straight assignment is what made the text lurch.
+		expect(src).not.toContain("\t\t\tm.content = p.text;");
+	});
+
+	it("snaps BEFORE run:end clears streaming", () => {
+		// SUX-6 skips the reload because the streamed text is assumed to equal the
+		// final text. A cursor still mid-walk would make that assumption false and
+		// leave the answer truncated on screen.
+		const i = src.indexOf("flushReveal(p.message_id);");
+		const j = src.indexOf("if (m) m.streaming = false;");
+		expect(i).toBeGreaterThan(-1);
+		expect(j).toBeGreaterThan(i);
+	});
+
+	it("snaps on stop, on error, on conversation switch and on unmount", () => {
+		expect(src).toContain("flushReveal(m.name);"); // stopRun
+		expect(src).toContain("flushReveal(); // nothing is streaming anymore"); // clearStreamingActivity
+		expect(src).toContain("flushReveal(); // cancels the frame loop"); // onBeforeUnmount
+		expect(src).toMatch(/function resetRunState\(\) \{[\s\S]{0,220}flushReveal\(\);/);
+	});
+
+	it("snaps when the tab goes to the background, where rAF does not run", () => {
+		expect(src).toMatch(/onVisibility\(\)[\s\S]{0,220}else flushReveal\(\);/);
+	});
+
+	it("paints far less often than it animates, and pays back the skipped frames", () => {
+		// The regression this guards: painting every rAF re-parsed the whole message
+		// 60 times a second, several times the old socket-rate cost, and a long reply
+		// stuttered. Throttling alone would slow the text down; the frame payback is
+		// what keeps the speed while cutting the renders.
+		expect(src).toContain("const REVEAL_PAINT_MS = 40;");
+		expect(src).toContain("if (dt < REVEAL_PAINT_MS) {");
+		expect(src).toContain("const frames = Math.max(1, Math.round(dt / FRAME_MS));");
+		expect(src).toContain("revealer.tick(id, frames)");
+	});
+});
+
+describe("stale tool events cannot reopen the activity list", () => {
+	const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+	it("guards both tool events on a live run", () => {
+		// The CDX-3 pump fence deliberately lets an epoch-less tool event through, so
+		// a straggler tool:start after run:end pushed a `running` entry that no
+		// tool:end would settle, leaving a spinner the user never opened.
+		expect(src).toContain("function toolEventIsStale(p)");
+		expect(src).toContain("if (!currentRunId.value) return true;");
+		const guards = src.match(/if \(toolEventIsStale\(p\)\) break;/g) || [];
+		expect(guards).toHaveLength(2); // tool:start AND tool:end
+	});
+});

--- a/frontend/src/lib/typedConfirm.spec.js
+++ b/frontend/src/lib/typedConfirm.spec.js
@@ -102,9 +102,10 @@ describe("the card advertises both ways to approve", () => {
 		// The selective example numbers must track the real card count, so the hint
 		// is built from `n` rather than a literal "1 and 3" that overshoots a 2-card
 		// stack. (Behaviour of the count itself is a component concern; here we only
-		// pin that the example is dynamic, not hardcoded out of range.)
-		expect(src).toContain('confirm 1 and ${n}');
-		expect(src).not.toContain('"confirm 1 and 3"');
+		// pin that the example is dynamic, not hardcoded out of range. We do NOT
+		// assert the absence of the literal "confirm 1 and 3" - it legitimately
+		// still appears in nearby explanatory comments.)
+		expect(src).toContain("confirm 1 and ${n}");
 		expect(src).toContain('or type "go ahead"');
 	});
 

--- a/frontend/src/lib/typedConfirm.spec.js
+++ b/frontend/src/lib/typedConfirm.spec.js
@@ -99,7 +99,12 @@ describe("the card advertises both ways to approve", () => {
 	});
 
 	it("teaches bulk and selective forms only when there is a choice to make", () => {
-		expect(src).toContain('or type "confirm all", or "confirm 1 and 3"');
+		// The selective example numbers must track the real card count, so the hint
+		// is built from `n` rather than a literal "1 and 3" that overshoots a 2-card
+		// stack. (Behaviour of the count itself is a component concern; here we only
+		// pin that the example is dynamic, not hardcoded out of range.)
+		expect(src).toContain('confirm 1 and ${n}');
+		expect(src).not.toContain('"confirm 1 and 3"');
 		expect(src).toContain('or type "go ahead"');
 	});
 
@@ -108,9 +113,12 @@ describe("the card advertises both ways to approve", () => {
 		expect(src).toContain("{{ pi + 1 }} of {{ visiblePendingActions.length }}");
 	});
 
-	it("orders the cards the way the server orders them", () => {
-		// If the screen and the server disagree about which card is number 1, a
-		// typed "confirm 1" runs the wrong write.
-		expect(src).toContain("(a.expires_at || 0) - (b.expires_at || 0) ||");
+	it("orders the cards through the shared, unit-tested comparator", () => {
+		// The order a typed "confirm 1" resolves against is now the single
+		// sortPendingCards() source of truth (behaviour pinned in
+		// sortPendingCards.spec.js with real inputs), not an inline sort grepped
+		// for its text - a source grep passes even when a client drops expires_at,
+		// which is exactly how the Desk-widget wrong-write bug shipped.
+		expect(src).toContain("sortPendingCards(");
 	});
 });

--- a/frontend/src/lib/typedConfirm.spec.js
+++ b/frontend/src/lib/typedConfirm.spec.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * A typed go-ahead is answered by the server running the confirmation, NOT by
+ * starting a turn. So no run:start, no assistant:delta and no run:end are
+ * coming, and the client has to take the spinner down itself. If it does not,
+ * the composer locks forever on the one interaction the whole gate depends on.
+ *
+ * These pin the client half of that contract at the source level, the same way
+ * chatAction.spec.js pins the two gates that used to disagree.
+ */
+
+const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+// send()'s confirmed handling sits on the ACCEPTED path, after the rejection
+// block. It has to: the voice-dictation lifecycle tests anchor on the FIRST
+// occurrence of the one-shot context clear and the voice release, so a second
+// copy of either above the rejection block silently moves their anchor.
+const CONFIRMED = "if (r && r.confirmed) {";
+const confirmedAt = src.indexOf(CONFIRMED);
+const sendConfirmedBlock = src.slice(confirmedAt, confirmedAt + 700);
+
+describe("send() handles a confirmed response", () => {
+	it("keeps a confirmed response OUT of the rejection branch", () => {
+		// A failed confirmation carries ok:false AND confirmed:true. Falling into the
+		// rejection branch would restore the text to the composer and tell the user
+		// the send failed, when in fact their card was spent. The guard excludes it
+		// explicitly rather than relying on branch order.
+		expect(confirmedAt).toBeGreaterThan(-1);
+		expect(src).toContain("if (r && r.ok === false && !r.confirmed) {");
+	});
+
+	it("reuses the accepted path's one-shot clear and voice release", () => {
+		// Duplicating them above the rejection block is what broke the voice
+		// lifecycle tests, which anchor on the FIRST occurrence of each.
+		expect(src.indexOf("_prefillSendContext = null;")).toBeLessThan(confirmedAt);
+		expect(src.indexOf("if (_voiceAck) voiceStore?.acknowledge(_voiceAck);")).toBeLessThan(
+			confirmedAt
+		);
+	});
+
+	it("unlocks the composer, since no run will arrive to do it", () => {
+		const block = sendConfirmedBlock;
+		expect(block).toContain("sending.value = false;");
+		expect(block).toContain("waiting.value = false;");
+	});
+
+	it("retires EVERY card the server confirmed, not just the first", () => {
+		// A bulk approval spends N tokens in one response. Removing one would leave
+		// the rest on screen as live-looking offers for writes that already ran.
+		expect(sendConfirmedBlock).toContain("for (const t of r.tokens || []) removePending(t);");
+	});
+
+	it("drops the optimistic bubble, because nothing was persisted for it", () => {
+		// The button records no user message either. Leaving the bubble would show a
+		// message that a reload does not bring back.
+		const block = sendConfirmedBlock;
+		expect(block).toContain("messages.value.filter((x) => x.name !== tmpName)");
+	});
+
+	it("routes both outcomes through one shared resolver", () => {
+		// The typed path and the button must not drift in what the user then sees.
+		expect(src).toContain("async function onTypedConfirmResolved(r)");
+		expect(src).toContain("await onTypedConfirmResolved(r);");
+	});
+});
+
+describe("the shared resolver covers every outcome", () => {
+	const fnAt = src.indexOf("async function onTypedConfirmResolved(r)");
+	const fn = src.slice(fnAt, src.indexOf("// Dismiss: consume the token server-side", fnAt));
+
+	it("surfaces a storage outage and re-reads the parked list", () => {
+		// The write did NOT run and the card is already off screen, so the list has
+		// to be re-read or the user loses the card entirely.
+		expect(fn).toContain("confirmationStorageUnavailable(r)");
+		expect(fn).toContain("resyncPendingConfirmations(currentId.value)");
+	});
+
+	it("explains an invalid token instead of failing silently", () => {
+		expect(fn).toContain('r.error.type === "InvalidConfirmation"');
+	});
+
+	it("reloads so the durable receipt chip is what the user sees", () => {
+		expect(fn).toContain("loadConversation(currentId.value)");
+	});
+
+	it("raises the queued chip when the continuation is queued", () => {
+		expect(fn).toContain("queuedTurn.value = {");
+		expect(fn).toContain("sending.value = true;");
+	});
+});
+
+describe("the card advertises both ways to approve", () => {
+	it("shows the hint once per stack, on the last card", () => {
+		// A queue of five must not repeat the same line five times.
+		expect(src).toContain('v-if="pi === visiblePendingActions.length - 1"');
+	});
+
+	it("teaches bulk and selective forms only when there is a choice to make", () => {
+		expect(src).toContain('or type "confirm all", or "confirm 1 and 3"');
+		expect(src).toContain('or type "go ahead"');
+	});
+
+	it("numbers the cards, since a typed selection picks by that number", () => {
+		expect(src).toContain('v-if="visiblePendingActions.length > 1" class="jv-pending-num"');
+		expect(src).toContain("{{ pi + 1 }} of {{ visiblePendingActions.length }}");
+	});
+
+	it("orders the cards the way the server orders them", () => {
+		// If the screen and the server disagree about which card is number 1, a
+		// typed "confirm 1" runs the wrong write.
+		expect(src).toContain("(a.expires_at || 0) - (b.expires_at || 0) ||");
+	});
+});

--- a/frontend/src/notify/globalNotifier.js
+++ b/frontend/src/notify/globalNotifier.js
@@ -19,6 +19,9 @@ import { ref } from "vue";
 import { useShellStore } from "@/stores/shell";
 import { session } from "@/data/session";
 import { report as reportError } from "@/lib/errorReporter";
+// The SAME fence ChatView applies to terminals, from the same module, so the two
+// listeners on this socket cannot disagree about what counts as a duplicate.
+import { fenceAccept, fenceReject } from "@/utils/eventFence";
 import { agentName } from "@/branding";
 
 // ---- toast state (rendered by NotifyToaster.vue) -----------------------------
@@ -131,6 +134,16 @@ export function attachGlobalNotifier({ socket, router }) {
 	const trigSignalAt = new Map();
 	const TRIG_SIGNAL_WINDOW_MS = 5000;
 
+	// Terminal fence, per listener. The server publishes a turn's terminal MORE THAN
+	// ONCE (settlement, then the finalize backstop re-publish), and ChatView has always
+	// deduped it one-shot so its announce + reload fire once. This listener did not, so
+	// every doubled terminal became TWO "Reply ready" toasts for one reply.
+	//
+	// Own state, deliberately NOT shared with ChatView's: both listeners see every
+	// frame, and a shared fence would let whichever ran first accept the terminal and
+	// the other reject it, silently breaking one of the two.
+	const fence = {};
+
 	// hidden → browser notification; visible-but-elsewhere → toast;
 	// visible on the conversation → nothing.
 	function signal({ conv, title, body, tag, open, toastAnywhere = false }) {
@@ -146,6 +159,11 @@ export function attachGlobalNotifier({ socket, router }) {
 		switch (p.kind) {
 			case "run:end":
 			case "run:error": {
+				// One-shot per (run, epoch): a re-published terminal must not signal
+				// twice. Placed before reportError too, so a duplicate error frame is
+				// not reported twice either.
+				if (fenceReject(fence, p, true)) return;
+				fenceAccept(fence, p, true);
 				const conv = p.conversation_id;
 				// A failed turn is the most common error a user faces. Report it
 				// (classified, with the run id) regardless of on-screen state - this

--- a/frontend/src/notify/globalNotifier.spec.js
+++ b/frontend/src/notify/globalNotifier.spec.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * The bug: a reply produced TWO "Reply ready" toasts.
+ *
+ * A turn's terminal is published more than once (settlement, then the finalize
+ * backstop re-publish). ChatView has always deduped that one-shot so its announce
+ * and reload fire once per run. This listener, on the same socket, did not, so each
+ * doubled terminal signalled twice for one reply.
+ *
+ * These tests drive the real listener through a fake socket and count toasts, so
+ * they fail if the fence is removed rather than merely if the source text changes.
+ */
+
+const store = {
+	markUnread: vi.fn(),
+	applyRemoteNew: vi.fn(),
+	currentConvId: null,
+	conversations: [{ name: "conv-a", title: "Chat A" }],
+	approvalsCount: 0,
+};
+
+vi.mock("@/stores/shell", () => ({ useShellStore: () => store }));
+vi.mock("@/data/session", () => ({ session: { user: "u@example.com" } }));
+vi.mock("@/lib/errorReporter", () => ({ report: vi.fn() }));
+vi.mock("@/branding", () => ({ agentName: "Jarvis" }));
+
+const { attachGlobalNotifier, useToasts, dismissToast } = await import("./globalNotifier");
+
+/** A socket that hands every emitted payload to the attached listener. */
+function fakeSocket() {
+	const handlers = [];
+	return {
+		on: (_evt, fn) => handlers.push(fn),
+		off: (_evt, fn) => {
+			const i = handlers.indexOf(fn);
+			if (i !== -1) handlers.splice(i, 1);
+		},
+		emit: (payload) => handlers.forEach((fn) => fn(payload)),
+	};
+}
+
+// Not the conversation any event below names, so signal() takes the toast branch.
+// meta.chat falsy means "no conversation is on screen", so signal() takes the toast
+// branch, which is the branch the doubling was visible in.
+const router = {
+	currentRoute: { value: { name: "Approvals", params: {}, meta: {} } },
+	push: vi.fn(),
+};
+
+function terminal(over = {}) {
+	return {
+		kind: "run:end",
+		conversation_id: "conv-a",
+		run_id: "run-1",
+		pump_epoch: 3,
+		event_seq: 12,
+		preview: "All done.",
+		...over,
+	};
+}
+
+let socket, detach;
+
+// jsdom exposes document.hidden as a getter with no setter, so assignment throws.
+function setHidden(v) {
+	Object.defineProperty(document, "hidden", { configurable: true, get: () => v });
+}
+
+beforeEach(() => {
+	for (const t of [...useToasts().value]) dismissToast(t.id);
+	vi.clearAllMocks();
+	setHidden(false);
+	socket = fakeSocket();
+	detach = attachGlobalNotifier({ socket, router });
+});
+
+describe("a re-published terminal signals once", () => {
+	it("toasts ONCE for the same terminal delivered twice", () => {
+		// THE bug: settlement publishes it, then the finalize backstop re-publishes
+		// the identical frame.
+		socket.emit(terminal());
+		socket.emit(terminal());
+		expect(useToasts().value).toHaveLength(1);
+	});
+
+	it("toasts once even when the repeat arrives at a LOWER epoch", () => {
+		// A superseded writer's late terminal, which must never re-signal.
+		socket.emit(terminal({ pump_epoch: 3 }));
+		socket.emit(terminal({ pump_epoch: 2 }));
+		expect(useToasts().value).toHaveLength(1);
+	});
+
+	it("dedupes a re-published run:error the same way", () => {
+		socket.emit(terminal({ kind: "run:error", error: "It broke." }));
+		socket.emit(terminal({ kind: "run:error", error: "It broke." }));
+		expect(useToasts().value).toHaveLength(1);
+	});
+
+	it("still signals a DIFFERENT run", () => {
+		// The fence must dedupe repeats, not swallow the next reply.
+		socket.emit(terminal({ run_id: "run-1" }));
+		socket.emit(terminal({ run_id: "run-2" }));
+		expect(useToasts().value).toHaveLength(2);
+	});
+
+	it("still signals a genuinely newer epoch for the same run", () => {
+		// A recovered turn re-runs at a higher epoch and IS a new outcome.
+		socket.emit(terminal({ pump_epoch: 3 }));
+		socket.emit(terminal({ pump_epoch: 4, event_seq: 20 }));
+		expect(useToasts().value).toHaveLength(2);
+	});
+
+	it("leaves an epoch-less legacy terminal alone", () => {
+		// No pump_epoch means the fence has nothing to reason about, so the frame is
+		// applied unchanged. Documented behaviour, matching ChatView.
+		socket.emit(terminal({ pump_epoch: undefined, event_seq: undefined }));
+		expect(useToasts().value).toHaveLength(1);
+	});
+});
+
+describe("the fence does not touch the other signals", () => {
+	it("still toasts a parked confirmation, which is a separate event", () => {
+		// action:pending and run:end are different things and each deserves its own
+		// signal. Two DIFFERENT toasts for one turn is intended, unlike two identical ones.
+		socket.emit({
+			kind: "action:pending",
+			conversation: "conv-a",
+			tool: "jarvis__create_doc",
+		});
+		socket.emit(terminal());
+		expect(useToasts().value).toHaveLength(2);
+	});
+
+	it("stops signalling once detached", () => {
+		detach();
+		socket.emit(terminal({ run_id: "run-9" }));
+		expect(useToasts().value).toHaveLength(0);
+	});
+});
+
+describe("a hidden tab takes the browser-notification branch, not the toast", () => {
+	it("does not stack toasts while hidden", () => {
+		setHidden(true);
+		socket.emit(terminal());
+		socket.emit(terminal());
+		expect(useToasts().value).toHaveLength(0);
+	});
+});

--- a/frontend/src/utils/voiceSendGlue.test.js
+++ b/frontend/src/utils/voiceSendGlue.test.js
@@ -922,7 +922,9 @@ test("jarvis#496 source pin: ChatView clears _prefillSendContext only on the acc
 	assert.ok(start > -1 && end > start, "located ChatView.vue's send() function body");
 	const sendSrc = chatViewSrc.slice(start, end);
 
-	const awaitIdx = sendSrc.indexOf("await api.sendMessage(sentFrom");
+	// Anchor on the call itself, not its first arg: prettier wraps a long
+	// sendMessage(...) across lines, so "sendMessage(sentFrom" is not contiguous.
+	const awaitIdx = sendSrc.indexOf("await api.sendMessage(");
 	// Anchors the rejection block's CLOSING brace, not just its opening `if (...)` — a scope-aware
 	// check. A regression that clears the context as the FIRST statement inside the rejected branch
 	// (unconditionally wiping it on every rejection, reintroducing the jarvis#496 bug) would still

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -663,7 +663,7 @@
 						<Message
 							v-else
 							variant="row"
-							:html="m.error ? '' : render(m.content)"
+							:html="m.error ? '' : render(m.content, m.streaming)"
 							:attachments="m.canvas"
 							:timestamp="msgTime(m)"
 							:timestampFull="msgTimeFull(m)"
@@ -3758,6 +3758,8 @@ import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.v
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { normaliseAction } from "@/lib/chatAction";
+import { stripBlocks } from "@/lib/chatBlocks";
+import { createRevealer } from "@/lib/streamReveal";
 import { errMessage, turnErrorInfo } from "@/lib/errors";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { pickGreeting } from "@/lib/greeting";
@@ -5178,19 +5180,8 @@ function parseXychart(body) {
 	if (horizontal) spec.options = { horizontal: true };
 	return spec;
 }
-function stripBlocks(text) {
-	return (text || "")
-		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```confirm[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```jarvis-ask[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```jarvis-cards[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```jarvis-skill[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```jarvis-macro[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, "")
-		.replace(/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g, "")
-		.replace(/\n{3,}/g, "\n\n")
-		.trim();
-}
+// Moved to lib/chatBlocks.js so the streaming rule (hold an unterminated block
+// instead of letting marked render it as raw JSON) is unit-testable.
 const _skillUsedCache = new Map();
 function skillsUsedOf(m) {
 	const content = (m && m.content) || "";
@@ -5420,17 +5411,21 @@ function confirmLabel(m) {
 // identical content in two messages renders identically.
 let _renderCacheRegex = undefined;
 let _renderCache = new Map();
-function render(text) {
+function render(text, streaming = false) {
 	const re = docNameRegex.value;
 	if (re !== _renderCacheRegex) {
 		_renderCacheRegex = re;
 		_renderCache = new Map();
 	}
-	const hit = _renderCache.get(text);
+	// The same text renders two ways: mid-stream an unterminated block is held
+	// back, once settled it is shown. So the flag is part of the cache key, or a
+	// reply would keep the held version for the rest of the session.
+	const key = (streaming ? "S:" : "F:") + text;
+	const hit = _renderCache.get(key);
 	if (hit !== undefined) return hit;
-	const out = linkifyDocs(renderMarkdown(stripBlocks(text)));
+	const out = linkifyDocs(renderMarkdown(stripBlocks(text, streaming)));
 	if (_renderCache.size >= 800) _renderCache.clear();
-	_renderCache.set(text, out);
+	_renderCache.set(key, out);
 	return out;
 }
 // {document name → DocType} harvested from THIS conversation's tool calls

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4335,6 +4335,22 @@ function clearStreamingActivity() {
 	currentRunId.value = null;
 	store.streamingConvId = null;
 	recovering.value = null;
+	flushReveal(); // nothing is streaming anymore, so nothing may stay mid-reveal
+}
+// Tool events are only meaningful while their run is live. The CDX-3 pump fence
+// deliberately lets an epoch-less tool event through, so a straggler or replayed
+// tool:start arriving AFTER run:end (which clears activeTools) used to push a
+// fresh `running` entry that no tool:end would ever settle. The live activity
+// block renders on activeTools.length alone, so the user got an expanded tool row
+// with a spinner they never opened, stuck until the next turn. That is the
+// intermittent "the tool list is showing on its own".
+//
+// A tool event is stale when no run is in flight, or when it names a different
+// run than the one on screen. An event with no run_id is trusted while a run is
+// live, which keeps the legacy epoch-less path working.
+function toolEventIsStale(p) {
+	if (!currentRunId.value) return true;
+	return !!p.run_id && p.run_id !== currentRunId.value;
 }
 function tearDownActivityIfSettled() {
 	const rid = currentRunId.value;
@@ -4380,6 +4396,83 @@ onUnmounted(() => enrichmentTracker.reset());
 const recovering = ref(null); // { message_id, reason } while a turn is parked for background recovery — the composer stays UNLOCKED so the user isn't trapped
 const retrying = ref(false); // guards the error-card Retry against a double-enqueue while one is in flight
 const srMessage = ref(""); // visually-hidden aria-live text (turn completion / failure) for screen readers
+// ── Smooth reveal ───────────────────────────────────────────────────────────
+// assistant:delta carries the CUMULATIVE reply, and assigning it straight to the
+// row made the text move at whatever rate the socket delivered it: a word, a
+// stall, then a paragraph in a single frame. The revealer holds the newest text
+// as a target and a frame loop walks the row toward it, absorbing bursts.
+// lib/streamReveal.js owns the cursor arithmetic and the snap rules; this owns
+// the frame loop and the DOM writes.
+const revealer = createRevealer();
+let _revealRaf = 0;
+function _applyRevealed(id, text) {
+	const m = messages.value.find((x) => x.name === id);
+	if (m) m.content = text;
+	return !!m;
+}
+// A painted frame costs a full markdown re-parse plus a v-html rewrite of the
+// whole message, so painting all 60 frames a second is several times the work the
+// old socket-rate rendering did and a long reply visibly stutters. Paint at ~25/s
+// instead, and hand tick() the frames that were skipped so the reveal moves at the
+// same SPEED with a fraction of the render cost. 40ms is still well inside what
+// reads as continuous for text appearing.
+const REVEAL_PAINT_MS = 40;
+const FRAME_MS = 1000 / 60;
+let _lastPaintMs = 0;
+function revealFrame() {
+	_revealRaf = 0;
+	const now = performance.now();
+	const dt = now - _lastPaintMs;
+	if (dt < REVEAL_PAINT_MS) {
+		// Too soon to repaint, but the reveal is not finished: keep the loop alive.
+		_revealRaf = requestAnimationFrame(revealFrame);
+		return;
+	}
+	// Frames' worth of catch-up owed since the last paint, so a slow frame (or a
+	// throttled tab) does not slow the text down, it just moves further per paint.
+	const frames = Math.max(1, Math.round(dt / FRAME_MS));
+	_lastPaintMs = now;
+	let painted = false;
+	for (const id of revealer.pending()) {
+		const step = revealer.tick(id, frames);
+		if (!step) continue;
+		// The row went away (conversation switch, reload). Stop animating into
+		// nothing rather than holding the loop open forever.
+		if (!_applyRevealed(id, step.text)) revealer.drop(id);
+		else painted = true;
+	}
+	// Scroll rides the reveal, not the socket: following the text as it appears
+	// is what keeps a long answer readable while it writes itself.
+	if (painted) scrollBottomIfPinned();
+	if (revealer.pending().length) _revealRaf = requestAnimationFrame(revealFrame);
+}
+function pumpReveal() {
+	if (_revealRaf || !revealer.pending().length) return;
+	// Start the clock now: a timestamp left over from the previous reply would
+	// otherwise make this burst's first paint either instant or a frame late.
+	if (!_lastPaintMs || performance.now() - _lastPaintMs > 1000)
+		_lastPaintMs = performance.now() - REVEAL_PAINT_MS;
+	_revealRaf = requestAnimationFrame(revealFrame);
+}
+// Snap one message (or every message) to its full text. Every terminal calls
+// this: a cursor still mid-walk when the run settles would truncate the answer.
+function flushReveal(id) {
+	if (id) {
+		const full = revealer.flush(id);
+		if (full != null) _applyRevealed(id, full);
+		return;
+	}
+	for (const [mid, full] of revealer.flushAll()) _applyRevealed(mid, full);
+	if (_revealRaf) {
+		cancelAnimationFrame(_revealRaf);
+		_revealRaf = 0;
+	}
+}
+// requestAnimationFrame does not run in a background tab, so an animating reply
+// would freeze there until the user came back. Snap instead.
+function onVisibilityChange() {
+	if (document.hidden) flushReveal();
+}
 const activeTools = ref([]); // [{ id, name, status }] for the in-flight run
 // Live activity shows ONE tool at a time: the most-recently-started tool that's
 // still running, plus a compact count of the ones already finished this turn.
@@ -7205,6 +7298,9 @@ function downloadSvgAsPng(svgEl) {
 // send() bails on sending) because the leaving run's run:end event is dropped
 // by the conversation guard in onEvent.
 function resetRunState() {
+	// Leaving the conversation: apply whatever is mid-reveal to the rows we are
+	// about to drop, so a reload of this chat cannot find a truncated message.
+	flushReveal();
 	sending.value = false;
 	waiting.value = false;
 	activeTools.value = [];
@@ -7874,13 +7970,18 @@ function onEvent(p) {
 				m = { name: p.message_id, role: "assistant", content: "", streaming: true };
 				messages.value = [...messages.value, m];
 			}
-			m.content = p.text;
+			// Reveal paced rather than assigned. The first delta of a message comes
+			// back whole, so the row never renders empty (the view hides an empty
+			// streaming row, which would flicker the reply out just as it arrives).
+			m.content = revealer.receive(p.message_id, p.text);
 			m.streaming = true;
+			pumpReveal();
 			nextTick(scrollBottomIfPinned);
 			break;
 		}
 		case "tool:start": {
 			if (pumpFenceReject(p)) break; // CDX-3 (epoch-less legacy tool events bypass)
+			if (toolEventIsStale(p)) break;
 			pumpFenceAccept(p, false);
 			const id = p.tool_call_id || `${p.tool_name}-${activeTools.value.length}`;
 			activeTools.value = [
@@ -7894,6 +7995,7 @@ function onEvent(p) {
 		}
 		case "tool:end": {
 			if (pumpFenceReject(p)) break; // CDX-3 (epoch-less legacy tool events bypass)
+			if (toolEventIsStale(p)) break;
 			pumpFenceAccept(p, false);
 			const t = activeTools.value.find((x) => x.id === p.tool_call_id);
 			if (t) t.status = p.status || "completed";
@@ -7954,6 +8056,10 @@ function onEvent(p) {
 			resyncPendingConfirmations(currentId.value);
 			// Defensive: if a promoted turn's run:start was missed, retire the chip.
 			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
+			// Snap BEFORE clearing `streaming`: the SUX-6 identical-skip below assumes
+			// the streamed text already equals the final text, which is only true once
+			// the reveal cursor has caught up.
+			flushReveal(p.message_id);
 			const m = messages.value.find((x) => x.name === p.message_id);
 			if (m) m.streaming = false;
 			// SUX-6: the terminal final text is the last cumulative mirror in the normal
@@ -8074,6 +8180,7 @@ function onEvent(p) {
 					[p.message_id]: { code: p.code || "", changed_data: p.changed_data },
 				};
 			}
+			flushReveal(p.message_id); // whatever streamed before the error stays whole
 			recovering.value = null;
 			waiting.value = false;
 			sending.value = false;
@@ -8098,6 +8205,9 @@ function stopRun() {
 	if (currentMsgId.value) stoppedMsgIds.value.add(currentMsgId.value);
 	const m = [...messages.value].reverse().find((x) => x.role === "assistant" && x.streaming);
 	if (m) {
+		// Stop keeps whatever streamed. Snap first so the marker lands on the text
+		// the run actually produced, not on wherever the cursor happened to be.
+		flushReveal(m.name);
 		m.streaming = false;
 		if (m.name) stoppedMsgIds.value.add(m.name);
 		// A stop is a state of the turn, not prose: leave whatever streamed
@@ -9179,6 +9289,9 @@ function onResync() {
 }
 function onVisibility() {
 	if (document.visibilityState === "visible") onResync();
+	// Going to the background stops requestAnimationFrame, so anything mid-reveal
+	// would sit frozen until the user came back. Snap it instead.
+	else flushReveal();
 }
 
 // ---- shell contract (§3.7): New Chat requests, external navigation and
@@ -9407,6 +9520,7 @@ onMounted(async () => {
 	composerRef.value?.focusInput();
 });
 onBeforeUnmount(() => {
+	flushReveal(); // cancels the frame loop and leaves every row whole
 	socket?.off("jarvis:event", onEvent);
 	socket?.off("connect", onResync);
 	document.removeEventListener("visibilitychange", onVisibility);

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1862,7 +1862,7 @@
 					     carries its own server-minted one-time token. A single turn can
 					     park more than one, so we stack a card per queued token (#4). -->
 					<div
-						v-for="pa in visiblePendingActions"
+						v-for="(pa, pi) in visiblePendingActions"
 						:key="pa.token"
 						class="jv-action jv-pending"
 					>
@@ -1883,6 +1883,11 @@
 								<path d="M12 9v4M12 17h.01" />
 							</svg>
 							<span class="jv-action-title">Confirm before this runs</span>
+							<!-- The number is what a typed "confirm 1 and 3" selects by, so it
+							     only appears when there is actually a choice to make. -->
+							<span v-if="visiblePendingActions.length > 1" class="jv-pending-num">
+								{{ pi + 1 }} of {{ visiblePendingActions.length }}
+							</span>
 						</div>
 						<div class="jv-pending-body">
 							<div v-if="pendingSummaryOf(pa)" class="jv-pending-summary">
@@ -1944,6 +1949,14 @@
 								<span v-if="pa.busy">Confirming…</span
 								><span v-else>✓ Confirm</span>
 							</button>
+							<!-- Two equal ways to approve. Shown once per stack, on the last
+							     card, so a queue of five does not repeat it five times. -->
+							<span
+								v-if="pi === visiblePendingActions.length - 1"
+								class="jv-action-typehint"
+							>
+								{{ typedApprovalHint }}
+							</span>
 							<button
 								class="jv-action-discard"
 								:disabled="pa.busy"
@@ -6263,8 +6276,33 @@ const pendingActions = ref([]);
 // Only the cards belonging to the conversation on screen render (a parked write
 // from another chat must not show here). The queue is already pruned to the
 // current conversation on load, but filter defensively for the template v-for.
+// Sorted the SAME way the server orders the parked list (mint order: expires_at
+// is mint time plus a fixed TTL, with the token breaking a same-second tie).
+// Load-bearing once a typed "confirm 1 and 3" can select by the number printed on
+// each card: if the screen and the server disagree about which card is number 1,
+// the wrong write runs. The queue's own arrival order is close but not identical,
+// since a resync merges cards in whatever order the store returned them.
+// What the hint offers depends on how many cards are stacked: with one there
+// is nothing to select, with several the useful thing to teach is that both
+// all-at-once and pick-a-few work.
+const typedApprovalHint = computed(() =>
+	visiblePendingActions.value.length > 1
+		? 'or type "confirm all", or "confirm 1 and 3"'
+		: 'or type "go ahead"'
+);
 const visiblePendingActions = computed(() =>
-	pendingActions.value.filter((pa) => pa.conversation === currentId.value)
+	pendingActions.value
+		.filter((pa) => pa.conversation === currentId.value)
+		// Compared by code unit, NOT localeCompare: the server tiebreaks with
+		// Python's byte order, and localeCompare disagrees with it on mixed-case
+		// tokens. Cards minted in the same second would then be numbered one way
+		// on screen and another on the server, which is the wrong-write bug this
+		// ordering exists to prevent.
+		.sort(
+			(a, b) =>
+				(a.expires_at || 0) - (b.expires_at || 0) ||
+				(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
+		)
 );
 
 // A legacy container (persona v0.39, pre write-safety) may still emit a
@@ -6421,6 +6459,43 @@ async function confirmPending(pa) {
 	} finally {
 		const card = cardById();
 		if (card) card.busy = false;
+	}
+}
+// Resolution shared by the typed go-ahead and the Confirm button, so the two
+// ways of approving a card cannot drift apart in what the user then sees.
+// `r` is the envelope from the confirmation itself, already stripped of its card.
+async function onTypedConfirmResolved(r) {
+	if (r && r.ok === false) {
+		// A storage wobble means the write did NOT run, and the card has already
+		// been retired on screen, so say so plainly rather than leave them guessing.
+		if (confirmationStorageUnavailable(r)) {
+			notify(r.error.message, { type: "error" });
+			await resyncPendingConfirmations(currentId.value);
+			return;
+		}
+		if (r.error && r.error.type === "InvalidConfirmation") {
+			notify("That confirmation is no longer valid. Ask me to try the action again.", {
+				type: "error",
+			});
+			return;
+		}
+		// The token was spent and the write failed. A durable "failed" receipt chip
+		// is already in the transcript; reload so it is what the user sees.
+		await loadConversation(currentId.value);
+		store.loadConversations();
+		return;
+	}
+	await loadConversation(currentId.value);
+	store.loadConversations();
+	// The continuation turn queued behind other work. Same chip the button raises,
+	// so an approved action never vanishes into silence.
+	if (r && r.queued) {
+		queuedTurn.value = {
+			run_id: r.run_id,
+			message_id: r.message_id,
+			position: r.queued_position || null,
+		};
+		sending.value = true;
 	}
 }
 // Dismiss: consume the token server-side (closes the 15-min replay window and
@@ -7634,7 +7709,13 @@ async function send(textArg, resendAck) {
 		// so a rejected send keeps it armed for retry.)
 		if (triggerMode.value) sendCtx = { ...(sendCtx || {}), page: "triggers" };
 		const r = await api.sendMessage(sentFrom, text, undefined, attachments, sendCtx);
-		if (r && r.ok === false) {
+		// A typed go-ahead was consumed as an approval, not rejected as a send, so it
+		// must not fall into the rejection branch below even when the confirmation
+		// itself failed. It is handled further down, on the accepted path, where it
+		// shares that path's one-shot context clear and voice release rather than
+		// duplicating them (the lifecycle tests anchor on the FIRST occurrence of
+		// those lines, and a second copy above the rejection block moves the anchor).
+		if (r && r.ok === false && !r.confirmed) {
 			// The server rejected the send (e.g. the single-flight guard:
 			// "a reply is already in progress", or the monthly usage cap).
 			// Nothing was persisted — recover it (below) so no work and no voice audio
@@ -7720,6 +7801,21 @@ async function send(textArg, resendAck) {
 		// chips say so rather than reading like leftover clutter next to an already-answered
 		// message, and so their Retry promises the current draft, not an edit of a sent message.
 		if (voiceStore) for (const _fid of _failedAtSend) voiceStore.markSentWithout(_fid);
+		// The server ran the parked confirmation instead of starting a turn. No run
+		// events are coming, so the spinner comes down here or it hangs forever, and
+		// nothing was persisted for the typed words (the button persists none either)
+		// so the optimistic bubble goes too: the receipt chip and the continuation
+		// reply are the record. Placed after the release above, which a confirmed
+		// message has legitimately earned.
+		if (r && r.confirmed) {
+			if (_currentScope() === _sentScope)
+				messages.value = messages.value.filter((x) => x.name !== tmpName);
+			sending.value = false;
+			waiting.value = false;
+			for (const t of r.tokens || []) removePending(t);
+			await onTypedConfirmResolved(r);
+			return;
+		}
 		// Phase-0 admission: the send was accepted but QUEUED (all slots taken).
 		// Show the "~N ahead" chip + Cancel instead of the streaming spinner; the
 		// reply begins when a slot frees (run:start clears queuedTurn). Position
@@ -12592,6 +12688,24 @@ onUnmounted(() => {
 	color: var(--cta-fg) !important;
 	border-color: var(--cta) !important;
 	filter: brightness(1.18);
+}
+/* The card's position in the parked stack. It is a selector, not decoration:
+   "confirm 2" means this one. */
+.jv-pending-num {
+	margin-left: auto;
+	font-size: 11.5px;
+	font-weight: 600;
+	color: var(--amber);
+	white-space: nowrap;
+}
+/* The typed-approval hint. Quiet by design: the button is the primary path and
+   this is the shortcut, so it must not compete with either action beside it. */
+.jv-action-typehint {
+	font-size: 12px;
+	color: var(--text-3);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .jv-action-discard {
 	margin-left: auto;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7714,7 +7714,14 @@ async function send(textArg, resendAck) {
 		// The confirmation cards currently on screen, in the order the numbers are
 		// shown, so a typed "confirm 2" binds to the card the user actually sees.
 		const approvalTokens = visiblePendingActions.value.map((a) => a.token);
-		const r = await api.sendMessage(sentFrom, text, undefined, attachments, sendCtx, approvalTokens);
+		const r = await api.sendMessage(
+			sentFrom,
+			text,
+			undefined,
+			attachments,
+			sendCtx,
+			approvalTokens
+		);
 		// A typed go-ahead was consumed as an approval, not rejected as a send, so it
 		// must not fall into the rejection branch below even when the confirmation
 		// itself failed. It is handled further down, on the accepted path, where it

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3773,6 +3773,7 @@ import { parseAsk } from "@/lib/chatAsk";
 import { normaliseAction } from "@/lib/chatAction";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { createRevealer } from "@/lib/streamReveal";
+import { sortPendingCards } from "@/lib/sortPendingCards";
 import { errMessage, turnErrorInfo } from "@/lib/errors";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { pickGreeting } from "@/lib/greeting";
@@ -6285,24 +6286,18 @@ const pendingActions = ref([]);
 // What the hint offers depends on how many cards are stacked: with one there
 // is nothing to select, with several the useful thing to teach is that both
 // all-at-once and pick-a-few work.
-const typedApprovalHint = computed(() =>
-	visiblePendingActions.value.length > 1
-		? 'or type "confirm all", or "confirm 1 and 3"'
-		: 'or type "go ahead"'
-);
+const typedApprovalHint = computed(() => {
+	const n = visiblePendingActions.value.length;
+	// The example must reference cards that actually exist: with two parked,
+	// "confirm 1 and 3" names a card 3 that is not there, so a user who copies it
+	// verbatim gets an out-of-range no-op. Use the real first and last numbers.
+	return n > 1 ? `or type "confirm all", or "confirm 1 and ${n}"` : 'or type "go ahead"';
+});
 const visiblePendingActions = computed(() =>
-	pendingActions.value
-		.filter((pa) => pa.conversation === currentId.value)
-		// Compared by code unit, NOT localeCompare: the server tiebreaks with
-		// Python's byte order, and localeCompare disagrees with it on mixed-case
-		// tokens. Cards minted in the same second would then be numbered one way
-		// on screen and another on the server, which is the wrong-write bug this
-		// ordering exists to prevent.
-		.sort(
-			(a, b) =>
-				(a.expires_at || 0) - (b.expires_at || 0) ||
-				(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
-		)
+	// Ordered by the shared, unit-tested comparator (sortPendingCards) so the
+	// numbers on screen match the server's (expires_at, token) order a typed
+	// "confirm N" resolves against. See lib/sortPendingCards.js.
+	sortPendingCards(pendingActions.value.filter((pa) => pa.conversation === currentId.value))
 );
 
 // A legacy container (persona v0.39, pre write-safety) may still emit a
@@ -7077,6 +7072,14 @@ async function loadConversation(id) {
 	// does a single clean load, would put it right. (Root cause of "open a
 	// chat, switch away and back, it shows empty until I refresh".)
 	if (currentId.value !== id) return;
+	// Flush any in-flight reveal BEFORE swapping in the freshly-loaded rows. On a
+	// reconnect resync the socket may have missed a run's terminal (fire-and-forget
+	// pub/sub, no replay), so flushReveal(message_id) never ran for it; a leftover
+	// cursor would otherwise keep ticking and overwrite the DB-correct final text
+	// with its stale, truncated target - a shortened answer with no spinner and no
+	// error, fixable only by a hard refresh. flushReveal() cancels the loop and
+	// clears all reveal state, so nothing survives to touch the new array.
+	flushReveal();
 	messages.value = d?.messages || [];
 	// VR4-2: re-inject any failed optimistic bubbles whose send was rejected while THIS conversation
 	// was off-screen (their rendered copy was dropped when messages was replaced). They are kept
@@ -7708,7 +7711,10 @@ async function send(textArg, resendAck) {
 		// one-shot _prefillSendContext is cleared after the send is accepted, below,
 		// so a rejected send keeps it armed for retry.)
 		if (triggerMode.value) sendCtx = { ...(sendCtx || {}), page: "triggers" };
-		const r = await api.sendMessage(sentFrom, text, undefined, attachments, sendCtx);
+		// The confirmation cards currently on screen, in the order the numbers are
+		// shown, so a typed "confirm 2" binds to the card the user actually sees.
+		const approvalTokens = visiblePendingActions.value.map((a) => a.token);
+		const r = await api.sendMessage(sentFrom, text, undefined, attachments, sendCtx, approvalTokens);
 		// A typed go-ahead was consumed as an approval, not rejected as a send, so it
 		// must not fall into the rejection branch below even when the confirmation
 		// itself failed. It is handled further down, on the accepted path, where it

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -478,7 +478,10 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 		# through to a graceful failure envelope: the "failed" receipt + continuation
 		# below still fire, so the user sees it and the agent learns.
 		frappe.db.rollback()
-		frappe.log_error(title="confirm_tool dispatch crashed", message=frappe.get_traceback())
+		frappe.log_error(
+			title="confirm dispatch crashed",
+			message=f"token={token} conversation={guard_conv}\n{frappe.get_traceback()}",
+		)
 		result = api._error("InternalError", "the confirmed action failed unexpectedly and was not saved")
 
 	# Leave a transcript receipt (#7) so a confirmed delete/submit/email shows on
@@ -507,7 +510,10 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 				action_outcome="confirmed" if ok else "failed",
 			)
 		except Exception:
-			frappe.log_error(title="confirm_tool receipt failed", message=frappe.get_traceback())
+			frappe.log_error(
+				title="confirm receipt failed",
+				message=f"token={token} conversation={conv}\n{frappe.get_traceback()}",
+			)
 
 		# Continue the agent's plan: the model was told only "awaiting the
 		# user's confirmation" and stopped, so without this turn it never
@@ -535,7 +541,10 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 		try:
 			_cont = enqueue_continuation(conv, _confirm_receipt_text(record, result), failed=not ok)
 		except Exception:
-			frappe.log_error(title="confirm_tool continuation failed", message=frappe.get_traceback())
+			frappe.log_error(
+				title="confirm continuation failed",
+				message=f"token={token} conversation={conv}\n{frappe.get_traceback()}",
+			)
 		# SUX-3/SUXI-2: thread the queued continuation's position onto a SUCCESSFUL
 		# confirm result so the SPA shows the queued chip (the card doesn't vanish
 		# into silence while the continuation sits queued). A failed confirm keeps

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -412,6 +412,29 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 	browser session's sid + data are always restored - a bare ``frappe.set_user``
 	would gut the cookie session and log the user out.
 	"""
+	return _confirm_core(token, conversation)
+
+
+def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = False) -> dict:
+	"""The confirmation itself, with no HTTP surface of its own.
+
+	Two human paths reach it: the Confirm button (``confirm_tool`` above) and a
+	typed approval in the composer (``jarvis.chat.api.send_message``). Both are
+	the same authenticated session user acting on the same card, so they share
+	one implementation rather than one calling the other's whitelisted endpoint.
+
+	Every guarantee stays below this line, not in the callers: Guest refusal,
+	owner + conversation binding, the atomic single-use ``consume``, execution
+	under the stored ``exec_user``, the transcript receipt and the continuation
+	turn. A second entry point therefore cannot weaken the gate, and two racing
+	approvals (a click and a typed one) still resolve to exactly one winner.
+
+	``batch``: this card is one of several being approved together. The write, the
+	receipt chip and every guard still run per card, so nothing about the gate is
+	relaxed; only the follow-up turn is deferred. The receipt line is returned as
+	``receipt_text`` for the caller to fold into ONE continuation covering the
+	whole batch, instead of N turns queueing against each other.
+	"""
 	if frappe.session.user == "Guest":
 		raise frappe.PermissionError("authentication required")
 
@@ -500,6 +523,14 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 			from jarvis.chat import admission
 
 			admission.publish_action_confirmed(conv)
+		# In a batch the caller owns the follow-up: N cards approved in one breath
+		# must produce ONE continuation carrying all N receipts, not N turns racing
+		# each other through admission. The receipt line rides out on the envelope
+		# so the caller can compose them.
+		if batch:
+			if isinstance(result, dict):
+				result["receipt_text"] = _confirm_receipt_text(record, result)
+			return result
 		_cont = None
 		try:
 			_cont = enqueue_continuation(conv, _confirm_receipt_text(record, result), failed=not ok)

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -864,6 +864,165 @@ def _conversation_busy(conversation: str) -> bool:
 	return age < _INFLIGHT_FRESH_SECONDS
 
 
+def _ordered_parked_cards(user: str, conversation: str) -> list[dict] | None:
+	"""This user's parked cards for this conversation, in the order they are shown.
+
+	Order is load-bearing: a typed "confirm 1 and 3" selects by the number printed
+	on each card, so the server's list and the user's screen must agree or the
+	wrong write runs. The store keeps tokens in a Redis SET, which has no order at
+	all, so an explicit sort is the only thing standing between the numbers and a
+	coin flip. ``expires_at`` is mint time plus a fixed TTL, so it sorts into mint
+	order, and the token breaks ties for cards minted in the same second.
+
+	Returns None when the store cannot answer, which the caller treats as "not an
+	approval" rather than as an empty list.
+	"""
+	from jarvis.chat import pending_confirm
+
+	try:
+		parked = pending_confirm.list_items_for_owner(user, conversation, strict=True)
+	except pending_confirm.PendingConfirmStorageError:
+		# Unknown state is not approval. Falling through is recoverable: the user's
+		# "go ahead" reaches the model. A wrong answer here is a write nobody
+		# authorised, which is not.
+		return None
+	return sorted(parked, key=lambda c: (c.get("expires_at") or 0, c.get("token") or ""))
+
+
+def _typed_confirmation(user: str, conversation: str, message: str) -> dict | None:
+	"""Run the parked confirmations the user approved by typing, or return None.
+
+	The card gives two equal ways to say yes: the Confirm button, and saying so in
+	the composer. This is the second one, and it covers the same ground the buttons
+	do, including several cards at once:
+
+	  * "go ahead" with one card parked confirms it;
+	  * "go ahead" (or "confirm all") with several parked confirms ALL of them,
+	    because a user who lines up three writes and says go ahead means three;
+	  * "confirm 1 and 3" confirms exactly those, by the number on each card, for
+	    when the answer is these but not that one.
+
+	It is a convenience over the buttons, never a widening of them, so all of these
+	must hold or the message falls through and reaches the model as ordinary text:
+
+	  * the WHOLE message parses as an approval (``approval_phrases``). "Yes but
+	    change the quantity to 5" approves nothing and must reach the model;
+	  * every number named exists. "Confirm 4" against three cards is a
+	    misunderstanding, and running three writes on the strength of it would be
+	    exactly the wrong recovery;
+	  * the confirmation store can actually answer;
+	  * the caller is a human, interactive session with no attachments.
+
+	The security property is unchanged from the button, per card: same
+	authenticated session user, same owner-bound single-use ``consume``, same
+	``exec_user`` execution scope, same receipt chip. Approving in bulk runs N
+	independent confirmations; it does not create a path that skips any of them.
+	The model cannot reach this at all, since it arrives only through the human
+	session endpoint and never the plugin callback, and a typed approval racing a
+	click resolves to one winner inside ``consume``.
+
+	Running before the single-flight guard is safe even though the button carries a
+	client-side "wait for the current reply" check: the follow-up goes through
+	``enqueue_continuation``, which enqueues via admission and QUEUES behind a live
+	turn rather than racing it. A batch produces exactly ONE such turn, carrying
+	every receipt, so ten approvals do not become ten turns.
+
+	The numbers can move between the user's glance and their send: a card can
+	expire on its 15-minute TTL, a stopped run clears the tokens it parked (F6),
+	and the run:end resync can add one mid-stack. The ordering makes that
+	renumbering CONSISTENT rather than arbitrary, which is the most any ordinal
+	scheme can offer here. The residual failure is bounded and small: ``consume``
+	is owner-bound and single-use, so the worst case is confirming a different card
+	the same user owns and can see, never someone else's and never twice.
+
+	No user message is persisted, exactly as the buttons persist none. The
+	transcript still reads correctly because each confirmation writes its own
+	receipt chip.
+	"""
+	from jarvis.chat import approval_phrases
+
+	# Cheap reject first: most messages are not approvals, and this costs no I/O.
+	if not approval_phrases.looks_like_approval(message):
+		return None
+
+	parked = _ordered_parked_cards(user, conversation)
+	if not parked:
+		return None
+
+	picked = approval_phrases.parse_approval(message, len(parked))
+	if not picked:
+		return None
+
+	from jarvis.chat.actions_api import _confirm_core
+
+	single = len(picked) == 1
+	results, tokens, receipts = [], [], []
+	solo_envelope = None
+	for i in picked:
+		card = parked[i]
+		# batch=True for every card in a multi-card approval so the follow-up turn
+		# is composed once, below, instead of one per card.
+		res = _confirm_core(card["token"], conversation, batch=not single)
+		if not isinstance(res, dict):
+			res = {"ok": False, "error": {"type": "InternalError", "message": "confirmation failed"}}
+		if single:
+			solo_envelope = res
+		tokens.append(card["token"])
+		results.append(
+			{
+				"token": card["token"],
+				"position": i + 1,
+				"summary": card.get("summary") or "",
+				"ok": bool(res.get("ok")),
+				"error": res.get("error"),
+			}
+		)
+		if res.get("receipt_text"):
+			receipts.append(res["receipt_text"])
+
+	failed = [r for r in results if not r["ok"]]
+	# One continuation for the whole batch. The single-card path already queued its
+	# own inside _confirm_core, so only the batch path composes one here.
+	cont = None
+	if receipts:
+		from jarvis.chat.actions_api import enqueue_continuation as _enqueue_cont
+
+		try:
+			cont = _enqueue_cont(conversation, " ".join(receipts), failed=bool(failed))
+		except Exception:
+			frappe.log_error(
+				title="typed bulk confirmation continuation failed", message=frappe.get_traceback()
+			)
+
+	# The single-card envelope is the tool result itself, so the client keeps the
+	# shape it already handles. A batch reports per card instead: with three
+	# writes, "it worked" is not an answer when one of them did not.
+	if single:
+		# Pass the confirmation's own envelope straight through, so the queued
+		# chip details it already threaded on survive untouched.
+		out = dict(solo_envelope)
+	else:
+		out = {"ok": not failed}
+		if failed:
+			out["error"] = {
+				"type": "PartialConfirmation",
+				"message": (
+					f"{len(results) - len(failed)} of {len(results)} actions went through; "
+					f"{len(failed)} could not be completed."
+				),
+			}
+		if cont and cont.get("queued"):
+			out["queued"] = True
+			out["queued_position"] = cont.get("queued_position")
+			out["run_id"] = cont.get("run_id")
+			out["message_id"] = cont.get("message_id")
+	out["confirmed"] = True
+	out["conversation_id"] = conversation
+	out["tokens"] = tokens
+	out["results"] = results
+	return out
+
+
 @frappe.whitelist()
 def send_message(
 	conversation: str | None = None,
@@ -969,6 +1128,19 @@ def send_message(
 			raise
 		conversation = create_or_focus_empty()
 		conv_doc = _get_owned_conversation(conversation)
+
+	# A typed go-ahead on a parked confirmation card is the SAME act as clicking
+	# Confirm, so it runs the confirmation instead of becoming a chat turn. Placed
+	# here on purpose: ownership of the conversation is settled, but nothing has
+	# been reserved or persisted yet, so an approval never burns a turn credit and
+	# never leaves a user row behind. Returns None whenever anything is less than
+	# unambiguous, and the message then continues as an ordinary send.
+	# A background send is a non-interactive turn, so there is no human at a
+	# composer to be approving anything with it.
+	if not _delegated and not atts and not int(background or 0):
+		_typed = _typed_confirmation(user, conversation, message)
+		if _typed is not None:
+			return _typed
 
 	# Single-flight guard: reject a second concurrent turn on the same
 	# conversation (extra tab / double-send / a retry racing a live turn) -

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -865,14 +865,14 @@ def _conversation_busy(conversation: str) -> bool:
 
 
 def _ordered_parked_cards(user: str, conversation: str) -> list[dict] | None:
-	"""This user's parked cards for this conversation, in the order they are shown.
+	"""This user's currently-live parked cards for this conversation.
 
-	Order is load-bearing: a typed "confirm 1 and 3" selects by the number printed
-	on each card, so the server's list and the user's screen must agree or the
-	wrong write runs. The store keeps tokens in a Redis SET, which has no order at
-	all, so an explicit sort is the only thing standing between the numbers and a
-	coin flip. ``expires_at`` is mint time plus a fixed TTL, so it sorts into mint
-	order, and the token breaks ties for cards minted in the same second.
+	Used by ``_typed_confirmation`` to (a) know whether any named token is still
+	live and (b) source each card's summary for the receipt. Selection numbering
+	is NOT taken from this list's order any more - a typed number binds to the
+	token the CLIENT displayed (``approval_tokens``), which is what closes the
+	renumber-between-glance-and-send hole. The sort is kept only so the returned
+	list is deterministic; the caller reads it as a token->card map, not by index.
 
 	Returns None when the store cannot answer, which the caller treats as "not an
 	approval" rather than as an empty list.
@@ -885,11 +885,77 @@ def _ordered_parked_cards(user: str, conversation: str) -> list[dict] | None:
 		# Unknown state is not approval. Falling through is recoverable: the user's
 		# "go ahead" reaches the model. A wrong answer here is a write nobody
 		# authorised, which is not.
+		#
+		# Leave ONE greppable line: this path silently turns a typed approval into
+		# an ordinary chat turn, so during a store outage a user's "go ahead" reaches
+		# the model with no card context and gets a confused reply. Without this,
+		# that failure is indistinguishable in the logs from a normal message. WARNING
+		# (not log_error): it is an expected degradation, not a bug, and the store is
+		# already unhealthy so a Desk Error Log row per send would pile on.
+		frappe.logger("jarvis.pending_confirm").warning(
+			"typed approval degraded to an ordinary turn: store unavailable (user=%s conversation=%s)",
+			user,
+			conversation,
+		)
 		return None
 	return sorted(parked, key=lambda c: (c.get("expires_at") or 0, c.get("token") or ""))
 
 
-def _typed_confirmation(user: str, conversation: str, message: str) -> dict | None:
+#: Cap on how many displayed tokens a client may send. A confirmation stack is a
+#: handful of cards; a longer list is a malformed or hostile payload, not a real
+#: screen, so it is rejected rather than trusted.
+_MAX_APPROVAL_TOKENS = 50
+
+
+def _clean_approval_tokens(raw: str | list | None) -> list[str] | None:
+	"""The ordered tokens a client displayed for numbered typed approval, or None.
+
+	The list is load-bearing: a typed "confirm 2" indexes into THIS order, so it
+	must be exactly what the user saw. Returns None (caller falls through to the
+	model) on anything untrustworthy - not a list, empty, oversized, or any element
+	that is not a non-empty string - because a garbled position list must never be
+	best-guessed against a real ERP write. Order is preserved and never mutated;
+	dropping or reordering an element would silently renumber the selection, which
+	is the whole failure this exists to prevent.
+	"""
+	if raw is None:
+		return None
+	if isinstance(raw, str):
+		try:
+			raw = json.loads(raw)
+		except Exception:
+			return None
+	if not isinstance(raw, list) or not raw or len(raw) > _MAX_APPROVAL_TOKENS:
+		return None
+	out: list[str] = []
+	for t in raw:
+		if not isinstance(t, str):
+			return None
+		t = t.strip()
+		if not t:
+			return None
+		out.append(t)
+	return out
+
+
+def _typed_approval_eligible(delegated, attachments, background) -> bool:
+	"""Whether a send may be read as a typed approval of a parked card.
+
+	Only a human, interactive, foreground composer send with no attachments
+	qualifies. Delegated/system re-entries (scheduler, agent runs, File-Box drops)
+	and background turns have no human at a composer, and an attachment means the
+	user is sending a file, not answering a card. Extracted and named so the gate
+	is unit-testable on its own - a refactor that quietly drops one of these
+	conditions could otherwise let a scripted/background message consume a card,
+	and no test would fail. ``int(background or 0)`` tolerates the "0"/"1" string
+	forms Frappe may pass a whitelisted int param.
+	"""
+	return not delegated and not attachments and not int(background or 0)
+
+
+def _typed_confirmation(
+	user: str, conversation: str, message: str, approval_tokens: str | list | None = None
+) -> dict | None:
 	"""Run the parked confirmations the user approved by typing, or return None.
 
 	The card gives two equal ways to say yes: the Confirm button, and saying so in
@@ -927,13 +993,15 @@ def _typed_confirmation(user: str, conversation: str, message: str) -> dict | No
 	turn rather than racing it. A batch produces exactly ONE such turn, carrying
 	every receipt, so ten approvals do not become ten turns.
 
-	The numbers can move between the user's glance and their send: a card can
-	expire on its 15-minute TTL, a stopped run clears the tokens it parked (F6),
-	and the run:end resync can add one mid-stack. The ordering makes that
-	renumbering CONSISTENT rather than arbitrary, which is the most any ordinal
-	scheme can offer here. The residual failure is bounded and small: ``consume``
-	is owner-bound and single-use, so the worst case is confirming a different card
-	the same user owns and can see, never someone else's and never twice.
+	A card can expire between the user's glance and their send (its 15-minute TTL,
+	a stopped run clearing the tokens it parked (F6), a resync). A typed number
+	binds to the token the client showed at that number (``approval_tokens``), NOT
+	to a position in a list the server re-fetches, so an expired card cannot
+	renumber the rest onto a different write. If the token behind a named number is
+	no longer live it fails ITS OWN card inside the owner-bound single-use
+	``consume`` (never a substitution); if none of the named tokens is live the
+	whole message falls through to the model instead. This is the same guarantee
+	the Confirm button has - it too carries a specific token, not a position.
 
 	No user message is persisted, exactly as the buttons persist none. The
 	transcript still reads correctly because each confirmation writes its own
@@ -945,12 +1013,36 @@ def _typed_confirmation(user: str, conversation: str, message: str) -> dict | No
 	if not approval_phrases.looks_like_approval(message):
 		return None
 
+	# Bind the selection to the exact tokens the CLIENT displayed at each number,
+	# not to a position in a list the server re-fetches at send time. A card can
+	# expire between the user's glance and their send; the server list would then
+	# renumber and "confirm 2" could run a different, possibly more destructive
+	# card. Numbering the client's own displayed tokens makes the typed path
+	# token-bound like the Confirm button: a stale/foreign token fails its own
+	# card inside the owner-bound consume, and can never select another card.
+	client_tokens = _clean_approval_tokens(approval_tokens)
+	if not client_tokens:
+		# No displayed-token context (an older/other client, or a client that sent
+		# nothing): a number cannot be resolved safely, so fall through to the model
+		# and leave the user the Confirm button.
+		return None
+
+	# The server's own live set: needed so a selection that names ONLY cards the
+	# server no longer holds falls through (nothing valid to confirm) rather than
+	# reporting a batch of failures, and to source summaries for the receipts.
 	parked = _ordered_parked_cards(user, conversation)
 	if not parked:
 		return None
+	by_token = {c.get("token"): c for c in parked}
 
-	picked = approval_phrases.parse_approval(message, len(parked))
+	picked = approval_phrases.parse_approval(message, len(client_tokens))
 	if not picked:
+		return None
+
+	tokens_to_confirm = [client_tokens[i] for i in picked]
+	# If not one named token is still live server-side, treat it as "not an approval
+	# right now" and fall through - same outcome as the old no-cards-parked case.
+	if not any(t in by_token for t in tokens_to_confirm):
 		return None
 
 	from jarvis.chat.actions_api import _confirm_core
@@ -959,18 +1051,21 @@ def _typed_confirmation(user: str, conversation: str, message: str) -> dict | No
 	results, tokens, receipts = [], [], []
 	solo_envelope = None
 	for i in picked:
-		card = parked[i]
+		token = client_tokens[i]
+		card = by_token.get(token) or {}
 		# batch=True for every card in a multi-card approval so the follow-up turn
-		# is composed once, below, instead of one per card.
-		res = _confirm_core(card["token"], conversation, batch=not single)
+		# is composed once, below, instead of one per card. A token no longer live
+		# (card gone since the client rendered it) reaches _confirm_core and fails
+		# its own card via the single-use consume - never a substitution.
+		res = _confirm_core(token, conversation, batch=not single)
 		if not isinstance(res, dict):
 			res = {"ok": False, "error": {"type": "InternalError", "message": "confirmation failed"}}
 		if single:
 			solo_envelope = res
-		tokens.append(card["token"])
+		tokens.append(token)
 		results.append(
 			{
-				"token": card["token"],
+				"token": token,
 				"position": i + 1,
 				"summary": card.get("summary") or "",
 				"ok": bool(res.get("ok")),
@@ -1004,11 +1099,17 @@ def _typed_confirmation(user: str, conversation: str, message: str) -> dict | No
 	else:
 		out = {"ok": not failed}
 		if failed:
+			# Name the cards that failed by the number the user saw, so a partial
+			# batch is actionable ("card 2 could not be completed") instead of a
+			# bare count. The per-card results[] carries the same detail for a
+			# client that wants to render each chip; this is the at-a-glance line.
+			failed_positions = ", ".join(str(r["position"]) for r in failed)
 			out["error"] = {
 				"type": "PartialConfirmation",
 				"message": (
 					f"{len(results) - len(failed)} of {len(results)} actions went through; "
-					f"{len(failed)} could not be completed."
+					f"{len(failed)} could not be completed "
+					f"(card{'s' if len(failed) != 1 else ''} {failed_positions})."
 				),
 			}
 		if cont and cont.get("queued"):
@@ -1032,8 +1133,22 @@ def send_message(
 	context: str | None = None,
 	thinking_override: str | None = None,
 	background: int = 0,
+	approval_tokens: str | list | None = None,
 ) -> dict:
 	"""Validate, persist the user message, enqueue the worker.
+
+	RETURN SHAPE - two forms, and callers MUST branch on ``confirmed``:
+	  * ordinary send -> ``{ok, conversation_id, run_id, message_id, ...}`` (a turn
+	    was enqueued; run events follow over the socket).
+	  * typed approval of a parked confirmation card -> ``{ok, confirmed: True,
+	    conversation_id, tokens, results, ...}`` (the message WAS a go-ahead and ran
+	    the confirmation instead of a turn; NO run events follow, so a client that
+	    ignores ``confirmed`` and waits for run:start spins forever). ``ok`` can be
+	    False here with ``confirmed`` True (a batch where some cards failed), so a
+	    client must check ``confirmed`` BEFORE treating ``ok:False`` as a send error.
+	  See ``approval_tokens`` and ``_typed_confirmation``. A client that does not
+	  send ``approval_tokens`` never triggers the second form for a numbered
+	  selection, so an un-updated client degrades safely to ordinary sends.
 
 	`conversation` (optional): when empty, an empty active conversation is
 	created (or the existing empty one focused) server-side and its id is
@@ -1137,8 +1252,8 @@ def send_message(
 	# unambiguous, and the message then continues as an ordinary send.
 	# A background send is a non-interactive turn, so there is no human at a
 	# composer to be approving anything with it.
-	if not _delegated and not atts and not int(background or 0):
-		_typed = _typed_confirmation(user, conversation, message)
+	if _typed_approval_eligible(_delegated, atts, background):
+		_typed = _typed_confirmation(user, conversation, message, approval_tokens)
 		if _typed is not None:
 			return _typed
 

--- a/jarvis/chat/approval_phrases.py
+++ b/jarvis/chat/approval_phrases.py
@@ -1,0 +1,148 @@
+"""Recognises a typed approval of a parked confirmation card.
+
+The write-safety gate parks a mutating tool call and waits for a human. Clicking
+Confirm is one way to give that go-ahead; saying it is the other, because in a
+chat window the natural reply to "shall I create this supplier?" is "go ahead",
+not a hunt for a button.
+
+This module decides ONLY whether a message is that go-ahead. It grants nothing:
+the caller still has to find exactly one parked card owned by this user in this
+conversation, and the confirmation still runs through the same owner-bound,
+single-use consume the button uses.
+
+The matching rule is deliberately blunt: the WHOLE message, once normalised,
+must equal one of a short fixed list. Substring matching would be a security
+regression on the one gate that stands between the model and a real ERP write.
+"Yes, but change the quantity to 5" contains "yes" and is emphatically not an
+approval of what is on the card, so it has to reach the model as an ordinary
+message. When in doubt this returns False and the user still has the button.
+
+Pure and import-light so the rule is unit-testable without a site.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Whole-message approvals. Short, unambiguous, and each one a complete reply on
+# its own. Anything that needs a qualifier to make sense ("fine", "sounds good
+# but") is deliberately absent.
+APPROVAL_PHRASES = frozenset(
+	{
+		"confirm",
+		"confirmed",
+		"yes",
+		"yes please",
+		"y",
+		"go ahead",
+		"go",
+		"proceed",
+		"approve",
+		"approved",
+		"do it",
+		"ok",
+		"okay",
+		"sure",
+	}
+)
+
+# A typed approval is a handful of characters. The cap is a cheap second guard:
+# a long message is a message, whatever words it starts with.
+MAX_APPROVAL_LEN = 24
+
+_TRAILING_PUNCT = re.compile(r"[\s.!,]+$")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def normalise(text: str) -> str:
+	"""Lowercase, collapse whitespace, drop trailing punctuation.
+
+	Only trailing punctuation is stripped. A message with INTERNAL punctuation
+	("yes, but wait") keeps it and therefore cannot match, which is the point.
+	A question mark is not stripped either: "confirm?" is a question about the
+	card, not an approval of it.
+	"""
+	return _TRAILING_PUNCT.sub("", _WHITESPACE.sub(" ", (text or "").strip().lower()))
+
+
+def is_approval(text: str) -> bool:
+	"""True when the whole message is an unambiguous go-ahead."""
+	if not text:
+		return False
+	if len(text) > MAX_APPROVAL_LEN:
+		return False
+	return normalise(text) in APPROVAL_PHRASES
+
+
+# ── several cards at once ──────────────────────────────────────────────────
+#
+# With more than one card parked, a bare "go ahead" approves ALL of them. That
+# is a deliberate product decision: a user who lines up three writes and says go
+# ahead means all three, and making them click three times is the friction this
+# whole feature exists to remove.
+#
+# Saying so explicitly is supported too ("confirm all"), and so is approving
+# only some of them by the number shown on each card ("confirm 1 and 3"), which
+# is the escape hatch for when the answer really is "these but not that one".
+# Numbers are used rather than descriptions because a card's number is on screen
+# and exact, whereas matching "the supplier one" against a summary is guesswork,
+# and guesswork is what this gate exists to prevent.
+
+# The verbs that can carry a selection. Kept separate from APPROVAL_PHRASES:
+# these are only meaningful with an object ("confirm 2"), never alone.
+_SELECT_VERB = r"(?:confirm|approve|do|run|yes to|go ahead with|proceed with)"
+
+# "confirm all", "yes to all", "approve all of them", "confirm both".
+_ALL_RE = re.compile(rf"^(?:{_SELECT_VERB}|yes|ok|okay)?\s*(?:all(?: of them)?|both)$")
+
+# "confirm 1", "yes to 2 and 3", "approve 1, 3", "do 1 & 2".
+_SELECT_RE = re.compile(rf"^{_SELECT_VERB}\s+(\d+(?:\s*(?:,|and|&)\s*\d+)*)$")
+_NUMBER_RE = re.compile(r"\d+")
+
+# A selection can name every card, so the length cap has to grow with the list.
+MAX_SELECTION_LEN = 80
+
+
+def looks_like_approval(text: str) -> bool:
+	"""Cheap pre-filter: could this message possibly be an approval?
+
+	Almost every message is not, and the real answer needs the parked-card list,
+	which costs a Redis read. This rejects the obvious no on length alone before
+	any I/O happens. It is deliberately generous: a false yes here just means the
+	precise check runs, while ``parse_approval`` remains the only authority.
+	"""
+	return bool(text) and len(text.strip()) <= MAX_SELECTION_LEN
+
+
+def parse_approval(text: str, count: int) -> list[int] | None:
+	"""Which of ``count`` parked cards this message approves.
+
+	Returns a sorted list of 0-based indexes, or None when the message is not an
+	approval at all and should reach the model as ordinary text.
+
+	The indexes are positions in the caller's ordered card list, so the caller
+	MUST order it the same way the user sees it. An out-of-range number returns
+	None rather than a best guess: "confirm 4" against three cards is a
+	misunderstanding, and running three writes on the strength of it would be
+	exactly the wrong recovery.
+	"""
+	if not text or count < 1:
+		return None
+	raw = (text or "").strip()
+	if len(raw) > MAX_SELECTION_LEN:
+		return None
+	norm = normalise(raw)
+
+	# A plain go-ahead: the single card, or every card when several are parked.
+	if len(raw) <= MAX_APPROVAL_LEN and norm in APPROVAL_PHRASES:
+		return list(range(count))
+	if _ALL_RE.match(norm):
+		return list(range(count))
+
+	m = _SELECT_RE.match(norm)
+	if not m:
+		return None
+	picked = sorted({int(n) for n in _NUMBER_RE.findall(m.group(1))})
+	if not picked or picked[0] < 1 or picked[-1] > count:
+		return None
+	return [n - 1 for n in picked]

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -396,6 +396,8 @@
 						</button>
 					</div>
 				</div>
+				<!-- Both ways to approve, shown once under the stack. -->
+				<div class="jvp-typehint">{{ typedApprovalHint }}</div>
 			</div>
 
 			<!-- Jump to latest. stickToBottom already refuses to drag a reader who
@@ -588,6 +590,7 @@ import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
 import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
+import { sortPendingCards } from "./pending_order.mjs";
 import { ONBOARDING_URL } from "./config.mjs";
 import {
 	listConversations,
@@ -790,13 +793,15 @@ const resolving = ref("");
 // selects by the number shown here, and the store keeps tokens in a Redis SET
 // with no order of its own. Tokens compare by code unit so the tiebreak matches
 // the server's byte order rather than locale rules.
-const orderedPending = computed(() =>
-	[...(stream.value.pending || [])].sort(
-		(a, b) =>
-			(a.expires_at || 0) - (b.expires_at || 0) ||
-			(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
-	)
-);
+// Ordered by the shared, unit-tested comparator so the numbers on screen match
+// the server's (expires_at, token) order a typed "confirm N" resolves against.
+const orderedPending = computed(() => sortPendingCards(stream.value.pending || []));
+// Typed approval works in the widget too, but only the desktop advertised it.
+// The selective example numbers track the real count so it never overshoots.
+const typedApprovalHint = computed(() => {
+	const n = orderedPending.value.length;
+	return n > 1 ? 'or type "confirm all", or "confirm 1 and ' + n + '"' : 'or type "go ahead"';
+});
 const lastSent = ref("");
 // Prompt recall, matching the full chat: Up walks back through prompts sent from
 // this panel, Down walks forward and finally restores whatever was being typed.
@@ -1098,6 +1103,10 @@ async function load() {
 					token: r.token,
 					tool: r.tool || "",
 					summary: r.summary || r.preview || "",
+					// Carry expires_at so orderedPending sorts by (expires_at,
+					// token) the same way the server does; without it a typed
+					// "confirm N" can select a different card than shown.
+					expires_at: r.expires_at ?? null,
 				})),
 			};
 		} catch (e) {
@@ -1299,7 +1308,10 @@ async function send() {
 		// Context is read at SEND time, not at open time: a conversation outlives
 		// the page it started on, and pinning it would leave the agent silently
 		// answering about the wrong record after a navigation.
-		const res = await sendMessage(convId.value, text, props.context, atts);
+		// Tokens of the parked cards in the order shown, so a typed "confirm 2"
+		// binds to the card at that number rather than a server-side re-fetch.
+		const approvalTokens = orderedPending.value.map((p) => p.token);
+		const res = await sendMessage(convId.value, text, props.context, atts, approvalTokens);
 		if (res?.conversation_id) convId.value = res.conversation_id;
 		// A go-ahead on the parked card ran the confirmation instead of starting a
 		// turn. No run is coming, so marking the panel busy would spin forever, and
@@ -1309,7 +1321,12 @@ async function send() {
 			sending.value = false;
 			messages.value = messages.value.filter((m) => !String(m.name).startsWith("local-"));
 			if (res.ok === false)
-				loadError.value = "That confirmation is no longer valid. Ask again to retry it.";
+				// Prefer the server's own message: a partial batch ("2 of 3 went
+				// through") is a success for most cards, so the generic "no longer
+				// valid, ask again" both misreports it and invites a duplicate retry
+				// of writes that already ran. Fall back only when none was sent.
+				loadError.value =
+					res.error?.message || "That confirmation is no longer valid. Ask again to retry it.";
 			await load();
 			return;
 		}
@@ -2505,6 +2522,12 @@ defineExpose({ load, startNewChat, convId });
 	display: flex;
 	gap: 8px;
 	justify-content: flex-end;
+}
+.jvp-typehint {
+	margin: 6px 2px 0;
+	font-size: 12px;
+	line-height: 1.4;
+	opacity: 0.6;
 }
 
 /* ---- composer ---- */

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1326,7 +1326,8 @@ async function send() {
 				// valid, ask again" both misreports it and invites a duplicate retry
 				// of writes that already ran. Fall back only when none was sent.
 				loadError.value =
-					res.error?.message || "That confirmation is no longer valid. Ask again to retry it.";
+					res.error?.message ||
+					"That confirmation is no longer valid. Ask again to retry it.";
 			await load();
 			return;
 		}

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -376,9 +376,11 @@
 			</div>
 
 			<div v-if="stream.pending.length" class="jvp-pending">
-				<div v-for="p in stream.pending" :key="p.token" class="jvp-pending-row">
+				<div v-for="(p, pi) in orderedPending" :key="p.token" class="jvp-pending-row">
 					<div class="jvp-pending-txt">
-						{{ p.summary || "Jarvis wants to make a change." }}
+						<b v-if="orderedPending.length > 1"
+							>{{ pi + 1 }} of {{ orderedPending.length }}: </b
+						>{{ p.summary || "Jarvis wants to make a change." }}
 					</div>
 					<div class="jvp-pending-acts">
 						<button class="jvp-btn-subtle" type="button" @click="$emit('open-full')">
@@ -784,6 +786,17 @@ const draft = ref("");
 const sending = ref(false);
 const composerFocused = ref(false);
 const resolving = ref("");
+// Ordered the SAME way the server orders the parked list: a typed "confirm 2"
+// selects by the number shown here, and the store keeps tokens in a Redis SET
+// with no order of its own. Tokens compare by code unit so the tiebreak matches
+// the server's byte order rather than locale rules.
+const orderedPending = computed(() =>
+	[...(stream.value.pending || [])].sort(
+		(a, b) =>
+			(a.expires_at || 0) - (b.expires_at || 0) ||
+			(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
+	)
+);
 const lastSent = ref("");
 // Prompt recall, matching the full chat: Up walks back through prompts sent from
 // this panel, Down walks forward and finally restores whatever was being typed.
@@ -1288,6 +1301,18 @@ async function send() {
 		// answering about the wrong record after a navigation.
 		const res = await sendMessage(convId.value, text, props.context, atts);
 		if (res?.conversation_id) convId.value = res.conversation_id;
+		// A go-ahead on the parked card ran the confirmation instead of starting a
+		// turn. No run is coming, so marking the panel busy would spin forever, and
+		// nothing was persisted for the typed words. Reload: the durable receipt
+		// chip is the record of what happened.
+		if (res?.confirmed) {
+			sending.value = false;
+			messages.value = messages.value.filter((m) => !String(m.name).startsWith("local-"));
+			if (res.ok === false)
+				loadError.value = "That confirmation is no longer valid. Ask again to retry it.";
+			await load();
+			return;
+		}
 		stream.value = { ...stream.value, busy: true };
 		ensureRealtime();
 		startPolling();

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -135,6 +135,10 @@ function applyAdmitted(s, p) {
         token: p.token,
         tool: p.tool || "",
         summary: p.summary || "",
+        // expires_at is the primary sort key for numbered typed approval
+        // ("confirm 2"). Dropping it makes orderedPending fall back to token
+        // order, which disagrees with the server and can run the wrong card.
+        expires_at: p.expires_at ?? null,
       });
       return s;
 

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -133,19 +133,46 @@ test("action:pending queues a confirmation, ignoring duplicate tokens", () => {
     token: "t1",
     tool: "create_doc",
     summary: "Create ToDo",
+    expires_at: 1700,
   });
   s = applyEvent(s, {
     kind: "action:pending",
     token: "t1",
     tool: "create_doc",
     summary: "Create ToDo",
+    expires_at: 1700,
   });
   assert.equal(s.pending.length, 1);
   assert.deepEqual(s.pending[0], {
     token: "t1",
     tool: "create_doc",
     summary: "Create ToDo",
+    expires_at: 1700,
   });
+});
+
+test("action:pending carries expires_at so numbered typed approval sorts by mint time", () => {
+  // expires_at is the primary sort key the panel numbers cards by. If it is
+  // dropped here, orderedPending falls back to token order and diverges from the
+  // server, so a typed "confirm 2" can run the wrong card. Pin that it survives.
+  const s = applyEvent(emptyStream(), {
+    kind: "action:pending",
+    token: "abc",
+    tool: "delete_doc",
+    summary: "Delete Customer",
+    expires_at: 1902,
+  });
+  assert.equal(s.pending[0].expires_at, 1902);
+});
+
+test("action:pending with no expires_at on the wire falls back to null, not undefined", () => {
+  const s = applyEvent(emptyStream(), {
+    kind: "action:pending",
+    token: "z",
+    tool: "submit_doc",
+    summary: "Submit SO",
+  });
+  assert.equal(s.pending[0].expires_at, null);
 });
 
 test("action:pending without a token is ignored", () => {

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -24,13 +24,19 @@ export const getConversation = (conversation) =>
 //
 // `context` is the object from desk_context.contextFromRoute. Send it only when
 // there is one, so a non-record page behaves as a plain chat.
-export const sendMessage = (conversation, message, context, attachments) =>
+export const sendMessage = (conversation, message, context, attachments, approvalTokens) =>
   call(CHAT + "send_message", {
     conversation: conversation || "",
     message,
     ...(context ? { context: JSON.stringify(context) } : {}),
     ...(attachments && attachments.length
       ? { attachments: JSON.stringify(attachments) }
+      : {}),
+    // Ordered tokens of the on-screen confirmation cards, so a typed "confirm 2"
+    // resolves to the card shown at that number instead of a re-fetched position
+    // that a mid-flight expiry could renumber onto a different write.
+    ...(approvalTokens && approvalTokens.length
+      ? { approval_tokens: JSON.stringify(approvalTokens) }
       : {}),
   });
 

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -24,7 +24,13 @@ export const getConversation = (conversation) =>
 //
 // `context` is the object from desk_context.contextFromRoute. Send it only when
 // there is one, so a non-record page behaves as a plain chat.
-export const sendMessage = (conversation, message, context, attachments, approvalTokens) =>
+export const sendMessage = (
+  conversation,
+  message,
+  context,
+  attachments,
+  approvalTokens
+) =>
   call(CHAT + "send_message", {
     conversation: conversation || "",
     message,

--- a/jarvis/public/js/jarvis_chat/widget/pending_order.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/pending_order.mjs
@@ -1,0 +1,25 @@
+// One source of truth for the parked confirmation-card order in the Desk widget.
+//
+// A typed "confirm 2" selects by the number the user sees, and the server
+// resolves that number against the tokens this client sends in this order, so
+// numbered cards MUST order by (expires_at ascending, then token by CODE UNIT) -
+// the same key the server uses (`sorted(key=(expires_at, token))`).
+//
+// Code unit, not localeCompare: locale rules disagree on mixed-case tokens and
+// would renumber a card between screen and server, i.e. run the wrong write.
+//
+// This widget is a separate build from the SPA/PWA, so the comparator is
+// duplicated here and pinned by its own test (pending_order.test.mjs). The bug
+// this guards against was not the comparator itself but a card built WITHOUT
+// expires_at, so the tests also assert the field survives onto the item.
+
+export function comparePendingCards(a, b) {
+  return (
+    (a.expires_at || 0) - (b.expires_at || 0) ||
+    (a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
+  );
+}
+
+export function sortPendingCards(cards) {
+  return [...(cards || [])].sort(comparePendingCards);
+}

--- a/jarvis/public/js/jarvis_chat/widget/pending_order.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/pending_order.test.mjs
@@ -15,7 +15,7 @@ test("orders by expires_at ascending, earliest-minted is number 1", () => {
   ]);
   assert.deepEqual(
     out.map((c) => c.token),
-    ["a", "z"],
+    ["a", "z"]
   );
 });
 
@@ -28,7 +28,7 @@ test("tie-breaks equal expires_at by token in code-unit order, matching the serv
   ]);
   assert.deepEqual(
     out.map((c) => c.token),
-    ["A0", "z9"],
+    ["A0", "z9"]
   );
 });
 
@@ -41,7 +41,7 @@ test("two cards with differing expires_at do NOT collapse to token order", () =>
   ]);
   assert.deepEqual(
     out.map((c) => c.token),
-    ["z9", "A0"],
+    ["z9", "A0"]
   );
 });
 
@@ -49,6 +49,6 @@ test("treats a missing expires_at as 0 without throwing", () => {
   const out = sortPendingCards([{ token: "b", expires_at: 5 }, { token: "a" }]);
   assert.deepEqual(
     out.map((c) => c.token),
-    ["a", "b"],
+    ["a", "b"]
   );
 });

--- a/jarvis/public/js/jarvis_chat/widget/pending_order.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/pending_order.test.mjs
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { comparePendingCards, sortPendingCards } from "./pending_order.mjs";
+
+// The Desk widget shipped the wrong-write bug because its cards were built
+// without expires_at, so its correct-looking comparator sorted by token alone.
+// These pin the comparator's real behaviour with real inputs (a source grep
+// would not have caught that); chat_stream.test.mjs pins that the field actually
+// reaches the item.
+
+test("orders by expires_at ascending, earliest-minted is number 1", () => {
+  const out = sortPendingCards([
+    { token: "z", expires_at: 200 },
+    { token: "a", expires_at: 100 },
+  ]);
+  assert.deepEqual(
+    out.map((c) => c.token),
+    ["a", "z"],
+  );
+});
+
+test("tie-breaks equal expires_at by token in code-unit order, matching the server", () => {
+  // 'A' (0x41) < 'z' (0x7A) by code unit; a locale compare would disagree - the
+  // exact divergence that renumbers a card between screen and server.
+  const out = sortPendingCards([
+    { token: "z9", expires_at: 100 },
+    { token: "A0", expires_at: 100 },
+  ]);
+  assert.deepEqual(
+    out.map((c) => c.token),
+    ["A0", "z9"],
+  );
+});
+
+test("two cards with differing expires_at do NOT collapse to token order", () => {
+  // Regression for the shipped bug: if expires_at is present it must dominate.
+  // 'A0' has the LATER expiry, so token order (A0 first) must lose to mint order.
+  const out = sortPendingCards([
+    { token: "A0", expires_at: 200 },
+    { token: "z9", expires_at: 100 },
+  ]);
+  assert.deepEqual(
+    out.map((c) => c.token),
+    ["z9", "A0"],
+  );
+});
+
+test("treats a missing expires_at as 0 without throwing", () => {
+  const out = sortPendingCards([{ token: "b", expires_at: 5 }, { token: "a" }]);
+  assert.deepEqual(
+    out.map((c) => c.token),
+    ["a", "b"],
+  );
+});

--- a/jarvis/tests/test_typed_confirmation.py
+++ b/jarvis/tests/test_typed_confirmation.py
@@ -11,7 +11,29 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import approval_phrases
-from jarvis.chat.api import _typed_confirmation
+from jarvis.chat.api import _typed_approval_eligible, _typed_confirmation
+
+
+class TestTypedApprovalGate(FrappeTestCase):
+	"""The entry gate: only a human, foreground, attachment-free send may be read
+	as an approval. A refactor that drops one condition could let a scripted or
+	background message consume a real ERP-write card, so pin the whole truth table."""
+
+	def test_a_plain_human_foreground_send_is_eligible(self):
+		self.assertTrue(_typed_approval_eligible(delegated=False, attachments=[], background=0))
+
+	def test_a_delegated_send_is_never_eligible(self):
+		self.assertFalse(_typed_approval_eligible(delegated=True, attachments=[], background=0))
+
+	def test_a_background_send_is_never_eligible(self):
+		self.assertFalse(_typed_approval_eligible(delegated=False, attachments=[], background=1))
+		# Frappe may hand a whitelisted int param through as a string.
+		self.assertFalse(_typed_approval_eligible(delegated=False, attachments=[], background="1"))
+
+	def test_a_send_carrying_attachments_is_never_eligible(self):
+		self.assertFalse(
+			_typed_approval_eligible(delegated=False, attachments=[{"file_url": "/f.png"}], background=0)
+		)
 
 
 class TestApprovalPhrases(FrappeTestCase):
@@ -142,12 +164,21 @@ class TestTypedConfirmation(FrappeTestCase):
 	def _card(self, token="tok-1"):
 		return {"token": token, "tool": "create_doc", "summary": "create Supplier"}
 
+	def _toks(self, cards):
+		"""The tokens a client displays, in the (expires_at, token) order the panel
+		shows them - exactly what a real client now sends as ``approval_tokens``.
+		A typed number binds to THIS order, not to a list the server re-fetches."""
+		return [
+			c["token"]
+			for c in sorted(cards, key=lambda c: (c.get("expires_at") or 0, c.get("token") or ""))
+		]
+
 	def test_a_lone_card_and_a_plain_go_ahead_runs_the_confirmation(self):
 		with (
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
 			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
 		):
-			out = _typed_confirmation(self.user, self.conv, "go ahead")
+			out = _typed_confirmation(self.user, self.conv, "go ahead", self._toks([self._card()]))
 		core.assert_called_once_with("tok-1", self.conv, batch=False)
 		self.assertTrue(out["confirmed"])
 		self.assertTrue(out["ok"])
@@ -162,7 +193,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
 			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
 		):
-			out = _typed_confirmation(self.user, self.conv, "go ahead")
+			out = _typed_confirmation(self.user, self.conv, "go ahead", self._toks(cards))
 		self.assertEqual(core.call_count, 3)
 		self.assertEqual(out["tokens"], ["a", "b", "c"])
 		self.assertTrue(out["ok"])
@@ -178,7 +209,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			) as core,
 			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}) as cont,
 		):
-			_typed_confirmation(self.user, self.conv, "confirm all")
+			_typed_confirmation(self.user, self.conv, "confirm all", self._toks(cards))
 		# Every card ran in batch mode, so none queued its own follow-up...
 		for call in core.call_args_list:
 			self.assertTrue(call.kwargs["batch"])
@@ -193,7 +224,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
 			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
 		):
-			out = _typed_confirmation(self.user, self.conv, "confirm 1 and 3")
+			out = _typed_confirmation(self.user, self.conv, "confirm 1 and 3", self._toks(cards))
 		self.assertEqual([c.args[0] for c in core.call_args_list], ["a", "c"])
 		self.assertEqual(out["tokens"], ["a", "c"])
 		self.assertEqual([r["position"] for r in out["results"]], [1, 3])
@@ -205,7 +236,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
 			patch("jarvis.chat.actions_api._confirm_core") as core,
 		):
-			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm 4"))
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm 4", self._toks(cards)))
 		core.assert_not_called()
 
 	def test_a_partial_batch_failure_is_reported_per_card(self):
@@ -220,10 +251,15 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.actions_api._confirm_core", side_effect=envelopes),
 			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
 		):
-			out = _typed_confirmation(self.user, self.conv, "confirm all")
+			out = _typed_confirmation(self.user, self.conv, "confirm all", self._toks(cards))
 		self.assertFalse(out["ok"])
 		self.assertEqual(out["error"]["type"], "PartialConfirmation")
 		self.assertEqual([r["ok"] for r in out["results"]], [True, False])
+		# The user-facing count AND which card failed, by its number (card b is 2).
+		self.assertEqual(
+			out["error"]["message"],
+			"1 of 2 actions went through; 1 could not be completed (card 2).",
+		)
 
 	def test_cards_are_ordered_so_the_numbers_mean_what_the_screen_shows(self):
 		"""The store is a Redis SET with no order at all.
@@ -240,7 +276,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
 			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
 		):
-			_typed_confirmation(self.user, self.conv, "confirm 1")
+			_typed_confirmation(self.user, self.conv, "confirm 1", self._toks(cards))
 		core.assert_called_once()
 		self.assertEqual(core.call_args.args[0], "early")
 
@@ -249,7 +285,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[]),
 			patch("jarvis.chat.actions_api._confirm_core") as core,
 		):
-			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm"))
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm", ["ghost"]))
 		core.assert_not_called()
 
 	def test_a_qualified_yes_reaches_the_model_even_with_a_card_open(self):
@@ -258,7 +294,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
 			patch("jarvis.chat.actions_api._confirm_core") as core,
 		):
-			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes but change the quantity to 5"))
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes but change the quantity to 5", self._toks([self._card()])))
 		# Reading the parked list is harmless; running a write is not.
 		core.assert_not_called()
 
@@ -277,7 +313,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			),
 			patch("jarvis.chat.actions_api._confirm_core") as core,
 		):
-			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes"))
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes", ["tok-1"]))
 		core.assert_not_called()
 
 	def test_a_failed_confirmation_still_reports_as_handled(self):
@@ -291,7 +327,7 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
 			patch("jarvis.chat.actions_api._confirm_core", return_value=envelope),
 		):
-			out = _typed_confirmation(self.user, self.conv, "yes")
+			out = _typed_confirmation(self.user, self.conv, "yes", self._toks([self._card()]))
 		self.assertTrue(out["confirmed"])
 		self.assertFalse(out["ok"])
 
@@ -302,10 +338,73 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
 			patch("jarvis.chat.actions_api._confirm_core", return_value=envelope),
 		):
-			out = _typed_confirmation(self.user, self.conv, "confirm")
+			out = _typed_confirmation(self.user, self.conv, "confirm", self._toks([self._card()]))
 		self.assertTrue(out["queued"])
 		self.assertEqual(out["queued_position"], 2)
 		self.assertEqual(out["run_id"], "r1")
+
+
+class TestTypedApprovalBindsToDisplayedTokens(FrappeTestCase):
+	"""C2: a typed number selects by the token the client showed at that number,
+	not by a position in a list the server re-fetches. A card expiring between the
+	user's glance and their send must never renumber the rest onto a wrong write."""
+
+	def setUp(self):
+		self.user = frappe.session.user
+		self.conv = "conv-typed-confirm"
+
+	def _card(self, token, tool="create_doc", summary="do it"):
+		return {"token": token, "tool": tool, "summary": summary}
+
+	def test_a_number_pointing_at_an_expired_card_runs_nothing(self):
+		"""The exact wrong-card bug. Client showed [A=submit(1), B=delete(2)]. A
+		expires; the server's live set is now just B. "confirm 1" means A, which is
+		gone - it must NOT fall onto B and run the delete."""
+		displayed = ["A", "B"]  # what the client rendered, positions 1 and 2
+		live_now = [self._card("B", tool="delete_doc", summary="delete Customer")]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=live_now),
+			patch("jarvis.chat.actions_api._confirm_core") as core,
+		):
+			out = _typed_confirmation(self.user, self.conv, "confirm 1", displayed)
+		# Falls through to the model; the delete never ran.
+		self.assertIsNone(out)
+		core.assert_not_called()
+
+	def test_a_still_live_number_confirms_that_exact_card_after_a_sibling_expired(self):
+		"""The mirror: "confirm 2" means B, B is still live, so B runs - selection
+		follows what the user saw, not the shrunken server list."""
+		displayed = ["A", "B"]
+		live_now = [self._card("B", tool="delete_doc", summary="delete Customer")]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=live_now),
+			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
+		):
+			out = _typed_confirmation(self.user, self.conv, "confirm 2", displayed)
+		core.assert_called_once_with("B", self.conv, batch=False)
+		self.assertEqual(out["tokens"], ["B"])
+
+	def test_without_displayed_tokens_a_typed_approval_falls_through(self):
+		"""A client that sends no token list (an older or third-party client) cannot
+		resolve a number safely, so the message reaches the model and the button
+		still works - never a positional guess against a re-fetched list."""
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card("A")]),
+			patch("jarvis.chat.actions_api._confirm_core") as core,
+		):
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm 1", None))
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "go ahead", []))
+		core.assert_not_called()
+
+	def test_a_malformed_token_list_falls_through(self):
+		"""A garbled position list must never be best-guessed against an ERP write."""
+		for bad in (["A", ""], ["A", 2], "not-json", [""], list(range(60))):
+			with (
+				patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card("A")]),
+				patch("jarvis.chat.actions_api._confirm_core") as core,
+			):
+				self.assertIsNone(_typed_confirmation(self.user, self.conv, "go ahead", bad), bad)
+				core.assert_not_called()
 
 
 class TestConfirmCoreIsShared(FrappeTestCase):

--- a/jarvis/tests/test_typed_confirmation.py
+++ b/jarvis/tests/test_typed_confirmation.py
@@ -169,8 +169,7 @@ class TestTypedConfirmation(FrappeTestCase):
 		shows them - exactly what a real client now sends as ``approval_tokens``.
 		A typed number binds to THIS order, not to a list the server re-fetches."""
 		return [
-			c["token"]
-			for c in sorted(cards, key=lambda c: (c.get("expires_at") or 0, c.get("token") or ""))
+			c["token"] for c in sorted(cards, key=lambda c: (c.get("expires_at") or 0, c.get("token") or ""))
 		]
 
 	def test_a_lone_card_and_a_plain_go_ahead_runs_the_confirmation(self):
@@ -294,7 +293,11 @@ class TestTypedConfirmation(FrappeTestCase):
 			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
 			patch("jarvis.chat.actions_api._confirm_core") as core,
 		):
-			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes but change the quantity to 5", self._toks([self._card()])))
+			self.assertIsNone(
+				_typed_confirmation(
+					self.user, self.conv, "yes but change the quantity to 5", self._toks([self._card()])
+				)
+			)
 		# Reading the parked list is harmless; running a write is not.
 		core.assert_not_called()
 

--- a/jarvis/tests/test_typed_confirmation.py
+++ b/jarvis/tests/test_typed_confirmation.py
@@ -1,0 +1,319 @@
+"""Typed approval of a parked confirmation card.
+
+A card gives two equal ways to say yes: the Confirm button, and saying so in the
+composer. The second one is a convenience over the first and must never be wider
+than it, so most of what follows asserts what does NOT confirm.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import approval_phrases
+from jarvis.chat.api import _typed_confirmation
+
+
+class TestApprovalPhrases(FrappeTestCase):
+	"""The matcher alone: whole-message equality against a short fixed list."""
+
+	def test_accepts_the_plain_go_aheads(self):
+		for phrase in ("confirm", "yes", "go ahead", "proceed", "do it", "ok", "approve"):
+			self.assertTrue(approval_phrases.is_approval(phrase), phrase)
+
+	def test_ignores_case_padding_and_trailing_punctuation(self):
+		for phrase in ("  Go Ahead  ", "YES!", "Confirm.", "ok,", "Yes  Please"):
+			self.assertTrue(approval_phrases.is_approval(phrase), phrase)
+
+	def test_rejects_an_approval_carrying_a_qualifier(self):
+		"""The whole point of whole-message matching.
+
+		Every one of these contains an approval word and none of them approves
+		what is on the card. Substring matching would run the wrong write.
+		"""
+		for phrase in (
+			"yes but change the quantity to 5",
+			"yes, use Acme instead",
+			"go ahead and also create the item",
+			"confirm the other one",
+			"ok so what does this do",
+			"do it tomorrow",
+			"no, go ahead with the first one",
+		):
+			self.assertFalse(approval_phrases.is_approval(phrase), phrase)
+
+	def test_rejects_a_question_about_the_card(self):
+		"""A question mark survives normalisation, so it cannot match."""
+		for phrase in ("confirm?", "go ahead?", "ok?"):
+			self.assertFalse(approval_phrases.is_approval(phrase), phrase)
+
+	def test_rejects_declines_and_unrelated_text(self):
+		for phrase in ("no", "cancel", "stop", "discard", "wait", "hello", ""):
+			self.assertFalse(approval_phrases.is_approval(phrase), phrase)
+
+	def test_rejects_the_strings_the_confirm_CARD_button_already_sends(self):
+		"""A different card type already answers itself by sending a message.
+
+		The model-authored ```confirm block's buttons call send() with these exact
+		strings (ChatView.vue). They belong to that card, not to a parked gated
+		write, so they must keep reaching the model. The internal comma is what
+		keeps them out, which is easy to break by "tidying" the phrase list.
+		"""
+		for phrase in ("Yes, go ahead.", "No, cancel that.", "Yes — Confirm and save"):
+			self.assertFalse(approval_phrases.is_approval(phrase), phrase)
+
+	def test_rejects_anything_long_enough_to_be_a_message(self):
+		self.assertFalse(approval_phrases.is_approval("yes " * 20))
+
+	def test_tolerates_nullish_input(self):
+		self.assertFalse(approval_phrases.is_approval(None))
+
+
+class TestParseApproval(FrappeTestCase):
+	"""Which of N cards a message approves. None means "not an approval at all"."""
+
+	def test_a_plain_go_ahead_takes_the_only_card(self):
+		self.assertEqual(approval_phrases.parse_approval("go ahead", 1), [0])
+
+	def test_a_plain_go_ahead_takes_EVERY_card_when_several_are_parked(self):
+		self.assertEqual(approval_phrases.parse_approval("yes", 3), [0, 1, 2])
+
+	def test_explicit_bulk_phrases(self):
+		for phrase in ("confirm all", "yes to all", "approve all of them", "all", "confirm both"):
+			self.assertEqual(approval_phrases.parse_approval(phrase, 2), [0, 1], phrase)
+
+	def test_selecting_by_number(self):
+		self.assertEqual(approval_phrases.parse_approval("confirm 1", 3), [0])
+		self.assertEqual(approval_phrases.parse_approval("confirm 1 and 3", 3), [0, 2])
+		self.assertEqual(approval_phrases.parse_approval("approve 2, 3", 3), [1, 2])
+		self.assertEqual(approval_phrases.parse_approval("yes to 2", 3), [1])
+		self.assertEqual(approval_phrases.parse_approval("do 1 & 2", 3), [0, 1])
+
+	def test_a_selection_is_deduped_and_sorted(self):
+		self.assertEqual(approval_phrases.parse_approval("confirm 3, 1, 3", 3), [0, 2])
+
+	def test_a_number_out_of_range_approves_NOTHING(self):
+		"""Not "everything", and not "the ones that do exist".
+
+		"Confirm 4" against three cards means the user is looking at something we
+		are not. Running any write on that basis is the wrong recovery.
+		"""
+		self.assertIsNone(approval_phrases.parse_approval("confirm 4", 3))
+		self.assertIsNone(approval_phrases.parse_approval("confirm 0", 3))
+		self.assertIsNone(approval_phrases.parse_approval("confirm 1 and 9", 3))
+
+	def test_a_qualifier_still_beats_every_form(self):
+		for phrase in (
+			"confirm 1 but change the date",
+			"yes to all of the suppliers except the second",
+			"confirm all the details look wrong",
+			"approve 1 tomorrow",
+		):
+			self.assertIsNone(approval_phrases.parse_approval(phrase, 3), phrase)
+
+	def test_a_bare_number_is_not_an_approval(self):
+		"""Without a verb, "1" is far more likely to be an answer to a question."""
+		self.assertIsNone(approval_phrases.parse_approval("1", 3))
+		self.assertIsNone(approval_phrases.parse_approval("1 and 2", 3))
+
+	def test_declines_are_never_approvals_in_any_form(self):
+		for phrase in ("no", "cancel all", "no to all", "discard 1"):
+			self.assertIsNone(approval_phrases.parse_approval(phrase, 3), phrase)
+
+	def test_a_question_is_not_a_bulk_approval_either(self):
+		"""The question-mark rule has to survive into the bulk forms.
+
+		"All?" is a user asking what the cards are, not approving three writes.
+		"""
+		for phrase in ("all?", "confirm all?", "confirm 1?"):
+			self.assertIsNone(approval_phrases.parse_approval(phrase, 3), phrase)
+
+	def test_no_cards_means_no_approval(self):
+		self.assertIsNone(approval_phrases.parse_approval("confirm all", 0))
+
+
+class TestTypedConfirmation(FrappeTestCase):
+	"""The intercept: which messages reach the confirmation, and which fall through."""
+
+	def setUp(self):
+		self.user = frappe.session.user
+		self.conv = "conv-typed-confirm"
+
+	def _card(self, token="tok-1"):
+		return {"token": token, "tool": "create_doc", "summary": "create Supplier"}
+
+	def test_a_lone_card_and_a_plain_go_ahead_runs_the_confirmation(self):
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
+			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
+		):
+			out = _typed_confirmation(self.user, self.conv, "go ahead")
+		core.assert_called_once_with("tok-1", self.conv, batch=False)
+		self.assertTrue(out["confirmed"])
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["tokens"], ["tok-1"])
+		self.assertEqual(out["conversation_id"], self.conv)
+
+	def test_a_plain_go_ahead_with_several_cards_confirms_them_all(self):
+		"""A user who lines up three writes and says go ahead means three."""
+		cards = [self._card("a"), self._card("b"), self._card("c")]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
+			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
+			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
+		):
+			out = _typed_confirmation(self.user, self.conv, "go ahead")
+		self.assertEqual(core.call_count, 3)
+		self.assertEqual(out["tokens"], ["a", "b", "c"])
+		self.assertTrue(out["ok"])
+
+	def test_a_batch_produces_ONE_continuation_turn_not_one_per_card(self):
+		"""Ten approvals must not become ten turns racing through admission."""
+		cards = [self._card(t) for t in ("a", "b", "c")]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
+			patch(
+				"jarvis.chat.actions_api._confirm_core",
+				return_value={"ok": True, "receipt_text": "created X."},
+			) as core,
+			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}) as cont,
+		):
+			_typed_confirmation(self.user, self.conv, "confirm all")
+		# Every card ran in batch mode, so none queued its own follow-up...
+		for call in core.call_args_list:
+			self.assertTrue(call.kwargs["batch"])
+		# ...and exactly one carries all three receipts.
+		cont.assert_called_once()
+		self.assertEqual(cont.call_args.args[1], "created X. created X. created X.")
+
+	def test_selecting_by_number_confirms_only_those_cards(self):
+		cards = [self._card("a"), self._card("b"), self._card("c")]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
+			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
+			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
+		):
+			out = _typed_confirmation(self.user, self.conv, "confirm 1 and 3")
+		self.assertEqual([c.args[0] for c in core.call_args_list], ["a", "c"])
+		self.assertEqual(out["tokens"], ["a", "c"])
+		self.assertEqual([r["position"] for r in out["results"]], [1, 3])
+
+	def test_a_number_that_does_not_exist_confirms_NOTHING(self):
+		"""The wrong recovery would be to run all three anyway."""
+		cards = [self._card("a"), self._card("b"), self._card("c")]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
+			patch("jarvis.chat.actions_api._confirm_core") as core,
+		):
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm 4"))
+		core.assert_not_called()
+
+	def test_a_partial_batch_failure_is_reported_per_card(self):
+		"""With three writes, "it worked" is not an answer when one did not."""
+		cards = [self._card("a"), self._card("b")]
+		envelopes = [
+			{"ok": True, "receipt_text": "created X."},
+			{"ok": False, "error": {"type": "InvalidConfirmation", "message": "gone"}},
+		]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
+			patch("jarvis.chat.actions_api._confirm_core", side_effect=envelopes),
+			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
+		):
+			out = _typed_confirmation(self.user, self.conv, "confirm all")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["type"], "PartialConfirmation")
+		self.assertEqual([r["ok"] for r in out["results"]], [True, False])
+
+	def test_cards_are_ordered_so_the_numbers_mean_what_the_screen_shows(self):
+		"""The store is a Redis SET with no order at all.
+
+		Without the sort, "confirm 1" would pick whichever token the set happened
+		to yield first, which is the wrong write roughly half the time.
+		"""
+		cards = [
+			dict(self._card("late"), expires_at=200),
+			dict(self._card("early"), expires_at=100),
+		]
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=cards),
+			patch("jarvis.chat.actions_api._confirm_core", return_value={"ok": True}) as core,
+			patch("jarvis.chat.actions_api.enqueue_continuation", return_value={}),
+		):
+			_typed_confirmation(self.user, self.conv, "confirm 1")
+		core.assert_called_once()
+		self.assertEqual(core.call_args.args[0], "early")
+
+	def test_no_parked_card_falls_through(self):
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[]),
+			patch("jarvis.chat.actions_api._confirm_core") as core,
+		):
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "confirm"))
+		core.assert_not_called()
+
+	def test_a_qualified_yes_reaches_the_model_even_with_a_card_open(self):
+		"""The message that must NOT confirm, with a card sitting right there."""
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
+			patch("jarvis.chat.actions_api._confirm_core") as core,
+		):
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes but change the quantity to 5"))
+		# Reading the parked list is harmless; running a write is not.
+		core.assert_not_called()
+
+	def test_a_storage_outage_falls_through_instead_of_confirming(self):
+		"""Unknown state is not approval.
+
+		A "go ahead" that reaches the model is recoverable. A write nobody
+		authorised is not, so an unreadable store must never resolve to a confirm.
+		"""
+		from jarvis.chat import pending_confirm
+
+		with (
+			patch(
+				"jarvis.chat.pending_confirm.list_items_for_owner",
+				side_effect=pending_confirm.PendingConfirmStorageError("redis down"),
+			),
+			patch("jarvis.chat.actions_api._confirm_core") as core,
+		):
+			self.assertIsNone(_typed_confirmation(self.user, self.conv, "yes"))
+		core.assert_not_called()
+
+	def test_a_failed_confirmation_still_reports_as_handled(self):
+		"""The client has to know no run is coming, whatever the outcome.
+
+		`confirmed` means "this was taken as an approval, not a turn". The
+		envelope's own `ok` carries success or failure.
+		"""
+		envelope = {"ok": False, "error": {"type": "InvalidConfirmation", "message": "gone"}}
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
+			patch("jarvis.chat.actions_api._confirm_core", return_value=envelope),
+		):
+			out = _typed_confirmation(self.user, self.conv, "yes")
+		self.assertTrue(out["confirmed"])
+		self.assertFalse(out["ok"])
+
+	def test_the_queued_continuation_details_survive_to_the_client(self):
+		"""So the approved action shows the queued chip instead of going silent."""
+		envelope = {"ok": True, "queued": True, "queued_position": 2, "run_id": "r1"}
+		with (
+			patch("jarvis.chat.pending_confirm.list_items_for_owner", return_value=[self._card()]),
+			patch("jarvis.chat.actions_api._confirm_core", return_value=envelope),
+		):
+			out = _typed_confirmation(self.user, self.conv, "confirm")
+		self.assertTrue(out["queued"])
+		self.assertEqual(out["queued_position"], 2)
+		self.assertEqual(out["run_id"], "r1")
+
+
+class TestConfirmCoreIsShared(FrappeTestCase):
+	"""Both approval paths run the same implementation, so neither can drift."""
+
+	def test_the_button_endpoint_delegates_to_the_shared_core(self):
+		from jarvis.chat import actions_api
+
+		with patch.object(actions_api, "_confirm_core", return_value={"ok": True}) as core:
+			actions_api.confirm_tool("tok-9", "conv-9")
+		core.assert_called_once_with("tok-9", "conv-9")

--- a/pwa/src/api.js
+++ b/pwa/src/api.js
@@ -34,7 +34,11 @@ export const getChatUiSettings = () => call(CHAT + "get_chat_ui_settings");
 // model/thinking are sent as per-turn overrides, which is how the new-chat
 // screen applies the device's preferred model without mutating the workspace
 // default.
-export const sendMessage = (conversation, message, { attachments = [], model, thinking, approvalTokens } = {}) =>
+export const sendMessage = (
+	conversation,
+	message,
+	{ attachments = [], model, thinking, approvalTokens } = {}
+) =>
 	call(CHAT + "send_message", {
 		conversation: conversation || "",
 		message,

--- a/pwa/src/api.js
+++ b/pwa/src/api.js
@@ -34,13 +34,19 @@ export const getChatUiSettings = () => call(CHAT + "get_chat_ui_settings");
 // model/thinking are sent as per-turn overrides, which is how the new-chat
 // screen applies the device's preferred model without mutating the workspace
 // default.
-export const sendMessage = (conversation, message, { attachments = [], model, thinking } = {}) =>
+export const sendMessage = (conversation, message, { attachments = [], model, thinking, approvalTokens } = {}) =>
 	call(CHAT + "send_message", {
 		conversation: conversation || "",
 		message,
 		...(attachments.length ? { attachments: JSON.stringify(attachments) } : {}),
 		...(model ? { model_override: model } : {}),
 		...(thinking ? { thinking_override: thinking } : {}),
+		// Ordered tokens of the on-screen confirmation cards, so a typed "confirm 2"
+		// binds to the card shown at that number rather than a server-re-fetched
+		// position that a mid-flight expiry could renumber onto the wrong write.
+		...(approvalTokens && approvalTokens.length
+			? { approval_tokens: JSON.stringify(approvalTokens) }
+			: {}),
 	});
 
 export const stopRun = (conversation, runId) =>

--- a/pwa/src/lib/sortPendingCards.js
+++ b/pwa/src/lib/sortPendingCards.js
@@ -1,0 +1,22 @@
+// One source of truth for the parked confirmation-card order on the PWA.
+//
+// A typed "confirm 2" selects by the number the user sees, and the server
+// resolves that number against the tokens this client sends in this order, so
+// numbered cards MUST order by (expires_at ascending, then token by CODE UNIT) -
+// the same key the server uses (`sorted(key=(expires_at, token))`).
+//
+// Code unit, not localeCompare: locale rules disagree on mixed-case tokens and
+// would renumber a card between screen and server, i.e. run the wrong write.
+//
+// Duplicated per client build (SPA/PWA/Desk cannot share a module); each copy is
+// pinned by its own test so they cannot drift. See sortPendingCards.test.js.
+export function comparePendingCards(a, b) {
+	return (
+		(a.expires_at || 0) - (b.expires_at || 0) ||
+		(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
+	);
+}
+
+export function sortPendingCards(cards) {
+	return [...(cards || [])].sort(comparePendingCards);
+}

--- a/pwa/src/lib/sortPendingCards.test.js
+++ b/pwa/src/lib/sortPendingCards.test.js
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { comparePendingCards, sortPendingCards } from "./sortPendingCards.js";
+
+// Real behavioural tests for the order a typed "confirm N" indexes into. A
+// source grep of the comparator text passes even when the client drops
+// expires_at (how the Desk-widget wrong-write bug shipped), so pin behaviour.
+
+test("orders by expires_at ascending, earliest-minted is number 1", () => {
+	const out = sortPendingCards([
+		{ token: "z", expires_at: 200 },
+		{ token: "a", expires_at: 100 },
+	]);
+	assert.deepEqual(
+		out.map((c) => c.token),
+		["a", "z"]
+	);
+});
+
+test("tie-breaks equal expires_at by token in code-unit order, matching the server", () => {
+	// 'A' (0x41) < 'z' (0x7A) by code unit; a locale compare would disagree.
+	const out = sortPendingCards([
+		{ token: "z9", expires_at: 100 },
+		{ token: "A0", expires_at: 100 },
+	]);
+	assert.deepEqual(
+		out.map((c) => c.token),
+		["A0", "z9"]
+	);
+});
+
+test("treats a missing expires_at as 0 without throwing", () => {
+	const out = sortPendingCards([{ token: "b", expires_at: 5 }, { token: "a" }]);
+	assert.deepEqual(
+		out.map((c) => c.token),
+		["a", "b"]
+	);
+});
+
+test("does not mutate its input", () => {
+	const input = [
+		{ token: "z", expires_at: 2 },
+		{ token: "a", expires_at: 1 },
+	];
+	sortPendingCards(input);
+	assert.deepEqual(
+		input.map((c) => c.token),
+		["z", "a"]
+	);
+});
+
+test("distinct tokens never tie (total order)", () => {
+	assert.ok(comparePendingCards({ token: "a", expires_at: 1 }, { token: "b", expires_at: 1 }) < 0);
+	assert.ok(comparePendingCards({ token: "b", expires_at: 1 }, { token: "a", expires_at: 1 }) > 0);
+	assert.equal(comparePendingCards({ token: "a", expires_at: 1 }, { token: "a", expires_at: 1 }), 0);
+});

--- a/pwa/src/lib/sortPendingCards.test.js
+++ b/pwa/src/lib/sortPendingCards.test.js
@@ -50,7 +50,14 @@ test("does not mutate its input", () => {
 });
 
 test("distinct tokens never tie (total order)", () => {
-	assert.ok(comparePendingCards({ token: "a", expires_at: 1 }, { token: "b", expires_at: 1 }) < 0);
-	assert.ok(comparePendingCards({ token: "b", expires_at: 1 }, { token: "a", expires_at: 1 }) > 0);
-	assert.equal(comparePendingCards({ token: "a", expires_at: 1 }, { token: "a", expires_at: 1 }), 0);
+	assert.ok(
+		comparePendingCards({ token: "a", expires_at: 1 }, { token: "b", expires_at: 1 }) < 0
+	);
+	assert.ok(
+		comparePendingCards({ token: "b", expires_at: 1 }, { token: "a", expires_at: 1 }) > 0
+	);
+	assert.equal(
+		comparePendingCards({ token: "a", expires_at: 1 }, { token: "a", expires_at: 1 }),
+		0
+	);
 });

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -29,6 +29,7 @@ import {
 	toolStatus,
 } from "../lib/blocks";
 import { spanBetween } from "../lib/time";
+import { sortPendingCards } from "../lib/sortPendingCards.js";
 import ActionCard from "../components/ActionCard.vue";
 import ChartCard from "../components/ChartCard.vue";
 import Composer from "../components/Composer.vue";
@@ -70,13 +71,15 @@ const pending = ref([]); // parked writes awaiting approval
 // a Redis SET, which has no order at all, so without this the numbers on screen
 // and the numbers the server counts could disagree and the wrong write would run.
 // Tokens compare by code unit to match Python's byte order, not localeCompare.
-const orderedPending = computed(() =>
-	[...pending.value].sort(
-		(a, b) =>
-			(a.expires_at || 0) - (b.expires_at || 0) ||
-			(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
-	)
-);
+// Ordered by the shared, unit-tested comparator so the numbers on screen match
+// the server's (expires_at, token) order a typed "confirm N" resolves against.
+const orderedPending = computed(() => sortPendingCards(pending.value));
+// Typed approval works here as on the desktop, but only the desktop advertised
+// it. The selective example numbers track the real count so it never overshoots.
+const typedApprovalHint = computed(() => {
+	const n = orderedPending.value.length;
+	return n > 1 ? `or type "confirm all", or "confirm 1 and ${n}"` : 'or type "go ahead"';
+});
 const settings = ref(null);
 
 // The turn in flight. Held separately from `messages` because it is not durable
@@ -288,6 +291,9 @@ async function send() {
 		// screen — same rule as the native app.
 		const res = await api.sendMessage(convId.value, text, {
 			attachments: ready.map((a) => ({ file_url: a.file_url, file_name: a.name })),
+			// Numbers a typed approval selects by must resolve against the cards on
+			// screen, in this order, not a list the server re-fetches at send time.
+			approvalTokens: orderedPending.value.map((p) => p.token),
 		});
 		// The server read this as a go-ahead on the parked card and ran the
 		// confirmation instead of starting a turn, so no run events are coming and
@@ -775,6 +781,8 @@ onUnmounted(() => {
 			"
 			@open="decision = p"
 		/>
+		<!-- Both ways to approve, shown once under the stack. -->
+		<p v-if="orderedPending.length" class="jv-typehint">{{ typedApprovalHint }}</p>
 	</div>
 
 	<div v-if="errorBanner" class="jv-banner">
@@ -1147,6 +1155,12 @@ onUnmounted(() => {
 	border-radius: 4px;
 }
 
+.jv-typehint {
+	margin: 6px 4px 2px;
+	font-size: 12px;
+	line-height: 1.4;
+	color: var(--ink5);
+}
 .jv-banner {
 	display: flex;
 	align-items: center;

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -65,6 +65,18 @@ const sendBusy = ref(false);
 const errorBanner = ref("");
 const attachments = ref([]);
 const pending = ref([]); // parked writes awaiting approval
+// Ordered the SAME way the server orders the parked list, because a typed
+// "confirm 2" selects by the number shown on the card. The store keeps tokens in
+// a Redis SET, which has no order at all, so without this the numbers on screen
+// and the numbers the server counts could disagree and the wrong write would run.
+// Tokens compare by code unit to match Python's byte order, not localeCompare.
+const orderedPending = computed(() =>
+	[...pending.value].sort(
+		(a, b) =>
+			(a.expires_at || 0) - (b.expires_at || 0) ||
+			(a.token < b.token ? -1 : a.token > b.token ? 1 : 0)
+	)
+);
 const settings = ref(null);
 
 // The turn in flight. Held separately from `messages` because it is not durable
@@ -277,6 +289,22 @@ async function send() {
 		const res = await api.sendMessage(convId.value, text, {
 			attachments: ready.map((a) => ({ file_url: a.file_url, file_name: a.name })),
 		});
+		// The server read this as a go-ahead on the parked card and ran the
+		// confirmation instead of starting a turn, so no run events are coming and
+		// nothing was persisted for the typed words. Take the spinner down here or
+		// it waits forever, and drop the optimistic echo of a message that does not
+		// exist. The receipt chip in the reloaded thread is what the user sees.
+		if (res?.confirmed) {
+			sendBusy.value = false;
+			messages.value = messages.value.filter((m) => !m.optimistic);
+			if (res.ok === false)
+				errorBanner.value =
+					res.error?.message ||
+					"That confirmation is no longer valid. Ask again to retry it.";
+			await load(true);
+			await loadPending();
+			return;
+		}
 		if (res?.ok === false) {
 			sendBusy.value = false;
 			messages.value = messages.value.filter((m) => !m.optimistic);
@@ -739,9 +767,12 @@ onUnmounted(() => {
 		<ThinkingIndicator v-if="sending && !(live && live.text)" />
 
 		<DecisionCard
-			v-for="p in pending"
+			v-for="(p, pi) in orderedPending"
 			:key="p.token"
-			:summary="p.summary || p.tool || `${agentName} needs your approval`"
+			:summary="
+				(orderedPending.length > 1 ? `${pi + 1} of ${orderedPending.length}: ` : '') +
+				(p.summary || p.tool || `${agentName} needs your approval`)
+			"
 			@open="decision = p"
 		/>
 	</div>


### PR DESCRIPTION
Four fix-wise chat-surface commits.

## Commits

**`fix(chat): stop a streaming reply flashing its raw block JSON`**
The block-strip patterns matched on the CLOSING fence, so while a block was still being written nothing matched and marked drew it as a code block. The reader watched a wall of raw JSON type itself out and vanish. It hit all eight block types. Blocks are now held from the opener while streaming and released once settled, so a block the agent never closed is still shown rather than silently swallowed. `stripBlocks` moves to `lib/chatBlocks.js`; `streaming` joins the render cache key.

**`fix(chat): pace streamed text and fence stale tool events`**
`assistant:delta` carries the cumulative reply and the view assigned it straight through, so text moved at whatever rate the socket delivered it. A reveal cursor now paces it, snapping to full on every path that could truncate: `run:end` before `streaming` clears, a recovered-run rewrite, stop/error/conversation switch, and a hidden tab where rAF stops. Painting runs at ~25/s rather than 60/s because each paint costs a full markdown re-parse plus a `v-html` rewrite; skipped frames are paid back so the speed is unchanged.

Also fences stale tool events. The CDX-3 pump fence deliberately lets an epoch-less tool event through, and `run:end` clears `activeTools`, so a straggler `tool:start` pushed a `running` entry no `tool:end` would settle, leaving a spinner nobody opened. These land together because the teardown they both touch is one contiguous insertion.

**`feat(chat): approve a confirmation card by typing, including in bulk`**
"go ahead" now approves the parked card, and with several parked it approves all of them; "confirm 1 and 3" approves exactly those by the number on each card. See the security note below.

**`fix(notify): signal a re-published terminal once`**
A finished reply produced two "Reply ready" toasts. A terminal is published more than once (settlement, then the finalize backstop re-publish). ChatView has always deduped it one-shot; the global notifier had no fence at all. It now uses the same fence from the same module, with its own state.

**`fix(compat): run on Frappe 15 as well as 16`**
`pyproject` declares `frappe >=15,<17`, but three APIs that moved between majors were written against 16 and shipped onto 15 benches, where they raised at call time: `File.get_content(encodings=)`, the openpyxl-to-xlsxwriter `xlsxutils` rewrite, and ERPNext's `get_itemised_tax` signature. The `get_content` one was swallowed by a surrounding `except`, so every chat attachment and `read_file` call silently extracted to empty text. Each shim probes a capability rather than branching on `frappe.__version__`.

## Security note on typed approval

This touches the write-safety gate, so it deserves a careful read.

It is a convenience over the Confirm button, never a widening of it. A message must satisfy all of: the WHOLE message parses as an approval, every number named exists, the confirmation store can answer, and the caller is a human interactive session with no attachments. Anything less falls through to the model as ordinary text. `"yes but change the quantity to 5"` approves nothing.

Matching is whole-message equality against a short fixed list. Substring matching would be a security regression on the one gate between the model and a real ERP write.

Per card, the guarantees are identical to the button: same authenticated session user, same owner-bound single-use `consume`, same `exec_user` scope, same receipt chip. Bulk runs N independent confirmations; it creates no path that skips any of them. The model cannot reach this at all, arriving only through the human session endpoint and never the plugin callback. A typed approval racing a click resolves to one winner inside `consume`.

`confirm_tool`'s body moved to `_confirm_core` so both paths share one implementation and neither can weaken the gate.

## Reviewer notes

- **Ordering is load-bearing** once a number selects a card. The store is a Redis SET with no order, so the server and all three clients sort by `(expires_at, token)`, comparing tokens by code unit to match Python's byte order. `localeCompare` disagrees on mixed-case tokens.
- **All three clients were updated.** The SPA, PWA and Desk widget each render these cards; without handling the confirmed response a typed approval would hang their spinner waiting for a run that never comes.
- **Two loose allowlist entries** worth a second opinion: `all` on its own, and `ok`/`sure`/`y`. Safe only because of whole-message matching. Easy to trim.
- **A known bounded window:** numbers can shift between a glance and a send (TTL expiry, a stopped run clearing its tokens, a resync adding one mid-stack). The ordering makes renumbering consistent rather than arbitrary; `consume` being owner-bound and single-use bounds the worst case to confirming a different card the same user owns and can see.

## Testing

- Frontend: **1000 passing across 66 files**, including 18 block-strip, 23 reveal, 10 typed-approval and 9 notifier tests.
- The notifier tests were verified non-vacuous: with the fence removed, exactly the three dedupe tests fail.
- Bench: 32 tests for typed approval, plus `test_compat_frappe_versions.py` for the shims. **These were not run against a site for this PR** and need CI to confirm.
- Two pre-existing failures in `test_confirm_gate` and `test_pending_confirm` were reproduced on a clean `develop`, so they are unrelated to this branch.


---

**Update:** the Frappe 15/16 compatibility commit was moved OUT of this PR to `fix/frappe-15-16-compat`. It was the only red check: 3 errors in `test_compat_frappe_versions.py` (the v15 permission predicate builds over the unaliased table, so an aliased query fails with `Unknown column 'tabToDo.allocated_to'`; and `itemised_tax` on an unsaved taxless doc hits `_item_wise_tax_details = None`). It will come back as its own PR once fixed. This PR is now the four chat-surface fixes only.