### PR TITLE
fix(list): make the Sort field picker actually selectable (+ Created datetime sort)

### DIFF
--- a/frontend/src/components/list/SortButton.spec.js
+++ b/frontend/src/components/list/SortButton.spec.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// frappe-ui's ESM entry doesn't resolve under vitest; stub the three components
+// SortButton uses. The Popover stub renders BOTH slots so the picker body (which
+// used to be trapped behind a portal-select) is queryable in jsdom.
+vi.mock("frappe-ui", () => ({
+	Popover: {
+		name: "Popover",
+		template: `<div>
+			<slot name="target" :togglePopover="() => {}" />
+			<slot name="body" :close="() => {}" />
+		</div>`,
+	},
+	Button: {
+		name: "Button",
+		props: ["label", "icon", "tooltip", "variant"],
+		emits: ["click"],
+		template: `<button :data-icon="icon" @click="$emit('click')">{{ label }}</button>`,
+	},
+	FeatherIcon: {
+		name: "FeatherIcon",
+		props: ["name"],
+		template: `<span class="feather" :data-name="name" />`,
+	},
+}));
+
+import SortButton from "./SortButton.vue";
+
+const OPTIONS = [
+	{ label: "Name", value: "skill_name" },
+	{ label: "Updated", value: "modified" },
+	{ label: "Created", value: "creation" },
+];
+const DEFAULT = { field: "skill_name", dir: "asc" };
+
+function mountBtn(sort = { field: "", dir: "" }) {
+	return mount(SortButton, {
+		props: { sortOptions: OPTIONS, sort, defaultSort: DEFAULT },
+	});
+}
+
+describe("SortButton field picker (portal-free menu)", () => {
+	it("renders EVERY sort option as an in-DOM menuitemradio button (not a portal Select)", () => {
+		const w = mountBtn();
+		const items = w.findAll('[role="menuitemradio"]');
+		expect(items).toHaveLength(OPTIONS.length);
+		expect(items.map((i) => i.text())).toEqual(["Name", "Updated", "Created"]);
+	});
+
+	it("marks the current field aria-checked (the page default when no sort is active)", () => {
+		const checked = mountBtn()
+			.findAll('[role="menuitemradio"]')
+			.filter((i) => i.attributes("aria-checked") === "true");
+		expect(checked).toHaveLength(1);
+		expect(checked[0].text()).toBe("Name");
+		// and it tracks the active sort when one is set
+		const w2 = mountBtn({ field: "creation", dir: "desc" });
+		const checked2 = w2
+			.findAll('[role="menuitemradio"]')
+			.filter((i) => i.attributes("aria-checked") === "true");
+		expect(checked2[0].text()).toBe("Created");
+	});
+
+	it("clicking a field emits update:sort for THAT field (reachable now, was dismissed before)", async () => {
+		const w = mountBtn();
+		const updated = w.findAll('[role="menuitemradio"]').find((i) => i.text() === "Updated");
+		await updated.trigger("click");
+		const emits = w.emitted("update:sort");
+		expect(emits).toBeTruthy();
+		expect(emits.at(-1)[0]).toMatchObject({ field: "modified" });
+	});
+
+	it("the datetime columns (Updated/Created) are both pickable", async () => {
+		const w = mountBtn();
+		const created = w.findAll('[role="menuitemradio"]').find((i) => i.text() === "Created");
+		await created.trigger("click");
+		expect(w.emitted("update:sort").at(-1)[0]).toMatchObject({ field: "creation" });
+	});
+
+	// The always-visible direction toggle + Clear Sort are pre-existing, but the picker
+	// refactor sits beside them; pin them so the whole control stays covered.
+	it("the direction toggle flips dir and keeps the current field", async () => {
+		const w = mountBtn(); // default dir resolves to asc → toggle shows arrow-up
+		await w.find('[data-icon="arrow-up"]').trigger("click");
+		expect(w.emitted("update:sort").at(-1)[0]).toMatchObject({
+			field: "skill_name",
+			dir: "desc",
+		});
+	});
+
+	it("Clear Sort resets to the page default", async () => {
+		const w = mountBtn({ field: "creation", dir: "desc" });
+		const clear = w.findAll("button").find((b) => b.text() === "Clear Sort");
+		await clear.trigger("click");
+		expect(w.emitted("update:sort").at(-1)[0]).toEqual({ field: "skill_name", dir: "asc" });
+	});
+});

--- a/frontend/src/components/list/SortButton.spec.js
+++ b/frontend/src/components/list/SortButton.spec.js
@@ -95,4 +95,31 @@ describe("SortButton field picker (portal-free menu)", () => {
 		await clear.trigger("click");
 		expect(w.emitted("update:sort").at(-1)[0]).toEqual({ field: "skill_name", dir: "asc" });
 	});
+
+	// The button label bug: at the page default it reads "Sort" (a CTA), but toggling the
+	// direction and returning to the default snapped it back to "Sort" as if sort were cleared.
+	function mountAtDefault() {
+		return mount(SortButton, {
+			props: { sortOptions: OPTIONS, sort: { ...DEFAULT }, defaultSort: DEFAULT },
+		});
+	}
+
+	it("shows the 'Sort' CTA on a pristine list sitting at its default sort", () => {
+		expect(
+			mountAtDefault()
+				.findAll("button")
+				.map((b) => b.text())
+		).toContain("Sort");
+	});
+
+	it("keeps the field label (not 'Sort') after toggling direction back to the default", async () => {
+		const w = mountAtDefault();
+		await w.find('[data-icon="arrow-up"]').trigger("click"); // engage: asc -> desc
+		await w.setProps({ sort: { field: "skill_name", dir: "desc" } });
+		await w.find('[data-icon="arrow-down"]').trigger("click"); // desc -> asc (== default)
+		await w.setProps({ sort: { field: "skill_name", dir: "asc" } });
+		const labels = w.findAll("button").map((b) => b.text());
+		expect(labels).toContain("Name"); // stays the chosen field
+		expect(labels).not.toContain("Sort"); // NOT the cleared-CTA anymore
+	});
 });

--- a/frontend/src/components/list/SortButton.vue
+++ b/frontend/src/components/list/SortButton.vue
@@ -20,7 +20,7 @@
 		<Popover placement="bottom-end">
 			<template #target="{ togglePopover }">
 				<Button
-					:label="isDefault ? 'Sort' : fieldLabel"
+					:label="touched || !isDefault ? fieldLabel : 'Sort'"
 					class="rounded-l-none"
 					@click="togglePopover()"
 				/>
@@ -84,7 +84,7 @@
 // asc/desc toggle joined to the field button ("Sort" at the page default, the
 // field label once chosen); a ghost x reset appears once a non-default sort is
 // active. Emits update:sort {field, dir}.
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { Popover, Button, FeatherIcon } from "frappe-ui";
 
 const props = defineProps({
@@ -108,12 +108,18 @@ const dir = computed(() => props.sort.dir || props.defaultSort.dir || "desc");
 // The field the menu marks as selected: the active sort, else the page default.
 const currentField = computed(() => props.sort.field || props.defaultSort.field || "");
 
+// Once the user engages the sort (picks a field OR flips direction) the button shows the
+// chosen field, even when the values happen to equal the page default - otherwise toggling
+// Name desc->asc snaps the label back to "Sort" as if the sort were cleared. Reset clears it.
+const touched = ref(false);
+
 const fieldLabel = computed(() => {
-	const opt = (props.sortOptions || []).find((o) => o.value === props.sort.field);
-	return (opt && opt.label) || props.sort.field || "Sort";
+	const opt = (props.sortOptions || []).find((o) => o.value === currentField.value);
+	return (opt && opt.label) || currentField.value || "Sort";
 });
 
 function toggleDir() {
+	touched.value = true;
 	// Fall back to the default field so toggling from the untouched default state
 	// (where sort.field may not yet be set by the page) still emits a real field.
 	emit("update:sort", {
@@ -124,11 +130,13 @@ function toggleDir() {
 
 function pickField(field, close) {
 	if (!field) return;
+	touched.value = true;
 	emit("update:sort", { field, dir: props.sort.dir || props.defaultSort.dir || "asc" });
 	if (close) close();
 }
 
 function reset(close) {
+	touched.value = false;
 	emit("update:sort", {
 		field: props.defaultSort.field || "",
 		dir: props.defaultSort.dir || "",

--- a/frontend/src/components/list/SortButton.vue
+++ b/frontend/src/components/list/SortButton.vue
@@ -29,13 +29,35 @@
 				<div
 					class="my-2 min-w-60 rounded-lg bg-surface-modal p-2 shadow-2xl ring-1 ring-black ring-opacity-5"
 				>
-					<FormControl
-						type="select"
-						label="Sort by"
-						:options="sortOptions"
-						:modelValue="sort.field || defaultSort.field || ''"
-						@update:modelValue="(v) => pickField(v, close)"
-					/>
+					<!-- A portal-free radio menu, NOT a frappe-ui Select: that renders its
+					     options through a reka SelectPortal, whose click counts as OUTSIDE
+					     this Popover and dismisses it before a field can be picked - so only
+					     the default field was ever reachable. In-popover buttons stay in the
+					     Popover's own DOM, so it stays open until pickField() closes it. -->
+					<div
+						id="sort-by-heading"
+						class="px-2 pb-1 text-xs font-medium text-ink-gray-5"
+					>
+						Sort by
+					</div>
+					<div role="menu" aria-labelledby="sort-by-heading" class="flex flex-col">
+						<button
+							v-for="opt in sortOptions"
+							:key="opt.value"
+							type="button"
+							role="menuitemradio"
+							:aria-checked="opt.value === currentField"
+							class="flex items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-base text-ink-gray-8 hover:bg-surface-gray-2 focus:outline-none focus-visible:bg-surface-gray-2"
+							@click="pickField(opt.value, close)"
+						>
+							<span class="truncate">{{ opt.label }}</span>
+							<FeatherIcon
+								v-if="opt.value === currentField"
+								name="check"
+								class="size-4 text-ink-gray-7"
+							/>
+						</button>
+					</div>
 					<div class="mt-2 flex justify-end border-t pt-2">
 						<Button
 							variant="ghost"
@@ -63,7 +85,7 @@
 // field label once chosen); a ghost x reset appears once a non-default sort is
 // active. Emits update:sort {field, dir}.
 import { computed } from "vue";
-import { Popover, Button, FormControl } from "frappe-ui";
+import { Popover, Button, FeatherIcon } from "frappe-ui";
 
 const props = defineProps({
 	sortOptions: { type: Array, default: () => [] }, // [{label, value}]
@@ -82,6 +104,9 @@ const isDefault = computed(
 // Effective direction: the active sort's dir, else the page default, else desc.
 // The always-visible toggle needs a value even before the user has changed sort.
 const dir = computed(() => props.sort.dir || props.defaultSort.dir || "desc");
+
+// The field the menu marks as selected: the active sort, else the page default.
+const currentField = computed(() => props.sort.field || props.defaultSort.field || "");
 
 const fieldLabel = computed(() => {
 	const opt = (props.sortOptions || []).find((o) => o.value === props.sort.field);

--- a/frontend/src/pages/skills/SkillsList.vue
+++ b/frontend/src/pages/skills/SkillsList.vue
@@ -178,6 +178,7 @@ const QUICK_CLAUSES = { enabled: "enabled" };
 const sortOptions = [
 	{ label: "Name", value: "skill_name" },
 	{ label: "Updated", value: "modified" },
+	{ label: "Created", value: "creation" },
 	{ label: "Enabled", value: "enabled" },
 ];
 const DEFAULT_SORT = { field: "skill_name", dir: "asc" };

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -190,7 +190,12 @@ def _attach_shared_by(rows: list) -> None:
 # Paginated list (frozen envelope) — chat-features-page-migration-design §2.2.
 # ADDITIVE: list_custom_skills (above) STAYS for the composer "/" autocomplete.
 # --------------------------------------------------------------------------- #
-_SKILLS_SORTABLE = {"skill_name": "skill_name", "modified": "modified", "enabled": "enabled"}
+_SKILLS_SORTABLE = {
+	"skill_name": "skill_name",
+	"modified": "modified",
+	"creation": "creation",
+	"enabled": "enabled",
+}
 _SKILLS_FILTERS = {"scope", "enabled", "user_invocable"}
 
 

--- a/jarvis/tests/test_list_filters_pilots.py
+++ b/jarvis/tests/test_list_filters_pilots.py
@@ -469,3 +469,63 @@ class TestErrorCodesOnTheWire(unittest.TestCase):
 		contract still throws, which is what its existing callers expect."""
 		with _as(USER_A), self.assertRaises(frappe.ValidationError):
 			self._request("jarvis.chat.macros_api.list_macros_page", filters='{"bogus_key": 1}')
+
+
+class TestSkillsSortableColumns(unittest.TestCase):
+	"""The skills list must sort by its datetime columns, not just Name (jarvis#900+):
+	the reachable frontend sort options (skill_name, modified, creation, enabled) each
+	have to be honored server-side, and anything else falls back to the Name default."""
+
+	def _order(self, field, direction="asc"):
+		from jarvis.chat.custom_skills_api import _SKILLS_SORTABLE
+
+		return list_filters.order_by(field, direction, _SKILLS_SORTABLE, "skill_name", "asc")
+
+	def test_created_datetime_is_a_sortable_column(self):
+		# Killing mutation: drop "creation" from _SKILLS_SORTABLE -> this falls back to
+		# skill_name asc and the assertion reds.
+		self.assertEqual(self._order("creation", "desc"), "`creation` desc, `name` asc")
+
+	def test_updated_datetime_is_a_sortable_column(self):
+		self.assertEqual(self._order("modified", "desc"), "`modified` desc, `name` asc")
+
+	def test_an_unknown_sort_field_falls_back_to_name(self):
+		self.assertEqual(self._order("description"), "`skill_name` asc, `name` asc")
+
+	def test_creation_sort_actually_reorders_rows_end_to_end(self):
+		# Real endpoint proof (mirrors test_feature_pages_api.test_sort_creation_default_desc):
+		# three skills with KNOWN, distinct creation times -> sort_field=creation returns them
+		# in creation order, not the skill_name default. Names are chosen so name-order and
+		# creation-order differ, so a fallback-to-name would be visible.
+		names = ["lfp-cr-c", "lfp-cr-a", "lfp-cr-b"]  # insert order != alpha order
+		try:
+			with _as(USER_A):
+				for n in names:
+					frappe.get_doc(
+						{
+							"doctype": SKILL,
+							"skill_name": n,
+							"description": "creation-sort e2e fixture",
+							"instructions": "creation-sort e2e fixture instructions",
+							"scope": "User",
+							"enabled": 1,
+						}
+					).insert(ignore_permissions=True)
+			for i, n in enumerate(names):
+				frappe.db.set_value(
+					SKILL, {"skill_name": n}, "creation", f"2026-01-0{i + 1} 00:00:00", update_modified=False
+				)
+			frappe.db.commit()
+			with _as(USER_A):
+				desc = list_custom_skills_page(sort_field="creation", sort_dir="desc")
+				asc = list_custom_skills_page(sort_field="creation", sort_dir="asc")
+			desc_names = [r["skill_name"] for r in desc["rows"] if r["skill_name"] in names]
+			asc_names = [r["skill_name"] for r in asc["rows"] if r["skill_name"] in names]
+			# creation order is insert order (c, a, b); desc = newest first (b, a, c)
+			self.assertEqual(asc_names, ["lfp-cr-c", "lfp-cr-a", "lfp-cr-b"])
+			self.assertEqual(desc_names, ["lfp-cr-b", "lfp-cr-a", "lfp-cr-c"])
+		finally:
+			for n in names:
+				for nm in frappe.get_all(SKILL, filters={"skill_name": n}, pluck="name"):
+					frappe.delete_doc(SKILL, nm, force=True, ignore_permissions=True)
+			frappe.db.commit()


### PR DESCRIPTION
## Problem
On every list (Skills, Agents, Files, Macros, Dashboards, Support, Triggers) the **Sort** control only ever let you sort by the page default (e.g. `Name`). The "Sort by" field picker was a frappe-ui `FormControl type="select"` **inside a `Popover`**, and frappe-ui `Select` renders its options through a reka `SelectPortal` — whose click counts as an *outside-click* and **dismisses the popover before a field can be picked**. So the datetime columns (Updated, etc.) were wired end-to-end but unreachable. (`SortButton`'s own comment already flagged this for the direction toggle, which they'd moved out; the field select was left trapped.)

Reported on Skills: *"Unable to use column other than Name for sorting; it has to have date/datetime options; the UX is not good."*

## Fix
- **`SortButton.vue`**: replace the portal-based select with a **portal-free `role="menu"` list of `<button role="menuitemradio">` rows** rendered in the popover's own DOM. A click now stays inside the popover and applies via `pickField`. The public contract (props `sortOptions`/`sort`/`defaultSort`, emit `update:sort {field,dir}`), the always-visible direction toggle, and Clear Sort are unchanged. Shared component → **fixes sorting on every list page**. Adds an `aria-labelledby` group label.
- **Skills**: add a **`Created` (creation) datetime** sort option + whitelist `creation` in the backend `_SKILLS_SORTABLE`. `order_by` stays whitelist-only (no injection; `creation` is a real column, valid in `ORDER BY` without being in the `SELECT`).

## Tests
- `SortButton.spec.js`: renders every option as a menuitemradio, picks each (incl. Updated/Created) → emits the right field; direction toggle flips dir; Clear Sort resets. Frontend suite: **1337 green**.
- `test_list_filters_pilots.py`: `creation`/`modified` are honored sortable columns, an unknown field falls back to Name, and an **end-to-end** case creating 3 skills with distinct creation asserts real row-order for `sort_field=creation` (asc/desc). Backend module: 24 green. Mutation-verified.

## Verification note
This is an interaction fix; jsdom can't exercise the reka-portal outside-click, so the click-verification (open Sort → pick Updated/Created → list re-sorts, popover stays open) is a manual browser check. Follow-up: the **Filter** panel has the same reka-select-in-popover pattern (separate change).