### PR TITLE
feat: link the checkout T&C straight to the marketing terms page

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2007,11 +2007,12 @@ const state = reactive({
 	// contact consent (owner decision 2026-08-14): the terms cover being
 	// contacted about the account.
 	termsAccepted: false,
-	// The admin-hosted /terms URL (jarvis.onboarding.get_terms_url), fetched
-	// best-effort on mount so it is already available by the time the Details
-	// step (the second screen) renders. Empty when admin is unreachable/
-	// unconfigured - the checkbox label then renders plain unlinked text
-	// instead of a dead link.
+	// The public /terms URL (marketing site, or a rebranded admin's own
+	// /terms), via jarvis.onboarding.get_terms_url, fetched best-effort on
+	// mount so it is already available by the time the Details step (the
+	// second screen) renders. Empty only if that API call itself fails -
+	// the checkbox label then renders plain unlinked text instead of a
+	// dead link.
 	termsUrl: "",
 	// Gateways the operator has actually enabled, narrowed to what this build can
 	// render. Starts EMPTY and stays empty on a discovery failure (plan 02 P2-6):

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -590,17 +590,39 @@ def capture_onboarding_lead(
 		return {"ok": False}
 
 
+# The Terms of Service moved from the admin plane to the public marketing site
+# (jarvis_frappe_cloud); linking it directly skips admin's compatibility 301.
+MARKETING_TERMS_URL = "https://jarvis.aerele.in/terms"
+# Aerele's own stock admin origin. Deliberately a literal, NOT imported from
+# hooks: rebranding is documented as either a jarvis_admin_url override OR
+# editing hooks' fallback constant, and a rebrand of the second kind must not
+# compare equal to "stock" here. The flip side of that independence: if Aerele
+# ever migrates its admin domain, update this literal alongside hooks'
+# fallback. Drift in either direction is benign - the link falls back to
+# <admin>/terms, whose compatibility 301 still lands on the right document.
+_AERELE_STOCK_ADMIN_URL = "https://fleet.klerk.in"
+
+
 def terms_url() -> str:
-	"""The admin-hosted Terms & Conditions page for the Review & Pay checkbox
-	link. Best-effort: returns "" on any failure (no admin URL configured, a
-	malformed one, ...) rather than raising - the checkbox must render, and the
-	view falls back to plain unlinked text when this is empty."""
+	"""The public Terms & Conditions page for the Details-step checkbox link.
+
+	Aerele's stock deployment links the marketing site directly - its admin
+	plane only 301s ``/terms`` there anyway, so the hop is pure latency. A
+	rebranded deployment (admin base resolving anywhere other than Aerele's
+	stock admin, whichever documented rebrand path set it) keeps
+	``<its admin>/terms`` so its own legal page stays authoritative.
+	Best-effort like before: any failure falls back to the marketing URL
+	rather than blanking the checkout's T&C link."""
 	try:
 		settings = frappe.get_single("Jarvis Settings")
 		base = _admin_url(settings)
-		return f"{base}/terms" if base else ""
+		# Case-insensitive: scheme and host are case-insensitive per RFC 3986,
+		# and a differently-cased stock URL must not read as a rebrand.
+		if base and base.lower() != _AERELE_STOCK_ADMIN_URL:
+			return f"{base}/terms"
 	except Exception:
-		return ""
+		pass
+	return MARKETING_TERMS_URL
 
 
 # Admin-owned preset catalog (spec 3.3). Guest-safe fetch (get_plans pattern),

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -380,9 +380,9 @@ def capture_onboarding_lead(
 
 @frappe.whitelist()
 def get_terms_url() -> dict:
-	"""The admin-hosted Terms & Conditions URL for the Details-step checkbox
-	link. Best-effort: ``{"url": ""}`` on any failure so the checkbox still
-	renders (with plain unlinked text) when admin is unreachable or unconfigured."""
+	"""The public Terms & Conditions URL (marketing site) for the Details-step
+	checkbox link. Best-effort: ``{"url": ""}`` on any failure so the checkbox
+	still renders (with plain unlinked text)."""
 	try:
 		return {"url": admin_client.terms_url()}
 	except Exception:

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -2235,3 +2235,49 @@ class TestFixturesCannotDestroySiteCredentials(FrappeTestCase):
 		with patch("frappe.get_single", _REAL_GET_SINGLE):
 			with self.assertRaises(RuntimeError):
 				_settings_clear_admin()
+
+
+class TestTermsUrl(FrappeTestCase):
+	"""terms_url() is the one legal-page URL the checkout flow hands out.
+
+	The terms moved to the public marketing site (2026-08-17): Aerele's stock
+	deployment must link it directly (the admin plane only 301s /terms
+	there), while a rebranded deployment (admin base resolving away from
+	Aerele's stock admin, by either documented rebrand path) keeps its own
+	admin's /terms.
+	"""
+
+	def test_stock_default_links_the_marketing_site_directly(self):
+		with patch.object(admin_client, "_admin_url", return_value=admin_client._AERELE_STOCK_ADMIN_URL):
+			self.assertEqual(admin_client.terms_url(), admin_client.MARKETING_TERMS_URL)
+
+	def test_rebrand_by_editing_hooks_fallback_is_still_a_rebrand(self):
+		"""hooks.py documents a second rebrand path: edit its fallback constant
+		and ship. The stock check must compare against Aerele's literal admin
+		origin, not whatever hooks currently returns, or that rebrand would
+		silently link Aerele's terms."""
+		with (
+			patch("jarvis.hooks._DEFAULT_ADMIN_URL_FALLBACK", "https://erp.reseller.example"),
+			patch.object(admin_client, "_admin_url", return_value="https://erp.reseller.example"),
+		):
+			self.assertEqual(admin_client.terms_url(), "https://erp.reseller.example/terms")
+
+	def test_rebranded_admin_keeps_its_own_terms_page(self):
+		with patch.object(admin_client, "_admin_url", return_value="https://erp.reseller.example"):
+			self.assertEqual(admin_client.terms_url(), "https://erp.reseller.example/terms")
+
+	def test_stock_admin_in_different_case_is_still_stock(self):
+		"""Scheme and host are case-insensitive (RFC 3986); a shouty-cased
+		stock config must not be misread as a rebrand."""
+		with patch.object(admin_client, "_admin_url", return_value="https://Fleet.Klerk.IN"):
+			self.assertEqual(admin_client.terms_url(), admin_client.MARKETING_TERMS_URL)
+
+	def test_unconfigured_admin_falls_back_to_the_marketing_url(self):
+		with patch.object(admin_client, "_admin_url", return_value=""):
+			self.assertEqual(admin_client.terms_url(), admin_client.MARKETING_TERMS_URL)
+
+	def test_a_settings_failure_never_blanks_the_link(self):
+		"""The old implementation returned "" on any failure; the marketing
+		URL is now the worst case, so the checkout link never goes dead."""
+		with patch("frappe.get_single", side_effect=RuntimeError("settings down")):
+			self.assertEqual(admin_client.terms_url(), admin_client.MARKETING_TERMS_URL)


### PR DESCRIPTION
## Summary

The onboarding Details-step T&C link now resolves to the terms page directly instead of bouncing through the admin plane's 301: `terms_url()` returns `https://jarvis.aerele.in/terms` for Aerele's stock deployment (the terms moved there in Aerele-RnD/jarvis_frappe_cloud#1; Aerele-RnD/jarvis-admin-v2#379 left only a compatibility redirect behind).

- A rebranded deployment (admin base resolving anywhere other than Aerele's stock admin, by either documented rebrand path) keeps `<its admin>/terms`, so a white-label's own legal page stays authoritative. The stock check is case-insensitive.
- Any failure now falls back to the marketing URL instead of `""`, so the checkout link never goes dead.
- Six new `TestTermsUrl` tests cover stock, both rebrand paths, case variance, unconfigured, and settings-failure branches.

**Merge order:** only after jarvis_frappe_cloud#1 is deployed (the target must be live). Until this deploys, tenants keep working through admin's 301, so there is no urgency coupling.

Pipeline: plan + three adversarial review rounds + flow evidence recorded in `.claude/workflow/` (verdicts GREEN).

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_011QuHM1oB5Y11PwcoZcs2ha
