### PR TITLE
feat: auto-tell import completion (Slice B)

### DIFF
--- a/frontend/src/lib/importFinishedRender.spec.js
+++ b/frontend/src/lib/importFinishedRender.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Slice B ("auto-tell import completion"): when a background Data Import
+ * finishes, the bench posts a message into the originating conversation and
+ * publishes `{ kind: "import:finished", conversation_id, message_id }` to the
+ * conversation owner's socket. Two disjoint listeners share this socket:
+ *
+ *   - ChatView's onEvent (this file) owns the ON-SCREEN case: the
+ *     conversation-id guard already filtered to the conversation the user is
+ *     looking at, so the case just re-reads the transcript, the same way
+ *     message:enriched does.
+ *   - globalNotifier.js (see its own spec) owns the OFF-SCREEN case: the
+ *     sidebar unread dot, with no toast.
+ *
+ * ChatView.vue can't be mounted here (router/socket/api surface), so — like
+ * pendingConfirmResync.spec.js — the wiring is asserted against the source.
+ */
+
+const src = fs.readFileSync(path.resolve(__dirname, "../views/ChatView.vue"), "utf8");
+
+function caseBody(kind) {
+	const at = src.indexOf(`case "${kind}":`);
+	expect(at).toBeGreaterThan(-1);
+	// Up to the next `case "` at the same switch level is close enough to scope it.
+	const rest = src.slice(at + `case "${kind}":`.length);
+	const end = rest.indexOf('\t\tcase "');
+	return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("ChatView renders a finished import live when its conversation is open", () => {
+	it("onEvent's switch has a dedicated import:finished case", () => {
+		expect(src).toContain('case "import:finished":');
+	});
+
+	it("the case re-reads the transcript the same way message:enriched does", () => {
+		const body = caseBody("import:finished");
+		expect(body).toContain("loadConversation(currentId.value);");
+	});
+
+	it("the case sits behind the conversation_id === currentId guard, like message:enriched", () => {
+		// Both cases live inside the same switch, which onEvent only reaches
+		// after `if (p.conversation_id !== currentId.value) return;` — pin the
+		// ordering so a future refactor can't hoist import:finished above it
+		// (the way action:pending/macro:*/conversation:new are, deliberately,
+		// for THEIR off-screen needs).
+		const guardAt = src.indexOf("if (p.conversation_id !== currentId.value) return;");
+		const switchAt = src.indexOf("switch (p.kind) {");
+		const caseAt = src.indexOf('case "import:finished":');
+		expect(guardAt).toBeGreaterThan(-1);
+		expect(guardAt).toBeLessThan(switchAt);
+		expect(switchAt).toBeLessThan(caseAt);
+	});
+
+	it("does not run the pump-epoch fence — this is a scheduler-originated signal, not a turn frame", () => {
+		const body = caseBody("import:finished");
+		expect(body).not.toContain("pumpFenceReject");
+		expect(body).not.toContain("pumpFenceAccept");
+	});
+});

--- a/frontend/src/notify/globalNotifier.js
+++ b/frontend/src/notify/globalNotifier.js
@@ -292,6 +292,19 @@ export function attachGlobalNotifier({ socket, router }) {
 				}
 				return;
 			}
+			case "import:finished": {
+				// Slice B: a background CSV import finished; the bench already
+				// posted the "✓ ..." completion message into the conversation and
+				// committed it durably. ChatView (this same socket, a separate
+				// listener) re-reads the transcript live when that conversation is
+				// on screen — this listener owns only the off-screen unread dot,
+				// and deliberately calls markUnread DIRECTLY, bypassing signal()/
+				// browserNotify: no push toast/browser notification for this
+				// event, this wave.
+				const conv = p.conversation_id;
+				if (conv && conv !== onScreenConv()) store.markUnread(conv);
+				return;
+			}
 		}
 	}
 

--- a/frontend/src/notify/globalNotifier.spec.js
+++ b/frontend/src/notify/globalNotifier.spec.js
@@ -71,6 +71,7 @@ beforeEach(() => {
 	for (const t of [...useToasts().value]) dismissToast(t.id);
 	vi.clearAllMocks();
 	setHidden(false);
+	store.currentConvId = null;
 	socket = fakeSocket();
 	detach = attachGlobalNotifier({ socket, router });
 });
