### PR TITLE
fix(onboarding): re-land #893, T&C acceptance on the Details step

### DIFF
--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -11,6 +11,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { CHECKOUT_NAV_KEY } from "@/onboarding/checkoutNav";
 import { STATES } from "@/onboarding/paymentMachine";
 import { ACTIONS } from "@/onboarding/paymentCodes";
+import { toast } from "frappe-ui";
 
 // A raw {status, body} envelope, exactly what the flow's codec decodes.
 const ENVELOPE = (data, over = {}) => ({
@@ -735,6 +736,10 @@ describe("Returning-customer forced reconnect gate", () => {
 		// Contact number is mandatory on Details now; fill it so onDetailsSubmit's
 		// gate doesn't block these reconnect-flow tests on an unrelated field.
 		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		// The required T&C checkbox now lives on Details too, but these tests are
+		// about the reconnect gate specifically, so tick it by default (a
+		// dedicated test below asserts the reconnect branch does NOT need it).
+		wrapper.vm.state.termsAccepted = true;
 		await flushPromises();
 		return wrapper;
 	}
@@ -746,6 +751,16 @@ describe("Returning-customer forced reconnect gate", () => {
 		await flushPromises();
 		// The await inside onDetailsSubmit resolved eligibility (it was NOT pre-settled
 		// by the debounce) - this is also the race-closure guarantee (C3).
+		expect(api.startAccountReconnect).toHaveBeenCalledWith("back@corp.test", "Corp");
+		expect(wrapper.vm.state.step).toBe("reconnect");
+	});
+
+	it("the required T&C checkbox does NOT gate the reconnect branch - a returning customer reconnecting an existing paid account never went through it before", async () => {
+		api.startAccountReconnect.mockResolvedValue({ request: "req_1" });
+		const wrapper = await detailsView({ eligible: true });
+		wrapper.vm.state.termsAccepted = false; // deliberately unticked
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
 		expect(api.startAccountReconnect).toHaveBeenCalledWith("back@corp.test", "Corp");
 		expect(wrapper.vm.state.step).toBe("reconnect");
 	});
@@ -858,6 +873,7 @@ describe("Returning-customer forced reconnect gate", () => {
 		wrapper.vm.state.company = "Corp";
 		wrapper.vm.state.identityFromUser = true;
 		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		wrapper.vm.state.termsAccepted = true;
 		await wrapper.vm.onDetailsSubmit();
 		await flushPromises();
 		expect(api.startAccountReconnect).not.toHaveBeenCalled();
@@ -948,6 +964,46 @@ describe("lead-capture + T&C (frozen contract)", () => {
 		await flushPromises();
 		expect(wrapper.text()).not.toContain("okay to contact me");
 		expect(wrapper.vm.billing.consent).toBeUndefined();
+	});
+
+	it("Details renders the required T&C checkbox; Pay no longer renders it", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		expect(wrapper.find("#jv-ob-terms").exists()).toBe(true);
+
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+		expect(wrapper.find("#jv-ob-terms").exists()).toBe(false);
+	});
+
+	it("Details' Continue is blocked until the required T&C box is ticked, with a visible inline error (not a toast)", async () => {
+		// Not eligible for reconnect - keeps this on the normal Continue path
+		// the T&C gate actually guards (item 5: reconnect is exempt).
+		api.reconnectAvailable.mockResolvedValue({ eligible: false, needs_company: false });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		wrapper.vm.state.email = "a@b.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.identityFromUser = true;
+		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		wrapper.vm.state.termsAccepted = false;
+		await flushPromises();
+
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("details");
+		expect(wrapper.vm.detailsFieldErrors.terms).toBeTruthy();
+		expect(wrapper.text()).toContain(wrapper.vm.detailsFieldErrors.terms);
+		expect(toast.error).not.toHaveBeenCalled();
+
+		wrapper.vm.state.termsAccepted = true;
+		await flushPromises();
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("plan");
 	});
 
 	it("Pay stays disabled until the required T&C box is ticked", async () => {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -363,11 +363,12 @@
 										/>
 									</div>
 									<!-- No separate contact-consent checkbox here (owner decision
-										 2026-08-14): consent to be contacted is part of the Terms &
-										 Conditions accepted at Review & Pay, where onPayClick sends
-										 contact_consent alongside terms_accepted. Consequence: a lead
-										 captured at the Plan step carries no consent until the
-										 customer accepts the terms. -->
+										 2026-08-14): consent to be contacted rides the T&C checkbox
+										 below (moved onto this step 2026-08-16), and onPayClick still
+										 sends contact_consent alongside terms_accepted. Consequence: a
+										 lead captured at the Plan step carries no consent until the
+										 customer accepts the terms, which now happens on THIS step
+										 before Plan is ever reached. -->
 									<!-- JvCombo (shared, out of scope) has no declared aria-invalid /
 										 aria-describedby / blur props, and does not spread $attrs onto
 										 its inner <input>, so those attrs would silently land on its
@@ -579,6 +580,57 @@
 									Enter it here</button
 								>.
 							</p>
+							<!-- Required T&C acceptance (moved here from Review & Pay 2026-08-16
+								 so lead-contact consent is captured before the Plan-step lead
+								 capture fires). Gates onDetailsSubmit()'s normal Continue path,
+								 not the reconnect side-branch above (a returning customer
+								 reconnecting an already-paid account never went through this
+								 checkbox before, and reconnect makes no signup call that needs
+								 terms_accepted / contact_consent). payDisabled and onPayClick's
+								 own `!state.termsAccepted` guard stay in place as invariants -
+								 both are already true by the time Pay is reachable. Checkbox's
+								 own `label` prop only takes plain text (no slot, no markup), so
+								 the link-bearing sentence is a sibling <label for=...> instead -
+								 clicking the embedded <a> navigates without also toggling the box. -->
+							<div
+								class="mx-auto mt-5 flex max-w-[620px] items-start justify-center gap-2"
+							>
+								<Checkbox
+									id="jv-ob-terms"
+									:model-value="state.termsAccepted"
+									aria-required="true"
+									:aria-invalid="detailsFieldErrors.terms ? 'true' : undefined"
+									:aria-describedby="
+										detailsFieldErrors.terms ? 'jv-ob-terms-err' : undefined
+									"
+									@update:model-value="
+										(v) => {
+											state.termsAccepted = v;
+											clearFieldErrorIfValid('terms', termsError, v);
+										}
+									"
+								/>
+								<label
+									for="jv-ob-terms"
+									class="cursor-pointer select-none text-p-sm text-ink-gray-7"
+								>
+									I agree to the
+									<a
+										v-if="state.termsUrl"
+										:href="state.termsUrl"
+										target="_blank"
+										rel="noopener"
+										class="ob-link"
+										@click.stop
+										>Terms &amp; Conditions</a
+									><span v-else>Terms &amp; Conditions</span>
+								</label>
+							</div>
+							<ErrorMessage
+								id="jv-ob-terms-err"
+								:message="detailsFieldErrors.terms"
+								class="mx-auto mt-1 max-w-[620px] text-center"
+							/>
 							<div class="ob-foot">
 								<button class="ob-back" @click="goBack">
 									<FeatherIcon
@@ -1291,38 +1343,11 @@
 									>
 										{{ payLinkDeadline }}
 									</p>
-									<!-- Required T&C acceptance (lead-capture + T&C frozen contract).
-										 Pay stays disabled until this is ticked; terms_accepted rides
-										 start_signup, and admin stamps the version server-side - this
-										 view never sends one. Checkbox's own `label` prop only takes
-										 plain text (no slot, no markup), so the link-bearing sentence is
-										 a sibling <label for=...> instead - clicking the embedded <a>
-										 navigates without also toggling the box. -->
-									<div
-										class="mx-auto mt-3.5 flex max-w-[560px] items-start justify-center gap-2"
-									>
-										<Checkbox
-											id="jv-ob-terms"
-											:model-value="state.termsAccepted"
-											aria-required="true"
-											@update:model-value="(v) => (state.termsAccepted = v)"
-										/>
-										<label
-											for="jv-ob-terms"
-											class="cursor-pointer select-none text-p-sm text-ink-gray-7"
-										>
-											I agree to the
-											<a
-												v-if="state.termsUrl"
-												:href="state.termsUrl"
-												target="_blank"
-												rel="noopener"
-												class="ob-link"
-												@click.stop
-												>Terms &amp; Conditions</a
-											><span v-else>Terms &amp; Conditions</span>
-										</label>
-									</div>
+									<!-- T&C acceptance moved to the Details step (2026-08-16): the
+										 checkbox no longer renders here. payDisabled and onPayClick's
+										 own `!state.termsAccepted` guard below stay in place as
+										 invariants - both are already true by the time Pay is
+										 reachable, since Details' Continue is gated on the same flag. -->
 								</div>
 								<div class="ob-foot">
 									<button
@@ -1951,16 +1976,22 @@ const state = reactive({
 	reconnectDirect: false,
 	reconnectEmail: "",
 	paymentProvider: "", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
-	// Required Review & Pay checkbox (T&C + lead-capture frozen contract). NOT
-	// localStorage-persisted - a legal acceptance is re-asked every time the
-	// customer lands fresh on this screen, same as it would be on any checkout.
-	// Pay stays disabled until this is true, and only a literal true is ever
-	// sent to start_signup. Accepting it also grants contact consent (owner
-	// decision 2026-08-14): the terms cover being contacted about the account.
+	// Required Details-step checkbox (T&C + lead-capture contract; moved off
+	// Review & Pay 2026-08-16 so consent is captured before the Plan-step lead
+	// capture fires). NOT localStorage-persisted - a legal acceptance is
+	// re-asked every time the customer lands fresh on this screen, same as it
+	// would be on any checkout. Details' Continue stays blocked until this is
+	// true, and only a literal true is ever sent to start_signup. payDisabled
+	// and onPayClick's own guard keep checking it too (invariants that are
+	// always true by the time Pay is reachable). Accepting it also grants
+	// contact consent (owner decision 2026-08-14): the terms cover being
+	// contacted about the account.
 	termsAccepted: false,
 	// The admin-hosted /terms URL (jarvis.onboarding.get_terms_url), fetched
-	// best-effort on mount. Empty when admin is unreachable/unconfigured - the
-	// checkbox label then renders plain unlinked text instead of a dead link.
+	// best-effort on mount so it is already available by the time the Details
+	// step (the second screen) renders. Empty when admin is unreachable/
+	// unconfigured - the checkbox label then renders plain unlinked text
+	// instead of a dead link.
 	termsUrl: "",
 	// Gateways the operator has actually enabled, narrowed to what this build can
 	// render. Starts EMPTY and stays empty on a discovery failure (plan 02 P2-6):
@@ -2288,8 +2319,12 @@ const payCta = computed(() => {
 // the CTA is disabled until then and the unavailable/retry note stands in for it.
 const payProviderReady = computed(() => !!state.paymentProvider);
 // The CTA's full gate, named rather than left as three booleans inline in the
-// template (T&C + lead-capture frozen contract adds the third leg): busy,
-// no confirmed gateway yet, or the required Terms & Conditions box unticked.
+// template: busy, no confirmed gateway yet, or the required Terms & Conditions
+// box unticked. The third leg is an invariant now, not a live gate - the
+// checkbox itself lives on Details and blocks Continue there, so by the time
+// Pay renders state.termsAccepted is already true. Kept here anyway (per the
+// T&C + lead-capture contract) so a future change to Details' gate fails
+// closed instead of silently reopening this hole.
 // payBusyView is declared further down; safe to close over here since this
 // getter only runs at render, after the whole setup script has executed.
 const payDisabled = computed(
@@ -2493,13 +2528,20 @@ function contactError(value) {
 	return (value || "").trim() ? "" : "Enter a contact number.";
 }
 // gstinError (gstin.js) already treats a blank value as "" (GSTIN is optional).
+// Required T&C checkbox (moved here from Review & Pay 2026-08-16): unlike the
+// other Details fields this isn't touched on blur (a checkbox has none worth
+// hooking), only set by onDetailsSubmit on the non-reconnect Continue path
+// and cleared live by clearFieldErrorIfValid as soon as it's ticked.
+function termsError(value) {
+	return value ? "" : "Please accept the Terms & Conditions to continue.";
+}
 
 // Details-step field errors, one bucket per field so each renders under its
 // OWN input via ErrorMessage instead of a single shared bar at the bottom with
 // no tie to what's wrong. Set all at once by onDetailsSubmit (every failure
 // shown together, not one submit per error); state.detailsErr stays reserved
 // for genuinely form-wide messages (see onPayClick's missing-details guard).
-const detailsFieldErrors = reactive({ email: "", company: "", contact: "", gstin: "" });
+const detailsFieldErrors = reactive({ email: "", company: "", contact: "", gstin: "", terms: "" });
 function touchEmailField() {
 	detailsFieldErrors.email = emailError(state.email);
 }
@@ -2599,6 +2641,13 @@ async function onDetailsSubmit() {
 	} finally {
 		state.detailsSubmitting = false;
 	}
+	// Required T&C acceptance: checked here, AFTER the reconnect branch above
+	// (which already returned if it applied), so this gate never blocks a
+	// returning customer reconnecting an existing paid account - reconnect
+	// makes no signup call and never needed terms_accepted/contact_consent.
+	// Only the path that actually advances to Plan is gated.
+	detailsFieldErrors.terms = termsError(state.termsAccepted);
+	if (detailsFieldErrors.terms) return;
 	// The customer just edited the details behind a FAILED attempt. Without this,
 	// walking forward from here landed them straight back on the old failure card
 	// with no new request made at all: the machine was still parked on the failed
@@ -3428,9 +3477,9 @@ async function onPayClick() {
 		state.step = "details";
 		return;
 	}
-	// Belt-and-suspenders: the Pay button is already disabled until this is
-	// ticked (the real gate), but a programmatic/stray click must not be able to
-	// start a signup admin will reject anyway for lacking acceptance.
+	// Belt-and-suspenders: Details' Continue is already gated on this (the real
+	// gate now), but a programmatic/stray click must not be able to start a
+	// signup admin will reject anyway for lacking acceptance.
 	if (!state.termsAccepted) return;
 	await flow.submitReview({
 		email: state.email,
@@ -3441,11 +3490,10 @@ async function onPayClick() {
 		// Top-level kwarg, parallel to nothing else here - NOT part of `billing`.
 		// Trimmed + undefined-when-blank so a blank field sends no key at all.
 		partner_code: state.partnerCode?.trim() || undefined,
-		// T&C + lead-capture frozen contract: only ever true here (the checkbox
-		// gates this click). contact_consent is granted BY the T&C acceptance
-		// itself (owner decision 2026-08-14, replacing the separate Details-step
-		// checkbox), so it is the same literal true, recorded at the exact moment
-		// identity is real.
+		// T&C + lead-capture contract: only ever true here (Details' Continue
+		// already required it). contact_consent is granted BY the T&C
+		// acceptance itself (owner decision 2026-08-14), so it is the same
+		// literal true, recorded at the exact moment identity is real.
 		terms_accepted: true,
 		contact_consent: true,
 	});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2600,6 +2600,11 @@ async function onDetailsSubmit() {
 	// wrong in one pass instead of fixing email only to have the next click
 	// reveal Company was empty too. A bad GSTIN blocks here too, on this same
 	// step, instead of dead-ending at the pay button three screens later.
+	// terms is the deliberate exception: it's checked separately, further down,
+	// AFTER the reconnect branch resolves - batching it in here would gate the
+	// reconnect branch too (item 5), which it must not. A customer with both a
+	// bad GSTIN and an unticked box sees the GSTIN error first and the terms
+	// error only on a second submit; accepted as the cost of that exemption.
 	touchEmailField();
 	touchCompanyField();
 	touchContactField();
@@ -4942,7 +4947,7 @@ onMounted(async () => {
 	// tick, before the awaited prefill below — the discovery loading note must show
 	// from first paint (X4), independent of prefill/company.
 	loadPaymentProviders();
-	// Best-effort terms-page link for the Review & Pay checkbox. Never blocks the
+	// Best-effort terms-page link for the Details-step checkbox. Never blocks the
 	// wizard and never throws into onMounted: a failure just leaves state.termsUrl
 	// empty, which the template renders as plain unlinked "Terms & Conditions" text.
 	getTermsUrl()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -5,7 +5,7 @@ never holds admin creds). admin_client returns already-unwrapped admin data."""
 import json
 
 import frappe
-from frappe.utils import cint
+from frappe.utils import cint, validate_email_address
 
 from jarvis import admin_client, onboarding_contract, release_notice
 from jarvis.exceptions import (
@@ -353,9 +353,17 @@ def capture_onboarding_lead(
 	surfaces to the customer.
 	``site_origin`` sent here is advisory only - admin_client overwrites it with
 	this bench's own server-derived public origin before it ever reaches admin.
+
+	A non-blank ``email`` that fails ``validate_email_address`` is dropped
+	silently (no admin call, no exception) rather than forwarded - this is
+	fire-and-forget with nothing to show the customer, so a malformed address
+	just never becomes a lead instead of surfacing anywhere. A blank/missing
+	email is left to admin_client as before (unchanged from prior behaviour).
 	"""
 	try:
 		require_jarvis_admin()
+		if email and not validate_email_address(email, throw=False):
+			return {"ok": False}
 		return admin_client.capture_onboarding_lead(
 			email,
 			company=company,
@@ -372,7 +380,7 @@ def capture_onboarding_lead(
 
 @frappe.whitelist()
 def get_terms_url() -> dict:
-	"""The admin-hosted Terms & Conditions URL for the Review & Pay checkbox
+	"""The admin-hosted Terms & Conditions URL for the Details-step checkbox
 	link. Best-effort: ``{"url": ""}`` on any failure so the checkbox still
 	renders (with plain unlinked text) when admin is unreachable or unconfigured."""
 	try:
@@ -982,8 +990,9 @@ def start_signup(
 	falsy value) and ``contact_consent`` (optional) are the T&C + lead-capture
 	frozen contract's two new kwargs. Threaded straight through to
 	``admin_client.signup`` unconditionally; the SPA only ever calls this with
-	``terms_accepted: true`` (the Review & Pay checkbox gates the Pay click), and
-	``terms_version`` is stamped SERVER-SIDE by admin — this bench never sends one.
+	``terms_accepted: true`` (the Details-step checkbox gates the Continue that
+	reaches Plan and, downstream, this call), and ``terms_version`` is stamped
+	SERVER-SIDE by admin — this bench never sends one.
 
 	Two response shapes depending on admin's
 	``require_email_verification`` flag:
@@ -996,6 +1005,12 @@ def start_signup(
 	    bench so the poll endpoint can authenticate.
 	"""
 	require_jarvis_admin()
+	# Light shape check on the caller-typed email, before anything else touches
+	# it (onboarding_contract.update below, admin_client.signup) - a malformed
+	# address is cheap to catch here with an actionable message rather than
+	# surfacing as an opaque admin-side rejection several calls later.
+	if not validate_email_address(email, throw=False):
+		frappe.throw("Enter a valid email address.")
 	_require_admin_url()
 	# Money the gateway is holding that an operator has not been able to place
 	# stops the WHOLE endpoint, not just the resume half below. The context is

--- a/jarvis/tests/test_capture_onboarding_lead.py
+++ b/jarvis/tests/test_capture_onboarding_lead.py
@@ -79,3 +79,26 @@ class TestCaptureOnboardingLead(FrappeTestCase):
 		finally:
 			frappe.set_user("Administrator")
 		self.assertEqual(out, {"ok": False})
+
+	def test_invalid_email_is_dropped_silently_without_calling_admin(self):
+		"""A malformed email must never reach admin_client, and must never raise -
+		this endpoint is fire-and-forget with nothing to show the customer, so a
+		bad address just never becomes a lead."""
+		with patch(
+			"jarvis.onboarding.admin_client.capture_onboarding_lead",
+			side_effect=AssertionError("admin_client.capture_onboarding_lead should never be reached"),
+		) as mock_capture:
+			out = onboarding.capture_onboarding_lead(email="not-an-email", company="Acme", step="plan")
+		self.assertEqual(out, {"ok": False})
+		mock_capture.assert_not_called()
+
+	def test_blank_email_still_forwards_as_before(self):
+		"""A blank/missing email is left to admin_client exactly like before this
+		change - only a NON-blank, malformed address is newly screened out."""
+		with patch(
+			"jarvis.onboarding.admin_client.capture_onboarding_lead",
+			return_value={"ok": False},
+		) as mock_capture:
+			out = onboarding.capture_onboarding_lead(email="", company="Acme", step="plan")
+		self.assertEqual(out, {"ok": False})
+		mock_capture.assert_called_once()

--- a/jarvis/tests/test_start_signup_validation.py
+++ b/jarvis/tests/test_start_signup_validation.py
@@ -1,0 +1,44 @@
+"""Tests for jarvis.onboarding.start_signup's email validation - a malformed
+address is rejected with a clean, actionable message right after the
+permission gate, before anything else (admin URL config, the reconciliation
+check, onboarding_contract.update, admin_client.signup) is ever touched."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import onboarding
+
+
+class TestStartSignupEmailValidation(FrappeTestCase):
+	def test_invalid_email_raises_before_reaching_admin(self):
+		"""admin_client.signup is mocked to raise loudly if reached at all - the
+		validation must short-circuit before _require_admin_url, so this proves
+		the ordering as well as the rejection itself."""
+		with patch(
+			"jarvis.onboarding.admin_client.signup",
+			side_effect=AssertionError("admin_client.signup should never be reached"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.start_signup(
+					email="not-an-email",
+					company="Acme",
+					plan="pro",
+					billing={"contact_number": "+91 90000 00000"},
+					terms_accepted=True,
+				)
+
+	def test_blank_email_also_rejected(self):
+		with patch(
+			"jarvis.onboarding.admin_client.signup",
+			side_effect=AssertionError("admin_client.signup should never be reached"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.start_signup(
+					email="   ",
+					company="Acme",
+					plan="pro",
+					billing={"contact_number": "+91 90000 00000"},
+					terms_accepted=True,
+				)


### PR DESCRIPTION
## Summary

Re-lands #893, which shows MERGED but never reached develop. Users accept the Terms and Conditions on the Details step instead of the Review and Pay step, exactly as #893 intended.

#893 was stacked on #888 and got merged into #888's feature branch 15 seconds after that branch was itself merged into develop, so its commits stranded on a dead side branch. This PR cherry-picks those same two commits (aa5978be, e0c1ead8 here; 3eacdce4, 1d0f9958 here) onto current develop. Clean pick, no conflicts. Carries its own frontend spec and backend validation tests.

<details><summary>How the strand happened</summary>

Merge timeline on 2026-08-16: #888 (base develop) merged at 16:50:45 as dc548efe. #893 (base fix/onboarding-contact-required, never retargeted) merged at 16:51:00 as 12fd555f, whose commits are not ancestors of develop. GitHub only retargets a stacked PR when the base branch is deleted before the second merge, which did not happen here.

</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (cut from develop tip 078286c8 today)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff