### PR TITLE
fix(dashboards): stop double-dispatching turns and ask answers

### DIFF
--- a/frontend/src/components/chat/AskCard.vue
+++ b/frontend/src/components/chat/AskCard.vue
@@ -12,6 +12,7 @@
 					:key="li"
 					class="jv-ask-opt"
 					:class="{ on: isPicked(qi, lbl) }"
+					:disabled="answered"
 					@click="toggleSingle(qi, lbl)"
 				>
 					<span v-if="isPicked(qi, lbl)" class="jv-ask-tick">✓</span>{{ lbl }}
@@ -24,6 +25,7 @@
 					:key="oi"
 					class="jv-ask-opt"
 					:class="{ on: isPicked(qi, opt) }"
+					:disabled="answered"
 					@click="q.type === 'multi' ? toggleMulti(qi, opt) : toggleSingle(qi, opt)"
 				>
 					<span v-if="isPicked(qi, opt)" class="jv-ask-tick">✓</span>{{ opt }}
@@ -35,6 +37,7 @@
 				type="date"
 				class="jv-ask-field"
 				:value="sel[qi] || ''"
+				:disabled="answered"
 				@input="pickSingle(qi, $event.target.value)"
 			/>
 			<input
@@ -42,6 +45,7 @@
 				type="datetime-local"
 				class="jv-ask-field"
 				:value="sel[qi] || ''"
+				:disabled="answered"
 				@input="pickSingle(qi, $event.target.value)"
 			/>
 			<input
@@ -49,6 +53,7 @@
 				type="text"
 				class="jv-ask-field"
 				:value="sel[qi] || ''"
+				:disabled="answered"
 				@input="pickSingle(qi, $event.target.value)"
 				placeholder="Type your answer…"
 				@keydown.enter.prevent
@@ -59,6 +64,7 @@
 					type="text"
 					class="jv-ask-field"
 					:value="link[qi] && link[qi].q != null ? link[qi].q : sel[qi] || ''"
+					:disabled="answered"
 					@input="onLinkSearch(qi, q.doctype, $event.target.value)"
 					@focus="onLinkSearch(qi, q.doctype, (link[qi] && link[qi].q) || '')"
 					:placeholder="'Search ' + (q.doctype || 'records') + '…'"
@@ -86,15 +92,18 @@
 				class="jv-ask-other"
 				v-model="other[qi]"
 				placeholder="Other…"
+				:disabled="answered"
 				@input="onOther(qi, q.type)"
 				@keydown.enter.prevent
 			/>
 		</div>
 		<div class="jv-ask-foot">
-			<button class="jv-ask-submit" :disabled="!ready" @click="submit">
-				Submit answers
+			<button class="jv-ask-submit" :disabled="!ready || answered || busy" @click="submit">
+				{{ answered ? "Answered" : "Submit answers" }}
 			</button>
-			<span v-if="!ready" class="jv-ask-hint">Answer each question to continue</span>
+			<span v-if="!ready && !answered" class="jv-ask-hint"
+				>Answer each question to continue</span
+			>
 		</div>
 	</div>
 </template>
@@ -126,6 +135,11 @@ import { ASK_FIELD_TYPES, isAskReady, askAnswerText } from "@/lib/chatAsk";
 const props = defineProps({
 	// A parsed ask: { questions: [{q, type, options, doctype}] } (see parseAsk).
 	spec: { type: Object, required: true },
+	// True while the host would SILENTLY refuse a submit right now (a send
+	// already in flight, a turn's tail still running for this conversation).
+	// Gates ONLY the Submit button — the user can keep filling in answers while
+	// this is true, they just cannot dispatch until the host would accept it.
+	busy: { type: Boolean, default: false },
 });
 // The formatted answer text; the host sends it as an ordinary user message.
 const emit = defineEmits(["submit"]);
@@ -133,6 +147,11 @@ const emit = defineEmits(["submit"]);
 const sel = ref({}); // qIdx -> string (single/yesno/date/datetime/text/link) | string[] (multi)
 const other = ref({}); // qIdx -> free-text (option types only)
 const link = ref({}); // qIdx -> { q, items, open } for link-type record search
