### PR TITLE
fix(ai-models): label the real provider on subscription rows, not always OpenAI

### DIFF
--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -961,3 +961,16 @@ describe("a subscription row's collapsed account identity (jarvis account-name b
 		expect(chip.text()).not.toContain("SUB_");
 	});
 });
+
+describe("subscription source chip labels the real provider", () => {
+	it("maps each upstream to its provider, not always OpenAI", async () => {
+		const w = await mountEditor();
+		const chip = (upstream) => w.vm.sourceChip({ credentialType: "subscription", upstream });
+		expect(chip("openai")).toBe("Subscription · OpenAI");
+		expect(chip("google")).toBe("Subscription · Google Gemini");
+		expect(chip("xai")).toBe("Subscription · xAI Grok");
+		expect(chip("kimi")).toBe("Subscription · Kimi (Moonshot)");
+		// an unknown upstream must never fall back to a wrong vendor
+		expect(chip("someday")).toBe("Subscription · someday");
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -2758,10 +2758,20 @@ function copyTextWithFallback(text) {
 
 // Compact "source" label for a list row (unified failover list, !singleMode
 // only) - e.g. "Subscription · OpenAI" / "API key · Anthropic".
+// Subscription upstream key (openai / google / xai / kimi — what the pool editor
+// stores, same keys ProviderLogo maps to a logo) -> its display label. Without the
+// full map, Kimi/xAI/Gemini rows all mislabelled as "OpenAI" while showing the
+// correct logo. Unknown upstream falls back to the raw value, never a wrong vendor.
+const SUB_UPSTREAM_LABELS = {
+	openai: "OpenAI",
+	google: "Google Gemini",
+	xai: "xAI Grok",
+	kimi: "Kimi (Moonshot)",
+};
 function sourceChip(row) {
 	if (!row) return "";
 	if (row.credentialType === "subscription")
-		return "Subscription · " + (row.upstream === "google" ? "Google" : "OpenAI");
+		return "Subscription · " + (SUB_UPSTREAM_LABELS[row.upstream] || row.upstream || "OpenAI");
 	return "API key · " + (row.provider || "—");
 }
 


### PR DESCRIPTION
## Summary

In the AI models list, a **Kimi** or **Gemini** chat-subscription row showed the correct provider **logo** but the chip still read **"Subscription · OpenAI"**. `sourceChip` only special-cased `google` and defaulted everything else to OpenAI. Now every subscription upstream (`openai` / `google` / `xai` / `kimi`) maps to its real label, and an unknown upstream falls back to the raw value rather than mislabelling as a vendor it isn't. 1 test added.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff