### PR TITLE
Expose parent_document_type on create_dashboard_chart

### DIFF
--- a/jarvis/tests/test_dashboard_tools.py
+++ b/jarvis/tests/test_dashboard_tools.py
@@ -55,6 +55,64 @@ class TestCreateDashboardChart(FrappeTestCase):
 				based_on="creation",
 			)
 
+	def test_group_by_child_table_needs_parent_document_type(self):
+		# Contact/Contact Email is a core Frappe parent/child pair - istable,
+		# no ERPNext fixture needed. Without parent_document_type Frappe's own
+		# Dashboard Chart.validate() would reject the insert; the tool should
+		# catch this itself and name the valid parent in the message.
+		with self.assertRaises(InvalidArgumentError) as ctx:
+			create_dashboard_chart(
+				chart_name=_h("JT Child NoParent"),
+				document_type="Contact Email",
+				chart_type="Group By",
+				group_by_based_on="email_id",
+			)
+		self.assertIn("Contact", str(ctx.exception))
+
+	def test_group_by_child_table_with_parent_document_type(self):
+		res = create_dashboard_chart(
+			chart_name=_h("JT Child Parent"),
+			document_type="Contact Email",
+			chart_type="Group By",
+			group_by_based_on="email_id",
+			parent_document_type="Contact",
+		)
+		self.assertTrue(res["name"])
+		self.assertEqual(
+			frappe.db.get_value("Dashboard Chart", res["name"], "parent_document_type"),
+			"Contact",
+		)
+
+	def test_wrong_parent_document_type_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			create_dashboard_chart(
+				chart_name=_h("JT Wrong Parent"),
+				document_type="Contact Email",
+				chart_type="Group By",
+				group_by_based_on="email_id",
+				parent_document_type="ToDo",
+			)
+
+	def test_junk_parent_document_type_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			create_dashboard_chart(
+				chart_name=_h("JT Junk Parent"),
+				document_type="Contact Email",
+				chart_type="Group By",
+				group_by_based_on="email_id",
+				parent_document_type="No Such Doctype 123",
+			)
+
+	def test_parent_document_type_rejected_for_non_child_doctype(self):
+		with self.assertRaises(InvalidArgumentError):
+			create_dashboard_chart(
+				chart_name=_h("JT Parent NonChild"),
+				document_type="ToDo",
+				chart_type="Count",
+				based_on="creation",
+				parent_document_type="ToDo",
+			)
+
 	def test_duplicate_chart_name_returns_clean_error(self):
 		# Dashboard Chart autonames on chart_name -> a repeat raises Frappe's
 		# DuplicateEntryError (a NameError). _run_tool must translate it to the

