### PR TITLE
Render site-relative /app/... paths in chat as clickable links

### DIFF
--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -42,7 +42,10 @@ function inline(s) {
 	// space-containing) path ends, so it stops at the first whitespace and trims
 	// trailing sentence punctuation; a docname with embedded spaces still comes
 	// through correctly when the agent wraps it in backticks, as in the bug's own
-	// evidence.
+	// evidence. The match also excludes ]/[/( so it can't run past the end of
+	// enclosing markdown link syntax ("[/app/foo](https://...)") and swallow the
+	// whole thing as one "path" — the restore pass below separately guards against
+	// nesting a second <a> inside a link built around that syntax.
 	const appLinks = [];
 	let t = String(s)
 		// Strip NUL first so attacker-supplied input can't collide with the sentinel below.
@@ -51,7 +54,7 @@ function inline(s) {
 			codes.push(c);
 			return `\u0000C${codes.length - 1}\u0000`;
 		})
-		.replace(/(^|[\s([{"'])(\/app\/[^\s<>"')\u0000]+)/g, (_m, pre, rawPath) => {
+		.replace(/(^|[\s([{"'])(\/app\/[^\s<>"')\]\[(\u0000]+)/g, (_m, pre, rawPath) => {
 			let path = rawPath;
 			let trail = "";
 			while (path.length > "/app/".length && /[.,;:!?)\]}'"]/.test(path[path.length - 1])) {
@@ -75,22 +78,47 @@ function inline(s) {
 		/\[([^\]]+)\]\((https?:[^)]+)\)/g,
 		'<a href="$2" target="_blank" rel="noopener" class="jv-md-link">$1</a>'
 	);
-	// Restore bare app-path links.
-	t = t.replace(/\u0000A(\d+)\u0000/g, (_m, i) => appPathLink(appLinks[Number(i)]));
-	// Restore code spans, escaping their raw content so it renders verbatim (a <br>,
-	// **bold**, etc. inside backticks shows as literal text, not markup). A code span
-	// whose ENTIRE content is a site-relative "/app/..." path becomes a link instead -
-	// that's the agent's usual way of citing where it put something, and a plain grey
-	// code box reads as inert text, which is exactly the bug (the user missed a link
-	// and re-asked for the dashboard). Anything else inside backticks stays a literal
-	// code span; arbitrary code is never auto-linked.
-	t = t.replace(/\u0000C(\d+)\u0000/g, (_m, i) => {
-		const raw = codes[Number(i)];
-		const trimmed = raw.trim();
-		return APP_PATH_RE.test(trimmed)
-			? appPathLink(trimmed)
-			: `<code class="jv-md-code">${esc(raw)}</code>`;
-	});
+	// Restore both sentinel kinds in ONE pass that tracks whether we're already
+	// inside an <a> the http(s) link transform above just built (e.g. an agent
+	// citing "[/app/foo](https://docs...)" or "[`/app/foo`](https://docs...)" -
+	// the /app/ path IS that link's own text). Wrapping it in a SECOND <a> there
+	// would nest anchors, which a browser resolves by silently closing the outer
+	// one - the external link goes dead and only the inner path stays clickable.
+	// So inside an anchor a sentinel restores to its inert form (plain text /
+	// <code>) same as it always did pre-linkification; only outside one does it
+	// become its own link. Mirrors the inAnchor walk ChatView's linkifyDocs()
+	// already uses for the same reason.
+	let inAnchor = 0;
+	t = t.replace(
+		/(<a\b[^>]*>)|(<\/a>)|(?:\u0000A(\d+)\u0000)|(?:\u0000C(\d+)\u0000)/g,
+		(_m, aOpen, aClose, appIdx, codeIdx) => {
+			if (aOpen) {
+				inAnchor++;
+				return aOpen;
+			}
+			if (aClose) {
+				inAnchor = Math.max(0, inAnchor - 1);
+				return aClose;
+			}
+			if (appIdx !== undefined) {
+				const path = appLinks[Number(appIdx)];
+				return inAnchor ? esc(path) : appPathLink(path);
+			}
+			// Restore code spans, escaping their raw content so it renders verbatim
+			// (a <br>, **bold**, etc. inside backticks shows as literal text, not
+			// markup). A code span whose ENTIRE content is a site-relative
+			// "/app/..." path becomes a link instead - that's the agent's usual way
+			// of citing where it put something, and a plain grey code box reads as
+			// inert text, which is exactly the bug (the user missed a link and
+			// re-asked for the dashboard). Anything else inside backticks stays a
+			// literal code span; arbitrary code is never auto-linked.
+			const raw = codes[Number(codeIdx)];
+			const trimmed = raw.trim();
+			return !inAnchor && APP_PATH_RE.test(trimmed)
+				? appPathLink(trimmed)
+				: `<code class="jv-md-code">${esc(raw)}</code>`;
+		}
+	);
 	return t;
 }
 

--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -9,6 +9,24 @@ function esc(s) {
 	);
 }
 
+// A site-relative Desk path the agent cites after creating/locating a record,
+// e.g. "/app/dashboard-view/Customer-Item Manufacturing Priority". Worth a
+// clickable link either way it shows up: alone inside a code span (the agent's
+// usual way of citing one) or as bare text. Docnames routinely contain spaces,
+// so the href percent-encodes them while the visible text stays exactly what
+// the agent wrote.
+const APP_PATH_RE = /^\/app\/\S[^\n]*$/;
+
+function appPathHref(path) {
+	return path.replace(/ /g, "%20");
+}
+
+function appPathLink(path) {
+	return `<a href="${esc(
+		appPathHref(path)
+	)}" target="_blank" rel="noopener" class="jv-md-link">${esc(path)}</a>`;
+}
+
 function inline(s) {
 	// Stash inline code spans behind a NUL sentinel FIRST, so none of the transforms
 	// below touch content meant to render verbatim: the <br> re-permit, and also
@@ -16,12 +34,32 @@ function inline(s) {
 	// `a*b*c` rendered a stray <em>). Restored last, HTML-escaped. NUL never occurs in
 	// agent/user text, so it can't collide with real content.
 	const codes = [];
+	// Bare (non-code) "/app/..." paths get the same sentinel treatment, so bold/em/
+	// link transforms below can't mangle a slash-heavy path. Only triggers after
+	// start-of-string/whitespace/an opening bracket or quote, so a path segment
+	// inside a full external URL ("https://x.com/app/foo") is never mistaken for a
+	// site-relative one. Bare text has no delimiter marking where a (possibly
+	// space-containing) path ends, so it stops at the first whitespace and trims
+	// trailing sentence punctuation; a docname with embedded spaces still comes
+	// through correctly when the agent wraps it in backticks, as in the bug's own
+	// evidence.
+	const appLinks = [];
 	let t = String(s)
 		// Strip NUL first so attacker-supplied input can't collide with the sentinel below.
 		.replace(/\u0000/g, "")
 		.replace(/`([^`]+)`/g, (_m, c) => {
 			codes.push(c);
 			return `\u0000C${codes.length - 1}\u0000`;
+		})
+		.replace(/(^|[\s([{"'])(\/app\/[^\s<>"')\u0000]+)/g, (_m, pre, rawPath) => {
+			let path = rawPath;
+			let trail = "";
+			while (path.length > "/app/".length && /[.,;:!?)\]}'"]/.test(path[path.length - 1])) {
+				trail = path[path.length - 1] + trail;
+				path = path.slice(0, -1);
+			}
+			appLinks.push(path);
+			return pre + `\u0000A${appLinks.length - 1}\u0000` + trail;
 		});
 	t = esc(t);
 	// esc() escaped ALL html (XSS-safe for LLM output). Re-permit ONLY a bare,
@@ -37,12 +75,22 @@ function inline(s) {
 		/\[([^\]]+)\]\((https?:[^)]+)\)/g,
 		'<a href="$2" target="_blank" rel="noopener" class="jv-md-link">$1</a>'
 	);
+	// Restore bare app-path links.
+	t = t.replace(/\u0000A(\d+)\u0000/g, (_m, i) => appPathLink(appLinks[Number(i)]));
 	// Restore code spans, escaping their raw content so it renders verbatim (a <br>,
-	// **bold**, etc. inside backticks shows as literal text, not markup).
-	t = t.replace(
-		/\u0000C(\d+)\u0000/g,
-		(_m, i) => `<code class="jv-md-code">${esc(codes[Number(i)])}</code>`
-	);
+	// **bold**, etc. inside backticks shows as literal text, not markup). A code span
+	// whose ENTIRE content is a site-relative "/app/..." path becomes a link instead -
+	// that's the agent's usual way of citing where it put something, and a plain grey
+	// code box reads as inert text, which is exactly the bug (the user missed a link
+	// and re-asked for the dashboard). Anything else inside backticks stays a literal
+	// code span; arbitrary code is never auto-linked.
+	t = t.replace(/\u0000C(\d+)\u0000/g, (_m, i) => {
+		const raw = codes[Number(i)];
+		const trimmed = raw.trim();
+		return APP_PATH_RE.test(trimmed)
+			? appPathLink(trimmed)
+			: `<code class="jv-md-code">${esc(raw)}</code>`;
+	});
 	return t;
 }
 

--- a/frontend/src/markdown.test.js
+++ b/frontend/src/markdown.test.js
@@ -153,3 +153,28 @@ test("a bare path immediately abutting a code span does not swallow the code-spa
 	);
 	assert.ok(html.includes('<code class="jv-md-code">y</code>'), "the code span restores intact");
 });
+
+test("an /app/ path used AS a markdown link's own text does not nest a second <a> inside it", () => {
+	// Regression: an agent citing "[/app/foo](https://docs...)" has the path sitting
+	// inside the link's own text. Auto-linking it there would nest <a> elements, and a
+	// browser resolves that by silently closing the OUTER anchor - the external link
+	// goes dead. The path must render as plain (escaped) text inside the one real <a>.
+	const html = renderMarkdown("[/app/dashboard-view/Foo](https://docs.example.com/help)");
+	assert.ok(
+		html.includes(
+			'<a href="https://docs.example.com/help" target="_blank" rel="noopener" class="jv-md-link">/app/dashboard-view/Foo</a>'
+		),
+		"exactly one anchor, wrapping the path as plain text"
+	);
+	assert.equal((html.match(/<a /g) || []).length, 1, "no nested second anchor");
+});
+
+test("an /app/ path inside BACKTICKS used as a markdown link's text also avoids a nested <a>", () => {
+	const html = renderMarkdown("[`/app/dashboard-view/Foo`](https://docs.example.com/help)");
+	assert.equal((html.match(/<a /g) || []).length, 1, "no nested second anchor");
+	assert.ok(html.includes('<a href="https://docs.example.com/help"'), "the outer link survives");
+	assert.ok(
+		html.includes('<code class="jv-md-code">/app/dashboard-view/Foo</code>'),
+		"the path still renders as code, just not as its own link, inside the outer anchor"
+	);
+});

--- a/frontend/src/markdown.test.js
+++ b/frontend/src/markdown.test.js
@@ -90,3 +90,66 @@ test("strips NUL so crafted input can't collide with the internal code-span sent
 	assert.ok(!html.includes("<code"), "no spurious code span from an injected sentinel");
 	assert.ok(!html.includes("undefined"), "no phantom code-index leak");
 });
+
+// The motivating bug: an agent reply cites a Desk location as inline code, e.g.
+// `/app/dashboard-view/Customer-Item Manufacturing Priority`. Rendered as plain
+// code text it read as inert, so a user who'd just had that dashboard created
+// missed the link and asked for it again (conversation ves2j96q81, seq 36).
+
+test("a code span that is EXACTLY a site-relative /app/... path renders as a clickable link", () => {
+	const html = renderMarkdown(
+		"Here you go: `/app/dashboard-view/Customer-Item Manufacturing Priority`"
+	);
+	assert.ok(!html.includes("<code"), "no code span left for a pure app-path");
+	assert.ok(
+		html.includes(
+			'<a href="/app/dashboard-view/Customer-Item%20Manufacturing%20Priority" target="_blank" rel="noopener" class="jv-md-link">/app/dashboard-view/Customer-Item Manufacturing Priority</a>'
+		),
+		"renders a jv-md-link with spaces percent-encoded in the href but not the visible text"
+	);
+});
+
+test("a code span that merely CONTAINS an app path alongside other text stays a plain code span", () => {
+	const html = renderMarkdown("run `cd /app/foo && ls` first");
+	assert.ok(html.includes("<code"), "still a code span");
+	assert.ok(!html.includes("<a "), "not linkified — it's not EXACTLY a path");
+});
+
+test("an ordinary code span unrelated to /app/ paths is untouched", () => {
+	const html = renderMarkdown("use `git status` to check");
+	assert.ok(html.includes('<code class="jv-md-code">git status</code>'));
+});
+
+test("a bare /app/... path in plain prose (no backticks) also becomes a clickable link", () => {
+	const html = renderMarkdown("It's live at /app/sales-invoice/SINV-2026-00042 now.");
+	assert.ok(
+		html.includes(
+			'<a href="/app/sales-invoice/SINV-2026-00042" target="_blank" rel="noopener" class="jv-md-link">/app/sales-invoice/SINV-2026-00042</a>'
+		)
+	);
+	assert.ok(html.includes("now."), "trailing sentence punctuation stays outside the link text");
+	assert.ok(!html.includes("00042.</a>"), "the trailing period is not swallowed into the link");
+});
+
+test("an external URL is left to its own link handling, not mistaken for a site-relative path", () => {
+	const html = renderMarkdown("See [the dashboard](https://example.com/app/foo) for details.");
+	assert.ok(html.includes('<a href="https://example.com/app/foo"'), "markdown link untouched");
+	assert.ok((html.match(/<a /g) || []).length === 1, "no second, spurious link was created");
+});
+
+test("bare app-path linking does not fire inside an existing <a> tag's own path segment", () => {
+	const html = renderMarkdown("Visit https://other.example/app/thing directly.");
+	assert.ok(!html.includes('href="/app/thing"'), "the /app/ inside a full URL is not re-linked");
+});
+
+test("a bare path immediately abutting a code span does not swallow the code-span sentinel", () => {
+	// Regression: the bare-path stash runs after code spans are stashed behind a NUL
+	// sentinel, so an un-excluded sentinel char in the path's match class would pull
+	// the sentinel into the href and corrupt both the link and the code span.
+	const html = renderMarkdown("see /app/x`y`");
+	assert.ok(
+		html.includes('<a href="/app/x"'),
+		"the bare path links cleanly, without the sentinel"
+	);
+	assert.ok(html.includes('<code class="jv-md-code">y</code>'), "the code span restores intact");
+});


### PR DESCRIPTION
## Summary

Agent replies that cite a Desk location as a `/app/...` path (in code or plain text) now render as a clickable link instead of inert text; a user had missed a dashboard the agent had just created because the reply showed only an unclickable code span.

- A code span whose entire content is a site-relative `/app/...` path renders as a link, not a `<code>` box.
- A bare `/app/...` path in prose also links, stopping at the first whitespace and trimming trailing punctuation.
- Spaces in the docname are percent-encoded in the href only; visible text is unchanged.
- External URLs and arbitrary code spans are untouched.

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop` (branched from latest `upstream/develop`)
- [x] New/changed behavior has tests (16 unit tests in `frontend/src/markdown.test.js`)
- [x] I self-reviewed the diff