### PR TITLE
fix(onboarding): partner-code error copy, AI-models UI, apply lock

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -5178,7 +5178,10 @@ onBeforeUnmount(() => {
 });
 
 // Let a host (onboarding, footerless) drive Save from its own footer, and a
-// hostScrim host (AiModelsPane) read the apply-in-flight state for its own scrim.
+// hostScrim host (AiModelsPane) read the apply-in-flight state for its own
+// scrim. AiModelsPane also re-exposes busy.active as `applying`, which
+// SettingsDialog reads through its own template ref to lock section
+// switching for the same duration.
 // canStart / startBlockedReason let the onboarding controller (saveConnect) REQUIRE
 // a savable+validated config - a connected subscription, a stored key, a local
 // endpoint, or a freshly-typed remote key with a PASSING probe bound to it (P0-09) -
@@ -5199,9 +5202,17 @@ defineExpose({
 /* ===== Blocking apply overlay =============================================
    The editor is the positioning context so the scrim covers exactly it, not the
    whole settings dialog: the customer should still be able to close the dialog
-   or move to another pane while their agent restarts in the background. Inside
-   the editor, though, nothing is clickable and (thanks to `inert` on the blocks
-   underneath) nothing is tabbable either.
+   while their agent restarts in the background, so a hung apply never traps
+   them. Inside the editor, though, nothing is clickable and (thanks to `inert`
+   on the blocks underneath) nothing is tabbable either.
+
+   Moving to another settings section while an apply is active is now BLOCKED,
+   not allowed. That guard lives one level up in SettingsDialog, which reads
+   AiModelsPane's exposed `applying` (itself mirroring this `busy` ref through
+   the poolEditor template ref) and locks the rail for the duration, so a click
+   elsewhere can no longer drop this scrim and abandon the apply mid-flight.
+   This file has no notion of sibling panes, so it only ever owns the close
+   affordance above, never the lock.
 
    hostScrim consumers (AiModelsPane) skip this box entirely and render their
    own wider one instead - the editor alone was too narrow a box: the pane's

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -251,11 +251,21 @@
 									<path d="M6 9l6 6 6-6" />
 								</svg>
 							</button>
-							<!-- Edit and Reconnect are meaningless on a subscription row with no
-			         connected account yet (a freshly added row - or one whose only
-			         account was disconnected): there is nothing to edit and nothing to
-			         reconnect. Keyed on rowHasConnectedAccount, not "just added", so a
-			         row left accountless by a disconnect hides them the same way. -->
+							<!-- Edit is meaningless on a subscription row with no connected account
+			         yet: there is nothing to edit. That covers both a freshly added,
+			         never-connected row AND one whose only account was disconnected -
+			         rows carry no "is this new" flag once the add-panel is closed
+			         (a preset-added row and a disconnected row both land here looking
+			         identical), so Edit stays keyed on rowHasConnectedAccount for both.
+
+			         Reconnect is DIFFERENT: an accountless row that lost its account to a
+			         disconnect needs Reconnect as its own recovery path (jarvis#821
+			         review - hiding it forced a destructive Remove + re-add that lost the
+			         row's place in the failover order). Since new-vs-disconnected can't be
+			         told apart reliably here, Reconnect is offered on every subscription
+			         row regardless of rowHasConnectedAccount; showing it on a row still
+			         mid-add is harmless (quickReconnect opens the same connect panel
+			         "+ Add a model" already would). -->
 							<button
 								v-if="
 									canEdit &&
@@ -269,11 +279,7 @@
 								Edit
 							</button>
 							<button
-								v-if="
-									canEdit &&
-									row.credentialType === 'subscription' &&
-									rowHasConnectedAccount(row)
-								"
+								v-if="canEdit && row.credentialType === 'subscription'"
 								:disabled="!editable"
 								@click="quickReconnect(i)"
 								class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -2332,8 +2338,7 @@ const ready = computed(() => {
 	if (!singleMode.value) return false;
 	const r = rows.value[0];
 	if (!r) return false;
-	if (r.credentialType === "subscription")
-		return (r.accounts || []).some((a) => a && (a.capture_id || a.account_ref));
+	if (r.credentialType === "subscription") return rowHasConnectedAccount(r);
 	return !!(
 		(r.provider || "").trim() &&
 		(r.model || "").trim() &&
@@ -2438,8 +2443,7 @@ const singleModeCanStart = computed(() => {
 	if (!singleMode.value) return false;
 	const r = rows.value[0];
 	if (!r) return false;
-	if (r.credentialType === "subscription")
-		return (r.accounts || []).some((a) => a && (a.capture_id || a.account_ref));
+	if (r.credentialType === "subscription") return rowHasConnectedAccount(r);
 	if (!(r.provider || "").trim() || !(r.model || "").trim()) return false;
 	if (smHardFailure()) return false;
 	if (isContainerOnlyRow(r)) return true; // local / private endpoint: no bench probe
@@ -2454,9 +2458,7 @@ const startBlockedReason = computed(() => {
 	const r = rows.value[0];
 	if (!r) return "Connect a model to continue.";
 	if (r.credentialType === "subscription")
-		return (r.accounts || []).some((a) => a && (a.capture_id || a.account_ref))
-			? ""
-			: "Connect your account to continue.";
+		return rowHasConnectedAccount(r) ? "" : "Connect your account to continue.";
 	if (!(r.provider || "").trim()) return "Choose a provider to continue.";
 	if (!(r.model || "").trim()) return "Enter a model id to continue.";
 	if (smHardFailure()) return "That test failed. Update the settings above to continue.";
@@ -2572,8 +2574,7 @@ function subTestIdemKey() {
 // directly in the template alongside this (they are timing-based, not a fact
 // about the row), so this only ever names a fact about the row itself.
 function subTestBlockedReason(m) {
-	if (!m || !(m.accounts || []).some((a) => a && (a.capture_id || a.account_ref)))
-		return "Connect your account before testing.";
+	if (!rowHasConnectedAccount(m)) return "Connect your account before testing.";
 	return "";
 }
 function subTestBannerType(result) {
@@ -3797,10 +3798,14 @@ function filledRows() {
 }
 // True when a subscription row has at least one account the connect flow actually
 // placed (capture_id: fresh from a just-finished sign-in; account_ref: a stored one
-// loaded from config). Same predicate used pool-wide to mean "connected" (ready,
-// singleModeCanStart, startBlockedReason, isRowEmpty). Keyed on this rather than
-// "row was just added" because that is the real UI state: a row can sit accountless
-// after a disconnect too, not only right after being added.
+// loaded from config). THE single predicate for "connected" pool-wide (jarvis#821
+// cleanup - this used to be inlined separately at each call site): ready,
+// singleModeCanStart, startBlockedReason, subTestBlockedReason, the submit guard in
+// buildSavePayload, and the Edit/Reconnect row actions in the template above all
+// call this now rather than repeating the (accounts || []).some(...) expression.
+// Keyed on this rather than "row was just added" because that is the real UI state:
+// a row can sit accountless after a disconnect too, not only right after being
+// added.
 function rowHasConnectedAccount(row) {
 	return !!(row && (row.accounts || []).some((a) => a && (a.capture_id || a.account_ref)));
 }
@@ -4828,11 +4833,7 @@ function buildSavePayload({ exclude = null } = {}) {
 	// clear message instead.
 	if (singleMode.value && llmMode.value !== "preset") {
 		const r0 = rows.value[0];
-		if (
-			r0 &&
-			r0.credentialType === "subscription" &&
-			!(r0.accounts || []).some((a) => a && (a.capture_id || a.account_ref))
-		) {
+		if (r0 && r0.credentialType === "subscription" && !rowHasConnectedAccount(r0)) {
 			return { error: "Connect your account to continue." };
 		}
 	}
@@ -5179,9 +5180,11 @@ onBeforeUnmount(() => {
 
 // Let a host (onboarding, footerless) drive Save from its own footer, and a
 // hostScrim host (AiModelsPane) read the apply-in-flight state for its own
-// scrim. AiModelsPane also re-exposes busy.active as `applying`, which
-// SettingsDialog reads through its own template ref to lock section
-// switching for the same duration.
+// scrim. AiModelsPane also mirrors busy.active into the shell store as
+// settingsApplying, which both SettingsDialog's go() and the store's own
+// openSettings() check before letting anything change settingsSection for
+// the same duration (jarvis#821 review: a template ref alone only covered
+// go(), not every writer of settingsSection).
 // canStart / startBlockedReason let the onboarding controller (saveConnect) REQUIRE
 // a savable+validated config - a connected subscription, a stored key, a local
 // endpoint, or a freshly-typed remote key with a PASSING probe bound to it (P0-09) -
@@ -5207,12 +5210,12 @@ defineExpose({
    on the blocks underneath) nothing is tabbable either.
 
    Moving to another settings section while an apply is active is now BLOCKED,
-   not allowed. That guard lives one level up in SettingsDialog, which reads
-   AiModelsPane's exposed `applying` (itself mirroring this `busy` ref through
-   the poolEditor template ref) and locks the rail for the duration, so a click
-   elsewhere can no longer drop this scrim and abandon the apply mid-flight.
-   This file has no notion of sibling panes, so it only ever owns the close
-   affordance above, never the lock.
+   not allowed. That guard lives up in the shell store (settingsApplying),
+   which AiModelsPane sets by watching this `busy` ref through the poolEditor
+   template ref; SettingsDialog's rail and the store's own openSettings() both
+   refuse to change section while it is true, so nothing that can unmount this
+   editor mid-apply is left uncovered. This file has no notion of sibling
+   panes, so it only ever owns the close affordance above, never the lock.
 
    hostScrim consumers (AiModelsPane) skip this box entirely and render their
    own wider one instead - the editor alone was too narrow a box: the pane's

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -251,8 +251,17 @@
 									<path d="M6 9l6 6 6-6" />
 								</svg>
 							</button>
+							<!-- Edit and Reconnect are meaningless on a subscription row with no
+			         connected account yet (a freshly added row - or one whose only
+			         account was disconnected): there is nothing to edit and nothing to
+			         reconnect. Keyed on rowHasConnectedAccount, not "just added", so a
+			         row left accountless by a disconnect hides them the same way. -->
 							<button
-								v-if="canEdit"
+								v-if="
+									canEdit &&
+									(row.credentialType !== 'subscription' ||
+										rowHasConnectedAccount(row))
+								"
 								:disabled="!editable"
 								@click="openEdit(i)"
 								class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -260,7 +269,11 @@
 								Edit
 							</button>
 							<button
-								v-if="canEdit && row.credentialType === 'subscription'"
+								v-if="
+									canEdit &&
+									row.credentialType === 'subscription' &&
+									rowHasConnectedAccount(row)
+								"
 								:disabled="!editable"
 								@click="quickReconnect(i)"
 								class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -268,7 +281,7 @@
 								Reconnect
 							</button>
 							<button
-								v-else-if="canEdit"
+								v-else-if="canEdit && row.credentialType !== 'subscription'"
 								:disabled="!editable"
 								@click="openEdit(i)"
 								class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -375,8 +388,11 @@
 											<path d="M6 9l6 6 6-6" />
 										</svg>
 									</button>
+									<!-- A grouped row always has 2+ accounts by construction (isGroupedRow),
+					         so rowHasConnectedAccount is always true here - kept for the same
+					         reason the ungrouped row keys on it, not row identity. -->
 									<button
-										v-if="canEdit"
+										v-if="canEdit && rowHasConnectedAccount(row)"
 										:disabled="!editable"
 										@click="openEdit(i)"
 										class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -384,7 +400,7 @@
 										Edit
 									</button>
 									<button
-										v-if="canEdit"
+										v-if="canEdit && rowHasConnectedAccount(row)"
 										:disabled="!editable"
 										@click="quickReconnect(i)"
 										class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -882,11 +898,8 @@
                entry, so two rows naming one model cannot both exist. Finding that
                out afterwards used to cost a whole wasted OAuth round trip (#575). -->
 					<p v-if="addFoldsInto" class="jv-pool-foldnote">
-						{{ upstreamLabelOf(panelRow.upstream) }} is already connected here with
-						{{ addFoldsInto.accounts.length }}
-						{{ addFoldsInto.accounts.length === 1 ? "account" : "accounts" }}. Signing
-						in adds another account to that same model, so your agent can spread its
-						work across them. It does not add a second model.
+						{{ upstreamLabelOf(panelRow.upstream) }} is already connected. Signing in
+						again adds another account to this model, not a new model.
 					</p>
 
 					<!-- Connect account: EDIT-mode re-entry only. In add mode the two-step sign-in
@@ -3781,6 +3794,15 @@ async function resync() {
 function filledRows() {
 	const pending = pendingAddRow();
 	return rows.value.filter((x) => !isRowEmpty(x) && x !== pending);
+}
+// True when a subscription row has at least one account the connect flow actually
+// placed (capture_id: fresh from a just-finished sign-in; account_ref: a stored one
+// loaded from config). Same predicate used pool-wide to mean "connected" (ready,
+// singleModeCanStart, startBlockedReason, isRowEmpty). Keyed on this rather than
+// "row was just added" because that is the real UI state: a row can sit accountless
+// after a disconnect too, not only right after being added.
+function rowHasConnectedAccount(row) {
+	return !!(row && (row.accounts || []).some((a) => a && (a.capture_id || a.account_ref)));
 }
 // True when removing this row would empty the pool, which is a disconnect rather than
 // an edit. Drives BOTH the row action's label and where remove() routes, so the button

--- a/frontend/src/components/settings/AiModelsPane.vue
+++ b/frontend/src/components/settings/AiModelsPane.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { Button } from "frappe-ui";
 import { getDirectSubscriptionStatus } from "@/api";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
@@ -199,4 +199,13 @@ async function onSaved(sync) {
 }
 
 onMounted(loadDirectSub);
+
+// Exposed for SettingsDialog: true while a model change is applying, so the
+// rail can lock section switching for the duration. Mirrors LlmPoolEditor's
+// own busy.active through the poolEditor template ref above, a template ref
+// rather than a shell-store flag, so the lock lives and dies with this pane
+// and can never get stuck true if the pane unmounts mid-apply.
+defineExpose({
+	applying: computed(() => !!poolEditor.value?.busy?.active),
+});
 </script>

--- a/frontend/src/components/settings/AiModelsPane.vue
+++ b/frontend/src/components/settings/AiModelsPane.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { Button } from "frappe-ui";
 import { getDirectSubscriptionStatus } from "@/api";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
@@ -99,6 +99,9 @@ import SettingsPane from "@/components/settings/SettingsPane.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { isSyncDisconnected } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
+import { useShellStore } from "@/stores/shell";
+
+const store = useShellStore();
 
 // Template ref onto LlmPoolEditor's exposed { save, busy } - read busy.active/
 // busy.label above for the pane-wide scrim in the #scrim slot.
@@ -200,12 +203,30 @@ async function onSaved(sync) {
 
 onMounted(loadDirectSub);
 
-// Exposed for SettingsDialog: true while a model change is applying, so the
-// rail can lock section switching for the duration. Mirrors LlmPoolEditor's
-// own busy.active through the poolEditor template ref above, a template ref
-// rather than a shell-store flag, so the lock lives and dies with this pane
-// and can never get stuck true if the pane unmounts mid-apply.
-defineExpose({
-	applying: computed(() => !!poolEditor.value?.busy?.active),
+// True while a model change is applying, mirroring LlmPoolEditor's own
+// busy.active through the poolEditor template ref above. Still exposed (some
+// callers may want it off a template ref), but the load-bearing consumer is
+// the watcher below: it publishes the same signal into the shell store as
+// settingsApplying, which is what SettingsDialog's go() AND the store's own
+// openSettings() both check before changing settingsSection (jarvis#821
+// review: go() alone left every OTHER writer of settingsSection, e.g.
+// GeneralPane's "AI models" buttons routed through store.openSettings, free
+// to unmount this pane mid-apply).
+//
+// Two ways this is guaranteed to clear, never stick true:
+//   1. immediate watcher: the moment busy.active flips back to false (apply
+//      settles, success or failure), the next tick syncs the store.
+//   2. onUnmounted: if this pane is torn down while an apply is still in
+//      flight (the one path a value watcher can't observe, since Vue stops
+//      watchers on unmount before a final "false" could ever fire), the store
+//      flag is force-cleared directly. This is what makes the lock provably
+//      un-stickable: the pane cannot vanish without also releasing the lock
+//      it published.
+const applying = computed(() => !!poolEditor.value?.busy?.active);
+watch(applying, (v) => (store.settingsApplying = v), { immediate: true });
+onUnmounted(() => {
+	store.settingsApplying = false;
 });
+
+defineExpose({ applying });
 </script>

--- a/frontend/src/components/shell/SettingsDialog.vue
+++ b/frontend/src/components/shell/SettingsDialog.vue
@@ -68,12 +68,15 @@
 							v-for="item in group.items"
 							:key="item.key"
 							class="mx-0.5 flex h-7 shrink-0 items-center gap-2 rounded px-2 text-sm text-ink-gray-8"
-							:class="
+							:class="[
 								section === item.key
 									? 'bg-surface-white shadow-sm'
-									: 'hover:bg-surface-gray-2'
-							"
+									: 'hover:bg-surface-gray-2',
+								applying ? 'cursor-not-allowed opacity-50' : '',
+							]"
 							:aria-current="section === item.key ? 'page' : undefined"
+							:aria-disabled="applying"
+							:disabled="applying"
 							@click="go(item.key)"
 						>
 							<FeatherIcon :name="item.icon" class="size-4 shrink-0" />
@@ -90,7 +93,7 @@
 				     the bottom. On a plain block wrapper both would clip silently
 				     with no scrollbar. -->
 				<div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-					<component :is="pane" />
+					<component :is="pane" ref="paneRef" />
 				</div>
 
 				<!-- Close lives at the dialog level, not in SettingsPane, so panes
@@ -109,7 +112,7 @@
 </template>
 
 <script setup>
-import { computed, defineAsyncComponent } from "vue";
+import { computed, defineAsyncComponent, ref } from "vue";
 import { Dialog, FeatherIcon } from "frappe-ui";
 // Straight from reka-ui, the same primitives frappe-ui's Dialog uses
 // internally. Needed because overriding the #body slot drops the ones it
@@ -219,7 +222,24 @@ const section = computed(() => {
 });
 const pane = computed(() => PANES[section.value]);
 
+// Template ref onto the active pane. Vue forwards a ref set on a
+// defineAsyncComponent-wrapped <component :is="..."> straight through to the
+// resolved inner component's exposed instance, so this resolves to
+// AiModelsPane's own defineExpose (which mirrors LlmPoolEditor's busy state)
+// once that pane has loaded. A pane that exposes nothing (every non-AiModels
+// pane today) just leaves `applying` false.
+const paneRef = ref(null);
+// True while the active pane is applying a change (currently only AiModelsPane
+// during a model apply). Read through the ref rather than a shell-store flag
+// so the signal dies with the pane and can never get stuck locked if the pane
+// unmounts mid-apply.
+const applying = computed(() => !!paneRef.value?.applying);
+
 function go(key) {
+	// Locked while an apply is in flight: switching sections would drop the
+	// applying pane's scrim and abandon the apply mid-flight. The dialog's own
+	// close (X) button is untouched, so a hung apply never traps the user.
+	if (applying.value) return;
 	store.settingsSection = key;
 }
 </script>

--- a/frontend/src/components/shell/SettingsDialog.vue
+++ b/frontend/src/components/shell/SettingsDialog.vue
@@ -93,7 +93,7 @@
 				     the bottom. On a plain block wrapper both would clip silently
 				     with no scrollbar. -->
 				<div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-					<component :is="pane" ref="paneRef" />
+					<component :is="pane" />
 				</div>
 
 				<!-- Close lives at the dialog level, not in SettingsPane, so panes
@@ -112,7 +112,7 @@
 </template>
 
 <script setup>
-import { computed, defineAsyncComponent, ref } from "vue";
+import { computed, defineAsyncComponent } from "vue";
 import { Dialog, FeatherIcon } from "frappe-ui";
 // Straight from reka-ui, the same primitives frappe-ui's Dialog uses
 // internally. Needed because overriding the #body slot drops the ones it
@@ -222,18 +222,17 @@ const section = computed(() => {
 });
 const pane = computed(() => PANES[section.value]);
 
-// Template ref onto the active pane. Vue forwards a ref set on a
-// defineAsyncComponent-wrapped <component :is="..."> straight through to the
-// resolved inner component's exposed instance, so this resolves to
-// AiModelsPane's own defineExpose (which mirrors LlmPoolEditor's busy state)
-// once that pane has loaded. A pane that exposes nothing (every non-AiModels
-// pane today) just leaves `applying` false.
-const paneRef = ref(null);
 // True while the active pane is applying a change (currently only AiModelsPane
-// during a model apply). Read through the ref rather than a shell-store flag
-// so the signal dies with the pane and can never get stuck locked if the pane
-// unmounts mid-apply.
-const applying = computed(() => !!paneRef.value?.applying);
+// during a model apply). AiModelsPane publishes this into the shell store
+// itself (watching LlmPoolEditor's busy state, cleared on settle AND from its
+// own onUnmounted so it can never stick true) rather than this dialog reading
+// it off a template ref: that way the SAME flag also gates the store's
+// openSettings(), which is a second, independent writer of settingsSection
+// (GeneralPane's "AI models" buttons, UserMenu, ChatView, AppShell's
+// ?settings= deep link all go through it, not through go() below). A lock
+// enforced only here would leave every one of those callers free to unmount
+// AiModelsPane mid-apply (jarvis#821 review).
+const applying = computed(() => !!store.settingsApplying);
 
 function go(key) {
 	// Locked while an apply is in flight: switching sections would drop the

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -27,6 +27,15 @@ const unreadConvs = ref(new Set());
 const approvalsCount = ref(0);
 const settingsOpen = ref(false); // the shell SettingsDialog binds to this
 const settingsSection = ref("general"); // active pane key in the settings dialog
+// True while the active settings pane is applying a change it cannot safely be
+// unmounted mid-flight (currently only AiModelsPane during a model apply).
+// Published by the pane itself (AiModelsPane watches LlmPoolEditor's busy.active
+// and mirrors it here, clearing it both when the apply settles AND from an
+// onUnmounted hook, so a pane torn down mid-apply can never leave this stuck
+// true). Read by every writer of settingsSection - SettingsDialog's go() and
+// openSettings() below - so a section switch can never abandon an in-flight
+// apply regardless of which caller triggered it (jarvis#821 review).
+const settingsApplying = ref(false);
 const pendingNewChat = ref(false); // consumed + cleared by ChatView
 const paletteOpen = ref(false);
 
@@ -409,8 +418,18 @@ function requestNewChat(router) {
 // gate. needsOnboarding() shares AppShell's own memoized readiness promise
 // (readiness.js's checkReady()), so this costs no extra round-trip: it's
 // already in flight or resolved by the time any real caller fires.
+//
+// Also guarded on settingsApplying (jarvis#821 review): this is a second writer
+// of settingsSection alongside SettingsDialog's rail go() - GeneralPane's "AI
+// models" buttons, UserMenu, ChatView and AppShell's deep-link handler all reach
+// settingsSection through here, not through go(), so a lock enforced only in
+// go() left every one of those callers free to switch away from AiModelsPane
+// mid-apply. settingsApplying can only be true while the dialog is already open
+// on the applying pane (see its own doc above), so refusing here never blocks a
+// legitimate first open.
 async function openSettings(section) {
 	if (await needsOnboarding()) return;
+	if (settingsApplying.value) return;
 	settingsOpen.value = true;
 	settingsSection.value = typeof section === "string" && section ? section : "general";
 }
@@ -456,6 +475,7 @@ const store = reactive({
 	approvalsCount,
 	settingsOpen,
 	settingsSection,
+	settingsApplying,
 	chatContext,
 	settingsActions,
 	activityDetail,

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3106,10 +3106,16 @@ async function onPayAction(a) {
 			// The partner-code input lives inside a collapsed disclosure (closed by
 			// default, since most customers have none). A walk-back landing here
 			// because of the partner code must open it, or the field the customer
-			// needs to fix stays invisible. Detected on the message text (admin names
-			// the field it rejected in the sentence) since no machine code exists yet
-			// for which field specifically failed.
-			if (/partner code/i.test(state.detailsErr)) {
+			// needs to fix stays invisible. Primary signal is local, not the message
+			// text: the customer already typed a code, so revealing the (optional,
+			// harmless-to-show) disclosure is correct even if this particular
+			// rejection turns out to be about a different field. The /partner code/i
+			// match on admin's free-text sentence is kept only as a secondary
+			// signal - it still opens the disclosure for a customer who somehow
+			// lands here with the field blank (jarvis#821 review: the text-only
+			// match silently missed a reworded/translated rejection message; no
+			// machine code exists yet for which field specifically failed).
+			if (state.partnerCode?.trim() || /partner code/i.test(state.detailsErr)) {
 				state.partnerCodeOpen = true;
 			}
 		}

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -407,7 +407,11 @@
 										 billing composable, so it is intentionally NOT restored on a
 										 mid-onboarding reload (localStorage-persisted like billing) -
 										 acceptable for v1 since it's typed once at signup. -->
-									<details class="col-span-2 text-p-xs text-ink-gray-5">
+									<details
+										class="col-span-2 text-p-xs text-ink-gray-5"
+										:open="state.partnerCodeOpen"
+										@toggle="state.partnerCodeOpen = $event.target.open"
+									>
 										<summary class="cursor-pointer">
 											Have a partner code? (optional)
 										</summary>
@@ -1782,6 +1786,11 @@ const state = reactive({
 	// leaving it off the persisted composable means it is simply NOT restored
 	// on reload, which is acceptable for v1.
 	partnerCode: "",
+	// Whether the partner-code disclosure (collapsed by default, see the
+	// `<details>` in the Details step template) is open. Forced open when a
+	// details-rejection walk-back names the partner code, so the field the
+	// customer must fix is not hidden inside a closed disclosure.
+	partnerCodeOpen: false,
 	// The four billing inputs (contact phone, address, city, GSTIN) live in the
 	// `billing` composable below (provenance-aware, fenced, namespaced) — Plan 01.
 	// True once a payment intent exists (a signup call created checkout handles,
@@ -3094,6 +3103,15 @@ async function onPayAction(a) {
 		// like the wizard threw their progress away for no reason.
 		if (pay.value.code === CODES.BENCH_SIGNUP_DETAILS_REJECTED) {
 			state.detailsErr = pay.value.message || payCopy.value.body;
+			// The partner-code input lives inside a collapsed disclosure (closed by
+			// default, since most customers have none). A walk-back landing here
+			// because of the partner code must open it, or the field the customer
+			// needs to fix stays invisible. Detected on the message text (admin names
+			// the field it rejected in the sentence) since no machine code exists yet
+			// for which field specifically failed.
+			if (/partner code/i.test(state.detailsErr)) {
+				state.partnerCodeOpen = true;
+			}
 		}
 		// jarvis#297 P0-2a: "Use a different email" on a signup this session TYPED
 		// through Details already has state.email/company live in memory, but a

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1984,6 +1984,12 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 			# GSTIN. It is a plain rejection with a precise, customer-safe message,
 			# which is exactly what this allowlist is for.
 			"BillingMetadataRejected",
+			# Another ValidationError subclass, raised when the customer's partner
+			# code is unknown or inactive. Same shape as BillingMetadataRejected: a
+			# precise, customer-safe message that was falling through to the
+			# unknown-exc_type branch and logging a spurious error on every rejected
+			# partner code.
+			"PartnerCodeRejected",
 		):
 			# The THROWN wire shape: admin's contract ``error`` object rides at
 			# the top level next to exc_type. Both survive here - the code for a

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -119,7 +119,7 @@ BENCH_SIGNUP_DETAILS_REJECTED = "BENCH_SIGNUP_DETAILS_REJECTED"
 #: are matched on the wire ``exc_type`` string, so a class admin renames must be
 #: added here too - which is the same append-only discipline every other code in
 #: this module follows.
-_DETAILS_REJECTION_EXC_TYPES = frozenset({"BillingMetadataRejected"})
+_DETAILS_REJECTION_EXC_TYPES = frozenset({"BillingMetadataRejected", "PartnerCodeRejected"})
 
 #: Field prefixes admin uses when it names the offending input. A message starting
 #: with one of these is, by admin's own convention, about a value the customer

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1158,6 +1158,38 @@ class TestClientCapabilityAdvert(FrappeTestCase):
 			admin_client.resume_pending_signup("Annual Plan")
 		self.assertNotIn("partner_code", captured["json"])
 
+	def test_partner_code_rejection_is_surfaced_as_a_details_error(self):
+		"""`PartnerCodeRejected` is a ValidationError SUBCLASS admin raises for an
+		unknown or inactive partner code, before it built any provider object. It
+		used to fall through admin_client's exc_type allowlist into the unknown
+		branch and (via onboarding_contract) render as BENCH_ADMIN_REJECTED, "the
+		payment service refused this request" - false in every particular, since no
+		payment service was ever contacted. It must classify like a bad GSTIN: a
+		details-rejection the customer can actually fix."""
+		_settings_clear_admin()  # guest signup path
+		mock_post = MagicMock(
+			return_value=_mock_response(
+				417,
+				json_body={
+					"exception": "jarvis_admin.exceptions.PartnerCodeRejected: Unknown partner code: ACME-2026",
+					"exc_type": "PartnerCodeRejected",
+					"_server_messages": '["{\\"message\\": \\"Unknown partner code: ACME-2026\\", \\"indicator\\": \\"red\\"}"]',
+				},
+			)
+		)
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				admin_client.signup("e@x.com", "Co", "Annual Plan", partner_code="ACME-2026")
+		self.assertEqual(str(cm.exception), "Unknown partner code: ACME-2026")
+
+		from jarvis import onboarding_contract
+
+		error, status = onboarding_contract.error_object(cm.exception)
+		self.assertEqual(error["code"], onboarding_contract.BENCH_SIGNUP_DETAILS_REJECTED)
+		self.assertNotEqual(error["code"], onboarding_contract.BENCH_ADMIN_REJECTED)
+		self.assertEqual(status, 409)
+		self.assertEqual(error["message"], "Unknown partner code: ACME-2026")
+
 	def test_billing_facades_carry_capability_advert(self):
 		"""plan-09 P0-2: the capability advert now rides EVERY billing initiation call,
 		not just signup/resume, because admin's billing facades gate on it too. Without

--- a/jarvis/tests/test_admin_contract.py
+++ b/jarvis/tests/test_admin_contract.py
@@ -505,6 +505,21 @@ class TestDetailsRejectionIsNotAPaymentFailure(_ContractCase):
 		# The precise server sentence is what makes this actionable; it must survive.
 		self.assertEqual(error["message"], "billing.gstin is not a valid GSTIN")
 
+	def test_partner_code_rejection_gets_its_own_code(self):
+		"""`PartnerCodeRejected` is the same shape as `BillingMetadataRejected`: a
+		ValidationError SUBCLASS admin raises when the customer's OWN typed partner
+		code is unknown or inactive, before it built any provider object. It used
+		to collapse into BENCH_ADMIN_REJECTED ("the payment service refused this
+		request"), which was false in every particular for the same reason as a bad
+		GSTIN."""
+		err = AdminValidationError("Unknown partner code: ACME-2026")
+		err.exc_type = "PartnerCodeRejected"
+		error, status = onboarding_contract.error_object(err)
+		self.assertEqual(error["code"], onboarding_contract.BENCH_SIGNUP_DETAILS_REJECTED)
+		self.assertEqual(status, 409)
+		# The precise server sentence is what makes this actionable, it must survive.
+		self.assertEqual(error["message"], "Unknown partner code: ACME-2026")
+
 	def test_an_unknown_exc_type_still_routes_on_the_field_prefix(self):
 		"""An admin build whose exception class this bench has never heard of still
 		names the field by admin's own convention, so the customer is not punished
@@ -527,6 +542,7 @@ class TestDetailsRejectionIsNotAPaymentFailure(_ContractCase):
 		a sentence. A reworded message that still names its field keeps working; a
 		message that merely mentions billing does not qualify."""
 		self.assertTrue(onboarding_contract.is_details_rejection("", "BillingMetadataRejected"))
+		self.assertTrue(onboarding_contract.is_details_rejection("", "PartnerCodeRejected"))
 		self.assertTrue(onboarding_contract.is_details_rejection("billing.city is too long"))
 		self.assertFalse(onboarding_contract.is_details_rejection("your billing could not be processed"))
 		self.assertFalse(onboarding_contract.is_details_rejection(""))


### PR DESCRIPTION
## Summary

A wrong or inactive partner code now walks the customer back to fix that field, instead of showing a false "the payment service refused this request" screen with dead-end buttons. Also two AI-models cleanups a tester flagged, and a settings lock so switching menus can no longer abandon a model apply mid-flight.

## What changed
- Partner-code rejection is classified as a details error (not a payment failure), so onboarding walks the customer back to Details and opens the collapsed partner-code disclosure to the field they must fix. Removes the spurious error-log line on every rejected code.
- Add-model helper text trimmed to one sentence; `Edit` and `Reconnect` are hidden on a chat-subscription row that has no connected account yet (only `Remove` shows).
- Settings: the section menu is locked while a model change is applying to the agent (the dialog close still works, so a slow restart never traps the user). Switching away used to drop the apply's scrim and abandon it.

## Risk and verification
- Frontend `vitest` 1227/1227 on Node 24. Added backend classification tests (`test_admin_contract`, `test_admin_client`). Hosted CI is the gate.
- Low blast radius: the partner-code change is an append to an allowlist and a set; the rest is presentational plus one nav guard.

<details><summary>Root cause (partner code)</summary>

Admin already rejects an unknown code (`PartnerCodeRejected`, a `ValidationError` subclass, http 400) before any provider object is created, so nothing is ever charged. But the bench classified that exc_type as a generic payment refusal (`BENCH_ADMIN_REJECTED`) because it was never added alongside `BillingMetadataRejected` to the details-rejection set. The fix adds it to `_DETAILS_REJECTION_EXC_TYPES` and the `admin_client` allowlist. Covers both the fresh-signup and resume-checkout paths, which converge on `error_object()`. Field detection on the walk-back is by message text since no per-field machine code survives to the client yet.

</details>

## Pre-merge checklist

- [ ] **CI is green** (pending the `tests` check on this PR)
- [x] Branch is based on the latest `develop` (this repo deploys from and PRs into `develop`)
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
