### PR TITLE
feat(skills): multi-role skill promotion + reviewer role-trim (with chat-scroll fix)

### DIFF
--- a/frontend/src/api/review.js
+++ b/frontend/src/api/review.js
@@ -87,12 +87,26 @@ export const listSkillPromotions = (p = {}) =>
 // WITHOUT publishing so the reviewer reconfirms the new impact. Returns {ok,
 // status, skill, materialized, push_projection?} on success, or {ok:false, reason,
 // needs_reconfirm?, push_projection?} for a stale/changed/already-decided request.
-export const decideSkillPromotion = (name, approve, note = "", ackProjection = null) =>
+// `approvedRoles` (approve only) is the reviewer-kept SUBSET of a multi-role Role
+// request: the server publishes exactly these roles and refuses any role that was
+// not requested (anti-escalation). Omit / null → the full requested set (back-compat).
+export const decideSkillPromotion = (
+	name,
+	approve,
+	note = "",
+	ackProjection = null,
+	approvedRoles = null
+) =>
 	call(CS + "decide_skill_promotion", {
 		request_name: name,
 		approve: approve ? 1 : 0,
 		note,
 		ack_projection: ackProjection ? JSON.stringify(ackProjection) : "",
+		// Send only on approve with an explicit set; JSON.stringify matches the
+		// server's list|str normalizer (Frappe form-data delivers arrays as strings).
+		...(approve && approvedRoles
+			? { approved_roles: JSON.stringify(Array.from(approvedRoles)) }
+			: {}),
 	});
 
 // Fresh push-budget projection for one Pending promotion, recomputed at the moment

--- a/frontend/src/api/skills.js
+++ b/frontend/src/api/skills.js
@@ -15,9 +15,26 @@ const CS = "jarvis.chat.custom_skills_api.";
 
 // Ask a reviewer to widen one of MY OWN User-scope skills up the ladder
 // (User → Role/Org). Files a Pending request and pings reviewers; the skill is
-// untouched until a reviewer decides. -> { ok, request, skill }
-export const requestSkillPromotion = ({ name, to_scope, target_role = "", note = "" }) =>
-	call(CS + "request_skill_promotion", { name, to_scope, target_role, note });
+// untouched until a reviewer decides. A Role-scope request may name SEVERAL roles
+// (target_roles); the whole set becomes the skill's audience on approval.
+// target_role stays the primary (first) for backward compatibility.
+// -> { ok, request, skill }
+export const requestSkillPromotion = ({
+	name,
+	to_scope,
+	target_role = "",
+	target_roles = [],
+	note = "",
+}) =>
+	call(CS + "request_skill_promotion", {
+		name,
+		to_scope,
+		target_role,
+		// JSON-encoded list, matching the deleteCustomSkillsBulk convention; the
+		// server (_normalize_promotion_roles) decodes the string or a raw list.
+		target_roles: JSON.stringify(Array.from(target_roles || [])),
+		note,
+	});
 
 // My most-recent promotion request for one of my skills, for the status chip.
 // Owner-scoped server-side. -> {} | {name, status, from_scope, to_scope,

