### PR TITLE
Render ReconnectRequired as a stop card with a Reconnect CTA (S4b frontend)

### DIFF
--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -192,13 +192,16 @@ export function provisioningPhase({ answered = false, tenantStatus = "" } = {}) 
  *
  * @param {{answered?: boolean, reason?: string, detail?: string}} [last]
  * @returns {{observed: boolean, state: string, label: string, detail: string,
- *   stop: boolean, paged?: boolean, editable?: boolean, title?: string}} `stop`
- *   means waiting cannot resolve this, so the loop must end rather than run to
- *   a ceiling whose copy invites a retry that cannot help. `paged` distinguishes
- *   "support has already been notified, do nothing" from "nobody was notified,
- *   you must act". `editable` (only ever true alongside `stop`) means the fix
- *   is a config change, so the caller must return to the form, not stay on a
- *   dead-end screen.
+ *   stop: boolean, paged?: boolean, editable?: boolean, reconnect?: boolean,
+ *   title?: string}} `stop` means waiting cannot resolve this, so the loop must
+ *   end rather than run to a ceiling whose copy invites a retry that cannot help.
+ *   `paged` distinguishes "support has already been notified, do nothing" from
+ *   "nobody was notified, you must act". `editable` (only ever true alongside
+ *   `stop`) means the fix is a config change, so the caller must return to the
+ *   form, not stay on a dead-end screen. `reconnect` (also only alongside `stop`,
+ *   slice 4b) means the fix is a subscription reconnect, so the caller shows a
+ *   Reconnect CTA into the wizard's reconnect entry rather than a support-only
+ *   dead end.
  */
 export function readinessPhase({ answered = false, reason = "", detail = "" } = {}) {
 	const say = String(detail || "").trim();
@@ -295,6 +298,27 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				detail: say,
 				stop: true,
 				editable: true,
+			};
+		case "reconnect_required":
+			// Slice 4b (C10b): an aged onboarding OAuth strand whose subscription
+			// connect never landed. account.py maps admin's chat_readiness ==
+			// "ReconnectRequired" onto this reason. Waiting cannot heal it - it cannot
+			// self-heal without the customer reconnecting - so it STOPS the wait like
+			// the paged/suspended/moved verdicts above, rather than falling into the
+			// default "coming online" spinner it used to (bucketed as
+			// container_provisioning). But the fix is a reconnect the customer CAN take
+			// here, so `reconnect: true` marks that for the caller, the action analogue
+			// of llm_rejected's `editable`. Not `paged`: nobody was notified, the
+			// customer acts. Admin's own reason (`say`) is the body, never reworded.
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				kind: PHASE_KIND.NONE,
+				label: "Your AI subscription needs reconnecting",
+				detail: say,
+				stop: true,
+				reconnect: true,
+				title: "Your AI subscription needs reconnecting",
 			};
 		default:
 			// A reason this build does not know about gets the neutral line. It

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -131,6 +131,7 @@ test("readiness: only a paged repair claims support was already notified", () =>
 		"subscription_suspended",
 		"site_replaced",
 		"llm_rejected",
+		"reconnect_required",
 		"container_provisioning",
 		"readiness_unconfirmed",
 		"unmapped",
@@ -167,8 +168,45 @@ test("readiness: only llm_rejected is editable - the three blocked stop cases ar
 		"authority_repair_required",
 		"subscription_suspended",
 		"site_replaced",
+		"reconnect_required",
 	]) {
 		assert.notEqual(readinessPhase({ answered: true, reason }).editable, true, reason);
+	}
+});
+
+// Slice 4b (C10b): an aged onboarding subscription-connect strand. account.py maps
+// admin's chat_readiness == "ReconnectRequired" onto is_ready_for_chat's own
+// "reconnect_required" reason. Waiting cannot heal it (the connect never landed and
+// cannot self-heal), so it STOPS the wait like the suspended/moved verdicts - but the
+// fix is a reconnect the customer takes here, so it carries `reconnect: true` (the
+// action analogue of llm_rejected's `editable`), never the "coming online" spinner.
+test("readiness: reconnect_required stops the wait, offers reconnect, quotes admin verbatim, never claims progress", () => {
+	const detail =
+		"Your AI subscription needs reconnecting. Open Jarvis Settings and reconnect your provider to finish.";
+	const p = readinessPhase({ answered: true, reason: "reconnect_required", detail });
+	assert.equal(p.stop, true);
+	assert.equal(p.reconnect, true);
+	assert.notEqual(p.editable, true); // not the return-to-form case
+	assert.notEqual(p.paged, true); // nobody was notified; the CUSTOMER acts
+	assert.equal(p.kind, PHASE_KIND.NONE);
+	assert.equal(p.detail, detail); // admin's own sentence, never reworded
+	assert.notEqual(p.state, PHASE_STATE.ACTIVE);
+	assert.ok(p.title);
+	assert.doesNotMatch(p.label, /coming online|getting ready|applying|keep (waiting|checking)/i);
+});
+
+test("readiness: only reconnect_required carries the reconnect flag", () => {
+	assert.equal(readinessPhase({ answered: true, reason: "reconnect_required" }).reconnect, true);
+	for (const reason of [
+		"authority_repair_required",
+		"subscription_suspended",
+		"site_replaced",
+		"llm_rejected",
+		"container_provisioning",
+		"readiness_unconfirmed",
+		"unmapped",
+	]) {
+		assert.notEqual(readinessPhase({ answered: true, reason }).reconnect, true, reason);
 	}
 });
 
@@ -237,6 +275,7 @@ test("readiness: no branch ever claims setup is finishing on its own", () => {
 		"subscription_suspended",
 		"site_replaced",
 		"llm_rejected",
+		"reconnect_required",
 		"unmapped",
 	];
 	for (const reason of reasons) {

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -68,6 +68,10 @@ vi.mock("@/onboarding/readiness.js", () => ({
 	forgetReady: forgetReadySpy,
 	hasReconnectIntent: () => false,
 	landingStep: ({ resumedStep }) => resumedStep,
+	// Slice 4b: the reconnect STOP card's CTA routes here. The real constant is
+	// "/jarvis/onboarding?reconnect=1"; pin the same literal so the click assertion
+	// below is exercising the true destination, not a placeholder.
+	RECONNECT_INTENT_URL: "/jarvis/onboarding?reconnect=1",
 }));
 
 vi.mock("@/theme", () => ({
@@ -893,6 +897,95 @@ describe("jarvis#727 an unverifiable model has a way out, not only a Retry", () 
 			expect(labels(w)).not.toContain("Use a different model");
 			w.unmount();
 		}
+	});
+
+	// Slice 4b (C10b): admin's chat_readiness == "ReconnectRequired" reaches the
+	// connect wait as is_ready_for_chat's "reconnect_required" reason. It must be a
+	// TERMINAL STOP with a Reconnect action - the honest headline + admin's own
+	// reason + a primary Reconnect CTA - and NEVER the endless "bringing your setup
+	// online" spinner it used to fall into (bucketed as container_provisioning).
+	describe("ReconnectRequired is a terminal STOP, not the endless spinner", () => {
+		const RECONNECT_REASON =
+			"Your AI subscription needs reconnecting. Open Jarvis Settings and reconnect your provider to finish.";
+
+		it("renders the reconnect STOP card with admin's reason, not the spinner", async () => {
+			const w = await mountConnect();
+			w.vm.connectModelChangeOffered = true; // a stale offer from an earlier attempt
+			w.vm.noteReadiness({
+				answered: true,
+				reason: "reconnect_required",
+				detail: RECONNECT_REASON,
+			});
+			await flushPromises();
+
+			expect(w.vm.state.connectPhase).toBe("reconnect");
+			// Not the working/finishing spinner, and not the support-only blocked card.
+			expect(w.vm.state.connectPhase).not.toBe("working");
+			expect(w.vm.state.connectPhase).not.toBe("blocked");
+			expect(w.vm.state.connectTitle).toMatch(/reconnect/i);
+			expect(w.vm.state.connectMessage).toBe(RECONNECT_REASON); // admin's own sentence, verbatim
+			expect(w.vm.connectModelChangeOffered).toBe(false); // a model change fixes nothing here
+			expect(labels(w)).toContain("Reconnect");
+			expect(labels(w)).not.toContain("Use a different model");
+			w.unmount();
+		});
+
+		it("the Reconnect CTA routes to the reconnect wizard entry", async () => {
+			const realLocation = window.location;
+			// jsdom's real window.location.assign is non-configurable; replace the
+			// whole object (same idiom as BillingPage.spec.js).
+			Object.defineProperty(window, "location", {
+				configurable: true,
+				value: { ...window.location, assign: vi.fn() },
+			});
+			try {
+				const w = await mountConnect();
+				w.vm.noteReadiness({
+					answered: true,
+					reason: "reconnect_required",
+					detail: RECONNECT_REASON,
+				});
+				await flushPromises();
+
+				const reconnectBtn = w
+					.findAll("button")
+					.find((b) => (b.attributes("label") || b.text()) === "Reconnect");
+				expect(reconnectBtn).toBeTruthy();
+				await reconnectBtn.trigger("click");
+
+				expect(window.location.assign).toHaveBeenCalledWith(
+					"/jarvis/onboarding?reconnect=1"
+				);
+				w.unmount();
+			} finally {
+				Object.defineProperty(window, "location", {
+					configurable: true,
+					value: realLocation,
+				});
+			}
+		});
+
+		it("stops polling the instant ReconnectRequired is seen (no 40-tick spinner)", async () => {
+			api.isReadyForChat.mockResolvedValue({
+				ready: false,
+				reason: "reconnect_required",
+				detail: RECONNECT_REASON,
+			});
+			vi.useFakeTimers();
+			const w = await mountConnect();
+			api.isReadyForChat.mockClear();
+
+			// READY-but-not-chat-ready starts waitForChatReadiness; its first poll sees
+			// the stop verdict and the loop must end rather than count down 40 ticks.
+			w.vm.onTerminal(readyChatBlockedStatus);
+			await flushPromises();
+			await vi.advanceTimersByTimeAsync(40 * 3000);
+			await flushPromises();
+
+			expect(api.isReadyForChat.mock.calls.length).toBe(1);
+			expect(w.vm.state.connectPhase).toBe("reconnect");
+			w.unmount();
+		});
 	});
 
 	it("an operation-level failure offers the change beside Retry, not instead of it", async () => {

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -63,15 +63,14 @@ const forgetReadySpy = vi.hoisted(() => vi.fn());
 // These specs assert the CONNECT step, so there is never a reconnect intent here:
 // the landing helpers are stubbed to "no intent, keep the resumed step". Mocked
 // explicitly rather than via importOriginal so the real module's graph (api.js ->
-// frappe-ui) stays out of this file.
+// frappe-ui) stays out of this file. Slice 4b note: the reconnect STOP card's CTA
+// no longer hard-navs anywhere (it resets local state back to the connect form in
+// place), so RECONNECT_INTENT_URL is deliberately NOT re-exported here - the view
+// no longer imports it, and the loop it caused is pinned by the form-assertion test.
 vi.mock("@/onboarding/readiness.js", () => ({
 	forgetReady: forgetReadySpy,
 	hasReconnectIntent: () => false,
 	landingStep: ({ resumedStep }) => resumedStep,
-	// Slice 4b: the reconnect STOP card's CTA routes here. The real constant is
-	// "/jarvis/onboarding?reconnect=1"; pin the same literal so the click assertion
-	// below is exercising the true destination, not a placeholder.
-	RECONNECT_INTENT_URL: "/jarvis/onboarding?reconnect=1",
 }));
 
 vi.mock("@/theme", () => ({
@@ -930,39 +929,51 @@ describe("jarvis#727 an unverifiable model has a way out, not only a Retry", () 
 			w.unmount();
 		});
 
-		it("the Reconnect CTA routes to the reconnect wizard entry", async () => {
-			const realLocation = window.location;
-			// jsdom's real window.location.assign is non-configurable; replace the
-			// whole object (same idiom as BillingPage.spec.js).
-			Object.defineProperty(window, "location", {
-				configurable: true,
-				value: { ...window.location, assign: vi.fn() },
+		// The review BLOCKER. The old CTA hard-navved to RECONNECT_INTENT_URL, but every
+		// customer who can see this card is already terminal (they reached PAID ->
+		// PROVISIONING -> connect), and the REAL landingStep DROPS the reconnect intent
+		// when terminal - so the nav resumed straight back to "connect", restarted the
+		// wait, re-observed reconnect_required and re-rendered THIS same card: an
+		// infinite no-op loop. The shipped test missed it because it mocked landingStep
+		// down to ({resumedStep}) => resumedStep. The CTA now re-opens the editable
+		// connect FORM in place so the customer can actually re-run the connect; this
+		// pins that it reaches the form, never the same stop card. Reverting the CTA fix
+		// (back to window.location.assign) reds this: state stays on the reconnect card.
+		it("the Reconnect CTA re-opens the connect FORM in place, never re-renders the stop card", async () => {
+			// Reach the stop card through the real wait, exactly as production does: a
+			// subscription apply completes but chat_readiness is false, the wait polls,
+			// and its first poll observes reconnect_required. finishing is true here, so
+			// the card shows and the form's "Start chatting" footer (v-if !finishing) is
+			// absent.
+			api.isReadyForChat.mockResolvedValue({
+				ready: false,
+				reason: "reconnect_required",
+				detail: RECONNECT_REASON,
 			});
-			try {
-				const w = await mountConnect();
-				w.vm.noteReadiness({
-					answered: true,
-					reason: "reconnect_required",
-					detail: RECONNECT_REASON,
-				});
-				await flushPromises();
+			vi.useFakeTimers();
+			const w = await mountConnect();
+			api.isReadyForChat.mockClear();
 
-				const reconnectBtn = w
-					.findAll("button")
-					.find((b) => (b.attributes("label") || b.text()) === "Reconnect");
-				expect(reconnectBtn).toBeTruthy();
-				await reconnectBtn.trigger("click");
+			w.vm.onTerminal(readyChatBlockedStatus);
+			await flushPromises();
+			expect(w.vm.state.connectPhase).toBe("reconnect");
+			expect(w.vm.state.finishing).toBe(true);
+			expect(labels(w)).not.toContain("Start chatting");
 
-				expect(window.location.assign).toHaveBeenCalledWith(
-					"/jarvis/onboarding?reconnect=1"
-				);
-				w.unmount();
-			} finally {
-				Object.defineProperty(window, "location", {
-					configurable: true,
-					value: realLocation,
-				});
-			}
+			const reconnectBtn = w
+				.findAll("button")
+				.find((b) => (b.attributes("label") || b.text()) === "Reconnect");
+			expect(reconnectBtn).toBeTruthy();
+			await reconnectBtn.trigger("click");
+			await flushPromises();
+
+			// The FORM, not the card. connectPhase back to "" un-renders the stop card;
+			// finishing=false re-shows the editor and its "Start chatting" footer. Both
+			// staying put would BE the loop, which is what the old hard-nav produced.
+			expect(w.vm.state.finishing).toBe(false);
+			expect(w.vm.state.connectPhase).toBe("");
+			expect(labels(w)).toContain("Start chatting");
+			w.unmount();
 		});
 
 		it("stops polling the instant ReconnectRequired is seen (no 40-tick spinner)", async () => {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1825,12 +1825,7 @@ import {
 	connectHeadline,
 	phaseProgress,
 } from "@/onboarding/waitPhases.js";
-import {
-	forgetReady,
-	hasReconnectIntent,
-	landingStep,
-	RECONNECT_INTENT_URL,
-} from "@/onboarding/readiness.js";
+import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
@@ -3757,25 +3752,28 @@ const setupTitle = computed(() =>
 // `blocked` panel, and a different model provably cannot resolve any of them.
 const connectModelChangeOffered = ref(false);
 
-// The escape hatch itself: back to the Connect form with the customer's own
-// choice still in it. The editor is v-show'd, never v-if'd, so its state - the
-// provider, the model, a passing key probe - is still mounted and simply
-// becomes visible again; there is nothing to re-fetch or re-fill.
+// Return to the editable Connect form in place, with the customer's own choice
+// still in it. The editor is v-show'd, never v-if'd, so its state - the provider,
+// the model, a passing key probe - is still mounted and simply becomes visible
+// again; there is nothing to re-fetch or re-fill. `blockReason` is the inline
+// banner above the editor that says why they are back and what to do next.
 //
-// It has to be in-wizard. Settings is the obvious home for "add another model",
-// but it is unreachable from here by construction: `llm_pool_provisioning`,
+// Shared by both in-wizard escapes out of the wait: the jarvis#727 model-change
+// (chooseDifferentModel) and slice 4b's Reconnect CTA (reconnectFromStall). It has
+// to be in-wizard for both. Settings is the obvious home for "reconnect / add a
+// model", but it is unreachable from here by construction: `llm_pool_provisioning`,
 // `llm_provisioning` and `readiness_unconfirmed` are all in readiness.js's
 // NOT_ONBOARDED_REASONS, so AppShell's `showGate` renders the full-screen
 // onboarding poster over every route except this one. A "go to Settings" link
 // would put the customer back on this wizard by a longer path.
 //
-// The three forgets are load-bearing, not tidying. The customer is about to
-// submit a DIFFERENT configuration, so this attempt's idempotency key must not
-// survive: admin dedupes on it and would hand back the very operation that
-// never converged. currentOpId must go with it, or retryConnect would re-follow
-// that dead operation instead of saving the new config (enterSaveRefusal, the
-// one terminal that can be reached next, never clears it).
-function chooseDifferentModel() {
+// The forgets are load-bearing, not tidying. The customer is about to submit a
+// FRESH configuration, so this attempt's idempotency key must not survive: admin
+// dedupes on it and would hand back the very operation that never converged.
+// currentOpId must go with it, or retryConnect would re-follow that dead operation
+// instead of saving the new config (enterSaveRefusal, the one terminal that can be
+// reached next, never clears it).
+function returnToConnectForm(blockReason) {
 	stopRetryCountdown();
 	forgetIdem();
 	opStore.forget();
@@ -3791,14 +3789,20 @@ function chooseDifferentModel() {
 	state.connectSupportOffered = false;
 	state.retryAfter = 0;
 	connectModelChangeOffered.value = false;
-	// Says what was observed - the wait ended without setup finishing - and never
-	// that the chosen model is broken, which nothing here established.
-	state.connectBlockReason =
-		"Setup didn't finish with the AI connection you chose, and waiting hasn't cleared it. Pick a different model and start again.";
+	state.connectBlockReason = blockReason;
 	// Any wait still sleeping between polls stops on its next tick (both loops
 	// re-check this), so a late ceiling cannot yank the customer back out of the
 	// form they were just returned to.
 	state.finishing = false;
+}
+
+// The jarvis#727 escape. The block reason says what was observed - the wait ended
+// without setup finishing - and never that the chosen model is broken, which
+// nothing here established.
+function chooseDifferentModel() {
+	returnToConnectForm(
+		"Setup didn't finish with the AI connection you chose, and waiting hasn't cleared it. Pick a different model and start again."
+	);
 }
 
 function ensureController() {
@@ -4228,12 +4232,11 @@ async function waitForChatReadiness() {
 	readinessSeen.value = null;
 	for (let i = 0; i < CHAT_READY_ATTEMPTS; i++) {
 		if (navigated.value) return;
-		// A blocked verdict is terminal for this wait (admin paged a human): stop
-		// polling rather than counting down to a ceiling whose exhaustion copy
-		// would invite the retry this state must not offer.
-		if (state.connectPhase === "blocked") return;
-		// The customer took the jarvis#727 escape back to the editor. This wait is
-		// about the configuration they just left behind, so its ceiling must not
+		// No pre-tick "blocked" guard: a blocked verdict is set by noteReadiness only
+		// alongside stage.stop, and this loop already returns on stage.stop in the same
+		// tick that observes it (below), so it can never sleep and re-enter here blocked.
+		// The customer took the jarvis#727 / slice-4b escape back to the editor. This
+		// wait is about the configuration they just left behind, so its ceiling must not
 		// fire and pull them back out of the form.
 		if (!state.finishing) return;
 		// The memoized verdict is what the router guard will read moments from now, so
@@ -4496,8 +4499,9 @@ async function followLegacyReadiness(result) {
 	readinessSeen.value = null;
 	for (let i = 0; i < attempts; i++) {
 		if (navigated.value) return;
-		if (state.connectPhase === "blocked") return;
-		// The jarvis#727 escape took the customer back to the editor - see
+		// No pre-tick "blocked" guard - see waitForChatReadiness: stage.stop below ends
+		// the wait in the same tick a blocked/stop verdict is observed.
+		// The jarvis#727 / slice-4b escape took the customer back to the editor - see
 		// waitForChatReadiness for why this wait must not outlive it.
 		if (!state.finishing) return;
 		let r = null;
@@ -4642,15 +4646,22 @@ function reloadConnect() {
 	window.location.reload();
 }
 
-// Slice 4b (C10b): the Reconnect CTA on the stalled-subscription STOP card. Same
-// destination as ChatView's own reconnect banner (goReconnect): a hard nav into the
-// wizard's reconnect entry with the intent flag, so a returning customer lands on
-// the code-confirm reconnect path rather than resuming the stalled onboarding. The
-// flag is load-bearing - see RECONNECT_INTENT_URL - and a hard assign (not the
-// in-wizard startReconnect) is used so identity/eligibility is captured fresh on the
-// Details step rather than assumed from a signup that never fully landed.
+// Slice 4b (C10b): the Reconnect CTA on the stalled-subscription STOP card. It
+// re-opens the editable Connect form IN PLACE so the customer can re-run the
+// subscription connect right here - success navigates to chat, a genuine re-strand
+// brings this card back, a too-old host fails clean (S1). It deliberately does NOT
+// hard-nav to RECONNECT_INTENT_URL (the old behaviour): every customer who can see
+// this card is already terminal (they reached PAID -> PROVISIONING -> connect), and
+// landingStep DROPS the reconnect intent when terminal, so that nav resumed straight
+// back to "connect", restarted the wait, re-observed reconnect_required and
+// re-rendered this exact card - an infinite no-op loop. The fix is local to this
+// step; landingStep's terminal guard is correct for the ChatView site_replaced flow
+// and is left alone. Same fresh-attempt reset as chooseDifferentModel (returnToConnectForm
+// drops the stalled operation so the next Start is genuinely new).
 function reconnectFromStall() {
-	window.location.assign(RECONNECT_INTENT_URL);
+	returnToConnectForm(
+		"Reconnect your AI subscription below, then start again to finish setting up."
+	);
 }
 
 // (An unreferenced `editConnect` lived here: a partial return-to-the-form that

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1568,6 +1568,48 @@
 											</p>
 										</div>
 									</template>
+									<!-- Slice 4b (C10b): the subscription-connect strand that
+										 waiting cannot heal. Unlike the paged authority-repair block
+										 above, the customer CAN act - so this is a real STOP with a
+										 primary Reconnect CTA into the wizard's reconnect entry, and
+										 admin's own reason as the body. Never the "bringing your setup
+										 online" spinner it used to fall into. -->
+									<template v-else-if="state.connectPhase === 'reconnect'">
+										<div class="ob-head">
+											<h1>
+												{{
+													state.connectTitle ||
+													"Your AI subscription needs reconnecting"
+												}}
+											</h1>
+											<p>
+												Waiting won't finish this one. Reconnect your AI
+												subscription to pick up where setup left off.
+											</p>
+										</div>
+										<div class="mx-auto mt-4 max-w-[560px]">
+											<Banner
+												v-if="state.connectMessage"
+												type="warning"
+												:message="state.connectMessage"
+											/>
+											<div class="mt-4 flex flex-wrap justify-center gap-2">
+												<Button
+													variant="solid"
+													label="Reconnect"
+													@click="reconnectFromStall"
+												/>
+											</div>
+											<p
+												class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
+											>
+												Not sure why this happened?
+												<button class="ob-link" @click="openSupport">
+													Contact support
+												</button>
+											</p>
+										</div>
+									</template>
 									<!-- A non-ready terminal (retry / superseded / support) or a
 										 deadline timeout: stay HERE with a real recovery action.
 										 Never a "continue anyway" jump into a chat that cannot yet
@@ -1783,7 +1825,12 @@ import {
 	connectHeadline,
 	phaseProgress,
 } from "@/onboarding/waitPhases.js";
-import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
+import {
+	forgetReady,
+	hasReconnectIntent,
+	landingStep,
+	RECONNECT_INTENT_URL,
+} from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
@@ -4117,6 +4164,21 @@ function noteReadiness(o) {
 			"That AI configuration was rejected. Edit your connection and try again.";
 		return stage;
 	}
+	// Slice 4b (C10b): a subscription-connect strand that waiting cannot heal, but
+	// one the customer CAN act on - unlike the paged/suspended/moved blocks below.
+	// Its own phase so the panel carries a primary Reconnect CTA into the wizard's
+	// reconnect entry instead of the support-only dead end, mirroring how `editable`
+	// routes llm_rejected back to the form. `state.finishing` stays true so this card
+	// (which lives under the setup screen's v-show) renders in place of the spinner.
+	// Admin's own sentence (stage.detail) is the body; no model change, because a
+	// rejected model is not the problem here.
+	if (stage.reconnect) {
+		state.connectPhase = "reconnect";
+		state.connectTitle = stage.title || "Your AI subscription needs reconnecting";
+		state.connectMessage = stage.detail;
+		connectModelChangeOffered.value = false;
+		return stage;
+	}
 	// A verdict that waiting cannot resolve is terminal for this wait: stop
 	// polling rather than counting down to a ceiling whose copy invites a retry
 	// that cannot help. Covers a paged authority repair (do nothing, we called
@@ -4201,10 +4263,13 @@ async function waitForChatReadiness() {
 			detail: r && r.detail,
 		});
 		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
-		// jarvis#757: stage.editable already returned to the form (noteReadiness
-		// set state.finishing = false) - stop polling THIS tick rather than
-		// sleeping once more on a config the customer may already be re-editing.
-		if (state.connectPhase === "blocked" || stage.editable) return;
+		// Any verdict waiting cannot resolve is terminal for this wait (stage.stop):
+		// the paged/suspended/moved blocks, jarvis#757's editable llm_rejected (which
+		// already returned to the form), and slice 4b's reconnect stop. Stop polling
+		// THIS tick rather than sleeping once more on a state that will not change on
+		// its own. `stage.stop` is exactly this set, so it replaces the older
+		// connectPhase/editable pair without altering their behaviour.
+		if (stage.stop) return;
 		await _sleep(CHAT_READY_INTERVAL_MS);
 	}
 	state.finishing = true;
@@ -4457,8 +4522,9 @@ async function followLegacyReadiness(result) {
 			detail: r && r.detail,
 		});
 		if (stage.kind !== PHASE_KIND.NONE) sawNamedSubject = true;
-		// jarvis#757: see the matching comment in waitForChatReadiness.
-		if (state.connectPhase === "blocked" || stage.editable) return;
+		// See waitForChatReadiness: stage.stop is every verdict waiting cannot resolve
+		// (blocked stops, jarvis#757's editable, slice 4b's reconnect).
+		if (stage.stop) return;
 		if (i < attempts - 1) await _sleep(LEGACY_READY_INTERVAL_MS);
 	}
 	state.finishing = true;
@@ -4574,6 +4640,17 @@ function retryConnect() {
 // that re-follows whatever operation now owns the truth.
 function reloadConnect() {
 	window.location.reload();
+}
+
+// Slice 4b (C10b): the Reconnect CTA on the stalled-subscription STOP card. Same
+// destination as ChatView's own reconnect banner (goReconnect): a hard nav into the
+// wizard's reconnect entry with the intent flag, so a returning customer lands on
+// the code-confirm reconnect path rather than resuming the stalled onboarding. The
+// flag is load-bearing - see RECONNECT_INTENT_URL - and a hard assign (not the
+// in-wizard startReconnect) is used so identity/eligibility is captured fresh on the
+// Details step rather than assumed from a signup that never fully landed.
+function reconnectFromStall() {
+	window.location.assign(RECONNECT_INTENT_URL);
 }
 
 // (An unreferenced `editConnect` lived here: a partial return-to-the-form that

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -482,9 +482,12 @@ def _admin_chat_gate() -> dict:
 	Returns ``{"ready": True, "reason": None}`` UNLESS admin is reachable AND
 	reports a ``chat_readiness`` != ``"Ready"``, in which case
 	``{"ready": False, "reason": <code>, "detail": <admin's sentence>}``. The
-	code is ``"subscription_suspended"`` for ``Suspended`` (renew) and
-	``"container_provisioning"`` otherwise (wait) - kept distinct so a suspended
-	customer isn't told to wait for a container that won't come back.
+	code is ``"authority_repair_required"`` for ``SupportRequired`` (a paged
+	incident, no self-service action), ``"reconnect_required"`` for
+	``ReconnectRequired`` (slice 4b: reconnect the provider), ``"subscription_suspended"``
+	for ``Suspended`` (renew) and ``"container_provisioning"`` otherwise (wait) -
+	each kept distinct so a customer isn't told to wait for a container that won't
+	come back, or to keep spinning on a strand that only a reconnect can clear.
 
 	- v1-tolerance: an ABSENT ``chat_readiness`` key (v1 admin, or a v2 that
 	  doesn't surface it) means the control plane has no opinion → allow.
@@ -552,6 +555,20 @@ def _admin_chat_gate() -> dict:
 			return {
 				"ready": False,
 				"reason": "authority_repair_required",
+				"billing_notice": {},
+				"detail": conn.get("chat_readiness_reason") or "",
+			}
+		# Slice 4b (C10b): an aged onboarding OAuth strand whose subscription connect
+		# never landed. The customer cannot self-heal by waiting - only by reconnecting
+		# their provider - so this MUST NOT bucket into "container_provisioning" below
+		# (which the onboarding UI renders as the endless "bringing your setup online"
+		# spinner). Its own reason surfaces the terminal-STOP-with-Reconnect card;
+		# admin owns the wording via ``chat_readiness_reason``. billing_notice stays
+		# empty like SupportRequired: the action is a reconnect, not a billing banner.
+		if conn["chat_readiness"] == "ReconnectRequired":
+			return {
+				"ready": False,
+				"reason": "reconnect_required",
 				"billing_notice": {},
 				"detail": conn.get("chat_readiness_reason") or "",
 			}

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -317,6 +317,44 @@ class TestAdminChatGate(FrappeTestCase):
 				{"ready": False, "reason": "subscription_suspended", "detail": "", "billing_notice": {}},
 			)
 
+	def test_reconnect_required_is_distinct_from_provisioning(self):
+		"""Slice 4b (C10b): an aged onboarding OAuth strand whose subscription
+		connect never landed must NOT read as "still starting up" (which spins the
+		onboarding UI forever). Its own reason drives the terminal-STOP-with-Reconnect
+		card; admin owns the sentence."""
+		reason = (
+			"Your AI subscription needs reconnecting. Open Jarvis Settings and "
+			"reconnect your provider to finish."
+		)
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "ReconnectRequired",
+				"chat_readiness_reason": reason,
+			},
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{
+					"ready": False,
+					"reason": "reconnect_required",
+					"detail": reason,
+					"billing_notice": {},
+				},
+			)
+
+	def test_reconnect_required_without_reason_still_classifies(self):
+		"""Older admin sends the state with no sentence — the code must still be the
+		reconnect one; the SPA supplies its own fallback copy."""
+		with patch.object(
+			admin_client, "get_connection", return_value={"chat_readiness": "ReconnectRequired"}
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{"ready": False, "reason": "reconnect_required", "detail": "", "billing_notice": {}},
+			)
+
 	def test_allows_when_admin_ready(self):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
 			self.assertEqual(


### PR DESCRIPTION
**Coordinated with admin-v2 PR #362 (S4b backend)**, which adds the `ReconnectRequired` chat-readiness state. API shape unchanged, so this can land alongside; an old admin never emits the state.

## What
An aged C10b onboarding OAuth strand used to bucket into `_admin_chat_gate`'s `container_provisioning` reason → the wizard's endless "bringing your setup online" spinner. Now:
- **`account.py` `_admin_chat_gate`**: map admin's `chat_readiness == "ReconnectRequired"` → a distinct `"reconnect_required"` reason (carrying `chat_readiness_reason` as `detail`).
- **`waitPhases.readinessPhase`**: a `reconnect_required` case → `stop:true, reconnect:true` (the action-analogue of `llm_rejected`'s `editable`), admin's reason as the body, never reworded.
- **`OnboardingView.vue`**: a stop card (honest headline + reason + primary **Reconnect** CTA) that stops the poll immediately; the CTA re-opens the connect **form in place** (shared `returnToConnectForm` reset) so the customer re-runs the connect — no nav, no loop. Both poll loops now terminate on any `stage.stop`.

## Review-loop (3 lanes) + fix
Correctness verified the poll-stop refactor is exactly equivalent to the old `blocked||editable` termination and the `ReconnectRequired → reconnect_required → reconnect` contract is consistent across all hops. **A blocker was caught and fixed:** the first CTA hard-navved to `RECONNECT_INTENT_URL`, which `landingStep` drops-when-terminal → an infinite loop back to the same card; the test had masked it with a `landingStep` mock. Now the CTA resets to the form in place, pinned by a test driving the *real* flow (mutation-verified).

## Tests
`waitPhases.test.js` 45, `OnboardingView.connect.spec.js` 84 (incl. the real-flow CTA test), full vitest 1328; `test_account.py` +2 (bench). prettier@2.7.1 + eslint clean.

## Out of scope (noted)
Established-workspace `ChatView` still shows its generic not-ready notice for this state — a separate surface, not the onboarding wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)