+// Locks the card once an answer has actually been DISPATCHED (not just typed).
+// Persists across re-renders of the same message (the component is not
+// remounted while it keeps the same v-if/:key) so a stale transcript refetch
+// can never resurrect a re-clickable card for an ask already answered.
+const answered = ref(false);
 
 // An ask whose questions are ALL field-type reads better as a compact mini-form
 // (no numbered badges, no dividers) than as a numbered question list.
@@ -198,7 +217,14 @@ function isPicked(i, opt) {
 	return Array.isArray(v) ? v.includes(opt) : v === opt;
 }
 function submit() {
-	if (!ready.value) return;
+	if (!ready.value || answered.value || props.busy) return;
+	// Lock BEFORE emitting (optimistic): a second click — or a re-render from
+	// the next transcript refetch — must not dispatch a second answer for this
+	// ask. Gated on props.busy too: if the host would refuse right now, locking
+	// first would silently swallow the answers with no way to retry (the same
+	// failure mode the REFUSE comment below already guards against for the
+	// picks themselves).
+	answered.value = true;
 	// Emit and keep the picks. The card is keyed by message, so it unmounts the
 	// moment the next assistant message arrives — there is nothing to reset. And
 	// a host is allowed to REFUSE the text (a send already in flight, a dictation
@@ -300,6 +326,12 @@ function submit() {
 	background: var(--cta-bg);
 	color: var(--text);
 	font-weight: 600;
+}
+.jv-ask-opt:disabled,
+.jv-ask-field:disabled,
+.jv-ask-other:disabled {
+	opacity: 0.55;
+	cursor: default;
 }
 .jv-ask-tick {
 	color: var(--cta);

--- a/frontend/src/components/chat/AskCard.vue
+++ b/frontend/src/components/chat/AskCard.vue
@@ -72,7 +72,7 @@
 					@keydown.enter.prevent
 				/>
 				<div
-					v-if="link[qi] && link[qi].open && (link[qi].items || []).length"
+					v-if="!answered && link[qi] && link[qi].open && (link[qi].items || []).length"
 					class="jv-ask-linkmenu"
 					v-scroll-fade
 				>

--- a/frontend/src/lib/chatAsk.test.js
+++ b/frontend/src/lib/chatAsk.test.js
@@ -190,3 +190,46 @@ test("the Dashboards builder pane RENDERS the ask instead of swallowing it", () 
 	assert.match(dashPaneSrc, /<AskCard[\s\S]{0,240}:key="m\.name"/);
 	assert.match(chatViewSrc, /<AskCard[\s\S]{0,200}:key="m\.name"/);
 });
+
+// ---- owner-reported: clicking Submit/answer twice fires duplicate answers -
+
+const fnBody = (src, decl) => {
+	const start = src.indexOf(decl);
+	assert.notEqual(start, -1, `source must still define ${decl}`);
+	const end = src.indexOf("\n}", start + decl.length);
+	assert.notEqual(end, -1, `${decl} must close at the top level`);
+	return src.slice(start, end);
+};
+
+test("submit() locks BEFORE emitting, so a second click cannot dispatch a second answer", () => {
+	const submit = fnBody(askCardSrc, "function submit()");
+	const lockAt = submit.indexOf("answered.value = true;");
+	const emitAt = submit.indexOf('emit("submit"');
+	assert.notEqual(lockAt, -1, "submit() must set the answered lock");
+	assert.notEqual(emitAt, -1);
+	assert.ok(lockAt < emitAt, "the lock must be set before the emit (optimistic)");
+	// re-entrant/re-render guard: already answered, or the host is busy, refuses
+	assert.match(submit, /if \(!ready\.value \|\| answered\.value \|\| props\.busy\) return;/);
+});
+
+test("an answered ask stays inert: every control disables on `answered`, not just Submit", () => {
+	// The submit button locks on its own answered flag...
+	assert.match(askCardSrc, /:disabled="!ready \|\| answered \|\| busy"/);
+	// ...and every input a user could still poke after answering is disabled too,
+	// so a re-render from server state can never present a re-editable, re-clickable
+	// card for an ask that was already dispatched.
+	const disabledOnAnswered = (askCardSrc.match(/:disabled="answered"/g) || []).length;
+	assert.equal(
+		disabledOnAnswered,
+		7,
+		"yesno + single/multi option buttons, date, datetime, text, link and Other inputs must all gate on `answered`"
+	);
+});
+
+test("the Submit button also refuses while the host would silently swallow the answer", () => {
+	// AskCard declares the busy prop...
+	assert.match(askCardSrc, /busy: \{ type: Boolean, default: false \}/);
+	// ...both hosts wire their real in-flight signal into it...
+	assert.match(chatViewSrc, /<AskCard[\s\S]{0,200}:busy="sending"/);
+	assert.match(dashPaneSrc, /<AskCard[\s\S]{0,240}:busy="sending \|\| runActive"/);
+});

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -357,7 +357,8 @@ test("send() clears the draft up front and restores it only on rejection", () =>
 	const send = fnBody(paneSrc, "async function send(");
 	// guard, clear, optimistic bubble - in that order
 	assert.ok(
-		send.indexOf("if (!text || sending.value) return;") < send.indexOf('draft.value = "";'),
+		send.indexOf("if (!text || sending.value || runActive.value) return;") <
+			send.indexOf('draft.value = "";'),
 		"the in-flight guard must precede the clear"
 	);
 	assert.match(send, /const text = draft\.value\.trim\(\);/);
@@ -370,4 +371,33 @@ test("send() clears the draft up front and restores it only on rejection", () =>
 		send,
 		/messages\.value = messages\.value\.filter\(\(m\) => m\.name !== tmpName\)/
 	);
+});
+
+// ---- owner-reported: repeat Enter/click fires a duplicate turn -----------
+// Three 1-char messages sent 18:57:00-18:57:02 each spawned a turn and wedged
+// the pump: `sending` only spans the POST, so once it resolves (fast) the
+// button and both send entry points re-armed while the agent's turn (tracked
+// by `runActive`) was still running.
+
+test("Send is disabled while a turn is running, not just while posting", () => {
+	const composer = composerOf(paneSrc);
+	const disabledBindings = composer.match(/:disabled="[^"]*"/g) || [];
+	assert.ok(
+		disabledBindings.some((b) => b.includes("sending") && b.includes("runActive")),
+		"the Send button must gate on runActive too, or a duplicate turn can be dispatched once the POST settles"
+	);
+});
+
+test("send() and sendText() refuse to dispatch while a turn is already running", () => {
+	const send = fnBody(paneSrc, "async function send(");
+	assert.match(send, /if \(!text \|\| sending\.value \|\| runActive\.value\) return;/);
+	const sendText = fnBody(paneSrc, "function sendText(");
+	assert.match(sendText, /if \(!t \|\| sending\.value \|\| runActive\.value\) return;/);
+});
+
+test("the ask card is told when the pane would refuse a submit", () => {
+	// AskCard's own single-submit lock only closes half the race: if the host
+	// silently swallows the answer (already sending, or the prior turn hasn't
+	// finished), the card must not lock until the host would actually accept it.
+	assert.match(paneSrc, /<AskCard[\s\S]{0,240}:busy="sending \|\| runActive"/);
 });

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -72,6 +72,7 @@
 							:key="m.name"
 							:spec="activeAsk"
 							:style="paletteVars"
+							:busy="sending || runActive"
 							@submit="sendText"
 						/>
 					</div>
@@ -139,7 +140,10 @@
 		     disabled gets blurred by the browser, which fires `change` — the
 		     frappe-ui Textarea this used to be listens on `change` too and
 		     re-emitted the PRE-CLEAR value, restoring the message we had just
-		     sent. Only the send button and send() are gated on `sending`. -->
+		     sent. Only the send button and send() are gated on `sending` /
+		     `runActive` — repeat Enter/click while a turn is still running (even
+		     after the POST that started it has long since resolved) must not fire
+		     a second turn for the same conversation. -->
 		<div class="shrink-0 border-t px-4 py-3">
 			<textarea
 				ref="box"
@@ -191,7 +195,7 @@
 				<Button
 					variant="solid"
 					label="Send"
-					:disabled="!draft.trim() || sending"
+					:disabled="!draft.trim() || sending || runActive"
 					:loading="sending"
 					@click="send"
 				/>
@@ -560,7 +564,7 @@ let ownRepoint = false;
 
 async function send() {
 	const text = draft.value.trim();
-	if (!text || sending.value) return;
+	if (!text || sending.value || runActive.value) return;
 	sending.value = true;
 	draft.value = "";
 	// optimistic user bubble - reconciled by the next transcript refetch
@@ -639,10 +643,11 @@ watch(conversation, (id, prev) => {
 });
 
 // Post a message into this pane programmatically (the save dialog's "Ask the
-// assistant to fix these" hand-off). Ignored while a send is already in flight.
+// assistant to fix these" hand-off, AskCard's answer submit). Ignored while a
+// send is already in flight OR a turn is still running for this conversation.
 function sendText(text) {
 	const t = String(text || "").trim();
-	if (!t || sending.value) return;
+	if (!t || sending.value || runActive.value) return;
 	draft.value = t;
 	send();
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1358,6 +1358,7 @@
 									v-else-if="askFor === m.name && activeAsk"
 									:key="m.name"
 									:spec="activeAsk"
+									:busy="sending"
 									@submit="send"
 								/>
 								<!-- record cards: scrollable card strip instead of a wide table -->

--- a/frontend/tests/support-extraction/ask-card.test.js
+++ b/frontend/tests/support-extraction/ask-card.test.js
@@ -9,6 +9,7 @@ import { expect, test, vi } from "vitest";
 // resources chain does not resolve under vitest. Only searchLink is used here.
 vi.mock("@/api", () => ({ searchLink: vi.fn(async () => []) }));
 
+import { searchLink } from "@/api";
 import AskCard from "../../src/components/chat/AskCard.vue";
 import { parseAsk } from "../../src/lib/chatAsk.js";
 import { mountWithPalette } from "./fixtures.js";
@@ -120,6 +121,26 @@ test("busy=false lets an otherwise-ready ask actually dispatch", async () => {
 	expect(submit(w).attributes("disabled")).toBeUndefined();
 	await submit(w).trigger("click");
 	expect(findCard(w).emitted("submit")).toHaveLength(1);
+});
+
+test("answering closes an open link-search dropdown for good, not just the input", async () => {
+	// The dropdown's own buttons had no `answered` gate - only @blur closed it,
+	// timing-fragile against a click that lands before the blur does. Focus AND
+	// input both call searchLink (empty query, then "acm"), so mock persistently.
+	searchLink.mockResolvedValue([{ value: "ACME Corp", description: "Customer" }]);
+	const withLink = spec('[{"q":"Which record?","type":"link","doctype":"Customer"}]');
+	const w = mountWithPalette(AskCard, { spec: withLink });
+	const input = w.find("input.jv-ask-field");
+	await input.trigger("focus");
+	await input.setValue("acm");
+	await vi.waitFor(() => expect(w.findAll(".jv-ask-linkmenu button").length).toBeGreaterThan(0));
+	await w.findAll(".jv-ask-linkmenu button")[0].trigger("mousedown");
+	expect(w.find(".jv-ask-linkmenu").exists()).toBe(false);
+	expect(submit(w).attributes("disabled")).toBeUndefined();
+	await submit(w).trigger("click");
+	// re-focusing (or any other path) must not resurrect the dropdown once answered
+	await input.trigger("focus");
+	expect(w.find(".jv-ask-linkmenu").exists()).toBe(false);
 });
 
 test("clicking a picked option unpicks it (and disarms Submit)", async () => {

--- a/frontend/tests/support-extraction/ask-card.test.js
+++ b/frontend/tests/support-extraction/ask-card.test.js
@@ -69,12 +69,57 @@ test("the picks survive Submit, so a host that refuses the text loses nothing", 
 	await optionNamed(w, "Approve").trigger("click");
 	await submit(w).trigger("click");
 	expect(optionNamed(w, "Open").classes()).toContain("on");
-	expect(submit(w).attributes("disabled")).toBeUndefined();
-	// ...and a second click re-sends the same answers rather than an empty one
+	expect(findCard(w).emitted("submit")).toHaveLength(1);
+});
+
+test("single-submit: once answered, Submit locks and a second click cannot dispatch again", async () => {
+	// Repeat-click / repeat-Enter is the owner-reported bug: the SAME picks
+	// firing a second "submit" is a duplicate answer, not a legitimate resend.
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	await submit(w).trigger("click");
+	// locked immediately (optimistic) - the button reflects the answered state
+	expect(submit(w).attributes("disabled")).toBeDefined();
+	expect(submit(w).text()).toBe("Answered");
 	await submit(w).trigger("click");
 	const emitted = findCard(w).emitted("submit");
-	expect(emitted).toHaveLength(2);
-	expect(emitted[1][0]).toBe(emitted[0][0]);
+	expect(emitted).toHaveLength(1);
+});
+
+test("an answered ask stays inert: every control locks, not just Submit", async () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	await submit(w).trigger("click");
+	// clicking a DIFFERENT option after answering must not change the picks -
+	// the card is inert, not just the Submit button
+	await optionNamed(w, "Closed").trigger("click");
+	expect(optionNamed(w, "Open").classes()).toContain("on");
+	expect(optionNamed(w, "Closed").classes()).not.toContain("on");
+});
+
+test("busy=true refuses the dispatch (host would swallow it) without locking the card", async () => {
+	// The busy window (a send in flight, a turn's tail still running) must not
+	// let the card lock on an answer that was never actually accepted - that
+	// would strand the user behind an inert "Answered" card with nothing sent.
+	const w = mountWithPalette(AskCard, { spec: CHOICES, busy: true });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	expect(submit(w).attributes("disabled")).toBeDefined();
+	await submit(w).trigger("click");
+	expect(findCard(w).emitted("submit")).toBeUndefined();
+	// not locked - the button still reads as an unanswered, resubmittable card
+	expect(submit(w).text()).toBe("Submit answers");
+});
+
+test("busy=false lets an otherwise-ready ask actually dispatch", async () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES, busy: false });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	expect(submit(w).attributes("disabled")).toBeUndefined();
+	await submit(w).trigger("click");
+	expect(findCard(w).emitted("submit")).toHaveLength(1);
 });
 
 test("clicking a picked option unpicks it (and disarms Submit)", async () => {


### PR DESCRIPTION
Repeat Enter/click in the Dashboards builder chat could fire duplicate turns and duplicate ask answers; both now stay locked out until the current turn actually finishes.

Live repro: three 1-char messages sent 18:57:00-18:57:02 each spawned a turn and wedged the pump. Root cause: `DashboardChatPane.vue`'s `send()`/`sendText()` only gated on `sending`, which clears as soon as the POST resolves, not when the turn (`runActive`) actually ends - so a fast repeat Enter/click landed in the window between "POST done" and "turn over." Both dispatch entry points and the Send button now also gate on `runActive`.

Separately, `AskCard.vue`'s Submit button never locked after a click; single-submit was left entirely to the host, and the dashboards host's guard only covered the POST window, so a second click could dispatch a duplicate answer while the turn's tail was still running. `AskCard` now locks itself optimistically (`answered`) right after a successful dispatch, and takes a `busy` prop so it refuses to lock when the host would silently swallow the emit instead - this closes a race the `runActive` fix above widens (the busy window is now longer). AskCard is the shared renderer for both ChatView and the Dashboards pane, so both surfaces get the fix.

Note: the existing test "the picks survive Submit, so a host that refuses the text loses nothing" previously asserted a second click re-emits the same answers - that was the owner-reported bug. Its retry-on-host-refusal intent is now covered by the `busy` prop (the card refuses to lock while the host would swallow the emit) rather than by allowing re-clicks; the test is updated accordingly, plus new tests for the lock and the busy-gated refusal.

## Pre-merge checklist

- [ ] CI is green - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with `develop` (branched from `upstream/develop` just before this PR)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff