### PR TITLE
fix(export_document): rich-PDF render defects from the FC smoke (Slice 1.1)

### DIFF
--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -691,8 +691,39 @@ class TestRenderLetterheadTemplate(unittest.TestCase):
 			raise RuntimeError("no doc context")
 
 		patch.object(furniture.frappe, "render_template", _boom).start()
+		patch.object(furniture.frappe, "clear_last_message", lambda: None).start()
 		self.addCleanup(patch.stopall)
 		out = furniture._render_letterhead('<img src="data:x"> {% if y %}{{ y }}{% endif %}', {})
 		self.assertNotIn("{%", out)
 		self.assertNotIn("{{", out)
 		self.assertIn("<img", out)  # static logo survives the fallback
+
+	def test_oversized_letterhead_dropped_without_hang(self) -> None:
+		# A pathological unclosed-{{ run must be dropped on size BEFORE the
+		# superlinear residual scrub (it runs pre-render, outside the render
+		# timeout). Guard: this returns quickly, not in O(n^2).
+		import time
+
+		called: list = []
+		patch.object(furniture.frappe, "render_template", lambda *_a, **_k: called.append(1) or "").start()
+		self.addCleanup(patch.stopall)
+		huge = "{{" * (furniture._MAX_FURNITURE_CHARS)  # >> the cap
+		start = time.monotonic()
+		out = furniture._render_letterhead(huge, {})
+		self.assertEqual(out, "")
+		self.assertEqual(called, [])  # never even reached render_template / scrub
+		self.assertLess(time.monotonic() - start, 1.0)
+
+	def test_render_error_clears_leaked_message(self) -> None:
+		# render_template's error path appends its traceback to message_log before
+		# raising; _render_letterhead must clear it so it can't leak to the caller.
+		cleared: list = []
+
+		def _boom(*_a, **_k):
+			raise RuntimeError("Jinja Template Error")
+
+		patch.object(furniture.frappe, "render_template", _boom).start()
+		patch.object(furniture.frappe, "clear_last_message", lambda: cleared.append(1)).start()
+		self.addCleanup(patch.stopall)
+		furniture._render_letterhead("<b>{{ x }}</b>", {})
+		self.assertEqual(cleared, [1])

--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -363,26 +363,40 @@ class TestBinaryResolution(unittest.TestCase):
 
 
 class TestPageNumbering(_FurnitureRenderBase):
-	def test_page_numbers_footer_uses_bracket_vars(self) -> None:
+	def test_page_numbers_use_text_footer_not_html(self) -> None:
+		# Page numbers go through the TEXT footer (--footer-center), which
+		# substitutes [page]/[topage] in wkhtmltopdf's C++ layer and so works under
+		# --disable-javascript. An HTML footer's bracket substitution needs JS, so
+		# it would print a literal "[page]" (the staging-smoke bug).
 		render_pdf("<p>hi</p>", page_numbers=True)
-		self.assertIn("--footer-html", self.fake_wk.args)
-		content = self.fake_wk.file_contents["--footer-html"]
-		self.assertIn("[page]", content)
-		self.assertIn("[topage]", content)
+		self.assertNotIn("--footer-html", self.fake_wk.args)
+		self.assertIn("--footer-center", self.fake_wk.args)
+		i = self.fake_wk.args.index("--footer-center")
+		self.assertEqual(self.fake_wk.args[i + 1], "Page [page] of [topage]")
 
 	def test_no_footer_when_page_numbers_off_and_no_footer(self) -> None:
 		render_pdf("<p>hi</p>", page_numbers=False)
 		self.assertNotIn("--footer-html", self.fake_wk.args)
+		self.assertNotIn("--footer-center", self.fake_wk.args)
 
 	def test_no_header_when_nothing_to_render(self) -> None:
 		render_pdf("<p>hi</p>", page_numbers=False)
 		self.assertNotIn("--header-html", self.fake_wk.args)
 
