### PR TITLE
feat: reset-onboarding button in Jarvis Settings

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -80,6 +80,10 @@ export const requestWorkspaceReset = (reason, opts = {}) =>
 		revoke_llm: opts.revokeLlm ? 1 : 0,
 	});
 export const workspaceResetState = () => call("jarvis.onboarding.workspace_reset_state");
+// Reset onboarding: clears connection + creds and (wipeData, the CLI default)
+// all workspace content, so the setup wizard re-runs. No container rebuild.
+export const resetOnboarding = (wipeData = true) =>
+	call("jarvis.onboarding.reset_onboarding", { wipe_data: wipeData ? 1 : 0 });
 
 // --- Per-user chat settings + real (measured) usage tracking, incl. the
 // tenant-admin usage table (design doc §4/§6). All return the house

--- a/frontend/src/components/settings/GeneralPane.spec.js
+++ b/frontend/src/components/settings/GeneralPane.spec.js
@@ -63,8 +63,10 @@ vi.mock("@/stores/shell", () => ({
 	}),
 }));
 
+// Shared so the Reset-onboarding tests can drive the danger confirm's answer.
+const { confirmMock } = vi.hoisted(() => ({ confirmMock: vi.fn() }));
 vi.mock("@/composables/useConfirm", () => ({
-	useConfirm: () => ({ confirm: vi.fn() }),
+	useConfirm: () => ({ confirm: confirmMock }),
 }));
 
 // Every network call the pane makes on mount. getUsage / getMySettings /
