### PR TITLE
feat: idle logo does the thinking glance in sidebar and chat popup

### DIFF
--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -88,8 +88,8 @@ const hasFace = computed(
 // but self-triggered every IDLE_PEEK_INTERVAL_MS while nothing else is
 // driving the face. Only meaningful while mood is "star" - an active mood
 // already owns the face.
-const IDLE_PEEK_INTERVAL_MS = 8000;
-const IDLE_PEEK_HOLD_MS = 1800; // one jvm-blink cycle, then back to resting
+const IDLE_PEEK_INTERVAL_MS = 9000;
+const IDLE_PEEK_HOLD_MS = 4800; // ~1.4 jvm-lookaround cycles: a visible "thinking" glance, then back to resting
 const autoPeek = ref(false);
 let idleTimeoutId = null;
 let idleHoldTimeoutId = null;
@@ -325,11 +325,13 @@ const markStyle = computed(() => ({
 	}
 }
 
-/* PEEK - resting star until triggered, then a friendly blink. Triggered by
+/* PEEK - resting star until triggered, then the same "thinking" glance the
+   thinking mood uses (eyes look around, with a soft blink) rather than a quick
+   one-off blink, so a resting mark is clearly, visibly alive. Triggered by
    hovering the mark itself (hoverPeek), by the `peek` prop (so a larger
    surface, e.g. the whole sidebar brand card, can drive the same reveal), or
    by `idlePeek`'s own timer toggling the same `jv-peek-on` class (see
-   scheduleIdlePeek in <script>) so the mark blinks on its own while resting.
+   scheduleIdlePeek in <script>) so the mark glances on its own while resting.
    Only meaningful while mood is "star" (the face is otherwise hidden). */
 .jv-hoverpeek:hover .jv-star,
 .jv-peek-on .jv-star {
@@ -338,10 +340,11 @@ const markStyle = computed(() => ({
 .jv-hoverpeek:hover .jv-face,
 .jv-peek-on .jv-face {
 	opacity: 1;
+	animation: jvm-lookaround 3.4s ease-in-out infinite;
 }
 .jv-hoverpeek:hover .jv-eye,
 .jv-peek-on .jv-eye {
-	animation: jvm-blink 1.8s ease-in-out infinite;
+	animation: jvm-blink 3.4s ease-in-out infinite;
 }
 
 /* One calm static frame per mood, matching how JvSpinner/SetupNeuralNet handle

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -101,8 +101,8 @@ let snapTimeoutHandle = null;
 // sync with JarvisMark.vue by hand. Distinct from idleTimer above, which
 // fades the whole FAB on page-wide inactivity; this one blinks the face on
 // its own regardless of that fade.
-const IDLE_PEEK_INTERVAL_MS = 8000;
-const IDLE_PEEK_HOLD_MS = 1800; // one jvw-blink cycle, then back to resting
+const IDLE_PEEK_INTERVAL_MS = 9000;
+const IDLE_PEEK_HOLD_MS = 4800; // ~1.4 jvw-lookaround cycles: a visible "thinking" glance, then back to resting
 const autoPeek = ref(false);
 let idlePeekTimeoutId = null;
 let idlePeekHoldTimeoutId = null;
@@ -683,11 +683,39 @@ onBeforeUnmount(() => {
 	}
 }
 
+/* The "thinking" glance, mirrored from JarvisMark.vue's jvm-lookaround (kept in
+   sync by hand). Magnitudes are a touch smaller since the FAB face box is the
+   full button, not just the eyes. */
+@keyframes jvw-lookaround {
+	0%,
+	100% {
+		transform: translate(-11%, -6%);
+	}
+	28% {
+		transform: translate(-11%, -6%);
+	}
+	52% {
+		transform: translate(12%, -3%);
+	}
+	70% {
+		transform: translate(0, -8%) scale(0.96, 1.04);
+	}
+}
+
 @media (prefers-reduced-motion: no-preference) {
 	.jvw-fab:hover .jvw-eye,
 	.jvw-fab:focus-visible .jvw-eye,
 	.jvw-fab--peek .jvw-eye {
 		animation: jvw-blink 1.8s ease-in-out infinite;
+	}
+	/* Idle peek does the thinking glance (look around) rather than a quick
+	   blink, so the resting popup logo is clearly alive. Scoped to --peek so
+	   hover and focus keep the snappier blink. */
+	.jvw-fab--peek .jvw-face {
+		animation: jvw-lookaround 3.4s ease-in-out infinite;
+	}
+	.jvw-fab--peek .jvw-eye {
+		animation: jvw-blink 3.4s ease-in-out infinite;
 	}
 	.jvw-fab > svg,
 	.jvw-face {


### PR DESCRIPTION
Makes the resting Jarvis logo visibly alive. The sidebar mark and the chat-popup button now do the same "thinking" look-around the assistant uses while replying, instead of a quick blink that was easy to miss.

- Idle reveal now runs `jvm-lookaround` / `jvw-lookaround` (eyes glance around) and holds ~4.8s of a ~9s cycle, so it actually reads.
- Sidebar mark (`JarvisMark.vue` peek reveal) and popup FAB (`Widget.vue`) kept in sync by hand.
- Hover/focus keep the snappier blink; `prefers-reduced-motion` still holds a still face.

Pure CSS + two timing constants. Previewed and approved before build.

<details><summary>Note</summary>
The chat-popup change is in the Desk widget bundle (`Widget.vue`), which needs a `bench build --app jarvis` to appear on the Desk-embedded widget; the SPA sidebar mark ships via the normal frontend build. The artifact's separate "idle star-twinkle" is not included here (this uses the thinking glance per the request); can be added to the chat message avatar as a follow-up if wanted.
</details>