### PR TITLE
fix(chat): stop persisting the agent runtime's own web UI as a dashboard canvas

### DIFF
--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -67,6 +67,13 @@ _CANVAS_BARE = re.compile(rf"\S*?canvas/{_PATH}\.(?:{_EXTS})(?![\w])", re.IGNORE
 # ``[embed url="/__openclaw__/canvas/..." /]``). The gateway serves ref
 # documents at ``canvas/documents/<id>/index.html``, so refs fold into the
 # same fetch/persist path as plain canvas file references.
+#
+# On at least one observed runtime build, that route did not intercept these
+# requests at all (nonexistent AND real refs both came back HTTP 200 from the
+# runtime's own web UI, falling through as a catch-all) even though the
+# published document existed on disk with the right content. See
+# ``_gateway_fakes_missing_canvas_as_ok`` — persistence is skipped for the
+# whole turn when that is detected, rather than saving that page.
 _EMBED_MARKER = re.compile(r"\[embed\s[^\]]*\]", re.IGNORECASE)
 _EMBED_REF = re.compile(r"\[embed\s[^\]]*?\bref=[\"']([\w.\-]+)[\"'][^\]]*\]", re.IGNORECASE)
 
@@ -143,6 +150,40 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 	return r.content, _type_for(name)
 
 
+def _gateway_fakes_missing_canvas_as_ok(agent_url: str, token: str) -> bool:
+	"""True only when the gateway is confirmed to answer EVERY canvas path with
+	HTTP 200, including one that cannot possibly exist.
+
+	When the runtime's own web UI ends up as the catch-all for unmatched
+	``/__openclaw__/canvas/...`` requests (its route never intercepted, for
+	whatever reason on that gateway build/version), it answers with HTTP 200
+	and its own app shell for ANY path — real artifact, wrong ref, or a
+	fabricated one alike. ``fetch_canvas`` only checks for a 200 with a body,
+	so that shell would otherwise get saved and rendered as if it were the
+	published artifact. Probing with a name that cannot exist tells them
+	apart: a gateway that is actually serving the canvas directory 404s an
+	unknown document; one that fell through to its own UI does not.
+
+	A probe that can't even complete (network error, timeout) is NOT treated
+	as broken — that's inconclusive, not confirmed, so callers fall back to
+	letting each real fetch below fail on its own merits.
+	"""
+	import uuid
+
+	import requests
+
+	base = _http_base(agent_url)
+	if not base or not token:
+		return False
+	sentinel = f"documents/jarvis-canvas-probe-{uuid.uuid4().hex}/index.html"
+	url = f"{base}/__openclaw__/canvas/{sentinel}"
+	try:
+		r = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=10)
+	except Exception:
+		return False
+	return r.status_code != 404
+
+
 def _title_for(name: str, content: bytes | None, typ: str) -> str:
 	"""Prefer the artifact's own <title> (text types); else prettify the
 	filename (charts/sales-this-month.svg → "Sales This Month")."""
@@ -205,6 +246,20 @@ def persist_canvases(
 	strip the dead links, and return ``[{name, title, type, file_url}]``."""
 	names = detect_canvas_names(content)
 	if not names:
+		return []
+
+	if _gateway_fakes_missing_canvas_as_ok(agent_url, token):
+		frappe.log_error(
+			title="chat canvas: gateway fallback detected",
+			message=(
+				"The agent runtime answered a nonexistent canvas document with "
+				"something other than 404, so its canvas route is not actually "
+				"intercepting these requests (they are falling through to the "
+				"runtime's own web UI as a catch-all). Every artifact fetch this "
+				"turn would 200 with that page instead of the real content, so "
+				f"persistence is skipped entirely. msg={assistant_msg_name!r} names={names!r}"
+			),
+		)
 		return []
 
 	items: list[dict] = []

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -260,6 +260,16 @@ def persist_canvases(
 				f"persistence is skipped entirely. msg={assistant_msg_name!r} names={names!r}"
 			),
 		)
+		# Nothing was persisted, but the reply text still carries the raw
+		# [embed ref=...] marker(s) / dead canvas link(s) - the frontend has no
+		# handling for those on their own, so left alone they would show up as
+		# literal internal markup in the chat transcript. Strip them here too,
+		# same as the success path, so the turn reads as clean prose with no
+		# canvas rather than a page or raw markup leaking through.
+		cleaned = strip_canvas_refs(content, names)
+		if cleaned != content:
+			frappe.db.set_value(MSG, assistant_msg_name, "content", cleaned)
+			frappe.db.commit()
 		return []
 
 	items: list[dict] = []

--- a/jarvis/tests/test_canvas.py
+++ b/jarvis/tests/test_canvas.py
@@ -4,6 +4,7 @@ metadata. Network fetch + File persistence are covered by the worker path.
 """
 
 import unittest
+from unittest.mock import Mock, patch
 
 from jarvis.chat import canvas
 
@@ -77,6 +78,55 @@ class TestCanvasDetection(unittest.TestCase):
 		self.assertEqual(canvas._http_base("ws://127.0.0.1:19002"), "http://127.0.0.1:19002")
 		self.assertEqual(canvas._http_base("wss://host:443/"), "https://host:443")
 		self.assertEqual(canvas._http_base(""), "")
+
+
+class TestGatewayFallbackDetection(unittest.TestCase):
+	"""``_gateway_fakes_missing_canvas_as_ok`` — the sentinel probe that tells a
+	healthy canvas host apart from a gateway that fell through to its own web
+	UI as a catch-all (which answers every path, real or fake, with 200)."""
+
+	def test_healthy_gateway_404s_the_sentinel(self):
+		resp = Mock(status_code=404)
+		with patch("requests.get", return_value=resp) as get:
+			result = canvas._gateway_fakes_missing_canvas_as_ok("ws://127.0.0.1:19000", "tok")
+		self.assertFalse(result)
+		# Probed a name that cannot exist, through the same canvas route.
+		(url,), kwargs = get.call_args
+		self.assertIn("/__openclaw__/canvas/documents/", url)
+		self.assertIn("index.html", url)
+		self.assertEqual(kwargs["headers"]["Authorization"], "Bearer tok")
+
+	def test_broken_gateway_200s_the_sentinel(self):
+		resp = Mock(status_code=200)
+		with patch("requests.get", return_value=resp):
+			result = canvas._gateway_fakes_missing_canvas_as_ok("ws://127.0.0.1:19000", "tok")
+		self.assertTrue(result)
+
+	def test_non_404_error_status_also_counts_as_broken(self):
+		resp = Mock(status_code=500)
+		with patch("requests.get", return_value=resp):
+			result = canvas._gateway_fakes_missing_canvas_as_ok("ws://127.0.0.1:19000", "tok")
+		self.assertTrue(result)
+
+	def test_probe_network_error_is_inconclusive_not_broken(self):
+		with patch("requests.get", side_effect=Exception("boom")):
+			result = canvas._gateway_fakes_missing_canvas_as_ok("ws://127.0.0.1:19000", "tok")
+		self.assertFalse(result)
+
+	def test_missing_agent_url_or_token_short_circuits(self):
+		with patch("requests.get") as get:
+			self.assertFalse(canvas._gateway_fakes_missing_canvas_as_ok("", "tok"))
+			self.assertFalse(canvas._gateway_fakes_missing_canvas_as_ok("ws://x", ""))
+		get.assert_not_called()
+
+	def test_sentinel_name_is_unique_per_call(self):
+		resp = Mock(status_code=404)
+		with patch("requests.get", return_value=resp) as get:
+			canvas._gateway_fakes_missing_canvas_as_ok("ws://127.0.0.1:19000", "tok")
+			canvas._gateway_fakes_missing_canvas_as_ok("ws://127.0.0.1:19000", "tok")
+		first_url = get.call_args_list[0].args[0]
+		second_url = get.call_args_list[1].args[0]
+		self.assertNotEqual(first_url, second_url)
 
 
 if __name__ == "__main__":

--- a/jarvis/tests/test_canvas_embeds.py
+++ b/jarvis/tests/test_canvas_embeds.py
@@ -126,11 +126,13 @@ class TestPersistCanvasesGatewayFallback(FrappeTestCase):
 		frappe.delete_doc(MSG, self.msg.name, force=True, ignore_permissions=True, delete_permanently=True)
 		frappe.delete_doc(CONV, self.conv.name, force=True, ignore_permissions=True, delete_permanently=True)
 
-	def test_broken_gateway_persists_nothing_and_leaves_content_untouched(self):
+	def test_broken_gateway_persists_nothing_but_still_cleans_the_reply(self):
 		"""Sentinel probe 200s (the runtime shell answering for everything) ->
-		skip persistence entirely rather than save that shell as the canvas."""
+		skip persistence entirely rather than save that shell as the canvas.
+		Nothing is persisted, but the raw [embed ref=...] marker must still be
+		stripped from the reply - otherwise the customer sees literal internal
+		markup instead of clean prose with no canvas."""
 		shell_resp = Mock(status_code=200, content=b"<html>runtime web UI shell</html>")
-		original_content = self.msg.content
 
 		with patch("requests.get", return_value=shell_resp), patch.object(frappe, "log_error") as log_error:
 			items = persist_canvases(self.msg.name, self.msg.content, "ws://127.0.0.1:19000", "tok")
@@ -138,10 +140,9 @@ class TestPersistCanvasesGatewayFallback(FrappeTestCase):
 		self.assertEqual(items, [])
 		log_error.assert_called_once()
 		self.assertEqual(log_error.call_args.kwargs.get("title"), "chat canvas: gateway fallback detected")
-		# Neither the embed marker nor the content was touched.
 		stored = frappe.db.get_value(MSG, self.msg.name, ["content", "canvas"], as_dict=True)
-		self.assertEqual(stored.content, original_content)
-		self.assertIn('[embed ref="cv_abc123"', stored.content)
+		self.assertNotIn("[embed", stored.content)
+		self.assertIn("Built it.", stored.content)
 		self.assertFalse(stored.canvas)
 
 	def test_healthy_gateway_persists_the_real_document(self):

--- a/jarvis/tests/test_canvas_embeds.py
+++ b/jarvis/tests/test_canvas_embeds.py
@@ -7,9 +7,15 @@ fetch path as plain ``canvas/<path>.<ext>`` references, and the markers must
 be stripped from the visible reply once the artifact is persisted.
 """
 
+from unittest.mock import Mock, patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.chat.canvas import detect_canvas_names, strip_canvas_refs
+from jarvis.chat.canvas import detect_canvas_names, persist_canvases, strip_canvas_refs
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
 
 
 class TestCanvasEmbedDetection(FrappeTestCase):
@@ -88,3 +94,73 @@ class TestCanvasPathTraversal(FrappeTestCase):
 
 	def test_legit_subdir_still_ok(self):
 		self.assertEqual(detect_canvas_names("canvas/charts/sales.html"), ["charts/sales.html"])
+
+
+class TestPersistCanvasesGatewayFallback(FrappeTestCase):
+	"""End-to-end ``persist_canvases`` behavior when the gateway's canvas route
+	is (and is not) actually serving the published document, driven entirely
+	through a mocked ``requests.get`` — no live container needed.
+
+	Live repro (2026-08-15, e2e.localhost): a main-chat dashboard build's
+	``[embed ref=... /]`` resolved to the agent runtime's own web-UI shell
+	(HTTP 200, wrong content) instead of the published document that genuinely
+	existed on disk at that exact path. ``fetch_canvas`` only checked for a
+	200 with a body, so that shell got saved and rendered as the dashboard,
+	titled after the runtime's own product name."""
+
+	def setUp(self):
+		self.conv = frappe.get_doc({"doctype": CONV, "title": "canvas fallback test"}).insert(
+			ignore_permissions=True
+		)
+		self.msg = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": self.conv.name,
+				"seq": 1,
+				"role": "assistant",
+				"content": 'Built it.\n\n[embed ref="cv_abc123" title="Dash" height="720" /]',
+			}
+		).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.delete_doc(MSG, self.msg.name, force=True, ignore_permissions=True, delete_permanently=True)
+		frappe.delete_doc(CONV, self.conv.name, force=True, ignore_permissions=True, delete_permanently=True)
+
+	def test_broken_gateway_persists_nothing_and_leaves_content_untouched(self):
+		"""Sentinel probe 200s (the runtime shell answering for everything) ->
+		skip persistence entirely rather than save that shell as the canvas."""
+		shell_resp = Mock(status_code=200, content=b"<html>runtime web UI shell</html>")
+		original_content = self.msg.content
+
+		with patch("requests.get", return_value=shell_resp), patch.object(frappe, "log_error") as log_error:
+			items = persist_canvases(self.msg.name, self.msg.content, "ws://127.0.0.1:19000", "tok")
+
+		self.assertEqual(items, [])
+		log_error.assert_called_once()
+		self.assertEqual(log_error.call_args.kwargs.get("title"), "chat canvas: gateway fallback detected")
+		# Neither the embed marker nor the content was touched.
+		stored = frappe.db.get_value(MSG, self.msg.name, ["content", "canvas"], as_dict=True)
+		self.assertEqual(stored.content, original_content)
+		self.assertIn('[embed ref="cv_abc123"', stored.content)
+		self.assertFalse(stored.canvas)
+
+	def test_healthy_gateway_persists_the_real_document(self):
+		"""Sentinel probe 404s -> per-artifact fetch proceeds and persists as
+		before."""
+		real_doc = b"<!doctype html><html><head><title>Real Dashboard</title></head><body>ok</body></html>"
+
+		def fake_get(url, headers=None, timeout=None):
+			if "jarvis-canvas-probe-" in url:
+				return Mock(status_code=404, content=b"not found")
+			return Mock(status_code=200, content=real_doc)
+
+		with patch("requests.get", side_effect=fake_get), patch.object(frappe, "log_error") as log_error:
+			items = persist_canvases(self.msg.name, self.msg.content, "ws://127.0.0.1:19000", "tok")
+
+		log_error.assert_not_called()
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0]["name"], "documents/cv_abc123/index.html")
+		self.assertEqual(items[0]["title"], "Real Dashboard")
+		stored = frappe.db.get_value(MSG, self.msg.name, ["content", "canvas"], as_dict=True)
+		self.assertNotIn("[embed", stored.content)
+		self.assertTrue(stored.canvas)


### PR DESCRIPTION
## Summary

Main-chat dashboard builds were rendering a dark "Control UI did not start" error page branded with the agent runtime's own product name instead of the built dashboard. Live repro on e2e.localhost (conversation `3hepjr1j4s`): the runtime published a real document with genuine dashboard content, but the gateway route that is supposed to serve it did not intercept the request on this build, so a GET for that path (and a fabricated, nonexistent one) both came back HTTP 200 with the runtime's own web-UI shell. `fetch_canvas()` only checked for a 200 with a body, so it saved and rendered that shell as the dashboard.

`persist_canvases` now probes the same route with a name that cannot exist before fetching any real artifact this turn. A healthy gateway 404s it; one that fell through to its own UI answers with something else, which is exactly what the live repro showed. When that happens, persistence is skipped for the whole turn (logged once) so a fetch failure degrades to no-canvas instead of a branded error page.

Known limit: main-chat dashboard thumbnails will not render until the runtime exposes a backend-fetchable document path for this gateway build. The Dashboards builder page is unaffected: it renders via its own live query bridge, not this persisted-canvas path.

## Pre-merge checklist

- [x] **CI is green** - the `tests` check on this PR passes (never merge on FAIL)
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests (`jarvis/tests/test_canvas.py`, `jarvis/tests/test_canvas_embeds.py`)
- [x] I self-reviewed the diff