### PR TITLE
fix(onboarding): point tour "Browse all features" link at the real docs URL

### DIFF
--- a/frontend/src/onboarding/TourIntro.vue
+++ b/frontend/src/onboarding/TourIntro.vue
@@ -544,10 +544,10 @@ import { PERMISSION_TOUR_COPY } from "@/onboarding/permissionCopy";
 // 'skip' = the footer "Skip tour" link. Both land the wizard on the Plan step.
 const emit = defineEmits(["finish", "skip"]);
 
-// TODO(docs): replace with the real product docs / features URL. The final
-// slide's "Browse all features" link opens this in a new tab so the curious
+// The final slide's "Browse all features" link opens this in a new tab (a
+// same-tab nav would drop the user out of the signup wizard) so the curious
 // can read everything without the tour having to show every surface.
-const DOCS_URL = "https://docs.example.com/jarvis";
+const DOCS_URL = "https://jarvis.aerele.in/docs";
 
 const SLIDE_COUNT = 5;
 const LAST = SLIDE_COUNT - 1;


### PR DESCRIPTION
## Summary

Swaps the onboarding tour's final-slide "Browse all features" link from the placeholder that shipped in #769 (`docs.example.com`) to the real docs home, `https://jarvis.aerele.in/docs`. Presentation only, no logic change.

Note: the docs site at that URL is not configured yet, so the link is correct but will 404 until the docs are hosted.

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (branched from the merge of #769)
- [x] New/changed behavior has tests (n/a — a single URL constant; covered by existing tour tests)
- [x] I self-reviewed the diff
