### PR TITLE
feat(onboarding): optional partner code passthrough to admin signup

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -423,15 +423,25 @@ async function rawOnboardingCall(method, args, opts = {}) {
 export const onboardingPaymentApi = {
 	getOnboardingState: (opts) =>
 		rawOnboardingCall("jarvis.onboarding.get_onboarding_state", {}, opts),
-	startSignup: ({ email, company, plan, provider, billing }, opts) =>
+	startSignup: ({ email, company, plan, provider, billing, partner_code }, opts) =>
 		// Plan 01: the normalized billing snapshot rides the FIRST signup call so it
 		// persists server-side while the customer is still a guest (update_billing is
 		// authenticated and unreachable mid-signup). Included only when present - an
 		// empty object is never sent (the caller omits it), so an older admin that
 		// ignores the kwarg is unaffected.
+		// partner_code: an optional TOP-LEVEL kwarg (never inside billing), same
+		// omit-when-absent shape - an older admin that doesn't know the kwarg drops
+		// it and the signup proceeds exactly as before.
 		rawOnboardingCall(
 			"jarvis.onboarding.start_signup",
-			{ email, company, plan, provider, ...(billing ? { billing } : {}) },
+			{
+				email,
+				company,
+				plan,
+				provider,
+				...(billing ? { billing } : {}),
+				...(partner_code ? { partner_code } : {}),
+			},
 			opts
 		),
 	initiateSignupPayment: ({ plan, provider }, opts) =>

--- a/frontend/src/onboarding/usePaymentFlow.js
+++ b/frontend/src/onboarding/usePaymentFlow.js
@@ -414,7 +414,7 @@ export function createPaymentFlow(deps) {
 	}
 
 	// ---- submit review: start the signup exactly once ----------------------
-	async function submitReview({ email, company, plan, provider, billing } = {}) {
+	async function submitReview({ email, company, plan, provider, billing, partner_code } = {}) {
 		const my = beginAction(null); // SUBMIT_REVIEW sets the busy flag itself
 		if (!my) return; // a burst of clicks produces exactly one start (P1-2)
 		try {
@@ -424,11 +424,13 @@ export function createPaymentFlow(deps) {
 				// Plan 01: the billing snapshot rides start_signup (the guest has no
 				// session for the authenticated update_billing facade). Omitted when the
 				// caller passes nothing, so an empty object never crosses the wire.
+				// partner_code is a separate, optional top-level kwarg - never nested
+				// inside billing - forwarded to admin verbatim; jarvis does no validation.
 				decoded = ingest(
 					await deadlined(
 						(signal) =>
 							api.startSignup(
-								{ email, company, plan, provider, billing },
+								{ email, company, plan, provider, billing, partner_code },
 								{ signal }
 							),
 						fetchDeadlineMs,

--- a/frontend/src/onboarding/usePaymentFlow.spec.js
+++ b/frontend/src/onboarding/usePaymentFlow.spec.js
@@ -109,6 +109,21 @@ describe("the first payment: navigate to the admin-hosted pay page", () => {
 		expect(flow.state.value.illegalTransitions).toBe(0);
 	});
 
+	test("a review submit forwards partner_code as a top-level field, not inside billing", async () => {
+		const { flow, api } = makeFlow();
+		await flow.submitReview({
+			email: "a@b.com",
+			company: "Acme",
+			plan: "pro",
+			provider: "razorpay",
+			partner_code: "PARTNER-1",
+		});
+		expect(api.startSignup).toHaveBeenCalledWith(
+			expect.objectContaining({ partner_code: "PARTNER-1" }),
+			expect.anything()
+		);
+	});
+
 	test("a signup still awaiting verification navigates nothing", async () => {
 		const api = makeApi({
 			startSignup: vi.fn(async () =>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -398,6 +398,34 @@
 											:message="detailsFieldErrors.company"
 										/>
 									</div>
+									<!-- Partner code: optional, closed by default (most customers have
+										 none). jarvis only threads the string to admin - no validation
+										 here, admin resolves/rejects it. Kept on `state`, not the
+										 billing composable, so it is intentionally NOT restored on a
+										 mid-onboarding reload (localStorage-persisted like billing) -
+										 acceptable for v1 since it's typed once at signup. -->
+									<details class="col-span-2 text-p-xs text-ink-gray-5">
+										<summary class="cursor-pointer">
+											Have a partner code? (optional)
+										</summary>
+										<div class="mt-2 flex flex-col gap-1">
+											<p class="text-p-xs text-ink-gray-5">
+												If a Frappe partner referred you, enter their code
+												here.
+											</p>
+											<FormControl
+												type="text"
+												variant="outline"
+												label="Partner code (optional)"
+												:model-value="state.partnerCode"
+												@update:model-value="
+													(v) => (state.partnerCode = v)
+												"
+												placeholder="PARTNER-CODE"
+												@keydown.enter="onDetailsSubmit"
+											/>
+										</div>
+									</details>
 									<div
 										class="col-span-2 mt-2 text-base font-semibold text-ink-gray-9"
 									>
@@ -1740,6 +1768,13 @@ const state = reactive({
 	company: "",
 	companies: [],
 	detailsErr: "",
+	// Optional partner-code passthrough (top-level kwarg to admin, NOT part of
+	// `billing`). Deliberately kept here rather than on the `billing` composable:
+	// billing is localStorage-persisted so a mid-onboarding reload restores it,
+	// but a partner code is entered once at signup and does not need that -
+	// leaving it off the persisted composable means it is simply NOT restored
+	// on reload, which is acceptable for v1.
+	partnerCode: "",
 	// The four billing inputs (contact phone, address, city, GSTIN) live in the
 	// `billing` composable below (provenance-aware, fenced, namespaced) — Plan 01.
 	// True once a payment intent exists (a signup call created checkout handles,
@@ -3145,6 +3180,9 @@ async function onPayClick() {
 		plan: state.planName,
 		provider: state.paymentProvider,
 		billing: Object.keys(billingPayload).length ? billingPayload : undefined,
+		// Top-level kwarg, parallel to nothing else here - NOT part of `billing`.
+		// Trimmed + undefined-when-blank so a blank field sends no key at all.
+		partner_code: state.partnerCode?.trim() || undefined,
 	});
 	// Plan 01: a successful signup left REVIEW for a live intent (verify / checkout /
 	// provisioning / duplicate). An intent now exists, so a subsequent Review & Pay

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -245,6 +245,7 @@ def signup(
 	coupon: str | None = None,
 	provider: str | None = None,
 	billing: dict | None = None,
+	partner_code: str | None = None,
 ) -> dict:
 	"""Guest signup against admin. Returns admin's data dict, which carries a
 	``payment_provider`` discriminator plus that gateway's checkout handles:
@@ -271,6 +272,12 @@ def signup(
 	stores on the Customer in the signup transaction; the response echoes
 	``billing_saved: true`` only when a NEW admin persisted it (an older admin
 	drops the unknown kwarg and never echoes it).
+
+	``partner_code`` (optional) is an opaque string admin resolves to a Partner
+	and attributes the customer to. Sent verbatim, unvalidated - admin raises on
+	an unknown code, and that error surfaces through the normal AdminValidationError
+	path like any other signup rejection. An older admin that does not know the
+	kwarg drops it silently.
 	"""
 	body = {
 		"email": email,
@@ -286,6 +293,8 @@ def signup(
 		body["provider"] = provider
 	if billing:
 		body["billing"] = billing
+	if partner_code:
+		body["partner_code"] = partner_code
 	return _post_guest(path=_m("billing.signup.signup"), body=body)
 
 
@@ -294,6 +303,7 @@ def resume_pending_signup(
 	provider: str | None = None,
 	*,
 	billing: dict | None = None,
+	partner_code: str | None = None,
 	idempotency_key: str | None = None,
 ) -> dict:
 	"""Authenticated failed-payment resume: re-issues checkout handles for the
@@ -318,6 +328,8 @@ def resume_pending_signup(
 		body["provider"] = provider
 	if billing:
 		body["billing"] = billing
+	if partner_code:
+		body["partner_code"] = partner_code
 	if idempotency_key:
 		body["idempotency_key"] = idempotency_key
 	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -859,7 +859,12 @@ def _clear_llm_secrets(settings) -> None:
 
 @frappe.whitelist()
 def start_signup(
-	email: str, company: str, plan: str, provider: str | None = None, billing: dict | None = None
+	email: str,
+	company: str,
+	plan: str,
+	provider: str | None = None,
+	billing: dict | None = None,
+	partner_code: str | None = None,
 ) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.
 
@@ -877,6 +882,12 @@ def start_signup(
 	admin_client falls back to the DEFAULT_ADMIN_URL, which on a multi-site
 	bench may be the wrong control plane. Fail fast with an actionable
 	error instead of silently landing the wrong tenancy.
+
+	``partner_code`` (optional) is forwarded verbatim to admin, which resolves
+	it to a Partner and attributes the customer. This bench does no validation
+	of the code itself — an unknown code is admin's rejection to raise, and it
+	surfaces through the normal ``_ADMIN_ERRORS`` → ``_throw_admin_error`` path
+	below like any other signup error.
 
 	Two response shapes depending on admin's
 	``require_email_verification`` flag:
@@ -922,9 +933,11 @@ def start_signup(
 		# frappe.throw, and the duplicate check below needs the class and the
 		# contract code that conversion discards. Anything non-resumable then
 		# goes through the identical mapping _surface would have applied.
-		data = admin_client.signup(email, company, plan, provider=provider, billing=billing)
+		data = admin_client.signup(
+			email, company, plan, provider=provider, billing=billing, partner_code=partner_code
+		)
 	except _ADMIN_ERRORS as e:
-		resumed = _try_resume_pending_signup(e, email, plan, provider, billing)
+		resumed = _try_resume_pending_signup(e, email, plan, provider, billing, partner_code)
 		if resumed is None:
 			_throw_admin_error(e)  # always raises
 		data = resumed
@@ -969,7 +982,12 @@ def start_signup(
 
 
 def _try_resume_pending_signup(
-	err, email: str, plan: str, provider: str | None, billing: dict | None = None
+	err,
+	email: str,
+	plan: str,
+	provider: str | None,
+	billing: dict | None = None,
+	partner_code: str | None = None,
 ) -> dict | None:
 	"""Failed-payment retry: when guest signup is rejected as a duplicate and
 	this bench holds admin credentials, resume the pending signup through admin's
@@ -1011,6 +1029,7 @@ def _try_resume_pending_signup(
 			plan,
 			provider=provider,
 			billing=billing,
+			partner_code=partner_code,
 			idempotency_key=_reserve_idempotency_key(context=context),
 		)
 	except Exception:

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1108,6 +1108,56 @@ class TestClientCapabilityAdvert(FrappeTestCase):
 			out = admin_client.signup("e@x.com", "Co", "Annual Plan")
 		self.assertEqual(out, legacy_data)
 
+	def test_signup_forwards_partner_code_when_given(self):
+		_settings_clear_admin()  # guest signup path
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.signup("e@x.com", "Co", "Annual Plan", partner_code="PARTNER-1")
+		self.assertEqual(captured["json"]["partner_code"], "PARTNER-1")
+
+	def test_signup_omits_partner_code_when_not_given(self):
+		# An older admin ignoring the kwarg is fine; the bench must never SEND an
+		# empty one - that would be a real (if blank) value, not "not provided".
+		_settings_clear_admin()
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.signup("e@x.com", "Co", "Annual Plan")
+		self.assertNotIn("partner_code", captured["json"])
+
+	def test_resume_pending_signup_forwards_partner_code_when_given(self):
+		_settings_for_admin()  # authenticated resume path
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.resume_pending_signup("Annual Plan", partner_code="PARTNER-1")
+		self.assertEqual(captured["json"]["partner_code"], "PARTNER-1")
+
+	def test_resume_pending_signup_omits_partner_code_when_not_given(self):
+		_settings_for_admin()
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.resume_pending_signup("Annual Plan")
+		self.assertNotIn("partner_code", captured["json"])
+
 	def test_billing_facades_carry_capability_advert(self):
 		"""plan-09 P0-2: the capability advert now rides EVERY billing initiation call,
 		not just signup/resume, because admin's billing facades gate on it too. Without


### PR DESCRIPTION
## Summary

Adds an optional "partner code" field to onboarding's Details step. When typed, it
rides `start_signup` (and the failed-payment resume path) as a new top-level
`partner_code` kwarg, forwarded to admin verbatim so it can resolve the code to a
Partner. This bench does no validation.

**Do NOT merge until the sibling `jarvis_admin_v2` Partner PR is merged and deployed.**
An un-deployed admin silently drops the kwarg, so a typed code would be discarded
with no error shown.

## What changed
- Closed-by-default disclosure below Company on the Details step, bound to a new
  `state.partnerCode` (kept off the persisted billing composable on purpose, so it
  does not survive a mid-onboarding reload, acceptable for v1).
- `partner_code` threaded through `submitReview` -> `startSignup`, and through
  `onboarding.py` + `admin_client.py`'s `signup`/`resume_pending_signup`, sent only
  when non-blank. The `billing` payload contract is untouched.
- Tests added for both admin_client calls and the `submitReview` boundary.

## Risk and verification
- Frontend suite green: `vitest run` (1222/1222) and `node --test` (701/701) on Node 24.
- `pre-commit run` clean (ruff, prettier, eslint) on all changed files.
- Billing contract files untouched (fixtures, `useBillingDetails.js`,
  `test_billing_contract.py`).

<details><summary>Known gap in error surfacing (not fixed here)</summary>

An admin rejection of an unknown code only renders on the Details step if admin's
error classifies as a "details rejection" (message prefixed `billing.`, or exc_type
`BillingMetadataRejected`). A plain `AdminValidationError` instead falls into
`BENCH_ADMIN_REJECTED`, which shows generic payment-refusal copy, not admin's actual
message, and not next to the partner-code field. Either the admin PR should raise a
details-rejection-shaped error, or this bench's classifier needs a partner-code-aware
prefix, in a follow-up.

</details>

## Pre-merge checklist
- [ ] CI is green
- [ ] Branch is up to date with `develop`
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