--- a/jarvis/tests/test_dashboard_tools.py
+++ b/jarvis/tests/test_dashboard_tools.py
@@ -4,7 +4,7 @@ test context). Inserts are rolled back by FrappeTestCase."""
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.tools.create_dashboard import create_dashboard
 from jarvis.tools.create_dashboard_chart import create_dashboard_chart
 
@@ -125,6 +125,110 @@ class TestCreateDashboardChart(FrappeTestCase):
 		res = _run_tool("create_dashboard_chart", dict(args))
 		self.assertFalse(res["ok"])
 		self.assertEqual(res["error"]["code"], "InvalidArgumentError")
+
+
+class TestCreateDashboardChartChildTablePermissions(FrappeTestCase):
+	"""F1 regression: a plain ``has_permission(document_type, "read")`` on a
+	child (istable) doctype returns False for every non-admin (child tables
+	carry no permissions of their own - see query.py's step-3 child-table
+	gate and get_list.py's ``_readable_child_parents``). All the tests above
+	run as Administrator, which bypasses permission checks entirely and so
+	cannot catch that. These use a dedicated custom parent/child doctype pair
+	and two non-admin users to prove the parent-qualified check actually
+	works: one user who can read the parent, one who cannot.
+	"""
+
+	PARENT_DT = "JT Chart Perm Parent"
+	CHILD_DT = "JT Chart Perm Child"
+	ROLE = "JT Chart Perm Reader"
+	USER_WITH_ACCESS = "jt-chart-perm-reader@example.com"
+	USER_WITHOUT_ACCESS = "jt-chart-perm-outsider@example.com"
+
+	@classmethod
+	def _ensure_role(cls):
+		if not frappe.db.exists("Role", cls.ROLE):
+			frappe.get_doc(
+				{"doctype": "Role", "role_name": cls.ROLE, "desk_access": 1, "is_custom": 1}
+			).insert(ignore_permissions=True)
+
+	@classmethod
+	def _ensure_user(cls, email, roles):
+		if not frappe.db.exists("User", email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": email.split("@")[0],
+					"send_welcome_email": 0,
+					"enabled": 1,
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True)
+		user = frappe.get_doc("User", email)
+		if "System Manager" in frappe.get_roles(email):
+			user.remove_roles("System Manager")
+		missing = [r for r in roles if r not in frappe.get_roles(email)]
+		if missing:
+			user.add_roles(*missing)
+
+	@classmethod
+	def _ensure_doctypes(cls):
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		for dt in (cls.PARENT_DT, cls.CHILD_DT):
+			if frappe.db.exists("DocType", dt):
+				frappe.delete_doc("DocType", dt, force=True, ignore_permissions=True)
+		# Child table (istable) - carries no permissions of its own; access is
+		# derived entirely from whoever can read the parent below.
+		new_doctype(
+			name=cls.CHILD_DT,
+			custom=1,
+			istable=1,
+			fields=[{"label": "Category", "fieldname": "category", "fieldtype": "Data"}],
+			permissions=[],
+		).insert()
+		new_doctype(
+			name=cls.PARENT_DT,
+			custom=1,
+			fields=[{"label": "Items", "fieldname": "items", "fieldtype": "Table", "options": cls.CHILD_DT}],
+			permissions=[{"role": cls.ROLE, "permlevel": 0, "read": 1}],
+		).insert()
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls._ensure_role()
+		cls._ensure_doctypes()
+		# Dashboard Manager: create permission on Dashboard Chart itself
+		# (unrelated to the child-table read check under test).
+		cls._ensure_user(cls.USER_WITH_ACCESS, (cls.ROLE, "Dashboard Manager"))
+		cls._ensure_user(cls.USER_WITHOUT_ACCESS, ("Dashboard Manager",))
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_non_admin_with_parent_read_can_chart_child_table(self):
+		frappe.set_user(self.USER_WITH_ACCESS)
+		res = create_dashboard_chart(
+			chart_name=_h("JT Perm OK"),
+			document_type=self.CHILD_DT,
+			chart_type="Group By",
+			group_by_based_on="category",
+			parent_document_type=self.PARENT_DT,
+		)
+		self.assertTrue(res["name"])
+
+	def test_non_admin_without_parent_read_rejected(self):
+		frappe.set_user(self.USER_WITHOUT_ACCESS)
+		with self.assertRaises(PermissionDeniedError):
+			create_dashboard_chart(
+				chart_name="x",
+				document_type=self.CHILD_DT,
+				chart_type="Group By",
+				group_by_based_on="category",
+				parent_document_type=self.PARENT_DT,
+			)
 
 
 class TestCreateDashboard(FrappeTestCase):

--- a/jarvis/tests/test_dashboard_tools.py
+++ b/jarvis/tests/test_dashboard_tools.py
@@ -238,6 +238,18 @@ class TestCreateDashboardChartChildTablePermissions(FrappeTestCase):
 
 	def test_non_admin_with_parent_read_can_chart_child_table(self):
 		frappe.set_user(self.USER_WITH_ACCESS)
+		# TEMP DIAGNOSTIC (removed before merge): CI has twice denied "create"
+		# on Dashboard Chart for this user despite the role grant; dump why.
+		from frappe import permissions as _fp
+
+		ok = _fp.has_permission("Dashboard Chart", "create", debug=True)
+		print(
+			f"\nDIAG create-perm on 'Dashboard Chart' for {self.USER_WITH_ACCESS}: "
+			f"ok={ok} roles={frappe.get_roles()} "
+			f"custom_docperm_rows={frappe.get_all('Custom DocPerm', filters={'parent': 'Dashboard Chart'}, fields=['role', 'create', 'read', 'permlevel'])} "
+			f"log={_fp._pop_debug_log()}\n",
+			flush=True,
+		)
 		res = create_dashboard_chart(
 			chart_name=_h("JT Perm OK"),
 			document_type=self.CHILD_DT,

--- a/jarvis/tests/test_dashboard_tools.py
+++ b/jarvis/tests/test_dashboard_tools.py
@@ -136,6 +136,23 @@ class TestCreateDashboardChartChildTablePermissions(FrappeTestCase):
 	cannot catch that. These use a dedicated custom parent/child doctype pair
 	and two non-admin users to prove the parent-qualified check actually
 	works: one user who can read the parent, one who cannot.
+
+	The happy-path user also needs "System Manager" (not just create rights
+	on Dashboard Chart via role): CORE Frappe registers its own has_permission
+	hook for "Dashboard Chart" (frappe/hooks.py -> dashboard_chart.has_permission)
+	that doc.insert() runs through in ADDITION to the plain role-DocPerm check.
+	That hook special-cases the literal role "System Manager" and otherwise
+	requires document_type to appear in get_doctypes_with_read(user) - built
+	purely from DocPerm/Custom DocPerm rows. A child (istable) doctype like
+	CHILD_DT carries none by design (that is the whole premise of #862), so it
+	can never satisfy that branch for ANY other role, including Dashboard
+	Manager - confirmed empirically (a Custom DocPerm grant for a dedicated
+	custom role reached "create": 1 via plain has_permission() with no doc, yet
+	doc.insert() still raised PermissionError). This is pre-existing Frappe
+	behavior, unrelated to #862's fix, and does not affect it: it only means a
+	realistic non-admin "Jarvis User" customer creating a CHILD-TABLE chart
+	still needs elevated (System Manager) access today, same as before this
+	fix - #862 only removes the missing-parameter blocker.
 	"""
 
 	PARENT_DT = "JT Chart Perm Parent"
@@ -195,42 +212,16 @@ class TestCreateDashboardChartChildTablePermissions(FrappeTestCase):
 		).insert()
 
 	@classmethod
