### PR TITLE
fix: consistent keyboard-focus outline across app-shell sidebar

### DIFF
--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -53,7 +53,7 @@
 						class="flex h-12 shrink-0 items-center gap-2 border-b px-3"
 					>
 						<button
-							class="grid size-9 place-items-center rounded-md text-ink-gray-7 focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
+							class="jv-focus-ring grid size-9 place-items-center rounded-md text-ink-gray-7"
 							aria-label="Open navigation"
 							@click="store.mobileDrawerOpen = true"
 						>

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -53,7 +53,7 @@
 						class="flex h-12 shrink-0 items-center gap-2 border-b px-3"
 					>
 						<button
-							class="grid size-9 place-items-center rounded-md text-ink-gray-7"
+							class="grid size-9 place-items-center rounded-md text-ink-gray-7 focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
 							aria-label="Open navigation"
 							@click="store.mobileDrawerOpen = true"
 						>

--- a/frontend/src/components/shell/ConversationRow.vue
+++ b/frontend/src/components/shell/ConversationRow.vue
@@ -39,7 +39,7 @@
 					<Button
 						variant="ghost"
 						icon="more-horizontal"
-						class="!h-5 !w-5 opacity-0 group-hover:opacity-100 focus:outline-none focus:transition-none focus-visible:!opacity-100 focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
+						class="!h-5 !w-5 opacity-0 group-hover:opacity-100 focus-visible:!opacity-100"
 						:aria-label="'Options for ' + (conv.title || 'chat')"
 						@click.stop
 					/>

--- a/frontend/src/components/shell/ConversationRow.vue
+++ b/frontend/src/components/shell/ConversationRow.vue
@@ -39,7 +39,7 @@
 					<Button
 						variant="ghost"
 						icon="more-horizontal"
-						class="!h-5 !w-5 opacity-0 group-hover:opacity-100"
+						class="!h-5 !w-5 opacity-0 group-hover:opacity-100 focus:outline-none focus:transition-none focus-visible:!opacity-100 focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
 						:aria-label="'Options for ' + (conv.title || 'chat')"
 						@click.stop
 					/>

--- a/frontend/src/components/shell/Sidebar.vue
+++ b/frontend/src/components/shell/Sidebar.vue
@@ -220,7 +220,7 @@
 			</SidebarLink>
 			<button
 				v-if="!collapsed && editing"
-				class="flex size-8 shrink-0 items-center justify-center rounded-md text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8 focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
+				class="jv-focus-ring flex size-8 shrink-0 items-center justify-center rounded-md text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8"
 				title="Reset to default order"
 				@click="resetOrder"
 			>
@@ -228,7 +228,7 @@
 			</button>
 			<button
 				v-if="!collapsed"
-				class="flex size-8 shrink-0 items-center justify-center rounded-md hover:bg-surface-gray-2 focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
+				class="jv-focus-ring flex size-8 shrink-0 items-center justify-center rounded-md hover:bg-surface-gray-2"
 				:class="editing ? 'text-ink-blue-link' : 'text-ink-gray-5 hover:text-ink-gray-8'"
 				:title="editing ? 'Done' : 'Edit sidebar order'"
 				@click="editing = !editing"

--- a/frontend/src/components/shell/Sidebar.vue
+++ b/frontend/src/components/shell/Sidebar.vue
@@ -220,7 +220,7 @@
 			</SidebarLink>
 			<button
 				v-if="!collapsed && editing"
-				class="flex size-8 shrink-0 items-center justify-center rounded-md text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8"
+				class="flex size-8 shrink-0 items-center justify-center rounded-md text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8 focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
 				title="Reset to default order"
 				@click="resetOrder"
 			>
@@ -228,7 +228,7 @@
 			</button>
 			<button
 				v-if="!collapsed"
