### PR TITLE
fix(billing): make subscription renewal work, read clearly, and pay before expiry

### DIFF
--- a/frontend/src/pages/billing/BillingPage.spec.js
+++ b/frontend/src/pages/billing/BillingPage.spec.js
@@ -195,6 +195,76 @@ describe("acceptance: renew's stuck-payment answer is no longer silent", () => {
 	});
 });
 
+describe("pre-expiry renew: pay now to extend before lapsing", () => {
+	// The backend (renew() / can_renew) already accepts a manual renewal on a
+	// still-running subscription and stacks the new period onto the days left.
+	// The button was the only missing piece: an Active/Past-Due customer with
+	// autorenew off used to see no pay-now action at all. The current-plan card
+	// (PlanCard) is stubbed here, so these assert on currentAction - the label the
+	// card renders - and drive doRenew directly, the same way the other renew
+	// tests in this file do.
+	it("labels the current-plan action 'Renew now' for an Active, autorenew-off, can_renew sub", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				subscription_status: "Active",
+				days_remaining: 1,
+				autorenew: 0,
+				can_reactivate: false,
+				can_renew: true,
+			})
+		);
+		expect(wrapper.vm.currentAction.label).toBe("Renew now");
+	});
+
+	it("routes the renew to the same-plan pay flow (no target_plan)", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				subscription_status: "Active",
+				days_remaining: 1,
+				autorenew: 0,
+				can_reactivate: false,
+				can_renew: true,
+			})
+		);
+		api.renewPlan.mockResolvedValue(rawOkBody({ tenant_status: "ready" }));
+
+		await wrapper.vm.doRenew();
+		await findByText(wrapper, ".dialog button", "Pay").trigger("click");
+		await flushPromises();
+
+		// A running subscription renews onto its OWN plan: no target_plan, or admin
+		// refuses it (NotLapsed).
+		expect(api.renewPlan).toHaveBeenCalledWith(undefined);
+	});
+
+	it("also labels 'Renew now' for a Past Due customer who otherwise had no CTA", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				subscription_status: "Past Due",
+				days_remaining: 2,
+				autorenew: 0,
+				can_reactivate: false,
+				can_reauthorize: false,
+				can_renew: true,
+			})
+		);
+		expect(wrapper.vm.currentAction.label).toBe("Renew now");
+	});
+
+	it("shows no renew action when the server withholds can_renew", async () => {
+		const wrapper = await mountPage(
+			baseAccount({
+				subscription_status: "Active",
+				days_remaining: 10,
+				autorenew: 1,
+				can_reactivate: false,
+				can_renew: false,
+			})
+		);
+		expect(wrapper.vm.currentAction.label).toBe("");
+	});
+});
+
 describe("edge 1: double-click cannot open a second gateway object", () => {
 	it("double-clicking Check runs the healer exactly once", async () => {
 		const wrapper = await mountPage();

--- a/frontend/src/pages/billing/BillingPage.spec.js
+++ b/frontend/src/pages/billing/BillingPage.spec.js
@@ -133,10 +133,10 @@ describe("acceptance: renew's stuck-payment answer is no longer silent", () => {
 		await flushPromises();
 
 		expect(wrapper.text()).toContain("We have not confirmed this payment.");
-		expect(findByText(wrapper, "button", "Check payment status")).toBeTruthy();
+		expect(findByText(wrapper, "button", "Check renewal status")).toBeTruthy();
 		// PAYMENT_CONFIRMATION_PENDING's row declares Check only - INITIATE must
 		// never appear here, or a stuck payment gets paid twice.
-		expect(findByText(wrapper, "button", "Start a new payment")).toBeUndefined();
+		expect(findByText(wrapper, "button", "Renew now")).toBeUndefined();
 	});
 
 	it("wires the rendered Check button to the healer then the passive re-read, in that order", async () => {
@@ -155,19 +155,19 @@ describe("acceptance: renew's stuck-payment answer is no longer silent", () => {
 			order.push("state");
 			return { code: "PAYMENT_CONFIRMATION_PENDING" };
 		});
-		await findByText(wrapper, "button", "Check payment status").trigger("click");
+		await findByText(wrapper, "button", "Check renewal status").trigger("click");
 		await flushPromises();
 
 		expect(order).toEqual(["check", "state"]);
 	});
 
 	// Regression: a status check that answers BILLING_NO_CURRENT_INTENT (409)
-	// renders a notice whose ONLY action is INITIATE ("Start a new payment").
+	// renders a notice whose ONLY action is INITIATE ("Renew now" on billing).
 	// doCheckStatus used to bind that notice's retry to itself, so clicking
-	// "Start a new payment" re-ran the status check - which answers the same 409
-	// against the same absent intent forever. The button looked dead: no
-	// redirect, no change. INITIATE here must start a renewal instead.
-	it("routes 'Start a new payment' on a no-intent 409 to renew, not back into the status check", async () => {
+	// "Renew now" re-ran the status check - which answers the same 409 against
+	// the same absent intent forever. The button looked dead: no redirect, no
+	// change. INITIATE here must start a renewal instead.
+	it("routes the no-intent 409 notice's Renew now to renew, not back into the status check", async () => {
 		const wrapper = await mountPage();
 		api.checkBillingPayment.mockResolvedValue(
 			rawFail("BILLING_NO_CURRENT_INTENT", { status: 409 })
@@ -176,7 +176,7 @@ describe("acceptance: renew's stuck-payment answer is no longer silent", () => {
 		await flushPromises();
 
 		expect(wrapper.vm.codeNotice.code).toBe(CODES.BILLING_NO_CURRENT_INTENT);
-		const initiate = findByText(wrapper, "button", "Start a new payment");
+		const initiate = findByText(wrapper, "button", "Renew now");
 		expect(initiate).toBeTruthy();
 
 		const checksBefore = api.checkBillingPayment.mock.calls.length;
@@ -233,7 +233,7 @@ describe("edge 3: a code with no branch and no copy-table entry", () => {
 		expect(wrapper.vm.codeNotice.copy.headline).toBe(UNKNOWN_COPY.headline);
 		expect(wrapper.vm.codeNotice.copy.actions.length).toBeGreaterThan(0);
 		expect(wrapper.text()).toContain(UNKNOWN_COPY.headline);
-		expect(findByText(wrapper, "button", "Check payment status")).toBeTruthy();
+		expect(findByText(wrapper, "button", "Check renewal status")).toBeTruthy();
 	});
 });
 
@@ -305,7 +305,7 @@ describe("edge 6: the intent resolves between Check and the re-read", () => {
 		// PAYMENT_ALREADY_ACTIVE declares CONTINUE only - never CHECK/INITIATE, so
 		// no path back into a second payment is offered.
 		expect(wrapper.vm.codeNotice.copy.actions).not.toContain(ACTIONS.INITIATE);
-		expect(findByText(wrapper, "button", "Start a new payment")).toBeUndefined();
+		expect(findByText(wrapper, "button", "Renew now")).toBeUndefined();
 	});
 });
 
@@ -940,7 +940,7 @@ describe("finding 7: the healer's coded refusals are answers, not transport erro
 		// The service WAS reached; saying otherwise would be a lie.
 		expect(wrapper.text()).not.toContain(copyFor("BENCH_ADMIN_UNREACHABLE").headline);
 		// A throttled check must never read as a decline - that invites a 2nd payment.
-		expect(findByText(wrapper, "button", "Start a new payment")).toBeUndefined();
+		expect(findByText(wrapper, "button", "Renew now")).toBeUndefined();
 	});
 
 	it("does not run the passive re-read when the healer refused", async () => {
@@ -966,7 +966,7 @@ describe("finding 7: the healer's coded refusals are answers, not transport erro
 });
 
 describe("finding 6: renew's coded refusals get a notice with an action, not red prose", () => {
-	it("renders PAYMENT_UNDER_REVIEW as a notice carrying Check payment status", async () => {
+	it("renders PAYMENT_UNDER_REVIEW as a notice carrying Check renewal status", async () => {
 		const wrapper = await mountPage();
 		api.renewPlan.mockResolvedValue(rawFail("PAYMENT_UNDER_REVIEW", { status: 409 }));
 
@@ -978,7 +978,7 @@ describe("finding 6: renew's coded refusals get a notice with an action, not red
 		expect(wrapper.vm.codeNotice).toBeTruthy();
 		expect(wrapper.vm.codeNotice.code).toBe("PAYMENT_UNDER_REVIEW");
 		expect(wrapper.vm.actionErr).toBe("");
-		expect(findByText(wrapper, "button", "Check payment status")).toBeTruthy();
+		expect(findByText(wrapper, "button", "Check renewal status")).toBeTruthy();
 	});
 
 	it("leaves a plan-validation refusal as the server's own sentence", async () => {

--- a/frontend/src/pages/billing/BillingPage.spec.js
+++ b/frontend/src/pages/billing/BillingPage.spec.js
@@ -160,6 +160,39 @@ describe("acceptance: renew's stuck-payment answer is no longer silent", () => {
 
 		expect(order).toEqual(["check", "state"]);
 	});
+
+	// Regression: a status check that answers BILLING_NO_CURRENT_INTENT (409)
+	// renders a notice whose ONLY action is INITIATE ("Start a new payment").
+	// doCheckStatus used to bind that notice's retry to itself, so clicking
+	// "Start a new payment" re-ran the status check - which answers the same 409
+	// against the same absent intent forever. The button looked dead: no
+	// redirect, no change. INITIATE here must start a renewal instead.
+	it("routes 'Start a new payment' on a no-intent 409 to renew, not back into the status check", async () => {
+		const wrapper = await mountPage();
+		api.checkBillingPayment.mockResolvedValue(
+			rawFail("BILLING_NO_CURRENT_INTENT", { status: 409 })
+		);
+		await wrapper.vm.doCheckStatus();
+		await flushPromises();
+
+		expect(wrapper.vm.codeNotice.code).toBe(CODES.BILLING_NO_CURRENT_INTENT);
+		const initiate = findByText(wrapper, "button", "Start a new payment");
+		expect(initiate).toBeTruthy();
+
+		const checksBefore = api.checkBillingPayment.mock.calls.length;
+		api.renewPlan.mockResolvedValue(rawOkBody({ tenant_status: "ready" }));
+		await initiate.trigger("click");
+		await flushPromises();
+
+		// The click must NOT re-run the healer, and it must open the renew
+		// confirm dialog so the customer can actually pay.
+		expect(api.checkBillingPayment.mock.calls.length).toBe(checksBefore);
+		const pay = findByText(wrapper, ".dialog button", "Pay");
+		expect(pay).toBeTruthy();
+		await pay.trigger("click");
+		await flushPromises();
+		expect(api.renewPlan).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("edge 1: double-click cannot open a second gateway object", () => {

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -411,6 +411,19 @@ const currentAction = computed(() => {
 	if (canReactivate.value)
 		return { label: "Renew", note: "Renewing restores access straight away." };
 	if (cancelling.value) return { label: "", note: "Resume above to keep this plan." };
+	// Pre-expiry pay-now-to-extend. The server (can_renew / _may_renew) accepts a
+	// manual renewal on a still-running subscription that is not autocharging, and
+	// activate_and_assign stacks the new period onto the days already left rather
+	// than resetting from now. doRenew (the card's @action) sends no target_plan
+	// here, which is the same-plan renewal renew() accepts. This is a distinct
+	// offer from the "Set up auto-renewal" banner: pay once now vs arm a future
+	// mandate. Without it, an Active-with-days-left or Past-Due customer whose
+	// autorenew is off had no way to pay before lapsing.
+	if (account.value.can_renew)
+		return {
+			label: "Renew now",
+			note: "Adds a full billing period on top of the days you have left.",
+		};
 	return { label: "", note: "You are on this plan." };
 });
 

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -672,7 +672,15 @@ async function doCheckStatus() {
 			const unreadable =
 				verdict.code === CLIENT_OFFLINE || verdict.code === CLIENT_UNREADABLE;
 			const code = unreadable ? CODES.BENCH_ADMIN_UNREACHABLE : verdict.code;
-			codeNotice.value = { code, copy: billingCopyFor(code), retry: doCheckStatus };
+			// A coded refusal here whose row offers INITIATE ("Start a new
+			// payment") - e.g. BILLING_NO_CURRENT_INTENT - must start a renewal,
+			// NOT re-run the status check. Binding retry to doCheckStatus made
+			// INITIATE re-check the same absent intent, answering the same 409
+			// forever: a button that looked dead. doRenew mirrors this function's
+			// own success path (settleWithRedirect below) and runCodeAction's
+			// no-notice fallback. Codes whose only action is CHECK are unaffected
+			// - runCodeAction routes CHECK straight to doCheckStatus, not retry.
+			codeNotice.value = { code, copy: billingCopyFor(code), retry: doRenew };
 			await loadAccount();
 			return;
 		}

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -692,7 +692,7 @@ async function doCheckStatus() {
 		// "Failed to fetch".
 		codeNotice.value = {
 			code: CODES.BENCH_ADMIN_UNREACHABLE,
-			copy: copyFor(CODES.BENCH_ADMIN_UNREACHABLE),
+			copy: billingCopyFor(CODES.BENCH_ADMIN_UNREACHABLE),
 			retry: doCheckStatus,
 		};
 	} finally {
@@ -788,7 +788,11 @@ async function runPayment({ key, start, retry, raw = false }) {
 			const verdict = decodePaymentResponse(await start());
 			if (!verdict.ok) {
 				if (verdict.code && copyFor(verdict.code) !== UNKNOWN_COPY) {
-					codeNotice.value = { code: verdict.code, copy: copyFor(verdict.code), retry };
+					codeNotice.value = {
+						code: verdict.code,
+						copy: billingCopyFor(verdict.code),
+						retry,
+					};
 				} else {
 					actionErr.value = verdict.message || errMsg(null);
 				}
@@ -952,11 +956,31 @@ const BILLING_COPY_OVERRIDES = {
 		body: "Nothing more is owed - your plan is active.",
 		actionLabels: { [ACTIONS.CONTINUE]: "Back to chat" },
 	},
+	[CODES.BILLING_NO_CURRENT_INTENT]: {
+		headline: "No renewal is in progress.",
+		body: "Nothing is waiting to be paid on this subscription right now. Renew to extend it.",
+	},
+};
+
+// The action vocabulary in paymentCodes.js is written for the SIGNUP wizard
+// ("Start a new payment", "Check payment status"). On the billing page every
+// payment is a RENEWAL of an existing subscription, so the surface renames the
+// affordances to say exactly that - without touching the shared labels the
+// wizard still relies on. A code's own override (above) wins over these, which
+// win over the shared signup defaults.
+const BILLING_ACTION_LABELS = {
+	[ACTIONS.INITIATE]: "Renew now",
+	[ACTIONS.CHECK]: "Check renewal status",
 };
 
 function billingCopyFor(code) {
 	const base = copyFor(code);
-	const over = BILLING_COPY_OVERRIDES[code];
-	return over ? { ...base, ...over } : base;
+	const over = BILLING_COPY_OVERRIDES[code] || {};
+	const actionLabels = {
+		...BILLING_ACTION_LABELS,
+		...(base.actionLabels || {}),
+		...(over.actionLabels || {}),
+	};
+	return { ...base, ...over, actionLabels };
 }
 </script>


### PR DESCRIPTION
Three fixes to the Plan & Billing renewal experience for existing customers.

**1. Renewal was a dead end.** When the status check answered `BILLING_NO_CURRENT_INTENT` (409, "no payment in progress"), the notice's only button was wired by `doCheckStatus` to re-run the status check against the same absent intent, so it answered the same 409 forever. The button looked dead. It now routes to `doRenew`, opening the confirm dialog and minting a real payment intent.

**2. The buttons read like signup, not renewal.** On this page every payment is a renewal, but the buttons borrowed the signup wizard's words. Renamed on the billing surface only (via the existing `billingCopyFor` override, wizard untouched): "Start a new payment" becomes **"Renew now"**, "Check payment status" becomes **"Check renewal status"**. Every coded billing notice now flows through `billingCopyFor` for consistency.

**3. No way to pay before lapsing.** An Active or Past Due customer with auto-renewal off could only "Set up auto-renewal" (a future mandate, nothing charged now), and Past Due showed no CTA at all, so they waited until expiry to reactivate. The backend already supports a manual pre-expiry renewal (`renew()` accepts it, `activate_and_assign` stacks the new period onto the remaining days, `can_renew` already computes eligibility) - only the button was missing. `currentAction` now shows **"Renew now"** whenever the server reports `can_renew`. Distinct from "Set up auto-renewal": pay once now vs arm a recurring mandate.

All frontend; no admin-v2 change. Regression tests pin the routing, the labels, and the pre-expiry action. 72 billing tests pass.

<details>
<summary>Auto-renewal, for context</summary>

Auto-renewal is enabled by the "Set up auto-renewal" button (`doReauthorize` -> mints a recurring mandate, first charge deferred to period end). It is never asked during onboarding: paid Monthly plans get a mandate at signup (autorenew on from day one), Annual plans get a one-shot order (autorenew off). No onboarding toggle exists.
</details>

https://claude.ai/code/session_01Uijmv3iCa2RRAvMseLnSWX