-	def _grant_dashboard_chart_create(cls):
-		"""Layer a Custom DocPerm onto the CORE "Dashboard Chart" doctype so
-		``cls.ROLE`` can create one - needed for the happy-path user to reach
-		``doc.insert()`` at all. ``setup_custom_perms`` first copies the
-		existing standard rows (System Manager/Dashboard Manager/Desk User)
-		into Custom DocPerm so this ADDS a rule rather than replacing them -
-		once any Custom DocPerm row exists for a doctype, Frappe's permission
-		engine uses only those, ignoring the standard permissions.json rows.
-		"""
-		from frappe.permissions import setup_custom_perms
-
-		setup_custom_perms("Dashboard Chart")
-		if not frappe.db.exists(
-			"Custom DocPerm", {"parent": "Dashboard Chart", "role": cls.ROLE, "permlevel": 0}
-		):
-			frappe.get_doc(
-				{
-					"doctype": "Custom DocPerm",
-					"parent": "Dashboard Chart",
-					"parenttype": "DocType",
-					"parentfield": "permissions",
-					"role": cls.ROLE,
-					"permlevel": 0,
-					"read": 1,
-					"create": 1,
-				}
-			).insert(ignore_permissions=True)
-
-	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		cls._ensure_role()
 		cls._ensure_doctypes()
-		cls._grant_dashboard_chart_create()
-		cls._ensure_user(cls.USER_WITH_ACCESS, (cls.ROLE,))
+		# "System Manager" is needed only to clear CORE Frappe's own
+		# Dashboard-Chart-creation hook (see class docstring) - it is NOT what
+		# grants read on CHILD_DT/PARENT_DT; that is cls.ROLE, the thing this
+		# test actually exercises.
+		cls._ensure_user(cls.USER_WITH_ACCESS, (cls.ROLE, "System Manager"))
 		cls._ensure_user(cls.USER_WITHOUT_ACCESS, ())
 
 	def tearDown(self):
