### PR TITLE
fix(chat): surface an operator signal for auth faults on pinned title/suggestions lanes (#738)

### DIFF
--- a/jarvis/chat/suggestions.py
+++ b/jarvis/chat/suggestions.py
@@ -31,7 +31,13 @@ import time
 
 import frappe
 
-from jarvis.chat.title import _clean, _is_greeting
+from jarvis.chat.title import (
+	_auth_fault_detail,
+	_clean,
+	_is_auth_fault,
+	_is_greeting,
+	_log_pinned_lane_auth_fault,
+)
 
 CONV = "Jarvis Conversation"
 MSG_DT = "Jarvis Chat Message"
@@ -215,6 +221,7 @@ def _generate_via_gateway(gateway_url, titles: list[str], *, model, provider) ->
 
 	prompt = _PROMPT.format(n=WANT, titles="\n".join(titles))
 	text = ""
+	lifecycle_error: str | None = None
 	label = f"jarvis-suggest-{frappe.generate_hash(length=10)}"
 	try:
 		with agent_session_pool.checkout(gateway_url) as sess:
@@ -231,6 +238,11 @@ def _generate_via_gateway(gateway_url, titles: list[str], *, model, provider) ->
 				):
 					if ev.get("kind") == "assistant" and ev.get("text"):
 						text = ev["text"]
+					elif ev.get("kind") == "lifecycle" and ev.get("phase") == "error" and ev.get("error"):
+						# See jarvis.chat.title._generate_via_gateway's copy of
+						# this branch: openclaw's only place the run names a
+						# provider failure, and it never raises here.
+						lifecycle_error = str(ev["error"])
 				run_ended = True
 			finally:
 				reclaim_throwaway_session(
@@ -239,12 +251,17 @@ def _generate_via_gateway(gateway_url, titles: list[str], *, model, provider) ->
 					logger_name="jarvis.chat.suggestions",
 					fired_at=None if run_ended else fired_at,
 				)
-	except Exception:
+	except Exception as e:
+		detail = _auth_fault_detail(e)
+		if detail:
+			_log_pinned_lane_auth_fault("suggestions", detail, model=model, provider=provider)
 		frappe.log_error(
 			title="prompt suggestions: gateway generation failed",
 			message=frappe.get_traceback(),
 		)
 		return []
+	if not text and _is_auth_fault(lifecycle_error):
+		_log_pinned_lane_auth_fault("suggestions", lifecycle_error, model=model, provider=provider)
 	return parse_lines(text)
 
 

--- a/jarvis/chat/suggestions.py
+++ b/jarvis/chat/suggestions.py
@@ -240,7 +240,7 @@ def _generate_via_gateway(gateway_url, titles: list[str], *, model, provider) ->
 						text = ev["text"]
 					elif ev.get("kind") == "lifecycle" and ev.get("phase") == "error" and ev.get("error"):
 						# See jarvis.chat.title._generate_via_gateway's copy of
-						# this branch: openclaw's only place the run names a
+						# this branch: the agent runtime's only place the run names a
 						# provider failure, and it never raises here.
 						lifecycle_error = str(ev["error"])
 				run_ended = True

--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -81,6 +81,86 @@ _TITLE_PROMPT = (
 )
 
 
+# A credential/provider-auth fault on the PINNED title/suggestions lane (#531
+# pins model+provider, dropping failover) gets no signal today: it is
+# swallowed exactly like an ordinary transient gateway blip, so an operator
+# has nothing to key on. This is deliberately narrow - HTTP 401/403 and each
+# provider's own auth vocabulary - so an ordinary failure (rate limit,
+# timeout, context overflow) still stays silently swallowed (#738).
+_AUTH_FAULT_RE = re.compile(
+	r"\b40[13]\b"
+	r"|unauthorized|unauthenticated|forbidden"
+	r"|authentication[_ ]?error"
+	r"|invalid[_ -]?api[_ -]?key|invalid[_ -]x-api-key|incorrect api key"
+	r"|permission[_ -]?denied"
+	r"|credential",
+	re.IGNORECASE,
+)
+
+
+def _is_auth_fault(text: str | None) -> bool:
+	"""True when ``text`` (a provider error string, or an exception's own text)
+	names an auth/credential fault rather than an ordinary failure."""
+	return bool(text) and bool(_AUTH_FAULT_RE.search(text))
+
+
+def _auth_fault_detail(exc: Exception) -> str | None:
+	"""The matched auth-fault text for ``exc``, or None when it isn't one.
+
+	Checks the exception's own message plus, when present, the structured
+	``.code`` / ``.details`` an ``AgentUnreachableError`` carries (see
+	jarvis.chat.agent_client). Explicitly excludes a stale device-token
+	pairing fault (``_is_stale_pairing``) - that is a whole-connection auth
+	failure with its own self-heal path, not a pinned-model credential
+	problem, and folding it in here would widen the signal past #738's scope."""
+	from jarvis.chat.agent_client import _is_stale_pairing
+
+	if _is_stale_pairing(exc):
+		return None
+	parts = [str(exc)]
+	code = getattr(exc, "code", None)
+	if code:
+		parts.append(str(code))
+	details = getattr(exc, "details", None)
+	if isinstance(details, dict):
+		parts.extend(str(v) for v in details.values())
+	combined = " | ".join(p for p in parts if p)
+	return combined if _is_auth_fault(combined) else None
+
+
+def _log_pinned_lane_auth_fault(lane: str, detail: str, *, model: str | None, provider: str | None) -> None:
+	"""Distinct, greppable Error Log for a credential fault on the PINNED
+	title/suggestions lane, so an operator (or the admin Errors feed that
+	``jarvis.error_push`` already forwards every jarvis-origin Error Log row
+	to, on its */5 cron) can key on this one instead of it drowning among
+	ordinary swallowed gateway blips. Still best-effort and additive only:
+	the lane's own fallback (derive_title / the previous suggestions strip)
+	runs exactly as it does for any other failure - this never changes what
+	the customer sees, it only adds the operator signal (#738).
+
+	The dotted ``jarvis.chat.<lane>:`` title is load-bearing on the
+	lifecycle-error path (no traceback to key off), where
+	``api_errors.is_jarvis_error`` only recognises this row via
+	``method.split(".", 1)[0] == "jarvis"``. The trailing synthetic
+	exception line gives ``api_errors._parse_traceback`` a real (class,
+	message) pair, so the admin-feed fingerprint keys on THIS fault instead
+	of folding into every other traceback-less log call here."""
+	exc_class = f"JarvisPinned{lane.capitalize()}AuthError"
+	try:
+		frappe.log_error(
+			title=f"jarvis.chat.{lane}: pinned lane auth fault",
+			message=(
+				f"Pinned-lane credential fault (#738): the {lane} lane pins "
+				f"model={model!r} provider={provider!r} and cannot fail over "
+				f"(#531). Chat/title continues via the lane's own fallback; "
+				f"this is only the operator signal.\n\n{detail}\n\n"
+				f"{exc_class}: lane={lane} model={model!r} provider={provider!r}"
+			),
+		)
+	except Exception:
+		pass
+
+
 def _clean(text: str | None) -> str:
 	return (text or "").strip()
 
@@ -156,6 +236,7 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 
 	prompt = _TITLE_PROMPT.format(msg=source_text[:_SOURCE_MAX_CHARS])
 	text = ""
+	lifecycle_error: str | None = None
 	# agent rejects sessions.create with a label that's already in use, so
 	# the label MUST be unique per call — a fixed "jarvis-title" works the first
 	# time then fails ("label already in use") and silently falls back to the
@@ -180,6 +261,12 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 				):
 					if ev.get("kind") == "assistant" and ev.get("text"):
 						text = ev["text"]
+					elif ev.get("kind") == "lifecycle" and ev.get("phase") == "error" and ev.get("error"):
+						# openclaw's ONLY place the run names a provider failure
+						# (see agent_client.failed_final_error). Not raised - the
+						# loop just ends with no text - so without this it is
+						# invisible: not even the generic except below fires.
+						lifecycle_error = str(ev["error"])
 				run_ended = True
 			finally:
 				# Reclaim the throwaway on the SAME pooled connection, turn
@@ -215,12 +302,17 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 					logger_name="jarvis.chat.title",
 					fired_at=None if run_ended else fired_at,
 				)
-	except Exception:
+	except Exception as e:
+		detail = _auth_fault_detail(e)
+		if detail:
+			_log_pinned_lane_auth_fault("title", detail, model=model, provider=provider)
 		frappe.log_error(
 			title="auto-title: gateway generation failed",
 			message=frappe.get_traceback(),
 		)
 		return ""
+	if not text and _is_auth_fault(lifecycle_error):
+		_log_pinned_lane_auth_fault("title", lifecycle_error, model=model, provider=provider)
 	return normalize_title(text)
 
 

--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -262,7 +262,7 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 					if ev.get("kind") == "assistant" and ev.get("text"):
 						text = ev["text"]
 					elif ev.get("kind") == "lifecycle" and ev.get("phase") == "error" and ev.get("error"):
