### PR TITLE
fix(chat): show the full subscription model list in the chat picker

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1611,49 +1611,96 @@ def _api_key_models() -> dict[str, list[dict]]:
 
 
 def _catalog_models_for_pool(settings) -> dict[str, list[dict]]:
-	"""Provider id -> api-key catalog models the chat picker may offer, for the
-	providers this tenant has ALREADY configured.
+	"""Provider id -> catalog models the chat picker may offer BEYOND the exact ids
+	saved in the pool, for the providers this tenant has ALREADY configured.
 
-	The point is that a customer with one saved model is not stuck with it. The
-	container holds a credential per provider, and the agent serves a model id the
-	pool spec never named, so switching within a configured provider costs nothing
-	and needs no re-save.
+	The point is that a customer with one saved model is not stuck with it: the
+	container already holds the credential and serves a model id the pool spec
+	never named, so switching within a configured provider costs nothing and needs
+	no re-save. Two kinds of provider contribute, each keyed by the SAME id its
+	``pool_models`` rows carry so the UI joins them without a second lookup:
 
-	Keyed on the canonical provider id the ``pool_models`` rows carry, so the UI
-	can join the two without a second lookup. The catalog's ``catalog_id`` IS that
-	id (``google`` the provider is ``gemini`` on the wire); ``provider_id`` is the
-	fallback for a legacy row.
+	* api-key providers (``accepts_any_model``): every ``api_key``-tier catalog
+	  model on the provider. Keyed on the catalog's ``catalog_id`` (``google`` the
+	  provider is ``gemini`` on the wire); ``provider_id`` is the legacy fallback.
+
+	* chat-subscription providers: every ``subscription``-tier catalog model on a
+	  provider the tenant has a connected account for. One cliproxy account serves
+	  the whole subscription tier, so the same "switch without re-saving" applies.
+	  Keyed on the account ``upstream`` (== the provider's ``agent_provider``:
+	  ``openai`` / ``google-gemini-cli`` / ...) derived from the encrypted accounts
+	  blob EXACTLY as the pool build does (chat/api.py:1757, raw — no
+	  ``normalize_provider``), so a subscription row and its extra models join.
+
+	OpenAI's ``catalog_id`` and ``agent_provider`` are both ``openai``, so a tenant
+	with an OpenAI key AND a ChatGPT subscription lands both tiers on one key: they
+	MERGE (dedup by id), they must not clobber.
 
 	Only providers already in the pool appear: a provider with no credential in
 	the container answers ``model_not_found``, and being an explicit bad-id
 	rejection rather than an upstream failure it does not fail over, so the turn
 	dies (#498). Adding a NEW provider stays a Settings operation.
 
-	z.ai rows are excluded by ``accepts_any_model`` -- see the note beside it in
-	pool_serialize, and keep this in step with the fleet render's ``any_model``.
+	z.ai api-key rows are excluded by ``accepts_any_model`` -- see the note beside
+	it in pool_serialize, and keep this in step with the fleet render's
+	``any_model``. Feeds BOTH the picker (``catalog_models``) and the pin
+	validation (``_allowed_pin_models``): if it is offered, it is pinnable.
 	"""
 	from jarvis import admin_client
-	from jarvis.jarvis.pool_serialize import accepts_any_model, normalize_provider
+	from jarvis.jarvis.pool_serialize import (
+		_credential_type,
+		_model_accounts,
+		accepts_any_model,
+		normalize_provider,
+	)
+	from jarvis.oauth.providers import agent_provider_for
 
-	wanted = {
+	# api-key providers whose whole api_key tier the picker may offer.
+	wanted_api = {
 		normalize_provider(getattr(m, "provider", "") or "")
 		for m in settings.models or []
 		if m.enabled and accepts_any_model(m)
 	}
-	wanted.discard("")
-	if not wanted:
+	wanted_api.discard("")
+
+	# Subscription upstreams the tenant actually has a connected account for. Only
+	# subscription rows are touched, so a pure api-key tenant decrypts nothing.
+	wanted_sub: set[str] = set()
+	for m in settings.models or []:
+		if not (m.enabled and _credential_type(m) == "subscription"):
+			continue
+		for a in _model_accounts(m):
+			up = (a.get("upstream") or "").strip() if isinstance(a, dict) else ""
+			if up:
+				wanted_sub.add(up)
+
+	if not wanted_api and not wanted_sub:
 		return {}
 
+	# Display fields only. The catalog carries no secrets by construction, but this
+	# endpoint is on the hot chat path, so the projection stays narrow. Merge by
+	# model id (see the OpenAI two-tier case in the docstring).
 	out: dict[str, list[dict]] = {}
+
+	def _add(key: str, models: list[dict]) -> None:
+		bucket = out.setdefault(key, [])
+		seen = {r["model"] for r in bucket}
+		for m in sorted(models, key=lambda m: (m.get("sort_order") or 0, m.get("model_id") or "")):
+			mid = m.get("model_id")
+			if not mid or mid in seen:
+				continue
+			seen.add(mid)
+			bucket.append({"model": mid, "label": m.get("label") or mid})
+
 	for provider in admin_client.get_model_catalog() or []:
+		models = provider.get("models") or []
 		pid = (provider.get("catalog_id") or provider.get("provider_id") or "").strip()
-		if pid not in wanted:
-			continue
-		rows = [m for m in provider.get("models") or [] if m.get("tier") == "api_key"]
-		rows.sort(key=lambda m: (m.get("sort_order") or 0, m.get("model_id") or ""))
-		# Display fields only. The catalog carries no secrets by construction, but
-		# this endpoint is on the hot chat path, so it stays a narrow projection.
-		out[pid] = [{"model": m["model_id"], "label": m.get("label") or m["model_id"]} for m in rows]
+		if pid and pid in wanted_api:
+			_add(pid, [m for m in models if m.get("tier") == "api_key"])
+		if wanted_sub:
+			upstream = agent_provider_for(provider.get("subscription_label") or provider.get("label") or "")
+			if upstream and upstream in wanted_sub:
+				_add(upstream, [m for m in models if m.get("tier") == "subscription"])
 	return out
 
 

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1627,10 +1627,15 @@ def _catalog_models_for_pool(settings) -> dict[str, list[dict]]:
 	* chat-subscription providers: every ``subscription``-tier catalog model on a
 	  provider the tenant has a connected account for. One cliproxy account serves
 	  the whole subscription tier, so the same "switch without re-saving" applies.
-	  Keyed on the account ``upstream`` (== the provider's ``agent_provider``:
-	  ``openai`` / ``google-gemini-cli`` / ...) derived from the encrypted accounts
-	  blob EXACTLY as the pool build does (chat/api.py:1757, raw — no
-	  ``normalize_provider``), so a subscription row and its extra models join.
+	  Keyed EXACTLY as the ``pool_models`` projection keys a subscription row
+	  (get_chat_ui_settings, ~line 1749): an explicit ``row.provider`` wins,
+	  otherwise each account's raw ``upstream`` (== the provider's
+	  ``agent_provider``: ``openai`` / ``google-gemini-cli`` / ...). The SPA stores
+	  ``provider=""`` for subscriptions today, so the upstream path is the common
+	  one, but honoring an explicit provider keeps the two projections in step no
+	  matter which shape the row has. A catalog entry is therefore matched by
+	  EITHER its ``catalog_id`` (explicit rows) or its ``agent_provider`` (derived
+	  rows), and offered under whichever key this tenant actually uses.
 
 	OpenAI's ``catalog_id`` and ``agent_provider`` are both ``openai``, so a tenant
 	with an OpenAI key AND a ChatGPT subscription lands both tiers on one key: they
@@ -1655,24 +1660,31 @@ def _catalog_models_for_pool(settings) -> dict[str, list[dict]]:
 	)
 	from jarvis.oauth.providers import agent_provider_for
 
-	# api-key providers whose whole api_key tier the picker may offer.
-	wanted_api = {
-		normalize_provider(getattr(m, "provider", "") or "")
-		for m in settings.models or []
-		if m.enabled and accepts_any_model(m)
-	}
-	wanted_api.discard("")
-
-	# Subscription upstreams the tenant actually has a connected account for. Only
-	# subscription rows are touched, so a pure api-key tenant decrypts nothing.
+	# One pass over the pool: classify each enabled row into the provider key(s)
+	# its pool_models projection carries, so catalog_models joins by the SAME key.
+	wanted_api: set[str] = set()
 	wanted_sub: set[str] = set()
 	for m in settings.models or []:
-		if not (m.enabled and _credential_type(m) == "subscription"):
+		if not m.enabled:
 			continue
-		for a in _model_accounts(m):
-			up = (a.get("upstream") or "").strip() if isinstance(a, dict) else ""
-			if up:
-				wanted_sub.add(up)
+		if _credential_type(m) == "subscription":
+			# Mirror the pool_models derivation: explicit provider wins, else the
+			# raw account upstream. A BLANK upstream is skipped, NOT defaulted to
+			# "openai" -- pool_models keys such a row as "" too, so offering under
+			# "openai" would never join (build_pool_payload's "openai" default is
+			# wire-only, a different projection). Explicit rows need no decrypt.
+			explicit = normalize_provider(getattr(m, "provider", "") or "")
+			if explicit:
+				wanted_sub.add(explicit)
+			else:
+				for a in _model_accounts(m):
+					up = (a.get("upstream") or "").strip() if isinstance(a, dict) else ""
+					if up:
+						wanted_sub.add(up)
+		elif accepts_any_model(m):
+			pid = normalize_provider(getattr(m, "provider", "") or "")
+			if pid:
+				wanted_api.add(pid)
 
 	if not wanted_api and not wanted_sub:
 		return {}
@@ -1698,9 +1710,17 @@ def _catalog_models_for_pool(settings) -> dict[str, list[dict]]:
 		if pid and pid in wanted_api:
 			_add(pid, [m for m in models if m.get("tier") == "api_key"])
 		if wanted_sub:
-			upstream = agent_provider_for(provider.get("subscription_label") or provider.get("label") or "")
-			if upstream and upstream in wanted_sub:
-				_add(upstream, [m for m in models if m.get("tier") == "subscription"])
+			sub_rows = [m for m in models if m.get("tier") == "subscription"]
+			if sub_rows:
+				# A subscription row keys on EITHER the catalog id (explicit
+				# provider) or the agent_provider upstream (derived). Offer under
+				# whichever this tenant actually uses so the pool_models join lands.
+				upstream = agent_provider_for(
+					provider.get("subscription_label") or provider.get("label") or ""
+				)
+				for key in {pid, upstream}:
+					if key and key in wanted_sub:
+						_add(key, sub_rows)
 	return out
 
 

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -145,6 +145,18 @@ def accepts_bare_code(label: str) -> bool:
 	return bool(_PROVIDER_OAUTH_MAP.get(label, {}).get("code_only_paste"))
 
 
+def agent_provider_for(label: str) -> str:
+	"""The ``agent_provider`` (cliproxy upstream id — ``openai`` /
+	``google-gemini-cli`` / ``xai`` / ``kimi``) for a subscription provider label,
+	or "" when the label is not a known OAuth/subscription provider.
+
+	Metadata only: unlike ``get_provider`` it never resolves the client id/secret,
+	so it is cheap enough for the chat hot path (``_catalog_models_for_pool`` maps
+	a catalog entry's ``subscription_label`` to the upstream a pool row carries).
+	"""
+	return (_PROVIDER_OAUTH_MAP.get(label) or {}).get("agent_provider", "")
+
+
 def get_provider(label: str) -> dict:
 	"""Look up provider metadata, including the lazy-resolved client_id +
 	client_secret. ``client_secret`` is an empty string for PKCE-only

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -915,7 +915,11 @@ class TestCatalogModelsForPool(FrappeTestCase):
 		{
 			"provider_id": "google",
 			"catalog_id": "gemini",
-			"models": [{"model_id": "gemini-3.6-flash", "label": "Flash", "tier": "api_key"}],
+			"subscription_label": "Google Gemini",
+			"models": [
+				{"model_id": "gemini-3.6-flash", "label": "Flash", "tier": "api_key"},
+				{"model_id": "gemini-2.5-pro", "label": "Pro", "tier": "subscription", "sort_order": 1},
+			],
 		},
 		{
 			"provider_id": "zai_coding",
@@ -991,13 +995,25 @@ class TestCatalogModelsForPool(FrappeTestCase):
 
 	def test_disabled_rows_contribute_nothing(self):
 		self.assertEqual(self._run([{"enabled": 0, "provider": "anthropic", "model": "x"}]), {})
-		# A subscription row with NO connected account yields no upstream to key on.
+		# A subscription row with empty provider AND no connected account has no
+		# upstream to key on (pool_models keys such a row as "" too, so nothing to
+		# join against).
 		self.assertEqual(
-			self._run(
-				[{"enabled": 1, "provider": "anthropic", "model": "x", "credential_type": "subscription"}]
-			),
+			self._run([{"enabled": 1, "provider": "", "model": "x", "credential_type": "subscription"}]),
 			{},
 		)
+
+	def test_explicit_provider_subscription_keys_on_catalog_id_not_upstream(self):
+		"""A subscription row that carries an explicit `provider` keys its pool_models
+		entry on that provider (like an api-key row), NOT the account upstream. So
+		catalog_models must key it the same way (`gemini`), or the picker's join
+		silently omits the tenant's extra models (review #0)."""
+		row = self._sub_row("gemini-2.5-pro", "google-gemini-cli")
+		row["provider"] = "gemini"
+		out = self._run([row])
+		self.assertEqual(list(out), ["gemini"])
+		self.assertEqual([r["model"] for r in out["gemini"]], ["gemini-2.5-pro"])
+		self.assertNotIn("google-gemini-cli", out)
 
 	def test_offers_subscription_tier_for_a_connected_subscription(self):
 		"""A ChatGPT-subscription tenant sees the whole subscription tier, keyed by

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -922,7 +922,35 @@ class TestCatalogModelsForPool(FrappeTestCase):
 			"catalog_id": "zai_coding",
 			"models": [{"model_id": "glm-4.6", "label": "GLM 4.6", "tier": "api_key"}],
 		},
+		# OpenAI carries BOTH tiers under one entry: catalog_id "openai" for the
+		# api-key join and subscription_label "OpenAI" (-> agent_provider "openai")
+		# for the subscription join. Both land on the same output key, so the two
+		# tiers must merge rather than clobber.
+		{
+			"provider_id": "openai",
+			"catalog_id": "openai",
+			"subscription_label": "OpenAI",
+			"models": [
+				{"model_id": "gpt-5.5", "label": "GPT-5.5", "tier": "subscription", "sort_order": 1},
+				{"model_id": "gpt-5.4", "label": "GPT-5.4", "tier": "subscription", "sort_order": 2},
+				{"model_id": "gpt-5-api", "label": "GPT-5 API", "tier": "api_key", "sort_order": 1},
+			],
+		},
 	]
+
+	@staticmethod
+	def _sub_row(model, upstream, enabled=1):
+		"""A subscription pool row whose encrypted accounts blob carries `upstream`,
+		matching how the pool build derives the provider (chat/api.py:1757)."""
+		import json
+
+		return {
+			"enabled": enabled,
+			"provider": "",
+			"model": model,
+			"credential_type": "subscription",
+			"subscription_accounts": json.dumps([{"upstream": upstream}]),
+		}
 
 	def _settings(self, rows):
 		return frappe._dict(models=[frappe._dict(r) for r in rows])
@@ -961,14 +989,37 @@ class TestCatalogModelsForPool(FrappeTestCase):
 		)
 		self.assertEqual(out, {})
 
-	def test_disabled_and_subscription_rows_contribute_nothing(self):
+	def test_disabled_rows_contribute_nothing(self):
 		self.assertEqual(self._run([{"enabled": 0, "provider": "anthropic", "model": "x"}]), {})
+		# A subscription row with NO connected account yields no upstream to key on.
 		self.assertEqual(
 			self._run(
 				[{"enabled": 1, "provider": "anthropic", "model": "x", "credential_type": "subscription"}]
 			),
 			{},
 		)
+
+	def test_offers_subscription_tier_for_a_connected_subscription(self):
+		"""A ChatGPT-subscription tenant sees the whole subscription tier, keyed by
+		the account upstream (`openai`) the pool row carries — not just its one
+		saved model. api_key-tier ids on the same provider must NOT leak in."""
+		out = self._run([self._sub_row("gpt-5.5", "openai")])
+		self.assertEqual(list(out), ["openai"])
+		self.assertEqual([r["model"] for r in out["openai"]], ["gpt-5.5", "gpt-5.4"])
+		self.assertEqual(out["openai"][0]["label"], "GPT-5.5")
+
+	def test_api_key_and_subscription_on_openai_merge_under_one_key(self):
+		"""catalog_id == agent_provider == "openai": both tiers land on one key and
+		must union (not clobber). The api-key row lets the picker offer gpt-5-api;
+		the subscription account lets it offer gpt-5.5 / gpt-5.4."""
+		out = self._run(
+			[
+				{"enabled": 1, "provider": "openai", "model": "gpt-5-api"},
+				self._sub_row("gpt-5.5", "openai"),
+			]
+		)
+		self.assertEqual(list(out), ["openai"])
+		self.assertEqual(sorted(r["model"] for r in out["openai"]), ["gpt-5-api", "gpt-5.4", "gpt-5.5"])
 
 	def test_legacy_google_provider_id_maps_onto_the_gemini_wire_id(self):
 		"""normalize_provider collapses the legacy `google` id onto `gemini`, which is
@@ -1185,3 +1236,41 @@ class TestAllowedPinModels(unittest.TestCase):
 		with patch.object(api, "_SUBSCRIPTION_MODELS", {"OpenAI": ["gpt-5.6", "gpt-5.5"]}):
 			allowed = api._allowed_pin_models(self._settings("OpenAI", []))
 		self.assertEqual(allowed, {"gpt-5.6", "gpt-5.5"})
+
+	def test_connected_subscription_tier_is_pinnable(self):
+		"""A ChatGPT-subscription tenant (llm_provider="") stores one model but may
+		PIN any model in the connected upstream's subscription tier — display and
+		validation share _catalog_models_for_pool, so the picker and the pin agree."""
+		import json
+
+		from jarvis.chat import api
+
+		catalog = [
+			{
+				"catalog_id": "openai",
+				"subscription_label": "OpenAI",
+				"models": [
+					{"model_id": "gpt-5.5", "tier": "subscription"},
+					{"model_id": "gpt-5.4", "tier": "subscription"},
+				],
+			}
+		]
+		sub_row = SimpleNamespace(
+			model="gpt-5.5",
+			enabled=1,
+			provider="",
+			credential_type="subscription",
+			subscription_accounts=json.dumps([{"upstream": "openai"}]),
+		)
+		settings = SimpleNamespace(llm_provider="", models=[sub_row])
+		# Patch _SUBSCRIPTION_MODELS too: leaving the real lazy map in place would
+		# resolve it against the tiny patched catalog and cache that on frappe.local,
+		# truncating the subscription catalogue for later tests. It is "" here anyway.
+		with (
+			patch("jarvis.admin_client.get_model_catalog", return_value=catalog),
+			patch.object(api, "_SUBSCRIPTION_MODELS", {}),
+		):
+			allowed = api._allowed_pin_models(settings)
+		# the saved model AND its sibling in the same subscription tier
+		self.assertIn("gpt-5.5", allowed)
+		self.assertIn("gpt-5.4", allowed)


### PR DESCRIPTION
## Summary

A ChatGPT-subscription tenant only saw the one model id saved in their pool in the chat model picker, even though the catalog carries the whole subscription tier. This shows every subscription-tier model for a connected subscription, so the customer can switch models in chat without re-saving Settings.

Root cause: the picker (and its pin validation) both source catalog models from `_catalog_models_for_pool`, which was api-key only. It gated on `accepts_any_model` (False for subscription rows) and emitted only `tier == "api_key"` rows, so a subscription tenant got an empty catalog and a single-model menu.

The fix widens that one function to also emit `tier == "subscription"` catalog models for every provider the tenant has a connected subscription account for, keyed by the account upstream exactly as the pool build derives it, so the frontend join needs no change. Because `_allowed_pin_models` reads the same function, the picker and pin validation stay in lockstep. Backend-only; adds a metadata-only `agent_provider_for` helper to keep it cheap on the chat hot path.

<details>
<summary>Note on runtime verification</summary>

Unit-tested (picker output + pin validation, including the OpenAI two-tier merge). Not yet exercised against a live ChatGPT-subscription tenant: whether a pinned non-primary subscription model is actually served by cliproxy vs silently misrouted to the primary should be confirmed on a real sub tenant before relying on it.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests (picker + pin validation + merge case)
- [x] I self-reviewed the diff