### PR TITLE
Onboarding: consent + lead capture + Terms & Conditions gate

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -372,6 +372,18 @@ export const getAccountDefaults = () => call("jarvis.onboarding.get_account_defa
 export const getCompanyOnboardingDefaults = (company) =>
 	call("jarvis.onboarding.get_company_onboarding_defaults", { company });
 export const syncConnection = () => call("jarvis.onboarding.sync_connection");
+// Lead-capture + T&C frozen contract. Fire-and-forget upsert of a Jarvis Lead
+// on entering the Plan step - the CALLER is responsible for not awaiting this
+// in a way that blocks the step transition and for swallowing rejections
+// (this wrapper does not catch; jarvis.onboarding.capture_onboarding_lead
+// itself never raises, but the underlying frappe-ui `call` can still reject
+// on a network failure).
+export const captureOnboardingLead = (payload) =>
+	call("jarvis.onboarding.capture_onboarding_lead", payload || {});
+// The admin-hosted Terms & Conditions URL for the Review & Pay checkbox link.
+// Best-effort ({url: ""} on any failure) - the view falls back to plain
+// unlinked text rather than gating the checkbox on this fetch.
+export const getTermsUrl = () => call("jarvis.onboarding.get_terms_url");
 export const startSignup = (email, company, plan, provider, billing) =>
 	call("jarvis.onboarding.start_signup", { email, company, plan, provider, billing });
 // Authenticated billing-only edit (Plan 01, post-intent Review & Pay "Edit"):
@@ -434,7 +446,10 @@ async function rawOnboardingCall(method, args, opts = {}) {
 export const onboardingPaymentApi = {
 	getOnboardingState: (opts) =>
 		rawOnboardingCall("jarvis.onboarding.get_onboarding_state", {}, opts),
-	startSignup: ({ email, company, plan, provider, billing, partner_code }, opts) =>
+	startSignup: (
+		{ email, company, plan, provider, billing, partner_code, terms_accepted, contact_consent },
+		opts
+	) =>
 		// Plan 01: the normalized billing snapshot rides the FIRST signup call so it
 		// persists server-side while the customer is still a guest (update_billing is
 		// authenticated and unreachable mid-signup). Included only when present - an
@@ -443,6 +458,10 @@ export const onboardingPaymentApi = {
 		// partner_code: an optional TOP-LEVEL kwarg (never inside billing), same
 		// omit-when-absent shape - an older admin that doesn't know the kwarg drops
 		// it and the signup proceeds exactly as before.
+		// terms_accepted / contact_consent (T&C + lead-capture frozen contract): sent
+		// UNCONDITIONALLY, unlike billing/partner_code above - the view only calls
+		// this once the required Review & Pay checkbox is ticked, and admin's
+		// acceptance check needs to see the real value, not an omitted key.
 		rawOnboardingCall(
 			"jarvis.onboarding.start_signup",
 			{
@@ -452,6 +471,8 @@ export const onboardingPaymentApi = {
 				provider,
 				...(billing ? { billing } : {}),
 				...(partner_code ? { partner_code } : {}),
+				terms_accepted,
+				contact_consent,
 			},
 			opts
 		),

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -136,6 +136,12 @@ export function useBillingDetails(opts = {}) {
 	// deliberately dumb: last write wins, no provenance, because unlike the billing
 	// fields nothing auto-fills these behind the customer's back.
 	const identity = reactive({ email: "", company: "" });
+	// Details-step OPTIONAL "okay to contact me" checkbox (lead-capture + T&C
+	// frozen contract). Lives here, not on the wizard's own `state`, for the same
+	// reason as `identity`: it rides the localStorage snapshot so a mid-flow
+	// reload or a checkout round trip does not silently lose an explicit "yes".
+	// Never auto-set - only the customer's own click flips it true.
+	const consent = ref(false);
 	// Provenance of the last-applied ERP defaults, forwarded to admin so it can
 	// record where the snapshot originated. Never rendered on Review & Pay.
 	const sourceCompany = ref("");
@@ -230,6 +236,13 @@ export function useBillingDetails(opts = {}) {
 		persist();
 	}
 
+	// The Details-step "It's okay to contact me" checkbox. Explicit boolean only
+	// - never inferred from anything else on the form.
+	function setConsent(value) {
+		consent.value = !!value;
+		persist();
+	}
+
 	function persist() {
 		if (!storage) return;
 		try {
@@ -242,6 +255,7 @@ export function useBillingDetails(opts = {}) {
 					gstin: fields.gstin.value,
 					email: identity.email,
 					company: identity.company,
+					contact_consent: consent.value,
 					// Stamped on every write so restore() can bound how long this PII
 					// lives, whatever happens to the session that wrote it.
 					saved_at: now(),
@@ -299,6 +313,13 @@ export function useBillingDetails(opts = {}) {
 				identity[name] = v;
 				any = true;
 			}
+		}
+		// Same "only ever restore forward" rule as identity: a stored `true` wins;
+		// a stored `false`/absent leaves whatever this mount already has (never
+		// flips an explicit in-session "yes" back to unchecked).
+		if (d && d.contact_consent && !consent.value) {
+			consent.value = true;
+			any = true;
 		}
 		return any;
 	}
@@ -414,6 +435,8 @@ export function useBillingDetails(opts = {}) {
 		fields,
 		identity,
 		setIdentity,
+		consent,
+		setConsent,
 		finish,
 		billingSaved,
 		sourceCompany,

--- a/frontend/src/onboarding/usePaymentFlow.js
+++ b/frontend/src/onboarding/usePaymentFlow.js
@@ -414,7 +414,16 @@ export function createPaymentFlow(deps) {
 	}
 
 	// ---- submit review: start the signup exactly once ----------------------
-	async function submitReview({ email, company, plan, provider, billing, partner_code } = {}) {
+	async function submitReview({
+		email,
+		company,
+		plan,
+		provider,
+		billing,
+		partner_code,
+		terms_accepted,
+		contact_consent,
+	} = {}) {
 		const my = beginAction(null); // SUBMIT_REVIEW sets the busy flag itself
 		if (!my) return; // a burst of clicks produces exactly one start (P1-2)
 		try {
@@ -426,11 +435,25 @@ export function createPaymentFlow(deps) {
 				// caller passes nothing, so an empty object never crosses the wire.
 				// partner_code is a separate, optional top-level kwarg - never nested
 				// inside billing - forwarded to admin verbatim; jarvis does no validation.
+				// terms_accepted / contact_consent: the T&C + lead-capture frozen
+				// contract's two new kwargs. The view only ever calls submitReview with
+				// terms_accepted true (the Review & Pay checkbox gates the Pay click);
+				// forwarded here unconditionally so admin's required-acceptance check
+				// sees exactly what the customer ticked.
 				decoded = ingest(
 					await deadlined(
 						(signal) =>
 							api.startSignup(
-								{ email, company, plan, provider, billing, partner_code },
+								{
+									email,
+									company,
+									plan,
+									provider,
+									billing,
+									partner_code,
+									terms_accepted,
+									contact_consent,
+								},
 								{ signal }
 							),
 						fetchDeadlineMs,

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -22,6 +22,8 @@ const api = vi.hoisted(() => ({
 	startSignup: vi.fn(async () => ({})),
 	finishPayment: vi.fn(async () => ({})),
 	syncConnection: vi.fn(async () => ({})),
+	captureOnboardingLead: vi.fn(async () => ({ ok: true })),
+	getTermsUrl: vi.fn(async () => ({ url: "" })),
 	getLlmApplyOperation: vi.fn(),
 	// The cutover's payment flow (plan-09) instantiates from this map at setup and
 	// hydrates on mount. A benign no-signup envelope lets the view mount and reconcile
@@ -107,6 +109,13 @@ vi.mock("frappe-ui", () => {
 		Button: stub("Button"),
 		FormControl: stub("FormControl", "input"),
 		FeatherIcon: stub("FeatherIcon", "span"),
+		Checkbox: {
+			name: "Checkbox",
+			props: ["modelValue", "label", "id"],
+			emits: ["update:modelValue"],
+			template:
+				'<input type="checkbox" :id="id" :checked="!!modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+		},
 		ErrorMessage: {
 			name: "ErrorMessage",
 			props: ["message"],

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -31,6 +31,8 @@ const api = vi.hoisted(() => ({
 	checkAccountReconnect: vi.fn(async () => ({})),
 	redeemReconnectCode: vi.fn(async () => ({})),
 	getAccountDefaults: vi.fn(async () => ({})),
+	captureOnboardingLead: vi.fn(async () => ({ ok: true })),
+	getTermsUrl: vi.fn(async () => ({ url: "" })),
 	onboardingPaymentApi: {
 		getOnboardingState: vi.fn(async () => ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })),
 		startSignup: vi.fn(),
@@ -56,6 +58,13 @@ vi.mock("frappe-ui", () => ({
 		template: '<div v-if="message">{{ message }}</div>',
 	},
 	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	Checkbox: {
+		name: "Checkbox",
+		props: ["modelValue", "label", "id"],
+		emits: ["update:modelValue"],
+		template:
+			'<input type="checkbox" :id="id" :checked="!!modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+	},
 	call: vi.fn(),
 	dayjs: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
 	toast: { error: vi.fn(), success: vi.fn() },
@@ -681,5 +690,97 @@ describe("812: Company field is constrained once ERPNext has real Company record
 		await flushPromises();
 		const combo = wrapper.find("jv-combo-stub");
 		expect(combo.attributes("allowcustom")).toBe("true");
+	});
+});
+
+describe("lead-capture + T&C (frozen contract)", () => {
+	it("captures a lead on entering the Plan step once email+company are present", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.email = "lead@example.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		expect(api.captureOnboardingLead).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: "lead@example.com",
+				company: "Acme",
+				step: "plan",
+			})
+		);
+	});
+
+	it("never captures before both email and company exist", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		api.captureOnboardingLead.mockClear();
+		wrapper.vm.state.email = "lead@example.com";
+		wrapper.vm.state.company = "";
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		expect(api.captureOnboardingLead).not.toHaveBeenCalled();
+	});
+
+	it("a capture rejection never breaks the step transition", async () => {
+		api.captureOnboardingLead.mockRejectedValueOnce(new Error("network"));
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.email = "lead@example.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("the optional contact-consent checkbox renders on Details and wires into the billing snapshot", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		expect(wrapper.vm.billing.consent.value).toBe(false);
+		wrapper.vm.billing.setConsent(true);
+		expect(wrapper.vm.billing.consent.value).toBe(true);
+		const checkboxes = wrapper.findAll('input[type="checkbox"]');
+		expect(checkboxes.length).toBeGreaterThan(0);
+	});
+
+	it("Pay stays disabled until the required T&C box is ticked", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.paymentProvider = "razorpay";
+		wrapper.vm.state.termsAccepted = false;
+		await flushPromises();
+		expect(wrapper.vm.payDisabled).toBe(true);
+		wrapper.vm.state.termsAccepted = true;
+		await flushPromises();
+		expect(wrapper.vm.payDisabled).toBe(false);
+	});
+
+	it("onPayClick refuses to start a signup until T&C is ticked, then sends terms_accepted:true", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.email = "a@b.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.planName = "pro";
+		wrapper.vm.state.paymentProvider = "razorpay";
+		wrapper.vm.state.termsAccepted = false;
+
+		await wrapper.vm.onPayClick();
+		expect(api.onboardingPaymentApi.startSignup).not.toHaveBeenCalled();
+
+		wrapper.vm.state.termsAccepted = true;
+		api.onboardingPaymentApi.startSignup.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_1",
+				generation: 0,
+			})
+		);
+		await wrapper.vm.onPayClick();
+		expect(api.onboardingPaymentApi.startSignup).toHaveBeenCalledWith(
+			expect.objectContaining({ terms_accepted: true }),
+			expect.anything()
+		);
 	});
 });

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -335,6 +335,17 @@
 										autocomplete="tel"
 										@keydown.enter="onDetailsSubmit"
 									/>
+									<!-- Optional lead-capture consent (lead-capture + T&C frozen
+										 contract): recorded on the Jarvis Lead, not on Pay - the DPDP
+										 requirement is that this is asked BEFORE the Plan-step capture
+										 fires, not bundled into the required T&C acceptance below. -->
+									<div class="col-span-2 -mt-1.5 flex items-start">
+										<Checkbox
+											:model-value="billing.consent.value"
+											label="It's okay to contact me about my account"
+											@update:model-value="(v) => billing.setConsent(v)"
+										/>
+									</div>
 									<!-- JvCombo (shared, out of scope) has no declared aria-invalid /
 										 aria-describedby / blur props, and does not spread $attrs onto
 										 its inner <input>, so those attrs would silently land on its
@@ -1249,6 +1260,38 @@
 									>
 										{{ payLinkDeadline }}
 									</p>
+									<!-- Required T&C acceptance (lead-capture + T&C frozen contract).
+										 Pay stays disabled until this is ticked; terms_accepted rides
+										 start_signup, and admin stamps the version server-side - this
+										 view never sends one. Checkbox's own `label` prop only takes
+										 plain text (no slot, no markup), so the link-bearing sentence is
+										 a sibling <label for=...> instead - clicking the embedded <a>
+										 navigates without also toggling the box. -->
+									<div
+										class="mx-auto mt-3.5 flex max-w-[560px] items-start gap-2"
+									>
+										<Checkbox
+											id="jv-ob-terms"
+											:model-value="state.termsAccepted"
+											aria-required="true"
+											@update:model-value="(v) => (state.termsAccepted = v)"
+										/>
+										<label
+											for="jv-ob-terms"
+											class="cursor-pointer select-none text-p-sm text-ink-gray-7"
+										>
+											I agree to the
+											<a
+												v-if="state.termsUrl"
+												:href="state.termsUrl"
+												target="_blank"
+												rel="noopener"
+												class="ob-link"
+												@click.stop
+												>Terms &amp; Conditions</a
+											><span v-else>Terms &amp; Conditions</span>
+										</label>
+									</div>
 								</div>
 								<div class="ob-foot">
 									<button
@@ -1263,7 +1306,7 @@
 									</button>
 									<Button
 										variant="solid"
-										:disabled="payBusyView || !payProviderReady"
+										:disabled="payDisabled"
 										:loading="payBusyView"
 										loading-text="Working…"
 										:label="payCta"
@@ -1698,7 +1741,7 @@
 <script setup>
 import { reactive, ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
 import { useRouter } from "vue-router";
-import { Button, FormControl, FeatherIcon, ErrorMessage } from "frappe-ui";
+import { Button, FormControl, FeatherIcon, ErrorMessage, Checkbox } from "frappe-ui";
 import { useJarvisTheme } from "@/theme";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
 import JvCombo from "@/components/JvCombo.vue";
@@ -1732,6 +1775,8 @@ import {
 	updateBilling,
 	onboardingPaymentApi,
 	supportCreateTicket,
+	captureOnboardingLead,
+	getTermsUrl,
 } from "@/api";
 import {
 	createOperationController,
@@ -1874,6 +1919,16 @@ const state = reactive({
 	reconnectDirect: false,
 	reconnectEmail: "",
 	paymentProvider: "", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
+	// Required Review & Pay checkbox (T&C + lead-capture frozen contract). NOT
+	// localStorage-persisted like `billing.consent` - a legal acceptance is
+	// re-asked every time the customer lands fresh on this screen, same as it
+	// would be on any checkout. Pay stays disabled until this is true, and only
+	// a literal true is ever sent to start_signup.
+	termsAccepted: false,
+	// The admin-hosted /terms URL (jarvis.onboarding.get_terms_url), fetched
+	// best-effort on mount. Empty when admin is unreachable/unconfigured - the
+	// checkbox label then renders plain unlinked text instead of a dead link.
+	termsUrl: "",
 	// Gateways the operator has actually enabled, narrowed to what this build can
 	// render. Starts EMPTY and stays empty on a discovery failure (plan 02 P2-6):
 	// seeding "razorpay" faked a choice the control plane never confirmed, so a
@@ -2027,6 +2082,40 @@ watch(
 	},
 	{ immediate: true }
 );
+// Lead capture (lead-capture + T&C frozen contract): fire-and-forget upsert of
+// a Jarvis Lead on entering the Plan step, so an abandoned onboarding still
+// leaves something for outreach. `immediate: true` covers a RESUME that lands
+// directly on "plan" (readiness.js's landingStep) as well as a genuine forward
+// transition from Details. Only fires once email+company are both present -
+// admin's own guard treats a missing/invalid email as a no-op anyway, and
+// firing before either exists would just upsert an unidentifiable row. Never
+// awaited and never lets a rejection escape the watcher: a burst re-entry
+// (Back then Continue again) simply re-upserts and bumps last_seen, which is
+// the intended behaviour, not a bug to dedupe.
+watch(
+	() => state.step,
+	(step) => {
+		if (step !== "plan") return;
+		if (!(state.email || "").trim() || !(state.company || "").trim()) return;
+		try {
+			captureOnboardingLead({
+				email: state.email,
+				company: state.company,
+				billing: billing.buildBilling(),
+				plan: state.planName || "",
+				step: "plan",
+				contact_consent: billing.consent.value,
+				partner_code: state.partnerCode?.trim() || undefined,
+				site_origin:
+					(typeof window !== "undefined" && window.location && window.location.origin) ||
+					"",
+			}).catch(() => {});
+		} catch (e) {
+			/* fire-and-forget: must never break the step transition */
+		}
+	},
+	{ immediate: true }
+);
 // Plan 01: a Company change re-fetches ERP-derived billing defaults (debounced +
 // fenced inside fetchCompanyDefaults). Fires on the prefilled default Company too
 // (harmless: it only fills empty/erp_default fields, never user edits). immediate
@@ -2156,6 +2245,14 @@ const payCta = computed(() => {
 // paid plan and an autopay trial need one (the trial authorizes a mandate), so
 // the CTA is disabled until then and the unavailable/retry note stands in for it.
 const payProviderReady = computed(() => !!state.paymentProvider);
+// The CTA's full gate, named rather than left as three booleans inline in the
+// template (T&C + lead-capture frozen contract adds the third leg): busy,
+// no confirmed gateway yet, or the required Terms & Conditions box unticked.
+// payBusyView is declared further down; safe to close over here since this
+// getter only runs at render, after the whole setup script has executed.
+const payDisabled = computed(
+	() => payBusyView.value || !payProviderReady.value || !state.termsAccepted
+);
 // #669: how long the checkout link is good for. Reads the machine's own
 // payTokenExpiresInS, which is cleared with the token it belongs to, so this
 // renders nothing the moment the link stops being openable rather than leaving a
@@ -3248,6 +3345,10 @@ async function onPayClick() {
 		state.step = "details";
 		return;
 	}
+	// Belt-and-suspenders: the Pay button is already disabled until this is
+	// ticked (the real gate), but a programmatic/stray click must not be able to
+	// start a signup admin will reject anyway for lacking acceptance.
+	if (!state.termsAccepted) return;
 	// Plan 01: the normalized billing snapshot rides this first signup call so it
 	// persists server-side while the customer is still a guest. Omitted (undefined,
 	// never an empty object) when nothing was entered, so a blank Details step sends
@@ -3262,6 +3363,11 @@ async function onPayClick() {
 		// Top-level kwarg, parallel to nothing else here - NOT part of `billing`.
 		// Trimmed + undefined-when-blank so a blank field sends no key at all.
 		partner_code: state.partnerCode?.trim() || undefined,
+		// T&C + lead-capture frozen contract: only ever true here (the checkbox
+		// gates this click); contact_consent rides the same call so admin can
+		// record it on the Customer/Lead at the exact moment identity is real.
+		terms_accepted: true,
+		contact_consent: billing.consent.value,
 	});
 	// Plan 01: a successful signup left REVIEW for a live intent (verify / checkout /
 	// provisioning / duplicate). An intent now exists, so a subsequent Review & Pay
@@ -4419,6 +4525,14 @@ onMounted(async () => {
 	// tick, before the awaited prefill below — the discovery loading note must show
 	// from first paint (X4), independent of prefill/company.
 	loadPaymentProviders();
+	// Best-effort terms-page link for the Review & Pay checkbox. Never blocks the
+	// wizard and never throws into onMounted: a failure just leaves state.termsUrl
+	// empty, which the template renders as plain unlinked "Terms & Conditions" text.
+	getTermsUrl()
+		.then((d) => {
+			state.termsUrl = (d && d.url) || "";
+		})
+		.catch(() => {});
 	await prefillAccount();
 	// prefillAccount may set the default Company synchronously; the watcher fires,
 	// but kick a fetch explicitly too in case the prefilled value equalled the

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -247,6 +247,8 @@ def signup(
 	provider: str | None = None,
 	billing: dict | None = None,
 	partner_code: str | None = None,
+	terms_accepted=None,
+	contact_consent=0,
 ) -> dict:
 	"""Guest signup against admin. Returns admin's data dict, which carries a
 	``payment_provider`` discriminator plus that gateway's checkout handles:
@@ -279,6 +281,13 @@ def signup(
 	an unknown code, and that error surfaces through the normal AdminValidationError
 	path like any other signup rejection. An older admin that does not know the
 	kwarg drops it silently.
+
+	``terms_accepted`` / ``contact_consent`` (lead-capture + T&C, frozen contract):
+	sent UNCONDITIONALLY, never omitted - unlike ``coupon``/``billing``/
+	``partner_code`` above. Admin hard-rejects a signup with no truthy
+	``terms_accepted`` (the only caller is the jarvis mirror, which always sends
+	one), so there is no "omit when absent" case to preserve; an older admin that
+	does not declare either kwarg drops it silently, same as any unknown kwarg.
 	"""
 	body = {
 		"email": email,
@@ -287,6 +296,8 @@ def signup(
 		"frappe_site_url": _public_origin(),
 		"supported_providers": list(SUPPORTED_PROVIDERS),
 		"client_capabilities": _client_capabilities(),
+		"terms_accepted": terms_accepted,
+		"contact_consent": contact_consent,
 	}
 	if coupon:
 		body["coupon"] = coupon
@@ -495,6 +506,68 @@ def get_payment_providers() -> dict:
 	gateway this bench build cannot render, and offering it would strand the
 	customer at a checkout step that never opens."""
 	return _post_guest(path=_m("billing.signup.get_payment_providers"), body={})
+
+
+# Short guest timeout for the lead-capture fire-and-forget call - it fires on
+# every Plan-step render and must never make the wizard wait on it (mirrors
+# reconnect_eligibility's 8s "gates a hint, never a decision" budget).
+_LEAD_CAPTURE_TIMEOUT_S = 8
+
+
+def capture_onboarding_lead(
+	email: str,
+	company: str | None = None,
+	billing: dict | None = None,
+	plan: str | None = None,
+	step: str | None = None,
+	contact_consent=0,
+	site_origin: str | None = None,
+	partner_code: str | None = None,
+) -> dict:
+	"""Guest, best-effort upsert of a ``Jarvis Lead`` from an in-progress
+	onboarding. NEVER raises - swallows every failure and returns
+	``{"ok": False}`` instead, mirroring get_preset_catalog's "Never raises"
+	guard: a scheme-less ``jarvis_admin_url`` raises ``requests.MissingSchema``,
+	which is not in the Admin* family _post_guest converts, so the whole body is
+	guarded rather than just the HTTP call.
+
+	``site_origin`` is ALWAYS overwritten with this bench's own server-derived
+	public origin (_public_origin), never the caller-supplied value - the same
+	Host-header injection guard ``signup``/``redeem_reconnect_code`` already
+	apply to ``frappe_site_url``. A guest POST could otherwise spoof which site
+	a lead is attributed to.
+	"""
+	try:
+		body = {
+			"email": email,
+			"company": company,
+			"billing": billing,
+			"plan": plan,
+			"step": step,
+			"contact_consent": contact_consent,
+			"site_origin": _public_origin(),
+			"partner_code": partner_code,
+		}
+		return _post_guest(
+			path=_m("billing.signup.capture_onboarding_lead"),
+			body=body,
+			timeout_s=_LEAD_CAPTURE_TIMEOUT_S,
+		)
+	except Exception:
+		return {"ok": False}
+
+
+def terms_url() -> str:
+	"""The admin-hosted Terms & Conditions page for the Review & Pay checkbox
+	link. Best-effort: returns "" on any failure (no admin URL configured, a
+	malformed one, ...) rather than raising - the checkbox must render, and the
+	view falls back to plain unlinked text when this is empty."""
+	try:
+		settings = frappe.get_single("Jarvis Settings")
+		base = _admin_url(settings)
+		return f"{base}/terms" if base else ""
+	except Exception:
+		return ""
 
 
 # Admin-owned preset catalog (spec 3.3). Guest-safe fetch (get_plans pattern),

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -317,14 +317,14 @@ def get_preset_catalog() -> list:
 
 @frappe.whitelist()
 def capture_onboarding_lead(
-	email=None,
-	company=None,
-	billing=None,
-	plan=None,
-	step=None,
-	contact_consent=0,
-	site_origin=None,
-	partner_code=None,
+	email: str | None = None,
+	company: str | None = None,
+	billing: dict | None = None,
+	plan: str | None = None,
+	step: str | None = None,
+	contact_consent: bool = False,
+	site_origin: str | None = None,
+	partner_code: str | None = None,
 ) -> dict:
 	"""Fire-and-forget mirror of admin's guest ``capture_onboarding_lead``: upsert
 	a ``Jarvis Lead`` from an in-progress onboarding (frozen contract). Called by
@@ -941,8 +941,8 @@ def start_signup(
 	provider: str | None = None,
 	billing: dict | None = None,
 	partner_code: str | None = None,
-	terms_accepted=None,
-	contact_consent=0,
+	terms_accepted: bool | None = None,
+	contact_consent: bool = False,
 ) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -315,6 +315,63 @@ def get_preset_catalog() -> list:
 	return admin_client.get_preset_catalog()
 
 
+@frappe.whitelist()
+def capture_onboarding_lead(
+	email=None,
+	company=None,
+	billing=None,
+	plan=None,
+	step=None,
+	contact_consent=0,
+	site_origin=None,
+	partner_code=None,
+) -> dict:
+	"""Fire-and-forget mirror of admin's guest ``capture_onboarding_lead``: upsert
+	a ``Jarvis Lead`` from an in-progress onboarding (frozen contract). Called by
+	the wizard on entering the Plan step, NOT awaited in a way that blocks the
+	step transition.
+
+	Every param defaults so a missing/partial call can never TypeError before the
+	try below runs, and the whole body is caught broadly (not just the Admin*
+	family — see admin_client.get_preset_catalog's "Never raises" comment for why
+	a narrower except would still let a scheme-less admin URL 500 this): this
+	endpoint must never break onboarding, so any failure - a bad admin URL, no
+	admin credentials needed (it's guest), a network blip - answers ``{"ok":
+	False}`` instead of raising. Gated the same as the rest of onboarding
+	(require_jarvis_admin — the customer is admin on their own fresh bench), but
+	the gate itself is inside the guard so a permission failure degrades the same
+	as every other failure rather than 403ing a background call the view never
+	surfaces to the customer.
+	``site_origin`` sent here is advisory only - admin_client overwrites it with
+	this bench's own server-derived public origin before it ever reaches admin.
+	"""
+	try:
+		require_jarvis_admin()
+		return admin_client.capture_onboarding_lead(
+			email,
+			company=company,
+			billing=billing,
+			plan=plan,
+			step=step,
+			contact_consent=contact_consent,
+			site_origin=site_origin,
+			partner_code=partner_code,
+		)
+	except Exception:
+		return {"ok": False}
+
+
+@frappe.whitelist()
+def get_terms_url() -> dict:
+	"""The admin-hosted Terms & Conditions URL for the Review & Pay checkbox
+	link. Best-effort: ``{"url": ""}`` on any failure so the checkbox still
+	renders (with plain unlinked text) when admin is unreachable or unconfigured."""
+	try:
+		return {"url": admin_client.terms_url()}
+	except Exception:
+		return {"url": ""}
+
+
 def _subscription_upstream(sub: dict) -> str:
 	"""The one upstream a posted subscription block's accounts agree on, or "".
 
@@ -884,6 +941,8 @@ def start_signup(
 	provider: str | None = None,
 	billing: dict | None = None,
 	partner_code: str | None = None,
+	terms_accepted=None,
+	contact_consent=0,
 ) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.
 
@@ -907,6 +966,13 @@ def start_signup(
 	of the code itself — an unknown code is admin's rejection to raise, and it
 	surfaces through the normal ``_ADMIN_ERRORS`` → ``_throw_admin_error`` path
 	below like any other signup error.
+
+	``terms_accepted`` (required in substance, not in signature — admin rejects a
+	falsy value) and ``contact_consent`` (optional) are the T&C + lead-capture
+	frozen contract's two new kwargs. Threaded straight through to
+	``admin_client.signup`` unconditionally; the SPA only ever calls this with
+	``terms_accepted: true`` (the Review & Pay checkbox gates the Pay click), and
+	``terms_version`` is stamped SERVER-SIDE by admin — this bench never sends one.
 
 	Two response shapes depending on admin's
 	``require_email_verification`` flag:
@@ -953,7 +1019,14 @@ def start_signup(
 		# contract code that conversion discards. Anything non-resumable then
 		# goes through the identical mapping _surface would have applied.
 		data = admin_client.signup(
-			email, company, plan, provider=provider, billing=billing, partner_code=partner_code
+			email,
+			company,
+			plan,
+			provider=provider,
+			billing=billing,
+			partner_code=partner_code,
+			terms_accepted=terms_accepted,
+			contact_consent=contact_consent,
 		)
 	except _ADMIN_ERRORS as e:
 		resumed = _try_resume_pending_signup(e, email, plan, provider, billing, partner_code)

--- a/jarvis/tests/test_capture_onboarding_lead.py
+++ b/jarvis/tests/test_capture_onboarding_lead.py
@@ -1,0 +1,81 @@
+"""Tests for jarvis.onboarding.capture_onboarding_lead - the fire-and-forget
+mirror of admin's guest lead-capture endpoint (lead-capture + T&C frozen
+contract). The one contract this mirror MUST meet: never raise, whatever
+admin (or the permission gate) does."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import onboarding
+
+
+class TestCaptureOnboardingLead(FrappeTestCase):
+	def test_swallows_admin_failure(self):
+		"""admin_client.capture_onboarding_lead raising must not propagate - the
+		Plan-step caller fires this without awaiting it in a way that could break
+		the step transition, so a raise here would be a bug regardless of what the
+		SPA does with the promise."""
+		with patch(
+			"jarvis.onboarding.admin_client.capture_onboarding_lead",
+			side_effect=RuntimeError("admin unreachable"),
+		):
+			out = onboarding.capture_onboarding_lead(
+				email="lead@example.com",
+				company="Acme",
+				plan="pro",
+				step="plan",
+			)
+		self.assertEqual(out, {"ok": False})
+
+	def test_forwards_to_admin_client_on_success(self):
+		"""The happy path: params land on admin_client.capture_onboarding_lead
+		under their FROZEN names, and admin's own answer is returned verbatim."""
+		with patch(
+			"jarvis.onboarding.admin_client.capture_onboarding_lead",
+			return_value={"ok": True},
+		) as mock_capture:
+			out = onboarding.capture_onboarding_lead(
+				email="lead@example.com",
+				company="Acme",
+				billing={"contact_number": "+91 90000 00000"},
+				plan="pro",
+				step="plan",
+				contact_consent=1,
+				site_origin="https://spoofed.example",
+				partner_code="PARTNER-1",
+			)
+		self.assertEqual(out, {"ok": True})
+		mock_capture.assert_called_once_with(
+			"lead@example.com",
+			company="Acme",
+			billing={"contact_number": "+91 90000 00000"},
+			plan="pro",
+			step="plan",
+			contact_consent=1,
+			site_origin="https://spoofed.example",
+			partner_code="PARTNER-1",
+		)
+
+	def test_missing_args_never_raises(self):
+		"""A call with nothing but the whitelist defaults (every param optional at
+		the mirror layer) must not TypeError before the guard even runs."""
+		with patch(
+			"jarvis.onboarding.admin_client.capture_onboarding_lead",
+			return_value={"ok": False},
+		):
+			out = onboarding.capture_onboarding_lead()
+		self.assertEqual(out, {"ok": False})
+
+	def test_permission_failure_swallowed_too(self):
+		"""require_jarvis_admin living INSIDE the try means a caller with no
+		session/role degrades exactly like an admin-side failure - {"ok": False},
+		never a PermissionError escaping a background call the view never
+		surfaces."""
+		frappe.set_user("Guest")
+		try:
+			out = onboarding.capture_onboarding_lead(email="lead@example.com", company="Acme")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(out, {"ok": False})

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -484,6 +484,7 @@ _OPEN_ALLOWLIST = {
 	"account.is_ready_for_chat": "boolean readiness probe, no secret",
 	"onboarding.list_plans": "public plan catalog (spec: leave ungated)",
 	"onboarding.get_preset_catalog": "public preset catalog (spec: leave ungated)",
+	"onboarding.get_terms_url": "public Terms & Conditions page URL for the checkout link, no secret",
 	"onboarding.list_payment_providers": "public gateway list for the onboarding chooser; keys only, no secret",
 	"onboarding.get_llm_sync_status": "sanitized sync poller, needed pre-role-settle",
 	"mobile.auth.get_pairing_qr": "Guest-rejected; encodes only the site URL, no secret",


### PR DESCRIPTION
## Summary

Customer-app half of onboarding lead capture + Terms & Conditions. **Depends on jarvis-admin-v2 PR #335** (the `capture_onboarding_lead` endpoint and the `signup()` `terms_accepted` param) — merge that first.

- **Details step:** an optional "okay to contact me" (`contact_consent`) checkbox, persisted in the onboarding localStorage snapshot.
- **Plan step:** fire-and-forget capture of the details the customer already typed (email, company, billing, plan, consent) so an abandoned onboarding becomes a lead. Never blocks or breaks the step — errors are swallowed; only fires once email + company are present.
- **Review & Pay:** a required "I agree to the Terms & Conditions" checkbox (links to the admin terms page) that keeps Pay disabled until ticked, and threads `terms_accepted` into signup.
- Backend: `admin_client` + `onboarding.py` mirror endpoint (`capture_onboarding_lead`), both best-effort; `start_signup` threads `terms_accepted` + `contact_consent`.

<details>
<summary>Notes</summary>

- Mirror endpoint uses `require_jarvis_admin()` (the customer is admin on their own bench), matching `start_signup`.
- `site_origin` is overwritten server-side with the public origin (same Host-header guard `signup()` uses).
- Added `get_terms_url()` so the checkbox can link the admin terms page; falls back to plain text if unavailable.
- Tests: 221/221 frontend pass (6 new lead/T&C tests); Pay-disabled-until-ticked asserted. pre-commit green.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check passes
- [ ] Branch up to date with `develop`
- [x] New behavior has tests (consent checkbox, capture call, T&C gate)
- [x] Self-reviewed the diff
