### PR TITLE
feat(onboarding): one stepped progress bar, used everywhere

### DIFF
--- a/frontend/src/components/StepProgress.spec.js
+++ b/frontend/src/components/StepProgress.spec.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import StepProgress from "./StepProgress.vue";
+
+const STEPS = [
+	{ id: "a", label: "Details" },
+	{ id: "b", label: "Plan" },
+	{ id: "c", label: "Pay" },
+];
+
+const segments = (wrapper) => wrapper.findAll('[role="listitem"] > .rounded-full');
+const items = (wrapper) => wrapper.findAll('[role="listitem"]');
+
+describe("StepProgress segments", () => {
+	it("renders one segment per step", () => {
+		const w = mount(StepProgress, { props: { steps: STEPS, currentIndex: 1 } });
+		expect(segments(w)).toHaveLength(3);
+	});
+
+	it("fills done and current steps, leaves upcoming steps on the track colour", () => {
+		const w = mount(StepProgress, { props: { steps: STEPS, currentIndex: 1 } });
+		const segs = segments(w);
+		expect(segs[0].classes()).toContain("bg-surface-gray-7"); // done
+		expect(segs[1].classes()).toContain("bg-surface-gray-7"); // current
+		expect(segs[2].classes()).toContain("bg-surface-gray-3"); // upcoming
+	});
+
+	it("fills only the first segment when currentIndex is 0", () => {
+		const w = mount(StepProgress, { props: { steps: STEPS, currentIndex: 0 } });
+		const segs = segments(w);
+		expect(segs[0].classes()).toContain("bg-surface-gray-7");
+		expect(segs[1].classes()).toContain("bg-surface-gray-3");
+		expect(segs[2].classes()).toContain("bg-surface-gray-3");
+	});
+});
+
+describe("StepProgress indeterminate state", () => {
+	it("marks only the current segment as indeterminate, not the done ones", () => {
+		const w = mount(StepProgress, {
+			props: { steps: STEPS, currentIndex: 1, indeterminate: true },
+		});
+		const segs = segments(w);
+		expect(segs[0].classes()).not.toContain("step-progress-segment--indeterminate");
+		expect(segs[1].classes()).toContain("step-progress-segment--indeterminate");
+		expect(segs[2].classes()).not.toContain("step-progress-segment--indeterminate");
+	});
+
+	it("does not mark anything indeterminate by default", () => {
+		const w = mount(StepProgress, { props: { steps: STEPS, currentIndex: 1 } });
+		expect(w.find(".step-progress-segment--indeterminate").exists()).toBe(false);
+	});
+});
+
+describe("StepProgress accessibility", () => {
+	it("renders step semantics as a labelled list, not a progressbar", () => {
+		const w = mount(StepProgress, { props: { steps: STEPS, currentIndex: 1 } });
+		expect(w.find('[role="list"]').exists()).toBe(true);
+		expect(items(w)).toHaveLength(3);
+		expect(w.find('[role="progressbar"]').exists()).toBe(false);
+	});
+
+	it("marks the current step with aria-current=step, and no other step", () => {
+		const w = mount(StepProgress, { props: { steps: STEPS, currentIndex: 1 } });
+		const rows = items(w);
+		expect(rows[0].attributes("aria-current")).toBeUndefined();
+		expect(rows[1].attributes("aria-current")).toBe("step");
+		expect(rows[2].attributes("aria-current")).toBeUndefined();
+	});
+
+	it("uses the ariaLabel prop to name the list when there is no visible caption", () => {
+		const w = mount(StepProgress, {
+			props: { steps: STEPS, currentIndex: 0, ariaLabel: "Setup steps" },
+		});
+		expect(w.find('[role="list"]').attributes("aria-label")).toBe("Setup steps");
+	});
+
+	it("names the list from the visible label instead, when one is given", () => {
+		const w = mount(StepProgress, {
+			props: { steps: [{}, {}, {}], currentIndex: 0, label: "Step 1 of 3" },
+		});
+		const list = w.find('[role="list"]');
+		expect(list.attributes("aria-label")).toBeUndefined();
+		const labelledBy = list.attributes("aria-labelledby");
+		expect(labelledBy).toBeTruthy();
+		expect(w.find(`#${labelledBy}`).text()).toBe("Step 1 of 3");
+	});
+
+	it("gives an unlabelled step an accessible name instead of leaving it silent", () => {
+		const w = mount(StepProgress, {
+			props: { steps: [{}, {}, {}], currentIndex: 1 },
+		});
+		expect(items(w)[1].find(".sr-only").text()).toBe("Step 2 of 3");
+	});
+});

