### PR TITLE
chore: align Jarvis install and CI with repository move

### DIFF
--- a/.github/docker/Dockerfile.ci-base
+++ b/.github/docker/Dockerfile.ci-base
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 #
-# ghcr.io/aerele-rnd/jarvis-ci-base:v16
+# ghcr.io/aerele/jarvis-ci-base:v16
 #
 # A pre-built Frappe bench (frappe + erpnext + hrms, version-16) plus a SQL dump of a site
 # with those three already installed. PR CI consumes this so it only has to install jarvis
@@ -148,7 +148,7 @@ WORKDIR /opt/frappe-bench
 ARG FRAPPE_SHA=unknown
 ARG ERPNEXT_SHA=unknown
 ARG HRMS_SHA=unknown
-LABEL org.opencontainers.image.source="https://github.com/Aerele-RnD/jarvis" \
+LABEL org.opencontainers.image.source="https://github.com/aerele/jarvis" \
       ai.jarvis.frappe-sha="${FRAPPE_SHA}" \
       ai.jarvis.erpnext-sha="${ERPNEXT_SHA}" \
       ai.jarvis.hrms-sha="${HRMS_SHA}"

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -1,6 +1,6 @@
 name: CI base image
 
-# Builds ghcr.io/aerele-rnd/jarvis-ci-base:v16 — a pre-built Frappe bench (frappe + erpnext +
+# Builds ghcr.io/aerele/jarvis-ci-base:v16 — a pre-built Frappe bench (frappe + erpnext +
 # hrms, version-16) plus a SQL dump of a site with all three already installed.
 #
 # Today, every PR run rebuilds that environment from scratch: ~5m26s of a ~7m21s run, identical
@@ -87,8 +87,8 @@ jobs:
           # run_number restarts if the workflow is renamed, so old numbered tags could be
           # silently overwritten by a new incarnation. run_id is unique for the repo, forever.
           tags: |
-            ghcr.io/aerele-rnd/jarvis-ci-base:v16
-            ghcr.io/aerele-rnd/jarvis-ci-base:v16-${{ github.run_id }}
+            ghcr.io/aerele/jarvis-ci-base:v16
+            ghcr.io/aerele/jarvis-ci-base:v16-${{ github.run_id }}
           build-args: |
             FRAPPE_SHA=${{ steps.shas.outputs.frappe }}
             ERPNEXT_SHA=${{ steps.shas.outputs.erpnext }}
@@ -101,7 +101,7 @@ jobs:
       # only proves the dump is non-empty.
       - name: Smoke-test the built image
         run: |
-          docker run --rm ghcr.io/aerele-rnd/jarvis-ci-base:v16 bash -lc '
+          docker run --rm ghcr.io/aerele/jarvis-ci-base:v16 bash -lc '
             set -e
             test -s /opt/ci/test_site.sql
             bytes=$(stat -c%s /opt/ci/test_site.sql)
@@ -122,5 +122,5 @@ jobs:
       - name: Push
         if: github.event_name != 'pull_request'
         run: |
-          docker push ghcr.io/aerele-rnd/jarvis-ci-base:v16
-          docker push ghcr.io/aerele-rnd/jarvis-ci-base:v16-${{ github.run_id }}
+          docker push ghcr.io/aerele/jarvis-ci-base:v16
+          docker push ghcr.io/aerele/jarvis-ci-base:v16-${{ github.run_id }}

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -3,7 +3,7 @@ name: CI (from scratch)
 # The pre-baked-image escape hatch. This is what .github/workflows/ci.yml used to be: it builds a
 # bench from nothing, fetching frappe/erpnext/hrms at version-16 HEAD.
 #
-# PR CI no longer does this — it consumes ghcr.io/aerele-rnd/jarvis-ci-base:v16, which is rebuilt
+# PR CI no longer does this — it consumes ghcr.io/aerele/jarvis-ci-base:v16, which is rebuilt
 # nightly. That makes PRs fast but means a PR can go green against a *stale* image. This job is the
 # thing that notices: it runs against live upstream every night, so a breaking change in frappe,
 # erpnext or hrms turns this red within a day, decoupled from PR latency.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-# Runs the jarvis test suite inside ghcr.io/aerele-rnd/jarvis-ci-base:v16, which already carries a