--- a/frontend/src/components/skills/PromotionRequestDialog.spec.js
+++ b/frontend/src/components/skills/PromotionRequestDialog.spec.js
@@ -34,7 +34,13 @@ vi.mock("frappe-ui", () => ({
 			<option v-for="o in options || []" :key="o.value" :value="o.value">{{ o.label }}</option>
 		</select><input v-else class="fc-input" :type="type" :placeholder="placeholder" @input="$emit('update:modelValue', $event.target.value)" />`,
 	},
-	Button: { name: "Button", props: ["label", "loading", "disabled"], template: "<button />" },
+	Button: {
+		name: "Button",
+		props: ["label", "loading", "disabled"],
+		emits: ["click"],
+		template: "<button :disabled='disabled' @click=\"$emit('click')\">{{ label }}</button>",
+	},
+	FeatherIcon: { name: "FeatherIcon", props: ["name"], template: "<i class='feather' />" },
 	toast: { error: vi.fn(), success: vi.fn() },
 }));
 
@@ -108,6 +114,67 @@ describe("PromotionRequestDialog role picker", () => {
 		await chooseScope(w, "Role");
 		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(true);
 		await pickRole(w, "Accounts");
+		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(false);
+	});
+
+	it("emits a single target_role and no target_roles in single-select mode", async () => {
+		const w = await openDialog();
+		await chooseScope(w, "Role");
+		await pickRole(w, "Accounts");
+		const send = w.findAll("button").find((b) => b.text() === "Send request");
+		await send.trigger("click");
+		const payload = w.emitted("submit")[0][0];
+		expect(payload.target_role).toBe("Accounts");
+		expect(payload.target_roles).toBeUndefined();
+	});
+});
+
+describe("PromotionRequestDialog multiselect (skills only)", () => {
+	const openMulti = async () => {
+		const w = mount(PromotionRequestDialog, {
+			props: { modelValue: false, noun: "skill", multiple: true },
+		});
+		await w.setProps({ modelValue: true });
+		await flushPromises();
+		return w;
+	};
+	// In multiselect mode the rows are checkboxes, not single-select options.
+	const boxes = (w) => w.findAll('[role="checkbox"]');
+	const pickBox = async (w, name) => {
+		const b = boxes(w).find((x) => x.text() === name);
+		await b.trigger("click");
+		await flushPromises();
+	};
+	const send = (w) => w.findAll("button").find((b) => b.text() === "Send request");
+
+	it("renders roles as toggleable checkboxes and counts the selection", async () => {
+		const w = await openMulti();
+		await chooseScope(w, "Role");
+		expect(boxes(w).map((b) => b.text())).toEqual(["Sales Manager", "Accounts"]);
+		await pickBox(w, "Sales Manager");
+		await pickBox(w, "Accounts");
+		expect(w.text()).toContain("2 roles selected");
+		await pickBox(w, "Sales Manager"); // toggling a selected role removes it
+		expect(w.text()).toContain("1 role selected");
+	});
+
+	it("emits the full target_roles set plus the primary target_role", async () => {
+		const w = await openMulti();
+		await chooseScope(w, "Role");
+		await pickBox(w, "Sales Manager");
+		await pickBox(w, "Accounts");
+		await send(w).trigger("click");
+		const payload = w.emitted("submit")[0][0];
+		expect(payload.to_scope).toBe("Role");
+		expect(payload.target_roles).toEqual(["Sales Manager", "Accounts"]);
+		expect(payload.target_role).toBe("Sales Manager");
+	});
+
+	it("stays un-submittable until at least one role is chosen", async () => {
+		const w = await openMulti();
+		await chooseScope(w, "Role");
+		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(true);
+		await pickBox(w, "Accounts");
 		expect(w.findComponent({ name: "Button" }).props("disabled")).toBe(false);
 	});
 });

--- a/frontend/src/components/skills/PromotionRequestDialog.vue
+++ b/frontend/src/components/skills/PromotionRequestDialog.vue
@@ -16,7 +16,9 @@
 				<p class="text-p-sm text-ink-gray-5">{{ scopeHelp[toScope] }}</p>
 
 				<div v-if="toScope === 'Role'" class="flex flex-col gap-1">
-					<span class="block text-xs text-ink-gray-5">Role</span>
+					<span class="block text-xs text-ink-gray-5">{{
+						multiple ? "Roles" : "Role"
+					}}</span>
 					<template v-if="roleOptions.length">
 						<!-- Inline search + list, NOT the frappe-ui Autocomplete: its search
 						     box renders in a popover portaled OUTSIDE this reka-ui Dialog, where
@@ -28,22 +30,31 @@
 							:modelValue="roleQuery"
 							@update:modelValue="(v) => (roleQuery = v)"
 						/>
-						<div class="max-h-44 overflow-y-auto rounded border" role="listbox">
+						<div
+							class="max-h-44 overflow-y-auto rounded border"
+							:role="multiple ? 'group' : 'listbox'"
+						>
 							<button
 								v-for="r in filteredRoles"
 								:key="r"
 								type="button"
-								role="option"
-								:aria-selected="targetRole === r"
-								class="flex w-full px-3 py-2 text-left text-sm hover:bg-surface-gray-2"
+								:role="multiple ? 'checkbox' : 'option'"
+								:aria-checked="multiple ? isSelected(r) : undefined"
+								:aria-selected="multiple ? undefined : isSelected(r)"
+								class="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-surface-gray-2"
 								:class="
-									targetRole === r
+									isSelected(r)
 										? 'bg-surface-gray-3 font-medium text-ink-gray-9'
 										: 'text-ink-gray-7'
 								"
-								@click="targetRole = r"
+								@click="pick(r)"
 							>
-								{{ r }}
+								<span>{{ r }}</span>
+								<FeatherIcon
+									v-if="isSelected(r)"
+									name="check"
+									class="h-4 w-4 text-ink-gray-7"
+								/>
 							</button>
 							<p
 								v-if="!filteredRoles.length"
@@ -52,6 +63,10 @@
 								No roles match your search.
 							</p>
 						</div>
+						<p v-if="multiple && selected.length" class="text-p-sm text-ink-gray-5">
+							{{ selected.length }} role{{ selected.length === 1 ? "" : "s" }}
+							selected
+						</p>
 					</template>
 					<p v-else-if="!rolesLoading" class="text-p-sm text-ink-gray-5">
 						You hold no roles that can be targeted - promote to the whole org instead,
@@ -92,13 +107,17 @@
 // busy flag. Role options are the requester's OWN targetable roles
 // (promotable_target_roles) — a requester widens to a team they belong to.
 import { ref, computed, watch } from "vue";
-import { Button, Dialog, FormControl, toast } from "frappe-ui";
+import { Button, Dialog, FeatherIcon, FormControl, toast } from "frappe-ui";
 import { promotableTargetRoles } from "@/api/skills";
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
 	noun: { type: String, default: "skill" }, // "skill" | "page"
 	busy: { type: Boolean, default: false },
+	// Multiselect role targeting (skills only). One request names several roles and
+	// the whole set becomes the skill's audience on approval. Wiki pages stay
+	// one-role-per-page, so WikiPageDialog leaves this false (single-select).
+	multiple: { type: Boolean, default: false },
 });
 const emit = defineEmits(["update:modelValue", "submit"]);
 
@@ -116,10 +135,27 @@ const show = computed({
 });
 
 const toScope = ref("Org");
-const targetRole = ref("");
+// The chosen role(s). Always an array so the single- and multi-select paths share
+// one model; single-select just holds at most one. submit() derives target_role
+// (the primary, for backward compatibility + wiki) from selected[0].
+const selected = ref([]);
 const note = ref("");
 const roles = ref([]);
 const rolesLoading = ref(false);
+
+function isSelected(r) {
+	return selected.value.includes(r);
+}
+// Single-select replaces the choice; multiselect toggles the role in/out.
+function pick(r) {
+	if (props.multiple) {
+		selected.value = isSelected(r)
+			? selected.value.filter((x) => x !== r)
+			: [...selected.value, r];
+	} else {
+		selected.value = [r];
+	}
+}
 
 const dialogTitle = computed(() => `Request promotion — ${props.noun}`);
 const roleOptions = computed(() => roles.value.map((r) => ({ label: r, value: r })));
@@ -131,11 +167,13 @@ const filteredRoles = computed(() => {
 	return q ? roles.value.filter((r) => r.toLowerCase().includes(q)) : roles.value;
 });
 const canSubmit = computed(
-	() => !!toScope.value && (toScope.value !== "Role" || !!targetRole.value)
+	() => !!toScope.value && (toScope.value !== "Role" || selected.value.length > 0)
 );
 const verb = computed(() => VERB[props.noun] || "use");
 const scopeHelp = computed(() => ({
-	Role: `Everyone who holds the chosen role will be able to ${verb.value} it.`,
+	Role: props.multiple
+		? `Everyone who holds ANY of the chosen roles will be able to ${verb.value} it.`
+		: `Everyone who holds the chosen role will be able to ${verb.value} it.`,
 	Org: `Everyone in your organisation will be able to ${verb.value} it.`,
 }));
 
@@ -161,7 +199,7 @@ watch(
 	(open) => {
 		if (!open) return;
 		toScope.value = "Org";
-		targetRole.value = "";
+		selected.value = [];
 		roleQuery.value = "";
 		note.value = "";
 		loadRoles();
@@ -170,13 +208,24 @@ watch(
 
 function submit() {
 	if (!canSubmit.value) {
-		toast.error("Pick a role for role-scope promotion.");
+		toast.error(
+			props.multiple
+				? "Pick at least one role for role-scope promotion."
+				: "Pick a role for role-scope promotion."
+		);
 		return;
 	}
-	emit("submit", {
+	const isRole = toScope.value === "Role";
+	const payload = {
 		to_scope: toScope.value,
-		target_role: toScope.value === "Role" ? targetRole.value : "",
+		// The primary role — first of the selection — kept for backward
+		// compatibility and the single-select (wiki) host.
+		target_role: isRole ? selected.value[0] || "" : "",
 		note: (note.value || "").trim(),
-	});
+	};
+	// Only the multiselect (skill) host sends the full set; the backend widens the
+	// skill's audience to every listed role.
+	if (props.multiple) payload.target_roles = isRole ? [...selected.value] : [];
+	emit("submit", payload);
 }
 </script>

--- a/frontend/src/components/skills/PromotionStatusChip.vue
+++ b/frontend/src/components/skills/PromotionStatusChip.vue
@@ -15,14 +15,26 @@ import { Badge, Tooltip } from "frappe-ui";
 import { timeAgo } from "@/utils/datetime";
 
 const props = defineProps({
-	// {} or {status, to_scope, target_role, reviewer, reviewer_name, decided_at, decision_note}
+	// {} or {status, to_scope, target_role, target_roles[], reviewer, reviewer_name, decided_at, decision_note}
 	req: { type: Object, default: null },
 	// "skill" | "page" — used in the tooltip copy.
 	noun: { type: String, default: "skill" },
 });
 
+// The full role set a Role request targets; my_skill_promotion returns
+// `target_roles`, falling back to the single `target_role` for legacy rows.
+function roleList(r) {
+	if (r.target_roles && r.target_roles.length) return r.target_roles;
+	return r.target_role ? [r.target_role] : [];
+}
 function targetLabel(r) {
-	return r.to_scope === "Role" ? `Role: ${r.target_role || "—"}` : "Org";
+	if (r.to_scope !== "Role") return "Org";
+	const roles = roleList(r);
+	if (!roles.length) return "Role: —";
+	if (roles.length === 1) return `Role: ${roles[0]}`;
+	// Keep the chip compact: first two roles, then an overflow count.
+	const shown = roles.slice(0, 2).join(", ");
+	return roles.length > 2 ? `Roles: ${shown} +${roles.length - 2}` : `Roles: ${shown}`;
 }
 
 const status = computed(() => (props.req && props.req.status) || "");
@@ -30,7 +42,14 @@ const theme = computed(() =>
 	status.value === "Approved" ? "green" : status.value === "Rejected" ? "red" : "orange"
 );
 const label = computed(() => {
-	if (status.value === "Approved") return `Promoted to ${targetLabel(props.req)}`;
+	const r = props.req || {};
+	if (status.value === "Approved")
+		// A reviewer may approve a SUBSET of the requested roles; `target_roles` is the
+		// ASK, not the grant. When the decision note records a trim, don't enumerate the
+		// requested roles as if granted — the exact granted set is in the tooltip.
+		return (r.decision_note || "").trim()
+			? "Promotion approved"
+			: `Promoted to ${targetLabel(r)}`;
 	if (status.value === "Rejected") return "Promotion rejected";
 	return "Promotion requested";
 });
@@ -42,9 +61,14 @@ const tip = computed(() => {
 		)} — awaiting a reviewer.`;
 	const who = r.reviewer_name || r.reviewer || "a reviewer";
 	const when = r.decided_at ? ` ${timeAgo(r.decided_at)}` : "";
+	const note = (r.decision_note || "").trim();
 	if (status.value === "Approved")
-		return `Approved by ${who}${when}. Now visible to ${targetLabel(r)}.`;
-	const reason = (r.decision_note || "").trim();
-	return `Rejected by ${who}${when}.` + (reason ? ` Reason: ${reason}` : " No reason given.");
+		// The decision note carries the ACTUAL granted roles when the reviewer trimmed
+		// the request (it names the kept set); prefer it over the requested-role label so
+		// the audience is never overstated. No note => the full requested set was granted.
+		return note
+			? `Approved by ${who}${when}. ${note}`
+			: `Approved by ${who}${when}. Now visible to ${targetLabel(r)}.`;
+	return `Rejected by ${who}${when}.` + (note ? ` Reason: ${note}` : " No reason given.");
 });
 </script>

--- a/frontend/src/lib/chatScroll.js
+++ b/frontend/src/lib/chatScroll.js
@@ -1,0 +1,22 @@
+// Chat auto-scroll invariant — extracted so the "don't drag the reader while a
+// reply streams" rule is unit-testable in isolation from the (huge) ChatView SFC.
+//
+// Content-driven scroll (streamed text, late-loading images/charts) may follow the
+// newest text to the bottom ONLY when ALL of:
+//   * pinned        — the reader is parked at the bottom (a reader who scrolled up
+//                     is never yanked down);
+//   * NOT streaming — the turn is settled. `convStreaming` stays true across the
+//                     WHOLE turn (set at send / run:start, cleared only at
+//                     run:end / run:error), so it covers the gaps BETWEEN deltas;
+//   * NOT revealPending — the paced reveal has drained. This OUTLIVES streaming
+//                     past a late run:end, so the trailing reveal animation does
+//                     not drag either.
+//
+// The bug this guards ("text keeps moving up"): following the bottom on every
+// streamed chunk dragged the line being read up and off the top of a long answer.
+// An earlier fix keyed only on `revealPending`, but the paced reveal EMPTIES
+// between deltas, so each gap briefly re-enabled following and it still dragged —
+// which is why `streaming` (true for the whole turn) is the load-bearing term.
+export function shouldFollowBottom({ pinned, streaming, revealPending }) {
+	return !!pinned && !streaming && !revealPending;
+}

--- a/frontend/src/lib/chatScroll.spec.js
+++ b/frontend/src/lib/chatScroll.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { shouldFollowBottom } from "./chatScroll";
+
+/**
+ * Regression guard for the "text keeps moving up" chat-scroll bug.
+ *
+ * While a reply streams, the view must NOT chase the bottom on every chunk — doing
+ * so dragged the line being read up and off the top of a long answer. Following is
+ * allowed ONLY when the reader is parked at the bottom AND the turn is fully settled
+ * (not streaming AND the paced reveal has drained). The load-bearing case is #4: an
+ * earlier fix keyed only on the reveal queue, which EMPTIES between deltas, so each
+ * gap re-enabled following mid-stream and it still dragged. `streaming` stays true
+ * across the whole turn and is what closes that hole.
+ */
+describe("shouldFollowBottom", () => {
+	it("follows when pinned and the turn is fully settled", () => {
+		expect(shouldFollowBottom({ pinned: true, streaming: false, revealPending: 0 })).toBe(
+			true
+		);
+	});
+
+	it("does NOT follow when the reader has scrolled up (not pinned)", () => {
+		expect(shouldFollowBottom({ pinned: false, streaming: false, revealPending: 0 })).toBe(
+			false
+		);
+	});
+
+	it("does NOT follow while a reply is streaming, even if pinned", () => {
+		expect(shouldFollowBottom({ pinned: true, streaming: true, revealPending: 5 })).toBe(
+			false
+		);
+	});
+
+	// The specific regression: mid-stream, the paced reveal has momentarily drained
+	// (revealPending === 0) in the gap between two deltas. Following here is exactly
+	// what dragged the reader; `streaming` must still block it.
+	it("does NOT follow between deltas mid-stream (reveal drained but still streaming)", () => {
+		expect(shouldFollowBottom({ pinned: true, streaming: true, revealPending: 0 })).toBe(
+			false
+		);
+	});
+
+	// The trailing reveal animation can outlive run:end (streaming already false), so
+	// a non-empty reveal queue must still hold following off until it drains.
+	it("does NOT follow during the post-run:end reveal tail", () => {
+		expect(shouldFollowBottom({ pinned: true, streaming: false, revealPending: 3 })).toBe(
+			false
+		);
+	});
+
+	it("resumes following once settled, so late images keep a pinned reader at the bottom", () => {
+		// Same inputs as a late image/chart load after the turn ended.
+		expect(shouldFollowBottom({ pinned: true, streaming: false, revealPending: 0 })).toBe(
+			true
+		);
+	});
+});

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -1064,6 +1064,57 @@
 									</span>
 								</div>
 
+								<!-- Multi-role audience. While PENDING the reviewer sees every requested
+								     role and may drop some before approving: the KEPT set (chips not struck
+								     through) is exactly what gets published, and a dropped role can be added
+								     back. Once DECIDED these are the REQUESTED roles shown statically (all
+								     solid, no trim styling); the roles actually GRANTED live in the decision
+								     note, since the request's role set is kept immutable as the original ask. -->
+								<div
+									v-if="p.to_scope === 'Role' && promoRolesFor(p).length"
+									class="mt-2 flex flex-wrap items-center gap-1.5"
+								>
+									<span class="text-sm text-ink-gray-5">{{
+										p.status === "Pending"
+											? "Grant to roles:"
+											: "Requested roles:"
+									}}</span>
+									<span
+										v-for="r in promoRolesFor(p)"
+										:key="r"
+										class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-sm"
+										:class="
+											p.status !== 'Pending' || isRoleKept(p, r)
+												? 'border-outline-gray-2 bg-surface-gray-2 text-ink-gray-8'
+												: 'border-dashed border-outline-gray-2 text-ink-gray-4 line-through'
+										"
+									>
+										{{ r }}
+										<button
+											v-if="p.status === 'Pending' && !isMyPromo(p)"
+											type="button"
+											class="-mr-0.5 text-ink-gray-5 hover:text-ink-gray-8"
+											:title="
+												isRoleKept(p, r)
+													? 'Remove this role from the approval'
+													: 'Add this role back'
+											"
+											@click="toggleRole(p, r)"
+										>
+											<FeatherIcon
+												:name="isRoleKept(p, r) ? 'x' : 'plus'"
+												class="size-3.5"
+											/>
+										</button>
+									</span>
+									<span
+										v-if="p.status === 'Pending' && !keptRolesFor(p).length"
+										class="text-sm text-ink-red-4"
+									>
+										Keep at least one role, or reject.
+									</span>
+								</div>
+
 								<!-- requester + when -->
 								<div
 									class="mt-2 flex flex-wrap items-center gap-2 text-sm text-ink-gray-6"
@@ -1152,7 +1203,11 @@
 											theme="green"
 											label="Approve"
 											:loading="skillPromoActing === p.name"
-											:disabled="!!skillPromoActing || isMyPromo(p)"
+											:disabled="
+												!!skillPromoActing ||
+												isMyPromo(p) ||
+												(p.to_scope === 'Role' && !keptRolesFor(p).length)
+											"
 											@click="approveSkillPromotion(p)"
 										/>
 										<Button
@@ -1948,6 +2003,32 @@ const skillPromoLoaded = ref(false);
 const skillPromoActing = ref(""); // skill promotion request name currently deciding
 const skillPromoExpanded = reactive({}); // name -> bool (un-clamp the instructions excerpt)
 const skillPromoReject = reactive({ show: false, p: null, reason: "" });
+// Multi-role reviewer trim: per-request KEPT role set. Absent key => default to the
+// full requested set (no mutation during render). Toggling writes an explicit array
+// here; the approve payload sends exactly this (the server refuses any role outside
+// the request). Keyed by request name, so it survives the needs_reconfirm re-open.
+const skillPromoKept = reactive({});
+// The full ordered role set a request targets (child rows, or the legacy scalar).
+function promoRolesFor(p) {
+	if (p.target_roles && p.target_roles.length) return p.target_roles;
+	return p.target_role ? [p.target_role] : [];
+}
+function keptRolesFor(p) {
+	return skillPromoKept[p.name] ?? promoRolesFor(p);
+}
+function isRoleKept(p, r) {
+	return keptRolesFor(p).includes(r);
+}
+// Toggle a role in/out of the kept set. Re-adding restores the ORIGINAL requested
+// order so the published primary (first) is stable regardless of click order.
+function toggleRole(p, r) {
+	const kept = keptRolesFor(p);
+	if (kept.includes(r)) {
+		skillPromoKept[p.name] = kept.filter((x) => x !== r);
+	} else {
+		skillPromoKept[p.name] = promoRolesFor(p).filter((x) => x === r || kept.includes(x));
+	}
+}
 // "Ask the user" follow-up dialog, shared by pattern + promotion cards. `name`
 // is the review-item name (a Jarvis Learned Pattern or a promotion request).
 const askDialog = reactive({ show: false, name: "", ask: "", sending: false });
@@ -2277,8 +2358,15 @@ function budgetWarn(p) {
 // and refuses to publish (asking for a fresh confirm) if the catalog moved again
 // (R2-SP-5). Publishing the snapshot is irreversible from the requester's side.
 async function approveSkillPromotion(p) {
-	const target = p.to_scope === "Role" ? `Role: ${esc(p.target_role || "—")}` : "Org";
-	const who = p.to_scope === "Role" ? "that role" : "everyone";
+	// Confirm + publish the KEPT roles (the reviewer may have trimmed the request),
+	// not the original ask. keptRolesFor reads the live per-request selection.
+	const kept = keptRolesFor(p);
+	const target =
+		p.to_scope === "Role"
+			? `Role${kept.length === 1 ? "" : "s"}: ${esc(kept.join(", ") || "—")}`
+			: "Org";
+	const who =
+		p.to_scope === "Role" ? (kept.length === 1 ? "that role" : "those roles") : "everyone";
 	// Recompute the budget truth fresh; fall back to the list-load projection if the
 	// preflight call fails (never block the decision on a warning fetch).
 	let ackProjection = p.push_projection || null;
@@ -2310,7 +2398,9 @@ async function approveSkillPromotion(p) {
 		message,
 		onConfirm: async ({ hideDialog }) => {
 			hideDialog();
-			await decideSkillPromo(p, 1, "", ackProjection);
+			// Re-read the kept set at confirm time; send only for Role scope.
+			const approved = p.to_scope === "Role" ? keptRolesFor(p) : null;
+			await decideSkillPromo(p, 1, "", ackProjection, approved);
 		},
 	});
 }
@@ -2328,10 +2418,10 @@ async function submitSkillPromoReject() {
 	);
 	if (ok) skillPromoReject.show = false;
 }
-async function decideSkillPromo(p, approve, note, ackProjection = null) {
+async function decideSkillPromo(p, approve, note, ackProjection = null, approvedRoles = null) {
 	skillPromoActing.value = p.name;
 	try {
-		const r = await decideSkillPromotion(p.name, approve, note, ackProjection);
+		const r = await decideSkillPromotion(p.name, approve, note, ackProjection, approvedRoles);
 		if (r && r.needs_reconfirm) {
 			// R2-SP-5: the shared catalog moved since the reviewer's ack, so the
 			// server published NOTHING. Refresh the row's projection and re-open the

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -1059,7 +1059,11 @@
 										<Badge
 											variant="subtle"
 											theme="blue"
-											:label="toScopeLabel(p)"
+											:label="
+												p.to_scope === 'Role'
+													? 'Role'
+													: p.to_scope || 'Org'
+											"
 										/>
 									</span>
 								</div>

--- a/frontend/src/pages/skills/SkillDetail.vue
+++ b/frontend/src/pages/skills/SkillDetail.vue
@@ -189,6 +189,7 @@
 		v-model="promoDialog"
 		noun="skill"
 		:busy="promoBusy"
+		:multiple="true"
 		@submit="submitPromotion"
 	/>
 
@@ -364,10 +365,16 @@ async function loadMyPromo() {
 	}
 }
 
-async function submitPromotion({ to_scope, target_role, note }) {
+async function submitPromotion({ to_scope, target_role, target_roles, note }) {
 	promoBusy.value = true;
 	try {
-		await requestSkillPromotion({ name: props.id, to_scope, target_role, note });
+		await requestSkillPromotion({
+			name: props.id,
+			to_scope,
+			target_role,
+			target_roles,
+			note,
+		});
 		promoDialog.value = false;
 		toast.success("Promotion requested — a reviewer will decide.");
 		await loadMyPromo();

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3836,6 +3836,7 @@ import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { normaliseAction } from "@/lib/chatAction";
 import { stripBlocks } from "@/lib/chatBlocks";
+import { shouldFollowBottom } from "@/lib/chatScroll";
 import { createRevealer } from "@/lib/streamReveal";
 import { sortPendingCards } from "@/lib/sortPendingCards";
 import { errMessage, turnErrorInfo } from "@/lib/errors";
@@ -4603,9 +4604,13 @@ function revealFrame() {
 		if (!_applyRevealed(id, step.text)) revealer.drop(id);
 		else painted = true;
 	}
-	// Scroll rides the reveal, not the socket: following the text as it appears
-	// is what keeps a long answer readable while it writes itself.
-	if (painted) scrollBottomIfPinned();
+	// The reveal is the streamed answer writing itself; it must NOT chase the
+	// bottom. Following the reveal dragged the line being read up and off the top
+	// of a long answer (the "text keeps moving up" report), in an already-full
+	// chat just as much as a fresh one. The answer grows downward instead; only
+	// the jump-to-latest arrow is kept honest so the reader can snap to the newest
+	// when they choose. The one-time land on the new turn still happens at send.
+	if (painted) showScrollDown.value = distanceFromBottom() > 140;
 	if (revealer.pending().length) _revealRaf = requestAnimationFrame(revealFrame);
 }
 function pumpReveal() {
@@ -6994,18 +6999,35 @@ function scrollBottom(smooth = false) {
 	if (smooth && "scrollTo" in el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
 	else el.scrollTop = el.scrollHeight;
 }
-// Content-driven scroll: only follow the newest text while the reader is already
-// parked at the bottom. Streaming a long reply used to call scrollBottom() on
-// every chunk, which dragged the view down mid-sentence and made a big answer
-// unreadable until the turn ended. When the reader HAS scrolled up we leave the
-// viewport alone and let onThreadScroll reveal the jump-to-latest arrow instead.
-// Only user-initiated moments (opening a chat, sending a message) scroll
-// unconditionally.
+// Content-driven scroll: follow the newest text ONLY when the reader is parked at
+// the bottom AND the turn is fully settled. "Settled" needs BOTH signals, because
+// neither alone is enough:
+//   * convStreaming - the conversation is mid-turn. It stays true across the WHOLE
+//     turn (set at send / run:start, cleared only at run:end / run:error), so it
+//     covers the gaps BETWEEN deltas. revealer.pending() alone did NOT: the paced
+//     reveal DRAINS between deltas, so pending() briefly empties in every gap, and
+//     each empty gap let the per-delta scrollBottomIfPinned (fired from the
+//     assistant:delta handler) chase the bottom - dragging the line you were
+//     reading up and off the top (the "text keeps moving up" report). It bit when
+//     pinned started true, i.e. opening a chat that is ALREADY mid-stream.
+//   * revealer.pending() - the paced reveal is still writing. It outlives
+//     convStreaming past a late run:end, so the trailing reveal animation does not
+//     drag either.
+// Only pinned AND not streaming AND reveal-drained do we follow, so a settled chat
+// still keeps a pinned reader on late-loading images/charts. The reply otherwise
+// grows downward and the jump-to-latest arrow snaps to newest on demand. User
+// moments (open, send, arrow) scroll unconditionally.
 function scrollBottomIfPinned() {
-	if (pinnedToBottom.value) {
+	if (
+		shouldFollowBottom({
+			pinned: pinnedToBottom.value,
+			streaming: convStreaming.value,
+			revealPending: revealer.pending().length,
+		})
+	) {
 		scrollBottom();
-		// While following, we are at the newest text by definition — clear any arrow
-		// a mid-growth scroll event flipped on, or it lingers pointing nowhere.
+		// At the newest text by definition here, so clear any arrow a mid-growth
+		// scroll event flipped on, or it lingers pointing nowhere.
 		showScrollDown.value = false;
 		return;
 	}
@@ -7060,7 +7082,13 @@ watch(threadInnerEl, (el) => {
 					return;
 				}
 			}
-			if (pinnedToBottom.value) {
+			if (
+				shouldFollowBottom({
+					pinned: pinnedToBottom.value,
+					streaming: convStreaming.value,
+					revealPending: revealer.pending().length,
+				})
+			) {
 				scrollBottom();
 				showScrollDown.value = false;
 				return;
@@ -7073,6 +7101,12 @@ watch(threadInnerEl, (el) => {
 			else showScrollDown.value = distanceFromBottom() > 140;
 		});
 		threadRO.observe(el);
+		// Also reconcile on VIEWPORT size changes (composer growth, on-screen
+		// keyboard, window resize), not just content growth: a shrinking viewport
+		// pushes content below the fold, and a stale arrow could otherwise linger
+		// showing after the geometry - not new content - changed. The callback
+		// re-reads distanceFromBottom(), so observing the viewport self-heals it.
+		if (threadEl.value) threadRO.observe(threadEl.value);
 	}
 });
 onBeforeUnmount(() => {

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -741,7 +741,11 @@ def _stamp_decision(req, reviewer: str, approved: bool, note: str) -> None:
 
 @frappe.whitelist()
 def decide_skill_promotion(
-	request_name: str, approve: int | str, note: str = "", ack_projection: str | dict | None = None
+	request_name: str,
+	approve: int | str,
+	note: str = "",
+	ack_projection: str | dict | None = None,
+	approved_roles: list | str | None = None,
 ) -> dict:
 	"""Approve or reject a skill promotion request. Reviewer-gated
 	(``require_skill_reviewer``) + four-eyes (a reviewer cannot approve their own
@@ -793,6 +797,37 @@ def decide_skill_promotion(
 		_stamp_decision(req, reviewer, False, note)
 		return out
 
+	# Multi-role reviewer trim: the reviewer may NARROW a Role promotion to a SUBSET
+	# of the roles the requester asked for — approve fewer roles, never more. Adding a
+	# role the requester did not request would let a reviewer grant an audience the
+	# requester was never vetted for (the request-time `promotable_target_roles` gate),
+	# so any role outside the request is refused here. ``approved_roles`` omitted (or a
+	# legacy client) publishes the FULL requested set unchanged; Org has no roles to trim.
+	# Validated BEFORE the catalog lock so a bad payload fails fast without contending.
+	effective_roles = None
+	decision_note = note
+	if (req.to_scope or "") == "Role":
+		requested = _promotion_roles(req.name, req.target_role or "")
+		if approved_roles is None:
+			effective_roles = requested
+		else:
+			kept = _normalize_promotion_roles(approved_roles, "")
+			outside = [r for r in kept if r not in set(requested)]
+			if outside:
+				frappe.throw(
+					_("You can only approve roles that were requested; '{0}' was not.").format(outside[0]),
+					frappe.PermissionError,
+				)
+			if not kept:
+				frappe.throw(_("Keep at least one role to approve, or reject the request instead."))
+			effective_roles = kept
+			if len(kept) < len(requested):
+				# Audit the narrowing: record granted-vs-requested on the decision note.
+				trimmed = _(" [Approved for {0} of {1} requested roles: {2}]").format(
+					len(kept), len(requested), ", ".join(kept)
+				)
+				decision_note = (note + trimmed) if note else trimmed.strip()
+
 	# R3-SP-3: serialize the WHOLE publish — the fresh budget recheck, the
 	# lineage/slug resolution, the materialize and the commit — under ONE CATALOG-WIDE
 	# lock held THROUGH commit. The Org push budget is a catalog-wide resource, not a
@@ -832,12 +867,12 @@ def decide_skill_promotion(
 						"push impact and confirm again."
 					),
 				}
-		out.update(_materialize_promotion(req))
-		_stamp_decision(req, reviewer, True, note)
+		out.update(_materialize_promotion(req, roles=effective_roles))
+		_stamp_decision(req, reviewer, True, decision_note)
 	return out
 
 
-def _materialize_promotion(req) -> dict:
+def _materialize_promotion(req, roles=None) -> dict:
 	"""Publish the reviewed snapshot as a system-owned Role/Org skill (the approve
 	path — CDX-SP-1). The requester's private (User) skill is left intact; the shared
 	copy carries EXACTLY the request-time snapshot content, is owned by the system
@@ -876,13 +911,16 @@ def _materialize_promotion(req) -> dict:
 	instructions = req.get("instructions_snapshot")
 	description = req.get("description_snapshot") or ""
 	user_invocable = int(req.get("user_invocable_snapshot"))
-	# The request's ``target_roles`` child rows are the FULL audience of a Role
-	# promotion; ``target_role`` is the primary (first). Legacy single-role requests
-	# carry no child rows, so fall back to the scalar ``target_role``.
+	# ``roles`` is the reviewer-approved EFFECTIVE audience (the subset the reviewer
+	# kept — validated in ``decide_skill_promotion`` as a subset of the request). When
+	# not passed, fall back to the request's FULL ``target_roles`` child rows, then the
+	# legacy scalar ``target_role`` for pre-child-table rows. ``target_role`` is the
+	# primary (first). An Org promotion carries no roles regardless of what was passed.
 	if req.to_scope == "Role":
-		roles = [r.role for r in (req.get("target_roles") or []) if r.role]
-		if not roles and req.target_role:
-			roles = [req.target_role]
+		if roles is None:
+			roles = [r.role for r in (req.get("target_roles") or []) if r.role]
+			if not roles and req.target_role:
+				roles = [req.target_role]
 	else:
 		roles = []
 	target_role = roles[0] if roles else None
@@ -1146,6 +1184,10 @@ def list_skill_promotion_requests(
 			"from_scope": r.get("from_scope") or "",
 			"to_scope": r.get("to_scope") or "",
 			"target_role": r.get("target_role") or "",
+			# Full ordered role set for a multi-role Role request (computed above via the
+			# batched child-table query); the reviewer card renders every role, and the
+			# approve payload trims from THIS set. Falls back to [target_role] for legacy.
+			"target_roles": r.get("target_roles") or ([r["target_role"]] if r.get("target_role") else []),
 			"note": r.get("note") or "",
 			"status": r.get("status") or "",
 			"requested_by": r.get("owner") or "",

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -618,9 +618,45 @@ def _notify_skill_reviewers(request_name: str | None = None) -> None:
 		pass
 
 
+def _normalize_promotion_roles(target_roles, target_role) -> list[str]:
+	"""Order-preserving, de-duplicated role list from the multi-select payload,
+	falling back to the single ``target_role``. Accepts a Python list or a
+	JSON-encoded list string (Frappe form-data delivers arrays as strings)."""
+	raw = target_roles
+	if isinstance(raw, str):
+		try:
+			raw = frappe.parse_json(raw)
+		except Exception:
+			raw = [raw]
+	if not isinstance(raw, (list, tuple)):
+		raw = []
+	seen: set[str] = set()
+	out: list[str] = []
+	for r in list(raw) + ([target_role] if target_role else []):
+		r = str(r).strip() if r else ""
+		if r and r not in seen:
+			seen.add(r)
+			out.append(r)
+	return out
+
+
+def _promotion_roles(req_name: str, target_role: str = "") -> list[str]:
+	"""The ordered role names of a promotion request's ``target_roles`` child
+	table; falls back to the single ``target_role`` for legacy single-role rows."""
+	rows = frappe.get_all(
+		"Jarvis Custom Skill Allowed Role",
+		filters={"parenttype": PROMO, "parent": req_name},
+		pluck="role",
+		order_by="idx asc",
+	)
+	return rows or ([target_role] if target_role else [])
+
+
 @frappe.whitelist()
 @require_jarvis_user
-def request_skill_promotion(name: str, to_scope: str, target_role: str = "", note: str = "") -> dict:
+def request_skill_promotion(
+	name: str, to_scope: str, target_role: str = "", note: str = "", target_roles: list | None = None
+) -> dict:
 	"""Ask a reviewer to widen one of the caller's OWN skills up the scope ladder
 	(User->Role->Org). Files a Pending ``Jarvis Skill Promotion Request`` and
 	pings the reviewer set — the skill itself is untouched; promotion is a
@@ -641,9 +677,23 @@ def request_skill_promotion(name: str, to_scope: str, target_role: str = "", not
 		frappe.throw(_("Promotion target must be Role or Org."))
 	if _SCOPE_RANK.get(to_scope, 0) <= _SCOPE_RANK.get(from_scope, 0):
 		frappe.throw(_("Promotion can only widen a skill's scope."))
-	target_role = (str(target_role).strip() if target_role else "") or None
-	if to_scope == "Role" and not target_role:
-		frappe.throw(_("Promoting to Role scope needs a target role."))
+	# Multi-role: a Role-scope request may name several roles; ``target_role`` is
+	# kept as the primary (first) for display + backward compatibility, and the
+	# full requested audience is ``target_roles``. Only roles the requester may
+	# actually target are accepted - never trust the client's list (this is the
+	# server-side gate the old single-role path lacked).
+	roles = _normalize_promotion_roles(target_roles, target_role)
+	if to_scope == "Role":
+		if not roles:
+			frappe.throw(_("Promoting to Role scope needs a target role."))
+		allowed = set(promotable_target_roles().get("roles") or [])
+		bad = [r for r in roles if r not in allowed]
+		if bad:
+			frappe.throw(_("You cannot promote to these role(s): {0}.").format(", ".join(bad)))
+		target_role = roles[0]
+	else:
+		roles = []
+		target_role = None
 
 	req = frappe.get_doc(
 		{
@@ -661,6 +711,7 @@ def request_skill_promotion(name: str, to_scope: str, target_role: str = "", not
 			"from_scope": from_scope,
 			"to_scope": to_scope,
 			"target_role": target_role if to_scope == "Role" else None,
+			"target_roles": [{"role": r} for r in roles],
 			"note": (note or "").strip()[:140] or None,
 			"status": "Pending",
 		}
@@ -821,20 +872,24 @@ def _materialize_promotion(req) -> dict:
 	instructions = req.get("instructions_snapshot")
 	description = req.get("description_snapshot") or ""
 	user_invocable = int(req.get("user_invocable_snapshot"))
-	target_role = req.target_role if req.to_scope == "Role" else None
-	# A Role promotion writes ``allowed_roles`` ALONGSIDE ``target_role`` (issue #478).
-	# ``target_role`` alone is only honoured by the per-doc read paths
-	# (``user_can_use_skill`` / find_skills / get_skill); every path that answers "which
-	# skills may this user invoke" (``_role_scoped_invocable_names``, and through it the
-	# ``/slug`` context clause) matches on the ``allowed_roles`` CHILD ROWS. Writing only
-	# ``target_role`` therefore published a skill that no role-holder could ever trigger
-	# deterministically. Both fields carry the SAME single role, so the audience is
-	# unchanged; this only makes the row visible to the role-matched invocation path.
-	# An Org promotion clears it: an Org row carrying ``allowed_roles`` is a
-	# "role-restricted Org skill", which ``_pushable_org_rows`` deliberately keeps OFF the
-	# shared container push (TASK 11), so a Role->Org widen that left the child row behind
-	# would silently un-push the skill it just widened.
-	allowed_roles = [{"role": target_role}] if target_role else []
+	# The request's ``target_roles`` child rows are the FULL audience of a Role
+	# promotion; ``target_role`` is the primary (first). Legacy single-role requests
+	# carry no child rows, so fall back to the scalar ``target_role``.
+	if req.to_scope == "Role":
+		roles = [r.role for r in (req.get("target_roles") or []) if r.role]
+		if not roles and req.target_role:
+			roles = [req.target_role]
+	else:
+		roles = []
+	target_role = roles[0] if roles else None
+	# ``allowed_roles`` carries the WHOLE set: every path that answers "which skills
+	# may this user invoke" (``_role_scoped_invocable_names`` / the ``/slug`` clause /
+	# the list query) matches on the child rows, and ``user_can_use_skill`` OR-s
+	# ``target_role`` with the ``allowed_roles`` intersection - so all named roles get
+	# access, not just the primary. An Org promotion clears it (an Org row carrying
+	# allowed_roles is a role-restricted Org skill kept OFF the shared container push -
+	# see ``_pushable_org_rows`` / TASK 11).
+	allowed_roles = [{"role": r} for r in roles]
 
 	# R3-SP-2 (lineage by SOURCE link, not slug). The container writes ONE
 	# custom-<slug> dir, so at most one SHARED (Role/Org) copy may carry a given slug —
@@ -983,6 +1038,22 @@ def list_skill_promotion_requests(
 		params,
 		as_dict=True,
 	)
+
+	# Multi-role: attach every request's FULL target_roles set (one batched query),
+	# so the reviewer sees exactly which roles their approval grants access to - not
+	# just the primary target_role. Legacy single-role rows fall back to target_role.
+	_req_names = [r["name"] for r in rows]
+	_role_map: dict[str, list[str]] = {}
+	if _req_names:
+		for _cr in frappe.get_all(
+			"Jarvis Custom Skill Allowed Role",
+			filters={"parenttype": PROMO, "parent": ("in", _req_names)},
+			fields=["parent", "role"],
+			order_by="idx asc",
+		):
+			_role_map.setdefault(_cr.parent, []).append(_cr.role)
+	for r in rows:
+		r["target_roles"] = _role_map.get(r["name"]) or ([r["target_role"]] if r.get("target_role") else [])
 
 	owner_names = list({r["owner"] for r in rows if r.get("owner")})
 	fullnames = {
@@ -1163,6 +1234,7 @@ def my_skill_promotion(name: str) -> dict:
 		"from_scope": r.from_scope or "",
 		"to_scope": r.to_scope or "",
 		"target_role": r.target_role or "",
+		"target_roles": _promotion_roles(r.name, r.target_role or ""),
 		"note": r.note or "",
 		"reviewer": r.reviewer or "",
 		"reviewer_name": _full_name(r.reviewer) if r.reviewer else "",

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -655,7 +655,11 @@ def _promotion_roles(req_name: str, target_role: str = "") -> list[str]:
 @frappe.whitelist()
 @require_jarvis_user
 def request_skill_promotion(
-	name: str, to_scope: str, target_role: str = "", note: str = "", target_roles: list | None = None
+	name: str,
+	to_scope: str,
+	target_role: str = "",
+	note: str = "",
+	target_roles: list | str | None = None,
 ) -> dict:
 	"""Ask a reviewer to widen one of the caller's OWN skills up the scope ladder
 	(User->Role->Org). Files a Pending ``Jarvis Skill Promotion Request`` and

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
@@ -214,22 +214,34 @@ class JarvisCustomSkill(Document):
 			self.target_role = (self.target_role or "").strip() or None
 			if not self.target_role:
 				frappe.throw(_("Role-scope skills need a Target Role."))
-			# ``allowed_roles`` MIRRORS ``target_role`` on EVERY write path (issue #478).
-			# ``target_role`` is the audience of record, but the invocation path
-			# (``custom_skills._role_scoped_invocable_names``, and through it the /slug
-			# context clause) matches on the child rows and is blind to target_role, so a
-			# Role skill with an empty allowed_roles can never be triggered by /slug.
-			# Mirroring HERE rather than only at the promotion seam is what makes a Desk
-			# or REST re-target self-heal: re-pointing target_role rewrites the mirror in
-			# the same save, so the two planes can never disagree about the audience.
-			# Assignment (not append) is deliberate. The audience of a Role skill is
-			# exactly one role, so a stale role left behind by an earlier target would
-			# keep granting /slug to holders the reviewer just re-targeted away from.
-			# Compiler-managed rows are pinned to Org scope and never reach this branch,
-			# so their multi-role allowed_roles is untouched. Nothing is widened: every
-			# role named here is the target_role that ``user_can_use_skill`` already
-			# admitted.
-			self.set("allowed_roles", [{"role": self.target_role}])
+			# The audience of a Role skill is its ``allowed_roles`` set; ``target_role``
+			# is the primary and MUST be one of them. Every path that answers "which
+			# skills may this user invoke" (``_role_scoped_invocable_names`` + the /slug
+			# clause + the list query) matches on the child rows, and ``user_can_use_skill``
+			# OR-s target_role with the allowed_roles intersection - so mirroring here is
+			# what keeps the invocation plane honest.
+			#
+			# Multi-role (issue #478 extended): a promotion materializes the FULL role
+			# set with target_role = its first, and we KEEP that set. But a single-role
+			# create, or a Desk/REST re-target where target_role is changed to a role NOT
+			# in the current set, self-heals to exactly ``[target_role]`` - so re-pointing
+			# still drops stale roles the reviewer targeted away from, and a mismatched or
+			# empty set can never leave the audience wider than intended. Compiler-managed
+			# rows are pinned to Org scope and never reach this branch, so their multi-role
+			# allowed_roles is untouched.
+			existing = [
+				(r.role or "").strip() for r in (self.get("allowed_roles") or []) if (r.role or "").strip()
+			]
+			if self.target_role in existing:
+				seen: set[str] = set()
+				ordered: list[str] = []
+				for r in existing:
+					if r not in seen:
+						seen.add(r)
+						ordered.append(r)
+				self.set("allowed_roles", [{"role": r} for r in ordered])
+			else:
+				self.set("allowed_roles", [{"role": self.target_role}])
 		elif self.scope == "User":
 			# A private skill has no role audience — clear both so a stray
 			# allowed_roles/target_role can never leak it to role-holders (TASK 13

--- a/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.json
+++ b/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.json
@@ -17,6 +17,7 @@
     "from_scope",
     "to_scope",
     "target_role",
+    "target_roles",
     "note",
     "status",
     "reviewer",
@@ -96,7 +97,16 @@
       "label": "Target Role",
       "options": "Role",
       "depends_on": "eval:doc.to_scope=='Role'",
-      "mandatory_depends_on": "eval:doc.to_scope=='Role'"
+      "mandatory_depends_on": "eval:doc.to_scope=='Role'",
+      "description": "Primary target role (the first of target_roles). Kept for backward compatibility and single-role display; the full audience is target_roles."
+    },
+    {
+      "fieldname": "target_roles",
+      "fieldtype": "Table",
+      "label": "Target Roles",
+      "options": "Jarvis Custom Skill Allowed Role",
+      "depends_on": "eval:doc.to_scope=='Role'",
+      "description": "Roles this request asks to share the skill with (Role scope). One approved request materializes a Role skill whose allowed_roles is this whole set; target_role holds the first as the primary."
     },
     {
       "fieldname": "note",

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1658,6 +1658,39 @@ class TestRoleScopedSkillInvocation(Part2Base):
 				src.name, "Role", target_roles=[self.AUD_ROLE, "System Manager"]
 			)
 
+	def test_role_promotion_accepts_json_string_target_roles(self):
+		"""Regression: the SPA sends target_roles as a JSON-encoded STRING (the
+		deleteCustomSkillsBulk convention), so the whitelisted endpoint must accept a
+		str and decode it. The original ``list``-only annotation made Frappe's type
+		validator reject the live request with a FrappeTypeError before any code ran."""
+		import json
+
+		from jarvis.chat import custom_skills_api
+
+		second = "Accounts User"
+		owner = _ensure_user("p2-jsonroles@example.com", ["Jarvis User", self.AUD_ROLE, second])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-jsonroles", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=json.dumps([self.AUD_ROLE, second])
+			)
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(req["request"], 1)
+		self.assertTrue(out["ok"])
+		self.assertEqual(
+			set(
+				frappe.get_all(
+					"Jarvis Custom Skill Allowed Role",
+					filters={"parent": out["materialized"], "parenttype": SKILL},
+					pluck="role",
+				)
+			),
+			{self.AUD_ROLE, second},
+		)
+
 	def test_role_promoted_skill_is_slug_invocable_by_a_role_holder(self):
 		from jarvis.chat.custom_skills import _role_scoped_invocable_names, invoked_skill_clause
 

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1691,6 +1691,163 @@ class TestRoleScopedSkillInvocation(Part2Base):
 			{self.AUD_ROLE, second},
 		)
 
+	# ── reviewer-side role trimming: approve a SUBSET, never widen the ask ──────
+	def test_reviewer_approves_role_subset(self):
+		"""The reviewer may NARROW a multi-role request: approving a kept subset
+		publishes exactly those roles (target_role = the first kept), and a holder of
+		a DROPPED role loses access even though it was requested."""
+		from jarvis.chat import custom_skills_api
+		from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import user_can_use_skill
+
+		second = "Accounts User"
+		owner = _ensure_user("p2-trimowner@example.com", ["Jarvis User", self.AUD_ROLE, second])
+		dropped_holder = _ensure_user("p2-trimdropped@example.com", ["Jarvis User", self.AUD_ROLE])
+		kept_holder = _ensure_user("p2-trimkept@example.com", ["Jarvis User", second])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-trim", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=[self.AUD_ROLE, second]
+			)
+		# Reviewer drops the PRIMARY (Sales User), keeps only Accounts User.
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(req["request"], 1, approved_roles=[second])
+		self.assertTrue(out["ok"])
+		shared = out["materialized"]
+
+		self.assertEqual(frappe.db.get_value(SKILL, shared, "target_role"), second)
+		self.assertEqual(
+			frappe.get_all(
+				"Jarvis Custom Skill Allowed Role",
+				filters={"parent": shared, "parenttype": SKILL},
+				pluck="role",
+			),
+			[second],
+		)
+		doc = frappe.get_doc(SKILL, shared)
+		self.assertTrue(user_can_use_skill(doc, kept_holder, frappe.get_roles(kept_holder)))
+		# The DROPPED role confers no access, though the requester had asked for it.
+		self.assertFalse(user_can_use_skill(doc, dropped_holder, frappe.get_roles(dropped_holder)))
+
+	def test_reviewer_cannot_approve_role_outside_request(self):
+		"""Anti-escalation: the reviewer can only approve roles the requester ASKED
+		for. A role outside the request is refused and NOTHING is published."""
+		from jarvis.chat import custom_skills_api
+
+		owner = _ensure_user("p2-escalowner@example.com", ["Jarvis User", self.AUD_ROLE])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-escal", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(src.name, "Role", target_role=self.AUD_ROLE)
+		with _as(REVIEWER), self.assertRaises(frappe.PermissionError):
+			custom_skills_api.decide_skill_promotion(
+				req["request"], 1, approved_roles=[self.AUD_ROLE, "Accounts User"]
+			)
+		# Nothing published; the request is still Pending and the source still private.
+		self.assertEqual(
+			frappe.db.get_value("Jarvis Skill Promotion Request", req["request"], "status"), "Pending"
+		)
+		self.assertEqual(frappe.db.get_value(SKILL, src.name, "scope"), "User")
+
+	def test_reviewer_cannot_approve_empty_role_set(self):
+		"""Removing ALL roles is not an approval - the reviewer must reject instead."""
+		from jarvis.chat import custom_skills_api
+
+		owner = _ensure_user("p2-emptyowner@example.com", ["Jarvis User", self.AUD_ROLE])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-empty", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(src.name, "Role", target_role=self.AUD_ROLE)
+		with _as(REVIEWER), self.assertRaises(frappe.ValidationError):
+			custom_skills_api.decide_skill_promotion(req["request"], 1, approved_roles=[])
+		self.assertEqual(
+			frappe.db.get_value("Jarvis Skill Promotion Request", req["request"], "status"), "Pending"
+		)
+
+	def test_approve_without_approved_roles_grants_full_set(self):
+		"""Back-compat: omitting approved_roles publishes the FULL requested set."""
+		from jarvis.chat import custom_skills_api
+
+		second = "Accounts User"
+		owner = _ensure_user("p2-fullowner@example.com", ["Jarvis User", self.AUD_ROLE, second])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-full", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=[self.AUD_ROLE, second]
+			)
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(req["request"], 1)  # no approved_roles
+		self.assertEqual(
+			set(
+				frappe.get_all(
+					"Jarvis Custom Skill Allowed Role",
+					filters={"parent": out["materialized"], "parenttype": SKILL},
+					pluck="role",
+				)
+			),
+			{self.AUD_ROLE, second},
+		)
+
+	def test_reviewer_approved_roles_accepts_json_string(self):
+		"""The approve payload arrives as a JSON-encoded STRING (Frappe form-data);
+		the endpoint must decode it like target_roles - no FrappeTypeError."""
+		import json
+
+		from jarvis.chat import custom_skills_api
+
+		second = "Accounts User"
+		owner = _ensure_user("p2-jsonapprove@example.com", ["Jarvis User", self.AUD_ROLE, second])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-jsonapprove", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=[self.AUD_ROLE, second]
+			)
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(
+				req["request"], 1, approved_roles=json.dumps([second])
+			)
+		self.assertTrue(out["ok"])
+		self.assertEqual(
+			frappe.get_all(
+				"Jarvis Custom Skill Allowed Role",
+				filters={"parent": out["materialized"], "parenttype": SKILL},
+				pluck="role",
+			),
+			[second],
+		)
+
+	def test_promotion_queue_serializes_target_roles(self):
+		"""The reviewer-queue serializer carries the FULL ordered role set so the card
+		renders every role (not just the primary)."""
+		from jarvis.chat import custom_skills_api
+
+		second = "Accounts User"
+		owner = _ensure_user("p2-queueowner@example.com", ["Jarvis User", self.AUD_ROLE, second])
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-queue", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=[self.AUD_ROLE, second]
+			)
+		with _as(REVIEWER):
+			rows = custom_skills_api.list_skill_promotion_requests()["rows"]
+		row = next(r for r in rows if r["name"] == req["request"])
+		self.assertEqual(row["target_roles"], [self.AUD_ROLE, second])
+
 	def test_role_promoted_skill_is_slug_invocable_by_a_role_holder(self):
 		from jarvis.chat.custom_skills import _role_scoped_invocable_names, invoked_skill_clause
 

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1603,6 +1603,61 @@ class TestRoleScopedSkillInvocation(Part2Base):
 			[self.AUD_ROLE],
 		)
 
+	def test_role_promotion_to_multiple_roles(self):
+		"""Multi-role (#478 extended): one request naming SEVERAL roles materializes a
+		Role skill whose allowed_roles is the WHOLE set (target_role = the first). A
+		holder of ANY named role - not only the primary - can use it, and a stranger
+		holding neither still cannot."""
+		from jarvis.chat import custom_skills_api
+		from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import user_can_use_skill
+
+		second = "Accounts User"
+		owner = _ensure_user("p2-multiowner@example.com", ["Jarvis User", self.AUD_ROLE, second])
+		holder2 = _ensure_user("p2-multiholder@example.com", ["Jarvis User", second])  # NOT Sales User
+		self.addCleanup(lambda: frappe.db.delete(SKILL, {"owner": owner}))
+		self.addCleanup(lambda: frappe.db.delete("Jarvis Skill Promotion Request", {"owner": owner}))
+
+		src = _mk_skill(owner, f"{PFX}-multirole", scope="User")
+		with _as(owner):
+			req = custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=[self.AUD_ROLE, second]
+			)
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(req["request"], 1)
+		self.assertTrue(out["ok"])
+		shared = out["materialized"]
+
+		# target_role is the primary (first); allowed_roles is the FULL set.
+		self.assertEqual(frappe.db.get_value(SKILL, shared, "target_role"), self.AUD_ROLE)
+		self.assertEqual(
+			set(
+				frappe.get_all(
+					"Jarvis Custom Skill Allowed Role",
+					filters={"parent": shared, "parenttype": SKILL},
+					pluck="role",
+				)
+			),
+			{self.AUD_ROLE, second},
+		)
+		# A holder of the SECOND role (never the primary) can use it - the whole point.
+		doc = frappe.get_doc(SKILL, shared)
+		self.assertTrue(user_can_use_skill(doc, holder2, frappe.get_roles(holder2)))
+		# A Jarvis-User-only stranger still cannot.
+		self.assertFalse(user_can_use_skill(doc, USER_B, frappe.get_roles(USER_B)))
+
+	def test_role_promotion_rejects_a_role_the_requester_cannot_target(self):
+		"""Server-side gate: a requester may only name roles in their OWN promotable
+		set - a hand-crafted request for a role they do not hold is refused, even
+		though the old single-role path validated presence only."""
+		from jarvis.chat import custom_skills_api
+
+		src = _mk_skill(USER_A, f"{PFX}-badrole", scope="User")
+		with _as(USER_A), self.assertRaises(frappe.ValidationError):
+			# USER_A holds Sales User, never "System Manager"; naming it must be refused.
+			custom_skills_api.request_skill_promotion(
+				src.name, "Role", target_roles=[self.AUD_ROLE, "System Manager"]
+			)
+
 	def test_role_promoted_skill_is_slug_invocable_by_a_role_holder(self):
 		from jarvis.chat.custom_skills import _role_scoped_invocable_names, invoked_skill_clause
 

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -218,10 +218,23 @@ function atBottom() {
 	if (!el) return true;
 	return el.scrollHeight - el.scrollTop - el.clientHeight < 120;
 }
-// Follow the stream only if the user is already at the bottom; yanking them
-// down while they scroll back through a long reply is the classic chat sin.
+// Whether new content should keep the view pinned to the newest text. Sending a
+// message drops this (see send): the reply then grows DOWNWARD from where the
+// turn landed instead of sliding its own opening up past the top of the viewport
+// on every streamed chunk — the "large paragraph slides upward" bug. A real
+// scroll back to the bottom resumes following; a fresh load restores it.
+const follow = ref(true);
+function onScroll() {
+	follow.value = atBottom();
+}
+// Follow the newest text only while `follow` holds (parked at the bottom) AND no
+// reply is streaming (`live`): chasing the bottom mid-stream drags the line you
+// are reading up and off the top, so a long reply never settles enough to read.
+// While streaming the reply grows downward and you scroll at your own pace; a
+// forced scroll (open / send / stop) always lands, and once the turn ends normal
+// follow resumes so late content still keeps a bottom-parked reader pinned.
 async function scrollToBottom(force = false) {
-	const stick = force || atBottom();
+	const stick = force || (follow.value && !live.value);
 	await nextTick();
 	if (stick && scroller.value) scroller.value.scrollTop = scroller.value.scrollHeight;
 }
@@ -229,6 +242,9 @@ async function scrollToBottom(force = false) {
 // ── loading ─────────────────────────────────────────────────────────────────
 async function load(force = false) {
 	if (!convId.value) return;
+	// A fresh open / refresh follows the newest content again (streaming replies
+	// arrive via socket events, never load(), so this never re-pins mid-reply).
+	follow.value = true;
 	loading.value = true;
 	try {
 		const d = await api.getConversation(convId.value);
@@ -283,6 +299,9 @@ async function send() {
 		optimistic: true,
 	});
 	await scrollToBottom(true);
+	// Land on the new turn, then stop following so the reply grows downward
+	// instead of dragging the view up as it streams (see `follow`).
+	follow.value = false;
 
 	try {
 		// No model/effort override here: an existing chat keeps whatever it was
@@ -660,7 +679,7 @@ onUnmounted(() => {
 		</button>
 	</div>
 
-	<div ref="scroller" class="jv-scroll jv-thread">
+	<div ref="scroller" class="jv-scroll jv-thread" @scroll.passive="onScroll">
 		<div v-if="!items.length && !live && !loading" class="jv-empty">
 			<BrandMark :size="52" />
 			<div style="font-size: 16px; font-weight: 600; color: var(--ink9)">


### PR DESCRIPTION
## Overview
This PR delivers the **complete** multi-role skill-promotion feature end to end and
adds a reviewer-side role-trim capability on top. It carries **two independent
concerns** (called out so review is easy):

1. **Multi-role skill promotion** — a request can target several roles; a reviewer
   sees the full set, may trim it, and approves the kept subset.
2. **Chat auto-scroll fix** — a self-contained bugfix for the "text keeps moving up"
   report while a reply streams (bundled here at the author's request).

---

## 1. Multi-role skill promotion

### Request + apply (backend)
- **JSPR doctype** — new `target_roles` child table (reuses `Jarvis Custom Skill
  Allowed Role`); `target_role` kept as the primary (first) for display + backward
  compatibility.
- **request_skill_promotion** — accepts a `target_roles` list (or JSON string) and
  gates each role server-side against the requester's own promotable set.
- **_materialize_promotion** — publishes `allowed_roles` = the approved set,
  `target_role` = the first; audience checks OR `target_role` with the
  `allowed_roles` intersection, so a holder of ANY granted role can use the skill.
- **Jarvis Custom Skill controller** — the Role-scope collapse keeps a multi-role
  `allowed_roles` on a promotion and still collapses to `[target_role]` on a single
  create / Desk re-target. No security-critical read path changed.

### Requester picker (frontend)
- `PromotionRequestDialog` gains a multi-select role picker (inline searchable list
  + clickable checkboxes, kept inside the reka-ui dialog focus scope). `SkillDetail`
  / `api/skills.js` forward `target_roles` as a JSON string; the endpoint decodes it
  (`list | str | None`, so no FrappeTypeError).

### Reviewer role-trim (new)
The reviewer deciding a multi-role Role promotion now sees **every requested role**
as a removable chip and may **drop some before approving**; the published skill's
audience is exactly the kept subset.
- **Security boundary:** `decide_skill_promotion(approved_roles)` is validated as a
  **SUBSET** of the request — a role that was **not** requested raises
  `PermissionError` and nothing is published (a reviewer narrows, never escalates).
  Empty set on Role scope → `ValidationError`; omitted → the full requested set
  (back-compat). Org scope ignores it. All validated **before** the catalog lock;
  four-eyes / TOCTOU re-read / Org-budget recheck are untouched.
- The **request's role set stays immutable** as the original ask; the granted subset
  is recorded on the decision note.
- **Display honesty:** a trimmed approval never shows the requested roles as granted
  — the status chip reads "Promotion approved" + the decision-note grant, and decided
  reviewer rows label the chips "Requested roles" (shown statically).

---

## 2. Chat auto-scroll fix

The reply handler called scroll-to-bottom on every streamed chunk. The prior guard
keyed only on the paced reveal queue, which empties **between** deltas, so each gap
re-enabled following mid-stream and dragged the line being read up off the top of a
long answer (worst when opening a chat already mid-reply, where pinned starts true).

Fix adds the whole-turn `convStreaming` term and extracts the invariant into a pure,
unit-tested helper `shouldFollowBottom(pinned, streaming, revealPending)`: follow
only when parked at the bottom **and** not streaming **and** the reveal has drained.
Applied to both SPA `ChatView` guard sites; the PWA already used its per-turn `live`
flag.

---

## Tests & verification
- **Backend** (`test_part2_security`): 6 new tests — subset approve, anti-escalation
  (`PermissionError`, nothing published), empty-role guard, omitted = full set,
  JSON-string `approved_roles`, and the reviewer-queue serializer shape — all green.
  (The lone module failure, `learned_api.get_review_access`, is the **pre-existing**
  `only_for` in-test bypass in an untouched function.)
- **Frontend** (vitest): `chatScroll.spec.js` 6/6 (incl. the between-deltas
  regression) + `PromotionRequestDialog.spec.js` 11/11.
- **Executed flow review** (running SPA): requested a 2-role promotion → in Review,
  removed one chip → the approve confirm showed only the kept role → approved → the
  published skill's `allowed_roles` was exactly the kept role, the request preserved
  its immutable ask, and the trim was recorded on the decision note.
- SPA + PWA both build clean.

## Edge cases covered
Anti-escalation (un-requested role refused), remove-all blocked (UI + server),
JSON-string vs list payloads, Org scope ignores trim, duplicate/reordered roles
deduped (primary = first kept), `needs_reconfirm` re-open preserves the kept set,
legacy single-role rows fall back to the scalar `target_role`.
