### PR TITLE
fix: remove stray blue focus ring app-wide, one clean ring everywhere

### DIFF
--- a/frontend/src/components/JvCombo.vue
+++ b/frontend/src/components/JvCombo.vue
@@ -222,6 +222,12 @@ onBeforeUnmount(() => document.removeEventListener("mousedown", onDocClick));
 .jvc-input:focus,
 .jvc-input:focus-visible {
 	outline: none;
+	/* Also kill the @tailwindcss/forms blue ring on the inner input (it rings via
+	   box-shadow + border-color, which outline:none alone leaves untouched), so the
+	   wrapper's --cta ring is the only focus mark and there is no blue box inside the
+	   box, robust even where the app-wide index.css reset may not reach. */
+	box-shadow: none;
+	border-color: transparent;
 }
 .jvc-field:focus-within {
 	border-color: var(--cta-bd);

--- a/frontend/src/components/shell/ConversationRow.vue
+++ b/frontend/src/components/shell/ConversationRow.vue
@@ -9,7 +9,7 @@
 			v-if="renaming"
 			ref="renameEl"
 			v-model="renameText"
-			class="h-6 w-full rounded border border-outline-gray-2 bg-surface-white px-1 text-sm text-ink-gray-8 focus:outline-none"
+			class="h-6 w-full rounded border border-outline-gray-2 bg-surface-white px-1 text-sm text-ink-gray-8 focus:border-outline-gray-3 focus:outline-none focus:ring-0"
 			@click.stop
 			@keydown.enter.stop.prevent="commitRename"
 			@keydown.esc.stop.prevent="cancelRename"

--- a/frontend/src/components/shell/SidebarLink.vue
+++ b/frontend/src/components/shell/SidebarLink.vue
@@ -1,6 +1,6 @@
 <template>
 	<button
-		class="flex h-7.5 cursor-pointer items-center rounded text-ink-gray-8 duration-300 ease-in-out focus:outline-none focus:transition-none focus-visible:rounded focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+		class="flex h-7.5 cursor-pointer items-center rounded text-ink-gray-8 duration-300 ease-in-out focus:outline-none focus:transition-none focus-visible:rounded focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
 		:class="isActive ? 'bg-surface-selected shadow-sm' : 'hover:bg-surface-gray-2'"
 		@click="handleClick"
 	>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,8 +76,21 @@
    forms-plugin's BLUE focus ring, which contradicts the monochrome accent. Note
    the plugin rings via box-shadow + border-color, not outline, so a component's
    `outline: none` does not suppress it. */
-.jv-root :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus,
-.jv-ob-root :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus {
+/* App-wide, not just .jv-root/.jv-ob-root: scoping this to those two roots left
+   every OTHER surface (Settings dialog, Skills, dashboards) painting the plugin's
+   blue focus ring. `:root :where(...)` keeps the exact (0,2,0) specificity the
+   class scoping had, so it still beats the plugin, now everywhere. .form-input and
+   .form-select cover frappe-ui internals (e.g. Autocomplete's search box) that opt
+   into the plugin's class strategy. The plugin rings via box-shadow + border-color,
+   not outline, so a component's `outline: none` alone never suppresses it. */
+:root
+	:where(
+		input:not([type="checkbox"]):not([type="radio"]),
+		textarea,
+		select,
+		.form-input,
+		.form-select
+	):focus {
 	outline: none;
 	box-shadow: none;
 	border-color: revert;
@@ -90,11 +103,15 @@
    Suppressing it outright would cost keyboard users their focus indicator, so the
    ring is re-drawn here in the app's own accent, and only for :focus-visible, so a
    mouse click leaves the field clean while Tab still shows where you are. */
-.jv-root
-	:where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible,
-.jv-ob-root
-	:where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible {
-	outline: 2px solid var(--cta, currentColor);
+:root
+	:where(
+		input:not([type="checkbox"]):not([type="radio"]),
+		textarea,
+		select,
+		.form-input,
+		.form-select
+	):focus-visible {
+	outline: 2px solid var(--focus-ring);
 	outline-offset: 1px;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,21 +76,20 @@
    forms-plugin's BLUE focus ring, which contradicts the monochrome accent. Note
    the plugin rings via box-shadow + border-color, not outline, so a component's
    `outline: none` does not suppress it. */
-/* App-wide, not just .jv-root/.jv-ob-root: scoping this to those two roots left
-   every OTHER surface (Settings dialog, Skills, dashboards) painting the plugin's
-   blue focus ring. `:root :where(...)` keeps the exact (0,2,0) specificity the
-   class scoping had, so it still beats the plugin, now everywhere. .form-input and
-   .form-select cover frappe-ui internals (e.g. Autocomplete's search box) that opt
-   into the plugin's class strategy. The plugin rings via box-shadow + border-color,
-   not outline, so a component's `outline: none` alone never suppresses it. */
-:root
-	:where(
-		input:not([type="checkbox"]):not([type="radio"]),
-		textarea,
-		select,
-		.form-input,
-		.form-select
-	):focus {
+.jv-root :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus,
+.jv-ob-root :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus {
+	outline: none;
+	box-shadow: none;
+	border-color: revert;
+}
+/* App-wide, but ONLY the plugin's class-strategy targets (.form-input /
+   .form-select). Those are used by frappe-ui internals like Autocomplete's search
+   box, which carry NO focus border/shadow of their own, so they leak the blue on
+   every surface. Neutralise just those. This is deliberately NOT extended to bare
+   input/textarea/select app-wide: frappe-ui's own TextInput/Select self-protect
+   (they set focus:border/shadow/ring themselves), and a blanket reset stripped
+   that and left a bare UA-grey border on plain click focus. */
+:root :where(.form-input, .form-select):focus {
 	outline: none;
 	box-shadow: none;
 	border-color: revert;
@@ -103,14 +102,14 @@
    Suppressing it outright would cost keyboard users their focus indicator, so the
    ring is re-drawn here in the app's own accent, and only for :focus-visible, so a
    mouse click leaves the field clean while Tab still shows where you are. */
-:root
-	:where(
-		input:not([type="checkbox"]):not([type="radio"]),
-		textarea,
-		select,
-		.form-input,
-		.form-select
-	):focus-visible {
+.jv-root
+	:where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible,
+.jv-ob-root
+	:where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible {
+	outline: 2px solid var(--focus-ring);
+	outline-offset: 1px;
+}
+:root :where(.form-input, .form-select):focus-visible {
 	outline: 2px solid var(--focus-ring);
 	outline-offset: 1px;
 }

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -18,6 +18,12 @@
 	--brand-2: #8b5cf6;
 	--brand-grad: linear-gradient(135deg, var(--brand-1), var(--brand-2));
 
+	/* App-wide keyboard-focus ring colour. On :root (not theme.js paletteVars) so
+	   it resolves on every surface, including plain pages and teleported dialogs
+	   that never bound paletteVars, same reason --brand-* live here. Near-black,
+	   matching the --cta focus idiom the app already uses on chat and onboarding. */
+	--focus-ring: #1c1c22;
+
 	/* Money green, for the banknotes in the payment-confirming illustration
 	   ONLY (PaymentConfirmingArt.vue).
 
@@ -42,6 +48,9 @@
 }
 
 [data-theme="dark"] {
+	/* Focus ring inverts to near-white so it stays visible on the dark UI,
+	   matching --cta's dark value. */
+	--focus-ring: #ececf0;
 	/* Lifted for legibility on the dark card; the border stays a touch lighter
 	   than the fill so the note keeps its edge. */
 	--money-note: #4fbf85;


### PR DESCRIPTION
Removes the awkward blue focus box that appeared on Link/combobox/input fields across the SPA (Settings dialog, Skills, dashboards, the chat rename box), including the "box inside a box" double ring on the AI-models Model field. Every field now shows one clean near-black focus ring, consistent everywhere, only on keyboard focus.

Root cause: `@tailwindcss/forms` (via frappe-ui) rings every input/select/textarea blue on `:focus`. The app's existing fix for it was scoped only to the chat and onboarding roots.

- Un-scoped the neutralisation to `:root` (identical specificity, now app-wide) + added `.form-input`/`.form-select` for frappe-ui internals.
- Hoisted a `--focus-ring` token to `:root` (near-black light / near-white dark) so it resolves on every surface and teleported dialog.
- Killed the inner blue on `JvCombo`'s input at the component.

Pure CSS. Previewed before build. Keyboard focus preserved (`:focus-visible`), reduced-motion N/A.

<details><summary>Scope note (sidebar)</summary>
The sidebar nav icons use a separate GRAY `:focus-visible` ring (frappe-ui `ring-outline-gray-3`), not the blue forms-plugin ring, so it's a legitimate keyboard-focus indicator and is left untouched here. If you want the sidebar ring restyled to match the new `--focus-ring`, that's a small follow-up.
</details>