### PR TITLE
feat(llm): serve a lone chat subscription direct, without sidecars

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -709,10 +709,23 @@ def is_ready_for_chat() -> dict:
 		# oauth flow only: save_llm_pool unconditionally clears it on every
 		# models[]-table save (see its comment), so gating here on it would
 		# never open chat for this leg.
-		if not getattr(settings, "llm_direct_synced_at", None) and not _confirm_apply_via_admin(
-			settings, is_pool=False
-		):
-			return {"ready": False, "reason": "llm_provisioning"}
+		#
+		# The marker short-circuits BOTH inner checks below, same as the plain
+		# `not getattr(...) and not _confirm_apply_via_admin(...)` shape used
+		# everywhere else in this function - an established tenant never pays a
+		# has_configured_subscription_model call, let alone an admin round-trip.
+		if not getattr(settings, "llm_direct_synced_at", None):
+			# jarvis#755 review: a tenant that never configured a subscription at
+			# all used to fall straight into the generic llm_provisioning
+			# verdict below, identical to one mid-apply. Distinguish "nothing to
+			# confirm" from "confirmation pending" first, mirroring the
+			# api_key/oauth branches' own missing-verdict exit above.
+			from jarvis.jarvis.pool_serialize import has_configured_subscription_model
+
+			if not has_configured_subscription_model(settings):
+				return _llm_missing_verdict(settings)
+			if not _confirm_apply_via_admin(settings, is_pool=False):
+				return {"ready": False, "reason": "llm_provisioning"}
 	elif auth_mode == "oauth":
 		# The legacy flat-field direct-oauth flow: llm_oauth_connected_at is
 		# set (read-only) when the oauth grant completes and the admin

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -701,8 +701,20 @@ def is_ready_for_chat() -> dict:
 			settings, is_pool=False
 		):
 			return {"ready": False, "reason": "llm_provisioning"}
-	elif auth_mode in ("subscription", "oauth"):
-		# Both modes use the same local signal: llm_oauth_connected_at is
+	elif auth_mode == "subscription":
+		# Unified models[]-table subscription on the DIRECT leg (jarvis#715 step
+		# 3): no cliproxy sidecar, so - like api_key direct above - this gates on
+		# a CONFIRMED /llm-creds apply (llm_direct_synced_at), NOT
+		# llm_oauth_connected_at. That marker belongs to the legacy flat-field
+		# oauth flow only: save_llm_pool unconditionally clears it on every
+		# models[]-table save (see its comment), so gating here on it would
+		# never open chat for this leg.
+		if not getattr(settings, "llm_direct_synced_at", None) and not _confirm_apply_via_admin(
+			settings, is_pool=False
+		):
+			return {"ready": False, "reason": "llm_provisioning"}
+	elif auth_mode == "oauth":
+		# The legacy flat-field direct-oauth flow: llm_oauth_connected_at is
 		# set (read-only) when the oauth grant completes and the admin
 		# pushes the auth-profile blob to the container.
 		if not getattr(settings, "llm_oauth_connected_at", None):
@@ -1306,8 +1318,13 @@ def _llm_apply_confirmed(settings, pool_mode: bool) -> bool:
 	them - the whole value of this signal is that chat and the connection badge
 	read the same evidence. Pool marker for a pool (including a BYO api-key pool,
 	which has no sidecar but is still pushed through /llm-pool and still stamps
-	llm_pool_synced_at), the OAuth connect stamp for a direct subscription/oauth
-	tenant, the direct apply marker otherwise.
+	llm_pool_synced_at); the OAuth connect stamp ONLY for the legacy flat-field
+	direct-oauth tenant; the direct apply marker for everything else, including
+	a models[]-table subscription now taking the direct leg (jarvis#715 step 3) -
+	that leg pushes its own oauth blob and stamps llm_direct_synced_at exactly
+	like an api-key direct tenant does, never llm_oauth_connected_at (which
+	save_llm_pool unconditionally clears on every models[]-table save, by
+	design - see its comment).
 
 	Legacy workspaces on both legs are backfilled by patch (v1_10 for the pool,
 	v2_00_backfill_llm_direct_synced_at for direct), so an established tenant does
@@ -1315,7 +1332,7 @@ def _llm_apply_confirmed(settings, pool_mode: bool) -> bool:
 	"""
 	if pool_mode:
 		return bool(settings.get("llm_pool_synced_at"))
-	if (settings.get("llm_auth_mode") or "api_key").strip() in ("subscription", "oauth"):
+	if (settings.get("llm_auth_mode") or "api_key").strip() == "oauth":
 		return bool(settings.get("llm_oauth_connected_at"))
 	return bool(settings.get("llm_direct_synced_at"))
 

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -99,7 +99,16 @@ def _llm_not_configured() -> bool:
 		if s.get("proxy_active"):
 			return False  # a pool is configured; pool health is admin's concern
 		mode = (s.get("llm_auth_mode") or "api_key").strip() or "api_key"
-		if mode in ("subscription", "oauth"):
+		if mode == "subscription":
+			# Unified models[]-table subscription on the DIRECT leg (jarvis#715):
+			# the credential lives in models[], not the flat oauth fields - a
+			# non-empty table IS the credential, mirroring _has_llm_config's
+			# models[] check. llm_oauth_connected_at belongs to the legacy
+			# flat-field flow and is unconditionally cleared by save_llm_pool on
+			# every models[]-table save, so gating on it here would block every
+			# send on a fully-working direct-leg subscription tenant.
+			return not s.get("models")
+		if mode == "oauth":
 			return not s.get("llm_oauth_connected_at")
 		key = s.get_password("llm_api_key", raise_exception=False) or ""
 		provider = (s.get("llm_provider") or "").strip()

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -101,13 +101,21 @@ def _llm_not_configured() -> bool:
 		mode = (s.get("llm_auth_mode") or "api_key").strip() or "api_key"
 		if mode == "subscription":
 			# Unified models[]-table subscription on the DIRECT leg (jarvis#715):
-			# the credential lives in models[], not the flat oauth fields - a
-			# non-empty table IS the credential, mirroring _has_llm_config's
-			# models[] check. llm_oauth_connected_at belongs to the legacy
-			# flat-field flow and is unconditionally cleared by save_llm_pool on
-			# every models[]-table save, so gating on it here would block every
-			# send on a fully-working direct-leg subscription tenant.
-			return not s.get("models")
+			# the credential lives in models[], not the flat oauth fields.
+			# llm_oauth_connected_at belongs to the legacy flat-field flow and is
+			# unconditionally cleared by save_llm_pool on every models[]-table
+			# save, so gating on it here would block every send on a
+			# fully-working direct-leg subscription tenant.
+			#
+			# Checks the row is ENABLED, subscription-typed, AND has a connected
+			# account - not merely that the table is non-empty (jarvis#755
+			# review): a bare-presence check let a send queue against a container
+			# with no credential yet (mid-connect, before the OAuth handshake
+			# lands) and hang. Shared with account.is_ready_for_chat's parallel
+			# check and reconcile_pending_llm_sync's direct_leg_configured.
+			from jarvis.jarvis.pool_serialize import has_configured_subscription_model
+
+			return not has_configured_subscription_model(s)
 		if mode == "oauth":
 			return not s.get("llm_oauth_connected_at")
 		key = s.get_password("llm_api_key", raise_exception=False) or ""

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -285,6 +285,50 @@ _PROVIDER_LABEL_TO_AGENT_ID = {
 POOL_VIRTUAL_MODEL = "jarvis-pool"
 
 
+def _subscription_agent_provider(settings) -> str | None:
+	"""Return the agent-provider id for the DIRECT subscription leg's lone
+	connected account, or None on any error.
+
+	The models[]-table subscription leg (jarvis#715) carries no ``llm_provider`` -
+	a subscription row has only a model id, not a provider field - so
+	``_PROVIDER_LABEL_TO_AGENT_ID``'s ``llm_provider`` lookup (the oauth-mode path
+	below) can never resolve it, and skipping it left ``provider`` at None for
+	every subscription-direct turn: agent-direct chat either 502s ("No API key
+	found for provider ...") or silently mis-routes, exactly on the tenants this
+	leg exists to serve.
+
+	The account's own oauth_blob already carries the agent provider id under its
+	``provider`` key (``"openai"``, ``"google-gemini-cli"`` - baked in when the
+	blob was minted by ``jarvis.oauth.api._exchange_and_build_blob``), so read it
+	from there instead of standing up a second upstream-to-provider table - see
+	``jarvis_settings.py``'s ``_push_direct_subscription_blob``, which relies on
+	the same key for the same reason.
+
+	Fails closed to None on ANY error - a malformed or missing blob must degrade
+	to "no opinion" (agent falls back to resolving its one registered model),
+	never crash the turn.
+	"""
+	import json
+
+	from jarvis.jarvis.pool_serialize import _credential_type, _enabled_models, _model_accounts
+
+	try:
+		for m in _enabled_models(settings):
+			if _credential_type(m) != "subscription":
+				continue
+			accounts = _model_accounts(m)
+			if not accounts:
+				return None
+			blob_raw = accounts[0].get("oauth_blob") if hasattr(accounts[0], "get") else ""
+			blob = json.loads(blob_raw) if blob_raw else None
+			if not isinstance(blob, dict):
+				return None
+			return (blob.get("provider") or "").strip() or None
+		return None
+	except Exception:
+		return None
+
+
 def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
 	"""Return (effective_model, agent_provider_id_or_None) for this conv.
 
@@ -312,9 +356,14 @@ def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
 		return "", None  # Let the pool route
 
 	effective_model = conv.model_override or settings.llm_model or ""
-	provider = (
-		_PROVIDER_LABEL_TO_AGENT_ID.get(settings.llm_provider) if settings.llm_auth_mode == "oauth" else None
-	)
+	if settings.llm_auth_mode == "oauth":
+		provider = _PROVIDER_LABEL_TO_AGENT_ID.get(settings.llm_provider)
+	elif settings.llm_auth_mode == "subscription":
+		# The models[]-table DIRECT leg (jarvis#715 step 3): compute_pool_mode
+		# already routed us here, so this IS the lone-direct-capable shape.
+		provider = _subscription_agent_provider(settings)
+	else:
+		provider = None
 	return effective_model, provider
 
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -696,6 +696,54 @@ class JarvisSettings(Document):
 		"""
 		return self.get_password("llm_api_key", raise_exception=False) or ""
 
+	def _push_direct_subscription_blob(self) -> None:
+		"""Push the DIRECT leg's lone subscription account's OAuth blob to
+		openclaw's auth store, before the ``/llm-creds`` render that depends on it
+		(jarvis#715 step 3, point 4).
+
+		Mirrors ``jarvis.oauth.api.complete_paste_signin``'s push: the blob's own
+		``provider`` key already carries the openclaw auth-profile id
+		(``agent_provider`` - "openai", "google-gemini-cli" - baked in when the
+		blob was minted), so no separate upstream-to-provider table is needed
+		here, and ``id_token`` is stripped because fleet's ``PUT /auth-profile``
+		schema is strict (``extra_forbidden``) and only the POOL path's
+		cliproxy-codex reformat needs it.
+
+		Only ever called for the config ``_lone_direct_capable`` allowed onto this
+		leg, so there is exactly one enabled subscription model with exactly one
+		account and ``validate_models`` has already required a well-formed,
+		non-empty ``oauth_blob`` on it before ``save()`` could reach here. Raises
+		(rather than silently skipping the push) if that invariant is somehow
+		violated - the caller's surrounding try/except in ``_sync_via_admin``
+		reports it exactly like an admin failure, which is safer than rendering
+		``auth: "oauth"`` against a container with no credential behind it.
+		"""
+		import json
+
+		from jarvis import admin_client
+		from jarvis.jarvis.pool_serialize import _model_accounts
+
+		for m in self.models or []:
+			if not m.enabled or (getattr(m, "credential_type", None) or "api_key") != "subscription":
+				continue
+			accounts = _model_accounts(m)
+			if not accounts:
+				raise admin_client.AdminValidationError(
+					"direct subscription leg: no connected account to push"
+				)
+			blob_raw = (accounts[0].get("oauth_blob") if hasattr(accounts[0], "get") else "") or ""
+			try:
+				blob = json.loads(blob_raw) if blob_raw else None
+			except (TypeError, ValueError):
+				blob = None
+			if not isinstance(blob, dict) or not (blob.get("provider") or "").strip():
+				raise admin_client.AdminValidationError(
+					"direct subscription leg: missing or malformed oauth_blob"
+				)
+			direct_blob = {k: v for k, v in blob.items() if k != "id_token"}
+			admin_client.post_push_oauth_blob(blob["provider"], direct_blob)
+			return
+
 	def on_update(self):
 		# ------------------------------------------------------------------ #
 		# Unified LLM path (2026-06-26): models table rows or preset present.
@@ -1088,6 +1136,16 @@ class JarvisSettings(Document):
 				result = admin_client.post_rotate_llm_secret(secret=secret) or {}
 				resolved_action = result.get("action", "reload")
 			else:  # "restart"
+				# A models[]-table subscription on the DIRECT leg (jarvis#715 step 3,
+				# point 4) owns its own credential push: unlike the legacy oauth flow
+				# (whose blob reaches auth-profiles.json via complete_paste_signin
+				# BEFORE this job ever runs), the unified table's oauth_blob just sits
+				# in subscription_accounts until something pushes it. Push it FIRST -
+				# same order complete_paste_signin uses (blob, then creds) - so a
+				# failure here lands in the except clauses below and post_update_llm_creds
+				# never renders auth:"oauth" against an empty auth store.
+				if (self.llm_auth_mode or "") == "subscription":
+					self._push_direct_subscription_blob()
 				# In oauth mode the api_key body is empty - container reads
 				# credentials from auth-profiles.json instead.
 				secret = self._resolve_llm_secret_for_push()
@@ -1398,6 +1456,19 @@ class JarvisSettings(Document):
 			return "restart"
 
 		old = self.get_doc_before_save()
+
+		# A models[]-table subscription RE-AUTH (jarvis#715 direct leg) changes
+		# only the child row's encrypted subscription_accounts - same provider,
+		# same model, same llm_auth_mode - so none of the checks in this function
+		# (structural_fields below, llm_api_key_changed) can see it. Without this,
+		# reconnecting an expired/revoked token would classify as "no change" and
+		# the fresh blob this leg itself pushes (_push_direct_subscription_blob)
+		# would never reach the container.
+		if old is not None and (self.llm_auth_mode or "") == "subscription":
+			current_snap = self.flags.get("pool_state_snapshot")
+			if current_snap is not None and current_snap != self._pool_state_snapshot(old):
+				return "restart"
+
 		if old is None:
 			# First-ever save: treat as restart only if at least one of
 			# provider/model is set now.
@@ -2429,13 +2500,18 @@ def reconcile_pending_llm_sync() -> None:
 		# stranding class as an unproven pool.
 		is_stuck = status.startswith("pending:") or status.startswith("failed:")
 		is_unproven_pool = pool_mode and not pool_synced and is_stuck
-		is_unproven_direct = (
-			not pool_mode
-			and not direct_synced
-			and is_stuck
-			and (settings.get("llm_auth_mode") or "api_key") == "api_key"
-			and bool((settings.get("llm_provider") or "").strip())
-		)
+		# api_key: "configured" means a provider was chosen. subscription (the
+		# jarvis#715 direct leg) has no llm_provider - a subscription model row
+		# carries no provider field - so "configured" means the models[] row
+		# itself exists instead. oauth (the legacy flat-field flow) is excluded
+		# here exactly as before: its evidence marker (llm_oauth_connected_at) is
+		# stamped synchronously inside the same request that pushes it, never
+		# left pending for this scheduled net to pick up.
+		auth_mode = (settings.get("llm_auth_mode") or "api_key").strip()
+		direct_leg_configured = (
+			auth_mode == "api_key" and bool((settings.get("llm_provider") or "").strip())
+		) or (auth_mode == "subscription" and bool(settings.get("models")))
+		is_unproven_direct = not pool_mode and not direct_synced and is_stuck and direct_leg_configured
 		# The disconnect leg's LOCAL precondition (see the docstring). It is true of
 		# every healthy CONNECTED workspace, so this leg does cost one extra
 		# get_connection per tick on those - unavoidable, because a bench that lost

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -698,11 +698,11 @@ class JarvisSettings(Document):
 
 	def _push_direct_subscription_blob(self) -> None:
 		"""Push the DIRECT leg's lone subscription account's OAuth blob to
-		openclaw's auth store, before the ``/llm-creds`` render that depends on it
+		agent's auth store, before the ``/llm-creds`` render that depends on it
 		(jarvis#715 step 3, point 4).
 
 		Mirrors ``jarvis.oauth.api.complete_paste_signin``'s push: the blob's own
-		``provider`` key already carries the openclaw auth-profile id
+		``provider`` key already carries the agent auth-profile id
 		(``agent_provider`` - "openai", "google-gemini-cli" - baked in when the
 		blob was minted), so no separate upstream-to-provider table is needed
 		here, and ``id_token`` is stripped because fleet's ``PUT /auth-profile``
@@ -716,7 +716,11 @@ class JarvisSettings(Document):
 		(rather than silently skipping the push) if that invariant is somehow
 		violated - the caller's surrounding try/except in ``_sync_via_admin``
 		reports it exactly like an admin failure, which is safer than rendering
-		``auth: "oauth"`` against a container with no credential behind it.
+		``auth: "oauth"`` against a container with no credential behind it. That
+		guarantee covers a NO-MATCH loop too (jarvis#755 review): if nothing
+		enabled turns out to be a subscription row when this runs, falling off
+		the loop without raising would be exactly the silent skip this docstring
+		promises never happens, so the loop's tail raises the same way.
 		"""
 		import json
 
@@ -743,6 +747,9 @@ class JarvisSettings(Document):
 			direct_blob = {k: v for k, v in blob.items() if k != "id_token"}
 			admin_client.post_push_oauth_blob(blob["provider"], direct_blob)
 			return
+		raise admin_client.AdminValidationError(
+			"direct subscription leg: no enabled subscription model to push"
+		)
 
 	def on_update(self):
 		# ------------------------------------------------------------------ #
@@ -1304,6 +1311,27 @@ class JarvisSettings(Document):
 			_commit_terminal_sync_status()
 			terminal_written = True
 			frappe.logger().info(f"admin_client: rate-limited; retry_after={retry}s")
+		except admin_client.AdminValidationError as e:
+			# jarvis#755 review: with no handler here this fell through to the
+			# generic "unexpected error" backstop below, discarding the concrete
+			# reason _push_direct_subscription_blob raised (e.g. "missing or
+			# malformed oauth_blob") right when a customer needs it most - the
+			# save already committed the models[] row, so this status is the only
+			# place that reason can still reach them. Mirrors the pool sync
+			# twin's handling of the same exception.
+			_write_settings_fields(
+				self,
+				{
+					"last_sync_at": frappe.utils.now(),
+					"last_sync_status": f"failed: validation: {e}",
+				},
+			)
+			_commit_terminal_sync_status()
+			terminal_written = True
+			frappe.log_error(
+				title="Jarvis: admin validation failed (direct sync)",
+				message=frappe.get_traceback(),
+			)
 		except _WRITE_CONFLICT_ERRORS:
 			# #713, a BACKSTOP rather than the primary path: the status writes above
 			# all go through _write_settings_fields, which reports a lost race instead
@@ -2480,7 +2508,7 @@ def reconcile_pending_llm_sync() -> None:
 		if not admin_api_key and not customer_pw:
 			return
 
-		from jarvis.jarvis.pool_serialize import compute_pool_mode
+		from jarvis.jarvis.pool_serialize import compute_pool_mode, has_configured_subscription_model
 
 		status = settings.get("last_sync_status") or ""
 		# The evidence marker follows the SYNC LEG, so this is pool mode, not the
@@ -2502,15 +2530,18 @@ def reconcile_pending_llm_sync() -> None:
 		is_unproven_pool = pool_mode and not pool_synced and is_stuck
 		# api_key: "configured" means a provider was chosen. subscription (the
 		# jarvis#715 direct leg) has no llm_provider - a subscription model row
-		# carries no provider field - so "configured" means the models[] row
-		# itself exists instead. oauth (the legacy flat-field flow) is excluded
-		# here exactly as before: its evidence marker (llm_oauth_connected_at) is
-		# stamped synchronously inside the same request that pushes it, never
-		# left pending for this scheduled net to pick up.
+		# carries no provider field - so "configured" means an ENABLED
+		# subscription row with a connected account instead (jarvis#755 review:
+		# bare row-presence would misclassify a disabled leftover row as
+		# unproven-direct and re-poll it forever). oauth (the legacy flat-field
+		# flow) is excluded here exactly as before: its evidence marker
+		# (llm_oauth_connected_at) is stamped synchronously inside the same
+		# request that pushes it, never left pending for this scheduled net to
+		# pick up.
 		auth_mode = (settings.get("llm_auth_mode") or "api_key").strip()
 		direct_leg_configured = (
 			auth_mode == "api_key" and bool((settings.get("llm_provider") or "").strip())
-		) or (auth_mode == "subscription" and bool(settings.get("models")))
+		) or (auth_mode == "subscription" and has_configured_subscription_model(settings))
 		is_unproven_direct = not pool_mode and not direct_synced and is_stuck and direct_leg_configured
 		# The disconnect leg's LOCAL precondition (see the docstring). It is true of
 		# every healthy CONNECTED workspace, so this leg does cost one extra

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -303,19 +303,27 @@ def compute_pool_mode(settings) -> bool:
 	readiness gate and installed-apps resync follow the pool leg. This is the
 	predicate ``compute_proxy_active`` used to encode.
 
-	True when ≥2 models are enabled OR (a preset is selected AND ≥1 model
-	enabled) OR any enabled model is a chat subscription. An empty enabled-model
-	list with a preset does NOT count as pool-valid.
+	True when >=2 models are enabled OR (a preset is selected AND >=1 model
+	enabled) OR any enabled model is a chat subscription that is NOT
+	``_lone_direct_capable`` (jarvis#715). An empty enabled-model list with a
+	preset does NOT count as pool-valid.
 	"""
 	enabled = _enabled_models(settings)
 	if len(enabled) >= 2 or (bool(settings.preset) and len(enabled) >= 1):
 		return True
-	# A chat-subscription model REQUIRES the cliproxy sidecar, which is
-	# provisioned ONLY on the pool path. The DIRECT (single-model) path just
+	# A chat-subscription model normally REQUIRES the cliproxy sidecar, which is
+	# provisioned ONLY on the pool path - the DIRECT (single-model) path just
 	# pushes llm-creds and has no cliproxy, so a lone subscription model would
 	# never get its OAuth blob served and chat would fail despite a "connected"
-	# UI. Force such a config onto the pool path. (#200 review #1)
-	return has_subscription_model(settings)
+	# UI (#200 review #1). _lone_direct_capable carves out the one shape openclaw
+	# can serve NATIVELY with no sidecar at all: exactly one enabled subscription
+	# model, one connected account, an upstream the fleet template can render on
+	# the direct oauth leg, and (the non-retroactivity gate) a workspace that has
+	# never synced through the pool leg before. See its docstring for why each
+	# condition is there.
+	if has_subscription_model(settings) and not _lone_direct_capable(settings):
+		return True
+	return False
 
 
 def has_subscription_model(settings) -> bool:
@@ -347,8 +355,104 @@ def compute_proxy_active(settings) -> bool:
 	``proxy_active`` now IMPLIES ``compute_pool_mode`` (a subscription forces
 	pool mode) but is strictly narrower. Ask ``compute_pool_mode`` for "which
 	sync / readiness leg does this tenant take".
+
+	Carries the SAME ``_lone_direct_capable`` exception as ``compute_pool_mode``
+	(jarvis#715): a lone renderable subscription takes the direct leg with no
+	sidecar at all, so both predicates must agree it needs none - a mismatch
+	(``pool_mode=False`` with ``proxy_active=True``, or the reverse) is the
+	#498 shape the implication above exists to rule out.
 	"""
-	return has_subscription_model(settings)
+	if not has_subscription_model(settings):
+		return False
+	return not _lone_direct_capable(settings)
+
+
+# ---------------------------------------------------------------------------
+# _lone_direct_capable: the jarvis#715 "no sidecar needed" exception
+# ---------------------------------------------------------------------------
+
+
+# Providers openclaw can authenticate NATIVELY on the direct oauth leg, keyed
+# by the bundled catalog's provider_id/catalog_id (== the models[].accounts[]
+# upstream for every upstream this can ever match - "openai" and "google" are
+# spelled identically in both vocabularies; Kimi's upstream "kimi" has no
+# matching catalog entry at all ("moonshot" is the catalog's own name for it,
+# a preexisting, unrelated vocabulary mismatch), which fails the lookup and
+# reads as "not renderable" - the same, safe answer a real lookup would give
+# since Kimi's catalog renderer_id is blank anyway). A provider with no
+# non-empty renderer_id has no fleet-template arm to render it (jarvis#715
+# thread, live-verified against openclaw 2026.6.8 + the live provider
+# catalog): xai and moonshot are both in that state today, so they stay on
+# the pool leg until a template arm + catalog id ship for them.
+def _upstream_has_renderer(upstream: str) -> bool:
+	"""True when the bundled provider catalog has a non-empty ``renderer_id``
+	for ``upstream``. Deliberately reads the BUNDLED (checked-into-git) catalog,
+	never the live admin one: this feeds a save-time, hot-chat-path decision
+	that must be a pure function of stored settings, and a live-fetched answer
+	would let admin silently move an ALREADY-PROVISIONED tenant between legs on
+	its own schedule - precisely the retroactive-move hazard the activation
+	gate below exists to rule out. Widening the renderable set is a deploy
+	(regenerate the bundle via scripts/gen_bundled_catalog.py), which is the
+	review gate this wants.
+	"""
+	from jarvis._model_catalog import BUNDLED_MODEL_CATALOG
+
+	needle = (upstream or "").strip().lower()
+	if not needle:
+		return False
+	for provider in BUNDLED_MODEL_CATALOG:
+		pid = (provider.get("provider_id") or "").strip().lower()
+		cid = (provider.get("catalog_id") or "").strip().lower()
+		if needle in (pid, cid):
+			return bool((provider.get("renderer_id") or "").strip())
+	return False
+
+
+def _lone_direct_capable(settings) -> bool:
+	"""True when this settings' lone enabled model needs no Bifrost/cliproxy
+	sidecar at all - it can be served entirely by openclaw's native oauth
+	auth-profile support (jarvis#715).
+
+	ALL of the following must hold:
+
+	- No preset (a preset always routes through the pool leg).
+	- Exactly one enabled model, and it is a chat subscription. Two-plus
+	  models, or a subscription mixed with api-key rows, still needs the pool
+	  leg (failover across N credentials is a pool feature).
+	- Exactly one connected account on that model. Multiple accounts mean
+	  ROTATION, which only cliproxy implements - the direct leg pushes a
+	  single oauth blob and has no rotation concept.
+	- That account's upstream is one the fleet template can render on the
+	  direct oauth leg today (``_upstream_has_renderer``).
+	- ``llm_pool_synced_at`` is unset. This is the NON-RETROACTIVITY gate
+	  (jarvis#715 "step 3 is not a predicate flip" analysis): the predicate is
+	  a pure function of stored settings, so without it this exception would
+	  retroactively flip every ALREADY-PROVISIONED lone-subscription tenant
+	  (OAuth blob sitting in cliproxy's auth dir, ``llm_pool_synced_at``
+	  stamped, ``llm_direct_synced_at`` never stamped) onto a leg it has no
+	  evidence of ever having applied - chat gates shut on a working tenant the
+	  moment this deploys. ``llm_pool_synced_at`` is stamped ONLY by a
+	  CONFIRMED pool apply (``_stamp_converged_ok``) and is never set by
+	  anything on the direct leg, so it is false for exactly the tenants this
+	  exception is safe to apply to: a brand-new connect (never synced through
+	  any leg) and a tenant that went through a full disconnect/reset (which
+	  clears it - see ``onboarding._DISCONNECTED_LLM_FIELDS``) before
+	  reconnecting.
+	"""
+	if bool(settings.preset):
+		return False
+	enabled = _enabled_models(settings)
+	if len(enabled) != 1:
+		return False
+	m = enabled[0]
+	if _credential_type(m) != "subscription":
+		return False
+	accounts = _model_accounts(m)
+	if len(accounts) != 1:
+		return False
+	if not _upstream_has_renderer(_field(accounts[0], "upstream")):
+		return False
+	return not bool(getattr(settings, "llm_pool_synced_at", None))
 
 
 def pool_primary_model(settings) -> str:

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -315,7 +315,7 @@ def compute_pool_mode(settings) -> bool:
 	# provisioned ONLY on the pool path - the DIRECT (single-model) path just
 	# pushes llm-creds and has no cliproxy, so a lone subscription model would
 	# never get its OAuth blob served and chat would fail despite a "connected"
-	# UI (#200 review #1). _lone_direct_capable carves out the one shape openclaw
+	# UI (#200 review #1). _lone_direct_capable carves out the one shape agent
 	# can serve NATIVELY with no sidecar at all: exactly one enabled subscription
 	# model, one connected account, an upstream the fleet template can render on
 	# the direct oauth leg, and (the non-retroactivity gate) a workspace that has
@@ -329,6 +329,26 @@ def compute_pool_mode(settings) -> bool:
 def has_subscription_model(settings) -> bool:
 	"""True when at least one ENABLED models[] row is a chat subscription."""
 	return any(_credential_type(m) == "subscription" for m in _enabled_models(settings))
+
+
+def has_configured_subscription_model(settings) -> bool:
+	"""True when at least one ENABLED subscription model row also has a
+	CONNECTED account - not merely that the row exists.
+
+	Stronger than ``has_subscription_model``, which only checks the row is
+	there: a subscription model can be enabled with zero accounts (mid-connect,
+	before the OAuth handshake lands), and gating a send or a readiness verdict
+	on row-presence alone lets that half-configured state read as "configured"
+	when there is nothing to serve. Shared by the three call sites that used to
+	each answer "is a subscription credential present" differently (jarvis#715
+	review, "gates that check a models[] row merely EXISTS rather than that a
+	credential is confirmed, enabled and usable"): ``chat.policy._llm_not_configured``,
+	``account.is_ready_for_chat``'s subscription branch, and
+	``jarvis_settings.reconcile_pending_llm_sync``'s ``direct_leg_configured``.
+	"""
+	return any(
+		_credential_type(m) == "subscription" and _model_accounts(m) for m in _enabled_models(settings)
+	)
 
 
 def compute_proxy_active(settings) -> bool:
@@ -372,7 +392,7 @@ def compute_proxy_active(settings) -> bool:
 # ---------------------------------------------------------------------------
 
 
-# Providers openclaw can authenticate NATIVELY on the direct oauth leg, keyed
+# Providers agent can authenticate NATIVELY on the direct oauth leg, keyed
 # by the bundled catalog's provider_id/catalog_id (== the models[].accounts[]
 # upstream for every upstream this can ever match - "openai" and "google" are
 # spelled identically in both vocabularies; Kimi's upstream "kimi" has no
@@ -381,7 +401,7 @@ def compute_proxy_active(settings) -> bool:
 # reads as "not renderable" - the same, safe answer a real lookup would give
 # since Kimi's catalog renderer_id is blank anyway). A provider with no
 # non-empty renderer_id has no fleet-template arm to render it (jarvis#715
-# thread, live-verified against openclaw 2026.6.8 + the live provider
+# thread, live-verified against agent 2026.6.8 + the live provider
 # catalog): xai and moonshot are both in that state today, so they stay on
 # the pool leg until a template arm + catalog id ship for them.
 def _upstream_has_renderer(upstream: str) -> bool:
@@ -410,7 +430,7 @@ def _upstream_has_renderer(upstream: str) -> bool:
 
 def _lone_direct_capable(settings) -> bool:
 	"""True when this settings' lone enabled model needs no Bifrost/cliproxy
-	sidecar at all - it can be served entirely by openclaw's native oauth
+	sidecar at all - it can be served entirely by agent's native oauth
 	auth-profile support (jarvis#715).
 
 	ALL of the following must hold:

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -796,14 +796,21 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 	the reason the customer's browser actually receives when the control plane
 	cannot be asked.
 
-	The workspace is pinned onto the subscription/oauth leg (connected marker set,
+	The workspace is pinned onto the subscription leg (connected marker set,
 	pool mode off) so the run reaches _admin_chat_gate deterministically instead of
 	depending on whatever this site's LLM config happens to be. is_ready_for_chat
 	reads the admin key through get_password, so this class provisions a real
 	encrypted one for the duration rather than the raw mask the gate-level tests
-	use."""
+	use.
 
-	_FIELDS = ("llm_auth_mode", "llm_oauth_connected_at", "chat_was_ready_at")
+	The connected marker is llm_direct_synced_at, not llm_oauth_connected_at
+	(jarvis#755): the subscription branch was regrouped away from the legacy
+	oauth branch onto the same evidence marker api_key direct uses, because
+	save_llm_pool unconditionally clears llm_oauth_connected_at on every
+	models[]-table save - gating on it would never open chat for this leg. See
+	account.is_ready_for_chat's subscription branch."""
+
+	_FIELDS = ("llm_auth_mode", "llm_direct_synced_at", "chat_was_ready_at")
 
 	def setUp(self):
 		from jarvis._password_utils import set_settings_password
@@ -817,7 +824,7 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		self._write(
 			{
 				"llm_auth_mode": "subscription",
-				"llm_oauth_connected_at": "2026-01-01 00:00:00",
+				"llm_direct_synced_at": "2026-01-01 00:00:00",
 				"chat_was_ready_at": None,
 			}
 		)
@@ -864,6 +871,23 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
 			out = account.is_ready_for_chat()
 		self.assertEqual(out, {"ready": True, "reason": None, "billing_notice": {}})
+
+	def test_a_never_configured_subscription_gets_the_missing_verdict_not_provisioning(self):
+		"""jarvis#755 review: a subscription tenant that never configured
+		anything at all used to fall into the SAME generic llm_provisioning
+		verdict as one mid-apply. Distinguishes "nothing to confirm" from
+		"confirmation pending" - the only difference between this test and
+		test_a_never_ready_workspace_is_not_told_it_is_ready is which of those
+		two states this workspace is in, and only the marker changes."""
+		self._write({"llm_direct_synced_at": None})
+		with (
+			patch("jarvis.jarvis.pool_serialize.has_configured_subscription_model", return_value=False),
+			patch.object(admin_client, "get_connection", side_effect=Exception("admin down")),
+		):
+			out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertNotEqual(out["reason"], "llm_provisioning")
+		self.assertEqual(out["reason"], "llm_credentials")
 
 
 class TestExplicitReadyOnlyMarker(FrappeTestCase):

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -232,3 +232,22 @@ class TestLlmConfiguredGate(FrappeTestCase):
 		ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
+
+	def test_subscription_row_with_no_connected_account_still_rejects_the_send(self):
+		"""jarvis#755 review: bare models[] presence used to be the whole check,
+		so a subscription row enabled but not yet connected (mid-OAuth-handshake,
+		before it has an account) read as configured and let a send queue
+		against a container with no credential, where it hangs. Now the gate
+		must require a connected account too."""
+		self._set(llm_provider="", llm_model="", llm_auth_mode="subscription", proxy_active=0)
+		with patch("jarvis.jarvis.pool_serialize.has_configured_subscription_model", return_value=False):
+			ok, reason = validate_can_send("Administrator")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "llm_not_configured")
+
+	def test_subscription_with_a_connected_account_sends(self):
+		self._set(llm_provider="", llm_model="", llm_auth_mode="subscription", proxy_active=0)
+		with patch("jarvis.jarvis.pool_serialize.has_configured_subscription_model", return_value=True):
+			ok, reason = validate_can_send("Administrator")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -117,7 +117,7 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		]
 
 	def test_one_renderable_subscription_model_is_direct(self):
-		"""jarvis#715: a FRESH lone subscription on a provider openclaw serves
+		"""jarvis#715: a FRESH lone subscription on a provider agent serves
 		NATIVELY (openai) needs no sidecar at all - it takes the direct
 		llm-creds leg, pushing its own oauth blob, not /llm-pool."""
 		blob_calls = []
@@ -143,8 +143,74 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(s.proxy_active or 0), 0)
 
+	def test_lone_direct_subscription_resolves_its_own_agent_provider(self):
+		"""jarvis#755 critical fix: turn_handler's provider resolution used to
+		gate on ``llm_auth_mode == "oauth"`` only, so every message from a
+		subscription-direct tenant resolved provider=None - agent then either
+		502s ("No API key found for provider ...") or silently mis-routes.
+		The lone account's own oauth_blob already carries the agent-provider id
+		under its "provider" key (the same key _push_direct_subscription_blob
+		relies on), so the turn dispatcher must read it from there."""
+		from jarvis.chat.turn_handler import _resolve_model_and_provider
+
+		with (
+			patch("jarvis.admin_client.post_push_oauth_blob"),
+			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
+		):
+			onboarding.save_llm_pool(
+				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
+			)
+		conv = frappe._dict(model_override="")
+		effective_model, provider = _resolve_model_and_provider(conv)
+		self.assertEqual(provider, "openai")
+		self.assertEqual(effective_model, "gpt-5.5")
+
+	def test_lone_direct_subscription_with_a_malformed_blob_resolves_no_provider(self):
+		"""A blob missing its "provider" key (or otherwise unreadable) must
+		degrade to None, never raise or crash the turn - see
+		_push_direct_subscription_blob's own guard for the write side of this
+		same invariant."""
+		from jarvis.chat.turn_handler import _resolve_model_and_provider
+
+		with (
+			patch("jarvis.admin_client.post_push_oauth_blob"),
+			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
+		):
+			onboarding.save_llm_pool(
+				frappe.as_json(self._lone_subscription_models(blob='{"refresh_token":"rt"}')),
+				preset=None,
+				routing_mode="failover",
+			)
+		conv = frappe._dict(model_override="")
+		_, provider = _resolve_model_and_provider(conv)
+		self.assertIsNone(provider)
+
+	def test_direct_subscription_push_validation_error_surfaces_specifically(self):
+		"""jarvis#755 review: _sync_via_admin had no except clause for
+		AdminValidationError, so a concrete "missing or malformed oauth_blob"
+		reason from _push_direct_subscription_blob fell through to the generic
+		"failed: unexpected error; see Error Log" backstop - exactly the
+		failure this exception exists to name. Mirrors the pool-sync twin's own
+		handling of the same exception (jarvis_settings.py ~1975)."""
+		from jarvis import admin_client
+
+		with (
+			patch(
+				"jarvis.admin_client.post_push_oauth_blob",
+				side_effect=admin_client.AdminValidationError("missing or malformed oauth_blob"),
+			),
+			patch("jarvis.admin_client.post_update_llm_creds") as creds,
+		):
+			onboarding.save_llm_pool(
+				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
+			)
+		creds.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(s.last_sync_status.startswith("failed: validation:"))
+		self.assertIn("missing or malformed oauth_blob", s.last_sync_status)
+
 	def test_one_unrenderable_subscription_model_is_still_proxy(self):
-		"""Kimi has no openclaw-native auth flow → still needs cliproxy → the
+		"""Kimi has no agent-native auth flow → still needs cliproxy → the
 		proxy pool path, NOT the direct llm-creds path (#200 review #1)."""
 		pool_calls = []
 		with (

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -28,6 +28,13 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		s.db_set("preset", "", update_modified=False)
 		s.db_set("routing_mode", "failover", update_modified=False)
 		s.db_set("proxy_active", 0, update_modified=False)
+		# jarvis#715's non-retroactivity gate keys the lone-subscription direct
+		# leg off "has this workspace ever synced through the pool leg" - clear
+		# both apply markers so these tests see a fresh-connect workspace
+		# regardless of what an earlier test in this (shared, DB-polluting)
+		# site left behind.
+		s.db_set("llm_pool_synced_at", None, update_modified=False)
+		s.db_set("llm_direct_synced_at", None, update_modified=False)
 		frappe.db.commit()
 
 	def test_two_models_writes_rows_and_routes_to_the_pool(self):
@@ -89,10 +96,8 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(s.proxy_active or 0), 0)
 
-	def test_one_subscription_model_is_proxy(self):
-		"""A single chat-subscription model needs cliproxy → proxy path, NOT the
-		DIRECT llm-creds path (which never serves the OAuth blob). #200 review #1."""
-		models = [
+	def _lone_subscription_models(self, upstream="openai", provider="openai", blob=None):
+		return [
 			{
 				"model": "gpt-5.5",
 				"tier": "strong",
@@ -101,30 +106,69 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 					"rotation": "sticky",
 					"accounts": [
 						{
-							"upstream": "openai",
+							"upstream": upstream,
 							"account_ref": "SUB_deadbeef",
 							"label": "me@x.com",
-							"oauth_blob": '{"refresh_token":"rt"}',
+							"oauth_blob": blob or ('{"provider":"%s","refresh_token":"rt"}' % provider),
 						},
 					],
 				},
 			}
 		]
+
+	def test_one_renderable_subscription_model_is_direct(self):
+		"""jarvis#715: a FRESH lone subscription on a provider openclaw serves
+		NATIVELY (openai) needs no sidecar at all - it takes the direct
+		llm-creds leg, pushing its own oauth blob, not /llm-pool."""
+		blob_calls = []
+		with (
+			patch("jarvis.admin_client.post_update_llm_pool") as pool,
+			patch(
+				"jarvis.admin_client.post_push_oauth_blob",
+				side_effect=lambda provider, blob: blob_calls.append((provider, blob)) or {},
+			),
+			patch(
+				"jarvis.admin_client.post_update_llm_creds",
+				return_value={"action": "restart", "status": "applied"},
+			) as creds,
+		):
+			onboarding.save_llm_pool(
+				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
+			)
+		pool.assert_not_called()
+		self.assertEqual(len(blob_calls), 1, "the direct leg must push the oauth blob")
+		self.assertEqual(blob_calls[0][0], "openai")
+		creds.assert_called_once()
+		self.assertEqual(creds.call_args.kwargs.get("auth_mode"), "oauth")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(int(s.proxy_active or 0), 0)
+
+	def test_one_unrenderable_subscription_model_is_still_proxy(self):
+		"""Kimi has no openclaw-native auth flow → still needs cliproxy → the
+		proxy pool path, NOT the direct llm-creds path (#200 review #1)."""
 		pool_calls = []
 		with (
 			patch(
 				"jarvis.admin_client.post_update_llm_pool",
 				side_effect=lambda **kw: pool_calls.append(kw) or {"action": "pool_update"},
 			),
+			patch("jarvis.admin_client.post_push_oauth_blob") as blob,
 			patch("jarvis.admin_client.post_update_llm_creds") as creds,
 		):
-			onboarding.save_llm_pool(frappe.as_json(models), preset=None, routing_mode="failover")
-		self.assertTrue(pool_calls, "single subscription model must route to the proxy pool path")
+			onboarding.save_llm_pool(
+				frappe.as_json(self._lone_subscription_models(upstream="kimi", provider="kimi")),
+				preset=None,
+				routing_mode="failover",
+			)
+		self.assertTrue(pool_calls, "a lone Kimi subscription must still route to the proxy pool path")
+		blob.assert_not_called()
 		creds.assert_not_called()
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(s.proxy_active or 0), 1)
 		# The account's blob reaches the pool push (served via cliproxy).
-		self.assertEqual(pool_calls[0]["oauth_blobs"].get("SUB_deadbeef"), {"refresh_token": "rt"})
+		self.assertEqual(
+			pool_calls[0]["oauth_blobs"].get("SUB_deadbeef"), {"provider": "kimi", "refresh_token": "rt"}
+		)
 
 	def test_legacy_preset_value_normalized_by_patch(self):
 		"""A legacy capitalized Select value is mapped to its lowercase catalog

--- a/jarvis/tests/test_save_llm_pool_operation.py
+++ b/jarvis/tests/test_save_llm_pool_operation.py
@@ -66,7 +66,7 @@ class _SaveOpBase(_RT3SettingsTestCase):
 		frappe.db.commit()
 
 	def _capture(self, ref="SUB_op0001", subject="acct-op-1"):
-		# Kimi (Moonshot), DELIBERATELY: it has no openclaw-native auth flow, so a
+		# Kimi (Moonshot), DELIBERATELY: it has no agent-native auth flow, so a
 		# lone Kimi subscription always stays on the pool leg regardless of
 		# jarvis#715's new lone-renderable-subscription exception. These tests are
 		# about POOL-leg plumbing (capture consumption, resumability, idempotency

--- a/jarvis/tests/test_save_llm_pool_operation.py
+++ b/jarvis/tests/test_save_llm_pool_operation.py
@@ -50,6 +50,14 @@ class _SaveOpBase(_RT3SettingsTestCase):
 		s.db_set("preset", "", update_modified=False)
 		s.db_set("routing_mode", "failover", update_modified=False)
 		s.db_set("proxy_active", 0, update_modified=False)
+		# jarvis#715 gives a LONE subscription its own routing decision, keyed
+		# partly on "has this workspace ever synced through the pool leg". This
+		# class's subscriptions use upstream "kimi" precisely so that decision
+		# stays out of these tests' way (see _capture/_sub_models below), but
+		# clear both markers anyway for determinism against a shared, DB-polluting
+		# site.
+		s.db_set("llm_pool_synced_at", None, update_modified=False)
+		s.db_set("llm_direct_synced_at", None, update_modified=False)
 		frappe.db.commit()
 
 	def tearDown(self):
@@ -58,11 +66,18 @@ class _SaveOpBase(_RT3SettingsTestCase):
 		frappe.db.commit()
 
 	def _capture(self, ref="SUB_op0001", subject="acct-op-1"):
-		blob = {"type": "oauth", "provider": "openai", "access": "AT-op", "refresh": "RT-op"}
+		# Kimi (Moonshot), DELIBERATELY: it has no openclaw-native auth flow, so a
+		# lone Kimi subscription always stays on the pool leg regardless of
+		# jarvis#715's new lone-renderable-subscription exception. These tests are
+		# about POOL-leg plumbing (capture consumption, resumability, idempotency
+		# threading, the apply-operation descriptor) - not about which leg a
+		# subscription takes, which is covered on its own in
+		# test_unified_llm_config.py and test_llm_pool_endpoints.py.
+		blob = {"type": "oauth", "provider": "kimi", "access": "AT-op", "refresh": "RT-op"}
 		return pc.create_capture(
-			provider="OpenAI",
-			upstream="openai",
-			agent_provider="openai",
+			provider="Kimi (Moonshot)",
+			upstream="kimi",
+			agent_provider="kimi",
 			oauth_blob=json.dumps(blob),
 			account_email="op@example.com",
 			account_ref=ref,
@@ -80,7 +95,7 @@ class _SaveOpBase(_RT3SettingsTestCase):
 					"rotation": "sticky",
 					"accounts": [
 						{
-							"upstream": "openai",
+							"upstream": "kimi",
 							"account_ref": ref,
 							"label": "op@example.com",
 							"capture_id": cap_id,

--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -313,7 +313,7 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 		frappe.db.delete("Jarvis Pending OAuth Capture")
 		frappe.db.commit()
 
-	def _mint(self, account_ref, blob='{"refresh_token":"fake-rt-ORPHAN"}'):
+	def _mint(self, account_ref, blob='{"provider":"openai","refresh_token":"fake-rt-ORPHAN"}'):
 		from jarvis.oauth import pending_capture
 
 		return pending_capture.create_capture(
@@ -342,7 +342,19 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 	def _save(self, payload):
 		with (
 			patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
-			patch("jarvis.admin_client.post_update_llm_creds"),
+			# status="applied" is load-bearing: a bare Mock's .get("status") is
+			# truthy-and-not-"applied", which routes _sync_via_admin into the
+			# converge branch and calls the UNMOCKED admin_client.get_connection.
+			patch(
+				"jarvis.admin_client.post_update_llm_creds",
+				return_value={"action": "restart", "status": "applied"},
+			),
+			# jarvis#715's lone-direct-capable exception routes a single
+			# renderable subscription (this class's whole fixture shape) onto
+			# the DIRECT leg, which pushes its own oauth blob before /llm-creds
+			# (_push_direct_subscription_blob) - unmocked, that is a real admin
+			# call attempt from inside _sync_via_admin.
+			patch("jarvis.admin_client.post_push_oauth_blob"),
 		):
 			return onboarding.save_llm_pool(frappe.as_json(payload), preset=None, routing_mode="failover")
 

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -596,12 +596,83 @@ class TestPoolSerializeFromSettings(FrappeTestCase):
 		settings.preset = None
 		self.assertFalse(compute_pool_mode(settings))
 
-	def test_compute_pool_mode_true_for_a_lone_subscription(self):
-		"""A single subscription is still a pool: it needs the cliproxy sidecar."""
+	def test_compute_pool_mode_false_for_a_fresh_lone_renderable_subscription(self):
+		"""jarvis#715: a lone subscription on a provider openclaw can serve
+		NATIVELY (openai, per the bundled catalog's renderer_id), with no prior
+		pool history, needs no sidecar at all - the direct leg serves it.
+		"""
 		from jarvis.jarvis.pool_serialize import compute_pool_mode
 
-		settings = _make_settings_with_models([_subscription_model(accounts=[_account()])])
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="openai")])])
 		settings.preset = None
+		self.assertFalse(compute_pool_mode(settings))
+
+	def test_compute_pool_mode_false_for_a_fresh_lone_google_subscription(self):
+		"""Google is the second renderable upstream (renderer_id google-gemini-cli)."""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="google")])])
+		settings.preset = None
+		self.assertFalse(compute_pool_mode(settings))
+
+	def test_compute_pool_mode_true_for_a_lone_subscription_already_pool_synced(self):
+		"""THE RETROACTIVITY PIN (jarvis#715): an already-provisioned tenant - its
+		OAuth blob sits in cliproxy's auth dir and llm_pool_synced_at is stamped -
+		must NOT be flipped onto a leg it has no evidence of ever having applied,
+		even though its upstream is otherwise renderable. This is the exact
+		scenario the issue's own "Existing" verification run protects.
+		"""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="openai")])])
+		settings.preset = None
+		settings.llm_pool_synced_at = "2026-08-01 00:00:00"
+		self.assertTrue(compute_pool_mode(settings))
+
+	def test_compute_pool_mode_true_for_a_lone_kimi_subscription(self):
+		"""Kimi has NO openclaw-native auth flow at all (bundled catalog:
+		renderer_id ""), so it stays on the pool leg regardless of history."""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="kimi")])])
+		settings.preset = None
+		self.assertTrue(compute_pool_mode(settings))
+
+	def test_compute_pool_mode_true_for_a_lone_xai_subscription(self):
+		"""xAI has no fleet-template arm yet (renderer_id ""), even though
+		openclaw's own bundle can authenticate it natively - see the jarvis#715
+		thread. Stays on the pool leg until a template arm + catalog id ship."""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="xai")])])
+		settings.preset = None
+		self.assertTrue(compute_pool_mode(settings))
+
+	def test_compute_pool_mode_true_for_a_subscription_with_two_accounts(self):
+		"""Two accounts on one subscription model means rotation, which only
+		cliproxy implements - the direct leg has no rotation concept."""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		settings = _make_settings_with_models(
+			[
+				_subscription_model(
+					accounts=[
+						_account(upstream="openai", account_ref="ACC_1"),
+						_account(upstream="openai", account_ref="ACC_2"),
+					]
+				)
+			]
+		)
+		settings.preset = None
+		self.assertTrue(compute_pool_mode(settings))
+
+	def test_compute_pool_mode_true_for_a_lone_subscription_with_a_preset(self):
+		"""A preset always routes through the pool leg, even for a single
+		otherwise-renderable subscription."""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="openai")])])
+		settings.preset = "Cost-saver"
 		self.assertTrue(compute_pool_mode(settings))
 
 	# ------------------------------------------------------------------ #
@@ -657,6 +728,117 @@ class TestPoolSerializeFromSettings(FrappeTestCase):
 		settings = _make_settings_with_models([m])
 		settings.preset = None
 		self.assertFalse(compute_proxy_active(settings))
+
+	# ------------------------------------------------------------------ #
+	# (h4) compute_proxy_active mirrors compute_pool_mode's jarvis#715 exception
+	# ------------------------------------------------------------------ #
+
+	def test_compute_proxy_active_false_for_a_fresh_lone_renderable_subscription(self):
+		"""jarvis#715: no sidecar is deployed for the exact config compute_pool_mode
+		now also routes direct - the #498 invariant (proxy_active implies
+		pool_mode) requires both predicates agree."""
+		_, _, compute_proxy_active = self._imports()
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="openai")])])
+		settings.preset = None
+		self.assertFalse(compute_proxy_active(settings))
+
+	def test_compute_proxy_active_true_for_a_lone_subscription_already_pool_synced(self):
+		"""Mirrors the retroactivity pin: an already-provisioned tenant keeps its
+		sidecar reported until it demonstrably has none (a fresh reconnect)."""
+		_, _, compute_proxy_active = self._imports()
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="openai")])])
+		settings.preset = None
+		settings.llm_pool_synced_at = "2026-08-01 00:00:00"
+		self.assertTrue(compute_proxy_active(settings))
+
+	def test_compute_proxy_active_true_for_a_lone_kimi_subscription(self):
+		"""Kimi has no openclaw-native auth flow - cliproxy is doing genuine work."""
+		_, _, compute_proxy_active = self._imports()
+		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="kimi")])])
+		settings.preset = None
+		self.assertTrue(compute_proxy_active(settings))
+
+	# ------------------------------------------------------------------ #
+	# (h5) The #498 invariant, pinned permanently: proxy_active implies
+	# pool_mode over every settings shape this module can build. jarvis#715's
+	# own postmortem asked for this: "an invariant test... over every settings
+	# shape... assert compute_proxy_active(settings) implies compute_pool_mode
+	# (settings). That pins the #498 class rather than one case of it."
+	# ------------------------------------------------------------------ #
+
+	def test_proxy_active_implies_pool_mode_over_every_shape(self):
+		from jarvis.jarvis.pool_serialize import compute_pool_mode, compute_proxy_active
+
+		def settings_for(models, preset=None, pool_synced=None):
+			s = _make_settings_with_models(models)
+			s.preset = preset
+			if pool_synced is not None:
+				s.llm_pool_synced_at = pool_synced
+			return s
+
+		shapes = [
+			("lone api key", settings_for([_api_key_model(enabled=1)])),
+			(
+				"lone subscription, fresh, openai",
+				settings_for([_subscription_model(accounts=[_account(upstream="openai")])]),
+			),
+			(
+				"lone subscription, fresh, google",
+				settings_for([_subscription_model(accounts=[_account(upstream="google")])]),
+			),
+			(
+				"lone subscription, already pool-synced",
+				settings_for(
+					[_subscription_model(accounts=[_account(upstream="openai")])],
+					pool_synced="2026-08-01 00:00:00",
+				),
+			),
+			(
+				"lone subscription, kimi (no renderer)",
+				settings_for([_subscription_model(accounts=[_account(upstream="kimi")])]),
+			),
+			(
+				"lone subscription, xai (no renderer)",
+				settings_for([_subscription_model(accounts=[_account(upstream="xai")])]),
+			),
+			(
+				"lone subscription, two accounts",
+				settings_for(
+					[
+						_subscription_model(
+							accounts=[
+								_account(upstream="openai", account_ref="A1"),
+								_account(upstream="openai", account_ref="A2"),
+							]
+						)
+					]
+				),
+			),
+			(
+				"lone subscription with a preset",
+				settings_for(
+					[_subscription_model(accounts=[_account(upstream="openai")])], preset="Cost-saver"
+				),
+			),
+			(
+				"two-model api-key pool",
+				settings_for(
+					[_api_key_model(enabled=1), _api_key_model(model="gpt-4-turbo", enabled=1, order=1)]
+				),
+			),
+			(
+				"mixed api-key + subscription pool",
+				settings_for([_api_key_model(enabled=1), _subscription_model(accounts=[_account()])]),
+			),
+			("empty config", settings_for([])),
+		]
+		for label, settings in shapes:
+			with self.subTest(shape=label):
+				if compute_proxy_active(settings):
+					self.assertTrue(
+						compute_pool_mode(settings),
+						f"{label}: proxy_active=True but pool_mode=False (#498 shape)",
+					)
 
 	# ------------------------------------------------------------------ #
 	# (h3) pool_primary_model — what the container runs by DEFAULT
@@ -1182,6 +1364,148 @@ class TestRT3UnifiedOnUpdateRouting(_RT3SettingsTestCase):
 		# A preset routes through /llm-pool (asserted above) but conjures no sidecar:
 		# the single credential is still a BYO api key, so this renders agent-direct.
 		self.assertEqual(int(settings.proxy_active or 0), 0, "an api-key preset pool gets no proxy sidecar")
+
+
+class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
+	"""jarvis#715 step 3: THE DECISION at the seam where it becomes an admin
+	call. A fresh lone renderable (openai) subscription must never reach
+	``/llm-pool`` - no Bifrost/cliproxy push - and instead pushes its oauth
+	blob + creds through the direct ``/llm-creds`` leg."""
+
+	_EXTRA_FIELDS = ("llm_pool_synced_at", "llm_direct_synced_at", "llm_auth_mode")
+
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		_reset_settings()
+		s = frappe.get_single("Jarvis Settings")
+		self._extra_snapshot = {f: s.get(f) for f in self._EXTRA_FIELDS}
+		s.db_set("preset", "", update_modified=False)
+		s.db_set("routing_mode", "failover", update_modified=False)
+		s.db_set("proxy_active", 0, update_modified=False)
+		# The non-retroactivity gate: a FRESH connect has never synced via pool.
+		s.db_set("llm_pool_synced_at", None, update_modified=False)
+		s.db_set("llm_direct_synced_at", None, update_modified=False)
+		frappe.db.commit()
+
+	def tearDown(self):
+		s = frappe.get_single("Jarvis Settings")
+		for field, value in self._extra_snapshot.items():
+			s.db_set(field, value, update_modified=False)
+		frappe.db.commit()
+		super().tearDown()
+
+	@staticmethod
+	def _lone_sub_payload(upstream="openai", agent_provider="openai"):
+		blob = json.dumps(
+			{
+				"type": "oauth",
+				"provider": agent_provider,
+				"access": "AT-direct",
+				"refresh": "RT-direct",
+				# fleet's PUT /auth-profile schema is extra_forbidden - the push must
+				# strip this, exactly like complete_paste_signin's direct_blob does.
+				"id_token": "should-be-stripped",
+			}
+		)
+		return [
+			{
+				"model": "gpt-5.5",
+				"tier": "cheap",
+				"order": 0,
+				"subscription": {
+					"rotation": "sticky",
+					"accounts": [
+						{
+							"upstream": upstream,
+							"account_ref": "ACC_DIRECT_1",
+							"label": "solo@example.com",
+							"oauth_blob": blob,
+						}
+					],
+				},
+			}
+		]
+
+	def test_fresh_lone_openai_subscription_never_reaches_the_pool_push(self):
+		from jarvis import onboarding
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		pool_calls = []
+		blob_calls = []
+		with (
+			frappe_patch(
+				"jarvis.admin_client.post_update_llm_pool",
+				side_effect=lambda **kw: pool_calls.append(kw) or {"action": "pool_update"},
+			),
+			frappe_patch(
+				"jarvis.admin_client.post_push_oauth_blob",
+				side_effect=lambda provider, blob: blob_calls.append((provider, blob)) or {},
+			),
+			frappe_patch(
+				"jarvis.admin_client.post_update_llm_creds",
+				return_value={"action": "restart", "status": "applied"},
+			) as mock_creds,
+		):
+			out = onboarding.save_llm_pool(
+				frappe.as_json(self._lone_sub_payload()),
+				preset=None,
+				routing_mode="failover",
+			)
+
+		# THE DECISION under test: the pool/proxy push is never reached.
+		self.assertEqual(pool_calls, [], "a fresh lone renderable subscription must never push /llm-pool")
+		self.assertEqual(out["mode"], "legacy", "no apply-operation descriptor on the direct leg")
+
+		# The oauth blob is pushed to openclaw's auth store BEFORE /llm-creds,
+		# with id_token stripped (jarvis#715 step 3, point 4).
+		self.assertEqual(len(blob_calls), 1, "the direct leg must push the oauth blob exactly once")
+		provider, pushed_blob = blob_calls[0]
+		self.assertEqual(provider, "openai")
+		self.assertNotIn("id_token", pushed_blob)
+		self.assertEqual(pushed_blob.get("refresh"), "RT-direct")
+
+		mock_creds.assert_called_once()
+		self.assertEqual(
+			mock_creds.call_args.kwargs.get("auth_mode"),
+			"oauth",
+			"a subscription credential must cross the wire as oauth, not the literal 'subscription'",
+		)
+
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(int(settings.proxy_active or 0), 0, "no sidecar for a lone renderable subscription")
+		self.assertFalse(compute_pool_mode(settings))
+		self.assertIsNotNone(
+			settings.llm_direct_synced_at,
+			"a confirmed direct apply must stamp llm_direct_synced_at (is_ready_for_chat's gate)",
+		)
+
+	def test_lone_kimi_subscription_still_reaches_the_pool_push(self):
+		"""Kimi has no openclaw-native auth flow, so it must still take the pool
+		leg - the seam-level counterpart to the compute_pool_mode unit test."""
+		from jarvis import onboarding
+
+		pool_calls = []
+		with (
+			frappe_patch(
+				"jarvis.admin_client.post_update_llm_pool",
+				side_effect=lambda **kw: pool_calls.append(kw) or {"action": "pool_update"},
+			),
+			frappe_patch("jarvis.admin_client.post_push_oauth_blob") as mock_blob,
+			frappe_patch("jarvis.admin_client.post_update_llm_creds") as mock_creds,
+		):
+			out = onboarding.save_llm_pool(
+				frappe.as_json(self._lone_sub_payload(upstream="kimi", agent_provider="kimi")),
+				preset=None,
+				routing_mode="failover",
+			)
+
+		self.assertTrue(len(pool_calls) >= 1, "a lone Kimi subscription must still push /llm-pool")
+		self.assertNotEqual(
+			out.get("last_sync_status", ""), "", "the pool leg must have run and stamped a status"
+		)
+		mock_blob.assert_not_called()
+		mock_creds.assert_not_called()
 
 
 class TestRT3LegacyNoModelsBackcompat(_RT3SettingsTestCase):

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -597,7 +597,7 @@ class TestPoolSerializeFromSettings(FrappeTestCase):
 		self.assertFalse(compute_pool_mode(settings))
 
 	def test_compute_pool_mode_false_for_a_fresh_lone_renderable_subscription(self):
-		"""jarvis#715: a lone subscription on a provider openclaw can serve
+		"""jarvis#715: a lone subscription on a provider agent can serve
 		NATIVELY (openai, per the bundled catalog's renderer_id), with no prior
 		pool history, needs no sidecar at all - the direct leg serves it.
 		"""
@@ -630,7 +630,7 @@ class TestPoolSerializeFromSettings(FrappeTestCase):
 		self.assertTrue(compute_pool_mode(settings))
 
 	def test_compute_pool_mode_true_for_a_lone_kimi_subscription(self):
-		"""Kimi has NO openclaw-native auth flow at all (bundled catalog:
+		"""Kimi has NO agent-native auth flow at all (bundled catalog:
 		renderer_id ""), so it stays on the pool leg regardless of history."""
 		from jarvis.jarvis.pool_serialize import compute_pool_mode
 
@@ -640,7 +640,7 @@ class TestPoolSerializeFromSettings(FrappeTestCase):
 
 	def test_compute_pool_mode_true_for_a_lone_xai_subscription(self):
 		"""xAI has no fleet-template arm yet (renderer_id ""), even though
-		openclaw's own bundle can authenticate it natively - see the jarvis#715
+		agent's own bundle can authenticate it natively - see the jarvis#715
 		thread. Stays on the pool leg until a template arm + catalog id ship."""
 		from jarvis.jarvis.pool_serialize import compute_pool_mode
 
@@ -752,7 +752,7 @@ class TestPoolSerializeFromSettings(FrappeTestCase):
 		self.assertTrue(compute_proxy_active(settings))
 
 	def test_compute_proxy_active_true_for_a_lone_kimi_subscription(self):
-		"""Kimi has no openclaw-native auth flow - cliproxy is doing genuine work."""
+		"""Kimi has no agent-native auth flow - cliproxy is doing genuine work."""
 		_, _, compute_proxy_active = self._imports()
 		settings = _make_settings_with_models([_subscription_model(accounts=[_account(upstream="kimi")])])
 		settings.preset = None
@@ -1457,7 +1457,7 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		self.assertEqual(pool_calls, [], "a fresh lone renderable subscription must never push /llm-pool")
 		self.assertEqual(out["mode"], "legacy", "no apply-operation descriptor on the direct leg")
 
-		# The oauth blob is pushed to openclaw's auth store BEFORE /llm-creds,
+		# The oauth blob is pushed to agent's auth store BEFORE /llm-creds,
 		# with id_token stripped (jarvis#715 step 3, point 4).
 		self.assertEqual(len(blob_calls), 1, "the direct leg must push the oauth blob exactly once")
 		provider, pushed_blob = blob_calls[0]
@@ -1481,7 +1481,7 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		)
 
 	def test_lone_kimi_subscription_still_reaches_the_pool_push(self):
-		"""Kimi has no openclaw-native auth flow, so it must still take the pool
+		"""Kimi has no agent-native auth flow, so it must still take the pool
 		leg - the seam-level counterpart to the compute_pool_mode unit test."""
 		from jarvis import onboarding
 
@@ -4543,6 +4543,37 @@ class TestConvergenceReconcile(_RT3SettingsTestCase):
 		)
 		self.assertTrue((settings.last_sync_status or "").startswith("ok"))
 
+	def test_reconcile_treats_an_unconfigured_subscription_tenant_as_nothing_to_converge(self):
+		"""jarvis#755 review: direct_leg_configured used to key on bare models[]
+		presence (bool(settings.get("models"))), so a leftover row that is
+		disabled, or has no connected account, still read as "configured" and
+		got re-polled forever even though there is nothing to converge. Patches
+		has_configured_subscription_model directly - the exact predicate that
+		changed - rather than fighting the models[]-table save/validate
+		pipeline to construct a disabled row."""
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+			reconcile_pending_llm_sync,
+		)
+
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			{
+				"llm_auth_mode": "subscription",
+				"llm_pool_synced_at": None,
+				"llm_direct_synced_at": None,
+				"last_sync_status": "failed: admin briefly unreachable",
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
+		with (
+			patch("jarvis.jarvis.pool_serialize.has_configured_subscription_model", return_value=False),
+			patch("jarvis.admin_client.get_connection") as m,
+		):
+			reconcile_pending_llm_sync()
+			m.assert_not_called()
+
 	def test_reconcile_leaves_a_healthy_tenant_alone(self):
 		"""Inert on a healthy fleet: an 'ok' tenant is never re-stamped.
 
@@ -4794,15 +4825,16 @@ class TestLeavingPoolModeConvergence(FrappeTestCase):
 	(jarvis#566).
 	"""
 
-	def _leaving(self, before_rows, after_rows):
+	def _leaving(self, before_rows, after_rows, before_pool_synced_at=None):
 		from unittest.mock import Mock
 
 		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import JarvisSettings
 
+		before_doc = _make_settings_with_models(before_rows) if before_rows is not None else None
+		if before_doc is not None and before_pool_synced_at is not None:
+			before_doc.llm_pool_synced_at = before_pool_synced_at
 		doc = _make_settings_with_models(after_rows)
-		doc.get_doc_before_save = Mock(
-			return_value=(_make_settings_with_models(before_rows) if before_rows is not None else None)
-		)
+		doc.get_doc_before_save = Mock(return_value=before_doc)
 		return JarvisSettings._is_leaving_pool_mode(doc)
 
 	def test_dropping_two_models_to_one_is_leaving_pool_mode(self):
@@ -4819,13 +4851,31 @@ class TestLeavingPoolModeConvergence(FrappeTestCase):
 		self.assertFalse(self._leaving([_api_key_model(order=0)], [_api_key_model(order=0)]))
 
 	def test_removing_the_last_subscription_is_leaving_pool_mode(self):
-		"""A lone subscription is pool mode, so dropping it also has to converge.
+		"""An ALREADY-PROVISIONED lone subscription is pool mode, so dropping it
+		also has to converge.
 
 		This is the transition that tears the Bifrost and CLIProxyAPI sidecars
-		down, which only the /llm-pool leg does.
+		down, which only the /llm-pool leg does. Stamps llm_pool_synced_at on the
+		before-doc (jarvis#715's retroactivity gate, jarvis#755 review): without
+		it a lone subscription with no sync history reads as
+		_lone_direct_capable and compute_pool_mode(before) is False, which would
+		make this indistinguishable from test_single_model_edit_is_not_leaving_
+		pool_mode's "never was a pool" case - the whole point of this test is a
+		tenant that GENUINELY was on the pool leg.
 		"""
 		before = [_subscription_model(order=0, accounts=[_account()])]
-		self.assertTrue(self._leaving(before, [_api_key_model(order=0)]))
+		self.assertTrue(
+			self._leaving(before, [_api_key_model(order=0)], before_pool_synced_at="2026-08-01 00:00:00")
+		)
+
+	def test_removing_a_fresh_never_synced_lone_subscription_is_not_leaving_pool_mode(self):
+		"""The complement of the test above: a lone subscription that never
+		synced through the pool leg (jarvis#715's _lone_direct_capable shape)
+		was never a pool to begin with, so dropping it tears down nothing and
+		must take the ordinary single-model leg like any other direct-to-direct
+		edit."""
+		before = [_subscription_model(order=0, accounts=[_account()])]
+		self.assertFalse(self._leaving(before, [_api_key_model(order=0)]))
 
 	def test_teardown_push_is_allowed_past_the_pool_mode_gate(self):
 		"""The worker must not skip the job whose whole purpose is the teardown."""
@@ -4851,3 +4901,30 @@ class TestLeavingPoolModeConvergence(FrappeTestCase):
 
 		pool = _make_settings_with_models([_api_key_model(order=0), _api_key_model(model="glm-4.7", order=1)])
 		self.assertTrue(_pool_spec_pushable(pool, False))
+
+
+class TestPushDirectSubscriptionBlobNoMatchInvariant(FrappeTestCase):
+	"""jarvis#755 review: _push_direct_subscription_blob's docstring promises it
+	raises rather than silently skipping the push when its "exactly one enabled
+	subscription model" invariant is violated. A NO-MATCH loop (every row
+	disabled, or none is a subscription) used to fall off the end and return
+	None instead - the caller would then push /llm-creds with auth:"oauth"
+	against an auth store nothing was ever written to."""
+
+	def test_raises_when_no_enabled_subscription_row_matches(self):
+		from jarvis import admin_client
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import JarvisSettings
+
+		settings = _make_settings_with_models(
+			[_subscription_model(order=0, enabled=0, accounts=[_account()])]
+		)
+		with self.assertRaises(admin_client.AdminValidationError):
+			JarvisSettings._push_direct_subscription_blob(settings)
+
+	def test_raises_when_models_is_empty(self):
+		from jarvis import admin_client
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import JarvisSettings
+
+		settings = _make_settings_with_models([])
+		with self.assertRaises(admin_client.AdminValidationError):
+			JarvisSettings._push_direct_subscription_blob(settings)


### PR DESCRIPTION
Fixes #715

## DO NOT MERGE before a live fresh-signup verification

Two risks below are unverified and both sit on the path this changes. Merging without testing could trade a wasteful-but-working connect for one that does not serve.

## Summary

A customer connecting a single chat subscription no longer pays for two cold sidecar starts they do not need. openclaw serves that credential natively, so the pool proxy was pure overhead on the shape most early customers will use.

## What changed

- `compute_pool_mode` and `compute_proxy_active` gain one shared exception, `_lone_direct_capable`: exactly one enabled subscription model, one connected account, an upstream with a renderer in the bundled catalog, and no preset. `xai` and `kimi` stay pooled.
- Not retroactive. The gate is `llm_pool_synced_at` being unset, and only a confirmed pool apply ever stamps it, so an existing tenant keeps evaluating as pool. Only a genuinely fresh connect takes the new leg.
- The direct leg now stamps readiness for a subscription, and the connect path pushes the OAuth blob to openclaw's auth store.

## Fixed while tracing, each would have broken this leg on its own

- `chat/policy.py` `_llm_not_configured` would have blocked every send.
- `reconcile_pending_llm_sync` only recognised `api_key`, so a stuck subscription apply could never self heal.
- `_classify_llm_change` read a subscription re-auth as a no-op, so a refreshed token never reached the container.

## Risk and verification

- Tests at the decision layer, including a permanent `proxy_active implies pool_mode` invariant and a dedicated retroactivity test. Without the fix, three of them fail because the old code forces pool.
- Two pre-existing tests were only passing because an earlier run had left `llm_pool_synced_at` stamped on the shared local database. They were genuinely broken on a fresh database and are now fixed.

<details><summary>Unverified, read before merging</summary>

**OAuth token audience.** The pool capture flow mints `pool_scope` tokens (`aud=chatgpt.com/backend-api`). Per `oauth/providers.py:26-35` the direct flow needs connectors-scope (`aud=api.openai.com`) for openclaw's codex app-server. A fresh lone-subscription connect still captures through the pool-scoped flow, so the blob this pushes may carry the wrong audience. Not reproducible without a live container.

**Chat-turn provider dispatch.** `turn_handler.py:314-317` sets the agent-provider hint only when `llm_auth_mode == "oauth"`, never for `"subscription"`, and `llm_provider` is blank on subscription rows. That function's own comments say a Google turn without the hint fails with "No API key found for provider 'google'". OpenAI may resolve a bare model id when it is the only registered provider; the comments do not say. Candidate fix is to derive the provider from the account blob's own `provider` key, failing to `None` on error. Not implemented, since guessing here would be worse than naming it.

**Frontend `pool.js` `deriveMode`** still labels any subscription as "Pool (proxied)" pre-save. Display only, and it cannot see the new gate. Left alone deliberately.

</details>
