### PR TITLE
fix(dashboards): resume the builder conversation on a repeat goto hand-off

### DIFF
--- a/frontend/src/composables/dashboardPrefill.js
+++ b/frontend/src/composables/dashboardPrefill.js
@@ -7,8 +7,20 @@ import { ref } from "vue";
 // on mount (and clears it on EVERY mount so a stale prompt can never fire
 // later): when `autoSend` is set it hands the text to the chat pane's
 // sendText(), which sends it as the next message on the builder's thread.
+//
+// jarvis#912: a repeat hand-off for the SAME goto message (the "Continue in
+// Dashboards" card is clickable on every later visit to the transcript, with
+// no per-click guard) must not build a second conversation on top of the one
+// the first hand-off already created. ChatView looks up that mapping (see
+// lib/chatGoto.js's fired-stamp helpers) before stashing this payload: when a
+// builder conversation is already known for the message, `resume` + `conv`
+// are set instead of `autoSend`, and `text` still rides along as the seed for
+// a fresh build IF that conversation turns out to have been deleted meanwhile.
 // Shape:
-//   { text: string, autoSend: true }
+//   { text: string, autoSend: true, messageId } - first hand-off, builds fresh
+//   { text: string, resume: true, conv: string, messageId } - repeat hand-off,
+//     navigates to the recorded conversation (falls back to the first shape's
+//     behaviour if `conv` no longer exists)
 export const pendingDashboardPrefill = ref(null);
 
 export function setDashboardPrefill(payload) {

--- a/frontend/src/lib/artifactActivityCard.test.js
+++ b/frontend/src/lib/artifactActivityCard.test.js
@@ -310,7 +310,7 @@ test("the goto morph line latches on a complete streaming goto and survives run:
 	assert.match(runEnd, /gotoMorph\.value = goto;/);
 	assert.match(runEnd, /prefers-reduced-motion/);
 	assert.match(runEnd, /GOTO_MORPH_HOLD_MS/);
-	assert.match(runEnd, /if \(gotoMorph\.value\) gotoDashboards\(goto\.prompt\);/);
+	assert.match(runEnd, /if \(gotoMorph\.value\) gotoDashboards\(goto\.prompt, m\.name\);/);
 	assert.match(runEnd, /if \(!redirected\) dropGotoMorph\(\);/);
 	// the unconditional clear must come AFTER the redirect gate, not before it
 	assert.ok(

--- a/frontend/src/lib/chatGoto.js
+++ b/frontend/src/lib/chatGoto.js
@@ -79,3 +79,47 @@ export function parseFiredStamp(raw) {
 export function encodeFiredStamp(t, conv) {
 	return conv ? JSON.stringify({ t, conv }) : String(t);
 }
+
+// ── closing the double-click race (jarvis#912 round 2) ──────────────────────
+//
+// The "Continue in Dashboards" card has no per-click guard (it stays
+// clickable on every later visit to the transcript), so two triggers for the
+// same message in the window before send() answers with a conversation used
+// to both read "no stamp yet" and each start their own build. gotoDashboards
+// (ChatView.vue) closes that by claiming the stamp synchronously through this
+// function before deciding anything else - the live run:end auto-redirect
+// claims through the same call, so there is exactly one place a fresh build
+// ever gets stamped.
+//
+// A bare stamp (fired, no conversation recorded yet) counts as an existing
+// claim only inside this window - comfortably above one send() round trip.
+// Two things depend on it expiring: a claim whose send() never reaches the
+// server because the tab died first (DashboardChatPane's forgetGotoClaim
+// undoes it on every ordinary failure, but not that one), and every
+// pre-#912 stamp already on disk, which is bare by construction and would
+// otherwise read as "claimed" forever.
+const GOTO_CLAIM_WINDOW_MS = 45000;
+
+/**
+ * Pure: decides what one gotoDashboards trigger for `messageId` should do,
+ * given whatever raw value is CURRENTLY at gotoFiredKey(messageId). Two
+ * synchronous callers threading the same value through it (the second using
+ * whatever the first returned as `stamp`) behave exactly as two real
+ * localStorage round trips would - the shape both the source wiring and a
+ * test exercising the race use.
+ *
+ * @param {string|null} raw the localStorage value at gotoFiredKey(messageId)
+ * @param {number} [now] fired-at timestamp for a fresh claim
+ * @returns {{build: true, stamp: string}|{build: false, conv: string}}
+ *   build: true  - unclaimed (or a claim past its window) - the caller must
+ *                  persist `stamp` before it does anything else, then build.
+ *   build: false - already claimed; resume `conv`, which is "" while the
+ *                  claiming send() is still in flight.
+ */
+export function claimGotoFire(raw, now = Date.now()) {
+	const stamp = parseFiredStamp(raw);
+	if (stamp && (stamp.conv || now - stamp.t < GOTO_CLAIM_WINDOW_MS)) {
+		return { build: false, conv: stamp.conv };
+	}
+	return { build: true, stamp: encodeFiredStamp(now) };
+}

--- a/frontend/src/lib/chatGoto.js
+++ b/frontend/src/lib/chatGoto.js
@@ -34,3 +34,48 @@ export function parseGoto(content) {
 		return null;
 	}
 }
+
+// ── the "fired" stamp (jarvis#912) ───────────────────────────────────────────
+//
+// One ```jarvis-goto message gets one durable localStorage stamp, keyed by
+// message id. Before #912 the stamp was a bare marker (a fired timestamp, so
+// the run:end handler never redirects twice for the same message). #912 adds
+// a second job: remembering WHICH builder conversation that hand-off created,
+// so a later trigger for the SAME message (the "Continue in Dashboards" card
+// button has no per-click guard, unlike the auto-redirect) can navigate
+// there instead of building a duplicate.
+//
+// The value stays a bare stringified timestamp ("<epochMs>") for as long as
+// no conversation is known yet - byte-identical to the pre-#912 shape, and
+// what an old stamp already on disk looks like. Once the conversation is
+// known it becomes JSON ({t, conv}). Both shapes parse.
+
+export function gotoFiredKey(messageId) {
+	return "jarvis:goto-fired:" + messageId;
+}
+
+/**
+ * @param {string|null} raw the localStorage value at gotoFiredKey(messageId)
+ * @returns {{t: number, conv: string}|null} null when unfired / unreadable
+ */
+export function parseFiredStamp(raw) {
+	if (!raw) return null;
+	try {
+		const v = JSON.parse(raw);
+		if (v && typeof v === "object" && typeof v.t === "number") {
+			return { t: v.t, conv: String(v.conv || "") };
+		}
+	} catch (e) {
+		// not JSON - the bare pre-#912 shape, handled below
+	}
+	const t = Number(raw);
+	return Number.isFinite(t) ? { t, conv: "" } : null;
+}
+
+/**
+ * @param {number} t fired-at timestamp (ms)
+ * @param {string} [conv] the builder conversation the hand-off landed on
+ */
+export function encodeFiredStamp(t, conv) {
+	return conv ? JSON.stringify({ t, conv }) : String(t);
+}

--- a/frontend/src/lib/chatGoto.test.js
+++ b/frontend/src/lib/chatGoto.test.js
@@ -16,7 +16,13 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseGoto, GOTO_RE } from "./chatGoto.js";
+import {
+	parseGoto,
+	GOTO_RE,
+	gotoFiredKey,
+	parseFiredStamp,
+	encodeFiredStamp,
+} from "./chatGoto.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const chatViewSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
@@ -79,9 +85,38 @@ test("chatBlocks strips jarvis-goto from the visible prose", () => {
 });
 
 test("ChatView parses goto through the shared module, not a private copy", () => {
-	assert.match(chatViewSrc, /import \{ parseGoto \} from "@\/lib\/chatGoto";/);
+	assert.match(
+		chatViewSrc,
+		/import \{ parseGoto, gotoFiredKey, parseFiredStamp, encodeFiredStamp \} from "@\/lib\/chatGoto";/
+	);
 	const gotoOf = fnBody(chatViewSrc, "function gotoOf(m)");
 	assert.match(gotoOf, /return parseGoto\(\(m && m\.content\) \|\| ""\);/);
+});
+
+// ---- the fired-stamp shape (jarvis#912) ------------------------------------
+
+test("gotoFiredKey namespaces on the message id", () => {
+	assert.equal(gotoFiredKey("msg-1"), "jarvis:goto-fired:msg-1");
+});
+
+test("a bare pre-#912 timestamp still parses, with no conversation known", () => {
+	assert.deepEqual(parseFiredStamp("1723890000000"), { t: 1723890000000, conv: "" });
+});
+
+test("an unreadable/missing stamp parses to null", () => {
+	assert.equal(parseFiredStamp(null), null);
+	assert.equal(parseFiredStamp(""), null);
+	assert.equal(parseFiredStamp("not a number"), null);
+});
+
+test("encodeFiredStamp writes the bare pre-#912 shape until a conversation is known", () => {
+	assert.equal(encodeFiredStamp(123), "123");
+	assert.deepEqual(parseFiredStamp(encodeFiredStamp(123)), { t: 123, conv: "" });
+});
+
+test("encodeFiredStamp/parseFiredStamp round-trip once a conversation is recorded", () => {
+	const encoded = encodeFiredStamp(456, "conv-9");
+	assert.deepEqual(parseFiredStamp(encoded), { t: 456, conv: "conv-9" });
 });
 
 test("the card renders the restated prompt and one button that hands off to the builder", () => {
@@ -89,7 +124,7 @@ test("the card renders the restated prompt and one button that hands off to the 
 	assert.match(chatViewSrc, /Continue in Dashboards/);
 	// prettier may wrap the interpolation onto its own line, so match loosely
 	assert.match(chatViewSrc, /\{\{\s*gotoOf\(m\)\.prompt\s*\}\}/);
-	assert.match(chatViewSrc, /@click="gotoDashboards\(gotoOf\(m\)\.prompt\)"/);
+	assert.match(chatViewSrc, /@click="gotoDashboards\(gotoOf\(m\)\.prompt, m\.name\)"/);
 });
 
 test("gotoDashboards stashes the prefill and navigates to the builder", () => {
@@ -97,9 +132,28 @@ test("gotoDashboards stashes the prefill and navigates to the builder", () => {
 		chatViewSrc,
 		/import \{ setDashboardPrefill \} from "@\/composables\/dashboardPrefill";/
 	);
-	const fn = fnBody(chatViewSrc, "function gotoDashboards(prompt)");
-	assert.match(fn, /setDashboardPrefill\(\{ text: prompt, autoSend: true \}\);/);
+	const fn = fnBody(chatViewSrc, "function gotoDashboards(prompt, messageId)");
+	assert.match(fn, /setDashboardPrefill\(\{ text: prompt, autoSend: true, messageId \}\);/);
 	assert.match(fn, /router\.push\("\/dashboards"\);/);
+});
+
+// jarvis#912: a repeat hand-off for a message that already has a recorded
+// builder conversation must navigate there instead of building again. See
+// dashboardOpen.test.js for the DashboardsPage/DashboardChatPane side of the
+// mechanism (recording the mapping, resuming it, the deleted-conversation
+// fallback).
+test("gotoDashboards resumes the recorded conversation for a repeat hand-off", () => {
+	const fn = fnBody(chatViewSrc, "function gotoDashboards(prompt, messageId)");
+	assert.match(fn, /const stamp = messageId/);
+	assert.match(
+		fn,
+		/\? parseFiredStamp\(localStorage\.getItem\(gotoFiredKey\(messageId\)\)\)\n\t\t: null;/
+	);
+	assert.match(fn, /if \(stamp && stamp\.conv\) \{/);
+	assert.match(
+		fn,
+		/setDashboardPrefill\(\{ text: prompt, resume: true, conv: stamp\.conv, messageId \}\);/
+	);
 });
 
 test("run:end auto-fires the redirect at most once, and never for an errored or stopped turn", () => {
@@ -110,10 +164,10 @@ test("run:end auto-fires the redirect at most once, and never for an errored or 
 	assert.match(runEnd, /if \(m && !m\.error && !m\.stopped\) \{/);
 	assert.match(runEnd, /const goto = gotoOf\(m\);/);
 	// durable stamp, keyed per message, checked before it is set
-	assert.match(runEnd, /const firedKey = "jarvis:goto-fired:" \+ m\.name;/);
+	assert.match(runEnd, /const firedKey = gotoFiredKey\(m\.name\);/);
 	const stampIdx = runEnd.indexOf("localStorage.getItem(firedKey)");
 	const setIdx = runEnd.indexOf("localStorage.setItem(firedKey,");
-	const gotoIdx = runEnd.indexOf("gotoDashboards(goto.prompt);");
+	const gotoIdx = runEnd.indexOf("gotoDashboards(goto.prompt, m.name);");
 	assert.notEqual(stampIdx, -1);
 	assert.ok(stampIdx < setIdx, "the stamp must be checked before it is written");
 	assert.ok(setIdx < gotoIdx, "the stamp must be written before the redirect fires");

--- a/frontend/src/lib/chatGoto.test.js
+++ b/frontend/src/lib/chatGoto.test.js
@@ -22,6 +22,7 @@ import {
 	gotoFiredKey,
 	parseFiredStamp,
 	encodeFiredStamp,
+	claimGotoFire,
 } from "./chatGoto.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -87,7 +88,7 @@ test("chatBlocks strips jarvis-goto from the visible prose", () => {
 test("ChatView parses goto through the shared module, not a private copy", () => {
 	assert.match(
 		chatViewSrc,
-		/import \{ parseGoto, gotoFiredKey, parseFiredStamp, encodeFiredStamp \} from "@\/lib\/chatGoto";/
+		/import \{ parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire \} from "@\/lib\/chatGoto";/
 	);
 	const gotoOf = fnBody(chatViewSrc, "function gotoOf(m)");
 	assert.match(gotoOf, /return parseGoto\(\(m && m\.content\) \|\| ""\);/);
@@ -144,16 +145,48 @@ test("gotoDashboards stashes the prefill and navigates to the builder", () => {
 // fallback).
 test("gotoDashboards resumes the recorded conversation for a repeat hand-off", () => {
 	const fn = fnBody(chatViewSrc, "function gotoDashboards(prompt, messageId)");
-	assert.match(fn, /const stamp = messageId/);
+	assert.match(fn, /const claim = key \? claimGotoFire\(localStorage\.getItem\(key\)\) /);
+	assert.match(fn, /\} else if \(claim\.conv\) \{/);
 	assert.match(
 		fn,
-		/\? parseFiredStamp\(localStorage\.getItem\(gotoFiredKey\(messageId\)\)\)\n\t\t: null;/
+		/setDashboardPrefill\(\{ text: prompt, resume: true, conv: claim\.conv, messageId \}\);/
 	);
-	assert.match(fn, /if \(stamp && stamp\.conv\) \{/);
-	assert.match(
-		fn,
-		/setDashboardPrefill\(\{ text: prompt, resume: true, conv: stamp\.conv, messageId \}\);/
-	);
+});
+
+// jarvis#912 round 2 (finding #3): the card has no per-click guard, so two
+// triggers for the same message close together (a double-click) used to both
+// read "no stamp" and each start a build. claimGotoFire is the pure decision
+// gotoDashboards makes that closes the race - exercised directly here since a
+// .vue SFC cannot be imported into this runner (see the module header).
+test("claimGotoFire: two synchronous triggers for the same message agree - only the first builds", () => {
+	const now = 1_000_000;
+	const first = claimGotoFire(null, now);
+	assert.deepEqual(first, { build: true, stamp: String(now) });
+	// what the caller (gotoDashboards) must persist before a second trigger can
+	// run - the second trigger reads exactly this back
+	const second = claimGotoFire(first.stamp, now);
+	assert.deepEqual(second, { build: false, conv: "" });
+});
+
+test("claimGotoFire resumes a stamp that already names a conversation, regardless of age", () => {
+	const encoded = encodeFiredStamp(1, "conv-9");
+	assert.deepEqual(claimGotoFire(encoded, 999_999_999), { build: false, conv: "conv-9" });
+});
+
+test("claimGotoFire treats a bare stamp as expired once its claim window has passed", () => {
+	// covers two cases: an abandoned claim whose send() never reached the
+	// server (the tab closed before DashboardChatPane's forgetGotoClaim could
+	// run), and every pre-#912 stamp already on disk - bare by construction,
+	// and old enough that it must not read as "claimed" forever.
+	const now = 1_000_000;
+	const stale = claimGotoFire(String(now - 60_000), now);
+	assert.equal(stale.build, true);
+	assert.equal(stale.stamp, String(now));
+});
+
+test("claimGotoFire: no stored value at all builds", () => {
+	assert.deepEqual(claimGotoFire(null, 1), { build: true, stamp: "1" });
+	assert.deepEqual(claimGotoFire("", 1), { build: true, stamp: "1" });
 });
 
 test("run:end auto-fires the redirect at most once, and never for an errored or stopped turn", () => {
@@ -163,12 +196,14 @@ test("run:end auto-fires the redirect at most once, and never for an errored or 
 	);
 	assert.match(runEnd, /if \(m && !m\.error && !m\.stopped\) \{/);
 	assert.match(runEnd, /const goto = gotoOf\(m\);/);
-	// durable stamp, keyed per message, checked before it is set
-	assert.match(runEnd, /const firedKey = gotoFiredKey\(m\.name\);/);
-	const stampIdx = runEnd.indexOf("localStorage.getItem(firedKey)");
-	const setIdx = runEnd.indexOf("localStorage.setItem(firedKey,");
+	// read-only: this gates the morph from replaying, but does not itself claim
+	// the stamp - gotoDashboards (via claimGotoFire) is the one place that
+	// happens now, so a manual card click and the live redirect race through
+	// the same claim (#912 round 2, finding #3)
+	assert.match(runEnd, /if \(goto && !localStorage\.getItem\(gotoFiredKey\(m\.name\)\)\) \{/);
+	assert.doesNotMatch(runEnd, /localStorage\.setItem\(/);
+	const gateIdx = runEnd.indexOf("if (goto && !localStorage.getItem(gotoFiredKey(m.name))) {");
 	const gotoIdx = runEnd.indexOf("gotoDashboards(goto.prompt, m.name);");
-	assert.notEqual(stampIdx, -1);
-	assert.ok(stampIdx < setIdx, "the stamp must be checked before it is written");
-	assert.ok(setIdx < gotoIdx, "the stamp must be written before the redirect fires");
+	assert.notEqual(gateIdx, -1);
+	assert.ok(gateIdx < gotoIdx, "the stamp must be checked before the redirect fires");
 });

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -861,6 +861,26 @@ test("send() learns the conversation a goto hand-off landed on and stamps it", (
 	assert.match(fnBody(paneSrc, "function sendText("), /send\(gotoMessageId\);/);
 });
 
+// jarvis#912 round 2, finding #3: gotoDashboards claims the fired-stamp
+// BEFORE this send() ever starts (see chatGoto.test.js's claimGotoFire
+// tests). A send that fails never reaches recordGotoConversation above, so
+// without this the claim would sit there un-resolved until its freshness
+// window lapses - fine for a dead tab, but needlessly slow for a failure this
+// function already knows about right here.
+test("send() forgets the goto claim on both failure exits, so a retry is not stuck behind it", () => {
+	const claim = fnBody(paneSrc, "function forgetGotoClaim(");
+	assert.match(claim, /if \(messageId\) localStorage\.removeItem\(gotoFiredKey\(messageId\)\);/);
+	const send = fnBody(paneSrc, "async function send(");
+	assert.equal((send.match(/forgetGotoClaim\(gotoMessageId\);/g) || []).length, 2);
+	// the rejected (r.ok === false) exit
+	const rejectedIdx = send.indexOf("if (r.ok === false) {");
+	const rejectedBranch = send.slice(rejectedIdx, send.indexOf("return;", rejectedIdx));
+	assert.match(rejectedBranch, /forgetGotoClaim\(gotoMessageId\);/);
+	// the thrown/network-failure exit
+	const catchBranch = send.slice(send.indexOf("} catch (e) {"));
+	assert.match(catchBranch, /forgetGotoClaim\(gotoMessageId\);/);
+});
+
 test("the page resolves a goto hand-off into resume/build/plain-restore, in that order", () => {
 	// gotoResume only when the STAMP names a conversation - `resume` alone
 	// (set by gotoDashboards whenever messageId was passed, even before a

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -782,12 +782,14 @@ test("a pending promotion holds the pane's restore off, exactly as ?edit= does",
 	assert.doesNotMatch(body, /promotionPending\.value = true;/);
 	// ...and a mount that will NOT promote releases the setup-time hold, or the
 	// pane's restore stays blocked for the life of the page. Since the
-	// jarvis-goto hand-off (#884), that branch then forks: a goto prefill
-	// starts a CLEAN builder (never the sticky editing restore), everything
-	// else restores as before - but the hold release always comes first.
+	// jarvis-goto hand-off (#884), that branch then forks: a FIRST-time goto
+	// prefill starts a CLEAN builder (never the sticky editing restore),
+	// everything else restores as before - but the hold release always comes
+	// first. jarvis#912 adds a third fork ahead of it: a REPEAT hand-off
+	// (gotoResume) resumes the recorded conversation instead of either.
 	assert.match(
 		pageSrc,
-		/promotionPending\.value = false;\n\t\tif \(gotoText\) \{[\s\S]*?clearBuilder\(\);\n\t\t\} else \{\n\t\t\tnormalMount\(\);\n\t\t\}/
+		/promotionPending\.value = false;\n\t\tif \(gotoResume\) \{[\s\S]*?resumeGotoHandoff\(gotoResume\.conv, gotoResume\.text, gotoMessageId\);\n\t\t\} else if \(gotoText\) \{[\s\S]*?clearBuilder\(\);\n\t\t\} else \{\n\t\t\tnormalMount\(\);\n\t\t\}/
 	);
 });
 
@@ -805,6 +807,111 @@ test("?edit= wins over ?chat=, and says so", () => {
 	// the mount path makes the same call
 	assert.match(pageSrc, /if \(routeEdit && routeChat\) \{\n\t\tconsole\.warn\(/);
 	assert.match(pageSrc, /if \(!routeEdit && routeChat && routeCanvas\) \{/);
+});
+
+// ---- jarvis#912: a repeat ```jarvis-goto hand-off resumes, not rebuilds ----
+//
+// One dashboard build used to produce several builder conversations: the
+// live auto-redirect (run:end, guarded by the fired stamp) built the first
+// one correctly, but the "Continue in Dashboards" card has no per-click
+// guard and stayed clickable on every later visit to the transcript. Each
+// extra click ran DashboardsPage's onMounted -> clearBuilder() -> sendText(),
+// which wiped the sticky builder conversation and posted the seeded prompt as
+// a message with conversation="" - a brand-new agent session (~78k tokens)
+// every time. The fix stashes which builder conversation the FIRST hand-off
+// for a given message landed on (the fired stamp - see chatGoto.test.js for
+// its shape) and has every later trigger for that SAME message resume it.
+
+test("gotoDashboards passes the message id through to the fired-stamp lookup", () => {
+	// see chatGoto.test.js for gotoDashboards' own body assertions - this only
+	// pins that BOTH call sites (the live redirect, the card button) pass the
+	// message id the stamp is keyed on, or the lookup has nothing to key off.
+	assert.match(chatSrc, /gotoDashboards\(goto\.prompt, m\.name\);/);
+	assert.match(chatSrc, /@click="gotoDashboards\(gotoOf\(m\)\.prompt, m\.name\)"/);
+});
+
+test("send() learns the conversation a goto hand-off landed on and stamps it", () => {
+	assert.match(
+		paneSrc,
+		/import \{ gotoFiredKey, parseFiredStamp, encodeFiredStamp \} from "@\/lib\/chatGoto";/
+	);
+	const record = fnBody(paneSrc, "function recordGotoConversation(");
+	assert.match(record, /if \(!messageId \|\| !conv\) return;/);
+	assert.match(record, /const key = gotoFiredKey\(messageId\);/);
+	// the fired-AT timestamp survives being upgraded to carry a conversation -
+	// only a stamp this send() itself just wrote (Date.now() fallback) invents
+	// a new one
+	assert.match(record, /const stamp = parseFiredStamp\(localStorage\.getItem\(key\)\);/);
+	assert.match(
+		record,
+		/localStorage\.setItem\(key, encodeFiredStamp\(stamp \? stamp\.t : Date\.now\(\), conv\)\);/
+	);
+	const send = fnBody(paneSrc, "async function send(");
+	assert.match(send, /async function send\(gotoMessageId = ""\)/);
+	// stamped with whatever conversation this send actually landed on - the
+	// REPOINTED id when send_message() opened a fresh one, the sticky one
+	// otherwise - not blindly the pre-send value
+	assert.match(
+		send,
+		/recordGotoConversation\(gotoMessageId, r\.conversation_id \|\| conversation\.value\);/
+	);
+	// sendText forwards it, and the Send button/Enter-key paths (message-less
+	// ordinary sends) pass none, which is a no-op inside recordGotoConversation
+	assert.match(paneSrc, /function sendText\(text, gotoMessageId = ""\)/);
+	assert.match(fnBody(paneSrc, "function sendText("), /send\(gotoMessageId\);/);
+});
+
+test("the page resolves a goto hand-off into resume/build/plain-restore, in that order", () => {
+	// gotoResume only when the STAMP names a conversation - `resume` alone
+	// (set by gotoDashboards whenever messageId was passed, even before a
+	// conversation exists) is not enough on its own.
+	assert.match(
+		pageSrc,
+		/const gotoResume =\n\t\tgotoClaimsCanvas && dashboardPrefill\.resume && dashboardPrefill\.conv\n\t\t\t\? \{ conv: dashboardPrefill\.conv, text: String\(dashboardPrefill\.text \|\| ""\)\.trim\(\) \}\n\t\t\t: null;/
+	);
+	// a FIRST-time hand-off (autoSend, no recorded conversation yet) still
+	// takes the pre-#912 clearBuilder() + sendText() path
+	assert.match(
+		pageSrc,
+		/const gotoText =\n\t\tgotoClaimsCanvas && !gotoResume && dashboardPrefill\.autoSend\n\t\t\t\? String\(dashboardPrefill\.text \|\| ""\)\.trim\(\)\n\t\t\t: "";/
+	);
+	const mount = fnBody(pageSrc, "onMounted(async () => {");
+	assert.match(mount, /if \(gotoResume\) \{/);
+	assert.match(mount, /resumeGotoHandoff\(gotoResume\.conv, gotoResume\.text, gotoMessageId\);/);
+	// gotoResume is checked BEFORE gotoText, so a repeat trigger can never fall
+	// through to a fresh clearBuilder() build
+	assert.ok(
+		mount.indexOf("if (gotoResume) {") < mount.indexOf("} else if (gotoText) {"),
+		"resume must be checked ahead of the fresh-build branch"
+	);
+	// the seeded first message (a first-time hand-off only) also carries the
+	// message id through, so ITS OWN send() records the stamp
+	assert.match(mount, /chatPane\.value\.sendText\(gotoText, gotoMessageId\);/);
+});
+
+test("resumeGotoHandoff repoints the sticky conversation, verified against the server first", () => {
+	const resume = fnBody(pageSrc, "async function resumeGotoHandoff(");
+	assert.match(resume, /await getDashboardConversation\(conv\);/);
+	// success (or a transient blip - not isGoneError): repoint, the pane's own
+	// watch(conversation, ...) tears the old thread down and loads the new one
+	assert.match(resume, /chatConv\.value = conv;/);
+	assert.match(resume, /dashDataMode\.value = "auto";/);
+});
+
+test("a recorded-but-deleted conversation falls back to a fresh build, and forgets the stale mapping", () => {
+	const resume = fnBody(pageSrc, "async function resumeGotoHandoff(");
+	assert.match(resume, /if \(isGoneError\(e\)\) \{/);
+	// the stamp named a conversation that is gone - remove the whole stamp
+	// (not just its conv half) so this degrades to a first-time hand-off,
+	// exactly as if the message had never fired before
+	assert.match(resume, /localStorage\.removeItem\(gotoFiredKey\(messageId\)\);/);
+	assert.match(resume, /clearBuilder\(\);/);
+	assert.match(resume, /chatPane\.value\.sendText\(text, messageId\);/);
+	// the fallback branch returns before the repoint below runs - never both
+	assert.ok(
+		resume.indexOf("return;") < resume.lastIndexOf("chatConv.value = conv;"),
+		"the deleted-conversation fallback must not also repoint onto the dead id"
+	);
 });
 
 test("the promotion is validated against the transcript, not the link", () => {

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -892,15 +892,16 @@ test("the page resolves a goto hand-off into resume/build/plain-restore, in that
 test("resumeGotoHandoff repoints the sticky conversation, verified against the server first", () => {
 	const resume = fnBody(pageSrc, "async function resumeGotoHandoff(");
 	assert.match(resume, /await getDashboardConversation\(conv\);/);
-	// success (or a transient blip - not isGoneError): repoint, the pane's own
-	// watch(conversation, ...) tears the old thread down and loads the new one
+	// success (or a transient blip - not isMissingConversation): repoint, the
+	// pane's own watch(conversation, ...) tears the old thread down and loads
+	// the new one
 	assert.match(resume, /chatConv\.value = conv;/);
 	assert.match(resume, /dashDataMode\.value = "auto";/);
 });
 
 test("a recorded-but-deleted conversation falls back to a fresh build, and forgets the stale mapping", () => {
 	const resume = fnBody(pageSrc, "async function resumeGotoHandoff(");
-	assert.match(resume, /if \(isGoneError\(e\)\) \{/);
+	assert.match(resume, /if \(isMissingConversation\(e\)\) \{/);
 	// the stamp named a conversation that is gone - remove the whole stamp
 	// (not just its conv half) so this degrades to a first-time hand-off,
 	// exactly as if the message had never fired before
@@ -912,6 +913,41 @@ test("a recorded-but-deleted conversation falls back to a fresh build, and forge
 		resume.indexOf("return;") < resume.lastIndexOf("chatConv.value = conv;"),
 		"the deleted-conversation fallback must not also repoint onto the dead id"
 	);
+});
+
+// jarvis#912 round 2, finding #1: resumeGotoHandoff used to reuse isGoneError
+// (row-deletion semantics: 404 OR a permission error) to decide the
+// conversation is gone. A conversation-specific 403 is not evidence of that -
+// a transient auth hiccup, a scope change - so it must NOT take the
+// fresh-build fallback above; isMissingConversation is narrower on purpose.
+test("resumeGotoHandoff's own gone-check excludes permission errors, unlike isGoneError", () => {
+	assert.match(
+		fnBody(pageSrc, "function isMissingConversation("),
+		/return !!\(e && \(e\.status === 404 \|\| e\.exc_type === "DoesNotExistError"\)\);/
+	);
+	assert.doesNotMatch(fnBody(pageSrc, "function isMissingConversation("), /isPermissionError/);
+	// isGoneError itself is untouched - other callers (resumeAdoption, openSave,
+	// promoteFromChat's adoption) still want the row-deletion semantics
+	assert.match(fnBody(pageSrc, "function isGoneError("), /isPermissionError\(e\)/);
+});
+
+// jarvis#912 round 2, finding #2: resumeGotoHandoff repointed chatConv but
+// never cleared editSeed - left set from setup (a sticky ?edit target, or
+// none), onCanvas's restore guard (builderHtml || editSeed ||
+// promotionPending) refused to put the resumed build's canvas up at all.
+test("resumeGotoHandoff clears the fields that would block the resumed canvas from restoring", () => {
+	const resume = fnBody(pageSrc, "async function resumeGotoHandoff(");
+	assert.match(resume, /editSeed\.value = "";\n\tbuilderHtml\.value = "";/);
+	// cleared before the repoint, and never via clearBuilder() (that would also
+	// wipe chatConv/the conversation this function exists to resume)
+	assert.ok(
+		resume.indexOf('editSeed.value = "";') < resume.indexOf("chatConv.value = conv;"),
+		"editSeed must be cleared before the repoint, or a restore racing it could still be blocked"
+	);
+	const onCanvasGuard = fnBody(pageSrc, "async function onCanvas(").match(
+		/if \(restore && \(builderHtml\.value \|\| editSeed\.value \|\| promotionPending\.value\)\) return false;/
+	);
+	assert.ok(onCanvasGuard, "onCanvas's restore guard must still be exactly what this resets");
 });
 
 test("the promotion is validated against the transcript, not the link", () => {

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -220,7 +220,7 @@
 					label="Send"
 					:disabled="!draft.trim() || sending || runActive"
 					:loading="sending"
-					@click="send"
+					@click="send()"
 				/>
 			</div>
 		</div>
@@ -262,6 +262,7 @@ import AskCard from "@/components/chat/AskCard.vue";
 import { renderMarkdown } from "@/markdown";
 import { parseAsk } from "@/lib/chatAsk";
 import { builderCanvasFrame } from "@/lib/dashboardRestore";
+import { gotoFiredKey, parseFiredStamp, encodeFiredStamp } from "@/lib/chatGoto";
 import {
 	DASHBOARD_BUILD_PHASES,
 	dashboardBuildPhase,
@@ -615,7 +616,20 @@ function onTranscript(text) {
 // screen, so the follow watcher below must not tear its Thinking indicator down.
 let ownRepoint = false;
 
-async function send() {
+// jarvis#912: the fired stamp's conversation slot (see lib/chatGoto.js) is
+// written here, the one place a send() call learns which conversation a
+// ```jarvis-goto message's hand-off actually landed on - fresh or repointed.
+// `messageId` comes from sendText()'s caller; a message-less send (the
+// ordinary composer, AskCard answers, the save dialog's "fix in chat") passes
+// none and this is a no-op.
+function recordGotoConversation(messageId, conv) {
+	if (!messageId || !conv) return;
+	const key = gotoFiredKey(messageId);
+	const stamp = parseFiredStamp(localStorage.getItem(key));
+	localStorage.setItem(key, encodeFiredStamp(stamp ? stamp.t : Date.now(), conv));
+}
+
+async function send(gotoMessageId = "") {
 	const text = draft.value.trim();
 	if (!text || sending.value || runActive.value) return;
 	sending.value = true;
@@ -644,6 +658,7 @@ async function send() {
 			ownRepoint = true;
 			conversation.value = r.conversation_id;
 		}
+		recordGotoConversation(gotoMessageId, r.conversation_id || conversation.value);
 		runActive.value = true;
 		// This send's own optimistic start - a run:start frame for the same run
 		// arrives moments later and does the same reset, but the ticks should
@@ -702,13 +717,15 @@ watch(conversation, (id, prev) => {
 });
 
 // Post a message into this pane programmatically (the save dialog's "Ask the
-// assistant to fix these" hand-off, AskCard's answer submit). Ignored while a
-// send is already in flight OR a turn is still running for this conversation.
-function sendText(text) {
+// assistant to fix these" hand-off, AskCard's answer submit, a ```jarvis-goto
+// hand-off's seeded first message). Ignored while a send is already in flight
+// OR a turn is still running for this conversation. `gotoMessageId` names the
+// goto message this send answers (jarvis#912) - see recordGotoConversation.
+function sendText(text, gotoMessageId = "") {
 	const t = String(text || "").trim();
 	if (!t || sending.value || runActive.value) return;
 	draft.value = t;
-	send();
+	send(gotoMessageId);
 }
 // Re-issue the transcript's restore frame. The page holds restores off while a
 // ?chat=&canvas= promotion is in flight (an explicit deep-link owns the canvas);

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -629,6 +629,16 @@ function recordGotoConversation(messageId, conv) {
 	localStorage.setItem(key, encodeFiredStamp(stamp ? stamp.t : Date.now(), conv));
 }
 
+// jarvis#912 round 2: undo the provisional claim gotoDashboards (ChatView.vue)
+// writes before a goto-seeded send() ever starts. A send that fails never
+// reaches recordGotoConversation above, so without this the claim would sit
+// there un-resolved - within its freshness window (claimGotoFire) that just
+// reads as "still in flight" and self-heals, but permanently blocking a retry
+// is not worth waiting out a window for when the failure is known right here.
+function forgetGotoClaim(messageId) {
+	if (messageId) localStorage.removeItem(gotoFiredKey(messageId));
+}
+
 async function send(gotoMessageId = "") {
 	const text = draft.value.trim();
 	if (!text || sending.value || runActive.value) return;
@@ -651,6 +661,7 @@ async function send(gotoMessageId = "") {
 			// rejected (single-flight guard / usage cap) - nothing persisted
 			messages.value = messages.value.filter((m) => m.name !== tmpName);
 			if (!draft.value) draft.value = text;
+			forgetGotoClaim(gotoMessageId);
 			toast.error(r.reason || "Couldn't send your message.");
 			return;
 		}
@@ -671,6 +682,7 @@ async function send(gotoMessageId = "") {
 	} catch (e) {
 		messages.value = messages.value.filter((m) => m.name !== tmpName);
 		if (!draft.value) draft.value = text;
+		forgetGotoClaim(gotoMessageId);
 		toast.error(errHtml(e));
 	} finally {
 		sending.value = false;

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -749,6 +749,16 @@ function isGoneError(e) {
 	);
 }
 
+// resumeGotoHandoff's own gone-check, narrower than isGoneError above: a
+// conversation-specific 403 is not evidence the conversation was deleted (a
+// transient auth hiccup, a scope change), so treating it the same as a 404
+// forgot the stamp and silently started a fresh build over an in-progress one
+// instead of just retrying (#912 round 2, finding #1). Only a genuine
+// does-not-exist degrades to a fresh build.
+function isMissingConversation(e) {
+	return !!(e && (e.status === 404 || e.exc_type === "DoesNotExistError"));
+}
+
 // jarvis#912: resuming a ```jarvis-goto hand-off that already has a recorded
 // builder conversation (the fired stamp carries one - see lib/chatGoto.js and
 // gotoDashboards in ChatView.vue), instead of building a duplicate. Verified
@@ -763,7 +773,7 @@ async function resumeGotoHandoff(conv, text, messageId) {
 	try {
 		await getDashboardConversation(conv);
 	} catch (e) {
-		if (isGoneError(e)) {
+		if (isMissingConversation(e)) {
 			// Gone - forget the stale mapping and fall back to a fresh build,
 			// exactly the path a first-time hand-off for this message takes.
 			if (messageId) localStorage.removeItem(gotoFiredKey(messageId));
@@ -774,7 +784,20 @@ async function resumeGotoHandoff(conv, text, messageId) {
 			});
 			return;
 		}
+		// Anything else (403, network blip, ...) falls through to the repoint
+		// below instead of forgetting the stamp - the pane's own loadTranscript()
+		// surfaces the failure (it retries, then degrades to its own gone-check)
+		// so a transient hiccup never silently drops the in-progress build.
 	}
+	// A resumed conversation is a different document than whatever this mount's
+	// setup seeded editSeed from (a sticky ?edit target, or nothing): left set,
+	// onCanvas's restore guard (builderHtml || editSeed || promotionPending)
+	// refuses to put the resumed build's canvas up at all (#912 round 2,
+	// finding #2). Reset only the two fields that guard checks - not the rest
+	// of what clearBuilder resets, which would also wipe the conversation this
+	// function exists to resume.
+	editSeed.value = "";
+	builderHtml.value = "";
 	// Same repoint idiom applyEditDetail uses for `d.source_conversation`: the
 	// pane's own watch(conversation, ...) does the rest (clears the thread on
 	// screen, loads the resumed one). Nothing is unsaved yet on a fresh mount,

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -213,6 +213,7 @@ import { getCanvas } from "@/api";
 import { agentName } from "@/branding";
 import { getDashboardsCaps, getDashboard, getDashboardConversation } from "@/api/dashboards";
 import { takeDashboardPrefill } from "@/composables/dashboardPrefill";
+import { gotoFiredKey } from "@/lib/chatGoto";
 import { builderCanvasFrame } from "@/lib/dashboardRestore";
 import {
 	adoptionIdentity,
@@ -748,6 +749,40 @@ function isGoneError(e) {
 	);
 }
 
+// jarvis#912: resuming a ```jarvis-goto hand-off that already has a recorded
+// builder conversation (the fired stamp carries one - see lib/chatGoto.js and
+// gotoDashboards in ChatView.vue), instead of building a duplicate. Verified
+// against the server first, the same way resumeAdoption verifies a sticky
+// name: a repeat click racing the row's deletion, or a stamp left over from a
+// conversation the user has since removed, must not repoint onto nothing.
+//
+// A transient failure keeps the stamp and repoints anyway - the pane's own
+// loadTranscript() retries the fetch and degrades to isGone there if the blip
+// turns out to be permanent, exactly as an ordinary chatConv repoint would.
+async function resumeGotoHandoff(conv, text, messageId) {
+	try {
+		await getDashboardConversation(conv);
+	} catch (e) {
+		if (isGoneError(e)) {
+			// Gone - forget the stale mapping and fall back to a fresh build,
+			// exactly the path a first-time hand-off for this message takes.
+			if (messageId) localStorage.removeItem(gotoFiredKey(messageId));
+			clearBuilder();
+			nextTick(() => {
+				if (chatPane.value && chatPane.value.sendText)
+					chatPane.value.sendText(text, messageId);
+			});
+			return;
+		}
+	}
+	// Same repoint idiom applyEditDetail uses for `d.source_conversation`: the
+	// pane's own watch(conversation, ...) does the rest (clears the thread on
+	// screen, loads the resumed one). Nothing is unsaved yet on a fresh mount,
+	// so no discard confirm.
+	chatConv.value = conv;
+	dashDataMode.value = "auto";
+}
+
 // The third mount path: coming back to an ADOPTED promotion (resumesAdoption
 // above). What was on the canvas is the transcript's build, NEWER than the row
 // it adopted, so loadEdit is the wrong restore - it would answer with the row's
@@ -1111,10 +1146,20 @@ onMounted(async () => {
 	// canvas - an ?edit= target or a ?chat=&canvas= promotion IS what the user
 	// asked to land on, and a queued prompt must not race a message into
 	// whatever thread that resolves to instead.
+	const gotoClaimsCanvas = !routeEdit && !(routeChat && routeCanvas) && !!dashboardPrefill;
+	// jarvis#912: a REPEAT hand-off for a message that already built a builder
+	// conversation resumes it instead - see resumeGotoHandoff above. `text`
+	// rides along on this shape too, as the fallback build if that conversation
+	// turns out to have been deleted.
+	const gotoResume =
+		gotoClaimsCanvas && dashboardPrefill.resume && dashboardPrefill.conv
+			? { conv: dashboardPrefill.conv, text: String(dashboardPrefill.text || "").trim() }
+			: null;
 	const gotoText =
-		!routeEdit && !(routeChat && routeCanvas) && dashboardPrefill && dashboardPrefill.autoSend
+		gotoClaimsCanvas && !gotoResume && dashboardPrefill.autoSend
 			? String(dashboardPrefill.text || "").trim()
 			: "";
+	const gotoMessageId = gotoClaimsCanvas ? dashboardPrefill.messageId || "" : "";
 	if (!routeEdit && routeChat && routeCanvas) {
 		promoteFromChat(routeChat, routeCanvas, { fallback: normalMount, dash: routeDash });
 	} else {
@@ -1122,12 +1167,16 @@ onMounted(async () => {
 		// present): release the hold taken at setup, or the pane's restore stays
 		// blocked for the life of the page.
 		promotionPending.value = false;
-		if (gotoText) {
-			// A goto hand-off is always a NEW build. Restoring the sticky editing
-			// target (or the previous thread under it) would land the seeded
-			// request as a revision of an older dashboard, so start clean instead
-			// of normalMount(). Nothing is unsaved at this instant - the page just
-			// mounted - so no discard confirm.
+		if (gotoResume) {
+			// Resuming an existing thread, not building - normalMount() (the
+			// sticky editing target) would fight it for the canvas.
+			resumeGotoHandoff(gotoResume.conv, gotoResume.text, gotoMessageId);
+		} else if (gotoText) {
+			// A first-time goto hand-off is always a NEW build. Restoring the
+			// sticky editing target (or the previous thread under it) would land
+			// the seeded request as a revision of an older dashboard, so start
+			// clean instead of normalMount(). Nothing is unsaved at this instant -
+			// the page just mounted - so no discard confirm.
 			clearBuilder();
 		} else {
 			normalMount();
@@ -1135,7 +1184,8 @@ onMounted(async () => {
 	}
 	if (gotoText) {
 		nextTick(() => {
-			if (chatPane.value && chatPane.value.sendText) chatPane.value.sendText(gotoText);
+			if (chatPane.value && chatPane.value.sendText)
+				chatPane.value.sendText(gotoText, gotoMessageId);
 		});
 	}
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4134,7 +4134,7 @@ import AskCard from "@/components/chat/AskCard.vue";
 import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
-import { parseGoto, gotoFiredKey, parseFiredStamp, encodeFiredStamp } from "@/lib/chatGoto";
+import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { shouldFollowBottom } from "@/lib/chatScroll";
@@ -6036,14 +6036,43 @@ function gotoOf(m) {
 // hand-off for this message landed on: a later trigger navigates there
 // instead of building again. `messageId` is optional only for callers that
 // predate #912's stamp lookup; every real caller below passes it.
+//
+// jarvis#912 round 2: TWO triggers for the same message this close together
+// (a double-click - the card still has no per-click guard) used to both read
+// "no stamp" and each start a build. claimGotoFire() closes that: it is the
+// ONE place a fresh build ever gets stamped, so the second caller in the
+// window always sees the first one's claim, whichever of the two fired
+// first. When the claim is already someone else's and no conversation is
+// recorded yet (that someone's send() is still in flight), this only
+// navigates - the prefill slot is left alone so the claimant's own payload
+// (set moments earlier, in the same tick or the one before) is what the
+// single resulting mount actually consumes.
 function gotoDashboards(prompt, messageId) {
-	const stamp = messageId
-		? parseFiredStamp(localStorage.getItem(gotoFiredKey(messageId)))
-		: null;
-	if (stamp && stamp.conv) {
-		setDashboardPrefill({ text: prompt, resume: true, conv: stamp.conv, messageId });
-	} else {
+	const key = messageId ? gotoFiredKey(messageId) : null;
+	const claim = key ? claimGotoFire(localStorage.getItem(key)) : { build: true };
+	if (claim.build) {
+		if (key) {
+			localStorage.setItem(key, claim.stamp);
+			// Bounded stamp set: these keys are write-once per redirect and
+			// would otherwise accumulate for the life of the origin. Keep the
+			// newest ~50 (the fired-stamp check above is the real guard; this
+			// only defends reloads of RECENT transcripts).
+			const stamps = [];
+			for (let i = 0; i < localStorage.length; i++) {
+				const k = localStorage.key(i);
+				if (k && k.startsWith("jarvis:goto-fired:")) {
+					const parsed = parseFiredStamp(localStorage.getItem(k));
+					stamps.push([k, parsed ? parsed.t : 0]);
+				}
+			}
+			stamps
+				.sort((a, b) => b[1] - a[1])
+				.slice(50)
+				.forEach(([k]) => localStorage.removeItem(k));
+		}
 		setDashboardPrefill({ text: prompt, autoSend: true, messageId });
+	} else if (claim.conv) {
+		setDashboardPrefill({ text: prompt, resume: true, conv: claim.conv, messageId });
 	}
 	router.push("/dashboards");
 }
@@ -8961,6 +8990,12 @@ function onEvent(p) {
 			// reaches this branch, so an old message opened again never gets here at
 			// all, but the stamp is the belt-and-braces the spec asks for.
 			//
+			// jarvis#912 round 2: this check is READ-ONLY. The stamp itself is
+			// claimed inside gotoDashboards (via claimGotoFire - see lib/chatGoto.js)
+			// now, the one place a manual card click races through too, so there is
+			// exactly one place a fresh build ever gets stamped. Left here, this
+			// still stops the morph from replaying for a message already handled.
+			//
 			// `redirected` tracks whether THIS run:end is the one that actually
 			// navigates, so the gotoMorph latch below can tell the two cases apart:
 			// the navigating path keeps the latch (it must survive the instant up to
@@ -8973,48 +9008,24 @@ function onEvent(p) {
 			let redirected = false;
 			if (m && !m.error && !m.stopped) {
 				const goto = gotoOf(m);
-				if (goto) {
-					const firedKey = gotoFiredKey(m.name);
-					if (!localStorage.getItem(firedKey)) {
-						// No conversation id yet - send_message() has not run, so this
-						// is a bare "fired" stamp exactly like pre-#912. The pane fills
-						// in the conversation once it learns one (see
-						// DashboardChatPane.vue's send()).
-						localStorage.setItem(firedKey, encodeFiredStamp(Date.now()));
-						// Bounded stamp set: these keys are write-once per redirect and
-						// would otherwise accumulate for the life of the origin. Keep
-						// the newest ~50 (the live-turn gate above is the real guard;
-						// the stamp only defends reloads of RECENT transcripts).
-						const stamps = [];
-						for (let i = 0; i < localStorage.length; i++) {
-							const k = localStorage.key(i);
-							if (k && k.startsWith("jarvis:goto-fired:")) {
-								const parsed = parseFiredStamp(localStorage.getItem(k));
-								stamps.push([k, parsed ? parsed.t : 0]);
-							}
-						}
-						stamps
-							.sort((a, b) => b[1] - a[1])
-							.slice(50)
-							.forEach(([k]) => localStorage.removeItem(k));
-						redirected = true;
-						// Latch explicitly: when the block lands WITH the terminal, the
-						// streaming watcher never saw it, and the hold below is the
-						// morph line's only screen time.
-						gotoMorph.value = goto;
-						const reducedMotion =
-							window.matchMedia &&
-							window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-						if (reducedMotion) {
-							gotoDashboards(goto.prompt, m.name);
-						} else {
-							gotoNavTimer = setTimeout(() => {
-								gotoNavTimer = null;
-								// dropGotoMorph() clearing the latch (new turn, chat switch,
-								// unmount) is the cancel signal for this pending navigation.
-								if (gotoMorph.value) gotoDashboards(goto.prompt, m.name);
-							}, GOTO_MORPH_HOLD_MS);
-						}
+				if (goto && !localStorage.getItem(gotoFiredKey(m.name))) {
+					redirected = true;
+					// Latch explicitly: when the block lands WITH the terminal, the
+					// streaming watcher never saw it, and the hold below is the
+					// morph line's only screen time.
+					gotoMorph.value = goto;
+					const reducedMotion =
+						window.matchMedia &&
+						window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+					if (reducedMotion) {
+						gotoDashboards(goto.prompt, m.name);
+					} else {
+						gotoNavTimer = setTimeout(() => {
+							gotoNavTimer = null;
+							// dropGotoMorph() clearing the latch (new turn, chat switch,
+							// unmount) is the cancel signal for this pending navigation.
+							if (gotoMorph.value) gotoDashboards(goto.prompt, m.name);
+						}, GOTO_MORPH_HOLD_MS);
 					}
 				}
 			}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1474,7 +1474,11 @@
 								     here with ```jarvis-goto. Stays clickable in history so an
 								     old transcript still has a way through, even though the
 								     redirect itself only auto-fires once, live (see gotoDashboards
-								     / the run:end handler). -->
+								     / the run:end handler). jarvis#912: every click on an old card
+								     hands off through the same fired-stamp lookup as the live
+								     redirect, so a second/third click resumes the builder
+								     conversation the first hand-off created instead of starting a
+								     new one. -->
 								<div v-if="gotoOf(m)" class="jv-macrocard">
 									<div class="jv-macrocard-ic">
 										<svg
@@ -1500,7 +1504,7 @@
 									</div>
 									<button
 										class="jv-macrocard-btn"
-										@click="gotoDashboards(gotoOf(m).prompt)"
+										@click="gotoDashboards(gotoOf(m).prompt, m.name)"
 									>
 										Open Dashboards
 									</button>
@@ -4130,7 +4134,7 @@ import AskCard from "@/components/chat/AskCard.vue";
 import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
 import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
-import { parseGoto } from "@/lib/chatGoto";
+import { parseGoto, gotoFiredKey, parseFiredStamp, encodeFiredStamp } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { shouldFollowBottom } from "@/lib/chatScroll";
@@ -6022,8 +6026,25 @@ function gotoOf(m) {
 // Shared by the card's button and the run:end auto-redirect below: stash the
 // restated request for the Dashboards builder to pick up on its own mount,
 // then navigate there.
-function gotoDashboards(prompt) {
-	setDashboardPrefill({ text: prompt, autoSend: true });
+//
+// jarvis#912: the card button has no per-click guard (the run:end
+// auto-redirect fires once, live, but the card stays clickable on every
+// later visit to the transcript), so a second/third click used to build a
+// brand-new builder conversation each time - discarding the in-progress one
+// and burning a fresh ~78k-token agent session per click. The fired stamp
+// (see lib/chatGoto.js) now remembers which builder conversation the FIRST
+// hand-off for this message landed on: a later trigger navigates there
+// instead of building again. `messageId` is optional only for callers that
+// predate #912's stamp lookup; every real caller below passes it.
+function gotoDashboards(prompt, messageId) {
+	const stamp = messageId
+		? parseFiredStamp(localStorage.getItem(gotoFiredKey(messageId)))
+		: null;
+	if (stamp && stamp.conv) {
+		setDashboardPrefill({ text: prompt, resume: true, conv: stamp.conv, messageId });
+	} else {
+		setDashboardPrefill({ text: prompt, autoSend: true, messageId });
+	}
 	router.push("/dashboards");
 }
 // Canonicalised at the single _ACTION_RE parse point so every consumer (render
@@ -8953,9 +8974,13 @@ function onEvent(p) {
 			if (m && !m.error && !m.stopped) {
 				const goto = gotoOf(m);
 				if (goto) {
-					const firedKey = "jarvis:goto-fired:" + m.name;
+					const firedKey = gotoFiredKey(m.name);
 					if (!localStorage.getItem(firedKey)) {
-						localStorage.setItem(firedKey, String(Date.now()));
+						// No conversation id yet - send_message() has not run, so this
+						// is a bare "fired" stamp exactly like pre-#912. The pane fills
+						// in the conversation once it learns one (see
+						// DashboardChatPane.vue's send()).
+						localStorage.setItem(firedKey, encodeFiredStamp(Date.now()));
 						// Bounded stamp set: these keys are write-once per redirect and
 						// would otherwise accumulate for the life of the origin. Keep
 						// the newest ~50 (the live-turn gate above is the real guard;
@@ -8963,8 +8988,10 @@ function onEvent(p) {
 						const stamps = [];
 						for (let i = 0; i < localStorage.length; i++) {
 							const k = localStorage.key(i);
-							if (k && k.startsWith("jarvis:goto-fired:"))
-								stamps.push([k, Number(localStorage.getItem(k)) || 0]);
+							if (k && k.startsWith("jarvis:goto-fired:")) {
+								const parsed = parseFiredStamp(localStorage.getItem(k));
+								stamps.push([k, parsed ? parsed.t : 0]);
+							}
 						}
 						stamps
 							.sort((a, b) => b[1] - a[1])
@@ -8979,13 +9006,13 @@ function onEvent(p) {
 							window.matchMedia &&
 							window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 						if (reducedMotion) {
-							gotoDashboards(goto.prompt);
+							gotoDashboards(goto.prompt, m.name);
 						} else {
 							gotoNavTimer = setTimeout(() => {
 								gotoNavTimer = null;
 								// dropGotoMorph() clearing the latch (new turn, chat switch,
 								// unmount) is the cancel signal for this pending navigation.
-								if (gotoMorph.value) gotoDashboards(goto.prompt);
+								if (gotoMorph.value) gotoDashboards(goto.prompt, m.name);
 							}, GOTO_MORPH_HOLD_MS);
 						}
 					}


### PR DESCRIPTION
Fixes #912

One dashboard build no longer spawns a new builder conversation (and a fresh ~78k-token agent session) on every "Open Dashboards" click: the hand-off now remembers the conversation it created and resumes it.

## What changed
- The per-message fired-stamp now also records the builder conversation id once the first send lands (backward compatible with old bare stamps).
- A repeat trigger for the same message resumes that conversation instead of clearing the builder and re-sending; the pane loads its history.
- A recorded-but-deleted conversation forgets the stale stamp and falls back to a fresh build.
- The auto-redirect first-fire path is unchanged.

## Risk and verification
- 1357 vitest + 780 node tests pass on Node 24, after rebasing onto develop tip 6b660dae; prettier (pre-commit) clean.
- Live-verified on e2e2.localhost against the real bench build: click 1 created + recorded conversation 5inm2or48d; clicks 2 and 3 resumed it with history shown; conversation and session counts stayed flat (screenshots below).

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (rebased onto develop tip 6b660dae)
- [x] New/changed behavior has tests (stamp codec units + the three scenario cases)
- [x] I self-reviewed the diff

## Screenshots (live verification on e2e2.localhost)

Main chat with the goto card (source conversation):

<img width="855" alt="chat with Continue in Dashboards card" src="https://github.com/user-attachments/assets/00f93111-01cf-496c-bddd-6c4a3d14c304" />

First click: builder conversation created and recorded:

<img width="855" alt="builder after first open" src="https://github.com/user-attachments/assets/96c22c3a-120a-42f3-aea7-4fe174497e46" />

After clicks 2 and 3: SAME conversation resumed with history (interview visible), conversation and session counts unchanged:

<img width="855" alt="resumed builder after three clicks" src="https://github.com/user-attachments/assets/ecd1d4d0-ca28-47b8-bc68-d44fecec8dea" />