### PR TITLE
Live dashboard-build progress card + click-through thumbnail in chat

### DIFF
--- a/frontend/src/lib/dashboardBuildCard.js
+++ b/frontend/src/lib/dashboardBuildCard.js
@@ -1,38 +1,90 @@
 // The "Building dashboard…" live card + finished thumbnail, for a dashboard
 // build watched from MAIN chat (issue #858).
 //
-// Two things this file decides, both pure and both fenced by
-// dashboardBuildCard.test.js so the wiring in ChatView.vue stays honest:
+// Corrected understanding (this file originally assumed main chat could
+// never originate a build at all — wrong, see below): three things this
+// file decides, all pure and all fenced by dashboardBuildCard.test.js so
+// the wiring in ChatView.vue stays honest:
 //
 //   1. Whether the turn CURRENTLY streaming into this conversation is a
-//      dashboard build, so the live progress card only ever shows for one.
+//      BUILDER-ORIGIN dashboard build, so the live progress card only ever
+//      shows for one.
 //   2. What phase that build is honestly in RIGHT NOW, from the same
 //      real events ChatView already keeps for its generic "Working on it…"
 //      indicator (tool:start/tool:end -> activeTools, statusPhase). Never a
 //      timer: a phase this mount has not seen evidence for is reported as
 //      `null` (indeterminate) rather than guessed.
+//   3. Whether a FINISHED canvas item is a dashboard build regardless of
+//      which conversation it landed in — the signal the thumbnail and its
+//      click-through gate on, since origin alone misses a real path.
 //
-// The turn-level gate reuses the exact origin binding
+// The turn-level gate (1) reuses the exact origin binding
 // `canOpenInDashboards` (dashboardOpen.js) already uses for the finished
 // artifact's "Open in Dashboards" button: `origin_page` is stamped
 // server-side only when the message that opened this turn was sent with the
 // Dashboards builder's `context: {page: "dashboards"}` (jarvis/chat/api.py).
-// A turn earns the live card under precisely the same rule a build earns the
-// promote button — main chat itself never originates one (api/dashboards.js
-// is the only sender of that context), so both gates read the same fact:
-// "this conversation's current activity came from the builder".
+// That gate is real for the LIVE PROGRESS CARD specifically — it controls
+// the extra system-prompt instructions turn_handler.py injects (theme
+// cheatsheet, interview-first flow), which only main chat's ORDINARY
+// composer never sends, so a turn watched there before the reply lands has
+// no honest pre-canvas signal (see isDashboardBuildTurn's own note).
+//
+// It is NOT true of the finished canvas, though: `jarvis/chat/canvas.py`'s
+// `persist_canvases` runs unconditionally at the end of EVERY turn, in
+// every conversation, with no origin check at all (jarvis/chat/turn_handler
+// .py's `_persist_canvas_and_publish`). And the jarvis-persona skill that
+// produces a Dashboards build (`skills/jarvis-dashboards/SKILL.md`) is
+// itself discoverable by ordinary description match in ANY chat — its own
+// text: "a dashboard request in ordinary chat... still gets built here, not
+// just pointed elsewhere". So a main-chat-originated dashboard canvas is a
+// real, reachable case, and `isDashboardCanvas` below is the signal the
+// finished-canvas UI (thumbnail, click-through) gates on instead of origin.
 
 /**
  * Does the turn currently streaming into `conversation` belong to a
- * dashboard build? Same binding rule as `canOpenInDashboards`: the origin
- * must be read FOR this exact conversation, not a stale value left over from
- * the thread the user was just looking at.
+ * BUILDER-ORIGIN dashboard build? Same binding rule as `canOpenInDashboards`:
+ * the origin must be read FOR this exact conversation, not a stale value
+ * left over from the thread the user was just looking at.
+ *
+ * This is deliberately narrower than "is this turn building a dashboard" —
+ * a main-chat build (no builder origin) is real but has no equivalent
+ * pre-canvas signal, so a plain conversation always reports `false` here
+ * and the live progress card simply does not show for it; the canvas
+ * itself still gets the thumbnail treatment once it lands, via
+ * `isDashboardCanvas` below.
  *
  * @param {{originPage: string, originOf: string, conversation: string}} arg
  */
 export function isDashboardBuildTurn({ originPage, originOf, conversation }) {
 	if (originPage !== "dashboards") return false;
 	return !!conversation && originOf === conversation;
+}
+
+// The dashboards skill is the ONLY skill in the persona catalog that uses
+// the agent's "hosted embed" canvas mechanism (`[embed ref="<id>" .../]`,
+// jarvis/chat/canvas.py `_EMBED_REF`/`_embed_ref_name`) — every hosted-embed
+// canvas item's `name` is stamped `documents/<id>/index.html` regardless of
+// which conversation produced it. A plain `canvas/<path>.html` file
+// reference (any other skill's chart/report/export output) never carries
+// this prefix. This is the cheapest signal available without a backend
+// change: it is exactly what jarvis-persona's skills/jarvis-dashboards/
+// SKILL.md already promises ("that reference is what makes the canvas
+// render it, whether that is the builder page's pane or a main-chat
+// preview") and nothing else in the 38-skill catalog emits it.
+const _HOSTED_EMBED_PREFIX = "documents/";
+
+/**
+ * Is this canvas item a dashboard build, regardless of which conversation
+ * (or turn origin) produced it? The signal the finished-canvas thumbnail and
+ * its "Open in Dashboards" click-through gate on — origin alone misses a
+ * main-chat-originated build, which is a real, reachable case (see the file
+ * header).
+ *
+ * @param {{type?: string, name?: string}|null|undefined} cv
+ */
+export function isDashboardCanvas(cv) {
+	if (!cv || cv.type !== "html") return false;
+	return typeof cv.name === "string" && cv.name.startsWith(_HOSTED_EMBED_PREFIX);
 }
 
 // Tool names that fetch data — the same jarvis__ registry names ChatView's

