### PR TITLE
feat(onboarding): a Test button for a chat subscription, on the real probe

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -304,17 +304,28 @@ export const getLlmSyncStatus = () => call("jarvis.onboarding.get_llm_sync_statu
 // rather than mint a second desired version; resumable:true with
 // apply_operation:null means the descriptor is available under the SAME key on a
 // re-call (a bench→admin timeout after a server-side retry).
+// `forceProbe` (jarvis_admin_v2#297) asks admin to run a real probe even against
+// a byte-identical config, so a repeat subscription Test does not just answer
+// from the last verdict on record. Defaults false: every ordinary save,
+// including "Start chatting", calls this with fewer than five arguments and so
+// never sends it. Reused for a fresh probe on demand only by
+// LlmPoolEditor.vue's testSubscriptionRow, which also mints a fresh
+// idempotencyKey on every press - force_probe is not part of admin's
+// idempotency fingerprint, so a repeated key would resolve through admin's
+// idempotent-reuse path regardless of this flag.
 export const saveLlmPool = (
 	models,
 	preset = null,
 	routingMode = "failover",
-	idempotencyKey = ""
+	idempotencyKey = "",
+	forceProbe = false
 ) =>
 	call("jarvis.onboarding.save_llm_pool", {
 		models: JSON.stringify(models),
 		preset: preset || "",
 		routing_mode: routingMode,
 		idempotency_key: idempotencyKey || "",
+		force_probe: forceProbe ? 1 : 0,
 	});
 // Tear the whole AI connection down: deletes every stored credential on the
 // bench (models[] rows + the legacy flat fields) and asks admin to delete them

--- a/frontend/src/components/LlmPoolEditor.connect.spec.js
+++ b/frontend/src/components/LlmPoolEditor.connect.spec.js
@@ -31,6 +31,7 @@ const api = vi.hoisted(() => ({
 	pollPoolAccountSignin: vi.fn(),
 	getPendingOauthCaptures: vi.fn(),
 	cancelPendingOauthCapture: vi.fn(),
+	getLlmApplyOperation: vi.fn(),
 }));
 vi.mock("@/api", () => api);
 
@@ -40,6 +41,8 @@ vi.mock("frappe-ui", () => ({
 	dayjsLocal: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
 	getConfig: () => null,
 	toast: { error: vi.fn(), success: vi.fn() },
+	// Banner.vue (the subscription Test result banner, below) needs this.
+	FeatherIcon: { name: "FeatherIcon", props: ["name"], template: "<span/>" },
 }));
 
 const answer = vi.hoisted(() => ({ confirm: true }));
@@ -316,5 +319,284 @@ describe("§10.2 capture rehydrate + wire", () => {
 		expect(res.result.apply_operation.operation_id).toBe("op1");
 		// The editor is NOT the observer in footerless mode: it does not poll sync status.
 		expect(api.getLlmSyncStatus.mock.calls.length).toBe(before);
+	});
+});
+
+// Connect a fresh subscription account onto the onboarding row the same way §10.2's
+// capture-rehydrate tests do, so testSubscriptionRow has something to run against.
+async function connectSubscriptionRow(w, { upstream = "openai" } = {}) {
+	const r = w.vm.rows[0];
+	r.credentialType = "subscription";
+	r.upstream = upstream;
+	if (!Array.isArray(r.accounts)) r.accounts = [];
+	r.accounts.push({ upstream, account_ref: "SUB_a", label: "a@x", capture_id: "capA" });
+	await flushPromises();
+	return r;
+}
+
+describe("subscription Test (same probe the apply path uses)", () => {
+	it("is blocked before an account is connected, and never calls saveLlmPool", async () => {
+		const w = await mountOnboarding();
+		expect(w.vm.subTestBlockedReason(w.vm.rows[0])).toMatch(/connect/i);
+		await w.vm.testSubscriptionRow(w.vm.rows[0]);
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
+	});
+
+	it("a genuine READY verdict reports success without navigating anywhere itself", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "ready",
+			code: "LLM_READY",
+			chat_readiness: true,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(api.saveLlmPool).toHaveBeenCalledTimes(1);
+		expect(w.vm.subTest.result.kind).toBe("ok");
+		expect(w.vm.subTest.result.message).toMatch(/openai/i);
+		expect(w.vm.subTest.result.message).toMatch(/start chatting/i);
+	});
+
+	it("a rejected verdict shows admin's chat_readiness_reason VERBATIM, not a reworded copy", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		const adminReason = "Your OpenAI subscription was rejected. Reconnect the account.";
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "failed",
+			code: "LLM_APPLY_REJECTED",
+			chat_readiness_reason: adminReason,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(w.vm.subTest.result.kind).toBe("fail");
+		expect(w.vm.subTest.result.message).toBe(adminReason);
+	});
+
+	it("mints its own idempotency key, distinct from any host save() key", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({ operation_id: "op1", state: "ready" });
+
+		await w.vm.testSubscriptionRow(r);
+		await w.vm.save("host-idem-key");
+
+		const testCallKey = api.saveLlmPool.mock.calls[0][3];
+		const hostCallKey = api.saveLlmPool.mock.calls[1][3];
+		expect(testCallKey).not.toBe("");
+		expect(testCallKey).not.toBe(hostCallKey);
+		expect(hostCallKey).toBe("host-idem-key");
+	});
+
+	it("a second click while one is already in flight is a no-op (only one saveLlmPool call)", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		let resolveOp;
+		api.getLlmApplyOperation.mockImplementation(
+			() => new Promise((resolve) => (resolveOp = resolve))
+		);
+
+		const first = w.vm.testSubscriptionRow(r);
+		await flushPromises();
+		expect(w.vm.subTest.testing).toBe(true);
+		const second = w.vm.testSubscriptionRow(r); // must be swallowed, not queued
+
+		resolveOp({ operation_id: "op1", state: "ready", chat_readiness: true });
+		await Promise.all([first, second]);
+
+		expect(api.saveLlmPool).toHaveBeenCalledTimes(1);
+	});
+
+	it("hostBusy (Start-chatting in flight) blocks Test from firing", async () => {
+		const w = mount(LlmPoolEditor, {
+			props: { modes: ["quick"], footerless: true, hostBusy: true },
+		});
+		await idle();
+		const r = await connectSubscriptionRow(w);
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
+	});
+
+	it("cools down after a result lands, then allows a fresh Test", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({ operation_id: "op1", state: "ready" });
+
+		await w.vm.testSubscriptionRow(r);
+		expect(w.vm.subTest.cooling).toBe(true);
+
+		await w.vm.testSubscriptionRow(r); // still cooling: swallowed
+		expect(api.saveLlmPool).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(15000);
+		expect(w.vm.subTest.cooling).toBe(false);
+
+		await w.vm.testSubscriptionRow(r);
+		expect(api.saveLlmPool).toHaveBeenCalledTimes(2);
+	});
+
+	it("emits subscription-testing(true) while running and (false) once settled, for the host's cross-guard", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		let resolveOp;
+		api.getLlmApplyOperation.mockImplementation(
+			() => new Promise((resolve) => (resolveOp = resolve))
+		);
+
+		const p = w.vm.testSubscriptionRow(r);
+		await flushPromises();
+		expect(w.emitted("subscription-testing")).toEqual([[true]]);
+
+		resolveOp({ operation_id: "op1", state: "ready", chat_readiness: true });
+		await p;
+
+		expect(w.emitted("subscription-testing")).toEqual([[true], [false]]);
+	});
+
+	it("a bounded timeout with no terminal state reports a neutral pending message, never a false pass or fail", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({ operation_id: "op1", state: "pending" });
+
+		const p = w.vm.testSubscriptionRow(r);
+		await vi.advanceTimersByTimeAsync(95000); // past SUB_TEST_TIMEOUT_MS
+		await p;
+
+		expect(w.vm.subTest.result.kind).toBe("pending");
+	});
+});
+
+// jarvis_admin_v2#297: admin now accepts force_probe on update_llm_pool so a
+// repeat Test can ask for a real re-check instead of admin's byte-identical
+// no-op path answering from the last verdict on record. Every ordinary save
+// (the settings-pane apply, and "Start chatting" via footerless save()) must
+// keep calling saveLlmPool with FEWER than five arguments, so force_probe
+// silently defaults to false there and the request they send is unchanged.
+describe("subscription Test force_probe (jarvis_admin_v2#297): no repeat can carry a stale verdict", () => {
+	it("every Test press asks admin for a forced probe, as the 5th saveLlmPool argument", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "ready",
+			chat_readiness: true,
+			force_probed: true,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(api.saveLlmPool.mock.calls[0][4]).toBe(true);
+	});
+
+	it("footerless save() (Start chatting's path) never asks for a forced probe", async () => {
+		const w = await mountOnboarding();
+		await connectSubscriptionRow(w);
+
+		await w.vm.save("host-idem-key");
+
+		expect(api.saveLlmPool).toHaveBeenCalledTimes(1);
+		// Fewer than 5 args: force_probe is not even mentioned on the ordinary path.
+		expect(api.saveLlmPool.mock.calls[0].length).toBeLessThan(5);
+	});
+
+	it("two Test presses in a row each mint their OWN fresh idempotency key, both requesting a forced probe", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "ready",
+			chat_readiness: true,
+			force_probed: true,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+		w.vm.subTest.cooling = false; // bypass the post-result cooldown, tested elsewhere
+		await w.vm.testSubscriptionRow(r);
+
+		const firstKey = api.saveLlmPool.mock.calls[0][3];
+		const secondKey = api.saveLlmPool.mock.calls[1][3];
+		expect(firstKey).not.toBe("");
+		expect(secondKey).not.toBe("");
+		expect(secondKey).not.toBe(firstKey);
+		expect(api.saveLlmPool.mock.calls[0][4]).toBe(true);
+		expect(api.saveLlmPool.mock.calls[1][4]).toBe(true);
+	});
+
+	it("force_probed: true reports the fresh-check copy, never the stale one", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "ready",
+			chat_readiness: true,
+			force_probed: true,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(w.vm.subTest.result.kind).toBe("ok");
+		expect(w.vm.subTest.result.message).toMatch(/just now/i);
+	});
+
+	it("force_probed: false on a PASS says this is the last check, not a fresh one, without claiming failure", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "ready",
+			chat_readiness: true,
+			force_probed: false, // host below fleet-agent contract 1.23 ignored the ask
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(w.vm.subTest.result.kind).toBe("ok");
+		expect(w.vm.subTest.result.message).not.toMatch(/just now/i);
+		expect(w.vm.subTest.result.message).toMatch(/last check/i);
+		expect(w.vm.subTest.result.message).toMatch(/start chatting/i);
+	});
+
+	it("force_probed: false on a FAILURE still quotes admin's reason verbatim, with a stale notice appended after it", async () => {
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		const adminReason = "Your OpenAI account has reached its usage limit.";
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "failed",
+			code: "LLM_APPLY_REJECTED",
+			chat_readiness_reason: adminReason,
+			force_probed: false,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(w.vm.subTest.result.kind).toBe("fail");
+		expect(w.vm.subTest.result.message.startsWith(adminReason)).toBe(true);
+		expect(w.vm.subTest.result.message).not.toBe(adminReason);
+	});
+
+	it("a mocked status with no force_probed field at all (older fixture) is treated as fresh, not stale", async () => {
+		// Guards the existing verbatim-reason and just-now tests above this describe
+		// block, none of which set force_probed: undefined must never satisfy the
+		// strict === false stale check.
+		const w = await mountOnboarding();
+		const r = await connectSubscriptionRow(w);
+		api.getLlmApplyOperation.mockResolvedValue({
+			operation_id: "op1",
+			state: "ready",
+			chat_readiness: true,
+		});
+
+		await w.vm.testSubscriptionRow(r);
+
+		expect(w.vm.subTest.result.message).toMatch(/just now/i);
 	});
 });

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -1498,6 +1498,48 @@
 								+ Add account
 							</button>
 						</div>
