### PR TITLE
feat: pull role-profile config from admin (Part B bench side)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -825,14 +825,17 @@ def get_role_profile_config(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	admin-decided ``enabled`` flag) for the daily bench pull
 	(``jarvis.chat.role_profiles.sync_role_profile_config``).
 
-	Response envelope: ``{"ok": True, "data": {version, enabled, sets,
-	shared_core, mappings, tool_tiers}}`` - the frozen role-profile-config wire
-	contract shared with the admin-side endpoint. Raises the same
-	``AdminAuthError`` / ``AdminUnreachableError`` / ``AdminValidationError``
-	family as every other admin_client call; an admin predating this endpoint
-	answers Frappe's method-not-found rejection (``is_method_not_found``),
-	which the caller treats identically to any other pull failure - never as
-	an error into the daily scheduler.
+	Wire envelope: the admin answers ``{"ok": True, "data": {version, enabled,
+	sets, shared_core, mappings, tool_tiers}}`` - but ``_post`` (via
+	``_do_post``) already unwraps that envelope on the way out
+	(``envelope.get("data", envelope)``), so what THIS FUNCTION RETURNS to its
+	caller is the bare data dict itself - ``{version, enabled, sets,
+	shared_core, mappings, tool_tiers}`` directly, not the ``{"ok", "data"}``
+	wrapper. Raises the same ``AdminAuthError`` / ``AdminUnreachableError`` /
+	``AdminValidationError`` family as every other admin_client call; an admin
+	predating this endpoint answers Frappe's method-not-found rejection
+	(``is_method_not_found``), which the caller treats identically to any
+	other pull failure - never as an error into the daily scheduler.
 	"""
 	return _post(
 		path=_m("api.tenant.get_role_profile_config"),

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -819,6 +819,28 @@ def get_connection(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	)
 
 
+def get_role_profile_config(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
+	"""Fetch the admin-owned role-profile config (skill sets, ERPNext role ->
+	set-key mappings, the ``standard`` tool tier's allow/core lists, and the
+	admin-decided ``enabled`` flag) for the daily bench pull
+	(``jarvis.chat.role_profiles.sync_role_profile_config``).
+
+	Response envelope: ``{"ok": True, "data": {version, enabled, sets,
+	shared_core, mappings, tool_tiers}}`` - the frozen role-profile-config wire
+	contract shared with the admin-side endpoint. Raises the same
+	``AdminAuthError`` / ``AdminUnreachableError`` / ``AdminValidationError``
+	family as every other admin_client call; an admin predating this endpoint
+	answers Frappe's method-not-found rejection (``is_method_not_found``),
+	which the caller treats identically to any other pull failure - never as
+	an error into the daily scheduler.
+	"""
+	return _post(
+		path=_m("api.tenant.get_role_profile_config"),
+		body={},
+		timeout_s=timeout_s,
+	)
+
+
 # --------------------------------------------------------------------------- #
 # Support panel proxies (Plan 3 B2). The customer bench forwards requesting_user +
 # scope to the control-plane support endpoints, which re-derive the customer from the

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -587,11 +587,21 @@ def _mappings_reference_known_sets(data: dict) -> bool:
 def _active_config() -> dict | None:
 	"""The validated, cached admin config for this request, or ``None`` when
 	no config is cached or it fails validation. Memoized on ``frappe.local``
-	at :data:`_CONFIG_MEMO_ATTR`, keyed on the current
-	``role_profiles_config_version`` so a version change mid-request - whether
-	via an explicit :func:`_invalidate_config_cache` call or a same-request DB
-	write this function simply notices on its next call - is never served
-	stale.
+	at :data:`_CONFIG_MEMO_ATTR` for the lifetime of this request/job: the
+	FIRST call reads, parses, and validates the cache exactly once, and every
+	later call in the same request returns that SAME memoized value - it does
+	NOT re-check ``role_profiles_config_version`` on each call. Only an
+	explicit :func:`_invalidate_config_cache` call (made by
+	:func:`sync_role_profile_config` itself, before its own forced re-push)
+	makes a same-request config update visible.
+
+	This is a deliberate stability contract, not an oversight: it makes one
+	``resolve_profile`` / ``needed_profiles`` run see a SINGLE config version
+	by construction - a mid-run version change can never mix two configs into
+	one resolution (which risked a KeyError-driven silent full-profile
+	fallback at the worst possible moment) - and it cuts what used to be an
+	uncached DB read on every one of the four accessor calls down to one read
+	total per request.
 
 	Never raises: any DB, JSON, or validation problem here is a fixture-
 	fallback signal to the accessors below, not an exception a caller has to
@@ -599,11 +609,8 @@ def _active_config() -> dict | None:
 	untouched by BJ2 - the accessors it calls can't raise.
 	"""
 	try:
-		version = frappe.db.get_single_value(_SETTINGS, "role_profiles_config_version", cache=False)
 		if hasattr(frappe.local, _CONFIG_MEMO_ATTR):
-			memo_version, memo_config = getattr(frappe.local, _CONFIG_MEMO_ATTR)
-			if memo_version == version:
-				return memo_config
+			return getattr(frappe.local, _CONFIG_MEMO_ATTR)
 
 		config = None
 		raw = frappe.db.get_single_value(_SETTINGS, "role_profiles_config", cache=False)
@@ -612,47 +619,49 @@ def _active_config() -> dict | None:
 			if _validate_role_profile_config(data) and _mappings_reference_known_sets(data):
 				config = data
 
-		setattr(frappe.local, _CONFIG_MEMO_ATTR, (version, config))
+		setattr(frappe.local, _CONFIG_MEMO_ATTR, config)
 		return config
 	except Exception:
 		return None
 
 
+def _config_or_fixture(key: str, fixture, coerce=lambda value: value):
+	"""Shared shape behind the four accessors below: the cached config's
+	``key`` (passed through ``coerce``) when a config is active for this
+	request, else ``fixture`` verbatim. Never raises: :func:`_active_config`
+	already can't raise, and ``coerce`` only ever runs on an already-validated
+	config value."""
+	config = _active_config()
+	if config is None:
+		return fixture
+	return coerce(config[key])
+
+
 def get_skill_sets() -> dict[str, frozenset[str]]:
 	"""Set-key -> skill-slug membership: the cached config's ``sets`` when a
 	config is active, else the module fixture (:data:`SKILL_SETS`)."""
-	config = _active_config()
-	if config is None:
-		return SKILL_SETS
-	return {set_key: frozenset(skills) for set_key, skills in config["sets"].items()}
+	return _config_or_fixture("sets", SKILL_SETS, lambda sets: {k: frozenset(v) for k, v in sets.items()})
 
 
 def get_role_to_set() -> dict[str, str]:
 	"""ERPNext role name -> set key: the cached config's ``mappings`` when a
 	config is active, else the module fixture (:data:`ROLE_TO_SET`)."""
-	config = _active_config()
-	if config is None:
-		return ROLE_TO_SET
-	return dict(config["mappings"])
+	return _config_or_fixture("mappings", ROLE_TO_SET, dict)
 
 
 def get_shared_core() -> frozenset[str]:
 	"""Always-on skill slugs: the cached config's ``shared_core`` when a
 	config is active, else the module fixture (:data:`SHARED_CORE_SKILLS`)."""
-	config = _active_config()
-	if config is None:
-		return SHARED_CORE_SKILLS
-	return frozenset(config["shared_core"])
+	return _config_or_fixture("shared_core", SHARED_CORE_SKILLS, frozenset)
 
 
 def get_tools_allow() -> list[str]:
 	"""The ``standard``-tier tool allow list: the cached config's
 	``tool_tiers.standard.allow`` when a config is active, else the module
 	fixture (:func:`standard_tools_allow`)."""
-	config = _active_config()
-	if config is None:
-		return standard_tools_allow()
-	return list(config["tool_tiers"]["standard"]["allow"])
+	return _config_or_fixture(
+		"tool_tiers", standard_tools_allow(), lambda tiers: list(tiers["standard"]["allow"])
+	)
 
 
 def sync_role_profile_config() -> dict:
@@ -676,9 +685,20 @@ def sync_role_profile_config() -> dict:
 	bench against an admin that predates this endpoint (method-not-found):
 	compat rule says that must leave the cache absent and the mirror OFF.
 
-	On success (version changed): invalidates BJ2's per-request config memo
-	BEFORE forcing a re-push, so the push recomputes :func:`needed_profiles`
-	from the NEW config rather than a value memoized earlier this request.
+	On a version change: invalidates BJ2's per-request config memo BEFORE
+	forcing a re-push, so the push recomputes :func:`needed_profiles` from the
+	NEW config rather than a value memoized earlier this request. The stored
+	``role_profiles_config_version`` itself is only advanced AFTER that push
+	reports success (``pushed: True`` - under ``force=True`` this is the only
+	non-exceptional outcome, since ``force`` bypasses
+	:func:`sync_role_profiles`'s own unchanged-is-a-noop short circuit, so a
+	``pushed: False`` here is unambiguously a real push failure, never a
+	legitimate no-op). A failed push is treated as this whole sync failing
+	(``{"synced": False}``) and deliberately leaves the OLD version stored -
+	the config JSON and the ``enable_role_profiles`` mirror are already
+	written by this point regardless, but the version field stays behind so
+	the NEXT tick sees ``version != previous_version`` again and retries the
+	push rather than silently going stale for up to a day.
 
 	Returns ``{"synced": bool}``.
 	"""
@@ -701,7 +721,6 @@ def sync_role_profile_config() -> dict:
 			_SETTINGS,
 			{
 				"role_profiles_config": frappe.as_json(data),
-				"role_profiles_config_version": version,
 				"role_profiles_config_synced_at": frappe.utils.now(),
 			},
 		)
@@ -710,7 +729,10 @@ def sync_role_profile_config() -> dict:
 		if version != previous_version:
 			phase = "push"
 			_invalidate_config_cache()
-			sync_role_profiles(force=True)
+			push_result = sync_role_profiles(force=True)
+			if not push_result.get("pushed"):
+				raise RuntimeError("role-profile push failed; config cached but version left unadvanced")
+			frappe.db.set_value(_SETTINGS, _SETTINGS, {"role_profiles_config_version": version})
 
 		return {"synced": True}
 	except Exception:
@@ -720,9 +742,28 @@ def sync_role_profile_config() -> dict:
 			has_cache = False
 		if not has_cache:
 			try:
+				previous_flag = frappe.db.get_single_value(_SETTINGS, "enable_role_profiles", cache=False)
+			except Exception:
+				previous_flag = None
+			try:
 				frappe.db.set_single_value(_SETTINGS, "enable_role_profiles", 0)
 			except Exception:
 				pass
+			if previous_flag:
+				# Ruling (whole-branch review): this zeroing is spec-mandated
+				# (B4 - admin-only ownership; never-synced means OFF; a hand-
+				# set historical value is overwritten by design), not a bug -
+				# but a 1->0 transition deserves its own operator-visible line
+				# distinct from the generic phase-failure log below.
+				frappe.log_error(
+					title="Jarvis: role-profile-config mirror defaulted OFF",
+					message=(
+						"role-profile config never synced (or lost its cache); "
+						"admin-owned enable_role_profiles flag defaulting OFF per "
+						"spec B4 - never tenant-controllable, and there is no "
+						"last-known-good state to preserve without a cache."
+					),
+				)
 		frappe.log_error(
 			title=f"Jarvis: role-profile-config {phase} failed",
 			message=frappe.get_traceback(),

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -272,15 +272,18 @@ def resolve_profile(user: str) -> ProfileChoice:
 		if roles & FULL_TIER_ROLES:
 			return _MAIN_PROFILE
 
-		matched = sorted({ROLE_TO_SET[role] for role in roles if role in ROLE_TO_SET})
+		role_to_set = get_role_to_set()
+		matched = sorted({role_to_set[role] for role in roles if role in role_to_set})
 		if not matched:
 			# No mapped ERPNext role: conservatively keep full tier / all
 			# skills in v1 rather than guess-trim (spec §3 fallback rule 2).
 			return _MAIN_PROFILE
 
-		skills = tuple(sorted(SHARED_CORE_SKILLS.union(*(SKILL_SETS[key] for key in matched))))
+		skill_sets = get_skill_sets()
+		shared_core = get_shared_core()
+		skills = tuple(sorted(shared_core.union(*(skill_sets[key] for key in matched))))
 		agent_id = "role-" + "+".join(matched)
-		allow = standard_tools_allow()
+		allow = get_tools_allow()
 		return ProfileChoice(
 			agent_id=agent_id,
 			tier="standard",
@@ -311,7 +314,7 @@ def needed_profiles() -> list[dict]:
 		pluck="name",
 	)
 
-	tools_allow = standard_tools_allow()
+	tools_allow = get_tools_allow()
 	profiles: dict[str, dict] = {}
 	# One frappe.get_roles call per user (via resolve_profile): N+1, but N is
 	# a tenant's enabled-user headcount, not a global scan, so this is fine.
@@ -553,6 +556,103 @@ def _validate_role_profile_config(data) -> bool:
 		return True
 	except Exception:
 		return False
+
+
+# --- Config-override accessor layer (task BJ2) ------------------------------
+#
+# Every fixture read below routes through these accessors: cached-config
+# value when a validated config is active for this request, else the module
+# fixture constant. Fallback is all-or-nothing (global constraints) - a
+# config that is charset-valid but structurally broken (e.g. a dangling
+# mapping set_key) is rejected here just as hard as one that fails BJ1's
+# type/charset check.
+
+
+def _mappings_reference_known_sets(data: dict) -> bool:
+	"""Referential integrity beyond BJ1's charset/shape check
+	(:func:`_validate_role_profile_config`): a config whose ``mappings`` point
+	at a ``set_key`` absent from ``sets`` is charset-valid but broken - left
+	unchecked, ``resolve_profile`` would KeyError on the dangling reference.
+	Rejected here so the caller takes the whole-config fallback path, never a
+	partial application. Never raises: any unexpected shape is treated as
+	invalid rather than crashing the accessor.
+	"""
+	try:
+		known_sets = set(data["sets"].keys())
+		return all(set_key in known_sets for set_key in data["mappings"].values())
+	except Exception:
+		return False
+
+
+def _active_config() -> dict | None:
+	"""The validated, cached admin config for this request, or ``None`` when
+	no config is cached or it fails validation. Memoized on ``frappe.local``
+	at :data:`_CONFIG_MEMO_ATTR`, keyed on the current
+	``role_profiles_config_version`` so a version change mid-request - whether
+	via an explicit :func:`_invalidate_config_cache` call or a same-request DB
+	write this function simply notices on its next call - is never served
+	stale.
+
+	Never raises: any DB, JSON, or validation problem here is a fixture-
+	fallback signal to the accessors below, not an exception a caller has to
+	handle. This is what lets :func:`resolve_profile`'s try/except stay
+	untouched by BJ2 - the accessors it calls can't raise.
+	"""
+	try:
+		version = frappe.db.get_single_value(_SETTINGS, "role_profiles_config_version", cache=False)
+		if hasattr(frappe.local, _CONFIG_MEMO_ATTR):
+			memo_version, memo_config = getattr(frappe.local, _CONFIG_MEMO_ATTR)
+			if memo_version == version:
+				return memo_config
+
+		config = None
+		raw = frappe.db.get_single_value(_SETTINGS, "role_profiles_config", cache=False)
+		if raw:
+			data = frappe.parse_json(raw)
+			if _validate_role_profile_config(data) and _mappings_reference_known_sets(data):
+				config = data
+
+		setattr(frappe.local, _CONFIG_MEMO_ATTR, (version, config))
+		return config
+	except Exception:
+		return None
+
+
+def get_skill_sets() -> dict[str, frozenset[str]]:
+	"""Set-key -> skill-slug membership: the cached config's ``sets`` when a
+	config is active, else the module fixture (:data:`SKILL_SETS`)."""
+	config = _active_config()
+	if config is None:
+		return SKILL_SETS
+	return {set_key: frozenset(skills) for set_key, skills in config["sets"].items()}
+
+
+def get_role_to_set() -> dict[str, str]:
+	"""ERPNext role name -> set key: the cached config's ``mappings`` when a
+	config is active, else the module fixture (:data:`ROLE_TO_SET`)."""
+	config = _active_config()
+	if config is None:
+		return ROLE_TO_SET
+	return dict(config["mappings"])
+
+
+def get_shared_core() -> frozenset[str]:
+	"""Always-on skill slugs: the cached config's ``shared_core`` when a
+	config is active, else the module fixture (:data:`SHARED_CORE_SKILLS`)."""
+	config = _active_config()
+	if config is None:
+		return SHARED_CORE_SKILLS
+	return frozenset(config["shared_core"])
+
+
+def get_tools_allow() -> list[str]:
+	"""The ``standard``-tier tool allow list: the cached config's
+	``tool_tiers.standard.allow`` when a config is active, else the module
+	fixture (:func:`standard_tools_allow`)."""
+	config = _active_config()
+	if config is None:
+		return standard_tools_allow()
+	return list(config["tool_tiers"]["standard"]["allow"])
 
 
 def sync_role_profile_config() -> dict:

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -708,7 +708,13 @@ def sync_role_profile_config() -> dict:
 
 		response = admin_client.get_role_profile_config()
 		phase = "validate"
-		data = response.get("data") if isinstance(response, dict) else None
+		# admin_client._post already unwraps the {"ok": True, "data": {...}}
+		# envelope (jarvis#907 live-verification fix): get_role_profile_config()
+		# returns the bare data dict directly. Tolerate both shapes here in
+		# case the transport ever changes back - response.get("data", response)
+		# reads the bare-dict wire format as-is, and still unwraps a legacy
+		# enveloped response if one is ever received.
+		data = response.get("data", response) if isinstance(response, dict) else None
 		if not _validate_role_profile_config(data):
 			raise ValueError("invalid or malformed role-profile config payload")
 

--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -23,6 +23,7 @@ built to never raise into a caller.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 import frappe
@@ -428,3 +429,202 @@ def on_user_update(doc, method: str | None = None) -> None:
 	cheap by design - ``enqueue_sync`` already swallows and logs its own
 	errors, so this never raises into the save path."""
 	enqueue_sync()
+
+
+# --- Admin-owned config pull (task BJ1) -------------------------------------
+#
+# The fixture module constants above (SKILL_SETS, ROLE_TO_SET, SHARED_CORE_SKILLS,
+# _STANDARD_TOOLS_ALLOW) remain the code-side fallback forever - fallback
+# discipline is absolute (global constraints): any missing/invalid/partial
+# cached config falls all the way back to the fixture, never a partial
+# application. This section only pulls, validates, caches, and mirrors the
+# admin-owned override; BJ2 is what actually routes fixture reads through it.
+
+# Wire-contract charset rules (frozen, mirrored from the admin editor's own
+# validation - see docs/superpowers/sdd .../global-constraints.md): a config
+# that violates any of these is rejected outright, never partially applied.
+_CONFIG_SKILL_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_CONFIG_SET_KEY_RE = re.compile(r"^[a-z][a-z0-9-]{0,30}$")
+_CONFIG_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9_]{1,64}$")
+_CONFIG_JARVIS_TOOL_RE = re.compile(r"^jarvis__[A-Za-z0-9_]+$")
+_CONFIG_TOOL_NAME_MAX_LEN = 200
+
+# frappe.local attribute BJ2's per-request `_active_config()` memo lives on.
+# Documented here (not in role_profiles' BJ2 half, which doesn't exist yet)
+# because this task defines the memo's home and the invalidation hook that
+# clears it; BJ2 reads/writes the same attribute name.
+_CONFIG_MEMO_ATTR = "jarvis_role_profile_config_memo"
+
+
+def _invalidate_config_cache() -> None:
+	"""Clear BJ2's per-request role-profile-config memo (kept on
+	``frappe.local`` at :data:`_CONFIG_MEMO_ATTR`) so a same-request config
+	update is never served stale to the code that reads it afterwards.
+
+	Called by :func:`sync_role_profile_config` immediately BEFORE a
+	version-changing ``sync_role_profiles(force=True)``, so that forced push
+	recomputes :func:`needed_profiles` from the freshly-stored config rather
+	than whatever BJ2's accessor may have already cached earlier in this same
+	request/job.
+
+	Defined here (BJ1) rather than in BJ2 because BJ1 lands first and must not
+	block on BJ2's accessor layer landing later: this is a no-op-safe stub
+	that only clears the attribute if present. BJ2 is free to memoize under
+	this same attribute name; nothing here assumes BJ2 exists yet.
+	"""
+	try:
+		if hasattr(frappe.local, _CONFIG_MEMO_ATTR):
+			delattr(frappe.local, _CONFIG_MEMO_ATTR)
+	except Exception:
+		pass
+
+
+def _valid_skill_slug(value) -> bool:
+	return isinstance(value, str) and bool(_CONFIG_SKILL_SLUG_RE.fullmatch(value))
+
+
+def _valid_set_key(value) -> bool:
+	return isinstance(value, str) and bool(_CONFIG_SET_KEY_RE.fullmatch(value))
+
+
+def _valid_tool_name(value) -> bool:
+	if not isinstance(value, str) or not value or len(value) > _CONFIG_TOOL_NAME_MAX_LEN:
+		return False
+	return bool(_CONFIG_TOOL_NAME_RE.fullmatch(value) or _CONFIG_JARVIS_TOOL_RE.fullmatch(value))
+
+
+def _validate_role_profile_config(data) -> bool:
+	"""Defensive shape + charset validation of the admin-pulled config payload
+	(wire contract: ``{version, enabled, sets, shared_core, mappings,
+	tool_tiers}``). Returns False on ANY structural or charset problem - the
+	caller then takes the failure path and never applies a partial config.
+	Never raises: any unexpected shape (wrong type where a dict/list was
+	assumed) is caught and treated as invalid rather than crashing the sync.
+	"""
+	try:
+		if not isinstance(data, dict):
+			return False
+		version = data.get("version")
+		if not isinstance(version, str) or not version:
+			return False
+		if not isinstance(data.get("enabled"), bool):
+			return False
+
+		sets = data.get("sets")
+		if not isinstance(sets, dict):
+			return False
+		for set_key, skills in sets.items():
+			# "shared-core" is a distinct top-level key (`shared_core`), never a
+			# mappable set - a config that puts it in `sets` too is malformed.
+			if not _valid_set_key(set_key) or set_key == "shared-core":
+				return False
+			if not isinstance(skills, list) or not all(_valid_skill_slug(s) for s in skills):
+				return False
+
+		shared_core = data.get("shared_core")
+		if not isinstance(shared_core, list) or not all(_valid_skill_slug(s) for s in shared_core):
+			return False
+
+		mappings = data.get("mappings")
+		if not isinstance(mappings, dict):
+			return False
+		for role_name, set_key in mappings.items():
+			if not isinstance(role_name, str) or not role_name or not _valid_set_key(set_key):
+				return False
+
+		tool_tiers = data.get("tool_tiers")
+		if not isinstance(tool_tiers, dict):
+			return False
+		standard = tool_tiers.get("standard")
+		if not isinstance(standard, dict):
+			return False
+		allow = standard.get("allow")
+		core = standard.get("core")
+		if not isinstance(allow, list) or not all(_valid_tool_name(t) for t in allow):
+			return False
+		if not isinstance(core, list) or not all(_valid_tool_name(t) for t in core):
+			return False
+		# core-flagged tools are a subset of the allow list by construction
+		# (global constraints: core rows can't be un-flagged/deleted); a
+		# payload violating that is malformed, not a partial-truth to accept.
+		if not set(core).issubset(set(allow)):
+			return False
+
+		return True
+	except Exception:
+		return False
+
+
+def sync_role_profile_config() -> dict:
+	"""Pull the admin-owned role-profile config, cache it, mirror the
+	admin-decided ``enable_role_profiles`` flag, and re-push role profiles
+	when the config's identity (``version``) changed since the last pull.
+
+	Never raises: this runs from the daily scheduler tick (and can be called
+	ad hoc via ``bench execute``), so every failure mode degrades rather than
+	propagates - logged once via ``frappe.log_error`` with a phase-tagged
+	title (mirrors :func:`sync_role_profiles`'s own convention) so an Error
+	Log entry doesn't need a traceback read to tell "admin unreachable" apart
+	from "admin sent a malformed payload".
+
+	Last-known-good rule (plan-binding): a transient failure (pull OR
+	validation) with an EXISTING cached config leaves BOTH the cache and the
+	``enable_role_profiles`` mirror untouched - a blip in admin reachability
+	must never silently disable a previously-synced tenant. A failure with NO
+	cache yet mirrors the flag OFF - nothing has ever been confirmed, so
+	there is no last-known-good state to preserve. This also covers an old
+	bench against an admin that predates this endpoint (method-not-found):
+	compat rule says that must leave the cache absent and the mirror OFF.
+
+	On success (version changed): invalidates BJ2's per-request config memo
+	BEFORE forcing a re-push, so the push recomputes :func:`needed_profiles`
+	from the NEW config rather than a value memoized earlier this request.
+
+	Returns ``{"synced": bool}``.
+	"""
+	phase = "pull"
+	try:
+		from jarvis import admin_client
+
+		response = admin_client.get_role_profile_config()
+		phase = "validate"
+		data = response.get("data") if isinstance(response, dict) else None
+		if not _validate_role_profile_config(data):
+			raise ValueError("invalid or malformed role-profile config payload")
+
+		phase = "store"
+		version = data["version"]
+		previous_version = frappe.db.get_single_value(_SETTINGS, "role_profiles_config_version", cache=False)
+
+		frappe.db.set_value(
+			_SETTINGS,
+			_SETTINGS,
+			{
+				"role_profiles_config": frappe.as_json(data),
+				"role_profiles_config_version": version,
+				"role_profiles_config_synced_at": frappe.utils.now(),
+			},
+		)
+		frappe.db.set_single_value(_SETTINGS, "enable_role_profiles", 1 if data["enabled"] else 0)
+
+		if version != previous_version:
+			phase = "push"
+			_invalidate_config_cache()
+			sync_role_profiles(force=True)
+
+		return {"synced": True}
+	except Exception:
+		try:
+			has_cache = bool(frappe.db.get_single_value(_SETTINGS, "role_profiles_config", cache=False))
+		except Exception:
+			has_cache = False
+		if not has_cache:
+			try:
+				frappe.db.set_single_value(_SETTINGS, "enable_role_profiles", 0)
+			except Exception:
+				pass
+		frappe.log_error(
+			title=f"Jarvis: role-profile-config {phase} failed",
+			message=frappe.get_traceback(),
+		)
+		return {"synced": False}

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -450,6 +450,13 @@ scheduler_events = {
 		# jarvis.chat.usage.record_turn_usage); without a sweep it grows
 		# forever. 90-day retention, same shape as the two prune jobs above.
 		"jarvis.chat.usage.prune_turn_usage",
+		# Role-profile-config bench pull (task BJ1): daily pull of the
+		# admin-owned skill-set/mapping/tool-tier config + the admin-decided
+		# enabled flag, cached and mirrored onto Jarvis Settings. Kept
+		# adjacent to the push entry below by convention only - ordering
+		# between the two does not matter for correctness, since a
+		# version-changing pull triggers its own forced re-push inline.
+		"jarvis.chat.role_profiles.sync_role_profile_config",
 		# Role-profile agents reconcile backstop: the User.on_update hook
 		# enqueues a resync on every role change, but a debounced job can be
 		# dropped (Redis down, a worker restart mid-run). Daily catches the

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -892,7 +892,7 @@
    "read_only": 1
   },
   {
-   "description": "Identity (sha256-derived) of the cached role_profiles_config, EXCLUDING the enabled flag. Compared against the freshly pulled version on every sync to decide whether a re-push of role profiles is needed.",
+   "description": "Opaque version identifier for the cached role_profiles_config (computed and owned by the admin side, EXCLUDING the enabled flag - the bench never hashes it, only compares it byte-for-byte). Compared against the freshly pulled version on every sync to decide whether a re-push of role profiles is needed.",
    "fieldname": "role_profiles_config_version",
    "fieldtype": "Data",
    "hidden": 1,

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -121,6 +121,9 @@
   "agent_catalog_version",
   "role_profiles_pushed",
   "role_profiles_pushed_at",
+  "role_profiles_config",
+  "role_profiles_config_version",
+  "role_profiles_config_synced_at",
   "release_notice_section",
   "release_notice_active",
   "latest_jarvis_version",
@@ -697,7 +700,9 @@
    "fieldtype": "Check",
    "label": "Enable Role-Based Agent Profiles",
    "default": "0",
-   "description": "When on, a new chat session may be pinned to a role-based agent profile (a reduced tool set plus the matching skill set derived from the user's ERPNext roles) instead of the main agent - but only once that profile has actually been rendered on the agent side (see Role Profiles Pushed below). Off (default): every session uses the main agent, matching pre-role-profiles behavior exactly. Operator intent, not tenant state - not reset between tenancies."
+   "read_only": 1,
+   "hidden": 1,
+   "description": "When on, a new chat session may be pinned to a role-based agent profile (a reduced tool set plus the matching skill set derived from the user's ERPNext roles) instead of the main agent - but only once that profile has actually been rendered on the agent side (see Role Profiles Pushed below). Off (default): every session uses the main agent, matching pre-role-profiles behavior exactly. Admin-owned mirror of the pulled role_profiles_config's `enabled` flag (spec B4) - never tenant-controllable; only jarvis.chat.role_profiles.sync_role_profile_config writes it. Reset to 0 between tenancies."
   },
   {
    "fieldname": "sync_tab",
@@ -876,6 +881,29 @@
    "fieldtype": "Datetime",
    "hidden": 1,
    "label": "Role Profiles Pushed At",
+   "read_only": 1
+  },
+  {
+   "description": "Canonical JSON of the admin-owned role-profile config last pulled (jarvis.chat.role_profiles.sync_role_profile_config): skill sets, ERPNext role -> set-key mappings, and the standard tool tier's allow/core lists. Empty when no config has ever been pulled (or the last pull failed with no prior cache) - readers fall back to the code fixture, never to a partial parse.",
+   "fieldname": "role_profiles_config",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Role Profile Config",
+   "read_only": 1
+  },
+  {
+   "description": "Identity (sha256-derived) of the cached role_profiles_config, EXCLUDING the enabled flag. Compared against the freshly pulled version on every sync to decide whether a re-push of role profiles is needed.",
+   "fieldname": "role_profiles_config_version",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Role Profile Config Version",
+   "read_only": 1
+  },
+  {
+   "fieldname": "role_profiles_config_synced_at",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "Role Profile Config Synced At",
    "read_only": 1
   },
   {

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -79,6 +79,12 @@ CONNECTION = ResetSpec(
 		# to the PREVIOUS tenancy's container; a reset must not let a fresh
 		# tenancy's first sync read it as "unchanged, no push needed".
 		"role_profiles_pushed",
+		# Same reasoning as role_profiles_pushed above: the cached admin config
+		# and its version identity belong to the PREVIOUS tenancy's admin pull.
+		# Left set, a fresh tenancy's first sync_role_profile_config would read
+		# an unrelated version as "unchanged" and skip its first re-push.
+		"role_profiles_config",
+		"role_profiles_config_version",
 		# Release notice + whitelabel branding of the previous tenancy. The SPA
 		# falls back to "Jarvis" when agent_name is blank.
 		"release_notice_message",
@@ -110,6 +116,7 @@ CONNECTION = ResetSpec(
 		"agent_skills_synced_at",
 		"learned_skills_synced_at",
 		"role_profiles_pushed_at",
+		"role_profiles_config_synced_at",
 		"wiki_mirror_last_synced_at",
 	),
 	zero=(
@@ -120,6 +127,10 @@ CONNECTION = ResetSpec(
 		# connection is accepted on its own terms, not rejected as "older" than
 		# the previous tenancy's generation (review plan 04 P0-5).
 		"tenant_authority_generation",
+		# enable_role_profiles is now an admin-owned mirror (spec B4), not
+		# operator intent - it must not carry the PREVIOUS tenancy's admin
+		# decision into a fresh one with no config pulled yet.
+		"enable_role_profiles",
 	),
 )
 

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -289,6 +289,176 @@ class TestSyncRoleProfiles(FrappeTestCase):
 		self.assertEqual([p["slug"] for p in first], ["role-accounts", "role-hr"])
 
 
+class TestRoleProfileConfigSync(FrappeTestCase):
+	"""``jarvis.chat.role_profiles.sync_role_profile_config`` - the admin-pull
+	+ cache + mirror + conditional re-push boundary (task BJ1).
+
+	Mirrors ``TestSyncRoleProfiles`` above: the three new Settings fields
+	(``role_profiles_config`` / ``_version`` / ``_synced_at``) only exist once
+	a ``bench migrate`` has run for the DocType JSON change in this task, and
+	this shared bench points at a live production tenancy, so the Settings
+	Single is stood in with a plain dict behind ``frappe.db.get_single_value``
+	/ ``set_value`` / ``set_single_value`` rather than written for real.
+	"""
+
+	@staticmethod
+	def _config(version="v1", enabled=True, skill="hrms-hr"):
+		return {
+			"version": version,
+			"enabled": enabled,
+			"sets": {"hr": [skill]},
+			"shared_core": ["frappe-core"],
+			"mappings": {"HR User": "hr"},
+			"tool_tiers": {"standard": {"allow": ["exec", "read"], "core": ["exec"]}},
+		}
+
+	@staticmethod
+	def _fake_store(initial=None):
+		"""Same shape as ``TestSyncRoleProfiles._fake_settings_store``, extended
+		with a ``set_single_value`` fake for the ``enable_role_profiles`` mirror
+		write."""
+		store = dict(initial or {})
+
+		def fake_get_single_value(doctype, fieldname, cache=True):
+			assert doctype == role_profiles._SETTINGS
+			return store.get(fieldname)
+
+		def fake_set_value(doctype, name, values, *args, **kwargs):
+			assert doctype == role_profiles._SETTINGS
+			assert name == role_profiles._SETTINGS
+			store.update(values)
+
+		def fake_set_single_value(doctype, fieldname, value, *args, **kwargs):
+			assert doctype == role_profiles._SETTINGS
+			store[fieldname] = value
+
+		return store, fake_get_single_value, fake_set_value, fake_set_single_value
+
+	def test_success_caches_mirrors_and_pushes_on_version_change(self):
+		store, fake_get, fake_set, fake_set_single = self._fake_store()
+		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		calls = []
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(
+				role_profiles, "_invalidate_config_cache", side_effect=lambda: calls.append("invalidate")
+			),
+			patch.object(
+				role_profiles, "sync_role_profiles", side_effect=lambda **kw: calls.append(("sync", kw))
+			),
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": True})
+		self.assertEqual(frappe.parse_json(store["role_profiles_config"])["version"], "v1")
+		self.assertEqual(store["role_profiles_config_version"], "v1")
+		self.assertIsNotNone(store.get("role_profiles_config_synced_at"))
+		self.assertEqual(store["enable_role_profiles"], 1)
+		# Invalidation must happen BEFORE the forced re-push, so the push
+		# recomputes needed_profiles() from the NEW config, not a value BJ2's
+		# accessor memoized earlier in this same request.
+		self.assertEqual(calls, ["invalidate", ("sync", {"force": True})])
+
+	def test_unchanged_version_does_not_repush(self):
+		store, fake_get, fake_set, fake_set_single = self._fake_store(
+			initial={"role_profiles_config_version": "v1"}
+		)
+		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(role_profiles, "_invalidate_config_cache") as mock_invalidate,
+			patch.object(role_profiles, "sync_role_profiles") as mock_sync,
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": True})
+		mock_invalidate.assert_not_called()
+		mock_sync.assert_not_called()
+		self.assertEqual(store["enable_role_profiles"], 1)
+
+	def test_pull_failure_with_existing_cache_keeps_cache_and_mirror(self):
+		store, fake_get, fake_set, fake_set_single = self._fake_store(
+			initial={
+				"role_profiles_config": frappe.as_json(self._config(version="v0")),
+				"role_profiles_config_version": "v0",
+				"enable_role_profiles": 1,
+			}
+		)
+		with (
+			patch(
+				"jarvis.admin_client.get_role_profile_config", side_effect=RuntimeError("admin unreachable")
+			),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+		):
+			before = dict(store)
+			result = role_profiles.sync_role_profile_config()
+			after = dict(store)
+
+		self.assertEqual(result, {"synced": False})
+		self.assertEqual(before, after)
+
+	def test_pull_failure_with_no_cache_mirrors_off(self):
+		store, fake_get, fake_set, fake_set_single = self._fake_store(
+			initial={"enable_role_profiles": 1}  # stale ON from a prior tenancy; no cache present
+		)
+		with (
+			patch(
+				"jarvis.admin_client.get_role_profile_config", side_effect=RuntimeError("admin unreachable")
+			),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": False})
+		self.assertEqual(store["enable_role_profiles"], 0)
+
+	def test_invalid_payload_is_failure_path_and_leaves_cache_untouched(self):
+		store, fake_get, fake_set, fake_set_single = self._fake_store()
+		bad = {"ok": True, "data": {"version": "v1"}}  # missing enabled/sets/mappings/tool_tiers
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=bad),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": False})
+		self.assertNotIn("role_profiles_config", store)
+		self.assertEqual(store.get("enable_role_profiles", 0), 0)
+
+	def test_invalidate_config_cache_is_safe_noop_when_nothing_memoized(self):
+		role_profiles._invalidate_config_cache()  # must not raise
+
+	def test_validate_rejects_bad_skill_slug_charset(self):
+		bad = self._config()
+		bad["sets"]["hr"] = ["HRMS_HR"]  # uppercase/underscore not allowed
+		self.assertFalse(role_profiles._validate_role_profile_config(bad))
+
+	def test_validate_rejects_core_tool_not_in_allow(self):
+		bad = self._config()
+		bad["tool_tiers"]["standard"]["core"] = ["exec", "not-allowed-tool"]
+		self.assertFalse(role_profiles._validate_role_profile_config(bad))
+
+	def test_validate_rejects_missing_key(self):
+		bad = self._config()
+		del bad["tool_tiers"]
+		self.assertFalse(role_profiles._validate_role_profile_config(bad))
+
+	def test_validate_accepts_well_formed_config(self):
+		self.assertTrue(role_profiles._validate_role_profile_config(self._config()))
+
+
 class FakeSess:
 	"""Stub pooled ``AgentSession``: counts ``create_session`` calls so tests
 	can assert the flag-gated legacy branch was (or was not) taken."""

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -338,6 +338,11 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 		store, fake_get, fake_set, fake_set_single = self._fake_store()
 		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
 		calls = []
+
+		def fake_sync(**kw):
+			calls.append(("sync", kw))
+			return {"pushed": True, "profiles": []}
+
 		with (
 			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
 			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
@@ -346,9 +351,7 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 			patch.object(
 				role_profiles, "_invalidate_config_cache", side_effect=lambda: calls.append("invalidate")
 			),
-			patch.object(
-				role_profiles, "sync_role_profiles", side_effect=lambda **kw: calls.append(("sync", kw))
-			),
+			patch.object(role_profiles, "sync_role_profiles", side_effect=fake_sync),
 		):
 			result = role_profiles.sync_role_profile_config()
 
@@ -361,6 +364,54 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 		# recomputes needed_profiles() from the NEW config, not a value BJ2's
 		# accessor memoized earlier in this same request.
 		self.assertEqual(calls, ["invalidate", ("sync", {"force": True})])
+
+	def test_failed_push_leaves_version_unadvanced_and_reports_synced_false(self):
+		"""Whole-branch review finding 1: a version-changing sync whose forced
+		re-push FAILS must not stamp the new version - stamping it anyway
+		would mean a failed push still reads as fully synced, leaving fleet
+		stale for up to a day before anything retries. The config JSON and
+		mirror are still written (they reflect the freshly validated pull,
+		independent of whether the push to admin/fleet succeeded); only the
+		version field is deliberately left at its old value so the next tick
+		sees a version mismatch again and retries."""
+		store, fake_get, fake_set, fake_set_single = self._fake_store(
+			initial={"role_profiles_config_version": "v0"}
+		)
+		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(role_profiles, "_invalidate_config_cache"),
+			patch.object(role_profiles, "sync_role_profiles", return_value={"pushed": False, "profiles": []}),
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": False})
+		self.assertEqual(store["role_profiles_config_version"], "v0")  # unadvanced
+		self.assertEqual(frappe.parse_json(store["role_profiles_config"])["version"], "v1")  # still cached
+
+	def test_successful_push_advances_the_stored_version(self):
+		"""Sibling of the failure test above: a version-changing sync whose
+		forced re-push SUCCEEDS does stamp the new version, so the next tick
+		correctly reads no change and stays a no-op."""
+		store, fake_get, fake_set, fake_set_single = self._fake_store(
+			initial={"role_profiles_config_version": "v0"}
+		)
+		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(role_profiles, "_invalidate_config_cache"),
+			patch.object(role_profiles, "sync_role_profiles", return_value={"pushed": True, "profiles": []}),
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": True})
+		self.assertEqual(store["role_profiles_config_version"], "v1")
 
 	def test_unchanged_version_does_not_repush(self):
 		store, fake_get, fake_set, fake_set_single = self._fake_store(
@@ -421,6 +472,52 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 
 		self.assertEqual(result, {"synced": False})
 		self.assertEqual(store["enable_role_profiles"], 0)
+
+	def test_mirror_off_transition_logs_a_distinct_operator_visible_reason(self):
+		"""Ruling (whole-branch review finding 2): zeroing the mirror on a
+		no-cache failure is spec-mandated (B4) and stays exactly as-is - but a
+		1->0 transition now writes its own log_error entry, distinct from the
+		generic phase-failure log, so an operator can tell "this tenant's
+		flag just went dark because it never synced" apart from every other
+		phase failure without reading a traceback."""
+		store, fake_get, fake_set, fake_set_single = self._fake_store(
+			initial={"enable_role_profiles": 1}  # stale ON from a prior tenancy; no cache present
+		)
+		with (
+			patch(
+				"jarvis.admin_client.get_role_profile_config", side_effect=RuntimeError("admin unreachable")
+			),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(frappe, "log_error") as mock_log_error,
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": False})
+		self.assertEqual(store["enable_role_profiles"], 0)
+		titles = [call.kwargs.get("title") for call in mock_log_error.call_args_list]
+		self.assertIn("Jarvis: role-profile-config mirror defaulted OFF", titles)
+
+	def test_mirror_already_off_does_not_log_a_transition(self):
+		"""Sibling of the transition test above: when the mirror is already 0
+		(no transition happening), the distinct log line must not fire - only
+		a real 1->0 flip is operator-visible-worthy."""
+		store, fake_get, fake_set, fake_set_single = self._fake_store(initial={"enable_role_profiles": 0})
+		with (
+			patch(
+				"jarvis.admin_client.get_role_profile_config", side_effect=RuntimeError("admin unreachable")
+			),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(frappe, "log_error") as mock_log_error,
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": False})
+		titles = [call.kwargs.get("title") for call in mock_log_error.call_args_list]
+		self.assertNotIn("Jarvis: role-profile-config mirror defaulted OFF", titles)
 
 	def test_invalid_payload_is_failure_path_and_leaves_cache_untouched(self):
 		store, fake_get, fake_set, fake_set_single = self._fake_store()
@@ -607,11 +704,18 @@ class TestRoleProfileConfigAccessors(FrappeTestCase):
 		with self._patched(None):
 			self.assertEqual(role_profiles.get_tools_allow(), role_profiles.standard_tools_allow())
 
-	def test_memo_keyed_on_version_picks_up_change_without_explicit_invalidate(self):
-		"""Design point: the memo is keyed on ``role_profiles_config_version``,
-		not just present/absent - a same-request write that bumps the version
-		must be picked up even without a separate ``_invalidate_config_cache``
-		call."""
+	def test_memo_is_stable_within_request_until_explicit_invalidate(self):
+		"""Deliberate semantic change (whole-branch review, findings 3+4+5):
+		``_active_config`` no longer re-checks ``role_profiles_config_version``
+		on every call - it memoizes on the FIRST read per request and does NOT
+		notice a same-request version bump on its own. Only an explicit
+		``_invalidate_config_cache()`` call (made by
+		``sync_role_profile_config`` itself before its forced re-push) makes a
+		same-request config update visible. This supersedes the old
+		version-keyed auto-refresh behavior: it keeps one
+		``resolve_profile`` / ``needed_profiles`` run on a SINGLE config
+		version by construction, so a mid-run version change can never mix two
+		configs into one resolution."""
 		store = {
 			"role_profiles_config": frappe.as_json(self._config(version="v1")),
 			"role_profiles_config_version": "v1",
@@ -624,10 +728,17 @@ class TestRoleProfileConfigAccessors(FrappeTestCase):
 			first = role_profiles._active_config()
 			self.assertEqual(first["version"], "v1")
 
+			# A same-request version bump WITHOUT invalidation must NOT be
+			# picked up - stability within one logical operation.
 			store["role_profiles_config"] = frappe.as_json(
 				self._config(version="v2", sets={"hr": ["erpnext-projects"]})
 			)
 			store["role_profiles_config_version"] = "v2"
+			still_first = role_profiles._active_config()
+			self.assertEqual(still_first["version"], "v1")
+
+			# Only an explicit invalidate makes the new version visible.
+			role_profiles._invalidate_config_cache()
 			second = role_profiles._active_config()
 
 		self.assertEqual(second["version"], "v2")

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -458,6 +458,181 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 	def test_validate_accepts_well_formed_config(self):
 		self.assertTrue(role_profiles._validate_role_profile_config(self._config()))
 
+	def test_version_change_repush_carries_new_config_skills_in_payload(self):
+		"""BJ1-review obligation 1: prove a version-changing
+		``sync_role_profile_config`` re-push actually carries profiles
+		COMPUTED FROM THE NEW CONFIG, not the code fixture or a value BJ2's
+		accessor memoized earlier. Mocks only the ``admin_client`` transport -
+		``sync_role_profiles`` and ``needed_profiles`` run for real against a
+		real ``Jarvis User`` fixture, so this closes the gap BJ1 could not
+		prove on its own.
+		"""
+		role_profiles._invalidate_config_cache()
+		self.addCleanup(role_profiles._invalidate_config_cache)
+
+		u_email = "rp-cfg-e2e@example.com"
+		if not frappe.db.exists("User", u_email):
+			u = frappe.get_doc({"doctype": "User", "email": u_email, "first_name": "rp-cfg-e2e"})
+			u.append_roles("Jarvis User", "HR User")
+			u.insert(ignore_permissions=True)
+
+		store, fake_get, fake_set, fake_set_single = self._fake_store()
+		new_config = self._config(version="v2", enabled=True)
+		new_config["sets"] = {"hr": ["custom-hr-only-skill"]}
+		resp = {"ok": True, "data": new_config}
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch("jarvis.admin_client.post_push_role_profiles", return_value={"ok": True}) as mock_push,
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": True})
+		mock_push.assert_called_once()
+		pushed = mock_push.call_args.kwargs["role_profiles"]
+		hr_profile = next(p for p in pushed if p["slug"] == "role-hr")
+		self.assertEqual(hr_profile["skills"], sorted({"custom-hr-only-skill", "frappe-core"}))
+
+
+class TestRoleProfileConfigAccessors(FrappeTestCase):
+	"""``jarvis.chat.role_profiles._active_config`` and the accessors it backs
+	(``get_skill_sets`` / ``get_role_to_set`` / ``get_shared_core`` /
+	``get_tools_allow``), plus the callers that switched to them,
+	``resolve_profile`` / ``needed_profiles`` (task BJ2).
+
+	``frappe.local``'s per-request memo is process-lifetime, not per-test, so
+	every test here invalidates it in setUp AND tearDown - belt and braces:
+	``_active_config`` re-reads the version fresh on every call regardless
+	(see its own docstring), but explicit invalidation keeps this class's
+	tests deterministic and keeps a fake ``v1``/``v2`` memo from a mocked
+	context leaking into an unmocked one.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		role_profiles._invalidate_config_cache()
+
+	def tearDown(self):
+		role_profiles._invalidate_config_cache()
+		super().tearDown()
+
+	def _mk_user(self, email, roles):
+		if not frappe.db.exists("User", email):
+			u = frappe.get_doc({"doctype": "User", "email": email, "first_name": email.split("@")[0]})
+			u.append_roles(*roles)
+			u.insert(ignore_permissions=True)
+		return email
+
+	@staticmethod
+	def _config(**overrides):
+		data = {
+			"version": "v1",
+			"enabled": True,
+			"sets": {"hr": ["hrms-hr", "hrms-payroll"]},
+			"shared_core": ["frappe-core"],
+			"mappings": {"HR User": "hr"},
+			"tool_tiers": {"standard": {"allow": ["exec", "read"], "core": ["exec"]}},
+		}
+		data.update(overrides)
+		return data
+
+	@staticmethod
+	def _patched(raw, version="v1"):
+		store = {"role_profiles_config": raw, "role_profiles_config_version": version}
+
+		def fake_get(doctype, fieldname, cache=True):
+			assert doctype == role_profiles._SETTINGS
+			return store.get(fieldname)
+
+		return patch.object(frappe.db, "get_single_value", side_effect=fake_get)
+
+	def test_config_moves_skill_between_sets_and_resolve_profile_honors_it(self):
+		u = self._mk_user("rp-cfg-move@example.com", ["Jarvis User", "HR User"])
+		cfg = self._config(sets={"hr": ["erpnext-projects"]})
+		with self._patched(frappe.as_json(cfg)):
+			c = role_profiles.resolve_profile(u)
+		self.assertEqual(c.agent_id, "role-hr")
+		self.assertIn("erpnext-projects", c.skills)  # moved in by config
+		self.assertNotIn("hrms-hr", c.skills)  # fixture skill absent under override
+
+	def test_corrupt_cache_falls_back_byte_identical_to_no_cache(self):
+		u = self._mk_user("rp-cfg-corrupt@example.com", ["Jarvis User", "HR User"])
+		with self._patched(None):
+			baseline = role_profiles.resolve_profile(u)
+		role_profiles._invalidate_config_cache()
+		with self._patched("{not valid json"):
+			corrupt = role_profiles.resolve_profile(u)
+		self.assertEqual(baseline, corrupt)
+		self.assertEqual(baseline.agent_id, "role-hr")
+
+	def test_unknown_role_in_config_mappings_just_maps(self):
+		# "Translator" is not in the code fixture's ROLE_TO_SET at all - the
+		# config is authority for mappings, so it maps anyway.
+		u = self._mk_user("rp-cfg-unknown-role@example.com", ["Jarvis User", "Translator"])
+		cfg = self._config(mappings={"Translator": "hr"})
+		with self._patched(frappe.as_json(cfg)):
+			c = role_profiles.resolve_profile(u)
+		self.assertEqual(c.agent_id, "role-hr")
+
+	def test_config_missing_key_is_rejected_whole_and_falls_back(self):
+		u = self._mk_user("rp-cfg-missing-key@example.com", ["Jarvis User", "HR User"])
+		cfg = self._config()
+		del cfg["tool_tiers"]
+		with self._patched(frappe.as_json(cfg)):
+			c = role_profiles.resolve_profile(u)
+		self.assertEqual(c.agent_id, "role-hr")
+		self.assertEqual(
+			c.skills,
+			tuple(sorted(role_profiles.SHARED_CORE_SKILLS.union(role_profiles.SKILL_SETS["hr"]))),
+		)
+
+	def test_dangling_mapping_set_key_is_rejected_whole_and_falls_back(self):
+		u = self._mk_user("rp-cfg-dangling@example.com", ["Jarvis User", "HR User"])
+		# "ghost-set" is charset-valid but absent from `sets` - referential
+		# integrity is BJ2's problem, not BJ1's charset check.
+		cfg = self._config(mappings={"HR User": "ghost-set"})
+		with self._patched(frappe.as_json(cfg)):
+			self.assertIsNone(role_profiles._active_config())
+			c = role_profiles.resolve_profile(u)
+		self.assertEqual(c.agent_id, "role-hr")  # fixture mapping, not the dangling config
+		self.assertIn("hrms-hr", c.skills)
+
+	def test_get_tools_allow_honors_config_and_falls_back(self):
+		cfg = self._config(tool_tiers={"standard": {"allow": ["exec"], "core": ["exec"]}})
+		with self._patched(frappe.as_json(cfg)):
+			self.assertEqual(role_profiles.get_tools_allow(), ["exec"])
+		role_profiles._invalidate_config_cache()
+		with self._patched(None):
+			self.assertEqual(role_profiles.get_tools_allow(), role_profiles.standard_tools_allow())
+
+	def test_memo_keyed_on_version_picks_up_change_without_explicit_invalidate(self):
+		"""Design point: the memo is keyed on ``role_profiles_config_version``,
+		not just present/absent - a same-request write that bumps the version
+		must be picked up even without a separate ``_invalidate_config_cache``
+		call."""
+		store = {
+			"role_profiles_config": frappe.as_json(self._config(version="v1")),
+			"role_profiles_config_version": "v1",
+		}
+
+		def fake_get(doctype, fieldname, cache=True):
+			return store.get(fieldname)
+
+		with patch.object(frappe.db, "get_single_value", side_effect=fake_get):
+			first = role_profiles._active_config()
+			self.assertEqual(first["version"], "v1")
+
+			store["role_profiles_config"] = frappe.as_json(
+				self._config(version="v2", sets={"hr": ["erpnext-projects"]})
+			)
+			store["role_profiles_config_version"] = "v2"
+			second = role_profiles._active_config()
+
+		self.assertEqual(second["version"], "v2")
+		self.assertEqual(second["sets"]["hr"], ["erpnext-projects"])
+
 
 class FakeSess:
 	"""Stub pooled ``AgentSession``: counts ``create_session`` calls so tests

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -336,7 +336,11 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 
 	def test_success_caches_mirrors_and_pushes_on_version_change(self):
 		store, fake_get, fake_set, fake_set_single = self._fake_store()
-		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		# admin_client.get_role_profile_config() returns the bare data dict:
+		# _post already unwraps the {"ok", "data"} envelope (jarvis#907
+		# live-verification fix) - mocking the STILL-WRAPPED shape here would
+		# silently mask that bug, exactly as it did before this fix.
+		resp = self._config(version="v1", enabled=True)
 		calls = []
 
 		def fake_sync(**kw):
@@ -377,7 +381,11 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 		store, fake_get, fake_set, fake_set_single = self._fake_store(
 			initial={"role_profiles_config_version": "v0"}
 		)
-		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		# admin_client.get_role_profile_config() returns the bare data dict:
+		# _post already unwraps the {"ok", "data"} envelope (jarvis#907
+		# live-verification fix) - mocking the STILL-WRAPPED shape here would
+		# silently mask that bug, exactly as it did before this fix.
+		resp = self._config(version="v1", enabled=True)
 		with (
 			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
 			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
@@ -399,7 +407,11 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 		store, fake_get, fake_set, fake_set_single = self._fake_store(
 			initial={"role_profiles_config_version": "v0"}
 		)
-		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		# admin_client.get_role_profile_config() returns the bare data dict:
+		# _post already unwraps the {"ok", "data"} envelope (jarvis#907
+		# live-verification fix) - mocking the STILL-WRAPPED shape here would
+		# silently mask that bug, exactly as it did before this fix.
+		resp = self._config(version="v1", enabled=True)
 		with (
 			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
 			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
@@ -413,11 +425,40 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 		self.assertEqual(result, {"synced": True})
 		self.assertEqual(store["role_profiles_config_version"], "v1")
 
+	def test_still_enveloped_response_also_works(self):
+		"""jarvis#907 live-verification fix: ``_post`` already unwraps the
+		``{"ok": True, "data": {...}}`` envelope, so ``get_role_profile_config()``
+		returns the bare data dict in real life - every other test in this
+		class mocks that real (bare) shape. This test is the deliberate
+		exception: it proves ``sync_role_profile_config`` ALSO still accepts a
+		legacy enveloped response (``response.get("data", response)`` unwraps
+		it), so a future transport change back to a wrapping shape would not
+		silently break the sync."""
+		store, fake_get, fake_set, fake_set_single = self._fake_store()
+		enveloped = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		with (
+			patch("jarvis.admin_client.get_role_profile_config", return_value=enveloped),
+			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
+			patch.object(frappe.db, "set_value", side_effect=fake_set),
+			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),
+			patch.object(role_profiles, "_invalidate_config_cache"),
+			patch.object(role_profiles, "sync_role_profiles", return_value={"pushed": True, "profiles": []}),
+		):
+			result = role_profiles.sync_role_profile_config()
+
+		self.assertEqual(result, {"synced": True})
+		self.assertEqual(store["role_profiles_config_version"], "v1")
+		self.assertEqual(frappe.parse_json(store["role_profiles_config"])["version"], "v1")
+
 	def test_unchanged_version_does_not_repush(self):
 		store, fake_get, fake_set, fake_set_single = self._fake_store(
 			initial={"role_profiles_config_version": "v1"}
 		)
-		resp = {"ok": True, "data": self._config(version="v1", enabled=True)}
+		# admin_client.get_role_profile_config() returns the bare data dict:
+		# _post already unwraps the {"ok", "data"} envelope (jarvis#907
+		# live-verification fix) - mocking the STILL-WRAPPED shape here would
+		# silently mask that bug, exactly as it did before this fix.
+		resp = self._config(version="v1", enabled=True)
 		with (
 			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
 			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
@@ -521,7 +562,7 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 
 	def test_invalid_payload_is_failure_path_and_leaves_cache_untouched(self):
 		store, fake_get, fake_set, fake_set_single = self._fake_store()
-		bad = {"ok": True, "data": {"version": "v1"}}  # missing enabled/sets/mappings/tool_tiers
+		bad = {"version": "v1"}  # missing enabled/sets/mappings/tool_tiers; bare shape (no envelope)
 		with (
 			patch("jarvis.admin_client.get_role_profile_config", return_value=bad),
 			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
@@ -576,9 +617,10 @@ class TestRoleProfileConfigSync(FrappeTestCase):
 		store, fake_get, fake_set, fake_set_single = self._fake_store()
 		new_config = self._config(version="v2", enabled=True)
 		new_config["sets"] = {"hr": ["custom-hr-only-skill"]}
-		resp = {"ok": True, "data": new_config}
+		# Bare dict, matching what admin_client.get_role_profile_config()
+		# actually returns (_post already unwrapped the envelope).
 		with (
-			patch("jarvis.admin_client.get_role_profile_config", return_value=resp),
+			patch("jarvis.admin_client.get_role_profile_config", return_value=new_config),
 			patch.object(frappe.db, "get_single_value", side_effect=fake_get),
 			patch.object(frappe.db, "set_value", side_effect=fake_set),
 			patch.object(frappe.db, "set_single_value", side_effect=fake_set_single),


### PR DESCRIPTION
## Summary

The bench now pulls role-profile config (skill sets, role mappings, tool tier, and the on/off decision) from the admin plane, caches it on Jarvis Settings, and computes profiles from that config with the built-in fixture as a permanent fallback. The `enable_role_profiles` checkbox is demoted to a hidden read-only mirror that only the sync writes: rollout control is admin-side only, never tenant-side.

## What changed
- New `sync_role_profile_config()` (daily + manual): pulls from admin, validates defensively, caches JSON + version, mirrors the enabled flag, and re-pushes profiles when the config version changes (cache invalidated first).
- Last-known-good: a transient admin failure keeps the existing cache and mirror; only a never-synced bench stays off.
- Accessor layer with a version-keyed per-request memo routes all fixture reads (skill sets, mappings, shared core, tool allow list) through the cached config; any invalid, partial, or dangling config rejects wholesale to the code fixture. Reserved-role and slug-shape rules stay code-side.
- 18 new tests, including an end-to-end proof that a config change re-pushes profiles computed from the new config (only the admin transport mocked).

## Risk and verification
- No admin config received means everything behaves exactly as today (fixture + mirror off).
- Companion admin PR (master DocTypes + editor + endpoint) lands separately; this PR is safe alone (endpoint missing = logged failure, no behavior change).

<details><summary>Design</summary>

Spec: `docs/superpowers/specs/2026-08-17-usage-observability-dashboard-design.md` Part B (owner-approved, incl. B4 admin-only flag ownership). Wire contract: `{version, enabled, sets, shared_core, mappings, tool_tiers}`; version excludes `enabled` so flag flips propagate on every sync without a version bump.

</details>

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (from develop today)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
