### PR TITLE
feat: honest prepared-report handling in run_report

### DIFF
--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -643,6 +643,31 @@ class TestRunDashboardSource(_DashboardsApiTestCase):
 		self.assertTrue(data["rows"])
 		self.assertIsInstance(data["took_ms"], int)
 
+	def test_run_report_prepared_at_runtime_rejected(self):
+		# Run-time backstop: a report toggled to prepared AFTER a source was saved
+		# must still be rejected. run_report now returns a {prepared_report: True,
+		# status: ...} envelope; the tile must not serve it (dashboards_api guards
+		# on res.get("prepared_report")).
+		self._mk_todo("Administrator")
+		frappe.set_user("Administrator")
+		created = self._save(
+			{
+				"dashboard_title": f"rt-{frappe.generate_hash(length=8)}",
+				"html": "<h1>rt</h1>",
+				"sources": [
+					{"source_name": "rep", "tool": "run_report", "spec": {"report_name": REPORT_NAME}}
+				],
+			}
+		)
+		frappe.db.set_value("Report", REPORT_NAME, "prepared_report", 1)
+		try:
+			with patch("frappe.core.doctype.prepared_report.prepared_report.enqueue"):
+				r = run_dashboard_source(created["name"], "rep")
+		finally:
+			frappe.db.set_value("Report", REPORT_NAME, "prepared_report", 0)
+		self.assertFalse(r.get("ok"))
+		self.assertIn("inline", frappe.as_json(r).lower())
+
 	def test_truncation_cap(self):
 		self._mk_todo("Administrator", "truncate one")
 		self._mk_todo("Administrator", "truncate two")

--- a/jarvis/tests/test_run_report.py
+++ b/jarvis/tests/test_run_report.py
@@ -1,13 +1,89 @@
-import unittest
+from unittest.mock import patch
 
 import frappe
+from frappe.core.doctype.prepared_report.prepared_report import (
+	create_json_gz_file,
+	process_filters_for_prepared_report,
+)
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, now
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools import _prepared_reports
 from jarvis.tools.run_report import run_report
 
+INLINE_REPORT = "Jarvis Test Inline Report"
+PREP_REPORT = "Jarvis Test Prepared Report"
 