--- a/frontend/src/lib/dashboardBuildCard.js
+++ b/frontend/src/lib/dashboardBuildCard.js
@@ -1,0 +1,156 @@
+// The "Building dashboard…" live card + finished thumbnail, for a dashboard
+// build watched from MAIN chat (issue #858).
+//
+// Two things this file decides, both pure and both fenced by
+// dashboardBuildCard.test.js so the wiring in ChatView.vue stays honest:
+//
+//   1. Whether the turn CURRENTLY streaming into this conversation is a
+//      dashboard build, so the live progress card only ever shows for one.
+//   2. What phase that build is honestly in RIGHT NOW, from the same
+//      real events ChatView already keeps for its generic "Working on it…"
+//      indicator (tool:start/tool:end -> activeTools, statusPhase). Never a
+//      timer: a phase this mount has not seen evidence for is reported as
+//      `null` (indeterminate) rather than guessed.
+//
+// The turn-level gate reuses the exact origin binding
+// `canOpenInDashboards` (dashboardOpen.js) already uses for the finished
+// artifact's "Open in Dashboards" button: `origin_page` is stamped
+// server-side only when the message that opened this turn was sent with the
+// Dashboards builder's `context: {page: "dashboards"}` (jarvis/chat/api.py).
+// A turn earns the live card under precisely the same rule a build earns the
+// promote button — main chat itself never originates one (api/dashboards.js
+// is the only sender of that context), so both gates read the same fact:
+// "this conversation's current activity came from the builder".
+
+/**
+ * Does the turn currently streaming into `conversation` belong to a
+ * dashboard build? Same binding rule as `canOpenInDashboards`: the origin
+ * must be read FOR this exact conversation, not a stale value left over from
+ * the thread the user was just looking at.
+ *
+ * @param {{originPage: string, originOf: string, conversation: string}} arg
+ */
+export function isDashboardBuildTurn({ originPage, originOf, conversation }) {
+	if (originPage !== "dashboards") return false;
+	return !!conversation && originOf === conversation;
+}
+
+// Tool names that fetch data — the same jarvis__ registry names ChatView's
+// own TOOL_PHRASES already speaks for the generic activity line (query,
+// run_report, get_schema, …). Grouped here as the "Querying data" signal.
+const DATA_TOOLS = new Set([
+	"get_schema",
+	"get_list",
+	"get_doc",
+	"get_report_filters",
+	"run_report",
+	"query",
+	"summarize_dataset",
+	"get_creation_context",
+	"resolve_links",
+]);
+
+// Tool names that write the output artifact rather than read data. Not all
+// of these are confirmed to fire for a dashboard build (only the finished
+// message's `canvas` array is a verified "published" signal), so a name in
+// here only lights the Publishing tick EARLY — it is never required for the
+// card to reach the finished state.
+const WRITE_TOOLS = new Set(["canvas", "bash", "exec", "image"]);
+
+export const DASHBOARD_BUILD_PHASES = [
+	{ key: "understanding", label: "Understanding" },
+	{ key: "querying", label: "Querying data" },
+	{ key: "composing", label: "Composing" },
+	{ key: "publishing", label: "Publishing" },
+];
+
+function toolBaseName(name) {
+	return String(name || "").replace(/^jarvis__/, "");
+}
+
+/**
+ * The phase a dashboard-build turn is honestly in right now.
+ *
+ * Reads exactly the signals ChatView keeps for the generic activity line —
+ * `activeTools` ({name, status}[] from tool:start/tool:end), `statusPhase`
+ * ("analyzing" once a tool has finished and nothing else is running yet),
+ * and `waiting` (true until the first event of the turn lands). A mount that
+ * JOINS a turn already in flight (e.g. "Open in chat" clicked mid-stream)
+ * starts with `activeTools` empty and nothing yet says which phase the turn
+ * is in — that reports `null` rather than defaulting to "Understanding",
+ * because this mount has not actually observed the start.
+ *
+ * @param {{activeTools: Array<{name?: string, status?: string}>, statusPhase: string|null, waiting: boolean}} arg
+ * @returns {string|null} one of DASHBOARD_BUILD_PHASES' keys, or null
+ */
+export function dashboardBuildPhase({ activeTools, statusPhase, waiting }) {
+	const tools = Array.isArray(activeTools) ? activeTools : [];
+	const running = [...tools].reverse().find((t) => t && t.status === "running");
+	if (running) {
+		const base = toolBaseName(running.name);
+		if (WRITE_TOOLS.has(base)) return "publishing";
+		if (DATA_TOOLS.has(base)) return "querying";
+		// An unrecognised tool while the turn is a confirmed dashboard build is
+		// still real activity, just not one this map can name precisely —
+		// "Composing" is the safest of the four to sit on, never "done".
+		return "composing";
+	}
+	if (tools.length) {
+		const sawWrite = tools.some((t) => WRITE_TOOLS.has(toolBaseName(t && t.name)));
+		if (sawWrite) return "publishing";
+		return "composing"; // results are in (statusPhase "analyzing") or the reply is streaming
+	}
+	if (waiting) return "understanding";
+	return null;
+}
+
+/** Index into DASHBOARD_BUILD_PHASES for tick rendering; -1 when indeterminate. */
+export function phaseTickIndex(phase) {
+	return DASHBOARD_BUILD_PHASES.findIndex((p) => p.key === phase);
+}
+
+// ── the finished canvas -> a compact clickable thumbnail ────────────────────
+//
+// The builder's own canvas render component (DashboardCanvas.vue) is NOT
+// reused here: both its modes wire the live postMessage bridge
+// (callDashboardTool / runDashboardSource) so the document's queries
+// actually run, and dashboardOpen.js documents that main chat deliberately
+// never does that ("main chat's canvas has no query-tool bridge... that is
+// accepted"). Auto-rendering that bridge for every dashboard message in a
+// scrolled transcript would fire live queries per render. So the thumbnail
+// reuses the SAME static srcdoc main chat already fetches for the artifact
+// preview panel (`cvOf` / `api.getCanvas`), just scaled down.
+//
+// The canvas itself is a responsive document (no fixed design width), so
+// there is no "true" size to scale from. A fixed source viewport is assumed
+// — the same trick page-thumbnail UIs use — and CSS-scaled down to the
+// card's own width, which is why this needs to be a pure, testable function
+// rather than inline arithmetic in the template.
+
+export const DASH_THUMB_SOURCE_WIDTH = 640;
+export const DASH_THUMB_SOURCE_HEIGHT = 400;
+
+/**
+ * The iframe/container geometry for a scaled dashboard thumbnail of
+ * `containerWidthPx` wide. `scale` shrinks a `DASH_THUMB_SOURCE_WIDTH`-wide
+ * iframe to fit; `containerHeightPx` is what the caller sizes the
+ * (overflow: hidden) wrapper to, so the scaled content never bleeds out.
+ *
+ * @param {number} containerWidthPx
+ * @param {number} [sourceWidthPx]
+ * @param {number} [sourceHeightPx]
+ */
+export function dashboardThumbnailTransform(
+	containerWidthPx,
+	sourceWidthPx = DASH_THUMB_SOURCE_WIDTH,
+	sourceHeightPx = DASH_THUMB_SOURCE_HEIGHT
+) {
+	const w = Number(containerWidthPx) > 0 ? Number(containerWidthPx) : sourceWidthPx;
+	const scale = w / sourceWidthPx;
+	return {
+		sourceWidthPx,
+		sourceHeightPx,
+		scale,
+		containerHeightPx: Math.round(sourceHeightPx * scale),
+	};
+}

--- a/frontend/src/lib/dashboardBuildCard.test.js
+++ b/frontend/src/lib/dashboardBuildCard.test.js
@@ -1,0 +1,204 @@
+// "Building dashboard…" progress card + finished thumbnail (issue #858).
+// Plain node built-ins (node:test + node:assert), the dashboardOpen.test.js
+// convention: pure decisions live in dashboardBuildCard.js and are tested
+// behaviourally here; ChatView.vue's wiring is fenced with source
+// assertions because a .vue SFC cannot be imported into this runner.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	DASHBOARD_BUILD_PHASES,
+	DASH_THUMB_SOURCE_HEIGHT,
+	DASH_THUMB_SOURCE_WIDTH,
+	dashboardBuildPhase,
+	dashboardThumbnailTransform,
+	isDashboardBuildTurn,
+	phaseTickIndex,
+} from "./dashboardBuildCard.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+const fnBody = (src, decl) => {
+	const start = src.indexOf(decl);
+	assert.notEqual(start, -1, `source must still define ${decl}`);
+	const end = src.indexOf("\n}", start + decl.length);
+	assert.notEqual(end, -1, `${decl} must close at the top level`);
+	return src.slice(start, end);
+};
+
+// ---- turn gate: same origin binding as the finished artifact's promote button ----
+
+test("a turn only earns the card when the origin was read for THIS conversation", () => {
+	assert.equal(
+		isDashboardBuildTurn({ originPage: "dashboards", originOf: "c1", conversation: "c1" }),
+		true
+	);
+	// wrong page
+	assert.equal(
+		isDashboardBuildTurn({ originPage: "triggers", originOf: "c1", conversation: "c1" }),
+		false
+	);
+	assert.equal(
+		isDashboardBuildTurn({ originPage: "", originOf: "c1", conversation: "c1" }),
+		false
+	);
+	// origin read for a DIFFERENT conversation than the one on screen (a stale
+	// pair mid-switch) must not light the card up on the wrong thread
+	assert.equal(
+		isDashboardBuildTurn({ originPage: "dashboards", originOf: "c1", conversation: "c2" }),
+		false
+	);
+	// no conversation yet (e.g. boot)
+	assert.equal(
+		isDashboardBuildTurn({ originPage: "dashboards", originOf: "", conversation: "" }),
+		false
+	);
+});
+
+// ---- phase: derived from real events only, never a timer ----
+
+test("no activity yet, still waiting on the first event -> Understanding", () => {
+	assert.equal(
+		dashboardBuildPhase({ activeTools: [], statusPhase: null, waiting: true }),
+		"understanding"
+	);
+});
+
+test("a data tool running -> Querying data", () => {
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "jarvis__query", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"querying"
+	);
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "get_schema", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"querying"
+	);
+});
+
+test("a data tool finished, nothing else running yet -> Composing", () => {
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "query", status: "completed" }],
+			statusPhase: "analyzing",
+			waiting: false,
+		}),
+		"composing"
+	);
+});
+
+test("a write-ish tool running or already seen -> Publishing", () => {
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "canvas", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [
+				{ name: "query", status: "completed" },
+				{ name: "canvas", status: "completed" },
+			],
+			statusPhase: "analyzing",
+			waiting: false,
+		}),
+		"publishing"
+	);
+});
+
+test("joining a turn already in flight reports null, not a guess", () => {
+	// activeTools empty, not waiting either (this mount only just mounted and
+	// hasn't seen the run:start / tool:start that already happened elsewhere)
+	assert.equal(
+		dashboardBuildPhase({ activeTools: [], statusPhase: null, waiting: false }),
+		null
+	);
+});
+
+test("an unmapped tool name while a build is confirmed stays Composing, not done", () => {
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "run_method", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"composing"
+	);
+});
+
+test("phaseTickIndex orders the four phases and reports -1 for indeterminate", () => {
+	assert.equal(phaseTickIndex("understanding"), 0);
+	assert.equal(phaseTickIndex("querying"), 1);
+	assert.equal(phaseTickIndex("composing"), 2);
+	assert.equal(phaseTickIndex("publishing"), 3);
+	assert.equal(phaseTickIndex(null), -1);
+	assert.equal(DASHBOARD_BUILD_PHASES.length, 4);
+});
+
+// ---- the finished canvas -> a scaled thumbnail transform ----
+
+test("thumbnail geometry scales the fixed source viewport to the card width", () => {
+	const g = dashboardThumbnailTransform(220);
+	assert.equal(g.sourceWidthPx, DASH_THUMB_SOURCE_WIDTH);
+	assert.equal(g.sourceHeightPx, DASH_THUMB_SOURCE_HEIGHT);
+	assert.equal(g.scale, 220 / DASH_THUMB_SOURCE_WIDTH);
+	assert.equal(g.containerHeightPx, Math.round(DASH_THUMB_SOURCE_HEIGHT * g.scale));
+});
+
+test("a bogus container width falls back to scale 1 rather than NaN/Infinity", () => {
+	assert.equal(dashboardThumbnailTransform(0).scale, 1);
+	assert.equal(dashboardThumbnailTransform(-5).scale, 1);
+	assert.equal(dashboardThumbnailTransform(undefined).scale, 1);
+});
+
+test("a custom source viewport is honoured", () => {
+	const g = dashboardThumbnailTransform(300, 900, 500);
+	assert.equal(g.scale, 300 / 900);
+	assert.equal(g.containerHeightPx, Math.round(500 * (300 / 900)));
+});
+
+// ---- ChatView wiring: source-fenced, the same precedent as dashboardOpen.test.js ----
+
+test("ChatView imports the build-card helpers and gates the live card on the turn", () => {
+	assert.match(
+		chatSrc,
+		/import \{\s*DASHBOARD_BUILD_PHASES,\s*dashboardBuildPhase,\s*dashboardThumbnailTransform,\s*isDashboardBuildTurn,\s*phaseTickIndex,\s*\} from "@\/lib\/dashboardBuildCard";/
+	);
+	const gate = fnBody(chatSrc, "const dashboardBuildTurn = computed(");
+	assert.match(gate, /originPage: originPage\.value,/);
+	assert.match(gate, /originOf: originOf\.value,/);
+	assert.match(gate, /conversation: currentId\.value,/);
+	// the live card and the generic activity line are mutually exclusive —
+	// exactly one of them can render for a given turn
+	assert.match(
+		chatSrc,
+		/v-if="dashboardBuildTurn && \(activeTools\.length \|\| waiting\) && !queuedTurn"/
+	);
+	assert.match(
+		chatSrc,
+		/v-if="\s*\(activeTools\.length \|\| waiting\) && !queuedTurn && !dashboardBuildTurn\s*"/
+	);
+});
+
+test("the finished thumbnail reuses openInDashboards and the static cvOf srcdoc, never the live builder mode", () => {
+	assert.match(chatSrc, /v-else-if="canOpenDash\(cv\)"\s*\n\s*class="jv-dash-thumb"/);
+	assert.match(chatSrc, /@click="openInDashboards\(m, cv\)"/);
+	assert.match(chatSrc, /:srcdoc="cvOf\(m, cv\)"/);
+	// DashboardCanvas.vue (the builder's live-query render component) must not
+	// be pulled into ChatView — that would fire queries on every scrolled-past
+	// dashboard message, which the codebase's own accepted design forbids.
+	assert.doesNotMatch(chatSrc, /DashboardCanvas/);
+});

--- a/frontend/src/lib/dashboardBuildCard.test.js
+++ b/frontend/src/lib/dashboardBuildCard.test.js
@@ -202,3 +202,16 @@ test("the finished thumbnail reuses openInDashboards and the static cvOf srcdoc,
 	// dashboard message, which the codebase's own accepted design forbids.
 	assert.doesNotMatch(chatSrc, /DashboardCanvas/);
 });
+
+test("a theme toggle re-fetches every on-screen dashboard thumbnail, not just the artifact panel", () => {
+	// cvOf's cache key carries the dark flag (`${msg}::${cv}::${dark}`), and the
+	// thumbnail is the first PASSIVE reader of it in the message list — nothing
+	// else re-triggers ensureCanvas for it on a theme flip, so without this the
+	// card would strand on its loading shimmer until an unrelated resync.
+	const w = chatSrc.slice(chatSrc.indexOf("watch(effectiveDark, () => {"));
+	const body = w.slice(0, w.indexOf("\n});") + 4);
+	assert.notEqual(chatSrc.indexOf("watch(effectiveDark, () => {"), -1);
+	assert.match(body, /for \(const m of messages\.value\) \{/);
+	assert.match(body, /m\.canvas\.some\(\(cv\) => canOpenDash\(cv\)\)/);
+	assert.match(body, /ensureCanvas\(m\)/);
+});

--- a/frontend/src/lib/dashboardBuildCard.test.js
+++ b/frontend/src/lib/dashboardBuildCard.test.js
@@ -15,6 +15,7 @@ import {
 	dashboardBuildPhase,
 	dashboardThumbnailTransform,
 	isDashboardBuildTurn,
+	isDashboardCanvas,
 	phaseTickIndex,
 } from "./dashboardBuildCard.js";
 
@@ -148,6 +149,25 @@ test("phaseTickIndex orders the four phases and reports -1 for indeterminate", (
 	assert.equal(DASHBOARD_BUILD_PHASES.length, 4);
 });
 
+// ---- the finished canvas: dashboard identity by content, not conversation ----
+
+test("a hosted-embed canvas item is a dashboard regardless of which conversation produced it", () => {
+	assert.equal(isDashboardCanvas({ type: "html", name: "documents/abc123/index.html" }), true);
+	// the dashboards skill is the only skill catalog-wide that uses the
+	// hosted-embed marker (documents/<id>/index.html) — a plain canvas file
+	// reference from any other skill never carries that prefix
+	assert.equal(isDashboardCanvas({ type: "html", name: "charts/sales.html" }), false);
+	assert.equal(isDashboardCanvas({ type: "html", name: "documents/abc/index.html" }), true);
+	// wrong type: an svg/pdf/image/file under the same path is not a dashboard
+	assert.equal(isDashboardCanvas({ type: "svg", name: "documents/abc/index.html" }), false);
+	assert.equal(isDashboardCanvas({ type: "image", name: "documents/abc/index.html" }), false);
+	// absent/malformed input never throws
+	assert.equal(isDashboardCanvas(null), false);
+	assert.equal(isDashboardCanvas(undefined), false);
+	assert.equal(isDashboardCanvas({ type: "html" }), false);
+	assert.equal(isDashboardCanvas({ type: "html", name: 42 }), false);
+});
+
 // ---- the finished canvas -> a scaled thumbnail transform ----
 
 test("thumbnail geometry scales the fixed source viewport to the card width", () => {
@@ -175,14 +195,17 @@ test("a custom source viewport is honoured", () => {
 test("ChatView imports the build-card helpers and gates the live card on the turn", () => {
 	assert.match(
 		chatSrc,
-		/import \{\s*DASHBOARD_BUILD_PHASES,\s*dashboardBuildPhase,\s*dashboardThumbnailTransform,\s*isDashboardBuildTurn,\s*phaseTickIndex,\s*\} from "@\/lib\/dashboardBuildCard";/
+		/import \{\s*DASHBOARD_BUILD_PHASES,\s*dashboardBuildPhase,\s*dashboardThumbnailTransform,\s*isDashboardBuildTurn,\s*isDashboardCanvas,\s*phaseTickIndex,\s*\} from "@\/lib\/dashboardBuildCard";/
 	);
 	const gate = fnBody(chatSrc, "const dashboardBuildTurn = computed(");
 	assert.match(gate, /originPage: originPage\.value,/);
 	assert.match(gate, /originOf: originOf\.value,/);
 	assert.match(gate, /conversation: currentId\.value,/);
 	// the live card and the generic activity line are mutually exclusive —
-	// exactly one of them can render for a given turn
+	// exactly one of them can render for a given turn. The live card stays
+	// origin-only: a main-chat build has no pre-canvas signal to key on (see
+	// dashboardBuildCard.js's file header), so it degrades to no card rather
+	// than guessing.
 	assert.match(
 		chatSrc,
 		/v-if="dashboardBuildTurn && \(activeTools\.length \|\| waiting\) && !queuedTurn"/
@@ -193,25 +216,37 @@ test("ChatView imports the build-card helpers and gates the live card on the tur
 	);
 });
 
+test("canPromoteDashCanvas combines the builder-origin rule with canvas-presence, and the click-through gates on it too", () => {
+	const combo = fnBody(chatSrc, "function canPromoteDashCanvas(cv) {");
+	assert.match(combo, /canOpenDash\(cv\) \|\| isDashboardCanvas\(cv\)/);
+	// openInDashboards must guard on the COMBINED gate — otherwise a click on
+	// a canvas-presence-only thumbnail (no builder origin) would silently no-op
+	const open = fnBody(chatSrc, "async function openInDashboards(m, cv) {");
+	assert.match(open, /if \(!conv \|\| !canPromoteDashCanvas\(cv\)\) return;/);
+});
+
 test("the finished thumbnail reuses openInDashboards and the static cvOf srcdoc, never the live builder mode", () => {
-	assert.match(chatSrc, /v-else-if="canOpenDash\(cv\)"\s*\n\s*class="jv-dash-thumb"/);
+	assert.match(chatSrc, /v-else-if="canPromoteDashCanvas\(cv\)"\s*\n\s*class="jv-dash-thumb"/);
 	assert.match(chatSrc, /@click="openInDashboards\(m, cv\)"/);
 	assert.match(chatSrc, /:srcdoc="cvOf\(m, cv\)"/);
 	// DashboardCanvas.vue (the builder's live-query render component) must not
 	// be pulled into ChatView — that would fire queries on every scrolled-past
 	// dashboard message, which the codebase's own accepted design forbids.
-	assert.doesNotMatch(chatSrc, /DashboardCanvas/);
+	// (word-boundary: must not catch our OWN isDashboardCanvas/canPromoteDashCanvas)
+	assert.doesNotMatch(chatSrc, /\bDashboardCanvas\.vue\b|<DashboardCanvas\b/);
 });
 
 test("a theme toggle re-fetches every on-screen dashboard thumbnail, not just the artifact panel", () => {
 	// cvOf's cache key carries the dark flag (`${msg}::${cv}::${dark}`), and the
 	// thumbnail is the first PASSIVE reader of it in the message list — nothing
 	// else re-triggers ensureCanvas for it on a theme flip, so without this the
-	// card would strand on its loading shimmer until an unrelated resync.
+	// card would strand on its loading shimmer until an unrelated resync. Must
+	// cover BOTH gates (builder-origin and canvas-presence), or a main-chat
+	// build's thumbnail would strand while a builder-origin one self-heals.
 	const w = chatSrc.slice(chatSrc.indexOf("watch(effectiveDark, () => {"));
 	const body = w.slice(0, w.indexOf("\n});") + 4);
 	assert.notEqual(chatSrc.indexOf("watch(effectiveDark, () => {"), -1);
 	assert.match(body, /for \(const m of messages\.value\) \{/);
-	assert.match(body, /m\.canvas\.some\(\(cv\) => canOpenDash\(cv\)\)/);
+	assert.match(body, /m\.canvas\.some\(\(cv\) => canPromoteDashCanvas\(cv\)\)/);
 	assert.match(body, /ensureCanvas\(m\)/);
 });

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -638,23 +638,27 @@ test("the open artifact carries the conversation it was opened from", () => {
 	assert.match(chatSrc, /artifact\.value = \{ \.\.\.artifact\.value, sheetIdx: si \};/);
 });
 
-test("the inline card offers it as a SIBLING button, never nested in the card", () => {
-	// .jv-artifact is itself a <button>; a button inside a button is invalid
-	// HTML and browsers drop it out of the card entirely.
+test("a dashboard build gets its OWN thumbnail card, not the generic file card", () => {
+	// canOpenDash(cv) now branches BEFORE the generic ".jv-artifact-group" card
+	// (issue #858's compact preview thumbnail), so a dashboard canvas never
+	// reaches the generic card at all — dashboardBuildCard.test.js fences the
+	// thumbnail's own markup (jv-dash-thumb, cvOf srcdoc, openInDashboards).
+	// This test only pins the ORDER and the exclusivity: the generic card's
+	// v-else must come after the dashboard branch, so every other canvas type
+	// is untouched.
+	assert.match(chatSrc, /v-else-if="canOpenDash\(cv\)"\s*\n\s*class="jv-dash-thumb"/);
 	assert.match(chatSrc, /<div v-else class="jv-artifact-group">/);
+	assert.ok(
+		chatSrc.indexOf('v-else-if="canOpenDash(cv)"') <
+			chatSrc.indexOf('<div v-else class="jv-artifact-group">'),
+		"the dashboard thumbnail must be offered before the generic file card falls through to it"
+	);
+	// the generic card itself no longer carries a canOpenDash branch of its own
 	const group = chatSrc.slice(
 		chatSrc.indexOf('<div v-else class="jv-artifact-group">'),
 		chatSrc.indexOf("</template>", chatSrc.indexOf('<div v-else class="jv-artifact-group">'))
 	);
-	assert.match(group, /class="jv-artifact"/);
-	assert.match(group, /v-if="canOpenDash\(cv\)"/);
-	assert.match(group, /@click="openInDashboards\(m, cv\)"/);
-	assert.match(group, /Open in Dashboards/);
-	// the button closes the card's <button> first
-	assert.ok(
-		group.indexOf("</button>") < group.indexOf('v-if="canOpenDash(cv)"'),
-		"the affordance must follow the card, not live inside it"
-	);
+	assert.doesNotMatch(group, /canOpenDash/);
 });
 
 test("the open preview panel offers the same hand-off, for its OWN conversation", () => {

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -639,17 +639,19 @@ test("the open artifact carries the conversation it was opened from", () => {
 });
 
 test("a dashboard build gets its OWN thumbnail card, not the generic file card", () => {
-	// canOpenDash(cv) now branches BEFORE the generic ".jv-artifact-group" card
-	// (issue #858's compact preview thumbnail), so a dashboard canvas never
-	// reaches the generic card at all — dashboardBuildCard.test.js fences the
-	// thumbnail's own markup (jv-dash-thumb, cvOf srcdoc, openInDashboards).
-	// This test only pins the ORDER and the exclusivity: the generic card's
-	// v-else must come after the dashboard branch, so every other canvas type
-	// is untouched.
-	assert.match(chatSrc, /v-else-if="canOpenDash\(cv\)"\s*\n\s*class="jv-dash-thumb"/);
+	// canPromoteDashCanvas(cv) (canOpenDash's builder-origin rule OR
+	// isDashboardCanvas's hosted-embed-marker signal) branches BEFORE the
+	// generic ".jv-artifact-group" card (issue #858's compact preview
+	// thumbnail), so a dashboard canvas never reaches the generic card at
+	// all — dashboardBuildCard.test.js fences the thumbnail's own markup
+	// (jv-dash-thumb, cvOf srcdoc, openInDashboards) and the combined gate
+	// itself. This test only pins the ORDER and the exclusivity: the generic
+	// card's v-else must come after the dashboard branch, so every other
+	// canvas type is untouched.
+	assert.match(chatSrc, /v-else-if="canPromoteDashCanvas\(cv\)"\s*\n\s*class="jv-dash-thumb"/);
 	assert.match(chatSrc, /<div v-else class="jv-artifact-group">/);
 	assert.ok(
-		chatSrc.indexOf('v-else-if="canOpenDash(cv)"') <
+		chatSrc.indexOf('v-else-if="canPromoteDashCanvas(cv)"') <
 			chatSrc.indexOf('<div v-else class="jv-artifact-group">'),
 		"the dashboard thumbnail must be offered before the generic file card falls through to it"
 	);

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1506,13 +1506,16 @@
 									<!-- a Dashboards build: a compact scaled preview of the
 									     canvas itself, its name, and the way through to the
 									     builder where it runs with data — the whole card
-									     clicks through (issue #858). The preview reuses the
-									     SAME static srcdoc main chat already fetches for the
-									     artifact panel (cvOf/ensureCanvas below); never the
-									     builder's own live-query render mode, which would
-									     fire queries on every scrolled-past message. -->
+									     clicks through (issue #858). Gated on canPromoteDashCanvas,
+									     not just builder origin: persist_canvases runs for every
+									     conversation, and the dashboards skill can build from
+									     ordinary main chat too — see the note above canOpenDash.
+									     The preview reuses the SAME static srcdoc main chat
+									     already fetches for the artifact panel (cvOf/ensureCanvas
+									     below); never the builder's own live-query render mode,
+									     which would fire queries on every scrolled-past message. -->
 									<button
-										v-else-if="canOpenDash(cv)"
+										v-else-if="canPromoteDashCanvas(cv)"
 										class="jv-dash-thumb"
 										@click="openInDashboards(m, cv)"
 										:title="
@@ -3974,6 +3977,7 @@ import {
 	dashboardBuildPhase,
 	dashboardThumbnailTransform,
 	isDashboardBuildTurn,
+	isDashboardCanvas,
 	phaseTickIndex,
 } from "@/lib/dashboardBuildCard";
 import { pickGreeting } from "@/lib/greeting";
@@ -7167,6 +7171,17 @@ function canOpenDash(cv) {
 		cv,
 	});
 }
+// Origin alone misses a real case: jarvis/chat/canvas.py's persist_canvases
+// runs unconditionally at the end of every turn (no origin check), and the
+// jarvis-persona dashboards skill is discoverable by ordinary description
+// match in ANY chat, not only a builder-page conversation (jarvis#858
+// review). So the thumbnail/click-through gate on BOTH signals: the
+// existing builder-origin rule above, OR the canvas itself carrying the
+// dashboards skill's own hosted-embed marker regardless of which
+// conversation produced it (isDashboardCanvas, dashboardBuildCard.js).
+function canPromoteDashCanvas(cv) {
+	return canOpenDash(cv) || isDashboardCanvas(cv);
+}
 // ---- "Building dashboard…" live card (issue #858) — a dashboard build
 // watched from main chat, same origin binding as canOpenDash above but
 // evaluated before any canvas exists yet (the turn is still running). Phase
@@ -7200,12 +7215,13 @@ const dashboardThumbGeom = computed(() => dashboardThumbnailTransform(220));
 // call ensureCanvas again.
 watch(effectiveDark, () => {
 	for (const m of messages.value) {
-		if (Array.isArray(m.canvas) && m.canvas.some((cv) => canOpenDash(cv))) ensureCanvas(m);
+		if (Array.isArray(m.canvas) && m.canvas.some((cv) => canPromoteDashCanvas(cv)))
+			ensureCanvas(m);
 	}
 });
 async function openInDashboards(m, cv) {
 	const conv = currentId.value;
-	if (!conv || !canOpenDash(cv)) return;
+	if (!conv || !canPromoteDashCanvas(cv)) return;
 	let dashboard = null;
 	try {
 		dashboard = await dashboardForConversation(conv);

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7190,6 +7190,19 @@ const dashboardBuildTickIndex = computed(() => phaseTickIndex(dashboardBuildPhas
 // Scaled-preview geometry for the finished-canvas thumbnail card (below);
 // fixed source viewport since the canvas itself has no set design width.
 const dashboardThumbGeom = computed(() => dashboardThumbnailTransform(220));
+// cvOf's cache key carries the theme (canvasContent is keyed by
+// `${msg}::${cv}::${dark}` — the backend themes the srcdoc shell), and the
+// thumbnail above is the first place that reads it PASSIVELY: every other
+// reader (openArtifact) re-fetches itself on a cache miss because a click
+// triggered it. A theme toggle alone would otherwise strand every dashboard
+// thumbnail already on screen on its loading shimmer until an unrelated
+// resync (tab focus, socket reconnect, conversation switch) happened to
+// call ensureCanvas again.
+watch(effectiveDark, () => {
+	for (const m of messages.value) {
+		if (Array.isArray(m.canvas) && m.canvas.some((cv) => canOpenDash(cv))) ensureCanvas(m);
+	}
+});
 async function openInDashboards(m, cv) {
 	const conv = currentId.value;
 	if (!conv || !canOpenDash(cv)) return;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1503,6 +1503,69 @@
 											>{{ cv.title }}</span
 										>
 									</button>
+									<!-- a Dashboards build: a compact scaled preview of the
+									     canvas itself, its name, and the way through to the
+									     builder where it runs with data — the whole card
+									     clicks through (issue #858). The preview reuses the
+									     SAME static srcdoc main chat already fetches for the
+									     artifact panel (cvOf/ensureCanvas below); never the
+									     builder's own live-query render mode, which would
+									     fire queries on every scrolled-past message. -->
+									<button
+										v-else-if="canOpenDash(cv)"
+										class="jv-dash-thumb"
+										@click="openInDashboards(m, cv)"
+										:title="
+											'Open ' + cv.title + ' in Dashboards, with its data'
+										"
+									>
+										<span
+											class="jv-dash-thumb-preview"
+											:style="{
+												height:
+													dashboardThumbGeom.containerHeightPx + 'px',
+											}"
+										>
+											<iframe
+												v-if="cvOf(m, cv)"
+												:srcdoc="cvOf(m, cv)"
+												sandbox="allow-scripts"
+												tabindex="-1"
+												aria-hidden="true"
+												class="jv-dash-thumb-frame"
+												:style="{
+													width: dashboardThumbGeom.sourceWidthPx + 'px',
+													height:
+														dashboardThumbGeom.sourceHeightPx + 'px',
+													transform:
+														'scale(' + dashboardThumbGeom.scale + ')',
+												}"
+											/>
+											<span
+												v-else
+												class="jv-dash-thumb-loading"
+												aria-hidden="true"
+											></span>
+										</span>
+										<span class="jv-dash-thumb-meta">
+											<span class="jv-dash-thumb-title">{{ cv.title }}</span>
+											<span class="jv-dash-thumb-open">
+												<svg
+													width="13"
+													height="13"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="1.9"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												>
+													<path d="M18 20V10M12 20V4M6 20v-6" />
+												</svg>
+												Open in Dashboards
+											</span>
+										</span>
+									</button>
 									<!-- everything else → the file card -->
 									<div v-else class="jv-artifact-group">
 										<button
@@ -1549,29 +1612,6 @@
 											>
 												<path d="M9 18l6-6-6-6" />
 											</svg>
-										</button>
-										<!-- a Dashboards build opened in main chat: the card
-										     above previews the document but never runs its
-										     queries — the builder does -->
-										<button
-											v-if="canOpenDash(cv)"
-											class="jv-artifact-open"
-											@click="openInDashboards(m, cv)"
-											title="Open this dashboard in Dashboards, with its data"
-										>
-											<svg
-												width="13"
-												height="13"
-												viewBox="0 0 24 24"
-												fill="none"
-												stroke="currentColor"
-												stroke-width="1.9"
-												stroke-linecap="round"
-												stroke-linejoin="round"
-											>
-												<path d="M18 20V10M12 20V4M6 20v-6" />
-											</svg>
-											Open in Dashboards
 										</button>
 									</div>
 								</template>
@@ -1720,13 +1760,63 @@
 						</Message>
 					</template>
 
+					<!-- dashboard build: a real progress card keyed to actual tool
+					     activity, never a timer (issue #858). Same turn gate as the
+					     generic activity line below (queued chip wins over both);
+					     mutually exclusive with it so only one ever shows. Phases
+					     light up from real events only — a mount that joined the
+					     turn already in flight (no activeTools seen yet) shows the
+					     honest indeterminate header with no tick lit, rather than
+					     guessing "Understanding". -->
+					<div
+						v-if="dashboardBuildTurn && (activeTools.length || waiting) && !queuedTurn"
+						class="jv-dashbuild"
+						style="display: flex; gap: 12px"
+					>
+						<JarvisMark
+							:size="28"
+							:radius="7"
+							mood="thinking"
+							style="margin-top: 2px"
+						/>
+						<div style="flex: 1; min-width: 0; padding-top: 3px">
+							<div class="jv-dashbuild-card" role="status" aria-live="polite">
+								<span class="jv-dashbuild-head">
+									<span class="jv-live-shim">Building dashboard…</span>
+								</span>
+								<ol class="jv-dashbuild-steps">
+									<li
+										v-for="(step, si) in DASHBOARD_BUILD_PHASES"
+										:key="step.key"
+										class="jv-dashbuild-step"
+										:class="{
+											done:
+												dashboardBuildTickIndex >= 0 &&
+												si < dashboardBuildTickIndex,
+											current: si === dashboardBuildTickIndex,
+										}"
+									>
+										<span class="jv-dashbuild-tick" aria-hidden="true"></span>
+										{{ step.label }}
+									</li>
+								</ol>
+								<div class="jv-dashbuild-skel" aria-hidden="true">
+									<span class="jv-dashbuild-skel-row"></span>
+									<span class="jv-dashbuild-skel-row"></span>
+									<span class="jv-dashbuild-skel-row short"></span>
+								</div>
+							</div>
+						</div>
+					</div>
 					<!-- live tool activity + thinking (Claude Code style). Suppressed
 					     while a queued chip is showing (F2): whenever the accept says
 					     the turn is queued, the "Queued — ~N ahead" chip WINS over this
 					     "Working on it…" / warming placeholder — never both, and never a
 					     stray warming spinner masking the chip. -->
 					<div
-						v-if="(activeTools.length || waiting) && !queuedTurn"
+						v-if="
+							(activeTools.length || waiting) && !queuedTurn && !dashboardBuildTurn
+						"
 						style="display: flex; gap: 12px"
 					>
 						<JarvisMark
@@ -3879,6 +3969,13 @@ import { createRevealer } from "@/lib/streamReveal";
 import { sortPendingCards } from "@/lib/sortPendingCards";
 import { errMessage, turnErrorInfo } from "@/lib/errors";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
+import {
+	DASHBOARD_BUILD_PHASES,
+	dashboardBuildPhase,
+	dashboardThumbnailTransform,
+	isDashboardBuildTurn,
+	phaseTickIndex,
+} from "@/lib/dashboardBuildCard";
 import { pickGreeting } from "@/lib/greeting";
 import { dashboardForConversation } from "@/api/dashboards";
 import {
@@ -7070,6 +7167,29 @@ function canOpenDash(cv) {
 		cv,
 	});
 }
+// ---- "Building dashboard…" live card (issue #858) — a dashboard build
+// watched from main chat, same origin binding as canOpenDash above but
+// evaluated before any canvas exists yet (the turn is still running). Phase
+// comes from the SAME real tool-activity signals the generic "Working on
+// it…" line already keeps (activeTools/statusPhase/waiting) — never a timer.
+const dashboardBuildTurn = computed(() =>
+	isDashboardBuildTurn({
+		originPage: originPage.value,
+		originOf: originOf.value,
+		conversation: currentId.value,
+	})
+);
+const dashboardBuildPhaseKey = computed(() =>
+	dashboardBuildPhase({
+		activeTools: activeTools.value,
+		statusPhase: statusPhase.value,
+		waiting: waiting.value,
+	})
+);
+const dashboardBuildTickIndex = computed(() => phaseTickIndex(dashboardBuildPhaseKey.value));
+// Scaled-preview geometry for the finished-canvas thumbnail card (below);
+// fixed source viewport since the canvas itself has no set design width.
+const dashboardThumbGeom = computed(() => dashboardThumbnailTransform(220));
 async function openInDashboards(m, cv) {
 	const conv = currentId.value;
 	if (!conv || !canOpenDash(cv)) return;
@@ -10886,6 +11006,11 @@ onUnmounted(() => {
 	.jv-mic-dot {
 		animation: none;
 	}
+	.jv-dashbuild-tick,
+	.jv-dashbuild-skel-row,
+	.jv-dash-thumb-loading {
+		animation: none;
+	}
 	.jv-settings,
 	.jv-skills-modal {
 		animation: none;
@@ -12402,6 +12527,158 @@ onUnmounted(() => {
 	border-color: var(--border-2);
 	background: var(--surface-2);
 	color: var(--text);
+}
+
+/* dashboard-build finished thumbnail (issue #858): whole card clicks through
+   to the builder, so — unlike .jv-artifact — there is no separate follow-on
+   button. */
+.jv-dash-thumb {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	max-width: 220px;
+	margin-top: 12px;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	background: var(--surface);
+	cursor: pointer;
+	text-align: left;
+	font-family: inherit;
+	overflow: hidden;
+	transition: border-color 0.12s, background 0.12s;
+}
+.jv-dash-thumb:hover {
+	border-color: var(--border-2);
+	background: var(--surface-1);
+}
+.jv-dash-thumb-preview {
+	position: relative;
+	width: 100%;
+	overflow: hidden;
+	background: var(--surface-1);
+	border-bottom: 1px solid var(--border);
+}
+.jv-dash-thumb-frame {
+	border: 0;
+	transform-origin: top left;
+	pointer-events: none;
+}
+.jv-dash-thumb-loading {
+	display: block;
+	width: 100%;
+	height: 100%;
+	background: linear-gradient(
+		90deg,
+		var(--surface-1) 25%,
+		var(--surface-2) 37%,
+		var(--surface-1) 63%
+	);
+	background-size: 400% 100%;
+	animation: jv-dashbuild-shimmer 1.6s ease infinite;
+}
+.jv-dash-thumb-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 9px 12px 10px;
+}
+.jv-dash-thumb-title {
+	font-size: 13px;
+	font-weight: 550;
+	color: var(--text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.jv-dash-thumb-open {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	font-weight: 550;
+	color: var(--cta);
+}
+
+/* dashboard-build live progress card (issue #858) */
+.jv-dashbuild-card {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-width: 260px;
+	padding: 10px 12px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	background: var(--surface);
+}
+.jv-dashbuild-head {
+	font-size: 12px;
+}
+.jv-dashbuild-steps {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+.jv-dashbuild-step {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 11.5px;
+	color: var(--text-3);
+}
+.jv-dashbuild-step.done,
+.jv-dashbuild-step.current {
+	color: var(--text-2);
+}
+.jv-dashbuild-step.current {
+	color: var(--text);
+	font-weight: 550;
+}
+.jv-dashbuild-tick {
+	flex: none;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--border-2);
+}
+.jv-dashbuild-step.done .jv-dashbuild-tick {
+	background: var(--green);
+}
+.jv-dashbuild-step.current .jv-dashbuild-tick {
+	background: var(--cta);
+	animation: jv-live-shim 1.8s ease-in-out infinite;
+}
+.jv-dashbuild-skel {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.jv-dashbuild-skel-row {
+	display: block;
+	height: 8px;
+	border-radius: 4px;
+	background: linear-gradient(
+		90deg,
+		var(--surface-1) 25%,
+		var(--surface-2) 37%,
+		var(--surface-1) 63%
+	);
+	background-size: 400% 100%;
+	animation: jv-dashbuild-shimmer 1.6s ease infinite;
+}
+.jv-dashbuild-skel-row.short {
+	width: 60%;
+}
+@keyframes jv-dashbuild-shimmer {
+	0% {
+		background-position: 100% 50%;
+	}
+	100% {
+		background-position: 0 50%;
+	}
 }
 
 /* confirm / cancel card for a pending ERP-mutating action */


### PR DESCRIPTION
## Summary

Main chat now shows a real "Building dashboard..." progress card while the agent builds a Jarvis Dashboard, and the finished canvas renders as a compact clickable thumbnail whose whole card opens the Dashboards builder with that canvas loaded.

Two new pure functions in `frontend/src/lib/dashboardBuildCard.js` (unit tested) decide the turn gate, the phase from real tool events, and the thumbnail scale; `ChatView.vue` wires them in without touching backend files. Both pieces are mutually exclusive with their existing generic counterparts (the "Working on it..." line, the generic file card), so no other flow changes.

The embed-marker assumption held, contrary to my first pass below; the deep-link assumption held outright; the render-component assumption did not hold. Details below, including a correction made after the first review round.

<details>
<summary>Investigation findings (with a correction)</summary>

1. **Corrected.** The `[embed ref="<document-id>" title="..." /]` marker is real and handled: `jarvis/chat/canvas.py:70-71,74-75,197-251` (`_EMBED_REF`, `_embed_ref_name`, `persist_canvases`). My first pass missed it (grepped only the file's first ~50 lines and a literal substring that did not match the regex) and concluded main chat could never originate a build. That was wrong in an important way: `persist_canvases` runs unconditionally at the end of **every** turn in **every** conversation (`jarvis/chat/turn_handler.py:106-127`, no origin check), and the `jarvis-persona` skill that produces a dashboard build (`skills/jarvis-dashboards/SKILL.md`) is discoverable by ordinary description match in any chat, independent of the builder-only `context.page === "dashboards"` prompt gate (`turn_handler.py:1617`, sent only by `frontend/src/api/dashboards.js:99`). Open persona PR #192 ships a main-chat first-cut build using this exact path. So the thumbnail and its click-through now gate on canvas presence (`isDashboardCanvas`, keyed on the hosted-embed `documents/` name prefix that only the dashboards skill emits) OR the pre-existing builder-origin rule, not origin alone. The live progress card stays origin-only: a main-chat build has no honest pre-canvas signal to key on, so it shows no card and the thumbnail simply appears when the canvas lands, rather than guessing a phase it never observed.
2. `dashboardOpenRoute` is reused unchanged for the thumbnail's click-through, exactly as assumed.
3. `DashboardCanvas.vue` wires the live query bridge (`callDashboardTool`/`runDashboardSource`) in both its modes, which `dashboardOpen.js` documents main chat deliberately never runs. Reusing it for an auto-rendered thumbnail would fire live queries per rendered message, so the thumbnail instead reuses the same static `cvOf`/`ensureCanvas` srcdoc main chat already fetches for the artifact preview panel, scaled down via CSS transform.

Piece A's phases come from the same live signals `ChatView.vue` already keeps for its generic activity line (`activeTools`, `statusPhase`, `waiting` from `tool:start`/`tool:end`), never a timer. A turn joined already in flight (no `activeTools` seen yet) reports no phase rather than guessing "Understanding." `activeTools` is never backfilled from history, confirmed at `ChatView.vue:5430-5435`.

Known limit, now narrower than the first pass: the live progress card still gates on conversation origin only, so a plain message typed into main chat's own composer on a builder-origin conversation also shows "Building dashboard..." even though that specific turn never triggers the dashboards skill. It resolves cleanly with no canvas once the turn ends.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on FAIL)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests (`frontend/src/lib/dashboardBuildCard.test.js`, `dashboardOpen.test.js` updated)
- [x] I self-reviewed the diff
