### PR TITLE
feat(usage): per-user token cap is now all-time, not monthly

### DIFF
--- a/frontend/src/components/settings/UsageAdminPane.vue
+++ b/frontend/src/components/settings/UsageAdminPane.vue
@@ -43,8 +43,8 @@
 				style="grid-template-columns: 1.5fr 1.8fr 1.3fr 0.9fr"
 			>
 				<div>User</div>
-				<div>This month</div>
-				<div>Monthly limit</div>
+				<div>Usage</div>
+				<div>Token limit</div>
 				<div>Last activity</div>
 			</div>
 
@@ -86,15 +86,12 @@
 								/>
 							</div>
 							<div class="mt-1 text-xs text-ink-gray-5">
-								{{ fmtTokens(u.month_tokens) }} of
+								{{ fmtTokens(u.total_tokens) }} of
 								{{ fmtTokens(u.monthly_token_limit) }} · {{ pct(u) }}%
 							</div>
 						</template>
 						<div v-else class="text-xs text-ink-gray-5">
-							{{ fmtTokens(u.month_tokens) }} this month · unlimited
-						</div>
-						<div class="mt-0.5 text-xs text-ink-gray-4">
-							{{ fmtTokens(u.total_tokens) }} total
+							{{ fmtTokens(u.total_tokens) }} total · unlimited
 						</div>
 					</div>
 
@@ -236,11 +233,13 @@ function fmtTokens(n) {
 	if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
 	return String(n);
 }