-class TestRunReport(FrappeTestCase):
+# after_insert on Prepared Report enqueues a real 25-min generate_report job; in
+# tests we never want it to run (and it wouldn't inline anyway), so we no-op the
+# enqueue at the module where it is bound.
+_ENQUEUE = "frappe.core.doctype.prepared_report.prepared_report.enqueue"
+
+# Sentinel: _make_pr with result=_NOGZ stores NO gz attachment (an in-flight or
+# corrupt-copy row); result=None stores a gz whose result is null (a genuine
+# 0-row completed report); result=[...] stores rows.
+_NOGZ = object()
+
+
+def _ensure_report(name: str, prepared: int) -> None:
+	"""Hermetic Query Report over ToDo. Idempotent; left in place across tests."""
+	if frappe.db.exists("Report", name):
+		return
+	frappe.get_doc(
+		{
+			"doctype": "Report",
+			"report_name": name,
+			"ref_doctype": "ToDo",
+			"report_type": "Query Report",
+			"is_standard": "No",
+			"query": "select name, description from `tabToDo` order by creation desc limit 5",
+			"prepared_report": prepared,
+			"disabled": 0,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _make_pr(status, *, owner="Administrator", filters=None, result=_NOGZ, columns=None, age_seconds=0):
+	"""Create a Prepared Report row for PREP_REPORT in a given state, optionally
+	with stored gz data and a back-dated creation."""
+	with patch(_ENQUEUE):
+		pr = frappe.get_doc(
+			{
+				"doctype": "Prepared Report",
+				"report_name": PREP_REPORT,
+				"filters": process_filters_for_prepared_report(filters or {}),
+			}
+		).insert(ignore_permissions=True)
+	updates = {"status": status, "owner": owner}
+	if status == "Completed":
+		updates["report_end_time"] = now()
+	frappe.db.set_value("Prepared Report", pr.name, updates, update_modified=False)
+	if age_seconds:
+		frappe.db.set_value(
+			"Prepared Report",
+			pr.name,
+			"creation",
+			add_to_date(now(), seconds=-age_seconds),
+			update_modified=False,
+		)
+	if result is not _NOGZ:
+		create_json_gz_file(
+			{"result": result, "columns": columns or []}, "Prepared Report", pr.name, PREP_REPORT
+		)
+	return pr.name
+
+
+class TestRunReportInline(FrappeTestCase):
+	"""The non-prepared path must stay byte-identical - no envelope, no status."""
+
+	def setUp(self):
+		_ensure_report(INLINE_REPORT, prepared=0)
+		# Commit the fixture so run()'s @read_only ("START TRANSACTION READ ONLY")
+		# doesn't hit an ImplicitCommitError on the pending insert (same reason
+		# test_dashboards_api commits its fixtures in setUp).
+		frappe.db.commit()
+
 	def test_runs_known_report(self):
 		company = frappe.defaults.get_global_default("company")
 		if not company:
@@ -19,6 +95,15 @@ class TestRunReport(FrappeTestCase):
 		self.assertIn("columns", result)
 		self.assertIn("result", result)
 
+	def test_inline_report_returns_no_status_envelope(self):
+		result = run_report(report_name=INLINE_REPORT)
+		self.assertIn("columns", result)
+		self.assertIn("result", result)
+		# regression: inline path is untouched - Frappe's run() dict has status=None
+		# and no prepared_report marker, unlike our prepared-report envelope.
+		self.assertNotIn("prepared_report", result)
+		self.assertIsNone(result.get("status"))
+
 	def test_rejects_unknown_report(self):
 		with self.assertRaises(InvalidArgumentError):
 			run_report(report_name="Definitely Not A Report")
@@ -28,6 +113,8 @@ class TestRunReport(FrappeTestCase):
 			run_report(report_name="")
 
 	def test_permission_check_blocks_unauthorized_user(self):
+		if not frappe.db.exists("Report", "Sales Register"):
+			self.skipTest("Sales Register needs erpnext; permission path covered in CI")
 		user_email = "reportless@example.com"
 		if not frappe.db.exists("User", user_email):
 			frappe.get_doc(
@@ -44,3 +131,223 @@ class TestRunReport(FrappeTestCase):
 				run_report(report_name="Sales Register")
 		finally:
 			frappe.set_user("Administrator")
+
+
+class TestRunReportPrepared(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_ensure_report(PREP_REPORT, prepared=1)
+		# A prepared report's gz File.save() breaks the per-test transaction
+		# rollback, so a Prepared Report created by one test can leak into the
+		# next and make the completed-copy path win. Start each test clean.
+		frappe.db.delete("Prepared Report", {"report_name": PREP_REPORT})
+		frappe.db.commit()
+
+	# ---- trigger + envelope shape -------------------------------------------
+	def test_prepared_started_when_nothing_exists(self):
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		with patch(_ENQUEUE):
+			env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "started")
+		self.assertTrue(env["prepared_report"])  # keeps dashboards_api backstop intact
+		self.assertIn("message", env)
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before + 1)
+
+	# ---- worker/queue unavailable => RAISE (not a silent envelope) ----------
+	def test_scheduler_paused_raises_without_triggering(self):
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		with (
+			patch.object(frappe, "in_test", False),
+			patch.dict(frappe.conf, {"developer_mode": 0}),
+			patch("jarvis.tools._prepared_reports.is_scheduler_inactive", return_value=True),
+		):
+			with self.assertRaises(InvalidArgumentError):
+				run_report(report_name=PREP_REPORT)
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before)
+
+	def test_queue_unreachable_raises_without_triggering(self):
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		with (
+			patch.object(frappe, "in_test", False),
+			patch.dict(frappe.conf, {"developer_mode": 0}),
+			patch("jarvis.tools._prepared_reports.is_scheduler_inactive", return_value=False),
+			patch("jarvis.tools._prepared_reports._queue_reachable", return_value=False),
+		):
+			with self.assertRaises(InvalidArgumentError):
+				run_report(report_name=PREP_REPORT)
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before)
+
+	# ---- completed copy reuse -----------------------------------------------
+	def test_ready_from_completed_copy(self):
+		_make_pr("Completed", result=[{"name": "T1", "description": "hi"}], columns=[{"label": "Name"}])
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "ready")
+		self.assertEqual(env["result"], [{"name": "T1", "description": "hi"}])
+		self.assertTrue(env["as_of"])
+
+	def test_empty_completed_is_ready_with_zero_rows(self):
+		_make_pr("Completed", result=[])
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "ready")
+		self.assertEqual(env["result"], [])  # 0 rows is a COMPLETE answer, not "no data"
+
+	def test_null_result_completed_is_ready_with_zero_rows(self):
+		# A report that stores result=None (columns but no rows) is a genuine 0-row
+		# answer - it must be `ready`, not fall through and regenerate forever.
+		_make_pr("Completed", result=None, columns=[{"label": "Name"}])
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "ready")
+		self.assertEqual(env["result"], [])
+
+	def test_completed_with_missing_gz_is_not_ready(self):
+		# Completed but no stored gz -> get_prepared_data throws -> must NOT be
+		# "ready"; it falls through and (re)generates instead.
+		_make_pr("Completed", result=_NOGZ)
+		with patch(_ENQUEUE):
+			env = run_report(report_name=PREP_REPORT)
+		self.assertNotEqual(env["status"], "ready")
+
+	def test_row_cap_applied_and_note_reports_true_total(self):
+		total = _prepared_reports._MAX_ROWS + 25
+		big = [{"name": f"T{i}"} for i in range(total)]
+		_make_pr("Completed", result=big)
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "ready")
+		self.assertEqual(len(env["result"]), _prepared_reports._MAX_ROWS)
+		self.assertIn(str(total), env["row_note"])  # note reports the UNCAPPED total
+
+	def test_canonical_filters_round_trip_reuses_completed_copy(self):
+		# A completed copy stored for {"company":"Acme"} must be reused when the
+		# agent passes the same logical filters plus a bookkeeping/empty key.
+		_make_pr("Completed", filters={"company": "Acme"}, result=[{"name": "X"}])
+		env = run_report(
+			report_name=PREP_REPORT,
+			filters={"company": "Acme", "prepared_report_name": "junk", "cost_center": ""},
+		)
+		self.assertEqual(env["status"], "ready")
+		self.assertEqual(env["result"], [{"name": "X"}])
+
+	# ---- in-flight + stall self-heal ----------------------------------------
+	def test_generating_when_recent_started(self):
+		_make_pr("Started", age_seconds=30)
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "generating")
+
+	def test_generating_when_fresh_queued(self):
+		_make_pr("Queued", age_seconds=5)
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "generating")
+
+	def test_stalled_started_retriggers(self):
+		# A Started row past its deadline is a stuck job - re-asking must start a
+		# fresh run, not dead-end on a non-actionable "stalled".
+		_make_pr("Started", age_seconds=_prepared_reports._DEFAULT_REPORT_TIMEOUT + 600)
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		with patch(_ENQUEUE):
+			env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "started")
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before + 1)
+
+	def test_old_queued_stays_generating_no_retrigger(self):
+		# A Queued row is enqueued and waiting - even an old one must NOT re-trigger
+		# (that would pile duplicate long-queue jobs); it reports generating.
+		_make_pr("Queued", age_seconds=3600)
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "generating")
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before)
+
+	# ---- terminal failure is surfaced, not looped ---------------------------
+	def test_errored_report_surfaced_as_failed_without_retrigger(self):
+		_make_pr("Error")
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "failed")
+		# must NOT re-fire a fresh doomed job
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before)
+
+	def test_newer_inflight_wins_over_older_error(self):
+		# An old Error must not shadow a newer in-flight run: the newest attempt
+		# decides. Older failed row, then a fresh Started -> generating, not failed.
+		_make_pr("Error", age_seconds=300)
+		_make_pr("Started", age_seconds=10)
+		env = run_report(report_name=PREP_REPORT)
+		self.assertEqual(env["status"], "generating")
+
+	# ---- filter guards ------------------------------------------------------
+	def test_filter_permission_gate_denies_before_triggering(self):
+		# The validate_filters_permissions gate is the only record-level Link-filter
+		# check on the ignore_permissions trigger/read path. With non-empty filters,
+		# a denial must translate to PermissionDeniedError AND create nothing.
+		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
+		with patch(
+			"jarvis.tools._prepared_reports.validate_filters_permissions",
+			side_effect=frappe.ValidationError("You do not have permission to access Company: Acme."),
+		):
+			with self.assertRaises(PermissionDeniedError):
+				run_report(report_name=PREP_REPORT, filters={"company": "Acme"})
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": PREP_REPORT}), before)
+
+	def test_malformed_filters_raise_invalid_argument(self):
+		with self.assertRaises(InvalidArgumentError):
+			run_report(report_name=PREP_REPORT, filters=[1, 2, 3])
+		with self.assertRaises(InvalidArgumentError):
+			run_report(report_name=PREP_REPORT, filters="not json")
+
+	# ---- C1: completed copy is readable WITHOUT the Prepared Report role -----
+	def test_read_completed_needs_no_prepared_report_role(self):
+		dn = _make_pr("Completed", owner="reportless2@example.com", result=[{"name": "T1"}])
+		if not frappe.db.exists("User", "reportless2@example.com"):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": "reportless2@example.com",
+					"first_name": "Reportless2",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+		frappe.set_user("reportless2@example.com")
+		try:
+			# get_doc-based read must not raise the Prepared Report read-perm error
+			env = _prepared_reports._read_completed(dn)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(env["status"], "ready")
+		self.assertEqual(env["result"], [{"name": "T1"}])
+
+	# ---- permission gate: Has Role on the report ----------------------------
+	def test_has_role_restricted_report_is_denied(self):
+		gated = "Jarvis Test Gated Prepared Report"
+		if not frappe.db.exists("Report", gated):
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"report_name": gated,
+					"ref_doctype": "ToDo",
+					"report_type": "Query Report",
+					"is_standard": "No",
+					"query": "select name from `tabToDo` limit 1",
+					"prepared_report": 1,
+					"disabled": 0,
+					"roles": [{"role": "System Manager"}],
+				}
+			).insert(ignore_permissions=True)
+		user_email = "gated-reportless@example.com"
+		if not frappe.db.exists("User", user_email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user_email,
+					"first_name": "GatedReportless",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+		frappe.set_user(user_email)
+		before = frappe.db.count("Prepared Report", {"report_name": gated})
+		try:
+			with self.assertRaises(PermissionDeniedError):
+				run_report(report_name=gated)
+		finally:
+			frappe.set_user("Administrator")
+		# denied BEFORE any generation is triggered
+		self.assertEqual(frappe.db.count("Prepared Report", {"report_name": gated}), before)

--- a/jarvis/tests/test_run_report.py
+++ b/jarvis/tests/test_run_report.py
@@ -1,8 +1,10 @@
+import json
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.prepared_report.prepared_report import (
-	create_json_gz_file,
+	PreparedReport,
 	process_filters_for_prepared_report,
 )
 from frappe.tests.utils import FrappeTestCase
@@ -19,11 +21,6 @@ PREP_REPORT = "Jarvis Test Prepared Report"
 # tests we never want it to run (and it wouldn't inline anyway), so we no-op the
 # enqueue at the module where it is bound.
 _ENQUEUE = "frappe.core.doctype.prepared_report.prepared_report.enqueue"
-
-# Sentinel: _make_pr with result=_NOGZ stores NO gz attachment (an in-flight or
-# corrupt-copy row); result=None stores a gz whose result is null (a genuine
-# 0-row completed report); result=[...] stores rows.
-_NOGZ = object()
 
 
 def _ensure_report(name: str, prepared: int) -> None:
@@ -44,9 +41,11 @@ def _ensure_report(name: str, prepared: int) -> None:
 	).insert(ignore_permissions=True)
 
 
