### PR TITLE
fix(billing): usage chart shows real tokens + formatted cost

### DIFF
--- a/frontend/src/charts/usageCharts.js
+++ b/frontend/src/charts/usageCharts.js
@@ -56,7 +56,9 @@ export function perModelBarSpec(perModel, metric = "tokens") {
 		// would otherwise render the same "axes with no bars" pathology this file
 		// exists to fix - chartTheme only nulls out a chart when a series has no
 		// data POINTS, and [0, 0, ...] still has points. Skip the chart instead.
-		if (!data.some((v) => v > 0)) return null;
+		// Hide only when there is NO cost signal at all (every value exactly 0).
+		// A negative value (a credit/refund adjustment) is real data, not "empty".
+		if (!data.some((v) => v !== 0)) return null;
 		return {
 			type: "bar",
 			x,
@@ -84,7 +86,9 @@ export function formatUsd(v) {
 	const n = Number(v);
 	if (!Number.isFinite(n)) return "$0.00";
 	const decimals = n !== 0 && Math.abs(n) < 0.01 ? 4 : 2;
-	return `$${n.toLocaleString("en-US", {
+	// Sign before the $ ("-$12.30", not "$-12.30") for the credit/refund case.
+	const sign = n < 0 ? "-" : "";
+	return `${sign}$${Math.abs(n).toLocaleString("en-US", {
 		minimumFractionDigits: decimals,
 		maximumFractionDigits: decimals,
 	})}`;

--- a/frontend/src/charts/usageCharts.js
+++ b/frontend/src/charts/usageCharts.js
@@ -39,17 +39,53 @@ export function budgetGaugeOption(used, limit, dark = false) {
 	};
 }
 
+// Real per-model rows (jarvis.account.get_llm_usage -> fleet-agent payload)
+// are {model, provider, tokens_in, tokens_out, cost_usd} - there is no flat
+// `tokens` or `cost` field. metric="tokens" (default) splits each model into
+// its in/out bars (stacked, so the bar length is still the model's total)
+// rather than collapsing to one number, which also gives the axis-trigger
+// tooltip (chartTheme.js) real "Tokens in" / "Tokens out" values to show
+// instead of a single hardcoded "Tokens" series. metric="cost" reads
+// cost_usd for a per-model spend view.
 export function perModelBarSpec(perModel, metric = "tokens") {
 	const rows = Array.isArray(perModel) ? perModel : [];
+	const x = rows.map((r) => String((r && r.model) || ""));
+	if (metric === "cost") {
+		const data = rows.map((r) => Number(r && r.cost_usd) || 0);
+		// All-zero cost is real (BYO-key pools may not compute per-model spend) but
+		// would otherwise render the same "axes with no bars" pathology this file
+		// exists to fix - chartTheme only nulls out a chart when a series has no
+		// data POINTS, and [0, 0, ...] still has points. Skip the chart instead.
+		if (!data.some((v) => v > 0)) return null;
+		return {
+			type: "bar",
+			x,
+			series: [{ name: "Cost ($)", data }],
+			options: { horizontal: true },
+		};
+	}
 	return {
 		type: "bar",
-		x: rows.map((r) => String(r.model || "")),
+		x,
 		series: [
-			{
-				name: metric === "cost" ? "Cost ($)" : "Tokens",
-				data: rows.map((r) => Number(r[metric]) || 0),
-			},
+			{ name: "Tokens in", data: rows.map((r) => Number(r && r.tokens_in) || 0) },
+			{ name: "Tokens out", data: rows.map((r) => Number(r && r.tokens_out) || 0) },
 		],
-		options: { horizontal: true },
+		options: { horizontal: true, stacked: true },
 	};
+}
+
+// Shared USD formatter for the Cost tile (and any per-model cost readout).
+// null/undefined/NaN and 0 all render as "$0.00" rather than "$NaN" or a bare
+// "$". Sub-cent spend would otherwise round to the same "$0.00" as no spend
+// at all, so a genuinely nonzero-but-tiny amount gets extra precision instead
+// of silently reading as free.
+export function formatUsd(v) {
+	const n = Number(v);
+	if (!Number.isFinite(n)) return "$0.00";
+	const decimals = n !== 0 && Math.abs(n) < 0.01 ? 4 : 2;
+	return `$${n.toLocaleString("en-US", {
+		minimumFractionDigits: decimals,
+		maximumFractionDigits: decimals,
+	})}`;
 }

--- a/frontend/src/charts/usageCharts.test.js
+++ b/frontend/src/charts/usageCharts.test.js
@@ -96,3 +96,11 @@ test("formatUsd: sub-cent nonzero amounts get extra precision instead of reading
 	assert.equal(formatUsd(0.003), "$0.0030");
 	assert.equal(formatUsd(0.0099), "$0.0099");
 });
+test("formatUsd: negative (credit/refund) puts the sign before the $", () => {
+	assert.equal(formatUsd(-12.3), "-$12.30");
+	assert.equal(formatUsd(-0.005), "-$0.0050");
+});
+test("perModelBarSpec: cost metric renders when values are nonzero-but-negative (credits), not hidden", () => {
+	const rows = [{ model: "gpt-5.5", cost_usd: -0.5 }];
+	assert.notEqual(perModelBarSpec(rows, "cost"), null);
+});

--- a/frontend/src/charts/usageCharts.test.js
+++ b/frontend/src/charts/usageCharts.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { budgetGaugeOption, perModelBarSpec } from "./usageCharts.js";
+import { budgetGaugeOption, perModelBarSpec, formatUsd } from "./usageCharts.js";
 import { buildOption } from "./chartTheme.js";
 
 test("gauge: null when no positive limit", () => {
@@ -15,12 +15,84 @@ test("gauge: percent, caps at 100, red at >=90%", () => {
 	assert.equal(over.series[0].data[0].value, 100);
 	assert.equal(over.series[0].progress.itemStyle.color, "#fc8181");
 });
-test("perModelBarSpec: chartTheme-renderable bar spec", () => {
+
+// The real per-model row shape has no `tokens` / `cost` field - only
+// tokens_in / tokens_out / cost_usd. A fixture in the old {model, tokens,
+// cost} shape must still resolve every value to 0 (proves the old bug is
+// gone, not silently reintroduced by a looser field read).
+test("perModelBarSpec: tokens metric ignores a stale {tokens} fixture (no such field)", () => {
 	const s = perModelBarSpec([{ model: "gpt-5.5", tokens: 10, cost: 0.2 }], "tokens");
 	assert.equal(s.type, "bar");
 	assert.deepEqual(s.x, ["gpt-5.5"]);
-	assert.deepEqual(s.series[0].data, [10]);
+	assert.deepEqual(s.series[0].data, [0]);
+	assert.deepEqual(s.series[1].data, [0]);
+});
+
+test("perModelBarSpec: tokens metric reads tokens_in/tokens_out and produces non-zero bars", () => {
+	const rows = [
+		{ model: "gpt-5.5", provider: "openai", tokens_in: 1200, tokens_out: 800, cost_usd: 0.42 },
+		{
+			model: "claude",
+			provider: "anthropic",
+			tokens_in: 300,
+			tokens_out: 100,
+			cost_usd: 0.05,
+		},
+	];
+	const s = perModelBarSpec(rows, "tokens");
+	assert.equal(s.type, "bar");
+	assert.deepEqual(s.x, ["gpt-5.5", "claude"]);
+	assert.equal(s.series.length, 2);
+	assert.equal(s.series[0].name, "Tokens in");
+	assert.equal(s.series[1].name, "Tokens out");
+	assert.deepEqual(s.series[0].data, [1200, 300]);
+	assert.deepEqual(s.series[1].data, [800, 100]);
+	// stacked so a horizontal bar's length still reads as the model's total.
+	assert.equal(s.options.stacked, true);
+	assert.equal(s.options.horizontal, true);
+	// every bar has a real (nonzero) value - the bug (all-0 from reading the
+	// nonexistent `tokens` field) is fixed.
+	assert.ok(s.series[0].data.every((v) => v > 0));
+	assert.ok(s.series[1].data.every((v) => v > 0));
 	assert.notEqual(buildOption(s), null);
-	const cost = perModelBarSpec([{ model: "m", tokens: 10, cost: 0.2 }], "cost");
+});
+
+test("perModelBarSpec: cost metric reads cost_usd", () => {
+	const cost = perModelBarSpec(
+		[{ model: "m", tokens_in: 10, tokens_out: 5, cost_usd: 0.2 }],
+		"cost"
+	);
+	assert.equal(cost.series[0].name, "Cost ($)");
 	assert.deepEqual(cost.series[0].data, [0.2]);
+	assert.notEqual(buildOption(cost), null);
+});
+
+test("perModelBarSpec: cost metric returns null when every row's cost is 0 (BYO-key pools) instead of an empty axes-only chart", () => {
+	const rows = [
+		{ model: "m1", tokens_in: 10, tokens_out: 5, cost_usd: 0 },
+		{ model: "m2", tokens_in: 4, tokens_out: 2 },
+	];
+	assert.equal(perModelBarSpec(rows, "cost"), null);
+});
+
+test("perModelBarSpec: empty/missing rows stay safe", () => {
+	assert.deepEqual(perModelBarSpec(undefined).x, []);
+	assert.deepEqual(perModelBarSpec([{ model: "m" }]).series[0].data, [0]);
+});
+
+test("formatUsd: zero and nullish coerce to $0.00", () => {
+	assert.equal(formatUsd(0), "$0.00");
+	assert.equal(formatUsd(null), "$0.00");
+	assert.equal(formatUsd(undefined), "$0.00");
+	assert.equal(formatUsd(NaN), "$0.00");
+	assert.equal(formatUsd("abc"), "$0.00");
+});
+test("formatUsd: normal amounts render at 2dp with thousands separators", () => {
+	assert.equal(formatUsd(0.42), "$0.42");
+	assert.equal(formatUsd(1234.5), "$1,234.50");
+	assert.equal(formatUsd(5), "$5.00");
+});
+test("formatUsd: sub-cent nonzero amounts get extra precision instead of reading as free", () => {
+	assert.equal(formatUsd(0.003), "$0.0030");
+	assert.equal(formatUsd(0.0099), "$0.0099");
 });

--- a/frontend/src/components/settings/BillingMeteringPane.vue
+++ b/frontend/src/components/settings/BillingMeteringPane.vue
@@ -76,13 +76,22 @@
 						</div>
 						<div class="rounded-md border p-4">
 							<div class="text-2xl font-medium text-ink-gray-8">
-								${{ usage.cost_usd }}
+								{{ formatUsd(usage.cost_usd) }}
 							</div>
 							<div class="mt-1 text-sm text-ink-gray-6">Cost</div>
 						</div>
 					</div>
 					<div class="mt-4 flex flex-col gap-4">
-						<JvChart v-if="perModelSpec" :spec="perModelSpec" :dark="dark" />
+						<div v-if="perModelSpec">
+							<h4 class="mb-1 text-sm font-medium text-ink-gray-7">
+								Tokens by model
+							</h4>
+							<JvChart :spec="perModelSpec" :dark="dark" />
+						</div>
+						<div v-if="perModelCostSpec">
+							<h4 class="mb-1 text-sm font-medium text-ink-gray-7">Cost by model</h4>
+							<JvChart :spec="perModelCostSpec" :dark="dark" />
+						</div>
 						<EChart v-if="gaugeOption" :option="gaugeOption" />
 					</div>
 				</template>
@@ -100,7 +109,7 @@ import { ref, computed, onMounted } from "vue";
 import { Badge, Button } from "frappe-ui";
 import JvChart from "@/charts/JvChart.vue";
 import EChart from "@/charts/EChart.vue";
-import { budgetGaugeOption, perModelBarSpec } from "@/charts/usageCharts.js";
+import { budgetGaugeOption, perModelBarSpec, formatUsd } from "@/charts/usageCharts.js";
 import { getLlmConfig, getLlmUsage, getLlmSyncStatus } from "@/api";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
 import { connectionModeLabel } from "@/llm/pool";
@@ -141,6 +150,11 @@ const syncLabel = computed(() => humaniseSyncStatus(sync.value.last_sync_status)
 
 const perModelSpec = computed(() =>
 	(usage.value.per_model || []).length ? perModelBarSpec(usage.value.per_model, "tokens") : null
+);
+// Cost breakdown alongside the tokens chart - same rows, already-supported
+// "cost" metric, no new data plumbing.
+const perModelCostSpec = computed(() =>
+	(usage.value.per_model || []).length ? perModelBarSpec(usage.value.per_model, "cost") : null
 );
 const gaugeOption = computed(() => {
 	const uv = usage.value.used_vs_limit || {};


### PR DESCRIPTION
## Summary

The "Billing and metering" usage chart rendered **empty** — x-axis stuck at `0→1`, no bars, tooltip reading "Tokens 0" — and the Cost tile showed a raw `$0`. Root cause: `perModelBarSpec` read a `tokens` field that **doesn't exist** on the real payload (rows are `{model, tokens_in, tokens_out, cost_usd}`), so every value collapsed to 0.

This plots **tokens_in + tokens_out** as stacked bars per model (real data, real hover), adds an optional **Cost by model** view off `cost_usd`, and formats the **Cost tile** as proper USD (`$0.00`, 4dp for sub-cent amounts, never raw). An all-zero cost chart renders nothing rather than an empty axis.

Frontend-only. Test fixtures corrected to the real row shape (the old `{tokens}` shape was why this shipped green), with a guard so the bug can't silently return.

> Note: cost is real only for managed-proxy tenants today. Exact cost for **API-key / BYO** tenants needs a per-model pricing table — a separate follow-up (Phase 2). This PR fixes the chart + formatting for the data that already flows.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff