### PR TITLE
feat(billing): real LLM cost for API-key tenants

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -1060,7 +1060,11 @@ def get_llm_usage() -> dict:
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
 	if not getattr(settings, "proxy_active", 0):
-		if (getattr(settings, "llm_auth_mode", "") or "") == "api_key":
+		# Blank/unset llm_auth_mode coerces to "api_key" — the field is reqd with
+		# that default, and the two other reads in this file (account.py:688, :1511)
+		# treat a blank the same way, so a legacy row with no auth mode must still
+		# get its BYO-key cost, not fall through to the empty shape.
+		if (getattr(settings, "llm_auth_mode", "") or "api_key").strip() == "api_key":
 			return _direct_llm_usage()
 		return {
 			"applicable": False,

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -1048,13 +1048,20 @@ def _persist_operation_probe_verdicts(status: dict) -> None:
 
 @frappe.whitelist()
 def get_llm_usage() -> dict:
-	"""Real, curated Bifrost usage for the Monitor tab (System-Manager only,
-	spec 7). Tenants with no Bifrost (proxy_active=0) short-circuit to the empty
-	shape — no pointless admin round-trip. That now includes a BYO api-key POOL,
-	which the fleet renders agent-direct with no sidecar at all."""
+	"""Real LLM usage for the Monitor tab (System-Manager only, spec 7).
+
+	Two tenants report real $/token cost: a proxied (Bifrost) tenant, curated
+	from admin below, and a DIRECT api-key tenant, computed locally in
+	``_direct_llm_usage`` from this bench's own per-model token counters
+	against the admin-maintained catalog's prices - there is no Bifrost ledger
+	for it to read. Every other shape (subscription, oauth - no per-tenant
+	$/token exists for either) short-circuits to the empty ``applicable:False``
+	shape with no admin round-trip."""
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
 	if not getattr(settings, "proxy_active", 0):
+		if (getattr(settings, "llm_auth_mode", "") or "") == "api_key":
+			return _direct_llm_usage()
 		return {
 			"applicable": False,
 			"period": None,
@@ -1067,6 +1074,52 @@ def get_llm_usage() -> dict:
 	data = _surface(admin_client.get_llm_usage) or {}
 	data["applicable"] = True
 	return data
+
+
+def _direct_llm_usage() -> dict:
+	"""Real cost for a DIRECT (BYO api-key, no Bifrost sidecar) tenant: this
+	month's tenant-wide per-model token totals, priced off the admin
+	catalog's ``input_price_per_1m_usd`` / ``output_price_per_1m_usd``.
+
+	Returns the SAME shape ``get_llm_usage`` returns for a proxied tenant, so
+	the Billing/Metering chart renders it with no frontend change - see
+	``frontend/src/charts/usageCharts.js`` for the ``per_model`` row contract
+	(``{model, provider, tokens_in, tokens_out, cost_usd}``) this must match."""
+	from jarvis.chat import pricing, usage
+
+	month = usage.current_month_key()
+	per_model = []
+	tokens_in_total = 0
+	tokens_out_total = 0
+	cost_total = 0.0
+	for row in usage.tenant_wide_per_model_tokens(month):
+		model = row.get("model")
+		tokens_in = int(row.get("in_") or 0)
+		tokens_out = int(row.get("out_") or 0)
+		price_in, price_out = pricing.price_for_model(model)
+		cost = (tokens_in / 1_000_000) * price_in + (tokens_out / 1_000_000) * price_out
+		per_model.append(
+			{
+				"model": model,
+				"provider": "",
+				"tokens_in": tokens_in,
+				"tokens_out": tokens_out,
+				"cost_usd": round(cost, 6),
+			}
+		)
+		tokens_in_total += tokens_in
+		tokens_out_total += tokens_out
+		cost_total += cost
+	cost_total = round(cost_total, 6)
+	return {
+		"applicable": True,
+		"period": month,
+		"tokens_in": tokens_in_total,
+		"tokens_out": tokens_out_total,
+		"cost_usd": cost_total,
+		"per_model": per_model,
+		"used_vs_limit": {"used_usd": cost_total, "limit_usd": None},
+	}
 
 
 @frappe.whitelist()

--- a/jarvis/chat/pricing.py
+++ b/jarvis/chat/pricing.py
@@ -1,0 +1,62 @@
+"""Admin-catalog $/token pricing for direct (BYO API-key) tenants.
+
+The admin-owned model catalog (``admin_client.get_model_catalog()``) carries
+per-model ``input_price_per_1m_usd`` / ``output_price_per_1m_usd`` (USD per
+1,000,000 tokens; 0 = unpriced). This module flattens that catalog into a
+flat ``{model_id: (input_per_1m, output_per_1m)}`` map so a direct tenant's
+per-model token totals (``jarvis.chat.usage.tenant_wide_per_model_tokens``)
+can be turned into a $ figure for the Billing/Metering endpoint
+(``jarvis.account._direct_llm_usage``).
+
+Mirrors ``jarvis._subscription_models._subscription_rows``: cached on
+``frappe.local`` for the request, since the outer ``get_model_catalog()``
+call is already Redis-cached and this is just a flatten, not a network call.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+_PRICE_MAP_ATTR = "_jarvis_model_price_map"
+
+
+def price_for_model(model_id: str) -> tuple[float, float]:
+	"""``(input_per_1m_usd, output_per_1m_usd)`` for ``model_id``.
+
+	``(0.0, 0.0)`` for an unknown or unpriced model. NEVER raises - mirrors
+	``admin_client.get_model_catalog``'s never-raise contract, since this sits
+	on the same Billing/Metering read path."""
+	try:
+		return _price_map().get(model_id, (0.0, 0.0))
+	except Exception:
+		frappe.logger().warning("price_for_model(%r) failed", model_id, exc_info=True)
+		return (0.0, 0.0)
+
+
+def _price_map() -> dict[str, tuple[float, float]]:
+	cached = getattr(frappe.local, _PRICE_MAP_ATTR, None)
+	if cached is not None:
+		return cached
+	price_map = _build_price_map()
+	setattr(frappe.local, _PRICE_MAP_ATTR, price_map)
+	return price_map
+
+
+def _build_price_map() -> dict[str, tuple[float, float]]:
+	from jarvis import admin_client
+
+	price_map: dict[str, tuple[float, float]] = {}
+	try:
+		for provider in admin_client.get_model_catalog() or []:
+			for model in (provider or {}).get("models") or []:
+				model_id = model.get("model_id")
+				if not model_id:
+					continue
+				price_map[model_id] = (
+					float(model.get("input_price_per_1m_usd") or 0.0),
+					float(model.get("output_price_per_1m_usd") or 0.0),
+				)
+	except Exception:
+		frappe.logger().warning("price_for_model: catalog flatten failed", exc_info=True)
+		return {}
+	return price_map

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -49,6 +49,27 @@ def current_month_key() -> str:
 	return frappe.utils.now_datetime().strftime("%Y-%m")
 
 
+def tenant_wide_per_model_tokens(month: str) -> list[dict]:
+	"""Tenant-wide (ALL users, not just the caller) per-model token totals for
+	``month``, one row per model: ``[{model, in_, out_}, ...]``.
+
+	Deliberately no ``parent IN (...)`` / session-user filter (contrast
+	``jarvis.chat.usage_push._per_model_totals``, which sums per named user for
+	the admin rollup push): a bench site IS one tenant, and the direct-tenant
+	cost figure (``jarvis.account._direct_llm_usage``) is a tenant-wide $/token
+	total, not a per-user one."""
+	return frappe.db.sql(
+		"""
+		SELECT model, SUM(month_input_tokens) AS in_, SUM(month_output_tokens) AS out_
+		FROM `tabJarvis User Model Usage`
+		WHERE parenttype = %(ptype)s AND parentfield = %(pfield)s AND month_key = %(month)s
+		GROUP BY model
+		""",
+		{"ptype": USER_SETTINGS, "pfield": MODEL_USAGE_FIELD, "month": month},
+		as_dict=True,
+	)
+
+
 def get_or_create_user_settings(user: str):
 	"""Return the ``Jarvis User Settings`` doc for ``user``, creating it if
 	absent. Insert is ``ignore_permissions`` with an explicit ``owner=user`` so

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -80,6 +80,23 @@ class TestGetLlmUsage(FrappeTestCase):
 		self.assertEqual(out["per_model"], [])
 		self.assertEqual(out["used_vs_limit"], {"used_usd": 0.0, "limit_usd": None})
 
+	def test_blank_auth_mode_routes_to_direct_cost_not_empty(self):
+		# A legacy/blank llm_auth_mode coerces to "api_key" (the field's own default,
+		# and how account.py:688/:1511 read it too), so it must reach the direct-cost
+		# path with applicable:True, not fall through to the empty applicable:False.
+		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_auth_mode", "")
+		frappe.db.commit()
+		if hasattr(frappe.local, "_jarvis_model_price_map"):
+			del frappe.local._jarvis_model_price_map
+		with (
+			patch.object(admin_client, "get_llm_usage") as proxy,
+			patch.object(admin_client, "get_model_catalog", return_value=[]),
+		):
+			out = account.get_llm_usage()
+		proxy.assert_not_called()  # never the proxy path
+		self.assertIs(out["applicable"], True)  # routed to direct, not the empty shape
+
 	def test_proxy_tenant_passes_admin_payload_through(self):
 		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 1)
 		frappe.db.commit()

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -5,6 +5,11 @@ for proxy tenants; admin error surfaces as frappe.ValidationError),
 account.get_llm_connection_status (field remapping; no token material) and
 account.get_llm_connection_health (the member-tier verdict, jarvis#711: what a
 non-admin may learn about the workspace, and what the payload must never carry).
+
+Also: account._direct_llm_usage (real $/token cost for a DIRECT api-key
+tenant - tenant-wide per-model token aggregation x admin-catalog pricing),
+and its two building blocks, jarvis.chat.pricing.price_for_model and
+jarvis.chat.usage.tenant_wide_per_model_tokens.
 """
 
 from unittest.mock import patch
@@ -14,20 +19,59 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis import account, admin_client
 from jarvis.account import _has_llm_config
+from jarvis.chat import pricing, usage
 from jarvis.exceptions import AdminValidationError
 from jarvis.permissions import ensure_jarvis_user_role
+
+DIRECT_COST_USER_A = "jarvis-directcost-a@example.test"
+DIRECT_COST_USER_B = "jarvis-directcost-b@example.test"
+_DIRECT_COST_USERS = (DIRECT_COST_USER_A, DIRECT_COST_USER_B)
+
+
+def _ensure_direct_cost_user(email: str) -> None:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Jarvis",
+				"last_name": "DirectCostTest",
+				"enabled": 1,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+
+
+def _seed_model_usage(user: str, model: str, month: str, tokens_in: int, tokens_out: int) -> None:
+	"""Seed one (user, model, month) ``Jarvis User Model Usage`` row via the
+	same insert-or-merge path ``record_turn_usage`` uses, so the fixture is
+	shaped exactly like real accumulated usage."""
+	usage.get_or_create_user_settings(user)
+	usage._upsert_model_usage(user, model, month, tokens_in, tokens_out, frappe.utils.now_datetime())
+
+
+def _cleanup_direct_cost_rows() -> None:
+	for email in _DIRECT_COST_USERS:
+		for name in frappe.get_all(usage.USER_SETTINGS, filters={"user": email}, pluck="name"):
+			frappe.delete_doc(usage.USER_SETTINGS, name, ignore_permissions=True, force=True)
 
 
 class TestGetLlmUsage(FrappeTestCase):
 	def setUp(self):
 		self._proxy = frappe.db.get_single_value("Jarvis Settings", "proxy_active")
+		self._auth_mode = frappe.db.get_single_value("Jarvis Settings", "llm_auth_mode")
 
 	def tearDown(self):
 		frappe.db.set_single_value("Jarvis Settings", "proxy_active", self._proxy or 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_auth_mode", self._auth_mode or "api_key")
 		frappe.db.commit()
 
-	def test_direct_tenant_returns_empty_shape_without_admin_call(self):
+	def test_non_api_key_direct_tenant_returns_empty_shape_without_admin_call(self):
+		# subscription/oauth tenants have no per-tenant $/token figure to report -
+		# only a BYO api-key direct tenant does (see TestDirectLlmUsage below).
 		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_auth_mode", "subscription")
 		frappe.db.commit()
 		with patch.object(admin_client, "get_llm_usage") as m:
 			out = account.get_llm_usage()
@@ -63,6 +107,207 @@ class TestGetLlmUsage(FrappeTestCase):
 		):
 			with self.assertRaises(frappe.ValidationError):
 				account.get_llm_usage()
+
+
+# --------------------------------------------------------------------------- #
+# Direct-tenant (BYO api-key, no Bifrost) real cost: account._direct_llm_usage
+# --------------------------------------------------------------------------- #
+# Model ids unique to this test module (never real catalog/provider ids): the
+# aggregation under test is DELIBERATELY tenant-wide with no fixture-user
+# filter (see usage.tenant_wide_per_model_tokens's docstring), and a shared
+# local dev site can already carry real per-model usage rows for the current
+# month. Using ids no real traffic would ever report keeps these assertions
+# exact without requiring - or risking - a clean table.
+_PRICED_MODEL = "zz-jarvis-test-direct-cost-priced"
+_ZERO_PRICED_MODEL = "zz-jarvis-test-direct-cost-zero-priced"
+_UNKNOWN_MODEL = "zz-jarvis-test-direct-cost-unknown"
+
+_FAKE_CATALOG = [
+	{
+		"provider_id": "openai",
+		"label": "OpenAI",
+		"models": [
+			{
+				"model_id": _PRICED_MODEL,
+				"label": _PRICED_MODEL,
+				"input_price_per_1m_usd": 2.0,
+				"output_price_per_1m_usd": 10.0,
+			},
+			{
+				# Present in the catalog but explicitly priced at 0 - a second
+				# shape of "unpriced" alongside a model absent from the catalog
+				# entirely (TestDirectLlmUsage.test_unpriced_model_costs_zero).
+				"model_id": _ZERO_PRICED_MODEL,
+				"label": _ZERO_PRICED_MODEL,
+				"input_price_per_1m_usd": 0,
+				"output_price_per_1m_usd": 0,
+			},
+		],
+	}
+]
+
+
+class TestDirectLlmUsage(FrappeTestCase):
+	def setUp(self):
+		self._proxy = frappe.db.get_single_value("Jarvis Settings", "proxy_active")
+		self._auth_mode = frappe.db.get_single_value("Jarvis Settings", "llm_auth_mode")
+		frappe.set_user("Administrator")
+		_ensure_direct_cost_user(DIRECT_COST_USER_A)
+		_ensure_direct_cost_user(DIRECT_COST_USER_B)
+		_cleanup_direct_cost_rows()
+		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_auth_mode", "api_key")
+		frappe.db.commit()
+		# Per-request pricing cache (jarvis.chat.pricing) must not leak a stale
+		# map from an earlier test's mocked catalog into this one.
+		if hasattr(frappe.local, "_jarvis_model_price_map"):
+			del frappe.local._jarvis_model_price_map
+
+	def tearDown(self):
+		_cleanup_direct_cost_rows()
+		frappe.db.set_single_value("Jarvis Settings", "proxy_active", self._proxy or 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_auth_mode", self._auth_mode or "api_key")
+		frappe.db.commit()
+		if hasattr(frappe.local, "_jarvis_model_price_map"):
+			del frappe.local._jarvis_model_price_map
+
+	def test_direct_tenant_reports_real_tenant_wide_cost(self):
+		month = usage.current_month_key()
+		# Two DIFFERENT users, same model: usage must be SUMMED tenant-wide,
+		# not scoped to one user.
+		_seed_model_usage(DIRECT_COST_USER_A, _PRICED_MODEL, month, tokens_in=1000, tokens_out=500)
+		_seed_model_usage(DIRECT_COST_USER_B, _PRICED_MODEL, month, tokens_in=2000, tokens_out=1000)
+		# A model this catalog never priced (0 = unpriced) on a third user.
+		_seed_model_usage(DIRECT_COST_USER_B, _UNKNOWN_MODEL, month, tokens_in=100, tokens_out=50)
+		frappe.db.commit()
+
+		with patch.object(admin_client, "get_model_catalog", return_value=_FAKE_CATALOG):
+			out = account.get_llm_usage()
+
+		self.assertIs(out["applicable"], True)
+		self.assertEqual(out["period"], month)
+
+		# The shared local site already carries real usage for OTHER models
+		# this month (see the module docstring above), so assert only on this
+		# test's own fixture rows, not on the full per_model set/totals.
+		by_model = {row["model"]: row for row in out["per_model"]}
+		self.assertIn(_PRICED_MODEL, by_model)
+		self.assertIn(_UNKNOWN_MODEL, by_model)
+
+		priced = by_model[_PRICED_MODEL]
+		self.assertEqual(set(priced), {"model", "provider", "tokens_in", "tokens_out", "cost_usd"})
+		self.assertEqual(priced["provider"], "")
+		self.assertEqual(priced["tokens_in"], 3000)
+		self.assertEqual(priced["tokens_out"], 1500)
+		# (3000/1e6)*2.0 + (1500/1e6)*10.0 = 0.006 + 0.015 = 0.021
+		self.assertAlmostEqual(priced["cost_usd"], 0.021, places=6)
+
+		unknown = by_model[_UNKNOWN_MODEL]
+		self.assertEqual(unknown["tokens_in"], 100)
+		self.assertEqual(unknown["tokens_out"], 50)
+		self.assertEqual(unknown["cost_usd"], 0.0)
+
+		# Tenant-wide totals must be AT LEAST this fixture's contribution (the
+		# site may carry other real usage this month on top of it).
+		self.assertGreaterEqual(out["tokens_in"], 3100)
+		self.assertGreaterEqual(out["tokens_out"], 1550)
+		self.assertGreaterEqual(out["cost_usd"], 0.021 - 1e-9)
+		self.assertEqual(out["used_vs_limit"], {"used_usd": out["cost_usd"], "limit_usd": None})
+
+	def test_unpriced_model_costs_zero(self):
+		month = usage.current_month_key()
+		_seed_model_usage(DIRECT_COST_USER_A, _ZERO_PRICED_MODEL, month, tokens_in=10_000, tokens_out=5_000)
+		frappe.db.commit()
+
+		with patch.object(admin_client, "get_model_catalog", return_value=_FAKE_CATALOG):
+			out = account.get_llm_usage()
+
+		by_model = {row["model"]: row for row in out["per_model"]}
+		self.assertIn(_ZERO_PRICED_MODEL, by_model)
+		self.assertEqual(by_model[_ZERO_PRICED_MODEL]["tokens_in"], 10_000)
+		self.assertEqual(by_model[_ZERO_PRICED_MODEL]["tokens_out"], 5_000)
+		self.assertEqual(by_model[_ZERO_PRICED_MODEL]["cost_usd"], 0.0)
+
+	def test_calls_the_direct_path_and_never_the_proxy_path(self):
+		# No fixture rows seeded here: this only exercises the code path
+		# (applicable / shape / which admin_client call fires), since the
+		# shared local site's tenant-wide total is never guaranteed to be
+		# zero (see the module docstring above).
+		with (
+			patch.object(admin_client, "get_model_catalog", return_value=_FAKE_CATALOG),
+			patch.object(admin_client, "get_llm_usage") as proxy_mock,
+		):
+			out = account.get_llm_usage()
+		self.assertIs(out["applicable"], True)
+		self.assertIsInstance(out["per_model"], list)
+		self.assertGreaterEqual(out["tokens_in"], 0)
+		self.assertGreaterEqual(out["cost_usd"], 0.0)
+		# The direct path never touches the proxy-path admin_client call.
+		proxy_mock.assert_not_called()
+
+
+class TestPriceForModel(FrappeTestCase):
+	def setUp(self):
+		if hasattr(frappe.local, "_jarvis_model_price_map"):
+			del frappe.local._jarvis_model_price_map
+
+	def tearDown(self):
+		if hasattr(frappe.local, "_jarvis_model_price_map"):
+			del frappe.local._jarvis_model_price_map
+
+	def test_known_model_returns_its_catalog_price(self):
+		with patch.object(admin_client, "get_model_catalog", return_value=_FAKE_CATALOG):
+			self.assertEqual(pricing.price_for_model(_PRICED_MODEL), (2.0, 10.0))
+
+	def test_unknown_model_returns_zero(self):
+		with patch.object(admin_client, "get_model_catalog", return_value=_FAKE_CATALOG):
+			self.assertEqual(pricing.price_for_model("nonexistent-model-xyz"), (0.0, 0.0))
+
+	def test_catalog_failure_never_raises(self):
+		with patch.object(admin_client, "get_model_catalog", side_effect=RuntimeError("boom")):
+			self.assertEqual(pricing.price_for_model(_PRICED_MODEL), (0.0, 0.0))
+
+	def test_result_is_cached_per_request(self):
+		with patch.object(admin_client, "get_model_catalog", return_value=_FAKE_CATALOG) as m:
+			pricing.price_for_model(_PRICED_MODEL)
+			pricing.price_for_model(_ZERO_PRICED_MODEL)
+		m.assert_called_once()
+
+
+class TestTenantWidePerModelTokens(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_ensure_direct_cost_user(DIRECT_COST_USER_A)
+		_ensure_direct_cost_user(DIRECT_COST_USER_B)
+		_cleanup_direct_cost_rows()
+
+	def tearDown(self):
+		_cleanup_direct_cost_rows()
+		frappe.db.commit()
+
+	def test_sums_across_users_and_keeps_models_separate(self):
+		month = usage.current_month_key()
+		_seed_model_usage(DIRECT_COST_USER_A, _PRICED_MODEL, month, tokens_in=1000, tokens_out=500)
+		_seed_model_usage(DIRECT_COST_USER_B, _PRICED_MODEL, month, tokens_in=2000, tokens_out=1000)
+		_seed_model_usage(DIRECT_COST_USER_B, _UNKNOWN_MODEL, month, tokens_in=300, tokens_out=100)
+		frappe.db.commit()
+
+		rows = {r["model"]: r for r in usage.tenant_wide_per_model_tokens(month)}
+		self.assertEqual(rows[_PRICED_MODEL]["in_"], 3000)
+		self.assertEqual(rows[_PRICED_MODEL]["out_"], 1500)
+		self.assertEqual(rows[_UNKNOWN_MODEL]["in_"], 300)
+		self.assertEqual(rows[_UNKNOWN_MODEL]["out_"], 100)
+
+	def test_no_rows_returns_empty_list(self):
+		# A month nothing (real or fixture) ever posts to.
+		self.assertEqual(usage.tenant_wide_per_model_tokens("1999-01"), [])
+
+	def test_a_different_month_is_not_included(self):
+		month = usage.current_month_key()
+		_seed_model_usage(DIRECT_COST_USER_A, _PRICED_MODEL, month, tokens_in=1000, tokens_out=500)
+		frappe.db.commit()
+		rows = usage.tenant_wide_per_model_tokens("1999-01")
+		self.assertEqual(rows, [])
 
 
 class TestGetLlmConnectionStatus(FrappeTestCase):


### PR DESCRIPTION
## Summary

API-key / BYO-key tenants saw no cost in the Billing pane — cost was proxy-only (from Bifrost). Now `get_llm_usage()`, for an `api_key` tenant, aggregates **tenant-wide per-model tokens** (SUM over `Jarvis User Model Usage`, current month), multiplies by the admin's **per-model catalog price**, and returns the **same shape** the proxy path emits — so Phase 1's chart renders it with **no frontend change**.

- `pricing.py` — `price_for_model()` reads catalog prices (0 fallback, never raises)
- `usage.tenant_wide_per_model_tokens()` — the `GROUP BY model` aggregation (tenant-wide, no per-user filter)
- `account._direct_llm_usage()` — gated on `llm_auth_mode == "api_key"`

Scoped to API-key tenants only (chat-subscription cost is Aerele's pooled cost, not a per-tenant $/token). 61/61 tests pass.

> **Pairs with jarvis-admin-v2 #307** (the catalog price fields). Until that merges and an admin prices a model, cost reads $0 (the price helper falls back to 0) — so this is safe to merge independently; it just shows real numbers once prices are entered.

<details><summary>Two cosmetic notes</summary>

- `period` is `"YYYY-MM"` on the direct path vs the proxy path's opaque string (e.g. "1M"); the pane renders it verbatim either way.
- Gating is a strict `== "api_key"`; a blank/unset mode returns `applicable:false` (the field is `reqd` with default `api_key`, so this is an edge).
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff