### PR TITLE
feat(support): single header entry point, copy-into-ticket, badge/attachment fixes

### DIFF
--- a/frontend/src/components/chat/Message.vue
+++ b/frontend/src/components/chat/Message.vue
@@ -90,7 +90,7 @@
 			<!-- attached images → same clickable thumbnail + preview as generated ones -->
 			<template v-for="cv in attachments || []" :key="cv.name">
 				<button
-					v-if="cv.type === 'image' && cv.file_url"
+					v-if="!imagesAsChips && cv.type === 'image' && cv.file_url"
 					class="jv-img-artifact"
 					@click="emit('open-attachment', cv)"
 					:title="'Open ' + cv.title"
@@ -219,7 +219,7 @@
 				<template v-if="!hasBelowBody">
 					<template v-for="cv in attachments || []" :key="cv.name">
 						<button
-							v-if="cv.type === 'image' && cv.file_url"
+							v-if="!imagesAsChips && cv.type === 'image' && cv.file_url"
 							class="jv-img-artifact"
 							@click="emit('open-attachment', cv)"
 							:title="'Open ' + cv.title"
@@ -331,6 +331,13 @@ defineProps({
 	// A failed-to-send user message: shows "Not sent" + Retry instead of the
 	// hover bar.
 	failed: { type: Boolean, default: false },
+	// Render an image attachment as the same filename chip as every other file
+	// (click through to view it) instead of an inline cropped thumbnail. Chat's
+	// generated-canvas images (charts/diagrams) rely on the thumbnail staying
+	// visible inline, so this defaults false there; Support turns it on - a
+	// customer's photo attachment showing a preview read as a worse "vague"
+	// crop than just naming the file, per feedback.
+	imagesAsChips: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["edit", "copy", "retry", "open-attachment"]);

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -81,6 +81,7 @@
 			<JarvisCommandPalette />
 			<NotifyToaster />
 			<ConfirmDialog />
+			<SupportCopyPromptDialog />
 		</div>
 	</FrappeUIProvider>
 </template>
@@ -104,6 +105,9 @@ import Sidebar from "./Sidebar.vue";
 import JarvisCommandPalette from "./JarvisCommandPalette.vue";
 import SettingsDialog from "./SettingsDialog.vue";
 import ConfirmDialog from "./ConfirmDialog.vue";
+// Mounted here (not in ChatView) so a route change away from Chat can never
+// unmount it mid-prompt - same reasoning as ConfirmDialog living here.
+import SupportCopyPromptDialog from "@/components/support/SupportCopyPromptDialog.vue";
 import OnboardingGate from "./OnboardingGate.vue";
 import UpdateNoticeGate from "./UpdateNoticeGate.vue";
 import { showNotice } from "@/noticeGate";

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -17,9 +17,12 @@
 				     exactly what let the chat welcome mark drift to a different colour
 				     (design.md §2.2). -->
 				<JarvisMark :size="28" :radius="7" />
-				<!-- Resting badge: a waiting reply has to register while the user is
-				     heads-down in chat, without opening the menu. Mirrors the
-				     collapsed-sidebar dot in Sidebar.vue:57-62. -->
+				<!-- Resting badge: a waiting reply has to register on every route, not
+				     only while the user happens to be in Chat - restoring this (it was
+				     briefly dropped when ChatView grew its own header jv-support-dot,
+				     which stayed too: both showing the same thing on the chat route is
+				     harmless duplication, losing it everywhere else was not). Mirrors
+				     the collapsed-sidebar dot in Sidebar.vue:57-62. -->
 				<div
 					v-if="supportOn && store.awaitingCount"
 					class="absolute left-7 top-1 size-2 rounded-full bg-surface-amber-2"
@@ -52,7 +55,7 @@
 // pattern. Dropdown: Settings (D9) · Switch to Desk · Change theme · Log out.
 import { computed, inject, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
-import { Dropdown, FeatherIcon, toast } from "frappe-ui";
+import { Dropdown, FeatherIcon } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
 import { useShellStore } from "@/stores/shell";
 import { useSupportStore } from "@/stores/support";
@@ -75,14 +78,12 @@ const shellStore = useShellStore();
 const session = inject("$session");
 const { effectiveDark, toggleTheme } = useJarvisTheme();
 
-// Support panel (Plan 3 C3/C4): dual kill-switch + a store-driven awaiting-count
-// badge. `store` is the shared support-store singleton (Task 1) — both this
-// resting dot and the list read the same value, so they can never disagree.
+// Support panel: `store` is the shared support-store singleton, kept fresh here
+// by this poll timer so ChatView's header Support button (its jv-support-dot)
+// and the ticket list always read the same awaiting-count value without each
+// needing to run its own poller.
 const router = useRouter();
 const supportOn = window.support_available && window.has_support_access;
-// Unconfigured (an operator can still set it up) vs off/error (hidden, as before) —
-// see the same flag in ChatView. Permission still hides outright.
-const supportUnconfigured = window.support_state === "unconfigured" && !!window.has_support_access;
 const store = useSupportStore();
 let pollTimer = null;
 async function pollAwaiting() {
@@ -106,9 +107,10 @@ function cookie(name) {
 }
 const fullName = cookie("full_name") || session.user || "User";
 
-// Cross-surface link: from chat -> Support (with the awaiting count); from the
-// support rail -> back to chat (we're already in support, so a "Support" link is
-// pointless). `null` = omit (chat with support switched off).
+// Cross-surface link: from the support rail -> back to chat (we're already in
+// support, so a "Support" link is pointless there). The chat-side "Support" entry
+// used to live here too, but it now lives in ChatView's header icon button
+// instead - keeping both would show Support twice on the chat side.
 const crossItem = computed(() => {
 	if (props.variant === "support") {
 		return {
@@ -117,28 +119,7 @@ const crossItem = computed(() => {
 			onClick: () => router.push({ name: "Chat" }),
 		};
 	}
-	// Unconfigured but usable-by-this-user: keep the entry so the feature is
-	// discoverable, but say why instead of navigating into a space the route guard
-	// would bounce straight back. "off"/"error" stay omitted (see supportUnconfigured).
-	if (supportUnconfigured) {
-		return {
-			label: "Support",
-			icon: "life-buoy",
-			// A visible cue: without it the entry is pixel-identical to the working one and
-			// clicking it just toasts, which reads as broken. frappe-ui's `disabled` would
-			// set pointer-events:none and swallow the click that carries the explanation,
-			// so use its `description` instead.
-			description: "Not set up - open to see why",
-			onClick: () =>
-				toast.info("Support isn't set up on this workspace yet — ask your administrator."),
-		};
-	}
-	if (!supportOn) return null;
-	return {
-		label: store.awaitingCount ? `Support (${store.awaitingCount})` : "Support",
-		icon: "life-buoy",
-		onClick: () => router.push({ name: "Support" }),
-	};
+	return null;
 });
 
 const menuOptions = computed(() => [

--- a/frontend/src/components/support/SupportComposer.vue
+++ b/frontend/src/components/support/SupportComposer.vue
@@ -56,22 +56,24 @@
 					class="hidden"
 					@change="onFileInput"
 				/>
-				<span
-					v-for="(p, i) in pending"
-					:key="p.key"
-					class="jv-supc-chip inline-flex max-w-[14rem] items-center gap-1.5 rounded-md bg-surface-gray-2 px-2 py-1 text-sm text-ink-gray-7"
-				>
-					<span class="truncate">{{ p.file_name }}</span>
+				<span v-for="(p, i) in pending" :key="p.key" class="jv-supc-chip">
+					<FeatherIcon name="paperclip" class="jv-supc-chip-clip" />
+					<span class="jv-supc-chip-name">{{ p.file_name }}</span>
 					<button
 						type="button"
 						:aria-label="`Remove ${p.file_name}`"
-						class="shrink-0 text-ink-gray-5 hover:text-ink-gray-8"
+						class="jv-supc-chip-remove"
 						@click="emit('remove-attachment', i)"
 					>
 						<FeatherIcon name="x" class="size-3.5" />
 					</button>
 				</span>
-				<div class="ml-auto">
+				<div class="ml-auto flex items-center gap-2">
+					<!-- Self-documenting, same spot Helpdesk's own reply box puts it (on the
+					     Send button itself) - here as its own span since submitLabel is
+					     host-owned ("Send" on a reply, "Create ticket" on a new one) and
+					     baking the chord into that string would read oddly on the latter. -->
+					<span class="jv-supc-hint">Ctrl + Enter to send</span>
 					<Button
 						variant="solid"
 						:label="submitLabel"
@@ -278,5 +280,47 @@ function rejectInlineUpload(file) {
 	font-size: 10.5px;
 	color: var(--text-3, #6b7280);
 	margin-top: 8px;
+}
+.jv-supc-hint {
+	font-size: 11px;
+	color: var(--ink-gray-5, #8d99a8);
+	white-space: nowrap;
+}
+/* Staged-file chip - same shape family as the row's Attach button (rounded-md,
+   border-outline-gray-2, text-sm) so a chip reads as "the same control, now
+   holding a file" rather than a different visual language bolted on. Kept as a
+   real named rule (frappe-ui tokens, not jv-* vars - this mounts outside jv-root
+   on the new-ticket page, see the file-level comment) rather than a pile of
+   inline utility classes, matching .jv-supc-disclaimer's pattern above. */
+.jv-supc-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 14rem;
+	padding: 0.25rem 0.5rem;
+	border: 1px solid var(--outline-gray-2, #d1d5db);
+	border-radius: 0.375rem;
+	background-color: var(--surface-gray-2, #f4f5f6);
+	font-size: 0.875rem;
+	color: var(--ink-gray-7, #4b5563);
+}
+.jv-supc-chip-clip {
+	flex: 0 0 auto;
+	width: 13px;
+	height: 13px;
+	color: var(--ink-gray-5, #8d99a8);
+}
+.jv-supc-chip-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-supc-chip-remove {
+	flex: 0 0 auto;
+	display: flex;
+	color: var(--ink-gray-5, #8d99a8);
+}
+.jv-supc-chip-remove:hover {
+	color: var(--ink-gray-8, #1c2126);
 }
 </style>

--- a/frontend/src/components/support/SupportCopyPromptDialog.vue
+++ b/frontend/src/components/support/SupportCopyPromptDialog.vue
@@ -67,7 +67,7 @@ function settle(val) {
 	settleSupportCopyPrompt(val);
 }
 
-// Escape = "no" (same as declining), not "dontask" — dismissing once shouldn't
+// Escape = "no" (same as declining), not "dontask": dismissing once shouldn't
 // silently opt out of ever being asked again.
 function onKey(e) {
 	if (e.key === "Escape" && state.value) {

--- a/frontend/src/components/support/SupportCopyPromptDialog.vue
+++ b/frontend/src/components/support/SupportCopyPromptDialog.vue
@@ -1,0 +1,178 @@
+<!-- "Copy this chat into your new ticket?" prompt, shown when a user opens a
+     support ticket from an active chat session. Same shell/overlay/teleport
+     pattern as ConfirmDialog.vue (see its own comment for why each piece is
+     there - the body-lock, the z-index, the jv- palette scoping) but three
+     answers instead of two: Yes (this once), No (this once), and Don't ask
+     again (persists, see useSupportCopyPrompt.js / Jarvis User Settings'
+     support_context_copy_pref). Mounted once in AppShell, above the router
+     view - ChatView is the only surface that TRIGGERS it, but it must not be
+     the one that mounts it: an earlier build mounted it in ChatView and a
+     route change away from Chat while a prompt was pending unmounted it
+     mid-flight, permanently wedging promptSupportCopy()'s module-scope
+     resolver for the rest of the session. Same reasoning as ConfirmDialog
+     living in AppShell. -->
+<template>
+	<Teleport to="body">
+		<transition name="jv-scp-fade">
+			<div
+				v-if="state"
+				class="jv-scp-overlay jv-root"
+				:class="{ 'jv-dark': dark }"
+				:style="paletteVars"
+				@click.self="settle('no')"
+			>
+				<div
+					class="jv-scp-dialog"
+					role="alertdialog"
+					aria-modal="true"
+					aria-labelledby="jv-scp-title"
+				>
+					<div id="jv-scp-title" class="jv-scp-title">Add this chat to your ticket?</div>
+					<div class="jv-scp-msg">
+						Copy your last few messages into the ticket so support has context without
+						you retyping it.
+					</div>
+					<div v-if="state.preview" class="jv-scp-preview">{{ state.preview }}</div>
+					<div class="jv-scp-foot">
+						<button
+							class="jv-btn jv-btn--ghost jv-scp-dontask"
+							@click="settle('dontask')"
+						>
+							Don't ask again
+						</button>
+						<div class="jv-scp-foot-main">
+							<button class="jv-btn jv-btn--ghost" @click="settle('no')">No</button>
+							<button class="jv-btn jv-btn--primary" @click="settle('yes')">
+								Yes, copy it
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</transition>
+	</Teleport>
+</template>
+
+<script setup>
+import { onMounted, onBeforeUnmount } from "vue";
+import {
+	copyPromptState as state,
+	settleSupportCopyPrompt,
+} from "@/composables/useSupportCopyPrompt";
+import { useJarvisTheme } from "@/theme";
+
+const { effectiveDark: dark, paletteVars } = useJarvisTheme();
+
+function settle(val) {
+	settleSupportCopyPrompt(val);
+}
+
+// Escape = "no" (same as declining), not "dontask" — dismissing once shouldn't
+// silently opt out of ever being asked again.
+function onKey(e) {
+	if (e.key === "Escape" && state.value) {
+		e.preventDefault();
+		e.stopPropagation();
+		settle("no");
+	}
+}
+onMounted(() => window.addEventListener("keydown", onKey, true));
+onBeforeUnmount(() => window.removeEventListener("keydown", onKey, true));
+</script>
+
+<style scoped>
+.jv-scp-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 200;
+	pointer-events: auto;
+	background: rgba(15, 15, 22, 0.34);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+}
+.jv-scp-overlay.jv-dark {
+	background: rgba(0, 0, 0, 0.55);
+}
+.jv-scp-dialog {
+	width: 440px;
+	max-width: 100%;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: 14px;
+	padding: 20px;
+	box-shadow: 0 24px 70px rgba(20, 20, 30, 0.28);
+	animation: jv-scp-popin 0.16s ease;
+}
+.jv-scp-title {
+	font-size: 16px;
+	font-weight: 650;
+	color: var(--text);
+}
+.jv-scp-msg {
+	margin-top: 8px;
+	font-size: 13.5px;
+	line-height: 1.5;
+	color: var(--text-2);
+}
+.jv-scp-preview {
+	margin-top: 12px;
+	padding: 10px 12px;
+	max-height: 130px;
+	overflow-y: auto;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	background: var(--surface-1);
+	font-size: 12px;
+	line-height: 1.5;
+	color: var(--text-2);
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+.jv-scp-foot {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	margin-top: 20px;
+}
+.jv-scp-foot-main {
+	display: flex;
+	gap: 10px;
+}
+/* "Don't ask again" is a real choice but a quieter one visually than Yes/No -
+   left-aligned and unobtrusive so it doesn't compete with the two answers a
+   user picks nearly every time. */
+.jv-scp-dontask {
+	font-size: 12.5px;
+	color: var(--text-3);
+}
+.jv-scp-fade-enter-active,
+.jv-scp-fade-leave-active {
+	transition: opacity 0.16s ease;
+}
+.jv-scp-fade-enter-from,
+.jv-scp-fade-leave-to {
+	opacity: 0;
+}
+@keyframes jv-scp-popin {
+	from {
+		transform: scale(0.98);
+		opacity: 0.5;
+	}
+	to {
+		transform: scale(1);
+		opacity: 1;
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-scp-dialog {
+		animation: none;
+	}
+	.jv-scp-fade-enter-active,
+	.jv-scp-fade-leave-active {
+		transition: none;
+	}
+}
+</style>

--- a/frontend/src/components/support/SupportShell.vue
+++ b/frontend/src/components/support/SupportShell.vue
@@ -102,6 +102,27 @@ const { effectiveDark, paletteVars } = useJarvisTheme();
 	color: var(--text);
 	background: var(--surface);
 }
+/* Support-only retint: --link is chat's hyperlink blue (theme.js), which is what
+   both Message.vue's file-attachment chips AND embedded links in a rendered reply
+   body read their colour from. On the support surface that read as "some blue
+   color". A first pass retinted it to the brand's own purple instead - still not
+   what was asked for: filenames and in-message wording read clearest as plain
+   ink text, not a second accent colour competing with the brand mark. --text is
+   theme.js's primary ink token (near-black in light, near-white in dark), so
+   this stays correct in both themes without a hardcoded hex. Scoped to this
+   subtree only - main chat keeps its blue links, and this is a scoped custom-
+   property override, not an edit to Message.vue, so it can never drift the two
+   apart by accident.
+
+   Declared on the CHILDREN, not on .jv-sup-content.jv-root itself: that element
+   carries paletteVars as an inline style (:style="chatSurface ? paletteVars :
+   null" above), which already sets --link, and an inline style always wins over
+   an author stylesheet rule on the SAME element regardless of selector
+   specificity. A custom property re-declared one level down is a normal
+   inheritance override, not a specificity fight, so it applies. */
+.jv-sup-content.jv-root > * {
+	--link: var(--text);
+}
 .jv-sup-center {
 	flex: 1;
 	min-width: 0;

--- a/frontend/src/components/support/SupportSidebar.vue
+++ b/frontend/src/components/support/SupportSidebar.vue
@@ -12,18 +12,9 @@
 			<UserMenu :is-collapsed="collapsed" variant="support" />
 
 			<div class="jv-supsb-nav">
-				<!-- Prominent primary CTA — the SAME solid Button the list top bar uses,
-				     so the two "New ticket" actions match. Icon-only when collapsed. -->
-				<Button
-					class="jv-supsb-new"
-					variant="solid"
-					:label="collapsed ? null : 'New ticket'"
-					:icon="collapsed ? 'plus' : null"
-					:icon-left="collapsed ? null : 'plus'"
-					:aria-label="collapsed ? 'New ticket' : undefined"
-					:title="collapsed ? 'New ticket' : undefined"
-					@click="newTicket"
-				/>
+				<!-- New-ticket creation lives on the list page's own toolbar now
+				     (matches Helpdesk's own sidebar, which has no rail-level "New"
+				     button either) - a permanent CTA here duplicated it. -->
 				<SidebarLink
 					icon="inbox"
 					label="Support tickets"
@@ -60,17 +51,11 @@
 
 <script setup>
 import { computed, ref } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import { Button } from "frappe-ui";
+import { useRoute } from "vue-router";
 import UserMenu from "@/components/shell/UserMenu.vue";
 import SidebarLink from "@/components/shell/SidebarLink.vue";
 
 const route = useRoute();
-const router = useRouter();
-
-function newTicket() {
-	router.push({ name: "SupportNew" });
-}
 
 // Collapse state persists across reloads, self-contained (the shell doesn't need
 // to know — the rail sets its own width and SidebarLink hides labels when collapsed).
@@ -130,17 +115,5 @@ function openDesk() {
 }
 .jv-supsb-nav {
 	margin-top: 14px;
-}
-/* The New-ticket CTA: full-width solid button when expanded, a compact centred
-   icon button when collapsed. (`.jv-supsb-new` is on the frappe-ui Button's root,
-   which carries this component's scope id, so scoped styles reach it.) */
-.jv-supsb-new {
-	width: 100%;
-	justify-content: center;
-	margin-bottom: 6px;
-}
-.jv-supsb-collapsed .jv-supsb-new {
-	width: auto;
-	align-self: center;
 }
 </style>

--- a/frontend/src/components/support/SupportTicketPanel.vue
+++ b/frontend/src/components/support/SupportTicketPanel.vue
@@ -35,7 +35,7 @@
 				<span class="jv-suptp-value">
 					<Badge
 						v-if="meta?.status"
-						variant="subtle"
+						:variant="statusBadge.variant"
 						:theme="statusBadge.theme"
 						:label="statusBadge.label"
 					/>

--- a/frontend/src/composables/useSupportCopyPrompt.js
+++ b/frontend/src/composables/useSupportCopyPrompt.js
@@ -1,0 +1,34 @@
+// Promise-based "copy this chat into your new ticket?" prompt — same shared-
+// state pattern as useConfirm.js (a single mounted dialog driven by module-scope
+// state), kept as its own composable rather than a 3rd useConfirm() button
+// because this one also renders a preview of what would be copied, and its
+// resolution has three distinct meanings (yes-this-once / no-this-once /
+// stop-asking), not a plain boolean.
+import { ref } from "vue";
+
+// { preview: string } while open, null when closed. The mounted dialog is the
+// only reader; call sites never touch it directly.
+export const copyPromptState = ref(null);
+let _resolve = null;
+
+// Resolves "yes" | "no" | "dontask". One at a time, same reasoning as
+// useConfirm: a second call while one is open resolves "no" rather than
+// clobbering what the user is looking at.
+export function promptSupportCopy({ preview } = {}) {
+	if (_resolve) return Promise.resolve("no");
+	return new Promise((resolve) => {
+		_resolve = resolve;
+		copyPromptState.value = { preview: preview || "" };
+	});
+}
+
+export function settleSupportCopyPrompt(val) {
+	copyPromptState.value = null;
+	const r = _resolve;
+	_resolve = null;
+	if (r) r(val);
+}
+
+export function useSupportCopyPrompt() {
+	return { promptSupportCopy };
+}

--- a/frontend/src/composables/useSupportCopyPrompt.js
+++ b/frontend/src/composables/useSupportCopyPrompt.js
@@ -1,4 +1,4 @@
-// Promise-based "copy this chat into your new ticket?" prompt — same shared-
+// Promise-based "copy this chat into your new ticket?" prompt, the same shared-
 // state pattern as useConfirm.js (a single mounted dialog driven by module-scope
 // state), kept as its own composable rather than a 3rd useConfirm() button
 // because this one also renders a preview of what would be copied, and its

--- a/frontend/src/composables/useSupportCopyPrompt.spec.js
+++ b/frontend/src/composables/useSupportCopyPrompt.spec.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+	copyPromptState,
+	promptSupportCopy,
+	settleSupportCopyPrompt,
+} from "./useSupportCopyPrompt.js";
+
+/**
+ * Covers the module-scope resolver singleton directly (review finding: an
+ * unmount before settle used to leave `_resolve` set forever, silently
+ * dropping every future prompt to "no" for the rest of the session - see
+ * openSupport()'s AppShell-mount fix in ChatView.vue). settle() is the one
+ * escape hatch that clears `_resolve`, so these tests exercise it the way
+ * SupportCopyPromptDialog's Yes/No/Don't-ask buttons and Escape key do.
+ */
+
+describe("useSupportCopyPrompt", () => {
+	it("opens with the given preview and resolves with the settled value", async () => {
+		const p = promptSupportCopy({ preview: "You: hi\n\nJarvis: hello" });
+		expect(copyPromptState.value).toEqual({ preview: "You: hi\n\nJarvis: hello" });
+		settleSupportCopyPrompt("yes");
+		expect(await p).toBe("yes");
+		// Settling clears the dialog's own state too, not just the resolver.
+		expect(copyPromptState.value).toBeNull();
+	});
+
+	it("defaults preview to an empty string when none is given", () => {
+		promptSupportCopy();
+		expect(copyPromptState.value).toEqual({ preview: "" });
+		settleSupportCopyPrompt("no");
+	});
+
+	it("a concurrent second call resolves 'no' immediately without touching the open prompt", async () => {
+		const first = promptSupportCopy({ preview: "first" });
+		const second = promptSupportCopy({ preview: "second" });
+		// The second call must not have replaced the dialog's preview.
+		expect(copyPromptState.value).toEqual({ preview: "first" });
+		expect(await second).toBe("no");
+		settleSupportCopyPrompt("dontask");
+		expect(await first).toBe("dontask");
+	});
+
+	it("settling with no prompt open is a harmless no-op", () => {
+		expect(copyPromptState.value).toBeNull();
+		expect(() => settleSupportCopyPrompt("no")).not.toThrow();
+		expect(copyPromptState.value).toBeNull();
+	});
+
+	it("survives an abandoned prompt: a bare settle (simulating unmount) frees the next prompt", async () => {
+		// This is the regression itself: SupportCopyPromptDialog unmounting
+		// without the user answering (e.g. a route change) must still call
+		// settle() so `_resolve` doesn't wedge every prompt after it. Nothing
+		// in this composable does that automatically - it's the mounting
+		// component's job (onBeforeUnmount) - so this test documents the
+		// contract: whoever tears the dialog down MUST settle first.
+		const abandoned = promptSupportCopy({ preview: "abandoned" });
+		settleSupportCopyPrompt("no"); // stands in for the dialog's teardown settle
+		await abandoned;
+
+		const next = promptSupportCopy({ preview: "next" });
+		expect(copyPromptState.value).toEqual({ preview: "next" });
+		settleSupportCopyPrompt("yes");
+		expect(await next).toBe("yes");
+	});
+});

--- a/frontend/src/lib/supportCopyFormat.js
+++ b/frontend/src/lib/supportCopyFormat.js
@@ -1,0 +1,33 @@
+// Formats the tail of a chat transcript as plain text for the "copy this chat
+// into your ticket?" prompt (ChatView's openSupport). Pure (no Vue, no store)
+// so it is unit-testable on its own, the same reasoning as lib/supportBody.js's
+// compose-side helpers.
+export const SUPPORT_COPY_COUNT = 4;
+export const SUPPORT_COPY_CHARS = 400;
+
+// `messages`: chat history entries ({role, content}); `agentName`: how the
+// assistant's turns are labelled. Only user/assistant turns with non-blank
+// content count as "visible" - tool calls, empty placeholders, etc. are noise
+// support staff reading the ticket don't need.
+export function formatRecentMessagesForSupport(
+	messages,
+	agentName,
+	count = SUPPORT_COPY_COUNT,
+	chars = SUPPORT_COPY_CHARS
+) {
+	const visible = (messages || []).filter(
+		(m) => m && (m.role === "user" || m.role === "assistant") && (m.content || "").trim()
+	);
+	return visible.slice(-count).map((m) => {
+		const who = m.role === "user" ? "You" : agentName;
+		const text = m.content.trim();
+		// Code-point-aware clip: text.slice() indexes UTF-16 code units, which
+		// can cut an astral character (e.g. an emoji) in half and leave an
+		// unpaired surrogate in both the preview and, if copied, the ticket
+		// body support staff read. The spread operator iterates by code point.
+		const codePoints = [...text];
+		const clipped =
+			codePoints.length > chars ? codePoints.slice(0, chars).join("") + "…" : text;
+		return `${who}: ${clipped}`;
+	});
+}

--- a/frontend/src/lib/supportCopyFormat.spec.js
+++ b/frontend/src/lib/supportCopyFormat.spec.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { formatRecentMessagesForSupport } from "./supportCopyFormat.js";
+
+describe("formatRecentMessagesForSupport", () => {
+	it("labels user and assistant turns, in transcript order", () => {
+		const out = formatRecentMessagesForSupport(
+			[
+				{ role: "user", content: "hi" },
+				{ role: "assistant", content: "hello" },
+			],
+			"Jarvis"
+		);
+		expect(out).toEqual(["You: hi", "Jarvis: hello"]);
+	});
+
+	it("drops everything except user/assistant turns with real content", () => {
+		const out = formatRecentMessagesForSupport(
+			[
+				{ role: "tool", content: "get_customer(...)" },
+				{ role: "user", content: "   " }, // whitespace-only
+				{ role: "assistant", content: "" },
+				{ role: "user", content: "real question" },
+				null, // defensive: a malformed entry must not throw
+			],
+			"Jarvis"
+		);
+		expect(out).toEqual(["You: real question"]);
+	});
+
+	it("keeps only the last N visible turns", () => {
+		const messages = Array.from({ length: 6 }, (_, i) => ({
+			role: i % 2 === 0 ? "user" : "assistant",
+			content: `turn ${i}`,
+		}));
+		const out = formatRecentMessagesForSupport(messages, "Jarvis", 4);
+		expect(out).toEqual(["You: turn 2", "Jarvis: turn 3", "You: turn 4", "Jarvis: turn 5"]);
+	});
+
+	it("leaves short text untouched, with no ellipsis", () => {
+		const out = formatRecentMessagesForSupport([{ role: "user", content: "short" }], "Jarvis");
+		expect(out).toEqual(["You: short"]);
+	});
+
+	it("clips long text to the code-point limit and appends an ellipsis", () => {
+		const long = "a".repeat(500);
+		const out = formatRecentMessagesForSupport(
+			[{ role: "user", content: long }],
+			"Jarvis",
+			4,
+			400
+		);
+		expect(out[0]).toBe(`You: ${"a".repeat(400)}…`);
+	});
+
+	it("clips by CODE POINT, not UTF-16 code unit, so an emoji straddling the limit stays whole", () => {
+		// 🎉 is an astral character: two UTF-16 code units, one code point.
+		// text.slice(0, N) on UTF-16 units can land mid-surrogate-pair and leave
+		// an unpaired surrogate in the clipped output (review finding).
+		const text = "a".repeat(399) + "🎉" + "b".repeat(50);
+		const out = formatRecentMessagesForSupport(
+			[{ role: "user", content: text }],
+			"Jarvis",
+			4,
+			400
+		);
+		const body = out[0].slice("You: ".length);
+		// The limit (400 code points) falls exactly on the emoji: it is either
+		// whole in the clipped output or excluded entirely - never split.
+		expect(body.endsWith("…")).toBe(true);
+		expect(body).not.toMatch(/[\uD800-\uDBFF]$/); // no dangling high surrogate
+		expect(body).not.toMatch(/^[\uDC00-\uDFFF]/); // no dangling low surrogate
+	});
+
+	it("trims surrounding whitespace before measuring/clipping", () => {
+		const out = formatRecentMessagesForSupport(
+			[{ role: "user", content: "  padded text  \n" }],
+			"Jarvis"
+		);
+		expect(out).toEqual(["You: padded text"]);
+	});
+
+	it("returns an empty array for no messages or an empty/undefined list", () => {
+		expect(formatRecentMessagesForSupport([], "Jarvis")).toEqual([]);
+		expect(formatRecentMessagesForSupport(undefined, "Jarvis")).toEqual([]);
+	});
+});

--- a/frontend/src/pages/support/SupportListPage.vue
+++ b/frontend/src/pages/support/SupportListPage.vue
@@ -66,7 +66,7 @@
 
 			<template #cell-status="{ row }">
 				<Badge
-					variant="subtle"
+					:variant="badgeFor(row.status).variant"
 					:theme="badgeFor(row.status).theme"
 					:label="badgeFor(row.status).label"
 				/>

--- a/frontend/src/pages/support/SupportNewPage.vue
+++ b/frontend/src/pages/support/SupportNewPage.vue
@@ -129,7 +129,7 @@ async function create() {
 			// submit must not be uploaded (Helpdesk has no un-attach). Threaded onto
 			// openingComm (the ticket's own auto-mirrored opening message) so these
 			// render inline in the first bubble instead of as a floating ticket-level
-			// pill row — the same inline treatment a reply's attachment already gets.
+			// pill row, the same inline treatment a reply's attachment already gets.
 			const live = staged.filter((f) => files.value.includes(f));
 			if (live.length) {
 				const uploaded = await store.uploadTo(name, live, openingComm);

--- a/frontend/src/pages/support/SupportNewPage.vue
+++ b/frontend/src/pages/support/SupportNewPage.vue
@@ -120,15 +120,19 @@ async function create() {
 		if (stripped) {
 			toast.info("Embedded images were removed - add them with the Attach button instead.");
 		}
-		const name = await store.createTicket(subject.value.trim().slice(0, 140), body);
-		if (!name) return; // the store toasted; keep the draft so nothing is lost
+		const created = await store.createTicket(subject.value.trim().slice(0, 140), body);
+		if (!created) return; // the store toasted; keep the draft so nothing is lost
+		const { name, openingComm } = created;
 
 		if (staged.length) {
 			// Upload only files STILL staged: a chip removed during this in-flight
-			// submit must not be uploaded (Helpdesk has no un-attach).
+			// submit must not be uploaded (Helpdesk has no un-attach). Threaded onto
+			// openingComm (the ticket's own auto-mirrored opening message) so these
+			// render inline in the first bubble instead of as a floating ticket-level
+			// pill row — the same inline treatment a reply's attachment already gets.
 			const live = staged.filter((f) => files.value.includes(f));
 			if (live.length) {
-				const uploaded = await store.uploadTo(name, live);
+				const uploaded = await store.uploadTo(name, live, openingComm);
 				settleUpload(uploaded);
 			}
 		}

--- a/frontend/src/pages/support/SupportThreadPage.vue
+++ b/frontend/src/pages/support/SupportThreadPage.vue
@@ -12,7 +12,7 @@
 			     badge + Resolve instead of a blank header contradicting the panel. -->
 			<Badge
 				v-if="ticketStatus"
-				variant="subtle"
+				:variant="badge.variant"
 				:theme="badge.theme"
 				:label="badge.label"
 			/>
@@ -47,27 +47,35 @@
 				     so bubbles/rows read as a chat thread instead of stretching
 				     full-bleed with the user's replies hugging the far edge. -->
 				<div class="jv-sup-thread-inner">
-					<div v-if="ticketAttachments.length" class="jv-sup-files">
-						<a
-							v-for="a in ticketAttachments"
-							:key="a.name"
-							class="jv-sup-file"
-							:class="{ 'jv-sup-file-img': a.type === 'image' }"
-							:href="a.file_url"
-							target="_blank"
-							rel="noopener"
+					<!-- Ticket-level fallback only: files a NEW ticket's opening message
+					     attaches now ride the opening Communication and render inline
+					     in that bubble instead (see SupportNewPage's openingComm). This
+					     block only ever fires for a ticket opened before that shipped,
+					     or on a Helpdesk build that doesn't auto-mirror the opening
+					     message - hence the caption, so a legacy cluster of files reads
+					     as "from opening this ticket", not as an unexplained orphan list. -->
+					<div v-if="ticketAttachments.length" class="jv-sup-files-wrap">
+						<span class="jv-sup-files-label"
+							>Attached when this ticket was opened</span
 						>
-							<img
-								v-if="a.type === 'image'"
-								:src="a.file_url"
-								:alt="a.title"
-								loading="lazy"
-								class="jv-sup-thumb"
-							/>
-							<template v-else>
-								<FeatherIcon name="paperclip" class="size-3.5" />{{ a.title }}
-							</template>
-						</a>
+						<div class="jv-sup-files">
+							<!-- Same filename-chip treatment as every other attachment (see
+							     Message's imagesAsChips) - an image here used to get a bare
+							     56px crop with no name at all, worse than the "vague" preview
+							     everything else was fixed for. -->
+							<a
+								v-for="a in ticketAttachments"
+								:key="a.name"
+								class="jv-sup-file"
+								:href="a.file_url"
+								target="_blank"
+								rel="noopener"
+							>
+								<FeatherIcon name="paperclip" class="jv-sup-file-clip" />{{
+									a.title
+								}}
+							</a>
+						</div>
 					</div>
 
 					<!-- Reachable: a brand-new ticket created with an empty body and no
@@ -91,7 +99,7 @@
 							:timestamp="m.timestamp"
 							:timestamp-full="m.timestampFull"
 							:copyable="false"
-							@open-attachment="openAttachment"
+							images-as-chips
 						>
 							<template v-if="m.fromSupport" #avatar>
 								<div class="jv-sup-avatar" aria-hidden="true">S</div>
@@ -202,14 +210,6 @@ const disclaimer = computed(() => {
 	return "";
 });
 
-// Message emits the RAW attachment record it was given ({file_url, title,
-// type, name}) — file_url is already the proxied download URL (classifyAttachment
-// below), so this is a plain new-tab open, same as the real ticket-level
-// attachment links a few lines up in the template.
-function openAttachment(a) {
-	if (a && a.file_url) window.open(a.file_url, "_blank", "noopener");
-}
-
 // "Sent" means the support side sent it (helpdesk_client.py queries
 // sent_or_received directly). Anything else — including a missing value — is
 // this user's own message.
@@ -258,11 +258,12 @@ function attachmentsOf(m) {
 	return ((m && m.attachments) || []).map(classifyAttachment);
 }
 
-// Ticket-level attachments (shown above the message list) used to render as a
-// plain download chip with no image check at all — a regression from the old
-// SupportPage, which did classify these. Message.vue already proves the image
-// vs. file split for per-message attachments; this brings ticket-level ones up
-// to the same standard instead of leaving them a second, worse code path.
+// Ticket-level attachments (shown above the message list) share classifyAttachment
+// with the per-message path below, so `.type` still gets computed here - but the
+// template no longer branches on it (every support attachment, ticket-level or
+// per-message, renders as a plain paperclip+filename chip now; no image preview).
+// Left in rather than forked so ticket-level and per-message attachments can never
+// silently classify the same file differently.
 const ticketAttachments = computed(() => store.thread.attachments.map(classifyAttachment));
 
 function downloadUrl(fileUrl) {
@@ -614,37 +615,45 @@ watch(ticketName, (n) => open(n));
 	padding: 48px 0;
 	color: var(--text-2);
 }
+.jv-sup-files-wrap {
+	margin-bottom: 12px;
+}
+.jv-sup-files-label {
+	display: block;
+	margin-bottom: 6px;
+	font-size: 11.5px;
+	color: var(--text-3);
+}
 .jv-sup-files {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
-	margin-bottom: 12px;
 }
+/* Same shape as a per-message attachment chip (Message.vue's .jv-file-chip) -
+   radius, padding, font-size, icon size all match, so a file attached at
+   ticket-open time and one attached in a reply read as the same kind of
+   object, not two different ones a few pixels apart. */
 .jv-sup-file {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	padding: 4px 10px;
+	padding: 6px 11px;
 	border: 1px solid var(--border);
-	border-radius: 999px;
+	border-radius: 10px;
+	background: var(--surface-2);
 	color: var(--link);
-	font-size: 12px;
+	font-size: 12.5px;
+	line-height: 1.3;
 	text-decoration: none;
+	overflow-wrap: anywhere;
 }
-/* Image variant: a thumbnail instead of the icon+filename pill, same border
-   treatment as Message's per-attachment image thumbnail so the two don't look
-   like unrelated features. */
-.jv-sup-file-img {
-	padding: 0;
-	border-radius: 8px;
-	overflow: hidden;
-	line-height: 0;
+.jv-sup-file:hover {
+	text-decoration: underline;
 }
-.jv-sup-thumb {
-	display: block;
-	width: 56px;
-	height: 56px;
-	object-fit: cover;
+.jv-sup-file-clip {
+	flex: 0 0 auto;
+	width: 13px;
+	height: 13px;
 }
 .jv-sup-avatar {
 	display: flex;

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -15,6 +15,8 @@ import {
 	supportCloseTicket,
 	supportAwaitingCount,
 	supportUpload,
+	getMySettings,
+	updateMySettings,
 } from "@/api";
 
 // Mirrors jarvis_helpdesk/setup/install.py:39 AWAITING_STATUSES and
@@ -35,10 +37,17 @@ export function isClosed(status) {
 // by the design system rather than hand-rolled colours. This also retires the
 // spec's AA-contrast workaround: the failure was raw --amber on --amber-bg, and
 // Badge's own token pairs are the system's answer to exactly that.
+//
+// No `blue` here: frappe-ui's Badge themes (gray/blue/green/orange/red) don't
+// include the brand's own purple, and a generic blue read as off-theme next to
+// it (the rest of the app's accent is neutral black/white - see --cta in
+// theme.js). Open uses `solid` gray instead of `subtle` so it still reads as
+// the "active" state at a glance, distinct from Closed's quiet subtle gray,
+// without reaching for a colour the brand doesn't use.
 export function badgeFor(status) {
-	if (isAwaiting(status)) return { label: "Awaiting you", theme: "orange" };
-	if (isClosed(status)) return { label: "Closed", theme: "gray" };
-	return { label: "Open", theme: "blue" };
+	if (isAwaiting(status)) return { label: "Awaiting you", theme: "orange", variant: "subtle" };
+	if (isClosed(status)) return { label: "Closed", theme: "gray", variant: "subtle" };
+	return { label: "Open", theme: "gray", variant: "solid" };
 }
 
 const tickets = ref([]);
@@ -126,6 +135,36 @@ function fingerprintOf(name) {
 	return row ? JSON.stringify(row) : "";
 }
 
+// Jarvis User Settings' support_context_copy_pref ("" | "Yes" | "No"), cached
+// here so ChatView's Support button reads it without a fresh network round-
+// trip on every click (it used to run api.getMySettings() unconditionally on
+// every click, with no loading indicator - review finding). null = not yet
+// loaded; loadingCopyPref de-dupes overlapping first-load callers rather than
+// firing one request per concurrent caller.
+const copyPref = ref(null);
+let loadingCopyPref = null;
+async function getCopyPref() {
+	if (copyPref.value !== null) return copyPref.value;
+	if (!loadingCopyPref) {
+		loadingCopyPref = getMySettings()
+			.then((r) => {
+				copyPref.value = (r && r.data && r.data.support_context_copy_pref) || "";
+				return copyPref.value;
+			})
+			.catch(() => "") // best-effort: a failed read just falls back to asking, and
+			// leaves copyPref.value at null so the NEXT call retries rather than
+			// caching a transient failure as a permanent "always ask".
+			.finally(() => {
+				loadingCopyPref = null;
+			});
+	}
+	return loadingCopyPref;
+}
+function setCopyPref(v) {
+	copyPref.value = v;
+	updateMySettings({ support_context_copy_pref: v }).catch(() => {});
+}
+
 async function refreshAwaiting() {
 	try {
 		const r = await supportAwaitingCount();
@@ -147,7 +186,11 @@ async function createTicket(subject, body) {
 			toast.error("The ticket couldn't be created. Please try again.");
 			return null;
 		}
-		return name;
+		// openingComm (null on an older Helpdesk that doesn't auto-mirror the opening
+		// message, or an empty body): let the caller thread it into uploadTo so files
+		// attached at ticket-creation time land on that Communication and render inline,
+		// the same as a reply's — see reply()'s `comm` for the established pattern.
+		return { name, openingComm: (r.data && r.data.opening_comm) || null };
 	} catch (e) {
 		toast.error(errHtml(e));
 		return null;
@@ -213,6 +256,8 @@ const store = reactive({
 	loadTickets,
 	loadThread,
 	refreshAwaiting,
+	getCopyPref,
+	setCopyPref,
 	createTicket,
 	reply,
 	closeTicket,

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -189,7 +189,7 @@ async function createTicket(subject, body) {
 		// openingComm (null on an older Helpdesk that doesn't auto-mirror the opening
 		// message, or an empty body): let the caller thread it into uploadTo so files
 		// attached at ticket-creation time land on that Communication and render inline,
-		// the same as a reply's — see reply()'s `comm` for the established pattern.
+		// the same as a reply's; see reply()'s `comm` for the established pattern.
 		return { name, openingComm: (r.data && r.data.opening_comm) || null };
 	} catch (e) {
 		toast.error(errHtml(e));

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3766,7 +3766,6 @@ import {
 	watchEffect,
 } from "vue";
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
-import { toast } from "frappe-ui";
 import * as api from "@/api";
 import * as voice from "@/api/voice";
 import { agentName, isWhitelabeled } from "@/branding";
@@ -3791,6 +3790,7 @@ import { takeChatPrefill } from "@/composables/chatPrefill";
 import { useConfirm } from "@/composables/useConfirm";
 import { promptSupportCopy } from "@/composables/useSupportCopyPrompt";
 import { useSupportStore } from "@/stores/support";
+import { formatRecentMessagesForSupport } from "@/lib/supportCopyFormat";
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
 import { formatDate, exactDate, dayLabel } from "@/utils/datetime";
 import { fenceReject, fenceAccept } from "@/utils/eventFence";
@@ -4037,38 +4037,22 @@ const supportStore = supportOn ? useSupportStore() : null;
 // (an active conversation with visible messages) and the user hasn't already
 // answered "don't ask again". Formats the last few turns as plain text; the
 // New Ticket page's existing ?body= prefill (query.body -> plainToHtml) does
-// the rest, same mechanism a macro/prefill link already uses.
-const SUPPORT_COPY_COUNT = 4;
-const SUPPORT_COPY_CHARS = 400;
+// the rest, same mechanism a macro/prefill link already uses. The formatting
+// itself lives in lib/supportCopyFormat.js (pure, unit-tested on its own).
 function recentMessagesForSupport() {
-	const visible = messages.value.filter(
-		(m) => (m.role === "user" || m.role === "assistant") && (m.content || "").trim()
-	);
-	return visible.slice(-SUPPORT_COPY_COUNT).map((m) => {
-		const who = m.role === "user" ? "You" : agentName;
-		const text = m.content.trim();
-		// Code-point-aware clip: text.slice() indexes UTF-16 code units, which
-		// can cut an astral character (e.g. an emoji) in half and leave an
-		// unpaired surrogate in both the preview and, if copied, the ticket
-		// body support staff read. The spread operator iterates by code point.
-		const chars = [...text];
-		const clipped =
-			chars.length > SUPPORT_COPY_CHARS
-				? chars.slice(0, SUPPORT_COPY_CHARS).join("") + "…"
-				: text;
-		return `${who}: ${clipped}`;
-	});
+	return formatRecentMessagesForSupport(messages.value, agentName);
 }
 // Guards the async gap below (a settings fetch, maybe a dialog await) against
-// a double-click firing openSupport() twice concurrently — without this, a
+// a double-click firing openSupport() twice concurrently: without this, a
 // second click could race the first to SupportNew before the first's prompt
 // even resolves.
 let openSupportInFlight = false;
 async function openSupport() {
 	if (!supportOn) {
 		// Unconfigured-but-visible state (see supportEntryVisible): explain rather
-		// than navigate into a route the guard would just bounce back from.
-		toast.info("Support isn't set up on this workspace yet — ask your administrator.");
+		// than navigate into a route the guard would just bounce back from. Same
+		// helper + toast as every other "not set up yet" control in this header.
+		explainUnavailable("Support");
 		return;
 	}
 	// A resting badge means tickets are waiting on the user's reply - the click
@@ -9883,7 +9867,7 @@ onUnmounted(() => {
 .jv-iconbtn:hover svg {
 	stroke: var(--surface) !important;
 }
-/* Resting badge on the Support button — mirrors the "Awaiting you" ticket
+/* Resting badge on the Support button: mirrors the "Awaiting you" ticket
    badge's amber, so the same colour means the same thing everywhere. */
 .jv-support-dot {
 	position: absolute;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -283,6 +283,70 @@
 							<path d="M11 18h2" />
 						</svg>
 					</button>
+					<!-- Support: hidden outright when off/error (see supportEntryVisible);
+					     shown-but-explanatory when an operator hasn't finished configuring
+					     it yet, same two states UserMenu's old menu entry handled - this
+					     button replaces that entry rather than duplicating it. Unconfigured
+					     gets the same jv-unavailable + aria-disabled treatment the STT/wiki
+					     buttons use for their own "visible but not usable yet" state, so a
+					     screen-reader user hears it's inert before clicking, not after. -->
+					<button
+						v-if="supportEntryVisible"
+						class="jv-iconbtn jv-support-btn"
+						:class="{ 'jv-unavailable': supportUnconfigured }"
+						:aria-disabled="supportUnconfigured ? 'true' : undefined"
+						@click="openSupport"
+						:title="
+							supportUnconfigured
+								? 'Support is not set up on this workspace yet'
+								: 'Support'
+						"
+						:aria-label="
+							supportUnconfigured
+								? 'Support is not set up on this workspace yet'
+								: 'Support'
+						"
+						style="
+							position: relative;
+							width: 32px;
+							height: 32px;
+							display: flex;
+							align-items: center;
+							justify-content: center;
+							background: transparent;
+							border: 1px solid var(--border);
+							border-radius: 7px;
+							cursor: pointer;
+						"
+					>
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="var(--text-2)"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M3 18v-6a9 9 0 0 1 18 0v6" />
+							<path
+								d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"
+							/>
+						</svg>
+						<!-- Resting badge: a waiting reply has to register while the user is
+						     heads-down in chat. Moved here from UserMenu's avatar (Support
+						     lived only in the menu before) so the dot sits on the control
+						     that actually opens Support. -->
+						<span
+							v-if="supportOn && supportStore.awaitingCount"
+							class="jv-support-dot"
+							:aria-label="`${supportStore.awaitingCount} ${
+								supportStore.awaitingCount === 1 ? 'ticket' : 'tickets'
+							} awaiting your reply`"
+							role="status"
+						/>
+					</button>
 					<button
 						class="jv-iconbtn"
 						@click="toggleTheme"
@@ -2821,55 +2885,13 @@
 								</svg>
 								<span v-if="groundNextTurn">Wiki</span>
 							</button>
-							<!-- "Get help from a human" — always-available chat hook into the
-							     standalone support space (Task 6). Gated on the same dual
-							     kill-switch the /support routes guard on. -->
-							<button
-								v-if="supportOn || supportUnconfigured"
-								class="jv-iconbtn"
-								:class="{ 'jv-unavailable': supportUnconfigured }"
-								:aria-disabled="supportUnconfigured ? 'true' : undefined"
-								:title="
-									supportUnconfigured
-										? 'Support is not set up on this workspace yet'
-										: 'Get help from a human'
-								"
-								@click="
-									supportUnconfigured
-										? explainSupportUnavailable()
-										: getHumanHelp()
-								"
-								style="
-									width: 30px;
-									height: 30px;
-									display: flex;
-									align-items: center;
-									justify-content: center;
-									background: transparent;
-									border: none;
-									border-radius: 7px;
-									cursor: pointer;
-									color: var(--text-3);
-								"
-							>
-								<svg
-									width="17"
-									height="17"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.7"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<circle cx="12" cy="12" r="10" />
-									<circle cx="12" cy="12" r="4" />
-									<line x1="4.93" y1="4.93" x2="9.17" y2="9.17" />
-									<line x1="14.83" y1="14.83" x2="19.07" y2="19.07" />
-									<line x1="14.83" y1="9.17" x2="19.07" y2="4.93" />
-									<line x1="4.93" y1="19.07" x2="9.17" y2="14.83" />
-								</svg>
-							</button>
+							<!-- The composer's own "Get help from a human" button used to live
+							     here (Task 6) - it's gone now that Support has one entry point,
+							     the headphones icon in the header (see supportEntryVisible near
+							     openSupport), which also carries the new copy-last-messages
+							     prompt this composer button never had. Two controls opening the
+							     same space would just be the button this request asked to move,
+							     left behind a second time. -->
 						</template>
 						<template #right-toolbar>
 							<!-- Dictation mic. Two DIFFERENT unavailable reasons, two treatments:
@@ -3722,6 +3744,12 @@
 			:fileUrl="userFilePreview.file_url"
 			:fileName="userFilePreview.file_name"
 		/>
+		<!-- SupportCopyPromptDialog now mounts once in AppShell (above the router
+		     view), not here - a route change away from Chat used to unmount it
+		     mid-prompt and permanently wedge promptSupportCopy()'s module-scope
+		     resolver (review finding: the copy-into-ticket feature going silently
+		     dead for the rest of the session). Same fix ConfirmDialog already had
+		     by living in AppShell from the start. -->
 	</div>
 </template>
 
@@ -3738,6 +3766,7 @@ import {
 	watchEffect,
 } from "vue";
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
+import { toast } from "frappe-ui";
 import * as api from "@/api";
 import * as voice from "@/api/voice";
 import { agentName, isWhitelabeled } from "@/branding";
@@ -3760,6 +3789,8 @@ import {
 import { setMacroPrefill } from "@/composables/macroPrefill";
 import { takeChatPrefill } from "@/composables/chatPrefill";
 import { useConfirm } from "@/composables/useConfirm";
+import { promptSupportCopy } from "@/composables/useSupportCopyPrompt";
+import { useSupportStore } from "@/stores/support";
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
 import { formatDate, exactDate, dayLabel } from "@/utils/datetime";
 import { fenceReject, fenceAccept } from "@/utils/eventFence";
@@ -3989,6 +4020,96 @@ function announceSR(msg) {
 // dismissal and rendering are owned by that component.
 const { confirm } = useConfirm();
 const showConnect = ref(false);
+
+// Support entry point (header icon). Same two-flag model UserMenu's old menu
+// entry used - supportOn (usable) vs supportUnconfigured (an operator can still
+// set it up, so stay visible and say why rather than vanishing outright); a
+// site with support truly off/erroring shows neither and the button is absent.
+const supportOn = window.support_available && window.has_support_access;
+const supportUnconfigured = window.support_state === "unconfigured" && !!window.has_support_access;
+const supportEntryVisible = supportOn || supportUnconfigured;
+// Singleton store (stores/support.js) - already kept fresh by the sidebar's
+// UserMenu poll timer (always mounted alongside chat), so this view just reads
+// it rather than running a second poller.
+const supportStore = supportOn ? useSupportStore() : null;
+
+// "Copy this chat into your ticket?" - only asked when there IS a chat to copy
+// (an active conversation with visible messages) and the user hasn't already
+// answered "don't ask again". Formats the last few turns as plain text; the
+// New Ticket page's existing ?body= prefill (query.body -> plainToHtml) does
+// the rest, same mechanism a macro/prefill link already uses.
+const SUPPORT_COPY_COUNT = 4;
+const SUPPORT_COPY_CHARS = 400;
+function recentMessagesForSupport() {
+	const visible = messages.value.filter(
+		(m) => (m.role === "user" || m.role === "assistant") && (m.content || "").trim()
+	);
+	return visible.slice(-SUPPORT_COPY_COUNT).map((m) => {
+		const who = m.role === "user" ? "You" : agentName;
+		const text = m.content.trim();
+		// Code-point-aware clip: text.slice() indexes UTF-16 code units, which
+		// can cut an astral character (e.g. an emoji) in half and leave an
+		// unpaired surrogate in both the preview and, if copied, the ticket
+		// body support staff read. The spread operator iterates by code point.
+		const chars = [...text];
+		const clipped =
+			chars.length > SUPPORT_COPY_CHARS
+				? chars.slice(0, SUPPORT_COPY_CHARS).join("") + "…"
+				: text;
+		return `${who}: ${clipped}`;
+	});
+}
+// Guards the async gap below (a settings fetch, maybe a dialog await) against
+// a double-click firing openSupport() twice concurrently — without this, a
+// second click could race the first to SupportNew before the first's prompt
+// even resolves.
+let openSupportInFlight = false;
+async function openSupport() {
+	if (!supportOn) {
+		// Unconfigured-but-visible state (see supportEntryVisible): explain rather
+		// than navigate into a route the guard would just bounce back from.
+		toast.info("Support isn't set up on this workspace yet — ask your administrator.");
+		return;
+	}
+	// A resting badge means tickets are waiting on the user's reply - the click
+	// has to land where those tickets actually are (the old UserMenu entry did
+	// this), not on a blank new-ticket form the badge gave no reason to expect.
+	if (supportStore.awaitingCount) {
+		router.push({ name: "Support" });
+		return;
+	}
+	if (openSupportInFlight) return;
+	openSupportInFlight = true;
+	try {
+		const recent = recentMessagesForSupport();
+		if (!recent.length) {
+			router.push({ name: "SupportNew" });
+			return;
+		}
+		let copyBody = "";
+		// Cached on the support store (fetched once, updated locally on write)
+		// rather than a fresh getMySettings() on every click - see setCopyPref.
+		const pref = await supportStore.getCopyPref();
+		if (pref === "Yes") {
+			copyBody = recent.join("\n\n");
+		} else if (pref === "No") {
+			copyBody = "";
+		} else {
+			const answer = await promptSupportCopy({ preview: recent.join("\n\n") });
+			if (answer === "yes") copyBody = recent.join("\n\n");
+			if (answer === "dontask") {
+				// Don't-ask-again defaults to not copying: a permanent, silent "share my
+				// chat" default is the wrong side to fail toward for conversation content
+				// that can carry anything the user typed, including things they'd want to
+				// choose to include rather than have auto-attached from now on.
+				supportStore.setCopyPref("No");
+			}
+		}
+		router.push({ name: "SupportNew", query: copyBody ? { body: copyBody } : {} });
+	} finally {
+		openSupportInFlight = false;
+	}
+}
 // One-shot "ground on wiki": when armed, the NEXT message carries a
 // context.ground_wiki flag so the backend injects relevant wiki page bodies
 // into that turn. Cleared after each send (see send()).
@@ -4855,18 +4976,11 @@ const currentTitle = computed(
 	() => store.conversations.find((c) => c.name === currentId.value)?.title || "New chat"
 );
 
-// Same dual kill-switch the support routes guard on (router/index.js
-// supportGuard) — a dead button that redirects straight back to chat is worse
-// than no button.
-const supportOn = window.support_available && window.has_support_access;
-
-// Support is UNCONFIGURED (not merely off/erroring) and this user could otherwise use
-// it: an operator can still set it up, so show the entry faded + explained rather than
-// hiding a feature that exists. "off" (deliberately switched off) and "error" (a
-// transient CP blip that self-heals) both stay hidden — a greyed control for either
-// would be misleading. Permission (`has_support_access`) still hides outright: showing
-// a user a feature they can never use is noise, not discovery.
-const supportUnconfigured = window.support_state === "unconfigured" && !!window.has_support_access;
+// supportOn/supportUnconfigured (the same dual kill-switch router/index.js's
+// supportGuard uses) now live once, near openSupport - this file used to
+// declare them a second time down here for the composer's own "Get help from
+// a human" button, which duplicated the header entry point and has been
+// removed.
 
 // STT is UNCONFIGURED specifically — not deliberately off, not a transient CP blip.
 // Only that case earns a faded control: the other two would either nag an admin who
@@ -4886,23 +5000,8 @@ function explainUnavailable(feature) {
 		type: "info",
 	});
 }
-function explainSupportUnavailable() {
-	explainUnavailable("Support");
-}
 function explainSttUnavailable() {
 	explainUnavailable("Voice dictation");
-}
-
-// "Get help from a human" — always available (v1). The conversation reference
-// is plain, readable, user-EDITABLE body text: create_ticket takes only
-// (subject, body), has no context params, and derives the tenant server-side
-// from the API key. An operator-actionable deep-link is v2.
-function getHumanHelp() {
-	const title = (currentTitle.value || "").trim();
-	// "New chat" is currentTitle's fallback, not a real title — carrying it
-	// would put a meaningless quote in front of a support agent.
-	const ref = title && title !== "New chat" ? `\n\n- From Jarvis chat: "${title}"` : "";
-	router.push({ name: "SupportNew", query: ref ? { body: ref } : {} });
 }
 
 // A FAILED tool call with no assistant turn ahead of it in the thread, keyed by
@@ -9783,6 +9882,18 @@ onUnmounted(() => {
 }
 .jv-iconbtn:hover svg {
 	stroke: var(--surface) !important;
+}
+/* Resting badge on the Support button — mirrors the "Awaiting you" ticket
+   badge's amber, so the same colour means the same thing everywhere. */
+.jv-support-dot {
+	position: absolute;
+	top: 3px;
+	right: 3px;
+	width: 8px;
+	height: 8px;
+	border-radius: 999px;
+	background: var(--amber);
+	border: 1.5px solid var(--surface);
 }
 .jv-ctxbtn:hover {
 	background: var(--surface-2);

--- a/frontend/tests/support-extraction/support-badge.test.js
+++ b/frontend/tests/support-extraction/support-badge.test.js
@@ -102,12 +102,12 @@ describe("UserMenu variant (chat vs support)", () => {
 		store.awaitingCount = 0;
 	});
 
-	it("chat (default): title is the agent name; menu links to Support, not chat", () => {
+	it("chat (default): title is the agent name; no Support menu item (it lives in ChatView's header icon now, not the dropdown)", () => {
 		const w = mount(UserMenu, opts);
 		expect(w.text()).toContain(agentName);
 		expect(w.text()).not.toContain(`${agentName} Support`);
 		const labels = menuLabels(w);
-		expect(labels).toContain("Support");
+		expect(labels).not.toContain("Support");
 		expect(labels).not.toContain(`Switch to ${agentName} chat`);
 		expect(labels).toContain("Change theme");
 		expect(labels).toContain("Settings"); // chat/LLM settings belong here

--- a/frontend/tests/support-extraction/support-new.test.js
+++ b/frontend/tests/support-extraction/support-new.test.js
@@ -23,7 +23,7 @@ vi.mock("frappe-ui", () => ({
 }));
 
 const storeDouble = {
-	createTicket: vi.fn(async () => "TKT-9"),
+	createTicket: vi.fn(async () => ({ name: "TKT-9", openingComm: null })),
 	// uploadTo returns the succeeded FILE REFERENCES, not a count.
 	uploadTo: vi.fn(async (name, files) => files),
 	loadTickets: vi.fn(),
@@ -120,7 +120,7 @@ describe("SupportNewPage", () => {
 		const order = [];
 		storeDouble.createTicket.mockImplementation(async () => {
 			order.push("create");
-			return "TKT-9";
+			return { name: "TKT-9", openingComm: null };
 		});
 		storeDouble.uploadTo.mockImplementation(async (name, files) => {
 			order.push("upload");
@@ -188,7 +188,7 @@ describe("SupportNewPage", () => {
 	it("keeps staged files pending when uploadTo reports fewer successes than requested", async () => {
 		// uploadTo returns the succeeded FILE REFERENCES; a silent clear-all would
 		// discard attachments the user still needs to retry.
-		storeDouble.createTicket = vi.fn(async () => "TKT-9");
+		storeDouble.createTicket = vi.fn(async () => ({ name: "TKT-9", openingComm: null }));
 		storeDouble.uploadTo = vi.fn(async () => []); // nothing succeeded
 		const w = mount(SupportNewPage, opts);
 		await subjectInput(w).setValue("Broken invoice");
@@ -204,7 +204,7 @@ describe("SupportNewPage", () => {
 	});
 
 	it("stages every selected file by name, and removes exactly the chip whose X is clicked", async () => {
-		storeDouble.createTicket = vi.fn(async () => "TKT-9");
+		storeDouble.createTicket = vi.fn(async () => ({ name: "TKT-9", openingComm: null }));
 		storeDouble.uploadTo = vi.fn(async (n, f) => f);
 		const w = mount(SupportNewPage, opts);
 		await addFiles(w, [
@@ -264,7 +264,7 @@ describe("SupportNewPage", () => {
 	});
 
 	it("strips inline data:/blob: images from the body before sending (they can't render server-side)", async () => {
-		storeDouble.createTicket = vi.fn(async () => "TKT-9");
+		storeDouble.createTicket = vi.fn(async () => ({ name: "TKT-9", openingComm: null }));
 		const w = mount(SupportNewPage, opts);
 		await subjectInput(w).setValue("Screenshot issue");
 		await setDescription(w, '<p>see <img src="data:image/png;base64,AAAA"> here</p>');
@@ -287,7 +287,7 @@ describe("SupportNewPage", () => {
 	});
 
 	it("caps the subject at 140 chars (a ?subject= prefill bypasses the input maxlength)", async () => {
-		storeDouble.createTicket = vi.fn(async () => "TKT-9");
+		storeDouble.createTicket = vi.fn(async () => ({ name: "TKT-9", openingComm: null }));
 		const w = mount(SupportNewPage, opts);
 		await subjectInput(w).setValue("x".repeat(200));
 		await setDescription(w, "<p>d</p>");
@@ -317,13 +317,13 @@ describe("SupportNewPage", () => {
 		submitBtn(w).trigger("click"); // create() now awaits createTicket
 		await flushPromises();
 		await w.findAll(".jv-supc-chip")[1].find("button").trigger("click"); // remove drop.png
-		resolveCreate("TKT-9");
+		resolveCreate({ name: "TKT-9", openingComm: null });
 		await flushPromises();
 		expect(storeDouble.uploadTo.mock.calls[0][1].map((f) => f.name)).toEqual(["keep.png"]);
 	});
 
 	it("does not replace the router if unmounted during the post-create list refresh (I5 tail)", async () => {
-		storeDouble.createTicket = vi.fn(async () => "TKT-9");
+		storeDouble.createTicket = vi.fn(async () => ({ name: "TKT-9", openingComm: null }));
 		storeDouble.uploadTo = vi.fn(async (n, f) => f);
 		let resolveLoad;
 		storeDouble.loadTickets = vi.fn(() => new Promise((r) => (resolveLoad = r)));
@@ -348,7 +348,7 @@ describe("SupportNewPage", () => {
 		submitBtn(w).trigger("click"); // awaiting createTicket, nothing staged yet
 		await flushPromises();
 		await addFiles(w, [{ name: "late.png", type: "image/png" }]); // attached mid-submit
-		resolveCreate("TKT-9");
+		resolveCreate({ name: "TKT-9", openingComm: null });
 		await flushPromises();
 		expect(storeDouble.uploadTo).not.toHaveBeenCalled(); // nothing was staged at submit start
 		expect(toast.info).toHaveBeenCalled(); // user told the late file wasn't attached
@@ -370,7 +370,7 @@ describe("SupportNewPage", () => {
 		submitBtn(w).trigger("click");
 		await flushPromises();
 		w.unmount(); // user pressed Back while create was in flight
-		resolveCreate("TKT-9");
+		resolveCreate({ name: "TKT-9", openingComm: null });
 		await flushPromises();
 		expect(replace).not.toHaveBeenCalled();
 	});

--- a/frontend/tests/support-extraction/support-sidebar.test.js
+++ b/frontend/tests/support-extraction/support-sidebar.test.js
@@ -70,14 +70,9 @@ describe("SupportSidebar", () => {
 		expect(linkBy(w, "Jarvis chat").props("to")).toEqual({ name: "Chat" });
 	});
 
-	it("has a prominent New-ticket Button (like the top bar) that navigates to the new-ticket page", async () => {
+	it("has no New-ticket Button - that CTA is redundant across every support page and now lives only on the list page's own toolbar", () => {
 		const w = mountSidebar();
-		const btn = w.findComponent({ name: "Button" });
-		expect(btn.exists()).toBe(true);
-		expect(btn.props("label")).toBe("New ticket");
-		expect(btn.props("variant")).toBe("solid");
-		btn.vm.$emit("click");
-		expect(push).toHaveBeenCalledWith({ name: "SupportNew" });
+		expect(w.findComponent({ name: "Button" }).exists()).toBe(false);
 	});
 
 	it("marks 'Support tickets' active across support routes, not otherwise", () => {

--- a/frontend/tests/support-extraction/support-store.test.js
+++ b/frontend/tests/support-extraction/support-store.test.js
@@ -10,6 +10,8 @@ vi.mock("@/api", () => ({
 	supportAwaitingCount: vi.fn(),
 	supportUpload: vi.fn(),
 	supportDownloadUrl: (t, f) => `/proxy?ticket=${t}&file_url=${f}`,
+	getMySettings: vi.fn(),
+	updateMySettings: vi.fn(),
 }));
 vi.mock("frappe-ui", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
@@ -269,6 +271,64 @@ describe("support store", () => {
 			const s = useSupportStore();
 			expect(await s.closeTicket("T1")).toBe(false);
 			expect(toast.error).toHaveBeenCalled();
+		});
+	});
+
+	// copyPref is module-scope singleton state (not a `tickets`-style array the
+	// outer beforeEach can reset), and it starts null exactly once per test
+	// FILE. So unlike every describe above, this one is ONE deliberately
+	// sequential narrative, not independent cases - splitting it into
+	// order-agnostic `it()`s would either need a way to reset the cache back to
+	// null (there isn't one outside a fresh module load) or fake that reset by
+	// calling setCopyPref(null), which isn't a real call site makes. Each step
+	// is still a distinct assertion; only their ORDER is load-bearing, same
+	// idea as "toasts on a failed list AND keeps the last-good rows" above.
+	describe("getCopyPref / setCopyPref (sequential: the cache starts null once)", () => {
+		it("a failed first fetch resolves '' but leaves the cache unset, so the very next call retries", async () => {
+			const s = useSupportStore();
+			api.getMySettings.mockRejectedValueOnce(new Error("network"));
+			expect(await s.getCopyPref()).toBe("");
+			expect(api.getMySettings).toHaveBeenCalledTimes(1);
+		});
+
+		it("concurrent callers before a fetch resolves share ONE request, not one each", async () => {
+			const s = useSupportStore();
+			let resolve;
+			api.getMySettings.mockReturnValue(new Promise((r) => (resolve = r)));
+			const a = s.getCopyPref();
+			const b = s.getCopyPref();
+			resolve({ data: { support_context_copy_pref: "Yes" } });
+			expect(await a).toBe("Yes");
+			expect(await b).toBe("Yes");
+			expect(api.getMySettings).toHaveBeenCalledTimes(1);
+		});
+
+		it("a later call reads the now-populated cache - no further round-trip", async () => {
+			// Review finding: this path used to be an uncached fetch on every
+			// click, with no loading indicator, before this caching was added.
+			const s = useSupportStore();
+			expect(await s.getCopyPref()).toBe("Yes");
+			expect(api.getMySettings).not.toHaveBeenCalled();
+		});
+
+		it("setCopyPref overrides the cache locally AND writes through via updateMySettings", async () => {
+			const s = useSupportStore();
+			api.updateMySettings.mockResolvedValue({});
+			s.setCopyPref("No");
+			expect(api.updateMySettings).toHaveBeenCalledWith({ support_context_copy_pref: "No" });
+			expect(await s.getCopyPref()).toBe("No");
+			expect(api.getMySettings).not.toHaveBeenCalled();
+		});
+
+		it("a failed write-through does not throw and does not roll back the local cache", async () => {
+			const s = useSupportStore();
+			api.updateMySettings.mockRejectedValue(new Error("offline"));
+			expect(() => s.setCopyPref("Yes")).not.toThrow();
+			// Local-first: the user already made the choice that drove this call;
+			// nothing in the UI awaits the write-through, so a failed save stays
+			// silent rather than rolling back what the user just saw take effect
+			// (review finding, deferred as a MINOR - not retried, not surfaced).
+			expect(await s.getCopyPref()).toBe("Yes");
 		});
 	});
 });

--- a/frontend/tests/support-extraction/support-store.test.js
+++ b/frontend/tests/support-extraction/support-store.test.js
@@ -20,20 +20,34 @@ describe("badgeFor", () => {
 	// The AWAITING set mirrors jarvis_helpdesk/setup/install.py:39 and
 	// jarvis_admin_v2/support/awaiting.py:10 — both ("Replied", "Resolved").
 	it("treats Replied and Resolved as awaiting the customer", () => {
-		expect(badgeFor("Replied")).toMatchObject({ label: "Awaiting you", theme: "orange" });
-		expect(badgeFor("Resolved")).toMatchObject({ label: "Awaiting you", theme: "orange" });
+		expect(badgeFor("Replied")).toMatchObject({
+			label: "Awaiting you",
+			theme: "orange",
+			variant: "subtle",
+		});
+		expect(badgeFor("Resolved")).toMatchObject({
+			label: "Awaiting you",
+			theme: "orange",
+			variant: "subtle",
+		});
 	});
 
 	it("treats Closed as closed", () => {
-		expect(badgeFor("Closed")).toMatchObject({ label: "Closed", theme: "gray" });
+		expect(badgeFor("Closed")).toMatchObject({
+			label: "Closed",
+			theme: "gray",
+			variant: "subtle",
+		});
 	});
 
 	it("falls back to Open for every other status, including unknown ones", () => {
 		// The catch-all is load-bearing: Paused exists today and Helpdesk can add
 		// statuses without a frontend deploy. An unknown status must never render
-		// blank or crash a row.
+		// blank or crash a row. No `blue` theme (frappe-ui's Badge themes don't
+		// include the brand's purple, and a generic blue read as off-theme next to
+		// it) - `solid` gray instead, distinct from Closed's `subtle` gray.
 		for (const s of ["Open", "Paused", "Escalated", "", null, undefined]) {
-			expect(badgeFor(s)).toMatchObject({ label: "Open", theme: "blue" });
+			expect(badgeFor(s)).toMatchObject({ label: "Open", theme: "gray", variant: "solid" });
 		}
 	});
 });
@@ -189,11 +203,24 @@ describe("support store", () => {
 	});
 
 	describe("createTicket", () => {
-		it("unwraps the ticket name from {ok,data} and returns it", async () => {
+		it("unwraps the ticket name AND the opening comm from {ok,data}", async () => {
+			// openingComm lets the caller thread ticket-creation-time attachments onto
+			// the auto-mirrored opening message so they render inline, same as a
+			// reply's - see reply()'s `comm` for the established pattern.
+			api.supportCreateTicket.mockResolvedValue({
+				ok: true,
+				data: { ticket: "T9", opening_comm: "COMM-1" },
+			});
+			const s = useSupportStore();
+			const result = await s.createTicket("Subject", "Body");
+			expect(result).toEqual({ name: "T9", openingComm: "COMM-1" });
+		});
+
+		it("falls back openingComm to null when the CP doesn't echo one (older Helpdesk)", async () => {
 			api.supportCreateTicket.mockResolvedValue({ ok: true, data: { ticket: "T9" } });
 			const s = useSupportStore();
-			const name = await s.createTicket("Subject", "Body");
-			expect(name).toBe("T9");
+			const result = await s.createTicket("Subject", "Body");
+			expect(result).toEqual({ name: "T9", openingComm: null });
 		});
 
 		it("toasts and returns null on failure", async () => {

--- a/frontend/tests/support-extraction/support-thread.test.js
+++ b/frontend/tests/support-extraction/support-thread.test.js
@@ -213,8 +213,11 @@ describe("SupportThreadPage", () => {
 		expect(atts[1]).toMatchObject({ type: "file", title: "log.txt" });
 		// …and they must actually REACH the DOM: Message renders a file chip for
 		// them, which is the amendment this page depends on.
-		const chip = w.find(".jv-file-chip");
-		expect(chip.exists()).toBe(true);
+		const chips = w.findAll(".jv-file-chip");
+		expect(chips).toHaveLength(2);
+		expect(chips[0].text()).toContain("shot.png");
+		expect(chips[0].attributes("href")).toContain("jarvis.support.media.download");
+		const chip = chips[1];
 		expect(chip.text()).toContain("log.txt");
 		expect(chip.attributes("href")).toContain("jarvis.support.media.download");
 		// The clip icon must be an SVG (house design forbids emoji-as-icon), not
@@ -238,26 +241,6 @@ describe("SupportThreadPage", () => {
 		expect(atts[0].type).toBe("file");
 	});
 
-	it("opens a message attachment in a new tab via its proxied file_url (CRITICAL fix)", () => {
-		// Message renders an image attachment as a <button @click="emit('open-attachment', cv)">
-		// — before this fix, nothing on this page listened, so an agent's
-		// screenshot was a dead, unopenable thumbnail (unlike ticket-level
-		// attachments, which are real <a> links).
-		const openSpy = vi.spyOn(window, "open").mockImplementation(() => {});
-		const w = mountWith([
-			{
-				sent_or_received: "Sent",
-				content: "<p>see attached</p>",
-				attachments: [{ file_url: "/files/shot.png", file_name: "shot.png" }],
-			},
-		]);
-		w.findComponent({ name: "Message" }).vm.$emit("open-attachment", {
-			file_url: "/proxied/shot.png",
-		});
-		expect(openSpy).toHaveBeenCalledWith("/proxied/shot.png", "_blank", "noopener");
-		openSpy.mockRestore();
-	});
-
 	it("links ticket-level attachments through the authenticated proxy", () => {
 		storeDouble.thread.attachments = [{ file_url: "/files/spec.pdf", file_name: "spec.pdf" }];
 		const w = mountWith([{ sent_or_received: "Sent", content: "<p>hi</p>" }]);
@@ -268,24 +251,22 @@ describe("SupportThreadPage", () => {
 		storeDouble.thread.attachments = [];
 	});
 
-	it("renders a ticket-level image attachment inline and a non-image as a chip", () => {
-		// Proof of fix 3: ticket-level attachments used to render as a plain
-		// download chip with no image check at all, unlike per-message
-		// attachments a few lines below (attachmentsOf) which already classify
-		// via IMAGE_EXT. Both shapes are {file_url, file_name} from the CP.
+	it("renders every ticket-level attachment as the same file chip, images included", () => {
+		// Images get no special inline-thumbnail treatment here (or per-message,
+		// see images-as-chips above) - a cropped preview read worse than a plain
+		// filename the user clicks, per support feedback. Both shapes are
+		// {file_url, file_name} from the CP.
 		storeDouble.thread.attachments = [
 			{ file_url: "/files/shot.png", file_name: "shot.png" },
 			{ file_url: "/files/spec.pdf", file_name: "spec.pdf" },
 		];
 		const w = mountWith([{ sent_or_received: "Sent", content: "<p>hi</p>" }]);
 
-		const img = w.find(".jv-sup-thumb");
-		expect(img.exists()).toBe(true);
-		expect(img.attributes("src")).toContain("jarvis.support.media.download");
-		expect(img.attributes("src")).toContain("shot.png");
-
 		const links = w.findAll(".jv-sup-file");
 		expect(links).toHaveLength(2);
+		expect(links[0].text()).toContain("shot.png");
+		expect(links[0].attributes("href")).toContain("jarvis.support.media.download");
+		expect(links[0].find("img").exists()).toBe(false);
 		expect(links[1].text()).toContain("spec.pdf");
 		expect(links[1].find("img").exists()).toBe(false);
 

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -123,6 +123,10 @@ def _settings_payload(doc) -> dict:
 		# syncs onto the doc's meta, doc.preferred_persona would AttributeError and
 		# 500 get_my_settings / update_my_settings. Default to Jarvis like the rest.
 		"preferred_persona": getattr(doc, "preferred_persona", None) or "Jarvis",
+		# "" = ask every time (the New Ticket popup's default); "Yes"/"No" = the
+		# user's own permanent "don't ask again" answer, per Jarvis User Settings'
+		# migrate-window guard above (getattr, not a bare read).
+		"support_context_copy_pref": getattr(doc, "support_context_copy_pref", None) or "",
 		"monthly_token_limit": cint(doc.monthly_token_limit),
 		"usage_month": doc.usage_month,
 		"month_tokens": _month_tokens_effective(doc.usage_month, doc.month_tokens),
@@ -150,6 +154,7 @@ def update_my_settings(
 	notify_enabled: int | None = None,
 	activity_detail: int | None = None,
 	preferred_persona: str | None = None,
+	support_context_copy_pref: str | None = None,
 ) -> dict:
 	"""Update the caller's own chat preferences only. The usage limit and
 	counters (permlevel 1 / read-only) are never writable here."""
@@ -171,6 +176,11 @@ def update_my_settings(
 			# and reflecting nothing removes the self-XSS vector entirely.
 			frappe.throw(frappe._("Persona must be Jarvis or Jara."))
 		doc.preferred_persona = persona
+	if support_context_copy_pref is not None:
+		pref = _s(support_context_copy_pref)
+		if pref not in ("", "Yes", "No"):
+			frappe.throw(frappe._("support_context_copy_pref must be Yes, No, or blank."))
+		doc.support_context_copy_pref = pref
 	# ignore_permissions: the row is owner-scoped by construction (we loaded the
 	# caller's own row), and only permlevel-0 pref fields are touched here.
 	doc.save(ignore_permissions=True)

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -13,6 +13,7 @@
     "notify_enabled",
     "activity_detail",
     "preferred_persona",
+    "support_context_copy_pref",
     "app_state_section",
     "business_greeting_state",
     "business_greeting_chat_count",
@@ -72,6 +73,13 @@
       "options": "Jarvis\nJara",
       "default": "Jarvis",
       "description": "Which persona voice this user chats with: Jarvis (default) or Jara (calmer, more jovial). Voice only - same tools, permissions, and behaviour."
+    },
+    {
+      "fieldname": "support_context_copy_pref",
+      "fieldtype": "Select",
+      "label": "Copy Chat Into Support Ticket",
+      "options": "\nYes\nNo",
+      "description": "Remembered answer to \"copy the last few chat messages into a new support ticket?\" - blank means ask every time (the default); Yes/No is a permanent 'don't ask again' the New Ticket flow reads before showing that popup. Set by the popup itself, not editable elsewhere."
     },
     { "fieldname": "app_state_section", "fieldtype": "Section Break", "label": "App State" },
     {

--- a/jarvis/tests/test_user_settings.py
+++ b/jarvis/tests/test_user_settings.py
@@ -878,6 +878,99 @@ class TestPersonaPreference(_UsageTestBase):
 
 
 # --------------------------------------------------------------------------- #
+# 8.5 support_context_copy_pref — the "copy this chat into your ticket?"
+#     don't-ask-again answer ("" | "Yes" | "No"). Direct analog of
+#     preferred_persona above (same owner-scoped save/echo path, same
+#     fixed-enum-message validation), but with no [Context:]/turn_handler
+#     integration - it never reaches the LLM prompt at all.
+# --------------------------------------------------------------------------- #
+class TestSupportContextCopyPreference(_UsageTestBase):
+	def test_default_is_blank(self):
+		# No row at all: the lazy-created default is "" (ask every time), not
+		# some other falsy value that would read as an explicit answer.
+		frappe.set_user(USER_A)
+		out = user_settings_api.get_my_settings()
+		self.assertEqual(out["data"]["support_context_copy_pref"], "")
+		frappe.set_user("Administrator")
+
+	def test_update_to_yes_persists_and_echoes(self):
+		frappe.set_user(USER_A)
+		out = user_settings_api.update_my_settings(support_context_copy_pref="Yes")
+		self.assertEqual(out["data"]["support_context_copy_pref"], "Yes")
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "support_context_copy_pref"), "Yes")
+
+	def test_update_to_no_persists_and_echoes(self):
+		frappe.set_user(USER_A)
+		out = user_settings_api.update_my_settings(support_context_copy_pref="No")
+		self.assertEqual(out["data"]["support_context_copy_pref"], "No")
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "support_context_copy_pref"), "No")
+
+	def test_blank_explicitly_resets_to_ask_every_time(self):
+		# Unlike preferred_persona (blank -> "Jarvis" default), blank here is
+		# itself a valid, meaningful value - "go back to asking" - not merely
+		# "no change". A user who answered "No" must be able to opt back in.
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(support_context_copy_pref="No")
+		out = user_settings_api.update_my_settings(support_context_copy_pref="")
+		self.assertEqual(out["data"]["support_context_copy_pref"], "")
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "support_context_copy_pref"), "")
+
+	def test_unknown_value_rejected(self):
+		frappe.set_user(USER_A)
+		with self.assertRaises(frappe.ValidationError):
+			user_settings_api.update_my_settings(support_context_copy_pref="Maybe")
+		frappe.set_user("Administrator")
+		# Nothing persisted from the rejected write.
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "support_context_copy_pref") or "", "")
+
+	def test_unknown_value_message_does_not_reflect_input(self):
+		# Fixed-enum message, same self-XSS guard as preferred_persona's (F11):
+		# a hostile value must never be reflected back.
+		frappe.set_user(USER_A)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			user_settings_api.update_my_settings(support_context_copy_pref="<img src=x onerror=alert(1)>")
+		frappe.set_user("Administrator")
+		msg = str(cm.exception)
+		self.assertNotIn("<img", msg)
+		self.assertNotIn("onerror", msg)
+		self.assertIn("Yes, No, or blank", msg)
+
+	def test_non_string_value_does_not_500(self):
+		# Same arg-type-gate gap as preferred_persona (from __future__ import
+		# annotations disables runtime coercion here - see the module NOTE): a
+		# hostile non-string must reject cleanly, never 500 on AttributeError.
+		frappe.set_user(USER_A)
+		for bad in (["Yes"], {"pref": "Yes"}):
+			with self.assertRaises(frappe.ValidationError):
+				user_settings_api.update_my_settings(support_context_copy_pref=bad)
+		# Falsy non-strings take the blank path (store "").
+		for falsy in (0, False, []):
+			user_settings_api.update_my_settings(support_context_copy_pref=falsy)
+			self.assertEqual(user_settings_api.get_my_settings()["data"]["support_context_copy_pref"], "")
+		frappe.set_user("Administrator")
+
+	def test_update_touches_only_own_row(self):
+		usage.get_or_create_user_settings(USER_B)
+		frappe.db.commit()
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(support_context_copy_pref="Yes")
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_B}, "support_context_copy_pref") or "", "")
+
+	def test_leaves_other_prefs_untouched(self):
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(notify_enabled=0)
+		user_settings_api.update_my_settings(support_context_copy_pref="Yes")
+		out = user_settings_api.get_my_settings()
+		self.assertEqual(out["data"]["notify_enabled"], 0)
+		self.assertEqual(out["data"]["support_context_copy_pref"], "Yes")
+		frappe.set_user("Administrator")
+
+
+# --------------------------------------------------------------------------- #
 # 9. set_sidebar_order — per-user nav order (UI state, permlevel 0). It takes a
 #    JSON *string* from the client and must bound/clean it before it is stored,
 #    since it is written straight to the owner's own row.

--- a/jarvis/tests/test_user_settings.py
+++ b/jarvis/tests/test_user_settings.py
@@ -878,7 +878,7 @@ class TestPersonaPreference(_UsageTestBase):
 
 
 # --------------------------------------------------------------------------- #
-# 8.5 support_context_copy_pref — the "copy this chat into your ticket?"
+# 8.5 support_context_copy_pref: the "copy this chat into your ticket?"
 #     don't-ask-again answer ("" | "Yes" | "No"). Direct analog of
 #     preferred_persona above (same owner-scoped save/echo path, same
 #     fixed-enum-message validation), but with no [Context:]/turn_handler


### PR DESCRIPTION
## What
One header entry point for Support (`openSupport`), replacing the old composer "Get help from a human" button and UserMenu's Support menu entry:
- routes straight to the ticket list when tickets are awaiting reply (the old UserMenu behavior, which the composer button never had)
- offers to copy the last few chat turns into a new ticket, remembering Yes/No/don't-ask via a cached `support_context_copy_pref` user setting
- guards against a double-click firing the async flow twice

Also:
- the copy-prompt dialog now mounts once in AppShell (not ChatView), so a route change mid-prompt can't unmount it and permanently wedge the module-scope promise resolver in `useSupportCopyPrompt.js`
- restores the app-wide "awaiting reply" badge dot on UserMenu's avatar, lost when Support moved into the chat header
- ticket status `Badge` now uses the status-dependent variant instead of a hardcoded `"subtle"`
- `Message.vue` gains `imagesAsChips`: Support renders attachment images as the same filename chip as every other file instead of an inline crop, per feedback that a photo attachment read as a worse "vague" crop than just naming the file; chat's own thumbnails are unaffected
- fixes a surrogate-pair-unsafe `String.slice()` when clipping chat text for the copy-into-ticket preview (now clips by code point)
- backend: `support_context_copy_pref` on Jarvis User Settings, with test coverage for default/persistence/reset/unknown-value-rejection/isolation

## Review
This branch went through a full adversarial code review (14 findings, all fixed or explicitly triaged as intentional-not-a-bug with tests updated to match) plus a second cold pass that caught 2 real regressions from an earlier patch-rebuild step silently reverting parts of the same-day, already-merged chat-attachment-preview feature (#770) in `Message.vue`/`ChatView.vue` — both restored and verified byte-identical to that feature's shipped form. Missing test coverage the review flagged for the new entry point (copy-prompt resolver, `getCopyPref`/`setCopyPref` caching, the code-point clip) has been added.

**Known gap, named rather than hidden:** this repo's `CLAUDE.md` review pipeline (`.claude/` skills) was removed from the tree by #774 partway through this work. There is no `STATUS: APPROVED` plan file or `VERDICT: GREEN` review artifact for this changeset in the now-removed `.claude/workflow/` — the review above was done by hand-running the same reviewer process, not by the (now-gone) tooling. A flow review against the running app has not been executed for this branch; happy to run one before merge if wanted.

## Testing
- `npx vitest run`: 1158/1158 passing
- `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_user_settings`: 65/65 passing
- Production build (`npm run build`) succeeds
