### PR TITLE
fix: apply a connect-step re-save once, not twice

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -90,6 +90,7 @@
   "chat_device_token",
   "last_sync_section",
   "last_sync_requested_at",
+  "llm_last_apply_fingerprint",
   "last_sync_at",
   "last_sync_status",
   "llm_pool_synced_at",
@@ -676,6 +677,13 @@
    "fieldname": "last_sync_requested_at",
    "fieldtype": "Datetime",
    "label": "Last Sync Requested At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "llm_last_apply_fingerprint",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "LLM Last Apply Fingerprint",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1243,6 +1243,13 @@ class JarvisSettings(Document):
 			{
 				"last_sync_status": "pending: provisioning container (pool)",
 				"last_sync_requested_at": frappe.utils.now(),
+				# The jarvis#841 dedup stamp names a DIRECT-leg apply; a pool
+				# excursion refreshes this timestamp and later lands an "ok"
+				# without going through the classifier, so a stale stamp left
+				# here could absorb a direct re-save after the pool teardown
+				# even though /llm-pool never pushed the direct blob. Cleared,
+				# same as the disconnect/reset writers.
+				"llm_last_apply_fingerprint": "",
 			},
 		)
 		run_inline = bool(frappe.flags.in_test or frappe.flags.run_admin_sync_inline)

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1166,7 +1166,15 @@ class JarvisSettings(Document):
 		window is deliberately the SPA's 300s subscription readiness budget
 		(onboarding.save_llm_pool), not the 600s job budget: when the wizard's
 		poll exhausts and the customer retries, the re-save must fire a REAL
-		apply even where the */5 reconcile cannot help (paused scheduler)."""
+		apply even where the */5 reconcile cannot help (paused scheduler).
+
+		Accepted residual (#846 review): a container rebuilt OUT-OF-BAND
+		(image roll, host move) inside the ok-window can absorb one identical
+		re-save, because nothing bench-side witnessed the rebuild. Bounded by
+		the 600s window, and rebuild flows that go through admin re-gate
+		readiness (authority generation / chat_readiness), which is what the
+		customer-facing surfaces key on - so the skip window closes on its
+		own rather than stranding the tenant."""
 		fingerprint = self._llm_apply_fingerprint(self.flags.get("pool_state_snapshot"))
 		if not fingerprint or fingerprint != (self.get("llm_last_apply_fingerprint") or ""):
 			return False
@@ -1929,6 +1937,12 @@ def _stamp_pool_applied_ok(settings, result: dict) -> bool:
 		"last_sync_at": _frappe.utils.now(),
 		"last_sync_status": f"ok ({resolved_action} via admin)",
 		"llm_pool_synced_at": _frappe.utils.now(),
+		# The jarvis#841 dedup stamp names a DIRECT-leg apply; this "ok" is a
+		# POOL apply, so any stamp left standing next to it is stale by
+		# definition. Belt-and-braces with the _enqueue_pool_sync clear: the
+		# synchronous sync_pool_now path suppresses that enqueue, so this is
+		# the only clear that covers it (#846 review).
+		"llm_last_apply_fingerprint": "",
 	}
 	if not result.get("unchanged"):
 		_synced["last_subscription_status"] = str(result.get("subscription_status") or "")

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -66,6 +66,15 @@ _CONTAINER_OWNED_MODES = {"oauth", "subscription"}
 ADMIN_SYNC_RQ_TIMEOUT_S = 600
 ADMIN_SYNC_LOCK_TIMEOUT_S = ADMIN_SYNC_RQ_TIMEOUT_S
 
+# jarvis#841: how long a "pending:" single-model apply may absorb a
+# byte-identical re-save (_identical_apply_already_underway). Deliberately the
+# SPA's subscription readiness budget (onboarding.save_llm_pool's
+# readiness_budget_s), NOT the 600s job budget: when the wizard's poll exhausts
+# and the customer retries, that re-save must fire a real apply even where the
+# */5 reconcile cannot heal a dead worker (paused scheduler). The confirmed-"ok"
+# case uses ADMIN_SYNC_RQ_TIMEOUT_S instead.
+_IDENTICAL_APPLY_PENDING_WINDOW_S = 300
+
 # Lock-acquisition waits for the sync workers. A dead (SIGKILLed/OOMed)
 # holder blocks the lock for up to the full TTL (600s) - nothing releases
 # the key early in that case - so the retry chain's CUMULATIVE wait must
@@ -1129,6 +1138,49 @@ class JarvisSettings(Document):
 			tuple(rows),
 		)
 
+	@staticmethod
+	def _llm_apply_fingerprint(snapshot) -> str:
+		"""Digest of a ``_pool_state_snapshot`` tuple, or "" when there is none
+		to digest (a save path that skipped validate must never dedup). The
+		snapshot already sha256-digests every row secret, so the stored value
+		never contains credential material (at worst it is an equality oracle
+		for a full guessed config, whose secrets are high-entropy). repr() of a
+		tuple of primitives is deterministic, which is all the equality check
+		needs."""
+		import hashlib
+
+		if snapshot is None:
+			return ""
+		return hashlib.sha256(repr(snapshot).encode("utf-8")).hexdigest()
+
+	def _identical_apply_already_underway(self) -> bool:
+		"""True iff the config being saved is byte-identical to the last
+		ENQUEUED single-model apply (jarvis#841) and that apply is still good:
+		confirmed "ok" recently, or "pending" inside the wizard's own readiness
+		budget. The single-model twin of ``_pool_sync_is_redundant``, except the
+		before-doc's masks make a snapshot comparison useless here - hence the
+		fingerprint stamped at enqueue time (``_on_update_single_model_legacy``).
+
+		A "failed:" status never skips: an identical re-save after a failed
+		apply is the customer's retry lever (the F5 rule below). The "pending"
+		window is deliberately the SPA's 300s subscription readiness budget
+		(onboarding.save_llm_pool), not the 600s job budget: when the wizard's
+		poll exhausts and the customer retries, the re-save must fire a REAL
+		apply even where the */5 reconcile cannot help (paused scheduler)."""
+		fingerprint = self._llm_apply_fingerprint(self.flags.get("pool_state_snapshot"))
+		if not fingerprint or fingerprint != (self.get("llm_last_apply_fingerprint") or ""):
+			return False
+		requested_at = self.get("last_sync_requested_at")
+		if not requested_at:
+			return False
+		age_s = frappe.utils.time_diff_in_seconds(frappe.utils.now(), requested_at)
+		status = self.get("last_sync_status") or ""
+		if status.startswith("ok"):
+			return age_s <= ADMIN_SYNC_RQ_TIMEOUT_S
+		if status.startswith("pending"):
+			return age_s <= _IDENTICAL_APPLY_PENDING_WINDOW_S
+		return False
+
 	def _pool_sync_is_redundant(self) -> bool:
 		"""True iff this save changes nothing the pool push would transmit
 		AND the container is already in a known-good state.
@@ -1236,8 +1288,22 @@ class JarvisSettings(Document):
 		# last_sync_requested_at (jarvis C2): same enqueue-time stamp as the pool
 		# leg above - see that comment for why, and account._APPLYING_SOFT_WINDOW_S
 		# for how it is consumed.
+		#
+		# llm_last_apply_fingerprint (jarvis#841): what this enqueue is applying,
+		# stamped HERE rather than at convergence so it has one writer (the save
+		# path) instead of joining _stamp_converged_ok's five racing callers. The
+		# worker re-reads the doc at run time, and commit order equals stamp
+		# order, so the field always names the config the container will end up
+		# holding. _identical_apply_already_underway is the sole reader.
 		_write_settings_fields(
-			self, {"last_sync_status": pending_label, "last_sync_requested_at": frappe.utils.now()}
+			self,
+			{
+				"last_sync_status": pending_label,
+				"last_sync_requested_at": frappe.utils.now(),
+				"llm_last_apply_fingerprint": self._llm_apply_fingerprint(
+					self.flags.get("pool_state_snapshot")
+				),
+			},
 		)
 		# In tests, run inline so existing assertions on the final status
 		# don't have to poll. Set ``frappe.flags.run_admin_sync_inline``
@@ -1651,6 +1717,18 @@ class JarvisSettings(Document):
 		if old is not None and (self.llm_auth_mode or "") == "subscription":
 			current_snap = self.flags.get("pool_state_snapshot")
 			if current_snap is not None and current_snap != self._pool_state_snapshot(old):
+				# jarvis#841: this comparison cannot see that a RE-SAVE is
+				# byte-identical - the before-doc's row secrets are '*'-masks
+				# while the submitted ones are plaintext - so the wizard's
+				# Start-chatting save re-applied the exact config the sign-in
+				# step's save had just applied, bouncing the container a second
+				# time underneath the customer's first chat message. Recognise
+				# that one case by fingerprint against the last ENQUEUED apply
+				# instead. A genuinely refreshed token changes the blob and so
+				# the fingerprint, which keeps the jarvis#755 re-auth restart;
+				# force_admin_sync / llm_auth_mode_changed returned above.
+				if self._identical_apply_already_underway():
+					return None
 				return "restart"
 
 		if old is None:

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -994,6 +994,10 @@ def disconnect() -> dict:
 	settings = frappe.get_single("Jarvis Settings")
 	settings.db_set("llm_auth_mode", "api_key", update_modified=False)
 	settings.db_set("last_sync_status", "disconnected", update_modified=False)
+	# Inert today ("disconnected" matches neither prefix the jarvis#841 dedup
+	# gate accepts) but cleared like every other non-direct status writer, so a
+	# future status rewording can never re-arm a stale stamp (#846 review).
+	settings.db_set("llm_last_apply_fingerprint", "", update_modified=False)
 	settings.db_set("llm_oauth_account_email", "", update_modified=False)
 	settings.db_set("llm_oauth_connected_at", None, update_modified=False)
 	# DON'T wipe _CACHE_KEY here. The previous shape called

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -756,6 +756,8 @@ _DISCONNECTED_LLM_FIELDS = {
 	# recognise it, which is correct here: the editor's status strip hides itself
 	# rather than reporting on an apply that no longer has a subject.
 	"last_sync_status": "disconnected",
+	# The apply this stamp described no longer has a subject either (jarvis#841).
+	"llm_last_apply_fingerprint": "",
 	"last_subscription_status": "",
 	"last_sync_warnings": "[]",
 	"last_model_statuses": "[]",
@@ -1881,6 +1883,10 @@ def _disconnect_agent_transport(settings, reconnect_llm: bool = False) -> None:
 	settings.db_set(
 		"last_sync_status", _RESETTING_RECONNECT_LLM_STATUS if reconnect_llm else _RESETTING_STATUS
 	)
+	# The container this stamp described is being torn down; left set, an
+	# identical re-save inside its window could dedup against a rebuilt
+	# container that never received the config (jarvis#841 review).
+	settings.db_set("llm_last_apply_fingerprint", "")
 	_bust_chat_gate()
 	frappe.db.commit()
 
@@ -1925,6 +1931,10 @@ def _workspace_reset_poll() -> dict:
 
 		write_connection(data)
 		settings.db_set("last_sync_status", "ok (workspace reset)")
+		# This "ok" is about the RESET, not about any config apply - the fresh
+		# container holds no direct-leg credential yet. Keep the jarvis#841
+		# dedup stamp cleared so the next save always applies for real.
+		settings.db_set("llm_last_apply_fingerprint", "")
 		_bust_chat_gate()
 		frappe.db.commit()
 	elif _resetting() and data.get("agent_url") and not (settings.get("agent_url") or ""):

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -65,6 +65,10 @@ CONNECTION = ResetSpec(
 		"chat_device_public_key",
 		# Per-push statuses that otherwise read as "already sent" on a fresh site
 		"last_sync_status",
+		# The jarvis#841 dedup stamp names a config the PREVIOUS tenancy's
+		# container held; left set, it could absorb the fresh tenancy's first
+		# identical save inside its window.
+		"llm_last_apply_fingerprint",
 		"last_sync_warnings",
 		"installed_apps_synced",
 		"custom_skills_sync_status",

--- a/jarvis/tests/test_connect_double_apply.py
+++ b/jarvis/tests/test_connect_double_apply.py
@@ -196,6 +196,23 @@ class TestConnectDoubleApplyDedup(_RT3SettingsTestCase):
 		connect3, _ = self._save(_lone_subscription_models())
 		connect3.assert_called_once()
 
+	def test_every_non_direct_writer_clears_the_stamp(self):
+		"""The stamp only ever describes the last DIRECT-leg enqueue. Every
+		other writer that refreshes last_sync_* without going through the
+		classifier (pool enqueue, disconnect blanks, tenancy reset spec) must
+		clear it, or a stale stamp could absorb a later repair save against a
+		container that never received the config (jarvis#841 review)."""
+		from jarvis import settings_reset
+		from jarvis.onboarding import _DISCONNECTED_LLM_FIELDS
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("llm_last_apply_fingerprint", "f" * 64, update_modified=False)
+		with patch("frappe.enqueue"):
+			s._enqueue_pool_sync()
+		self.assertEqual(s.get("llm_last_apply_fingerprint"), "")
+		self.assertIn("llm_last_apply_fingerprint", settings_reset.CONNECTION.blank)
+		self.assertEqual(_DISCONNECTED_LLM_FIELDS.get("llm_last_apply_fingerprint"), "")
+
 	def test_forced_sync_still_restarts_through_an_identical_resave(self):
 		"""flags.force_admin_sync (the explicit resync lever) still applies after
 		a recent identical apply. (On this loaded-doc save the masked snapshot

--- a/jarvis/tests/test_connect_double_apply.py
+++ b/jarvis/tests/test_connect_double_apply.py
@@ -205,10 +205,19 @@ class TestConnectDoubleApplyDedup(_RT3SettingsTestCase):
 		from jarvis import settings_reset
 		from jarvis.onboarding import _DISCONNECTED_LLM_FIELDS
 
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+			_stamp_pool_applied_ok,
+		)
+
 		s = frappe.get_single("Jarvis Settings")
 		s.db_set("llm_last_apply_fingerprint", "f" * 64, update_modified=False)
 		with patch("frappe.enqueue"):
 			s._enqueue_pool_sync()
+		self.assertEqual(s.get("llm_last_apply_fingerprint"), "")
+		# The synchronous pool push (sync_pool_now) suppresses that enqueue, so
+		# its confirmed-apply stamp must clear the stamp itself (#846 review).
+		s.db_set("llm_last_apply_fingerprint", "f" * 64, update_modified=False)
+		self.assertTrue(_stamp_pool_applied_ok(s, {"action": "pool_update"}))
 		self.assertEqual(s.get("llm_last_apply_fingerprint"), "")
 		self.assertIn("llm_last_apply_fingerprint", settings_reset.CONNECTION.blank)
 		self.assertEqual(_DISCONNECTED_LLM_FIELDS.get("llm_last_apply_fingerprint"), "")

--- a/jarvis/tests/test_connect_double_apply.py
+++ b/jarvis/tests/test_connect_double_apply.py
@@ -1,0 +1,215 @@
+"""jarvis#841: the connect step's two byte-identical saves must apply ONCE.
+
+On the onboarding connect step the sign-in step's save (the Test press's
+save_llm_pool) applies the config and restarts the container; "Start chatting"
+then re-posts the identical payload. _classify_llm_change's subscription branch
+compares the plaintext pool_state_snapshot against the before-doc, whose row
+secrets are '*'-masks, so the identical re-save always read as a change and
+bounced the container a second time - underneath the customer's first chat
+message.
+
+The fix stamps a fingerprint of the enqueued config at enqueue time
+(_on_update_single_model_legacy) and classifies an identical re-save as None
+while that apply is recent-"ok" (600s) or still "pending" inside the SPA's own
+300s readiness budget (_identical_apply_already_underway). These tests drive
+the REAL save path twice, exactly as the wizard does - including the
+consumed-capture -> stored-blob fallback that makes save #2's payload
+byte-identical - and pin what must still restart: a refreshed token
+(jarvis#755), a failed prior apply (the F5 retry lever), and a stale window.
+"""
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.utils import add_to_date, now_datetime
+
+from jarvis import onboarding
+from jarvis.oauth import pending_capture as pc
+from jarvis.tests.test_settings_on_update import _reset_settings
+from jarvis.tests.test_unified_llm_config import _RT3SettingsTestCase
+
+CAP_DT = "Jarvis Pending OAuth Capture"
+
+_BLOB = '{"provider":"openai","refresh_token":"fake-rt-841"}'
+_BLOB_RECONNECTED = '{"provider":"openai","refresh_token":"fake-rt-841-RECONNECTED"}'
+
+
+def _lone_subscription_models(blob=_BLOB, capture_id=""):
+	"""One renderable openai subscription - the jarvis#715 direct leg. The
+	account cites EITHER an inline blob (test shorthand) or a capture_id (what
+	the wizard really posts; the blob then stays server-side)."""
+	account = {
+		"upstream": "openai",
+		"account_ref": "SUB_841_ref1",
+		"label": "me@example.com",
+	}
+	if capture_id:
+		account["capture_id"] = capture_id
+	else:
+		account["oauth_blob"] = blob
+	return [
+		{
+			"provider": "openai",
+			"model": "gpt-5.5",
+			"tier": "strong",
+			"order": 0,
+			"subscription": {"rotation": "sticky", "accounts": [account]},
+		}
+	]
+
+
+class TestConnectDoubleApplyDedup(_RT3SettingsTestCase):
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		_reset_settings()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("preset", "", update_modified=False)
+		s.db_set("routing_mode", "failover", update_modified=False)
+		s.db_set("proxy_active", 0, update_modified=False)
+		# Fresh-connect workspace: jarvis#715's non-retroactivity gate keys the
+		# direct leg off these markers (shared, DB-polluting site).
+		s.db_set("llm_pool_synced_at", None, update_modified=False)
+		s.db_set("llm_direct_synced_at", None, update_modified=False)
+		s.db_set("last_sync_status", "", update_modified=False)
+		s.db_set("last_sync_requested_at", None, update_modified=False)
+		s.db_set("llm_last_apply_fingerprint", "", update_modified=False)
+		frappe.db.commit()
+
+	def tearDown(self):
+		for name in frappe.get_all(CAP_DT, pluck="name"):
+			frappe.delete_doc(CAP_DT, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _capture(self):
+		return pc.create_capture(
+			provider="OpenAI",
+			upstream="openai",
+			agent_provider="openai",
+			oauth_blob=_BLOB,
+			account_email="me@example.com",
+			account_ref="SUB_841_ref1",
+			safe_label="me@example.com",
+			provider_subject="acct-841",
+		)
+
+	def _save(self, models, connect_result=None):
+		"""Drive the real save; return (connect_mock, save_result)."""
+		with patch(
+			"jarvis.admin_client.post_subscription_connect",
+			return_value=connect_result or {"action": "restart", "status": "applied"},
+		) as connect:
+			out = onboarding.save_llm_pool(frappe.as_json(models), preset=None, routing_mode="failover")
+		return connect, out
+
+	# -- the jarvis#841 wizard sequence itself --------------------------------
+
+	def test_start_chatting_resave_after_confirmed_signin_apply_is_a_noop(self):
+		"""The exact wizard sequence: save #1 cites a capture and applies; save
+		#2 re-posts the same payload (capture now consumed, so the stored blob
+		is merged back) and must NOT reach admin again."""
+		view = self._capture()
+		connect1, _ = self._save(_lone_subscription_models(capture_id=view["capture_id"]))
+		connect1.assert_called_once()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue((s.last_sync_status or "").startswith("ok"))
+		self.assertTrue(s.llm_direct_synced_at)
+		fingerprint = s.get("llm_last_apply_fingerprint") or ""
+		self.assertEqual(len(fingerprint), 64, "enqueue must stamp the apply fingerprint")
+
+		connect2, out2 = self._save(_lone_subscription_models(capture_id=view["capture_id"]))
+		connect2.assert_not_called()
+		self.assertEqual(out2["mode"], "legacy")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue(
+			(s.last_sync_status or "").startswith("ok"),
+			"a skipped re-save must not overwrite the confirmed status with pending:",
+		)
+		self.assertEqual(s.get("llm_last_apply_fingerprint"), fingerprint)
+		# The blob itself survived the fallback merge (byte-identity's substrate).
+		accounts = json.loads(s.models[0].get_password("subscription_accounts"))
+		self.assertEqual(json.loads(accounts[0]["oauth_blob"])["refresh_token"], "fake-rt-841")
+
+	def test_resave_while_the_first_apply_is_still_pending_is_a_noop(self):
+		"""The fast clicker: "Start chatting" lands while the sign-in apply is
+		still converging. The identical re-save must follow the in-flight apply,
+		not enqueue a second one."""
+		with patch(
+			"jarvis.admin_client.get_connection",
+			return_value={"chat_readiness": "Configuring", "chat_readiness_reason": ""},
+		):
+			connect1, _ = self._save(
+				_lone_subscription_models(),
+				connect_result={"action": "restart", "status": "applying"},
+			)
+		connect1.assert_called_once()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertTrue((s.last_sync_status or "").startswith("pending"))
+
+		connect2, _ = self._save(_lone_subscription_models())
+		connect2.assert_not_called()
+
+	# -- what must STILL restart ----------------------------------------------
+
+	def test_refreshed_token_still_restarts(self):
+		"""jarvis#755: a re-save carrying a genuinely refreshed blob changes the
+		fingerprint and must re-apply, recent ok or not."""
+		connect1, _ = self._save(_lone_subscription_models())
+		connect1.assert_called_once()
+		connect2, _ = self._save(_lone_subscription_models(blob=_BLOB_RECONNECTED))
+		connect2.assert_called_once()
+
+	def test_identical_resave_after_a_failed_apply_still_restarts(self):
+		"""The F5 retry lever: a failed apply is retried by re-saving, and the
+		fingerprint gate must never absorb that."""
+		connect1, _ = self._save(_lone_subscription_models())
+		connect1.assert_called_once()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "failed: admin unreachable: x", update_modified=False)
+		connect2, _ = self._save(_lone_subscription_models())
+		connect2.assert_called_once()
+
+	def test_identical_resave_outside_the_windows_still_restarts(self):
+		"""A stale stamp never dedups: past 600s for a confirmed "ok", past 300s
+		for a "pending" (the SPA's readiness budget - its post-exhaustion Retry
+		must fire a real apply even with the scheduler paused)."""
+		connect1, _ = self._save(_lone_subscription_models())
+		connect1.assert_called_once()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set(
+			"last_sync_requested_at",
+			add_to_date(now_datetime(), seconds=-601),
+			update_modified=False,
+		)
+		connect2, _ = self._save(_lone_subscription_models())
+		connect2.assert_called_once()
+
+		# Same, on the pending window: 301s-old pending is past its budget.
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "pending: provisioning container", update_modified=False)
+		s.db_set(
+			"last_sync_requested_at",
+			add_to_date(now_datetime(), seconds=-301),
+			update_modified=False,
+		)
+		connect3, _ = self._save(_lone_subscription_models())
+		connect3.assert_called_once()
+
+	def test_forced_sync_still_restarts_through_an_identical_resave(self):
+		"""flags.force_admin_sync (the explicit resync lever) still applies after
+		a recent identical apply. (On this loaded-doc save the masked snapshot
+		compares equal anyway, so the flag's own "restart" is what fires; the
+		point pinned is the observable one - a forced resync always reaches
+		admin, fingerprint stamp or not.)"""
+		connect1, _ = self._save(_lone_subscription_models())
+		connect1.assert_called_once()
+		with patch(
+			"jarvis.admin_client.post_subscription_connect",
+			return_value={"action": "restart", "status": "applied"},
+		) as connect2:
+			s = frappe.get_single("Jarvis Settings")
+			s.flags.force_admin_sync = True
+			# Re-trigger on_update the way a forced save path does.
+			s.save(ignore_permissions=True)
+		connect2.assert_called_once()

--- a/jarvis/tests/test_connect_double_apply.py
+++ b/jarvis/tests/test_connect_double_apply.py
@@ -203,11 +203,10 @@ class TestConnectDoubleApplyDedup(_RT3SettingsTestCase):
 		clear it, or a stale stamp could absorb a later repair save against a
 		container that never received the config (jarvis#841 review)."""
 		from jarvis import settings_reset
-		from jarvis.onboarding import _DISCONNECTED_LLM_FIELDS
-
 		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
 			_stamp_pool_applied_ok,
 		)
+		from jarvis.onboarding import _DISCONNECTED_LLM_FIELDS
 
 		s = frappe.get_single("Jarvis Settings")
 		s.db_set("llm_last_apply_fingerprint", "f" * 64, update_modified=False)

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -37,6 +37,9 @@ _SNAPSHOT_PLAIN_FIELDS = (
 	"chat_was_ready_at",
 	"chat_ready_authority",
 	"last_sync_requested_at",
+	# The jarvis#841 dedup stamp: restored so a class's test-config fingerprint
+	# never lingers on the shared site.
+	"llm_last_apply_fingerprint",
 )
 
 # Password fields the tests overwrite. Snapshotted via get_password() because


### PR DESCRIPTION
Fixes #841

## Summary

Connecting a chat subscription during onboarding now restarts the customer's container once, not twice: the "Start chatting" save recognises it is re-posting the exact config the sign-in step's save (the Test press) just applied, and skips the second apply instead of running it underneath the customer's first chat message.

## What changed

- Jarvis Settings stamps a fingerprint (a hash of the config; secrets are pre-digested) each time a single-model apply is enqueued. A byte-identical subscription re-save is a no-op while that apply is recently confirmed (600s) or still in flight (300s, the wizard's own readiness poll budget).
- A failed apply never dedups, so re-saving stays the customer's retry lever; a genuinely refreshed token changes the fingerprint and still restarts (the #755 decision is untouched); every disconnect/reset path clears the stamp.
- Behavior change: a repeat Test press on the direct subscription leg no longer bounces the container when nothing changed and the last apply is recent and confirmed.

## Risk and verification

- New tests drive the real double-save sequence, including the consumed-capture fallback that makes the payloads identical; disconnect, workspace-reset, classify and pool-gate suites are green; a live two-save run on the local bench produced exactly one apply with the SPA contract unchanged.
- The full from-scratch onboarding e2e (real ChatGPT sign-in) is scheduled as the post-merge live verification.

<details><summary>Root cause detail</summary>

The subscription branch of the change classifier compares a plaintext snapshot of the submitted config against the doc as loaded from the DB, whose row secrets are `*`-masks. An identical re-save therefore always reads as changed, and jarvis#755 deliberately classifies a subscription change as restart-worthy (a refreshed token must reach the container). Fleet's no-op probe cannot help either: doctor rewrites the blob file post-migration (accepted in fleet#224 review). The fix compares against a fingerprint of the last enqueued apply instead, stamped in the same guarded write as the pending status so it has a single writer and never joins the five-caller convergence-stamp race (admin-v2#330 territory). The 300s pending window matches the SPA's subscription readiness budget so a post-exhaustion Retry always lands outside it and fires a real apply, which matters because the reconcile cron never re-enqueues a sync.

Observed live 2026-08-14: two `subscription-connect` applies 17s apart; the second ran underneath the first chat message, which sat "Queued" until it finished. The first save is the onboarding Test press (in footerless onboarding the editor does not save at sign-in completion), the second is "Start chatting".

</details>

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (cut from upstream/develop today)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