-				class="flex size-8 shrink-0 items-center justify-center rounded-md hover:bg-surface-gray-2"
+				class="flex size-8 shrink-0 items-center justify-center rounded-md hover:bg-surface-gray-2 focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
 				:class="editing ? 'text-ink-blue-link' : 'text-ink-gray-5 hover:text-ink-gray-8'"
 				:title="editing ? 'Done' : 'Edit sidebar order'"
 				@click="editing = !editing"

--- a/frontend/src/components/shell/SidebarLink.vue
+++ b/frontend/src/components/shell/SidebarLink.vue
@@ -1,6 +1,6 @@
 <template>
 	<button
-		class="flex h-7.5 cursor-pointer items-center rounded text-ink-gray-8 duration-300 ease-in-out focus:outline-none focus:transition-none focus-visible:rounded focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
+		class="jv-focus-ring flex h-7.5 cursor-pointer items-center rounded text-ink-gray-8 duration-300 ease-in-out"
 		:class="isActive ? 'bg-surface-selected shadow-sm' : 'hover:bg-surface-gray-2'"
 		@click="handleClick"
 	>

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -2,7 +2,7 @@
 	<Dropdown :options="menuOptions">
 		<template #trigger="{ open }">
 			<button
-				class="relative flex h-12 items-center rounded-md py-2 duration-300 ease-in-out"
+				class="relative flex h-12 items-center rounded-md py-2 duration-300 ease-in-out focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
 				:class="
 					isCollapsed
 						? 'w-auto px-0'

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -2,7 +2,7 @@
 	<Dropdown :options="menuOptions">
 		<template #trigger="{ open }">
 			<button
-				class="relative flex h-12 items-center rounded-md py-2 duration-300 ease-in-out focus:outline-none focus:transition-none focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
+				class="jv-focus-ring relative flex h-12 items-center rounded-md py-2 duration-300 ease-in-out"
 				:class="
 					isCollapsed
 						? 'w-auto px-0'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,6 +140,25 @@
 	--ink-gray-4: #6a6a74;
 }
 
+/* App-wide keyboard-focus outline (app-shell sidebar controls: SidebarLink,
+   Sidebar's reset-order/edit-toggle buttons, UserMenu, AppShell's mobile
+   hamburger). Suppresses the browser's default outline on a mouse click,
+   restores it only for :focus-visible (keyboard) navigation, in the app's
+   --focus-ring token instead of the browser's own blue. One definition so
+   every sidebar control shares it instead of a copy-pasted Tailwind
+   arbitrary-value string. */
+.jv-focus-ring {
+	outline: none;
+}
+.jv-focus-ring:focus {
+	outline: none;
+	transition: none;
+}
+.jv-focus-ring:focus-visible {
+	outline: 2px solid var(--focus-ring);
+	outline-offset: 2px;
+}
+
 /* "Go to Desk" header button (LayoutHeader, variant=outline): black-inversion
    hover so it matches the chat header's boxed icon buttons. --ink-gray-9 /
    --surface-white invert per theme (black bg / white icon in light; the reverse


### PR DESCRIPTION
## Summary

Sidebar nav icons keep the browser's default blue focus box on click; this makes every sidebar control (not just Dashboard) suppress it on mouse click and show the app's own near-black outline only on keyboard focus.

Root cause: `SidebarLink.vue`, the single component every rail link (New Chat, Search, File Box, Approval Board, Dashboard, Skills, Agents, More, Macros, Triggers, Search chats, Collapse) renders through, was already fixed for this in a prior commit (377171d0), gating the outline behind `:focus-visible` with the app's `--focus-ring` token. The reported blue box is a stale pre-fix bundle. What was still open: several bare sidebar controls outside that shared component had no focus styling at all and would show the raw browser blue outline on Tab - the reset-order and edit-toggle buttons, UserMenu's brand/user button, ConversationRow's "..." options button, and the mobile hamburger. This PR applies the same treatment to all of them.

Non-focusable elements checked and left alone: the drawer scrim and the resize-handle separator (neither is a real interactive element).

## Pre-merge checklist

- [x] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop`
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff