### PR TITLE
fix(agents): do not retry an ambiguous dispatch as a new run (#743)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1072,7 +1072,12 @@ def post_agent_run(run_id: str, agent_id: str, session_key: str, message: str, t
 	fleet boundary: a re-dispatch of a seen run returns the existing state.
 
 	Raises:
-		AdminAuthError, AdminUnreachableError, AdminValidationError.
+		AdminAuthError, AdminUnreachableError, AdminValidationError. The dispatch
+		is NON-idempotent from the bench's view (a fresh run_id would not dedupe),
+		so a transport failure where admin MAY already have received the turn
+		raises AdminAmbiguousError (an AdminUnreachableError subclass) rather than
+		the base class - the scheduler branches on it to leave the run running
+		instead of retrying under a new id (#743).
 	"""
 	return _post(
 		path=_m("api.tenant.agent_run"),

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -20,6 +20,7 @@ import frappe
 import requests
 
 from jarvis.exceptions import (
+	AdminAmbiguousError,
 	AdminAuthError,
 	AdminContractError,
 	AdminRateLimitedError,
@@ -823,6 +824,9 @@ def _authenticated_raw(path: str, body: dict, *, timeout_s: int):
 		try:
 			return requests.post(url, json=body, headers=headers, timeout=timeout_s, stream=True)
 		except (requests.ConnectionError, requests.Timeout) as e:
+			# Deliberately NOT the AdminAmbiguousError split _do_post makes (#743): this
+			# path only serves idempotent media reads, so a re-send can never double a
+			# side effect and the caller never needs to tell delivered from not.
 			raise AdminUnreachableError("admin is unreachable; check network / service status") from e
 
 	bearer = {"Content-Type": "application/json"}
@@ -1893,6 +1897,53 @@ def _permanent_rejection_code(envelope) -> str:
 	return code if code in _PERMANENT_REJECTION_CODES else ""
 
 
+def _request_maybe_delivered(e: BaseException) -> bool:
+	"""True when a transport-level failure leaves it UNKNOWN whether admin received
+	the request, so re-sending a NON-idempotent call could double its side effect
+	(jarvis #743). False only when nothing was sent: a connect timeout, or a
+	connection that was REFUSED / never established.
+
+	Fails toward ``maybe`` on purpose. A wrong ``maybe`` costs one agent-run slot a
+	3h wait for the stale-run reaper; a wrong ``not-delivered`` costs the customer a
+	duplicate audit they pay for. Only the second is unrecoverable.
+
+	  * ConnectTimeout       - the TCP handshake did not complete, nothing was sent.
+	  * refused / DNS-failed  - urllib3 raises NewConnectionError / the OS raises
+	    ConnectionRefusedError while OPENING the socket, so nothing was sent.
+	  * a bare/read Timeout   - the request WAS sent, admin may be running it now.
+	  * a reset / broken pipe - the request may already have crossed before the peer
+	    dropped it.
+	"""
+	from urllib3.exceptions import NewConnectionError
+
+	# A connect timeout is a Timeout AND a ConnectionError; check it first so it is
+	# classified as not-delivered rather than swept up by the Timeout branch below.
+	if isinstance(e, requests.ConnectTimeout):
+		return False
+	if isinstance(e, requests.Timeout):
+		return True
+	# A ConnectionError. Walk the (bounded) cause/reason chain for a definitive
+	# "the socket never opened" marker; if we find one, nothing was sent. requests
+	# wraps a refusal as ConnectionError(MaxRetryError(reason=NewConnectionError)),
+	# so ``reason`` is followed alongside __cause__ / __context__ / exception args.
+	seen: list[int] = []
+	stack: list = [e]
+	while stack and len(seen) < 20:
+		cur = stack.pop()
+		if cur is None or id(cur) in seen:
+			continue
+		seen.append(id(cur))
+		if isinstance(cur, (ConnectionRefusedError, NewConnectionError)):
+			return False
+		stack.append(getattr(cur, "__cause__", None))
+		stack.append(getattr(cur, "__context__", None))
+		stack.append(getattr(cur, "reason", None))
+		stack.extend(a for a in (getattr(cur, "args", None) or ()) if isinstance(a, BaseException))
+	# No not-delivered marker found (a reset, a broken pipe, an unknown wrap): the
+	# request may already have been received.
+	return True
+
+
 def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str) -> dict:
 	try:
 		resp = requests.post(url, json=body, headers=headers, timeout=timeout_s)
@@ -1907,6 +1958,16 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 			title="admin_client: network error",
 			message=f"url={url!r} error={e!r}",
 		)
+		# jarvis #743: a transport failure where admin MAY already have received the
+		# request (a read timeout, a mid-flight reset) is distinct from one where
+		# nothing was sent (connect timeout, connection refused). AdminAmbiguousError
+		# is an AdminUnreachableError SUBCLASS, so every existing catcher is
+		# unaffected; only a caller dispatching a non-idempotent turn branches on it
+		# to avoid re-sending a call admin may already be running.
+		if _request_maybe_delivered(e):
+			raise AdminAmbiguousError(
+				"admin did not answer in time; the request may already be running"
+			) from e
 		raise AdminUnreachableError("admin is unreachable; check network / service status") from e
 
 	try:

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -289,17 +289,20 @@ def _dispatch(row, now, *, run_as: str, original_user: str, source_apps: list[st
 	running, and the slot is genuinely unspent. Reading the run rather than the
 	exception is what tells the two apart.
 
-	NOT covered here: a dispatch call that fails AMBIGUOUSLY, a timeout where admin may
-	already have started the turn. ``_launch_audit`` records that as ``failed`` (it
-	cannot know better), so the retry mints a fresh run id and the fleet's run-id
-	idempotency does not engage. That is a different duplicate with a different cause,
-	pre-dating this path, and closing it needs a decision about what an ambiguous
-	dispatch means rather than another guard here.
+	The fourth case, a dispatch that fails AMBIGUOUSLY (a timeout, or a reset mid-flight,
+	where admin may already have started the turn), is #743. ``_launch_audit`` no longer
+	records it ``failed``: it leaves the run ``running`` and re-raises AdminAmbiguousError,
+	and the explicit branch below keeps the slot CLAIMED rather than handing it back. So no
+	fresh run id is minted an hour later, the fleet's run-id idempotency is never bypassed,
+	and the 3h stale-run reaper is the single arbiter of the still-running run. Leaving the
+	customer with a ``running`` run after a timeout is the accepted cost of never billing a
+	second audit for one slot.
 
 	A Redis fault propagates out of the lock instead of dispatching, which is
 	deliberate: without the lock there is no exclusivity to be had, and a slot left due
 	is recoverable where a duplicate is not.
 	"""
+	from jarvis import admin_client
 	from jarvis._redis_lock import redis_lock
 
 	with redis_lock(_dispatch_lock_name(row.name), timeout_s=DISPATCH_LOCK_TTL_S) as acquired:
@@ -327,6 +330,17 @@ def _dispatch(row, now, *, run_as: str, original_user: str, source_apps: list[st
 			# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
 			# it has no initiating human: the scheduler user (Administrator) is not one.
 			_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
+		except admin_client.AdminAmbiguousError:
+			# #743: the dispatch timed out and admin MAY be running this turn.
+			# ``_launch_audit`` deliberately left the run ``running``, so the slot must
+			# stay CLAIMED: do NOT _unclaim it, do NOT _record_failed, do NOT notify the
+			# owner a run could not start (it may have). Keep the claim and let the 3h
+			# reaper arbitrate the running run. This is the same net effect as the
+			# generic ``_live_run`` branch below would reach for this row, made explicit
+			# so the money decision is not read out of a liveness query.
+			frappe.set_user(original_user)
+			frappe.db.commit()
+			return
 		except Exception:
 			frappe.set_user(original_user)
 			frappe.log_error(
@@ -838,12 +852,33 @@ def _launch_audit(
 			message=_audit_prompt(listing, inst, trigger, scope),
 			timeout_s=registry_timeout_s(slug),
 		)
+	except admin_client.AdminAmbiguousError:
+		# #743: the dispatch TIMED OUT (or the connection reset mid-flight) - admin
+		# MAY already be running this turn. Terminalizing the run ``failed`` here is
+		# exactly what let the slot be retried under a FRESH run id an hour later, so
+		# the fleet's run-id idempotency never engaged and the customer paid for two
+		# audits of one slot. So do the opposite of the confirmed-failure branch
+		# below: leave the run ``running`` (it is already committed so), do NOT tear
+		# down its session (a genuinely-live delegate resolves its identity and its
+		# record_agent_run writeback through that row), and re-raise the SAME
+		# ambiguous signal so the caller keeps the slot claimed instead of handing it
+		# back. The 3h stale-run reaper is then the single arbiter: it completes a
+		# run the writeback lands for and fails one that truly never started - it
+		# never relabels a real outcome. The commit persists the Error Log before the
+		# re-raise trips the request-level rollback on the manual path.
+		frappe.log_error(
+			title=f"jarvis agent-run dispatch ambiguous (left running): {run.name}",
+			message=frappe.get_traceback(),
+		)
+		frappe.db.commit()
+		raise
 	except Exception:
-		# The dispatch call itself failed. Mark THIS Run failed (mirror
-		# _record_failed's writeback onto the already-created "running" row so
-		# it is never orphaned), then re-raise so the caller's retry/notify path
-		# runs (scheduler: no next_run_at advance -> retry next hour;
-		# run_agent_now: surfaces the error to the UI).
+		# The dispatch call itself failed, and CONFIRMEDLY: nothing was sent (a clean
+		# refusal / connect timeout), a 4xx rejection, or an auth denial. Mark THIS
+		# Run failed (mirror _record_failed's writeback onto the already-created
+		# "running" row so it is never orphaned), then re-raise so the caller's
+		# retry/notify path runs (scheduler: no next_run_at advance -> retry next
+		# hour; run_agent_now: surfaces the error to the UI).
 		frappe.db.set_value(
 			RUN,
 			run.name,

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -124,6 +124,27 @@ class AdminUnreachableError(JarvisError):
 	"""HTTPS call to jarvis_admin failed (network, timeout, 5xx, non-JSON)."""
 
 
+class AdminAmbiguousError(AdminUnreachableError):
+	"""The HTTPS call to jarvis_admin failed at the TRANSPORT layer in a way that
+	leaves it UNKNOWN whether admin received the request: a read timeout, or a
+	connection reset AFTER the request went out. The request may already be running
+	admin-side, so re-sending it can DOUBLE a non-idempotent side effect.
+
+	Contrast ``AdminUnreachableError`` (the base), which a caller may treat as "the
+	request definitely did not land" only when it is one of the confirmed-not-sent
+	shapes routed to it: a clean connection refusal, a connect timeout (nothing was
+	sent), a 5xx (admin answered), or a non-JSON body (admin answered). Everything in
+	this subclass is the ``maybe`` case.
+
+	Deliberately a SUBCLASS of AdminUnreachableError, exactly like AdminRejectedError:
+	every existing catch site already treats an admin failure as terminal and keeps
+	working unchanged. Only a caller dispatching a NON-idempotent turn (the agent-run
+	relay, jarvis.chat.agent_scheduler) branches on it - to leave its already-running
+	run alone rather than terminalize it and mint a fresh, un-deduplicated retry
+	(jarvis #743). Idempotent readers (media download, catalog fetches) never need to
+	tell the two apart, so they keep catching the base class."""
+
+
 class AdminRejectedError(AdminUnreachableError):
 	"""jarvis_admin was REACHED and PERMANENTLY refused the request.
 

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -14,6 +14,7 @@ from jarvis import admin_client
 from jarvis.admin_client import (
 	DEFAULT_ADMIN_URL,
 	DEFAULT_TIMEOUT_S,
+	AdminAmbiguousError,
 	AdminAuthError,
 	AdminUnreachableError,
 	AdminValidationError,
@@ -322,6 +323,67 @@ class TestNetworkErrors(FrappeTestCase):
 		with patch("requests.post", side_effect=requests.Timeout("read timeout")):
 			with self.assertRaises(AdminUnreachableError):
 				post_update_llm_creds("p", "m", "b", "k")
+
+	# ------------------------------------------------------------------ #
+	# #743: distinguish an AMBIGUOUS transport failure (admin MAY have received
+	# the request) from a CONFIRMED not-delivered one (nothing was sent). Every
+	# ambiguous case is still an AdminUnreachableError subclass, so the two tests
+	# above keep passing unchanged - that inheritance is the zero-regret proof.
+	# ------------------------------------------------------------------ #
+	@staticmethod
+	def _refused_connection_error():
+		"""The shape requests raises when the socket is REFUSED / never opened:
+		ConnectionError(MaxRetryError(reason=NewConnectionError(...))). Built by hand
+		so the classifier is exercised against the real production nesting, not a bare
+		ConnectionError."""
+		from urllib3.exceptions import MaxRetryError, NewConnectionError
+
+		reason = NewConnectionError(None, "[Errno 111] Connection refused")
+		return requests.ConnectionError(MaxRetryError(pool=None, url="/x", reason=reason))
+
+	@staticmethod
+	def _reset_connection_error():
+		"""A connection RESET after the request went out: ConnectionError(ProtocolError(
+		'Connection aborted.', ConnectionResetError(...))). The request may already have
+		crossed, so this is ambiguous."""
+		from urllib3.exceptions import ProtocolError
+
+		aborted = ProtocolError("Connection aborted.", ConnectionResetError(104, "reset by peer"))
+		return requests.ConnectionError(aborted)
+
+	def test_read_timeout_is_ambiguous(self):
+		with patch("requests.post", side_effect=requests.ReadTimeout("read timed out")):
+			with self.assertRaises(AdminAmbiguousError):
+				post_update_llm_creds("p", "m", "b", "k")
+
+	def test_bare_timeout_is_ambiguous(self):
+		with patch("requests.post", side_effect=requests.Timeout("timed out")):
+			with self.assertRaises(AdminAmbiguousError):
+				post_update_llm_creds("p", "m", "b", "k")
+
+	def test_connect_timeout_is_not_ambiguous(self):
+		"""A connect timeout never completed the handshake, so nothing was sent."""
+		with patch("requests.post", side_effect=requests.ConnectTimeout("connect timed out")):
+			with self.assertRaises(AdminUnreachableError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertNotIsInstance(cm.exception, AdminAmbiguousError)
+
+	def test_refused_connection_is_not_ambiguous(self):
+		"""A refused / never-opened socket sent nothing, so a retry is safe."""
+		with patch("requests.post", side_effect=self._refused_connection_error()):
+			with self.assertRaises(AdminUnreachableError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertNotIsInstance(cm.exception, AdminAmbiguousError)
+
+	def test_reset_connection_is_ambiguous(self):
+		"""A reset AFTER the request went out may already have been received."""
+		with patch("requests.post", side_effect=self._reset_connection_error()):
+			with self.assertRaises(AdminAmbiguousError):
+				post_update_llm_creds("p", "m", "b", "k")
+
+	def test_ambiguous_is_an_unreachable_subclass(self):
+		"""Every existing catch site that catches AdminUnreachableError keeps working."""
+		self.assertTrue(issubclass(AdminAmbiguousError, AdminUnreachableError))
 
 
 class TestAdminErrorResponses(FrappeTestCase):

--- a/jarvis/tests/test_agent_dispatch_idempotency.py
+++ b/jarvis/tests/test_agent_dispatch_idempotency.py
@@ -617,3 +617,168 @@ class TestManualAndScheduledCannotInterleave(DispatchIdempotencyTestCase):
 
 		self._run_now(inst)
 		self.assertEqual(len(self._launched(inst)), 2)
+
+
+class TestAmbiguousDispatchIsNotRetriedAsANewRun(DispatchIdempotencyTestCase):
+	"""#743: a dispatch that TIMES OUT (admin may already be running the turn) must not
+	terminalize the run, must not hand the slot back, and must not mint a fresh run id
+	an hour later - that fresh id is what bypassed the fleet's run-id idempotency and
+	billed the customer for two audits of one slot. The run is left ``running`` for the
+	3h stale-run reaper to arbitrate."""
+
+	def _ambiguous(self, **kw):
+		self.dispatched.append(kw)
+		raise admin_client.AdminAmbiguousError("admin did not answer in time; may be running")
+
+	def test_an_ambiguous_dispatch_leaves_the_run_running_and_claims_the_slot(self):
+		inst = self._due_install()
+		now = now_datetime()
+
+		self._sweep(dispatch=self._ambiguous)
+
+		running = self._runs(inst, "running")
+		self.assertEqual(len(running), 1, "the timed-out run is left running for the reaper")
+		self.assertEqual(self._runs(inst, "failed"), [], "an ambiguous dispatch is not recorded as a failure")
+		self.assertEqual(len(self._dispatched_for(inst)), 1, "exactly one dispatch attempt")
+		self.assertEqual(
+			frappe.get_all(NOTIFICATION, filters={"for_user": self.owner}, pluck="name"),
+			[],
+			"the owner is not told a run that may be running could not start",
+		)
+		self.assertGreater(self._next_run_at(inst), now, "the slot is CLAIMED, never handed back")
+
+	def test_a_later_tick_does_not_mint_a_second_run_for_the_still_running_slot(self):
+		"""THE money assertion. Even if the slot is forced due again, the still-running
+		ambiguous run blocks a second audit (via ``_live_run``): no new run id, no second
+		dispatch reaches the container."""
+		inst = self._due_install()
+
+		self._sweep(dispatch=self._ambiguous)
+		running = self._runs(inst, "running")
+		self.assertEqual(len(running), 1)
+
+		# Force the slot due again and run a HEALTHY tick: prove the running run - not
+		# merely the advanced schedule - is what stops the duplicate.
+		frappe.db.set_value(
+			INSTALLATION, inst, "next_run_at", add_days(now_datetime(), -1), update_modified=False
+		)
+		frappe.db.commit()
+		self._sweep()
+
+		self.assertEqual(self._runs(inst, "running"), running, "the same single run; no new id minted")
+		self.assertEqual(len(self._dispatched_for(inst)), 1, "no second audit reaches the container")
+
+	def test_a_confirmed_refusal_still_records_notifies_and_returns_the_slot(self):
+		"""Control (unchanged behavior): a CONFIRMED refusal - a base AdminUnreachableError,
+		not the ambiguous subclass - is terminalized, notified and retried exactly as before."""
+		inst = self._due_install()
+		now = now_datetime()
+
+		def _refused(**kw):
+			self.dispatched.append(kw)
+			raise admin_client.AdminUnreachableError("admin returned a 400 error")
+
+		self._sweep(dispatch=_refused)
+
+		self.assertEqual(self._runs(inst, "running"), [], "a confirmed refusal leaves nothing alive")
+		self.assertTrue(
+			frappe.get_all(RUN, filters={"installation": inst, "status": "failed"}, ignore_permissions=True),
+			"the failure is recorded for the customer",
+		)
+		self.assertTrue(
+			frappe.get_all(NOTIFICATION, filters={"for_user": self.owner}, pluck="name"),
+			"the owner is told the run could not start",
+		)
+		self.assertLessEqual(self._next_run_at(inst), now, "the slot goes back for a retry")
+
+
+class TestAmbiguousDispatchManualPath(DispatchIdempotencyTestCase):
+	"""#743: the manual ``run_agent_now`` path must behave the SAME as the scheduled path
+	for both outcomes - an ambiguous dispatch leaves the run running (a re-click is
+	refused), a confirmed refusal fails it (a re-click is allowed)."""
+
+	def test_a_manual_ambiguous_dispatch_leaves_the_run_running_and_blocks_a_retry(self):
+		inst = self._due_install()
+
+		def _ambiguous(**kw):
+			self.dispatched.append(kw)
+			raise admin_client.AdminAmbiguousError("admin did not answer in time; may be running")
+
+		with self.assertRaises(admin_client.AdminAmbiguousError):
+			self._run_now(inst, dispatch=_ambiguous)
+
+		self.assertEqual(len(self._runs(inst, "running")), 1, "the run is left running, not failed")
+		self.assertEqual(self._runs(inst, "failed"), [], "an ambiguous dispatch is not a failure")
+
+		# The customer clicks again: the live run must refuse it, so the timed-out turn
+		# admin may already be running is never dispatched a second time.
+		with self.assertRaises(frappe.ValidationError) as cm:
+			self._run_now(inst)
+		self.assertIn("already running", str(cm.exception))
+		self.assertEqual(len(self._dispatched_for(inst)), 1, "the second click never reaches the container")
+
+	def test_a_manual_confirmed_refusal_fails_the_run_and_allows_a_retry(self):
+		inst = self._due_install()
+
+		def _refused(**kw):
+			self.dispatched.append(kw)
+			raise admin_client.AdminUnreachableError("admin returned a 400 error")
+
+		with self.assertRaises(admin_client.AdminUnreachableError):
+			self._run_now(inst, dispatch=_refused)
+
+		self.assertEqual(self._runs(inst, "running"), [], "a confirmed refusal leaves nothing alive")
+		self.assertEqual(len(self._runs(inst, "failed")), 1, "the run is recorded failed")
+
+		# Unchanged: a confirmed refusal is retryable, so the next click starts a fresh audit.
+		self._run_now(inst)
+		self.assertEqual(len(self._launched(inst)), 1, "the retry starts a fresh audit")
+
+
+class TestReaperDoesNotRelabelAnAmbiguousRun(DispatchIdempotencyTestCase):
+	"""#743 bullet 4: whatever an ambiguous run is left as, the stale-run reaper must not
+	relabel a REAL outcome. A run admin actually completed (record_agent_run lands within
+	the hour) stays completed; a run that truly never started is the reaper's to fail."""
+
+	def _stale_running_run(self, inst: str) -> str:
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": SLUG,
+				"installation": inst,
+				"trigger": "scheduled",
+				"status": "running",
+				"started_at": add_to_date(
+					now_datetime(), seconds=-(agent_scheduler.STALE_RUN_AFTER_SECONDS + 600)
+				),
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert(ignore_permissions=True)
+		frappe.db.commit()
+		return run.name
+
+	def test_a_completed_writeback_is_never_relabeled_failed(self):
+		inst = self._due_install()
+		run = self._stale_running_run(inst)
+		# The writeback lands: admin DID run the turn, minutes into the hour.
+		frappe.db.set_value(RUN, run, "status", "completed", update_modified=False)
+		frappe.db.commit()
+
+		agent_scheduler.reap_stale_agent_runs()
+
+		self.assertEqual(
+			frappe.db.get_value(RUN, run, "status"), "completed", "the reaper never overwrites a real outcome"
+		)
+
+	def test_a_still_running_ambiguous_run_is_the_reapers_to_fail(self):
+		inst = self._due_install()
+		run = self._stale_running_run(inst)
+
+		agent_scheduler.reap_stale_agent_runs()
+
+		self.assertEqual(
+			frappe.db.get_value(RUN, run, "status"),
+			"failed",
+			"a run that truly never started is failed by the 3h backstop, the single arbiter",
+		)


### PR DESCRIPTION
An agent-run dispatch that times out (rather than being refused) is no longer retried as a brand-new run. Customers whose audit dispatch times out after admin already accepted the turn stop being billed for a second audit of the same slot. Closes #743.

**What changed**
- `admin_client` now tells an AMBIGUOUS transport failure (a read timeout, or a reset after the request went out) apart from a CONFIRMED not-delivered one (a connect timeout, a refused socket). The ambiguous case raises the new `AdminAmbiguousError`, a subclass of `AdminUnreachableError` so every existing catch site is unaffected.
- On an ambiguous dispatch, the run is left `running`, its session is kept, and the scheduler keeps the slot CLAIMED (no new run id, no "could not start" notification). The 3h stale-run reaper is the single arbiter. A confirmed refusal keeps today's record/notify/retry behavior exactly. The manual "Run now" path inherits both, so a re-click on a timed-out run is refused instead of starting a second audit.

**Tests** (all four issue verification bullets)
- ambiguous dispatch is not retried as a new run, scheduled and manual
- confirmed refusal still records, notifies and retries, unchanged
- the stale-run reaper never relabels a real outcome
Ran the 3 new + 3 existing `TestCase`s in `test_agent_dispatch_idempotency` and `TestNetworkErrors` in `test_admin_client`; all green locally. Hosted Actions is the gate.

<details>
<summary>Root cause</summary>

`admin_client._do_post` mapped a `requests.Timeout` to `AdminUnreachableError` identically to a hard refusal. `_launch_audit` caught it, stamped the run `failed`, tore down the session and re-raised; `_dispatch` then saw no live run, handed the slot back, and the next hourly tick minted a fresh run id. Because fleet idempotency is keyed on `run_id`, the new id bypassed it and a turn admin may already have run was dispatched a second time. This is the second route to the #672 duplicate and survives PR #742. Fix chosen is the issue's option 1 (fail-safe: leave the run running); option 2 (same-run-id retry) and option 3 (pre-check round-trip) were deliberately not taken this close to launch.
</details>