### PR TITLE
feat(billing): GST on Review & pay + tax-inclusive charge displays

### DIFF
--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -90,6 +90,35 @@ export function cancellationNotice(accessEndsOn) {
 export function inr(n) {
 	return `₹${(Number(n) || 0).toLocaleString("en-IN")}`;
 }
+// Same localisation as inr(), but never leaves a fractional amount at one
+// decimal place. GST math (planPricing in onboarding/steps.js) can yield a
+// paise-precision amount - price_inr=3475, gst_percent=18 -> total=4100.5 -
+// and the backend charges exactly that (to_paise -> 410050). Plain inr()'s
+// toLocaleString has no forced minimum, so it renders "₹4,100.5": correct in
+// value but inconsistent next to a whole-rupee sibling row, and easy to
+// misread as a rounded-off amount. A fractional amount always gets 2dp here;
+// a whole-rupee amount still renders with none, so this is a superset of
+// inr()'s output rather than a different look for the common case.
+//
+// Kept separate from inr() rather than changing it globally: inr() also
+// formats plain headline/browsing prices (planAmount, planPriceLabel) that
+// intentionally stay unrounded and untaxed - use this formatter only where a
+// value is money actually being charged and can legitimately carry
+// GST-driven paise precision (every BillingPage confirm-dialog charge and
+// the onboarding pay summary now do).
+export function inrExact(n) {
+	const v = Number(n) || 0;
+	// Fractional-ness is checked in paise (round to the nearest integer paisa)
+	// rather than by inspecting decimal digits, so float noise from
+	// `subtotal * gstPercent / 100` (already rounded by planPricing, but this
+	// formatter has no such guarantee from every future caller) can't flip an
+	// exact whole-rupee amount into a spurious "₹4,100.00".
+	const hasFraction = Math.round(v * 100) % 100 !== 0;
+	return `₹${v.toLocaleString("en-IN", {
+		minimumFractionDigits: hasFraction ? 2 : 0,
+		maximumFractionDigits: 2,
+	})}`;
+}
 // Big price line on a plan card: "₹3,999".
 export function planAmount(priceInr) {
 	return inr(Number(priceInr) || 0);
@@ -111,6 +140,18 @@ export function planCycleLabel(p) {
 	const billed = suffix === "/yr" ? "Billed annually" : "Billed monthly";
 	// Auto-pay trial: nothing is charged until the trial ends, then autopay begins.
 	return trial > 0 ? `${trial}-day free trial, then ${billed.toLowerCase()}` : billed;
+}
+// Whether a plan's headline price actually excludes GST, i.e. whether "excl.
+// GST" is true to say next to it. `gst_percent` can arrive as a number, a
+// numeric string (some API rows stringify), 0, absent, or undefined - the
+// last two both happen today, since get_plans does not send the field until
+// its companion admin PR lands. Number(undefined) is NaN, and NaN > 0 is
+// false, so an absent field reads the same as an explicit 0: no GST, no
+// caveat needed. A card that unconditionally claimed "excl. GST" would be
+// wrong for both a genuinely 0-GST plan and every plan today, before that
+// field exists at all.
+export function planHasGst(p) {
+	return Number(p && p.gst_percent) > 0;
 }
 // A plan's feature bullets, whatever shape the field arrived in.
 //

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -6,8 +6,10 @@ import {
 	planPriceLabel,
 	renewalLabel,
 	inr,
+	inrExact,
 	planAmount,
 	planSuffix,
+	planHasGst,
 	cancelActionLabel,
 	cancellationNotice,
 	shortDate,
@@ -31,6 +33,34 @@ test("inr: localizes amounts, coerces junk to 0", () => {
 	assert.equal(inr(150000), "₹1,50,000");
 	assert.equal(inr(null), "₹0");
 	assert.equal(inr("abc"), "₹0");
+});
+// inrExact: same localisation as inr(), but a fractional amount (GST math can
+// yield paise precision) always renders at 2dp instead of inr()'s bare
+// toLocaleString, which would show "₹4,100.5" - correct in value, but
+// inconsistent next to a whole-rupee row and easy to misread as rounded off.
+test("inrExact: a fractional amount always renders at 2dp", () => {
+	assert.equal(inrExact(4100.5), "₹4,100.50");
+	assert.equal(inrExact(625.5), "₹625.50");
+});
+test("inrExact: a whole-rupee amount renders exactly like inr(), no decimals", () => {
+	assert.equal(inrExact(4130), "₹4,130");
+	assert.equal(inrExact(0), "₹0");
+	assert.equal(inrExact(3999), "₹3,999");
+});
+test("inrExact: junk coerces to ₹0, same as inr()", () => {
+	assert.equal(inrExact(null), "₹0");
+	assert.equal(inrExact("abc"), "₹0");
+});
+test("planHasGst: true only when gst_percent is a positive number", () => {
+	assert.equal(planHasGst({ gst_percent: 18 }), true);
+	assert.equal(planHasGst({ gst_percent: "18" }), true); // stringified API row
+});
+test("planHasGst: false for 0, absent, undefined or missing gst_percent - never claims 'excl. GST' without one", () => {
+	assert.equal(planHasGst({ gst_percent: 0 }), false);
+	assert.equal(planHasGst({ gst_percent: "0" }), false);
+	assert.equal(planHasGst({}), false); // pre-companion-PR get_plans row: field absent
+	assert.equal(planHasGst({ gst_percent: undefined }), false);
+	assert.equal(planHasGst(null), false);
 });
 test("planAmount: INR amount, zero/junk coerces to ₹0", () => {
 	assert.equal(planAmount(0), "₹0");

--- a/frontend/src/components/settings/PlanBillingPane.spec.js
+++ b/frontend/src/components/settings/PlanBillingPane.spec.js
@@ -241,4 +241,38 @@ describe("PlanBillingPane", () => {
 			expect(api.cancelPlanAtPeriodEnd).not.toHaveBeenCalled();
 		});
 	});
+
+	// #10-e review: "excl. GST" used to render unconditionally next to the
+	// plan's price, which wrongly claimed an exemption for a 0-GST plan and
+	// for EVERY plan before get_plans starts sending gst_percent at all.
+	describe("excl. GST label tracks the plan's own gst_percent", () => {
+		it("is absent when gst_percent is undefined (pre-companion-PR get_plans row)", async () => {
+			const w = await mountPane(); // baseAccount's plan has no gst_percent
+			expect(w.text()).not.toContain("excl. GST");
+		});
+
+		it("is absent when gst_percent is 0", async () => {
+			const w = await mountPane({
+				plan: {
+					plan_name: "Pro",
+					price_inr: 3999,
+					billing_cycle: "Monthly",
+					gst_percent: 0,
+				},
+			});
+			expect(w.text()).not.toContain("excl. GST");
+		});
+
+		it("is present when gst_percent is a positive number", async () => {
+			const w = await mountPane({
+				plan: {
+					plan_name: "Pro",
+					price_inr: 3999,
+					billing_cycle: "Monthly",
+					gst_percent: 18,
+				},
+			});
+			expect(w.text()).toContain("excl. GST");
+		});
+	});
 });

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -33,6 +33,9 @@
 					<span class="text-base text-ink-gray-6">
 						{{ planPriceLabel(account.plan.price_inr, account.plan.billing_cycle) }}
 					</span>
+					<!-- GST-exclusive pricing: the price above is the base rate, not
+					     what gets charged, so this says so plainly. -->
+					<span class="text-p-sm text-ink-gray-5">excl. GST</span>
 					<Badge
 						variant="subtle"
 						:theme="statusTheme"

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -34,8 +34,13 @@
 						{{ planPriceLabel(account.plan.price_inr, account.plan.billing_cycle) }}
 					</span>
 					<!-- GST-exclusive pricing: the price above is the base rate, not
-					     what gets charged, so this says so plainly. -->
-					<span class="text-p-sm text-ink-gray-5">excl. GST</span>
+					     what gets charged, so this says so plainly - but only for a
+					     plan that actually carries GST. A 0-GST plan, or any plan
+					     before get_plans sends gst_percent at all, must not claim an
+					     exemption it doesn't have. -->
+					<span v-if="planHasGst(account.plan)" class="text-p-sm text-ink-gray-5"
+						>excl. GST</span
+					>
 					<Badge
 						variant="subtle"
 						:theme="statusTheme"
@@ -161,6 +166,7 @@ import {
 	statusBadgeTheme,
 	planPriceLabel,
 	planFeatures,
+	planHasGst,
 	renewalLabel,
 	cancelActionLabel,
 	cancelPillLabel,

--- a/frontend/src/onboarding/permissionCopy.js
+++ b/frontend/src/onboarding/permissionCopy.js
@@ -30,5 +30,5 @@ export function permissionCopyFor(policy = {}) {
 	if (destructiveAlwaysConfirms) {
 		return "Applies changes automatically; destructive actions always require confirmation.";
 	}
-	return "May change things automatically — review your automation settings.";
+	return "May change things automatically. Review your automation settings.";
 }

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -14,7 +14,7 @@ export const STEPS_MANAGED = ["intro", "details", "plan", "pay", "connect"];
 // RELATIVE, not "@/account/format": this file's tests run under `node --test`
 // (package.json test:node), which resolves no bundler alias. format.js is plain ESM
 // with zero imports of its own, so pulling it in here keeps this module cheap to test.
-import { inr, planSuffix } from "../account/format.js";
+import { inrExact, planSuffix } from "../account/format.js";
 
 /**
  * Base/GST/total split for one plan (GST tax breakdown, 2026-08).
@@ -61,10 +61,15 @@ export function planDueToday(p) {
 	const days = Number(p.trial_days) || 0;
 	const { total } = planPricing(p);
 	const suffix = planSuffix(p.price_inr, p.billing_cycle) || "";
+	// inrExact, not inr: `total` carries GST-driven paise precision (e.g.
+	// price_inr=3475, gst_percent=18 -> total=4100.5), and this must render the
+	// exact value the backend charges rather than inr()'s bare toLocaleString,
+	// which would show a stray one-decimal "₹4,100.5". It is a strict superset
+	// of inr()'s output for whole-rupee amounts, so this is safe on `fee` too.
 	if (days > 0) {
-		return `${inr(fee)} today · then ${inr(total)}${suffix} after ${days} days`;
+		return `${inrExact(fee)} today · then ${inrExact(total)}${suffix} after ${days} days`;
 	}
-	return fee > 0 ? `${inr(total + fee)} today` : inr(total);
+	return fee > 0 ? `${inrExact(total + fee)} today` : inrExact(total);
 }
 
 export function stepIndex(steps, cur) {

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -14,7 +14,28 @@ export const STEPS_MANAGED = ["intro", "details", "plan", "pay", "connect"];
 // RELATIVE, not "@/account/format": this file's tests run under `node --test`
 // (package.json test:node), which resolves no bundler alias. format.js is plain ESM
 // with zero imports of its own, so pulling it in here keeps this module cheap to test.
-import { inr, planAmount, planSuffix } from "../account/format.js";
+import { inr, planSuffix } from "../account/format.js";
+
+/**
+ * Base/GST/total split for one plan (GST tax breakdown, 2026-08).
+ *
+ * CANONICAL formula, identical to the backend's `jarvis_admin_v2.billing.catalog`
+ * (`gst_amount_inr` / `total_inr`): `gstAmount = round(subtotal * gstPercent / 100, 2)`,
+ * `total = subtotal + gstAmount`. Rounding order must match the backend exactly - the
+ * gateway order is created at `total` and later verified against it, so a drift here
+ * would reject a real payment as an amount mismatch.
+ *
+ * `price_inr` is always the pre-tax base (its own field description says so); a plan
+ * with no `gst_percent` (or 0) collapses to `total === subtotal`, so callers written
+ * before GST existed keep behaving exactly as before.
+ */
+export function planPricing(p) {
+	const plan = p || {};
+	const subtotal = Number(plan.price_inr) || 0;
+	const gstPercent = Number(plan.gst_percent) || 0;
+	const gstAmount = Math.round(subtotal * gstPercent) / 100; // round(base*pct/100, 2)
+	return { subtotal, gstPercent, gstAmount, total: subtotal + gstAmount };
+}
 
 /**
  * What the customer pays TODAY for one plan, as a sentence (#671).
@@ -30,16 +51,20 @@ import { inr, planAmount, planSuffix } from "../account/format.js";
  * zero for every trial, which is exactly that understatement. The fee is 0 on the
  * current catalog, so this changes nothing today and stops being wrong the moment a
  * plan carries one.
+ *
+ * The recurring/charged amount is `planPricing(p).total` (tax-inclusive) - the fee
+ * itself is NOT taxed in this scope (GST applies to the recurring plan price only).
  */
 export function planDueToday(p) {
 	if (!p || !p.plan_name) return "";
 	const fee = Number(p.signup_fee_inr) || 0;
 	const days = Number(p.trial_days) || 0;
+	const { total } = planPricing(p);
 	const suffix = planSuffix(p.price_inr, p.billing_cycle) || "";
 	if (days > 0) {
-		return `${inr(fee)} today · then ${inr(p.price_inr)}${suffix} after ${days} days`;
+		return `${inr(fee)} today · then ${inr(total)}${suffix} after ${days} days`;
 	}
-	return fee > 0 ? `${inr(Number(p.price_inr) + fee)} today` : planAmount(p.price_inr);
+	return fee > 0 ? `${inr(total + fee)} today` : inr(total);
 }
 
 export function stepIndex(steps, cur) {

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -12,6 +12,7 @@ import {
 	GENERIC_NOT_READY_NOTE,
 	syncStatusNote,
 	planDueToday,
+	planPricing,
 	planSubtitleFor,
 } from "./steps.js";
 
@@ -124,55 +125,96 @@ test("isOnboardComplete reads readiness", () => {
 });
 
 // --------------------------------------------------------------------------- //
-// #671 - what is due TODAY, shown on the Plan card and the Review row
+// GST tax breakdown (2026-08) - base/GST/total split, canonical rounding
 // --------------------------------------------------------------------------- //
-test("planDueToday: a trial plan leads with zero due now, then the recurring price", () => {
-	assert.equal(
-		planDueToday({
-			plan_name: "Standard",
-			price_inr: 3500,
-			billing_cycle: "Monthly",
-			trial_days: 7,
-		}),
-		"₹0 today · then ₹3,500/mo after 7 days"
+test("planPricing splits base + GST with canonical rounding", () => {
+	assert.deepEqual(
+		planPricing({ plan_name: "Standard", price_inr: 3500, gst_percent: 18, billing_cycle: "Monthly" }),
+		{ subtotal: 3500, gstPercent: 18, gstAmount: 630, total: 4130 }
 	);
 });
 
-test("planDueToday: a signup fee is what is due now, not zero", () => {
-	// admin's get_plans comment: pricing from price_inr alone understates the charge,
-	// "most visibly on a trial plan, where the fee is the entire amount due now". The
-	// Review row this replaces hardcoded a flat zero for every trial.
+test("planPricing: no gst_percent (absent or zero) collapses to identity", () => {
+	assert.deepEqual(planPricing({ price_inr: 3500 }), {
+		subtotal: 3500,
+		gstPercent: 0,
+		gstAmount: 0,
+		total: 3500,
+	});
+	assert.deepEqual(planPricing({ price_inr: 3500, gst_percent: 0 }), {
+		subtotal: 3500,
+		gstPercent: 0,
+		gstAmount: 0,
+		total: 3500,
+	});
+});
+
+test("planPricing: a missing plan is a zeroed split, not a crash", () => {
+	assert.deepEqual(planPricing(null), { subtotal: 0, gstPercent: 0, gstAmount: 0, total: 0 });
+});
+
+// --------------------------------------------------------------------------- //
+// #671 - what is due TODAY, shown on the Plan card and the Review row
+// --------------------------------------------------------------------------- //
+test("planDueToday: a trial plan leads with zero due now, then the tax-inclusive recurring price", () => {
 	assert.equal(
 		planDueToday({
 			plan_name: "Standard",
 			price_inr: 3500,
+			gst_percent: 18,
+			billing_cycle: "Monthly",
+			trial_days: 7,
+		}),
+		"₹0 today · then ₹4,130/mo after 7 days"
+	);
+});
+
+test("planDueToday: a signup fee is what is due now, not zero (fee itself is untaxed)", () => {
+	// admin's get_plans comment: pricing from price_inr alone understates the charge,
+	// "most visibly on a trial plan, where the fee is the entire amount due now". The
+	// Review row this replaces hardcoded a flat zero for every trial. The signup fee is
+	// NOT taxed in this scope - GST applies to the recurring plan price only.
+	assert.equal(
+		planDueToday({
+			plan_name: "Standard",
+			price_inr: 3500,
+			gst_percent: 18,
 			billing_cycle: "Monthly",
 			trial_days: 7,
 			signup_fee_inr: 499,
 		}),
-		"₹499 today · then ₹3,500/mo after 7 days"
+		"₹499 today · then ₹4,130/mo after 7 days"
 	);
 });
 
-test("planDueToday: a plan with no trial just shows its price", () => {
-	// planAmount deliberately omits the cycle suffix: the card already renders the big
-	// price with its own "/mo" directly above this line, and the Review row did the
-	// same before this change. Repeating it would read as a second, different price.
+test("planDueToday: a plan with no trial and no gst_percent just shows its pre-tax price", () => {
+	// Backward-compat: a plan that never carries gst_percent (or carries 0) behaves
+	// exactly as before GST existed. inr(total) collapses to inr(subtotal) here.
+	// The card already renders the big price with its own "/mo" directly above this
+	// line, so no cycle suffix is repeated here either.
 	assert.equal(
 		planDueToday({ plan_name: "Pro", price_inr: 3500, billing_cycle: "Monthly" }),
 		"₹3,500"
 	);
 });
 
-test("planDueToday: a no-trial plan with a fee shows the combined amount", () => {
+test("planDueToday: a no-trial plan shows the tax-inclusive price when gst_percent is present", () => {
+	assert.equal(
+		planDueToday({ plan_name: "Pro", price_inr: 3500, gst_percent: 18, billing_cycle: "Monthly" }),
+		"₹4,130"
+	);
+});
+
+test("planDueToday: a no-trial plan with a fee shows the combined tax-inclusive amount", () => {
 	assert.equal(
 		planDueToday({
 			plan_name: "Pro",
 			price_inr: 3500,
+			gst_percent: 18,
 			billing_cycle: "Monthly",
 			signup_fee_inr: 500,
 		}),
-		"₹4,000 today"
+		"₹4,630 today"
 	);
 });
 

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -129,7 +129,12 @@ test("isOnboardComplete reads readiness", () => {
 // --------------------------------------------------------------------------- //
 test("planPricing splits base + GST with canonical rounding", () => {
 	assert.deepEqual(
-		planPricing({ plan_name: "Standard", price_inr: 3500, gst_percent: 18, billing_cycle: "Monthly" }),
+		planPricing({
+			plan_name: "Standard",
+			price_inr: 3500,
+			gst_percent: 18,
+			billing_cycle: "Monthly",
+		}),
 		{ subtotal: 3500, gstPercent: 18, gstAmount: 630, total: 4130 }
 	);
 });
@@ -151,6 +156,22 @@ test("planPricing: no gst_percent (absent or zero) collapses to identity", () =>
 
 test("planPricing: a missing plan is a zeroed split, not a crash", () => {
 	assert.deepEqual(planPricing(null), { subtotal: 0, gstPercent: 0, gstAmount: 0, total: 0 });
+});
+
+// price_inr=3475, gst_percent=18 -> gstAmount=625.5, total=4100.5: a genuine
+// paise-precision result (gstAmount is NOT a whole rupee). The backend charges
+// this exact value (to_paise -> 410050), so the split - and everything
+// downstream of it - must carry the fraction rather than rounding it away.
+test("planPricing: a fractional GST result keeps its paise precision", () => {
+	assert.deepEqual(
+		planPricing({
+			plan_name: "Standard",
+			price_inr: 3475,
+			gst_percent: 18,
+			billing_cycle: "Monthly",
+		}),
+		{ subtotal: 3475, gstPercent: 18, gstAmount: 625.5, total: 4100.5 }
+	);
 });
 
 // --------------------------------------------------------------------------- //
@@ -200,7 +221,12 @@ test("planDueToday: a plan with no trial and no gst_percent just shows its pre-t
 
 test("planDueToday: a no-trial plan shows the tax-inclusive price when gst_percent is present", () => {
 	assert.equal(
-		planDueToday({ plan_name: "Pro", price_inr: 3500, gst_percent: 18, billing_cycle: "Monthly" }),
+		planDueToday({
+			plan_name: "Pro",
+			price_inr: 3500,
+			gst_percent: 18,
+			billing_cycle: "Monthly",
+		}),
 		"₹4,130"
 	);
 });
@@ -221,4 +247,33 @@ test("planDueToday: a no-trial plan with a fee shows the combined tax-inclusive 
 test("planDueToday: nothing to say without a plan", () => {
 	assert.equal(planDueToday(null), "");
 	assert.equal(planDueToday({}), "");
+});
+
+// A fractional total (price_inr=3475, gst_percent=18 -> total=4100.5) must
+// display the EXACT charged value, not inr()'s bare one-decimal "₹4,100.5"
+// nor a rounded-off "₹4,101" - either would diverge from the paise-precise
+// amount the backend actually charges (to_paise -> 410050).
+test("planDueToday: a fractional GST total renders its exact paise-precise value, not rounded", () => {
+	assert.equal(
+		planDueToday({
+			plan_name: "Standard",
+			price_inr: 3475,
+			gst_percent: 18,
+			billing_cycle: "Monthly",
+		}),
+		"₹4,100.50"
+	);
+});
+
+test("planDueToday: a fractional GST total on a trial plan renders exactly in the 'then' clause too", () => {
+	assert.equal(
+		planDueToday({
+			plan_name: "Standard",
+			price_inr: 3475,
+			gst_percent: 18,
+			billing_cycle: "Monthly",
+			trial_days: 7,
+		}),
+		"₹0 today · then ₹4,100.50/mo after 7 days"
+	);
 });

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -56,7 +56,7 @@ const USER_OWNED = new Set(["user", "local_restore"]);
 export const STORAGE_PROMISE_SAVED =
 	"Billing details are kept with your account for upcoming invoicing.";
 export const STORAGE_PROMISE_LOCAL =
-	"Saved in this browser for now — kept with your account once your signup is confirmed.";
+	"Saved in this browser for now. Kept with your account once your signup is confirmed.";
 
 // Transitional-storage key scheme (P0-02/C01-6): namespaced by site identity and
 // user so one site's or user's billing PII can never prefill another's on a

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -5,7 +5,6 @@ import {
 	billingStorageKey,
 	STORAGE_PROMISE_SAVED,
 	BILLING_SNAPSHOT_TTL_MS,
-	STORAGE_PROMISE_LOCAL,
 } from "./useBillingDetails.js";
 
 // A default ERP-defaults response for "Aerele" (company A) and one for "Beta".
@@ -199,27 +198,27 @@ describe("re-fetch discipline (back/continue does not lose edits)", () => {
 	});
 });
 
-describe("ack-gated storage promise (P0-01)", () => {
-	it("shows the honest local copy until billing_saved: true is observed", () => {
-		const b = useBillingDetails({ site: "s1", user: "u1" });
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
-		b.markBillingSaved(true);
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
-	});
-
+// The "ack-gated storage promise (P0-01)" suite that lived here is gone: the
+// rendered promise copy (billing.promiseCopy) is no longer shown anywhere in
+// the UI (see OnboardingView.vue B4). promiseCopy/STORAGE_PROMISE_* remain
+// exported from useBillingDetails.js only because usePaymentFlow.spec.js
+// still imports and asserts on them directly; that file was left untouched.
+//
+// Two behaviors this suite covered are NOT re-tested for promiseCopy itself,
+// but the underlying mechanics they exercised (unrelated to the promise text)
+// are still covered below: markBillingSaved's "only a literal true flips the
+// ack" guard, and the local snapshot surviving a durable ack but being
+// retired by finish().
+describe("markBillingSaved / local snapshot lifecycle", () => {
 	// Mutation guard for the ack gate: only a literal boolean true may flip it.
 	// A truthy-but-not-true ack (older admin echoing 1, or a "true" string) must
 	// NOT claim persistence.
-	it("only a literal true ack flips the promise", () => {
+	it("only a literal true ack returns true", () => {
 		const b = useBillingDetails({ site: "s1", user: "u1" });
 		expect(b.markBillingSaved(1)).toBe(false);
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
 		expect(b.markBillingSaved("true")).toBe(false);
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
 		expect(b.markBillingSaved(undefined)).toBe(false);
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
 		expect(b.markBillingSaved(true)).toBe(true);
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED);
 	});
 
 	// The durable ack used to ALSO clear the local snapshot. It no longer does, and
@@ -227,7 +226,7 @@ describe("ack-gated storage promise (P0-01)", () => {
 	// which is the call made immediately before the customer is top-level-navigated
 	// away to the checkout. Clearing there destroyed the only copy that could
 	// survive the round trip, so a customer who came back from a failed payment and
-	// pressed Back found an empty form. The promise is now kept at the END of
+	// pressed Back found an empty form. The snapshot is now retired at the END of
 	// onboarding instead, via finish().
 	it("keeps the local snapshot through a durable ack, so a checkout round trip can resume", () => {
 		const b = useBillingDetails({ site: "s1", user: "u1" });
@@ -236,8 +235,7 @@ describe("ack-gated storage promise (P0-01)", () => {
 		b.markBillingSaved(false);
 		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy(); // kept
 		b.markBillingSaved(true);
-		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_SAVED); // the promise still flips
-		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy(); // but the copy stays
+		expect(window.localStorage.getItem(b.storageKey)).toBeTruthy(); // still kept
 	});
 
 	it("retires the local snapshot when onboarding finishes", () => {

--- a/frontend/src/pages/billing/BillingPage.spec.js
+++ b/frontend/src/pages/billing/BillingPage.spec.js
@@ -472,6 +472,88 @@ describe("feature: reactivate onto any plan", () => {
 	});
 });
 
+describe("GO-LIVE: the confirm dialog shows the tax-inclusive charge, not the pre-tax price", () => {
+	// Renew/reactivate charge tax-inclusive server-side (price_inr + 18% GST).
+	// get_account_summary now additively exposes that as total_inr on both the
+	// current-plan object and each reactivation_plans row; price_inr stays the
+	// pre-tax base. The "Pay ₹X" figure the customer confirms before paying must
+	// equal what actually gets charged, so it has to read total_inr - falling
+	// back to price_inr only when an older backend has not started sending it.
+
+	it("doRenew's dialog shows total_inr (tax-inclusive) when the backend sends it, not price_inr", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				plan: {
+					plan_name: "Pro",
+					name: "pro",
+					price_inr: 100,
+					total_inr: 118,
+					billing_cycle: "Monthly",
+				},
+			})
+		);
+
+		await wrapper.vm.doRenew();
+
+		expect(wrapper.vm.pending.amount).toBe(inrLabel(118));
+		expect(wrapper.vm.pending.confirmLabel).toBe(`Pay ${inrLabel(118)}`);
+	});
+
+	it("doRenew falls back to price_inr when an older backend omits total_inr", async () => {
+		const wrapper = await mountPage(baseAccount()); // plan.price_inr: 100, no total_inr
+
+		await wrapper.vm.doRenew();
+
+		expect(wrapper.vm.pending.amount).toBe(inrLabel(100));
+		expect(wrapper.vm.pending.confirmLabel).toBe(`Pay ${inrLabel(100)}`);
+	});
+
+	it("doReactivate's dialog shows the row's total_inr (tax-inclusive), not price_inr", async () => {
+		const wrapper = await mountPage(reactivationAccount());
+		const plan = { name: "growth", plan_name: "Growth", price_inr: 500, total_inr: 590 };
+
+		wrapper.vm.doReactivate(plan);
+
+		expect(wrapper.vm.pending.amount).toBe(inrLabel(590));
+		expect(wrapper.vm.pending.confirmLabel).toBe(`Pay ${inrLabel(590)}`);
+	});
+
+	it("doReactivate falls back to price_inr when the row has no total_inr", async () => {
+		const wrapper = await mountPage(reactivationAccount());
+
+		wrapper.vm.doReactivate(GROWTH_PLAN); // no total_inr on this fixture
+
+		expect(wrapper.vm.pending.amount).toBe(inrLabel(500));
+		expect(wrapper.vm.pending.confirmLabel).toBe(`Pay ${inrLabel(500)}`);
+	});
+
+	it("what get_account_summary actually returns for renew charges the exact amount shown", async () => {
+		// End-to-end through the mocked api boundary: the amount shown pre-pay
+		// and the amount the payment call is asked to charge must be the same
+		// server truth, not two different reads of the plan object.
+		const wrapper = await mountPage(
+			baseAccount({
+				plan: {
+					plan_name: "Pro",
+					name: "pro",
+					price_inr: 100,
+					total_inr: 118,
+					billing_cycle: "Monthly",
+				},
+			})
+		);
+		api.renewPlan.mockResolvedValue(rawOkBody({ tenant_status: "ready" }));
+
+		await wrapper.vm.doRenew();
+		expect(wrapper.vm.pending.amount).toBe(inrLabel(118));
+
+		await wrapper.vm.confirmPending();
+		await flushPromises();
+
+		expect(api.renewPlan).toHaveBeenCalled();
+	});
+});
+
 describe("edge 6/8: a cheaper reactivation charges full price, never implies a prorated switch", () => {
 	it("the card's own note names full price and explicitly rules out proration/scheduling", async () => {
 		const wrapper = await mountPage(reactivationAccount());

--- a/frontend/src/pages/billing/BillingPage.spec.js
+++ b/frontend/src/pages/billing/BillingPage.spec.js
@@ -554,6 +554,46 @@ describe("GO-LIVE: the confirm dialog shows the tax-inclusive charge, not the pr
 	});
 });
 
+// #10-e review: "excl. GST" used to render unconditionally next to the current
+// plan's price, which wrongly claimed an exemption for a 0-GST plan and for
+// EVERY plan before get_plans starts sending gst_percent at all.
+describe("excl. GST label tracks the current plan's own gst_percent", () => {
+	it("is absent when gst_percent is undefined (pre-companion-PR get_plans row)", async () => {
+		const wrapper = await mountPage(baseAccount()); // no gst_percent on plan
+		expect(wrapper.text()).not.toContain("excl. GST");
+	});
+
+	it("is absent when gst_percent is 0", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				plan: {
+					plan_name: "Pro",
+					name: "pro",
+					price_inr: 100,
+					billing_cycle: "Monthly",
+					gst_percent: 0,
+				},
+			})
+		);
+		expect(wrapper.text()).not.toContain("excl. GST");
+	});
+
+	it("is present when gst_percent is a positive number", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				plan: {
+					plan_name: "Pro",
+					name: "pro",
+					price_inr: 100,
+					billing_cycle: "Monthly",
+					gst_percent: 18,
+				},
+			})
+		);
+		expect(wrapper.text()).toContain("excl. GST");
+	});
+});
+
 describe("edge 6/8: a cheaper reactivation charges full price, never implies a prorated switch", () => {
 	it("the card's own note names full price and explicitly rules out proration/scheduling", async () => {
 		const wrapper = await mountPage(reactivationAccount());

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -60,8 +60,13 @@
 								}}
 							</span>
 							<!-- GST-exclusive pricing: the price above is the base rate, not
-							     what gets charged, so this says so plainly. -->
-							<span class="text-p-sm text-ink-gray-5">excl. GST</span>
+							     what gets charged, so this says so plainly - but only for a
+							     plan that actually carries GST. A 0-GST plan, or any plan
+							     before get_plans sends gst_percent at all, must not claim an
+							     exemption it doesn't have. -->
+							<span v-if="planHasGst(currentPlan)" class="text-p-sm text-ink-gray-5"
+								>excl. GST</span
+							>
 							<Badge
 								variant="subtle"
 								:theme="statusTheme"
@@ -302,10 +307,11 @@ import {
 } from "@/onboarding/paymentCodes";
 import { payPageUrl, STATES as PAY_STATES } from "@/onboarding/paymentMachine";
 import {
-	inr,
+	inrExact,
 	statusLabel,
 	statusBadgeTheme,
 	planPriceLabel,
+	planHasGst,
 	renewalLabel,
 	cancelPillLabel,
 	cancellationNotice,
@@ -513,11 +519,15 @@ async function doUpgrade(plan) {
 		preview: () => api.previewUpgrade(plan.name),
 		title: `Upgrade to ${plan.plan_name || plan.name}`,
 		// The prorated figure is the whole point of previewing, so it leads.
+		// inrExact, not inr: prorated_inr is a real charge computed server-side
+		// (days-left * GST-inclusive daily rate) and can land on paise, same as
+		// total_inr below - inr()'s bare toLocaleString would show a stray
+		// one-decimal amount instead of the exact figure charged.
 		describe: (d) => ({
-			amount: inr(d.prorated_inr),
+			amount: inrExact(d.prorated_inr),
 			message:
 				"Charged now for the days left in your current billing period. Your new plan starts immediately.",
-			confirmLabel: `Pay ${inr(d.prorated_inr)}`,
+			confirmLabel: `Pay ${inrExact(d.prorated_inr)}`,
 		}),
 		start: () => api.startUpgrade(plan.name),
 		retry: () => doUpgrade(plan),
@@ -558,9 +568,12 @@ async function doRenew() {
 		: 0;
 	openConfirm({
 		title: "Renew subscription",
-		amount: inr(charge),
+		// inrExact, not inr: charge is total_inr (or its price_inr fallback),
+		// which can carry GST-driven paise precision - the exact figure charged
+		// has to render exactly, not with inr()'s bare toLocaleString.
+		amount: inrExact(charge),
 		message: "Renewing restores access straight away for another full billing period.",
-		confirmLabel: `Pay ${inr(charge)}`,
+		confirmLabel: `Pay ${inrExact(charge)}`,
 		run: () =>
 			runPayment({
 				key: "renew",
@@ -586,10 +599,11 @@ async function doReactivate(plan) {
 	const charge = plan.total_inr ?? plan.price_inr;
 	openConfirm({
 		title: `Renew on ${plan.plan_name || plan.name}`,
-		amount: inr(charge),
+		// inrExact, not inr: same paise-precision reasoning as doRenew above.
+		amount: inrExact(charge),
 		message:
 			"This charges the plan's full price and starts a new billing period right away. There is no credit for time already lapsed, and nothing is scheduled.",
-		confirmLabel: `Pay ${inr(charge)}`,
+		confirmLabel: `Pay ${inrExact(charge)}`,
 		run: () =>
 			runPayment({
 				key: "react:" + plan.name,

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -546,15 +546,21 @@ async function doDowngrade(plan) {
 }
 
 async function doRenew() {
-	const price = currentPlan.value ? currentPlan.value.price_inr : 0;
 	// Renew has no preview_* sibling: the amount is simply the plan's price, so
 	// the confirm step reads it off the plan rather than minting an order the
-	// customer has not agreed to yet.
+	// customer has not agreed to yet. Renew/reactivate charge tax-inclusive
+	// server-side, so the confirm dialog must show total_inr (price_inr + GST),
+	// not the pre-tax price_inr - otherwise the number shown here understates
+	// what actually gets charged. Fall back to price_inr against an older
+	// backend that has not started sending total_inr yet.
+	const charge = currentPlan.value
+		? currentPlan.value.total_inr ?? currentPlan.value.price_inr
+		: 0;
 	openConfirm({
 		title: "Renew subscription",
-		amount: inr(price),
+		amount: inr(charge),
 		message: "Renewing restores access straight away for another full billing period.",
-		confirmLabel: `Pay ${inr(price)}`,
+		confirmLabel: `Pay ${inr(charge)}`,
 		run: () =>
 			runPayment({
 				key: "renew",
@@ -574,12 +580,16 @@ async function doRenew() {
  * period left to prorate or schedule against, so it is one full-price payment
  * that starts a new period - up or down, mechanically identical. */
 async function doReactivate(plan) {
+	// Same tax-inclusive rule as doRenew above: total_inr is what gets charged,
+	// price_inr is only the pre-tax base, so the dialog leads with total_inr and
+	// falls back to price_inr against an older backend.
+	const charge = plan.total_inr ?? plan.price_inr;
 	openConfirm({
 		title: `Renew on ${plan.plan_name || plan.name}`,
-		amount: inr(plan.price_inr),
+		amount: inr(charge),
 		message:
 			"This charges the plan's full price and starts a new billing period right away. There is no credit for time already lapsed, and nothing is scheduled.",
-		confirmLabel: `Pay ${inr(plan.price_inr)}`,
+		confirmLabel: `Pay ${inr(charge)}`,
 		run: () =>
 			runPayment({
 				key: "react:" + plan.name,

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -59,6 +59,9 @@
 									)
 								}}
 							</span>
+							<!-- GST-exclusive pricing: the price above is the base rate, not
+							     what gets charged, so this says so plainly. -->
+							<span class="text-p-sm text-ink-gray-5">excl. GST</span>
 							<Badge
 								variant="subtle"
 								:theme="statusTheme"

--- a/frontend/src/pages/billing/PlanCard.spec.js
+++ b/frontend/src/pages/billing/PlanCard.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("frappe-ui", () => ({
+	Badge: { name: "Badge", props: ["label", "theme", "variant"], template: `<span />` },
+	Button: {
+		name: "Button",
+		props: ["label", "variant", "disabled", "loading"],
+		emits: ["click"],
+		template: `<button @click="$emit('click')">{{ label }}</button>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: `<span />` },
+}));
+
+import PlanCard from "./PlanCard.vue";
+
+// #10-e review (2026-08): "excl. GST" used to render unconditionally, which
+// wrongly claimed an exemption for a 0-GST plan and for EVERY plan before
+// get_plans starts sending gst_percent at all. It must track the plan's own
+// gst_percent, exactly like the Review & pay card's Subtotal/GST/Total rows.
+describe("PlanCard: excl. GST label tracks the plan's own gst_percent", () => {
+	function cycleLine(w) {
+		// The cycle text and the optional "· excl. GST" suffix share one line.
+		return w.text();
+	}
+
+	it("is absent when gst_percent is undefined (pre-companion-PR get_plans row)", () => {
+		const w = mount(PlanCard, {
+			props: { plan: { plan_name: "Pro", price_inr: 3999, billing_cycle: "Monthly" } },
+		});
+		expect(cycleLine(w)).not.toContain("excl. GST");
+	});
+
+	it("is absent when gst_percent is 0", () => {
+		const w = mount(PlanCard, {
+			props: {
+				plan: {
+					plan_name: "Pro",
+					price_inr: 3999,
+					billing_cycle: "Monthly",
+					gst_percent: 0,
+				},
+			},
+		});
+		expect(cycleLine(w)).not.toContain("excl. GST");
+	});
+
+	it("is present when gst_percent is a positive number", () => {
+		const w = mount(PlanCard, {
+			props: {
+				plan: {
+					plan_name: "Pro",
+					price_inr: 3999,
+					billing_cycle: "Monthly",
+					gst_percent: 18,
+				},
+			},
+		});
+		expect(cycleLine(w)).toContain("excl. GST");
+	});
+});

--- a/frontend/src/pages/billing/PlanCard.vue
+++ b/frontend/src/pages/billing/PlanCard.vue
@@ -29,8 +29,12 @@
 		</div>
 		<!-- GST-exclusive pricing: the headline price above is the base rate, not
 		     what gets charged, so this line says so plainly - same treatment as
-		     the onboarding plan-selection card this one mirrors. -->
-		<div class="text-xs text-ink-gray-5">{{ cycleLabel }} · excl. GST</div>
+		     the onboarding plan-selection card this one mirrors. Gated on
+		     hasGst: a 0-GST plan, or any plan before get_plans sends
+		     gst_percent at all, must not claim an exemption it doesn't have. -->
+		<div class="text-xs text-ink-gray-5">
+			{{ cycleLabel }}<template v-if="hasGst"> · excl. GST</template>
+		</div>
 
 		<ul v-if="features.length" class="mt-3.5 grid gap-2">
 			<li
@@ -68,7 +72,13 @@
 // a returning customer recognises the surface they first bought on.
 import { computed } from "vue";
 import { Badge, Button, FeatherIcon } from "frappe-ui";
-import { planAmount, planSuffix, planFeatures, planCycleLabel } from "@/account/format.js";
+import {
+	planAmount,
+	planSuffix,
+	planFeatures,
+	planCycleLabel,
+	planHasGst,
+} from "@/account/format.js";
 
 const props = defineProps({
 	plan: { type: Object, required: true },
@@ -84,4 +94,5 @@ const emit = defineEmits(["action"]);
 
 const features = computed(() => planFeatures(props.plan));
 const cycleLabel = computed(() => planCycleLabel(props.plan));
+const hasGst = computed(() => planHasGst(props.plan));
 </script>

--- a/frontend/src/pages/billing/PlanCard.vue
+++ b/frontend/src/pages/billing/PlanCard.vue
@@ -27,7 +27,10 @@
 				{{ planSuffix(plan.price_inr, plan.billing_cycle) }}</span
 			>
 		</div>
-		<div class="text-xs text-ink-gray-5">{{ cycleLabel }}</div>
+		<!-- GST-exclusive pricing: the headline price above is the base rate, not
+		     what gets charged, so this line says so plainly - same treatment as
+		     the onboarding plan-selection card this one mirrors. -->
+		<div class="text-xs text-ink-gray-5">{{ cycleLabel }} · excl. GST</div>
 
 		<ul v-if="features.length" class="mt-3.5 grid gap-2">
 			<li

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -428,3 +428,34 @@ describe("GST tax breakdown: Review & pay Subtotal/GST/Total rows", () => {
 		expect(text).not.toContain("GST (");
 	});
 });
+
+describe("B3: gateway picker shows on trial plans", () => {
+	it("a trial plan with one available provider still renders the gateway chooser", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "standard",
+				plan_name: "Standard",
+				price_inr: 3500,
+				gst_percent: 18,
+				billing_cycle: "Monthly",
+				trial_days: 7,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.availableProviders = ["razorpay"];
+		wrapper.vm.state.paymentProvider = "razorpay";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.isTrialPlan).toBe(true);
+		expect(wrapper.vm.showProviderChooser).toBe(true);
+		expect(wrapper.find(".ob-provseg").exists()).toBe(true);
+		expect(wrapper.find('[aria-label="Payment method: Razorpay"]').exists()).toBe(true);
+	});
+});

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -351,3 +351,80 @@ describe("jarvis#297 P0-2a: verification is no longer a dead end", () => {
 		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// GST tax breakdown (2026-08): Review & pay card's Subtotal/GST/Total rows.
+// ---------------------------------------------------------------------------
+describe("GST tax breakdown: Review & pay Subtotal/GST/Total rows", () => {
+	it("a trial Standard plan with gst_percent 18 shows the base/GST/total split and a ₹0 due-today", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "standard",
+				plan_name: "Standard",
+				price_inr: 3500,
+				gst_percent: 18,
+				billing_cycle: "Monthly",
+				trial_days: 7,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		// The default pay machine state is STATES.REVIEW (initialState()), so a fresh
+		// mount with none of the paid/verify/confirming/busy/recovery/maintenance
+		// branches triggered lands on the Review & pay summary card.
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.pricing).toEqual({
+			subtotal: 3500,
+			gstPercent: 18,
+			gstAmount: 630,
+			total: 4130,
+		});
+		expect(wrapper.vm.dueTodayLabel).toBe("₹0 today · then ₹4,130/mo after 7 days");
+
+		const text = wrapper.text();
+		const html = wrapper.html();
+		expect(text).toContain("Subtotal");
+		expect(text).toContain("GST (18%)");
+		expect(text).toContain("₹630");
+		// A plain toContain("Total") would also pass if the Total row went missing,
+		// since "Subtotal" and "₹4,130" (from the due-today label) are already on
+		// the page - match the row's own span so it verifies the row itself renders.
+		expect(html).toMatch(/<span[^>]*class="text-ink-gray-5">Total<\/span>/);
+		expect(text).toContain("₹4,130");
+		expect(text).toContain("Due today");
+		expect(text).toContain("₹0 today");
+	});
+
+	it("a plan without gst_percent renders no Subtotal/GST/Total rows", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "legacy",
+				plan_name: "Legacy",
+				price_inr: 3500,
+				billing_cycle: "Monthly",
+				trial_days: 0,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "legacy";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.pricing.gstPercent).toBe(0);
+		const text = wrapper.text();
+		expect(text).not.toContain("Subtotal");
+		expect(text).not.toContain("GST (");
+	});
+});

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -427,6 +427,95 @@ describe("GST tax breakdown: Review & pay Subtotal/GST/Total rows", () => {
 		expect(text).not.toContain("Subtotal");
 		expect(text).not.toContain("GST (");
 	});
+
+	// #10-e: gstAmount/total can be a genuine fraction (price_inr=3475,
+	// gst_percent=18 -> gstAmount=625.5, total=4100.5), and the backend charges
+	// exactly that paise-precise value (to_paise -> 410050). The Review card
+	// must render the SAME value it will be charged - inrExact, not inr()'s
+	// bare one-decimal "₹4,100.5" and never a rounded-off "₹4,101".
+	it("a fractional GST split renders its exact paise-precise value on every row", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "standard",
+				plan_name: "Standard",
+				price_inr: 3475,
+				gst_percent: 18,
+				billing_cycle: "Monthly",
+				trial_days: 0,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		expect(wrapper.vm.pricing).toEqual({
+			subtotal: 3475,
+			gstPercent: 18,
+			gstAmount: 625.5,
+			total: 4100.5,
+		});
+		expect(wrapper.vm.dueTodayLabel).toBe("₹4,100.50");
+
+		const text = wrapper.text();
+		expect(text).toContain("₹3,475");
+		expect(text).toContain("₹625.50");
+		expect(text).toContain("₹4,100.50");
+		// Neither the collapsed one-decimal form nor a rounded integer may appear.
+		expect(text).not.toContain("₹625.5 ");
+		expect(text).not.toContain("₹4,101");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #10-e review: the plan-selection card's "excl. GST" caveat must track the
+// plan's own gst_percent, not render unconditionally.
+// ---------------------------------------------------------------------------
+describe("Plan step: excl. GST label tracks the plan's own gst_percent", () => {
+	async function mountOnPlanStep(plan) {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [plan];
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		return wrapper;
+	}
+
+	it("is absent when gst_percent is undefined (pre-companion-PR get_plans row)", async () => {
+		const wrapper = await mountOnPlanStep({
+			name: "legacy",
+			plan_name: "Legacy",
+			price_inr: 3999,
+			billing_cycle: "Monthly",
+		});
+		expect(wrapper.text()).not.toContain("excl. GST");
+	});
+
+	it("is absent when gst_percent is 0", async () => {
+		const wrapper = await mountOnPlanStep({
+			name: "zero-gst",
+			plan_name: "Zero GST",
+			price_inr: 3999,
+			billing_cycle: "Monthly",
+			gst_percent: 0,
+		});
+		expect(wrapper.text()).not.toContain("excl. GST");
+	});
+
+	it("is present when gst_percent is a positive number", async () => {
+		const wrapper = await mountOnPlanStep({
+			name: "standard",
+			plan_name: "Standard",
+			price_inr: 3999,
+			billing_cycle: "Monthly",
+			gst_percent: 18,
+		});
+		expect(wrapper.text()).toContain("excl. GST");
+	});
 });
 
 describe("B3: gateway picker shows on trial plans", () => {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -209,11 +209,17 @@
 											>
 										</div>
 										<!-- GST-exclusive pricing: the headline price above is the base
-										     rate, not what gets charged, so this line says so plainly.
+										     rate, not what gets charged, so this line says so plainly -
+										     but only for a plan that actually carries GST (planHasGst).
+										     A 0-GST plan, and every plan before get_plans sends
+										     gst_percent at all, must not claim "excl. GST" they don't owe.
 										     The due-today line right below IS tax-inclusive (it's a real
 										     charge amount) - only the base rate needs the caveat. -->
 										<div class="text-xs text-ink-gray-5">
-											{{ planCycleLabel(p) }} · excl. GST
+											{{ planCycleLabel(p)
+											}}<template v-if="planHasGst(p)">
+												· excl. GST</template
+											>
 										</div>
 										<!-- #671: what is due TODAY, on the card. The customer
 										     used to meet this only on Review, a screen after
@@ -483,8 +489,8 @@
 									:disabled="state.payBusy"
 									@click="startReconnect"
 								>
-									Reconnect instead
-								</button>. We'll email a code to confirm it's you. Nothing to pay again.
+									Reconnect instead</button
+								>. We'll email a code to confirm it's you. Nothing to pay again.
 							</p>
 							<p
 								v-else-if="state.reconnectNeedsCompany"
@@ -816,8 +822,8 @@
 									>
 										Still not resolved after a few checks?
 										<button class="ob-link" @click="onPayAction(A.SUPPORT)">
-											Contact support
-										</button>. We'll place it for you. Please don't pay again.
+											Contact support</button
+										>. We'll place it for you. Please don't pay again.
 									</p>
 									<!-- X7 (defensive): Reconnect is offered but no identity exists to send
 										 it with. Rather than a dead disabled button, ask for the email and
@@ -996,16 +1002,17 @@
 										>
 											<span class="text-ink-gray-5">Subtotal</span
 											><b class="font-medium text-ink-gray-9">{{
-												inr(pricing.subtotal)
+												inrExact(pricing.subtotal)
 											}}</b>
 										</div>
 										<div
 											v-if="pricing.gstPercent"
 											class="flex items-center justify-between gap-3 border-b border-outline-gray-1 px-4 py-3 text-p-sm"
 										>
-											<span class="text-ink-gray-5">GST ({{ pricing.gstPercent }}%)</span
+											<span class="text-ink-gray-5"
+												>GST ({{ pricing.gstPercent }}%)</span
 											><b class="font-medium text-ink-gray-9">{{
-												inr(pricing.gstAmount)
+												inrExact(pricing.gstAmount)
 											}}</b>
 										</div>
 										<div
@@ -1014,7 +1021,7 @@
 										>
 											<span class="text-ink-gray-5">Total</span
 											><b class="font-medium text-ink-gray-9">{{
-												inr(pricing.total)
+												inrExact(pricing.total)
 											}}</b>
 										</div>
 										<div
@@ -1229,9 +1236,9 @@
 								<div class="ob-head">
 									<h1>Enter your reconnect code</h1>
 									<p>
-										Sent to <b>{{ state.email || "your email" }}</b>. Connects
-										this site to your existing subscription, nothing to pay
-										again.
+										Sent to <b>{{ state.email || "your email" }}</b
+										>. Connects this site to your existing subscription,
+										nothing to pay again.
 									</p>
 								</div>
 								<input
@@ -1626,7 +1633,7 @@ import {
 	planPricing,
 	planSubtitleFor,
 } from "@/onboarding/steps";
-import { inr, planAmount, planSuffix } from "@/account/format";
+import { inrExact, planAmount, planSuffix, planHasGst } from "@/account/format";
 import {
 	isReadyForChat,
 	getLlmApplyOperation,
@@ -2533,7 +2540,10 @@ const paySummaryRows = computed(() => {
 	if (s.dueTodayInr != null && !Number.isNaN(s.dueTodayInr)) {
 		rows.push({
 			label: "Amount",
-			value: paySummaryTrial.value ? "₹0 today" : inr(s.dueTodayInr),
+			// inrExact, not inr: dueTodayInr is a real charge (server-computed,
+			// GST-inclusive) and can carry paise precision - same reasoning as
+			// planDueToday/the subtotal-GST-total rows above.
+			value: paySummaryTrial.value ? "₹0 today" : inrExact(s.dueTodayInr),
 		});
 	}
 	const ref = maskedIntentRef.value;

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -393,9 +393,6 @@
 									>
 										Billing
 									</div>
-									<div class="col-span-2 -mt-1 text-p-xs text-ink-gray-5">
-										{{ billing.promiseCopy.value }}
-									</div>
 									<FormControl
 										class="col-span-2"
 										type="text"
@@ -483,15 +480,14 @@
 									@click="startReconnect"
 								>
 									Reconnect instead
-								</button>
-								— we'll email a code to confirm it's you. Nothing to pay again.
+								</button>. We'll email a code to confirm it's you. Nothing to pay again.
 							</p>
 							<p
 								v-else-if="state.reconnectNeedsCompany"
 								class="mx-auto mt-5 max-w-[620px] text-center text-p-sm text-ink-gray-5"
 							>
-								This email already has a subscription under a different company —
-								enter that company above to reconnect it instead of paying again.
+								This email already has a subscription under a different company.
+								Enter that company above to reconnect it instead of paying again.
 							</p>
 							<div class="ob-foot">
 								<button class="ob-back" @click="goBack">
@@ -817,8 +813,7 @@
 										Still not resolved after a few checks?
 										<button class="ob-link" @click="onPayAction(A.SUPPORT)">
 											Contact support
-										</button>
-										— we'll place it for you. Please don't pay again.
+										</button>. We'll place it for you. Please don't pay again.
 									</p>
 									<!-- X7 (defensive): Reconnect is offered but no identity exists to send
 										 it with. Rather than a dead disabled button, ask for the email and
@@ -916,7 +911,7 @@
 										<h1>Payments are paused right now</h1>
 										<p>
 											We're doing some scheduled maintenance on secure
-											payments. Nothing has been charged — please check back
+											payments. Nothing has been charged. Please check back
 											shortly, or contact support if you need to get set up
 											today.
 										</p>
@@ -937,7 +932,7 @@
 										<p>
 											{{
 												isTrialPlan
-													? "Confirm the details below. You'll authorize auto-pay securely — nothing is charged until your trial ends."
+													? "Confirm the details below. You'll authorize auto-pay securely. Nothing is charged until your trial ends."
 													: "Confirm the details below. You'll complete payment securely."
 											}}
 										</p>
@@ -1027,15 +1022,14 @@
 											}}</b>
 										</div>
 									</div>
-									<!-- Plan 01: the billing promise + an Edit affordance under the review
-										 rows. Edit returns to Details WITHOUT touching the payment intent;
-										 once an intent exists the subsequent Continue persists through the
-										 authenticated update_billing facade, never a fresh guest signup. -->
+									<!-- Plan 01: an Edit affordance under the review rows. Edit returns to
+										 Details WITHOUT touching the payment intent; once an intent exists
+										 the subsequent Continue persists through the authenticated
+										 update_billing facade, never a fresh guest signup. -->
 									<div
 										v-if="billing.reviewRows.value.length"
-										class="mx-auto mt-2 flex max-w-[560px] items-center justify-between gap-3 text-p-xs text-ink-gray-5"
+										class="mx-auto mt-2 flex max-w-[560px] items-center justify-end gap-3 text-p-xs text-ink-gray-5"
 									>
-										<span>{{ billing.promiseCopy.value }}</span>
 										<button
 											class="ob-link shrink-0"
 											:disabled="state.payBusy"
@@ -1176,7 +1170,7 @@
 											@click="startReconnect"
 										/>
 										<p class="mt-1.5 text-p-sm text-ink-gray-5">
-											We'll email a code to {{ payEmail }} — enter it to
+											We'll email a code to {{ payEmail }}. Enter it to
 											connect this site to your existing subscription.
 											Nothing to pay again.
 										</p>
@@ -1231,7 +1225,7 @@
 								<div class="ob-head">
 									<h1>Enter your reconnect code</h1>
 									<p>
-										Sent to <b>{{ state.email || "your email" }}</b> — connects
+										Sent to <b>{{ state.email || "your email" }}</b>. Connects
 										this site to your existing subscription, nothing to pay
 										again.
 									</p>
@@ -1536,7 +1530,7 @@
 									<div class="ob-head">
 										<h1>Connect an AI model</h1>
 										<p>
-											Choose which AI powers {{ agentName }} — a chat
+											Choose which AI powers {{ agentName }}, a chat
 											subscription or your own API key. You can change this
 											anytime in Settings → AI models.
 										</p>
@@ -1939,7 +1933,9 @@ const isTrialPlan = computed(() => trialDays.value > 0);
 // The chooser is only a choice when there is more than one gateway. With a
 // single enabled gateway a radiogroup of one is noise: it asks the customer to
 // decide something already decided, and the "Secured by X" line below already
-// names it. Free/trial plans collect no payment at all.
+// names it. A trial still authorizes a mandate now (the free-plan "no payment
+// at all" model was removed), so the gateway chooser must show on trial plans
+// too.
 // The only gateways this wizard can render a chip for and hand a sheet to. The
 // chooser template hard-codes a Razorpay and a Cashfree chip and the checkout
 // dispatcher knows only those two families, so this is the closed set the
@@ -1974,9 +1970,7 @@ const providerChoices = computed(() => state.availableProviders || []);
 // is weaker assurance than the brand they are about to be handed to. A single
 // gateway therefore renders as a NON-INTERACTIVE chip - present and legible,
 // with nothing to decide.
-const showProviderChooser = computed(
-	() => !isTrialPlan.value && providerChoices.value.length >= 1
-);
+const showProviderChooser = computed(() => providerChoices.value.length >= 1);
 const isSingleProvider = computed(() => providerChoices.value.length === 1);
 const providerAvailable = (p) => providerChoices.value.includes(p);
 // Clicking is only meaningful when there is something to switch to. Guarding
@@ -3481,7 +3475,7 @@ function onOpUpdate(ui) {
 	if (phase === OP_PHASE.FINISHING) {
 		state.connectPhase = "finishing";
 		state.connectMessage = "";
-		state.finishSubtitle = "Saved. Finishing setup — this can take a minute.";
+		state.finishSubtitle = "Saved. Finishing setup, this can take a minute.";
 	} else if (phase === OP_PHASE.RETRY) {
 		state.connectPhase = "retry";
 		state.connectMessage = (ui && ui.message) || "We hit a snag applying your AI connection.";

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -208,8 +208,12 @@
 												}}</span
 											>
 										</div>
+										<!-- GST-exclusive pricing: the headline price above is the base
+										     rate, not what gets charged, so this line says so plainly.
+										     The due-today line right below IS tax-inclusive (it's a real
+										     charge amount) - only the base rate needs the caveat. -->
 										<div class="text-xs text-ink-gray-5">
-											{{ planCycleLabel(p) }}
+											{{ planCycleLabel(p) }} · excl. GST
 										</div>
 										<!-- #671: what is due TODAY, on the card. The customer
 										     used to meet this only on Review, a screen after

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -992,6 +992,33 @@
 											}}</b>
 										</div>
 										<div
+											v-if="pricing.gstPercent"
+											class="flex items-center justify-between gap-3 border-b border-outline-gray-1 px-4 py-3 text-p-sm"
+										>
+											<span class="text-ink-gray-5">Subtotal</span
+											><b class="font-medium text-ink-gray-9">{{
+												inr(pricing.subtotal)
+											}}</b>
+										</div>
+										<div
+											v-if="pricing.gstPercent"
+											class="flex items-center justify-between gap-3 border-b border-outline-gray-1 px-4 py-3 text-p-sm"
+										>
+											<span class="text-ink-gray-5">GST ({{ pricing.gstPercent }}%)</span
+											><b class="font-medium text-ink-gray-9">{{
+												inr(pricing.gstAmount)
+											}}</b>
+										</div>
+										<div
+											v-if="pricing.gstPercent"
+											class="flex items-center justify-between gap-3 border-b border-outline-gray-1 px-4 py-3 text-p-sm"
+										>
+											<span class="text-ink-gray-5">Total</span
+											><b class="font-medium text-ink-gray-9">{{
+												inr(pricing.total)
+											}}</b>
+										</div>
+										<div
 											class="flex items-center justify-between gap-3 bg-surface-gray-1 px-4 py-3 text-p-sm"
 										>
 											<span class="text-ink-gray-5">Due today</span
@@ -1598,6 +1625,7 @@ import {
 	nextStep,
 	prevStep,
 	planDueToday,
+	planPricing,
 	planSubtitleFor,
 } from "@/onboarding/steps";
 import { inr, planAmount, planSuffix } from "@/account/format";
@@ -2033,6 +2061,10 @@ const planRowLabel = computed(() => {
 // #671: planDueToday lives in onboarding/steps.js so the Plan cards and this Review
 // row read ONE definition, and so it is unit-testable under node --test.
 const dueTodayLabel = computed(() => planDueToday(selectedPlan.value));
+// GST tax breakdown (2026-08): base/GST/total split for the Review card's
+// Subtotal/GST/Total rows. Same canonical formula as planDueToday's `total` -
+// planPricing is the one place that math lives.
+const pricing = computed(() => planPricing(selectedPlan.value));
 
 function goNext() {
 	state.step = nextStep(steps.value, state.step);


### PR DESCRIPTION
## Summary

The onboarding **Review & pay** page now shows a Subtotal / GST / Total split, and every amount a customer sees before paying — checkout, renew, reactivate — is the **tax-inclusive** total, so quotes match what's actually charged. Plan-selection and account plan prices keep the base price with an **"excl. GST"** label.

This is the **customer-app half** of GST-exclusive pricing. It depends on the companion admin PR (`jarvis-admin-v2`, branch `feat/gst-tax-breakdown`) that adds `gst_percent` to `get_plans` and makes the gateway charges tax-inclusive — **merge admin first**, or the frontend reads a field `develop` doesn't yet return.

Also bundled (small onboarding fixes found while here):
- Payment **gateway picker now shows on trial plans** (was hidden by a stale free-plan guard).
- Removed the "saved in this browser" storage note.
- Em-dash sweep across onboarding copy.

Full frontend suite **1140/1140 green** locally (with the `--localstorage-file` flag that works around the pre-existing Node-v26 jsdom issue).

<details><summary>Files / mechanism</summary>

- `onboarding/steps.js` — `planPricing()` canonical GST math (`gst = round(base*pct/100, 2)`, matches backend rounding).
- `views/OnboardingView.vue` — Subtotal/GST/Total rows on Review & pay; gateway-picker fix; "excl. GST" on the plan-selection card; removed storage note.
- `pages/billing/BillingPage.vue` — renew/reactivate confirm dialogs read the new tax-inclusive `total_inr` (falls back to `price_inr`).
- `pages/billing/PlanCard.vue`, `components/settings/PlanBillingPane.vue` — "excl. GST" label.
</details>

## Pre-merge checklist

- [x] **CI is green** — all 8 hosted GitHub Actions checks pass (lint, tests 1-4, coverage, frontend-tests, frontend-build)
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests (frontend suite green locally)
- [x] I self-reviewed the diff
