### PR TITLE
fix: capture the customer's real public site URL at signup (not the internal site name)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -13,6 +13,7 @@ Guest calls (signup, get_plans) skip the header entirely; their admin
 endpoints are @frappe.whitelist(allow_guest=True).
 """
 
+import ipaddress
 import re
 import time
 
@@ -201,25 +202,58 @@ def _is_production_bench() -> bool:
 	)
 
 
-def _public_origin() -> str:
+_RESERVED_TLDS = frozenset(
+	{
+		"local",
+		"localhost",
+		"test",
+		"example",
+		"invalid",
+		"internal",
+		"corp",
+		"home",
+		"lan",
+		"mail",
+		"intranet",
+	}
+)
+
+
+def _is_real_public_host(host: str) -> bool:
+	"""True for a routable public domain (so we can safely force https on it), False for a
+	dev/internal host we must leave as-is. Public = dotted, not localhost, not an IP literal,
+	and an alphabetic non-reserved TLD. Rejects ``jarvis.local`` (reserved), ``staging.v15``
+	(non-alpha TLD), IPv4/IPv6 literals, and bare hostnames. (IDN ``xn--`` TLDs read as
+	non-public and keep their request scheme - an accepted minor limitation.)"""
+	if not host or "." not in host:
+		return False
+	if host == "localhost" or host.endswith(".localhost"):
+		return False
+	try:
+		ipaddress.ip_address(host)
+		return False
+	except ValueError:
+		pass
+	tld = host.rsplit(".", 1)[-1]
+	return tld.isalpha() and tld not in _RESERVED_TLDS
+
+
+def _public_origin(trust_host: bool = False) -> str:
 	"""A public site origin for the ``frappe_site_url`` this bench hands admin.
 
-	The bench half of the plan-09 P1-5 ``get_url`` sweep. A bare
-	``frappe.utils.get_url()`` derives the host from the request ``Host`` header
-	when ``host_name`` is unset (``get_url``'s own ``allow_header_override`` path —
-	proven reachable on this very environment), so a guest spoofing ``Host:`` on a
-	signup / reconnect / replacement-lookup POST could choose the
-	``frappe_site_url`` admin records for this tenant and the base of the magic
-	link admin then mails. The load-bearing fix is ``allow_header_override=False``:
-	it kills that injection vector.
+	A configured ``host_name`` (validated https) always wins. Otherwise ``get_url`` derives
+	the host from the request ``Host`` header only when ``allow_header_override`` is on.
 
-	Resolution order mirrors the admin-side ``admin_public_origin`` (jarvis_admin_v2
-	WS5): a configured ``host_name`` (validated https) wins; otherwise the site
-	fallback from ``get_url`` with header override OFF. An ``http://`` base on a
-	production bench is a misconfiguration — but it is caught at DEPLOY time by the
-	readiness gate, NOT by throwing here: throwing would break signup on any bench
-	where ``host_name`` is unset (every dev bench), and the injection vector is
-	already closed regardless of scheme."""
+	``trust_host`` is passed True by ONE caller - ``signup`` - and False everywhere else. All
+	onboarding endpoints are authenticated (``require_jarvis_admin``), but only signup creates
+	a NEW account, so trusting the admin's own request Host is self-scoped there. Reconnect /
+	replacement / lead target an EXISTING account by email, a different trust context, so they
+	keep header override OFF - a spoofed Host cannot choose their recorded site URL. On the
+	signup path a real public domain reached over http (proxy without X-Forwarded-Proto) is
+	normalized to https. Residual (low): a require_jarvis_admin admin can put a lookalike https
+	origin into their OWN welcome email via a crafted Host - a slightly broader reach than the
+	host_name config lever, but still self-scoped, admin-re-validated, and never the base of the
+	verification magic link (that uses admin's own origin)."""
 	from urllib.parse import urlsplit
 
 	host_name = (frappe.conf.get("host_name") or frappe.conf.get("hostname") or "").strip()
@@ -230,7 +264,14 @@ def _public_origin() -> str:
 		if parts.scheme == "https" and parts.hostname and "." in parts.hostname:
 			return f"https://{parts.hostname.lower()}"
 
