### PR TITLE
feat(voice): route speech-to-text through Bifrost for audio to English

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -604,12 +604,12 @@ _STT_CONFIG_MISS = {"__stt_unavailable__": True}
 
 def get_stt_config() -> dict | None:
 	"""Fetch the tenant's speech-to-text config from admin
-	(``{"enabled": bool, "api_key": str, "model": str}``), cache it, and
-	return None on ANY failure — voice features must degrade to
-	"not configured" rather than break callers (``get_chat_ui_settings``
-	runs on every SPA load). Failures are negative-cached briefly so a
-	slow/down admin can't make every SPA load pay a fresh round-trip.
-	Never raises."""
+	(``{"enabled": bool, "api_key": str, "model": str, "base_url": str,
+	"mode": str}``), cache it, and return None on ANY failure: voice
+	features must degrade to "not configured" rather than break callers
+	(``get_chat_ui_settings`` runs on every SPA load). Failures are
+	negative-cached briefly so a slow/down admin can't make every SPA load
+	pay a fresh round-trip. Never raises."""
 	cache = frappe.cache()
 	cached = cache.get_value(_STT_CONFIG_CACHE_KEY)
 	if cached == _STT_CONFIG_MISS:
@@ -630,6 +630,8 @@ def get_stt_config() -> dict | None:
 		"enabled": bool(cfg.get("enabled")),
 		"api_key": cfg.get("api_key") or "",
 		"model": cfg.get("model") or "",
+		"base_url": cfg.get("base_url") or "",
+		"mode": cfg.get("mode") or "",
 	}
 	cache.set_value(_STT_CONFIG_CACHE_KEY, out, expires_in_sec=_STT_CONFIG_TTL_S)
 	return out

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -206,9 +206,7 @@ def stt_config() -> dict | None:
 		return None
 	model = (cfg.get("model") or "").strip()
 	base_url = (cfg.get("base_url") or "").strip()
-	mode = (cfg.get("mode") or "").strip() or (
-		_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION
-	)
+	mode = (cfg.get("mode") or "").strip() or (_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION)
 	default_model = _DEFAULT_CHAT_AUDIO_MODEL if mode == _STT_MODE_CHAT_AUDIO else _DEFAULT_STT_MODEL
 	return {
 		"enabled": True,
@@ -431,9 +429,7 @@ def _audio_format_token(mime: str) -> str:
 	return _AUDIO_FORMAT_BY_MIME.get((mime or "").split(";")[0].strip().lower(), "webm")
 
 
-def _bifrost_chat_audio_transcribe(
-	content: bytes, mime: str, model: str, api_key: str, base_url: str
-) -> str:
+def _bifrost_chat_audio_transcribe(content: bytes, mime: str, model: str, api_key: str, base_url: str) -> str:
 	"""One Bifrost ``/chat/completions`` call carrying the clip as an
 	``input_audio`` part; returns the English text. Same transport discipline
 	as ``_openrouter_transcribe`` (no retry here, the client owns it; 4xx never

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -1,21 +1,33 @@
 """Speech-to-text for the chat composer (voice notes / business tab).
 
 Config resolution (``stt_config``) is two-tier: explicit site_config keys win
-(dev benches: ``jarvis_stt_openrouter_api_key`` + optional
-``jarvis_stt_model`` / ``jarvis_stt_enabled``), else the managed path asks the
-admin app via ``jarvis.admin_client.get_stt_config`` (Redis-cached, never
-raises). Transcription itself is one OpenRouter TRANSCRIPTION call: the clip is
-posted as multipart to ``/audio/transcriptions`` under its own filename and
-mime — no bytes are stored on the bench and nothing is written to disk.
+(dev benches: ``jarvis_stt_openrouter_api_key`` plus optional
+``jarvis_stt_model``, ``jarvis_stt_enabled``, ``jarvis_stt_base_url`` and
+``jarvis_stt_mode``), else the managed path asks the admin app via
+``jarvis.admin_client.get_stt_config`` (Redis-cached, never raises). The
+resolved config also carries ``mode``, which selects the transport used to
+turn the clip into text: ``transcription`` (the default when no ``base_url``
+is set) posts the clip as multipart to ``/audio/transcriptions`` under its own
+filename and mime, no bytes are stored on the bench and nothing is written to
+disk; ``chat-audio`` (the default once a ``base_url`` is set) posts it as an
+OpenAI ``input_audio`` part to ``/chat/completions`` against a Bifrost
+gateway, for providers such as Gemini that only take audio through the chat
+API and can translate natively while doing it.
 
-Why not chat-completions: a chat model told to "transcribe" paraphrases, and
-its failure mode is a fluent HTTP 200 fabrication — on a clean probe clip it
-rewrote "seven lazy dogs" to "the lazy dog", and real mic audio degraded into
-invented sentences that the assistant then answered. A transcription model on
-the transcription API either returns the words or errors; it cannot quietly
-invent them. It also retires the mime -> format table: the endpoint reads the
-container from the part itself, so a browser recording mp4 (Safari) or ogg
-works without a mapping entry.
+Chat-completions was ruled out for transcription for a real reason, and that
+reason still shapes chat-audio mode rather than disappearing: a chat model
+told to "transcribe" paraphrases, and its failure mode is a fluent HTTP 200
+fabrication. On a clean probe clip it rewrote "seven lazy dogs" to "the lazy
+dog", and real mic audio degraded into invented sentences that the assistant
+then answered. That is why chat-audio mode pins a strict
+transcribe-and-translate system prompt and ships behind a faithfulness probe
+(English verbatim, translated meaning, near-silent), and why a tenant that
+needs verbatim fidelity is routed to ``mode=transcription`` (whisper/Sarvam)
+instead: a transcription model on the transcription API still either returns
+the words or errors, it cannot quietly invent them the way a chat model can.
+The transcription path also has no mime to format table: the endpoint reads
+the container from the part itself, so a browser recording mp4 (Safari) or
+ogg works without a mapping entry.
 
 ``openrouter_complete`` (chat-completions) stays for its TEXT callers — wiki
 ingest, voice facts, chat mining, wiki lint, insight drafts, trigger LLM
@@ -155,12 +167,17 @@ def _credentials() -> tuple[str, str]:
 
 
 def stt_config() -> dict | None:
-	"""Resolved speech-to-text config ``{"enabled", "api_key", "model"}`` or
-	None when voice features / STT are off or no key is available.
+	"""Resolved speech-to-text config
+	``{"enabled", "api_key", "model", "base_url", "mode"}`` or None when voice
+	features / STT are off or no key is available.
 
 	Site config WINS when ``jarvis_stt_openrouter_api_key`` is present
 	(dev benches); the managed path defers to admin's tenant config
 	(Redis-cached in admin_client, errors degrade to None).
+
+	``base_url`` empty means "OpenRouter transcription default" (back-compat).
+	``mode`` defaults to ``chat-audio`` only when a ``base_url`` is set, else
+	``transcription`` (whisper/Sarvam through OpenRouter/Bifrost).
 	"""
 	if not _voice_features_enabled():
 		return None
@@ -171,14 +188,35 @@ def stt_config() -> dict | None:
 		if enabled is not None and not cint(enabled):
 			return None
 		model = (frappe.conf.get("jarvis_stt_model") or "").strip()
-		return {"enabled": True, "api_key": key, "model": model or _DEFAULT_STT_MODEL}
+		base_url = (frappe.conf.get("jarvis_stt_base_url") or "").strip()
+		mode = (frappe.conf.get("jarvis_stt_mode") or "").strip() or (
+			_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION
+		)
+		return {
+			"enabled": True,
+			"api_key": key,
+			"model": model or _DEFAULT_STT_MODEL,
+			"base_url": base_url,
+			"mode": mode,
+		}
 	from jarvis import admin_client
 
 	cfg = admin_client.get_stt_config()
 	if not cfg or not cfg.get("enabled") or not cfg.get("api_key"):
 		return None
 	model = (cfg.get("model") or "").strip()
-	return {"enabled": True, "api_key": cfg["api_key"], "model": model or _DEFAULT_STT_MODEL}
+	base_url = (cfg.get("base_url") or "").strip()
+	mode = (cfg.get("mode") or "").strip() or (
+		_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION
+	)
+	default_model = _DEFAULT_CHAT_AUDIO_MODEL if mode == _STT_MODE_CHAT_AUDIO else _DEFAULT_STT_MODEL
+	return {
+		"enabled": True,
+		"api_key": cfg["api_key"],
+		"model": model or default_model,
+		"base_url": base_url,
+		"mode": mode,
+	}
 
 
 # Why STT is unavailable — the UI treats these differently, so collapsing them into one
@@ -312,8 +350,15 @@ def _upload_mime(upload) -> str:
 	return mime
 
 
-def _openrouter_transcribe(content: bytes, filename: str, mime: str, model: str, api_key: str) -> str:
-	"""One OpenRouter transcription call; returns the transcript text.
+def _openrouter_transcribe(
+	content: bytes, filename: str, mime: str, model: str, api_key: str, base_url: str = ""
+) -> str:
+	"""One transcription call against ``/audio/transcriptions``; returns the
+	transcript text.
+
+	``base_url`` defaults to OpenRouter's fixed URL (back-compat); when set
+	(a Bifrost gateway routing to Sarvam/whisper) the call goes there instead,
+	same multipart shape.
 
 	Same transport contract as ``openrouter_complete`` (4xx never retries,
 	secret-scrubbed messages), but the request is multipart ``file`` + ``model``
@@ -324,12 +369,13 @@ def _openrouter_transcribe(content: bytes, filename: str, mime: str, model: str,
 	cannot read out of the provider is an error, never a plausible string
 	handed to the composer as if it were speech.
 	"""
+	url = base_url.rstrip("/") + "/audio/transcriptions" if base_url else _OPENROUTER_TRANSCRIBE_URL
 	headers = {"Authorization": f"Bearer {api_key}"}
 	last_error = ""
 	for _attempt in range(_TRANSCRIBE_ATTEMPTS):
 		try:
 			resp = requests.post(
-				_OPENROUTER_TRANSCRIBE_URL,
+				url,
 				files={"file": (filename, content, mime)},
 				data={"model": model},
 				headers=headers,
@@ -450,8 +496,8 @@ def _bifrost_chat_audio_transcribe(
 def transcribe_audio() -> dict:
 	"""Transcribe one recorded clip (multipart field ``audio`` + form
 	``duration_s``). Desk (System User) only; bytes are size/duration capped
-	and streamed straight to OpenRouter's transcription endpoint — never
-	persisted on the bench.
+	and streamed straight to the resolved STT transport (chat-audio via
+	Bifrost, or a transcription endpoint), never persisted on the bench.
 
 	Returns ``{"ok": True, "text", "stt_ms", "model"}``.
 	"""
@@ -486,14 +532,23 @@ def transcribe_audio() -> dict:
 			frappe.ValidationError,
 		)
 
+	mode = cfg.get("mode") or _STT_MODE_TRANSCRIPTION
 	t_stt = time.monotonic()
-	text = _openrouter_transcribe(
-		content,
-		_upload_filename(upload),
-		_upload_mime(upload),
-		cfg["model"],
-		cfg["api_key"],
-	)
+	if mode == _STT_MODE_CHAT_AUDIO and cfg.get("base_url"):
+		if len(content) > _CHAT_AUDIO_MAX_BYTES:
+			frappe.throw(_("Audio is too large for voice translation."), frappe.ValidationError)
+		text = _bifrost_chat_audio_transcribe(
+			content, _upload_mime(upload), cfg["model"], cfg["api_key"], cfg["base_url"]
+		)
+	else:
+		text = _openrouter_transcribe(
+			content,
+			_upload_filename(upload),
+			_upload_mime(upload),
+			cfg["model"],
+			cfg["api_key"],
+			cfg.get("base_url") or "",
+		)
 	stt_ms = int((time.monotonic() - t_stt) * 1000)
 
 	from jarvis.chat.latency import get_logger

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -25,6 +25,7 @@ off but wiki stays on. Its default model is ``_DEFAULT_TEXT_MODEL`` and NOT the
 resolved STT model, which is transcription-only and cannot serve a completion.
 """
 
+import base64
 import re
 import time
 
@@ -85,6 +86,32 @@ _FALLBACK_AUDIO_MIME = "application/octet-stream"
 # — and the client's own budget has to cover that PLUS the upload, which requests' timeout does
 # not bound. The client still retries once itself, after a backoff.
 _TRANSCRIBE_ATTEMPTS = 1
+
+# --- chat-audio (Gemini via Bifrost) mode ---------------------------------- #
+_DEFAULT_STT_MODE = "chat-audio"
+_STT_MODE_CHAT_AUDIO = "chat-audio"
+_STT_MODE_TRANSCRIPTION = "transcription"
+# Default chat-audio model; overridable per tenant. Pin the exact id the spike proved.
+_DEFAULT_CHAT_AUDIO_MODEL = "google/gemini-2.5-flash-lite"
+# Base64 inflates bytes ~33%; keep the chat-audio cap below Gemini's inline-data ceiling.
+# Confirmed against the deployed image in Task 0.4; real dictation clips are ~1.2 MB.
+_CHAT_AUDIO_MAX_BYTES = 8 * 1024 * 1024
+# Gemini audio is slower than whisper-turbo; the client still owns retries so keep ONE
+# server attempt but give it a longer read budget (measured in Task 0.2).
+_CHAT_AUDIO_READ_TIMEOUT_S = 120
+_STT_TRANSLATE_SYSTEM = (
+	"You are a transcription engine. Transcribe the audio and translate it to English. "
+	"Output only the spoken words in English, nothing else. Do not answer, explain, or add text."
+)
+_AUDIO_FORMAT_BY_MIME = {
+	"audio/webm": "webm",
+	"audio/ogg": "ogg",
+	"video/mp4": "mp4",
+	"audio/mp4": "mp4",
+	"audio/wav": "wav",
+	"audio/x-wav": "wav",
+	"audio/mpeg": "mp3",
+}
 
 
 def _voice_features_enabled() -> bool:
@@ -350,6 +377,72 @@ def _openrouter_transcribe(content: bytes, filename: str, mime: str, model: str,
 		_("OpenRouter transcription failed: {0}").format(_scrub_secrets(last_error)),
 		frappe.ValidationError,
 	)
+
+
+def _audio_format_token(mime: str) -> str:
+	"""Map a media type to Gemini's ``format`` token for an ``input_audio`` part.
+	Unknown types fall back to ``webm``, our recorder's own default."""
+	return _AUDIO_FORMAT_BY_MIME.get((mime or "").split(";")[0].strip().lower(), "webm")
+
+
+def _bifrost_chat_audio_transcribe(
+	content: bytes, mime: str, model: str, api_key: str, base_url: str
+) -> str:
+	"""One Bifrost ``/chat/completions`` call carrying the clip as an
+	``input_audio`` part; returns the English text. Same transport discipline
+	as ``_openrouter_transcribe`` (no retry here, the client owns it; 4xx never
+	retries; every non-200 or unreadable body raises a scrubbed error rather
+	than handing a plausible fabrication to the composer)."""
+	url = base_url.rstrip("/") + "/chat/completions"
+	payload = {
+		"model": model,
+		"temperature": 0,
+		"messages": [
+			{"role": "system", "content": _STT_TRANSLATE_SYSTEM},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "input_audio",
+						"input_audio": {
+							"data": base64.b64encode(content).decode("ascii"),
+							"format": _audio_format_token(mime),
+						},
+					}
+				],
+			},
+		],
+	}
+	headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+	try:
+		resp = requests.post(
+			url,
+			json=payload,
+			headers=headers,
+			timeout=(_CONNECT_TIMEOUT_S, _CHAT_AUDIO_READ_TIMEOUT_S),
+		)
+	except requests.RequestException as e:
+		frappe.throw(_("Voice request failed: {0}").format(_scrub_secrets(str(e))), frappe.ValidationError)
+	if resp.status_code != 200:
+		detail = ""
+		try:
+			err = resp.json().get("error")
+			detail = err.get("message") if isinstance(err, dict) else str(err or "")
+		except Exception:
+			detail = (getattr(resp, "text", "") or "")[:200]
+		frappe.throw(
+			_("Voice gateway rejected the request ({0}): {1}").format(
+				resp.status_code, _scrub_secrets(detail or "no detail")
+			),
+			frappe.ValidationError,
+		)
+	try:
+		content_out = resp.json()["choices"][0]["message"]["content"]
+	except Exception:
+		content_out = None
+	if not isinstance(content_out, str):
+		frappe.throw(_("Voice gateway returned no transcript for this recording."), frappe.ValidationError)
+	return content_out
 
 
 @frappe.whitelist()

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -100,7 +100,6 @@ _FALLBACK_AUDIO_MIME = "application/octet-stream"
 _TRANSCRIBE_ATTEMPTS = 1
 
 # --- chat-audio (Gemini via Bifrost) mode ---------------------------------- #
