### PR TITLE
Default model backups off, refresh chat pin, scroll picker list

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -806,9 +806,9 @@
 						{{ panel.testResult.caveat }}
 					</div>
 
-					<!-- Resilient-by-default (API KEYS ONLY): expands this provider into
-               its full single-vendor failover chain on close, sharing the
-               same key. Add-mode only. -->
+					<!-- Opt-in backups (API KEYS ONLY): when switched on, expands this
+               provider into its full single-vendor failover chain on close,
+               sharing the same key. Off by default; add-mode only. -->
 					<label
 						v-if="panel.mode === 'add'"
 						style="
@@ -832,7 +832,7 @@
 						>
 							<span class="jv-switch-knob"></span>
 						</button>
-						Add backup models automatically (recommended)
+						Add backup models automatically
 					</label>
 				</div>
 
@@ -3081,7 +3081,7 @@ const panel = ref({
 	mode: "add",
 	uid: null,
 	source: "subscription",
-	addBackups: true,
+	addBackups: false,
 	testing: false,
 	testResult: null,
 	testGen: 0,
@@ -3121,7 +3121,7 @@ function closedPanel() {
 		mode: "add",
 		uid: null,
 		source: "subscription",
-		addBackups: true,
+		addBackups: false,
 		testing: false,
 		testResult: null,
 		testGen: 0,
@@ -3181,7 +3181,7 @@ function openAdd() {
 		mode: "add",
 		uid: r._uid,
 		source: "subscription",
-		addBackups: true,
+		addBackups: false,
 		testing: false,
 		testResult: null,
 		testGen: 0,
@@ -3195,7 +3195,7 @@ function openEdit(i) {
 		mode: "edit",
 		uid: r._uid,
 		source: r.credentialType === "subscription" ? "subscription" : "api_key",
-		addBackups: true,
+		addBackups: false,
 		testing: false,
 		testResult: null,
 		testGen: 0,
@@ -3341,10 +3341,10 @@ function testResultOf(res) {
 	};
 }
 
-// Resilient-by-default (API KEYS ONLY - no subscription presets exist and
+// Opt-in backups (API KEYS ONLY - no subscription presets exist and
 // multi-model-per-account is unconfirmed for cliproxy, so subscriptions never
 // auto-add backups). Finds the catalog's single-vendor preset for this
-// provider, if any.
+// provider, if any. Only consulted when the add panel's backup switch is on.
 function vendorSinglePreset(provider) {
 	const pid = providerId(provider);
 	return catalog.value.find(

--- a/frontend/src/components/chat/ModelEffortPicker.vue
+++ b/frontend/src/components/chat/ModelEffortPicker.vue
@@ -47,48 +47,53 @@
 
 		<!-- dropdown: opens UPWARD (the pill lives at the bottom of the screen) -->
 		<div v-if="open" class="mep-menu" role="menu">
-			<!-- models -->
-			<template v-for="(g, gi) in modelsByProvider" :key="g.provider">
-				<div v-if="showProviders" class="mep-head">{{ g.provider }}</div>
-				<button
-					v-if="gi === 0"
-					class="mep-item"
-					role="menuitemradio"
-					:aria-checked="!modelOverride"
-					@click="onModel('')"
-				>
-					<span class="mep-item-body">
-						<span class="mep-name">Auto</span>
-						<span class="mep-desc"
-							>Let {{ assistantName }} choose · {{ defaultModel || "default" }}</span
-						>
-					</span>
-					<CheckMark v-if="!modelOverride" />
-				</button>
-				<button
-					v-for="r in g.models"
-					:key="g.provider + '/' + r.model"
-					class="mep-item"
-					role="menuitemradio"
-					:aria-checked="r.model === modelOverride"
-					@click="onModel(r.model)"
-				>
-					<span class="mep-item-body">
-						<span class="mep-name">{{ r.model }}</span>
-						<!-- `tier` belongs to a configured pool row. An `extra` row is another
+			<!-- models (scrolls: the list can grow tall across several providers;
+			     the Effort/Persona rows and their side-flyouts stay OUTSIDE this
+			     scroll region so the flyouts anchor correctly and never clip) -->
+			<div class="mep-scroll">
+				<template v-for="(g, gi) in modelsByProvider" :key="g.provider">
+					<div v-if="showProviders" class="mep-head">{{ g.provider }}</div>
+					<button
+						v-if="gi === 0"
+						class="mep-item"
+						role="menuitemradio"
+						:aria-checked="!modelOverride"
+						@click="onModel('')"
+					>
+						<span class="mep-item-body">
+							<span class="mep-name">Auto</span>
+							<span class="mep-desc"
+								>Let {{ assistantName }} choose ·
+								{{ defaultModel || "default" }}</span
+							>
+						</span>
+						<CheckMark v-if="!modelOverride" />
+					</button>
+					<button
+						v-for="r in g.models"
+						:key="g.provider + '/' + r.model"
+						class="mep-item"
+						role="menuitemradio"
+						:aria-checked="r.model === modelOverride"
+						@click="onModel(r.model)"
+					>
+						<span class="mep-item-body">
+							<span class="mep-name">{{ r.model }}</span>
+							<!-- `tier` belongs to a configured pool row. An `extra` row is another
 						     model on a provider the customer ALREADY configured, offered so they
 						     can switch without re-saving Settings; its catalog label is the more
 						     useful subtitle, skipped when it merely repeats the id. -->
-						<span v-if="r.tier" class="mep-desc">{{ r.tier }}</span>
-						<span
-							v-else-if="r.extra && r.label && r.label !== r.model"
-							class="mep-desc"
-							>{{ r.label }}</span
-						>
-					</span>
-					<CheckMark v-if="r.model === modelOverride" />
-				</button>
-			</template>
+							<span v-if="r.tier" class="mep-desc">{{ r.tier }}</span>
+							<span
+								v-else-if="r.extra && r.label && r.label !== r.model"
+								class="mep-desc"
+								>{{ r.label }}</span
+							>
+						</span>
+						<CheckMark v-if="r.model === modelOverride" />
+					</button>
+				</template>
+			</div>
 
 			<!-- Adding a PROVIDER is configuration, not selection. The picker lists
 			     only what this tenant can actually run today (its configured
@@ -411,6 +416,14 @@ watch(open, (isOpen) => {
 	box-shadow: 0 12px 34px rgba(20, 20, 30, 0.18);
 	padding: 5px;
 	z-index: 60;
+}
+/* Only the model list scrolls; the Effort/Persona rows below stay pinned so
+   their side-flyouts anchor correctly. Caps the menu height so a long list
+   never runs off the top of the viewport (it opens upward). */
+.mep-scroll {
+	max-height: min(52vh, 420px);
+	overflow-y: auto;
+	overscroll-behavior: contain;
 }
 .mep-head {
 	padding: 6px 9px 4px;

--- a/frontend/src/components/settings/AiModelsPane.vue
+++ b/frontend/src/components/settings/AiModelsPane.vue
@@ -183,6 +183,8 @@ async function loadDirectSub() {
 // reflects the new state.
 async function onDirectChanged() {
 	await loadDirectSub();
+	// A connect/disconnect changes which models the chat picker can offer.
+	store.bumpLlmConfig();
 }
 
 // After a pool save: flash the note and re-probe direct status (a save can't
@@ -199,6 +201,9 @@ async function onSaved(sync) {
 		savedNote.value = "";
 	}, 4000);
 	await loadDirectSub();
+	// Tell any mounted chat view its model list just changed so the picker
+	// refreshes without a full page reload.
+	store.bumpLlmConfig();
 }
 
 onMounted(loadDirectSub);

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -36,6 +36,14 @@ const settingsSection = ref("general"); // active pane key in the settings dialo
 // openSettings() below - so a section switch can never abandon an in-flight
 // apply regardless of which caller triggered it (jarvis#821 review).
 const settingsApplying = ref(false);
+// Bumped whenever the tenant's LLM config changes (a pool save, a subscription
+// connect/disconnect) so views that snapshot chat-ui settings at mount - the
+// chat model picker in particular - can re-fetch instead of showing a stale
+// model list until a full page reload (jarvis: pin-not-refreshed-after-add).
+const llmConfigVersion = ref(0);
+function bumpLlmConfig() {
+	llmConfigVersion.value += 1;
+}
 const pendingNewChat = ref(false); // consumed + cleared by ChatView
 const paletteOpen = ref(false);
 
@@ -476,6 +484,7 @@ const store = reactive({
 	settingsOpen,
 	settingsSection,
 	settingsApplying,
+	llmConfigVersion,
 	chatContext,
 	settingsActions,
 	activityDetail,
@@ -509,6 +518,7 @@ const store = reactive({
 	applyRemoteNew,
 	markUnread,
 	clearUnread,
+	bumpLlmConfig,
 });
 
 export function useShellStore() {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -9881,6 +9881,19 @@ onMounted(async () => {
 		if (busy.value) nowMs.value = Date.now();
 	}, 1000);
 	ui.value = (await uiP) || {};
+	// The model picker snapshots ui at mount. When AI-model settings change in
+	// the settings dialog (a pool save or a subscription connect/disconnect),
+	// the shell store bumps llmConfigVersion; re-fetch so the pin reflects the
+	// new model list without a full page reload. Fields the picker reads
+	// (pool_models, catalog_models, llm_model, ...) all live on this object, and
+	// getChatUiSettings is the same call the mount used, so a reassign is safe.
+	watch(
+		() => store.llmConfigVersion,
+		async () => {
+			const next = await api.getChatUiSettings().catch(() => null);
+			if (next) ui.value = next;
+		}
+	);
 	// Reconcile the persona pill with the server's current value, so a persona
 	// switched on another device shows up here too. Adopt only, never a write
 	// (persist:false), since this is us catching up to the server, not a change.

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3963,6 +3963,21 @@ const queuedTurn = ref(null);
 const confirmedAck = ref(false);
 let _confirmedAckTimer = null;
 const ui = ref({});
+// The model picker snapshots ui at mount. When AI-model settings change in the
+// settings dialog (a pool save, or a subscription connect/disconnect), the shell
+// store bumps llmConfigVersion; re-fetch so the pin reflects the new model list
+// without a full page reload. Fields the picker reads (pool_models,
+// catalog_models, llm_model, ...) all live on this object, and getChatUiSettings
+// is the same call the mount used, so a reassign is safe. Registered here in
+// synchronous setup scope (NOT inside onMounted, which is async - a watch created
+// after its first await loses the effect scope and would never auto-dispose).
+watch(
+	() => store.llmConfigVersion,
+	async () => {
+		const next = await api.getChatUiSettings().catch(() => null);
+		if (next) ui.value = next;
+	}
+);
 // Renew-banner copy when the subscription has lapsed; null while entitled.
 // The composer is disabled alongside it (no send can succeed while stopped).
 const suspendedNotice = ref(null);
@@ -9881,19 +9896,6 @@ onMounted(async () => {
 		if (busy.value) nowMs.value = Date.now();
 	}, 1000);
 	ui.value = (await uiP) || {};
-	// The model picker snapshots ui at mount. When AI-model settings change in
-	// the settings dialog (a pool save or a subscription connect/disconnect),
-	// the shell store bumps llmConfigVersion; re-fetch so the pin reflects the
-	// new model list without a full page reload. Fields the picker reads
-	// (pool_models, catalog_models, llm_model, ...) all live on this object, and
-	// getChatUiSettings is the same call the mount used, so a reassign is safe.
-	watch(
-		() => store.llmConfigVersion,
-		async () => {
-			const next = await api.getChatUiSettings().catch(() => null);
-			if (next) ui.value = next;
-		}
-	);
 	// Reconcile the persona pill with the server's current value, so a persona
 	// switched on another device shows up here too. Adopt only, never a write
 	// (persist:false), since this is us catching up to the server, not a change.


### PR DESCRIPTION
## Summary

Three fixes to the AI-models settings flow and the chat model picker, all frontend.

- **Backups off by default.** The "Add backup models automatically" switch in the API-key add panel now defaults **off** (was on). Adding an API-key model no longer silently expands into the provider's whole failover chain; the user picks model IDs from the full catalog list instead (that list, a `JvCombo`, already shows every catalog model and already scrolls).
- **Chat pin refreshes after a settings change.** The picker snapshotted chat-ui settings at mount and never re-fetched, so after adding a model the pin kept showing the old one until a full page reload. A new shell-store signal (`llmConfigVersion`, bumped on pool save and on subscription connect/disconnect) makes `ChatView` re-fetch and the pin update live.
- **Picker list scrolls.** The dropdown had no `max-height`/scroll and opened upward, so a long model list ran off the top of the screen. Only the model list now scrolls; the Effort/Persona rows and their side-flyouts stay outside the scroll region so they still anchor cleanly.

> [!NOTE]
> **Reviewer decision:** the backup switch is shared by the onboarding wizard, so onboarding is now opt-in for backups too. If onboarding should stay resilient-by-default, say so and I will scope the flip to Settings only.
>
> On "list all model IDs": the catalog already carries every model ID on the `api_key` tier (subscription IDs are duplicated onto it), so no backend change was needed. Turning the switch off is what surfaces the full list for manual pick. If a specific ID is still missing live, that is admin-managed catalog data, not app code.

<details>
<summary>Root cause + verification</summary>

- Default set in four spots in `LlmPoolEditor.vue` (`panel` init, `closedPanel`, `openAdd`, `openEdit`); all flipped, stale "resilient-by-default" comments updated, "(recommended)" dropped from the label.
- `ChatView`'s `ui` ref was assigned once in `onMounted`; no watcher/store channel existed. Picker reads props reactively (computed/template), so a single `ui.value` reassign updates it.
- `.mep-menu` had `max-width` but no `max-height`/`overflow`; wrapped only the model `v-for` in `.mep-scroll { max-height: min(52vh, 420px); overflow-y: auto }`.
- Tests: `ModelEffortPicker`, `LlmPoolEditor` (+ connect), `OnboardingView` (+ connect) specs pass (184 tests) on Node 24. pre-commit prettier + eslint green. Live visual check (scroll + pin refresh) still pending.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `develop`**
- [x] Existing specs pass; new-behavior tests for the pin refresh/scroll not added (UI behavior)
- [x] I self-reviewed the diff
