### PR TITLE
Clean connection info and unify the no-model experience

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -100,38 +100,93 @@
 				/>
 			</div>
 
-			<div
-				v-if="!rows.length && !showDirectRow"
-				style="font-size: 13px; color: var(--text-3); padding: 8px 0"
-			>
-				No models yet. Add one below.
+			<!-- Empty/disconnected state. Used to be a left-aligned "No models yet"
+	           line with the Add button pushed to the pane's far RIGHT edge (see the
+	           end-aligned button below) - and when the pool was empty because of a
+	           disconnect, the actual reason ("Your keys and connected accounts were
+	           deleted") sat in an unrelated pill down at the pane's bottom, so the
+	           two facts read as unrelated instead of one. This box says why (reusing
+	           applyStatus's own pill markup verbatim - never a second copy of that
+	           sentence) and puts the one way out directly under it. Hidden while the
+	           add panel is open: that panel IS the next step, so a second "Add a
+	           model" trigger above it would compete with it, not help (mirrors the
+	           end-aligned button's own !panel.open guard). -->
+			<div v-if="!rows.length && !showDirectRow && !panel.open" class="jv-flist-empty">
+				<!-- 'failed' is deliberately excluded here: the savebar below owns that
+	             status (it is the one place with a Resync button), so painting it a
+	             second time in this box - with no way to retry from it - would be the
+	             exact duplication this box exists to remove. Anything else non-idle
+	             (today, only 'warn'/disconnected) has no action to offer either way,
+	             so it is safe, and more honest, to surface here instead of at the
+	             very bottom of the pane. -->
+				<span
+					v-if="applyStatus.kind !== 'idle' && applyStatus.kind !== 'failed'"
+					class="jv-pool-syncpill"
+					:class="'jv-pool-syncpill--' + applyStatus.kind"
+					role="status"
+				>
+					<span class="jv-pool-syncpill-ic" aria-hidden="true"></span
+					>{{ applyStatus.text }}</span
+				>
+				<!-- A pool that was simply never set up (fresh tenant, nothing ever
+	             applied) has no status to report - "No models yet" is the neutral
+	             line for that, not a hardcoded stand-in for the warning above. Also
+	             the fallback for 'failed', which the savebar below reports instead. -->
+				<p v-else class="jv-flist-empty__msg">No models yet.</p>
+				<button
+					v-if="canEdit"
+					:disabled="!editable"
+					@click="openAdd"
+					class="jv-btn jv-btn--primary jv-flist-addbtn"
+				>
+					<svg
+						viewBox="0 0 24 24"
+						width="15"
+						height="15"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.9"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M12 5v14M5 12h14" />
+					</svg>
+					Add a model
+				</button>
 			</div>
 
-			<div v-for="(row, i) in rows" :key="row._uid ?? i" class="jv-flist-row">
-				<span class="jv-pool-badge">{{ i + 1 }}</span>
-				<ProviderLogo :provider="row.provider" :upstream="row.upstream" :size="18" />
-				<span class="jv-flist-chip">{{ sourceChip(row) }}</span>
-				<span class="jv-flist-model" :class="{ 'jv-flist-model--unset': !row.model }">{{
-					rowModelLabel(row)
-				}}</span>
-				<span
-					v-if="row.credentialType !== 'subscription' && row.hasKey"
-					style="font-size: 11px; color: var(--text-3)"
-					>key set</span
-				>
-				<span
-					class="jv-pool-dot"
-					:class="'jv-pool-dot--' + accountHealth(row).level"
-					aria-hidden="true"
-				></span>
-				<span
-					v-if="accountHealth(row).label"
-					class="jv-pool-acct-health"
-					:class="'jv-pool-acct-health--' + accountHealth(row).level"
-					:title="accountHealth(row).title"
-					>{{ accountHealth(row).label }}</span
-				>
-				<!-- Reorder + [Edit][Reconnect|Replace key][Remove], always right-aligned.
+			<!-- template wrapper, not v-if on the row div itself: Vue 3 gives v-if
+			     higher precedence than v-for on the SAME element, so it would run
+			     before `row` exists in scope. See pendingAddUid's doc above for what
+			     this v-if is hiding and why. -->
+			<template v-for="(row, i) in rows" :key="row._uid ?? i">
+				<div v-if="row._uid !== pendingAddUid" class="jv-flist-row">
+					<span class="jv-pool-badge">{{ i + 1 }}</span>
+					<ProviderLogo :provider="row.provider" :upstream="row.upstream" :size="18" />
+					<span class="jv-flist-chip">{{ sourceChip(row) }}</span>
+					<span
+						class="jv-flist-model"
+						:class="{ 'jv-flist-model--unset': !row.model }"
+						>{{ rowModelLabel(row) }}</span
+					>
+					<span
+						v-if="row.credentialType !== 'subscription' && row.hasKey"
+						style="font-size: 11px; color: var(--text-3)"
+						>key set</span
+					>
+					<span
+						class="jv-pool-dot"
+						:class="'jv-pool-dot--' + accountHealth(row).level"
+						aria-hidden="true"
+					></span>
+					<span
+						v-if="accountHealth(row).label"
+						class="jv-pool-acct-health"
+						:class="'jv-pool-acct-health--' + accountHealth(row).level"
+						:title="accountHealth(row).title"
+						>{{ accountHealth(row).label }}</span
+					>
+					<!-- Reorder + [Edit][Reconnect|Replace key][Remove], always right-aligned.
              All stay LIVE while the config panel is open. The panel used to track its
              target row by ARRAY INDEX, so reordering or removing underneath it silently
              repointed it at a different row (open Edit on row 2, start OAuth, reorder
@@ -141,88 +196,89 @@
              blank seeded one could not be saved OR emptied while the panel was open.
              The panel now tracks its row by IDENTITY (panel.uid -> row._uid), so the
              array can be mutated freely and the panel always follows its own row. -->
-				<span class="jv-flist-acts">
-					<button
-						@click="move(i, -1)"
-						:disabled="!editable || i === 0"
-						title="Up"
-						class="jv-pool-iconbtn"
-					>
-						<svg
-							viewBox="0 0 24 24"
-							width="14"
-							height="14"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.8"
-							stroke-linecap="round"
-							stroke-linejoin="round"
+					<span class="jv-flist-acts">
+						<button
+							@click="move(i, -1)"
+							:disabled="!editable || i === 0"
+							title="Up"
+							class="jv-pool-iconbtn"
 						>
-							<path d="M18 15l-6-6-6 6" />
-						</svg>
-					</button>
-					<button
-						@click="move(i, 1)"
-						:disabled="!editable || i === rows.length - 1"
-						title="Down"
-						class="jv-pool-iconbtn"
-					>
-						<svg
-							viewBox="0 0 24 24"
-							width="14"
-							height="14"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.8"
-							stroke-linecap="round"
-							stroke-linejoin="round"
+							<svg
+								viewBox="0 0 24 24"
+								width="14"
+								height="14"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.8"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<path d="M18 15l-6-6-6 6" />
+							</svg>
+						</button>
+						<button
+							@click="move(i, 1)"
+							:disabled="!editable || i === rows.length - 1"
+							title="Down"
+							class="jv-pool-iconbtn"
 						>
-							<path d="M6 9l6 6 6-6" />
-						</svg>
-					</button>
-					<button
-						v-if="canEdit"
-						:disabled="!editable"
-						@click="openEdit(i)"
-						class="jv-btn jv-btn--sm jv-btn--ghost"
-					>
-						Edit
-					</button>
-					<button
-						v-if="canEdit && row.credentialType === 'subscription'"
-						:disabled="!editable"
-						@click="quickReconnect(i)"
-						class="jv-btn jv-btn--sm jv-btn--ghost"
-					>
-						Reconnect
-					</button>
-					<button
-						v-else-if="canEdit"
-						:disabled="!editable"
-						@click="openEdit(i)"
-						class="jv-btn jv-btn--sm jv-btn--ghost"
-					>
-						Replace key
-					</button>
-					<!-- One button, two meanings, and the label says which BEFORE it is
+							<svg
+								viewBox="0 0 24 24"
+								width="14"
+								height="14"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.8"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<path d="M6 9l6 6 6-6" />
+							</svg>
+						</button>
+						<button
+							v-if="canEdit"
+							:disabled="!editable"
+							@click="openEdit(i)"
+							class="jv-btn jv-btn--sm jv-btn--ghost"
+						>
+							Edit
+						</button>
+						<button
+							v-if="canEdit && row.credentialType === 'subscription'"
+							:disabled="!editable"
+							@click="quickReconnect(i)"
+							class="jv-btn jv-btn--sm jv-btn--ghost"
+						>
+							Reconnect
+						</button>
+						<button
+							v-else-if="canEdit"
+							:disabled="!editable"
+							@click="openEdit(i)"
+							class="jv-btn jv-btn--sm jv-btn--ghost"
+						>
+							Replace key
+						</button>
+						<!-- One button, two meanings, and the label says which BEFORE it is
 			         pressed: with other models left this drops one entry from the
 			         failover list; on the last one there is no list left to edit and it
 			         tears the whole connection down instead. -->
-					<button
-						v-if="canEdit"
-						:disabled="!editable"
-						@click="remove(i)"
-						class="jv-btn jv-btn--sm jv-btn--ghost jv-pool-disc"
-						:title="
-							isLastConnectedRow(row)
-								? 'Delete your keys and connected accounts everywhere'
-								: 'Remove this model from the failover list'
-						"
-					>
-						{{ isLastConnectedRow(row) ? "Disconnect" : "Remove" }}
-					</button>
-				</span>
-			</div>
+						<button
+							v-if="canEdit"
+							:disabled="!editable"
+							@click="remove(i)"
+							class="jv-btn jv-btn--sm jv-btn--ghost jv-pool-disc"
+							:title="
+								isLastConnectedRow(row)
+									? 'Delete your keys and connected accounts everywhere'
+									: 'Remove this model from the failover list'
+							"
+						>
+							{{ isLastConnectedRow(row) ? "Disconnect" : "Remove" }}
+						</button>
+					</span>
+				</div>
+			</template>
 
 			<!-- Ordering is the one change in this editor that does not apply itself
            (see move() for why), so it has to say so and offer a way to commit.
@@ -245,8 +301,11 @@
            (Edit / Reconnect / Remove). The dashed treatment is reserved for an EMPTY
            SLOT the content will fill -- which is what "+ Connect account" is, inside
            the panel, where the account itself then appears. -->
+			<!-- Guarded by (rows.length || showDirectRow): an empty pool already has its
+	           OWN centered "Add a model" button in the box above - this end-aligned
+	           one is only for a pool that already has something to list. -->
 			<button
-				v-if="canEdit && !panel.open"
+				v-if="canEdit && !panel.open && (rows.length || showDirectRow)"
 				:disabled="!editable"
 				@click="openAdd"
 				class="jv-btn jv-btn--primary jv-flist-addbtn jv-flist-addbtn--end"
@@ -1790,7 +1849,15 @@
 	         your agent…" next to its spinner, and this strip says the exact same
 	         sentence, so showing both is a duplicate, not a second, more useful
 	         status (jarvis#559). -->
-		<div v-if="!footerless && statusLine && !busy.active" class="jv-pool-savebar">
+		<div
+			v-if="
+				!footerless &&
+				statusLine &&
+				!busy.active &&
+				(!emptyBoxShowing || statusLine.kind === 'failed')
+			"
+			class="jv-pool-savebar"
+		>
 			<span
 				class="jv-pool-syncpill"
 				:class="'jv-pool-syncpill--' + statusLine.kind"
@@ -2771,6 +2838,19 @@ function pendingAddRow() {
 	const r = rows.value.find((x) => x._uid === panel.value.uid);
 	return r && !r._committed ? r : null;
 }
+// _uid of the row above, or null. The list below hides that ONE row while it is
+// the pool's only entry: rendered as a normal list row it reads as an already-
+// connected model ("1 | Subscription · OpenAI | gpt-5.5 | Reconnect / Edit /
+// Remove") when nothing has been connected yet -- worst right after a disconnect,
+// where "+ Add a model" on an empty pool produced exactly that phantom row. Scoped
+// to rows.length === 1 (not every in-progress add) because a SECOND model being
+// added to an already-populated pool relies on staying visible in the list, and
+// hiding it there would desync the Down-arrow's `i === rows.length - 1` bound and
+// move()'s raw-index reorder (both index into the real, unfiltered `rows` array).
+const pendingAddUid = computed(() => {
+	const r = pendingAddRow();
+	return r && rows.value.length === 1 ? r._uid : null;
+});
 // Append a blank row up-front (not on a later "commit") so finishConnect's
 // !footerless auto-save - which can fire while this panel is still open -
 // already includes it instead of silently dropping an in-progress connect.
@@ -3388,12 +3468,39 @@ function isLastConnectedRow(row) {
 async function remove(i) {
 	const r = rows.value[i];
 	if (!r || busy.value.active) return;
+	// An add-in-progress row was never saved (pendingAddRow's doc above explains
+	// why it sits in rows.value at all): there is nothing on the server to confirm
+	// removing and nothing to persist by dropping it, so this IS closePanel's
+	// Cancel, not a Remove. Without this branch it fell into the generic
+	// confirm+filter+runApply path below like any committed row, and on a pool
+	// with nothing else in it that meant SAVING an empty pool - validatePool
+	// (jarvis/llm/pool.js) rejects that with "Add at least one model.", a save-path
+	// error surfacing on an action that was never a save (jarvis phantom-row bug:
+	// disconnect -> "+ Add a model" -> Remove on the still-unconnected draft).
+	const pending = pendingAddRow();
+	if (pending && pending._uid === r._uid) {
+		rows.value = rows.value.filter((x) => x._uid !== r._uid);
+		panel.value = closedPanel();
+		return;
+	}
 	// save_llm_pool rejects an empty pool server-side, and so does the fleet agent.
 	// Taking the agent's last model away is therefore a different operation, not a
 	// smaller edit: it goes through disconnect_llm, which deletes the credentials
 	// everywhere instead of writing a pool nobody will accept.
 	if (isLastConnectedRow(r)) {
 		await disconnect();
+		return;
+	}
+	// A row with no account/key/has_key was never persisted either -
+	// seedRowsFromConfig (jarvis/llm/pool.js) only ever builds a row FROM one of
+	// those, so isRowEmpty is proof this row is local-only regardless of how it
+	// got here (e.g. closePanel's own source==="preset" exception can leave one
+	// behind after Cancel). If nothing else in the pool would survive removing it,
+	// dropping it locally already matches what the server has - there is nothing
+	// to apply, and nothing to warn the customer they are about to lose.
+	const after = rows.value.filter((x) => x._uid !== r._uid);
+	if (isRowEmpty(r) && !after.some((row) => !isRowEmpty(row))) {
+		rows.value = after;
 		return;
 	}
 	const label = rowModelLabel(r);
@@ -4517,6 +4624,17 @@ const statusLine = computed(() => {
 	if (applyStatus.value.kind !== "idle") return applyStatus.value;
 	return null;
 });
+// True exactly when the empty/disconnected box (rows list, !singleMode only -
+// onboarding always seeds a row, see load()) is on screen. That box already
+// shows applyStatus's own text, so the savebar below repeating the identical
+// pill would be the same duplication busy.active already avoids for "Applying
+// to your agent..." above. Read by the savebar's v-if, which still shows a
+// failed status regardless: its Resync button lives only there, and a failed
+// apply is not what put the pool in this empty state, so hiding it here would
+// bury the one apply that still needs a retry.
+const emptyBoxShowing = computed(
+	() => !singleMode.value && !rows.value.length && !showDirectRow.value && !panel.value.open
+);
 
 // The ONE sync poller. Fire-and-forget callers (load, save) ignore the return
 // value and get the old behaviour: refresh sync.value every few seconds until the
@@ -5203,12 +5321,42 @@ defineExpose({
 	text-transform: uppercase;
 }
 
+/* Empty/disconnected box (see the template note above it). Framed like
+   .jv-cfgpanel below so it reads as an intentional state, not a stray line of
+   text -- message centered, action directly under it, nothing new invented:
+   the pill is .jv-pool-syncpill verbatim and the button is .jv-flist-addbtn
+   verbatim, just laid out centered instead of end-aligned. */
+.jv-flist-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	gap: 10px;
+	padding: 22px 16px;
+	border: 1px solid var(--border-2);
+	border-radius: 11px;
+	background: var(--surface);
+}
+.jv-flist-empty__msg {
+	margin: 0;
+	max-width: 46ch;
+	font-size: 13px;
+	line-height: 1.55;
+	color: var(--text-3);
+}
 /* "+ Add a model" is a .jv-btn (see the template note): only its spacing and the
    plus glyph's tint are local. Everything else — height, radius, type, hover — comes
    from the shared button system, so it can never drift from Edit / Remove / Save. */
 .jv-flist-addbtn {
 	margin-top: 10px;
 	gap: 6px;
+}
+/* Inside the centered empty box the button already sits under the message
+   with the box's own `gap`, so the button's own top margin (needed for the
+   end-aligned case below, where nothing else provides that spacing) would
+   just double it. */
+.jv-flist-empty .jv-flist-addbtn {
+	margin-top: 0;
 }
 /* "Add a model" trails the failover LIST, so it sits at the list's right edge --
    the same edge Save configuration occupies, which is where the eye already is

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -2,24 +2,17 @@
 	<SettingsPane title="General" description="Chat behavior, notifications and token usage.">
 		<h3 class="text-base font-semibold text-ink-gray-9">Connection</h3>
 		<div class="mt-2">
-			<!-- Mode names the TOPOLOGY, Status reports its HEALTH. They used to be
-			     the same row, which is how a 2-model pool came to be labelled
-			     "Direct" here while Billing and metering called the identical state
-			     "Pool (direct failover)". Both panes now read the one
-			     connectionModeLabel(). -->
-			<KvRow v-if="modeLabel" label="Mode" :value="modeLabel" />
-			<!-- A failover pool has no single Model/Provider/Auth mode. Those three
-			     rows were filled from the legacy models[0] mirror, so a 4-model pool
-			     described member one and presented it as the whole connection, under
-			     a Model row naming the synthetic Bifrost endpoint nobody chose. AI
-			     models owns the per-model story (every model in failover order, with
-			     its own status); this is a summary that points at it. The triple
-			     stays for a single-credential tenant, where it is accurate. -->
+			<!-- A failover pool has no single Model/Provider. Those rows were filled
+			     from the legacy models[0] mirror, so a 4-model pool described member
+			     one and presented it as the whole connection, under a Model row
+			     naming the synthetic Bifrost endpoint nobody chose. AI models owns
+			     the per-model story (every model in failover order, with its own
+			     status); this is a summary that points at it. The pair stays for a
+			     single-credential tenant, where it is accurate. -->
 			<KvRow v-if="isPool" label="Models" :value="poolSummary" />
 			<template v-else>
 				<KvRow label="Model" :value="modelLabel" />
 				<KvRow label="Provider" :value="ui.llm_provider || '—'" />
-				<KvRow label="Auth mode" :value="ui.llm_auth_mode || '—'" />
 			</template>
 			<KvRow label="Status">
 				<Badge :label="statusLabel" :theme="statusTheme" variant="subtle" />
@@ -280,7 +273,6 @@ import { useConfirm } from "@/composables/useConfirm";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import KvRow from "@/components/settings/KvRow.vue";
 import ToggleRow from "@/components/settings/ToggleRow.vue";
-import { connectionModeLabel } from "@/llm/pool";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
 import * as api from "@/api";
@@ -372,17 +364,7 @@ const expiresLabel = computed(() => {
 	const ms = connStatus.value && connStatus.value.oauth_expires_at;
 	return ms ? new Date(Number(ms)).toLocaleString() : "—";
 });
-// Shared with Billing and metering so the two panes cannot name the same state
-// differently again: that pane called a 2-model api-key pool "Pool (direct
-// failover)" while this one called it "Direct". Blank without a verdict, which
-// hides the row rather than guessing - and a member never has one: their
-// endpoint answers health only, and topology is precisely what it withholds.
-const modeLabel = computed(() =>
-	connStatus.value
-		? connectionModeLabel(connStatus.value.proxy_active, connStatus.value.model_count)
-		: ""
-);
-// The one line that replaces the triple for a pool: how many models, how they
+// The one line that replaces the pair for a pool: how many models, how they
 // are routed, and whether the container has the current set. humaniseSyncStatus
 // is the same translator Billing and metering's Sync row uses, so the two cannot
 // describe one last_sync_status differently. Its text is a standalone label

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -174,6 +174,40 @@ watch(
 	() => regateOnRouteChange(gatedOnboarding, regatingOnboarding)
 );
 
+// Deep-link contract: desk surfaces outside the SPA (the onboarding banner
+// bundle, the floating chat widget's degraded-connection CTA) can't call
+// store.openSettings() directly - they navigate here instead, to
+// "/jarvis/?settings=aimodels" and the like, and this reads the param once on
+// mount. Kept as a plain Set rather than importing SettingsDialog.vue's PANES
+// (a stack of defineAsyncComponent imports this file has no other reason to
+// pull in) - keep it in sync with that object BY HAND, same duplication
+// tradeoff panel_readiness.mjs makes against readiness.js.
+const SETTINGS_DEEP_LINK_KEYS = new Set([
+	"general",
+	"usage",
+	"activity",
+	"shortcuts",
+	"plan",
+	"aimodels",
+	"billing",
+	"branding",
+	"usageadmin",
+]);
+// Only ever OPENS a pane - an absent or unrecognised key is silently ignored
+// so a plain "/jarvis/" load is untouched. Strips the param either way it
+// matched or not is irrelevant once read; leaving it in the URL would reopen
+// the dialog on every refresh, which is the one thing a deep link must not do.
+function openSettingsFromQuery() {
+	const params = new URLSearchParams(window.location.search);
+	const key = params.get("settings");
+	if (key && SETTINGS_DEEP_LINK_KEYS.has(key)) store.openSettings(key);
+	if (!params.has("settings")) return;
+	params.delete("settings");
+	const query = params.toString();
+	const url = window.location.pathname + (query ? `?${query}` : "") + window.location.hash;
+	history.replaceState(history.state, "", url);
+}
+
 // Boot gate: hold the routed page (NOT the shell chrome) until systemTimezone
 // is configured — timeAgo strings render once, so a late setConfig would leave
 // stale future-tense timestamps on the first paint. Production boot injects
@@ -231,6 +265,7 @@ const removeAfterEach = router.afterEach(() => {
 let _detachNotifier = null;
 
 onMounted(async () => {
+	openSettingsFromQuery();
 	document.addEventListener("visibilitychange", onVisibility);
 	if (document.visibilityState === "visible") startInterval();
 	_detachNotifier = attachGlobalNotifier({ socket, router });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2116,7 +2116,7 @@
 					v-else-if="noAiConnected"
 					type="warning"
 					title="No AI connected"
-					message="Connect a model to start chatting again"
+					:message="noAiConnectedMessage"
 					style="margin-bottom: 10px"
 				>
 					<template #action>
@@ -3923,6 +3923,16 @@ const noAiConnected = ref(false);
 // they should know why), just without a button that would only bounce them back to
 // General.
 const canConnectModel = !!(window.is_jarvis_admin || window.is_system_manager);
+// The button above is already role-gated; the COPY needs to be too. The original
+// single message ("Connect a model to start chatting again") told a member to do
+// something the server would refuse, with the one button that could have routed
+// them anywhere already hidden - just a dead-end sentence. A member gets told to
+// ask an admin instead; an admin keeps the original actionable wording.
+const noAiConnectedMessage = computed(() =>
+	canConnectModel
+		? "Connect a model to start chatting again"
+		: "Ask your administrator to reconnect a model"
+);
 function goConnectModel() {
 	store.openSettings("aimodels");
 }
@@ -7718,7 +7728,15 @@ async function send(textArg, resendAck) {
 	// at all. With no model connected the turn can only fail at the agent, so refuse it
 	// here and keep the banner's own wording rather than surfacing a backend error.
 	if (noAiConnected.value) {
-		notify("No AI connected. Connect a model to start chatting again.", { type: "info" });
+		// Same role split as the banner above (noAiConnectedMessage): a member
+		// cannot open the AI models pane, so telling them to "connect a model"
+		// is a dead end.
+		notify(
+			canConnectModel
+				? "No AI connected. Connect a model to start chatting again."
+				: "No AI connected. Ask your administrator to reconnect a model.",
+			{ type: "info" }
+		);
 		return;
 	}
 	if (text && promptHistory.value[promptHistory.value.length - 1] !== text) {

--- a/jarvis/boot.py
+++ b/jarvis/boot.py
@@ -11,6 +11,12 @@ Keys we set:
   setup wizard, used by the desk's not-onboarded banner
   (``jarvis_onboarding_banner.bundle.js``) to decide whether to nag a
   System Manager toward ``/jarvis/onboarding``.
+- ``jarvis_ready_reason`` - the ``reason`` from the same readiness check,
+  set only when NOT ready. Lets desk surfaces tell "never onboarded"
+  apart from "was onboarded, lost its AI connection" (``reason ==
+  "llm_credentials"``) without a second round trip, so the banner can
+  send the second case to the AI models settings pane instead of
+  restarting the wizard.
 - ``jarvis_has_access`` - whether the current user may reach Jarvis at
   all (``jarvis.permissions.has_jarvis_access``). Lets the desk's
   floating Jarvis button send an unauthorized user to
@@ -36,9 +42,14 @@ def set_jarvis_boot(bootinfo):
 	try:
 		from jarvis.account import is_ready_for_chat
 
-		bootinfo.jarvis_onboarded = bool((is_ready_for_chat() or {}).get("ready"))
+		# Captured once: jarvis_ready_reason below reads the same dict rather
+		# than calling is_ready_for_chat() a second time.
+		readiness = is_ready_for_chat() or {}
+		bootinfo.jarvis_onboarded = bool(readiness.get("ready"))
+		bootinfo.jarvis_ready_reason = "" if bootinfo.jarvis_onboarded else (readiness.get("reason") or "")
 	except Exception:
 		bootinfo.jarvis_onboarded = True  # fail-safe: never nag on a boot error
+		bootinfo.jarvis_ready_reason = ""
 
 	# Drives the desk's floating Jarvis button: an unauthorized user is routed
 	# to /jarvis-no-access instead of the chat panel opening. Import kept

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -372,7 +372,19 @@
 						d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
 					/>
 				</svg>
-				<span>{{ readinessNotice }}</span>
+				<div class="jvp-notice-body">
+					<span>{{ readinessNotice }}</span>
+					<!-- Only an admin gets a CTA (readinessCta stays null for a member -
+					     see degradedActionable in panel_readiness.mjs). -->
+					<button
+						v-if="readinessCta"
+						type="button"
+						class="jvp-btn-solid jvp-notice-cta"
+						@click="goReadinessCta"
+					>
+						{{ readinessCta.label }}
+					</button>
+				</div>
 			</div>
 
 			<div v-if="stream.pending.length" class="jvp-pending">
@@ -588,7 +600,7 @@ import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import { renderReply } from "./panel_markdown.mjs";
 import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
-import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
+import { classifyReadiness, degradedActionable } from "./panel_readiness.mjs";
 import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
 import { sortPendingCards } from "./pending_order.mjs";
 import { ONBOARDING_URL } from "./config.mjs";
@@ -885,6 +897,11 @@ let recStartedAt = 0;
 const readiness = ref(null);
 const readinessResolved = computed(() => readiness.value !== null);
 const readinessNotice = ref("");
+// Set alongside readinessNotice when the degraded verdict is one an admin can
+// actually fix (see degradedActionable in panel_readiness.mjs) - {label, href}
+// or null. A member never gets one: canOnboard below gates it off before the
+// widget even asks for actionable copy.
+const readinessCta = ref(null);
 // Only an admin who can actually reach the wizard gets the CTA button in the
 // gate state, mirroring OnboardingGate.vue's isSystemManager split. Read off
 // frappe.boot.user.roles - core Frappe bootinfo (User.load_user), already
@@ -1196,6 +1213,13 @@ function removeAttachment(url) {
 // full navigation since the wizard lives in the SPA, not this widget.
 function goOnboard() {
 	window.location.assign(ONBOARDING_URL);
+}
+
+// The degraded banner's CTA (readinessCta), when present. Same full-navigation
+// pattern as goOnboard above - the AI models settings pane lives in the SPA,
+// not this widget.
+function goReadinessCta() {
+	if (readinessCta.value?.href) window.location.assign(readinessCta.value.href);
 }
 
 // The mic button lives in the footer, and the footer unmounts the moment the
@@ -1562,14 +1586,24 @@ onMounted(() => {
 	isReadyForChat()
 		.then((r) => {
 			readiness.value = classifyReadiness(r);
-			readinessNotice.value =
-				readiness.value === "degraded" ? degradedMessage(r, brandName) : "";
+			if (readiness.value === "degraded") {
+				// canOnboard already matches JARVIS_ADMIN_ROLES (System Manager or
+				// Jarvis Admin - jarvis/permissions.py), so it doubles as the
+				// "can this person actually reconnect a model" check here.
+				const actionable = degradedActionable(r, brandName, canOnboard);
+				readinessNotice.value = actionable.text;
+				readinessCta.value = actionable.cta;
+			} else {
+				readinessNotice.value = "";
+				readinessCta.value = null;
+			}
 		})
 		.catch(() => {
 			// Fail OPEN, same as classifyReadiness(null): a flaky/unreachable check
 			// must never strand a real user behind the gate.
 			readiness.value = classifyReadiness(null);
 			readinessNotice.value = "";
+			readinessCta.value = null;
 		});
 });
 
@@ -2501,6 +2535,18 @@ defineExpose({ load, startNewChat, convId });
 	height: 15px;
 	flex: none;
 	margin-top: 1px;
+}
+.jvp-notice-body {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 7px;
+	flex: 1;
+}
+.jvp-notice-cta {
+	height: 26px;
+	padding: 0 11px;
+	font-size: 12px;
 }
 
 /* ---- pending write confirmation ---- */

--- a/jarvis/public/js/jarvis_chat/widget/config.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/config.mjs
@@ -16,6 +16,12 @@ export const conversationUrl = (id) =>
 // here rather than duplicating the wizard in 400px.
 export const ONBOARDING_URL = "/jarvis/onboarding";
 
+// Deep link that opens the SPA straight to the AI models settings tab
+// (AppShell.vue's onMounted `settings` query-param handler). Used by the
+// degraded banner's "Connect a model" CTA: a disconnected-but-onboarded
+// workspace needs the settings dialog, not the onboarding wizard above.
+export const AI_MODELS_SETTINGS_URL = "/jarvis/?settings=aimodels";
+
 // Below this viewport width a 400px docked panel is most of the screen, so the
 // FAB falls back to navigating to the SPA instead of opening in place.
 export const PANEL_MIN_VIEWPORT_PX = 640;

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -8,6 +8,8 @@
 // for the full reasoning behind each reason's placement - repeated here only
 // to the extent this module needs it to classify a verdict.
 
+import { AI_MODELS_SETTINGS_URL } from "./config.mjs";
+
 // Reasons meaning the workspace has NEVER completed onboarding at all - the
 // only case that should replace the whole panel with a setup nudge.
 //
@@ -108,4 +110,41 @@ export function degradedMessage(resp, agentName = "Jarvis") {
   if (reason === "readiness_unconfirmed")
     return detail || unconfirmedDegraded(brand);
   return GENERIC_DEGRADED;
+}
+
+// Role-aware wrapper around degradedMessage() for the one case an admin can
+// actually do something about: no AI attached at all. That is exactly the
+// case degradedMessage() flattens into the generic "ask your administrator"
+// sentence (subscription_suspended, container_provisioning and
+// readiness_unconfirmed all have their own dedicated copy above and are left
+// untouched - none of them are fixed by reconnecting a model, so none of them
+// get this CTA). An admin gets actionable copy plus a link to the AI models
+// settings pane; a member still can't act on it, so they keep
+// degradedMessage()'s member wording with no button.
+export function degradedActionable(
+  resp,
+  agentName = "Jarvis",
+  isAdmin = false
+) {
+  const reason = (resp && resp.reason) || "";
+  const text = degradedMessage(resp, agentName);
+  const hasOwnCopy =
+    reason === "subscription_suspended" ||
+    reason === "container_provisioning" ||
+    reason === "readiness_unconfirmed" ||
+    // Neither of these is a "no AI attached" problem the AI models pane can
+    // fix. site_replaced has its own reconnect-the-SITE flow (readiness.js's
+    // replacedBanner, RECONNECT_INTENT_URL) - the account moved elsewhere, no
+    // model to connect here. authority_repair_required is admin's own
+    // reassurance after paging support; readiness.js is explicit that this
+    // reason must NEVER offer a Renew or Reconnect action, which could make
+    // an ambiguous/invalid container worse. Both keep degradedMessage's plain
+    // text, no CTA - same as the three reasons above.
+    reason === "authority_repair_required" ||
+    reason === "site_replaced";
+  if (!isAdmin || hasOwnCopy) return { text, cta: null };
+  return {
+    text: "No AI connected. Connect a model to start chatting again.",
+    cta: { label: "Connect a model", href: AI_MODELS_SETTINGS_URL },
+  };
 }

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -33,11 +33,20 @@ import { AI_MODELS_SETTINGS_URL } from "./config.mjs";
 // "llm_setup" is the server-decided HARD variant of llm_credentials (creds
 // missing + nothing ever synced + subscription never Active): a half-finished
 // signup, where chat cannot work at all.
+// "llm_rejected" (jarvis#757): a first pool/direct sync the server explicitly
+// refused. readiness.js lists it here for the same reason as the two
+// provisioning reasons (a first sync that never succeeded), and the desk
+// onboarding banner routes it to setup too, so the widget must agree or the two
+// desk surfaces show contradictory recovery paths for one verdict (jarvis
+// review). "readiness_unconfirmed" is deliberately NOT added: it is transient
+// (the control plane could not answer yet), and degradedMessage below gives it
+// a dedicated "try again shortly" line that a one-way setup gate would bury.
 const NOT_ONBOARDED_REASONS = new Set([
   "signup",
   "llm_setup",
   "llm_pool_provisioning",
   "llm_provisioning",
+  "llm_rejected",
 ]);
 
 // Three-way verdict the panel renders around:
@@ -112,39 +121,35 @@ export function degradedMessage(resp, agentName = "Jarvis") {
   return GENERIC_DEGRADED;
 }
 
-// Role-aware wrapper around degradedMessage() for the one case an admin can
-// actually do something about: no AI attached at all. That is exactly the
-// case degradedMessage() flattens into the generic "ask your administrator"
-// sentence (subscription_suspended, container_provisioning and
-// readiness_unconfirmed all have their own dedicated copy above and are left
-// untouched - none of them are fixed by reconnecting a model, so none of them
-// get this CTA). An admin gets actionable copy plus a link to the AI models
-// settings pane; a member still can't act on it, so they keep
-// degradedMessage()'s member wording with no button.
+// Role-aware wrapper around degradedMessage() for the ONE reason an admin can
+// fix from here: "llm_credentials", a workspace whose AI was disconnected or
+// whose credential expired, so no model is attached at all. An admin gets
+// actionable "no AI connected" copy plus a link to the AI models settings pane;
+// a member cannot act on it, so they keep degradedMessage()'s member wording
+// with no button.
+//
+// ALLOWLIST, not a denylist (jarvis review). Every OTHER reason keeps
+// degradedMessage()'s own copy and gets no CTA. Listing instead the reasons that
+// have dedicated copy silently handed this "Connect a model" button - and threw
+// away the reason's real detail - to "llm_rejected" (a config the server
+// refused, where a model IS attached; now gated to setup above) and to any
+// reason account.py grows later. Only the reason this button actually fixes
+// opts in.
+//
+// The "No AI connected..." string is duplicated verbatim from ChatView.vue's
+// noAiConnectedMessage (the SPA banner for the same condition). Keep the two in
+// sync BY HAND, same as NOT_ONBOARDED_REASONS above.
 export function degradedActionable(
   resp,
   agentName = "Jarvis",
   isAdmin = false
 ) {
   const reason = (resp && resp.reason) || "";
-  const text = degradedMessage(resp, agentName);
-  const hasOwnCopy =
-    reason === "subscription_suspended" ||
-    reason === "container_provisioning" ||
-    reason === "readiness_unconfirmed" ||
-    // Neither of these is a "no AI attached" problem the AI models pane can
-    // fix. site_replaced has its own reconnect-the-SITE flow (readiness.js's
-    // replacedBanner, RECONNECT_INTENT_URL) - the account moved elsewhere, no
-    // model to connect here. authority_repair_required is admin's own
-    // reassurance after paging support; readiness.js is explicit that this
-    // reason must NEVER offer a Renew or Reconnect action, which could make
-    // an ambiguous/invalid container worse. Both keep degradedMessage's plain
-    // text, no CTA - same as the three reasons above.
-    reason === "authority_repair_required" ||
-    reason === "site_replaced";
-  if (!isAdmin || hasOwnCopy) return { text, cta: null };
-  return {
-    text: "No AI connected. Connect a model to start chatting again.",
-    cta: { label: "Connect a model", href: AI_MODELS_SETTINGS_URL },
-  };
+  if (isAdmin && reason === "llm_credentials") {
+    return {
+      text: "No AI connected. Connect a model to start chatting again.",
+      cta: { label: "Connect a model", href: AI_MODELS_SETTINGS_URL },
+    };
+  }
+  return { text: degradedMessage(resp, agentName), cta: null };
 }

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -31,6 +31,11 @@
 	// Same check the SPA gate and the widget popup use, so all three surfaces
 	// agree on what "set up" means.
 	var READY_METHOD = "jarvis.account.is_ready_for_chat";
+	// Deep link to the AI models settings tab, used by the reconnect variant's
+	// CTA. Must match config.mjs's AI_MODELS_SETTINGS_URL: this standalone desk
+	// bundle is loaded via app_include_js and cannot import from the widget
+	// module graph, so the string is kept in sync here by hand.
+	var AI_MODELS_SETTINGS_URL = "/jarvis/?settings=aimodels";
 	// Floor between server re-checks for the chatty triggers (route change,
 	// tab focus). A bfcache restore bypasses it: that is the exact moment the
 	// flag is most likely stale and the user is looking straight at it.
@@ -194,24 +199,29 @@
 	// reconnected, so they get different copy and a different destination.
 	function nudgeVariant() {
 		var reason = (window.frappe && frappe.boot && frappe.boot.jarvis_ready_reason) || "";
-		// White-label: the reconnect copy names the agent, so it must not say
-		// "Jarvis" for a tenant that renamed it. The never-onboarded copy below
-		// is left as literal "Jarvis" text - unchanged, per the existing pitch.
+		// White-label: the reconnect copy names the agent, so its whole bubble -
+		// text, header and aria-label - must not say "Jarvis" for a tenant that
+		// renamed it. The never-onboarded pitch below is left as literal "Jarvis",
+		// unchanged, per the existing copy.
 		var agentName =
 			(window.frappe && frappe.boot && frappe.boot.jarvis_agent_name) || "Jarvis";
 		if (reason === "llm_credentials") {
 			return {
+				name: agentName,
+				aria: "Reconnect " + agentName,
 				text:
 					"Your AI connection dropped, so " +
 					agentName +
 					" can't reply right now. Reconnect a model to pick up where you left off.",
 				ctaLabel: "Reconnect a model →",
-				href: "/jarvis/?settings=aimodels",
+				href: AI_MODELS_SETTINGS_URL,
 			};
 		}
 		// Every other reason (never onboarded, or an empty/unknown reason from an
 		// older boot payload) keeps the original pitch and destination.
 		return {
+			name: "Jarvis",
+			aria: "Set up Jarvis",
 			text: "Hey 👋 I'm Jarvis. Set me up and I'll handle the ERP busywork like quotes, invoices, and reports.",
 			ctaLabel: "Set up Jarvis →",
 			href: "/jarvis/onboarding",
@@ -229,12 +239,12 @@
 		if (document.getElementById(NUDGE_ID)) return;
 		ensureStyles();
 
+		var variant = nudgeVariant();
+
 		var wrap = document.createElement("div");
 		wrap.id = NUDGE_ID;
 		wrap.setAttribute("role", "complementary");
-		wrap.setAttribute("aria-label", "Set up Jarvis");
-
-		var variant = nudgeVariant();
+		wrap.setAttribute("aria-label", variant.aria);
 
 		// Single bubble — greeting + pitch + CTA + dismiss.
 		wrap.appendChild(
@@ -252,7 +262,7 @@
 
 				var n = document.createElement("div");
 				n.className = "jvn-name";
-				n.textContent = "Jarvis";
+				n.textContent = variant.name;
 				b.appendChild(n);
 
 				var t = document.createElement("div");

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -185,6 +185,39 @@
 		document.head.appendChild(st);
 	}
 
+	// Which bubble to show, decided from frappe.boot.jarvis_ready_reason (set in
+	// jarvis.boot.set_jarvis_boot, same round trip as jarvis_onboarded). A
+	// workspace that was NEVER onboarded and one that finished onboarding but
+	// later lost its AI connection ("llm_credentials") both read jarvis_onboarded
+	// === false, and would look identical to this nudge without the reason -
+	// but the first needs the full wizard and the second only needs a model
+	// reconnected, so they get different copy and a different destination.
+	function nudgeVariant() {
+		var reason = (window.frappe && frappe.boot && frappe.boot.jarvis_ready_reason) || "";
+		// White-label: the reconnect copy names the agent, so it must not say
+		// "Jarvis" for a tenant that renamed it. The never-onboarded copy below
+		// is left as literal "Jarvis" text - unchanged, per the existing pitch.
+		var agentName =
+			(window.frappe && frappe.boot && frappe.boot.jarvis_agent_name) || "Jarvis";
+		if (reason === "llm_credentials") {
+			return {
+				text:
+					"Your AI connection dropped, so " +
+					agentName +
+					" can't reply right now. Reconnect a model to pick up where you left off.",
+				ctaLabel: "Reconnect a model →",
+				href: "/jarvis/?settings=aimodels",
+			};
+		}
+		// Every other reason (never onboarded, or an empty/unknown reason from an
+		// older boot payload) keeps the original pitch and destination.
+		return {
+			text: "Hey 👋 I'm Jarvis. Set me up and I'll handle the ERP busywork like quotes, invoices, and reports.",
+			ctaLabel: "Set up Jarvis →",
+			href: "/jarvis/onboarding",
+		};
+	}
+
 	function bubbleRow(cls, buildBubble) {
 		var row = document.createElement("div");
 		row.className = "jvn-row " + cls;
@@ -200,6 +233,8 @@
 		wrap.id = NUDGE_ID;
 		wrap.setAttribute("role", "complementary");
 		wrap.setAttribute("aria-label", "Set up Jarvis");
+
+		var variant = nudgeVariant();
 
 		// Single bubble — greeting + pitch + CTA + dismiss.
 		wrap.appendChild(
@@ -221,14 +256,13 @@
 				b.appendChild(n);
 
 				var t = document.createElement("div");
-				t.textContent =
-					"Hey 👋 I'm Jarvis. Set me up and I'll handle the ERP busywork like quotes, invoices, and reports.";
+				t.textContent = variant.text;
 				b.appendChild(t);
 
 				var cta = document.createElement("a");
 				cta.className = "jvn-btn";
-				cta.href = "/jarvis/onboarding";
-				cta.textContent = "Set up Jarvis →";
+				cta.href = variant.href;
+				cta.textContent = variant.ctaLabel;
 				b.appendChild(cta);
 				return b;
 			})


### PR DESCRIPTION
## Summary

Six small UI fixes to the settings dialog, chat, and desk surfaces, all around the "no AI model connected" experience.

- **General > Connection**: drops the Mode and Auth mode rows (Model, Provider, Status stay).
- **AI models pane**: a centered empty/disconnected state (warning plus a centered "Add a model" button) instead of a stray line with a right-pushed button.
- **Add a model**: the uncommitted draft no longer renders as a fake "row 1", and removing it cancels cleanly instead of raising the misleading "Add at least one model" toast.
- **Role-aware "no AI connected" copy** everywhere (main chat, floating widget, desk nudge): admins get a "Connect a model" button into the AI models settings tab; members are told to ask their administrator.
- **Desk nudge splits by state**: a never-onboarded tenant still goes to onboarding; a disconnected-but-onboarded tenant gets a "Reconnect a model" bubble into AI models settings.

Adds a `jarvis_ready_reason` boot field and a `/jarvis/?settings=aimodels` deep link so desk surfaces outside the SPA can open the settings tab.

Deployed to `e2e.localhost` for manual verification.

<details>
<summary>Root cause of the "row 1" phantom and the wrong toast</summary>

The phantom row was not stale server data. `openAdd()` appends an uncommitted draft row into `rows` before anything connects; on an empty pool it rendered as list row "1" with full controls. Clicking Remove fell through to the generic filter + `runApply` path, which called `validatePool()` on the now-empty pool and surfaced its save-path error "Add at least one model." on an action that was never a save. Fixed by hiding the sole-row draft and treating its removal as a Cancel.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on failure)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
