### PR TITLE
Blink the Jarvis mark on hover and while idle

### DIFF
--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -22,7 +22,7 @@
 	<span
 		v-else
 		class="jv-mark"
-		:class="[`jv-mood-${mood}`, { 'jv-hoverpeek': hoverPeek, 'jv-peek-on': peek }]"
+		:class="[`jv-mood-${mood}`, { 'jv-hoverpeek': hoverPeek, 'jv-peek-on': peek || autoPeek }]"
 		:style="markStyle"
 	>
 		<svg
@@ -42,7 +42,7 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { brandLogoUrl } from "@/branding";
 import { BRAND_STAR_PATH } from "@/lib/brand";
 
@@ -66,11 +66,61 @@ const props = defineProps({
 	    surface (e.g. the whole sidebar brand card) drive the same reveal that
 	    hoverPeek gives on the mark alone. */
 	peek: { type: Boolean, default: false },
+	/** Opt-in: while resting ("star"), blink on its own every few seconds via
+	    the same peek reveal hover/hoverPeek trigger on demand — the "idle"
+	    animation the mark was designed to have. Off by default: message rows
+	    render dozens of marks at once and only a chosen resting surface (the
+	    sidebar brand mark) should breathe unprompted. Skips prefers-reduced-motion
+	    entirely (never starts the timer), same posture as TourIntro's clocks. */
+	idlePeek: { type: Boolean, default: false },
 });
 
