### PR TITLE
fix(chat): stop avatar clip when a tool-using turn finishes

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8375,7 +8375,19 @@ function onEvent(p) {
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;
-			activeTools.value = [];
+			// jarvis#808: deferred one tick past the mood->happy flip above
+			// (markAnswerLanded). Clearing activeTools synchronously here unmounts
+			// the sibling "thinking" JarvisMark (v-if on activeTools.length) in the
+			// SAME tick the landed message's own JarvisMark starts its one-shot
+			// cheer animation, so two overflow:hidden avatars mid-transition
+			// collide and paint a clipped frame. nextTick lets the cheer's mood
+			// change commit first, so the sibling's teardown lands a frame later
+			// instead of colliding with it. Guarded on currentRunId so a new run
+			// that starts (and pushes its own tool) before this callback fires is
+			// never clobbered by a stale clear from the run that just ended.
+			nextTick(() => {
+				if (!currentRunId.value) activeTools.value = [];
+			});
 			currentRunId.value = null;
 			store.streamingConvId = null;
 			// (browser notification moved to the app-scoped global notifier —


### PR DESCRIPTION
## Summary

The assistant avatar (JarvisMark) briefly renders clipped when a tool-using turn finishes. Fixes #808.

Root cause: `run:end` cleared `activeTools` in the same tick that `markAnswerLanded` flipped the landed message's avatar to its one-shot "happy" cheer animation. That synchronous clear unmounted the sibling "thinking" avatar mid-transition, so two overflow:hidden avatars collided and painted a clipped frame.

Fix: defer the `activeTools` clear to `nextTick()` so the mood change commits first and the sibling unmounts a frame later instead of colliding with it. Guarded on `currentRunId` so a new run started before the deferred callback fires is never clobbered by a stale clear from the run that just ended.

Minimal, single-handler change in `frontend/src/views/ChatView.vue`.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on X)
- [ ] Branch is **up to date with `main`**
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01NyY2CzWQ6HLjWnheuosHHp
