### PR TITLE
feat(onboarding): show the route verdict on the Connect step

### DIFF
--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -100,14 +100,22 @@ export const PHASE_KIND = {
  *
  *   Defaults to NONE so a caller that cannot ground a subject gets no headline
  *   derived from one.
+ * @param {string} [detail] - admin's own live explanation for this same phase,
+ *   when the caller already has one (jarvis#752). The apply-operation poll
+ *   carries `chat_readiness_reason` on every non-terminal status once a
+ *   subscription pool's force-probe verdict lands (fleet contract 1.23), so a
+ *   route that cannot serve (a quota-exhausted account, an unverified
+ *   credential) is nameable well before the readiness wait that used to be
+ *   the only source `readinessPhase` read a detail from. Defaults to "" so
+ *   every other caller, and every tick where admin sent nothing, is unchanged.
  */
-export function inFlightPhase(label, kind = PHASE_KIND.NONE) {
+export function inFlightPhase(label, kind = PHASE_KIND.NONE, detail = "") {
 	return {
 		observed: false,
 		state: PHASE_STATE.ACTIVE,
 		kind,
 		label,
-		detail: "",
+		detail,
 		stop: false,
 	};
 }

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -150,6 +150,29 @@ test("inFlight: names the act of checking, and claims no observation", () => {
 	assert.doesNotMatch(p.label, /couldn't reach|could not reach/i);
 });
 
+// jarvis#752: the apply-operation poll can carry admin's own chat_readiness_reason
+// well before any readiness wait starts (a subscription pool's force-probe verdict
+// lands mid-apply, not only at a terminal). A caller that already has one passes it
+// through unchanged; the phase stays ACTIVE either way, so a route that cannot
+// serve still reads as progress, not as a failure.
+test("inFlight: a caller-supplied detail is carried through unchanged", () => {
+	const p = inFlightPhase(
+		"Applying your AI connection",
+		PHASE_KIND.LLM_APPLY,
+		"Your OpenAI account has reached its usage limit. It resets in 2 hours."
+	);
+	assert.equal(p.state, PHASE_STATE.ACTIVE);
+	assert.equal(
+		p.detail,
+		"Your OpenAI account has reached its usage limit. It resets in 2 hours."
+	);
+});
+
+test("inFlight: no detail argument still defaults to an empty string", () => {
+	const p = inFlightPhase("Checking on your workspace");
+	assert.equal(p.detail, "");
+});
+
 test("readiness: a resolvable wait never stops itself", () => {
 	const reasons = [
 		"llm_pool_provisioning",

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1453,6 +1453,26 @@ describe("jarvis#752 the connect step shows admin's route verdict while still co
 		w.unmount();
 	});
 
+	it("a reason that later cleared is not quoted at the deadline", async () => {
+		// Round-1 review: the remembered reason used to ratchet to the newest
+		// NON-EMPTY value, so a condition that had since resolved (a quota reset)
+		// was still quoted while something else held the operation open. That is a
+		// confidently wrong diagnosis at the exact moment a right one matters most.
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+		// Admin no longer names a reason: the quota cleared, something else is slow.
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: "" });
+		await flushPromises();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+
+		expect(w.vm.state.connectMessage).toMatch(/was still running when we last checked/i);
+		expect(w.vm.state.connectMessage).not.toContain(QUOTA_REASON);
+		w.unmount();
+	});
+
 	it("a timeout with nothing ever heard renders the plain fallback, nothing invented", async () => {
 		const w = await mountConnect();
 

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1373,3 +1373,127 @@ describe("every connect terminal carries its own headline", () => {
 		w.unmount();
 	});
 });
+
+// jarvis#752: the apply operation's own chat_readiness_reason (fleet contract 1.23,
+// force_probe) reaches this screen on every non-terminal poll, well before any
+// readiness wait starts - so a subscription pool's route verdict (out of quota,
+// unverified, still probing) is nameable during the ordinary "Applying"/"Finishing"
+// state instead of only surfacing at a five-minute deadline. Previously onOpUpdate
+// read ui.chatReadinessReason nowhere and rendered fixed copy for the whole wait.
+describe("jarvis#752 the connect step shows admin's route verdict while still converging", () => {
+	const QUOTA_REASON = "Your OpenAI account has reached its usage limit. It resets in 2 hours.";
+
+	it("a live reason during Applying renders in the phase row, still as progress", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("working");
+		expect(w.vm.readinessStage.detail).toBe(QUOTA_REASON);
+		// Still progress, not a failure: the row stays ACTIVE (spinner), the same
+		// state it would be in with no reason to show at all.
+		expect(w.vm.readinessStage.state).toBe("active");
+		expect(w.find(".ob-phase-detail").text()).toBe(QUOTA_REASON);
+		w.unmount();
+	});
+
+	it("the same reason renders during Finishing (applied_waiting_readiness)", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "finishing", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("finishing");
+		expect(w.vm.readinessStage.detail).toBe(QUOTA_REASON);
+		expect(w.find(".ob-phase-detail").text()).toBe(QUOTA_REASON);
+		w.unmount();
+	});
+
+	it("a later tick that names nothing blanks the row rather than keeping the earlier reason", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+		expect(w.vm.readinessStage.detail).toBe(QUOTA_REASON);
+
+		w.vm.onOpUpdate({ phase: "applying" });
+		await flushPromises();
+
+		expect(w.vm.readinessStage.detail).toBe("");
+		w.unmount();
+	});
+
+	it("a retry terminal does not leave a stale reason on the (now hidden) phase row", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		w.vm.onOpUpdate({ phase: "retry", message: "We hit a snag applying your AI connection." });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(w.vm.readinessStage.detail).toBe("");
+		w.unmount();
+	});
+
+	it("the deadline timeout quotes the last reason this attempt heard, past tense", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+
+		expect(w.vm.state.connectPhase).toBe("retry");
+		// The existing sentence is preserved verbatim, not replaced.
+		expect(w.vm.state.connectMessage).toMatch(/was still running when we last checked/i);
+		expect(w.vm.state.connectMessage).toContain(QUOTA_REASON);
+		w.unmount();
+	});
+
+	it("a timeout with nothing ever heard renders the plain fallback, nothing invented", async () => {
+		const w = await mountConnect();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+
+		expect(w.vm.state.connectMessage).toBe(
+			"Setup was still running when we last checked, and it's taking longer than usual. You can keep waiting and retry."
+		);
+		w.unmount();
+	});
+
+	it("a never-confirmed timeout does not quote a reason: nothing was ever heard from admin", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: true });
+
+		expect(w.vm.state.connectMessage).toMatch(/couldn't reach your AI provider/i);
+		expect(w.vm.state.connectMessage).not.toContain(QUOTA_REASON);
+		w.unmount();
+	});
+
+	it("a genuinely fresh Start forgets the previous attempt's last-heard reason", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+		expect(w.vm.state.connectMessage).toContain(QUOTA_REASON);
+
+		// A genuinely new attempt: never terminal, so it parks on the working screen
+		// without needing a full follow to resolve.
+		api.getLlmApplyOperation.mockResolvedValue(pending);
+		w.vm.saveConnect();
+		await flushPromises();
+
+		w.vm.onTerminal({ timedOut: true, neverConfirmed: false });
+		expect(w.vm.state.connectMessage).not.toContain(QUOTA_REASON);
+		w.unmount();
+	});
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1769,12 +1769,25 @@ const state = reactive({
 // "We couldn't reach your workspace to check" on the first frame after a
 // successful save, announcing a failed check before one had been attempted.
 const readinessSeen = ref(null);
+// jarvis#752: the apply-operation poll's OWN chat_readiness_reason, mirrored from
+// the last onOpUpdate tick. This is a DIFFERENT source than readinessSeen above -
+// the operation carries admin's free-text explanation from the moment a save is
+// accepted (well before the readiness wait that seeds readinessSeen ever starts),
+// so a route that cannot serve (an exhausted subscription, an unverified account)
+// is nameable during the ordinary "Applying"/"Finishing" phase instead of only
+// after a five-minute deadline. Mirrors the CURRENT tick exactly - see onOpUpdate -
+// so a tick that named nothing blanks it rather than sticking an earlier one.
+const opReadinessDetail = ref("");
 const readinessStage = computed(() =>
 	readinessSeen.value
 		? readinessPhase(readinessSeen.value)
 		: // The apply operation is what is running, and the operation controller
 		  // reported that, so naming it is grounded.
-		  inFlightPhase("Applying your AI connection", PHASE_KIND.LLM_APPLY)
+		  inFlightPhase(
+				"Applying your AI connection",
+				PHASE_KIND.LLM_APPLY,
+				opReadinessDetail.value
+		  )
 );
 // jarvis#726: the Progress bar next to the phase list above, reading the SAME
 // readinessStage - see waitPhases.phaseProgress.
@@ -3227,6 +3240,17 @@ const currentOpId = ref("");
 const navigated = ref(false);
 let retryTimer = null;
 
+// jarvis#752: the last NON-EMPTY chat_readiness_reason this attempt's operation
+// polls have seen, kept across the whole follow (unlike opReadinessDetail, which
+// mirrors only the current tick). Needed because the controller's own 5-minute
+// deadline synthesizes a bare timedOut status with no reason on it at all - see
+// createOperationController's tick() - so the only place left to read admin's
+// last word from is what earlier ticks already told onOpUpdate. Reset only on a
+// genuinely fresh attempt (saveConnect, chooseDifferentModel); a Retry re-follows
+// the SAME operation, so the last reason it gave is still about the config on
+// screen.
+let lastOpChatReadinessReason = "";
+
 // The setup screen's headline, following the live phase (jarvis#727) instead of
 // the fixed "Setting up {agentName}" that used to sit above a phase list which
 // had already become real (jarvis#722). setupHeadline owns every honesty
@@ -3293,6 +3317,8 @@ function chooseDifferentModel() {
 	currentOpId.value = "";
 	forgetReady();
 	readinessSeen.value = null;
+	opReadinessDetail.value = "";
+	lastOpChatReadinessReason = "";
 	state.connectPhase = "";
 	state.connectTitle = "";
 	state.connectMessage = "";
@@ -3350,6 +3376,13 @@ function startRetryCountdown() {
 // copy. Navigation lives in onTerminal, never here.
 function onOpUpdate(ui) {
 	const phase = ui && ui.phase;
+	// jarvis#752: mirror THIS tick's chat_readiness_reason for the live phase row
+	// (blank when this tick named nothing, never a stale earlier one - see
+	// opReadinessDetail), and separately remember the last NON-EMPTY one this
+	// attempt has seen, for the deadline timeout onTerminal renders with no ui of
+	// its own to read from.
+	opReadinessDetail.value = (ui && ui.chatReadinessReason) || "";
+	if (ui && ui.chatReadinessReason) lastOpChatReadinessReason = ui.chatReadinessReason;
 	if (phase === OP_PHASE.REJECTED) {
 		// The input is the problem: return to the editable form with the reason.
 		// This IS the jarvis#727 escape, already built, for the one case admin can
@@ -3569,6 +3602,16 @@ function onTerminal(status) {
 			// when that observation happened instead of projected forward.
 			state.connectMessage =
 				"Setup was still running when we last checked, and it's taking longer than usual. You can keep waiting and retry.";
+			// jarvis#752: quote admin's own last word, if this attempt ever got one.
+			// The deadline itself carries no reason (createOperationController's
+			// synthetic timedOut status has none to read), so this is the one place
+			// left that remembers it. Never reworded, only punctuation-closed, same
+			// idiom as readinessWait.js's readinessWaitExhaustedMessage.
+			const lastReason = lastOpChatReadinessReason.trim();
+			if (lastReason) {
+				const closed = /[.!?]$/.test(lastReason) ? lastReason : `${lastReason}.`;
+				state.connectMessage += ` The last thing we heard: ${closed}`;
+			}
 		}
 		// jarvis#727. The operation that wires the chosen model in was CONFIRMED in
 		// flight and still did not finish inside its deadline, which is the state
@@ -3806,9 +3849,11 @@ async function saveConnect() {
 	// A genuinely fresh attempt: any earlier attempt's "we couldn't confirm this,
 	// get a person to look into it" offer was about THAT attempt, not this one.
 	// Same for the jarvis#727 model-change offer, which is an observation about a
-	// configuration this attempt has not yet tried.
+	// configuration this attempt has not yet tried. Same for the jarvis#752 last-
+	// heard reason: it described the operation this attempt is about to replace.
 	state.connectSupportOffered = false;
 	connectModelChangeOffered.value = false;
+	lastOpChatReadinessReason = "";
 	savingConnect.value = true;
 	try {
 		let idem = recallIdem();

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3240,15 +3240,16 @@ const currentOpId = ref("");
 const navigated = ref(false);
 let retryTimer = null;
 
-// jarvis#752: the last NON-EMPTY chat_readiness_reason this attempt's operation
-// polls have seen, kept across the whole follow (unlike opReadinessDetail, which
-// mirrors only the current tick). Needed because the controller's own 5-minute
-// deadline synthesizes a bare timedOut status with no reason on it at all - see
-// createOperationController's tick() - so the only place left to read admin's
-// last word from is what earlier ticks already told onOpUpdate. Reset only on a
-// genuinely fresh attempt (saveConnect, chooseDifferentModel); a Retry re-follows
-// the SAME operation, so the last reason it gave is still about the config on
-// screen.
+// jarvis#752: the chat_readiness_reason the most recent poll carried, held
+// across the follow so the deadline can quote it. Needed because the
+// controller's own 5-minute deadline synthesizes a bare timedOut status with no
+// reason on it at all - see createOperationController's tick() - so the only
+// place left to read admin's last word from is what the ticks already told
+// onOpUpdate. It TRACKS that value, including back to empty: a reason that later
+// cleared is no longer true, and quoting it at a timeout would be a confident
+// wrong answer (round-1 review). Reset on a genuinely fresh attempt (saveConnect,
+// chooseDifferentModel); a Retry re-follows the SAME operation, so what it last
+// said is still about the config on screen.
 let lastOpChatReadinessReason = "";
 
 // The setup screen's headline, following the live phase (jarvis#727) instead of
@@ -3382,7 +3383,15 @@ function onOpUpdate(ui) {
 	// attempt has seen, for the deadline timeout onTerminal renders with no ui of
 	// its own to read from.
 	opReadinessDetail.value = (ui && ui.chatReadinessReason) || "";
-	if (ui && ui.chatReadinessReason) lastOpChatReadinessReason = ui.chatReadinessReason;
+	// Round-1 review: TRACKS the live value rather than ratcheting to the newest
+	// non-empty one. Only holding onto non-empty reasons meant a condition that
+	// later CLEARED (a quota reset, say) while something else kept the operation
+	// from finishing would still be quoted at the deadline, giving the customer a
+	// confidently wrong diagnosis at the exact moment they most need a right one.
+	// A blank tick is admin saying it no longer has a reason, which is itself the
+	// truth, so honour it. Kept as a separate variable because onTerminal's
+	// timeout branch synthesizes a bare status with no ui to read from.
+	lastOpChatReadinessReason = (ui && ui.chatReadinessReason) || "";
 	if (phase === OP_PHASE.REJECTED) {
 		// The input is the problem: return to the editable form with the reason.
 		// This IS the jarvis#727 escape, already built, for the one case admin can
@@ -3854,6 +3863,14 @@ async function saveConnect() {
 	state.connectSupportOffered = false;
 	connectModelChangeOffered.value = false;
 	lastOpChatReadinessReason = "";
+	// Round-1 review: the LIVE detail must clear here too, not only the
+	// remembered one. A timeout ends an attempt through onTerminal, which never
+	// calls onOpUpdate, so nothing blanks it. Until this new operation's first
+	// tick lands, readinessStage falls to its else branch and would render the
+	// PREVIOUS attempt's verdict, describing a credential this attempt has
+	// already replaced. Showing a stale verdict is the exact failure this change
+	// exists to remove.
+	opReadinessDetail.value = "";
 	savingConnect.value = true;
 	try {
 		let idem = recallIdem();


### PR DESCRIPTION
Fixes #752

## Summary

A customer whose AI connection cannot serve is now told why, while they are still in the wizard holding their credentials, instead of watching a spinner and then getting a generic retry.

The explanation already existed. Admin computes it, the bench forwards it verbatim, and the frontend already parsed it into `ui.chatReadinessReason` on every poll. The Connect step received it each tick and rendered fixed copy over it.

## What changed

- `onOpUpdate` mirrors the live reason into the phase row's existing detail slot, so admin's own sentence appears next to "Applying your AI connection" while it is still converging.
- The last non-empty reason is remembered across the attempt, so the 5 minute timeout can quote it in the past tense rather than falling back to generic copy. The controller synthesizes a bare timed-out status with nothing to read, which is why the earlier value has to be kept.
- Both reset only on a genuinely fresh attempt, not on Retry, which re-follows the same operation.

No control plane change was needed.

## Risk and verification

- A still-converging state keeps reading as progress. Only a verdict that explains a route which cannot serve reads as a problem.
- No template change: the detail slot already existed inside the `role="status"` phase row and was simply never fed real data during this phase. Focus management is untouched.
- 10 new tests. Full suites pass on Node 24: 1006 vitest, 675 node. Lint clean under the pinned prettier.

<details><summary>Where the chain actually broke</summary>

The reason travels intact on the live path: `apply_operation.derive()` puts `chat_readiness_reason` on every non-terminal status, `account.py:844` forwards admin's dict verbatim, and `llmOperation.js:78` parses it into `ui.chatReadinessReason` on every tick.

Two other discards were investigated and deliberately left alone. `onboarding.py:2200` and `:2262` do drop the reason, but they feed the Settings pane's Resync pill, which is hidden once the Connect step starts following the apply, so they are not the controlling defect for this surface. `account.py:771` drops it on the legacy `is_ready_for_chat` path, where a pre-force_probe admin had nothing truthful to show anyway.

Latent issue found while tracing, reported not fixed: `llmOperation.js` `classifyOperation` compares `chatReadiness === false` against admin's actual string contract (`"Ready"` / `"Configuring"` / `"Provisioning"` / null). That makes `awaitingChatReadiness` and the second `waitForChatReadiness()` loop structurally unreachable, and the spec's own `readyChatBlockedStatus` fixture tests a shape admin cannot emit. Worth its own issue.

</details>
