### PR TITLE
feat: calmer 'working on it' indicator, drop the clashing dots

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -100,10 +100,6 @@ body {
 :root[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
 	background-color: #4a4a55;
 }
-@keyframes jv-dot {
-	0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
-	30% { transform: translateY(-4px); opacity: 1; }
-}
 @keyframes jv-fade {
 	from { opacity: 0; transform: translateY(6px); }
 	to { opacity: 1; transform: translateY(0); }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1807,12 +1807,9 @@
 									padding-top: 4px;
 								"
 							>
-								<span style="display: flex; gap: 4px" aria-hidden="true">
-									<span class="jv-tdot"></span>
-									<span class="jv-tdot" style="animation-delay: 0.18s"></span>
-									<span class="jv-tdot" style="animation-delay: 0.36s"></span>
-								</span>
-								<span style="font-size: 12px; color: var(--text-3)"
+								<span
+									class="jv-live-shim"
+									style="font-size: 12px; color: var(--text-3)"
 									>{{ liveStatus
 									}}<span
 										v-if="liveElapsedLabel"
@@ -10686,13 +10683,20 @@ onUnmounted(() => {
 	color: var(--text-1);
 	background: var(--surface-gray-2, rgba(0, 0, 0, 0.05));
 }
-/* thinking dots — classed so reduced-motion can disable them (UX #13) */
-.jv-tdot {
-	width: 6px;
-	height: 6px;
-	border-radius: 50%;
-	background: var(--text-3);
-	animation: jv-dot 1.1s infinite;
+/* live-status label: a gentle breathing shimmer so the "Working on it…" line
+   reads as active on its own, without the old bouncing dots competing with the
+   avatar mark's motion next to it. Disabled under reduced-motion below. */
+.jv-live-shim {
+	animation: jv-live-shim 1.8s ease-in-out infinite;
+}
+@keyframes jv-live-shim {
+	0%,
+	100% {
+		opacity: 0.55;
+	}
+	50% {
+		opacity: 1;
+	}
 }
 /* visually-hidden live region for screen-reader announcements (UX #5) */
 .jv-sr {
@@ -10719,9 +10723,9 @@ onUnmounted(() => {
 	.jv-spin {
 		animation: none;
 	}
-	.jv-tdot {
+	.jv-live-shim {
 		animation: none;
-		opacity: 0.55;
+		opacity: 1;
 	}
 	.jv-tool-dot.run,
 	.jv-mic-dot {


### PR DESCRIPTION
Calms the pending-reply indicator in the chat. The bouncing three dots and the avatar mark were animating on two different clocks (1.1s vs 3.4s) right next to each other, which read as busy. This drops the dots and lets the avatar carry the motion, with a gentle breathing shimmer on the "Working on it…" label.

- Removed the three `jv-tdot` dots from the live-status row.
- Added a soft `jv-live-shim` opacity breathe (1.8s) on the status label.
- Deleted the now-dead `.jv-tdot` rule and `@keyframes jv-dot`.
- Reduced-motion holds the label static; the recovery row (spinner) is untouched.

Pure CSS/markup in `ChatView.vue` + `main.css`. Previewed and approved (option B) before build.