### PR TITLE
fix(theme): toggle always flips the visible theme in one click

### DIFF
--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -131,10 +131,21 @@ function setTheme(t) {
 		.catch(() => {});
 }
 // Cycle light → dark → system → light so "follow system" stays reachable
-// (the Appearance pane that offered it was removed).
+// (the Appearance pane that offered it was removed). A step that would not
+// change the EFFECTIVE appearance is skipped: with a dark OS, dark → system
+// renders identically, so that click would look dead and reaching light would
+// take two clicks. Skipping keeps the invariant that every click visibly
+// flips the theme. Exported pure so theme.test.js can pin the invariant.
 const _THEME_CYCLE = { light: "dark", dark: "system", system: "light" };
+export function nextTheme(current, prefersDark) {
+	let next = _THEME_CYCLE[current] || "dark";
+	if (isDark(next, prefersDark) === isDark(current, prefersDark)) {
+		next = _THEME_CYCLE[next];
+	}
+	return next;
+}
 function toggleTheme() {
-	setTheme(_THEME_CYCLE[theme.value] || "dark");
+	setTheme(nextTheme(theme.value, prefersDark.value));
 }
 
 export function useJarvisTheme() {

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -130,19 +130,18 @@ function setTheme(t) {
 		.then(({ setUserTheme }) => setUserTheme(t))
 		.catch(() => {});
 }
-// Cycle light → dark → system → light so "follow system" stays reachable
-// (the Appearance pane that offered it was removed). A step that would not
-// change the EFFECTIVE appearance is skipped: with a dark OS, dark → system
-// renders identically, so that click would look dead and reaching light would
-// take two clicks. Skipping keeps the invariant that every click visibly
-// flips the theme. Exported pure so theme.test.js can pin the invariant.
-const _THEME_CYCLE = { light: "dark", dark: "system", system: "light" };
+// The toggle is a strict two-state flip of the EFFECTIVE appearance. It used
+// to cycle light → dark → system, but with a dark OS the dark → system step
+// rendered identically, so that click looked dead and reaching light took two
+// clicks. "system" also was not truly kept reachable by the cycle (the skip
+// that fixed the dead click made it unreachable on a dark OS anyway, and no
+// other UI offers it since the Appearance pane was removed), so the cycle was
+// dropped rather than half-kept: "system" remains the default for users who
+// never touch the toggle, and a deliberate three-way choice belongs in a
+// Settings picker if it ever comes back. Exported pure so theme.test.js can
+// pin the every-click-flips invariant.
 export function nextTheme(current, prefersDark) {
-	let next = _THEME_CYCLE[current] || "dark";
-	if (isDark(next, prefersDark) === isDark(current, prefersDark)) {
-		next = _THEME_CYCLE[next];
-	}
-	return next;
+	return isDark(current, prefersDark) ? "light" : "dark";
 }
 function toggleTheme() {
 	setTheme(nextTheme(theme.value, prefersDark.value));

--- a/frontend/src/theme.test.js
+++ b/frontend/src/theme.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { LIGHT_VARS, DARK_VARS, isDark } from "./theme.js";
+import { LIGHT_VARS, DARK_VARS, isDark, nextTheme } from "./theme.js";
 
 test("palettes expose the core vars used across views", () => {
 	for (const v of ["--surface", "--border", "--text", "--cta", "--red", "--green", "--amber"])
@@ -11,4 +11,28 @@ test("isDark: explicit wins, system follows OS", () => {
 	assert.equal(isDark("light", true), false);
 	assert.equal(isDark("system", true), true);
 	assert.equal(isDark("system", false), false);
+});
+
+test("nextTheme: every click flips the effective appearance", () => {
+	for (const prefersDark of [true, false]) {
+		for (const cur of ["light", "dark", "system"]) {
+			const next = nextTheme(cur, prefersDark);
+			assert.notEqual(
+				isDark(next, prefersDark),
+				isDark(cur, prefersDark),
+				`${cur} (OS ${prefersDark ? "dark" : "light"}) -> ${next} must flip`
+			);
+		}
+	}
+});
+test("nextTheme: skips the no-op step, keeps system reachable", () => {
+	// dark OS: dark -> system would render identically, so it skips to light
+	assert.equal(nextTheme("dark", true), "light");
+	assert.equal(nextTheme("light", true), "dark");
+	assert.equal(nextTheme("system", true), "light");
+	// light OS: dark -> system is a visible change (system renders light)
+	assert.equal(nextTheme("dark", false), "system");
+	assert.equal(nextTheme("light", false), "dark");
+	// light OS: system -> light would render identically, so it skips to dark
+	assert.equal(nextTheme("system", false), "dark");
 });

--- a/frontend/src/theme.test.js
+++ b/frontend/src/theme.test.js
@@ -25,14 +25,12 @@ test("nextTheme: every click flips the effective appearance", () => {
 		}
 	}
 });
-test("nextTheme: skips the no-op step, keeps system reachable", () => {
-	// dark OS: dark -> system would render identically, so it skips to light
+test("nextTheme: strict two-state flip of the effective appearance", () => {
 	assert.equal(nextTheme("dark", true), "light");
 	assert.equal(nextTheme("light", true), "dark");
+	// "system" leaves via whichever side it currently renders as
 	assert.equal(nextTheme("system", true), "light");
-	// light OS: dark -> system is a visible change (system renders light)
-	assert.equal(nextTheme("dark", false), "system");
+	assert.equal(nextTheme("dark", false), "light");
 	assert.equal(nextTheme("light", false), "dark");
-	// light OS: system -> light would render identically, so it skips to dark
 	assert.equal(nextTheme("system", false), "dark");
 });


### PR DESCRIPTION
## Summary

Fixes the theme toggle needing two clicks to get from dark back to light when the OS is in dark mode. The toggle cycled light, dark, system; from dark, the first click landed on "system", which renders dark too, so it looked like a dead click. The toggle is now a strict two-state flip of the visible appearance, so every click switches the theme. "System" stays the default for users who never touch the toggle; the cycle was not truly keeping it reachable anyway (on a dark OS it was skipped or dead), and no other UI offers it. The decision is a pure exported helper, `nextTheme`, pinned by node:test cases covering all six state and OS combinations.

No visual change to any screen, so no before/after screenshots; the behavior is pinned by the new tests ("every click flips the effective appearance").

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
