### PR TITLE
security(export_document): sanitize both content branches, expose to the agent

### DIFF
--- a/jarvis/tests/test_export_document.py
+++ b/jarvis/tests/test_export_document.py
@@ -98,7 +98,9 @@ class TestExportDocumentFormats(FrappeTestCase):
 		self.assertTrue(fname.endswith(".png"))
 		self.assertEqual(payload[:4], b"\x89PNG")
 
-	def test_raw_html_passthrough(self):
+	def test_raw_html_benign_tags_survive_sanitization(self):
+		"""content_is_html=True skips markdown conversion, not sanitization —
+		benign tags with no dangerous attributes pass through unchanged."""
 		m = self._mock()
 		export_document("<h1>Raw</h1><p>kept verbatim</p>", format="html", content_is_html=True)
 		_, payload = _saved(m)
@@ -113,3 +115,79 @@ class TestExportDocumentFormats(FrappeTestCase):
 		out = export_document(_MD, title="d")
 		self.assertEqual(out["mime_type"], "application/pdf")
 		self.assertEqual(_saved(m)[1][:4], b"%PDF")
+
+
+class TestExportDocumentSanitization(FrappeTestCase):
+	"""content is agent-composed (effectively LLM-controlled) text. Two threats,
+	both must be closed on BOTH the Markdown branch and the content_is_html=True
+	raw-HTML branch: XSS in the standalone HTML, and SSRF-via-render — wkhtmltopdf
+	fetches any <img>/<link>/SVG <image> it finds, server-side, at render time."""
+
+	def _mock(self):
+		m = patch("frappe.utils.file_manager.save_file").start()
+		self.addCleanup(patch.stopall)
+		m.return_value = frappe._dict(
+			file_url="/private/files/doc.out", file_name="doc.out", file_size=1, name="F-DOC"
+		)
+		return m
+
+	def _rendered_html(self, content: str, *, content_is_html: bool) -> str:
+		m = self._mock()
+		export_document(content, format="html", content_is_html=content_is_html)
+		return _saved(m)[1].decode("utf-8")
+
+	def test_script_tag_stripped_markdown_branch(self):
+		text = self._rendered_html("hello <script>alert(1)</script> world", content_is_html=False)
+		self.assertNotIn("<script", text)
+		self.assertNotIn("alert(1)", text.replace("&#39;", "'"))  # not present as live JS either way
+
+	def test_script_tag_stripped_raw_html_branch(self):
+		text = self._rendered_html("<p>hi</p><script>alert(1)</script>", content_is_html=True)
+		self.assertNotIn("<script", text)
+
+	def test_img_tag_stripped_both_branches(self):
+		"""The SSRF vector this whole change exists to close: an <img src> makes
+		wkhtmltopdf issue a server-side fetch at render time (cloud metadata
+		endpoints, internal network probing, file:// local reads)."""
+		md_text = self._rendered_html("![x](http://169.254.169.254/latest/meta-data/)", content_is_html=False)
+		self.assertNotIn("<img", md_text)
+		html_text = self._rendered_html('<img src="file:///etc/passwd">', content_is_html=True)
+		self.assertNotIn("<img", html_text)
+
+	def test_svg_image_href_stripped(self):
+		text = self._rendered_html(
+			'<svg><image href="http://attacker.example/beacon"/></svg>', content_is_html=True
+		)
+		self.assertNotIn("<svg", text)
+		self.assertNotIn("<image", text)
+
+	def test_link_and_meta_stripped(self):
+		text = self._rendered_html(
+			'<link rel="stylesheet" href="http://attacker.example/x.css">'
+			'<meta http-equiv="refresh" content="0;url=http://attacker.example">',
+			content_is_html=True,
+		)
+		self.assertNotIn("<link", text)
+		self.assertNotIn("http-equiv", text)
+
+	def test_onerror_attribute_and_javascript_href_stripped(self):
+		text = self._rendered_html(
+			'<a href="javascript:alert(1)" onclick="alert(2)">click</a>', content_is_html=True
+		)
+		self.assertNotIn("javascript:", text)
+		self.assertNotIn("onclick", text)
+
+	def test_benign_markdown_formatting_still_renders(self):
+		text = self._rendered_html("# Title\n\n**bold** and *italic*\n\n- one\n- two", content_is_html=False)
+		self.assertIn("<h1", text)  # md_to_html's header-ids extra adds an id attribute
+		self.assertIn("Title", text)
+		self.assertIn("<strong>bold</strong>", text)
+		self.assertIn("<li>one</li>", text)
+
+	def test_content_length_cap(self):
+		with self.assertRaises(InvalidArgumentError):
+			export_document("x" * 200_001, format="html")
+		# exactly at the cap is accepted
+		m = self._mock()
+		export_document("x" * 200_000, format="html")
+		self.assertTrue(m.called)

