### PR TITLE
feat(export): rich branded-PDF engine for export_document (Slice 1)

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1618,6 +1618,22 @@
 											</svg>
 										</button>
 									</div>
+									<!-- degrade notes for this artifact (e.g. a chart whose
+									     placeholder was missing, or a letterhead not found):
+									     shown deterministically so a degraded document is never
+									     visually identical to a clean one. -->
+									<div
+										v-if="cv.notes && cv.notes.length"
+										class="jv-artifact-notes"
+										role="note"
+									>
+										<span
+											v-for="(nt, ni) in cv.notes"
+											:key="ni"
+											class="jv-artifact-note"
+											>{{ nt }}</span
+										>
+									</div>
 								</template>
 								<div v-if="skillsUsedOf(m).length" class="jv-skillused">
 									<span
@@ -12527,6 +12543,22 @@ onUnmounted(() => {
 .jv-artifact-go {
 	color: var(--text-3);
 	flex: none;
+}
+/* degrade notes under an artifact card: quiet, but present — a degraded document
+   must never look identical to a clean one. */
+.jv-artifact-notes {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin-top: 4px;
+	max-width: 340px;
+}
+.jv-artifact-note {
+	font-size: 11px;
+	line-height: 1.35;
+	color: var(--text-3);
+	padding-left: 10px;
+	border-left: 2px solid var(--border);
 }
 /* the card plus its follow-on action ("Open in Dashboards"), so the button is a
    SIBLING of the card, never nested inside that <button> */

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -510,6 +510,14 @@ def _maybe_attach_artifact(conv_name: str, user: str, result: dict) -> None:
 		"type": typ,
 		"file_url": file_url,
 	}
+	# Surface any degrade notes (e.g. a dropped chart, a letterhead that wasn't
+	# found) DETERMINISTICALLY on the card — otherwise a degraded document looks
+	# identical to a clean one and the user only learns of it if the model happens
+	# to narrate it in prose. Kept as a durable card caption (the receipt-chip
+	# convention: state as data, never prose).
+	notes = data.get("notes")
+	if isinstance(notes, list) and notes:
+		item["notes"] = [str(n) for n in notes][:10]
 	MSG = "Jarvis Chat Message"
 	# Prefer the in-flight (streaming) assistant message; fall back to the latest.
 	rows = frappe.get_all(

--- a/jarvis/telemetry.py
+++ b/jarvis/telemetry.py
@@ -86,25 +86,43 @@ def record_budget_event(
 		pass
 
 
-def record_export_event(tool: str, fmt: str, rows: int, mode: str = "sync", outcome: str = "ok") -> None:
+def record_export_event(
+	tool: str,
+	fmt: str,
+	rows: int,
+	mode: str = "sync",
+	outcome: str = "ok",
+	rich: bool | None = None,
+	detail: str | None = None,
+) -> None:
 	"""One line per server-side export ATTEMPT (export_query etc.): format, row
-	count, sync/background, and ``outcome`` (ok / no_data / denied / rejected).
+	count, sync/background, and ``outcome`` (ok / degraded / no_data / rejected).
 	Emitting on the fail-closed paths too is the point - the refused large exports
 	are exactly the signal that would justify raising the ceiling / building the
-	async path. Routes through the same INFO-pinned logger. Never raises."""
+	async path.
+
+	``rich`` distinguishes export_document's new branded path from its
+	byte-preserved plain path (they would otherwise collapse to one tuple), and
+	``detail`` carries a short failure reason so a systemic regression (a bad chart
+	pattern, a wkhtmltopdf bump) can be reconstructed from the stream rather than
+	guessed. Both are omitted from the line when not supplied. Routes through the
+	same INFO-pinned logger. Never raises."""
 	try:
-		_emit(
-			{
-				"kind": "export",
-				"ts": frappe.utils.now(),
-				"site": getattr(frappe.local, "site", None),
-				"tool": tool,
-				"format": fmt,
-				"rows": int(rows),
-				"mode": mode,
-				"outcome": outcome,
-			}
-		)
+		entry = {
+			"kind": "export",
+			"ts": frappe.utils.now(),
+			"site": getattr(frappe.local, "site", None),
+			"tool": tool,
+			"format": fmt,
+			"rows": int(rows),
+			"mode": mode,
+			"outcome": outcome,
+		}
+		if rich is not None:
+			entry["rich"] = bool(rich)
+		if detail:
+			entry["detail"] = str(detail)[:200]
+		_emit(entry)
 	except Exception:
 		pass
 

--- a/jarvis/tests/test_export_document.py
+++ b/jarvis/tests/test_export_document.py
@@ -2,16 +2,39 @@
 
 save_file is mocked so we inspect the exact bytes the tool produced (real
 render engines still run — get_pdf / md_to_html / pypdfium2).
+
+Two test tiers live here:
+
+  * ``TestExportDocument*`` (``FrappeTestCase``) — the ORIGINAL plain-path suite.
+    These need a site (they run in the bench gate / ``bench run-tests``).
+  * ``TestRich*`` / ``TestPlainPathBackCompat`` (plain ``unittest.TestCase``) —
+    the Slice-1 rich-path orchestration suite. Everything site-dependent
+    (``render_pdf`` shells out to wkhtmltopdf; ``save_export_file``/``save_file``/
+    ``get_pdf``/telemetry touch the site) is mocked, so these run under bare
+    pytest from the worktree AND under the bench gate. They are the load-bearing
+    proof of the dual-path branch / splice / guard / order / telemetry logic.
 """
 
 from __future__ import annotations
 
+import os
+import unittest
 from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+# Frappe's file logger writes to a cwd-relative ``../logs`` (frappe/utils/logger.py),
+# and importing ``frappe.utils.pdf`` opens a cssutils handler there at import time. A
+# real bench already has that directory; bare pytest run from a worktree does not, so
+# the site-free unit tests below (which mock frappe.utils.pdf.get_pdf) would hit a
+# FileNotFoundError. Create it ONLY when running site-free (no bench init) so the
+# real ``bench run-tests`` gate — where a site is initialized — is untouched.
+if not getattr(frappe.local, "site", None):
+	os.makedirs(os.path.join(os.pardir, "logs"), exist_ok=True)
+
 from jarvis.exceptions import InvalidArgumentError, NoDataError
+from jarvis.tools._export.document.sanitizer import sanitize_rich as _real_sanitize_rich
 from jarvis.tools.export_document import export_document
 
 _MD = "# Report\n\n| Metric | Value |\n|---|---|\n| Revenue | 1000 |\n\n- point one\n"
@@ -191,3 +214,314 @@ class TestExportDocumentSanitization(FrappeTestCase):
 		m = self._mock()
 		export_document("x" * 200_000, format="html")
 		self.assertTrue(m.called)
+
+
+# ---------------------------------------------------------------------------
+# Slice-1 RICH PATH orchestration (site-free unit tests)
+#
+# export_document imports frappe (md_to_html / save_file / telemetry) and the
+# rich render shells out to wkhtmltopdf. We mock the site-dependent seams at the
+# module namespace so these prove the *orchestration* — the dual-path branch,
+# the post-sanitize splice, the guards, the sanitize→render order, and the
+# telemetry outcome — without needing a bench.
+# ---------------------------------------------------------------------------
+
+_MODULE = "jarvis.tools.export_document"
+_RICH_MD = "# Report\n\nSome prose.\n"
+
+
+class _RichBase(unittest.TestCase):
+	"""Common mocks: render_pdf (no wkhtmltopdf locally), the two savers, and
+	telemetry (touches frappe.local). sanitize_rich / component_css / css_bar stay
+	REAL — they are pure modules, so the splice/order assertions exercise the true
+	code path."""
+
+	def setUp(self):
+		self.render = patch(f"{_MODULE}.render_pdf", return_value=b"%PDF-1.4 fake").start()
+		self.save_rich = patch(
+			f"{_MODULE}.save_export_file",
+			return_value={
+				"file_url": "/private/files/document.pdf",
+				"filename": "document.pdf",
+				"title": "Document",
+				"mime_type": "application/pdf",
+				"size_bytes": 12,
+				"name": "F-RICH",
+			},
+		).start()
+		# Plain path uses its own save_file + get_pdf; keep them site-free too.
+		self.save_plain = patch("frappe.utils.file_manager.save_file").start()
+		self.save_plain.return_value = frappe._dict(
+			file_url="/private/files/doc.out", file_name="doc.out", file_size=1, name="F-PLAIN"
+		)
+		self.get_pdf = patch("frappe.utils.pdf.get_pdf", return_value=b"%PDF-plain").start()
+		self.telemetry = patch(f"{_MODULE}.telemetry.record_export_event").start()
+		self.addCleanup(patch.stopall)
+
+	def _rich_doc_body(self) -> str:
+		"""The composed doc_body export_document handed render_pdf."""
+		self.assertTrue(self.render.called, "render_pdf was not called (took the plain path?)")
+		return self.render.call_args.args[0]
+
+
+class TestDualPathBranching(_RichBase):
+	"""Branch on TRUTHY (non-empty) rich kwargs. Empty ≠ present."""
+
+	def test_no_rich_kwargs_takes_plain_path(self):
+		# The load-bearing regression: a legacy call renders through the plain
+		# get_pdf path and NEVER touches the rich renderer.
+		export_document(_RICH_MD, format="pdf", title="Legacy")
+		self.assertTrue(self.get_pdf.called)
+		self.assertFalse(self.render.called)
+		self.assertTrue(self.save_plain.called)
+		self.assertFalse(self.save_rich.called)
+
+	def test_falsy_rich_kwargs_stay_plain(self):
+		# empty string / empty list / False / None must NOT flip to rich.
+		for kw in (
+			{"header": ""},
+			{"footer": ""},
+			{"watermark": ""},
+			{"charts": []},
+			{"theme": False},
+			{"letterhead": None},
+			{"letterhead": ""},
+			{"letterhead": False},
+		):
+			with self.subTest(kw=kw):
+				self.render.reset_mock()
+				self.get_pdf.reset_mock()
+				export_document(_RICH_MD, format="pdf", **kw)
+				self.assertFalse(self.render.called, f"{kw} wrongly flipped to the rich path")
+				self.assertTrue(self.get_pdf.called)
+
+	def test_truthy_rich_kwargs_take_rich_path(self):
+		for kw in (
+			{"theme": True},
+			{"header": "Confidential"},
+			{"footer": "page footer"},
+			{"watermark": "DRAFT"},
+			{"letterhead": "Standard"},
+			{"letterhead": True},
+			{"charts": [{"rows": [{"label": "A", "value": "1", "pct": 50}]}]},
+		):
+			with self.subTest(kw=kw):
+				self.render.reset_mock()
+				self.get_pdf.reset_mock()
+				# charts case needs its token so the splice has a home.
+				content = "{{chart:0}}\n\nbody" if "charts" in kw else _RICH_MD
+				export_document(content, format="pdf", **kw)
+				self.assertTrue(self.render.called, f"{kw} did not flip to the rich path")
+				self.assertFalse(self.get_pdf.called)
+
+
+class TestRichPipeline(_RichBase):
+	def test_sanitize_runs_on_full_body_before_render(self):
+		"""Structural order spy: sanitize_rich is called on the body, and its
+		stripping is visible in the exact doc_body handed to render_pdf, which runs
+		strictly AFTER sanitize."""
+		order = []
+
+		def spy_sanitize(html):
+			order.append("sanitize")
+			return _real_sanitize_rich(html)
+
+		def spy_render(doc_body, **kw):
+			order.append("render")
+			spy_render.doc_body = doc_body
+			return b"%PDF-1.4 fake"
+
+		with (
+			patch(f"{_MODULE}.sanitize_rich", side_effect=spy_sanitize),
+			patch(f"{_MODULE}.render_pdf", side_effect=spy_render),
+		):
+			export_document(
+				"<p>keep me</p><script>alert(1)</script>",
+				format="pdf",
+				content_is_html=True,
+				theme=True,
+			)
+		self.assertEqual(order, ["sanitize", "render"])
+		self.assertIn("keep me", spy_render.doc_body)
+		self.assertNotIn("<script", spy_render.doc_body)  # sanitize ran before render
+
+	def test_chart_token_spliced_post_sanitize_into_render_body(self):
+		"""{{chart:0}} is replaced by css_bar() output — tool-generated HTML added
+		AFTER sanitize — and that output reaches the doc_body render_pdf sees."""
+		with patch(f"{_MODULE}.css_bar", return_value="<div>SENTINEL_BAR</div>") as bar:
+			export_document(
+				"<p>{{chart:0}}</p>",
+				format="pdf",
+				content_is_html=True,
+				charts=[{"rows": [{"label": "A", "value": "1", "pct": 50}]}],
+			)
+		self.assertTrue(bar.called)
+		body = self._rich_doc_body()
+		self.assertIn("SENTINEL_BAR", body)
+		self.assertNotIn("{{chart:0}}", body)
+		# THEME_CSS is tool-added after sanitize.
+		self.assertIn("<style>", body)
+		self.assertIn("bar-chart", body)  # component_css contract class present
+
+	def test_post_sanitize_empty_raises_no_data(self):
+		# content that sanitizes to nothing must never yield a blank PDF.
+		with self.assertRaises(NoDataError):
+			export_document("<script>only unsafe</script>", content_is_html=True, theme=True)
+		self.assertFalse(self.render.called)
+
+	def test_too_many_charts_raises_invalid_argument(self):
+		import jarvis.tools.export_document as ed
+
+		specs = [{"rows": []} for _ in range(ed._MAX_CHARTS + 1)]
+		with self.assertRaises(InvalidArgumentError):
+			export_document(_RICH_MD, format="pdf", charts=specs)
+		self.assertFalse(self.render.called)
+
+	def test_max_charts_boundary_accepted(self):
+		import jarvis.tools.export_document as ed
+
+		specs = [{"rows": []} for _ in range(ed._MAX_CHARTS)]
+		export_document(_RICH_MD, format="pdf", charts=specs)  # at the cap: fine
+		self.assertTrue(self.render.called)
+
+	def test_spec_without_token_adds_note(self):
+		out = export_document(
+			"<p>no placeholder here</p>",
+			format="pdf",
+			content_is_html=True,
+			charts=[{"rows": [{"label": "A", "value": "1", "pct": 50}]}],
+		)
+		self.assertTrue(self.render.called)  # no crash
+		self.assertTrue(any("chart 0" in n for n in out["notes"]), out["notes"])
+
+	def test_token_without_spec_adds_note(self):
+		out = export_document(
+			"<p>{{chart:5}}</p>",
+			format="pdf",
+			content_is_html=True,
+			header="Confidential",  # trigger rich without providing chart 5
+		)
+		self.assertTrue(any("chart:5" in n for n in out["notes"]), out["notes"])
+		# the orphan token is not left as literal junk in the document.
+		self.assertNotIn("{{chart:5}}", self._rich_doc_body())
+
+	def test_rich_render_passes_furniture_and_caps_to_render_pdf(self):
+		import jarvis.tools.export_document as ed
+
+		export_document(
+			_RICH_MD,
+			format="pdf",
+			header="H",
+			footer="F",
+			watermark="W",
+			letterhead="Standard",
+			page_size="Letter",
+			orientation="landscape",
+			margins_mm=20,
+			page_numbers=False,
+		)
+		_, kwargs = self.render.call_args
+		self.assertEqual(kwargs["header_html"], "H")
+		self.assertEqual(kwargs["footer_html"], "F")
+		self.assertEqual(kwargs["watermark"], "W")
+		self.assertEqual(kwargs["letterhead"], "Standard")
+		self.assertEqual(kwargs["page_size"], "Letter")
+		self.assertEqual(kwargs["orientation"], "landscape")
+		self.assertEqual(kwargs["margins_mm"], 20)
+		self.assertFalse(kwargs["page_numbers"])
+		self.assertEqual(kwargs["timeout"], ed._RENDER_TIMEOUT_S)
+
+	def test_letterhead_bool_not_forwarded_as_name(self):
+		# letterhead=True triggers rich but is NOT a Letter Head name -> None.
+		export_document(_RICH_MD, format="pdf", letterhead=True)
+		_, kwargs = self.render.call_args
+		self.assertIsNone(kwargs["letterhead"])
+
+	def test_notes_field_present_even_when_clean(self):
+		out = export_document(_RICH_MD, format="pdf", theme=True)
+		self.assertEqual(out["notes"], [])
+
+
+class TestFormatMatrix(_RichBase):
+	def test_html_returns_composed_doc_body(self):
+		out = export_document("<p>hello</p>", format="html", content_is_html=True, theme=True)
+		self.assertFalse(self.render.called)  # html needs no wkhtmltopdf
+		fname, payload = self.save_rich.call_args.args[0], self.save_rich.call_args.args[1]
+		self.assertTrue(fname.endswith(".html"))
+		text = payload.decode("utf-8")
+		self.assertIn("hello", text)
+		self.assertIn("<style>", text)  # component_css composed in
+		self.assertEqual(out["notes"], [])
+
+	def test_html_with_furniture_kwarg_adds_ignored_note(self):
+		out = export_document("<p>hi</p>", format="html", content_is_html=True, header="Confidential")
+		self.assertFalse(self.render.called)
+		self.assertTrue(
+			any("only to PDF" in n or "furniture" in n.lower() for n in out["notes"]), out["notes"]
+		)
+
+	def test_png_renders_pdf_then_rasterizes(self):
+		with patch(f"{_MODULE}._pdf_to_png", return_value=b"\x89PNG-fake") as topng:
+			export_document(_RICH_MD, format="png", theme=True)
+		self.assertTrue(self.render.called)
+		topng.assert_called_once_with(b"%PDF-1.4 fake")
+		self.assertEqual(self.save_rich.call_args.args[1], b"\x89PNG-fake")
+
+
+class TestTelemetry(_RichBase):
+	def _last_outcome(self):
+		self.assertTrue(self.telemetry.called)
+		return self.telemetry.call_args.kwargs["outcome"]
+
+	def test_clean_rich_render_is_ok(self):
+		export_document(_RICH_MD, format="html", theme=True)
+		self.assertEqual(self._last_outcome(), "ok")
+
+	def test_degraded_when_notes_emitted(self):
+		export_document("<p>hi</p>", format="html", content_is_html=True, header="Confidential")
+		self.assertEqual(self._last_outcome(), "degraded")
+
+	def test_plain_path_emits_ok(self):
+		export_document(_RICH_MD, format="html")
+		self.assertEqual(self._last_outcome(), "ok")
+
+	def test_no_data_guard_emits_no_data_outcome(self):
+		with self.assertRaises(NoDataError):
+			export_document("")
+		self.assertEqual(self._last_outcome(), "no_data")
+
+	def test_bad_format_emits_rejected_outcome(self):
+		with self.assertRaises(InvalidArgumentError):
+			export_document(_RICH_MD, format="docx")
+		self.assertEqual(self._last_outcome(), "rejected")
+
+
+class TestPlainPathBackCompatUnit(_RichBase):
+	"""Site-free mirror of the FrappeTestCase plain-path assertions, so the
+	'plain path unchanged' contract is proven under bare pytest too."""
+
+	def _plain_html(self, content, *, content_is_html=False):
+		export_document(content, format="html", content_is_html=content_is_html, title="My Report")
+		return self.save_plain.call_args.args[1].decode("utf-8")
+
+	def test_plain_html_is_standalone_and_renders_markdown(self):
+		text = self._plain_html(_MD)
+		self.assertFalse(self.render.called)
+		self.assertIn("<!doctype html>", text.lower())
+		self.assertIn("<title>My Report</title>", text)
+		self.assertIn("<table", text)
+		self.assertIn("Revenue", text)
+
+	def test_plain_script_and_img_stripped(self):
+		md = self._plain_html("![x](http://169.254.169.254/latest/meta-data/)")
+		self.assertNotIn("<img", md)
+		html_text = self._plain_html("<p>hi</p><script>alert(1)</script>", content_is_html=True)
+		self.assertNotIn("<script", html_text)
+
+	def test_plain_pdf_uses_get_pdf_not_rich(self):
+		out = export_document(_MD, format="pdf", title="d")
+		self.assertTrue(self.get_pdf.called)
+		self.assertFalse(self.render.called)
+		self.assertEqual(self.save_plain.call_args.args[1], b"%PDF-plain")
+		self.assertEqual(out["mime_type"], "application/pdf")
+		self.assertNotIn("notes", out)  # plain return shape unchanged (no notes key)

--- a/jarvis/tests/test_export_document.py
+++ b/jarvis/tests/test_export_document.py
@@ -238,6 +238,10 @@ class _RichBase(unittest.TestCase):
 
 	def setUp(self):
 		self.render = patch(f"{_MODULE}.render_pdf", return_value=b"%PDF-1.4 fake").start()
+		# resolve_letterhead touches frappe.db/has_permission (needs a site); it is
+		# unit-tested directly in test_export_document_furniture. Here it is stubbed
+		# to the "no letterhead, no note" default; letterhead-specific tests override.
+		self.resolve_lh = patch(f"{_MODULE}.resolve_letterhead", return_value=("", "", None)).start()
 		self.save_rich = patch(
 			f"{_MODULE}.save_export_file",
 			return_value={
@@ -396,7 +400,7 @@ class TestRichPipeline(_RichBase):
 
 	def test_token_without_spec_adds_note(self):
 		out = export_document(
-			"<p>{{chart:5}}</p>",
+			"<p>Report body</p><p>{{chart:5}}</p>",  # real body + an orphan token
 			format="pdf",
 			content_is_html=True,
 			header="Confidential",  # trigger rich without providing chart 5
@@ -405,9 +409,96 @@ class TestRichPipeline(_RichBase):
 		# the orphan token is not left as literal junk in the document.
 		self.assertNotIn("{{chart:5}}", self._rich_doc_body())
 
+	def test_blank_after_orphan_token_raises_no_data(self):
+		# content that is ONLY an orphan chart token strips to <p></p> — a childless
+		# skeleton — which must be caught as blank, not shipped as an empty PDF.
+		with self.assertRaises(NoDataError):
+			export_document("{{chart:0}}", content_is_html=False, theme=True)
+		self.assertFalse(self.render.called)
+
+	def test_tag_skeleton_blank_raises_no_data(self):
+		with self.assertRaises(NoDataError):
+			export_document("<div><span></span></div>", content_is_html=True, theme=True)
+		self.assertFalse(self.render.called)
+
+	def test_malformed_chart_rows_degrade_to_note_not_crash(self):
+		# A malformed rows shape (the review's top cross-lane finding) degrades the
+		# chart to a note; the export still succeeds, and telemetry still fires.
+		out = export_document(
+			"<p>Body</p><p>{{chart:0}}</p>",
+			format="pdf",
+			content_is_html=True,
+			charts=[{"rows": [[1, 2]]}],  # 2-tuple rows → css_bar would raise
+		)
+		self.assertTrue(self.render.called)
+		self.assertTrue(any("chart 0" in n for n in out["notes"]), out["notes"])
+		self.assertNotIn("{{chart:0}}", self._rich_doc_body())
+
+	def test_total_chart_rows_cap(self):
+		import jarvis.tools.export_document as ed
+
+		big = [{"rows": [{"label": "x", "value": "1", "pct": 1}] * (ed._MAX_TOTAL_CHART_ROWS + 1)}]
+		with self.assertRaises(InvalidArgumentError):
+			export_document(_RICH_MD, format="pdf", charts=big)
+		self.assertFalse(self.render.called)
+
+	def test_token_in_code_block_left_literal(self):
+		# A {{chart:0}} shown inside <code> is documentation, not a placeholder —
+		# it must NOT be spliced (tree-aware, text-node-only splice).
+		export_document(
+			"<p>Docs:</p><pre><code>{{chart:0}}</code></pre>",
+			format="pdf",
+			content_is_html=True,
+			charts=[{"rows": [{"label": "A", "value": "1", "pct": 50}]}],
+		)
+		body = self._rich_doc_body()
+		self.assertIn("{{chart:0}}", body)  # left literal inside code
+		self.assertNotIn("bar-chart", body.split("<code>")[1].split("</code>")[0])
+
+	def test_token_in_attribute_not_corrupted(self):
+		# A token that survives inside an href must not corrupt the tag (the splice
+		# never touches attribute values).
+		with patch(f"{_MODULE}.css_bar", return_value="<div>BAR</div>"):
+			export_document(
+				'<a href="https://x/{{chart:0}}">link</a>',
+				format="pdf",
+				content_is_html=True,
+				charts=[{"rows": [{"label": "A", "value": "1", "pct": 50}]}],
+			)
+		body = self._rich_doc_body()
+		self.assertNotIn('<div>BAR</div>"', body)  # not spliced INTO the href value
+		self.assertIn("link", body)
+
+	def test_chart_value_with_token_no_double_substitution(self):
+		# chart 0's rendered output contains the literal text "{{chart:1}}"; chart 1
+		# must NOT be spliced into chart 0's already-rendered markup.
+		def fake_bar(rows):
+			label = rows[0]["label"] if rows else ""
+			return f"<div>BAR::{label}</div>"
+
+		with patch(f"{_MODULE}.css_bar", side_effect=fake_bar):
+			export_document(
+				"<p>{{chart:0}}</p><p>{{chart:1}}</p>",
+				format="pdf",
+				content_is_html=True,
+				charts=[{"rows": [{"label": "{{chart:1}}", "value": "x", "pct": 1}]}, {"rows": []}],
+			)
+		body = self._rich_doc_body()
+		# chart 0 rendered once with its literal label; chart 1 rendered once.
+		self.assertEqual(body.count("BAR::"), 2)
+
+	def test_unexpected_error_logged_and_reraised_clean(self):
+		# A bug on the rich path (here: sanitize_rich blows up) must not escape as a
+		# raw 500 — it is caught at the boundary, re-raised clean, and telemetried.
+		with patch(f"{_MODULE}.sanitize_rich", side_effect=RuntimeError("boom")):
+			with self.assertRaises(InvalidArgumentError):
+				export_document(_RICH_MD, format="pdf", theme=True)
+		self.assertEqual(self.telemetry.call_args.kwargs["outcome"], "rejected")
+
 	def test_rich_render_passes_furniture_and_caps_to_render_pdf(self):
 		import jarvis.tools.export_document as ed
 
+		self.resolve_lh.return_value = ("<div>LHH</div>", "<div>LHF</div>", None)
 		export_document(
 			_RICH_MD,
 			format="pdf",
@@ -424,18 +515,43 @@ class TestRichPipeline(_RichBase):
 		self.assertEqual(kwargs["header_html"], "H")
 		self.assertEqual(kwargs["footer_html"], "F")
 		self.assertEqual(kwargs["watermark"], "W")
-		self.assertEqual(kwargs["letterhead"], "Standard")
+		# letterhead is RESOLVED (default lookup + read-perm + image inline) into
+		# safe HTML before render_pdf; the name is never forwarded raw.
+		self.assertEqual(kwargs["letterhead_header"], "<div>LHH</div>")
+		self.assertEqual(kwargs["letterhead_footer"], "<div>LHF</div>")
+		self.assertNotIn("letterhead", kwargs)
 		self.assertEqual(kwargs["page_size"], "Letter")
 		self.assertEqual(kwargs["orientation"], "landscape")
 		self.assertEqual(kwargs["margins_mm"], 20)
 		self.assertFalse(kwargs["page_numbers"])
-		self.assertEqual(kwargs["timeout"], ed._RENDER_TIMEOUT_S)
+		# timeout is the render budget minus pre-render work already spent.
+		self.assertLessEqual(kwargs["timeout"], ed._RENDER_TIMEOUT_S)
+		self.assertGreaterEqual(kwargs["timeout"], 5)
 
-	def test_letterhead_bool_not_forwarded_as_name(self):
-		# letterhead=True triggers rich but is NOT a Letter Head name -> None.
+	def test_letterhead_name_resolved_verbatim(self):
+		export_document(_RICH_MD, format="pdf", letterhead="Acme")
+		self.assertEqual(self.resolve_lh.call_args.args[0], "Acme")
+
+	def test_letterhead_bool_resolves_to_default(self):
+		# letterhead=True triggers rich but is NOT a name -> resolve with None so
+		# the site's DEFAULT Letter Head is used.
 		export_document(_RICH_MD, format="pdf", letterhead=True)
-		_, kwargs = self.render.call_args
-		self.assertIsNone(kwargs["letterhead"])
+		self.assertIsNone(self.resolve_lh.call_args.args[0])
+
+	def test_charts_only_rich_render_still_resolves_default_letterhead(self):
+		# A branded render with no letterhead intent still gets the default one.
+		export_document(
+			"body {{chart:0}}",
+			format="pdf",
+			charts=[{"rows": [{"label": "A", "value": "1", "pct": 50}]}],
+		)
+		self.assertTrue(self.resolve_lh.called)
+		self.assertIsNone(self.resolve_lh.call_args.args[0])
+
+	def test_letterhead_not_found_note_surfaced(self):
+		self.resolve_lh.return_value = ("", "", "letterhead 'Ghost' not found — rendered without it")
+		out = export_document(_RICH_MD, format="pdf", letterhead="Ghost")
+		self.assertTrue(any("Ghost" in n for n in out["notes"]), out["notes"])
 
 	def test_notes_field_present_even_when_clean(self):
 		out = export_document(_RICH_MD, format="pdf", theme=True)
@@ -444,13 +560,18 @@ class TestRichPipeline(_RichBase):
 
 class TestFormatMatrix(_RichBase):
 	def test_html_returns_composed_doc_body(self):
-		out = export_document("<p>hello</p>", format="html", content_is_html=True, theme=True)
+		out = export_document("<p>hello</p>", format="html", content_is_html=True, theme=True, title="Q3")
 		self.assertFalse(self.render.called)  # html needs no wkhtmltopdf
 		fname, payload = self.save_rich.call_args.args[0], self.save_rich.call_args.args[1]
 		self.assertTrue(fname.endswith(".html"))
 		text = payload.decode("utf-8")
 		self.assertIn("hello", text)
 		self.assertIn("<style>", text)  # component_css composed in
+		# rich HTML must be a WELL-FORMED standalone document (doctype + charset +
+		# title), not a bare fragment — else non-ASCII renders as mojibake.
+		self.assertIn("<!doctype html>", text.lower())
+		self.assertIn("charset", text.lower())
+		self.assertIn("<title>Q3</title>", text)
 		self.assertEqual(out["notes"], [])
 
 	def test_html_with_furniture_kwarg_adds_ignored_note(self):
@@ -494,6 +615,15 @@ class TestTelemetry(_RichBase):
 		with self.assertRaises(InvalidArgumentError):
 			export_document(_RICH_MD, format="docx")
 		self.assertEqual(self._last_outcome(), "rejected")
+
+	def test_telemetry_carries_rich_flag(self):
+		# The rich path and the byte-preserved plain path must be distinguishable in
+		# the telemetry stream (they would otherwise collapse to one tuple).
+		export_document(_RICH_MD, format="html", theme=True)
+		self.assertIs(self.telemetry.call_args.kwargs["rich"], True)
+		self.telemetry.reset_mock()
+		export_document(_RICH_MD, format="html")
+		self.assertIs(self.telemetry.call_args.kwargs["rich"], False)
 
 
 class TestPlainPathBackCompatUnit(_RichBase):

--- a/jarvis/tests/test_export_document.py
+++ b/jarvis/tests/test_export_document.py
@@ -13,6 +13,14 @@ Two test tiers live here:
     ``get_pdf``/telemetry touch the site) is mocked, so these run under bare
     pytest from the worktree AND under the bench gate. They are the load-bearing
     proof of the dual-path branch / splice / guard / order / telemetry logic.
+
+Running site-free with BARE pytest: deselect the ``FrappeTestCase`` classes, e.g.
+``-k "not (TestExportDocumentGuards or TestExportDocumentFormats or
+TestExportDocumentSanitization)"``. Otherwise ``FrappeTestCase.setUpClass`` calls
+``frappe.init("test_site")`` (setting ``frappe.local.site`` before failing with
+no real site), which then poisons the site-free guards in the other classes. The
+real bench gate (``bench run-tests``) has a real ``test_site`` and needs no
+deselect.
 """
 
 from __future__ import annotations
@@ -655,3 +663,74 @@ class TestPlainPathBackCompatUnit(_RichBase):
 		self.assertEqual(self.save_plain.call_args.args[1], b"%PDF-plain")
 		self.assertEqual(out["mime_type"], "application/pdf")
 		self.assertNotIn("notes", out)  # plain return shape unchanged (no notes key)
+
+
+class TestBlankAndNoteEdges(_RichBase):
+	def test_entity_whitespace_only_raises_no_data(self):
+		# A doc whose only content is entity-whitespace (&nbsp;) renders blank —
+		# _has_visible_content unescapes entities, so this is caught, not shipped.
+		with self.assertRaises(NoDataError):
+			export_document("<p>&nbsp;&nbsp;</p>", content_is_html=True, theme=True)
+		self.assertFalse(self.render.called)
+
+	def test_chart_only_empty_labels_still_renders(self):
+		# A chart-only doc whose rows carry no label/value still has visible bars —
+		# it must NOT be rejected as blank (bar-chart presence counts as content).
+		out = export_document(
+			"{{chart:0}}",
+			format="pdf",
+			charts=[{"rows": [{"pct": 50}, {"pct": 80}]}],
+		)
+		self.assertTrue(self.render.called)
+		self.assertEqual(out["notes"], [])
+		self.assertIn("bar-chart", self._rich_doc_body())
+
+	def test_token_in_code_with_spec_no_false_not_found_note(self):
+		# A chart referenced ONLY inside a <code> example (left literal) must not be
+		# mis-reported as "placeholder not found" — it IS in the content.
+		out = export_document(
+			"<p>Body</p><pre><code>{{chart:0}}</code></pre>",
+			format="pdf",
+			content_is_html=True,
+			charts=[{"rows": [{"label": "A", "value": "1", "pct": 50}]}],
+		)
+		self.assertEqual(out["notes"], [], out["notes"])
+		self.assertIn("{{chart:0}}", self._rich_doc_body())  # left literal
+
+
+class TestTelemetryDirect(unittest.TestCase):
+	"""Direct coverage of record_export_event's new rich/detail fields (the
+	call-site tests only prove export_document PASSES them; this proves the
+	function actually lands them in the emitted line)."""
+
+	def test_emits_rich_and_detail(self):
+		captured: dict = {}
+		with (
+			patch("jarvis.telemetry._emit", side_effect=lambda e: captured.update(e)),
+			patch("jarvis.telemetry.frappe.utils.now", return_value="2026-01-01 00:00:00"),
+		):
+			from jarvis import telemetry
+
+			telemetry.record_export_event(
+				tool="export_document",
+				fmt="pdf",
+				rows=0,
+				outcome="rejected",
+				rich=True,
+				detail="ValueError: boom",
+			)
+		self.assertEqual(captured.get("kind"), "export")
+		self.assertIs(captured.get("rich"), True)
+		self.assertIn("boom", captured.get("detail", ""))
+
+	def test_omits_rich_and_detail_when_absent(self):
+		captured: dict = {}
+		with (
+			patch("jarvis.telemetry._emit", side_effect=lambda e: captured.update(e)),
+			patch("jarvis.telemetry.frappe.utils.now", return_value="x"),
+		):
+			from jarvis import telemetry
+
+			telemetry.record_export_event(tool="t", fmt="pdf", rows=0)
+		self.assertNotIn("rich", captured)
+		self.assertNotIn("detail", captured)

--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -6,7 +6,7 @@ wkhtmltopdf is ABSENT in local dev (brew removed it), so this suite NEVER runs a
 real render - that is the Frappe Cloud smoke gate. Instead ``subprocess.run`` is
 mocked and ``_resolve_binary`` is stubbed to a fake path, and the assertions
 cover:
-  * the UNCONDITIONAL security/fidelity arg list (parametrized; drop a flag ->
+  * the UNCONDITIONAL security/fidelity arg list (looped; drop a flag ->
     the matching case fails - the mutation target);
   * page-geometry validation (orientation / page_size / margins);
   * header/footer/watermark are run through ``sanitize_rich`` before the temp
@@ -19,15 +19,18 @@ cover:
   * letterhead resolution: image inlining (data kept / remote dropped /
     same-site base64 with perm check) and the not-found degrade note.
 
-The real ``get_letter_head`` + real render are gated (``skipif`` a site) and
+The real ``get_letter_head`` + real render are gated (``skipUnless`` a site) and
 belong to the FC smoke gate.
 """
 
 import os
+import shutil
 import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
 
 import frappe
-import pytest
 
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools._export.document import furniture
@@ -87,357 +90,319 @@ class _Recorder:
 		return self.args[self.args.index(flag) + 1]
 
 
-@pytest.fixture
-def fake_wk(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+class _FurnitureRenderBase(unittest.TestCase):
 	"""Stub the binary resolver + ``subprocess.run`` so ``render_pdf`` runs its
 	full logic (temp files, arg build, cleanup) without a real wkhtmltopdf."""
-	recorder = _Recorder()
-	monkeypatch.setattr(furniture, "_resolve_binary", lambda: "/usr/bin/wkhtmltopdf")
-	monkeypatch.setattr(furniture.subprocess, "run", recorder)
-	return recorder
+
+	def setUp(self) -> None:
+		self.fake_wk = _Recorder()
+		patch.object(furniture, "_resolve_binary", lambda: "/usr/bin/wkhtmltopdf").start()
+		patch.object(furniture.subprocess, "run", self.fake_wk).start()
+		self.addCleanup(patch.stopall)
 
 
 # --- arg list: unconditional security/fidelity flags ------------------------
 
 
-@pytest.mark.parametrize("flag", _REQUIRED_FLAGS)
-def test_required_flag_always_present(flag: str, fake_wk: _Recorder) -> None:
-	# No header/footer/watermark, page numbers off: the leanest render still
-	# carries every security/fidelity flag. Dropping any from _build_args fails
-	# exactly this case (the mutation target).
-	render_pdf("<p>hi</p>", page_numbers=False)
-	assert flag in fake_wk.args
+class TestRequiredFlags(_FurnitureRenderBase):
+	def test_required_flag_always_present(self) -> None:
+		# No header/footer/watermark, page numbers off: the leanest render still
+		# carries every security/fidelity flag. Dropping any from _build_args fails
+		# exactly this case (the mutation target).
+		for flag in _REQUIRED_FLAGS:
+			with self.subTest(flag=flag):
+				render_pdf("<p>hi</p>", page_numbers=False)
+				self.assertIn(flag, self.fake_wk.args)
 
+	def test_encoding_flag_value(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=False)
+		i = self.fake_wk.args.index("--encoding")
+		self.assertEqual(self.fake_wk.args[i + 1], "utf-8")
 
-def test_encoding_flag_value(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=False)
-	i = fake_wk.args.index("--encoding")
-	assert fake_wk.args[i + 1] == "utf-8"
+	def test_page_size_default_and_custom(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertEqual(self.fake_wk.args[self.fake_wk.args.index("--page-size") + 1], "A4")
+		render_pdf("<p>hi</p>", page_size="letter", page_numbers=False)
+		# canonicalized spelling
+		self.assertEqual(self.fake_wk.args[self.fake_wk.args.index("--page-size") + 1], "Letter")
 
+	def test_page_size_invalid_raises(self) -> None:
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", page_size="A2", page_numbers=False)
 
-def test_page_size_default_and_custom(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=False)
-	assert fake_wk.args[fake_wk.args.index("--page-size") + 1] == "A4"
-	render_pdf("<p>hi</p>", page_size="letter", page_numbers=False)
-	# canonicalized spelling
-	assert fake_wk.args[fake_wk.args.index("--page-size") + 1] == "Letter"
+	def test_orientation_portrait_default(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertEqual(self.fake_wk.args[self.fake_wk.args.index("--orientation") + 1], "Portrait")
 
+	def test_orientation_landscape(self) -> None:
+		render_pdf("<p>hi</p>", orientation="landscape", page_numbers=False)
+		self.assertEqual(self.fake_wk.args[self.fake_wk.args.index("--orientation") + 1], "Landscape")
 
-def test_page_size_invalid_raises(fake_wk: _Recorder) -> None:
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", page_size="A2", page_numbers=False)
+	def test_orientation_invalid_raises(self) -> None:
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", orientation="sideways")
 
+	def test_margins_all_four_sides(self) -> None:
+		render_pdf("<p>hi</p>", margins_mm=20, page_numbers=False)
+		for side in ("--margin-top", "--margin-bottom", "--margin-left", "--margin-right"):
+			self.assertEqual(self.fake_wk.args[self.fake_wk.args.index(side) + 1], "20mm")
 
-def test_orientation_portrait_default(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=False)
-	assert fake_wk.args[fake_wk.args.index("--orientation") + 1] == "Portrait"
+	def test_margins_negative_raises(self) -> None:
+		# A negative margin would produce a "-5mm" token wkhtmltopdf could mis-parse
+		# as a flag; reject it app-side like orientation.
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", margins_mm=-5)
 
+	def test_margins_too_large_raises(self) -> None:
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", margins_mm=500)
 
-def test_orientation_landscape(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", orientation="landscape", page_numbers=False)
-	assert fake_wk.args[fake_wk.args.index("--orientation") + 1] == "Landscape"
+	def test_reads_stdin_writes_stdout(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertEqual(self.fake_wk.args[-2:], ["-", "-"])
 
+	def test_body_passed_as_input_bytes(self) -> None:
+		render_pdf("<p>UNIQUEBODYMARKER</p>", page_numbers=False)
+		self.assertTrue(isinstance(self.fake_wk.input, bytes))
+		self.assertIn(b"UNIQUEBODYMARKER", self.fake_wk.input)
 
-def test_orientation_invalid_raises(fake_wk: _Recorder) -> None:
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", orientation="sideways")
+	def test_timeout_passed_through_to_subprocess(self) -> None:
+		render_pdf("<p>hi</p>", timeout=13, page_numbers=False)
+		self.assertEqual(self.fake_wk.timeout, 13)
 
-
-def test_margins_all_four_sides(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", margins_mm=20, page_numbers=False)
-	for side in ("--margin-top", "--margin-bottom", "--margin-left", "--margin-right"):
-		assert fake_wk.args[fake_wk.args.index(side) + 1] == "20mm"
-
-
-def test_margins_negative_raises(fake_wk: _Recorder) -> None:
-	# A negative margin would produce a "-5mm" token wkhtmltopdf could mis-parse
-	# as a flag; reject it app-side like orientation.
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", margins_mm=-5)
-
-
-def test_margins_too_large_raises(fake_wk: _Recorder) -> None:
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", margins_mm=500)
-
-
-def test_reads_stdin_writes_stdout(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=False)
-	assert fake_wk.args[-2:] == ["-", "-"]
-
-
-def test_body_passed_as_input_bytes(fake_wk: _Recorder) -> None:
-	render_pdf("<p>UNIQUEBODYMARKER</p>", page_numbers=False)
-	assert isinstance(fake_wk.input, bytes)
-	assert b"UNIQUEBODYMARKER" in fake_wk.input
-
-
-def test_timeout_passed_through_to_subprocess(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", timeout=13, page_numbers=False)
-	assert fake_wk.timeout == 13
-
-
-def test_oversized_furniture_rejected(fake_wk: _Recorder) -> None:
-	# Header/footer/watermark are agent-influenced; an unbounded one is refused
-	# before the pre-render sanitize (the body is capped upstream).
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", header_html="x" * 20_001)
+	def test_oversized_furniture_rejected(self) -> None:
+		# Header/footer/watermark are agent-influenced; an unbounded one is refused
+		# before the pre-render sanitize (the body is capped upstream).
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", header_html="x" * 20_001)
 
 
 # --- header/footer/watermark are sanitized before hitting the temp file ------
 
 
-def test_header_is_sanitized(fake_wk: _Recorder) -> None:
-	render_pdf("<p>body</p>", header_html='<img src="http://evil"><script>x</script><b>keepme</b>')
-	content = fake_wk.file_contents["--header-html"]
-	low = content.lower()
-	assert "<img" not in low
-	assert "evil" not in low
-	assert "<script" not in low
-	assert "keepme" in content
+class TestFurnitureSanitization(_FurnitureRenderBase):
+	def test_header_is_sanitized(self) -> None:
+		render_pdf("<p>body</p>", header_html='<img src="http://evil"><script>x</script><b>keepme</b>')
+		content = self.fake_wk.file_contents["--header-html"]
+		low = content.lower()
+		self.assertNotIn("<img", low)
+		self.assertNotIn("evil", low)
+		self.assertNotIn("<script", low)
+		self.assertIn("keepme", content)
 
+	def test_footer_is_sanitized(self) -> None:
+		render_pdf("<p>body</p>", footer_html='<img src="http://evil"><script>x</script><b>footkeep</b>')
+		content = self.fake_wk.file_contents["--footer-html"]
+		low = content.lower()
+		self.assertNotIn("<img", low)
+		self.assertNotIn("evil", low)
+		self.assertNotIn("<script", low)
+		self.assertIn("footkeep", content)
 
-def test_footer_is_sanitized(fake_wk: _Recorder) -> None:
-	render_pdf("<p>body</p>", footer_html='<img src="http://evil"><script>x</script><b>footkeep</b>')
-	content = fake_wk.file_contents["--footer-html"]
-	low = content.lower()
-	assert "<img" not in low
-	assert "evil" not in low
-	assert "<script" not in low
-	assert "footkeep" in content
-
-
-def test_watermark_is_sanitized_and_rotated_in_header(fake_wk: _Recorder) -> None:
-	render_pdf("<p>body</p>", watermark='DRAFT<img src="http://evil"><script>x</script>')
-	content = fake_wk.file_contents["--header-html"]
-	low = content.lower()
-	assert "<img" not in low
-	assert "evil" not in low
-	assert "<script" not in low
-	assert "jv-watermark" in content
-	assert "rotate(-45deg)" in content
-	assert "DRAFT" in content
+	def test_watermark_is_sanitized_and_rotated_in_header(self) -> None:
+		render_pdf("<p>body</p>", watermark='DRAFT<img src="http://evil"><script>x</script>')
+		content = self.fake_wk.file_contents["--header-html"]
+		low = content.lower()
+		self.assertNotIn("<img", low)
+		self.assertNotIn("evil", low)
+		self.assertNotIn("<script", low)
+		self.assertIn("jv-watermark", content)
+		self.assertIn("rotate(-45deg)", content)
+		self.assertIn("DRAFT", content)
 
 
 # --- temp-file lifecycle: created, then removed (success + failures) ---------
 
 
-def test_temp_files_exist_during_call_then_removed(fake_wk: _Recorder) -> None:
-	render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>")
-	for flag in ("--header-html", "--footer-html"):
-		path = fake_wk.path_for(flag)
-		assert fake_wk.files_existed[path] is True, f"{flag} temp missing during call"
-		assert not os.path.exists(path), f"{flag} temp not cleaned up after return"
+class TestTempFileLifecycle(_FurnitureRenderBase):
+	def test_temp_files_exist_during_call_then_removed(self) -> None:
+		render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>")
+		for flag in ("--header-html", "--footer-html"):
+			path = self.fake_wk.path_for(flag)
+			self.assertTrue(self.fake_wk.files_existed[path], f"{flag} temp missing during call")
+			self.assertFalse(os.path.exists(path), f"{flag} temp not cleaned up after return")
+
+	def test_timeout_cleans_temp_and_raises_clean_error(self) -> None:
+		self.fake_wk.raise_timeout = True
+		with self.assertRaises(InvalidArgumentError) as cm:
+			render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>", timeout=7)
+		self.assertIn("7s", str(cm.exception))
+		self.assertFalse(isinstance(cm.exception, subprocess.TimeoutExpired))
+		for flag in ("--header-html", "--footer-html"):
+			self.assertFalse(os.path.exists(self.fake_wk.path_for(flag)))
+
+	def test_oserror_from_exec_is_clean_and_cleans_temp(self) -> None:
+		# The resolved binary fails to EXECUTE (OSError, not TimeoutExpired) → clean
+		# InvalidArgumentError, never a raw OSError, and temp files are cleaned.
+		self.fake_wk.raise_oserror = True
+		with self.assertRaises(InvalidArgumentError) as cm:
+			render_pdf("<p>body</p>", header_html="<b>H</b>")
+		self.assertFalse(isinstance(cm.exception, OSError))
+		self.assertFalse(os.path.exists(self.fake_wk.path_for("--header-html")))
+
+	def test_render_exception_still_cleans_temp(self) -> None:
+		self.fake_wk.returncode = 1
+		self.fake_wk.stderr = b"boom: qt render blew up"
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>body</p>", header_html="<b>H</b>")
+		# temp cleaned even on a non-zero exit (this test's point)
+		self.assertFalse(os.path.exists(self.fake_wk.path_for("--header-html")))
+
+	def test_first_temp_cleaned_when_second_write_fails(self) -> None:
+		# ENOSPC / fd-exhaustion on the SECOND temp write must not orphan the FIRST -
+		# temp creation is inside the try so the finally still cleans it.
+		real_write = furniture._write_temp
+		created: list[str] = []
+		calls = {"n": 0}
+
+		def _wt(tmp_dir: str, content: str) -> str:
+			calls["n"] += 1
+			if calls["n"] == 2:
+				raise OSError("disk full")
+			path = real_write(tmp_dir, content)
+			created.append(path)
+			return path
+
+		patch.object(furniture, "_write_temp", _wt).start()
+		with self.assertRaises(OSError):
+			render_pdf("<p>hi</p>", header_html="<b>H</b>", footer_html="<b>F</b>")
+		self.assertTrue(created, "first temp was never created")
+		self.assertFalse(os.path.exists(created[0]), "first temp leaked when the second write failed")
+
+	def test_two_calls_use_distinct_temp_names(self) -> None:
+		render_pdf("<p>a</p>", header_html="<b>H</b>")
+		first = self.fake_wk.path_for("--header-html")
+		render_pdf("<p>b</p>", header_html="<b>H</b>")
+		second = self.fake_wk.path_for("--header-html")
+		self.assertNotEqual(first, second)
 
 
-def test_timeout_cleans_temp_and_raises_clean_error(fake_wk: _Recorder) -> None:
-	fake_wk.raise_timeout = True
-	with pytest.raises(InvalidArgumentError) as excinfo:
-		render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>", timeout=7)
-	assert "7s" in str(excinfo.value)
-	assert not isinstance(excinfo.value, subprocess.TimeoutExpired)
-	for flag in ("--header-html", "--footer-html"):
-		assert not os.path.exists(fake_wk.path_for(flag))
+class TestWriteTempPartialCleanup(unittest.TestCase):
+	def test_write_temp_removes_partial_on_write_failure(self) -> None:
+		class _BadFile:
+			def __enter__(self):
+				return self
 
+			def __exit__(self, *_a):
+				return False
 
-def test_oserror_from_exec_is_clean_and_cleans_temp(fake_wk: _Recorder) -> None:
-	# The resolved binary fails to EXECUTE (OSError, not TimeoutExpired) → clean
-	# InvalidArgumentError, never a raw OSError, and temp files are cleaned.
-	fake_wk.raise_oserror = True
-	with pytest.raises(InvalidArgumentError) as excinfo:
-		render_pdf("<p>body</p>", header_html="<b>H</b>")
-	assert not isinstance(excinfo.value, OSError)
-	assert not os.path.exists(fake_wk.path_for("--header-html"))
+			def write(self, _data):
+				raise OSError("disk full mid-write")
 
-
-def test_render_exception_still_cleans_temp(fake_wk: _Recorder) -> None:
-	fake_wk.returncode = 1
-	fake_wk.stderr = b"boom: qt render blew up"
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>body</p>", header_html="<b>H</b>")
-	# temp cleaned even on a non-zero exit (this test's point)
-	assert not os.path.exists(fake_wk.path_for("--header-html"))
-
-
-def test_first_temp_cleaned_when_second_write_fails(
-	fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch
-) -> None:
-	# ENOSPC / fd-exhaustion on the SECOND temp write must not orphan the FIRST -
-	# temp creation is inside the try so the finally still cleans it.
-	real_write = furniture._write_temp
-	created: list[str] = []
-	calls = {"n": 0}
-
-	def _wt(tmp_dir: str, content: str) -> str:
-		calls["n"] += 1
-		if calls["n"] == 2:
-			raise OSError("disk full")
-		path = real_write(tmp_dir, content)
-		created.append(path)
-		return path
-
-	monkeypatch.setattr(furniture, "_write_temp", _wt)
-	with pytest.raises(OSError):
-		render_pdf("<p>hi</p>", header_html="<b>H</b>", footer_html="<b>F</b>")
-	assert created, "first temp was never created"
-	assert not os.path.exists(created[0]), "first temp leaked when the second write failed"
-
-
-def test_write_temp_removes_partial_on_write_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-	class _BadFile:
-		def __enter__(self):
-			return self
-
-		def __exit__(self, *_a):
-			return False
-
-		def write(self, _data):
-			raise OSError("disk full mid-write")
-
-	removed: list[str] = []
-	monkeypatch.setattr(furniture, "open", lambda *_a, **_k: _BadFile(), raising=False)
-	monkeypatch.setattr(furniture, "_remove_quietly", lambda p: removed.append(p))
-	with pytest.raises(OSError):
-		furniture._write_temp(str(tmp_path), "content")
-	assert removed, "partial file was not cleaned up on write failure"
-
-
-# --- distinct temp names across calls (generate_hash uniqueness) -------------
-
-
-def test_two_calls_use_distinct_temp_names(fake_wk: _Recorder) -> None:
-	render_pdf("<p>a</p>", header_html="<b>H</b>")
-	first = fake_wk.path_for("--header-html")
-	render_pdf("<p>b</p>", header_html="<b>H</b>")
-	second = fake_wk.path_for("--header-html")
-	assert first != second
+		removed: list[str] = []
+		tmp_dir = tempfile.mkdtemp()
+		self.addCleanup(shutil.rmtree, tmp_dir, ignore_errors=True)
+		patch.object(furniture, "open", lambda *_a, **_k: _BadFile(), create=True).start()
+		patch.object(furniture, "_remove_quietly", lambda p: removed.append(p)).start()
+		self.addCleanup(patch.stopall)
+		with self.assertRaises(OSError):
+			furniture._write_temp(tmp_dir, "content")
+		self.assertTrue(removed, "partial file was not cleaned up on write failure")
 
 
 # --- output guards -----------------------------------------------------------
 
 
-def test_returns_pdf_bytes_on_success(fake_wk: _Recorder) -> None:
-	out = render_pdf("<p>hi</p>", page_numbers=False)
-	assert out == b"%PDF-1.4 fake pdf bytes"
+class TestOutputGuards(_FurnitureRenderBase):
+	def test_returns_pdf_bytes_on_success(self) -> None:
+		out = render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertEqual(out, b"%PDF-1.4 fake pdf bytes")
 
+	def test_empty_output_raises(self) -> None:
+		self.fake_wk.stdout = b""
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", page_numbers=False)
 
-def test_empty_output_raises(fake_wk: _Recorder) -> None:
-	fake_wk.stdout = b""
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", page_numbers=False)
+	def test_nonpdf_output_raises(self) -> None:
+		# Non-empty but not a PDF (an error page slipping past exit 0) is rejected.
+		self.fake_wk.stdout = b"<html><body>gateway error</body></html>"
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", page_numbers=False)
 
+	def test_nonzero_exit_logs_stderr_but_keeps_it_out_of_user_message(self) -> None:
+		# stderr can carry the /tmp/jv-pdf-<hash>.html temp path — it goes to the
+		# Error Log, NOT the user-facing message (which stays clean).
+		logged: list[dict] = []
+		patch.object(furniture.frappe, "log_error", lambda **k: logged.append(k)).start()
+		self.fake_wk.returncode = 3
+		self.fake_wk.stderr = b"unique-stderr-signature /tmp/jv-pdf-abc.html"
+		with self.assertRaises(InvalidArgumentError) as cm:
+			render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertNotIn("unique-stderr-signature", str(cm.exception))
+		self.assertIn("3", str(cm.exception))  # the exit code is fine to surface
+		self.assertTrue(any("unique-stderr-signature" in str(k.get("message", "")) for k in logged))
 
-def test_nonpdf_output_raises(fake_wk: _Recorder) -> None:
-	# Non-empty but not a PDF (an error page slipping past exit 0) is rejected.
-	fake_wk.stdout = b"<html><body>gateway error</body></html>"
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", page_numbers=False)
-
-
-def test_nonzero_exit_logs_stderr_but_keeps_it_out_of_user_message(
-	fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch
-) -> None:
-	# stderr can carry the /tmp/jv-pdf-<hash>.html temp path — it goes to the
-	# Error Log, NOT the user-facing message (which stays clean).
-	logged: list[dict] = []
-	monkeypatch.setattr(furniture.frappe, "log_error", lambda **k: logged.append(k))
-	fake_wk.returncode = 3
-	fake_wk.stderr = b"unique-stderr-signature /tmp/jv-pdf-abc.html"
-	with pytest.raises(InvalidArgumentError) as excinfo:
-		render_pdf("<p>hi</p>", page_numbers=False)
-	assert "unique-stderr-signature" not in str(excinfo.value)
-	assert "3" in str(excinfo.value)  # the exit code is fine to surface
-	assert any("unique-stderr-signature" in str(k.get("message", "")) for k in logged)
-
-
-def test_infra_failure_is_logged(fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch) -> None:
-	# A working binary misbehaving (non-zero exit) must hit the Error Log so a
-	# systemic regression is visible to operators, not only surfaced to the user.
-	logged: list[dict] = []
-	monkeypatch.setattr(furniture.frappe, "log_error", lambda **k: logged.append(k))
-	fake_wk.returncode = 2
-	fake_wk.stderr = b"err"
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>", page_numbers=False)
-	assert logged, "infra render failure was not logged"
+	def test_infra_failure_is_logged(self) -> None:
+		# A working binary misbehaving (non-zero exit) must hit the Error Log so a
+		# systemic regression is visible to operators, not only surfaced to the user.
+		logged: list[dict] = []
+		patch.object(furniture.frappe, "log_error", lambda **k: logged.append(k)).start()
+		self.fake_wk.returncode = 2
+		self.fake_wk.stderr = b"err"
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertTrue(logged, "infra render failure was not logged")
 
 
 # --- binary resolution -------------------------------------------------------
 
 
-def test_binary_not_found_raises_clean_error(monkeypatch: pytest.MonkeyPatch) -> None:
-	def _no_config(*_a, **_k):
-		raise OSError("No wkhtmltopdf executable found")
+class TestBinaryResolution(unittest.TestCase):
+	def test_binary_not_found_raises_clean_error(self) -> None:
+		def _no_config(*_a, **_k):
+			raise OSError("No wkhtmltopdf executable found")
 
-	monkeypatch.setattr(furniture.pdfkit, "configuration", _no_config)
-	monkeypatch.setattr(furniture.shutil, "which", lambda _name: None)
-	with pytest.raises(InvalidArgumentError):
-		render_pdf("<p>hi</p>")
+		patch.object(furniture.pdfkit, "configuration", _no_config).start()
+		patch.object(furniture.shutil, "which", lambda _name: None).start()
+		self.addCleanup(patch.stopall)
+		with self.assertRaises(InvalidArgumentError):
+			render_pdf("<p>hi</p>")
 
 
 # --- page numbering ----------------------------------------------------------
 
 
-def test_page_numbers_footer_uses_bracket_vars(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=True)
-	assert "--footer-html" in fake_wk.args
-	content = fake_wk.file_contents["--footer-html"]
-	assert "[page]" in content
-	assert "[topage]" in content
+class TestPageNumbering(_FurnitureRenderBase):
+	def test_page_numbers_footer_uses_bracket_vars(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=True)
+		self.assertIn("--footer-html", self.fake_wk.args)
+		content = self.fake_wk.file_contents["--footer-html"]
+		self.assertIn("[page]", content)
+		self.assertIn("[topage]", content)
 
+	def test_no_footer_when_page_numbers_off_and_no_footer(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertNotIn("--footer-html", self.fake_wk.args)
 
-def test_no_footer_when_page_numbers_off_and_no_footer(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=False)
-	assert "--footer-html" not in fake_wk.args
+	def test_no_header_when_nothing_to_render(self) -> None:
+		render_pdf("<p>hi</p>", page_numbers=False)
+		self.assertNotIn("--header-html", self.fake_wk.args)
 
-
-def test_no_header_when_nothing_to_render(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", page_numbers=False)
-	assert "--header-html" not in fake_wk.args
-
-
-def test_explicit_footer_suppresses_auto_page_numbers(fake_wk: _Recorder) -> None:
-	render_pdf("<p>hi</p>", footer_html="<b>my-footer</b>", page_numbers=True)
-	content = fake_wk.file_contents["--footer-html"]
-	assert "my-footer" in content
-	assert "[page]" not in content
+	def test_explicit_footer_suppresses_auto_page_numbers(self) -> None:
+		render_pdf("<p>hi</p>", footer_html="<b>my-footer</b>", page_numbers=True)
+		content = self.fake_wk.file_contents["--footer-html"]
+		self.assertIn("my-footer", content)
+		self.assertNotIn("[page]", content)
 
 
 # --- letterhead: folding (pre-resolved, trusted HTML) -----------------------
 
 
-def test_letterhead_header_footer_folded(fake_wk: _Recorder) -> None:
-	# render_pdf receives ALREADY-RESOLVED, safe letterhead HTML and folds it in
-	# as-is (it is not re-sanitized - the images were neutralised in resolve).
-	render_pdf(
-		"<p>hi</p>",
-		letterhead_header="<div>LH-HEADER-MARK</div>",
-		letterhead_footer="<div>LH-FOOTER-MARK</div>",
-		page_numbers=False,
-	)
-	assert "LH-HEADER-MARK" in fake_wk.file_contents["--header-html"]
-	assert "LH-FOOTER-MARK" in fake_wk.file_contents["--footer-html"]
+class TestLetterheadFolding(_FurnitureRenderBase):
+	def test_letterhead_header_footer_folded(self) -> None:
+		# render_pdf receives ALREADY-RESOLVED, safe letterhead HTML and folds it in
+		# as-is (it is not re-sanitized - the images were neutralised in resolve).
+		render_pdf(
+			"<p>hi</p>",
+			letterhead_header="<div>LH-HEADER-MARK</div>",
+			letterhead_footer="<div>LH-FOOTER-MARK</div>",
+			page_numbers=False,
+		)
+		self.assertIn("LH-HEADER-MARK", self.fake_wk.file_contents["--header-html"])
+		self.assertIn("LH-FOOTER-MARK", self.fake_wk.file_contents["--footer-html"])
 
 
 # --- letterhead: image inlining (the SSRF fix), site-free via stubs ----------
-
-
-def test_inline_keeps_data_uri() -> None:
-	src = '<img src="data:image/png;base64,AAAA">'
-	assert furniture._inline_letterhead_images(src) == src
-
-
-def test_inline_drops_remote_image() -> None:
-	out = furniture._inline_letterhead_images('<p>x</p><img src="http://evil/logo.png"><p>y</p>')
-	assert "<img" not in out.lower()
-	assert "evil" not in out.lower()
-	assert "x" in out and "y" in out
-
-
-def test_inline_drops_protocol_relative_image() -> None:
-	out = furniture._inline_letterhead_images('<img src="//evil/logo.png">')
-	assert "<img" not in out.lower()
-	assert "evil" not in out.lower()
 
 
 class _FakeDB:
@@ -468,96 +433,115 @@ class _PngFile:
 		return b"\x89PNG\r\n\x1a\nDATA"  # valid PNG magic → passes the image sniff
 
 
-def test_inline_same_site_to_base64_with_perm(monkeypatch: pytest.MonkeyPatch) -> None:
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
-	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile())
-	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
-	assert "data:image/png;base64," in out
-	assert "http" not in out.lower()
+class TestInlineLetterheadImages(unittest.TestCase):
+	def test_inline_keeps_data_uri(self) -> None:
+		src = '<img src="data:image/png;base64,AAAA">'
+		self.assertEqual(furniture._inline_letterhead_images(src), src)
 
+	def test_inline_drops_remote_image(self) -> None:
+		out = furniture._inline_letterhead_images('<p>x</p><img src="http://evil/logo.png"><p>y</p>')
+		self.assertNotIn("<img", out.lower())
+		self.assertNotIn("evil", out.lower())
+		self.assertTrue("x" in out and "y" in out)
 
-def test_inline_same_site_dropped_without_perm(monkeypatch: pytest.MonkeyPatch) -> None:
-	# get_doc is mocked to SUCCEED so the drop is attributable ONLY to
-	# has_permission=False — if the perm check were removed, this would LEAK a
-	# base64 image and the test would fail (mutation-catching).
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: False)
-	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile())
-	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
-	assert "<img" not in out.lower()
-	assert "base64" not in out.lower()
+	def test_inline_drops_protocol_relative_image(self) -> None:
+		out = furniture._inline_letterhead_images('<img src="//evil/logo.png">')
+		self.assertNotIn("<img", out.lower())
+		self.assertNotIn("evil", out.lower())
 
+	def test_inline_same_site_to_base64_with_perm(self) -> None:
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv())).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: True).start()
+		patch.object(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile()).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
+		self.assertIn("data:image/png;base64,", out)
+		self.assertNotIn("http", out.lower())
 
-def test_inline_unknown_file_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv(name=None)))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
-	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile())
-	out = furniture._inline_letterhead_images('<img src="/files/missing.png">')
-	assert "<img" not in out.lower()
+	def test_inline_same_site_dropped_without_perm(self) -> None:
+		# get_doc is mocked to SUCCEED so the drop is attributable ONLY to
+		# has_permission=False — if the perm check were removed, this would LEAK a
+		# base64 image and the test would fail (mutation-catching).
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv())).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: False).start()
+		patch.object(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile()).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
+		self.assertNotIn("<img", out.lower())
+		self.assertNotIn("base64", out.lower())
 
+	def test_inline_unknown_file_dropped(self) -> None:
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv(name=None))).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: True).start()
+		patch.object(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile()).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/missing.png">')
+		self.assertNotIn("<img", out.lower())
 
-def test_inline_oversized_logo_dropped_before_read(monkeypatch: pytest.MonkeyPatch) -> None:
-	# An oversized File is rejected on its file_size BEFORE get_content is called.
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv(size=furniture._MAX_LOGO_BYTES + 1)))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+	def test_inline_oversized_logo_dropped_before_read(self) -> None:
+		# An oversized File is rejected on its file_size BEFORE get_content is called.
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv(size=furniture._MAX_LOGO_BYTES + 1))).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: True).start()
 
-	def _boom(*_a, **_k):
-		raise AssertionError("get_content must not be called for an oversized logo")
+		def _boom(*_a, **_k):
+			raise AssertionError("get_content must not be called for an oversized logo")
 
-	monkeypatch.setattr(furniture.frappe, "get_doc", _boom)
-	out = furniture._inline_letterhead_images('<img src="/files/huge.png">')
-	assert "<img" not in out.lower()
+		patch.object(furniture.frappe, "get_doc", _boom).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/huge.png">')
+		self.assertNotIn("<img", out.lower())
 
+	def test_inline_nonimage_bytes_dropped(self) -> None:
+		# A file whose bytes are not an image (mislabeled *.png) is not inlined.
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv())).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: True).start()
 
-def test_inline_nonimage_bytes_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
-	# A file whose bytes are not an image (mislabeled *.png) is not inlined.
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+		class _NotImg:
+			def get_content(self):
+				return b"<html>not an image</html>"
 
-	class _NotImg:
-		def get_content(self):
-			return b"<html>not an image</html>"
+		patch.object(furniture.frappe, "get_doc", lambda *_a, **_k: _NotImg()).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/fake.png">')
+		self.assertNotIn("<img", out.lower())
+		self.assertNotIn("base64", out.lower())
 
-	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _NotImg())
-	out = furniture._inline_letterhead_images('<img src="/files/fake.png">')
-	assert "<img" not in out.lower()
-	assert "base64" not in out.lower()
+	def test_inline_svg_by_extension_refused(self) -> None:
+		# SVG is refused (an inlined data:image/svg+xml is an opaque active-content blob
+		# nh3 can't inspect). A *.svg File is dropped at the mime check, before read.
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv())).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: True).start()
 
+		def _boom(*_a, **_k):
+			raise AssertionError("SVG must be refused before reading it")
 
-def test_inline_svg_by_extension_refused(monkeypatch: pytest.MonkeyPatch) -> None:
-	# SVG is refused (an inlined data:image/svg+xml is an opaque active-content blob
-	# nh3 can't inspect). A *.svg File is dropped at the mime check, before read.
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+		patch.object(furniture.frappe, "get_doc", _boom).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/logo.svg">')
+		self.assertNotIn("<img", out.lower())
 
-	def _boom(*_a, **_k):
-		raise AssertionError("SVG must be refused before reading it")
+	def test_inline_svg_bytes_in_png_name_refused(self) -> None:
+		# SVG bytes smuggled behind a *.png name are refused by the raster-only sniff.
+		patch.object(furniture.frappe, "db", _FakeDB(_file_gv())).start()
+		patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: True).start()
 
-	monkeypatch.setattr(furniture.frappe, "get_doc", _boom)
-	out = furniture._inline_letterhead_images('<img src="/files/logo.svg">')
-	assert "<img" not in out.lower()
+		class _Svg:
+			def get_content(self):
+				return b'<svg xmlns="x"><image href="http://169.254.169.254/x"/></svg>'
 
-
-def test_inline_svg_bytes_in_png_name_refused(monkeypatch: pytest.MonkeyPatch) -> None:
-	# SVG bytes smuggled behind a *.png name are refused by the raster-only sniff.
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
-
-	class _Svg:
-		def get_content(self):
-			return b'<svg xmlns="x"><image href="http://169.254.169.254/x"/></svg>'
-
-	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _Svg())
-	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
-	assert "<img" not in out.lower()
-	assert "169.254" not in out
+		patch.object(furniture.frappe, "get_doc", lambda *_a, **_k: _Svg()).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
+		self.assertNotIn("<img", out.lower())
+		self.assertNotIn("169.254", out)
 
 
 # --- letterhead: resolution + degrade note, site-free via stubs --------------
 
 
-def _stub_letterhead(monkeypatch, *, default=None, docs=None, perms=True):
+def _stub_letterhead(*, default=None, docs=None, perms=True):
+	"""Patch ``frappe.db``/``has_permission`` to site-free stubs. Patches are
+	started but not stopped - the caller must ``self.addCleanup(patch.stopall)``."""
 	docs = docs or {}
 
 	def _get_value(_dt, filt, _field=None, **_k):
@@ -565,83 +549,82 @@ def _stub_letterhead(monkeypatch, *, default=None, docs=None, perms=True):
 			return default
 		return docs.get(filt)  # named/default-name doc lookup
 
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_get_value))
-	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: perms)
+	patch.object(furniture.frappe, "db", _FakeDB(_get_value)).start()
+	patch.object(furniture.frappe, "has_permission", lambda *_a, **_k: perms).start()
 
 
-def test_resolve_letterhead_default_used_when_unnamed(monkeypatch: pytest.MonkeyPatch) -> None:
-	_stub_letterhead(
-		monkeypatch,
-		default="Std",
-		docs={"Std": {"content": "<div>HDR</div>", "footer": "<div>FTR</div>"}},
-	)
-	header, footer, note = resolve_letterhead(None)
-	assert "HDR" in header and "FTR" in footer
-	assert note is None
+class TestResolveLetterhead(unittest.TestCase):
+	def test_resolve_letterhead_default_used_when_unnamed(self) -> None:
+		_stub_letterhead(
+			default="Std",
+			docs={"Std": {"content": "<div>HDR</div>", "footer": "<div>FTR</div>"}},
+		)
+		self.addCleanup(patch.stopall)
+		header, footer, note = resolve_letterhead(None)
+		self.assertTrue("HDR" in header and "FTR" in footer)
+		self.assertIsNone(note)
 
+	def test_resolve_letterhead_named(self) -> None:
+		_stub_letterhead(docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}})
+		self.addCleanup(patch.stopall)
+		header, _footer, note = resolve_letterhead("Acme")
+		self.assertIn("ACME", header)
+		self.assertIsNone(note)
 
-def test_resolve_letterhead_named(monkeypatch: pytest.MonkeyPatch) -> None:
-	_stub_letterhead(monkeypatch, docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}})
-	header, _footer, note = resolve_letterhead("Acme")
-	assert "ACME" in header
-	assert note is None
+	def test_resolve_letterhead_no_default_no_note(self) -> None:
+		_stub_letterhead(default=None)
+		self.addCleanup(patch.stopall)
+		header, footer, note = resolve_letterhead(None)
+		self.assertTrue(header == "" and footer == "")
+		self.assertIsNone(note)  # no default configured is a normal unbranded render
 
+	def test_resolve_letterhead_named_not_found_notes(self) -> None:
+		_stub_letterhead(docs={})  # named lookup returns None
+		self.addCleanup(patch.stopall)
+		header, footer, note = resolve_letterhead("Nope")
+		self.assertTrue(header == "" and footer == "")
+		self.assertTrue(note and "Nope" in note)
 
-def test_resolve_letterhead_no_default_no_note(monkeypatch: pytest.MonkeyPatch) -> None:
-	_stub_letterhead(monkeypatch, default=None)
-	header, footer, note = resolve_letterhead(None)
-	assert header == "" and footer == ""
-	assert note is None  # no default configured is a normal unbranded render
+	def test_resolve_letterhead_no_read_perm_notes(self) -> None:
+		_stub_letterhead(docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}}, perms=False)
+		self.addCleanup(patch.stopall)
+		header, _footer, note = resolve_letterhead("Acme")
+		self.assertEqual(header, "")
+		self.assertTrue(note and "Acme" in note)
 
+	def test_resolve_letterhead_strips_remote_image_end_to_end(self) -> None:
+		# The F1 SSRF gate wired through resolve_letterhead: a Letter Head whose content
+		# carries a remote <img>/<link> must come back with NO remote URL (the gate runs
+		# after inlining), while benign text survives.
+		_stub_letterhead(
+			docs={
+				"Evil": {
+					"content": '<div>Acme<img src="http://169.254.169.254/x">'
+					'<link href="http://evil/x.css"></div>',
+					"footer": "",
+				}
+			},
+		)
+		self.addCleanup(patch.stopall)
+		header, _footer, note = resolve_letterhead("Evil")
+		low = header.lower()
+		self.assertTrue("169.254" not in low and "evil" not in low)
+		self.assertNotIn("<link", low)
+		self.assertIn("Acme", header)
+		self.assertIsNone(note)
 
-def test_resolve_letterhead_named_not_found_notes(monkeypatch: pytest.MonkeyPatch) -> None:
-	_stub_letterhead(monkeypatch, docs={})  # named lookup returns None
-	header, footer, note = resolve_letterhead("Nope")
-	assert header == "" and footer == ""
-	assert note and "Nope" in note
+	def test_remove_quietly_suppresses_oserror(self) -> None:
+		# A non-FileNotFound OSError (e.g. EPERM) during cleanup must be swallowed so
+		# the finally loop can't abort (leaking the other temp) or mask the real error.
+		def _raise(_p):
+			raise PermissionError("EPERM")
 
+		patch.object(furniture.os, "remove", _raise).start()
+		self.addCleanup(patch.stopall)
+		furniture._remove_quietly("/tmp/whatever")  # must NOT raise
 
-def test_resolve_letterhead_no_read_perm_notes(monkeypatch: pytest.MonkeyPatch) -> None:
-	_stub_letterhead(monkeypatch, docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}}, perms=False)
-	header, _footer, note = resolve_letterhead("Acme")
-	assert header == ""
-	assert note and "Acme" in note
-
-
-def test_resolve_letterhead_strips_remote_image_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
-	# The F1 SSRF gate wired through resolve_letterhead: a Letter Head whose content
-	# carries a remote <img>/<link> must come back with NO remote URL (the gate runs
-	# after inlining), while benign text survives.
-	_stub_letterhead(
-		monkeypatch,
-		docs={
-			"Evil": {
-				"content": '<div>Acme<img src="http://169.254.169.254/x">'
-				'<link href="http://evil/x.css"></div>',
-				"footer": "",
-			}
-		},
-	)
-	header, _footer, note = resolve_letterhead("Evil")
-	low = header.lower()
-	assert "169.254" not in low and "evil" not in low
-	assert "<link" not in low
-	assert "Acme" in header
-	assert note is None
-
-
-def test_remove_quietly_suppresses_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
-	# A non-FileNotFound OSError (e.g. EPERM) during cleanup must be swallowed so
-	# the finally loop can't abort (leaking the other temp) or mask the real error.
-	def _raise(_p):
-		raise PermissionError("EPERM")
-
-	monkeypatch.setattr(furniture.os, "remove", _raise)
-	furniture._remove_quietly("/tmp/whatever")  # must NOT raise
-
-
-@pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (get_letter_head / File)")
-def test_resolve_letterhead_real_default() -> None:
-	header, footer, note = resolve_letterhead(None)
-	assert isinstance(header, str) and isinstance(footer, str)
-	assert note is None
+	@unittest.skipUnless(_HAS_SITE, "needs a bench site (get_letter_head / File)")
+	def test_resolve_letterhead_real_default(self) -> None:
+		header, footer, note = resolve_letterhead(None)
+		self.assertTrue(isinstance(header, str) and isinstance(footer, str))
+		self.assertIsNone(note)

--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -1,0 +1,314 @@
+"""Tests for ``jarvis.tools._export.document.furniture.render_pdf`` (the rich-PDF
+render core: security flags + a real subprocess render timeout).
+
+wkhtmltopdf is ABSENT in local dev (brew removed it), so this suite NEVER runs a
+real render - that is the Frappe Cloud smoke gate. Instead ``subprocess.run`` is
+mocked and ``_resolve_binary`` is stubbed to a fake path, and the assertions
+cover:
+  * the UNCONDITIONAL security/fidelity arg list (parametrized; drop a flag ->
+    the matching case fails - the mutation target);
+  * header/footer/watermark are run through ``sanitize_rich`` before the temp
+    file is written (a mock reads each temp file WHILE it still exists);
+  * temp-file lifecycle: created for the call, gone after return, AND removed on a
+    ``TimeoutExpired`` (which surfaces as a clean ``InvalidArgumentError``);
+  * distinct temp names across calls; empty-output guard; binary-not-found.
+
+``fmt_amount``-style site-dependent behavior and the real ``get_letter_head`` /
+real render are gated (skipped) here and belong to the FC smoke gate.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._export.document import furniture
+from jarvis.tools._export.document.furniture import render_pdf
+
+# The security/fidelity flags that MUST appear on every render, unconditionally.
+_REQUIRED_FLAGS = [
+	"--disable-local-file-access",
+	"--disable-javascript",
+	"--background",
+	"--images",
+	"--print-media-type",
+	"--disable-smart-shrinking",
+	"--quiet",
+]
+
+
+class _Recorder:
+	"""Stand-in for ``subprocess.run``. Records the arg list / stdin / timeout,
+	and - crucially - reads any ``--header-html``/``--footer-html`` temp file
+	WHILE the call is in flight (before the ``finally`` cleanup deletes it), so a
+	test can assert both the file's sanitized content and that it existed at call
+	time."""
+
+	def __init__(self) -> None:
+		self.args: list[str] | None = None
+		self.input: bytes | None = None
+		self.timeout: int | None = None
+		self.file_contents: dict[str, str] = {}
+		self.files_existed: dict[str, bool] = {}
+		self.returncode = 0
+		self.stdout = b"%PDF-1.4 fake pdf bytes"
+		self.stderr = b""
+		self.raise_timeout = False
+
+	def __call__(self, args, input=None, capture_output=False, timeout=None):
+		self.args = list(args)
+		self.input = input
+		self.timeout = timeout
+		for flag in ("--header-html", "--footer-html"):
+			if flag in self.args:
+				path = self.args[self.args.index(flag) + 1]
+				self.files_existed[path] = os.path.exists(path)
+				with open(path, encoding="utf-8") as fh:
+					self.file_contents[flag] = fh.read()
+		if self.raise_timeout:
+			raise subprocess.TimeoutExpired(args, timeout)
+		return subprocess.CompletedProcess(args, self.returncode, self.stdout, self.stderr)
+
+	def path_for(self, flag: str) -> str:
+		assert self.args is not None
+		return self.args[self.args.index(flag) + 1]
+
+
+@pytest.fixture
+def fake_wk(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+	"""Stub the binary resolver + ``subprocess.run`` so ``render_pdf`` runs its
+	full logic (temp files, arg build, cleanup) without a real wkhtmltopdf."""
+	recorder = _Recorder()
+	monkeypatch.setattr(furniture, "_resolve_binary", lambda: "/usr/bin/wkhtmltopdf")
+	monkeypatch.setattr(furniture.subprocess, "run", recorder)
+	return recorder
+
+
+# --- arg list: unconditional security/fidelity flags ------------------------
+
+
+@pytest.mark.parametrize("flag", _REQUIRED_FLAGS)
+def test_required_flag_always_present(flag: str, fake_wk: _Recorder) -> None:
+	# No header/footer/watermark/letterhead, page numbers off: the leanest render
+	# still carries every security/fidelity flag. Dropping any from _build_args
+	# fails exactly this case (the mutation target).
+	render_pdf("<p>hi</p>", page_numbers=False)
+	assert flag in fake_wk.args
+
+
+def test_encoding_flag_value(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=False)
+	i = fake_wk.args.index("--encoding")
+	assert fake_wk.args[i + 1] == "utf-8"
+
+
+def test_page_size_default_and_custom(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=False)
+	assert fake_wk.args[fake_wk.args.index("--page-size") + 1] == "A4"
+	render_pdf("<p>hi</p>", page_size="Letter", page_numbers=False)
+	assert fake_wk.args[fake_wk.args.index("--page-size") + 1] == "Letter"
+
+
+def test_orientation_portrait_default(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=False)
+	assert fake_wk.args[fake_wk.args.index("--orientation") + 1] == "Portrait"
+
+
+def test_orientation_landscape(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", orientation="landscape", page_numbers=False)
+	assert fake_wk.args[fake_wk.args.index("--orientation") + 1] == "Landscape"
+
+
+def test_orientation_invalid_raises(fake_wk: _Recorder) -> None:
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", orientation="sideways")
+
+
+def test_margins_all_four_sides(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", margins_mm=20, page_numbers=False)
+	for side in ("--margin-top", "--margin-bottom", "--margin-left", "--margin-right"):
+		assert fake_wk.args[fake_wk.args.index(side) + 1] == "20mm"
+
+
+def test_reads_stdin_writes_stdout(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=False)
+	assert fake_wk.args[-2:] == ["-", "-"]
+
+
+def test_body_passed_as_input_bytes(fake_wk: _Recorder) -> None:
+	render_pdf("<p>UNIQUEBODYMARKER</p>", page_numbers=False)
+	assert isinstance(fake_wk.input, bytes)
+	assert b"UNIQUEBODYMARKER" in fake_wk.input
+
+
+def test_timeout_passed_through_to_subprocess(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", timeout=13, page_numbers=False)
+	assert fake_wk.timeout == 13
+
+
+# --- header/footer/watermark are sanitized before hitting the temp file ------
+
+
+def test_header_is_sanitized(fake_wk: _Recorder) -> None:
+	render_pdf("<p>body</p>", header_html='<img src="http://evil"><script>x</script><b>keepme</b>')
+	content = fake_wk.file_contents["--header-html"]
+	low = content.lower()
+	assert "<img" not in low
+	assert "evil" not in low
+	assert "<script" not in low
+	assert "keepme" in content
+
+
+def test_footer_is_sanitized(fake_wk: _Recorder) -> None:
+	render_pdf("<p>body</p>", footer_html='<img src="http://evil"><script>x</script><b>footkeep</b>')
+	content = fake_wk.file_contents["--footer-html"]
+	low = content.lower()
+	assert "<img" not in low
+	assert "evil" not in low
+	assert "<script" not in low
+	assert "footkeep" in content
+
+
+def test_watermark_is_sanitized_and_rotated_in_header(fake_wk: _Recorder) -> None:
+	render_pdf("<p>body</p>", watermark='DRAFT<img src="http://evil"><script>x</script>')
+	content = fake_wk.file_contents["--header-html"]
+	low = content.lower()
+	# sanitized: no fetch-capable/active markup from the agent survives
+	assert "<img" not in low
+	assert "evil" not in low
+	assert "<script" not in low
+	# but the tool-controlled rotate block and the (escaped-safe) text remain
+	assert "jv-watermark" in content
+	assert "rotate(-45deg)" in content
+	assert "DRAFT" in content
+
+
+# --- temp-file lifecycle: created, then removed (success + timeout) ----------
+
+
+def test_temp_files_exist_during_call_then_removed(fake_wk: _Recorder) -> None:
+	render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>")
+	for flag in ("--header-html", "--footer-html"):
+		path = fake_wk.path_for(flag)
+		assert fake_wk.files_existed[path] is True, f"{flag} temp missing during call"
+		assert not os.path.exists(path), f"{flag} temp not cleaned up after return"
+
+
+def test_timeout_cleans_temp_and_raises_clean_error(fake_wk: _Recorder) -> None:
+	fake_wk.raise_timeout = True
+	with pytest.raises(InvalidArgumentError) as excinfo:
+		render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>", timeout=7)
+	# clean, actionable message - NOT a raw TimeoutExpired
+	assert "7s" in str(excinfo.value)
+	assert not isinstance(excinfo.value, subprocess.TimeoutExpired)
+	# finally-block removed the temp files even though the render "hung"
+	for flag in ("--header-html", "--footer-html"):
+		assert not os.path.exists(fake_wk.path_for(flag))
+
+
+def test_render_exception_still_cleans_temp(fake_wk: _Recorder) -> None:
+	# A non-zero exit is a render failure; temp files must still be cleaned.
+	fake_wk.returncode = 1
+	fake_wk.stderr = b"boom: qt render blew up"
+	with pytest.raises(InvalidArgumentError) as excinfo:
+		render_pdf("<p>body</p>", header_html="<b>H</b>")
+	assert "boom" in str(excinfo.value)
+	assert not os.path.exists(fake_wk.path_for("--header-html"))
+
+
+# --- distinct temp names across calls (generate_hash uniqueness) -------------
+
+
+def test_two_calls_use_distinct_temp_names(fake_wk: _Recorder) -> None:
+	render_pdf("<p>a</p>", header_html="<b>H</b>")
+	first = fake_wk.path_for("--header-html")
+	render_pdf("<p>b</p>", header_html="<b>H</b>")
+	second = fake_wk.path_for("--header-html")
+	assert first != second
+
+
+# --- output guards -----------------------------------------------------------
+
+
+def test_returns_pdf_bytes_on_success(fake_wk: _Recorder) -> None:
+	out = render_pdf("<p>hi</p>", page_numbers=False)
+	assert out == b"%PDF-1.4 fake pdf bytes"
+
+
+def test_empty_output_raises(fake_wk: _Recorder) -> None:
+	fake_wk.stdout = b""
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", page_numbers=False)
+
+
+def test_nonzero_exit_includes_stderr_tail(fake_wk: _Recorder) -> None:
+	fake_wk.returncode = 3
+	fake_wk.stderr = b"unique-stderr-signature"
+	with pytest.raises(InvalidArgumentError) as excinfo:
+		render_pdf("<p>hi</p>", page_numbers=False)
+	assert "unique-stderr-signature" in str(excinfo.value)
+
+
+# --- binary resolution -------------------------------------------------------
+
+
+def test_binary_not_found_raises_clean_error(monkeypatch: pytest.MonkeyPatch) -> None:
+	def _no_config(*_a, **_k):
+		raise OSError("No wkhtmltopdf executable found")
+
+	monkeypatch.setattr(furniture.pdfkit, "configuration", _no_config)
+	monkeypatch.setattr(furniture.shutil, "which", lambda _name: None)
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>")
+
+
+# --- page numbering ----------------------------------------------------------
+
+
+def test_page_numbers_footer_uses_bracket_vars(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=True)
+	assert "--footer-html" in fake_wk.args
+	content = fake_wk.file_contents["--footer-html"]
+	assert "[page]" in content
+	assert "[topage]" in content
+
+
+def test_no_footer_when_page_numbers_off_and_no_footer(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=False)
+	assert "--footer-html" not in fake_wk.args
+
+
+def test_no_header_when_nothing_to_render(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", page_numbers=False)
+	assert "--header-html" not in fake_wk.args
+
+
+def test_explicit_footer_suppresses_auto_page_numbers(fake_wk: _Recorder) -> None:
+	render_pdf("<p>hi</p>", footer_html="<b>my-footer</b>", page_numbers=True)
+	content = fake_wk.file_contents["--footer-html"]
+	assert "my-footer" in content
+	assert "[page]" not in content
+
+
+# --- letterhead: fold logic (site-free via a stub); real call is gated -------
+
+
+def test_letterhead_folded_into_header_and_footer(
+	fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	# Stub the site-dependent Letter Head lookup; assert its header/footer HTML is
+	# folded into the composed temp documents (trusted config, not re-sanitized).
+	monkeypatch.setattr(
+		furniture,
+		"_letterhead_parts",
+		lambda name: ("<div>LH-HEADER-MARK</div>", "<div>LH-FOOTER-MARK</div>"),
+	)
+	render_pdf("<p>hi</p>", letterhead="Standard", page_numbers=False)
+	assert "LH-HEADER-MARK" in fake_wk.file_contents["--header-html"]
+	assert "LH-FOOTER-MARK" in fake_wk.file_contents["--footer-html"]
+
+
+@pytest.mark.skip(reason="needs bench site — FC smoke gate (real get_letter_head + real render)")
+def test_letterhead_real_lookup() -> None:
+	render_pdf("<p>hi</p>", letterhead="Standard")

--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -253,9 +253,9 @@ def test_oserror_from_exec_is_clean_and_cleans_temp(fake_wk: _Recorder) -> None:
 def test_render_exception_still_cleans_temp(fake_wk: _Recorder) -> None:
 	fake_wk.returncode = 1
 	fake_wk.stderr = b"boom: qt render blew up"
-	with pytest.raises(InvalidArgumentError) as excinfo:
+	with pytest.raises(InvalidArgumentError):
 		render_pdf("<p>body</p>", header_html="<b>H</b>")
-	assert "boom" in str(excinfo.value)
+	# temp cleaned even on a non-zero exit (this test's point)
 	assert not os.path.exists(fake_wk.path_for("--header-html"))
 
 
@@ -334,12 +334,20 @@ def test_nonpdf_output_raises(fake_wk: _Recorder) -> None:
 		render_pdf("<p>hi</p>", page_numbers=False)
 
 
-def test_nonzero_exit_includes_stderr_tail(fake_wk: _Recorder) -> None:
+def test_nonzero_exit_logs_stderr_but_keeps_it_out_of_user_message(
+	fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	# stderr can carry the /tmp/jv-pdf-<hash>.html temp path — it goes to the
+	# Error Log, NOT the user-facing message (which stays clean).
+	logged: list[dict] = []
+	monkeypatch.setattr(furniture.frappe, "log_error", lambda **k: logged.append(k))
 	fake_wk.returncode = 3
-	fake_wk.stderr = b"unique-stderr-signature"
+	fake_wk.stderr = b"unique-stderr-signature /tmp/jv-pdf-abc.html"
 	with pytest.raises(InvalidArgumentError) as excinfo:
 		render_pdf("<p>hi</p>", page_numbers=False)
-	assert "unique-stderr-signature" in str(excinfo.value)
+	assert "unique-stderr-signature" not in str(excinfo.value)
+	assert "3" in str(excinfo.value)  # the exit code is fine to surface
+	assert any("unique-stderr-signature" in str(k.get("message", "")) for k in logged)
 
 
 def test_infra_failure_is_logged(fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -443,31 +451,78 @@ class _FakeDB:
 		return self._gv(*a, **k)
 
 
+def _file_gv(name="FILE1", size=100):
+	"""A field-aware File.get_value stub: the file_url→name lookup returns ``name``
+	(or None to simulate 'no such File'), and the file_size lookup returns ``size``."""
+
+	def gv(_dt, _filt, field=None, **_k):
+		if field == "file_size":
+			return size
+		return name
+
+	return gv
+
+
+class _PngFile:
+	def get_content(self):
+		return b"\x89PNG\r\n\x1a\nDATA"  # valid PNG magic → passes the image sniff
+
+
 def test_inline_same_site_to_base64_with_perm(monkeypatch: pytest.MonkeyPatch) -> None:
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(lambda *_a, **_k: "FILE1"))
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
 	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
-
-	class _F:
-		def get_content(self):
-			return b"\x89PNG\r\n\x1a\nDATA"
-
-	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _F())
+	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile())
 	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
 	assert "data:image/png;base64," in out
 	assert "http" not in out.lower()
 
 
 def test_inline_same_site_dropped_without_perm(monkeypatch: pytest.MonkeyPatch) -> None:
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(lambda *_a, **_k: "FILE1"))
+	# get_doc is mocked to SUCCEED so the drop is attributable ONLY to
+	# has_permission=False — if the perm check were removed, this would LEAK a
+	# base64 image and the test would fail (mutation-catching).
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
 	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: False)
+	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile())
 	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
 	assert "<img" not in out.lower()
+	assert "base64" not in out.lower()
 
 
 def test_inline_unknown_file_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
-	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(lambda *_a, **_k: None))
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv(name=None)))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _PngFile())
 	out = furniture._inline_letterhead_images('<img src="/files/missing.png">')
 	assert "<img" not in out.lower()
+
+
+def test_inline_oversized_logo_dropped_before_read(monkeypatch: pytest.MonkeyPatch) -> None:
+	# An oversized File is rejected on its file_size BEFORE get_content is called.
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv(size=furniture._MAX_LOGO_BYTES + 1)))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+
+	def _boom(*_a, **_k):
+		raise AssertionError("get_content must not be called for an oversized logo")
+
+	monkeypatch.setattr(furniture.frappe, "get_doc", _boom)
+	out = furniture._inline_letterhead_images('<img src="/files/huge.png">')
+	assert "<img" not in out.lower()
+
+
+def test_inline_nonimage_bytes_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+	# A file whose bytes are not an image (mislabeled *.png) is not inlined.
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+
+	class _NotImg:
+		def get_content(self):
+			return b"<html>not an image</html>"
+
+	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _NotImg())
+	out = furniture._inline_letterhead_images('<img src="/files/fake.png">')
+	assert "<img" not in out.lower()
+	assert "base64" not in out.lower()
 
 
 # --- letterhead: resolution + degrade note, site-free via stubs --------------
@@ -522,6 +577,38 @@ def test_resolve_letterhead_no_read_perm_notes(monkeypatch: pytest.MonkeyPatch) 
 	header, _footer, note = resolve_letterhead("Acme")
 	assert header == ""
 	assert note and "Acme" in note
+
+
+def test_resolve_letterhead_strips_remote_image_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+	# The F1 SSRF gate wired through resolve_letterhead: a Letter Head whose content
+	# carries a remote <img>/<link> must come back with NO remote URL (the gate runs
+	# after inlining), while benign text survives.
+	_stub_letterhead(
+		monkeypatch,
+		docs={
+			"Evil": {
+				"content": '<div>Acme<img src="http://169.254.169.254/x">'
+				'<link href="http://evil/x.css"></div>',
+				"footer": "",
+			}
+		},
+	)
+	header, _footer, note = resolve_letterhead("Evil")
+	low = header.lower()
+	assert "169.254" not in low and "evil" not in low
+	assert "<link" not in low
+	assert "Acme" in header
+	assert note is None
+
+
+def test_remove_quietly_suppresses_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+	# A non-FileNotFound OSError (e.g. EPERM) during cleanup must be swallowed so
+	# the finally loop can't abort (leaking the other temp) or mask the real error.
+	def _raise(_p):
+		raise PermissionError("EPERM")
+
+	monkeypatch.setattr(furniture.os, "remove", _raise)
+	furniture._remove_quietly("/tmp/whatever")  # must NOT raise
 
 
 @pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (get_letter_head / File)")

--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -525,6 +525,35 @@ def test_inline_nonimage_bytes_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
 	assert "base64" not in out.lower()
 
 
+def test_inline_svg_by_extension_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+	# SVG is refused (an inlined data:image/svg+xml is an opaque active-content blob
+	# nh3 can't inspect). A *.svg File is dropped at the mime check, before read.
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+
+	def _boom(*_a, **_k):
+		raise AssertionError("SVG must be refused before reading it")
+
+	monkeypatch.setattr(furniture.frappe, "get_doc", _boom)
+	out = furniture._inline_letterhead_images('<img src="/files/logo.svg">')
+	assert "<img" not in out.lower()
+
+
+def test_inline_svg_bytes_in_png_name_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+	# SVG bytes smuggled behind a *.png name are refused by the raster-only sniff.
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_file_gv()))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+
+	class _Svg:
+		def get_content(self):
+			return b'<svg xmlns="x"><image href="http://169.254.169.254/x"/></svg>'
+
+	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _Svg())
+	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
+	assert "<img" not in out.lower()
+	assert "169.254" not in out
+
+
 # --- letterhead: resolution + degrade note, site-free via stubs --------------
 
 

--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -1,5 +1,6 @@
 """Tests for ``jarvis.tools._export.document.furniture.render_pdf`` (the rich-PDF
-render core: security flags + a real subprocess render timeout).
+render core: security flags + a real subprocess render timeout) and its
+letterhead resolution (default lookup, read-perm, image inlining).
 
 wkhtmltopdf is ABSENT in local dev (brew removed it), so this suite NEVER runs a
 real render - that is the Frappe Cloud smoke gate. Instead ``subprocess.run`` is
@@ -7,24 +8,32 @@ mocked and ``_resolve_binary`` is stubbed to a fake path, and the assertions
 cover:
   * the UNCONDITIONAL security/fidelity arg list (parametrized; drop a flag ->
     the matching case fails - the mutation target);
+  * page-geometry validation (orientation / page_size / margins);
   * header/footer/watermark are run through ``sanitize_rich`` before the temp
     file is written (a mock reads each temp file WHILE it still exists);
-  * temp-file lifecycle: created for the call, gone after return, AND removed on a
-    ``TimeoutExpired`` (which surfaces as a clean ``InvalidArgumentError``);
-  * distinct temp names across calls; empty-output guard; binary-not-found.
+  * temp-file lifecycle: created for the call, gone after return, removed on a
+    ``TimeoutExpired`` / ``OSError`` / non-zero exit, and the FIRST temp cleaned
+    when the SECOND write fails;
+  * output guards: empty output, non-zero exit (+stderr tail), non-PDF output,
+    and that every infra failure is logged;
+  * letterhead resolution: image inlining (data kept / remote dropped /
+    same-site base64 with perm check) and the not-found degrade note.
 
-``fmt_amount``-style site-dependent behavior and the real ``get_letter_head`` /
-real render are gated (skipped) here and belong to the FC smoke gate.
+The real ``get_letter_head`` + real render are gated (``skipif`` a site) and
+belong to the FC smoke gate.
 """
 
 import os
 import subprocess
 
+import frappe
 import pytest
 
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools._export.document import furniture
-from jarvis.tools._export.document.furniture import render_pdf
+from jarvis.tools._export.document.furniture import render_pdf, resolve_letterhead
+
+_HAS_SITE = bool(getattr(frappe.local, "site", None))
 
 # The security/fidelity flags that MUST appear on every render, unconditionally.
 _REQUIRED_FLAGS = [
@@ -55,6 +64,7 @@ class _Recorder:
 		self.stdout = b"%PDF-1.4 fake pdf bytes"
 		self.stderr = b""
 		self.raise_timeout = False
+		self.raise_oserror = False
 
 	def __call__(self, args, input=None, capture_output=False, timeout=None):
 		self.args = list(args)
@@ -68,6 +78,8 @@ class _Recorder:
 					self.file_contents[flag] = fh.read()
 		if self.raise_timeout:
 			raise subprocess.TimeoutExpired(args, timeout)
+		if self.raise_oserror:
+			raise OSError("wkhtmltopdf failed to execute")
 		return subprocess.CompletedProcess(args, self.returncode, self.stdout, self.stderr)
 
 	def path_for(self, flag: str) -> str:
@@ -90,9 +102,9 @@ def fake_wk(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
 
 @pytest.mark.parametrize("flag", _REQUIRED_FLAGS)
 def test_required_flag_always_present(flag: str, fake_wk: _Recorder) -> None:
-	# No header/footer/watermark/letterhead, page numbers off: the leanest render
-	# still carries every security/fidelity flag. Dropping any from _build_args
-	# fails exactly this case (the mutation target).
+	# No header/footer/watermark, page numbers off: the leanest render still
+	# carries every security/fidelity flag. Dropping any from _build_args fails
+	# exactly this case (the mutation target).
 	render_pdf("<p>hi</p>", page_numbers=False)
 	assert flag in fake_wk.args
 
@@ -106,8 +118,14 @@ def test_encoding_flag_value(fake_wk: _Recorder) -> None:
 def test_page_size_default_and_custom(fake_wk: _Recorder) -> None:
 	render_pdf("<p>hi</p>", page_numbers=False)
 	assert fake_wk.args[fake_wk.args.index("--page-size") + 1] == "A4"
-	render_pdf("<p>hi</p>", page_size="Letter", page_numbers=False)
+	render_pdf("<p>hi</p>", page_size="letter", page_numbers=False)
+	# canonicalized spelling
 	assert fake_wk.args[fake_wk.args.index("--page-size") + 1] == "Letter"
+
+
+def test_page_size_invalid_raises(fake_wk: _Recorder) -> None:
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", page_size="A2", page_numbers=False)
 
 
 def test_orientation_portrait_default(fake_wk: _Recorder) -> None:
@@ -131,6 +149,18 @@ def test_margins_all_four_sides(fake_wk: _Recorder) -> None:
 		assert fake_wk.args[fake_wk.args.index(side) + 1] == "20mm"
 
 
+def test_margins_negative_raises(fake_wk: _Recorder) -> None:
+	# A negative margin would produce a "-5mm" token wkhtmltopdf could mis-parse
+	# as a flag; reject it app-side like orientation.
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", margins_mm=-5)
+
+
+def test_margins_too_large_raises(fake_wk: _Recorder) -> None:
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", margins_mm=500)
+
+
 def test_reads_stdin_writes_stdout(fake_wk: _Recorder) -> None:
 	render_pdf("<p>hi</p>", page_numbers=False)
 	assert fake_wk.args[-2:] == ["-", "-"]
@@ -145,6 +175,13 @@ def test_body_passed_as_input_bytes(fake_wk: _Recorder) -> None:
 def test_timeout_passed_through_to_subprocess(fake_wk: _Recorder) -> None:
 	render_pdf("<p>hi</p>", timeout=13, page_numbers=False)
 	assert fake_wk.timeout == 13
+
+
+def test_oversized_furniture_rejected(fake_wk: _Recorder) -> None:
+	# Header/footer/watermark are agent-influenced; an unbounded one is refused
+	# before the pre-render sanitize (the body is capped upstream).
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", header_html="x" * 20_001)
 
 
 # --- header/footer/watermark are sanitized before hitting the temp file ------
@@ -174,17 +211,15 @@ def test_watermark_is_sanitized_and_rotated_in_header(fake_wk: _Recorder) -> Non
 	render_pdf("<p>body</p>", watermark='DRAFT<img src="http://evil"><script>x</script>')
 	content = fake_wk.file_contents["--header-html"]
 	low = content.lower()
-	# sanitized: no fetch-capable/active markup from the agent survives
 	assert "<img" not in low
 	assert "evil" not in low
 	assert "<script" not in low
-	# but the tool-controlled rotate block and the (escaped-safe) text remain
 	assert "jv-watermark" in content
 	assert "rotate(-45deg)" in content
 	assert "DRAFT" in content
 
 
-# --- temp-file lifecycle: created, then removed (success + timeout) ----------
+# --- temp-file lifecycle: created, then removed (success + failures) ---------
 
 
 def test_temp_files_exist_during_call_then_removed(fake_wk: _Recorder) -> None:
@@ -199,22 +234,72 @@ def test_timeout_cleans_temp_and_raises_clean_error(fake_wk: _Recorder) -> None:
 	fake_wk.raise_timeout = True
 	with pytest.raises(InvalidArgumentError) as excinfo:
 		render_pdf("<p>body</p>", header_html="<b>H</b>", footer_html="<b>F</b>", timeout=7)
-	# clean, actionable message - NOT a raw TimeoutExpired
 	assert "7s" in str(excinfo.value)
 	assert not isinstance(excinfo.value, subprocess.TimeoutExpired)
-	# finally-block removed the temp files even though the render "hung"
 	for flag in ("--header-html", "--footer-html"):
 		assert not os.path.exists(fake_wk.path_for(flag))
 
 
+def test_oserror_from_exec_is_clean_and_cleans_temp(fake_wk: _Recorder) -> None:
+	# The resolved binary fails to EXECUTE (OSError, not TimeoutExpired) → clean
+	# InvalidArgumentError, never a raw OSError, and temp files are cleaned.
+	fake_wk.raise_oserror = True
+	with pytest.raises(InvalidArgumentError) as excinfo:
+		render_pdf("<p>body</p>", header_html="<b>H</b>")
+	assert not isinstance(excinfo.value, OSError)
+	assert not os.path.exists(fake_wk.path_for("--header-html"))
+
+
 def test_render_exception_still_cleans_temp(fake_wk: _Recorder) -> None:
-	# A non-zero exit is a render failure; temp files must still be cleaned.
 	fake_wk.returncode = 1
 	fake_wk.stderr = b"boom: qt render blew up"
 	with pytest.raises(InvalidArgumentError) as excinfo:
 		render_pdf("<p>body</p>", header_html="<b>H</b>")
 	assert "boom" in str(excinfo.value)
 	assert not os.path.exists(fake_wk.path_for("--header-html"))
+
+
+def test_first_temp_cleaned_when_second_write_fails(
+	fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	# ENOSPC / fd-exhaustion on the SECOND temp write must not orphan the FIRST -
+	# temp creation is inside the try so the finally still cleans it.
+	real_write = furniture._write_temp
+	created: list[str] = []
+	calls = {"n": 0}
+
+	def _wt(tmp_dir: str, content: str) -> str:
+		calls["n"] += 1
+		if calls["n"] == 2:
+			raise OSError("disk full")
+		path = real_write(tmp_dir, content)
+		created.append(path)
+		return path
+
+	monkeypatch.setattr(furniture, "_write_temp", _wt)
+	with pytest.raises(OSError):
+		render_pdf("<p>hi</p>", header_html="<b>H</b>", footer_html="<b>F</b>")
+	assert created, "first temp was never created"
+	assert not os.path.exists(created[0]), "first temp leaked when the second write failed"
+
+
+def test_write_temp_removes_partial_on_write_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+	class _BadFile:
+		def __enter__(self):
+			return self
+
+		def __exit__(self, *_a):
+			return False
+
+		def write(self, _data):
+			raise OSError("disk full mid-write")
+
+	removed: list[str] = []
+	monkeypatch.setattr(furniture, "open", lambda *_a, **_k: _BadFile(), raising=False)
+	monkeypatch.setattr(furniture, "_remove_quietly", lambda p: removed.append(p))
+	with pytest.raises(OSError):
+		furniture._write_temp(str(tmp_path), "content")
+	assert removed, "partial file was not cleaned up on write failure"
 
 
 # --- distinct temp names across calls (generate_hash uniqueness) -------------
@@ -242,12 +327,31 @@ def test_empty_output_raises(fake_wk: _Recorder) -> None:
 		render_pdf("<p>hi</p>", page_numbers=False)
 
 
+def test_nonpdf_output_raises(fake_wk: _Recorder) -> None:
+	# Non-empty but not a PDF (an error page slipping past exit 0) is rejected.
+	fake_wk.stdout = b"<html><body>gateway error</body></html>"
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", page_numbers=False)
+
+
 def test_nonzero_exit_includes_stderr_tail(fake_wk: _Recorder) -> None:
 	fake_wk.returncode = 3
 	fake_wk.stderr = b"unique-stderr-signature"
 	with pytest.raises(InvalidArgumentError) as excinfo:
 		render_pdf("<p>hi</p>", page_numbers=False)
 	assert "unique-stderr-signature" in str(excinfo.value)
+
+
+def test_infra_failure_is_logged(fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch) -> None:
+	# A working binary misbehaving (non-zero exit) must hit the Error Log so a
+	# systemic regression is visible to operators, not only surfaced to the user.
+	logged: list[dict] = []
+	monkeypatch.setattr(furniture.frappe, "log_error", lambda **k: logged.append(k))
+	fake_wk.returncode = 2
+	fake_wk.stderr = b"err"
+	with pytest.raises(InvalidArgumentError):
+		render_pdf("<p>hi</p>", page_numbers=False)
+	assert logged, "infra render failure was not logged"
 
 
 # --- binary resolution -------------------------------------------------------
@@ -291,24 +395,137 @@ def test_explicit_footer_suppresses_auto_page_numbers(fake_wk: _Recorder) -> Non
 	assert "[page]" not in content
 
 
-# --- letterhead: fold logic (site-free via a stub); real call is gated -------
+# --- letterhead: folding (pre-resolved, trusted HTML) -----------------------
 
 
-def test_letterhead_folded_into_header_and_footer(
-	fake_wk: _Recorder, monkeypatch: pytest.MonkeyPatch
-) -> None:
-	# Stub the site-dependent Letter Head lookup; assert its header/footer HTML is
-	# folded into the composed temp documents (trusted config, not re-sanitized).
-	monkeypatch.setattr(
-		furniture,
-		"_letterhead_parts",
-		lambda name: ("<div>LH-HEADER-MARK</div>", "<div>LH-FOOTER-MARK</div>"),
+def test_letterhead_header_footer_folded(fake_wk: _Recorder) -> None:
+	# render_pdf receives ALREADY-RESOLVED, safe letterhead HTML and folds it in
+	# as-is (it is not re-sanitized - the images were neutralised in resolve).
+	render_pdf(
+		"<p>hi</p>",
+		letterhead_header="<div>LH-HEADER-MARK</div>",
+		letterhead_footer="<div>LH-FOOTER-MARK</div>",
+		page_numbers=False,
 	)
-	render_pdf("<p>hi</p>", letterhead="Standard", page_numbers=False)
 	assert "LH-HEADER-MARK" in fake_wk.file_contents["--header-html"]
 	assert "LH-FOOTER-MARK" in fake_wk.file_contents["--footer-html"]
 
 
-@pytest.mark.skip(reason="needs bench site — FC smoke gate (real get_letter_head + real render)")
-def test_letterhead_real_lookup() -> None:
-	render_pdf("<p>hi</p>", letterhead="Standard")
+# --- letterhead: image inlining (the SSRF fix), site-free via stubs ----------
+
+
+def test_inline_keeps_data_uri() -> None:
+	src = '<img src="data:image/png;base64,AAAA">'
+	assert furniture._inline_letterhead_images(src) == src
+
+
+def test_inline_drops_remote_image() -> None:
+	out = furniture._inline_letterhead_images('<p>x</p><img src="http://evil/logo.png"><p>y</p>')
+	assert "<img" not in out.lower()
+	assert "evil" not in out.lower()
+	assert "x" in out and "y" in out
+
+
+def test_inline_drops_protocol_relative_image() -> None:
+	out = furniture._inline_letterhead_images('<img src="//evil/logo.png">')
+	assert "<img" not in out.lower()
+	assert "evil" not in out.lower()
+
+
+class _FakeDB:
+	"""Stand-in for the ``frappe.db`` LocalProxy, which is unbound (raises) without
+	a site - so we replace the whole ``db`` object rather than a method on it."""
+
+	def __init__(self, get_value):
+		self._gv = get_value
+
+	def get_value(self, *a, **k):
+		return self._gv(*a, **k)
+
+
+def test_inline_same_site_to_base64_with_perm(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(lambda *_a, **_k: "FILE1"))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: True)
+
+	class _F:
+		def get_content(self):
+			return b"\x89PNG\r\n\x1a\nDATA"
+
+	monkeypatch.setattr(furniture.frappe, "get_doc", lambda *_a, **_k: _F())
+	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
+	assert "data:image/png;base64," in out
+	assert "http" not in out.lower()
+
+
+def test_inline_same_site_dropped_without_perm(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(lambda *_a, **_k: "FILE1"))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: False)
+	out = furniture._inline_letterhead_images('<img src="/files/logo.png">')
+	assert "<img" not in out.lower()
+
+
+def test_inline_unknown_file_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(lambda *_a, **_k: None))
+	out = furniture._inline_letterhead_images('<img src="/files/missing.png">')
+	assert "<img" not in out.lower()
+
+
+# --- letterhead: resolution + degrade note, site-free via stubs --------------
+
+
+def _stub_letterhead(monkeypatch, *, default=None, docs=None, perms=True):
+	docs = docs or {}
+
+	def _get_value(_dt, filt, _field=None, **_k):
+		if isinstance(filt, dict):  # the default (is_default=1) lookup
+			return default
+		return docs.get(filt)  # named/default-name doc lookup
+
+	monkeypatch.setattr(furniture.frappe, "db", _FakeDB(_get_value))
+	monkeypatch.setattr(furniture.frappe, "has_permission", lambda *_a, **_k: perms)
+
+
+def test_resolve_letterhead_default_used_when_unnamed(monkeypatch: pytest.MonkeyPatch) -> None:
+	_stub_letterhead(
+		monkeypatch,
+		default="Std",
+		docs={"Std": {"content": "<div>HDR</div>", "footer": "<div>FTR</div>"}},
+	)
+	header, footer, note = resolve_letterhead(None)
+	assert "HDR" in header and "FTR" in footer
+	assert note is None
+
+
+def test_resolve_letterhead_named(monkeypatch: pytest.MonkeyPatch) -> None:
+	_stub_letterhead(monkeypatch, docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}})
+	header, _footer, note = resolve_letterhead("Acme")
+	assert "ACME" in header
+	assert note is None
+
+
+def test_resolve_letterhead_no_default_no_note(monkeypatch: pytest.MonkeyPatch) -> None:
+	_stub_letterhead(monkeypatch, default=None)
+	header, footer, note = resolve_letterhead(None)
+	assert header == "" and footer == ""
+	assert note is None  # no default configured is a normal unbranded render
+
+
+def test_resolve_letterhead_named_not_found_notes(monkeypatch: pytest.MonkeyPatch) -> None:
+	_stub_letterhead(monkeypatch, docs={})  # named lookup returns None
+	header, footer, note = resolve_letterhead("Nope")
+	assert header == "" and footer == ""
+	assert note and "Nope" in note
+
+
+def test_resolve_letterhead_no_read_perm_notes(monkeypatch: pytest.MonkeyPatch) -> None:
+	_stub_letterhead(monkeypatch, docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}}, perms=False)
+	header, _footer, note = resolve_letterhead("Acme")
+	assert header == ""
+	assert note and "Acme" in note
+
+
+@pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (get_letter_head / File)")
+def test_resolve_letterhead_real_default() -> None:
+	header, footer, note = resolve_letterhead(None)
+	assert isinstance(header, str) and isinstance(footer, str)
+	assert note is None

--- a/jarvis/tests/test_export_document_graphics.py
+++ b/jarvis/tests/test_export_document_graphics.py
@@ -4,7 +4,7 @@ KPI/RAG components, and locale-correct number formatting - no image deps).
 Two groups:
 
 * ``css_bar``/``kpi_tile``/``rag_chip`` are pure (no ``frappe`` import) and run
-  WITHOUT a site: ``python -m pytest jarvis/tests/test_export_document_graphics.py``.
+  WITHOUT a site: ``python -m unittest jarvis.tests.test_export_document_graphics``.
 * ``fmt_amount``/``fmt_pct`` reuse ``frappe.utils.fmt_money`` /
   ``frappe.utils.data.get_number_format``, both of which read
   ``frappe.local.lang`` - they raise ``AttributeError: lang`` outside a real
@@ -12,15 +12,16 @@ Two groups:
   ``skip`` with that reason (verified against this repo's bench-env python,
   see the task report) and belong to the end-to-end/site gate instead. The
   edge-case GUARD logic (None/NaN/Inf/-0.0 handling, before ``fmt_money`` is
-  ever reached) is still fully unit-tested here by monkeypatching
+  ever reached) is still fully unit-tested here by patching
   ``fmt_money``/``get_number_format`` to site-free stubs.
 """
 
 import html
 import math
+import unittest
+from unittest.mock import patch
 
 import frappe
-import pytest
 
 from jarvis.tools._export.document import graphics
 from jarvis.tools._export.document.graphics import css_bar, fmt_amount, fmt_pct, kpi_tile, rag_chip
@@ -30,315 +31,279 @@ _HAS_SITE = bool(getattr(frappe.local, "site", None))
 # --- css_bar --------------------------------------------------------------
 
 
-def test_css_bar_wraps_in_bar_chart_class() -> None:
-	out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
-	assert out.startswith('<div class="bar-chart">')
-	assert out.endswith("</div>")
+class TestCssBar(unittest.TestCase):
+	def test_css_bar_wraps_in_bar_chart_class(self) -> None:
+		out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
+		self.assertTrue(out.startswith('<div class="bar-chart">'))
+		self.assertTrue(out.endswith("</div>"))
 
+	def test_css_bar_bar_class_and_width(self) -> None:
+		out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
+		self.assertIn('<div class="bar" style="width:50%">Q1 10</div>', out)
 
-def test_css_bar_bar_class_and_width() -> None:
-	out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
-	assert '<div class="bar" style="width:50%">Q1 10</div>' in out
+	def test_css_bar_width_clamps_low(self) -> None:
+		out = css_bar([{"label": "x", "value": "y", "pct": -5}])
+		self.assertIn('style="width:0%"', out)
 
+	def test_css_bar_width_clamps_high(self) -> None:
+		out = css_bar([{"label": "x", "value": "y", "pct": 150}])
+		self.assertIn('style="width:100%"', out)
 
-def test_css_bar_width_clamps_low() -> None:
-	out = css_bar([{"label": "x", "value": "y", "pct": -5}])
-	assert 'style="width:0%"' in out
+	def test_css_bar_width_clamps_nan_to_zero(self) -> None:
+		out = css_bar([{"label": "x", "value": "y", "pct": float("nan")}])
+		self.assertIn('style="width:0%"', out)
 
+	def test_css_bar_width_clamps_inf_to_hundred(self) -> None:
+		out = css_bar([{"label": "x", "value": "y", "pct": float("inf")}])
+		self.assertIn('style="width:100%"', out)
 
-def test_css_bar_width_clamps_high() -> None:
-	out = css_bar([{"label": "x", "value": "y", "pct": 150}])
-	assert 'style="width:100%"' in out
+	def test_css_bar_width_non_numeric_clamps_to_zero(self) -> None:
+		out = css_bar([{"label": "x", "value": "y", "pct": "garbage"}])
+		self.assertIn('style="width:0%"', out)
 
+	def test_css_bar_escapes_script_label(self) -> None:
+		out = css_bar([{"label": "<script>alert(1)</script>", "value": "1", "pct": 10}])
+		self.assertNotIn("<script", out)
+		self.assertIn("&lt;script&gt;", out)
 
-def test_css_bar_width_clamps_nan_to_zero() -> None:
-	out = css_bar([{"label": "x", "value": "y", "pct": float("nan")}])
-	assert 'style="width:0%"' in out
+	def test_css_bar_escapes_quote_in_value(self) -> None:
+		out = css_bar([{"label": "x", "value": '10" onmouseover="x()', "pct": 10}])
+		self.assertNotIn('onmouseover="x()"', out)
+		self.assertIn("&quot;", out)
 
+	def test_css_bar_accepts_positional_tuple_rows(self) -> None:
+		out = css_bar([("Q1", "10", 50)])
+		self.assertIn('<div class="bar" style="width:50%">Q1 10</div>', out)
 
-def test_css_bar_width_clamps_inf_to_hundred() -> None:
-	out = css_bar([{"label": "x", "value": "y", "pct": float("inf")}])
-	assert 'style="width:100%"' in out
+	def test_css_bar_multiple_rows(self) -> None:
+		out = css_bar([{"label": "A", "value": "1", "pct": 10}, {"label": "B", "value": "2", "pct": 90}])
+		self.assertEqual(out.count('<div class="bar"'), 2)
 
+	def test_css_bar_empty_rows(self) -> None:
+		self.assertEqual(css_bar([]), '<div class="bar-chart"></div>')
 
-def test_css_bar_width_non_numeric_clamps_to_zero() -> None:
-	out = css_bar([{"label": "x", "value": "y", "pct": "garbage"}])
-	assert 'style="width:0%"' in out
+	def test_css_bar_missing_keys_default_safely(self) -> None:
+		out = css_bar([{}])
+		self.assertIn('style="width:0%"', out)
 
+	def test_css_bar_malformed_row_raises(self) -> None:
+		"""A row that is neither a mapping nor a 3-item (label, value, pct) sequence
+		raises ValueError rather than a blind-unpack TypeError/ValueError - so the
+		orchestrator's _splice_charts can catch it and degrade the chart to a note
+		instead of the whole export crashing with a raw 500 and no telemetry."""
+		for bad in [5, None, True, "abc", [1, 2], [1, 2, 3, 4], object()]:
+			with self.subTest(bad=bad):
+				with self.assertRaises(ValueError):
+					css_bar([bad])
 
-def test_css_bar_escapes_script_label() -> None:
-	out = css_bar([{"label": "<script>alert(1)</script>", "value": "1", "pct": 10}])
-	assert "<script" not in out
-	assert "&lt;script&gt;" in out
+	def test_css_bar_valid_3seq_does_not_raise(self) -> None:
+		# Exactly three positional items is the legitimate shape and must still work.
+		out = css_bar([[1, 2, 50]])
+		self.assertIn('<div class="bar" style="width:50%">1 2</div>', out)
 
+	def test_css_bar_none_label_value_render_blank_not_none(self) -> None:
+		out = css_bar([{"label": None, "value": None, "pct": 10}])
+		self.assertNotIn("None", out)
+		self.assertIn('<div class="bar" style="width:10%"> </div>', out)
 
-def test_css_bar_escapes_quote_in_value() -> None:
-	out = css_bar([{"label": "x", "value": '10" onmouseover="x()', "pct": 10}])
-	assert 'onmouseover="x()"' not in out
-	assert "&quot;" in out
+	def test_css_bar_tiny_pct_no_scientific_notation(self) -> None:
+		# 0.00001 formatted with :g would be "1e-05", which old WebKit drops. Fixed
+		# notation renders it as a plain (rounded-to-zero) width.
+		out = css_bar([{"label": "x", "value": "y", "pct": 0.00001}])
+		self.assertNotIn("e-", out)
+		self.assertIn('style="width:0%"', out)
 
-
-def test_css_bar_accepts_positional_tuple_rows() -> None:
-	out = css_bar([("Q1", "10", 50)])
-	assert '<div class="bar" style="width:50%">Q1 10</div>' in out
-
-
-def test_css_bar_multiple_rows() -> None:
-	out = css_bar([{"label": "A", "value": "1", "pct": 10}, {"label": "B", "value": "2", "pct": 90}])
-	assert out.count('<div class="bar"') == 2
-
-
-def test_css_bar_empty_rows() -> None:
-	assert css_bar([]) == '<div class="bar-chart"></div>'
-
-
-def test_css_bar_missing_keys_default_safely() -> None:
-	out = css_bar([{}])
-	assert 'style="width:0%"' in out
-
-
-@pytest.mark.parametrize("bad", [5, None, True, "abc", [1, 2], [1, 2, 3, 4], object()])
-def test_css_bar_malformed_row_raises(bad: object) -> None:
-	"""A row that is neither a mapping nor a 3-item (label, value, pct) sequence
-	raises ValueError rather than a blind-unpack TypeError/ValueError - so the
-	orchestrator's _splice_charts can catch it and degrade the chart to a note
-	instead of the whole export crashing with a raw 500 and no telemetry."""
-	with pytest.raises(ValueError):
-		css_bar([bad])
-
-
-def test_css_bar_valid_3seq_does_not_raise() -> None:
-	# Exactly three positional items is the legitimate shape and must still work.
-	out = css_bar([[1, 2, 50]])
-	assert '<div class="bar" style="width:50%">1 2</div>' in out
-
-
-def test_css_bar_none_label_value_render_blank_not_none() -> None:
-	out = css_bar([{"label": None, "value": None, "pct": 10}])
-	assert "None" not in out
-	assert '<div class="bar" style="width:10%"> </div>' in out
-
-
-def test_css_bar_tiny_pct_no_scientific_notation() -> None:
-	# 0.00001 formatted with :g would be "1e-05", which old WebKit drops. Fixed
-	# notation renders it as a plain (rounded-to-zero) width.
-	out = css_bar([{"label": "x", "value": "y", "pct": 0.00001}])
-	assert "e-" not in out
-	assert 'style="width:0%"' in out
-
-
-def test_css_bar_fractional_pct_trims_trailing_zeros() -> None:
-	out = css_bar([{"label": "x", "value": "y", "pct": 33.5}])
-	assert 'style="width:33.5%"' in out
+	def test_css_bar_fractional_pct_trims_trailing_zeros(self) -> None:
+		out = css_bar([{"label": "x", "value": "y", "pct": 33.5}])
+		self.assertIn('style="width:33.5%"', out)
 
 
 # --- kpi_tile ---------------------------------------------------------------
 
 
-def test_kpi_tile_class_name() -> None:
-	out = kpi_tile("Revenue", "1,000")
-	assert '<div class="kpi-tile">' in out
+class TestKpiTile(unittest.TestCase):
+	def test_kpi_tile_class_name(self) -> None:
+		out = kpi_tile("Revenue", "1,000")
+		self.assertIn('<div class="kpi-tile">', out)
 
+	def test_kpi_tile_label_and_value_present(self) -> None:
+		out = kpi_tile("Revenue", "1,000")
+		self.assertIn("Revenue", out)
+		self.assertIn("1,000", out)
 
-def test_kpi_tile_label_and_value_present() -> None:
-	out = kpi_tile("Revenue", "1,000")
-	assert "Revenue" in out
-	assert "1,000" in out
+	def test_kpi_tile_without_delta_omits_delta_div(self) -> None:
+		out = kpi_tile("Revenue", "1,000")
+		self.assertNotIn("kpi-delta", out)
 
+	def test_kpi_tile_with_delta(self) -> None:
+		out = kpi_tile("Revenue", "1,000", delta="+5%")
+		self.assertIn('<div class="kpi-delta">+5%</div>', out)
 
-def test_kpi_tile_without_delta_omits_delta_div() -> None:
-	out = kpi_tile("Revenue", "1,000")
-	assert "kpi-delta" not in out
+	def test_kpi_tile_escapes_script_in_label(self) -> None:
+		out = kpi_tile("<script>alert(1)</script>", "1")
+		self.assertNotIn("<script", out)
+		self.assertIn("&lt;script&gt;", out)
 
+	def test_kpi_tile_escapes_quote_in_value(self) -> None:
+		out = kpi_tile("x", '1" onmouseover="x()')
+		self.assertNotIn('onmouseover="x()"', out)
+		self.assertIn("&quot;", out)
 
-def test_kpi_tile_with_delta() -> None:
-	out = kpi_tile("Revenue", "1,000", delta="+5%")
-	assert '<div class="kpi-delta">+5%</div>' in out
+	def test_kpi_tile_escapes_delta(self) -> None:
+		out = kpi_tile("x", "1", delta="<script>bad()</script>")
+		self.assertNotIn("<script", out)
 
-
-def test_kpi_tile_escapes_script_in_label() -> None:
-	out = kpi_tile("<script>alert(1)</script>", "1")
-	assert "<script" not in out
-	assert "&lt;script&gt;" in out
-
-
-def test_kpi_tile_escapes_quote_in_value() -> None:
-	out = kpi_tile("x", '1" onmouseover="x()')
-	assert 'onmouseover="x()"' not in out
-	assert "&quot;" in out
-
-
-def test_kpi_tile_escapes_delta() -> None:
-	out = kpi_tile("x", "1", delta="<script>bad()</script>")
-	assert "<script" not in out
-
-
-def test_kpi_tile_none_value_renders_blank_not_none() -> None:
-	out = kpi_tile("Revenue", None)
-	assert "None" not in out
-	assert '<div class="kpi-value"></div>' in out
+	def test_kpi_tile_none_value_renders_blank_not_none(self) -> None:
+		out = kpi_tile("Revenue", None)
+		self.assertNotIn("None", out)
+		self.assertIn('<div class="kpi-value"></div>', out)
 
 
 # --- rag_chip -----------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-	"status,expected_class",
-	[("red", "rag-red"), ("amber", "rag-amber"), ("green", "rag-green")],
-)
-def test_rag_chip_class_names(status: str, expected_class: str) -> None:
-	out = rag_chip(status)
-	assert f'class="{expected_class}"' in out
+class TestRagChip(unittest.TestCase):
+	def test_rag_chip_class_names(self) -> None:
+		for status, expected_class in [("red", "rag-red"), ("amber", "rag-amber"), ("green", "rag-green")]:
+			with self.subTest(status=status):
+				out = rag_chip(status)
+				self.assertIn(f'class="{expected_class}"', out)
 
+	def test_rag_chip_case_insensitive(self) -> None:
+		out = rag_chip("GREEN")
+		self.assertIn('class="rag-green"', out)
 
-def test_rag_chip_case_insensitive() -> None:
-	out = rag_chip("GREEN")
-	assert 'class="rag-green"' in out
+	def test_rag_chip_invalid_status_raises(self) -> None:
+		with self.assertRaises(ValueError):
+			rag_chip("blue")
 
-
-def test_rag_chip_invalid_status_raises() -> None:
-	with pytest.raises(ValueError):
-		rag_chip("blue")
-
-
-def test_rag_chip_preserves_original_casing_as_escaped_text() -> None:
-	out = rag_chip("Red")
-	assert out == '<span class="rag-red">Red</span>'
+	def test_rag_chip_preserves_original_casing_as_escaped_text(self) -> None:
+		out = rag_chip("Red")
+		self.assertEqual(out, '<span class="rag-red">Red</span>')
 
 
 # --- fmt_amount / fmt_pct: real integration (needs a Frappe site) -----------
 #
 # frappe.utils.fmt_money / frappe.utils.data.get_number_format read
 # frappe.local.lang and raise `AttributeError: lang` outside a site. These use
-# ``skipif`` (NOT unconditional ``skip``, which would never run even inside the
-# bench gate) so they DO run once a site is present, and they assert exact
+# ``skipUnless`` (NOT unconditional ``skip``, which would never run even inside
+# the bench gate) so they DO run once a site is present, and they assert exact
 # DELEGATION to fmt_money rather than a hard-coded locale string - proving
 # fmt_amount/fmt_pct reuse the framework formatter without pinning the test to
 # one site's number-format setting.
 
 
-@pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (frappe.local.lang)")
-def test_fmt_amount_delegates_to_fmt_money() -> None:
-	from frappe.utils import fmt_money
+class TestFmtRealIntegration(unittest.TestCase):
+	@unittest.skipUnless(_HAS_SITE, "needs a bench site (frappe.local.lang)")
+	def test_fmt_amount_delegates_to_fmt_money(self) -> None:
+		from frappe.utils import fmt_money
 
-	# Whatever the site's number format (incl. Indian lakh/crore), fmt_amount must
-	# equal the escaped fmt_money output - i.e. it reuses the framework grouping.
-	assert fmt_amount(1234567) == html.escape(fmt_money(1234567))
+		# Whatever the site's number format (incl. Indian lakh/crore), fmt_amount must
+		# equal the escaped fmt_money output - i.e. it reuses the framework grouping.
+		self.assertEqual(fmt_amount(1234567), html.escape(fmt_money(1234567)))
 
+	@unittest.skipUnless(_HAS_SITE, "needs a bench site (frappe.local.lang)")
+	def test_fmt_pct_delegates_at_number_format_precision(self) -> None:
+		from frappe.utils import fmt_money
+		from frappe.utils.data import get_number_format
 
-@pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (frappe.local.lang)")
-def test_fmt_pct_delegates_at_number_format_precision() -> None:
-	from frappe.utils import fmt_money
-	from frappe.utils.data import get_number_format
-
-	expected = html.escape(fmt_money(42.5, precision=get_number_format().precision)) + "%"
-	assert fmt_pct(42.5) == expected
+		expected = html.escape(fmt_money(42.5, precision=get_number_format().precision)) + "%"
+		self.assertEqual(fmt_pct(42.5), expected)
 
 
 # --- fmt_amount / fmt_pct: edge-case guard logic (no site needed) -----------
 #
-# fmt_money/get_number_format are monkeypatched to site-free stubs so ONLY the
+# fmt_money/get_number_format are patched to site-free stubs so ONLY the
 # wrapper's own None/NaN/Inf/-0.0/negative-parens guard logic is under test.
 # For the None/NaN/Inf cases the guard returns before ever calling the stub
 # (proven below by asserting the stub was not invoked), so those specific
-# assertions do not even depend on the monkeypatch being correct.
+# assertions do not even depend on the patch being correct.
 
 
-@pytest.fixture
-def stub_formatters(monkeypatch: pytest.MonkeyPatch) -> dict:
-	calls = {"fmt_money": [], "get_number_format": 0}
+class TestFmtGuards(unittest.TestCase):
+	def setUp(self) -> None:
+		self.calls = {"fmt_money": [], "get_number_format": 0}
 
-	def _fmt_money_stub(amount, precision=None, currency=None, format=None):
-		calls["fmt_money"].append((amount, precision, currency))
-		return f"{amount:.2f}"
+		def _fmt_money_stub(amount, precision=None, currency=None, format=None):
+			self.calls["fmt_money"].append((amount, precision, currency))
+			return f"{amount:.2f}"
 
-	class _NF:
-		precision = 2
+		class _NF:
+			precision = 2
 
-	def _get_number_format_stub():
-		calls["get_number_format"] += 1
-		return _NF()
+		def _get_number_format_stub():
+			self.calls["get_number_format"] += 1
+			return _NF()
 
-	monkeypatch.setattr(graphics, "fmt_money", _fmt_money_stub)
-	monkeypatch.setattr(graphics, "get_number_format", _get_number_format_stub)
-	return calls
+		patch.object(graphics, "fmt_money", _fmt_money_stub).start()
+		patch.object(graphics, "get_number_format", _get_number_format_stub).start()
+		self.addCleanup(patch.stopall)
 
+	def test_fmt_amount_none_nan_inf_render_em_dash(self) -> None:
+		for bad in [None, float("nan"), float("inf"), float("-inf")]:
+			with self.subTest(bad=bad):
+				self.assertEqual(fmt_amount(bad), "—")
+				self.assertEqual(self.calls["fmt_money"], [])  # never reaches the (stubbed) formatter
 
-@pytest.mark.parametrize("bad", [None, float("nan"), float("inf"), float("-inf")])
-def test_fmt_amount_none_nan_inf_render_em_dash(bad, stub_formatters: dict) -> None:
-	assert fmt_amount(bad) == "—"
-	assert stub_formatters["fmt_money"] == []  # never reaches the (stubbed) formatter
+	def test_fmt_pct_none_nan_inf_render_em_dash(self) -> None:
+		for bad in [None, float("nan"), float("inf"), float("-inf")]:
+			with self.subTest(bad=bad):
+				self.assertEqual(fmt_pct(bad), "—")
+				self.assertEqual(self.calls["fmt_money"], [])
+				self.assertEqual(self.calls["get_number_format"], 0)
 
+	def test_fmt_amount_negative_zero_is_not_negative(self) -> None:
+		out = fmt_amount(-0.0)
+		self.assertNotEqual(out, "—")
+		self.assertNotIn("neg", out)
+		# the stub received a non-negative magnitude, never a bare "-0.00"
+		((amount, _precision, _currency),) = self.calls["fmt_money"]
+		self.assertEqual(amount, 0.0)
+		self.assertEqual(math.copysign(1, amount), 1.0)
 
-@pytest.mark.parametrize("bad", [None, float("nan"), float("inf"), float("-inf")])
-def test_fmt_pct_none_nan_inf_render_em_dash(bad, stub_formatters: dict) -> None:
-	assert fmt_pct(bad) == "—"
-	assert stub_formatters["fmt_money"] == []
-	assert stub_formatters["get_number_format"] == 0
+	def test_fmt_pct_negative_zero_is_not_negative(self) -> None:
+		out = fmt_pct(-0.0)
+		self.assertNotEqual(out, "—")
+		self.assertNotIn("neg", out)
 
+	def test_fmt_amount_negative_wraps_in_parens_and_neg_class(self) -> None:
+		out = fmt_amount(-1234.5)
+		self.assertEqual(out, '<span class="neg">(1234.50)</span>')
 
-def test_fmt_amount_negative_zero_is_not_negative(stub_formatters: dict) -> None:
-	out = fmt_amount(-0.0)
-	assert out != "—"
-	assert "neg" not in out
-	# the stub received a non-negative magnitude, never a bare "-0.00"
-	((amount, _precision, _currency),) = stub_formatters["fmt_money"]
-	assert amount == 0.0
-	assert math.copysign(1, amount) == 1.0
+	def test_fmt_amount_positive_has_no_neg_class(self) -> None:
+		out = fmt_amount(1234.5)
+		self.assertNotIn("neg", out)
+		self.assertEqual(out, "1234.50")
 
+	def test_fmt_amount_passes_abs_value_to_formatter(self) -> None:
+		fmt_amount(-1234.5)
+		((amount, _precision, _currency),) = self.calls["fmt_money"]
+		self.assertEqual(amount, 1234.5)
 
-def test_fmt_pct_negative_zero_is_not_negative(stub_formatters: dict) -> None:
-	out = fmt_pct(-0.0)
-	assert out != "—"
-	assert "neg" not in out
+	def test_fmt_amount_passes_currency_through(self) -> None:
+		fmt_amount(10, currency="INR")
+		((_amount, _precision, currency),) = self.calls["fmt_money"]
+		self.assertEqual(currency, "INR")
 
+	def test_fmt_pct_negative_wraps_in_parens_and_neg_class(self) -> None:
+		out = fmt_pct(-42.5)
+		self.assertEqual(out, '<span class="neg">(42.50%)</span>')
 
-def test_fmt_amount_negative_wraps_in_parens_and_neg_class(stub_formatters: dict) -> None:
-	out = fmt_amount(-1234.5)
-	assert out == '<span class="neg">(1234.50)</span>'
+	def test_fmt_pct_positive_has_percent_suffix_no_neg_class(self) -> None:
+		out = fmt_pct(42.5)
+		self.assertEqual(out, "42.50%")
+		self.assertNotIn("neg", out)
 
+	def test_fmt_pct_uses_number_format_precision_not_currency_default(self) -> None:
+		fmt_pct(42.5)
+		self.assertEqual(self.calls["get_number_format"], 1)
+		((_amount, precision, _currency),) = self.calls["fmt_money"]
+		self.assertEqual(precision, 2)  # from the stub NumberFormat, not a currency-precision default
 
-def test_fmt_amount_positive_has_no_neg_class(stub_formatters: dict) -> None:
-	out = fmt_amount(1234.5)
-	assert "neg" not in out
-	assert out == "1234.50"
+	def test_fmt_amount_string_input_with_commas(self) -> None:
+		out = fmt_amount("1,234.5")
+		self.assertEqual(out, "1234.50")
 
-
-def test_fmt_amount_passes_abs_value_to_formatter(stub_formatters: dict) -> None:
-	fmt_amount(-1234.5)
-	((amount, _precision, _currency),) = stub_formatters["fmt_money"]
-	assert amount == 1234.5
-
-
-def test_fmt_amount_passes_currency_through(stub_formatters: dict) -> None:
-	fmt_amount(10, currency="INR")
-	((_amount, _precision, currency),) = stub_formatters["fmt_money"]
-	assert currency == "INR"
-
-
-def test_fmt_pct_negative_wraps_in_parens_and_neg_class(stub_formatters: dict) -> None:
-	out = fmt_pct(-42.5)
-	assert out == '<span class="neg">(42.50%)</span>'
-
-
-def test_fmt_pct_positive_has_percent_suffix_no_neg_class(stub_formatters: dict) -> None:
-	out = fmt_pct(42.5)
-	assert out == "42.50%"
-	assert "neg" not in out
-
-
-def test_fmt_pct_uses_number_format_precision_not_currency_default(stub_formatters: dict) -> None:
-	fmt_pct(42.5)
-	assert stub_formatters["get_number_format"] == 1
-	((_amount, precision, _currency),) = stub_formatters["fmt_money"]
-	assert precision == 2  # from the stub NumberFormat, not a currency-precision default
-
-
-def test_fmt_amount_string_input_with_commas(stub_formatters: dict) -> None:
-	out = fmt_amount("1,234.5")
-	assert out == "1234.50"
-
-
-def test_fmt_amount_unparseable_string_renders_em_dash(stub_formatters: dict) -> None:
-	assert fmt_amount("not-a-number") == "—"
-	assert stub_formatters["fmt_money"] == []
+	def test_fmt_amount_unparseable_string_renders_em_dash(self) -> None:
+		self.assertEqual(fmt_amount("not-a-number"), "—")
+		self.assertEqual(self.calls["fmt_money"], [])

--- a/jarvis/tests/test_export_document_graphics.py
+++ b/jarvis/tests/test_export_document_graphics.py
@@ -1,0 +1,292 @@
+"""Tests for ``jarvis.tools._export.document.graphics`` (Slice 1: CSS charts,
+KPI/RAG components, and locale-correct number formatting - no image deps).
+
+Two groups:
+
+* ``css_bar``/``kpi_tile``/``rag_chip`` are pure (no ``frappe`` import) and run
+  WITHOUT a site: ``python -m pytest jarvis/tests/test_export_document_graphics.py``.
+* ``fmt_amount``/``fmt_pct`` reuse ``frappe.utils.fmt_money`` /
+  ``frappe.utils.data.get_number_format``, both of which read
+  ``frappe.local.lang`` - they raise ``AttributeError: lang`` outside a real
+  Frappe site/request context. The real-formatting tests below are marked
+  ``skip`` with that reason (verified against this repo's bench-env python,
+  see the task report) and belong to the end-to-end/site gate instead. The
+  edge-case GUARD logic (None/NaN/Inf/-0.0 handling, before ``fmt_money`` is
+  ever reached) is still fully unit-tested here by monkeypatching
+  ``fmt_money``/``get_number_format`` to site-free stubs.
+"""
+
+import math
+
+import pytest
+
+from jarvis.tools._export.document import graphics
+from jarvis.tools._export.document.graphics import css_bar, fmt_amount, fmt_pct, kpi_tile, rag_chip
+
+# --- css_bar --------------------------------------------------------------
+
+
+def test_css_bar_wraps_in_bar_chart_class() -> None:
+	out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
+	assert out.startswith('<div class="bar-chart">')
+	assert out.endswith("</div>")
+
+
+def test_css_bar_bar_class_and_width() -> None:
+	out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
+	assert '<div class="bar" style="width:50%">Q1 10</div>' in out
+
+
+def test_css_bar_width_clamps_low() -> None:
+	out = css_bar([{"label": "x", "value": "y", "pct": -5}])
+	assert 'style="width:0%"' in out
+
+
+def test_css_bar_width_clamps_high() -> None:
+	out = css_bar([{"label": "x", "value": "y", "pct": 150}])
+	assert 'style="width:100%"' in out
+
+
+def test_css_bar_width_clamps_nan_to_zero() -> None:
+	out = css_bar([{"label": "x", "value": "y", "pct": float("nan")}])
+	assert 'style="width:0%"' in out
+
+
+def test_css_bar_width_clamps_inf_to_hundred() -> None:
+	out = css_bar([{"label": "x", "value": "y", "pct": float("inf")}])
+	assert 'style="width:100%"' in out
+
+
+def test_css_bar_width_non_numeric_clamps_to_zero() -> None:
+	out = css_bar([{"label": "x", "value": "y", "pct": "garbage"}])
+	assert 'style="width:0%"' in out
+
+
+def test_css_bar_escapes_script_label() -> None:
+	out = css_bar([{"label": "<script>alert(1)</script>", "value": "1", "pct": 10}])
+	assert "<script" not in out
+	assert "&lt;script&gt;" in out
+
+
+def test_css_bar_escapes_quote_in_value() -> None:
+	out = css_bar([{"label": "x", "value": '10" onmouseover="x()', "pct": 10}])
+	assert 'onmouseover="x()"' not in out
+	assert "&quot;" in out
+
+
+def test_css_bar_accepts_positional_tuple_rows() -> None:
+	out = css_bar([("Q1", "10", 50)])
+	assert '<div class="bar" style="width:50%">Q1 10</div>' in out
+
+
+def test_css_bar_multiple_rows() -> None:
+	out = css_bar([{"label": "A", "value": "1", "pct": 10}, {"label": "B", "value": "2", "pct": 90}])
+	assert out.count('<div class="bar"') == 2
+
+
+def test_css_bar_empty_rows() -> None:
+	assert css_bar([]) == '<div class="bar-chart"></div>'
+
+
+def test_css_bar_missing_keys_default_safely() -> None:
+	out = css_bar([{}])
+	assert 'style="width:0%"' in out
+
+
+# --- kpi_tile ---------------------------------------------------------------
+
+
+def test_kpi_tile_class_name() -> None:
+	out = kpi_tile("Revenue", "1,000")
+	assert '<div class="kpi-tile">' in out
+
+
+def test_kpi_tile_label_and_value_present() -> None:
+	out = kpi_tile("Revenue", "1,000")
+	assert "Revenue" in out
+	assert "1,000" in out
+
+
+def test_kpi_tile_without_delta_omits_delta_div() -> None:
+	out = kpi_tile("Revenue", "1,000")
+	assert "kpi-delta" not in out
+
+
+def test_kpi_tile_with_delta() -> None:
+	out = kpi_tile("Revenue", "1,000", delta="+5%")
+	assert '<div class="kpi-delta">+5%</div>' in out
+
+
+def test_kpi_tile_escapes_script_in_label() -> None:
+	out = kpi_tile("<script>alert(1)</script>", "1")
+	assert "<script" not in out
+	assert "&lt;script&gt;" in out
+
+
+def test_kpi_tile_escapes_quote_in_value() -> None:
+	out = kpi_tile("x", '1" onmouseover="x()')
+	assert 'onmouseover="x()"' not in out
+	assert "&quot;" in out
+
+
+def test_kpi_tile_escapes_delta() -> None:
+	out = kpi_tile("x", "1", delta="<script>bad()</script>")
+	assert "<script" not in out
+
+
+# --- rag_chip -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+	"status,expected_class",
+	[("red", "rag-red"), ("amber", "rag-amber"), ("green", "rag-green")],
+)
+def test_rag_chip_class_names(status: str, expected_class: str) -> None:
+	out = rag_chip(status)
+	assert f'class="{expected_class}"' in out
+
+
+def test_rag_chip_case_insensitive() -> None:
+	out = rag_chip("GREEN")
+	assert 'class="rag-green"' in out
+
+
+def test_rag_chip_invalid_status_raises() -> None:
+	with pytest.raises(ValueError):
+		rag_chip("blue")
+
+
+def test_rag_chip_preserves_original_casing_as_escaped_text() -> None:
+	out = rag_chip("Red")
+	assert out == '<span class="rag-red">Red</span>'
+
+
+# --- fmt_amount / fmt_pct: real integration (needs a Frappe site) -----------
+#
+# Confirmed against this repo's bench-env python (see task report): calling
+# frappe.utils.fmt_money / frappe.utils.data.get_number_format outside a site
+# raises `AttributeError: lang` (frappe.local.lang is unset). These are the
+# true, unstubbed formatting behaviors and belong in the site-backed
+# end-to-end gate, not in this no-site suite.
+
+
+@pytest.mark.skip(reason="needs bench site — runs in the end-to-end gate")
+def test_fmt_amount_real_lakh_crore_grouping() -> None:
+	# Indian lakh/crore grouping is a site-level number-format setting; this
+	# proves fmt_amount reuses frappe.utils.fmt_money rather than hand-rolling
+	# digit grouping, once a real site/number-format is available.
+	assert fmt_amount(1234567) == "12,34,567.00"  # depends on site's #,##,###.## format
+
+
+@pytest.mark.skip(reason="needs bench site — runs in the end-to-end gate")
+def test_fmt_pct_real_precision() -> None:
+	assert fmt_pct(42.5) == "42.50%"
+
+
+# --- fmt_amount / fmt_pct: edge-case guard logic (no site needed) -----------
+#
+# fmt_money/get_number_format are monkeypatched to site-free stubs so ONLY the
+# wrapper's own None/NaN/Inf/-0.0/negative-parens guard logic is under test.
+# For the None/NaN/Inf cases the guard returns before ever calling the stub
+# (proven below by asserting the stub was not invoked), so those specific
+# assertions do not even depend on the monkeypatch being correct.
+
+
+@pytest.fixture
+def stub_formatters(monkeypatch: pytest.MonkeyPatch) -> dict:
+	calls = {"fmt_money": [], "get_number_format": 0}
+
+	def _fmt_money_stub(amount, precision=None, currency=None, format=None):
+		calls["fmt_money"].append((amount, precision, currency))
+		return f"{amount:.2f}"
+
+	class _NF:
+		precision = 2
+
+	def _get_number_format_stub():
+		calls["get_number_format"] += 1
+		return _NF()
+
+	monkeypatch.setattr(graphics, "fmt_money", _fmt_money_stub)
+	monkeypatch.setattr(graphics, "get_number_format", _get_number_format_stub)
+	return calls
+
+
+@pytest.mark.parametrize("bad", [None, float("nan"), float("inf"), float("-inf")])
+def test_fmt_amount_none_nan_inf_render_em_dash(bad, stub_formatters: dict) -> None:
+	assert fmt_amount(bad) == "—"
+	assert stub_formatters["fmt_money"] == []  # never reaches the (stubbed) formatter
+
+
+@pytest.mark.parametrize("bad", [None, float("nan"), float("inf"), float("-inf")])
+def test_fmt_pct_none_nan_inf_render_em_dash(bad, stub_formatters: dict) -> None:
+	assert fmt_pct(bad) == "—"
+	assert stub_formatters["fmt_money"] == []
+	assert stub_formatters["get_number_format"] == 0
+
+
+def test_fmt_amount_negative_zero_is_not_negative(stub_formatters: dict) -> None:
+	out = fmt_amount(-0.0)
+	assert out != "—"
+	assert "neg" not in out
+	# the stub received a non-negative magnitude, never a bare "-0.00"
+	((amount, _precision, _currency),) = stub_formatters["fmt_money"]
+	assert amount == 0.0
+	assert math.copysign(1, amount) == 1.0
+
+
+def test_fmt_pct_negative_zero_is_not_negative(stub_formatters: dict) -> None:
+	out = fmt_pct(-0.0)
+	assert out != "—"
+	assert "neg" not in out
+
+
+def test_fmt_amount_negative_wraps_in_parens_and_neg_class(stub_formatters: dict) -> None:
+	out = fmt_amount(-1234.5)
+	assert out == '<span class="neg">(1234.50)</span>'
+
+
+def test_fmt_amount_positive_has_no_neg_class(stub_formatters: dict) -> None:
+	out = fmt_amount(1234.5)
+	assert "neg" not in out
+	assert out == "1234.50"
+
+
+def test_fmt_amount_passes_abs_value_to_formatter(stub_formatters: dict) -> None:
+	fmt_amount(-1234.5)
+	((amount, _precision, _currency),) = stub_formatters["fmt_money"]
+	assert amount == 1234.5
+
+
+def test_fmt_amount_passes_currency_through(stub_formatters: dict) -> None:
+	fmt_amount(10, currency="INR")
+	((_amount, _precision, currency),) = stub_formatters["fmt_money"]
+	assert currency == "INR"
+
+
+def test_fmt_pct_negative_wraps_in_parens_and_neg_class(stub_formatters: dict) -> None:
+	out = fmt_pct(-42.5)
+	assert out == '<span class="neg">(42.50%)</span>'
+
+
+def test_fmt_pct_positive_has_percent_suffix_no_neg_class(stub_formatters: dict) -> None:
+	out = fmt_pct(42.5)
+	assert out == "42.50%"
+	assert "neg" not in out
+
+
+def test_fmt_pct_uses_number_format_precision_not_currency_default(stub_formatters: dict) -> None:
+	fmt_pct(42.5)
+	assert stub_formatters["get_number_format"] == 1
+	((_amount, precision, _currency),) = stub_formatters["fmt_money"]
+	assert precision == 2  # from the stub NumberFormat, not a currency-precision default
+
+
+def test_fmt_amount_string_input_with_commas(stub_formatters: dict) -> None:
+	out = fmt_amount("1,234.5")
+	assert out == "1234.50"
+
+
+def test_fmt_amount_unparseable_string_renders_em_dash(stub_formatters: dict) -> None:
+	assert fmt_amount("not-a-number") == "—"
+	assert stub_formatters["fmt_money"] == []

--- a/jarvis/tests/test_export_document_graphics.py
+++ b/jarvis/tests/test_export_document_graphics.py
@@ -16,12 +16,16 @@ Two groups:
   ``fmt_money``/``get_number_format`` to site-free stubs.
 """
 
+import html
 import math
 
+import frappe
 import pytest
 
 from jarvis.tools._export.document import graphics
 from jarvis.tools._export.document.graphics import css_bar, fmt_amount, fmt_pct, kpi_tile, rag_chip
+
+_HAS_SITE = bool(getattr(frappe.local, "site", None))
 
 # --- css_bar --------------------------------------------------------------
 
@@ -93,6 +97,41 @@ def test_css_bar_missing_keys_default_safely() -> None:
 	assert 'style="width:0%"' in out
 
 
+@pytest.mark.parametrize("bad", [5, None, True, "abc", [1, 2], [1, 2, 3, 4], object()])
+def test_css_bar_malformed_row_raises(bad: object) -> None:
+	"""A row that is neither a mapping nor a 3-item (label, value, pct) sequence
+	raises ValueError rather than a blind-unpack TypeError/ValueError - so the
+	orchestrator's _splice_charts can catch it and degrade the chart to a note
+	instead of the whole export crashing with a raw 500 and no telemetry."""
+	with pytest.raises(ValueError):
+		css_bar([bad])
+
+
+def test_css_bar_valid_3seq_does_not_raise() -> None:
+	# Exactly three positional items is the legitimate shape and must still work.
+	out = css_bar([[1, 2, 50]])
+	assert '<div class="bar" style="width:50%">1 2</div>' in out
+
+
+def test_css_bar_none_label_value_render_blank_not_none() -> None:
+	out = css_bar([{"label": None, "value": None, "pct": 10}])
+	assert "None" not in out
+	assert '<div class="bar" style="width:10%"> </div>' in out
+
+
+def test_css_bar_tiny_pct_no_scientific_notation() -> None:
+	# 0.00001 formatted with :g would be "1e-05", which old WebKit drops. Fixed
+	# notation renders it as a plain (rounded-to-zero) width.
+	out = css_bar([{"label": "x", "value": "y", "pct": 0.00001}])
+	assert "e-" not in out
+	assert 'style="width:0%"' in out
+
+
+def test_css_bar_fractional_pct_trims_trailing_zeros() -> None:
+	out = css_bar([{"label": "x", "value": "y", "pct": 33.5}])
+	assert 'style="width:33.5%"' in out
+
+
 # --- kpi_tile ---------------------------------------------------------------
 
 
@@ -134,6 +173,12 @@ def test_kpi_tile_escapes_delta() -> None:
 	assert "<script" not in out
 
 
+def test_kpi_tile_none_value_renders_blank_not_none() -> None:
+	out = kpi_tile("Revenue", None)
+	assert "None" not in out
+	assert '<div class="kpi-value"></div>' in out
+
+
 # --- rag_chip -----------------------------------------------------------
 
 
@@ -163,24 +208,31 @@ def test_rag_chip_preserves_original_casing_as_escaped_text() -> None:
 
 # --- fmt_amount / fmt_pct: real integration (needs a Frappe site) -----------
 #
-# Confirmed against this repo's bench-env python (see task report): calling
-# frappe.utils.fmt_money / frappe.utils.data.get_number_format outside a site
-# raises `AttributeError: lang` (frappe.local.lang is unset). These are the
-# true, unstubbed formatting behaviors and belong in the site-backed
-# end-to-end gate, not in this no-site suite.
+# frappe.utils.fmt_money / frappe.utils.data.get_number_format read
+# frappe.local.lang and raise `AttributeError: lang` outside a site. These use
+# ``skipif`` (NOT unconditional ``skip``, which would never run even inside the
+# bench gate) so they DO run once a site is present, and they assert exact
+# DELEGATION to fmt_money rather than a hard-coded locale string - proving
+# fmt_amount/fmt_pct reuse the framework formatter without pinning the test to
+# one site's number-format setting.
 
 
-@pytest.mark.skip(reason="needs bench site — runs in the end-to-end gate")
-def test_fmt_amount_real_lakh_crore_grouping() -> None:
-	# Indian lakh/crore grouping is a site-level number-format setting; this
-	# proves fmt_amount reuses frappe.utils.fmt_money rather than hand-rolling
-	# digit grouping, once a real site/number-format is available.
-	assert fmt_amount(1234567) == "12,34,567.00"  # depends on site's #,##,###.## format
+@pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (frappe.local.lang)")
+def test_fmt_amount_delegates_to_fmt_money() -> None:
+	from frappe.utils import fmt_money
+
+	# Whatever the site's number format (incl. Indian lakh/crore), fmt_amount must
+	# equal the escaped fmt_money output - i.e. it reuses the framework grouping.
+	assert fmt_amount(1234567) == html.escape(fmt_money(1234567))
 
 
-@pytest.mark.skip(reason="needs bench site — runs in the end-to-end gate")
-def test_fmt_pct_real_precision() -> None:
-	assert fmt_pct(42.5) == "42.50%"
+@pytest.mark.skipif(not _HAS_SITE, reason="needs a bench site (frappe.local.lang)")
+def test_fmt_pct_delegates_at_number_format_precision() -> None:
+	from frappe.utils import fmt_money
+	from frappe.utils.data import get_number_format
+
+	expected = html.escape(fmt_money(42.5, precision=get_number_format().precision)) + "%"
+	assert fmt_pct(42.5) == expected
 
 
 # --- fmt_amount / fmt_pct: edge-case guard logic (no site needed) -----------

--- a/jarvis/tests/test_export_document_sanitizer.py
+++ b/jarvis/tests/test_export_document_sanitizer.py
@@ -1,25 +1,45 @@
 """Attack corpus for ``sanitize_rich`` - the rich-PDF security core.
 
-``sanitize_rich`` is a pure module (imports only ``nh3`` + ``bs4``), so this
-suite runs WITHOUT a bench/site: ``python -m pytest`` against it directly. Each
-case is a real vector the agent could compose; the assertion proves the vector is
-neutralized before it could reach the (unauthenticated, fetch-capable) wkhtmltopdf
-render.
+``sanitize_rich`` is a pure module (imports only ``nh3``), so this suite runs
+WITHOUT a bench/site: ``python -m pytest`` against it directly. Each case is a
+real vector the agent could compose; the assertion proves the vector is
+neutralized before it could reach the (unauthenticated, fetch-capable)
+wkhtmltopdf render.
 
-The sanitizer has TWO independent layers (BeautifulSoup decompose + ``nh3.clean``
-allowlist), so the corpus is mutation-verified per layer:
-  * decompose layer -- drop ``audio`` from ``_DECOMPOSE_TAGS`` and the
-    ``AUDIO-LEAK`` inner text survives nh3 (the ``audio`` case fails).
-  * nh3 layer -- the ``<img>`` cases only fail if BOTH layers are defeated (drop
-    ``img`` from ``_DECOMPOSE_TAGS`` AND add it to ``_ALLOWED_TAGS``), proving
-    nh3's allowlist independently backstops image stripping.
+``sanitize_rich`` is a SINGLE ``nh3.clean`` pass: a tag/attribute/url-scheme
+allowlist plus ``clean_content_tags`` (removes each fetch-capable / active /
+raw-text tag together with its subtree, natively - so a ``<script>``'s payload is
+deleted, not kept as visible text). The two data-driven tests below exercise the
+WHOLE ``_DECOMPOSE_TAGS`` set (not a hand-picked subset), so they are
+mutation-verified for every tag and auto-cover any tag added to the set later:
+drop a tag from ``_DECOMPOSE_TAGS`` and its ``<tag`` + fetchable attribute (and,
+for content-bearing tags, its inner text) survive - the case fails.
 """
 
 import time
 
 import pytest
 
-from jarvis.tools._export.document.sanitizer import sanitize_rich
+from jarvis.tools._export.document.sanitizer import _DECOMPOSE_TAGS, sanitize_rich
+
+# Content-bearing subset of the decompose set: their INNER TEXT must be removed
+# too (not just the tag), so a stripped tag can't leave inert payload text behind.
+# The void / special-parsing tags (img/input/source/base/link/meta/embed and
+# xmp/plaintext/textarea/title) are covered by the tag+attr test only - they have
+# no normal element content to assert on.
+_CONTENT_BEARING = (
+	"script",
+	"style",
+	"svg",
+	"iframe",
+	"object",
+	"audio",
+	"video",
+	"noscript",
+	"template",
+	"form",
+	"button",
+)
 
 
 def _assert_neutralized(payload: str, forbidden: list[str], required: list[str]) -> None:
@@ -32,26 +52,48 @@ def _assert_neutralized(payload: str, forbidden: list[str], required: list[str])
 		assert needle in out, f"{needle!r} missing from {out!r}"
 
 
+@pytest.mark.parametrize("tag", _DECOMPOSE_TAGS)
+def test_decompose_tag_and_attr_stripped(tag: str) -> None:
+	"""EVERY tag in the decompose set is removed together with any fetchable
+	attribute - the core SSRF property, exercised across the whole set so no tag
+	is left without a regression shield."""
+	out = sanitize_rich(f'<{tag} src="http://evil-{tag}" href="http://evil-{tag}">X</{tag}>').lower()
+	assert f"<{tag}" not in out, f"<{tag}> survived: {out!r}"
+	assert f"evil-{tag}" not in out, f"{tag} fetchable attribute survived: {out!r}"
+
+
+@pytest.mark.parametrize("tag", _CONTENT_BEARING)
+def test_decompose_tag_content_removed(tag: str) -> None:
+	"""A content-bearing decompose tag has its INNER TEXT removed, not kept as
+	inert visible text (nh3 alone would keep it - clean_content_tags is what
+	deletes the subtree)."""
+	out = sanitize_rich(f"<{tag}>ZAP_{tag}</{tag}><p>ok</p>")
+	assert f"ZAP_{tag}" not in out, f"{tag} inner content survived: {out!r}"
+	assert "ok" in out, f"legit sibling content dropped for {tag}: {out!r}"
+
+
 # (id, payload, forbidden-substrings, required-substrings). ``forbidden`` is
-# matched case-insensitively; ``required`` case-sensitively.
+# matched case-insensitively; ``required`` case-sensitively. Specific vectors
+# beyond the whole-set sweep above.
 _ATTACKS = [
-	("script", "<script>alert(1)</script>", ["<script", "alert(1)"], []),
-	("script-mixedcase", "<ScRiPt>alert(1)</ScRiPt>", ["script", "alert(1)"], []),
+	("script-mixedcase", "<ScRiPt>alert(1)</ScRiPt>", ["<script", "alert(1)"], []),
 	("comment-script", "<!--><script>x</script>", ["<script"], []),
+	("nested-split-script", "<scr<script>ipt>bad()</scr</script>ipt>", ["<script"], []),
 	("href-js", '<a href="javascript:alert(1)">click</a>', ["javascript"], []),
 	("href-js-mixedcase", '<a href="JavaScript:alert(1)">click</a>', ["javascript"], []),
 	("img-data", '<img src="data:image/png;base64,AAAA">', ["<img", "data:"], []),
 	("img-http", '<img src="http://evil/x.png">', ["<img", "evil"], []),
-	# A same-site path is still an agent-supplied <img> - it MUST be stripped too.
+	# A same-site path is still an agent-supplied <img> - it MUST be stripped too
+	# (agent content never carries images; only trusted letterhead logos do, and
+	# those are inlined in furniture.py, never through this sanitizer).
 	("img-same-site", '<img src="/files/x.png">', ["<img", "/files"], []),
 	("img-file", '<img src="file:///etc/passwd">', ["<img", "file:", "passwd"], []),
 	("svg-image", '<svg><image href="http://evil"/></svg>', ["svg", "<image", "evil"], []),
-	# nh3 alone STRIPS the <audio>/<iframe> tag but KEEPS its inner text (unlike
-	# script/style, which ammonia removes with content). The decompose pre-pass is
-	# what deletes the inner text - so these cases keep the decompose layer honest
-	# (mutation-verified: drop the tag from _DECOMPOSE_TAGS and the LEAK survives).
-	("audio", '<audio src="http://evil">AUDIO-LEAK</audio>', ["audio", "evil", "AUDIO-LEAK"], []),
-	("iframe-text", "<iframe>IFRAME-LEAK</iframe>", ["iframe", "IFRAME-LEAK"], []),
+	("math-foreign", '<math><mtext><img src="http://evil"></mtext></math>', ["<img", "evil"], []),
+	("meta-refresh", '<meta http-equiv="refresh" content="0;url=http://evil">', ["<meta", "evil"], []),
+	("link-css", '<link rel="stylesheet" href="http://evil/x.css">', ["<link", "evil"], []),
+	("base-href", '<base href="http://evil/">', ["<base", "evil"], []),
+	("noscript-img", '<noscript><img src="http://evil"></noscript>', ["<img", "evil"], []),
 	("td-background", '<td background="http://evil">x</td>', ["background", "evil"], ["x"]),
 	# style attribute dropped entirely (classes-only), text preserved.
 	(
@@ -76,6 +118,19 @@ def test_attack_neutralized(payload: str, forbidden: list[str], required: list[s
 	_assert_neutralized(payload, forbidden, required)
 
 
+def test_long_nested_returns_promptly() -> None:
+	"""A 200k-char DEEPLY NESTED fragment (the pathological input that made the old
+	BeautifulSoup/html5lib pre-pass run ~80s) must sanitize well within budget -
+	nh3's single Rust pass does the tree construction natively. This is the guard
+	the sanitizer collapse exists to make true."""
+	payload = "<div>" * 20_000 + "x" + "</div>" * 20_000
+	start = time.monotonic()
+	out = sanitize_rich(payload)
+	elapsed = time.monotonic() - start
+	assert "x" in out
+	assert elapsed < 5.0, f"sanitize took {elapsed:.3f}s on a deeply-nested 200k fragment"
+
+
 def test_long_style_value_returns_promptly() -> None:
 	"""A 200k-char inline style value must be dropped and must not stall the
 	sanitizer (ReDoS / pathological-parse guard)."""
@@ -86,7 +141,7 @@ def test_long_style_value_returns_promptly() -> None:
 	assert "style" not in out.lower()
 	assert "aaaa" not in out.lower()
 	assert "x" in out
-	assert elapsed < 2.0, f"sanitize took {elapsed:.3f}s on a 200k style value"
+	assert elapsed < 5.0, f"sanitize took {elapsed:.3f}s on a 200k style value"
 
 
 # --- positive cases: legitimate rich content must survive intact --------------

--- a/jarvis/tests/test_export_document_sanitizer.py
+++ b/jarvis/tests/test_export_document_sanitizer.py
@@ -1,0 +1,151 @@
+"""Attack corpus for ``sanitize_rich`` - the rich-PDF security core.
+
+``sanitize_rich`` is a pure module (imports only ``nh3`` + ``bs4``), so this
+suite runs WITHOUT a bench/site: ``python -m pytest`` against it directly. Each
+case is a real vector the agent could compose; the assertion proves the vector is
+neutralized before it could reach the (unauthenticated, fetch-capable) wkhtmltopdf
+render.
+
+The sanitizer has TWO independent layers (BeautifulSoup decompose + ``nh3.clean``
+allowlist), so the corpus is mutation-verified per layer:
+  * decompose layer -- drop ``audio`` from ``_DECOMPOSE_TAGS`` and the
+    ``AUDIO-LEAK`` inner text survives nh3 (the ``audio`` case fails).
+  * nh3 layer -- the ``<img>`` cases only fail if BOTH layers are defeated (drop
+    ``img`` from ``_DECOMPOSE_TAGS`` AND add it to ``_ALLOWED_TAGS``), proving
+    nh3's allowlist independently backstops image stripping.
+"""
+
+import time
+
+import pytest
+
+from jarvis.tools._export.document.sanitizer import sanitize_rich
+
+
+def _assert_neutralized(payload: str, forbidden: list[str], required: list[str]) -> None:
+	out = sanitize_rich(payload)
+	assert isinstance(out, str)
+	low = out.lower()
+	for needle in forbidden:
+		assert needle.lower() not in low, f"{needle!r} survived in {out!r}"
+	for needle in required:
+		assert needle in out, f"{needle!r} missing from {out!r}"
+
+
+# (id, payload, forbidden-substrings, required-substrings). ``forbidden`` is
+# matched case-insensitively; ``required`` case-sensitively.
+_ATTACKS = [
+	("script", "<script>alert(1)</script>", ["<script", "alert(1)"], []),
+	("script-mixedcase", "<ScRiPt>alert(1)</ScRiPt>", ["script", "alert(1)"], []),
+	("comment-script", "<!--><script>x</script>", ["<script"], []),
+	("href-js", '<a href="javascript:alert(1)">click</a>', ["javascript"], []),
+	("href-js-mixedcase", '<a href="JavaScript:alert(1)">click</a>', ["javascript"], []),
+	("img-data", '<img src="data:image/png;base64,AAAA">', ["<img", "data:"], []),
+	("img-http", '<img src="http://evil/x.png">', ["<img", "evil"], []),
+	# A same-site path is still an agent-supplied <img> - it MUST be stripped too.
+	("img-same-site", '<img src="/files/x.png">', ["<img", "/files"], []),
+	("img-file", '<img src="file:///etc/passwd">', ["<img", "file:", "passwd"], []),
+	("svg-image", '<svg><image href="http://evil"/></svg>', ["svg", "<image", "evil"], []),
+	# nh3 alone STRIPS the <audio>/<iframe> tag but KEEPS its inner text (unlike
+	# script/style, which ammonia removes with content). The decompose pre-pass is
+	# what deletes the inner text - so these cases keep the decompose layer honest
+	# (mutation-verified: drop the tag from _DECOMPOSE_TAGS and the LEAK survives).
+	("audio", '<audio src="http://evil">AUDIO-LEAK</audio>', ["audio", "evil", "AUDIO-LEAK"], []),
+	("iframe-text", "<iframe>IFRAME-LEAK</iframe>", ["iframe", "IFRAME-LEAK"], []),
+	("td-background", '<td background="http://evil">x</td>', ["background", "evil"], ["x"]),
+	# style attribute dropped entirely (classes-only), text preserved.
+	(
+		"style-bg-url",
+		'<div style="background-image:url(http://evil)">x</div>',
+		["style", "url(", "evil"],
+		["x"],
+	),
+	("style-color", '<div style="color:red">x</div>', ["style"], ["x"]),
+	("id-attr", '<div id="header-html">x</div>', ['id="', "header-html"], ["x"]),
+	("onclick", '<div onclick="x()">y</div>', ["onclick"], ["y"]),
+	# Markdown image syntax passed as literal text must not regenerate an <img>.
+	("markdown-img", "![alt](http://evil)", ["<img"], []),
+	("malformed-table", "<table><tr><td>unclosed", [], ["unclosed"]),
+]
+
+
+@pytest.mark.parametrize(
+	"payload,forbidden,required", [c[1:] for c in _ATTACKS], ids=[c[0] for c in _ATTACKS]
+)
+def test_attack_neutralized(payload: str, forbidden: list[str], required: list[str]) -> None:
+	_assert_neutralized(payload, forbidden, required)
+
+
+def test_long_style_value_returns_promptly() -> None:
+	"""A 200k-char inline style value must be dropped and must not stall the
+	sanitizer (ReDoS / pathological-parse guard)."""
+	payload = '<div style="width:' + ("a" * 200_000) + '">x</div>'
+	start = time.monotonic()
+	out = sanitize_rich(payload)
+	elapsed = time.monotonic() - start
+	assert "style" not in out.lower()
+	assert "aaaa" not in out.lower()
+	assert "x" in out
+	assert elapsed < 2.0, f"sanitize took {elapsed:.3f}s on a 200k style value"
+
+
+# --- positive cases: legitimate rich content must survive intact --------------
+
+
+def test_rich_document_survives() -> None:
+	"""A realistic rich doc keeps its structural tags and class hooks (styling is
+	classes-only, so classes MUST pass through)."""
+	doc = (
+		'<h1 class="cover-title">Q3 Report</h1>'
+		'<section class="section"><p class="lead">Summary text.</p>'
+		"<ul><li>one</li><li>two</li></ul>"
+		'<table class="zebra"><thead><tr><th scope="col" class="hd">Metric</th></tr></thead>'
+		'<tbody><tr><td class="num">42</td></tr></tbody></table>'
+		"<blockquote>quote</blockquote><pre><code>x = 1</code></pre></section>"
+	)
+	out = sanitize_rich(doc)
+	for tag in (
+		"<h1",
+		"<section",
+		"<p",
+		"<ul",
+		"<li",
+		"<table",
+		"<thead",
+		"<th",
+		"<tbody",
+		"<td",
+		"<blockquote",
+		"<pre",
+		"<code",
+	):
+		assert tag in out, f"{tag} was dropped"
+	for cls in ("cover-title", "section", "lead", "zebra", "hd", "num"):
+		assert cls in out, f"class {cls!r} was dropped"
+	assert "Q3 Report" in out and "Summary text." in out
+
+
+def test_table_cell_layout_attrs_survive() -> None:
+	"""colspan/rowspan/scope on cells inside a real table are the ONLY cell attrs
+	kept (id/background already proven stripped)."""
+	doc = (
+		"<table><thead><tr>"
+		'<th colspan="2" scope="col">Wide</th></tr></thead>'
+		'<tbody><tr><td rowspan="3">Tall</td></tr></tbody></table>'
+	)
+	out = sanitize_rich(doc)
+	assert 'colspan="2"' in out
+	assert 'scope="col"' in out
+	assert 'rowspan="3"' in out
+
+
+@pytest.mark.parametrize(
+	"href",
+	['href="https://ok"', 'href="#sec"', 'href="mailto:x@y"'],
+)
+def test_safe_anchor_hrefs_survive(href: str) -> None:
+	"""http/https/mailto and bare ``#`` fragment hrefs are the allowed link
+	schemes and must pass through."""
+	out = sanitize_rich(f"<a {href}>link</a>")
+	assert href in out
+	assert ">link</a>" in out

--- a/jarvis/tests/test_export_document_sanitizer.py
+++ b/jarvis/tests/test_export_document_sanitizer.py
@@ -1,7 +1,7 @@
 """Attack corpus for ``sanitize_rich`` - the rich-PDF security core.
 
 ``sanitize_rich`` is a pure module (imports only ``nh3``), so this suite runs
-WITHOUT a bench/site: ``python -m pytest`` against it directly. Each case is a
+WITHOUT a bench/site: plain ``unittest`` against it directly. Each case is a
 real vector the agent could compose; the assertion proves the vector is
 neutralized before it could reach the (unauthenticated, fetch-capable)
 wkhtmltopdf render.
@@ -17,8 +17,7 @@ for content-bearing tags, its inner text) survive - the case fails.
 """
 
 import time
-
-import pytest
+import unittest
 
 from jarvis.tools._export.document.sanitizer import (
 	_DECOMPOSE_TAGS,
@@ -64,28 +63,6 @@ def _assert_neutralized(payload: str, forbidden: list[str], required: list[str])
 		assert needle in out, f"{needle!r} missing from {out!r}"
 
 
-@pytest.mark.parametrize("tag", _DECOMPOSE_TAGS)
-def test_decompose_tag_and_attr_stripped(tag: str) -> None:
-	"""EVERY tag in the decompose set is removed together with any fetchable
-	attribute - the core SSRF property, exercised across the whole set so no tag
-	is left without a regression shield."""
-	out = sanitize_rich(f'<{tag} src="http://evil-{tag}" href="http://evil-{tag}">X</{tag}>').lower()
-	assert f"<{tag}" not in out, f"<{tag}> survived: {out!r}"
-	assert f"evil-{tag}" not in out, f"{tag} fetchable attribute survived: {out!r}"
-
-
-@pytest.mark.parametrize("tag", _CONTENT_BEARING)
-def test_decompose_tag_content_removed(tag: str) -> None:
-	"""A content-bearing decompose tag has its INNER TEXT removed, not kept as
-	inert visible text (nh3 alone would keep it - clean_content_tags is what
-	deletes the subtree). The legit sibling is placed BEFORE the tag so a
-	raw-text element like <plaintext>/<xmp> (which consumes everything AFTER it)
-	does not eat it."""
-	out = sanitize_rich(f"<p>ok</p><{tag}>ZAP_{tag}</{tag}>")
-	assert f"ZAP_{tag}" not in out, f"{tag} inner content survived: {out!r}"
-	assert "ok" in out, f"legit sibling content dropped for {tag}: {out!r}"
-
-
 # (id, payload, forbidden-substrings, required-substrings). ``forbidden`` is
 # matched case-insensitively; ``required`` case-sensitively. Specific vectors
 # beyond the whole-set sweep above.
@@ -124,103 +101,7 @@ _ATTACKS = [
 	("malformed-table", "<table><tr><td>unclosed", [], ["unclosed"]),
 ]
 
-
-@pytest.mark.parametrize(
-	"payload,forbidden,required", [c[1:] for c in _ATTACKS], ids=[c[0] for c in _ATTACKS]
-)
-def test_attack_neutralized(payload: str, forbidden: list[str], required: list[str]) -> None:
-	_assert_neutralized(payload, forbidden, required)
-
-
-def test_long_nested_returns_promptly() -> None:
-	"""A 200k-char DEEPLY NESTED fragment (the pathological input that made the old
-	BeautifulSoup/html5lib pre-pass run ~80s) must sanitize well within budget -
-	nh3's single Rust pass does the tree construction natively. This is the guard
-	the sanitizer collapse exists to make true."""
-	payload = "<div>" * 20_000 + "x" + "</div>" * 20_000
-	start = time.monotonic()
-	out = sanitize_rich(payload)
-	elapsed = time.monotonic() - start
-	assert "x" in out
-	assert elapsed < 5.0, f"sanitize took {elapsed:.3f}s on a deeply-nested 200k fragment"
-
-
-def test_long_style_value_returns_promptly() -> None:
-	"""A 200k-char inline style value must be dropped and must not stall the
-	sanitizer (ReDoS / pathological-parse guard)."""
-	payload = '<div style="width:' + ("a" * 200_000) + '">x</div>'
-	start = time.monotonic()
-	out = sanitize_rich(payload)
-	elapsed = time.monotonic() - start
-	assert "style" not in out.lower()
-	assert "aaaa" not in out.lower()
-	assert "x" in out
-	assert elapsed < 5.0, f"sanitize took {elapsed:.3f}s on a 200k style value"
-
-
-# --- positive cases: legitimate rich content must survive intact --------------
-
-
-def test_rich_document_survives() -> None:
-	"""A realistic rich doc keeps its structural tags and class hooks (styling is
-	classes-only, so classes MUST pass through)."""
-	doc = (
-		'<h1 class="cover-title">Q3 Report</h1>'
-		'<section class="section"><p class="lead">Summary text.</p>'
-		"<ul><li>one</li><li>two</li></ul>"
-		'<table class="zebra"><thead><tr><th scope="col" class="hd">Metric</th></tr></thead>'
-		'<tbody><tr><td class="num">42</td></tr></tbody></table>'
-		"<blockquote>quote</blockquote><pre><code>x = 1</code></pre></section>"
-	)
-	out = sanitize_rich(doc)
-	for tag in (
-		"<h1",
-		"<section",
-		"<p",
-		"<ul",
-		"<li",
-		"<table",
-		"<thead",
-		"<th",
-		"<tbody",
-		"<td",
-		"<blockquote",
-		"<pre",
-		"<code",
-	):
-		assert tag in out, f"{tag} was dropped"
-	for cls in ("cover-title", "section", "lead", "zebra", "hd", "num"):
-		assert cls in out, f"class {cls!r} was dropped"
-	assert "Q3 Report" in out and "Summary text." in out
-
-
-def test_table_cell_layout_attrs_survive() -> None:
-	"""colspan/rowspan/scope on cells inside a real table are the ONLY cell attrs
-	kept (id/background already proven stripped)."""
-	doc = (
-		"<table><thead><tr>"
-		'<th colspan="2" scope="col">Wide</th></tr></thead>'
-		'<tbody><tr><td rowspan="3">Tall</td></tr></tbody></table>'
-	)
-	out = sanitize_rich(doc)
-	assert 'colspan="2"' in out
-	assert 'scope="col"' in out
-	assert 'rowspan="3"' in out
-
-
-@pytest.mark.parametrize(
-	"href",
-	['href="https://ok"', 'href="#sec"', 'href="mailto:x@y"'],
-)
-def test_safe_anchor_hrefs_survive(href: str) -> None:
-	"""http/https/mailto and bare ``#`` fragment hrefs are the allowed link
-	schemes and must pass through."""
-	out = sanitize_rich(f"<a {href}>link</a>")
-	assert href in out
-	assert ">link</a>" in out
-
-
-# --- sanitize_letterhead: the F1 SSRF gate (data: images only) ----------------
+# --- letterhead SSRF vectors --------------------------------------------------
 
 _DATA_LOGO = "data:image/png;base64,iVBORw0KGgo="
 
@@ -248,24 +129,143 @@ _LETTERHEAD_SSRF = [
 ]
 
 
-@pytest.mark.parametrize(
-	"payload,forbidden", [(p, f) for _, p, f in _LETTERHEAD_SSRF], ids=[c[0] for c in _LETTERHEAD_SSRF]
-)
-def test_letterhead_gate_blocks_ssrf(payload: str, forbidden: list[str]) -> None:
-	out = sanitize_letterhead(payload).lower()
-	for needle in forbidden:
-		assert needle.lower() not in out, f"{needle!r} survived the letterhead gate: {out!r}"
+class TestDecomposeTags(unittest.TestCase):
+	def test_decompose_tag_and_attr_stripped(self) -> None:
+		"""EVERY tag in the decompose set is removed together with any fetchable
+		attribute - the core SSRF property, exercised across the whole set so no tag
+		is left without a regression shield."""
+		for tag in _DECOMPOSE_TAGS:
+			with self.subTest(tag=tag):
+				out = sanitize_rich(
+					f'<{tag} src="http://evil-{tag}" href="http://evil-{tag}">X</{tag}>'
+				).lower()
+				self.assertNotIn(f"<{tag}", out, f"<{tag}> survived: {out!r}")
+				self.assertNotIn(f"evil-{tag}", out, f"{tag} fetchable attribute survived: {out!r}")
+
+	def test_decompose_tag_content_removed(self) -> None:
+		"""A content-bearing decompose tag has its INNER TEXT removed, not kept as
+		inert visible text (nh3 alone would keep it - clean_content_tags is what
+		deletes the subtree). The legit sibling is placed BEFORE the tag so a
+		raw-text element like <plaintext>/<xmp> (which consumes everything AFTER it)
+		does not eat it."""
+		for tag in _CONTENT_BEARING:
+			with self.subTest(tag=tag):
+				out = sanitize_rich(f"<p>ok</p><{tag}>ZAP_{tag}</{tag}>")
+				self.assertNotIn(f"ZAP_{tag}", out, f"{tag} inner content survived: {out!r}")
+				self.assertIn("ok", out, f"legit sibling content dropped for {tag}: {out!r}")
 
 
-def test_letterhead_gate_keeps_data_logo_and_structure() -> None:
-	out = sanitize_letterhead(f'<div class="lh"><img src="{_DATA_LOGO}"><span>Acme Ltd</span></div>')
-	assert "data:image/png;base64," in out  # the inlined logo survives
-	assert "Acme Ltd" in out
-	assert 'class="lh"' in out
+class TestAttackCorpus(unittest.TestCase):
+	def test_attack_neutralized(self) -> None:
+		for case_id, payload, forbidden, required in _ATTACKS:
+			with self.subTest(case_id=case_id):
+				_assert_neutralized(payload, forbidden, required)
 
 
-def test_letterhead_gate_drops_anchor_but_keeps_text() -> None:
-	# <a> is dropped (keeping http on <a href> would re-open the image hole).
-	out = sanitize_letterhead('<a href="http://x">Visit</a>')
-	assert "<a" not in out.lower()
-	assert "Visit" in out
+class TestPerformanceGuards(unittest.TestCase):
+	def test_long_nested_returns_promptly(self) -> None:
+		"""A 200k-char DEEPLY NESTED fragment (the pathological input that made the old
+		BeautifulSoup/html5lib pre-pass run ~80s) must sanitize well within budget -
+		nh3's single Rust pass does the tree construction natively. This is the guard
+		the sanitizer collapse exists to make true."""
+		payload = "<div>" * 20_000 + "x" + "</div>" * 20_000
+		start = time.monotonic()
+		out = sanitize_rich(payload)
+		elapsed = time.monotonic() - start
+		self.assertIn("x", out)
+		self.assertTrue(elapsed < 5.0, f"sanitize took {elapsed:.3f}s on a deeply-nested 200k fragment")
+
+	def test_long_style_value_returns_promptly(self) -> None:
+		"""A 200k-char inline style value must be dropped and must not stall the
+		sanitizer (ReDoS / pathological-parse guard)."""
+		payload = '<div style="width:' + ("a" * 200_000) + '">x</div>'
+		start = time.monotonic()
+		out = sanitize_rich(payload)
+		elapsed = time.monotonic() - start
+		self.assertNotIn("style", out.lower())
+		self.assertNotIn("aaaa", out.lower())
+		self.assertIn("x", out)
+		self.assertTrue(elapsed < 5.0, f"sanitize took {elapsed:.3f}s on a 200k style value")
+
+
+# --- positive cases: legitimate rich content must survive intact --------------
+
+
+class TestLegitimateContentSurvives(unittest.TestCase):
+	def test_rich_document_survives(self) -> None:
+		"""A realistic rich doc keeps its structural tags and class hooks (styling is
+		classes-only, so classes MUST pass through)."""
+		doc = (
+			'<h1 class="cover-title">Q3 Report</h1>'
+			'<section class="section"><p class="lead">Summary text.</p>'
+			"<ul><li>one</li><li>two</li></ul>"
+			'<table class="zebra"><thead><tr><th scope="col" class="hd">Metric</th></tr></thead>'
+			'<tbody><tr><td class="num">42</td></tr></tbody></table>'
+			"<blockquote>quote</blockquote><pre><code>x = 1</code></pre></section>"
+		)
+		out = sanitize_rich(doc)
+		for tag in (
+			"<h1",
+			"<section",
+			"<p",
+			"<ul",
+			"<li",
+			"<table",
+			"<thead",
+			"<th",
+			"<tbody",
+			"<td",
+			"<blockquote",
+			"<pre",
+			"<code",
+		):
+			self.assertIn(tag, out, f"{tag} was dropped")
+		for cls in ("cover-title", "section", "lead", "zebra", "hd", "num"):
+			self.assertIn(cls, out, f"class {cls!r} was dropped")
+		self.assertTrue("Q3 Report" in out and "Summary text." in out)
+
+	def test_table_cell_layout_attrs_survive(self) -> None:
+		"""colspan/rowspan/scope on cells inside a real table are the ONLY cell attrs
+		kept (id/background already proven stripped)."""
+		doc = (
+			"<table><thead><tr>"
+			'<th colspan="2" scope="col">Wide</th></tr></thead>'
+			'<tbody><tr><td rowspan="3">Tall</td></tr></tbody></table>'
+		)
+		out = sanitize_rich(doc)
+		self.assertIn('colspan="2"', out)
+		self.assertIn('scope="col"', out)
+		self.assertIn('rowspan="3"', out)
+
+	def test_safe_anchor_hrefs_survive(self) -> None:
+		"""http/https/mailto and bare ``#`` fragment hrefs are the allowed link
+		schemes and must pass through."""
+		for href in ['href="https://ok"', 'href="#sec"', 'href="mailto:x@y"']:
+			with self.subTest(href=href):
+				out = sanitize_rich(f"<a {href}>link</a>")
+				self.assertIn(href, out)
+				self.assertIn(">link</a>", out)
+
+
+# --- sanitize_letterhead: the F1 SSRF gate (data: images only) ----------------
+
+
+class TestSanitizeLetterheadGate(unittest.TestCase):
+	def test_letterhead_gate_blocks_ssrf(self) -> None:
+		for case_id, payload, forbidden in _LETTERHEAD_SSRF:
+			with self.subTest(case_id=case_id):
+				out = sanitize_letterhead(payload).lower()
+				for needle in forbidden:
+					self.assertNotIn(needle.lower(), out, f"{needle!r} survived the letterhead gate: {out!r}")
+
+	def test_letterhead_gate_keeps_data_logo_and_structure(self) -> None:
+		out = sanitize_letterhead(f'<div class="lh"><img src="{_DATA_LOGO}"><span>Acme Ltd</span></div>')
+		self.assertIn("data:image/png;base64,", out)  # the inlined logo survives
+		self.assertIn("Acme Ltd", out)
+		self.assertIn('class="lh"', out)
+
+	def test_letterhead_gate_drops_anchor_but_keeps_text(self) -> None:
+		# <a> is dropped (keeping http on <a href> would re-open the image hole).
+		out = sanitize_letterhead('<a href="http://x">Visit</a>')
+		self.assertNotIn("<a", out.lower())
+		self.assertIn("Visit", out)

--- a/jarvis/tests/test_export_document_sanitizer.py
+++ b/jarvis/tests/test_export_document_sanitizer.py
@@ -20,7 +20,11 @@ import time
 
 import pytest
 
-from jarvis.tools._export.document.sanitizer import _DECOMPOSE_TAGS, sanitize_rich
+from jarvis.tools._export.document.sanitizer import (
+	_DECOMPOSE_TAGS,
+	sanitize_letterhead,
+	sanitize_rich,
+)
 
 # Content-bearing subset of the decompose set: their INNER TEXT must be removed
 # too (not just the tag), so a stripped tag can't leave inert payload text behind.
@@ -39,6 +43,14 @@ _CONTENT_BEARING = (
 	"template",
 	"form",
 	"button",
+	# raw-text / escapable / metadata elements — their content must be DISCARDED,
+	# not merely stripped-tag-keep-text (the module docstring names these). A
+	# hardcoded tuple (NOT derived from _DECOMPOSE_TAGS) so removing one of these
+	# from the decompose set makes the matching case go RED.
+	"title",
+	"textarea",
+	"xmp",
+	"plaintext",
 )
 
 
@@ -66,8 +78,10 @@ def test_decompose_tag_and_attr_stripped(tag: str) -> None:
 def test_decompose_tag_content_removed(tag: str) -> None:
 	"""A content-bearing decompose tag has its INNER TEXT removed, not kept as
 	inert visible text (nh3 alone would keep it - clean_content_tags is what
-	deletes the subtree)."""
-	out = sanitize_rich(f"<{tag}>ZAP_{tag}</{tag}><p>ok</p>")
+	deletes the subtree). The legit sibling is placed BEFORE the tag so a
+	raw-text element like <plaintext>/<xmp> (which consumes everything AFTER it)
+	does not eat it."""
+	out = sanitize_rich(f"<p>ok</p><{tag}>ZAP_{tag}</{tag}>")
 	assert f"ZAP_{tag}" not in out, f"{tag} inner content survived: {out!r}"
 	assert "ok" in out, f"legit sibling content dropped for {tag}: {out!r}"
 
@@ -204,3 +218,54 @@ def test_safe_anchor_hrefs_survive(href: str) -> None:
 	out = sanitize_rich(f"<a {href}>link</a>")
 	assert href in out
 	assert ">link</a>" in out
+
+
+# --- sanitize_letterhead: the F1 SSRF gate (data: images only) ----------------
+
+_DATA_LOGO = "data:image/png;base64,iVBORw0KGgo="
+
+# Every remote/relative image src form + fetch-capable construct that must NOT
+# survive the letterhead gate (each would make wkhtmltopdf fetch server-side).
+_LETTERHEAD_SSRF = [
+	("remote-quoted", '<img src="http://169.254.169.254/x">', ["169.254", "http://"]),
+	("remote-noquote", "<img src=http://evil/x.png>", ["evil"]),
+	("image-alias", '<image src="http://evil/x.png">', ["evil"]),
+	("image-href", '<image href="http://evil/x.png">', ["evil"]),
+	("alt-truncation", '<img alt="a>b" src="http://evil/x.png">', ["evil"]),
+	("protocol-relative", '<img src="//evil/x.png">', ["evil"]),
+	("relative-files", '<img src="/files/logo.png">', ["/files/logo.png"]),
+	("srcset", '<img srcset="http://evil/x 1x">', ["evil"]),
+	("link-css", '<link rel="stylesheet" href="http://evil/x.css">', ["evil", "<link"]),
+	("style-tag-url", "<style>body{background:url(http://evil/x)}</style>", ["evil", "<style"]),
+	("style-attr-url", '<div style="background:url(http://evil/x)">y</div>', ["evil", "style="]),
+	("svg-image", '<svg><image href="http://evil/x"/></svg>', ["evil", "<svg", "<image"]),
+	("iframe", '<iframe src="http://evil/x"></iframe>', ["evil", "<iframe"]),
+	("input-image", '<input type="image" src="http://evil/x">', ["evil", "<input"]),
+	("video-poster", '<video poster="http://evil/x"></video>', ["evil", "<video"]),
+	("object-data", '<object data="http://evil/x"></object>', ["evil", "<object"]),
+	("base-href", '<base href="http://evil/">', ["evil", "<base"]),
+	("meta-refresh", '<meta http-equiv="refresh" content="0;url=http://evil">', ["evil", "<meta"]),
+]
+
+
+@pytest.mark.parametrize(
+	"payload,forbidden", [(p, f) for _, p, f in _LETTERHEAD_SSRF], ids=[c[0] for c in _LETTERHEAD_SSRF]
+)
+def test_letterhead_gate_blocks_ssrf(payload: str, forbidden: list[str]) -> None:
+	out = sanitize_letterhead(payload).lower()
+	for needle in forbidden:
+		assert needle.lower() not in out, f"{needle!r} survived the letterhead gate: {out!r}"
+
+
+def test_letterhead_gate_keeps_data_logo_and_structure() -> None:
+	out = sanitize_letterhead(f'<div class="lh"><img src="{_DATA_LOGO}"><span>Acme Ltd</span></div>')
+	assert "data:image/png;base64," in out  # the inlined logo survives
+	assert "Acme Ltd" in out
+	assert 'class="lh"' in out
+
+
+def test_letterhead_gate_drops_anchor_but_keeps_text() -> None:
+	# <a> is dropped (keeping http on <a href> would re-open the image hole).
+	out = sanitize_letterhead('<a href="http://x">Visit</a>')
+	assert "<a" not in out.lower()
+	assert "Visit" in out

--- a/jarvis/tests/test_export_document_theme.py
+++ b/jarvis/tests/test_export_document_theme.py
@@ -1,8 +1,8 @@
 """Contract tests for the rich-PDF branded component stylesheet.
 
 ``jarvis.tools._export.document.theme`` is a pure module (no ``frappe``
-import), so this suite runs WITHOUT a bench/site - plain ``pytest`` against it
-directly, same as the sanitizer corpus.
+import), so this suite runs WITHOUT a bench/site - plain ``unittest`` against
+it directly, same as the sanitizer corpus.
 
 The class names asserted here are the CONTRACT other Slice-1 tasks (Task 4's
 number/RAG/chart builders, Task 6's ``export_document`` HTML assembly) build
@@ -12,9 +12,8 @@ silently break those callers without this guard.
 
 import ast
 import re
+import unittest
 from pathlib import Path
-
-import pytest
 
 from jarvis.tools._export.document import theme
 
@@ -69,35 +68,41 @@ def _has_tag_selector(css: str, tag: str) -> bool:
 	return re.search(pattern, css) is not None
 
 
-class TestComponentCss:
+class TestComponentCss(unittest.TestCase):
 	def test_non_empty(self):
 		css = theme.component_css()
-		assert isinstance(css, str)
-		assert len(css.strip()) > 0
+		self.assertTrue(isinstance(css, str))
+		self.assertTrue(len(css.strip()) > 0)
 
 	def test_theme_css_matches_component_css(self):
 		"""THEME_CSS is the cached, deterministic output of component_css()."""
-		assert theme.THEME_CSS == theme.component_css()
+		self.assertEqual(theme.THEME_CSS, theme.component_css())
 
 	def test_deterministic(self):
-		assert theme.component_css() == theme.component_css()
+		self.assertEqual(theme.component_css(), theme.component_css())
 
-	@pytest.mark.parametrize("class_name", _CONTRACT_CLASSES)
-	def test_contract_class_present(self, class_name: str):
-		css = theme.component_css()
-		assert _has_class_token(css, class_name), f".{class_name} missing from component_css()"
+	def test_contract_class_present(self):
+		for class_name in _CONTRACT_CLASSES:
+			with self.subTest(class_name=class_name):
+				css = theme.component_css()
+				self.assertTrue(
+					_has_class_token(css, class_name), f".{class_name} missing from component_css()"
+				)
 
-	@pytest.mark.parametrize("tag", _TYPOGRAPHY_TAGS)
-	def test_typography_tag_present(self, tag: str):
-		css = theme.component_css()
-		assert _has_tag_selector(css, tag), f"bare `{tag}` selector missing from component_css()"
+	def test_typography_tag_present(self):
+		for tag in _TYPOGRAPHY_TAGS:
+			with self.subTest(tag=tag):
+				css = theme.component_css()
+				self.assertTrue(
+					_has_tag_selector(css, tag), f"bare `{tag}` selector missing from component_css()"
+				)
 
 	def test_print_color_adjust_present(self):
 		"""wkhtmltopdf drops print background fills without this - required on
 		anything with a background fill; theme.py applies it globally."""
 		css = theme.component_css()
-		assert "-webkit-print-color-adjust:exact" in css
-		assert "print-color-adjust:exact" in css
+		self.assertIn("-webkit-print-color-adjust:exact", css)
+		self.assertIn("print-color-adjust:exact", css)
 
 	def test_bar_has_no_width(self):
 		"""`.bar` styles color/height only - the tool sets `width` per bar via a
@@ -105,31 +110,30 @@ class TestComponentCss:
 		stylesheet also set width, the two could fight."""
 		css = theme.component_css()
 		match = re.search(r"(?<![\w-])\.bar\s*\{([^}]*)\}", css)
-		assert match, ".bar rule not found"
-		assert "width" not in match.group(1)
+		self.assertTrue(match, ".bar rule not found")
+		self.assertNotIn("width", match.group(1))
 
 	def test_neg_is_reused_by_kpi_delta(self):
 		"""`.kpi-tile .kpi-delta.neg` reuses the single `.neg` contract class
 		rather than inventing a second negative-color token."""
 		css = theme.component_css()
-		assert ".kpi-tile .kpi-delta.neg" in css
+		self.assertIn(".kpi-tile .kpi-delta.neg", css)
 
 	# --- snapshot: a handful of key selectors, verbatim -----------------------
 
-	@pytest.mark.parametrize(
-		"selector",
-		[
+	def test_snapshot_key_selector(self):
+		selectors = [
 			"table.zebra tbody tr:nth-child(even) td",
 			"tr.grouped td",
 			".kpi-tile .kpi-value",
 			".rag-red { background: #fbe9e7; color: #b3261e; }",
 			".cover {",
 			".signature-block .signature-line {",
-		],
-	)
-	def test_snapshot_key_selector(self, selector: str):
-		css = theme.component_css()
-		assert selector in css, f"expected selector/rule {selector!r} not found verbatim"
+		]
+		for selector in selectors:
+			with self.subTest(selector=selector):
+				css = theme.component_css()
+				self.assertIn(selector, css, f"expected selector/rule {selector!r} not found verbatim")
 
 	def test_indent_levels_step_consistently(self):
 		""".indent-1..indent-5 step by a fixed padding-left amount, largest last."""
@@ -137,27 +141,28 @@ class TestComponentCss:
 		values = []
 		for level in range(1, 6):
 			match = re.search(rf"\.indent-{level}\s*{{\s*padding-left:\s*(\d+)pt", css)
-			assert match, f".indent-{level} rule not found"
+			self.assertTrue(match, f".indent-{level} rule not found")
 			values.append(int(match.group(1)))
-		assert values == sorted(values)
-		assert len(set(values)) == 5, "indent levels must all be distinct"
+		self.assertEqual(values, sorted(values))
+		self.assertEqual(len(set(values)), 5, "indent levels must all be distinct")
 
 	def test_unknown_class_is_inert(self):
 		"""A class the contract never names produces no selector - nothing in
 		the stylesheet can accidentally style agent-chosen class names."""
 		css = theme.component_css()
-		assert not _has_class_token(css, "totally-made-up-class-xyz")
+		self.assertFalse(_has_class_token(css, "totally-made-up-class-xyz"))
 
 
-def test_theme_module_is_pure():
-	"""theme.py must never import frappe - it has to be unit-testable without a
-	bench, same purity guarantee sanitizer.py makes for the same reason."""
-	path = Path(theme.__file__)
-	tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-	imported_names = set()
-	for node in ast.walk(tree):
-		if isinstance(node, ast.Import):
-			imported_names.update(alias.name.split(".")[0] for alias in node.names)
-		elif isinstance(node, ast.ImportFrom) and node.module:
-			imported_names.add(node.module.split(".")[0])
-	assert "frappe" not in imported_names
+class TestThemeModulePurity(unittest.TestCase):
+	def test_theme_module_is_pure(self):
+		"""theme.py must never import frappe - it has to be unit-testable without a
+		bench, same purity guarantee sanitizer.py makes for the same reason."""
+		path = Path(theme.__file__)
+		tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+		imported_names = set()
+		for node in ast.walk(tree):
+			if isinstance(node, ast.Import):
+				imported_names.update(alias.name.split(".")[0] for alias in node.names)
+			elif isinstance(node, ast.ImportFrom) and node.module:
+				imported_names.add(node.module.split(".")[0])
+		self.assertNotIn("frappe", imported_names)

--- a/jarvis/tests/test_export_document_theme.py
+++ b/jarvis/tests/test_export_document_theme.py
@@ -1,0 +1,163 @@
+"""Contract tests for the rich-PDF branded component stylesheet.
+
+``jarvis.tools._export.document.theme`` is a pure module (no ``frappe``
+import), so this suite runs WITHOUT a bench/site - plain ``pytest`` against it
+directly, same as the sanitizer corpus.
+
+The class names asserted here are the CONTRACT other Slice-1 tasks (Task 4's
+number/RAG/chart builders, Task 6's ``export_document`` HTML assembly) build
+their output against. A class disappearing or getting renamed here would
+silently break those callers without this guard.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from jarvis.tools._export.document import theme
+
+# The full class-name contract from theme.py's module docstring. ".bar" is
+# listed separately from ".bar-chart"/".bar-row"/etc - the regex helper below
+# matches a class as a whole token, so ".bar" only matches the real `.bar {`
+# selector, never as a prefix of ".bar-chart".
+_CONTRACT_CLASSES = [
+	"zebra",
+	"grouped",
+	"indent-1",
+	"indent-2",
+	"indent-3",
+	"indent-4",
+	"indent-5",
+	"neg",
+	"rag-red",
+	"rag-amber",
+	"rag-green",
+	"num",
+	"callout",
+	"kpi-tile",
+	"cover",
+	"section-divider",
+	"signature-block",
+	"bar-chart",
+	"bar",
+]
+
+# Bare typography tag selectors (no class needed - the sanitizer allows these
+# tags directly with only a `class` attribute).
+_TYPOGRAPHY_TAGS = ["h1", "h2", "h3", "h4", "h5", "h6"]
+
+
+def _has_class_token(css: str, class_name: str) -> bool:
+	"""True if ``.class_name`` appears in ``css`` as a whole CSS class token
+	(not merely as a prefix of a longer class, e.g. ``.bar`` inside
+	``.bar-chart``).
+
+	No lookbehind on what precedes the ``.`` - a class selector is legitimately
+	preceded by an element name (``table.zebra``), a combinator, a comma, or
+	nothing at all, so only the character AFTER the class name distinguishes a
+	real token from a longer one it happens to prefix."""
+	pattern = r"\." + re.escape(class_name) + r"(?![\w-])"
+	return re.search(pattern, css) is not None
+
+
+def _has_tag_selector(css: str, tag: str) -> bool:
+	"""True if ``tag`` appears in ``css`` as a bare tag selector token (not
+	inside a longer identifier or a class name)."""
+	pattern = r"(?<![\w.-])" + re.escape(tag) + r"(?![\w-])"
+	return re.search(pattern, css) is not None
+
+
+class TestComponentCss:
+	def test_non_empty(self):
+		css = theme.component_css()
+		assert isinstance(css, str)
+		assert len(css.strip()) > 0
+
+	def test_theme_css_matches_component_css(self):
+		"""THEME_CSS is the cached, deterministic output of component_css()."""
+		assert theme.THEME_CSS == theme.component_css()
+
+	def test_deterministic(self):
+		assert theme.component_css() == theme.component_css()
+
+	@pytest.mark.parametrize("class_name", _CONTRACT_CLASSES)
+	def test_contract_class_present(self, class_name: str):
+		css = theme.component_css()
+		assert _has_class_token(css, class_name), f".{class_name} missing from component_css()"
+
+	@pytest.mark.parametrize("tag", _TYPOGRAPHY_TAGS)
+	def test_typography_tag_present(self, tag: str):
+		css = theme.component_css()
+		assert _has_tag_selector(css, tag), f"bare `{tag}` selector missing from component_css()"
+
+	def test_print_color_adjust_present(self):
+		"""wkhtmltopdf drops print background fills without this - required on
+		anything with a background fill; theme.py applies it globally."""
+		css = theme.component_css()
+		assert "-webkit-print-color-adjust:exact" in css
+		assert "print-color-adjust:exact" in css
+
+	def test_bar_has_no_width(self):
+		"""`.bar` styles color/height only - the tool sets `width` per bar via a
+		tool-controlled inline style spliced in after sanitize_rich; if the
+		stylesheet also set width, the two could fight."""
+		css = theme.component_css()
+		match = re.search(r"(?<![\w-])\.bar\s*\{([^}]*)\}", css)
+		assert match, ".bar rule not found"
+		assert "width" not in match.group(1)
+
+	def test_neg_is_reused_by_kpi_delta(self):
+		"""`.kpi-tile .kpi-delta.neg` reuses the single `.neg` contract class
+		rather than inventing a second negative-color token."""
+		css = theme.component_css()
+		assert ".kpi-tile .kpi-delta.neg" in css
+
+	# --- snapshot: a handful of key selectors, verbatim -----------------------
+
+	@pytest.mark.parametrize(
+		"selector",
+		[
+			"table.zebra tbody tr:nth-child(even) td",
+			"tr.grouped td",
+			".kpi-tile .kpi-value",
+			".rag-red { background: #fbe9e7; color: #b3261e; }",
+			".cover {",
+			".signature-block .signature-line {",
+		],
+	)
+	def test_snapshot_key_selector(self, selector: str):
+		css = theme.component_css()
+		assert selector in css, f"expected selector/rule {selector!r} not found verbatim"
+
+	def test_indent_levels_step_consistently(self):
+		""".indent-1..indent-5 step by a fixed padding-left amount, largest last."""
+		css = theme.component_css()
+		values = []
+		for level in range(1, 6):
+			match = re.search(rf"\.indent-{level}\s*{{\s*padding-left:\s*(\d+)pt", css)
+			assert match, f".indent-{level} rule not found"
+			values.append(int(match.group(1)))
+		assert values == sorted(values)
+		assert len(set(values)) == 5, "indent levels must all be distinct"
+
+	def test_unknown_class_is_inert(self):
+		"""A class the contract never names produces no selector - nothing in
+		the stylesheet can accidentally style agent-chosen class names."""
+		css = theme.component_css()
+		assert not _has_class_token(css, "totally-made-up-class-xyz")
+
+
+def test_theme_module_is_pure():
+	"""theme.py must never import frappe - it has to be unit-testable without a
+	bench, same purity guarantee sanitizer.py makes for the same reason."""
+	path = Path(theme.__file__)
+	tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+	imported_names = set()
+	for node in ast.walk(tree):
+		if isinstance(node, ast.Import):
+			imported_names.update(alias.name.split(".")[0] for alias in node.names)
+		elif isinstance(node, ast.ImportFrom) and node.module:
+			imported_names.add(node.module.split(".")[0])
+	assert "frappe" not in imported_names

--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -425,8 +425,19 @@ def _ensure_company(name: str, abbr: str) -> None:
 				"abbr": abbr,
 				"default_currency": "INR",
 				"country": "India",
+				# COA is skipped above, so this company has NO default inventory
+				# account; perpetual inventory MUST be off or erpnext refuses to
+				# create a Warehouse here ("Please set Account in Warehouse ... or
+				# Default Inventory Account in Company"). This showed up only under
+				# some test-shard orderings; the fixture never posts stock, so
+				# disabling it just lets _ensure_warehouse succeed deterministically.
+				"enable_perpetual_inventory": 0,
 			}
 		).insert(ignore_permissions=True)
+		# Belt-and-suspenders: if a Company hook re-enabled it on insert, force off
+		# before any Warehouse is created against this company.
+		if frappe.db.get_value("Company", name, "enable_perpetual_inventory"):
+			frappe.db.set_value("Company", name, "enable_perpetual_inventory", 0)
 	finally:
 		frappe.local.flags.ignore_chart_of_accounts = False
 

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -1,0 +1,306 @@
+"""Page furniture + the rich-PDF render call (the 2nd, sanitized render path).
+
+``render_pdf`` turns a *already-sanitized* body-HTML fragment into PDF bytes on
+wkhtmltopdf, wrapping it with header/footer/watermark/letterhead furniture and a
+real, hard render timeout.
+
+WHY the binary is called DIRECTLY via ``subprocess.run`` (deviation from the
+plan's "pdfkit.from_string + patched FrappePDFKit"): ``pdfkit.from_string`` shells
+out with ``subprocess.communicate()`` and NO timeout, so a runaway render cannot
+be aborted - it pins the RQ worker well past the plugin's 30s ``call_tool`` abort
+and leaves an orphaned File. ``subprocess.run([...], timeout=...)`` gives a REAL
+hard bound: on ``TimeoutExpired`` the child process is killed and no partial
+output is returned. A bonus: because we build the exact wkhtmltopdf arg list here,
+pdfkit's ``<meta name="pdfkit-...">`` option-injection vector does not exist at
+all, so the ``FrappePDFKit`` monkeypatch is unnecessary (and the sanitizer already
+strips ``<meta>`` regardless).
+
+WHY header/footer/watermark are sanitized here too: they are as agent-influenced
+as the body, and wkhtmltopdf will FETCH any ``<img src>``/``<link>`` it finds in a
+``--header-html``/``--footer-html`` document (a *separate* render), so each runs
+through ``sanitize_rich`` before it is written to a temp file. The letterhead
+header/footer is operator-authored trusted config (a ``Letter Head`` doc) and is
+folded in WITHOUT sanitizing - sanitizing would strip its logo, which is the whole
+point of a letterhead.
+
+WHY the watermark lives in the HEADER template, not the body: wkhtmltopdf only
+paints a body ``position:fixed`` element on page 1, whereas the header document is
+composited onto EVERY page, so a rotated, absolutely-positioned block placed in
+the header repeats across all pages.
+
+Testability: wkhtmltopdf is absent in local dev (brew removed it) - the real
+render is the Frappe Cloud smoke gate, not a unit test. The unit suite mocks
+``subprocess.run`` and asserts the arg list, the sanitized temp-file contents, and
+the temp-file lifecycle. See ``jarvis/tests/test_export_document_furniture.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+import tempfile
+
+import frappe
+import pdfkit
+
+from jarvis.exceptions import InvalidArgumentError
+
+from .sanitizer import sanitize_rich
+
+_SANS = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+
+# Self-contained CSS for the header/footer documents - they are SEPARATE
+# wkhtmltopdf renders, so they carry no body/theme styling and must style
+# themselves. ``.jv-watermark`` is the tool-controlled rotate/position trick
+# (agent content can never carry a ``style`` attribute - it is class-only after
+# ``sanitize_rich`` - so the rotation must come from here, not the payload).
+_FURNITURE_CSS = f"""
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{
+	font-family: {_SANS};
+	font-size: 9pt;
+	color: #666666;
+	-webkit-print-color-adjust: exact;
+	print-color-adjust: exact;
+}}
+.jv-pageno {{ text-align: center; }}
+.jv-lh-header, .jv-lh-footer {{ width: 100%; }}
+.jv-watermark {{
+	position: absolute;
+	top: 340pt;
+	left: 0;
+	right: 0;
+	text-align: center;
+	transform: rotate(-45deg);
+	font-size: 72pt;
+	font-weight: 700;
+	color: rgba(0, 0, 0, 0.08);
+	z-index: -1;
+}}
+"""
+
+# wkhtmltopdf substitutes the bracket variables ``[page]``/``[topage]`` inside
+# header/footer HTML natively (text replacement, NOT JavaScript) - so page
+# numbering survives ``--disable-javascript``.
+_PAGE_NUMBER_HTML = '<div class="jv-pageno">Page [page] of [topage]</div>'
+
+
+def render_pdf(
+	body_html: str,
+	*,
+	page_size: str = "A4",
+	orientation: str = "portrait",
+	margins_mm: int = 15,
+	header_html: str | None = None,
+	footer_html: str | None = None,
+	watermark: str | None = None,
+	letterhead: str | None = None,
+	page_numbers: bool = True,
+	timeout: int = 25,
+) -> bytes:
+	"""Render ``body_html`` (a fragment the caller already sanitized) to PDF bytes
+	via a direct, hard-timed wkhtmltopdf subprocess.
+
+	Header/footer/watermark are agent-influenced and re-sanitized here; letterhead
+	is trusted operator config, folded in as-is. Temp files for the header/footer
+	documents use content-independent ``frappe.generate_hash()`` names and are
+	removed in a ``finally`` that runs on success, error, AND timeout.
+
+	Raises ``InvalidArgumentError`` (clean, user-facing) when the binary is
+	missing, the render times out, wkhtmltopdf exits non-zero, or the output is
+	empty - never a raw ``TimeoutExpired`` and never a partial/zero-byte PDF.
+	"""
+	binary = _resolve_binary()
+	orientation_flag = _normalize_orientation(orientation)
+
+	lh_header, lh_footer = _letterhead_parts(letterhead) if letterhead else ("", "")
+	header_doc = _build_header(header_html, watermark, lh_header)
+	footer_doc = _build_footer(footer_html, page_numbers, lh_footer)
+
+	tmp_dir = tempfile.gettempdir()
+	header_file = _write_temp(tmp_dir, header_doc) if header_doc else None
+	footer_file = _write_temp(tmp_dir, footer_doc) if footer_doc else None
+
+	try:
+		args = _build_args(
+			binary,
+			page_size=page_size,
+			orientation=orientation_flag,
+			margins_mm=margins_mm,
+			header_file=header_file,
+			footer_file=footer_file,
+		)
+		document = _compose_document(body_html, "")
+		try:
+			result = subprocess.run(
+				args,
+				input=document.encode("utf-8"),
+				capture_output=True,
+				timeout=timeout,
+			)
+		except subprocess.TimeoutExpired as exc:
+			# Hard bound hit: the child was killed, no usable output. Surface a
+			# clean, actionable error rather than the raw TimeoutExpired.
+			raise InvalidArgumentError(f"PDF render exceeded {timeout}s — reduce content/charts") from exc
+
+		if result.returncode != 0:
+			tail = (result.stderr or b"").decode("utf-8", "replace").strip()[-500:]
+			raise InvalidArgumentError(f"PDF render failed (wkhtmltopdf exit {result.returncode}): {tail}")
+		if not result.stdout:
+			# A zero-byte result is a failed render, never a valid empty PDF.
+			raise InvalidArgumentError("PDF render produced no output")
+		return result.stdout
+	finally:
+		for path in (header_file, footer_file):
+			if path:
+				_remove_quietly(path)
+
+
+def _resolve_binary() -> str:
+	"""Return the wkhtmltopdf executable path, or raise a clean error.
+
+	Tries pdfkit's own resolver first (it decodes ``$PDFKIT_...``/PATH lookups and
+	raises ``OSError`` when nothing is found), then ``shutil.which``. A missing
+	binary is EXPECTED in local dev (the real render runs on the FC bench), so the
+	failure is an ``InvalidArgumentError``, not a crash.
+	"""
+	with contextlib.suppress(OSError):
+		raw = pdfkit.configuration().wkhtmltopdf
+		path = raw.decode() if isinstance(raw, bytes) else str(raw)
+		if path:
+			return path
+	path = shutil.which("wkhtmltopdf")
+	if path:
+		return path
+	raise InvalidArgumentError(
+		"wkhtmltopdf binary not found — rich PDF rendering needs wkhtmltopdf "
+		"(present on the Frappe Cloud bench; absent in local dev)"
+	)
+
+
+def _normalize_orientation(orientation: str) -> str:
+	"""Validate orientation and return wkhtmltopdf's expected capitalized token
+	(``Portrait``/``Landscape``)."""
+	value = str(orientation).strip().lower()
+	if value not in ("portrait", "landscape"):
+		raise InvalidArgumentError(f"orientation must be 'portrait' or 'landscape', got {orientation!r}")
+	return value.capitalize()
+
+
+def _build_args(
+	binary: str,
+	*,
+	page_size: str,
+	orientation: str,
+	margins_mm: int,
+	header_file: str | None,
+	footer_file: str | None,
+) -> list[str]:
+	"""Build the exact wkhtmltopdf CLI arg list.
+
+	The leading security/fidelity flags are UNCONDITIONAL - they are present on
+	every render regardless of options (a test asserts each one; dropping any
+	fails it). Body is read from stdin and the PDF written to stdout via ``- -``.
+	"""
+	args = [
+		binary,
+		"--disable-local-file-access",
+		"--disable-javascript",
+		"--background",
+		"--images",
+		"--print-media-type",
+		"--disable-smart-shrinking",
+		"--quiet",
+		"--encoding",
+		"utf-8",
+		"--page-size",
+		page_size,
+		"--orientation",
+		orientation,
+		"--margin-top",
+		f"{margins_mm}mm",
+		"--margin-bottom",
+		f"{margins_mm}mm",
+		"--margin-left",
+		f"{margins_mm}mm",
+		"--margin-right",
+		f"{margins_mm}mm",
+	]
+	if header_file:
+		args += ["--header-html", header_file]
+	if footer_file:
+		args += ["--footer-html", footer_file]
+	args += ["-", "-"]  # stdin in, stdout out
+	return args
+
+
+def _build_header(header_html: str | None, watermark: str | None, letterhead_header: str) -> str:
+	"""Compose the header document, or ``""`` when there is nothing to render.
+
+	Order: trusted letterhead header (as-is) → sanitized agent header → sanitized
+	watermark wrapped in the tool-controlled ``.jv-watermark`` rotate block.
+	"""
+	parts = []
+	if letterhead_header:
+		parts.append(f'<div class="jv-lh-header">{letterhead_header}</div>')
+	if header_html:
+		parts.append(f'<div class="jv-header">{sanitize_rich(header_html)}</div>')
+	if watermark:
+		parts.append(f'<div class="jv-watermark">{sanitize_rich(watermark)}</div>')
+	return _compose_document("".join(parts), _FURNITURE_CSS) if parts else ""
+
+
+def _build_footer(footer_html: str | None, page_numbers: bool, letterhead_footer: str) -> str:
+	"""Compose the footer document, or ``""`` when there is nothing to render.
+
+	An explicit ``footer_html`` wins over auto page numbers (they are mutually
+	exclusive); the trusted letterhead footer is always folded in when present.
+	"""
+	parts = []
+	if letterhead_footer:
+		parts.append(f'<div class="jv-lh-footer">{letterhead_footer}</div>')
+	if footer_html:
+		parts.append(f'<div class="jv-footer">{sanitize_rich(footer_html)}</div>')
+	elif page_numbers:
+		parts.append(_PAGE_NUMBER_HTML)
+	return _compose_document("".join(parts), _FURNITURE_CSS) if parts else ""
+
+
+def _letterhead_parts(letterhead: str) -> tuple[str, str]:
+	"""Return ``(header_html, footer_html)`` for a named ``Letter Head``.
+
+	Lazy-imports ``printview`` so this module stays importable without a bench;
+	needs a site, so its direct test is gated. Unit tests stub THIS function to
+	exercise the fold logic site-free.
+	"""
+	from frappe.www.printview import get_letter_head
+
+	parts = get_letter_head(None, no_letterhead=False, letterhead=letterhead) or {}
+	return parts.get("content") or "", parts.get("footer") or ""
+
+
+def _compose_document(inner: str, css: str) -> str:
+	"""Wrap a fragment in a minimal, self-contained HTML document with a declared
+	charset - header/footer are separate renders and the body fragment needs a
+	well-formed page around it."""
+	return (
+		'<!doctype html><html><head><meta charset="utf-8">'
+		f"<style>{css}</style></head><body>{inner}</body></html>"
+	)
+
+
+def _write_temp(tmp_dir: str, content: str) -> str:
+	"""Write ``content`` to a uniquely named temp file (name from
+	``frappe.generate_hash()``, never derived from content) and return its path."""
+	path = os.path.join(tmp_dir, f"jv-pdf-{frappe.generate_hash()}.html")
+	with open(path, "wb") as fh:
+		fh.write(content.encode("utf-8"))
+	return path
+
+
+def _remove_quietly(path: str) -> None:
+	"""Best-effort temp-file removal - a missing file is fine (already gone)."""
+	with contextlib.suppress(FileNotFoundError):
+		os.remove(path)

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -59,7 +59,7 @@ import pdfkit
 
 from jarvis.exceptions import InvalidArgumentError
 
-from .sanitizer import sanitize_rich
+from .sanitizer import sanitize_letterhead, sanitize_rich
 
 _SANS = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
 
@@ -201,14 +201,16 @@ def render_pdf(
 			raise InvalidArgumentError("PDF render could not start — the renderer failed to execute") from exc
 
 		if result.returncode != 0:
+			# stderr can carry the /tmp/jv-pdf-<hash>.html temp path — log it for
+			# operators, but keep it OUT of the user-facing message.
 			tail = (result.stderr or b"").decode("utf-8", "replace").strip()[-500:]
 			_log_infra_failure(f"rich-pdf render exit {result.returncode}", tail)
-			raise InvalidArgumentError(f"PDF render failed (wkhtmltopdf exit {result.returncode}): {tail}")
+			raise InvalidArgumentError(f"PDF render failed (renderer exited {result.returncode})")
 		if not result.stdout:
 			# A zero-byte result is a failed render, never a valid empty PDF.
 			tail = (result.stderr or b"").decode("utf-8", "replace").strip()[-500:]
 			_log_infra_failure("rich-pdf render produced no output", tail)
-			raise InvalidArgumentError(f"PDF render produced no output{(': ' + tail) if tail else ''}")
+			raise InvalidArgumentError("PDF render produced no output")
 		if not result.stdout.startswith(b"%PDF-"):
 			# Non-empty but not a PDF: a corrupt/error render slipping past exit 0.
 			_log_infra_failure(
@@ -397,8 +399,11 @@ def resolve_letterhead(letterhead: str | None) -> tuple[str, str, str | None]:
 		lh = frappe.db.get_value("Letter Head", name, ["content", "footer"], as_dict=True)
 		if not lh:
 			return "", "", (f"letterhead {named!r} not found — rendered without it" if named else None)
-		header = _inline_letterhead_images(lh.get("content") or "")
-		footer = _inline_letterhead_images(lh.get("footer") or "")
+		# Inline same-site logos to permission-checked base64, THEN run the airtight
+		# letterhead gate (nh3, data-only images) so no remote/relative/protocol-
+		# relative src or other fetch-capable markup can reach the renderer.
+		header = sanitize_letterhead(_inline_letterhead_images(lh.get("content") or ""))
+		footer = sanitize_letterhead(_inline_letterhead_images(lh.get("footer") or ""))
 		return header, footer, None
 	except Exception:
 		# Letterhead is a nicety, never a hard failure of the export.
@@ -449,6 +454,14 @@ def _resolve_letterhead_img_src(url: str) -> str | None:
 			break
 	if not file_name or not frappe.has_permission("File", "read", doc=file_name):
 		return None
+	# Reject an oversized logo BEFORE reading it into memory (a user-readable
+	# multi-hundred-MB File referenced in a letterhead must not be slurped first).
+	size = frappe.db.get_value("File", file_name, "file_size")
+	if size and int(size) > _MAX_LOGO_BYTES:
+		return None
+	mime = mimetypes.guess_type(path)[0] or ""
+	if not mime.startswith("image/"):
+		return None
 	try:
 		content = frappe.get_doc("File", file_name).get_content()
 		if isinstance(content, str):
@@ -457,10 +470,27 @@ def _resolve_letterhead_img_src(url: str) -> str | None:
 		return None
 	if not content or len(content) > _MAX_LOGO_BYTES:
 		return None
-	mime = mimetypes.guess_type(path)[0] or ""
-	if not mime.startswith("image/"):
+	# Trust the bytes, not the filename extension: a non-image renamed *.png must
+	# not be inlined as data:image/*. (Harmless downstream anyway - the data-only
+	# letterhead gate never fetches - but this keeps the data: label honest.)
+	if not _looks_like_image(content):
 		return None
 	return f"data:{mime};base64,{base64.b64encode(content).decode('ascii')}"
+
+
+def _looks_like_image(content: bytes) -> bool:
+	"""Cheap magic-byte sniff for the common raster/vector logo formats."""
+	head = content[:16]
+	return (
+		head.startswith(b"\x89PNG\r\n\x1a\n")  # png
+		or head.startswith(b"\xff\xd8\xff")  # jpeg
+		or head.startswith(b"GIF87a")
+		or head.startswith(b"GIF89a")
+		or (head[:4] == b"RIFF" and content[8:12] == b"WEBP")  # webp
+		or head.lstrip()[:5].lower() == b"<?xml"  # svg (xml-declared)
+		or b"<svg" in head.lower()  # svg (bare)
+		or head.startswith(b"BM")  # bmp
+	)
 
 
 def _compose_document(inner: str, css: str) -> str:
@@ -489,8 +519,11 @@ def _write_temp(tmp_dir: str, content: str) -> str:
 
 
 def _remove_quietly(path: str) -> None:
-	"""Best-effort temp-file removal - a missing file is fine (already gone)."""
-	with contextlib.suppress(FileNotFoundError):
+	"""Best-effort temp-file removal. Suppress ANY OSError (a missing file, or an
+	unusual EPERM/read-only tmpdir) - cleanup must never abort the finally loop
+	(leaking the other temp) or replace the real in-flight error with a raw
+	OSError."""
+	with contextlib.suppress(OSError):
 		os.remove(path)
 
 

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -1,6 +1,6 @@
 """Page furniture + the rich-PDF render call (the 2nd, sanitized render path).
 
-``render_pdf`` turns a *already-sanitized* body-HTML fragment into PDF bytes on
+``render_pdf`` turns an *already-sanitized* body-HTML fragment into PDF bytes on
 wkhtmltopdf, wrapping it with header/footer/watermark/letterhead furniture and a
 real, hard render timeout.
 
@@ -18,10 +18,19 @@ strips ``<meta>`` regardless).
 WHY header/footer/watermark are sanitized here too: they are as agent-influenced
 as the body, and wkhtmltopdf will FETCH any ``<img src>``/``<link>`` it finds in a
 ``--header-html``/``--footer-html`` document (a *separate* render), so each runs
-through ``sanitize_rich`` before it is written to a temp file. The letterhead
-header/footer is operator-authored trusted config (a ``Letter Head`` doc) and is
-folded in WITHOUT sanitizing - sanitizing would strip its logo, which is the whole
-point of a letterhead.
+through ``sanitize_rich`` before it is written to a temp file.
+
+WHY the letterhead is resolved OUTSIDE this module (``resolve_letterhead``, called
+from ``export_document._render_rich`` where the ``notes`` channel lives): a
+letterhead is folded in as trusted operator config, but "trusted" must be
+ENFORCED, not assumed - so resolution (a) defaults to the site's default Letter
+Head when the caller named none, (b) checks the impersonated user's READ
+permission on the Letter Head, and (c) neutralises its images: an ``<img>`` with a
+remote ``src`` is DROPPED (wkhtmltopdf would fetch it server-side - the SSRF the
+whole rich path exists to prevent), and a same-site ``/files/`` logo is inlined as
+a permission-checked base64 ``data:`` URI (which also makes it actually render -
+the body is fed via stdin with no base URL, so a relative ``src`` would not
+resolve otherwise). ``render_pdf`` then receives the resolved, safe HTML.
 
 WHY the watermark lives in the HEADER template, not the body: wkhtmltopdf only
 paints a body ``position:fixed`` element on page 1, whereas the header document is
@@ -36,8 +45,11 @@ the temp-file lifecycle. See ``jarvis/tests/test_export_document_furniture.py``.
 
 from __future__ import annotations
 
+import base64
 import contextlib
+import mimetypes
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -50,6 +62,31 @@ from jarvis.exceptions import InvalidArgumentError
 from .sanitizer import sanitize_rich
 
 _SANS = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+
+# Header/footer/watermark are agent-influenced; cap them so a runaway model can't
+# hand the pre-render sanitize an unbounded fragment (the body itself is capped in
+# export_document; these are the other agent-controlled inputs).
+_MAX_FURNITURE_CHARS = 20_000
+
+# A letterhead logo is small operator config; refuse to inline anything larger so
+# a base64 blob can't bloat the header document.
+_MAX_LOGO_BYTES = 2_000_000
+
+# Page sizes we forward to wkhtmltopdf (canonical spelling). An unknown size would
+# otherwise reach the CLI and fail the whole render with an opaque exit code.
+_PAGE_SIZES = {
+	"a3": "A3",
+	"a4": "A4",
+	"a5": "A5",
+	"letter": "Letter",
+	"legal": "Legal",
+	"tabloid": "Tabloid",
+}
+
+_MAX_MARGIN_MM = 100
+
+_IMG_TAG_RE = re.compile(r"<img\b[^>]*?/?>", re.IGNORECASE)
+_SRC_RE = re.compile(r"""\bsrc\s*=\s*(?P<q>["'])(?P<url>.*?)(?P=q)""", re.IGNORECASE)
 
 # Self-contained CSS for the header/footer documents - they are SEPARATE
 # wkhtmltopdf renders, so they carry no body/theme styling and must style
@@ -96,34 +133,46 @@ def render_pdf(
 	header_html: str | None = None,
 	footer_html: str | None = None,
 	watermark: str | None = None,
-	letterhead: str | None = None,
+	letterhead_header: str = "",
+	letterhead_footer: str = "",
 	page_numbers: bool = True,
 	timeout: int = 25,
 ) -> bytes:
 	"""Render ``body_html`` (a fragment the caller already sanitized) to PDF bytes
 	via a direct, hard-timed wkhtmltopdf subprocess.
 
-	Header/footer/watermark are agent-influenced and re-sanitized here; letterhead
-	is trusted operator config, folded in as-is. Temp files for the header/footer
+	Header/footer/watermark are agent-influenced and re-sanitized here.
+	``letterhead_header``/``letterhead_footer`` are ALREADY resolved + safe (see
+	``resolve_letterhead``) and folded in as-is. Temp files for the header/footer
 	documents use content-independent ``frappe.generate_hash()`` names and are
 	removed in a ``finally`` that runs on success, error, AND timeout.
 
 	Raises ``InvalidArgumentError`` (clean, user-facing) when the binary is
-	missing, the render times out, wkhtmltopdf exits non-zero, or the output is
-	empty - never a raw ``TimeoutExpired`` and never a partial/zero-byte PDF.
+	missing, an argument is out of range, the render times out, wkhtmltopdf exits
+	non-zero, or the output is empty/not a PDF - never a raw ``TimeoutExpired`` /
+	``OSError`` and never a partial/zero-byte PDF. Every infra-caused failure (a
+	working binary misbehaving) is also written to the Error Log so a systemic
+	regression - e.g. an FC image bump changing wkhtmltopdf's behaviour - is
+	visible to operators rather than silently surfacing as a user-facing rejection
+	forever.
 	"""
 	binary = _resolve_binary()
 	orientation_flag = _normalize_orientation(orientation)
+	page_size = _normalize_page_size(page_size)
+	margins_mm = _normalize_margin(margins_mm)
+	_guard_furniture_len(header_html, footer_html, watermark)
 
-	lh_header, lh_footer = _letterhead_parts(letterhead) if letterhead else ("", "")
-	header_doc = _build_header(header_html, watermark, lh_header)
-	footer_doc = _build_footer(footer_html, page_numbers, lh_footer)
+	header_doc = _build_header(header_html, watermark, letterhead_header)
+	footer_doc = _build_footer(footer_html, page_numbers, letterhead_footer)
 
 	tmp_dir = tempfile.gettempdir()
-	header_file = _write_temp(tmp_dir, header_doc) if header_doc else None
-	footer_file = _write_temp(tmp_dir, footer_doc) if footer_doc else None
-
+	header_file = footer_file = None
 	try:
+		# Temp creation is INSIDE the try so a failure writing the second file
+		# (ENOSPC / fd exhaustion) still runs the finally that removes the first.
+		header_file = _write_temp(tmp_dir, header_doc) if header_doc else None
+		footer_file = _write_temp(tmp_dir, footer_doc) if footer_doc else None
+
 		args = _build_args(
 			binary,
 			page_size=page_size,
@@ -143,14 +192,29 @@ def render_pdf(
 		except subprocess.TimeoutExpired as exc:
 			# Hard bound hit: the child was killed, no usable output. Surface a
 			# clean, actionable error rather than the raw TimeoutExpired.
+			_log_infra_failure("rich-pdf render timed out", f"exceeded {timeout}s")
 			raise InvalidArgumentError(f"PDF render exceeded {timeout}s — reduce content/charts") from exc
+		except OSError as exc:
+			# The resolved binary failed to EXECUTE (not-executable, bad format,
+			# removed between resolve and run, fork failure under memory pressure).
+			_log_infra_failure("rich-pdf binary failed to execute", str(exc))
+			raise InvalidArgumentError("PDF render could not start — the renderer failed to execute") from exc
 
 		if result.returncode != 0:
 			tail = (result.stderr or b"").decode("utf-8", "replace").strip()[-500:]
+			_log_infra_failure(f"rich-pdf render exit {result.returncode}", tail)
 			raise InvalidArgumentError(f"PDF render failed (wkhtmltopdf exit {result.returncode}): {tail}")
 		if not result.stdout:
 			# A zero-byte result is a failed render, never a valid empty PDF.
-			raise InvalidArgumentError("PDF render produced no output")
+			tail = (result.stderr or b"").decode("utf-8", "replace").strip()[-500:]
+			_log_infra_failure("rich-pdf render produced no output", tail)
+			raise InvalidArgumentError(f"PDF render produced no output{(': ' + tail) if tail else ''}")
+		if not result.stdout.startswith(b"%PDF-"):
+			# Non-empty but not a PDF: a corrupt/error render slipping past exit 0.
+			_log_infra_failure(
+				"rich-pdf render output is not a PDF", result.stdout[:80].decode("latin-1", "replace")
+			)
+			raise InvalidArgumentError("PDF render produced invalid output (not a PDF)")
 		return result.stdout
 	finally:
 		for path in (header_file, footer_file):
@@ -164,7 +228,9 @@ def _resolve_binary() -> str:
 	Tries pdfkit's own resolver first (it decodes ``$PDFKIT_...``/PATH lookups and
 	raises ``OSError`` when nothing is found), then ``shutil.which``. A missing
 	binary is EXPECTED in local dev (the real render runs on the FC bench), so the
-	failure is an ``InvalidArgumentError``, not a crash.
+	failure is an ``InvalidArgumentError``, not a crash - but it is also logged, so
+	a binary that goes missing on the FC bench (where it should be present) is
+	visible to operators rather than silently rejecting every render.
 	"""
 	with contextlib.suppress(OSError):
 		raw = pdfkit.configuration().wkhtmltopdf
@@ -174,6 +240,7 @@ def _resolve_binary() -> str:
 	path = shutil.which("wkhtmltopdf")
 	if path:
 		return path
+	_log_infra_failure("rich-pdf binary not found", "wkhtmltopdf missing from PATH and pdfkit config")
 	raise InvalidArgumentError(
 		"wkhtmltopdf binary not found — rich PDF rendering needs wkhtmltopdf "
 		"(present on the Frappe Cloud bench; absent in local dev)"
@@ -187,6 +254,38 @@ def _normalize_orientation(orientation: str) -> str:
 	if value not in ("portrait", "landscape"):
 		raise InvalidArgumentError(f"orientation must be 'portrait' or 'landscape', got {orientation!r}")
 	return value.capitalize()
+
+
+def _normalize_page_size(page_size: str) -> str:
+	"""Validate ``page_size`` against the allowlist and return the canonical
+	spelling wkhtmltopdf expects. Rejects an unknown value with a clean error
+	(consistent with ``orientation``) instead of letting the CLI fail opaquely."""
+	value = str(page_size).strip().lower()
+	if value not in _PAGE_SIZES:
+		raise InvalidArgumentError(
+			f"page_size must be one of {sorted(v for v in _PAGE_SIZES.values())}, got {page_size!r}"
+		)
+	return _PAGE_SIZES[value]
+
+
+def _normalize_margin(margins_mm: int) -> int:
+	"""Validate the margin is a non-negative int within a sane bound. A negative
+	value would produce a ``-50mm`` token wkhtmltopdf's arg parser can mis-read as
+	a flag; an absurd value would leave no printable area."""
+	try:
+		value = int(margins_mm)
+	except (TypeError, ValueError):
+		raise InvalidArgumentError(f"margins_mm must be an integer, got {margins_mm!r}") from None
+	if value < 0 or value > _MAX_MARGIN_MM:
+		raise InvalidArgumentError(f"margins_mm must be between 0 and {_MAX_MARGIN_MM}, got {value}")
+	return value
+
+
+def _guard_furniture_len(header_html, footer_html, watermark) -> None:
+	"""Bound the agent-influenced furniture inputs (the body is capped upstream)."""
+	for label, value in (("header", header_html), ("footer", footer_html), ("watermark", watermark)):
+		if value and len(value) > _MAX_FURNITURE_CHARS:
+			raise InvalidArgumentError(f"{label} exceeds {_MAX_FURNITURE_CHARS} characters")
 
 
 def _build_args(
@@ -239,8 +338,8 @@ def _build_args(
 def _build_header(header_html: str | None, watermark: str | None, letterhead_header: str) -> str:
 	"""Compose the header document, or ``""`` when there is nothing to render.
 
-	Order: trusted letterhead header (as-is) → sanitized agent header → sanitized
-	watermark wrapped in the tool-controlled ``.jv-watermark`` rotate block.
+	Order: resolved-and-safe letterhead header (as-is) → sanitized agent header →
+	sanitized watermark wrapped in the tool-controlled ``.jv-watermark`` block.
 	"""
 	parts = []
 	if letterhead_header:
@@ -256,7 +355,8 @@ def _build_footer(footer_html: str | None, page_numbers: bool, letterhead_footer
 	"""Compose the footer document, or ``""`` when there is nothing to render.
 
 	An explicit ``footer_html`` wins over auto page numbers (they are mutually
-	exclusive); the trusted letterhead footer is always folded in when present.
+	exclusive); the resolved-and-safe letterhead footer is always folded in when
+	present.
 	"""
 	parts = []
 	if letterhead_footer:
@@ -268,17 +368,99 @@ def _build_footer(footer_html: str | None, page_numbers: bool, letterhead_footer
 	return _compose_document("".join(parts), _FURNITURE_CSS) if parts else ""
 
 
-def _letterhead_parts(letterhead: str) -> tuple[str, str]:
-	"""Return ``(header_html, footer_html)`` for a named ``Letter Head``.
+def resolve_letterhead(letterhead: str | None) -> tuple[str, str, str | None]:
+	"""Resolve a letterhead to safe ``(header_html, footer_html, note)``.
 
-	Lazy-imports ``printview`` so this module stays importable without a bench;
-	needs a site, so its direct test is gated. Unit tests stub THIS function to
-	exercise the fold logic site-free.
+	``letterhead`` is a ``Letter Head`` name, or ``None`` to use the site's default
+	Letter Head (``is_default=1``). Enforces the "trusted config" assumption the
+	rich path rests on:
+
+	  * READ-permission checked as the impersonated user (an agent may only use a
+	    Letter Head that user can read).
+	  * Images neutralised via ``_inline_letterhead_images`` - remote ``<img>`` is
+	    DROPPED (no server-side fetch / SSRF), same-site ``/files/`` logos are
+	    inlined as permission-checked base64 ``data:`` URIs.
+
+	``note`` is ``None`` on success (including "no default configured", which is a
+	normal unbranded render), or a degrade message when a NAMED letterhead can't be
+	found / read - so the caller can surface it rather than silently dropping the
+	branding the user asked for. Never raises: any failure yields ``("", "", note)``.
 	"""
-	from frappe.www.printview import get_letter_head
+	named = letterhead if isinstance(letterhead, str) and letterhead.strip() else None
+	try:
+		name = named or frappe.db.get_value("Letter Head", {"is_default": 1}, "name")
+		if not name:
+			# No name given and no default configured → plain, unbranded render.
+			return "", "", None
+		if not frappe.has_permission("Letter Head", "read", doc=name):
+			return "", "", (f"letterhead {named!r} not found — rendered without it" if named else None)
+		lh = frappe.db.get_value("Letter Head", name, ["content", "footer"], as_dict=True)
+		if not lh:
+			return "", "", (f"letterhead {named!r} not found — rendered without it" if named else None)
+		header = _inline_letterhead_images(lh.get("content") or "")
+		footer = _inline_letterhead_images(lh.get("footer") or "")
+		return header, footer, None
+	except Exception:
+		# Letterhead is a nicety, never a hard failure of the export.
+		_log_infra_failure("rich-pdf letterhead resolution failed", f"letterhead={named!r}")
+		return "", "", (f"letterhead {named!r} could not be applied" if named else None)
 
-	parts = get_letter_head(None, no_letterhead=False, letterhead=letterhead) or {}
-	return parts.get("content") or "", parts.get("footer") or ""
+
+def _inline_letterhead_images(html: str) -> str:
+	"""Rewrite each ``<img src>`` in trusted letterhead HTML: keep ``data:`` URIs,
+	inline a same-site ``/files/`` logo as a permission-checked base64 ``data:``
+	URI, and DROP a remote ``<img>`` outright (wkhtmltopdf would fetch it)."""
+	if not html or "<img" not in html.lower():
+		return html
+
+	def _repl(match: re.Match) -> str:
+		tag = match.group(0)
+		src = _SRC_RE.search(tag)
+		if not src:
+			return tag
+		new_src = _resolve_letterhead_img_src(src.group("url"))
+		if new_src is None:
+			return ""  # remote / unresolvable → drop the whole <img>, no fetch
+		return tag[: src.start("url")] + new_src + tag[src.end("url") :]
+
+	return _IMG_TAG_RE.sub(_repl, html)
+
+
+def _resolve_letterhead_img_src(url: str) -> str | None:
+	"""Return a safe ``src`` for a letterhead image, or ``None`` to drop it.
+
+	``data:`` URIs pass through (already inline, no fetch). Remote URLs
+	(``http(s)://`` / protocol-relative) are dropped. A same-site path is resolved
+	to its ``File``, read-permission checked, and returned as a base64 ``data:``
+	URI so wkhtmltopdf never issues a request."""
+	value = (url or "").strip()
+	if not value:
+		return None
+	if value.startswith("data:"):
+		return value
+	if value.lower().startswith(("http://", "https://", "//")):
+		return None
+	path = value.split("?", 1)[0].split("#", 1)[0]
+	candidates = [path] if path.startswith("/") else ["/" + path, path]
+	file_name = None
+	for candidate in candidates:
+		file_name = frappe.db.get_value("File", {"file_url": candidate}, "name")
+		if file_name:
+			break
+	if not file_name or not frappe.has_permission("File", "read", doc=file_name):
+		return None
+	try:
+		content = frappe.get_doc("File", file_name).get_content()
+		if isinstance(content, str):
+			content = content.encode("utf-8")
+	except Exception:
+		return None
+	if not content or len(content) > _MAX_LOGO_BYTES:
+		return None
+	mime = mimetypes.guess_type(path)[0] or ""
+	if not mime.startswith("image/"):
+		return None
+	return f"data:{mime};base64,{base64.b64encode(content).decode('ascii')}"
 
 
 def _compose_document(inner: str, css: str) -> str:
@@ -293,10 +475,16 @@ def _compose_document(inner: str, css: str) -> str:
 
 def _write_temp(tmp_dir: str, content: str) -> str:
 	"""Write ``content`` to a uniquely named temp file (name from
-	``frappe.generate_hash()``, never derived from content) and return its path."""
+	``frappe.generate_hash()``, never derived from content) and return its path. If
+	the write fails mid-stream (ENOSPC), remove the partial file before re-raising -
+	its random name was never returned, so nothing else could ever clean it up."""
 	path = os.path.join(tmp_dir, f"jv-pdf-{frappe.generate_hash()}.html")
-	with open(path, "wb") as fh:
-		fh.write(content.encode("utf-8"))
+	try:
+		with open(path, "wb") as fh:
+			fh.write(content.encode("utf-8"))
+	except Exception:
+		_remove_quietly(path)
+		raise
 	return path
 
 
@@ -304,3 +492,11 @@ def _remove_quietly(path: str) -> None:
 	"""Best-effort temp-file removal - a missing file is fine (already gone)."""
 	with contextlib.suppress(FileNotFoundError):
 		os.remove(path)
+
+
+def _log_infra_failure(title: str, message: str) -> None:
+	"""Write an infra-caused render failure to the Error Log, best-effort. Logging
+	must NEVER replace the real error the caller is about to raise, so every failure
+	here (including a missing site in a unit test) is swallowed."""
+	with contextlib.suppress(Exception):
+		frappe.log_error(title=f"jarvis.rich_pdf: {title}"[:140], message=message or title)

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -460,7 +460,12 @@ def _resolve_letterhead_img_src(url: str) -> str | None:
 	if size and int(size) > _MAX_LOGO_BYTES:
 		return None
 	mime = mimetypes.guess_type(path)[0] or ""
-	if not mime.startswith("image/"):
+	# RASTER images only. SVG is deliberately refused: an inlined data:image/svg+xml
+	# is an OPAQUE blob nh3 does not look inside, so an SVG carrying <image href>/
+	# <script> would ride into the render and rely on QtWebKit's (untested-here)
+	# SVG-static mode for containment. A raster logo has no such surface. Company
+	# logos are almost always PNG/JPG; an SVG degrades to no logo, not a risk.
+	if not mime.startswith("image/") or mime == "image/svg+xml":
 		return None
 	try:
 		content = frappe.get_doc("File", file_name).get_content()
@@ -470,16 +475,18 @@ def _resolve_letterhead_img_src(url: str) -> str | None:
 		return None
 	if not content or len(content) > _MAX_LOGO_BYTES:
 		return None
-	# Trust the bytes, not the filename extension: a non-image renamed *.png must
-	# not be inlined as data:image/*. (Harmless downstream anyway - the data-only
-	# letterhead gate never fetches - but this keeps the data: label honest.)
+	# Trust the bytes, not the filename extension: a non-image (or an SVG) renamed
+	# *.png must not be inlined as data:image/*. (Harmless downstream anyway - the
+	# data-only letterhead gate never fetches - but this keeps the data: label
+	# honest and keeps active SVG markup out of the render entirely.)
 	if not _looks_like_image(content):
 		return None
 	return f"data:{mime};base64,{base64.b64encode(content).decode('ascii')}"
 
 
 def _looks_like_image(content: bytes) -> bool:
-	"""Cheap magic-byte sniff for the common raster/vector logo formats."""
+	"""Cheap magic-byte sniff for the common RASTER logo formats (SVG is refused -
+	see _resolve_letterhead_img_src)."""
 	head = content[:16]
 	return (
 		head.startswith(b"\x89PNG\r\n\x1a\n")  # png
@@ -487,8 +494,6 @@ def _looks_like_image(content: bytes) -> bool:
 		or head.startswith(b"GIF87a")
 		or head.startswith(b"GIF89a")
 		or (head[:4] == b"RIFF" and content[8:12] == b"WEBP")  # webp
-		or head.lstrip()[:5].lower() == b"<?xml"  # svg (xml-declared)
-		or b"<svg" in head.lower()  # svg (bare)
 		or head.startswith(b"BM")  # bmp
 	)
 

--- a/jarvis/tools/_export/document/graphics.py
+++ b/jarvis/tools/_export/document/graphics.py
@@ -1,0 +1,178 @@
+"""CSS charts, KPI/RAG components, and locale-correct number formatting for the
+rich-PDF document engine.
+
+This is the CSS/number half of the module (Slice 1 - zero new dependencies). A
+later task adds the image half (matplotlib charts, QR, logo inlining) alongside
+these functions; nothing here should assume or import an imaging library.
+
+``css_bar``/``kpi_tile``/``rag_chip`` are pure builders: no inline ``style``
+beyond a single numeric ``width:N%`` on a chart bar (a clamped float can never
+carry markup), and every text field is escaped with the stdlib ``html.escape``.
+They import nothing from ``frappe`` and are testable without a Frappe site.
+Class names (``bar-chart``/``bar``/``kpi-tile``/``rag-red|amber|green``/``neg``)
+match Task 2's ``THEME_CSS`` contract - keep them in lockstep if either side
+changes.
+
+``fmt_amount``/``fmt_pct`` DO need a Frappe site: they reuse
+``frappe.utils.fmt_money``/``frappe.utils.data.get_number_format`` for
+locale-correct digit grouping (Indian lakh/crore included) rather than
+hand-rolling grouping logic. Both guard ``None``/``NaN``/``Inf`` explicitly
+ahead of ``fmt_money`` - a naive ``"%.2f" % float("nan")`` renders the literal
+string ``"nan"``, which must never reach a document - and treat ``-0.0`` as a
+non-negative zero. Negative amounts render in parentheses wrapped in the
+``.neg`` class hook from Task 2's conditional-table contract. NOTE for callers:
+the returned string for a negative value is itself a small HTML fragment (a
+``<span class="neg">...</span>``), meant for direct embedding (e.g. into a
+table cell) - do NOT route it back through ``css_bar``/``kpi_tile``'s ``value``
+escaping, which would double-escape the span tag.
+"""
+
+import html
+import math
+from collections.abc import Mapping, Sequence
+
+from frappe.utils import fmt_money
+from frappe.utils.data import get_number_format
+
+_RAG_STATUSES = ("red", "amber", "green")
+
+
+def css_bar(rows: Sequence[Mapping[str, object] | Sequence[object]]) -> str:
+	"""Render an inert CSS bar chart: a ``.bar-chart`` wrapper holding one ``.bar``
+	per row, per Task 2's contract classes.
+
+	Each row supplies ``label``, ``value`` (rendered as escaped text, joined as
+	``"{label} {value}"``) and ``pct`` (the bar's width, clamped to 0-100 - the
+	only number that reaches the inline ``style`` attribute). A row may be a
+	mapping with those three keys, or a positional ``(label, value, pct)``
+	sequence.
+	"""
+	bars = []
+	for row in rows:
+		label, value, pct = _row_parts(row)
+		width = _clamp_pct(pct)
+		text = f"{html.escape(str(label))} {html.escape(str(value))}"
+		bars.append(f'<div class="bar" style="width:{width}%">{text}</div>')
+	return '<div class="bar-chart">' + "".join(bars) + "</div>"
+
+
+def kpi_tile(label: str, value: str, delta: str | None = None) -> str:
+	"""Render a ``.kpi-tile``: a labeled headline number with an optional delta
+	line. All fields are escaped text content. Callers wanting delta styling
+	(e.g. red for a negative change) format the delta string themselves before
+	calling this - ``fmt_amount``/``fmt_pct`` already emit the ``.neg`` hook for
+	negatives, but that hook is HTML and must be embedded directly, not passed
+	through this function's escaping (see module docstring).
+	"""
+	parts = [
+		'<div class="kpi-tile">',
+		f'<div class="kpi-label">{html.escape(str(label))}</div>',
+		f'<div class="kpi-value">{html.escape(str(value))}</div>',
+	]
+	if delta is not None:
+		parts.append(f'<div class="kpi-delta">{html.escape(str(delta))}</div>')
+	parts.append("</div>")
+	return "".join(parts)
+
+
+def rag_chip(status: str) -> str:
+	"""Render a ``.rag-{red,amber,green}`` status chip.
+
+	``status`` must be exactly one of red/amber/green (case-insensitive). This is
+	a tool-side builder fed by code that already computed the RAG bucket from
+	real thresholds, not agent free text, so an unrecognized value fails loud
+	rather than silently defaulting to some color (Task 2's caveat: a fabricated
+	RAG status is a trust-signaling risk, so the builder should never invent one
+	on bad input).
+	"""
+	normalized = str(status).strip().lower()
+	if normalized not in _RAG_STATUSES:
+		raise ValueError(f"rag_chip: status must be one of {_RAG_STATUSES}, got {status!r}")
+	return f'<span class="rag-{normalized}">{html.escape(str(status))}</span>'
+
+
+def fmt_amount(value: float | int | str | None, currency: str | None = None) -> str:
+	"""Format ``value`` as a locale-correct money amount via ``fmt_money``
+	(Indian lakh/crore grouping when the site's number format calls for it - do
+	NOT hand-roll digit grouping).
+
+	``None``, ``NaN``, and ``Inf``/``-Inf`` all render as ``"—"`` rather than
+	being handed to ``fmt_money`` (which would render the literal "nan"/"inf").
+	``-0.0`` is a non-negative zero. Negative amounts render in parentheses
+	wrapped in a ``.neg`` class hook, so a caller dropping the string straight
+	into a ``<td>`` gets negative styling for free.
+	"""
+	num = _to_float_or_none(value)
+	if num is None:
+		return "—"
+	formatted = html.escape(fmt_money(abs(num), currency=currency))
+	return f'<span class="neg">({formatted})</span>' if num < 0 else formatted
+
+
+def fmt_pct(value: float | int | str | None) -> str:
+	"""Format ``value`` - already a percent number, e.g. ``42.5`` -> ``"42.5%"``
+	- via ``fmt_money`` at the site's own number-format precision.
+
+	Explicitly passes ``get_number_format().precision`` rather than letting
+	``fmt_money`` fall back to the system currency-precision default: a percent
+	has nothing to do with currency precision, so decoupling keeps the decimal
+	count locale-correct without accidentally inheriting a currency setting.
+
+	Same edge-case handling as ``fmt_amount``: ``None``/``NaN``/``Inf`` -> "—",
+	``-0.0`` is non-negative, negatives get parentheses + the ``.neg`` hook.
+	"""
+	num = _to_float_or_none(value)
+	if num is None:
+		return "—"
+	precision = get_number_format().precision
+	formatted = html.escape(fmt_money(abs(num), precision=precision))
+	return f'<span class="neg">({formatted}%)</span>' if num < 0 else f"{formatted}%"
+
+
+def _row_parts(row: Mapping[str, object] | Sequence[object]) -> tuple[object, object, object]:
+	"""Pull ``(label, value, pct)`` out of a ``css_bar`` row - a mapping with
+	those keys, or a positional 3-item sequence."""
+	if isinstance(row, Mapping):
+		return row.get("label", ""), row.get("value", ""), row.get("pct", 0)
+	label, value, pct = row
+	return label, value, pct
+
+
+def _clamp_pct(pct: object) -> str:
+	"""Clamp a bar width to 0-100 and render it as a bare number for
+	``width:N%``.
+
+	Non-numeric or NaN input clamps to 0 (an empty bar, never a broken ``style``
+	attribute); ``+Inf`` clamps to 100. The clamped range never needs scientific
+	notation, so plain ``:g`` formatting is safe.
+	"""
+	try:
+		num = float(pct)
+	except (TypeError, ValueError):
+		return "0"
+	if math.isnan(num):
+		return "0"
+	num = max(0.0, min(100.0, num))
+	return f"{num:g}"
+
+
+def _to_float_or_none(value: object) -> float | None:
+	"""Normalize a raw numeric-ish value ahead of Frappe's formatters.
+
+	``None`` and any unparseable value collapse to ``None`` (rendered "—").
+	``NaN``/``Inf``/``-Inf`` also collapse to ``None`` rather than being handed to
+	``fmt_money``, which would render the literal string "nan"/"inf". ``-0.0``
+	survives as a float whose sign Python's own ``< 0`` already reports False
+	for, so it is never treated as negative.
+	"""
+	if value is None:
+		return None
+	if isinstance(value, str):
+		value = value.replace(",", "").strip()
+	try:
+		num = float(value)
+	except (TypeError, ValueError):
+		return None
+	if math.isnan(num) or math.isinf(num):
+		return None
+	return num

--- a/jarvis/tools/_export/document/graphics.py
+++ b/jarvis/tools/_export/document/graphics.py
@@ -51,7 +51,7 @@ def css_bar(rows: Sequence[Mapping[str, object] | Sequence[object]]) -> str:
 	for row in rows:
 		label, value, pct = _row_parts(row)
 		width = _clamp_pct(pct)
-		text = f"{html.escape(str(label))} {html.escape(str(value))}"
+		text = f"{_esc(label)} {_esc(value)}"
 		bars.append(f'<div class="bar" style="width:{width}%">{text}</div>')
 	return '<div class="bar-chart">' + "".join(bars) + "</div>"
 
@@ -66,11 +66,11 @@ def kpi_tile(label: str, value: str, delta: str | None = None) -> str:
 	"""
 	parts = [
 		'<div class="kpi-tile">',
-		f'<div class="kpi-label">{html.escape(str(label))}</div>',
-		f'<div class="kpi-value">{html.escape(str(value))}</div>',
+		f'<div class="kpi-label">{_esc(label)}</div>',
+		f'<div class="kpi-value">{_esc(value)}</div>',
 	]
 	if delta is not None:
-		parts.append(f'<div class="kpi-delta">{html.escape(str(delta))}</div>')
+		parts.append(f'<div class="kpi-delta">{_esc(delta)}</div>')
 	parts.append("</div>")
 	return "".join(parts)
 
@@ -129,13 +129,28 @@ def fmt_pct(value: float | int | str | None) -> str:
 	return f'<span class="neg">({formatted}%)</span>' if num < 0 else f"{formatted}%"
 
 
+def _esc(value: object) -> str:
+	"""Escape a text field for embedding, rendering ``None`` as empty rather than
+	the literal string ``"None"`` (parity with ``fmt_amount``'s None handling)."""
+	return "" if value is None else html.escape(str(value))
+
+
 def _row_parts(row: Mapping[str, object] | Sequence[object]) -> tuple[object, object, object]:
 	"""Pull ``(label, value, pct)`` out of a ``css_bar`` row - a mapping with
-	those keys, or a positional 3-item sequence."""
+	those keys, or a positional 3-item sequence.
+
+	The plugin schema types each row as ``Any``, so a runaway/confused model can
+	send an int, ``None``, a string, or a wrong-length sequence. Rather than let a
+	blind unpack raise ``TypeError``/``ValueError`` that escapes the tool as a raw
+	500 (``_splice_charts`` catches this and degrades the chart to a note), reject
+	a malformed row shape with a clear ``ValueError``."""
 	if isinstance(row, Mapping):
 		return row.get("label", ""), row.get("value", ""), row.get("pct", 0)
-	label, value, pct = row
-	return label, value, pct
+	if isinstance(row, Sequence) and not isinstance(row, (str, bytes)) and len(row) == 3:
+		return row[0], row[1], row[2]
+	raise ValueError(
+		f"css_bar row must be a mapping or a 3-item (label, value, pct) sequence, got {type(row).__name__}"
+	)
 
 
 def _clamp_pct(pct: object) -> str:
@@ -143,8 +158,10 @@ def _clamp_pct(pct: object) -> str:
 	``width:N%``.
 
 	Non-numeric or NaN input clamps to 0 (an empty bar, never a broken ``style``
-	attribute); ``+Inf`` clamps to 100. The clamped range never needs scientific
-	notation, so plain ``:g`` formatting is safe.
+	attribute); ``+Inf`` clamps to 100. Uses FIXED (never scientific) notation:
+	``:g`` renders a tiny positive width like ``0.00001`` as ``1e-05``, which old
+	WebKit rejects as an invalid ``width`` and drops - fixed formatting with the
+	trailing zeros trimmed keeps it a plain number.
 	"""
 	try:
 		num = float(pct)
@@ -153,7 +170,7 @@ def _clamp_pct(pct: object) -> str:
 	if math.isnan(num):
 		return "0"
 	num = max(0.0, min(100.0, num))
-	return f"{num:g}"
+	return f"{num:.4f}".rstrip("0").rstrip(".") or "0"
 
 
 def _to_float_or_none(value: object) -> float | None:

--- a/jarvis/tools/_export/document/sanitizer.py
+++ b/jarvis/tools/_export/document/sanitizer.py
@@ -1,0 +1,173 @@
+"""Sanitize agent-composed rich HTML before it reaches the rich-PDF renderer.
+
+This is the security core of the rich-PDF document engine. ``content`` (plus
+header/footer/watermark) on the rich path is effectively LLM-controlled, and the
+renderer that consumes it (wkhtmltopdf) will FETCH any ``<img src>`` /
+``<link href>`` / SVG ``<image href>`` it finds at render time, server-side. So
+the output of this module must contain no fetch-capable tag and no active markup
+at all - only inert, class-styled structural HTML.
+
+WHY a pure module (imports ONLY ``nh3`` + ``bs4``, never ``frappe``): the
+sanitizer is the one place a mistake becomes an SSRF/XSS hole, so it is kept
+importable and unit-testable without a running bench - the attack corpus runs in
+plain CI, not only inside a site.
+
+WHY ``nh3.clean`` directly, NOT ``frappe.utils.sanitize_html``: that helper only
+exposes ``disallowed_tags``; its defaults *allow* ``id``/``name``/``background``/
+``data``/``poster``/``src``/``href`` + all ~726 style properties + broad url
+schemes, and it early-returns the input UNSANITIZED when the payload looks like
+JSON or contains no tags. None of that is acceptable here, and none of it is
+configurable through that signature. We call ``nh3.clean`` with an explicit,
+tight allowlist instead.
+
+The pipeline is two layers, mirroring the decompose-then-clean shape Frappe's own
+``clean_email_html`` uses:
+
+  1. ``_strip_unsafe_tags`` - a BeautifulSoup ``decompose`` pre-pass that REMOVES
+     each fetch-capable / active tag together with its subtree. nh3 alone would
+     strip a disallowed tag but KEEP its text, so ``<script>alert(1)</script>``
+     would survive as the visible text ``alert(1)``. Decomposing first deletes
+     the payload cleanly.
+  2. ``nh3.clean`` with a tight tag/attribute/url-scheme allowlist on what
+     remains - the airtight allowlist pass (belt-and-suspenders once the unsafe
+     tags are already gone).
+
+WHY inline ``style`` is DISALLOWED entirely (classes-only): nh3's
+``filter_style_properties`` is a property-NAME allowlist ONLY. It does not reject
+``url(...)`` values and it re-forms CSS escapes, so a permitted property is not a
+safe property. The only airtight option is to forbid the ``style`` attribute on
+agent content and drive every visual through THEME_CSS classes. Tool-generated
+components (CSS bar charts, etc.) are spliced in AFTER sanitize, so they never
+need agent-supplied inline style.
+"""
+
+import nh3
+from bs4 import BeautifulSoup
+
+# Removed OUTRIGHT (tag + subtree) by the decompose pre-pass rather than left to
+# nh3's allowlist. Every one of these can trigger an out-of-band fetch when
+# wkhtmltopdf renders (img/svg/iframe/object/embed/audio/video/source/link/
+# base), execute (script), inject styling/url() (style), carry metadata refresh
+# (meta), or submit/collect (form/input/button). Removing the whole subtree also
+# deletes the inert-but-visible text nh3 would otherwise keep.
+_DECOMPOSE_TAGS = (
+	"script",
+	"style",
+	"link",
+	"meta",
+	"svg",
+	"img",
+	"iframe",
+	"object",
+	"embed",
+	"base",
+	"form",
+	"input",
+	"button",
+	"audio",
+	"video",
+	"source",
+)
+
+# The rich structural set an org document needs. Deliberately NO ``img`` - agent
+# content never supplies its own images; the tool splices its own permission-
+# checked base64 images in AFTER sanitize.
+_ALLOWED_TAGS = {
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+	"p",
+	"br",
+	"hr",
+	"ul",
+	"ol",
+	"li",
+	"blockquote",
+	"pre",
+	"code",
+	"strong",
+	"em",
+	"b",
+	"i",
+	"u",
+	"s",
+	"sup",
+	"sub",
+	"span",
+	"div",
+	"section",
+	"header",
+	"footer",
+	"table",
+	"thead",
+	"tbody",
+	"tfoot",
+	"tr",
+	"th",
+	"td",
+	"caption",
+	"colgroup",
+	"col",
+	"a",
+}
+
+# ``"*"`` allows ``class`` on every permitted tag (styling is classes-only);
+# ``href`` only on ``a``; table-layout attrs only on cells. Everything else
+# (``id``/``name``/``style``/``background``/``data-*``/``on*``/``src``/``srcset``/
+# ``poster``/``formaction`` ...) is dropped by omission - nh3 keeps ONLY what is
+# listed here.
+_ALLOWED_ATTRIBUTES = {
+	"*": {"class"},
+	"a": {"href"},
+	"th": {"colspan", "rowspan", "scope"},
+	"td": {"colspan", "rowspan", "scope"},
+}
+
+# Only these href schemes survive on ``<a>``. ``javascript:``/``data:``/``file:``
+# are rejected by omission. nh3 also permits bare ``#`` fragment and
+# scheme-relative/relative paths (harmless as links - they are not fetched by the
+# renderer the way an ``<img src>`` would be).
+_URL_SCHEMES = {"http", "https", "mailto"}
+
+
+def _strip_unsafe_tags(html: str) -> str:
+	"""Remove (not escape) every tag in ``_DECOMPOSE_TAGS`` together with its
+	subtree, ahead of ``nh3.clean``.
+
+	nh3's own default for a disallowed tag is to strip the tag but keep its inner
+	text, which would leave a ``<script>``'s payload sitting as visible text.
+	Decomposing first deletes the payload. ``BeautifulSoup(html, "html5lib")``
+	parses with the same HTML5 tree-construction algorithm a browser/renderer
+	uses (the safest reading of adversarial input) and always wraps a fragment in
+	its own ``<html><head></head><body>...</body></html>``, so we return the body's
+	inner HTML - ``html`` here is a fragment about to be spliced into the engine's
+	own page shell, not a standalone page.
+	"""
+	soup = BeautifulSoup(html, "html5lib")
+	for tag in soup(list(_DECOMPOSE_TAGS)):
+		tag.decompose()
+	return soup.body.decode_contents() if soup.body else soup.decode_contents()
+
+
+def sanitize_rich(html: str) -> str:
+	"""Return ``html`` reduced to inert, class-styled structural markup safe to
+	hand an unauthenticated wkhtmltopdf render.
+
+	Two layers: a BeautifulSoup ``decompose`` pre-pass that deletes every
+	fetch-capable / active tag and its subtree, then ``nh3.clean`` with a tight
+	tag/attribute/url-scheme allowlist. Inline ``style`` is disallowed outright
+	(classes-only) - see the module docstring for why the ``style`` attribute
+	cannot be made airtight via ``filter_style_properties``. No ``<img>``,
+	``on*`` handler, ``id``, ``javascript:``/``data:``/``file:`` url, or event
+	attribute can survive this.
+	"""
+	stripped = _strip_unsafe_tags(html)
+	return nh3.clean(
+		stripped,
+		tags=_ALLOWED_TAGS,
+		attributes=_ALLOWED_ATTRIBUTES,
+		url_schemes=_URL_SCHEMES,
+	)

--- a/jarvis/tools/_export/document/sanitizer.py
+++ b/jarvis/tools/_export/document/sanitizer.py
@@ -145,6 +145,32 @@ _URL_SCHEMES = {"http", "https", "mailto"}
 
 _DECOMPOSE_SET = set(_DECOMPOSE_TAGS)
 
+# --- Letterhead gate ---------------------------------------------------------
+# A Letter Head is operator config, but "trusted" must be ENFORCED, not assumed:
+# the render is unauthenticated and wkhtmltopdf fetches any remote resource it
+# finds. So a resolved letterhead (after its same-site logos are already inlined
+# to permission-checked base64 data: URIs by furniture._inline_letterhead_images)
+# passes through this gate, which is sanitize_rich PLUS a single concession: an
+# <img> is allowed, but ONLY with a ``data:`` src.
+#   * ``url_schemes={"data"}`` strips every http/https/file/etc. image src, no
+#     matter how it is written (no-quote, alt-truncation, <image> alias, srcset).
+#   * ``url_relative="deny"`` strips protocol-relative (``//host``) and relative
+#     (``/files/x``) srcs too, which url_schemes alone does NOT catch.
+#   * ``<a>`` is dropped (a letterhead needs no live links, and keeping it would
+#     force http(s) back into url_schemes, re-opening the image hole).
+# Result: the only image that can survive is the inlined data: logo; <link>,
+# <style>, <image>/<svg>, <iframe>, <input type=image>, style="url(...)", etc.
+# are all removed. Verified against a bypass corpus.
+_LETTERHEAD_TAGS = (_ALLOWED_TAGS - {"a"}) | {"img"}
+_LETTERHEAD_ATTRIBUTES = {
+	"*": {"class"},
+	"img": {"src", "alt", "class", "width", "height"},
+	"th": {"colspan", "rowspan", "scope"},
+	"td": {"colspan", "rowspan", "scope"},
+}
+_LETTERHEAD_URL_SCHEMES = {"data"}
+_LETTERHEAD_DECOMPOSE = _DECOMPOSE_SET - {"img"}
+
 
 def sanitize_rich(html: str) -> str:
 	"""Return ``html`` reduced to inert, class-styled structural markup safe to
@@ -164,4 +190,27 @@ def sanitize_rich(html: str) -> str:
 		attributes=_ALLOWED_ATTRIBUTES,
 		url_schemes=_URL_SCHEMES,
 		clean_content_tags=_DECOMPOSE_SET,
+	)
+
+
+def sanitize_letterhead(html: str) -> str:
+	"""Return trusted-but-enforced letterhead HTML safe for the render.
+
+	Same airtight base as ``sanitize_rich`` with ONE concession: an ``<img>`` is
+	allowed, but only with a ``data:`` src (a permission-checked base64 logo that
+	``furniture._inline_letterhead_images`` has already inlined). ``url_schemes``
+	restricted to ``data`` strips every remote/file image src regardless of syntax;
+	``url_relative="deny"`` additionally strips protocol-relative (``//host``) and
+	relative srcs that ``url_schemes`` alone would let through; ``<a>`` is dropped.
+	Everything else fetch-capable (``<link>``/``<style>``/``<image>``/``<svg>``/
+	``<iframe>``/``<input type=image>``/``style="url(...)"`` ...) is removed. So no
+	server-side fetch (SSRF) can be provoked through a letterhead - see the
+	module's letterhead-gate note."""
+	return nh3.clean(
+		html,
+		tags=_LETTERHEAD_TAGS,
+		attributes=_LETTERHEAD_ATTRIBUTES,
+		url_schemes=_LETTERHEAD_URL_SCHEMES,
+		url_relative="deny",
+		clean_content_tags=_LETTERHEAD_DECOMPOSE,
 	)

--- a/jarvis/tools/_export/document/sanitizer.py
+++ b/jarvis/tools/_export/document/sanitizer.py
@@ -7,10 +7,16 @@ renderer that consumes it (wkhtmltopdf) will FETCH any ``<img src>`` /
 the output of this module must contain no fetch-capable tag and no active markup
 at all - only inert, class-styled structural HTML.
 
-WHY a pure module (imports ONLY ``nh3`` + ``bs4``, never ``frappe``): the
+WHY a pure module (imports ONLY ``nh3``, never ``frappe`` or ``bs4``): the
 sanitizer is the one place a mistake becomes an SSRF/XSS hole, so it is kept
 importable and unit-testable without a running bench - the attack corpus runs in
-plain CI, not only inside a site.
+plain CI, not only inside a site. Depending on a single, Rust-based HTML parser
+(``nh3``/``ammonia``, on ``html5ever``) also means untrusted input is parsed
+ONCE, by the same engine that sanitizes it - a second, different parser ahead of
+it (the previous BeautifulSoup/html5lib pre-pass) is both a parser-differential
+mutation-XSS surface and, in pure Python, quadratic on adversarial nesting depth
+(a 200k-char deeply-nested fragment parsed for ~80s, defeating the render's
+wall-clock budget). ``nh3`` does the same tree construction natively in ~2s.
 
 WHY ``nh3.clean`` directly, NOT ``frappe.utils.sanitize_html``: that helper only
 exposes ``disallowed_tags``; its defaults *allow* ``id``/``name``/``background``/
@@ -20,17 +26,14 @@ JSON or contains no tags. None of that is acceptable here, and none of it is
 configurable through that signature. We call ``nh3.clean`` with an explicit,
 tight allowlist instead.
 
-The pipeline is two layers, mirroring the decompose-then-clean shape Frappe's own
-``clean_email_html`` uses:
-
-  1. ``_strip_unsafe_tags`` - a BeautifulSoup ``decompose`` pre-pass that REMOVES
-     each fetch-capable / active tag together with its subtree. nh3 alone would
-     strip a disallowed tag but KEEP its text, so ``<script>alert(1)</script>``
-     would survive as the visible text ``alert(1)``. Decomposing first deletes
-     the payload cleanly.
-  2. ``nh3.clean`` with a tight tag/attribute/url-scheme allowlist on what
-     remains - the airtight allowlist pass (belt-and-suspenders once the unsafe
-     tags are already gone).
+WHY ``clean_content_tags`` (not a manual decompose pre-pass): nh3's default for a
+disallowed tag is to strip the tag but KEEP its inner text, so
+``<script>alert(1)</script>`` would otherwise survive as the visible text
+``alert(1)``. ``clean_content_tags`` tells nh3 to remove the tag together with
+its subtree - natively, in the same single pass as the allowlist. This is the
+exact parameter ``frappe.utils.html_utils.clean_html``/``clean_email_html`` use
+for the same purpose (frappe's older ``clean_script_and_style``, a
+BeautifulSoup-decompose pass, is deprecated in favour of it).
 
 WHY inline ``style`` is DISALLOWED entirely (classes-only): nh3's
 ``filter_style_properties`` is a property-NAME allowlist ONLY. It does not reject
@@ -42,14 +45,16 @@ need agent-supplied inline style.
 """
 
 import nh3
-from bs4 import BeautifulSoup
 
-# Removed OUTRIGHT (tag + subtree) by the decompose pre-pass rather than left to
-# nh3's allowlist. Every one of these can trigger an out-of-band fetch when
-# wkhtmltopdf renders (img/svg/iframe/object/embed/audio/video/source/link/
-# base), execute (script), inject styling/url() (style), carry metadata refresh
-# (meta), or submit/collect (form/input/button). Removing the whole subtree also
-# deletes the inert-but-visible text nh3 would otherwise keep.
+# Removed OUTRIGHT (tag + subtree) via nh3's ``clean_content_tags`` rather than
+# left to the allowlist (which would keep inner text). Every one of these can
+# trigger an out-of-band fetch when wkhtmltopdf renders (img/svg/iframe/object/
+# embed/audio/video/source/link/base), execute (script), inject styling/url()
+# (style), carry a metadata refresh (meta), or submit/collect (form/input/
+# button). The raw-text / escapable / metadata elements (noscript/template/xmp/
+# plaintext/textarea/title) are here too so their contents are discarded rather
+# than surviving as inert-but-visible escaped junk in a document meant to read
+# as a clean report.
 _DECOMPOSE_TAGS = (
 	"script",
 	"style",
@@ -67,6 +72,12 @@ _DECOMPOSE_TAGS = (
 	"audio",
 	"video",
 	"source",
+	"noscript",
+	"template",
+	"xmp",
+	"plaintext",
+	"textarea",
+	"title",
 )
 
 # The rich structural set an org document needs. Deliberately NO ``img`` - agent
@@ -132,42 +143,25 @@ _ALLOWED_ATTRIBUTES = {
 # renderer the way an ``<img src>`` would be).
 _URL_SCHEMES = {"http", "https", "mailto"}
 
-
-def _strip_unsafe_tags(html: str) -> str:
-	"""Remove (not escape) every tag in ``_DECOMPOSE_TAGS`` together with its
-	subtree, ahead of ``nh3.clean``.
-
-	nh3's own default for a disallowed tag is to strip the tag but keep its inner
-	text, which would leave a ``<script>``'s payload sitting as visible text.
-	Decomposing first deletes the payload. ``BeautifulSoup(html, "html5lib")``
-	parses with the same HTML5 tree-construction algorithm a browser/renderer
-	uses (the safest reading of adversarial input) and always wraps a fragment in
-	its own ``<html><head></head><body>...</body></html>``, so we return the body's
-	inner HTML - ``html`` here is a fragment about to be spliced into the engine's
-	own page shell, not a standalone page.
-	"""
-	soup = BeautifulSoup(html, "html5lib")
-	for tag in soup(list(_DECOMPOSE_TAGS)):
-		tag.decompose()
-	return soup.body.decode_contents() if soup.body else soup.decode_contents()
+_DECOMPOSE_SET = set(_DECOMPOSE_TAGS)
 
 
 def sanitize_rich(html: str) -> str:
 	"""Return ``html`` reduced to inert, class-styled structural markup safe to
 	hand an unauthenticated wkhtmltopdf render.
 
-	Two layers: a BeautifulSoup ``decompose`` pre-pass that deletes every
-	fetch-capable / active tag and its subtree, then ``nh3.clean`` with a tight
-	tag/attribute/url-scheme allowlist. Inline ``style`` is disallowed outright
-	(classes-only) - see the module docstring for why the ``style`` attribute
-	cannot be made airtight via ``filter_style_properties``. No ``<img>``,
-	``on*`` handler, ``id``, ``javascript:``/``data:``/``file:`` url, or event
-	attribute can survive this.
+	One pass: ``nh3.clean`` with a tight tag/attribute/url-scheme allowlist and
+	``clean_content_tags`` (removes every fetch-capable / active / raw-text tag
+	together with its subtree, so a ``<script>``'s payload is deleted, not kept as
+	visible text). Inline ``style`` is disallowed outright (classes-only) - see the
+	module docstring for why the ``style`` attribute cannot be made airtight via
+	``filter_style_properties``. No ``<img>``, ``on*`` handler, ``id``,
+	``javascript:``/``data:``/``file:`` url, or event attribute can survive this.
 	"""
-	stripped = _strip_unsafe_tags(html)
 	return nh3.clean(
-		stripped,
+		html,
 		tags=_ALLOWED_TAGS,
 		attributes=_ALLOWED_ATTRIBUTES,
 		url_schemes=_URL_SCHEMES,
+		clean_content_tags=_DECOMPOSE_SET,
 	)

--- a/jarvis/tools/_export/document/theme.py
+++ b/jarvis/tools/_export/document/theme.py
@@ -1,0 +1,345 @@
+"""Branded component stylesheet for the rich-PDF document engine.
+
+This is the visual layer the rich path (Task 3's ``furniture.render_pdf`` and
+Task 6's ``export_document`` orchestrator) wraps around ``sanitize_rich``'s
+output. It is a **pure module** - no ``import frappe`` anywhere in it - so the
+stylesheet and its class-name contract are unit-testable without a bench, the
+same purity guarantee ``sanitizer.py`` makes for the same reason.
+
+WHY a function AND a constant: ``component_css()`` is the source of truth
+(callable, so a later per-tenant token layer - accent color from ``Jarvis
+Settings``, say - can build on top of it without breaking this signature);
+``THEME_CSS`` is the same output cached at import time for callers that just
+want the static string.
+
+THE CONTRACT: every class name below is load-bearing. Task 4's number/RAG/
+chart builders and Task 6's HTML assembly emit these EXACT class names onto
+sanitized (agent) or tool-built (post-sanitize) markup, so renaming one here
+silently breaks a downstream tool. New classes are free to add; the existing
+names are not free to rename without updating every caller.
+
+  * Typography: bare ``h1``..``h6`` + ``body`` (no class needed - the
+    sanitizer already allows these tags with only a ``class`` attribute).
+  * Tables: bare ``table``/``th``/``td`` (base) + ``.zebra`` (put on the
+    ``<table>``; alternates via ``tr:nth-child``) + ``.grouped`` (put on the
+    subtotal/group-total ``<tr>``) + ``.indent-1``..``.indent-5`` (tree-row
+    label indent, any tag) + ``.neg`` (negative-value red; the tool supplies
+    the parenthetical text, this only supplies the color) + ``.rag-red`` /
+    ``.rag-amber`` / ``.rag-green`` (status cell or nested chip ``<span>``).
+  * ``.num`` - ``text-align:right`` helper for numeric columns.
+  * ``.callout`` - accent left-border + tinted background.
+  * ``.kpi-tile`` - a value/label/delta card. The tile itself is a complete,
+    reasonable-looking box with no children; nested ``.kpi-value`` /
+    ``.kpi-label`` / ``.kpi-delta`` are optional convenience sub-classes for
+    callers that want the full value+label+delta layout (``.kpi-delta``
+    reuses the contract's own ``.neg`` to flip red - one negative-color
+    token for the whole document, not two).
+  * ``.cover`` - full-bleed title page, ``page-break-after`` so body content
+    starts on its own page.
+  * ``.section-divider`` - ``page-break-before`` section header rule.
+  * ``.signature-block`` - sign-off area; nested ``.signature-line`` is an
+    optional convenience sub-class for an individual name/date line.
+  * ``.bar-chart`` (container) + ``.bar`` (a single bar). ``.bar`` styles
+    ONLY color/height - the tool sets ``width`` per bar via a tool-controlled
+    inline ``style`` spliced in AFTER ``sanitize_rich`` (agent content itself
+    can never carry a ``style`` attribute - see ``sanitizer.py``). Nested
+    ``.bar-row`` / ``.bar-label`` / ``.bar-track`` are optional convenience
+    sub-classes for the label+track layout around a bar.
+
+WHY no flexbox/grid and no CSS custom properties (``var()``): the render
+engine is wkhtmltopdf's patched-Qt WebKit (a pre-2013 WebKit fork - see the
+plan's "Engine = wkhtmltopdf ONLY" constraint), which does not reliably
+support either. Every layout below uses block / inline-block / table flow
+only, and every color is baked into the CSS text at build time through
+``string.Template`` ``$``-substitution rather than emitted as ``var(--x)``.
+
+WHY ``string.Template`` and not an f-string: the CSS body below is mostly
+literal ``{`` / ``}`` (every rule block), which an f-string would force
+escaping into ``{{``/``}}`` throughout - error-prone at this size.
+``string.Template`` substitutes ``$name`` tokens instead, so the CSS reads as
+plain CSS.
+
+WHY one global ``-webkit-print-color-adjust:exact`` rule instead of repeating
+it on every background-bearing selector: wkhtmltopdf drops print background
+fills without it, and ``*`` is a strict superset of "anything with a
+background fill" - elements with no fill simply ignore a harmless
+color-adjust hint. One rule, easy to snapshot-test, nothing to keep in sync
+by hand as components are added.
+"""
+
+from __future__ import annotations
+
+from string import Template
+
+# --- brand tokens (v1 default; a future per-tenant layer swaps these before
+# calling component_css(), not the template itself) ------------------------
+
+_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+
+_PRIMARY = "#1f4e79"  # accents, rules, chart bars, thead fill
+_DARK = "#132d47"  # headings, cover background
+_MUTED = "#666666"  # captions, labels, footnotes
+_INK = "#1a1a1a"  # body text
+_LINE = "#d9d9d9"  # hairline borders
+_TINT = "#eef2f7"  # zebra/callout/subtotal tinted background
+
+_RED = "#b3261e"
+_RED_BG = "#fbe9e7"
+_AMBER = "#8a5a00"
+_AMBER_BG = "#fff4e0"
+_GREEN = "#1e7d32"
+_GREEN_BG = "#e6f4ea"
+
+# Tree-row indent step; five levels (.indent-1..indent-5) generated below.
+_INDENT_STEP_PT = 14
+_INDENT_LEVELS = range(1, 6)
+
+_CSS_TEMPLATE = Template(
+	"""
+/* === Branded component stylesheet (Slice 1) - see theme.py docstring for
+   the full class-name contract and the wkhtmltopdf layout constraints. === */
+
+* {
+	-webkit-print-color-adjust:exact;
+	print-color-adjust:exact;
+}
+
+body {
+	font-family: $font;
+	font-size: 11pt;
+	line-height: 1.5;
+	color: $ink;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	font-weight: 700;
+	line-height: 1.25;
+	color: $dark;
+	margin: 0 0 10pt;
+}
+h1 { font-size: 26pt; }
+h2 { font-size: 20pt; }
+h3 { font-size: 16pt; }
+h4 { font-size: 13pt; }
+h5 { font-size: 11.5pt; }
+h6 {
+	font-size: 10pt;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: $muted;
+}
+
+/* --- tables --------------------------------------------------------- */
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 8pt 0 16pt;
+}
+th, td {
+	padding: 6pt 8pt;
+	border-bottom: 0.75pt solid $line;
+	text-align: left;
+	vertical-align: top;
+}
+thead th {
+	background: $primary;
+	color: #ffffff;
+	font-weight: 600;
+	border-bottom: none;
+}
+
+/* Right-align a numeric column/cell. */
+.num {
+	text-align: right;
+}
+
+/* Alternating body-row shading - opt a table in with class="zebra". */
+table.zebra tbody tr:nth-child(even) td,
+table.zebra tbody tr:nth-child(even) th {
+	background: $tint;
+}
+
+/* A subtotal/group-total row - put class="grouped" on the <tr>. */
+tr.grouped td,
+tr.grouped th {
+	font-weight: 700;
+	background: $tint;
+	border-top: 1.5pt solid $primary;
+	border-bottom: 0.75pt solid $primary;
+}
+
+/* Tree-structured rows: indent the label cell by nesting depth. */
+$indent_rules
+
+/* A negative value - color only; the tool supplies "(1,234)"-style text. */
+.neg {
+	color: $red;
+}
+
+/* RAG status - safe directly on a <td>/<th>, or on a nested <span> chip. */
+.rag-red, .rag-amber, .rag-green {
+	padding: 2pt 8pt;
+	border-radius: 3pt;
+	font-weight: 600;
+	font-size: 9.5pt;
+	white-space: nowrap;
+}
+.rag-red { background: $red_bg; color: $red; }
+.rag-amber { background: $amber_bg; color: $amber; }
+.rag-green { background: $green_bg; color: $green; }
+
+/* --- callout ---------------------------------------------------------- */
+
+.callout {
+	border-left: 4pt solid $primary;
+	background: $tint;
+	padding: 10pt 14pt;
+	margin: 10pt 0;
+}
+.callout h1, .callout h2, .callout h3,
+.callout h4, .callout h5, .callout h6 {
+	margin-top: 0;
+}
+
+/* --- kpi tile ----------------------------------------------------------- */
+
+.kpi-tile {
+	display: inline-block;
+	min-width: 120pt;
+	padding: 12pt 16pt;
+	margin: 0 8pt 8pt 0;
+	border: 0.75pt solid $line;
+	border-radius: 4pt;
+	background: #ffffff;
+	vertical-align: top;
+}
+.kpi-tile .kpi-value {
+	display: block;
+	font-size: 22pt;
+	font-weight: 700;
+	color: $dark;
+}
+.kpi-tile .kpi-label {
+	display: block;
+	font-size: 9pt;
+	color: $muted;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	margin-top: 2pt;
+}
+.kpi-tile .kpi-delta {
+	display: inline-block;
+	font-size: 9.5pt;
+	font-weight: 600;
+	margin-top: 4pt;
+	color: $green;
+}
+.kpi-tile .kpi-delta.neg {
+	color: $red;
+}
+
+/* --- cover / section pages ----------------------------------------------- */
+
+.cover {
+	page-break-after: always;
+	height: 100%;
+	padding-top: 200pt;
+	text-align: center;
+	background: $dark;
+	color: #ffffff;
+}
+.cover h1, .cover h2, .cover h3 {
+	color: #ffffff;
+}
+.cover p {
+	color: #f2f2f2;
+}
+
+.section-divider {
+	page-break-before: always;
+	border-top: 2pt solid $primary;
+	padding-top: 14pt;
+	margin: 0 0 12pt;
+	color: $dark;
+}
+
+/* --- signature block -------------------------------------------------- */
+
+.signature-block {
+	margin-top: 40pt;
+	padding-top: 10pt;
+	border-top: 0.75pt solid $line;
+}
+.signature-block .signature-line {
+	display: block;
+	width: 220pt;
+	margin-top: 28pt;
+	padding-top: 4pt;
+	border-top: 0.75pt solid $ink;
+	font-size: 9.5pt;
+	color: $muted;
+}
+
+/* --- CSS bar charts ------------------------------------------------------ */
+
+.bar-chart {
+	margin: 10pt 0 16pt;
+}
+.bar-chart .bar-row {
+	margin-bottom: 6pt;
+}
+.bar-chart .bar-label {
+	display: inline-block;
+	width: 28%;
+	font-size: 9.5pt;
+	color: $muted;
+	vertical-align: middle;
+}
+.bar-chart .bar-track {
+	display: inline-block;
+	width: 70%;
+	background: $tint;
+	vertical-align: middle;
+}
+/* Color/height only - the tool sets `width` per bar via inline style. */
+.bar {
+	display: block;
+	height: 14pt;
+	background: $primary;
+}
+"""
+)
+
+
+def component_css() -> str:
+	"""Return the branded component stylesheet (see module docstring for the
+	full class-name contract).
+
+	Pure string composition - no I/O, no ``frappe``. Deterministic: two calls
+	return identical text, so it is safe to call once and cache (``THEME_CSS``
+	does exactly that) or call per-render if a future per-tenant token layer
+	needs to vary the substitution inputs.
+	"""
+	indent_rules = "\n".join(
+		f".indent-{level} {{ padding-left: {level * _INDENT_STEP_PT}pt; }}" for level in _INDENT_LEVELS
+	)
+	return _CSS_TEMPLATE.substitute(
+		font=_FONT,
+		ink=_INK,
+		dark=_DARK,
+		muted=_MUTED,
+		primary=_PRIMARY,
+		line=_LINE,
+		tint=_TINT,
+		red=_RED,
+		red_bg=_RED_BG,
+		amber=_AMBER,
+		amber_bg=_AMBER_BG,
+		green=_GREEN,
+		green_bg=_GREEN_BG,
+		indent_rules=indent_rules,
+	)
+
+
+THEME_CSS: str = component_css()

--- a/jarvis/tools/export_document.py
+++ b/jarvis/tools/export_document.py
@@ -224,9 +224,12 @@ def export_document(
 		# best-effort: it must never REPLACE the real error (nor break a no-site
 		# unit test), so it is suppressed.
 		with contextlib.suppress(Exception):
+			# Plain traceback only — NOT with_context, which dumps local variable
+			# VALUES (the agent's document content, an inlined base64 logo) into the
+			# operator-readable Error Log.
 			frappe.log_error(
 				title="jarvis.export_document: unexpected render failure",
-				message=frappe.get_traceback(with_context=True),
+				message=frappe.get_traceback(),
 			)
 		telemetry.record_export_event(
 			tool="export_document",
@@ -301,7 +304,7 @@ def _render_rich(
 	# 4. emptiness guard: never emit a blank PDF. Check VISIBLE TEXT, not the raw
 	#    markup string — content that sanitized/spliced down to empty tags
 	#    (e.g. "<p></p>") is a truthy string but a blank document.
-	if not _visible_text(body):
+	if not _has_visible_content(body):
 		raise NoDataError("No content to export after sanitization.")
 	# 5. theme is tool-added AFTER sanitize (agent content never carries styling).
 
@@ -370,11 +373,20 @@ def _guard_chart_rows(charts: list) -> None:
 		)
 
 
-def _visible_text(html_fragment: str) -> str:
-	"""Return the visible text of an HTML fragment (tags stripped, whitespace
-	collapsed) for the emptiness guard — so a childless-tag skeleton reads as
-	empty. Cheap regex strip; this is an emptiness heuristic, not a sanitizer."""
-	return re.sub(r"<[^>]+>", "", html_fragment or "").strip()
+def _has_visible_content(html_fragment: str) -> bool:
+	"""True if the fragment would render something the user can see, for the
+	emptiness guard — so a childless-tag skeleton (``<p></p>``) reads as empty but
+	a real document (or a rendered chart with no text labels) does not.
+
+	Cheap heuristic (not a sanitizer): strip tags, UNESCAPE entities (so a
+	``&nbsp;``-only doc collapses to whitespace and is caught), and check for
+	non-whitespace text — OR the presence of a spliced chart, whose colored bars
+	render even when every row label/value is blank."""
+	body = html_fragment or ""
+	if 'class="bar-chart"' in body:
+		return True
+	text = _html.unescape(re.sub(r"<[^>]+>", "", body))
+	return bool(text.strip())
 
 
 def _short_err(exc: Exception) -> str:
@@ -401,6 +413,11 @@ def _splice_charts(body: str, charts: list, notes: list[str]) -> str:
 	tokens are removed so no literal ``{{chart:N}}`` junk survives."""
 	if not charts and _CHART_TOKEN_RE.search(body) is None:
 		return body
+
+	# Indices whose token appears ANYWHERE in the body (incl. a <code> example or
+	# an attribute), so a chart referenced only in a literal example is not
+	# mis-reported as "placeholder not found".
+	referenced = {int(m.group(1)) for m in _CHART_TOKEN_RE.finditer(body)}
 
 	# Render each spec ONCE (or degrade to a note), keyed by index.
 	rendered: dict[int, str] = {}
@@ -435,7 +452,7 @@ def _splice_charts(body: str, charts: list, notes: list[str]) -> str:
 		node.extract()
 
 	for i in rendered:
-		if i not in seen:
+		if i not in referenced:
 			notes.append(
 				f"chart {i} was provided but its {{{{chart:{i}}}}} placeholder was not found in the content"
 			)

--- a/jarvis/tools/export_document.py
+++ b/jarvis/tools/export_document.py
@@ -5,11 +5,21 @@ This is the write-side twin of ``export_excel`` for prose/tabular *documents*.
 ``download_pdf`` only prints one existing record through a Print Format; a
 report the agent composed from many queries has no record to print, so without
 this the agent hand-builds the file with ``exec``/``browser`` and it never
-reaches the user. Here we render the content with Frappe's own engines
-(``md_to_html`` + ``get_pdf``) and save a private File the chat renders as a
-download card.
+reaches the user.
 
-Security: ``content`` is agent-composed, which means it is effectively
+Two rendering paths share this one entry point:
+
+  * The PLAIN path (the original, in-prod behaviour) — a runaway-guarded
+    Markdown/HTML → ``get_pdf`` render with a minimal built-in stylesheet. It is
+    taken whenever NO rich kwarg is truthy, and its behaviour is byte-preserved
+    (same sanitizer, same shell, same ``save_file``) so every legacy call is
+    unaffected. See ``_render_plain`` and the sanitizer note below.
+  * The RICH path (Slice 1) — a branded, class-styled document rendered through
+    the hard-timed direct-wkhtmltopdf pipeline (``_export/document``). It is
+    opt-in: passing any truthy rich kwarg (``theme``/``letterhead``/``header``/
+    ``footer``/``watermark``/``charts``) switches to it. See ``_render_rich``.
+
+Security (PLAIN path): ``content`` is agent-composed, i.e. effectively
 LLM-controlled text — it must never reach the HTML unsanitized. Two distinct
 threats, both closed at one choke point:
 
@@ -19,10 +29,8 @@ threats, both closed at one choke point:
     ``<img src>`` / ``<link href>`` / SVG ``<image href>`` it finds at render
     time, server-side. An agent-composed ``<img src="http://169.254.169.254/…">``
     (cloud metadata) or ``file:///etc/passwd`` would make the PDF renderer
-    issue that request. This tool does not support embedded
-    images/charts (deliberately out of scope), so every fetch-capable tag is
-    stripped outright rather than merely attribute-filtered — no feature is
-    lost by removing a tag nothing here is meant to use.
+    issue that request. The plain path supports no embedded images, so every
+    fetch-capable tag is stripped outright rather than merely attribute-filtered.
 
 Two layers, mirroring the pattern ``frappe.utils.html_utils`` already uses for
 ``<script>``/``<style>`` (``clean_script_and_style``, a BeautifulSoup decompose
@@ -43,13 +51,23 @@ pass ahead of ``bleach.clean``):
 
 Applied identically to BOTH the Markdown-rendered branch and the
 ``content_is_html=True`` raw-HTML branch — the flag changes how ``content``
-becomes HTML, never whether the result gets sanitized.
+becomes HTML, never whether the result gets sanitized. The rich path uses its
+own, tighter ``sanitize_rich`` (a direct ``nh3.clean``); see that module.
 """
+
+import re
+from collections.abc import Mapping
 
 import frappe
 from frappe.utils.html_utils import sanitize_html
 
+from jarvis import telemetry
 from jarvis.exceptions import InvalidArgumentError, NoDataError
+from jarvis.tools._export import save_export_file
+from jarvis.tools._export.document.furniture import render_pdf
+from jarvis.tools._export.document.graphics import css_bar
+from jarvis.tools._export.document.sanitizer import sanitize_rich
+from jarvis.tools._export.document.theme import component_css
 
 _FORMATS = {
 	"pdf": ("pdf", "application/pdf"),
@@ -69,6 +87,250 @@ _UNSAFE_TAGS = {"img", "image", "svg", "link", "meta", "style", "script"}
 
 # A runaway model must not be able to hand wkhtmltopdf an unbounded document.
 _MAX_CONTENT_CHARS = 200_000
+
+# A document with dozens of charts is either a bug or an attempt to blow the
+# render past its wall-clock budget; cap it loudly rather than let the render
+# time out. CSS bars are cheap, so this ceiling is generous.
+_MAX_CHARTS = 20
+
+# Hard wall-clock bound handed to the rich renderer's subprocess watchdog. Kept
+# under the plugin's 30s call_tool abort so the bench kills a runaway render
+# before the client gives up (a number, not "<30s").
+_RENDER_TIMEOUT_S = 25
+
+# {{chart:N}} placeholder token the agent drops into ``content`` where a chart
+# should appear; the tool splices its own generated HTML in at that spot AFTER
+# sanitize (so the tool-controlled markup is trusted). This is the reusable
+# splice mechanism Slice 2 extends for images/QR/logos.
+_CHART_TOKEN_RE = re.compile(r"\{\{chart:(\d+)\}\}")
+
+
+def export_document(
+	content: str,
+	format: str = "pdf",
+	title: str | None = None,
+	content_is_html: bool = False,
+	*,
+	theme: bool = False,
+	letterhead: str | bool | None = None,
+	header: str | None = None,
+	footer: str | None = None,
+	watermark: str | None = None,
+	page_size: str = "A4",
+	orientation: str = "portrait",
+	margins_mm: int = 15,
+	page_numbers: bool = True,
+	charts: list | None = None,
+) -> dict:
+	"""Render ``content`` and return ``{file_url, filename, title, mime_type,
+	size_bytes, name}`` for a private downloadable File (the rich path also adds
+	``notes``).
+
+	``content`` is the composed document — Markdown by default (tables, headings,
+	lists all render), or raw HTML when ``content_is_html`` is set. ``format`` is
+	``"pdf"`` (default), ``"html"``, or ``"png"`` (a single image of the rendered
+	pages, stacked). ``title`` names the file + document.
+
+	DUAL PATH. With no truthy rich kwarg this is the original plain render —
+	sanitized (see the module docstring), image-free by design. Passing any truthy
+	rich kwarg switches to the branded rich path:
+
+	  * ``theme`` — apply the branded component stylesheet.
+	  * ``letterhead`` — a ``Letter Head`` name (str) folded in as trusted config,
+	    or ``True`` to opt into the rich path with no named letterhead.
+	  * ``header`` / ``footer`` / ``watermark`` — page furniture (PDF only).
+	  * ``page_size`` / ``orientation`` / ``margins_mm`` / ``page_numbers`` — page
+	    geometry (consumed by the rich path; they do NOT by themselves trigger it).
+	  * ``charts`` — a list of CSS-bar specs (``{"rows": [...]}``); reference each
+	    with a ``{{chart:N}}`` token in ``content`` and it is spliced in after
+	    sanitize. A token with no spec (or a spec with no token) is reported in
+	    ``notes`` rather than crashing.
+
+	Falsy rich kwargs (``header=""`` / ``charts=[]`` / ``theme=False`` /
+	``letterhead=None``) do NOT flip to the rich path — empty is not present.
+
+	SLICE-1 SCOPE (this release): rich means branding via **letterhead + CSS
+	components + CSS bar charts** only. No embedded images — no matplotlib/image
+	charts, no QR, no base64 logos (those are Slice 2). ``fmt_amount``/``fmt_pct``
+	from ``_export.document.graphics`` return small HTML fragments meant for DIRECT
+	embedding into ``content`` (e.g. a table cell); do NOT pass their output
+	through ``kpi_tile``/``css_bar``, whose text escaping would double-escape the
+	fragment's span.
+
+	OUT OF SCOPE — HARD WALLS (fail loud / degrade, never silently pretend): tagged
+	PDF / PDF-UA accessibility, PDF encryption + digital signatures, prepress CMYK
+	/ bleed, full right-to-left text shaping, row-level keep-together, widow/orphan
+	control, automatic hyphenation, and interactive AcroForm / embedded JavaScript.
+	Do not promise any of these to the user.
+	"""
+	fmt = (format or "pdf").lower()
+	try:
+		_guard_content(content)
+		if fmt not in _FORMATS:
+			raise InvalidArgumentError(f"format must be one of {sorted(_FORMATS)}")
+		if _rich_requested(theme, letterhead, header, footer, watermark, charts):
+			env = _render_rich(
+				content,
+				fmt,
+				title,
+				content_is_html,
+				letterhead=letterhead,
+				header=header,
+				footer=footer,
+				watermark=watermark,
+				page_size=page_size,
+				orientation=orientation,
+				margins_mm=margins_mm,
+				page_numbers=page_numbers,
+				charts=charts,
+			)
+			outcome = "degraded" if env["notes"] else "ok"
+		else:
+			env = _render_plain(content, fmt, title, content_is_html)
+			outcome = "ok"
+	except (NoDataError, InvalidArgumentError) as exc:
+		# Emit on the fail-closed exits too (export_document previously emitted no
+		# telemetry at all — this closes that gap on both success and failure).
+		telemetry.record_export_event(
+			tool="export_document", fmt=fmt, rows=0, mode="sync", outcome=_outcome_for(exc)
+		)
+		raise
+	telemetry.record_export_event(tool="export_document", fmt=fmt, rows=0, mode="sync", outcome=outcome)
+	return env
+
+
+def _guard_content(content: str) -> None:
+	"""Shared front-gate for both paths: non-empty string within the char cap."""
+	if not isinstance(content, str) or not content.strip():
+		raise NoDataError("No content to export.")
+	if len(content) > _MAX_CONTENT_CHARS:
+		raise InvalidArgumentError(f"content exceeds {_MAX_CONTENT_CHARS} characters")
+
+
+def _rich_requested(theme, letterhead, header, footer, watermark, charts) -> bool:
+	"""Branch on TRUTHY (non-empty) rich kwargs. Geometry kwargs (page_size /
+	orientation / margins_mm / page_numbers) have non-falsy defaults and are NOT
+	activators — only these intent kwargs flip the path, and only when truthy, so
+	``header=""`` / ``charts=[]`` / ``theme=False`` / ``letterhead=None`` stay
+	plain."""
+	return bool(theme or letterhead or header or footer or watermark or charts)
+
+
+def _render_rich(
+	content: str,
+	fmt: str,
+	title: str | None,
+	content_is_html: bool,
+	*,
+	letterhead,
+	header,
+	footer,
+	watermark,
+	page_size,
+	orientation,
+	margins_mm,
+	page_numbers,
+	charts,
+) -> dict:
+	"""The branded rich pipeline: md→HTML → sanitize → post-sanitize chart splice
+	→ emptiness guard → theme-wrap → render/compose → save. Returns the download
+	envelope plus a ``notes`` list carrying every degrade."""
+	charts = charts or []
+	if len(charts) > _MAX_CHARTS:
+		raise InvalidArgumentError(f"charts exceeds the {_MAX_CHARTS}-chart limit")
+	notes: list[str] = []
+
+	# 1. markdown → HTML BEFORE sanitize (else ![](…)/autolinks regenerate <img>/
+	#    links post-strip); raw HTML is passed straight to the sanitizer.
+	body = content if content_is_html else frappe.utils.md_to_html(content)
+	# 2. sanitize the full agent body.
+	body = sanitize_rich(body)
+	# 3. splice tool-generated chart HTML into {{chart:N}} tokens (AFTER sanitize —
+	#    this markup is tool-controlled, so it is trusted).
+	body = _splice_charts(body, charts, notes)
+	# 4. emptiness guard: never emit a blank PDF for content that sanitized away.
+	if not body.strip():
+		raise NoDataError("No content to export after sanitization.")
+	# 5. theme is tool-added AFTER sanitize (agent content never carries styling).
+	doc_body = f"<style>{component_css()}</style>{body}"
+
+	if fmt == "html":
+		# No wkhtmltopdf on the HTML path, so page furniture can't be applied —
+		# surface that rather than silently dropping it. page_numbers is excluded
+		# from this check: its default True would fire on every HTML render, and
+		# page numbers are auto-furniture, not caller content.
+		if header or footer or watermark or letterhead:
+			notes.append("furniture (header/footer/watermark) applies only to PDF output")
+		payload = doc_body.encode("utf-8")
+	else:
+		pdf_bytes = render_pdf(
+			doc_body,
+			page_size=page_size,
+			orientation=orientation,
+			margins_mm=margins_mm,
+			header_html=header,
+			footer_html=footer,
+			watermark=watermark,
+			letterhead=(letterhead if isinstance(letterhead, str) else None),
+			page_numbers=page_numbers,
+			timeout=_RENDER_TIMEOUT_S,
+		)
+		payload = pdf_bytes if fmt == "pdf" else _pdf_to_png(pdf_bytes)
+
+	if not payload:
+		raise InvalidArgumentError(f"{fmt} rendering produced no content.")
+	ext, mime = _FORMATS[fmt]
+	env = save_export_file(f"document.{ext}", payload, title or "Document", mime)
+	env["notes"] = notes
+	return env
+
+
+def _splice_charts(body: str, charts: list, notes: list[str]) -> str:
+	"""Replace each ``{{chart:N}}`` token with ``css_bar`` output for ``charts[N]``.
+
+	Runs AFTER ``sanitize_rich`` so the tool-generated bar markup (which carries a
+	single clamped ``width:N%`` inline style) is trusted and not stripped. A spec
+	whose token is absent, or a token with no matching spec, is reported in
+	``notes`` — never a crash. Orphan tokens are removed so no literal ``{{chart:N}}``
+	junk survives into the document."""
+	for i, spec in enumerate(charts):
+		token = f"{{{{chart:{i}}}}}"
+		if token not in body:
+			notes.append(f"chart {i} was provided but its {token} placeholder was not found in the content")
+			continue
+		rows = spec.get("rows", []) if isinstance(spec, Mapping) else []
+		body = body.replace(token, css_bar(rows))
+	leftovers = sorted({int(m.group(1)) for m in _CHART_TOKEN_RE.finditer(body)})
+	for idx in leftovers:
+		notes.append(f"placeholder {{{{chart:{idx}}}}} has no matching chart spec")
+	if leftovers:
+		body = _CHART_TOKEN_RE.sub("", body)
+	return body
+
+
+def _outcome_for(exc: Exception) -> str:
+	"""Map a fail-closed exception to its telemetry outcome (NoDataError first, as
+	it subclasses InvalidArgumentError)."""
+	if isinstance(exc, NoDataError):
+		return "no_data"
+	return "rejected"
+
+
+# Minimal, self-contained stylesheet so tables/headings read cleanly in every
+# format (the HTML file opens standalone; the PDF/PNG render from the same CSS).
+# PLAIN PATH ONLY — the rich path uses the branded component stylesheet instead.
+_CSS = """
+body{font-family:-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  font-size:12px;color:#1a1a1a;line-height:1.5;margin:28px;}
+h1,h2,h3,h4{color:#111;margin:1.1em 0 .4em;line-height:1.25;}
+h1{font-size:20px;} h2{font-size:16px;} h3{font-size:14px;}
+table{border-collapse:collapse;width:100%;margin:.7em 0;}
+th,td{border:1px solid #ccc;padding:5px 8px;text-align:left;font-size:11px;
+  vertical-align:top;}
+th{background:#f4f4f5;font-weight:600;}
+code{background:#f4f4f5;padding:0 3px;border-radius:3px;font-size:.92em;}
+ul,ol{margin:.4em 0 .4em 1.2em;} p{margin:.5em 0;}
+"""
 
 
 def _strip_unsafe_tags(html: str) -> str:
@@ -94,50 +356,11 @@ def _strip_unsafe_tags(html: str) -> str:
 	return frappe.as_unicode(soup.body.decode_contents()) if soup.body else frappe.as_unicode(soup)
 
 
-# Minimal, self-contained stylesheet so tables/headings read cleanly in every
-# format (the HTML file opens standalone; the PDF/PNG render from the same CSS).
-_CSS = """
-body{font-family:-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
-  font-size:12px;color:#1a1a1a;line-height:1.5;margin:28px;}
-h1,h2,h3,h4{color:#111;margin:1.1em 0 .4em;line-height:1.25;}
-h1{font-size:20px;} h2{font-size:16px;} h3{font-size:14px;}
-table{border-collapse:collapse;width:100%;margin:.7em 0;}
-th,td{border:1px solid #ccc;padding:5px 8px;text-align:left;font-size:11px;
-  vertical-align:top;}
-th{background:#f4f4f5;font-weight:600;}
-code{background:#f4f4f5;padding:0 3px;border-radius:3px;font-size:.92em;}
-ul,ol{margin:.4em 0 .4em 1.2em;} p{margin:.5em 0;}
-"""
-
-
-def export_document(
-	content: str,
-	format: str = "pdf",
-	title: str | None = None,
-	content_is_html: bool = False,
-) -> dict:
-	"""Render ``content`` and return ``{file_url, filename, title, mime_type,
-	size_bytes, name}`` for a private downloadable File.
-
-	``content`` is the composed document — Markdown by default (tables,
-	headings, lists all render), or raw HTML when ``content_is_html`` is set.
-	``format`` is ``"pdf"`` (default), ``"html"``, or ``"png"`` (a single image
-	of the rendered pages, stacked). ``title`` names the file + document.
-
-	Both content modes are sanitized identically before rendering (see the
-	module docstring): ``content_is_html`` changes how ``content`` becomes
-	HTML, never whether the result is sanitized. Images/embedded charts are
-	not supported by design, not omission — do not ask for a workaround via
-	``content_is_html``.
-	"""
-	if not isinstance(content, str) or not content.strip():
-		raise NoDataError("No content to export.")
-	if len(content) > _MAX_CONTENT_CHARS:
-		raise InvalidArgumentError(f"content exceeds {_MAX_CONTENT_CHARS} characters")
-	fmt = (format or "pdf").lower()
-	if fmt not in _FORMATS:
-		raise InvalidArgumentError(f"format must be one of {sorted(_FORMATS)}")
-
+def _render_plain(content: str, fmt: str, title: str | None, content_is_html: bool) -> dict:
+	"""The original plain render — byte-preserved so every legacy call is
+	unchanged: same two-layer sanitizer, same self-contained shell, same
+	``get_pdf``/``_pdf_to_png`` engines, same ``save_file`` (its own filename
+	sanitizer + return shape, without a ``notes`` key)."""
 	body = content if content_is_html else frappe.utils.md_to_html(content)
 	body = _strip_unsafe_tags(body)
 	body = sanitize_html(body)

--- a/jarvis/tools/export_document.py
+++ b/jarvis/tools/export_document.py
@@ -55,7 +55,10 @@ becomes HTML, never whether the result gets sanitized. The rich path uses its
 own, tighter ``sanitize_rich`` (a direct ``nh3.clean``); see that module.
 """
 
+import contextlib
+import html as _html
 import re
+import time
 from collections.abc import Mapping
 
 import frappe
@@ -64,7 +67,7 @@ from frappe.utils.html_utils import sanitize_html
 from jarvis import telemetry
 from jarvis.exceptions import InvalidArgumentError, NoDataError
 from jarvis.tools._export import save_export_file
-from jarvis.tools._export.document.furniture import render_pdf
+from jarvis.tools._export.document.furniture import render_pdf, resolve_letterhead
 from jarvis.tools._export.document.graphics import css_bar
 from jarvis.tools._export.document.sanitizer import sanitize_rich
 from jarvis.tools._export.document.theme import component_css
@@ -93,6 +96,11 @@ _MAX_CONTENT_CHARS = 200_000
 # time out. CSS bars are cheap, so this ceiling is generous.
 _MAX_CHARTS = 20
 
+# Chart COUNT is capped above, but a single chart with millions of rows would
+# still inflate the spliced body without limit (each row is a <div>), defeating
+# _MAX_CONTENT_CHARS. Cap total rows across all charts too.
+_MAX_TOTAL_CHART_ROWS = 2_000
+
 # Hard wall-clock bound handed to the rich renderer's subprocess watchdog. Kept
 # under the plugin's 30s call_tool abort so the bench kills a runaway render
 # before the client gives up (a number, not "<30s").
@@ -101,8 +109,10 @@ _RENDER_TIMEOUT_S = 25
 # {{chart:N}} placeholder token the agent drops into ``content`` where a chart
 # should appear; the tool splices its own generated HTML in at that spot AFTER
 # sanitize (so the tool-controlled markup is trusted). This is the reusable
-# splice mechanism Slice 2 extends for images/QR/logos.
-_CHART_TOKEN_RE = re.compile(r"\{\{chart:(\d+)\}\}")
+# splice mechanism Slice 2 extends for images/QR/logos. Whitespace after the
+# colon is tolerated (a common LLM formatting variance); the index is capped at
+# 3 digits so a pathological ``{{chart:<190k digits>}}`` can never reach int().
+_CHART_TOKEN_RE = re.compile(r"\{\{chart:\s*(\d{1,3})\s*\}\}")
 
 
 def export_document(
@@ -135,9 +145,14 @@ def export_document(
 	sanitized (see the module docstring), image-free by design. Passing any truthy
 	rich kwarg switches to the branded rich path:
 
-	  * ``theme`` — apply the branded component stylesheet.
-	  * ``letterhead`` — a ``Letter Head`` name (str) folded in as trusted config,
-	    or ``True`` to opt into the rich path with no named letterhead.
+	  * ``theme`` — opt into the branded rich path. (The branded component
+	    stylesheet is applied to EVERY rich render regardless; ``theme`` is one of
+	    the activators, not an independent on/off switch for the CSS.)
+	  * ``letterhead`` — a ``Letter Head`` name (str) to brand with, or ``True`` to
+	    opt into the rich path without naming one. On the PDF path a letterhead is
+	    ALWAYS applied when one can be resolved — the named one, else the site's
+	    default ``Letter Head``. Its logo images are read-permission-checked and
+	    base64-inlined; images with a remote URL are dropped (never fetched).
 	  * ``header`` / ``footer`` / ``watermark`` — page furniture (PDF only).
 	  * ``page_size`` / ``orientation`` / ``margins_mm`` / ``page_numbers`` — page
 	    geometry (consumed by the rich path; they do NOT by themselves trigger it).
@@ -164,11 +179,12 @@ def export_document(
 	Do not promise any of these to the user.
 	"""
 	fmt = (format or "pdf").lower()
+	rich = _rich_requested(theme, letterhead, header, footer, watermark, charts)
 	try:
 		_guard_content(content)
 		if fmt not in _FORMATS:
 			raise InvalidArgumentError(f"format must be one of {sorted(_FORMATS)}")
-		if _rich_requested(theme, letterhead, header, footer, watermark, charts):
+		if rich:
 			env = _render_rich(
 				content,
 				fmt,
@@ -192,10 +208,42 @@ def export_document(
 		# Emit on the fail-closed exits too (export_document previously emitted no
 		# telemetry at all — this closes that gap on both success and failure).
 		telemetry.record_export_event(
-			tool="export_document", fmt=fmt, rows=0, mode="sync", outcome=_outcome_for(exc)
+			tool="export_document",
+			fmt=fmt,
+			rows=0,
+			mode="sync",
+			outcome=_outcome_for(exc),
+			rich=rich,
+			detail=_short_err(exc),
 		)
 		raise
-	telemetry.record_export_event(tool="export_document", fmt=fmt, rows=0, mode="sync", outcome=outcome)
+	except Exception as exc:
+		# Any OTHER exception (an unforeseen input, a bug) must not escape as a raw
+		# 500 with no telemetry — that was the observability blind spot the review
+		# found. Log it, record it, and re-raise a clean error. Logging is
+		# best-effort: it must never REPLACE the real error (nor break a no-site
+		# unit test), so it is suppressed.
+		with contextlib.suppress(Exception):
+			frappe.log_error(
+				title="jarvis.export_document: unexpected render failure",
+				message=frappe.get_traceback(with_context=True),
+			)
+		telemetry.record_export_event(
+			tool="export_document",
+			fmt=fmt,
+			rows=0,
+			mode="sync",
+			outcome="rejected",
+			rich=rich,
+			detail=_short_err(exc),
+		)
+		raise InvalidArgumentError(
+			"The document could not be generated due to an unexpected error. "
+			"Simplify the content or charts and try again."
+		) from exc
+	telemetry.record_export_event(
+		tool="export_document", fmt=fmt, rows=0, mode="sync", outcome=outcome, rich=rich
+	)
 	return env
 
 
@@ -235,9 +283,11 @@ def _render_rich(
 	"""The branded rich pipeline: md→HTML → sanitize → post-sanitize chart splice
 	→ emptiness guard → theme-wrap → render/compose → save. Returns the download
 	envelope plus a ``notes`` list carrying every degrade."""
+	start = time.monotonic()
 	charts = charts or []
 	if len(charts) > _MAX_CHARTS:
 		raise InvalidArgumentError(f"charts exceeds the {_MAX_CHARTS}-chart limit")
+	_guard_chart_rows(charts)
 	notes: list[str] = []
 
 	# 1. markdown → HTML BEFORE sanitize (else ![](…)/autolinks regenerate <img>/
@@ -248,11 +298,12 @@ def _render_rich(
 	# 3. splice tool-generated chart HTML into {{chart:N}} tokens (AFTER sanitize —
 	#    this markup is tool-controlled, so it is trusted).
 	body = _splice_charts(body, charts, notes)
-	# 4. emptiness guard: never emit a blank PDF for content that sanitized away.
-	if not body.strip():
+	# 4. emptiness guard: never emit a blank PDF. Check VISIBLE TEXT, not the raw
+	#    markup string — content that sanitized/spliced down to empty tags
+	#    (e.g. "<p></p>") is a truthy string but a blank document.
+	if not _visible_text(body):
 		raise NoDataError("No content to export after sanitization.")
 	# 5. theme is tool-added AFTER sanitize (agent content never carries styling).
-	doc_body = f"<style>{component_css()}</style>{body}"
 
 	if fmt == "html":
 		# No wkhtmltopdf on the HTML path, so page furniture can't be applied —
@@ -261,19 +312,37 @@ def _render_rich(
 		# page numbers are auto-furniture, not caller content.
 		if header or footer or watermark or letterhead:
 			notes.append("furniture (header/footer/watermark) applies only to PDF output")
-		payload = doc_body.encode("utf-8")
+		doc_title = frappe.utils.escape_html(title) if title else "Document"
+		payload = (
+			f"<!doctype html><html><head><meta charset='utf-8'>"
+			f"<title>{doc_title}</title><style>{component_css()}</style></head>"
+			f"<body>{body}</body></html>"
+		).encode()
 	else:
+		# letterhead resolved HERE (notes is in scope): default to the site's
+		# default Letter Head when the caller named none, read-perm checked, images
+		# neutralised. render_pdf receives already-safe HTML.
+		lh_header, lh_footer, lh_note = resolve_letterhead(
+			letterhead if isinstance(letterhead, str) else None
+		)
+		if lh_note:
+			notes.append(lh_note)
+		styled_body = f"<style>{component_css()}</style>{body}"
 		pdf_bytes = render_pdf(
-			doc_body,
+			styled_body,
 			page_size=page_size,
 			orientation=orientation,
 			margins_mm=margins_mm,
 			header_html=header,
 			footer_html=footer,
 			watermark=watermark,
-			letterhead=(letterhead if isinstance(letterhead, str) else None),
+			letterhead_header=lh_header,
+			letterhead_footer=lh_footer,
 			page_numbers=page_numbers,
-			timeout=_RENDER_TIMEOUT_S,
+			# The 25s bound covers the whole render; subtract the pre-render work
+			# (md→HTML, sanitize, splice) already spent so the total stays under
+			# the plugin's 30s call_tool abort.
+			timeout=max(5, _RENDER_TIMEOUT_S - int(time.monotonic() - start)),
 		)
 		payload = pdf_bytes if fmt == "pdf" else _pdf_to_png(pdf_bytes)
 
@@ -285,27 +354,95 @@ def _render_rich(
 	return env
 
 
+def _guard_chart_rows(charts: list) -> None:
+	"""Bound total rows across all charts (chart COUNT is capped separately). A
+	non-sized ``rows`` is skipped here and rejected per-chart later in the splice."""
+	total = 0
+	for spec in charts:
+		rows = spec.get("rows", []) if isinstance(spec, Mapping) else []
+		try:
+			total += len(rows)
+		except TypeError:
+			continue
+	if total > _MAX_TOTAL_CHART_ROWS:
+		raise InvalidArgumentError(
+			f"charts contain {total} rows, exceeding the {_MAX_TOTAL_CHART_ROWS}-row limit"
+		)
+
+
+def _visible_text(html_fragment: str) -> str:
+	"""Return the visible text of an HTML fragment (tags stripped, whitespace
+	collapsed) for the emptiness guard — so a childless-tag skeleton reads as
+	empty. Cheap regex strip; this is an emptiness heuristic, not a sanitizer."""
+	return re.sub(r"<[^>]+>", "", html_fragment or "").strip()
+
+
+def _short_err(exc: Exception) -> str:
+	"""A short, log-safe one-liner for a failure's telemetry ``detail`` field."""
+	return f"{type(exc).__name__}: {exc}"[:200]
+
+
 def _splice_charts(body: str, charts: list, notes: list[str]) -> str:
 	"""Replace each ``{{chart:N}}`` token with ``css_bar`` output for ``charts[N]``.
 
 	Runs AFTER ``sanitize_rich`` so the tool-generated bar markup (which carries a
-	single clamped ``width:N%`` inline style) is trusted and not stripped. A spec
-	whose token is absent, or a token with no matching spec, is reported in
-	``notes`` — never a crash. Orphan tokens are removed so no literal ``{{chart:N}}``
-	junk survives into the document."""
+	single clamped ``width:N%`` inline style) is trusted and not stripped.
+
+	The splice is TREE-AWARE, not a blind string replace: it walks TEXT NODES only
+	(via a bounded ``html.parser`` parse of the already-sanitized, capped body), so
+	a token that happens to sit inside an attribute value (e.g. an ``href``) or
+	inside a ``<pre>``/``<code>`` block (documenting the syntax) is left alone
+	rather than corrupting the tag or replacing a literal example. Each chart's
+	markup is rendered once and inserted by index, so a token appearing inside a
+	chart's own text can never trigger a second substitution.
+
+	Degrades, never crashes: a malformed ``rows`` value, a spec whose token is
+	absent, and a token with no matching spec are each reported in ``notes``. Orphan
+	tokens are removed so no literal ``{{chart:N}}`` junk survives."""
+	if not charts and _CHART_TOKEN_RE.search(body) is None:
+		return body
+
+	# Render each spec ONCE (or degrade to a note), keyed by index.
+	rendered: dict[int, str] = {}
 	for i, spec in enumerate(charts):
-		token = f"{{{{chart:{i}}}}}"
-		if token not in body:
-			notes.append(f"chart {i} was provided but its {token} placeholder was not found in the content")
-			continue
 		rows = spec.get("rows", []) if isinstance(spec, Mapping) else []
-		body = body.replace(token, css_bar(rows))
-	leftovers = sorted({int(m.group(1)) for m in _CHART_TOKEN_RE.finditer(body)})
-	for idx in leftovers:
-		notes.append(f"placeholder {{{{chart:{idx}}}}} has no matching chart spec")
-	if leftovers:
-		body = _CHART_TOKEN_RE.sub("", body)
-	return body
+		try:
+			rendered[i] = css_bar(rows)
+		except Exception:
+			notes.append(f"chart {i} was provided but its rows were malformed and could not be rendered")
+			rendered[i] = ""  # its token is removed rather than left as junk
+
+	from bs4 import BeautifulSoup
+
+	soup = BeautifulSoup(body, "html.parser")
+	seen: set[int] = set()
+	for node in list(soup.find_all(string=_CHART_TOKEN_RE)):
+		if node.find_parent(["pre", "code"]):
+			continue  # a token shown as a literal code example stays literal
+		text = str(node)
+		pieces: list[str] = []
+		last = 0
+		for m in _CHART_TOKEN_RE.finditer(text):
+			idx = int(m.group(1))
+			seen.add(idx)
+			pieces.append(_html.escape(text[last : m.start()]))
+			pieces.append(rendered.get(idx, ""))  # unknown index → drop token
+			last = m.end()
+		pieces.append(_html.escape(text[last:]))
+		fragment = BeautifulSoup("".join(pieces), "html.parser")
+		for child in list(fragment.contents):
+			node.insert_before(child)
+		node.extract()
+
+	for i in rendered:
+		if i not in seen:
+			notes.append(
+				f"chart {i} was provided but its {{{{chart:{i}}}}} placeholder was not found in the content"
+			)
+	for idx in sorted(seen):
+		if idx not in rendered:
+			notes.append(f"placeholder {{{{chart:{idx}}}}} has no matching chart spec")
+	return str(soup)
 
 
 def _outcome_for(exc: Exception) -> str:


### PR DESCRIPTION
## What

Slice 1 of the rich-PDF engine. `export_document` becomes **dual-path**: the existing plain path is **byte-preserved** (legacy calls unchanged), and a new **opt-in branded rich path** renders letterhead / header / footer / watermark + styled tables / KPI / callout / RAG components + CSS bar charts, hard-timed on wkhtmltopdf.

New modules under `jarvis/tools/_export/document/`: `sanitizer.py` (nh3 airtight sanitize), `theme.py` (branded stylesheet), `graphics.py` (locale number formatting + CSS bar/KPI/RAG builders), `furniture.py` (direct `wkhtmltopdf` subprocess with a real hard timeout + letterhead resolution), and the dual-path orchestrator in `export_document.py`.

## Reviewed — full `/review-loop` (3 verification rounds)

A 10-lane back-gate panel + 2 focused re-verification rounds ran on this diff. It found and this PR fixes a **CRITICAL DoS**, a **letterhead SSRF**, and a spread of correctness / resilience / observability gaps:

- **DoS (Critical):** the sanitizer's BeautifulSoup/html5lib pre-pass was quadratic on nesting depth (a 200k in-cap fragment parsed ~82s, past the render timeout). Collapsed to nh3's native `clean_content_tags` (single Rust pass, ~2.3s worst case — 36×), which also removed a double-parser mXSS surface and a code duplication.
- **SSRF (High):** the letterhead was folded in without a real sanitizer, so an `<img>`-only regex missed `<link>`/`<style>url()`/`<image>`/`<iframe>`/no-quote/`//host`/etc. → server-side fetch. Added `sanitize_letterhead()` = nh3 with `url_schemes={"data"}` + `url_relative="deny"` (data-only images, `<a>` dropped) after inlining same-site logos to permission-checked base64. Verified against a 55-payload bypass corpus. SVG logos are refused (raster only — an inlined SVG is an opaque active-content blob).
- **Correctness/resilience/observability:** malformed chart rows → per-chart note (was an uncaught 500 + no telemetry); a boundary catch-all logs + records + re-raises clean for any unexpected error; blank-PDF guard checks visible text (not raw markup); rich HTML is a full doctype/charset document; `{{chart:N}}` splice is tree-aware (skips `pre`/`code` + attributes, no double-substitution); header temp-leak, exec-`OSError`, `%PDF-` magic check, `log_error` on infra failures, page-geometry validation, stderr-out-of-user-message; telemetry gains `rich`/`detail`; degrade notes surface **deterministically** on the chat card (not model prose).

## Tests

**282 pure unit tests + 15 subtests green** (3 site-gated skips), ruff clean. The `sanitize_rich`/`sanitize_letterhead` security cores are adversarially probed and the decompose set is mutation-covered; the plain path has a byte-shape regression test. **The real wkhtmltopdf render is mocked (no binary in CI)** — see the smoke gate below.

## Rollout

Deploy order (one-way): **app → plugin (#75) → persona (#195).** App-first is required (`registry.dispatch` filters unknown kwargs, so a plugin-first deploy silently ships plain PDFs). Old-app+new-plugin and new-app+old-plugin both coexist safely. **Zero new pip deps** (nh3/beautifulsoup4/pdfkit are already frappe-pinned).

## ⚠️ Pending pre-merge gates — NOT yet run (need a bench / Frappe Cloud)

- **Bench test-gate:** `bench --site <test-site> run-tests --app jarvis --module jarvis.tests.test_export_document` (+ the `test_export_document_*` siblings) — runs the `FrappeTestCase` + site-gated tests too.
- **FC real-render smoke — the TRUE gate:** nothing has actually rendered a rich PDF (unit tests mock wkhtmltopdf). On `frappe-claw-test`, call `export_document(theme=True, letterhead=…, header=…, charts=…)` and eyeball the PDF (+ confirm the notes caption renders — the SPA needs a rebuild).

## Scope / deferred

Slice 1 = branded PDFs via letterhead + CSS + CSS bar charts. **Slice 2** (deferred, behind a matplotlib-on-FC spike) = image charts, QR, embedded raster logos beyond letterhead. **Surfaced by the Approach lane (not blocking):** the plain path still rolls its own `save_file` (a known deferred migration in `_export/envelope.py`) and retains a latent `</b>`-title slash crash + the pre-existing plain-path html5lib DoS — both untouched here to keep the byte-preserved contract.

**DO NOT MERGE — navin merges** (after the gates above, in app → plugin → persona order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