@@ -238,18 +229,6 @@ class TestCreateDashboardChartChildTablePermissions(FrappeTestCase):
 
 	def test_non_admin_with_parent_read_can_chart_child_table(self):
 		frappe.set_user(self.USER_WITH_ACCESS)
-		# TEMP DIAGNOSTIC (removed before merge): CI has twice denied "create"
-		# on Dashboard Chart for this user despite the role grant; dump why.
-		from frappe import permissions as _fp
-
-		ok = _fp.has_permission("Dashboard Chart", "create", debug=True)
-		print(
-			f"\nDIAG create-perm on 'Dashboard Chart' for {self.USER_WITH_ACCESS}: "
-			f"ok={ok} roles={frappe.get_roles()} "
-			f"custom_docperm_rows={frappe.get_all('Custom DocPerm', filters={'parent': 'Dashboard Chart'}, fields=['role', 'create', 'read', 'permlevel'])} "
-			f"log={_fp._pop_debug_log()}\n",
-			flush=True,
-		)
 		res = create_dashboard_chart(
 			chart_name=_h("JT Perm OK"),
 			document_type=self.CHILD_DT,

--- a/jarvis/tests/test_dashboard_tools.py
+++ b/jarvis/tests/test_dashboard_tools.py
@@ -195,15 +195,43 @@ class TestCreateDashboardChartChildTablePermissions(FrappeTestCase):
 		).insert()
 
 	@classmethod
+	def _grant_dashboard_chart_create(cls):
+		"""Layer a Custom DocPerm onto the CORE "Dashboard Chart" doctype so
+		``cls.ROLE`` can create one - needed for the happy-path user to reach
+		``doc.insert()`` at all. ``setup_custom_perms`` first copies the
+		existing standard rows (System Manager/Dashboard Manager/Desk User)
+		into Custom DocPerm so this ADDS a rule rather than replacing them -
+		once any Custom DocPerm row exists for a doctype, Frappe's permission
+		engine uses only those, ignoring the standard permissions.json rows.
+		"""
+		from frappe.permissions import setup_custom_perms
+
+		setup_custom_perms("Dashboard Chart")
+		if not frappe.db.exists(
+			"Custom DocPerm", {"parent": "Dashboard Chart", "role": cls.ROLE, "permlevel": 0}
+		):
+			frappe.get_doc(
+				{
+					"doctype": "Custom DocPerm",
+					"parent": "Dashboard Chart",
+					"parenttype": "DocType",
+					"parentfield": "permissions",
+					"role": cls.ROLE,
+					"permlevel": 0,
+					"read": 1,
+					"create": 1,
+				}
+			).insert(ignore_permissions=True)
+
+	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		cls._ensure_role()
 		cls._ensure_doctypes()
-		# Dashboard Manager: create permission on Dashboard Chart itself
-		# (unrelated to the child-table read check under test).
-		cls._ensure_user(cls.USER_WITH_ACCESS, (cls.ROLE, "Dashboard Manager"))
-		cls._ensure_user(cls.USER_WITHOUT_ACCESS, ("Dashboard Manager",))
+		cls._grant_dashboard_chart_create()
+		cls._ensure_user(cls.USER_WITH_ACCESS, (cls.ROLE,))
+		cls._ensure_user(cls.USER_WITHOUT_ACCESS, ())
 
 	def tearDown(self):
 		frappe.set_user("Administrator")

--- a/jarvis/tools/create_dashboard_chart.py
+++ b/jarvis/tools/create_dashboard_chart.py
@@ -60,34 +60,59 @@ def create_dashboard_chart(
 		raise InvalidArgumentError(f"chart_type must be one of {sorted(_CHART_TYPES)}")
 	if type not in _RENDER_TYPES:
 		raise InvalidArgumentError(f"type must be one of {sorted(_RENDER_TYPES)}")
-	if not frappe.has_permission(document_type, "read"):
-		raise PermissionDeniedError(f"no read permission on {document_type!r}")
-
-	# Child (istable) doctypes carry no rows of their own - Frappe's chart
-	# queries read them through an owning parent (`parent_doctype` on
-	# get_list), and Dashboard Chart.validate() rejects the chart outright
-	# without one. get_parent_doctypes() is the same lookup Frappe's own
-	# Dashboard Chart form uses to populate parent_document_type, so a
-	# non-table document_type always yields [] here and any supplied
-	# parent_document_type is rejected as junk for it.
-	valid_parents = get_parent_doctypes(document_type)
-	if valid_parents:
+	# Branch on istable directly - Dashboard Chart.validate() itself gates the
+	# "needs a parent" requirement on istable, and get_parent_doctypes() (a
+	# live-Table-field scan) can diverge from it both ways: an istable
+	# doctype whose owning field was since deleted/renamed still needs a
+	# parent even though the scan now returns []; a doctype only reachable
+	# via a Table MultiSelect shows up in the scan but is NOT istable and
+	# does not need one. get_parent_doctypes() is used below only to name/
+	# validate candidate parents, never to decide "is this a child table".
+	if frappe.get_meta(document_type).istable:
+		# Child (istable) doctypes carry no permissions of their own - Frappe
+		# derives read access from an owning PARENT via
+		# has_permission(child, ptype="read", parent_doctype=P) (the same call
+		# get_list.py's _readable_child_parents / query.py's step-3 child-table
+		# gate use). The plain has_permission(document_type, "read") above is
+		# never reached for a child doctype: with no parent_doctype it returns
+		# False for every non-admin regardless of real access, which would make
+		# every child-table chart Administrator-only.
+		valid_parents = get_parent_doctypes(document_type)
 		if not parent_document_type:
+			# Name only parents the caller can actually read the child
+			# through - naming an unreadable one would disclose a schema
+			# relationship to a DocType they have no access to.
+			readable = [
+				p
+				for p in valid_parents
+				if frappe.has_permission(document_type, ptype="read", parent_doctype=p)
+			]
+			if not readable:
+				raise PermissionDeniedError(
+					f"no read permission on {document_type!r} through any parent DocType"
+				)
 			raise InvalidArgumentError(
 				f"{document_type!r} is a child table; pass parent_document_type "
-				f"(one of: {', '.join(valid_parents)})"
+				f"(one of: {', '.join(readable)})"
 			)
 		if not frappe.db.exists("DocType", parent_document_type):
 			raise InvalidArgumentError(f"no such DocType {parent_document_type!r}")
 		if parent_document_type not in valid_parents:
+			# Deliberately do not list valid_parents here: the caller supplied
+			# this value themselves, but the full candidate list may include a
+			# parent they cannot read.
 			raise InvalidArgumentError(
-				f"parent_document_type {parent_document_type!r} is not a parent of "
-				f"{document_type!r} (one of: {', '.join(valid_parents)})"
+				f"parent_document_type {parent_document_type!r} is not a parent of {document_type!r}"
 			)
-		if not frappe.has_permission(parent_document_type, "read"):
-			raise PermissionDeniedError(f"no read permission on {parent_document_type!r}")
-	elif parent_document_type:
-		raise InvalidArgumentError(f"{document_type!r} is not a child table; omit parent_document_type")
+		if not frappe.has_permission(document_type, ptype="read", parent_doctype=parent_document_type):
+			raise PermissionDeniedError(
+				f"no read permission on {document_type!r} through parent {parent_document_type!r}"
+			)
+	else:
+		if parent_document_type:
+			raise InvalidArgumentError(f"{document_type!r} is not a child table; omit parent_document_type")
+		if not frappe.has_permission(document_type, "read"):
+			raise PermissionDeniedError(f"no read permission on {document_type!r}")
 
 	doc = frappe.new_doc("Dashboard Chart")
 	doc.chart_name = chart_name

--- a/jarvis/tools/create_dashboard_chart.py
+++ b/jarvis/tools/create_dashboard_chart.py
@@ -12,6 +12,7 @@ Dashboard Chart, and we check read permission on the charted doctype.
 """
 
 import frappe
+from frappe.desk.doctype.dashboard_chart.dashboard_chart import get_parent_doctypes
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
@@ -37,6 +38,7 @@ def create_dashboard_chart(
 	time_interval: str = "Monthly",
 	filters: dict | list | None = None,
 	is_public: int = 0,
+	parent_document_type: str | None = None,
 ) -> dict:
 	"""Create a Dashboard Chart; return {name, chart_name, chart_type, url}.
 
@@ -45,6 +47,10 @@ def create_dashboard_chart(
 	By`` (need ``group_by_based_on``; Sum/Average ``group_by_type`` also needs
 	``aggregate_function_based_on``). ``type`` is the render style. ``filters``
 	is an optional Frappe filter dict/list scoping the charted records.
+	``parent_document_type`` is required when ``document_type`` is a child
+	table (e.g. charting "Sales Order Item" grouped by "item_code" needs
+	``parent_document_type="Sales Order"``) - Frappe reads a child table's
+	rows through its owning parent, and rejects the chart without it.
 	"""
 	if not chart_name:
 		raise InvalidArgumentError("chart_name is required")
@@ -57,6 +63,32 @@ def create_dashboard_chart(
 	if not frappe.has_permission(document_type, "read"):
 		raise PermissionDeniedError(f"no read permission on {document_type!r}")
 
+	# Child (istable) doctypes carry no rows of their own - Frappe's chart
+	# queries read them through an owning parent (`parent_doctype` on
+	# get_list), and Dashboard Chart.validate() rejects the chart outright
+	# without one. get_parent_doctypes() is the same lookup Frappe's own
+	# Dashboard Chart form uses to populate parent_document_type, so a
+	# non-table document_type always yields [] here and any supplied
+	# parent_document_type is rejected as junk for it.
+	valid_parents = get_parent_doctypes(document_type)
+	if valid_parents:
+		if not parent_document_type:
+			raise InvalidArgumentError(
+				f"{document_type!r} is a child table; pass parent_document_type "
+				f"(one of: {', '.join(valid_parents)})"
+			)
+		if not frappe.db.exists("DocType", parent_document_type):
+			raise InvalidArgumentError(f"no such DocType {parent_document_type!r}")
+		if parent_document_type not in valid_parents:
+			raise InvalidArgumentError(
+				f"parent_document_type {parent_document_type!r} is not a parent of "
+				f"{document_type!r} (one of: {', '.join(valid_parents)})"
+			)
+		if not frappe.has_permission(parent_document_type, "read"):
+			raise PermissionDeniedError(f"no read permission on {parent_document_type!r}")
+	elif parent_document_type:
+		raise InvalidArgumentError(f"{document_type!r} is not a child table; omit parent_document_type")
+
 	doc = frappe.new_doc("Dashboard Chart")
 	doc.chart_name = chart_name
 	doc.chart_type = chart_type
@@ -64,6 +96,8 @@ def create_dashboard_chart(
 	doc.type = type
 	doc.is_public = 1 if is_public else 0
 	doc.filters_json = frappe.as_json(filters if filters is not None else [])
+	if parent_document_type:
+		doc.parent_document_type = parent_document_type
 
 	if chart_type in ("Count", "Sum", "Average"):
 		if not based_on:


### PR DESCRIPTION
Fixes #862

Charting a child-table field (e.g. Sales Order Item grouped by item_code) always failed with "Parent document type is required to create a dashboard chart" because the tool never exposed the field Frappe's Dashboard Chart doctype needs for it.

Adds an optional `parent_document_type` param, validated with Frappe's own `get_parent_doctypes()` lookup (real DocType, actual parent of `document_type`, read-permitted on that parent through Frappe's parent-qualified `has_permission`), threaded through to the created chart. The schema/description in `jarvis-openclaw-plugin` mirrors this tool's params, so a matching PR is up there too (Aerele-RnD/jarvis-openclaw-plugin#73, this PR merges first: the plugin's advertised param is dead until the Python side accepts it, and jarvis-side alone is already safe since dispatch filters unknown args to the function signature).

Note: creating any Dashboard Chart on a child-table `document_type` still requires the core Frappe `System Manager` role for non-admin users - Frappe's own `has_permission` hook for Dashboard Chart only bypasses its doctype-read check for that literal role, and a child table never carries its own DocPerm rows to satisfy the check otherwise. This is pre-existing Frappe behavior, unrelated to and unaffected by this PR.

## Pre-merge checklist

- [x] CI is green — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop` (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff