### PR TITLE
fix(ui): support attachment inline, wiki role-scope gating, promotion role search

### DIFF
--- a/frontend/src/components/skills/PromotionRequestDialog.spec.js
+++ b/frontend/src/components/skills/PromotionRequestDialog.spec.js
@@ -6,19 +6,20 @@ import path from "node:path";
 /**
  * The "Request promotion" dialog's role picker.
  *
- * Two failure modes are pinned here, because the bug that prompted them was
- * invisible to a normal unit test: the picker RENDERED fine and was simply
- * painted over. So the behaviour half is mounted, and the stacking half is
- * asserted against the stylesheet — the only place it can be checked without a
- * real browser.
+ * The picker is an INLINE search box + clickable list, NOT the frappe-ui
+ * Autocomplete: the Autocomplete's search box renders in a popover portaled
+ * OUTSIDE this reka-ui Dialog, where the Dialog's focus scope left it
+ * unclickable. The behaviour half is mounted here; the stacking half (the
+ * app-wide z-index guard other portaled pickers still rely on) is asserted
+ * against the stylesheet.
  */
 
 const rolesMock = vi.fn(async () => ({ roles: ["Sales Manager", "Accounts"] }));
 vi.mock("@/api/skills", () => ({ promotableTargetRoles: () => rolesMock() }));
 
 // frappe-ui's ESM entry does not resolve under vitest (every other spec here
-// stubs it the same way). The stubs keep the contracts this dialog relies on:
-// FormControl emits update:modelValue, Autocomplete emits an {label,value}.
+// stubs it the same way). The stub keeps the contracts this dialog relies on:
+// FormControl select emits the value on change; a text field emits on input.
 vi.mock("frappe-ui", () => ({
 	Dialog: {
 		name: "Dialog",
@@ -31,13 +32,7 @@ vi.mock("frappe-ui", () => ({
 		emits: ["update:modelValue"],
 		template: `<select v-if="type === 'select'" class="fc-select" @change="$emit('update:modelValue', $event.target.value)">
 			<option v-for="o in options || []" :key="o.value" :value="o.value">{{ o.label }}</option>
-		</select><textarea v-else class="fc-textarea" />`,
-	},
-	Autocomplete: {
-		name: "Autocomplete",
-		props: ["options", "modelValue", "placeholder"],
-		emits: ["update:modelValue"],
-		template: "<div class='autocomplete' />",
+		</select><input v-else class="fc-input" :type="type" :placeholder="placeholder" @input="$emit('update:modelValue', $event.target.value)" />`,
 	},
 	Button: { name: "Button", props: ["label", "loading", "disabled"], template: "<button />" },
 	toast: { error: vi.fn(), success: vi.fn() },
@@ -60,27 +55,44 @@ const chooseScope = async (w, value) => {
 	await flushPromises();
 };
 
+// Type into the inline role search box (a plain input, clickable inside the Dialog).
+const typeSearch = async (w, value) => {
+	const input = w.find('input[placeholder="Search your roles"]');
+	input.element.value = value;
+	await input.trigger("input");
+	await flushPromises();
+};
+
+// The role list is inline clickable options (role="option"), not a portaled popover.
+const roleOptionTexts = (w) => w.findAll('[role="option"]').map((b) => b.text());
+const pickRole = async (w, name) => {
+	const btn = w.findAll('[role="option"]').find((b) => b.text() === name);
+	await btn.trigger("click");
+	await flushPromises();
+};
+
 beforeEach(() => rolesMock.mockClear());
 
 describe("PromotionRequestDialog role picker", () => {
-	it("hides the role picker on the default Org scope", async () => {
+	it("shows no role options on the default Org scope", async () => {
 		const w = await openDialog();
-		expect(w.findComponent({ name: "Autocomplete" }).exists()).toBe(false);
+		expect(roleOptionTexts(w)).toEqual([]);
 	});
 
-	it("reveals the role picker when the scope becomes Role", async () => {
+	it("lists the requester's own targetable roles when the scope becomes Role", async () => {
 		const w = await openDialog();
 		await chooseScope(w, "Role");
-		expect(w.findComponent({ name: "Autocomplete" }).exists()).toBe(true);
+		expect(roleOptionTexts(w)).toEqual(["Sales Manager", "Accounts"]);
 	});
 
-	it("offers the requester's own targetable roles", async () => {
+	it("filters the list as the requester types in the (clickable) search box", async () => {
 		const w = await openDialog();
 		await chooseScope(w, "Role");
-		expect(w.findComponent({ name: "Autocomplete" }).props("options")).toEqual([
-			{ label: "Sales Manager", value: "Sales Manager" },
-			{ label: "Accounts", value: "Accounts" },
-		]);
+		await typeSearch(w, "sales");
+		expect(roleOptionTexts(w)).toEqual(["Sales Manager"]);
+		await typeSearch(w, "zzz");
+		expect(roleOptionTexts(w)).toEqual([]);
+		expect(w.text()).toContain("No roles match your search");
 	});
 
 	it("explains itself instead of showing an empty picker when the user holds no roles", async () => {
@@ -88,17 +100,14 @@ describe("PromotionRequestDialog role picker", () => {
 		const w = await openDialog();
 		await chooseScope(w, "Role");
 		expect(w.text()).toContain("You hold no roles that can be targeted");
+		expect(roleOptionTexts(w)).toEqual([]);
 	});
 
-	it("cannot submit a Role promotion until a role is chosen", async () => {
+	it("cannot submit a Role promotion until a role is picked", async () => {
 		const w = await openDialog();
 		await chooseScope(w, "Role");
 		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(true);
-		w.findComponent({ name: "Autocomplete" }).vm.$emit("update:modelValue", {
-			label: "Accounts",
-			value: "Accounts",
-		});
-		await flushPromises();
+		await pickRole(w, "Accounts");
 		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(false);
 	});
 });

--- a/frontend/src/components/skills/PromotionRequestDialog.vue
+++ b/frontend/src/components/skills/PromotionRequestDialog.vue
@@ -17,19 +17,44 @@
 
 				<div v-if="toScope === 'Role'" class="flex flex-col gap-1">
 					<span class="block text-xs text-ink-gray-5">Role</span>
-					<!-- Autocomplete: same role-picker idiom the wiki create dialog
-					     uses; options are the requester's OWN targetable roles. -->
-					<Autocomplete
-						placeholder="Search your roles"
-						:options="roleOptions"
-						:modelValue="targetRole"
-						@update:modelValue="(v) => (targetRole = (v && v.value) || '')"
-					/>
-					<p
-						v-if="!rolesLoading && !roleOptions.length"
-						class="text-p-sm text-ink-gray-5"
-					>
-						You hold no roles that can be targeted — promote to the whole org instead,
+					<template v-if="roleOptions.length">
+						<!-- Inline search + list, NOT the frappe-ui Autocomplete: its search
+						     box renders in a popover portaled OUTSIDE this reka-ui Dialog, where
+						     the Dialog's focus scope left it unclickable. A plain input and an
+						     inline list both sit inside the Dialog, so search AND selection work. -->
+						<FormControl
+							type="text"
+							placeholder="Search your roles"
+							:modelValue="roleQuery"
+							@update:modelValue="(v) => (roleQuery = v)"
+						/>
+						<div class="max-h-44 overflow-y-auto rounded border" role="listbox">
+							<button
+								v-for="r in filteredRoles"
+								:key="r"
+								type="button"
+								role="option"
+								:aria-selected="targetRole === r"
+								class="flex w-full px-3 py-2 text-left text-sm hover:bg-surface-gray-2"
+								:class="
+									targetRole === r
+										? 'bg-surface-gray-3 font-medium text-ink-gray-9'
+										: 'text-ink-gray-7'
+								"
+								@click="targetRole = r"
+							>
+								{{ r }}
+							</button>
+							<p
+								v-if="!filteredRoles.length"
+								class="px-3 py-2 text-p-sm text-ink-gray-5"
+							>
+								No roles match your search.
+							</p>
+						</div>
+					</template>
+					<p v-else-if="!rolesLoading" class="text-p-sm text-ink-gray-5">
+						You hold no roles that can be targeted - promote to the whole org instead,
 						or ask an admin to add you to the role first.
 					</p>
 				</div>
@@ -67,7 +92,7 @@
 // busy flag. Role options are the requester's OWN targetable roles
 // (promotable_target_roles) — a requester widens to a team they belong to.
 import { ref, computed, watch } from "vue";
-import { Autocomplete, Button, Dialog, FormControl, toast } from "frappe-ui";
+import { Button, Dialog, FormControl, toast } from "frappe-ui";
 import { promotableTargetRoles } from "@/api/skills";
 
 const props = defineProps({
@@ -98,6 +123,13 @@ const rolesLoading = ref(false);
 
 const dialogTitle = computed(() => `Request promotion — ${props.noun}`);
 const roleOptions = computed(() => roles.value.map((r) => ({ label: r, value: r })));
+const roleQuery = ref("");
+// Client-side filter for the inline role list (see the template note on why this
+// is a plain input + list rather than the portaled Autocomplete search).
+const filteredRoles = computed(() => {
+	const q = roleQuery.value.trim().toLowerCase();
+	return q ? roles.value.filter((r) => r.toLowerCase().includes(q)) : roles.value;
+});
 const canSubmit = computed(
 	() => !!toScope.value && (toScope.value !== "Role" || !!targetRole.value)
 );
@@ -130,6 +162,7 @@ watch(
 		if (!open) return;
 		toScope.value = "Org";
 		targetRole.value = "";
+		roleQuery.value = "";
 		note.value = "";
 		loadRoles();
 	}

--- a/frontend/src/pages/skills/WikiTab.spec.js
+++ b/frontend/src/pages/skills/WikiTab.spec.js
@@ -24,7 +24,9 @@ vi.mock("frappe-ui", () => ({
 	Popover: {},
 	Tooltip: {},
 }));
-vi.mock("@/data/session", () => ({ sessionUser: { value: "a@x.com" } }));
+// sessionUser is a FUNCTION (slugPreview calls sessionUser()), not a ref — an
+// object mock throws the moment the create dialog computes a User-scope slug.
+vi.mock("@/data/session", () => ({ sessionUser: () => "a@x.com" }));
 // jsdom here has no usable localStorage, and useListPage's persisted view state is
 // beside the point for this test.
 vi.mock("@vueuse/core", async (importOriginal) => {
@@ -45,6 +47,7 @@ vi.mock("@/api/wiki", () => ({
 }));
 
 import WikiTab from "./WikiTab.vue";
+import { getWikiCaps, createWikiPage } from "@/api/wiki";
 
 async function label(raw) {
 	const w = mount(WikiTab, { shallow: true });
@@ -76,5 +79,53 @@ describe("wiki mirror sync label", () => {
 
 	it("degrades an unrecognised status instead of passing it through", async () => {
 		expect(await label("weird_new_backend_state")).toBe("Status unavailable");
+	});
+});
+
+describe("wiki role-scope create", () => {
+	it("defaults to Role and creates a Role page with the picked target_role", async () => {
+		getWikiCaps.mockResolvedValueOnce({
+			is_sm: false,
+			creatable_scopes: ["Role", "User"],
+			manageable_roles: ["Sales User"],
+		});
+		createWikiPage.mockResolvedValueOnce({ ok: true, slug: "process--note--r-sales-user" });
+		const w = mount(WikiTab, { shallow: true });
+		await flushPromises();
+		// the role picker is populated straight from caps.manageable_roles
+		expect(w.vm.roleSelectOptions).toEqual([{ label: "Sales User", value: "Sales User" }]);
+		w.vm.openCreate();
+		expect(w.vm.createDialog.scope).toBe("Role");
+		w.vm.createDialog.title = "Note";
+		w.vm.createDialog.page_type = "Process";
+		// a Role page cannot submit until a role is chosen
+		expect(w.vm.canCreate).toBe(false);
+		w.vm.createDialog.target_role = "Sales User";
+		expect(w.vm.canCreate).toBe(true);
+		await w.vm.doCreate();
+		expect(createWikiPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope: "Role",
+				target_role: "Sales User",
+				page_type: "Process",
+			})
+		);
+	});
+
+	it("never offers or defaults to Role when no roles are manageable", async () => {
+		// The backend hides Role from creatable_scopes when manageable_roles is
+		// empty (e.g. a Jarvis Admin with only blanket roles), so the dialog opens
+		// on a usable scope and never strands on an empty role picker.
+		getWikiCaps.mockResolvedValueOnce({
+			is_sm: false,
+			creatable_scopes: ["User"],
+			manageable_roles: [],
+		});
+		const w = mount(WikiTab, { shallow: true });
+		await flushPromises();
+		expect(w.vm.roleSelectOptions).toEqual([]);
+		expect(w.vm.scopeSelectOptions.map((o) => o.value)).not.toContain("Role");
+		w.vm.openCreate();
+		expect(w.vm.createDialog.scope).toBe("User");
 	});
 });

--- a/frontend/src/pages/support/SupportThreadPage.vue
+++ b/frontend/src/pages/support/SupportThreadPage.vue
@@ -47,36 +47,9 @@
 				     so bubbles/rows read as a chat thread instead of stretching
 				     full-bleed with the user's replies hugging the far edge. -->
 				<div class="jv-sup-thread-inner">
-					<!-- Ticket-level fallback only: files a NEW ticket's opening message
-					     attaches now ride the opening Communication and render inline
-					     in that bubble instead (see SupportNewPage's openingComm). This
-					     block only ever fires for a ticket opened before that shipped,
-					     or on a Helpdesk build that doesn't auto-mirror the opening
-					     message - hence the caption, so a legacy cluster of files reads
-					     as "from opening this ticket", not as an unexplained orphan list. -->
-					<div v-if="ticketAttachments.length" class="jv-sup-files-wrap">
-						<span class="jv-sup-files-label"
-							>Attached when this ticket was opened</span
-						>
-						<div class="jv-sup-files">
-							<!-- Same filename-chip treatment as every other attachment (see
-							     Message's imagesAsChips) - an image here used to get a bare
-							     56px crop with no name at all, worse than the "vague" preview
-							     everything else was fixed for. -->
-							<a
-								v-for="a in ticketAttachments"
-								:key="a.name"
-								class="jv-sup-file"
-								:href="a.file_url"
-								target="_blank"
-								rel="noopener"
-							>
-								<FeatherIcon name="paperclip" class="jv-sup-file-clip" />{{
-									a.title
-								}}
-							</a>
-						</div>
-					</div>
+					<!-- Opening (ticket-level) attachments are merged into the opening
+					     message by displayMessages, so they read as part of that message
+					     instead of a captioned slab above the thread. -->
 
 					<!-- Reachable: a brand-new ticket created with an empty body and no
 					     files has zero Communications (the initial text is the HD Ticket's
@@ -258,7 +231,8 @@ function attachmentsOf(m) {
 	return ((m && m.attachments) || []).map(classifyAttachment);
 }
 
-// Ticket-level attachments (shown above the message list) share classifyAttachment
+// Ticket-level attachments (merged into the opening message by displayMessages)
+// share classifyAttachment
 // with the per-message path below, so `.type` still gets computed here - but the
 // template no longer branches on it (every support attachment, ticket-level or
 // per-message, renders as a plain paperclip+filename chip now; no image preview).
@@ -285,7 +259,7 @@ function downloadUrl(fileUrl) {
 // chat) so it can never split a day group of its own accord.
 const displayMessages = computed(() => {
 	let prevDay = "";
-	return store.thread.messages.map((m) => {
+	const rows = store.thread.messages.map((m) => {
 		const support = fromSupport(m);
 		const day = dayLabel(m.creation);
 		const dayDivider = day && day !== prevDay ? day : "";
@@ -302,6 +276,40 @@ const displayMessages = computed(() => {
 			dayDivider,
 		};
 	});
+	// Opening (ticket-level) files render WITH the opening message, not in a
+	// captioned slab above the thread: the CP only lists a file ticket-level when
+	// the opening message wasn't auto-mirrored to a Communication, so from the
+	// user's seat those files belong to the message they opened the ticket with.
+	// Merge them onto the first message when it is the customer's (never a Support
+	// reply); if the opening text isn't a Communication at all, carry them in a
+	// synthetic opening bubble. Dedup by file_url so a file already inline on a
+	// message never double-renders (guard for a CP that BOTH threads AND lists it).
+	const opening = ticketAttachments.value;
+	if (opening.length) {
+		const inline = new Set(
+			rows.flatMap((r) => r.attachments.map((a) => a.file_url)).filter(Boolean)
+		);
+		const fresh = opening.filter((a) => !inline.has(a.file_url));
+		if (fresh.length) {
+			const first = rows[0];
+			if (first && !first.fromSupport) {
+				first.attachments = [...fresh, ...first.attachments];
+			} else {
+				rows.unshift({
+					key: "__opening-attachments__",
+					variant: "bubble",
+					html: "",
+					attachments: fresh,
+					sender: "",
+					timestamp: "",
+					timestampFull: "",
+					fromSupport: false,
+					dayDivider: "",
+				});
+			}
+		}
+	}
+	return rows;
 });
 
 // M10: named for what this actually does — it calls store.closeTicket and the
@@ -614,46 +622,6 @@ watch(ticketName, (n) => open(n));
 	gap: 10px;
 	padding: 48px 0;
 	color: var(--text-2);
-}
-.jv-sup-files-wrap {
-	margin-bottom: 12px;
-}
-.jv-sup-files-label {
-	display: block;
-	margin-bottom: 6px;
-	font-size: 11.5px;
-	color: var(--text-3);
-}
-.jv-sup-files {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-/* Same shape as a per-message attachment chip (Message.vue's .jv-file-chip) -
-   radius, padding, font-size, icon size all match, so a file attached at
-   ticket-open time and one attached in a reply read as the same kind of
-   object, not two different ones a few pixels apart. */
-.jv-sup-file {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	padding: 6px 11px;
-	border: 1px solid var(--border);
-	border-radius: 10px;
-	background: var(--surface-2);
-	color: var(--link);
-	font-size: 12.5px;
-	line-height: 1.3;
-	text-decoration: none;
-	overflow-wrap: anywhere;
-}
-.jv-sup-file:hover {
-	text-decoration: underline;
-}
-.jv-sup-file-clip {
-	flex: 0 0 auto;
-	width: 13px;
-	height: 13px;
 }
 .jv-sup-avatar {
 	display: flex;

--- a/frontend/tests/support-extraction/support-thread.test.js
+++ b/frontend/tests/support-extraction/support-thread.test.js
@@ -241,35 +241,52 @@ describe("SupportThreadPage", () => {
 		expect(atts[0].type).toBe("file");
 	});
 
-	it("links ticket-level attachments through the authenticated proxy", () => {
+	it("merges ticket-level opening attachments into the opening message, proxy-authenticated", () => {
+		// The opening file used to render in a captioned slab ABOVE the thread; it
+		// now rides the opening message itself (the message the customer opened the
+		// ticket with — "Received"), still through the authenticated download proxy.
 		storeDouble.thread.attachments = [{ file_url: "/files/spec.pdf", file_name: "spec.pdf" }];
-		const w = mountWith([{ sent_or_received: "Sent", content: "<p>hi</p>" }]);
-		const link = w.find(".jv-sup-file");
-		expect(link.exists()).toBe(true);
-		expect(link.attributes("href")).toContain("jarvis.support.media.download");
-		expect(link.attributes("href")).toContain("spec.pdf");
+		const w = mountWith([{ sent_or_received: "Received", content: "<p>hi</p>" }]);
+		const atts = w.findComponent({ name: "Message" }).props("attachments");
+		const spec = atts.find((a) => a.title === "spec.pdf");
+		expect(spec).toBeTruthy();
+		expect(spec.file_url).toContain("jarvis.support.media.download");
+		expect(spec.file_url).toContain("spec.pdf");
 		storeDouble.thread.attachments = [];
 	});
 
-	it("renders every ticket-level attachment as the same file chip, images included", () => {
-		// Images get no special inline-thumbnail treatment here (or per-message,
-		// see images-as-chips above) - a cropped preview read worse than a plain
-		// filename the user clicks, per support feedback. Both shapes are
-		// {file_url, file_name} from the CP.
+	it("renders every opening attachment as the same file chip, images included", () => {
+		// Images get no special inline-thumbnail treatment (images-as-chips) - a
+		// cropped preview read worse than a plain filename the user clicks. Both
+		// shapes are {file_url, file_name} from the CP.
 		storeDouble.thread.attachments = [
 			{ file_url: "/files/shot.png", file_name: "shot.png" },
 			{ file_url: "/files/spec.pdf", file_name: "spec.pdf" },
 		];
-		const w = mountWith([{ sent_or_received: "Sent", content: "<p>hi</p>" }]);
+		const w = mountWith([{ sent_or_received: "Received", content: "<p>hi</p>" }]);
 
-		const links = w.findAll(".jv-sup-file");
-		expect(links).toHaveLength(2);
-		expect(links[0].text()).toContain("shot.png");
-		expect(links[0].attributes("href")).toContain("jarvis.support.media.download");
-		expect(links[0].find("img").exists()).toBe(false);
-		expect(links[1].text()).toContain("spec.pdf");
-		expect(links[1].find("img").exists()).toBe(false);
+		const atts = w.findComponent({ name: "Message" }).props("attachments");
+		const titles = atts.map((a) => a.title);
+		expect(titles).toContain("shot.png");
+		expect(titles).toContain("spec.pdf");
+		// image renders as a file chip, never an inline <img>
+		const chips = w.findAll(".jv-file-chip");
+		expect(chips.some((c) => c.text().includes("shot.png"))).toBe(true);
+		expect(w.find(".jv-file-chip img").exists()).toBe(false);
 
+		storeDouble.thread.attachments = [];
+	});
+
+	it("carries opening attachments in a synthetic customer bubble when the first message is a Support reply", () => {
+		// If the opening text was never mirrored to a Communication, the first
+		// Communication can be a Support reply. The customer's opening files must
+		// NOT land on the agent's bubble — they get their own opening bubble.
+		storeDouble.thread.attachments = [{ file_url: "/files/spec.pdf", file_name: "spec.pdf" }];
+		const w = mountWith([{ sent_or_received: "Sent", content: "<p>agent first</p>" }]);
+		const msgs = w.findAllComponents({ name: "Message" });
+		expect(msgs).toHaveLength(2);
+		expect(msgs[0].props("variant")).toBe("bubble");
+		expect(msgs[0].props("attachments").some((a) => a.title === "spec.pdf")).toBe(true);
 		storeDouble.thread.attachments = [];
 	});
 

--- a/jarvis/chat/wiki_permissions.py
+++ b/jarvis/chat/wiki_permissions.py
@@ -136,7 +136,12 @@ def creatable_scopes(user: str | None = None) -> list[str]:
 		return ["Org", "Role", "User"]
 	roles = set(frappe.get_roles(user))
 	out: list[str] = []
-	if _is_wiki_manager(roles):
+	# Only offer Role when the curator actually holds a targetable role. A wiki
+	# manager who holds only blanket roles (e.g. a Jarvis Admin with no
+	# department role) has an empty manageable_roles(); offering "Role" there
+	# stranded the New-page dialog on scope=Role with an empty, unsubmittable
+	# role picker (creatable_scopes and manageable_roles must agree).
+	if _is_wiki_manager(roles) and manageable_roles(user):
 		out.append("Role")
 	if _is_wiki_user(roles):
 		out.append("User")

--- a/jarvis/tests/test_wiki_scopes_api.py
+++ b/jarvis/tests/test_wiki_scopes_api.py
@@ -16,7 +16,7 @@ from frappe.utils import add_to_date, now_datetime
 
 from jarvis.chat import wiki
 from jarvis.exceptions import PermissionDeniedError
-from jarvis.permissions import JARVIS_USER_ROLE
+from jarvis.permissions import JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE
 from jarvis.tools.read_wiki import read_wiki
 from jarvis.tools.update_wiki import update_wiki
 
@@ -191,6 +191,29 @@ class TestWikiCapsAndLanguage(_WikiScopeFixture):
 		self.assertTrue(caps["is_sm"])
 		self.assertEqual(set(caps["creatable_scopes"]), {"Org", "Role", "User"})
 		self.assertIn(TEST_ROLE, caps["manageable_roles"])
+
+	def test_manager_with_no_targetable_roles_hides_role_scope(self):
+		# A wiki manager (here a Jarvis Admin) who holds only blanket roles has an
+		# empty manageable_roles: JARVIS_ADMIN_ROLE / JARVIS_USER_ROLE / "Desk User"
+		# are all in _NON_TARGETABLE_ROLES. creatable_scopes must NOT offer "Role"
+		# then, or the New-page dialog strands on scope=Role with an empty,
+		# unsubmittable picker. "User" is still offered (an admin is a wiki user).
+		email = "wkscope-admin@test.invalid"
+		_ensure_user(email, "Wkscope Admin", ["Desk User", JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE])
+		frappe.clear_cache(user=email)
+		frappe.db.commit()
+		try:
+			frappe.set_user(email)
+			caps = wiki.get_wiki_caps()
+			self.assertFalse(caps["is_sm"])
+			self.assertEqual(caps["manageable_roles"], [])
+			self.assertNotIn("Role", caps["creatable_scopes"])
+			self.assertIn("User", caps["creatable_scopes"])
+		finally:
+			frappe.set_user("Administrator")
+			if frappe.db.exists("User", email):
+				frappe.delete_doc("User", email, ignore_permissions=True, force=True)
+			frappe.db.commit()
 
 	def test_caps_guest_rejected(self):
 		frappe.set_user("Guest")


### PR DESCRIPTION
## What

Three independent, tested fixes to the customer SPA and wiki permissions.

### 1. Support ticket — opening attachments render inline
A ticket's opening-message attachments used to appear in a captioned "Attached
when this ticket was opened" slab *above* the thread (the control plane doesn't
thread the opening file onto a Communication). They now render **inline in the
first message bubble** — merged onto the customer's opening message, or a
synthetic opening bubble when the first Communication is a Support reply —
deduped by `file_url`. Dead `.jv-sup-file` CSS removed. Tests updated.

### 2. Wiki — Role scope no longer offered when there are no targetable roles
`creatable_scopes()` offered "Role" to any wiki manager, but `manageable_roles()`
returns `[]` for a manager holding only blanket roles (e.g. a non-System-Manager
Jarvis Admin), stranding the New-page dialog on `scope=Role` with an empty,
unsubmittable picker. It now offers Role only when `manageable_roles()` is
non-empty. Adds a backend test and the missing frontend role-path coverage (and
fixes `WikiTab.spec`'s `sessionUser` mock, which was an object where the code
calls it as a function).

### 3. Skills — promotion role picker search is now clickable
The "Request promotion" role picker used the frappe-ui `Autocomplete`, whose
search box renders in a popover **portaled outside** the reka-ui `Dialog`, where
the Dialog's focus scope left it unclickable/untypeable. Replaced with an
**inline search box + clickable list** that lives inside the Dialog. Fixes both
wiki and skill promotion.

## Tests
- `run-tests --app jarvis --module jarvis.tests.test_wiki_scopes_api` — 39 pass.
- Frontend vitest full suite — 1181 pass (support-thread, WikiTab,
  PromotionRequestDialog included).

## Not in this PR (follow-ups)
- Chat-scroll readability (reply-streaming drag) — under investigation, needs a
  live browser repro to close.
- Skill multi-role promotion — a separate, security-sensitive change.
