### PR TITLE
fix: disable perpetual inventory for tier2a test company

### DIFF
--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -415,7 +415,12 @@ def _ensure_company(name: str, abbr: str) -> None:
 	# Skip default chart-of-accounts / warehouse / tax-template creation -
 	# this fixture only needs a Company row for permission checks, not a
 	# functioning ledger, and CI sites may be missing the fixtures those
-	# hooks depend on (e.g. Warehouse Type "Transit").
+	# hooks depend on (e.g. Warehouse Type "Transit"). For the same reason,
+	# perpetual inventory is off: with no chart of accounts there is no
+	# stock/inventory Account to point a warehouse at, and ERPNext's
+	# Warehouse.validate() now requires one (an Account on the warehouse or
+	# a default_inventory_account on the company) whenever the company has
+	# enable_perpetual_inventory set, which defaults to 1.
 	frappe.local.flags.ignore_chart_of_accounts = True
 	try:
 		frappe.get_doc(
@@ -425,6 +430,7 @@ def _ensure_company(name: str, abbr: str) -> None:
 				"abbr": abbr,
 				"default_currency": "INR",
 				"country": "India",
+				"enable_perpetual_inventory": 0,
 			}
 		).insert(ignore_permissions=True)
 	finally:


### PR DESCRIPTION
## Summary

Fixes CI red on every fresh jarvis run since today: `test_tier2a_erpnext_reads.py` fails
in `setUpClass` because ERPNext's `Warehouse.validate()` now requires an inventory
account whenever the company has perpetual inventory enabled, which the test's minimal
company fixture never set up. This disables perpetual inventory on that fixture company,
matching its existing intent (a Company row for permission checks only, no chart of
accounts, no functioning ledger).

## Pre-merge checklist

> These repos are private on the GitHub **Free** plan, so branch protection is
> not enforced — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — jarvis is public, hosted Actions is the gate; these tests need a
      live bench site so they cannot be run locally, this PR's hosted `tests` check is the
      evidence
- [x] Branch is up to date with `develop` (base branch for this repo)
- [x] New/changed behavior has tests (existing tests, seeding-only fix, no new test needed)
- [x] I self-reviewed the diff

<details>
<summary>Root-cause evidence</summary>

- The scheduled "CI (from scratch)" run on `main` (run id 31926989611, started 2026-08-16
  04:35 UTC) fails with the identical error. All `develop` CI runs on 2026-08-15 were
  green with no relevant jarvis commits in between, so this is environment drift, not a
  jarvis diff.
- `.github/workflows/ci.yml` runs tests inside `ghcr.io/aerele-rnd/jarvis-ci-base:v16`,
  which bakes a built bench with ERPNext version-16 rather than pinning a sha; the
  from-scratch nightly rebuilds ERPNext from the `version-16` branch HEAD, so upstream
  version-16 changes surface once the base image or nightly build picks them up.
- Upstream `frappe/erpnext` on `version-16` added the validation:
  - `0dfa54f8` "fix(stock): validate warehouse accounts when used" (2026-08-11)
  - `fce0eb15` "fix(stock): validate new warehouse inventory account after naming"
    (2026-08-11), which moved the check from `before_insert` into `validate()` so it now
    runs on `Warehouse.insert()` whenever `is_new()` and the company has
    `enable_perpetual_inventory` set (default `1` on Company).
- `erpnext/stock/doctype/warehouse/warehouse.py::validate_inventory_account` calls
  `get_warehouse_account`, which raises exactly the observed message,
  "Please set Account in Warehouse {0} or Default Inventory Account in Company {1}",
  when neither the warehouse nor the company has an account configured — true for this
  test's fixture company, which deliberately skips chart-of-accounts seeding.
- I did not verify the exact date the base image was rebuilt to pick up those two
  commits; the correlation is the nightly run on `main` failing identically today plus
  the commits landing on `version-16` before today's run.

</details>
