### PR TITLE
chore: correct Jarvis app metadata

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -1,8 +1,8 @@
 app_name = "jarvis"
 app_title = "Jarvis"
-app_publisher = "Aerele"
-app_description = "AI superpowers for Frappe/ERPNext"
-app_email = "navin@aerele.in"
+app_publisher = "Aerele Technologies Pvt Ltd"
+app_description = "The AI teammate inside ERPNext"
+app_email = "jarvis@aerele.in"
 app_license = "AGPL-3.0-only"
 
 


### PR DESCRIPTION
## Summary

- use the full Aerele Technologies company name as the publisher
- set the Jarvis product contact to `jarvis@aerele.in`
- describe Jarvis as the AI teammate inside ERPNext

## Validation

- `python3 -m py_compile jarvis/hooks.py`
- `pre-commit run --files jarvis/hooks.py`