### PR TITLE
fix(export_document): letterhead logo-only for composed reports (stag…

### DIFF
--- a/jarvis/tests/test_export_document_furniture.py
+++ b/jarvis/tests/test_export_document_furniture.py
@@ -568,37 +568,56 @@ def _stub_letterhead(*, default=None, docs=None, perms=True):
 
 
 class TestResolveLetterhead(unittest.TestCase):
-	def test_resolve_letterhead_default_used_when_unnamed(self) -> None:
+	def test_resolve_letterhead_default_logo_kept_text_dropped(self) -> None:
+		# Logo-only: a data: logo survives; the doc-bound text block is dropped.
 		_stub_letterhead(
 			default="Std",
-			docs={"Std": {"content": "<div>HDR</div>", "footer": "<div>FTR</div>"}},
+			docs={
+				"Std": {
+					"content": '<div>HDR<img src="data:image/png;base64,AAAA"></div>',
+					"footer": '<img src="data:image/png;base64,BBBB">FTR',
+				}
+			},
 		)
 		self.addCleanup(patch.stopall)
 		header, footer, note = resolve_letterhead(None)
-		self.assertTrue("HDR" in header and "FTR" in footer)
+		self.assertIn("data:image/png;base64,AAAA", header)
+		self.assertNotIn("HDR", header)  # doc-bound text dropped
+		self.assertIn("data:image/png;base64,BBBB", footer)
+		self.assertNotIn("FTR", footer)
 		self.assertIsNone(note)
 
 	def test_resolve_letterhead_named(self) -> None:
-		_stub_letterhead(docs={"Acme": {"content": "<div>ACME</div>", "footer": ""}})
-		self.addCleanup(patch.stopall)
-		header, _footer, note = resolve_letterhead("Acme")
-		self.assertIn("ACME", header)
-		self.assertIsNone(note)
-
-	def test_resolve_letterhead_jinja_never_leaks_raw(self) -> None:
-		# The staging-smoke bug: a Jinja Letter Head folded in raw leaked
-		# {% if %}/{{ }} into the PDF. Even in the worst case (render leaves the
-		# tags), the residual scrub must remove them; static text survives.
 		_stub_letterhead(
-			default="Std",
-			docs={"Std": {"content": "<div>{% if x %}{{ x }}{% endif %}Acme Ltd</div>", "footer": ""}},
+			docs={"Acme": {"content": '<img src="data:image/png;base64,CCCC">ACME', "footer": ""}}
 		)
 		self.addCleanup(patch.stopall)
-		with patch.object(furniture.frappe, "render_template", lambda tpl, ctx: tpl):
-			header, _footer, _note = resolve_letterhead(None)
+		header, _footer, note = resolve_letterhead("Acme")
+		self.assertIn("data:image/png;base64,CCCC", header)
+		self.assertNotIn("ACME", header)
+		self.assertIsNone(note)
+
+	def test_resolve_letterhead_jinja_never_leaks(self) -> None:
+		# The staging-smoke bug: a doc-bound Jinja Letter Head produced raw {% %}
+		# (folded raw) or "None"/junk (rendered without a doc). Logo-only drops the
+		# entire Jinja text block — no tags, no rendered junk — keeping only a logo.
+		_stub_letterhead(
+			default="Std",
+			docs={
+				"Std": {
+					"content": "<div>{% if x %}{{ company_address }}{% endif %}"
+					'<img src="data:image/png;base64,DDDD"></div>',
+					"footer": "",
+				}
+			},
+		)
+		self.addCleanup(patch.stopall)
+		header, _footer, _note = resolve_letterhead(None)
 		self.assertNotIn("{%", header)
 		self.assertNotIn("{{", header)
-		self.assertIn("Acme Ltd", header)
+		self.assertNotIn("None", header)
+		self.assertNotIn("company_address", header)
+		self.assertIn("data:image/png;base64,DDDD", header)  # logo survives
 
 	def test_resolve_letterhead_no_default_no_note(self) -> None:
 		_stub_letterhead(default=None)
@@ -622,13 +641,15 @@ class TestResolveLetterhead(unittest.TestCase):
 		self.assertTrue(note and "Acme" in note)
 
 	def test_resolve_letterhead_strips_remote_image_end_to_end(self) -> None:
-		# The F1 SSRF gate wired through resolve_letterhead: a Letter Head whose content
-		# carries a remote <img>/<link> must come back with NO remote URL (the gate runs
-		# after inlining), while benign text survives.
+		# The F1 SSRF gate wired through resolve_letterhead: a Letter Head whose
+		# content carries a REMOTE <img> (and a <link>) comes back with NO remote
+		# URL — logo-only extracts the imgs, the remote one is dropped by the inline
+		# step, the <link>/text never survive, and a data: logo is kept.
 		_stub_letterhead(
 			docs={
 				"Evil": {
 					"content": '<div>Acme<img src="http://169.254.169.254/x">'
+					'<img src="data:image/png;base64,EEEE">'
 					'<link href="http://evil/x.css"></div>',
 					"footer": "",
 				}
@@ -639,7 +660,8 @@ class TestResolveLetterhead(unittest.TestCase):
 		low = header.lower()
 		self.assertTrue("169.254" not in low and "evil" not in low)
 		self.assertNotIn("<link", low)
-		self.assertIn("Acme", header)
+		self.assertNotIn("Acme", header)  # doc-bound text dropped (logo-only)
+		self.assertIn("data:image/png;base64,EEEE", header)  # the safe logo survives
 		self.assertIsNone(note)
 
 	def test_remove_quietly_suppresses_oserror(self) -> None:
@@ -659,71 +681,36 @@ class TestResolveLetterhead(unittest.TestCase):
 		self.assertIsNone(note)
 
 
-class TestRenderLetterheadTemplate(unittest.TestCase):
-	"""_render_letterhead: render a Letter Head's Jinja, then scrub residual tags."""
+class TestLetterheadLogos(unittest.TestCase):
+	"""_letterhead_logos: keep only <img> logos from a Letter Head, drop the
+	doc-bound Jinja/text block (a composed report has no doc to render it cleanly,
+	so rendering would leak raw tags or "None"/junk — the staging-smoke defect)."""
 
-	def test_non_jinja_passthrough_does_not_render(self) -> None:
-		called: list = []
-
-		def _spy(*_a, **_k):
-			called.append(1)
-			return ""
-
-		patch.object(furniture.frappe, "render_template", _spy).start()
-		self.addCleanup(patch.stopall)
-		out = furniture._render_letterhead("<div>plain logo</div>", {})
-		self.assertEqual(out, "<div>plain logo</div>")
-		self.assertEqual(called, [])  # no template markers → render_template skipped
-
-	def test_renders_then_scrubs_residual(self) -> None:
-		patch.object(
-			furniture.frappe, "render_template", lambda t, c: "<b>Acme</b>{% stray %}keep{{ x }}"
-		).start()
-		self.addCleanup(patch.stopall)
-		out = furniture._render_letterhead("<b>{{ company }}</b>", {})
+	def test_extracts_img_drops_text_and_jinja(self) -> None:
+		out = furniture._letterhead_logos(
+			"<div>{% if x %}{{ company_address }}{% endif %}Acme Ltd"
+			'<img src="data:image/png;base64,AAAA"></div>'
+		)
+		self.assertIn('src="data:image/png;base64,AAAA"', out)
+		self.assertNotIn("Acme", out)
 		self.assertNotIn("{%", out)
 		self.assertNotIn("{{", out)
-		self.assertIn("Acme", out)
-		self.assertIn("keep", out)
+		self.assertNotIn("company_address", out)
 
-	def test_render_error_falls_back_to_stripped_raw(self) -> None:
-		def _boom(*_a, **_k):
-			raise RuntimeError("no doc context")
+	def test_no_img_returns_empty(self) -> None:
+		self.assertEqual(furniture._letterhead_logos("<div>{{ company }} Just text</div>"), "")
+		self.assertEqual(furniture._letterhead_logos(""), "")
 
-		patch.object(furniture.frappe, "render_template", _boom).start()
-		patch.object(furniture.frappe, "clear_last_message", lambda: None).start()
-		self.addCleanup(patch.stopall)
-		out = furniture._render_letterhead('<img src="data:x"> {% if y %}{{ y }}{% endif %}', {})
-		self.assertNotIn("{%", out)
-		self.assertNotIn("{{", out)
-		self.assertIn("<img", out)  # static logo survives the fallback
+	def test_multiple_imgs_kept_text_between_dropped(self) -> None:
+		out = furniture._letterhead_logos('<img src="/files/a.png"><span>x</span><img src="/files/b.png">')
+		self.assertEqual(out.count("<img"), 2)
+		self.assertNotIn("<span", out)
 
 	def test_oversized_letterhead_dropped_without_hang(self) -> None:
-		# A pathological unclosed-{{ run must be dropped on size BEFORE the
-		# superlinear residual scrub (it runs pre-render, outside the render
-		# timeout). Guard: this returns quickly, not in O(n^2).
 		import time
 
-		called: list = []
-		patch.object(furniture.frappe, "render_template", lambda *_a, **_k: called.append(1) or "").start()
-		self.addCleanup(patch.stopall)
-		huge = "{{" * (furniture._MAX_FURNITURE_CHARS)  # >> the cap
+		huge = "<img>" + "x" * (furniture._MAX_FURNITURE_CHARS + 10)
 		start = time.monotonic()
-		out = furniture._render_letterhead(huge, {})
-		self.assertEqual(out, "")
-		self.assertEqual(called, [])  # never even reached render_template / scrub
+		out = furniture._letterhead_logos(huge)
+		self.assertEqual(out, "")  # over the cap → dropped
 		self.assertLess(time.monotonic() - start, 1.0)
-
-	def test_render_error_clears_leaked_message(self) -> None:
-		# render_template's error path appends its traceback to message_log before
-		# raising; _render_letterhead must clear it so it can't leak to the caller.
-		cleared: list = []
-
-		def _boom(*_a, **_k):
-			raise RuntimeError("Jinja Template Error")
-
-		patch.object(furniture.frappe, "render_template", _boom).start()
-		patch.object(furniture.frappe, "clear_last_message", lambda: cleared.append(1)).start()
-		self.addCleanup(patch.stopall)
-		furniture._render_letterhead("<b>{{ x }}</b>", {})
-		self.assertEqual(cleared, [1])

--- a/jarvis/tools/_export/document/furniture.py
+++ b/jarvis/tools/_export/document/furniture.py
@@ -87,9 +87,6 @@ _MAX_MARGIN_MM = 100
 
 _IMG_TAG_RE = re.compile(r"<img\b[^>]*?/?>", re.IGNORECASE)
 _SRC_RE = re.compile(r"""\bsrc\s*=\s*(?P<q>["'])(?P<url>.*?)(?P=q)""", re.IGNORECASE)
-# Residual Jinja tags to scrub AFTER a best-effort render, so a Letter Head's raw
-# template ({% if %} / {{ }}) can never leak into the PDF as literal text.
-_JINJA_RE = re.compile(r"{%.*?%}|{{.*?}}", re.DOTALL)
 
 # Self-contained CSS for the header/footer documents - they are SEPARATE
 # wkhtmltopdf renders, so they carry no body/theme styling and must style
@@ -413,19 +410,15 @@ def resolve_letterhead(letterhead: str | None) -> tuple[str, str, str | None]:
 		lh = frappe.db.get_value("Letter Head", name, ["content", "footer"], as_dict=True)
 		if not lh:
 			return "", "", (f"letterhead {named!r} not found — rendered without it" if named else None)
-		# A Letter Head's content/footer is a Jinja TEMPLATE (company address block,
-		# etc.). Render it first (a composed report has no source doc, so we supply a
-		# best-effort company context; undefined refs blank out) — else the raw
-		# {% if %}/{{ }} leaks into the PDF. THEN inline same-site logos to
-		# permission-checked base64 and run the airtight letterhead gate (nh3,
-		# data-only images) so no remote/relative src or fetch-capable markup remains.
-		ctx = _letterhead_context(name)
-		header = sanitize_letterhead(
-			_inline_letterhead_images(_render_letterhead(lh.get("content") or "", ctx))
-		)
-		footer = sanitize_letterhead(
-			_inline_letterhead_images(_render_letterhead(lh.get("footer") or "", ctx))
-		)
+		# A Letter Head's content/footer is a document-BOUND Jinja template (company
+		# address/contact keyed off the printed doc). A composed report has no such
+		# doc, so rendering it produces "None"/partial junk, and folding it in raw
+		# leaks {% %}/{{ }}. So keep ONLY the brand logo(s) and drop the text: extract
+		# the <img> tags, inline same-site logos to permission-checked base64, and run
+		# the airtight letterhead gate (nh3, data-only images). A tenant that wants
+		# text branding on a report can pass header=/footer= explicitly.
+		header = sanitize_letterhead(_inline_letterhead_images(_letterhead_logos(lh.get("content") or "")))
+		footer = sanitize_letterhead(_inline_letterhead_images(_letterhead_logos(lh.get("footer") or "")))
 		return header, footer, None
 	except Exception:
 		# Letterhead is a nicety, never a hard failure of the export.
@@ -433,53 +426,17 @@ def resolve_letterhead(letterhead: str | None) -> tuple[str, str, str | None]:
 		return "", "", (f"letterhead {named!r} could not be applied" if named else None)
 
 
-def _render_letterhead(tpl: str, ctx: dict) -> str:
-	"""Render a Letter Head Jinja template with ``ctx`` (best-effort), then scrub any
-	residual ``{% %}``/``{{ }}`` so a raw or partially-rendered template can never
-	leak into the PDF as literal text. Non-template content is returned unchanged.
-	Never raises: on a render error, the residual scrub still runs on the raw
-	template, keeping its static HTML (a logo ``<img>``) while dropping the tags."""
-	if not tpl:
+def _letterhead_logos(raw: str) -> str:
+	"""Return only the ``<img>`` logo tags from a Letter Head's HTML, dropping its
+	document-bound Jinja text block (which cannot render cleanly on a doc-less
+	composed report). Bounds the input first: a letterhead larger than the
+	furniture cap is broken/abuse and this runs BEFORE render_pdf's timeout."""
+	if not raw or "<img" not in raw.lower():
 		return ""
-	if len(tpl) > _MAX_FURNITURE_CHARS:
-		# A letterhead this large is broken/abuse. Rendering it — and the residual
-		# scrub, whose regex is superlinear on a long run of unclosed ``{{`` — would
-		# be unbounded CPU, and this runs BEFORE render_pdf's subprocess timeout, so
-		# it would pin the worker. Drop the block (a real letterhead is tiny).
-		_log_infra_failure("rich-pdf letterhead too large to render", f"{len(tpl)} chars")
+	if len(raw) > _MAX_FURNITURE_CHARS:
+		_log_infra_failure("rich-pdf letterhead too large", f"{len(raw)} chars")
 		return ""
-	if "{{" in tpl or "{%" in tpl:
-		try:
-			tpl = frappe.render_template(tpl, ctx)
-		except Exception:
-			# render_template's error path appends the traceback to
-			# ``frappe.message_log`` BEFORE raising; catching the exception does not
-			# undo that, so a broken-letterhead traceback could ride out to the
-			# caller via ``_server_messages``. Clear it.
-			with contextlib.suppress(Exception):
-				frappe.clear_last_message()
-			_log_infra_failure("rich-pdf letterhead template render failed", "")
-		tpl = _JINJA_RE.sub("", tpl)
-	return tpl
-
-
-def _letterhead_context(name: str) -> dict:
-	"""Best-effort Jinja context for a Letter Head on a doc-less composed report:
-	the site's default company + its address/contact block, so a standard company
-	letterhead renders its details instead of blanking. Never raises."""
-	ctx: dict = {"letter_head": name}
-	try:
-		company = frappe.defaults.get_global_default("company") or frappe.db.get_value("Company", {}, "name")
-		if company:
-			ctx["company"] = company
-			ctx["doc"] = frappe._dict({"company": company, "letter_head": name})
-			with contextlib.suppress(Exception):
-				from frappe.contacts.doctype.address.address import get_company_address
-
-				ctx.update(get_company_address(company) or {})
-	except Exception:
-		pass
-	return ctx
+	return "".join(_IMG_TAG_RE.findall(raw))
 
 
 def _inline_letterhead_images(html: str) -> str:


### PR DESCRIPTION
…ing smoke)

The staging re-smoke showed the render approach (Slice 1.1) no longer leaked raw Jinja, but produced tenant "None"/partial junk ("g", "(Demo)", "None") in the header: a Letter Head is a document-BOUND template (company address/contact keyed off the printed doc) and a composed report has no such doc — an unwinnable render.

Pivot to LOGO-ONLY for composed reports: resolve_letterhead now extracts only the Letter Head's <img> logo(s) (bounded first, then inlined to permission-checked base64 + the nh3 data-only gate) and DROPS the doc-bound Jinja/text block. No render, so no raw tags and no "None"/junk — deterministic and clean. A tenant that wants text branding on a report passes header=/footer= explicitly (the agent already supplies its own report title/footer). Removed _render_letterhead / _letterhead_context / _JINJA_RE (no longer rendering the letterhead).

Tests: replaced the render-template cases with _letterhead_logos (extract img, drop text+Jinja, size-cap) and updated the resolve tests (logo kept, text/Jinja dropped, remote img still stripped by the inline gate). 165 site-free tests + 151 subtests green; ruff clean.

⚠️ Still render-behavior — confirm on the staging re-smoke: header shows the logo (or nothing for a text-only letterhead), never raw template or "None" junk.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
