### PR TITLE
fix(wiki): scrub mirrored files when the wiki is disabled (#731)

### DIFF
--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -72,6 +72,14 @@ _LOCK_WAIT_S = 75.0
 JOB_ID_RETRY = "wiki-mirror-sync-retry"
 JOB_ID_FULL_RETRY = "wiki-mirror-sync-full-retry"
 
+# #731: the one-shot scrub queued when "Enable Business Wiki" goes ON -> OFF. Its
+# own dedup slots, distinct from the sync ids above, for the same reason the sync
+# retry ids are distinct: a contended scrub re-queueing itself must not reuse an id
+# that is already STARTED (its own), or frappe.enqueue's deduplicate=True declines
+# it silently and the scrub is dropped, leaving the kill switch a no-op.
+JOB_ID_SCRUB = "wiki-mirror-scrub"
+JOB_ID_SCRUB_RETRY = "wiki-mirror-scrub-retry"
+
 # fleet-agent hard-caps request bodies at 256KB; keep each push call's b64
 # file payload comfortably under it.
 MAX_CALL_PAYLOAD_BYTES = 200 * 1024
@@ -518,6 +526,119 @@ def _chunk_files(files: list[dict]) -> list[list[dict]]:
 
 
 # --------------------------------------------------------------------------- #
+# scrub (kill switch: #731)
+# --------------------------------------------------------------------------- #
+def scrub() -> dict:
+	"""Remove EVERY mirrored wiki file from the tenant container. This is what
+	the "Enable Business Wiki" kill switch enqueues on its ON -> OFF transition.
+
+	Turning the wiki off only gates NEW reads/writes (``read_wiki`` etc.) and
+	short-circuits ``sync`` at its #493 entry, so already-mirrored page files sit
+	in the org-shared workspace ``wiki/`` where the agent can still grep them off
+	disk, and a page trashed/archived/narrowed while the wiki is off never has its
+	file revoked (the gated sync never runs the delete, and there is no periodic
+	sweep). Scrubbing on disable closes both: the files are gone, and the blocked
+	revocations become moot.
+
+	Run-time re-check of the toggle, the inverse of ``sync``'s #493 gate: a
+	re-enable that raced ahead of this queued job (disable -> re-enable -> "Sync
+	now") means a live mirror we must NOT wipe, so whichever job runs last leaves
+	the container matching the current toggle state.
+
+	Serialised on the SAME lock as ``sync`` (#622): a reconcile already past its
+	own gate when the operator disabled would otherwise re-push files AFTER the
+	prune, reopening the very hole this closes. On contention or crash the scrub is
+	re-queued under a DISTINCT id (``JOB_ID_SCRUB_RETRY``) rather than dropped,
+	because there is no periodic sweep to pick a stranded scrub up later.
+
+	Reuses the existing mirror push API: an explicit ``delete`` list of every
+	stamped page file plus ``index.md``/``log.md``, AND ``known_paths=[]`` so the
+	fleet's full-sync walk also prunes strays (files left at an old path by a slug
+	or type move). Idempotent and never raises: a no-op when nothing was mirrored,
+	and a logged non-error when the container is absent (the push swallows +
+	logs, returning None). Re-enabling later re-mirrors through the existing full
+	sync (``sync_wiki_mirror_now`` / a page edit)."""
+	if wiki_enabled():
+		return {"ok": False, "skipped": True, "reason": "wiki re-enabled before scrub ran"}
+	from jarvis._redis_lock import redis_lock
+
+	try:
+		with redis_lock(_LOCK_NAME, timeout_s=_LOCK_TTL_S, blocking_timeout_s=_LOCK_WAIT_S) as acquired:
+			if acquired:
+				return _scrub()
+			return _requeue_scrub(why="another mirror op still in flight")
+	except Exception:
+		frappe.log_error(title="wiki mirror: scrub crashed", message=frappe.get_traceback())
+		# A fault reaching here may be the lock itself (redis_lock propagates real
+		# Redis errors by design), in which case _scrub never ran. Re-queue rather
+		# than let the kill switch silently do nothing.
+		return _requeue_scrub(why="scrub crashed; see Error Log")
+
+
+def _scrub() -> dict:
+	# Read the stamped rows INSIDE the lock: a sync that finished while we waited
+	# has just stamped new files, and a snapshot taken before the wait would leave
+	# those stamps set after the prune - a later incremental sync would then
+	# hash-skip a file that is no longer on the container.
+	rows = frappe.get_all(
+		WIKI,
+		filters=[["mirror_hash", "!=", ""]],
+		fields=["name", "slug", "page_type"],
+		limit_page_length=0,
+	)
+	# The full set of paths this mirror ever writes: every stamped page file plus
+	# the two navigation files. Deleting an already-gone path is tolerated (the
+	# sync's delete path relies on the same), so this stays safe when nothing is
+	# actually on the container.
+	delete_paths = sorted(
+		{_wire_path(page_path(r)) for r in rows} | {_wire_path(INDEX_PATH), _wire_path(LOG_PATH)}
+	)
+
+	from jarvis import admin_client
+
+	# known_paths=[] (NOT None) tells the fleet to prune everything under wiki/,
+	# sweeping strays the path list cannot name; the explicit delete list covers
+	# the tracked files even if an empty known_paths were ever coerced away.
+	resp = admin_client.push_wiki_files(files=[], delete=delete_paths, known_paths=[])
+	if resp is None:
+		# Container absent / admin unreachable: nothing was pruned, so leave the
+		# stamps intact. Not an error - the wiki is off regardless, and a re-toggle
+		# re-fires the scrub. There is nothing to retry against an absent container.
+		frappe.log_error(
+			title="wiki mirror: scrub push failed",
+			message="admin/tenant unreachable; wiki files left in place",
+		)
+		return {"ok": False, "reason": "admin/tenant unreachable; nothing scrubbed"}
+
+	# Clear the stamps only after the confirmed prune, mirroring _sync: the stamp
+	# is the standing proof a file is on the container, so "no file" and "no stamp"
+	# stay consistent and a later re-enable full sync re-pushes cleanly.
+	for r in rows:
+		frappe.db.set_value(WIKI, r.name, "mirror_hash", "", update_modified=False)
+	frappe.db.commit()
+
+	return {
+		"ok": True,
+		"scrubbed": True,
+		"cleared": len(rows),
+		"deleted": len(delete_paths),
+		"pruned": resp.get("pruned", 0) if isinstance(resp, dict) else 0,
+	}
+
+
+def _requeue_scrub(why: str) -> dict:
+	"""Re-queue a scrub that could not run, under the RETRY job id (see
+	``_requeue_contended`` for why the id must differ from the running job's)."""
+	queued = enqueue_scrub(retry=True)
+	return {
+		"ok": False,
+		"skipped": bool(queued),
+		"requeued": bool(queued),
+		"reason": f"{why}; {'re-queued' if queued else 'RE-QUEUE FAILED, files may linger'}",
+	}
+
+
+# --------------------------------------------------------------------------- #
 # triggers
 # --------------------------------------------------------------------------- #
 def enqueue_sync(full: bool = False, after_commit: bool = False, retry: bool = False) -> bool:
@@ -567,6 +688,38 @@ def enqueue_sync(full: bool = False, after_commit: bool = False, retry: bool = F
 		return True
 	except Exception:
 		frappe.log_error(title="wiki mirror: enqueue failed", message=frappe.get_traceback())
+		return False
+
+
+def enqueue_scrub(after_commit: bool = True, retry: bool = False) -> bool:
+	"""Queue the one-shot kill-switch scrub (#731). Returns whether a job was
+	really queued.
+
+	Deliberately NOT gated on ``wiki_enabled`` the way ``enqueue_sync`` is: this
+	runs precisely because the wiki was just turned OFF, and ``scrub`` itself
+	re-checks the toggle at run time. Suppressed under tests unless
+	``frappe.flags.jarvis_test_wiki_mirror_enqueue`` is set, so a fixture save that
+	flips the toggle does not spray RQ jobs; a test invokes ``scrub`` directly.
+
+	``after_commit`` defaults True: the toggle write must land before the worker
+	runs so its own re-check sees the disable. ``retry=True`` uses the RETRY id, a
+	separate dedup slot, so a contended scrub re-queueing itself is not declined
+	for colliding with its own STARTED job."""
+	if frappe.flags.in_test and not frappe.flags.jarvis_test_wiki_mirror_enqueue:
+		return False
+	job_id = JOB_ID_SCRUB_RETRY if retry else JOB_ID_SCRUB
+	try:
+		frappe.enqueue(
+			"jarvis.chat.wiki_mirror.scrub",
+			queue=QUEUE,
+			timeout=JOB_TIMEOUT_S,
+			job_id=job_id,
+			deduplicate=True,
+			enqueue_after_commit=bool(after_commit),
+		)
+		return True
+	except Exception:
+		frappe.log_error(title="wiki mirror: scrub enqueue failed", message=frappe.get_traceback())
 		return False
 
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -546,6 +546,15 @@ class JarvisSettings(Document):
 				self.llm_api_key = api_key_val
 
 	def validate(self):
+		# #731: capture the RAW pre-save wiki toggle state here, while tabSingles
+		# still holds the old value (validate runs before db_update). wiki_enabled()
+		# honours the NULL=ON idiom that has_value_changed cannot - a Check coerces
+		# NULL to 0, so the coerced before-doc would miss a NULL(=ON) -> 0 disable.
+		# on_update reads this flag to decide whether to scrub the container mirror.
+		from jarvis.chat.wiki import wiki_enabled
+
+		self.flags.wiki_was_enabled = wiki_enabled()
+
 		# Detect a new llm_api_key before _save_passwords() masks it to '****'.
 		current_key = getattr(self, "llm_api_key", None) or ""
 		if not current_key or self.is_dummy_password(current_key):
@@ -752,6 +761,10 @@ class JarvisSettings(Document):
 		)
 
 	def on_update(self):
+		# #731: runs BEFORE the unified-LLM early returns below so a settings save
+		# that both reconfigures the LLM and disables the wiki still scrubs.
+		self._maybe_scrub_wiki_on_disable()
+
 		# ------------------------------------------------------------------ #
 		# Unified LLM path (2026-06-26): models table rows or preset present.
 		# ------------------------------------------------------------------ #
@@ -772,6 +785,29 @@ class JarvisSettings(Document):
 		self.db_set("proxy_active", 0, update_modified=False)
 		self.db_set("proxy_recommended", 0, update_modified=False)
 		self._on_update_single_model_legacy()
+
+	def _maybe_scrub_wiki_on_disable(self):
+		"""Scrub the container's mirrored wiki files when "Enable Business Wiki"
+		goes ON -> OFF (#731).
+
+		The kill switch has to actually remove already-mirrored content, not just
+		gate new reads: the agent can otherwise still grep the page files off the
+		org-shared workspace, and revocation deletes never fire while the wiki is
+		off. Fires only on a real 1 -> 0 flip - the pre-save state comes from the
+		raw ``wiki_enabled()`` captured in validate() (so a NULL=ON -> 0 disable is
+		caught, which has_value_changed would miss), and the new state from the
+		value being saved. A save while already off, or a re-enable, does nothing.
+		A missing flag (validate skipped) means no scrub."""
+		from jarvis.chat import wiki_mirror
+
+		if not self.flags.get("wiki_was_enabled"):
+			return
+		raw_new = getattr(self, "wiki_enabled", None)
+		# NULL=ON idiom on the new value too: an unset field still reads as enabled.
+		now_enabled = True if raw_new is None else bool(frappe.utils.cint(raw_new))
+		if now_enabled:
+			return
+		wiki_mirror.enqueue_scrub(after_commit=True)
 
 	def _on_update_unified_llm(self):
 		"""New LLM path: validate → derive proxy_active/proxy_recommended →

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -546,14 +546,18 @@ class JarvisSettings(Document):
 				self.llm_api_key = api_key_val
 
 	def validate(self):
-		# #731: capture the RAW pre-save wiki toggle state here, while tabSingles
-		# still holds the old value (validate runs before db_update). wiki_enabled()
-		# honours the NULL=ON idiom that has_value_changed cannot - a Check coerces
-		# NULL to 0, so the coerced before-doc would miss a NULL(=ON) -> 0 disable.
-		# on_update reads this flag to decide whether to scrub the container mirror.
-		from jarvis.chat.wiki import wiki_enabled
-
-		self.flags.wiki_was_enabled = wiki_enabled()
+		# #731: a genuine ON -> OFF flip of the wiki toggle enqueues a container
+		# scrub in on_update. Capture the change here, the same way
+		# llm_auth_mode_changed is captured below: has_value_changed compares the
+		# SUBMITTED value against the stored one, so an unrelated settings save that
+		# never touched the checkbox reads as "not changed" and cannot spuriously
+		# wipe the mirror. A loaded Check always coerces to 0/1 (never None), and
+		# pre-v2 rows whose wiki_enabled is NULL are backfilled to 1 by patch, so a
+		# real disable is a 1 -> 0 change there too (a bare NULL would coerce to 0
+		# and hide the change).
+		self.flags.wiki_disabled_transition = bool(self.has_value_changed("wiki_enabled")) and not (
+			frappe.utils.cint(getattr(self, "wiki_enabled", 0))
+		)
 
 		# Detect a new llm_api_key before _save_passwords() masks it to '****'.
 		current_key = getattr(self, "llm_api_key", None) or ""
@@ -793,19 +797,13 @@ class JarvisSettings(Document):
 		The kill switch has to actually remove already-mirrored content, not just
 		gate new reads: the agent can otherwise still grep the page files off the
 		org-shared workspace, and revocation deletes never fire while the wiki is
-		off. Fires only on a real 1 -> 0 flip - the pre-save state comes from the
-		raw ``wiki_enabled()`` captured in validate() (so a NULL=ON -> 0 disable is
-		caught, which has_value_changed would miss), and the new state from the
-		value being saved. A save while already off, or a re-enable, does nothing.
-		A missing flag (validate skipped) means no scrub."""
+		off. Fires only on a genuine 1 -> 0 change of the toggle, captured in
+		validate() via has_value_changed so an unrelated settings save can never
+		wipe the mirror; a save while already off, or a re-enable, does nothing. A
+		missing flag (validate skipped) means no scrub."""
 		from jarvis.chat import wiki_mirror
 
-		if not self.flags.get("wiki_was_enabled"):
-			return
-		raw_new = getattr(self, "wiki_enabled", None)
-		# NULL=ON idiom on the new value too: an unset field still reads as enabled.
-		now_enabled = True if raw_new is None else bool(frappe.utils.cint(raw_new))
-		if now_enabled:
+		if not self.flags.get("wiki_disabled_transition"):
 			return
 		wiki_mirror.enqueue_scrub(after_commit=True)
 

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -51,3 +51,4 @@ jarvis.patches.v2_12_reload_macro_doctypes_for_indexes
 jarvis.patches.v2_13_repush_learned_skills_role_gated
 jarvis.patches.v2_13_unique_agent_installation
 jarvis.patches.v2_14_reconcile_token_limit_to_alltime
+jarvis.patches.v2_14_backfill_wiki_enabled

--- a/jarvis/patches/v2_14_backfill_wiki_enabled.py
+++ b/jarvis/patches/v2_14_backfill_wiki_enabled.py
@@ -1,0 +1,43 @@
+import frappe
+
+
+def execute():
+	"""Seed wiki_enabled=1 for benches whose Jarvis Settings Single predates the
+	field, so BOTH the read and the write paths default to ON.
+
+	The NULL=ON reader (``chat.wiki.wiki_enabled``) already treats a missing/NULL
+	row as ON, but that alone is not enough for the #731 kill switch. Two problems
+	the explicit row fixes:
+
+	* A full ``Jarvis Settings.save()`` (onboarding, re-sync, any Desk save) runs
+	  the unset Check through ``get_valid_dict``, which coerces it to 0 and writes
+	  an explicit "0" row - silently disabling the wiki fleet-wide with no admin
+	  action. This mirrors ``v2_11_backfill_home_intro_enabled`` /
+	  ``v2_09_backfill_persona_enabled`` for the sibling kill switch.
+	* The #731 scrub trigger fires on a genuine 1 -> 0 change of the toggle. A
+	  bare NULL coerces to 0 on load, so a real disable of a pre-v2 tenant would
+	  read as "0 -> 0" (unchanged) and the scrub would never run - the kill switch
+	  would be inert for exactly the tenants that predate the field. A real "1"
+	  row makes a disable a 1 -> 0 change the trigger can see.
+
+	Probe mirrors ``wiki_enabled`` itself (row absent OR value NULL reads as ON):
+	seed ONLY those, so a re-run never clobbers an admin's explicit 0 (a deliberate
+	disable) and an already-explicit 1 is left alone. ``update_modified=False`` so
+	the backfill does not bump ``Jarvis Settings.modified``. Fresh installs get "1"
+	from the field default on first insert and never run patches, so both paths
+	converge on ON.
+
+	Jarvis Settings is a Single (data in tabSingles, no tab<Doctype> table), so
+	gate on the meta field, not a column check.
+	"""
+	if not frappe.get_meta("Jarvis Settings").has_field("wiki_enabled"):
+		return
+	row = frappe.db.sql(
+		"select value from tabSingles where doctype=%s and field=%s",
+		("Jarvis Settings", "wiki_enabled"),
+	)
+	# Absent row, or a row whose value is NULL: both currently read as ON by
+	# default. An explicit "0" (deliberate disable) or "1" must never be touched.
+	if row and row[0][0] is not None:
+		return
+	frappe.db.set_single_value("Jarvis Settings", "wiki_enabled", 1, update_modified=False)

--- a/jarvis/tests/test_settings_wiki_scrub.py
+++ b/jarvis/tests/test_settings_wiki_scrub.py
@@ -1,0 +1,129 @@
+"""Tests for the "Enable Business Wiki" ON -> OFF scrub trigger (#731).
+
+Disabling the wiki must enqueue a one-shot scrub that removes the tenant's
+already-mirrored page files from the container. The trigger lives on the Jarvis
+Settings controller: validate() captures the RAW pre-save toggle state (so the
+NULL=ON idiom is honoured, which has_value_changed cannot), and on_update() fires
+``wiki_mirror.enqueue_scrub`` only on a real 1 -> 0 flip.
+
+``Jarvis Settings`` is a Single (one row shared by the whole DB), and
+``wiki_enabled`` may be absent from tabSingles entirely (NULL = ON). setUp
+snapshots the RAW value - including "row absent" - and tearDown restores it so the
+suite leaves the shared toggle exactly as it found it.
+
+The two LLM dispatch methods are patched out in the save-path tests: saving Jarvis
+Settings runs the LLM sync INLINE under ``frappe.flags.in_test``, and this trigger
+is orthogonal to it.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import wiki_mirror
+
+SETTINGS = "Jarvis Settings"
+
+
+def _raw_wiki_enabled():
+	"""The stored ``wiki_enabled`` exactly as ``wiki_enabled()`` reads it: the
+	tabSingles value, or None when the row is absent (NULL = ON)."""
+	rows = frappe.db.sql(
+		"select value from `tabSingles` where doctype=%s and field=%s",
+		(SETTINGS, "wiki_enabled"),
+	)
+	return rows[0][0] if rows else None
+
+
+def _set_raw_wiki_enabled(value):
+	"""Force the stored toggle to ``value`` (0/1) or, for None, remove the row so
+	the NULL=ON default applies. Commits so a subsequent get_single reads it."""
+	frappe.db.sql(
+		"delete from `tabSingles` where doctype=%s and field=%s",
+		(SETTINGS, "wiki_enabled"),
+	)
+	if value is not None:
+		frappe.db.set_single_value(SETTINGS, "wiki_enabled", value, update_modified=False)
+	frappe.db.commit()
+
+
+class TestWikiScrubGuardUnit(FrappeTestCase):
+	"""The guard method in isolation: the 1 -> 0 truth table, no save machinery."""
+
+	def _guard(self, was_enabled, new_value):
+		settings = frappe.get_single(SETTINGS)
+		if was_enabled is None:
+			settings.flags.pop("wiki_was_enabled", None)
+		else:
+			settings.flags.wiki_was_enabled = was_enabled
+		settings.wiki_enabled = new_value
+		with mock.patch.object(wiki_mirror, "enqueue_scrub") as enq:
+			settings._maybe_scrub_wiki_on_disable()
+		return enq
+
+	def test_on_to_off_scrubs(self):
+		self.assertTrue(self._guard(was_enabled=True, new_value=0).called)
+
+	def test_off_to_off_does_nothing(self):
+		self.assertFalse(self._guard(was_enabled=False, new_value=0).called)
+
+	def test_still_on_does_nothing(self):
+		self.assertFalse(self._guard(was_enabled=True, new_value=1).called)
+
+	def test_untouched_field_while_on_does_nothing(self):
+		# NULL=ON on the new value too: an unset field still reads as enabled.
+		self.assertFalse(self._guard(was_enabled=True, new_value=None).called)
+
+	def test_missing_capture_flag_does_nothing(self):
+		# validate() skipped -> no captured state -> err toward not scrubbing.
+		self.assertFalse(self._guard(was_enabled=None, new_value=0).called)
+
+
+class TestWikiScrubGuardOnSave(FrappeTestCase):
+	"""The full save lifecycle: validate() captures the raw pre-save state and
+	on_update() fires. Locks in the NULL(=ON) -> 0 case that motivates the raw
+	read - the coerced before-doc would report 0 -> 0 and miss it."""
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		self._wiki_enabled_before = _raw_wiki_enabled()
+
+	def tearDown(self):
+		_set_raw_wiki_enabled(self._wiki_enabled_before)
+		super().tearDown()
+
+	def _save_toggling_to(self, new_value):
+		"""Save Jarvis Settings with wiki_enabled set to ``new_value``, LLM
+		dispatch stubbed out, and enqueue_scrub captured. Returns the mock."""
+		settings = frappe.get_single(SETTINGS)
+		settings.wiki_enabled = new_value
+		with (
+			mock.patch.object(type(settings), "_on_update_unified_llm"),
+			mock.patch.object(type(settings), "_on_update_single_model_legacy"),
+			mock.patch.object(wiki_mirror, "enqueue_scrub") as enq,
+		):
+			settings.save(ignore_permissions=True)
+		return enq
+
+	def test_a_real_save_from_on_to_off_scrubs(self):
+		_set_raw_wiki_enabled(1)
+		self.assertTrue(self._save_toggling_to(0).called)
+
+	def test_a_real_save_from_null_on_to_off_scrubs(self):
+		# Row absent => NULL => effectively ON. This is the case has_value_changed
+		# misses (the Check coerces NULL to 0, so it sees 0 -> 0) and the whole
+		# reason validate() re-reads the raw tabSingles value.
+		_set_raw_wiki_enabled(None)
+		self.assertTrue(self._save_toggling_to(0).called)
+
+	def test_a_real_save_while_already_off_does_nothing(self):
+		_set_raw_wiki_enabled(0)
+		self.assertFalse(self._save_toggling_to(0).called)
+
+	def test_a_real_re_enable_does_nothing(self):
+		_set_raw_wiki_enabled(0)
+		self.assertFalse(self._save_toggling_to(1).called)

--- a/jarvis/tests/test_settings_wiki_scrub.py
+++ b/jarvis/tests/test_settings_wiki_scrub.py
@@ -2,18 +2,24 @@
 
 Disabling the wiki must enqueue a one-shot scrub that removes the tenant's
 already-mirrored page files from the container. The trigger lives on the Jarvis
-Settings controller: validate() captures the RAW pre-save toggle state (so the
-NULL=ON idiom is honoured, which has_value_changed cannot), and on_update() fires
-``wiki_mirror.enqueue_scrub`` only on a real 1 -> 0 flip.
+Settings controller: validate() records a genuine 1 -> 0 change of the toggle via
+has_value_changed, and on_update() fires ``wiki_mirror.enqueue_scrub`` on it.
+
+The pivotal hazard this file guards against: a loaded Check field always coerces
+to 0/1 (never None - see frappe base_document._fix_numeric_types), so a pre-v2
+tenant whose ``wiki_enabled`` row is NULL surfaces as 0 in memory. A state-based
+guard would therefore read "was ON (raw), now 0 (coerced)" on EVERY unrelated
+settings save and wipe the mirror. Change-detection (has_value_changed compares
+the SUBMITTED value against the stored one) does not, because an untouched field
+compares equal to itself. The v2_14 backfill patch then makes a real disable of a
+pre-v2 tenant a visible 1 -> 0 change so the kill switch works for them too.
 
 ``Jarvis Settings`` is a Single (one row shared by the whole DB), and
 ``wiki_enabled`` may be absent from tabSingles entirely (NULL = ON). setUp
-snapshots the RAW value - including "row absent" - and tearDown restores it so the
-suite leaves the shared toggle exactly as it found it.
-
-The two LLM dispatch methods are patched out in the save-path tests: saving Jarvis
-Settings runs the LLM sync INLINE under ``frappe.flags.in_test``, and this trigger
-is orthogonal to it.
+snapshots the RAW value - including "row absent" - and tearDown restores it. The
+LLM dispatch methods are patched out in the save-path tests: saving Jarvis
+Settings runs the LLM sync INLINE under ``frappe.flags.in_test``, orthogonal to
+this trigger.
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import wiki_mirror
+from jarvis.patches import v2_14_backfill_wiki_enabled
 
 SETTINGS = "Jarvis Settings"
 
@@ -50,43 +57,7 @@ def _set_raw_wiki_enabled(value):
 	frappe.db.commit()
 
 
-class TestWikiScrubGuardUnit(FrappeTestCase):
-	"""The guard method in isolation: the 1 -> 0 truth table, no save machinery."""
-
-	def _guard(self, was_enabled, new_value):
-		settings = frappe.get_single(SETTINGS)
-		if was_enabled is None:
-			settings.flags.pop("wiki_was_enabled", None)
-		else:
-			settings.flags.wiki_was_enabled = was_enabled
-		settings.wiki_enabled = new_value
-		with mock.patch.object(wiki_mirror, "enqueue_scrub") as enq:
-			settings._maybe_scrub_wiki_on_disable()
-		return enq
-
-	def test_on_to_off_scrubs(self):
-		self.assertTrue(self._guard(was_enabled=True, new_value=0).called)
-
-	def test_off_to_off_does_nothing(self):
-		self.assertFalse(self._guard(was_enabled=False, new_value=0).called)
-
-	def test_still_on_does_nothing(self):
-		self.assertFalse(self._guard(was_enabled=True, new_value=1).called)
-
-	def test_untouched_field_while_on_does_nothing(self):
-		# NULL=ON on the new value too: an unset field still reads as enabled.
-		self.assertFalse(self._guard(was_enabled=True, new_value=None).called)
-
-	def test_missing_capture_flag_does_nothing(self):
-		# validate() skipped -> no captured state -> err toward not scrubbing.
-		self.assertFalse(self._guard(was_enabled=None, new_value=0).called)
-
-
-class TestWikiScrubGuardOnSave(FrappeTestCase):
-	"""The full save lifecycle: validate() captures the raw pre-save state and
-	on_update() fires. Locks in the NULL(=ON) -> 0 case that motivates the raw
-	read - the coerced before-doc would report 0 -> 0 and miss it."""
-
+class _WikiToggleTestCase(FrappeTestCase):
 	def setUp(self):
 		super().setUp()
 		frappe.set_user("Administrator")
@@ -96,11 +67,46 @@ class TestWikiScrubGuardOnSave(FrappeTestCase):
 		_set_raw_wiki_enabled(self._wiki_enabled_before)
 		super().tearDown()
 
-	def _save_toggling_to(self, new_value):
-		"""Save Jarvis Settings with wiki_enabled set to ``new_value``, LLM
-		dispatch stubbed out, and enqueue_scrub captured. Returns the mock."""
+
+class TestWikiScrubGuardUnit(_WikiToggleTestCase):
+	"""The guard method reads exactly one flag; validate() owns the detection."""
+
+	def _guard(self, flag):
 		settings = frappe.get_single(SETTINGS)
-		settings.wiki_enabled = new_value
+		if flag is None:
+			settings.flags.pop("wiki_disabled_transition", None)
+		else:
+			settings.flags.wiki_disabled_transition = flag
+		with mock.patch.object(wiki_mirror, "enqueue_scrub") as enq:
+			settings._maybe_scrub_wiki_on_disable()
+		return enq
+
+	def test_fires_when_the_transition_flag_is_set(self):
+		self.assertTrue(self._guard(True).called)
+
+	def test_does_nothing_when_the_flag_is_false(self):
+		self.assertFalse(self._guard(False).called)
+
+	def test_does_nothing_when_the_flag_is_missing(self):
+		# validate() skipped -> no captured state -> err toward not scrubbing.
+		self.assertFalse(self._guard(None).called)
+
+
+class TestWikiScrubGuardOnSave(_WikiToggleTestCase):
+	"""The full save lifecycle: validate() detects the change, on_update() fires."""
+
+	def _save(self, *, set_wiki_enabled=None, touch_unrelated=False):
+		"""Save Jarvis Settings with LLM dispatch stubbed and enqueue_scrub
+		captured. ``set_wiki_enabled`` explicitly sets the toggle; leaving it None
+		models a save that never touched the checkbox. ``touch_unrelated`` changes
+		a benign field so the save is a real write, not a no-op."""
+		settings = frappe.get_single(SETTINGS)
+		if set_wiki_enabled is not None:
+			settings.wiki_enabled = set_wiki_enabled
+		if touch_unrelated:
+			settings.wiki_nudge_cooldown_hours = (
+				frappe.utils.cint(getattr(settings, "wiki_nudge_cooldown_hours", 0)) + 1
+			)
 		with (
 			mock.patch.object(type(settings), "_on_update_unified_llm"),
 			mock.patch.object(type(settings), "_on_update_single_model_legacy"),
@@ -109,21 +115,63 @@ class TestWikiScrubGuardOnSave(FrappeTestCase):
 			settings.save(ignore_permissions=True)
 		return enq
 
-	def test_a_real_save_from_on_to_off_scrubs(self):
+	def test_an_explicit_disable_scrubs(self):
 		_set_raw_wiki_enabled(1)
-		self.assertTrue(self._save_toggling_to(0).called)
+		self.assertTrue(self._save(set_wiki_enabled=0).called)
 
-	def test_a_real_save_from_null_on_to_off_scrubs(self):
-		# Row absent => NULL => effectively ON. This is the case has_value_changed
-		# misses (the Check coerces NULL to 0, so it sees 0 -> 0) and the whole
-		# reason validate() re-reads the raw tabSingles value.
+	def test_an_unrelated_save_on_an_enabled_tenant_does_not_scrub(self):
+		# The mirror must survive a settings save that never touched the wiki.
+		_set_raw_wiki_enabled(1)
+		self.assertFalse(self._save(touch_unrelated=True).called)
+
+	def test_an_unrelated_save_on_a_pre_v2_null_tenant_does_not_scrub(self):
+		# THE regression: a NULL row coerces to 0 in memory, but has_value_changed
+		# compares 0 (loaded) against 0 (unchanged) and sees no change. A state
+		# guard would wipe the mirror here on every save.
 		_set_raw_wiki_enabled(None)
-		self.assertTrue(self._save_toggling_to(0).called)
+		self.assertFalse(self._save(touch_unrelated=True).called)
 
-	def test_a_real_save_while_already_off_does_nothing(self):
+	def test_a_save_while_already_off_does_nothing(self):
 		_set_raw_wiki_enabled(0)
-		self.assertFalse(self._save_toggling_to(0).called)
+		self.assertFalse(self._save(set_wiki_enabled=0, touch_unrelated=True).called)
 
-	def test_a_real_re_enable_does_nothing(self):
+	def test_a_re_enable_does_nothing(self):
 		_set_raw_wiki_enabled(0)
-		self.assertFalse(self._save_toggling_to(1).called)
+		self.assertFalse(self._save(set_wiki_enabled=1).called)
+
+	def test_a_pre_v2_tenant_scrubs_after_the_backfill(self):
+		# The backfill turns a NULL row into an explicit 1, so a subsequent disable
+		# is a visible 1 -> 0 change and the kill switch works for pre-v2 tenants.
+		_set_raw_wiki_enabled(None)
+		v2_14_backfill_wiki_enabled.execute()
+		frappe.db.commit()
+		self.assertEqual(frappe.utils.cint(_raw_wiki_enabled()), 1)
+		self.assertTrue(self._save(set_wiki_enabled=0).called)
+
+
+class TestWikiEnabledBackfillPatch(_WikiToggleTestCase):
+	"""v2_14: seed an explicit ON row for NULL=ON tenants without ever re-enabling
+	a wiki an admin deliberately turned off."""
+
+	def test_backfill_seeds_an_absent_row(self):
+		_set_raw_wiki_enabled(None)
+		v2_14_backfill_wiki_enabled.execute()
+		frappe.db.commit()
+		self.assertEqual(frappe.utils.cint(_raw_wiki_enabled()), 1)
+
+	def test_backfill_seeds_a_null_valued_row(self):
+		_set_raw_wiki_enabled(1)
+		frappe.db.sql(
+			"update `tabSingles` set value=NULL where doctype=%s and field=%s",
+			(SETTINGS, "wiki_enabled"),
+		)
+		frappe.db.commit()
+		v2_14_backfill_wiki_enabled.execute()
+		frappe.db.commit()
+		self.assertEqual(frappe.utils.cint(_raw_wiki_enabled()), 1)
+
+	def test_backfill_leaves_an_explicit_disable_alone(self):
+		_set_raw_wiki_enabled(0)
+		v2_14_backfill_wiki_enabled.execute()
+		frappe.db.commit()
+		self.assertEqual(frappe.utils.cint(_raw_wiki_enabled()), 0)

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -862,3 +862,159 @@ class TestMirrorKillSwitch(WikiMirrorTestCase):
 			self.assertEqual(enq.call_args[0][0], wiki_mirror.JOB_METHOD)
 		finally:
 			frappe.flags.jarvis_test_wiki_mirror_enqueue = False
+
+
+class TestScrubOnDisable(WikiMirrorTestCase):
+	"""#731: turning the wiki OFF must actively REMOVE the already-mirrored page
+	files from the container, not merely gate new reads. ``scrub`` is what the
+	"Enable Business Wiki" toggle enqueues on its ON -> OFF transition; it reuses
+	the mirror push API (explicit delete list + ``known_paths=[]`` prune) and is
+	safe to run twice, with nothing mirrored, or against an absent container."""
+
+	@contextlib.contextmanager
+	def _lock_denied(self, *a, **k):
+		"""Stand-in for redis_lock that never grants (another mirror op in flight)."""
+		yield False
+
+	def setUp(self):
+		# scrub() is tenant-wide by design: it clears EVERY page's mirror_hash and
+		# commits. site.jarvis is a shared single tenant carrying real wiki pages,
+		# so snapshot every stamp and restore it in tearDown - otherwise a scrub
+		# here leaves the site's real pages unstamped for the next module.
+		super().setUp()
+		self._hash_snapshot = {
+			r.name: r.mirror_hash
+			for r in frappe.get_all(WIKI, fields=["name", "mirror_hash"], limit_page_length=0)
+		}
+
+	def tearDown(self):
+		for name, digest in self._hash_snapshot.items():
+			if frappe.db.exists(WIKI, name):
+				frappe.db.set_value(WIKI, name, "mirror_hash", digest, update_modified=False)
+		frappe.db.commit()
+		super().tearDown()
+
+	def _clear_all_stamps(self):
+		"""Force the 'nothing mirrored' state on this shared site (real pages carry
+		stamps); tearDown restores them from the snapshot."""
+		for name in frappe.get_all(WIKI, filters=[["mirror_hash", "!=", ""]], pluck="name"):
+			frappe.db.set_value(WIKI, name, "mirror_hash", "", update_modified=False)
+		frappe.db.commit()
+
+	def test_scrub_removes_every_mirrored_file_and_clears_the_stamps(self):
+		a = self._page("scrub-a")
+		b = self._page("scrub-b", page_type="Supplier")
+		with self._mock_push():
+			wiki_mirror.sync()
+		self.assertTrue(frappe.db.get_value(WIKI, a.name, "mirror_hash"))
+		self.assertTrue(frappe.db.get_value(WIKI, b.name, "mirror_hash"))
+
+		with _wiki_disabled():
+			with self._mock_push() as push:
+				out = wiki_mirror.scrub()
+
+		self.assertTrue(out["ok"])
+		self.assertTrue(out["scrubbed"])
+		# One push: no files written, an EMPTY known_paths (prune everything under
+		# wiki/), and a delete list naming every mirrored file plus the two nav
+		# files. The empty-list-vs-None distinction is load-bearing.
+		push.assert_called_once()
+		kw = push.call_args.kwargs
+		self.assertEqual(kw["files"], [])
+		self.assertEqual(kw["known_paths"], [])
+		self.assertIn(f"customers/{a.name}.md", kw["delete"])
+		self.assertIn(f"suppliers/{b.name}.md", kw["delete"])
+		self.assertIn("index.md", kw["delete"])
+		self.assertIn("log.md", kw["delete"])
+		# "no file, no stamp": a later re-enable full sync re-pushes cleanly.
+		self.assertFalse(frappe.db.get_value(WIKI, a.name, "mirror_hash"))
+		self.assertFalse(frappe.db.get_value(WIKI, b.name, "mirror_hash"))
+
+	def test_scrub_is_idempotent(self):
+		a = self._page("scrub-twice")
+		with self._mock_push():
+			wiki_mirror.sync()
+		with _wiki_disabled():
+			with self._mock_push():
+				first = wiki_mirror.scrub()
+			with self._mock_push() as push2:
+				second = wiki_mirror.scrub()  # nothing left to clear
+		self.assertTrue(first["ok"])
+		self.assertTrue(second["ok"])
+		self.assertEqual(second["cleared"], 0)
+		self.assertFalse(frappe.db.get_value(WIKI, a.name, "mirror_hash"))
+		# still asks the fleet to prune, so a stray can never outlive the switch
+		self.assertEqual(push2.call_args.kwargs["known_paths"], [])
+
+	def test_scrub_with_nothing_mirrored_is_a_safe_noop(self):
+		self._clear_all_stamps()
+		with _wiki_disabled():
+			with self._mock_push() as push:
+				out = wiki_mirror.scrub()
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["cleared"], 0)
+		self.assertEqual(push.call_args.kwargs["known_paths"], [])
+
+	def test_scrub_against_an_absent_container_does_not_crash_or_clear_stamps(self):
+		a = self._page("scrub-offline")
+		with self._mock_push():
+			wiki_mirror.sync()
+		self.assertTrue(frappe.db.get_value(WIKI, a.name, "mirror_hash"))
+		with _wiki_disabled():
+			with self._mock_push(result=None):  # offline / not provisioned
+				out = wiki_mirror.scrub()  # must not raise
+		self.assertFalse(out["ok"])
+		# stamps left intact so a re-toggle can still reconcile against the container
+		self.assertTrue(frappe.db.get_value(WIKI, a.name, "mirror_hash"))
+
+	def test_scrub_skips_when_the_wiki_is_re_enabled_before_it_runs(self):
+		"""The flap: disable (scrub queued) -> re-enable + Sync now -> the stale
+		scrub runs last. Its run-time re-check must leave the live mirror alone,
+		so whichever job runs last matches the current toggle state."""
+		a = self._page("scrub-flap")
+		with self._mock_push():
+			wiki_mirror.sync()
+		# wiki is ON (the normal state), so the run-time gate short-circuits.
+		with self._mock_push() as push:
+			out = wiki_mirror.scrub()
+		push.assert_not_called()
+		self.assertTrue(out.get("skipped"))
+		self.assertTrue(frappe.db.get_value(WIKI, a.name, "mirror_hash"))
+
+	def test_a_contended_scrub_requeues_instead_of_dropping(self):
+		with (
+			_wiki_disabled(),
+			mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+			mock.patch.object(wiki_mirror, "_scrub") as inner,
+			mock.patch.object(wiki_mirror, "enqueue_scrub", return_value=True) as enq,
+		):
+			out = wiki_mirror.scrub()
+		self.assertFalse(inner.called, "a contended scrub must not prune concurrently")
+		self.assertTrue(enq.called, "contended work must be re-queued, never dropped")
+		self.assertTrue(out.get("requeued"))
+
+	def test_the_scrub_retry_uses_a_distinct_job_id(self):
+		"""Re-queueing under JOB_ID_SCRUB from inside the STARTED scrub would be
+		dedup-declined and the work dropped (the trap wiki_mirror documents for the
+		sync retry ids); the retry must use its own slot."""
+		frappe.flags.jarvis_test_wiki_mirror_enqueue = True
+		try:
+			with (
+				_wiki_disabled(),
+				mock.patch("jarvis._redis_lock.redis_lock", self._lock_denied),
+				mock.patch.object(wiki_mirror, "_scrub"),
+				mock.patch.object(frappe, "enqueue") as enq,
+			):
+				wiki_mirror.scrub()
+			job_id = enq.call_args.kwargs["job_id"]
+			self.assertEqual(job_id, wiki_mirror.JOB_ID_SCRUB_RETRY)
+			self.assertNotEqual(job_id, wiki_mirror.JOB_ID_SCRUB)
+		finally:
+			frappe.flags.jarvis_test_wiki_mirror_enqueue = False
+
+	def test_enqueue_scrub_is_suppressed_under_tests_without_the_optin(self):
+		"""Fixture saves that flip the toggle must not spray RQ jobs; a test drives
+		``scrub`` directly instead."""
+		with mock.patch.object(frappe, "enqueue") as enq:
+			self.assertFalse(wiki_mirror.enqueue_scrub())
+		enq.assert_not_called()


### PR DESCRIPTION
## Summary

Disabling **Enable Business Wiki** now actually removes the tenant's mirrored page files from the container, instead of only gating new reads. Previously the kill switch left already-mirrored markdown in the container's org-shared `wiki/` folder (still greppable off disk) and blocked revocation deletes while the wiki was off, so an operator turning the wiki off during a content incident did not remove the content. Closes #731.

On a genuine Enable-Business-Wiki 1 -> 0 change, one sweep prunes every mirrored wiki file from the container. Re-enabling later re-mirrors through the existing full sync.

<details>
<summary>Mechanism</summary>

- `wiki_mirror.scrub()` reuses the mirror push API: an explicit `delete` list of every stamped page file plus `index.md`/`log.md`, AND `known_paths=[]` so the fleet's full-sync walk also prunes strays left at old paths. Serialised on the same redis lock as `sync` (#622) so an in-flight reconcile cannot re-push after the prune; reads the stamped rows inside the lock. Run-time re-checks the toggle (inverse of #493's gate) so a re-enable race cannot wipe a live mirror; re-queues under a distinct id on contention/crash. Clears `mirror_hash` only after a confirmed prune; safe/no-op when nothing is mirrored or the container is absent.
- **Trigger (revised after review):** `validate()` records a real 1 -> 0 change of the toggle via `has_value_changed` (the file's `llm_auth_mode_changed` convention); `on_update()` fires the scrub on that flag, before the unified-LLM early returns. Change-detection, not raw state: a loaded Check coerces NULL to 0, so a state-based guard would have wiped the mirror on any unrelated settings save for a pre-v2 (NULL=ON) tenant.
- **Patch `v2_14_backfill_wiki_enabled`:** seeds an explicit `1` for absent/NULL `wiki_enabled` rows (never touches an explicit `0`), so a real disable of a pre-v2 tenant is a visible 1 -> 0 change the trigger can see. Mirrors the sibling `v2_11_backfill_home_intro_enabled`.

**Known gaps:** a scrub against an unreachable admin/tenant is logged, not retried (a re-toggle re-fires it); only the toggle's doc save path is wired (a raw `set_single_value` bypasses it); the scrub does not stamp `wiki_mirror_last_sync_status`.
</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on failure)
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests (`TestScrubOnDisable`, `TestWikiScrubGuardUnit`, `TestWikiScrubGuardOnSave`, `TestWikiEnabledBackfillPatch`)
- [x] I self-reviewed the diff (an independent review caught the pre-v2 spurious-scrub case, fixed in the second commit)