+# Runs the jarvis test suite inside ghcr.io/aerele/jarvis-ci-base:v16, which already carries a
 # built bench with frappe + erpnext + hrms (version-16) and /opt/ci/test_site.sql — a dump of a
 # site with all three installed. Everything this job does is jarvis-specific.
 #
@@ -185,7 +185,7 @@ jobs:
         shard: [1, 2, 3, 4]
 
     container:
-      image: ghcr.io/aerele-rnd/jarvis-ci-base:v16
+      image: ghcr.io/aerele/jarvis-ci-base:v16
       # bench hard-exits as root (bench/cli.py -> change_uid: "You should not run this command as
       # root", exit 1). Actions job containers run as root by default. uid 1001 is both the `ci`
       # user baked into the image and the runner user that owns the mounted workspace.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Jarvis supports Frappe 15 and 16.
 Run these commands from your Frappe bench:
 
 ```bash
-bench get-app https://github.com/Aerele-RnD/jarvis.git --branch beta
+bench get-app https://github.com/aerele/jarvis.git --branch main
 bench --site your-site.example install-app jarvis
 ```
 
@@ -92,7 +92,7 @@ bench --site your-site.example install-app jarvis
 On a private bench group:
 
 1. Open **Bench Group > Apps**, choose **Add App**, and add
-   `https://github.com/Aerele-RnD/jarvis.git` from the `beta` branch.
+   `https://github.com/aerele/jarvis.git` from the `main` branch.
 2. Deploy the bench update to your site.
 3. Open **Site > Apps**, choose **Install App**, and install **Jarvis**.
 


### PR DESCRIPTION
## Why

Jarvis moved from `Aerele-RnD/jarvis` to `aerele/jarvis`.

The repository follows this branch model:

- `develop` is the working and integration branch
- `main` contains released production code
- customer installations should use `main`

The installation instructions and CI image configuration still referenced the former organization and old GHCR package path. After the repository move, backend CI could not pull `ghcr.io/aerele-rnd/jarvis-ci-base:v16`.

## What changed

### Customer installation

- use `https://github.com/aerele/jarvis.git --branch main` for self-hosted Bench installation
- tell Frappe Cloud users to install from `main`
- update OCI source metadata to the canonical repository

### Development and CI

- keep normal development and push CI on `develop`
- keep CI cancellation protection for `develop`
- keep CI base-image publishing tied to changes merged into `develop`
- move the CI base image to `ghcr.io/aerele/jarvis-ci-base:v16`
- update base-image build, smoke-test, normal CI, and nightly workflow references

Pull requests remain covered by the unfiltered `pull_request` CI trigger, including production release PRs from `develop` to `main`.

## Base image bootstrap

The new base image was built, smoke-tested, and published under the Aerele organization before merge:

- [Successful CI base image run](https://github.com/aerele/jarvis/actions/runs/32129324304)

This prevents CI from referring to a package that does not exist.

## Verification

- rebuilt the PR branch from the latest `develop`
- confirmed that the PR now targets `develop`
- confirmed that workflow push triggers and protections still reference `develop`
- confirmed that public installation instructions reference released code on `main`
- confirmed that the changed files contain no remaining `Aerele-RnD/jarvis` or `ghcr.io/aerele-rnd/jarvis-ci-base` references
- passed all applicable pre-commit checks, including YAML validation
- passed the base-image build, lint, frontend build, frontend tests, all four backend test shards, and coverage in the [replacement CI run](https://github.com/aerele/jarvis/actions/runs/32130647787)

## Scope

This PR does not change Jarvis product or runtime behavior. It only updates installation guidance, repository metadata, and CI package references after the repository move.

## Merge status

All automated checks pass. The PR is ready for the required review.