### PR TITLE
Center onboarding T&C checkbox row

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1263,7 +1263,7 @@
 										 a sibling <label for=...> instead - clicking the embedded <a>
 										 navigates without also toggling the box. -->
 									<div
-										class="mx-auto mt-3.5 flex max-w-[560px] items-start gap-2"
+										class="mx-auto mt-3.5 flex max-w-[560px] items-start justify-center gap-2"
 									>
 										<Checkbox
 											id="jv-ob-terms"


### PR DESCRIPTION
## Summary

Centers the "I agree to the Terms & Conditions" checkbox row on the onboarding Review & Pay step so it lines up with the centered Razorpay button and "Secured by" caption above it. One-line CSS change (adds `justify-center`), no logic touched.

## Pre-merge checklist

- [x] **CI is green** - the `tests` check on this PR passes (never merge on failure)
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests (existing OnboardingView tests still pass, no new behavior to cover for a class-only change)
- [x] I self-reviewed the diff