### PR TITLE
fix(connect): plain-English errors for chat-subscription sign-in failures

### DIFF
--- a/frontend/src/components/LlmPoolEditor.connect.spec.js
+++ b/frontend/src/components/LlmPoolEditor.connect.spec.js
@@ -600,3 +600,65 @@ describe("subscription Test force_probe (jarvis_admin_v2#297): no repeat can car
 		expect(w.vm.subTest.result.message).toMatch(/just now/i);
 	});
 });
+
+// Connect-error copy: jarvis/oauth/api.py's {ok:false, error:{code, message}} envelope
+// carries a raw developer `message` ("nonce not recognized" etc.) alongside a `code`.
+// finishConnect (and startConnect / _pollDeviceConnect, same envelope) must show the
+// customer the friendly CONNECT_ERROR_COPY text keyed on `code`, not that raw message
+// verbatim - and must still show SOMETHING (the raw message) for a code it doesn't know.
+describe("connect-flow error copy (finishConnect)", () => {
+	async function beginSignin(w, { model = "gpt-4o", upstream = "openai" } = {}) {
+		const r = w.vm.rows[0];
+		r.credentialType = "subscription";
+		r.upstream = upstream;
+		r.model = model;
+		api.beginPoolAccountSignin.mockResolvedValue({
+			ok: true,
+			data: { nonce: "nonce1", authorize_url: "https://provider.example/authorize" },
+		});
+		// openTab: false skips the popup window.open() this test has no need to drive.
+		await w.vm.startConnect(r, null, { openTab: false });
+		await flushPromises();
+		expect(r._connect.nonce).toBe("nonce1"); // sanity: signin actually began
+		r._connect.pastedUrl = "https://app.example/callback?code=abc&state=xyz";
+		return r;
+	}
+
+	it("maps a known code (unknown_nonce) to friendly copy, not the raw backend message", async () => {
+		const w = await mountOnboarding();
+		const r = await beginSignin(w);
+		api.completePoolAccountSignin.mockResolvedValue({
+			ok: false,
+			error: { code: "unknown_nonce", message: "nonce not recognized" },
+		});
+
+		await w.vm.finishConnect(r);
+
+		expect(r._connect.error).not.toBe("nonce not recognized");
+		expect(r._connect.error).toMatch(/sign-in session was lost/i);
+		expect(r._connect.error).toMatch(/open sign-in/i);
+	});
+
+	it("falls back to the backend's own message for an unmapped/unknown code", async () => {
+		const w = await mountOnboarding();
+		const r = await beginSignin(w);
+		api.completePoolAccountSignin.mockResolvedValue({
+			ok: false,
+			error: { code: "some_future_code", message: "some raw backend text" },
+		});
+
+		await w.vm.finishConnect(r);
+
+		expect(r._connect.error).toBe("some raw backend text");
+	});
+
+	it("falls back to the generic Connect failure copy when the error has no code or message at all", async () => {
+		const w = await mountOnboarding();
+		const r = await beginSignin(w);
+		api.completePoolAccountSignin.mockResolvedValue({ ok: false });
+
+		await w.vm.finishConnect(r);
+
+		expect(r._connect.error).toMatch(/couldn't connect the account/i);
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -3822,6 +3822,42 @@ function openConnectPanel(m, reconnectIdx = null) {
 	m._connect = { ...blankConnect(), open: true, reconnectIdx, pastedUrl: carried };
 }
 
+// Connect-flow error codes -> customer-facing copy. jarvis/oauth/api.py's _err(code,
+// message) sends the RAW developer message ("nonce not recognized", "nonce has
+// expired; generate a new sign-in URL", ...) as `message`; showing that verbatim to a
+// customer is meaningless jargon. This maps the small, closed set of codes the
+// connect/complete/device-poll paths can return to something a non-technical customer
+// can actually act on. A code that isn't in this map (unknown_provider,
+// device_flow_required - both rare, and already readable) deliberately falls through
+// to the backend's own message in connectErrorMessage() below, so nothing is ever
+// hidden or silently dropped.
+const CONNECT_ERROR_COPY = {
+	unknown_nonce:
+		'Your sign-in session was lost. Click "Open sign-in" and finish the steps in one go without pausing.',
+	expired: 'Your sign-in link expired. Click "Open sign-in" to get a fresh one.',
+	state_mismatch:
+		'That sign-in didn\'t match this attempt. Click "Open sign-in" and paste the new link.',
+	missing_code:
+		"That doesn't look like the callback URL. After approving, copy the FULL URL from the address bar and paste it here.",
+	not_pending: 'This sign-in was already used. Click "Open sign-in" to start a new one.',
+	token_exchange_failed:
+		'The provider rejected the sign-in. Click "Open sign-in" and try again.',
+	code_invalid: 'The provider rejected the sign-in. Click "Open sign-in" and try again.',
+	auth_failed: 'The provider rejected the sign-in. Click "Open sign-in" and try again.',
+	network_error:
+		"Couldn't reach the sign-in provider. Check your connection and try again in a minute.",
+	device_start_failed: "Couldn't start sign-in with the provider. Try again.",
+};
+// Pull a customer-facing message out of the {ok:false, error:{code, message}} envelope
+// startConnect/finishConnect/_pollDeviceConnect all get back on failure. A known code
+// wins; an unmapped code (or a response with no code at all, e.g. a plain network
+// throw) falls back to the backend's own `message`, and only then to the caller's
+// generic `fallback` - so this can never crash and never hides a real error.
+function connectErrorMessage(res, fallback) {
+	const err = res && res.error;
+	if (!err) return fallback;
+	return CONNECT_ERROR_COPY[err.code] || err.message || fallback;
+}
 async function startConnect(m, reconnectIdx = null, opts = {}) {
 	if (!m._connect) m._connect = blankConnect();
 	// Simplified editor hides the model field - make sure a subscription row always
@@ -3871,8 +3907,7 @@ async function startConnect(m, reconnectIdx = null, opts = {}) {
 		// hanging on "Starting sign-in…".
 		if (!res || res.ok === false) {
 			m._connect.loading = false;
-			m._connect.error =
-				(res && res.error && res.error.message) || "Couldn't start sign-in. Try again.";
+			m._connect.error = connectErrorMessage(res, "Couldn't start sign-in. Try again.");
 			if (win) win.close();
 			return;
 		}
@@ -3921,8 +3956,7 @@ async function _pollDeviceConnect(m, intervalSecs) {
 		}
 		if (!m._connect || m._connect.nonce !== nonce) return;
 		if (!res || res.ok === false) {
-			m._connect.error =
-				(res && res.error && res.error.message) || "Sign-in failed. Start again.";
+			m._connect.error = connectErrorMessage(res, "Sign-in failed. Start again.");
 			m._connect.polling = false;
 			return;
 		}
@@ -4072,11 +4106,12 @@ async function finishConnect(m) {
 	// Same {ok, data} envelope as begin - unwrap + surface errors.
 	if (!res || res.ok === false) {
 		m._connect.loading = false;
-		m._connect.error =
-			(res && res.error && res.error.message) ||
-			(isCodeOnlyPaste(m.upstream)
+		m._connect.error = connectErrorMessage(
+			res,
+			isCodeOnlyPaste(m.upstream)
 				? "Couldn't connect the account. Check the pasted code and try again."
-				: "Couldn't connect the account. Check the pasted URL and try again.");
+				: "Couldn't connect the account. Check the pasted URL and try again."
+		);
 		return;
 	}
 	// Place the (re)connected account. The backend mints a fresh account_ref on


### PR DESCRIPTION
## Summary

Connecting a chat subscription (Settings → AI models → Add a model → sign in → paste callback URL) surfaced raw developer text to customers on failure — the worst being **"nonce not recognized"**, seen live during onboarding. This maps the connect error codes to plain, actionable copy.

A lost or expired sign-in session now reads *"Your sign-in session was lost. Click 'Open sign-in' and finish the steps in one go without pausing."* instead of jargon. Unmapped codes still fall back to the backend message, so no real error is ever hidden. Frontend-only: a `code → copy` map + `connectErrorMessage()` helper, wired into `startConnect`, `finishConnect`, and the device-poll path.

Codes covered: `unknown_nonce`, `expired`, `state_mismatch`, `missing_code`, `not_pending`, `token_exchange_failed`, `code_invalid`, `auth_failed`, `network_error`, `device_start_failed`. 3 new tests.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff