### PR TITLE
feat: CSV import tools (preview_import + run_import) with a data-showing confirm card

### DIFF
--- a/frontend/src/components/PendingCard.spec.js
+++ b/frontend/src/components/PendingCard.spec.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import PendingCard from "./PendingCard.vue";
+
+// The `import` confirmation-card kind (run_import). The card is the human's independent
+// check on the agent, so these pin what it shows AND that untrusted file cell values can
+// never be interpreted as HTML.
+const importCard = (overrides = {}) => ({
+	kind: "import",
+	doctype: "Timesheet",
+	import_type: "Insert New Records",
+	file: "timesheets.csv",
+	total_rows: 280,
+	total_records: 280,
+	submit_after_import: false,
+	columns: { mapped: ["Title -> title"], unmapped: ["Journal"] },
+	sample: { columns: ["Title", "Hours"], rows: [{ cells: ["REC-1", "8"] }], extra_cols: 0 },
+	advisory: ["This creates 280 separate records, one per row."],
+	...overrides,
+});
+
+describe("PendingCard import kind", () => {
+	it("renders target, counts, file and sample rows", () => {
+		const w = mount(PendingCard, { props: { card: importCard(), details: "" } });
+		const text = w.text();
+		expect(text).toContain("Timesheet");
+		expect(text).toContain("280");
+		expect(text).toContain("timesheets.csv");
+		expect(w.find("table").exists()).toBe(true);
+		expect(text).toContain("REC-1");
+	});
+
+	it("shows the fan-out advisory and the unmapped-columns line", () => {
+		const w = mount(PendingCard, { props: { card: importCard(), details: "" } });
+		expect(w.text()).toContain("separate records");
+		expect(w.text()).toContain("Journal");
+	});
+
+	it("does NOT interpret an untrusted cell value as HTML (XSS-safe)", () => {
+		const w = mount(PendingCard, {
+			props: {
+				card: importCard({
+					sample: {
+						columns: ["Note"],
+						rows: [{ cells: ["<img src=x onerror=alert(1)>"] }],
+						extra_cols: 0,
+					},
+				}),
+				details: "",
+			},
+		});
+		// A v-html render would create an <img>; escaped interpolation keeps it as text.
+		expect(w.find("td img").exists()).toBe(false);
+		expect(w.text()).toContain("<img src=x onerror=alert(1)>");
+	});
+
+	it("renders the empty state when there are no sample rows", () => {
+		const w = mount(PendingCard, {
+			props: {
+				card: importCard({ sample: { columns: [], rows: [], extra_cols: 0 } }),
+				details: "",
+			},
+		});
+		expect(w.text()).toContain("No preview rows.");
+	});
+
+	it("shows the submit note only when submit_after_import is set", () => {
+		const on = mount(PendingCard, {
+			props: { card: importCard({ submit_after_import: true }), details: "" },
+		});
+		expect(on.text()).toMatch(/submit each record/i);
+		const off = mount(PendingCard, { props: { card: importCard(), details: "" } });
+		expect(off.text()).not.toMatch(/submit each record/i);
+	});
+});

--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -3,9 +3,9 @@
 // write's confirmation card - replacing the raw-JSON dump. The structured card
 // comes from jarvis/chat/confirm_card.py (kind = create | update | bulk_update |
 // verb | email | bulk_email | share | assign | skill | wiki | method |
-// batch_create) and is already perm-filtered + size-capped server-side. All values
-// render through escaped interpolation (no v-html); the raw dry-run preview stays
-// available behind a collapsed Details expander.
+// batch_create | import) and is already perm-filtered + size-capped server-side.
+// All values render through escaped interpolation (no v-html); the raw dry-run
+// preview stays available behind a collapsed Details expander.
 //
 // A kind rendered here ALSO needs an entry in CARD_KINDS (@/lib/actionSummary):
 // pendingCardOf returns null for a kind not in that set and the SPA falls back to
