### PR TITLE
fix(tests): unbreak CI against upstream Warehouse inventory-account validation

### DIFF
--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -466,6 +466,13 @@ def _ensure_warehouse(name: str, company: str) -> str:
 			"company": company,
 		}
 	)
+	# Upstream erpnext develop now validates a new Warehouse against the
+	# company's inventory account (Warehouse.validate_inventory_account ->
+	# get_warehouse_account), and this fixture's companies deliberately skip
+	# chart-of-accounts creation - they exist for permission checks, not a
+	# ledger. Use the escape flag upstream provides for exactly this case
+	# (harmless on older erpnext that predates the validation).
+	doc.flags.ignore_inventory_account_validation = True
 	doc.insert(ignore_permissions=True)
 	return doc.name
 


### PR DESCRIPTION
## Summary

Unbreaks CI for every open PR. ERPNext develop (installed fresh by CI) added `Warehouse.validate_inventory_account`, which throws when a new Warehouse's company has no default inventory account. The tier2a permission fixture deliberately creates companies without a chart of accounts, so every shard containing `test_tier2a_erpnext_reads` now fails in `setUpClass` ("Please set Account in Warehouse ... or Default Inventory Account in Company ..."). Confirmed on two unrelated PRs (#886, #888) with identical signatures; the same heads were green yesterday.

One-line fix: the fixture sets the escape flag upstream provides for exactly this case (`flags.ignore_inventory_account_validation`), harmless on older ERPNext. Verified locally with the fixture-exercising class.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `develop`**
- [x] New/changed behavior has tests (this IS a test fix)
- [x] I self-reviewed the diff
