### PR TITLE
feat(dashboards): redirect main chat to the builder, deliver builds via save_dashboard (#884)

### DIFF
--- a/frontend/src/composables/dashboardPrefill.js
+++ b/frontend/src/composables/dashboardPrefill.js
@@ -1,0 +1,24 @@
+import { ref } from "vue";
+
+// Cross-view hand-off for a ```jarvis-goto redirect (main chat -> Dashboards
+// builder, issue #884). Main chat no longer builds dashboards itself: the
+// agent restates the request and points here with a fenced block, ChatView
+// stashes it and router.push("/dashboards"); DashboardsPage consumes it ONCE
+// on mount (and clears it on EVERY mount so a stale prompt can never fire
+// later): when `autoSend` is set it hands the text to the chat pane's
+// sendText(), which sends it as the next message on the builder's thread.
+// Shape:
+//   { text: string, autoSend: true }
+export const pendingDashboardPrefill = ref(null);
+
+export function setDashboardPrefill(payload) {
+	pendingDashboardPrefill.value = payload || null;
+}
+
+// Read-and-clear: returns the pending payload (or null) and empties the slot
+// so a later plain visit to Dashboards doesn't re-fill a stale prompt.
+export function takeDashboardPrefill() {
+	const v = pendingDashboardPrefill.value;
+	pendingDashboardPrefill.value = null;
+	return v;
+}

--- a/frontend/src/composables/dashboardPrefill.spec.js
+++ b/frontend/src/composables/dashboardPrefill.spec.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	pendingDashboardPrefill,
+	setDashboardPrefill,
+	takeDashboardPrefill,
+} from "./dashboardPrefill.js";
+
+// The cross-view stash a ```jarvis-goto redirect hands to the Dashboards
+// builder (jarvis#884), mirroring chatPrefill.js's one-shot contract exactly:
+// set stashes a payload, take reads it and empties the slot in the same call,
+// so a later plain visit to the page can never replay a stale prompt.
+describe("dashboardPrefill", () => {
+	beforeEach(() => {
+		pendingDashboardPrefill.value = null;
+	});
+
+	it("starts empty", () => {
+		expect(takeDashboardPrefill()).toBeNull();
+	});
+
+	it("returns what was set", () => {
+		setDashboardPrefill({ text: "Monthly sales by territory", autoSend: true });
+		expect(takeDashboardPrefill()).toEqual({
+			text: "Monthly sales by territory",
+			autoSend: true,
+		});
+	});
+
+	it("is one-shot: a second take on the same mount finds nothing", () => {
+		setDashboardPrefill({ text: "x", autoSend: true });
+		takeDashboardPrefill();
+		expect(takeDashboardPrefill()).toBeNull();
+	});
+
+	it("setDashboardPrefill(null/undefined) clears the slot", () => {
+		setDashboardPrefill({ text: "x", autoSend: true });
+		setDashboardPrefill(null);
+		expect(takeDashboardPrefill()).toBeNull();
+	});
+});

--- a/frontend/src/lib/artifactActivityCard.js
+++ b/frontend/src/lib/artifactActivityCard.js
@@ -1,0 +1,128 @@
+// The common "producing an artifact" live card (jarvis#884), replacing the
+// dashboard-only card issue #874 shipped. Same idea, generalized: whichever
+// write tool a main-chat turn is actually running names the artifact it is
+// building, and the same four-phase tick mechanics dashboardBuildCard.js
+// already proved out for dashboards now drive pdf/spreadsheet/image turns
+// too — parameterized, not forked (see dashboardBuildPhase's toolSets arg).
+//
+// Deliberate exclusion: `run_report` is a DATA tool (dashboardBuildCard.js's
+// own DATA_TOOLS already lists it) — it reads a saved Report's rows for
+// ordinary Q&A ("what were last month's sales") and never by itself produces
+// a downloadable artifact. A report the user actually wants AS A FILE goes
+// through `report_pdf`/`export_document` (PDF) or `export_query` (workbook),
+// which is what the "Creating your PDF" / "Exporting your spreadsheet" copy
+// is promising. Lighting the card on run_report alone would show "Creating
+// your PDF" for a plain question with no PDF coming — worse than no card.
+//
+// The image tool name was verified, not assumed: this app's own jarvis__
+// tool registry (jarvis/tools/registry.py) has no "image"/"imagegen" entry
+// at all — generated images come from the agent runtime's own NATIVE tool
+// (unprefixed, like "bash"/"exec"/"canvas"), named "imagegen" (the fleet
+// agent's own config template calls it "the agent runtime's native imagegen
+// tool"; the persona's AGENTS.md/TOOLS.md call it `imagegen` too). ChatView's
+// existing TOOL_PHRASES
+// and this file's own WRITE_TOOLS both carry a stale "image" entry that
+// backend evidence says never actually fires as a tool_name — left alone
+// there (out of scope, dashboard behaviour must stay exactly as it was), but
+// NOT copied into this generalized set. Only "imagegen" is wired here.
+
+import {
+	dashboardBuildPhase,
+	toolBaseName,
+	DASHBOARD_BUILD_PHASES,
+} from "./dashboardBuildCard.js";
+
+const PDF_TOOLS = new Set(["download_pdf", "export_document"]);
+const SPREADSHEET_TOOLS = new Set(["export_excel", "export_query"]);
+const IMAGE_TOOLS = new Set(["imagegen"]);
+
+// Same "Understanding -> data -> compose -> write" shape dashboardBuildPhase
+// already reads off real activeTools/statusPhase/waiting events; queried data
+// tools are shared with dashboardBuildCard.js's own DATA_TOOLS (get_schema,
+// get_list, run_report, query, …), and the write signal is the union of every
+// artifact-producing tool above — whichever one actually ran is what decided
+// `kind` in the first place, so any one of them lighting "Delivering" is
+// correct for every non-dashboard kind.
+const ARTIFACT_DATA_TOOLS = new Set([
+	"get_schema",
+	"get_list",
+	"get_doc",
+	"get_report_filters",
+	"run_report",
+	"query",
+	"summarize_dataset",
+	"get_creation_context",
+	"resolve_links",
+]);
+const ARTIFACT_WRITE_TOOLS = new Set([...PDF_TOOLS, ...SPREADSHEET_TOOLS, ...IMAGE_TOOLS]);
+
+/**
+ * What artifact-producing thing (if any) the CURRENT turn is doing, from the
+ * same real tool-activity signals the live card and generic activity line
+ * already keep. `dashboardTurn` wins outright — it is the existing
+ * builder-origin gate (isDashboardBuildTurn), evaluated before any tool has
+ * necessarily run, exactly like the #858/#874 card already did.
+ *
+ * Tool names arrive both bare (native tools: bash/exec/canvas/imagegen) and
+ * jarvis__-prefixed (registry tools: download_pdf/export_excel/…) — stripped
+ * the same way dashboardBuildCard.js does before matching.
+ *
+ * @param {Array<{name?: string, status?: string}>} activeTools
+ * @param {{dashboardTurn?: boolean}} [opts]
+ * @returns {"dashboard"|"pdf"|"spreadsheet"|"image"|null}
+ */
+export function detectArtifactKind(activeTools, { dashboardTurn } = {}) {
+	if (dashboardTurn) return "dashboard";
+	const tools = Array.isArray(activeTools) ? activeTools : [];
+	for (const t of tools) {
+		const base = toolBaseName(t && t.name);
+		if (PDF_TOOLS.has(base)) return "pdf";
+		if (SPREADSHEET_TOOLS.has(base)) return "spreadsheet";
+		if (IMAGE_TOOLS.has(base)) return "image";
+	}
+	return null;
+}
+
+/** Card title, adaptive to the detected artifact kind. */
+export const ARTIFACT_TITLES = {
+	dashboard: "Building your dashboard",
+	pdf: "Creating your PDF",
+	spreadsheet: "Exporting your spreadsheet",
+	image: "Generating your image",
+};
+
+// Non-dashboard phase labels (jarvis#884). The dashboard card keeps its own
+// existing DASHBOARD_BUILD_PHASES labels/wording unchanged — only these four
+// generalized ones are new. Phase KEYS match dashboardBuildPhase's output
+// ("understanding"/"querying"/"composing"/"publishing") so both label sets
+// tick off the exact same phase function; only the display label differs.
+export const ARTIFACT_BUILD_PHASES = [
+	{ key: "understanding", label: "Understanding" },
+	{ key: "querying", label: "Fetching data" },
+	{ key: "composing", label: "Composing" },
+	{ key: "publishing", label: "Delivering" },
+];
+
+/** The phase list to tick against for a given artifact kind. */
+export function artifactPhaseList(kind) {
+	return kind === "dashboard" ? DASHBOARD_BUILD_PHASES : ARTIFACT_BUILD_PHASES;
+}
+
+/**
+ * The phase a `kind` artifact turn is honestly in right now. Dashboard turns
+ * read dashboardBuildPhase exactly as before (its own tool sets, unchanged
+ * behaviour); every other kind reads the same function through the
+ * generalized data/write tool sets above — wrapped, not forked.
+ *
+ * @param {"dashboard"|"pdf"|"spreadsheet"|"image"|null} kind
+ * @param {{activeTools: Array<{name?: string, status?: string}>, statusPhase: string|null, waiting: boolean}} signals
+ * @returns {string|null}
+ */
+export function artifactBuildPhase(kind, signals) {
+	if (!kind) return null;
+	if (kind === "dashboard") return dashboardBuildPhase(signals);
+	return dashboardBuildPhase(signals, {
+		dataTools: ARTIFACT_DATA_TOOLS,
+		writeTools: ARTIFACT_WRITE_TOOLS,
+	});
+}

--- a/frontend/src/lib/artifactActivityCard.test.js
+++ b/frontend/src/lib/artifactActivityCard.test.js
@@ -285,9 +285,24 @@ test("the goto morph line latches on a complete streaming goto and survives run:
 	assert.match(stopRun, /gotoMorph\.value = null;/);
 	const resetRunState = fnBody(chatSrc, "function resetRunState() {");
 	assert.match(resetRunState, /gotoMorph\.value = null;/);
+	// run:end is the one path that can EITHER navigate (this exact terminal is
+	// the one that fires gotoDashboards) or not (a second tab that lost the
+	// localStorage stamp race, an errored/stopped row, or a was_recovered
+	// replacement whose final text dropped the goto block). The latch must
+	// only survive the navigating case — every other run:end must still drop
+	// it, or a non-navigating terminal leaves the morph line animating
+	// forever with no redirect coming.
 	const runEnd = chatSrc.slice(
 		chatSrc.indexOf('case "run:end": {'),
 		chatSrc.indexOf('case "message:enriched": {')
 	);
-	assert.doesNotMatch(runEnd, /gotoMorph\.value = null;/);
+	assert.match(runEnd, /let redirected = false;/);
+	assert.match(runEnd, /redirected = true;\s*\n\s*gotoDashboards\(goto\.prompt\);/);
+	assert.match(runEnd, /if \(!redirected\) gotoMorph\.value = null;/);
+	// the unconditional clear must come AFTER the redirect gate, not before it
+	assert.ok(
+		runEnd.indexOf("if (!redirected) gotoMorph.value = null;") >
+			runEnd.indexOf("redirected = true;"),
+		"the redirected check must run after the redirect branch, not race it"
+	);
 });