-	base = (frappe.utils.get_url(allow_header_override=False) or "").rstrip("/")
+	base = (frappe.utils.get_url(allow_header_override=trust_host) or "").rstrip("/")
+	if trust_host:
+		try:
+			host = (urlsplit(base).hostname or "").lower().rstrip(".")
+			if _is_real_public_host(host):
+				return f"https://{host}"
+		except Exception:
+			pass  # never break signup; fall through to the raw base
 	if base.startswith("http://") and _is_production_bench():
 		frappe.logger("jarvis.onboarding").warning(
 			"frappe_site_url resolved to an http base on a production bench; "
@@ -293,7 +334,9 @@ def signup(
 		"email": email,
 		"company_name": company_name,
 		"plan": plan,
-		"frappe_site_url": _public_origin(),
+		# signup creates a NEW account -> trust the authenticated admin's own request Host
+		# (self-scoped); reconnect/replacement/lead keep it OFF (they target an existing account).
+		"frappe_site_url": _public_origin(trust_host=True),
 		"supported_providers": list(SUPPORTED_PROVIDERS),
 		"client_capabilities": _client_capabilities(),
 		"terms_accepted": terms_accepted,

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -220,11 +220,9 @@ _RESERVED_TLDS = frozenset(
 
 
 def _is_real_public_host(host: str) -> bool:
-	"""True for a routable public domain (so we can safely force https on it), False for a
-	dev/internal host we must leave as-is. Public = dotted, not localhost, not an IP literal,
-	and an alphabetic non-reserved TLD. Rejects ``jarvis.local`` (reserved), ``staging.v15``
-	(non-alpha TLD), IPv4/IPv6 literals, and bare hostnames. (IDN ``xn--`` TLDs read as
-	non-public and keep their request scheme - an accepted minor limitation.)"""
+	"""A routable public domain (safe to force https on) vs a dev/internal host to leave as-is:
+	dotted, not localhost, not an IP literal, alphabetic non-reserved TLD. Rejects jarvis.local
+	(reserved), staging.v15 (non-alpha TLD), IPs, bare hosts; IDN xn-- reads non-public (keeps its scheme)."""
 	if not host or "." not in host:
 		return False
 	if host == "localhost" or host.endswith(".localhost"):
@@ -239,21 +237,14 @@ def _is_real_public_host(host: str) -> bool:
 
 
 def _public_origin(trust_host: bool = False) -> str:
-	"""A public site origin for the ``frappe_site_url`` this bench hands admin.
+	"""The public origin the bench sends admin as ``frappe_site_url``. A configured ``host_name``
+	(https) always wins; else ``get_url`` derives it from the request Host only when
+	``allow_header_override`` is on.
 
-	A configured ``host_name`` (validated https) always wins. Otherwise ``get_url`` derives
-	the host from the request ``Host`` header only when ``allow_header_override`` is on.
-
-	``trust_host`` is passed True by ONE caller - ``signup`` - and False everywhere else. All
-	onboarding endpoints are authenticated (``require_jarvis_admin``), but only signup creates
-	a NEW account, so trusting the admin's own request Host is self-scoped there. Reconnect /
-	replacement / lead target an EXISTING account by email, a different trust context, so they
-	keep header override OFF - a spoofed Host cannot choose their recorded site URL. On the
-	signup path a real public domain reached over http (proxy without X-Forwarded-Proto) is
-	normalized to https. Residual (low): a require_jarvis_admin admin can put a lookalike https
-	origin into their OWN welcome email via a crafted Host - a slightly broader reach than the
-	host_name config lever, but still self-scoped, admin-re-validated, and never the base of the
-	verification magic link (that uses admin's own origin)."""
+	Only ``signup`` passes ``trust_host=True`` - a NEW account, so trusting the authenticated
+	admin's own Host is self-scoped. Reconnect / replacement / lead keep it OFF: they target an
+	EXISTING account by email, so a spoofed Host must not choose its URL. A real public domain
+	reached over http is normalized to https."""
 	from urllib.parse import urlsplit
 
 	host_name = (frappe.conf.get("host_name") or frappe.conf.get("hostname") or "").strip()
@@ -334,8 +325,7 @@ def signup(
 		"email": email,
 		"company_name": company_name,
 		"plan": plan,
-		# signup creates a NEW account -> trust the authenticated admin's own request Host
-		# (self-scoped); reconnect/replacement/lead keep it OFF (they target an existing account).
+		# signup is the only trust_host=True caller (new account, self-scoped).
 		"frappe_site_url": _public_origin(trust_host=True),
 		"supported_providers": list(SUPPORTED_PROVIDERS),
 		"client_capabilities": _client_capabilities(),

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -4,6 +4,8 @@ All HTTP is mocked. Tests verify header construction, error mapping,
 envelope unwrapping, and missing-config handling.
 """
 
+import contextlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -1381,12 +1383,34 @@ class TestClientCapabilityAdvert(FrappeTestCase):
 				self.assertEqual(captured["json"].get("client_capabilities"), _EXPECTED_ADVERT, name)
 
 
+@contextlib.contextmanager
+def _fake_request(*, host: str, user: str = "Administrator"):
+	"""Minimal request + session so get_url's allow_header_override path reads a Host.
+	Restores frappe.local.request + the session user (determinism)."""
+	sentinel = object()
+	prev_request = getattr(frappe.local, "request", sentinel)
+	prev_user = frappe.session.user
+	frappe.local.request = SimpleNamespace(host=host, headers={})
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(prev_user)
+		if prev_request is sentinel:
+			try:
+				del frappe.local.request
+			except AttributeError:
+				pass
+		else:
+			frappe.local.request = prev_request
+
+
 class TestPublicOriginSweep(FrappeTestCase):
-	"""plan-09 P1-5: the bench half of the ``get_url`` sweep. The ``frappe_site_url``
-	the bench hands admin must NOT be derivable from the request ``Host`` header (a
-	guest could otherwise choose the tenant's recorded site URL / magic-link base).
-	The fix is ``allow_header_override=False`` on the fallback, with a configured
-	``host_name`` preferred."""
+	"""plan-09 P1-5 + plan 2026-08-17: the ``frappe_site_url`` the bench hands admin.
+	Non-signup callers must NOT derive it from the request ``Host`` (a spoofed Host
+	could choose the recorded site URL). ONLY the signup flow (``trust_host=True``)
+	trusts the authenticated Host, forcing https for a real public domain; a configured
+	``host_name`` still wins for everyone."""
 
 	def tearDown(self):
 		_settings_clear_admin()
@@ -1466,6 +1490,81 @@ class TestPublicOriginSweep(FrappeTestCase):
 		self.assertTrue(captured["url"].endswith("billing.reconnect.redeem_reconnect_code"))
 		self.assertEqual(captured["json"]["code"], "ABCD2345")
 		self.assertEqual(captured["json"]["email"], "e@x.com")
+
+	# --- signup-flow Host capture (plan 2026-08-17) ---
+
+	def _pop_host(self):
+		frappe.conf.pop("host_name", None)
+		frappe.conf.pop("hostname", None)
+
+	def test_signup_flow_call_uses_header_override_ON(self):
+		# trust_host=True (signup only) flips get_url to allow_header_override=True.
+		self._pop_host()
+		with patch("frappe.utils.get_url", return_value="https://x.example.com") as gu:
+			admin_client._public_origin(trust_host=True)
+		gu.assert_called_once_with(allow_header_override=True)
+
+	def test_signup_forces_https_on_an_http_real_domain(self):
+		# A real domain reached over http (proxy without XF-Proto) -> https. Mutation: drop the
+		# normalization -> stays http -> reds.
+		self._pop_host()
+		with patch("frappe.utils.get_url", return_value="http://staging-fleet.klerk.in"):
+			out = admin_client._public_origin(trust_host=True)
+		self.assertEqual(out, "https://staging-fleet.klerk.in")
+
+	def test_signup_keeps_dev_local_host_unchanged(self):
+		# A dev .local bench (reserved TLD) must NOT be https-forced / port-dropped. Mutation:
+		# drop the reserved-TLD / isalpha guard -> normalizes -> reds.
+		self._pop_host()
+		with patch("frappe.utils.get_url", return_value="http://jarvis.local:8002"):
+			out = admin_client._public_origin(trust_host=True)
+		self.assertEqual(out, "http://jarvis.local:8002")
+
+	def test_signup_does_not_normalize_a_dotted_ip(self):
+		# A dotted IP literal is not a public domain. Double-guarded by design: the ipaddress check
+		# AND the numeric-last-label isalpha check both reject it (defense-in-depth).
+		self._pop_host()
+		with patch("frappe.utils.get_url", return_value="http://192.168.1.5:8000"):
+			out = admin_client._public_origin(trust_host=True)
+		self.assertEqual(out, "http://192.168.1.5:8000")
+
+	def test_signup_does_not_normalize_an_internal_site_name(self):
+		# staging.v15 - non-alphabetic TLD (v15) - is an internal site name, not a public domain.
+		self._pop_host()
+		with patch("frappe.utils.get_url", return_value="http://staging.v15"):
+			out = admin_client._public_origin(trust_host=True)
+		self.assertEqual(out, "http://staging.v15")
+
+	def test_signup_malformed_host_does_not_raise(self):
+		# A get_url value whose netloc breaks urlsplit must never 500 signup.
+		self._pop_host()
+		with patch("frappe.utils.get_url", return_value="http://[oops"):
+			out = admin_client._public_origin(trust_host=True)  # must not raise
+		self.assertEqual(out, "http://[oops")
+
+	def test_default_ignores_a_spoofed_host_even_when_authenticated(self):
+		# SECURITY (real get_url): the DEFAULT (non-signup) path must NOT trust a spoofed Host,
+		# even under an authenticated session. Mutation: default trust_host to True -> reds.
+		self._pop_host()
+		with _fake_request(host="evil.attacker.com", user="Administrator"):
+			out = admin_client._public_origin()  # default trust_host=False
+		self.assertNotIn("evil.attacker.com", out)
+
+	def test_signup_captures_the_authenticated_host_end_to_end(self):
+		# End-to-end (real get_url): trust_host=True derives the customer's real host from the
+		# request and forces https for a real domain.
+		self._pop_host()
+		with _fake_request(host="staging-fleet.klerk.in", user="Administrator"):
+			out = admin_client._public_origin(trust_host=True)
+		self.assertEqual(out, "https://staging-fleet.klerk.in")
+
+	def test_configured_host_name_wins_over_a_spoofed_host_on_signup(self):
+		# host_name must win even on the trust_host=True path (early return before the Host is
+		# consulted). Guards against a future reorder that lets a spoofed Host beat host_name.
+		frappe.conf["host_name"] = "https://tenant.example.com"
+		with _fake_request(host="evil.attacker.com", user="Administrator"):
+			out = admin_client._public_origin(trust_host=True)
+		self.assertEqual(out, "https://tenant.example.com")
 
 
 class TestPostUpdateLlmCredsAuthMode(FrappeTestCase):


### PR DESCRIPTION
## Problem
When a customer's site admin onboards from their own Frappe site (e.g. served at `https://staging-fleet.klerk.in`, internal site name `staging.v15`), the bench handed admin **`http://staging.v15`** as `frappe_site_url` whenever `host_name` was unset. `_public_origin()` used `allow_header_override=False` for *every* caller, so it fell back to the internal site name. That wrong value then drove the **post-payment redirect** back to the customer (and the welcome-email link), sending them to an unreachable internal URL.

## Fix — capture the real URL on the signup flow, keep the rest secure
The natural source of the customer's real public URL is the request `Host` header — but the code deliberately refused it to stop a spoofed Host from poisoning the recorded URL. **All** onboarding paths are authenticated (`require_jarvis_admin`), but only **signup** creates a *new* account, so trusting that admin's own request Host is self-scoped there; reconnect/replacement/lead target an *existing* account by email and must stay on the secure derivation.

- `_public_origin(trust_host=False)` — `host_name` still wins; else `get_url(allow_header_override=trust_host)`. **Only `signup()` passes `trust_host=True`**; the four other callers keep the default `False` (unchanged, secure).
- `_is_real_public_host()` — a real domain (dotted, not localhost, not an IP literal via `ipaddress`, alphabetic non-reserved TLD) is normalized to `https://<host>`; `jarvis.local`, `staging.v15`, IPs, and bare/dev hosts are left as-is, so **dev benches are unaffected**.
- A malformed `Host` never raises — signup can't 500.

## Security
Reviewed in depth: `trust_host=True` is unreachable by a guest (`start_signup` is `@whitelist` + `require_jarvis_admin`); a spoofed Host is ignored on the non-signup paths even under an authenticated session; signup always inserts a *fresh* Customer (no cross-tenant poisoning); admin re-validates `^https?://…`; the verification magic-link uses admin's own origin, not this value; no SSRF sink.

## Tests
110 green on `test_jarvis` (+ onboarding suites, 225 total). New tests drive the **real unmocked `get_url`** with a request Host to prove both the capture (`staging-fleet.klerk.in` → https) and the security guarantee (a spoofed Host is ignored on the default path). Each load-bearing guard mutation-verified; `host_name`-wins-under-`trust_host=True` covered. ruff clean.

## Note
Bench-only. Existing `Jarvis Customer.frappe_site_url` rows already stored with the internal name need a one-time admin-side data correction (owner-run ops step, out of this PR).