### PR TITLE
feat(support): unread indicator on the avatar + count flag on the tickets menu item

### DIFF
--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -20,15 +20,15 @@
 				     (design.md §2.2). idlePeek: this is the one mark that sits resting on
 				     every route, so it's the chosen surface for the designed idle blink. -->
 				<JarvisMark :size="28" :radius="7" :peek="brandPeek" idlePeek />
-				<!-- Resting badge: a waiting reply has to register on every route, not
-				     only while the user happens to be in Chat - restoring this (it was
-				     briefly dropped when ChatView grew its own header jv-support-dot,
-				     which stayed too: both showing the same thing on the chat route is
-				     harmless duplication, losing it everywhere else was not). Mirrors
-				     the collapsed-sidebar dot in Sidebar.vue:57-62. -->
+				<!-- Resting badge: a waiting reply has to register on every route, so it
+				     lives here on the avatar - the SOLE unread indicator now (the
+				     chat-header jv-support-dot was removed; that control is new-ticket
+				     only). Red + pulse to actually pull the eye: an unheard reply is a
+				     pending action ON the user, the same semantic (bg-surface-red-5) as
+				     Sidebar.vue's approvals dot. motion-safe so reduced-motion stays calm. -->
 				<div
 					v-if="supportOn && store.awaitingCount"
