### PR TITLE
feat: make the pre-chat wait a real preflight checklist

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -303,6 +303,11 @@ export const getPresetCatalog = () => call("jarvis.onboarding.get_preset_catalog
 // calls that. See jarvis.chat.api.get_model_catalog_ui.
 export const getModelCatalogUi = () => call("jarvis.chat.api.get_model_catalog_ui");
 export const getLlmSyncStatus = () => call("jarvis.onboarding.get_llm_sync_status");
+// jarvis#840: the pre-chat preflight. Answers what readiness cannot -
+// { plugin, persona, usable: {state, detail} } - and never refuses: every
+// failure inside it degrades to unchecked/unknown (only usable.state "auth"
+// blocks, client-side). Plain dict, no ok-envelope, like isReadyForChat.
+export const runChatPreflight = () => call("jarvis.preflight.run_chat_preflight");
 // Persist the desired pool AND return the durable apply-operation descriptor the
 // Start-chatting controller follows (plan-05 D2). Returns (unwrapped)
 // { apply_operation: <12-key descriptor|null>, idempotency_key, resumable }.

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -14,6 +14,13 @@ const api = vi.hoisted(() => ({
 	getAccountDefaults: vi.fn(async () => ({})),
 	listPaymentProviders: vi.fn(async () => ({ providers: ["razorpay"], default: "razorpay" })),
 	isReadyForChat: vi.fn(async () => ({ ready: false, reason: "signup" })),
+	// jarvis#840: default all-green so every pre-existing "ready navigates"
+	// assertion still holds; the preflight describe block below overrides it.
+	runChatPreflight: vi.fn(async () => ({
+		plugin: "ok",
+		persona: "ok",
+		usable: { state: "ok", detail: "" },
+	})),
 	checkSignupPaymentState: vi.fn(async () => ({})),
 	listPlans: vi.fn(async () => []),
 	reconnectAvailable: vi.fn(async () => ({})),
@@ -1687,14 +1694,15 @@ describe("jarvis wait-phases-horizontal: detail hoisted out of the phase columns
 		w.unmount();
 	});
 
-	it("still lays out exactly three phase columns, each its own row item", async () => {
+	it("still lays out each phase as its own row item (six with the jarvis#840 checklist)", async () => {
 		const w = await mountConnect();
 
 		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
 		await flushPromises();
 
+		// 3 original phases + the preflight's 3 checklist rows (jarvis#840).
 		const columns = w.findAll(".ob-phases > .ob-phase");
-		expect(columns).toHaveLength(3);
+		expect(columns).toHaveLength(6);
 		// Every column still carries only its label, never the detail sentence -
 		// the hoist removed the ONLY per-row detail span, it did not just add a
 		// duplicate copy alongside it.
@@ -1777,5 +1785,68 @@ describe("subscription Test / Start-chatting mutual exclusion", () => {
 		await flushPromises();
 		expect(editor.props("hostBusy")).toBe(true);
 		w.unmount();
+	});
+});
+
+describe("jarvis#840 the pre-chat preflight gate", () => {
+	async function driveToReady(w) {
+		api.getLlmApplyOperation.mockResolvedValue(readyStatus);
+		const p = w.vm.saveConnect();
+		await flushPromises();
+		await vi.advanceTimersByTimeAsync(50);
+		await p;
+		await flushPromises();
+	}
+
+	it("runs exactly once between ready and navigation, and all-green proceeds", async () => {
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		await driveToReady(w);
+		expect(api.runChatPreflight).toHaveBeenCalledTimes(1);
+		expect(routerReplace).toHaveBeenCalledTimes(1);
+		expect(routerReplace).toHaveBeenCalledWith({ name: "Chat" });
+	});
+
+	it("a credential rejection blocks navigation and restores the editable form with the provider's sentence", async () => {
+		api.runChatPreflight.mockResolvedValue({
+			plugin: "ok",
+			persona: "ok",
+			usable: {
+				state: "auth",
+				detail: "OpenAI API error (401): Incorrect API key provided",
+			},
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		await driveToReady(w);
+		expect(routerReplace).not.toHaveBeenCalled();
+		expect(w.vm.state.finishing).toBe(false);
+		expect(w.vm.state.connectBlockReason).toMatch(/401/);
+		// A fresh attempt re-runs the preflight rather than reusing the refusal.
+		expect(w.vm.preflight.done).toBe(false);
+	});
+
+	it("a provider usage limit is shown honestly and does NOT block chat", async () => {
+		api.runChatPreflight.mockResolvedValue({
+			plugin: "ok",
+			persona: "ok",
+			usable: { state: "rate_limit", detail: "429 usage_limit_reached" },
+		});
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		await driveToReady(w);
+		expect(w.vm.preflight.notice).toMatch(/usage limit/i);
+		expect(routerReplace).not.toHaveBeenCalled(); // still inside the honest beat
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+		expect(routerReplace).toHaveBeenCalledTimes(1);
+	});
+
+	it("unchecked rows and even a failed preflight call never block (fail open)", async () => {
+		api.runChatPreflight.mockRejectedValue(new Error("admin down"));
+		vi.useFakeTimers();
+		const w = await mountConnect();
+		await driveToReady(w);
+		expect(routerReplace).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1856,4 +1856,17 @@ describe("jarvis#840 the pre-chat preflight gate", () => {
 		await driveToReady(w);
 		expect(routerReplace).toHaveBeenCalledTimes(1);
 	});
+
+	it("a stale terminal after the customer escaped to the form neither navigates nor probes", async () => {
+		// PR #848 review: chooseDifferentModel resets the UI but never aborts an
+		// in-flight follow; when that stale operation later resolves ready, the
+		// gate must not yank the screen or bill a probe against the abandoned
+		// config. finishing=false is the escape's signature.
+		const w = await mountConnect();
+		w.vm.state.finishing = false;
+		await w.vm.navigateToChat();
+		await flushPromises();
+		expect(api.runChatPreflight).not.toHaveBeenCalled();
+		expect(routerReplace).not.toHaveBeenCalled();
+	});
 });

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1824,6 +1824,13 @@ describe("jarvis#840 the pre-chat preflight gate", () => {
 		expect(w.vm.state.connectBlockReason).toMatch(/401/);
 		// A fresh attempt re-runs the preflight rather than reusing the refusal.
 		expect(w.vm.preflight.done).toBe(false);
+		// Review B1: the forgets are load-bearing. Admin dedupes on the
+		// idempotency key and the stored operation id, so keeping either would
+		// hand the next Start straight back the operation whose credential the
+		// probe just refused - a permanent block. Both must be gone so the
+		// customer's FIXED credential mints a fresh operation.
+		expect(sessionStorage.getItem(IDEM_KEY)).toBeNull();
+		expect(sessionStorage.getItem(OP_STORE_KEY)).toBeNull();
 	});
 
 	it("a provider usage limit is shown honestly and does NOT block chat", async () => {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1422,6 +1422,41 @@
 														}}</span>
 													</span>
 												</li>
+												<!-- jarvis#840: the preflight's own rows. Same
+												     ob-phase states as the rows above; these fill in
+												     one step (the single preflight call) once
+												     readiness turns green, and none of them can hold
+												     the screen - see runPreflightGate. -->
+												<li
+													v-for="row in preflightRows"
+													:key="row.key"
+													class="ob-phase"
+													:class="`ob-phase--${row.state}`"
+												>
+													<span class="ob-phase-ico">
+														<JvSpinner
+															v-if="row.state === 'active'"
+															color="currentColor"
+															:size="20"
+														/>
+														<FeatherIcon
+															v-else-if="row.state === 'done'"
+															name="check"
+															class="h-4 w-4"
+														/>
+														<FeatherIcon
+															v-else-if="row.state === 'unknown'"
+															name="alert-circle"
+															class="h-4 w-4"
+														/>
+														<i v-else class="ob-phase-dot"></i>
+													</span>
+													<span class="ob-phase-txt">
+														<span class="ob-phase-label">{{
+															row.label
+														}}</span>
+													</span>
+												</li>
 												<li class="ob-phase ob-phase--waiting">
 													<span class="ob-phase-ico"
 														><i class="ob-phase-dot"></i
@@ -1438,6 +1473,11 @@
 												class="ob-phase-detail"
 											>
 												{{ readinessStage.detail }}
+											</p>
+											<!-- The honest usage-limit line (jarvis#840): shown for
+											     a beat before chat opens anyway; never a blocker. -->
+											<p v-if="preflight.notice" class="ob-phase-detail">
+												{{ preflight.notice }}
 											</p>
 										</div>
 										<!-- min-height (not h-full) is load-bearing: SetupNeuralNet's
@@ -1679,6 +1719,7 @@ import {
 import { inrExact, planAmount, planSuffix, planHasGst } from "@/account/format";
 import {
 	isReadyForChat,
+	runChatPreflight,
 	getLlmApplyOperation,
 	listPlans,
 	listPaymentProviders,
@@ -3599,11 +3640,117 @@ function onOpUpdate(ui) {
 	}
 }
 
+// jarvis#840: the ONE preflight between "readiness turned green" and chat. All
+// three arrival paths (waitForChatReadiness, followLegacyReadiness, the durable
+// operation's onTerminal) converge on navigateToChat, so gating here covers the
+// instant-green case that motivated the issue - a perfectly-wired connect whose
+// FIRST message then died upstream on a quota 429 nothing had checked.
+//
+// Verdict policy (the issue's core constraint): only a genuine credential
+// rejection ("auth") blocks - back to the connect form with the verbatim
+// reason. A provider usage limit shows an honest line for a beat and proceeds;
+// unchecked/unknown/unreachable rows NEVER block; a preflight call that itself
+// fails is skipped entirely (fail open - this gate must not be able to strand
+// a customer the old readiness flow would have let through).
+const preflight = reactive({
+	running: false,
+	done: false,
+	plugin: "",
+	persona: "",
+	usable: null,
+	notice: "",
+});
+const PREFLIGHT_NOTICE_MS = 2500;
+
+async function runPreflightGate() {
+	if (preflight.running) return false;
+	preflight.running = true;
+	// The checklist renders inside the working screen, so make sure it shows
+	// even when readiness was instantly green and no wait was ever displayed.
+	state.finishing = true;
+	if (!state.connectPhase) state.connectPhase = "working";
+	let d = null;
+	try {
+		d = await runChatPreflight();
+	} catch (e) {
+		d = null;
+	}
+	preflight.running = false;
+	preflight.done = true;
+	preflight.plugin = (d && d.plugin) || "unchecked";
+	preflight.persona = (d && d.persona) || "unchecked";
+	preflight.usable = (d && d.usable) || { state: "unknown", detail: "" };
+	if (preflight.usable.state === "auth") {
+		// The connection itself was rejected upstream: the fix is in the
+		// customer's hands, so land them back on the editable form with the
+		// provider's own sentence. A fresh attempt re-runs the preflight.
+		preflight.done = false;
+		state.finishing = false;
+		state.connectPhase = "";
+		state.connectBlockReason =
+			preflight.usable.detail ||
+			"Your AI provider rejected this connection. Reconnect your account.";
+		return false;
+	}
+	if (preflight.usable.state === "rate_limit") {
+		// Honest, non-blocking: the plan is out of quota, chat still opens.
+		preflight.notice =
+			"Your AI plan is at its usage limit right now. Chat will respond again when it resets.";
+		await _sleep(PREFLIGHT_NOTICE_MS);
+	}
+	return true;
+}
+
+// The three checklist rows the preflight owns (jarvis#840), rendered between
+// the readiness row and "Opening chat": waiting -> active (the one call in
+// flight) -> done/unknown. No row state ever blocks - the blocking "auth"
+// verdict leaves this screen entirely (runPreflightGate), so it never renders
+// as a row.
+const preflightRows = computed(() => {
+	const rowState = (v) => {
+		if (preflight.running) return "active";
+		if (!preflight.done) return "waiting";
+		return v === "ok" ? "done" : "unknown";
+	};
+	const suffix = (v) =>
+		!preflight.done || v === "ok"
+			? ""
+			: v === "unchecked"
+			? ": not checked"
+			: ": needs attention";
+	const usable = (preflight.usable && preflight.usable.state) || "";
+	const usableLabel = !preflight.done
+		? "AI connection answers a live check"
+		: usable === "ok"
+		? "AI connection checked"
+		: usable === "rate_limit"
+		? "AI connection is at its usage limit"
+		: "AI connection: no live check ran";
+	return [
+		{
+			key: "plugin",
+			state: rowState(preflight.plugin),
+			label: `Business tools wired${suffix(preflight.plugin)}`,
+		},
+		{
+			key: "persona",
+			state: rowState(preflight.persona),
+			label: `Assistant persona loaded${suffix(preflight.persona)}`,
+		},
+		{ key: "usable", state: rowState(usable), label: usableLabel },
+	];
+});
+
 // Navigate to Chat exactly once, only on an authoritative ready. forgetReady() clears
 // the router's memoized readiness so its guard re-checks fresh, and router.replace
 // re-runs that guard → Chat.
-function navigateToChat() {
+async function navigateToChat() {
 	if (navigated.value) return;
+	if (!preflight.done) {
+		const proceed = await runPreflightGate();
+		if (!proceed) return;
+		if (navigated.value) return;
+	}
 	navigated.value = true;
 	stopRetryCountdown();
 	forgetIdem();

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3684,12 +3684,33 @@ async function runPreflightGate() {
 		// The connection itself was rejected upstream: the fix is in the
 		// customer's hands, so land them back on the editable form with the
 		// provider's own sentence. A fresh attempt re-runs the preflight.
+		//
+		// The forgets mirror chooseDifferentModel's and are load-bearing, not
+		// tidying (jarvis#840 review B1): the customer is about to submit a
+		// FIXED credential, so this attempt's idempotency key and operation id
+		// must not survive - admin dedupes on both and would hand straight
+		// back the very operation whose credential the probe just refused,
+		// re-blocking forever. Stale terminal copy goes with them.
 		preflight.done = false;
-		state.finishing = false;
+		stopRetryCountdown();
+		forgetIdem();
+		opStore.forget();
+		currentOpId.value = "";
+		forgetReady();
+		readinessSeen.value = null;
+		opReadinessDetail.value = "";
+		lastOpChatReadinessReason = "";
 		state.connectPhase = "";
+		state.connectTitle = "";
+		state.connectMessage = "";
+		state.connectPaged = false;
+		state.connectSupportOffered = false;
+		state.retryAfter = 0;
+		connectModelChangeOffered.value = false;
 		state.connectBlockReason =
 			preflight.usable.detail ||
 			"Your AI provider rejected this connection. Reconnect your account.";
+		state.finishing = false;
 		return false;
 	}
 	if (preflight.usable.state === "rate_limit") {
@@ -3697,9 +3718,18 @@ async function runPreflightGate() {
 		preflight.notice =
 			"Your AI plan is at its usage limit right now. Chat will respond again when it resets.";
 		await _sleep(PREFLIGHT_NOTICE_MS);
+		// The customer may have left the wizard during the notice beat; a
+		// navigation fired after unmount would yank a different view around.
+		if (preflightDisposed.value) return false;
 	}
 	return true;
 }
+// Unmount cancels a pending notice-beat navigation (jarvis#840 review); the
+// operation controller's own unmount abort does not cover this local sleep.
+const preflightDisposed = ref(false);
+onUnmounted(() => {
+	preflightDisposed.value = true;
+});
 
 // The three checklist rows the preflight owns (jarvis#840), rendered between
 // the readiness row and "Opening chat": waiting -> active (the one call in

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3755,6 +3755,8 @@ const preflightRows = computed(() => {
 		? "AI connection checked"
 		: usable === "rate_limit"
 		? "AI connection is at its usage limit"
+		: usable === "timeout"
+		? "The live check timed out"
 		: "AI connection: no live check ran";
 	return [
 		{

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3778,6 +3778,12 @@ const preflightRows = computed(() => {
 // re-runs that guard → Chat.
 async function navigateToChat() {
 	if (navigated.value) return;
+	// A terminal that resolves AFTER the customer escaped back to the editable
+	// form (the jarvis#727 chooseDifferentModel path sets finishing=false and
+	// never aborts the in-flight follow) must not yank the screen into a
+	// preflight over the abandoned config, let alone bill a probe against it
+	// (PR #848 review). Only the wait screen owns navigation.
+	if (!state.finishing && !preflight.running) return;
 	if (!preflight.done) {
 		const proceed = await runPreflightGate();
 		if (!proceed) return;

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -653,6 +653,26 @@ def confirm_payment(payload: dict) -> dict:
 	return _post(path=_m("api.tenant.confirm_payment"), body=payload)
 
 
+def get_integration_status(*, deep: bool = False, timeout_s: int = 20) -> dict:
+	"""Plugin + persona wiring tri-states for this bench's own container
+	(jarvis#840 preflight). Admin relays the fleet's integration probe and
+	answers {"tri_state": {"plugin": ..., "persona": ...}, "source":
+	"live|cached|none", "checked_at": ...} with only customer-safe fields.
+
+	``deep`` asks for the ~3s in-container probe (the boot-log truth about
+	registered tools) instead of the sub-second static one. The 20s budget
+	covers admin's own relay with headroom; callers treat EVERY failure of
+	this call as "unchecked", never as an error - an admin without the method
+	yet (deploy window) surfaces as Frappe's method-not-found rejection (see
+	``is_method_not_found``)."""
+	body = {"deep": 1} if deep else {}
+	return _post(
+		path=_m("api.tenant.integration_status"),
+		body=body,
+		timeout_s=timeout_s,
+	)
+
+
 def get_connection(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	"""Fetch the assigned container connection (fallback / scheduled sync).
 

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -135,16 +135,24 @@ ORPHAN_BATCH_MAX = 200
 _CHAT_NAMESPACE_MARKER = ":dashboard:"
 
 # Labels of every throwaway session kind the bench mints: prewarm.warm_prefix,
-# title._generate_via_gateway, and learning.polish._run_gateway_turn. All three
-# now delete their own sessions, so these only turn up here when that cleanup was
-# missed (a crash, a lost cache pointer, a gateway blip) - never as live state.
+# title._generate_via_gateway, learning.polish._run_gateway_turn, and the
+# onboarding preflight's live probe (jarvis#840). Each deletes or reclaims its
+# own session, so these only turn up here when that cleanup was missed (a
+# crash, a lost cache pointer, a gateway blip) or deliberately skipped (the
+# preflight's abandoned-worker timeout path leaves its billed session for THIS
+# sweep) - never as live state.
 #
 # A short grace is SAFE for these specifically because the labels are namespaced:
 # a real conversation session is always "jarvis-chat-<user>-<ms>" (api.py
 # _ensure_session_key), so a throwaway label can never be a conversation whose
 # freshly-minted session_key has not committed yet. That race is exactly what
 # ORPHAN_GRACE_HOURS protects, and it still gets the full 24h.
-_THROWAWAY_LABEL_PREFIXES = ("jarvis-prewarm-", "jarvis-title-", "jarvis-polish-")
+_THROWAWAY_LABEL_PREFIXES = (
+	"jarvis-prewarm-",
+	"jarvis-title-",
+	"jarvis-polish-",
+	"jarvis-preflight-",
+)
 THROWAWAY_GRACE_HOURS = 1
 
 

--- a/jarvis/chat/session_pin_sweep.py
+++ b/jarvis/chat/session_pin_sweep.py
@@ -118,10 +118,12 @@ MAX_CLEAR = 200
 PAGE_LIMIT = 100
 MAX_PAGES = 50
 
-# Labels of the throwaway sessions the bench mints for its own turns (mirrors
-# session_lifecycle._THROWAWAY_LABEL_PREFIXES). A real conversation session is
-# always "jarvis-chat-<user>-<ms>", so these prefixes can never collide with one.
-_BENCH_LABEL_PREFIXES = ("jarvis-prewarm-", "jarvis-title-", "jarvis-polish-")
+# Labels of the throwaway sessions the bench mints for its own turns - the ONE
+# list, imported so this can never diverge from the sweep that reaps them
+# (jarvis#840 review: the previous hand-copied mirror did). A real conversation
+# session is always "jarvis-chat-<user>-<ms>", so these prefixes can never
+# collide with one.
+from jarvis.chat.session_lifecycle import _THROWAWAY_LABEL_PREFIXES as _BENCH_LABEL_PREFIXES
 
 # agent's own per-agent session: "agent:<id>:main" and its ":heartbeat"
 # sibling. The heartbeat resumes on every tick, so a pin there fails forever.

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -35,20 +35,32 @@ from jarvis.permissions import require_jarvis_admin
 
 _PROBE_PROMPT = "Reply with the single word: ok"
 _PROBE_BUDGET_S = 20
-# One customer clicking through onboarding fires ONE billed probe; a reload
-# or double-entry inside the TTL reuses the verdict instead of re-billing.
+# One customer clicking through onboarding fires ONE billed probe; a reload or
+# double-entry inside the TTL reuses the verdict instead of re-billing. Keyed
+# by the jarvis#841 apply fingerprint so a FIXED credential (new blob, new
+# fingerprint) always probes fresh and can never be answered by the previous
+# credential's refusal. Billed outcomes keep the long TTL; an unreachable
+# gateway (a restart blip, nothing billed) retries almost immediately so the
+# checklist cannot lie for half a minute about a container that just came back.
 _PROBE_CACHE_KEY = "jarvis.preflight.probe_verdict"
 _PROBE_CACHE_TTL_S = 30
+_PROBE_CACHE_TTL_UNREACHABLE_S = 5
 
 # Provider quota/exhaustion vocabulary, checked BEFORE the auth patterns so
-# "insufficient credit" style messages land on the non-blocking side. The
-# auth side reuses chat/title.py's _AUTH_FAULT_RE (single source, jarvis#738)
-# rather than growing a second, drifting copy.
+# quota prose lands on the non-blocking side. Deliberately CONTEXT-BOUND
+# (jarvis#840 review M2): bare tokens like "insufficient"/"credit" also occur
+# in genuine credential failures ("Request had insufficient authentication
+# scopes", a 403), and the issue's tolerance is asymmetric - wrongly BLOCKING
+# is recoverable, wrongly letting a broken credential into chat is the exact
+# failure this feature exists to prevent. The auth side reuses
+# chat/title.py's _AUTH_FAULT_RE (single source, jarvis#738).
 _RATE_LIMIT_RE = re.compile(
 	r"\b429\b"
-	r"|rate.?limit|usage.?limit(?:_reached)?|too.?many.?requests"
-	r"|quota|overloaded|exhausted"
-	r"|insufficient|credit|billing",
+	r"|rate.?limit|usage.?limit|too.?many.?requests"
+	r"|\bquota\b|overloaded|resource.?exhausted"
+	r"|insufficient[_ -]?(?:quota|credits?|balance|funds)"
+	r"|credit.?balance|out.?of.?(?:credits?|messages)"
+	r"|billing.?(?:hard.?)?limit",
 	re.IGNORECASE,
 )
 
@@ -88,19 +100,21 @@ def _integration_item() -> dict:
 	unchecked = {"plugin": "unchecked", "persona": "unchecked", "integration_source": "unavailable"}
 	try:
 		data = admin_client.get_integration_status() or {}
-	except admin_client.AdminValidationError as e:
-		if admin_client.is_method_not_found(e):
-			return unchecked
-		return unchecked
 	except Exception:
+		# Deploy-window method-not-found, unreachable admin, anything: all the
+		# same "unchecked" - there is no second call worth making when the
+		# FIRST admin round trip already failed (jarvis#840 review M3).
 		return unchecked
 	tri = data.get("tri_state") or {}
 	plugin = _tri(tri.get("plugin"))
 	persona = _tri(tri.get("persona"))
-	if plugin != "ok" or persona != "ok":
+	if data.get("source") == "live" and (plugin != "ok" or persona != "ok"):
 		# Escalate once to the deep probe: the static one cannot see whether
 		# the plugin actually registered its tools, so a not-ok cheap answer
-		# is a suspicion, not a verdict. Best-effort - on failure the cheap
+		# is a suspicion, not a verdict. ONLY on a live not-ok (review M3): a
+		# "cached"/"none" answer means the fleet call already failed or there
+		# is no container, and the deep retry would pay a second full round
+		# trip to meet the same wall. Best-effort - on failure the cheap
 		# answer stands.
 		try:
 			deep = admin_client.get_integration_status(deep=True) or {}
@@ -165,22 +179,75 @@ def _probe_stored_api_key(settings) -> dict:
 	return {"state": "unknown", "detail": message[:300], "source": "key_probe"}
 
 
+def _probe_cache_key(settings) -> str:
+	"""Per-config cache key (jarvis#840 review M4): the jarvis#841 apply
+	fingerprint changes whenever the credential/config changes, so a fixed
+	credential always probes fresh while a reload of the SAME config reuses
+	the billed verdict."""
+	return f"{_PROBE_CACHE_KEY}:{settings.get('llm_last_apply_fingerprint') or 'nofp'}"
+
+
+def _drain_probe_stream(sess, session_key: str, run_id: str, model, provider) -> dict:
+	"""Consume the turn stream in a worker thread joined on the probe budget
+	(jarvis#840 review B2): stream_agent_turn's own deadline is the chat
+	turn's 600s and it can block long before its first yield, which would pin
+	this whitelisted request's worker for minutes on a wedged upstream. The
+	thread is pure WS work (no frappe state beyond an already-created stdlib
+	logger); abandoning it on timeout is safe because the caller closes the
+	socket right after, which unblocks the recv."""
+	import threading
+
+	out = {"saw_text": False, "error_text": "", "exc": None, "done": False}
+
+	def _drain():
+		try:
+			for event in sess.stream_agent_turn(
+				session_key,
+				_PROBE_PROMPT,
+				run_id,
+				model=model or None,
+				provider=provider,
+			):
+				kind = event.get("kind")
+				if kind == "assistant" and (event.get("delta") or event.get("text")):
+					out["saw_text"] = True
+					break
+				if kind == "lifecycle" and event.get("phase") == "error":
+					out["error_text"] = str(event.get("error") or "")
+					break
+				if kind == "lifecycle" and event.get("phase") == "end":
+					break
+		except Exception as e:
+			out["exc"] = e
+		out["done"] = True
+
+	worker = threading.Thread(target=_drain, daemon=True, name="jarvis-preflight-probe")
+	worker.start()
+	worker.join(_PROBE_BUDGET_S)
+	return out
+
+
 def _probe_direct_subscription(settings) -> dict:
 	"""ONE bounded real turn through the tenant's own container - the only
 	honest usability check the direct-subscription leg has (its Test button
 	says so in as many words). Billed, hence the cache; throwaway session,
-	deleted afterward; hard wall-clock budget so the wizard never hangs on a
-	wedged upstream."""
+	reclaimed afterward (never bare-deleted: jarvis#525/#535 - deleting under
+	a live run re-creates the session as an orphan or kills the run); hard
+	wall-clock budget so the wizard never hangs on a wedged upstream.
+
+	Model/provider pin comes from turn_handler's resolver, DELIBERATELY not
+	prewarm's simpler one: on this leg the agent-provider id rides the
+	account's own blob (jarvis#755) and only turn_handler reads it, so this is
+	what the customer's real first turn would use."""
 	cache = frappe.cache()
-	cached = cache.get_value(_PROBE_CACHE_KEY)
+	cache_key = _probe_cache_key(settings)
+	cached = cache.get_value(cache_key)
 	if isinstance(cached, dict) and cached.get("state"):
 		return cached
-	# Deliberate reuse of the chat pipeline's own private helpers - single
-	# sources for the gateway URL, the model/provider pin, and the auth
-	# vocabulary, so the probe can never drift from what a real first turn
-	# would do (the prewarm module makes the same choice).
 	from jarvis.chat.agent_client import AgentSession, AgentUnreachableError, oneshot_run_id
 	from jarvis.chat.prewarm import _gateway_ws_url
+	from jarvis.chat.session_lifecycle import reclaim_throwaway_session
+	from jarvis.chat.title import _auth_fault_detail
 	from jarvis.chat.turn_handler import _resolve_model_and_provider
 
 	gateway_url = _gateway_ws_url(settings)
@@ -190,46 +257,41 @@ def _probe_direct_subscription(settings) -> dict:
 	verdict = {"state": "unknown", "detail": ""}
 	sess = None
 	throwaway = None
+	fired_at = None
 	try:
 		sess = AgentSession.connect(gateway_url)
 		throwaway = sess.create_session(label=f"jarvis-preflight-{uuid.uuid4().hex[:8]}")
-		deadline = time.monotonic() + _PROBE_BUDGET_S
-		error_text = ""
-		saw_text = False
-		for event in sess.stream_agent_turn(
+		fired_at = time.time()
+		out = _drain_probe_stream(
+			sess,
 			throwaway,
-			_PROBE_PROMPT,
 			oneshot_run_id("preflight", uuid.uuid4().hex, model=model, provider=provider),
-			model=model or None,
-			provider=provider,
-		):
-			kind = event.get("kind")
-			if kind == "assistant" and (event.get("delta") or event.get("text")):
-				saw_text = True
-				break
-			if kind == "lifecycle" and event.get("phase") == "error":
-				error_text = str(event.get("error") or "")
-				break
-			if kind == "relay:error":
-				error_text = str(event.get("error") or "")
-				break
-			if kind == "lifecycle" and event.get("phase") == "end":
-				break
-			if time.monotonic() > deadline:
-				break
-		if saw_text:
+			model,
+			provider,
+		)
+		if out["saw_text"]:
 			verdict = {"state": "ok", "detail": ""}
-		elif error_text:
-			verdict = _classify_probe_error(error_text)
+		elif out["error_text"]:
+			verdict = _classify_probe_error(out["error_text"])
+		elif out["exc"] is not None:
+			verdict = _classify_probe_exception(out["exc"], _auth_fault_detail)
+		elif not out["done"]:
+			# Budget expired with the run still going: billed, so cache it.
+			verdict = {"state": "unknown", "detail": "The live check timed out."}
 	except AgentUnreachableError as e:
-		verdict = {"state": "unreachable", "detail": str(e)[:300]}
+		verdict = _classify_probe_exception(e, _auth_fault_detail)
 	except Exception:
 		verdict = {"state": "unknown", "detail": ""}
 	finally:
 		if sess is not None:
 			if throwaway:
 				try:
-					sess.delete_session(throwaway)
+					# fired_at marks "no active run" untrustworthy until the
+					# grace elapses, so a not-yet-started run is never deleted
+					# out from under itself; a busy one is left for the sweep.
+					reclaim_throwaway_session(
+						sess, throwaway, logger_name="jarvis.preflight", fired_at=fired_at
+					)
 				except Exception:
 					pass  # orphan; the gateway's own sweep collects it
 			try:
@@ -237,8 +299,24 @@ def _probe_direct_subscription(settings) -> dict:
 			except Exception:
 				pass
 	verdict["source"] = "live_probe"
-	cache.set_value(_PROBE_CACHE_KEY, verdict, expires_in_sec=_PROBE_CACHE_TTL_S)
+	ttl = _PROBE_CACHE_TTL_UNREACHABLE_S if verdict["state"] == "unreachable" else _PROBE_CACHE_TTL_S
+	cache.set_value(cache_key, verdict, expires_in_sec=ttl)
 	return verdict
+
+
+def _classify_probe_exception(exc, auth_fault_detail) -> dict:
+	"""An auth fault can arrive as a RAISED gateway rejection, not only as
+	lifecycle error text (jarvis#840 review M1) - title.py handles both
+	surfaces and so must this, or a credential the probe just proved rejected
+	would read as a shrug-grade "unreachable" and open chat anyway."""
+	auth_text = None
+	try:
+		auth_text = auth_fault_detail(exc)
+	except Exception:
+		auth_text = None
+	if auth_text:
+		return {"state": "auth", "detail": str(auth_text)[:300]}
+	return {"state": "unreachable", "detail": str(exc)[:300]}
 
 
 def _classify_probe_error(text: str) -> dict:

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -75,9 +75,14 @@ def run_chat_preflight() -> dict:
 	{
 	  "plugin":  "ok|degraded|broken|unchecked",
 	  "persona": "ok|degraded|broken|unchecked",
-	  "usable":  {"state": "ok|rate_limit|auth|unreachable|unknown",
+	  "usable":  {"state": "ok|rate_limit|auth|timeout|unreachable|unknown",
 	              "detail": <provider text, trimmed>, "source": ...},
 	}
+
+	Latency: the all-green path is one cheap relay + one short live turn. The
+	worst non-green path is bounded at roughly two 20s admin round trips (a
+	live "degraded" answer pays the deep escalation) plus the 20s probe
+	budget; every leg degrades rather than raises.
 
 	Plain dict like ``account.is_ready_for_chat`` (no ok-envelope): this
 	endpoint cannot refuse - every failure shape inside it degrades to an
@@ -193,8 +198,9 @@ def _drain_probe_stream(sess, session_key: str, run_id: str, model, provider) ->
 	turn's 600s and it can block long before its first yield, which would pin
 	this whitelisted request's worker for minutes on a wedged upstream. The
 	thread is pure WS work (no frappe state beyond an already-created stdlib
-	logger); abandoning it on timeout is safe because the caller closes the
-	socket right after, which unblocks the recv."""
+	logger). An abandoned worker still OWNS the socket's recv, so the caller
+	must close the socket FIRST and issue no further RPC on it (review round-2
+	MAJOR 1: a reclaim RPC would race the worker for frames and lose)."""
 	import threading
 
 	out = {"saw_text": False, "error_text": "", "exc": None, "done": False}
@@ -258,6 +264,7 @@ def _probe_direct_subscription(settings) -> dict:
 	sess = None
 	throwaway = None
 	fired_at = None
+	stream_finished = False
 	try:
 		sess = AgentSession.connect(gateway_url)
 		throwaway = sess.create_session(label=f"jarvis-preflight-{uuid.uuid4().hex[:8]}")
@@ -269,22 +276,23 @@ def _probe_direct_subscription(settings) -> dict:
 			model,
 			provider,
 		)
+		stream_finished = bool(out["done"])
 		if out["saw_text"]:
 			verdict = {"state": "ok", "detail": ""}
 		elif out["error_text"]:
 			verdict = _classify_probe_error(out["error_text"])
 		elif out["exc"] is not None:
 			verdict = _classify_probe_exception(out["exc"], _auth_fault_detail)
-		elif not out["done"]:
+		elif not stream_finished:
 			# Budget expired with the run still going: billed, so cache it.
-			verdict = {"state": "unknown", "detail": "The live check timed out."}
+			verdict = {"state": "timeout", "detail": "The live check timed out."}
 	except AgentUnreachableError as e:
 		verdict = _classify_probe_exception(e, _auth_fault_detail)
 	except Exception:
 		verdict = {"state": "unknown", "detail": ""}
 	finally:
 		if sess is not None:
-			if throwaway:
+			if throwaway and stream_finished:
 				try:
 					# fired_at marks "no active run" untrustworthy until the
 					# grace elapses, so a not-yet-started run is never deleted
@@ -294,6 +302,11 @@ def _probe_direct_subscription(settings) -> dict:
 					)
 				except Exception:
 					pass  # orphan; the gateway's own sweep collects it
+			# On the abandoned-worker path (stream_finished False) the socket
+			# closes FIRST and no reclaim RPC is issued at all: the worker
+			# still owns the recv, so a reclaim would race it for frames and
+			# burn ~10s to lose (review round-2 MAJOR 1). The hourly sweep
+			# collects the throwaway - documented-safe in session_lifecycle.
 			try:
 				sess.close()
 			except Exception:
@@ -308,7 +321,20 @@ def _classify_probe_exception(exc, auth_fault_detail) -> dict:
 	"""An auth fault can arrive as a RAISED gateway rejection, not only as
 	lifecycle error text (jarvis#840 review M1) - title.py handles both
 	surfaces and so must this, or a credential the probe just proved rejected
-	would read as a shrug-grade "unreachable" and open chat anyway."""
+	would read as a shrug-grade "unreachable" and open chat anyway.
+
+	Rate-limit FIRST, same invariant as _classify_probe_error (review round-2
+	MAJOR 2): the auth vocabulary carries a bare "credential" token, and
+	proxied upstreams phrase exhaustion as "credentials exhausted" / "no
+	healthy credential, rate limited" - quota arriving as a refused RPC must
+	still land on the non-blocking side."""
+	parts = [str(exc), str(getattr(exc, "code", "") or "")]
+	details = getattr(exc, "details", None)
+	if isinstance(details, dict):
+		parts.extend(str(v) for v in details.values())
+	text = " ".join(p for p in parts if p)
+	if _RATE_LIMIT_RE.search(text):
+		return {"state": "rate_limit", "detail": str(exc)[:300]}
 	auth_text = None
 	try:
 		auth_text = auth_fault_detail(exc)
@@ -317,6 +343,15 @@ def _classify_probe_exception(exc, auth_fault_detail) -> dict:
 	if auth_text:
 		return {"state": "auth", "detail": str(auth_text)[:300]}
 	return {"state": "unreachable", "detail": str(exc)[:300]}
+
+
+# Auth vocabulary title.py's #738-scoped regex deliberately lacks but a
+# preflight must catch: scope failures phrased without a status code. Kept
+# local rather than widening title's regex, whose scope is pinned by #738.
+_AUTH_SUPPLEMENT_RE = re.compile(
+	r"insufficient authentication|invalid[_ -]?scope",
+	re.IGNORECASE,
+)
 
 
 def _classify_probe_error(text: str) -> dict:
@@ -329,6 +364,6 @@ def _classify_probe_error(text: str) -> dict:
 	detail = (text or "")[:300]
 	if _RATE_LIMIT_RE.search(text or ""):
 		return {"state": "rate_limit", "detail": detail}
-	if _AUTH_FAULT_RE.search(text or ""):
+	if _AUTH_FAULT_RE.search(text or "") or _AUTH_SUPPLEMENT_RE.search(text or ""):
 		return {"state": "auth", "detail": detail}
 	return {"state": "unknown", "detail": detail}

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -92,8 +92,21 @@ def run_chat_preflight() -> dict:
 	unchecked/unknown row by design. Same gate as the wizard's endpoints."""
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
-	integration = _integration_item()
-	usable = _usable_item(settings)
+	# Outer degrade guard, same shape admin grew in #334: a bug anywhere below
+	# must answer as an unchecked/unknown checklist, never a 500 the wizard
+	# has to swallow (round-5 review). The permission gate above still raises.
+	try:
+		integration = _integration_item()
+	except Exception:
+		integration = {
+			"plugin": "unchecked",
+			"persona": "unchecked",
+			"integration_source": "unavailable",
+		}
+	try:
+		usable = _usable_item(settings)
+	except Exception:
+		usable = {"state": "unknown", "detail": "", "source": "none"}
 	return {**integration, "usable": usable}
 
 
@@ -256,19 +269,6 @@ def _probe_direct_subscription(settings) -> dict:
 	cached = cache.get_value(cache_key)
 	if isinstance(cached, dict) and cached.get("state"):
 		return cached
-	# In-flight claim (PR #848 review): the verdict caches only AFTER the probe
-	# completes, so a reload/second tab during the up-to-20s window would fire
-	# a SECOND billed turn. The claim closes that window; the concurrent caller
-	# gets a non-blocking, uncached "still checking" answer and the next
-	# preflight (Retry, reload) reads the finished verdict from the cache.
-	inflight_key = f"{cache_key}:inflight"
-	if cache.get_value(inflight_key):
-		return {
-			"state": "unknown",
-			"detail": "A live check is already running.",
-			"source": "live_probe",
-		}
-	cache.set_value(inflight_key, "1", expires_in_sec=int(_PROBE_BUDGET_S) + 10)
 	from jarvis.chat.agent_client import AgentSession, AgentUnreachableError, oneshot_run_id
 	from jarvis.chat.prewarm import _gateway_ws_url
 	from jarvis.chat.session_lifecycle import reclaim_throwaway_session
@@ -278,6 +278,21 @@ def _probe_direct_subscription(settings) -> dict:
 	gateway_url = _gateway_ws_url(settings)
 	if not gateway_url:
 		return {"state": "unreachable", "detail": "", "source": "live_probe"}
+	# In-flight claim (PR #848 review): the verdict caches only AFTER the probe
+	# completes, so a reload/second tab during the up-to-20s window would fire
+	# a SECOND billed turn. The claim closes that window; the concurrent caller
+	# gets a non-blocking, uncached "still checking" answer and the next
+	# preflight (Retry, reload) reads the finished verdict from the cache.
+	# Claimed only AFTER the no-gateway early return, which bills nothing and
+	# must not leave a 30s "already running" ghost behind (round-5 review).
+	inflight_key = f"{cache_key}:inflight"
+	if cache.get_value(inflight_key):
+		return {
+			"state": "unknown",
+			"detail": "A live check is already running.",
+			"source": "live_probe",
+		}
+	cache.set_value(inflight_key, "1", expires_in_sec=int(_PROBE_BUDGET_S) + 10)
 	model, provider = _resolve_model_and_provider(frappe._dict(model_override=""))
 	verdict = {"state": "unknown", "detail": ""}
 	sess = None

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -306,7 +306,9 @@ def _probe_direct_subscription(settings) -> dict:
 			# closes FIRST and no reclaim RPC is issued at all: the worker
 			# still owns the recv, so a reclaim would race it for frames and
 			# burn ~10s to lose (review round-2 MAJOR 1). The hourly sweep
-			# collects the throwaway - documented-safe in session_lifecycle.
+			# collects the throwaway on the 1h throwaway grace - the
+			# "jarvis-preflight-" prefix is registered in
+			# session_lifecycle._THROWAWAY_LABEL_PREFIXES for exactly this.
 			try:
 				sess.close()
 			except Exception:

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -45,6 +45,9 @@ _PROBE_BUDGET_S = 20
 _PROBE_CACHE_KEY = "jarvis.preflight.probe_verdict"
 _PROBE_CACHE_TTL_S = 30
 _PROBE_CACHE_TTL_UNREACHABLE_S = 5
+# Every verdict detail shown to the customer is trimmed to this (one place,
+# five consumers - PR #848 review).
+_DETAIL_MAX_CHARS = 300
 
 # Provider quota/exhaustion vocabulary, checked BEFORE the auth patterns so
 # quota prose lands on the non-blocking side. Deliberately CONTEXT-BOUND
@@ -133,7 +136,10 @@ def _integration_item() -> dict:
 
 
 def _tri(value) -> str:
-	value = (value or "").lower()
+	# str() first: a type-drifted relay value (bool/int) must degrade to
+	# "unchecked", never raise out of the one endpoint whose contract is that
+	# it cannot refuse (PR #848 review).
+	value = str(value or "").lower()
 	return value if value in ("ok", "degraded", "broken") else "unchecked"
 
 
@@ -181,7 +187,7 @@ def _probe_stored_api_key(settings) -> dict:
 		return {"state": "ok", "detail": "", "source": "key_probe"}
 	if verdict == "fail":
 		return {**_classify_probe_error(message), "source": "key_probe"}
-	return {"state": "unknown", "detail": message[:300], "source": "key_probe"}
+	return {"state": "unknown", "detail": message[:_DETAIL_MAX_CHARS], "source": "key_probe"}
 
 
 def _probe_cache_key(settings) -> str:
@@ -250,6 +256,19 @@ def _probe_direct_subscription(settings) -> dict:
 	cached = cache.get_value(cache_key)
 	if isinstance(cached, dict) and cached.get("state"):
 		return cached
+	# In-flight claim (PR #848 review): the verdict caches only AFTER the probe
+	# completes, so a reload/second tab during the up-to-20s window would fire
+	# a SECOND billed turn. The claim closes that window; the concurrent caller
+	# gets a non-blocking, uncached "still checking" answer and the next
+	# preflight (Retry, reload) reads the finished verdict from the cache.
+	inflight_key = f"{cache_key}:inflight"
+	if cache.get_value(inflight_key):
+		return {
+			"state": "unknown",
+			"detail": "A live check is already running.",
+			"source": "live_probe",
+		}
+	cache.set_value(inflight_key, "1", expires_in_sec=int(_PROBE_BUDGET_S) + 10)
 	from jarvis.chat.agent_client import AgentSession, AgentUnreachableError, oneshot_run_id
 	from jarvis.chat.prewarm import _gateway_ws_url
 	from jarvis.chat.session_lifecycle import reclaim_throwaway_session
@@ -316,6 +335,7 @@ def _probe_direct_subscription(settings) -> dict:
 	verdict["source"] = "live_probe"
 	ttl = _PROBE_CACHE_TTL_UNREACHABLE_S if verdict["state"] == "unreachable" else _PROBE_CACHE_TTL_S
 	cache.set_value(cache_key, verdict, expires_in_sec=ttl)
+	cache.delete_value(inflight_key)
 	return verdict
 
 
@@ -336,15 +356,19 @@ def _classify_probe_exception(exc, auth_fault_detail) -> dict:
 		parts.extend(str(v) for v in details.values())
 	text = " ".join(p for p in parts if p)
 	if _RATE_LIMIT_RE.search(text):
-		return {"state": "rate_limit", "detail": str(exc)[:300]}
+		return {"state": "rate_limit", "detail": str(exc)[:_DETAIL_MAX_CHARS]}
 	auth_text = None
 	try:
 		auth_text = auth_fault_detail(exc)
 	except Exception:
 		auth_text = None
-	if auth_text:
-		return {"state": "auth", "detail": str(auth_text)[:300]}
-	return {"state": "unreachable", "detail": str(exc)[:300]}
+	# The supplement covers BOTH surfaces, same as the title regex it extends:
+	# a scope failure phrased without a status code can arrive as a refused
+	# RPC too, and missing it here would open chat on a rejected credential
+	# (PR #848 review).
+	if auth_text or _AUTH_SUPPLEMENT_RE.search(text):
+		return {"state": "auth", "detail": str(auth_text or exc)[:_DETAIL_MAX_CHARS]}
+	return {"state": "unreachable", "detail": str(exc)[:_DETAIL_MAX_CHARS]}
 
 
 # Auth vocabulary title.py's #738-scoped regex deliberately lacks but a
@@ -363,7 +387,7 @@ def _classify_probe_error(text: str) -> dict:
 	never blocks."""
 	from jarvis.chat.title import _AUTH_FAULT_RE
 
-	detail = (text or "")[:300]
+	detail = (text or "")[:_DETAIL_MAX_CHARS]
 	if _RATE_LIMIT_RE.search(text or ""):
 		return {"state": "rate_limit", "detail": detail}
 	if _AUTH_FAULT_RE.search(text or "") or _AUTH_SUPPLEMENT_RE.search(text or ""):

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -1,0 +1,256 @@
+"""Onboarding chat preflight (jarvis#840).
+
+Readiness (jarvis.account.is_ready_for_chat) proves the config APPLIED;
+nothing proves the connection is USABLE. The 2026-08-14 e2e wired a fresh
+chat subscription perfectly and the FIRST message still failed upstream with
+a quota 429, because no check ever exercises the credential. This module is
+the wizard's last step before chat: one call answering the checklist items
+readiness cannot - plugin wired, persona present, credential actually usable.
+
+Verdict policy (the issue's core constraint): a provider quota/rate-limit is
+NON-BLOCKING - shown honestly, then the customer proceeds; only a genuine
+credential rejection sends them back to the connect form. Anything this
+module cannot determine is "unchecked"/"unknown" and never blocks.
+
+The usable item is leg-discriminated so the live probe is spent only where
+no cheaper verdict exists:
+- pool tenants reuse the pool apply's own persisted probe verdict
+  (last_subscription_status, jarvis_admin_v2#193 classifiers);
+- api-key direct reuses the stateless bench-side key probe (jarvis#679);
+- ONLY the direct-subscription leg (jarvis#715), which has no check at all
+  today, fires one bounded real turn through the tenant's own container
+  (the prewarm precedent: throwaway session, deleted afterward). That turn
+  is billed against the customer's plan, so it is cached briefly and never
+  looped (the prewarm quota incident is the cautionary tale).
+"""
+
+import re
+import time
+import uuid
+
+import frappe
+
+from jarvis import admin_client
+from jarvis.permissions import require_jarvis_admin
+
+_PROBE_PROMPT = "Reply with the single word: ok"
+_PROBE_BUDGET_S = 20
+# One customer clicking through onboarding fires ONE billed probe; a reload
+# or double-entry inside the TTL reuses the verdict instead of re-billing.
+_PROBE_CACHE_KEY = "jarvis.preflight.probe_verdict"
+_PROBE_CACHE_TTL_S = 30
+
+# Provider quota/exhaustion vocabulary, checked BEFORE the auth patterns so
+# "insufficient credit" style messages land on the non-blocking side. The
+# auth side reuses chat/title.py's _AUTH_FAULT_RE (single source, jarvis#738)
+# rather than growing a second, drifting copy.
+_RATE_LIMIT_RE = re.compile(
+	r"\b429\b"
+	r"|rate.?limit|usage.?limit(?:_reached)?|too.?many.?requests"
+	r"|quota|overloaded|exhausted"
+	r"|insufficient|credit|billing",
+	re.IGNORECASE,
+)
+
+
+@frappe.whitelist()
+def run_chat_preflight() -> dict:
+	"""The wizard's pre-chat checklist (jarvis#840). Container health and
+	config-applied are NOT re-derived here - the SPA just watched its own
+	readiness poll turn green and renders those two rows from that verdict.
+	This answers only what readiness cannot:
+
+	{
+	  "plugin":  "ok|degraded|broken|unchecked",
+	  "persona": "ok|degraded|broken|unchecked",
+	  "usable":  {"state": "ok|rate_limit|auth|unreachable|unknown",
+	              "detail": <provider text, trimmed>, "source": ...},
+	}
+
+	Plain dict like ``account.is_ready_for_chat`` (no ok-envelope): this
+	endpoint cannot refuse - every failure shape inside it degrades to an
+	unchecked/unknown row by design. Same gate as the wizard's endpoints."""
+	require_jarvis_admin()
+	settings = frappe.get_single("Jarvis Settings")
+	integration = _integration_item()
+	usable = _usable_item(settings)
+	return {**integration, "usable": usable}
+
+
+def _integration_item() -> dict:
+	"""Plugin/persona tri-states via admin's relay of the fleet probe.
+
+	Cheap probe first; anything not "ok" retries once with deep=1 (the
+	boot-log truth - the static probe cannot see whether the plugin actually
+	registered its tools). EVERY failure shape is "unchecked": an admin
+	without the endpoint (deploy window), an unreachable admin, a malformed
+	answer. An unchecked row renders as "not checked" and never blocks."""
+	unchecked = {"plugin": "unchecked", "persona": "unchecked", "integration_source": "unavailable"}
+	try:
+		data = admin_client.get_integration_status() or {}
+	except admin_client.AdminValidationError as e:
+		if admin_client.is_method_not_found(e):
+			return unchecked
+		return unchecked
+	except Exception:
+		return unchecked
+	tri = data.get("tri_state") or {}
+	plugin = _tri(tri.get("plugin"))
+	persona = _tri(tri.get("persona"))
+	if plugin != "ok" or persona != "ok":
+		# Escalate once to the deep probe: the static one cannot see whether
+		# the plugin actually registered its tools, so a not-ok cheap answer
+		# is a suspicion, not a verdict. Best-effort - on failure the cheap
+		# answer stands.
+		try:
+			deep = admin_client.get_integration_status(deep=True) or {}
+			deep_tri = deep.get("tri_state") or {}
+			plugin = _tri(deep_tri.get("plugin"))
+			persona = _tri(deep_tri.get("persona"))
+			data = deep
+		except Exception:
+			pass
+	return {"plugin": plugin, "persona": persona, "integration_source": data.get("source") or ""}
+
+
+def _tri(value) -> str:
+	value = (value or "").lower()
+	return value if value in ("ok", "degraded", "broken") else "unchecked"
+
+
+def _usable_item(settings) -> dict:
+	"""Leg-discriminated usability verdict; see the module docstring."""
+	from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+	if compute_pool_mode(settings):
+		status = (settings.get("last_subscription_status") or "").strip()
+		if status == "verified":
+			return {"state": "ok", "detail": "", "source": "pool_probe"}
+		# unverified/unchecked/not_applicable: the pool apply's own classifier
+		# had no fresh verdict; do not invent one (and do not bill a second
+		# probe - the pool Test button exists for an explicit re-check).
+		return {"state": "unknown", "detail": "", "source": "pool_probe"}
+	mode = settings.llm_auth_mode or ""
+	if mode == "api_key":
+		return _probe_stored_api_key(settings)
+	if mode == "subscription":
+		return _probe_direct_subscription(settings)
+	return {"state": "unknown", "detail": "", "source": "none"}
+
+
+def _probe_stored_api_key(settings) -> dict:
+	"""Reuse the stateless bench-side key probe (jarvis#679) against the
+	STORED key - persists nothing, never touches the container."""
+	from jarvis.llm_key_probe import test_llm_api_key
+
+	try:
+		res = (
+			test_llm_api_key(
+				provider=settings.llm_provider or "",
+				model=settings.llm_model or "",
+				api_key="",
+				base_url=settings.llm_base_url or "",
+				use_stored_key=1,
+			)
+			or {}
+		)
+	except Exception:
+		return {"state": "unknown", "detail": "", "source": "key_probe"}
+	verdict = res.get("verdict") or ""
+	message = str(res.get("message") or "")
+	if verdict == "pass":
+		return {"state": "ok", "detail": "", "source": "key_probe"}
+	if verdict == "fail":
+		return {**_classify_probe_error(message), "source": "key_probe"}
+	return {"state": "unknown", "detail": message[:300], "source": "key_probe"}
+
+
+def _probe_direct_subscription(settings) -> dict:
+	"""ONE bounded real turn through the tenant's own container - the only
+	honest usability check the direct-subscription leg has (its Test button
+	says so in as many words). Billed, hence the cache; throwaway session,
+	deleted afterward; hard wall-clock budget so the wizard never hangs on a
+	wedged upstream."""
+	cache = frappe.cache()
+	cached = cache.get_value(_PROBE_CACHE_KEY)
+	if isinstance(cached, dict) and cached.get("state"):
+		return cached
+	# Deliberate reuse of the chat pipeline's own private helpers - single
+	# sources for the gateway URL, the model/provider pin, and the auth
+	# vocabulary, so the probe can never drift from what a real first turn
+	# would do (the prewarm module makes the same choice).
+	from jarvis.chat.agent_client import AgentSession, AgentUnreachableError, oneshot_run_id
+	from jarvis.chat.prewarm import _gateway_ws_url
+	from jarvis.chat.turn_handler import _resolve_model_and_provider
+
+	gateway_url = _gateway_ws_url(settings)
+	if not gateway_url:
+		return {"state": "unreachable", "detail": "", "source": "live_probe"}
+	model, provider = _resolve_model_and_provider(frappe._dict(model_override=""))
+	verdict = {"state": "unknown", "detail": ""}
+	sess = None
+	throwaway = None
+	try:
+		sess = AgentSession.connect(gateway_url)
+		throwaway = sess.create_session(label=f"jarvis-preflight-{uuid.uuid4().hex[:8]}")
+		deadline = time.monotonic() + _PROBE_BUDGET_S
+		error_text = ""
+		saw_text = False
+		for event in sess.stream_agent_turn(
+			throwaway,
+			_PROBE_PROMPT,
+			oneshot_run_id("preflight", uuid.uuid4().hex, model=model, provider=provider),
+			model=model or None,
+			provider=provider,
+		):
+			kind = event.get("kind")
+			if kind == "assistant" and (event.get("delta") or event.get("text")):
+				saw_text = True
+				break
+			if kind == "lifecycle" and event.get("phase") == "error":
+				error_text = str(event.get("error") or "")
+				break
+			if kind == "relay:error":
+				error_text = str(event.get("error") or "")
+				break
+			if kind == "lifecycle" and event.get("phase") == "end":
+				break
+			if time.monotonic() > deadline:
+				break
+		if saw_text:
+			verdict = {"state": "ok", "detail": ""}
+		elif error_text:
+			verdict = _classify_probe_error(error_text)
+	except AgentUnreachableError as e:
+		verdict = {"state": "unreachable", "detail": str(e)[:300]}
+	except Exception:
+		verdict = {"state": "unknown", "detail": ""}
+	finally:
+		if sess is not None:
+			if throwaway:
+				try:
+					sess.delete_session(throwaway)
+				except Exception:
+					pass  # orphan; the gateway's own sweep collects it
+			try:
+				sess.close()
+			except Exception:
+				pass
+	verdict["source"] = "live_probe"
+	cache.set_value(_PROBE_CACHE_KEY, verdict, expires_in_sec=_PROBE_CACHE_TTL_S)
+	return verdict
+
+
+def _classify_probe_error(text: str) -> dict:
+	"""Rate-limit BEFORE auth: quota messages routinely contain words like
+	"credit"/"insufficient" and must land on the NON-blocking side (the
+	issue's core constraint). Unclassifiable text is "unknown", which also
+	never blocks."""
+	from jarvis.chat.title import _AUTH_FAULT_RE
+
+	detail = (text or "")[:300]
+	if _RATE_LIMIT_RE.search(text or ""):
+		return {"state": "rate_limit", "detail": detail}
+	if _AUTH_FAULT_RE.search(text or ""):
+		return {"state": "auth", "detail": detail}
+	return {"state": "unknown", "detail": detail}

--- a/jarvis/tests/test_preflight.py
+++ b/jarvis/tests/test_preflight.py
@@ -171,7 +171,8 @@ class TestPreflight(_RT3SettingsTestCase):
 		# run re-creates the session as an orphan or kills the run) - the
 		# reclaim helper, with fired_at so a not-yet-started run is protected.
 		reclaim.assert_called_once()
-		self.assertEqual(reclaim.call_args.args[1], sess.created and "throwaway-0")
+		self.assertTrue(sess.created, "the probe must have opened its throwaway session")
+		self.assertEqual(reclaim.call_args.args[1], "throwaway-0")
 		self.assertIsNotNone(reclaim.call_args.kwargs.get("fired_at"))
 		self.assertTrue(sess.closed)
 
@@ -230,17 +231,21 @@ class TestPreflight(_RT3SettingsTestCase):
 
 		with (
 			patch("jarvis.chat.agent_client.AgentSession", _Conn),
-			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session") as reclaim,
 			patch.object(preflight, "_PROBE_BUDGET_S", 0.2),
 		):
 			t0 = _time.monotonic()
 			item = preflight._usable_item(s)
 			elapsed = _time.monotonic() - t0
+		# Round-2 MAJOR 1: the abandoned worker still owns the socket's recv,
+		# so no reclaim RPC may be issued on it - close only, sweep collects.
+		reclaim.assert_not_called()
 		self.assertLess(elapsed, 1.5, "the probe must not wait out the stream's own deadline")
-		self.assertEqual(item["state"], "unknown")
+		self.assertEqual(item["state"], "timeout")
 		self.assertIn("timed out", item["detail"])
+		self.assertTrue(sess.closed, "the abandoned worker's socket must be closed")
 		cached = frappe.cache().get_value(preflight._probe_cache_key(s))
-		self.assertEqual((cached or {}).get("state"), "unknown", "a billed timeout must cache")
+		self.assertEqual((cached or {}).get("state"), "timeout", "a billed timeout must cache")
 
 	def test_live_probe_connect_failure_is_unreachable(self):
 		from jarvis.chat.agent_client import AgentUnreachableError
@@ -252,19 +257,48 @@ class TestPreflight(_RT3SettingsTestCase):
 			def connect(*a, **kw):
 				raise AgentUnreachableError("gateway down")
 
-		with patch("jarvis.chat.agent_client.AgentSession", _Conn):
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", _Conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+		):
 			item = preflight._usable_item(s)
 		self.assertEqual(item["state"], "unreachable")
 
 	def test_live_probe_verdict_is_cached_not_rebilled(self):
 		s = self._direct_sub()
 		sess, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])
-		with patch("jarvis.chat.agent_client.AgentSession", conn):
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+		):
 			first = preflight._usable_item(s)
 			second = preflight._usable_item(s)
 		self.assertEqual(first["state"], "ok")
 		self.assertEqual(second["state"], "ok")
 		self.assertEqual(len(sess.created), 1, "a repeat inside the TTL must not bill again")
+
+	def test_live_probe_quota_arriving_as_a_refused_rpc_is_rate_limit(self):
+		"""Round-2 MAJOR 2: proxied upstreams phrase exhaustion as refused RPCs
+		naming the credential ("credentials exhausted, rate limited"); the
+		bare "credential" token in the auth vocabulary must not gate chat shut
+		on what is a quota condition."""
+		from jarvis.chat.agent_client import AgentUnreachableError
+
+		s = self._direct_sub()
+		boom = AgentUnreachableError("agent rejected: no healthy credential, rate limited")
+		sess = _FakeSession([], raise_exc=boom)
+
+		class _Conn:
+			@staticmethod
+			def connect(*a, **kw):
+				return sess
+
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", _Conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+		):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "rate_limit")
 
 	# -- classification order --------------------------------------------------
 

--- a/jarvis/tests/test_preflight.py
+++ b/jarvis/tests/test_preflight.py
@@ -25,9 +25,10 @@ class _FakeSession:
 	"""Signature-compatible AgentSession stand-in (the admin#330 CI trap:
 	kwargs-only fakes die on real positional args BEFORE assertions run)."""
 
-	def __init__(self, events):
+	def __init__(self, events, raise_exc=None, stall_s=0.0):
 		self._events = events
-		self.deleted = []
+		self._raise = raise_exc
+		self._stall_s = stall_s
 		self.closed = False
 		self.created = []
 
@@ -37,10 +38,16 @@ class _FakeSession:
 		return key
 
 	def stream_agent_turn(self, *a, **kw):
+		import time as _time
+
+		if self._stall_s:
+			_time.sleep(self._stall_s)
+		if self._raise is not None:
+			raise self._raise
 		yield from self._events
 
 	def delete_session(self, *a, **kw):
-		self.deleted.append(a[0] if a else kw.get("session_key"))
+		pass  # reclaim_throwaway_session owns deletion; patched in tests
 
 	def close(self, *a, **kw):
 		self.closed = True
@@ -55,11 +62,12 @@ class TestPreflight(_RT3SettingsTestCase):
 		s.db_set("llm_pool_synced_at", None, update_modified=False)
 		s.db_set("llm_direct_synced_at", None, update_modified=False)
 		s.db_set("agent_url", "http://tenant.example:19060", update_modified=False)
-		frappe.cache().delete_value(preflight._PROBE_CACHE_KEY)
+		s.db_set("llm_last_apply_fingerprint", "", update_modified=False)
+		frappe.cache().delete_value(preflight._probe_cache_key(s))
 		frappe.db.commit()
 
 	def tearDown(self):
-		frappe.cache().delete_value(preflight._PROBE_CACHE_KEY)
+		frappe.cache().delete_value(preflight._probe_cache_key(frappe.get_single("Jarvis Settings")))
 
 	def _fake_connect(self, events):
 		sess = _FakeSession(events)
@@ -79,11 +87,28 @@ class TestPreflight(_RT3SettingsTestCase):
 	# -- integration rows ------------------------------------------------------
 
 	def test_integration_unchecked_on_any_admin_failure(self):
-		for boom in (Exception("down"), frappe.ValidationError("no such method")):
-			with patch("jarvis.admin_client.get_integration_status", side_effect=boom):
+		from jarvis.admin_client import AdminValidationError
+
+		method_not_found = AdminValidationError(
+			"Failed to get method for command jarvis_admin_v2.api.tenant.integration_status"
+		)
+		for boom in (Exception("down"), method_not_found):
+			with patch("jarvis.admin_client.get_integration_status", side_effect=boom) as m:
 				item = preflight._integration_item()
+			self.assertEqual(m.call_count, 1, "a failed admin round trip must not be retried deep")
 			self.assertEqual(item["plugin"], "unchecked")
 			self.assertEqual(item["persona"], "unchecked")
+
+	def test_integration_cached_not_ok_is_not_escalated(self):
+		"""Review M3: a cached/none answer means the fleet call already failed
+		or there is no container - the deep retry would pay a second full
+		round trip to meet the same wall."""
+		with patch(
+			"jarvis.admin_client.get_integration_status",
+			return_value={"tri_state": {"plugin": "unchecked", "persona": "unchecked"}, "source": "cached"},
+		) as m:
+			preflight._integration_item()
+		self.assertEqual(m.call_count, 1)
 
 	def test_integration_ok_needs_no_deep_probe(self):
 		with patch(
@@ -135,11 +160,19 @@ class TestPreflight(_RT3SettingsTestCase):
 	def test_live_probe_ok_on_first_token_and_cleans_up(self):
 		s = self._direct_sub()
 		sess, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])
-		with patch("jarvis.chat.agent_client.AgentSession", conn):
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session") as reclaim,
+		):
 			item = preflight._usable_item(s)
 		self.assertEqual(item["state"], "ok")
 		self.assertEqual(item["source"], "live_probe")
-		self.assertEqual(len(sess.deleted), 1, "the billed throwaway session must be deleted")
+		# NEVER a bare delete_session (jarvis#525/#535: deleting under a live
+		# run re-creates the session as an orphan or kills the run) - the
+		# reclaim helper, with fired_at so a not-yet-started run is protected.
+		reclaim.assert_called_once()
+		self.assertEqual(reclaim.call_args.args[1], sess.created and "throwaway-0")
+		self.assertIsNotNone(reclaim.call_args.kwargs.get("fired_at"))
 		self.assertTrue(sess.closed)
 
 	def test_live_probe_quota_429_is_rate_limit(self):
@@ -152,10 +185,62 @@ class TestPreflight(_RT3SettingsTestCase):
 
 	def test_live_probe_credential_rejection_is_auth(self):
 		s = self._direct_sub()
-		_, conn = self._fake_connect([{"kind": "relay:error", "state": "error", "error": _AUTH_TEXT}])
+		_, conn = self._fake_connect([{"kind": "lifecycle", "phase": "error", "error": _AUTH_TEXT}])
 		with patch("jarvis.chat.agent_client.AgentSession", conn):
 			item = preflight._usable_item(s)
 		self.assertEqual(item["state"], "auth")
+
+	def test_live_probe_raised_auth_fault_is_auth_not_unreachable(self):
+		"""Review M1: an auth fault can arrive as a RAISED gateway rejection
+		(agent RPC refused), not only as lifecycle error text. Mapping it to
+		"unreachable" would open chat on a credential the probe just proved
+		rejected."""
+		from jarvis.chat.agent_client import AgentUnreachableError
+
+		s = self._direct_sub()
+		boom = AgentUnreachableError(f"agent rejected: INVALID_REQUEST: {_AUTH_TEXT}")
+		sess = _FakeSession([], raise_exc=boom)
+
+		class _Conn:
+			@staticmethod
+			def connect(*a, **kw):
+				return sess
+
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", _Conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+		):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "auth")
+
+	def test_live_probe_hard_budget_never_hangs_the_request(self):
+		"""Review B2: stream_agent_turn's own deadline is the chat turn's 600s
+		and it can block long before its first yield. The probe must come back
+		within its OWN budget with a non-blocking verdict, and cache it (the
+		run was billed)."""
+		s = self._direct_sub()
+		sess = _FakeSession([{"kind": "lifecycle", "phase": "end"}], stall_s=2.0)
+
+		class _Conn:
+			@staticmethod
+			def connect(*a, **kw):
+				return sess
+
+		import time as _time
+
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", _Conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+			patch.object(preflight, "_PROBE_BUDGET_S", 0.2),
+		):
+			t0 = _time.monotonic()
+			item = preflight._usable_item(s)
+			elapsed = _time.monotonic() - t0
+		self.assertLess(elapsed, 1.5, "the probe must not wait out the stream's own deadline")
+		self.assertEqual(item["state"], "unknown")
+		self.assertIn("timed out", item["detail"])
+		cached = frappe.cache().get_value(preflight._probe_cache_key(s))
+		self.assertEqual((cached or {}).get("state"), "unknown", "a billed timeout must cache")
 
 	def test_live_probe_connect_failure_is_unreachable(self):
 		from jarvis.chat.agent_client import AgentUnreachableError
@@ -186,12 +271,22 @@ class TestPreflight(_RT3SettingsTestCase):
 	def test_quota_wins_over_auth_vocabulary(self):
 		"""Quota prose routinely contains words like credit; it must stay on
 		the NON-blocking side even when auth words co-occur."""
-		verdict = preflight._classify_probe_error("insufficient credit for this credential")
+		verdict = preflight._classify_probe_error("insufficient credit balance for this credential")
 		self.assertEqual(verdict["state"], "rate_limit")
 		self.assertEqual(
 			preflight._classify_probe_error("some entirely novel upstream failure")["state"],
 			"unknown",
 		)
+
+	def test_scope_failures_are_auth_not_rate_limit(self):
+		"""Review M2: the quota vocabulary is context-bound, so a genuine
+		credential/permission failure that happens to say "insufficient" never
+		lands on the non-blocking side."""
+		verdict = preflight._classify_probe_error(
+			"Google Generative AI API error (403): PERMISSION_DENIED: "
+			"Request had insufficient authentication scopes."
+		)
+		self.assertEqual(verdict["state"], "auth")
 
 	# -- endpoint envelope -----------------------------------------------------
 

--- a/jarvis/tests/test_preflight.py
+++ b/jarvis/tests/test_preflight.py
@@ -64,10 +64,13 @@ class TestPreflight(_RT3SettingsTestCase):
 		s.db_set("agent_url", "http://tenant.example:19060", update_modified=False)
 		s.db_set("llm_last_apply_fingerprint", "", update_modified=False)
 		frappe.cache().delete_value(preflight._probe_cache_key(s))
+		frappe.cache().delete_value(f"{preflight._probe_cache_key(s)}:inflight")
 		frappe.db.commit()
 
 	def tearDown(self):
-		frappe.cache().delete_value(preflight._probe_cache_key(frappe.get_single("Jarvis Settings")))
+		key = preflight._probe_cache_key(frappe.get_single("Jarvis Settings"))
+		frappe.cache().delete_value(key)
+		frappe.cache().delete_value(f"{key}:inflight")
 
 	def _fake_connect(self, events):
 		sess = _FakeSession(events)
@@ -276,6 +279,47 @@ class TestPreflight(_RT3SettingsTestCase):
 		self.assertEqual(first["state"], "ok")
 		self.assertEqual(second["state"], "ok")
 		self.assertEqual(len(sess.created), 1, "a repeat inside the TTL must not bill again")
+
+	def test_inflight_claim_never_double_bills(self):
+		"""PR #848 review: the verdict caches only after the probe completes, so
+		a reload during the up-to-20s window fired a SECOND billed turn. The
+		in-flight claim answers the concurrent caller without a session."""
+		s = self._direct_sub()
+		frappe.cache().set_value(f"{preflight._probe_cache_key(s)}:inflight", "1", expires_in_sec=30)
+		sess, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+		):
+			item = preflight._usable_item(s)
+		self.assertEqual(sess.created, [], "a concurrent caller must not open a billed session")
+		self.assertEqual(item["state"], "unknown")
+		self.assertIn("already running", item["detail"])
+		self.assertIsNone(
+			frappe.cache().get_value(preflight._probe_cache_key(s)),
+			"the still-checking answer must not be cached as a verdict",
+		)
+
+	def test_scope_failure_arriving_as_a_refused_rpc_is_auth(self):
+		"""PR #848 review: the supplement vocabulary covers BOTH surfaces - a
+		scope rejection can arrive as a raised RPC refusal too."""
+		from jarvis.chat.agent_client import AgentUnreachableError
+
+		s = self._direct_sub()
+		boom = AgentUnreachableError("Request had insufficient authentication scopes")
+		sess = _FakeSession([], raise_exc=boom)
+
+		class _Conn:
+			@staticmethod
+			def connect(*a, **kw):
+				return sess
+
+		with (
+			patch("jarvis.chat.agent_client.AgentSession", _Conn),
+			patch("jarvis.chat.session_lifecycle.reclaim_throwaway_session"),
+		):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "auth")
 
 	def test_live_probe_quota_arriving_as_a_refused_rpc_is_rate_limit(self):
 		"""Round-2 MAJOR 2: proxied upstreams phrase exhaustion as refused RPCs

--- a/jarvis/tests/test_preflight.py
+++ b/jarvis/tests/test_preflight.py
@@ -324,7 +324,18 @@ class TestPreflight(_RT3SettingsTestCase):
 
 	# -- endpoint envelope -----------------------------------------------------
 
+	def test_sweep_knows_the_preflight_label(self):
+		"""The abandoned-worker timeout path leans on the hourly sweep; an
+		unregistered label would fall to the 24h orphan grace instead of the
+		1h throwaway one (round-3 review)."""
+		from jarvis.chat.session_lifecycle import _THROWAWAY_LABEL_PREFIXES
+
+		self.assertIn("jarvis-preflight-", _THROWAWAY_LABEL_PREFIXES)
+
 	def test_endpoint_shape(self):
+		# Deliberately does NOT patch reclaim_throwaway_session: this is the
+		# one test exercising the real helper's swallow against a session that
+		# will not answer its probe - production behavior, keep it covered.
 		s = self._direct_sub()
 		s.db_set("last_sync_at", now(), update_modified=False)
 		_, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])

--- a/jarvis/tests/test_preflight.py
+++ b/jarvis/tests/test_preflight.py
@@ -1,0 +1,212 @@
+"""jarvis#840: the pre-chat preflight answers what readiness cannot.
+
+Pins the verdict policy: a provider quota/429 classifies rate_limit (NON-
+blocking by contract), only a genuine credential rejection classifies auth,
+everything undeterminable is unchecked/unknown and never an error. Pins the
+leg discrimination (pool reuses its persisted verdict, api-key reuses the
+bench key probe, only direct-subscription fires the live turn), the deep
+escalation of a not-ok integration answer, the billed-probe cache, and the
+throwaway session's cleanup."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.utils import now
+
+from jarvis import preflight
+from jarvis.tests.test_settings_on_update import _reset_settings
+from jarvis.tests.test_unified_llm_config import _RT3SettingsTestCase
+
+_QUOTA_TEXT = "OpenAI API error (429): usage_limit_reached - your plan is out of messages"
+_AUTH_TEXT = "OpenAI API error (401): Incorrect API key provided"
+
+
+class _FakeSession:
+	"""Signature-compatible AgentSession stand-in (the admin#330 CI trap:
+	kwargs-only fakes die on real positional args BEFORE assertions run)."""
+
+	def __init__(self, events):
+		self._events = events
+		self.deleted = []
+		self.closed = False
+		self.created = []
+
+	def create_session(self, *a, **kw):
+		key = f"throwaway-{len(self.created)}"
+		self.created.append(kw.get("label") or (a[0] if a else ""))
+		return key
+
+	def stream_agent_turn(self, *a, **kw):
+		yield from self._events
+
+	def delete_session(self, *a, **kw):
+		self.deleted.append(a[0] if a else kw.get("session_key"))
+
+	def close(self, *a, **kw):
+		self.closed = True
+
+
+class TestPreflight(_RT3SettingsTestCase):
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		_reset_settings()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("llm_pool_synced_at", None, update_modified=False)
+		s.db_set("llm_direct_synced_at", None, update_modified=False)
+		s.db_set("agent_url", "http://tenant.example:19060", update_modified=False)
+		frappe.cache().delete_value(preflight._PROBE_CACHE_KEY)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.cache().delete_value(preflight._PROBE_CACHE_KEY)
+
+	def _fake_connect(self, events):
+		sess = _FakeSession(events)
+
+		class _Conn:
+			@staticmethod
+			def connect(*a, **kw):
+				return sess
+
+		return sess, _Conn
+
+	def _direct_sub(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("llm_auth_mode", "subscription", update_modified=False)
+		return s
+
+	# -- integration rows ------------------------------------------------------
+
+	def test_integration_unchecked_on_any_admin_failure(self):
+		for boom in (Exception("down"), frappe.ValidationError("no such method")):
+			with patch("jarvis.admin_client.get_integration_status", side_effect=boom):
+				item = preflight._integration_item()
+			self.assertEqual(item["plugin"], "unchecked")
+			self.assertEqual(item["persona"], "unchecked")
+
+	def test_integration_ok_needs_no_deep_probe(self):
+		with patch(
+			"jarvis.admin_client.get_integration_status",
+			return_value={"tri_state": {"plugin": "ok", "persona": "ok"}, "source": "live"},
+		) as m:
+			item = preflight._integration_item()
+		self.assertEqual(m.call_count, 1, "an all-ok cheap probe must not pay the deep one")
+		self.assertEqual((item["plugin"], item["persona"]), ("ok", "ok"))
+
+	def test_integration_escalates_once_to_the_deep_probe(self):
+		answers = [
+			{"tri_state": {"plugin": "degraded", "persona": "ok"}, "source": "live"},
+			{"tri_state": {"plugin": "ok", "persona": "ok"}, "source": "live"},
+		]
+		with patch("jarvis.admin_client.get_integration_status", side_effect=answers) as m:
+			item = preflight._integration_item()
+		self.assertEqual(m.call_count, 2)
+		self.assertTrue(m.call_args_list[1].kwargs.get("deep"), "the retry must be the deep probe")
+		self.assertEqual((item["plugin"], item["persona"]), ("ok", "ok"))
+
+	# -- usable: leg discrimination -------------------------------------------
+
+	def test_pool_leg_reuses_the_persisted_verdict(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_subscription_status", "verified", update_modified=False)
+		with (
+			patch("jarvis.jarvis.pool_serialize.compute_pool_mode", return_value=True),
+			patch("jarvis.chat.agent_client.AgentSession") as never,
+		):
+			item = preflight._usable_item(s)
+		never.connect.assert_not_called()
+		self.assertEqual(item["state"], "ok")
+		self.assertEqual(item["source"], "pool_probe")
+
+	def test_api_key_leg_reuses_the_bench_key_probe(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("llm_auth_mode", "api_key", update_modified=False)
+		with patch(
+			"jarvis.llm_key_probe.test_llm_api_key",
+			return_value={"ok": False, "verdict": "fail", "message": _QUOTA_TEXT},
+		) as probe:
+			item = preflight._usable_item(s)
+		self.assertTrue(probe.call_args.kwargs.get("use_stored_key"))
+		self.assertEqual(item["state"], "rate_limit", "a key probe 429 is non-blocking too")
+
+	# -- usable: the direct-subscription live turn -----------------------------
+
+	def test_live_probe_ok_on_first_token_and_cleans_up(self):
+		s = self._direct_sub()
+		sess, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])
+		with patch("jarvis.chat.agent_client.AgentSession", conn):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "ok")
+		self.assertEqual(item["source"], "live_probe")
+		self.assertEqual(len(sess.deleted), 1, "the billed throwaway session must be deleted")
+		self.assertTrue(sess.closed)
+
+	def test_live_probe_quota_429_is_rate_limit(self):
+		s = self._direct_sub()
+		_, conn = self._fake_connect([{"kind": "lifecycle", "phase": "error", "error": _QUOTA_TEXT}])
+		with patch("jarvis.chat.agent_client.AgentSession", conn):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "rate_limit")
+		self.assertIn("usage_limit_reached", item["detail"])
+
+	def test_live_probe_credential_rejection_is_auth(self):
+		s = self._direct_sub()
+		_, conn = self._fake_connect([{"kind": "relay:error", "state": "error", "error": _AUTH_TEXT}])
+		with patch("jarvis.chat.agent_client.AgentSession", conn):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "auth")
+
+	def test_live_probe_connect_failure_is_unreachable(self):
+		from jarvis.chat.agent_client import AgentUnreachableError
+
+		s = self._direct_sub()
+
+		class _Conn:
+			@staticmethod
+			def connect(*a, **kw):
+				raise AgentUnreachableError("gateway down")
+
+		with patch("jarvis.chat.agent_client.AgentSession", _Conn):
+			item = preflight._usable_item(s)
+		self.assertEqual(item["state"], "unreachable")
+
+	def test_live_probe_verdict_is_cached_not_rebilled(self):
+		s = self._direct_sub()
+		sess, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])
+		with patch("jarvis.chat.agent_client.AgentSession", conn):
+			first = preflight._usable_item(s)
+			second = preflight._usable_item(s)
+		self.assertEqual(first["state"], "ok")
+		self.assertEqual(second["state"], "ok")
+		self.assertEqual(len(sess.created), 1, "a repeat inside the TTL must not bill again")
+
+	# -- classification order --------------------------------------------------
+
+	def test_quota_wins_over_auth_vocabulary(self):
+		"""Quota prose routinely contains words like credit; it must stay on
+		the NON-blocking side even when auth words co-occur."""
+		verdict = preflight._classify_probe_error("insufficient credit for this credential")
+		self.assertEqual(verdict["state"], "rate_limit")
+		self.assertEqual(
+			preflight._classify_probe_error("some entirely novel upstream failure")["state"],
+			"unknown",
+		)
+
+	# -- endpoint envelope -----------------------------------------------------
+
+	def test_endpoint_shape(self):
+		s = self._direct_sub()
+		s.db_set("last_sync_at", now(), update_modified=False)
+		_, conn = self._fake_connect([{"kind": "assistant", "text": "ok", "delta": "ok"}])
+		with (
+			patch(
+				"jarvis.admin_client.get_integration_status",
+				return_value={"tri_state": {"plugin": "ok", "persona": "ok"}, "source": "live"},
+			),
+			patch("jarvis.chat.agent_client.AgentSession", conn),
+		):
+			data = preflight.run_chat_preflight()
+		self.assertEqual(data["plugin"], "ok")
+		self.assertEqual(data["persona"], "ok")
+		self.assertEqual(data["usable"]["state"], "ok")


### PR DESCRIPTION
Fixes #840. Depends on Aerele-RnD/jarvis-admin-v2's `api.tenant.integration_status` relay (degrades to "not checked" until that deploys).

## Summary

The step-2 "Giving Jarvis a brain" wait is now a real preflight checklist: before the wizard opens chat it verifies the plugin is wired, the persona is present, and the connection is actually usable, instead of dropping the customer into a chat whose first message dies upstream (the live 2026-08-14 e2e: perfect wiring, then a quota 429 nothing had checked).

## What changed
- One preflight gate at the wizard's single navigation chokepoint, covering all three arrival paths including the instant-green case.
- Usability is leg-discriminated: pool tenants reuse the pool apply's persisted probe verdict, api-key tenants reuse the bench key probe against the stored key, and only the direct-subscription leg (which has no check at all today) fires one bounded, cached, throwaway-session live turn through the real container.
- Verdict policy per the issue: a provider usage limit shows an honest line and never blocks; only a genuine credential rejection returns the customer to the connect form with the provider's own sentence; everything undeterminable is "not checked" and never blocks; a preflight that itself fails is skipped entirely.
- The wait screen's phase list gains three checklist rows (tools, persona, live check); all-green flashes in well under a second plus one probe round trip.

## Risk and verification
- Fail-open by construction, proven live: the endpoint driven with zero mocks on a blank bench site answered in 0.13s with every row degraded and nothing raised.
- 12 new backend tests (classification order, leg discrimination, deep escalation, probe cache, session cleanup) and 4 new wizard specs; full frontend suite 1242 green on Node 24.
- The all-green live path (real ChatGPT subscription) is the scheduled post-merge from-scratch onboarding e2e.

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (cut from upstream/develop today)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff (plus a 4-round adversarial review to GREEN)
