### PR TITLE
fix(subscriptions): show the connected account name for chat subscriptions

### DIFF
--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -909,10 +909,9 @@ describe("the verdict and the surrounding controls agree", () => {
  */
 describe("a subscription row's collapsed account identity (jarvis account-name bug)", () => {
 	it("gives two label-less, email-less accounts distinct identifiers via accountLabel()", async () => {
-		// Real refs are secrets.token_hex(8): lowercase hex, letters included. Ending
-		// each in a distinct letter-bearing suffix (not all-digits) is what actually
-		// exercises accountLabel()'s .toUpperCase() - digits uppercase to themselves,
-		// so an all-digit suffix would pass this test with or without that call.
+		// Real refs are secrets.token_hex(8): lowercase hex. The fallback shows the last
+		// 6 chars of the ref (lowercase, matching the server-side Kimi convention), so
+		// two refs that differ within their last 6 render as distinct labels.
 		setPool([
 			subModel("gpt-5", 0, [
 				account("SUB_aaaaaaaaabcd", ""),
@@ -924,8 +923,8 @@ describe("a subscription row's collapsed account identity (jarvis account-name b
 		// accountLabel is a <script setup> binding, not part of defineExpose - reachable
 		// through the component's setupState the way @vue/test-utils exposes it on `vm`.
 		const [a, b] = w.vm.rows[0].accounts;
-		expect(w.vm.accountLabel(a)).toBe("Account ABCD");
-		expect(w.vm.accountLabel(b)).toBe("Account EF01");
+		expect(w.vm.accountLabel(a)).toBe("Account aaabcd");
+		expect(w.vm.accountLabel(b)).toBe("Account bbef01");
 		expect(w.vm.accountLabel(a)).not.toBe(w.vm.accountLabel(b));
 	});
 
@@ -941,7 +940,7 @@ describe("a subscription row's collapsed account identity (jarvis account-name b
 		const chip = w.find(".jv-flist-acct");
 		expect(chip.exists()).toBe(true);
 		// Two accounts folded onto one row: only the first is named, the rest counted.
-		expect(chip.text()).toBe("Account ABCD +1 more");
+		expect(chip.text()).toBe("Account aaabcd +1 more");
 	});
 
 	it("shows the real email when the account has one", async () => {
@@ -953,13 +952,12 @@ describe("a subscription row's collapsed account identity (jarvis account-name b
 		expect(chip.text()).toBe("a@example.com");
 	});
 
-	it("never surfaces the raw SUB_<hex> token, and uppercases the last 4 chars", async () => {
+	it("never surfaces the raw SUB_<hex> token, and shows the last 6 chars of the ref", async () => {
 		setPool([subModel("gpt-5", 0, [account("SUB_aaaaaaaaabcd", "")])]);
 		const w = await mountEditor();
 
 		const chip = w.find(".jv-flist-acct");
-		expect(chip.text()).toBe("Account ABCD");
+		expect(chip.text()).toBe("Account aaabcd");
 		expect(chip.text()).not.toContain("SUB_");
-		expect(chip.text()).not.toContain("abcd"); // must be the uppercased form, not a raw substring
 	});
 });

--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -898,3 +898,68 @@ describe("the verdict and the surrounding controls agree", () => {
 		expect(w.vm.startBlockedReason).toBe("");
 	});
 });
+
+/**
+ * Two ChatGPT subscriptions used to render as identical collapsed rows: the same
+ * "Subscription · OpenAI" chip and the same model id, with no way to tell which
+ * account is which. accountLabel() falls all the way to a generic "Account
+ * connected" for accounts with neither a label nor an email (the pre-fix accounts
+ * this bug is about), so the row template needs its own per-account fallback -
+ * this covers both halves: the label logic and what the row actually renders.
+ */
+describe("a subscription row's collapsed account identity (jarvis account-name bug)", () => {
+	it("gives two label-less, email-less accounts distinct identifiers via accountLabel()", async () => {
+		// Real refs are secrets.token_hex(8): lowercase hex, letters included. Ending
+		// each in a distinct letter-bearing suffix (not all-digits) is what actually
+		// exercises accountLabel()'s .toUpperCase() - digits uppercase to themselves,
+		// so an all-digit suffix would pass this test with or without that call.
+		setPool([
+			subModel("gpt-5", 0, [
+				account("SUB_aaaaaaaaabcd", ""),
+				account("SUB_bbbbbbbbef01", ""),
+			]),
+		]);
+		const w = await mountEditor();
+
+		// accountLabel is a <script setup> binding, not part of defineExpose - reachable
+		// through the component's setupState the way @vue/test-utils exposes it on `vm`.
+		const [a, b] = w.vm.rows[0].accounts;
+		expect(w.vm.accountLabel(a)).toBe("Account ABCD");
+		expect(w.vm.accountLabel(b)).toBe("Account EF01");
+		expect(w.vm.accountLabel(a)).not.toBe(w.vm.accountLabel(b));
+	});
+
+	it("renders two distinct account identifiers for two label-less, email-less accounts", async () => {
+		setPool([
+			subModel("gpt-5", 0, [
+				account("SUB_aaaaaaaaabcd", ""),
+				account("SUB_bbbbbbbbef01", ""),
+			]),
+		]);
+		const w = await mountEditor();
+
+		const chip = w.find(".jv-flist-acct");
+		expect(chip.exists()).toBe(true);
+		// Two accounts folded onto one row: only the first is named, the rest counted.
+		expect(chip.text()).toBe("Account ABCD +1 more");
+	});
+
+	it("shows the real email when the account has one", async () => {
+		setPool([subModel("gpt-5", 0, [account("SUB_aaaaaaaaabcd", "a@example.com")])]);
+		const w = await mountEditor();
+
+		const chip = w.find(".jv-flist-acct");
+		expect(chip.exists()).toBe(true);
+		expect(chip.text()).toBe("a@example.com");
+	});
+
+	it("never surfaces the raw SUB_<hex> token, and uppercases the last 4 chars", async () => {
+		setPool([subModel("gpt-5", 0, [account("SUB_aaaaaaaaabcd", "")])]);
+		const w = await mountEditor();
+
+		const chip = w.find(".jv-flist-acct");
+		expect(chip.text()).toBe("Account ABCD");
+		expect(chip.text()).not.toContain("SUB_");
+		expect(chip.text()).not.toContain("abcd"); // must be the uppercased form, not a raw substring
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -3620,11 +3620,12 @@ function accountLabel(a) {
 	if (email) return email;
 	// Accounts connected before the backend email fix carry neither a label nor an
 	// email, so two of them used to both fall through to the same generic string and
-	// stay visually identical. Fall back to a short per-account identifier derived
-	// from account_ref (mirrors how Kimi's device-code accounts are already named,
-	// "Kimi <last 4>") - just the last 4 chars, never the full SUB_<hex> token.
+	// stay visually identical. Fall back to a short per-account identifier from the
+	// account_ref tail (same convention as Kimi's server-side "Kimi <tail>" label,
+	// lowercase). Six chars, not four, so two distinct refs are very unlikely to
+	// collide back into one label; never the full SUB_<hex> token.
 	const ref = (a && a.account_ref) || "";
-	if (ref) return "Account " + ref.slice(-4).toUpperCase();
+	if (ref) return "Account " + ref.slice(-6);
 	return "Account connected";
 }
 function firstWarningMessage() {

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -114,6 +114,19 @@
 				<span class="jv-flist-model" :class="{ 'jv-flist-model--unset': !row.model }">{{
 					rowModelLabel(row)
 				}}</span>
+				<!-- Two subscriptions to the same provider/model otherwise render as identical
+				     rows ("Subscription · OpenAI" + the model id, nothing else) - the connected
+				     account's own identity is what tells them apart. A subscription row can fold
+				     MULTIPLE accounts, so only the first is named and the rest are counted. -->
+				<span
+					v-if="row.credentialType === 'subscription' && row.accounts?.length"
+					class="jv-flist-acct"
+					:title="row.accounts.map(accountLabel).join(', ')"
+					>{{
+						accountLabel(row.accounts[0]) +
+						(row.accounts.length > 1 ? " +" + (row.accounts.length - 1) + " more" : "")
+					}}</span
+				>
 				<span
 					v-if="row.credentialType !== 'subscription' && row.hasKey"
 					style="font-size: 11px; color: var(--text-3)"
@@ -3603,7 +3616,16 @@ function accountLabel(a) {
 	// Show a real label / email; never surface the internal SUB_<hex> account ref.
 	const l = (a && a.label) || "";
 	if (l && !/^SUB_/i.test(l)) return l;
-	return (a && a.account_email) || "Account connected";
+	const email = (a && a.account_email) || "";
+	if (email) return email;
+	// Accounts connected before the backend email fix carry neither a label nor an
+	// email, so two of them used to both fall through to the same generic string and
+	// stay visually identical. Fall back to a short per-account identifier derived
+	// from account_ref (mirrors how Kimi's device-code accounts are already named,
+	// "Kimi <last 4>") - just the last 4 chars, never the full SUB_<hex> token.
+	const ref = (a && a.account_ref) || "";
+	if (ref) return "Account " + ref.slice(-4).toUpperCase();
+	return "Account connected";
 }
 function firstWarningMessage() {
 	return (sync.value.warnings && sync.value.warnings[0] && sync.value.warnings[0].message) || "";
@@ -5127,6 +5149,19 @@ defineExpose({
 .jv-flist-model--unset {
 	color: var(--text-3);
 	font-style: italic;
+}
+/* Connected-account identity on a collapsed subscription row - a muted sub-label,
+   not a chip, so it reads as detail on the model name rather than a second badge.
+   Capped and ellipsized like its neighbours (.jv-flist-model, .jv-pool-acct-health)
+   so a long email can never push the row's actions off the edge. */
+.jv-flist-acct {
+	flex: none;
+	max-width: 160px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	color: var(--text-3);
 }
 
 /* ---- explainer + add affordance + failover nudge (settings editor only) ----

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -909,26 +909,15 @@ def _exchange_code(*, provider: str, code: str, code_verifier: str, redirect_uri
 	return resp.json()
 
 
-def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str:
-	"""Best-effort email lookup via the provider's Bearer-authenticated
-	userinfo endpoint (OpenAI + Gemini). The id_token JWT branch below is
-	retained as a defensive fallback for any future provider configured
-	with ``userinfo: None`` - no current provider takes that path."""
-	p = get_provider(provider)
-	if p["userinfo"]:
-		try:
-			resp = requests.get(
-				p["userinfo"],
-				headers={"Authorization": f"Bearer {access_token}"},
-				timeout=_HTTP_TIMEOUT,
-			)
-			if resp.ok:
-				return resp.json().get("email") or ""
-		except requests.RequestException:
-			pass
-		return ""
-	# Fallback for providers with userinfo=None - parse id_token JWT for email.
-	# No current provider takes this path; retained defensively.
+def _email_from_id_token(id_token: str) -> str:
+	"""Best-effort parse of the ``email`` claim out of an id_token JWT.
+
+	Deliberately unverified (no signature check): this is a display label,
+	not an auth decision, and it lands in the container blob as the same
+	value userinfo would give. There's precedent - ``extract_account_id``
+	decodes tokens unverified too. Never raises: malformed base64, broken
+	JSON, or a missing/short id_token all just fall through to "".
+	"""
 	if not id_token or id_token.count(".") < 2:
 		return ""
 	try:
@@ -945,6 +934,41 @@ def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str
 		# missing dots) is non-fatal: id_token is a best-effort source
 		# for the email hint, callers always have a fallback.
 		return ""
+
+
+def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str:
+	"""Best-effort email lookup, preferring the id_token JWT's ``email``
+	claim over the provider's Bearer-authenticated userinfo endpoint.
+
+	This is not merely defensive: POOL sign-ins (OpenAI/ChatGPT chat
+	subscriptions) request scope ``openid email profile offline_access``,
+	so the id_token carries an email claim, but the pool access_token's
+	audience is ``chatgpt.com/backend-api`` (see the OpenAI provider entry
+	in providers.py) - it's the wrong audience for
+	``https://api.openai.com/v1/userinfo``, so that call fails and used to
+	leave the account unlabeled. Trying the id_token first fixes that
+	without special-casing OpenAI. Providers with no id_token (Google
+	Gemini's DIRECT flow) still fall through to the userinfo call, which
+	works for them.
+	"""
+	email = _email_from_id_token(id_token)
+	if email:
+		return email
+
+	p = get_provider(provider)
+	if not p["userinfo"]:
+		return ""
+	try:
+		resp = requests.get(
+			p["userinfo"],
+			headers={"Authorization": f"Bearer {access_token}"},
+			timeout=_HTTP_TIMEOUT,
+		)
+		if resp.ok:
+			return resp.json().get("email") or ""
+	except requests.RequestException:
+		pass
+	return ""
 
 
 @frappe.whitelist()

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -921,12 +921,10 @@ def _email_from_id_token(id_token: str) -> str:
 	if not id_token or id_token.count(".") < 2:
 		return ""
 	try:
-		import json as _json
-
 		_, payload, _ = id_token.split(".", 2)
 		padding = "=" * (-len(payload) % 4)
 		decoded = base64.urlsafe_b64decode(payload + padding)
-		return _json.loads(decoded).get("email", "") or ""
+		return json.loads(decoded).get("email", "") or ""
 	except Exception:
 		# ValueError used to be listed explicitly but it's a subclass
 		# of Exception - the union was redundant. Anything that goes
@@ -950,6 +948,11 @@ def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str
 	without special-casing OpenAI. Providers with no id_token (Google
 	Gemini's DIRECT flow) still fall through to the userinfo call, which
 	works for them.
+
+	Called only at the initial code exchange (``_exchange_and_build_blob``),
+	so the id_token was minted by the provider in this same exchange and its
+	email claim is current - there is no refresh path that could hand this a
+	stale id_token. If one is ever added, prefer userinfo there.
 	"""
 	email = _email_from_id_token(id_token)
 	if email:

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -1344,3 +1344,31 @@ class TestXaiPoolCapture(_OAuthApiBase):
 		self.assertTrue(blob["id_token"])  # xai transform REQUIRES it
 		frappe.delete_doc("Jarvis Pending OAuth Capture", name, force=True, ignore_permissions=True)
 		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))  # single-use
+
+
+class TestFetchAccountEmail(_OAuthApiBase):
+	"""Regression for the pool-signin "Account connected" bug: OpenAI's POOL
+	access_token has aud=chatgpt.com/backend-api, so a userinfo call with it
+	fails, but the id_token (scope includes ``email``) carries the email
+	claim directly. _fetch_account_email must try the id_token first and
+	only fall back to userinfo when there's no usable id_token."""
+
+	def test_id_token_email_used_without_http_call(self):
+		id_token = _jwt({"email": "alice@example.com"})
+		with patch("jarvis.oauth.api.requests.get") as mock_get:
+			email = oauth_api._fetch_account_email("OpenAI", "AT", id_token)
+		mock_get.assert_not_called()
+		self.assertEqual(email, "alice@example.com")
+
+	def test_no_id_token_falls_back_to_userinfo(self):
+		resp = _FakeResp(ok=True, status=200, json_body={"email": "bob@example.com"})
+		with patch("jarvis.oauth.api.requests.get", return_value=resp) as mock_get:
+			email = oauth_api._fetch_account_email("OpenAI", "AT", "")
+		mock_get.assert_called_once()
+		self.assertEqual(email, "bob@example.com")
+
+	def test_malformed_id_token_falls_through_to_userinfo(self):
+		resp = _FakeResp(ok=True, status=200, json_body={"email": "carol@example.com"})
+		with patch("jarvis.oauth.api.requests.get", return_value=resp):
+			email = oauth_api._fetch_account_email("OpenAI", "AT", "not-a-jwt")
+		self.assertEqual(email, "carol@example.com")


### PR DESCRIPTION
## Summary

A chat subscription never showed *which* account it was, so onboarding displayed "Account connected" with no name, and two ChatGPT subscriptions looked identical in AI Models settings. This surfaces the connected account's name/email in both places.

**1. Backend — the account email was being thrown away.** It rides in the OAuth id_token (pool sign-in requests `openid email profile`), but `_fetch_account_email` only parsed the id_token when a provider had `userinfo: None` — which none do. For OpenAI it always called `api.openai.com/v1/userinfo` with the pool access-token, whose audience is `chatgpt.com/backend-api`, so that call fails and the email came back empty → generic "Account connected". Now the id_token email claim is preferred, with userinfo as the fallback (Google Gemini has no id_token and still uses it). General, not OpenAI-special-cased.

**2. Frontend — the settings list never showed the account.** The collapsed subscription row now shows the connected account name (first account + "+N more"), and `accountLabel()` falls back to a short per-account tag ("Account &lt;last4&gt;", mirroring how Kimi names accounts) when an older account has no stored label/email — so two accounts are never rendered identically.

Tests: 3 new backend tests (id_token-first, no-HTTP-when-claim-present, userinfo fallback, malformed id_token) and 4 new frontend tests (distinct labels for label-less accounts, email shown when present, `SUB_` token never surfaced).

<details>
<summary>Scope note</summary>

This fixes the *display* half of the duplicate-subscription complaint. Whether two same-provider/same-model subscriptions should also be *merged* into one row (the coalesce path) is being diagnosed separately against a live repro on e2e.localhost — not in this PR.
</details>

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`**
- [x] New/changed behavior has tests (backend + frontend)
- [x] I self-reviewed the diff