-_DEFAULT_STT_MODE = "chat-audio"
 _STT_MODE_CHAT_AUDIO = "chat-audio"
 _STT_MODE_TRANSCRIPTION = "transcription"
 # Default chat-audio model; overridable per tenant. Pin the exact id the spike proved.
@@ -166,6 +165,20 @@ def _credentials() -> tuple[str, str]:
 	return "", model
 
 
+def _resolve_stt_mode_and_model(raw_mode: str, raw_model: str, base_url: str) -> tuple[str, str]:
+	"""Resolve ``(mode, model)`` from raw config, shared by both ``stt_config``
+	branches so dev-bench and managed-tenant defaults never drift.
+
+	``mode`` defaults to ``chat-audio`` only when a ``base_url`` is set, else
+	``transcription``. ``model`` defaults mode-aware: the Gemini chat-audio
+	model for chat-audio, the whisper transcription model otherwise — an
+	explicit model always wins.
+	"""
+	mode = (raw_mode or "").strip() or (_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION)
+	default_model = _DEFAULT_CHAT_AUDIO_MODEL if mode == _STT_MODE_CHAT_AUDIO else _DEFAULT_STT_MODEL
+	return mode, (raw_model or "").strip() or default_model
+
+
 def stt_config() -> dict | None:
 	"""Resolved speech-to-text config
 	``{"enabled", "api_key", "model", "base_url", "mode"}`` or None when voice
@@ -187,15 +200,14 @@ def stt_config() -> dict | None:
 		# NULL=ON: a bench that set only the key clearly wants STT.
 		if enabled is not None and not cint(enabled):
 			return None
-		model = (frappe.conf.get("jarvis_stt_model") or "").strip()
 		base_url = (frappe.conf.get("jarvis_stt_base_url") or "").strip()
-		mode = (frappe.conf.get("jarvis_stt_mode") or "").strip() or (
-			_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION
+		mode, model = _resolve_stt_mode_and_model(
+			frappe.conf.get("jarvis_stt_mode") or "", frappe.conf.get("jarvis_stt_model") or "", base_url
 		)
 		return {
 			"enabled": True,
 			"api_key": key,
-			"model": model or _DEFAULT_STT_MODEL,
+			"model": model,
 			"base_url": base_url,
 			"mode": mode,
 		}
@@ -204,14 +216,12 @@ def stt_config() -> dict | None:
 	cfg = admin_client.get_stt_config()
 	if not cfg or not cfg.get("enabled") or not cfg.get("api_key"):
 		return None
-	model = (cfg.get("model") or "").strip()
 	base_url = (cfg.get("base_url") or "").strip()
-	mode = (cfg.get("mode") or "").strip() or (_STT_MODE_CHAT_AUDIO if base_url else _STT_MODE_TRANSCRIPTION)
-	default_model = _DEFAULT_CHAT_AUDIO_MODEL if mode == _STT_MODE_CHAT_AUDIO else _DEFAULT_STT_MODEL
+	mode, model = _resolve_stt_mode_and_model(cfg.get("mode") or "", cfg.get("model") or "", base_url)
 	return {
 		"enabled": True,
 		"api_key": cfg["api_key"],
-		"model": model or default_model,
+		"model": model,
 		"base_url": base_url,
 		"mode": mode,
 	}

--- a/jarvis/tests/test_voice.py
+++ b/jarvis/tests/test_voice.py
@@ -5,6 +5,7 @@ All HTTP is mocked (requests.post is patched); every test runs on a bare
 site with no network and no admin onboarding.
 """
 