-// The face element only exists when something can show it: an active mood, or a
-// hover-peek surface (where mood stays "star" but hover reveals the eyes).
-const hasFace = computed(() => props.mood !== "star" || props.hoverPeek || props.peek);
+// The face element only exists when something can show it: an active mood, a
+// hover-peek surface (where mood stays "star" but hover reveals the eyes), or
+// an idle auto-peek cycle.
+const hasFace = computed(
+	() => props.mood !== "star" || props.hoverPeek || props.peek || autoPeek.value
+);
+
+// ---- idle auto-peek: the same friendly blink hoverPeek/peek give on demand,
+// but self-triggered every IDLE_PEEK_INTERVAL_MS while nothing else is
+// driving the face. Only meaningful while mood is "star" - an active mood
+// already owns the face.
+const IDLE_PEEK_INTERVAL_MS = 8000;
+const IDLE_PEEK_HOLD_MS = 1800; // one jvm-blink cycle, then back to resting
+const autoPeek = ref(false);
+let idleTimeoutId = null;
+let idleHoldTimeoutId = null;
+
+function prefersReducedMotion() {
+	return (
+		typeof window !== "undefined" &&
+		typeof window.matchMedia === "function" &&
+		window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	);
+}
+
+function scheduleIdlePeek() {
+	idleTimeoutId = window.setTimeout(() => {
+		if (props.mood === "star") {
+			autoPeek.value = true;
+			idleHoldTimeoutId = window.setTimeout(() => {
+				autoPeek.value = false;
+			}, IDLE_PEEK_HOLD_MS);
+		}
+		scheduleIdlePeek();
+	}, IDLE_PEEK_INTERVAL_MS);
+}
+
+onMounted(() => {
+	if (!props.idlePeek || prefersReducedMotion()) return;
+	scheduleIdlePeek();
+});
+
+onBeforeUnmount(() => {
+	if (idleTimeoutId) window.clearTimeout(idleTimeoutId);
+	if (idleHoldTimeoutId) window.clearTimeout(idleHoldTimeoutId);
+});
 
 const markStyle = computed(() => ({
 	width: `${props.size}px`,
@@ -239,9 +289,11 @@ const markStyle = computed(() => ({
 }
 
 /* PEEK - resting star until triggered, then a friendly blink. Triggered by
-   hovering the mark itself (hoverPeek) or by the `peek` prop, so a larger
-   surface (e.g. the whole sidebar brand card) can drive the same reveal. Only
-   meaningful while mood is "star" (the face is otherwise hidden). */
+   hovering the mark itself (hoverPeek), by the `peek` prop (so a larger
+   surface, e.g. the whole sidebar brand card, can drive the same reveal), or
+   by `idlePeek`'s own timer toggling the same `jv-peek-on` class (see
+   scheduleIdlePeek in <script>) so the mark blinks on its own while resting.
+   Only meaningful while mood is "star" (the face is otherwise hidden). */
 .jv-hoverpeek:hover .jv-star,
 .jv-peek-on .jv-star {
 	opacity: 0;

--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { brandLogoUrl } from "@/branding";
 import { BRAND_STAR_PATH } from "@/lib/brand";
 
@@ -70,8 +70,10 @@ const props = defineProps({
 	    the same peek reveal hover/hoverPeek trigger on demand — the "idle"
 	    animation the mark was designed to have. Off by default: message rows
 	    render dozens of marks at once and only a chosen resting surface (the
-	    sidebar brand mark) should breathe unprompted. Skips prefers-reduced-motion
-	    entirely (never starts the timer), same posture as TourIntro's clocks. */
+	    sidebar brand mark) should breathe unprompted. Tracks prefers-reduced-motion
+	    LIVE via a matchMedia change listener (not just at mount): the timer
+	    stops the moment the OS preference flips on mid-session, and resumes if
+	    it flips off again, so a mid-session toggle is always honored. */
 	idlePeek: { type: Boolean, default: false },
 });
 
@@ -91,13 +93,18 @@ const IDLE_PEEK_HOLD_MS = 1800; // one jvm-blink cycle, then back to resting
 const autoPeek = ref(false);
 let idleTimeoutId = null;
 let idleHoldTimeoutId = null;
+let reducedMotionMql = null;
 
-function prefersReducedMotion() {
-	return (
-		typeof window !== "undefined" &&
-		typeof window.matchMedia === "function" &&
-		window.matchMedia("(prefers-reduced-motion: reduce)").matches
-	);
+function stopIdlePeek() {
+	if (idleTimeoutId) {
+		window.clearTimeout(idleTimeoutId);
+		idleTimeoutId = null;
+	}
+	if (idleHoldTimeoutId) {
+		window.clearTimeout(idleHoldTimeoutId);
+		idleHoldTimeoutId = null;
+	}
+	autoPeek.value = false;
 }
 
 function scheduleIdlePeek() {
@@ -112,14 +119,44 @@ function scheduleIdlePeek() {
 	}, IDLE_PEEK_INTERVAL_MS);
 }
 
+// Reacts to the OS preference changing mid-session, not just its value at
+// mount: reduced-motion turning on stops the timer and clears any peek in
+// progress; turning back off resumes scheduling.
+function handleReducedMotionChange(e) {
+	if (e.matches) {
+		stopIdlePeek();
+	} else if (props.idlePeek) {
+		scheduleIdlePeek();
+	}
+}
+
+// A mood taking over the face (e.g. a reply starts streaming) mid-hold must
+// not leave jv-peek-on layered on top of it - the new mood should own the
+// face immediately, not after the peek's own hold timer runs out.
+watch(
+	() => props.mood,
+	(mood) => {
+		if (mood !== "star" && autoPeek.value) {
+			if (idleHoldTimeoutId) {
+				window.clearTimeout(idleHoldTimeoutId);
+				idleHoldTimeoutId = null;
+			}
+			autoPeek.value = false;
+		}
+	}
+);
+
 onMounted(() => {
-	if (!props.idlePeek || prefersReducedMotion()) return;
-	scheduleIdlePeek();
+	if (!props.idlePeek) return;
+	if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+	reducedMotionMql = window.matchMedia("(prefers-reduced-motion: reduce)");
+	reducedMotionMql.addEventListener("change", handleReducedMotionChange);
+	if (!reducedMotionMql.matches) scheduleIdlePeek();
 });
 
 onBeforeUnmount(() => {
-	if (idleTimeoutId) window.clearTimeout(idleTimeoutId);
-	if (idleHoldTimeoutId) window.clearTimeout(idleHoldTimeoutId);
+	stopIdlePeek();
+	reducedMotionMql?.removeEventListener("change", handleReducedMotionChange);
 });
 
 const markStyle = computed(() => ({

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -17,8 +17,9 @@
 				<!-- the jarvis mark, 28×28 rounded — rendered from JarvisMark rather than
 				     a hand-pasted copy of its gradient + path data. That duplication is
 				     exactly what let the chat welcome mark drift to a different colour
-				     (design.md §2.2). -->
-				<JarvisMark :size="28" :radius="7" :peek="brandPeek" />
+				     (design.md §2.2). idlePeek: this is the one mark that sits resting on
+				     every route, so it's the chosen surface for the designed idle blink. -->
+				<JarvisMark :size="28" :radius="7" :peek="brandPeek" idlePeek />
 				<!-- Resting badge: a waiting reply has to register on every route, not
 				     only while the user happens to be in Chat - restoring this (it was
 				     briefly dropped when ChatView grew its own header jv-support-dot,

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
 import { panelLayout } from "./panel_anchor.mjs";
@@ -106,19 +106,46 @@ const IDLE_PEEK_HOLD_MS = 1800; // one jvw-blink cycle, then back to resting
 const autoPeek = ref(false);
 let idlePeekTimeoutId = null;
 let idlePeekHoldTimeoutId = null;
+let reducedMotionMql = null;
 
-function prefersReducedMotion() {
-	return Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+function stopIdlePeek() {
+	if (idlePeekTimeoutId) {
+		window.clearTimeout(idlePeekTimeoutId);
+		idlePeekTimeoutId = null;
+	}
+	if (idlePeekHoldTimeoutId) {
+		window.clearTimeout(idlePeekHoldTimeoutId);
+		idlePeekHoldTimeoutId = null;
+	}
+	autoPeek.value = false;
 }
 
 function scheduleIdlePeek() {
 	idlePeekTimeoutId = window.setTimeout(() => {
-		autoPeek.value = true;
-		idlePeekHoldTimeoutId = window.setTimeout(() => {
-			autoPeek.value = false;
-		}, IDLE_PEEK_HOLD_MS);
+		// Dragging or an open panel must never grow eyes mid-interaction -
+		// mirrors idleTimer's own `if (!dragging.value)` guard on its onIdle
+		// fade above. Still reschedules either way so the cadence keeps ticking
+		// and simply resumes blinking once the FAB is resting again.
+		if (!dragging.value && !panelOpen.value) {
+			autoPeek.value = true;
+			idlePeekHoldTimeoutId = window.setTimeout(() => {
+				autoPeek.value = false;
+			}, IDLE_PEEK_HOLD_MS);
+		}
 		scheduleIdlePeek();
 	}, IDLE_PEEK_INTERVAL_MS);
+}
+
+// Reacts to the OS preference changing mid-session, not just its value at
+// mount: reduced-motion turning on stops the timer and clears any peek in
+// progress; turning back off resumes scheduling. Kept in sync with
+// JarvisMark.vue's handleReducedMotionChange by hand.
+function handleReducedMotionChange(e) {
+	if (e.matches) {
+		stopIdlePeek();
+	} else if (!brandLogoUrl) {
+		scheduleIdlePeek();
+	}
 }
 
 // Access gate: desk boot sets this once for the session (see Task B).
@@ -134,6 +161,20 @@ let unwatchTheme = null;
 const panelOpen = ref(false);
 const deskContext = ref(null);
 const contextDismissed = ref(false);
+
+// A drag starting (or the panel opening) mid-hold must cancel an in-progress
+// idle peek immediately rather than let it ride out its 1.8s hold - same
+// posture as JarvisMark.vue's mood watcher taking the face back the instant
+// something else needs to own it.
+watch([dragging, panelOpen], ([isDragging, isPanelOpen]) => {
+	if (isDragging || isPanelOpen) {
+		if (idlePeekHoldTimeoutId) {
+			window.clearTimeout(idlePeekHoldTimeoutId);
+			idlePeekHoldTimeoutId = null;
+		}
+		autoPeek.value = false;
+	}
+});
 
 // Dismissing the chip suppresses context for the current page only; a new
 // route is a new subject, so the dismissal does not carry over.
@@ -433,7 +474,11 @@ onMounted(() => {
 			if (!dragging.value) faded.value = true;
 		},
 	});
-	if (!brandLogoUrl && !prefersReducedMotion()) scheduleIdlePeek();
+	if (!brandLogoUrl && typeof window.matchMedia === "function") {
+		reducedMotionMql = window.matchMedia("(prefers-reduced-motion: reduce)");
+		reducedMotionMql.addEventListener("change", handleReducedMotionChange);
+		if (!reducedMotionMql.matches) scheduleIdlePeek();
+	}
 	window.addEventListener("resize", onResize);
 	window.addEventListener("orientationchange", onResize);
 	document.addEventListener("mousemove", onDocumentActivity, { passive: true });
@@ -459,8 +504,8 @@ onBeforeUnmount(() => {
 		window.clearTimeout(snapTimeoutHandle);
 		snapTimeoutHandle = null;
 	}
-	if (idlePeekTimeoutId) window.clearTimeout(idlePeekTimeoutId);
-	if (idlePeekHoldTimeoutId) window.clearTimeout(idlePeekHoldTimeoutId);
+	stopIdlePeek();
+	reducedMotionMql?.removeEventListener("change", handleReducedMotionChange);
 });
 </script>
 

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -13,6 +13,7 @@
 				'jvw-fab--dragging': dragging,
 				'jvw-fab--faded': faded && !dragging,
 				'jvw-fab--dock-left': side === 'left',
+				'jvw-fab--peek': autoPeek,
 			}"
 			:style="fabStyle"
 			:aria-label="panelOpen ? `Close ${brandName}` : `Ask ${brandName}`"
@@ -31,6 +32,18 @@
 			<svg v-if="!brandLogoUrl" viewBox="0 0 24 24" width="24" height="24" fill="#fff">
 				<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
 			</svg>
+			<!-- Blink face: DUPLICATED from JarvisMark.vue's jv-face/jv-eye + PEEK
+			     block, by necessity not choice — this widget cannot import from
+			     frontend/src or use JarvisMark itself (see panel_readiness.mjs for
+			     why). Keep this markup, the CSS below, and the idle-blink timing in
+			     ./Widget.vue's <script> in sync with JarvisMark.vue by hand. Hover
+			     and focus reveal it like JarvisMark's hoverPeek; jvw-fab--peek
+			     (autoPeek below) blinks it on its own while resting, like
+			     JarvisMark's idlePeek. A whitelabel logo gets no face, same as
+			     JarvisMark's img branch. -->
+			<span v-if="!brandLogoUrl" class="jvw-face" aria-hidden="true">
+				<i class="jvw-eye"></i><i class="jvw-eye"></i>
+			</span>
 		</button>
 
 		<!-- Dimming backdrop for the expand-into-the-big-chat handoff: fades the
@@ -81,6 +94,32 @@ let dragSession = null;
 let suppressClick = false;
 let idleTimer = null;
 let snapTimeoutHandle = null;
+
+// ---- Idle blink: DUPLICATED from JarvisMark.vue's idlePeek timer, by
+// necessity not choice (see the jvw-face comment in <template> for why this
+// file can't just import JarvisMark). Keep the constants and behavior in
+// sync with JarvisMark.vue by hand. Distinct from idleTimer above, which
+// fades the whole FAB on page-wide inactivity; this one blinks the face on
+// its own regardless of that fade.
+const IDLE_PEEK_INTERVAL_MS = 8000;
+const IDLE_PEEK_HOLD_MS = 1800; // one jvw-blink cycle, then back to resting
+const autoPeek = ref(false);
+let idlePeekTimeoutId = null;
+let idlePeekHoldTimeoutId = null;
+
+function prefersReducedMotion() {
+	return Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+}
+
+function scheduleIdlePeek() {
+	idlePeekTimeoutId = window.setTimeout(() => {
+		autoPeek.value = true;
+		idlePeekHoldTimeoutId = window.setTimeout(() => {
+			autoPeek.value = false;
+		}, IDLE_PEEK_HOLD_MS);
+		scheduleIdlePeek();
+	}, IDLE_PEEK_INTERVAL_MS);
+}
 
 // Access gate: desk boot sets this once for the session (see Task B).
 const hasAccess = Boolean(window.frappe?.boot?.jarvis_has_access);
@@ -394,6 +433,7 @@ onMounted(() => {
 			if (!dragging.value) faded.value = true;
 		},
 	});
+	if (!brandLogoUrl && !prefersReducedMotion()) scheduleIdlePeek();
 	window.addEventListener("resize", onResize);
 	window.addEventListener("orientationchange", onResize);
 	document.addEventListener("mousemove", onDocumentActivity, { passive: true });
@@ -419,6 +459,8 @@ onBeforeUnmount(() => {
 		window.clearTimeout(snapTimeoutHandle);
 		snapTimeoutHandle = null;
 	}
+	if (idlePeekTimeoutId) window.clearTimeout(idlePeekTimeoutId);
+	if (idlePeekHoldTimeoutId) window.clearTimeout(idlePeekHoldTimeoutId);
 });
 </script>
 
@@ -547,12 +589,69 @@ onBeforeUnmount(() => {
 	opacity: 0.55;
 }
 
+/* ---- blink face ----
+   DUPLICATED from JarvisMark.vue's PEEK block (jv-face/jv-eye + jvm-blink),
+   by necessity not choice — see the jvw-face comment in <template>. This is a
+   deliberate, scoped divergence from design.md 1.3 (no hover motion) the same
+   way the accent gradient above already is: the mark's face reveal already
+   ships as a sanctioned exception elsewhere (UserMenu.vue's sidebar brand
+   mark), so hover/focus revealing it here keeps the FAB consistent with the
+   rest of the brand mark rather than introducing a new pattern. Keep this
+   block, the template markup, and the idle-blink timing in <script> in sync
+   with JarvisMark.vue by hand. */
+.jvw-face {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	opacity: 0;
+	transition: opacity 0.25s ease;
+}
+.jvw-eye {
+	width: 7px;
+	height: 11px;
+	background: #fff;
+	border-radius: 999px;
+}
+.jvw-fab:hover > svg,
+.jvw-fab:focus-visible > svg,
+.jvw-fab--peek > svg {
+	opacity: 0;
+}
+.jvw-fab:hover .jvw-face,
+.jvw-fab:focus-visible .jvw-face,
+.jvw-fab--peek .jvw-face {
+	opacity: 1;
+}
+
+@keyframes jvw-blink {
+	0%,
+	46%,
+	100% {
+		transform: scaleY(1);
+	}
+	49%,
+	52% {
+		transform: scaleY(0.14);
+	}
+}
+
 @media (prefers-reduced-motion: no-preference) {
-	.jvw-fab > svg {
-		transition: transform 0.12s ease;
+	.jvw-fab:hover .jvw-eye,
+	.jvw-fab:focus-visible .jvw-eye,
+	.jvw-fab--peek .jvw-eye {
+		animation: jvw-blink 1.8s ease-in-out infinite;
+	}
+	.jvw-fab > svg,
+	.jvw-face {
+		transition: transform 0.12s ease, opacity 0.25s ease;
 	}
 	.jvw-fab:active > svg,
-	.jvw-fab--dragging > svg {
+	.jvw-fab--dragging > svg,
+	.jvw-fab:active .jvw-face,
+	.jvw-fab--dragging .jvw-face {
 		transform: scale(0.98);
 	}
 }


### PR DESCRIPTION
The Jarvis mark was built to blink its eyes as a friendly "resting" reveal, but nothing ever triggered that while idle, so it ran nowhere. The floating chat button (the purple FAB on every Desk page) also had no eyes at all. Now the mark blinks on its own about every 8 seconds, and the chat FAB blinks on hover/focus and on that same idle beat, so the product's mascot feels alive instead of static.

Reuses the existing blink keyframe (no new animation system) and skips entirely under `prefers-reduced-motion: reduce`.

Approved against a live before/after animation preview.

Tests: widget suite 132/132, mark-render specs 43/43, pre-commit clean.

<details>
<summary>Scope</summary>

- `JarvisMark.vue`: new opt-in `idlePeek` prop; a JS timer toggles the existing `jv-peek-on` class on the same ~8s beat, reduced-motion guarded via `matchMedia`.
- `UserMenu.vue`: turns on `idlePeek` for the sidebar brand mark (the one mark resting on every route).
- `Widget.vue` (Desk-embedded chat FAB): cannot import from `frontend/src` (build isolation, see `panel_readiness.mjs`), so the face markup, `jvw-blink` keyframe and idle timer are duplicated by hand per the repo's existing sync-by-comment convention. Hover/focus and the idle beat cross-fade the spark to the blinking-eyes face. A whitelabel logo gets no face.

Not verified in a live browser (no bench build); worth an eyeball on the real FAB and sidebar mark.
</details>

https://claude.ai/code/session_01D7RSk8v8xoZpQZskU6hgHV