--- a/jarvis/tools/_tool_contract.py
+++ b/jarvis/tools/_tool_contract.py
@@ -60,12 +60,6 @@ BACKEND_ONLY: dict[str, str] = {
 		"would resurrect the retired surface. Delete the module (and this entry) once no "
 		"deployed bundle references it."
 	),
-	"export_document": (
-		"Implemented by jarvis #337 but never given a plugin descriptor, so no agent can call it "
-		"today. Exposing it is a product decision (it writes a File and needs a jarvis-persona "
-		"TOOLS.md row), not a drift fix — recorded here so the gap is explicit while every OTHER "
-		"drift still fails CI. Remove this entry in the change that adds the descriptor."
-	),
 }
 
 _COMMENT: tuple[str, ...] = (

--- a/jarvis/tools/export_document.py
+++ b/jarvis/tools/export_document.py
@@ -8,9 +8,46 @@ this the agent hand-builds the file with ``exec``/``browser`` and it never
 reaches the user. Here we render the content with Frappe's own engines
 (``md_to_html`` + ``get_pdf``) and save a private File the chat renders as a
 download card.
+
+Security: ``content`` is agent-composed, which means it is effectively
+LLM-controlled text — it must never reach the HTML unsanitized. Two distinct
+threats, both closed at one choke point:
+
+  * XSS in the standalone HTML output — ``<script>``, inline event handlers,
+    ``javascript:`` hrefs.
+  * SSRF-via-render — ``get_pdf`` runs wkhtmltopdf, which FETCHES any
+    ``<img src>`` / ``<link href>`` / SVG ``<image href>`` it finds at render
+    time, server-side. An agent-composed ``<img src="http://169.254.169.254/…">``
+    (cloud metadata) or ``file:///etc/passwd`` would make the PDF renderer
+    issue that request. This tool does not support embedded
+    images/charts (deliberately out of scope), so every fetch-capable tag is
+    stripped outright rather than merely attribute-filtered — no feature is
+    lost by removing a tag nothing here is meant to use.
+
+Two layers, mirroring the pattern ``frappe.utils.html_utils`` already uses for
+``<script>``/``<style>`` (``clean_script_and_style``, a BeautifulSoup decompose
+pass ahead of ``bleach.clean``):
+
+  1. ``_strip_unsafe_tags`` — a BeautifulSoup decompose pass that REMOVES the
+     fetch-capable tags outright (``img``/``svg``/``image``/``link``/``meta``/
+     ``style``), plus ``<script>``. Bleach's own default behaviour for a tag
+     outside its allowlist is to *escape* it into visible garbled text, not
+     remove it — safe (nothing executes or fetches) but ugly in a document
+     meant to read as a clean report, and it would leave a stripped
+     ``<script>``'s payload sitting as visible inert text. Decomposing first
+     gives a clean removal instead.
+  2. ``frappe.utils.sanitize_html`` (bleach-based) on what remains — blocks
+     event-handler attributes and non-``{cid,http,https,mailto}`` protocols
+     as part of its base allowlist (belt-and-suspenders once ``<script>`` and
+     every fetch-capable tag are already gone).
+
+Applied identically to BOTH the Markdown-rendered branch and the
+``content_is_html=True`` raw-HTML branch — the flag changes how ``content``
+becomes HTML, never whether the result gets sanitized.
 """
 
 import frappe
+from frappe.utils.html_utils import sanitize_html
 
 from jarvis.exceptions import InvalidArgumentError, NoDataError
 
@@ -19,6 +56,43 @@ _FORMATS = {
 	"html": ("html", "text/html"),
 	"png": ("png", "image/png"),
 }
+
+# Every tag capable of triggering an out-of-band fetch when wkhtmltopdf renders
+# the page, plus <script> — decomposed here (not left to sanitize_html's own
+# allowlist filtering) so its content disappears cleanly instead of surviving
+# as inert escaped text sitting visibly in the rendered document. A duplicate
+# <html>/<head>/<body> in the caller's content is not a separate risk to name
+# here: the HTML5 tree-construction algorithm (which html5lib implements)
+# already folds a second html/head/body into the single real one rather than
+# nesting it — verified empirically before relying on it.
+_UNSAFE_TAGS = {"img", "image", "svg", "link", "meta", "style", "script"}
+
+# A runaway model must not be able to hand wkhtmltopdf an unbounded document.
+_MAX_CONTENT_CHARS = 200_000
+
+
+def _strip_unsafe_tags(html: str) -> str:
+	"""Remove (not merely escape) every tag in ``_UNSAFE_TAGS``.
+
+	Same technique ``frappe.utils.html_utils.clean_script_and_style`` already
+	uses for ``<script>``/``<style>``: a BeautifulSoup decompose pass. Doing
+	this ahead of ``sanitize_html`` gives a clean removal — bleach's own
+	default for a disallowed tag is to escape it into visible text, which is
+	safe but leaves garbled tag source sitting in the rendered document.
+
+	``BeautifulSoup(html, "html5lib")`` always parses into a full document
+	(wrapping bare content in its own ``<html><head></head><body>…</body></html>``,
+	confirmed empirically), so this returns ``soup.body``'s inner HTML, not the
+	whole parsed tree — ``html`` here is a fragment about to be spliced into
+	this module's own page shell, not a full page in its own right.
+	"""
+	from bs4 import BeautifulSoup
+
+	soup = BeautifulSoup(html, "html5lib")
+	for tag in soup(list(_UNSAFE_TAGS)):
+		tag.decompose()
+	return frappe.as_unicode(soup.body.decode_contents()) if soup.body else frappe.as_unicode(soup)
+
 
 # Minimal, self-contained stylesheet so tables/headings read cleanly in every
 # format (the HTML file opens standalone; the PDF/PNG render from the same CSS).
@@ -49,14 +123,24 @@ def export_document(
 	headings, lists all render), or raw HTML when ``content_is_html`` is set.
 	``format`` is ``"pdf"`` (default), ``"html"``, or ``"png"`` (a single image
 	of the rendered pages, stacked). ``title`` names the file + document.
+
+	Both content modes are sanitized identically before rendering (see the
+	module docstring): ``content_is_html`` changes how ``content`` becomes
+	HTML, never whether the result is sanitized. Images/embedded charts are
+	not supported by design, not omission — do not ask for a workaround via
+	``content_is_html``.
 	"""
 	if not isinstance(content, str) or not content.strip():
 		raise NoDataError("No content to export.")
+	if len(content) > _MAX_CONTENT_CHARS:
+		raise InvalidArgumentError(f"content exceeds {_MAX_CONTENT_CHARS} characters")
 	fmt = (format or "pdf").lower()
 	if fmt not in _FORMATS:
 		raise InvalidArgumentError(f"format must be one of {sorted(_FORMATS)}")
 
 	body = content if content_is_html else frappe.utils.md_to_html(content)
+	body = _strip_unsafe_tags(body)
+	body = sanitize_html(body)
 	doc_title = frappe.utils.escape_html(title) if title else "Document"
 	html = (
 		f"<!doctype html><html><head><meta charset='utf-8'>"

--- a/jarvis/tools/tool-names.json
+++ b/jarvis/tools/tool-names.json
@@ -18,7 +18,7 @@
     "repo copies are compared by it, because no CI job can see both repos."
   ],
   "contract_version": 1,
-  "digest": "sha256:ab340f555a1801764b832738f7fe4866d1952b715b608deaff34ecb15d772b51",
+  "digest": "sha256:4f87815c52fe26085ebc72d8443144caa04fc7c0196ac17b0c25e5639c714def",
   "tools": [
     "add_comment",
     "add_tag",
@@ -35,6 +35,7 @@
     "describe_customizations",
     "download_pdf",
     "download_vcard",
+    "export_document",
     "export_excel",
     "find_skills",
     "finish_app_learning_run",
@@ -92,7 +93,6 @@
     "update_wiki"
   ],
   "backend_only": {
-    "create_docs": "Deprecated compat shim for already-shipped plugin bundles that still advertise jarvis__create_docs; bulk create is create_doc(docs=[...]) now. Re-adding a descriptor would resurrect the retired surface. Delete the module (and this entry) once no deployed bundle references it.",
-    "export_document": "Implemented by jarvis #337 but never given a plugin descriptor, so no agent can call it today. Exposing it is a product decision (it writes a File and needs a jarvis-persona TOOLS.md row), not a drift fix — recorded here so the gap is explicit while every OTHER drift still fails CI. Remove this entry in the change that adds the descriptor."
+    "create_docs": "Deprecated compat shim for already-shipped plugin bundles that still advertise jarvis__create_docs; bulk create is create_doc(docs=[...]) now. Re-adding a descriptor would resurrect the retired surface. Delete the module (and this entry) once no deployed bundle references it."
   }
 }


### PR DESCRIPTION
## What

`export_document` (jarvis #337, merged 2026-07-16) is the freeform PDF/HTML/PNG
tool this repo already had - agent-composed content, not tied to a saved
Report or an existing record. It has never been reachable: `_tool_contract.py`
recorded the gap explicitly ("exposing it is a product decision"). This PR
makes that decision, and closes the one thing that made it unsafe to make
before now.

## The gap (security, not just a wiring gap)

`content` is effectively LLM-controlled text. It went through
`frappe.utils.md_to_html` with zero sanitization - raw HTML passed straight
through. Two live threats:

- **XSS** in the standalone HTML output.
- **SSRF-via-render** - `get_pdf` runs wkhtmltopdf, which fetches any
  `<img src>` / `<link href>` / SVG `<image href>` it finds AT RENDER TIME,
  server-side. An agent-composed `<img src="http://169.254.169.254/...">`
  (cloud metadata) or `file:///etc/passwd` would make the PDF renderer issue
  that request. `content_is_html=True` bypassed markdown entirely, verbatim.

`frappe.utils.markdown(sanitize=True)` was investigated and rejected: it
wraps `sanitize_html` but exposes no `disallowed_tags`, and `sanitize_html`'s
allowlist (built for Desk rich-text in a browser, not for content about to
hit a server-side PDF renderer) still permits `img`/`svg`/`link`/`meta`/
`style` - every one of them fetch-capable. Images/charts are already out of
scope for this tool, so there's no feature lost by removing them outright.

## The fix

Two layers, mirroring `frappe.utils.html_utils.clean_script_and_style`'s own
BeautifulSoup-decompose-then-bleach pattern for `<script>`/`<style>`:

1. `_strip_unsafe_tags` - BeautifulSoup decompose pass, REMOVES (not merely
   escapes - bleach's own default for a disallowed tag) `img`/`image`/`svg`/
   `link`/`meta`/`style`/`script` outright. Applied identically on the
   Markdown branch and the `content_is_html=True` branch - the flag changes
   how `content` becomes HTML, never whether the result is sanitized.
2. `frappe.utils.sanitize_html` on what remains - event-handler attributes,
   non-`{cid,http,https,mailto}` protocols.

Plus a content-size cap (`_MAX_CONTENT_CHARS = 200_000`, mirrors `read_file`'s
bounding convention) so a runaway model can't hand wkhtmltopdf an unbounded
document.

`_tool_contract.py`: removed the `export_document` `BACKEND_ONLY` exemption;
`tool-names.json` regenerated via
`env/bin/python -m jarvis.tools._tool_contract --write`.

## Verification

- 15 unit tests (`jarvis.tests.test_export_document`): script/img/svg/link/meta
  stripped on BOTH branches with real attacker payloads (cloud-metadata IP,
  `file://` path, `javascript:` href), benign formatting (headings, bold,
  lists, tables) still renders, content-cap boundary, existing behaviour
  preserved (renamed `test_raw_html_passthrough` ->
  `test_raw_html_benign_tags_survive_sanitization`, same assertions - `<h1>`/
  `<p>` have no dangerous attributes so still pass through untouched).
- Full jarvis app suite: green, no regressions.
- **Live verification against a real bench** (jarvis-v16.localhost), calling
  the actual `jarvis.tools.registry.dispatch("export_document", ...)` path
  used by the agent's tool calls: happy-path content (markdown summary +
  table) produced a genuine `%PDF-1.4` file; an adversarial payload
  (`<script>`, an `<img>` at the cloud metadata IP, an `<img src=file://...>`,
  `<svg><image>`, `<link>`) rendered with every dangerous tag AND every
  attacker URL completely absent from the output, while the benign heading/
  paragraph in the same payload survived untouched.

## Companion PRs (stacked)

- jarvis-openclaw-plugin: exposes `jarvis__export_document` (descriptor,
  manifest, contract) - depends on #70 (report_pdf), which this stacks on.
- jarvis-persona: routes both `report_pdf` and `export_document` into
  `TOOLS.md`/`AGENTS.md` (neither had a persona row before).
