### PR TITLE
feat(readiness): honest retryable state for a stuck model apply (#825)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -55,6 +55,12 @@ export const checkAccountReconnect = (requestId, code) =>
 	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId, code: code || "" });
 
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat");
+// Re-drive this workspace's saved AI config through admin - the customer lever
+// for a stuck apply (jarvis#825, reason "llm_apply_stuck"). Probes admin first
+// and only re-pushes if the container is NOT already serving; throttled once per
+// 180s server-side. Admin-gated (require_jarvis_admin). Returns get_llm_sync_status()'s
+// shape plus `outcome`: converged | queued | throttled | not_configured.
+export const resyncLlm = () => call("jarvis.onboarding.resync_llm");
 // Read-only poll of a durable LLM-apply operation (plan-05 D2). The single
 // Start-chatting controller (frontend/src/lib/llmOperation.js) follows exactly one
 // operation id to a terminal state through this; it never spends the apply bucket.

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -91,6 +91,10 @@ export async function isWorkspaceReady() {
 // pool/direct leg is mid-apply" (e.g. adding a model in Settings), which must
 // keep the customer in their chat + history, not bounce them to the setup
 // poster on a reload. See isLlmApplying() below for its quiet in-app banner.
+// "llm_apply_stuck" (jarvis#825) is deliberately ABSENT for the same reason:
+// the server only returns it for an established workspace whose apply hung, and
+// it must keep its chat + history and get a retryable banner, never the setup
+// poster. Do NOT "fix" the omission by adding it - see isLlmApplyStuck() below.
 const NOT_ONBOARDED_REASONS = new Set([
 	"signup",
 	"llm_pool_provisioning",
@@ -287,4 +291,21 @@ export async function needsLlmConnection() {
 export async function isLlmApplying() {
 	const r = await checkReady();
 	return !!(r && !r.ready && r.reason === "llm_applying");
+}
+
+// True when an established workspace's apply got STUCK: it was mid-apply
+// (llm_applying) but has aged past the server's soft window without ever
+// converging or writing a terminal failure (jarvis#825 - fleet-agent down, a
+// sync that hangs). Its own accessor for the same "one reason, one accessor"
+// reason as isLlmApplying above. Deliberately NOT in NOT_ONBOARDED_REASONS: the
+// workspace WAS established, so it keeps its chat + history and gets an honest,
+// retryable banner instead of the full-screen setup poster - which is the whole
+// point of #825 (before it, a stuck apply silently fell back to the hard
+// provisioning reason and bounced the customer to the wizard). The banner's
+// Retry calls resyncLlm(), gated to Jarvis Admins because the backend endpoint
+// is (jarvis.onboarding.resync_llm -> require_jarvis_admin); a non-admin sees the
+// state named but no button.
+export async function isLlmApplyStuck() {
+	const r = await checkReady();
+	return !!(r && !r.ready && r.reason === "llm_apply_stuck");
 }

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -19,6 +19,8 @@ const {
 	replacedBanner,
 	hasReconnectIntent,
 	landingStep,
+	isLlmApplying,
+	isLlmApplyStuck,
 	RECONNECT_INTENT_URL,
 } = await import("./readiness.js");
 
@@ -111,6 +113,8 @@ describe("readiness verdict ownership", () => {
 			"container_provisioning",
 			"authority_repair_required",
 			"subscription_suspended",
+			"llm_applying",
+			"llm_apply_stuck",
 			null,
 		];
 		for (const reason of reasons) {
@@ -142,6 +146,41 @@ describe("llm_rejected still gates (jarvis#757, round-1 review of #760)", () => 
 		forgetReady();
 		verdict({ ready: false, reason: "llm_rejected", detail: "provider + model required" });
 		expect(await needsOnboarding()).toBe(true);
+	});
+});
+
+/**
+ * jarvis#825: a stuck apply must be its own honest, retryable in-app state - NOT
+ * the full-screen setup gate (that was the pre-#825 bug: an established customer
+ * whose apply hung got silently bounced to the wizard), and NOT the two ownership
+ * accessors above (it gets its own banner + Retry). These pin all three.
+ */
+describe("llm_apply_stuck (jarvis#825)", () => {
+	it("isLlmApplyStuck answers ONLY for its own reason", async () => {
+		verdict({ ready: false, reason: "llm_apply_stuck" });
+		expect(await isLlmApplyStuck()).toBe(true);
+		forgetReady();
+		verdict({ ready: false, reason: "llm_applying" });
+		expect(await isLlmApplyStuck()).toBe(false);
+		forgetReady();
+		verdict({ ready: true, reason: null });
+		expect(await isLlmApplyStuck()).toBe(false);
+	});
+
+	it("isLlmApplying and isLlmApplyStuck are mutually exclusive", async () => {
+		verdict({ ready: false, reason: "llm_apply_stuck" });
+		expect(await isLlmApplying()).toBe(false);
+		forgetReady();
+		verdict({ ready: false, reason: "llm_applying" });
+		expect(await isLlmApplyStuck()).toBe(false);
+	});
+
+	it("does NOT trip the full-screen onboarding gate", async () => {
+		// The whole point of #825: the workspace WAS established, so it keeps its
+		// chat + history and gets a banner, never the setup poster. If this ever
+		// returns true, llm_apply_stuck was wrongly added to NOT_ONBOARDED_REASONS.
+		verdict({ ready: false, reason: "llm_apply_stuck" });
+		expect(await needsOnboarding()).toBe(false);
 	});
 });
 
@@ -300,6 +339,18 @@ describe("ChatView banner chain order", () => {
 		// call to action, so a generic banner ahead of it in the chain leaves a
 		// disconnected customer with no discoverable way back to the AI models pane.
 		expect(specific).toBeLessThan(generic);
+	});
+
+	it("orders the stuck-apply banner AFTER the still-converging one (jarvis#825)", () => {
+		const applying = chatSrc.indexOf('v-else-if="llmApplying"');
+		const stuck = chatSrc.indexOf('v-else-if="llmApplyStuck"');
+		expect(applying, "ChatView must still render the llmApplying banner").not.toBe(-1);
+		expect(stuck, "ChatView must render the llmApplyStuck banner").not.toBe(-1);
+		// llmApplying is the LIVE, still-converging window; llmApplyStuck is the
+		// aged-out one. Applying must win the chain while it is true, so the honest
+		// "didn't finish" banner only shows once the soft window has genuinely
+		// lapsed - never over a retry that just flipped the reason back to applying.
+		expect(applying).toBeLessThan(stuck);
 	});
 });
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2171,6 +2171,35 @@
 					message="Chat may be briefly unavailable while this finishes."
 					style="margin-bottom: 10px"
 				/>
+				<!-- jarvis#825: the mid-apply window (llmApplying) aged out without ever
+					 finishing - a genuinely stuck apply. Honest state + a Retry that
+					 re-drives the saved config (resyncLlm), admin-gated like the AI-connect
+					 banner above. A member gets the state named but is pointed at their
+					 admin rather than a button the server would refuse. A successful retry
+					 flips the reason back to llm_applying, so this banner is replaced by the
+					 quiet "Updating" one above. Ordered LAST in the chain, after llmApplying,
+					 so the still-converging window always wins while it is live. -->
+				<Banner
+					v-else-if="llmApplyStuck"
+					type="warning"
+					title="Your last AI update didn't finish"
+					:message="
+						canRetryApply
+							? 'It looks like the last change to your AI setup got stuck. Retry to finish it.'
+							: 'It looks like the last change to your AI setup got stuck. Ask your administrator to retry it.'
+					"
+					style="margin-bottom: 10px"
+				>
+					<template v-if="canRetryApply" #action>
+						<button
+							class="jv-btn jv-btn--sm"
+							:disabled="retryingApply"
+							@click="retryApply"
+						>
+							{{ retryingApply ? "Retrying…" : "Retry" }}
+						</button>
+					</template>
+				</Banner>
 
 				<!-- floats just above the composer; jumps the thread to the newest message -->
 				<transition name="jv-sd">
@@ -3857,6 +3886,7 @@ import {
 	readinessDetailOf,
 	needsLlmConnection,
 	isLlmApplying,
+	isLlmApplyStuck,
 	forgetReady,
 } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
@@ -3956,6 +3986,45 @@ const noAiConnected = ref(false);
 // the previous config serving, so this is a quiet heads-up, not a working-chat
 // guarantee - no CTA, no composer-disable. See isLlmApplying (readiness.js).
 const llmApplying = ref(false);
+// jarvis#825: the established-workspace apply llmApplying covered aged past the
+// server's soft window without ever converging or failing terminally (fleet-agent
+// down, a sync that hangs). Unlike llmApplying this is NOT a quiet heads-up: chat
+// genuinely cannot answer, and before #825 it silently bounced the customer to the
+// setup wizard. Its own honest banner with a Retry that re-drives the saved config.
+const llmApplyStuck = ref(false);
+// True while a Retry (resyncLlm) is in flight, so the button shows progress and
+// cannot be double-clicked into the server's 180s throttle for no reason.
+const retryingApply = ref(false);
+// Retry is gated the same as the other admin actions here: resyncLlm hits
+// require_jarvis_admin() server-side, so a member gets the state NAMED but no
+// button that would only 403 (canRetryApply below drives the copy too).
+const canRetryApply = !!(window.is_jarvis_admin || window.is_system_manager);
+// Re-drive the saved AI config, then re-read readiness so the banner reflects the
+// new state without a page reload. resyncLlm probes admin first (converged ->
+// nothing to do) and only re-pushes otherwise, restamping last_sync_requested_at,
+// which flips the server reason back to llm_applying: so a successful retry visibly
+// swaps this banner for the quiet "Updating your AI configuration" one. All
+// outcomes (converged/queued/throttled) resolve the same way - forget the memoized
+// verdict and re-derive both flags.
+async function retryApply() {
+	if (retryingApply.value || !canRetryApply) return;
+	retryingApply.value = true;
+	try {
+		await api.resyncLlm();
+	} catch (e) {
+		/* fall through to the re-read: a throttle or transient error still resolves
+		   by re-checking readiness rather than leaving the banner stale */
+	}
+	try {
+		forgetReady();
+		llmApplyStuck.value = await isLlmApplyStuck();
+		llmApplying.value = await isLlmApplying();
+	} catch (e) {
+		/* leave the last known state */
+	} finally {
+		retryingApply.value = false;
+	}
+}
 // Connecting a model is gated on require_jarvis_admin() server-side. A member who
 // cannot reach the AI models pane still gets the banner (their chat IS broken and
 // they should know why), just without a button that would only bounce them back to
@@ -4247,6 +4316,14 @@ watch(
 			// round trip, not two.
 			try {
 				llmApplying.value = await isLlmApplying();
+			} catch (e) {
+				/* leave the last known state */
+			}
+			// ...and the stuck half (jarvis#825): a model add that never converges
+			// can leave this pane on a stuck apply, so re-derive it here too off the
+			// same dropped verdict.
+			try {
+				llmApplyStuck.value = await isLlmApplyStuck();
 			} catch (e) {
 				/* leave the last known state */
 			}
@@ -9778,6 +9855,14 @@ onMounted(async () => {
 	isLlmApplying()
 		.then((v) => {
 			llmApplying.value = v;
+		})
+		.catch(() => {});
+	// ...and the llm_apply_stuck half (jarvis#825): same fail-open posture, an
+	// unreachable backend just leaves the stuck banner off. Rides the same memoized
+	// verdict as the two flags above, so still no extra round trip.
+	isLlmApplyStuck()
+		.then((v) => {
+			llmApplyStuck.value = v;
 		})
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4006,6 +4006,12 @@ const canRetryApply = !!(window.is_jarvis_admin || window.is_system_manager);
 // swaps this banner for the quiet "Updating your AI configuration" one. All
 // outcomes (converged/queued/throttled) resolve the same way - forget the memoized
 // verdict and re-derive both flags.
+//
+// The Desk widget (jarvis/public/js/jarvis_chat/widget/Panel.vue) carries a
+// near-identical retryApply for the same stuck-apply state. The two cannot share a
+// helper - the widget is plain .mjs served into Desk and cannot import from
+// frontend/src (see panel_readiness.mjs's header) - so keep the retry SEMANTICS in
+// sync by hand, the same convention readiness.js <-> panel_readiness.mjs already use.
 async function retryApply() {
 	if (retryingApply.value || !canRetryApply) return;
 	retryingApply.value = true;

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -336,6 +336,25 @@ def _apply_recently_requested(requested_at) -> bool:
 		return False
 
 
+def _apply_requested_but_stale(requested_at) -> bool:
+	"""Was an apply requested (``last_sync_requested_at`` present and parseable)
+	but so long ago it has aged out of ``_APPLYING_SOFT_WINDOW_S``? This is the
+	STUCK signal for jarvis#825, and the deliberate mirror image of
+	``_apply_recently_requested``: that one returns False both for a recent apply
+	and for a workspace that never enqueued one (null/unparseable), collapsing two
+	very different states. Here we need the third: there IS a real apply on record,
+	it is just not converging. A null/unparseable stamp means no apply to be stuck
+	on, so it returns False and the caller keeps the hard setup-wizard reason. Runs
+	on the hot is_ready_for_chat path, so an unparseable value fails closed rather
+	than raising."""
+	if not requested_at:
+		return False
+	try:
+		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), requested_at) >= _APPLYING_SOFT_WINDOW_S
+	except Exception:
+		return False
+
+
 def _write_is_durable() -> bool:
 	"""Would a write made right now survive the end of this request?
 
@@ -666,6 +685,18 @@ def is_ready_for_chat() -> dict:
 	  transition bounces it (10-30s); this reason is only about keeping the
 	  customer IN the app during that window, not a claim that chat keeps
 	  answering uninterrupted.
+	- ``"llm_apply_stuck"`` - the established-workspace apply that ``llm_applying``
+	  covered has aged past ``_APPLYING_SOFT_WINDOW_S`` without ever converging or
+	  writing a terminal ``"failed:"`` status (fleet-agent down, a sync that hangs).
+	  Before jarvis#825 this silently fell back to the hard
+	  ``llm_pool_provisioning`` / ``llm_provisioning`` reason, bouncing an
+	  established customer to the setup wizard with no explanation. Now it is its
+	  own honest, retryable state: the readiness surfaces render "your last AI
+	  update didn't finish" and offer Jarvis Admins a Retry that calls
+	  ``jarvis.onboarding.resync_llm`` (probe-first, throttled), which restamps
+	  ``last_sync_requested_at`` and flips the reason back to ``llm_applying``.
+	  Only reachable for a workspace that HAS an apply on record; a never-applied
+	  one keeps the hard reason.
 	- ``"llm_rejected"`` - the pool/api_key/subscription config's FIRST sync ended
 	  in a terminal ``last_sync_status`` of ``"failed: ..."`` AND admin's own
 	  refusal is what produced it (an unusable spec, a validation error, a
@@ -1034,9 +1065,18 @@ def _provisioning_verdict(raw: dict, hard_reason: str) -> dict:
 	"""
 	if not _has_been_chat_ready(raw):
 		return {"ready": False, "reason": hard_reason}
-	if not _apply_recently_requested(raw.get(_APPLYING_TIMESTAMP_FIELD)):
-		return {"ready": False, "reason": hard_reason}
-	return {"ready": False, "reason": "llm_applying"}
+	requested_at = raw.get(_APPLYING_TIMESTAMP_FIELD)
+	if _apply_recently_requested(requested_at):
+		return {"ready": False, "reason": "llm_applying"}
+	# Established workspace, an apply WAS requested (timestamp present and
+	# parseable) but has aged out of the soft window without converging: a stuck
+	# apply (jarvis#825). Surface an honest, retryable state instead of silently
+	# routing an established, chatting customer to the setup wizard. An
+	# absent/unparseable timestamp is a workspace with no apply to be stuck on, so
+	# it keeps the hard reason - exactly the pre-#825 fallback.
+	if _apply_requested_but_stale(requested_at):
+		return {"ready": False, "reason": "llm_apply_stuck"}
+	return {"ready": False, "reason": hard_reason}
 
 
 def _llm_missing_verdict(settings) -> dict:

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -318,41 +318,22 @@ def _marker_is_fresh(current) -> bool:
 		return False
 
 
-def _apply_recently_requested(requested_at) -> bool:
-	"""Is ``last_sync_requested_at`` recent enough to still cover a soft
-	llm_applying verdict? Same shape as ``_marker_is_fresh`` above: a
-	null/unset value is NOT recent (a workspace that has never enqueued an
-	apply, or predates the field, must not be treated as mid-apply), and an
-	unparseable one fails the same way rather than raising - this runs on the
-	hot is_ready_for_chat path and must never turn a bad value into a 500.
-	Time-boxes review finding 1: a stuck apply that never converges and never
-	writes a terminal status ages out of the soft window and falls back to the
-	hard reason, exactly the pre-PR behaviour."""
+def _apply_age_seconds(requested_at):
+	"""Seconds elapsed since ``last_sync_requested_at``, or ``None`` when there is
+	no usable timestamp. ``None`` covers both a workspace that never enqueued an
+	apply (null/unset - predates the field, or simply none pending) and an
+	unparseable value: this runs on the hot is_ready_for_chat path and must never
+	turn a bad value into a 500, so a parse failure is swallowed to ``None`` rather
+	than raised. The single parse+diff path for the soft-window decision, so the
+	"recent" and "stale" boundaries (in ``_provisioning_verdict``) cannot drift
+	apart or be computed inconsistently - the reason a bare ``None`` sentinel is
+	returned rather than two separate predicate helpers (jarvis#825 review)."""
 	if not requested_at:
-		return False
+		return None
 	try:
-		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), requested_at) < _APPLYING_SOFT_WINDOW_S
+		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), requested_at)
 	except Exception:
-		return False
-
-
-def _apply_requested_but_stale(requested_at) -> bool:
-	"""Was an apply requested (``last_sync_requested_at`` present and parseable)
-	but so long ago it has aged out of ``_APPLYING_SOFT_WINDOW_S``? This is the
-	STUCK signal for jarvis#825, and the deliberate mirror image of
-	``_apply_recently_requested``: that one returns False both for a recent apply
-	and for a workspace that never enqueued one (null/unparseable), collapsing two
-	very different states. Here we need the third: there IS a real apply on record,
-	it is just not converging. A null/unparseable stamp means no apply to be stuck
-	on, so it returns False and the caller keeps the hard setup-wizard reason. Runs
-	on the hot is_ready_for_chat path, so an unparseable value fails closed rather
-	than raising."""
-	if not requested_at:
-		return False
-	try:
-		return frappe.utils.time_diff_in_seconds(frappe.utils.now(), requested_at) >= _APPLYING_SOFT_WINDOW_S
-	except Exception:
-		return False
+		return None
 
 
 def _write_is_durable() -> bool:
@@ -1037,8 +1018,8 @@ def _not_ready_verdict(settings, raw: dict, hard_reason: str) -> dict:
 # can tell them apart is _has_been_chat_ready's durable, authority-bound proof.
 #
 # TIME-BOXED (review finding 1): softening to llm_applying also requires
-# last_sync_requested_at to be present and recent (_apply_recently_requested,
-# within _APPLYING_SOFT_WINDOW_S). Without a bound, a STUCK first apply - the
+# last_sync_requested_at to be present and recent (_apply_age_seconds below
+# _APPLYING_SOFT_WINDOW_S). Without a bound, a STUCK first apply - the
 # fleet-agent down, an apply that never converges and never writes a terminal
 # "failed:" status - would stay soft indefinitely with no way out: the reload
 # it was built to fix would instead trap the customer in a chat that can never
@@ -1065,18 +1046,20 @@ def _provisioning_verdict(raw: dict, hard_reason: str) -> dict:
 	"""
 	if not _has_been_chat_ready(raw):
 		return {"ready": False, "reason": hard_reason}
-	requested_at = raw.get(_APPLYING_TIMESTAMP_FIELD)
-	if _apply_recently_requested(requested_at):
+	# One parse+diff for both boundaries (see _apply_age_seconds). None = no apply
+	# on record (never enqueued, or unparseable): a workspace with nothing to be
+	# mid-apply OR stuck on, so it keeps the hard reason.
+	age = _apply_age_seconds(raw.get(_APPLYING_TIMESTAMP_FIELD))
+	if age is None:
+		return {"ready": False, "reason": hard_reason}
+	if age < _APPLYING_SOFT_WINDOW_S:
+		# Requested recently enough to still be plausibly converging: soft.
 		return {"ready": False, "reason": "llm_applying"}
-	# Established workspace, an apply WAS requested (timestamp present and
-	# parseable) but has aged out of the soft window without converging: a stuck
-	# apply (jarvis#825). Surface an honest, retryable state instead of silently
-	# routing an established, chatting customer to the setup wizard. An
-	# absent/unparseable timestamp is a workspace with no apply to be stuck on, so
-	# it keeps the hard reason - exactly the pre-#825 fallback.
-	if _apply_requested_but_stale(requested_at):
-		return {"ready": False, "reason": "llm_apply_stuck"}
-	return {"ready": False, "reason": hard_reason}
+	# An apply WAS requested but has aged out of the soft window without
+	# converging: a stuck apply (jarvis#825). Surface an honest, retryable state
+	# instead of silently routing an established, chatting customer to the setup
+	# wizard.
+	return {"ready": False, "reason": "llm_apply_stuck"}
 
 
 def _llm_missing_verdict(settings) -> dict:

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -380,9 +380,10 @@
 						v-if="readinessCta"
 						type="button"
 						class="jvp-btn-solid jvp-notice-cta"
+						:disabled="retryingApply"
 						@click="goReadinessCta"
 					>
-						{{ readinessCta.label }}
+						{{ retryingApply ? "Retrying…" : readinessCta.label }}
 					</button>
 				</div>
 			</div>
@@ -615,6 +616,7 @@ import {
 	transcribeAudio,
 	getChatUiSettings,
 	isReadyForChat,
+	resyncLlm,
 } from "./panel_api.mjs";
 
 const props = defineProps({
@@ -902,6 +904,9 @@ const readinessNotice = ref("");
 // or null. A member never gets one: canOnboard below gates it off before the
 // widget even asks for actionable copy.
 const readinessCta = ref(null);
+// True while a Retry (resyncLlm, for a stuck apply - jarvis#825) is in flight, so
+// the CTA shows progress and cannot be double-clicked into the server's throttle.
+const retryingApply = ref(false);
 // Only an admin who can actually reach the wizard gets the CTA button in the
 // gate state, mirroring OnboardingGate.vue's isSystemManager split. Read off
 // frappe.boot.user.roles - core Frappe bootinfo (User.load_user), already
@@ -1215,11 +1220,65 @@ function goOnboard() {
 	window.location.assign(ONBOARDING_URL);
 }
 
-// The degraded banner's CTA (readinessCta), when present. Same full-navigation
-// pattern as goOnboard above - the AI models settings pane lives in the SPA,
-// not this widget.
+// The degraded banner's CTA (readinessCta), when present. Two shapes:
+//   { href }   navigate to a settings pane in the SPA (e.g. "Connect a model").
+//   { action } an in-place action handled here (e.g. "resync" for a stuck apply,
+//              jarvis#825) - no navigation, so the customer stays in the panel.
 function goReadinessCta() {
-	if (readinessCta.value?.href) window.location.assign(readinessCta.value.href);
+	const cta = readinessCta.value;
+	if (!cta) return;
+	if (cta.href) {
+		window.location.assign(cta.href);
+		return;
+	}
+	if (cta.action === "resync") retryApply();
+}
+
+// Re-fetch the readiness verdict and re-render the degraded banner from it. Pulled
+// out of onMounted so a Retry can reuse it. Fails OPEN, same as classifyReadiness(null):
+// a flaky/unreachable check must never strand a real user behind the gate.
+function refreshReadiness() {
+	return isReadyForChat()
+		.then((r) => {
+			readiness.value = classifyReadiness(r);
+			if (readiness.value === "degraded") {
+				// canOnboard already matches JARVIS_ADMIN_ROLES (System Manager or
+				// Jarvis Admin - jarvis/permissions.py), so it doubles as the
+				// "can this person actually reconnect a model" check here.
+				const actionable = degradedActionable(r, brandName, canOnboard);
+				readinessNotice.value = actionable.text;
+				readinessCta.value = actionable.cta;
+			} else {
+				readinessNotice.value = "";
+				readinessCta.value = null;
+			}
+		})
+		.catch(() => {
+			readiness.value = classifyReadiness(null);
+			readinessNotice.value = "";
+			readinessCta.value = null;
+		});
+}
+
+// jarvis#825: re-drive the saved AI config for a stuck apply, then re-read
+// readiness so the banner reflects the new state in place. resyncLlm probes admin
+// first (converged -> nothing to do) and only re-pushes otherwise, restamping the
+// apply, which flips the reason back to llm_applying: so a successful retry swaps
+// this "didn't finish" banner for the quiet "Updating your AI configuration" one.
+// All outcomes (converged/queued/throttled) resolve the same way - just re-check.
+async function retryApply() {
+	if (retryingApply.value) return;
+	retryingApply.value = true;
+	try {
+		await resyncLlm();
+	} catch (e) {
+		/* a throttle or transient error still resolves by re-checking below */
+	}
+	try {
+		await refreshReadiness();
+	} finally {
+		retryingApply.value = false;
+	}
 }
 
 // The mic button lives in the footer, and the footer unmounts the moment the
@@ -1582,29 +1641,10 @@ onMounted(() => {
 			sttEnabled.value = false;
 		});
 	// Resolved once per mount, not on every open/keystroke - see the `readiness`
-	// declaration above for why that is still "once per Desk page load".
-	isReadyForChat()
-		.then((r) => {
-			readiness.value = classifyReadiness(r);
-			if (readiness.value === "degraded") {
-				// canOnboard already matches JARVIS_ADMIN_ROLES (System Manager or
-				// Jarvis Admin - jarvis/permissions.py), so it doubles as the
-				// "can this person actually reconnect a model" check here.
-				const actionable = degradedActionable(r, brandName, canOnboard);
-				readinessNotice.value = actionable.text;
-				readinessCta.value = actionable.cta;
-			} else {
-				readinessNotice.value = "";
-				readinessCta.value = null;
-			}
-		})
-		.catch(() => {
-			// Fail OPEN, same as classifyReadiness(null): a flaky/unreachable check
-			// must never strand a real user behind the gate.
-			readiness.value = classifyReadiness(null);
-			readinessNotice.value = "";
-			readinessCta.value = null;
-		});
+	// declaration above for why that is still "once per Desk page load". A Retry
+	// (goReadinessCta -> resync) re-runs this same fetch so the banner reflects the
+	// new verdict without a page reload.
+	refreshReadiness();
 });
 
 onBeforeUnmount(() => {

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1266,6 +1266,11 @@ function refreshReadiness() {
 // apply, which flips the reason back to llm_applying: so a successful retry swaps
 // this "didn't finish" banner for the quiet "Updating your AI configuration" one.
 // All outcomes (converged/queued/throttled) resolve the same way - just re-check.
+//
+// The SPA (frontend/src/views/ChatView.vue) carries a near-identical retryApply for
+// the same state. The two cannot share a helper - this widget is plain .mjs served
+// into Desk and cannot import from frontend/src (see panel_readiness.mjs's header) -
+// so keep the retry semantics in sync by hand.
 async function retryApply() {
 	if (retryingApply.value) return;
 	retryingApply.value = true;

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -8,6 +8,7 @@
 const CHAT = "jarvis.chat.api.";
 const ACTIONS = "jarvis.chat.actions_api.";
 const ACCOUNT = "jarvis.account.";
+const ONBOARDING = "jarvis.onboarding.";
 
 function call(method, args) {
   return frappe.call({ method, args: args || {} }).then((r) => r.message);
@@ -118,3 +119,9 @@ export const listPendingConfirmations = (conversation) =>
 // Chat-readiness verdict ({ready, reason, detail, billing_notice}) - see
 // panel_readiness.mjs for how the panel classifies it into gate/degraded/ready.
 export const isReadyForChat = () => call(ACCOUNT + "is_ready_for_chat");
+
+// Re-drive the saved AI config through admin - the lever for a stuck apply
+// (reason "llm_apply_stuck", jarvis#825). Probes admin first, only re-pushes if
+// not already serving, throttled 180s server-side. Admin-gated (require_jarvis_admin);
+// the panel only shows the Retry CTA to a Jarvis Admin / System Manager.
+export const resyncLlm = () => call(ONBOARDING + "resync_llm");

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -49,6 +49,10 @@ import { AI_MODELS_SETTINGS_URL } from "./config.mjs";
 // with a quiet heads-up instead of replacing it with the setup nudge. Keep
 // this file and readiness.js's own "deliberately ABSENT" note in sync BY HAND -
 // do not "fix" this by adding it to the set.
+// "llm_apply_stuck" (jarvis#825) is deliberately ABSENT too, same reasoning: an
+// established workspace whose apply hung falls through to "degraded" and gets an
+// honest banner + admin Retry (degradedActionable below), never the whole-panel
+// setup gate. Keep this in sync with readiness.js by hand.
 const NOT_ONBOARDED_REASONS = new Set([
   "signup",
   "llm_setup",
@@ -129,6 +133,20 @@ const unconfirmedDegraded = (agentName) =>
 const APPLYING_DEGRADED =
   "Updating your AI configuration. Chat may be briefly unavailable while this finishes.";
 
+//   llm_apply_stuck         (jarvis#825) the llm_applying window aged out without
+//                           the apply ever finishing - a genuinely stuck apply,
+//                           not a still-converging one. The MEMBER copy here names
+//                           the state and points at an admin; the ADMIN gets the
+//                           actionable copy + Retry via degradedActionable below,
+//                           the one reason besides llm_credentials that opts into a
+//                           CTA. Same "your last AI update didn't finish" framing
+//                           as ChatView.vue's SPA banner - keep the two in sync BY
+//                           HAND.
+const APPLY_STUCK_MEMBER =
+  "Your last AI update didn't finish, so replies may fail. Ask your administrator to retry it.";
+const APPLY_STUCK_ADMIN =
+  "Your last AI update didn't finish, so replies may fail. Retry to finish it.";
+
 export function degradedMessage(resp, agentName = "Jarvis") {
   const reason = (resp && resp.reason) || "";
   const detail = (resp && resp.detail) || "";
@@ -138,6 +156,7 @@ export function degradedMessage(resp, agentName = "Jarvis") {
   if (reason === "readiness_unconfirmed")
     return detail || unconfirmedDegraded(brand);
   if (reason === "llm_applying") return APPLYING_DEGRADED;
+  if (reason === "llm_apply_stuck") return APPLY_STUCK_MEMBER;
   return GENERIC_DEGRADED;
 }
 
@@ -169,6 +188,15 @@ export function degradedActionable(
     return {
       text: "No AI connected. Connect a model to start chatting again.",
       cta: { label: "Connect a model", href: AI_MODELS_SETTINGS_URL },
+    };
+  }
+  // jarvis#825: a stuck apply an admin CAN act on from here - Retry re-drives the
+  // saved config in place (resyncLlm), so the CTA carries an `action` the panel
+  // handles locally, not an `href` that would navigate away from the chat.
+  if (isAdmin && reason === "llm_apply_stuck") {
+    return {
+      text: APPLY_STUCK_ADMIN,
+      cta: { label: "Retry", action: "resync" },
     };
   }
   return { text: degradedMessage(resp, agentName), cta: null };

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   classifyReadiness,
   degradedMessage,
+  degradedActionable,
   SUSPENDED_FALLBACK,
 } from "./panel_readiness.mjs";
 
@@ -149,4 +150,51 @@ test("degradedMessage: never prints a raw detail for an unrecognised reason", ()
     }),
     generic
   );
+});
+
+// jarvis#825: a stuck apply is a DEGRADED state on an established workspace, never
+// the whole-panel setup gate. If it ever gated, llm_apply_stuck was wrongly added
+// to NOT_ONBOARDED_REASONS - the same regression the llm_credentials test guards.
+test("classifyReadiness: llm_apply_stuck degrades, it does NOT gate", () => {
+  assert.equal(
+    classifyReadiness({ ready: false, reason: "llm_apply_stuck" }),
+    "degraded"
+  );
+});
+
+// The member (non-admin) sees the state named and is pointed at their admin - the
+// Retry endpoint is admin-gated, so a member button would only 403. Distinct from
+// the generic "ask your administrator to finish reconnecting" line.
+test("degradedMessage: a stuck apply tells a member to ask their admin to retry", () => {
+  const msg = degradedMessage({ ready: false, reason: "llm_apply_stuck" });
+  assert.match(msg, /didn't finish/i);
+  assert.match(msg, /administrator/i);
+});
+
+// An admin gets actionable copy plus a Retry CTA carrying an `action` (handled in
+// the panel), NOT an `href` - the retry re-drives the config in place rather than
+// navigating away. This is the one reason besides llm_credentials that opts into a
+// CTA at all.
+test("degradedActionable: an admin gets a Retry action for a stuck apply", () => {
+  const out = degradedActionable(
+    { ready: false, reason: "llm_apply_stuck" },
+    "Jarvis",
+    true
+  );
+  assert.match(out.text, /Retry to finish it/);
+  assert.equal(out.cta.label, "Retry");
+  assert.equal(out.cta.action, "resync");
+  assert.equal(out.cta.href, undefined);
+});
+
+// A member never gets the button (canOnboard gates it off before the panel even
+// asks), so degradedActionable must return no CTA for them and keep the member copy.
+test("degradedActionable: a member gets no CTA for a stuck apply", () => {
+  const out = degradedActionable(
+    { ready: false, reason: "llm_apply_stuck" },
+    "Jarvis",
+    false
+  );
+  assert.equal(out.cta, null);
+  assert.match(out.text, /administrator/i);
 });

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -345,8 +345,11 @@
 			btn.disabled = false;
 			btn.textContent = label;
 		};
+		// Re-read readiness, update the cached boot flags from the fresh verdict,
+		// then re-sync the nudge. Returns the readiness call so the button can be
+		// restored only AFTER this settles - not before.
 		var recheck = function () {
-			frappe.call({
+			return frappe.call({
 				method: READY_METHOD,
 				callback: function (r) {
 					var m = (r && r.message) || null;
@@ -358,12 +361,27 @@
 				},
 			});
 		};
+		// The whole point is that a stuck-apply retry must NOT re-enable the button
+		// until its outcome is on screen: resync -> recheck -> THEN restore. Chaining
+		// restore onto the resync call directly (a sibling of recheck) would flip the
+		// button back mid-recheck, letting an admin double-click straight into the
+		// server's 180s throttle for no benefit. So restore rides recheck's own
+		// completion, and recheck only starts once resync has settled.
+		var afterResync = function () {
+			var rq;
+			try {
+				rq = recheck();
+			} catch (e) {
+				restore();
+				return;
+			}
+			if (rq && rq.always) rq.always(restore);
+			else restore();
+		};
 		try {
 			var req = frappe.call({ method: RESYNC_METHOD });
-			if (req && req.then) req.then(recheck, recheck);
-			else recheck();
-			if (req && req.always) req.always(restore);
-			else restore();
+			if (req && req.then) req.then(afterResync, afterResync);
+			else afterResync();
 		} catch (e) {
 			restore();
 		}

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -31,6 +31,10 @@
 	// Same check the SPA gate and the widget popup use, so all three surfaces
 	// agree on what "set up" means.
 	var READY_METHOD = "jarvis.account.is_ready_for_chat";
+	// The stuck-apply Retry lever (jarvis#825). Admin-gated server-side
+	// (require_jarvis_admin, which accepts System Manager - the same role this
+	// nudge is already gated to), probe-first and throttled 180s.
+	var RESYNC_METHOD = "jarvis.onboarding.resync_llm";
 	// Deep link to the AI models settings tab, used by the reconnect variant's
 	// CTA. Must match config.mjs's AI_MODELS_SETTINGS_URL: this standalone desk
 	// bundle is loaded via app_include_js and cannot import from the widget
@@ -225,6 +229,24 @@
 				href: AI_MODELS_SETTINGS_URL,
 			};
 		}
+		// jarvis#825: an established workspace whose last AI update got stuck (the
+		// soft llm_applying window aged out without converging). Like llm_credentials
+		// this reads jarvis_onboarded === false but is NOT a never-set-up workspace,
+		// so the generic "Set up Jarvis" pitch below would be actively wrong. Honest
+		// copy + a Retry that re-drives the saved config IN PLACE (resync) rather than
+		// sending them to the wizard - `action` instead of `href`, handled in inject().
+		if (reason === "llm_apply_stuck") {
+			return {
+				name: agentName,
+				aria: "Retry " + agentName + " update",
+				text:
+					"Your last " +
+					agentName +
+					" update didn't finish, so replies may fail. Retry to finish it.",
+				ctaLabel: "Retry",
+				action: "resync",
+			};
+		}
 		// Every other reason (never onboarded, or an empty/unknown reason from an
 		// older boot payload) keeps the original pitch and destination.
 		return {
@@ -277,10 +299,24 @@
 				t.textContent = variant.text;
 				b.appendChild(t);
 
-				var cta = document.createElement("a");
-				cta.className = "jvn-btn";
-				cta.href = variant.href;
-				cta.textContent = variant.ctaLabel;
+				// An in-place action (jarvis#825 Retry) is a <button> that stays on
+				// the page; every other variant is an <a> that navigates to the wizard
+				// or the settings pane.
+				var cta;
+				if (variant.action === "resync") {
+					cta = document.createElement("button");
+					cta.type = "button";
+					cta.className = "jvn-btn";
+					cta.textContent = variant.ctaLabel;
+					cta.addEventListener("click", function () {
+						retryApply(cta, variant.ctaLabel);
+					});
+				} else {
+					cta = document.createElement("a");
+					cta.className = "jvn-btn";
+					cta.href = variant.href;
+					cta.textContent = variant.ctaLabel;
+				}
 				b.appendChild(cta);
 				return b;
 			})
@@ -292,6 +328,45 @@
 		wrap.appendChild(tail);
 
 		document.body.appendChild(wrap);
+	}
+
+	// jarvis#825 Retry: re-drive the saved AI config, then re-read readiness and
+	// re-sync the nudge from the fresh verdict. A successful resync flips the reason
+	// back to llm_applying (or clears it once ready), and shouldShow() suppresses the
+	// nudge for llm_applying - so the bubble visibly goes away on success rather than
+	// leaving stale "didn't finish" copy on screen. frappe.boot.jarvis_ready_reason is
+	// a cached boot value that reverify() never rewrites (it only corrects the
+	// onboarded flag false->true), so this updates it by hand from the fresh check.
+	function retryApply(btn, label) {
+		if (btn.disabled) return;
+		btn.disabled = true;
+		btn.textContent = "Retrying…";
+		var restore = function () {
+			btn.disabled = false;
+			btn.textContent = label;
+		};
+		var recheck = function () {
+			frappe.call({
+				method: READY_METHOD,
+				callback: function (r) {
+					var m = (r && r.message) || null;
+					if (m) {
+						frappe.boot.jarvis_onboarded = !!m.ready;
+						frappe.boot.jarvis_ready_reason = m.reason || "";
+					}
+					sync();
+				},
+			});
+		};
+		try {
+			var req = frappe.call({ method: RESYNC_METHOD });
+			if (req && req.then) req.then(recheck, recheck);
+			else recheck();
+			if (req && req.always) req.always(restore);
+			else restore();
+		} catch (e) {
+			restore();
+		}
 	}
 
 	function sync() {

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -910,7 +910,10 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 	exit stands in for all three, the same reasoning TestRejectedSyncVerdictWiring
 	above uses for its own single-leg pin. Also pins review finding 1's
 	time-box: (b) and (d) below are the same established-workspace state,
-	differing only in how recently the apply was requested."""
+	differing only in how recently the apply was requested - (b) recent rides
+	the soft llm_applying reason, (d) stale surfaces the retryable
+	llm_apply_stuck (jarvis#825), and (e) an established marker with no apply on
+	record at all keeps the hard reason."""
 
 	_FIELDS = (
 		"chat_was_ready_at",
@@ -992,13 +995,15 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 		self.assertFalse(out["ready"])
 		self.assertEqual(out["reason"], "llm_applying")
 
-	def test_established_tenant_stuck_apply_past_the_soft_window_gates_to_setup(self):
-		"""(d) review finding 1: an established workspace whose apply was
-		requested LONGER AGO than _APPLYING_SOFT_WINDOW_S - a stuck first-apply
-		that never converges and never writes a terminal status - must age out of
-		the soft reason and fall back to the hard one, pinning the time-box in
-		the direction (b) does not cover. Otherwise a workspace whose fleet-agent
-		never comes back would stay soft indefinitely with no way out."""
+	def test_established_tenant_stuck_apply_past_the_soft_window_is_llm_apply_stuck(self):
+		"""(d) jarvis#825: an established workspace whose apply was requested LONGER
+		AGO than _APPLYING_SOFT_WINDOW_S - a stuck first-apply that never converges
+		and never writes a terminal status - ages out of the soft llm_applying
+		reason. Before #825 it fell back to the HARD reason and silently routed the
+		established customer to the setup wizard; now it surfaces its own honest,
+		retryable ``llm_apply_stuck`` instead. The distinction from (e) below is the
+		whole point: there IS an apply on record (a present, parseable timestamp),
+		it just never finished, so there is something concrete to retry."""
 		raw = account._settings_raw(account._GATE_STATE_FIELDS)
 		anchor = account._authority_anchor(raw)
 		stale = frappe.utils.add_to_date(
@@ -1009,6 +1014,26 @@ class TestEstablishedWorkspaceStaysInAppMidApply(FrappeTestCase):
 				"chat_was_ready_at": "2026-01-01 00:00:00",
 				"chat_ready_authority": anchor,
 				"last_sync_requested_at": frappe.utils.get_datetime_str(stale),
+			}
+		)
+		out = account.is_ready_for_chat()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "llm_apply_stuck")
+
+	def test_established_tenant_with_no_apply_on_record_gates_to_setup(self):
+		"""(e) jarvis#825 guard: an established workspace (durable marker set, anchor
+		still matches) but whose last_sync_requested_at is ABSENT has no apply to be
+		stuck on, so it must keep the HARD reason - NOT llm_apply_stuck. This is what
+		separates "an apply hung" (retryable, (d)) from "there is simply no apply
+		here" (route to setup). A null stamp is the default this class's setUp writes,
+		so this pins that an established marker alone never fabricates a stuck apply."""
+		raw = account._settings_raw(account._GATE_STATE_FIELDS)
+		anchor = account._authority_anchor(raw)
+		self._write(
+			{
+				"chat_was_ready_at": "2026-01-01 00:00:00",
+				"chat_ready_authority": anchor,
+				"last_sync_requested_at": None,
 			}
 		)
 		out = account.is_ready_for_chat()


### PR DESCRIPTION
A stuck model apply now shows an honest "Your last AI update didn't finish" state with a Retry button, instead of silently bouncing an established customer to the setup wizard.

When an established workspace's model apply hangs (fleet-agent down, a sync that never converges and never writes a terminal failure), the soft `llm_applying` window ages out. Before this, it fell back to the hard provisioning reason and routed the customer to the setup wizard with no explanation. Now that exact case surfaces a distinct, retryable `llm_apply_stuck` reason across all three readiness surfaces (SPA chat banner, floating Desk widget, Desk onboarding nudge).

Retry wires the existing but previously unwired `jarvis.onboarding.resync_llm`: it probes admin first and only re-pushes if the container is not already serving, throttled 180s server-side, so it never double-fires a still-running apply. A successful retry restamps the apply and flips the reason back to `llm_applying`, so the stuck banner is replaced by the quiet "Updating" one. The Retry button is admin-gated (matching `require_jarvis_admin`); non-admins see the state named and are pointed at their admin.

Closes #825 (will need manual close — PRs merge to `develop`, not the default branch).

<details>
<summary>Design notes</summary>

- Backend (`account.py`): new `_apply_requested_but_stale` helper + a branch in `_provisioning_verdict`. Stuck requires `_has_been_chat_ready` AND a `last_sync_requested_at` that is **present, parseable, and past `_APPLYING_SOFT_WINDOW_S`**. An absent/unparseable stamp = no apply on record, so it keeps the hard setup-wizard reason (pinned by test (e)).
- The Desk onboarding nudge previously suppressed only `llm_applying`; the new reason would otherwise have shown the wrong "Set up Jarvis" pitch, so it's handled explicitly with its own copy + in-place Retry.
- `llm_apply_stuck` is deliberately kept OUT of both `NOT_ONBOARDED_REASONS` sets (SPA + widget, hand-duplicated) so an established workspace keeps its chat + history rather than hitting the full-screen gate.

Tests: backend verdict branch (stuck vs no-apply-on-record); SPA accessor, gate exclusion, banner order; widget classify/message/actionable. Full frontend suite (1233) and `test_account` (105) green; pre-commit clean.
</details>
