### PR TITLE
fix(widget): match mini-chat popup surface to full chat (#16161a)

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1699,7 +1699,7 @@ defineExpose({ load, startNewChat, convId });
 	--jv-warn-bd: #f3e0bb;
 }
 .jvp-panel--dark {
-	--jv-surface: #1e1d23;
+	--jv-surface: #16161a;
 	--jv-rule: #2a2833;
 	--jv-rule-2: #2e2c36;
 	--jv-ink: #eceaf2;


### PR DESCRIPTION
## What

The dark-mode Jarvis side-chat **popup** (the FAB mini-chat on the Desk) painted its panel background with `--jv-surface: #1e1d23` — a shade lighter than the **full chat** window's `--surface: #16161a`. The two chat surfaces looked inconsistent side by side.

This aligns the popup's dark surface token to `#16161a`, so both windows share the same background.

## Change

- `jarvis/public/js/jarvis_chat/widget/Panel.vue` — `.jvp-panel--dark { --jv-surface: #1e1d23 → #16161a }` (one line).

## Scope / safety

- `#1e1d23` occurred exactly once in the whole repo; this is its only reference.
- `--jv-surface` also backs the online-status dot border, which stays consistent with the new background.
- Light mode is untouched; no logic, interaction, or state paths affected.
- Verified in the running app: the live `bench watch` bundle (`jarvis_widget.bundle.*.js`) recompiled to contain `16161a` and zero `1e1d23`, and the rendered popup was visually confirmed to match the full chat.