### PR TITLE
feat: role-based prompt trimming — profile pick at session create

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1234,6 +1234,29 @@ def post_push_learned_skills(learned_skills: list[dict]) -> dict:
 	)
 
 
+def post_push_role_profiles(role_profiles: list[dict]) -> dict:
+	"""POST the tenant's computed role-based agent profiles to admin -> fleet ->
+	container render (role-profile-agents design, spec §7).
+
+	``role_profiles`` is the list built by
+	``jarvis.chat.role_profiles.needed_profiles`` (each
+	``{slug, skills, tools_allow}`` where ``slug`` is ``role-<set-keys>``). The
+	fleet-agent renders one agent entry per profile into ``agents.list[]`` (the
+	main agent, ``agent_id=None``, is never included here and always renders
+	regardless). An empty list is a valid "no role-based profiles needed"
+	reconcile - every enabled user maps to main.
+
+	Raises:
+		AdminAuthError, AdminUnreachableError, AdminValidationError
+		(rate-limit shares the rotate-secret bucket).
+	"""
+	return _post(
+		path=_m("api.tenant.push_role_profiles"),
+		body={"role_profiles": role_profiles},
+		timeout_s=180,
+	)
+
+
 def post_agent_run(run_id: str, agent_id: str, session_key: str, message: str, timeout_s: int = 600) -> dict:
 	"""Dispatch ONE marketplace-agent delegate turn: bench → admin → fleet → the
 	customer's container (Phase 2C run relay).

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -858,11 +858,13 @@ def set_star(conversation: str, starred: str | int | bool) -> dict:
 	return {"ok": True, "data": {"starred": on}}
 
 
+import re
 import time
 import uuid
 
 from frappe import _
 
+from jarvis.chat import role_profiles
 from jarvis.chat.agent_client import AgentSession
 from jarvis.chat.policy import validate_can_send
 
@@ -2995,6 +2997,30 @@ def enqueue_continuation(conversation: str, receipt: str, *, failed: bool = Fals
 	return _enqueue_turn(conversation, scaffold.format(receipt=safe), hidden=True, exempt_overload=True)
 
 
+def scrub(value: str) -> str:
+	"""Key-safe label segment for a self-addressed profile-agent session key
+	(the ``agent:<agent-id>:<key>`` self-addressing contract,
+	agent_scheduler.py:795-815): lowercase, collapse any run of characters
+	outside ``[a-z0-9]`` to a single "-", and strip leading/trailing "-"."""
+	collapsed = re.sub(r"[^a-z0-9]+", "-", (value or "").lower())
+	return collapsed.strip("-")
+
+
+def _pushed_profile_slugs(settings) -> set[str]:
+	"""Slugs present in the last-pushed role-profiles snapshot
+	(``Jarvis Settings.role_profiles_pushed``, the
+	``jarvis.chat.role_profiles.needed_profiles`` output J2 stamped there).
+	Empty, missing (schema not migrated yet), or unparseable input returns an
+	empty set, which correctly routes every profile pick to the legacy path -
+	never self-address an agent that may not actually be rendered."""
+	raw = getattr(settings, "role_profiles_pushed", None)
+	try:
+		pushed = frappe.parse_json(raw) if raw else []
+	except Exception:
+		return set()
+	return {p.get("slug") for p in (pushed or []) if isinstance(p, dict) and p.get("slug")}
+
+
 def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 	"""Create an agent session for `user`, persist the Chat Session row,
 	and return the session_key. Caller is responsible for storing it on the
@@ -3005,18 +3031,44 @@ def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 	connection (turn_handler.handle_chat_send) so the first turn pays ONE
 	handshake, off the browser-blocking path. The ``sess=None`` one-shot
 	branch remains for callers without a pooled connection.
+
+	Flag-gated profile pick (``Jarvis Settings.enable_role_profiles``, off by
+	default): when on, and ``role_profiles.resolve_profile(user)`` resolves
+	to a role-based agent whose slug is already present in the last-pushed
+	role-profiles snapshot, that agent is addressed directly via the
+	self-addressing session-key contract (agent_scheduler.py:795-815 -
+	``agent:<agent-id>:<key>``; sessions are lazily created, no
+	``sessions.create`` RPC needed), skipping ``create_session`` entirely.
+	Off, or no matching rendered profile, falls through to exactly today's
+	path. Either way the Chat Session row records which profile was picked
+	(main/full when none) in the same insert - the observability hook for
+	this pick (spec §9).
 	"""
-	if sess is not None:
+	settings = frappe.get_single("Jarvis Settings")
+
+	choice = None
+	# getattr, not settings.enable_role_profiles: a site whose code deployed
+	# ahead of its reload-doctype/migrate has no such attribute yet, and a
+	# missing flag must degrade to exactly today's path, never crash session
+	# creation.
+	if getattr(settings, "enable_role_profiles", 0):
+		resolved = role_profiles.resolve_profile(user)
+		if resolved.agent_id is not None and resolved.agent_id in _pushed_profile_slugs(settings):
+			choice = resolved
+		# else: resolved to main (agent_id is None), or resolved to a profile
+		# not yet rendered on the agent side - fall through to the legacy
+		# path rather than self-address an agent that may not exist there.
+
+	if choice is not None:
+		session_key = f"agent:{choice.agent_id}:jarvis-chat-{scrub(user)}-{int(time.time() * 1000)}"
+	elif sess is not None:
 		# Reuse the caller's already-connected (pooled) session — no extra
 		# connect/handshake. Label includes a timestamp because agent
 		# deduplicates sessions by label and rejects collisions.
 		session_key = sess.create_session(label=f"jarvis-chat-{user}-{int(time.time() * 1000)}")
 	else:
-		settings_check = frappe.get_single("Jarvis Settings")
-		gateway_url = (
-			(settings_check.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
-		)
-		gateway_token = settings_check.get_password("agent_token")
+		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
+		gateway_token = settings.get_password("agent_token")
 		if not gateway_url or not gateway_token:
 			frappe.throw(_("agent is not configured"))
 
@@ -3025,8 +3077,6 @@ def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 			session_key = one_shot.create_session(label=f"jarvis-chat-{user}-{int(time.time() * 1000)}")
 		finally:
 			one_shot.close()
-
-	settings = frappe.get_single("Jarvis Settings")
 
 	# C2 stretch (2026-06-16 review): snapshot the bench's current
 	# chat_device_id into the Jarvis Chat Session row. On every
@@ -3037,13 +3087,18 @@ def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 	# a leaked-session-key replay attack to "until the next re-pair."
 	current_device_id = (settings.chat_device_id or "").strip()
 
-	# Insert the Chat Session row (plugin's sessionKey → user lookup table)
+	# Insert the Chat Session row (plugin's sessionKey → user lookup table).
+	# profile_* fields record the pick above (main/full when there was none).
 	frappe.get_doc(
 		{
 			"doctype": "Jarvis Chat Session",
 			"session_key": session_key,
 			"user": user,
 			"chat_device_id": current_device_id,
+			"profile_agent_id": choice.agent_id if choice else "",
+			"profile_tier": choice.tier if choice else "full",
+			"profile_sets": ",".join(choice.set_keys) if choice else "",
+			"profile_n_skills": len(choice.skills or ()) if choice else 0,
 		}
 	).insert(ignore_permissions=True)
 	frappe.db.commit()

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -858,7 +858,6 @@ def set_star(conversation: str, starred: str | int | bool) -> dict:
 	return {"ok": True, "data": {"starred": on}}
 
 
-import re
 import time
 import uuid
 
@@ -866,6 +865,7 @@ from frappe import _
 
 from jarvis.chat import role_profiles
 from jarvis.chat.agent_client import AgentSession
+from jarvis.chat.entities import scrub
 from jarvis.chat.policy import validate_can_send
 
 _INFLIGHT_FRESH_SECONDS = 180
@@ -2997,15 +2997,6 @@ def enqueue_continuation(conversation: str, receipt: str, *, failed: bool = Fals
 	return _enqueue_turn(conversation, scaffold.format(receipt=safe), hidden=True, exempt_overload=True)
 
 
-def scrub(value: str) -> str:
-	"""Key-safe label segment for a self-addressed profile-agent session key
-	(the ``agent:<agent-id>:<key>`` self-addressing contract,
-	agent_scheduler.py:795-815): lowercase, collapse any run of characters
-	outside ``[a-z0-9]`` to a single "-", and strip leading/trailing "-"."""
-	collapsed = re.sub(r"[^a-z0-9]+", "-", (value or "").lower())
-	return collapsed.strip("-")
-
-
 def _pushed_profile_slugs(settings) -> set[str]:
 	"""Slugs present in the last-pushed role-profiles snapshot
 	(``Jarvis Settings.role_profiles_pushed``, the
@@ -3021,7 +3012,7 @@ def _pushed_profile_slugs(settings) -> set[str]:
 	return {p.get("slug") for p in (pushed or []) if isinstance(p, dict) and p.get("slug")}
 
 
-def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
+def _ensure_session_key(user: str, sess: AgentSession | None = None, *, profile: bool = False) -> str:
 	"""Create an agent session for `user`, persist the Chat Session row,
 	and return the session_key. Caller is responsible for storing it on the
 	parent Conversation row.
@@ -3032,26 +3023,42 @@ def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 	handshake, off the browser-blocking path. The ``sess=None`` one-shot
 	branch remains for callers without a pooled connection.
 
-	Flag-gated profile pick (``Jarvis Settings.enable_role_profiles``, off by
-	default): when on, and ``role_profiles.resolve_profile(user)`` resolves
-	to a role-based agent whose slug is already present in the last-pushed
-	role-profiles snapshot, that agent is addressed directly via the
-	self-addressing session-key contract (agent_scheduler.py:795-815 -
+	``profile`` (keyword-only, default False - legacy behavior): opts a
+	caller into the flag-gated profile pick below. Only the two deferred
+	session-creation points the 2026-07 latency plan moved OUT of
+	``send_message`` - ``turn_handler.handle_chat_send`` and
+	``prepare.run_prepare`` - pass ``profile=True``, because those are the
+	only call sites reached exclusively for a genuine first turn of
+	interactive chat: a macro/scheduled turn (``jarvis.chat.macros`` via
+	``api._enqueue_turn``) always mints its session eagerly, synchronously,
+	before either worker path runs, so this function is never reached a
+	second time for it. Spec §8 - non-chat sessions always run `full` - and
+	macros.py's dispatch try/except relies on this function still THROWING
+	on a misconfigured agent (see the config-presence guard below), so the
+	default must stay the exact legacy path, not silently swallow a
+	misconfiguration into a hung run.
+
+	When ``profile`` is True and ``Jarvis Settings.enable_role_profiles`` is
+	on, and ``role_profiles.resolve_profile(user)`` resolves to a role-based
+	agent whose slug is already present in the last-pushed role-profiles
+	snapshot, that agent is addressed directly via the self-addressing
+	session-key contract (agent_scheduler.py:795-815 -
 	``agent:<agent-id>:<key>``; sessions are lazily created, no
 	``sessions.create`` RPC needed), skipping ``create_session`` entirely.
-	Off, or no matching rendered profile, falls through to exactly today's
-	path. Either way the Chat Session row records which profile was picked
-	(main/full when none) in the same insert - the observability hook for
-	this pick (spec §9).
+	Otherwise (``profile=False``, flag off, or no matching rendered profile)
+	falls through to exactly today's path. Either way the Chat Session row
+	records which profile was picked (main/full when none) in the same
+	insert - the observability hook for this pick (spec §9).
 	"""
 	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 
 	choice = None
 	# getattr, not settings.enable_role_profiles: a site whose code deployed
 	# ahead of its reload-doctype/migrate has no such attribute yet, and a
 	# missing flag must degrade to exactly today's path, never crash session
 	# creation.
-	if getattr(settings, "enable_role_profiles", 0):
+	if profile and getattr(settings, "enable_role_profiles", 0):
 		resolved = role_profiles.resolve_profile(user)
 		if resolved.agent_id is not None and resolved.agent_id in _pushed_profile_slugs(settings):
 			choice = resolved
@@ -3060,14 +3067,26 @@ def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 		# path rather than self-address an agent that may not exist there.
 
 	if choice is not None:
-		session_key = f"agent:{choice.agent_id}:jarvis-chat-{scrub(user)}-{int(time.time() * 1000)}"
+		# Keep the legacy config-presence guard even though this path skips
+		# create_session/sessions.create entirely: a totally unconfigured
+		# agent must still fail fast here, not silently mint a key nothing
+		# can ever connect to.
+		gateway_token = settings.get_password("agent_token")
+		if not gateway_url or not gateway_token:
+			frappe.throw(_("agent is not configured"))
+		# ":dashboard:" is the SAME chat-session namespace marker the gateway
+		# stamps into every legacy-minted key - session_lifecycle.py's
+		# _CHAT_NAMESPACE_MARKER (the idle/orphan reaper) and
+		# session_pin_sweep.py's _is_agent_main_key both key off it.
+		# Omitting it here would make this session permanently invisible to
+		# both sweeps, leaking a live gateway session on every profile pick.
+		session_key = f"agent:{choice.agent_id}:dashboard:jarvis-chat-{scrub(user)}-{int(time.time() * 1000)}"
 	elif sess is not None:
 		# Reuse the caller's already-connected (pooled) session — no extra
 		# connect/handshake. Label includes a timestamp because agent
 		# deduplicates sessions by label and rejects collisions.
 		session_key = sess.create_session(label=f"jarvis-chat-{user}-{int(time.time() * 1000)}")
 	else:
-		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 		gateway_token = settings.get_password("agent_token")
 		if not gateway_url or not gateway_token:
 			frappe.throw(_("agent is not configured"))
@@ -3099,6 +3118,7 @@ def _ensure_session_key(user: str, sess: AgentSession | None = None) -> str:
 			"profile_tier": choice.tier if choice else "full",
 			"profile_sets": ",".join(choice.set_keys) if choice else "",
 			"profile_n_skills": len(choice.skills or ()) if choice else 0,
+			"profile_n_tools": (choice.n_tools or 0) if choice else 0,
 		}
 	).insert(ignore_permissions=True)
 	frappe.db.commit()

--- a/jarvis/chat/prepare.py
+++ b/jarvis/chat/prepare.py
@@ -165,7 +165,11 @@ def run_prepare(run_id: str, relay_target_id: str | None = None) -> dict:
 				# callback can fire (the plugin sessionKey->user moat, jarvis/api.py:55).
 				from jarvis.chat.api import _ensure_session_key
 
-				session_key = _ensure_session_key(chat_user, sess=sess)
+				# profile=True: the pump pipeline's deferred creation point,
+				# reached only for a genuine first turn of interactive chat -
+				# a macro/scheduled turn always mints its session eagerly at
+				# api._enqueue_turn, before this worker path ever runs.
+				session_key = _ensure_session_key(chat_user, sess=sess, profile=True)
 				frappe.db.set_value(CONV, conversation, "session_key", session_key)
 				frappe.db.commit()
 			# (#23) model patch (stateful — agent remembers across turns). A None ref

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -11,11 +11,14 @@ Two independent axes, both curated data (spec §5), never runtime discovery:
   (``SKILL_SETS``), plus the always-on ``SHARED_CORE_SKILLS``, a user's
   profile includes.
 
-:func:`resolve_profile` is the only entry point other modules should call.
-It never raises: any failure anywhere falls back to the main agent (spec §3
-fallback rule 3), so a bad role lookup can never leave a user with a broken
-or over-trimmed agent. The mapping itself is fixed data reviewed with the
-app, not something resolved against a live agent container.
+:func:`resolve_profile` is the per-user resolver other modules call to decide
+one user's profile; it never raises: any failure anywhere falls back to the
+main agent (spec §3 fallback rule 3), so a bad role lookup can never leave a
+user with a broken or over-trimmed agent. The mapping itself is fixed data
+reviewed with the app, not something resolved against a live agent
+container. :func:`sync_role_profiles` is the tenant-wide push boundary: it
+computes :func:`needed_profiles` and reconciles it to admin, and is likewise
+built to never raise into a caller.
 """
 
 from __future__ import annotations
@@ -23,6 +26,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import frappe
+
+_SETTINGS = "Jarvis Settings"
 
 # --- Axis 1: tool tier -----------------------------------------------------
 
@@ -318,4 +323,102 @@ def needed_profiles() -> list[dict]:
 			"skills": list(choice.skills or ()),
 			"tools_allow": list(tools_allow),
 		}
-	return list(profiles.values())
+	# Sorted by slug: frappe.get_all("User", ...) above carries no order_by, so
+	# it follows Frappe's default `modified desc` and reorders on any User
+	# save. Without a deterministic output order here, sync_role_profiles's
+	# snapshot comparison (a plain `==` against the last-pushed list) would
+	# read an unchanged profile SET as "changed" on ordering alone, forcing a
+	# spurious re-push.
+	return sorted(profiles.values(), key=lambda p: p["slug"])
+
+
+# --- Push to admin ---------------------------------------------------------
+
+
+def sync_role_profiles(force: bool = False) -> dict:
+	"""Compute :func:`needed_profiles` and push it to admin only when the set
+	actually changed since the last push (or ``force=True``).
+
+	This is the fallback-discipline boundary for the whole sync (unlike
+	``needed_profiles`` itself, which is deliberately left unwrapped so a real
+	``frappe.get_all`` failure is visible rather than silently read as "no
+	profiles needed"). Everything downstream of that computation - the
+	snapshot comparison, the admin push, the settings stamp - is wrapped in
+	one try/except: a push failure (admin down, rejected, a bug in this
+	function) must never raise into a caller such as a ``User.on_update`` save
+	or the daily scheduler tick. Logged via ``frappe.log_error`` the way other
+	``admin_client`` callers in this app do.
+
+	Returns ``{"pushed": bool, "profiles": [...]}``. ``profiles`` is always
+	the freshly computed desired state (even on failure, as long as
+	``needed_profiles`` itself succeeded), so a caller can inspect what SHOULD
+	be live without having to re-derive it.
+	"""
+	profiles: list[dict] = []
+	try:
+		profiles = needed_profiles()
+
+		last_raw = frappe.db.get_single_value(_SETTINGS, "role_profiles_pushed", cache=False)
+		last = frappe.parse_json(last_raw) if last_raw else None
+		if not force and last == profiles:
+			return {"pushed": False, "profiles": profiles}
+
+		from jarvis import admin_client
+
+		admin_client.post_push_role_profiles(role_profiles=profiles)
+
+		frappe.db.set_value(
+			_SETTINGS,
+			_SETTINGS,
+			{
+				"role_profiles_pushed": frappe.as_json(profiles),
+				"role_profiles_pushed_at": frappe.utils.now(),
+			},
+		)
+		return {"pushed": True, "profiles": profiles}
+	except Exception:
+		frappe.log_error(title="Jarvis: role-profiles push failed", message=frappe.get_traceback())
+		return {"pushed": False, "profiles": profiles}
+
+
+def enqueue_sync(after_commit: bool = True) -> bool:
+	"""Debounced queue of a role-profiles resync.
+
+	``after_commit`` defaults True: this is called from the ``User.on_update``
+	doc_event, and the enqueued job opens its own DB connection, so it must
+	not run before the role change that triggered it has actually committed -
+	the same reasoning as ``jarvis.chat.wiki_mirror.enqueue_sync``.
+
+	Suppressed under tests unless ``frappe.flags.jarvis_test_role_profiles_enqueue``
+	is set, also mirroring ``wiki_mirror``: ``frappe.enqueue`` runs its job
+	INLINE under ``frappe.flags.in_test``, so an un-suppressed enqueue here
+	would fire an unmocked admin push on every fixture user insert/update in
+	the test suite.
+
+	Swallows and logs enqueue failures (e.g. Redis down): this is reached from
+	a doc_event, which must never fail a save.
+
+	Returns whether a job was really queued.
+	"""
+	if frappe.flags.in_test and not frappe.flags.jarvis_test_role_profiles_enqueue:
+		return False
+	try:
+		frappe.enqueue(
+			"jarvis.chat.role_profiles.sync_role_profiles",
+			queue="short",
+			job_id="role-profiles-sync",
+			deduplicate=True,
+			enqueue_after_commit=bool(after_commit),
+		)
+		return True
+	except Exception:
+		frappe.log_error(title="Jarvis: role-profiles enqueue failed", message=frappe.get_traceback())
+		return False
+
+
+def on_user_update(doc, method: str | None = None) -> None:
+	"""doc_events hook (``User.on_update``): a role change may change which
+	role-based profile a user needs, so debounce-enqueue a resync. Thin and
+	cheap by design - ``enqueue_sync`` already swallows and logs its own
+	errors, so this never raises into the save path."""
+	enqueue_sync()

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -4,10 +4,10 @@ Spec: ``docs/superpowers/specs/2026-08-16-role-profile-agents-design.md``.
 
 Two independent axes, both curated data (spec §5), never runtime discovery:
 
-* **Tool tier** — the jarvis-plane role decides ``full`` (today's 94 tools)
+* **Tool tier**: the jarvis-plane role decides ``full`` (today's 94 tools)
   vs ``standard`` (68 tools; ``STANDARD_DROP_TOOLS`` is the 26-tool drop
   list, spec §3).
-* **Skill set** — ERPNext roles decide which of the 6 named skill sets
+* **Skill set**: ERPNext roles decide which of the 6 named skill sets
   (``SKILL_SETS``), plus the always-on ``SHARED_CORE_SKILLS``, a user's
   profile includes.
 
@@ -151,7 +151,7 @@ def standard_tools_allow() -> list[str]:
 
 # Everyone gets these regardless of ERPNext role (spec §3): all frappe-*,
 # all jarvis-*, and the domain-neutral erpnext/utility skills that no single
-# role set claims — including erpnext-bulk-transaction, which spans domains
+# role set claims, including erpnext-bulk-transaction, which spans domains
 # and so belongs to no one set.
 SHARED_CORE_SKILLS = frozenset(
 	{
@@ -244,7 +244,7 @@ class ProfileChoice:
 
 
 # agent_id=None means "use main": full tier, no trimming. Never "main" or
-# an "agent-" prefixed slug literal — those are reserved by the fleet side.
+# an "agent-" prefixed slug literal: those are reserved by the fleet side.
 _MAIN_PROFILE = ProfileChoice(agent_id=None, tier="full", set_keys=(), skills=None, n_tools=None)
 
 
@@ -255,6 +255,12 @@ def resolve_profile(user: str) -> ProfileChoice:
 	main agent (spec §3 fallback rule 3). There is no partial trim on error.
 	"""
 	try:
+		if not user:
+			# frappe.get_roles(None) resolves to the *session* user, not "no
+			# user" - that's a different, deterministic case here, not the
+			# fallback path.
+			return _MAIN_PROFILE
+
 		roles = set(frappe.get_roles(user))
 
 		if roles & FULL_TIER_ROLES:
@@ -308,6 +314,6 @@ def needed_profiles() -> list[dict]:
 		profiles[choice.agent_id] = {
 			"slug": choice.agent_id,
 			"skills": list(choice.skills or ()),
-			"tools_allow": tools_allow,
+			"tools_allow": list(tools_allow),
 		}
 	return list(profiles.values())

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -26,7 +26,7 @@ import frappe
 
 # --- Axis 1: tool tier -----------------------------------------------------
 
-FULL_TIER_ROLES = frozenset({"Jarvis Admin", "System Manager"})
+FULL_TIER_ROLES: frozenset[str] = frozenset({"Jarvis Admin", "System Manager"})
 
 # Verified drop list (26 tools, spec §3): app-learning tools (system-initiated
 # learning runs only, which always run `full`), session/infra tools (zero
@@ -35,7 +35,7 @@ FULL_TIER_ROLES = frozenset({"Jarvis Admin", "System Manager"})
 # persona forbids browser outright), web (no web feature in v1), and the
 # agent's builtin skill-authoring tool (jarvis has its own path via
 # jarvis__create_custom_skill). Copied verbatim from spec §3.
-STANDARD_DROP_TOOLS = frozenset(
+STANDARD_DROP_TOOLS: frozenset[str] = frozenset(
 	{
 		"cron",
 		"browser",
@@ -153,7 +153,7 @@ def standard_tools_allow() -> list[str]:
 # all jarvis-*, and the domain-neutral erpnext/utility skills that no single
 # role set claims, including erpnext-bulk-transaction, which spans domains
 # and so belongs to no one set.
-SHARED_CORE_SKILLS = frozenset(
+SHARED_CORE_SKILLS: frozenset[str] = frozenset(
 	{
 		"frappe-automation",
 		"frappe-contacts",
@@ -307,6 +307,8 @@ def needed_profiles() -> list[dict]:
 
 	tools_allow = standard_tools_allow()
 	profiles: dict[str, dict] = {}
+	# One frappe.get_roles call per user (via resolve_profile): N+1, but N is
+	# a tenant's enabled-user headcount, not a global scan, so this is fine.
 	for user in enabled_users:
 		choice = resolve_profile(user)
 		if choice.agent_id is None or choice.agent_id in profiles:

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -1,0 +1,313 @@
+"""Role -> agent-profile fixture and resolver.
+
+Spec: ``docs/superpowers/specs/2026-08-16-role-profile-agents-design.md``.
+
+Two independent axes, both curated data (spec §5), never runtime discovery:
+
+* **Tool tier** — the jarvis-plane role decides ``full`` (today's 94 tools)
+  vs ``standard`` (68 tools; ``STANDARD_DROP_TOOLS`` is the 26-tool drop
+  list, spec §3).
+* **Skill set** — ERPNext roles decide which of the 6 named skill sets
+  (``SKILL_SETS``), plus the always-on ``SHARED_CORE_SKILLS``, a user's
+  profile includes.
+
+:func:`resolve_profile` is the only entry point other modules should call.
+It never raises: any failure anywhere falls back to the main agent (spec §3
+fallback rule 3), so a bad role lookup can never leave a user with a broken
+or over-trimmed agent. The mapping itself is fixed data reviewed with the
+app, not something resolved against a live agent container.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import frappe
+
+# --- Axis 1: tool tier -----------------------------------------------------
+
+FULL_TIER_ROLES = frozenset({"Jarvis Admin", "System Manager"})
+
+# Verified drop list (26 tools, spec §3): app-learning tools (system-initiated
+# learning runs only, which always run `full`), session/infra tools (zero
+# references in live-tenant transcripts), file-editing tools (skills only
+# need `exec` + `read`), cron/browser (Frappe-side scheduling covers cron;
+# persona forbids browser outright), web (no web feature in v1), and the
+# agent's builtin skill-authoring tool (jarvis has its own path via
+# jarvis__create_custom_skill). Copied verbatim from spec §3.
+STANDARD_DROP_TOOLS = frozenset(
+	{
+		"cron",
+		"browser",
+		"jarvis__record_agent_run",
+		"jarvis__record_app_wiki",
+		"jarvis__read_app_source",
+		"jarvis__finish_app_learning_run",
+		"skill_workshop",
+		"sessions_spawn",
+		"sessions_send",
+		"sessions_list",
+		"sessions_history",
+		"sessions_yield",
+		"subagents",
+		"nodes",
+		"gateway",
+		"process",
+		"tts",
+		"edit",
+		"write",
+		"apply_patch",
+		"file_write",
+		"file_fetch",
+		"dir_fetch",
+		"dir_list",
+		"web_fetch",
+		"web_search",
+	}
+)
+
+# The full 94-tool universe minus STANDARD_DROP_TOOLS, hardcoded explicit and
+# sorted (spec §2 evidence capture: ~/.claude/jobs/bce488ac/tmp/postfix-cap.jsonl).
+# An allow list must be explicit here: deriving it at runtime from a live
+# agent container is not possible bench-side.
+_STANDARD_TOOLS_ALLOW = [
+	"agents_list",
+	"canvas",
+	"create_goal",
+	"exec",
+	"get_goal",
+	"image",
+	"jarvis__add_comment",
+	"jarvis__add_tag",
+	"jarvis__amend_doc",
+	"jarvis__apply_workflow_action",
+	"jarvis__assign_to",
+	"jarvis__attach_to_doc",
+	"jarvis__cancel_doc",
+	"jarvis__create_custom_skill",
+	"jarvis__create_dashboard",
+	"jarvis__create_dashboard_chart",
+	"jarvis__create_doc",
+	"jarvis__delete_doc",
+	"jarvis__describe_customizations",
+	"jarvis__download_pdf",
+	"jarvis__download_vcard",
+	"jarvis__export_document",
+	"jarvis__export_excel",
+	"jarvis__export_query",
+	"jarvis__find_skills",
+	"jarvis__follow_document",
+	"jarvis__get_creation_context",
+	"jarvis__get_doc",
+	"jarvis__get_file_pages",
+	"jarvis__get_linked_docs",
+	"jarvis__get_list",
+	"jarvis__get_naming_series_preview",
+	"jarvis__get_report_filters",
+	"jarvis__get_schema",
+	"jarvis__get_skill",
+	"jarvis__get_submitted_linked_docs",
+	"jarvis__get_workflow_transitions",
+	"jarvis__list_app_modules",
+	"jarvis__preview_doc",
+	"jarvis__preview_import",
+	"jarvis__query",
+	"jarvis__read_file",
+	"jarvis__read_wiki",
+	"jarvis__remove_tag",
+	"jarvis__report_pdf",
+	"jarvis__resolve_links",
+	"jarvis__run_import",
+	"jarvis__run_method",
+	"jarvis__run_report",
+	"jarvis__save_agent_dashboard",
+	"jarvis__save_dashboard",
+	"jarvis__send_email",
+	"jarvis__share_doc",
+	"jarvis__submit_doc",
+	"jarvis__summarize_dataset",
+	"jarvis__unassign_from",
+	"jarvis__unfollow_document",
+	"jarvis__unshare_doc",
+	"jarvis__update_comment",
+	"jarvis__update_doc",
+	"jarvis__update_wiki",
+	"memory_get",
+	"memory_search",
+	"message",
+	"pdf",
+	"read",
+	"session_status",
+	"update_goal",
+]
+
+
+def standard_tools_allow() -> list[str]:
+	"""The 68-tool allow list for the ``standard`` tier (spec §3)."""
+	return list(_STANDARD_TOOLS_ALLOW)
+
+
+# --- Axis 2: skill set -------------------------------------------------------
+
+# Everyone gets these regardless of ERPNext role (spec §3): all frappe-*,
+# all jarvis-*, and the domain-neutral erpnext/utility skills that no single
+# role set claims — including erpnext-bulk-transaction, which spans domains
+# and so belongs to no one set.
+SHARED_CORE_SKILLS = frozenset(
+	{
+		"frappe-automation",
+		"frappe-contacts",
+		"frappe-core",
+		"frappe-custom",
+		"frappe-desk",
+		"frappe-email",
+		"frappe-geo",
+		"frappe-integrations",
+		"frappe-printing",
+		"frappe-website",
+		"frappe-workflow",
+		"jarvis-app-analysis",
+		"jarvis-chat-blocks",
+		"jarvis-dashboards",
+		"jarvis-drafting",
+		"jarvis-rich-pdf",
+		"jarvis-site-customizations",
+		"jarvis-skill-writer",
+		"jarvis-triggers",
+		"jarvis-wiki",
+		"erpnext-setup",
+		"erpnext-utilities",
+		"erpnext-regional",
+		"erpnext-communication",
+		"erpnext-integrations",
+		"erpnext-bulk-transaction",
+		"ocr-data-entry",
+		"macro-merge",
+	}
+)
+
+# Skill-set additions on top of SHARED_CORE_SKILLS, spec §3 table.
+SKILL_SETS: dict[str, frozenset[str]] = {
+	"accounts": frozenset({"erpnext-accounts", "erpnext-assets", "india-compliance"}),
+	"sales": frozenset({"erpnext-selling", "erpnext-crm", "erpnext-support", "erpnext-telephony"}),
+	"purchase": frozenset({"erpnext-buying", "erpnext-subcontracting", "erpnext-edi"}),
+	"stock-mfg": frozenset(
+		{
+			"erpnext-stock",
+			"erpnext-manufacturing",
+			"erpnext-maintenance",
+			"erpnext-quality-management",
+		}
+	),
+	"hr": frozenset({"hrms-hr", "hrms-payroll"}),
+	"projects": frozenset({"erpnext-projects"}),
+}
+
+# Every triggering ERPNext role name, spec §3 table, mapped to its set key.
+ROLE_TO_SET: dict[str, str] = {
+	"Accounts User": "accounts",
+	"Accounts Manager": "accounts",
+	"Auditor": "accounts",
+	"Sales User": "sales",
+	"Sales Manager": "sales",
+	"Purchase User": "purchase",
+	"Purchase Manager": "purchase",
+	"Stock User": "stock-mfg",
+	"Stock Manager": "stock-mfg",
+	"Manufacturing User": "stock-mfg",
+	"Manufacturing Manager": "stock-mfg",
+	"Maintenance User": "stock-mfg",
+	"Maintenance Manager": "stock-mfg",
+	"Quality Manager": "stock-mfg",
+	"Delivery Manager": "stock-mfg",
+	"Delivery User": "stock-mfg",
+	"Fulfillment User": "stock-mfg",
+	"Item Manager": "stock-mfg",
+	"HR User": "hr",
+	"HR Manager": "hr",
+	"Employee": "hr",
+	"Projects User": "projects",
+	"Projects Manager": "projects",
+}
+
+
+# --- Resolver -----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProfileChoice:
+	agent_id: str | None
+	tier: str
+	set_keys: tuple[str, ...]
+	skills: tuple[str, ...] | None
+	n_tools: int | None
+
+
+# agent_id=None means "use main": full tier, no trimming. Never "main" or
+# an "agent-" prefixed slug literal — those are reserved by the fleet side.
+_MAIN_PROFILE = ProfileChoice(agent_id=None, tier="full", set_keys=(), skills=None, n_tools=None)
+
+
+def resolve_profile(user: str) -> ProfileChoice:
+	"""Resolve the chat-agent profile for ``user`` (spec §3 / §5).
+
+	Never raises: any exception anywhere in resolution falls back to the
+	main agent (spec §3 fallback rule 3). There is no partial trim on error.
+	"""
+	try:
+		roles = set(frappe.get_roles(user))
+
+		if roles & FULL_TIER_ROLES:
+			return _MAIN_PROFILE
+
+		matched = sorted({ROLE_TO_SET[role] for role in roles if role in ROLE_TO_SET})
+		if not matched:
+			# No mapped ERPNext role: conservatively keep full tier / all
+			# skills in v1 rather than guess-trim (spec §3 fallback rule 2).
+			return _MAIN_PROFILE
+
+		skills = tuple(sorted(SHARED_CORE_SKILLS.union(*(SKILL_SETS[key] for key in matched))))
+		agent_id = "role-" + "+".join(matched)
+		allow = standard_tools_allow()
+		return ProfileChoice(
+			agent_id=agent_id,
+			tier="standard",
+			set_keys=tuple(matched),
+			skills=skills,
+			n_tools=len(allow),
+		)
+	except Exception:
+		return _MAIN_PROFILE
+
+
+def needed_profiles() -> list[dict]:
+	"""Distinct role-based profiles across every enabled ``Jarvis User`` (spec §7).
+
+	Returns the render-ready shape fleet consumes for ``agents.list[]``.
+	Skills here are persona skills only; custom/learned skill slugs are
+	unioned in by fleet at apply time for every profile, main included
+	(spec §7), not here.
+	"""
+	user_names = frappe.get_all(
+		"Has Role",
+		filters={"role": "Jarvis User", "parenttype": "User"},
+		pluck="parent",
+	)
+	enabled_users = frappe.get_all(
+		"User",
+		filters={"name": ["in", user_names], "enabled": 1},
+		pluck="name",
+	)
+
+	tools_allow = standard_tools_allow()
+	profiles: dict[str, dict] = {}
+	for user in enabled_users:
+		choice = resolve_profile(user)
+		if choice.agent_id is None or choice.agent_id in profiles:
+			continue
+		profiles[choice.agent_id] = {
+			"slug": choice.agent_id,
+			"skills": list(choice.skills or ()),
+			"tools_allow": tools_allow,
+		}
+	return list(profiles.values())

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -339,15 +339,19 @@ def sync_role_profiles(force: bool = False) -> dict:
 	"""Compute :func:`needed_profiles` and push it to admin only when the set
 	actually changed since the last push (or ``force=True``).
 
-	This is the fallback-discipline boundary for the whole sync (unlike
-	``needed_profiles`` itself, which is deliberately left unwrapped so a real
-	``frappe.get_all`` failure is visible rather than silently read as "no
-	profiles needed"). Everything downstream of that computation - the
-	snapshot comparison, the admin push, the settings stamp - is wrapped in
-	one try/except: a push failure (admin down, rejected, a bug in this
-	function) must never raise into a caller such as a ``User.on_update`` save
-	or the daily scheduler tick. Logged via ``frappe.log_error`` the way other
-	``admin_client`` callers in this app do.
+	This is the fallback-discipline boundary for the whole sync. Unlike
+	``needed_profiles`` itself (which carries no internal guard of its own -
+	a real ``frappe.get_all`` failure there is meant to be visible to a
+	caller that invokes it directly, rather than silently read as "no
+	profiles needed"), this function DOES call ``needed_profiles`` inside its
+	own try/except below, alongside the snapshot comparison, the admin push,
+	and the settings stamp: a failure at ANY of those steps (compute
+	included) must never raise into a caller such as a ``User.on_update``
+	save or the daily scheduler tick. Logged via ``frappe.log_error`` the way
+	other ``admin_client`` callers in this app do, with the title naming
+	which phase failed (``compute`` vs ``push``) so an Error Log entry
+	doesn't need a traceback read to tell a broken role→set mapping apart
+	from an unreachable admin.
 
 	Returns ``{"pushed": bool, "profiles": [...]}``. ``profiles`` is always
 	the freshly computed desired state (even on failure, as long as
@@ -355,8 +359,10 @@ def sync_role_profiles(force: bool = False) -> dict:
 	be live without having to re-derive it.
 	"""
 	profiles: list[dict] = []
+	phase = "compute"
 	try:
 		profiles = needed_profiles()
+		phase = "push"
 
 		last_raw = frappe.db.get_single_value(_SETTINGS, "role_profiles_pushed", cache=False)
 		last = frappe.parse_json(last_raw) if last_raw else None
@@ -377,7 +383,7 @@ def sync_role_profiles(force: bool = False) -> dict:
 		)
 		return {"pushed": True, "profiles": profiles}
 	except Exception:
-		frappe.log_error(title="Jarvis: role-profiles push failed", message=frappe.get_traceback())
+		frappe.log_error(title=f"Jarvis: role-profiles {phase} failed", message=frappe.get_traceback())
 		return {"pushed": False, "profiles": profiles}
 
 

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1086,7 +1086,11 @@ def handle_chat_send(payload: dict) -> None:
 					from jarvis.chat.api import _ensure_session_key
 
 					t_sess = time.monotonic()
-					conv.session_key = _ensure_session_key(chat_user, sess=sess)
+					# profile=True: this deferred creation point is only ever
+					# reached for a genuine first turn of interactive chat - a
+					# macro/scheduled turn always mints its session eagerly at
+					# api._enqueue_turn, before this worker path runs at all.
+					conv.session_key = _ensure_session_key(chat_user, sess=sess, profile=True)
 					frappe.db.set_value(CONV, conversation_id, "session_key", conv.session_key)
 					frappe.db.commit()
 					session_create_ms = int((time.monotonic() - t_sess) * 1000)

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -445,6 +445,12 @@ scheduler_events = {
 		# admin past the retention window (the durable record lives in the admin's
 		# Jarvis Tenant Error). Keeps the local buffer small.
 		"jarvis.error_push.prune_pushed_client_errors",
+		# Role-profile agents reconcile backstop: the User.on_update hook
+		# enqueues a resync on every role change, but a debounced job can be
+		# dropped (Redis down, a worker restart mid-run). Daily catches the
+		# drift; short-circuits to a no-op push when the computed profile
+		# set already matches what admin last received.
+		"jarvis.chat.role_profiles.sync_role_profiles",
 	],
 	"weekly": [
 		# Wiki v2 health check: deterministic lint over Active pages
@@ -512,6 +518,15 @@ doc_events["Jarvis Wiki Page"] = {
 # save, inactive rules no-op).
 doc_events["Jarvis Personalise Question Rule"] = {
 	"on_update": "jarvis.learning.questions.on_rule_update",
+}
+
+# Role-profile agents (spec 2026-08-16-role-profile-agents): a role change on
+# a User may change which role-based agent profile they resolve to, so
+# debounce-enqueue a resync on every save. Thin and self-suppressing (never
+# raises, never sprays RQ jobs under tests): see
+# jarvis.chat.role_profiles.on_user_update / enqueue_sync.
+doc_events["User"] = {
+	"on_update": "jarvis.chat.role_profiles.on_user_update",
 }
 
 # Phase-0 admission (chat concurrency, WP-0): a deleted conversation must not

--- a/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
@@ -14,6 +14,7 @@
     "profile_tier",
     "profile_sets",
     "profile_n_skills",
+    "profile_n_tools",
     "created_at",
     "last_seen_at",
     "input_tokens",
@@ -76,6 +77,13 @@
       "label": "Profile Skill Count",
       "read_only": 1,
       "description": "Number of persona skills in the profile addressed at session-create time. 0 for the main/full agent."
+    },
+    {
+      "fieldname": "profile_n_tools",
+      "fieldtype": "Int",
+      "label": "Profile Tool Count",
+      "read_only": 1,
+      "description": "Number of agent tools allowed in the profile addressed at session-create time (jarvis.chat.role_profiles.ProfileChoice.n_tools). 0 for the main/full agent."
     },
     {
       "fieldname": "created_at",

--- a/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
@@ -10,6 +10,10 @@
     "session_key",
     "user",
     "chat_device_id",
+    "profile_agent_id",
+    "profile_tier",
+    "profile_sets",
+    "profile_n_skills",
     "created_at",
     "last_seen_at",
     "input_tokens",
@@ -44,6 +48,34 @@
       "label": "Chat Device ID",
       "read_only": 1,
       "description": "Snapshot of Jarvis Settings.chat_device_id at session-create time. C2 stretch: if the bench re-pairs (device_id changes), all prior session_keys become invalid - even a leaked session_key + leaked agent_token can no longer impersonate after a routine re-pair."
+    },
+    {
+      "fieldname": "profile_agent_id",
+      "fieldtype": "Data",
+      "label": "Profile Agent ID",
+      "read_only": 1,
+      "description": "Role-based agent profile addressed at session-create time (jarvis.chat.role_profiles.ProfileChoice.agent_id). Empty when the session used the main/full agent - Enable Role-Based Agent Profiles off, an unmapped role, or the profile not yet rendered on the agent side."
+    },
+    {
+      "fieldname": "profile_tier",
+      "fieldtype": "Data",
+      "label": "Profile Tier",
+      "read_only": 1,
+      "description": "\"full\" or \"standard\" - the tool tier of the profile addressed at session-create time."
+    },
+    {
+      "fieldname": "profile_sets",
+      "fieldtype": "Data",
+      "label": "Profile Skill Sets",
+      "read_only": 1,
+      "description": "Comma-joined skill-set keys (e.g. \"accounts,hr\") that made up this session's profile. Empty for the main/full agent."
+    },
+    {
+      "fieldname": "profile_n_skills",
+      "fieldtype": "Int",
+      "label": "Profile Skill Count",
+      "read_only": 1,
+      "description": "Number of persona skills in the profile addressed at session-create time. 0 for the main/full agent."
     },
     {
       "fieldname": "created_at",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -118,6 +118,8 @@
   "learned_skills_sync_status",
   "agent_catalog_dirty",
   "agent_catalog_version",
+  "role_profiles_pushed",
+  "role_profiles_pushed_at",
   "release_notice_section",
   "release_notice_active",
   "latest_jarvis_version",
@@ -851,6 +853,21 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "Agent Catalog Version",
+   "read_only": 1
+  },
+  {
+   "description": "JSON snapshot of the role-based agent profiles last pushed to admin (jarvis.chat.role_profiles.needed_profiles output). Compared against the freshly computed set on every sync to short-circuit an unchanged push.",
+   "fieldname": "role_profiles_pushed",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Role Profiles Pushed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "role_profiles_pushed_at",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "Role Profiles Pushed At",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -93,6 +93,7 @@
   "auto_apply_changes",
   "core_apps_override",
   "enable_customizations_clause",
+  "enable_role_profiles",
   "sync_tab",
   "last_sync_section",
   "last_sync_at",
@@ -690,6 +691,13 @@
    "label": "Enable Customizations Context Clause",
    "default": "1",
    "description": "Adds a one-line, counts-only summary of this site's customizations (custom apps, doctype/field/workflow counts) to every chat turn's context, pointing the agent at jarvis__describe_customizations. Readers treat an unset value as ON."
+  },
+  {
+   "fieldname": "enable_role_profiles",
+   "fieldtype": "Check",
+   "label": "Enable Role-Based Agent Profiles",
+   "default": "0",
+   "description": "When on, a new chat session may be pinned to a role-based agent profile (a reduced tool set plus the matching skill set derived from the user's ERPNext roles) instead of the main agent - but only once that profile has actually been rendered on the agent side (see Role Profiles Pushed below). Off (default): every session uses the main agent, matching pre-role-profiles behavior exactly. Operator intent, not tenant state - not reset between tenancies."
   },
   {
    "fieldname": "sync_tab",

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -75,6 +75,10 @@ CONNECTION = ResetSpec(
 		"agent_skills_sync_status",
 		"learned_skills_sync_status",
 		"wiki_mirror_last_sync_status",
+		# The role-based profile snapshot names agent slugs already deployed
+		# to the PREVIOUS tenancy's container; a reset must not let a fresh
+		# tenancy's first sync read it as "unchanged, no push needed".
+		"role_profiles_pushed",
 		# Release notice + whitelabel branding of the previous tenancy. The SPA
 		# falls back to "Jarvis" when agent_name is blank.
 		"release_notice_message",
@@ -105,6 +109,7 @@ CONNECTION = ResetSpec(
 		"custom_skills_synced_at",
 		"agent_skills_synced_at",
 		"learned_skills_synced_at",
+		"role_profiles_pushed_at",
 		"wiki_mirror_last_synced_at",
 	),
 	zero=(

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -1,10 +1,12 @@
-"""Tests for the role -> agent-profile fixture and resolver (spec
+"""Tests for the role -> agent-profile fixture and resolver, and the
+compute-and-push-to-admin sync (spec
 docs/superpowers/specs/2026-08-16-role-profile-agents-design.md).
 
 Run ONLY with --case (bare --module silently skips TestCases), and pair it
 with --module: --case alone walks every test file in the app and errors on
 the first module lacking the class, rather than finding this one.
   bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_role_profiles --case TestRoleProfiles
+  bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_role_profiles --case TestSyncRoleProfiles
 """
 
 from unittest.mock import patch
@@ -129,3 +131,111 @@ class TestRoleProfiles(FrappeTestCase):
 			claimed |= skills
 		self.assertEqual(shared & claimed, set())
 		self.assertEqual(len(shared | claimed), 45)
+
+
+class TestSyncRoleProfiles(FrappeTestCase):
+	"""``jarvis.chat.role_profiles.sync_role_profiles`` - the compute-then-
+	push-to-admin boundary (spec J2 / task-J2-brief.md).
+
+	``needed_profiles`` is patched to a fixed fixture so these tests are
+	isolated from whatever real ``Jarvis User``-holding users already exist
+	on the shared test site (created by ``TestRoleProfiles`` above, or by
+	prior runs).
+
+	The Jarvis Settings snapshot fields (``role_profiles_pushed`` /
+	``role_profiles_pushed_at``) are stood in with an in-memory fake behind
+	``frappe.db.get_single_value`` / ``frappe.db.set_value`` rather than
+	written to the real Single doctype: those two columns only exist once a
+	``bench migrate`` has run for this DocType JSON change, and this shared
+	bench points at a live production tenancy, so exercising the snapshot
+	*logic* does not need to depend on that migration having been run here.
+	"""
+
+	@staticmethod
+	def _fixture():
+		return [{"slug": "role-hr", "skills": ["hrms-hr"], "tools_allow": ["exec"]}]
+
+	@staticmethod
+	def _fake_settings_store(initial=None):
+		"""Returns ``(store, get_single_value, set_value)``: a plain dict plus
+		two callables shaped like the real ``frappe.db`` methods, scoped to
+		just the two fields ``sync_role_profiles`` touches."""
+		store = dict(initial or {})
+
+		def fake_get_single_value(doctype, fieldname, cache=True):
+			assert doctype == role_profiles._SETTINGS
+			return store.get(fieldname)
+
+		def fake_set_value(doctype, name, values, *args, **kwargs):
+			assert doctype == role_profiles._SETTINGS
+			assert name == role_profiles._SETTINGS
+			store.update(values)
+
+		return store, fake_get_single_value, fake_set_value
+
+	def test_first_sync_pushes_and_stamps_settings(self):
+		store, fake_get, fake_set = self._fake_settings_store()
+		with (
+			patch.object(role_profiles, "needed_profiles", return_value=self._fixture()),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch("jarvis.admin_client.post_push_role_profiles", return_value={"ok": True}) as mock_push,
+		):
+			result = role_profiles.sync_role_profiles()
+
+		self.assertTrue(result["pushed"])
+		self.assertEqual(result["profiles"], self._fixture())
+		mock_push.assert_called_once_with(role_profiles=self._fixture())
+		self.assertEqual(frappe.parse_json(store["role_profiles_pushed"]), self._fixture())
+		self.assertIsNotNone(store.get("role_profiles_pushed_at"))
+
+	def test_unchanged_second_call_is_a_noop(self):
+		store, fake_get, fake_set = self._fake_settings_store()
+		with (
+			patch.object(role_profiles, "needed_profiles", return_value=self._fixture()),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch("jarvis.admin_client.post_push_role_profiles", return_value={"ok": True}) as mock_push,
+		):
+			first = role_profiles.sync_role_profiles()
+			mock_push.reset_mock()
+			second = role_profiles.sync_role_profiles()
+
+		self.assertTrue(first["pushed"])
+		self.assertFalse(second["pushed"])
+		self.assertEqual(second["profiles"], self._fixture())
+		mock_push.assert_not_called()
+
+	def test_force_repushes_even_when_unchanged(self):
+		store, fake_get, fake_set = self._fake_settings_store()
+		with (
+			patch.object(role_profiles, "needed_profiles", return_value=self._fixture()),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch("jarvis.admin_client.post_push_role_profiles", return_value={"ok": True}) as mock_push,
+		):
+			role_profiles.sync_role_profiles()
+			mock_push.reset_mock()
+			result = role_profiles.sync_role_profiles(force=True)
+
+		self.assertTrue(result["pushed"])
+		mock_push.assert_called_once_with(role_profiles=self._fixture())
+
+	def test_push_exception_returns_pushed_false_and_never_raises(self):
+		store, fake_get, fake_set = self._fake_settings_store()
+		with (
+			patch.object(role_profiles, "needed_profiles", return_value=self._fixture()),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch(
+				"jarvis.admin_client.post_push_role_profiles",
+				side_effect=RuntimeError("admin unreachable"),
+			),
+		):
+			before = dict(store)
+			result = role_profiles.sync_role_profiles()  # must not raise
+			after = dict(store)
+
+		self.assertFalse(result["pushed"])
+		self.assertEqual(result["profiles"], self._fixture())
+		self.assertEqual(before, after)

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -361,25 +361,30 @@ class TestSessionProfilePick(FrappeTestCase):
 		)
 		sess = FakeSess()
 		with patch.object(chat_api.frappe, "get_single", return_value=settings):
-			key = chat_api._ensure_session_key(self._USER, sess=sess)
+			key = chat_api._ensure_session_key(self._USER, sess=sess, profile=True)
 
-		self.assertTrue(key.startswith("agent:role-hr:jarvis-chat-"))
+		# ":dashboard:" is the chat-namespace marker session_lifecycle.py's
+		# idle/orphan reaper and session_pin_sweep.py both key off - a key
+		# missing it would leak this gateway session forever.
+		self.assertTrue(key.startswith("agent:role-hr:dashboard:jarvis-chat-"))
 		self.assertEqual(sess.calls, 0)
 		row = frappe.get_doc(SESSION, {"session_key": key})
 		self.assertEqual(row.profile_agent_id, "role-hr")
 		self.assertEqual(row.profile_tier, "standard")
+		self.assertEqual(row.profile_n_tools, 68)
 
 	def test_flag_off_uses_legacy_create_session_path(self):
 		settings = self._fake_settings(enable_role_profiles=False)
 		sess = FakeSess()
 		with patch.object(chat_api.frappe, "get_single", return_value=settings):
-			key = chat_api._ensure_session_key(self._USER, sess=sess)
+			key = chat_api._ensure_session_key(self._USER, sess=sess, profile=True)
 
 		self.assertEqual(sess.calls, 1)
 		self.assertEqual(key, "sess-key-1")
 		row = frappe.get_doc(SESSION, {"session_key": key})
 		self.assertEqual(row.profile_tier, "full")
 		self.assertEqual(row.profile_sets, "")
+		self.assertEqual(row.profile_n_tools, 0)
 
 	def test_flag_on_agent_not_in_pushed_snapshot_falls_back_to_legacy(self):
 		# resolve_profile(self._USER) resolves to role-hr (real HR User role),
@@ -391,10 +396,48 @@ class TestSessionProfilePick(FrappeTestCase):
 		)
 		sess = FakeSess()
 		with patch.object(chat_api.frappe, "get_single", return_value=settings):
-			key = chat_api._ensure_session_key(self._USER, sess=sess)
+			key = chat_api._ensure_session_key(self._USER, sess=sess, profile=True)
 
 		self.assertEqual(sess.calls, 1)
 		self.assertEqual(key, "sess-key-1")
+
+	def test_macro_style_call_profile_false_still_uses_legacy_even_if_resolvable(self):
+		# Coordinator review finding #2 (spec §8 - non-chat sessions always
+		# run `full`): a macro/scheduled dispatch never passes profile=True
+		# (jarvis.chat.macros -> api._enqueue_turn's session-key call keeps
+		# the default). Even with the flag on and a fully resolvable, pushed
+		# profile, `profile=False` (the default - this call omits the kwarg
+		# entirely, exactly like a macro caller would) must still take the
+		# legacy create_session path, because macros.py's own dispatch
+		# try/except relies on this function still THROWING on a
+		# misconfigured agent rather than silently minting an unusable key.
+		settings = self._fake_settings(
+			enable_role_profiles=True,
+			pushed=[{"slug": "role-hr", "skills": ["hrms-hr"], "tools_allow": ["exec"]}],
+		)
+		sess = FakeSess()
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			key = chat_api._ensure_session_key(self._USER, sess=sess)  # profile omitted -> False
+
+		self.assertEqual(sess.calls, 1)
+		self.assertEqual(key, "sess-key-1")
+		row = frappe.get_doc(SESSION, {"session_key": key})
+		self.assertEqual(row.profile_tier, "full")
+
+	def test_profile_true_missing_gateway_config_still_throws(self):
+		# Coordinator review finding #2: the profile (self-addressed) path
+		# skips create_session/sessions.create entirely, but a totally
+		# unconfigured agent must still fail fast here - never silently mint
+		# a session key nothing can ever connect to.
+		settings = self._fake_settings(
+			enable_role_profiles=True,
+			pushed=[{"slug": "role-hr", "skills": ["hrms-hr"], "tools_allow": ["exec"]}],
+		)
+		settings.agent_url = ""
+		settings.get_password = lambda *a, **k: ""
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			with self.assertRaises(frappe.ValidationError):
+				chat_api._ensure_session_key(self._USER, sess=FakeSess(), profile=True)
 
 	def test_missing_flag_attribute_degrades_to_legacy_not_a_crash(self):
 		# Regression: a site whose code deployed ahead of its reload-doctype /
@@ -402,7 +445,9 @@ class TestSessionProfilePick(FrappeTestCase):
 		# Settings doc at all (AttributeError, not a falsy value) - caught
 		# live via jarvis.tests.test_pump_pipeline.TestPumpPipelineE2E before
 		# the getattr guard was added. A missing flag must behave exactly
-		# like flag-off, never break session creation.
+		# like flag-off, never break session creation. profile=True so the
+		# `getattr` guard (short-circuited behind `if profile and ...`) is
+		# actually exercised.
 		settings = SimpleNamespace(
 			chat_device_id="dev-1",
 			agent_url="ws://fake-agent",
@@ -410,12 +455,34 @@ class TestSessionProfilePick(FrappeTestCase):
 		)
 		sess = FakeSess()
 		with patch.object(chat_api.frappe, "get_single", return_value=settings):
-			key = chat_api._ensure_session_key(self._USER, sess=sess)
+			key = chat_api._ensure_session_key(self._USER, sess=sess, profile=True)
 
 		self.assertEqual(sess.calls, 1)
 		self.assertEqual(key, "sess-key-1")
 		row = frappe.get_doc(SESSION, {"session_key": key})
 		self.assertEqual(row.profile_tier, "full")
 
+	def test_missing_pushed_snapshot_attribute_degrades_to_legacy(self):
+		# Narrower sibling of the missing-flag test above: the flag itself IS
+		# present and on, but `role_profiles_pushed` is missing entirely (same
+		# metadata-lag scenario, different field) - _pushed_profile_slugs'
+		# own getattr guard must return an empty set rather than raise, which
+		# routes to the legacy path exactly like an empty/unparseable snapshot
+		# already does.
+		settings = SimpleNamespace(
+			enable_role_profiles=True,
+			chat_device_id="dev-1",
+			agent_url="ws://fake-agent",
+			get_password=lambda *a, **k: "fake-token",
+		)
+		sess = FakeSess()
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			key = chat_api._ensure_session_key(self._USER, sess=sess, profile=True)
+
+		self.assertEqual(sess.calls, 1)
+		self.assertEqual(key, "sess-key-1")
+
 	def test_scrub(self):
+		# scrub is jarvis.chat.entities.scrub, imported (not duplicated) into
+		# api.py; assert it through its use in the self-addressed key shape.
 		self.assertEqual(chat_api.scrub("RP-HR@Example.com"), "rp-hr-example-com")

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -1,0 +1,116 @@
+"""Tests for the role -> agent-profile fixture and resolver (spec
+docs/superpowers/specs/2026-08-16-role-profile-agents-design.md).
+
+Run ONLY with --case (bare --module silently skips TestCases):
+  bench --site site.jarvis run-tests --app jarvis --case TestRoleProfiles
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import role_profiles
+
+
+class TestRoleProfiles(FrappeTestCase):
+	def _mk_user(self, email, roles):
+		if not frappe.db.exists("User", email):
+			u = frappe.get_doc({"doctype": "User", "email": email, "first_name": email.split("@")[0]})
+			u.append_roles(*roles)
+			u.insert(ignore_permissions=True)
+		return email
+
+	def test_admin_roles_pin_main(self):
+		u = self._mk_user("rp-admin@example.com", ["Jarvis User", "System Manager"])
+		c = role_profiles.resolve_profile(u)
+		self.assertIsNone(c.agent_id)
+		self.assertEqual(c.tier, "full")
+
+	def test_single_role_maps_to_set(self):
+		u = self._mk_user("rp-hr@example.com", ["Jarvis User", "HR User"])
+		c = role_profiles.resolve_profile(u)
+		self.assertEqual(c.agent_id, "role-hr")
+		self.assertIn("hrms-hr", c.skills)
+		self.assertIn("frappe-core", c.skills)  # shared core present
+		self.assertNotIn("erpnext-accounts", c.skills)  # other domains absent
+
+	def test_multi_role_merges_sorted(self):
+		u = self._mk_user("rp-multi@example.com", ["Jarvis User", "HR User", "Accounts User"])
+		c = role_profiles.resolve_profile(u)
+		self.assertEqual(c.agent_id, "role-accounts+hr")  # sorted set keys
+		self.assertIn("hrms-payroll", c.skills)
+		self.assertIn("erpnext-accounts", c.skills)
+
+	def test_unmapped_roles_fall_back_to_main(self):
+		u = self._mk_user("rp-none@example.com", ["Jarvis User", "Translator"])
+		c = role_profiles.resolve_profile(u)
+		self.assertIsNone(c.agent_id)
+
+	def test_resolution_error_falls_back_to_main(self):
+		c = role_profiles.resolve_profile(None)  # type: ignore[arg-type]
+		self.assertIsNone(c.agent_id)
+
+	def test_standard_tools_allow_excludes_drops_keeps_features(self):
+		allow = set(role_profiles.standard_tools_allow())
+		self.assertEqual(len(allow), 68)
+		for kept in (
+			"exec",
+			"read",
+			"canvas",
+			"pdf",
+			"image",
+			"jarvis__read_wiki",
+			"jarvis__update_wiki",
+			"jarvis__create_custom_skill",
+			"jarvis__run_import",
+			"jarvis__query",
+			"jarvis__save_dashboard",
+		):
+			self.assertIn(kept, allow)
+		for dropped in (
+			"cron",
+			"browser",
+			"web_search",
+			"sessions_spawn",
+			"jarvis__record_agent_run",
+			"skill_workshop",
+		):
+			self.assertNotIn(dropped, allow)
+
+	def test_tool_universe_is_94(self):
+		# standard_tools_allow() (68) + STANDARD_DROP_TOOLS (26) must
+		# reconstruct the full evidence-captured 94-tool universe with no
+		# overlap and no gap (spec §2).
+		allow = set(role_profiles.standard_tools_allow())
+		drop = set(role_profiles.STANDARD_DROP_TOOLS)
+		self.assertEqual(len(drop), 26)
+		self.assertEqual(allow & drop, set())
+		self.assertEqual(len(allow | drop), 94)
+
+	def test_shared_core_membership(self):
+		shared = role_profiles.SHARED_CORE_SKILLS
+		self.assertEqual(len(shared), 28)
+		# all frappe-* and jarvis-* skills are shared core
+		self.assertEqual(len([s for s in shared if s.startswith("frappe-")]), 11)
+		self.assertEqual(len([s for s in shared if s.startswith("jarvis-")]), 9)
+		# named additions from spec §3
+		for slug in (
+			"erpnext-setup",
+			"erpnext-utilities",
+			"erpnext-regional",
+			"erpnext-communication",
+			"erpnext-integrations",
+			"erpnext-bulk-transaction",
+			"ocr-data-entry",
+			"macro-merge",
+		):
+			self.assertIn(slug, shared)
+		# role-set-claimed skills are NOT in shared core
+		for slug in ("erpnext-accounts", "hrms-hr", "erpnext-projects", "erpnext-selling"):
+			self.assertNotIn(slug, shared)
+		# shared core and role-set skills never overlap, and their union is
+		# every skill any of the 6 role sets can add
+		claimed = set()
+		for skills in role_profiles.SKILL_SETS.values():
+			claimed |= skills
+		self.assertEqual(shared & claimed, set())
+		self.assertEqual(len(shared | claimed), 45)

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -7,14 +7,19 @@ with --module: --case alone walks every test file in the app and errors on
 the first module lacking the class, rather than finding this one.
   bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_role_profiles --case TestRoleProfiles
   bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_role_profiles --case TestSyncRoleProfiles
+  bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_role_profiles --case TestSessionProfilePick
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis.chat import api as chat_api
 from jarvis.chat import role_profiles
+
+SESSION = "Jarvis Chat Session"
 
 
 class TestRoleProfiles(FrappeTestCase):
@@ -239,3 +244,178 @@ class TestSyncRoleProfiles(FrappeTestCase):
 		self.assertFalse(result["pushed"])
 		self.assertEqual(result["profiles"], self._fixture())
 		self.assertEqual(before, after)
+
+	def test_needed_profiles_order_stable_across_differently_ordered_user_listings(self):
+		"""Fold-in from the J2 review: guards the sort fix in
+		``role_profiles.needed_profiles``. Two ``frappe.get_all`` "User"
+		listings that differ ONLY in row order must still produce the
+		identical (list-equal) ``needed_profiles()`` output, since
+		``sync_role_profiles``'s snapshot compare is a plain ``==`` against
+		the previously pushed list - an order-only difference must never read
+		as "changed"."""
+
+		def _resolve(user):
+			if user == "user-hr":
+				return role_profiles.ProfileChoice(
+					agent_id="role-hr",
+					tier="standard",
+					set_keys=("hr",),
+					skills=("hrms-hr",),
+					n_tools=1,
+				)
+			return role_profiles.ProfileChoice(
+				agent_id="role-accounts",
+				tier="standard",
+				set_keys=("accounts",),
+				skills=("erpnext-accounts",),
+				n_tools=1,
+			)
+
+		def _make_get_all(user_order):
+			def _get_all(doctype, filters=None, pluck=None, **kwargs):
+				if doctype == "Has Role":
+					return ["user-hr", "user-accounts"]
+				return list(user_order)
+
+			return _get_all
+
+		with patch.object(role_profiles, "resolve_profile", side_effect=_resolve):
+			with patch.object(frappe, "get_all", side_effect=_make_get_all(["user-hr", "user-accounts"])):
+				first = role_profiles.needed_profiles()
+			with patch.object(frappe, "get_all", side_effect=_make_get_all(["user-accounts", "user-hr"])):
+				second = role_profiles.needed_profiles()
+
+		self.assertEqual(first, second)
+		self.assertEqual([p["slug"] for p in first], ["role-accounts", "role-hr"])
+
+
+class FakeSess:
+	"""Stub pooled ``AgentSession``: counts ``create_session`` calls so tests
+	can assert the flag-gated legacy branch was (or was not) taken."""
+
+	def __init__(self):
+		self.calls = 0
+
+	def create_session(self, label):
+		self.calls += 1
+		return "sess-key-1"
+
+
+class TestSessionProfilePick(FrappeTestCase):
+	"""``jarvis.chat.api._ensure_session_key`` flag-gated profile pick (task
+	J3 / spec docs/superpowers/specs/2026-08-16-role-profile-agents-design.md
+	§9).
+
+	``_ensure_session_key`` ends with a real ``frappe.db.commit()`` (it
+	always has - unrelated to this task), so - like
+	``jarvis.tests.test_pump_pipeline``'s ``_PipelineCase`` - these tests
+	call the real function and clean up their own committed rows in
+	``tearDown`` rather than relying on ``FrappeTestCase``'s per-test
+	savepoint rollback, which a real commit bypasses.
+
+	``Jarvis Settings`` is stood in with a ``SimpleNamespace`` behind
+	``frappe.get_single`` (mirrors ``TestSyncRoleProfiles``'s fake-store
+	approach, adapted for the doc-attribute access ``_ensure_session_key``
+	uses instead of ``frappe.db.get_single_value``); no real Settings row is
+	touched.
+	"""
+
+	_USER = "rp-session-pick@example.com"
+
+	def setUp(self):
+		super().setUp()
+		if not frappe.db.exists("User", self._USER):
+			u = frappe.get_doc({"doctype": "User", "email": self._USER, "first_name": "rp-session-pick"})
+			u.append_roles("Jarvis User", "HR User")
+			u.insert(ignore_permissions=True)
+
+	def tearDown(self):
+		# Real commits happened inside _ensure_session_key; undo them for
+		# real rather than relying on the (already-bypassed) savepoint. Best-
+		# effort (mirrors test_pump_pipeline._PipelineCase): a setUp failure
+		# must surface as ITS OWN error, not get masked by a teardown
+		# DoesNotExistError on a user that was never created.
+		try:
+			frappe.db.delete(SESSION, {"user": self._USER})
+			if frappe.db.exists("User", self._USER):
+				frappe.delete_doc("User", self._USER, force=True, ignore_permissions=True)
+			frappe.db.commit()
+		except Exception:
+			pass
+		super().tearDown()
+
+	@staticmethod
+	def _fake_settings(*, enable_role_profiles, pushed=None):
+		return SimpleNamespace(
+			enable_role_profiles=enable_role_profiles,
+			role_profiles_pushed=frappe.as_json(pushed) if pushed is not None else None,
+			chat_device_id="dev-1",
+			agent_url="ws://fake-agent",
+			get_password=lambda *a, **k: "fake-token",
+		)
+
+	def test_flag_on_pushed_snapshot_has_role_self_addresses_the_agent(self):
+		settings = self._fake_settings(
+			enable_role_profiles=True,
+			pushed=[{"slug": "role-hr", "skills": ["hrms-hr"], "tools_allow": ["exec"]}],
+		)
+		sess = FakeSess()
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			key = chat_api._ensure_session_key(self._USER, sess=sess)
+
+		self.assertTrue(key.startswith("agent:role-hr:jarvis-chat-"))
+		self.assertEqual(sess.calls, 0)
+		row = frappe.get_doc(SESSION, {"session_key": key})
+		self.assertEqual(row.profile_agent_id, "role-hr")
+		self.assertEqual(row.profile_tier, "standard")
+
+	def test_flag_off_uses_legacy_create_session_path(self):
+		settings = self._fake_settings(enable_role_profiles=False)
+		sess = FakeSess()
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			key = chat_api._ensure_session_key(self._USER, sess=sess)
+
+		self.assertEqual(sess.calls, 1)
+		self.assertEqual(key, "sess-key-1")
+		row = frappe.get_doc(SESSION, {"session_key": key})
+		self.assertEqual(row.profile_tier, "full")
+		self.assertEqual(row.profile_sets, "")
+
+	def test_flag_on_agent_not_in_pushed_snapshot_falls_back_to_legacy(self):
+		# resolve_profile(self._USER) resolves to role-hr (real HR User role),
+		# but the pushed snapshot only carries a DIFFERENT profile - never
+		# self-address an agent that may not be rendered on the agent side.
+		settings = self._fake_settings(
+			enable_role_profiles=True,
+			pushed=[{"slug": "role-accounts", "skills": [], "tools_allow": []}],
+		)
+		sess = FakeSess()
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			key = chat_api._ensure_session_key(self._USER, sess=sess)
+
+		self.assertEqual(sess.calls, 1)
+		self.assertEqual(key, "sess-key-1")
+
+	def test_missing_flag_attribute_degrades_to_legacy_not_a_crash(self):
+		# Regression: a site whose code deployed ahead of its reload-doctype /
+		# migrate has no `enable_role_profiles` attribute on the real Jarvis
+		# Settings doc at all (AttributeError, not a falsy value) - caught
+		# live via jarvis.tests.test_pump_pipeline.TestPumpPipelineE2E before
+		# the getattr guard was added. A missing flag must behave exactly
+		# like flag-off, never break session creation.
+		settings = SimpleNamespace(
+			chat_device_id="dev-1",
+			agent_url="ws://fake-agent",
+			get_password=lambda *a, **k: "fake-token",
+		)
+		sess = FakeSess()
+		with patch.object(chat_api.frappe, "get_single", return_value=settings):
+			key = chat_api._ensure_session_key(self._USER, sess=sess)
+
+		self.assertEqual(sess.calls, 1)
+		self.assertEqual(key, "sess-key-1")
+		row = frappe.get_doc(SESSION, {"session_key": key})
+		self.assertEqual(row.profile_tier, "full")
+
+	def test_scrub(self):
+		self.assertEqual(chat_api.scrub("RP-HR@Example.com"), "rp-hr-example-com")

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -5,6 +5,8 @@ Run ONLY with --case (bare --module silently skips TestCases):
   bench --site site.jarvis run-tests --app jarvis --case TestRoleProfiles
 """
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -48,6 +50,17 @@ class TestRoleProfiles(FrappeTestCase):
 	def test_resolution_error_falls_back_to_main(self):
 		c = role_profiles.resolve_profile(None)  # type: ignore[arg-type]
 		self.assertIsNone(c.agent_id)
+
+	def test_resolution_exception_falls_back_to_main(self):
+		# frappe.get_roles(None) resolves to the session user rather than
+		# raising, so the test above exercises the deterministic `not user`
+		# guard, not the except branch. Force a genuine exception here to
+		# cover the "absolute" fallback rule (spec §3 rule 3) for real.
+		u = self._mk_user("rp-boom@example.com", ["Jarvis User", "HR User"])
+		with patch.object(role_profiles.frappe, "get_roles", side_effect=RuntimeError("boom")):
+			c = role_profiles.resolve_profile(u)
+		self.assertIsNone(c.agent_id)
+		self.assertEqual(c.tier, "full")
 
 	def test_standard_tools_allow_excludes_drops_keeps_features(self):
 		allow = set(role_profiles.standard_tools_allow())

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -1,8 +1,10 @@
 """Tests for the role -> agent-profile fixture and resolver (spec
 docs/superpowers/specs/2026-08-16-role-profile-agents-design.md).
 
-Run ONLY with --case (bare --module silently skips TestCases):
-  bench --site site.jarvis run-tests --app jarvis --case TestRoleProfiles
+Run ONLY with --case (bare --module silently skips TestCases), and pair it
+with --module: --case alone walks every test file in the app and errors on
+the first module lacking the class, rather than finding this one.
+  bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_role_profiles --case TestRoleProfiles
 """
 
 from unittest.mock import patch


### PR DESCRIPTION
## Summary

Single-role users get a much smaller assistant prompt (~15k fewer tokens per turn): the app now maps each chat user's roles to a "role profile" (trimmed tool and skill subsets), pushes the needed profiles to the fleet through admin, and pins the matching profile agent when a conversation's session is created. Everything sits behind a new Jarvis Settings flag (`enable_role_profiles`, default off) — flag off is today's behavior bit for bit.

## What changed
- `jarvis/chat/role_profiles.py`: curated role-to-profile fixture (6 skill sets over a 28-skill shared core, 68-tool standard tier vs 26 dropped power tools) and a resolver with absolute fallbacks: admins, unmapped roles, and any error all get the full main profile. Multi-role users get a merged set.
- Profile push: distinct combos across enabled users go to admin's `push_role_profiles` (no-op when unchanged, stamped on Jarvis Settings; User update hook + daily reconcile).
- Session create: with the flag on and the profile pushed, the session key self-addresses the profile agent (`agent:role-hr:...`, the same gateway contract delegate runs use); otherwise the legacy gateway path runs unchanged. Note: the two Jarvis Settings reads in `_ensure_session_key` were consolidated to one fetch (no observable difference).
- Chat Session rows record profile id, tier, sets, and skill count for the upcoming usage dashboard.

## Risk and verification
- Flag default off; rollback = leave it off. 19 new tests across resolver, sync, and session pick, including un-migrated-schema guards (settings reads degrade to legacy, never crash chat).
- Companion PRs: fleet-agent#234 (renders profiles), admin-v2#363 (pass-through) — both CI-green and review-clean. Live end-to-end verification runs after those merge and deploy.

<details><summary>Design</summary>

Spec: `docs/superpowers/specs/2026-08-16-role-profile-agents-design.md` (untracked by repo convention). Verified facts the design rests on: skills load via the exec tool so it is never droppable; scheduled macros and reminders run through the Frappe scheduler, not the agent's cron tool (dropping cron also closes a shadow-automation hole); profiles are pinned per session for cache stability (prompt prefix stays byte-identical across turns, preserving the #861 fix).

</details>

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (rebased on develop today)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
