### PR TITLE
fix(agents): seed the marketplace catalog at install time

### DIFF
--- a/jarvis/install.py
+++ b/jarvis/install.py
@@ -15,8 +15,14 @@ absent on such a site before this hook existed:
 Observed live on a freshly reinstalled tenant: all three synced roles present,
 all three of the above missing.
 
-Reuses the migrate-time seeder rather than duplicating it, so the two entry
-points cannot drift. Idempotent: every seeder inside is exists-guarded.
+The Agents Marketplace catalog (``Jarvis Agent Listing``) has the same shape:
+it is synced from the bundled registry ONLY by the ``after_migrate`` hook, so a
+freshly onboarded site shows an empty Agents section until its first later
+migrate. Seeded here too, for the same reason.
+
+Reuses the migrate-time seeders rather than duplicating them, so the two entry
+points cannot drift. Idempotent: every seeder inside is exists-guarded (the
+catalog sync upserts by ``agent_slug``).
 
 Mirrors ``jarvis_admin_v2/install.py``, which exists for the same reason.
 """
@@ -59,4 +65,29 @@ def after_install() -> None:
 			+ ", ".join(missing)
 			+ ". The seeder swallows its own errors; see the 'jarvis wiki roles "
 			"seed failed' Error Log entry for the cause."
+		)
+
+	# The Agents Marketplace catalog (Jarvis Agent Listing) is otherwise seeded
+	# ONLY by the after_migrate hook, which install_app never runs -- so a freshly
+	# onboarded site shows an EMPTY Agents section until its first later migrate
+	# happens to fire the sync. Seed it here, the same as the roles above, so a
+	# day-1 site has the catalog from the moment jarvis is installed.
+	#
+	# Called directly (not agent_catalog.after_migrate, whose wrapper swallows
+	# exceptions -- against this hook's fail-loudly doctrine). Function-local
+	# import to avoid a new module-level import edge (agent_catalog itself
+	# lazy-imports to break a cycle).
+	from jarvis.chat.agent_catalog import sync_agent_listings
+
+	sync_agent_listings()
+	# _load_registry() returns an empty agent list WITHOUT raising if the bundled
+	# registry is missing, so a direct call can still seed nothing silently. The
+	# bundle ships at least one agent, so a 0 count is a real provisioning
+	# failure -- fail the install rather than leave the tenant with a permanently
+	# empty catalog it can only recover from via a manual migrate.
+	if frappe.db.count("Jarvis Agent Listing") == 0:
+		frappe.throw(
+			"jarvis after_install seeded an empty Agents Marketplace catalog. "
+			"The bundled jarvis/agents/registry.json is missing or empty; see the "
+			"'jarvis agent catalog: registry.json missing' Error Log entry."
 		)

--- a/jarvis/tests/test_install_catalog_seed.py
+++ b/jarvis/tests/test_install_catalog_seed.py
@@ -1,0 +1,57 @@
+"""after_install must seed the Agents Marketplace catalog.
+
+Regression for the fresh-onboard gap: ``Jarvis Agent Listing`` was seeded ONLY
+by the ``after_migrate`` hook, which ``install_app`` never runs, so a newly
+onboarded site showed an empty Agents section until its first later migrate.
+``jarvis.install.after_install`` now seeds the catalog too (and fails loudly if
+the bundled registry is missing).
+
+``after_install`` commits, so these tests cannot rely on the FrappeTestCase
+transaction rollback for the catalog table -- they restore it explicitly in
+tearDown by re-running the real sync.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import install
+from jarvis.chat import agent_catalog
+
+LISTING = "Jarvis Agent Listing"
+ALLOWED_ROLE = "Jarvis Agent Allowed Role"
+
+
+class TestInstallSeedsCatalog(FrappeTestCase):
+	def tearDown(self):
+		# after_install commits, so restore the catalog to the bundled registry
+		# regardless of what each test left behind.
+		agent_catalog.sync_agent_listings()
+		frappe.db.commit()
+
+	def _clear_catalog(self):
+		frappe.db.delete(ALLOWED_ROLE, {"parenttype": LISTING})
+		frappe.db.delete(LISTING)
+		frappe.db.commit()
+
+	def test_after_install_seeds_the_catalog(self):
+		"""On an empty catalog (a fresh install), after_install populates one
+		listing per bundled registry agent."""
+		self._clear_catalog()
+		self.assertEqual(frappe.db.count(LISTING), 0)
+
+		install.after_install()
+
+		expected = len(agent_catalog._load_registry().get("agents") or [])
+		self.assertGreater(expected, 0, "the bundled registry must ship at least one agent")
+		self.assertEqual(frappe.db.count(LISTING), expected)
+
+	def test_after_install_fails_loudly_on_empty_registry(self):
+		"""A missing/empty bundle leaves the catalog empty; after_install must
+		throw rather than let the site land with a permanently empty catalog."""
+		self._clear_catalog()
+
+		with patch.object(agent_catalog, "_load_registry", return_value={"agents": []}):
+			with self.assertRaises(frappe.ValidationError):
+				install.after_install()


### PR DESCRIPTION
## Problem
On a freshly onboarded customer site the **Agents** section is empty. The
Agents Marketplace catalog (`Jarvis Agent Listing`) is synced from the bundled
`jarvis/agents/registry.json` **only** by the `after_migrate` hook. But
`install_app` runs `after_install` and marks patches complete *without* running
them, and the documented onboarding (`new-site` + `install-app`, no `migrate`)
leaves a new site with an empty catalog until its first *later* migrate.

This is the same class of gap the roles/settings seed already closed in
`after_install` (see the `hooks.py` note: "A fresh install runs THIS and never
after_migrate…"); it just never got extended to the agent catalog.

## Fix
Seed the catalog in `after_install` too, mirroring the existing role seed, and
**fail the install loudly** if the bundle produced an empty catalog (same
fail-loud-then-verify doctrine already used for the install-only roles). Reuses
`sync_agent_listings` (idempotent) so the two entry points cannot drift.

## Verified
- Fresh `install-app`-only site: catalog `0` → after `after_install()` → **32**.
- `test_install_catalog_seed`: 2/2 green (happy path asserts count ==
  `len(registry.agents)`, not a hardcoded number; plus the fail-loud path).
- Live `list_agents_page` on the running server returns all 32 through the real
  auth + permission path.

## Already-affected sites
No data patch needed — a live site self-heals on its next `bench migrate`. For
immediate remediation: `bench --site <site> migrate` (or a console
`sync_agent_listings()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn6fmNAihoNB8swPsM3BcZ
