### PR TITLE
Heal the onboarding wizard's return from a failed/pending payment

### DIFF
--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -39,7 +39,8 @@ function isInternalCrash(e) {
 // duplication #699 exists to remove, and one that would have failed silently
 // (falling back to the generic sentence) the day the wording changed. Pass the
 // custom sentence in as `fallback` instead.
-export const GENERIC_ERROR_MESSAGE = "Something went wrong. Please try again.";
+export const GENERIC_ERROR_MESSAGE =
+	"Something went wrong. Try again, and check back if it keeps happening.";
 
 export function errMessage(e, fallback = GENERIC_ERROR_MESSAGE) {
 	// The server's OWN explicit message always wins, even on a 401/403 (round-4

--- a/frontend/src/lib/errors.test.js
+++ b/frontend/src/lib/errors.test.js
@@ -6,7 +6,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { errMessage, turnErrorInfo } from "./errors.js";
+import { errMessage, turnErrorInfo, GENERIC_ERROR_MESSAGE } from "./errors.js";
 
 test("extracts the first server message when present", () => {
 	assert.equal(errMessage({ messages: ["Settings -> Developer"] }), "Settings -> Developer");
@@ -17,8 +17,8 @@ test("falls back to e.message when there are no server messages", () => {
 });
 
 test("falls back to a generic sentence for a falsy error", () => {
-	assert.equal(errMessage(null), "Something went wrong. Please try again.");
-	assert.equal(errMessage(undefined), "Something went wrong. Please try again.");
+	assert.equal(errMessage(null), GENERIC_ERROR_MESSAGE);
+	assert.equal(errMessage(undefined), GENERIC_ERROR_MESSAGE);
 });
 
 // #696: frappe-ui's call() can itself crash mid-parse (error.exc_type read with
@@ -31,17 +31,17 @@ test("never echoes a raw TypeError's message (the exact #696 crash, current V8 w
 	const msg = errMessage(e);
 	assert.notEqual(msg, e.message);
 	assert.doesNotMatch(msg, /exc_type/);
-	assert.equal(msg, "Something went wrong. Please try again.");
+	assert.equal(msg, GENERIC_ERROR_MESSAGE);
 });
 
 test("never echoes a raw TypeError's message (pre-2021 V8 wording)", () => {
 	const e = new TypeError("Cannot read property 'exc_type' of undefined");
-	assert.equal(errMessage(e), "Something went wrong. Please try again.");
+	assert.equal(errMessage(e), GENERIC_ERROR_MESSAGE);
 });
 
 test("also catches the null-target form of the same crash", () => {
 	const e = new TypeError("Cannot read properties of null (reading 'exc_type')");
-	assert.equal(errMessage(e), "Something went wrong. Please try again.");
+	assert.equal(errMessage(e), GENERIC_ERROR_MESSAGE);
 });
 
 // Round-4 review F2: a blanket `instanceof TypeError` (or Reference/SyntaxError)
@@ -113,7 +113,7 @@ test("a 401 with no usable message gets the same session-expired sentence", () =
 // not somehow trip the 401/403 branch.
 test("the #696 crash shape (no status) falls through to the generic sentence, not session-expired", () => {
 	const e = new TypeError("Cannot read properties of undefined (reading 'exc_type')");
-	assert.equal(errMessage(e), "Something went wrong. Please try again.");
+	assert.equal(errMessage(e), GENERIC_ERROR_MESSAGE);
 });
 
 test("a non-auth status keeps its own message", () => {

--- a/frontend/src/onboarding/paymentCodes.js
+++ b/frontend/src/onboarding/paymentCodes.js
@@ -320,7 +320,10 @@ const TABLE = {
 	},
 	[CODES.BENCH_ADMIN_REJECTED]: {
 		headline: "The payment service refused this request.",
-		body: "Nothing was charged. Check the status, or start a new payment.",
+		// Same register as INTENT_HANDLE_UNAVAILABLE's sibling row: name what to do,
+		// not just that nothing was charged. "Refused" alone left the customer no
+		// wiser than the vague catch-all this row exists to replace.
+		body: "Nothing was charged. This is usually temporary. Check the status, or try again if it doesn't clear.",
 		tone: TONE.ALERT,
 		actions: [ACTIONS.CHECK, ACTIONS.INITIATE],
 	},

--- a/frontend/src/onboarding/paymentMachine.js
+++ b/frontend/src/onboarding/paymentMachine.js
@@ -684,8 +684,23 @@ function applyContract(state, decoded, opts) {
 	// Capability flags: honour the backend, then let the reconciliation flag veto
 	// initiate. A code that is definitionally paid/terminal never offers initiate
 	// regardless of what a flag says.
+	//
+	// canInitiate has NO fail-open default here (unlike _backendCanCheck just
+	// below) because an open Pay button on a still-live mandate could authorize a
+	// second one - see PAYMENT_AUTHORIZED_PENDING_CONFIRM's own copy. PAYMENT_DECLINED
+	// is the one code where that caution does not apply: a declined payment can
+	// always be safely retried (admin's own capability rule for it - see
+	// jarvis_admin_v2 billing/signup.py's _capabilities), so an envelope that
+	// happens to omit the flag for THIS code alone (a decoded {ok:false} failure
+	// carries no `data` at all - see paymentCodec.js - or a pre-capability admin)
+	// must not leave a just-declined customer with no way to pay again. Only the
+	// ABSENT case defaults: an explicit `can_initiate_payment: false` still wins.
 	const backendCanInitiate =
-		"can_initiate_payment" in data ? !!data.can_initiate_payment : next.canInitiate;
+		"can_initiate_payment" in data
+			? !!data.can_initiate_payment
+			: code === CODES.PAYMENT_DECLINED
+			? true
+			: next.canInitiate;
 	next._backendCanCheck =
 		"can_check_status" in data
 			? !!data.can_check_status

--- a/frontend/src/onboarding/paymentMachine.test.js
+++ b/frontend/src/onboarding/paymentMachine.test.js
@@ -224,6 +224,30 @@ test("a decline is retryable and stays on the pay step", () => {
 	assert.equal(s.value, STATES.FAILED_RETRYABLE);
 });
 
+// jarvis onboarding-return-heal: canInitiate has no fail-open default (a live
+// mandate must not offer a blind retry), except for PAYMENT_DECLINED - a
+// declined payment can always be safely retried, so an envelope that omits the
+// flag for THIS code alone must not leave the customer with no way to pay
+// again. Only the ABSENT case defaults; an explicit false still wins.
+test("PAYMENT_DECLINED with no can_initiate_payment key defaults canInitiate to true", () => {
+	const s = reduce(initialState(), at(CODES.PAYMENT_DECLINED));
+	assert.equal(s.value, STATES.FAILED_RETRYABLE);
+	assert.equal(s.canInitiate, true);
+});
+
+test("an explicit can_initiate_payment: false on PAYMENT_DECLINED is still honoured", () => {
+	const s = reduce(initialState(), at(CODES.PAYMENT_DECLINED, { can_initiate_payment: false }));
+	assert.equal(s.canInitiate, false);
+});
+
+test("a missing can_initiate_payment on a DIFFERENT code is never defaulted true", () => {
+	// Same FAILED_RETRYABLE shape as PAYMENT_DECLINED, but the fail-open scoping
+	// is keyed on the CODE, not the state it lands on.
+	const s = reduce(initialState(), at(CODES.NO_CURRENT_INTENT));
+	assert.equal(s.value, STATES.FAILED_RETRYABLE);
+	assert.equal(s.canInitiate, false);
+});
+
 test("SIGNUP_TERMINAL is terminal: no blind payment retry", () => {
 	const s = reduce(initialState(), at(CODES.SIGNUP_TERMINAL, { can_initiate_payment: true }));
 	assert.equal(s.value, STATES.FAILED_TERMINAL);

--- a/frontend/src/onboarding/supportHandoff.js
+++ b/frontend/src/onboarding/supportHandoff.js
@@ -14,8 +14,14 @@
  * and offer to put a person on it instead.
  */
 
-/** Checks against one intent before the support moment is surfaced. */
-export const SUPPORT_AFTER_CHECKS = 4;
+/** Checks against one intent before the support moment is surfaced.
+ *
+ * Lowered from 4 (jarvis onboarding-return-heal): a customer stuck in
+ * PAYMENT_CONFIRMATION_PENDING/UNKNOWN now gets auto-polled (see
+ * OnboardingView's pending auto-poll), so a click-driven ceiling tuned for a
+ * customer who has to press the button four times themselves left an
+ * auto-polled customer waiting far longer than that for the same offer. */
+export const SUPPORT_AFTER_CHECKS = 2;
 
 /** A counter keyed to nothing yet. */
 export function emptyCounter() {

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -1090,3 +1090,237 @@ describe("payment intent reference is shown in full, not masked", () => {
 		expect(wrapper.vm.supportContext).toContain(`Reference: ${longAttemptId}`);
 	});
 });
+
+// jarvis onboarding-return-heal, fix 1: the FRESH-MOUNT return heal. `?pay=` on
+// first paint only proves the pay page sent the customer back top-level - the
+// passive hydrate (getOnboardingState) reads admin's last-known DB row, never
+// asks the gateway. A fresh mount can never be CHECKOUT_OPEN (paymentMachine.js
+// always initializes to REVIEW), so the in-memory RETURNED_FROM_CHECKOUT exit
+// (usePaymentFlow.hydrate's own frozen-checkout branch) is unreachable here;
+// these pin the mount-time active check (check_signup_payment_status) that
+// covers this path instead, mirroring BillingPage.vue's run-healer-once shape.
+describe("FRESH-MOUNT RETURN HEAL: a genuine top-level ?pay= return converges once", () => {
+	function atSearch(search) {
+		window.history.pushState(null, "", "/onboarding" + search);
+	}
+	afterEach(() => {
+		window.history.pushState(null, "", "/onboarding");
+	});
+
+	it("runs check_signup_payment_status exactly once when a mid-flight signup exists", async () => {
+		atSearch("?pay=failed");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_1", generation: 1 })
+		);
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT run the active check on an ordinary visit (no ?pay=)", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_1", generation: 1 })
+		);
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+	});
+
+	it("does NOT run the active check when there is no mid-flight signup (day one)", async () => {
+		atSearch("?pay=done");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })
+		);
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+	});
+
+	it("a stale (lower-generation) active answer cannot repaint the newer passive state", async () => {
+		atSearch("?pay=failed");
+		// The passive hydrate already knows generation 5 for this attempt.
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_1",
+				generation: 5,
+			})
+		);
+		// A stale active answer carrying an OLDER generation of the same attempt -
+		// the generation fence must drop it outright, never repainting backward.
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_DECLINED", attempt_id: "att_1", generation: 2 })
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+		expect(wrapper.vm.pay.value).toBe(STATES.CONFIRM_REQUIRED);
+	});
+
+	it("PAID stays a floor: no later active answer undoes it", async () => {
+		atSearch("?pay=failed");
+		// The passive hydrate already found the signup PAID.
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_ALREADY_ACTIVE", attempt_id: "att_1", generation: 2 })
+		);
+		// An ADVANCED-generation active answer (so the generation fence alone would
+		// let it through) that would otherwise walk the machine back to a decline -
+		// only the paid floor stops this one.
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_DECLINED", attempt_id: "att_1", generation: 3 })
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+		// PAID is a floor: the machine may keep climbing forward off it (the
+		// paid->provisioning handoff fires on its own watcher), but the declined
+		// answer must never have walked it back to FAILED_RETRYABLE.
+		expect([STATES.PAID, STATES.PROVISIONING, STATES.PROVISIONING_DELAYED]).toContain(
+			wrapper.vm.pay.value
+		);
+	});
+});
+
+// jarvis onboarding-return-heal, fix 2: PAYMENT_CONFIRMATION_PENDING / UNKNOWN
+// used to do nothing on their own - every other wait in the wizard polls itself
+// (provisioning 45x2s, readiness 40x3s). These pin the bounded auto-poll: a
+// gentle interval, a hard ceiling with an honest stuck note, and a backoff on
+// PAYMENT_CHECK_RATE_LIMITED instead of hammering through the server's cooldown.
+describe("pending-payment auto-poll", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("auto-polls without a click and offers support within ~2 minutes", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.UNKNOWN);
+		// Nothing fires before the first tick - a fresh mount already ran its own
+		// one-shot passive hydrate; the poll adds no immediate second call.
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+
+		// SUPPORT_AFTER_CHECKS is 2 (lowered from 4): two auto-polled ticks, no
+		// manual click, and the existing support-offer machinery (noteStatusCheck)
+		// picks them up the same way it counts a manual Check.
+		await vi.advanceTimersByTimeAsync(15_000);
+		await vi.advanceTimersByTimeAsync(15_000);
+
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(2);
+		expect(wrapper.vm.pay.supportOffered).toBe(true);
+	});
+
+	it("stops at the ceiling and shows the honest stuck note, never a silent forever-spinner", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+
+		await vi.advanceTimersByTimeAsync(8 * 15_000); // PENDING_CHECK_ATTEMPTS x interval
+
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(8);
+		expect(wrapper.vm.pendingPollStuck).toBe(true);
+
+		// The ceiling is a hard stop: more elapsed time fires no 9th check.
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(8);
+	});
+
+	it("backs off on a rate limit instead of polling straight through the cooldown", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus
+			.mockResolvedValueOnce({
+				status: 429,
+				body: {
+					message: {
+						ok: false,
+						error: { code: "PAYMENT_CHECK_RATE_LIMITED", retry_after_seconds: 40 },
+						context: {},
+					},
+				},
+			})
+			.mockResolvedValue(
+				ENVELOPE({
+					code: "PAYMENT_CONFIRMATION_PENDING",
+					attempt_id: "att_poll",
+					generation: 1,
+				})
+			);
+		vi.useFakeTimers();
+		mountView();
+		await flushPromises();
+
+		// First tick (t=15s): rate-limited.
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+
+		// The ordinary interval alone (t=30s) must NOT be enough - the server's
+		// 40s cooldown from the 429 is still running.
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+
+		// Once the cooldown has fully elapsed, the next attempt fires.
+		await vi.advanceTimersByTimeAsync(40_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(2);
+	});
+
+	it("stops when the customer leaves the Pay step - no late tick into a hidden step", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("pay");
+
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+
+		await vi.advanceTimersByTimeAsync(120_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1027,6 +1027,19 @@
 									>
 										{{ statusCheckNote }}
 									</p>
+									<!-- The pending-payment auto-poll hit its ceiling with no resolution.
+										 Say so plainly instead of quietly giving up - a manual check
+										 still works, and support is offered above once the check
+										 ceiling was reached. -->
+									<p
+										v-if="pendingPollStuck"
+										class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
+										role="status"
+									>
+										We've been checking automatically for a couple of minutes
+										and still don't have an answer. You can check again, or
+										contact support and we'll look into it.
+									</p>
 									<!-- The checkout this signup already has is still open. Say so,
 										 because the alternative the customer would otherwise reach for
 										 (start a new payment) silently leaves the previous Razorpay
@@ -2417,15 +2430,19 @@ const PAID_NEEDS_CONNECT_REASONS = new Set([
 	"llm_setup",
 ]);
 
+// Returns the passive {paid, truthKnown, notStarted} truth flow.hydrate() read
+// (or null on a fail-open), so the caller (onMounted's fresh-mount return heal)
+// can tell whether a mid-flight signup actually exists without re-deriving it
+// from state.step.
 async function reconcileMidFlightSignup() {
 	let truth;
 	try {
 		truth = await flow.hydrate(); // {paid: true|false|null, truthKnown, notStarted}
 	} catch (e) {
-		return; // fail open to the intro tour
+		return null; // fail open to the intro tour
 	}
 	// Day one: no signup on this site. Leave the default intro tour (fresh start).
-	if (truth.notStarted) return;
+	if (truth.notStarted) return truth;
 
 	if (truth.paid === true) {
 		// Paid - so, and only so, the connect shortcut is allowed. Ask readiness
@@ -2441,7 +2458,7 @@ async function reconcileMidFlightSignup() {
 		if (ready && PAID_NEEDS_CONNECT_REASONS.has(ready.reason)) {
 			state.reconciledConnect = true;
 			state.step = "connect";
-			return;
+			return truth;
 		}
 		// Paid but not yet chat-ready (container provisioning): land on Pay, where
 		// the machine renders the paid receipt + "preparing your workspace". A paid
@@ -2449,7 +2466,7 @@ async function reconcileMidFlightSignup() {
 		// through the authenticated update_billing facade, never a fresh guest signup.
 		state.intentExists = true;
 		state.step = "pay";
-		return;
+		return truth;
 	}
 
 	// Not paid, or payment truth could not be established. Either way the connect
@@ -2464,6 +2481,7 @@ async function reconcileMidFlightSignup() {
 		state.intentExists = true;
 		state.step = "pay";
 	}
+	return truth;
 }
 
 // ---- Plan (Choose Your Plan) ------------------------------------------------
@@ -3210,6 +3228,66 @@ async function runStatusCheck() {
 		statusCheckNote.value = "We checked just now, and nothing has changed yet.";
 	}
 }
+
+// ---- pending-payment auto-poll -----------------------------------------------
+// Every other wait in the wizard polls on its own (provisioning 45x2s, readiness
+// 40x3s); this recovery card used to do nothing until the customer clicked Check
+// themselves. UNKNOWN covers PAYMENT_CONFIRMATION_PENDING (the coded wait) and a
+// return from checkout that has not resolved yet - both are "ask again shortly"
+// states, never a dead end.
+//
+// Gentler than the other waits ON PURPOSE: unlike readiness/provisioning,
+// checkStatus asks the real payment gateway and the server rate-limits it
+// (PAYMENT_CHECK_RATE_LIMITED) - so this reads the machine's own cooldown after
+// every check and waits it out before the next attempt, instead of a fixed
+// interval that could poll straight through a 429.
+const PENDING_CHECK_INTERVAL_MS = 15_000;
+const PENDING_CHECK_ATTEMPTS = 8; // ~15s x 8 ≈ 2 minutes
+// Set once the ceiling is reached with no resolution - an honest "we stopped
+// auto-checking" note, never a spinner that quietly gives up. Cleared the moment
+// the state leaves UNKNOWN (resolved) or Pay is left (see restartPendingAutoPoll).
+const pendingPollStuck = ref(false);
+// Bumped on every (re)start AND on every stop, so a run already sleeping/awaiting
+// checkStatus() can tell it has been superseded and quit without touching state
+// that no longer belongs to it (leaving Pay, a fresh CONTRACT_STATE, unmount).
+let pendingPollRun = 0;
+
+async function runPendingAutoPoll(myRun) {
+	for (let i = 0; i < PENDING_CHECK_ATTEMPTS; i++) {
+		await _sleep(PENDING_CHECK_INTERVAL_MS);
+		if (pendingPollRun !== myRun || pay.value.value !== S.UNKNOWN) return;
+		await flow.checkStatus();
+		if (pendingPollRun !== myRun || pay.value.value !== S.UNKNOWN) return;
+		// A rate limit says nothing about the money (see paymentCodes.js) - wait
+		// out the SERVER's own cooldown ON TOP OF the ordinary interval already
+		// elapsed, so the next attempt cannot land inside it and poll straight
+		// through a 429. checkCooldownUntil is whatever the machine is currently
+		// holding (0 on an ordinary answer), so this is a no-op except right after
+		// a rate limit.
+		const waitMs = (pay.value.checkCooldownUntil || 0) - Date.now();
+		if (waitMs > 0) {
+			await _sleep(waitMs);
+			if (pendingPollRun !== myRun || pay.value.value !== S.UNKNOWN) return;
+		}
+	}
+	if (pendingPollRun === myRun && pay.value.value === S.UNKNOWN) {
+		pendingPollStuck.value = true;
+	}
+}
+
+// (Re)starts the poll if - and only if - the machine is genuinely waiting on
+// this signup's payment AND the customer is looking at the Pay step. Called from
+// both the value-watch below (a fresh CONTRACT_STATE) and the step-lifecycle
+// watch (entering/leaving Pay), so either kind of change restarts or stops it
+// the same way; idempotent to call when neither condition holds.
+function restartPendingAutoPoll() {
+	pendingPollRun += 1; // supersede whatever was already running
+	pendingPollStuck.value = false;
+	if (pay.value.value === S.UNKNOWN && state.step === "pay") {
+		runPendingAutoPoll(pendingPollRun);
+	}
+}
+watch(() => pay.value.value, restartPendingAutoPoll);
 
 // ---- "Resend the link" (jarvis#297 P0-2a) -----------------------------------
 // A truthful confirmation line, not a toast that could be missed off-screen -
@@ -4854,10 +4932,17 @@ watch(
 		if (s === "pay" && (prev === "details" || prev === "reconnect")) {
 			reconcileMidFlightSignup();
 		}
+		// Same P1-8 lifecycle discipline for the pending auto-poll: stop it the
+		// instant Pay is left (a late tick must not fire into a hidden step), and
+		// (re)start it on entry if the machine is already sitting in UNKNOWN.
+		restartPendingAutoPoll();
 	}
 );
 onUnmounted(() => {
 	if (cooldownTimer) clearInterval(cooldownTimer);
+	// Stop the pending auto-poll: a sleeping tick otherwise fires a real check
+	// into a torn-down component minutes after navigation away.
+	pendingPollRun += 1;
 	// Invalidate any in-flight client work so a late response cannot touch a
 	// torn-down component (P1-8), and drop the checkout-return listeners.
 	flow.cancelInFlight();
@@ -5002,7 +5087,27 @@ onMounted(async () => {
 		clearExternalCheckoutNav();
 	}
 	try {
-		await reconcileMidFlightSignup();
+		const midFlightTruth = await reconcileMidFlightSignup();
+		// FRESH-MOUNT RETURN HEAL. `checkoutReturn` only proves the pay page sent
+		// the customer back top-level; the passive hydrate above only read admin's
+		// last-known DB row (get_onboarding_state), never asked the gateway. A
+		// fresh mount can never be CHECKOUT_OPEN (paymentMachine.js reinitializes to
+		// REVIEW), so the in-memory RETURNED_FROM_CHECKOUT exit that already asks
+		// the gateway (usePaymentFlow's returnFromCheckout / handleCheckoutReturn)
+		// is unreachable here - this is the ONLY path that converges a fresh-mount
+		// return. Mirrors BillingPage.vue's run-healer-once pattern: exactly one
+		// active check, only when a mid-flight signup exists (nothing to check
+		// otherwise - a day-one visitor's check_signup_payment_status call would
+		// just spend a rate-limited read on an absent subscription row).
+		//
+		// No extra fencing needed beyond that: checkStatus() routes its answer
+		// through the SAME applyContract every other answer takes, so the
+		// attempt/generation fence and the PAID floor already guarantee a stale
+		// answer here can never repaint a newer state and a paid answer is never
+		// undone (paymentMachine.js applyContract).
+		if (checkoutReturn && midFlightTruth && !midFlightTruth.notStarted) {
+			await flow.checkStatus();
+		}
 	} finally {
 		confirmingReturn.value = false;
 	}


### PR DESCRIPTION
Fixes the onboarding wizard's return from a failed or pending payment: a fresh page load now actively re-checks with the payment gateway instead of only reading the last-known status, a stuck pending payment now checks itself automatically instead of waiting on manual clicks, and a declined payment's retry button can no longer be silently hidden.

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on failing)
- [ ] Branch is **up to date with `develop`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

Visual evidence from the live e2e pass (2026-08-18) is attached in the comment below.

<details>
<summary>What changed and why</summary>

The wizard polls a passive `get_onboarding_state` read (admin's DB row) and separately has an active `check_signup_payment_status` call that asks the gateway. On a fresh page load back from the admin-hosted pay page, only the passive read ran - the active check was only reachable from an in-memory `CHECKOUT_OPEN` state a fresh mount can never be in. So a payment that genuinely failed, or converged after a false `pay=failed`, could sit stale until the customer clicked Check by hand.

- `OnboardingView.vue`: on mount, when a `?pay=` outcome coincides with a mid-flight signup, run the active check once after the passive hydrate, mirroring `BillingPage.vue`'s run-healer-once pattern. The existing attempt/generation fence and paid floor protect it for free. Also adds a bounded auto-poll (15s interval, 8-attempt ceiling, backs off on `PAYMENT_CHECK_RATE_LIMITED`) for the PAYMENT_CONFIRMATION_PENDING/UNKNOWN wait, which previously did nothing on its own.
- `supportHandoff.js`: `SUPPORT_AFTER_CHECKS` 4 -> 2, so the support offer appears well inside 2 minutes with the new auto-poll instead of requiring four manual clicks.
- `paymentMachine.js`: `canInitiate` defaults to true for `PAYMENT_DECLINED` alone when the backend omits `can_initiate_payment` - a decline is always safely retryable; every other code keeps its fail-closed default (an open Pay button on a live mandate could double-authorize).
- `paymentCodes.js` / `errors.js`: sharper, more actionable copy for `BENCH_ADMIN_REJECTED` and the generic error fallback.

Tests: `paymentMachine.test.js` (canInitiate defaulting), `OnboardingView.spec.js` (mount-heal exactly-once, stale-answer/paid-floor fencing, auto-poll ceiling and rate-limit backoff, step-leave cancellation).
</details>

https://claude.ai/code/session_01RnnexCQ15YNq3LvopKCRqx