@@ -462,6 +462,56 @@ function tableNote(t) {
 			</div>
 			<div v-if="card.extra > 0" class="jv-pcard-more">
 				+{{ card.extra }} more · full list in Details
+			</div>
+		</template>
+
+		<!-- import: run_import (bulk load via Frappe's Data Import). Rows vs records
+		     shown distinctly - a flat file with a mapped child table can fan out into
+		     more records than sheet rows (confirm_card.py::_import_card). Cells are
+		     already secret-masked server-side ("[hidden]"); escaped interpolation
+		     only, never v-html. -->
+		<template v-else-if="card.kind === 'import'">
+			<div class="jv-pcard-head">Import into {{ card.doctype }}</div>
+			<div class="jv-pcard-kv">
+				<span>Import type</span><b>{{ card.import_type }}</b>
+			</div>
+			<div class="jv-pcard-kv">
+				<span>File</span><b>{{ card.file }}</b>
+			</div>
+			<div class="jv-pcard-kv">
+				<span>Rows → records</span><b>{{ card.total_rows }} → {{ card.total_records }}</b>
+			</div>
+			<div v-if="card.submit_after_import" class="jv-pcard-warn">
+				Will submit each record after import
+			</div>
+			<div v-if="(card.sample?.rows || []).length" class="jv-pcard-table">
+				<div class="jv-pcard-table-head">Preview</div>
+				<div class="jv-pcard-table-scroll">
+					<table>
+						<thead>
+							<tr>
+								<th v-for="(c, ci) in card.sample.columns" :key="'ic' + ci">
+									{{ c }}
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr v-for="(r, ri) in card.sample.rows" :key="'ir' + ri">
+								<td v-for="(cell, di) in r.cells" :key="'id' + di">{{ cell }}</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-if="card.sample.extra_cols > 0" class="jv-pcard-more">
+					+{{ card.sample.extra_cols }} more columns
+				</div>
+			</div>
+			<div v-else class="jv-pcard-empty">No preview rows.</div>
+			<ul v-if="(card.advisory || []).length" class="jv-pcard-list">
+				<li v-for="(a, i) in card.advisory" :key="'ia' + i">{{ a }}</li>
+			</ul>
+			<div v-if="(card.columns?.unmapped || []).length" class="jv-pcard-more">
+				Unmapped columns ignored: {{ card.columns.unmapped.join(", ") }}
 			</div>
 		</template>
 

--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -77,6 +77,7 @@ const CARD_KINDS = new Set([
 	"assign",
 	"skill",
 	"wiki",
+	"import",
 ]);
 
 // The structured card for a parked action ({kind, ...}), or null when the server
@@ -126,6 +127,10 @@ const RECEIPT_VERB = {
 	amend_doc: { past: "Amended", present: "amend" },
 	apply_workflow_action: { past: "Applied", present: "apply" },
 	send_email: { past: "Emailed", present: "email" },
+	// The import is only QUEUED at confirm (form_start_import kicks off a background
+	// job) - "Ran"/"Created" would falsely claim it already finished (Slice A ends at
+	// the queue; the completion tell is Slice B).
+	run_import: { past: "Queued", present: "queue" },
 };
 
 function pluralize(word, n) {

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -188,6 +188,7 @@ test("pendingCardOf: every kind build_card emits is whitelisted", () => {
 		"assign",
 		"skill",
 		"wiki",
+		"import",
 	]) {
 		assert.ok(pendingCardOf({ preview: { card: { kind } } }), `${kind} is not in CARD_KINDS`);
 	}

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -578,6 +578,7 @@ _WRITE_TOOLS = frozenset(
 		"amend_doc",
 		"delete_doc",
 		"run_method",
+		"run_import",
 		"apply_workflow_action",
 		"send_email",
 		"add_comment",
@@ -655,6 +656,7 @@ _GATED_WRITES = frozenset(
 		"amend_doc",
 		"delete_doc",
 		"run_method",
+		"run_import",
 		"apply_workflow_action",
 		"send_email",
 		"create_custom_skill",
@@ -670,7 +672,9 @@ _GATED_WRITES = frozenset(
 _WIKI_TOOLS = frozenset({"read_wiki", "update_wiki"})
 # Irreversible/consequential subset - gated even when a user has auto-apply
 # on (Task 4 uses this; define it here so the sets live together).
-_DESTRUCTIVE = frozenset({"delete_doc", "cancel_doc", "amend_doc", "send_email", "apply_workflow_action"})
+_DESTRUCTIVE = frozenset(
+	{"delete_doc", "cancel_doc", "amend_doc", "send_email", "apply_workflow_action", "run_import"}
+)
 # Writes that auto-apply may fast-path without a confirmation click. Strictly
 # the reversible create/update pair, per spec. submit_doc, run_method and every
 # _DESTRUCTIVE tool ALWAYS park even with auto-apply on: run_method's
@@ -865,6 +869,94 @@ def _pending_preview(tool: str, args: dict) -> dict:
 		# than blocking the park, so the human sees why before confirming.
 		described["note"] = f"preview unavailable: {e}"
 		return described
+
+
+def _import_park(args: dict) -> tuple[dict | None, dict | None]:
+	"""Park-time validation for ``run_import`` (analogous to the ``_DRY_RUN_ON_PARK``
+	pre-park block, but for a tool that cannot be sandbox-run). Computes the read-only
+	import preview AS THE CALLER and REFUSES - returns an error envelope, mints no token,
+	shows no card - when the import cannot run:
+
+	  * a non-importable doctype (blocked / ``allow_import`` off),
+	  * blocking warnings (invalid values / an unmapped mandatory field / Update-Upsert
+	    without an ID column) - so the human never confirms a card that imports nothing,
+	  * a caller who cannot create Data Imports (usually not a System Manager) - so a
+	    non-admin never gets a confirm-then-fail.
+
+	On success returns ``(None, preview)`` where ``preview`` carries the whole import
+	payload the card renders from (``preview["import"]``) and a described-intent note
+	(so a build_card miss still shows the guaranteed floor, never a blank card)."""
+	from jarvis.tools._import_preview import build_import_preview
+
+	if not isinstance(args, dict):
+		return _error("InvalidArgumentError", "run_import needs arguments"), None
+	# Kill-switch honored AT PARK: refuse before showing a card, never confirm-then-fail.
+	if frappe.conf.get("jarvis_import_disabled"):
+		return (
+			_error(
+				"FeatureDisabledError",
+				"imports are switched off on this site right now; ask an administrator to re-enable them.",
+			),
+			None,
+		)
+	try:
+		prev = build_import_preview(
+			doctype=args.get("doctype"),
+			file_url=args.get("file_url"),
+			filename=args.get("filename"),
+			import_type=args.get("import_type") or "Insert New Records",
+			mapping=args.get("mapping"),
+		)
+	except (JarvisError, frappe.PermissionError, frappe.ValidationError) as e:
+		return _preview_error(e), None
+
+	if not prev.get("importable"):
+		return _error(
+			"InvalidArgumentError", prev.get("reason") or "this doctype does not allow import"
+		), None
+
+	blocking = (prev.get("warnings") or {}).get("blocking") or []
+	if blocking:
+		reasons = "; ".join(b.get("message", "") for b in blocking if b.get("message"))
+		return (
+			_error(
+				"ImportBlockedError",
+				f"the import can't run yet - {reasons}. Fix the file or adjust the column "
+				"mapping (call preview_import to see the details), then try again.",
+			),
+			None,
+		)
+
+	if not prev.get("can_run"):
+		return (
+			_error(
+				"PermissionDeniedError",
+				"you don't have permission to run imports on this site (it needs the Data "
+				"Import create permission, usually System Manager); ask an administrator.",
+			),
+			None,
+		)
+
+	# Thread the RESOLVED file identity into the stored args so confirm imports the EXACT
+	# file the card showed. A bare ``filename`` re-resolves to "most recent readable match"
+	# at confirm and could drift to a different file uploaded meanwhile. ``args`` is the
+	# same dict api.py stores in the confirmation token, so this canonicalizes both.
+	resolved = prev.get("resolved_file_url")
+	if resolved:
+		args["file_url"] = resolved
+		args.pop("filename", None)
+
+	# Nothing here should surface a validation msgprint on the success path.
+	frappe.clear_messages()
+
+	preview = {
+		"preview": False,
+		"described": True,
+		"summary": _describe_call("run_import", args),
+		"note": f"not a dry run - this imports the file into {prev.get('doctype')} on confirm",
+		"import": prev,
+	}
+	return None, preview
 
 
 # --- Enriched write-error translation (shared by the model/confirm path here
@@ -1270,7 +1362,15 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 		# preview_doc). Every other gated write (submit/cancel/delete/amend get a
 		# sandboxed preview; send_email/run_method/create_custom_skill/update_wiki
 		# a described-intent one) parks via _pending_preview exactly as before.
-		if tool in _DRY_RUN_ON_PARK:
+		if tool == "run_import":
+			# run_import cannot be sandbox-run (staging + a background job), so it has its
+			# own pre-park validation: refuse a blocked / non-importable / non-admin import
+			# BEFORE minting a token, exactly as _DRY_RUN_ON_PARK refuses a doomed create.
+			rejected, preview = _import_park(args)
+			if rejected is not None:
+				frappe.clear_messages()
+				return rejected
+		elif tool in _DRY_RUN_ON_PARK:
 			try:
 				preview = _run_preview(tool, args)
 			except (

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -115,6 +115,8 @@ def build_card(tool: str, args, preview) -> dict | None:
 			return _wiki_card(args)
 		if tool == "run_method":
 			return _method_card(args)
+		if tool == "run_import":
+			return _import_card(args, preview)
 	except Exception:
 		frappe.log_error(title="build_card failed", message=frappe.get_traceback())
 	return None
@@ -648,3 +650,56 @@ def _method_card(args: dict) -> dict:
 		# No meta for a run_method arg bag, so this is the key-name check only.
 		shown[str(k)] = "[hidden]" if is_secret(None, k) else fmt(v)
 	return {"kind": "method", "method": fmt(args.get("method") or ""), "args": shown}
+
+
+_MAX_SAMPLE_COLS = 8  # columns rendered in the import sample table (20 is unusable)
+
+
+def _import_card(args: dict, preview) -> dict | None:
+	"""Rich confirmation card for run_import, rendered from the read-only import preview
+	the park stashed at ``preview["import"]`` (already secret-masked, permission-checked).
+	Shows WHAT is imported - target doctype, record vs row count, the file, the sample
+	rows, the column mapping, advisory warnings - not a function path. Returns None on a
+	malformed preview so build_card's caller shows the described-intent floor (the park
+	always attaches a ``note``), never a blank card."""
+	imp = preview.get("import") if isinstance(preview, dict) else None
+	if not isinstance(imp, dict):
+		return None
+
+	columns = imp.get("columns") or []
+	mapped = [
+		(f"{c.get('header')} -> {c.get('label')}" if c.get("label") else c.get("header"))
+		for c in columns
+		if c.get("mapped")
+	]
+	unmapped = [c.get("header") for c in columns if not c.get("mapped")]
+
+	sample = imp.get("sample") if isinstance(imp.get("sample"), dict) else {}
+	sample_cols = sample.get("columns") or []
+	sample_rows = sample.get("rows") or []
+	col_cap = min(len(sample_cols), _MAX_SAMPLE_COLS)
+	shown_cols = sample_cols[:col_cap]
+	shown_rows = [{"cells": (r.get("cells") or [])[:col_cap]} for r in sample_rows]
+
+	advisory = [
+		w.get("message") for w in (imp.get("warnings") or {}).get("advisory") or [] if w.get("message")
+	]
+
+	return {
+		"kind": "import",
+		"doctype": imp.get("doctype"),
+		"import_type": imp.get("import_type"),
+		"file": (imp.get("file") or {}).get("name"),
+		"total_rows": imp.get("total_rows"),
+		"total_records": imp.get("total_records"),
+		# Only claim "will submit" when the target is actually submittable (else the card
+		# lies: submit_after_import silently no-ops on a non-submittable doctype).
+		"submit_after_import": bool(args.get("submit_after_import")) and bool(imp.get("submittable")),
+		"columns": {"mapped": mapped[:_MAX_ROWS], "unmapped": unmapped[:_MAX_ROWS]},
+		"sample": {
+			"columns": shown_cols,
+			"rows": shown_rows,
+			"extra_cols": max(0, len(sample_cols) - col_cap),
+		},
+		"advisory": advisory[:_MAX_ROWS],
+	}

--- a/jarvis/tests/test_import_preview.py
+++ b/jarvis/tests/test_import_preview.py
@@ -1,0 +1,279 @@
+"""Tests for jarvis.tools._import_preview - the read-only, transient Data Import preview.
+
+The load-bearing assumption (spec Phase-0): a preview computed on an UN-INSERTED
+``Data Import`` doc persists nothing. We prove it here against an ephemeral custom
+parent+child DocType created in ``setUpClass`` (Timesheet is ERPNext-owned and absent
+on jarvis.test, so we cannot use it) - mirroring Frappe's own
+``data_import/test_importer.py::create_doctype_if_not_exists``.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._import_preview import build_import_preview
+from jarvis.tools.preview_import import preview_import
+
+PARENT_DT = "Jarvis Import Test DT"
+CHILD_DT = "Jarvis Import Test Log"
+
+
+def _ensure_doctypes():
+	# DocType creation is DDL and persists across runs; delete+recreate so fixture
+	# changes always take effect.
+	frappe.delete_doc_if_exists("DocType", PARENT_DT)
+	frappe.delete_doc_if_exists("DocType", CHILD_DT)
+	frappe.get_doc(
+		{
+			"doctype": "DocType",
+			"name": CHILD_DT,
+			"module": "Custom",
+			"custom": 1,
+			"istable": 1,
+			"fields": [
+				{"label": "Activity", "fieldname": "activity", "fieldtype": "Data", "reqd": 1},
+				{"label": "Hours", "fieldname": "hours", "fieldtype": "Float"},
+			],
+		}
+	).insert(ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": "DocType",
+			"name": PARENT_DT,
+			"module": "Custom",
+			"custom": 1,
+			"autoname": "field:title",
+			"allow_import": 1,
+			"fields": [
+				{"label": "Title", "fieldname": "title", "fieldtype": "Data", "reqd": 1, "unique": 1},
+				# reqd WITH a default -> Frappe auto-fills it -> the stricter guard must NOT block it.
+				{
+					"label": "Status",
+					"fieldname": "status",
+					"fieldtype": "Select",
+					"options": "Open\nClosed",
+					"reqd": 1,
+					"default": "Open",
+				},
+				{"label": "Assignee", "fieldname": "assignee", "fieldtype": "Link", "options": "User"},
+				{"label": "Secret Code", "fieldname": "secret_code", "fieldtype": "Password"},
+				# reqd Table -> blocks only when NO child column is mapped to it.
+				{"label": "Logs", "fieldname": "logs", "fieldtype": "Table", "options": CHILD_DT, "reqd": 1},
+			],
+			"permissions": [{"role": "System Manager", "read": 1, "write": 1, "create": 1, "import": 1}],
+		}
+	).insert(ignore_permissions=True)
+
+
+def _make_csv(content: str, name: str) -> str:
+	existing = frappe.db.exists("File", {"file_name": name})
+	if existing:
+		frappe.delete_doc("File", existing, ignore_permissions=True, force=True)
+	f = frappe.get_doc(doctype="File", content=content, file_name=name, is_private=1).save(
+		ignore_permissions=True
+	)
+	return f.file_url
+
+
+# A FLAT export: parent columns repeated on every row (the Timesheet-CSV shape).
+_FLAT_CSV = (
+	"Title,Status,Assignee,Activity (Logs),Hours (Logs)\n"
+	"REC-1,Open,Administrator,Did a thing,2\n"
+	"REC-2,Open,Administrator,Did another,3\n"
+)
+_NO_TITLE_CSV = "Status,Assignee\nOpen,Administrator\n"
+_BAD_LINK_CSV = "Title,Assignee\nX-1,nonexistent-user-zzz\n"
+_JUNK_CSV = "Foo,Bar\n1,2\n"
+_SECRET_CSV = "Title,Secret Code\nX-1,hunter2\n"
+# Omits Status (reqd but defaulted) - the guard must NOT block it. Has child cols so
+# the reqd Logs table is satisfied.
+_NO_STATUS_CSV = "Title,Activity (Logs),Hours (Logs)\nX-9,do,1\n"
+# Parent-only: the reqd Logs table has no child columns mapped -> must block.
+_NO_CHILD_CSV = "Title,Status\nX-8,Open\n"
+# An unrecognised header remapped onto a child field via the override.
+_EXTRA_CSV = "Title,Activity (Logs),Extra\nX-7,do,5\n"
+
+
+class TestImportPreview(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_doctypes()
+		cls.flat_url = _make_csv(_FLAT_CSV, "jarvis_import_flat.csv")
+		cls.no_title_url = _make_csv(_NO_TITLE_CSV, "jarvis_import_no_title.csv")
+		cls.bad_link_url = _make_csv(_BAD_LINK_CSV, "jarvis_import_bad_link.csv")
+		cls.junk_url = _make_csv(_JUNK_CSV, "jarvis_import_junk.csv")
+		cls.secret_url = _make_csv(_SECRET_CSV, "jarvis_import_secret.csv")
+		cls.no_status_url = _make_csv(_NO_STATUS_CSV, "jarvis_import_no_status.csv")
+		cls.no_child_url = _make_csv(_NO_CHILD_CSV, "jarvis_import_no_child.csv")
+		cls.extra_url = _make_csv(_EXTRA_CSV, "jarvis_import_extra.csv")
+		# Header-only (0 data rows) exercises Frappe's "no data" throw -> clean error.
+		cls.header_only_url = _make_csv("Title,Status\n", "jarvis_import_header_only.csv")
+
+	# --- core / transient ---------------------------------------------------
+
+	def test_transient_preview_returns_shapes_and_persists_nothing(self):
+		before = frappe.db.count("Data Import")
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		self.assertTrue(out["importable"])
+		self.assertEqual(out["total_rows"], 2)
+		self.assertEqual(len(out["sample"]["rows"]), 2)
+		self.assertEqual(frappe.db.count("Data Import"), before)
+
+	def test_child_column_is_marked(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		by_header = {c["header"]: c for c in out["columns"]}
+		self.assertFalse(by_header["Title"]["child"])
+		self.assertTrue(by_header["Activity (Logs)"]["child"])
+		self.assertEqual(by_header["Activity (Logs)"]["child_doctype"], CHILD_DT)
+
+	def test_flat_file_fans_out_records_equal_rows(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		self.assertEqual(out["total_rows"], 2)
+		self.assertEqual(out["total_records"], 2)
+
+	def test_fan_out_advisory_emitted(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		types = {w["type"] for w in out["warnings"]["advisory"]}
+		self.assertIn("fan_out", types)
+
+	def test_can_run_true_for_admin(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		self.assertTrue(out["can_run"])
+
+	# --- guards -------------------------------------------------------------
+
+	def test_import_type_literal_validated(self):
+		with self.assertRaises(InvalidArgumentError):
+			build_import_preview(doctype=PARENT_DT, file_url=self.flat_url, import_type="Insert")
+
+	def test_missing_mandatory_parent_blocks(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.no_title_url)
+		fields = {w.get("field") for w in out["warnings"]["blocking"] if w["type"] == "missing_mandatory"}
+		self.assertIn("title", fields)
+
+	def test_invalid_link_blocks(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.bad_link_url)
+		types = {w["type"] for w in out["warnings"]["blocking"]}
+		# A bad Link value is a Frappe-derived (non-info) warning -> classified invalid_value.
+		self.assertIn("invalid_value", types)
+
+	def test_near_zero_mapping_blocks(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.junk_url)
+		types = {w["type"] for w in out["warnings"]["blocking"]}
+		self.assertIn("no_mapping", types)
+
+	def test_unmapped_columns_advisory(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.junk_url)
+		types = {w["type"] for w in out["warnings"]["advisory"]}
+		self.assertIn("unmapped_columns", types)
+
+	def test_update_without_id_blocks(self):
+		out = build_import_preview(
+			doctype=PARENT_DT, file_url=self.no_title_url, import_type="Update Existing Records"
+		)
+		types = {w["type"] for w in out["warnings"]["blocking"]}
+		self.assertIn("missing_id", types)
+
+	def test_secret_column_masked(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.secret_url)
+		headers = out["sample"]["columns"]
+		idx = headers.index("Secret Code")
+		self.assertEqual(out["sample"]["rows"][0]["cells"][idx], "[hidden]")
+
+	def test_header_only_file_clean_error(self):
+		with self.assertRaises(InvalidArgumentError):
+			build_import_preview(doctype=PARENT_DT, file_url=self.header_only_url)
+
+	def test_row_bound_refuses(self):
+		frappe.conf.jarvis_import_max_rows = 1
+		try:
+			with self.assertRaises(InvalidArgumentError):
+				build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		finally:
+			del frappe.conf["jarvis_import_max_rows"]
+
+	def test_bad_filename_errors(self):
+		with self.assertRaises(InvalidArgumentError):
+			build_import_preview(doctype=PARENT_DT, filename="no_such_file_zzz.csv")
+
+	# --- stricter-mandatory nuances -----------------------------------------
+
+	def test_defaulted_mandatory_not_blocked(self):
+		# Status is reqd but has a default -> Frappe auto-fills it -> must NOT block.
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.no_status_url)
+		fields = {w.get("field") for w in out["warnings"]["blocking"] if w["type"] == "missing_mandatory"}
+		self.assertNotIn("status", fields)
+
+	def test_mandatory_table_without_child_columns_blocks(self):
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.no_child_url)
+		fields = {w.get("field") for w in out["warnings"]["blocking"] if w["type"] == "missing_mandatory"}
+		self.assertIn("logs", fields)
+
+	# --- mapping override ---------------------------------------------------
+
+	def test_mapping_dont_import_drops_column(self):
+		out = build_import_preview(
+			doctype=PARENT_DT, file_url=self.flat_url, mapping={"Status": "Don't Import"}
+		)
+		by_header = {c["header"]: c for c in out["columns"]}
+		self.assertFalse(by_header["Status"]["mapped"])
+
+	def test_mapping_child_field_by_qualified_key(self):
+		out = build_import_preview(
+			doctype=PARENT_DT, file_url=self.extra_url, mapping={"Extra": "logs.hours"}
+		)
+		by_header = {c["header"]: c for c in out["columns"]}
+		self.assertTrue(by_header["Extra"]["mapped"])
+		self.assertTrue(by_header["Extra"]["child"])
+		self.assertEqual(by_header["Extra"]["field"], "hours")
+
+	def test_mapping_miskey_errors(self):
+		with self.assertRaises(InvalidArgumentError):
+			build_import_preview(
+				doctype=PARENT_DT, file_url=self.flat_url, mapping={"NoSuchHeader": "status"}
+			)
+
+	# --- preview_import tool wrapper ----------------------------------------
+
+	def test_preview_import_tool_delegates_and_is_read_only(self):
+		before = frappe.db.count("Data Import")
+		out = preview_import(PARENT_DT, file_url=self.flat_url)
+		self.assertTrue(out["importable"])
+		self.assertEqual(out["total_rows"], 2)
+		self.assertIn("warnings", out)
+		self.assertEqual(frappe.db.count("Data Import"), before)
+
+	# --- reviewer fixes -----------------------------------------------------
+
+	def test_file_read_is_permission_gated(self):
+		# A raw file_url must NOT disclose a file the caller cannot read (Frappe's importer
+		# resolves a File by url with no permission check; we gate it as the caller).
+		real = frappe.has_permission
+
+		def fake(doctype=None, ptype="read", *a, **k):
+			if doctype == "File" and ptype == "read":
+				return False
+			return real(doctype, ptype, *a, **k)
+
+		with patch("frappe.has_permission", side_effect=fake):
+			with self.assertRaises(InvalidArgumentError):
+				build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+
+	def test_mapping_to_nonexistent_field_errors(self):
+		with self.assertRaises(InvalidArgumentError):
+			build_import_preview(
+				doctype=PARENT_DT, file_url=self.flat_url, mapping={"Title": "no_such_field_zzz"}
+			)
+
+	def test_mapping_wrong_type_errors(self):
+		# A truthy non-dict mapping must fail loud/clean, not 500 on .items().
+		with self.assertRaises(InvalidArgumentError):
+			build_import_preview(doctype=PARENT_DT, file_url=self.flat_url, mapping=["not", "a", "dict"])
+
+	def test_submittable_flag_reflects_meta(self):
+		# PARENT_DT is not submittable, so the card must not later claim "will submit".
+		out = build_import_preview(doctype=PARENT_DT, file_url=self.flat_url)
+		self.assertFalse(out["submittable"])

--- a/jarvis/tests/test_run_import.py
+++ b/jarvis/tests/test_run_import.py
@@ -1,0 +1,251 @@
+"""Tests for the gated run_import path: the api.py park-time refusal (_import_park) and
+the confirm-time tool (jarvis.tools.run_import).
+
+Reuses the ephemeral parent+child fixture from test_import_preview.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.api import (
+	_AUTO_APPLYABLE,
+	_DESTRUCTIVE,
+	_DRY_RUN_ON_PARK,
+	_GATED_WRITES,
+	_PREVIEWABLE,
+	_WRITE_TOOLS,
+	_import_park,
+)
+from jarvis.chat import confirm_card
+from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError
+from jarvis.tests.test_import_preview import (
+	_BAD_LINK_CSV,
+	_FLAT_CSV,
+	_NO_TITLE_CSV,
+	CHILD_DT,
+	PARENT_DT,
+	_ensure_doctypes,
+	_make_csv,
+)
+from jarvis.tools._import_preview import build_import_preview
+from jarvis.tools.run_import import run_import
+
+
+class TestRunImportGating(FrappeTestCase):
+	_files = ("jarvis_run_flat.csv", "jarvis_run_bad_link.csv", "jarvis_run_no_title.csv")
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_doctypes()
+		cls.flat_url = _make_csv(_FLAT_CSV, "jarvis_run_flat.csv")
+		cls.bad_link_url = _make_csv(_BAD_LINK_CSV, "jarvis_run_bad_link.csv")
+		cls.no_title_url = _make_csv(_NO_TITLE_CSV, "jarvis_run_no_title.csv")
+		# run_import commits mid-test (commit-before-enqueue), which collapses the
+		# per-test savepoint - so commit the fixtures now to keep them durable.
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		for name in cls._files:
+			existing = frappe.db.exists("File", {"file_name": name})
+			if existing:
+				frappe.delete_doc("File", existing, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _cleanup_records(self, di_name):
+		# run_import commits (Data Import + the synchronous test-mode import), so the
+		# framework rollback can't undo it - delete explicitly. Reap the Data Import with
+		# a RAW delete: delete_doc would cascade to remove its attached import_file (the
+		# shared fixture File), breaking later tests.
+		for title in ("REC-1", "REC-2"):
+			if frappe.db.exists(PARENT_DT, title):
+				frappe.delete_doc(PARENT_DT, title, force=True, ignore_permissions=True)
+		if di_name:
+			frappe.db.delete("Data Import Log", {"data_import": di_name})
+			frappe.db.delete("Data Import", {"name": di_name})
+		frappe.db.commit()
+
+	# --- gate membership ----------------------------------------------------
+
+	def test_gate_membership(self):
+		self.assertIn("run_import", _WRITE_TOOLS)
+		self.assertIn("run_import", _GATED_WRITES)
+		self.assertIn("run_import", _DESTRUCTIVE)
+		# NEVER auto-applies; not sandbox-dry-run at park; not the sandbox-preview set.
+		self.assertNotIn("run_import", _AUTO_APPLYABLE)
+		self.assertNotIn("run_import", _DRY_RUN_ON_PARK)
+		self.assertNotIn("run_import", _PREVIEWABLE)
+
+	# --- park-time refusal (_import_park) -----------------------------------
+
+	def test_park_clean_returns_preview_no_reject(self):
+		rejected, preview = _import_park({"doctype": PARENT_DT, "file_url": self.flat_url})
+		self.assertIsNone(rejected)
+		self.assertIn("import", preview)
+		self.assertEqual(preview["import"]["doctype"], PARENT_DT)
+		self.assertTrue(preview.get("note"))
+
+	def test_park_blocking_refuses(self):
+		rejected, preview = _import_park({"doctype": PARENT_DT, "file_url": self.bad_link_url})
+		self.assertIsNone(preview)
+		self.assertFalse(rejected["ok"])
+		self.assertEqual(rejected["error"]["code"], "ImportBlockedError")
+
+	def test_park_missing_mandatory_refuses(self):
+		rejected, preview = _import_park({"doctype": PARENT_DT, "file_url": self.no_title_url})
+		self.assertIsNone(preview)
+		self.assertFalse(rejected["ok"])
+
+	def test_park_refuses_caller_who_cannot_create_data_import(self):
+		# A caller without Data Import create permission (the usual non-System-Manager)
+		# is refused AT PARK - no card, no confirm-then-fail. Simulate by denying only
+		# the Data Import create check; the import-perm and File-read checks still pass.
+		real = frappe.has_permission
+
+		def fake(doctype=None, ptype="read", *a, **k):
+			if doctype == "Data Import" and ptype == "create":
+				return False
+			return real(doctype, ptype, *a, **k)
+
+		with patch("frappe.has_permission", side_effect=fake):
+			rejected, preview = _import_park({"doctype": PARENT_DT, "file_url": self.flat_url})
+		self.assertIsNone(preview)
+		self.assertFalse(rejected["ok"])
+		self.assertEqual(rejected["error"]["code"], "PermissionDeniedError")
+
+	def test_park_honors_kill_switch(self):
+		frappe.conf.jarvis_import_disabled = 1
+		try:
+			rejected, preview = _import_park({"doctype": PARENT_DT, "file_url": self.flat_url})
+		finally:
+			del frappe.conf["jarvis_import_disabled"]
+		self.assertIsNone(preview)
+		self.assertFalse(rejected["ok"])
+		self.assertEqual(rejected["error"]["code"], "FeatureDisabledError")
+
+	def test_park_canonicalizes_filename_to_file_url(self):
+		# A bare filename is resolved to a concrete file_url ONCE at park and threaded to
+		# confirm, so confirm can't re-resolve to a different "most recent" file (drift).
+		args = {"doctype": PARENT_DT, "filename": "jarvis_run_flat.csv"}
+		rejected, preview = _import_park(args)
+		self.assertIsNone(rejected)
+		self.assertTrue(args.get("file_url"))
+		self.assertNotIn("filename", args)
+
+	# --- confirm-time tool --------------------------------------------------
+
+	def test_run_import_stages_and_imports(self):
+		# In test mode form_start_import runs synchronously, so the import actually lands.
+		out = None
+		try:
+			out = run_import(doctype=PARENT_DT, file_url=self.flat_url)
+			self.assertEqual(out["status"], "queued")
+			self.assertEqual(out["total_records"], 2)
+			di = frappe.get_doc("Data Import", out["data_import"])
+			self.assertEqual(di.reference_doctype, PARENT_DT)
+			# The two parent records were created by the synchronous import.
+			self.assertTrue(frappe.db.exists(PARENT_DT, "REC-1"))
+			self.assertTrue(frappe.db.exists(PARENT_DT, "REC-2"))
+		finally:
+			self._cleanup_records(out["data_import"] if out else None)
+
+	def test_run_import_kill_switch(self):
+		frappe.conf.jarvis_import_disabled = 1
+		try:
+			with self.assertRaises(FeatureDisabledError):
+				run_import(doctype=PARENT_DT, file_url=self.flat_url)
+		finally:
+			del frappe.conf["jarvis_import_disabled"]
+
+	def test_run_import_belt_refuses_blocking(self):
+		# Even if the park were bypassed, the confirm-time belt refuses a blocking file
+		# and stages nothing.
+		before = frappe.db.count("Data Import")
+		with self.assertRaises(InvalidArgumentError):
+			run_import(doctype=PARENT_DT, file_url=self.bad_link_url)
+		self.assertEqual(frappe.db.count("Data Import"), before)
+
+	def test_run_import_scheduler_paused_refuses_and_stages_nothing(self):
+		# The harness's frappe.in_test short-circuits run_now, so force the prod path
+		# (run_now False) with an inactive scheduler and assert a clean refusal - a paused
+		# scheduler must NOT stage an import that would sit Pending forever.
+		before = frappe.db.count("Data Import")
+		with (
+			patch.object(frappe, "in_test", False),
+			patch.dict(frappe.conf, {"developer_mode": 0}),
+			patch("jarvis.tools.run_import.is_scheduler_inactive", return_value=True),
+		):
+			with self.assertRaises(FeatureDisabledError):
+				run_import(doctype=PARENT_DT, file_url=self.flat_url)
+		self.assertEqual(frappe.db.count("Data Import"), before)
+
+	def test_run_import_starts_last_after_commit(self):
+		# start_import must be called; stage the DI, then start it. Mock start_import so
+		# the real import doesn't run - we only assert ordering/receipt here.
+		out = None
+		with patch(
+			"frappe.core.doctype.data_import.data_import.DataImport.start_import",
+			return_value=True,
+		) as m:
+			try:
+				out = run_import(doctype=PARENT_DT, file_url=self.flat_url)
+				m.assert_called_once()
+				self.assertTrue(frappe.db.exists("Data Import", out["data_import"]))
+			finally:
+				self._cleanup_records(out["data_import"] if out else None)
+
+
+class TestImportCard(FrappeTestCase):
+	_files = ("jarvis_card_flat.csv", "jarvis_card_secret.csv")
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_doctypes()
+		cls.flat_url = _make_csv(_FLAT_CSV, "jarvis_card_flat.csv")
+		cls.secret_url = _make_csv("Title,Secret Code\nX-1,hunter2\n", "jarvis_card_secret.csv")
+
+	@classmethod
+	def tearDownClass(cls):
+		for name in cls._files:
+			existing = frappe.db.exists("File", {"file_name": name})
+			if existing:
+				frappe.delete_doc("File", existing, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _card(self, url, **kwargs):
+		# The card renders from the preview payload; build it directly (park gating is a
+		# separate concern already covered by TestRunImportGating).
+		prev = build_import_preview(doctype=PARENT_DT, file_url=url, **kwargs)
+		return confirm_card.build_card(
+			"run_import", {"doctype": PARENT_DT, "file_url": url, **kwargs}, {"import": prev, "note": "x"}
+		)
+
+	def test_card_kind_and_shape(self):
+		card = self._card(self.flat_url)
+		self.assertEqual(card["kind"], "import")
+		self.assertEqual(card["doctype"], PARENT_DT)
+		self.assertEqual(card["total_rows"], 2)
+		self.assertEqual(card["total_records"], 2)
+		self.assertIn("Title", card["sample"]["columns"])
+		self.assertEqual(len(card["sample"]["rows"]), 2)
+
+	def test_card_masks_secret(self):
+		card = self._card(self.secret_url)
+		cols = card["sample"]["columns"]
+		idx = cols.index("Secret Code")
+		self.assertEqual(card["sample"]["rows"][0]["cells"][idx], "[hidden]")
+
+	def test_card_advisory_carries_fan_out(self):
+		card = self._card(self.flat_url)
+		self.assertTrue(any("separate" in a for a in card["advisory"]))
+
+	def test_card_none_on_malformed_preview(self):
+		# No import payload -> None, so build_card's caller shows the described-intent
+		# floor (the park always attaches a note), never a blank card.
+		self.assertIsNone(confirm_card.build_card("run_import", {"doctype": PARENT_DT}, {"note": "x"}))

--- a/jarvis/tools/_import_preview.py
+++ b/jarvis/tools/_import_preview.py
@@ -1,0 +1,448 @@
+"""Read-only preview for a Frappe Data Import, computed on a TRANSIENT (un-inserted)
+``Data Import`` document so nothing is persisted.
+
+Shared by the ``preview_import`` tool and the ``run_import`` confirmation card, so the
+card renders exactly what the tool showed. This module owns the whole safety core:
+
+  - the FILE read is gated as the CALLER (Frappe's importer resolves a File by URL with
+    no permission check - a private-file leak); we reuse ``read_file._resolve_file``,
+    which enforces ``File`` ``has_permission("read")`` per candidate.
+  - the import gate is REUSED, not re-implemented: ``DataImport.validate_doctype()`` runs
+    the real BLOCKED_DOCTYPES / ``allow_import`` / ``has_permission(..., "import")`` checks
+    on the transient doc (no hand-rolled copy that could drift from Frappe).
+  - file size is bounded before the parse; the row count is bounded from the parse result.
+  - the transient preview calls the ``ImportFile``-level ``get_data_for_import_preview()``
+    (NOT the ``Importer`` wrapper that queries ``Data Import Log`` by ``name=None``).
+
+It never inserts a ``Data Import`` row. It is read-only.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+from jarvis.chat._record_summary import fmt, is_secret
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools.read_file import _resolve_file
+
+_TABLE_FIELDTYPES = ("Table", "Table MultiSelect")
+
+# Exact import-type literals Frappe's importer branches on. Anything else silently
+# becomes upsert semantics in Frappe (importer.process_doc), so we validate up front.
+IMPORT_TYPES = (
+	"Insert New Records",
+	"Update Existing Records",
+	"Insert or Update Records",
+)
+
+# Frappe's own sentinel for a column the user chose not to import.
+DONT_IMPORT = "Don't Import"
+
+_DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_DEFAULT_MAX_ROWS = 10_000
+
+
+def _max_bytes() -> int:
+	return int(frappe.conf.get("jarvis_import_max_bytes") or _DEFAULT_MAX_BYTES)
+
+
+def _max_rows() -> int:
+	return int(frappe.conf.get("jarvis_import_max_rows") or _DEFAULT_MAX_ROWS)
+
+
+def build_import_preview(
+	*,
+	doctype: str,
+	file_url: str | None = None,
+	filename: str | None = None,
+	import_type: str = "Insert New Records",
+	mapping: dict | None = None,
+) -> dict:
+	"""Compute a read-only import preview on a transient Data Import doc.
+
+	Returns ``{doctype, import_type, file, total_rows, total_records, columns, sample,
+	warnings, importable, resolved_file_url, note}``. Raises ``InvalidArgumentError`` for
+	a bad doctype/import_type/file or an oversized file, and ``frappe.PermissionError``
+	for a caller who lacks import permission on the target doctype.
+
+	NOTHING is persisted: no ``Data Import`` row is created.
+	"""
+	if not doctype or not isinstance(doctype, str):
+		raise InvalidArgumentError("doctype is required")
+	if import_type not in IMPORT_TYPES:
+		raise InvalidArgumentError(f"import_type must be one of {IMPORT_TYPES}; got {import_type!r}")
+	if mapping is not None and not isinstance(mapping, dict):
+		raise InvalidArgumentError("mapping must be an object of {column: field} entries")
+
+	# 1. Resolve + permission-gate the File AS THE CALLER. _resolve_file's file_url branch
+	#    does NOT permission-check (only its filename branch does, per-candidate), so gate
+	#    the read here - mirrors read_file.py:60 - else a raw file_url discloses a private
+	#    file the caller can't read. Generic message: never confirm a private file's
+	#    existence to a caller who cannot see it.
+	file_doc = _resolve_file(file_url, filename)
+	if not frappe.has_permission("File", "read", doc=file_doc.name):
+		raise InvalidArgumentError("no matching file found")
+	resolved_url = file_doc.file_url
+
+	# 2. Byte bound BEFORE any parse (cheap metadata read; the importer would otherwise
+	#    fully parse even a huge file just to show 10 rows). Fall back to the content
+	#    length when file_size is missing so an oversized file is still bounded pre-parse.
+	size = file_doc.file_size or len(file_doc.get_content() or b"")
+	if size and size > _max_bytes():
+		raise InvalidArgumentError(
+			f"file is {size} bytes; the import limit is {_max_bytes()} bytes - "
+			"use the Desk importer for larger files"
+		)
+
+	# 3. Transient (un-inserted) Data Import doc.
+	doc = frappe.new_doc("Data Import")
+	doc.reference_doctype = doctype
+	doc.import_type = import_type
+	doc.import_file = resolved_url
+
+	# 4. Reuse Frappe's real gate. blocked-doctype / allow_import -> ValidationError
+	#    (a doctype-level fact -> importable:false); missing import perm -> PermissionError
+	#    (a caller fault -> propagate).
+	try:
+		doc.validate_doctype()
+	except frappe.PermissionError:
+		raise
+	except frappe.ValidationError as e:
+		return {
+			"doctype": doctype,
+			"import_type": import_type,
+			"file": {"name": file_doc.file_name, "url": resolved_url},
+			"importable": False,
+			"reason": _clean(e),
+			"resolved_file_url": resolved_url,
+		}
+
+	# 5. Apply a column mapping override (resolve header->index against the parsed columns).
+	resolved_template_options = None
+	index_map: dict = {}
+	if mapping:
+		index_map = _resolve_mapping(mapping, doc)
+		doc.template_options = json.dumps({"column_to_field_map": index_map})
+		resolved_template_options = doc.template_options
+
+	# 6. Parse + preview via the ImportFile-level call (transient-safe). Any parse throw
+	#    (empty / non-UTF8 / non-table / malformed) becomes a clean tool error.
+	doc.set_delimiters_flag()
+	try:
+		importer = doc.get_importer()
+		import_file = importer.import_file
+		preview = import_file.get_data_for_import_preview()
+	except InvalidArgumentError:
+		raise
+	except Exception as e:
+		raise InvalidArgumentError(_clean(e)) from e
+
+	# v16 only sets total_number_of_rows when the file exceeds the 10-row preview cap; for a
+	# small file it is absent and the (untruncated) data holds every row. v17 always sets it.
+	total_rows = preview.total_number_of_rows or len(preview.data or [])
+	if total_rows > _max_rows():
+		raise InvalidArgumentError(
+			f"file has {total_rows} rows; the import limit is {_max_rows()} rows - "
+			"use the Desk importer for larger files"
+		)
+
+	columns = _columns_view(preview, doctype)
+
+	# Reject a mapping whose TARGET field did not resolve: Frappe would silently drop a
+	# mis-typed target to an `info` warning and import the column as if unmapped.
+	for idx_str, target in index_map.items():
+		if target == DONT_IMPORT:
+			continue
+		col = next((c for c in columns if c["index"] == int(idx_str)), None)
+		if col is None or not col["mapped"]:
+			raise InvalidArgumentError(f"mapping target {target!r} did not match any field on {doctype}")
+
+	sample = _sample_view(preview, columns, doctype)
+	total_records = _count_records(importer)
+	warnings = _classify_warnings(preview, columns, doctype, import_type, total_rows, total_records)
+
+	return {
+		"doctype": doctype,
+		"import_type": import_type,
+		"file": {"name": file_doc.file_name, "url": resolved_url},
+		"total_rows": total_rows,
+		"total_records": total_records,
+		"submittable": bool(getattr(frappe.get_meta(doctype), "is_submittable", 0)),
+		"columns": columns,
+		"sample": sample,
+		"warnings": warnings,
+		"importable": True,
+		"can_run": frappe.has_permission("Data Import", "create"),
+		"resolved_file_url": resolved_url,
+		"template_options": resolved_template_options,
+		"note": ("read-only preview - nothing was created. Use run_import to import."),
+	}
+
+
+def _classify_warnings(preview, columns, doctype, import_type, total_rows, total_records) -> dict:
+	"""Split warnings into ``blocking`` (import would create nothing / fail every row) and
+	``advisory`` (allowed, but the user should know). Blocking = Frappe's non-``info``
+	warnings (invalid Link/Select values, bad dates, malformed rows) PLUS the app-level
+	guards (near-zero mapping, stricter parent-scoped mandatory, Update/Upsert without an
+	ID column).
+	"""
+	blocking: list[dict] = []
+
+	# Frappe-derived blocking warnings, classified version-agnostically: a warning that is
+	# not "info" blocks the import. This is EXACTLY Frappe v16's own import_data rule
+	# (importer.py: `[w for w in warnings if w.get("type") != "info"]`); on v17 it is
+	# slightly more conservative than value_mapping.get_blocking_warnings, which is correct
+	# for a pre-confirmation refusal (an invalid value should block until fixed). Crucially
+	# it avoids the v17-ONLY `frappe...data_import.value_mapping` import, which does not
+	# exist on v16 (CI/prod) and would crash the whole tool layer at registry load.
+	for w in preview.warnings or []:
+		if isinstance(w, dict) and w.get("type") != "info":
+			blocking.append(
+				{
+					"type": "invalid_value",
+					"column": _col_header(columns, w.get("col")),
+					"message": _clean_msg(w.get("message")),
+				}
+			)
+
+	mapped = [c for c in columns if c["mapped"]]
+
+	# Guard: near-zero mapping - the file doesn't look like this doctype.
+	if not mapped:
+		blocking.append(
+			{
+				"type": "no_mapping",
+				"message": (
+					f"No columns in the file matched any field on {doctype} - "
+					f"this file does not look like a {doctype} import."
+				),
+			}
+		)
+
+	# Guard: stricter parent-scoped mandatory (empirical default check).
+	blocking += _mandatory_blocks(doctype, columns)
+
+	# Guard: Update / Upsert needs an ID column, else it silently bulk-inserts duplicates.
+	if import_type in ("Update Existing Records", "Insert or Update Records"):
+		if not _has_id_column(columns, doctype):
+			blocking.append(
+				{
+					"type": "missing_id",
+					"message": (
+						f"{import_type} needs a column mapped to the record ID (name), "
+						"otherwise every row would be inserted as a new record."
+					),
+				}
+			)
+
+	# Advisory: unrecognised columns are ignored (never blocks - a sparse file is legit).
+	unmapped = [c["header"] for c in columns if not c["mapped"]]
+	advisory: list[dict] = []
+	if unmapped:
+		advisory.append(
+			{
+				"type": "unmapped_columns",
+				"columns": unmapped,
+				"message": (
+					f"{len(unmapped)} of {len(columns)} columns were not recognised "
+					f"and will be ignored: {', '.join(unmapped)}"
+				),
+			}
+		)
+
+	# Advisory: a flat parent-repeated file FANS OUT into one record per row.
+	if any(c["mapped"] and c["child"] for c in columns) and total_records == total_rows and total_rows > 1:
+		advisory.append(
+			{
+				"type": "fan_out",
+				"message": (
+					f"This creates {total_records} separate {doctype} records, one per row. "
+					"If you meant one record with many child rows, the file must be grouped "
+					"first (blank the parent columns on continuation rows)."
+				),
+			}
+		)
+
+	return {"blocking": blocking, "advisory": advisory}
+
+
+def _mandatory_blocks(doctype: str, columns: list[dict]) -> list[dict]:
+	"""Block if a mandatory PARENT field Frappe cannot auto-fill is left unmapped, or a
+	mandatory Table field has no mapped child columns. Child-ROW mandatory fields are NOT
+	pre-checked (Frappe enforces them per-payload at insert; pre-checking false-positives
+	on child defaults/fetch-from).
+
+	"Auto-fillable" is measured EMPIRICALLY: a fresh ``new_doc`` already carries a value
+	(default / naming series / hook), or the field is read-only / fetched from a link.
+	"""
+	blocks: list[dict] = []
+	meta = frappe.get_meta(doctype)
+	fresh = frappe.new_doc(doctype)
+	mapped_parent = {c["field"] for c in columns if c["mapped"] and not c["child"]}
+	mapped_child_doctypes = {c["child_doctype"] for c in columns if c["mapped"] and c["child"]}
+
+	for df in meta.fields:
+		if not df.reqd:
+			continue
+		if df.fieldtype in _TABLE_FIELDTYPES:
+			# A mandatory child table with no mapped child columns -> every parent insert
+			# fails on the empty mandatory table.
+			if df.options not in mapped_child_doctypes:
+				blocks.append(
+					{
+						"type": "missing_mandatory",
+						"field": df.fieldname,
+						"message": f"Required table '{df.label}' has no columns mapped to it.",
+					}
+				)
+			continue
+		if df.fieldname in mapped_parent:
+			continue
+		if df.read_only or df.fetch_from or df.default:
+			continue
+		if fresh.get(df.fieldname):
+			continue  # auto-filled by a default / naming series / hook
+		blocks.append(
+			{
+				"type": "missing_mandatory",
+				"field": df.fieldname,
+				"message": f"Required field '{df.label}' isn't mapped to any column.",
+			}
+		)
+	return blocks
+
+
+def _has_id_column(columns: list[dict], doctype: str) -> bool:
+	"""True if a mapped column feeds the record ID (the ``name`` field or the autoname
+	``field:`` target)."""
+	id_fields = {"name"}
+	autoname = frappe.get_meta(doctype).autoname or ""
+	if autoname.startswith("field:"):
+		id_fields.add(autoname.split(":", 1)[1])
+	return any(c["mapped"] and c["field"] in id_fields for c in columns)
+
+
+def _col_header(columns: list[dict], col_number) -> str | None:
+	# Frappe warnings carry a 1-based ``col``; our columns view is 0-based.
+	try:
+		idx = int(col_number) - 1
+	except (TypeError, ValueError):
+		return None
+	for c in columns:
+		if c["index"] == idx:
+			return c["header"]
+	return None
+
+
+def _clean_msg(msg) -> str:
+	from frappe.utils import strip_html_tags
+
+	try:
+		return strip_html_tags(str(msg)) if msg else ""
+	except Exception:
+		return str(msg) if msg else ""
+
+
+def _resolve_mapping(mapping: dict, doc) -> dict:
+	"""Turn a user ``{header|index: fieldname|"Don't Import"}`` map into Frappe's
+	``column_to_field_map`` (0-based stringified column index -> header key).
+
+	A key that matches no column raises rather than being silently ignored (Frappe would
+	drop a mis-keyed override to a harmless ``info`` warning).
+	"""
+	# Parse once without the override to learn the file's header order.
+	doc.set_delimiters_flag()
+	base_importer = doc.get_importer()
+	headers = [c.header_title for c in base_importer.import_file.header.columns]
+	by_header = {h: i for i, h in enumerate(headers)}
+
+	index_map: dict[str, str] = {}
+	for key, value in mapping.items():
+		if isinstance(key, int) or (isinstance(key, str) and key.isdigit()):
+			idx = int(key)
+			if idx < 0 or idx >= len(headers):
+				raise InvalidArgumentError(
+					f"mapping column index {idx} is out of range (file has {len(headers)} columns)"
+				)
+		elif key in by_header:
+			idx = by_header[key]
+		else:
+			raise InvalidArgumentError(f"mapping key {key!r} matches no column header in the file")
+		index_map[str(idx)] = value
+	return index_map
+
+
+def _columns_view(preview, reference_doctype: str) -> list[dict]:
+	"""One row per real file column (the synthetic 'Sr. No' at index 0 is dropped).
+
+	A child-table column is identified by ``df.parent != reference_doctype`` (its df.parent
+	is the CHILD doctype). ``mapped`` is False for a column Frappe could not match.
+	"""
+	out = []
+	# preview.columns[0] is the synthetic Sr. No; real columns follow, 0-based from here.
+	for idx, col in enumerate(preview.columns[1:]):
+		df = col.get("df")
+		mapped = bool(df) and not col.get("skip_import")
+		child = bool(df) and df.get("parent") and df.get("parent") != reference_doctype
+		out.append(
+			{
+				"index": idx,
+				"header": col.get("header_title"),
+				"field": df.get("fieldname") if df else None,
+				"label": df.get("label") if df else None,
+				"fieldtype": df.get("fieldtype") if df else None,
+				"reqd": bool(df.get("reqd")) if df else False,
+				"mapped": mapped,
+				"child": bool(child),
+				"child_doctype": df.get("parent") if child else None,
+			}
+		)
+	return out
+
+
+def _sample_view(preview, columns: list[dict], reference_doctype: str) -> dict:
+	"""Up to 10 sample rows, with secret-mapped columns masked to ``[hidden]``.
+
+	Cell j aligns with ``columns[j]`` (both drop the synthetic Sr. No column).
+	"""
+	# Which columns map to a secret field -> mask those cells.
+	meta = frappe.get_meta(reference_doctype)
+	secret_idx = set()
+	for c in columns:
+		field = c.get("field")
+		if not field:
+			continue
+		# For a parent field, check against the parent meta; a secret-NAMED field is
+		# caught regardless of meta.
+		child_meta = frappe.get_meta(c["child_doctype"]) if c.get("child") else meta
+		if is_secret(child_meta, field):
+			secret_idx.add(c["index"])
+
+	rows = []
+	for data_row in preview.data:
+		cells = data_row[1:]  # drop the leading row_number
+		masked = ["[hidden]" if i in secret_idx else fmt(v) for i, v in enumerate(cells)]
+		rows.append({"cells": masked})
+	return {"columns": [c["header"] for c in columns], "rows": rows}
+
+
+def _count_records(importer) -> int:
+	"""Number of parent DOCUMENTS the file produces (= payload_count), which differs
+	from the sheet-row count exactly when child rows are grouped under a parent.
+	"""
+	try:
+		return len(importer.import_file.get_payloads_for_import())
+	except Exception:
+		return 0
+
+
+def _clean(e: Exception) -> str:
+	from frappe.utils import strip_html_tags
+
+	msg = str(e) or type(e).__name__
+	try:
+		return strip_html_tags(msg)
+	except Exception:
+		return msg

--- a/jarvis/tools/preview_import.py
+++ b/jarvis/tools/preview_import.py
@@ -1,0 +1,41 @@
+"""Read-only preview of a would-be Data Import.
+
+Given an attached file and a target DocType, returns the column-to-field mapping, up to
+10 sample rows, validation warnings (blocking vs advisory), the parent-record count, and
+whether the caller can actually run the import - WITHOUT creating anything. The whole
+safety core (caller-scoped File read, reused Frappe import gate, secret masking, bounds,
+blocking classification) lives in ``_import_preview.build_import_preview``.
+
+Use this BEFORE ``run_import`` to show the customer what a raw file load would produce,
+and to catch a mismatched file / blocking values early. For data that needs any
+transformation before it becomes records, use ``create_doc(docs=[...])`` instead - import
+is only for loading a file as-is.
+"""
+
+from jarvis.tools._import_preview import build_import_preview
+
+
+def preview_import(
+	doctype: str,
+	file_url: str | None = None,
+	filename: str | None = None,
+	import_type: str = "Insert New Records",
+	mapping: dict | None = None,
+) -> dict:
+	"""Preview a Data Import without creating anything.
+
+	Identify the file by ``file_url`` (exact, preferred) or ``filename`` (most recent
+	readable match). ``import_type`` is one of "Insert New Records" /
+	"Update Existing Records" / "Insert or Update Records". ``mapping`` optionally forces
+	a column onto a field: ``{header_or_index: fieldname | "table.field" | "Don't Import"}``.
+
+	Requires the caller's read permission on the file and import permission on the target
+	DocType. Runs as the calling user.
+	"""
+	return build_import_preview(
+		doctype=doctype,
+		file_url=file_url,
+		filename=filename,
+		import_type=import_type,
+		mapping=mapping,
+	)

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -45,6 +45,12 @@ _TOOL_NAMES: tuple[str, ...] = (
 	# Batch, atomic create for a doc's missing dependencies (one gated card).
 	"create_docs",
 	"preview_doc",
+	# CSV / file import: preview_import (read-only) shows what a raw file load would
+	# produce; run_import (gated) stages a Frappe Data Import and starts it. For data
+	# that needs any processing first, create_doc(docs=[...]) stays the path - import
+	# is only for loading a file AS-IS.
+	"preview_import",
+	"run_import",
 	"submit_doc",
 	"cancel_doc",
 	"delete_doc",

--- a/jarvis/tools/run_import.py
+++ b/jarvis/tools/run_import.py
@@ -1,0 +1,104 @@
+"""Run a Data Import: load a file straight into a DocType, as-is.
+
+GATED + DESTRUCTIVE: an import creates (or overwrites) many records and is NOT reversible,
+so this never auto-applies - it always parks for a human confirmation card built from the
+same preview ``preview_import`` shows. The park refuses up front if the file has blocking
+problems or the caller can't run imports, so a confirmed card always corresponds to an
+import that can actually proceed.
+
+On confirm it stages a ``Data Import`` (as the calling user - Frappe's own gate requires
+Data Import create permission, usually System Manager) and starts it; the import runs in
+the background. Only for loading a file AS-IS - for data that needs any transformation
+before it becomes records, use ``create_doc(docs=[...])`` instead.
+"""
+
+import json
+
+import frappe
+from frappe.utils.scheduler import is_scheduler_inactive
+
+from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError
+from jarvis.tools._import_preview import build_import_preview
+
+
+def run_import(
+	doctype: str,
+	file_url: str | None = None,
+	filename: str | None = None,
+	import_type: str = "Insert New Records",
+	mapping: dict | None = None,
+	submit_after_import: bool = False,
+) -> dict:
+	"""Stage and start a Data Import. Runs only after the human confirms the card.
+
+	Identify the file by ``file_url`` (exact, preferred) or ``filename``. ``import_type``
+	is one of "Insert New Records" / "Update Existing Records" / "Insert or Update
+	Records". ``mapping`` optionally forces columns onto fields. ``submit_after_import``
+	submits each created record (submittable doctypes only; default: leave as Draft).
+	"""
+	if frappe.conf.get("jarvis_import_disabled"):
+		raise FeatureDisabledError(
+			"imports are switched off on this site right now; ask an administrator to re-enable them."
+		)
+
+	# Belt: recompute the preview AS THE CALLER and re-check blocking. The park already
+	# refused a blocking import, but the file (or a referenced record) could have changed
+	# since park - never start an import that is doomed to import nothing.
+	prev = build_import_preview(
+		doctype=doctype,
+		file_url=file_url,
+		filename=filename,
+		import_type=import_type,
+		mapping=mapping,
+	)
+	if not prev.get("importable"):
+		raise InvalidArgumentError(prev.get("reason") or "this doctype does not allow import")
+	blocking = (prev.get("warnings") or {}).get("blocking") or []
+	if blocking:
+		reasons = "; ".join(b.get("message", "") for b in blocking if b.get("message"))
+		raise InvalidArgumentError(f"the import can't run - {reasons}")
+
+	# Refuse cleanly BEFORE creating anything if the scheduler is paused, so a staged
+	# import never sits Pending with nothing to run it. Test / developer_mode run inline.
+	run_now = frappe.in_test or frappe.conf.developer_mode
+	if not run_now and is_scheduler_inactive():
+		# FeatureDisabledError (not InvalidArgumentError): a paused scheduler is an ops
+		# condition, so the model must NOT be nudged to "check the fields and retry" - the
+		# fix is an administrator enabling the scheduler, which its hint conveys.
+		raise FeatureDisabledError(
+			"the import can't start because the site scheduler is paused; ask an "
+			"administrator to enable it, then try again."
+		)
+
+	# Stage the Data Import AS THE CALLER (no ignore_permissions): validate() enforces the
+	# import gate AND Data Import create = System Manager, which is the elevation guard.
+	di = frappe.new_doc("Data Import")
+	di.reference_doctype = doctype
+	di.import_type = import_type
+	di.import_file = prev["resolved_file_url"]
+	# submit_after_import only means something on a submittable target (else it silently
+	# no-ops); gate it so the DI flag matches what the card told the user.
+	di.submit_after_import = 1 if (submit_after_import and prev.get("submittable")) else 0
+	di.mute_emails = 1
+	if prev.get("template_options"):
+		di.template_options = prev["template_options"]
+	di.insert()
+
+	# Commit BEFORE starting the import: start_import enqueues a background job that reloads
+	# the Data Import by name; an uncommitted row would race the worker to a "does not
+	# exist". _dispatch_and_wrap guards the (now-gone) savepoint, so committing here is safe.
+	frappe.db.commit()
+
+	started = di.start_import()  # enqueues (prod) or runs inline (test / developer_mode)
+
+	records = prev.get("total_records")
+	return {
+		"data_import": di.name,
+		"status": "queued" if started else "already_running",
+		"total_records": records,
+		"total_rows": prev.get("total_rows"),
+		"note": (
+			f"Import of {records} {doctype} record(s) from {prev['file']['name']} has "
+			"started in the background. Ask me to check on it."
+		),
+	}

--- a/jarvis/tools/tool-names.json
+++ b/jarvis/tools/tool-names.json
@@ -18,7 +18,7 @@
     "repo copies are compared by it, because no CI job can see both repos."
   ],
   "contract_version": 1,
-  "digest": "sha256:5565c8d0893fbf010c6ef2f141c292d600c967edd01138b57984057b2dc1c41d",
+  "digest": "sha256:ab340f555a1801764b832738f7fe4866d1952b715b608deaff34ecb15d772b51",
   "tools": [
     "add_comment",
     "add_tag",
@@ -65,6 +65,7 @@
     "get_workflow_transitions",
     "list_app_modules",
     "preview_doc",
+    "preview_import",
     "query",
     "read_app_source",
     "read_file",
@@ -74,6 +75,7 @@
     "remove_tag",
     "report_pdf",
     "resolve_links",
+    "run_import",
     "run_method",
     "run_report",
     "save_agent_dashboard",

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -2,10 +2,10 @@
 // Renders the server-built "what will change" summary (F9) for a parked write's
 // approval sheet - replacing the raw-JSON dump. The structured card comes from
 // jarvis/chat/confirm_card.py (kind = create | update | bulk_update | verb | email |
-// bulk_email | share | assign | skill | wiki | method | batch_create), already
-// perm-filtered + size-capped + secret-masked server-side. Logic (verbSentence) is
-// the SAME helper the desktop uses (@shared). All values render as escaped text;
-// the raw dry-run JSON stays behind a Details expander.
+// bulk_email | share | assign | skill | wiki | method | batch_create | import),
+// already perm-filtered + size-capped + secret-masked server-side. Logic
+// (verbSentence) is the SAME helper the desktop uses (@shared). All values render
+// as escaped text; the raw dry-run JSON stays behind a Details expander.
 //
 // A kind rendered here ALSO needs an entry in CARD_KINDS
 // (@shared/lib/actionSummary.js): pendingCardOf returns null for a kind not in that
@@ -447,6 +447,56 @@ function tableNote(t) {
 			</div>
 			<div v-if="card.extra > 0" class="jv-pc-more">
 				+{{ card.extra }} more · full list in Details
+			</div>
+		</template>
+
+		<!-- import: run_import (bulk load via Frappe's Data Import). Rows vs records
+		     shown distinctly - a flat file with a mapped child table can fan out into
+		     more records than sheet rows (confirm_card.py::_import_card). Cells are
+		     already secret-masked server-side ("[hidden]"); escaped text only, never
+		     v-html. -->
+		<template v-else-if="card.kind === 'import'">
+			<div class="jv-pc-head">Import into {{ card.doctype }}</div>
+			<div class="jv-pc-kv">
+				<span>Import type</span><b>{{ card.import_type }}</b>
+			</div>
+			<div class="jv-pc-kv">
+				<span>File</span><b>{{ card.file }}</b>
+			</div>
+			<div class="jv-pc-kv">
+				<span>Rows → records</span><b>{{ card.total_rows }} → {{ card.total_records }}</b>
+			</div>
+			<div v-if="card.submit_after_import" class="jv-pc-warn">
+				Will submit each record after import
+			</div>
+			<div v-if="(card.sample?.rows || []).length" class="jv-pc-table">
+				<div class="jv-pc-table-head">Preview</div>
+				<div class="jv-pc-table-scroll">
+					<table>
+						<thead>
+							<tr>
+								<th v-for="(c, ci) in card.sample.columns" :key="'ic' + ci">
+									{{ c }}
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr v-for="(r, ri) in card.sample.rows" :key="'ir' + ri">
+								<td v-for="(cell, di) in r.cells" :key="'id' + di">{{ cell }}</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-if="card.sample.extra_cols > 0" class="jv-pc-more">
+					+{{ card.sample.extra_cols }} more columns
+				</div>
+			</div>
+			<div v-else class="jv-pc-empty">No preview rows.</div>
+			<ul v-if="(card.advisory || []).length" class="jv-pc-list">
+				<li v-for="(a, i) in card.advisory" :key="'ia' + i">{{ a }}</li>
+			</ul>
+			<div v-if="(card.columns?.unmapped || []).length" class="jv-pc-more">
+				Unmapped columns ignored: {{ card.columns.unmapped.join(", ") }}
 			</div>
 		</template>
 


### PR DESCRIPTION
## What & why

Fixes the reported UX bug: asking Jarvis to import a CSV showed an **opaque `run_method … form_start_import` confirmation card** (a function path, no data). This adds a first-class import capability so the confirmation shows the **data** instead.

- **`preview_import`** (read-only): builds a **transient, un-inserted** `Data Import` and returns columns/mapping, ≤10 sample rows, blocking-vs-advisory warnings, and record/row counts — **nothing is persisted**.
- **`run_import`** (gated, always parks, `_DESTRUCTIVE`): stages a `Data Import` **as the calling user** and starts it; returns a "Queued" receipt.
- New **`import` confirmation-card kind** on both frontends (escaped render, reuses the create-card table markup) — target doctype, rows→records, file, sample table, advisory warnings.

## Safety (all tested)

- Caller-scoped **File-read permission gate** (Frappe's importer skips it) + reused Frappe `validate_doctype` gate (no hand-rolled copy).
- Park-time **refusal** (no card) on: blocking values, non-importable doctype, non-admin (`can_run`), and the `frappe.conf.jarvis_import_disabled` kill-switch.
- Secret-column masking; byte+row bounds (`jarvis_import_max_bytes`/`max_rows`, 5 MB/10k defaults); **stricter parent-scoped mandatory** guard (empirical default check); Update/Upsert-without-ID guard; `import_type` literal validation; mapping-target validation.
- **records ≠ rows** surfaced honestly (a flat parent-repeated file fans out into N records — with an advisory); child-column marking; `commit`-before-`start_import` (enqueue race fix).

## Routing

Import is a **specialist for raw file loads only**; anything needing preprocessing stays on the existing `create_docs` path (**untouched** — regression-verified). Persona routing rule + "ask when unclear" copy ship in the sibling persona PR.

## Tests

`test_import_preview` (25), `test_run_import` (16), `test_tool_contract` (10), `PendingCard.spec.js` (5, incl. an XSS break-attempt), `actionSummary` drift-guard (18); ruff clean; regression `confirm_gate`/`create_doc`/`create_docs` green.

## Scope / follow-ups

Slice A only. **Slice B** = the auto-tell "✓ import finished" chat message (separate plan). Reviewed GREEN (code + flow) via the repo pipeline; live browser E2E deferred to deploy. Requires a coordinated roll with the plugin + persona PRs (app-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)