### PR TITLE
fix(telemetry): redact JSON values but keep keys legible (#745)

### DIFF
--- a/jarvis/api_errors.py
+++ b/jarvis/api_errors.py
@@ -79,10 +79,11 @@ _LONG_BLOB_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{24,}\b")
 _ID_RE = re.compile(r"\b(?=[A-Z0-9]*[A-Z])(?=[A-Z0-9]*\d)[A-Z0-9]{10,23}\b")
 # decimals, thousand-grouped, or 4+ digit runs = amounts / quantities / ids
 _NUMBER_RE = re.compile(r"(?<![\w.])(?:\d[\d,]*\.\d+|\d{1,3}(?:,\d{3})+|\d{4,})(?![\w])")
-# any quoted literal - redacted unconditionally. ERP messages quote entity names
-# ('Tata Steel Ltd') that carry no digit and sit under 24 chars, so the old
-# length/digit heuristic leaked them. A traceback's `File "..."` path is dropped
-# too; the frame's function name + line survive unquoted, which is what triage needs.
+# any quoted literal - redacted unless it sits in JSON object-key position (see
+# _redact_quoted). ERP messages quote entity names ('Tata Steel Ltd') that carry
+# no digit and sit under 24 chars, so the old length/digit heuristic leaked them.
+# A traceback's `File "..."` path is dropped too; the frame's function name +
+# line survive unquoted, which is what triage needs.
 _QUOTED_RE = re.compile(r"(['\"])((?:\\.|(?!\1).)*?)\1")
 # a run of 2+ Capitalised words - the shape of an *unquoted* ERP entity name
 # ("Employee Priya Sharma", "Supplier Reliance Industries"). Most
@@ -94,9 +95,19 @@ _NAME_RUN_RE = re.compile(r"\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z0-9]*){1,}\b")
 
 
 def _redact_quoted(m: re.Match) -> str:
-	# Every quoted literal is a candidate data value; redact unconditionally.
+	# Preserve a quoted literal ONLY in true JSON object-key position: preceded
+	# by '{' or ',' (start of an object/member) and followed by ':' (the key/value
+	# separator), whitespace either side allowed. A one-sided "followed by ':'"
+	# check is not enough - ordinary prose like "Item 'widget': not found" would
+	# leak the value, since colons show up outside JSON too. Every other quoted
+	# literal, including a VALUE that happens to look like a key (e.g. a string
+	# value "provider"), is a candidate data value and is redacted unconditionally.
 	# Keeping "path-shaped" quotes was tempting but unsafe - a base64 secret
 	# contains '/' too, and _LONG_BLOB_RE already drops long paths regardless.
+	head = m.string[: m.start()].rstrip()
+	tail = m.string[m.end() :].lstrip()
+	if head.endswith(("{", ",")) and tail.startswith(":"):
+		return m.group(0)
 	return m.group(1) + "[VAL]" + m.group(1)
 
 
@@ -104,12 +115,13 @@ def _scrub_error_text(text: str | None, *, keep_email: str | None = None) -> str
 	"""Redact PII / ERP values from a free-text error message or traceback.
 
 	Deliberately conservative on structure (keeps error codes, class names, field
-	names, frame functions) while removing values: emails (except the reporting user's
-	own), secret-shaped tokens, long hashes, amounts / quantities / long ids, and
-	both *quoted* and *bare capitalised* entity names. The name redaction is
-	blunt on purpose - the failure mode of a blocklist here (a leaked customer /
-	supplier / employee name crossing benches to the control plane) is worse than
-	over-redacting a doctype label."""
+	names, frame functions, and JSON object keys) while removing values: emails
+	(except the reporting user's own), secret-shaped tokens, long hashes, amounts /
+	quantities / long ids, and both *quoted* and *bare capitalised* entity names.
+	A quoted literal in JSON key position (see _redact_quoted) survives; every
+	quoted value does not. The name redaction is blunt on purpose - the failure
+	mode of a blocklist here (a leaked customer / supplier / employee name crossing
+	benches to the control plane) is worse than over-redacting a doctype label."""
 	if not text:
 		return ""
 	out = str(text)
@@ -139,7 +151,7 @@ _NORM_DIGITS = re.compile(r"\d+")
 #: change to _scrub_error_text would silently re-key the whole admin feed. Bump
 #: this constant in the SAME commit as any scrubber change, so the re-key becomes
 #: an intentional, dated event and the old rows age out via the 90-day prune.
-_SCRUB_VERSION = "1"
+_SCRUB_VERSION = "2"
 
 
 def _fingerprint(error_code: str, error_class: str, message: str, surface: str) -> str:

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -4,6 +4,7 @@ jarvis-only Error Log reader, and the self-gating push."""
 from __future__ import annotations
 
 import contextlib
+import json
 import time
 from unittest.mock import Mock, patch
 
@@ -113,6 +114,50 @@ class TestScrub(ApiErrorsBase):
 
 	def test_empty_is_safe(self):
 		self.assertEqual(api_errors._scrub_error_text(None), "")
+
+	def test_json_keys_stay_legible_values_redacted(self):
+		# #745: a payment_transition telemetry record must scrub to legible keys -
+		# only the values become [VAL]. All-string values so the comparison is exact
+		# (a bare int would survive _NUMBER_RE untouched and break the equality).
+		payload = {
+			"event": "payment.captured",
+			"from": "pending",
+			"to": "paid",
+			"code": "200",
+			"provider": "razorpay",
+			"generation": "gen-1",
+			"elapsed_bucket": "0-5s",
+			"source": "webhook",
+		}
+		out = api_errors._scrub_error_text(json.dumps(payload))
+		expected = json.dumps({k: "[VAL]" for k in payload})
+		self.assertEqual(out, expected)
+		# every value is actually gone
+		for v in payload.values():
+			self.assertNotIn(v, out)
+
+	def test_value_that_looks_like_a_key_is_still_redacted(self):
+		# A quoted VALUE that happens to spell a plausible key name (here the
+		# string "provider" used as a value, not a key) must still be redacted -
+		# position, not content, decides.
+		out = api_errors._scrub_error_text(json.dumps({"note": "provider"}))
+		self.assertEqual(out, '{"note": "[VAL]"}')
+		self.assertNotIn('"provider"', out)
+
+	def test_non_json_quoted_string_still_redacted(self):
+		# No regression on the original PII guarantee: outside JSON there is no
+		# key position at all, so every quoted literal is redacted as before -
+		# including one immediately followed by a colon in ordinary prose (the
+		# naive "redact unless followed by ':'" fix would leak this).
+		out = api_errors._scrub_error_text("Item 'widget': not found")
+		self.assertNotIn("widget", out)
+		self.assertIn("[VAL]", out)
+
+	def test_nested_objects_keep_keys_legible(self):
+		payload = {"outer": {"inner": "secret-value", "sibling": "another"}}
+		out = api_errors._scrub_error_text(json.dumps(payload))
+		expected = json.dumps({"outer": {"inner": "[VAL]", "sibling": "[VAL]"}})
+		self.assertEqual(out, expected)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

The client-error scrubber redacted every quoted JSON literal unconditionally, so keys and values both became `[VAL]`. A `payment_transition` telemetry record (keys `event, from, to, code, provider, generation, elapsed_bucket, source`) landed as `{"[VAL]":"[VAL]", ...}` - unreadable. `_redact_quoted` now spares a quoted literal only when it sits in true JSON object-key position (preceded by `{`/`,`, followed by `:`); every value, including one that happens to look like a key name, is still redacted. `_SCRUB_VERSION` is bumped so the admin feed re-keys deliberately.

Unblocks #746 (an uncaught TypeError) - legible logs now make it diagnosable.

<details>
<summary>Mechanism + test coverage</summary>

`_redact_quoted` peeks at the surrounding text via `m.string` to classify each quoted match by position, not content: `head.endswith(("{", ","))` and `tail.startswith(":")`. A one-sided "followed by `:`" check would leak ordinary prose like `Item 'widget': not found`, so both sides are checked.

Added to `TestScrub` in `jarvis/tests/test_api_errors.py`:
- the exact `payment_transition` shape scrubs to legible keys, `[VAL]` values
- a quoted *value* that looks like a key (e.g. `"provider"` as a value) is still redacted
- non-JSON quoted strings, including one followed by a colon, are still redacted (no PII regression)
- nested objects keep keys legible at every level

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
</details>