### PR TITLE
feat: per-turn usage capture + role/cache/tool rollup

### DIFF
--- a/jarvis/chat/entities.py
+++ b/jarvis/chat/entities.py
@@ -74,7 +74,15 @@ def refs_from_tool(args: dict | None, result) -> tuple[str | None, str | None]:
 def entities_for_turn(conversation: str, after_seq: int) -> list[dict]:
 	"""Distinct ``{"doctype", "name"}`` refs from the conversation's
 	``role=tool`` message rows with ``seq > after_seq`` (newest first, max
-	20). ``after_seq=0`` scans the whole conversation's recent tool rows."""
+	20). ``after_seq=0`` scans the whole conversation's recent tool rows.
+
+	Sibling idiom: ``jarvis.chat.usage._turn_tool_call_count`` mirrors this
+	same seq-bounded "tool rows belong to a turn" reasoning to COUNT tool
+	calls within a turn's exact ``[seed_message, assistant_message]`` seq
+	range, rather than list entity refs after a floor - the filter shapes
+	differ (bounded both sides, no ``ref_doctype`` requirement) so it is not
+	a call to this function, just the same idiom applied to a different
+	question."""
 	if not conversation:
 		return []
 	rows = frappe.get_all(

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -374,7 +374,7 @@ def _effect_usage(ctx: _Ctx) -> None:
 	# cycle (subject to the bounded force-done budget, which logs the undercount at
 	# the cap). `recorded` / `valid_zero` return normally: the guard commits with the
 	# effect (done), never double-counting the soft monthly cap on a later replay.
-	outcome = _usage.record_turn_usage(session_key, row)
+	outcome = _usage.record_turn_usage(session_key, row, run_id=ctx.run_id)
 	if outcome == _usage.USAGE_RETRY:
 		raise _UsageRetry(f"usage not fresh for {ctx.run_id} (session {session_key})")
 

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -429,7 +429,12 @@ def _turn_tool_call_count(run_id: str | None) -> int:
 		["conversation", "seed_message", "assistant_message"],
 		as_dict=True,
 	)
-	if not turn or not turn.get("conversation") or not turn.get("seed_message") or not turn.get("assistant_message"):
+	if (
+		not turn
+		or not turn.get("conversation")
+		or not turn.get("seed_message")
+		or not turn.get("assistant_message")
+	):
 		return 0
 	seqs = frappe.db.get_all(
 		CHAT_MESSAGE,

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -227,15 +227,29 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 		input_tokens = int(raw_in or 0)
 		output_tokens = int(raw_out or 0)
 		delta = input_tokens + output_tokens
+		# CDX-review: ONE session fetch (user + profile_agent_id + profile_tier)
+		# covers both branches below - the RECORDED path used to fetch only
+		# `user` here and `_write_turn_usage_row` re-queried the same row for
+		# the two profile fields; VALID_ZERO relied on that same internal
+		# re-query. Widened + threaded through instead (review finding #3).
+		session = (
+			frappe.db.get_value(
+				CHAT_SESSION,
+				{"session_key": session_key},
+				["user", "profile_agent_id", "profile_tier"],
+				as_dict=True,
+			)
+			or {}
+		)
+		user = session.get("user") or ""
 		if delta <= 0:
 			# Task U1: attribution is still worth recording even though there is
 			# no token delta - the turn happened and this is the only record of
 			# WHO it happened for. Isolated + never raises (see the docstring).
-			_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens)
+			_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens, session)
 			return USAGE_VALID_ZERO
 		context_tokens = int(row.get("totalTokens") or 0)
 
-		user = frappe.db.get_value(CHAT_SESSION, {"session_key": session_key}, "user")
 		if not user:
 			# CDX-6: a FRESH POSITIVE token delta with no `Jarvis Chat Session` user
 			# mapping is unattributed real usage, NOT legitimate zero — it must NOT be
@@ -333,7 +347,7 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 		# Task U1: the per-turn usage row, same isolation as the per-model
 		# write just above - a failure here must not lose the aggregate delta
 		# already applied in this transaction, so it only logs and continues.
-		_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens)
+		_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens, session)
 		frappe.db.commit()
 		return USAGE_RECORDED
 	except Exception:
@@ -352,8 +366,16 @@ def _write_turn_usage_row(
 	run_id: str | None,
 	tokens_in: int,
 	tokens_out: int,
+	session: dict,
 ) -> None:
 	"""Best-effort ``Jarvis Turn Usage`` row (task U1, usage-dashboard Part A).
