### PR TITLE
feat(chat): trigger the brand peek from the whole sidebar card

### DIFF
--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -22,7 +22,7 @@
 	<span
 		v-else
 		class="jv-mark"
-		:class="[`jv-mood-${mood}`, { 'jv-hoverpeek': hoverPeek }]"
+		:class="[`jv-mood-${mood}`, { 'jv-hoverpeek': hoverPeek, 'jv-peek-on': peek }]"
 		:style="markStyle"
 	>
 		<svg
@@ -62,11 +62,15 @@ const props = defineProps({
 	},
 	/** Sidebar/brand use: reveal a friendly blink on hover, calm otherwise. */
 	hoverPeek: { type: Boolean, default: false },
+	/** Externally-driven peek: show the blinking eyes while true. Lets a larger
+	    surface (e.g. the whole sidebar brand card) drive the same reveal that
+	    hoverPeek gives on the mark alone. */
+	peek: { type: Boolean, default: false },
 });
 
 // The face element only exists when something can show it: an active mood, or a
 // hover-peek surface (where mood stays "star" but hover reveals the eyes).
-const hasFace = computed(() => props.mood !== "star" || props.hoverPeek);
+const hasFace = computed(() => props.mood !== "star" || props.hoverPeek || props.peek);
 
 const markStyle = computed(() => ({
 	width: `${props.size}px`,
@@ -234,16 +238,20 @@ const markStyle = computed(() => ({
 	}
 }
 
-/* HOVER PEEK - resting star until hovered, then a friendly blink. Enabled only
-   where hoverPeek is set (the sidebar brand), and only meaningful while mood is
-   "star" (the face is otherwise hidden). Pure CSS, no listeners. */
-.jv-hoverpeek:hover .jv-star {
+/* PEEK - resting star until triggered, then a friendly blink. Triggered by
+   hovering the mark itself (hoverPeek) or by the `peek` prop, so a larger
+   surface (e.g. the whole sidebar brand card) can drive the same reveal. Only
+   meaningful while mood is "star" (the face is otherwise hidden). */
+.jv-hoverpeek:hover .jv-star,
+.jv-peek-on .jv-star {
 	opacity: 0;
 }
-.jv-hoverpeek:hover .jv-face {
+.jv-hoverpeek:hover .jv-face,
+.jv-peek-on .jv-face {
 	opacity: 1;
 }
-.jv-hoverpeek:hover .jv-eye {
+.jv-hoverpeek:hover .jv-eye,
+.jv-peek-on .jv-eye {
 	animation: jvm-blink 1.8s ease-in-out infinite;
 }
 
@@ -252,7 +260,8 @@ const markStyle = computed(() => ({
 @media (prefers-reduced-motion: reduce) {
 	.jv-face,
 	.jv-eye,
-	.jv-hoverpeek:hover .jv-eye {
+	.jv-hoverpeek:hover .jv-eye,
+	.jv-peek-on .jv-eye {
 		animation: none !important;
 	}
 	.jv-mood-thinking .jv-eye {

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -11,12 +11,14 @@
 						: 'w-full px-2 hover:bg-surface-gray-3'
 				"
 				:aria-label="`${cardTitle} menu`"
+				@mouseenter="brandPeek = true"
+				@mouseleave="brandPeek = false"
 			>
 				<!-- the jarvis mark, 28×28 rounded — rendered from JarvisMark rather than
 				     a hand-pasted copy of its gradient + path data. That duplication is
 				     exactly what let the chat welcome mark drift to a different colour
 				     (design.md §2.2). -->
-				<JarvisMark :size="28" :radius="7" hover-peek />
+				<JarvisMark :size="28" :radius="7" :peek="brandPeek" />
 				<!-- Resting badge: a waiting reply has to register on every route, not
 				     only while the user happens to be in Chat - restoring this (it was
 				     briefly dropped when ChatView grew its own header jv-support-dot,
@@ -53,7 +55,7 @@
 <script setup>
 // Sidebar header (DESIGN-V3 §3.2.1): brand + session user, HD's UserMenu
 // pattern. Dropdown: Settings (D9) · Switch to Desk · Change theme · Log out.
-import { computed, inject, onMounted, onUnmounted } from "vue";
+import { computed, inject, onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { Dropdown, FeatherIcon } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
@@ -68,6 +70,11 @@ const props = defineProps({
 	// "Jarvis Support" title + a "Switch to Jarvis chat" link (we're already in support).
 	variant: { type: String, default: "chat" },
 });
+
+// Whole-card peek: hovering anywhere on the brand button (mark + name), not just
+// the mark itself, reveals the blinking eyes. Two tiny handlers because the
+// hover surface is the parent button, wider than the mark JarvisMark owns.
+const brandPeek = ref(false);
 
 // Card title: agentName ("Jarvis") in chat; "<agentName> Support" on the support rail.
 const cardTitle = computed(() =>


### PR DESCRIPTION
## Summary

Follow-up to #785. The sidebar brand mark revealed its blinking eyes only when you hovered the small 28px mark. Now hovering **anywhere on the brand button** (the mark plus "Jarvis" and the user name) triggers the same reveal, which is the natural hit target for the card.

`JarvisMark` gains a `peek` prop, the externally-driven equivalent of its own `hoverPeek`, and `UserMenu` toggles it from the button's `mouseenter`/`mouseleave`. Same blink, same white-on-gradient, same `prefers-reduced-motion` handling. Verified live: hovering the name text (away from the logo) blinks the eyes.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (coverage gate) — N/A, presentational: a prop + two hover handlers, no logic branch
- [x] I self-reviewed the diff

https://claude.ai/code/session_01764H79tpJmSsD89aWDAEgV
