### PR TITLE
feat(llm): single admin call for the subscription connect

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -970,6 +970,67 @@ def post_push_oauth_blob(provider: str, blob: dict) -> dict:
 	)
 
 
+def post_subscription_connect(
+	provider: str,
+	blob: dict,
+	*,
+	model: str,
+	base_url: str,
+	api_key: str = "",
+	installed_apps: list[str] | None = None,
+) -> dict:
+	"""POST one combined subscription-connect to admin's
+	``api.tenant.subscription_connect``.
+
+	Collapses what used to be two round trips out of ``jarvis_settings.py``'s
+	subscription "restart" leg - ``post_push_oauth_blob`` (the auth-profile
+	write) THEN ``post_update_llm_creds`` (the openclaw.json render + restart)
+	- into one call, so the doctor+healthz work behind it runs once instead of
+	twice.
+
+	``provider`` is the agent auth-profile id baked into the oauth blob itself
+	(``blob["provider"]`` - "openai", "google-gemini-cli", ...; the same
+	identifier ``post_push_oauth_blob`` took), NOT necessarily
+	``Jarvis Settings.llm_provider`` - that legacy mirror is often blank for a
+	subscription model row (the UI never asks for a catalog provider on the
+	subscription leg; upstream + account already say which one). ``blob`` is
+	that oauth blob with ``id_token`` already stripped (fleet's
+	``PUT /auth-profile`` schema is ``extra_forbidden``).
+
+	``model``/``base_url``/``api_key``/``installed_apps`` mirror
+	``post_update_llm_creds``'s creds fields for parity with the two-call shape
+	this replaces - ``api_key`` is empty in practice (oauth mode's credential
+	lives in the auth-profile store, not here) but is still sent, matching what
+	the old restart leg sent unconditionally. ``auth_mode`` is hardcoded to
+	``"oauth"`` on the wire (not a parameter): this endpoint exists only for
+	the subscription/oauth leg, so there is nothing else it could be.
+
+	Timeout is 240s - strictly above the admin->fleet leg's own 210s budget
+	(same each-layer-exceeds-the-one-below rule as PR#826): this outer
+	bench->admin leg must never hang up on an apply admin is still driving.
+
+	Raises:
+		AdminAuthError, AdminUnreachableError, AdminValidationError,
+		AdminRateLimitedError, AdminRejectedError as usual. A caller that needs
+		to detect "admin has not deployed this dotted path yet" (a deploy-order
+		gap between the jarvis and admin legs) checks ``is_method_not_found``
+		on a caught ``AdminValidationError``.
+	"""
+	return _post(
+		path=_m("api.tenant.subscription_connect"),
+		body={
+			"provider": provider,
+			"blob": blob,
+			"model": model,
+			"base_url": base_url,
+			"api_key": api_key,
+			"auth_mode": "oauth",
+			"installed_apps": installed_apps if installed_apps is not None else frappe.get_installed_apps(),
+		},
+		timeout_s=240,
+	)
+
+
 def post_push_custom_skills(skills: list[dict]) -> dict:
 	"""POST the customer's rendered custom skills to admin → fleet → container.
 
@@ -1826,6 +1887,49 @@ def _contract_error(payload) -> dict:
 	out = dict(err)
 	out["message"] = _scrub_secrets(str(err.get("message") or ""))
 	return out
+
+
+# Frappe's OWN "no such whitelisted method" rejection (frappe/handler.py
+# execute_cmd: get_attr() raises when the dotted path doesn't resolve, caught
+# and re-thrown via frappe.throw(_("Failed to get method for command {0} with
+# {1}").format(cmd, str(e))) - default exc class ValidationError,
+# http_status_code 417). It reaches _do_post as an AdminValidationError with
+# exc_type "ValidationError" - the SAME exc_type an ordinary business
+# rejection carries, so exc_type alone can't tell the two apart.
+#
+# The marker string is framework-owned (frappe/handler.py's literal format
+# string), not admin_app-owned prose, so - unlike a hand-authored admin
+# business message (AdminValidationError's own docstring warns never to
+# string-match one; an admin release reworded such a sentence once and broke
+# a substring match silently) - it is not going to be reworded out from under
+# this check by an admin deploy. The interpolated dotted path IS still
+# translation-proof even if a non-English admin locale translates the format
+# string's fixed text, so the check below accepts either half - the fixed
+# English marker OR the interpolated dotted method path (checked WITHOUT the
+# admin-app namespace prefix, since _admin_app() is a deployment override and
+# the method name after it is the constant part).
+_METHOD_NOT_FOUND_MARKER = "Failed to get method for command"
+_SUBSCRIPTION_CONNECT_METHOD = "api.tenant.subscription_connect"
+
+
+def is_method_not_found(exc: AdminValidationError) -> bool:
+	"""True when ``exc`` is Frappe's own missing-whitelisted-method rejection
+	(the dotted path this bench build calls does not exist on admin yet)
+	rather than the target endpoint's own business validation.
+
+	Callers use this to detect a deploy-order gap - this leg shipped ahead of
+	the admin endpoint it calls - and fall back to an older call sequence,
+	without keying off business-message text an admin release can reword (see
+	the marker comment above). The asymmetry in what this accepts is
+	deliberate: a false positive here just runs the old two-call sequence
+	(harmless - it is today's production path), while a false negative would
+	leave subscription connects broken until admin deploys, so the check
+	matches broadly rather than narrowly.
+	"""
+	if getattr(exc, "exc_type", None) not in (None, "ValidationError"):
+		return False
+	text = str(exc)
+	return _METHOD_NOT_FOUND_MARKER in text or _SUBSCRIPTION_CONNECT_METHOD in text
 
 
 def _rejection(message: str, *, payload, status: int, exc_type: str = "") -> AdminValidationError:

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -973,10 +973,10 @@ def post_push_oauth_blob(provider: str, blob: dict) -> dict:
 def post_subscription_connect(
 	provider: str,
 	blob: dict,
+	llm_provider: str,
 	*,
 	model: str,
 	base_url: str,
-	api_key: str = "",
 	installed_apps: list[str] | None = None,
 ) -> dict:
 	"""POST one combined subscription-connect to admin's
@@ -990,24 +990,35 @@ def post_subscription_connect(
 
 	``provider`` is the agent auth-profile id baked into the oauth blob itself
 	(``blob["provider"]`` - "openai", "google-gemini-cli", ...; the same
-	identifier ``post_push_oauth_blob`` took), NOT necessarily
-	``Jarvis Settings.llm_provider`` - that legacy mirror is often blank for a
-	subscription model row (the UI never asks for a catalog provider on the
-	subscription leg; upstream + account already say which one). ``blob`` is
-	that oauth blob with ``id_token`` already stripped (fleet's
-	``PUT /auth-profile`` schema is ``extra_forbidden``).
+	identifier ``post_push_oauth_blob`` took). ``llm_provider`` is the
+	customer-facing catalog label ``post_update_llm_creds`` takes as its own
+	``provider`` argument (e.g. "OpenAI"). Admin REQUIRES both and derives the
+	auth-profile id it expects from ``llm_provider``, 400ing
+	(``ProviderMismatch``) when the two disagree - so a caller must never send
+	a blank or mismatched ``llm_provider``; see
+	``jarvis_settings._sync_subscription_connect_restart`` for the local guard
+	that refuses a blank one before this is ever called. ``blob`` is the oauth
+	blob with ``id_token`` already stripped (fleet's ``PUT /auth-profile``
+	schema is ``extra_forbidden``).
 
-	``model``/``base_url``/``api_key``/``installed_apps`` mirror
-	``post_update_llm_creds``'s creds fields for parity with the two-call shape
-	this replaces - ``api_key`` is empty in practice (oauth mode's credential
-	lives in the auth-profile store, not here) but is still sent, matching what
-	the old restart leg sent unconditionally. ``auth_mode`` is hardcoded to
-	``"oauth"`` on the wire (not a parameter): this endpoint exists only for
-	the subscription/oauth leg, so there is nothing else it could be.
+	``model``/``base_url``/``installed_apps`` mirror ``post_update_llm_creds``'s
+	creds fields for parity with the two-call shape this replaces. Admin's
+	``subscription_connect`` does not declare ``api_key`` or ``auth_mode`` (an
+	oauth-only endpoint has no other mode to name), so neither is sent - a
+	kwarg Frappe's whitelist handler does not declare is silently dropped, so
+	sending them would be dead weight, not a hidden bug.
 
 	Timeout is 240s - strictly above the admin->fleet leg's own 210s budget
 	(same each-layer-exceeds-the-one-below rule as PR#826): this outer
 	bench->admin leg must never hang up on an apply admin is still driving.
+	Past ~180s admin's own gunicorn worker can time out before the merged
+	fleet round trip returns (rare, but this leg's work is strictly more than
+	either old call did alone); the HTTP response is then lost, but admin
+	already persisted the desired state before dispatching to fleet, so the
+	existing reconcile path (``_confirm_apply_via_admin`` / the periodic
+	reconcile) converges the tenant without this leg retrying - a stray
+	"failed: admin unreachable" on a slow connect is transient and
+	self-corrects, not lost work.
 
 	Raises:
 		AdminAuthError, AdminUnreachableError, AdminValidationError,
@@ -1021,10 +1032,9 @@ def post_subscription_connect(
 		body={
 			"provider": provider,
 			"blob": blob,
+			"llm_provider": llm_provider,
 			"model": model,
 			"base_url": base_url,
-			"api_key": api_key,
-			"auth_mode": "oauth",
 			"installed_apps": installed_apps if installed_apps is not None else frappe.get_installed_apps(),
 		},
 		timeout_s=240,
@@ -1920,12 +1930,32 @@ def is_method_not_found(exc: AdminValidationError) -> bool:
 	Callers use this to detect a deploy-order gap - this leg shipped ahead of
 	the admin endpoint it calls - and fall back to an older call sequence,
 	without keying off business-message text an admin release can reword (see
-	the marker comment above). The asymmetry in what this accepts is
-	deliberate: a false positive here just runs the old two-call sequence
-	(harmless - it is today's production path), while a false negative would
-	leave subscription connects broken until admin deploys, so the check
-	matches broadly rather than narrowly.
+	the marker comment above).
+
+	The landed ``subscription_connect``'s own 400/409 business rejections
+	(InvalidBlob, UnknownProvider, ProviderMismatch, NoRunningTenant,
+	InvalidIdempotencyKey) all route through ``@fleet_endpoint``'s
+	``EndpointError`` family, which ALWAYS sets a structured ``error.code`` -
+	that arrives here as an ``AdminContractError`` (an AdminValidationError
+	subclass) with a non-empty ``code``, whereas Frappe's OWN missing-method
+	rejection is a bare ``AdminValidationError`` with no ``code`` at all.
+	Checking that first is a stronger signal than the message text below: it
+	excludes every CURRENT admin business rejection outright, by shape rather
+	than by wording, so a future admin release is free to reword any of those
+	messages without this silently drifting. (RateLimitExceeded's 429 never
+	reaches here at all - ``_do_post`` special-cases 429 into
+	``AdminRateLimitedError``, a sibling exception this function is never
+	called with.)
+
+	The message check is what is left to guard against an admin business
+	rejection that (now or later) uses a bare ``frappe.throw`` with no code -
+	the asymmetry in what it accepts is deliberate: a false positive here just
+	runs the old two-call sequence (harmless - it is today's production
+	path), while a false negative would leave subscription connects broken
+	until admin deploys, so it matches broadly rather than narrowly.
 	"""
+	if getattr(exc, "code", ""):
+		return False
 	if getattr(exc, "exc_type", None) not in (None, "ValidationError"):
 		return False
 	text = str(exc)

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -502,6 +502,70 @@ def _schedule_sync_lock_retry(*, method: str, job_base: str, retry_left: int, **
 	)
 
 
+def _direct_subscription_blob(doc) -> tuple[str, dict]:
+	"""Find + validate the DIRECT leg's lone enabled subscription model's OAuth
+	blob, stripped of ``id_token``, ready to push or fold into a payload.
+
+	Module-level (not a method) so ``JarvisSettings._push_direct_subscription_blob``
+	can still be called UNBOUND against a bare ``frappe._dict`` test fixture
+	(``TestPushDirectSubscriptionBlobNoMatchInvariant``): reading ``doc.models``
+	rather than ``self.models`` works whether ``doc`` is a real JarvisSettings
+	document or a ``frappe._dict`` standing in for one - a helper hung off
+	``self`` would need ``self`` to already be a bound instance of this class,
+	which the fixture is not.
+
+	Mirrors ``jarvis.oauth.api.complete_paste_signin``'s push: the blob's own
+	``provider`` key already carries the agent auth-profile id (``agent_provider``
+	- "openai", "google-gemini-cli" - baked in when the blob was minted), so no
+	separate upstream-to-provider table is needed here, and ``id_token`` is
+	stripped because fleet's ``PUT /auth-profile`` schema is strict
+	(``extra_forbidden``) and only the POOL path's cliproxy-codex reformat needs it.
+
+	Only ever called for the config ``_lone_direct_capable`` allowed onto this
+	leg, so there is exactly one enabled subscription model with exactly one
+	account and ``validate_models`` has already required a well-formed,
+	non-empty ``oauth_blob`` on it before ``save()`` could reach here. Raises
+	(rather than silently skipping) if that invariant is somehow violated - the
+	caller's surrounding try/except in ``_sync_via_admin`` reports it exactly
+	like an admin failure, which is safer than rendering ``auth:"oauth"``
+	against a container with no credential behind it. That guarantee covers a
+	NO-MATCH loop too (jarvis#755 review): if nothing enabled turns out to be a
+	subscription row when this runs, falling off the loop without raising would
+	be exactly the silent skip this docstring promises never happens, so the
+	loop's tail raises the same way.
+
+	Returns ``(provider, blob)`` - the agent auth-profile id and the blob dict
+	with ``id_token`` already stripped.
+	"""
+	import json
+
+	from jarvis import admin_client
+	from jarvis.jarvis.pool_serialize import _model_accounts
+
+	for m in doc.models or []:
+		if not m.enabled or (getattr(m, "credential_type", None) or "api_key") != "subscription":
+			continue
+		accounts = _model_accounts(m)
+		if not accounts:
+			raise admin_client.AdminValidationError(
+				"direct subscription leg: no connected account to push"
+			)
+		blob_raw = (accounts[0].get("oauth_blob") if hasattr(accounts[0], "get") else "") or ""
+		try:
+			blob = json.loads(blob_raw) if blob_raw else None
+		except (TypeError, ValueError):
+			blob = None
+		if not isinstance(blob, dict) or not (blob.get("provider") or "").strip():
+			raise admin_client.AdminValidationError(
+				"direct subscription leg: missing or malformed oauth_blob"
+			)
+		direct_blob = {k: v for k, v in blob.items() if k != "id_token"}
+		return direct_blob["provider"], direct_blob
+	raise admin_client.AdminValidationError(
+		"direct subscription leg: no enabled subscription model to push"
+	)
+
+
 class JarvisSettings(Document):
 	def before_validate(self):
 		"""Mirror models[0] into legacy fields BEFORE validate() runs.
@@ -701,55 +765,79 @@ class JarvisSettings(Document):
 		agent's auth store, before the ``/llm-creds`` render that depends on it
 		(jarvis#715 step 3, point 4).
 
-		Mirrors ``jarvis.oauth.api.complete_paste_signin``'s push: the blob's own
-		``provider`` key already carries the agent auth-profile id
-		(``agent_provider`` - "openai", "google-gemini-cli" - baked in when the
-		blob was minted), so no separate upstream-to-provider table is needed
-		here, and ``id_token`` is stripped because fleet's ``PUT /auth-profile``
-		schema is strict (``extra_forbidden``) and only the POOL path's
-		cliproxy-codex reformat needs it.
-
-		Only ever called for the config ``_lone_direct_capable`` allowed onto this
-		leg, so there is exactly one enabled subscription model with exactly one
-		account and ``validate_models`` has already required a well-formed,
-		non-empty ``oauth_blob`` on it before ``save()`` could reach here. Raises
-		(rather than silently skipping the push) if that invariant is somehow
-		violated - the caller's surrounding try/except in ``_sync_via_admin``
-		reports it exactly like an admin failure, which is safer than rendering
-		``auth: "oauth"`` against a container with no credential behind it. That
-		guarantee covers a NO-MATCH loop too (jarvis#755 review): if nothing
-		enabled turns out to be a subscription row when this runs, falling off
-		the loop without raising would be exactly the silent skip this docstring
-		promises never happens, so the loop's tail raises the same way.
+		Thin wrapper around the module-level ``_direct_subscription_blob``
+		(find/validate/strip-``id_token``) - kept as its OWN method, rather than
+		inlined at the one remaining call site, because
+		``TestPushDirectSubscriptionBlobNoMatchInvariant`` calls it UNBOUND
+		against a bare test fixture; see that helper's docstring for the
+		raise-not-skip guarantee this preserves. Still used by the fallback leg
+		of ``_sync_subscription_connect_restart`` for an admin that has not yet
+		deployed ``subscription_connect``.
 		"""
-		import json
-
 		from jarvis import admin_client
-		from jarvis.jarvis.pool_serialize import _model_accounts
 
-		for m in self.models or []:
-			if not m.enabled or (getattr(m, "credential_type", None) or "api_key") != "subscription":
-				continue
-			accounts = _model_accounts(m)
-			if not accounts:
-				raise admin_client.AdminValidationError(
-					"direct subscription leg: no connected account to push"
+		provider, direct_blob = _direct_subscription_blob(self)
+		admin_client.post_push_oauth_blob(provider, direct_blob)
+
+	def _sync_subscription_connect_restart(self) -> dict:
+		"""The subscription leg of the "restart" action's admin call.
+
+		Single call (``admin_client.post_subscription_connect``) to admin's
+		``api.tenant.subscription_connect``, which folds together what used to
+		be two round trips - push the DIRECT leg's oauth blob (the auth-profile
+		write), THEN render+restart via ``update-llm-creds`` - into one call
+		that does the doctor+healthz work behind it once. Payload building
+		reuses ``_direct_subscription_blob``'s find/validate/strip-``id_token``
+		logic (the same one ``_push_direct_subscription_blob`` used), so a
+		missing or malformed blob raises the identical ``AdminValidationError``
+		the ``_sync_via_admin`` except clauses already handle - this method
+		does not add a new failure shape, only a new call shape.
+
+		TODO(delete-me after admin-v2 subscription_connect deploys): admin may
+		not have the new dotted path live yet if this leg's PR lands before the
+		admin one. When ``post_subscription_connect`` comes back as Frappe's own
+		"no such whitelisted method" rejection
+		(``admin_client.is_method_not_found``), fall back to the old two-call
+		sequence this endpoint is meant to replace - same push-blob-then-creds
+		order the old code used, so a failure still lands before
+		``post_update_llm_creds`` could render ``auth:"oauth"`` against an empty
+		auth store. Any OTHER AdminValidationError (the new endpoint's own
+		business rejection) is not a deploy-window gap and re-raises straight
+		into the normal except clauses below.
+		"""
+		from jarvis import admin_client
+		from jarvis.installed_apps_sync import record_synced_snapshot
+
+		provider, blob = _direct_subscription_blob(self)
+		try:
+			result = (
+				admin_client.post_subscription_connect(
+					provider,
+					blob,
+					model=self.llm_model or "",
+					base_url=self.llm_base_url or "",
+					api_key=self._resolve_llm_secret_for_push(),
 				)
-			blob_raw = (accounts[0].get("oauth_blob") if hasattr(accounts[0], "get") else "") or ""
-			try:
-				blob = json.loads(blob_raw) if blob_raw else None
-			except (TypeError, ValueError):
-				blob = None
-			if not isinstance(blob, dict) or not (blob.get("provider") or "").strip():
-				raise admin_client.AdminValidationError(
-					"direct subscription leg: missing or malformed oauth_blob"
+				or {}
+			)
+		except admin_client.AdminValidationError as e:
+			if not admin_client.is_method_not_found(e):
+				raise
+			admin_client.post_push_oauth_blob(provider, blob)
+			result = (
+				admin_client.post_update_llm_creds(
+					provider=self.llm_provider or "",
+					model=self.llm_model or "",
+					base_url=self.llm_base_url or "",
+					api_key=self._resolve_llm_secret_for_push(),
+					auth_mode=creds_wire_auth_mode(self.llm_auth_mode),
 				)
-			direct_blob = {k: v for k, v in blob.items() if k != "id_token"}
-			admin_client.post_push_oauth_blob(blob["provider"], direct_blob)
-			return
-		raise admin_client.AdminValidationError(
-			"direct subscription leg: no enabled subscription model to push"
-		)
+				or {}
+			)
+		# The payload carries installed_apps either way; admin persisted it
+		# desired-first, so stamp even if the apply is converging.
+		record_synced_snapshot()
+		return result
 
 	def on_update(self):
 		# ------------------------------------------------------------------ #
@@ -1160,34 +1248,33 @@ class JarvisSettings(Document):
 				result = admin_client.post_rotate_llm_secret(secret=secret) or {}
 				resolved_action = result.get("action", "reload")
 			else:  # "restart"
-				# A models[]-table subscription on the DIRECT leg (jarvis#715 step 3,
-				# point 4) owns its own credential push: unlike the legacy oauth flow
-				# (whose blob reaches auth-profiles.json via complete_paste_signin
-				# BEFORE this job ever runs), the unified table's oauth_blob just sits
-				# in subscription_accounts until something pushes it. Push it FIRST -
-				# same order complete_paste_signin uses (blob, then creds) - so a
-				# failure here lands in the except clauses below and post_update_llm_creds
-				# never renders auth:"oauth" against an empty auth store.
 				if (self.llm_auth_mode or "") == "subscription":
-					self._push_direct_subscription_blob()
-				# In oauth mode the api_key body is empty - container reads
-				# credentials from auth-profiles.json instead.
-				secret = self._resolve_llm_secret_for_push()
-				result = (
-					admin_client.post_update_llm_creds(
-						provider=self.llm_provider or "",
-						model=self.llm_model or "",
-						base_url=self.llm_base_url or "",
-						api_key=secret,
-						auth_mode=creds_wire_auth_mode(self.llm_auth_mode),
+					# A models[]-table subscription on the DIRECT leg (jarvis#715 step
+					# 3, point 4) owns its own credential push: unlike the legacy oauth
+					# flow (whose blob reaches auth-profiles.json via
+					# complete_paste_signin BEFORE this job ever runs), the unified
+					# table's oauth_blob just sits in subscription_accounts until
+					# something pushes it. See _sync_subscription_connect_restart.
+					result = self._sync_subscription_connect_restart() or {}
+				else:
+					# In api_key mode the container reads the credential from this
+					# very push.
+					secret = self._resolve_llm_secret_for_push()
+					result = (
+						admin_client.post_update_llm_creds(
+							provider=self.llm_provider or "",
+							model=self.llm_model or "",
+							base_url=self.llm_base_url or "",
+							api_key=secret,
+							auth_mode=creds_wire_auth_mode(self.llm_auth_mode),
+						)
+						or {}
 					)
-					or {}
-				)
-				# The payload carried installed_apps; admin persisted it
-				# desired-first, so stamp even if the apply is converging.
-				from jarvis.installed_apps_sync import record_synced_snapshot
+					# The payload carried installed_apps; admin persisted it
+					# desired-first, so stamp even if the apply is converging.
+					from jarvis.installed_apps_sync import record_synced_snapshot
 
-				record_synced_snapshot()
+					record_synced_snapshot()
 				resolved_action = result.get("action", "restart")
 			# The push is the long part of this job, and until now every status
 			# write below still ran on the snapshot taken before it (#713). Ending

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -766,13 +766,14 @@ class JarvisSettings(Document):
 		(jarvis#715 step 3, point 4).
 
 		Thin wrapper around the module-level ``_direct_subscription_blob``
-		(find/validate/strip-``id_token``) - kept as its OWN method, rather than
-		inlined at the one remaining call site, because
-		``TestPushDirectSubscriptionBlobNoMatchInvariant`` calls it UNBOUND
-		against a bare test fixture; see that helper's docstring for the
-		raise-not-skip guarantee this preserves. Still used by the fallback leg
-		of ``_sync_subscription_connect_restart`` for an admin that has not yet
-		deployed ``subscription_connect``.
+		(find/validate/strip-``id_token``) plus the push itself - kept as a
+		method (not inlined) because it has two callers: the deploy-window
+		fallback leg of ``_sync_subscription_connect_restart`` (an admin that
+		has not yet deployed ``subscription_connect`` still needs the OLD
+		push-blob-then-creds sequence), and
+		``TestPushDirectSubscriptionBlobNoMatchInvariant``, which calls it
+		UNBOUND against a bare test fixture - see that helper's docstring for
+		the raise-not-skip guarantee this preserves.
 		"""
 		from jarvis import admin_client
 
@@ -843,7 +844,7 @@ class JarvisSettings(Document):
 		except admin_client.AdminValidationError as e:
 			if not admin_client.is_method_not_found(e):
 				raise
-			admin_client.post_push_oauth_blob(provider, blob)
+			self._push_direct_subscription_blob()
 			result = (
 				admin_client.post_update_llm_creds(
 					provider=self.llm_provider or "",
@@ -1614,8 +1615,9 @@ class JarvisSettings(Document):
 		# same model, same llm_auth_mode - so none of the checks in this function
 		# (structural_fields below, llm_api_key_changed) can see it. Without this,
 		# reconnecting an expired/revoked token would classify as "no change" and
-		# the fresh blob this leg itself pushes (_push_direct_subscription_blob)
-		# would never reach the container.
+		# the fresh blob this leg itself pushes (_sync_subscription_connect_restart,
+		# via post_subscription_connect or its _push_direct_subscription_blob
+		# deploy-window fallback) would never reach the container.
 		if old is not None and (self.llm_auth_mode or "") == "subscription":
 			current_snap = self.flags.get("pool_state_snapshot")
 			if current_snap is not None and current_snap != self._pool_state_snapshot(old):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -793,6 +793,20 @@ class JarvisSettings(Document):
 		the ``_sync_via_admin`` except clauses already handle - this method
 		does not add a new failure shape, only a new call shape.
 
+		Admin's subscription_connect REQUIRES ``llm_provider`` (the catalog
+		label, e.g. "OpenAI") alongside the auth-profile ``provider`` id, and
+		derives the auth-profile id it expects from ``llm_provider`` - a blank
+		or mismatched one 400s (``ProviderMismatch``). ``on_update`` mirrors
+		``models[0].provider`` verbatim into ``self.llm_provider`` for EVERY
+		credential type, subscription included, so it is populated whenever a
+		save went through the SPA's own gate (jarvis#756's ``validatePool``
+		refuses a provider-less subscription row client-side) - but nothing on
+		the bench enforces that server-side, so a blank mirror is still
+		reachable here from any other caller of ``save_llm_pool``. Guarded
+		below with the same AdminValidationError shape the missing/malformed-
+		blob guard uses, so that reaches this method's caller as a clean local
+		rejection instead of a round trip that comes back a 400.
+
 		TODO(delete-me after admin-v2 subscription_connect deploys): admin may
 		not have the new dotted path live yet if this leg's PR lands before the
 		admin one. When ``post_subscription_connect`` comes back as Frappe's own
@@ -802,21 +816,27 @@ class JarvisSettings(Document):
 		order the old code used, so a failure still lands before
 		``post_update_llm_creds`` could render ``auth:"oauth"`` against an empty
 		auth store. Any OTHER AdminValidationError (the new endpoint's own
-		business rejection) is not a deploy-window gap and re-raises straight
+		business rejection - InvalidBlob, UnknownProvider, ProviderMismatch,
+		NoRunningTenant, ...) is not a deploy-window gap and re-raises straight
 		into the normal except clauses below.
 		"""
 		from jarvis import admin_client
 		from jarvis.installed_apps_sync import record_synced_snapshot
 
 		provider, blob = _direct_subscription_blob(self)
+		llm_provider = (self.llm_provider or "").strip()
+		if not llm_provider:
+			raise admin_client.AdminValidationError(
+				"direct subscription leg: missing llm_provider (catalog provider)"
+			)
 		try:
 			result = (
 				admin_client.post_subscription_connect(
 					provider,
 					blob,
+					llm_provider,
 					model=self.llm_model or "",
 					base_url=self.llm_base_url or "",
-					api_key=self._resolve_llm_secret_for_push(),
 				)
 				or {}
 			)

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -547,9 +547,7 @@ def _direct_subscription_blob(doc) -> tuple[str, dict]:
 			continue
 		accounts = _model_accounts(m)
 		if not accounts:
-			raise admin_client.AdminValidationError(
-				"direct subscription leg: no connected account to push"
-			)
+			raise admin_client.AdminValidationError("direct subscription leg: no connected account to push")
 		blob_raw = (accounts[0].get("oauth_blob") if hasattr(accounts[0], "get") else "") or ""
 		try:
 			blob = json.loads(blob_raw) if blob_raw else None
@@ -561,9 +559,7 @@ def _direct_subscription_blob(doc) -> tuple[str, dict]:
 			)
 		direct_blob = {k: v for k, v in blob.items() if k != "id_token"}
 		return direct_blob["provider"], direct_blob
-	raise admin_client.AdminValidationError(
-		"direct subscription leg: no enabled subscription model to push"
-	)
+	raise admin_client.AdminValidationError("direct subscription leg: no enabled subscription model to push")
 
 
 class JarvisSettings(Document):

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -541,10 +541,11 @@ class TestAdminErrorResponses(FrappeTestCase):
 class TestIsMethodNotFound(FrappeTestCase):
 	"""admin_client.is_method_not_found: the subscription_connect deploy-window
 	discriminator that tells "admin has not shipped this dotted path yet"
-	apart from an ordinary business rejection - both arrive as
-	AdminValidationError with exc_type "ValidationError", so the message
-	content is the only signal (see is_method_not_found's docstring for why
-	that is safe here, unlike matching an admin-authored business message)."""
+	apart from the endpoint's own business rejections. The landed admin build's
+	rejections (InvalidBlob, UnknownProvider, ProviderMismatch, ...) all carry
+	a structured error.code via @fleet_endpoint's EndpointError family, which
+	excludes them outright; the message-text check is the fallback signal for
+	anything that reaches here uncoded (see is_method_not_found's docstring)."""
 
 	def setUp(self):
 		_settings_for_admin()
@@ -573,14 +574,47 @@ class TestIsMethodNotFound(FrappeTestCase):
 		)
 		with patch("requests.post", mock_post):
 			with self.assertRaises(AdminValidationError) as cm:
-				admin_client.post_subscription_connect("openai", {}, model="m", base_url="")
+				admin_client.post_subscription_connect("openai", {}, "OpenAI", model="m", base_url="")
 		self.assertTrue(admin_client.is_method_not_found(cm.exception))
 
-	def test_an_ordinary_business_rejection_is_not_method_not_found(self):
-		"""The discriminator's whole job: a real rejection from a deployed
-		endpoint must NOT be misread as "admin doesn't have this method yet",
-		or a genuine failure would silently retry through the old fallback
-		instead of surfacing to the customer."""
+	def test_a_coded_business_rejection_is_not_method_not_found(self):
+		"""The REAL wire shape of the landed subscription_connect's business
+		rejections: @fleet_endpoint RETURNS (never throws) {"ok": false,
+		"error": {"code": ..., "message": ...}} under a 400 - e.g.
+		ProviderMismatch when llm_provider's expected auth-profile id disagrees
+		with provider. That arrives here as an AdminContractError whose
+		exc_type is None, the SAME as the missing-method case - so the code
+		check (not exc_type) is what has to exclude it."""
+		mock_post = MagicMock(
+			return_value=_mock_response(
+				400,
+				json_body={
+					"message": {
+						"ok": False,
+						"error": {
+							"code": "ProviderMismatch",
+							"message": (
+								"provider 'openai' does not match llm_provider 'gemini' "
+								"(expected 'google-gemini-cli')"
+							),
+						},
+					}
+				},
+			)
+		)
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				admin_client.post_subscription_connect(
+					"openai", {}, "gemini", model="m", base_url=""
+				)
+		self.assertEqual(getattr(cm.exception, "code", ""), "ProviderMismatch")
+		self.assertFalse(admin_client.is_method_not_found(cm.exception))
+
+	def test_an_ordinary_uncoded_business_rejection_is_not_method_not_found(self):
+		"""Belt-and-suspenders: even a hypothetical bare frappe.throw business
+		rejection (no code, exc_type "ValidationError" - the same shape the
+		missing-method case has) must not be misread as "admin doesn't have
+		this method yet" on message content alone."""
 		mock_post = MagicMock(
 			return_value=_mock_response(
 				417,
@@ -593,13 +627,14 @@ class TestIsMethodNotFound(FrappeTestCase):
 		)
 		with patch("requests.post", mock_post):
 			with self.assertRaises(AdminValidationError) as cm:
-				admin_client.post_subscription_connect("openai", {}, model="m", base_url="")
+				admin_client.post_subscription_connect("openai", {}, "OpenAI", model="m", base_url="")
 		self.assertFalse(admin_client.is_method_not_found(cm.exception))
 
-	def test_an_unrelated_exc_type_is_not_method_not_found(self):
-		"""A DuplicateEntryError (or any other allowlisted-but-different
-		exc_type) can never be Frappe's missing-method rejection, whatever its
-		text happens to say - is_method_not_found gates on exc_type first."""
+	def test_a_coded_exception_is_not_method_not_found_regardless_of_text(self):
+		"""A DuplicateEntryError (or any other coded/typed rejection) can never
+		be Frappe's missing-method rejection, whatever its text happens to
+		say - is_method_not_found excludes on code/exc_type before ever
+		reading the message."""
 		exc = AdminValidationError(
 			"Failed to get method for command x with y", exc_type="DuplicateEntryError"
 		)
@@ -1502,22 +1537,22 @@ class TestPostSubscriptionConnect(FrappeTestCase):
 			result = admin_client.post_subscription_connect(
 				"openai",
 				blob,
+				"OpenAI",
 				model="gpt-5.5",
 				base_url="",
 			)
 		self.assertEqual(result, {"action": "restart"})
 		self.assertIn("subscription_connect", captured["url"])
-		# auth_mode is hardcoded "oauth" on the wire - not a caller kwarg -
-		# because this endpoint exists only for the subscription/oauth leg.
+		# Admin's subscription_connect does not declare api_key or auth_mode
+		# (an oauth-only endpoint has no other mode to name) - neither is sent.
 		self.assertEqual(
 			captured["body"],
 			{
 				"provider": "openai",
 				"blob": blob,
+				"llm_provider": "OpenAI",
 				"model": "gpt-5.5",
 				"base_url": "",
-				"api_key": "",
-				"auth_mode": "oauth",
 				"installed_apps": frappe.get_installed_apps(),
 			},
 		)

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -538,6 +538,74 @@ class TestAdminErrorResponses(FrappeTestCase):
 		self.assertEqual(str(cm.exception), "customer status: Suspended")
 
 
+class TestIsMethodNotFound(FrappeTestCase):
+	"""admin_client.is_method_not_found: the subscription_connect deploy-window
+	discriminator that tells "admin has not shipped this dotted path yet"
+	apart from an ordinary business rejection - both arrive as
+	AdminValidationError with exc_type "ValidationError", so the message
+	content is the only signal (see is_method_not_found's docstring for why
+	that is safe here, unlike matching an admin-authored business message)."""
+
+	def setUp(self):
+		_settings_for_admin()
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def test_frappes_own_missing_method_rejection_is_detected_end_to_end(self):
+		"""Frappe's handler.py execute_cmd wraps get_attr()'s failure in
+		frappe.throw(_("Failed to get method for command {0} with {1}")...) -
+		default exc class ValidationError, http_status_code 417. Shape the mock
+		response exactly like that wire contract and confirm the resulting
+		AdminValidationError classifies as method-not-found."""
+		mock_post = MagicMock(
+			return_value=_mock_response(
+				417,
+				json_body={
+					"exception": (
+						"frappe.exceptions.ValidationError: Failed to get method for command "
+						"jarvis_admin_v2.api.tenant.subscription_connect with module "
+						"'jarvis_admin_v2.api.tenant' has no attribute 'subscription_connect'"
+					),
+					"exc_type": "ValidationError",
+				},
+			)
+		)
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				admin_client.post_subscription_connect("openai", {}, model="m", base_url="")
+		self.assertTrue(admin_client.is_method_not_found(cm.exception))
+
+	def test_an_ordinary_business_rejection_is_not_method_not_found(self):
+		"""The discriminator's whole job: a real rejection from a deployed
+		endpoint must NOT be misread as "admin doesn't have this method yet",
+		or a genuine failure would silently retry through the old fallback
+		instead of surfacing to the customer."""
+		mock_post = MagicMock(
+			return_value=_mock_response(
+				417,
+				json_body={
+					"exception": "frappe.exceptions.ValidationError: unusable oauth grant",
+					"exc_type": "ValidationError",
+					"_server_messages": '["{\\"message\\": \\"unusable oauth grant\\", \\"indicator\\": \\"red\\"}"]',
+				},
+			)
+		)
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				admin_client.post_subscription_connect("openai", {}, model="m", base_url="")
+		self.assertFalse(admin_client.is_method_not_found(cm.exception))
+
+	def test_an_unrelated_exc_type_is_not_method_not_found(self):
+		"""A DuplicateEntryError (or any other allowlisted-but-different
+		exc_type) can never be Frappe's missing-method rejection, whatever its
+		text happens to say - is_method_not_found gates on exc_type first."""
+		exc = AdminValidationError(
+			"Failed to get method for command x with y", exc_type="DuplicateEntryError"
+		)
+		self.assertFalse(admin_client.is_method_not_found(exc))
+
+
 class TestPermanentRejectionClassification(FrappeTestCase):
 	"""jarvis #542: 502 is admin's answer BOTH to a gateway fault AND to its
 	fleet layer permanently refusing the config (@fleet_endpoint answers every
@@ -1405,6 +1473,61 @@ class TestPostPushOauthBlob(FrappeTestCase):
 			180,
 			"post_push_oauth_blob timeout must accommodate fleet-agent's "
 			"doctor + restart + healthz chain (~120s typical, 150s cap)",
+		)
+
+
+class TestPostSubscriptionConnect(FrappeTestCase):
+	def setUp(self):
+		_settings_for_admin()
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def test_happy_path_posts_combined_payload(self):
+		captured = {}
+		blob = {
+			"type": "oauth",
+			"provider": "openai",
+			"access": "AT-fresh",
+			"refresh": "RT-fresh",
+		}
+
+		def _fake_post(url, json=None, timeout=None, **_kw):
+			captured["url"] = url
+			captured["body"] = json
+			captured["timeout"] = timeout
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {"action": "restart"}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			result = admin_client.post_subscription_connect(
+				"openai",
+				blob,
+				model="gpt-5.5",
+				base_url="",
+			)
+		self.assertEqual(result, {"action": "restart"})
+		self.assertIn("subscription_connect", captured["url"])
+		# auth_mode is hardcoded "oauth" on the wire - not a caller kwarg -
+		# because this endpoint exists only for the subscription/oauth leg.
+		self.assertEqual(
+			captured["body"],
+			{
+				"provider": "openai",
+				"blob": blob,
+				"model": "gpt-5.5",
+				"base_url": "",
+				"api_key": "",
+				"auth_mode": "oauth",
+				"installed_apps": frappe.get_installed_apps(),
+			},
+		)
+		# Must exceed the admin->fleet leg's own 210s budget (each layer
+		# exceeds the one below it, same rule PR#826 established) so the
+		# bench never gives up on an apply admin is still driving.
+		self.assertGreater(
+			captured["timeout"],
+			210,
+			"post_subscription_connect timeout must outlast admin's own admin->fleet budget",
 		)
 
 

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -604,9 +604,7 @@ class TestIsMethodNotFound(FrappeTestCase):
 		)
 		with patch("requests.post", mock_post):
 			with self.assertRaises(AdminValidationError) as cm:
-				admin_client.post_subscription_connect(
-					"openai", {}, "gemini", model="m", base_url=""
-				)
+				admin_client.post_subscription_connect("openai", {}, "gemini", model="m", base_url="")
 		self.assertEqual(getattr(cm.exception, "code", ""), "ProviderMismatch")
 		self.assertFalse(admin_client.is_method_not_found(cm.exception))
 

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -99,6 +99,13 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 	def _lone_subscription_models(self, upstream="openai", provider="openai", blob=None):
 		return [
 			{
+				# jarvis#756: the SPA's own validatePool gate refuses a
+				# provider-less subscription row client-side, so a real save
+				# always carries this - on_update mirrors it verbatim into
+				# self.llm_provider, which admin-v2's subscription_connect
+				# (jarvis_admin_v2 branch feat/subscription-connect-relay)
+				# requires.
+				"provider": provider,
 				"model": "gpt-5.5",
 				"tier": "strong",
 				"order": 0,
@@ -133,8 +140,9 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 			)
 		pool.assert_not_called()
 		connect.assert_called_once()
-		provider, _blob = connect.call_args.args
+		provider, _blob, llm_provider = connect.call_args.args
 		self.assertEqual(provider, "openai")
+		self.assertEqual(llm_provider, "openai")
 		self.assertEqual(connect.call_args.kwargs.get("model"), "gpt-5.5")
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(s.proxy_active or 0), 0)
@@ -249,6 +257,29 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		self.assertEqual(calls[1][1].get("auth_mode"), "oauth")
 		s = frappe.get_single("Jarvis Settings")
 		self.assertTrue(s.last_sync_status.startswith("ok"), f"expected ok, got {s.last_sync_status!r}")
+
+	def test_blank_llm_provider_is_a_clean_local_rejection(self):
+		"""admin's subscription_connect REQUIRES llm_provider and 400s
+		(ProviderMismatch) on a blank one. A provider-less subscription row is
+		refused client-side by the SPA's own validatePool gate (jarvis#756),
+		but nothing enforces that server-side, so a non-SPA caller of
+		save_llm_pool can still reach this leg with one. That must surface as
+		a clean local rejection - never an admin round trip, never the
+		method-not-found fallback."""
+		models = self._lone_subscription_models()
+		del models[0]["provider"]
+		with (
+			patch("jarvis.admin_client.post_subscription_connect") as connect,
+			patch("jarvis.admin_client.post_push_oauth_blob") as blob,
+			patch("jarvis.admin_client.post_update_llm_creds") as creds,
+		):
+			onboarding.save_llm_pool(frappe.as_json(models), preset=None, routing_mode="failover")
+		connect.assert_not_called()
+		blob.assert_not_called()
+		creds.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(s.last_sync_status.startswith("failed: validation:"))
+		self.assertIn("missing llm_provider", s.last_sync_status)
 
 	def test_one_unrenderable_subscription_model_is_still_proxy(self):
 		"""Kimi has no agent-native auth flow → still needs cliproxy → the

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -223,7 +223,11 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		(handler.py's ``execute_cmd`` -> ``get_attr`` failure, wrapped in
 		``frappe.throw``). That must fall back to the old push-blob-then-creds
 		sequence, in that order, rather than surface as a broken subscription
-		connect."""
+		connect. The blob push now goes through ``self._push_direct_subscription_blob``
+		(the same wrapper the pre-collapse code used) rather than an inlined
+		call, but the observable effect - a ``post_push_oauth_blob`` call before
+		``post_update_llm_creds`` - is unchanged, so the assertions below still
+		verify it."""
 		from jarvis import admin_client
 
 		calls = []

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -237,9 +237,7 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 			exc_type="ValidationError",
 		)
 		with (
-			patch(
-				"jarvis.admin_client.post_subscription_connect", side_effect=method_not_found
-			) as connect,
+			patch("jarvis.admin_client.post_subscription_connect", side_effect=method_not_found) as connect,
 			patch(
 				"jarvis.admin_client.post_push_oauth_blob",
 				side_effect=lambda provider, blob: calls.append(("blob", provider, blob)) or {},

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -119,27 +119,23 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 	def test_one_renderable_subscription_model_is_direct(self):
 		"""jarvis#715: a FRESH lone subscription on a provider agent serves
 		NATIVELY (openai) needs no sidecar at all - it takes the direct
-		llm-creds leg, pushing its own oauth blob, not /llm-pool."""
-		blob_calls = []
+		leg, one subscription_connect call carrying its own oauth blob, not
+		/llm-pool."""
 		with (
 			patch("jarvis.admin_client.post_update_llm_pool") as pool,
 			patch(
-				"jarvis.admin_client.post_push_oauth_blob",
-				side_effect=lambda provider, blob: blob_calls.append((provider, blob)) or {},
-			),
-			patch(
-				"jarvis.admin_client.post_update_llm_creds",
+				"jarvis.admin_client.post_subscription_connect",
 				return_value={"action": "restart", "status": "applied"},
-			) as creds,
+			) as connect,
 		):
 			onboarding.save_llm_pool(
 				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
 			)
 		pool.assert_not_called()
-		self.assertEqual(len(blob_calls), 1, "the direct leg must push the oauth blob")
-		self.assertEqual(blob_calls[0][0], "openai")
-		creds.assert_called_once()
-		self.assertEqual(creds.call_args.kwargs.get("auth_mode"), "oauth")
+		connect.assert_called_once()
+		provider, _blob = connect.call_args.args
+		self.assertEqual(provider, "openai")
+		self.assertEqual(connect.call_args.kwargs.get("model"), "gpt-5.5")
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(s.proxy_active or 0), 0)
 
@@ -149,14 +145,11 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		subscription-direct tenant resolved provider=None - agent then either
 		502s ("No API key found for provider ...") or silently mis-routes.
 		The lone account's own oauth_blob already carries the agent-provider id
-		under its "provider" key (the same key _push_direct_subscription_blob
+		under its "provider" key (the same key ``_direct_subscription_blob``
 		relies on), so the turn dispatcher must read it from there."""
 		from jarvis.chat.turn_handler import _resolve_model_and_provider
 
-		with (
-			patch("jarvis.admin_client.post_push_oauth_blob"),
-			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
-		):
+		with patch("jarvis.admin_client.post_subscription_connect", return_value={"action": "restart"}):
 			onboarding.save_llm_pool(
 				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
 			)
@@ -168,14 +161,11 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 	def test_lone_direct_subscription_with_a_malformed_blob_resolves_no_provider(self):
 		"""A blob missing its "provider" key (or otherwise unreadable) must
 		degrade to None, never raise or crash the turn - see
-		_push_direct_subscription_blob's own guard for the write side of this
+		``_direct_subscription_blob``'s own guard for the write side of this
 		same invariant."""
 		from jarvis.chat.turn_handler import _resolve_model_and_provider
 
-		with (
-			patch("jarvis.admin_client.post_push_oauth_blob"),
-			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
-		):
+		with patch("jarvis.admin_client.post_subscription_connect", return_value={"action": "restart"}):
 			onboarding.save_llm_pool(
 				frappe.as_json(self._lone_subscription_models(blob='{"refresh_token":"rt"}')),
 				preset=None,
@@ -185,29 +175,80 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
 		_, provider = _resolve_model_and_provider(conv)
 		self.assertIsNone(provider)
 
-	def test_direct_subscription_push_validation_error_surfaces_specifically(self):
+	def test_direct_subscription_connect_validation_error_surfaces_specifically(self):
 		"""jarvis#755 review: _sync_via_admin had no except clause for
-		AdminValidationError, so a concrete "missing or malformed oauth_blob"
-		reason from _push_direct_subscription_blob fell through to the generic
-		"failed: unexpected error; see Error Log" backstop - exactly the
-		failure this exception exists to name. Mirrors the pool-sync twin's own
-		handling of the same exception (jarvis_settings.py ~1975)."""
+		AdminValidationError, so a concrete rejection reason fell through to
+		the generic "failed: unexpected error; see Error Log" backstop -
+		exactly the failure this exception exists to name. Mirrors the
+		pool-sync twin's own handling of the same exception (jarvis_settings.py
+		~1975).
+
+		Also the DISCRIMINATOR for the deploy-window fallback (see
+		test_subscription_connect_method_not_found_falls_back_to_two_calls
+		below): a plain business rejection from the new endpoint is NOT the
+		"no such method" signal and must surface directly, never trigger the
+		old two-call fallback."""
 		from jarvis import admin_client
 
 		with (
 			patch(
-				"jarvis.admin_client.post_push_oauth_blob",
+				"jarvis.admin_client.post_subscription_connect",
 				side_effect=admin_client.AdminValidationError("missing or malformed oauth_blob"),
-			),
+			) as connect,
+			patch("jarvis.admin_client.post_push_oauth_blob") as blob,
 			patch("jarvis.admin_client.post_update_llm_creds") as creds,
 		):
 			onboarding.save_llm_pool(
 				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
 			)
+		connect.assert_called_once()
+		blob.assert_not_called()
 		creds.assert_not_called()
 		s = frappe.get_single("Jarvis Settings")
 		self.assertTrue(s.last_sync_status.startswith("failed: validation:"))
 		self.assertIn("missing or malformed oauth_blob", s.last_sync_status)
+
+	def test_subscription_connect_method_not_found_falls_back_to_two_calls(self):
+		"""TODO(delete-me after admin-v2 subscription_connect deploys) deploy-window
+		coverage: an admin build that has not shipped ``subscription_connect``
+		yet answers with Frappe's own "no such whitelisted method" rejection
+		(handler.py's ``execute_cmd`` -> ``get_attr`` failure, wrapped in
+		``frappe.throw``). That must fall back to the old push-blob-then-creds
+		sequence, in that order, rather than surface as a broken subscription
+		connect."""
+		from jarvis import admin_client
+
+		calls = []
+		method_not_found = admin_client.AdminValidationError(
+			"Failed to get method for command jarvis_admin_v2.api.tenant.subscription_connect "
+			"with module 'jarvis_admin_v2.api.tenant' has no attribute 'subscription_connect'",
+			exc_type="ValidationError",
+		)
+		with (
+			patch(
+				"jarvis.admin_client.post_subscription_connect", side_effect=method_not_found
+			) as connect,
+			patch(
+				"jarvis.admin_client.post_push_oauth_blob",
+				side_effect=lambda provider, blob: calls.append(("blob", provider, blob)) or {},
+			) as blob,
+			patch(
+				"jarvis.admin_client.post_update_llm_creds",
+				side_effect=lambda **kw: calls.append(("creds", kw))
+				or {"action": "restart", "status": "applied"},
+			) as creds,
+		):
+			onboarding.save_llm_pool(
+				frappe.as_json(self._lone_subscription_models()), preset=None, routing_mode="failover"
+			)
+		connect.assert_called_once()
+		blob.assert_called_once()
+		creds.assert_called_once()
+		self.assertEqual([c[0] for c in calls], ["blob", "creds"], "blob must push before creds")
+		self.assertEqual(calls[0][1], "openai")
+		self.assertEqual(calls[1][1].get("auth_mode"), "oauth")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(s.last_sync_status.startswith("ok"), f"expected ok, got {s.last_sync_status!r}")
 
 	def test_one_unrenderable_subscription_model_is_still_proxy(self):
 		"""Kimi has no agent-native auth flow → still needs cliproxy → the

--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -332,6 +332,12 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 		acct.update(extra)
 		return [
 			{
+				# jarvis#756: the SPA's own validatePool gate refuses a
+				# provider-less subscription row client-side, so a real save
+				# always carries this - on_update mirrors it verbatim into
+				# self.llm_provider, which admin's subscription_connect now
+				# requires.
+				"provider": "openai",
 				"model": "gpt-5.5",
 				"tier": "strong",
 				"order": 0,

--- a/jarvis/tests/test_subscription_accounts_roundtrip.py
+++ b/jarvis/tests/test_subscription_accounts_roundtrip.py
@@ -345,16 +345,17 @@ class TestOrphanCaptureAdoption(_RT3SettingsTestCase):
 			# status="applied" is load-bearing: a bare Mock's .get("status") is
 			# truthy-and-not-"applied", which routes _sync_via_admin into the
 			# converge branch and calls the UNMOCKED admin_client.get_connection.
-			patch(
-				"jarvis.admin_client.post_update_llm_creds",
-				return_value={"action": "restart", "status": "applied"},
-			),
+			#
 			# jarvis#715's lone-direct-capable exception routes a single
 			# renderable subscription (this class's whole fixture shape) onto
-			# the DIRECT leg, which pushes its own oauth blob before /llm-creds
-			# (_push_direct_subscription_blob) - unmocked, that is a real admin
-			# call attempt from inside _sync_via_admin.
-			patch("jarvis.admin_client.post_push_oauth_blob"),
+			# the DIRECT leg, which makes ONE subscription_connect call
+			# (_sync_subscription_connect_restart, folding the oauth-blob push
+			# and the /llm-creds render into one admin round trip) - unmocked,
+			# that is a real admin call attempt from inside _sync_via_admin.
+			patch(
+				"jarvis.admin_client.post_subscription_connect",
+				return_value={"action": "restart", "status": "applied"},
+			),
 		):
 			return onboarding.save_llm_pool(frappe.as_json(payload), preset=None, routing_mode="failover")
 

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1410,6 +1410,12 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		)
 		return [
 			{
+				# jarvis#756: the SPA's own validatePool gate refuses a
+				# provider-less subscription row client-side, so a real save
+				# always carries this - on_update mirrors it verbatim into
+				# self.llm_provider, which admin's subscription_connect now
+				# requires.
+				"provider": agent_provider,
 				"model": "gpt-5.5",
 				"tier": "cheap",
 				"order": 0,
@@ -1452,14 +1458,16 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		self.assertEqual(pool_calls, [], "a fresh lone renderable subscription must never push /llm-pool")
 		self.assertEqual(out["mode"], "legacy", "no apply-operation descriptor on the direct leg")
 
-		# ONE call now carries both the oauth blob (id_token stripped) and the
-		# creds fields (jarvis#715 step 3, point 4 - collapsed from two admin
-		# round trips into one subscription_connect call). auth_mode itself is
-		# hardcoded to "oauth" inside post_subscription_connect, not a caller
-		# kwarg - see test_admin_client.py for that body-construction test.
+		# ONE call now carries the oauth blob (id_token stripped), the
+		# auth-profile provider, AND the catalog llm_provider admin's
+		# subscription_connect cross-checks against it (jarvis#715 step 3,
+		# point 4 - collapsed from two admin round trips into one call).
+		# Admin does not declare api_key or auth_mode, so post_subscription_connect
+		# does not send them - see test_admin_client.py for that body test.
 		mock_connect.assert_called_once()
-		provider, pushed_blob = mock_connect.call_args.args
+		provider, pushed_blob, llm_provider = mock_connect.call_args.args
 		self.assertEqual(provider, "openai")
+		self.assertEqual(llm_provider, "openai")
 		self.assertNotIn("id_token", pushed_blob)
 		self.assertEqual(pushed_blob.get("refresh"), "RT-direct")
 		self.assertEqual(mock_connect.call_args.kwargs.get("model"), "gpt-5.5")

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1432,20 +1432,15 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		from jarvis.jarvis.pool_serialize import compute_pool_mode
 
 		pool_calls = []
-		blob_calls = []
 		with (
 			frappe_patch(
 				"jarvis.admin_client.post_update_llm_pool",
 				side_effect=lambda **kw: pool_calls.append(kw) or {"action": "pool_update"},
 			),
 			frappe_patch(
-				"jarvis.admin_client.post_push_oauth_blob",
-				side_effect=lambda provider, blob: blob_calls.append((provider, blob)) or {},
-			),
-			frappe_patch(
-				"jarvis.admin_client.post_update_llm_creds",
+				"jarvis.admin_client.post_subscription_connect",
 				return_value={"action": "restart", "status": "applied"},
-			) as mock_creds,
+			) as mock_connect,
 		):
 			out = onboarding.save_llm_pool(
 				frappe.as_json(self._lone_sub_payload()),
@@ -1457,20 +1452,17 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		self.assertEqual(pool_calls, [], "a fresh lone renderable subscription must never push /llm-pool")
 		self.assertEqual(out["mode"], "legacy", "no apply-operation descriptor on the direct leg")
 
-		# The oauth blob is pushed to agent's auth store BEFORE /llm-creds,
-		# with id_token stripped (jarvis#715 step 3, point 4).
-		self.assertEqual(len(blob_calls), 1, "the direct leg must push the oauth blob exactly once")
-		provider, pushed_blob = blob_calls[0]
+		# ONE call now carries both the oauth blob (id_token stripped) and the
+		# creds fields (jarvis#715 step 3, point 4 - collapsed from two admin
+		# round trips into one subscription_connect call). auth_mode itself is
+		# hardcoded to "oauth" inside post_subscription_connect, not a caller
+		# kwarg - see test_admin_client.py for that body-construction test.
+		mock_connect.assert_called_once()
+		provider, pushed_blob = mock_connect.call_args.args
 		self.assertEqual(provider, "openai")
 		self.assertNotIn("id_token", pushed_blob)
 		self.assertEqual(pushed_blob.get("refresh"), "RT-direct")
-
-		mock_creds.assert_called_once()
-		self.assertEqual(
-			mock_creds.call_args.kwargs.get("auth_mode"),
-			"oauth",
-			"a subscription credential must cross the wire as oauth, not the literal 'subscription'",
-		)
+		self.assertEqual(mock_connect.call_args.kwargs.get("model"), "gpt-5.5")
 
 		settings = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(settings.proxy_active or 0), 0, "no sidecar for a lone renderable subscription")
@@ -1491,8 +1483,7 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 				"jarvis.admin_client.post_update_llm_pool",
 				side_effect=lambda **kw: pool_calls.append(kw) or {"action": "pool_update"},
 			),
-			frappe_patch("jarvis.admin_client.post_push_oauth_blob") as mock_blob,
-			frappe_patch("jarvis.admin_client.post_update_llm_creds") as mock_creds,
+			frappe_patch("jarvis.admin_client.post_subscription_connect") as mock_connect,
 		):
 			out = onboarding.save_llm_pool(
 				frappe.as_json(self._lone_sub_payload(upstream="kimi", agent_provider="kimi")),
@@ -1504,8 +1495,7 @@ class TestRT6LoneSubscriptionDirectLeg(_RT3SettingsTestCase):
 		self.assertNotEqual(
 			out.get("last_sync_status", ""), "", "the pool leg must have run and stamped a status"
 		)
-		mock_blob.assert_not_called()
-		mock_creds.assert_not_called()
+		mock_connect.assert_not_called()
 
 
 class TestRT3LegacyNoModelsBackcompat(_RT3SettingsTestCase):


### PR DESCRIPTION
Final leg of jarvis#827: the subscription connect now makes one admin call (`post_subscription_connect`) instead of two, so the tenant container restarts once. Requires fleet-agent#224 and the admin-v2 relay to be deployed first; until then a deploy-window fallback transparently uses the old two-call path (marked `TODO(delete-me after admin-v2 subscription_connect deploys)`).

**What changed.** `_sync_via_admin`'s subscription branch calls `post_subscription_connect(provider=blob["provider"], llm_provider=self.llm_provider, ...)` with a 240s budget (each layer exceeds the one below: fleet ~200s, admin client 210s). Payload building folds `_push_direct_subscription_blob`'s account lookup, id_token strip, and validation, raising the same `AdminValidationError` shapes, so the load-bearing `last_sync_status` literals `account.py` classifies on are byte-identical. A blank `llm_provider` mirror is rejected locally as `failed: validation: missing llm_provider` before any HTTP call.

**Fallback detection is structural, not string-guessed.** Admin business rejections arrive as coded envelopes (`AdminContractError` with `error.code`), which the discriminator excludes before any text match; only Frappe's method-not-found ValidationError shape from an old admin triggers the fallback. Verified against the landed admin branch.

**Untouched.** The api-key leg, `mode:"legacy"` + `readiness_budget_s` (PR#826), `llm_direct_synced_at` stamping, and the legacy paste-signin flow.

**Tests** updated across four modules; hosted CI is the gate.


## Pre-merge checklist

- [ ] **CI is green** - the test checks on this PR pass (never merge on ❌)
- [x] Branch is **up to date with `develop`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff