### PR TITLE
fix(jarvis): gate Desk widget FAB on ERPNext setup being complete

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/widget_visibility.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/widget_visibility.mjs
@@ -1,20 +1,21 @@
 // Visibility decision for the global floating Jarvis widget (the FAB).
 //
 // Pure so it can be unit-tested away from the Desk DOM (jarvis_widget.bundle.js
-// wires it to frappe.get_route()). The FAB is hidden only on full-page routes
-// where a floating launcher is redundant or unwanted:
+// wires it to frappe.get_route() and frappe.boot). The FAB is hidden on
+// full-page routes where a floating launcher is redundant or unwanted:
 //
 //   - Jarvis's own full-page surfaces (the chat page, the onboarding wizard).
 //   - Frappe's SETUP WIZARD — while a site's initial setup isn't finished Frappe
 //     forces every route to "setup-wizard" (router.js) and blocks the desk, so a
 //     Jarvis launcher floating over the setup screen is just noise.
 //
-// Deliberately ROUTE-based, NOT gated on whether the ERP is "set up" (a Company
-// existing): a site can be past the setup wizard with no Company yet, and that is
-// exactly where a user opens this bubble to set Jarvis up — so the launcher must
-// stay available there. The moment setup completes Frappe re-routes away from
-// "setup-wizard" and the FAB returns; the panel itself then handles the
-// onboarded / degraded / gate states (panel_readiness.classifyReadiness).
+// It is also hidden whenever `siteSetupComplete` is explicitly false: a site
+// can be past ERPNext's setup wizard route with no Company yet (e.g. the
+// wizard was skipped), and popping a "working" chat bubble there just walks a
+// user into a broken session. `siteSetupComplete` is
+// frappe.boot.jarvis_site_setup_complete (jarvis/boot.py — true once a
+// Company exists). Strict === false, matching the onboarding banner's
+// check, so an older boot payload without the key still shows the FAB.
 
 export const HIDE_ON_ROUTES = [
   "jarvis-chat",
@@ -23,7 +24,9 @@ export const HIDE_ON_ROUTES = [
 ];
 
 // `route` is frappe.get_route() (an array; route[0] is the page).
-export function shouldHideWidget(route) {
+// `siteSetupComplete` is frappe.boot.jarvis_site_setup_complete.
+export function shouldHideWidget(route, siteSetupComplete) {
   const page = (Array.isArray(route) && route[0]) || "";
-  return HIDE_ON_ROUTES.indexOf(page) !== -1;
+  if (HIDE_ON_ROUTES.indexOf(page) !== -1) return true;
+  return siteSetupComplete === false;
 }

--- a/jarvis/public/js/jarvis_chat/widget/widget_visibility.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/widget_visibility.test.mjs
@@ -16,15 +16,29 @@ test("hidden on Jarvis's own full-page routes", () => {
 
 test("hidden on Frappe's setup wizard (the site-setup screen)", () => {
   // While setup isn't complete Frappe forces route[0] to "setup-wizard"
-  // (router.js), so hiding on that route keeps the FAB off the setup screen
-  // WITHOUT suppressing it on normal desk pages — where a user sets Jarvis up
-  // from the bubble even before a Company exists.
+  // (router.js), so hiding on that route keeps the FAB off the setup screen.
   assert.equal(shouldHideWidget(["setup-wizard"]), true);
 });
 
-test("HIDE_ON_ROUTES are the only hidden routes", () => {
+test("HIDE_ON_ROUTES are the only hidden routes when setup is complete", () => {
   assert.equal(
-    HIDE_ON_ROUTES.every((r) => shouldHideWidget([r]) === true),
+    HIDE_ON_ROUTES.every((r) => shouldHideWidget([r], true) === true),
     true
   );
+});
+
+test("hidden on a normal desk page when the site has no Company yet", () => {
+  // frappe.boot.jarvis_site_setup_complete === false (jarvis/boot.py).
+  assert.equal(shouldHideWidget(["List", "Sales Invoice"], false), true);
+  assert.equal(shouldHideWidget([], false), true);
+});
+
+test("shown when setup-complete is unknown (older boot payload)", () => {
+  // Strict === false only, so a boot payload without the key behaves like
+  // before: route-based hiding is the only gate.
+  assert.equal(shouldHideWidget(["List", "Sales Invoice"], undefined), false);
+});
+
+test("shown on a normal desk page once setup is complete", () => {
+  assert.equal(shouldHideWidget(["List", "Sales Invoice"], true), false);
 });

--- a/jarvis/public/js/jarvis_widget.bundle.js
+++ b/jarvis/public/js/jarvis_widget.bundle.js
@@ -1,9 +1,10 @@
 // Global floating Jarvis widget — a draggable, edge-snapping FAB that opens
 // the side chat panel in place, present on every Desk page EXCEPT the full
-// chat page, the onboarding flow (where the agent isn't ready yet), and
-// Frappe's setup wizard (a fresh install whose site setup isn't finished, where
-// Frappe blocks the desk on the wizard). The visibility rule lives in
-// widget_visibility.mjs.
+// chat page, the onboarding flow (where the agent isn't ready yet), Frappe's
+// setup wizard (a fresh install whose site setup isn't finished, where
+// Frappe blocks the desk on the wizard), and any page where ERPNext's own
+// setup is otherwise incomplete (no Company yet). The visibility rule lives
+// in widget_visibility.mjs.
 //
 // The panel is a child of the FAB component, so hiding this host hides both.
 // On a narrow viewport the FAB navigates to the chat SPA instead of opening a
@@ -33,7 +34,8 @@ import { shouldHideWidget } from "./jarvis_chat/widget/widget_visibility.mjs";
 	function sync() {
 		ensureMounted();
 		const route = (window.frappe && frappe.get_route && frappe.get_route()) || [];
-		host.style.display = shouldHideWidget(route) ? "none" : "";
+		const siteSetupComplete = window.frappe?.boot?.jarvis_site_setup_complete;
+		host.style.display = shouldHideWidget(route, siteSetupComplete) ? "none" : "";
 	}
 
 	function start() {


### PR DESCRIPTION
## Summary

The Desk floating chat widget (FAB) popped a working chat even when ERPNext's setup wizard hadn't run and no Company existed yet, walking users into a broken session. `widget_visibility.mjs` now also hides the FAB when `frappe.boot.jarvis_site_setup_complete` is strictly `false` (set in `jarvis/boot.py` from Company existence, already used by the desk onboarding banner). Route-based hiding is unchanged, and an older boot payload without the key still shows the FAB.

Two notes:
- Scoped to the Desk widget only. The full-page SPA chat (`frontend/src/.../readiness.js`, `ChatView`) has the same gap and is intentionally left untouched here as an open question: gating it would lock out non-ERPNext tenants, a much bigger blast radius.
- `frappe.boot` is populated at page load, so it stays stale until a reload after the wizard completes. Acceptable: the same staleness already applies to the onboarding banner's use of this flag.

Fixes #811

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced**, so CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green**: the `tests` check on this PR passes (never merge on X)
- [x] Branch is **up to date with `main`** (based on fresh `develop`)
- [x] New/changed behavior has tests (`widget_visibility.test.mjs` extended, 7/7 passing locally)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01NyY2CzWQ6HLjWnheuosHHp
