### PR TITLE
fix(whitelabel): render tenant agent_name on the no-access page (#773)

### DIFF
--- a/jarvis/tests/test_no_access_page.py
+++ b/jarvis/tests/test_no_access_page.py
@@ -4,6 +4,9 @@ Covers:
 - Boot flag: set_jarvis_boot(bootinfo) sets jarvis_has_access True/False per access.
 - No-access page gates: unauthorized (render), authorized (redirect to /jarvis),
   Guest (redirect to /login).
+- No-access page branding (#773): context.agent_name mirrors the tenant's
+  whitelabel Jarvis Settings.agent_name, same lookup as www/jarvis.py and
+  www/jarvis_mobile.py, falling back to "Jarvis" only when unset.
 - Main app gates: roleless → /jarvis-no-access on both; Guest → /app on jarvis.py,
   but gets the shell on jarvis_mobile.py (PWA scope — its own login route handles Guests).
 
@@ -11,6 +14,7 @@ Hermetic: throwaway System User rows (one per role shape) are created in setUp
 and deleted in tearDown; the Jarvis User role is seeded and dropped idempotently.
 """
 
+import os
 from unittest.mock import patch
 
 import frappe
@@ -183,6 +187,55 @@ class TestJarvisNoAccessPage(FrappeTestCase):
 		context = frappe._dict()
 		jarvis_no_access.get_context(context)
 		self.assertEqual(context.user_fullname, expected_fullname)
+
+	# --- (b2) whitelabel brand on the no-access page (#773) ------------------ #
+
+	def test_no_access_uses_custom_agent_name(self):
+		"""A white-label tenant's agent_name renders on the no-access page
+		instead of the hardcoded "Jarvis" (the #773 brand leak)."""
+		settings = frappe.get_single("Jarvis Settings")
+		original = settings.agent_name or ""
+		settings.db_set("agent_name", "Acme Assistant", update_modified=False)
+		frappe.db.commit()
+		try:
+			frappe.set_user(USER_NONE)
+			context = frappe._dict()
+			jarvis_no_access.get_context(context)
+			self.assertEqual(context.agent_name, "Acme Assistant")
+		finally:
+			frappe.get_single("Jarvis Settings").db_set("agent_name", original, update_modified=False)
+			frappe.db.commit()
+
+	def test_no_access_falls_back_to_jarvis_when_agent_name_blank(self):
+		"""A non-white-label tenant (agent_name unset) keeps the "Jarvis"
+		default, so this fix does not change existing tenants."""
+		settings = frappe.get_single("Jarvis Settings")
+		original = settings.agent_name or ""
+		settings.db_set("agent_name", "", update_modified=False)
+		frappe.db.commit()
+		try:
+			frappe.set_user(USER_NONE)
+			context = frappe._dict()
+			jarvis_no_access.get_context(context)
+			self.assertEqual(context.agent_name, "Jarvis")
+		finally:
+			frappe.get_single("Jarvis Settings").db_set("agent_name", original, update_modified=False)
+			frappe.db.commit()
+
+	def test_no_access_html_renders_custom_agent_name_not_jarvis(self):
+		"""The template itself (not just the context dict) consumes agent_name:
+		rendering jarvis_no_access.html with a custom name must not fall back
+		to the literal "Jarvis" copy anywhere in the visible strings."""
+		import jinja2
+
+		html_path = os.path.join(frappe.get_app_path("jarvis"), "www", "jarvis_no_access.html")
+		with open(html_path) as f:
+			template_src = f.read()
+		html = jinja2.Template(template_src).render(agent_name="Acme Assistant", user_fullname="Priya Sharma")
+		self.assertIn("You need access to Acme Assistant", html)
+		self.assertIn("and Acme Assistant is all yours", html)
+		self.assertNotIn("You need access to Jarvis", html)
+		self.assertNotIn("and Jarvis is all yours", html)
 
 	# --- (c) www.jarvis gate ------------------------------------------------- #
 

--- a/jarvis/www/jarvis_no_access.html
+++ b/jarvis/www/jarvis_no_access.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="robots" content="noindex, nofollow" />
-		<title>Jarvis · Access required</title>
+		<title>{{ agent_name | e }} · Access required</title>
 		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 		<meta name="theme-color" content="#16161a" media="(prefers-color-scheme: dark)" />
 		<!-- The Jarvis mark uses the SPA brand gradient (JarvisMark.vue) inline; every
@@ -255,8 +255,8 @@
 			<div class="jvna-pill"><i></i>Signed in as <strong>{{ user_fullname | e }}</strong></div>
 			{% endif %}
 
-			<h1>You need access to Jarvis</h1>
-			<p class="jvna-body">You&rsquo;re not authorized just yet. One quick request to your admin, and Jarvis is all yours.</p>
+			<h1>You need access to {{ agent_name | e }}</h1>
+			<p class="jvna-body">You&rsquo;re not authorized just yet. One quick request to your admin, and {{ agent_name | e }} is all yours.</p>
 
 			<div class="jvna-actions">
 				<a class="jvna-btn jvna-btn-primary" href="/app">Back to Home</a>

--- a/jarvis/www/jarvis_no_access.py
+++ b/jarvis/www/jarvis_no_access.py
@@ -24,4 +24,18 @@ def get_context(context):
 		raise frappe.Redirect
 
 	context.user_fullname = frappe.utils.get_fullname(frappe.session.user)
+
+	# Whitelabel branding: same lookup as www/jarvis.py and www/jarvis_mobile.py,
+	# so a white-label tenant doesn't leak the underlying "Jarvis" brand on this
+	# gate page. Blank => the template falls back to "Jarvis".
+	_brand = (
+		frappe.get_cached_value(
+			"Jarvis Settings",
+			"Jarvis Settings",
+			["agent_name"],
+			as_dict=True,
+		)
+		or {}
+	)
+	context.agent_name = _brand.get("agent_name") or "Jarvis"
 	return context


### PR DESCRIPTION
Fixes #773 (white-label brand leak only; the rest of #773 is already covered/fine-as-is).

`www/jarvis_no_access.html` hardcoded "Jarvis" in the title, heading, and body copy, so a white-label tenant with a custom agent name still saw "Jarvis" on this gate page while every other surface (`www/jarvis.py`, `www/jarvis_mobile.py`) substitutes the tenant's `agent_name`.

`jarvis_no_access.py` now resolves `agent_name` the same way those two surfaces do and passes it to the template, with a fallback to "Jarvis" only when unset, so existing non-white-label tenants are unchanged.

<details>
<summary>Mechanism and evidence</summary>

- `jarvis/www/jarvis_no_access.py`: added the same `frappe.get_cached_value("Jarvis Settings", "Jarvis Settings", ["agent_name"], as_dict=True)` lookup used in `www/jarvis.py`/`www/jarvis_mobile.py`, setting `context.agent_name = _brand.get("agent_name") or "Jarvis"`.
- `jarvis/www/jarvis_no_access.html`: replaced the hardcoded "Jarvis" in `<title>`, `<h1>`, and body copy with `{{ agent_name | e }}`.
- Tests added to `jarvis/tests/test_no_access_page.py`: custom agent_name renders in context, blank agent_name falls back to "Jarvis", and a direct Jinja render of the template confirms the literal "Jarvis" copy is gone when a custom name is set. Command: `bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_no_access_page --case TestJarvisNoAccessPage`, result 21/21 pass.
- Screenshot: an offline Jinja render of the fixed template (agent_name="Acme Assistant") confirms the visual result, since the local bench serves a different worktree/branch and a true live render wasn't available in this session.

Deferred as follow-up (not touched here, live in other files): the `support@aerele.in` address and docs URLs in `frontend/src/views/OnboardingView.vue:2841` and `TourIntro.vue:550` are also brand-coupled strings, out of scope for this fix.

</details>