+import base64
 import contextlib
 from unittest.mock import MagicMock, patch
 
@@ -267,6 +268,122 @@ class TestTextModelDecoupledFromStt(FrappeTestCase):
 		self.assertEqual(out, "ok")
 		self.assertEqual(mock_post.call_args.args[0], voice._OPENROUTER_URL)
 		self.assertEqual(mock_post.call_args.kwargs["json"]["model"], voice._DEFAULT_TEXT_MODEL)
+
+
+class TestAudioFormatToken(FrappeTestCase):
+	"""``_audio_format_token`` maps a clip's media type to Gemini's ``format``
+	token for an ``input_audio`` part; unknown types default to webm, our
+	recorder's own default."""
+
+	def test_maps_known_and_defaults(self):
+		self.assertEqual(voice._audio_format_token("audio/webm"), "webm")
+		self.assertEqual(voice._audio_format_token("video/mp4"), "mp4")
+		self.assertEqual(voice._audio_format_token("audio/mp4"), "mp4")
+		self.assertEqual(voice._audio_format_token("audio/ogg"), "ogg")
+		self.assertEqual(voice._audio_format_token("audio/wav"), "wav")
+		self.assertEqual(voice._audio_format_token("audio/x-wav"), "wav")
+		self.assertEqual(voice._audio_format_token("audio/mpeg"), "mp3")
+		self.assertEqual(voice._audio_format_token("application/octet-stream"), "webm")
+
+	def test_strips_parameters_and_is_case_insensitive(self):
+		self.assertEqual(voice._audio_format_token("AUDIO/WEBM;codecs=opus"), "webm")
+
+	def test_empty_or_none_defaults_to_webm(self):
+		self.assertEqual(voice._audio_format_token(""), "webm")
+		self.assertEqual(voice._audio_format_token(None), "webm")
+
+
+class TestBifrostChatAudioTranscribe(FrappeTestCase):
+	"""``_bifrost_chat_audio_transcribe`` posts the clip as an ``input_audio``
+	part to Bifrost's ``/chat/completions``, never to the transcription
+	endpoint, and returns the English text from the completion."""
+
+	def test_posts_input_audio_to_chat_completions(self):
+		with patch("jarvis.chat.voice.requests.post", return_value=_ok_completion("hello world")) as mock_post:
+			out = voice._bifrost_chat_audio_transcribe(
+				b"AUDIOBYTES",
+				"audio/webm",
+				"google/gemini-2.5-flash-lite",
+				"vk",
+				"https://bifrost.internal/v1",
+			)
+		self.assertEqual(out, "hello world")
+		self.assertEqual(mock_post.call_args.args[0], "https://bifrost.internal/v1/chat/completions")
+		payload = mock_post.call_args.kwargs["json"]
+		self.assertEqual(payload["temperature"], 0)
+		self.assertEqual(payload["model"], "google/gemini-2.5-flash-lite")
+		part = payload["messages"][1]["content"][0]
+		self.assertEqual(part["type"], "input_audio")
+		self.assertEqual(part["input_audio"]["format"], "webm")
+		self.assertEqual(
+			part["input_audio"]["data"],
+			base64.b64encode(b"AUDIOBYTES").decode("ascii"),
+		)
+		self.assertEqual(mock_post.call_args.kwargs["headers"]["Authorization"], "Bearer vk")
+		self.assertEqual(
+			mock_post.call_args.kwargs["timeout"],
+			(voice._CONNECT_TIMEOUT_S, voice._CHAT_AUDIO_READ_TIMEOUT_S),
+		)
+
+	def test_base_url_trailing_slash_is_normalised(self):
+		with patch("jarvis.chat.voice.requests.post", return_value=_ok_completion()) as mock_post:
+			voice._bifrost_chat_audio_transcribe(
+				b"x", "audio/webm", "m", "vk", "https://bifrost.internal/v1/"
+			)
+		self.assertEqual(mock_post.call_args.args[0], "https://bifrost.internal/v1/chat/completions")
+
+	def test_mp4_format_token_sent_for_safari_clips(self):
+		with patch("jarvis.chat.voice.requests.post", return_value=_ok_completion()) as mock_post:
+			voice._bifrost_chat_audio_transcribe(b"x", "video/mp4", "m", "vk", "https://bifrost.internal/v1")
+		part = mock_post.call_args.kwargs["json"]["messages"][1]["content"][0]
+		self.assertEqual(part["input_audio"]["format"], "mp4")
+
+	def test_never_posts_to_audio_transcriptions(self):
+		with patch("jarvis.chat.voice.requests.post", return_value=_ok_completion()) as mock_post:
+			voice._bifrost_chat_audio_transcribe(b"x", "audio/webm", "m", "vk", "https://bifrost.internal/v1")
+		url = mock_post.call_args.args[0]
+		self.assertNotIn("audio/transcriptions", url)
+		self.assertNotIn("files", mock_post.call_args.kwargs)
+
+	def test_non_200_raises_scrubbed_error(self):
+		with patch(
+			"jarvis.chat.voice.requests.post",
+			return_value=_response(401, {"error": {"message": f"api_key={TEST_KEY} is invalid"}}),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				voice._bifrost_chat_audio_transcribe(
+					b"x", "audio/webm", "m", TEST_KEY, "https://bifrost.internal/v1"
+				)
+		self.assertNotIn(TEST_KEY, str(ctx.exception))
+
+	def test_request_exception_raises_scrubbed_error(self):
+		with patch(
+			"jarvis.chat.voice.requests.post",
+			side_effect=requests.ConnectionError(f"connection failed, api_key={TEST_KEY}"),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				voice._bifrost_chat_audio_transcribe(
+					b"x", "audio/webm", "m", "vk", "https://bifrost.internal/v1"
+				)
+		self.assertNotIn(TEST_KEY, str(ctx.exception))
+
+	def test_missing_content_raises(self):
+		for body in ({"choices": []}, {"choices": [{"message": {}}]}, {"choices": [{"message": {"content": 1}}]}, {}):
+			with patch("jarvis.chat.voice.requests.post", return_value=_response(200, body)):
+				with self.assertRaises(frappe.ValidationError):
+					voice._bifrost_chat_audio_transcribe(
+						b"x", "audio/webm", "m", "vk", "https://bifrost.internal/v1"
+					)
+
+	def test_non_json_response_raises(self):
+		with patch(
+			"jarvis.chat.voice.requests.post",
+			return_value=_response(200, None, text="<html>gateway</html>"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				voice._bifrost_chat_audio_transcribe(
+					b"x", "audio/webm", "m", "vk", "https://bifrost.internal/v1"
+				)
 
 
 class TestTranscribeAudio(FrappeTestCase):

--- a/jarvis/tests/test_voice.py
+++ b/jarvis/tests/test_voice.py
@@ -687,3 +687,191 @@ class TestAdminGetSttConfig(FrappeTestCase):
 		self.assertEqual(first, {"enabled": True, "api_key": "k1", "model": "m1"})
 		self.assertEqual(second, first)
 		self.assertEqual(mock_post.call_count, 1)
+
+
+class TestAdminClientSttConfigCarriesBaseUrlAndMode(FrappeTestCase):
+	"""``get_stt_config``'s ``out`` dict is the bench-side leg of the 3-place
+	base_url/mode lockstep: a key admin sends but this dict drops silently
+	falls back to defaults for every managed tenant."""
+
+	def setUp(self):
+		frappe.cache().delete_value(admin_client._STT_CONFIG_CACHE_KEY)
+
+	def tearDown(self):
+		frappe.cache().delete_value(admin_client._STT_CONFIG_CACHE_KEY)
+
+	def test_carries_base_url_and_mode(self):
+		with patch(
+			"jarvis.admin_client._post",
+			return_value={
+				"enabled": True,
+				"api_key": "vk",
+				"model": "google/gemini-2.5-flash-lite",
+				"base_url": "https://bifrost.internal/v1",
+				"mode": "chat-audio",
+			},
+		):
+			out = admin_client.get_stt_config()
+		self.assertEqual(out["base_url"], "https://bifrost.internal/v1")
+		self.assertEqual(out["mode"], "chat-audio")
+
+	def test_missing_keys_default_to_empty_string(self):
+		"""Back-compat: an admin response that has not shipped the new keys
+		yet must not KeyError the managed path."""
+		with patch(
+			"jarvis.admin_client._post",
+			return_value={"enabled": True, "api_key": "vk", "model": "m"},
+		):
+			out = admin_client.get_stt_config()
+		self.assertEqual(out["base_url"], "")
+		self.assertEqual(out["mode"], "")
+
+
+class TestSttConfigModeResolution(FrappeTestCase):
+	"""``mode`` defaults to chat-audio only once a base_url is set; every
+	config without one (today's whisper/Sarvam tenants and dev benches) keeps
+	resolving to the transcription transport unchanged."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def test_defaults_mode_to_chat_audio_when_base_url_set(self):
+		with _conf(jarvis_stt_openrouter_api_key=""):
+			with patch(
+				"jarvis.admin_client.get_stt_config",
+				return_value={
+					"enabled": True,
+					"api_key": "vk",
+					"model": "google/gemini-2.5-flash-lite",
+					"base_url": "https://bifrost.internal/v1",
+					"mode": "",
+				},
+			):
+				cfg = voice.stt_config()
+		self.assertEqual(cfg["mode"], "chat-audio")
+		self.assertEqual(cfg["base_url"], "https://bifrost.internal/v1")
+
+	def test_defaults_mode_to_transcription_without_base_url(self):
+		with _conf(jarvis_stt_openrouter_api_key=""):
+			with patch(
+				"jarvis.admin_client.get_stt_config",
+				return_value={
+					"enabled": True,
+					"api_key": "k",
+					"model": "openai/whisper-large-v3-turbo",
+					"base_url": "",
+					"mode": "",
+				},
+			):
+				cfg = voice.stt_config()
+		self.assertEqual(cfg["mode"], "transcription")
+		self.assertEqual(cfg["base_url"], "")
+
+	def test_explicit_mode_from_admin_is_not_overridden(self):
+		with _conf(jarvis_stt_openrouter_api_key=""):
+			with patch(
+				"jarvis.admin_client.get_stt_config",
+				return_value={
+					"enabled": True,
+					"api_key": "k",
+					"model": "openai/whisper-large-v3-turbo",
+					"base_url": "https://bifrost.internal/v1",
+					"mode": "transcription",
+				},
+			):
+				cfg = voice.stt_config()
+		self.assertEqual(cfg["mode"], "transcription")
+
+	def test_site_config_resolves_mode_from_base_url(self):
+		"""Dev benches can point at Bifrost too via jarvis_stt_base_url."""
+		with _conf(
+			jarvis_stt_openrouter_api_key=TEST_KEY,
+			jarvis_stt_base_url="https://bifrost.internal/v1",
+			jarvis_stt_mode="",
+		):
+			cfg = voice.stt_config()
+		self.assertEqual(cfg["mode"], "chat-audio")
+		self.assertEqual(cfg["base_url"], "https://bifrost.internal/v1")
+
+	def test_site_config_without_base_url_stays_transcription(self):
+		with _conf(jarvis_stt_openrouter_api_key=TEST_KEY, jarvis_stt_base_url="", jarvis_stt_mode=""):
+			cfg = voice.stt_config()
+		self.assertEqual(cfg["mode"], "transcription")
+		self.assertEqual(cfg["base_url"], "")
+
+
+class TestTranscribeAudioModeRouting(FrappeTestCase):
+	"""``transcribe_audio`` must dispatch on the resolved ``mode``: chat-audio
+	calls the Bifrost client and never the OpenRouter transcription client,
+	and transcription mode is the mirror image."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_chat_audio_mode_calls_bifrost(self):
+		with patch(
+			"jarvis.chat.voice.stt_config",
+			return_value={
+				"enabled": True,
+				"api_key": "vk",
+				"model": "google/gemini-2.5-flash-lite",
+				"base_url": "https://bifrost.internal/v1",
+				"mode": "chat-audio",
+			},
+		):
+			with patch(
+				"jarvis.chat.voice._bifrost_chat_audio_transcribe", return_value="english text"
+			) as mock_bifrost:
+				with patch("jarvis.chat.voice._openrouter_transcribe") as mock_openrouter:
+					with _audio_request():
+						out = voice.transcribe_audio()
+		mock_bifrost.assert_called_once_with(
+			b"\x1aEfake-webm-bytes", "audio/webm", "google/gemini-2.5-flash-lite", "vk",
+			"https://bifrost.internal/v1",
+		)
+		mock_openrouter.assert_not_called()
+		self.assertEqual(out["text"], "english text")
+		self.assertEqual(out["model"], "google/gemini-2.5-flash-lite")
+
+	def test_transcription_mode_calls_openrouter_not_bifrost(self):
+		with patch(
+			"jarvis.chat.voice.stt_config",
+			return_value={
+				"enabled": True,
+				"api_key": TEST_KEY,
+				"model": voice._DEFAULT_STT_MODEL,
+				"base_url": "",
+				"mode": "transcription",
+			},
+		):
+			with patch(
+				"jarvis.chat.voice._openrouter_transcribe", return_value="hola"
+			) as mock_openrouter:
+				with patch("jarvis.chat.voice._bifrost_chat_audio_transcribe") as mock_bifrost:
+					with _audio_request():
+						out = voice.transcribe_audio()
+		mock_openrouter.assert_called_once()
+		mock_bifrost.assert_not_called()
+		self.assertEqual(out["text"], "hola")
+
+	def test_transcription_mode_with_base_url_still_uses_openrouter_client(self):
+		"""A Sarvam/whisper tenant routed through Bifrost still uses the
+		transcription transport, just against the Bifrost base_url, so the
+		parameterised ``_openrouter_transcribe`` gets it as an argument."""
+		with patch(
+			"jarvis.chat.voice.stt_config",
+			return_value={
+				"enabled": True,
+				"api_key": "vk",
+				"model": "sarvam/saaras:v3",
+				"base_url": "https://bifrost.internal/v1",
+				"mode": "transcription",
+			},
+		):
+			with patch("jarvis.chat.voice.requests.post", return_value=_ok_response("hola")) as mock_post:
+				with _audio_request():
+					voice.transcribe_audio()
+		self.assertEqual(mock_post.call_args.args[0], "https://bifrost.internal/v1/audio/transcriptions")

--- a/jarvis/tests/test_voice.py
+++ b/jarvis/tests/test_voice.py
@@ -93,7 +93,16 @@ class TestSttConfig(FrappeTestCase):
 		with _conf(jarvis_stt_openrouter_api_key=TEST_KEY, jarvis_stt_model="test/model-x"):
 			with patch("jarvis.admin_client.get_stt_config") as mock_admin:
 				cfg = voice.stt_config()
-		self.assertEqual(cfg, {"enabled": True, "api_key": TEST_KEY, "model": "test/model-x"})
+		self.assertEqual(
+			cfg,
+			{
+				"enabled": True,
+				"api_key": TEST_KEY,
+				"model": "test/model-x",
+				"base_url": "",
+				"mode": "transcription",
+			},
+		)
 		mock_admin.assert_not_called()
 
 	def test_site_config_default_model(self):
@@ -526,11 +535,20 @@ class TestTranscribeAudio(FrappeTestCase):
 		self.assertEqual(payload, data)
 		self.assertEqual(mime, "audio/webm")
 
-	def test_never_calls_chat_completions(self):
-		"""Regression pin for the paraphrase defect: STT rides the transcription
-		API only. On chat-completions a chat model 'transcribes' by inventing
-		fluent text and returning it as a 200."""
-		with _conf(jarvis_stt_openrouter_api_key=TEST_KEY):
+	def test_transcription_mode_never_posts_to_chat_completions(self):
+		"""Regression pin for the paraphrase defect: transcription-mode STT
+		rides the transcription API only. On chat-completions a chat model
+		'transcribes' by inventing fluent text and returning it as a 200."""
+		with patch(
+			"jarvis.chat.voice.stt_config",
+			return_value={
+				"enabled": True,
+				"api_key": TEST_KEY,
+				"model": voice._DEFAULT_STT_MODEL,
+				"base_url": "",
+				"mode": "transcription",
+			},
+		):
 			with _audio_request():
 				with patch("jarvis.chat.voice.requests.post", return_value=_ok_response()) as mock_post:
 					voice.transcribe_audio()
@@ -540,6 +558,32 @@ class TestTranscribeAudio(FrappeTestCase):
 			self.assertNotEqual(url, voice._OPENROUTER_URL)
 			self.assertNotIn("chat/completions", url)
 			self.assertNotIn("json", call.kwargs)
+
+	def test_chat_audio_mode_never_posts_to_audio_transcriptions(self):
+		"""Mirror image: chat-audio mode must hit /chat/completions only,
+		never the multipart transcription endpoint. The new chat-audio default
+		deliberately sends the clip to a chat model, so this is a mode-scoped
+		guardrail, not a blanket ban on chat/completions."""
+		with patch(
+			"jarvis.chat.voice.stt_config",
+			return_value={
+				"enabled": True,
+				"api_key": "vk",
+				"model": "google/gemini-2.5-flash-lite",
+				"base_url": "https://bifrost.internal/v1",
+				"mode": "chat-audio",
+			},
+		):
+			with _audio_request():
+				with patch(
+					"jarvis.chat.voice.requests.post", return_value=_ok_completion("hello world")
+				) as mock_post:
+					voice.transcribe_audio()
+		self.assertTrue(mock_post.call_args_list)
+		for call in mock_post.call_args_list:
+			url = call.args[0] if call.args else call.kwargs.get("url", "")
+			self.assertNotIn("audio/transcriptions", url)
+			self.assertNotIn("files", call.kwargs)
 
 	def test_browser_container_forwarded_verbatim(self):
 		"""No mime->format table any more: whatever the browser recorded is
@@ -684,7 +728,10 @@ class TestAdminGetSttConfig(FrappeTestCase):
 		) as mock_post:
 			first = admin_client.get_stt_config()
 			second = admin_client.get_stt_config()
-		self.assertEqual(first, {"enabled": True, "api_key": "k1", "model": "m1"})
+		self.assertEqual(
+			first,
+			{"enabled": True, "api_key": "k1", "model": "m1", "base_url": "", "mode": ""},
+		)
 		self.assertEqual(second, first)
 		self.assertEqual(mock_post.call_count, 1)
 

--- a/jarvis/tests/test_voice.py
+++ b/jarvis/tests/test_voice.py
@@ -847,6 +847,19 @@ class TestSttConfigModeResolution(FrappeTestCase):
 		self.assertEqual(cfg["mode"], "chat-audio")
 		self.assertEqual(cfg["base_url"], "https://bifrost.internal/v1")
 
+	def test_site_config_chat_audio_defaults_to_gemini_model(self):
+		"""A dev bench that sets base_url but no model must default to the
+		chat-audio model, not the whisper transcription model."""
+		with _conf(
+			jarvis_stt_openrouter_api_key=TEST_KEY,
+			jarvis_stt_base_url="https://bifrost.internal/v1",
+			jarvis_stt_mode="",
+			jarvis_stt_model="",
+		):
+			cfg = voice.stt_config()
+		self.assertEqual(cfg["mode"], "chat-audio")
+		self.assertEqual(cfg["model"], "google/gemini-2.5-flash-lite")
+
 	def test_site_config_without_base_url_stays_transcription(self):
 		with _conf(jarvis_stt_openrouter_api_key=TEST_KEY, jarvis_stt_base_url="", jarvis_stt_mode=""):
 			cfg = voice.stt_config()

--- a/jarvis/tests/test_voice.py
+++ b/jarvis/tests/test_voice.py
@@ -308,7 +308,9 @@ class TestBifrostChatAudioTranscribe(FrappeTestCase):
 	endpoint, and returns the English text from the completion."""
 
 	def test_posts_input_audio_to_chat_completions(self):
-		with patch("jarvis.chat.voice.requests.post", return_value=_ok_completion("hello world")) as mock_post:
+		with patch(
+			"jarvis.chat.voice.requests.post", return_value=_ok_completion("hello world")
+		) as mock_post:
 			out = voice._bifrost_chat_audio_transcribe(
 				b"AUDIOBYTES",
 				"audio/webm",
@@ -377,7 +379,12 @@ class TestBifrostChatAudioTranscribe(FrappeTestCase):
 		self.assertNotIn(TEST_KEY, str(ctx.exception))
 
 	def test_missing_content_raises(self):
-		for body in ({"choices": []}, {"choices": [{"message": {}}]}, {"choices": [{"message": {"content": 1}}]}, {}):
+		for body in (
+			{"choices": []},
+			{"choices": [{"message": {}}]},
+			{"choices": [{"message": {"content": 1}}]},
+			{},
+		):
 			with patch("jarvis.chat.voice.requests.post", return_value=_response(200, body)):
 				with self.assertRaises(frappe.ValidationError):
 					voice._bifrost_chat_audio_transcribe(
@@ -876,7 +883,10 @@ class TestTranscribeAudioModeRouting(FrappeTestCase):
 					with _audio_request():
 						out = voice.transcribe_audio()
 		mock_bifrost.assert_called_once_with(
-			b"\x1aEfake-webm-bytes", "audio/webm", "google/gemini-2.5-flash-lite", "vk",
+			b"\x1aEfake-webm-bytes",
+			"audio/webm",
+			"google/gemini-2.5-flash-lite",
+			"vk",
 			"https://bifrost.internal/v1",
 		)
 		mock_openrouter.assert_not_called()
@@ -894,9 +904,7 @@ class TestTranscribeAudioModeRouting(FrappeTestCase):
 				"mode": "transcription",
 			},
 		):
-			with patch(
-				"jarvis.chat.voice._openrouter_transcribe", return_value="hola"
-			) as mock_openrouter:
+			with patch("jarvis.chat.voice._openrouter_transcribe", return_value="hola") as mock_openrouter:
 				with patch("jarvis.chat.voice._bifrost_chat_audio_transcribe") as mock_bifrost:
 					with _audio_request():
 						out = voice.transcribe_audio()


### PR DESCRIPTION
Adds a Bifrost path to the chat dictation feature so a customer can speak any language and get English text in the composer to review before sending. Anyone using voice input notices better regional-language support (Gemini native audio); everyone else is unaffected.

This is inert by default. With no Bifrost base_url configured, every tenant keeps today's whisper/OpenRouter behaviour byte for byte. The admin config that turns it on lives in the paired jarvis-admin-v2 PR.

What changed:
- New chat-audio STT mode that sends `input_audio` to a Bifrost `/v1/chat/completions` model (default `google/gemini-2.5-flash-lite`), transcribing and translating to English in one call.
- `stt_config()` now carries `base_url` + `mode`; `transcribe_audio()` branches on mode. The legacy transcription path is preserved and parameterised by base_url.
- Response contract unchanged: `{ok, text, stt_ms, model}`.

Tests: 67/67 voice tests pass locally. Hosted CI is the authority.

Targets `integration/voice-stt` for combined e2e with the admin PR; will retarget to develop after testing.