-	def test_explicit_footer_suppresses_auto_page_numbers(self) -> None:
+	def test_html_footer_wins_over_text_page_numbers(self) -> None:
+		# An explicit footer (or a letterhead footer) needs --footer-html; it and
+		# the text footer are mutually exclusive, so auto page numbers are omitted.
 		render_pdf("<p>hi</p>", footer_html="<b>my-footer</b>", page_numbers=True)
+		self.assertIn("--footer-html", self.fake_wk.args)
+		self.assertNotIn("--footer-center", self.fake_wk.args)
 		content = self.fake_wk.file_contents["--footer-html"]
 		self.assertIn("my-footer", content)
-		self.assertNotIn("[page]", content)
+
+	def test_letterhead_footer_uses_html_footer(self) -> None:
+		render_pdf("<p>hi</p>", letterhead_footer="<div>LH-FOOT</div>", page_numbers=True)
+		self.assertIn("--footer-html", self.fake_wk.args)
+		self.assertNotIn("--footer-center", self.fake_wk.args)
+		self.assertIn("LH-FOOT", self.fake_wk.file_contents["--footer-html"])
 
 
 # --- letterhead: folding (pre-resolved, trusted HTML) -----------------------
@@ -571,6 +585,21 @@ class TestResolveLetterhead(unittest.TestCase):
 		self.assertIn("ACME", header)
 		self.assertIsNone(note)
 
+	def test_resolve_letterhead_jinja_never_leaks_raw(self) -> None:
+		# The staging-smoke bug: a Jinja Letter Head folded in raw leaked
+		# {% if %}/{{ }} into the PDF. Even in the worst case (render leaves the
+		# tags), the residual scrub must remove them; static text survives.
+		_stub_letterhead(
+			default="Std",
+			docs={"Std": {"content": "<div>{% if x %}{{ x }}{% endif %}Acme Ltd</div>", "footer": ""}},
+		)
+		self.addCleanup(patch.stopall)
+		with patch.object(furniture.frappe, "render_template", lambda tpl, ctx: tpl):
+			header, _footer, _note = resolve_letterhead(None)
+		self.assertNotIn("{%", header)
+		self.assertNotIn("{{", header)
+		self.assertIn("Acme Ltd", header)
+
 	def test_resolve_letterhead_no_default_no_note(self) -> None:
 		_stub_letterhead(default=None)
 		self.addCleanup(patch.stopall)
@@ -628,3 +657,42 @@ class TestResolveLetterhead(unittest.TestCase):
 		header, footer, note = resolve_letterhead(None)
 		self.assertTrue(isinstance(header, str) and isinstance(footer, str))
 		self.assertIsNone(note)
+
+
+class TestRenderLetterheadTemplate(unittest.TestCase):
+	"""_render_letterhead: render a Letter Head's Jinja, then scrub residual tags."""
+
+	def test_non_jinja_passthrough_does_not_render(self) -> None:
+		called: list = []
+
+		def _spy(*_a, **_k):
+			called.append(1)
+			return ""
+
+		patch.object(furniture.frappe, "render_template", _spy).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._render_letterhead("<div>plain logo</div>", {})
+		self.assertEqual(out, "<div>plain logo</div>")
+		self.assertEqual(called, [])  # no template markers → render_template skipped
+
+	def test_renders_then_scrubs_residual(self) -> None:
+		patch.object(
+			furniture.frappe, "render_template", lambda t, c: "<b>Acme</b>{% stray %}keep{{ x }}"
+		).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._render_letterhead("<b>{{ company }}</b>", {})
+		self.assertNotIn("{%", out)
+		self.assertNotIn("{{", out)
+		self.assertIn("Acme", out)
+		self.assertIn("keep", out)
+
+	def test_render_error_falls_back_to_stripped_raw(self) -> None:
+		def _boom(*_a, **_k):
+			raise RuntimeError("no doc context")
+
+		patch.object(furniture.frappe, "render_template", _boom).start()
+		self.addCleanup(patch.stopall)
+		out = furniture._render_letterhead('<img src="data:x"> {% if y %}{{ y }}{% endif %}', {})
+		self.assertNotIn("{%", out)
+		self.assertNotIn("{{", out)
+		self.assertIn("<img", out)  # static logo survives the fallback

--- a/jarvis/tests/test_export_document_graphics.py
+++ b/jarvis/tests/test_export_document_graphics.py
@@ -37,9 +37,16 @@ class TestCssBar(unittest.TestCase):
 		self.assertTrue(out.startswith('<div class="bar-chart">'))
 		self.assertTrue(out.endswith("</div>"))
 
-	def test_css_bar_bar_class_and_width(self) -> None:
+	def test_css_bar_row_structure_label_bar_value(self) -> None:
+		# label + value sit BESIDE the bar (their own columns), NOT crammed inside
+		# the colored bar (the old flat layout overlapped in the render).
 		out = css_bar([{"label": "Q1", "value": "10", "pct": 50}])
-		self.assertIn('<div class="bar" style="width:50%">Q1 10</div>', out)
+		self.assertIn('<div class="bar-row">', out)
+		self.assertIn('<span class="bar-label">Q1</span>', out)
+		self.assertIn('<span class="bar-track"><span class="bar" style="width:50%"></span></span>', out)
+		self.assertIn('<span class="bar-value">10</span>', out)
+		# the bar itself carries NO text (would overflow a narrow bar)
+		self.assertNotIn('style="width:50%">Q1', out)
 
 	def test_css_bar_width_clamps_low(self) -> None:
 		out = css_bar([{"label": "x", "value": "y", "pct": -5}])
@@ -73,11 +80,13 @@ class TestCssBar(unittest.TestCase):
 
 	def test_css_bar_accepts_positional_tuple_rows(self) -> None:
 		out = css_bar([("Q1", "10", 50)])
-		self.assertIn('<div class="bar" style="width:50%">Q1 10</div>', out)
+		self.assertIn('<span class="bar-label">Q1</span>', out)
+		self.assertIn('style="width:50%"', out)
+		self.assertIn('<span class="bar-value">10</span>', out)
 
 	def test_css_bar_multiple_rows(self) -> None:
 		out = css_bar([{"label": "A", "value": "1", "pct": 10}, {"label": "B", "value": "2", "pct": 90}])
-		self.assertEqual(out.count('<div class="bar"'), 2)
+		self.assertEqual(out.count('<div class="bar-row">'), 2)
 
 	def test_css_bar_empty_rows(self) -> None:
 		self.assertEqual(css_bar([]), '<div class="bar-chart"></div>')
@@ -99,12 +108,16 @@ class TestCssBar(unittest.TestCase):
 	def test_css_bar_valid_3seq_does_not_raise(self) -> None:
 		# Exactly three positional items is the legitimate shape and must still work.
 		out = css_bar([[1, 2, 50]])
-		self.assertIn('<div class="bar" style="width:50%">1 2</div>', out)
+		self.assertIn('<span class="bar-label">1</span>', out)
+		self.assertIn('style="width:50%"', out)
+		self.assertIn('<span class="bar-value">2</span>', out)
 
 	def test_css_bar_none_label_value_render_blank_not_none(self) -> None:
 		out = css_bar([{"label": None, "value": None, "pct": 10}])
 		self.assertNotIn("None", out)
