### PR TITLE
onboarding: add 5-10 minute expectation note to AI-connect wait screen

### DIFF
--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1306,7 +1306,15 @@ describe("connect wait time-expectation note", () => {
 	it("shows the 5-to-10-minute note on the initial working screen", async () => {
 		const w = await mountConnect();
 
-		expect(w.vm.state.connectPhase).toBeFalsy();
+		// state.finishing gates the working/finishing screen with v-show, which
+		// only toggles CSS display - a bare mountConnect() never sets it, so
+		// asserting against the DOM before this would pass even if the note
+		// were rendered behind a hidden picker screen.
+		w.vm.onOpUpdate({ phase: "applying" });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("working");
+		expect(w.vm.state.finishing).toBe(true);
 		expect(w.find(".ob-head-note").text()).toContain("5 to 10 minutes");
 		w.unmount();
 	});

--- a/frontend/src/views/OnboardingView.connect.spec.js
+++ b/frontend/src/views/OnboardingView.connect.spec.js
@@ -1302,6 +1302,42 @@ describe("jarvis#727 the setup headline follows the live phase", () => {
 	});
 });
 
+describe("connect wait time-expectation note", () => {
+	it("shows the 5-to-10-minute note on the initial working screen", async () => {
+		const w = await mountConnect();
+
+		expect(w.vm.state.connectPhase).toBeFalsy();
+		expect(w.find(".ob-head-note").text()).toContain("5 to 10 minutes");
+		w.unmount();
+	});
+
+	it("keeps showing the note once the operation reaches finishing", async () => {
+		const w = await mountConnect();
+
+		w.vm.onOpUpdate({ phase: "finishing" });
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("finishing");
+		expect(w.find(".ob-head-note").text()).toContain("5 to 10 minutes");
+		w.unmount();
+	});
+
+	it("does not show the note once the wait resolves to a blocked stop", async () => {
+		const w = await mountConnect();
+
+		w.vm.noteReadiness({
+			answered: true,
+			reason: "authority_repair_required",
+			detail: "a person has to look",
+		});
+		await flushPromises();
+
+		expect(w.vm.state.connectPhase).toBe("blocked");
+		expect(w.find(".ob-head-note").exists()).toBe(false);
+		w.unmount();
+	});
+});
+
 describe("staged readiness phases: the screen renders what the poll observed", () => {
 	// Every one of these 40 polls used to be discarded except the last detail, so
 	// the wait showed one fixed sentence for two minutes.

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1501,6 +1501,16 @@
 													"We'll take you to chat as soon as your setup is done."
 												}}
 											</p>
+											<!-- Expectation-setting note: this whole template branch IS
+												 the working/finishing wait, so the note is on screen for
+												 all of it, not just the first frame. Its own line, smaller
+												 and greyer than the subtitle above (.ob-head p.ob-head-note
+												 out-specifies the shared .ob-head p rule), so it reads as a
+												 secondary aside, not a second headline. -->
+											<p class="ob-head-note">
+												This usually takes 5 to 10 minutes: we're setting
+												up a private, isolated workspace dedicated to you.
+											</p>
 										</div>
 										<!-- One smooth progress bar for the whole connect wait
 											 (2026-08-16 redesign). The jarvis#726 "Step N of 3" bar
@@ -5151,6 +5161,16 @@ onUnmounted(() => {
 	line-height: 1.5;
 	color: var(--text-2);
 	margin: 0;
+}
+/* The connect wait's expectation-setting note (jarvis onboarding time note):
+   needs the extra class on the specificity to beat .ob-head p above on rule
+   weight, not source order, since it sits right after the subtitle in the
+   same .ob-head block and both are <p> tags. Smaller and greyer than the
+   subtitle by design - a secondary line, not a second headline. */
+.ob-head p.ob-head-note {
+	margin-top: 6px;
+	font-size: 12.5px;
+	color: var(--text-3);
 }
 .ob-foot {
 	display: flex;


### PR DESCRIPTION
## Summary

Customers now see a 5 to 10 minute expectation note during AI setup, so the working screen no longer looks stuck on a long wait with no time signal.

The AI-connect step's working/finishing screen (`OnboardingView.vue`) gets one short, always-visible line under the subtitle: "This usually takes 5 to 10 minutes: we're setting up a private, isolated workspace dedicated to you." It sits inside the existing `ob-head` block, styled smaller and greyer than the subtitle, and stays on screen for the whole wait (working and finishing), not just the first frame. It does not show on the blocked, reconnect, or rejected branches.

Added `OnboardingView.connect.spec.js` coverage for the note appearing on working and finishing, and staying off the blocked stop.

## Pre-merge checklist

- [x] CI is green, the `tests` check on this PR passes (never merge on failure)
- [x] Branch is up to date with `develop` (branched from current upstream/develop)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
