### PR TITLE
fix(wiki): scope-filter voice-note merge page reads (#732)

### DIFF
--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -822,7 +822,7 @@ def _ingest_note(note_name: str) -> None:
 		return
 
 	entities = _note_entities(note)
-	suggested, existing = _pages_for_prompt(entities)
+	suggested, existing = _pages_for_prompt(entities, note.owner)
 	updates = _extract_page_updates(note, entities, suggested, existing)
 	if updates is None:
 		return  # extraction failed (logged); stays New for the sweep
@@ -884,10 +884,12 @@ def _note_entities(note) -> list[dict]:
 	]
 
 
-def _pages_for_prompt(entities: list[dict]) -> tuple[list[dict], list[dict]]:
+def _pages_for_prompt(entities: list[dict], user: str) -> tuple[list[dict], list[dict]]:
 	"""(suggested page refs for the note's entities, existing page rows for
-	those refs) — both handed to the merge prompt so the model reuses our
-	slug conventions and sees the current bodies it must merge into."""
+	those refs), both handed to the merge prompt so the model reuses our
+	slug conventions and sees the current bodies it must merge into. ``user`` is
+	the human whose statement produced the note (the ingest write actor), so the
+	read filter and the later write attribution name the same principal."""
 	from jarvis.chat import entities as entities_mod
 
 	suggested: list[dict] = []
@@ -902,9 +904,26 @@ def _pages_for_prompt(entities: list[dict]) -> tuple[list[dict], list[dict]]:
 	rows = frappe.get_all(
 		WIKI,
 		filters={"slug": ["in", [s["slug"] for s in suggested]]},
-		fields=["slug", "title", "page_type", "ref_doctype", "ref_name", "summary", "body_md"],
+		fields=[
+			"slug",
+			"title",
+			"page_type",
+			"ref_doctype",
+			"ref_name",
+			"summary",
+			"body_md",
+			"scope",
+			"target_role",
+			"target_user",
+		],
 		limit_page_length=len(suggested),
 	)
+	# Scope visibility (belt and braces, mirroring wiki_clause): entity-derived
+	# slugs are unsuffixed so only Org pages should match, but an Org page
+	# NARROWED to User/Role scope after creation keeps its org-convention slug
+	# (the audience suffix is applied at create time only), so it still matches
+	# here. Never inline a body ``user`` cannot read into the merge prompt.
+	rows = [r for r in rows if wiki_permissions.can_read_page(r, user)]
 	for r in rows:
 		r["body_md"] = _body_for_prompt(r.get("body_md"))
 	return suggested, rows

--- a/jarvis/tests/test_wiki.py
+++ b/jarvis/tests/test_wiki.py
@@ -16,8 +16,9 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis import api
 from jarvis.chat import entities as entities_mod
-from jarvis.chat import wiki
+from jarvis.chat import wiki, wiki_permissions
 from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError, PermissionDeniedError
+from jarvis.permissions import JARVIS_USER_ROLE
 from jarvis.tools.read_wiki import read_wiki
 from jarvis.tools.update_wiki import update_wiki
 
@@ -1110,3 +1111,90 @@ class TestWikiKillSwitchTools(FrappeTestCase):
 		hint = api._ERROR_HINTS.get("FeatureDisabledError", "")
 		self.assertTrue(hint)
 		self.assertNotIn("permission", hint.lower())
+
+
+class TestPagesForPromptScopeFilter(FrappeTestCase):
+	"""Issue #732: the voice-note merge prompt must never inline the body of a
+	page the note's owner cannot read. An Org page NARROWED to User/Role scope
+	AFTER creation keeps its unsuffixed, org-convention slug (the audience
+	suffix is applied at create time only), so ``_pages_for_prompt`` matches it
+	by slug and would otherwise read a body the owner must not see."""
+
+	OWNER = "wiki732-owner@test.invalid"
+	OTHER = "wiki732-other@test.invalid"
+	ENTITIES = [{"doctype": "Customer", "name": ALPHA}]
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+		for email in (self.OWNER, self.OTHER):
+			if not frappe.db.exists("User", email):
+				frappe.get_doc(
+					{
+						"doctype": "User",
+						"email": email,
+						"first_name": email.split("@")[0],
+						# Jarvis User (not System Manager): a real desk user who is
+						# NOT an SM, so can_read_page does not short-circuit True.
+						"user_type": "System User",
+						"send_welcome_email": 0,
+						"roles": [{"role": JARVIS_USER_ROLE}],
+					}
+				).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		_delete_test_pages()
+		frappe.set_user("Administrator")
+
+	def _make_org_page(self):
+		# The entity-derived slug is exactly what _pages_for_prompt computes, so
+		# the planted Org page really is the one the merge lookup would match.
+		ref = entities_mod.page_ref_for("Customer", ALPHA)
+		self.assertEqual(ref["slug"], ALPHA_SLUG)
+		return _make_page(
+			ALPHA_SLUG,
+			ALPHA,
+			summary="Org summary.",
+			body_md="## Secret\n\nMargin is 42 percent.",
+			scope="Org",
+		)
+
+	def _narrow(self, doc, target_user):
+		doc.scope = "User"
+		doc.target_user = target_user
+		doc.save(ignore_permissions=True)
+		# Premise of the leak: narrowing after create leaves the slug unsuffixed,
+		# so the merge lookup still matches it by the org-convention slug.
+		self.assertEqual(doc.slug, ALPHA_SLUG)
+		return doc
+
+	def test_org_page_is_inlined_for_a_user_who_can_read_it(self):
+		# Under-block guard: a plain Org page must still reach the prompt whole.
+		self._make_org_page()
+		self.assertTrue(
+			wiki_permissions.can_read_page(frappe.get_doc(WIKI_DT, ALPHA_SLUG), self.OWNER)
+		)
+		suggested, rows = wiki._pages_for_prompt(self.ENTITIES, self.OWNER)
+		self.assertEqual([s["slug"] for s in suggested], [ALPHA_SLUG])
+		self.assertEqual([r["slug"] for r in rows], [ALPHA_SLUG])
+		self.assertIn("Margin is 42 percent", rows[0]["body_md"])
+
+	def test_page_narrowed_to_another_user_is_not_inlined(self):
+		# The confidentiality direction: a body the owner cannot read is gone.
+		doc = self._narrow(self._make_org_page(), self.OTHER)
+		# Precondition: the note owner genuinely cannot read it (and is not SM),
+		# so a passing test proves the filter, not an incidental SM bypass.
+		self.assertFalse(wiki_permissions.can_read_page(doc, self.OWNER))
+		suggested, rows = wiki._pages_for_prompt(self.ENTITIES, self.OWNER)
+		# The ref is still suggested (slug convention is public), but its body is
+		# withheld, which degenerates to the append-only "no existing page" case.
+		self.assertEqual([s["slug"] for s in suggested], [ALPHA_SLUG])
+		self.assertEqual(rows, [])
+
+	def test_page_narrowed_to_the_owner_is_still_inlined(self):
+		# No over-block: a page narrowed to the OWNER'S OWN scope stays visible.
+		doc = self._narrow(self._make_org_page(), self.OWNER)
+		self.assertTrue(wiki_permissions.can_read_page(doc, self.OWNER))
+		suggested, rows = wiki._pages_for_prompt(self.ENTITIES, self.OWNER)
+		self.assertEqual([r["slug"] for r in rows], [ALPHA_SLUG])
+		self.assertIn("Margin is 42 percent", rows[0]["body_md"])

--- a/jarvis/tests/test_wiki.py
+++ b/jarvis/tests/test_wiki.py
@@ -1171,9 +1171,7 @@ class TestPagesForPromptScopeFilter(FrappeTestCase):
 	def test_org_page_is_inlined_for_a_user_who_can_read_it(self):
 		# Under-block guard: a plain Org page must still reach the prompt whole.
 		self._make_org_page()
-		self.assertTrue(
-			wiki_permissions.can_read_page(frappe.get_doc(WIKI_DT, ALPHA_SLUG), self.OWNER)
-		)
+		self.assertTrue(wiki_permissions.can_read_page(frappe.get_doc(WIKI_DT, ALPHA_SLUG), self.OWNER))
 		suggested, rows = wiki._pages_for_prompt(self.ENTITIES, self.OWNER)
 		self.assertEqual([s["slug"] for s in suggested], [ALPHA_SLUG])
 		self.assertEqual([r["slug"] for r in rows], [ALPHA_SLUG])


### PR DESCRIPTION
## Summary

Closes #732. The voice-note merge prompt inlined wiki page bodies with no visibility check. `_pages_for_prompt` looked pages up by entity-derived slug and handed their `body_md` to the merge model. An Org page narrowed to User or Role scope after creation keeps its unsuffixed, org-convention slug (the audience suffix is applied at create time only), so the lookup matched it and read a body the note's owner must not see. This applies the same `can_read_page` guard the `wiki_clause` sibling already uses, keyed on `note.owner`.

<details>
<summary>Mechanism and principal choice</summary>

`_pages_for_prompt(entities, user)` now fetches `scope`/`target_role`/`target_user` and filters rows through `wiki_permissions.can_read_page(row, user)`, mirroring the sibling at `wiki.py` `wiki_clause`. The principal is `note.owner`, not `frappe.session.user`: `_ingest_note` also runs from the Administrator-driven daily `voice_facts` sweep, where a session-user filter would short-circuit True and leave the leak on the backstop path. `note.owner` is also the write actor passed to `apply_extracted_page_updates`, so read visibility and write attribution name the same principal. Withholding a hidden row degenerates to the "no existing page" case, which #488 already makes append-only, so the fix cannot cause a destructive write.

Tests (`TestPagesForPromptScopeFilter`) prove both directions: a page narrowed to another user is not inlined (and assert the owner genuinely cannot read it, non-SM), a page narrowed to the owner's own scope still is, and a plain Org page still is. Each asserts the slug stays unsuffixed after the post-create narrow, proving the premise.
</details>

## Pre-merge checklist

- [x] New/changed behavior has tests
- [x] I self-reviewed the diff
- [ ] **CI is green** (hosted Actions is the gate for this public repo)
