### PR TITLE
feat(wiki): remove a curated Knowledge Graph link (#644)

### DIFF
--- a/frontend/src/api/wiki.js
+++ b/frontend/src/api/wiki.js
@@ -70,6 +70,10 @@ export const getWikiGraph = () => call(WK + "get_wiki_graph");
 // concurrency-safe, permission-checked both ends. → {ok, manual_links, already?}
 export const addWikiLink = (slug, targetSlug) =>
 	call(WK + "add_wiki_link", { slug, target_slug: targetSlug });
+// Undo a curated [[link]] slug→target. Same permission/lock shape as addWikiLink;
+// removing a link that isn't there is a safe no-op. → {ok, manual_links, already?}
+export const removeWikiLink = (slug, targetSlug) =>
+	call(WK + "remove_wiki_link", { slug, target_slug: targetSlug });
 // Measured daily graph totals [{date, pages, links, orphans, ...}] for the
 // Evolution tab; [] until the daily snapshot job has recorded a day.
 export const getWikiGraphHistory = () => call(WK + "get_wiki_graph_history");

--- a/frontend/src/pages/wiki/KnowledgeGraph.spec.js
+++ b/frontend/src/pages/wiki/KnowledgeGraph.spec.js
@@ -27,9 +27,16 @@ const nodes = [
 ];
 const UNLINKED = { nodes, edges: [] };
 const LINKED = { nodes, edges: [{ source: A_ID, target: B_ID, kind: "links-to" }] };
+// #644: A curated a link to B. `manual_links` only ever rides on the node that
+// did the linking (the server-side asymmetry `get_wiki_graph` returns).
+const LINKED_WITH_MANUAL = {
+	nodes: [{ ...nodes[0], manual_links: [B_SLUG] }, nodes[1]],
+	edges: [{ source: A_ID, target: B_ID, kind: "links-to" }],
+};
 
 const api = vi.hoisted(() => ({
 	addWikiLink: vi.fn(async () => ({ ok: true, manual_links: ["process--billing"] })),
+	removeWikiLink: vi.fn(async () => ({ ok: true, manual_links: [] })),
 	getWikiGraph: vi.fn(),
 	getWikiGraphHistory: vi.fn(async () => []),
 }));
@@ -67,8 +74,17 @@ vi.mock("frappe-ui", () => {
 	};
 });
 
