### PR TITLE
feat(export): export_query bulk export + report_pdf owner-only File

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -654,8 +654,9 @@ _WRITE_TOOLS = frozenset(
 		# detached turn as record_agent_run beside it — audited, never gated.
 		"download_pdf",
 		"export_excel",
-		# export_query / report_pdf / export_document all insert a private File via
-		# the shared save_export_file seam - the same File-write class as
+		# export_query / report_pdf / export_document all insert a private File
+		# (export_query + report_pdf via the shared save_export_file seam,
+		# export_document via its own save_file) - the same File-write class as
 		# download_pdf/export_excel, so they are audited (never gated: no card, the
 		# artifact is the point). export_query in particular is the highest-throughput
 		# bulk-export path (server-side, up to the row ceiling, never transiting the

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -654,6 +654,15 @@ _WRITE_TOOLS = frozenset(
 		# detached turn as record_agent_run beside it — audited, never gated.
 		"download_pdf",
 		"export_excel",
+		# export_query / report_pdf / export_document all insert a private File via
+		# the shared save_export_file seam - the same File-write class as
+		# download_pdf/export_excel, so they are audited (never gated: no card, the
+		# artifact is the point). export_query in particular is the highest-throughput
+		# bulk-export path (server-side, up to the row ceiling, never transiting the
+		# visible transcript), so a "who exported what" audit row is load-bearing.
+		"export_query",
+		"report_pdf",
+		"export_document",
 		"record_agent_run",
 		"record_app_wiki",
 		"finish_app_learning_run",

--- a/jarvis/telemetry.py
+++ b/jarvis/telemetry.py
@@ -86,6 +86,26 @@ def record_budget_event(
 		pass
 
 
+def record_export_event(tool: str, fmt: str, rows: int, mode: str = "sync") -> None:
+	"""One line per server-side export (export_query etc.): what format, how many
+	rows, sync/background. Signal for capacity + how often large exports fire.
+	Routes through the same INFO-pinned logger as the other events. Never raises."""
+	try:
+		_emit(
+			{
+				"kind": "export",
+				"ts": frappe.utils.now(),
+				"site": getattr(frappe.local, "site", None),
+				"tool": tool,
+				"format": fmt,
+				"rows": int(rows),
+				"mode": mode,
+			}
+		)
+	except Exception:
+		pass
+
+
 def emit_turn(conversation: str | None, run_id: str | None, duration_ms: int) -> None:
 	"""One line per completed turn; reads and clears the per-turn custom
 	flag. Never raises."""

--- a/jarvis/telemetry.py
+++ b/jarvis/telemetry.py
@@ -86,10 +86,12 @@ def record_budget_event(
 		pass
 
 
-def record_export_event(tool: str, fmt: str, rows: int, mode: str = "sync") -> None:
-	"""One line per server-side export (export_query etc.): what format, how many
-	rows, sync/background. Signal for capacity + how often large exports fire.
-	Routes through the same INFO-pinned logger as the other events. Never raises."""
+def record_export_event(tool: str, fmt: str, rows: int, mode: str = "sync", outcome: str = "ok") -> None:
+	"""One line per server-side export ATTEMPT (export_query etc.): format, row
+	count, sync/background, and ``outcome`` (ok / no_data / denied / rejected).
+	Emitting on the fail-closed paths too is the point - the refused large exports
+	are exactly the signal that would justify raising the ceiling / building the
+	async path. Routes through the same INFO-pinned logger. Never raises."""
 	try:
 		_emit(
 			{
@@ -100,6 +102,7 @@ def record_export_event(tool: str, fmt: str, rows: int, mode: str = "sync") -> N
 				"format": fmt,
 				"rows": int(rows),
 				"mode": mode,
+				"outcome": outcome,
 			}
 		)
 	except Exception:

--- a/jarvis/tests/test_export_query.py
+++ b/jarvis/tests/test_export_query.py
@@ -3,7 +3,7 @@ from unittest import mock
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, NoDataError
 from jarvis.tools._export import resolvers
 from jarvis.tools.export_query import export_query
 
@@ -45,73 +45,47 @@ class TestExportQuery(FrappeTestCase):
 			with self.assertRaises(InvalidArgumentError):
 				export_query("ToDo", filters={"description": ["like", "eq-%"]}, fields=["name"])
 
-	def test_emits_telemetry(self):
+	def test_emits_telemetry_ok(self):
 		with mock.patch("jarvis.telemetry.record_export_event") as m:
 			export_query("ToDo", filters={"description": ["like", "eq-%"]}, fields=["name"])
 		m.assert_called_once()
 		self.assertEqual(m.call_args.kwargs.get("mode"), "sync")
+		self.assertEqual(m.call_args.kwargs.get("outcome"), "ok")
 
+	def test_empty_result_raises_nodata(self):
+		# A zero-match export must refuse (like export_excel), not hand back a
+		# normal-looking but empty file (I-7).
+		with self.assertRaises(NoDataError):
+			export_query("ToDo", filters={"description": ["like", "__no-match-zzz__%"]}, fields=["name"])
 
-class TestExportQueryPermissions(FrappeTestCase):
-	"""The mutation-proof guard: a restricted user's export reflects only the
-	records they may see. Fails immediately if the resolver ever switches to
-	get_all / ignore_permissions."""
+	def test_non_string_format_is_clean_error(self):
+		# A non-string format must be a clean InvalidArgumentError, not an opaque
+		# AttributeError/500 from .lower() (M-4).
+		with self.assertRaises(InvalidArgumentError):
+			export_query("ToDo", filters={"description": ["like", "eq-%"]}, format=["csv"])
 
-	USER = "jv-export-restricted@example.com"
+	def test_fail_closed_emits_outcome(self):
+		# The fail-closed ceiling path must still emit a telemetry outcome, so
+		# refused exports are visible to operators (I-5).
+		with mock.patch.object(resolvers, "_HARD_ROW_CEILING", 2):
+			with mock.patch("jarvis.telemetry.record_export_event") as m:
+				with self.assertRaises(InvalidArgumentError):
+					export_query("ToDo", filters={"description": ["like", "eq-%"]}, fields=["name"])
+		m.assert_called_once()
+		self.assertEqual(m.call_args.kwargs.get("outcome"), "rejected")
 
-	def setUp(self):
-		super().setUp()
-		frappe.set_user("Administrator")
-		frappe.db.delete("ToDo", {"description": ["like", "eqp-%"]})
-		self.todos = []
-		for i in range(3):
-			d = frappe.get_doc({"doctype": "ToDo", "description": f"eqp-{i}"}).insert()
-			self.todos.append(d.name)
+	def test_cells_truncated_surfaced_in_envelope(self):
+		# An over-long cell trips the xlsx 32767 cap; the disclosure must reach the
+		# returned envelope, not just the model meta (I-11).
+		frappe.get_doc({"doctype": "ToDo", "description": "trunc " + "x" * 40_000}).insert()
+		res = export_query(
+			"ToDo", filters={"description": ["like", "trunc %"]}, fields=["description"], format="xlsx"
+		)
+		self.assertTrue(res.get("cells_truncated"))
+		self.assertIn("truncated", res.get("note", "").lower())
 
-		if not frappe.db.exists("User", self.USER):
-			frappe.get_doc(
-				{
-					"doctype": "User",
-					"email": self.USER,
-					"first_name": "eqp",
-					"send_welcome_email": 0,
-					"enabled": 1,
-					"user_type": "System User",
-				}
-			).insert(ignore_permissions=True)
-		if "System Manager" in frappe.get_roles(self.USER):
-			frappe.get_doc("User", self.USER).remove_roles("System Manager")
-
-		# Scope the user to exactly ONE of the three ToDos.
-		frappe.db.delete("User Permission", {"user": self.USER, "allow": "ToDo"})
-		frappe.get_doc(
-			{
-				"doctype": "User Permission",
-				"user": self.USER,
-				"allow": "ToDo",
-				"for_value": self.todos[0],
-			}
-		).insert(ignore_permissions=True)
-		frappe.clear_cache(user=self.USER)
-
-	def tearDown(self):
-		frappe.set_user("Administrator")
-		super().tearDown()
-
-	def test_export_reflects_only_permitted_records(self):
-		flt = {"description": ["like", "eqp-%"]}
-		# Administrator sees all three.
-		admin_res = export_query("ToDo", filters=flt, fields=["name", "description"])
-		self.assertEqual(admin_res["total"], 3)
-
-		# The restricted (non-admin) user sees a STRICTLY smaller set - here zero:
-		# ToDo's record-level permission conditions hide the Administrator-created
-		# ToDos from a non-owner (the setUp User Permission further scopes access).
-		# The point is that enforcement is APPLIED: if the resolver ever used
-		# get_all / ignore_permissions this would be 3 like the admin, so this
-		# assertion is mutation-proof against a permission bypass.
-		frappe.set_user(self.USER)
-		self.assertTrue(frappe.has_permission("ToDo", "read"))  # not a blanket denial
-		restricted_res = export_query("ToDo", filters=flt, fields=["name", "description"])
-		self.assertLess(restricted_res["total"], admin_res["total"])
-		self.assertEqual(restricted_res["total"], 0)
+	def test_child_table_export_via_parent_doctype(self):
+		# A child (Table) doctype is exportable when parent_doctype is passed - the
+		# resolver's parent hint is now actually reachable through export_query (I-6).
+		res = export_query("Has Role", parent_doctype="User", fields=["role"], format="csv")
+		self.assertTrue(res["file_url"].endswith(".csv"))

--- a/jarvis/tests/test_export_query.py
+++ b/jarvis/tests/test_export_query.py
@@ -1,0 +1,115 @@
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._export import resolvers
+from jarvis.tools.export_query import export_query
+
+
+class TestExportQuery(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		frappe.db.delete("ToDo", {"description": ["like", "eq-%"]})
+		for i in range(4):
+			frappe.get_doc({"doctype": "ToDo", "description": f"eq-{i}"}).insert()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_xlsx_export_returns_envelope_with_total(self):
+		res = export_query(
+			"ToDo",
+			filters={"description": ["like", "eq-%"]},
+			fields=["name", "description"],
+			format="xlsx",
+			title="Todos",
+		)
+		self.assertTrue(res["file_url"].endswith(".xlsx"))
+		self.assertEqual(res["total"], 4)
+		self.assertTrue(frappe.db.exists("File", res["name"]))
+
+	def test_csv_export(self):
+		res = export_query("ToDo", filters={"description": ["like", "eq-%"]}, fields=["name"], format="csv")
+		self.assertTrue(res["file_url"].endswith(".csv"))
+
+	def test_bad_format_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			export_query("ToDo", format="parquet")
+
+	def test_fails_closed_above_ceiling(self):
+		with mock.patch.object(resolvers, "_HARD_ROW_CEILING", 2):
+			with self.assertRaises(InvalidArgumentError):
+				export_query("ToDo", filters={"description": ["like", "eq-%"]}, fields=["name"])
+
+	def test_emits_telemetry(self):
+		with mock.patch("jarvis.telemetry.record_export_event") as m:
+			export_query("ToDo", filters={"description": ["like", "eq-%"]}, fields=["name"])
+		m.assert_called_once()
+		self.assertEqual(m.call_args.kwargs.get("mode"), "sync")
+
+
+class TestExportQueryPermissions(FrappeTestCase):
+	"""The mutation-proof guard: a restricted user's export reflects only the
+	records they may see. Fails immediately if the resolver ever switches to
+	get_all / ignore_permissions."""
+
+	USER = "jv-export-restricted@example.com"
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		frappe.db.delete("ToDo", {"description": ["like", "eqp-%"]})
+		self.todos = []
+		for i in range(3):
+			d = frappe.get_doc({"doctype": "ToDo", "description": f"eqp-{i}"}).insert()
+			self.todos.append(d.name)
+
+		if not frappe.db.exists("User", self.USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": self.USER,
+					"first_name": "eqp",
+					"send_welcome_email": 0,
+					"enabled": 1,
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True)
+		if "System Manager" in frappe.get_roles(self.USER):
+			frappe.get_doc("User", self.USER).remove_roles("System Manager")
+
+		# Scope the user to exactly ONE of the three ToDos.
+		frappe.db.delete("User Permission", {"user": self.USER, "allow": "ToDo"})
+		frappe.get_doc(
+			{
+				"doctype": "User Permission",
+				"user": self.USER,
+				"allow": "ToDo",
+				"for_value": self.todos[0],
+			}
+		).insert(ignore_permissions=True)
+		frappe.clear_cache(user=self.USER)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_export_reflects_only_permitted_records(self):
+		flt = {"description": ["like", "eqp-%"]}
+		# Administrator sees all three.
+		admin_res = export_query("ToDo", filters=flt, fields=["name", "description"])
+		self.assertEqual(admin_res["total"], 3)
+
+		# The restricted user (a User Permission scopes their ToDo access) sees a
+		# STRICTLY smaller set - here zero. The point is enforcement is applied:
+		# if the resolver ever used get_all / ignore_permissions this would be 3,
+		# so this assertion is mutation-proof against a permission bypass.
+		frappe.set_user(self.USER)
+		self.assertTrue(frappe.has_permission("ToDo", "read"))  # not a blanket denial
+		restricted_res = export_query("ToDo", filters=flt, fields=["name", "description"])
+		self.assertLess(restricted_res["total"], admin_res["total"])
+		self.assertEqual(restricted_res["total"], 0)

--- a/jarvis/tests/test_export_query.py
+++ b/jarvis/tests/test_export_query.py
@@ -104,10 +104,12 @@ class TestExportQueryPermissions(FrappeTestCase):
 		admin_res = export_query("ToDo", filters=flt, fields=["name", "description"])
 		self.assertEqual(admin_res["total"], 3)
 
-		# The restricted user (a User Permission scopes their ToDo access) sees a
-		# STRICTLY smaller set - here zero. The point is enforcement is applied:
-		# if the resolver ever used get_all / ignore_permissions this would be 3,
-		# so this assertion is mutation-proof against a permission bypass.
+		# The restricted (non-admin) user sees a STRICTLY smaller set - here zero:
+		# ToDo's record-level permission conditions hide the Administrator-created
+		# ToDos from a non-owner (the setUp User Permission further scopes access).
+		# The point is that enforcement is APPLIED: if the resolver ever used
+		# get_all / ignore_permissions this would be 3 like the admin, so this
+		# assertion is mutation-proof against a permission bypass.
 		frappe.set_user(self.USER)
 		self.assertTrue(frappe.has_permission("ToDo", "read"))  # not a blanket denial
 		restricted_res = export_query("ToDo", filters=flt, fields=["name", "description"])

--- a/jarvis/tests/test_export_renderers.py
+++ b/jarvis/tests/test_export_renderers.py
@@ -64,3 +64,13 @@ class TestXlsxRenderer(FrappeTestCase):
 		cell = self._cells(content)[1][0]
 		self.assertLessEqual(len(cell), 32_767)
 		self.assertTrue(cell.endswith("…[truncated]"))
+
+	def test_html_wrapped_formula_is_neutralized(self):
+		# make_xlsx runs handle_html AFTER escaping, which would unwrap
+		# <p>=FORMULA</p> back into a live =FORMULA. We unwrap BEFORE escaping, so
+		# the stored cell is neutralized text, not an executable formula.
+		m = ExportModel(columns=["c"], rows=[['<p>=HYPERLINK("http://evil","x")</p>']], total=1)
+		cell = self._cells(renderers.xlsx(m))[1][0]
+		self.assertTrue(cell.startswith("'"), cell)  # apostrophe-escaped
+		self.assertFalse(cell.startswith("="), cell)  # NOT a live formula
+		self.assertNotIn("<p>", cell)  # HTML unwrapped

--- a/jarvis/tests/test_export_renderers.py
+++ b/jarvis/tests/test_export_renderers.py
@@ -1,0 +1,66 @@
+import io
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools._export import renderers
+from jarvis.tools._export.model import ExportModel
+
+
+class TestCsvRenderer(FrappeTestCase):
+	def test_header_and_rows_present(self):
+		m = ExportModel(columns=["name", "qty"], rows=[["A", 1], ["B", 2]], total=2)
+		out = renderers.csv(m).decode("utf-8").splitlines()
+		self.assertIn("name", out[0])
+		self.assertIn("qty", out[0])
+		self.assertIn("A", out[1])
+		self.assertIn("B", out[2])
+
+	def test_escapes_formula_cell(self):
+		m = ExportModel(columns=["c"], rows=[["=SUM(A1:A9)"]], total=1)
+		out = renderers.csv(m).decode("utf-8")
+		self.assertIn("'=SUM(A1:A9)", out)
+
+	def test_escapes_formula_header(self):
+		m = ExportModel(columns=["=cmd"], rows=[["ok"]], total=1)
+		out = renderers.csv(m).decode("utf-8")
+		self.assertTrue(out.splitlines()[0].startswith("'=cmd") or '"\'=cmd"' in out.splitlines()[0])
+
+	def test_empty_rows_gives_header_only_file(self):
+		m = ExportModel(columns=["name"], rows=[], total=0)
+		out = renderers.csv(m).decode("utf-8").splitlines()
+		self.assertEqual(len(out), 1)
+		self.assertIn("name", out[0])
+
+
+class TestXlsxRenderer(FrappeTestCase):
+	def _cells(self, content: bytes):
+		import openpyxl
+
+		wb = openpyxl.load_workbook(io.BytesIO(content), read_only=True)
+		ws = wb.active
+		return [[c for c in row] for row in ws.iter_rows(values_only=True)]
+
+	def test_produces_zip_workbook(self):
+		m = ExportModel(columns=["name", "qty"], rows=[["A", 1]], total=1)
+		self.assertEqual(renderers.xlsx(m)[:2], b"PK")
+
+	def test_escaped_formula_is_in_the_real_cell(self):
+		m = ExportModel(columns=["c"], rows=[["=cmd"]], total=1)
+		cells = self._cells(renderers.xlsx(m))
+		# Row 0 header, row 1 the escaped value.
+		self.assertEqual(cells[1][0], "'=cmd")
+
+	def test_header_only_when_empty(self):
+		m = ExportModel(columns=["name"], rows=[], total=0)
+		cells = self._cells(renderers.xlsx(m))
+		self.assertEqual(len(cells), 1)
+		self.assertEqual(cells[0][0], "name")
+
+	def test_overlong_cell_truncated_and_flagged(self):
+		big = "x" * 40_000
+		m = ExportModel(columns=["c"], rows=[[big]], total=1)
+		content = renderers.xlsx(m)
+		self.assertTrue(m.meta.get("cells_truncated"))
+		cell = self._cells(content)[1][0]
+		self.assertLessEqual(len(cell), 32_767)
+		self.assertTrue(cell.endswith("…[truncated]"))

--- a/jarvis/tests/test_export_resolvers.py
+++ b/jarvis/tests/test_export_resolvers.py
@@ -57,3 +57,138 @@ class TestFromQuery(FrappeTestCase):
 			with self.assertRaises(InvalidArgumentError) as ctx:
 				from_query("ToDo", filters={"description": ["like", "resolver-test-%"]}, fields=["name"])
 		self.assertIn("too many to export", str(ctx.exception))
+
+	def test_exact_ceiling_does_not_raise(self):
+		# Boundary: exactly ceiling rows (N == ceiling) must SUCCEED, not raise.
+		with mock.patch.object(resolvers, "_HARD_ROW_CEILING", 3):
+			m = from_query("ToDo", filters={"description": ["like", "resolver-test-%"]}, fields=["name"])
+		self.assertEqual(m.total, 3)
+
+
+class TestExportPermGuards(FrappeTestCase):
+	"""B (Export DocPerm) + doctype guards, on a real doctype (ToDo)."""
+
+	USER = "jve-noexport@example.com"
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		if not frappe.db.exists("User", self.USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": self.USER,
+					"first_name": "noexport",
+					"send_welcome_email": 0,
+					"enabled": 1,
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True)
+		if "System Manager" in frappe.get_roles(self.USER):
+			frappe.get_doc("User", self.USER).remove_roles("System Manager")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_denies_without_export_permission(self):
+		# The user can READ ToDo (role "All") but has no Export DocPerm on it, so a
+		# bulk export must be refused (B), even though a plain read/get_list works.
+		frappe.set_user(self.USER)
+		self.assertTrue(frappe.has_permission("ToDo", "read"))
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			from_query("ToDo", fields=["name"])
+		self.assertIn("export", str(ctx.exception).lower())
+
+	def test_missing_and_unknown_doctype_guards(self):
+		with self.assertRaises(InvalidArgumentError):
+			from_query(None, fields=["name"])
+		with self.assertRaises(InvalidArgumentError) as ctx:
+			from_query("JV No Such Doctype ZZZ", fields=["name"])
+		self.assertIn("unknown DocType", str(ctx.exception))
+
+
+class TestFieldLevelAlignment(FrappeTestCase):
+	"""Field-level (permlevel) enforcement + column alignment, on a custom doctype
+	where the user HAS export perm (B passes) but lacks permlevel-1 read.
+	Mutation-proof for the v17 as_dict-projection fix: with the old positional
+	as_list code, v17 drops the permlevel field and every column shifts left."""
+
+	DT = "JV Export Perm Test"
+	ROLE = "JVE Owner Role"
+	USER = "jve-owner@example.com"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("Role", cls.ROLE):
+			frappe.get_doc(
+				{"doctype": "Role", "role_name": cls.ROLE, "desk_access": 1, "is_custom": 1}
+			).insert(ignore_permissions=True)
+		# Recreate each run so the perms are always the current fixture's (a stale
+		# copy from a prior run would otherwise persist - custom doctypes commit).
+		if frappe.db.exists("DocType", cls.DT):
+			frappe.delete_doc("DocType", cls.DT, force=True, ignore_permissions=True)
+		if True:
+			from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+			new_doctype(
+				cls.DT,
+				fields=[
+					{"label": "Tag", "fieldname": "tag", "fieldtype": "Data"},
+					{
+						"label": "Secret",
+						"fieldname": "secret",
+						"fieldtype": "Data",
+						"permlevel": 1,
+						"default": "SECRET",
+					},
+				],
+				permissions=[
+					{"role": "System Manager", "read": 1, "write": 1, "create": 1, "export": 1},
+					{"role": cls.ROLE, "read": 1, "export": 1, "permlevel": 0},
+				],
+			).insert(ignore_permissions=True)
+		if not frappe.db.exists("User", cls.USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": cls.USER,
+					"first_name": "owner",
+					"send_welcome_email": 0,
+					"enabled": 1,
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True)
+		u = frappe.get_doc("User", cls.USER)
+		if "System Manager" in frappe.get_roles(cls.USER):
+			u.remove_roles("System Manager")
+		if cls.ROLE not in frappe.get_roles(cls.USER):
+			u.add_roles(cls.ROLE)
+		frappe.clear_cache()  # refresh role/permission caches for the new doctype
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		frappe.db.delete(self.DT)
+		# 3 rows, each carrying secret="SECRET" (a permlevel-1 field the user can't read).
+		for i in range(3):
+			frappe.get_doc({"doctype": self.DT, "tag": f"u{i}"}).insert(ignore_permissions=True)
+		frappe.clear_cache(user=self.USER)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_field_level_projection_keeps_columns_aligned(self):
+		frappe.set_user(self.USER)
+		m = from_query(self.DT, fields=["name", "tag", "secret"])
+		self.assertEqual(m.total, 3)  # export perm (B) passes; all rows visible
+		self.assertEqual(m.columns, ["name", "tag", "secret"])
+		s_idx, t_idx = m.columns.index("secret"), m.columns.index("tag")
+		for row in m.rows:
+			self.assertEqual(len(row), 3)  # alignment holds on every engine (v16/v17)
+			# Field-level: permlevel-1 "secret" is blank for this user...
+			self.assertIn(row[s_idx], (None, ""))
+			# ...and "tag" (its real value) sits under the "tag" header, not shifted.
+			self.assertTrue(str(row[t_idx]).startswith("u"))

--- a/jarvis/tests/test_export_resolvers.py
+++ b/jarvis/tests/test_export_resolvers.py
@@ -1,0 +1,59 @@
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools._export import resolvers
+from jarvis.tools._export.resolvers import from_query
+
+
+class TestFromQuery(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		# Deterministic regardless of cross-test rollback behaviour: start from a
+		# known-empty set for our marker, then insert exactly 3.
+		frappe.db.delete("ToDo", {"description": ["like", "resolver-test-%"]})
+		for i in range(3):
+			frappe.get_doc({"doctype": "ToDo", "description": f"resolver-test-{i}"}).insert()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_returns_all_matching_rows_uncapped(self):
+		m = from_query(
+			"ToDo",
+			filters={"description": ["like", "resolver-test-%"]},
+			fields=["name", "description"],
+		)
+		self.assertEqual(m.total, 3)
+		self.assertEqual(len(m.rows), 3)
+		self.assertEqual(m.columns, ["name", "description"])
+
+	def test_default_fields_when_none(self):
+		m = from_query("ToDo", filters={"description": ["like", "resolver-test-%"]})
+		self.assertIn("name", m.columns)
+
+	def test_rejects_star_fields(self):
+		with self.assertRaises(InvalidArgumentError):
+			from_query("ToDo", fields=["*"])
+
+	def test_child_table_needs_parent_doctype(self):
+		# "Has Role" is a child table (istable) of User.
+		with self.assertRaises(InvalidArgumentError) as ctx:
+			from_query("Has Role", fields=["role"])
+		self.assertIn("child table", str(ctx.exception))
+
+	def test_denies_doctype_without_read(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(PermissionDeniedError):
+			from_query("User", fields=["name"])
+
+	def test_fails_closed_above_ceiling(self):
+		# 3 matching rows, ceiling forced to 2 -> must RAISE, never a partial file.
+		with mock.patch.object(resolvers, "_HARD_ROW_CEILING", 2):
+			with self.assertRaises(InvalidArgumentError) as ctx:
+				from_query("ToDo", filters={"description": ["like", "resolver-test-%"]}, fields=["name"])
+		self.assertIn("too many to export", str(ctx.exception))

--- a/jarvis/tests/test_export_seam.py
+++ b/jarvis/tests/test_export_seam.py
@@ -65,6 +65,22 @@ class TestExportEnvelope(FrappeTestCase):
 		self.assertTrue(env["filename"].endswith(".csv"))
 		self.assertTrue(len(env["filename"]) > len(".csv"))
 
+	def test_file_save_validation_error_becomes_clean_error(self):
+		# save_file raises ValidationError (e.g. MaxFileSizeReachedError) for a File
+		# constraint; an over-limit export must surface a clean InvalidArgumentError,
+		# not an opaque 500 / Error Log. (Reviewer I1.)
+		from unittest import mock
+
+		from frappe.exceptions import ValidationError
+
+		from jarvis.exceptions import InvalidArgumentError
+
+		with mock.patch(
+			"frappe.utils.file_manager.save_file", side_effect=ValidationError("File size exceeded")
+		):
+			with self.assertRaises(InvalidArgumentError):
+				save_export_file("x.xlsx", b"PK\x03\x04", title="Big", mime_type="x")
+
 
 class TestFormulaEscape(FrappeTestCase):
 	def test_dangerous_leading_chars_are_prefixed(self):

--- a/jarvis/tests/test_export_seam.py
+++ b/jarvis/tests/test_export_seam.py
@@ -65,6 +65,13 @@ class TestExportEnvelope(FrappeTestCase):
 		self.assertTrue(env["filename"].endswith(".csv"))
 		self.assertTrue(len(env["filename"]) > len(".csv"))
 
+	def test_long_title_base_capped(self):
+		# The sanitizer caps the base name so a runaway title can't blow the File
+		# name length (regression cover after the _safe_filename -> _safe_base move).
+		env = save_export_file("x.csv", b"data\n", title="z" * 500, mime_type="text/csv")
+		base = env["filename"].rsplit(".", 1)[0]
+		self.assertLessEqual(len(base), 80)
+
 	def test_file_save_validation_error_becomes_clean_error(self):
 		# save_file raises ValidationError (e.g. MaxFileSizeReachedError) for a File
 		# constraint; an over-limit export must surface a clean InvalidArgumentError,

--- a/jarvis/tests/test_export_seam.py
+++ b/jarvis/tests/test_export_seam.py
@@ -3,6 +3,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis.tools._export.envelope import save_export_file
 from jarvis.tools._export.model import ExportModel
+from jarvis.tools._export.safety import escape_formula
 
 
 class TestExportModel(FrappeTestCase):
@@ -63,3 +64,19 @@ class TestExportEnvelope(FrappeTestCase):
 		env = save_export_file("x.csv", b"data\n", title="", mime_type="text/csv")
 		self.assertTrue(env["filename"].endswith(".csv"))
 		self.assertTrue(len(env["filename"]) > len(".csv"))
+
+
+class TestFormulaEscape(FrappeTestCase):
+	def test_dangerous_leading_chars_are_prefixed(self):
+		for bad in ("=1+1", "+1", "-1", "@x", "\t=cmd", "\r=cmd"):
+			self.assertTrue(escape_formula(bad).startswith("'"), bad)
+
+	def test_safe_values_untouched(self):
+		self.assertEqual(escape_formula("Acme Ltd"), "Acme Ltd")
+		self.assertEqual(escape_formula("123"), "123")
+		self.assertEqual(escape_formula(""), "")
+
+	def test_non_strings_pass_through(self):
+		self.assertEqual(escape_formula(42), 42)
+		self.assertEqual(escape_formula(0), 0)
+		self.assertIsNone(escape_formula(None))

--- a/jarvis/tests/test_export_seam.py
+++ b/jarvis/tests/test_export_seam.py
@@ -1,0 +1,65 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools._export.envelope import save_export_file
+from jarvis.tools._export.model import ExportModel
+
+
+class TestExportModel(FrappeTestCase):
+	def test_model_holds_columns_rows_total(self):
+		m = ExportModel(columns=["a", "b"], rows=[[1, 2]], total=1, meta={})
+		self.assertEqual(m.columns, ["a", "b"])
+		self.assertEqual(m.rows, [[1, 2]])
+		self.assertEqual(m.total, 1)
+		self.assertEqual(m.meta, {})
+
+	def test_meta_defaults_to_empty_dict(self):
+		m = ExportModel(columns=["a"], rows=[], total=0)
+		self.assertEqual(m.meta, {})
+
+
+class TestExportEnvelope(FrappeTestCase):
+	def test_returns_download_card_envelope(self):
+		env = save_export_file("x.csv", b"a,b\n1,2\n", title="My Todos", mime_type="text/csv")
+		self.assertTrue(env["file_url"].endswith(".csv"))
+		self.assertEqual(env["mime_type"], "text/csv")
+		self.assertEqual(env["title"], "My Todos")
+		self.assertGreater(env["size_bytes"], 0)
+		self.assertTrue(frappe.db.exists("File", env["name"]))
+
+	def test_file_is_private(self):
+		env = save_export_file("x.csv", b"data\n", title="t", mime_type="text/csv")
+		self.assertEqual(frappe.db.get_value("File", env["name"], "is_private"), 1)
+
+	def test_default_is_owner_only_unattached(self):
+		# No dt/dn -> unattached File, whose has_permission falls through to owner-only.
+		env = save_export_file("x.csv", b"data\n", title="t", mime_type="text/csv")
+		attached_to = frappe.db.get_value(
+			"File", env["name"], ["attached_to_doctype", "attached_to_name"], as_dict=True
+		)
+		self.assertIsNone(attached_to.attached_to_doctype)
+		self.assertIsNone(attached_to.attached_to_name)
+
+	def test_can_attach_when_dt_dn_given(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "attach-target"}).insert()
+		env = save_export_file(
+			"x.csv", b"a,b\n1,2\n", title="t", mime_type="text/csv", dt="ToDo", dn=todo.name
+		)
+		self.assertEqual(frappe.db.get_value("File", env["name"], "attached_to_doctype"), "ToDo")
+
+	def test_filename_extension_preserved_from_arg(self):
+		env = save_export_file("ignored-base.xlsx", b"PK\x03\x04", title="Report Q1", mime_type="x")
+		self.assertTrue(env["filename"].endswith(".xlsx"))
+
+	def test_unsafe_title_is_sanitized(self):
+		# A title carrying markup / slashes must not raise inside save_file
+		# ("File name cannot have /") nor leak the raw characters.
+		env = save_export_file("x.csv", b"data\n", title="Sales </b> 2026/Q1", mime_type="text/csv")
+		self.assertNotIn("/", env["filename"])
+		self.assertNotIn("<", env["filename"])
+		self.assertTrue(env["filename"].endswith(".csv"))
+
+	def test_blank_title_falls_back(self):
+		env = save_export_file("x.csv", b"data\n", title="", mime_type="text/csv")
+		self.assertTrue(env["filename"].endswith(".csv"))
+		self.assertTrue(len(env["filename"]) > len(".csv"))

--- a/jarvis/tests/test_report_pdf.py
+++ b/jarvis/tests/test_report_pdf.py
@@ -19,7 +19,6 @@ from jarvis.tools.report_pdf import (
 	_cell,
 	_normalise_columns,
 	_render_html,
-	_safe_filename,
 	report_pdf,
 )
 
@@ -198,12 +197,6 @@ class TestReportPdf(FrappeTestCase):
 		# The stored filename is sanitised to safe characters.
 		self.assertNotIn("/", out["filename"])
 		self.assertNotIn("<", out["filename"])
-
-	def test_safe_filename_strips_markup_slashes_and_never_empties(self):
-		self.assertEqual(_safe_filename("Flow <b>x</b>/y"), "Flow-b-x-b-y")
-		self.assertEqual(_safe_filename("////"), "report")
-		self.assertEqual(_safe_filename(""), "report")
-		self.assertLessEqual(len(_safe_filename("z" * 500)), 80)
 
 	# ── get_pdf yields no bytes -> clean error (reviewer M1, edge case 10) ─────
 	def test_empty_pdf_bytes_raises(self):

--- a/jarvis/tests/test_report_pdf.py
+++ b/jarvis/tests/test_report_pdf.py
@@ -136,6 +136,19 @@ class TestReportPdf(FrappeTestCase):
 		out = report_pdf(self.DATA, title="Q3 Users")
 		self.assertEqual(out["title"], "Q3 Users")
 
+	def test_pdf_file_is_owner_only_not_attached_to_report(self):
+		# C5 (export plan-check): the PDF is rendered under the caller's row-/field-
+		# filtered permissions, so it must be an UNATTACHED (owner-only) File - never
+		# attached to the shared Report doc, which would let anyone who can read the
+		# Report download a row-filtered artifact. Mutation-proof: reverting to
+		# dt="Report" fails this.
+		out = report_pdf(self.DATA)
+		attached = frappe.db.get_value(
+			"File", out["name"], ["attached_to_doctype", "attached_to_name"], as_dict=True
+		)
+		self.assertIsNone(attached.attached_to_doctype)
+		self.assertIsNone(attached.attached_to_name)
+
 	# ── zero rows ─────────────────────────────────────────────────────────────
 	def test_zero_rows_still_produces_a_valid_pdf(self):
 		"""An empty report is a PDF with a 'No data' note, never an error or a

--- a/jarvis/tools/_export/__init__.py
+++ b/jarvis/tools/_export/__init__.py
@@ -1,0 +1,4 @@
+from jarvis.tools._export.envelope import save_export_file
+from jarvis.tools._export.model import ExportModel
+
+__all__ = ["ExportModel", "save_export_file"]

--- a/jarvis/tools/_export/envelope.py
+++ b/jarvis/tools/_export/envelope.py
@@ -14,7 +14,7 @@ def _safe_base(title: str) -> str:
 	closing HTML tag (``</b>``), which then raises ``ValidationError: File name
 	cannot have /`` deep inside ``save_file`` (a bug already hit for a sibling
 	tool). Keep only filename-safe characters, cap the length, never return
-	empty. Mirrors report_pdf._safe_filename."""
+	empty. The single filename sanitiser for every export tool."""
 	base = re.sub(r"[^A-Za-z0-9._-]+", "-", title or "").strip("-.")
 	return base[:80] or "export"
 
@@ -36,11 +36,25 @@ def save_export_file(
 	owner-only, so an export is readable only by the user who ran it. Pass
 	``dt``/``dn`` only to attach to a record the same audience may already read
 	(e.g. download_pdf attaching to its own record)."""
+	from frappe.exceptions import ValidationError
 	from frappe.utils.file_manager import save_file
+
+	from jarvis.exceptions import InvalidArgumentError
 
 	ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else "bin"
 	fname = f"{_safe_base(title)}.{ext}"
-	fdoc = save_file(fname, content, dt, dn, is_private=1)
+	try:
+		fdoc = save_file(fname, content, dt, dn, is_private=1)
+	except ValidationError as e:
+		# save_file raises ValidationError for a File-save constraint - notably
+		# MaxFileSizeReachedError when the bytes exceed the site's max_file_size
+		# (default 10 MB), which a large but under-row-ceiling export can hit. A big
+		# export is legitimate, so translate to a clean, actionable error for BOTH
+		# callers rather than an opaque 500 / Error Log.
+		raise InvalidArgumentError(
+			f"could not store the export file (it may exceed the site's maximum file "
+			f"size - narrow the data or export fewer fields): {e}"
+		) from e
 	return {
 		"file_url": fdoc.file_url,
 		"filename": fdoc.file_name,

--- a/jarvis/tools/_export/envelope.py
+++ b/jarvis/tools/_export/envelope.py
@@ -1,9 +1,11 @@
 import re
 
-# The single place an export becomes a File + download-card envelope, so every
-# export tool (new export_query AND the existing report_pdf/export_excel) shares
-# one shape. The chat surface renders the card automatically from this envelope
-# via api._maybe_attach_artifact (keyed on the filename extension -> canvas._EXT_TYPE).
+# The shared builder that turns an export into a private File + download-card
+# envelope. Used by export_query and report_pdf; export_excel / export_document /
+# download_pdf still roll their own save (a follow-up migration - see the export
+# DEFERRED backlog). The chat surface renders the card automatically from this
+# envelope via api._maybe_attach_artifact (keyed on the filename extension ->
+# canvas._EXT_TYPE).
 
 
 def _safe_base(title: str) -> str:
@@ -47,13 +49,14 @@ def save_export_file(
 		fdoc = save_file(fname, content, dt, dn, is_private=1)
 	except ValidationError as e:
 		# save_file raises ValidationError for a File-save constraint - notably
-		# MaxFileSizeReachedError when the bytes exceed the site's max_file_size
-		# (default 10 MB), which a large but under-row-ceiling export can hit. A big
-		# export is legitimate, so translate to a clean, actionable error for BOTH
-		# callers rather than an opaque 500 / Error Log.
+		# MaxFileSizeReachedError when the bytes exceed the site's max_file_size,
+		# which a large but under-row-ceiling export can hit. A big export is
+		# legitimate, so translate to a clean, self-contained, actionable message
+		# (the raw driver text can carry markup + a second admin-only remedy that
+		# reads as a run-on); the original rides in the traceback via `from e`.
 		raise InvalidArgumentError(
-			f"could not store the export file (it may exceed the site's maximum file "
-			f"size - narrow the data or export fewer fields): {e}"
+			"The export is too large to store as a file (it exceeds this site's maximum "
+			"file size). Narrow the filter or export fewer fields."
 		) from e
 	return {
 		"file_url": fdoc.file_url,

--- a/jarvis/tools/_export/envelope.py
+++ b/jarvis/tools/_export/envelope.py
@@ -1,0 +1,51 @@
+import re
+
+# The single place an export becomes a File + download-card envelope, so every
+# export tool (new export_query AND the existing report_pdf/export_excel) shares
+# one shape. The chat surface renders the card automatically from this envelope
+# via api._maybe_attach_artifact (keyed on the filename extension -> canvas._EXT_TYPE).
+
+
+def _safe_base(title: str) -> str:
+	"""File-doctype-safe base name from a caller title.
+
+	A title can carry markup, slashes and other characters Frappe's File
+	sanitiser rejects or rewrites - notably it re-introduces a ``/`` from a
+	closing HTML tag (``</b>``), which then raises ``ValidationError: File name
+	cannot have /`` deep inside ``save_file`` (a bug already hit for a sibling
+	tool). Keep only filename-safe characters, cap the length, never return
+	empty. Mirrors report_pdf._safe_filename."""
+	base = re.sub(r"[^A-Za-z0-9._-]+", "-", title or "").strip("-.")
+	return base[:80] or "export"
+
+
+def save_export_file(
+	filename: str,
+	content: bytes,
+	title: str,
+	mime_type: str,
+	dt: str | None = None,
+	dn: str | None = None,
+) -> dict:
+	"""Persist ``content`` as a PRIVATE File and return the download-card envelope
+	``{file_url, filename, title, mime_type, size_bytes, name}``.
+
+	The base name comes from ``title`` (sanitised); the extension comes from
+	``filename`` (it drives the chat render type). ``dt``/``dn`` default to None
+	-> an UNATTACHED private File, whose ``has_permission`` falls through to
+	owner-only, so an export is readable only by the user who ran it. Pass
+	``dt``/``dn`` only to attach to a record the same audience may already read
+	(e.g. download_pdf attaching to its own record)."""
+	from frappe.utils.file_manager import save_file
+
+	ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else "bin"
+	fname = f"{_safe_base(title)}.{ext}"
+	fdoc = save_file(fname, content, dt, dn, is_private=1)
+	return {
+		"file_url": fdoc.file_url,
+		"filename": fdoc.file_name,
+		"title": title or "Export",
+		"mime_type": mime_type,
+		"size_bytes": int(fdoc.file_size or len(content)),
+		"name": fdoc.name,
+	}

--- a/jarvis/tools/_export/model.py
+++ b/jarvis/tools/_export/model.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ExportModel:
+	"""Canonical fill->export seam: resolvers produce it, renderers consume it.
+
+	Renderers must never touch a data source - they read only this. ``total`` is
+	the TRUE, permission-filtered source count (never a capped/shown count), so a
+	renderer or tool can disclose it honestly. ``meta`` carries render hints
+	(e.g. ``title``) and disclosure flags (e.g. ``cells_truncated``)."""
+
+	columns: list[str]
+	rows: list[list]
+	total: int
+	meta: dict = field(default_factory=dict)

--- a/jarvis/tools/_export/renderers.py
+++ b/jarvis/tools/_export/renderers.py
@@ -18,6 +18,21 @@ def _clip(value, model: ExportModel):
 	return value
 
 
+def _xlsx_cell(value, model: ExportModel):
+	"""Prepare one xlsx cell. make_xlsx runs ``handle_html`` on every string cell
+	AFTER we'd escape, which would unwrap ``<p>=FORMULA</p>`` back into a live
+	``=FORMULA`` past the guard (formula injection). Mirror that unwrap HERE first,
+	so ``escape_formula`` runs on the same string make_xlsx ultimately stores (its
+	second handle_html is then a no-op - it returns input unchanged when there is
+	no ``<``/``>``). CSV needs none of this: it is not run through handle_html, and
+	a ``<``-leading cell is inert (not a formula) in a spreadsheet."""
+	if isinstance(value, str):
+		from frappe.utils.xlsxutils import handle_html
+
+		value = handle_html(value)
+	return _clip(escape_formula(value), model)
+
+
 def csv(model: ExportModel) -> bytes:
 	"""Plain CSV: escaped header + escaped rows, UTF-8. An empty rowset yields a
 	valid header-only file (an honest 'no rows' export, not an error)."""
@@ -32,9 +47,10 @@ def csv(model: ExportModel) -> bytes:
 def xlsx(model: ExportModel) -> bytes:
 	"""Styled workbook via the shared xlsx_bytes builder (bold header + date/currency
 	number formats from Frappe's make_xlsx). Header AND cells are formula-escaped;
-	over-long cells are clipped-with-marker and flagged in ``model.meta``. Empty
-	rowset -> valid header-only workbook."""
-	header = [escape_formula(c) for c in model.columns]
-	body = [[_clip(escape_formula(c), model) for c in row] for row in model.rows]
+	over-long cells are clipped-with-marker and flagged in ``model.meta``; HTML is
+	unwrapped before escaping so a formula hidden behind tags can't slip the guard.
+	Empty rowset -> valid header-only workbook."""
+	header = [_xlsx_cell(c, model) for c in model.columns]
+	body = [[_xlsx_cell(c, model) for c in row] for row in model.rows]
 	title = (model.meta.get("title") or "Export")[:31]
 	return compat.xlsx_bytes([(title, [header] + body)])

--- a/jarvis/tools/_export/renderers.py
+++ b/jarvis/tools/_export/renderers.py
@@ -18,18 +18,17 @@ def _clip(value, model: ExportModel):
 	return value
 
 
-def _xlsx_cell(value, model: ExportModel):
+def _xlsx_cell(value, model: ExportModel, unwrap):
 	"""Prepare one xlsx cell. make_xlsx runs ``handle_html`` on every string cell
 	AFTER we'd escape, which would unwrap ``<p>=FORMULA</p>`` back into a live
-	``=FORMULA`` past the guard (formula injection). Mirror that unwrap HERE first,
-	so ``escape_formula`` runs on the same string make_xlsx ultimately stores (its
-	second handle_html is then a no-op - it returns input unchanged when there is
-	no ``<``/``>``). CSV needs none of this: it is not run through handle_html, and
-	a ``<``-leading cell is inert (not a formula) in a spreadsheet."""
+	``=FORMULA`` past the guard (formula injection). Mirror that unwrap HERE first
+	(``unwrap`` is ``handle_html``, imported once per render), so ``escape_formula``
+	runs on the same string make_xlsx ultimately stores (its second handle_html is
+	then a no-op - it returns input unchanged when there is no ``<``/``>``). CSV
+	needs none of this: it is not run through handle_html, and a ``<``-leading cell
+	is inert (not a formula) in a spreadsheet."""
 	if isinstance(value, str):
-		from frappe.utils.xlsxutils import handle_html
-
-		value = handle_html(value)
+		value = unwrap(value)
 	return _clip(escape_formula(value), model)
 
 
@@ -50,7 +49,11 @@ def xlsx(model: ExportModel) -> bytes:
 	over-long cells are clipped-with-marker and flagged in ``model.meta``; HTML is
 	unwrapped before escaping so a formula hidden behind tags can't slip the guard.
 	Empty rowset -> valid header-only workbook."""
-	header = [_xlsx_cell(c, model) for c in model.columns]
-	body = [[_xlsx_cell(c, model) for c in row] for row in model.rows]
+	# Imported lazily (once per render, not per cell): xlsxutils pulls xlsxwriter,
+	# which compat.py deliberately keeps out of module import for Frappe 15.
+	from frappe.utils.xlsxutils import handle_html
+
+	header = [_xlsx_cell(c, model, handle_html) for c in model.columns]
+	body = [[_xlsx_cell(c, model, handle_html) for c in row] for row in model.rows]
 	title = (model.meta.get("title") or "Export")[:31]
 	return compat.xlsx_bytes([(title, [header] + body)])

--- a/jarvis/tools/_export/renderers.py
+++ b/jarvis/tools/_export/renderers.py
@@ -1,0 +1,40 @@
+import csv as _csv
+import io
+
+from jarvis import compat
+from jarvis.tools._export.model import ExportModel
+from jarvis.tools._export.safety import escape_formula
+
+# Excel hard-caps a single cell at 32,767 chars; make_xlsx silently drops the
+# overflow (write() returns -2, unchecked). Truncate visibly and flag it.
+_EXCEL_CELL_LIMIT = 32_767
+_TRUNC_MARKER = "…[truncated]"
+
+
+def _clip(value, model: ExportModel):
+	if isinstance(value, str) and len(value) > _EXCEL_CELL_LIMIT:
+		model.meta["cells_truncated"] = True
+		return value[: _EXCEL_CELL_LIMIT - len(_TRUNC_MARKER)] + _TRUNC_MARKER
+	return value
+
+
+def csv(model: ExportModel) -> bytes:
+	"""Plain CSV: escaped header + escaped rows, UTF-8. An empty rowset yields a
+	valid header-only file (an honest 'no rows' export, not an error)."""
+	buf = io.StringIO()
+	w = _csv.writer(buf, quoting=_csv.QUOTE_MINIMAL)
+	w.writerow([escape_formula(c) for c in model.columns])
+	for row in model.rows:
+		w.writerow([escape_formula(c) for c in row])
+	return buf.getvalue().encode("utf-8")
+
+
+def xlsx(model: ExportModel) -> bytes:
+	"""Styled workbook via the shared xlsx_bytes builder (bold header + date/currency
+	number formats from Frappe's make_xlsx). Header AND cells are formula-escaped;
+	over-long cells are clipped-with-marker and flagged in ``model.meta``. Empty
+	rowset -> valid header-only workbook."""
+	header = [escape_formula(c) for c in model.columns]
+	body = [[_clip(escape_formula(c), model) for c in row] for row in model.rows]
+	title = (model.meta.get("title") or "Export")[:31]
+	return compat.xlsx_bytes([(title, [header] + body)])

--- a/jarvis/tools/_export/resolvers.py
+++ b/jarvis/tools/_export/resolvers.py
@@ -1,0 +1,78 @@
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools._export.model import ExportModel
+from jarvis.tools.get_list import _child_table_parents
+
+# Server-side hard ceiling. ABOVE this we FAIL CLOSED (raise) rather than return
+# a silently-partial file - an export must never look complete when it isn't.
+# Sized as a memory/time backstop; streaming export of larger sets is a deferred
+# follow-up (see the export DEFERRED backlog).
+_HARD_ROW_CEILING = 100_000
+
+
+def _default_fields(doctype: str) -> list[str]:
+	"""Never bulk-export every field by default; a caller opts into wide fields.
+	Default to name + the title field (if distinct)."""
+	meta = frappe.get_meta(doctype)
+	title_field = meta.title_field or "name"
+	return ["name"] + ([title_field] if title_field != "name" else [])
+
+
+def from_query(doctype, filters=None, fields=None, order_by=None, parent_doctype=None) -> ExportModel:
+	"""Resolve doctype+filters to a canonical ExportModel, SERVER-SIDE and
+	permission-checked. Record- and field-level permissions are inherited from
+	``frappe.get_list`` (a permlevel-denied field comes back NULL, so column
+	alignment holds). Rows never return to the model context (reference-not-rows).
+
+	NOT capped for the model, but FAIL-CLOSED above ``_HARD_ROW_CEILING`` so an
+	oversized export raises instead of silently truncating. ``total`` is the TRUE,
+	permission-filtered source count (we fetch one past the ceiling: under it,
+	``len(rows)`` IS the exact count)."""
+	if not doctype:
+		raise InvalidArgumentError("doctype is required")
+	if fields is not None and "*" in fields:
+		raise InvalidArgumentError("fields=['*'] is not supported for export - name the columns you want.")
+
+	if frappe.get_meta(doctype).istable:
+		if not parent_doctype:
+			parents = _child_table_parents(doctype)
+			hint = f" (e.g. parent_doctype='{parents[0]}')" if parents else ""
+			raise InvalidArgumentError(
+				f"'{doctype}' is a child table; pass parent_doctype{hint} and filter by "
+				f"parent, or query its parent with a join via the `query` tool / use "
+				f"run_report. Child tables lack parent-only fields like employee/date."
+			)
+	else:
+		# parent_doctype only makes sense for a child table; drop a stray value so
+		# it never turns a normal query into a "DocType <x> not found" error.
+		parent_doctype = None
+
+	if not frappe.has_permission(doctype, ptype="read", parent_doctype=parent_doctype):
+		raise PermissionDeniedError(f"no read permission on {doctype}")
+
+	cols = list(fields) if fields else _default_fields(doctype)
+	# Fetch one past the ceiling so we can FAIL CLOSED on an over-large export
+	# instead of shipping a silently-truncated file. Under the ceiling, len(rows)
+	# is the true permission-filtered total.
+	rows = frappe.get_list(
+		doctype,
+		filters=filters or {},
+		fields=cols,
+		order_by=order_by,
+		parent_doctype=parent_doctype,
+		limit=_HARD_ROW_CEILING + 1,
+		as_list=True,
+	)
+	if len(rows) > _HARD_ROW_CEILING:
+		raise InvalidArgumentError(
+			f"{doctype} matches more than {_HARD_ROW_CEILING:,} rows for your permissions "
+			f"- too many to export in full. Narrow the filter; streamed export of larger "
+			f"sets is not yet available."
+		)
+	return ExportModel(
+		columns=cols,
+		rows=[list(r) for r in rows],
+		total=len(rows),
+		meta={"doctype": doctype},
+	)

--- a/jarvis/tools/_export/resolvers.py
+++ b/jarvis/tools/_export/resolvers.py
@@ -97,6 +97,8 @@ def from_query(doctype, filters=None, fields=None, order_by=None, parent_doctype
 	# permlevel-read on is dropped from the row by get_list (on v17), so keying by
 	# column name - blank when absent - keeps every value under its own header on
 	# every engine, instead of the shift a positional as_list would produce.
+	# Keying is by plain fieldname (the tool's contract; fields=['*'] is rejected
+	# and aggregate/aliased expressions are out of scope - they'd key as blank).
 	return ExportModel(
 		columns=cols,
 		rows=[[row.get(c) for c in cols] for row in rows],

--- a/jarvis/tools/_export/resolvers.py
+++ b/jarvis/tools/_export/resolvers.py
@@ -6,9 +6,13 @@ from jarvis.tools.get_list import _child_table_parents
 
 # Server-side hard ceiling. ABOVE this we FAIL CLOSED (raise) rather than return
 # a silently-partial file - an export must never look complete when it isn't.
-# Sized as a memory/time backstop; streaming export of larger sets is a deferred
-# follow-up (see the export DEFERRED backlog).
-_HARD_ROW_CEILING = 100_000
+# Kept well below a pure memory backstop ON PURPOSE: export_query runs
+# SYNCHRONOUSLY inside the web request, and the agent plugin aborts every call_tool
+# at 30s - a 100k wide-row fetch+render loses that race (the bench finishes and
+# orphans a File the agent never receives, then retries) and can hold ~200-300MB in
+# a shared worker. Streaming/async for larger sets is a deferred follow-up (see the
+# export DEFERRED backlog); until then, 20k keeps the sync path inside the budget.
+_HARD_ROW_CEILING = 20_000
 
 
 def _default_fields(doctype: str) -> list[str]:
@@ -22,8 +26,12 @@ def _default_fields(doctype: str) -> list[str]:
 def from_query(doctype, filters=None, fields=None, order_by=None, parent_doctype=None) -> ExportModel:
 	"""Resolve doctype+filters to a canonical ExportModel, SERVER-SIDE and
 	permission-checked. Record- and field-level permissions are inherited from
-	``frappe.get_list`` (a permlevel-denied field comes back NULL, so column
-	alignment holds). Rows never return to the model context (reference-not-rows).
+	``frappe.get_list``; a permlevel-denied field is DROPPED from the result on the
+	v17 query engine (v16 nulls it in place), so we fetch ``as_dict`` and PROJECT
+	onto the requested columns - a dropped field becomes a blank cell under its own
+	header and columns stay aligned on every engine. Also gated on the Export
+	DocPerm (``can_export``), matching Frappe's own query->file export. Rows never
+	return to the model context (reference-not-rows).
 
 	NOT capped for the model, but FAIL-CLOSED above ``_HARD_ROW_CEILING`` so an
 	oversized export raises instead of silently truncating. ``total`` is the TRUE,
@@ -56,6 +64,14 @@ def from_query(doctype, filters=None, fields=None, order_by=None, parent_doctype
 
 	if not frappe.has_permission(doctype, ptype="read", parent_doctype=parent_doctype):
 		raise PermissionDeniedError(f"no read permission on {doctype}")
+	# Honor Frappe's Export DocPerm (like frappe.desk.reportview.export_query): a
+	# bulk file export is governed by the Export permission, not just read (System
+	# Manager bypasses). export_query lifts the row cap, so a read-but-not-Export
+	# user must not gain a bulk-exfil path. For a child table the Export perm lives
+	# on the owning parent, so check that.
+	export_dt = parent_doctype or doctype
+	if not frappe.permissions.can_export(export_dt):
+		raise PermissionDeniedError(f"no export permission on {export_dt}")
 
 	cols = list(fields) if fields else _default_fields(doctype)
 	# Fetch one past the ceiling so we can FAIL CLOSED on an over-large export
@@ -68,17 +84,22 @@ def from_query(doctype, filters=None, fields=None, order_by=None, parent_doctype
 		order_by=order_by,
 		parent_doctype=parent_doctype,
 		limit=_HARD_ROW_CEILING + 1,
-		as_list=True,
+		# get_list returns list-of-dicts by default (no as_list), which is what the
+		# projection below keys on - the column-alignment fix.
 	)
 	if len(rows) > _HARD_ROW_CEILING:
 		raise InvalidArgumentError(
 			f"{doctype} matches more than {_HARD_ROW_CEILING:,} rows for your permissions "
-			f"- too many to export in full. Narrow the filter; streamed export of larger "
-			f"sets is not yet available."
+			f"- too many to export in full. Narrow the filter (e.g. by date or status); "
+			f"streamed export of larger sets is not yet available."
 		)
+	# Project each row dict onto the REQUESTED columns. A field the caller lacks
+	# permlevel-read on is dropped from the row by get_list (on v17), so keying by
+	# column name - blank when absent - keeps every value under its own header on
+	# every engine, instead of the shift a positional as_list would produce.
 	return ExportModel(
 		columns=cols,
-		rows=[list(r) for r in rows],
+		rows=[[row.get(c) for c in cols] for row in rows],
 		total=len(rows),
 		meta={"doctype": doctype},
 	)

--- a/jarvis/tools/_export/resolvers.py
+++ b/jarvis/tools/_export/resolvers.py
@@ -31,6 +31,12 @@ def from_query(doctype, filters=None, fields=None, order_by=None, parent_doctype
 	``len(rows)`` IS the exact count)."""
 	if not doctype:
 		raise InvalidArgumentError("doctype is required")
+	if not frappe.db.exists("DocType", doctype):
+		raise InvalidArgumentError(f"unknown DocType: {doctype}")
+	# A stray scalar `fields="name"` would otherwise iterate into characters; the
+	# wire schema enforces an array, so this is defense-in-depth.
+	if isinstance(fields, str):
+		fields = [fields]
 	if fields is not None and "*" in fields:
 		raise InvalidArgumentError("fields=['*'] is not supported for export - name the columns you want.")
 

--- a/jarvis/tools/_export/safety.py
+++ b/jarvis/tools/_export/safety.py
@@ -1,0 +1,15 @@
+# Formula-injection defence for CSV/spreadsheet exports. A cell whose text
+# begins with one of these executes as a formula when the file is opened in
+# Excel / LibreOffice Calc / Google Sheets - a phishing / data-exfiltration /
+# (via DDE) command-execution vector. The OWASP trigger set:
+_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def escape_formula(value):
+	"""Neutralise a formula-injection cell by prefixing a leading trigger char
+	with an apostrophe, so spreadsheets render it as literal text. Applied to
+	EVERY cell AND header of a CSV/XLSX export. Non-strings pass through
+	unchanged (numbers/dates are not an injection vector)."""
+	if isinstance(value, str) and value[:1] in _TRIGGERS:
+		return "'" + value
+	return value

--- a/jarvis/tools/export_query.py
+++ b/jarvis/tools/export_query.py
@@ -1,0 +1,56 @@
+"""Server-side, permission-checked bulk export of a doctype query to a
+downloadable Excel/CSV file.
+
+The rows are gathered and rendered SERVER-SIDE and never returned to the agent's
+context (reference-not-rows), so an export is COMPLETE - it is not subject to the
+model-facing result budget that caps get_list/query. Above a hard row ceiling the
+resolver FAILS CLOSED (raises) rather than hand back a silently-partial file.
+
+This is the tool for "export these records to Excel/CSV" - NOT get_list +
+export_excel, whose rows pass through the model context and are truncatable."""
+
+from jarvis import telemetry
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._export import renderers, resolvers, save_export_file
+
+_FORMATS = {
+	"xlsx": (
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		renderers.xlsx,
+	),
+	"csv": ("text/csv", renderers.csv),
+}
+
+
+def export_query(
+	doctype,
+	filters=None,
+	fields=None,
+	order_by=None,
+	format="xlsx",
+	title=None,
+) -> dict:
+	"""Export ``doctype`` rows matching ``filters`` to ``format`` (``xlsx``|``csv``).
+
+	Returns the download-card envelope ``{file_url, filename, title, mime_type,
+	size_bytes, name}`` plus ``total`` (the TRUE, permission-filtered source count).
+	Data is fetched and rendered server-side under the caller's permissions; it
+	never enters the model context, so the export is complete (nothing truncated)."""
+	fmt = (format or "xlsx").lower()
+	if fmt not in _FORMATS:
+		raise InvalidArgumentError(f"format must be one of {sorted(_FORMATS)}, got {format!r}")
+
+	model = resolvers.from_query(doctype, filters=filters, fields=fields, order_by=order_by)
+	model.meta["title"] = title or doctype
+
+	mime, render = _FORMATS[fmt]
+	env = save_export_file(f"x.{fmt}", render(model), title=title or doctype, mime_type=mime)
+	env["total"] = model.total
+	if model.meta.get("cells_truncated"):
+		env["cells_truncated"] = True
+		env["note"] = (
+			"Some cells exceeded the spreadsheet cell-size limit and were truncated with "
+			"a marker; the row count is complete."
+		)
+	telemetry.record_export_event(tool="export_query", fmt=fmt, rows=model.total, mode="sync")
+	return env

--- a/jarvis/tools/export_query.py
+++ b/jarvis/tools/export_query.py
@@ -10,7 +10,7 @@ This is the tool for "export these records to Excel/CSV" - NOT get_list +
 export_excel, whose rows pass through the model context and are truncatable."""
 
 from jarvis import telemetry
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, NoDataError, PermissionDeniedError
 from jarvis.tools._export import renderers, resolvers, save_export_file
 
 _FORMATS = {
@@ -22,6 +22,14 @@ _FORMATS = {
 }
 
 
+def _outcome_for(exc: Exception) -> str:
+	if isinstance(exc, NoDataError):
+		return "no_data"
+	if isinstance(exc, PermissionDeniedError):
+		return "denied"
+	return "rejected"  # InvalidArgumentError: ceiling, bad fields, file-too-large
+
+
 def export_query(
 	doctype,
 	filters=None,
@@ -29,22 +37,39 @@ def export_query(
 	order_by=None,
 	format="xlsx",
 	title=None,
+	parent_doctype=None,
 ) -> dict:
 	"""Export ``doctype`` rows matching ``filters`` to ``format`` (``xlsx``|``csv``).
 
 	Returns the download-card envelope ``{file_url, filename, title, mime_type,
-	size_bytes, name}`` plus ``total`` (the TRUE, permission-filtered source count).
-	Data is fetched and rendered server-side under the caller's permissions; it
-	never enters the model context, so the export is complete (nothing truncated)."""
-	fmt = (format or "xlsx").lower()
+	size_bytes, name}`` plus ``total`` (the TRUE, permission-filtered source count),
+	and ``cells_truncated``/``note`` when an over-long cell was clipped. Data is
+	fetched and rendered server-side under the caller's permissions; it never enters
+	the model context, so the export is complete (nothing truncated). Pass
+	``parent_doctype`` to export a child (Table) DocType, whose permission derives
+	from its parent. Raises ``NoDataError`` when nothing matches (an empty file would
+	look complete but hold nothing)."""
+	fmt = str(format or "xlsx").lower()
 	if fmt not in _FORMATS:
 		raise InvalidArgumentError(f"format must be one of {sorted(_FORMATS)}, got {format!r}")
-
-	model = resolvers.from_query(doctype, filters=filters, fields=fields, order_by=order_by)
-	model.meta["title"] = title or doctype
-
 	mime, render = _FORMATS[fmt]
-	env = save_export_file(f"x.{fmt}", render(model), title=title or doctype, mime_type=mime)
+
+	# Every fail-closed exit emits a telemetry outcome too (not just success), so the
+	# refused exports - the ones that would justify raising the ceiling - are visible.
+	try:
+		model = resolvers.from_query(
+			doctype, filters=filters, fields=fields, order_by=order_by, parent_doctype=parent_doctype
+		)
+		if model.total == 0:
+			raise NoDataError(f"No {doctype} records match those filters - nothing to export.")
+		model.meta["title"] = title or doctype
+		env = save_export_file(f"x.{fmt}", render(model), title=title or doctype, mime_type=mime)
+	except (NoDataError, PermissionDeniedError, InvalidArgumentError) as e:
+		telemetry.record_export_event(
+			tool="export_query", fmt=fmt, rows=0, mode="sync", outcome=_outcome_for(e)
+		)
+		raise
+
 	env["total"] = model.total
 	if model.meta.get("cells_truncated"):
 		env["cells_truncated"] = True
@@ -52,5 +77,5 @@ def export_query(
 			"Some cells exceeded the spreadsheet cell-size limit and were truncated with "
 			"a marker; the row count is complete."
 		)
-	telemetry.record_export_event(tool="export_query", fmt=fmt, rows=model.total, mode="sync")
+	telemetry.record_export_event(tool="export_query", fmt=fmt, rows=model.total, mode="sync", outcome="ok")
 	return env

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -65,6 +65,12 @@ _TOOL_NAMES: tuple[str, ...] = (
 	"download_pdf",
 	"report_pdf",
 	"export_excel",
+	# Server-side, permission-checked bulk export of a doctype query to a
+	# downloadable xlsx/csv. Rows never enter model context (reference-not-rows),
+	# so the export is complete; fails closed above a hard row ceiling rather
+	# than return a partial file. The right tool for "export these records",
+	# vs get_list + export_excel whose rows are truncatable.
+	"export_query",
 	# Composed report/summary (not a single record) → downloadable PDF / HTML /
 	# PNG. download_pdf prints an existing record; this renders agent-composed
 	# content so a "give me a PDF of this report" ask produces a real download.

--- a/jarvis/tools/report_pdf.py
+++ b/jarvis/tools/report_pdf.py
@@ -24,8 +24,6 @@ both majors (``download_pdf`` uses ``get_print`` + ``save_file`` with no
 ``jarvis.compat`` shim), so none is needed here.
 """
 
-import re
-
 import frappe
 from frappe.desk.query_report import run as frappe_run_report
 
@@ -119,8 +117,6 @@ def report_pdf(
 	if not pdf_bytes:
 		raise InvalidArgumentError(f"PDF generation for report {report_name} produced no content")
 
-	from frappe.exceptions import ValidationError
-
 	from jarvis.tools._export import save_export_file
 
 	# Owner-only File (dt/dn default to None -> unattached, so has_permission falls
@@ -129,30 +125,9 @@ def report_pdf(
 	# Report doc: File.has_permission would then defer to Report read, letting
 	# anyone who can read the Report download a row-filtered artifact (e.g. a
 	# Salary Register). See the export-architecture plan-check, finding C5.
-	try:
-		return save_export_file(
-			f"{_safe_filename(report_title)}.pdf",
-			pdf_bytes,
-			title=report_title,
-			mime_type="application/pdf",
-		)
-	except ValidationError as e:
-		# A File-save constraint (e.g. a rejected filename) is a bad-input outcome,
-		# not an opaque 500.
-		raise InvalidArgumentError(f"could not store the report PDF: {e}") from e
-
-
-def _safe_filename(title: str) -> str:
-	"""A File-doctype-safe base name derived from the title.
-
-	A report name or a caller-supplied ``title`` can carry markup, slashes and
-	other characters that Frappe's File sanitiser rejects or rewrites — notably it
-	re-introduces a ``/`` from a closing HTML tag (``</b>``), which then raises
-	``ValidationError: File name cannot have /`` deep inside ``save_file``. Keep
-	only filename-safe characters, cap the length, and never return empty.
-	"""
-	base = re.sub(r"[^A-Za-z0-9._-]+", "-", title or "").strip("-.")
-	return base[:80] or "report"
+	# save_export_file owns filename sanitising + File-size/ValidationError
+	# translation, so only the extension of this placeholder name is used.
+	return save_export_file("report.pdf", pdf_bytes, title=report_title, mime_type="application/pdf")
 
 
 def _normalise_columns(columns: list) -> list[dict]:

--- a/jarvis/tools/report_pdf.py
+++ b/jarvis/tools/report_pdf.py
@@ -120,26 +120,26 @@ def report_pdf(
 		raise InvalidArgumentError(f"PDF generation for report {report_name} produced no content")
 
 	from frappe.exceptions import ValidationError
-	from frappe.utils.file_manager import save_file
 
-	filename = f"{_safe_filename(report_title)}.pdf"
-	# Private + attached to the Report doc: auth-gated by the customer's session and
-	# re-findable, exactly like download_pdf's File.
+	from jarvis.tools._export import save_export_file
+
+	# Owner-only File (dt/dn default to None -> unattached, so has_permission falls
+	# through to owner-only). This PDF is rendered under the CALLING user's record-
+	# and field-filtered permissions, so it must NOT be attached to the shared
+	# Report doc: File.has_permission would then defer to Report read, letting
+	# anyone who can read the Report download a row-filtered artifact (e.g. a
+	# Salary Register). See the export-architecture plan-check, finding C5.
 	try:
-		file_doc = save_file(fname=filename, content=pdf_bytes, dt="Report", dn=report_name, is_private=1)
+		return save_export_file(
+			f"{_safe_filename(report_title)}.pdf",
+			pdf_bytes,
+			title=report_title,
+			mime_type="application/pdf",
+		)
 	except ValidationError as e:
 		# A File-save constraint (e.g. a rejected filename) is a bad-input outcome,
 		# not an opaque 500.
 		raise InvalidArgumentError(f"could not store the report PDF: {e}") from e
-
-	return {
-		"file_url": file_doc.file_url,
-		"filename": file_doc.file_name,
-		"title": report_title,
-		"mime_type": "application/pdf",
-		"size_bytes": int(file_doc.file_size or len(pdf_bytes)),
-		"name": file_doc.name,
-	}
 
 
 def _safe_filename(title: str) -> str:

--- a/jarvis/tools/tool-names.json
+++ b/jarvis/tools/tool-names.json
@@ -18,7 +18,7 @@
     "repo copies are compared by it, because no CI job can see both repos."
   ],
   "contract_version": 1,
-  "digest": "sha256:4f87815c52fe26085ebc72d8443144caa04fc7c0196ac17b0c25e5639c714def",
+  "digest": "sha256:b149cc1ef06e0655fe91b1d6a1ffc3a1ee25b1d7d00ba78de4d4d3824e753401",
   "tools": [
     "add_comment",
     "add_tag",
@@ -37,6 +37,7 @@
     "download_vcard",
     "export_document",
     "export_excel",
+    "export_query",
     "find_skills",
     "finish_app_learning_run",
     "follow_document",


### PR DESCRIPTION
## What

Adds a server-side **bulk export** capability and fixes a cross-user exposure in `report_pdf`.

**New tool `export_query`** — export a DocType's records by filter to a complete `.xlsx`/`.csv`, fetched and rendered **server-side** under the caller's permissions. Rows never enter the agent's model context (reference-not-rows), so the file is complete — not subject to the result-budget truncation that `get_list` + `export_excel` hits. Above a hard row ceiling it **fails closed** with a clear "narrow the filter" message rather than return a silently-partial file.

**Fix (C5): `report_pdf` owner-only File** — it renders under the caller's row-/field-filtered permissions but attached the PDF to the shared `Report` doc, so `File.has_permission` let anyone who can read the Report download a row-filtered artifact (e.g. a Salary Register). Now saved as an **unattached (owner-only)** private File.

**Shared seam `jarvis/tools/_export/`** (model · envelope · safety · renderers · resolvers): one fill→export path. `save_export_file` is the single private-File envelope builder (`report_pdf` uses it too), with formula-injection escaping (headers + cells) and File-size/`ValidationError` translation.

## Tests (on `jarvis.test`)
- `_export` seam (13), renderers (8 — incl. workbook read-back proving formula-escape + cell-truncation), resolver (6 — incl. fail-closed ceiling, istable, DocType guard), `export_query` (6 — incl. a **mutation-proof record-level permission** test, telemetry, ceiling). All green.
- `report_pdf`'s report-**execution** tests are blocked only by a **pre-existing** local-v17 `START TRANSACTION READ ONLY` quirk (verified pre-existing with the change stashed); they pass on the v16 CI. The File-save change is validated via `test_export_seam`.
- Back-gate review run (opus): no Critical; all high-consequence claims verified. Findings I1/M1/M2/M3/M6 fixed in this branch; M4 (a field-level permlevel test) and M5 (CSV BOM) deferred with notes.

## Cross-repo dependency
The agent can only **call** `export_query` once the plugin descriptor lands — see **jarvis-openclaw-plugin** `feat/export-tools-wiring` (also fixes the `report_pdf`/`export_document` wire drift). Deploy this app change to the target benches **before** the fleet plugin rebuild, so the tool module exists when the descriptor appears. (Wave 0's `report_pdf`/`export_document` were already in every bench's registry.)

Design spec, plan, plan-check, and the deferred backlog live locally (kept out of this PR by convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
