### PR TITLE
fix(onboarding): a lapsed signup is offered the page that can renew it

### DIFF
--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -158,6 +158,8 @@ export const ACTIONS = {
 	RESEND: "resend",
 	/** A human. Offered on terminal states and after the client-local check ceiling. */
 	SUPPORT: "support",
+	/** To the billing page, which owns renewal. Routes; never charges. */
+	BILLING: "billing",
 	/** Back to the top of the wizard - nothing exists to recover. */
 	RESTART: "restart",
 };
@@ -275,9 +277,9 @@ const TABLE = {
 	},
 	[CODES.SIGNUP_TERMINAL]: {
 		headline: "This signup cannot be continued.",
-		body: "The subscription it belongs to has ended. Renew from your account, or talk to us and we will sort it out.",
+		body: "The subscription it belongs to has ended. Renew it from your billing page, or talk to us and we will sort it out.",
 		tone: TONE.ALERT,
-		actions: [ACTIONS.SUPPORT],
+		actions: [ACTIONS.BILLING, ACTIONS.SUPPORT],
 	},
 	[CODES.INVALID_REQUEST]: {
 		headline: "That payment request could not be accepted.",
@@ -493,6 +495,7 @@ export const ACTION_LABELS = {
 	// OnboardingView's resendLabel, the same way checkLabel overrides this one
 	// for ACTIONS.CHECK.
 	[ACTIONS.RESEND]: "Resend the link",
+	[ACTIONS.BILLING]: "Renew your plan",
 	[ACTIONS.SUPPORT]: "Contact support",
 	[ACTIONS.RESTART]: "Start again",
 };

--- a/frontend/src/onboarding/paymentCodes.test.js
+++ b/frontend/src/onboarding/paymentCodes.test.js
@@ -277,3 +277,19 @@ test("RESEND is never baked into the verification row either: it is a granted ca
 	assert.ok(!copyFor(CODES.SIGNUP_VERIFICATION_REQUIRED).actions.includes(ACTIONS.RESEND));
 	assert.equal(actionLabelFor({}, ACTIONS.RESEND), "Resend the link");
 });
+
+test("a lapsed signup is offered the page that can actually renew it", () => {
+	// The dead end: copy said "renew from your account", only button was support.
+	const copy = copyFor(CODES.SIGNUP_TERMINAL);
+	assert.equal(copy.actions[0], ACTIONS.BILLING, "renewing is the PRIMARY way out");
+	assert.ok(copy.actions.includes(ACTIONS.SUPPORT), "support stays available");
+	assert.equal(actionLabelFor(copy, ACTIONS.BILLING), "Renew your plan");
+	assert.match(copy.body, /billing page/i);
+});
+
+test("the wizard never grows its own renewal verb", () => {
+	// Renewal lives on billing, with the cohort rules. This action routes, not charges.
+	const copy = copyFor(CODES.SIGNUP_TERMINAL);
+	assert.equal(copy.actions.includes(ACTIONS.INITIATE), false);
+	assert.equal(copy.actions.includes(ACTIONS.RESUME), false);
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2946,6 +2946,11 @@ async function onPayAction(a) {
 	if (a === ACTIONS.RECONNECT) return startReconnect();
 	if (a === ACTIONS.VERIFY) return flow.verifyAndContinue();
 	if (a === ACTIONS.RESEND) return runResendVerification();
+	if (a === ACTIONS.BILLING) {
+		// Hard navigation: AppShell's gate re-renders the poster over an in-SPA route.
+		window.location.assign("/jarvis/billing");
+		return;
+	}
 	if (a === ACTIONS.SUPPORT) return openSupport();
 	if (a === ACTIONS.RESTART) {
 		// A details rejection is not a restart in any meaningful sense: admin named a


### PR DESCRIPTION
Follow-up to #751 (merged). Reported from the running bench: navigating to
`/jarvis/onboarding` on an **expired** site shows

> **This signup cannot be continued.**
> The subscription it belongs to has ended. Renew from your account, or talk to us…

above a single button reading **Contact support**. The copy names the way out and the
screen does not provide it.

This is the same defect #751 fixed for the pay-page *return*, reached from the other
direction: there the checkout **sent** customers to the wizard, here they type the URL
themselves. Both land on `SIGNUP_TERMINAL`, which is the wizard's one code for every
lapsed status.

## The fix routes; it does not rebuild

`SIGNUP_TERMINAL` gains `ACTIONS.BILLING` — **"Renew your plan"** — as its primary
action, with Contact support kept secondary, and the body now points at the billing
page it actually goes to.

The wizard deliberately does **not** grow its own plan grid and payment, which is the
literal reading of "I expected the plan selection page". Renewal already exists on the
billing page together with the rules that make it safe — `can_reactivate`, the
same-cycle grid, and the order-vs-mandate shape decision — and a second
checkout-initiation path for the same money is how two surfaces drift apart. That drift
is what produced the bug being fixed here. A test pins that this code never gains
`INITIATE` or `RESUME` of its own.

It is a hard `window.location.assign`, not a router push: the wizard is rendered by
AppShell's gate over a workspace it considers unready, so an in-SPA route lands back on
the same poster.

## Notes

- `CLAUDE.md`: the review loop runs to GREEN unattended — a RED verdict is work to do,
  not a decision to escalate.
- The review verdict files carry round 3 of the mandate-recovery review (RED on both;
  every code finding since fixed). The three flow scenarios remain unexecuted because
  completing them requires entering card details.

vitest 63 files / 998 tests · node 675 · formatted with the pinned prettier 2.7.1.