-// Captured live prop objects (reactive), plus a handle on AnalysisTabs' emit.
-const seen = vi.hoisted(() => ({ detail: null, tabs: null, graph: null, fireAddLink: null }));
+// Captured live prop objects (reactive), plus handles on the child emits this
+// suite drives: AnalysisTabs' add-link, Graph3D's node-click (selection),
+// DetailPanel's remove-link.
+const seen = vi.hoisted(() => ({
+	detail: null,
+	tabs: null,
+	graph: null,
+	fireAddLink: null,
+	fireNodeClick: null,
+	fireRemoveLink: null,
+}));
 
 vi.mock("wiki-graph-core", () => {
 	const stub = (name, props, slot, emits = []) => ({
@@ -78,16 +94,23 @@ vi.mock("wiki-graph-core", () => {
 		setup(componentProps, { emit }) {
 			seen[slot] = componentProps;
 			if (name === "AnalysisTabs") seen.fireAddLink = (s) => emit("add-link", s);
+			if (name === "Graph3D") seen.fireNodeClick = (n) => emit("node-click", n);
+			if (name === "DetailPanel") seen.fireRemoveLink = (t) => emit("remove-link", t);
 			return () => h("div", { class: name });
 		},
 	});
 	return {
-		// Prop defaults copied from the real package: DetailPanel.vue showActions,
-		// AnalysisTabs.vue canAct / showPriority / showActionsTab.
+		// Prop defaults copied from the real package: DetailPanel.vue showActions /
+		// canRemoveLink, AnalysisTabs.vue canAct / showPriority / showActionsTab.
 		DetailPanel: stub(
 			"DetailPanel",
-			{ showActions: { type: Boolean, default: true } },
-			"detail"
+			{
+				node: Object,
+				showActions: { type: Boolean, default: true },
+				canRemoveLink: { type: Boolean, default: false },
+			},
+			"detail",
+			["focus", "remove-link"]
 		),
 		AnalysisTabs: stub(
 			"AnalysisTabs",
@@ -106,7 +129,8 @@ vi.mock("wiki-graph-core", () => {
 		Graph3D: stub(
 			"Graph3D",
 			{ data: Object, metrics: Object, mode: String, dark: Boolean },
-			"graph"
+			"graph",
+			["node-click"]
 		),
 		FilterBar: { name: "FilterBar", setup: () => () => h("div") },
 		ExclusionRules: { name: "ExclusionRules", setup: () => () => h("div") },
@@ -141,6 +165,8 @@ beforeEach(() => {
 	localStorage.clear();
 	api.addWikiLink.mockClear();
 	api.addWikiLink.mockResolvedValue({ ok: true, manual_links: [B_SLUG] });
+	api.removeWikiLink.mockClear();
+	api.removeWikiLink.mockResolvedValue({ ok: true, manual_links: [] });
 	api.getWikiGraphHistory.mockClear();
 	api.getWikiGraph.mockReset();
 	api.getWikiGraph.mockResolvedValue(UNLINKED);
@@ -227,6 +253,100 @@ describe("KnowledgeGraph action layer (#492)", () => {
 		seen.fireAddLink(SUGGESTION);
 		await flushPromises();
 		expect(api.addWikiLink).toHaveBeenCalledTimes(1);
+
+		release();
+		await flushPromises();
+		expect(seen.tabs.canAct).toBe(true);
+		expect(wrapper.exists()).toBe(true);
+	});
+});
+
+// #644: the undo counterpart. add_wiki_link had no way to remove a curated link,
+// so a mis-clicked "+ link" was permanent short of a Desk/DB edit.
+describe("KnowledgeGraph remove-link affordance (#644)", () => {
+	it("passes can-remove-link and the selected node's curated links to the detail panel", async () => {
+		api.getWikiGraph.mockResolvedValue(LINKED_WITH_MANUAL);
+		await mountGraph();
+		expect(seen.detail.canRemoveLink).toBe(true);
+
+		seen.fireNodeClick(seen.graph.data.nodes.find((n) => n.id === A_ID));
+		await flushPromises();
+		expect(seen.detail.node.manual_links).toEqual([B_SLUG]);
+	});
+
+	it("removes the curated link and the edge disappears after the refetch", async () => {
+		api.getWikiGraph.mockResolvedValue(LINKED_WITH_MANUAL);
+		const wrapper = await mountGraph();
+		seen.fireNodeClick(seen.graph.data.nodes.find((n) => n.id === A_ID));
+		await flushPromises();
+		expect(seen.graph.data.edges).toHaveLength(1);
+
+		// the server now reports the link gone
+		api.getWikiGraph.mockResolvedValue(UNLINKED);
+		seen.fireRemoveLink(B_SLUG);
+		await flushPromises();
+		await flushPromises();
+
+		// node ids are "page:<slug>"; the endpoint takes the bare source slug plus
+		// the bare target slug that DetailPanel emitted.
+		expect(api.removeWikiLink).toHaveBeenCalledWith(A_SLUG, B_SLUG);
+		expect(api.getWikiGraph).toHaveBeenCalledTimes(2);
+		expect(seen.graph.data.edges).toHaveLength(0);
+		expect(wrapper.text()).toContain(`Removed link to ${B_SLUG}`);
+		// the panel re-points at the refetched node, whose manual_links no longer
+		// includes B (the fixture's post-removal shape carries none at all).
+		expect(seen.detail.node.manual_links || []).toEqual([]);
+	});
+
+	it("still reports success when only the refetch fails, because the link is gone", async () => {
+		api.getWikiGraph.mockResolvedValueOnce(LINKED_WITH_MANUAL);
+		const wrapper = await mountGraph();
+		seen.fireNodeClick(seen.graph.data.nodes.find((n) => n.id === A_ID));
+		await flushPromises();
+
+		api.getWikiGraph.mockRejectedValueOnce(new Error("Network error"));
+		seen.fireRemoveLink(B_SLUG);
+		await flushPromises();
+		await flushPromises();
+
+		expect(api.removeWikiLink).toHaveBeenCalledTimes(1);
+		expect(wrapper.text()).toContain(`Removed link to ${B_SLUG}`);
+		expect(wrapper.text()).not.toContain("Network error");
+	});
+
+	it("surfaces a server denial and leaves the link in place", async () => {
+		api.getWikiGraph.mockResolvedValue(LINKED_WITH_MANUAL);
+		const wrapper = await mountGraph();
+		seen.fireNodeClick(seen.graph.data.nodes.find((n) => n.id === A_ID));
+		await flushPromises();
+
+		api.removeWikiLink.mockRejectedValueOnce(new Error("Not permitted."));
+		seen.fireRemoveLink(B_SLUG);
+		await flushPromises();
+		await flushPromises();
+
+		expect(wrapper.text()).toContain("Not permitted.");
+		expect(api.getWikiGraph).toHaveBeenCalledTimes(1);
+		expect(seen.graph.data.edges).toHaveLength(1);
+	});
+
+	it("ignores a second click while one removal is in flight", async () => {
+		api.getWikiGraph.mockResolvedValue(LINKED_WITH_MANUAL);
+		const wrapper = await mountGraph();
+		seen.fireNodeClick(seen.graph.data.nodes.find((n) => n.id === A_ID));
+		await flushPromises();
+
+		let release;
+		api.removeWikiLink.mockReturnValueOnce(
+			new Promise((r) => (release = () => r({ ok: true })))
+		);
+		seen.fireRemoveLink(B_SLUG);
+		await flushPromises();
+		expect(seen.tabs.canAct).toBe(false);
+
+		seen.fireRemoveLink(B_SLUG);
+		await flushPromises();
+		expect(api.removeWikiLink).toHaveBeenCalledTimes(1);
 
 		release();
 		await flushPromises();

--- a/frontend/src/pages/wiki/KnowledgeGraph.vue
+++ b/frontend/src/pages/wiki/KnowledgeGraph.vue
@@ -77,7 +77,9 @@
 					:node="state.selected"
 					:metrics="state.analysis.metrics"
 					:communities="state.analysis.communities"
+					:can-remove-link="true"
 					@focus="(id) => (state.focus = id)"
+					@remove-link="onRemoveLink"
 				/>
 				<AnalysisTabs
 					:analysis="state.analysis"
@@ -99,7 +101,9 @@
 // Tenant Knowledge Graph — the productive tool. Fetch caller-scoped graph → apply
 // exclusion → worker analysis (structure + TF-IDF similarity) → 3D graph + the
 // four analysis tabs. Productive loop: accept a suggested connection → add_wiki_link
-// (durable, out-of-body) → refetch → the edge appears.
+// (durable, out-of-body) → refetch → the edge appears. #644 wires the undo side:
+// select a page, see its curated links in the detail panel, remove one →
+// remove_wiki_link → refetch → the edge disappears.
 //
 // That loop used to be described here and switched off in the template: the page
 // passed :show-actions / :can-act / :show-priority / :show-actions-tab as false,
@@ -126,7 +130,7 @@ import {
 	egoGraph,
 	searchGraph,
 } from "wiki-graph-core";
-import { addWikiLink, getWikiGraph, getWikiGraphHistory } from "@/api/wiki";
+import { addWikiLink, getWikiGraph, getWikiGraphHistory, removeWikiLink } from "@/api/wiki";
 import { useJarvisTheme } from "@/theme";
 
 // Same breadcrumb + persistent "Open ERPNext Desk" top bar the other Skills
@@ -294,6 +298,36 @@ async function onAddLink(suggestion) {
 	toast(`Linked ${suggestion.aLabel || from} to ${suggestion.bLabel || to}`);
 	try {
 		await refetchGraph();
+	} catch (_) {}
+}
+
+// The undo side of the same loop (#644): a curated link shown in the detail
+// panel of the page it starts from -> remove -> a refetch that drops the edge.
+// remove_wiki_link is a safe no-op on a link that's already gone, so a stray
+// double-click just re-confirms it's absent rather than erroring.
+async function onRemoveLink(targetSlug) {
+	if (state.linking || !state.selected || !targetSlug) return;
+	const from = slugOf(state.selected.id);
+	if (!from) return;
+
+	state.linking = true;
+	try {
+		await removeWikiLink(from, targetSlug);
+	} catch (e) {
+		toast((e && e.message) || "Could not remove that link.");
+		return;
+	} finally {
+		state.linking = false;
+	}
+
+	toast(`Removed link to ${targetSlug}`);
+	try {
+		await refetchGraph();
+		// refetchGraph replaces state.data.nodes wholesale, so state.selected still
+		// points at the pre-removal node object; re-point it at the fresh one so
+		// the panel actually shows the link gone instead of looking unchanged.
+		const again = (state.data.nodes || []).find((n) => n.id === state.selected?.id);
+		if (again) state.selected = again;
 	} catch (_) {}
 }
 

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -2249,3 +2249,52 @@ def add_wiki_link(slug: str, target_slug: str) -> dict:
 	# stale doc raises TimestampMismatch instead of silently clobbering (R1).
 	frappe.db.set_value(WIKI, name, "manual_links", json.dumps(links))
 	return {"ok": True, "slug": slug, "manual_links": links}
+
+
+@frappe.whitelist()
+def remove_wiki_link(slug: str, target_slug: str) -> dict:
+	"""Undo a curated ``[[link]]`` from ``slug`` -> ``target_slug`` in
+	``manual_links``.
+
+	#644: ``add_wiki_link`` had no counterpart, so a mis-clicked "+ link" was
+	permanent short of a Desk/DB edit. Mirrors ``add_wiki_link`` exactly for
+	permission shape and locking; only the mutation differs (remove, not append):
+
+	- R1 durable: this write never touches body_md either.
+	- R2 idempotent: removing a target that isn't there is a safe no-op.
+	- R2 concurrency-safe: the SAME row-locking read (``for_update``) as add, so
+	  this sees the latest committed value rather than a stale snapshot.
+	- R3 permission-checked BOTH ends: caller must be able to EDIT ``slug`` and
+	  READ ``target_slug``, the same bar as adding, so no one can remove a link
+	  they couldn't have added, and a non-visible target reads as not-found so its
+	  existence isn't disclosed. (A manual link whose target page was since
+	  deleted can't be removed through this endpoint either; it also never
+	  renders as an edge, since the graph drops dangling links, so it's inert.)"""
+	_require_system_user()
+	slug = (slug or "").strip().lower()
+	target = (target_slug or "").strip().lower()
+	if not slug or not target:
+		frappe.throw(_("slug and target_slug are required."))
+
+	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
+	if not name:
+		frappe.throw(_("Wiki page not found."))
+	if not wiki_permissions.can_edit_page(frappe.get_doc(WIKI, name), frappe.session.user):
+		frappe.throw(_("Not permitted."), frappe.PermissionError)
+
+	target_name = frappe.db.get_value(WIKI, {"slug": target}, "name")
+	if not target_name or not wiki_permissions.can_read_page(
+		frappe.get_doc(WIKI, target_name), frappe.session.user
+	):
+		# Don't disclose a page the caller can't see.
+		frappe.throw(_("Target page not found."))
+
+	# Locking read: same reason as add_wiki_link's (see there); blocks until any
+	# concurrent add/remove on this row commits, then returns the latest value.
+	raw = frappe.db.get_value(WIKI, name, "manual_links", for_update=True)
+	links = _parse_manual_links(raw)
+	if target not in links:
+		return {"ok": True, "slug": slug, "already": True, "manual_links": links}
+	links.remove(target)
+	frappe.db.set_value(WIKI, name, "manual_links", json.dumps(links))
+	return {"ok": True, "slug": slug, "manual_links": links}

--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -249,8 +249,10 @@ def _build_graph_from_pages(pages, include_content: bool = False, minimise_scope
 	Shared by ``compute_graph`` (org-wide → admin push) and ``get_wiki_graph``
 	(caller-scoped → tenant SPA). Nodes: one ``org``; ``role`` nodes per
 	``target_role``; ``user`` nodes for authors + User-page targets; a ``page``
-	node per page (slug, title, type, scope, stale/contradiction; +summary when
-	``include_content``). Edges: ``scope`` (page→tier), ``authored`` (user→page,
+	node per page (slug, title, type, scope, stale/contradiction; +summary and
+	+curated ``manual_links`` targets when ``include_content`` (#644, so the
+	tenant detail panel can offer removal of exactly what it curated)). Edges:
+	``scope`` (page→tier), ``authored`` (user→page,
 	weighted), ``member-of`` (user→role via live ``frappe.get_roles``),
 	``links-to`` (body ``[[links]]`` ∪ durable ``manual_links``). Callers pass a
 	page set already filtered to what they may emit, so edges to pages outside
@@ -289,6 +291,9 @@ def _build_graph_from_pages(pages, include_content: bool = False, minimise_scope
 		emit_slug, emit_label = emitted[slug]
 		pid = f"page:{emit_slug}"
 		scope = _norm_scope(p.scope)
+		# Computed once, up front, so both the node's curated-links list below and
+		# the links-to edges further down read the same value.
+		manual_targets = _manual_link_targets(p.get("manual_links"), known_slugs)
 		node = {
 			"id": pid,
 			"kind": "page",
@@ -306,6 +311,15 @@ def _build_graph_from_pages(pages, include_content: bool = False, minimise_scope
 		if include_content:
 			# tenant SPA needs content for client-side TF-IDF similarity.
 			node["summary"] = p.get("summary") or ""
+			# #644: the curated (manual_links) targets only, never body-derived;
+			# what the tenant detail panel offers a "remove" affordance on, since
+			# that is exactly what remove_wiki_link mutates. Plain slugs, not
+			# `emitted[...]`: include_content is only ever True on this
+			# (minimise_scopes=False) tenant path, so emission is identity here.
+			# Every entry already passed through `known_slugs` (the caller's own
+			# visible-page set) inside `_manual_link_targets`, so this can never
+			# leak a target slug the caller isn't allowed to see (R3).
+			node["manual_links"] = [t for t in manual_targets if t != slug]
 		nodes.append(node)
 
 		# scope-covers edge: page → the tier that can see it. A User-scope page
@@ -334,7 +348,7 @@ def _build_graph_from_pages(pages, include_content: bool = False, minimise_scope
 		# page→page links — the Obsidian knowledge graph itself: body [[wikilinks]]
 		# ∪ durable out-of-body manual_links (R1), deduped.
 		targets = _extract_link_targets(p.body_md, known_slugs)
-		for t in _manual_link_targets(p.get("manual_links"), known_slugs):
+		for t in manual_targets:
 			if t not in targets:
 				targets.append(t)
 		for target in targets:

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -287,6 +287,19 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 			{"source": f"page:{b.name}", "target": f"page:{a.name}", "kind": "links-to"},
 			g["edges"],
 		)
+		# #644: the curated targets ride on the LINKING page's node, not the target's.
+		bn = self._node(g, f"page:{b.name}")
+		self.assertEqual(bn.get("manual_links"), [a.name])
+		self.assertEqual(an.get("manual_links"), [])  # a curated nothing itself
+
+	def test_manual_links_never_travel_to_admin(self):
+		"""#644: the new node field is gated on include_content, same as summary;
+		the admin (org-wide) push must not grow a new content-shaped field."""
+		a = self._page(f"{_PREFIX}-nta", "A", body_md="")
+		self._page(f"{_PREFIX}-ntp", "P", body_md="", manual_links=[a.name])
+		g = self._graph()  # compute_graph() -> admin path, include_content=False
+		pn = self._node(g, self._pid(frappe.get_doc(WIKI, f"{_PREFIX}-ntp")))
+		self.assertNotIn("manual_links", pn)
 
 	def test_get_wiki_graph_history_non_sm_blocked(self):
 		"""R3: org-wide aggregates are SM-only, unlike get_wiki_graph."""
@@ -443,6 +456,77 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		frappe.db.set_value(WIKI, doc.name, "status", "Archived", update_modified=False)
 		g = self._graph()
 		self.assertIsNone(self._node(g, f"page:{doc.name}"))
+
+	# --- remove_wiki_link (#644: mirrors add_wiki_link's R1/R2/R3) ---
+	def test_remove_link_clears_manual_links_and_edge(self):
+		a = self._page(f"{_PREFIX}-rla", "A", body_md="")
+		p = self._page(f"{_PREFIX}-rlp", "P", body_md="original body")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		res = wiki_mod.remove_wiki_link(p.name, a.name)
+		self.assertTrue(res["ok"])
+		self.assertFalse(res.get("already"))
+		# body_md untouched (R1, out of body)
+		self.assertEqual(frappe.db.get_value(WIKI, p.name, "body_md"), "original body")
+		links = wiki_mod._parse_manual_links(frappe.db.get_value(WIKI, p.name, "manual_links"))
+		self.assertNotIn(a.name, links)
+		g = self._graph()
+		self.assertNotIn(
+			{"source": f"page:{p.name}", "target": f"page:{a.name}", "kind": "links-to"}, g["edges"]
+		)
+
+	def test_remove_link_missing_edge_is_safe_noop(self):
+		a = self._page(f"{_PREFIX}-rna", "A", body_md="")
+		p = self._page(f"{_PREFIX}-rnp", "P", body_md="")
+		res = wiki_mod.remove_wiki_link(p.name, a.name)  # never added
+		self.assertTrue(res["ok"])
+		self.assertTrue(res.get("already"))
+		self.assertEqual(res["manual_links"], [])
+
+	def test_remove_link_leaves_other_targets_intact(self):
+		a = self._page(f"{_PREFIX}-rka", "A", body_md="")
+		b = self._page(f"{_PREFIX}-rkb", "B", body_md="")
+		p = self._page(f"{_PREFIX}-rkp", "P", body_md="")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		wiki_mod.add_wiki_link(p.name, b.name)
+		wiki_mod.remove_wiki_link(p.name, a.name)
+		links = wiki_mod._parse_manual_links(frappe.db.get_value(WIKI, p.name, "manual_links"))
+		self.assertNotIn(a.name, links)
+		self.assertIn(b.name, links)
+
+	def test_remove_link_source_not_editable_blocked(self):
+		a = self._page(f"{_PREFIX}-rea", "A", body_md="")
+		p = self._page(f"{_PREFIX}-rep", "P", body_md="")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		with patch("jarvis.chat.wiki_permissions.can_edit_page", return_value=False):
+			with self.assertRaises(frappe.PermissionError):
+				wiki_mod.remove_wiki_link(p.name, a.name)
+
+	def test_remove_link_target_not_readable_blocked(self):
+		a = self._page(f"{_PREFIX}-rra", "A", body_md="")
+		p = self._page(f"{_PREFIX}-rrp", "P", body_md="")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		# target invisible → reads as not-found (doesn't disclose existence, R3)
+		with patch("jarvis.chat.wiki_permissions.can_read_page", return_value=False):
+			with self.assertRaises(frappe.ValidationError):
+				wiki_mod.remove_wiki_link(p.name, a.name)
+
+	def test_remove_link_uses_locking_read(self):
+		"""Same mechanism assertion as add_wiki_link's: for_update=True on the
+		manual_links read is what makes the write race-free (R2)."""
+		p = self._page(f"{_PREFIX}-rlockp", "P", body_md="")
+		a = self._page(f"{_PREFIX}-rlocka", "A", body_md="")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		orig = frappe.db.get_value
+		seen = {}
+
+		def spy(dt, name=None, field=None, *args, **kwargs):
+			if dt == WIKI and field == "manual_links":
+				seen["for_update"] = kwargs.get("for_update")
+			return orig(dt, name, field, *args, **kwargs)
+
+		with patch.object(frappe.db, "get_value", side_effect=spy):
+			wiki_mod.remove_wiki_link(p.name, a.name)
+		self.assertTrue(seen.get("for_update"))
 
 
 class TestCuratedLinksReachReaders(WikiGraphTestCase):

--- a/wiki-graph-core/src/DetailPanel.vue
+++ b/wiki-graph-core/src/DetailPanel.vue
@@ -55,6 +55,18 @@
 			<button class="wg-act" v-if="siteUrl" @click="openPage">Open page ↗</button>
 			<button class="wg-act" @click="copySlug">Copy slug</button>
 		</div>
+		<div
+			class="wg-links"
+			v-if="canRemoveLink && node.kind === 'page' && (node.manual_links || []).length"
+		>
+			<div class="wg-links-h">Curated links</div>
+			<ul>
+				<li v-for="target in node.manual_links" :key="target">
+					<span class="wg-link-target">{{ target }}</span>
+					<button class="wg-remove" @click="$emit('remove-link', target)">Remove</button>
+				</li>
+			</ul>
+		</div>
 	</div>
 	<div class="wg-detail empty text-muted" v-else><i>Click a node for details.</i></div>
 </template>
@@ -70,8 +82,14 @@ export default {
 		// Focus / Copy slug / Open page actions. On for the operator graph; the
 		// tenant graph turns them off for a read-only detail view.
 		showActions: { type: Boolean, default: true },
+		// #644: list `node.manual_links` (curated, out-of-body [[links]]) with a
+		// "Remove" affordance per entry. Off by default, additive: this component
+		// is shared with the admin/operator build (wiki-graph-core), which never
+		// gets `manual_links` on a node (it isn't `include_content`-fetched there)
+		// and never opts into this prop.
+		canRemoveLink: { type: Boolean, default: false },
 	},
-	emits: ["focus"],
+	emits: ["focus", "remove-link"],
 	computed: {
 		m() {
 			return (this.node && this.metrics[this.node.id]) || {};
@@ -165,5 +183,50 @@ export default {
 }
 .wg-act:hover {
 	background: var(--control-bg, #f3f4f6);
+}
+.wg-links {
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid var(--border-color, #e2e6ea);
+}
+.wg-links-h {
+	font-size: 11px;
+	text-transform: uppercase;
+	color: var(--text-muted, #888);
+	margin-bottom: 4px;
+}
+.wg-links ul {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+.wg-links li {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	font-size: 12px;
+	padding: 2px 0;
+}
+.wg-link-target {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+/* Mirrors SuggestPanel's `.wg-add` pill shape, in the warn red used elsewhere on
+   this panel (`.wg-kv .warn`) since this action is destructive, unlike "+ link". */
+.wg-remove {
+	font-size: 10px;
+	padding: 1px 7px;
+	border: 1px solid #d9534f;
+	color: #d9534f;
+	background: transparent;
+	border-radius: 10px;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+.wg-remove:hover {
+	background: #d9534f;
+	color: #fff;
 }
 </style>


### PR DESCRIPTION
## Summary

add_wiki_link (#642) let a user curate a link but gave no way to undo one, so a mis-clicked "+ link" was permanent short of a Desk/DB edit. This adds a `remove_wiki_link` endpoint plus a Remove affordance in the Knowledge Graph's detail panel, so a curated link can be undone from the same place it was added.

Fixes #644.

<details>
<summary>Mechanism</summary>

`remove_wiki_link` mirrors `add_wiki_link` exactly on the parts that matter: it checks edit rights on the source page and read rights on the target, takes the same row lock (`for_update`), writes `manual_links` only (never `body_md`), and treats removing an absent link as a safe no-op. The tenant graph (`get_wiki_graph`) now also carries each page's curated targets on its node, gated on `include_content` the same way `summary` already is, so nothing new travels to the admin push.

Two deliberate omissions: the `slug == target` self-link guard from `add_wiki_link` is skipped, since a self-link could never have been added, so it just falls into the no-op branch. And a manual link whose target page was since deleted can't be removed through this endpoint, but it also never renders as an edge (dangling links are dropped), so it's inert either way.

For parity with `add_wiki_link`, this does not add audit logging either. Auditing both add and remove is a reasonable follow-up, out of scope here.

No live screenshot: the local Playwright browser profile was locked by another concurrent session, and claude-in-chrome cannot reach the local bench host. Evidence instead is 5 new passing spec tests in `KnowledgeGraph.spec.js` that drive the exact affordance end to end (select a node, curated links list, Remove click, `removeWikiLink` call, refetch, panel re-points at the updated node).
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is up to date with `develop`
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