--- a/frontend/src/lib/artifactActivityCard.test.js
+++ b/frontend/src/lib/artifactActivityCard.test.js
@@ -1,0 +1,293 @@
+// The common artifact-producing live card (jarvis#884), replacing the
+// dashboard-only card #874 shipped. Plain node built-ins (node:test +
+// node:assert), the dashboardBuildCard.test.js convention: pure decisions
+// live in artifactActivityCard.js and are tested behaviourally here;
+// ChatView.vue's wiring is fenced with source assertions because a .vue SFC
+// cannot be imported into this runner.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { phaseTickIndex } from "./dashboardBuildCard.js";
+import {
+	ARTIFACT_BUILD_PHASES,
+	ARTIFACT_TITLES,
+	artifactBuildPhase,
+	artifactPhaseList,
+	detectArtifactKind,
+} from "./artifactActivityCard.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+const fnBody = (src, decl) => {
+	const start = src.indexOf(decl);
+	assert.notEqual(start, -1, `source must still define ${decl}`);
+	const end = src.indexOf("\n}", start + decl.length);
+	assert.notEqual(end, -1, `${decl} must close at the top level`);
+	return src.slice(start, end);
+};
+
+// ---- detectArtifactKind: dashboard wins, then whichever write tool ran ----
+
+test("dashboardTurn wins outright, regardless of activeTools", () => {
+	assert.equal(detectArtifactKind([], { dashboardTurn: true }), "dashboard");
+	assert.equal(
+		detectArtifactKind([{ name: "jarvis__export_excel", status: "running" }], {
+			dashboardTurn: true,
+		}),
+		"dashboard"
+	);
+});
+
+test("no dashboard turn and no recognised write tool -> null", () => {
+	assert.equal(detectArtifactKind([], {}), null);
+	assert.equal(detectArtifactKind([]), null);
+	assert.equal(
+		detectArtifactKind([{ name: "get_list", status: "completed" }], { dashboardTurn: false }),
+		null
+	);
+});
+
+test("run_report alone never triggers the card (a read used for ordinary Q&A)", () => {
+	assert.equal(
+		detectArtifactKind([{ name: "jarvis__run_report", status: "completed" }], {
+			dashboardTurn: false,
+		}),
+		null
+	);
+	assert.equal(
+		detectArtifactKind(
+			[
+				{ name: "get_schema", status: "completed" },
+				{ name: "run_report", status: "completed" },
+			],
+			{ dashboardTurn: false }
+		),
+		null
+	);
+});
+
+test("pdf: download_pdf or export_document, bare or jarvis__-prefixed", () => {
+	assert.equal(detectArtifactKind([{ name: "download_pdf", status: "running" }]), "pdf");
+	assert.equal(detectArtifactKind([{ name: "jarvis__download_pdf", status: "running" }]), "pdf");
+	assert.equal(detectArtifactKind([{ name: "export_document", status: "running" }]), "pdf");
+	assert.equal(
+		detectArtifactKind([{ name: "jarvis__export_document", status: "completed" }]),
+		"pdf"
+	);
+});
+
+test("spreadsheet: export_excel or export_query, bare or jarvis__-prefixed", () => {
+	assert.equal(detectArtifactKind([{ name: "export_excel", status: "running" }]), "spreadsheet");
+	assert.equal(
+		detectArtifactKind([{ name: "jarvis__export_excel", status: "running" }]),
+		"spreadsheet"
+	);
+	assert.equal(detectArtifactKind([{ name: "export_query", status: "running" }]), "spreadsheet");
+	assert.equal(
+		detectArtifactKind([{ name: "jarvis__export_query", status: "completed" }]),
+		"spreadsheet"
+	);
+});
+
+test("image: the verified native imagegen tool, never the stale 'image' name", () => {
+	assert.equal(detectArtifactKind([{ name: "imagegen", status: "running" }]), "image");
+	// "image" is NOT a real tool_name (verified: absent from jarvis/tools/
+	// registry.py and the agent runtime's own native tool set) — it must not
+	// light the card, or a stray unrelated tool literally named "image" would.
+	assert.equal(detectArtifactKind([{ name: "image", status: "running" }]), null);
+	assert.equal(detectArtifactKind([{ name: "jarvis__image", status: "running" }]), null);
+});
+
+test("an unrecognised tool name never lights a kind", () => {
+	assert.equal(detectArtifactKind([{ name: "bash", status: "running" }]), null);
+	assert.equal(detectArtifactKind([{ name: "canvas", status: "running" }]), null);
+	assert.equal(detectArtifactKind([{ name: "run_method", status: "running" }]), null);
+});
+
+test("the first recognised write tool in call order decides the kind", () => {
+	assert.equal(
+		detectArtifactKind([
+			{ name: "get_schema", status: "completed" },
+			{ name: "export_excel", status: "completed" },
+			{ name: "download_pdf", status: "running" },
+		]),
+		"spreadsheet"
+	);
+});
+
+// ---- adaptive copy ----------------------------------------------------------
+
+test("every kind has a title, and only the four kinds", () => {
+	assert.deepEqual(Object.keys(ARTIFACT_TITLES).sort(), [
+		"dashboard",
+		"image",
+		"pdf",
+		"spreadsheet",
+	]);
+	assert.equal(ARTIFACT_TITLES.dashboard, "Building your dashboard");
+	assert.equal(ARTIFACT_TITLES.pdf, "Creating your PDF");
+	assert.equal(ARTIFACT_TITLES.spreadsheet, "Exporting your spreadsheet");
+	assert.equal(ARTIFACT_TITLES.image, "Generating your image");
+});
+
+// ---- phase mapping: generalized, but wraps dashboardBuildPhase, never forks ----
+
+test("artifactPhaseList picks the dashboard's own labels for dashboard, the generalized four otherwise", () => {
+	assert.equal(artifactPhaseList("pdf"), ARTIFACT_BUILD_PHASES);
+	assert.equal(artifactPhaseList("spreadsheet"), ARTIFACT_BUILD_PHASES);
+	assert.equal(artifactPhaseList("image"), ARTIFACT_BUILD_PHASES);
+	assert.deepEqual(
+		ARTIFACT_BUILD_PHASES.map((p) => p.label),
+		["Understanding", "Fetching data", "Composing", "Delivering"]
+	);
+});
+
+test("artifactBuildPhase(null, …) reports null — no kind, no phase", () => {
+	assert.equal(
+		artifactBuildPhase(null, { activeTools: [], statusPhase: null, waiting: true }),
+		null
+	);
+});
+
+test("a pdf turn: waiting -> understanding, a data tool -> fetching, the write tool -> delivering", () => {
+	assert.equal(
+		artifactBuildPhase("pdf", { activeTools: [], statusPhase: null, waiting: true }),
+		"understanding"
+	);
+	assert.equal(
+		artifactBuildPhase("pdf", {
+			activeTools: [{ name: "jarvis__get_schema", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"querying"
+	);
+	assert.equal(
+		artifactBuildPhase("pdf", {
+			activeTools: [{ name: "jarvis__download_pdf", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+});
+
+test("a spreadsheet turn's write tool (export_excel/export_query) lights the last phase", () => {
+	assert.equal(
+		artifactBuildPhase("spreadsheet", {
+			activeTools: [{ name: "export_excel", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+	assert.equal(
+		artifactBuildPhase("spreadsheet", {
+			activeTools: [{ name: "jarvis__export_query", status: "completed" }],
+			statusPhase: "analyzing",
+			waiting: false,
+		}),
+		"publishing"
+	);
+});
+
+test("an image turn's write tool (imagegen) lights the last phase", () => {
+	assert.equal(
+		artifactBuildPhase("image", {
+			activeTools: [{ name: "imagegen", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+});
+
+test("a dashboard turn still reads dashboardBuildPhase's own tool sets unchanged (save_dashboard, canvas)", () => {
+	assert.equal(
+		artifactBuildPhase("dashboard", {
+			activeTools: [{ name: "jarvis__save_dashboard", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+	// export_excel is NOT one of dashboardBuildCard.js's own write tools — a
+	// dashboard-origin turn reads unchanged, so this stays "Composing", never
+	// "Delivering", proving the two tool sets were not merged for dashboard.
+	assert.equal(
+		artifactBuildPhase("dashboard", {
+			activeTools: [{ name: "export_excel", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"composing"
+	);
+});
+
+test("phaseTickIndex ticks the generalized phases when passed explicitly", () => {
+	assert.equal(phaseTickIndex("understanding", ARTIFACT_BUILD_PHASES), 0);
+	assert.equal(phaseTickIndex("querying", ARTIFACT_BUILD_PHASES), 1);
+	assert.equal(phaseTickIndex("composing", ARTIFACT_BUILD_PHASES), 2);
+	assert.equal(phaseTickIndex("publishing", ARTIFACT_BUILD_PHASES), 3);
+	assert.equal(phaseTickIndex(null, ARTIFACT_BUILD_PHASES), -1);
+});
+
+// ---- ChatView wiring: source-fenced, the same precedent as dashboardBuildCard.test.js ----
+
+test("ChatView imports the artifact-card helpers and detects the kind from real activity", () => {
+	assert.match(
+		chatSrc,
+		/import \{\s*ARTIFACT_TITLES,\s*artifactBuildPhase,\s*artifactPhaseList,\s*detectArtifactKind,\s*\} from "@\/lib\/artifactActivityCard";/
+	);
+	const gate = fnBody(chatSrc, "const artifactKind = computed(");
+	assert.match(gate, /detectArtifactKind\(activeTools\.value,/);
+	assert.match(gate, /dashboardTurn: dashboardBuildTurn\.value/);
+	// the goto morph line wins outright (jarvis#884): a goto turn produces no
+	// artifact, and artifactKind nulls out under the latch so the card and the
+	// morph line can never both render for one turn.
+	assert.match(gate, /gotoMorph\.value\s*\?\s*null\s*:/);
+});
+
+test("the common card is gated on artifactKind, mutually exclusive with the morph line and the generic activity line", () => {
+	assert.match(
+		chatSrc,
+		/v-if="artifactKind && \(activeTools\.length \|\| waiting\) && !queuedTurn"/
+	);
+	assert.match(
+		chatSrc,
+		/v-if="\s*\(activeTools\.length \|\| waiting\) &&\s*!queuedTurn &&\s*!artifactKind &&\s*!gotoMorph\s*"/
+	);
+});
+
+test("the goto morph line latches on a complete streaming goto and survives run:end (does not derive from m.streaming)", () => {
+	assert.match(chatSrc, /const gotoMorph = ref\(null\);/);
+	const watchBody = fnBody(chatSrc, "watch(streamingGoto, (g) => {");
+	assert.match(watchBody, /if \(g\) gotoMorph\.value = g;/);
+	assert.match(chatSrc, /v-if="gotoMorph && !queuedTurn"/);
+	// cleared on the next turn / an error / a stop / leaving the conversation —
+	// deliberately NOT cleared in run:end, since surviving that instant (up to
+	// navigation) is the entire point of the latch.
+	const runStart = chatSrc.slice(
+		chatSrc.indexOf('case "run:start":'),
+		chatSrc.indexOf('case "queue:position":')
+	);
+	assert.notEqual(chatSrc.indexOf('case "run:start":'), -1);
+	assert.notEqual(chatSrc.indexOf('case "queue:position":'), -1);
+	assert.match(runStart, /gotoMorph\.value = null;/);
+	const runErrorStart = chatSrc.indexOf('case "run:error":');
+	assert.notEqual(runErrorStart, -1);
+	const runError = chatSrc.slice(runErrorStart, runErrorStart + 2000);
+	assert.match(runError, /gotoMorph\.value = null;/);
+	const stopRun = fnBody(chatSrc, "function stopRun() {");
+	assert.match(stopRun, /gotoMorph\.value = null;/);
+	const resetRunState = fnBody(chatSrc, "function resetRunState() {");
+	assert.match(resetRunState, /gotoMorph\.value = null;/);
+	const runEnd = chatSrc.slice(
+		chatSrc.indexOf('case "run:end": {'),
+		chatSrc.indexOf('case "message:enriched": {')
+	);
+	assert.doesNotMatch(runEnd, /gotoMorph\.value = null;/);
+});

--- a/frontend/src/lib/artifactActivityCard.test.js
+++ b/frontend/src/lib/artifactActivityCard.test.js
@@ -276,15 +276,20 @@ test("the goto morph line latches on a complete streaming goto and survives run:
 	);
 	assert.notEqual(chatSrc.indexOf('case "run:start":'), -1);
 	assert.notEqual(chatSrc.indexOf('case "queue:position":'), -1);
-	assert.match(runStart, /gotoMorph\.value = null;/);
+	// every clear site goes through dropGotoMorph(), which also cancels the
+	// pending hold-navigation timer - a cleared latch with a live timer would
+	// still redirect a user who moved on
+	const dropFn = fnBody(chatSrc, "function dropGotoMorph() {");
+	assert.match(dropFn, /clearTimeout\(gotoNavTimer\)/);
+	assert.match(dropFn, /gotoMorph\.value = null;/);
+	assert.match(chatSrc, /onUnmounted\(dropGotoMorph\);/);
+	assert.match(runStart, /dropGotoMorph\(\);/);
 	const runErrorStart = chatSrc.indexOf('case "run:error":');
 	assert.notEqual(runErrorStart, -1);
 	const runError = chatSrc.slice(runErrorStart, runErrorStart + 2000);
-	assert.match(runError, /gotoMorph\.value = null;/);
+	assert.match(runError, /dropGotoMorph\(\);/);
 	const stopRun = fnBody(chatSrc, "function stopRun() {");
-	assert.match(stopRun, /gotoMorph\.value = null;/);
-	const resetRunState = fnBody(chatSrc, "function resetRunState() {");
-	assert.match(resetRunState, /gotoMorph\.value = null;/);
+	assert.match(stopRun, /dropGotoMorph\(\);/);
 	// run:end is the one path that can EITHER navigate (this exact terminal is
 	// the one that fires gotoDashboards) or not (a second tab that lost the
 	// localStorage stamp race, an errored/stopped row, or a was_recovered
@@ -297,12 +302,19 @@ test("the goto morph line latches on a complete streaming goto and survives run:
 		chatSrc.indexOf('case "message:enriched": {')
 	);
 	assert.match(runEnd, /let redirected = false;/);
-	assert.match(runEnd, /redirected = true;\s*\n\s*gotoDashboards\(goto\.prompt\);/);
-	assert.match(runEnd, /if \(!redirected\) gotoMorph\.value = null;/);
+	// the navigating terminal latches explicitly (the block can land WITH the
+	// terminal, unseen by the streaming watcher) and holds ~1s so the morph
+	// line gets real screen time - except under prefers-reduced-motion, where
+	// it navigates at once (there is no animation to show)
+	assert.match(runEnd, /redirected = true;/);
+	assert.match(runEnd, /gotoMorph\.value = goto;/);
+	assert.match(runEnd, /prefers-reduced-motion/);
+	assert.match(runEnd, /GOTO_MORPH_HOLD_MS/);
+	assert.match(runEnd, /if \(gotoMorph\.value\) gotoDashboards\(goto\.prompt\);/);
+	assert.match(runEnd, /if \(!redirected\) dropGotoMorph\(\);/);
 	// the unconditional clear must come AFTER the redirect gate, not before it
 	assert.ok(
-		runEnd.indexOf("if (!redirected) gotoMorph.value = null;") >
-			runEnd.indexOf("redirected = true;"),
+		runEnd.indexOf("if (!redirected) dropGotoMorph();") > runEnd.indexOf("redirected = true;"),
 		"the redirected check must run after the redirect branch, not race it"
 	);
 });

--- a/frontend/src/lib/chatBlocks.js
+++ b/frontend/src/lib/chatBlocks.js
@@ -5,9 +5,10 @@
  * A reply is not only prose. The agent also emits fenced blocks that OTHER
  * surfaces render as real UI: the draft summary card (```jarvis-action), the
  * confirmation card (```confirm), the clarifying question (```jarvis-ask), the
- * suggestion cards, the skill/macro markers and the charts. Every one of them
- * must be cut out of the markdown body, or the same payload would be drawn
- * twice: once as its card, once as a raw code block underneath it.
+ * suggestion cards, the skill/macro markers, the charts, and the redirect to
+ * another page (```jarvis-goto). Every one of them must be cut out of the
+ * markdown body, or the same payload would be drawn twice: once as its card,
+ * once as a raw code block underneath it.
  *
  * The subtle part is STREAMING. The closing fence is the last thing to arrive,
  * so for as long as a block is still being written there is nothing for a
@@ -35,6 +36,7 @@ export const BLOCK_TAGS = [
 	"jarvis-skill",
 	"jarvis-macro",
 	"jarvis-chart",
+	"jarvis-goto",
 ];
 
 // Completed blocks. `mermaid` is special: only the xychart-beta variant is a

--- a/frontend/src/lib/chatBlocks.spec.js
+++ b/frontend/src/lib/chatBlocks.spec.js
@@ -24,6 +24,12 @@ describe("stripBlocks, settled reply", () => {
 		}
 	});
 
+	it("removes a settled jarvis-goto block (jarvis#884: rendered as the redirect card, not raw JSON)", () => {
+		const text =
+			'Sure thing.\n\n```jarvis-goto\n{"page":"dashboards","prompt":"Monthly sales"}\n```\n\nOne moment.';
+		expect(stripBlocks(text)).toBe("Sure thing.\n\nOne moment.");
+	});
+
 	it("removes a jarvis xychart but keeps an ordinary mermaid diagram", () => {
 		const chart = "```mermaid\nxychart-beta\n  title x\n```";
 		const diagram = "```mermaid\ngraph TD;\n  A-->B;\n```";
@@ -57,6 +63,11 @@ describe("stripBlocks, mid-stream", () => {
 			const text = "prose\n\n```" + tag + '\n{"half":';
 			expect(stripBlocks(text, true)).toBe("prose");
 		}
+	});
+
+	it("holds an unterminated jarvis-goto block, so a mid-stream reply never flashes the raw redirect JSON", () => {
+		const text = 'One sec.\n\n```jarvis-goto\n{"page":"dashboards","prompt":"Mon';
+		expect(stripBlocks(text, true)).toBe("One sec.");
 	});
 
 	it("holds a fence whose language tag is still being typed", () => {

--- a/frontend/src/lib/chatGoto.js
+++ b/frontend/src/lib/chatGoto.js
@@ -1,0 +1,36 @@
+// The ```jarvis-goto contract, as a plain function: parse a fenced block into
+// a normalised {page, prompt} pair, or null.
+//
+// Extracted the same way chatAsk.js is, so ChatView.vue's gotoOf(m) stays a
+// thin cached wrapper and the parsing itself is unit-testable without
+// mounting the view (jarvis#884: dashboard builds move off the agent canvas,
+// and the agent redirects here instead of building inline).
+//
+// This is deliberately an ALLOWLIST, not generic navigation: the agent picks
+// a request restatement, not an arbitrary route. Today the only destination
+// is "dashboards"; a block naming anything else is not a valid goto and is
+// left for the raw markdown fallback to show.
+
+export const GOTO_RE = /```jarvis-goto[ \t]*\n([\s\S]*?)```/;
+
+const ALLOWED_PAGES = new Set(["dashboards"]);
+
+/**
+ * Parse the first ```jarvis-goto block out of a message.
+ * @param {string} content raw assistant message text
+ * @returns {{page: string, prompt: string}|null}
+ */
+export function parseGoto(content) {
+	const mt = String(content || "").match(GOTO_RE);
+	if (!mt) return null;
+	try {
+		const a = JSON.parse(mt[1].trim());
+		if (!a || typeof a !== "object") return null;
+		const page = String(a.page || "").trim();
+		const prompt = String(a.prompt || "").trim();
+		if (!ALLOWED_PAGES.has(page) || !prompt) return null;
+		return { page, prompt };
+	} catch (e) {
+		return null;
+	}
+}

--- a/frontend/src/lib/chatGoto.test.js
+++ b/frontend/src/lib/chatGoto.test.js
@@ -1,0 +1,120 @@
+// Real executable tests for the ```jarvis-goto contract (chatGoto.js), plus
+// source assertions fencing how ChatView wires it up. Plain node built-ins
+// (node:test + node:assert), the chatAsk.test.js / dashboardBuildCard.test.js
+// convention: a .vue SFC cannot be imported into this runner, so its wiring is
+// checked by reading the source text instead.
+//
+// What is being defended: main chat no longer builds a dashboard inline
+// (jarvis#884) - it restates the request and points here with a fenced
+// ```jarvis-goto block, ChatView stashes the prompt and redirects to the
+// Dashboards builder. The parser is an ALLOWLIST (only "dashboards" is a
+// valid destination today), never generic navigation, and the redirect must
+// fire at most once per message even though the block is real UI on every
+// later visit to the transcript.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseGoto, GOTO_RE } from "./chatGoto.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const chatViewSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+const fence = (body) => "Some lead-in.\n\n```jarvis-goto\n" + body + "\n```";
+
+const fnBody = (src, decl) => {
+	const start = src.indexOf(decl);
+	assert.notEqual(start, -1, `source must still define ${decl}`);
+	const end = src.indexOf("\n}", start + decl.length);
+	assert.notEqual(end, -1, `${decl} must close at the top level`);
+	return src.slice(start, end);
+};
+
+// ---- parsing ---------------------------------------------------------------
+
+test("parses a valid dashboards redirect", () => {
+	const goto = parseGoto(fence('{"page":"dashboards","prompt":"Monthly sales by territory"}'));
+	assert.deepEqual(goto, { page: "dashboards", prompt: "Monthly sales by territory" });
+});
+
+test("only dashboards is allowlisted - any other page parses to null", () => {
+	assert.equal(
+		parseGoto(fence('{"page":"triggers","prompt":"Warn me on overdue invoices"}')),
+		null
+	);
+	assert.equal(parseGoto(fence('{"page":"skills","prompt":"x"}')), null);
+	assert.equal(parseGoto(fence('{"prompt":"no page at all"}')), null);
+	assert.equal(parseGoto(fence('{"page":"","prompt":"blank page"}')), null);
+});
+
+test("prompt must be present and non-blank", () => {
+	assert.equal(parseGoto(fence('{"page":"dashboards"}')), null);
+	assert.equal(parseGoto(fence('{"page":"dashboards","prompt":""}')), null);
+	assert.equal(parseGoto(fence('{"page":"dashboards","prompt":"   "}')), null);
+});
+
+test("no block, malformed JSON, and a non-object payload all parse to null", () => {
+	assert.equal(parseGoto("just prose"), null);
+	assert.equal(parseGoto(""), null);
+	assert.equal(parseGoto(null), null);
+	assert.equal(parseGoto(fence("{not json")), null);
+	assert.equal(parseGoto(fence('"a string"')), null);
+	assert.equal(parseGoto(fence("[1,2,3]")), null);
+});
+
+test("an unterminated block does not parse (a half-streamed reply shows no card)", () => {
+	assert.equal(parseGoto('```jarvis-goto\n{"page":"dashboards","prompt":"x"'), null);
+});
+
+test("GOTO_RE matches exactly the fenced block chatBlocks.js strips", () => {
+	assert.match(fence('{"page":"dashboards","prompt":"x"}'), GOTO_RE);
+});
+
+// ---- source fences: BLOCK_TAGS, the card, and the one-shot auto-redirect --
+
+test("chatBlocks strips jarvis-goto from the visible prose", () => {
+	const blocksSrc = fs.readFileSync(path.join(HERE, "chatBlocks.js"), "utf8");
+	assert.match(blocksSrc, /"jarvis-goto",/);
+});
+
+test("ChatView parses goto through the shared module, not a private copy", () => {
+	assert.match(chatViewSrc, /import \{ parseGoto \} from "@\/lib\/chatGoto";/);
+	const gotoOf = fnBody(chatViewSrc, "function gotoOf(m)");
+	assert.match(gotoOf, /return parseGoto\(\(m && m\.content\) \|\| ""\);/);
+});
+
+test("the card renders the restated prompt and one button that hands off to the builder", () => {
+	assert.match(chatViewSrc, /v-if="gotoOf\(m\)" class="jv-macrocard"/);
+	assert.match(chatViewSrc, /Continue in Dashboards/);
+	// prettier may wrap the interpolation onto its own line, so match loosely
+	assert.match(chatViewSrc, /\{\{\s*gotoOf\(m\)\.prompt\s*\}\}/);
+	assert.match(chatViewSrc, /@click="gotoDashboards\(gotoOf\(m\)\.prompt\)"/);
+});
+
+test("gotoDashboards stashes the prefill and navigates to the builder", () => {
+	assert.match(
+		chatViewSrc,
+		/import \{ setDashboardPrefill \} from "@\/composables\/dashboardPrefill";/
+	);
+	const fn = fnBody(chatViewSrc, "function gotoDashboards(prompt)");
+	assert.match(fn, /setDashboardPrefill\(\{ text: prompt, autoSend: true \}\);/);
+	assert.match(fn, /router\.push\("\/dashboards"\);/);
+});
+
+test("run:end auto-fires the redirect at most once, and never for an errored or stopped turn", () => {
+	const runEnd = chatViewSrc.slice(
+		chatViewSrc.indexOf('case "run:end": {'),
+		chatViewSrc.indexOf('case "message:enriched": {')
+	);
+	assert.match(runEnd, /if \(m && !m\.error && !m\.stopped\) \{/);
+	assert.match(runEnd, /const goto = gotoOf\(m\);/);
+	// durable stamp, keyed per message, checked before it is set
+	assert.match(runEnd, /const firedKey = "jarvis:goto-fired:" \+ m\.name;/);
+	const stampIdx = runEnd.indexOf("localStorage.getItem(firedKey)");
+	const setIdx = runEnd.indexOf("localStorage.setItem(firedKey,");
+	const gotoIdx = runEnd.indexOf("gotoDashboards(goto.prompt);");
+	assert.notEqual(stampIdx, -1);
+	assert.ok(stampIdx < setIdx, "the stamp must be checked before it is written");
+	assert.ok(setIdx < gotoIdx, "the stamp must be written before the redirect fires");
+});

--- a/frontend/src/lib/dashboardBuildCard.js
+++ b/frontend/src/lib/dashboardBuildCard.js
@@ -106,8 +106,10 @@ const DATA_TOOLS = new Set([
 // of these are confirmed to fire for a dashboard build (only the finished
 // message's `canvas` array is a verified "published" signal), so a name in
 // here only lights the Publishing tick EARLY — it is never required for the
-// card to reach the finished state.
-const WRITE_TOOLS = new Set(["canvas", "bash", "exec", "image"]);
+// card to reach the finished state. `save_dashboard` is the new builder-tool
+// path (jarvis#884): the agent no longer builds on the agent canvas, it
+// saves a Jarvis Dashboard row directly, so that tool is the write signal now.
+const WRITE_TOOLS = new Set(["canvas", "bash", "exec", "image", "save_dashboard"]);
 
 export const DASHBOARD_BUILD_PHASES = [
 	{ key: "understanding", label: "Understanding" },

--- a/frontend/src/lib/dashboardBuildCard.js
+++ b/frontend/src/lib/dashboardBuildCard.js
@@ -118,7 +118,7 @@ export const DASHBOARD_BUILD_PHASES = [
 	{ key: "publishing", label: "Publishing" },
 ];
 
-function toolBaseName(name) {
+export function toolBaseName(name) {
 	return String(name || "").replace(/^jarvis__/, "");
 }
 
@@ -134,23 +134,34 @@ function toolBaseName(name) {
  * is in — that reports `null` rather than defaulting to "Understanding",
  * because this mount has not actually observed the start.
  *
+ * `dataTools`/`writeTools` default to this file's own dashboard-specific
+ * sets, so every existing caller (this module's tests, DashboardChatPane.vue)
+ * keeps its exact behaviour unchanged. artifactActivityCard.js (jarvis#884)
+ * passes its own generalized sets instead of forking this function, so a
+ * pdf/spreadsheet/image turn reads the identical phase logic through the
+ * same real activeTools/statusPhase/waiting signals.
+ *
  * @param {{activeTools: Array<{name?: string, status?: string}>, statusPhase: string|null, waiting: boolean}} arg
+ * @param {{dataTools?: Set<string>, writeTools?: Set<string>}} [toolSets]
  * @returns {string|null} one of DASHBOARD_BUILD_PHASES' keys, or null
  */
-export function dashboardBuildPhase({ activeTools, statusPhase, waiting }) {
+export function dashboardBuildPhase(
+	{ activeTools, statusPhase, waiting },
+	{ dataTools = DATA_TOOLS, writeTools = WRITE_TOOLS } = {}
+) {
 	const tools = Array.isArray(activeTools) ? activeTools : [];
 	const running = [...tools].reverse().find((t) => t && t.status === "running");
 	if (running) {
 		const base = toolBaseName(running.name);
-		if (WRITE_TOOLS.has(base)) return "publishing";
-		if (DATA_TOOLS.has(base)) return "querying";
+		if (writeTools.has(base)) return "publishing";
+		if (dataTools.has(base)) return "querying";
 		// An unrecognised tool while the turn is a confirmed dashboard build is
 		// still real activity, just not one this map can name precisely —
 		// "Composing" is the safest of the four to sit on, never "done".
 		return "composing";
 	}
 	if (tools.length) {
-		const sawWrite = tools.some((t) => WRITE_TOOLS.has(toolBaseName(t && t.name)));
+		const sawWrite = tools.some((t) => writeTools.has(toolBaseName(t && t.name)));
 		if (sawWrite) return "publishing";
 		return "composing"; // results are in (statusPhase "analyzing") or the reply is streaming
 	}
@@ -158,9 +169,13 @@ export function dashboardBuildPhase({ activeTools, statusPhase, waiting }) {
 	return null;
 }
 
-/** Index into DASHBOARD_BUILD_PHASES for tick rendering; -1 when indeterminate. */
-export function phaseTickIndex(phase) {
-	return DASHBOARD_BUILD_PHASES.findIndex((p) => p.key === phase);
+/**
+ * Index into `phases` for tick rendering; -1 when indeterminate. Defaults to
+ * DASHBOARD_BUILD_PHASES so every existing caller is unchanged; pass the
+ * generalized artifact phase list to tick against that instead.
+ */
+export function phaseTickIndex(phase, phases = DASHBOARD_BUILD_PHASES) {
+	return phases.findIndex((p) => p.key === phase);
 }
 
 // ── the finished canvas -> a compact clickable thumbnail ────────────────────

--- a/frontend/src/lib/dashboardBuildCard.test.js
+++ b/frontend/src/lib/dashboardBuildCard.test.js
@@ -170,6 +170,46 @@ test("an unmapped tool name while a build is confirmed stays Composing, not done
 	);
 });
 
+test("jarvis#884: dataTools/writeTools are overridable so artifactActivityCard.js can wrap this instead of forking it", () => {
+	const customSets = {
+		dataTools: new Set(["custom_read"]),
+		writeTools: new Set(["custom_write"]),
+	};
+	assert.equal(
+		dashboardBuildPhase(
+			{
+				activeTools: [{ name: "custom_read", status: "running" }],
+				statusPhase: null,
+				waiting: false,
+			},
+			customSets
+		),
+		"querying"
+	);
+	assert.equal(
+		dashboardBuildPhase(
+			{
+				activeTools: [{ name: "custom_write", status: "running" }],
+				statusPhase: null,
+				waiting: false,
+			},
+			customSets
+		),
+		"publishing"
+	);
+	// the DEFAULT sets are unchanged when no override is passed — dashboard
+	// callers (this file's own tests, DashboardChatPane.vue) keep behaving
+	// exactly as before
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "query", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"querying"
+	);
+});
+
 test("phaseTickIndex orders the four phases and reports -1 for indeterminate", () => {
 	assert.equal(phaseTickIndex("understanding"), 0);
 	assert.equal(phaseTickIndex("querying"), 1);
@@ -221,29 +261,23 @@ test("a custom source viewport is honoured", () => {
 });
 
 // ---- ChatView wiring: source-fenced, the same precedent as dashboardOpen.test.js ----
+//
+// The live card itself (jarvis#884) moved to the common artifact activity
+// card — see artifactActivityCard.test.js for its wiring fences. What stays
+// true here is narrower: ChatView still imports the thumbnail/origin helpers
+// from THIS module, and dashboardBuildTurn (the builder-origin gate) is still
+// computed the same way, since it is now an INPUT to detectArtifactKind
+// rather than a direct template gate.
 
-test("ChatView imports the build-card helpers and gates the live card on the turn", () => {
+test("ChatView imports the thumbnail/origin helpers from dashboardBuildCard, not a private copy", () => {
 	assert.match(
 		chatSrc,
-		/import \{\s*DASHBOARD_BUILD_PHASES,\s*dashboardBuildPhase,\s*dashboardThumbnailTransform,\s*isDashboardBuildTurn,\s*isDashboardCanvas,\s*phaseTickIndex,\s*\} from "@\/lib\/dashboardBuildCard";/
+		/import \{\s*dashboardThumbnailTransform,\s*isDashboardBuildTurn,\s*isDashboardCanvas,\s*phaseTickIndex,\s*\} from "@\/lib\/dashboardBuildCard";/
 	);
 	const gate = fnBody(chatSrc, "const dashboardBuildTurn = computed(");
 	assert.match(gate, /originPage: originPage\.value,/);
 	assert.match(gate, /originOf: originOf\.value,/);
 	assert.match(gate, /conversation: currentId\.value,/);
-	// the live card and the generic activity line are mutually exclusive —
-	// exactly one of them can render for a given turn. The live card stays
-	// origin-only: a main-chat build has no pre-canvas signal to key on (see
-	// dashboardBuildCard.js's file header), so it degrades to no card rather
-	// than guessing.
-	assert.match(
-		chatSrc,
-		/v-if="dashboardBuildTurn && \(activeTools\.length \|\| waiting\) && !queuedTurn"/
-	);
-	assert.match(
-		chatSrc,
-		/v-if="\s*\(activeTools\.length \|\| waiting\) && !queuedTurn && !dashboardBuildTurn\s*"/
-	);
 });
 
 test("canPromoteDashCanvas combines the builder-origin rule with canvas-presence, and the click-through gates on it too", () => {

--- a/frontend/src/lib/dashboardBuildCard.test.js
+++ b/frontend/src/lib/dashboardBuildCard.test.js
@@ -120,6 +120,36 @@ test("a write-ish tool running or already seen -> Publishing", () => {
 	);
 });
 
+test("jarvis#884: save_dashboard also lights Publishing, with or without the jarvis__ registry prefix", () => {
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "save_dashboard", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [{ name: "jarvis__save_dashboard", status: "running" }],
+			statusPhase: null,
+			waiting: false,
+		}),
+		"publishing"
+	);
+	assert.equal(
+		dashboardBuildPhase({
+			activeTools: [
+				{ name: "query", status: "completed" },
+				{ name: "jarvis__save_dashboard", status: "completed" },
+			],
+			statusPhase: "analyzing",
+			waiting: false,
+		}),
+		"publishing"
+	);
+});
+
 test("joining a turn already in flight reports null, not a guess", () => {
 	// activeTools empty, not waiting either (this mount only just mounted and
 	// hasn't seen the run:start / tool:start that already happened elsewhere)

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -920,9 +920,11 @@ test("the two identities are bound separately, and the adoption ends where they 
 		/const adoptedRow = useStorage\(`jarvis-dash-adopted-\$\{session\.user \|\| "anon"\}`, ""\);/
 	);
 	// it ends exactly where the row and the canvas become one document again:
-	// the first successful Save, an ?edit= load, or a builder that was cleared
+	// the first successful Save, an ?edit= load, or a builder that was cleared.
+	// loadEdit's own copy moved into applyEditDetail (jarvis#884), which
+	// onDashboardSaved (the pane's own build) also calls directly.
 	assert.match(fnBody(pageSrc, "function onSaved("), /adoptedRow\.value = "";/);
-	assert.match(fnBody(pageSrc, "async function loadEdit("), /adoptedRow\.value = "";/);
+	assert.match(fnBody(pageSrc, "function applyEditDetail("), /adoptedRow\.value = "";/);
 	assert.match(fnBody(pageSrc, "function clearBuilder("), /adoptedRow\.value = "";/);
 	// the send itself takes the pane's prop, so the suppression reaches the agent
 	assert.match(paneSrc, /editingName: \{ type: String, default: "" \},/);
@@ -1073,8 +1075,9 @@ test("an adoption whose artifact is gone falls back to the row it adopted", () =
 	);
 	assert.match(onCanvas, /if \(restore && failedRestores\.has\(message_id\)\) return false;/);
 	// loadEdit is what ends the adoption: the canvas becomes the row's own html,
-	// so the two documents are one again
-	const edit = fnBody(pageSrc, "async function loadEdit(");
+	// so the two documents are one again. Its own state-setting moved into
+	// applyEditDetail (jarvis#884), which it still reaches via confirmDiscard.
+	const edit = fnBody(pageSrc, "function applyEditDetail(");
 	assert.match(edit, /adoptedRow\.value = "";/);
 	assert.match(edit, /canvasMsg\.value = "";/);
 	// a live frame's failure is untouched — it toasts, and there is no stale

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -781,8 +781,14 @@ test("a pending promotion holds the pane's restore off, exactly as ?edit= does",
 	const body = watcher.slice(0, watcher.indexOf("\n);"));
 	assert.doesNotMatch(body, /promotionPending\.value = true;/);
 	// ...and a mount that will NOT promote releases the setup-time hold, or the
-	// pane's restore stays blocked for the life of the page
-	assert.match(pageSrc, /promotionPending\.value = false;\n\t\tnormalMount\(\);/);
+	// pane's restore stays blocked for the life of the page. Since the
+	// jarvis-goto hand-off (#884), that branch then forks: a goto prefill
+	// starts a CLEAN builder (never the sticky editing restore), everything
+	// else restores as before - but the hold release always comes first.
+	assert.match(
+		pageSrc,
+		/promotionPending\.value = false;\n\t\tif \(gotoText\) \{[\s\S]*?clearBuilder\(\);\n\t\t\} else \{\n\t\t\tnormalMount\(\);\n\t\t\}/
+	);
 });
 
 test("?edit= wins over ?chat=, and says so", () => {

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -114,9 +114,16 @@ test("the page records WHICH message is on the canvas, under the same key", () =
 			onCanvas.indexOf("canvasMsg.value = message_id;"),
 		"the id is recorded for the html that was rendered"
 	);
-	// and dropped whenever the canvas stops being a chat artifact
+	// and dropped whenever the canvas stops being a chat artifact. loadEdit's
+	// own state-setting (jarvis#884) moved into applyEditDetail, which it calls
+	// from inside the discard confirm, so the same guarantee holds, just in a
+	// different function.
 	assert.match(fnBody(pageSrc, "function clearBuilder("), /canvasMsg\.value = "";/);
-	assert.match(fnBody(pageSrc, "async function loadEdit("), /canvasMsg\.value = "";/);
+	assert.match(fnBody(pageSrc, "function applyEditDetail("), /canvasMsg\.value = "";/);
+	assert.match(
+		fnBody(pageSrc, "async function loadEdit("),
+		/applyEditDetail\(d, \{ deepLink \}\);/
+	);
 });
 
 test("a restore never overwrites a live canvas, an ?edit target or a promotion", () => {
@@ -188,8 +195,10 @@ test("a remount restores WHAT WAS BEING EDITED, not just the pixels", () => {
 		pageSrc,
 		/if \(editSeed\.value\) loadEdit\(editSeed\.value, \{ deepLink: !!routeEdit \}\);/
 	);
-	// written by both paths that make this page "the editor of X"...
-	assert.match(fnBody(pageSrc, "async function loadEdit("), /editingSticky\.value = d\.name;/);
+	// written by both paths that make this page "the editor of X"... loadEdit's
+	// own copy moved into applyEditDetail (jarvis#884), which onDashboardSaved
+	// (the pane's own build) also calls directly, bypassing the confirm.
+	assert.match(fnBody(pageSrc, "function applyEditDetail("), /editingSticky\.value = d\.name;/);
 	assert.match(fnBody(pageSrc, "function onSaved("), /editingSticky\.value = detail\.name;/);
 	// ...and dropped by every path that stops editing it
 	assert.match(fnBody(pageSrc, "function clearBuilder("), /editingSticky\.value = "";/);

--- a/frontend/src/pages/dashboards/DashboardChatPane.spec.js
+++ b/frontend/src/pages/dashboards/DashboardChatPane.spec.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#884 - dashboard builds no longer land as a canvas artifact; the new
+ * save_dashboard tool saves a Jarvis Dashboard row directly and publishes a
+ * realtime {kind: "dashboard", conversation_id, name} frame on the SAME
+ * jarvis:event channel every other turn frame already rides. This pins that
+ * the pane recognises the new frame kind, gates it on OUR conversation the
+ * same way every other frame here does, and bubbles it up as emit("dashboard",
+ * {name}) for the page to load.
+ */
+
+// Deterministic per-user storage keys without touching real localStorage
+// (WikiTab.spec.js precedent: jsdom's localStorage is not reliably usable
+// here). The pane's conversation slot is seeded to a known id up front so a
+// realtime frame naming it passes the "OUR conversation" gate.
+vi.mock("@vueuse/core", async (importOriginal) => {
+	const actual = await importOriginal();
+	const { ref } = await import("vue");
+	return {
+		...actual,
+		useStorage: (key, initial) => ref(key.startsWith("jarvis-dash-conv-") ? "conv1" : initial),
+	};
+});
+
+vi.mock("@/data/session", () => ({ session: { user: "u@x.com" } }));
+vi.mock("@/branding", () => ({ agentName: "Jarvis" }));
+
+vi.mock("frappe-ui", () => ({
+	Button: {
+		name: "Button",
+		props: ["label", "disabled", "loading", "variant", "iconLeft"],
+		emits: ["click"],
+		template: `<button :disabled="disabled" @click="$emit('click')">{{ label }}</button>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	TabButtons: { name: "TabButtons", props: ["buttons", "modelValue"], template: "<div />" },
+	toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/components/JvSpinner.vue", () => ({
+	default: { name: "JvSpinner", template: "<i />" },
+}));
+vi.mock("@/components/VoiceRecorder.vue", () => ({
+	default: { name: "VoiceRecorder", template: "<i />" },
+}));
+vi.mock("@/components/chat/AskCard.vue", () => ({
+	default: { name: "AskCard", template: "<div />" },
+}));
+vi.mock("@/markdown", () => ({ renderMarkdown: (s) => s }));
+
+const api = vi.hoisted(() => ({
+	sendDashboardChat: vi.fn(async () => ({ ok: true, conversation_id: "conv1" })),
+	getDashboardConversation: vi.fn(async () => ({ messages: [] })),
+}));
+vi.mock("@/api/dashboards", () => api);
+vi.mock("@/api", () => ({
+	listPendingConfirmations: vi.fn(async () => ({ ok: true, data: { pending: [] } })),
+	confirmTool: vi.fn(),
+	dismissTool: vi.fn(),
+}));
+
+import DashboardChatPane from "./DashboardChatPane.vue";
+
+// useJarvisTheme() (AskCard's paletteVars binding) reads the OS color scheme
+// on its first call; jsdom has no matchMedia at all.
+window.matchMedia =
+	window.matchMedia ||
+	(() => ({
+		matches: false,
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+	}));
+
+function fakeSocket() {
+	let handler = null;
+	return {
+		on: vi.fn((event, fn) => {
+			if (event === "jarvis:event") handler = fn;
+		}),
+		off: vi.fn(),
+		fire(payload) {
+			handler && handler(payload);
+		},
+	};
+}
+
+function mountPane() {
+	const socket = fakeSocket();
+	const wrapper = mount(DashboardChatPane, {
+		global: { provide: { $socket: socket } },
+	});
+	return { wrapper, socket };
+}
+
+describe('DashboardChatPane realtime: kind="dashboard"', () => {
+	beforeEach(() => {
+		api.sendDashboardChat.mockClear();
+		api.getDashboardConversation.mockClear();
+	});
+
+	it("emits dashboard with the saved row's name for OUR conversation", async () => {
+		const { wrapper, socket } = mountPane();
+		await flushPromises();
+		socket.fire({ kind: "dashboard", conversation_id: "conv1", name: "DASH-001" });
+		await flushPromises();
+		expect(wrapper.emitted("dashboard")).toEqual([[{ name: "DASH-001" }]]);
+	});
+
+	it("ignores a dashboard frame for a DIFFERENT conversation", async () => {
+		const { wrapper, socket } = mountPane();
+		await flushPromises();
+		socket.fire({ kind: "dashboard", conversation_id: "some-other-conv", name: "DASH-002" });
+		await flushPromises();
+		expect(wrapper.emitted("dashboard")).toBeUndefined();
+	});
+
+	it("never schedules a transcript refetch for a dashboard frame (canvas precedent)", async () => {
+		const { wrapper, socket } = mountPane();
+		await flushPromises();
+		api.getDashboardConversation.mockClear();
+		socket.fire({ kind: "dashboard", conversation_id: "conv1", name: "DASH-003" });
+		// scheduleRefetch debounces 300ms; give it a chance to fire and confirm it never does
+		await new Promise((r) => setTimeout(r, 350));
+		expect(api.getDashboardConversation).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -758,7 +758,15 @@ function onEvent(p) {
 			break;
 		}
 		case "tool:end": {
-			const t = activeTools.value.find((x) => x.id === p.tool_call_id);
+			// tool_call_id is optional on the wire; tool:start synthesized a
+			// fallback id for an id-less frame, so an id-less end must fall back
+			// too (latest running entry with the same name) or the entry stays
+			// "running" and the phase ticks freeze on it for the rest of the turn.
+			const t =
+				(p.tool_call_id && activeTools.value.find((x) => x.id === p.tool_call_id)) ||
+				[...activeTools.value]
+					.reverse()
+					.find((x) => x.name === p.tool_name && x.status === "running");
 			if (t) t.status = p.status || "completed";
 			break;
 		}

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -78,22 +78,45 @@
 					</div>
 				</template>
 
-				<!-- thinking indicator: subtle three-dot pulse while a run is active -->
+				<!-- build progress while a run is active: the same Understanding /
+				     Querying data / Composing / Publishing ticks main chat's live
+				     dashboard-build card shows, once real tool activity names a
+				     phase; a plain three-dot pulse while it is still indeterminate
+				     (a mount that joined a run already in flight, or one that
+				     hasn't seen its first tool yet). -->
 				<div
 					v-if="runActive"
 					role="status"
 					aria-live="polite"
-					class="flex items-center gap-2 pt-1"
+					class="flex items-center gap-3 pt-1"
 				>
-					<span class="flex gap-1" aria-hidden="true">
+					<template v-if="buildTickIndex >= 0">
 						<span
-							v-for="i in 3"
-							:key="i"
-							class="size-1.5 rounded-full bg-surface-gray-5 motion-safe:animate-pulse"
-							:style="{ animationDelay: (i - 1) * 0.18 + 's' }"
-						/>
-					</span>
-					<span class="text-xs text-ink-gray-5">Thinking…</span>
+							v-for="(ph, i) in DASHBOARD_BUILD_PHASES"
+							:key="ph.key"
+							class="flex items-center gap-1.5 text-xs"
+							:class="i <= buildTickIndex ? 'text-ink-gray-7' : 'text-ink-gray-4'"
+						>
+							<span
+								class="size-1.5 rounded-full"
+								:class="
+									i <= buildTickIndex ? 'bg-surface-gray-7' : 'bg-surface-gray-3'
+								"
+							/>
+							{{ ph.label }}
+						</span>
+					</template>
+					<template v-else>
+						<span class="flex gap-1" aria-hidden="true">
+							<span
+								v-for="i in 3"
+								:key="i"
+								class="size-1.5 rounded-full bg-surface-gray-5 motion-safe:animate-pulse"
+								:style="{ animationDelay: (i - 1) * 0.18 + 's' }"
+							/>
+						</span>
+						<span class="text-xs text-ink-gray-5">Thinking…</span>
+					</template>
 				</div>
 			</div>
 		</div>
@@ -218,10 +241,15 @@
 //                      clears storage and starts fresh.
 //   realtime         → "jarvis:event" frames for OUR conversation schedule a
 //                      debounced (300ms) get_conversation refetch; run:start
-//                      raises run-active, run:end / run:error clear it.
-//                      kind==="canvas" frames for our conversation bubble up
-//                      as emit("canvas", {message_id, items}) - the page pulls
-//                      the html artifact onto the canvas pane.
+//                      raises run-active (and starts tracking tool:start/end
+//                      for the phase ticks below), run:end / run:error clear
+//                      it. kind==="canvas" frames for our conversation bubble
+//                      up as emit("canvas", {message_id, items}) - the page
+//                      pulls the html artifact onto the canvas pane.
+//                      kind==="dashboard" frames (the new save_dashboard tool,
+//                      jarvis#884 - dashboards no longer land as a canvas
+//                      artifact) bubble up as emit("dashboard", {name}) - the
+//                      page loads that saved row as the current document.
 //   no socket        → (?nosocket / headless QA) a bounded refetch ladder after
 //                      each send stands in for the realtime frames.
 import { ref, computed, watch, nextTick, inject, onMounted, onBeforeUnmount } from "vue";
@@ -234,6 +262,11 @@ import AskCard from "@/components/chat/AskCard.vue";
 import { renderMarkdown } from "@/markdown";
 import { parseAsk } from "@/lib/chatAsk";
 import { builderCanvasFrame } from "@/lib/dashboardRestore";
+import {
+	DASHBOARD_BUILD_PHASES,
+	dashboardBuildPhase,
+	phaseTickIndex,
+} from "@/lib/dashboardBuildCard";
 import { useJarvisTheme } from "@/theme";
 import { session } from "@/data/session";
 import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards";
@@ -255,8 +288,10 @@ const props = defineProps({
 
 // canvas: {message_id, items[, restore]} for a canvas frame on our conversation
 // (restore = replayed from the loaded transcript, not a live socket frame);
-// activity: a run ended (the page may refresh lists); reset: New chat clicked.
-const emit = defineEmits(["canvas", "activity", "reset"]);
+// activity: a run ended (the page may refresh lists); reset: New chat clicked;
+// dashboard: {name} - the agent's save_dashboard tool saved a row this turn
+// (jarvis#884), so the page can load it as the current document.
+const emit = defineEmits(["canvas", "activity", "reset", "dashboard"]);
 
 const router = useRouter();
 const socket = inject("$socket", null);
@@ -512,6 +547,24 @@ const sending = ref(false);
 const draft = ref("");
 const box = ref(null);
 
+// ── build phase ticks (issue #884) ───────────────────────────────────────────
+// Same real signals ChatView keeps for its own "Working on it…" line and the
+// live dashboard-build card: tool:start/tool:end for OUR conversation ->
+// activeTools, and whether the run has started but not yet shown its first
+// tool. dashboardBuildPhase never actually reads statusPhase (only whether a
+// tool is running, has run, or nothing has happened yet), so it is passed
+// null here - this pane has no equivalent of ChatView's "analyzing" text.
+const activeTools = ref([]); // {id, name, status}[] for the run in progress
+const waitingFirstTool = ref(false); // true from run:start until the first tool:start
+const buildPhaseKey = computed(() =>
+	dashboardBuildPhase({
+		activeTools: activeTools.value,
+		statusPhase: null,
+		waiting: waitingFirstTool.value,
+	})
+);
+const buildTickIndex = computed(() => phaseTickIndex(buildPhaseKey.value));
+
 // Explicit data-mode toggle (goal requirement): "auto" = one of the questions
 // the agent asks before the first build (it no longer guesses from wording),
 // "static" = baked one-time report, "live" = declared view-time sources.
@@ -592,6 +645,12 @@ async function send() {
 			conversation.value = r.conversation_id;
 		}
 		runActive.value = true;
+		// This send's own optimistic start - a run:start frame for the same run
+		// arrives moments later and does the same reset, but the ticks should
+		// read "Understanding" from the instant Send is clicked, not lag behind
+		// the socket round trip.
+		activeTools.value = [];
+		waitingFirstTool.value = true;
 		nextTick(scrollBottom);
 		if (!socket) startNoSocketLadder();
 	} catch (e) {
@@ -674,18 +733,45 @@ function onEvent(p) {
 		emit("canvas", { message_id: p.message_id, items: p.items });
 		return;
 	}
+	// the agent's save_dashboard tool saved a row this turn (jarvis#884) - the
+	// page loads it as the current document, no discard confirm needed since
+	// it is this same chat's own build
+	if (p.kind === "dashboard") {
+		emit("dashboard", { name: p.name });
+		return;
+	}
 	// any frame for OUR conversation refreshes the transcript (debounced)
 	scheduleRefetch();
 	switch (p.kind) {
 		case "run:start":
 			runActive.value = true;
+			activeTools.value = [];
+			waitingFirstTool.value = true;
 			break;
+		case "tool:start": {
+			const id = p.tool_call_id || `${p.tool_name}-${activeTools.value.length}`;
+			activeTools.value = [
+				...activeTools.value,
+				{ id, name: p.tool_name, status: "running" },
+			];
+			waitingFirstTool.value = false;
+			break;
+		}
+		case "tool:end": {
+			const t = activeTools.value.find((x) => x.id === p.tool_call_id);
+			if (t) t.status = p.status || "completed";
+			break;
+		}
 		case "run:end":
 			runActive.value = false;
+			activeTools.value = [];
+			waitingFirstTool.value = false;
 			emit("activity");
 			break;
 		case "run:error":
 			runActive.value = false;
+			activeTools.value = [];
+			waitingFirstTool.value = false;
 			break;
 	}
 }

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -700,9 +700,7 @@ async function loadEdit(name, { deepLink = true } = {}) {
 
 // The chat pane just saved a dashboard (the new save_dashboard tool,
 // jarvis#884 - dashboard builds no longer land as a canvas artifact) and told
-// us its name over the realtime channel. This is the current chat's own
-// output, replacing the very canvas the builder already has on screen, so it
-// never needs the discard confirm loadEdit uses for every other target.
+// us its name over the realtime channel.
 async function onDashboardSaved({ name } = {}) {
 	if (!name) return;
 	let d = null;
@@ -715,7 +713,16 @@ async function onDashboardSaved({ name } = {}) {
 		return;
 	}
 	if (!d || !d.name) return;
-	applyEditDetail(d, { deepLink: false });
+	// The current edit target updating itself (the normal revision loop) adopts
+	// straight away. A DIFFERENT row landing here replaces the on-screen canvas
+	// like any other target, so it rides the same discard confirm as loadEdit -
+	// confirmDiscard is a no-op when nothing unsaved is at stake, which is the
+	// whole first-build case.
+	if (savedName.value && d.name === savedName.value) {
+		applyEditDetail(d, { deepLink: false });
+		return;
+	}
+	confirmDiscard(() => applyEditDetail(d, { deepLink: false }));
 }
 
 // ?edit= also changes WITHOUT a remount — "Edit in builder" on a second

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -1100,6 +1100,14 @@ onMounted(async () => {
 	if (routeEdit && routeChat) {
 		console.warn("dashboards: ?edit= wins over ?chat=&canvas=; the promotion is ignored");
 	}
+	// ```jarvis-goto hand-off: honored only when neither deep-link claims the
+	// canvas - an ?edit= target or a ?chat=&canvas= promotion IS what the user
+	// asked to land on, and a queued prompt must not race a message into
+	// whatever thread that resolves to instead.
+	const gotoText =
+		!routeEdit && !(routeChat && routeCanvas) && dashboardPrefill && dashboardPrefill.autoSend
+			? String(dashboardPrefill.text || "").trim()
+			: "";
 	if (!routeEdit && routeChat && routeCanvas) {
 		promoteFromChat(routeChat, routeCanvas, { fallback: normalMount, dash: routeDash });
 	} else {
@@ -1107,26 +1115,21 @@ onMounted(async () => {
 		// present): release the hold taken at setup, or the pane's restore stays
 		// blocked for the life of the page.
 		promotionPending.value = false;
-		normalMount();
-	}
-	// ```jarvis-goto hand-off: only sent when neither deep-link above claims
-	// the canvas - an ?edit= target or a ?chat=&canvas= promotion IS what the
-	// user asked to land on, and a queued prompt must not race a message into
-	// whatever thread that resolves to instead. sendText() itself already
-	// no-ops if the pane is mid-send or mid-run, so a resumed thread with a
-	// build in flight simply drops the prefill rather than double-sending.
-	if (
-		!routeEdit &&
-		!(routeChat && routeCanvas) &&
-		dashboardPrefill &&
-		dashboardPrefill.autoSend
-	) {
-		const text = String(dashboardPrefill.text || "").trim();
-		if (text) {
-			nextTick(() => {
-				if (chatPane.value && chatPane.value.sendText) chatPane.value.sendText(text);
-			});
+		if (gotoText) {
+			// A goto hand-off is always a NEW build. Restoring the sticky editing
+			// target (or the previous thread under it) would land the seeded
+			// request as a revision of an older dashboard, so start clean instead
+			// of normalMount(). Nothing is unsaved at this instant - the page just
+			// mounted - so no discard confirm.
+			clearBuilder();
+		} else {
+			normalMount();
 		}
+	}
+	if (gotoText) {
+		nextTick(() => {
+			if (chatPane.value && chatPane.value.sendText) chatPane.value.sendText(gotoText);
+		});
 	}
 });
 </script>

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -153,6 +153,7 @@
 					:editing-name="agentEditingName"
 					@canvas="onCanvas"
 					@reset="resetBuilder"
+					@dashboard="onDashboardSaved"
 				/>
 			</div>
 
@@ -201,7 +202,7 @@
 // Probe failures follow the TriggersPage rule: a genuine 403 shows the
 // no-access state; a transient 500/network blip retries once and otherwise
 // proceeds with default caps rather than blocking an authorized user.
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
 import { Badge, Breadcrumbs, Button, Dialog, Dropdown, FeatherIcon, toast } from "frappe-ui";
@@ -211,6 +212,7 @@ import { session } from "@/data/session";
 import { getCanvas } from "@/api";
 import { agentName } from "@/branding";
 import { getDashboardsCaps, getDashboard, getDashboardConversation } from "@/api/dashboards";
+import { takeDashboardPrefill } from "@/composables/dashboardPrefill";
 import { builderCanvasFrame } from "@/lib/dashboardRestore";
 import {
 	adoptionIdentity,
@@ -348,6 +350,14 @@ const routeCanvas = typeof route.query.canvas === "string" ? route.query.canvas 
 // permission-gated get_dashboard, so an unknown or foreign name simply fails and
 // degrades to an identity-less promotion.
 const routeDash = typeof route.query.dash === "string" ? route.query.dash : "";
+// ```jarvis-goto hand-off (main chat -> here, jarvis#884): taken on EVERY
+// mount, the same discipline chatPrefill uses in ChatView, so a stale prompt
+// can never survive to fire on a later, unrelated visit. Sent from onMounted
+// once the caps probe settles - but ONLY when neither deep-link above owns
+// the canvas: an ?edit= or ?chat=&canvas= promotion is what the user actually
+// asked to land on, and a stray prompt must not race a message into that
+// conversation instead.
+const dashboardPrefill = takeDashboardPrefill();
 // A promotion the page owes the user but has not finished, held exactly like
 // `editSeed`: an explicit deep-link owns the canvas, so the chat pane's own
 // transcript restore must not land on it first. The pane's onMounted fires
@@ -620,6 +630,38 @@ function resetBuilder() {
 	});
 }
 
+// The state-setting guts of adopting a saved dashboard's detail as the
+// current document - factored out of loadEdit so a caller that already knows
+// nothing is unsaved (onDashboardSaved, below: the pane's own build landing
+// where its canvas already was) can apply it directly, without the discard
+// confirm every OTHER caller needs wrapped around it.
+//
+// `deepLink` also gates the chatConv repoint below: true for every ordinary
+// caller (?edit=, a fresh loadEdit), but onDashboardSaved passes false and
+// still repoints WHEN `d.source_conversation` is set - which for a row this
+// pane's own conversation just saved is that same conversation, so the write
+// is a same-value no-op against the pane's watcher (it only reacts to an
+// actual change). A future caller that adopts a row built by a DIFFERENT
+// conversation would need its own guard here; onDashboardSaved does not.
+function applyEditDetail(d, { deepLink = true } = {}) {
+	builderHtml.value = d.html || "";
+	editingDetail.value = d;
+	editingSticky.value = d.name;
+	savedName.value = d.name;
+	builderTheme.value = themeKey(d.theme);
+	// the canvas is this document now, not an artifact from the transcript
+	canvasMsg.value = "";
+	// ...so whatever the builder was holding is no longer ahead of its row:
+	// the agent revises this document by name again.
+	adoptedRow.value = "";
+	// resume the build thread, or a fresh one — never the stale sticky
+	// conversation left over from editing a different dashboard.
+	if (deepLink || d.source_conversation) {
+		chatConv.value = d.source_conversation || "";
+		dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static";
+	}
+}
+
 // ?edit=<name> deep-link: seed the canvas + save dialog from a saved dashboard.
 // Also resume the conversation that built it (so the agent has memory of the
 // document) and seed the data-mode from its derived type, so an edit session
@@ -644,22 +686,7 @@ async function loadEdit(name, { deepLink = true } = {}) {
 			return;
 		}
 		confirmDiscard(() => {
-			builderHtml.value = d.html || "";
-			editingDetail.value = d;
-			editingSticky.value = d.name;
-			savedName.value = d.name;
-			builderTheme.value = themeKey(d.theme);
-			// the canvas is this document now, not an artifact from the transcript
-			canvasMsg.value = "";
-			// ...so whatever the builder was holding is no longer ahead of its row:
-			// the agent revises this document by name again.
-			adoptedRow.value = "";
-			// resume the build thread, or a fresh one — never the stale sticky
-			// conversation left over from editing a different dashboard.
-			if (deepLink || d.source_conversation) {
-				chatConv.value = d.source_conversation || "";
-				dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static";
-			}
+			applyEditDetail(d, { deepLink });
 			settle();
 		}, settle);
 	} catch (e) {
@@ -669,6 +696,26 @@ async function loadEdit(name, { deepLink = true } = {}) {
 		else editingSticky.value = "";
 		settle();
 	}
+}
+
+// The chat pane just saved a dashboard (the new save_dashboard tool,
+// jarvis#884 - dashboard builds no longer land as a canvas artifact) and told
+// us its name over the realtime channel. This is the current chat's own
+// output, replacing the very canvas the builder already has on screen, so it
+// never needs the discard confirm loadEdit uses for every other target.
+async function onDashboardSaved({ name } = {}) {
+	if (!name) return;
+	let d = null;
+	try {
+		d = await getDashboard(name);
+	} catch (e) {
+		// The save itself already succeeded server-side (the pane's own
+		// confirmation card said so before this event ever fired); a blip
+		// fetching it back is not worth interrupting the builder over.
+		return;
+	}
+	if (!d || !d.name) return;
+	applyEditDetail(d, { deepLink: false });
 }
 
 // ?edit= also changes WITHOUT a remount — "Edit in builder" on a second
@@ -1061,6 +1108,25 @@ onMounted(async () => {
 		// blocked for the life of the page.
 		promotionPending.value = false;
 		normalMount();
+	}
+	// ```jarvis-goto hand-off: only sent when neither deep-link above claims
+	// the canvas - an ?edit= target or a ?chat=&canvas= promotion IS what the
+	// user asked to land on, and a queued prompt must not race a message into
+	// whatever thread that resolves to instead. sendText() itself already
+	// no-ops if the pane is mid-send or mid-run, so a resumed thread with a
+	// build in flight simply drops the prefill rather than double-sending.
+	if (
+		!routeEdit &&
+		!(routeChat && routeCanvas) &&
+		dashboardPrefill &&
+		dashboardPrefill.autoSend
+	) {
+		const text = String(dashboardPrefill.text || "").trim();
+		if (text) {
+			nextTick(() => {
+				if (chatPane.value && chatPane.value.sendText) chatPane.value.sendText(text);
+			});
+		}
 	}
 });
 </script>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8749,7 +8749,21 @@ function onEvent(p) {
 				if (goto) {
 					const firedKey = "jarvis:goto-fired:" + m.name;
 					if (!localStorage.getItem(firedKey)) {
-						localStorage.setItem(firedKey, "1");
+						localStorage.setItem(firedKey, String(Date.now()));
+						// Bounded stamp set: these keys are write-once per redirect and
+						// would otherwise accumulate for the life of the origin. Keep
+						// the newest ~50 (the live-turn gate above is the real guard;
+						// the stamp only defends reloads of RECENT transcripts).
+						const stamps = [];
+						for (let i = 0; i < localStorage.length; i++) {
+							const k = localStorage.key(i);
+							if (k && k.startsWith("jarvis:goto-fired:"))
+								stamps.push([k, Number(localStorage.getItem(k)) || 0]);
+						}
+						stamps
+							.sort((a, b) => b[1] - a[1])
+							.slice(50)
+							.forEach(([k]) => localStorage.removeItem(k));
 						gotoDashboards(goto.prompt);
 					}
 				}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8909,6 +8909,17 @@ function onEvent(p) {
 			// same transcript never re-fires it. Only the live socket terminal ever
 			// reaches this branch, so an old message opened again never gets here at
 			// all, but the stamp is the belt-and-braces the spec asks for.
+			//
+			// `redirected` tracks whether THIS run:end is the one that actually
+			// navigates, so the gotoMorph latch below can tell the two cases apart:
+			// the navigating path keeps the latch (it must survive the instant up to
+			// navigation — the whole point of the latch), while every other path
+			// that reaches run:end with the latch still set — a second tab that lost
+			// the race on the localStorage stamp, an errored/stopped terminal, or a
+			// was_recovered replacement whose final text dropped the goto block —
+			// must drop it, or the morph line would animate forever with no
+			// redirect coming.
+			let redirected = false;
 			if (m && !m.error && !m.stopped) {
 				const goto = gotoOf(m);
 				if (goto) {
@@ -8929,10 +8940,12 @@ function onEvent(p) {
 							.sort((a, b) => b[1] - a[1])
 							.slice(50)
 							.forEach(([k]) => localStorage.removeItem(k));
+						redirected = true;
 						gotoDashboards(goto.prompt);
 					}
 				}
 			}
+			if (!redirected) gotoMorph.value = null;
 			break;
 		}
 		case "message:enriched": {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7386,6 +7386,20 @@ const gotoMorph = ref(null);
 watch(streamingGoto, (g) => {
 	if (g) gotoMorph.value = g;
 });
+// The goto block usually lands with the reply's LAST tokens, so without a
+// short hold the morph line gets a sub-frame of screen time before the
+// redirect (measured live: under 400ms, one capture frame). The hold IS the
+// animation's screen time; reduced-motion users skip it and navigate at once.
+const GOTO_MORPH_HOLD_MS = 900;
+let gotoNavTimer = null;
+function dropGotoMorph() {
+	if (gotoNavTimer) {
+		clearTimeout(gotoNavTimer);
+		gotoNavTimer = null;
+	}
+	gotoMorph.value = null;
+}
+onUnmounted(dropGotoMorph);
 // ---- common artifact activity card (jarvis#884) ───────────────────────────
 // Generalizes the #874 dashboard-only live card to any artifact-producing
 // main-chat turn: whichever write tool actually ran (or the builder-origin
@@ -8032,7 +8046,7 @@ function resetRunState() {
 	mention.value = { ...mention.value, open: false };
 	histIdx.value = null;
 	histDraft.value = "";
-	gotoMorph.value = null; // a latch from the chat we are leaving must not follow us in
+	dropGotoMorph(); // a latch (or pending hold-nav) from the chat we are leaving must not follow us in
 }
 // Stash the leaving chat's draft and restore the target chat's own, so unsent
 // text follows its conversation instead of bleeding into the next one. Both the
@@ -8689,9 +8703,9 @@ function onEvent(p) {
 			statusPhase.value = "model";
 			store.streamingConvId = p.conversation_id || currentId.value;
 			// A new turn starting must not inherit the previous turn's morph
-			// latch (jarvis#884) — only THIS turn's own complete goto block may
-			// light it again.
-			gotoMorph.value = null;
+			// latch or its pending hold-navigation (jarvis#884) — only THIS
+			// turn's own complete goto block may light it again.
+			dropGotoMorph();
 			break;
 		case "queue:position":
 			// Phase-0 admission: this queued turn's approximate position shifted
@@ -8941,11 +8955,27 @@ function onEvent(p) {
 							.slice(50)
 							.forEach(([k]) => localStorage.removeItem(k));
 						redirected = true;
-						gotoDashboards(goto.prompt);
+						// Latch explicitly: when the block lands WITH the terminal, the
+						// streaming watcher never saw it, and the hold below is the
+						// morph line's only screen time.
+						gotoMorph.value = goto;
+						const reducedMotion =
+							window.matchMedia &&
+							window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+						if (reducedMotion) {
+							gotoDashboards(goto.prompt);
+						} else {
+							gotoNavTimer = setTimeout(() => {
+								gotoNavTimer = null;
+								// dropGotoMorph() clearing the latch (new turn, chat switch,
+								// unmount) is the cancel signal for this pending navigation.
+								if (gotoMorph.value) gotoDashboards(goto.prompt);
+							}, GOTO_MORPH_HOLD_MS);
+						}
 					}
 				}
 			}
-			if (!redirected) gotoMorph.value = null;
+			if (!redirected) dropGotoMorph();
 			break;
 		}
 		case "message:enriched": {
@@ -9030,7 +9060,7 @@ function onEvent(p) {
 			activeTools.value = [];
 			currentRunId.value = null;
 			store.streamingConvId = null;
-			gotoMorph.value = null; // an errored turn never redirects — drop the latch
+			dropGotoMorph(); // an errored turn never redirects — drop the latch and any pending hold-nav
 			announceSR("That didn't go through. See the error in the chat.");
 			loadConversation(currentId.value);
 			break;
@@ -9081,7 +9111,7 @@ function stopRun() {
 	activeTools.value = [];
 	store.streamingConvId = null;
 	recovering.value = null;
-	gotoMorph.value = null; // a stopped turn never redirects — drop the latch
+	dropGotoMorph(); // a stopped turn never redirects — drop the latch and any pending hold-nav
 	if (cid) api.stopRun(cid, rid).catch(() => {});
 	notify("Stopped.");
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1469,6 +1469,42 @@
 										Save as macro
 									</button>
 								</div>
+								<!-- redirect card: dashboard builds no longer run inline in main
+								     chat (jarvis#884) - the agent restates the request and points
+								     here with ```jarvis-goto. Stays clickable in history so an
+								     old transcript still has a way through, even though the
+								     redirect itself only auto-fires once, live (see gotoDashboards
+								     / the run:end handler). -->
+								<div v-if="gotoOf(m)" class="jv-macrocard">
+									<div class="jv-macrocard-ic">
+										<svg
+											width="16"
+											height="16"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="1.7"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+										>
+											<path d="M18 20V10M12 20V4M6 20v-6" />
+										</svg>
+									</div>
+									<div class="jv-macrocard-txt">
+										<span class="jv-macrocard-title"
+											>Continue in Dashboards</span
+										>
+										<span class="jv-macrocard-sub">{{
+											gotoOf(m).prompt
+										}}</span>
+									</div>
+									<button
+										class="jv-macrocard-btn"
+										@click="gotoDashboards(gotoOf(m).prompt)"
+									>
+										Open Dashboards
+									</button>
+								</div>
 								<!-- inline charts: ECharts rendered from the agent's jarvis-chart spec -->
 								<div
 									v-for="(spec, ci) in chartsOf(m)"
@@ -3940,6 +3976,7 @@ import {
 } from "@/utils/voiceAudioMirror";
 import { setMacroPrefill } from "@/composables/macroPrefill";
 import { takeChatPrefill } from "@/composables/chatPrefill";
+import { setDashboardPrefill } from "@/composables/dashboardPrefill";
 import { useConfirm } from "@/composables/useConfirm";
 import { promptSupportCopy } from "@/composables/useSupportCopyPrompt";
 import { useSupportStore } from "@/stores/support";
@@ -3966,6 +4003,7 @@ import AskCard from "@/components/chat/AskCard.vue";
 import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
+import { parseGoto } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { shouldFollowBottom } from "@/lib/chatScroll";
@@ -5846,6 +5884,16 @@ function chartsOf(m) {
 
 function askOf(m) {
 	return parseAsk((m && m.content) || "");
+}
+function gotoOf(m) {
+	return parseGoto((m && m.content) || "");
+}
+// Shared by the card's button and the run:end auto-redirect below: stash the
+// restated request for the Dashboards builder to pick up on its own mount,
+// then navigate there.
+function gotoDashboards(prompt) {
+	setDashboardPrefill({ text: prompt, autoSend: true });
+	router.push("/dashboards");
 }
 // Canonicalised at the single _ACTION_RE parse point so every consumer (render
 // gate, build watcher, buildDraftModel, edit panel, apply) sees ONE shape. See
@@ -8688,6 +8736,23 @@ function onEvent(p) {
 				// (mutex-guarded, no-op when nothing's pending) catch that race.
 				setTimeout(processMermaid, 300);
 				setTimeout(processMermaid, 900);
+			}
+			// jarvis#884: a ```jarvis-goto block on the turn that just ENDED, live,
+			// in THIS mounted view, auto-redirects to the Dashboards builder exactly
+			// once. Gated the same way markAnswerLanded is above (never a stopped or
+			// errored row), plus a durable stamp so a later reload/revisit of the
+			// same transcript never re-fires it. Only the live socket terminal ever
+			// reaches this branch, so an old message opened again never gets here at
+			// all, but the stamp is the belt-and-braces the spec asks for.
+			if (m && !m.error && !m.stopped) {
+				const goto = gotoOf(m);
+				if (goto) {
+					const firedKey = "jarvis:goto-fired:" + m.name;
+					if (!localStorage.getItem(firedKey)) {
+						localStorage.setItem(firedKey, "1");
+						gotoDashboards(goto.prompt);
+					}
+				}
 			}
 			break;
 		}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1800,17 +1800,74 @@
 						</Message>
 					</template>
 
-					<!-- dashboard build: a real progress card keyed to actual tool
-					     activity, never a timer (issue #858). Same turn gate as the
-					     generic activity line below (queued chip wins over both);
-					     mutually exclusive with it so only one ever shows. Phases
-					     light up from real events only — a mount that joined the
-					     turn already in flight (no activeTools seen yet) shows the
-					     honest indeterminate header with no tick lit, rather than
-					     guessing "Understanding". -->
+					<!-- pre-redirect morph line (jarvis#884): the working line morphs
+					     in place the instant the streaming reply's own jarvis-goto
+					     block is complete. Wins over the artifact card and the generic
+					     line below (a goto turn produces no artifact) — see the
+					     gotoMorph latch's own comment for why this renders off the
+					     latch, not off streamingGoto directly. Zero added delay: the
+					     run:end auto-redirect is untouched, this is only the visual for
+					     the beat before it fires (and the instant after, until the
+					     route actually changes). -->
+					<div v-if="gotoMorph && !queuedTurn" style="display: flex; gap: 12px">
+						<JarvisMark
+							:size="28"
+							:radius="7"
+							mood="thinking"
+							style="margin-top: 2px"
+						/>
+						<div style="flex: 1; min-width: 0; padding-top: 3px">
+							<div class="jv-goto-morph" role="status" aria-live="polite">
+								<span class="jv-goto-chevrons" aria-hidden="true">
+									<svg
+										v-for="i in 3"
+										:key="i"
+										class="jv-goto-chevron"
+										:style="{ animationDelay: (i - 1) * 0.15 + 's' }"
+										width="10"
+										height="10"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2.6"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path d="M9 6l6 6-6 6" />
+									</svg>
+								</span>
+								<span class="jv-live-shim"
+									>Taking you to the Dashboards builder</span
+								>
+								<svg
+									class="jv-goto-arrow"
+									width="13"
+									height="13"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M5 12h14M13 5l7 7-7 7" />
+								</svg>
+							</div>
+						</div>
+					</div>
+					<!-- common artifact activity card (jarvis#884): one shared card for
+					     any artifact-producing main-chat turn — dashboard (builder
+					     origin, issue #858's own gate), pdf, spreadsheet, or image —
+					     replacing the dashboard-only card issue #874 shipped. Same turn
+					     gate as the generic activity line below (queued chip, and now
+					     the goto morph line, both win over it); mutually exclusive with
+					     the generic line so only one ever shows. Phases light up from
+					     real events only — a mount that joined the turn already in
+					     flight (no activeTools seen yet) shows the honest indeterminate
+					     header with no tick lit, rather than guessing "Understanding". -->
 					<div
-						v-if="dashboardBuildTurn && (activeTools.length || waiting) && !queuedTurn"
-						class="jv-dashbuild"
+						v-if="artifactKind && (activeTools.length || waiting) && !queuedTurn"
+						class="jv-artifact-live"
 						style="display: flex; gap: 12px"
 					>
 						<JarvisMark
@@ -1820,31 +1877,82 @@
 							style="margin-top: 2px"
 						/>
 						<div style="flex: 1; min-width: 0; padding-top: 3px">
-							<div class="jv-dashbuild-card" role="status" aria-live="polite">
-								<span class="jv-dashbuild-head">
-									<span class="jv-live-shim">Building dashboard…</span>
+							<div class="jv-artifact-card" role="status" aria-live="polite">
+								<span class="jv-artifact-head">
+									<svg
+										v-if="artifactKind === 'dashboard'"
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.8"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path d="M18 20V10M12 20V4M6 20v-6" />
+									</svg>
+									<svg
+										v-else-if="artifactKind === 'pdf'"
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.8"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path
+											d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+										/>
+										<path d="M14 2v6h6" />
+									</svg>
+									<svg
+										v-else-if="artifactKind === 'spreadsheet'"
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.8"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<rect x="3" y="3" width="18" height="18" rx="2" />
+										<path d="M3 9h18M3 15h18M9 3v18M15 3v18" />
+									</svg>
+									<svg
+										v-else-if="artifactKind === 'image'"
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.8"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<rect x="3" y="3" width="18" height="18" rx="2" />
+										<circle cx="8.5" cy="8.5" r="1.5" />
+										<path d="M21 15l-5-5L5 21" />
+									</svg>
+									<span class="jv-live-shim">{{ artifactTitle }}</span>
 								</span>
-								<ol class="jv-dashbuild-steps">
+								<ol class="jv-artifact-steps">
 									<li
-										v-for="(step, si) in DASHBOARD_BUILD_PHASES"
+										v-for="(step, si) in artifactPhases"
 										:key="step.key"
-										class="jv-dashbuild-step"
+										class="jv-artifact-step"
 										:class="{
-											done:
-												dashboardBuildTickIndex >= 0 &&
-												si < dashboardBuildTickIndex,
-											current: si === dashboardBuildTickIndex,
+											done: artifactTickIndex >= 0 && si < artifactTickIndex,
+											current: si === artifactTickIndex,
 										}"
 									>
-										<span class="jv-dashbuild-tick" aria-hidden="true"></span>
+										<span class="jv-artifact-tick" aria-hidden="true"></span>
 										{{ step.label }}
 									</li>
 								</ol>
-								<div class="jv-dashbuild-skel" aria-hidden="true">
-									<span class="jv-dashbuild-skel-row"></span>
-									<span class="jv-dashbuild-skel-row"></span>
-									<span class="jv-dashbuild-skel-row short"></span>
-								</div>
 							</div>
 						</div>
 					</div>
@@ -1855,7 +1963,10 @@
 					     stray warming spinner masking the chip. -->
 					<div
 						v-if="
-							(activeTools.length || waiting) && !queuedTurn && !dashboardBuildTurn
+							(activeTools.length || waiting) &&
+							!queuedTurn &&
+							!artifactKind &&
+							!gotoMorph
 						"
 						style="display: flex; gap: 12px"
 					>
@@ -4012,13 +4123,17 @@ import { sortPendingCards } from "@/lib/sortPendingCards";
 import { errMessage, turnErrorInfo } from "@/lib/errors";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import {
-	DASHBOARD_BUILD_PHASES,
-	dashboardBuildPhase,
 	dashboardThumbnailTransform,
 	isDashboardBuildTurn,
 	isDashboardCanvas,
 	phaseTickIndex,
 } from "@/lib/dashboardBuildCard";
+import {
+	ARTIFACT_TITLES,
+	artifactBuildPhase,
+	artifactPhaseList,
+	detectArtifactKind,
+} from "@/lib/artifactActivityCard";
 import { pickGreeting } from "@/lib/greeting";
 import { dashboardForConversation } from "@/api/dashboards";
 import {
@@ -7243,14 +7358,59 @@ const dashboardBuildTurn = computed(() =>
 		conversation: currentId.value,
 	})
 );
-const dashboardBuildPhaseKey = computed(() =>
-	dashboardBuildPhase({
+// ---- pre-redirect morph line (jarvis#884) ─────────────────────────────────
+// The moment the turn CURRENTLY streaming into this conversation carries a
+// COMPLETE ```jarvis-goto block, the generic "Working on it…" line morphs in
+// place into a branded "Taking you to the Dashboards builder" line. gotoOf
+// only returns truthy once the closing fence has actually arrived (chatGoto.js
+// requires it), so "complete" falls out of the existing parser for free —
+// nothing here holds back an unterminated block itself.
+//
+// Rendering off `streamingGoto` directly would drop the line the instant
+// run:end flips `m.streaming` false (line ~8668), which lands BEFORE
+// gotoDashboards() fires a few statements later — exactly the "instant
+// between run:end and navigation" the line is required to survive, and a
+// lazy-loaded /dashboards route chunk can turn that instant into a real
+// visible gap. So this is a LATCH: once a turn earns the morph, `gotoMorph`
+// stays truthy until the next turn starts, errors, is stopped, or the
+// conversation is left — never cleared by run:end itself, since surviving
+// that is the entire point.
+const streamingMessage = computed(
+	() => [...messages.value].reverse().find((m) => m.role === "assistant" && m.streaming) || null
+);
+const streamingGoto = computed(() => {
+	const m = streamingMessage.value;
+	return m ? gotoOf(m) : null;
+});
+const gotoMorph = ref(null);
+watch(streamingGoto, (g) => {
+	if (g) gotoMorph.value = g;
+});
+// ---- common artifact activity card (jarvis#884) ───────────────────────────
+// Generalizes the #874 dashboard-only live card to any artifact-producing
+// main-chat turn: whichever write tool actually ran (or the builder-origin
+// dashboard gate above) names the kind, and the SAME real activeTools/
+// statusPhase/waiting signals the generic activity line reads drive its
+// phase. The goto morph line above wins outright — a goto turn produces no
+// artifact — so artifactKind nulls out under the latch rather than needing a
+// second exclusion wired through every consumer below.
+const artifactKind = computed(() =>
+	gotoMorph.value
+		? null
+		: detectArtifactKind(activeTools.value, { dashboardTurn: dashboardBuildTurn.value })
+);
+const artifactTitle = computed(() => ARTIFACT_TITLES[artifactKind.value] || "");
+const artifactPhaseKey = computed(() =>
+	artifactBuildPhase(artifactKind.value, {
 		activeTools: activeTools.value,
 		statusPhase: statusPhase.value,
 		waiting: waiting.value,
 	})
 );
-const dashboardBuildTickIndex = computed(() => phaseTickIndex(dashboardBuildPhaseKey.value));
+const artifactPhases = computed(() => artifactPhaseList(artifactKind.value));
+const artifactTickIndex = computed(() =>
+	phaseTickIndex(artifactPhaseKey.value, artifactPhases.value)
+);
 // Scaled-preview geometry for the finished-canvas thumbnail card (below);
 // fixed source viewport since the canvas itself has no set design width.
 const dashboardThumbGeom = computed(() => dashboardThumbnailTransform(220));
@@ -7872,6 +8032,7 @@ function resetRunState() {
 	mention.value = { ...mention.value, open: false };
 	histIdx.value = null;
 	histDraft.value = "";
+	gotoMorph.value = null; // a latch from the chat we are leaving must not follow us in
 }
 // Stash the leaving chat's draft and restore the target chat's own, so unsent
 // text follows its conversation instead of bleeding into the next one. Both the
@@ -8527,6 +8688,10 @@ function onEvent(p) {
 			waiting.value = true;
 			statusPhase.value = "model";
 			store.streamingConvId = p.conversation_id || currentId.value;
+			// A new turn starting must not inherit the previous turn's morph
+			// latch (jarvis#884) — only THIS turn's own complete goto block may
+			// light it again.
+			gotoMorph.value = null;
 			break;
 		case "queue:position":
 			// Phase-0 admission: this queued turn's approximate position shifted
@@ -8852,6 +9017,7 @@ function onEvent(p) {
 			activeTools.value = [];
 			currentRunId.value = null;
 			store.streamingConvId = null;
+			gotoMorph.value = null; // an errored turn never redirects — drop the latch
 			announceSR("That didn't go through. See the error in the chat.");
 			loadConversation(currentId.value);
 			break;
@@ -8902,6 +9068,7 @@ function stopRun() {
 	activeTools.value = [];
 	store.streamingConvId = null;
 	recovering.value = null;
+	gotoMorph.value = null; // a stopped turn never redirects — drop the latch
 	if (cid) api.stopRun(cid, rid).catch(() => {});
 	notify("Stopped.");
 }
@@ -11082,6 +11249,48 @@ onUnmounted(() => {
 		opacity: 1;
 	}
 }
+/* pre-redirect morph line (jarvis#884): occupies the exact same single-row
+   box as the generic "Working on it…" status line it replaces (same
+   font-size/gap/padding-top), so the transcript never jumps when one morphs
+   into the other. Compositor-friendly only: the chevrons animate
+   transform+opacity, nothing else — no width/height/position/background
+   properties in the keyframe, so the loop never triggers layout or paint
+   beyond the small icons themselves. Disabled under reduced-motion below. */
+.jv-goto-morph {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	padding-top: 4px;
+	font-size: 12px;
+	color: var(--text-3);
+}
+.jv-goto-chevrons {
+	display: inline-flex;
+	align-items: center;
+	color: var(--cta);
+}
+.jv-goto-chevron {
+	margin-left: -5px;
+	animation: jv-goto-chevron-slide 1s ease-in-out infinite;
+}
+.jv-goto-chevron:first-child {
+	margin-left: 0;
+}
+@keyframes jv-goto-chevron-slide {
+	0%,
+	100% {
+		transform: translateX(0);
+		opacity: 0.4;
+	}
+	50% {
+		transform: translateX(3px);
+		opacity: 1;
+	}
+}
+.jv-goto-arrow {
+	flex: none;
+	color: var(--text-3);
+}
 /* visually-hidden live region for screen-reader announcements (UX #5) */
 .jv-sr {
 	position: absolute;
@@ -11115,10 +11324,14 @@ onUnmounted(() => {
 	.jv-mic-dot {
 		animation: none;
 	}
-	.jv-dashbuild-tick,
-	.jv-dashbuild-skel-row,
+	.jv-artifact-tick,
 	.jv-dash-thumb-loading {
 		animation: none;
+	}
+	.jv-goto-chevron {
+		animation: none;
+		opacity: 1;
+		transform: none;
 	}
 	.jv-settings,
 	.jv-skills-modal {
@@ -12686,6 +12899,14 @@ onUnmounted(() => {
 	background-size: 400% 100%;
 	animation: jv-dashbuild-shimmer 1.6s ease infinite;
 }
+@keyframes jv-dashbuild-shimmer {
+	0% {
+		background-position: 100% 50%;
+	}
+	100% {
+		background-position: 0 50%;
+	}
+}
 .jv-dash-thumb-meta {
 	display: flex;
 	flex-direction: column;
@@ -12709,8 +12930,13 @@ onUnmounted(() => {
 	color: var(--cta);
 }
 
-/* dashboard-build live progress card (issue #858) */
-.jv-dashbuild-card {
+/* common artifact activity card (jarvis#884): one shared card for any
+   artifact-producing main-chat turn (dashboard/pdf/spreadsheet/image),
+   replacing the dashboard-only card issue #874 shipped. Height is fixed from
+   first paint — head row + all four phase rows always render, tick state
+   only changes color/scale, never the row count — so the card never grows
+   once mounted. */
+.jv-artifact-card {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
@@ -12720,10 +12946,14 @@ onUnmounted(() => {
 	border-radius: 10px;
 	background: var(--surface);
 }
-.jv-dashbuild-head {
+.jv-artifact-head {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	font-size: 12px;
+	color: var(--text-2);
 }
-.jv-dashbuild-steps {
+.jv-artifact-steps {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
@@ -12731,63 +12961,48 @@ onUnmounted(() => {
 	padding: 0;
 	list-style: none;
 }
-.jv-dashbuild-step {
+.jv-artifact-step {
 	display: flex;
 	align-items: center;
 	gap: 7px;
 	font-size: 11.5px;
 	color: var(--text-3);
 }
-.jv-dashbuild-step.done,
-.jv-dashbuild-step.current {
+.jv-artifact-step.done,
+.jv-artifact-step.current {
 	color: var(--text-2);
 }
-.jv-dashbuild-step.current {
+.jv-artifact-step.current {
 	color: var(--text);
 	font-weight: 550;
 }
-.jv-dashbuild-tick {
+/* Tick "lighting up" is a transform/opacity transition (addendum #2/#8),
+   never a keyframe loop — only the CURRENT tick's gentle pulse (reused
+   jv-live-shim, already opacity-only) is a loop, and that is removed under
+   reduced-motion below. background-color is swapped directly (no
+   transition on it), so a state change is one cheap repaint, not an
+   animated one. */
+.jv-artifact-tick {
 	flex: none;
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
 	background: var(--border-2);
+	transform: scale(0.7);
+	opacity: 0.8;
+	transition: transform 0.2s ease, opacity 0.2s ease;
 }
-.jv-dashbuild-step.done .jv-dashbuild-tick {
+.jv-artifact-step.done .jv-artifact-tick,
+.jv-artifact-step.current .jv-artifact-tick {
+	transform: scale(1);
+	opacity: 1;
+}
+.jv-artifact-step.done .jv-artifact-tick {
 	background: var(--green);
 }
-.jv-dashbuild-step.current .jv-dashbuild-tick {
+.jv-artifact-step.current .jv-artifact-tick {
 	background: var(--cta);
 	animation: jv-live-shim 1.8s ease-in-out infinite;
-}
-.jv-dashbuild-skel {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-}
-.jv-dashbuild-skel-row {
-	display: block;
-	height: 8px;
-	border-radius: 4px;
-	background: linear-gradient(
-		90deg,
-		var(--surface-1) 25%,
-		var(--surface-2) 37%,
-		var(--surface-1) 63%
-	);
-	background-size: 400% 100%;
-	animation: jv-dashbuild-shimmer 1.6s ease infinite;
-}
-.jv-dashbuild-skel-row.short {
-	width: 60%;
-}
-@keyframes jv-dashbuild-shimmer {
-	0% {
-		background-position: 100% 50%;
-	}
-	100% {
-		background-position: 0 50%;
-	}
 }
 
 /* confirm / cancel card for a pending ERP-mutating action */

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -630,6 +630,11 @@ _WRITE_TOOLS = frozenset(
 		"attach_to_doc",
 		"create_dashboard_chart",
 		"create_dashboard",
+		# #884 chat/builder dashboard delivery: inserts/updates a Jarvis Dashboard
+		# mid-turn. Audited but NEVER gated (like record_agent_run below) - the
+		# build must land without a card for the builder canvas to render it;
+		# scope is pinned to User server-side and the row is one-per-conversation.
+		"save_dashboard",
 		"create_custom_skill",
 		"update_wiki",
 		# Audited but NOT gated (see _GATED_WRITES comment below):

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1580,11 +1580,7 @@ def _dashboard_saved(conversation_id: str) -> bool:
 	if not conversation_id:
 		return False
 	try:
-		return bool(
-			frappe.db.exists(
-				"Jarvis Dashboard", {"source_conversation": conversation_id}
-			)
-		)
+		return bool(frappe.db.exists("Jarvis Dashboard", {"source_conversation": conversation_id}))
 	except Exception:
 		frappe.log_error(
 			title="dashboards: saved probe failed",

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1568,6 +1568,31 @@ def _dashboard_has_canvas(conversation_id: str) -> bool:
 		return True
 
 
+def _dashboard_saved(conversation_id: str) -> bool:
+	"""Has a ``Jarvis Dashboard`` already been saved from this conversation?
+
+	The #884 delivery path (the ``save_dashboard`` tool) stamps
+	``source_conversation``, so a saved row is the new "the shape is agreed,
+	iterate instead of interviewing" signal — the canvas-item probe above only
+	covers pre-#884 transcripts. Fails to True on any error, same degradation
+	rule as ``_dashboard_has_canvas``.
+	"""
+	if not conversation_id:
+		return False
+	try:
+		return bool(
+			frappe.db.exists(
+				"Jarvis Dashboard", {"source_conversation": conversation_id}
+			)
+		)
+	except Exception:
+		frappe.log_error(
+			title="dashboards: saved probe failed",
+			message=f"conversation={conversation_id!r}\n\n{frappe.get_traceback()}",
+		)
+		return True
+
+
 def _dashboard_has_asked(conversation_id: str) -> bool:
 	"""Has the assistant already put a ``jarvis-ask`` block in this conversation?
 
@@ -1674,7 +1699,11 @@ def _prepend_doc_context(user_message: str, context, conversation_id: str = "") 
 		# never trap the user in a question loop. Once a canvas exists the wording
 		# below is unchanged from the iterate-only original.
 		clarify_line = ""
-		if not edit_line and not _dashboard_has_canvas(conversation_id):
+		if (
+			not edit_line
+			and not _dashboard_saved(conversation_id)
+			and not _dashboard_has_canvas(conversation_id)
+		):
 			if _dashboard_has_asked(conversation_id):
 				clarify_line = (
 					" You have ALREADY asked your clarifying questions in this conversation, "
@@ -1709,8 +1738,11 @@ def _prepend_doc_context(user_message: str, context, conversation_id: str = "") 
 			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
 			"create or iterate on a dashboard/report. Read and follow the "
 			"jarvis-dashboards skill before acting. Non-negotiable contract: produce "
-			"ONE complete self-contained HTML document per iteration and publish it as "
-			"a hosted canvas embed; no external resources. Live data sources MUST be "
+			"ONE complete self-contained HTML document per iteration and deliver it "
+			"with ONE jarvis__save_dashboard call (first build: dashboard_title + "
+			"html; revisions: name + html - the tool returns the name); never publish "
+			"a hosted canvas embed or [embed] marker; no external resources. Live "
+			"data sources MUST be "
 			"declared inside the HTML exactly as "
 			'<script type="application/json" id="jarvis-sources">{"sources":[{'
 			'"source_name":"<snake_case>","tool":"query|get_list|run_report",'

--- a/jarvis/tests/test_save_dashboard_tool.py
+++ b/jarvis/tests/test_save_dashboard_tool.py
@@ -1,0 +1,201 @@
+"""#884: the ``jarvis__save_dashboard`` chat tool — agent-delivered dashboards.
+
+The dashboards flow no longer publishes hosted canvas documents; the agent
+delivers the authored HTML through this tool, which resolves the conversation
+from the caller's session bearer and delegates persistence to the one shared
+save path (``dashboards_api.save_dashboard``). These tests drive the tool
+exactly as the plugin dispatch would (session_key stashed on frappe.local,
+user impersonated) without a live model turn.
+
+Run: bench --site <site> run-tests --module jarvis.tests.test_save_dashboard_tool
+"""
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._agent_run_ctx import clear_session_key, set_session_key
+from jarvis.tools.save_dashboard import save_dashboard
+
+CONVERSATION = "Jarvis Conversation"
+DASHBOARD = "Jarvis Dashboard"
+
+USER = "dash884@example.com"
+SESSION_KEY = "test-884-session-key"
+
+_HTML = "<!doctype html><html><body><h1>Total Items</h1><p>10</p></body></html>"
+_HTML_V2 = "<!doctype html><html><body><h1>Total Items</h1><p>11</p></body></html>"
+_HTML_CONNECTED = (
+	"<!doctype html><html><body>"
+	'<script type="application/json" id="jarvis-sources">'
+	'{"sources":[{"source_name":"items","tool":"get_list",'
+	'"spec":{"doctype":"Item","limit":5}}]}'
+	"</script><h1>Items</h1></body></html>"
+)
+
+
+def _ensure_user(email: str) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert()
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles("Jarvis User")
+	return email
+
+
+def _make_conversation(owner: str, session_key: str) -> str:
+	conv = frappe.get_doc({"doctype": CONVERSATION, "title": "dash 884 test"})
+	conv.flags.ignore_permissions = True
+	conv.insert()
+	# owner is stamped from the acting session; pin it plus the permlevel-1
+	# session_key the worker normally sets via db.set_value.
+	frappe.db.set_value(
+		CONVERSATION,
+		conv.name,
+		{"owner": owner, "session_key": session_key},
+		update_modified=False,
+	)
+	return conv.name
+
+
+class TestSaveDashboardTool(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls._orig_user = frappe.session.user
+		frappe.set_user("Administrator")
+		_ensure_user(USER)
+		cls.conversation = _make_conversation(USER, SESSION_KEY)
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all(
+			DASHBOARD, filters={"source_conversation": cls.conversation}, pluck="name"
+		):
+			frappe.delete_doc(DASHBOARD, name, force=True, ignore_permissions=True)
+		frappe.delete_doc(CONVERSATION, cls.conversation, force=True, ignore_permissions=True)
+		frappe.set_user(cls._orig_user)
+
+	def setUp(self):
+		frappe.set_user(USER)
+		set_session_key(SESSION_KEY)
+
+	def tearDown(self):
+		clear_session_key()
+		frappe.set_user("Administrator")
+		for name in frappe.get_all(
+			DASHBOARD, filters={"source_conversation": self.conversation}, pluck="name"
+		):
+			frappe.delete_doc(DASHBOARD, name, force=True, ignore_permissions=True)
+
+	def test_first_save_creates_user_scoped_row_and_publishes(self):
+		with patch("jarvis.chat.events.publish_to_user") as pub:
+			out = save_dashboard(html=_HTML, dashboard_title="Total Items")
+		self.assertTrue(out["dashboard"])
+		row = frappe.db.get_value(
+			DASHBOARD,
+			out["dashboard"],
+			["dashboard_title", "scope", "source_conversation", "dashboard_type", "owner"],
+			as_dict=True,
+		)
+		self.assertEqual(row.dashboard_title, "Total Items")
+		self.assertEqual(row.scope, "User")
+		self.assertEqual(row.source_conversation, self.conversation)
+		self.assertEqual(row.dashboard_type, "Static")
+		self.assertEqual(row.owner, USER)
+		pub.assert_called_once()
+		user, payload = pub.call_args.args
+		self.assertEqual(user, USER)
+		self.assertEqual(payload["kind"], "dashboard")
+		self.assertEqual(payload["conversation_id"], self.conversation)
+		self.assertEqual(payload["name"], out["dashboard"])
+
+	def test_revision_updates_in_place(self):
+		with patch("jarvis.chat.events.publish_to_user"):
+			first = save_dashboard(html=_HTML, dashboard_title="Total Items")
+			second = save_dashboard(html=_HTML_V2, name=first["dashboard"])
+		self.assertEqual(first["dashboard"], second["dashboard"])
+		rows = frappe.get_all(
+			DASHBOARD, filters={"source_conversation": self.conversation}, pluck="name"
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertIn("11", frappe.db.get_value(DASHBOARD, rows[0], "html"))
+
+	def test_sources_block_yields_connected_dashboard(self):
+		with patch("jarvis.chat.events.publish_to_user"):
+			out = save_dashboard(html=_HTML_CONNECTED, dashboard_title="Items Live")
+		self.assertEqual(
+			frappe.db.get_value(DASHBOARD, out["dashboard"], "dashboard_type"),
+			"Connected",
+		)
+
+	def test_saved_probe_flips_after_first_save(self):
+		from jarvis.chat.turn_handler import _dashboard_saved
+
+		self.assertFalse(_dashboard_saved(self.conversation))
+		with patch("jarvis.chat.events.publish_to_user"):
+			save_dashboard(html=_HTML, dashboard_title="Total Items")
+		self.assertTrue(_dashboard_saved(self.conversation))
+
+	def test_create_requires_title(self):
+		with self.assertRaises(InvalidArgumentError):
+			save_dashboard(html=_HTML)
+
+	def test_empty_html_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			save_dashboard(html="  ", dashboard_title="x")
+
+	def test_missing_session_key_rejected(self):
+		clear_session_key()
+		with self.assertRaises(InvalidArgumentError):
+			save_dashboard(html=_HTML, dashboard_title="x")
+
+	def test_unknown_session_key_rejected(self):
+		set_session_key("some-other-session")
+		with self.assertRaises(InvalidArgumentError):
+			save_dashboard(html=_HTML, dashboard_title="x")
+
+	def test_cannot_revise_another_conversations_dashboard(self):
+		frappe.set_user("Administrator")
+		other_conv = _make_conversation(USER, "other-884-session")
+		frappe.set_user(USER)
+		try:
+			set_session_key("other-884-session")
+			with patch("jarvis.chat.events.publish_to_user"):
+				theirs = save_dashboard(html=_HTML, dashboard_title="Other Conv Dash")
+			set_session_key(SESSION_KEY)
+			with self.assertRaises(InvalidArgumentError):
+				save_dashboard(html=_HTML_V2, name=theirs["dashboard"])
+		finally:
+			frappe.set_user("Administrator")
+			for name in frappe.get_all(
+				DASHBOARD, filters={"source_conversation": other_conv}, pluck="name"
+			):
+				frappe.delete_doc(DASHBOARD, name, force=True, ignore_permissions=True)
+			frappe.delete_doc(CONVERSATION, other_conv, force=True, ignore_permissions=True)
+			frappe.set_user(USER)
+
+	def test_validation_error_surfaces_as_invalid_argument(self):
+		# 141-char title trips the DocType controller's cap; the tool must hand
+		# the model a clean InvalidArgumentError, never a raw ValidationError.
+		with self.assertRaises(InvalidArgumentError):
+			save_dashboard(html=_HTML, dashboard_title="x" * 141)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_save_dashboard_tool.py
+++ b/jarvis/tests/test_save_dashboard_tool.py
@@ -130,9 +130,7 @@ class TestSaveDashboardTool(unittest.TestCase):
 			first = save_dashboard(html=_HTML, dashboard_title="Total Items")
 			second = save_dashboard(html=_HTML_V2, name=first["dashboard"])
 		self.assertEqual(first["dashboard"], second["dashboard"])
-		rows = frappe.get_all(
-			DASHBOARD, filters={"source_conversation": self.conversation}, pluck="name"
-		)
+		rows = frappe.get_all(DASHBOARD, filters={"source_conversation": self.conversation}, pluck="name")
 		self.assertEqual(len(rows), 1)
 		self.assertIn("11", frappe.db.get_value(DASHBOARD, rows[0], "html"))
 
@@ -183,9 +181,7 @@ class TestSaveDashboardTool(unittest.TestCase):
 				save_dashboard(html=_HTML_V2, name=theirs["dashboard"])
 		finally:
 			frappe.set_user("Administrator")
-			for name in frappe.get_all(
-				DASHBOARD, filters={"source_conversation": other_conv}, pluck="name"
-			):
+			for name in frappe.get_all(DASHBOARD, filters={"source_conversation": other_conv}, pluck="name"):
 				frappe.delete_doc(DASHBOARD, name, force=True, ignore_permissions=True)
 			frappe.delete_doc(CONVERSATION, other_conv, force=True, ignore_permissions=True)
 			frappe.set_user(USER)

--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -466,6 +466,13 @@ def _ensure_warehouse(name: str, company: str) -> str:
 			"company": company,
 		}
 	)
+	# Upstream erpnext develop now validates a new Warehouse against the
+	# company's inventory account (Warehouse.validate_inventory_account ->
+	# get_warehouse_account), and this fixture's companies deliberately skip
+	# chart-of-accounts creation - they exist for permission checks, not a
+	# ledger. Use the escape flag upstream provides for exactly this case
+	# (harmless on older erpnext that predates the validation).
+	doc.flags.ignore_inventory_account_validation = True
 	doc.insert(ignore_permissions=True)
 	return doc.name
 

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -122,6 +122,13 @@ _TOOL_NAMES: tuple[str, ...] = (
 	"summarize_dataset",
 	"create_dashboard_chart",
 	"create_dashboard",
+	# #884 chat/builder → saved Jarvis Dashboard: the agent authors the full
+	# self-contained dashboard HTML and delivers it here (same "Option A" wire
+	# as save_agent_dashboard — no hosted-canvas gateway fetch). Resolves the
+	# conversation from the caller's session_key; delegates validation to
+	# dashboards_api.save_dashboard; publishes a "dashboard" frame the builder
+	# renders via its saved-row path.
+	"save_dashboard",
 	# Phase-3 delegate writeback: the auditor/operator delegate passes its
 	# deterministic evaluator output here VERBATIM. It resolves the Jarvis Agent
 	# Run from the caller's session_key, validates every finding (token/doctype/

--- a/jarvis/tools/save_dashboard.py
+++ b/jarvis/tools/save_dashboard.py
@@ -1,6 +1,6 @@
 """``jarvis__save_dashboard`` — chat/builder build → saved Jarvis Dashboard (#884).
 
-The dashboards flow no longer rides the openclaw hosted-canvas mechanism (the
+The dashboards flow no longer rides the agent runtime's hosted-canvas mechanism (the
 gateway fetch that #880 had to defend against). The agent authors the complete
 self-contained dashboard HTML and delivers it HERE, in the same "Option A" wire
 ``save_agent_dashboard`` already proved for delegate runs: persist the agent's

--- a/jarvis/tools/save_dashboard.py
+++ b/jarvis/tools/save_dashboard.py
@@ -1,0 +1,135 @@
+"""``jarvis__save_dashboard`` — chat/builder build → saved Jarvis Dashboard (#884).
+
+The dashboards flow no longer rides the openclaw hosted-canvas mechanism (the
+gateway fetch that #880 had to defend against). The agent authors the complete
+self-contained dashboard HTML and delivers it HERE, in the same "Option A" wire
+``save_agent_dashboard`` already proved for delegate runs: persist the agent's
+OWN document directly, so the bench never fetches a canvas back out of the
+container gateway.
+
+Identity mirrors the other session-bound tools: the conversation is resolved
+from the CALLER's ``session_key`` (``Jarvis Conversation.session_key`` — never a
+model-supplied id), so an agent can only ever save into its own conversation.
+All payload validation (field allow-list, sources parsing from the HTML's
+``jarvis-sources`` block, the 1MB html cap, the save-time theme validator,
+scope/permission gates) is delegated to ``dashboards_api.save_dashboard`` — one
+save path, whether the click or the agent does it. Validation failures come
+back as ``InvalidArgumentError`` so the model reads the validator's message and
+re-saves a fixed document instead of dying on a 500.
+
+On success a ``{"kind": "dashboard"}`` realtime frame tells the builder page to
+render the saved row (its ``loadEdit`` path — no canvas frame involved).
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+CONVERSATION = "Jarvis Conversation"
+DASHBOARD = "Jarvis Dashboard"
+
+
+def save_dashboard(
+	html: str,
+	dashboard_title: str | None = None,
+	name: str | None = None,
+	theme: str | None = None,
+	description: str | None = None,
+) -> dict:
+	"""Persist the authored dashboard HTML as a real ``Jarvis Dashboard``.
+
+	Args:
+	  html: the FULL self-contained HTML document (inline CSS/JS only; live
+	    sources declared in the ``jarvis-sources`` script block are parsed out
+	    server-side).
+	  dashboard_title: required on the first save of a conversation's dashboard.
+	  name: the saved dashboard's name, required when revising (returned by the
+	    first call — pass it back on every iteration).
+	  theme: Jarvis | Insight | Claude | Graphite | Custom (defaults server-side).
+	  description: optional one-line summary.
+
+	Returns ``{dashboard, dashboard_title, dashboard_type, theme}``.
+	"""
+	from jarvis.chat import dashboards_api
+	from jarvis.chat.events import publish_to_user
+	from jarvis.tools._agent_run_ctx import get_session_key
+
+	if not (html or "").strip():
+		raise InvalidArgumentError("save_dashboard requires a non-empty html document")
+
+	session_key = get_session_key()
+	if not session_key:
+		raise InvalidArgumentError(
+			"save_dashboard must be called from a chat agent session "
+			"(no session_key in context)"
+		)
+
+	conv = frappe.db.get_value(
+		CONVERSATION,
+		{"session_key": session_key},
+		["name", "owner"],
+		as_dict=True,
+	)
+	if not conv:
+		raise InvalidArgumentError("no chat conversation is bound to this session")
+	# The dispatcher already impersonated the mapped user; a mismatch here means
+	# the session/conversation binding drifted — refuse rather than cross-save.
+	if frappe.session.user != conv.owner:
+		raise InvalidArgumentError("session user does not own this conversation")
+
+	fields: dict = {"html": html, "source_conversation": conv.name}
+	if name:
+		row = frappe.db.get_value(
+			DASHBOARD, name, ["name", "source_conversation"], as_dict=True
+		)
+		if not row:
+			raise InvalidArgumentError(f"no saved dashboard named {name!r}")
+		if (row.source_conversation or "") != conv.name:
+			raise InvalidArgumentError(
+				"that dashboard belongs to a different conversation; "
+				"omit name to save a new one"
+			)
+		fields["name"] = name
+	else:
+		if not (dashboard_title or "").strip():
+			raise InvalidArgumentError(
+				"dashboard_title is required on the first save"
+			)
+	if dashboard_title:
+		fields["dashboard_title"] = dashboard_title
+	if theme:
+		fields["theme"] = theme
+	if description:
+		fields["description"] = description
+
+	try:
+		result = dashboards_api.save_dashboard(payload=frappe.as_json(fields))
+	except frappe.ValidationError as e:
+		# Caps, scope, sources shape, and the theme validator all land here —
+		# hand the model the message so it can fix the document and re-save.
+		raise InvalidArgumentError(str(e))
+
+	detail = (result or {}).get("data") or {}
+	saved_name = detail.get("name")
+	publish_to_user(
+		conv.owner,
+		{
+			"kind": "dashboard",
+			"conversation_id": conv.name,
+			"name": saved_name,
+			"dashboard_title": detail.get("dashboard_title"),
+		},
+	)
+	# Same test-vs-live commit discipline as save_agent_dashboard: keep the
+	# enclosing test transaction rollback-able; make the row durable live.
+	if not frappe.flags.in_test:
+		frappe.db.commit()
+
+	return {
+		"dashboard": saved_name,
+		"dashboard_title": detail.get("dashboard_title"),
+		"dashboard_type": detail.get("dashboard_type"),
+		"theme": detail.get("theme"),
+	}

--- a/jarvis/tools/save_dashboard.py
+++ b/jarvis/tools/save_dashboard.py
@@ -62,8 +62,7 @@ def save_dashboard(
 	session_key = get_session_key()
 	if not session_key:
 		raise InvalidArgumentError(
-			"save_dashboard must be called from a chat agent session "
-			"(no session_key in context)"
+			"save_dashboard must be called from a chat agent session (no session_key in context)"
 		)
 
 	conv = frappe.db.get_value(
@@ -81,22 +80,17 @@ def save_dashboard(
 
 	fields: dict = {"html": html, "source_conversation": conv.name}
 	if name:
-		row = frappe.db.get_value(
-			DASHBOARD, name, ["name", "source_conversation"], as_dict=True
-		)
+		row = frappe.db.get_value(DASHBOARD, name, ["name", "source_conversation"], as_dict=True)
 		if not row:
 			raise InvalidArgumentError(f"no saved dashboard named {name!r}")
 		if (row.source_conversation or "") != conv.name:
 			raise InvalidArgumentError(
-				"that dashboard belongs to a different conversation; "
-				"omit name to save a new one"
+				"that dashboard belongs to a different conversation; omit name to save a new one"
 			)
 		fields["name"] = name
 	else:
 		if not (dashboard_title or "").strip():
-			raise InvalidArgumentError(
-				"dashboard_title is required on the first save"
-			)
+			raise InvalidArgumentError("dashboard_title is required on the first save")
 	if dashboard_title:
 		fields["dashboard_title"] = dashboard_title
 	if theme:

--- a/jarvis/tools/save_dashboard.py
+++ b/jarvis/tools/save_dashboard.py
@@ -116,10 +116,10 @@ def save_dashboard(
 			"dashboard_title": detail.get("dashboard_title"),
 		},
 	)
-	# Same test-vs-live commit discipline as save_agent_dashboard: keep the
-	# enclosing test transaction rollback-able; make the row durable live.
-	if not frappe.flags.in_test:
-		frappe.db.commit()
+	# No commit here: dashboards_api.save_dashboard already committed the row
+	# unconditionally (its own contract with the SPA Save button). Tests must
+	# clean up their rows by hand - the enclosing test transaction does NOT
+	# roll this back (test_save_dashboard_tool.py does exactly that).
 
 	return {
 		"dashboard": saved_name,

--- a/jarvis/tools/tool-names.json
+++ b/jarvis/tools/tool-names.json
@@ -18,7 +18,7 @@
     "repo copies are compared by it, because no CI job can see both repos."
   ],
   "contract_version": 1,
-  "digest": "sha256:b149cc1ef06e0655fe91b1d6a1ffc3a1ee25b1d7d00ba78de4d4d3824e753401",
+  "digest": "sha256:5956acaed23f3096f10be2a6724e77be91e77928bc29ac7910408a0a9080f0b4",
   "tools": [
     "add_comment",
     "add_tag",
@@ -81,6 +81,7 @@
     "run_method",
     "run_report",
     "save_agent_dashboard",
+    "save_dashboard",
     "scan_barcode",
     "send_email",
     "share_doc",


### PR DESCRIPTION
## Summary

Implements #884: dashboard builds never touch the agent-runtime canvas again. Main chat now redirects a dashboard ask to the Dashboards builder (new `jarvis-goto` fence, seeded prompt, one-shot auto-navigate), the builder shows the phase-tick build animation from live tool events, and the built HTML is delivered by a new `save_dashboard` registry tool that saves a real Jarvis Dashboard and publishes a `dashboard` frame the builder renders via its saved-row path.

Merge order: this PR first, then jarvis-openclaw-plugin (tool descriptor), then jarvis-persona (skill rewrite). Old canvas machinery stays for old transcripts; removing it is a later cleanup.

Live e2e (e2e.localhost, integration of all three branches): redirect fired once, interview asked only the undecided question, phase ticks ran, `Jarvis Dashboard` row saved Connected with `source_conversation` stamped, revision updated in place and re-rendered live, zero canvas events, zero fallback Error Logs, zero `[embed]` markers. Known follow-up: the very first event-driven adoption can render blank until reload (revision re-renders fine).

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`**
- [x] New/changed behavior has tests (`test_save_dashboard_tool.py`, `chatGoto.test.js`, `dashboardPrefill.spec.js`, `DashboardChatPane.spec.js`, extended block/build-card suites)
- [x] I self-reviewed the diff
