### PR TITLE
fix(onboarding): carry the provider through, and stop faking success

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -3937,6 +3937,23 @@ function buildSaveModels(sourceRows) {
 	return (sourceRows || []).map((r, i) => {
 		if (r.credentialType === "subscription") {
 			return {
+				// jarvis#756: the Provider select for a subscription row writes to
+				// r.upstream (onUpstreamChange), never to r.provider - so this row's
+				// OWN `provider` field is never touched by the UI. Without this line
+				// the posted row carried no `provider` key at all, save_llm_pool's
+				// normalize_provider(m.get("provider")) then defaulted to "", and the
+				// STORED row saved a subscription with an empty provider even though
+				// the customer had picked one. Admin later rejected the apply with
+				// "provider + model required in oauth mode", but by then the wizard
+				// had already told the customer their connection was saved.
+				// UPSTREAM_OAUTH_PROVIDER is the same upstream-value -> label map the
+				// OAuth sign-in call already uses (line ~3455), so a row that never
+				// resolves a label (should not happen - setCredType defaults upstream
+				// to "openai") posts an EMPTY provider here rather than a silently
+				// invented one - validatePool (jarvis/llm/pool.js) then refuses the
+				// save locally with a clear message instead of letting admin be the
+				// only thing that ever checks this.
+				provider: UPSTREAM_OAUTH_PROVIDER[r.upstream] || "",
 				model: (r.model || "").trim(),
 				order: i,
 				subscription: {

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -133,9 +133,14 @@ export function validatePool(models, preset) {
 	if (!Array.isArray(models) || models.length === 0)
 		return { ok: false, error: "Add at least one model." };
 	for (const m of models) {
-		// Chat-subscription model: needs a model id + at least one connected account.
-		// No provider / api_key required.
+		// Chat-subscription model: needs a provider + a model id + at least one
+		// connected account. No api_key required (jarvis#756: a subscription row
+		// that reaches here with no provider is refused HERE, with a clear
+		// message, rather than accepted locally and rejected later by admin once
+		// the OAuth capture already went through).
 		if (m.subscription) {
+			if (!(m.provider || "").trim())
+				return { ok: false, error: "Choose a provider for your chat subscription." };
 			if (!(m.model || "").trim())
 				return { ok: false, error: "Every model needs a model id." };
 			const accounts = Array.isArray(m.subscription.accounts) ? m.subscription.accounts : [];

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -193,8 +193,9 @@ test("validatePool: rejects empty pool", () => {
 		true
 	);
 });
-test("validatePool: subscription model valid with a connected account (no provider/api_key)", () => {
+test("validatePool: subscription model valid with a provider + a connected account (no api_key)", () => {
 	const sub = {
+		provider: "OpenAI",
 		model: "gpt-5.5",
 		order: 0,
 		subscription: {
@@ -211,12 +212,46 @@ test("validatePool: subscription model valid with a connected account (no provid
 	};
 	assert.equal(validatePool([sub], null).ok, true);
 });
+// jarvis#756: buildSaveModels used to omit `provider` entirely for a subscription
+// row (the Provider select writes to r.upstream, never to r.provider), so a
+// customer's chosen provider never reached the saved payload - admin later
+// rejected the apply with "provider + model required in oauth mode" while the
+// wizard had already told the customer their connection was saved. This is the
+// save-path refusal that closes the gap: a provider-less subscription row is
+// invalid LOCALLY, with a clear message, rather than accepted here and rejected
+// only later by admin.
+test("validatePool: subscription model with no provider is refused locally, with a clear message", () => {
+	const sub = {
+		model: "gpt-5.5",
+		order: 0,
+		subscription: {
+			rotation: "sticky",
+			accounts: [
+				{
+					upstream: "openai",
+					account_ref: "SUB_abc123",
+					label: "me@x.com",
+					oauth_blob: '{"token":"t"}',
+				},
+			],
+		},
+	};
+	const v = validatePool([sub], null);
+	assert.equal(v.ok, false);
+	assert.match(v.error, /provider/i);
+});
 test("validatePool: subscription model invalid with no accounts", () => {
-	const sub = { model: "gpt-5.5", order: 0, subscription: { rotation: "sticky", accounts: [] } };
+	const sub = {
+		provider: "OpenAI",
+		model: "gpt-5.5",
+		order: 0,
+		subscription: { rotation: "sticky", accounts: [] },
+	};
 	assert.equal(validatePool([sub], null).ok, false);
 });
 test("validatePool: subscription account with account_ref but blank blob is valid (previously connected; blob merged back on save)", () => {
 	const sub = {
+		provider: "OpenAI",
 		model: "gpt-5.5",
 		order: 0,
 		subscription: {

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -76,10 +76,18 @@ export async function isWorkspaceReady() {
 // thrown-call catch above resolves to this same reason for the severe own-bench
 // failure, which also fails closed. It differs from llm_credentials, which fires
 // on an ESTABLISHED workspace's later credential rotation and must stay degraded.
+// "llm_rejected" (jarvis#757) belongs here for the same reason the two
+// provisioning reasons do: it fires in the SAME structural position, a first sync
+// that never succeeded, and it only ever REPLACES one of them. Round-1 review of
+// jarvis#760 caught that adding the reason without listing it here silently
+// reopened the gate: needsOnboarding() returned false, so AppShell rendered the
+// normal chat shell for a customer whose connection was never accepted and whose
+// chat therefore cannot answer.
 const NOT_ONBOARDED_REASONS = new Set([
 	"signup",
 	"llm_pool_provisioning",
 	"llm_provisioning",
+	"llm_rejected",
 	"llm_setup",
 	"readiness_unconfirmed",
 ]);

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -131,6 +131,20 @@ describe("readiness verdict ownership", () => {
  * what AppShell calls on every route change to close that gap; these pin its
  * two behaviours directly, without mounting the (heavy) shell component.
  */
+describe("llm_rejected still gates (jarvis#757, round-1 review of #760)", () => {
+	it("keeps a never-connected customer on the onboarding gate", async () => {
+		// llm_rejected fires in the SAME structural position as the two
+		// provisioning reasons, a first sync that never succeeded, and it only
+		// ever REPLACES one of them. Adding the reason without listing it in
+		// NOT_ONBOARDED_REASONS silently reopened the gate, dropping a customer
+		// whose connection was never accepted into a chat shell that cannot
+		// answer them.
+		forgetReady();
+		verdict({ ready: false, reason: "llm_rejected", detail: "provider + model required" });
+		expect(await needsOnboarding()).toBe(true);
+	});
+});
+
 describe("regateOnboarding (jarvis#691 stale-gate re-check)", () => {
 	it("re-confirms with the backend when the caller is currently gated", async () => {
 		// The memo held a stale "never onboarded" verdict (captured before an

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -176,12 +176,29 @@ export function provisioningPhase({ answered = false, tenantStatus = "" } = {}) 
  *     thing this surface can do is show admin's own reassurance, never an
  *     action, because retrying payment or reconnecting could make it worse.
  *
+ * A third, `llm_rejected` (jarvis#757), must never render as either of the two
+ * shapes above knows how to show it. Admin permanently refused the config the
+ * customer just submitted (a terminal `last_sync_status` of `"failed: ..."`,
+ * nothing left to converge) - waiting cannot resolve that either, so it stops
+ * the wait like the paged/suspended/moved verdicts do, but the fix is IN the
+ * customer's hands (the connection they chose), unlike those three. `editable`
+ * marks that difference for the caller: route back to the editable form with
+ * admin's own reason, not the support-only "we've stopped checking" screen -
+ * the same distinction OP_PHASE.REJECTED already draws for the pool/operation
+ * path (jarvis#727). This case is EARLIER than jarvis#752's route verdict
+ * (`inFlightPhase`'s `detail` param): that one names a route problem on a
+ * config admin already accepted and probed, while this one means the config
+ * was never accepted at all, so there is no operation and no probe, only this.
+ *
  * @param {{answered?: boolean, reason?: string, detail?: string}} [last]
  * @returns {{observed: boolean, state: string, label: string, detail: string,
- *   stop: boolean, paged?: boolean, title?: string}} `stop` means waiting cannot
- *   resolve this, so the loop must end rather than run to a ceiling whose copy
- *   invites a retry that cannot help. `paged` distinguishes "support has already
- *   been notified, do nothing" from "nobody was notified, you must act".
+ *   stop: boolean, paged?: boolean, editable?: boolean, title?: string}} `stop`
+ *   means waiting cannot resolve this, so the loop must end rather than run to
+ *   a ceiling whose copy invites a retry that cannot help. `paged` distinguishes
+ *   "support has already been notified, do nothing" from "nobody was notified,
+ *   you must act". `editable` (only ever true alongside `stop`) means the fix
+ *   is a config change, so the caller must return to the form, not stay on a
+ *   dead-end screen.
  */
 export function readinessPhase({ answered = false, reason = "", detail = "" } = {}) {
 	const say = String(detail || "").trim();
@@ -266,6 +283,18 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				stop: true,
 				paged: false,
 				title: "This site no longer has your workspace",
+			};
+		case "llm_rejected":
+			// jarvis#757: a hard rejection, not a timeout. Admin's own reason (`say`)
+			// is the whole point of this case - never replace it with generic copy.
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				kind: PHASE_KIND.NONE,
+				label: "That connection was rejected",
+				detail: say,
+				stop: true,
+				editable: true,
 			};
 		default:
 			// A reason this build does not know about gets the neutral line. It

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -130,11 +130,45 @@ test("readiness: only a paged repair claims support was already notified", () =>
 	for (const reason of [
 		"subscription_suspended",
 		"site_replaced",
+		"llm_rejected",
 		"container_provisioning",
 		"readiness_unconfirmed",
 		"unmapped",
 	]) {
 		assert.notEqual(readinessPhase({ answered: true, reason }).paged, true, reason);
+	}
+});
+
+// jarvis#757: a hard rejection (admin permanently refused the config; jarvis/
+// account.py's is_ready_for_chat returns "llm_rejected" only when the last sync
+// ended in a terminal "failed: ..." status) must read as a rejection, quoting
+// admin's own reason, and must not be confused with either the ordinary
+// still-provisioning phases OR the three "blocked, nothing to do" stop cases
+// above (authority_repair_required / subscription_suspended / site_replaced):
+// unlike those three, the fix here IS a config change, so the caller is told to
+// go back to the editable form (`editable: true`) instead of a dead end.
+test("readiness: llm_rejected stops the wait, is editable, quotes admin verbatim, never claims progress", () => {
+	const detail = "Your AI configuration was rejected: provider + model required in oauth mode";
+	const p = readinessPhase({ answered: true, reason: "llm_rejected", detail });
+	assert.equal(p.stop, true);
+	assert.equal(p.editable, true);
+	assert.equal(p.detail, detail);
+	assert.notEqual(p.state, PHASE_STATE.ACTIVE);
+	assert.notEqual(p.paged, true);
+	assert.doesNotMatch(
+		p.label + " " + p.detail,
+		/couldn't confirm|coming online|still progressing/i
+	);
+});
+
+test("readiness: only llm_rejected is editable - the three blocked stop cases are not", () => {
+	assert.equal(readinessPhase({ answered: true, reason: "llm_rejected" }).editable, true);
+	for (const reason of [
+		"authority_repair_required",
+		"subscription_suspended",
+		"site_replaced",
+	]) {
+		assert.notEqual(readinessPhase({ answered: true, reason }).editable, true, reason);
 	}
 });
 
@@ -202,6 +236,7 @@ test("readiness: no branch ever claims setup is finishing on its own", () => {
 		"authority_repair_required",
 		"subscription_suspended",
 		"site_replaced",
+		"llm_rejected",
 		"unmapped",
 	];
 	for (const reason of reasons) {
@@ -279,6 +314,7 @@ test("setup headline: no readiness reason reaches the chat-opening headline on i
 		"authority_repair_required",
 		"subscription_suspended",
 		"site_replaced",
+		"llm_rejected",
 		"unmapped",
 	];
 	for (const reason of reasons) {

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1221,6 +1221,82 @@ describe("staged readiness phases: the screen renders what the poll observed", (
 	});
 });
 
+// jarvis#757 review, gap 2: readinessPhase's "llm_rejected" case (waitPhases.js,
+// waitPhases.test.js) was only ever exercised as a pure function. Nothing asserted
+// that OnboardingView ITSELF routes an llm_rejected readiness answer back to the
+// editable form and shows admin's reason - the whole customer-visible point of
+// jarvis#757. These pin the routing, not just the copy: the wait must stop on the
+// FIRST poll that names a rejection (never grind to the 40-poll ceiling the way an
+// ordinary transient reason does), the form must become visible again
+// (`state.finishing === false`, mirroring the jarvis#727 REJECTED operation path),
+// and it must never offer the ceiling's Retry/support pair - retrying the exact
+// config admin just refused cannot succeed.
+describe("jarvis#757 llm_rejected routes back to the editable form", () => {
+	it("stops the wait on the first poll, returns to the form, and shows admin's reason verbatim", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		const detail = "Your AI configuration was rejected: unknown llm_provider: 'gemini'";
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_rejected", detail });
+		api.isReadyForChat.mockClear(); // ignore the one mount-time readiness probe
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+
+		expect(api.isReadyForChat).toHaveBeenCalledTimes(1); // no ceiling-grinding on a rejection
+		expect(w.vm.state.finishing).toBe(false); // the editable form is showing again
+		expect(w.vm.state.connectPhase).toBe("rejected");
+		expect(w.vm.state.connectBlockReason).toBe(detail);
+		expect(routerReplace).not.toHaveBeenCalled();
+		w.unmount();
+	});
+
+	it("never reaches the retry/support ceiling copy, even if the wait is left to run out", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockResolvedValue({
+			ready: false,
+			reason: "llm_rejected",
+			detail: "Your AI configuration was rejected: provider + model required in oauth mode",
+		});
+
+		w.vm.onTerminal(readyChatBlockedStatus);
+		await flushPromises();
+		// Running out the rest of the would-be ceiling must not convert this into a
+		// retry: the loop already returned on the first poll (see the test above).
+		await vi.advanceTimersByTimeAsync(40 * 3000);
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("rejected");
+		expect(w.vm.state.connectPhase).not.toBe("retry");
+		expect(w.vm.state.connectSupportOffered).not.toBe(true);
+		w.unmount();
+	});
+
+	it("followLegacyReadiness (mode:legacy) routes the same llm_rejected answer back to the form", async () => {
+		saveMock.mockResolvedValue({
+			ok: true,
+			result: opResult({ apply_operation: null, resumable: false, mode: "legacy" }),
+		});
+		const detail = "Your AI configuration was rejected: unknown llm_provider: 'gemini'";
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_rejected", detail });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear();
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+
+		expect(api.isReadyForChat).toHaveBeenCalledTimes(1);
+		expect(w.vm.state.finishing).toBe(false);
+		expect(w.vm.state.connectPhase).toBe("rejected");
+		expect(w.vm.state.connectBlockReason).toBe(detail);
+		await vi.advanceTimersByTimeAsync(30 * 2500);
+		await p;
+		expect(w.vm.state.connectPhase).toBe("rejected"); // still not "retry" at the would-be ceiling
+		w.unmount();
+	});
+});
+
 // The payment-confirming screen. This is the moment right after the customer
 // pays: they are sent back to the SPA and the bench asks the control plane
 // whether the payment landed. Before this it rendered the marketing intro tour,

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1476,21 +1476,33 @@
 													label="Use a different model"
 													@click="chooseDifferentModel"
 												/>
+												<!-- jarvis#758: a real button, weighted alongside Retry /
+													 Use a different model - at the point a customer has hit
+													 a wall (and already paid), support is the action most
+													 likely to matter and must not read as the least
+													 prominent one. `subtle`, matching "Use a different
+													 model": design.md 3.1 allows exactly one `solid` button
+													 per surface. -->
+												<Button
+													v-if="state.connectSupportOffered"
+													variant="subtle"
+													label="Contact support"
+													@click="openSupport"
+												/>
 											</div>
 											<!-- jarvis#708: offered the moment a bounded readiness wait
 												 runs out with no Ready verdict - never after N retries,
 												 same as jarvis_admin_v2#259's checkout-shell poll ceiling.
-												 A real exit alongside Retry, not instead of it. -->
+												 A real exit alongside Retry, not instead of it. The button
+												 above is the action; this stays as the reassurance line
+												 (jarvis#758 moved the link itself into that button, out of
+												 this sentence). -->
 											<p
 												v-if="state.connectSupportOffered"
 												class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
 												role="status"
 											>
-												Still not resolved?
-												<button class="ob-link" @click="openSupport">
-													Contact support
-												</button>
-												- we'll take a look for you.
+												Still not resolved? We'll take a look for you.
 											</p>
 										</div>
 									</template>
@@ -3480,6 +3492,24 @@ function noteReadiness(o) {
 	};
 	readinessSeen.value = seen;
 	const stage = readinessPhase(seen);
+	// jarvis#757: a hard rejection (admin permanently refused this config; see
+	// readinessPhase's "llm_rejected" case) is EARLIER than the jarvis#752
+	// operation-verdict case above and unlike the three "blocked" stop-cases
+	// below - the fix IS in the customer's hands (the connection they chose), so
+	// this returns to the EDITABLE form with admin's own reason, mirroring
+	// exactly what onOpUpdate's OP_PHASE.REJECTED branch already does for the
+	// pool/operation path (jarvis#727). Never Retry: retrying the identical
+	// rejected config cannot succeed, which is the false promise this state
+	// exists to stop making.
+	if (stage.editable) {
+		state.finishing = false;
+		state.connectPhase = "rejected";
+		connectModelChangeOffered.value = false;
+		state.connectBlockReason =
+			stage.detail ||
+			"That AI configuration was rejected. Edit your connection and try again.";
+		return stage;
+	}
 	// A verdict that waiting cannot resolve is terminal for this wait: stop
 	// polling rather than counting down to a ceiling whose copy invites a retry
 	// that cannot help. Covers a paged authority repair (do nothing, we called
@@ -3564,7 +3594,10 @@ async function waitForChatReadiness() {
 			detail: r && r.detail,
 		});
 		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
-		if (state.connectPhase === "blocked") return;
+		// jarvis#757: stage.editable already returned to the form (noteReadiness
+		// set state.finishing = false) - stop polling THIS tick rather than
+		// sleeping once more on a config the customer may already be re-editing.
+		if (state.connectPhase === "blocked" || stage.editable) return;
 		await _sleep(CHAT_READY_INTERVAL_MS);
 	}
 	state.finishing = true;
@@ -3802,7 +3835,8 @@ async function followLegacyReadiness() {
 			detail: r && r.detail,
 		});
 		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
-		if (state.connectPhase === "blocked") return;
+		// jarvis#757: see the matching comment in waitForChatReadiness.
+		if (state.connectPhase === "blocked" || stage.editable) return;
 		if (i < LEGACY_READY_ATTEMPTS - 1) await _sleep(LEGACY_READY_INTERVAL_MS);
 	}
 	state.finishing = true;

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -613,6 +613,18 @@ def is_ready_for_chat() -> dict:
 	- ``"llm_pool_provisioning"`` - a pool is configured (pool mode) but
 	  no sync has ever applied it to the container (first sync pending or
 	  failed).
+	- ``"llm_rejected"`` - the pool/api_key/subscription config's FIRST sync ended
+	  in a terminal ``last_sync_status`` of ``"failed: ..."`` AND admin's own
+	  refusal is what produced it (an unusable spec, a validation error, a
+	  subscription needing re-authentication) - re-submitting the SAME config
+	  would just be refused again. ``detail`` carries the recorded reason
+	  verbatim (jarvis#757; see ``_rejected_sync_verdict``). A terminal
+	  ``"failed: ..."`` from a transient cause instead (admin unreachable,
+	  rate-limited, a lock timeout, an unclassified error) is deliberately
+	  NOT this reason - retrying could clear it, so it falls through to the
+	  same ``llm_pool_provisioning``/``llm_provisioning`` verdict a
+	  still-converging sync gets, which is what lets the wizard keep polling
+	  and, at its ceiling, offer Retry (jarvis#757 review, gap 1).
 	- ``"container_provisioning"`` - all local checks passed, but admin reports
 	  the container isn't chat-ready yet (chat_readiness != "Ready"). Set only by
 	  the final ``_admin_chat_gate`` at the managed ready-exits; fail-open and
@@ -671,7 +683,7 @@ def is_ready_for_chat() -> dict:
 	if compute_pool_mode(settings):
 		if getattr(settings, "llm_pool_synced_at", None) or _confirm_apply_via_admin(settings, is_pool=True):
 			return _admin_chat_gate()
-		return {"ready": False, "reason": "llm_pool_provisioning"}
+		return _rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_pool_provisioning"}
 
 	auth_mode = (getattr(settings, "llm_auth_mode", "") or "api_key").strip()
 
@@ -700,7 +712,7 @@ def is_ready_for_chat() -> dict:
 		if not getattr(settings, "llm_direct_synced_at", None) and not _confirm_apply_via_admin(
 			settings, is_pool=False
 		):
-			return {"ready": False, "reason": "llm_provisioning"}
+			return _rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_provisioning"}
 	elif auth_mode == "subscription":
 		# Unified models[]-table subscription on the DIRECT leg (jarvis#715 step
 		# 3): no cliproxy sidecar, so - like api_key direct above - this gates on
@@ -725,7 +737,7 @@ def is_ready_for_chat() -> dict:
 			if not has_configured_subscription_model(settings):
 				return _llm_missing_verdict(settings)
 			if not _confirm_apply_via_admin(settings, is_pool=False):
-				return {"ready": False, "reason": "llm_provisioning"}
+				return _rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_provisioning"}
 	elif auth_mode == "oauth":
 		# The legacy flat-field direct-oauth flow: llm_oauth_connected_at is
 		# set (read-only) when the oauth grant completes and the admin
@@ -804,6 +816,104 @@ def _confirm_apply_via_admin(settings, *, is_pool: bool) -> bool:
 		return True
 	except Exception:
 		return False
+
+
+# jarvis#757 review, gap 1: a terminal ``"failed: ..."`` status is not one fact,
+# it is at least two, and the first shipped ``_rejected_sync_verdict`` treated
+# them as the same:
+#
+# - genuinely REJECTED: admin looked at this exact config and refused it (an
+#   unusable spec, a validation error, a subscription that needs
+#   re-authentication). Re-submitting the identical config will be refused
+#   again - there is nothing to wait for, and the wizard must say so and send
+#   the customer back to the form, with no Retry.
+# - merely FAILED, transiently: admin was unreachable, rate-limited, a sync
+#   lock timed out, or something unclassified blew up. The config itself may
+#   be perfectly fine - a retry (the customer's own Retry click, or the next
+#   sync a re-save enqueues) could clear it outright. Telling this customer
+#   "that connection was rejected" and refusing to let them retry is simply
+#   false, and it is the false claim gap 1 of the #757 review exists to stop.
+#
+# ``last_sync_status`` is one free-text field with no second field to carry
+# this distinction, and jarvis_settings.py's ``_sync_via_admin`` / ``sync_pool_now``
+# do not hand this function the exception that produced it - only the flattened
+# string, written long before (a prior poll, possibly a prior process). So the
+# only signal available is the literal text those two functions write, and this
+# allowlist leans on it deliberately, NOT on admin's own free-form prose (matching
+# an admin-authored sentence is exactly what broke the failed-payment resume -
+# see ``AdminValidationError``'s docstring in jarvis/exceptions.py): every
+# terminal write in those two functions uses one of a small, closed set of
+# literal tokens right after ``"failed:"``, tokens THIS codebase wrote, not
+# admin's. Two of those shapes are structurally guaranteed, not guessed: both
+# ``_admin_rejection_reason`` and ``_admin_customer_facing_reason`` (jarvis_settings.py)
+# check their own output starts with "Your " before using it, and they are the
+# ONLY writers of the bare ``f"failed: {reason}"`` shape (no other token in
+# front of the reason) - so ``"failed: Your "`` reliably means one of those two
+# ran, and both only run for a genuine, admin-decided refusal.
+#
+# This is an ALLOWLIST, not a denylist: an unrecognised "failed:" shape (a
+# status format a future change adds without updating this list) stays on the
+# side that was already correct before jarvis#757 existed - falls through as
+# "still provisioning", retryable - rather than a newly-invented "rejected"
+# telling a customer their working connection was refused. The coupling this
+# creates is real: change one of the literal prefixes in jarvis_settings.py
+# without updating this list and a case silently reclassifies. The fix that
+# removes the coupling is a dedicated field (e.g. a Check
+# ``last_sync_is_rejection`` stamped by jarvis_settings.py at each of these
+# same call sites) so this function reads a fact instead of re-deriving one
+# from text shape - that needs a doctype change and a migration, which this
+# fix deliberately avoids; see the #757 gap-1 report for the tradeoff.
+def _is_genuine_rejection_status(status: str) -> bool:
+	if status.startswith("failed: validation: "):
+		# AdminValidationError (jarvis_settings.py's _sync_via_admin /
+		# sync_pool_now): the pushed payload itself was invalid (e.g. a
+		# missing/malformed oauth_blob) - the customer's config is the problem.
+		return True
+	if status == "failed: subscription needs re-authentication (blocked)":
+		# The pool leg's "blocked" apply status: only a fresh re-auth (which
+		# happens on this same editable form) can ever clear it.
+		return True
+	if status.startswith("failed: Your "):
+		# _admin_rejection_reason / _admin_customer_facing_reason: a config
+		# admin was REACHED and PERMANENTLY refused (AdminRejectedError, or the
+		# pool leg's structured-rejection AdminUnreachableError branch).
+		return True
+	return False
+
+
+def _rejected_sync_verdict(settings) -> dict | None:
+	"""jarvis#757 (gap-1 hardening): a terminal ``last_sync_status`` of
+	``"failed: ..."`` is not the same fact as "still provisioning", but it is
+	also not ONE fact either - see ``_is_genuine_rejection_status`` above for
+	the split and why it is drawn where it is.
+
+	``is_ready_for_chat``'s three provisioning exits (pool, api_key, subscription)
+	each answer "nothing has confirmed this leg applied yet" with the SAME generic
+	reason whether the last attempt is genuinely still converging (``last_sync_status``
+	is ``"pending: ..."`` or unset), transiently failed (unreachable, rate-limited,
+	a lock timeout - a retry could clear it), or admin permanently refused it. Only
+	the last of those three is a rejection: waiting AND retrying are both useless
+	against it, so the Connect step's readiness wait stops rather than grinding to
+	its five-minute ceiling over a config admin had already, explicitly, turned
+	down. The other two stay on the generic provisioning reason, unchanged, so the
+	wizard keeps polling and a genuinely stuck one still reaches its own Retry at
+	the ceiling - a transient failure must never be told "rejected, no retry".
+
+	Returns the ``{"ready": False, "reason": "llm_rejected", "detail": ...}`` verdict
+	only for a genuine rejection (``_is_genuine_rejection_status``), or ``None``
+	otherwise - a blank/``"pending: ..."`` status, an unrecognised "failed:" shape,
+	or a known-transient one all fall through to the caller's own generic
+	provisioning reason unchanged.
+	"""
+	status = (settings.get("last_sync_status") or "").strip()
+	if not status.startswith("failed:") or not _is_genuine_rejection_status(status):
+		return None
+	detail = status[len("failed:") :].strip()
+	return {
+		"ready": False,
+		"reason": "llm_rejected",
+		"detail": detail or "Your AI configuration was rejected.",
+	}
 
 
 def _llm_missing_verdict(settings) -> dict:

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -2178,11 +2178,21 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 				except (admin_client.AdminAuthError, admin_client.AdminValidationError) as e:
 					# Fail BEFORE any operation is allocated (auth / spec validation): a
 					# terminal, non-resumable error, nothing to follow or converge.
+					#
+					# PREFIXED the way the direct leg already prefixes its own two
+					# handlers (jarvis#757, round-1 review). This wrote a bare
+					# "failed: {e}" for both, which account.py's
+					# _is_genuine_rejection_status could not distinguish from a
+					# transient failure, so a pool config admin had PERMANENTLY
+					# rejected read as still applying and ground to the wizard's five
+					# minute ceiling before offering a Retry that could never succeed.
+					# Auth and validation are different facts and now say so.
+					_prefix = "validation: " if isinstance(e, admin_client.AdminValidationError) else "auth: "
 					_write_settings_fields(
 						settings,
 						{
 							"last_sync_at": _frappe.utils.now(),
-							"last_sync_status": f"failed: {e}",
+							"last_sync_status": f"failed: {_prefix}{e}",
 							**_cleared_subscription_status_fields(),
 						},
 					)

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -930,6 +930,17 @@ class TestRejectedSyncVerdictClassification(FrappeTestCase):
 		self.assertIsNotNone(out)
 		self.assertEqual(out["reason"], "llm_rejected")
 
+	def test_the_pool_legs_validation_failure_is_flagged_rejected_too(self):
+		# Round-1 review of jarvis#760: sync_pool_now wrote a BARE "failed: {e}"
+		# for AdminValidationError while the direct leg wrote
+		# "failed: validation: {e}", so a pool config admin had PERMANENTLY
+		# rejected read as still applying and ground to the wizard's five minute
+		# ceiling before offering a Retry that could never succeed. Both legs now
+		# prefix the same way; this pins that they stay in step.
+		out = self._verdict("failed: validation: unknown llm_provider 'gemini'")
+		self.assertIsNotNone(out)
+		self.assertEqual(out["reason"], "llm_rejected")
+
 	def test_a_blocked_subscription_needing_reauth_is_flagged_rejected(self):
 		# The pool leg's "blocked" apply status: only a fresh re-auth (on this
 		# same editable form) can ever clear it, so it belongs with the other

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -890,6 +890,177 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		self.assertEqual(out["reason"], "llm_credentials")
 
 
+class TestRejectedSyncVerdictClassification(FrappeTestCase):
+	"""jarvis#757 review, gap 1: _rejected_sync_verdict had no test at all, and
+	its first cut keyed on the ``"failed:"`` prefix ALONE - so a rate-limit or an
+	admin-unreachable failure read exactly like a genuine spec rejection: no
+	Retry, "that connection was rejected", sent back to re-edit a config that
+	was never the problem. This pins the fixed classifier
+	(account._is_genuine_rejection_status) against every literal shape
+	jarvis_settings.py's ``_sync_via_admin`` / ``sync_pool_now`` actually write,
+	so a future rewording of one of those literals without updating the
+	allowlist fails HERE instead of silently reclassifying a live customer.
+
+	Calls ``_rejected_sync_verdict`` directly against a bare ``frappe._dict`` -
+	it only ever reads ``last_sync_status`` off whatever it is handed, so this
+	needs no Jarvis Settings fixture at all."""
+
+	def _verdict(self, status):
+		return account._rejected_sync_verdict(frappe._dict({"last_sync_status": status}))
+
+	# --- genuine rejections: the config is the problem, no retry can help ---
+
+	def test_an_admin_rejected_config_is_flagged_rejected_with_detail_verbatim(self):
+		detail = "Your AI configuration was rejected: unknown llm_provider: 'gemini'"
+		out = self._verdict(f"failed: {detail}")
+		self.assertIsNotNone(out)
+		self.assertEqual(out["reason"], "llm_rejected")
+		self.assertEqual(out["detail"], detail, "admin's own sentence must reach the customer unedited")
+
+	def test_a_rejection_with_no_admin_sentence_still_gets_a_readable_default_detail(self):
+		out = self._verdict("failed: Your AI configuration was rejected")
+		self.assertIsNotNone(out)
+		self.assertEqual(out["reason"], "llm_rejected")
+		self.assertEqual(out["detail"], "Your AI configuration was rejected")
+
+	def test_a_push_validation_failure_is_flagged_rejected(self):
+		# AdminValidationError, e.g. a malformed oauth_blob: the pushed payload
+		# itself is invalid, which is the customer's config, not a transient blip.
+		out = self._verdict("failed: validation: missing or malformed oauth_blob")
+		self.assertIsNotNone(out)
+		self.assertEqual(out["reason"], "llm_rejected")
+
+	def test_a_blocked_subscription_needing_reauth_is_flagged_rejected(self):
+		# The pool leg's "blocked" apply status: only a fresh re-auth (on this
+		# same editable form) can ever clear it, so it belongs with the other
+		# genuine rejections even though no AdminRejectedError was raised.
+		out = self._verdict("failed: subscription needs re-authentication (blocked)")
+		self.assertIsNotNone(out)
+		self.assertEqual(out["reason"], "llm_rejected")
+
+	# --- transient failures: a retry could clear these, must not read as rejected ---
+
+	def test_admin_unreachable_is_not_flagged_rejected(self):
+		self.assertIsNone(self._verdict("failed: admin unreachable: timeout"))
+
+	def test_rate_limited_is_not_flagged_rejected(self):
+		self.assertIsNone(self._verdict("failed: rate-limited; retry_after=30s"))
+
+	def test_an_auth_token_failure_is_not_flagged_rejected(self):
+		# AdminAuthError: a bench-to-admin token problem, not the customer's LLM
+		# config - re-minting the token (or a retry after it refreshes) can clear it.
+		self.assertIsNone(self._verdict("failed: auth: 401 unauthorized"))
+
+	def test_a_lock_timeout_is_not_flagged_rejected(self):
+		self.assertIsNone(self._verdict("failed: skipped (concurrent sync did not finish in time)"))
+
+	def test_the_unexpected_error_backstop_is_not_flagged_rejected(self):
+		# An unclassified exception: we do not know it was the customer's fault,
+		# so the safe default is "retryable", not "rejected".
+		self.assertIsNone(self._verdict("failed: unexpected error; see Error Log"))
+
+	# --- non-failures: must fall through unchanged ---
+
+	def test_a_pending_status_is_not_flagged_rejected(self):
+		self.assertIsNone(self._verdict("pending: provisioning container (pool)"))
+
+	def test_a_blank_status_is_not_flagged_rejected(self):
+		self.assertIsNone(self._verdict(""))
+
+	def test_an_ok_status_is_not_flagged_rejected(self):
+		self.assertIsNone(self._verdict("ok (restart via admin)"))
+
+
+class TestRejectedSyncVerdictWiring(FrappeTestCase):
+	"""jarvis#757 review, gap 1: the classification above is only half the
+	story - none of is_ready_for_chat's three provisioning exits (pool,
+	api_key, subscription) that CALL _rejected_sync_verdict had a test either,
+	so nothing proved the wiring actually reaches it. Pinned on the
+	subscription leg (same fixture TestIsReadyForChatCohorts uses) as the one
+	representative exit: all three call sites share the identical
+	``_rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_..."}``
+	line, and the classifier itself (covered exhaustively above) is leg-agnostic."""
+
+	_FIELDS = ("llm_auth_mode", "llm_direct_synced_at", "chat_was_ready_at", "last_sync_status")
+
+	def setUp(self):
+		from jarvis._password_utils import set_settings_password
+
+		account._bust_chat_gate()
+		self._snap = account._settings_raw(self._FIELDS)
+		self._key_snap = account._settings_raw(("jarvis_admin_api_key",)).get("jarvis_admin_api_key")
+		set_settings_password(
+			frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key", "test-only-rejected-key"
+		)
+		self._write(
+			{
+				"llm_auth_mode": "subscription",
+				"llm_direct_synced_at": None,
+				"chat_was_ready_at": None,
+			}
+		)
+		self._pool_off = patch.object(account, "compute_pool_mode", return_value=False)
+		self._pool_off.start()
+		self._has_sub_model = patch(
+			"jarvis.jarvis.pool_serialize.has_configured_subscription_model", return_value=True
+		)
+		self._has_sub_model.start()
+		# Forces the exit past _confirm_apply_via_admin without needing to fake
+		# an admin_client round-trip - only last_sync_status is under test here.
+		self._confirm_miss = patch.object(account, "_confirm_apply_via_admin", return_value=False)
+		self._confirm_miss.start()
+
+	def tearDown(self):
+		from jarvis._password_utils import clear_settings_password
+
+		self._confirm_miss.stop()
+		self._has_sub_model.stop()
+		self._pool_off.stop()
+		clear_settings_password(frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key")
+		self._write({f: self._snap.get(f) for f in self._FIELDS})
+		frappe.db.set_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			"jarvis_admin_api_key",
+			self._key_snap,
+			update_modified=False,
+		)
+		account._bust_chat_gate()
+
+	def _write(self, values: dict) -> None:
+		for f, v in values.items():
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v, update_modified=False)
+
+	def test_a_terminal_rejection_reaches_the_customer_as_llm_rejected_with_detail_verbatim(self):
+		detail = "Your AI configuration was rejected: unknown llm_provider: 'gemini'"
+		self._write({"last_sync_status": f"failed: {detail}"})
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_rejected")
+		self.assertEqual(out["detail"], detail)
+
+	def test_a_transient_failure_does_not_reach_the_customer_as_llm_rejected(self):
+		self._write({"last_sync_status": "failed: admin unreachable: timeout"})
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertNotEqual(
+			out["reason"], "llm_rejected", "gap 1: a retry could clear this, must not read as rejected"
+		)
+		self.assertEqual(out["reason"], "llm_provisioning")
+
+	def test_a_pending_status_falls_through_to_provisioning_unchanged(self):
+		self._write({"last_sync_status": "pending: applying subscription blob"})
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_provisioning")
+
+	def test_a_blank_status_falls_through_to_provisioning_unchanged(self):
+		self._write({"last_sync_status": ""})
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_provisioning")
+
+
 class TestExplicitReadyOnlyMarker(FrappeTestCase):
 	"""Review P0-07: only an EXPLICIT admin `Ready` may mint the established marker.
 	A reachable response that never mentions chat_readiness (v1 tolerance) still


### PR DESCRIPTION
Fixes #756
Fixes #757
Fixes #758

## Summary

Onboarding with a chat subscription can now complete. The Connect step was saving a model row with no provider, admin rejected it, and the wizard reported "AI connection saved" and waited forever for an apply that could never happen.

Found on a live run on 2026-08-09, tenant `7roi89k6ka`, on a fresh paid signup.

## What changed

**The blocker (#756).** The Provider select writes to a row's `upstream`, never to its `provider`, so the posted row carried no provider key at all and `normalize_provider` defaulted it to empty. It is now mapped through the same upstream-to-label table the OAuth sign-in call already uses. The OAuth capture itself was always fine, the account was linked.

Also refused locally: a subscription row with no provider is now rejected at save with a clear message, rather than accepted and left for admin to be the only validator. That false success is what turned a one-field bug into a dead end.

**Honest failure copy (#757).** A configuration admin genuinely rejected no longer renders as "we couldn't confirm your setup ... it may still be progressing". It stops the wait on the first poll, returns to the editable form, and quotes admin's own reason.

Narrowed deliberately after review: only an admin-decided rejection takes that path. A transient failure, unreachable admin, rate limit, auth error, lock skip, behaves exactly as it did before this PR, polling to the ceiling and offering Retry. Telling a customer their connection was rejected because the control plane blipped, and giving them no Retry, would be worse than the bug being fixed.

**Recovery actions (#758).** Contact support is a real button beside Retry and Use a different model, not a link inside a sentence.

## Risk and verification

- 1010 vitest and 680 node tests pass on Node 24, run locally. New coverage for the provider mapping, the local refusal, the classifier, and the view-level routing back to the editable form.
- The provider map covers every upstream the picker offers, `openai`, `google`, `xai`, `kimi`, so other providers are unaffected.
- Python tests for the classifier and its three call sites are written but were not executed locally, per the repo rule against running bench tests on the shared database. CI is the authority for those.

<details><summary>Known residual, worth its own issue</summary>

The split keys on literal status prefixes this codebase writes in `jarvis_settings.py`. Changing one of those literals without updating the allowlist silently reclassifies a case, defaulting toward retryable, which is the safer direction. A dedicated field stamped at each write site would be sounder but needs a doctype change and migration.

One asymmetry, pre-existing and not introduced here: on the direct leg an `AdminUnreachableError` never runs `_admin_customer_facing_reason`, which only the pool leg does, so a definitive customer-facing rejection wrapped in that class on the direct leg classifies as transient.

Separately, `readiness.js`'s `NOT_ONBOARDED_REASONS` does not include `llm_rejected` even though it fires in the same structural position as the two reasons that are listed, so `needsOnboarding()` would not gate a rejected-first-sync tenant back to the onboarding poster.

</details>