-		self.assertIn('<div class="bar" style="width:10%"> </div>', out)
+		self.assertIn('<span class="bar-label"></span>', out)
+		self.assertIn('<span class="bar-value"></span>', out)
+		self.assertIn('style="width:10%"', out)
 
 	def test_css_bar_tiny_pct_no_scientific_notation(self) -> None:
 		# 0.00001 formatted with :g would be "1e-05", which old WebKit drops. Fixed

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -441,10 +441,23 @@ def _render_letterhead(tpl: str, ctx: dict) -> str:
 	template, keeping its static HTML (a logo ``<img>``) while dropping the tags."""
 	if not tpl:
 		return ""
+	if len(tpl) > _MAX_FURNITURE_CHARS:
+		# A letterhead this large is broken/abuse. Rendering it — and the residual
+		# scrub, whose regex is superlinear on a long run of unclosed ``{{`` — would
+		# be unbounded CPU, and this runs BEFORE render_pdf's subprocess timeout, so
+		# it would pin the worker. Drop the block (a real letterhead is tiny).
+		_log_infra_failure("rich-pdf letterhead too large to render", f"{len(tpl)} chars")
+		return ""
 	if "{{" in tpl or "{%" in tpl:
 		try:
 			tpl = frappe.render_template(tpl, ctx)
 		except Exception:
+			# render_template's error path appends the traceback to
+			# ``frappe.message_log`` BEFORE raising; catching the exception does not
+			# undo that, so a broken-letterhead traceback could ride out to the
+			# caller via ``_server_messages``. Clear it.
+			with contextlib.suppress(Exception):
+				frappe.clear_last_message()
 			_log_infra_failure("rich-pdf letterhead template render failed", "")
 		tpl = _JINJA_RE.sub("", tpl)
 	return tpl

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -87,6 +87,9 @@ _MAX_MARGIN_MM = 100
 
 _IMG_TAG_RE = re.compile(r"<img\b[^>]*?/?>", re.IGNORECASE)
 _SRC_RE = re.compile(r"""\bsrc\s*=\s*(?P<q>["'])(?P<url>.*?)(?P=q)""", re.IGNORECASE)
+# Residual Jinja tags to scrub AFTER a best-effort render, so a Letter Head's raw
+# template ({% if %} / {{ }}) can never leak into the PDF as literal text.
+_JINJA_RE = re.compile(r"{%.*?%}|{{.*?}}", re.DOTALL)
 
 # Self-contained CSS for the header/footer documents - they are SEPARATE
 # wkhtmltopdf renders, so they carry no body/theme styling and must style
@@ -102,7 +105,6 @@ body {{
 	-webkit-print-color-adjust: exact;
 	print-color-adjust: exact;
 }}
-.jv-pageno {{ text-align: center; }}
 .jv-lh-header, .jv-lh-footer {{ width: 100%; }}
 .jv-watermark {{
 	position: absolute;
@@ -117,11 +119,6 @@ body {{
 	z-index: -1;
 }}
 """
-
-# wkhtmltopdf substitutes the bracket variables ``[page]``/``[topage]`` inside
-# header/footer HTML natively (text replacement, NOT JavaScript) - so page
-# numbering survives ``--disable-javascript``.
-_PAGE_NUMBER_HTML = '<div class="jv-pageno">Page [page] of [topage]</div>'
 
 
 def render_pdf(
@@ -163,7 +160,7 @@ def render_pdf(
 	_guard_furniture_len(header_html, footer_html, watermark)
 
 	header_doc = _build_header(header_html, watermark, letterhead_header)
-	footer_doc = _build_footer(footer_html, page_numbers, letterhead_footer)
+	footer_doc = _build_footer(footer_html, letterhead_footer)
 
 	tmp_dir = tempfile.gettempdir()
 	header_file = footer_file = None
@@ -180,6 +177,7 @@ def render_pdf(
 			margins_mm=margins_mm,
 			header_file=header_file,
 			footer_file=footer_file,
+			page_numbers=page_numbers,
 		)
 		document = _compose_document(body_html, "")
 		try:
@@ -298,12 +296,21 @@ def _build_args(
 	margins_mm: int,
 	header_file: str | None,
 	footer_file: str | None,
+	page_numbers: bool,
 ) -> list[str]:
 	"""Build the exact wkhtmltopdf CLI arg list.
 
 	The leading security/fidelity flags are UNCONDITIONAL - they are present on
 	every render regardless of options (a test asserts each one; dropping any
 	fails it). Body is read from stdin and the PDF written to stdout via ``- -``.
+
+	Page numbers use the TEXT footer (``--footer-center``), NOT an HTML footer:
+	wkhtmltopdf substitutes ``[page]``/``[topage]`` in the text header/footer
+	options in its own C++ layer, which WORKS under ``--disable-javascript`` - the
+	``--footer-html`` bracket substitution relies on JS wkhtmltopdf injects, so it
+	renders a literal ``[page]`` when JS is off. A text footer and an HTML footer
+	are mutually exclusive, so when there IS an HTML footer (a letterhead footer or
+	an explicit ``footer``) it wins and auto page numbers are omitted.
 	"""
 	args = [
 		binary,
@@ -333,6 +340,15 @@ def _build_args(
 		args += ["--header-html", header_file]
 	if footer_file:
 		args += ["--footer-html", footer_file]
+	elif page_numbers:
+		args += [
+			"--footer-center",
+			"Page [page] of [topage]",
+			"--footer-font-size",
+			"8",
+			"--footer-spacing",
+			"4",
+		]
 	args += ["-", "-"]  # stdin in, stdout out
 	return args
 
@@ -353,20 +369,18 @@ def _build_header(header_html: str | None, watermark: str | None, letterhead_hea
 	return _compose_document("".join(parts), _FURNITURE_CSS) if parts else ""
 
 
-def _build_footer(footer_html: str | None, page_numbers: bool, letterhead_footer: str) -> str:
-	"""Compose the footer document, or ``""`` when there is nothing to render.
+def _build_footer(footer_html: str | None, letterhead_footer: str) -> str:
+	"""Compose the HTML footer document, or ``""`` when there is none.
 
-	An explicit ``footer_html`` wins over auto page numbers (they are mutually
-	exclusive); the resolved-and-safe letterhead footer is always folded in when
-	present.
-	"""
+	Holds the resolved-and-safe letterhead footer and/or a sanitized explicit
+	``footer``. Page numbers are NOT here - they go through the text footer in
+	``_build_args`` (see there for why: ``[page]`` substitution needs JS in an HTML
+	footer but not in a text footer)."""
 	parts = []
 	if letterhead_footer:
 		parts.append(f'<div class="jv-lh-footer">{letterhead_footer}</div>')
 	if footer_html:
 		parts.append(f'<div class="jv-footer">{sanitize_rich(footer_html)}</div>')
-	elif page_numbers:
-		parts.append(_PAGE_NUMBER_HTML)
 	return _compose_document("".join(parts), _FURNITURE_CSS) if parts else ""
 
 
@@ -399,16 +413,60 @@ def resolve_letterhead(letterhead: str | None) -> tuple[str, str, str | None]:
 		lh = frappe.db.get_value("Letter Head", name, ["content", "footer"], as_dict=True)
 		if not lh:
 			return "", "", (f"letterhead {named!r} not found — rendered without it" if named else None)
-		# Inline same-site logos to permission-checked base64, THEN run the airtight
-		# letterhead gate (nh3, data-only images) so no remote/relative/protocol-
-		# relative src or other fetch-capable markup can reach the renderer.
-		header = sanitize_letterhead(_inline_letterhead_images(lh.get("content") or ""))
-		footer = sanitize_letterhead(_inline_letterhead_images(lh.get("footer") or ""))
+		# A Letter Head's content/footer is a Jinja TEMPLATE (company address block,
+		# etc.). Render it first (a composed report has no source doc, so we supply a
+		# best-effort company context; undefined refs blank out) — else the raw
+		# {% if %}/{{ }} leaks into the PDF. THEN inline same-site logos to
+		# permission-checked base64 and run the airtight letterhead gate (nh3,
+		# data-only images) so no remote/relative src or fetch-capable markup remains.
+		ctx = _letterhead_context(name)
+		header = sanitize_letterhead(
+			_inline_letterhead_images(_render_letterhead(lh.get("content") or "", ctx))
+		)
+		footer = sanitize_letterhead(
+			_inline_letterhead_images(_render_letterhead(lh.get("footer") or "", ctx))
+		)
 		return header, footer, None
 	except Exception:
 		# Letterhead is a nicety, never a hard failure of the export.
 		_log_infra_failure("rich-pdf letterhead resolution failed", f"letterhead={named!r}")
 		return "", "", (f"letterhead {named!r} could not be applied" if named else None)
+
+
+def _render_letterhead(tpl: str, ctx: dict) -> str:
+	"""Render a Letter Head Jinja template with ``ctx`` (best-effort), then scrub any
+	residual ``{% %}``/``{{ }}`` so a raw or partially-rendered template can never
+	leak into the PDF as literal text. Non-template content is returned unchanged.
+	Never raises: on a render error, the residual scrub still runs on the raw
+	template, keeping its static HTML (a logo ``<img>``) while dropping the tags."""
+	if not tpl:
+		return ""
+	if "{{" in tpl or "{%" in tpl:
+		try:
+			tpl = frappe.render_template(tpl, ctx)
+		except Exception:
+			_log_infra_failure("rich-pdf letterhead template render failed", "")
+		tpl = _JINJA_RE.sub("", tpl)
+	return tpl
+
+
+def _letterhead_context(name: str) -> dict:
+	"""Best-effort Jinja context for a Letter Head on a doc-less composed report:
+	the site's default company + its address/contact block, so a standard company
+	letterhead renders its details instead of blanking. Never raises."""
+	ctx: dict = {"letter_head": name}
+	try:
+		company = frappe.defaults.get_global_default("company") or frappe.db.get_value("Company", {}, "name")
+		if company:
+			ctx["company"] = company
+			ctx["doc"] = frappe._dict({"company": company, "letter_head": name})
+			with contextlib.suppress(Exception):
+				from frappe.contacts.doctype.address.address import get_company_address
+
+				ctx.update(get_company_address(company) or {})
+	except Exception:
+		pass
+	return ctx
 
 
 def _inline_letterhead_images(html: str) -> str:

--- a/jarvis/tools/_export/document/graphics.py
+++ b/jarvis/tools/_export/document/graphics.py
@@ -38,22 +38,28 @@ _RAG_STATUSES = ("red", "amber", "green")
 
 
 def css_bar(rows: Sequence[Mapping[str, object] | Sequence[object]]) -> str:
-	"""Render an inert CSS bar chart: a ``.bar-chart`` wrapper holding one ``.bar``
-	per row, per Task 2's contract classes.
+	"""Render an inert CSS bar chart as ``.bar-row`` blocks, each a three-column
+	line: ``.bar-label`` (name) · ``.bar-track`` holding the width-set ``.bar`` ·
+	``.bar-value`` (the figure). This is the structure ``theme.THEME_CSS`` styles;
+	the label and value sit BESIDE the bar, never as text crammed inside it.
 
-	Each row supplies ``label``, ``value`` (rendered as escaped text, joined as
-	``"{label} {value}"``) and ``pct`` (the bar's width, clamped to 0-100 - the
-	only number that reaches the inline ``style`` attribute). A row may be a
-	mapping with those three keys, or a positional ``(label, value, pct)``
-	sequence.
+	Each row supplies ``label``, ``value`` (both escaped text) and ``pct`` (the
+	bar's width, clamped to 0-100 - the only number reaching an inline ``style``).
+	A row may be a mapping with those three keys, or a positional
+	``(label, value, pct)`` sequence.
 	"""
-	bars = []
+	rows_html = []
 	for row in rows:
 		label, value, pct = _row_parts(row)
 		width = _clamp_pct(pct)
-		text = f"{_esc(label)} {_esc(value)}"
-		bars.append(f'<div class="bar" style="width:{width}%">{text}</div>')
-	return '<div class="bar-chart">' + "".join(bars) + "</div>"
+		rows_html.append(
+			'<div class="bar-row">'
+			f'<span class="bar-label">{_esc(label)}</span>'
+			f'<span class="bar-track"><span class="bar" style="width:{width}%"></span></span>'
+			f'<span class="bar-value">{_esc(value)}</span>'
+			"</div>"
+		)
+	return '<div class="bar-chart">' + "".join(rows_html) + "</div>"
 
 
 def kpi_tile(label: str, value: str, delta: str | None = None) -> str:

--- a/jarvis/tools/_export/document/theme.py
+++ b/jarvis/tools/_export/document/theme.py
@@ -286,23 +286,40 @@ $indent_rules
 .bar-chart {
 	margin: 10pt 0 16pt;
 }
+/* One row = label | track (holds the bar) | value, kept on a single line so the
+   text never overlaps the bar (nowrap; the three inline-blocks sum to <100%). */
 .bar-chart .bar-row {
 	margin-bottom: 6pt;
+	white-space: nowrap;
 }
 .bar-chart .bar-label {
 	display: inline-block;
-	width: 28%;
+	width: 26%;
 	font-size: 9.5pt;
 	color: $muted;
 	vertical-align: middle;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .bar-chart .bar-track {
 	display: inline-block;
-	width: 70%;
+	width: 52%;
+	height: 14pt;
 	background: $tint;
 	vertical-align: middle;
+	overflow: hidden;
 }
-/* Color/height only - the tool sets `width` per bar via inline style. */
+.bar-chart .bar-value {
+	display: inline-block;
+	width: 20%;
+	font-size: 9.5pt;
+	text-align: right;
+	vertical-align: middle;
+	white-space: nowrap;
+}
+/* Color/height only - the tool sets `width` per bar via inline style. The bar
+   fills the track height and is empty (label/value live in their own columns). */
 .bar {
 	display: block;
 	height: 14pt;


### PR DESCRIPTION
## What

Slice 1.1 — fixes the three rich-PDF **render** defects the Frappe Cloud smoke found (the true gate; Slice 1's unit tests all mock wkhtmltopdf). Rich PDFs otherwise render correctly now (KPI tiles, zebra tables, RAG chips, chart splicing all confirmed on staging).

- **A — letterhead leaked raw Jinja** (`{% if %}`, `{{ }}`) into every page header. The default Letter Head is an HTML/Jinja template that was folded in unrendered. Now rendered via `frappe.render_template` (best-effort company context; a composed report has no source doc, so undefined refs blank out) + a residual-Jinja scrub so a raw/partial template can never leak — static HTML (a logo) survives. Still passes through the existing image-inline + nh3 data-only letterhead gate.
- **B — page numbers printed literal `[page] of [topage]`.** `--disable-javascript` kills wkhtmltopdf's JS-based `[page]` substitution in `--footer-html`. Switched to the **text footer** (`--footer-center`), whose substitution runs in wkhtmltopdf's C++ layer (works with JS off). HTML footer (letterhead/explicit) and text footer are mutually exclusive, so an HTML footer wins and omits auto numbers.
- **C — CSS bar charts rendered garbled** (labels overlapping bars). `css_bar` emitted a flat `.bar` with text crammed inside the colored bar, but `theme.py` styles a `.bar-row/.bar-label/.bar-track/.bar` layout. Rewrote `css_bar` to emit that structure (label | track(bar) | value, one nowrap row) + added the `.bar-value` column and a fixed-height track.

## Tests

164 site-free tests + 151 subtests green; ruff clean. Updated to the new `css_bar` structure + text-footer args; added: letterhead-Jinja-never-leaks-raw, `_render_letterhead` unit cases, html-footer-wins-over-text-page-numbers, letterhead-footer-uses-html-footer.

## ⚠️ Verification

These are **render-behavior** fixes — verified at the structure/logic level here, but the VISUAL result (clean bars, real page numbers, a rendered letterhead) can only be confirmed by a **Frappe Cloud re-smoke** (no wkhtmltopdf locally). Re-run the same "sales & purchase report with charts" prompt on staging after deploy.

## Scope

App-only (plugin/persona unchanged). Builds on the merged Slice 1 (#889). "Trends/line/pie graphs" remain **Slice 2** (matplotlib) — this only fixes the existing CSS **bar** charts.

**DO NOT MERGE — navin merges** (after the staging re-smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