-						# openclaw's ONLY place the run names a provider failure
+						# the agent runtime's ONLY place the run names a provider failure
 						# (see agent_client.failed_final_error). Not raised - the
 						# loop just ends with no text - so without this it is
 						# invisible: not even the generic except below fires.

--- a/jarvis/tests/test_pinned_lane_auth_signal.py
+++ b/jarvis/tests/test_pinned_lane_auth_signal.py
@@ -1,0 +1,287 @@
+"""Issue #738. The auto-title and suggestions lanes pin a model+provider
+(#531, dropping failover on purpose) and then swallow every failure so a
+title/suggestions blip never breaks chat. That swallowing is correct - but it
+means a credential/provider-auth fault on ONLY the pinned model produced no
+signal at all: not the customer (by design) and not an operator either.
+
+Two failure shapes reach ``_generate_via_gateway`` and both need the same
+treatment:
+
+  - an in-run provider failure, which openclaw reports as a lifecycle
+    ``phase == "error"`` event carrying the provider's own error text and
+    never raises (see agent_client.failed_final_error) - before this fix
+    that text was read by nobody, auth fault or not;
+  - a raised exception (connect/ack rejection, WS drop, timeout).
+
+For each shape: an AUTH fault (401/403, "unauthorized", a provider's own
+auth vocabulary) must emit ONE distinct, greppable Error Log
+(jarvis.chat.title._log_pinned_lane_auth_fault) while the lane still falls
+back exactly as before; an ORDINARY failure must stay swallowed with no new
+signal, byte-identical to pre-#738 behaviour. A stale device-token pairing
+fault (a whole-connection auth failure with its own self-heal path, not a
+pinned-model credential problem) must NOT be classified as a #738 auth fault
+even though its own text says "unauthorized".
+
+SCOPE NOTE: the transport is stubbed, as everywhere else in this suite (see
+test_throwaway_session_reclaim.py) - these tests assert what the bench does
+with the events/exceptions openclaw can hand it, not openclaw's own behaviour.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import AgentUnreachableError
+
+SKEY = "agent:main:dashboard:throwaway-1"
+
+DISTINCT_TITLE_PREFIX = "jarvis.chat."
+GENERIC_TITLE_AUTOTITLE = "auto-title: gateway generation failed"
+GENERIC_TITLE_SUGGEST = "prompt suggestions: gateway generation failed"
+
+
+def _pool_session(*, events=None, raises=None) -> MagicMock:
+	"""A pooled AgentSession stub whose run is never reported active, so the
+	reclaim in ``finally`` never blocks these tests on the busy-probe path
+	covered by test_throwaway_session_reclaim.py."""
+	sess = MagicMock()
+	sess.create_session.return_value = SKEY
+	sess.is_run_active.return_value = False
+	if raises is not None:
+		sess.stream_agent_turn.side_effect = raises
+	else:
+		sess.stream_agent_turn.return_value = iter(events or [])
+	return sess
+
+
+@contextlib.contextmanager
+def _checkout_yielding(sess):
+	@contextlib.contextmanager
+	def _cm(_gateway_url):
+		yield sess
+
+	with patch("jarvis.chat.agent_session_pool.checkout", _cm):
+		yield
+
+
+def _distinct_titles(log_error_mock) -> list[str]:
+	return [
+		c.kwargs.get("title")
+		for c in log_error_mock.call_args_list
+		if "pinned lane auth fault" in (c.kwargs.get("title") or "")
+	]
+
+
+class TestTitleLanePinnedAuthSignal(FrappeTestCase):
+	def _generate(self, sess):
+		from jarvis.chat import title
+
+		with _checkout_yielding(sess):
+			return title._generate_via_gateway(
+				"ws://gw.example",
+				"Show me last month's overdue invoices",
+				model="gpt-5.5-mini",
+				provider="OpenAI",
+			)
+
+	def test_lifecycle_auth_fault_emits_signal_and_still_falls_back(self):
+		sess = _pool_session(
+			events=[
+				{
+					"kind": "lifecycle",
+					"phase": "error",
+					"error": "OpenAI API error (401): Incorrect API key provided",
+				}
+			]
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, "", "chat/title must still fall back gracefully")
+		titles = _distinct_titles(log_error)
+		self.assertEqual(len(titles), 1)
+		self.assertTrue(titles[0].startswith(DISTINCT_TITLE_PREFIX))
+		self.assertIn("title", titles[0])
+
+	def test_lifecycle_ordinary_failure_stays_silent(self):
+		"""No exception, no auth text - this is the pre-#738 case where nothing
+		was ever logged at all. Must stay exactly that way: no new signal."""
+		sess = _pool_session(
+			events=[
+				{
+					"kind": "lifecycle",
+					"phase": "error",
+					"error": "Google Generative AI API error (429): quota exceeded",
+				}
+			]
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, "")
+		log_error.assert_not_called()
+
+	def test_exception_auth_fault_emits_signal_alongside_the_generic_log(self):
+		sess = _pool_session(
+			raises=AgentUnreachableError(
+				"agent rejected: INVALID_REQUEST: authentication_error: invalid api key"
+			)
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, "")
+		all_titles = [c.kwargs.get("title") for c in log_error.call_args_list]
+		self.assertIn(GENERIC_TITLE_AUTOTITLE, all_titles, "existing swallow behaviour must be untouched")
+		self.assertEqual(len(_distinct_titles(log_error)), 1)
+
+	def test_exception_ordinary_failure_only_logs_the_generic_row(self):
+		sess = _pool_session(raises=AgentUnreachableError("agent turn timed out before lifecycle end"))
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, "")
+		log_error.assert_called_once()
+		self.assertEqual(log_error.call_args.kwargs.get("title"), GENERIC_TITLE_AUTOTITLE)
+		self.assertEqual(_distinct_titles(log_error), [])
+
+	def test_stale_device_pairing_fault_is_not_a_pinned_lane_auth_fault(self):
+		"""A whole-connection auth failure (#525/#535's own self-heal path),
+		not a pinned-model credential problem - must not widen #738's signal."""
+		sess = _pool_session(
+			raises=AgentUnreachableError(
+				"connect rejected: INVALID_REQUEST: unauthorized: device token mismatch "
+				"(rotate/reissue device token)",
+				details={"authReason": "device_token_mismatch"},
+			)
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, "")
+		self.assertEqual(_distinct_titles(log_error), [])
+
+
+class TestSuggestionsLanePinnedAuthSignal(FrappeTestCase):
+	def _generate(self, sess):
+		from jarvis.chat import suggestions
+
+		with _checkout_yielding(sess):
+			return suggestions._generate_via_gateway(
+				"ws://gw.example",
+				["Timesheet Report Date Range", "Purchase Order Approval Flow"],
+				model="gpt-5.5-mini",
+				provider="OpenAI",
+			)
+
+	def test_lifecycle_auth_fault_emits_signal_and_still_falls_back(self):
+		sess = _pool_session(
+			events=[
+				{
+					"kind": "lifecycle",
+					"phase": "error",
+					"error": "Anthropic API error (403): permission_denied",
+				}
+			]
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, [], "the suggestions strip must still fall back gracefully")
+		titles = _distinct_titles(log_error)
+		self.assertEqual(len(titles), 1)
+		self.assertTrue(titles[0].startswith(DISTINCT_TITLE_PREFIX))
+		self.assertIn("suggestions", titles[0])
+
+	def test_lifecycle_ordinary_failure_stays_silent(self):
+		sess = _pool_session(
+			events=[{"kind": "lifecycle", "phase": "error", "error": "context overflow: prompt too large"}]
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, [])
+		log_error.assert_not_called()
+
+	def test_exception_auth_fault_emits_signal_alongside_the_generic_log(self):
+		sess = _pool_session(
+			raises=AgentUnreachableError("agent rejected: INVALID_REQUEST: 401 unauthorized")
+		)
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, [])
+		all_titles = [c.kwargs.get("title") for c in log_error.call_args_list]
+		self.assertIn(GENERIC_TITLE_SUGGEST, all_titles)
+		self.assertEqual(len(_distinct_titles(log_error)), 1)
+
+	def test_exception_ordinary_failure_only_logs_the_generic_row(self):
+		sess = _pool_session(raises=AgentUnreachableError("agent turn timed out before lifecycle end"))
+
+		with patch("frappe.log_error") as log_error:
+			result = self._generate(sess)
+
+		self.assertEqual(result, [])
+		log_error.assert_called_once()
+		self.assertEqual(log_error.call_args.kwargs.get("title"), GENERIC_TITLE_SUGGEST)
+
+
+class TestPinnedLaneAuthFaultReachesTheAdminFeed(FrappeTestCase):
+	"""``_log_pinned_lane_auth_fault``'s shape has two contracts with
+	``jarvis.api_errors`` that the tests above never exercise (they only see
+	that ``frappe.log_error`` was called, not what the error-forwarding
+	pipeline does with the row afterwards): the dotted ``jarvis.chat.<lane>:``
+	title is what lets ``is_jarvis_error`` recognise it on the lifecycle path
+	(no traceback), and the synthetic trailing exception line is what keeps
+	its admin-feed fingerprint from folding into every other traceback-less
+	log call here. Pinning both directly means a future reformat of the
+	message can't silently sever the signal from the feed while every test
+	above still passes."""
+
+	def _logged(self, lane: str) -> tuple[str, str]:
+		from jarvis.chat.title import _log_pinned_lane_auth_fault
+
+		with patch("frappe.log_error") as log_error:
+			_log_pinned_lane_auth_fault(
+				lane,
+				"OpenAI API error (401): Incorrect API key provided",
+				model="gpt-5.5",
+				provider="OpenAI",
+			)
+		call = log_error.call_args
+		return call.kwargs["title"], call.kwargs["message"]
+
+	def test_title_row_is_recognised_as_jarvis_origin(self):
+		from jarvis import api_errors
+
+		title, message = self._logged("title")
+		self.assertTrue(api_errors.is_jarvis_error(title, message))
+
+	def test_suggestions_row_is_recognised_as_jarvis_origin(self):
+		from jarvis import api_errors
+
+		title, message = self._logged("suggestions")
+		self.assertTrue(api_errors.is_jarvis_error(title, message))
+
+	def test_each_lane_gets_a_distinct_admin_feed_fingerprint(self):
+		from jarvis import api_errors
+
+		_, title_message = self._logged("title")
+		_, suggestions_message = self._logged("suggestions")
+		title_class, _, _ = api_errors._parse_traceback(title_message)
+		suggestions_class, _, _ = api_errors._parse_traceback(suggestions_message)
+
+		self.assertEqual(title_class, "JarvisPinnedTitleAuthError")
+		self.assertEqual(suggestions_class, "JarvisPinnedSuggestionsAuthError")
+		self.assertNotEqual(title_class, suggestions_class)

