### PR TITLE
fix(account): keep an established workspace in-app on a mid-apply reload

### DIFF
--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -83,6 +83,14 @@ export async function isWorkspaceReady() {
 // reopened the gate: needsOnboarding() returned false, so AppShell rendered the
 // normal chat shell for a customer whose connection was never accepted and whose
 // chat therefore cannot answer.
+// "llm_applying" is deliberately ABSENT (jarvis C2): the server only ever returns
+// it for a workspace _has_been_chat_ready has already confirmed established
+// (account.py's _provisioning_verdict), so it can never fire on a genuinely
+// never-onboarded tenant - those stay on the hard llm_pool_provisioning /
+// llm_provisioning reason above. It means "an established workspace's FIRST
+// pool/direct leg is mid-apply" (e.g. adding a model in Settings), which must
+// keep the customer in their chat + history, not bounce them to the setup
+// poster on a reload. See isLlmApplying() below for its quiet in-app banner.
 const NOT_ONBOARDED_REASONS = new Set([
 	"signup",
 	"llm_pool_provisioning",
@@ -261,4 +269,18 @@ export async function readinessDetailOf() {
 export async function needsLlmConnection() {
 	const r = await checkReady();
 	return !!(r && !r.ready && r.reason === "llm_credentials");
+}
+
+// True when an established workspace's LLM leg is mid-apply for the first time
+// (jarvis C2 - e.g. adding a model in Settings > AI models just flipped it into
+// pool mode). Its own accessor, same "one reason, one accessor" convention as
+// needsLlmConnection above, rather than folding into readinessDetailOf: that one
+// is spec-pinned to container_provisioning/authority_repair_required and
+// is_ready_for_chat sends no `detail` for this reason - there is nothing to
+// quote, only a state to name. The caller's banner is quiet (no CTA, no
+// composer-disable): the container is still serving the workspace's PREVIOUS
+// config while this converges, so chat keeps working.
+export async function isLlmApplying() {
+	const r = await checkReady();
+	return !!(r && !r.ready && r.reason === "llm_applying");
 }

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -278,8 +278,12 @@ export async function needsLlmConnection() {
 // is spec-pinned to container_provisioning/authority_repair_required and
 // is_ready_for_chat sends no `detail` for this reason - there is nothing to
 // quote, only a state to name. The caller's banner is quiet (no CTA, no
-// composer-disable): the container is still serving the workspace's PREVIOUS
-// config while this converges, so chat keeps working.
+// composer-disable) but NOT a promise that chat keeps answering: a FIRST
+// direct->pool transition stops and restarts the container (a 10-30s bounce),
+// so the previous config does NOT keep serving through it. This just keeps the
+// customer in their chat + history instead of bouncing them to the setup
+// wizard - see account._APPLYING_SOFT_WINDOW_S for the time-box that keeps a
+// stuck apply from staying soft forever.
 export async function isLlmApplying() {
 	const r = await checkReady();
 	return !!(r && !r.ready && r.reason === "llm_applying");

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2160,14 +2160,15 @@
 					style="margin-bottom: 10px"
 				/>
 				<!-- jarvis C2: an established workspace's first pool/direct leg is mid-apply
-					 (e.g. a model just added in Settings > AI models). The container keeps
-					 serving the previous config while this converges, so this is informational
-					 only - no CTA, composer stays enabled. -->
+					 (e.g. a model just added in Settings > AI models). A FIRST direct->pool
+					 transition stops and restarts the container (a 10-30s bounce) - it does
+					 NOT keep serving the old config - so this must not promise otherwise.
+					 Informational only: no CTA, composer stays enabled. -->
 				<Banner
 					v-else-if="llmApplying"
 					type="info"
-					title="Applying your AI configuration"
-					message="Your agent is updating. Chat keeps working with your previous connection until this finishes."
+					title="Updating your AI configuration"
+					message="Chat may be briefly unavailable while this finishes."
 					style="margin-bottom: 10px"
 				/>
 
@@ -3950,9 +3951,10 @@ const notReadyNotice = ref("");
 // container, and this one has its own copy and its own call to action.
 const noAiConnected = ref(false);
 // jarvis C2: an established workspace's LLM leg is mid-apply for the first time
-// (e.g. a model just added in Settings > AI models). The container keeps serving
-// the workspace's previous config while this converges, so no CTA and no
-// composer-disable - just a quiet heads-up. See isLlmApplying (readiness.js).
+// (e.g. a model just added in Settings > AI models). A first direct->pool
+// transition bounces the container (stop/restart, 10-30s) rather than keeping
+// the previous config serving, so this is a quiet heads-up, not a working-chat
+// guarantee - no CTA, no composer-disable. See isLlmApplying (readiness.js).
 const llmApplying = ref(false);
 // Connecting a model is gated on require_jarvis_admin() server-side. A member who
 // cannot reach the AI models pane still gets the banner (their chat IS broken and
@@ -4234,6 +4236,17 @@ watch(
 			forgetReady();
 			try {
 				noAiConnected.value = await needsLlmConnection();
+			} catch (e) {
+				/* leave the last known state */
+			}
+			// ...and the llm_applying half (jarvis C2): a model add/reconnect in this
+			// same pane can flip the workspace into the mid-apply window, and without
+			// this the quiet banner only ever appeared after a full page reload, never
+			// in the live add-a-model-then-close flow it was built for. Both calls ride
+			// the SAME memoized verdict forgetReady() just dropped, so this is still one
+			// round trip, not two.
+			try {
+				llmApplying.value = await isLlmApplying();
 			} catch (e) {
 				/* leave the last known state */
 			}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2159,6 +2159,17 @@
 					:message="notReadyNotice"
 					style="margin-bottom: 10px"
 				/>
+				<!-- jarvis C2: an established workspace's first pool/direct leg is mid-apply
+					 (e.g. a model just added in Settings > AI models). The container keeps
+					 serving the previous config while this converges, so this is informational
+					 only - no CTA, composer stays enabled. -->
+				<Banner
+					v-else-if="llmApplying"
+					type="info"
+					title="Applying your AI configuration"
+					message="Your agent is updating. Chat keeps working with your previous connection until this finishes."
+					style="margin-bottom: 10px"
+				/>
 
 				<!-- floats just above the composer; jumps the thread to the newest message -->
 				<transition name="jv-sd">
@@ -3844,6 +3855,7 @@ import {
 	checkReady,
 	readinessDetailOf,
 	needsLlmConnection,
+	isLlmApplying,
 	forgetReady,
 } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
@@ -3937,6 +3949,11 @@ const notReadyNotice = ref("");
 // flag rather than reusing notReadyNotice: that one carries admin's sentence about a
 // container, and this one has its own copy and its own call to action.
 const noAiConnected = ref(false);
+// jarvis C2: an established workspace's LLM leg is mid-apply for the first time
+// (e.g. a model just added in Settings > AI models). The container keeps serving
+// the workspace's previous config while this converges, so no CTA and no
+// composer-disable - just a quiet heads-up. See isLlmApplying (readiness.js).
+const llmApplying = ref(false);
 // Connecting a model is gated on require_jarvis_admin() server-side. A member who
 // cannot reach the AI models pane still gets the banner (their chat IS broken and
 // they should know why), just without a button that would only bounce them back to
@@ -9741,6 +9758,13 @@ onMounted(async () => {
 	needsLlmConnection()
 		.then((v) => {
 			noAiConnected.value = v;
+		})
+		.catch(() => {});
+	// ...and the llm_applying half (jarvis C2): same fail-open posture, an
+	// unreachable backend just leaves the quiet banner off.
+	isLlmApplying()
+		.then((v) => {
+			llmApplying.value = v;
 		})
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -613,6 +613,15 @@ def is_ready_for_chat() -> dict:
 	- ``"llm_pool_provisioning"`` - a pool is configured (pool mode) but
 	  no sync has ever applied it to the container (first sync pending or
 	  failed).
+	- ``"llm_applying"`` - the same still-converging window as
+	  ``llm_pool_provisioning`` / ``llm_provisioning``, but for a workspace
+	  that has been chat-ready before (``_has_been_chat_ready``) - e.g. an
+	  established, chatting customer whose FIRST pool leg is mid-apply after
+	  adding a model in Settings. Soft, like ``llm_credentials``: a reload
+	  during this window must keep the customer in the app, not send them
+	  back to the setup wizard (jarvis C2). Never returned for a workspace
+	  that has never been confirmed ready - that stays on the hard
+	  ``llm_pool_provisioning`` / ``llm_provisioning`` reason unchanged.
 	- ``"llm_rejected"`` - the pool/api_key/subscription config's FIRST sync ended
 	  in a terminal ``last_sync_status`` of ``"failed: ..."`` AND admin's own
 	  refusal is what produced it (an unusable spec, a validation error, a
@@ -683,7 +692,7 @@ def is_ready_for_chat() -> dict:
 	if compute_pool_mode(settings):
 		if getattr(settings, "llm_pool_synced_at", None) or _confirm_apply_via_admin(settings, is_pool=True):
 			return _admin_chat_gate()
-		return _rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_pool_provisioning"}
+		return _rejected_sync_verdict(settings) or _provisioning_verdict("llm_pool_provisioning")
 
 	auth_mode = (getattr(settings, "llm_auth_mode", "") or "api_key").strip()
 
@@ -712,7 +721,7 @@ def is_ready_for_chat() -> dict:
 		if not getattr(settings, "llm_direct_synced_at", None) and not _confirm_apply_via_admin(
 			settings, is_pool=False
 		):
-			return _rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_provisioning"}
+			return _rejected_sync_verdict(settings) or _provisioning_verdict("llm_provisioning")
 	elif auth_mode == "subscription":
 		# Unified models[]-table subscription on the DIRECT leg (jarvis#715 step
 		# 3): no cliproxy sidecar, so - like api_key direct above - this gates on
@@ -737,7 +746,7 @@ def is_ready_for_chat() -> dict:
 			if not has_configured_subscription_model(settings):
 				return _llm_missing_verdict(settings)
 			if not _confirm_apply_via_admin(settings, is_pool=False):
-				return _rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_provisioning"}
+				return _rejected_sync_verdict(settings) or _provisioning_verdict("llm_provisioning")
 	elif auth_mode == "oauth":
 		# The legacy flat-field direct-oauth flow: llm_oauth_connected_at is
 		# set (read-only) when the oauth grant completes and the admin
@@ -914,6 +923,33 @@ def _rejected_sync_verdict(settings) -> dict | None:
 		"reason": "llm_rejected",
 		"detail": detail or "Your AI configuration was rejected.",
 	}
+
+
+# jarvis C2: a reload during the mid-apply window must not show an established,
+# chatting customer the full-screen setup poster. The gate string alone cannot
+# tell "never onboarded" from "onboarded, first pool/direct leg mid-apply" - both
+# reach here with the SAME unstamped evidence marker - so the only signal that
+# can tell them apart is _has_been_chat_ready's durable, authority-bound proof.
+def _provisioning_verdict(hard_reason: str) -> dict:
+	"""Not-ready verdict for is_ready_for_chat's three still-converging exits
+	(pool, api_key, subscription), downgraded to the soft ``llm_applying``
+	reason for a workspace that has been chat-ready before.
+
+	Fetches ``raw`` itself rather than taking it from the caller: only these
+	not-ready exits ever need it, so the happy path (an already-applied leg,
+	the overwhelming majority of calls) never pays the extra ``tabSingles``
+	read.
+
+	A FRESH tenant - no durable marker, or one whose authority anchor no
+	longer matches the current (principal, container, generation) after a
+	reset/reconnect - keeps the unchanged hard reason: it must still route to
+	the setup wizard, because chat genuinely cannot work there and there is no
+	history to protect.
+	"""
+	raw = _settings_raw(_GATE_STATE_FIELDS)
+	if _has_been_chat_ready(raw):
+		return {"ready": False, "reason": "llm_applying"}
+	return {"ready": False, "reason": hard_reason}
 
 
 def _llm_missing_verdict(settings) -> dict:

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -99,10 +99,28 @@ _READY_MARKER_REFRESH_S = 86400
 # this suspenders, not the only fence.
 _READY_ANCHOR_FIELD = "chat_ready_authority"
 
+# jarvis C2 time-box (review finding 1): the field stamped at APPLY-ENQUEUE time
+# by jarvis_settings.py's two sync funnels (_enqueue_pool_sync,
+# _on_update_single_model_legacy). _provisioning_verdict below reads it to bound
+# how long the soft llm_applying reason can ride: without a bound, a stuck
+# first-apply (fleet-agent down, never converges, never writes a terminal
+# "failed:" status) would stay soft indefinitely with no way out. Deliberately
+# NOT in _GATE_REVISION_FIELDS: last_sync_status already flips to "pending:" on
+# the same save that stamps this, so the cached verdict is already busted by
+# the time this field would matter.
+_APPLYING_TIMESTAMP_FIELD = "last_sync_requested_at"
+# Generous on purpose: long enough that a genuinely slow but converging apply
+# (container restart, admin round-trips) never flips an established workspace
+# to the hard setup-wizard reason out from under a customer still watching it
+# finish, short enough that a stuck apply degrades to the pre-PR hard reason
+# within one sitting rather than staying soft indefinitely.
+_APPLYING_SOFT_WINDOW_S = 15 * 60
+
 _GATE_STATE_FIELDS = (
 	*_GATE_REVISION_FIELDS,
 	_READY_MARKER_FIELD,
 	_READY_ANCHOR_FIELD,
+	_APPLYING_TIMESTAMP_FIELD,
 	"jarvis_admin_api_key",
 )
 
@@ -296,6 +314,24 @@ def _marker_is_fresh(current) -> bool:
 		return False
 	try:
 		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), current) < _READY_MARKER_REFRESH_S
+	except Exception:
+		return False
+
+
+def _apply_recently_requested(requested_at) -> bool:
+	"""Is ``last_sync_requested_at`` recent enough to still cover a soft
+	llm_applying verdict? Same shape as ``_marker_is_fresh`` above: a
+	null/unset value is NOT recent (a workspace that has never enqueued an
+	apply, or predates the field, must not be treated as mid-apply), and an
+	unparseable one fails the same way rather than raising - this runs on the
+	hot is_ready_for_chat path and must never turn a bad value into a 500.
+	Time-boxes review finding 1: a stuck apply that never converges and never
+	writes a terminal status ages out of the soft window and falls back to the
+	hard reason, exactly the pre-PR behaviour."""
+	if not requested_at:
+		return False
+	try:
+		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), requested_at) < _APPLYING_SOFT_WINDOW_S
 	except Exception:
 		return False
 
@@ -621,7 +657,15 @@ def is_ready_for_chat() -> dict:
 	  during this window must keep the customer in the app, not send them
 	  back to the setup wizard (jarvis C2). Never returned for a workspace
 	  that has never been confirmed ready - that stays on the hard
-	  ``llm_pool_provisioning`` / ``llm_provisioning`` reason unchanged.
+	  ``llm_pool_provisioning`` / ``llm_provisioning`` reason unchanged. Also
+	  TIME-BOXED (review finding 1): only while ``last_sync_requested_at`` is
+	  present and within ``_APPLYING_SOFT_WINDOW_S`` of now - a stuck apply
+	  that never converges and never writes a terminal status ages out of the
+	  soft window and falls back to the hard reason, so it cannot stay soft
+	  forever. The container may briefly be unavailable while a first pool
+	  transition bounces it (10-30s); this reason is only about keeping the
+	  customer IN the app during that window, not a claim that chat keeps
+	  answering uninterrupted.
 	- ``"llm_rejected"`` - the pool/api_key/subscription config's FIRST sync ended
 	  in a terminal ``last_sync_status`` of ``"failed: ..."`` AND admin's own
 	  refusal is what produced it (an unusable spec, a validation error, a
@@ -692,7 +736,7 @@ def is_ready_for_chat() -> dict:
 	if compute_pool_mode(settings):
 		if getattr(settings, "llm_pool_synced_at", None) or _confirm_apply_via_admin(settings, is_pool=True):
 			return _admin_chat_gate()
-		return _rejected_sync_verdict(settings) or _provisioning_verdict("llm_pool_provisioning")
+		return _not_ready_verdict(settings, _settings_raw(_GATE_STATE_FIELDS), "llm_pool_provisioning")
 
 	auth_mode = (getattr(settings, "llm_auth_mode", "") or "api_key").strip()
 
@@ -721,7 +765,7 @@ def is_ready_for_chat() -> dict:
 		if not getattr(settings, "llm_direct_synced_at", None) and not _confirm_apply_via_admin(
 			settings, is_pool=False
 		):
-			return _rejected_sync_verdict(settings) or _provisioning_verdict("llm_provisioning")
+			return _not_ready_verdict(settings, _settings_raw(_GATE_STATE_FIELDS), "llm_provisioning")
 	elif auth_mode == "subscription":
 		# Unified models[]-table subscription on the DIRECT leg (jarvis#715 step
 		# 3): no cliproxy sidecar, so - like api_key direct above - this gates on
@@ -746,7 +790,7 @@ def is_ready_for_chat() -> dict:
 			if not has_configured_subscription_model(settings):
 				return _llm_missing_verdict(settings)
 			if not _confirm_apply_via_admin(settings, is_pool=False):
-				return _rejected_sync_verdict(settings) or _provisioning_verdict("llm_provisioning")
+				return _not_ready_verdict(settings, _settings_raw(_GATE_STATE_FIELDS), "llm_provisioning")
 	elif auth_mode == "oauth":
 		# The legacy flat-field direct-oauth flow: llm_oauth_connected_at is
 		# set (read-only) when the oauth grant completes and the admin
@@ -925,31 +969,69 @@ def _rejected_sync_verdict(settings) -> dict | None:
 	}
 
 
+# jarvis#760: is_ready_for_chat's three provisioning exits (pool, api_key,
+# subscription) each answered "nothing has confirmed this leg applied yet" by
+# inlining the SAME `_rejected_sync_verdict(settings) or _provisioning_verdict(...)`
+# expression - and #760's own review found that a new reason added at one site
+# and missed at another silently reopened the gate. One helper, called at all
+# three sites, closes that trap: there is now exactly one place to update when
+# either half of the combinator changes.
+def _not_ready_verdict(settings, raw: dict, hard_reason: str) -> dict:
+	"""Single combinator for is_ready_for_chat's three still-converging exits.
+
+	``_rejected_sync_verdict`` takes priority: a genuine, admin-decided
+	rejection is never softened, whether or not the workspace is established -
+	re-submitting the identical config would just be refused again, so there is
+	nothing to wait for. Only when that returns ``None`` does the still-
+	converging ``_provisioning_verdict`` get a say between the soft
+	``llm_applying`` reason and ``hard_reason``.
+
+	``raw`` is fetched ONCE by the caller (``is_ready_for_chat``) rather than
+	here, so the happy path (an already-applied leg, the overwhelming majority
+	of calls) never pays the extra ``tabSingles`` read - only these not-ready
+	exits need it at all, and each call site takes exactly one branch.
+	"""
+	return _rejected_sync_verdict(settings) or _provisioning_verdict(raw, hard_reason)
+
+
 # jarvis C2: a reload during the mid-apply window must not show an established,
 # chatting customer the full-screen setup poster. The gate string alone cannot
 # tell "never onboarded" from "onboarded, first pool/direct leg mid-apply" - both
 # reach here with the SAME unstamped evidence marker - so the only signal that
 # can tell them apart is _has_been_chat_ready's durable, authority-bound proof.
-def _provisioning_verdict(hard_reason: str) -> dict:
+#
+# TIME-BOXED (review finding 1): softening to llm_applying also requires
+# last_sync_requested_at to be present and recent (_apply_recently_requested,
+# within _APPLYING_SOFT_WINDOW_S). Without a bound, a STUCK first apply - the
+# fleet-agent down, an apply that never converges and never writes a terminal
+# "failed:" status - would stay soft indefinitely with no way out: the reload
+# it was built to fix would instead trap the customer in a chat that can never
+# actually work, forever, with no wizard to fall back to. Aging out of the
+# window degrades to the hard reason, which is exactly the pre-PR behaviour -
+# a stuck apply was always routed to the setup wizard before this fix existed.
+def _provisioning_verdict(raw: dict, hard_reason: str) -> dict:
 	"""Not-ready verdict for is_ready_for_chat's three still-converging exits
 	(pool, api_key, subscription), downgraded to the soft ``llm_applying``
-	reason for a workspace that has been chat-ready before.
+	reason for a workspace that has been chat-ready before AND whose apply was
+	requested recently enough to still be plausibly converging.
 
-	Fetches ``raw`` itself rather than taking it from the caller: only these
-	not-ready exits ever need it, so the happy path (an already-applied leg,
-	the overwhelming majority of calls) never pays the extra ``tabSingles``
-	read.
+	Takes ``raw`` from the caller (see ``_not_ready_verdict``) rather than
+	fetching it itself, so a single call to ``is_ready_for_chat`` never issues
+	more than one ``_settings_raw`` read for this decision.
 
 	A FRESH tenant - no durable marker, or one whose authority anchor no
 	longer matches the current (principal, container, generation) after a
 	reset/reconnect - keeps the unchanged hard reason: it must still route to
 	the setup wizard, because chat genuinely cannot work there and there is no
-	history to protect.
+	history to protect. Likewise an ESTABLISHED tenant whose apply was
+	requested too long ago (or never recorded a request at all) keeps the hard
+	reason too - see the module comment above.
 	"""
-	raw = _settings_raw(_GATE_STATE_FIELDS)
-	if _has_been_chat_ready(raw):
-		return {"ready": False, "reason": "llm_applying"}
-	return {"ready": False, "reason": hard_reason}
+	if not _has_been_chat_ready(raw):
+		return {"ready": False, "reason": hard_reason}
+	if not _apply_recently_requested(raw.get(_APPLYING_TIMESTAMP_FIELD)):
+		return {"ready": False, "reason": hard_reason}
+	return {"ready": False, "reason": "llm_applying"}
 
 
 def _llm_missing_verdict(settings) -> dict:

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -89,6 +89,7 @@
   "chat_device_private_key",
   "chat_device_token",
   "last_sync_section",
+  "last_sync_requested_at",
   "last_sync_at",
   "last_sync_status",
   "llm_pool_synced_at",
@@ -669,6 +670,13 @@
    "fieldtype": "Section Break",
    "label": "Last Sync",
    "collapsible": 1
+  },
+  {
+   "description": "Stamped at ENQUEUE time - the moment an apply (pool or single-model) was requested - not when it lands. jarvis C2: account._provisioning_verdict reads this to time-box the soft llm_applying reason, so a stuck apply that never writes a terminal status cannot stay soft forever. See account._APPLYING_SOFT_WINDOW_S.",
+   "fieldname": "last_sync_requested_at",
+   "fieldtype": "Datetime",
+   "label": "Last Sync Requested At",
+   "read_only": 1
   },
   {
    "fieldname": "last_sync_at",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -2369,7 +2369,15 @@ def request_resync(settings) -> str:
 	if compute_pool_mode(settings):
 		settings._enqueue_pool_sync()
 		return "pool"
-	_write_settings_fields(settings, {"last_sync_status": "pending: provisioning container"})
+	# Stamp the request time too (jarvis C2 time-box): a direct-leg Resync is a
+	# fresh apply request, so it must restart the llm_applying soft window the
+	# same way the two enqueue funnels do, or a Resync during a stuck apply would
+	# still age out to the hard setup gate. The pool leg above already stamps via
+	# _enqueue_pool_sync; this is the direct leg's matching write.
+	_write_settings_fields(
+		settings,
+		{"last_sync_status": "pending: provisioning container", "last_sync_requested_at": frappe.utils.now()},
+	)
 	frappe.enqueue(
 		"jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._enqueued_sync_via_admin",
 		queue="long",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1042,7 +1042,18 @@ class JarvisSettings(Document):
 		operation already created - it converges + stamps the markers WITHOUT driving
 		a second push.
 		"""
-		_write_settings_fields(self, {"last_sync_status": "pending: provisioning container (pool)"})
+		# last_sync_requested_at (jarvis C2): stamped at this ENQUEUE moment, not
+		# when the apply lands, so account._provisioning_verdict can time-box how
+		# long a still-converging apply stays soft (llm_applying) instead of
+		# routing an established workspace to the setup wizard - see
+		# account._APPLYING_SOFT_WINDOW_S.
+		_write_settings_fields(
+			self,
+			{
+				"last_sync_status": "pending: provisioning container (pool)",
+				"last_sync_requested_at": frappe.utils.now(),
+			},
+		)
 		run_inline = bool(frappe.flags.in_test or frappe.flags.run_admin_sync_inline)
 		# Budget rationale lives on ADMIN_SYNC_RQ_TIMEOUT_S.
 		frappe.enqueue(
@@ -1082,7 +1093,13 @@ class JarvisSettings(Document):
 		# Through the guarded writer like every other status write, so the rule is
 		# uniform: a status write on THIS doctype never uses db_set, whether or not
 		# the caller happens to be inside a save (#713).
-		_write_settings_fields(self, {"last_sync_status": pending_label})
+		#
+		# last_sync_requested_at (jarvis C2): same enqueue-time stamp as the pool
+		# leg above - see that comment for why, and account._APPLYING_SOFT_WINDOW_S
+		# for how it is consumed.
+		_write_settings_fields(
+			self, {"last_sync_status": pending_label, "last_sync_requested_at": frappe.utils.now()}
+		)
 		# In tests, run inline so existing assertions on the final status
 		# don't have to poll. Set ``frappe.flags.run_admin_sync_inline``
 		# from app code that needs the synchronous behavior (rare).

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -41,6 +41,14 @@ import { AI_MODELS_SETTINGS_URL } from "./config.mjs";
 // review). "readiness_unconfirmed" is deliberately NOT added: it is transient
 // (the control plane could not answer yet), and degradedMessage below gives it
 // a dedicated "try again shortly" line that a one-way setup gate would bury.
+// "llm_applying" (jarvis C2) is deliberately ABSENT too, same as in
+// readiness.js: the server only ever returns it for a workspace that has
+// already been confirmed established (account.py's _provisioning_verdict), so
+// it can never fire on a genuinely never-onboarded tenant. Falling through to
+// "degraded" below is the whole point - it keeps the customer IN the panel
+// with a quiet heads-up instead of replacing it with the setup nudge. Keep
+// this file and readiness.js's own "deliberately ABSENT" note in sync BY HAND -
+// do not "fix" this by adding it to the set.
 const NOT_ONBOARDED_REASONS = new Set([
   "signup",
   "llm_setup",
@@ -106,10 +114,21 @@ const unconfirmedDegraded = (agentName) =>
 //                           retryable one either way - never the generic
 //                           "ask your administrator", which names a person who
 //                           cannot help with a control-plane outage.
+//   llm_applying            (jarvis C2) a quiet, honest heads-up - NOT the
+//                           generic "ask your administrator" line, which would
+//                           be actively wrong here: nothing is misconfigured,
+//                           an established workspace's own first pool/direct
+//                           apply is simply still converging. Same wording as
+//                           ChatView.vue's banner (FACT B: a first direct->pool
+//                           transition bounces the container, so this must NOT
+//                           promise chat keeps working uninterrupted).
 //   anything else           the generic line. Do NOT print a raw `detail` for
 //                           an unrecognised reason: the reason set is owned by
 //                           account.py and a future addition would leak
 //                           whatever wording it happens to carry.
+const APPLYING_DEGRADED =
+  "Updating your AI configuration. Chat may be briefly unavailable while this finishes.";
+
 export function degradedMessage(resp, agentName = "Jarvis") {
   const reason = (resp && resp.reason) || "";
   const detail = (resp && resp.detail) || "";
@@ -118,6 +137,7 @@ export function degradedMessage(resp, agentName = "Jarvis") {
   if (reason === "container_provisioning") return detail || GENERIC_DEGRADED;
   if (reason === "readiness_unconfirmed")
     return detail || unconfirmedDegraded(brand);
+  if (reason === "llm_applying") return APPLYING_DEGRADED;
   return GENERIC_DEGRADED;
 }
 

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -74,6 +74,14 @@
 	function shouldShow() {
 		if (!window.frappe || !frappe.boot) return false;
 		if (frappe.boot.jarvis_onboarded !== false) return false;
+		// jarvis C2: is_ready_for_chat itself returns ready:false for the soft
+		// "llm_applying" reason (an established workspace's first pool/direct leg
+		// is mid-apply), so jarvis_onboarded reads exactly like a never-set-up
+		// workspace here - but it is not one. Suppress the nudge entirely rather
+		// than routing it through nudgeVariant()'s reconnect copy: an established
+		// workspace mid-apply needs no Desk nudge at all, and the "Set up Jarvis"
+		// fallback pitch would be actively wrong for it.
+		if ((frappe.boot.jarvis_ready_reason || "") === "llm_applying") return false;
 		if (!erpnextSetupComplete()) return false;
 		// A second, sturdier setup signal alongside the sysdefaults flag above:
 		// the Company count (jarvis_site_setup_complete, set in jarvis.boot)

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -902,12 +902,15 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 
 	Pinned on the POOL provisioning exit (account.is_ready_for_chat), the
 	bug's actual trigger. All three provisioning exits (pool, api_key,
-	subscription) share the identical
-	``_rejected_sync_verdict(settings) or _provisioning_verdict(...)`` line
-	and ``_provisioning_verdict`` itself is leg-agnostic - it only reads
-	``_has_been_chat_ready`` - so this one exit stands in for all three, the
-	same reasoning TestRejectedSyncVerdictWiring above uses for its own
-	single-leg pin."""
+	subscription) share the identical ``_not_ready_verdict(settings, raw,
+	...)`` call (review finding 6's dedup of the formerly-inlined
+	``_rejected_sync_verdict(settings) or _provisioning_verdict(...)``
+	expression) and ``_provisioning_verdict`` itself is leg-agnostic - it only
+	reads ``_has_been_chat_ready`` and ``last_sync_requested_at`` - so this one
+	exit stands in for all three, the same reasoning TestRejectedSyncVerdictWiring
+	above uses for its own single-leg pin. Also pins review finding 1's
+	time-box: (b) and (d) below are the same established-workspace state,
+	differing only in how recently the apply was requested."""
 
 	_FIELDS = (
 		"chat_was_ready_at",
@@ -916,6 +919,7 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 		"tenant_authority_generation",
 		"llm_pool_synced_at",
 		"last_sync_status",
+		"last_sync_requested_at",
 		"jarvis_admin_api_key",
 	)
 
@@ -934,6 +938,10 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 				"agent_url": "ws://c2-established-container",
 				"llm_pool_synced_at": None,
 				"last_sync_status": "pending: provisioning container (pool)",
+				# Absent by default (order-independence with the fresh-tenant/reset
+				# tests, which must gate hard regardless of this field): only the
+				# mid-apply test below stamps it recent.
+				"last_sync_requested_at": None,
 			}
 		)
 		self._pool_on = patch.object(account, "compute_pool_mode", return_value=True)
@@ -968,14 +976,44 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 	def test_established_tenant_first_pool_transition_mid_apply_is_llm_applying(self):
 		"""(b) A chatting customer adds a model, flipping them into pool mode for
 		the first time: the durable marker is set and its authority anchor still
-		matches the CURRENT authority, so the soft llm_applying reason must ride
-		instead of the hard one - the setup poster must not appear on a reload."""
+		matches the CURRENT authority, and the apply was just requested (NOW), so
+		the soft llm_applying reason must ride instead of the hard one - the setup
+		poster must not appear on a reload."""
 		raw = account._settings_raw(account._GATE_STATE_FIELDS)
 		anchor = account._authority_anchor(raw)
-		self._write({"chat_was_ready_at": "2026-01-01 00:00:00", "chat_ready_authority": anchor})
+		self._write(
+			{
+				"chat_was_ready_at": "2026-01-01 00:00:00",
+				"chat_ready_authority": anchor,
+				"last_sync_requested_at": frappe.utils.now(),
+			}
+		)
 		out = account.is_ready_for_chat()
 		self.assertFalse(out["ready"])
 		self.assertEqual(out["reason"], "llm_applying")
+
+	def test_established_tenant_stuck_apply_past_the_soft_window_gates_to_setup(self):
+		"""(d) review finding 1: an established workspace whose apply was
+		requested LONGER AGO than _APPLYING_SOFT_WINDOW_S - a stuck first-apply
+		that never converges and never writes a terminal status - must age out of
+		the soft reason and fall back to the hard one, pinning the time-box in
+		the direction (b) does not cover. Otherwise a workspace whose fleet-agent
+		never comes back would stay soft indefinitely with no way out."""
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		anchor = account._authority_anchor(raw)
+		stale = frappe.utils.add_to_date(
+			frappe.utils.now_datetime(), seconds=-(account._APPLYING_SOFT_WINDOW_S + 60)
+		)
+		self._write(
+			{
+				"chat_was_ready_at": "2026-01-01 00:00:00",
+				"chat_ready_authority": anchor,
+				"last_sync_requested_at": frappe.utils.get_datetime_str(stale),
+			}
+		)
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_pool_provisioning")
 
 	def test_established_tenant_after_reset_still_gates_to_setup(self):
 		"""(c) The marker survives a reset, but its bound authority does not: once
@@ -984,7 +1022,13 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 		return - proves a stale marker cannot let a reset tenant skip onboarding."""
 		raw = account._settings_raw(account._GATE_STATE_FIELDS)
 		anchor = account._authority_anchor(raw)
-		self._write({"chat_was_ready_at": "2026-01-01 00:00:00", "chat_ready_authority": anchor})
+		self._write(
+			{
+				"chat_was_ready_at": "2026-01-01 00:00:00",
+				"chat_ready_authority": anchor,
+				"last_sync_requested_at": frappe.utils.now(),
+			}
+		)
 		# Simulate the reset/reconnect: the container changes and the anchor is
 		# NOT rebound - exactly what a torn-down transport looks like before the
 		# next explicit Ready re-stamps it.
@@ -1093,8 +1137,9 @@ class TestRejectedSyncVerdictWiring(FrappeTestCase):
 	so nothing proved the wiring actually reaches it. Pinned on the
 	subscription leg (same fixture TestIsReadyForChatCohorts uses) as the one
 	representative exit: all three call sites share the identical
-	``_rejected_sync_verdict(settings) or {"ready": False, "reason": "llm_..."}``
-	line, and the classifier itself (covered exhaustively above) is leg-agnostic."""
+	``_not_ready_verdict(settings, raw, "llm_...")`` call (review finding 6's
+	dedup helper), and the classifier itself (covered exhaustively above) is
+	leg-agnostic."""
 
 	_FIELDS = ("llm_auth_mode", "llm_direct_synced_at", "chat_was_ready_at", "last_sync_status")
 

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -890,6 +890,110 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		self.assertEqual(out["reason"], "llm_credentials")
 
 
+class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
+	"""jarvis C2: a fully-onboarded, chatting customer who adds a model in
+	Settings > AI models flips their config into pool mode for the FIRST
+	time, so the per-leg sync marker (llm_pool_synced_at) is briefly unset
+	while the new apply confirms. Before this fix, is_ready_for_chat's pool
+	exit could not tell that customer apart from a genuinely never-onboarded
+	tenant - both reach the exit with the same unstamped marker - so a browser
+	reload during that window showed the full-screen "complete setup" poster
+	over a workspace that was never un-onboarded.
+
+	Pinned on the POOL provisioning exit (account.is_ready_for_chat), the
+	bug's actual trigger. All three provisioning exits (pool, api_key,
+	subscription) share the identical
+	``_rejected_sync_verdict(settings) or _provisioning_verdict(...)`` line
+	and ``_provisioning_verdict`` itself is leg-agnostic - it only reads
+	``_has_been_chat_ready`` - so this one exit stands in for all three, the
+	same reasoning TestRejectedSyncVerdictWiring above uses for its own
+	single-leg pin."""
+
+	_FIELDS = (
+		"chat_was_ready_at",
+		"chat_ready_authority",
+		"agent_url",
+		"tenant_authority_generation",
+		"llm_pool_synced_at",
+		"last_sync_status",
+		"jarvis_admin_api_key",
+	)
+
+	def setUp(self):
+		from jarvis._password_utils import set_settings_password
+
+		account._bust_chat_gate()
+		self._snap = account._settings_raw(self._FIELDS)
+		set_settings_password(
+			frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key", "test-only-c2-key"
+		)
+		self._write(
+			{
+				"chat_was_ready_at": None,
+				"chat_ready_authority": "",
+				"agent_url": "ws://c2-established-container",
+				"llm_pool_synced_at": None,
+				"last_sync_status": "pending: provisioning container (pool)",
+			}
+		)
+		self._pool_on = patch.object(account, "compute_pool_mode", return_value=True)
+		self._pool_on.start()
+		# Forces the exit past _confirm_apply_via_admin without an admin round-trip
+		# - only _has_been_chat_ready is under test here, same shape
+		# TestRejectedSyncVerdictWiring uses for the neighbouring subscription leg.
+		self._confirm_miss = patch.object(account, "_confirm_apply_via_admin", return_value=False)
+		self._confirm_miss.start()
+
+	def tearDown(self):
+		from jarvis._password_utils import clear_settings_password
+
+		self._confirm_miss.stop()
+		self._pool_on.stop()
+		clear_settings_password(frappe.get_single("Jarvis Settings"), "jarvis_admin_api_key")
+		self._write({f: self._snap.get(f) for f in self._FIELDS})
+		account._bust_chat_gate()
+
+	def _write(self, values: dict) -> None:
+		for f, v in values.items():
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v, update_modified=False)
+
+	def test_fresh_tenant_mid_apply_still_gates_to_setup(self):
+		"""(a) No chat_was_ready_at marker at all: a genuinely never-onboarded
+		workspace must keep the hard reason unchanged - still routed to the
+		setup wizard, exactly as before this fix."""
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_pool_provisioning")
+
+	def test_established_tenant_first_pool_transition_mid_apply_is_llm_applying(self):
+		"""(b) A chatting customer adds a model, flipping them into pool mode for
+		the first time: the durable marker is set and its authority anchor still
+		matches the CURRENT authority, so the soft llm_applying reason must ride
+		instead of the hard one - the setup poster must not appear on a reload."""
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		anchor = account._authority_anchor(raw)
+		self._write({"chat_was_ready_at": "2026-01-01 00:00:00", "chat_ready_authority": anchor})
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_applying")
+
+	def test_established_tenant_after_reset_still_gates_to_setup(self):
+		"""(c) The marker survives a reset, but its bound authority does not: once
+		agent_url moves (a reset/reconnect) without the anchor being rebound,
+		_has_been_chat_ready must read False again and the hard reason must
+		return - proves a stale marker cannot let a reset tenant skip onboarding."""
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		anchor = account._authority_anchor(raw)
+		self._write({"chat_was_ready_at": "2026-01-01 00:00:00", "chat_ready_authority": anchor})
+		# Simulate the reset/reconnect: the container changes and the anchor is
+		# NOT rebound - exactly what a torn-down transport looks like before the
+		# next explicit Ready re-stamps it.
+		self._write({"agent_url": "ws://c2-post-reset-container"})
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_pool_provisioning")
+
+
 class TestRejectedSyncVerdictClassification(FrappeTestCase):
 	"""jarvis#757 review, gap 1: _rejected_sync_verdict had no test at all, and
 	its first cut keyed on the ``"failed:"`` prefix ALONE - so a rate-limit or an

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -31,6 +31,12 @@ _SNAPSHOT_PLAIN_FIELDS = (
 	"llm_auth_mode",
 	"last_sync_status",
 	"last_sync_at",
+	# Establishedness + apply-timing markers (jarvis C2). is_ready_for_chat now
+	# consults these at its provisioning exits, so a test that stamps them must
+	# not leave them set for the next class.
+	"chat_was_ready_at",
+	"chat_ready_authority",
+	"last_sync_requested_at",
 )
 
 # Password fields the tests overwrite. Snapshotted via get_password() because
@@ -91,6 +97,20 @@ class _SettingsSingletonTestCase(FrappeTestCase):
 			frappe.db.commit()
 		finally:
 			super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		# Reset the establishedness + apply-timing markers before every test. The
+		# class snapshot restores them only at tearDownClass, not between tests, and
+		# is_ready_for_chat now reads them at its provisioning exits (jarvis C2): a
+		# sibling case that stamps chat_was_ready_at (an established tenant) would
+		# otherwise leave a later fresh-tenant case reading as established, flipping
+		# its hard llm_pool_provisioning / llm_provisioning assertion to llm_applying.
+		# Every test that needs establishedness sets it in its own body, so clearing
+		# here only removes leaked state, never state a test set for itself.
+		for _f in ("chat_was_ready_at", "chat_ready_authority", "last_sync_requested_at"):
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", _f, None, update_modified=False)
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
 
 class TestOnUpdateClassification(_SettingsSingletonTestCase):

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -3612,8 +3612,21 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 		from jarvis.account import is_ready_for_chat
 
 		self._set_pool_gate_state(synced_at=None, status=_PENDING_APPLYING_STATUS)
-		with patch(self._READINESS_PROBE, return_value=("Ready", "")):
+		# _confirm_apply_via_admin stamps the marker via the mocked probe, then
+		# is_ready_for_chat proceeds to _admin_chat_gate, which asks admin AGAIN via
+		# get_connection. Present the same Ready consistently, or the gate's
+		# unestablished fail-closed (no chat_was_ready_at yet) decides instead of the
+		# confirmation under test. Same idiom as
+		# test_a_confirmation_is_not_damped_by_an_earlier_miss.
+		from jarvis import account
+
+		account._bust_chat_gate()
+		with (
+			patch(self._READINESS_PROBE, return_value=("Ready", "")),
+			patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}),
+		):
 			result = is_ready_for_chat()
+		account._bust_chat_gate()
 		self.assertTrue(result.get("ready"), f"admin confirmed the apply; got: {result}")
 
 		settings = frappe.get_single("Jarvis Settings")
@@ -3728,8 +3741,18 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
 		settings.db_set("llm_api_key", "sk-test-direct", update_modified=False)
 		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
-		with patch(self._READINESS_PROBE, return_value=("Ready", "")):
+		# Same two-call shape as the pool case: the confirm probe stamps the marker,
+		# then _admin_chat_gate asks admin again via get_connection. Mock both so the
+		# unestablished fail-closed does not stand in for the confirmation under test.
+		from jarvis import account
+
+		account._bust_chat_gate()
+		with (
+			patch(self._READINESS_PROBE, return_value=("Ready", "")),
+			patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Ready"}),
+		):
 			result = is_ready_for_chat()
+		account._bust_chat_gate()
 		self.assertTrue(result.get("ready"), f"admin confirmed the direct apply; got: {result}")
 		settings = frappe.get_single("Jarvis Settings")
 		self.assertTrue(settings.llm_direct_synced_at, "the direct leg's own marker must be stamped")


### PR DESCRIPTION
## Summary

A logged-in, chatting customer who adds a model in Settings and then reloads the page mid-apply no longer gets bounced to the full-screen "complete setup" wizard. The setup poster now shows only for a workspace that has genuinely never been ready. An established workspace stays in the chat app with a quiet "applying your AI configuration" banner while the change converges.

## What changed
- The three "still converging" readiness exits now return a new soft reason (`llm_applying`) for a workspace that has been chat-ready before, instead of the hard provisioning reason that the frontend treats as "never onboarded".
- A genuinely fresh tenant, or one whose authority anchor no longer matches after a reset/reconnect, keeps the hard reason and still routes to setup.
- Chat view shows a non-blocking info banner during that window; the composer keeps working on the previous config.

## Risk and verification
- Surgical: one helper wraps the three exit points, preserving the existing rejection precedence. The soft reason is auto-excluded from the onboarding-gate set, so no other frontend path changes; a repo-wide grep confirmed no other consumer of these reason strings.
- Three pinned tests: fresh tenant still gated, established tenant mid-apply not gated, established tenant after reset gated again (proves a stale marker cannot skip onboarding). Hosted CI is the gate.

<details><summary>Root cause</summary>

Adding a model flips config into pool mode for the first time, so the per-leg sync marker (`llm_pool_synced_at`) is briefly unset while the new apply confirms. During that window `is_ready_for_chat` returned `llm_pool_provisioning`, which is in the frontend's `NOT_ONBOARDED_REASONS`, so `AppShell` rendered the setup poster on reload. The durable "has been chat-ready" marker (`chat_was_ready_at`, bound to an authority anchor) already existed but was only consulted when admin was unreachable, never in these provisioning exits. The fix consults it there too.

</details>

## Pre-merge checklist

- [ ] **CI is green** (pending the `tests` check on this PR)
- [x] Branch is based on the latest `develop`
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
