### PR TITLE
feat(support): add "Support tickets" entry to the avatar menu

### DIFF
--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -146,6 +146,21 @@ const menuOptions = computed(() => [
 							onClick: () => shellStore.openSettings(),
 						},
 				  ]),
+			// Support tickets -> the LIST (/support). Distinct from ChatView's header
+			// headset icon, which opens a NEW ticket pre-filled with the current chat;
+			// this entry is the way back to existing tickets. Chat variant only (the
+			// support rail reaches its own list), and gated on supportOn because the
+			// /support routes sit behind supportGuard on the same flags — so it is
+			// never a dead link that bounces the user back to Chat.
+			...(props.variant === "support" || !supportOn
+				? []
+				: [
+						{
+							label: "Support tickets",
+							icon: "life-buoy",
+							onClick: () => router.push({ name: "Support" }),
+						},
+				  ]),
 			...(crossItem.value ? [crossItem.value] : []),
 			{
 				label: "Switch to Desk",


### PR DESCRIPTION
## What

Adds a **Support tickets** item to the avatar dropdown (`UserMenu.vue`) that navigates to the support ticket **list** (`/support`).

## Why

Today the only support entry point from chat is the header headset icon, and `openSupport()` sends it to `SupportNew` (`/support/new`) — a *new* ticket pre-filled with the current chat. There was **no** entry point to the ticket **list** from chat at all (the `Support` route existed but nothing linked to it). This adds that path without disturbing the header icon.

## Behaviour

- New menu item **"Support tickets"** → `router.push({ name: "Support" })` (the list).
- **Labelled "Support tickets"** (not "Support") so it reads distinctly from the header's "Support" headset icon, which opens a new ticket.
- **Gated on `supportOn`** (`window.support_available && window.has_support_access`) — the same flags `supportGuard` enforces on the `/support*` routes — so it can never be a dead link that bounces the user back to Chat.
- **Chat variant only.** On the support rail (`variant === "support"`) it's omitted; that rail reaches its own list and already offers "Switch to chat".
- Icon `life-buoy` (Feather), consistent with `SupportListPage.vue`.

Header headset icon (new ticket + copy-current-chat) is **untouched**.

## Verification

- `prettier` pre-commit hook **passed**; indentation is byte-identical to the sibling `Settings` spread block.
- Confirmed against `origin/develop`: the `Support` list route (`name: "Support"`, `/support`) exists behind `supportGuard`, and `life-buoy` is a valid Feather icon already used on the support surface.
- ⏳ **Remaining manual smoke** (needs SPA build + a support-enabled workspace): open the avatar menu with support available → "Support tickets" shows and opens the list; with support unavailable → item hidden. The built bundle is produced by the deploy pipeline (gitignored artifact), so no bundle is committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)