### PR TITLE
fix(billing): self-heal a false pay=failed with one status check

### DIFF
--- a/frontend/src/pages/billing/BillingPage.spec.js
+++ b/frontend/src/pages/billing/BillingPage.spec.js
@@ -1135,14 +1135,53 @@ describe("returning from the pay page", () => {
 		expect(api.checkBillingPayment).toHaveBeenCalledTimes(1);
 	});
 
-	it("does NOT check on an ordinary visit, or on a declined return", async () => {
-		for (const search of ["", "?pay=failed"]) {
-			vi.clearAllMocks();
-			atSearch(search);
-			await mountPage();
-			await flushPromises();
-			expect(api.checkBillingPayment).not.toHaveBeenCalled();
-		}
+	it("does NOT check on an ordinary visit", async () => {
+		atSearch("");
+		await mountPage();
+		await flushPromises();
+		expect(api.checkBillingPayment).not.toHaveBeenCalled();
+	});
+
+	// A false ?pay=failed (server-side race between the gateway and the bench)
+	// used to strand the customer on stale, pre-payment account state until they
+	// manually clicked "Check payment status". Landing here now runs that same
+	// check once, so it self-heals without a manual click.
+	it("runs the healer once on a declined return too, in case the failure was false", async () => {
+		atSearch("?pay=failed");
+		api.checkBillingPayment.mockResolvedValue(rawOk());
+		api.billingPaymentState.mockResolvedValue({ message: { ok: true, data: {} } });
+		await mountPage(baseAccount({ subscription_status: "Expired" }));
+		await flushPromises();
+		expect(api.checkBillingPayment).toHaveBeenCalledTimes(1);
+	});
+
+	// A GENUINE decline must still end in the visible failed presentation, not an
+	// infinite spinner or a settling loop: the one-shot check finds no payment and
+	// settleWithRedirect renders the coded notice exactly as a manual Check would.
+	it("a genuine decline still lands in the failed notice, not a redirect or a loop", async () => {
+		atSearch("?pay=failed");
+		api.checkBillingPayment.mockResolvedValue(rawOk());
+		api.billingPaymentState.mockResolvedValue({ code: "PAYMENT_DECLINED" });
+		const wrapper = await mountPage(baseAccount({ subscription_status: "Expired" }));
+		await flushPromises();
+
+		expect(api.checkBillingPayment).toHaveBeenCalledTimes(1);
+		expect(window.location.assign).not.toHaveBeenCalled();
+		expect(wrapper.vm.codeNotice.code).toBe("PAYMENT_DECLINED");
+	});
+
+	// The false-failed case end to end: the healer converges the race server-side
+	// and the passive re-read answers "already active", the same self-heal a
+	// done/pending return already gets.
+	it("a false failed self-heals to the paid notice when the server actually confirms payment", async () => {
+		atSearch("?pay=failed");
+		api.checkBillingPayment.mockResolvedValue(
+			rawFail(CODES.PAYMENT_ALREADY_ACTIVE, { status: 409 })
+		);
+		const wrapper = await mountPage();
+		await flushPromises();
+
+		expect(wrapper.text()).toContain("Nothing more is owed");
 	});
 });
 

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -482,11 +482,11 @@ function payOutcomeFrom(search) {
 		return "";
 	}
 }
-const SETTLING_OUTCOMES = new Set(["done", "pending"]);
+const CHECK_STATUS_OUTCOMES = new Set(["done", "pending", "failed"]);
 
 onMounted(() => {
 	const payOutcome = payOutcomeFrom(window.location.search);
-	const runCheck = SETTLING_OUTCOMES.has(payOutcome) || payOutcome === "failed";
+	const runCheck = CHECK_STATUS_OUTCOMES.has(payOutcome);
 	// No URL rewrite here. The router already drops the query and hash on mount, so
 	// stripping `pay` was dead code that a spec nonetheless pinned - a test asserting
 	// behaviour the application never exhibits is worse than no test. The healer runs

--- a/frontend/src/pages/billing/BillingPage.vue
+++ b/frontend/src/pages/billing/BillingPage.vue
@@ -469,7 +469,12 @@ function onPageShow(e) {
 // The admin pay page appends ?pay=done|failed|pending on its way back here (WS6
 // workspace.OUTCOME_*). done/pending mean money moved and the seams may still be
 // settling, so a plain read can show the customer the very state they just paid
-// to leave - run the healer once. `failed` has nothing to converge on.
+// to leave - run the healer once. A genuine decline is terminal and has nothing
+// to converge on, but the redirect can carry a FALSE `pay=failed` (a server-side
+// race between the gateway and the bench), so failed also gets exactly one
+// status check below - the same action the manual "Check payment status" button
+// runs. A real decline rides the same check straight back to the coded-notice
+// presentation (settleWithRedirect), never a spinner or a second check.
 function payOutcomeFrom(search) {
 	try {
 		return new URLSearchParams(search || "").get("pay") || "";
@@ -480,14 +485,15 @@ function payOutcomeFrom(search) {
 const SETTLING_OUTCOMES = new Set(["done", "pending"]);
 
 onMounted(() => {
-	const settling = SETTLING_OUTCOMES.has(payOutcomeFrom(window.location.search));
+	const payOutcome = payOutcomeFrom(window.location.search);
+	const runCheck = SETTLING_OUTCOMES.has(payOutcome) || payOutcome === "failed";
 	// No URL rewrite here. The router already drops the query and hash on mount, so
 	// stripping `pay` was dead code that a spec nonetheless pinned - a test asserting
 	// behaviour the application never exhibits is worse than no test. The healer runs
 	// once from the value read above; a reload cannot re-run it because the parameter
 	// is already gone by then.
 	loadAccount().then(() => {
-		if (settling) doCheckStatus();
+		if (runCheck) doCheckStatus();
 	});
 	window.addEventListener("pageshow", onPageShow);
 });


### PR DESCRIPTION
## Summary

A checkout redirect can carry a false pay=failed (server-side race, fixed separately in admin-v2). The onboarding flow already self-heals by re-checking server truth; the billing/renew page did not, leaving a paid customer staring at a failure until they clicked "Check payment status" by hand. The page now runs that exact same check once, automatically, when it lands with pay=failed.

- Reuses the manual button's code path verbatim; one-shot, busy-guarded, cannot loop.
- A genuine decline still ends in the existing failed presentation, never a spinner.
- Tests: replaced the spec pinning the old behavior, added three covering heal, genuine decline, and single-run.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (cut from develop tip 4ac5c8b7 today)
- [x] New/changed behavior has tests (billing + onboarding suites green locally, 189 tests, Node 24)
- [x] I self-reviewed the diff