### PR TITLE
feat(billing): cancel-dialog warnings for trial + scheduled-downgrade customers

### DIFF
--- a/frontend/src/components/settings/PlanBillingPane.spec.js
+++ b/frontend/src/components/settings/PlanBillingPane.spec.js
@@ -173,6 +173,26 @@ describe("PlanBillingPane", () => {
 			expect(message).toContain("2026-09-15");
 		});
 
+		it("shows an immediate-access-loss message for a trial customer", async () => {
+			// A trial cancel ends access right now — is_trial must win over the
+			// mandate branch, and must NOT promise access until access_ends_on.
+			const w = await mountPane({
+				is_trial: true,
+				has_mandate: true,
+				can_cancel: true,
+				access_ends_on: "2026-09-15",
+			});
+			const btn = cancelButton(w);
+			await btn?.trigger("click");
+			await flushPromises();
+
+			expect(confirm).toHaveBeenCalled();
+			const { message } = confirm.mock.calls[0][0];
+			expect(message).toContain("ends your free trial right now");
+			expect(message).not.toContain("2026-09-15");
+			expect(message).not.toContain("Auto-renewal will turn off");
+		});
+
 		it("shows autopay message without date when access_ends_on is missing", async () => {
 			const w = await mountPane({ has_mandate: true, can_cancel: true, access_ends_on: "" });
 			const btn = cancelButton(w);

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -249,6 +249,12 @@ async function doCancel() {
 			? `You'll keep full access until ${endsOn}. You can resume any time before then.`
 			: "You'll keep full access until the end of your current period, and can resume any time before then.";
 	}
+	// A scheduled downgrade is dropped when you cancel (it doesn't survive to fire on a
+	// later renewal), so say so - the customer arranged it deliberately.
+	if (account.value.scheduled_plan) {
+		const to = account.value.scheduled_plan_name || "your scheduled plan change";
+		message += ` Your scheduled switch to ${to} will also be cancelled.`;
+	}
 	const ok = await confirm({
 		title: `${label}?`,
 		message,

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -238,7 +238,13 @@ async function doCancel() {
 	const label = cancelActionLabel(account.value.has_mandate);
 	const endsOn = (account.value.access_ends_on || "").split(" ")[0];
 	let message;
-	if (account.value.has_mandate) {
+	if (account.value.is_trial) {
+		// Trial cancel is IMMEDIATE (server: cancel-during-trial ends access now). No
+		// runway to trial end - turning off auto-renewal in the trial is declining to
+		// convert, so say so plainly rather than promising access until a date.
+		message =
+			"This ends your free trial right now - access stops immediately and auto-renewal is cancelled. You won't be charged. You can subscribe again anytime.";
+	} else if (account.value.has_mandate) {
 		// AutoPay branch: turn off auto-renewal, keep full access, can re-arm anytime.
 		message = endsOn
 			? `Auto-renewal will turn off. You'll keep full access until ${endsOn}, and can set it up again anytime.`


### PR DESCRIPTION
## What

Two small, additive **cancel-confirmation** copy warnings in the customer bench SPA (`PlanBillingPane.vue`), the frontend companion to the control-plane billing-QA work in **jarvis-admin-v2#309**. Both only change the *message the customer reads before confirming a cancel* — no behavioural/state change.

1. **Trial cancel is immediate.** When a customer on a free trial hits "Cancel", the dialog now says access ends **right now** (no runway to trial-end, no charge, can subscribe again) — `is_trial` wins over the mandate/period-end branches. Previously a trial customer saw the paid-customer "you keep access until `access_ends_on`" message, which is wrong for a trial.

2. **A scheduled downgrade is dropped on cancel.** When a customer with a pending scheduled plan-change cancels, the dialog now appends that the scheduled switch will also be cancelled (it doesn't survive to fire on a later renewal).

## Why

Surfaced during the R6 / billing-QA browser walks: the cancel dialog told trial and scheduled-downgrade customers something that didn't match what the server actually does, in a **no-refund** shop where a surprised cancel is costly.

## Tests

`PlanBillingPane.spec.js` — 18 passing, incl. the new `it("shows an immediate-access-loss message for a trial customer")` asserting the trial message wins and does **not** promise access until `access_ends_on`.

## Scope

Frontend-only, 2 files (`PlanBillingPane.vue` + its spec), 33 insertions. Deliberately excludes the deferred re-arm-autopay / pending-mandate UX (its own architect cycle).

## Merge order

Independent of #309 (different repo), but semantically the bench companion — merge either order.