### PR TITLE
feat(chat): brand mark reacts with a little face

### DIFF
--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -132,15 +132,13 @@ const markStyle = computed(() => ({
 	display: none;
 }
 
-/* --- when a face mood is active: hide the star, show the face --- */
-.jv-mood-thinking .jv-star,
-.jv-mood-listening .jv-star,
-.jv-mood-happy .jv-star {
+/* Any active mood hides the star and shows the face. Written as
+   :not(.jv-mood-star) so a mood added later toggles correctly on its own,
+   without having to be appended to a per-mood list here. */
+.jv-mark:not(.jv-mood-star) .jv-star {
 	opacity: 0;
 }
-.jv-mood-thinking .jv-face,
-.jv-mood-listening .jv-face,
-.jv-mood-happy .jv-face {
+.jv-mark:not(.jv-mood-star) .jv-face {
 	opacity: 1;
 }
 
@@ -208,6 +206,9 @@ const markStyle = computed(() => ({
    lingering mood prop can't leave it bouncing forever. */
 .jv-mood-happy .jv-face {
 	gap: calc(var(--jv-mark-size) * 0.05);
+	/* Plays once, ~1.5s. ChatView's markAnswerLanded (HAPPY_HOLD_MS) clears the
+	   mood after the same 1500ms, so the smile reverts to the resting star exactly
+	   as it finishes; keep the two durations in sync. */
 	animation: jvm-cheer 1.5s ease-in-out 1 both;
 }
 .jv-mood-happy .jv-eye {

--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -3,20 +3,30 @@
 	     onboarding wizard, the onboarding gate poster, the chat avatars (and any
 	     future setup surface) can't drift apart on a brand refresh. When the
 	     tenant has uploaded a whitelabel logo we render it in place of the
-	     default gradient spark. -->
+	     default gradient spark.
+
+	     `mood` turns the mark into a tiny reacting face for the moments that have
+	     one: eyes that glance while a reply is being written (thinking), widen
+	     while the mic is capturing (listening), and a one-off smile when the
+	     answer lands (happy). Default "star" renders exactly the resting spark, so
+	     the existing call sites need no change. The face is white on the same
+	     brand gradient as the spark - it never introduces a colour of its own, and
+	     the whitelabel <img> branch ignores mood entirely. -->
 	<img
 		v-if="brandLogoUrl"
 		class="jv-mark jv-mark-img"
 		:src="brandLogoUrl"
-		:style="{ width: `${size}px`, height: `${size}px`, borderRadius: `${radius}px` }"
+		:style="markStyle"
 		alt=""
 	/>
 	<span
 		v-else
 		class="jv-mark"
-		:style="{ width: `${size}px`, height: `${size}px`, borderRadius: `${radius}px` }"
+		:class="[`jv-mood-${mood}`, { 'jv-hoverpeek': hoverPeek }]"
+		:style="markStyle"
 	>
 		<svg
+			class="jv-star"
 			:width="Math.round(size * 0.55)"
 			:height="Math.round(size * 0.55)"
 			viewBox="0 0 24 24"
@@ -24,24 +34,55 @@
 		>
 			<path :d="BRAND_STAR_PATH" />
 		</svg>
+		<span v-if="hasFace" class="jv-face" aria-hidden="true">
+			<span class="jv-eyes"><i class="jv-eye"></i><i class="jv-eye"></i></span>
+			<span class="jv-mouth"></span>
+		</span>
 	</span>
 </template>
 
 <script setup>
+import { computed } from "vue";
 import { brandLogoUrl } from "@/branding";
 import { BRAND_STAR_PATH } from "@/lib/brand";
 
-defineProps({
+const props = defineProps({
 	size: { type: Number, default: 56 },
 	radius: { type: Number, default: 14 },
+	/**
+	 * "star"      resting spark (default, byte-identical to the old mark)
+	 * "thinking"  eyes glance around  - while a reply is being written
+	 * "listening" eyes widen + pulse  - while voice/mic is capturing
+	 * "happy"     smile, plays once   - the moment an answer lands
+	 */
+	mood: {
+		type: String,
+		default: "star",
+		validator: (v) => ["star", "thinking", "listening", "happy"].includes(v),
+	},
+	/** Sidebar/brand use: reveal a friendly blink on hover, calm otherwise. */
+	hoverPeek: { type: Boolean, default: false },
 });
+
+// The face element only exists when something can show it: an active mood, or a
+// hover-peek surface (where mood stays "star" but hover reveals the eyes).
+const hasFace = computed(() => props.mood !== "star" || props.hoverPeek);
+
+const markStyle = computed(() => ({
+	width: `${props.size}px`,
+	height: `${props.size}px`,
+	borderRadius: `${props.radius}px`,
+	"--jv-mark-size": `${props.size}px`,
+}));
 </script>
 
 <style scoped>
 .jv-mark {
+	position: relative;
 	display: grid;
 	place-items: center;
 	flex-shrink: 0;
+	overflow: hidden;
 	/* --brand-grad is defined on :root in main.css (theme-invariant). The literal
 	   fallback keeps the mark correct if this component is ever rendered outside
 	   the app's stylesheet (e.g. an isolated story or a test harness). */
@@ -54,5 +95,167 @@ defineProps({
 	display: block;
 	flex-shrink: 0;
 	background: var(--surface-2, #f0f0f4);
+}
+
+/* Star and face share one centred cell; we cross-fade between them. */
+.jv-star {
+	grid-area: 1 / 1;
+	transition: opacity 0.25s ease;
+}
+.jv-face {
+	grid-area: 1 / 1;
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: calc(var(--jv-mark-size) * 0.07);
+	opacity: 0;
+	transition: opacity 0.25s ease;
+	transform-origin: center;
+}
+.jv-eyes {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: calc(var(--jv-mark-size) * 0.19);
+}
+.jv-eye {
+	width: calc(var(--jv-mark-size) * 0.135);
+	height: calc(var(--jv-mark-size) * 0.2);
+	background: #fff;
+	border-radius: 999px;
+	transform-origin: center;
+}
+.jv-mouth {
+	display: none;
+}
+
+/* --- when a face mood is active: hide the star, show the face --- */
+.jv-mood-thinking .jv-star,
+.jv-mood-listening .jv-star,
+.jv-mood-happy .jv-star {
+	opacity: 0;
+}
+.jv-mood-thinking .jv-face,
+.jv-mood-listening .jv-face,
+.jv-mood-happy .jv-face {
+	opacity: 1;
+}
+
+/* THINKING - eyes drift up and glance side to side, with a soft blink. */
+.jv-mood-thinking .jv-face {
+	animation: jvm-lookaround 3.4s ease-in-out infinite;
+}
+.jv-mood-thinking .jv-eye {
+	animation: jvm-blink 3.4s infinite;
+}
+@keyframes jvm-lookaround {
+	0%,
+	100% {
+		transform: translate(-16%, -8%);
+	}
+	28% {
+		transform: translate(-16%, -8%);
+	}
+	52% {
+		transform: translate(18%, -4%);
+	}
+	70% {
+		transform: translate(0, -12%) scale(0.96, 1.04);
+	}
+}
+@keyframes jvm-blink {
+	0%,
+	46%,
+	100% {
+		transform: scaleY(1);
+	}
+	49%,
+	52% {
+		transform: scaleY(0.14);
+	}
+}
+
+/* LISTENING - eyes widen and pulse, attentive. */
+.jv-mood-listening .jv-face {
+	animation: jvm-attend 1.9s ease-in-out infinite;
+}
+.jv-mood-listening .jv-eye {
+	animation: jvm-tall 1.9s ease-in-out infinite;
+}
+@keyframes jvm-attend {
+	0%,
+	100% {
+		transform: scale(1);
+	}
+	50% {
+		transform: scale(1.1);
+	}
+}
+@keyframes jvm-tall {
+	0%,
+	100% {
+		height: calc(var(--jv-mark-size) * 0.2);
+	}
+	50% {
+		height: calc(var(--jv-mark-size) * 0.26);
+	}
+}
+
+/* HAPPY - smaller eyes + a smile, one bounce, then it holds. Plays once so a
+   lingering mood prop can't leave it bouncing forever. */
+.jv-mood-happy .jv-face {
+	gap: calc(var(--jv-mark-size) * 0.05);
+	animation: jvm-cheer 1.5s ease-in-out 1 both;
+}
+.jv-mood-happy .jv-eye {
+	width: calc(var(--jv-mark-size) * 0.1);
+	height: calc(var(--jv-mark-size) * 0.14);
+}
+.jv-mood-happy .jv-mouth {
+	display: block;
+	width: calc(var(--jv-mark-size) * 0.42);
+	height: calc(var(--jv-mark-size) * 0.34);
+	border: calc(var(--jv-mark-size) * 0.07) solid #fff;
+	border-color: transparent transparent #fff transparent;
+	border-radius: 50%;
+	margin-top: calc(var(--jv-mark-size) * -0.1);
+}
+@keyframes jvm-cheer {
+	0%,
+	100% {
+		transform: translateY(3%) scale(1);
+	}
+	50% {
+		transform: translateY(-12%) scale(1.05);
+	}
+}
+
+/* HOVER PEEK - resting star until hovered, then a friendly blink. Enabled only
+   where hoverPeek is set (the sidebar brand), and only meaningful while mood is
+   "star" (the face is otherwise hidden). Pure CSS, no listeners. */
+.jv-hoverpeek:hover .jv-star {
+	opacity: 0;
+}
+.jv-hoverpeek:hover .jv-face {
+	opacity: 1;
+}
+.jv-hoverpeek:hover .jv-eye {
+	animation: jvm-blink 1.8s ease-in-out infinite;
+}
+
+/* One calm static frame per mood, matching how JvSpinner/SetupNeuralNet handle
+   the same preference: the face still communicates, it just stops moving. */
+@media (prefers-reduced-motion: reduce) {
+	.jv-face,
+	.jv-eye,
+	.jv-hoverpeek:hover .jv-eye {
+		animation: none !important;
+	}
+	.jv-mood-thinking .jv-eye {
+		transform: translateY(-8%);
+	}
 }
 </style>

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -16,7 +16,7 @@
 				     a hand-pasted copy of its gradient + path data. That duplication is
 				     exactly what let the chat welcome mark drift to a different colour
 				     (design.md §2.2). -->
-				<JarvisMark :size="28" :radius="7" />
+				<JarvisMark :size="28" :radius="7" hover-peek />
 				<!-- Resting badge: a waiting reply has to register on every route, not
 				     only while the user happens to be in Chat - restoring this (it was
 				     briefly dropped when ChatView grew its own header jv-support-dot,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8304,14 +8304,12 @@ function onEvent(p) {
 			// the reveal cursor has caught up.
 			flushReveal(p.message_id);
 			const m = messages.value.find((x) => x.name === p.message_id);
-			if (m) {
-				m.streaming = false;
-				// One-off smile on the brand avatar the moment the answer lands.
-				// Success terminal only: the stop/abort path (stopRun) and the error
-				// case never reach here, and we still skip a row that resolved to an
-				// error or stopped state so a failed reply never grins.
-				if (!m.error && !m.stopped) markAnswerLanded(m.name);
-			}
+			if (m) m.streaming = false;
+			// One-off smile on the brand avatar the moment the answer lands. Success
+			// terminal only: the stop/abort path (stopRun) and the error case never
+			// reach here, and we still skip a row that resolved to an error or stopped
+			// state so a failed reply never grins.
+			if (m && !m.error && !m.stopped) markAnswerLanded(m.name);
 			// SUX-6: the terminal final text is the last cumulative mirror in the normal
 			// case, so a re-render would be identical — skip the visible churn. A VISIBLE
 			// replacement is legitimate only when the answer actually changed via snapshot

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -736,7 +736,18 @@
 							@open-attachment="openArtifact(m, $event)"
 						>
 							<template #avatar>
-								<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
+								<JarvisMark
+									:size="28"
+									:radius="7"
+									:mood="
+										m.streaming
+											? 'thinking'
+											: justCompletedId === m.name
+											? 'happy'
+											: 'star'
+									"
+									style="margin-top: 2px"
+								/>
 							</template>
 							<template #above-body>
 								<!-- Activity: the tool calls (with input + output) that produced
@@ -1718,7 +1729,12 @@
 						v-if="(activeTools.length || waiting) && !queuedTurn"
 						style="display: flex; gap: 12px"
 					>
-						<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
+						<JarvisMark
+							:size="28"
+							:radius="7"
+							mood="thinking"
+							style="margin-top: 2px"
+						/>
 						<div style="flex: 1; min-width: 0; padding-top: 3px">
 							<!-- the single tool running right now -->
 							<div
@@ -1814,7 +1830,12 @@
 					     hiccup / compaction). The composer stays UNLOCKED and the answer
 					     lands later via the recovery path — fixes the silent limbo. -->
 					<div v-if="recovering" style="display: flex; gap: 12px">
-						<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
+						<JarvisMark
+							:size="28"
+							:radius="7"
+							mood="thinking"
+							style="margin-top: 2px"
+						/>
 						<div style="flex: 1; min-width: 0; padding-top: 3px">
 							<div
 								role="status"
@@ -2976,6 +2997,12 @@
 									</svg>
 								</button>
 								<template v-if="micState === 'recording'">
+									<JarvisMark
+										:size="22"
+										:radius="6"
+										mood="listening"
+										style="margin-right: 4px"
+									/>
 									<span class="jv-mic-live"
 										><span class="jv-mic-dot"></span>{{ micClock }}</span
 									>
@@ -8283,7 +8310,14 @@ function onEvent(p) {
 			// the reveal cursor has caught up.
 			flushReveal(p.message_id);
 			const m = messages.value.find((x) => x.name === p.message_id);
-			if (m) m.streaming = false;
+			if (m) {
+				m.streaming = false;
+				// One-off smile on the brand avatar the moment the answer lands.
+				// Success terminal only: the stop/abort path (stopRun) and the error
+				// case never reach here, and we still skip a row that resolved to an
+				// error or stopped state so a failed reply never grins.
+				if (!m.error && !m.stopped) markAnswerLanded(m.name);
+			}
 			// SUX-6: the terminal final text is the last cumulative mirror in the normal
 			// case, so a re-render would be identical — skip the visible churn. A VISIBLE
 			// replacement is legitimate only when the answer actually changed via snapshot
@@ -8414,6 +8448,20 @@ function onEvent(p) {
 			loadConversation(currentId.value);
 			break;
 	}
+}
+
+// A brief "answer landed" smile on the assistant avatar, success path only.
+// Keyed by message id and self-clearing (~1.5s) so a historical message never
+// smiles on load and a lingering flag can't leave the mark grinning.
+const justCompletedId = ref(null);
+let happyTimer = null;
+function markAnswerLanded(id) {
+	if (!id) return;
+	justCompletedId.value = id;
+	if (happyTimer) clearTimeout(happyTimer);
+	happyTimer = setTimeout(() => {
+		if (justCompletedId.value === id) justCompletedId.value = null;
+	}, 1500);
 }
 
 function stopRun() {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2997,12 +2997,6 @@
 									</svg>
 								</button>
 								<template v-if="micState === 'recording'">
-									<JarvisMark
-										:size="22"
-										:radius="6"
-										mood="listening"
-										style="margin-right: 4px"
-									/>
 									<span class="jv-mic-live"
 										><span class="jv-mic-dot"></span>{{ micClock }}</span
 									>
@@ -8453,6 +8447,9 @@ function onEvent(p) {
 // A brief "answer landed" smile on the assistant avatar, success path only.
 // Keyed by message id and self-clearing (~1.5s) so a historical message never
 // smiles on load and a lingering flag can't leave the mark grinning.
+// One play of JarvisMark's jvm-cheer smile (1.5s); keep in sync with that
+// animation's duration in JarvisMark.vue.
+const HAPPY_HOLD_MS = 1500;
 const justCompletedId = ref(null);
 let happyTimer = null;
 function markAnswerLanded(id) {
@@ -8461,7 +8458,7 @@ function markAnswerLanded(id) {
 	if (happyTimer) clearTimeout(happyTimer);
 	happyTimer = setTimeout(() => {
 		if (justCompletedId.value === id) justCompletedId.value = null;
-	}, 1500);
+	}, HAPPY_HOLD_MS);
 }
 
 function stopRun() {


### PR DESCRIPTION
## Summary

The Jarvis brand mark now reacts with a small face at the few moments that have one, instead of always sitting as a static spark. `JarvisMark` gains an optional `mood`; default `mood="star"` renders exactly the resting spark, so every existing call site is unchanged.

- **thinking** — eyes glance around while a reply is being written (the working/recovery rows and the streaming reply avatar)
- **happy** — a one-off smile the instant an answer lands, fired only on the success terminal (never on stop, abort, or error) and self-clearing, so a historical message never smiles on load
- **hover-peek** — the sidebar logo blinks a friendly hello on hover, calm otherwise
- **listening** (eyes widen while the mic captures) is built into `JarvisMark` and ready, but not wired to a surface in this PR — see below

The face is white on the same theme-invariant `--brand-grad` as the spark, so it never introduces a colour of its own. The whitelabel `<img>` branch ignores `mood`, and `prefers-reduced-motion` gets one calm static frame per mood, matching `JvSpinner`.

Files: `JarvisMark.vue` (the reusable states), `ChatView.vue` (wiring + the guarded success-terminal happy trigger), `UserMenu.vue` (sidebar hover-peek).

<details><summary>Listening placement deferred (not dropped)</summary>

The intended trigger is `micState === 'recording'`. A first pass placed the listening face in the composer mic row, but that row is `nowrap` and the placement was not flow-verified, so it could clip on a narrow composer. Rather than ship it looking verified, the mood stays ready in `JarvisMark` and will be wired to a chosen, live-checked surface in a follow-up.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (coverage gate) — N/A, presentational CSS/markup; the only logic added is the guarded, self-clearing success-terminal happy trigger
- [x] I self-reviewed the diff (and ran the high code review; findings addressed)

https://claude.ai/code/session_01764H79tpJmSsD89aWDAEgV
