### PR TITLE
fix(onboarding): labeled connect-wait progress bar; consent via T&C

### DIFF
--- a/frontend/src/components/StepProgress.spec.js
+++ b/frontend/src/components/StepProgress.spec.js
@@ -92,4 +92,17 @@ describe("StepProgress accessibility", () => {
 		});
 		expect(items(w)[1].find(".sr-only").text()).toBe("Step 2 of 3");
 	});
+
+	it("collapseLabels tags labels collapsible (visually hidden under the breakpoint, still announced)", () => {
+		const w = mount(StepProgress, {
+			props: { steps: STEPS, currentIndex: 1, collapseLabels: true },
+		});
+		// jsdom computes no CSS: assert the hook class, whose media query does
+		// the hiding, and that the label text itself is untouched.
+		const labels = w.findAll(".step-progress-label--collapsible");
+		expect(labels).toHaveLength(3);
+		expect(labels[0].text()).toBe("Details");
+		const plain = mount(StepProgress, { props: { steps: STEPS, currentIndex: 1 } });
+		expect(plain.find(".step-progress-label--collapsible").exists()).toBe(false);
+	});
 });

--- a/frontend/src/components/StepProgress.vue
+++ b/frontend/src/components/StepProgress.vue
@@ -31,7 +31,14 @@
 				class="flex flex-1 flex-col gap-1.5"
 				:aria-current="i === currentIndex ? 'step' : undefined"
 			>
-				<span v-if="step.label" class="text-p-sm" :class="labelClass(i)">
+				<span
+					v-if="step.label"
+					class="text-p-sm"
+					:class="[
+						labelClass(i),
+						collapseLabels ? 'step-progress-label--collapsible' : '',
+					]"
+				>
 					{{ step.label }}
 				</span>
 				<!-- No visible per-step label (the two wait bars have none): keep an
@@ -63,6 +70,14 @@ const props = defineProps({
 	label: { type: String, default: "" },
 	/** Accessible name for the list when there is no visible `label`. */
 	ariaLabel: { type: String, default: "Setup steps" },
+	/**
+	 * Visually hide the per-step labels on narrow screens (they stay readable
+	 * to screen readers). For bars with many short-labeled steps - the connect
+	 * wait's six - a phone-width card cannot fit a label per segment; the
+	 * caption and the caller's own explanation line carry the words there.
+	 * 719px matches the onboarding wait block's own stacking breakpoint.
+	 */
+	collapseLabels: { type: Boolean, default: false },
 });
 
 const labelId = useId();
@@ -102,6 +117,21 @@ function segmentClass(i) {
 	.step-progress-segment--indeterminate {
 		animation: none;
 		opacity: 0.75;
+	}
+}
+/* collapseLabels: the sr-only recipe, applied only under the breakpoint so
+   the label stays announced while taking no visual space. */
+@media (max-width: 719px) {
+	.step-progress-label--collapsible {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 }
 </style>

--- a/frontend/src/components/StepProgress.vue
+++ b/frontend/src/components/StepProgress.vue
@@ -75,7 +75,8 @@ const props = defineProps({
 	 * to screen readers). For bars with many short-labeled steps - the connect
 	 * wait's six - a phone-width card cannot fit a label per segment; the
 	 * caption and the caller's own explanation line carry the words there.
-	 * 719px matches the onboarding wait block's own stacking breakpoint.
+	 * 720px matches the onboarding wait block's own max-width: 720px rule, so
+	 * the labels collapse at exactly the width the block goes narrow.
 	 */
 	collapseLabels: { type: Boolean, default: false },
 });
@@ -121,7 +122,7 @@ function segmentClass(i) {
 }
 /* collapseLabels: the sr-only recipe, applied only under the breakpoint so
    the label stays announced while taking no visual space. */
-@media (max-width: 719px) {
+@media (max-width: 720px) {
 	.step-progress-label--collapsible {
 		position: absolute;
 		width: 1px;

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -136,12 +136,11 @@ export function useBillingDetails(opts = {}) {
 	// deliberately dumb: last write wins, no provenance, because unlike the billing
 	// fields nothing auto-fills these behind the customer's back.
 	const identity = reactive({ email: "", company: "" });
-	// Details-step OPTIONAL "okay to contact me" checkbox (lead-capture + T&C
-	// frozen contract). Lives here, not on the wizard's own `state`, for the same
-	// reason as `identity`: it rides the localStorage snapshot so a mid-flow
-	// reload or a checkout round trip does not silently lose an explicit "yes".
-	// Never auto-set - only the customer's own click flips it true.
-	const consent = ref(false);
+	// No contact-consent state here any more: the Details-step "okay to contact
+	// me" checkbox was folded into the required T&C acceptance on Review & Pay
+	// (owner decision 2026-08-14), so consent rides start_signup as a literal
+	// true alongside terms_accepted and nothing about it needs to survive a
+	// reload.
 	// Provenance of the last-applied ERP defaults, forwarded to admin so it can
 	// record where the snapshot originated. Never rendered on Review & Pay.
 	const sourceCompany = ref("");
@@ -236,13 +235,6 @@ export function useBillingDetails(opts = {}) {
 		persist();
 	}
 
-	// The Details-step "It's okay to contact me" checkbox. Explicit boolean only
-	// - never inferred from anything else on the form.
-	function setConsent(value) {
-		consent.value = !!value;
-		persist();
-	}
-
 	function persist() {
 		if (!storage) return;
 		try {
@@ -255,7 +247,6 @@ export function useBillingDetails(opts = {}) {
 					gstin: fields.gstin.value,
 					email: identity.email,
 					company: identity.company,
-					contact_consent: consent.value,
 					// Stamped on every write so restore() can bound how long this PII
 					// lives, whatever happens to the session that wrote it.
 					saved_at: now(),
@@ -314,13 +305,9 @@ export function useBillingDetails(opts = {}) {
 				any = true;
 			}
 		}
-		// Same "only ever restore forward" rule as identity: a stored `true` wins;
-		// a stored `false`/absent leaves whatever this mount already has (never
-		// flips an explicit in-session "yes" back to unchecked).
-		if (d && d.contact_consent && !consent.value) {
-			consent.value = true;
-			any = true;
-		}
+		// A `contact_consent` key from a snapshot written by an older build is
+		// simply ignored: the consent checkbox no longer exists (it lives inside
+		// the T&C acceptance now), so there is nothing to restore it into.
 		return any;
 	}
 
@@ -435,8 +422,6 @@ export function useBillingDetails(opts = {}) {
 		fields,
 		identity,
 		setIdentity,
-		consent,
-		setConsent,
 		finish,
 		billingSaved,
 		sourceCompany,

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -399,16 +399,15 @@ export function connectHeadline(phase, { fromReadinessCeiling = false } = {}) {
  * codes, which waitPhases.js does not encode and never has: a phase counts
  * as done ONLY when the model itself says PHASE_STATE.DONE.
  *
- * That means the two waits behave differently here, honestly:
- * provisioningPhase has a DONE branch (tenant_status === "running"), so the
- * provisioning wait's bar can and does advance to 2 of 3 mid-screen.
- * readinessPhase has NO done branch at all - every reason it knows about
- * maps to ACTIVE or UNKNOWN - so the connect wait's bar stays at 1 of 3
- * until the moment is_ready_for_chat says ready and the screen navigates
- * away; it never fills to 2 in place. Both waits still get the bar: the
- * provisioning wait makes the determinate case real and demonstrable, and
- * the connect wait's honestly-stuck-at-1/3 bar is exactly the indeterminate
- * case this function has to tell apart from real progress.
+ * As of the 2026-08-14 connect-wait redesign only the PROVISIONING wait
+ * reads this: provisioningPhase has a DONE branch (tenant_status ===
+ * "running"), so that bar can and does advance to 2 of 3 mid-screen. The
+ * connect wait used to read it too and honestly sat at 1 of 3 forever
+ * (readinessPhase has NO done branch), which - combined with the jarvis#840
+ * checklist rows - left a 3-count bar over six phase columns. It now builds
+ * its own six-step labeled bar (OnboardingView's connectSteps), the
+ * "future non-duplicating layout" the label paragraph below anticipated,
+ * keeping this function's indeterminate rule but not its fixed count.
  *
  * `indeterminate` is true whenever the phase carries nothing to act on -
  * PHASE_STATE.UNKNOWN, or no phase read yet. It must render differently from

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1673,90 +1673,88 @@ describe("jarvis#752 the connect step shows admin's route verdict while still co
 	});
 });
 
-// jarvis wait-phases-horizontal: the wait block widened to 75% and the three
-// phases moved from a stacked list to equal-width columns under the bar. The
-// admin-authored detail sentence (jarvis#752/#754) no longer fits inside a
-// column a third of that width, so it was hoisted out of the phase row and
-// now renders once, full width, below the phase columns instead. These tests
-// pin the DOM shape that hoist depends on, not pixel layout (jsdom does not
-// compute CSS): the detail is a sibling of the phase list, not nested in any
-// `<li>`, and both the active phase and the detail keep their own
-// `role="status"` so a screen reader still hears each independently.
-describe("jarvis wait-phases-horizontal: detail hoisted out of the phase columns", () => {
+// 2026-08-14 connect-wait redesign: the phase columns are gone; the connect
+// wait renders ONE labeled six-segment bar (connectSteps) with the current
+// step's one-line explanation below it, and admin's own detail sentence
+// (jarvis#752/#754) below that. These tests pin the DOM shape, not pixel
+// layout (jsdom does not compute CSS).
+describe("connect wait bar: six labeled steps with a one-line explanation", () => {
 	const QUOTA_REASON = "Your OpenAI account has reached its usage limit. It resets in 2 hours.";
 
-	it("renders the detail as a sibling of the phase list, not inside a phase row", async () => {
+	it("renders six labeled steps and marks the readiness step current while applying", async () => {
 		const w = await mountConnect();
 
 		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
 		await flushPromises();
 
-		const phases = w.find(".ob-phases");
-		const detail = w.find(".ob-phase-detail");
-		expect(detail.exists()).toBe(true);
-		expect(detail.text()).toBe(QUOTA_REASON);
-		// Hoisted OUT: no longer a descendant of the phase list or any row.
-		expect(detail.element.closest("ul")).toBeNull();
-		expect(detail.element.closest("li")).toBeNull();
-		// Reads as belonging to the same block: immediately after the phase list.
-		expect(phases.element.nextElementSibling).toBe(detail.element);
-		w.unmount();
-	});
+		// The old ob-phases column list must be gone from the connect screen.
+		expect(w.find(".ob-phases").exists()).toBe(false);
 
-	it("still lays out each phase as its own row item (six with the jarvis#840 checklist)", async () => {
-		const w = await mountConnect();
-
-		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
-		await flushPromises();
-
-		// 3 original phases + the preflight's 3 checklist rows (jarvis#840).
-		const columns = w.findAll(".ob-phases > .ob-phase");
-		expect(columns).toHaveLength(6);
-		// Every column still carries only its label, never the detail sentence -
-		// the hoist removed the ONLY per-row detail span, it did not just add a
-		// duplicate copy alongside it.
-		for (const column of columns) {
-			expect(column.find(".ob-phase-detail").exists()).toBe(false);
+		// Scoped to the wait bar: the top rail is its own StepProgress with its
+		// own aria-current, and must not leak into these assertions.
+		const items = w.find(".ob-progress").findAll('[role="listitem"]');
+		const labels = items.map((i) => i.text());
+		for (const expected of [
+			"Connection",
+			"Workspace",
+			"Tools",
+			"Persona",
+			"Live check",
+			"Chat",
+		]) {
+			expect(labels).toContain(expected);
 		}
+		const current = items.filter((i) => i.attributes("aria-current") === "step");
+		expect(current).toHaveLength(1);
+		expect(current[0].text()).toBe("Workspace");
 		w.unmount();
 	});
 
-	it("announces the phase and its detail as ONE live region, not two", async () => {
-		// Round-1 review: giving the hoisted detail its own role="status" made a
-		// screen reader hear the phase and the sentence explaining that phase as
-		// two unrelated announcements. Worse, that region was v-if gated, so it
-		// mounted already populated, and a live region announces CHANGES to a
-		// region that is already present, not its initial content. One shared
-		// wrapper fixes both at once.
+	it("explains the current step in one line and keeps admin's detail separate", async () => {
 		const w = await mountConnect();
 
 		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
 		await flushPromises();
 
-		const active = w.find(".ob-phase--active");
+		// The explanation is the readiness phase's own sentence (waitPhases.js),
+		// never invented copy; the admin-authored detail keeps its own line.
+		expect(w.find(".ob-step-explain").text()).toBe(w.vm.readinessStage.label);
+		expect(w.find(".ob-phase-detail").text()).toBe(QUOTA_REASON);
+		w.unmount();
+	});
+
+	it("announces the explanation and admin's detail as ONE live region, not two", async () => {
+		// Same rule the phase columns followed: separate role="status" regions
+		// read as unrelated announcements, and a v-if-gated region mounts
+		// already populated so its content is never announced at all.
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
+		await flushPromises();
+
+		const explain = w.find(".ob-step-explain");
 		const detail = w.find(".ob-phase-detail");
-		expect(active.attributes("role")).toBeUndefined();
+		expect(explain.attributes("role")).toBeUndefined();
 		expect(detail.attributes("role")).toBeUndefined();
 
 		const owning = w
 			.findAll('[role="status"]')
 			.filter(
-				(r) => r.element.contains(active.element) && r.element.contains(detail.element)
+				(r) => r.element.contains(explain.element) && r.element.contains(detail.element)
 			);
 		expect(owning.length).toBe(1);
 		w.unmount();
 	});
 
-	it("the active phase's spinner and the waiting phase's dot are unchanged by the hoist", async () => {
+	it("the bar caption counts all six steps, matching what is drawn", async () => {
+		// The user-reported defect this redesign fixes: a "Step 2 of 3" caption
+		// over six visible items.
 		const w = await mountConnect();
 
 		w.vm.onOpUpdate({ phase: "applying", chatReadinessReason: QUOTA_REASON });
 		await flushPromises();
 
-		// design.md §3.8: JvSpinner is the only loading indicator, never a
-		// bespoke one - it renders `.jv-spin` with its own role="status".
-		expect(w.find(".ob-phase--active .jv-spin").exists()).toBe(true);
-		expect(w.find(".ob-phase--waiting .ob-phase-dot").exists()).toBe(true);
+		expect(w.text()).toContain("Step 2 of 6");
 		w.unmount();
 	});
 });

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -732,16 +732,13 @@ describe("lead-capture + T&C (frozen contract)", () => {
 		expect(wrapper.vm.state.step).toBe("plan");
 	});
 
-	it("the optional contact-consent checkbox renders on Details and wires into the billing snapshot", async () => {
+	it("Details renders no separate contact-consent checkbox (consent rides the T&C acceptance)", async () => {
 		const wrapper = mountView();
 		await flushPromises();
 		wrapper.vm.state.step = "details";
 		await flushPromises();
-		expect(wrapper.vm.billing.consent.value).toBe(false);
-		wrapper.vm.billing.setConsent(true);
-		expect(wrapper.vm.billing.consent.value).toBe(true);
-		const checkboxes = wrapper.findAll('input[type="checkbox"]');
-		expect(checkboxes.length).toBeGreaterThan(0);
+		expect(wrapper.text()).not.toContain("okay to contact me");
+		expect(wrapper.vm.billing.consent).toBeUndefined();
 	});
 
 	it("Pay stays disabled until the required T&C box is ticked", async () => {
@@ -779,7 +776,9 @@ describe("lead-capture + T&C (frozen contract)", () => {
 		);
 		await wrapper.vm.onPayClick();
 		expect(api.onboardingPaymentApi.startSignup).toHaveBeenCalledWith(
-			expect.objectContaining({ terms_accepted: true }),
+			// contact_consent is granted BY the T&C acceptance (owner decision
+			// 2026-08-14): the same click that sends terms_accepted sends it.
+			expect.objectContaining({ terms_accepted: true, contact_consent: true }),
 			expect.anything()
 		);
 	});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -335,17 +335,12 @@
 										autocomplete="tel"
 										@keydown.enter="onDetailsSubmit"
 									/>
-									<!-- Optional lead-capture consent (lead-capture + T&C frozen
-										 contract): recorded on the Jarvis Lead, not on Pay - the DPDP
-										 requirement is that this is asked BEFORE the Plan-step capture
-										 fires, not bundled into the required T&C acceptance below. -->
-									<div class="col-span-2 -mt-1.5 flex items-start">
-										<Checkbox
-											:model-value="billing.consent.value"
-											label="It's okay to contact me about my account"
-											@update:model-value="(v) => billing.setConsent(v)"
-										/>
-									</div>
+									<!-- No separate contact-consent checkbox here (owner decision
+										 2026-08-14): consent to be contacted is part of the Terms &
+										 Conditions accepted at Review & Pay, where onPayClick sends
+										 contact_consent alongside terms_accepted. Consequence: a lead
+										 captured at the Plan step carries no consent until the
+										 customer accepts the terms. -->
 									<!-- JvCombo (shared, out of scope) has no declared aria-invalid /
 										 aria-describedby / blur props, and does not spread $attrs onto
 										 its inner <input>, so those attrs would silently land on its
@@ -1435,123 +1430,38 @@
 												}}
 											</p>
 										</div>
-										<!-- jarvis#726: same step-counted bar as the provisioning wait,
-											 reading readinessStage. readinessPhase has no DONE branch
-											 (waitPhases.js), so the label stays "Step 2 of 3" until the
-											 screen navigates to chat: segment two renders as the CURRENT
-											 step (filled, design.md §4.3), never as done, and segment
-											 three only fills once the screen actually leaves. Label is
-											 "Step N of 3" only, not the phase's own sentence - see the
-											 provisioning bar's comment above. -->
+										<!-- One labeled progress bar for the whole connect wait
+											 (2026-08-14 redesign). The jarvis#726 "Step N of 3" bar
+											 plus phase columns stopped working once the jarvis#840
+											 checklist made it six columns under a 3-count bar: long
+											 wrapping labels and a count that contradicted the list
+											 (user report). The columns are gone; the bar now carries
+											 one SHORT-labeled segment per step and the current step
+											 explains itself in one line below (ob-step-explain).
+											 jarvis#763's "no per-step labels on the wait bars" held
+											 while the columns carried the words next to the bar; with
+											 the columns removed this is the non-duplicating labeled
+											 layout waitPhases.phaseProgress anticipated. Honesty is
+											 unchanged: segments fill only from observed states
+											 (connectSteps), and an UNKNOWN current step pulses
+											 indeterminate instead of filling. -->
 										<div class="ob-progress">
 											<StepProgress
-												:steps="WAIT_STEPS"
-												:current-index="readinessProgress.current - 1"
-												:indeterminate="readinessProgress.indeterminate"
-												:label="`Step ${readinessProgress.current} of ${readinessProgress.total}`"
+												:steps="connectSteps"
+												:current-index="connectProgress.index"
+												:indeterminate="connectProgress.indeterminate"
+												:label="`Step ${connectProgress.index + 1} of ${connectSteps.length}`"
+												collapse-labels
 											/>
 										</div>
-										<!-- Phase columns, driven by is_ready_for_chat's `reason` on the
-											 LAST poll (waitPhases.js). Before this the screen showed one
-											 fixed sentence for the whole two-minute wait, so a workspace
-											 being built and one that was stuck looked identical. Laid out
-											 side by side under the bar's segments, same as the
-											 provisioning wait above: the active phase's `detail` is a
-											 full admin sentence (jarvis#752/#754), so it renders once,
-											 full width, below every column rather than inside one.
-
-											 ONE live region over the phases AND that detail, same
-											 reason as the provisioning block: two role="status"
-											 regions made a screen reader hear the phase and the
-											 sentence explaining it as unrelated announcements. -->
+										<!-- ONE live region over the explanation and admin's own
+											 detail sentence (jarvis#752/#754), same reason as the
+											 provisioning block: separate role="status" regions read
+											 as unrelated announcements. -->
 										<div role="status">
-											<ul class="ob-phases" role="list">
-												<li class="ob-phase ob-phase--done">
-													<span class="ob-phase-ico">
-														<FeatherIcon
-															name="check"
-															class="h-4 w-4"
-														/>
-													</span>
-													<span class="ob-phase-txt">
-														<span class="ob-phase-label"
-															>AI connection saved</span
-														>
-													</span>
-												</li>
-												<li
-													class="ob-phase"
-													:class="`ob-phase--${readinessStage.state}`"
-												>
-													<span class="ob-phase-ico">
-														<!-- currentColor so the active step matches its
-														     sibling step icons (.ob-phase-ico sets the
-														     colour), not JvSpinner's brand default. -->
-														<JvSpinner
-															v-if="
-																readinessStage.state === 'active'
-															"
-															color="currentColor"
-															:size="20"
-														/>
-														<FeatherIcon
-															v-else
-															name="alert-circle"
-															class="h-4 w-4"
-														/>
-													</span>
-													<span class="ob-phase-txt">
-														<span class="ob-phase-label">{{
-															readinessStage.label
-														}}</span>
-													</span>
-												</li>
-												<!-- jarvis#840: the preflight's own rows. Same
-												     ob-phase states as the rows above; these fill in
-												     one step (the single preflight call) once
-												     readiness turns green, and none of them can hold
-												     the screen - see runPreflightGate. -->
-												<li
-													v-for="row in preflightRows"
-													:key="row.key"
-													class="ob-phase"
-													:class="`ob-phase--${row.state}`"
-												>
-													<span class="ob-phase-ico">
-														<JvSpinner
-															v-if="row.state === 'active'"
-															color="currentColor"
-															:size="20"
-														/>
-														<FeatherIcon
-															v-else-if="row.state === 'done'"
-															name="check"
-															class="h-4 w-4"
-														/>
-														<FeatherIcon
-															v-else-if="row.state === 'unknown'"
-															name="alert-circle"
-															class="h-4 w-4"
-														/>
-														<i v-else class="ob-phase-dot"></i>
-													</span>
-													<span class="ob-phase-txt">
-														<span class="ob-phase-label">{{
-															row.label
-														}}</span>
-													</span>
-												</li>
-												<li class="ob-phase ob-phase--waiting">
-													<span class="ob-phase-ico"
-														><i class="ob-phase-dot"></i
-													></span>
-													<span class="ob-phase-txt">
-														<span class="ob-phase-label"
-															>Opening chat</span
-														>
-													</span>
-												</li>
-											</ul>
+											<p class="ob-step-explain">
+												{{ connectProgress.explain }}
+											</p>
 											<p
 												v-if="readinessStage.detail"
 												class="ob-phase-detail"
@@ -1874,14 +1784,13 @@ const RAIL = [
 	{ id: "connect", label: "Connect" },
 ];
 
-// Unlabelled StepProgress segments for the two wait bars below, which count
-// steps (waitPhases.phaseProgress) without naming them the way RAIL does.
-//
-// A module constant, not two computeds (round-1 review of #763). Both bars read
-// their total from phaseProgress, which counts to 3 and only 3, so a per-bar
-// computed rebuilt an identical array on every poll tick and left two places to
-// keep in step when one of them changed. If a bar ever needs a different length,
-// give it its own named constant rather than reintroducing the pair.
+// Unlabelled StepProgress segments for the PROVISIONING wait bar, which counts
+// steps (waitPhases.phaseProgress) without naming them the way RAIL does. The
+// connect wait used to share this constant; since the 2026-08-14 redesign it
+// has its own labeled six-step array (connectSteps), which is exactly the
+// "give it its own named constant" escape hatch the #763 round-1 review
+// prescribed for a bar that needs a different length - a computed there is
+// justified because its states change per tick, unlike this static shape.
 const WAIT_STEPS = Object.freeze(Array.from({ length: 3 }, (_, i) => Object.freeze({ id: i })));
 
 // Frame subtitle next to the brand mark, mirroring the active step's title.
@@ -1961,10 +1870,11 @@ const state = reactive({
 	reconnectEmail: "",
 	paymentProvider: "", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
 	// Required Review & Pay checkbox (T&C + lead-capture frozen contract). NOT
-	// localStorage-persisted like `billing.consent` - a legal acceptance is
-	// re-asked every time the customer lands fresh on this screen, same as it
-	// would be on any checkout. Pay stays disabled until this is true, and only
-	// a literal true is ever sent to start_signup.
+	// localStorage-persisted - a legal acceptance is re-asked every time the
+	// customer lands fresh on this screen, same as it would be on any checkout.
+	// Pay stays disabled until this is true, and only a literal true is ever
+	// sent to start_signup. Accepting it also grants contact consent (owner
+	// decision 2026-08-14): the terms cover being contacted about the account.
 	termsAccepted: false,
 	// The admin-hosted /terms URL (jarvis.onboarding.get_terms_url), fetched
 	// best-effort on mount. Empty when admin is unreachable/unconfigured - the
@@ -2053,12 +1963,10 @@ const readinessStage = computed(() =>
 				opReadinessDetail.value
 		  )
 );
-// jarvis#726: the progress bar next to the phase list above, reading the SAME
-// readinessStage - see waitPhases.phaseProgress.
-const readinessProgress = computed(() => phaseProgress(readinessStage.value));
-// StepProgress wants a segment per step; this wait has no named steps of its
-// own (waitPhases.phaseProgress only ever counts to 3), so the segments carry
-// no per-step label and the bar's own "Step N of 3" caption does the talking.
+// The connect wait's bar is connectSteps/connectProgress (defined with the
+// jarvis#840 preflight state they read, further down) - it stopped using
+// waitPhases.phaseProgress in the 2026-08-14 redesign because its six steps
+// are named, while phaseProgress only ever counts an unnamed 3.
 
 // Plan 01 billing state. Namespaced by site identity + logged-in user so one
 // site's / user's transitional billing PII can never prefill another's on a
@@ -2145,7 +2053,10 @@ watch(
 				billing: billing.buildBilling(),
 				plan: state.planName || "",
 				step: "plan",
-				contact_consent: billing.consent.value,
+				// No contact_consent here (defaults false upstream): the Details-step
+				// consent checkbox was folded into the T&C acceptance (owner decision
+				// 2026-08-14), which only happens later at Review & Pay. An abandoned
+				// lead therefore carries no consent to contact.
 				partner_code: state.partnerCode?.trim() || undefined,
 				site_origin:
 					(typeof window !== "undefined" && window.location && window.location.origin) ||
@@ -3405,10 +3316,12 @@ async function onPayClick() {
 		// Trimmed + undefined-when-blank so a blank field sends no key at all.
 		partner_code: state.partnerCode?.trim() || undefined,
 		// T&C + lead-capture frozen contract: only ever true here (the checkbox
-		// gates this click); contact_consent rides the same call so admin can
-		// record it on the Customer/Lead at the exact moment identity is real.
+		// gates this click). contact_consent is granted BY the T&C acceptance
+		// itself (owner decision 2026-08-14, replacing the separate Details-step
+		// checkbox), so it is the same literal true, recorded at the exact moment
+		// identity is real.
 		terms_accepted: true,
-		contact_consent: billing.consent.value,
+		contact_consent: true,
 	});
 	// Plan 01: a successful signup left REVIEW for a live intent (verify / checkout /
 	// provisioning / duplicate). An intent now exists, so a subsequent Review & Pay
@@ -3956,6 +3869,59 @@ const preflightRows = computed(() => {
 		},
 		{ key: "usable", state: rowState(usable), label: usableLabel },
 	];
+});
+
+// The six connect-wait steps as ONE labeled bar (2026-08-14 redesign; see the
+// template comment for why the phase columns are gone). Short labels sit above
+// the segments; `explain` is the sentence the line under the bar shows while
+// that step is current. Nothing here is invented: step 1 is settled by
+// reaching this screen (the save was accepted), step 2 reads readinessStage
+// (waitPhases.readinessPhase has no DONE branch - readiness counts as done
+// exactly when the preflight it hands off to has started), steps 3-5 read the
+// jarvis#840 preflight rows verbatim, and "Chat" turns active only once the
+// preflight resolved, which is also when navigateToChat runs.
+const connectSteps = computed(() => {
+	const rows = preflightRows.value;
+	const readinessDone = preflight.running || preflight.done;
+	return [
+		{
+			id: "saved",
+			label: "Connection",
+			state: "done",
+			explain: "Your AI connection is saved.",
+		},
+		{
+			id: "workspace",
+			label: "Workspace",
+			state: readinessDone ? "done" : readinessStage.value.state,
+			explain: readinessStage.value.label,
+		},
+		{ id: "plugin", label: "Tools", state: rows[0].state, explain: rows[0].label },
+		{ id: "persona", label: "Persona", state: rows[1].state, explain: rows[1].label },
+		{ id: "check", label: "Live check", state: rows[2].state, explain: rows[2].label },
+		{
+			id: "chat",
+			label: "Chat",
+			state: preflight.done ? "active" : "waiting",
+			explain: "Opening your chat.",
+		},
+	];
+});
+
+// Current step = the first one not done; `indeterminate` keeps the honesty
+// rule waitPhases.phaseProgress drew: an UNKNOWN current step (a poll that
+// answered with nothing, or a degraded non-blocking preflight row) pulses
+// instead of filling. While the single preflight call is in flight all three
+// of its rows are active at once, so the explanation collapses them into one
+// sentence rather than naming a row the call does not check first.
+const connectProgress = computed(() => {
+	const steps = connectSteps.value;
+	let index = steps.findIndex((s) => s.state !== "done");
+	if (index < 0) index = steps.length - 1;
+	const explain = preflight.running
+		? "Running final checks on your setup."
+		: steps[index].explain;
+	return { index, indeterminate: steps[index].state === "unknown", explain };
 });
 
 // Navigate to Chat exactly once, only on an authoritative ready. forgetReady() clears
@@ -4953,17 +4919,18 @@ onUnmounted(() => {
 	max-width: 640px;
 }
 
-/* ---- staged wait phases (waitPhases.js) --------------------------------
+/* ---- staged wait phases (waitPhases.js), PROVISIONING wait only --------
    One column per phase, side by side under the bar's segments so the whole
    block reads as one horizontal progression rather than a bar with an
    unrelated list under it (jarvis wait-phases-horizontal). Segment one sits
    above phase one for free: both this row and StepProgress.vue's own row are
    a 3-up flex with equal (`flex: 1`) children and the same 8px gap over the
-   same width, so they align without the phase labels having to become the
-   bar's own per-step labels - that route was considered and rejected, see
-   WAIT_STEPS's comment below (script section): the bar is deliberately
-   unlabelled per jarvis#763, and reintroducing labels there would require a
-   per-bar computed the same comment already warns against reintroducing.
+   same width. jarvis#763 rejected per-step labels on the bar itself BECAUSE
+   these columns already carried the words; the CONNECT wait dropped its
+   columns in the 2026-08-14 redesign (six of them under a 3-count bar wrapped
+   into unreadable towers), so its bar is now the labeled, non-duplicating
+   layout that rejection anticipated, and only the provisioning wait still
+   renders this list.
 
    The MODIFIER on each column is the honesty contract, not decoration:
    `active` is only ever set from an observation, `unknown` means a poll
@@ -5027,6 +4994,23 @@ onUnmounted(() => {
 	font-size: 12px;
 	line-height: 1.5;
 	color: var(--text-3);
+	text-align: center;
+	box-sizing: border-box;
+}
+/* The connect bar's one-line explanation of the CURRENT step (2026-08-14
+   redesign): the sentence the phase columns used to carry. Slightly stronger
+   than .ob-phase-detail below it, which stays reserved for admin's own detail
+   sentence and the preflight notice. */
+.ob-step-explain {
+	display: block;
+	width: 75%;
+	max-width: 640px;
+	margin: 10px auto 0;
+	padding: 0 8px;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--text-2);
+	font-weight: 500;
 	text-align: center;
 	box-sizing: border-box;
 }
@@ -5125,7 +5109,8 @@ onUnmounted(() => {
 @media (max-width: 720px) {
 	.ob-progress,
 	.ob-phases,
-	.ob-phase-detail {
+	.ob-phase-detail,
+	.ob-step-explain {
 		width: 100%;
 	}
 	.ob-phases {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1450,7 +1450,7 @@
 												:steps="connectSteps"
 												:current-index="connectProgress.index"
 												:indeterminate="connectProgress.indeterminate"
-												:label="`Step ${connectProgress.index + 1} of ${connectSteps.length}`"
+												:label="connectProgress.caption"
 												collapse-labels
 											/>
 										</div>
@@ -3921,7 +3921,12 @@ const connectProgress = computed(() => {
 	const explain = preflight.running
 		? "Running final checks on your setup."
 		: steps[index].explain;
-	return { index, indeterminate: steps[index].state === "unknown", explain };
+	return {
+		index,
+		indeterminate: steps[index].state === "unknown",
+		explain,
+		caption: `Step ${index + 1} of ${steps.length}`,
+	};
 });
 
 // Navigate to Chat exactly once, only on an authoritative ready. forgetReady() clears

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3916,8 +3916,9 @@ const connectSteps = computed(() => {
 // sentence rather than naming a row the call does not check first.
 const connectProgress = computed(() => {
 	const steps = connectSteps.value;
-	let index = steps.findIndex((s) => s.state !== "done");
-	if (index < 0) index = steps.length - 1;
+	// Always hits: the chat step is never "done" (only active or waiting), so
+	// a first not-done step always exists.
+	const index = steps.findIndex((s) => s.state !== "done");
 	const explain = preflight.running
 		? "Running final checks on your setup."
 		: steps[index].explain;


### PR DESCRIPTION
## Summary

Cleans up the onboarding connect wait: one labeled six-segment progress bar (Step k of 6) with a one-line explanation of the current step, replacing the "Step 2 of 3" bar that sat over six long wrapping checklist labels. Also removes the Details-step "It's okay to contact me" checkbox: contact consent is now part of accepting the Terms & Conditions at Review & Pay (owner decision, 2026-08-14).

## What changed
- Connect wait: six short-labeled segments (Connection, Workspace, Tools, Persona, Live check, Chat); the current step explains itself in one line below the bar. Fill states remain observed-only; an unknown step pulses indeterminate. Admin's detail sentence and the usage-limit notice keep their own lines.
- StepProgress gains `collapseLabels`: labels drop to sr-only below 720px.
- Details step: contact-consent checkbox removed. The terms-gated Pay click now sends `contact_consent: true` alongside `terms_accepted`; the Plan-step lead capture no longer sends consent.

## Risk and verification
- **Behavioral consequence:** abandoned leads (captured at Plan, terms never accepted) are no longer contactable. Consent is only ever recorded at signup.
- **Open item:** the admin-hosted `/terms` page has no contact clause yet; the owner should add one and bump the terms version (`signup.py`).
- Frontend suite green under Node 24: 1260/1260.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (cut from e113a628, current head)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
