### PR TITLE
feat(onboarding): widen the wait block and lay its phases out horizontally

### DIFF
--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1592,3 +1592,76 @@ describe("jarvis#752 the connect step shows admin's route verdict while still co
 		w.unmount();
 	});
 });
+
+// jarvis wait-phases-horizontal: the wait block widened to 75% and the three
+// phases moved from a stacked list to equal-width columns under the bar. The
+// admin-authored detail sentence (jarvis#752/#754) no longer fits inside a
+// column a third of that width, so it was hoisted out of the phase row and
+// now renders once, full width, below the phase columns instead. These tests
+// pin the DOM shape that hoist depends on, not pixel layout (jsdom does not
+// compute CSS): the detail is a sibling of the phase list, not nested in any
+// `<li>`, and both the active phase and the detail keep their own
+// `role="status"` so a screen reader still hears each independently.
+describe("jarvis wait-phases-horizontal: detail hoisted out of the phase columns", () => {
+	const QUOTA_REASON = "Your OpenAI account has reached its usage limit. It resets in 2 hours.";
+
+	it("renders the detail as a sibling of the phase list, not inside a phase row", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		const phases = w.find(".ob-phases");
+		const detail = w.find(".ob-phase-detail");
+		expect(detail.exists()).toBe(true);
+		expect(detail.text()).toBe(QUOTA_REASON);
+		// Hoisted OUT: no longer a descendant of the phase list or any row.
+		expect(detail.element.closest("ul")).toBeNull();
+		expect(detail.element.closest("li")).toBeNull();
+		// Reads as belonging to the same block: immediately after the phase list.
+		expect(phases.element.nextElementSibling).toBe(detail.element);
+		w.unmount();
+	});
+
+	it("still lays out exactly three phase columns, each its own row item", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		const columns = w.findAll(".ob-phases > .ob-phase");
+		expect(columns).toHaveLength(3);
+		// Every column still carries only its label, never the detail sentence -
+		// the hoist removed the ONLY per-row detail span, it did not just add a
+		// duplicate copy alongside it.
+		for (const column of columns) {
+			expect(column.find(".ob-phase-detail").exists()).toBe(false);
+		}
+		w.unmount();
+	});
+
+	it("keeps role=status on the active phase AND gives the hoisted detail its own", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		const active = w.find(".ob-phase--active");
+		expect(active.attributes("role")).toBe("status");
+		expect(w.find(".ob-phase-detail").attributes("role")).toBe("status");
+		w.unmount();
+	});
+
+	it("the active phase's spinner and the waiting phase's dot are unchanged by the hoist", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		// design.md §3.8: JvSpinner is the only loading indicator, never a
+		// bespoke one - it renders `.jv-spin` with its own role="status".
+		expect(w.find(".ob-phase--active .jv-spin").exists()).toBe(true);
+		expect(w.find(".ob-phase--waiting .ob-phase-dot").exists()).toBe(true);
+		w.unmount();
+	});
+});

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1640,15 +1640,29 @@ describe("jarvis wait-phases-horizontal: detail hoisted out of the phase columns
 		w.unmount();
 	});
 