@@ -75,6 +77,7 @@ vi.mock("@/api", () => ({
 	getMySettings: vi.fn(() => Promise.resolve({ ok: false })),
 	workspaceResetState: vi.fn(() => Promise.resolve({})),
 	requestWorkspaceReset: vi.fn(() => Promise.resolve({})),
+	resetOnboarding: vi.fn(() => Promise.resolve({ ok: true })),
 	clearAllHistory: vi.fn(() => Promise.resolve({})),
 	getLlmConnectionStatus: vi.fn(() => new Promise(() => {})),
 	getLlmConnectionHealth: vi.fn(() => new Promise(() => {})),
@@ -95,9 +98,9 @@ function buttonLabels(w) {
 	return w.findAll(".stub-button").map((b) => b.attributes("data-label") || "");
 }
 
-async function mountAs({ admin }) {
+async function mountAs({ admin, jarvisAdmin = false }) {
 	window.is_system_manager = admin;
-	window.is_jarvis_admin = false;
+	window.is_jarvis_admin = jarvisAdmin;
 	const w = mount(GeneralPane);
 	await flushPromises();
 	return w;
@@ -281,5 +284,60 @@ describe("GeneralPane Status badge, admin seat", () => {
 		);
 		const w = await mountAs({ admin: true });
 		expect(badge(w)).toEqual({ label: "Disconnected", theme: "orange" });
+	});
+});
+
+describe("GeneralPane Reset onboarding button", () => {
+	function resetBtn(w) {
+		return w
+			.findAll(".stub-button")
+			.find((b) => b.attributes("data-label") === "Reset onboarding");
+	}
+
+	beforeEach(() => {
+		confirmMock.mockReset();
+		api.resetOnboarding.mockReset();
+		api.resetOnboarding.mockImplementation(() => Promise.resolve({ ok: true }));
+	});
+
+	it("is offered to an admin and hidden from a member", async () => {
+		const wAdmin = await mountAs({ admin: true });
+		expect(buttonLabels(wAdmin)).toContain("Reset onboarding");
+		const wMember = await mountAs({ admin: false });
+		expect(buttonLabels(wMember)).not.toContain("Reset onboarding");
+	});
+
+	// The backend (dev.reset_onboarding) is only_for("System Manager"), stricter
+	// than the sibling Reset workspace. A Jarvis-Admin-only seat (is_jarvis_admin
+	// but not is_system_manager) must NOT see this button, or it 403s as a dead
+	// control. It still sees the rest of the danger zone (gated on isSM).
+	it("is hidden from a Jarvis-Admin-only seat that the backend would reject", async () => {
+		const w = await mountAs({ admin: false, jarvisAdmin: true });
+		expect(buttonLabels(w)).not.toContain("Reset onboarding");
+		// The danger zone itself renders for this seat — only this stricter button is gone.
+		expect(buttonLabels(w)).toContain("Reset workspace");
+	});
+
+	it("does nothing when the danger confirm is dismissed", async () => {
+		confirmMock.mockResolvedValue(false);
+		const w = await mountAs({ admin: true });
+		await resetBtn(w).trigger("click");
+		await flushPromises();
+		expect(confirmMock).toHaveBeenCalledTimes(1);
+		expect(api.resetOnboarding).not.toHaveBeenCalled();
+	});
+
+	it("full-wipes only after the confirm is accepted", async () => {
+		confirmMock.mockResolvedValue(true);
+		const w = await mountAs({ admin: true });
+		await resetBtn(w).trigger("click");
+		await flushPromises();
+		// The danger confirm must have been the gate, and the call is the
+		// CLI-matching full reset (wipe_data=true), not connection-only.
+		expect(confirmMock).toHaveBeenCalledTimes(1);
+		expect(confirmMock.mock.calls[0][0]).toMatchObject({ danger: true });
+		expect(api.resetOnboarding).toHaveBeenCalledWith(true);
+		// The success reload to /jarvis/onboarding is exercised in the browser
+		// flow review — jsdom makes window.location.assign non-stubbable.
 	});
 });

--- a/frontend/src/components/settings/GeneralPane.spec.js
+++ b/frontend/src/components/settings/GeneralPane.spec.js
@@ -291,7 +291,7 @@ describe("GeneralPane Reset onboarding button", () => {
 	function resetBtn(w) {
 		return w
 			.findAll(".stub-button")
-			.find((b) => b.attributes("data-label") === "Reset onboarding");
+			.find((b) => b.attributes("data-label") === "Reset to onboarding");
 	}
 
 	beforeEach(() => {
@@ -302,9 +302,9 @@ describe("GeneralPane Reset onboarding button", () => {
 
 	it("is offered to an admin and hidden from a member", async () => {
 		const wAdmin = await mountAs({ admin: true });
-		expect(buttonLabels(wAdmin)).toContain("Reset onboarding");
+		expect(buttonLabels(wAdmin)).toContain("Reset to onboarding");
 		const wMember = await mountAs({ admin: false });
-		expect(buttonLabels(wMember)).not.toContain("Reset onboarding");
+		expect(buttonLabels(wMember)).not.toContain("Reset to onboarding");
 	});
 
 	// The backend (dev.reset_onboarding) is only_for("System Manager"), stricter
@@ -313,7 +313,7 @@ describe("GeneralPane Reset onboarding button", () => {
 	// control. It still sees the rest of the danger zone (gated on isSM).
 	it("is hidden from a Jarvis-Admin-only seat that the backend would reject", async () => {
 		const w = await mountAs({ admin: false, jarvisAdmin: true });
-		expect(buttonLabels(w)).not.toContain("Reset onboarding");
+		expect(buttonLabels(w)).not.toContain("Reset to onboarding");
 		// The danger zone itself renders for this seat — only this stricter button is gone.
 		expect(buttonLabels(w)).toContain("Reset workspace");
 	});

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -261,6 +261,30 @@
 					/>
 				</div>
 			</div>
+
+			<!-- Reset onboarding (jarvis.onboarding.reset_onboarding): clears the
+			     connection + all workspace content and re-runs the setup wizard.
+			     Synchronous — no container rebuild, so no poll; on success we hard-
+			     reload into /jarvis/onboarding. Full wipe always (the bench
+			     reset-onboarding CLI); the red solid lives in the useConfirm. -->
+			<div v-if="isSystemManager" class="mt-6 flex items-start justify-between gap-4">
+				<div class="flex flex-col gap-0.5">
+					<span class="text-base font-medium text-ink-gray-8">Reset onboarding</span>
+					<span class="max-w-lg text-p-sm text-ink-gray-6">
+						Clears this workspace's connection and AI setup and permanently deletes all
+						content — chats, skills, macros, triggers, learned patterns, wiki pages and
+						dashboards — then restarts the setup wizard. Your subscription is kept.
+						This cannot be undone.
+					</span>
+				</div>
+				<Button
+					variant="subtle"
+					theme="red"
+					label="Reset onboarding"
+					:loading="onboardingResetBusy"
+					@click="doResetOnboarding"
+				/>
+			</div>
 		</template>
 	</SettingsPane>
 </template>
@@ -316,6 +340,11 @@ const autoApplyNote = computed(() => (ctx.value && ctx.value.autoApplyNote) || "
 // a verdict while chat was failing, while a save was applying, and while the
 // workspace was disconnected. It was not stale, it was a constant.
 const isSM = !!(window.is_system_manager || window.is_jarvis_admin);
+// Reset onboarding gates STRICTER than the rest of the danger zone: its backend
+// (dev.reset_onboarding) is only_for("System Manager"), unlike the sibling Reset
+// workspace whose require_jarvis_admin also accepts a Jarvis Admin. Reusing isSM
+// here would show a Jarvis-Admin-only seat a destructive button the server 403s.
+const isSystemManager = !!window.is_system_manager;
 // Admin only. Deliberately NOT reused for the member verdict: modeLabel, isPool,
 // disconnected and modelLabel all read this object, so pouring a one-field
 // member payload into it would silently rewrite rows that have nothing to do
@@ -569,6 +598,7 @@ const resetting = ref(false);
 const resetState = ref({});
 const wipeData = ref(false);
 const revokeLlm = ref(false);
+const onboardingResetBusy = ref(false);
 
 // Poll every 3s while resetting, up to 15 min; the tenant-side */5 cron backstop
 // converges a closed tab, so timing out here just stops the spinner.
@@ -640,6 +670,29 @@ async function doReset() {
 		toast.error(errHtml(e, "Could not reset the workspace."));
 	} finally {
 		resetBusy.value = false;
+	}
+}
+
+// Reset onboarding: synchronous full reset (no rebuild, no poll). On success the
+// bench is disconnected + wizard-fresh, so we hard-reload straight into the
+// onboarding wizard. Full wipe every time, per the reset-onboarding CLI.
+async function doResetOnboarding() {
+	const ok = await confirm({
+		title: "Reset onboarding?",
+		message:
+			"This permanently deletes all chats, skills, macros, triggers, learned patterns, wiki pages and dashboards, and clears your AI setup, then restarts the setup wizard. Your subscription is kept. This cannot be undone.",
+		confirmLabel: "Reset onboarding",
+		danger: true,
+	});
+	if (!ok) return;
+	onboardingResetBusy.value = true;
+	try {
+		await api.resetOnboarding(true);
+		toast.success("Onboarding reset — restarting setup.");
+		setTimeout(() => window.location.assign("/jarvis/onboarding"), 600);
+	} catch (e) {
+		toast.error(errHtml(e, "Could not reset onboarding."));
+		onboardingResetBusy.value = false;
 	}
 }
 

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -193,7 +193,7 @@
 					<span class="text-base font-medium text-ink-gray-8">Reset workspace</span>
 					<span class="max-w-lg text-p-sm text-ink-gray-6">
 						Destroys this workspace's container and attaches a fresh one, then
-						reconnects automatically — use it when the workspace is stuck or won't
+						reconnects automatically. Use it when the workspace is stuck or won't
 						connect. Chat is unavailable while it runs (usually a few minutes). Your
 						subscription, chat history and AI connections are kept unless you tick the
 						options.
@@ -272,8 +272,8 @@
 					<span class="text-base font-medium text-ink-gray-8">Reset onboarding</span>
 					<span class="max-w-lg text-p-sm text-ink-gray-6">
 						Clears this workspace's connection and AI setup and permanently deletes all
-						content — chats, skills, macros, triggers, learned patterns, wiki pages and
-						dashboards — then restarts the setup wizard. Your subscription is kept.
+						content (chats, skills, macros, triggers, learned patterns, wiki pages and
+						dashboards), then restarts the setup wizard. Your subscription is kept.
 						This cannot be undone.
 					</span>
 				</div>
@@ -688,7 +688,7 @@ async function doResetOnboarding() {
 	onboardingResetBusy.value = true;
 	try {
 		await api.resetOnboarding(true);
-		toast.success("Onboarding reset — restarting setup.");
+		toast.success("Onboarding reset. Restarting setup.");
 		setTimeout(() => window.location.assign("/jarvis/onboarding"), 600);
 	} catch (e) {
 		toast.error(errHtml(e, "Could not reset onboarding."));

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -269,7 +269,7 @@
 			     reset-onboarding CLI); the red solid lives in the useConfirm. -->
 			<div v-if="isSystemManager" class="mt-6 flex items-start justify-between gap-4">
 				<div class="flex flex-col gap-0.5">
-					<span class="text-base font-medium text-ink-gray-8">Reset onboarding</span>
+					<span class="text-base font-medium text-ink-gray-8">Reset to onboarding</span>
 					<span class="max-w-lg text-p-sm text-ink-gray-6">
 						Clears this workspace's connection and AI setup and permanently deletes all
 						content (chats, skills, macros, triggers, learned patterns, wiki pages and
@@ -280,7 +280,7 @@
 				<Button
 					variant="subtle"
 					theme="red"
-					label="Reset onboarding"
+					label="Reset to onboarding"
 					:loading="onboardingResetBusy"
 					@click="doResetOnboarding"
 				/>
@@ -678,10 +678,10 @@ async function doReset() {
 // onboarding wizard. Full wipe every time, per the reset-onboarding CLI.
 async function doResetOnboarding() {
 	const ok = await confirm({
-		title: "Reset onboarding?",
+		title: "Reset to onboarding?",
 		message:
 			"This permanently deletes all chats, skills, macros, triggers, learned patterns, wiki pages and dashboards, and clears your AI setup, then restarts the setup wizard. Your subscription is kept. This cannot be undone.",
-		confirmLabel: "Reset onboarding",
+		confirmLabel: "Reset to onboarding",
 		danger: true,
 	});
 	if (!ok) return;

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -1852,6 +1852,26 @@ def request_workspace_reset(reason: str = "", wipe_data: bool = False, revoke_ll
 	return out
 
 
+@frappe.whitelist()
+def reset_onboarding(wipe_data: bool = True) -> dict:
+	"""Customer-facing "Reset onboarding" (Jarvis Settings button): clear this
+	bench's connection + LLM credentials and — by default, matching the
+	``bench reset-onboarding`` CLI — delete all workspace content, so the setup
+	wizard runs from step 1.
+
+	Thin whitelisted wrapper over :func:`jarvis.dev.reset_onboarding`, which does
+	the teardown (container OAuth auth-profile + chat-device unpair, both
+	best-effort; subscription/billing untouched). Distinct from
+	:func:`request_workspace_reset`, which rebuilds the container via admin.
+
+	System Manager only — the same gate dev.reset_onboarding enforces, stated here
+	so the endpoint 403s before importing rather than deep inside the teardown."""
+	frappe.only_for("System Manager")
+	from jarvis import dev
+
+	return dev.reset_onboarding(wipe_data=bool(cint(wipe_data)))
+
+
 def _wipe_workspace_content() -> None:
 	for dt in _WIPE_DOCTYPES:
 		frappe.db.delete(dt)

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -207,3 +207,81 @@ class TestResetUnpairsTheContainer(FrappeTestCase):
 		frappe.db.commit()
 		reset_onboarding()
 		self.assertFalse(self.unpair_chat_devices.called)
+
+
+class TestResetOnboardingEndpoint(FrappeTestCase):
+	"""The whitelisted jarvis.onboarding.reset_onboarding wrapper behind the
+	'Reset onboarding' settings button. Its whole job is gate + coerce +
+	delegate to jarvis.dev.reset_onboarding (exhaustively covered above), so
+	these assert exactly that contract with dev patched out."""
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_requires_system_manager(self):
+		from jarvis.onboarding import reset_onboarding as endpoint
+
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			endpoint()
+
+	def test_rejects_jarvis_admin_who_is_not_system_manager(self):
+		"""Stricter-than-sibling gate: the Jarvis Admin (desk) role alone is not
+		enough — only System Manager runs the wipe. Mirrors the frontend button
+		gated on is_system_manager, not the combined isSM (a Jarvis-Admin-only
+		seat must neither see nor be able to execute it)."""
+		from jarvis.onboarding import reset_onboarding as endpoint
+		from jarvis.permissions import JARVIS_ADMIN_ROLE, ensure_jarvis_admin_role
+
+		ensure_jarvis_admin_role()
+		email = "reset-ob-jarvis-admin-only@example.com"
+		if not frappe.db.exists("User", email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": "Reset OB",
+					"send_welcome_email": 0,
+					"roles": [{"role": JARVIS_ADMIN_ROLE}],
+				}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+		self.addCleanup(frappe.db.commit)
+		self.addCleanup(lambda: frappe.delete_doc("User", email, ignore_permissions=True, force=True))
+
+		roles = set(frappe.get_roles(email))
+		self.assertIn(JARVIS_ADMIN_ROLE, roles)
+		self.assertNotIn("System Manager", roles)
+
+		frappe.set_user(email)
+		with self.assertRaises(frappe.PermissionError):
+			endpoint()
+
+	@patch("jarvis.dev.reset_onboarding", return_value={"ok": True, "data": {}})
+	def test_defaults_to_full_wipe_matching_the_cli(self, m):
+		from jarvis.onboarding import reset_onboarding as endpoint
+
+		endpoint()
+		m.assert_called_once_with(wipe_data=True)
+
+	@patch("jarvis.dev.reset_onboarding", return_value={"ok": True, "data": {}})
+	def test_coerces_http_string_false(self, m):
+		"""A falsy string must forward False (never a truthy non-empty string), so
+		a stray wipe_data can't trigger the destructive content wipe. Coerced by
+		the @whitelist bool annotation in request/test context, with cint() as the
+		belt-and-suspenders fallback."""
+		from jarvis.onboarding import reset_onboarding as endpoint
+
+		endpoint(wipe_data="0")
+		m.assert_called_once_with(wipe_data=False)
+
+	@patch(
+		"jarvis.dev.reset_onboarding",
+		return_value={"ok": True, "data": {"cleared_fields": [], "wiped_doctypes": ["X"]}},
+	)
+	def test_returns_dev_payload_unchanged(self, m):
+		from jarvis.onboarding import reset_onboarding as endpoint
+
+		out = endpoint()
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["data"]["wiped_doctypes"], ["X"])


### PR DESCRIPTION
## What this adds

A customer-facing **"Reset onboarding"** button in Jarvis Settings → General → Danger zone (System Manager only). One click, behind a danger confirm, runs the exact same reset as the `bench reset-onboarding` CLI: clears the connection + LLM credentials and **deletes all workspace content** (chats, skills, macros, triggers, learned patterns, wiki, dashboards), then reloads into the onboarding wizard. **Subscription/billing is untouched.**

This surfaces the existing, already-tested `jarvis.dev.reset_onboarding()` — nothing about the teardown itself changes.

## Design

- **`jarvis.onboarding.reset_onboarding`** — thin whitelisted wrapper over `jarvis.dev.reset_onboarding` (the CLI's function): `frappe.only_for("System Manager")` + `cint()` coercion, then delegates. Full wipe by default (`wipe_data=True`), matching the CLI.
- Distinct from the sibling **"Reset workspace"** button (`request_workspace_reset`), which is the heavier *container rebuild via admin*. This one is a synchronous, local reset — no rebuild, no poll.
- The teardown (best-effort container OAuth-profile clear + chat-device unpair) is idempotent and non-fatal on a dead/unreachable container.

## Guard (stricter than the sibling)

`dev.reset_onboarding` is **`only_for("System Manager")`**, stricter than "Reset workspace" (`require_jarvis_admin`, which also accepts Jarvis Admin). So the button is gated on **`window.is_system_manager` specifically**, not the looser `isSM` — a Jarvis-Admin-only seat never sees a control the backend would 403.

## Tests

- Backend (`test_dev.py`, +5 → 15 OK): SM required, **Jarvis-Admin-only rejected**, default-full-wipe (mutation-verified), `"0"`→no-wipe coercion, dev payload passthrough.
- Frontend (`GeneralPane.spec.js`, +4 → 21 OK): SM shows / member hidden / **Jarvis-Admin-only hidden** (mutation-verified), dismissed-confirm → no call, accepted-confirm → full-wipe call (mutation-verified).
- Regression `test_onboarding_sync` 105 OK; ruff + prettier@2.7.1 clean; SPA builds.

## Review status

- **Code review: GREEN** (adversarial opus). Round 1 caught one MAJOR — the button was over-exposed to Jarvis-Admin-only seats the backend rejects (a dead control); fixed by the `is_system_manager` gate + two new gate tests; round 2 GREEN.
- **Flow review: waived** — the live Claude-in-Chrome walk couldn't run (the driving browser can't reach this bench). A manual click-test recipe (target `jarvis.local`) is available for a pre-merge check; the one step no automated test covers is the real post-reset landing on the wizard.
