### PR TITLE
Match the chat FAB to the logo colour and animate the composer focus border

### DIFF
--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -562,13 +562,15 @@ defineExpose({ el: inputEl, focusInput });
 	inset: 0;
 	border-radius: 13px;
 	padding: 1.6px;
+	/* Logo tokens from main.css (:root), not literal hex, so a brand retune
+	   carries here instead of drifting. */
 	background: conic-gradient(
 		from var(--jv-comp-angle),
-		#6e8bff,
-		#8b5cf6,
-		#6e8bff,
-		#8b5cf6,
-		#6e8bff
+		var(--brand-1),
+		var(--brand-2),
+		var(--brand-1),
+		var(--brand-2),
+		var(--brand-1)
 	);
 	/* Mask keeps only the padding band, turning the fill into a border ring. */
 	-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
@@ -587,6 +589,15 @@ defineExpose({ el: inputEl, focusInput });
 @media (prefers-reduced-motion: reduce) {
 	.jv-composer:focus-within::after {
 		animation: none;
+	}
+}
+/* Forced-colors / high-contrast: the masked gradient ring is dropped by the
+   system, so guarantee a focus cue with an outline (which the inline border
+   cannot override). Keyboard users always get an affordance. */
+@media (forced-colors: active) {
+	.jv-composer:focus-within {
+		outline: 2px solid Highlight;
+		outline-offset: 2px;
 	}
 }
 /* The send button inverts to black/white on hover (depends on its base color,

--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -545,10 +545,49 @@ defineExpose({ el: inputEl, focusInput });
 </script>
 
 <style scoped>
-/* black focus highlight on the composer */
-.jv-composer:focus-within {
-	border-color: var(--text-3);
-	box-shadow: 0 0 0 3px rgba(23, 23, 23, 0.07);
+/* Brand focus highlight: while the box is focused, a gradient ring in the logo
+   colours flows around its edge. Drawn by a masked ::after so it lays exactly
+   over the 1px edge without having to beat the element's inline border/shadow
+   (which would win by specificity). The motion is the conic gradient's ANGLE
+   animating, not a rotating element, so the border stays put and only the
+   colour travels around it. */
+@property --jv-comp-angle {
+	syntax: "<angle>";
+	inherits: false;
+	initial-value: 0deg;
+}
+.jv-composer:focus-within::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	border-radius: 13px;
+	padding: 1.6px;
+	background: conic-gradient(
+		from var(--jv-comp-angle),
+		#6e8bff,
+		#8b5cf6,
+		#6e8bff,
+		#8b5cf6,
+		#6e8bff
+	);
+	/* Mask keeps only the padding band, turning the fill into a border ring. */
+	-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+	-webkit-mask-composite: xor;
+	mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+	mask-composite: exclude;
+	animation: jv-comp-flow 3s linear infinite;
+	pointer-events: none;
+}
+@keyframes jv-comp-flow {
+	to {
+		--jv-comp-angle: 360deg;
+	}
+}
+/* Reduced motion: hold a still gradient border rather than spinning it. */
+@media (prefers-reduced-motion: reduce) {
+	.jv-composer:focus-within::after {
+		animation: none;
+	}
 }
 /* The send button inverts to black/white on hover (depends on its base color,
    so the white icon flips to the surface color). !important beats the inline

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -512,10 +512,10 @@ onBeforeUnmount(() => {
 <style scoped>
 /* Scoped tokens for the FAB (it lives in <body>). */
 .jvw-root {
-	/* Brand gradient from the Jarvis Side Chat design board (a recorded
-	   divergence from design.md's near-black chrome, scoped to this widget). */
-	--accent: #6a56e8;
-	--accent-grad: linear-gradient(140deg, #8b7cf7, #6a56e8);
+	/* Logo gradient (same --brand-1 -> --brand-2 the SPA mark uses), so the FAB
+	   reads as the Jarvis logo rather than the deeper indigo it carried before. */
+	--accent: #8b5cf6;
+	--accent-grad: linear-gradient(135deg, #6e8bff, #8b5cf6);
 	--jvw-safe-bottom: env(safe-area-inset-bottom, 0px);
 	font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
@@ -548,8 +548,8 @@ onBeforeUnmount(() => {
    the indigo brand blue (the SPA's theme.js DARK_VARS accent) so the FAB stays
    visible against dark surfaces. */
 .jvw-root--dark {
-	--accent: #8b7cf7;
-	--accent-grad: linear-gradient(140deg, #9d90ff, #7a68f0);
+	--accent: #9d7bf8;
+	--accent-grad: linear-gradient(135deg, #7e97ff, #9d7bf8);
 }
 
 /* ---- launcher bubble ---- */
@@ -564,7 +564,7 @@ onBeforeUnmount(() => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	box-shadow: 0 10px 26px -6px rgba(106, 86, 232, 0.55);
+	box-shadow: 0 10px 26px -6px rgba(139, 92, 246, 0.5);
 	position: fixed;
 	left: 0;
 	top: 0;
@@ -581,7 +581,7 @@ onBeforeUnmount(() => {
 	/* A ring that HUGS the rounded tile. outline + outline-offset drew a
 	   detached square that looked misaligned against a full-bleed logo. */
 	outline: none;
-	box-shadow: 0 10px 26px -6px rgba(106, 86, 232, 0.55), 0 0 0 2px #fff, 0 0 0 4px var(--accent);
+	box-shadow: 0 10px 26px -6px rgba(139, 92, 246, 0.5), 0 0 0 2px #fff, 0 0 0 4px var(--accent);
 }
 .jvw-fab--snapping {
 	transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.25s ease;


### PR DESCRIPTION
Two small brand-colour polish tweaks from live feedback: the floating chat button now uses the logo gradient instead of a heavier indigo, and the chat composer grows a gradient border in the logo colours that flows around the box while focused (instead of a static grey highlight).

Both approved against live animated previews. Reduced-motion holds a still gradient.

<details>
<summary>Scope</summary>

- `Widget.vue` (Desk chat FAB): `--accent` / `--accent-grad` and the glow repointed from the indigo `#8b7cf7 → #6a56e8` to the logo gradient `#6e8bff → #8b5cf6`; dark variant tracks it.
- `Composer.vue` (SPA chat composer): focus highlight replaced with a masked `::after` gradient ring animated via the conic gradient's angle (border stays put, colour travels). `@media (prefers-reduced-motion: reduce)` holds it still.

Tests: SPA `npm run build` clean; `attachUpload.spec.js` 18/18; prettier clean. Not yet eyeballed in a live browser.
</details>

https://claude.ai/code/session_01D7RSk8v8xoZpQZskU6hgHV