-	it("keeps role=status on the active phase AND gives the hoisted detail its own", async () => {
+	it("announces the phase and its detail as ONE live region, not two", async () => {
+		// Round-1 review: giving the hoisted detail its own role="status" made a
+		// screen reader hear the phase and the sentence explaining that phase as
+		// two unrelated announcements. Worse, that region was v-if gated, so it
+		// mounted already populated, and a live region announces CHANGES to a
+		// region that is already present, not its initial content. One shared
+		// wrapper fixes both at once.
 		const w = await mountConnect();
 
 		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
 		await flushPromises();
 
 		const active = w.find(".ob-phase--active");
-		expect(active.attributes("role")).toBe("status");
-		expect(w.find(".ob-phase-detail").attributes("role")).toBe("status");
+		const detail = w.find(".ob-phase-detail");
+		expect(active.attributes("role")).toBeUndefined();
+		expect(detail.attributes("role")).toBeUndefined();
+
+		const owning = w
+			.findAll('[role="status"]')
+			.filter(
+				(r) => r.element.contains(active.element) && r.element.contains(detail.element)
+			);
+		expect(owning.length).toBe(1);
 		w.unmount();
 	});
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -576,12 +576,19 @@
 											:label="`Step ${provisioningProgress.current} of ${provisioningProgress.total}`"
 										/>
 									</div>
-									<!-- Phase list. Row 1 is a settled fact. Row 2 renders ONLY what
-										 the last provisioning tick observed (waitPhases.js), so
-										 "Jarvis is getting ready for you" appears when admin itself
-										 answered, and an honest "we couldn't check" appears when it
-										 did not. Row 3 names a phase that has not started and says
-										 nothing further about it. -->
+									<!-- Phase columns, side by side under the bar's segments (jarvis
+										 wait-phases-horizontal): same three phases as before, laid out
+										 as equal-width columns instead of stacked rows so segment one
+										 sits above phase one. Column 1 is a settled fact. Column 2
+										 renders ONLY what the last provisioning tick observed
+										 (waitPhases.js), so "Jarvis is getting ready for you" appears
+										 when admin itself answered, and an honest "we couldn't check"
+										 appears when it did not. Column 3 names a phase that has not
+										 started and says nothing further about it. The active phase's
+										 `detail` (waitPhases.js's own provisioningPhase copy) is a full
+										 sentence, too long for a column a third of this width, so it
+										 renders once, full width, below every column rather than
+										 inside one of them. -->
 									<ul v-if="!provisioningDelayed" class="ob-phases" role="list">
 										<li class="ob-phase ob-phase--done">
 											<span class="ob-phase-ico">
@@ -613,11 +620,6 @@
 												<span class="ob-phase-label">{{
 													provisioningStage.label
 												}}</span>
-												<span
-													v-if="provisioningStage.detail"
-													class="ob-phase-detail"
-													>{{ provisioningStage.detail }}</span
-												>
 											</span>
 										</li>
 										<li class="ob-phase ob-phase--waiting">
@@ -631,6 +633,13 @@
 											</span>
 										</li>
 									</ul>
+									<p
+										v-if="!provisioningDelayed && provisioningStage.detail"
+										class="ob-phase-detail"
+										role="status"
+									>
+										{{ provisioningStage.detail }}
+									</p>
 									<!-- The sanctioned provisioning illustration (design.md §2.2).
 										 min-height, never a percentage height - see SetupNeuralNet's
 										 own comment. Dropped at the delayed ceiling, where there is a
@@ -1280,10 +1289,14 @@
 												:label="`Step ${readinessProgress.current} of ${readinessProgress.total}`"
 											/>
 										</div>
-										<!-- Phase list, driven by is_ready_for_chat's `reason` on the
+										<!-- Phase columns, driven by is_ready_for_chat's `reason` on the
 											 LAST poll (waitPhases.js). Before this the screen showed one
 											 fixed sentence for the whole two-minute wait, so a workspace
-											 being built and one that was stuck looked identical. -->
+											 being built and one that was stuck looked identical. Laid out
+											 side by side under the bar's segments, same as the
+											 provisioning wait above: the active phase's `detail` is a
+											 full admin sentence (jarvis#752/#754), so it renders once,
+											 full width, below every column rather than inside one. -->
 										<ul class="ob-phases" role="list">
 											<li class="ob-phase ob-phase--done">
 												<span class="ob-phase-ico">
@@ -1315,11 +1328,6 @@
 													<span class="ob-phase-label">{{
 														readinessStage.label
 													}}</span>
-													<span
-														v-if="readinessStage.detail"
-														class="ob-phase-detail"
-														>{{ readinessStage.detail }}</span
-													>
 												</span>
 											</li>
 											<li class="ob-phase ob-phase--waiting">
@@ -1333,6 +1341,13 @@
 												</span>
 											</li>
 										</ul>
+										<p
+											v-if="readinessStage.detail"
+											class="ob-phase-detail"
+											role="status"
+										>
+											{{ readinessStage.detail }}
+										</p>
 										<!-- min-height (not h-full) is load-bearing: SetupNeuralNet's
 											 canvas fills via absolute+inset-0, and percentage heights
 											 don't resolve against a min-height parent - see its own
@@ -4382,29 +4397,58 @@ onUnmounted(() => {
 /* ---- staged wait progress bar (jarvis#726, waitPhases.phaseProgress) ----
    Layout wrapper only - the segments themselves, including the indeterminate
    pulse on the current one, are StepProgress.vue's (design.md §4.3, one
-   shared component for every stepped indicator in the app). */
+   shared component for every stepped indicator in the app).
+
+   Width (jarvis wait-phases-horizontal): a live run called the old 420px cap
+   "very congested". 75% of the card reads roomy without turning into an
+   unreadably long line on a wide monitor - 640px caps that, chosen so the
+   longest phase label ("Applying your AI configuration") still gets a
+   sensible column width at 3-up rather than the columns ballooning past what
+   the text needs. `.ob-phases` and `.ob-phase-detail` below share the exact
+   same width/gap so the phase columns line up under the bar's segments and
+   the detail line reads as belonging to the same block. */
 .ob-progress {
 	margin: 0 auto;
-	max-width: 420px;
+	width: 75%;
+	max-width: 640px;
 }
 
 /* ---- staged wait phases (waitPhases.js) --------------------------------
-   One row per phase. The row's MODIFIER is the honesty contract, not
-   decoration: `active` is only ever set from an observation, `unknown` means a
-   poll answered with nothing (or with the absence of a verdict) and must never
-   look like progress, and `waiting` says nothing at all about a phase that has
-   not started. Colour carries no status here beyond the completed check - the
-   words do that. */
+   One column per phase, side by side under the bar's segments so the whole
+   block reads as one horizontal progression rather than a bar with an
+   unrelated list under it (jarvis wait-phases-horizontal). Segment one sits
+   above phase one for free: both this row and StepProgress.vue's own row are
+   a 3-up flex with equal (`flex: 1`) children and the same 8px gap over the
+   same width, so they align without the phase labels having to become the
+   bar's own per-step labels - that route was considered and rejected, see
+   WAIT_STEPS's comment below (script section): the bar is deliberately
+   unlabelled per jarvis#763, and reintroducing labels there would require a
+   per-bar computed the same comment already warns against reintroducing.
+
+   The MODIFIER on each column is the honesty contract, not decoration:
+   `active` is only ever set from an observation, `unknown` means a poll
+   answered with nothing (or with the absence of a verdict) and must never
+   look like progress, and `waiting` says nothing at all about a phase that
+   has not started. Colour carries no status here beyond the completed check -
+   the words do that.
+
+   Below 720px there is no room for three icon+label columns without wrapping
+   into a cramped, unreadable tower, so the media query at the bottom of this
+   file reverts to the original stacked single column. */
 .ob-phases {
 	list-style: none;
 	margin: 0 auto;
 	padding: 0;
-	max-width: 420px;
+	width: 75%;
+	max-width: 640px;
 	display: flex;
-	flex-direction: column;
-	gap: 2px;
+	flex-direction: row;
+	align-items: stretch;
+	gap: 8px;
 }
 .ob-phase {
+	flex: 1 1 0;
+	min-width: 0;
 	display: flex;
 	align-items: flex-start;
 	gap: 10px;
@@ -4426,12 +4470,25 @@ onUnmounted(() => {
 	font-size: 13px;
 	line-height: 1.5;
 }
+/* Hoisted OUT of the phase column (jarvis wait-phases-horizontal): the active
+   phase's `detail` is admin's own full sentence (jarvis#752/#754, e.g. "Your
+   OpenAI account has reached its usage limit. It resets in 2 hours."), too
+   long for a column a third of this block's width without wrecking the row.
+   Only one phase is ever active, so there is only ever one detail: it renders
+   once, full width, centered below every column. Its own `role="status"`
+   keeps detail changes announced now that they are no longer inside the
+   active column's status region. */
 .ob-phase-detail {
 	display: block;
+	width: 75%;
+	max-width: 640px;
+	margin: 6px auto 0;
+	padding: 0 8px;
 	font-size: 12px;
 	line-height: 1.5;
 	color: var(--text-3);
-	margin-top: 2px;
+	text-align: center;
+	box-sizing: border-box;
 }
 .ob-phase--done .ob-phase-label {
 	color: var(--text-2);
@@ -4513,6 +4570,30 @@ onUnmounted(() => {
 	}
 	.ob-head h1 {
 		font-size: 18px;
+	}
+}
+/* Narrow window (jarvis wait-phases-horizontal): three icon+label columns
+   plus the bar above them do not fit a phone-width card without the labels
+   wrapping into a cramped tower, so below 720px the phase columns revert to
+   the original single-column stack and the block itself uses the full
+   available width instead of 75% of an already-small card. 720, not the
+   block's own 640px cap: right at that cap the card is not yet wide enough
+   for 75% of it to give each column real breathing room (the ob-body's own
+   padding and the card's max-width still leave the card under ~700px in that
+   band), so the fallback range is deliberately wider than the point the cap
+   stops mattering. */
+@media (max-width: 720px) {
+	.ob-progress,
+	.ob-phases,
+	.ob-phase-detail {
+		width: 100%;
+	}
+	.ob-phases {
+		flex-direction: column;
+		gap: 2px;
+	}
+	.ob-phase {
+		flex: none;
 	}
 }
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -589,57 +589,64 @@
 										 sentence, too long for a column a third of this width, so it
 										 renders once, full width, below every column rather than
 										 inside one of them. -->
-									<ul v-if="!provisioningDelayed" class="ob-phases" role="list">
-										<li class="ob-phase ob-phase--done">
-											<span class="ob-phase-ico">
-												<FeatherIcon name="check" class="h-4 w-4" />
-											</span>
-											<span class="ob-phase-txt">
-												<span class="ob-phase-label"
-													>Payment confirmed</span
-												>
-											</span>
-										</li>
-										<li
-											class="ob-phase"
-											:class="`ob-phase--${provisioningStage.state}`"
-											role="status"
-										>
-											<span class="ob-phase-ico">
-												<JvSpinner
-													v-if="provisioningStage.state === 'active'"
-													:size="20"
-												/>
-												<FeatherIcon
-													v-else
-													name="alert-circle"
-													class="h-4 w-4"
-												/>
-											</span>
-											<span class="ob-phase-txt">
-												<span class="ob-phase-label">{{
-													provisioningStage.label
-												}}</span>
-											</span>
-										</li>
-										<li class="ob-phase ob-phase--waiting">
-											<span class="ob-phase-ico"
-												><i class="ob-phase-dot"></i
-											></span>
-											<span class="ob-phase-txt">
-												<span class="ob-phase-label"
-													>Connecting your AI</span
-												>
-											</span>
-										</li>
-									</ul>
-									<p
-										v-if="!provisioningDelayed && provisioningStage.detail"
-										class="ob-phase-detail"
-										role="status"
-									>
-										{{ provisioningStage.detail }}
-									</p>
+									<!-- ONE live region over the phases AND the detail (round-1 review
+										 of the horizontal change). Hoisting the detail out of the
+										 active row had given it its own role="status", so a screen
+										 reader heard the phase and the sentence explaining that phase
+										 as two unrelated announcements. Worse, that region was v-if
+										 gated, so it MOUNTED already populated, and a live region
+										 announces changes to a region that is already present, not
+										 its initial content. Wrapping both means one coherent
+										 announcement per tick, and the region outlives the sentence
+										 appearing inside it. -->
+									<div v-if="!provisioningDelayed" role="status">
+										<ul class="ob-phases" role="list">
+											<li class="ob-phase ob-phase--done">
+												<span class="ob-phase-ico">
+													<FeatherIcon name="check" class="h-4 w-4" />
+												</span>
+												<span class="ob-phase-txt">
+													<span class="ob-phase-label"
+														>Payment confirmed</span
+													>
+												</span>
+											</li>
+											<li
+												class="ob-phase"
+												:class="`ob-phase--${provisioningStage.state}`"
+											>
+												<span class="ob-phase-ico">
+													<JvSpinner
+														v-if="provisioningStage.state === 'active'"
+														:size="20"
+													/>
+													<FeatherIcon
+														v-else
+														name="alert-circle"
+														class="h-4 w-4"
+													/>
+												</span>
+												<span class="ob-phase-txt">
+													<span class="ob-phase-label">{{
+														provisioningStage.label
+													}}</span>
+												</span>
+											</li>
+											<li class="ob-phase ob-phase--waiting">
+												<span class="ob-phase-ico"
+													><i class="ob-phase-dot"></i
+												></span>
+												<span class="ob-phase-txt">
+													<span class="ob-phase-label"
+														>Connecting your AI</span
+													>
+												</span>
+											</li>
+										</ul>
+										<p v-if="provisioningStage.detail" class="ob-phase-detail">
+											{{ provisioningStage.detail }}
+										</p>
+									</div>
 									<!-- The sanctioned provisioning illustration (design.md §2.2).
 										 min-height, never a percentage height - see SetupNeuralNet's
 										 own comment. Dropped at the delayed ceiling, where there is a
@@ -1296,58 +1303,68 @@
 											 side by side under the bar's segments, same as the
 											 provisioning wait above: the active phase's `detail` is a
 											 full admin sentence (jarvis#752/#754), so it renders once,
-											 full width, below every column rather than inside one. -->
-										<ul class="ob-phases" role="list">
-											<li class="ob-phase ob-phase--done">
-												<span class="ob-phase-ico">
-													<FeatherIcon name="check" class="h-4 w-4" />
-												</span>
-												<span class="ob-phase-txt">
-													<span class="ob-phase-label"
-														>AI connection saved</span
-													>
-												</span>
-											</li>
-											<li
-												class="ob-phase"
-												:class="`ob-phase--${readinessStage.state}`"
-												role="status"
+											 full width, below every column rather than inside one.
+
+											 ONE live region over the phases AND that detail, same
+											 reason as the provisioning block: two role="status"
+											 regions made a screen reader hear the phase and the
+											 sentence explaining it as unrelated announcements. -->
+										<div role="status">
+											<ul class="ob-phases" role="list">
+												<li class="ob-phase ob-phase--done">
+													<span class="ob-phase-ico">
+														<FeatherIcon
+															name="check"
+															class="h-4 w-4"
+														/>
+													</span>
+													<span class="ob-phase-txt">
+														<span class="ob-phase-label"
+															>AI connection saved</span
+														>
+													</span>
+												</li>
+												<li
+													class="ob-phase"
+													:class="`ob-phase--${readinessStage.state}`"
+												>
+													<span class="ob-phase-ico">
+														<JvSpinner
+															v-if="
+																readinessStage.state === 'active'
+															"
+															:size="20"
+														/>
+														<FeatherIcon
+															v-else
+															name="alert-circle"
+															class="h-4 w-4"
+														/>
+													</span>
+													<span class="ob-phase-txt">
+														<span class="ob-phase-label">{{
+															readinessStage.label
+														}}</span>
+													</span>
+												</li>
+												<li class="ob-phase ob-phase--waiting">
+													<span class="ob-phase-ico"
+														><i class="ob-phase-dot"></i
+													></span>
+													<span class="ob-phase-txt">
+														<span class="ob-phase-label"
+															>Opening chat</span
+														>
+													</span>
+												</li>
+											</ul>
+											<p
+												v-if="readinessStage.detail"
+												class="ob-phase-detail"
 											>
-												<span class="ob-phase-ico">
-													<JvSpinner
-														v-if="readinessStage.state === 'active'"
-														:size="20"
-													/>
-													<FeatherIcon
-														v-else
-														name="alert-circle"
-														class="h-4 w-4"
-													/>
-												</span>
-												<span class="ob-phase-txt">
-													<span class="ob-phase-label">{{
-														readinessStage.label
-													}}</span>
-												</span>
-											</li>
-											<li class="ob-phase ob-phase--waiting">
-												<span class="ob-phase-ico"
-													><i class="ob-phase-dot"></i
-												></span>
-												<span class="ob-phase-txt">
-													<span class="ob-phase-label"
-														>Opening chat</span
-													>
-												</span>
-											</li>
-										</ul>
-										<p
-											v-if="readinessStage.detail"
-											class="ob-phase-detail"
-											role="status"
-										>
-											{{ readinessStage.detail }}
-										</p>
+												{{ readinessStage.detail }}
+											</p>
+										</div>
 										<!-- min-height (not h-full) is load-bearing: SetupNeuralNet's
 											 canvas fills via absolute+inset-0, and percentage heights
 											 don't resolve against a min-height parent - see its own


### PR DESCRIPTION
## Summary

The onboarding wait block was capped at 420px inside a card more than twice that width, so it read as congested, and its three phases stacked line by line underneath a bar describing those same three steps. Reported from a live run: "very congested", and "line by line is not nice, make it horizontal".

It is now 75 percent wide and the phases sit side by side under the bar's segments.

## What changed

- The bar and the phase list both go to 75 percent, capped at 640px.
- The phases become three equal columns. They align with the segments by construction, not coincidence: both are a 3-up flex with equal children over the same width, so segment one sits above phase one.
- The active phase's detail is hoisted out of the columns and runs full width beneath them.

Alignment did not require giving the bar its own per-step labels, which keeps `WAIT_STEPS` unlabelled. A previous review settled that deliberately, and reintroducing labels would have brought back the per-bar computed that review removed.

## Why the detail moved

That line carries admin's own sentence explaining why a route cannot serve, for example "Your OpenAI account has reached its usage limit. It resets in 2 hours." Inside a third-width column it wraps into a tower. It keeps `role="status"`, because it now sits outside the active row's own status region and would otherwise stop being announced when it changes.

## Risk and verification

- Design confirmed from a rendered preview before shipping, built from this branch's actual CSS and the product's real tokens rather than a mockup.
- Below 720px three icon and label columns cannot fit without wrapping, so it reverts to the stacked shape at full width. 720 rather than 640 because in that band the card itself is still narrow enough that columns would land around 100 to 150px.
- `role="status"` on the active phase, the spinner, the done check and the waiting dot are all unchanged.
- 85 tests pass across the two onboarding specs, including four new ones asserting the detail is a sibling of the phase list rather than nested in a column, that exactly three columns render with no per-column detail, and that `role="status"` survives in both places.

<details><summary>Coverage gap worth knowing</summary>

The provisioning wait surface has no pre-existing DOM mount test, only state-machine coverage, so the new tests exercise the readiness surface only. The provisioning block received the identical template and CSS treatment, but no mount test was added for it because none of that scaffolding exists yet.

</details>
