### PR TITLE
feat(billing): render the "Payment retrying" dunning banner

### DIFF
--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -193,7 +193,12 @@ export function renewalLabel(currentPeriodEnd, daysRemaining) {
 // Billing lifecycle banner, or null when there is nothing to say. The server
 // sends BOTH audiences' wording because it authenticates the customer, not the
 // individual - only the bench knows who is looking, so the pick happens here.
-const BILLING_TONE = { expiring: "info", grace: "warning", expired: "warning", retrying: "warning" };
+const BILLING_TONE = {
+	expiring: "info",
+	grace: "warning",
+	expired: "warning",
+	retrying: "warning",
+};
 const BILLING_TITLE = {
 	expiring: "Plan ending soon",
 	grace: "Payment overdue",

--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -193,11 +193,12 @@ export function renewalLabel(currentPeriodEnd, daysRemaining) {
 // Billing lifecycle banner, or null when there is nothing to say. The server
 // sends BOTH audiences' wording because it authenticates the customer, not the
 // individual - only the bench knows who is looking, so the pick happens here.
-const BILLING_TONE = { expiring: "info", grace: "warning", expired: "warning" };
+const BILLING_TONE = { expiring: "info", grace: "warning", expired: "warning", retrying: "warning" };
 const BILLING_TITLE = {
 	expiring: "Plan ending soon",
 	grace: "Payment overdue",
 	expired: "Chat is paused",
+	retrying: "Payment retrying",
 };
 
 export function billingBanner(notice, canRenew) {

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -166,3 +166,13 @@ test("billingBanner: tone escalates across the lifecycle", () => {
 test("billingBanner: says nothing when this audience has no copy", () => {
 	assert.equal(billingBanner({ phase: "grace", admin_message: "x" }, false), null);
 });
+
+test("billingBanner: retrying is an amber, persistent dunning banner", () => {
+	// Slice 2: a failed auto-renewal in the gateway's retry window.
+	const b = billingBanner(_notice("retrying"), true);
+	assert.equal(b.type, "warning");
+	assert.equal(b.title, "Payment retrying");
+	assert.equal(b.message, "ADMIN COPY");
+	assert.equal(b.dismissible, false); // persistent - only the pre-expiry nudge dismisses
+	assert.equal(billingBanner(_notice("retrying"), false).message, "MEMBER COPY");
+});


### PR DESCRIPTION
Slice 2 of the confirmation-reliability program — the bench half. **Paired with admin PR Aerele-RnD/jarvis-admin-v2#319** (the `retrying` phase producer).

Adds the `retrying` phase to the billing lifecycle banner (`format.js`): **warning (amber)** tone, **"Payment retrying"** title, **persistent** (not dismissible). The control plane emits this phase on the connection/chat-gate payload when a subscription's auto-charge is in Razorpay's retry window.

Additive + order-safe: `billingBanner` already returns `null` on an unknown phase, so a bench that predates this key renders no banner and cannot break — the two PRs can merge in either order.

Verification: `format.test.js` 25 pass (tone/title/message/dismissible=false/unknown→null).