+// All-time: compares against total_tokens (the cumulative, never-reset
+// counter), not month_tokens. See jarvis.chat.policy._over_total_limit.
 function pct(u) {
 	if (!u || !u.monthly_token_limit) return 0;
 	return Math.min(
 		100,
-		Math.round((Number(u.month_tokens || 0) / Number(u.monthly_token_limit)) * 100)
+		Math.round((Number(u.total_tokens || 0) / Number(u.monthly_token_limit)) * 100)
 	);
 }
 function modelPct(m) {

--- a/frontend/src/components/settings/UsagePane.vue
+++ b/frontend/src/components/settings/UsagePane.vue
@@ -19,12 +19,12 @@
 					<div class="h-full bg-surface-gray-7" :style="{ width: measuredPct + '%' }" />
 				</div>
 				<p class="mt-2 text-p-sm text-ink-gray-5">
-					{{ fmtTokens(measured.month_tokens) }} of
-					{{ fmtTokens(measured.monthly_token_limit) }} this month, {{ measuredPct }}%
+					{{ fmtTokens(measured.total_tokens) }} of
+					{{ fmtTokens(measured.monthly_token_limit) }} all time, {{ measuredPct }}%
 				</p>
 			</template>
 			<p v-else class="mt-2 text-p-sm text-ink-gray-5">
-				No monthly limit set on your account.
+				No token limit set on your account.
 			</p>
 
 			<template v-if="perModel.length">
@@ -192,12 +192,14 @@ const measured = computed(() => (usage.value && usage.value.measured) || null);
 // showing both once real counters exist. So the block appears only once there is
 // something measured to show.
 const hasMeasured = computed(() => !!(measured.value && Number(measured.value.total_tokens || 0)));
+// All-time: compares against total_tokens (the cumulative, never-reset
+// counter), not month_tokens. See jarvis.chat.policy._over_total_limit.
 const measuredPct = computed(() => {
 	const m = measured.value;
 	if (!m || !m.monthly_token_limit) return 0;
 	return Math.min(
 		100,
-		Math.round((Number(m.month_tokens || 0) / Number(m.monthly_token_limit)) * 100)
+		Math.round((Number(m.total_tokens || 0) / Number(m.monthly_token_limit)) * 100)
 	);
 });
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7903,8 +7903,12 @@ async function send(textArg, resendAck) {
 				return;
 			}
 			notify(
+				// Period-neutral copy: "usage_limit" fires from BOTH the all-time
+				// aggregate cap (jarvis.chat.policy._over_total_limit) and the
+				// still-monthly per-model cap (_over_model_limit) - the toast can't
+				// say "monthly" or "all-time" without being wrong for one of them.
 				r.reason === "usage_limit"
-					? `Monthly usage limit reached. Ask your ${agentName} admin to raise your limit.`
+					? `You've reached your usage limit. Ask your ${agentName} admin to raise it.`
 					: r.reason || "Couldn't send your message.",
 				{ type: "error" }
 			);

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -2,7 +2,7 @@
 
 Called by jarvis.chat.api.send_message before enqueuing the agent worker.
 It rejects empty users and Guest, and (design section 5) enforces the
-per-user monthly token cap set via ``Jarvis User Settings``. Phase 3's
+per-user all-time token cap set via ``Jarvis User Settings``. Phase 3's
 jarvis_admin app may layer real subscription gating on top by overriding
 this module's contract.
 
@@ -22,8 +22,8 @@ def validate_can_send(user: str, model: str | None = None) -> tuple[bool, str | 
 		return False, "no authenticated user"
 	if user == "Guest":
 		return False, "Guest users cannot use Jarvis chat"
-	# Aggregate monthly cap is the OUTER gate — checked first (fleet spec §7).
-	if _over_monthly_limit(user):
+	# Aggregate all-time cap is the OUTER gate — checked first (fleet spec §7).
+	if _over_total_limit(user):
 		return False, "usage_limit"
 	if _subscription_suspended():
 		return False, "subscription_suspended"
@@ -214,17 +214,23 @@ def _over_model_limit(user: str, model: str) -> bool:
 		return False
 
 
-def _over_monthly_limit(user: str) -> bool:
-	"""True iff ``user`` has a positive monthly token cap and this month's
+def _over_total_limit(user: str) -> bool:
+	"""True iff ``user`` has a positive all-time token cap and their all-time
 	recorded usage has reached it. Dependency-light: one ``db.get_value`` on the
-	settings row, no lazy create (a missing row = no limit). Rollover-aware: a
-	stale ``usage_month`` means this month's usage is effectively 0. Fails open
-	on any error — an accounting lookup bug must never block a legitimate send."""
+	settings row, no lazy create (a missing row = no limit). No rollover: unlike
+	the per-model gate, this cap never resets, so it compares against
+	``total_tokens`` (the cumulative, never-reset counter) rather than a
+	month-scoped bucket. Fails open on any error — an accounting lookup bug
+	must never block a legitimate send.
+
+	NOTE: the field is still named ``monthly_token_limit`` (kept to avoid a
+	migration for ~15 existing references / the wire contract) but the cap it
+	now enforces is all-time, not monthly."""
 	try:
 		row = frappe.db.get_value(
 			"Jarvis User Settings",
 			{"user": user},
-			["monthly_token_limit", "usage_month", "month_tokens"],
+			["monthly_token_limit", "total_tokens"],
 			as_dict=True,
 		)
 		if not row:
@@ -232,11 +238,7 @@ def _over_monthly_limit(user: str) -> bool:
 		limit = int(row.monthly_token_limit or 0)
 		if limit <= 0:
 			return False
-		# Stale month ⇒ this month's usage hasn't started ⇒ 0 used. One shared
-		# bucket-key helper (jarvis.chat.usage) so writer and gate can't drift.
-		from jarvis.chat.usage import current_month_key
-
-		used = int(row.month_tokens or 0) if row.usage_month == current_month_key() else 0
+		used = int(row.total_tokens or 0)
 		return used >= limit
 	except Exception:
 		# See _over_model_limit: don't let a logging failure defeat fail-open.

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -214,7 +214,7 @@ def mark_home_intro_seen(version: int = 0) -> dict:
 	``greeting``'s cadence counter). A full-doc save writes back EVERY field
 	from a snapshot taken before those writes, and because they leave
 	``modified`` untouched there is no timestamp mismatch to catch it: an admin
-	setting a user's monthly spend cap in the same moment this user's browser
+	setting a user's token spend cap in the same moment this user's browser
 	acks the introduction would have the cap silently reverted to the stale
 	value. Touching exactly the two columns this endpoint owns removes that
 	whole class of interaction.
@@ -360,8 +360,10 @@ def admin_list_user_usage() -> dict:
 
 @frappe.whitelist()
 def admin_set_user_limit(user: str, monthly_token_limit: int = 0) -> dict:
-	"""Set a user's monthly token cap (0 = unlimited), creating the settings
-	row if absent. Admins only."""
+	"""Set a user's all-time token cap (0 = unlimited), creating the settings
+	row if absent. Admins only. NOTE: arg/field name ``monthly_token_limit`` is
+	legacy (kept as the wire contract) - the cap it sets is all-time, not
+	monthly."""
 	require_jarvis_admin()
 	# Coerce before the db calls: a dict `user` would turn the identity check into
 	# a filter match (see the module NOTE / N10).

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -163,10 +163,10 @@
     {
       "fieldname": "monthly_token_limit",
       "fieldtype": "Int",
-      "label": "Monthly Token Limit",
+      "label": "Token Limit",
       "permlevel": 1,
       "default": "0",
-      "description": "Per-user monthly token cap. 0 = unlimited. Admins only."
+      "description": "Per-user all-time token cap. 0 = unlimited. Admins only. Fieldname is legacy-named (\"monthly\") but the cap does not reset - it is an all-time budget."
     },
     {
       "fieldname": "usage_section",

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.py
@@ -1,9 +1,10 @@
 """Jarvis User Settings DocType controller.
 
 One row per Frappe user, holding that user's chat preferences
-(``notify_enabled`` / ``activity_detail``), an admin-set monthly token cap
-(``monthly_token_limit``, permlevel 1), and the read-only usage counters the
-turn handler increments via atomic SQL (``jarvis.chat.usage``).
+(``notify_enabled`` / ``activity_detail``), an admin-set all-time token cap
+(``monthly_token_limit`` - legacy fieldname, the cap is now all-time not
+monthly, permlevel 1), and the read-only usage counters the turn handler
+increments via atomic SQL (``jarvis.chat.usage``).
 
 Rows are created lazily by ``jarvis.chat.usage.get_or_create_user_settings``
 with an explicit ``owner`` so the ``if_owner`` permlevel-0 grant holds even

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -50,3 +50,4 @@ jarvis.patches.v2_12_reload_agent_doctypes_for_indexes
 jarvis.patches.v2_12_reload_macro_doctypes_for_indexes
 jarvis.patches.v2_13_repush_learned_skills_role_gated
 jarvis.patches.v2_13_unique_agent_installation
+jarvis.patches.v2_14_reconcile_token_limit_to_alltime

--- a/jarvis/patches/v2_14_reconcile_token_limit_to_alltime.py
+++ b/jarvis/patches/v2_14_reconcile_token_limit_to_alltime.py
@@ -1,0 +1,57 @@
+"""Bump every existing per-user cap by that user's current usage, so switching
+``Jarvis User Settings.monthly_token_limit`` from a monthly-resetting cap to an
+all-time cap (jarvis.chat.policy._over_total_limit) cannot instantly, permanently
+lock out an existing user on deploy.
+
+Before this change the field was compared against ``month_tokens`` (reset every
+month); after it, it is compared against ``total_tokens`` (cumulative, never
+reset - see policy.py). A user already past their old monthly-sized cap in
+lifetime usage would otherwise fail ``used >= limit`` on their very next send,
+forever, with no month rollover left to save them.
+
+The admin's original number encoded intended HEADROOM, not an absolute
+lifetime ceiling - a "100k/month" cap meant "block after 100k more than
+whatever came before". Preserving that intent means adding today's already-
+accrued usage on top of the existing cap: a 100k cap on a user already at 500k
+total becomes 600k (existing cap + intended headroom), so nobody already
+compliant is retroactively over, and nobody is silently made unlimited (0
+stays out of scope - the WHERE guard below only touches positive caps).
+
+Only rows with ``monthly_token_limit > 0`` are touched; a 0 (unlimited) row has
+nothing to reconcile. Deliberately NOT idempotent against a manual re-run (a
+second pass would double-add), but that is not a concern for a normal
+migrate - the patch log runs this exactly once.
+"""
+
+import frappe
+
+SETTINGS = "Jarvis User Settings"
+
+
+def execute() -> None:
+	if not frappe.db.has_column(SETTINGS, "monthly_token_limit") or not frappe.db.has_column(
+		SETTINGS, "total_tokens"
+	):
+		return
+
+	(affected,) = frappe.db.sql(
+		f"""
+		SELECT COUNT(*) FROM `tab{SETTINGS}`
+		WHERE monthly_token_limit > 0
+		"""
+	)[0]
+
+	frappe.db.sql(
+		f"""
+		UPDATE `tab{SETTINGS}`
+		SET monthly_token_limit = monthly_token_limit + total_tokens
+		WHERE monthly_token_limit > 0
+		"""
+	)
+	frappe.db.commit()
+
+	frappe.logger("jarvis").info(
+		f"v2_14 token-limit reconciliation: bumped {affected} Jarvis User Settings "
+		f"row(s) with a positive cap by their current total_tokens, ahead of the "
+		f"monthly -> all-time cap switch"
+	)

--- a/jarvis/tests/test_policy_model_limit.py
+++ b/jarvis/tests/test_policy_model_limit.py
@@ -146,13 +146,13 @@ class TestPerModelGate(_Base):
 		self.assertTrue(ok)
 
 	def test_aggregate_gate_fires_first(self):
-		# Aggregate over-limit blocks regardless of model, and even with no
-		# per-model row for the passed model.
+		# Aggregate (all-time) over-limit blocks regardless of model, and even
+		# with no per-model row for the passed model.
 		user_settings_api.admin_set_user_limit(user=USER_A, monthly_token_limit=100)
 		frappe.db.set_value(
 			USETT,
 			{"user": USER_A},
-			{"usage_month": usage.current_month_key(), "month_tokens": 150},
+			{"total_tokens": 150},
 			update_modified=False,
 		)
 		frappe.db.commit()

--- a/jarvis/tests/test_user_settings.py
+++ b/jarvis/tests/test_user_settings.py
@@ -470,11 +470,13 @@ class TestEnforcement(_UsageTestBase):
 		self.assertIsNone(reason)
 
 	def test_over_limit_rejects_with_usage_limit(self):
+		# All-time cap: compares against total_tokens (never resets), not
+		# month_tokens. 150 >= 100 ⇒ blocked.
 		user_settings_api.admin_set_user_limit(user=USER_A, monthly_token_limit=100)
 		frappe.db.set_value(
 			USETT,
 			{"user": USER_A},
-			{"usage_month": usage.current_month_key(), "month_tokens": 150},
+			{"total_tokens": 150},
 			update_modified=False,
 		)
 		frappe.db.commit()
@@ -487,7 +489,7 @@ class TestEnforcement(_UsageTestBase):
 		frappe.db.set_value(
 			USETT,
 			{"user": USER_A},
-			{"usage_month": usage.current_month_key(), "month_tokens": 50},
+			{"total_tokens": 50},
 			update_modified=False,
 		)
 		frappe.db.commit()
@@ -495,25 +497,28 @@ class TestEnforcement(_UsageTestBase):
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
 
-	def test_stale_month_allows_despite_high_count(self):
+	def test_stale_usage_month_does_not_matter(self):
+		# The cap is all-time now, so a stale (or absent) usage_month/month_tokens
+		# rollover state must NOT protect a user whose all-time total is over the
+		# cap - unlike the old monthly gate, there is no rollover to reset.
 		user_settings_api.admin_set_user_limit(user=USER_A, monthly_token_limit=100)
 		frappe.db.set_value(
 			USETT,
 			{"user": USER_A},
-			{"usage_month": "2020-01", "month_tokens": 9999},
+			{"usage_month": "2020-01", "month_tokens": 9999, "total_tokens": 150},
 			update_modified=False,
 		)
 		frappe.db.commit()
 		ok, reason = policy.validate_can_send(USER_A)
-		self.assertTrue(ok)  # rollover ⇒ this month's usage is 0
-		self.assertIsNone(reason)
+		self.assertFalse(ok)  # all-time total is over the cap regardless of usage_month
+		self.assertEqual(reason, "usage_limit")
 
 	def test_zero_limit_is_unlimited(self):
 		user_settings_api.admin_set_user_limit(user=USER_A, monthly_token_limit=0)
 		frappe.db.set_value(
 			USETT,
 			{"user": USER_A},
-			{"usage_month": usage.current_month_key(), "month_tokens": 999999},
+			{"total_tokens": 999999},
 			update_modified=False,
 		)
 		frappe.db.commit()
@@ -526,7 +531,7 @@ class TestEnforcement(_UsageTestBase):
 		frappe.db.set_value(
 			USETT,
 			{"user": USER_A},
-			{"usage_month": usage.current_month_key(), "month_tokens": 150},
+			{"total_tokens": 150},
 			update_modified=False,
 		)
 		frappe.db.commit()


### PR DESCRIPTION
## Summary

The per-user usage cap ("Monthly limit") reset every month. A token budget can reasonably span longer than a month, so it's now a simple **all-time token cap** — enforcement compares cumulative `total_tokens` against the limit (no monthly rollover), and the control is relabeled **"Token limit"** across the DocType and both usage panes.

Kept the DocType fieldname `monthly_token_limit` (and the `admin_set_user_limit` arg) as the wire contract — no field-rename migration — with a comment that the name is legacy but the cap no longer resets. The **per-model** month-keyed limit is intentionally untouched.

Backend tests updated to total-based enforcement (65 + 8 pass); frontend labels updated (1192 specs pass).

> ⚠️ **Deploy heads-up (behavior change, not a bug):** any user whose all-time `total_tokens` already exceeds a cap an admin set expecting a *monthly* reset will be blocked on their next send once this ships (there's no monthly reset to save them). Admins who set caps under the old monthly semantics may want to review/raise them before/after deploy.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff