### PR TITLE
fix(list): portal-free Sort + Filter dropdowns (open inside the toolbar popover)

### DIFF
--- a/frontend/src/components/list/FilterButton.vue
+++ b/frontend/src/components/list/FilterButton.vue
@@ -41,12 +41,12 @@
 							</div>
 							<div class="text-base text-ink-gray-5">is</div>
 							<div class="flex-1">
-								<FormControl
+								<PanelSelect
 									v-if="def.type === 'select'"
-									type="select"
 									class="!min-w-[140px]"
+									:aria-label="`Value for ${def.label}`"
 									:options="def.options"
-									:modelValue="filters[def.key] == null ? '' : filters[def.key]"
+									:model-value="filters[def.key] == null ? '' : filters[def.key]"
 									@update:modelValue="(v) => setValue(def, v)"
 								/>
 								<div
@@ -71,13 +71,12 @@
 						</div>
 					</div>
 					<div class="flex items-center justify-between gap-2">
-						<FormControl
+						<PanelSelect
 							v-if="unsetDefs.length"
-							type="select"
 							variant="ghost"
-							class="!text-ink-gray-5"
+							aria-label="Add a filter"
 							:options="addOptions"
-							:modelValue="''"
+							model-value=""
 							@update:modelValue="addFilter"
 						/>
 						<div v-else />
@@ -108,7 +107,8 @@
 // (daterange contributes from_date/to_date keys). Count-chip split trigger,
 // CRM popover anatomy ("Where/And <field> is <control>").
 import { ref, computed } from "vue";
-import { Popover, Button, FormControl, DatePicker } from "frappe-ui";
+import { Popover, Button, DatePicker } from "frappe-ui";
+import PanelSelect from "@/components/list/PanelSelect.vue";
 
 const props = defineProps({
 	filterDefs: { type: Array, default: () => [] }, // [{key,label,type:'select'|'daterange',options}]

--- a/frontend/src/components/list/FilterGroup.vue
+++ b/frontend/src/components/list/FilterGroup.vue
@@ -113,13 +113,14 @@
 												@update:modelValue="(o) => pickField(i, o)"
 											/>
 										</div>
-										<!-- operator -->
+										<!-- operator: PanelSelect (portal-free, globally themed) - a FormControl
+										     select will not open inside this teleported Popover (its reka SelectPortal);
+										     the component keeps its listbox inline. -->
 										<div class="w-32 shrink-0">
-											<FormControl
-												type="select"
+											<PanelSelect
 												:aria-label="`Condition for ${rowName(i)}`"
 												:options="operatorOptions(clause)"
-												:modelValue="clause.operator"
+												:model-value="clause.operator"
 												@update:modelValue="(v) => pickOperator(i, v)"
 											/>
 										</div>
@@ -226,13 +227,13 @@ import { computed, ref, watch, nextTick } from "vue";
 import {
 	Popover,
 	Button,
-	FormControl,
 	Autocomplete,
 	ErrorMessage,
 	LoadingIndicator,
 	FeatherIcon,
 } from "frappe-ui";
 import FilterValueControl from "@/components/list/FilterValueControl.vue";
+import PanelSelect from "@/components/list/PanelSelect.vue";
 import {
 	schemaIndex,
 	fieldOptions,

--- a/frontend/src/components/list/FilterValueControl.vue
+++ b/frontend/src/components/list/FilterValueControl.vue
@@ -1,8 +1,7 @@
 <template>
 	<!-- Check → Yes/No mapped to 1/0 (plan §5.1) -->
-	<FormControl
+	<PanelSelect
 		v-if="rendered === 'check'"
-		type="select"
 		:aria-label="ariaLabel"
 		:options="YES_NO"
 		:modelValue="scalar"
@@ -12,9 +11,8 @@
 	<!-- Select → metadata options. A LEADING BLANK is a real option meaning
 	     'not set', so it is labelled rather than dropped, and the "no filter"
 	     choice is removing the row - not picking an empty line. -->
-	<FormControl
+	<PanelSelect
 		v-else-if="rendered === 'select'"
-		type="select"
 		:aria-label="ariaLabel"
 		:options="selectChoices"
 		:modelValue="scalar"
@@ -22,18 +20,16 @@
 	/>
 
 	<!-- is set / is not set -->
-	<FormControl
+	<PanelSelect
 		v-else-if="rendered === 'is'"
-		type="select"
 		:aria-label="ariaLabel"
 		:options="IS_OPTIONS"
 		:modelValue="scalar || 'set'"
 		@update:modelValue="(v) => emitValue(v)"
 	/>
 
-	<FormControl
+	<PanelSelect
 		v-else-if="rendered === 'timespan'"
-		type="select"
 		:aria-label="ariaLabel"
 		:options="timespanChoices"
 		:modelValue="scalar"
@@ -219,6 +215,7 @@
 // {display} title we should keep showing).
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { FormControl, Autocomplete, DatePicker, Badge, FeatherIcon } from "frappe-ui";
+import PanelSelect from "@/components/list/PanelSelect.vue";
 import {
 	controlFor,
 	selectControlOptions,

--- a/frontend/src/components/list/PanelSelect.spec.js
+++ b/frontend/src/components/list/PanelSelect.spec.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+
+// frappe-ui's ESM entry doesn't resolve under vitest; OperatorSelect only pulls
+// FeatherIcon from it.
+vi.mock("frappe-ui", () => ({
+	FeatherIcon: { name: "FeatherIcon", props: ["name"], template: `<span :data-icon="name" />` },
+}));
+
+import PanelSelect from "./PanelSelect.vue";
+
+const OPTIONS = [
+	{ label: "equals", value: "=" },
+	{ label: "not equals", value: "!=" },
+	{ label: "greater than or equals", value: ">=" },
+];
+
+function mountSel(modelValue = "=", extra = {}) {
+	return mount(PanelSelect, {
+		attachTo: document.body,
+		props: { options: OPTIONS, modelValue, ariaLabel: "Condition for Enabled", ...extra },
+	});
+}
+
+describe("PanelSelect (portal-free select)", () => {
+	it("shows the current operator's label on the trigger", () => {
+		const w = mountSel("!=");
+		expect(w.find("button").text()).toContain("not equals");
+		w.unmount();
+	});
+
+	it("is a labelled listbox button, collapsed by default", () => {
+		const w = mountSel();
+		const btn = w.find("button");
+		expect(btn.attributes("aria-label")).toBe("Condition for Enabled");
+		expect(btn.attributes("aria-haspopup")).toBe("listbox");
+		expect(btn.attributes("aria-expanded")).toBe("false");
+		expect(w.find('[role="listbox"]').exists()).toBe(false);
+		w.unmount();
+	});
+
+	it("opens IN-DOM on click with EVERY option reachable (not a reka portal)", async () => {
+		const w = mountSel();
+		await w.find("button").trigger("click");
+		expect(w.find("button").attributes("aria-expanded")).toBe("true");
+		// the listbox is a real child in the component tree, not teleported to <body>
+		expect(w.find('[role="listbox"]').exists()).toBe(true);
+		const opts = w.findAll('[role="option"]');
+		expect(opts).toHaveLength(OPTIONS.length);
+		expect(opts.map((o) => o.text().trim())).toEqual([
+			"equals",
+			"not equals",
+			"greater than or equals",
+		]);
+		w.unmount();
+	});
+
+	it("marks the current option aria-selected", async () => {
+		const w = mountSel(">=");
+		await w.find("button").trigger("click");
+		const sel = w
+			.findAll('[role="option"]')
+			.filter((o) => o.attributes("aria-selected") === "true");
+		expect(sel).toHaveLength(1);
+		expect(sel[0].text()).toContain("greater than or equals");
+		w.unmount();
+	});
+
+	it("applies a clicked option (emits update:modelValue) and closes", async () => {
+		const w = mountSel("=");
+		await w.find("button").trigger("click");
+		const notEq = w.findAll('[role="option"]').find((o) => o.text().includes("not equals"));
+		await notEq.trigger("mousedown");
+		expect(w.emitted("update:modelValue").at(-1)).toEqual(["!="]);
+		expect(w.find('[role="listbox"]').exists()).toBe(false);
+		w.unmount();
+	});
+
+	// The keyboard reach past the first option is exactly what the native <select>
+	// had and JvCombo's plain picker lost.
+	it("is keyboard operable to ANY option (arrow-move + enter)", async () => {
+		const w = mountSel("=");
+		const btn = w.find("button");
+		await btn.trigger("keydown", { key: "ArrowDown" }); // open, highlight 0
+		await btn.trigger("keydown", { key: "ArrowDown" }); // -> 1
+		await btn.trigger("keydown", { key: "ArrowDown" }); // -> 2
+		await btn.trigger("keydown", { key: "Enter" }); // pick highlighted (>=)
+		expect(w.emitted("update:modelValue").at(-1)).toEqual([">="]);
+		w.unmount();
+	});
+
+	it("Escape closes without emitting", async () => {
+		const w = mountSel();
+		await w.find("button").trigger("click");
+		await w.find("button").trigger("keydown", { key: "Escape" });
+		expect(w.find('[role="listbox"]').exists()).toBe(false);
+		expect(w.emitted("update:modelValue")).toBeFalsy();
+		w.unmount();
+	});
+
+	it("an outside click closes the menu on its own (never leans on the parent Popover)", async () => {
+		const w = mountSel();
+		await w.find("button").trigger("click");
+		expect(w.find('[role="listbox"]').exists()).toBe(true);
+		document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+		await nextTick();
+		expect(w.find('[role="listbox"]').exists()).toBe(false);
+		w.unmount();
+	});
+});

--- a/frontend/src/components/list/PanelSelect.vue
+++ b/frontend/src/components/list/PanelSelect.vue
@@ -1,0 +1,119 @@
+<template>
+	<div class="relative" ref="root">
+		<button
+			type="button"
+			:class="[
+				'flex h-7 w-full items-center justify-between gap-1 rounded px-2 text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3',
+				variant === 'ghost'
+					? 'text-ink-gray-5 hover:bg-surface-gray-2'
+					: 'bg-surface-gray-2 text-ink-gray-8 hover:bg-surface-gray-3',
+			]"
+			:aria-label="ariaLabel"
+			:aria-expanded="open"
+			aria-haspopup="listbox"
+			@click="toggle"
+			@keydown.down.prevent="open ? move(1) : openMenu(0)"
+			@keydown.up.prevent="open ? move(-1) : openMenu(options.length - 1)"
+			@keydown.enter.prevent="open ? choose(hi) : openMenu(currentIndex)"
+			@keydown.esc="close"
+		>
+			<span class="truncate">{{ currentLabel }}</span>
+			<FeatherIcon name="chevron-down" class="size-4 shrink-0 text-ink-gray-5" />
+		</button>
+		<!-- Inline listbox (NO reka SelectPortal): it lives in the panel's own DOM so a
+		     click on it is not read as an outside-click, and it opens - the FormControl
+		     select it replaces would not open at all inside the teleported Popover. -->
+		<ul
+			v-if="open"
+			role="listbox"
+			:aria-label="ariaLabel"
+			class="absolute left-0 z-30 mt-1 max-h-60 min-w-full overflow-auto whitespace-nowrap rounded-lg bg-surface-modal p-1 shadow-2xl ring-1 ring-black ring-opacity-5"
+		>
+			<li
+				v-for="(o, idx) in options"
+				:key="o.value"
+				role="option"
+				:aria-selected="o.value === modelValue"
+				class="flex cursor-pointer items-center justify-between gap-3 rounded px-2 py-1.5 text-base text-ink-gray-8"
+				:class="idx === hi ? 'bg-surface-gray-2' : ''"
+				@mousedown.prevent="choose(idx)"
+				@mousemove="hi = idx"
+			>
+				<span>{{ o.label }}</span>
+				<FeatherIcon
+					v-if="o.value === modelValue"
+					name="check"
+					class="size-4 shrink-0 text-ink-gray-7"
+				/>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<script setup>
+// PanelSelect - a portal-free, globally-themed {label,value} select for the filter
+// panel (the operator picker AND the value selects). frappe-ui's FormControl select renders options through a reka SelectPortal
+// that will NOT open inside FilterGroup's teleported Popover (the same portal trap
+// SortButton dodged). This keeps the listbox inline in the panel's own DOM and styles
+// it from GLOBAL surface/ink tokens that resolve inside a teleport - JvCombo's
+// paletteVars-based styling renders transparent there. Contract mirrors the old
+// FormControl: options [{label,value}], modelValue, emit update:modelValue.
+import { ref, computed, watch, onBeforeUnmount } from "vue";
+import { FeatherIcon } from "frappe-ui";
+
+const props = defineProps({
+	modelValue: { type: String, default: "" },
+	options: { type: Array, default: () => [] },
+	ariaLabel: { type: String, default: undefined },
+	// "filled" (default, a select box) or "ghost" (a subtle text trigger, e.g. "+ Add Filter")
+	variant: { type: String, default: "filled" },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const root = ref(null);
+const open = ref(false);
+const hi = ref(-1); // highlighted index while the menu is open
+
+const currentIndex = computed(() => props.options.findIndex((o) => o.value === props.modelValue));
+const currentLabel = computed(() => {
+	const o = props.options[currentIndex.value];
+	return (o && o.label) || props.modelValue || "";
+});
+
+function openMenu(start) {
+	open.value = true;
+	hi.value = start >= 0 && start < props.options.length ? start : 0;
+	document.addEventListener("mousedown", onDocMouseDown, true);
+}
+function close() {
+	if (!open.value) return;
+	open.value = false;
+	hi.value = -1;
+	document.removeEventListener("mousedown", onDocMouseDown, true);
+}
+function toggle() {
+	open.value ? close() : openMenu(currentIndex.value);
+}
+function move(d) {
+	const n = props.options.length;
+	if (n) hi.value = (hi.value + d + n) % n;
+}
+function choose(idx) {
+	const o = props.options[idx];
+	if (o) emit("update:modelValue", o.value);
+	close();
+}
+// A click anywhere outside closes the menu WITHOUT dismissing the parent Popover,
+// because this listener only closes our own listbox.
+function onDocMouseDown(e) {
+	if (root.value && !root.value.contains(e.target)) close();
+}
+// The row can be retargeted to another field mid-open; keep the highlight in range.
+watch(
+	() => props.options,
+	() => {
+		if (open.value) hi.value = Math.min(Math.max(hi.value, 0), props.options.length - 1);
+	}
+);
+onBeforeUnmount(() => document.removeEventListener("mousedown", onDocMouseDown, true));
+</script>

--- a/frontend/src/components/list/SortButton.spec.js
+++ b/frontend/src/components/list/SortButton.spec.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// frappe-ui's ESM entry doesn't resolve under vitest; stub the three components
+// SortButton uses. The Popover stub renders BOTH slots so the picker body (which
+// used to be trapped behind a portal-select) is queryable in jsdom.
+vi.mock("frappe-ui", () => ({
+	Popover: {
+		name: "Popover",
+		template: `<div>
+			<slot name="target" :togglePopover="() => {}" />
+			<slot name="body" :close="() => {}" />
+		</div>`,
+	},
+	Button: {
+		name: "Button",
+		props: ["label", "icon", "tooltip", "variant"],
+		emits: ["click"],
+		template: `<button :data-icon="icon" @click="$emit('click')">{{ label }}</button>`,
+	},
+	FeatherIcon: {
+		name: "FeatherIcon",
+		props: ["name"],
+		template: `<span class="feather" :data-name="name" />`,
+	},
+}));
+
+import SortButton from "./SortButton.vue";
+
+const OPTIONS = [
+	{ label: "Name", value: "skill_name" },
+	{ label: "Updated", value: "modified" },
+	{ label: "Created", value: "creation" },
+];
+const DEFAULT = { field: "skill_name", dir: "asc" };
+
+function mountBtn(sort = { field: "", dir: "" }) {
+	return mount(SortButton, {
+		props: { sortOptions: OPTIONS, sort, defaultSort: DEFAULT },
+	});
+}
+
+describe("SortButton field picker (portal-free menu)", () => {
+	it("renders EVERY sort option as an in-DOM menuitemradio button (not a portal Select)", () => {
+		const w = mountBtn();
+		const items = w.findAll('[role="menuitemradio"]');
+		expect(items).toHaveLength(OPTIONS.length);
+		expect(items.map((i) => i.text())).toEqual(["Name", "Updated", "Created"]);
+	});
+
+	it("marks the current field aria-checked (the page default when no sort is active)", () => {
+		const checked = mountBtn()
+			.findAll('[role="menuitemradio"]')
+			.filter((i) => i.attributes("aria-checked") === "true");
+		expect(checked).toHaveLength(1);
+		expect(checked[0].text()).toBe("Name");
+		// and it tracks the active sort when one is set
+		const w2 = mountBtn({ field: "creation", dir: "desc" });
+		const checked2 = w2
+			.findAll('[role="menuitemradio"]')
+			.filter((i) => i.attributes("aria-checked") === "true");
+		expect(checked2[0].text()).toBe("Created");
+	});
+
+	it("clicking a field emits update:sort for THAT field (reachable now, was dismissed before)", async () => {
+		const w = mountBtn();
+		const updated = w.findAll('[role="menuitemradio"]').find((i) => i.text() === "Updated");
+		await updated.trigger("click");
+		const emits = w.emitted("update:sort");
+		expect(emits).toBeTruthy();
+		expect(emits.at(-1)[0]).toMatchObject({ field: "modified" });
+	});
+
+	it("the datetime columns (Updated/Created) are both pickable", async () => {
+		const w = mountBtn();
+		const created = w.findAll('[role="menuitemradio"]').find((i) => i.text() === "Created");
+		await created.trigger("click");
+		expect(w.emitted("update:sort").at(-1)[0]).toMatchObject({ field: "creation" });
+	});
+
+	// The always-visible direction toggle + Clear Sort are pre-existing, but the picker
+	// refactor sits beside them; pin them so the whole control stays covered.
+	it("the direction toggle flips dir and keeps the current field", async () => {
+		const w = mountBtn(); // default dir resolves to asc → toggle shows arrow-up
+		await w.find('[data-icon="arrow-up"]').trigger("click");
+		expect(w.emitted("update:sort").at(-1)[0]).toMatchObject({
+			field: "skill_name",
+			dir: "desc",
+		});
+	});
+
+	it("Clear Sort resets to the page default", async () => {
+		const w = mountBtn({ field: "creation", dir: "desc" });
+		const clear = w.findAll("button").find((b) => b.text() === "Clear Sort");
+		await clear.trigger("click");
+		expect(w.emitted("update:sort").at(-1)[0]).toEqual({ field: "skill_name", dir: "asc" });
+	});
+});

--- a/frontend/src/components/list/SortButton.spec.js
+++ b/frontend/src/components/list/SortButton.spec.js
@@ -95,4 +95,31 @@ describe("SortButton field picker (portal-free menu)", () => {
 		await clear.trigger("click");
 		expect(w.emitted("update:sort").at(-1)[0]).toEqual({ field: "skill_name", dir: "asc" });
 	});
+
+	// The button label bug: at the page default it reads "Sort" (a CTA), but toggling the
+	// direction and returning to the default snapped it back to "Sort" as if sort were cleared.
+	function mountAtDefault() {
+		return mount(SortButton, {
+			props: { sortOptions: OPTIONS, sort: { ...DEFAULT }, defaultSort: DEFAULT },
+		});
+	}
+
+	it("shows the 'Sort' CTA on a pristine list sitting at its default sort", () => {
+		expect(
+			mountAtDefault()
+				.findAll("button")
+				.map((b) => b.text())
+		).toContain("Sort");
+	});
+
+	it("keeps the field label (not 'Sort') after toggling direction back to the default", async () => {
+		const w = mountAtDefault();
+		await w.find('[data-icon="arrow-up"]').trigger("click"); // engage: asc -> desc
+		await w.setProps({ sort: { field: "skill_name", dir: "desc" } });
+		await w.find('[data-icon="arrow-down"]').trigger("click"); // desc -> asc (== default)
+		await w.setProps({ sort: { field: "skill_name", dir: "asc" } });
+		const labels = w.findAll("button").map((b) => b.text());
+		expect(labels).toContain("Name"); // stays the chosen field
+		expect(labels).not.toContain("Sort"); // NOT the cleared-CTA anymore
+	});
 });

--- a/frontend/src/components/list/SortButton.vue
+++ b/frontend/src/components/list/SortButton.vue
@@ -20,7 +20,7 @@
 		<Popover placement="bottom-end">
 			<template #target="{ togglePopover }">
 				<Button
-					:label="isDefault ? 'Sort' : fieldLabel"
+					:label="touched || !isDefault ? fieldLabel : 'Sort'"
 					class="rounded-l-none"
 					@click="togglePopover()"
 				/>
@@ -84,7 +84,7 @@
 // asc/desc toggle joined to the field button ("Sort" at the page default, the
 // field label once chosen); a ghost x reset appears once a non-default sort is
 // active. Emits update:sort {field, dir}.
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { Popover, Button, FeatherIcon } from "frappe-ui";
 
 const props = defineProps({
@@ -108,12 +108,18 @@ const dir = computed(() => props.sort.dir || props.defaultSort.dir || "desc");
 // The field the menu marks as selected: the active sort, else the page default.
 const currentField = computed(() => props.sort.field || props.defaultSort.field || "");
 
+// Once the user engages the sort (picks a field OR flips direction) the button shows the
+// chosen field, even when the values happen to equal the page default - otherwise toggling
+// Name desc->asc snaps the label back to "Sort" as if the sort were cleared. Reset clears it.
+const touched = ref(false);
+
 const fieldLabel = computed(() => {
-	const opt = (props.sortOptions || []).find((o) => o.value === props.sort.field);
-	return (opt && opt.label) || props.sort.field || "Sort";
+	const opt = (props.sortOptions || []).find((o) => o.value === currentField.value);
+	return (opt && opt.label) || currentField.value || "Sort";
 });
 
 function toggleDir() {
+	touched.value = true;
 	// Fall back to the default field so toggling from the untouched default state
 	// (where sort.field may not yet be set by the page) still emits a real field.
 	emit("update:sort", {
@@ -124,11 +130,13 @@ function toggleDir() {
 
 function pickField(field, close) {
 	if (!field) return;
+	touched.value = true;
 	emit("update:sort", { field, dir: props.sort.dir || props.defaultSort.dir || "asc" });
 	if (close) close();
 }
 
 function reset(close) {
+	touched.value = false;
 	emit("update:sort", {
 		field: props.defaultSort.field || "",
 		dir: props.defaultSort.dir || "",

--- a/frontend/src/components/list/SortButton.vue
+++ b/frontend/src/components/list/SortButton.vue
@@ -29,13 +29,35 @@
 				<div
 					class="my-2 min-w-60 rounded-lg bg-surface-modal p-2 shadow-2xl ring-1 ring-black ring-opacity-5"
 				>
-					<FormControl
-						type="select"
-						label="Sort by"
-						:options="sortOptions"
-						:modelValue="sort.field || defaultSort.field || ''"
-						@update:modelValue="(v) => pickField(v, close)"
-					/>
+					<!-- A portal-free radio menu, NOT a frappe-ui Select: that renders its
+					     options through a reka SelectPortal, whose click counts as OUTSIDE
+					     this Popover and dismisses it before a field can be picked - so only
+					     the default field was ever reachable. In-popover buttons stay in the
+					     Popover's own DOM, so it stays open until pickField() closes it. -->
+					<div
+						id="sort-by-heading"
+						class="px-2 pb-1 text-xs font-medium text-ink-gray-5"
+					>
+						Sort by
+					</div>
+					<div role="menu" aria-labelledby="sort-by-heading" class="flex flex-col">
+						<button
+							v-for="opt in sortOptions"
+							:key="opt.value"
+							type="button"
+							role="menuitemradio"
+							:aria-checked="opt.value === currentField"
+							class="flex items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-base text-ink-gray-8 hover:bg-surface-gray-2 focus:outline-none focus-visible:bg-surface-gray-2"
+							@click="pickField(opt.value, close)"
+						>
+							<span class="truncate">{{ opt.label }}</span>
+							<FeatherIcon
+								v-if="opt.value === currentField"
+								name="check"
+								class="size-4 text-ink-gray-7"
+							/>
+						</button>
+					</div>
 					<div class="mt-2 flex justify-end border-t pt-2">
 						<Button
 							variant="ghost"
@@ -63,7 +85,7 @@
 // field label once chosen); a ghost x reset appears once a non-default sort is
 // active. Emits update:sort {field, dir}.
 import { computed } from "vue";
-import { Popover, Button, FormControl } from "frappe-ui";
+import { Popover, Button, FeatherIcon } from "frappe-ui";
 
 const props = defineProps({
 	sortOptions: { type: Array, default: () => [] }, // [{label, value}]
@@ -82,6 +104,9 @@ const isDefault = computed(
 // Effective direction: the active sort's dir, else the page default, else desc.
 // The always-visible toggle needs a value even before the user has changed sort.
 const dir = computed(() => props.sort.dir || props.defaultSort.dir || "desc");
+
+// The field the menu marks as selected: the active sort, else the page default.
+const currentField = computed(() => props.sort.field || props.defaultSort.field || "");
 
 const fieldLabel = computed(() => {
 	const opt = (props.sortOptions || []).find((o) => o.value === props.sort.field);

--- a/frontend/src/pages/skills/SkillsList.vue
+++ b/frontend/src/pages/skills/SkillsList.vue
@@ -178,6 +178,7 @@ const QUICK_CLAUSES = { enabled: "enabled" };
 const sortOptions = [
 	{ label: "Name", value: "skill_name" },
 	{ label: "Updated", value: "modified" },
+	{ label: "Created", value: "creation" },
 	{ label: "Enabled", value: "enabled" },
 ];
 const DEFAULT_SORT = { field: "skill_name", dir: "asc" };

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -38,11 +38,15 @@
 						<div
 							class="my-2 w-[320px] rounded-lg bg-surface-modal p-3 shadow-2xl ring-1 ring-black ring-opacity-5"
 						>
-							<FormControl
-								type="select"
-								label="Knowledge language"
+							<!-- PanelSelect, not FormControl select: a reka SelectPortal won't open
+							     inside this settings Popover (same bug fixed in the list filters). -->
+							<label class="mb-1 block text-xs text-ink-gray-5"
+								>Knowledge language</label
+							>
+							<PanelSelect
+								aria-label="Knowledge language"
 								:options="LANGUAGE_OPTIONS"
-								:modelValue="caps.knowledge_language"
+								:model-value="caps.knowledge_language"
 								@update:modelValue="changeLanguage"
 							/>
 							<p class="mt-1 text-p-sm text-ink-gray-5">
@@ -307,6 +311,7 @@ import {
 } from "frappe-ui";
 import { sessionUser } from "@/data/session";
 import ListPage from "@/components/list/ListPage.vue";
+import PanelSelect from "@/components/list/PanelSelect.vue";
 import WikiPageDialog from "@/components/wiki/WikiPageDialog.vue";
 import { useListPage } from "@/composables/useListPage";
 import { wikiListFetch } from "@/pages/list/listFetchers";

--- a/frontend/tests/list-filters/FilterGroup.spec.js
+++ b/frontend/tests/list-filters/FilterGroup.spec.js
@@ -8,7 +8,18 @@ vi.mock("frappe-ui", () => frappeUiStubs());
 vi.mock("@/api", () => ({ searchLink: vi.fn(async () => []) }));
 
 import FilterGroup from "@/components/list/FilterGroup.vue";
+import PanelSelect from "@/components/list/PanelSelect.vue";
 import { clauseForEntry, setOperator, fieldKey } from "@/components/list/filterModel";
+
+// Both the operator AND the select-family value controls are portal-free PanelSelects
+// now (a frappe-ui FormControl select won't open inside the teleported Popover), so
+// read their contract off props / emitted events rather than a <select>/<option> tree.
+// They're told apart by their aria-label: "Condition for …" vs "Value for …".
+const panels = (w) => w.findAllComponents(PanelSelect);
+const operators = (w) =>
+	panels(w).filter((c) => (c.props("ariaLabel") || "").startsWith("Condition"));
+const values = (w) => panels(w).filter((c) => (c.props("ariaLabel") || "").startsWith("Value"));
+const setOp = (op, value) => op.vm.$emit("update:modelValue", value);
 
 /**
  * FilterGroup is CONTROLLED: it never mutates its own clause array, it emits a
@@ -60,18 +71,14 @@ describe("rows", () => {
 
 	it("offers each field's OWN operator list, with the server's default preselected", () => {
 		const w = mountPanel({ clauses: [clauseForEntry(ENABLED), clauseForEntry(CREATION)] });
-		const selects = w.findAll("select");
+		const ops = operators(w);
 		// Check exposes Equals only — the panel must not offer `like` on it.
-		const checkOperators = selects[0].findAll("option").map((o) => o.attributes("value"));
-		expect(checkOperators).toEqual(["="]);
+		expect(ops[0].props("options").map((o) => o.value)).toEqual(["="]);
 		// Datetime's default is Between (D5), and it never offers like/in.
-		const dtOperators = w
-			.findAll("select")[2]
-			.findAll("option")
-			.map((o) => o.attributes("value"));
+		const dtOperators = ops[1].props("options").map((o) => o.value);
 		expect(dtOperators).toContain("Between");
 		expect(dtOperators).not.toContain("like");
-		expect(w.findAll("select")[2].element.value).toBe("Between");
+		expect(ops[1].props("modelValue")).toBe("Between");
 	});
 
 	it("counts COMPLETE clauses, not rows on screen", () => {
@@ -102,8 +109,12 @@ describe("rows", () => {
 describe("value controls, one per family", () => {
 	it("Check → a Yes/No select mapped to 1/0", () => {
 		const w = mountPanel({ clauses: [clauseForEntry(ENABLED)] });
-		const value = w.findAll("select")[1];
-		expect(value.findAll("option").map((o) => [o.text(), o.attributes("value")])).toEqual([
+		// the value control is a portal-free PanelSelect now; read its options off props
+		expect(
+			values(w)[0]
+				.props("options")
+				.map((o) => [o.label, o.value])
+		).toEqual([
 			["Yes", "1"],
 			["No", "0"],
 		]);
@@ -111,12 +122,11 @@ describe("value controls, one per family", () => {
 
 	it("Select → metadata options with the leading blank labelled 'Not set'", () => {
 		const w = mountPanel({ clauses: [clauseForEntry(SCOPE)] });
-		const value = w.findAll("select")[1];
-		expect(value.findAll("option").map((o) => o.text())).toEqual([
-			"Not set",
-			"Org",
-			"Personal",
-		]);
+		expect(
+			values(w)[0]
+				.props("options")
+				.map((o) => o.label)
+		).toEqual(["Not set", "Org", "Personal"]);
 	});
 
 	it("Date/Datetime Between → two bounds, both required", () => {
@@ -155,11 +165,11 @@ describe("value controls, one per family", () => {
 
 	it("`is` → set / not set, whatever the family", () => {
 		const w = mountPanel({ clauses: [setOperator(clauseForEntry(SCOPE), "is")] });
-		const value = w.findAll("select")[1];
-		expect(value.findAll("option").map((o) => o.attributes("value"))).toEqual([
-			"set",
-			"not set",
-		]);
+		expect(
+			values(w)[0]
+				.props("options")
+				.map((o) => o.value)
+		).toEqual(["set", "not set"]);
 	});
 
 	it("`in` over a free-text family → chips, never a comma string (D10)", async () => {
@@ -175,8 +185,9 @@ describe("value controls, one per family", () => {
 
 	it("Timespan → the server's own token list", () => {
 		const w = mountPanel({ clauses: [setOperator(clauseForEntry(CREATION), "Timespan")] });
-		const value = w.findAll("select")[1];
-		const tokens = value.findAll("option").map((o) => o.attributes("value"));
+		const tokens = values(w)[0]
+			.props("options")
+			.map((o) => o.value);
 		expect(tokens).toContain("last week");
 		expect(tokens).toContain("this quarter");
 	});
@@ -212,7 +223,8 @@ describe("editing", () => {
 
 		await w.setProps({ clauses: next });
 		// change only the second row's operator
-		await w.findAll("select")[1].setValue("not like");
+		setOp(operators(w)[1], "not like");
+		await nextTick();
 		expect(lastClauses(w)[0].operator).toBe("like");
 		expect(lastClauses(w)[1].operator).toBe("not like");
 	});
@@ -246,11 +258,13 @@ describe("editing", () => {
 		await w.find('input[type="text"]').setValue("month");
 		expect(w.emitted("update:clauses").at(-1)[1]).toEqual({ immediate: false });
 
-		await w.findAll("select")[0].setValue("=");
+		setOp(operators(w)[0], "="); // a discrete operator pick is immediate
+		await nextTick();
 		expect(w.emitted("update:clauses").at(-1)[1]).toEqual({ immediate: true });
 
 		await w.setProps({ clauses: [clauseForEntry(ENABLED)] });
-		await w.findAll("select")[1].setValue("0");
+		setOp(values(w)[0], "0"); // a discrete Yes/No value pick is immediate too
+		await nextTick();
 		expect(w.emitted("update:clauses").at(-1)[1]).toEqual({ immediate: true });
 	});
 
@@ -450,7 +464,7 @@ describe("accessibility", () => {
 				withValue(CREATION, ["2026-03-01", "2026-04-01"]),
 			],
 		});
-		const labels = w.findAll("select").map((s) => s.attributes("aria-label"));
+		const labels = operators(w).map((op) => op.props("ariaLabel"));
 		expect(labels).toContain("Condition for Created On (filter 1)");
 		expect(labels).toContain("Condition for Created On (filter 2)");
 		expect(labels).toContain("Condition for Description");
@@ -494,7 +508,7 @@ describe("accessibility", () => {
 	it("labels the trigger, every control and every remove button", () => {
 		const w = mountPanel({ clauses: [withValue(DESCRIPTION, "a")] });
 		expect(w.find("button").attributes("aria-label")).toBe("Filter (1 active)");
-		expect(w.find("select").attributes("aria-label")).toBe("Condition for Description");
+		expect(operators(w)[0].props("ariaLabel")).toBe("Condition for Description");
 		expect(w.find('input[type="text"]').attributes("aria-label")).toBe(
 			"Value for Description"
 		);

--- a/frontend/tests/list-filters/FilterGroupPopover.spec.js
+++ b/frontend/tests/list-filters/FilterGroupPopover.spec.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { frappeUiStubs } from "./stubs.js";
+import { SKILLS_SCHEMA, DESCRIPTION, ENABLED } from "./fixtures.js";
+import { clauseForEntry } from "@/components/list/filterModel";
 
 /**
  * FilterGroup against the REAL frappe-ui Popover.
@@ -131,6 +133,78 @@ describe("FilterGroup on the real Popover", () => {
 		await w.find('button[aria-label="Filter"]').trigger("click");
 		await settle();
 		expect(w.emitted("request-schema")).toHaveLength(2);
+		w.unmount();
+	});
+});
+
+// The regression this whole change exists to fix: a FormControl select's reka
+// SelectPortal would NOT open inside the teleported Popover, so the operator was
+// unpickable. PanelSelect keeps the listbox inline; prove it opens + applies
+// against the REAL Popover, which the stubbed specs cannot vouch for.
+describe("FilterGroup operator picker on the real Popover", () => {
+	it("opens the operator listbox in-panel and applies a pick without dismissing it", async () => {
+		const w = mount(FilterGroup, {
+			attachTo: document.body,
+			props: {
+				schema: SKILLS_SCHEMA,
+				schemaState: "ready",
+				clauses: [clauseForEntry(DESCRIPTION)],
+			},
+		});
+		await w.find('button[aria-label="Filter"]').trigger("click");
+		await settle();
+
+		const trigger = document.querySelector('button[aria-label^="Condition for"]');
+		expect(trigger).toBeTruthy();
+		trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		await settle();
+
+		// the listbox is inline in the panel's own DOM - a SelectPortal would not open here
+		const options = document.querySelectorAll('[role="listbox"] [role="option"]');
+		expect(options.length).toBeGreaterThan(1);
+
+		// pick a NON-current operator; the panel must stay open and the clause update
+		const current = w.props("clauses")[0].operator;
+		let target = null;
+		options.forEach((o) => {
+			if (!target && o.getAttribute("aria-selected") === "false") target = o;
+		});
+		target.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+		await settle();
+
+		expect(w.emitted("update:clauses").at(-1)[0][0].operator).not.toBe(current);
+		expect(document.querySelectorAll("[data-filter-row]")).toHaveLength(1); // still open
+		w.unmount();
+	});
+
+	// The exact case the owner hit: Enabled -> equals -> No. The Check VALUE select is
+	// also a PanelSelect now; prove its dropdown opens in-panel and applies "No".
+	it("opens the Check value dropdown in-panel and applies 'No' without dismissing", async () => {
+		const w = mount(FilterGroup, {
+			attachTo: document.body,
+			props: {
+				schema: SKILLS_SCHEMA,
+				schemaState: "ready",
+				clauses: [clauseForEntry(ENABLED)],
+			},
+		});
+		await w.find('button[aria-label="Filter"]').trigger("click");
+		await settle();
+
+		const valueTrigger = document.querySelector('button[aria-label^="Value for"]');
+		expect(valueTrigger).toBeTruthy();
+		valueTrigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		await settle();
+
+		const options = Array.from(document.querySelectorAll('[role="listbox"] [role="option"]'));
+		expect(options.map((o) => o.textContent.trim())).toEqual(["Yes", "No"]);
+		options
+			.find((o) => o.textContent.includes("No"))
+			.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+		await settle();
+
+		expect(w.emitted("update:clauses").at(-1)[0][0].value).toBe("0"); // No -> "0"
+		expect(document.querySelectorAll("[data-filter-row]")).toHaveLength(1); // still open
 		w.unmount();
 	});
 });

--- a/frontend/tests/list-filters/FilterValueControl.spec.js
+++ b/frontend/tests/list-filters/FilterValueControl.spec.js
@@ -9,6 +9,7 @@ const apiDouble = vi.hoisted(() => ({ searchLink: vi.fn(async () => []) }));
 vi.mock("@/api", () => apiDouble);
 
 import FilterValueControl from "@/components/list/FilterValueControl.vue";
+import PanelSelect from "@/components/list/PanelSelect.vue";
 import { clauseForEntry, setOperator } from "@/components/list/filterModel";
 
 function mountControl(entry, clause, props = {}) {
@@ -330,8 +331,11 @@ describe("multi-value", () => {
 describe("scalar families", () => {
 	it("sentence-cases the timespan menu without touching the wire token", () => {
 		const w = mountControl(CREATION, setOperator(clauseForEntry(CREATION), "Timespan"));
-		const options = w.find("select").findAll("option");
-		const pairs = options.map((o) => [o.text(), o.attributes("value")]);
+		// timespan value is a portal-free PanelSelect now; read its options off props
+		const pairs = w
+			.findComponent(PanelSelect)
+			.props("options")
+			.map((o) => [o.label, o.value]);
 		expect(pairs).toContainEqual(["Last 7 days", "last 7 days"]);
 		expect(pairs).toContainEqual(["This quarter", "this quarter"]);
 	});
@@ -382,7 +386,9 @@ describe("scalar families", () => {
 
 	it("Check emits the 1/0 the compiler expects", async () => {
 		const w = mountControl(ENABLED, clauseForEntry(ENABLED));
-		await w.find("select").setValue("0");
+		// the Check value is a portal-free PanelSelect; a pick emits its update:modelValue
+		w.findComponent(PanelSelect).vm.$emit("update:modelValue", "0");
+		await w.vm.$nextTick();
 		expect(patch(w)).toEqual({ value: "0", display: null, immediate: true });
 	});
 });

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -190,7 +190,12 @@ def _attach_shared_by(rows: list) -> None:
 # Paginated list (frozen envelope) — chat-features-page-migration-design §2.2.
 # ADDITIVE: list_custom_skills (above) STAYS for the composer "/" autocomplete.
 # --------------------------------------------------------------------------- #
-_SKILLS_SORTABLE = {"skill_name": "skill_name", "modified": "modified", "enabled": "enabled"}
+_SKILLS_SORTABLE = {
+	"skill_name": "skill_name",
+	"modified": "modified",
+	"creation": "creation",
+	"enabled": "enabled",
+}
 _SKILLS_FILTERS = {"scope", "enabled", "user_invocable"}
 
 

--- a/jarvis/tests/test_list_filters_pilots.py
+++ b/jarvis/tests/test_list_filters_pilots.py
@@ -469,3 +469,63 @@ class TestErrorCodesOnTheWire(unittest.TestCase):
 		contract still throws, which is what its existing callers expect."""
 		with _as(USER_A), self.assertRaises(frappe.ValidationError):
 			self._request("jarvis.chat.macros_api.list_macros_page", filters='{"bogus_key": 1}')
+
+
+class TestSkillsSortableColumns(unittest.TestCase):
+	"""The skills list must sort by its datetime columns, not just Name (jarvis#900+):
+	the reachable frontend sort options (skill_name, modified, creation, enabled) each
+	have to be honored server-side, and anything else falls back to the Name default."""
+
+	def _order(self, field, direction="asc"):
+		from jarvis.chat.custom_skills_api import _SKILLS_SORTABLE
+
+		return list_filters.order_by(field, direction, _SKILLS_SORTABLE, "skill_name", "asc")
+
+	def test_created_datetime_is_a_sortable_column(self):
+		# Killing mutation: drop "creation" from _SKILLS_SORTABLE -> this falls back to
+		# skill_name asc and the assertion reds.
+		self.assertEqual(self._order("creation", "desc"), "`creation` desc, `name` asc")
+
+	def test_updated_datetime_is_a_sortable_column(self):
+		self.assertEqual(self._order("modified", "desc"), "`modified` desc, `name` asc")
+
+	def test_an_unknown_sort_field_falls_back_to_name(self):
+		self.assertEqual(self._order("description"), "`skill_name` asc, `name` asc")
+
+	def test_creation_sort_actually_reorders_rows_end_to_end(self):
+		# Real endpoint proof (mirrors test_feature_pages_api.test_sort_creation_default_desc):
+		# three skills with KNOWN, distinct creation times -> sort_field=creation returns them
+		# in creation order, not the skill_name default. Names are chosen so name-order and
+		# creation-order differ, so a fallback-to-name would be visible.
+		names = ["lfp-cr-c", "lfp-cr-a", "lfp-cr-b"]  # insert order != alpha order
+		try:
+			with _as(USER_A):
+				for n in names:
+					frappe.get_doc(
+						{
+							"doctype": SKILL,
+							"skill_name": n,
+							"description": "creation-sort e2e fixture",
+							"instructions": "creation-sort e2e fixture instructions",
+							"scope": "User",
+							"enabled": 1,
+						}
+					).insert(ignore_permissions=True)
+			for i, n in enumerate(names):
+				frappe.db.set_value(
+					SKILL, {"skill_name": n}, "creation", f"2026-01-0{i + 1} 00:00:00", update_modified=False
+				)
+			frappe.db.commit()
+			with _as(USER_A):
+				desc = list_custom_skills_page(sort_field="creation", sort_dir="desc")
+				asc = list_custom_skills_page(sort_field="creation", sort_dir="asc")
+			desc_names = [r["skill_name"] for r in desc["rows"] if r["skill_name"] in names]
+			asc_names = [r["skill_name"] for r in asc["rows"] if r["skill_name"] in names]
+			# creation order is insert order (c, a, b); desc = newest first (b, a, c)
+			self.assertEqual(asc_names, ["lfp-cr-c", "lfp-cr-a", "lfp-cr-b"])
+			self.assertEqual(desc_names, ["lfp-cr-b", "lfp-cr-a", "lfp-cr-c"])
+		finally:
+			for n in names:
+				for nm in frappe.get_all(SKILL, filters={"skill_name": n}, pluck="name"):
+					frappe.delete_doc(SKILL, nm, force=True, ignore_permissions=True)
+			frappe.db.commit()


### PR DESCRIPTION
## Problem
The list toolbar's Sort and Filter dropdowns are frappe-ui `FormControl`/`Select` controls that render their options through a reka `SelectPortal`. Inside the toolbar's teleported `Popover`, that portal click reads as an outside-click, so the dropdowns either don't open or dismiss the panel before a value applies. Result: every list's Sort field picker was stuck on the default column, and the Filter operator/value dropdowns were unpickable.

## Fix
- **Sort** (`SortButton`): portal-free `role=menu` field picker + always-visible asc/desc toggle; added a `Created` datetime sort.
- **Filter**: new portal-free, globally-themed **`PanelSelect`** (inline listbox, full keyboard, styled from `:root` tokens that survive the teleport) backing:
  - `FilterGroup` operator + `FilterValueControl` value selects (Check / Select / is / Timespan),
  - the legacy **`FilterButton`** — covers every unmigrated list (Support, Files, Triggers, …),
  - the Wiki settings language dropdown (same bug, non-list surface).

Autocomplete- and DatePicker-in-popover controls use a different (nested-popover) mechanism that works, so they're left as-is.

## Coverage
These are shared components, so the fix reaches every list page: Skills, Agents, Files, Macros, Support, Triggers, Dashboards, Wiki.

## Tests
- New `PanelSelect.spec` (open / keyboard / pick / outside-click / a11y) and `SortButton.spec`.
- `FilterGroup` / `FilterValueControl` specs updated; **real-`Popover` tests** prove the operator and the Check value open in-panel and apply without dismissing.
- Full frontend suite green (1352); prettier@2.7.1 + eslint@8.44.0 clean; production build green.
- Browser-verified by the owner (filter apply + File Box sort).

Supersedes #906 (Sort-only).