### PR TITLE
Fade model-picker scrollbar to macOS overlay style

### DIFF
--- a/frontend/src/components/chat/AskCard.vue
+++ b/frontend/src/components/chat/AskCard.vue
@@ -68,6 +68,7 @@
 				<div
 					v-if="link[qi] && link[qi].open && (link[qi].items || []).length"
 					class="jv-ask-linkmenu"
+					v-scroll-fade
 				>
 					<button
 						v-for="(it, ii) in link[qi].items"
@@ -119,6 +120,7 @@
 // half-made picks. Remounting on a new message is what clears the draft.
 import { ref, computed } from "vue";
 import { searchLink } from "@/api";
+import { vScrollFade } from "@/composables/useScrollFade";
 import { ASK_FIELD_TYPES, isAskReady, askAnswerText } from "@/lib/chatAsk";
 
 const props = defineProps({

--- a/frontend/src/components/chat/ModelEffortPicker.vue
+++ b/frontend/src/components/chat/ModelEffortPicker.vue
@@ -50,7 +50,7 @@
 			<!-- models (scrolls: the list can grow tall across several providers;
 			     the Effort/Persona rows and their side-flyouts stay OUTSIDE this
 			     scroll region so the flyouts anchor correctly and never clip) -->
-			<div class="mep-scroll">
+			<div class="mep-scroll" v-scroll-fade>
 				<template v-for="(g, gi) in modelsByProvider" :key="g.provider">
 					<div v-if="showProviders" class="mep-head">{{ g.provider }}</div>
 					<button
@@ -231,6 +231,7 @@
 import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { agentName } from "@/branding";
 import { useDismissable } from "@/composables/useDismissable";
+import { vScrollFade } from "@/composables/useScrollFade";
 import { useShellStore } from "@/stores/shell";
 import CheckMark from "@/components/chat/CheckMark.vue";
 import PersonaOptions from "@/components/chat/PersonaOptions.vue";

--- a/frontend/src/composables/useScrollFade.js
+++ b/frontend/src/composables/useScrollFade.js
@@ -1,0 +1,41 @@
+// macOS-style overlay scrollbar for popover/dropdown scroll regions. The
+// scrollbar track is permanently invisible; a scroll event marks the element
+// as `.is-scrolling` (revealing the thumb via the `.jv-scroll-fade` CSS in
+// main.css) and a timer removes that class ~800ms after scrolling stops.
+//
+// Exposed as a Vue custom directive rather than a ref-based composable so it
+// drops onto ANY scrollable element with a single `v-scroll-fade` attribute
+// — including elements repeated by v-for (each gets its own listener/timer),
+// which a single-ref composable can't handle without extra per-item wiring.
+// Vue 3.2+ auto-registers a `<script setup>` import named `vXxx` as the
+// directive `v-xxx`, so no global registration in main.js is needed.
+const HIDE_DELAY_MS = 800;
+const timers = new WeakMap();
+
+function handleScroll(el) {
+	el.classList.add("is-scrolling");
+	const prev = timers.get(el);
+	if (prev) clearTimeout(prev);
+	timers.set(
+		el,
+		setTimeout(() => {
+			el.classList.remove("is-scrolling");
+			timers.delete(el);
+		}, HIDE_DELAY_MS)
+	);
+}
+
+export const vScrollFade = {
+	mounted(el) {
+		el.classList.add("jv-scroll-fade");
+		el.__jvScrollFadeHandler = () => handleScroll(el);
+		el.addEventListener("scroll", el.__jvScrollFadeHandler, { passive: true });
+	},
+	unmounted(el) {
+		el.removeEventListener("scroll", el.__jvScrollFadeHandler);
+		delete el.__jvScrollFadeHandler;
+		const t = timers.get(el);
+		if (t) clearTimeout(t);
+		timers.delete(el);
+	},
+};

--- a/frontend/src/composables/useScrollFade.spec.js
+++ b/frontend/src/composables/useScrollFade.spec.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { vScrollFade } from "./useScrollFade";
+
+// Bare host element: the `v-scroll-fade` directive works on any scrollable
+// node, so a plain <div> is enough to exercise mounted()/unmounted() without
+// pulling in a real popover component. The vXxx -> v-xxx auto-registration
+// only kicks in for <script setup> SFCs, so the test wires the directive in
+// explicitly via `global.directives`.
+const Host = {
+	template: '<div class="scroll-region" v-scroll-fade style="overflow:auto"></div>',
+};
+
+function mountHost() {
+	return mount(Host, { global: { directives: { "scroll-fade": vScrollFade } } });
+}
+
+describe("v-scroll-fade directive", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("marks the element as an overlay-scrollbar surface on mount", () => {
+		const w = mountHost();
+		expect(w.find(".scroll-region").classes()).toContain("jv-scroll-fade");
+	});
+
+	it("adds is-scrolling while a scroll event is firing", async () => {
+		const w = mountHost();
+		await w.find(".scroll-region").trigger("scroll");
+		expect(w.find(".scroll-region").classes()).toContain("is-scrolling");
+	});
+
+	it("removes is-scrolling ~800ms after scrolling stops", async () => {
+		const w = mountHost();
+		await w.find(".scroll-region").trigger("scroll");
+		expect(w.find(".scroll-region").classes()).toContain("is-scrolling");
+		vi.advanceTimersByTime(800);
+		expect(w.find(".scroll-region").classes()).not.toContain("is-scrolling");
+	});
+
+	it("restarts the hide timer on repeated scrolling instead of hiding early", async () => {
+		const w = mountHost();
+		const el = w.find(".scroll-region");
+		await el.trigger("scroll");
+		vi.advanceTimersByTime(500);
+		await el.trigger("scroll"); // still scrolling — should push the deadline out
+		vi.advanceTimersByTime(500);
+		expect(el.classes()).toContain("is-scrolling");
+		vi.advanceTimersByTime(300);
+		expect(el.classes()).not.toContain("is-scrolling");
+	});
+
+	it("cleans up its scroll listener on unmount", async () => {
+		const w = mountHost();
+		const el = w.element;
+		const removeSpy = vi.spyOn(el, "removeEventListener");
+		w.unmount();
+		expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
+	});
+});

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -109,6 +109,48 @@ body {
 :root[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
 	background-color: #4a4a55;
 }
+/* Overlay scrollbar primitive for popovers/dropdowns: applied by the
+   `v-scroll-fade` directive (composables/useScrollFade.js), which toggles
+   `.is-scrolling` on scroll and removes it ~800ms after scrolling stops.
+   Invisible at rest, revealed only while actively scrolling, matching the
+   macOS overlay style rather than a permanent track. Opt-in via this class
+   so it doesn't widen the global ::-webkit-scrollbar rule above to every
+   scroll surface in the app. */
+.jv-scroll-fade {
+	scrollbar-width: thin;
+	scrollbar-color: transparent transparent;
+}
+.jv-scroll-fade.is-scrolling {
+	scrollbar-color: #d6d6dc transparent;
+}
+.jv-scroll-fade::-webkit-scrollbar {
+	width: 7px;
+	height: 7px;
+}
+.jv-scroll-fade::-webkit-scrollbar-thumb {
+	background-color: transparent;
+	border-radius: 8px;
+	border: 2px solid transparent;
+	background-clip: padding-box;
+	transition: background-color 0.2s ease;
+}
+.jv-scroll-fade.is-scrolling::-webkit-scrollbar-thumb {
+	background-color: #d6d6dc;
+	background-clip: padding-box;
+}
+.jv-scroll-fade::-webkit-scrollbar-thumb:hover {
+	background-color: #c2c2ca;
+	background-clip: padding-box;
+}
+:root[data-theme="dark"] .jv-scroll-fade.is-scrolling {
+	scrollbar-color: #3a3a45 transparent;
+}
+:root[data-theme="dark"] .jv-scroll-fade.is-scrolling::-webkit-scrollbar-thumb {
+	background-color: #3a3a45;
+}
+:root[data-theme="dark"] .jv-scroll-fade::-webkit-scrollbar-thumb:hover {
+	background-color: #4a4a55;
+}
 @keyframes jv-fade {
 	from { opacity: 0; transform: translateY(6px); }
 	to { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary

The composer's model-picker popover showed a permanent scrollbar track down its right edge. It now stays hidden and only appears while the user is actively scrolling, fading out about 800ms after they stop, matching macOS overlay scrollbar behavior.

Added a reusable `v-scroll-fade` directive (`frontend/src/composables/useScrollFade.js`) plus a `.jv-scroll-fade` CSS primitive in `main.css`, since no shared popover/dropdown component exists to hold the fix once. Applied it to the model picker's `.mep-scroll` list and to the chat "Ask" card's link-search dropdown (`.jv-ask-linkmenu`), the two floating popovers in the chat SPA with an always-visible scrollbar. `JvCombo`'s and `LlmPoolEditor`'s dropdown menus have the same pattern but are being edited on other branches right now, so they were left for a follow-up (just adding the directive). The settings dialog's existing `.jv-scroll-overlay` hover-reveal utility was checked and left as is, since it already has no permanent track.

Keyboard and trackpad scrolling are unaffected; only the scrollbar's paint changed.

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`** (branched from latest `upstream/develop`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff