### PR TITLE
fix(onboarding): widen readiness poll for the dual-restart subscription leg

### DIFF
--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -486,6 +486,69 @@ describe("§10.4 mode:legacy fallback (no durable operation)", () => {
 		expect(routerReplace).not.toHaveBeenCalled();
 	});
 
+	it("the subscription leg honors readiness_budget_s: the poll bound widens to 300s, not 75s", async () => {
+		// jarvis#715 step 3 leg does TWO container restarts, so its confirmed apply
+		// routinely lands after the 75s default. save_llm_pool returns
+		// readiness_budget_s:300 for it; the poll must run to ~120 attempts (300s /
+		// 2.5s), NOT stop at 30 and show a false "not connected, retry".
+		saveMock.mockResolvedValue({
+			ok: true,
+			result: opResult({
+				apply_operation: null,
+				resumable: false,
+				mode: "legacy",
+				readiness_budget_s: 300,
+			}),
+		});
+		api.isReadyForChat.mockResolvedValue({ ready: false, reason: "llm_provisioning" });
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear(); // ignore the one mount-time readiness probe
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(120 * 2500); // widened 300s budget
+		await p;
+
+		expect(api.isReadyForChat).toHaveBeenCalledTimes(120); // 300s / 2.5s, not 30
+		expect(w.vm.state.connectPhase).toBe("retry");
+		expect(routerReplace).not.toHaveBeenCalled();
+	});
+
+	it("a subscription apply that confirms AFTER the old 75s ceiling still navigates (the fix)", async () => {
+		// The exact bug: the dual-restart apply confirms past 30 probes (75s). With the
+		// widened budget the poll is still running and navigates once, instead of having
+		// already shown Retry at the old ceiling.
+		saveMock.mockResolvedValue({
+			ok: true,
+			result: opResult({
+				apply_operation: null,
+				resumable: false,
+				mode: "legacy",
+				readiness_budget_s: 300,
+			}),
+		});
+		let calls = 0;
+		api.isReadyForChat.mockImplementation(async () => {
+			calls += 1;
+			// Not ready through the old 75s (30-probe) ceiling; ready afterwards.
+			return calls >= 45 ? { ready: true } : { ready: false, reason: "llm_provisioning" };
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		api.isReadyForChat.mockClear(); // ignore the one mount-time readiness probe
+		calls = 0;
+
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(120 * 2500);
+		await p;
+
+		expect(routerReplace).toHaveBeenCalledTimes(1); // navigated, no false retry
+		expect(routerReplace).toHaveBeenCalledWith({ name: "Chat" });
+		expect(w.vm.state.connectPhase).not.toBe("retry");
+	});
+
 	it("a THROWING isReadyForChat is not a verdict: the legacy poll stays fail-closed", async () => {
 		saveMock.mockResolvedValue({
 			ok: true,

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3895,7 +3895,7 @@ async function resolveAndFollow(result, idem) {
 			continue;
 		}
 		if (r.mode === "legacy") {
-			await followLegacyReadiness();
+			await followLegacyReadiness(r);
 			return;
 		}
 		// Operation path, no descriptor, not resumable: a refusal (e.g. a rate limit).
@@ -3905,14 +3905,29 @@ async function resolveAndFollow(result, idem) {
 	await followDescriptor(r.apply_operation);
 }
 
-// Legacy fallback (single BYO api-key model, mode:"legacy"): admin's creds endpoint
-// mints no durable operation, so there is nothing to follow - poll readiness instead,
-// bounded and fail-closed. On ready → navigate once; on timeout / persistent not-ready
-// → the SAME support/retry state a non-navigable terminal gets (stay on Connect, offer
-// Retry). Deliberately NO "continue anyway" bypass (review P0-08).
+// Legacy fallback (single-model direct config, mode:"legacy" - a BYO api-key model
+// or a lone chat subscription): admin's creds endpoint mints no durable operation,
+// so there is nothing to follow - poll readiness instead, bounded and fail-closed.
+// The bound is the save result's readiness_budget_s (75s default, 300s for the
+// dual-restart subscription leg) - see legacyReadyAttempts. On ready → navigate
+// once; on timeout / persistent not-ready → the SAME support/retry state a
+// non-navigable terminal gets (stay on Connect, offer Retry). Deliberately NO
+// "continue anyway" bypass (review P0-08).
 const LEGACY_READY_ATTEMPTS = 30;
 const LEGACY_READY_INTERVAL_MS = 2500;
-async function followLegacyReadiness() {
+// The save result may carry readiness_budget_s (seconds) for a leg that takes
+// longer than the 30x2.5s=75s default - today only the subscription direct leg,
+// which does two container restarts back to back (see onboarding.py). Absent /
+// invalid = the historic 75s, so the api_key/oauth legs and any old backend are
+// byte-identical to before. The 2.5s interval is unchanged, so only the attempt
+// count grows: 300s budget -> 120 attempts.
+function legacyReadyAttempts(result) {
+	const budgetS = Number(result && result.readiness_budget_s);
+	if (!Number.isFinite(budgetS) || budgetS <= 0) return LEGACY_READY_ATTEMPTS;
+	return Math.max(LEGACY_READY_ATTEMPTS, Math.ceil((budgetS * 1000) / LEGACY_READY_INTERVAL_MS));
+}
+async function followLegacyReadiness(result) {
+	const attempts = legacyReadyAttempts(result);
 	state.finishing = true;
 	state.connectPhase = "working";
 	state.finishSubtitle = "We'll take you to chat as soon as your setup is done.";
@@ -3924,7 +3939,7 @@ async function followLegacyReadiness() {
 	let sawNamedSubject = false;
 	let lastDetail = "";
 	readinessSeen.value = null;
-	for (let i = 0; i < LEGACY_READY_ATTEMPTS; i++) {
+	for (let i = 0; i < attempts; i++) {
 		if (navigated.value) return;
 		if (state.connectPhase === "blocked") return;
 		// The jarvis#727 escape took the customer back to the editor - see
@@ -3954,7 +3969,7 @@ async function followLegacyReadiness() {
 		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
 		// jarvis#757: see the matching comment in waitForChatReadiness.
 		if (state.connectPhase === "blocked" || stage.editable) return;
-		if (i < LEGACY_READY_ATTEMPTS - 1) await _sleep(LEGACY_READY_INTERVAL_MS);
+		if (i < attempts - 1) await _sleep(LEGACY_READY_INTERVAL_MS);
 	}
 	state.finishing = true;
 	state.connectPhase = "retry";

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -755,11 +755,16 @@ def is_ready_for_chat() -> dict:
 # confirmation stamps the durable marker, which ends the question for good.
 #
 # Needed because the two not-ready exits below are polled hard. OnboardingView's
-# waitUntilReady runs 30 probes at 2.5s (75s) after a Connect, and the desk
-# banner + widget probe on their own schedules — so an unproven tenant would put
-# one admin round-trip on every one of those ticks. 10s costs at most one extra
-# poll before a convergence is noticed against that 75s budget, and cuts the
-# round-trips it can generate by roughly two thirds.
+# legacy readiness wait runs a 2.5s probe loop after a Connect, and the desk
+# banner + widget probe on their own schedules, so an unproven tenant would put
+# one admin round-trip on every one of those ticks. The budget is now
+# leg-dependent (onboarding.save_llm_pool.readiness_budget_s): 75s for a
+# single-restart api_key/oauth apply, 300s for the dual-restart subscription leg
+# (jarvis#715 step 3). This 10s damp still costs at most one extra poll before a
+# convergence is noticed, and cuts the round-trips a poll generates by roughly two
+# thirds; on the widened 300s subscription poll that is ~30 damped round-trips per
+# connect instead of ~7, which is acceptable and priced in here so the next reader
+# does not rediscover it.
 _APPLY_CONFIRM_MISS_KEY = "jarvis:apply_confirm_miss"
 _APPLY_CONFIRM_MISS_TTL_S = 10
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -665,6 +665,18 @@ def save_llm_pool(
 	apply_operation = None
 	resumable = False
 	retry_after_seconds = 0
+	# Readiness-poll budget the SPA's legacy fallback should use for THIS leg, in
+	# seconds. None means "use the SPA default" (75s), correct for a single-restart
+	# api_key/oauth direct apply. The subscription direct leg (jarvis#715 step 3)
+	# does TWO admin round-trips back to back in one sync job - _push_direct_
+	# subscription_blob's doctor+restart THEN post_update_llm_creds's render+restart
+	# (jarvis_settings.py:1154-1168) - so its confirmed-apply routinely outlasts 75s
+	# and the wizard falsely showed "not connected, retry" mid-provision. 300s
+	# matches the pool path's 5-minute operation deadline and spans one */5
+	# reconcile_pending_llm_sync tick, so a stuck apply can self-heal inside the
+	# poll rather than after it. Keyed on llm_auth_mode, the same field
+	# _sync_via_admin branches on to cause the second restart - not re-derived.
+	readiness_budget_s = None
 	if compute_pool_mode(s):
 		# The durable apply operation lives on the POOL path (admin creates it in
 		# update_llm_pool). Push synchronously and hand its descriptor back so the
@@ -688,6 +700,10 @@ def save_llm_pool(
 		# admin's creds endpoint mints no apply operation, so there is no descriptor
 		# to follow - the SPA falls back to the readiness poll for this config.
 		mode = "legacy"
+		if (s.llm_auth_mode or "") == "subscription":
+			# Dual-restart leg: give the fallback poll room to see the second
+			# restart's confirmed apply (see readiness_budget_s comment above).
+			readiness_budget_s = 300
 
 	row = (
 		frappe.db.get_value(
@@ -703,6 +719,9 @@ def save_llm_pool(
 		"resumable": resumable,
 		"retry_after_seconds": retry_after_seconds,
 		"mode": mode,
+		# Legacy readiness-poll budget (seconds) for the mode:"legacy" fallback; null
+		# = SPA default. Set only for the dual-restart subscription direct leg.
+		"readiness_budget_s": readiness_budget_s,
 		# Legacy fields kept for the settings status strip and older callers.
 		"last_sync_at": str(row.get("last_sync_at") or ""),
 		"last_sync_status": row.get("last_sync_status") or "",


### PR DESCRIPTION
Connecting a ChatGPT/OpenAI chat subscription during onboarding showed "model not connected, retry", and only worked after a retry or two. Fixed by matching the readiness poll to how long that leg actually takes.

**Why it happened.** The subscription direct leg (jarvis#715 step 3) does two container restarts back to back in one sync job: `_push_direct_subscription_blob`'s doctor+restart, then `post_update_llm_creds`'s render+restart. Its confirmed apply routinely outlasts the SPA's 75s legacy readiness poll, so the wizard gave up and showed Retry while the container was still provisioning. A retry started a fresh 75s poll that usually landed after the background job had finally converged, so it "worked on retry".

**The fix.** `save_llm_pool` now returns `readiness_budget_s` (300s) for the subscription direct leg only. `followLegacyReadiness` honours it and defaults to the historic 75s when absent, so the api-key/oauth legs and any older backend behave identically to before. 300s matches the pool path's 5-minute deadline and spans one reconcile tick.

**Note on mechanism.** The scoping preview described routing this leg through the durable `apply_operation` poll; this ships the lower-risk budget hint instead, same user-visible outcome. Folding it into the durable operation belongs with the deeper fix.

**Tradeoff, by design.** Transient failures on this leg now reach Retry at ~300s instead of 75s, matching the pool path and jarvis#757's documented "grind to the ceiling, then Retry" decision (only genuine rejections short-circuit). The double-restart collapse that shrinks this window for real is a follow-up.

**Verification.** Frontend suite green on Node 24 (76/76, two new tests: the widened bound, and a confirm-after-75s connect that now navigates instead of showing Retry). pre-commit green (pinned prettier 2.7.1 + ruff + eslint). Backend change is additive; relying on hosted CI for the Python suite.
