### PR TITLE
Replace ERPNext Assistant tagline with Your AI Teammate

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -5435,7 +5435,7 @@ const starredCount = computed(() => store.conversations.filter((c) => c.starred)
 // jarvis.chat.api.get_tool_activity / get_usage.chat_tool_calls.
 const headerSub = computed(() => {
 	const n = visibleMessages.value.length;
-	return n ? `${Math.ceil(n / 2)} message${n > 2 ? "s" : ""}` : "ERPNext Assistant";
+	return n ? `${Math.ceil(n / 2)} message${n > 2 ? "s" : ""}` : "Your AI Teammate";
 });
 const canSend = computed(
 	() =>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1795,7 +1795,7 @@ const WAIT_STEPS = Object.freeze(Array.from({ length: 3 }, (_, i) => Object.free
 
 // Frame subtitle next to the brand mark, mirroring the active step's title.
 const FRAME_SUBS = {
-	intro: "Meet your ERPNext assistant",
+	intro: "Meet Your AI Teammate",
 	plan: "Choose your plan",
 	details: "Your details",
 	pay: "Review & pay",


### PR DESCRIPTION
## Summary

Swaps the "ERPNext Assistant" tagline for "Your AI Teammate" everywhere it's user-visible: the chat header subtitle (shown before any messages exist) and the onboarding intro frame subtitle ("Meet your ERPNext assistant" -> "Meet Your AI Teammate"). Both were the source constants, not copies, so this is the full fix. Repo-wide grep (including proximity variants) found no other occurrences, no DocType default, no translation files, and no test assertions on either string.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff