### PR TITLE
fix(chat): release Finishing affordance when the visible set completes (#737)

### DIFF
--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -3,7 +3,11 @@
 Short RQ job enqueued by settlement (D3 S6) and re-enqueued by the pump watchdog
 for a ``finalizing`` turn (R-13). It drives the turn's owed ``Jarvis Turn Effect``
 rows — the closed set settlement fixed atomically (OAR-9) — to ``done``, then flips
-``finalizing -> done`` and publishes ``message:enriched`` (SUX-7).
+``finalizing -> done``. jarvis#737: ``message:enriched`` (SUX-7) no longer waits on
+that flip; it publishes as soon as the VISIBLE effects are done, so a stalled
+invisible effect (usage, telemetry) never holds the "Finishing..." affordance up
+while everything the user can perceive already landed (turn_state.VISIBLE_EFFECT_NAMES,
+claim_enrichment_publish for the exactly-once guarantee across the two publish sites).
 
 Every effect is idempotent per ``(turn, effect_name)`` (the ledger's composite PK)
 and best-effort: a failing effect is retried on the next finalize cycle and
@@ -18,7 +22,7 @@ materialize (#45), macro advance + app-learning (#46/#47), auto-title (#50), wik
 nudge (#51), USAGE (#42, R-4: the ≤4.5s gateway poll runs HERE off the critical
 path, with a (turn_id) idempotency guard so a replay can't double-count the soft
 cap), and telemetry (#49). ``run:end`` is settlement's (S5); this publishes
-``message:enriched`` at completion.
+``message:enriched`` once the visible subset of the above is done (jarvis#737).
 
 Wired as the pump's ``enqueue_finalize`` seam target
 (``jarvis.chat.finalize.run_finalize``); tests drive it in-process.
@@ -134,17 +138,40 @@ def run_finalize(run_id: str, relay_target_id: str | None = None, deps=None) -> 
 				pass
 			frappe.log_error(title=f"finalize.{name}", message=frappe.get_traceback())
 
+	# jarvis#737: release the VISIBLE "Finishing..." affordance as soon as the
+	# perceivable effects are done, without waiting on usage/telemetry, which
+	# legitimately keep retrying on their own cadence. This does NOT flip the
+	# turn's state; 'finalizing' -> 'done' below still requires EVERY required
+	# effect, so ledger semantics (the force-done budget, the usage soft-cap
+	# guard) are unchanged, only WHEN the publish fires moves earlier.
+	# claim_enrichment_publish is the single exactly-once gate shared with the
+	# finalize_done branch below, so whichever of the two fires first wins and
+	# the other is a no-op, never a double publish.
+	published = False
+	assistant_message = turn.get("assistant_message")
+	if (
+		state == "finalizing"
+		and owner
+		and assistant_message
+		and ts.visible_effects_done(run_id)
+		and ts.claim_enrichment_publish(run_id)
+	):
+		frappe.db.commit()
+		published = _publish_enriched(run_id, conversation, owner, assistant_message)
+
 	# Success path only: flip finalizing -> done once every required effect is done
-	# (force-done counts as done), then publish message:enriched (SUX-7). An
-	# errored/cancelled turn is already terminal — no finalize_done, no un-settling.
+	# (force-done counts as done, including usage/telemetry). An errored/cancelled
+	# turn is already terminal; no finalize_done, no un-settling.
 	done = False
 	if state == "finalizing" and ts.all_required_effects_done(run_id):
 		v = int(frappe.db.get_value(TURN, run_id, "version") or 0)
 		if ts.finalize_done(run_id, v):
 			frappe.db.commit()
 			done = True
-			_publish_enriched(run_id, conversation, owner, turn.get("assistant_message"))
-	return {"ok": True, "ran": ran, "done": done, "state": state}
+			if not published and ts.claim_enrichment_publish(run_id):
+				frappe.db.commit()
+				published = _publish_enriched(run_id, conversation, owner, assistant_message)
+	return {"ok": True, "ran": ran, "done": done, "published": published, "state": state}
 
 
 def _conversation_owner(conversation: str) -> str | None:

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -107,6 +107,35 @@ EFFECT_NAMES = (
 	"telemetry_flush",
 )
 
+# jarvis#737: the perceivable subset of EFFECT_NAMES, the set the "Finishing..."
+# affordance actually exists to wait for. rich_outputs is attachments/canvas
+# (#43/#44); enrich_cards fills bare-id jarvis-cards with real schema fields
+# BEFORE the client reload a message:enriched publish triggers (finalize.py's
+# _effect_enrich_cards), so publishing ahead of it would show a bare card, a new
+# visible regression; chat_asks materializes the Approval Board fence from the
+# same reply; macro_advance/auto_title/wiki_nudge are the remaining turn-visible
+# side effects; terminal_publish is the CDX-12 terminal re-publish backstop and
+# runs first in the canon, so it is effectively always settled by the time the
+# rest are. usage and telemetry_flush are ledger/telemetry work with no visible
+# surface, and usage is the one with real external I/O (the gateway poll) that
+# legitimately stalls and retries on its own cadence, so they are excluded here
+# and race the affordance instead of gating it. Every EFFECT_NAMES member is
+# assigned to exactly one of the two tuples below (asserted immediately after),
+# so a name added to the canon without a classification fails loudly rather than
+# silently defaulting into either bucket.
+VISIBLE_EFFECT_NAMES = (
+	"terminal_publish",
+	"rich_outputs",
+	"enrich_cards",
+	"chat_asks",
+	"macro_advance",
+	"auto_title",
+	"wiki_nudge",
+)
+INVISIBLE_EFFECT_NAMES = ("usage", "telemetry_flush")
+assert set(VISIBLE_EFFECT_NAMES) | set(INVISIBLE_EFFECT_NAMES) == set(EFFECT_NAMES)
+assert not (set(VISIBLE_EFFECT_NAMES) & set(INVISIBLE_EFFECT_NAMES))
+
 TERMINAL_STATES = ("done", "errored", "cancelled")
 # Nonterminal states for the idle-release NOT EXISTS + watchdog scans.
 NONTERMINAL_STATES = (
@@ -1211,6 +1240,41 @@ def all_required_effects_done(run_id: str) -> bool:
 	return not frappe.db.sql(
 		f"""SELECT 1 FROM `tab{EFFECT}` WHERE turn=%(r)s AND status!='done' LIMIT 1""",
 		{"r": run_id},
+	)
+
+
+def visible_effects_done(run_id: str) -> bool:
+	"""jarvis#737: True iff no required VISIBLE_EFFECT_NAMES row for the turn is
+	still pending/running (force-done counts as done). Mirrors
+	all_required_effects_done but scoped to the perceivable subset, so finalize
+	can release the "Finishing..." affordance without waiting on usage/telemetry.
+	A turn that owes no visible effect at all (an all-usage synthetic ledger, or
+	a future required set with none) reads True vacuously, matching intent:
+	nothing visible is held, so there is nothing for the affordance to wait on."""
+	return not frappe.db.sql(
+		f"""SELECT 1 FROM `tab{EFFECT}` WHERE turn=%(r)s AND status!='done'
+		AND effect_name IN %(names)s LIMIT 1""",
+		{"r": run_id, "names": VISIBLE_EFFECT_NAMES},
+	)
+
+
+def claim_enrichment_publish(run_id: str) -> bool:
+	"""jarvis#737: the exactly-once gate for the message:enriched publish across
+	the two sites that can trigger it, finalize's early visible-set release and
+	the later finalize_done all-effects release. A CAS 0->1 on
+	enriched_published, so whichever site calls this first wins the publish and
+	the other affects 0 rows and skips it. Independent of finalize_done's own
+	state CAS: this never changes when the turn reaches 'done', only which call
+	is allowed to publish. Does NOT gate the jarvis#681 already-done redelivery
+	(finalize.run_finalize's top branch), which stays an unconditional
+	best-effort resend by design. No commit (caller owns the txn, same
+	discipline as the sibling effect-ledger CAS helpers)."""
+	return (
+		_run_cas(
+			f"UPDATE `tab{TURN}` SET enriched_published=1 WHERE name=%(r)s AND enriched_published=0",
+			{"r": run_id},
+		)
+		== 1
 	)
 
 

--- a/jarvis/jarvis/doctype/jarvis_chat_turn/jarvis_chat_turn.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_turn/jarvis_chat_turn.json
@@ -24,6 +24,7 @@
   "recovering",
   "was_recovered",
   "usage_recorded",
+  "enriched_published",
   "terminal_kind",
   "terminal_payload",
   "error",
@@ -196,6 +197,14 @@
    "description": "(turn_id) idempotency guard for token-usage accrual (R-4 / §10.7): CAS 0->1 in finalize so a finalize replay can never double-count the soft monthly cap. The naked += is retired; usage is a fenced once-only enrichment effect."
   },
   {
+   "fieldname": "enriched_published",
+   "fieldtype": "Check",
+   "label": "Enriched Published",
+   "default": "0",
+   "no_copy": 1,
+   "description": "jarvis#737: exactly-once guard for the message:enriched publish. CAS 0->1 in finalize so the early visible-set release and the later finalize_done all-effects release can never both fire; whichever wins the CAS is the one call that publishes. Does not gate the jarvis#681 already-done redelivery, which stays an unconditional best-effort resend."
+  },
+  {
    "fieldname": "terminal_kind",
    "fieldtype": "Select",
    "label": "Terminal Kind",
@@ -289,7 +298,7 @@
  ],
  "index_web_pages_for_search": 0,
  "links": [],
- "modified": "2026-07-23 00:00:00.000000",
+ "modified": "2026-08-14 00:00:00.000000",
  "module": "Jarvis",
  "name": "Jarvis Chat Turn",
  "naming_rule": "By fieldname",

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -1034,7 +1034,9 @@ class TestStuckFinishingAfterAFailingLane(_PipelineCase):
 		self.assertTrue(out["ok"], "finalize never errors a settled turn")
 		self.assertFalse(out["done"], "usage/telemetry are still owed; the turn stays finalizing")
 		self.assertTrue(out["published"], "the visible set is done, so THIS call published the clear")
-		self.assertEqual(self._state(rid), "finalizing", "the failing lane holds the state, not the affordance")
+		self.assertEqual(
+			self._state(rid), "finalizing", "the failing lane holds the state, not the affordance"
+		)
 		self.assertEqual(self._effects(rid)["usage"], "pending", "released for the next cycle")
 		self.assertEqual(int(self._val(rid, "usage_recorded")), 0, "the guard CAS rolled back")
 		self.assertEqual(

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -258,7 +258,10 @@ class TestPumpPipelineE2E(_PipelineCase):
 			out = finalize.run_finalize(rid, self._target)
 		self.assertTrue(out["done"])
 		self.assertEqual(self._state(rid), "done")
-		self.assertIn("message:enriched", self._pub_kinds())
+		# jarvis#737: the visible-set release and the finalize_done release land in the
+		# SAME call here (nothing stalls), so the exactly-once claim must still hold:
+		# one publish, not two.
+		self.assertEqual(self._pub_kinds().count("message:enriched"), 1)
 		# Every owed effect reached done exactly once (D1 spot-check).
 		self.assertTrue(all(v == "done" for v in self._effects(rid).values()))
 		self.assertEqual(recs["rich"].count, 1, "rich_outputs owner ran once")
@@ -968,14 +971,21 @@ class TestStuckFinishingAfterAFailingLane(_PipelineCase):
 	handing the code a healthy row.
 
 	What that proves, and what the fix adds:
-	  * the turn legitimately stays ``finalizing`` and promises NO ``message:enriched``
-	    while the lane keeps failing. That is by design and is NOT changed here.
-	  * the retry budget eventually force-dones the effect and the turn reaches
-	    ``done``, publishing ``message:enriched`` exactly once. But that ONE publish is
-	    best-effort, and every retry is 5 minutes apart behind the pump watchdog cron.
-	  * so a finalize that arrives AFTER the turn is done now RE-DELIVERS
-	    ``message:enriched`` (the counterpart of the CDX-12 terminal backstop), instead
-	    of returning ``already_done`` in silence and leaving the client stuck.
+	  * jarvis#737: usage is INVISIBLE ledger work (turn_state.INVISIBLE_EFFECT_NAMES).
+	    Everything the user can actually perceive (rich_outputs, auto_title, ...) is
+	    the VISIBLE set, and it is already done by the time the dead lane is hit, so
+	    ``message:enriched`` publishes right away and the turn STAYS ``finalizing``:
+	    the state transition, the force-done budget, and the usage soft-cap guard are
+	    all unchanged, only WHEN the client is told to stop waiting moves earlier.
+	  * the usage retry budget still eventually force-dones the effect and the turn
+	    reaches ``done``, but that does NOT publish a second time; the exactly-once
+	    claim (turn_state.claim_enrichment_publish) was already spent by the early
+	    visible-set publish.
+	  * separately, jarvis#681's redelivery is untouched: a finalize that arrives
+	    AFTER the turn is done still RE-DELIVERS ``message:enriched`` unconditionally
+	    (the counterpart of the CDX-12 terminal backstop), instead of returning
+	    ``already_done`` in silence and leaving a client that missed the original
+	    push stuck.
 	The client-side half of the fix, the deadline that bounds the affordance whatever
 	the server does, is covered by frontend/src/lib/enrichmentPending.test.js.
 	"""
@@ -1017,25 +1027,30 @@ class TestStuckFinishingAfterAFailingLane(_PipelineCase):
 		blind = _FakeSess()
 		blind.list_sessions = lambda: []
 
-		# ---- 1. the reported state: a completed answer, a dead lane, no clear ----
+		# ---- 1. jarvis#737: the VISIBLE set is already done, so the affordance
+		#         releases even though the dead lane holds the STATE open. ----
 		with self._gateway(blind), self._mock_enrichment_except_usage():
 			out = finalize.run_finalize(rid, self._target)
 		self.assertTrue(out["ok"], "finalize never errors a settled turn")
-		self.assertFalse(out["done"])
-		self.assertEqual(self._state(rid), "finalizing", "the failing lane holds the turn open")
+		self.assertFalse(out["done"], "usage/telemetry are still owed; the turn stays finalizing")
+		self.assertTrue(out["published"], "the visible set is done, so THIS call published the clear")
+		self.assertEqual(self._state(rid), "finalizing", "the failing lane holds the state, not the affordance")
 		self.assertEqual(self._effects(rid)["usage"], "pending", "released for the next cycle")
 		self.assertEqual(int(self._val(rid, "usage_recorded")), 0, "the guard CAS rolled back")
-		self.assertNotIn(
-			"message:enriched",
-			self._pub_kinds(),
-			"nothing tells the client to stop showing Finishing... while enrichment is owed",
+		self.assertEqual(
+			self._pub_kinds().count("message:enriched"),
+			1,
+			"the client is told to stop showing Finishing... as soon as everything it can "
+			"perceive has landed, without waiting on the invisible usage lane",
 		)
 		# Everything the USER can see did land: the answer is complete, which is why a
 		# permanent "Finishing..." is a lie rather than merely pessimistic.
 		self.assertEqual(self._effects(rid)["rich_outputs"], "done")
 		self.assertEqual(self._effects(rid)["auto_title"], "done")
 
-		# ---- 2. the retry budget frees it, but only after the watchdog cadence ----
+		# ---- 2. the retry budget eventually frees the STATE too, but does NOT
+		#         publish a second time; the exactly-once claim was already spent
+		#         by the early visible-set publish above. ----
 		for _ in range(ts.FINALIZE_MAX_ATTEMPTS):
 			if self._state(rid) == "done":
 				break
@@ -1043,7 +1058,10 @@ class TestStuckFinishingAfterAFailingLane(_PipelineCase):
 				finalize.run_finalize(rid, self._target)
 		self.assertEqual(self._state(rid), "done", "a broken lane can never strand a settled turn")
 		self.assertEqual(
-			self._pub_kinds().count("message:enriched"), 1, "the clear is published exactly once"
+			self._pub_kinds().count("message:enriched"),
+			1,
+			"still exactly one publish: the ledger reaching done does not re-clear an "
+			"affordance the visible set already cleared",
 		)
 
 		# ---- 3. THE FIX: that single publish is best-effort, so a later finalize

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -1438,7 +1438,9 @@ class TestVisibleEffectsAndEnrichmentClaim(_TurnStateTestCase):
 
 	def test_visible_done_vacuous_when_no_visible_effect_is_owed(self):
 		rid = self._mk_finalizing(("usage",))
-		self.assertTrue(ts.visible_effects_done(rid), "nothing visible is held, so there is nothing to wait on")
+		self.assertTrue(
+			ts.visible_effects_done(rid), "nothing visible is held, so there is nothing to wait on"
+		)
 
 	def test_claim_enrichment_publish_is_exactly_once(self):
 		rid = self._mk_finalizing(("auto_title", "usage"))

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -1401,6 +1401,54 @@ class TestEffectLedger(_TurnStateTestCase):
 
 
 # --------------------------------------------------------------------------- #
+# jarvis#737: the visible/invisible split and the exactly-once publish claim.
+# --------------------------------------------------------------------------- #
+
+
+class TestVisibleEffectsAndEnrichmentClaim(_TurnStateTestCase):
+	def _mk_finalizing(self, effects):
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		rid = f"ts_vis_{frappe.generate_hash(length=6)}"
+		self._mk_turn(conv, rid, seed, "finalizing", version=7)
+		ts.insert_required_effects(rid, effects)
+		frappe.db.commit()
+		return rid
+
+	def test_vocabulary_partitions_exactly(self):
+		# Every canonical effect is classified as exactly one of visible/invisible,
+		# so a future addition to EFFECT_NAMES fails loudly instead of silently
+		# defaulting into either bucket.
+		self.assertEqual(set(ts.VISIBLE_EFFECT_NAMES) | set(ts.INVISIBLE_EFFECT_NAMES), set(ts.EFFECT_NAMES))
+		self.assertFalse(set(ts.VISIBLE_EFFECT_NAMES) & set(ts.INVISIBLE_EFFECT_NAMES))
+		self.assertIn("usage", ts.INVISIBLE_EFFECT_NAMES)
+		self.assertIn("telemetry_flush", ts.INVISIBLE_EFFECT_NAMES)
+		self.assertIn("rich_outputs", ts.VISIBLE_EFFECT_NAMES)
+		self.assertIn("auto_title", ts.VISIBLE_EFFECT_NAMES)
+
+	def test_visible_done_ignores_a_pending_invisible_effect(self):
+		rid = self._mk_finalizing(("auto_title", "usage"))
+		self.assertFalse(ts.visible_effects_done(rid), "auto_title is still pending")
+		o, tok = ts.claim_effect(rid, "auto_title")
+		self.assertTrue(ts.complete_effect(rid, "auto_title", tok))
+		frappe.db.commit()
+		# usage stays pending throughout; visible_effects_done must not wait on it.
+		self.assertTrue(ts.visible_effects_done(rid), "the only visible effect is done")
+		self.assertFalse(ts.all_required_effects_done(rid), "usage is still owed")
+
+	def test_visible_done_vacuous_when_no_visible_effect_is_owed(self):
+		rid = self._mk_finalizing(("usage",))
+		self.assertTrue(ts.visible_effects_done(rid), "nothing visible is held, so there is nothing to wait on")
+
+	def test_claim_enrichment_publish_is_exactly_once(self):
+		rid = self._mk_finalizing(("auto_title", "usage"))
+		self.assertTrue(ts.claim_enrichment_publish(rid), "the first claim wins")
+		frappe.db.commit()
+		self.assertFalse(ts.claim_enrichment_publish(rid), "a second claim on the same turn is a no-op")
+		self.assertEqual(int(frappe.db.get_value("Jarvis Chat Turn", rid, "enriched_published")), 1)
+
+
+# --------------------------------------------------------------------------- #
 # JF-002: ONE canonical turn-effect vocabulary. EFFECT_NAMES is the single
 # authority; settlement, finalize and the DocType description all derive from it,
 # and the insert seam fails CLOSED on anything outside it.


### PR DESCRIPTION
## Summary

`message:enriched` used to wait on every finalize effect, including usage and
telemetry ledger work the customer never sees. A stalled usage poll (e.g. mid
credential rotation) held the "Finishing..." label up for the full retry budget
on a reply that was already complete. Now it publishes as soon as the visible
effects (attachments/canvas, cards, chat-asks, macro/title/wiki, the terminal
backstop) are done, independent of when usage/telemetry finish.

## What changed
- `message:enriched` releases on the visible-effect subset, not the full ledger.
- A new `enriched_published` CAS on `Jarvis Chat Turn` makes the publish
  exactly once, whichever site fires first.
- `finalize_done`, the force-done budget, and the usage soft-cap guard are
  unchanged; only when the publish fires moves earlier.

## Risk and verification
- Tested directly (`TestVisibleEffectsAndEnrichmentClaim`) and through the
  dead-lane scenario (`TestStuckFinishingAfterAFailingLane`): single publish
  even when the invisible effect finishes after the visible ones.
- `ChatView.vue` is the only `message:enriched` consumer; it clears on set
  membership, so the existing jarvis#681 redelivery backstop stays untouched.

<details>
<summary>Classification and the crash window</summary>

`enrich_cards` and `chat_asks` are classified visible, not just the issue's
named three, because the publish-triggered client reload is what renders their
filled content (card schema fields, the Approval Board fence). Publishing ahead
of them would show stale content, a new visible regression.

The publish claim commits before the actual publish call, so a crash in
between spends the claim without delivering the event. Unlike the prior code,
that is not auto-recovered by the next finalize cycle while usage/telemetry
are still retrying; recovery there needs the client's own 120s deadline
(jarvis#681, enrichmentPending.js), the same bound the affordance already had.
Narrow, and no worse than the pre-#681 world for that one window, but not
fully symmetric with the old crash window either.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on X)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
