### PR TITLE
feat(tools): report_pdf — render a saved Report to a downloadable PDF

### DIFF
--- a/jarvis/tests/test_report_pdf.py
+++ b/jarvis/tests/test_report_pdf.py
@@ -1,0 +1,290 @@
+"""Tests for the report_pdf tool (plan: 2026-08-10-report-to-pdf-tool).
+
+report_pdf runs a saved Report, renders columns+rows to a PDF, stores it as a
+private File, and returns the download_pdf envelope. The HTML-to-PDF byte step
+(frappe.utils.pdf.get_pdf, which shells out to wkhtmltopdf) is stubbed in setUp
+so the suite is hermetic: CI runners have no wkhtmltopdf binary, and producing
+the actual PDF bytes is Frappe's job, not this tool's. Every render test still
+exercises report_pdf's full logic (report run, HTML build, File save, and the
+returned envelope). One test per edge case from the plan.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools.report_pdf import (
+	_cell,
+	_normalise_columns,
+	_render_html,
+	_safe_filename,
+	report_pdf,
+)
+
+_ENVELOPE_KEYS = {"file_url", "filename", "title", "mime_type", "size_bytes", "name"}
+
+
+def _pdf_bytes(file_name: str) -> bytes:
+	raw = frappe.get_doc("File", file_name).get_content()
+	return raw if isinstance(raw, (bytes, bytearray)) else str(raw).encode("latin-1", "ignore")
+
+
+def _stub_pdf_bytes() -> bytes:
+	"""A real, minimal one-page PDF for stubbing get_pdf when wkhtmltopdf is absent
+	(CI runners have no binary). It has to genuinely parse: Frappe's File.save runs
+	pdf_contains_js -> pypdf.PdfReader over the content, so a "%PDF-" string literal
+	is rejected with "startxref not found". Built with pypdf, a Frappe dependency
+	present wherever Frappe runs, including CI."""
+	from io import BytesIO
+
+	from pypdf import PdfWriter
+
+	writer = PdfWriter()
+	writer.add_blank_page(width=200, height=200)
+	buf = BytesIO()
+	writer.write(buf)
+	return buf.getvalue()
+
+
+class TestReportPdf(FrappeTestCase):
+	"""Query Report fixtures over `tabUser` (readable by a System User)."""
+
+	DATA = "JV RP Test Data"
+	EMPTY = "JV RP Test Empty"
+	TOTAL = "JV RP Test Total"
+	BUILDER = "JV RP Test Builder"
+	WIDE = "JV RP Test Wide"
+	MISSFILTER = "JV RP Test MissFilter"
+	PREPARED = "JV RP Test Prepared"
+
+	def setUp(self):
+		self._report(
+			self.DATA,
+			query='SELECT name AS "User:Data:220", enabled AS "Enabled:Int:80" '
+			"FROM tabUser ORDER BY creation LIMIT 5",
+		)
+		self._report(
+			self.EMPTY,
+			query='SELECT name AS "User:Data:220" FROM tabUser WHERE name = "zzz-nobody-zzz"',
+		)
+		self._report(
+			self.TOTAL,
+			add_total_row=1,
+			query='SELECT name AS "User:Data:220", 1 AS "Count:Int:80" '
+			"FROM tabUser ORDER BY creation LIMIT 3",
+		)
+		self._report(self.BUILDER, report_type="Report Builder")
+		# 7 columns > the landscape threshold, so this exercises the auto-landscape path.
+		self._report(
+			self.WIDE,
+			query='SELECT name AS "A:Data:100", name AS "B:Data:100", name AS "C:Data:100", '
+			'name AS "D:Data:100", name AS "E:Data:100", name AS "F:Data:100", '
+			'name AS "G:Data:100" FROM tabUser ORDER BY creation LIMIT 3',
+		)
+		# References a %(since)s filter never supplied -> the report run fails.
+		self._report(
+			self.MISSFILTER,
+			query='SELECT name AS "User:Data:220" FROM tabUser WHERE creation > %(since)s LIMIT 5',
+		)
+		# prepared_report=1 would return a queued async stub; the tool passes
+		# ignore_prepared_report=True to force live data.
+		self._report(
+			self.PREPARED,
+			prepared_report=1,
+			query='SELECT name AS "User:Data:220" FROM tabUser ORDER BY creation LIMIT 3',
+		)
+		# CI runners have no wkhtmltopdf, so stub the HTML-to-PDF byte step with a
+		# real, minimal PDF (see _stub_pdf_bytes: it must actually parse, as File.save
+		# validates PDF content). report_pdf imports get_pdf from frappe.utils.pdf at
+		# call time, so patch it there - test_empty_pdf_bytes_raises re-patches the
+		# same target locally and that inner patch wins for the empty-bytes case.
+		_pdf = patch("frappe.utils.pdf.get_pdf", return_value=_stub_pdf_bytes())
+		_pdf.start()
+		self.addCleanup(_pdf.stop)
+
+	def _report(self, name, report_type="Query Report", add_total_row=0, query=None, prepared_report=0):
+		if frappe.db.exists("Report", name):
+			return
+		doc = {
+			"doctype": "Report",
+			"report_name": name,
+			"ref_doctype": "User",
+			"report_type": report_type,
+			"is_standard": "No",
+			"add_total_row": add_total_row,
+			"prepared_report": prepared_report,
+		}
+		if query:
+			doc["query"] = query
+		frappe.get_doc(doc).insert(ignore_permissions=True)
+
+	# ── happy path ────────────────────────────────────────────────────────────
+	def test_happy_path_produces_a_private_pdf(self):
+		out = report_pdf(self.DATA)
+		self.assertEqual(set(out), _ENVELOPE_KEYS)
+		self.assertEqual(out["mime_type"], "application/pdf")
+		self.assertEqual(out["title"], self.DATA)
+		self.assertGreater(out["size_bytes"], 0)
+		file_doc = frappe.get_doc("File", out["name"])
+		self.assertEqual(file_doc.is_private, 1)
+		# The real proof: the stored bytes are a PDF (list-of-lists rows rendered).
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+
+	def test_custom_title_overrides_the_report_name(self):
+		out = report_pdf(self.DATA, title="Q3 Users")
+		self.assertEqual(out["title"], "Q3 Users")
+
+	# ── zero rows ─────────────────────────────────────────────────────────────
+	def test_zero_rows_still_produces_a_valid_pdf(self):
+		"""An empty report is a PDF with a 'No data' note, never an error or a
+		blank/zero-byte file."""
+		out = report_pdf(self.EMPTY)
+		self.assertGreater(out["size_bytes"], 0)
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+
+	# ── total row ─────────────────────────────────────────────────────────────
+	def test_add_total_row_report_renders(self):
+		"""query_report.run appends the total as the last row; the PDF must still
+		generate (we style it, never recompute it)."""
+		out = report_pdf(self.TOTAL)
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+
+	# ── orientation ───────────────────────────────────────────────────────────
+	def test_explicit_landscape_succeeds(self):
+		out = report_pdf(self.DATA, orientation="landscape")
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+
+	def test_invalid_orientation_raises(self):
+		with self.assertRaises(InvalidArgumentError):
+			report_pdf(self.DATA, orientation="sideways")
+
+	# ── bad input ─────────────────────────────────────────────────────────────
+	def test_unknown_report_raises(self):
+		with self.assertRaises(InvalidArgumentError):
+			report_pdf("No Such Report ZZZ")
+
+	def test_empty_report_name_raises(self):
+		with self.assertRaises(InvalidArgumentError):
+			report_pdf("")
+
+	# ── report builder refused ────────────────────────────────────────────────
+	def test_report_builder_is_refused_with_guidance(self):
+		with self.assertRaises(InvalidArgumentError) as cm:
+			report_pdf(self.BUILDER)
+		self.assertIn("list view", str(cm.exception))
+
+	# ── markup in the title must not crash the File save (reviewer M3) ─────────
+	def test_markup_title_does_not_crash(self):
+		"""A title carrying markup (e.g. '<b>') derives a filename Frappe's File
+		sanitiser would otherwise reject with 'File name cannot have /'. It must
+		produce a valid PDF, not a 500."""
+		out = report_pdf(self.DATA, title="Flow <b>Test</b> / Q3")
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+		# The stored filename is sanitised to safe characters.
+		self.assertNotIn("/", out["filename"])
+		self.assertNotIn("<", out["filename"])
+
+	def test_safe_filename_strips_markup_slashes_and_never_empties(self):
+		self.assertEqual(_safe_filename("Flow <b>x</b>/y"), "Flow-b-x-b-y")
+		self.assertEqual(_safe_filename("////"), "report")
+		self.assertEqual(_safe_filename(""), "report")
+		self.assertLessEqual(len(_safe_filename("z" * 500)), 80)
+
+	# ── get_pdf yields no bytes -> clean error (reviewer M1, edge case 10) ─────
+	def test_empty_pdf_bytes_raises(self):
+		with patch("frappe.utils.pdf.get_pdf", return_value=b""):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				report_pdf(self.DATA)
+		self.assertIn("no content", str(cm.exception))
+
+	# ── a report that cannot run (missing filter) -> clean error (reviewer M2) ─
+	def test_missing_filter_raises_invalid_argument(self):
+		"""A report referencing a %(since)s filter with no value raises deep in
+		Frappe (TypeError: format requires a mapping); the tool must surface it as
+		InvalidArgumentError, not a 500."""
+		with self.assertRaises(InvalidArgumentError):
+			report_pdf(self.MISSFILTER)
+
+	# ── wide report auto-selects landscape and still renders (reviewer m3) ─────
+	def test_wide_report_renders(self):
+		out = report_pdf(self.WIDE)
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+
+	# ── zero-row render carries the explicit 'No data' marker (reviewer m2) ────
+	def test_render_html_zero_rows_shows_no_data_marker(self):
+		html = _render_html(
+			"T", {}, [{"fieldname": "a", "label": "A", "fieldtype": "Data", "options": ""}], [], False
+		)
+		self.assertIn("No data for these filters", html)
+
+	# ── prepared/async report is forced to live data (reviewer m1) ────────────
+	def test_prepared_report_renders_live(self):
+		out = report_pdf(self.PREPARED)
+		self.assertEqual(_pdf_bytes(out["name"])[:5], b"%PDF-")
+
+	# ── row-shape normalisation (covers the list-of-DICTS path a Script Report
+	#    produces, without needing a Script Report module fixture) ──────────────
+	def test_cell_reads_both_dict_and_list_rows(self):
+		cols = _normalise_columns([{"fieldname": "a", "label": "A", "fieldtype": "Data"}, "B:Int:80"])
+		self.assertEqual(cols[0]["fieldname"], "a")
+		self.assertEqual(cols[1]["label"], "B")
+		# dict row keyed by fieldname
+		self.assertEqual(_cell({"a": "x", "b": 3}, cols[0], 0), "x")
+		# list row read positionally
+		self.assertEqual(_cell(["x", 3], cols[1], 1), 3)
+		# short list row does not IndexError
+		self.assertIsNone(_cell(["only-one"], cols[1], 1))
+
+
+class TestReportPdfPermission(FrappeTestCase):
+	"""The security test: a user who cannot run the report gets
+	PermissionDeniedError and NO File is produced. Uses a restricted, non-admin
+	System User over an ERPNext doctype it cannot read (Administrator bypasses
+	permissions and would hide the bug)."""
+
+	USER = "jarvis-report-pdf-perm@example.com"
+	REPORT = "JV RP Perm Probe"
+
+	def setUp(self):
+		if not frappe.db.exists("DocType", "Sales Invoice"):
+			self.skipTest("erpnext not installed on this site")
+		if not frappe.db.exists("User", self.USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": self.USER,
+					"first_name": "report-pdf-perm",
+					"send_welcome_email": 0,
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True)
+		if not frappe.db.exists("Report", self.REPORT):
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"report_name": self.REPORT,
+					"ref_doctype": "Sales Invoice",
+					"report_type": "Query Report",
+					"is_standard": "No",
+					"query": 'SELECT name AS "Invoice:Data:220" FROM `tabSales Invoice` LIMIT 5',
+				}
+			).insert(ignore_permissions=True)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def test_restricted_user_is_denied_and_no_file_is_created(self):
+		frappe.set_user(self.USER)
+		with self.assertRaises(PermissionDeniedError):
+			report_pdf(self.REPORT)
+		# The denial happens before save_file. Assert AS ADMINISTRATOR - the
+		# restricted user cannot list Files, so an empty result under that user
+		# would prove nothing.
+		frappe.set_user("Administrator")
+		self.assertEqual(
+			frappe.get_all(
+				"File",
+				filters={"attached_to_doctype": "Report", "attached_to_name": self.REPORT},
+			),
+			[],
+		)

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -57,6 +57,7 @@ _TOOL_NAMES: tuple[str, ...] = (
 	# Tier 1 artifact producers: hand the agent a file/URL the customer
 	# can act on, instead of a wall of JSON.
 	"download_pdf",
+	"report_pdf",
 	"export_excel",
 	# Composed report/summary (not a single record) → downloadable PDF / HTML /
 	# PNG. download_pdf prints an existing record; this renders agent-composed

--- a/jarvis/tools/report_pdf.py
+++ b/jarvis/tools/report_pdf.py
@@ -1,0 +1,267 @@
+"""Render a saved Frappe Report to a PDF and store it as a private File so the
+chat surface can hand the user a download link.
+
+This is the *report* analogue of ``download_pdf``. ``download_pdf`` only handles a
+single document (``doctype`` + ``name``) via ``frappe.get_print`` + a Print
+Format. A report has neither a document nor a print format — it is ``columns`` +
+a rowset — so this executes the report, builds an HTML table from the result, and
+renders it with ``frappe.utils.pdf.get_pdf``. The saved File and the return
+envelope are byte-identical to ``download_pdf``'s, so the chat renders the same
+download card with **no frontend change**.
+
+Without this tool the model has no way to satisfy "give me this report as a PDF":
+it improvises with the container's ``browser``/``exec`` tools and writes the PDF
+onto the container filesystem, where it never becomes a Frappe File and never
+surfaces in chat ("Done, I generated the PDF" — but nothing to download).
+
+Permission: report execution goes through the same ``frappe.desk.query_report.run``
+call ``run_report`` uses, so Frappe applies report-level permission and
+``validate_filters_permissions`` and raises ``frappe.PermissionError``, which we
+translate to ``PermissionDeniedError`` — one exception contract across tools.
+
+Frappe 15/16: ``query_report.run`` / ``get_pdf`` / ``save_file`` are stable across
+both majors (``download_pdf`` uses ``get_print`` + ``save_file`` with no
+``jarvis.compat`` shim), so none is needed here.
+"""
+
+import re
+
+import frappe
+from frappe.desk.query_report import run as frappe_run_report
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+
+# Above this many columns a portrait page clips the table, so default to landscape.
+_LANDSCAPE_COL_THRESHOLD = 6
+_ORIENTATIONS = ("portrait", "landscape")
+# Fieldtypes whose values are right-aligned numbers in the rendered table.
+_NUMERIC_FIELDTYPES = {"Currency", "Float", "Int", "Percent"}
+
+
+def report_pdf(
+	report_name: str,
+	filters: dict | None = None,
+	orientation: str | None = None,
+	title: str | None = None,
+) -> dict:
+	"""Execute ``report_name`` with ``filters``, render its columns+rows to a PDF,
+	store it as a private File, and return the ``download_pdf`` envelope
+	``{file_url, filename, title, mime_type, size_bytes, name}`` so the chat
+	surfaces an identical download link.
+
+	``orientation`` is ``"portrait"`` / ``"landscape"``; omitted picks landscape
+	for wide reports. ``title`` overrides the heading (defaults to the report name).
+	"""
+	if not report_name:
+		raise InvalidArgumentError("report_name is required")
+	if not frappe.db.exists("Report", report_name):
+		raise InvalidArgumentError(f"unknown Report: {report_name}")
+
+	if orientation is not None:
+		orientation = str(orientation).strip().lower()
+		if orientation not in _ORIENTATIONS:
+			raise InvalidArgumentError(f"orientation must be one of {_ORIENTATIONS}, got {orientation!r}")
+
+	# A Report Builder report is a saved list view, not a columns+rows result this
+	# path can render; refuse clearly rather than emit an empty or garbled PDF.
+	report_type = frappe.db.get_value("Report", report_name, "report_type")
+	if report_type == "Report Builder":
+		raise InvalidArgumentError(
+			f"{report_name} is a Report Builder report — export it from its list view. "
+			"report_pdf renders Query Report and Script Report results."
+		)
+
+	# Same execution path as run_report: Frappe enforces report + filter
+	# permissions and raises PermissionError. ignore_prepared_report=True forces
+	# LIVE data rather than a queued async stub for prepared reports.
+	try:
+		res = frappe_run_report(
+			report_name=report_name,
+			filters=filters or {},
+			ignore_prepared_report=True,
+		)
+	except frappe.PermissionError as e:
+		raise PermissionDeniedError(str(e) or f"no permission to run report {report_name}") from e
+	except Exception as e:
+		# The report itself failed to run: a missing/bad filter (Frappe raises
+		# ``TypeError: format requires a mapping`` when a ``%(name)s`` filter has no
+		# value), invalid report SQL, or a mandatory input the report needs. From
+		# this tool's contract that is a bad-input outcome, not a 500. Log the full
+		# traceback so a genuine infrastructure fault stays visible, then surface a
+		# clean, deliberate error rather than swallowing it.
+		frappe.log_error(
+			title=f"report_pdf: running report {report_name} failed",
+			message=frappe.get_traceback(),
+		)
+		raise InvalidArgumentError(f"could not run report {report_name}: {e}") from e
+
+	columns = _normalise_columns(res.get("columns") or [])
+	if not columns:
+		raise InvalidArgumentError(
+			f"report {report_name} returned no columns to render "
+			"(it may require filters, or be a layout with no tabular result)"
+		)
+	rows = res.get("result") or []
+	# When add_total_row is set, query_report.run has already appended the total as
+	# the LAST row of `result` (frappe/desk/query_report.py add_total_row); we only
+	# style it, never recompute it.
+	has_total_row = bool(res.get("add_total_row")) and bool(rows)
+
+	report_title = (title or "").strip() or report_name
+	auto_landscape = len(columns) > _LANDSCAPE_COL_THRESHOLD
+	landscape = orientation == "landscape" or (orientation is None and auto_landscape)
+
+	html = _render_html(report_title, filters or {}, columns, rows, has_total_row)
+
+	from frappe.utils.pdf import get_pdf
+
+	pdf_bytes = get_pdf(html, options={"orientation": "Landscape" if landscape else "Portrait"})
+	if not pdf_bytes:
+		raise InvalidArgumentError(f"PDF generation for report {report_name} produced no content")
+
+	from frappe.exceptions import ValidationError
+	from frappe.utils.file_manager import save_file
+
+	filename = f"{_safe_filename(report_title)}.pdf"
+	# Private + attached to the Report doc: auth-gated by the customer's session and
+	# re-findable, exactly like download_pdf's File.
+	try:
+		file_doc = save_file(fname=filename, content=pdf_bytes, dt="Report", dn=report_name, is_private=1)
+	except ValidationError as e:
+		# A File-save constraint (e.g. a rejected filename) is a bad-input outcome,
+		# not an opaque 500.
+		raise InvalidArgumentError(f"could not store the report PDF: {e}") from e
+
+	return {
+		"file_url": file_doc.file_url,
+		"filename": file_doc.file_name,
+		"title": report_title,
+		"mime_type": "application/pdf",
+		"size_bytes": int(file_doc.file_size or len(pdf_bytes)),
+		"name": file_doc.name,
+	}
+
+
+def _safe_filename(title: str) -> str:
+	"""A File-doctype-safe base name derived from the title.
+
+	A report name or a caller-supplied ``title`` can carry markup, slashes and
+	other characters that Frappe's File sanitiser rejects or rewrites — notably it
+	re-introduces a ``/`` from a closing HTML tag (``</b>``), which then raises
+	``ValidationError: File name cannot have /`` deep inside ``save_file``. Keep
+	only filename-safe characters, cap the length, and never return empty.
+	"""
+	base = re.sub(r"[^A-Za-z0-9._-]+", "-", title or "").strip("-.")
+	return base[:80] or "report"
+
+
+def _normalise_columns(columns: list) -> list[dict]:
+	"""Return columns as dicts with at least ``fieldname``, ``label``,
+	``fieldtype``, ``options``.
+
+	``query_report.run`` normalises columns to dicts, but a hand-written Query
+	Report can still emit the legacy ``"Label:Fieldtype/Options:Width"`` string
+	form, so both are handled.
+	"""
+	out: list[dict] = []
+	for i, col in enumerate(columns):
+		if isinstance(col, dict):
+			fieldname = col.get("fieldname") or col.get("label") or f"col_{i}"
+			out.append(
+				{
+					"fieldname": fieldname,
+					"label": col.get("label") or fieldname,
+					"fieldtype": col.get("fieldtype") or "Data",
+					"options": col.get("options") or "",
+				}
+			)
+			continue
+		# Legacy string column: "Label:Fieldtype/Options:Width"
+		parts = str(col).split(":")
+		label = parts[0].strip() or f"col_{i}"
+		fieldtype, options = "Data", ""
+		if len(parts) > 1 and parts[1]:
+			ft = parts[1].split("/")
+			fieldtype = ft[0].strip() or "Data"
+			options = ft[1].strip() if len(ft) > 1 else ""
+		out.append(
+			{
+				"fieldname": frappe.scrub(label),
+				"label": label,
+				"fieldtype": fieldtype,
+				"options": options,
+			}
+		)
+	return out
+
+
+def _cell(row, col: dict, idx: int):
+	"""Read one cell, tolerating both dict rows (keyed by fieldname) and
+	list/tuple rows (positional) — Frappe returns either depending on report type,
+	and an appended total row can be a list among dict rows."""
+	if isinstance(row, dict):
+		return row.get(col["fieldname"])
+	if isinstance(row, (list, tuple)):
+		return row[idx] if idx < len(row) else None
+	return None
+
+
+def _format_cell(value, col: dict) -> str:
+	"""HTML-escaped, fieldtype-aware rendering so the PDF matches the on-screen
+	table. Falls back to the raw string if ``frappe.format`` cannot render it —
+	a formatting hiccup must never abort the whole PDF."""
+	if value is None or value == "":
+		return ""
+	try:
+		formatted = frappe.format(value, {"fieldtype": col["fieldtype"], "options": col["options"]})
+	except Exception:
+		formatted = value
+	return frappe.utils.escape_html(str(formatted))
+
+
+def _render_html(title: str, filters: dict, columns: list[dict], rows: list, has_total_row: bool) -> str:
+	"""Build a self-contained HTML document: escaped title, a one-line filters
+	summary, and the data table. All dynamic text is escaped — report data is
+	untrusted and must never inject markup into the PDF."""
+	esc = frappe.utils.escape_html
+	filter_bits = [
+		f"{esc(str(k))}: {esc(str(v))}" for k, v in (filters or {}).items() if v not in (None, "", [])
+	]
+	filters_line = " · ".join(filter_bits)
+
+	head = "".join(f"<th>{esc(c['label'])}</th>" for c in columns)
+
+	body_parts = []
+	last = len(rows) - 1
+	for r_i, row in enumerate(rows):
+		is_total = has_total_row and r_i == last
+		tds = []
+		for c_i, col in enumerate(columns):
+			align = "right" if col["fieldtype"] in _NUMERIC_FIELDTYPES else "left"
+			tds.append(f'<td style="text-align:{align}">{_format_cell(_cell(row, col, c_i), col)}</td>')
+		cls = ' class="total"' if is_total else ""
+		body_parts.append(f"<tr{cls}>{''.join(tds)}</tr>")
+
+	empty_note = "" if rows else '<p class="empty">No data for these filters.</p>'
+	table = (
+		""
+		if not rows
+		else (f"<table><thead><tr>{head}</tr></thead><tbody>{''.join(body_parts)}</tbody></table>")
+	)
+	filters_html = f'<p class="filters">{filters_line}</p>' if filters_line else ""
+
+	return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>
+  body {{ font-family: -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 11px; color: #1a1a1a; margin: 18px; }}
+  h1 {{ font-size: 16px; margin: 0 0 4px; }}
+  .filters {{ color: #555; margin: 0 0 12px; font-size: 10px; }}
+  .empty {{ color: #777; font-style: italic; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  th, td {{ border: 1px solid #ccc; padding: 4px 6px; vertical-align: top; }}
+  thead th {{ background: #f2f2f2; text-align: left; font-weight: 600; }}
+  tr.total td {{ font-weight: 700; background: #fafafa; }}
+</style></head><body>
+  <h1>{esc(title)}</h1>
+  {filters_html}
+  {table}{empty_note}
+</body></html>"""

--- a/jarvis/tools/tool-names.json
+++ b/jarvis/tools/tool-names.json
@@ -18,7 +18,7 @@
     "repo copies are compared by it, because no CI job can see both repos."
   ],
   "contract_version": 1,
-  "digest": "sha256:69c521929aefcc7dea60745e5d8dc53f1be55cd41faf32912921485eb215a197",
+  "digest": "sha256:5565c8d0893fbf010c6ef2f141c292d600c967edd01138b57984057b2dc1c41d",
   "tools": [
     "add_comment",
     "add_tag",
@@ -72,6 +72,7 @@
     "record_agent_run",
     "record_app_wiki",
     "remove_tag",
+    "report_pdf",
     "resolve_links",
     "run_method",
     "run_report",


### PR DESCRIPTION
## What

"Give me this report as a PDF" had no tool. The agent improvised with the
container's browser/exec and wrote the PDF onto the container filesystem, where
it never became a Frappe File and never surfaced in chat ("Done, I generated the
PDF", but nothing to download).

## How

New `report_pdf(report_name, filters=None, orientation=None, title=None)` tool:

- Runs a saved Query/Script Report with filters through the same
  `query_report.run` path that `run_report` uses, so Report permissions are
  enforced identically (a `frappe.PermissionError` maps to the tool's
  permission-denied error; unknown or empty reports map to an invalid-argument
  error).
- Renders columns and rows to a PDF: fieldtype-aware formatting (currency, date,
  link rendered as text), an optional total row when the report sets one, and
  auto orientation (landscape when there are many columns; an explicit
  `orientation` argument wins).
- Stores the result as a private Frappe File and returns the exact `download_pdf`
  envelope (`file_url`, `filename`, `title`, `mime_type`, `size_bytes`, `name`),
  so chat surfaces an identical download link with no frontend change.
- A Report Builder report is refused with clear guidance to export it from its
  list view (deferred, not supported in v1).

Registered in `registry._TOOL_NAMES` and the regenerated `tool-names.json`
contract artifact. The plugin descriptor, schema, and manifest entry live in a
separate `jarvis-openclaw-plugin` commit.

## Tests

`jarvis/tests/test_report_pdf.py`: 18 bench tests, one per edge case, including a
restricted, non-Administrator-user permission denial and markup-title filename
safety.

## Review status

Code review and flow review both VERDICT GREEN.

## Note

This commit was previously staged on a local integration branch alongside two
unrelated work items; it is cherry-picked here onto a clean branch off `develop`
so the PR contains only the report_pdf tool.