+
+	``session`` is the ``Jarvis Chat Session`` row (``user`` /
+	``profile_agent_id`` / ``profile_tier``) the caller already fetched ONCE
+	(review finding #3 - this used to re-query the same session by
+	``session_key`` a second time; the caller's single fetch now covers both
+	call sites). May be ``{}`` when the session mapping is missing (blank-user
+	attribution row, U1's VALID_ZERO/unmapped-session case).
 
 	Wrapped end-to-end so a failure here can NEVER change ``record_turn_usage``'s
 	returned outcome or raise into the turn - the same isolation the per-model
@@ -370,15 +392,6 @@ def _write_turn_usage_row(
 	until a later agent-runtime build adds one. Re-run the Step-1 live probe from
 	the task-U1 brief to check."""
 	try:
-		session = (
-			frappe.db.get_value(
-				CHAT_SESSION,
-				{"session_key": session_key},
-				["user", "profile_agent_id", "profile_tier"],
-				as_dict=True,
-			)
-			or {}
-		)
 		model, _provider = resolved_model_identity(row)
 		fields = {
 			"run_id": run_id or "",
@@ -416,11 +429,13 @@ def _turn_tool_call_count(run_id: str | None) -> int:
 	"""Count of ``role=tool`` ``Jarvis Chat Message`` rows belonging to the turn
 	named ``run_id``, or 0 when ``run_id`` is absent or unresolvable.
 
-	``Jarvis Chat Message`` carries no direct run/turn link, so this reuses the
-	seq-bounded idiom ``jarvis.chat.entities.entities_for_turn`` already applies
-	for the same reason: tool rows strictly after the turn's ``seed_message``
-	and at-or-before its ``assistant_message`` (by ``seq``, within the same
-	conversation) belong to this turn and no other."""
+	``Jarvis Chat Message`` carries no direct run/turn link, so this MIRRORS
+	(does not call - the filter shapes differ: this needs both a seq LOWER and
+	UPPER bound and no ``ref_doctype`` requirement, see the sibling comment on
+	``jarvis.chat.entities.entities_for_turn``) the same seq-bounded idiom that
+	function applies for the same reason: tool rows strictly after the turn's
+	``seed_message`` and at-or-before its ``assistant_message`` (by ``seq``,
+	within the same conversation) belong to this turn and no other."""
 	if not run_id:
 		return 0
 	turn = frappe.db.get_value(
@@ -446,17 +461,14 @@ def _turn_tool_call_count(run_id: str | None) -> int:
 	asst_seq = seq_by_name.get(turn["assistant_message"])
 	if seed_seq is None or asst_seq is None:
 		return 0
-	return len(
-		frappe.get_all(
-			CHAT_MESSAGE,
-			filters=[
-				["conversation", "=", turn["conversation"]],
-				["role", "=", "tool"],
-				["seq", ">", seed_seq],
-				["seq", "<=", asst_seq],
-			],
-			pluck="name",
-		)
+	return frappe.db.count(
+		CHAT_MESSAGE,
+		filters=[
+			["conversation", "=", turn["conversation"]],
+			["role", "=", "tool"],
+			["seq", ">", seed_seq],
+			["seq", "<=", asst_seq],
+		],
 	)
 
 

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -11,7 +11,7 @@ see ``jarvis.chat.turn_handler`` and the design at
 Three entry points:
   * ``get_or_create_user_settings(user)`` — race-safe lazy row creation with an
     explicit ``owner`` so the ``if_owner`` grant holds when an admin triggers it.
-  * ``record_turn_usage(session_key, row, run_id=None)`` — atomic SQL increments
+  * ``record_turn_usage(session_key, row, run_id=None)`` - atomic SQL increments
     on both the per-user ``Jarvis User Settings`` (month-rollover aware) and the
     cumulative ``Jarvis Chat Session`` fields, plus a best-effort per-turn
     ``Jarvis Turn Usage`` row (usage-dashboard Part A, task U1) carrying the
@@ -48,6 +48,7 @@ TURN_USAGE = "Jarvis Turn Usage"
 CHAT_TURN = "Jarvis Chat Turn"
 CHAT_MESSAGE = "Jarvis Chat Message"
 TURN_USAGE_RETENTION_DAYS = 90
+TURN_USAGE_PRUNE_BATCH_LIMIT = 5000
 
 
 def current_month_key() -> str:
@@ -462,7 +463,9 @@ def prune_turn_usage() -> int:
 	table needs an explicit sweep or it grows forever. Best-effort; never
 	raises out of the scheduler."""
 	cutoff = frappe.utils.add_days(frappe.utils.today(), -TURN_USAGE_RETENTION_DAYS)
-	names = frappe.get_all(TURN_USAGE, filters={"day": ["<", cutoff]}, pluck="name", limit=5000)
+	names = frappe.get_all(
+		TURN_USAGE, filters={"day": ["<", cutoff]}, pluck="name", limit=TURN_USAGE_PRUNE_BATCH_LIMIT
+	)
 	deleted = 0
 	for name in names:
 		try:

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -11,9 +11,12 @@ see ``jarvis.chat.turn_handler`` and the design at
 Three entry points:
   * ``get_or_create_user_settings(user)`` — race-safe lazy row creation with an
     explicit ``owner`` so the ``if_owner`` grant holds when an admin triggers it.
-  * ``record_turn_usage(session_key, row)`` — atomic SQL increments on both the
-    per-user ``Jarvis User Settings`` (month-rollover aware) and the cumulative
-    ``Jarvis Chat Session`` fields. Never raises into the turn.
+  * ``record_turn_usage(session_key, row, run_id=None)`` — atomic SQL increments
+    on both the per-user ``Jarvis User Settings`` (month-rollover aware) and the
+    cumulative ``Jarvis Chat Session`` fields, plus a best-effort per-turn
+    ``Jarvis Turn Usage`` row (usage-dashboard Part A, task U1) carrying the
+    session's role-profile fields, the resolved model, and a tool-call count.
+    Never raises into the turn.
   * ``refresh_session_snapshots(rows)`` — the admin "sync from agent" sweep;
     refreshes per-session snapshot fields WITHOUT accumulating counters.
 """
@@ -41,6 +44,10 @@ USER_SETTINGS = "Jarvis User Settings"
 CHAT_SESSION = "Jarvis Chat Session"
 MODEL_USAGE = "Jarvis User Model Usage"
 MODEL_USAGE_FIELD = "user_model_usage"
+TURN_USAGE = "Jarvis Turn Usage"
+CHAT_TURN = "Jarvis Chat Turn"
+CHAT_MESSAGE = "Jarvis Chat Message"
+TURN_USAGE_RETENTION_DAYS = 90
 
 
 def current_month_key() -> str:
@@ -178,13 +185,21 @@ def resolved_model_identity(row: dict | None) -> tuple[str, str]:
 	return (row.get("model") or "").strip(), (row.get("modelProvider") or "").strip()
 
 
-def record_turn_usage(session_key: str, row: dict | None) -> str:
+def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = None) -> str:
 	"""Record one completed turn's token delta from a ``sessions.list`` row.
 
 	``row`` is the gateway row for THIS session (matched by ``key`` upstream).
 	``inputTokens``/``outputTokens`` are last-run values, so the turn delta is
 	their sum; ``totalTokens`` is the context size (snapshot only). A row with
 	``totalTokensFresh`` false/missing, or null token fields, is do-not-record.
+
+	``run_id`` (task U1, usage-dashboard Part A) is the ``Jarvis Chat Turn.name``
+	finalize's usage effect calls this with, threaded through ONLY to attribute
+	the best-effort ``Jarvis Turn Usage`` row and to seq-bound its tool-call
+	count. Optional and defaulted to ``None`` so the standalone-caller contract
+	(tests, and any future non-finalize caller) is unchanged: without it the row
+	still gets written on the RECORDED/VALID_ZERO paths, just with
+	``tool_calls=0`` and a blank ``run_id``.
 
 	CDX-6 — returns an EXPLICIT outcome so a caller (finalize's usage effect) can
 	distinguish a real accrual from a transient no-data read instead of treating a
@@ -212,6 +227,10 @@ def record_turn_usage(session_key: str, row: dict | None) -> str:
 		output_tokens = int(raw_out or 0)
 		delta = input_tokens + output_tokens
 		if delta <= 0:
+			# Task U1: attribution is still worth recording even though there is
+			# no token delta - the turn happened and this is the only record of
+			# WHO it happened for. Isolated + never raises (see the docstring).
+			_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens)
 			return USAGE_VALID_ZERO
 		context_tokens = int(row.get("totalTokens") or 0)
 
@@ -310,6 +329,10 @@ def record_turn_usage(session_key: str, row: dict | None) -> str:
 					title="jarvis usage: per-model write failed",
 					message=frappe.get_traceback(),
 				)
+		# Task U1: the per-turn usage row, same isolation as the per-model
+		# write just above - a failure here must not lose the aggregate delta
+		# already applied in this transaction, so it only logs and continues.
+		_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens)
 		frappe.db.commit()
 		return USAGE_RECORDED
 	except Exception:
@@ -320,6 +343,136 @@ def record_turn_usage(session_key: str, row: dict | None) -> str:
 		# A partial write is possible; treat a hard failure as retriable so the
 		# finalize usage effect leaves its guard rolled back and re-attempts.
 		return USAGE_RETRY
+
+
+def _write_turn_usage_row(
+	session_key: str,
+	row: dict | None,
+	run_id: str | None,
+	tokens_in: int,
+	tokens_out: int,
+) -> None:
+	"""Best-effort ``Jarvis Turn Usage`` row (task U1, usage-dashboard Part A).
+
+	Wrapped end-to-end so a failure here can NEVER change ``record_turn_usage``'s
+	returned outcome or raise into the turn - the same isolation the per-model
+	attribution write above uses, and for the same reason: this runs between the
+	aggregate UPDATEs and the outer commit (RECORDED path) or before any commit at
+	all (VALID_ZERO path), so a bare exception left to reach the caller would lose
+	real accrual, and a rollback here would be equally wrong (it would
+	deterministically discard the aggregate delta on the RECORDED path).
+
+	cache_read / cache_write / cache_reported: live-checked against a real gateway
+	(tenant jarvis-pool-68b37b, 2026-08-17) - the union of keys across 23 live
+	``sessions.list`` rows carried no cache-token field at all, so these are
+	always ``0 / 0 / False`` (an honest "not reported", not a fabricated zero)
+	until a later agent-runtime build adds one. Re-run the Step-1 live probe from
+	the task-U1 brief to check."""
+	try:
+		session = (
+			frappe.db.get_value(
+				CHAT_SESSION,
+				{"session_key": session_key},
+				["user", "profile_agent_id", "profile_tier"],
+				as_dict=True,
+			)
+			or {}
+		)
+		model, _provider = resolved_model_identity(row)
+		fields = {
+			"run_id": run_id or "",
+			"session_key": session_key,
+			"user": session.get("user") or "",
+			"profile_agent_id": session.get("profile_agent_id") or "",
+			"profile_tier": session.get("profile_tier") or "full",
+			"model": model,
+			"tokens_in": int(tokens_in or 0),
+			"tokens_out": int(tokens_out or 0),
+			"cache_read": 0,
+			"cache_write": 0,
+			"cache_reported": 0,
+			"tool_calls": _turn_tool_call_count(run_id),
+			"day": frappe.utils.today(),
+		}
+		_insert_turn_usage_row(fields)
+	except Exception:
+		frappe.log_error(
+			title="jarvis usage: turn usage row write failed",
+			message=frappe.get_traceback(),
+		)
+
+
+def _insert_turn_usage_row(fields: dict) -> None:
+	"""Plain ORM insert, one row per call - no race to guard against (contrast
+	the per-model child-row upsert machinery above, which merges concurrent
+	writers on the SAME parent+model+month key). Split out as its own function
+	so tests can monkeypatch just the write and observe that a raise here
+	never escapes ``_write_turn_usage_row``."""
+	frappe.get_doc({"doctype": TURN_USAGE, **fields}).insert(ignore_permissions=True)
+
+
+def _turn_tool_call_count(run_id: str | None) -> int:
+	"""Count of ``role=tool`` ``Jarvis Chat Message`` rows belonging to the turn
+	named ``run_id``, or 0 when ``run_id`` is absent or unresolvable.
+
+	``Jarvis Chat Message`` carries no direct run/turn link, so this reuses the
+	seq-bounded idiom ``jarvis.chat.entities.entities_for_turn`` already applies
+	for the same reason: tool rows strictly after the turn's ``seed_message``
+	and at-or-before its ``assistant_message`` (by ``seq``, within the same
+	conversation) belong to this turn and no other."""
+	if not run_id:
+		return 0
+	turn = frappe.db.get_value(
+		CHAT_TURN,
+		run_id,
+		["conversation", "seed_message", "assistant_message"],
+		as_dict=True,
+	)
+	if not turn or not turn.get("conversation") or not turn.get("seed_message") or not turn.get("assistant_message"):
+		return 0
+	seqs = frappe.db.get_all(
+		CHAT_MESSAGE,
+		filters={"name": ["in", [turn["seed_message"], turn["assistant_message"]]]},
+		fields=["name", "seq"],
+	)
+	seq_by_name = {r["name"]: r["seq"] for r in seqs}
+	seed_seq = seq_by_name.get(turn["seed_message"])
+	asst_seq = seq_by_name.get(turn["assistant_message"])
+	if seed_seq is None or asst_seq is None:
+		return 0
+	return len(
+		frappe.get_all(
+			CHAT_MESSAGE,
+			filters=[
+				["conversation", "=", turn["conversation"]],
+				["role", "=", "tool"],
+				["seq", ">", seed_seq],
+				["seq", "<=", asst_seq],
+			],
+			pluck="name",
+		)
+	)
+
+
+def prune_turn_usage() -> int:
+	"""Daily scheduler job (``hooks.py``) - delete ``Jarvis Turn Usage`` rows
+	older than ``TURN_USAGE_RETENTION_DAYS``. Mirrors
+	``jarvis.mobile.device_auth.prune_revoked_devices`` /
+	``jarvis.error_push.prune_pushed_client_errors``: an append-only accounting
+	table needs an explicit sweep or it grows forever. Best-effort; never
+	raises out of the scheduler."""
+	cutoff = frappe.utils.add_days(frappe.utils.today(), -TURN_USAGE_RETENTION_DAYS)
+	names = frappe.get_all(TURN_USAGE, filters={"day": ["<", cutoff]}, pluck="name", limit=5000)
+	deleted = 0
+	for name in names:
+		try:
+			frappe.delete_doc(TURN_USAGE, name, ignore_permissions=True, force=True, delete_permanently=True)
+			deleted += 1
+		except Exception:
+			frappe.logger("jarvis.usage").warning(f"could not prune turn usage row {name}", exc_info=True)
+	if deleted:
+		frappe.db.commit()
+	return deleted
 
 
 def _next_child_idx(user: str) -> int:

--- a/jarvis/chat/usage_push.py
+++ b/jarvis/chat/usage_push.py
@@ -20,10 +20,6 @@ from jarvis.exceptions import AdminAuthError
 USER_SETTINGS = usage.USER_SETTINGS
 MODEL_USAGE = usage.MODEL_USAGE
 MODEL_USAGE_FIELD = usage.MODEL_USAGE_FIELD
-TURN_USAGE = usage.TURN_USAGE
-CHAT_SESSION = usage.CHAT_SESSION
-CHAT_MESSAGE = usage.CHAT_MESSAGE
-CONVERSATION = "Jarvis Conversation"
 
 # Hard cap on users per push (spec §7). Bounds payload size; extra users are
 # dropped (highest-usage first kept) and the truncation is logged.

--- a/jarvis/chat/usage_push.py
+++ b/jarvis/chat/usage_push.py
@@ -79,12 +79,11 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 	truncated = len(rows) > cap
 	rows = rows[:cap]
 	per_model_by_user = _per_model_totals([s.user for s in rows], month)
-	turn_sums_by_user = _turn_usage_user_sums(start, next_month)
-	profile_by_user = _turn_usage_user_profile(start, next_month)
-	top_tools_by_user = _top_tools_by_user(start, next_month)
+	turn_aggregates_by_user = _turn_usage_user_aggregates(start, next_month)
+	top_tools_by_user, tool_calls_by_user, top_tools_tenant = _tool_message_aggregates(start, next_month)
 	users = []
 	for s in rows:
-		sums = turn_sums_by_user.get(s.user, {})
+		agg = turn_aggregates_by_user.get(s.user, {})
 		users.append(
 			{
 				"email": s.user,
@@ -92,12 +91,15 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 				"tokens_out": int(s.month_output_tokens or 0),
 				"total_tokens": int(s.month_tokens or 0),
 				"per_model": per_model_by_user.get(s.user, {}),
-				"profile": profile_by_user.get(s.user, "full"),
-				"turns": sums.get("turns", 0),
-				"cache_read": sums.get("cache_read", 0),
-				"cache_write": sums.get("cache_write", 0),
-				"cache_reported": sums.get("cache_reported", False),
-				"tool_calls": sums.get("tool_calls", 0),
+				"profile": agg.get("profile", "full"),
+				"turns": agg.get("turns", 0),
+				"cache_read": agg.get("cache_read", 0),
+				"cache_write": agg.get("cache_write", 0),
+				"cache_reported": agg.get("cache_reported", False),
+				# Deliberately from _tool_message_aggregates (the SAME
+				# role=tool-message population top_tools counts), NOT from
+				# Turn Usage - see that function's docstring (finding #2).
+				"tool_calls": tool_calls_by_user.get(s.user, 0),
 				"top_tools": top_tools_by_user.get(s.user, []),
 			}
 		)
@@ -105,7 +107,7 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 		"month_key": month,
 		"users": users,
 		"by_profile": _by_profile(start, next_month),
-		"top_tools": _top_tools_tenant(start, next_month),
+		"top_tools": top_tools_tenant,
 	}
 	return rollup, truncated
 
@@ -143,46 +145,34 @@ def _normalize_profile(raw: str | None) -> str:
 	return "full"
 
 
-def _turn_usage_user_sums(start: str, next_month: str) -> dict[str, dict]:
-	"""Per-user turns / cache / tool_calls sums for the month, ONE grouped
-	query (no N+1 over users). Blank-user rows (U1: VALID_ZERO turns with an
-	unmapped session, documented on the Jarvis Turn Usage DocType) are
-	excluded - every rollup aggregate over this table must filter them."""
+def _turn_usage_user_aggregates(start: str, next_month: str) -> dict[str, dict]:
+	"""Per-user turns / cache sums AND profile attribution for the month, ONE
+	grouped query (``GROUP BY user, profile_agent_id``) instead of two
+	separate scans of the same table/window (review finding #6). Blank-user
+	rows (U1: VALID_ZERO turns with an unmapped session, documented on the
+	Jarvis Turn Usage DocType) are excluded - every rollup aggregate over
+	this table must filter them.
+
+	Profile: most-frequent ``profile_agent_id`` this month, mapped to the
+	payload's "full" spelling; ties broken by the most recent turn. ``ORDER
+	BY user, cnt DESC, last_seen DESC`` puts each user's winning row first,
+	so ``setdefault`` only ever sets ``profile`` from that first row while
+	every row (winner or not) still folds into the running sums below.
+
+	NOTE: does NOT return ``tool_calls`` - see ``_tool_message_aggregates``
+	(review finding #2): a user's ``tool_calls`` must describe the SAME
+	role=tool-message population ``top_tools`` counts (including
+	errored/in-flight turns), not Turn Usage's per-COMPLETED-turn count."""
 	out: dict[str, dict] = {}
 	for r in frappe.db.sql(
 		"""
 		SELECT user,
-			   COUNT(*) AS turns,
+			   profile_agent_id,
+			   COUNT(*) AS cnt,
+			   MAX(creation) AS last_seen,
 			   SUM(cache_read) AS cache_read,
 			   SUM(cache_write) AS cache_write,
-			   MAX(cache_reported) AS cache_reported,
-			   SUM(tool_calls) AS tool_calls
-		FROM `tabJarvis Turn Usage`
-		WHERE user != '' AND day >= %(start)s AND day < %(next_month)s
-		GROUP BY user
-		""",
-		{"start": start, "next_month": next_month},
-		as_dict=True,
-	):
-		out[r.user] = {
-			"turns": int(r.turns or 0),
-			"cache_read": int(r.cache_read or 0),
-			"cache_write": int(r.cache_write or 0),
-			"cache_reported": bool(r.cache_reported),
-			"tool_calls": int(r.tool_calls or 0),
-		}
-	return out
-
-
-def _turn_usage_user_profile(start: str, next_month: str) -> dict[str, str]:
-	"""Each user's most-frequent ``profile_agent_id`` this month, mapped to the
-	payload's "full" spelling; ties broken by the most recent turn. ONE grouped
-	query (``GROUP BY user, profile_agent_id``, ordered ``count DESC, last_seen
-	DESC``) - the first row seen per user in that order is the winner."""
-	winners: dict[str, str] = {}
-	for r in frappe.db.sql(
-		"""
-		SELECT user, profile_agent_id, COUNT(*) AS cnt, MAX(creation) AS last_seen
+			   MAX(cache_reported) AS cache_reported
 		FROM `tabJarvis Turn Usage`
 		WHERE user != '' AND day >= %(start)s AND day < %(next_month)s
 		GROUP BY user, profile_agent_id
@@ -191,8 +181,21 @@ def _turn_usage_user_profile(start: str, next_month: str) -> dict[str, str]:
 		{"start": start, "next_month": next_month},
 		as_dict=True,
 	):
-		winners.setdefault(r.user, _normalize_profile(r.profile_agent_id))
-	return winners
+		bucket = out.setdefault(
+			r.user,
+			{
+				"profile": _normalize_profile(r.profile_agent_id),
+				"turns": 0,
+				"cache_read": 0,
+				"cache_write": 0,
+				"cache_reported": False,
+			},
+		)
+		bucket["turns"] += int(r.cnt or 0)
+		bucket["cache_read"] += int(r.cache_read or 0)
+		bucket["cache_write"] += int(r.cache_write or 0)
+		bucket["cache_reported"] = bucket["cache_reported"] or bool(r.cache_reported)
+	return out
 
 
 def _by_profile(start: str, next_month: str) -> list[dict]:
@@ -200,14 +203,19 @@ def _by_profile(start: str, next_month: str) -> list[dict]:
 	Turn Usage, plus n_skills / n_tools - static per profile, read off any
 	Chat Session row referenced by this month's turns for that profile (LEFT
 	JOIN + MAX, no N+1 and no "most recent session" ordering to get right).
-	Raw ``profile_agent_id`` values are merged AFTER mapping to the payload
-	name (""/an invalid value both fold into "full") so the payload never
-	carries two rows for the same profile."""
+
+	Grouped by (user, profile_agent_id) - NOT profile_agent_id alone - so
+	``users`` is deduplicated AFTER mapping to the payload's profile name
+	(review finding #1): a user whose rows split across raw values that both
+	normalize to the same bucket (e.g. "" and an invalid value both folding
+	into "full") must be counted once, which a raw ``COUNT(DISTINCT user)``
+	grouped by the UNMAPPED ``profile_agent_id`` cannot do."""
+	bucket_users: dict[str, set[str]] = {}
 	merged: dict[str, dict] = {}
 	for r in frappe.db.sql(
 		"""
-		SELECT tu.profile_agent_id AS profile_agent_id,
-			   COUNT(DISTINCT tu.user) AS users,
+		SELECT tu.user AS user,
+			   tu.profile_agent_id AS profile_agent_id,
 			   COUNT(*) AS turns,
 			   SUM(tu.tokens_in) AS tokens_in,
 			   SUM(tu.tokens_out) AS tokens_out,
@@ -217,7 +225,7 @@ def _by_profile(start: str, next_month: str) -> list[dict]:
 		FROM `tabJarvis Turn Usage` tu
 		LEFT JOIN `tabJarvis Chat Session` cs ON cs.session_key = tu.session_key
 		WHERE tu.user != '' AND tu.day >= %(start)s AND tu.day < %(next_month)s
-		GROUP BY tu.profile_agent_id
+		GROUP BY tu.user, tu.profile_agent_id
 		""",
 		{"start": start, "next_month": next_month},
 		as_dict=True,
@@ -236,25 +244,49 @@ def _by_profile(start: str, next_month: str) -> list[dict]:
 				"n_tools": 0,
 			},
 		)
-		bucket["users"] += int(r.users or 0)
+		bucket_users.setdefault(profile, set()).add(r.user)
 		bucket["turns"] += int(r.turns or 0)
 		bucket["tokens_in"] += int(r.tokens_in or 0)
 		bucket["tokens_out"] += int(r.tokens_out or 0)
 		bucket["cache_read"] += int(r.cache_read or 0)
 		bucket["n_skills"] = max(bucket["n_skills"], int(r.n_skills or 0))
 		bucket["n_tools"] = max(bucket["n_tools"], int(r.n_tools or 0))
+	for profile, bucket in merged.items():
+		bucket["users"] = len(bucket_users[profile])
 	return sorted(merged.values(), key=lambda b: b["turns"], reverse=True)
 
 
-def _top_tools_by_user(start: str, next_month: str) -> dict[str, list[dict]]:
-	"""Per-user top-``_TOP_TOOLS_USER_CAP`` tool-call counts this month, ONE
-	query (no N+1 over users). Tool names come from the STRUCTURED
-	``tool_name`` field on role=tool ``Jarvis Chat Message`` rows (read at the
-	insert site - ``jarvis.chat.pump._insert_tool_start_row`` - not parsed
-	from the content prefix; a distinct field already carries the name).
-	Attribution is via each message's conversation OWNER - Jarvis Chat
-	Message carries no direct user field, and the brief pins this route."""
-	by_user: dict[str, list[dict]] = {}
+def _tool_message_aggregates(
+	start: str, next_month: str
+) -> tuple[dict[str, list[dict]], dict[str, int], list[dict]]:
+	"""ONE scan of role=tool ``Jarvis Chat Message`` rows this month, deriving
+	THREE results from the same grouped result set instead of two separate
+	table scans (review finding #5 - the tenant-wide total no longer re-scans
+	the table, it is summed from the per-user rows below):
+
+	  * per-user top-``_TOP_TOOLS_USER_CAP`` tool lists (count desc, name asc)
+	  * per-user UNCAPPED tool-call totals - deliberately the SAME population
+	    ``top_tools`` counts: ALL role=tool messages this month, INCLUDING
+	    errored/in-flight turns (review finding #2). This is NOT Turn Usage's
+	    per-COMPLETED-turn ``tool_calls`` sum - that field only ever counts
+	    turns that reached ``record_turn_usage``, so without this fix a user
+	    could show ``tool_calls=0`` with a non-empty ``top_tools`` for the
+	    same month. Turn Usage's own per-turn ``tool_calls`` field (seq-bounded
+	    to ONE turn, written at record time by ``usage._write_turn_usage_row``)
+	    is a different, unrelated field and is untouched by this change.
+	  * tenant-wide top-``_TOP_TOOLS_TENANT_CAP`` list, summed across users.
+
+	Tool names come from the STRUCTURED ``tool_name`` field on role=tool rows
+	(read at the insert site - ``jarvis.chat.pump._insert_tool_start_row`` -
+	not parsed from the content prefix; a distinct field already carries the
+	name). Attribution is via each message's conversation OWNER - Jarvis Chat
+	Message carries no direct user field, and the brief pins this route. A
+	message whose conversation has no resolvable owner (INNER JOIN miss) is
+	excluded from all three results, same as a message with no owner was
+	already excluded from the per-user results before this change."""
+	top_tools_by_user: dict[str, list[dict]] = {}
+	tool_calls_by_user: dict[str, int] = {}
+	tenant_counts: dict[str, int] = {}
 	for r in frappe.db.sql(
 		"""
 		SELECT c.owner AS user, m.tool_name AS tool, COUNT(*) AS cnt
@@ -273,34 +305,15 @@ def _top_tools_by_user(start: str, next_month: str) -> dict[str, list[dict]]:
 		if not _valid_tool_name(r.tool):
 			frappe.logger("jarvis.usage_push").warning("dropping invalid tool name %r from rollup", r.tool)
 			continue
-		bucket = by_user.setdefault(r.user, [])
+		count = int(r.cnt or 0)
+		tool_calls_by_user[r.user] = tool_calls_by_user.get(r.user, 0) + count
+		bucket = top_tools_by_user.setdefault(r.user, [])
 		if len(bucket) < _TOP_TOOLS_USER_CAP:
-			bucket.append({"tool": r.tool, "count": int(r.cnt or 0)})
-	return by_user
-
-
-def _top_tools_tenant(start: str, next_month: str) -> list[dict]:
-	"""Tenant-wide top-``_TOP_TOOLS_TENANT_CAP`` tool-call counts this month,
-	across ALL users (no owner join needed - unlike ``_top_tools_by_user``,
-	nothing here is attributed per user)."""
-	counts: dict[str, int] = {}
-	for r in frappe.db.sql(
-		"""
-		SELECT tool_name AS tool, COUNT(*) AS cnt
-		FROM `tabJarvis Chat Message`
-		WHERE role = 'tool' AND tool_name IS NOT NULL AND tool_name != ''
-		  AND creation >= %(start)s AND creation < %(next_month)s
-		GROUP BY tool_name
-		""",
-		{"start": start, "next_month": next_month},
-		as_dict=True,
-	):
-		if not _valid_tool_name(r.tool):
-			frappe.logger("jarvis.usage_push").warning("dropping invalid tool name %r from rollup", r.tool)
-			continue
-		counts[r.tool] = int(r.cnt or 0)
-	ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
-	return [{"tool": tool, "count": count} for tool, count in ranked[:_TOP_TOOLS_TENANT_CAP]]
+			bucket.append({"tool": r.tool, "count": count})
+		tenant_counts[r.tool] = tenant_counts.get(r.tool, 0) + count
+	ranked = sorted(tenant_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+	top_tools_tenant = [{"tool": tool, "count": count} for tool, count in ranked[:_TOP_TOOLS_TENANT_CAP]]
+	return top_tools_by_user, tool_calls_by_user, top_tools_tenant
 
 
 def _per_model_totals(users: list[str], month: str) -> dict[str, dict[str, dict]]:

--- a/jarvis/chat/usage_push.py
+++ b/jarvis/chat/usage_push.py
@@ -10,6 +10,8 @@ push; admin then shows "no usage".
 
 from __future__ import annotations
 
+import re
+
 import frappe
 
 from jarvis.chat import usage
@@ -18,10 +20,31 @@ from jarvis.exceptions import AdminAuthError
 USER_SETTINGS = usage.USER_SETTINGS
 MODEL_USAGE = usage.MODEL_USAGE
 MODEL_USAGE_FIELD = usage.MODEL_USAGE_FIELD
+TURN_USAGE = usage.TURN_USAGE
+CHAT_SESSION = usage.CHAT_SESSION
+CHAT_MESSAGE = usage.CHAT_MESSAGE
+CONVERSATION = "Jarvis Conversation"
 
 # Hard cap on users per push (spec §7). Bounds payload size; extra users are
 # dropped (highest-usage first kept) and the truncation is logged.
 _MAX_USERS = 500
+
+# Caps on the rollup's task-U2 aggregate lists (contract settled 2026-08-17).
+_TOP_TOOLS_USER_CAP = 10
+_TOP_TOOLS_TENANT_CAP = 15
+
+# Mirrors the admin ingest validator exactly (contract settled 2026-08-17): a
+# bare name, or a "jarvis__" prefixed tool with an UNBOUNDED suffix. A name
+# that matches neither would 400 the whole push (payload-atomic), so it is
+# dropped and logged here instead of ever being emitted - see _valid_tool_name.
+_TOOL_NAME_RE = re.compile(r"[A-Za-z0-9_]{1,64}")
+_JARVIS_TOOL_NAME_RE = re.compile(r"jarvis__[A-Za-z0-9_]+")
+
+# Mirrors the admin profile validator: "" | "full" | role-[a-z0-9+-]{1,63}.
+# profile_agent_id already stores "" or a well-formed "role-*" id in
+# practice; this is cheap insurance against ever emitting something the
+# validator would 400 on.
+_PROFILE_RE = re.compile(r"role-[a-z0-9+-]{1,63}")
 
 
 def _admin_configured() -> bool:
@@ -41,8 +64,16 @@ def _admin_configured() -> bool:
 def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 	"""Month-to-date snapshot: every settings row on the CURRENT month, highest
 	usage first, capped. Returns (rollup, truncated). per_model is a dict keyed by
-	model -> {in, out} (the pinned ingest contract)."""
+	model -> {in, out} (the pinned ingest contract).
+
+	Task U2 adds, sourced from ``Jarvis Turn Usage`` / ``Jarvis Chat Message``
+	(NOT from ``Jarvis User Settings``, which only carries token sums): each
+	user's profile attribution, cache/tool-call aggregates and top_tools, plus
+	the tenant-wide ``by_profile`` and ``top_tools`` blocks. ``users[]`` stays
+	settings-sourced - a settings row with no Turn Usage rows this month just
+	gets the empty/zero defaults, never an entry invented from Turn Usage."""
 	month = usage.current_month_key()
+	start, next_month = _month_range(month)
 	rows = frappe.get_all(
 		USER_SETTINGS,
 		filters={"usage_month": month},
@@ -52,8 +83,12 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 	truncated = len(rows) > cap
 	rows = rows[:cap]
 	per_model_by_user = _per_model_totals([s.user for s in rows], month)
+	turn_sums_by_user = _turn_usage_user_sums(start, next_month)
+	profile_by_user = _turn_usage_user_profile(start, next_month)
+	top_tools_by_user = _top_tools_by_user(start, next_month)
 	users = []
 	for s in rows:
+		sums = turn_sums_by_user.get(s.user, {})
 		users.append(
 			{
 				"email": s.user,
@@ -61,9 +96,215 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 				"tokens_out": int(s.month_output_tokens or 0),
 				"total_tokens": int(s.month_tokens or 0),
 				"per_model": per_model_by_user.get(s.user, {}),
+				"profile": profile_by_user.get(s.user, "full"),
+				"turns": sums.get("turns", 0),
+				"cache_read": sums.get("cache_read", 0),
+				"cache_write": sums.get("cache_write", 0),
+				"cache_reported": sums.get("cache_reported", False),
+				"tool_calls": sums.get("tool_calls", 0),
+				"top_tools": top_tools_by_user.get(s.user, []),
 			}
 		)
-	return {"month_key": month, "users": users}, truncated
+	rollup = {
+		"month_key": month,
+		"users": users,
+		"by_profile": _by_profile(start, next_month),
+		"top_tools": _top_tools_tenant(start, next_month),
+	}
+	return rollup, truncated
+
+
+def _month_range(month: str) -> tuple[str, str]:
+	"""Half-open ``[start, next)`` date strings ``"YYYY-MM-DD"`` for a
+	``"YYYY-MM"`` month key - usable against both a Date column (Turn Usage's
+	``day``) and a Datetime column (Chat Message's ``creation``)."""
+	year, mon = (int(part) for part in month.split("-"))
+	start = f"{month}-01"
+	next_month = f"{year + 1}-01-01" if mon == 12 else f"{year}-{mon + 1:02d}-01"
+	return start, next_month
+
+
+def _valid_tool_name(name: str | None) -> bool:
+	"""True iff ``name`` matches one of the admin ingest validator's two
+	accepted shapes. Anything else must never be emitted (the push is
+	payload-atomic on the admin side - one bad name 400s the whole rollup)."""
+	if not name:
+		return False
+	return bool(_TOOL_NAME_RE.fullmatch(name) or _JARVIS_TOOL_NAME_RE.fullmatch(name))
+
+
+def _normalize_profile(raw: str | None) -> str:
+	"""Empty string -> "full"; a well-formed "role-*" id passes through unchanged;
+	anything else is coerced to "full" and logged - should never fire in
+	practice (profile_agent_id is only ever written as "" or "role-*"), but
+	the admin's profile validator would 400 the whole push on a bad value."""
+	raw = (raw or "").strip()
+	if not raw:
+		return "full"
+	if _PROFILE_RE.fullmatch(raw):
+		return raw
+	frappe.logger("jarvis.usage_push").warning("dropping invalid profile_agent_id %r from rollup", raw)
+	return "full"
+
+
+def _turn_usage_user_sums(start: str, next_month: str) -> dict[str, dict]:
+	"""Per-user turns / cache / tool_calls sums for the month, ONE grouped
+	query (no N+1 over users). Blank-user rows (U1: VALID_ZERO turns with an
+	unmapped session, documented on the Jarvis Turn Usage DocType) are
+	excluded - every rollup aggregate over this table must filter them."""
+	out: dict[str, dict] = {}
+	for r in frappe.db.sql(
+		"""
+		SELECT user,
+			   COUNT(*) AS turns,
+			   SUM(cache_read) AS cache_read,
+			   SUM(cache_write) AS cache_write,
+			   MAX(cache_reported) AS cache_reported,
+			   SUM(tool_calls) AS tool_calls
+		FROM `tabJarvis Turn Usage`
+		WHERE user != '' AND day >= %(start)s AND day < %(next_month)s
+		GROUP BY user
+		""",
+		{"start": start, "next_month": next_month},
+		as_dict=True,
+	):
+		out[r.user] = {
+			"turns": int(r.turns or 0),
+			"cache_read": int(r.cache_read or 0),
+			"cache_write": int(r.cache_write or 0),
+			"cache_reported": bool(r.cache_reported),
+			"tool_calls": int(r.tool_calls or 0),
+		}
+	return out
+
+
+def _turn_usage_user_profile(start: str, next_month: str) -> dict[str, str]:
+	"""Each user's most-frequent ``profile_agent_id`` this month, mapped to the
+	payload's "full" spelling; ties broken by the most recent turn. ONE grouped
+	query (``GROUP BY user, profile_agent_id``, ordered ``count DESC, last_seen
+	DESC``) - the first row seen per user in that order is the winner."""
+	winners: dict[str, str] = {}
+	for r in frappe.db.sql(
+		"""
+		SELECT user, profile_agent_id, COUNT(*) AS cnt, MAX(creation) AS last_seen
+		FROM `tabJarvis Turn Usage`
+		WHERE user != '' AND day >= %(start)s AND day < %(next_month)s
+		GROUP BY user, profile_agent_id
+		ORDER BY user, cnt DESC, last_seen DESC
+		""",
+		{"start": start, "next_month": next_month},
+		as_dict=True,
+	):
+		winners.setdefault(r.user, _normalize_profile(r.profile_agent_id))
+	return winners
+
+
+def _by_profile(start: str, next_month: str) -> list[dict]:
+	"""Tenant-wide per-profile block: users / turns / token+cache sums from
+	Turn Usage, plus n_skills / n_tools - static per profile, read off any
+	Chat Session row referenced by this month's turns for that profile (LEFT
+	JOIN + MAX, no N+1 and no "most recent session" ordering to get right).
+	Raw ``profile_agent_id`` values are merged AFTER mapping to the payload
+	name (""/an invalid value both fold into "full") so the payload never
+	carries two rows for the same profile."""
+	merged: dict[str, dict] = {}
+	for r in frappe.db.sql(
+		"""
+		SELECT tu.profile_agent_id AS profile_agent_id,
+			   COUNT(DISTINCT tu.user) AS users,
+			   COUNT(*) AS turns,
+			   SUM(tu.tokens_in) AS tokens_in,
+			   SUM(tu.tokens_out) AS tokens_out,
+			   SUM(tu.cache_read) AS cache_read,
+			   MAX(cs.profile_n_skills) AS n_skills,
+			   MAX(cs.profile_n_tools) AS n_tools
+		FROM `tabJarvis Turn Usage` tu
+		LEFT JOIN `tabJarvis Chat Session` cs ON cs.session_key = tu.session_key
+		WHERE tu.user != '' AND tu.day >= %(start)s AND tu.day < %(next_month)s
+		GROUP BY tu.profile_agent_id
+		""",
+		{"start": start, "next_month": next_month},
+		as_dict=True,
+	):
+		profile = _normalize_profile(r.profile_agent_id)
+		bucket = merged.setdefault(
+			profile,
+			{
+				"profile": profile,
+				"users": 0,
+				"turns": 0,
+				"tokens_in": 0,
+				"tokens_out": 0,
+				"cache_read": 0,
+				"n_skills": 0,
+				"n_tools": 0,
+			},
+		)
+		bucket["users"] += int(r.users or 0)
+		bucket["turns"] += int(r.turns or 0)
+		bucket["tokens_in"] += int(r.tokens_in or 0)
+		bucket["tokens_out"] += int(r.tokens_out or 0)
+		bucket["cache_read"] += int(r.cache_read or 0)
+		bucket["n_skills"] = max(bucket["n_skills"], int(r.n_skills or 0))
+		bucket["n_tools"] = max(bucket["n_tools"], int(r.n_tools or 0))
+	return sorted(merged.values(), key=lambda b: b["turns"], reverse=True)
+
+
+def _top_tools_by_user(start: str, next_month: str) -> dict[str, list[dict]]:
+	"""Per-user top-``_TOP_TOOLS_USER_CAP`` tool-call counts this month, ONE
+	query (no N+1 over users). Tool names come from the STRUCTURED
+	``tool_name`` field on role=tool ``Jarvis Chat Message`` rows (read at the
+	insert site - ``jarvis.chat.pump._insert_tool_start_row`` - not parsed
+	from the content prefix; a distinct field already carries the name).
+	Attribution is via each message's conversation OWNER - Jarvis Chat
+	Message carries no direct user field, and the brief pins this route."""
+	by_user: dict[str, list[dict]] = {}
+	for r in frappe.db.sql(
+		"""
+		SELECT c.owner AS user, m.tool_name AS tool, COUNT(*) AS cnt
+		FROM `tabJarvis Chat Message` m
+		INNER JOIN `tabJarvis Conversation` c ON c.name = m.conversation
+		WHERE m.role = 'tool' AND m.tool_name IS NOT NULL AND m.tool_name != ''
+		  AND m.creation >= %(start)s AND m.creation < %(next_month)s
+		GROUP BY c.owner, m.tool_name
+		ORDER BY c.owner, cnt DESC, m.tool_name ASC
+		""",
+		{"start": start, "next_month": next_month},
+		as_dict=True,
+	):
+		if not r.user:
+			continue
+		if not _valid_tool_name(r.tool):
+			frappe.logger("jarvis.usage_push").warning("dropping invalid tool name %r from rollup", r.tool)
+			continue
+		bucket = by_user.setdefault(r.user, [])
+		if len(bucket) < _TOP_TOOLS_USER_CAP:
+			bucket.append({"tool": r.tool, "count": int(r.cnt or 0)})
+	return by_user
+
+
+def _top_tools_tenant(start: str, next_month: str) -> list[dict]:
+	"""Tenant-wide top-``_TOP_TOOLS_TENANT_CAP`` tool-call counts this month,
+	across ALL users (no owner join needed - unlike ``_top_tools_by_user``,
+	nothing here is attributed per user)."""
+	counts: dict[str, int] = {}
+	for r in frappe.db.sql(
+		"""
+		SELECT tool_name AS tool, COUNT(*) AS cnt
+		FROM `tabJarvis Chat Message`
+		WHERE role = 'tool' AND tool_name IS NOT NULL AND tool_name != ''
+		  AND creation >= %(start)s AND creation < %(next_month)s
+		GROUP BY tool_name
+		""",
+		{"start": start, "next_month": next_month},
+		as_dict=True,
+	):
+		if not _valid_tool_name(r.tool):
+			frappe.logger("jarvis.usage_push").warning("dropping invalid tool name %r from rollup", r.tool)
+			continue
+		counts[r.tool] = int(r.cnt or 0)
+	ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+	return [{"tool": tool, "count": count} for tool, count in ranked[:_TOP_TOOLS_TENANT_CAP]]
 
 
 def _per_model_totals(users: list[str], month: str) -> dict[str, dict[str, dict]]:

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -445,6 +445,11 @@ scheduler_events = {
 		# admin past the retention window (the durable record lives in the admin's
 		# Jarvis Tenant Error). Keeps the local buffer small.
 		"jarvis.error_push.prune_pushed_client_errors",
+		# Usage-dashboard Part A (task U1): Jarvis Turn Usage is an append-only
+		# per-turn accounting row written on every completed turn (see
+		# jarvis.chat.usage.record_turn_usage); without a sweep it grows
+		# forever. 90-day retention, same shape as the two prune jobs above.
+		"jarvis.chat.usage.prune_turn_usage",
 		# Role-profile agents reconcile backstop: the User.on_update hook
 		# enqueues a resync on every role change, but a debounced job can be
 		# dropped (Redis down, a worker restart mid-run). Daily catches the

--- a/jarvis/jarvis/doctype/jarvis_turn_usage/jarvis_turn_usage.json
+++ b/jarvis/jarvis/doctype/jarvis_turn_usage/jarvis_turn_usage.json
@@ -1,0 +1,141 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-17 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "run_id",
+  "session_key",
+  "user",
+  "profile_agent_id",
+  "profile_tier",
+  "model",
+  "tokens_in",
+  "tokens_out",
+  "cache_read",
+  "cache_write",
+  "cache_reported",
+  "tool_calls",
+  "day"
+ ],
+ "fields": [
+  {
+   "fieldname": "run_id",
+   "fieldtype": "Data",
+   "label": "Run ID",
+   "search_index": 1,
+   "in_list_view": 1,
+   "description": "Jarvis Chat Turn.name (run_id) this row attributes to. Not schema-unique: record_turn_usage's NEVER-raises contract must never fail an insert on a duplicate-key error, so any at-most-once guarantee is enforced by the caller (finalize's usage_recorded CAS), not by this table."
+  },
+  {
+   "fieldname": "session_key",
+   "fieldtype": "Data",
+   "label": "Session Key",
+   "search_index": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Data",
+   "label": "User",
+   "search_index": 1,
+   "in_list_view": 1,
+   "description": "Snapshot of Jarvis Chat Session.user at write time (Data, not a Link, matching this table's other snapshot fields)."
+  },
+  {
+   "fieldname": "profile_agent_id",
+   "fieldtype": "Data",
+   "label": "Profile Agent ID",
+   "description": "Jarvis Chat Session.profile_agent_id snapshot. Empty string means the main/full agent (no role profile)."
+  },
+  {
+   "fieldname": "profile_tier",
+   "fieldtype": "Data",
+   "label": "Profile Tier",
+   "default": "full",
+   "description": "Jarvis Chat Session.profile_tier snapshot; defaults to \"full\" when the session carries no tier (pre-role-profile sessions)."
+  },
+  {
+   "fieldname": "model",
+   "fieldtype": "Data",
+   "label": "Model",
+   "in_list_view": 1,
+   "description": "usage.resolved_model_identity(row) for this turn - the same decode the aggregate + per-model accrual use, so this row's credit can never disagree with them."
+  },
+  {
+   "fieldname": "tokens_in",
+   "fieldtype": "Int",
+   "label": "Tokens In",
+   "default": "0",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "tokens_out",
+   "fieldtype": "Int",
+   "label": "Tokens Out",
+   "default": "0",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "cache_read",
+   "fieldtype": "Int",
+   "label": "Cache Read",
+   "default": "0",
+   "description": "0 when the gateway build in use does not report cache token fields on sessions.list rows (verified empty against a live gateway on 2026-08-17; re-check resolved_model_identity's neighbouring cache decode if a later runtime adds cache*Tokens keys)."
+  },
+  {
+   "fieldname": "cache_write",
+   "fieldtype": "Int",
+   "label": "Cache Write",
+   "default": "0",
+   "description": "See cache_read: 0 under the same no-cache-fields-reported condition."
+  },
+  {
+   "fieldname": "cache_reported",
+   "fieldtype": "Check",
+   "label": "Cache Reported",
+   "default": "0",
+   "description": "True only when the gateway row actually carried cache token fields for this turn. False means cache_read/cache_write are NOT a real zero measurement - the admin UI must render \"n/a\", not 0, when this is unchecked."
+  },
+  {
+   "fieldname": "tool_calls",
+   "fieldtype": "Int",
+   "label": "Tool Calls",
+   "default": "0",
+   "in_list_view": 1,
+   "description": "Count of role=tool Jarvis Chat Message rows in this turn's conversation, seq-bounded between the turn's seed_message and assistant_message (Jarvis Chat Message carries no direct run/turn link - jarvis.chat.entities.entities_for_turn uses the same seq-bounded idiom)."
+  },
+  {
+   "fieldname": "day",
+   "fieldtype": "Date",
+   "label": "Day",
+   "search_index": 1,
+   "in_list_view": 1,
+   "description": "Calendar day (site timezone) the turn was recorded, for daily rollups and the 90-day prune job."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-17 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Turn Usage",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "role": "Jarvis Admin"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_turn_usage/jarvis_turn_usage.json
+++ b/jarvis/jarvis/doctype/jarvis_turn_usage/jarvis_turn_usage.json
@@ -42,7 +42,7 @@
    "label": "User",
    "search_index": 1,
    "in_list_view": 1,
-   "description": "Snapshot of Jarvis Chat Session.user at write time (Data, not a Link, matching this table's other snapshot fields)."
+   "description": "Snapshot of Jarvis Chat Session.user at write time (Data, not a Link, matching this table's other snapshot fields). Can be empty on a VALID_ZERO turn whose session_key has no Jarvis Chat Session row (no mapping to attribute to) - downstream rollups must filter blank-user rows rather than treating them as a real user."
   },
   {
    "fieldname": "profile_agent_id",

--- a/jarvis/jarvis/doctype/jarvis_turn_usage/jarvis_turn_usage.py
+++ b/jarvis/jarvis/doctype/jarvis_turn_usage/jarvis_turn_usage.py
@@ -1,0 +1,16 @@
+"""Jarvis Turn Usage DocType controller.
+
+One append-only row per completed turn's usage attribution (role-labelled,
+cache-aware usage-dashboard Part A, task U1). Written best-effort inside
+``jarvis.chat.usage.record_turn_usage`` on the RECORDED and VALID_ZERO paths,
+try/except-wrapped so a write failure here can never change that function's
+returned outcome or raise into the turn (the module's NEVER-raises contract).
+There is no end-user create/write/delete; every insert goes through a server
+path with ``ignore_permissions=True``.
+"""
+
+from frappe.model.document import Document
+
+
+class JarvisTurnUsage(Document):
+	pass

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -65,7 +65,9 @@ def _cleanup() -> None:
 	# every fixture in this file uses instead.
 	for name in frappe.get_all(TURN_USAGE, filters={"session_key": ["like", "agent:tu-%"]}, pluck="name"):
 		frappe.delete_doc(TURN_USAGE, name, ignore_permissions=True, force=True)
-	for name in frappe.get_all(CHAT_TURN, filters={"relay_target_id": ["like", "test-turnusage-%"]}, pluck="name"):
+	for name in frappe.get_all(
+		CHAT_TURN, filters={"relay_target_id": ["like", "test-turnusage-%"]}, pluck="name"
+	):
 		frappe.delete_doc(CHAT_TURN, name, ignore_permissions=True, force=True)
 	for name in frappe.get_all(
 		CONV, filters={"title": ["like", "turnusage-fixture%"]}, pluck="name"
@@ -168,9 +170,7 @@ class TestTurnUsage(FrappeTestCase):
 		self.assertFalse(frappe.db.exists(TURN_USAGE, {"session_key": "agent:tu-retry"}))
 
 	def test_retry_no_session_mapping_writes_nothing(self):
-		outcome = usage.record_turn_usage(
-			"agent:tu-unmapped", self._row(inputTokens=5, outputTokens=5)
-		)
+		outcome = usage.record_turn_usage("agent:tu-unmapped", self._row(inputTokens=5, outputTokens=5))
 		self.assertEqual(outcome, usage.USAGE_RETRY)
 		self.assertFalse(frappe.db.exists(TURN_USAGE, {"session_key": "agent:tu-unmapped"}))
 

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -261,11 +261,16 @@ def _seed_turn_row(
 	cache_reported: int = 0,
 	tool_calls: int = 0,
 	creation=None,
+	day=None,
 ) -> str:
 	"""Insert a bare Jarvis Turn Usage row (task U2 rollup tests): the rollup
 	builder consumes these rows directly, so seeding them straight (rather
 	than round-tripping through record_turn_usage's gateway-row shape) keeps
-	the fixtures focused on the aggregation being tested."""
+	the fixtures focused on the aggregation being tested. ``day`` defaults to
+	today (the real current month); pass an explicit day to land a row in a
+	synthetic month a test has pinned via current_month_key, keeping it
+	isolated from this bench's real Turn Usage traffic in the real current
+	month (see test_empty_month_yields_old_shape_plus_empty_new_fields)."""
 	doc = frappe.get_doc(
 		{
 			"doctype": TURN_USAGE,
@@ -280,7 +285,7 @@ def _seed_turn_row(
 			"cache_write": cache_write,
 			"cache_reported": cache_reported,
 			"tool_calls": tool_calls,
-			"day": frappe.utils.today(),
+			"day": day or frappe.utils.today(),
 			"run_id": "",
 		}
 	)
@@ -383,6 +388,9 @@ class TestUsageRollup(FrappeTestCase):
 			cache_read=2,
 			cache_write=1,
 			cache_reported=1,
+			# Turn Usage's OWN tool_calls (per-turn, seq-bounded) is a
+			# different field from the rollup's per-user tool_calls - see
+			# test_tool_calls_reflects_tool_messages_not_turn_usage below.
 			tool_calls=3,
 		)
 		_seed_turn_row(
@@ -407,7 +415,26 @@ class TestUsageRollup(FrappeTestCase):
 		# bool OR over the month's rows - one row reported, one did not.
 		self.assertTrue(u["cache_reported"])
 		self.assertIs(u["cache_reported"], True)
-		self.assertEqual(u["tool_calls"], 4)
+		# No Chat Message role=tool rows were seeded, so the rollup's
+		# tool_calls (sourced from Chat Message, not Turn Usage - review
+		# finding #2) is 0 despite Turn Usage rows carrying tool_calls=3/1.
+		self.assertEqual(u["tool_calls"], 0)
+
+	# -- (b2) tool_calls tracks Chat Message, not Turn Usage (finding #2) --- #
+	def test_tool_calls_reflects_tool_messages_not_turn_usage(self):
+		self._seed_settings(USER_A, 10)
+		# A completed turn whose OWN Turn Usage row says tool_calls=5 - this
+		# must NOT leak into the rollup's per-user tool_calls.
+		_seed_turn_row("agent:tu-roll-tc1", USER_A, profile_agent_id="role-hr", tool_calls=5)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		self.assertEqual(users[USER_A]["tool_calls"], 0)
+		# Now add role=tool messages (the population top_tools/tool_calls
+		# actually describe) - tool_calls must track THIS count instead.
+		_seed_tool_messages(USER_A, "rollup-fixture-toolcalls", ["get_list", "get_list", "read_doc"])
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		self.assertEqual(users[USER_A]["tool_calls"], 3)
 
 	# -- (c) blank profile_agent_id maps to "full" --------------------------- #
 	def test_blank_profile_maps_to_full(self):
@@ -479,6 +506,27 @@ class TestUsageRollup(FrappeTestCase):
 		self.assertEqual(by_profile["role-p2"]["n_skills"], 2)
 		self.assertEqual(by_profile["role-p2"]["n_tools"], 3)
 
+	# -- (f2) by_profile users dedups a user split across raw values that --- #
+	# -- both normalize to the same bucket (finding #1) --------------------- #
+	def test_by_profile_users_deduped_after_normalization(self):
+		# Pinned to a synthetic month (see test_empty_month_...): this bench's
+		# real Turn Usage traffic in the ACTUAL current month already has
+		# other users landing in the "full" bucket, which would make a users
+		# count assertion against the real month flaky/wrong.
+		with patch("jarvis.chat.usage.current_month_key", return_value="2000-02"):
+			self._seed_settings(USER_A, 10)
+			# "" and an invalid raw profile_agent_id (fails the role-*
+			# validator) both normalize to "full" - the SAME user must only
+			# be counted once.
+			_seed_turn_row("agent:tu-roll-norm1", USER_A, profile_agent_id="", day="2000-02-10")
+			_seed_turn_row(
+				"agent:tu-roll-norm2", USER_A, profile_agent_id="not-a-valid-profile", day="2000-02-11"
+			)
+			rollup, _ = usage_push._build_rollup()
+		by_profile = {b["profile"]: b for b in rollup["by_profile"]}
+		self.assertEqual(by_profile["full"]["users"], 1)
+		self.assertEqual(by_profile["full"]["turns"], 2)
+
 	# -- (g) top_tools: per-user ordering by count, cap 10 -------------------- #
 	def test_top_tools_per_user_ordering_and_cap(self):
 		self._seed_settings(USER_A, 10)
@@ -493,6 +541,9 @@ class TestUsageRollup(FrappeTestCase):
 		self.assertEqual(len(top), 10)
 		self.assertEqual([t["tool"] for t in top], sorted(names)[:10])
 		self.assertTrue(all(t["count"] == 1 for t in top))
+		# tool_calls is the UNCAPPED total (11), not len(top_tools) (10) -
+		# the cap only bounds the list, not the count (findings #2 / #5).
+		self.assertEqual(users[USER_A]["tool_calls"], 11)
 
 	def test_top_tools_ordering_by_count(self):
 		self._seed_settings(USER_A, 10)

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -1,0 +1,241 @@
+"""Tests for per-turn usage capture (usage-dashboard Part A, task U1).
+
+Hermetic like test_usage_per_model.py: disposable fixture users/sessions
+created in setUp, and because record_turn_usage COMMITS, every Jarvis User
+Settings + Jarvis Chat Session + Jarvis Turn Usage row (plus, for the
+tool_calls tests, the Jarvis Conversation / Jarvis Chat Turn / Jarvis Chat
+Message rows) owned or referencing a fixture user is deleted in tearDown - a
+transaction rollback cannot undo a commit.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import usage
+
+USETT = "Jarvis User Settings"
+SESSION = "Jarvis Chat Session"
+TURN_USAGE = "Jarvis Turn Usage"
+CONV = "Jarvis Conversation"
+CHAT_TURN = "Jarvis Chat Turn"
+MSG = "Jarvis Chat Message"
+
+USER_A = "jarvis-turnusage-a@example.test"
+_ALL_USERS = (USER_A,)
+
+
+def _ensure_user(email: str) -> None:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Jarvis",
+				"last_name": "TurnUsageTest",
+				"enabled": 1,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+
+
+def _make_session(session_key: str, user: str, *, profile_agent_id: str = "", profile_tier: str = "") -> None:
+	frappe.get_doc(
+		{
+			"doctype": SESSION,
+			"session_key": session_key,
+			"user": user,
+			"profile_agent_id": profile_agent_id,
+			"profile_tier": profile_tier,
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _cleanup() -> None:
+	for name in frappe.get_all(TURN_USAGE, filters={"user": ["in", list(_ALL_USERS)]}, pluck="name"):
+		frappe.delete_doc(TURN_USAGE, name, ignore_permissions=True, force=True)
+	for name in frappe.get_all(CHAT_TURN, filters={"relay_target_id": ["like", "test-turnusage-%"]}, pluck="name"):
+		frappe.delete_doc(CHAT_TURN, name, ignore_permissions=True, force=True)
+	for name in frappe.get_all(CONV, filters={"title": ["like", "turnusage-fixture%"]}, pluck="name"):
+		for msg in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
+			frappe.delete_doc(MSG, msg, ignore_permissions=True, force=True)
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	for email in _ALL_USERS:
+		for name in frappe.get_all(USETT, filters={"user": email}, pluck="name"):
+			frappe.delete_doc(USETT, name, ignore_permissions=True, force=True)
+		for name in frappe.get_all(SESSION, filters={"user": email}, pluck="name"):
+			frappe.delete_doc(SESSION, name, ignore_permissions=True, force=True)
+
+
+class TestTurnUsage(FrappeTestCase):
+	def setUp(self):
+		self._orig_user = frappe.session.user
+		frappe.set_user("Administrator")
+		_ensure_user(USER_A)
+		_cleanup()
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_cleanup()
+		frappe.db.commit()
+		frappe.set_user(self._orig_user)
+
+	def _row(self, **kw):
+		base = {
+			"totalTokensFresh": True,
+			"inputTokens": 0,
+			"outputTokens": 0,
+			"totalTokens": 0,
+			"model": "gpt-5.5",
+			"modelProvider": "openai",
+		}
+		base.update(kw)
+		return base
+
+	# -- (a) RECORDED path writes one row with profile fields + in/out ------- #
+	def test_recorded_row_carries_profile_and_tokens(self):
+		_make_session("agent:tu-rec", USER_A, profile_agent_id="role-hr", profile_tier="lite")
+		outcome = usage.record_turn_usage(
+			"agent:tu-rec", self._row(inputTokens=10, outputTokens=5, totalTokens=100)
+		)
+		self.assertEqual(outcome, usage.USAGE_RECORDED)
+		rows = frappe.get_all(
+			TURN_USAGE,
+			filters={"session_key": "agent:tu-rec"},
+			fields=[
+				"user",
+				"profile_agent_id",
+				"profile_tier",
+				"model",
+				"tokens_in",
+				"tokens_out",
+				"cache_read",
+				"cache_write",
+				"cache_reported",
+			],
+		)
+		self.assertEqual(len(rows), 1)
+		row = rows[0]
+		self.assertEqual(row.user, USER_A)
+		self.assertEqual(row.profile_agent_id, "role-hr")
+		self.assertEqual(row.profile_tier, "lite")
+		self.assertEqual(row.model, "gpt-5.5")
+		self.assertEqual(row.tokens_in, 10)
+		self.assertEqual(row.tokens_out, 5)
+		# Live-checked 2026-08-17: the gateway build in use reports no cache
+		# token fields on sessions.list rows, so these are always the honest
+		# "not reported" state, never a fabricated zero.
+		self.assertEqual(row.cache_read, 0)
+		self.assertEqual(row.cache_write, 0)
+		self.assertEqual(row.cache_reported, 0)
+
+	# -- (b) VALID_ZERO path still writes a row (attribution, zero tokens) -- #
+	def test_valid_zero_row_writes_attribution(self):
+		_make_session("agent:tu-zero", USER_A, profile_agent_id="", profile_tier="full")
+		outcome = usage.record_turn_usage("agent:tu-zero", self._row(inputTokens=0, outputTokens=0))
+		self.assertEqual(outcome, usage.USAGE_VALID_ZERO)
+		rows = frappe.get_all(
+			TURN_USAGE,
+			filters={"session_key": "agent:tu-zero"},
+			fields=["user", "tokens_in", "tokens_out"],
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].user, USER_A)
+		self.assertEqual(rows[0].tokens_in, 0)
+		self.assertEqual(rows[0].tokens_out, 0)
+
+	# -- (c) RETRY path writes nothing ---------------------------------------- #
+	def test_retry_path_writes_nothing(self):
+		_make_session("agent:tu-retry", USER_A)
+		outcome = usage.record_turn_usage(
+			"agent:tu-retry", self._row(totalTokensFresh=False, inputTokens=10, outputTokens=5)
+		)
+		self.assertEqual(outcome, usage.USAGE_RETRY)
+		self.assertFalse(frappe.db.exists(TURN_USAGE, {"session_key": "agent:tu-retry"}))
+
+	def test_retry_no_session_mapping_writes_nothing(self):
+		outcome = usage.record_turn_usage(
+			"agent:tu-unmapped", self._row(inputTokens=5, outputTokens=5)
+		)
+		self.assertEqual(outcome, usage.USAGE_RETRY)
+		self.assertFalse(frappe.db.exists(TURN_USAGE, {"session_key": "agent:tu-unmapped"}))
+
+	# -- (d) a raising turn-usage write must not break the accrual ---------- #
+	def test_row_write_failure_does_not_change_outcome(self):
+		_make_session("agent:tu-fail", USER_A)
+		title = "jarvis usage: turn usage row write failed"
+		before = frappe.db.count("Error Log", {"method": title})
+		with patch("jarvis.chat.usage._insert_turn_usage_row", side_effect=RuntimeError("boom")):
+			outcome = usage.record_turn_usage(
+				"agent:tu-fail", self._row(inputTokens=7, outputTokens=3, totalTokens=50)
+			)
+		self.assertEqual(outcome, usage.USAGE_RECORDED)
+		# The aggregate accrual still landed even though the per-turn row write failed.
+		s = frappe.db.get_value(USETT, {"user": USER_A}, "month_tokens")
+		self.assertEqual(s, 10)
+		after = frappe.db.count("Error Log", {"method": title})
+		self.assertGreater(after, before)
+		self.assertFalse(frappe.db.exists(TURN_USAGE, {"session_key": "agent:tu-fail"}))
+
+	# -- (e) tool_calls counts tool-role messages seq-bounded to the turn --- #
+	def _make_turn_with_tools(self, user: str) -> str:
+		"""Conversation: [tool(before), user(seed), tool, tool, assistant, tool(after)].
+		Returns the Jarvis Chat Turn's run_id. Only the two tool rows strictly
+		between seed_message and assistant_message (by seq) must count."""
+		conv = frappe.get_doc(
+			{"doctype": CONV, "title": "turnusage-fixture", "status": "Active", "owner": user}
+		)
+		conv.insert(ignore_permissions=True)
+
+		def _msg(seq: int, role: str, **kw) -> str:
+			doc = frappe.get_doc(
+				{"doctype": MSG, "conversation": conv.name, "seq": seq, "role": role, "content": "", **kw}
+			)
+			doc.insert(ignore_permissions=True)
+			return doc.name
+
+		_msg(1, "tool", tool_name="before_turn")
+		seed_name = _msg(2, "user", content="do the thing")
+		_msg(3, "tool", tool_name="in_turn_1")
+		_msg(4, "tool", tool_name="in_turn_2")
+		asst_name = _msg(5, "assistant", content="done")
+		_msg(6, "tool", tool_name="after_turn")
+
+		run_id = f"test-turnusage-{frappe.generate_hash(length=10)}"
+		frappe.get_doc(
+			{
+				"doctype": CHAT_TURN,
+				"run_id": run_id,
+				"conversation": conv.name,
+				"relay_target_id": run_id,
+				"seed_message": seed_name,
+				"assistant_message": asst_name,
+				"state": "done",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return run_id
+
+	def test_tool_calls_counts_only_rows_within_the_turn(self):
+		_make_session("agent:tu-tools", USER_A)
+		run_id = self._make_turn_with_tools(USER_A)
+		outcome = usage.record_turn_usage(
+			"agent:tu-tools",
+			self._row(inputTokens=4, outputTokens=2, totalTokens=60),
+			run_id=run_id,
+		)
+		self.assertEqual(outcome, usage.USAGE_RECORDED)
+		tool_calls = frappe.db.get_value(TURN_USAGE, {"session_key": "agent:tu-tools"}, "tool_calls")
+		self.assertEqual(tool_calls, 2)
+
+	def test_tool_calls_zero_when_no_run_id(self):
+		_make_session("agent:tu-norun", USER_A)
+		usage.record_turn_usage("agent:tu-norun", self._row(inputTokens=1, outputTokens=1, totalTokens=10))
+		tool_calls = frappe.db.get_value(TURN_USAGE, {"session_key": "agent:tu-norun"}, "tool_calls")
+		self.assertEqual(tool_calls, 0)

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.chat import usage
+from jarvis.chat import usage, usage_push
 
 USETT = "Jarvis User Settings"
 SESSION = "Jarvis Chat Session"
@@ -25,7 +25,8 @@ CHAT_TURN = "Jarvis Chat Turn"
 MSG = "Jarvis Chat Message"
 
 USER_A = "jarvis-turnusage-a@example.test"
-_ALL_USERS = (USER_A,)
+USER_B = "jarvis-turnusage-b@example.test"
+_ALL_USERS = (USER_A, USER_B)
 
 
 def _ensure_user(email: str) -> None:
@@ -59,9 +60,16 @@ def _make_session(session_key: str, user: str, *, profile_agent_id: str = "", pr
 def _cleanup() -> None:
 	for name in frappe.get_all(TURN_USAGE, filters={"user": ["in", list(_ALL_USERS)]}, pluck="name"):
 		frappe.delete_doc(TURN_USAGE, name, ignore_permissions=True, force=True)
+	# Blank-user Turn Usage fixtures (unmapped-session rollup test) aren't
+	# caught by the user filter above - clean by the shared session_key prefix
+	# every fixture in this file uses instead.
+	for name in frappe.get_all(TURN_USAGE, filters={"session_key": ["like", "agent:tu-%"]}, pluck="name"):
+		frappe.delete_doc(TURN_USAGE, name, ignore_permissions=True, force=True)
 	for name in frappe.get_all(CHAT_TURN, filters={"relay_target_id": ["like", "test-turnusage-%"]}, pluck="name"):
 		frappe.delete_doc(CHAT_TURN, name, ignore_permissions=True, force=True)
-	for name in frappe.get_all(CONV, filters={"title": ["like", "turnusage-fixture%"]}, pluck="name"):
+	for name in frappe.get_all(
+		CONV, filters={"title": ["like", "turnusage-fixture%"]}, pluck="name"
+	) + frappe.get_all(CONV, filters={"title": ["like", "rollup-fixture%"]}, pluck="name"):
 		for msg in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
 			frappe.delete_doc(MSG, msg, ignore_permissions=True, force=True)
 		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
@@ -239,3 +247,293 @@ class TestTurnUsage(FrappeTestCase):
 		usage.record_turn_usage("agent:tu-norun", self._row(inputTokens=1, outputTokens=1, totalTokens=10))
 		tool_calls = frappe.db.get_value(TURN_USAGE, {"session_key": "agent:tu-norun"}, "tool_calls")
 		self.assertEqual(tool_calls, 0)
+
+
+def _seed_turn_row(
+	session_key: str,
+	user: str,
+	*,
+	profile_agent_id: str = "",
+	tokens_in: int = 0,
+	tokens_out: int = 0,
+	cache_read: int = 0,
+	cache_write: int = 0,
+	cache_reported: int = 0,
+	tool_calls: int = 0,
+	creation=None,
+) -> str:
+	"""Insert a bare Jarvis Turn Usage row (task U2 rollup tests): the rollup
+	builder consumes these rows directly, so seeding them straight (rather
+	than round-tripping through record_turn_usage's gateway-row shape) keeps
+	the fixtures focused on the aggregation being tested."""
+	doc = frappe.get_doc(
+		{
+			"doctype": TURN_USAGE,
+			"session_key": session_key,
+			"user": user,
+			"profile_agent_id": profile_agent_id,
+			"profile_tier": "full",
+			"model": "gpt-5.5",
+			"tokens_in": tokens_in,
+			"tokens_out": tokens_out,
+			"cache_read": cache_read,
+			"cache_write": cache_write,
+			"cache_reported": cache_reported,
+			"tool_calls": tool_calls,
+			"day": frappe.utils.today(),
+			"run_id": "",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	if creation is not None:
+		# Controls the tie-break ("most recent turn wins") deterministically -
+		# ORM inserts a few lines apart can otherwise land in the same second.
+		frappe.db.set_value(TURN_USAGE, doc.name, "creation", creation, update_modified=False)
+	frappe.db.commit()
+	return doc.name
+
+
+def _seed_tool_messages(owner: str, title: str, tool_names: list[str]) -> None:
+	"""One Jarvis Conversation (owned by ``owner``) with one role=tool message
+	per entry in ``tool_names`` (repeat a name to raise its count). Frappe
+	stamps ``owner`` from the session user at insert (Administrator, here) -
+	same trap ``get_or_create_user_settings`` works around - so it is forced
+	back to ``owner`` afterwards; the rollup's top_tools attribution reads
+	exactly this field."""
+	conv = frappe.get_doc({"doctype": CONV, "title": title, "status": "Active"})
+	conv.insert(ignore_permissions=True)
+	frappe.db.set_value(CONV, conv.name, "owner", owner, update_modified=False)
+	for i, tool_name in enumerate(tool_names, start=1):
+		frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conv.name,
+				"seq": i,
+				"role": "tool",
+				"content": "",
+				"tool_name": tool_name,
+				"tool_status": "completed",
+			}
+		).insert(ignore_permissions=True)
+	frappe.db.commit()
+
+
+class TestUsageRollup(FrappeTestCase):
+	"""Task U2: the MTD rollup builder's profile/cache/tool-call extension.
+	Hermetic like TestTurnUsage - fixtures are disposable and committed rows
+	(Turn Usage inserts, conversation/message inserts) are removed in
+	tearDown via the shared ``_cleanup``."""
+
+	def setUp(self):
+		self._orig_user = frappe.session.user
+		frappe.set_user("Administrator")
+		_ensure_user(USER_A)
+		_ensure_user(USER_B)
+		_cleanup()
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_cleanup()
+		frappe.db.commit()
+		frappe.set_user(self._orig_user)
+
+	def _seed_settings(self, user: str, tokens: int) -> None:
+		"""A Jarvis User Settings row for the CURRENT month - the rollup's
+		users[] list is settings-sourced (task U1's builder), so a user with
+		no settings row this month never appears there even if Turn Usage
+		rows exist for them."""
+		doc = usage.get_or_create_user_settings(user)
+		frappe.db.set_value(
+			USETT,
+			doc.name,
+			{
+				"usage_month": usage.current_month_key(),
+				"month_input_tokens": tokens,
+				"month_output_tokens": tokens,
+				"month_tokens": tokens * 2,
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	# -- (a) empty month: old shape + empty/zero new fields ------------------ #
+	def test_empty_month_yields_old_shape_plus_empty_new_fields(self):
+		# This bench is live-used (real Turn Usage rows land from actual dev
+		# chat traffic), so the CURRENT month is never genuinely empty here -
+		# pin the builder to a month key no fixture or real traffic can have
+		# written to, which is what "empty month" actually needs to exercise.
+		with patch("jarvis.chat.usage.current_month_key", return_value="2000-01"):
+			rollup, truncated = usage_push._build_rollup()
+		self.assertFalse(truncated)
+		self.assertEqual(rollup["month_key"], "2000-01")
+		self.assertEqual(rollup["users"], [])
+		self.assertEqual(rollup["by_profile"], [])
+		self.assertEqual(rollup["top_tools"], [])
+
+	# -- (b) per-user sums + profile attribution + cache_reported ----------- #
+	def test_per_user_sums_and_profile_attribution(self):
+		self._seed_settings(USER_A, 100)
+		_seed_turn_row(
+			"agent:tu-roll-a1",
+			USER_A,
+			profile_agent_id="role-hr",
+			tokens_in=10,
+			tokens_out=5,
+			cache_read=2,
+			cache_write=1,
+			cache_reported=1,
+			tool_calls=3,
+		)
+		_seed_turn_row(
+			"agent:tu-roll-a2",
+			USER_A,
+			profile_agent_id="role-hr",
+			tokens_in=4,
+			tokens_out=1,
+			cache_read=0,
+			cache_write=0,
+			cache_reported=0,
+			tool_calls=1,
+		)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		self.assertIn(USER_A, users)
+		u = users[USER_A]
+		self.assertEqual(u["profile"], "role-hr")
+		self.assertEqual(u["turns"], 2)
+		self.assertEqual(u["cache_read"], 2)
+		self.assertEqual(u["cache_write"], 1)
+		# bool OR over the month's rows - one row reported, one did not.
+		self.assertTrue(u["cache_reported"])
+		self.assertIs(u["cache_reported"], True)
+		self.assertEqual(u["tool_calls"], 4)
+
+	# -- (c) blank profile_agent_id maps to "full" --------------------------- #
+	def test_blank_profile_maps_to_full(self):
+		self._seed_settings(USER_A, 10)
+		_seed_turn_row("agent:tu-roll-full", USER_A, profile_agent_id="")
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		self.assertEqual(users[USER_A]["profile"], "full")
+
+	# -- (d) profile tie -> most recent turn wins ---------------------------- #
+	def test_profile_tie_breaks_to_most_recent_turn(self):
+		self._seed_settings(USER_A, 10)
+		older = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-10)
+		newer = frappe.utils.now_datetime()
+		# role-p1: 2 turns, both older. role-p2: 2 turns, one newer - equal
+		# counts, role-p2's most recent turn is later, so role-p2 wins.
+		_seed_turn_row("agent:tu-roll-tie1", USER_A, profile_agent_id="role-p1", creation=older)
+		_seed_turn_row(
+			"agent:tu-roll-tie2",
+			USER_A,
+			profile_agent_id="role-p1",
+			creation=frappe.utils.add_to_date(older, minutes=1),
+		)
+		_seed_turn_row("agent:tu-roll-tie3", USER_A, profile_agent_id="role-p2", creation=older)
+		_seed_turn_row("agent:tu-roll-tie4", USER_A, profile_agent_id="role-p2", creation=newer)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		self.assertEqual(users[USER_A]["profile"], "role-p2")
+
+	# -- (e) blank-user Turn Usage rows are filtered out everywhere ---------- #
+	def test_blank_user_rows_are_filtered(self):
+		self._seed_settings(USER_A, 10)
+		_seed_turn_row("agent:tu-roll-a", USER_A, profile_agent_id="role-hr", tokens_in=1, tokens_out=1)
+		_seed_turn_row("agent:tu-roll-blank", "", profile_agent_id="role-hr", tokens_in=999, tokens_out=999)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		self.assertEqual(users[USER_A]["turns"], 1)
+		by_profile = {b["profile"]: b for b in rollup["by_profile"]}
+		self.assertEqual(by_profile["role-hr"]["turns"], 1)
+		self.assertEqual(by_profile["role-hr"]["tokens_in"], 1)
+
+	# -- (f) by_profile: users/turns/token sums + n_skills/n_tools ----------- #
+	def test_by_profile_block(self):
+		self._seed_settings(USER_A, 10)
+		self._seed_settings(USER_B, 10)
+		_make_session("agent:tu-roll-p1", USER_A, profile_agent_id="role-p1", profile_tier="full")
+		frappe.db.set_value(
+			SESSION, {"session_key": "agent:tu-roll-p1"}, {"profile_n_skills": 4, "profile_n_tools": 7}
+		)
+		_make_session("agent:tu-roll-p2", USER_B, profile_agent_id="role-p2", profile_tier="full")
+		frappe.db.set_value(
+			SESSION, {"session_key": "agent:tu-roll-p2"}, {"profile_n_skills": 2, "profile_n_tools": 3}
+		)
+		_seed_turn_row(
+			"agent:tu-roll-p1", USER_A, profile_agent_id="role-p1", tokens_in=10, tokens_out=5, cache_read=1
+		)
+		_seed_turn_row(
+			"agent:tu-roll-p2", USER_B, profile_agent_id="role-p2", tokens_in=20, tokens_out=8, cache_read=3
+		)
+		rollup, _ = usage_push._build_rollup()
+		by_profile = {b["profile"]: b for b in rollup["by_profile"]}
+		self.assertEqual(by_profile["role-p1"]["users"], 1)
+		self.assertEqual(by_profile["role-p1"]["turns"], 1)
+		self.assertEqual(by_profile["role-p1"]["tokens_in"], 10)
+		self.assertEqual(by_profile["role-p1"]["tokens_out"], 5)
+		self.assertEqual(by_profile["role-p1"]["cache_read"], 1)
+		self.assertEqual(by_profile["role-p1"]["n_skills"], 4)
+		self.assertEqual(by_profile["role-p1"]["n_tools"], 7)
+		self.assertEqual(by_profile["role-p2"]["n_skills"], 2)
+		self.assertEqual(by_profile["role-p2"]["n_tools"], 3)
+
+	# -- (g) top_tools: per-user ordering by count, cap 10 -------------------- #
+	def test_top_tools_per_user_ordering_and_cap(self):
+		self._seed_settings(USER_A, 10)
+		names = []
+		for i in range(1, 12):  # 11 distinct tools, tied count (1 each) -> alpha order, cap 10
+			name = f"cap_tool_{i:02d}"
+			names.append(name)
+		_seed_tool_messages(USER_A, "rollup-fixture-cap", names)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		top = users[USER_A]["top_tools"]
+		self.assertEqual(len(top), 10)
+		self.assertEqual([t["tool"] for t in top], sorted(names)[:10])
+		self.assertTrue(all(t["count"] == 1 for t in top))
+
+	def test_top_tools_ordering_by_count(self):
+		self._seed_settings(USER_A, 10)
+		_seed_tool_messages(
+			USER_A,
+			"rollup-fixture-order",
+			["get_list"] * 3 + ["read_doc"] * 2 + ["submit_doc"] * 1,
+		)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		top = users[USER_A]["top_tools"]
+		self.assertEqual(
+			top,
+			[
+				{"tool": "get_list", "count": 3},
+				{"tool": "read_doc", "count": 2},
+				{"tool": "submit_doc", "count": 1},
+			],
+		)
+
+	def test_top_tools_drops_invalid_names(self):
+		self._seed_settings(USER_A, 10)
+		_seed_tool_messages(
+			USER_A,
+			"rollup-fixture-invalid",
+			["get_list", "bad tool!", "jarvis__" + ("x" * 80)],
+		)
+		rollup, _ = usage_push._build_rollup()
+		users = {u["email"]: u for u in rollup["users"]}
+		tools = {t["tool"] for t in users[USER_A]["top_tools"]}
+		self.assertIn("get_list", tools)
+		self.assertIn("jarvis__" + ("x" * 80), tools)
+		self.assertNotIn("bad tool!", tools)
+
+	# -- (h) top_tools: tenant-wide top 15 ------------------------------------ #
+	def test_top_tools_tenant_wide_cap(self):
+		self._seed_settings(USER_A, 10)
+		self._seed_settings(USER_B, 10)
+		names = [f"tenant_tool_{i:02d}" for i in range(1, 17)]  # 16 distinct, tied count
+		_seed_tool_messages(USER_A, "rollup-fixture-tenant-a", names[:8])
+		_seed_tool_messages(USER_B, "rollup-fixture-tenant-b", names[8:])
+		rollup, _ = usage_push._build_rollup()
+		self.assertEqual(len(rollup["top_tools"]), 15)
+		self.assertEqual([t["tool"] for t in rollup["top_tools"]], sorted(names)[:15])


### PR DESCRIPTION
## Summary

Records one usage row per completed chat turn (tokens in/out, the session's role profile, tool-call count) and extends the existing monthly usage push to admin with per-user profile labels, cache fields, and top-tools aggregates, so the admin Usage tab can show who chats under which role profile and what it costs. Passive capture, no new cron, no behavior change for chat.

## What changed
- New `Jarvis Turn Usage` DocType, written inside the existing turn-usage accrual under its never-break-chat contract (a failing write logs and changes nothing); 90-day daily prune.
- The monthly rollup push gains per-user: profile, turns, cache read/write (0 with a reported flag until the agent runtime exposes cache counters; live-verified absent today), tool calls, top 10 tools; plus tenant-level by-profile totals and top 15 tools.
- Tool names come from the structured `tool_name` field on tool message rows; blank-user rows (unattributable zero turns) are filtered from every aggregate.

## Risk and verification
- 17 tests (capture isolation, profile tie-breaks, caps/ordering, contract-safe name filtering); existing usage suites unchanged and green.
- Counts and token integers only; no message content leaves the bench.
- Companion PR: admin-v2 ingest + Usage tab UI (separate, backward compatible in both directions).

<details><summary>Design</summary>

Spec: `docs/superpowers/specs/2026-08-17-usage-observability-dashboard-design.md` (untracked by convention), Part A. Built on the role-profiles feature (#896): the profile fields recorded per chat session are denormalized onto each turn row so rollups need no joins at push time.

</details>

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (rebased on develop post-#896)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