--- a/frontend/src/components/StepProgress.vue
+++ b/frontend/src/components/StepProgress.vue
@@ -1,0 +1,107 @@
+<!--
+  The ONE stepped progress indicator (design.md §4.3): flat segments, one per
+  step, filling left to right. No numbered circles, no connector lines, no
+  checkmark dots. Replaces two treatments that used to disagree - the
+  onboarding rail's own markup and two frappe-ui `<Progress intervals>` bars -
+  with a single component both now render through.
+
+  Accessibility: `role="list"` / `role="listitem"` with `aria-current="step"`
+  on the current item, not `role="progressbar"`. A progressbar exposes one
+  number (0-100); it cannot name individual steps or say which one is
+  current without a parallel aria-valuetext hack. A list of steps, one of
+  them current, is exactly what this widget is, and list semantics say that
+  directly - it's also what the original rail already did, so keeping it is
+  not a new accessibility surface, only removing a divergent one.
+-->
+<template>
+	<div class="w-full">
+		<p v-if="label" :id="labelId" class="mb-2.5 text-base font-medium text-ink-gray-8">
+			{{ label }}
+		</p>
+		<div
+			class="flex w-full items-stretch gap-2"
+			role="list"
+			:aria-label="label ? undefined : ariaLabel"
+			:aria-labelledby="label ? labelId : undefined"
+		>
+			<div
+				v-for="(step, i) in steps"
+				:key="step.id ?? i"
+				role="listitem"
+				class="flex flex-1 flex-col gap-1.5"
+				:aria-current="i === currentIndex ? 'step' : undefined"
+			>
+				<span v-if="step.label" class="text-p-sm" :class="labelClass(i)">
+					{{ step.label }}
+				</span>
+				<!-- No visible per-step label (the two wait bars have none): keep an
+					 accessible name on the list item anyway rather than an unnamed
+					 "listitem, 2 of 3" announcement. -->
+				<span v-else class="sr-only">{{ `Step ${i + 1} of ${steps.length}` }}</span>
+				<span class="h-1 rounded-full" :class="segmentClass(i)"></span>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { useId } from "vue";
+
+const props = defineProps({
+	/** One entry per segment. `label` is optional per-step text above it. */
+	steps: { type: Array, required: true },
+	/** 0-based index of the current step. Steps at or before it are filled. */
+	currentIndex: { type: Number, required: true },
+	/**
+	 * The current step's own state is unknown (nothing observed yet), so it
+	 * cannot claim to be "done". Renders the current segment as a muted pulse
+	 * instead of a solid fill. See waitPhases.phaseProgress for the source of
+	 * this flag - it is never guessed here.
+	 */
+	indeterminate: { type: Boolean, default: false },
+	/** Optional summary caption above the row, e.g. "Step 2 of 3". */
+	label: { type: String, default: "" },
+	/** Accessible name for the list when there is no visible `label`. */
+	ariaLabel: { type: String, default: "Setup steps" },
+});
+
+const labelId = useId();
+
+function labelClass(i) {
+	if (i === props.currentIndex) return "font-medium text-ink-gray-9";
+	if (i < props.currentIndex) return "text-ink-gray-7";
+	return "text-ink-gray-5";
+}
+
+function segmentClass(i) {
+	if (i === props.currentIndex && props.indeterminate) {
+		return "step-progress-segment--indeterminate bg-surface-gray-3";
+	}
+	return i <= props.currentIndex ? "bg-surface-gray-7" : "bg-surface-gray-3";
+}
+</script>
+
+<style scoped>
+/* Same muted pulse the old .ob-progress--indeterminate rule drew on frappe-ui
+   Progress's middle interval: reuses the upcoming/track colour rather than a
+   new one, so "we don't currently know" reads the same here as it does on
+   the waiting dot next to it (waitPhases.js). */
+.step-progress-segment--indeterminate {
+	animation: step-progress-pulse 1.6s ease-in-out infinite;
+}
+@keyframes step-progress-pulse {
+	0%,
+	100% {
+		opacity: 0.5;
+	}
+	50% {
+		opacity: 1;
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.step-progress-segment--indeterminate {
+		animation: none;
+		opacity: 0.75;
+	}
+}
+</style>

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -111,7 +111,6 @@ vi.mock("frappe-ui", () => {
 			props: ["message"],
 			template: '<div v-if="message">{{ message }}</div>',
 		},
-		Progress: { name: "Progress", template: '<div><slot name="hint" /></div>' },
 		dayjs: () => ({ format: () => "", fromNow: () => "" }),
 		toast: { error: vi.fn(), success: vi.fn() },
 	};

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -55,7 +55,6 @@ vi.mock("frappe-ui", () => ({
 		template: '<div v-if="message">{{ message }}</div>',
 	},
 	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
-	Progress: { name: "Progress", template: '<div><slot name="hint" /></div>' },
 	call: vi.fn(),
 	dayjs: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
 	toast: { error: vi.fn(), success: vi.fn() },

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -570,7 +570,7 @@
 										 here read as an accidental duplicate rather than emphasis. -->
 									<div v-if="!provisioningDelayed" class="ob-progress">
 										<StepProgress
-											:steps="provisioningSteps"
+											:steps="WAIT_STEPS"
 											:current-index="provisioningProgress.current - 1"
 											:indeterminate="provisioningProgress.indeterminate"
 											:label="`Step ${provisioningProgress.current} of ${provisioningProgress.total}`"
@@ -1274,7 +1274,7 @@
 											 provisioning bar's comment above. -->
 										<div class="ob-progress">
 											<StepProgress
-												:steps="readinessSteps"
+												:steps="WAIT_STEPS"
 												:current-index="readinessProgress.current - 1"
 												:indeterminate="readinessProgress.indeterminate"
 												:label="`Step ${readinessProgress.current} of ${readinessProgress.total}`"
@@ -1633,9 +1633,13 @@ const RAIL = [
 
 // Unlabelled StepProgress segments for the two wait bars below, which count
 // steps (waitPhases.phaseProgress) without naming them the way RAIL does.
-function stepPlaceholders(total) {
-	return Array.from({ length: total }, (_, i) => ({ id: i }));
-}
+//
+// A module constant, not two computeds (round-1 review of #763). Both bars read
+// their total from phaseProgress, which counts to 3 and only 3, so a per-bar
+// computed rebuilt an identical array on every poll tick and left two places to
+// keep in step when one of them changed. If a bar ever needs a different length,
+// give it its own named constant rather than reintroducing the pair.
+const WAIT_STEPS = Object.freeze(Array.from({ length: 3 }, (_, i) => Object.freeze({ id: i })));
 
 // Frame subtitle next to the brand mark, mirroring the active step's title.
 const FRAME_SUBS = {
@@ -1780,7 +1784,6 @@ const readinessProgress = computed(() => phaseProgress(readinessStage.value));
 // StepProgress wants a segment per step; this wait has no named steps of its
 // own (waitPhases.phaseProgress only ever counts to 3), so the segments carry
 // no per-step label and the bar's own "Step N of 3" caption does the talking.
-const readinessSteps = computed(() => stepPlaceholders(readinessProgress.value.total));
 
 // Plan 01 billing state. Namespaced by site identity + logged-in user so one
 // site's / user's transitional billing PII can never prefill another's on a
@@ -2551,7 +2554,6 @@ const provisioningStage = computed(() =>
 // jarvis#726: the progress bar next to the phase list above, reading the SAME
 // provisioningStage - see waitPhases.phaseProgress.
 const provisioningProgress = computed(() => phaseProgress(provisioningStage.value));
-const provisioningSteps = computed(() => stepPlaceholders(provisioningProgress.value.total));
 
 // The FULL-SCREEN busy view is only for the phases where there is genuinely
 // nothing to press: starting the signup, the sheet being open, confirming.

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -36,35 +36,8 @@
 					<!-- step rail: flat progress segments with labels (design.md §4.3 —
 					 no numbered circles, no connector lines). Hidden on the intro
 					 tour (chromeless). -->
-					<div
-						v-if="railIndex >= 0"
-						class="my-4 flex w-full max-w-[720px] items-stretch gap-2"
-						role="list"
-						aria-label="Setup steps"
-					>
-						<div
-							v-for="(s, i) in RAIL"
-							:key="s.id"
-							role="listitem"
-							class="flex flex-1 flex-col gap-1.5"
-							:aria-current="i === railIndex ? 'step' : undefined"
-						>
-							<span
-								class="text-p-sm"
-								:class="
-									i === railIndex
-										? 'font-medium text-ink-gray-9'
-										: i < railIndex
-										? 'text-ink-gray-7'
-										: 'text-ink-gray-5'
-								"
-								>{{ s.label }}</span
-							>
-							<span
-								class="h-1 rounded-full"
-								:class="i <= railIndex ? 'bg-surface-gray-7' : 'bg-surface-gray-3'"
-							></span>
-						</div>
+					<div v-if="railIndex >= 0" class="my-4 w-full max-w-[720px]">
+						<StepProgress :steps="RAIL" :current-index="railIndex" />
 					</div>
 
 					<div
@@ -588,26 +561,21 @@
 											{{ setupRecheckNote }}
 										</p>
 									</div>
-									<!-- jarvis#726: a step-counted Progress bar, reading the SAME
+									<!-- jarvis#726: a step-counted progress bar, reading the SAME
 										 phase object the row below already renders - see
 										 waitPhases.phaseProgress for what it measures and why it
 										 goes indeterminate instead of guessing a percentage. Label is
 										 just "Step N of 3", not the phase's own sentence - that
 										 sentence already renders once, in the row below; repeating it
 										 here read as an accidental duplicate rather than emphasis. -->
-									<Progress
-										v-if="!provisioningDelayed"
-										class="ob-progress"
-										:class="{
-											'ob-progress--indeterminate':
-												provisioningProgress.indeterminate,
-										}"
-										:value="provisioningProgress.percent"
-										intervals
-										:interval-count="provisioningProgress.total"
-										size="md"
-										:label="`Step ${provisioningProgress.current} of ${provisioningProgress.total}`"
-									/>
+									<div v-if="!provisioningDelayed" class="ob-progress">
+										<StepProgress
+											:steps="provisioningSteps"
+											:current-index="provisioningProgress.current - 1"
+											:indeterminate="provisioningProgress.indeterminate"
+											:label="`Step ${provisioningProgress.current} of ${provisioningProgress.total}`"
+										/>
+									</div>
 									<!-- Phase list. Row 1 is a settled fact. Row 2 renders ONLY what
 										 the last provisioning tick observed (waitPhases.js), so
 										 "Jarvis is getting ready for you" appears when admin itself
@@ -1298,22 +1266,20 @@
 										</div>
 										<!-- jarvis#726: same step-counted bar as the provisioning wait,
 											 reading readinessStage. readinessPhase has no DONE branch
-											 (waitPhases.js), so this bar stays at 1 of 3 until the
-											 screen navigates to chat - it never fills segment two in
-											 place. Label is "Step N of 3" only, not the phase's own
-											 sentence - see the provisioning bar's comment above. -->
-										<Progress
-											class="ob-progress"
-											:class="{
-												'ob-progress--indeterminate':
-													readinessProgress.indeterminate,
-											}"
-											:value="readinessProgress.percent"
-											intervals
-											:interval-count="readinessProgress.total"
-											size="md"
-											:label="`Step ${readinessProgress.current} of ${readinessProgress.total}`"
-										/>
+											 (waitPhases.js), so the label stays "Step 2 of 3" until the
+											 screen navigates to chat: segment two renders as the CURRENT
+											 step (filled, design.md §4.3), never as done, and segment
+											 three only fills once the screen actually leaves. Label is
+											 "Step N of 3" only, not the phase's own sentence - see the
+											 provisioning bar's comment above. -->
+										<div class="ob-progress">
+											<StepProgress
+												:steps="readinessSteps"
+												:current-index="readinessProgress.current - 1"
+												:indeterminate="readinessProgress.indeterminate"
+												:label="`Step ${readinessProgress.current} of ${readinessProgress.total}`"
+											/>
+										</div>
 										<!-- Phase list, driven by is_ready_for_chat's `reason` on the
 											 LAST poll (waitPhases.js). Before this the screen showed one
 											 fixed sentence for the whole two-minute wait, so a workspace
@@ -1577,13 +1543,14 @@
 <script setup>
 import { reactive, ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
 import { useRouter } from "vue-router";
-import { Button, FormControl, FeatherIcon, ErrorMessage, Progress } from "frappe-ui";
+import { Button, FormControl, FeatherIcon, ErrorMessage } from "frappe-ui";
 import { useJarvisTheme } from "@/theme";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
 import JvCombo from "@/components/JvCombo.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
 import JarvisMark from "@/components/JarvisMark.vue";
 import Banner from "@/components/Banner.vue";
+import StepProgress from "@/components/StepProgress.vue";
 import TourIntro from "@/onboarding/TourIntro.vue";
 import SetupNeuralNet from "@/onboarding/SetupNeuralNet.vue";
 import cashfreeLogo from "@/assets/cashfree.png";
@@ -1663,6 +1630,12 @@ const RAIL = [
 	{ id: "pay", label: "Pay" },
 	{ id: "connect", label: "Connect" },
 ];
+
+// Unlabelled StepProgress segments for the two wait bars below, which count
+// steps (waitPhases.phaseProgress) without naming them the way RAIL does.
+function stepPlaceholders(total) {
+	return Array.from({ length: total }, (_, i) => ({ id: i }));
+}
 
 // Frame subtitle next to the brand mark, mirroring the active step's title.
 const FRAME_SUBS = {
@@ -1801,9 +1774,13 @@ const readinessStage = computed(() =>
 				opReadinessDetail.value
 		  )
 );
-// jarvis#726: the Progress bar next to the phase list above, reading the SAME
+// jarvis#726: the progress bar next to the phase list above, reading the SAME
 // readinessStage - see waitPhases.phaseProgress.
 const readinessProgress = computed(() => phaseProgress(readinessStage.value));
+// StepProgress wants a segment per step; this wait has no named steps of its
+// own (waitPhases.phaseProgress only ever counts to 3), so the segments carry
+// no per-step label and the bar's own "Step N of 3" caption does the talking.
+const readinessSteps = computed(() => stepPlaceholders(readinessProgress.value.total));
 
 // Plan 01 billing state. Namespaced by site identity + logged-in user so one
 // site's / user's transitional billing PII can never prefill another's on a
@@ -2571,9 +2548,10 @@ const provisioningStage = computed(() =>
 		? provisioningPhase(provisioningSeen.value)
 		: inFlightPhase("Checking on your workspace")
 );
-// jarvis#726: the Progress bar next to the phase list above, reading the SAME
+// jarvis#726: the progress bar next to the phase list above, reading the SAME
 // provisioningStage - see waitPhases.phaseProgress.
 const provisioningProgress = computed(() => phaseProgress(provisioningStage.value));
+const provisioningSteps = computed(() => stepPlaceholders(provisioningProgress.value.total));
 
 // The FULL-SCREEN busy view is only for the phases where there is genuinely
 // nothing to press: starting the signup, the sheet being open, confirming.
@@ -4400,30 +4378,12 @@ onUnmounted(() => {
 	outline-offset: 2px;
 }
 /* ---- staged wait progress bar (jarvis#726, waitPhases.phaseProgress) ----
-   Segment one (the settled fact) is never touched here - it stays the plain
-   frappe-ui Progress fill in every state, determinate or not. Only the
-   CURRENT segment (nth-child(2) of the three fixed intervals) gets the
-   indeterminate treatment, and only when the phase itself is UNKNOWN: a
-   muted pulse reusing --surface-3, the same colour the waiting dot below
-   already uses for "nothing has reported this yet", so "we don't currently
-   know" reads consistently across both the bar and the phase list next to
-   it instead of inventing a second visual vocabulary for the same idea. */
+   Layout wrapper only - the segments themselves, including the indeterminate
+   pulse on the current one, are StepProgress.vue's (design.md §4.3, one
+   shared component for every stepped indicator in the app). */
 .ob-progress {
 	margin: 0 auto;
 	max-width: 420px;
-}
-.ob-progress--indeterminate :deep([role="progressbar"] > div:nth-child(2)) {
-	background: var(--surface-3);
-	animation: ob-progress-pulse 1.6s ease-in-out infinite;
-}
-@keyframes ob-progress-pulse {
-	0%,
-	100% {
-		opacity: 0.5;
-	}
-	50% {
-		opacity: 1;
-	}
 }
 
 /* ---- staged wait phases (waitPhases.js) --------------------------------
@@ -4560,9 +4520,7 @@ onUnmounted(() => {
 	.ob-details-form :deep(.jvc-field) {
 		transition: none;
 	}
-	.ob-progress--indeterminate :deep([role="progressbar"] > div:nth-child(2)) {
-		animation: none;
-		opacity: 0.75;
-	}
+	/* StepProgress.vue owns its own reduced-motion fallback for the
+	   indeterminate segment. */
 }
 </style>


### PR DESCRIPTION
## Summary

One stepped progress bar, used everywhere a step sequence is shown. The app had two treatments for the same idea: the wizard rail already used design.md's flat segments, while the Connect step's two wait bars used a frappe-ui `Progress` with an interval count. Adjacent screens looked like different products.

## What changed

- New `StepProgress` component, extracted from the wizard rail rather than redesigned.
- Three call sites now use it: the rail, the provisioning wait and the readiness wait.
- The rail is byte-identical, only delegated. The two wait bars adopt the segment pattern.

Per design.md section 4.3: `h-1 flex-1 rounded-full`, done and current on `surface-gray-7`, upcoming on `surface-gray-3`. No numbered circles, no connectors, which that section names explicitly.

## Accessibility

Chose list semantics with `aria-current="step"` over `role="progressbar"`. A progressbar exposes a single number and cannot name its steps or say which one is current without an `aria-valuetext` hack. A labelled step indicator is a list of steps with one current, and the rail already said so, so this removes the divergent treatment rather than inventing a third. The visible "Step N of 3" caption is kept and wired as `aria-labelledby`, falling back to an `aria-label` where there is no caption.

## Risk and verification

- Indeterminate is preserved, including its reduced-motion fallback. `waitPhases` deliberately refuses to guess a percentage, and this keeps that honest. The pulse now lives in the component's own scoped style instead of a `:deep()` reach into frappe-ui's internal DOM, and only the current segment pulses.
- 10 new component tests plus the existing onboarding suites: 91 tests pass across the three touched specs, and the full suites pass on Node 24.

## Visible change worth a look before merging

On the two wait bars the CURRENT segment now renders filled, because design.md gives done and current the same treatment. The old frappe-ui bar filled only completed segments and left the current one on the track colour. Each segment is also its own rounded pill rather than blocks inside one rounded container.

That is the contract, and it is the point of unifying, but it is a visible change on a screen that has had a lot of attention this week.

<details><summary>Edge case flagged during the build</summary>

When provisioning reaches `running`, all three segments render filled under a "Step 3 of 3" caption for the tick before the screen navigates away. Contract-compliant, but this codebase is otherwise careful about the bar never overclaiming, so it is called out rather than buried.

</details>