-def _make_pr(status, *, owner="Administrator", filters=None, result=_NOGZ, columns=None, age_seconds=0):
-	"""Create a Prepared Report row for PREP_REPORT in a given state, optionally
-	with stored gz data and a back-dated creation."""
+def _make_pr(status, *, owner="Administrator", filters=None, age_seconds=0):
+	"""Create a Prepared Report row for PREP_REPORT in a given state and back-date
+	its creation. Stores NO gz attachment - completed-copy reads are simulated by
+	patching get_prepared_data (see _completed), because the real
+	create_json_gz_file physical-file round-trip is flaky under run-parallel-tests."""
 	with patch(_ENQUEUE):
 		pr = frappe.get_doc(
 			{
@@ -67,11 +66,19 @@ def _make_pr(status, *, owner="Administrator", filters=None, result=_NOGZ, colum
 			add_to_date(now(), seconds=-age_seconds),
 			update_modified=False,
 		)
-	if result is not _NOGZ:
-		create_json_gz_file(
-			{"result": result, "columns": columns or []}, "Prepared Report", pr.name, PREP_REPORT
-		)
 	return pr.name
+
+
+@contextmanager
+def _completed(result, *, columns=None, filters=None, owner="Administrator"):
+	"""A Completed Prepared Report row whose stored output is `result`, made
+	readable WITHOUT touching disk: get_prepared_data returns the decompressed
+	json bytes the real method would (its physical gz round-trip is unreliable
+	under run-parallel-tests). Yields the row name."""
+	dn = _make_pr("Completed", owner=owner, filters=filters)
+	payload = json.dumps({"result": result, "columns": columns or []}).encode("utf-8")
+	with patch.object(PreparedReport, "get_prepared_data", return_value=payload):
+		yield dn
 
 
 class TestRunReportInline(FrappeTestCase):
@@ -137,9 +144,9 @@ class TestRunReportPrepared(FrappeTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
 		_ensure_report(PREP_REPORT, prepared=1)
-		# A prepared report's gz File.save() breaks the per-test transaction
-		# rollback, so a Prepared Report created by one test can leak into the
-		# next and make the completed-copy path win. Start each test clean.
+		# A Prepared Report row does not roll back with the test transaction, so a
+		# row from one test would leak into the next; start each test from a clean
+		# slate (scoped to this fixture report, so it's parallel-safe).
 		frappe.db.delete("Prepared Report", {"report_name": PREP_REPORT})
 		frappe.db.commit()
 
@@ -179,30 +186,30 @@ class TestRunReportPrepared(FrappeTestCase):
 
 	# ---- completed copy reuse -----------------------------------------------
 	def test_ready_from_completed_copy(self):
-		_make_pr("Completed", result=[{"name": "T1", "description": "hi"}], columns=[{"label": "Name"}])
-		env = run_report(report_name=PREP_REPORT)
+		with _completed([{"name": "T1", "description": "hi"}], columns=[{"label": "Name"}]):
+			env = run_report(report_name=PREP_REPORT)
 		self.assertEqual(env["status"], "ready")
 		self.assertEqual(env["result"], [{"name": "T1", "description": "hi"}])
 		self.assertTrue(env["as_of"])
 
 	def test_empty_completed_is_ready_with_zero_rows(self):
-		_make_pr("Completed", result=[])
-		env = run_report(report_name=PREP_REPORT)
+		with _completed([]):
+			env = run_report(report_name=PREP_REPORT)
 		self.assertEqual(env["status"], "ready")
 		self.assertEqual(env["result"], [])  # 0 rows is a COMPLETE answer, not "no data"
 
 	def test_null_result_completed_is_ready_with_zero_rows(self):
 		# A report that stores result=None (columns but no rows) is a genuine 0-row
 		# answer - it must be `ready`, not fall through and regenerate forever.
-		_make_pr("Completed", result=None, columns=[{"label": "Name"}])
-		env = run_report(report_name=PREP_REPORT)
+		with _completed(None, columns=[{"label": "Name"}]):
+			env = run_report(report_name=PREP_REPORT)
 		self.assertEqual(env["status"], "ready")
 		self.assertEqual(env["result"], [])
 
-	def test_completed_with_missing_gz_is_not_ready(self):
-		# Completed but no stored gz -> get_prepared_data throws -> must NOT be
-		# "ready"; it falls through and (re)generates instead.
-		_make_pr("Completed", result=_NOGZ)
+	def test_completed_with_unreadable_output_is_not_ready(self):
+		# Completed but its stored output won't read (get_prepared_data throws) ->
+		# must NOT be "ready"; it falls through and (re)generates instead.
+		_make_pr("Completed")  # no attachment -> real get_prepared_data throws
 		with patch(_ENQUEUE):
 			env = run_report(report_name=PREP_REPORT)
 		self.assertNotEqual(env["status"], "ready")
@@ -210,8 +217,8 @@ class TestRunReportPrepared(FrappeTestCase):
 	def test_row_cap_applied_and_note_reports_true_total(self):
 		total = _prepared_reports._MAX_ROWS + 25
 		big = [{"name": f"T{i}"} for i in range(total)]
-		_make_pr("Completed", result=big)
-		env = run_report(report_name=PREP_REPORT)
+		with _completed(big):
+			env = run_report(report_name=PREP_REPORT)
 		self.assertEqual(env["status"], "ready")
 		self.assertEqual(len(env["result"]), _prepared_reports._MAX_ROWS)
 		self.assertIn(str(total), env["row_note"])  # note reports the UNCAPPED total
@@ -219,11 +226,11 @@ class TestRunReportPrepared(FrappeTestCase):
 	def test_canonical_filters_round_trip_reuses_completed_copy(self):
 		# A completed copy stored for {"company":"Acme"} must be reused when the
 		# agent passes the same logical filters plus a bookkeeping/empty key.
-		_make_pr("Completed", filters={"company": "Acme"}, result=[{"name": "X"}])
-		env = run_report(
-			report_name=PREP_REPORT,
-			filters={"company": "Acme", "prepared_report_name": "junk", "cost_center": ""},
-		)
+		with _completed([{"name": "X"}], filters={"company": "Acme"}):
+			env = run_report(
+				report_name=PREP_REPORT,
+				filters={"company": "Acme", "prepared_report_name": "junk", "cost_center": ""},
+			)
 		self.assertEqual(env["status"], "ready")
 		self.assertEqual(env["result"], [{"name": "X"}])
 
@@ -296,22 +303,23 @@ class TestRunReportPrepared(FrappeTestCase):
 
 	# ---- C1: completed copy is readable WITHOUT the Prepared Report role -----
 	def test_read_completed_needs_no_prepared_report_role(self):
-		dn = _make_pr("Completed", owner="reportless2@example.com", result=[{"name": "T1"}])
-		if not frappe.db.exists("User", "reportless2@example.com"):
-			frappe.get_doc(
-				{
-					"doctype": "User",
-					"email": "reportless2@example.com",
-					"first_name": "Reportless2",
-					"send_welcome_email": 0,
-				}
-			).insert(ignore_permissions=True)
-		frappe.set_user("reportless2@example.com")
-		try:
-			# get_doc-based read must not raise the Prepared Report read-perm error
-			env = _prepared_reports._read_completed(dn)
-		finally:
-			frappe.set_user("Administrator")
+		# _read_completed uses frappe.get_doc (no Prepared Report read role needed),
+		# never run()-by-name (which throws for a roleless user).
+		with _completed([{"name": "T1"}], owner="reportless2@example.com") as dn:
+			if not frappe.db.exists("User", "reportless2@example.com"):
+				frappe.get_doc(
+					{
+						"doctype": "User",
+						"email": "reportless2@example.com",
+						"first_name": "Reportless2",
+						"send_welcome_email": 0,
+					}
+				).insert(ignore_permissions=True)
+			frappe.set_user("reportless2@example.com")
+			try:
+				env = _prepared_reports._read_completed(dn)
+			finally:
+				frappe.set_user("Administrator")
 		self.assertEqual(env["status"], "ready")
 		self.assertEqual(env["result"], [{"name": "T1"}])
 

--- a/jarvis/tools/_prepared_reports.py
+++ b/jarvis/tools/_prepared_reports.py
@@ -1,0 +1,369 @@
+"""Prepared-report handling for the ``run_report`` tool (Phase 0, pull-model).
+
+A Frappe **Prepared Report** is one whose author flagged too heavy to run
+inline: ``run()`` never computes it, it only looks up an already-generated
+copy, and generation happens in a background job (25-min budget). So the bare
+``run_report`` tool returned an empty ``{prepared_report: True, doc: None}`` for
+a prepared report and the agent relayed that as "no data" - the bug this fixes.
+
+Instead we return a **self-describing status envelope**. On every call we
+recompute from live state (there is no stored ticket):
+  - ``ready``       - a completed copy exists; its rows + ``as_of`` ride along.
+  - ``generating``  - a background run for these filters is in flight.
+  - ``failed``      - the most recent run terminally errored; surfaced, not looped.
+  - ``started``     - nothing usable, so we kicked off a background run.
+A paused scheduler / unreachable job queue is RAISED (InvalidArgumentError),
+mirroring ``run_import`` - so the infra condition is a proper wire error, not a
+silent success envelope, and we never leave an orphan row that can't run.
+
+No proactive delivery - that is a later phase; this is pull-only and stateless.
+
+Every gate ``run()`` applies is applied here as the caller, because we bypass
+``run()``:
+  - ``get_report_doc`` - the report's "Has Role" allow-list (``is_permitted``),
+    the ``ref_doctype`` report permission, the disabled-check, Custom-Report
+    resolution. (``make_prepared_report`` also calls it, but the completed-copy
+    READ path would otherwise be ungated.)
+  - ``validate_filters_permissions`` - the record-level guard that a Link filter
+    value points at a doc the caller may read. ``make_prepared_report`` inserts
+    with ``ignore_permissions`` and skips this one, so we must apply it.
+
+The completed copy is read DIRECTLY from its ``Prepared Report`` doc, never via
+``run()`` by name: ``run()`` would (a) drop our filters for a Custom Report's
+``custom_filters`` and (b) throw ``PermissionError`` because a normal ERP user
+lacks the ``Prepared Report`` read role.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+from frappe.core.doctype.prepared_report.prepared_report import (
+	get_completed_prepared_report,
+	make_prepared_report,
+	process_filters_for_prepared_report,
+)
+from frappe.desk.query_report import get_report_doc, validate_filters_permissions
+from frappe.utils import cint
+from frappe.utils.background_jobs import get_redis_conn
+from frappe.utils.scheduler import is_scheduler_inactive
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+
+# Cap rows folded into the envelope. A prepared report is the likeliest place to
+# hit a huge result; an uncapped dump becomes a chat-message payload AND a
+# recurring per-turn token tax once re-serialised into the model context. Same
+# bound dashboards_api uses for the identical run_report-into-a-payload risk.
+_MAX_ROWS = 2000
+
+# Frappe's own default background budget for a prepared report
+# (prepared_report.REPORT_TIMEOUT); a report may override it via Report.timeout.
+_DEFAULT_REPORT_TIMEOUT = 25 * 60
+# A Started report is treated as stuck (worker died mid-run) once it passes its
+# own timeout plus this margin - only then do we re-generate. A Queued report is
+# NOT re-triggered on age: it is enqueued and waiting, and a `long`-queue backlog
+# can legitimately exceed the 25-min job budget, so re-triggering would pile
+# duplicate 25-min jobs. A stuck/orphan Queued therefore shows `generating` until
+# an operator intervenes - we never amplify the backlog.
+_STARTED_STALL_MARGIN = 5 * 60
+
+# Terminal-failure statuses (surface, do not auto-retrigger) and the statuses
+# that mean a run is genuinely in flight.
+_FAILED_STATUSES = ("Error", "Failed")
+_INFLIGHT_STATUSES = ("Queued", "Started")
+
+# Purely-cosmetic bookkeeping key run() itself pops before using filters. NOT
+# translate_data - run() passes that through and it changes the result content,
+# so it is a real request parameter that belongs in the match key.
+_BOOKKEEPING_KEYS = ("prepared_report_name",)
+
+
+def handle_prepared(report_name: str, raw_filters: dict, *, user: str) -> dict:
+	"""Return a status envelope (ready / generating / failed / started) for a
+	prepared report. Pull-model, stateless, runs as ``user``. Raises
+	InvalidArgumentError when the background queue can't run the report."""
+	_gate_report(report_name)
+	filters = _canonical_filters(raw_filters)
+	_gate_filters(report_name, filters, user)
+
+	# 1. A completed copy we can read? (0 rows is a valid answer; unreadable -> fall through)
+	dn = get_completed_prepared_report(filters, user, report_name)
+	if dn:
+		ready = _read_completed(dn)
+		if ready is not None:
+			return ready
+
+	# 2. The most recent non-completed attempt decides: still generating, or a
+	#    terminal failure to surface. A stalled attempt returns None so we re-run.
+	pending = _pending_state(report_name, filters, user)
+	if pending is not None:
+		return pending
+
+	# 3. Nothing usable -> (re)generate. Refuse (raise) if the queue can't run it,
+	#    so we never leave an orphan Queued row that no worker will drain.
+	_require_worker()
+	make_prepared_report(report_name, filters)
+	return _envelope(
+		report_name,
+		"started",
+		"This report is heavy, so it runs in the background - I've started it. "
+		"Ask me again in a little while and I'll have the results.",
+	)
+
+
+# --------------------------------------------------------------------------- #
+# gates
+# --------------------------------------------------------------------------- #
+def _gate_report(report_name: str) -> None:
+	"""Gate the report exactly as run() does: Has-Role allow-list, ref_doctype
+	report permission, disabled-check, Custom-Report resolution."""
+	try:
+		get_report_doc(report_name)
+	except frappe.PermissionError as e:
+		raise PermissionDeniedError(str(e) or f"no permission to run report {report_name}") from e
+	except frappe.ValidationError as e:
+		# a disabled report - not a permission problem; surface as an argument error
+		raise InvalidArgumentError(str(e) or f"report {report_name} is unavailable") from e
+
+
+def _gate_filters(report_name: str, filters: dict, user: str) -> None:
+	"""Record-level guard that a Link filter value points at a doc the caller may
+	read. make_prepared_report skips this (ignore_permissions insert), and the
+	completed-copy read path bypasses run() too, so we apply it once, up front."""
+	if not filters:
+		return
+	try:
+		validate_filters_permissions(report_name, filters, user)
+	except (frappe.PermissionError, frappe.ValidationError) as e:
+		raise PermissionDeniedError(
+			str(e) or f"no permission for the requested filters on {report_name}"
+		) from e
+
+
+# --------------------------------------------------------------------------- #
+# filters
+# --------------------------------------------------------------------------- #
+def _canonical_filters(raw: dict | str | None) -> dict:
+	"""One canonical filter value used for the completed-copy lookup, the
+	in-flight check AND the trigger - so a report WE start is always found by OUR
+	lookup. Strip bookkeeping keys and drop empty values; ordering/spacing is
+	normalised downstream by process_filters_for_prepared_report."""
+	if not raw:
+		return {}
+	if isinstance(raw, str):
+		try:
+			raw = json.loads(raw)
+		except (ValueError, TypeError) as e:
+			raise InvalidArgumentError("filters must be a JSON object of field: value pairs") from e
+	if not isinstance(raw, dict):
+		raise InvalidArgumentError("filters must be an object of field: value pairs")
+	out = {}
+	for key, value in raw.items():
+		if key in _BOOKKEEPING_KEYS:
+			continue
+		if value is None or value == "":
+			continue
+		out[key] = value
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# completed copy (read DIRECTLY - never via run() by name)
+# --------------------------------------------------------------------------- #
+def _read_completed(dn: str) -> dict | None:
+	"""Read a completed Prepared Report's rows straight from its doc. Returns a
+	`ready` envelope, or None if the stored output can't be read (missing/corrupt
+	gz) so the caller falls through to (re)generate rather than emit empty."""
+	try:
+		doc = frappe.get_doc("Prepared Report", dn)
+		raw = doc.get_prepared_data()
+		data = json.loads(raw.decode("utf-8")) if raw else None
+	except frappe.DoesNotExistError:
+		return None  # a concurrent cleanup removed it - benign, just regenerate
+	except Exception as exc:
+		# A completed copy whose stored output won't read is an internal fault, not
+		# a benign miss - log it (exception TYPE + name only; never the payload/
+		# filters, so no report data lands in the Error Log) so "why did this
+		# regenerate" is answerable, then fall through to regenerate.
+		frappe.log_error(
+			title=f"Jarvis: prepared report output unreadable ({dn})",
+			message=f"{type(exc).__name__} reading prepared report {dn}",
+		)
+		return None
+	if data is None:
+		return None
+	columns, result = _split_columns_result(doc, data)
+	# A Completed report can store a null result (columns but no rows) - that is a
+	# genuine 0-row answer, not an unreadable copy.
+	if result is None:
+		result = []
+	if not isinstance(result, list):
+		return None
+	capped, note = _cap_rows(result)
+	as_of = doc.get("report_end_time") or doc.get("creation")
+	env = _envelope(doc.report_name, "ready", _ready_message(len(result), as_of))
+	env["columns"] = columns or []
+	env["result"] = capped
+	env["as_of"] = str(as_of) if as_of else None
+	if note:
+		env["row_note"] = note
+	return env
+
+
+def _split_columns_result(doc, data):
+	"""Pull (columns, result) out of the stored payload. Modern prepared reports
+	store the generate_report_result dict; a legacy shape stored a bare list."""
+	if isinstance(data, dict):
+		return (data.get("columns") or []), data.get("result")
+	if isinstance(data, list):
+		try:
+			columns = json.loads(doc.columns) if doc.get("columns") else []
+		except (ValueError, TypeError):
+			columns = []
+		return columns, data
+	return [], None
+
+
+def _cap_rows(result: list):
+	if len(result) <= _MAX_ROWS:
+		return result, None
+	note = (
+		f"Showing the first {_MAX_ROWS} of {len(result)} rows. Ask me to narrow "
+		f"the filters, or to export the full report."
+	)
+	return result[:_MAX_ROWS], note
+
+
+def _ready_message(row_count: int, as_of) -> str:
+	# Phase 0 serves the existing completed copy for identical filters; there is no
+	# same-filters force-refresh, so the message must NOT promise an on-demand
+	# re-run - it states how current the figures are via as_of instead.
+	when = f" (generated {as_of})" if as_of else ""
+	if row_count == 0:
+		return f"I ran the report{when} - it returned no matching rows."
+	return (
+		f"Here are the results{when}. This report is generated in the background, "
+		f"so the figures are as of that run."
+	)
+
+
+# --------------------------------------------------------------------------- #
+# in-flight / recent failure / worker
+# --------------------------------------------------------------------------- #
+def _pending_state(report_name: str, filters: dict, user: str) -> dict | None:
+	"""State from the most recent NON-completed run for this owner+filters:
+	`generating` if a run is in flight within its stall deadline, `failed` if the
+	most recent run terminally errored, or None (nothing pending, or the in-flight
+	run has stalled) so the caller (re)generates.
+
+	One query over the SINGLE newest attempt, so an old failure can never shadow a
+	newer in-flight run. Owner-scoped with ignore_permissions - a normal ERP user
+	lacks the Prepared Report read role, so a permission-checked read finds nothing."""
+	row = _latest(
+		report_name,
+		filters,
+		user,
+		(*_INFLIGHT_STATUSES, *_FAILED_STATUSES),
+		extra_fields=["status", "creation"],
+	)
+	if not row:
+		return None
+	if row.status == "Queued":
+		# Enqueued and waiting for a worker - never re-trigger (see _STARTED_STALL_MARGIN).
+		return _generating(report_name)
+	if row.status == "Started":
+		age = frappe.utils.time_diff_in_seconds(frappe.utils.now(), row.creation)
+		if age <= _report_timeout(report_name) + _STARTED_STALL_MARGIN:
+			return _generating(report_name)
+		return None  # started but the worker died mid-run -> caller re-generates
+	# Error / Failed - surface it and stop; re-firing the same doomed job on every
+	# ask is the loop we are avoiding. The user can adjust the filters (a new match
+	# key -> a fresh run). The raw error (a traceback) stays out of the message;
+	# Frappe already logged it on the failing job.
+	return _envelope(
+		report_name,
+		"failed",
+		"That report failed to generate. If it needs a filter you didn't set "
+		"(a company, a date range, a required value), tell me and I'll run it "
+		"again with it.",
+	)
+
+
+def _latest(report_name, filters, user, statuses, extra_fields=None):
+	"""Newest owner-scoped Prepared Report for these filters in one of ``statuses``."""
+	rows = frappe.get_all(
+		"Prepared Report",
+		filters={
+			"report_name": report_name,
+			"filters": process_filters_for_prepared_report(filters),
+			"owner": user,
+			"status": ("in", statuses),
+		},
+		fields=["name", *(extra_fields or [])],
+		order_by="creation desc",
+		limit=1,
+		ignore_permissions=True,
+	)
+	return rows[0] if rows else None
+
+
+def _generating(report_name: str) -> dict:
+	return _envelope(
+		report_name,
+		"generating",
+		"Your report is still running in the background. Ask me again in a "
+		"little while and I'll have the results.",
+	)
+
+
+def _report_timeout(report_name: str) -> int:
+	# Key on the report_name we were called with (the custom name for a Custom
+	# Report), matching what after_insert uses to set the job timeout.
+	return cint(frappe.db.get_value("Report", report_name, "timeout")) or _DEFAULT_REPORT_TIMEOUT
+
+
+def _require_worker() -> None:
+	"""Raise if the background queue can't run the report, so we never leave an
+	orphan Queued row. Tests / developer_mode run inline, so skip the check."""
+	if frappe.in_test or frappe.conf.get("developer_mode"):
+		return
+	if is_scheduler_inactive():
+		raise InvalidArgumentError(
+			"This report runs in the background, but the site scheduler is paused, so "
+			"it can't start. Ask an administrator to enable it, then try again."
+		)
+	if not _queue_reachable():
+		raise InvalidArgumentError(
+			"This report runs in the background, but the job queue is unreachable right "
+			"now, so it can't start. Try again shortly, or ask an administrator to check it."
+		)
+
+
+def _queue_reachable() -> bool:
+	# Fail-closed queue probe using Frappe's auth-correct connection. A down
+	# (refused) Redis raises quickly - the common localhost case; a black-holed
+	# host could block, but that is bounded by the outer chat-turn timeout and is
+	# not a realistic localhost failure.
+	try:
+		get_redis_conn().ping()
+		return True
+	except Exception:
+		return False
+
+
+# --------------------------------------------------------------------------- #
+# envelope
+# --------------------------------------------------------------------------- #
+def _envelope(report_name: str, status: str, message: str, **extra) -> dict:
+	# prepared_report stays ALWAYS truthy so the dashboards_api run-time backstop
+	# (which rejects a tile whose run_report result carries prepared_report) keeps
+	# working regardless of status.
+	env = {
+		"prepared_report": True,
+		"status": status,
+		"report_name": report_name,
+		"message": message,
+	}
+	env.update(extra)
+	return env

--- a/jarvis/tools/run_report.py
+++ b/jarvis/tools/run_report.py
@@ -2,20 +2,33 @@ import frappe
 from frappe.desk.query_report import run as frappe_run_report
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools import _prepared_reports
 
 
 def run_report(report_name: str, filters: dict | None = None) -> dict:
 	"""Execute a saved Frappe Report by name.
 
-	Frappe enforces report-level permissions internally and raises frappe.PermissionError
-	on denial; we translate that to PermissionDeniedError so all tools share one
-	exception contract. Returns a dict with `columns` and `result` keys.
+	A normal report runs inline and returns ``{columns, result}``. A **Prepared
+	Report** (flagged too heavy to run inline) is handled by ``_prepared_reports``:
+	instead of Frappe's empty ``{prepared_report: True, doc: None}`` it returns a
+	status envelope (ready / generating / started / failed) and, when nothing is
+	ready, starts the background generation - see that module. A paused scheduler
+	or unreachable job queue is raised as InvalidArgumentError.
+
+	Frappe enforces report-level permissions internally and raises
+	frappe.PermissionError on denial; we translate that to PermissionDeniedError
+	so all tools share one exception contract.
 	"""
 	if not report_name:
 		raise InvalidArgumentError("report_name is required")
 
 	if not frappe.db.exists("Report", report_name):
 		raise InvalidArgumentError(f"unknown Report: {report_name}")
+
+	# A raw get_value on the named report reads the correct flag even for a
+	# Custom Report (get_report_doc carries the custom doc's own prepared_report).
+	if frappe.db.get_value("Report", report_name, "prepared_report"):
+		return _prepared_reports.handle_prepared(report_name, filters or {}, user=frappe.session.user)
 
 	try:
 		return frappe_run_report(report_name=report_name, filters=filters or {})


### PR DESCRIPTION
## What

`run_report` on a Frappe **Prepared Report** (flagged too heavy to run inline) used to return Frappe's empty `{prepared_report: True, doc: None}`, which the agent relayed as **"no data"**. It now returns a self-describing **status envelope** and, when nothing is ready, starts the background generation. Pull-model, stateless (no new doctype/hook/worker).

## How

New `jarvis/tools/_prepared_reports.py` helper (`run_report.py` stays a thin branch; the **inline path is byte-identical**):

- **Gated as `run()` gates**: `get_report_doc` (Has-Role allow-list via `is_permitted` + `ref_doctype` report perm + disabled + Custom-Report resolution) **and** `validate_filters_permissions` (Link-filter record perm) — `make_prepared_report` inserts with `ignore_permissions` and skips the latter, so we apply it.
- **Reads a completed copy directly** from its doc — never `run()`-by-name, which drops a Custom Report's filters and throws for users without the `Prepared Report` role. A null/empty result is a valid 0-row `ready`.
- **Status from the single newest attempt**: `generating` (in flight), `failed` (terminal error — surfaced, not re-fired every ask), or (re)generate. A stuck `Started` re-runs; a `Queued` row is **never** re-triggered (avoids piling duplicate 25-min `long`-queue jobs). A paused scheduler / unreachable queue is **raised** (`InvalidArgumentError`), never a silent envelope, so no orphan row.
- Rows capped; one canonical filter value (bookkeeping keys stripped, empties dropped) keys the completed-lookup, in-flight check, and trigger consistently.

The envelope keeps `prepared_report: True` on **every** status so the `dashboards_api` run-time backstop keeps rejecting prepared reports (regression test added).

## Tests

24 in `test_run_report` (permission gate denial before trigger; ready / empty / null-result / unreadable-gz; `failed` surfaced without re-fire; generating / stalled-retrigger / Queued-stays-generating; scheduler-paused & queue-unreachable raise; malformed filters; canonical round-trip; row cap) + a `run_dashboard_source` back-compat test. All green on `jarvis.test`.

Pairs with `jarvis-openclaw-plugin` and `jarvis-persona` PRs on the same branch (agent-facing envelope docs + etiquette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
