### PR TITLE
fix: AI-models rows show each row's own provider logo

### DIFF
--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -1070,3 +1070,29 @@ describe("subscription source chip labels the real provider", () => {
 		expect(chip("someday")).toBe("Subscription · someday");
 	});
 });
+
+describe("row logo matches the row's own provider (jarvis: AI-models row icon bug)", () => {
+	// seedRows() backfills a UI-only `upstream` field onto every row (subscription
+	// rows need it), defaulting to "openai" when a row has no accounts to read it
+	// from - which api-key rows never do. ProviderLogo gives that `upstream` prop
+	// priority over `provider`, so every api-key row rendered the OpenAI mark
+	// regardless of its actual provider. The fix scopes `:upstream` to subscription
+	// rows only at the two row-render call sites; this asserts through the real
+	// row template, not ProviderLogo in isolation, so it would have caught the bug.
+	it("shows the anthropic mark on an anthropic api-key row, not openai's", async () => {
+		setPool([
+			subModel("gpt-5.5", 0, [account("SUB_a", "a@x.com")]),
+			keyModel("anthropic", "claude-sonnet-5", 1),
+		]);
+		const w = await mountEditor();
+
+		const rows = w.findAll(".jv-flist-row");
+		const subRow = rows.find((r) => r.text().includes("Subscription · OpenAI"));
+		const apiKeyRow = rows.find((r) => r.text().includes("API key · Anthropic"));
+		expect(subRow).toBeTruthy();
+		expect(apiKeyRow).toBeTruthy();
+
+		expect(subRow.find('[role="img"]').attributes("aria-label")).toBe("OpenAI logo");
+		expect(apiKeyRow.find('[role="img"]').attributes("aria-label")).toBe("Anthropic logo");
+	});
+});

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -170,7 +170,7 @@
 						<span class="jv-pool-badge">{{ i + 1 }}</span>
 						<ProviderLogo
 							:provider="row.provider"
-							:upstream="row.upstream"
+							:upstream="row.credentialType === 'subscription' ? row.upstream : ''"
 							:size="18"
 						/>
 						<span class="jv-flist-chip">{{ sourceChip(row) }}</span>
@@ -333,7 +333,9 @@
 								<span class="jv-pool-badge">{{ i + 1 }}</span>
 								<ProviderLogo
 									:provider="row.provider"
-									:upstream="row.upstream"
+									:upstream="
+										row.credentialType === 'subscription' ? row.upstream : ''
+									"
 									:size="18"
 								/>
 								<span class="jv-flist-chip">{{ sourceChip(row) }}</span>


### PR DESCRIPTION
## Summary

Every row in Settings -> AI models showed the OpenAI logo regardless of its actual provider (an Anthropic API-key row rendered OpenAI's mark). The row's `ProviderLogo` was passed `upstream` unconditionally, and a UI-only default (`upstream: "openai"`) that every row carries for subscription support was taking priority over the row's real `provider`. Fixed by only passing `upstream` for subscription rows, so api-key rows now resolve their logo from their own provider.

## Pre-merge checklist

- [x] CI is green - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop` (branched from upstream/develop just now)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff