### PR TITLE
fix(agents): actionable error when running an un-applied agent

### DIFF
--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -872,20 +872,36 @@ def _launch_audit(
 		)
 		frappe.db.commit()
 		raise
-	except Exception:
+	except Exception as e:
 		# The dispatch call itself failed, and CONFIRMEDLY: nothing was sent (a clean
 		# refusal / connect timeout), a 4xx rejection, or an auth denial. Mark THIS
 		# Run failed (mirror _record_failed's writeback onto the already-created
 		# "running" row so it is never orphaned), then re-raise so the caller's
 		# retry/notify path runs (scheduler: no next_run_at advance -> retry next
 		# hour; run_agent_now: surfaces the error to the UI).
+		#
+		# One confirmed failure has a self-service fix, so translate it rather than
+		# leaving a raw fleet 502: the fleet-agent's "agent_id '<x>' is not an
+		# installed delegate on <container>" means the agent is ENABLED on the bench
+		# but its skill was never pushed to the container. Enabling only flags the
+		# catalog dirty; the skill reaches the container on APPLY. So the operator
+		# skipped (or has a pending) "Apply catalog changes" -- tell them that
+		# instead of a stack trace.
+		not_applied = "not an installed delegate" in str(e)
+		if not_applied:
+			error_msg = _(
+				"This agent is not loaded on your container yet. Open the Agents page, "
+				"click “Apply catalog changes” to push it, then run it again."
+			)
+		else:
+			error_msg = "agent-run dispatch failed; see Error Log"
 		frappe.db.set_value(
 			RUN,
 			run.name,
 			{
 				"status": "failed",
 				"finished_at": frappe.utils.now(),
-				"error": "agent-run dispatch failed; see Error Log",
+				"error": error_msg,
 			},
 			update_modified=False,
 		)
@@ -898,6 +914,12 @@ def _launch_audit(
 			title=f"jarvis agent-run dispatch failed: {run.name}",
 			message=frappe.get_traceback(),
 		)
+		if not_applied:
+			# Surface the actionable message straight to the SPA (a clean user error),
+			# not the raw AdminUnreachableError 502/500 the fleet verb produced. The
+			# failed Run + session teardown above are already committed, so this only
+			# swaps which exception the caller re-raises.
+			frappe.throw(error_msg, title=_("Agent not applied"))
 		raise
 	return {"run": run.name, "conversation": conv.name, "session_key": session_key}
 

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -213,6 +213,49 @@ class TestAgentsMarketplace(unittest.TestCase):
 		self.assertEqual(conv_owner, self.owner)
 		self.assertNotEqual(conv_owner, "Administrator")
 
+	def test_run_now_on_unapplied_agent_gives_apply_hint(self):
+		# An agent ENABLED on the bench but not yet pushed to the container produces
+		# the fleet-agent's "not an installed delegate on <container>" 502 (enabling
+		# only flags the catalog dirty; the skill reaches the container on APPLY).
+		# run_agent_now must translate that into an actionable "Apply catalog changes"
+		# message — never a raw 500 — and leave the Run FAILED, not stuck "running".
+		inst_name = _install_as(self.owner, "close-auditor")
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1)
+		agent = frappe.db.get_value(INSTALLATION, inst_name, "agent")
+		frappe.db.commit()
+
+		import jarvis.admin_client as admin_client
+		from jarvis.exceptions import AdminUnreachableError
+
+		orig_run = admin_client.post_agent_run
+
+		def _not_installed(**kw):
+			raise AdminUnreachableError(
+				"admin returned a 502 error: invalid_spec: agent_id "
+				f"'{kw.get('agent_id')}' is not an installed delegate on jarvis-pool-test"
+			)
+
+		admin_client.post_agent_run = _not_installed
+		try:
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agents_api.run_agent_now(inst_name)
+		finally:
+			admin_client.post_agent_run = orig_run
+
+		self.assertIn("Apply catalog changes", str(ctx.exception))
+		# The run must be terminal FAILED (never left stuck "running") and carry the
+		# same actionable message, not a raw fleet 502.
+		run = frappe.get_all(
+			RUN,
+			filters={"agent": agent, "owner": self.owner},
+			fields=["status", "error"],
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertTrue(run)
+		self.assertEqual(run[0].status, "failed")
+		self.assertIn("Apply catalog changes", run[0].error or "")
+
 	# ------------------------------------------------------------------ #
 	# (a2) Phase 2C — delegate dispatch routes through admin, not chat
 	# ------------------------------------------------------------------ #


### PR DESCRIPTION
## Problem (reported in production)
Running a marketplace agent that was **enabled but not Applied** returns a raw
500 to the SPA:

```
AdminUnreachableError: admin returned a 502 error: invalid_spec: agent_id
'agent-custom-app-learning' is not an installed delegate on jarvis-pool-3fa4d2
```

Enabling an agent only flags the catalog dirty; the skill reaches the container
only on **Apply catalog changes** (reviewer/admin-gated, one container restart).
So the operator skipped (or has a pending) Apply — but the error reads like a
crash, giving no hint about what to do.

## Fix
`_launch_audit` now detects the fleet-agent's `"not an installed delegate"`
failure and translates it into an actionable, user-facing message:

> This agent is not loaded on your container yet. Open the Agents page, click
> "Apply catalog changes" to push it, then run it again.

The message is stamped on the failed Run and re-raised as a clean `frappe`
error instead of the raw `AdminUnreachableError`. The Run is still marked
terminal **failed** (never left stuck "running") — only the surfaced exception
changes; all other dispatch-failure handling (session teardown, error log,
commit-before-raise) is untouched.

## Test
`test_run_now_on_unapplied_agent_gives_apply_hint`: an enabled-but-unapplied
`run_agent_now` raises the apply hint (a `frappe.ValidationError`) and leaves the
Run `failed` carrying that message. Full `test_agents_marketplace` module: 37/37
green. ruff clean.

## Note (not changed here)
This improves the *message*; the operator still performs the Apply. Two adjacent
follow-ups worth tracking: (a) the "Apply catalog changes" button is only visible
to Jarvis Skill Reviewer / Jarvis Admin / System Manager and only on the Agents
*list* page — an owner who can enable but not apply gets stuck; (b) a container
that lost its roster after a restart/move (`agent_roster_applied_version` in
sync but the container renders `[]`) would still hit the raw fleet error and is
not self-healed on the run path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn6fmNAihoNB8swPsM3BcZ
