### PR TITLE
feat: one-step operator reconnect — direct code redeem on a fresh bench

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -53,6 +53,11 @@ export const startAccountReconnect = (email, company = "") =>
 	call("jarvis.onboarding.start_account_reconnect", { email, company });
 export const checkAccountReconnect = (requestId, code) =>
 	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId, code: code || "" });
+// Operator-issued code path: no prior request, so the customer supplies the code
+// they got from support PLUS their registered email (the second factor). Same
+// landing as check_account_reconnect; a wrong/expired/unmatched pair -> "invalid".
+export const redeemReconnectCode = (code, email) =>
+	call("jarvis.onboarding.redeem_reconnect_code", { code: code || "", email: email || "" });
 
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat");
 // Re-drive this workspace's saved AI config through admin - the customer lever

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -29,6 +29,7 @@ const api = vi.hoisted(() => ({
 	reconnectAvailable: vi.fn(async () => ({ available: false })),
 	startAccountReconnect: vi.fn(async () => ({})),
 	checkAccountReconnect: vi.fn(async () => ({})),
+	redeemReconnectCode: vi.fn(async () => ({})),
 	getAccountDefaults: vi.fn(async () => ({})),
 	onboardingPaymentApi: {
 		getOnboardingState: vi.fn(async () => ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })),
@@ -198,6 +199,80 @@ describe("X7: defensive reconnect identity fields", () => {
 		await flushPromises();
 		expect(wrapper.vm.pay.value).toBe(STATES.RECONNECT);
 		expect(wrapper.vm.reconnectNeedsIdentity).toBe(false);
+	});
+});
+
+describe("operator-issued reconnect code: direct redeem vs emailed request", () => {
+	it("enterReconnectDirect opens the code screen in direct mode WITHOUT mailing a request", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.enterReconnectDirect();
+		expect(wrapper.vm.state.step).toBe("reconnect");
+		expect(wrapper.vm.state.reconnectDirect).toBe(true);
+		// A support code already exists out of band - never ask admin to mail one.
+		expect(api.startAccountReconnect).not.toHaveBeenCalled();
+	});
+
+	it("direct-mode submit redeems the code WITH the email, never the request poll", async () => {
+		api.redeemReconnectCode.mockResolvedValue({ status: "connected" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "known@example.com";
+		await wrapper.vm.submitReconnectCode();
+		expect(api.redeemReconnectCode).toHaveBeenCalledWith("ABCD2345", "known@example.com");
+		expect(api.checkAccountReconnect).not.toHaveBeenCalled();
+	});
+
+	it("request-mode submit polls the started request, never the direct redeem", async () => {
+		api.checkAccountReconnect.mockResolvedValue({ status: "connected" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = false;
+		wrapper.vm.state.reconnectRequestId = "rid-1";
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		await wrapper.vm.submitReconnectCode();
+		expect(api.checkAccountReconnect).toHaveBeenCalledWith("rid-1", "ABCD2345");
+		expect(api.redeemReconnectCode).not.toHaveBeenCalled();
+	});
+
+	it("direct-mode submit is blocked until the email is supplied (the 2nd factor)", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "   ";
+		await wrapper.vm.submitReconnectCode();
+		expect(api.redeemReconnectCode).not.toHaveBeenCalled();
+	});
+
+	it("a direct-mode invalid shows the code-or-email copy, never the confirmation-page one", async () => {
+		api.redeemReconnectCode.mockResolvedValue({ status: "invalid" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "known@example.com";
+		await wrapper.vm.submitReconnectCode();
+		// A support-code customer never saw a confirmation page - the copy must not send them there.
+		expect(wrapper.vm.state.payErr).not.toContain("confirmation page");
+		expect(wrapper.vm.state.payErr.toLowerCase()).toContain("email");
+	});
+
+	it("startReconnect (emailed path) clears direct-mode state so it can't leak in", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		// Simulate a prior direct attempt leaving residue.
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectEmail = "stale@example.com";
+		await wrapper.vm.startReconnect();
+		expect(wrapper.vm.state.reconnectDirect).toBe(false);
+		expect(wrapper.vm.state.reconnectEmail).toBe("");
 	});
 });
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -534,6 +534,18 @@
 								This email already has a subscription under a different company.
 								Enter that company above to reconnect it instead of paying again.
 							</p>
+							<p
+								class="mx-auto mt-3 max-w-[620px] text-center text-p-sm text-ink-gray-5"
+							>
+								Have a reconnect code from support?
+								<button
+									class="ob-link"
+									:disabled="state.payBusy"
+									@click="enterReconnectDirect"
+								>
+									Enter it here</button
+								>.
+							</p>
 							<div class="ob-foot">
 								<button class="ob-back" @click="goBack">
 									<FeatherIcon
@@ -1274,12 +1286,29 @@
 							<div class="ob-body ob-body--center">
 								<div class="ob-head">
 									<h1>Enter your reconnect code</h1>
-									<p>
+									<p v-if="state.reconnectDirect">
+										Enter the code support gave you and the email your
+										subscription is registered under. Connects this site to
+										your existing subscription, nothing to pay again.
+									</p>
+									<p v-else>
 										Sent to <b>{{ state.email || "your email" }}</b
 										>. Connects this site to your existing subscription,
 										nothing to pay again.
 									</p>
 								</div>
+								<FormControl
+									v-if="state.reconnectDirect"
+									v-model="state.reconnectEmail"
+									type="email"
+									variant="outline"
+									label="Registered email"
+									class="mx-auto mb-3 w-full max-w-[320px] text-left"
+									placeholder="you@company.com"
+									autocomplete="email"
+									aria-label="Registered email"
+									@keydown.enter="submitReconnectCode"
+								/>
 								<input
 									v-model="state.reconnectCode"
 									class="ob-code"
@@ -1293,7 +1322,10 @@
 									@keydown.enter="submitReconnectCode"
 								/>
 								<p class="ob-code-note">
-									<template v-if="state.reconnectResentIn > 0">
+									<template v-if="state.reconnectDirect">
+										Single-use, and expires shortly after support issued it.
+									</template>
+									<template v-else-if="state.reconnectResentIn > 0">
 										Sent. You can resend in {{ state.reconnectResentIn }}s.
 									</template>
 									<template v-else>
@@ -1302,6 +1334,12 @@
 											Resend code
 										</button>
 									</template>
+								</p>
+								<p v-if="!state.reconnectDirect" class="ob-code-note">
+									Got a code from support instead?
+									<button class="ob-link" @click="enterReconnectDirect">
+										Enter it here
+									</button>
 								</p>
 								<Banner v-if="state.payErr" type="error" :message="state.payErr" />
 							</div>
@@ -1316,7 +1354,10 @@
 									variant="solid"
 									:loading="state.payBusy"
 									loading-text="Working…"
-									:disabled="!state.reconnectCode.trim()"
+									:disabled="
+										!state.reconnectCode.trim() ||
+										(state.reconnectDirect && !state.reconnectEmail.trim())
+									"
 									label="Finish reconnect"
 									@click="submitReconnectCode"
 								/>
@@ -1685,6 +1726,7 @@ import {
 	reconnectAvailable,
 	startAccountReconnect,
 	checkAccountReconnect,
+	redeemReconnectCode,
 	getAccountDefaults,
 	getCompanyOnboardingDefaults,
 	updateBilling,
@@ -1825,6 +1867,12 @@ const state = reactive({
 	reconnectNeedsCompany: false,
 	reconnectCode: "",
 	reconnectResentIn: 0,
+	// Direct (operator-issued) reconnect: the customer got a code from support out
+	// of band, so there is NO customer-started request to poll. They redeem the code
+	// PLUS their registered email (the second factor) in one shot. reconnectDirect
+	// switches the code screen and submit path; reconnectEmail is the typed factor.
+	reconnectDirect: false,
+	reconnectEmail: "",
 	paymentProvider: "", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
 	// Gateways the operator has actually enabled, narrowed to what this build can
 	// render. Starts EMPTY and stays empty on a discovery failure (plan 02 P2-6):
@@ -3228,6 +3276,24 @@ function cancelReconnect() {
 	state.reconnectRequestId = "";
 	state.reconnectCode = "";
 	state.reconnectResentIn = 0;
+	state.reconnectDirect = false;
+	state.reconnectEmail = "";
+}
+
+// "I have a code from support": jump straight to the code screen in DIRECT mode
+// WITHOUT asking admin to mail a code (there is no customer-started request). The
+// operator already verified identity out of band and issued the code; the
+// customer redeems it here with their registered email. Reachable from Details and
+// from the emailed-code screen (a customer handed a support code instead).
+function enterReconnectDirect() {
+	state.payErr = "";
+	state.reconnectCode = "";
+	state.reconnectRequestId = "";
+	state.reconnectResentIn = 0;
+	state.reconnectEmail = reconnectIdentity.value.email || state.email || "";
+	state.reconnectFrom = state.step === "reconnect" ? state.reconnectFrom : state.step;
+	state.reconnectDirect = true;
+	state.step = "reconnect";
 }
 
 // The code the customer read off the confirmation page (or got from support).
@@ -3256,13 +3322,17 @@ async function resendReconnectCode() {
 
 async function submitReconnectCode() {
 	if (!state.reconnectCode.trim()) return;
+	if (state.reconnectDirect && !state.reconnectEmail.trim()) return;
 	state.payErr = "";
 	state.payBusy = true;
 	try {
-		const d = await checkAccountReconnect(
-			state.reconnectRequestId,
-			state.reconnectCode.trim()
-		);
+		// Direct mode redeems an operator-issued code with the registered email (no
+		// request_id); the emailed-request path polls the request the customer
+		// started. Both land through _land_reconnect, so the outcomes below are
+		// identical — only the redeeming call differs.
+		const d = state.reconnectDirect
+			? await redeemReconnectCode(state.reconnectCode.trim(), state.reconnectEmail.trim())
+			: await checkAccountReconnect(state.reconnectRequestId, state.reconnectCode.trim());
 		if (d && d.status === "connected") {
 			state.payBusy = false;
 			// Reconnect rotated this site onto an EXISTING, already-paid account
@@ -3290,10 +3360,17 @@ async function submitReconnectCode() {
 			if (state.step === "reconnect") state.step = "details";
 			return;
 		}
-		state.payErr =
-			d && d.status === "expired"
-				? "The reconnect request expired. Start it again."
-				: "That code didn't match. Check the confirmation page and try again.";
+		// Direct mode has no confirmation page (the code came from support) and its
+		// invalid covers a mistyped code OR the wrong registered email, so point the
+		// customer at both — never at a screen they never saw.
+		if (state.reconnectDirect) {
+			state.payErr = "That code or email didn't match. Check both and try again.";
+		} else {
+			state.payErr =
+				d && d.status === "expired"
+					? "The reconnect request expired. Start it again."
+					: "That code didn't match. Check the confirmation page and try again.";
+		}
 	} catch (e) {
 		state.payErr = errMsg(e);
 	} finally {
@@ -3307,6 +3384,8 @@ async function submitReconnectCode() {
 async function startReconnect() {
 	state.payErr = "";
 	state.reconnectCode = "";
+	state.reconnectDirect = false;
+	state.reconnectEmail = "";
 	state.payBusy = true;
 	// Where to return on Back/cancel: reconnect can be entered from Details
 	// (before any plan is chosen), from the recovery card, and from the review

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -393,6 +393,21 @@ def get_reconnect_state(request_id: str, code: str = "") -> dict:
 	)
 
 
+def redeem_reconnect_code(code: str, email: str = "") -> dict:
+	"""Guest: redeem an OPERATOR-ISSUED reconnect code on this fresh bench — the
+	request-less counterpart to get_reconnect_state. Admin verifies (code, email)
+	together (the email is the second factor), rotates credentials NOW and re-points
+	the account HERE, returning the SAME ready bundle get_reconnect_state does
+	(status/api_key/api_secret/customer/customer_password/subscription_status). The
+	site URL is server-derived via _public_origin() so the customer can't hand admin
+	a different site's URL. Every failure is an identical generic ``{status:"invalid"}``
+	(no code/account oracle)."""
+	return _post_guest(
+		path=_m("billing.reconnect.redeem_reconnect_code"),
+		body={"code": code, "email": email, "frappe_site_url": _public_origin()},
+	)
+
+
 def get_signup_payment_state() -> dict:
 	"""Authenticated poll. Returns one of:
 	    {pending_verification: True}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -1378,29 +1378,42 @@ def start_account_reconnect(email: str, company: str = "") -> dict:
 
 @frappe.whitelist()
 def check_account_reconnect(request_id: str, code: str = "") -> dict:
-	"""Redeem the reconnect code the customer received by email (or from
-	support). Only a correct code releases anything: admin then rotates and
-	delivers the credentials — persist them and
-	grant the onboarding admin role, exactly like a fresh signup would.
-
-	Two outcomes, because there are two things a reconnect can recover
-	(admin-v2 #162):
-
-	- ``connected`` - a PAID account whose container is already running. The
-	  wizard rides the normal sync_connection path to it; only the LLM step
-	  needs re-doing on this fresh site.
-	- ``resume_payment`` - an UNFINISHED checkout (declined card, interrupted
-	  payment). There is no container, so sync_connection has nothing to reach
-	  and the wizard would sit on "setting up your workspace" forever. What was
-	  recovered is the ability to authenticate, which is precisely what
-	  ``resume_pending_signup`` needs, so the wizard goes back to Pay.
-
-	Read off admin's ``subscription_status``. An admin that predates that key
-	sends nothing and this answers ``connected``, which is exactly what it
-	answered before and is right for the only population that admin can
-	reconnect."""
+	"""Redeem the reconnect code the customer received BY EMAIL (the customer-
+	started request path). Only a correct code releases anything: admin rotates and
+	delivers the credentials, which _land_reconnect persists — see it for the
+	connected-vs-resume_payment outcomes."""
 	require_jarvis_admin()
 	data = _surface(admin_client.get_reconnect_state, request_id, code) or {}
+	return _land_reconnect(data)
+
+
+@frappe.whitelist()
+def redeem_reconnect_code(code: str, email: str = "") -> dict:
+	"""Redeem an OPERATOR-ISSUED reconnect code on this fresh bench — the
+	request-less counterpart to check_account_reconnect. The customer got the code
+	from support (out of band) and enters it PLUS their registered email; admin
+	verifies both, rotates, and returns the SAME ready bundle, which lands
+	identically (_land_reconnect). No prior customer-started request exists, so
+	there is no request_id. Same require_jarvis_admin gate: the customer is admin on
+	their own new bench. A wrong/expired/unmatched code comes back ``invalid``."""
+	require_jarvis_admin()
+	data = _surface(admin_client.redeem_reconnect_code, code, email) or {}
+	return _land_reconnect(data)
+
+
+def _land_reconnect(data: dict) -> dict:
+	"""Persist a reconnect ready-bundle and grant the onboarding admin role, exactly
+	like a fresh signup would. Shared by the email/poll path
+	(check_account_reconnect) and the operator-code path (redeem_reconnect_code):
+	both receive the SAME ready bundle from admin, so landing MUST be identical or
+	the two paths would diverge in what a reconnected site ends up holding.
+
+	Two ready outcomes (admin-v2 #162): ``connected`` — a PAID account whose
+	container is already running (ride sync_connection; only the LLM step re-does on
+	this fresh site); ``resume_payment`` — an UNFINISHED checkout with no container,
+	so the wizard goes back to Pay. Anything not ``ready`` (pending / awaiting_code /
+	expired / invalid) is surfaced verbatim for the caller to render."""
+	data = data or {}
 	if data.get("status") != "ready":
 		return {"status": data.get("status") or "expired"}
 	# A reconnect deliberately re-points this bench at an existing account's

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1445,7 +1445,27 @@ class TestPublicOriginSweep(FrappeTestCase):
 		with patch("requests.post", side_effect=_fake_post):
 			admin_client.site_replacement()
 			admin_client.request_account_reconnect("e@x.com", "Co")
-		self.assertEqual(seen, ["https://tenant.example.com", "https://tenant.example.com"])
+			# redeem is guest-callable and hands over a workspace: the site URL MUST
+			# be server-derived, never taken from the customer, or the code could be
+			# redeemed onto a site the attacker doesn't control.
+			admin_client.redeem_reconnect_code("ABCD2345", "e@x.com")
+		self.assertEqual(seen, ["https://tenant.example.com"] * 3)
+
+	def test_redeem_forwards_code_and_email(self):
+		_settings_clear_admin()
+		frappe.conf["host_name"] = "https://tenant.example.com"
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["url"] = url
+			captured["json"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {"status": "invalid"}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.redeem_reconnect_code("ABCD2345", "e@x.com")
+		self.assertTrue(captured["url"].endswith("billing.reconnect.redeem_reconnect_code"))
+		self.assertEqual(captured["json"]["code"], "ABCD2345")
+		self.assertEqual(captured["json"]["email"], "e@x.com")
 
 
 class TestPostUpdateLlmCredsAuthMode(FrappeTestCase):

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1978,6 +1978,80 @@ class TestAccountReconnect(FrappeTestCase):
 			out = onboarding.check_account_reconnect("rid-x")
 		self.assertEqual(out["status"], "expired")
 
+	# ---- operator-issued code path (redeem_reconnect_code) -------------------
+	def test_redeem_forwards_code_and_email_and_lands_connected(self):
+		"""The request-less path: forward exactly (code, email) to admin and land
+		the returned ready bundle the same way check_account_reconnect does."""
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.redeem_reconnect_code",
+			return_value={
+				"status": "ready",
+				"api_key": "rk-key",
+				"api_secret": "rk-secret",
+				"customer": "someone@example.com",
+				"customer_password": "rk-pass",
+			},
+		) as redeem:
+			out = onboarding.redeem_reconnect_code("ABCD2345", "someone@example.com")
+		# email is the second factor - it MUST reach admin (never dropped).
+		redeem.assert_called_once_with("ABCD2345", "someone@example.com")
+		self.assertEqual(out["status"], "connected")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False), "rk-key")
+		self.assertEqual(s.jarvis_admin_customer_email, "someone@example.com")
+
+	def test_redeem_invalid_writes_nothing(self):
+		"""A generic invalid (wrong/expired code, or email mismatch) persists no
+		credentials and is surfaced verbatim for the wizard to render."""
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.redeem_reconnect_code",
+			return_value={"status": "invalid"},
+		):
+			out = onboarding.redeem_reconnect_code("WRONGCODE", "someone@example.com")
+		self.assertEqual(out["status"], "invalid")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	def test_redeem_pending_payment_routes_to_resume(self):
+		"""Same admin-v2 #162 branch as the emailed path: an unfinished checkout has
+		no container, so the wizard goes back to Pay, not sync_connection."""
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.redeem_reconnect_code",
+			return_value={
+				"status": "ready",
+				"api_key": "pp-key",
+				"api_secret": "pp-secret",
+				"customer": "cust-xyz@jarvis.invalid",
+				"customer_password": "pp-pass",
+				"subscription_status": "Pending Payment",
+			},
+		):
+			out = onboarding.redeem_reconnect_code("ABCD2345", "x@y.example")
+		self.assertEqual(out["status"], "resume_payment")
+
+	def test_both_paths_share_the_same_landing(self):
+		"""The emailed poll and the operator-code redeem MUST land identically -
+		both delegate to _land_reconnect. Inlining either path's landing (so the two
+		could drift in what a reconnected site ends up holding) breaks this."""
+		ready = {
+			"status": "ready",
+			"api_key": "s-key",
+			"api_secret": "s-secret",
+			"customer": "shared@example.com",
+			"customer_password": "s-pass",
+		}
+		with patch("jarvis.onboarding._land_reconnect", return_value={"status": "connected"}) as land:
+			with patch("jarvis.onboarding.admin_client.get_reconnect_state", return_value=dict(ready)):
+				onboarding.check_account_reconnect("rid-1", "ABCD2345")
+			with patch("jarvis.onboarding.admin_client.redeem_reconnect_code", return_value=dict(ready)):
+				onboarding.redeem_reconnect_code("ABCD2345", "shared@example.com")
+		self.assertEqual(land.call_count, 2)
+		for call in land.call_args_list:
+			self.assertEqual(call.args[0].get("api_key"), "s-key")
+
 
 class TestCredentialChangeBustsTheTokenCache(FrappeTestCase):
 	"""A cached bearer outlives the credentials it was minted from. Reconnecting a


### PR DESCRIPTION
## What

The bench half of the one-step operator reconnect (control plane: Aerele-RnD/jarvis-admin-v2#332). Adds the **"I have a code from support"** onboarding path: the customer redeems an operator-issued code with their registered email directly, without first starting a customer-initiated email reconnect request.

## Changes

- **`admin_client.redeem_reconnect_code(code, email)`** — guest POST forwarding `(code, email)` with a **server-derived** `frappe_site_url` via `_public_origin()` (the customer can't spoof a target site).
- **`onboarding.py`** — factor a shared **`_land_reconnect(data)`** used by BOTH the emailed poll (`check_account_reconnect`) and the new `redeem_reconnect_code` endpoint, so a reconnected site lands identically either way (`tenant_authority.clear` → `write_connection` → `grant_onboarding_admin` → connected/resume_payment). New endpoint is `require_jarvis_admin`.
- **`OnboardingView.vue`** — `reconnectDirect` mode: a registered-email 2nd-factor field, direct-mode copy/note, **Resend hidden**, Finish disabled until both filled; reachable from Details **and** the code screen; the flag is reset in `startReconnect`/`cancelReconnect` so it can't leak into a later emailed reconnect. Direct-mode invalid copy is "code or email didn't match" (no "confirmation page").
- `api.js redeemReconnectCode(code, email)`.

## Review + verification

- Adversarial multi-lane review — all GREEN.
- Backend 105 (`test_onboarding_sync`) + 101 (`test_admin_client`); frontend 106 (`OnboardingView` specs). Killing mutations verified (email 2nd-factor forwarding, shared `_land_reconnect`, direct-vs-request branch).
- Live browser flow verified end-to-end: Details → "Enter it here" → code + registered email → **lands connected** (skips Pay, existing AI account intact); wrong-email/expired-code → generic invalid, no rotation.

Deploy note: ships with the control-plane PR; rebuild both SPAs on deploy.