-					class="absolute left-7 top-1 size-2 rounded-full bg-surface-amber-2"
+					class="absolute left-7 top-1 size-2 rounded-full bg-surface-red-5 motion-safe:animate-pulse"
 					:aria-label="`${store.awaitingCount} ${
 						store.awaitingCount === 1 ? 'ticket' : 'tickets'
 					} awaiting your reply`"
@@ -87,9 +87,8 @@ const session = inject("$session");
 const { effectiveDark, toggleTheme } = useJarvisTheme();
 
 // Support panel: `store` is the shared support-store singleton, kept fresh here
-// by this poll timer so ChatView's header Support button (its jv-support-dot)
-// and the ticket list always read the same awaiting-count value without each
-// needing to run its own poller.
+// by this poll timer so the avatar's resting badge and the ticket list always
+// read the same awaiting-count value without each needing to run its own poller.
 const router = useRouter();
 const supportOn = window.support_available && window.has_support_access;
 const store = useSupportStore();
@@ -156,7 +155,11 @@ const menuOptions = computed(() => [
 				? []
 				: [
 						{
-							label: "Support tickets",
+							// Count flag mirrors the avatar's resting dot, so opening the
+							// menu confirms where the waiting reply is.
+							label: store.awaitingCount
+								? `Support tickets · ${store.awaitingCount}`
+								: "Support tickets",
 							icon: "life-buoy",
 							onClick: () => router.push({ name: "Support" }),
 						},

--- a/frontend/src/components/support/SupportSidebar.vue
+++ b/frontend/src/components/support/SupportSidebar.vue
@@ -17,7 +17,7 @@
 				     button either) - a permanent CTA here duplicated it. -->
 				<SidebarLink
 					icon="inbox"
-					label="Support tickets"
+					label="Support Tickets"
 					:to="{ name: 'Support' }"
 					:is-collapsed="collapsed"
 					:is-active="isTickets"
@@ -77,7 +77,7 @@ function toggle() {
 	}
 }
 
-// "Support tickets" is active across every support page (list/new/thread); "Jarvis
+// "Support Tickets" is active across every support page (list/new/thread); "Jarvis
 // chat" is the exit link, never active while we're on a support route.
 const isTickets = computed(() => route.path.startsWith("/support"));
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -334,18 +334,6 @@
 								d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"
 							/>
 						</svg>
-						<!-- Resting badge: a waiting reply has to register while the user is
-						     heads-down in chat. Moved here from UserMenu's avatar (Support
-						     lived only in the menu before) so the dot sits on the control
-						     that actually opens Support. -->
-						<span
-							v-if="supportOn && supportStore.awaitingCount"
-							class="jv-support-dot"
-							:aria-label="`${supportStore.awaitingCount} ${
-								supportStore.awaitingCount === 1 ? 'ticket' : 'tickets'
-							} awaiting your reply`"
-							role="status"
-						/>
 					</button>
 					<button
 						class="jv-iconbtn"
@@ -4468,13 +4456,9 @@ async function openSupport() {
 		explainUnavailable("Support");
 		return;
 	}
-	// A resting badge means tickets are waiting on the user's reply - the click
-	// has to land where those tickets actually are (the old UserMenu entry did
-	// this), not on a blank new-ticket form the badge gave no reason to expect.
-	if (supportStore.awaitingCount) {
-		router.push({ name: "Support" });
-		return;
-	}
+	// This header control is the NEW-TICKET entry point only. The "you have a
+	// waiting reply" signal + its route to the inbox now live solely on the
+	// avatar's resting badge (UserMenu), so the two concerns don't share a button.
 	if (openSupportInFlight) return;
 	openSupportInFlight = true;
 	try {
@@ -10622,18 +10606,6 @@ onUnmounted(() => {
 }
 .jv-iconbtn:hover svg {
 	stroke: var(--surface) !important;
-}
-/* Resting badge on the Support button: mirrors the "Awaiting you" ticket
-   badge's amber, so the same colour means the same thing everywhere. */
-.jv-support-dot {
-	position: absolute;
-	top: 3px;
-	right: 3px;
-	width: 8px;
-	height: 8px;
-	border-radius: 999px;
-	background: var(--amber);
-	border: 1.5px solid var(--surface);
 }
 .jv-ctxbtn:hover {
 	background: var(--surface-2);

--- a/frontend/tests/support-extraction/support-badge.test.js
+++ b/frontend/tests/support-extraction/support-badge.test.js
@@ -102,15 +102,27 @@ describe("UserMenu variant (chat vs support)", () => {
 		store.awaitingCount = 0;
 	});
 
-	it("chat (default): title is the agent name; no Support menu item (it lives in ChatView's header icon now, not the dropdown)", () => {
+	it("chat (default): title is the agent name; carries a 'Support tickets' inbox item (the read-path — new-ticket lives in the header icon)", () => {
 		const w = mount(UserMenu, opts);
 		expect(w.text()).toContain(agentName);
 		expect(w.text()).not.toContain(`${agentName} Support`);
 		const labels = menuLabels(w);
-		expect(labels).not.toContain("Support");
+		expect(labels).toContain("Support tickets"); // the inbox read-path (no unread here)
 		expect(labels).not.toContain(`Switch to ${agentName} chat`);
 		expect(labels).toContain("Change theme");
 		expect(labels).toContain("Settings"); // chat/LLM settings belong here
+	});
+
+	it("chat: the Support tickets item carries the awaiting count as a flag", () => {
+		store.awaitingCount = 3;
+		const w = mount(UserMenu, opts);
+		expect(menuLabels(w)).toContain("Support tickets · 3");
+	});
+
+	it("chat: no Support tickets item when support is switched off", () => {
+		window.support_available = false;
+		const w = mount(UserMenu, opts);
+		expect(menuLabels(w).some((l) => l.startsWith("Support tickets"))).toBe(false);
 	});
 
 	it("support: title is '<agent> Support'; menu swaps Support for 'Switch to <agent> chat' and keeps the theme switcher", () => {
@@ -118,7 +130,8 @@ describe("UserMenu variant (chat vs support)", () => {
 		expect(w.text()).toContain(`${agentName} Support`);
 		const labels = menuLabels(w);
 		expect(labels).toContain(`Switch to ${agentName} chat`);
-		expect(labels).not.toContain("Support");
+		// The inbox item is chat-only; on the support rail you're already there.
+		expect(labels.some((l) => l.startsWith("Support tickets"))).toBe(false);
 		expect(labels).toContain("Change theme");
 		// The Jarvis chat/LLM Settings dialog is out of place in the customer portal.
 		expect(labels).not.toContain("Settings");

--- a/frontend/tests/support-extraction/support-sidebar.test.js
+++ b/frontend/tests/support-extraction/support-sidebar.test.js
@@ -64,9 +64,9 @@ beforeEach(() => {
 });
 
 describe("SupportSidebar", () => {
-	it("offers Support tickets + Jarvis chat nav links, each to the right route", () => {
+	it("offers Support Tickets + Jarvis chat nav links, each to the right route", () => {
 		const w = mountSidebar();
-		expect(linkBy(w, "Support tickets").props("to")).toEqual({ name: "Support" });
+		expect(linkBy(w, "Support Tickets").props("to")).toEqual({ name: "Support" });
 		expect(linkBy(w, "Jarvis chat").props("to")).toEqual({ name: "Chat" });
 	});
 
@@ -75,11 +75,11 @@ describe("SupportSidebar", () => {
 		expect(w.findComponent({ name: "Button" }).exists()).toBe(false);
 	});
 
-	it("marks 'Support tickets' active across support routes, not otherwise", () => {
+	it("marks 'Support Tickets' active across support routes, not otherwise", () => {
 		routePath = "/support/TCK-1";
-		expect(linkBy(mountSidebar(), "Support tickets").props("isActive")).toBe(true);
+		expect(linkBy(mountSidebar(), "Support Tickets").props("isActive")).toBe(true);
 		routePath = "/"; // (contrived — the rail only shows on support routes) pins the computed
-		expect(linkBy(mountSidebar(), "Support tickets").props("isActive")).toBe(false);
+		expect(linkBy(mountSidebar(), "Support Tickets").props("isActive")).toBe(false);
 	});
 
 	it("renders the reused chat user card at the top", () => {
@@ -89,23 +89,23 @@ describe("SupportSidebar", () => {
 	it("collapses/expands on the toggle and persists the choice", async () => {
 		const w = mountSidebar();
 		// starts expanded: labels shown, toggle says "Collapse"
-		expect(linkBy(w, "Support tickets").props("isCollapsed")).toBe(false);
+		expect(linkBy(w, "Support Tickets").props("isCollapsed")).toBe(false);
 		expect(linkBy(w, "Collapse")).toBeTruthy();
 
 		await linkBy(w, "Collapse").trigger("click");
-		expect(linkBy(w, "Support tickets").props("isCollapsed")).toBe(true);
+		expect(linkBy(w, "Support Tickets").props("isCollapsed")).toBe(true);
 		expect(linkBy(w, "Expand")).toBeTruthy(); // label flipped
 		expect(localStorage.getItem("jv-support-sidebar-collapsed")).toBe("1");
 
 		await linkBy(w, "Expand").trigger("click");
-		expect(linkBy(w, "Support tickets").props("isCollapsed")).toBe(false);
+		expect(linkBy(w, "Support Tickets").props("isCollapsed")).toBe(false);
 		expect(localStorage.getItem("jv-support-sidebar-collapsed")).toBe("0");
 	});
 
 	it("starts collapsed when the persisted choice says so", () => {
 		localStorage.setItem("jv-support-sidebar-collapsed", "1");
 		const w = mountSidebar();
-		expect(linkBy(w, "Support tickets").props("isCollapsed")).toBe(true);
+		expect(linkBy(w, "Support Tickets").props("isCollapsed")).toBe(true);
 		expect(w.classes()).toContain("jv-supsb-collapsed");
 	});
 });


### PR DESCRIPTION
Consolidates the "you have a waiting support reply" signal onto one surface and makes it noticeable, and gives the read-path a count.

## Changes
- **Chat-header dot removed → header is new-ticket only.** Dropped the header Support control's `jv-support-dot` and its `awaitingCount → inbox` branch in `openSupport()`; that control now solely opens a **new** ticket. The unread signal no longer sits on a control that (when there's nothing waiting) opens a blank new-ticket form.
- **Avatar dot recoloured to grab attention.** The `UserMenu` resting badge goes from soft amber (`bg-surface-amber-2`) to the semantic **pending-action red** (`bg-surface-red-5`, #CC2929 / #E43838) + a `motion-safe:animate-pulse` — same token as Sidebar's approvals dot. It's now the single unread indicator, on every route.
- **Count flag on the existing "Support tickets" menu item.** `develop` already added a "Support tickets" entry to the chat-variant avatar menu (routes to the inbox); this adds the awaiting **count** to its label (`Support tickets · N`), mirroring the avatar dot so opening the menu confirms where the reply is.
- **Title-case the "Support Tickets" sidebar label** (+ its test).

## Resulting flow
Unread reply → red pulsing avatar dot (every route) → open the avatar menu → **"Support tickets · N"** → the inbox to read it. The header Support icon stays "new ticket."

## Note for review
This branch was rebased onto current `develop` — which had already shipped the "Support tickets" menu item since this work began, so the net change here is the **count flag** on it plus the header-dot removal, avatar recolour, and label. No duplicate item.

## Verified
- `vitest run tests/support-extraction` — **266/266** pass (count-flag + renamed-label tests added/updated).
- `prettier@2.7.1 --check` (the pinned pre-commit version) — clean; pre-commit hooks pass.

Per `CLAUDE.md`, this still needs the **reviewer (Opus) GREEN** + a **flow review** on the running app before merge — worth confirming the avatar-dot → menu → "Support tickets · N" → inbox path end-to-end there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)