### PR TITLE
fix(agents): agent install/macro create throws on Frappe 15 (microsecond schedule_time)

### DIFF
--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -306,6 +306,17 @@ def parse_schedule_seconds(t) -> int | None:
 	MariaDB's TIME column accepts up to 838:59:59, which is why an out-of-range value
 	could be persisted at all: the storage layer is not the guard here.
 
+	A trailing fractional-seconds component ("HH:MM:SS.ffffff") IS a real time of day
+	and is accepted (the fraction is dropped): on Frappe 15 ``create_new`` stamps EVERY
+	Time field of a new doc with ``nowtime()`` unconditionally, and this version formats
+	it with microseconds ("%H:%M:%S.%f"), so a freshly inserted Jarvis Agent Installation
+	/ Jarvis Macro reaches ``validate`` with a microsecond ``schedule_time`` the caller
+	never set. Frappe 16 injects that default only for ``default = "now"`` fields, so the
+	value is ``None`` there and this path is Frappe-15-only in practice -- which is also
+	why CI (Frappe 16) never caught the install/macro-create break. The ``datetime.time``
+	and ``timedelta`` branches already drop sub-second precision; this keeps the string
+	branch consistent with them. The out-of-range guards below are unchanged.
+
 	``compute_next_run`` is shared with the AGENT scheduler (``agent_scheduler._advance``,
 	``agents_api.set_schedule``, ``agent_runs``), which has the same unguarded shape: the
 	agent sweep calls ``_advance`` from ten sites and only one of them sits inside a try.
@@ -324,6 +335,15 @@ def parse_schedule_seconds(t) -> int | None:
 		parts = str(t).strip().split(":")
 		if len(parts) > 3:
 			return None
+		# Tolerate a fractional-seconds component on the SECONDS part only (see
+		# docstring): "SS.ffffff" -> "SS". The fraction must be digits, or the whole
+		# value is garbage and stays rejected. A fractional part anywhere else
+		# (e.g. "12.5:00") still fails the int() below.
+		if len(parts) == 3 and "." in parts[2]:
+			whole, _, frac = parts[2].partition(".")
+			if not frac.isdigit():
+				return None
+			parts[2] = whole
 		try:
 			nums = [int(p) for p in parts]
 		except ValueError:

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1394,6 +1394,45 @@ class TestAgentScheduleTimeAndSweepIsolation(FrappeTestCase):
 				stored = frappe.db.get_value(INSTALLATION, name, "schedule_time")
 				self.assertEqual(parse_schedule_seconds(stored), secs)
 
+	def test_microsecond_schedule_time_parses_as_a_time_of_day(self):
+		"""Frappe 15's ``create_new`` stamps EVERY Time field of a new doc with
+		``nowtime()`` unconditionally, formatted with microseconds ("%H:%M:%S.%f"),
+		so a freshly inserted installation reaches ``validate`` holding a value the
+		caller never set. That value IS a real time of day and must parse (the
+		fraction dropped), or no agent could be installed on Frappe 15. Garbage is
+		still refused. Frappe 16 injects the default only for ``default = "now"``
+		fields, so the value is ``None`` there -- which is why CI (Frappe 16) never
+		caught the break."""
+		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+
+		self.assertEqual(parse_schedule_seconds("12:53:02.208095"), 46382)
+		self.assertEqual(parse_schedule_seconds("00:00:00.000000"), 0)
+		self.assertEqual(parse_schedule_seconds("23:59:59.999999"), 86399)
+		# Still rejected: out of range, a fraction on the wrong component, and a
+		# non-digit fraction are all garbage, not a time of day.
+		self.assertIsNone(parse_schedule_seconds("99:00:00.5"))
+		self.assertIsNone(parse_schedule_seconds("12.5:00"))
+		self.assertIsNone(parse_schedule_seconds("12:00:00.abc"))
+
+	def test_install_without_a_schedule_time_is_accepted(self):
+		"""End-to-end regression for the Frappe-15 install break: creating an
+		installation WITHOUT a ``schedule_time`` must not throw. Pre-fix the
+		framework-injected microsecond ``nowtime()`` failed the schedule_time
+		validation and NO agent could be installed on a Frappe-15 customer bench.
+		The stored value must read back as a real time of day or be empty."""
+		from jarvis.chat.macro_scheduler import parse_schedule_seconds
+
+		# _install -> _mk_gate_install -> get_doc(...).insert() with no schedule_time,
+		# so the insert exercises the framework default-injection path.
+		name = self._install()
+		self.assertTrue(frappe.db.exists(INSTALLATION, name))
+		stored = frappe.db.get_value(INSTALLATION, name, "schedule_time")
+		if stored not in (None, ""):
+			self.assertIsNotNone(
+				parse_schedule_seconds(stored),
+				"a framework-injected schedule_time must read back as a time of day",
+			)
+
 	def test_a_row_holding_a_legacy_bad_time_cannot_be_saved_by_the_DB_either(self):
 		"""Review asked whether validating on EVERY save strands a row that already
 		holds a bad value, since ``set_enabled`` / ``set_config`` go through


### PR DESCRIPTION
## Problem (Frappe-15-only; invisible to CI)
On a **Frappe 15** customer bench, installing **any** marketplace agent throws
`ValidationError: Schedule time must be a time of day between 00:00:00 and
23:59:59.` Creating a scheduled **Jarvis Macro** breaks the same way.

Root cause: Frappe 15's `create_new.py` stamps **every** Time field of a new doc
with `nowtime()` **unconditionally**, and this version formats it with
microseconds (`TIME_FORMAT = "%H:%M:%S.%f"`). So a freshly inserted
`Jarvis Agent Installation` reaches `validate` holding a `schedule_time` the
caller never set (e.g. `12:53:02.208095`), and `parse_schedule_seconds` rejects
it (`int("02.208095")` → ValueError).

**Why CI never caught it:** Frappe 16 injects that default only for
`default = "now"` fields, so `schedule_time` stays `None` (exempt) there. CI runs
Frappe 16; production customer benches run Frappe 15.

## Fix
`parse_schedule_seconds` now tolerates a fractional-seconds component on the
seconds part only (`HH:MM:SS.ffffff` → `HH:MM:SS`) — a real time of day with
microseconds *is* a real time of day, consistent with the `datetime.time` /
`timedelta` branches that already drop sub-second precision. Every out-of-range
and garbage guard is unchanged. One shared rule → fixes agent install **and**
scheduled-macro create together.

## Verified
- `test_agents_marketplace`: **29 errors → 36/36 green** after the fix.
- 2 regression tests added (microsecond parses / garbage + range still rejected;
  end-to-end install with no `schedule_time` no longer throws).
- 13-case parser boundary sweep confirmed (`24:00:00`, `99:00:00.5`, `12.5:00`,
  `12:00:00.abc` all rejected).

## Note
Two unrelated survivors in `test_platform_agents_api_hardening`
(`test_version_bump…`, `test_cross_install_recurrence_bump…`) are Frappe-15
test-internal artifacts (they assume Frappe-16 `frappe.db.value_cache` shape) —
pre-existing, not touched here, and green on CI's Frappe 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn6fmNAihoNB8swPsM3BcZ