+						<!-- Onboarding Test: the same live probe "Start chatting" runs, fired
+						     on demand once an account is connected instead of only at the end
+						     of the step. See testSubscriptionRow's docstring for why this
+						     cannot be a side-effect-free check the way the API-key Test above
+						     is. `subtle`/ghost weight only - design.md 3.1 reserves the one
+						     `solid` button per surface for "Start chatting". -->
+						<div
+							v-if="singleMode"
+							style="
+								display: flex;
+								align-items: center;
+								gap: 10px;
+								margin-top: 11px;
+								flex-wrap: wrap;
+							"
+						>
+							<button
+								type="button"
+								class="jv-btn jv-btn--sm jv-btn--ghost"
+								:disabled="
+									!editable ||
+									hostBusy ||
+									subTest.testing ||
+									subTest.cooling ||
+									!!subTestBlockedReason(m)
+								"
+								:title="
+									subTestBlockedReason(m) ||
+									'Sends a real message through your subscription to confirm it works. Costs one message from your plan.'
+								"
+								@click="testSubscriptionRow(m)"
+							>
+								{{ subTest.testing ? "Testing…" : "Test" }}
+							</button>
+						</div>
+						<Banner
+							v-if="singleMode && subTest.result"
+							role="status"
+							style="margin-top: 10px"
+							:type="subTestBannerType(subTest.result)"
+							:message="subTest.result.message"
+						/>
 					</div>
 					<div
 						v-else-if="!singleMode"
@@ -1800,11 +1842,13 @@ import {
 } from "@/llm/pool";
 import { errMessage as _err } from "@/lib/errors";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
+import { classifyOperation } from "@/lib/llmOperation.js";
 import { useConfirm } from "@/composables/useConfirm";
 import JvCombo from "@/components/JvCombo.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
 import DirectSubscriptionCard from "@/components/DirectSubscriptionCard.vue";
 import ProviderLogo from "@/components/ProviderLogo.vue";
+import Banner from "@/components/Banner.vue";
 import { agentName } from "@/branding";
 
 const { confirm } = useConfirm();
@@ -1833,11 +1877,28 @@ const props = defineProps({
 	// to read; other consumers (onboarding, ChatView) never pass this, so their
 	// scrim is unaffected.
 	hostScrim: { type: Boolean, default: false },
+	// Onboarding's own apply (saveConnect / "Start chatting") is in flight. Gates
+	// the singleMode subscription Test button (below) so the two can never run
+	// concurrently - both would push the same desired pool, and letting them race
+	// would mean two idempotency keys chasing one config, each blind to the
+	// other's operation. `subscriptionTesting` (exposed below) is the mirror: the
+	// host reads it to disable its own "Start chatting" while a Test is in flight.
+	hostBusy: { type: Boolean, default: false },
 });
 // "settings-changed" is the footerless (onboarding) passive notice that the desired
 // pool was persisted - NOT a control-flow signal (the host controller owns the apply
 // transaction). The settings editor keeps using "saved" (runApply) as before.
-const emit = defineEmits(["saved", "ready", "direct-changed", "settings-changed"]);
+const emit = defineEmits([
+	"saved",
+	"ready",
+	"direct-changed",
+	"settings-changed",
+	// The subscription Test above is in flight - the host (OnboardingView) mirrors
+	// this into its own "Start chatting" disabled state, same watch+emit idiom as
+	// `ready` above, rather than reading the exposed ref reactively through the
+	// template ref.
+	"subscription-testing",
+]);
 
 // ---- state ---------------------------------------------------------------
 const cfg = ref({ models: [], preset: "", routing_mode: "failover", proxy_active: false });
@@ -2105,6 +2166,227 @@ const upstreamLabels = upstreamOpts.map((o) => o.label);
 const upstreamLabelOf = (v) =>
 	(upstreamOpts.find((o) => o.value === v) || {}).label || v || "your provider";
 const upstreamValueOf = (l) => (upstreamOpts.find((o) => o.label === l) || {}).value || l;
+
+// ---- singleMode (onboarding) chat-subscription Test -----------------------
+// The API-key Test above (smTest) is a stateless bench-side probe: it never
+// touches the fleet or the container. A chat-subscription credential has no
+// such side-effect-free check - "does this account work" can only be answered
+// by actually routing a real chat completion through the tenant's own running
+// pool, which is exactly what a normal apply does. So this Test does not
+// invent a second, different check: it fires the SAME save_llm_pool -> admin
+// update_llm_pool -> fleet-agent /llm-pool round trip "Start chatting" uses,
+// and reads the SAME apply-operation status (chat_readiness_reason and all) -
+// then simply does not navigate. A test pass and a real apply can therefore
+// never disagree; they are the same probe.
+//
+// Deliberately its OWN poll loop, separate from the host's single
+// createOperationController (OnboardingView's saveConnect owns that one): this
+// follows only the operation ITS OWN save_llm_pool call opened, with its own
+// idempotency key, so a Test can never dedupe onto - or get superseded by - a
+// concurrent Start-chatting attempt. `hostBusy` (passed down from the host) and
+// `subscriptionTesting` (exposed up, below) are the two halves of the guard
+// that keeps only one of Test / Start-chatting running at a time.
+//
+// Costs the customer a real chat completion on EVERY click, byte-changing or
+// not: it passes force_probe: true (jarvis_admin_v2#297), asking admin to run
+// a real probe even against a config identical to the last one, rather than
+// let a repeat click reach the fleet-agent's byte-identical no-op path and
+// answer from the last verdict on record. So it is never run except on an
+// explicit click: no auto-run on mount, no re-run on every keystroke, disabled
+// for the request's duration plus a short cooldown after it lands
+// (SUB_TEST_COOLDOWN_MS). Each click also mints its OWN fresh idempotency key
+// (subTestIdemKey, below): force_probe is not part of admin's idempotency
+// fingerprint, so a reused key would resolve through admin's idempotent-reuse
+// path and carry the previous verdict forward no matter what force_probe says.
+// A host below fleet-agent contract 1.23 does not honour the flag; the polled
+// operation's force_probed says whether THIS press actually got a fresh probe
+// (see describeTestOutcome), so a customer is never told a carried-forward
+// answer is new.
+const subTest = ref({
+	testing: false,
+	cooling: false, // short post-result lockout, see SUB_TEST_COOLDOWN_MS
+	result: null, // { kind: "ok"|"fail"|"pending", message } | null
+	gen: 0,
+});
+const SUB_TEST_POLL_MS = 2000;
+// Bounded the same as the full editor's own apply wait (APPLY_TIMEOUT_MS,
+// above) - a first subscription activation can spend real time bringing up
+// the proxy sidecar, and this must not give up sooner than that path does.
+const SUB_TEST_TIMEOUT_MS = APPLY_TIMEOUT_MS;
+const SUB_TEST_COOLDOWN_MS = 15000;
+let subTestCoolTimer = null;
+watch(
+	() => subTest.value.testing,
+	(v) => emit("subscription-testing", v)
+);
+
+function subTestIdemKey() {
+	try {
+		if (typeof crypto !== "undefined" && crypto.randomUUID)
+			return `test-${crypto.randomUUID()}`;
+	} catch (e) {
+		/* fall through to the timestamp+random fallback */
+	}
+	return `test-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+// Why the button is disabled, or "" when it isn't. Cooling/testing are read
+// directly in the template alongside this (they are timing-based, not a fact
+// about the row), so this only ever names a fact about the row itself.
+function subTestBlockedReason(m) {
+	if (!m || !(m.accounts || []).some((a) => a && (a.capture_id || a.account_ref)))
+		return "Connect your account before testing.";
+	return "";
+}
+function subTestBannerType(result) {
+	if (!result) return "info";
+	if (result.kind === "ok") return "success";
+	if (result.kind === "fail") return "error";
+	return "warning";
+}
+// Poll ONE apply-operation to a terminal state, entirely separate from the
+// host's createOperationController (no shared timers, no shared store, no
+// visibility handling - a Test is a short, bounded, one-off wait, not the
+// durable resume-across-reload machinery "Start chatting" needs). Returns the
+// classifyOperation() descriptor, plus the raw force_probed carried alongside
+// it (see describeTestOutcome), on a terminal state, or null on the bounded
+// timeout / staleness (a newer Test superseded this one).
+async function pollTestOperation(operationId, stale) {
+	const deadline = Date.now() + SUB_TEST_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		if (stale()) return null;
+		let status = null;
+		try {
+			status = await api.getLlmApplyOperation(operationId);
+		} catch (e) {
+			// Transient read failure: keep polling until the deadline rather than
+			// reporting a fail for a status call that simply hiccuped.
+		}
+		if (stale()) return null;
+		if (status) {
+			const ui = classifyOperation(status);
+			// force_probed (jarvis_admin_v2#297) rides the raw polled status, not the
+			// generic classifyOperation() projection shared with the host's own
+			// createOperationController (which never asks for a forced probe and so
+			// never reads this). Carried alongside ui rather than folded into the
+			// shared shape.
+			if (ui.terminal) return { ...ui, forceProbed: status.force_probed };
+		}
+		await new Promise((r) => setTimeout(r, SUB_TEST_POLL_MS));
+	}
+	return null;
+}
+// Turn a terminal (or timed-out) operation into the one line the customer sees.
+// `canNavigate` is the EXACT condition "Start chatting" itself uses to decide the
+// route is real (state ready AND admin has not flagged chat as blocked) - reused
+// here rather than re-deriving "did it work" a second way. A failure quotes
+// `chatReadinessReason` verbatim, never reworded: that is the same sentence the
+// Connect step's own banner renders elsewhere, so a Test failure and a real one
+// never read differently for the identical underlying cause. A stale verdict
+// (see `stale` below) still shows that same verbatim sentence, with one extra
+// sentence of our own appended after it.
+//
+// `forceProbed === false` (strict: admin always sends a real boolean here per
+// jarvis_admin_v2#297, never null) means THIS press asked for a fresh probe and
+// did not get one, most often a host below fleet-agent contract 1.23. The
+// verdict below is then whatever admin already had on record, not a new
+// answer, and the customer must never be told otherwise - a quota-limited
+// customer who just fixed their quota and pressed Test again must not read
+// "answered just now" about a check that never re-ran.
+function describeTestOutcome(ui, m) {
+	const provider = upstreamLabelOf(m && m.upstream);
+	if (!ui) {
+		return {
+			kind: "pending",
+			message: "Still checking. This can take a minute, then test again.",
+		};
+	}
+	const stale = ui.forceProbed === false;
+	if (ui.canNavigate) {
+		return {
+			kind: "ok",
+			message: stale
+				? `This is the result of ${provider}'s last check. A fresh check could not be run this time. Select Start chatting to continue.`
+				: `${provider} answered a live check just now. Select Start chatting to continue.`,
+		};
+	}
+	if (ui.phase === "retry" || ui.phase === "rejected") {
+		const reason = ui.chatReadinessReason || ui.message || "The check failed. Try again.";
+		return {
+			kind: "fail",
+			message: stale
+				? `${reason} This is the previous result. A fresh check could not be run this time.`
+				: reason,
+		};
+	}
+	// Ready-but-chat-blocked, superseded, or still finishing at our own bound:
+	// nothing definitive yet, and this must never assert a pass or a fail it did
+	// not earn.
+	return {
+		kind: "pending",
+		message:
+			ui.chatReadinessReason || "Still checking. This can take a minute, then test again.",
+	};
+}
+async function testSubscriptionRow(m) {
+	if (!m || subTest.value.testing || subTest.value.cooling || props.hostBusy) return;
+	if (subTestBlockedReason(m)) return;
+	const myGen = ++subTest.value.gen;
+	const stale = () => subTest.value.gen !== myGen;
+	subTest.value.testing = true;
+	subTest.value.result = null;
+	try {
+		const payload = buildSavePayload();
+		if (payload.error) {
+			if (!stale()) subTest.value.result = { kind: "fail", message: payload.error };
+			return;
+		}
+		const res = await api.saveLlmPool(
+			payload.models,
+			payload.preset,
+			"failover",
+			subTestIdemKey(),
+			true // force_probe: an explicit Test press always asks admin for a fresh probe.
+		);
+		if (stale()) return;
+		if (!res || !res.apply_operation) {
+			subTest.value.result = {
+				kind: "fail",
+				message:
+					res && res.retry_after_seconds
+						? "Too many changes in a short time. Wait a moment, then try again."
+						: "Could not start the check. Try again.",
+			};
+			return;
+		}
+		const ui = await pollTestOperation(res.apply_operation.operation_id, stale);
+		if (stale()) return;
+		subTest.value.result = describeTestOutcome(ui, m);
+	} catch (e) {
+		if (!stale()) subTest.value.result = { kind: "fail", message: _err(e) };
+	} finally {
+		if (!stale()) {
+			subTest.value.testing = false;
+			subTest.value.cooling = true;
+			clearTimeout(subTestCoolTimer);
+			subTestCoolTimer = setTimeout(() => {
+				subTest.value.cooling = false;
+			}, SUB_TEST_COOLDOWN_MS);
+		}
+	}
+}
+// Invalidate a stale/visible result the instant the connected-account set
+// changes (a Disconnect, or a fresh OAuth paste-back) - a verdict about the
+// PREVIOUS account must never linger under the new one. Does not touch an
+// in-flight request (bumping gen alone abandons it, same idiom as smTest above).
+watch(
+	() => (rows.value[0] && rows.value[0].accounts && rows.value[0].accounts.length) || 0,
+	() => {
+		if (!singleMode.value) return;
+		subTest.value.result = null;
+		subTest.value.gen++;
+	}
+);
+
 // Upstreams whose approval screen hands back a BARE authorization code instead
 // of redirecting to a callback URL the customer can copy from the address bar.
 // isCodeOnlyPaste (xAI) is imported from @/llm/pool so the pool editor and the
@@ -4374,6 +4656,7 @@ onBeforeUnmount(() => {
 	stopPolling();
 	stopBackgroundWatch();
 	clearTimeout(applyResultTimer);
+	clearTimeout(subTestCoolTimer);
 });
 
 // Let a host (onboarding, footerless) drive Save from its own footer, and a
@@ -4382,7 +4665,16 @@ onBeforeUnmount(() => {
 // a savable+validated config - a connected subscription, a stored key, a local
 // endpoint, or a freshly-typed remote key with a PASSING probe bound to it (P0-09) -
 // before it opens an apply operation, and show a precise reason when it can't yet.
-defineExpose({ save, busy, canStart: singleModeCanStart, startBlockedReason });
+// subscriptionTesting: the host (OnboardingView) reads this to disable "Start
+// chatting" while the subscription Test above is running, the other half of the
+// hostBusy prop's mutual-exclusion guard.
+defineExpose({
+	save,
+	busy,
+	canStart: singleModeCanStart,
+	startBlockedReason,
+	subscriptionTesting: computed(() => subTest.value.testing),
+});
 </script>
 
 <style scoped>

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -77,8 +77,8 @@ const canStartRef = vi.hoisted(() => ({ value: true }));
 vi.mock("@/components/LlmPoolEditor.vue", () => ({
 	default: {
 		name: "LlmPoolEditor",
-		props: ["editable", "modes", "footerless"],
-		emits: ["ready", "settings-changed"],
+		props: ["editable", "modes", "footerless", "hostBusy"],
+		emits: ["ready", "settings-changed", "subscription-testing"],
 		setup(_props, { emit, expose }) {
 			emit("ready", true);
 			// A real ref so the host's `poolRef.value.canStart` unwraps to a boolean, seeded
@@ -89,6 +89,7 @@ vi.mock("@/components/LlmPoolEditor.vue", () => ({
 				busy: { active: false },
 				canStart,
 				startBlockedReason: ref("Test your API key before you continue."),
+				subscriptionTesting: ref(false),
 			});
 			return () => h("div", "editor-stub");
 		},
@@ -1676,6 +1677,42 @@ describe("jarvis wait-phases-horizontal: detail hoisted out of the phase columns
 		// bespoke one - it renders `.jv-spin` with its own role="status".
 		expect(w.find(".ob-phase--active .jv-spin").exists()).toBe(true);
 		expect(w.find(".ob-phase--waiting .ob-phase-dot").exists()).toBe(true);
+		w.unmount();
+	});
+});
+
+describe("subscription Test / Start-chatting mutual exclusion", () => {
+	// LlmPoolEditor's own subscription Test button fires the same save_llm_pool ->
+	// apply_operation round trip "Start chatting" does, via its OWN idempotency key
+	// and poll loop (see LlmPoolEditor.connect.spec.js). The two must never run at
+	// once - this checks the host's half of that guard: the editor's
+	// "subscription-testing" emit disables the host's own gate, and the host feeds
+	// its busy state back down as hostBusy.
+	it("disables Start chatting while the editor reports a subscription Test in flight", async () => {
+		const w = await mountConnect();
+		expect(w.vm.subscriptionTesting).toBe(false);
+
+		const editor = w.findComponent({ name: "LlmPoolEditor" });
+		editor.vm.$emit("subscription-testing", true);
+		await flushPromises();
+		expect(w.vm.subscriptionTesting).toBe(true);
+
+		editor.vm.$emit("subscription-testing", false);
+		await flushPromises();
+		expect(w.vm.subscriptionTesting).toBe(false);
+		w.unmount();
+	});
+
+	it("passes its own saving state down to the editor as hostBusy", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		const editor = w.findComponent({ name: "LlmPoolEditor" });
+		expect(editor.props("hostBusy")).toBe(false);
+
+		api.getLlmApplyOperation.mockResolvedValue(pending);
+		w.vm.saveConnect();
+		await flushPromises();
+		expect(editor.props("hostBusy")).toBe(true);
 		w.unmount();
 	});
 });

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1520,7 +1520,9 @@
 											:editable="true"
 											:modes="['quick']"
 											:footerless="true"
+											:host-busy="savingConnect"
 											@ready="connectReady = $event"
+											@subscription-testing="subscriptionTesting = $event"
 										/>
 										<!-- Why the last Start was refused: a rejected apply verdict
 											 (error) or the start gate (no passing probe / no account). -->
@@ -1554,10 +1556,15 @@
 								</button>
 								<span v-else></span>
 								<!-- Always rendered; disabled until the editor reports a savable config,
-									 so the step never shows without a primary action. -->
+									 so the step never shows without a primary action. Also disabled
+									 while the editor's own subscription Test is running (see
+									 subscriptionTesting above) - the two must never push the same
+									 desired pool at once. -->
 								<Button
 									variant="solid"
-									:disabled="!connectReady || savingConnect"
+									:disabled="
+										!connectReady || savingConnect || subscriptionTesting
+									"
 									:loading="savingConnect"
 									loading-text="Connecting…"
 									label="Start chatting"
@@ -3227,6 +3234,11 @@ const savingConnect = ref(false);
 // STRICTER start gate (a passing probe for a freshly-typed remote key) is enforced in
 // saveConnect via the editor's exposed canStart, with an inline reason when it refuses.
 const connectReady = ref(false);
+// Mirrors LlmPoolEditor's own subscription Test (subscription-testing emit): while
+// it is running, "Start chatting" is disabled - the two would otherwise push the
+// same desired pool through two independent idempotency keys at once. The editor's
+// hostBusy prop (bound to savingConnect below) is the other half of this guard.
+const subscriptionTesting = ref(false);
 
 // Persist ONLY opaque handles across a reload: the operation id (operationStore) and
 // the idempotency key. Never a credential, never a token.

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1266,6 +1266,7 @@ def post_update_llm_pool(
 	oauth_blobs: dict,
 	idempotency_key: str | None = None,
 	timeout_s: int | None = None,
+	force_probe: bool = False,
 ) -> dict:
 	"""POST a PoolSpec + separated secrets to admin → fleet-agent → agent.
 
@@ -1282,6 +1283,16 @@ def post_update_llm_pool(
 	    A timeout here is not a lost apply: admin commits desired + operation before
 	    the fleet push, so the operation exists and the caller resumes via the same
 	    idempotency key. None keeps the long DEFAULT_TIMEOUT_S for the async worker.
+	``force_probe`` (jarvis_admin_v2#297): asks admin to run a real probe even
+	    against a byte-identical config, instead of its byte-identical no-op path
+	    answering from the last verdict on record. Admin allowlist-coerces the
+	    wire value; only a real ``true`` counts, so this is sent ONLY when the
+	    caller passed a truthy value - an ordinary (False) call posts a body with
+	    no ``force_probe`` key at all, byte-identical to before this parameter
+	    existed. Not part of admin's idempotency fingerprint: a caller that wants
+	    a fresh probe on every press must also mint a fresh ``idempotency_key``,
+	    since a reused key resolves through admin's idempotent-reuse path
+	    regardless of this flag.
 
 	The admin endpoint merges the secrets with the spec before forwarding to
 	fleet-agent. Implemented in T3 (jarvis_admin); this stub is the bench-side
@@ -1307,6 +1318,12 @@ def post_update_llm_pool(
 	}
 	if idempotency_key:
 		body["idempotency_key"] = idempotency_key
+	# Omitted (not merely False) on an ordinary call: admin allowlist-coerces
+	# anything but a real `true` to false anyway, but leaving the key out
+	# entirely on the common path keeps this body byte-identical to the one
+	# sent before force_probe existed.
+	if force_probe:
+		body["force_probe"] = True
 	kw = {"timeout_s": timeout_s} if timeout_s is not None else {}
 	return _post(path=_m("api.tenant.update_llm_pool"), body=body, **kw)
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -2065,7 +2065,7 @@ SYNC_PUSH_LOCK_WAIT_S = 10
 SYNC_DESCRIPTOR_TIMEOUT_S = 20
 
 
-def sync_pool_now(idempotency_key: str | None = None) -> dict:
+def sync_pool_now(idempotency_key: str | None = None, force_probe: bool = False) -> dict:
 	"""SHORT, tightly-bounded round-trip to OBTAIN the durable apply-operation
 	descriptor for the onboarding/settings save (Fable corrected ruling F2/F3,
 	review P0-02). The Start-chatting click owns the OPERATION, not the PUSH: this
@@ -2095,6 +2095,13 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 	Budget invariant: no path here exceeds the gunicorn timeout, and an exception
 	anywhere after the desired-state commit hands the config to the worker rather
 	than stranding it (F3).
+
+	``force_probe`` (jarvis_admin_v2#297) reaches ONLY this one synchronous
+	``post_update_llm_pool`` call, never the async worker hand-off below: the
+	worker re-dedupes to the SAME durable operation via the same
+	``idempotency_key``, which admin resolves through its idempotent-reuse path
+	regardless of ``force_probe`` - so passing it there would spend nothing and
+	risk nothing, it is simply moot.
 	"""
 	import frappe as _frappe
 
@@ -2135,6 +2142,7 @@ def sync_pool_now(idempotency_key: str | None = None) -> dict:
 							oauth_blobs=oauth_blobs,
 							idempotency_key=idempotency_key,
 							timeout_s=SYNC_DESCRIPTOR_TIMEOUT_S,
+							force_probe=force_probe,
 						)
 						or {}
 					)

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -447,6 +447,7 @@ def save_llm_pool(
 	preset: str | None = None,
 	routing_mode: str = "failover",
 	idempotency_key: str | None = None,
+	force_probe: str | int | bool = False,
 ) -> dict:
 	"""Write the customer's multi-model LLM pool into Jarvis Settings.models[]
 	(+ preset, routing_mode) and let the existing on_update pipeline validate
@@ -467,6 +468,18 @@ def save_llm_pool(
 	operation with no new desired version. A single-model config keeps the
 	async creds path and returns ``apply_operation: null`` with ``mode: "legacy"``.
 
+	``force_probe`` (jarvis_admin_v2#297): threaded straight into the synchronous
+	``sync_pool_now`` call so the subscription Test button can ask admin to run a
+	real probe even against a byte-identical config, instead of admin's
+	byte-identical no-op path answering from the last verdict on record. Defaults
+	False so every ordinary save, including "Start chatting", is unchanged: the
+	admin request body gains the ``force_probe`` key ONLY when this is true, so a
+	false-default call is byte-identical to the request this endpoint sent before
+	the flag existed. It is not part of admin's idempotency fingerprint, so a
+	repeat Test must mint a fresh ``idempotency_key`` on every press, never reuse
+	one - a reused key resolves through admin's idempotent-reuse path regardless
+	of this flag.
+
 	All params MUST stay annotated: with Frappe's
 	``require_type_annotated_api_methods`` enforced (declared in hooks.py),
 	an un-annotated whitelisted param 500s the request before the body runs
@@ -475,6 +488,11 @@ def save_llm_pool(
 	System-Manager-gated. routing_mode is always 'failover' in v1. preset is an
 	admin-catalog key or None; validated against the fetched catalog."""
 	require_jarvis_admin()
+	# Same coercion convention as jarvis.chat.api.set_star / set_auto_apply: a
+	# whitelisted call arrives over HTTP as a string most of the time, so an
+	# annotated `bool` param is trusted only after an explicit allowlist read,
+	# never truthy-cast directly.
+	force_probe = str(force_probe) in ("1", "true", "True", "on", "yes")
 	if isinstance(models, str):
 		models = json.loads(models)
 	if not isinstance(models, list) or not models:
@@ -651,7 +669,7 @@ def save_llm_pool(
 		# The durable apply operation lives on the POOL path (admin creates it in
 		# update_llm_pool). Push synchronously and hand its descriptor back so the
 		# SPA follows ONE operation across save -> apply -> readiness.
-		outcome = sync_pool_now(idempotency_key=idempotency_key or None)
+		outcome = sync_pool_now(idempotency_key=idempotency_key or None, force_probe=force_probe)
 		apply_operation = outcome.get("apply_operation")
 		resumable = bool(outcome.get("resumable"))
 		retry_after_seconds = int(outcome.get("retry_after_seconds") or 0)

--- a/jarvis/tests/test_save_llm_pool_operation.py
+++ b/jarvis/tests/test_save_llm_pool_operation.py
@@ -189,3 +189,77 @@ class TestSaveReturnsDescriptor(_SaveOpBase):
 		self.assertFalse(out["resumable"])
 		self.assertEqual(pool_calls, [], "single-model must NOT hit /llm-pool")
 		creds.assert_called()
+
+
+class TestSaveLlmPoolForceProbe(_SaveOpBase):
+	"""jarvis_admin_v2#297: force_probe reaches admin's update_llm_pool ONLY when
+	the caller (the subscription Test button) explicitly asks for it, so an
+	ordinary save's request is unchanged."""
+
+	def test_force_probe_true_reaches_post_update_llm_pool(self):
+		view = self._capture()
+		calls = []
+		with patch(
+			"jarvis.admin_client.post_update_llm_pool",
+			side_effect=lambda **kw: calls.append(kw) or _pool_ok(),
+		):
+			onboarding.save_llm_pool(
+				frappe.as_json(self._sub_models(view["capture_id"])),
+				preset=None,
+				routing_mode="failover",
+				idempotency_key="idem-force-1",
+				force_probe=True,
+			)
+		self.assertEqual(len(calls), 1)
+		self.assertIs(calls[0].get("force_probe"), True)
+
+	def test_force_probe_default_is_false_and_ordinary_saves_never_send_it_true(self):
+		view = self._capture()
+		calls = []
+		with patch(
+			"jarvis.admin_client.post_update_llm_pool",
+			side_effect=lambda **kw: calls.append(kw) or _pool_ok(),
+		):
+			# No force_probe kwarg at all - the same call shape "Start chatting"
+			# and every settings-pane save already make.
+			onboarding.save_llm_pool(
+				frappe.as_json(self._sub_models(view["capture_id"])),
+				preset=None,
+				routing_mode="failover",
+				idempotency_key="idem-ordinary",
+			)
+		self.assertEqual(len(calls), 1)
+		self.assertIs(calls[0].get("force_probe"), False)
+
+	def test_force_probe_accepts_the_wire_strings_a_frappe_call_actually_sends(self):
+		# Same allowlist convention as jarvis.chat.api.set_star: an HTTP form post
+		# arrives as a string, and only these exact spellings mean true.
+		view = self._capture()
+		for wire_value, expected in (
+			("1", True),
+			("true", True),
+			(1, True),
+			(True, True),
+			("0", False),
+			("false", False),
+			(0, False),
+			(False, False),
+			("", False),
+		):
+			calls = []
+			with patch(
+				"jarvis.admin_client.post_update_llm_pool",
+				side_effect=lambda **kw: calls.append(kw) or _pool_ok(),
+			):
+				onboarding.save_llm_pool(
+					frappe.as_json(self._sub_models(view["capture_id"])),
+					preset=None,
+					routing_mode="failover",
+					idempotency_key=f"idem-wire-{wire_value!r}",
+					force_probe=wire_value,
+				)
+			self.assertIs(
+				calls[0].get("force_probe"),
+				expected,
+				f"force_probe={wire_value!r} should coerce to {expected!r}",
+			)


### PR DESCRIPTION
## Summary

The chat-subscription connect surface now has a Test button, so a customer can ask "does this actually work" before leaving the step. It reuses the real apply path rather than inventing a second check, and it asks admin for a genuinely fresh verdict, so pressing Test twice cannot return a stale answer.

This is the customer-plane half of the work whose admin half landed in jarvis-admin-v2#297.

## Why one probe, not a second checker

A standalone tester asks a different question from the apply-time probe, the two can disagree, and this environment already had a Test button with a history of false negatives. So Test fires the SAME `save_llm_pool` to `update_llm_pool` to fleet-agent round trip that Start chatting uses, then polls the same durable apply operation. One source of truth.

It passes `force_probe: true`, so a repeat press on an unchanged config re-earns the verdict instead of carrying the last one forward. Each press mints a fresh idempotency key, per admin's contract.

## What changed

`force_probe` threads from the Test action through `api.js`, the `save_llm_pool` relay, `sync_pool_now`, and `post_update_llm_pool` into admin. Default false at every hop.

## Risk and verification

- Ordinary saves and Start chatting never force a probe, guaranteed three ways: only the Test action passes the flag, `post_update_llm_pool` omits the key entirely when false so an ordinary payload is byte-identical to before, and a test asserts Start chatting's call carries fewer than five arguments.
- Not spammable: explicit click only, disabled in flight, a cooldown, and mutual exclusion with Start chatting. Each subscription probe spends a real message from the customer's own quota, which is why this matters.
- A failure shows admin's own `chat_readiness_reason` verbatim, never a reworded copy.
- When `force_probed` comes back false after asking for true, the customer is told the result is the previous one, not a fresh check.
- 100 tests pass across the two connect specs, run locally on Node 24. The new Python test is in the diff and runs on CI, since this bench's path points at a different checkout.

## Customer copy

- Fresh pass: "{Provider} answered a live check just now. Select Start chatting to continue."
- Stale pass: "This is the result of {Provider}'s last check. A fresh check could not be run this time. Select Start chatting to continue."
- Failure: admin's reason verbatim, and if stale, followed by "This is the previous result. A fresh check could not be run this time." The original sentence is never reworded.

<details><summary>Worth a read before merging</summary>

The stale-case wording is a judgment call within the constraints of "must not claim freshness" and "must show admin's sentence verbatim". I also applied the no-freshness-claim rule to the failure branch, not only the pass branch, on the reasoning that a repeated stale failure is the same customer-facing symptom.

</details>