@@ -145,5 +146,57 @@ describe("a hidden tab takes the browser-notification branch, not the toast", ()
 		socket.emit(terminal());
 		socket.emit(terminal());
 		expect(useToasts().value).toHaveLength(0);
+	});
+});
+
+// Slice B ("auto-tell import completion"): a background Data Import posts its
+// "✓ ..." message into the conversation and publishes
+// { kind: "import:finished", conversation_id, message_id } to the owner. This
+// listener owns only the OFF-SCREEN half (the sidebar unread dot) — ChatView's
+// own onEvent (see importFinishedRender.spec.js) re-reads the transcript when
+// that conversation is the one on screen. The plan is explicit that this wave
+// ships NO push toast/browser notification for this event, so these tests pin
+// markUnread as a DIRECT call, bypassing signal()/browserNotify entirely.
+describe("import:finished marks the sidebar unread, never a toast", () => {
+	it("calls store.markUnread directly for an off-screen conversation", () => {
+		socket.emit({ kind: "import:finished", conversation_id: "conv-a", message_id: "msg-1" });
+		expect(store.markUnread).toHaveBeenCalledWith("conv-a");
+		expect(useToasts().value).toHaveLength(0);
+	});
+
+	it("still only marks unread — no toast — even while the tab is hidden", () => {
+		// The hidden branch is where run:end/run:error escalate to a browser
+		// notification (signal()'s first branch). import:finished must never
+		// reach signal() at all, so nothing renders here either.
+		setHidden(true);
+		socket.emit({ kind: "import:finished", conversation_id: "conv-a", message_id: "msg-1" });
+		expect(store.markUnread).toHaveBeenCalledWith("conv-a");
+		expect(useToasts().value).toHaveLength(0);
+	});
+
+	it("does nothing for a conversation-less event, rather than marking ambiently", () => {
+		socket.emit({ kind: "import:finished", message_id: "msg-1" });
+		expect(store.markUnread).not.toHaveBeenCalled();
+	});
+
+	it("leaves the ON-screen conversation alone — that's ChatView's job, not this listener's", () => {
+		const savedRoute = router.currentRoute.value;
+		store.currentConvId = "conv-a";
+		router.currentRoute.value = {
+			name: "Chat",
+			params: { id: "conv-a" },
+			meta: { chat: true },
+		};
+		try {
+			socket.emit({
+				kind: "import:finished",
+				conversation_id: "conv-a",
+				message_id: "msg-1",
+			});
+			expect(store.markUnread).not.toHaveBeenCalled();
+		} finally {
+			router.currentRoute.value = savedRoute;
+			store.currentConvId = null;
+		}
 	});
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8382,6 +8382,18 @@ function onEvent(p) {
 			setTimeout(processMermaid, 300);
 			break;
 		}
+		case "import:finished": {
+			// Slice B: a background CSV import finished and the bench already
+			// posted the "✓ ..." completion message into this conversation
+			// (durably committed, published only to the conversation owner).
+			// The conversation-id guard above already confirmed this is the
+			// conversation on screen, so mirror message:enriched's re-read
+			// rather than trying to splice the message in by hand — an
+			// off-screen import instead reaches the sidebar unread dot via
+			// globalNotifier.js's own listener on this same socket.
+			loadConversation(currentId.value);
+			break;
+		}
 		case "wiki:nudge": {
 			// Post-turn "remember this?" prompt. Don't clobber a card the user is
 			// already recording into / editing — only replace an idle (or absent)

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -328,6 +328,39 @@ def _persist_and_publish_tool_call(
 	persist_tool_receipt(conv_name, tool, args, result, tool_call_id=tool_call_id)
 
 
+def _locked_insert_chat_message(
+	conv_name: str, fields: dict, *, dedupe_filters: dict | None = None
+) -> str | None:
+	"""Allocate the next ``seq`` for ``conv_name`` UNDER a ``Jarvis Conversation``
+	``FOR UPDATE`` lock and insert one ``Jarvis Chat Message`` with ``fields`` merged
+	onto ``{conversation, seq}``. Returns the message name, or ``None`` when
+	``dedupe_filters`` already matches a row (nothing inserted).
+
+	MUST be called inside an ``impersonate(conv_owner)`` block that has already
+	``commit``ed, so this ``FOR UPDATE`` is the first statement of the transaction
+	(REPEATABLE-READ discipline). The caller commits AFTER (releasing the lock) and
+	publishes post-commit. This is the ONE ``FOR UPDATE`` + ``MAX(seq)+1`` critical
+	section in the codebase - shared by ``persist_tool_receipt`` (inline + confirmed
+	receipts) and ``import_announce._post_completion`` (the import auto-tell) so the
+	seq-collision guard is never forked (PC-1)."""
+	frappe.db.sql(
+		"SELECT name FROM `tabJarvis Conversation` WHERE name=%(c)s FOR UPDATE",
+		{"c": conv_name},
+	)
+	if dedupe_filters and frappe.db.exists("Jarvis Chat Message", dedupe_filters):
+		return None
+	seq = (
+		frappe.db.sql(
+			"SELECT MAX(seq) FROM `tabJarvis Chat Message` WHERE conversation=%(c)s",
+			{"c": conv_name},
+		)[0][0]
+		or 0
+	) + 1
+	doc = frappe.get_doc({"doctype": "Jarvis Chat Message", "conversation": conv_name, "seq": seq, **fields})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
 def persist_tool_receipt(
 	conv_name: str,
 	tool: str,
@@ -397,29 +430,9 @@ def persist_tool_receipt(
 		# callback for the same tool call is a no-op. Commit-first so the FOR UPDATE
 		# is the first statement (REPEATABLE-READ discipline).
 		frappe.db.commit()
-		frappe.db.sql(
-			"SELECT name FROM `tabJarvis Conversation` WHERE name=%(c)s FOR UPDATE",
-			{"c": conv_name},
-		)
-		if tool_call_id and frappe.db.exists(
-			"Jarvis Chat Message", {"conversation": conv_name, "tool_call_id": tool_call_id}
-		):
-			# Duplicate callback for the same tool call — already recorded. Release
-			# the lock and return; the out-of-band writer is idempotent (R-6).
-			frappe.db.commit()
-			return
-		seq = (
-			frappe.db.sql(
-				"SELECT MAX(seq) FROM `tabJarvis Chat Message` WHERE conversation=%(c)s",
-				{"c": conv_name},
-			)[0][0]
-			or 0
-		) + 1
-		doc = frappe.get_doc(
+		msg_name = _locked_insert_chat_message(
+			conv_name,
 			{
-				"doctype": "Jarvis Chat Message",
-				"conversation": conv_name,
-				"seq": seq,
 				"role": "tool",
 				"tool_name": tool,
 				"tool_args": frappe.as_json(args),
@@ -430,14 +443,22 @@ def persist_tool_receipt(
 				"ref_doctype": ref_doctype,
 				"ref_name": ref_name,
 				"content": f"{tool} → {action_outcome or status}",
-			}
+			},
+			# ``(conversation, tool_call_id)`` dedupe — a duplicate callback for the SAME
+			# tool call is a no-op (R-6 out-of-band idempotency). Null id: no dedupe, but
+			# the seq race is still fixed by the shared FOR UPDATE.
+			dedupe_filters=(
+				{"conversation": conv_name, "tool_call_id": tool_call_id} if tool_call_id else None
+			),
 		)
-		doc.insert(ignore_permissions=True)
 		frappe.db.commit()
+		if msg_name is None:
+			# Duplicate callback for the same tool call — already recorded (R-6 idempotent).
+			return
 		publish_realtime_tool_result(
 			user=conv_owner,
 			conversation_id=conv_name,
-			tool_message_id=doc.name,
+			tool_message_id=msg_name,
 			tool_name=tool,
 			args=args,
 			result=result,

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -484,6 +484,14 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 		)
 		result = api._error("InternalError", "the confirmed action failed unexpectedly and was not saved")
 
+	# Slice B: bind a Jarvis Import Announcement so the import's completion is
+	# announced back into this chat unprompted. Best-effort + self-gating (tool ==
+	# run_import + ok); binds to the token's OWN guarded conversation (PC-4), never
+	# the client-supplied passed_conv.
+	from jarvis.chat import import_announce
+
+	import_announce.bind_after_run_import(record, result)
+
 	# Leave a transcript receipt (#7) so a confirmed delete/submit/email shows on
 	# reload, matching the inline model-write path's tool card. Best-effort: the
 	# write already committed, so a receipt hiccup must not report failure.

--- a/jarvis/chat/import_announce.py
+++ b/jarvis/chat/import_announce.py
@@ -1,0 +1,524 @@
+"""Auto-tell of Data Import completion (Slice B).
+
+When a background import started by ``run_import`` (Slice A) finishes, Jarvis posts
+a completion message into the ORIGINATING chat on its own - "✓ Import into <doctype>
+from <file>: N imported, M failed" - so the user never has to ask "did it work?".
+Stuck / blocked / dead imports are announced too (never silent).
+
+TWO triggers drive ONE classifier - do NOT delete either:
+  * The ``*/2`` scheduler POLL (:func:`announce_finished_imports` with no filter) is
+    the CORRECTNESS GUARANTEE. It is the ONLY thing that catches a worker/container
+    death (deploy restart, reboot, eviction, work-horse OOM) - no in-process hook
+    survives a killed process. It will look "redundant" once the fast path works;
+    it is not. Never remove it.
+  * The ``after_job`` HOOK (:func:`on_after_job`) is a best-effort LATENCY shortcut:
+    it taps the same classifier for one import the instant its job ends, so the
+    healthy/errored/timed-out/blocked case pings in seconds instead of <=2 min. It
+    may silently vanish (absent on a Frappe build, mis-registered, ``short`` queue
+    starved) and the poll simply carries everything - safe degradation, watch
+    ``import_announce_stats().hook_rate_24h``.
+
+Kill switch: ``frappe.conf.jarvis_import_announce_disabled`` stops BOTH the poll and
+the hook (a broken hook *registration* needs a code revert - no flag can reach it).
+
+v16/v17: this module MUST import clean on Frappe v16 - it is wired into ``after_job``,
+which runs in the ``finally`` of EVERY background job on the bench, with no core
+try/except, so a module-top ImportError here would fail every job. Keep top-level
+imports to ``frappe`` + always-present utils; defer ``get_import_status`` /
+``is_job_enqueued`` into function bodies.
+"""
+
+import frappe
+from frappe.utils import now_datetime
+
+_ANNOUNCEMENT = "Jarvis Import Announcement"
+
+
+# ---------------------------------------------------------------------------
+# Confirm-time binding (T1) - create the tracking row after a confirmed run_import
+# ---------------------------------------------------------------------------
+def bind_after_run_import(record: dict, result) -> None:
+	"""Best-effort: after a CONFIRMED ``run_import`` dispatch, create one
+	``Jarvis Import Announcement`` so the poll + hook can announce the import's
+	completion into the originating chat.
+
+	NEVER fails the confirm - the import already ran; a failed bind is ``log_error``'d
+	(PC-3) and costs at most one silent import (no announcement), an accepted
+	sub-second residual (O-1), NOT a reverse-orphan sweep.
+
+	SECURITY (PC-4 / F4): binds to the TOKEN's OWN guarded ``conversation``/``owner``
+	(``record`` came from ``pending_confirm.consume``), NEVER the client-supplied
+	``passed_conv`` - else an attacker could post a Jarvis-spoofed completion into a
+	victim's chat.
+	"""
+	try:
+		if (record or {}).get("tool") != "run_import":
+			return
+		if not (isinstance(result, dict) and result.get("ok")):
+			return
+		# Kill-switch (AJ-6): while the announcer is disabled, do NOT create rows either -
+		# else a backlog accumulates unobserved and burst-replays stale completions on
+		# re-enable (review finding). One flag stops bind + poll + hook.
+		if frappe.conf.get("jarvis_import_announce_disabled"):
+			return
+		data = result.get("data") or {}
+		di = data.get("data_import")
+		conversation = record.get("conversation")  # guarded (from consume); never passed_conv
+		owner = record.get("owner")
+		if not (di and conversation and owner):
+			return
+		# Pre-migrate window: the binding + poll ship in the SAME release as the
+		# doctype; no-op cleanly until migrate creates the table (edge 13).
+		if not frappe.db.exists("DocType", _ANNOUNCEMENT):
+			return
+		# Idempotent: ``data_import`` is unique. A re-confirm or a race must not raise a
+		# DuplicateEntry into the confirm path.
+		if frappe.db.exists(_ANNOUNCEMENT, {"data_import": di}):
+			return
+		doc = frappe.new_doc(_ANNOUNCEMENT)
+		doc.data_import = di
+		doc.conversation = conversation
+		doc.owner = owner  # the conversation owner (respected by set_user_and_timestamp)
+		doc.kicked_off_at = now_datetime()
+		doc.announced = 0
+		doc.insert(ignore_permissions=True)
+	except (frappe.UniqueValidationError, frappe.DuplicateEntryError):
+		# A concurrent bind won the unique(data_import) race - benign, not a failure. A unique
+		# FIELD violation raises UniqueValidationError (DuplicateEntryError is primary-key only).
+		pass
+	except Exception:
+		frappe.log_error(title="import announce bind failed", message=frappe.get_traceback())
+
+
+# ---------------------------------------------------------------------------
+# Cascade (T5) - a deleted conversation must not orphan / block on its rows
+# ---------------------------------------------------------------------------
+def on_conversation_trash(doc, method=None) -> None:
+	"""Second ``on_trash`` handler for ``Jarvis Conversation`` (alongside
+	``admission.on_conversation_trash``): delete this conversation's announcement
+	rows so its Link does not block deletion (``LinkExistsError``) and no
+	``announced=0`` row is orphaned for the poll. Runs inside the trash txn, so a
+	failure correctly rolls the whole delete back rather than half-deleting."""
+	if not frappe.db.exists("DocType", _ANNOUNCEMENT):
+		return
+	frappe.db.delete(_ANNOUNCEMENT, {"conversation": doc.name})
+
+
+# ---------------------------------------------------------------------------
+# The classifier + poll (T2) and the message-post (T3)
+# ---------------------------------------------------------------------------
+_TERMINAL_STATUSES = frozenset({"Success", "Partial Success", "Error", "Timed Out"})
+_STALE_GRACE_MINUTES = 5  # O-5: absorb the enqueue-registration lag before "didn't complete"
+_CEILING_MINUTES = 720  # O-2: absolute age past which a still-"enqueued" import is presumed dead
+_WORKLIST_LIMIT = 50  # PC-6: drain across ticks; a completion burst can't scan-storm one tick
+_MAX_ROW_ATTEMPTS = 5  # bounded retry: quarantine a row whose classify raises this many ticks
+_DEADMAN_AGE_MINUTES = 30  # PC-3: an announced=0 row older than this is "stuck in the pipeline"
+_DEADMAN_BACKLOG = 25  # PC-3: alarm when this many pile up (poll wedged / kill-switch left on)
+_DEADMAN_DEDUPE_HOURS = 20  # alarm ~once/day, not every tick
+
+
+def _age_minutes(dt) -> float:
+	if not dt:
+		# A missing kicked_off_at must fail LOUD (past every threshold) so the row gets
+		# announced/quarantined, not sit at age 0 forever - invisible to grace/ceiling/deadman.
+		return float("inf")
+	from frappe.utils import get_datetime
+
+	return (now_datetime() - get_datetime(dt)).total_seconds() / 60.0
+
+
+def _is_job_enqueued(di: str) -> bool:
+	"""True while the import's RQ job is QUEUED/STARTED. Isolated behind this helper
+	(deferred import) for v16/v17 brittleness + module import-safety (PC-7/AJ-2)."""
+	from frappe.utils.background_jobs import is_job_enqueued
+
+	return is_job_enqueued(f"data_import||{di}")
+
+
+def _read_tally(di: str) -> dict | None:
+	"""The import outcome via RAW reads - deliberately NOT get_import_status, which
+	runs check_permission('read') and throws under a suspended/limited owner, leaving
+	an announced=0 limbo behind a terminal status (AJ-3). Works whether the poll
+	(Administrator) or the hook-enqueued classify (the import user) invokes it.
+	Returns None if the Data Import was deleted (a poison row - PC-5). success/failed
+	are summed (get_import_status OMITS those keys for an all-failed/zero-log import -
+	PC-2)."""
+	d = frappe.db.get_value("Data Import", di, ["status", "payload_count"], as_dict=True)
+	if not d:
+		return None
+	rows = frappe.db.sql(
+		"SELECT success, COUNT(*) AS c FROM `tabData Import Log` WHERE data_import=%(d)s GROUP BY success",
+		{"d": di},
+		as_dict=True,
+	)
+	success = sum(r.c for r in rows if r.success)
+	failed = sum(r.c for r in rows if not r.success)
+	return {"status": d.status, "total_records": d.payload_count, "success": success, "failed": failed}
+
+
+def _has_template_warnings(di: str) -> bool:
+	tw = frappe.db.get_value("Data Import", di, "template_warnings")
+	if not tw:
+		return False
+	try:
+		# template_warnings is a JSON list; parse it rather than string-compare "[]" so a
+		# format drift ("[ ]", "{}") can't be misread as "has warnings".
+		return bool(frappe.parse_json(tw))
+	except Exception:
+		return bool(str(tw).strip())
+
+
+def _neutralize(s) -> str:
+	"""Disarm an untrusted filename/label server-side so it cannot break out of the message
+	text on EITHER frontend (PC-4). The shared markdown renderer's link rule matches a literal
+	``[ ]( )`` even when the characters are backslash-escaped, so we REMOVE the structural
+	markdown metacharacters (replace with a space) rather than escape them - escaping would
+	still render an attacker-controlled link. HTML-escape angle brackets too."""
+	s = str(s)
+	s = s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+	for ch in ("`", "*", "_", "[", "]", "(", ")", "\\"):
+		s = s.replace(ch, " ")
+	return s
+
+
+def _di_context(di: str) -> tuple[str, str]:
+	d = frappe.db.get_value("Data Import", di, ["reference_doctype", "import_file"], as_dict=True) or {}
+	doctype = d.get("reference_doctype") or "records"
+	fu = d.get("import_file") or ""
+	fname = fu.rsplit("/", 1)[-1] if fu else "the file"
+	return _neutralize(doctype), _neutralize(fname)
+
+
+def _link(di: str) -> str:
+	"""ABSOLUTE link to the Data Import - the only way a failed-import message lets the user
+	open the record (no frontend reads ref_doctype/ref_name, PC-2). Must be an absolute
+	``http(s)://`` URL: the shared markdown renderer only linkifies ``https?://`` URLs, so a
+	relative ``/app/...`` path renders as inert literal text (review finding)."""
+	from urllib.parse import quote
+
+	url = frappe.utils.get_url("/app/data-import/" + quote(di, safe=""))
+	return f"[{_neutralize(di)}]({url})"
+
+
+def _completion_copy(tally: dict, di: str) -> tuple[str, str]:
+	"""(reason, content) for a covered terminal import - branch on STATUS FIRST (an Error /
+	Timed Out import must never render as a green "done", even with a 0/0 tally - review
+	finding), then on the RECORDS counts. Filename escaped, link to the Data Import (PC-2)."""
+	doctype, fname = _di_context(di)
+	link = _link(di)
+	s, f, status = tally["success"], tally["failed"], tally["status"]
+	head = f"Import into **{doctype}** from **{fname}**"
+	if status == "Timed Out":
+		return (
+			"timed_out",
+			f"⚠️ {head} timed out — **{s}** imported, **{f}** failed before it stopped. Check {link}.",
+		)
+	if status == "Error":
+		return "error", f"✗ {head} failed — **{s}** imported, **{f}** failed. Check {link}."
+	if s == 0 and f == 0:
+		return "done", f"✓ {head}: nothing to import — 0 records. ({link})"
+	if f == 0:
+		return "done", f"✓ {head}: **{s}** record(s) imported. ({link})"
+	if s == 0:
+		return "error", f"✗ {head} failed — **0** imported, **{f}** failed. Check {link}."
+	return "partial", f"⚠️ {head}: **{s}** imported, **{f}** failed. Check {link}."
+
+
+def _copy_blocked(di: str) -> str:
+	doctype, fname = _di_context(di)
+	return (
+		f"✗ Import into **{doctype}** from **{fname}** was blocked — nothing imported. "
+		f"Check the file's columns ({_link(di)})."
+	)
+
+
+def _copy_interrupted(tally: dict, di: str) -> str:
+	doctype, fname = _di_context(di)
+	return (
+		f"⚠️ Import into **{doctype}** from **{fname}** didn't complete — **{tally['success']}** "
+		f"record(s) imported so far. Check {_link(di)}."
+	)
+
+
+def _copy_status_unknown(di: str) -> str:
+	doctype, fname = _di_context(di)
+	return (
+		f"⚠️ Import into **{doctype}** from **{fname}** — status unknown after a long wait. Check {_link(di)}."
+	)
+
+
+def _set_reason(ann: str, reason: str) -> None:
+	# WHERE announced=0: never overwrite the reason of an already-terminal row - a late
+	# concurrent classify must not corrupt the by_reason stats (matches the CAS discipline).
+	frappe.db.sql(
+		"UPDATE `tabJarvis Import Announcement` SET reason=%(r)s WHERE name=%(n)s AND announced=0",
+		{"r": reason, "n": ann},
+	)
+	frappe.db.commit()
+
+
+def _mark_terminal(ann: str, reason: str, source: str) -> None:
+	"""Flip announced=1 WITHOUT posting (poison row / no resolvable owner / archived) so
+	the row leaves the worklist and never re-polls; ``reason`` records why it aborted."""
+	frappe.db.sql(
+		"UPDATE `tabJarvis Import Announcement` SET announced=1, announced_via=%(s)s, reason=%(r)s "
+		"WHERE name=%(n)s AND announced=0",
+		{"s": source, "r": reason, "n": ann},
+	)
+	frappe.db.commit()
+
+
+def _bump_attempts(row: dict) -> None:
+	"""Bounded retry (PC-5): a row whose classify raises EVERY tick would re-log forever and,
+	below the deadman's backlog threshold, never alarm. Count consecutive failures and, after
+	_MAX_ROW_ATTEMPTS, quarantine it terminal (reason="poison_error", surfaced in by_reason)."""
+	try:
+		n = (row.get("attempts") or 0) + 1
+		if n >= _MAX_ROW_ATTEMPTS:
+			_mark_terminal(row["name"], "poison_error", "poll")
+		else:
+			frappe.db.set_value(_ANNOUNCEMENT, row["name"], "attempts", n, update_modified=False)
+			frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+
+
+def _post_completion(row: dict, source: str, reason: str, content: str) -> str:
+	"""Post the completion message into the originating chat and flip announced=1,
+	EXACTLY once. Conversation-lock-FIRST (PC-1): commit -> FOR UPDATE conversation ->
+	natural-key dedupe on Jarvis Chat Message -> insert -> CAS announced=1 (same lock)
+	-> commit -> publish AFTER commit. Owner resolved fail-closed BEFORE impersonate
+	(impersonate(None) is a silent Administrator no-op - AJ-3/PC-4)."""
+	conv = row["conversation"]
+	di = row["data_import"]
+	ann = row["name"]
+	c = frappe.db.get_value("Jarvis Conversation", conv, ["owner", "status"], as_dict=True)
+	if not c or not c.owner:
+		# Conversation gone / owner unresolved on a live row: never post as Administrator.
+		_mark_terminal(ann, "no_conversation", source)
+		return "aborted"
+	if c.status == "Archived":
+		# EC5: don't post into a dead thread; mark terminal so it stops polling.
+		_mark_terminal(ann, "archived", source)
+		return "archived"
+
+	from jarvis._session import impersonate
+	from jarvis.api import _locked_insert_chat_message
+	from jarvis.chat import events
+
+	msg = None
+	with impersonate(c.owner):
+		frappe.db.commit()  # commit-first: the FOR UPDATE is the first statement (REPEATABLE-READ)
+		msg = _locked_insert_chat_message(
+			conv,
+			{
+				"role": "assistant",
+				"content": content,
+				"hidden": 0,
+				"ref_doctype": "Data Import",
+				"ref_name": di,
+			},
+			# Exactly-once is THIS natural-key dedupe (PC-1), not the flag: a concurrent
+			# poll + fast-path classify serialize on the conversation lock, and the loser
+			# sees the winner's message here and skips the insert. role="assistant" is
+			# LOAD-BEARING: a tool receipt (role="tool") for a get_doc of THIS Data Import -
+			# which the run_import note explicitly invites ("Ask me to check on it") - also
+			# carries ref_doctype="Data Import"/ref_name=di, and without the role scope it
+			# would false-match and SILENTLY suppress the real completion (only the
+			# announcement writes an assistant row with this ref).
+			dedupe_filters={
+				"conversation": conv,
+				"role": "assistant",
+				"ref_doctype": "Data Import",
+				"ref_name": di,
+			},
+		)
+		# CAS the row terminal inside the SAME lock. announced=1 whether we posted or
+		# deduped - the flag only stops the poll re-checking.
+		frappe.db.sql(
+			"UPDATE `tabJarvis Import Announcement` SET announced=1, announced_via=%(s)s, reason=%(r)s "
+			"WHERE name=%(n)s AND announced=0",
+			{"s": source, "r": reason, "n": ann},
+		)
+		frappe.db.commit()
+	if msg:
+		events.publish_to_user(
+			c.owner, {"kind": "import:finished", "conversation_id": conv, "message_id": msg}
+		)
+	return "announced"
+
+
+def _classify_and_announce(row: dict, source: str) -> str:
+	"""Decide one un-announced row's fate and act. Returns a count key. The completion
+	TRIGGER is job-done (is_job_enqueued == False), NOT status - 'Partial Success' is a
+	MID-import status written after row 1."""
+	ann = row["name"]
+	di = row["data_import"]
+	enqueued = _is_job_enqueued(di)
+	age = _age_minutes(row["kicked_off_at"])
+	prev_reason = row.get("reason") or ""
+
+	# 1) Job still enqueued -> legitimately running; skip WITHOUT reading the (unindexed) Data
+	#    Import Log tally. EXCEPT past the O-2 ceiling: a full worker/container death leaves
+	#    is_job_enqueued True FOREVER (the Redis job hash is never reaped), so an absolute-age
+	#    backstop surfaces it. Cheap-check-first also stops a backlog of long-running imports
+	#    from starving newer FINISHED rows behind them in the worklist.
+	if enqueued and age <= _CEILING_MINUTES:
+		if prev_reason == "stuck_seen":
+			_set_reason(ann, "")  # a transient not-enqueued blip resolved; clear the marker
+		return "running"
+
+	# We need the outcome from here.
+	tally = _read_tally(di)
+	if tally is None:
+		_mark_terminal(ann, "data_import_deleted", source)  # PC-5 poison row
+		return "poison"
+	if enqueued:  # enqueued AND past the ceiling -> presumed dead (worker/container death)
+		return _post_completion(row, source, "status_unknown", _copy_status_unknown(di))
+
+	status = tally["status"]
+	terminal = status in _TERMINAL_STATUSES
+	payload = tally["total_records"] or 0
+	covered = (tally["success"] + tally["failed"]) >= payload if payload else True
+
+	# --- job NOT enqueued from here ---
+
+	# 2) Blocked: the job returned WITHOUT a terminal status (import_data early-returns on
+	#    blocking warnings) - Pending + template_warnings, nothing imported (PC-2).
+	if not terminal:
+		if status == "Pending" and _has_template_warnings(di):
+			return _post_completion(row, source, "blocked", _copy_blocked(di))
+		# 3) Interrupted/stuck. Guard with the ~5-min grace (enqueue-registration lag) AND
+		#    a two-tick confirmation - a transient Redis is_job_enqueued blip must not
+		#    false-announce "didn't complete" (O-5).
+		if age < _STALE_GRACE_MINUTES:
+			return "running"
+		if prev_reason != "stuck_seen":
+			_set_reason(ann, "stuck_seen")  # first sighting; confirm on the next tick
+			return "stuck_pending"
+		return _post_completion(row, source, "interrupted", _copy_interrupted(tally, di))
+
+	# 4) Terminal status.
+	if not covered:
+		# Terminal (usually "Partial Success") but success+failed < payload_count -> the
+		# worker was hard-killed mid-run; never a clean tally (PC-2).
+		return _post_completion(row, source, "interrupted", _copy_interrupted(tally, di))
+	reason, content = _completion_copy(tally, di)
+	return _post_completion(row, source, reason, content)
+
+
+def _deadman_watch() -> None:
+	"""Poll-only tail (PC-3): if the backlog of announced=0 rows older than the grace
+	exceeds a threshold - the poll wedged, the kill-switch was left on, or every row is
+	silently skipping - log_error once/~day (deduped like recovery_rate_watch). Folded
+	into the poll, NOT a second cron."""
+	from frappe.utils import add_to_date
+
+	cutoff = add_to_date(now_datetime(), minutes=-_DEADMAN_AGE_MINUTES)
+	backlog = frappe.db.count(_ANNOUNCEMENT, {"announced": 0, "kicked_off_at": ["<", cutoff]})
+	if backlog < _DEADMAN_BACKLOG:
+		return
+	title = "import_announce: un-announced backlog"
+	since = add_to_date(now_datetime(), hours=-_DEADMAN_DEDUPE_HOURS)
+	if frappe.db.sql(
+		"SELECT name FROM `tabError Log` WHERE method=%(t)s AND creation>=%(s)s LIMIT 1",
+		{"t": title, "s": since},
+	):
+		return
+	frappe.log_error(
+		title=title,
+		message=(
+			f"{backlog} import announcement(s) un-announced for >{_DEADMAN_AGE_MINUTES}m - the poll "
+			f"may be wedged or the kill-switch left on (or a burst of long-running imports). "
+			f"See import_announce_stats."
+		),
+	)
+
+
+def announce_finished_imports(data_import: str | None = None, source: str = "poll") -> dict:
+	"""The classifier entry, driven by TWO callers (do not delete either - see the module
+	docstring): the ``*/2`` poll (no ``data_import`` - drains a bounded worklist, the
+	correctness guarantee) and the ``after_job`` fast path (one ``data_import`` - the
+	latency shortcut). Self-wraps per row + returns structured counts. Kill-switch +
+	DocType-existence guards first (pre-migrate + operator off-switch)."""
+	if frappe.conf.get("jarvis_import_announce_disabled"):
+		return {"skipped": "disabled"}
+	if not frappe.db.exists("DocType", _ANNOUNCEMENT):
+		return {"skipped": "no_doctype"}
+	filters = {"announced": 0}
+	if data_import:
+		filters["data_import"] = data_import
+	rows = frappe.get_all(
+		_ANNOUNCEMENT,
+		filters=filters,
+		fields=["name", "data_import", "conversation", "owner", "kicked_off_at", "reason", "attempts"],
+		order_by="creation asc",
+		limit=(1 if data_import else _WORKLIST_LIMIT),
+	)
+	counts = {"checked": len(rows)}
+	for r in rows:
+		try:
+			outcome = _classify_and_announce(r, source)
+		except Exception:
+			# Restore per-row isolation: release any conversation lock taken mid-_post_completion
+			# and discard partial writes so they don't bleed into the next row (review finding).
+			frappe.db.rollback()
+			outcome = "errored"
+			frappe.log_error(title="import_announce: row failed", message=frappe.get_traceback())
+			_bump_attempts(r)  # bounded retry -> quarantine a deterministically-failing row
+		counts[outcome] = counts.get(outcome, 0) + 1
+	if not data_import:  # poll-only tail
+		try:
+			_deadman_watch()
+		except Exception:
+			frappe.log_error(title="import_announce: deadman failed", message=frappe.get_traceback())
+	return counts
+
+
+# ---------------------------------------------------------------------------
+# The after_job fast path (T8) - a latency shortcut layered on the poll
+# ---------------------------------------------------------------------------
+def on_after_job(method=None, kwargs=None, result=None, **_) -> None:
+	"""``after_job`` hook - runs in the ``finally`` of EVERY background job on the bench,
+	inside a bare core loop with NO try/except. So it MUST be import-safe on every Frappe
+	version (no risky module-top imports - AJ-2) and MUST NEVER raise (a raise here would
+	replace the host job's own result bench-wide). The fast-path LATENCY shortcut: when a
+	Data Import job ends, enqueue a scoped completion-classify so a healthy/errored/blocked
+	import pings in SECONDS instead of <=2 min. The ``*/2`` poll stays the correctness
+	guarantee - this hook cannot survive a worker/container death.
+	"""
+	try:
+		# AJ-1: identify by METHOD (``job_id`` is NOT passed to after_job). Anchoring on
+		# the method (not "kwargs has a data_import key") is also what prevents self-
+		# recursion - the enqueued classify's method is announce_finished_imports, which
+		# never matches. On the ~100% non-matching path this is a single in-memory string
+		# compare: ZERO db/cache/conf reads (AJ-1 / perf floor).
+		if method != "frappe.core.doctype.data_import.data_import.start_import":
+			return
+		name = (kwargs or {}).get("data_import")
+		if not name:
+			return
+		# AJ-6: the kill-switch gates the hook's enqueue traffic too (before any enqueue) -
+		# one flag stops BOTH the poll and the fast path. frappe.conf is an in-memory dict,
+		# so this stays off the hot non-matching path above.
+		if frappe.conf.get("jarvis_import_announce_disabled"):
+			return
+		# Enqueue (Redis-only, no DB) - isolated from this job's finally, so the classify's
+		# conversation lock + insert + publish never runs in the worker's cleanup. Scoped to
+		# this one import; source="hook" for attribution; deduplicate collapses a re-fired
+		# after_job (execute_job's deadlock-retry unwind) while the classify is still queued.
+		frappe.enqueue(
+			"jarvis.chat.import_announce.announce_finished_imports",
+			queue="short",
+			job_id=f"jarvis_announce||{name}",
+			deduplicate=True,
+			data_import=name,
+			source="hook",
+		)
+	except Exception:
+		# NEVER propagate out of the job's finally (AJ-2). log_error itself does a DB write
+		# that can throw inside a poisoned finally, so guard it too.
+		try:
+			frappe.log_error(title="import_announce: after_job failed", message=frappe.get_traceback())
+		except Exception:
+			pass

--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -193,3 +193,56 @@ def reset_agent_pairing() -> dict:
 		return {"ok": False, "kind": "unreachable", "error": str(e)}
 	except Exception as e:
 		return {"ok": False, "kind": "error", "error": f"{type(e).__name__}: {e}"}
+
+
+@frappe.whitelist()
+def import_announce_stats() -> dict:
+	"""Operator visibility into the Slice B import auto-tell (import_announce). Surfaces
+	the pending/stuck backlog broken out by reason, and the fast-path ATTRIBUTION so a
+	silently-dead after_job hook is visible: if ``hook_rate_24h`` collapses toward 0 while
+	imports keep finishing (``total`` > 0), the fast path is down and the ``*/2`` poll is
+	carrying everything - act on it.
+
+	Gated on ``require_jarvis_admin``: the raw COUNTs span ALL users' announcements
+	(tenant-wide operational metadata), and the doctype has NO user-facing read grant."""
+	require_jarvis_admin()
+	ann = "Jarvis Import Announcement"
+	if not frappe.db.exists("DocType", ann):
+		return {"pending": 0, "note": "doctype not migrated"}
+	now = frappe.utils.now_datetime()
+	grace_cutoff = frappe.utils.add_to_date(now, minutes=-30)
+	pending = frappe.db.count(ann, {"announced": 0})
+	stuck = frappe.db.count(ann, {"announced": 0, "kicked_off_at": ["<", grace_cutoff]})
+	oldest = frappe.db.get_value(ann, {"announced": 0}, "kicked_off_at", order_by="kicked_off_at asc")
+	oldest_age_min = (
+		round((now - frappe.utils.get_datetime(oldest)).total_seconds() / 60.0, 1) if oldest else 0
+	)
+	since_24h = frappe.utils.add_to_date(now, hours=-24)
+	win = frappe.db.sql(
+		"""
+		SELECT COUNT(*) AS total,
+			   SUM(CASE WHEN announced_via = 'hook' THEN 1 ELSE 0 END) AS via_hook,
+			   SUM(CASE WHEN announced_via = 'poll' THEN 1 ELSE 0 END) AS via_poll
+		FROM `tabJarvis Import Announcement`
+		WHERE announced = 1 AND modified >= %(since)s
+		""",
+		{"since": since_24h},
+		as_dict=True,
+	)[0]
+	total = win.total or 0
+	reasons = frappe.db.sql(
+		"""
+		SELECT reason, COUNT(*) AS c FROM `tabJarvis Import Announcement`
+		WHERE announced = 1 AND modified >= %(since)s GROUP BY reason
+		""",
+		{"since": since_24h},
+		as_dict=True,
+	)
+	return {
+		"pending": pending,
+		"stuck_past_grace": stuck,
+		"oldest_pending_age_min": oldest_age_min,
+		"24h": {"total": total, "via_hook": win.via_hook or 0, "via_poll": win.via_poll or 0},
+		"hook_rate_24h": (win.via_hook / total) if total else 0,
+		"by_reason_24h": {(r.reason or "unknown"): r.c for r in reasons},
+	}

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -326,6 +326,12 @@ scheduler_events = {
 		],
 		"*/2 * * * *": [
 			"jarvis.chat.turn_recovery.recover_pending_turns",
+			# Slice B auto-tell: the CORRECTNESS GUARANTEE for import-completion
+			# announcements (the after_job hook is only a latency shortcut and cannot
+			# survive a worker/container death). Drains a bounded worklist of
+			# un-announced Data Imports, posts each finished/blocked/stuck/dead one into
+			# its chat, and self-gates cheaply (one COUNT) when nothing is pending.
+			"jarvis.chat.import_announce.announce_finished_imports",
 		],
 		# Learn-from-custom-apps has been REPLACED by the Custom App Learning
 		# *scribe* delegate agent (marketplace slug ``custom-app-learning``): it
@@ -512,7 +518,12 @@ doc_events["Jarvis Personalise Question Rule"] = {
 # leave orphaned Jarvis Chat Turn rows behind (they would linger as ghost queued/
 # dispatching rows in the admission shard). Cascade-delete them on trash.
 doc_events["Jarvis Conversation"] = {
-	"on_trash": "jarvis.chat.admission.on_conversation_trash",
+	"on_trash": [
+		"jarvis.chat.admission.on_conversation_trash",
+		# Slice B: delete the conversation's Jarvis Import Announcement rows so the
+		# Link never blocks deletion (LinkExistsError) or orphans the poll.
+		"jarvis.chat.import_announce.on_conversation_trash",
+	],
 }
 
 # ---------------------------------------------------------------------------
@@ -547,7 +558,19 @@ for _trigger_event in (
 # clear_old_logs mirrors core's WebhookRequestLog).
 default_log_clearing_doctypes = {
 	"Jarvis Trigger Activity": 90,
+	# Slice B: reap TERMINAL (announced=1) import-announcement rows after 30 days.
+	# The controller's clear_old_logs filters announced=1 AND modified<cutoff, so a
+	# still-live (announced=0) row is never swept.
+	"Jarvis Import Announcement": 30,
 }
+
+# Slice B fast-path: runs in the `finally` of EVERY background job on the bench (Frappe
+# calls it with no surrounding try/except), so the handler MUST stay import-safe on every
+# version and MUST NEVER raise - see import_announce.on_after_job. When a Data Import job
+# ends it enqueues a scoped completion-classify so a finished import pings in seconds.
+# LATENCY-ONLY; the `*/2` poll (scheduler_events) is the correctness guarantee and must
+# never be removed even though it looks redundant once the hook is working.
+after_job = ["jarvis.chat.import_announce.on_after_job"]
 
 # ---------------------------------------------------------------------------
 # Wiki page scoping (wiki v2)

--- a/jarvis/jarvis/doctype/jarvis_import_announcement/jarvis_import_announcement.json
+++ b/jarvis/jarvis/doctype/jarvis_import_announcement/jarvis_import_announcement.json
@@ -1,0 +1,93 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-12 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "data_import",
+  "conversation",
+  "kicked_off_at",
+  "announced",
+  "announced_via",
+  "reason",
+  "attempts"
+ ],
+ "fields": [
+  {
+   "fieldname": "data_import",
+   "fieldtype": "Link",
+   "label": "Data Import",
+   "options": "Data Import",
+   "reqd": 1,
+   "unique": 1,
+   "read_only": 1,
+   "description": "The staged Data Import this row tracks. Unique: one announcement per import. The tracking row the */2 poll and the after_job fast-path both drive to exactly one completion message."
+  },
+  {
+   "fieldname": "conversation",
+   "fieldtype": "Link",
+   "label": "Conversation",
+   "options": "Jarvis Conversation",
+   "reqd": 1,
+   "search_index": 1,
+   "read_only": 1,
+   "description": "The originating chat the completion message is posted into. Bound at confirm-time from the token's OWN guarded conversation (never client-supplied - security F4/PC-4). search_index: the on_conversation_trash cascade deletes by this column on every conversation delete - unindexed it takes whole-table next-key locks (ABBA-deadlock risk vs _post_completion)."
+  },
+  {
+   "fieldname": "kicked_off_at",
+   "fieldtype": "Datetime",
+   "label": "Kicked Off At",
+   "reqd": 1,
+   "read_only": 1,
+   "description": "When run_import was confirmed. The stale-guard grace (~5 min) and the O-2 absolute-age ceiling are measured from here."
+  },
+  {
+   "fieldname": "announced",
+   "fieldtype": "Check",
+   "label": "Announced",
+   "default": "0",
+   "search_index": 1,
+   "read_only": 1,
+   "description": "Terminal flag: 1 = the poll/hook is done with this row (a message was posted, OR it was aborted - see reason). The worklist filters announced=0. Flipped only via a CAS UPDATE ... WHERE announced=0 inside the conversation lock (PC-1)."
+  },
+  {
+   "fieldname": "announced_via",
+   "fieldtype": "Select",
+   "label": "Announced Via",
+   "options": "\nhook\npoll",
+   "read_only": 1,
+   "description": "Attribution (AJ-5): which mechanism classified this row - the after_job fast-path ('hook') or the */2 poll ('poll'). Surfaced in import_announce_stats as hook_rate_24h so on-call can see a silently-dead fast path (rate -> 0 while imports keep finishing)."
+  },
+  {
+   "fieldname": "reason",
+   "fieldtype": "Data",
+   "label": "Reason",
+   "read_only": 1,
+   "description": "Why the row went terminal: done | partial | error | timed_out | blocked | interrupted | status_unknown | data_import_deleted | no_conversation | archived | poison_error. Distinguishes a posted completion from an aborted one (stats/retention must not conflate them)."
+  },
+  {
+   "fieldname": "attempts",
+   "fieldtype": "Int",
+   "label": "Attempts",
+   "default": "0",
+   "read_only": 1,
+   "description": "Consecutive classify failures for this row (bounded retry). After a cap the poll quarantines the row terminal (reason=poison_error) so a deterministically-failing row can't re-log forever or sit un-announced below the deadman threshold."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-12 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Import Announcement",
+ "naming_rule": "Random",
+ "permissions": [],
+ "quick_entry": 0,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_import_announcement/jarvis_import_announcement.py
+++ b/jarvis/jarvis/doctype/jarvis_import_announcement/jarvis_import_announcement.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, Aerele and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe.utils import add_days, now_datetime
+
+
+class JarvisImportAnnouncement(Document):
+	"""Tracks one staged Data Import so its completion can be announced back into
+	the originating chat exactly once (Slice B). Backend-only: no role permissions,
+	so it is never readable by a user (every import-runner is a System Manager - a
+	read grant would be a cross-user side channel, PC-4). Admin visibility is the
+	``import_announce_stats`` diagnostics endpoint only.
+
+	Lifecycle: created ``announced=0`` at run_import confirm-time; the ``*/2`` poll
+	(``jarvis.chat.import_announce``) and the ``after_job`` fast-path both classify
+	it and, once the import is genuinely done/blocked/stuck/dead, post the completion
+	message and flip ``announced=1`` (or abort + flip with a ``reason``). It never
+	sits ``announced=0`` forever."""
+
+	@staticmethod
+	def clear_old_logs(days=30):
+		"""Retention: reap only TERMINAL rows (``announced=1`` = the poll/hook is
+		finished with them, whether a message was posted or the row was aborted).
+		An ``announced=0`` row is still live work and must NEVER be swept - a bare
+		age cutoff would delete un-announced imports and lose the completion. Called
+		by core log-clearing via ``default_log_clearing_doctypes`` (hooks.py)."""
+		cutoff = add_days(now_datetime(), -days)
+		frappe.db.delete(
+			"Jarvis Import Announcement",
+			{"announced": 1, "modified": ["<", cutoff]},
+		)

--- a/jarvis/tests/test_import_announce.py
+++ b/jarvis/tests/test_import_announce.py
@@ -1,0 +1,770 @@
+"""Tests for Slice B auto-tell of Data Import completion (jarvis.chat.import_announce).
+
+T1 here: the confirm-time binding (``bind_after_run_import``) + the conversation cascade.
+Reuses the ephemeral parent+child + CSV fixtures from test_import_preview.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, now_datetime
+
+from jarvis.chat import import_announce
+from jarvis.chat.import_announce import announce_finished_imports
+from jarvis.tests.test_import_preview import (
+	_FLAT_CSV,
+	PARENT_DT,
+	_ensure_doctypes,
+	_make_csv,
+)
+
+ANN = "Jarvis Import Announcement"
+
+
+class TestImportAnnounceBinding(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_doctypes()
+		cls.flat_url = _make_csv(_FLAT_CSV, "jarvis_ann_flat.csv")
+		# A real Data Import to be the Link target - staged only, not run.
+		di = frappe.new_doc("Data Import")
+		di.reference_doctype = PARENT_DT
+		di.import_type = "Insert New Records"
+		di.import_file = cls.flat_url
+		di.mute_emails = 1
+		di.insert(ignore_permissions=True)
+		cls.di_name = di.name
+		# A conversation to bind to (autoname hash, no reqd fields).
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "slice-b ann"}).insert(
+			ignore_permissions=True
+		)
+		cls.conv = conv.name
+		cls.owner = frappe.session.user
+		# The DI + conversation must outlive the per-test savepoint rollbacks.
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.delete(ANN, {"data_import": cls.di_name})
+		frappe.db.delete("Data Import", {"name": cls.di_name})
+		if frappe.db.exists("Jarvis Conversation", cls.conv):
+			frappe.delete_doc("Jarvis Conversation", cls.conv, force=True, ignore_permissions=True)
+		existing = frappe.db.exists("File", {"file_name": "jarvis_ann_flat.csv"})
+		if existing:
+			frappe.delete_doc("File", existing, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def tearDown(self):
+		# Announcement rows created by bind() are not reliably undone by the per-test
+		# rollback in this suite - clean explicitly so each test starts independent
+		# (mirrors the Slice A run_import test discipline).
+		frappe.db.delete(ANN)
+		frappe.db.commit()
+
+	# --- helpers ------------------------------------------------------------
+
+	def _record(self, **over):
+		r = {"tool": "run_import", "conversation": self.conv, "owner": self.owner, "args": {}}
+		r.update(over)
+		return r
+
+	def _ok(self, di=None):
+		return {"ok": True, "data": {"data_import": di or self.di_name, "status": "queued"}}
+
+	# --- T1: bind_after_run_import ------------------------------------------
+
+	def test_bind_creates_one_announcement(self):
+		import_announce.bind_after_run_import(self._record(), self._ok())
+		rows = frappe.get_all(
+			ANN,
+			filters={"data_import": self.di_name},
+			fields=["name", "conversation", "owner", "announced", "kicked_off_at"],
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].conversation, self.conv)
+		self.assertEqual(rows[0].owner, self.owner)
+		self.assertEqual(rows[0].announced, 0)
+		self.assertTrue(rows[0].kicked_off_at)
+
+	def test_bind_skips_non_run_import(self):
+		import_announce.bind_after_run_import(self._record(tool="delete_doc"), self._ok())
+		self.assertFalse(frappe.db.exists(ANN, {"data_import": self.di_name}))
+
+	def test_bind_skips_failed_result(self):
+		import_announce.bind_after_run_import(self._record(), {"ok": False, "error": {"code": "X"}})
+		self.assertFalse(frappe.db.exists(ANN, {"data_import": self.di_name}))
+
+	def test_bind_skips_missing_conversation(self):
+		# A conversation-less token: no announcement (accepted O-1 residual), no crash.
+		import_announce.bind_after_run_import(self._record(conversation=None), self._ok())
+		self.assertFalse(frappe.db.exists(ANN, {"data_import": self.di_name}))
+
+	def test_bind_is_idempotent(self):
+		import_announce.bind_after_run_import(self._record(), self._ok())
+		import_announce.bind_after_run_import(self._record(), self._ok())
+		rows = frappe.get_all(ANN, filters={"data_import": self.di_name})
+		self.assertEqual(len(rows), 1)
+
+	def test_bind_never_raises_on_bad_data_import(self):
+		# A Link to a non-existent Data Import fails validation inside insert(); the helper
+		# must swallow + log_error, never propagate into the confirm path (PC-3).
+		import_announce.bind_after_run_import(self._record(), self._ok(di="No Such Data Import xyz"))
+		self.assertFalse(frappe.db.exists(ANN, {"data_import": "No Such Data Import xyz"}))
+
+	def test_bind_uses_the_token_conversation_only(self):
+		# The helper reads record["conversation"] (the guarded token conv) - never a
+		# client-supplied value (PC-4). Binding is always to that conversation.
+		import_announce.bind_after_run_import(self._record(), self._ok())
+		row = frappe.get_all(ANN, filters={"data_import": self.di_name}, fields=["conversation"])
+		self.assertEqual(row[0].conversation, self.conv)
+
+	# --- T5: conversation cascade -------------------------------------------
+
+	def test_cascade_deletes_rows_on_conversation_trash(self):
+		# A conversation with a live announcement can be deleted (no LinkExistsError) and
+		# leaves no orphan announced=0 row for the poll.
+		throwaway = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "cascade"}).insert(
+			ignore_permissions=True
+		)
+		import_announce.bind_after_run_import(
+			{"tool": "run_import", "conversation": throwaway.name, "owner": self.owner, "args": {}},
+			self._ok(),
+		)
+		self.assertTrue(frappe.db.exists(ANN, {"conversation": throwaway.name}))
+		frappe.delete_doc("Jarvis Conversation", throwaway.name, force=True, ignore_permissions=True)
+		self.assertFalse(frappe.db.exists(ANN, {"conversation": throwaway.name}))
+
+
+class TestImportAnnounceClassifier(FrappeTestCase):
+	"""The classifier + message-post (T2/T3): job-done trigger, completeness, the
+	status branches, the stale guard (grace + two-tick), poison/owner/archived
+	handling, exactly-once, the O-2 ceiling, AJ-3 (works as a non-admin invoker),
+	and the kill-switch."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_doctypes()
+		cls.flat_url = _make_csv(_FLAT_CSV, "jarvis_ann_cls.csv")
+		di = frappe.new_doc("Data Import")
+		di.reference_doctype = PARENT_DT
+		di.import_type = "Insert New Records"
+		di.import_file = cls.flat_url
+		di.mute_emails = 1
+		di.insert(ignore_permissions=True)
+		cls.di_name = di.name
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "slice-b cls"}).insert(
+			ignore_permissions=True
+		)
+		cls.conv = conv.name
+		cls.owner = frappe.session.user
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		cls._reap()
+		frappe.db.delete("Data Import", {"name": cls.di_name})
+		if frappe.db.exists("Jarvis Conversation", cls.conv):
+			frappe.delete_doc("Jarvis Conversation", cls.conv, force=True, ignore_permissions=True)
+		existing = frappe.db.exists("File", {"file_name": "jarvis_ann_cls.csv"})
+		if existing:
+			frappe.delete_doc("File", existing, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	@classmethod
+	def _reap(cls):
+		frappe.db.delete(ANN)
+		frappe.db.delete("Jarvis Chat Message", {"conversation": cls.conv})
+		frappe.db.delete("Data Import Log", {"data_import": cls.di_name})
+		frappe.db.set_value(
+			"Data Import",
+			cls.di_name,
+			{"status": "Pending", "payload_count": 0, "template_warnings": None},
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	def tearDown(self):
+		self._reap()
+		frappe.set_user("Administrator")
+
+	# --- helpers ------------------------------------------------------------
+
+	def _ann(self, *, di=None, conv=None, kicked_off_min_ago=0, reason=""):
+		doc = frappe.new_doc(ANN)
+		doc.data_import = di or self.di_name
+		doc.conversation = conv or self.conv
+		doc.owner = self.owner
+		doc.kicked_off_at = add_to_date(now_datetime(), minutes=-kicked_off_min_ago)
+		doc.announced = 0
+		doc.reason = reason
+		doc.insert(ignore_permissions=True)
+		frappe.db.commit()
+		return doc.name
+
+	def _set_di(self, status, *, success=0, failed=0, payload=None, warnings=None):
+		frappe.db.set_value(
+			"Data Import",
+			self.di_name,
+			{
+				"status": status,
+				"payload_count": payload if payload is not None else (success + failed),
+				"template_warnings": warnings,
+			},
+			update_modified=False,
+		)
+		for i in range(success):
+			frappe.get_doc(
+				{"doctype": "Data Import Log", "data_import": self.di_name, "success": 1, "log_index": i}
+			).insert(ignore_permissions=True)
+		for i in range(failed):
+			frappe.get_doc(
+				{
+					"doctype": "Data Import Log",
+					"data_import": self.di_name,
+					"success": 0,
+					"log_index": 1000 + i,
+				}
+			).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def _run(self, *, enqueued=False, source="poll", di=None):
+		with patch("jarvis.chat.import_announce._is_job_enqueued", return_value=enqueued):
+			return announce_finished_imports(data_import=di or self.di_name, source=source)
+
+	def _messages(self, di=None):
+		return frappe.get_all(
+			"Jarvis Chat Message",
+			filters={"conversation": self.conv, "role": "assistant", "ref_name": di or self.di_name},
+			fields=["name", "content", "hidden"],
+		)
+
+	def _row(self, di=None):
+		return frappe.db.get_value(
+			ANN, {"data_import": di or self.di_name}, ["announced", "reason", "announced_via"], as_dict=True
+		)
+
+	# --- job-done trigger + terminal branches -------------------------------
+
+	def test_done_posts_one_records_message(self):
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		self._run(enqueued=False)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertIn("2", msgs[0].content)
+		self.assertEqual(msgs[0].hidden, 0)
+		row = self._row()
+		self.assertEqual(row.announced, 1)
+		self.assertEqual(row.reason, "done")
+		self.assertEqual(row.announced_via, "poll")
+
+	def test_still_enqueued_posts_nothing(self):
+		# Poll lands mid-import ("Partial Success" written after row 1, job still enqueued).
+		self._ann()
+		self._set_di("Partial Success", success=1, payload=2)
+		self._run(enqueued=True)
+		self.assertEqual(len(self._messages()), 0)
+		self.assertEqual(self._row().announced, 0)
+
+	def test_partial_covered_is_partial(self):
+		self._ann()
+		self._set_di("Partial Success", success=1, failed=1, payload=2)
+		self._run(enqueued=False)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertIn("failed", msgs[0].content.lower())
+		self.assertEqual(self._row().reason, "partial")
+
+	def test_partial_not_covered_is_interrupted(self):
+		# Terminal Partial Success but success+failed < payload_count -> hard-kill (PC-2).
+		self._ann()
+		self._set_di("Partial Success", success=1, failed=0, payload=100)
+		self._run(enqueued=False)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertIn("didn't complete", msgs[0].content)
+		self.assertEqual(self._row().reason, "interrupted")
+
+	def test_all_failed_zero_success_log_no_keyerror(self):
+		self._ann()
+		self._set_di("Error", success=0, failed=3, payload=3)
+		self._run(enqueued=False)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertIn("failed", msgs[0].content.lower())
+		self.assertEqual(self._row().reason, "error")
+
+	def test_blocked_posts_blocked(self):
+		self._ann()
+		self._set_di("Pending", payload=0, warnings='[{"type":"invalid_value"}]')
+		self._run(enqueued=False)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertIn("blocked", msgs[0].content.lower())
+		self.assertEqual(self._row().reason, "blocked")
+
+	# --- stale guard: grace + two-tick --------------------------------------
+
+	def test_within_grace_no_post(self):
+		self._ann(kicked_off_min_ago=1)  # inside the 5-min grace
+		self._set_di("Pending", payload=2)  # non-terminal, not enqueued
+		self._run(enqueued=False)
+		self.assertEqual(len(self._messages()), 0)
+		self.assertEqual(self._row().announced, 0)
+
+	def test_stuck_requires_two_ticks(self):
+		self._ann(kicked_off_min_ago=10)  # past grace
+		self._set_di("Pending", payload=2)
+		self._run(enqueued=False)  # first tick: mark provisional, no post
+		self.assertEqual(len(self._messages()), 0)
+		self.assertEqual(self._row().reason, "stuck_seen")
+		self.assertEqual(self._row().announced, 0)
+		self._run(enqueued=False)  # second tick: confirmed -> post
+		self.assertEqual(len(self._messages()), 1)
+		self.assertEqual(self._row().reason, "interrupted")
+
+	def test_enqueue_blip_clears_stuck_marker(self):
+		self._ann(kicked_off_min_ago=10)
+		self._set_di("Pending", payload=2)
+		self._run(enqueued=False)  # marks stuck_seen
+		self.assertEqual(self._row().reason, "stuck_seen")
+		self._run(enqueued=True)  # blip resolved: job enqueued again -> clear marker, no post
+		self.assertEqual(self._row().reason, "")
+		self.assertEqual(len(self._messages()), 0)
+
+	# --- exactly-once + crash window ----------------------------------------
+
+	def test_exactly_once_across_two_ticks(self):
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		self._run(enqueued=False)
+		self._run(enqueued=False)
+		self.assertEqual(len(self._messages()), 1)
+
+	def test_crash_window_no_double_post(self):
+		# Message committed but announced flag not (simulate: pre-insert the message, leave
+		# the row announced=0). Next tick must dedupe (no 2nd message) AND flip announced=1.
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		frappe.get_doc(
+			{
+				"doctype": "Jarvis Chat Message",
+				"conversation": self.conv,
+				"seq": 1,
+				"role": "assistant",
+				"content": "pre-existing",
+				"hidden": 0,
+				"ref_doctype": "Data Import",
+				"ref_name": self.di_name,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		self._run(enqueued=False)
+		self.assertEqual(len(self._messages()), 1)  # no double-post
+		self.assertEqual(self._row().announced, 1)  # recovered to terminal
+
+	# --- owner / poison / archived / ceiling --------------------------------
+
+	def test_poison_row_marks_terminal_no_post(self):
+		ghost = frappe.new_doc("Data Import")
+		ghost.reference_doctype = PARENT_DT
+		ghost.import_type = "Insert New Records"
+		ghost.import_file = self.flat_url
+		ghost.mute_emails = 1
+		ghost.insert(ignore_permissions=True)
+		gname = ghost.name
+		self._ann(di=gname)
+		frappe.db.commit()
+		frappe.db.delete("Data Import", {"name": gname})  # raw delete -> dangling Link
+		frappe.db.commit()
+		self._run(enqueued=False, di=gname)
+		self.assertEqual(len(self._messages(di=gname)), 0)
+		self.assertEqual(self._row(di=gname).reason, "data_import_deleted")
+		self.assertEqual(self._row(di=gname).announced, 1)
+
+	def test_missing_conversation_aborts_no_admin_post(self):
+		throw = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "gone"}).insert(
+			ignore_permissions=True
+		)
+		self._ann(conv=throw.name)
+		# RAW delete the conversation (bypass the cascade) so the row dangles, as a
+		# poll-vs-delete race would leave it.
+		frappe.db.delete("Jarvis Conversation", {"name": throw.name})
+		frappe.db.commit()
+		self._set_di("Success", success=2, payload=2)
+		self._run(enqueued=False)
+		self.assertEqual(frappe.db.count("Jarvis Chat Message", {"conversation": throw.name}), 0)
+		self.assertEqual(self._row().reason, "no_conversation")
+		self.assertEqual(self._row().announced, 1)
+
+	def test_archived_conversation_skips_and_marks(self):
+		frappe.db.set_value("Jarvis Conversation", self.conv, "status", "Archived", update_modified=False)
+		frappe.db.commit()
+		try:
+			self._ann()
+			self._set_di("Success", success=2, payload=2)
+			self._run(enqueued=False)
+			self.assertEqual(len(self._messages()), 0)
+			self.assertEqual(self._row().reason, "archived")
+			self.assertEqual(self._row().announced, 1)
+		finally:
+			frappe.db.set_value("Jarvis Conversation", self.conv, "status", "Active", update_modified=False)
+			frappe.db.commit()
+
+	def test_ceiling_announces_status_unknown(self):
+		self._ann(kicked_off_min_ago=800)  # past the 720-min O-2 ceiling
+		self._set_di("Partial Success", success=1, payload=2)
+		self._run(enqueued=True)  # is_job_enqueued STILL true (worker died, hash unreaped)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertIn("status unknown", msgs[0].content.lower())
+		self.assertEqual(self._row().reason, "status_unknown")
+
+	# --- AJ-3: works as a non-admin invoker (the fast-path runs as the import user) ---
+
+	def test_classify_works_as_non_admin_invoker(self):
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		user = "slice_b_importer@example.com"
+		if not frappe.db.exists("User", user):
+			frappe.get_doc(
+				{"doctype": "User", "email": user, "first_name": "Importer", "send_welcome_email": 0}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+		frappe.set_user(user)  # simulate the after_job-enqueued classify running as the import user
+		self._run(enqueued=False, source="hook")
+		frappe.set_user("Administrator")
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)  # posted despite the invoker having no read grant
+		self.assertEqual(self._row().announced_via, "hook")
+
+	# --- kill-switch --------------------------------------------------------
+
+	def test_kill_switch_skips(self):
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		frappe.conf.jarvis_import_announce_disabled = 1
+		try:
+			out = announce_finished_imports(data_import=self.di_name)
+		finally:
+			del frappe.conf["jarvis_import_announce_disabled"]
+		self.assertEqual(out, {"skipped": "disabled"})
+		self.assertEqual(len(self._messages()), 0)
+		self.assertEqual(self._row().announced, 0)
+
+	# --- T6: diagnostics attribution (hook vs poll) -------------------------
+
+	def test_stats_reports_hook_attribution(self):
+		from jarvis.diagnostics import import_announce_stats
+
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		self._run(enqueued=False, source="hook")
+		stats = import_announce_stats()
+		self.assertEqual(stats["24h"]["via_hook"], 1)
+		self.assertEqual(stats["hook_rate_24h"], 1.0)
+		self.assertIn("done", stats["by_reason_24h"])
+		self.assertEqual(stats["pending"], 0)
+
+	# --- review fix-wave regressions ---------------------------------------
+
+	def test_tool_receipt_for_same_import_does_not_suppress(self):
+		# CRITICAL regression: a role="tool" receipt (e.g. a get_doc of the Data Import
+		# mid-run) carries ref_doctype="Data Import"/ref_name=di. The dedupe MUST be scoped
+		# to role="assistant" so it does not false-match and silently drop the completion.
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		frappe.get_doc(
+			{
+				"doctype": "Jarvis Chat Message",
+				"conversation": self.conv,
+				"seq": 1,
+				"role": "tool",
+				"content": "get_doc receipt",
+				"hidden": 0,
+				"ref_doctype": "Data Import",
+				"ref_name": self.di_name,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		self._run(enqueued=False)
+		self.assertEqual(len(self._messages()), 1)  # completion still posted
+		self.assertEqual(self._row().announced, 1)
+
+	def test_error_status_with_zero_rows_is_not_done(self):
+		# An Error import with no logged rows must NOT render as a green "done".
+		self._ann()
+		self._set_di("Error", success=0, failed=0, payload=0)
+		self._run(enqueued=False)
+		msgs = self._messages()
+		self.assertEqual(len(msgs), 1)
+		self.assertNotIn("✓", msgs[0].content)
+		self.assertIn("✗", msgs[0].content)
+		self.assertEqual(self._row().reason, "error")
+
+	def test_partial_copy_places_counts_in_correct_slots(self):
+		# Asymmetric counts so a success/failed swap would fail (was mutation-insensitive).
+		self._ann()
+		self._set_di("Partial Success", success=3, failed=1, payload=4)
+		self._run(enqueued=False)
+		self.assertIn("**3** imported, **1** failed", self._messages()[0].content)
+
+	def test_untrusted_filename_link_injection_neutralized(self):
+		frappe.db.set_value(
+			"Data Import",
+			self.di_name,
+			"import_file",
+			"/files/[Click here](https://evil.example/x).csv",
+			update_modified=False,
+		)
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		self._run(enqueued=False)
+		content = self._messages()[0].content
+		self.assertNotIn("](https://evil.example", content)  # no injected markdown link
+		self.assertNotIn("[Click here]", content)
+
+	def test_data_import_link_is_absolute(self):
+		# A relative /app/... link renders as inert text; the link must be absolute http(s).
+		self._ann()
+		self._set_di("Error", success=0, failed=2, payload=2)
+		self._run(enqueued=False)
+		content = self._messages()[0].content
+		self.assertIn("](http", content)  # absolute markdown link (a relative one renders inert)
+		self.assertIn("/app/data-import/", content)
+
+	def test_message_is_owned_by_the_conversation_owner(self):
+		# impersonate(owner) is load-bearing: the posted row must be owned by the conversation
+		# owner, not whatever user invoked the classify.
+		user = "slice_b_importer2@example.com"
+		if not frappe.db.exists("User", user):
+			frappe.get_doc(
+				{"doctype": "User", "email": user, "first_name": "Imp2", "send_welcome_email": 0}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+		self._ann()
+		self._set_di("Success", success=2, payload=2)
+		frappe.set_user(user)
+		self._run(enqueued=False, source="hook")
+		frappe.set_user("Administrator")
+		owner = frappe.db.get_value("Jarvis Chat Message", self._messages()[0].name, "owner")
+		self.assertEqual(owner, self.owner)  # the conversation owner, not the invoker
+
+	def test_bounded_retry_quarantines_a_poison_row(self):
+		# A row whose classify raises every tick is quarantined terminal after the cap, so it
+		# can't re-log forever / sit un-announced below the deadman threshold.
+		self._ann()
+		with patch("jarvis.chat.import_announce._classify_and_announce", side_effect=RuntimeError("boom")):
+			for _ in range(import_announce._MAX_ROW_ATTEMPTS):
+				announce_finished_imports(data_import=self.di_name, source="poll")
+		row = self._row()
+		self.assertEqual(row.announced, 1)
+		self.assertEqual(row.reason, "poison_error")
+
+	def test_one_bad_row_does_not_block_the_batch(self):
+		di2 = frappe.new_doc("Data Import")
+		di2.reference_doctype = PARENT_DT
+		di2.import_type = "Insert New Records"
+		di2.import_file = self.flat_url
+		di2.mute_emails = 1
+		di2.insert(ignore_permissions=True)
+		conv2 = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "iso2"}).insert(
+			ignore_permissions=True
+		)
+		try:
+			self._ann()  # good row (di_name)
+			self._ann(di=di2.name, conv=conv2.name)  # bad row
+			self._set_di("Success", success=2, payload=2)  # di_name -> done
+			real = import_announce._read_tally
+
+			def flaky(di):
+				if di == di2.name:
+					raise RuntimeError("boom")
+				return real(di)
+
+			with (
+				patch("jarvis.chat.import_announce._read_tally", side_effect=flaky),
+				patch("jarvis.chat.import_announce._is_job_enqueued", return_value=False),
+			):
+				counts = announce_finished_imports(source="poll")
+			self.assertEqual(len(self._messages(di=self.di_name)), 1)  # good row posted
+			self.assertGreaterEqual(counts.get("errored", 0), 1)
+			bad = frappe.db.get_value(ANN, {"data_import": di2.name}, ["announced", "attempts"], as_dict=True)
+			self.assertEqual(bad.announced, 0)  # bad row still live for re-poll
+			self.assertEqual(bad.attempts, 1)  # bumped toward quarantine
+		finally:
+			frappe.db.delete(ANN, {"data_import": di2.name})
+			frappe.db.delete("Data Import", {"name": di2.name})
+			if frappe.db.exists("Jarvis Conversation", conv2.name):
+				frappe.delete_doc("Jarvis Conversation", conv2.name, force=True, ignore_permissions=True)
+			frappe.db.commit()
+
+	def test_deadman_alarms_on_backlog_and_dedupes(self):
+		title = "import_announce: un-announced backlog"
+		frappe.db.delete("Error Log", {"method": title})
+		frappe.db.commit()
+		try:
+			self._ann(kicked_off_min_ago=60)  # old + stays announced=0 (enqueued below)
+			self._set_di("Pending", payload=2)
+			with (
+				patch("jarvis.chat.import_announce._DEADMAN_BACKLOG", 1),
+				patch("jarvis.chat.import_announce._is_job_enqueued", return_value=True),
+			):
+				announce_finished_imports(source="poll")
+				n1 = frappe.db.count("Error Log", {"method": title})
+				announce_finished_imports(source="poll")
+				n2 = frappe.db.count("Error Log", {"method": title})
+			self.assertEqual(n1, 1)
+			self.assertEqual(n2, 1)  # deduped within the window
+		finally:
+			frappe.db.delete("Error Log", {"method": title})
+			frappe.db.commit()
+
+	def test_deadman_not_run_on_hook_path(self):
+		title = "import_announce: un-announced backlog"
+		frappe.db.delete("Error Log", {"method": title})
+		frappe.db.commit()
+		try:
+			self._ann(kicked_off_min_ago=60)
+			self._set_di("Pending", payload=2)
+			with (
+				patch("jarvis.chat.import_announce._DEADMAN_BACKLOG", 1),
+				patch("jarvis.chat.import_announce._is_job_enqueued", return_value=True),
+			):
+				announce_finished_imports(data_import=self.di_name, source="hook")  # scoped hook path
+			self.assertEqual(frappe.db.count("Error Log", {"method": title}), 0)
+		finally:
+			frappe.db.delete("Error Log", {"method": title})
+			frappe.db.commit()
+
+
+class TestImportAnnounceAfterJob(FrappeTestCase):
+	"""The after_job fast path (T8): method-anchored identification (AJ-1), never-raise
+	+ import-safe (AJ-2), no self-recursion, kill-switch, v16-shaped call, and the
+	real-dispatch registration test (AJ-2's only true defense)."""
+
+	_START = "frappe.core.doctype.data_import.data_import.start_import"
+
+	def test_matching_job_enqueues_one_scoped_classify(self):
+		with patch("frappe.enqueue") as enq:
+			import_announce.on_after_job(method=self._START, kwargs={"data_import": "DI-1"}, result=None)
+		enq.assert_called_once()
+		args, kw = enq.call_args
+		self.assertEqual(args[0], "jarvis.chat.import_announce.announce_finished_imports")
+		self.assertEqual(kw["data_import"], "DI-1")
+		self.assertEqual(kw["source"], "hook")
+		self.assertEqual(kw["queue"], "short")
+		self.assertEqual(kw["job_id"], "jarvis_announce||DI-1")
+		self.assertTrue(kw["deduplicate"])
+
+	def test_non_data_import_job_is_noop(self):
+		with patch("frappe.enqueue") as enq:
+			import_announce.on_after_job(method="some.other.module.fn", kwargs={"x": 1}, result=None)
+		enq.assert_not_called()
+
+	def test_no_self_recursion(self):
+		# The enqueued classify's own after_job carries method=announce_finished_imports;
+		# method-anchoring (not "kwargs has data_import") means it never re-enqueues.
+		with patch("frappe.enqueue") as enq:
+			import_announce.on_after_job(
+				method="jarvis.chat.import_announce.announce_finished_imports",
+				kwargs={"data_import": "DI-1"},
+				result=None,
+			)
+		enq.assert_not_called()
+
+	def test_missing_data_import_kwarg_is_noop(self):
+		with patch("frappe.enqueue") as enq:
+			import_announce.on_after_job(method=self._START, kwargs={}, result=None)
+		enq.assert_not_called()
+
+	def test_v16_shaped_call_without_result(self):
+		# A v16 call site may pass fewer args; the defaulted signature must still work.
+		with patch("frappe.enqueue") as enq:
+			import_announce.on_after_job(method=self._START, kwargs={"data_import": "DI-2"})
+		enq.assert_called_once()
+
+	def test_never_raises_when_enqueue_throws(self):
+		# Redis down / short queue error inside the job's finally must be swallowed, not
+		# propagated (a raise would replace the host job's result bench-wide).
+		with patch("frappe.enqueue", side_effect=RuntimeError("redis down")):
+			import_announce.on_after_job(method=self._START, kwargs={"data_import": "DI-3"}, result=None)
+
+	def test_kill_switch_blocks_enqueue(self):
+		frappe.conf.jarvis_import_announce_disabled = 1
+		try:
+			with patch("frappe.enqueue") as enq:
+				import_announce.on_after_job(method=self._START, kwargs={"data_import": "DI-4"}, result=None)
+		finally:
+			del frappe.conf["jarvis_import_announce_disabled"]
+		enq.assert_not_called()
+
+	def test_registered_and_dispatchable_via_real_hook(self):
+		# AJ-2: the ONLY defense against a broken hooks.py path / module-top ImportError -
+		# drive the REAL after_job registration + frappe.call, not a direct call.
+		hooks = frappe.get_hooks("after_job")
+		self.assertIn("jarvis.chat.import_announce.on_after_job", hooks)
+		with patch("frappe.enqueue") as enq:
+			frappe.call("jarvis.chat.import_announce.on_after_job", method="unrelated.job", kwargs={})
+		enq.assert_not_called()
+
+
+class TestImportAnnounceIntegration(FrappeTestCase):
+	"""One real end-to-end pass: run_import actually imports (synchronous in test mode),
+	then bind + the REAL classifier read the REAL Data Import Log and post the tally."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_doctypes()
+		cls.flat_url = _make_csv(_FLAT_CSV, "jarvis_ann_e2e.csv")
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "slice-b e2e"}).insert(
+			ignore_permissions=True
+		)
+		cls.conv = conv.name
+		cls.owner = frappe.session.user
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		if frappe.db.exists("Jarvis Conversation", cls.conv):
+			frappe.delete_doc("Jarvis Conversation", cls.conv, force=True, ignore_permissions=True)
+		existing = frappe.db.exists("File", {"file_name": "jarvis_ann_e2e.csv"})
+		if existing:
+			frappe.delete_doc("File", existing, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def test_end_to_end_real_import_posts_tally(self):
+		from jarvis.tools.run_import import run_import
+
+		out = run_import(doctype=PARENT_DT, file_url=self.flat_url)
+		di = out["data_import"]
+		try:
+			import_announce.bind_after_run_import(
+				{"tool": "run_import", "conversation": self.conv, "owner": self.owner, "args": {}},
+				{"ok": True, "data": out},
+			)
+			with patch("jarvis.chat.import_announce._is_job_enqueued", return_value=False):
+				announce_finished_imports(data_import=di, source="poll")
+			msgs = frappe.get_all(
+				"Jarvis Chat Message",
+				filters={"conversation": self.conv, "role": "assistant", "ref_name": di},
+				fields=["content"],
+			)
+			self.assertEqual(len(msgs), 1)
+			self.assertIn("2", msgs[0].content)
+		finally:
+			for title in ("REC-1", "REC-2"):
+				if frappe.db.exists(PARENT_DT, title):
+					frappe.delete_doc(PARENT_DT, title, force=True, ignore_permissions=True)
+			frappe.db.delete("Jarvis Import Announcement", {"data_import": di})
+			frappe.db.delete("Jarvis Chat Message", {"conversation": self.conv})
+			frappe.db.delete("Data Import Log", {"data_import": di})
+			frappe.db.delete("Data Import", {"name": di})
+			frappe.db.commit()

--- a/pwa/src/App.vue
+++ b/pwa/src/App.vue
@@ -68,6 +68,13 @@ function onEvent(p) {
 			const title = store.conversations.find((c) => c.name === conv)?.title || agentName;
 			notify(`${agentName} finished`, title, conv);
 		}
+	} else if (p.kind === "import:finished") {
+		// Slice B: a background CSV import finished; the completion message is
+		// already durable in the conversation. ChatView live-renders it when
+		// that chat is open — this shell-level handler owns only the
+		// off-screen unread dot. Deliberately no browser push for this event,
+		// this wave (unlike run:end above).
+		if (conv && conv !== openConversationId()) store.markUnread(conv);
 	} else if (p.kind === "action:pending" && prefs.notifyDecision) {
 		notify(
 			`${agentName} needs your approval`,

--- a/pwa/src/lib/importFinishedRender.test.js
+++ b/pwa/src/lib/importFinishedRender.test.js
@@ -1,0 +1,90 @@
+// Slice B ("auto-tell import completion") — the PWA half.
+//
+// When a background Data Import finishes, the bench posts a "✓ ..." message
+// into the originating conversation and publishes
+// { kind: "import:finished", conversation_id, message_id } to the owner's
+// socket. Three files split the work (design FE4):
+//   - views/ChatView.vue's local onEvent: live-append via load() when that
+//     conversation is the one open on screen.
+//   - App.vue's shell-level onEvent: the off-screen unread dot
+//     (store.markUnread), with no push notify().
+//   - lib/notifications.js's recordEvent: a durable bell-feed entry, also no
+//     push toast — just a row the user finds later.
+//
+// None of the three has a component/behavioural harness here (no vitest, no
+// @vue/test-utils in this app — see pumpFence.test.js's note on why), so the
+// wiring is asserted against the source, the same crude-but-real pattern.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const chatViewSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+const appSrc = fs.readFileSync(path.join(HERE, "..", "App.vue"), "utf8");
+const notificationsSrc = fs.readFileSync(path.join(HERE, "notifications.js"), "utf8");
+
+function chatViewOnEventBody() {
+	const start = chatViewSrc.indexOf("function onEvent(p) {");
+	assert.notEqual(start, -1, "ChatView must still define onEvent(p)");
+	const end = chatViewSrc.indexOf("\nfunction ", start + 1);
+	assert.notEqual(end, -1, "could not find the end of onEvent");
+	return chatViewSrc.slice(start, end);
+}
+
+test("PWA ChatView: onEvent's switch has a dedicated import:finished case", () => {
+	const body = chatViewOnEventBody();
+	assert.match(body, /case "import:finished":/);
+});
+
+test("PWA ChatView: the case live-appends via load(), not loadConversation (this frontend has no such helper)", () => {
+	const body = chatViewOnEventBody();
+	const at = body.indexOf('case "import:finished":');
+	const rest = body.slice(at);
+	const end = rest.indexOf('\n\t\tcase "', 1);
+	const caseBody = end === -1 ? rest : rest.slice(0, end);
+	assert.match(caseBody, /\bload\(\);/);
+	assert.doesNotMatch(caseBody, /loadConversation/, "the PWA has no loadConversation helper");
+});
+
+test("PWA ChatView: the case sits behind the open-conversation guard, like every other case", () => {
+	const body = chatViewOnEventBody();
+	const guardAt = body.indexOf("if (conv !== convId.value) return;");
+	const switchAt = body.indexOf("switch (p.kind) {");
+	const caseAt = body.indexOf('case "import:finished":');
+	assert.notEqual(guardAt, -1);
+	assert.ok(guardAt < switchAt, "the conversation guard must precede the switch");
+	assert.ok(switchAt < caseAt, "the case lives inside the switch, behind the guard");
+});
+
+test("PWA App.vue: the shell-level handler has an import:finished branch", () => {
+	assert.match(appSrc, /p\.kind === "import:finished"/);
+});
+
+test("PWA App.vue: the off-screen path calls store.markUnread directly, guarded off the open conversation", () => {
+	const at = appSrc.indexOf('p.kind === "import:finished"');
+	assert.notEqual(at, -1);
+	const rest = appSrc.slice(at);
+	const end = rest.indexOf("} else if (", 1);
+	const branch = end === -1 ? rest : rest.slice(0, end);
+	assert.match(branch, /store\.markUnread\(conv\)/);
+	assert.match(branch, /conv !== openConversationId\(\)/);
+});
+
+test("PWA App.vue: import:finished never calls notify() — no push toast/browser notification this wave", () => {
+	const at = appSrc.indexOf('p.kind === "import:finished"');
+	const rest = appSrc.slice(at);
+	const end = rest.indexOf("} else if (", 1);
+	const branch = end === -1 ? rest : rest.slice(0, end);
+	assert.doesNotMatch(branch, /\bnotify\(/);
+});
+
+test("PWA notifications.js: recordEvent folds import:finished into the bell feed", () => {
+	assert.match(notificationsSrc, /e\.kind === "import:finished"/);
+	const at = notificationsSrc.indexOf('e.kind === "import:finished"');
+	const rest = notificationsSrc.slice(at);
+	const end = rest.indexOf("} else if (", 1);
+	const branch = end === -1 ? rest : rest.slice(0, end);
+	assert.match(branch, /push\(\{/);
+});

--- a/pwa/src/lib/notifications.js
+++ b/pwa/src/lib/notifications.js
@@ -130,5 +130,19 @@ export function recordEvent(e) {
 			at,
 			read: false,
 		});
+	} else if (e.kind === "import:finished" && conv) {
+		// Slice B: the completion message already landed in the conversation
+		// (this event carries no filename/tally — just the pointer); the feed
+		// entry just tells the user something finished while they were away.
+		// No push toast here, only the bell feed.
+		push({
+			id: `imp:${e.message_id || conv}`,
+			kind: "import-finished",
+			title: "Import finished",
+			body: `${agentName} finished processing your import.`,
+			conversation: conv,
+			at,
+			read: false,
+		});
 	}
 }

--- a/pwa/src/lib/pumpFence.test.js
+++ b/pwa/src/lib/pumpFence.test.js
@@ -35,6 +35,7 @@ const UNFENCED_IN_CHATVIEW = new Set([
 	"action:pending", // a parked write — losing it strands the approval
 	"canvas",
 	"conversation:renamed",
+	"import:finished", // Slice B: a background-poll completion signal, not a pump-sequenced turn frame
 ]);
 
 function onEventBody() {

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -575,6 +575,15 @@ function onEvent(p) {
 		case "conversation:renamed":
 			load();
 			break;
+
+		case "import:finished":
+			// Slice B: a background CSV import finished; the bench already posted
+			// the "✓ ..." completion message into this conversation. The guard
+			// above already confirmed this is the open conversation, so pull it
+			// in the same way canvas/conversation:renamed do — a durable reload,
+			// since this frame carries no message body to splice in by hand.
+			load();
+			break;
 	}
 }
 


### PR DESCRIPTION
## What

When a background **Data Import** (started by Slice A's `run_import`) finishes, Jarvis posts a completion message into the **originating chat on its own** — so the user never has to ask *"did it work?"*. Stuck / blocked / dead imports are announced too — **never silent**.

The message is status-branched, records-based, with the filename neutralized and a link to the Data Import:
> ✓ Import into **Sales Invoice** from **file.csv**: **280** record(s) imported. ([link])
> ✗ … was blocked — nothing imported. Check the file's columns.
> ⚠️ … didn't complete — 140 imported so far. Check the Data Import.

## How

- **`Jarvis Import Announcement`** link doctype (backend-only, no user-facing read) — bound at confirm-time from the token's own guarded conversation.
- **`*/2` scheduler poll** — the correctness guarantee; completion trigger is **job-done** (`is_job_enqueued==False`), not status. Reads the tally as Administrator.
- **`after_job` fast-path** — latency shortcut so a healthy import pings in seconds; identified by method (not job_id), import-safe on v16, never raises.
- **Live `import:finished` render** on both frontends (desktop + PWA), off-screen unread with no toast.
- Exactly-once via a **conversation-lock-first CAS + natural-key dedupe**; owner fail-closed before `impersonate`; **bounded retry + dead-man + O-2 ceiling** so nothing sits un-announced; kill-switch `jarvis_import_announce_disabled`.

## Edge cases covered
done · partial · error · timed-out · blocked · interrupted · status-unknown · poison-row (deleted DI) · missing/archived conversation · exactly-once + crash-window · two-tick stuck + 5-min grace · non-admin invoker (fast-path) · untrusted-filename link-injection · v16 compatibility.

## Verification
- **45 backend tests** green (`jarvis.tests.test_import_announce`); `create_docs`/`delete_doc`/receipts regressions green; `ruff` clean.
- Frontend: vitest source-grep + behavioral (desktop + PWA suites green).
- **Code review**: full multi-lane panel — fixed a **Critical silent-suppression dedupe** (a mid-run `get_doc` of the import would have swallowed the completion) + ~11 Important, then an adversarial re-verify of the fix wave.
- **Flow**: the real `*/2` scheduler job dispatched to a worker and posted the completion against a running bench (`announced_via=poll`). The live browser pixel-render is covered by the frontend component tests.

Ships app-only; **one `bench migrate`** (additive doctype). Rollback = flip `jarvis_import_announce_disabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)