--- a/jarvis/tests/test_pinned_lane_auth_signal.py
+++ b/jarvis/tests/test_pinned_lane_auth_signal.py
@@ -7,7 +7,7 @@ signal at all: not the customer (by design) and not an operator either.
 Two failure shapes reach ``_generate_via_gateway`` and both need the same
 treatment:
 
-  - an in-run provider failure, which openclaw reports as a lifecycle
+  - an in-run provider failure, which the agent runtime reports as a lifecycle
     ``phase == "error"`` event carrying the provider's own error text and
     never raises (see agent_client.failed_final_error) - before this fix
     that text was read by nobody, auth fault or not;
@@ -24,7 +24,7 @@ even though its own text says "unauthorized".
 
 SCOPE NOTE: the transport is stubbed, as everywhere else in this suite (see
 test_throwaway_session_reclaim.py) - these tests assert what the bench does
-with the events/exceptions openclaw can hand it, not openclaw's own behaviour.
+with the events/exceptions the agent runtime can hand it, not the runtime's own behaviour.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

The auto-title and suggestions lanes pin a model+provider (#531) and swallow every failure, correctly, so a title/suggestion blip never breaks chat. But a credential/provider-auth fault on the pinned model got NO signal at all: an in-run provider failure arrives as an openclaw lifecycle error event that nobody read, and the raised-exception path logged the same generic Error Log regardless of cause. This adds one distinct, greppable Error Log for the auth-fault case specifically, reusing the existing `error_push` cron that already forwards jarvis-origin Error Log rows to the admin Errors feed every 5 minutes. Ordinary (non-auth) failures stay swallowed exactly as before.

Fixes #738

<details>
<summary>Mechanism</summary>

- `jarvis/chat/title.py`: new `_is_auth_fault` (401/403 + provider auth vocabulary), `_auth_fault_detail` (excludes stale device-token pairing, which is a whole-connection fault with its own self-heal, not a pinned-model credential problem), and `_log_pinned_lane_auth_fault`, which logs `title="jarvis.chat.<lane>: pinned lane auth fault"` plus a synthetic `JarvisPinned<Lane>AuthError` line so `api_errors._parse_traceback`/`is_jarvis_error` classify and fingerprint it correctly for the admin feed.
- `_generate_via_gateway` in both `title.py` and `suggestions.py` now also captures the lifecycle `phase == "error"` event text (previously ignored entirely) and classifies both that and any raised exception.
- No change to pinning, to the general swallow behavior, or to any customer-visible path.

Tests: `jarvis/tests/test_pinned_lane_auth_signal.py`, 12 cases covering both lanes' lifecycle-error and exception paths (auth vs ordinary), the stale-pairing exclusion, and that the logged row actually reaches the admin-feed classifier/fingerprint functions.
</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `develop`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff