### PR TITLE
fix: resolve number-format precision natively on Frappe 15 (graphics import)

### DIFF
--- a/jarvis/tests/test_export_document_graphics.py
+++ b/jarvis/tests/test_export_document_graphics.py
@@ -6,14 +6,14 @@ Two groups:
 * ``css_bar``/``kpi_tile``/``rag_chip`` are pure (no ``frappe`` import) and run
   WITHOUT a site: ``python -m unittest jarvis.tests.test_export_document_graphics``.
 * ``fmt_amount``/``fmt_pct`` reuse ``frappe.utils.fmt_money`` /
-  ``frappe.utils.data.get_number_format``, both of which read
-  ``frappe.local.lang`` - they raise ``AttributeError: lang`` outside a real
+  ``graphics.number_format_precision``, both of which read a site setting
+  (``frappe.local.lang`` / the site number format) - they raise outside a real
   Frappe site/request context. The real-formatting tests below are marked
   ``skip`` with that reason (verified against this repo's bench-env python,
   see the task report) and belong to the end-to-end/site gate instead. The
   edge-case GUARD logic (None/NaN/Inf/-0.0 handling, before ``fmt_money`` is
   ever reached) is still fully unit-tested here by patching
-  ``fmt_money``/``get_number_format`` to site-free stubs.
+  ``fmt_money``/``number_format_precision`` to site-free stubs.
 """
 
 import html
@@ -197,8 +197,8 @@ class TestRagChip(unittest.TestCase):
 
 # --- fmt_amount / fmt_pct: real integration (needs a Frappe site) -----------
 #
-# frappe.utils.fmt_money / frappe.utils.data.get_number_format read
-# frappe.local.lang and raise `AttributeError: lang` outside a site. These use
+# frappe.utils.fmt_money / graphics.number_format_precision read a site
+# setting and raise outside a site. These use
 # ``skipUnless`` (NOT unconditional ``skip``, which would never run even inside
 # the bench gate) so they DO run once a site is present, and they assert exact
 # DELEGATION to fmt_money rather than a hard-coded locale string - proving
@@ -218,15 +218,14 @@ class TestFmtRealIntegration(unittest.TestCase):
 	@unittest.skipUnless(_HAS_SITE, "needs a bench site (frappe.local.lang)")
 	def test_fmt_pct_delegates_at_number_format_precision(self) -> None:
 		from frappe.utils import fmt_money
-		from frappe.utils.data import get_number_format
 
-		expected = html.escape(fmt_money(42.5, precision=get_number_format().precision)) + "%"
+		expected = html.escape(fmt_money(42.5, precision=graphics.number_format_precision())) + "%"
 		self.assertEqual(fmt_pct(42.5), expected)
 
 
 # --- fmt_amount / fmt_pct: edge-case guard logic (no site needed) -----------
 #
-# fmt_money/get_number_format are patched to site-free stubs so ONLY the
+# fmt_money/number_format_precision are patched to site-free stubs so ONLY the
 # wrapper's own None/NaN/Inf/-0.0/negative-parens guard logic is under test.
 # For the None/NaN/Inf cases the guard returns before ever calling the stub
 # (proven below by asserting the stub was not invoked), so those specific
@@ -235,21 +234,18 @@ class TestFmtRealIntegration(unittest.TestCase):
 
 class TestFmtGuards(unittest.TestCase):
 	def setUp(self) -> None:
-		self.calls = {"fmt_money": [], "get_number_format": 0}
+		self.calls = {"fmt_money": [], "number_format_precision": 0}
 
 		def _fmt_money_stub(amount, precision=None, currency=None, format=None):
 			self.calls["fmt_money"].append((amount, precision, currency))
 			return f"{amount:.2f}"
 
-		class _NF:
-			precision = 2
-
-		def _get_number_format_stub():
-			self.calls["get_number_format"] += 1
-			return _NF()
+		def _number_format_precision_stub():
+			self.calls["number_format_precision"] += 1
+			return 2
 
 		patch.object(graphics, "fmt_money", _fmt_money_stub).start()
-		patch.object(graphics, "get_number_format", _get_number_format_stub).start()
+		patch.object(graphics, "number_format_precision", _number_format_precision_stub).start()
 		self.addCleanup(patch.stopall)
 
 	def test_fmt_amount_none_nan_inf_render_em_dash(self) -> None:
@@ -263,7 +259,7 @@ class TestFmtGuards(unittest.TestCase):
 			with self.subTest(bad=bad):
 				self.assertEqual(fmt_pct(bad), "—")
 				self.assertEqual(self.calls["fmt_money"], [])
-				self.assertEqual(self.calls["get_number_format"], 0)
+				self.assertEqual(self.calls["number_format_precision"], 0)
 
 	def test_fmt_amount_negative_zero_is_not_negative(self) -> None:
 		out = fmt_amount(-0.0)
@@ -309,9 +305,9 @@ class TestFmtGuards(unittest.TestCase):
 
 	def test_fmt_pct_uses_number_format_precision_not_currency_default(self) -> None:
 		fmt_pct(42.5)
-		self.assertEqual(self.calls["get_number_format"], 1)
+		self.assertEqual(self.calls["number_format_precision"], 1)
 		((_amount, precision, _currency),) = self.calls["fmt_money"]
-		self.assertEqual(precision, 2)  # from the stub NumberFormat, not a currency-precision default
+		self.assertEqual(precision, 2)  # from the stub precision, not a currency-precision default
 
 	def test_fmt_amount_string_input_with_commas(self) -> None:
 		out = fmt_amount("1,234.5")

--- a/jarvis/tools/_export/document/graphics.py
+++ b/jarvis/tools/_export/document/graphics.py
@@ -14,7 +14,8 @@ match Task 2's ``THEME_CSS`` contract - keep them in lockstep if either side
 changes.
 
 ``fmt_amount``/``fmt_pct`` DO need a Frappe site: they reuse
-``frappe.utils.fmt_money``/``frappe.utils.data.get_number_format`` for
+``frappe.utils.fmt_money`` (and, for ``fmt_pct``'s precision, Frappe 15's
+``frappe.utils.data.get_number_format_info``) for
 locale-correct digit grouping (Indian lakh/crore included) rather than
 hand-rolling grouping logic. Both guard ``None``/``NaN``/``Inf`` explicitly
 ahead of ``fmt_money`` - a naive ``"%.2f" % float("nan")`` renders the literal
@@ -31,10 +32,23 @@ import html
 import math
 from collections.abc import Mapping, Sequence
 
+import frappe
 from frappe.utils import fmt_money
-from frappe.utils.data import get_number_format
+from frappe.utils.data import get_number_format_info
 
 _RAG_STATUSES = ("red", "amber", "green")
+
+
+def number_format_precision() -> int:
+	"""The site number-format's decimal precision, resolved the Frappe 15 way.
+
+	Mirrors ``fmt_money``'s own resolution on Frappe 15 -
+	``get_number_format_info(frappe.db.get_default("number_format") or "#,###.##")``
+	- so ``fmt_pct`` gets exactly the precision the framework computes, without
+	inheriting ``fmt_money``'s currency-precision default.
+	"""
+	fmt = frappe.db.get_default("number_format") or "#,###.##"
+	return get_number_format_info(fmt)[2]
 
 
 def css_bar(rows: Sequence[Mapping[str, object] | Sequence[object]]) -> str:
@@ -119,7 +133,7 @@ def fmt_pct(value: float | int | str | None) -> str:
 	"""Format ``value`` - already a percent number, e.g. ``42.5`` -> ``"42.5%"``
 	- via ``fmt_money`` at the site's own number-format precision.
 
-	Explicitly passes ``get_number_format().precision`` rather than letting
+	Explicitly passes ``number_format_precision()`` rather than letting
 	``fmt_money`` fall back to the system currency-precision default: a percent
 	has nothing to do with currency precision, so decoupling keeps the decimal
 	count locale-correct without accidentally inheriting a currency setting.
@@ -130,7 +144,7 @@ def fmt_pct(value: float | int | str | None) -> str:
 	num = _to_float_or_none(value)
 	if num is None:
 		return "—"
-	precision = get_number_format().precision
+	precision = number_format_precision()
 	formatted = html.escape(fmt_money(abs(num), precision=precision))
 	return f'<span class="neg">({formatted}%)</span>' if num < 0 else f"{formatted}%"
 


### PR DESCRIPTION
## Summary

`jarvis/tools/_export/document/graphics.py` imported `frappe.utils.data.get_number_format` at **module top** — a Frappe-16-only symbol (re-exported there from `frappe.locale`). On **Frappe 15** that symbol does not exist, so the import raised `ImportError` at load time. Because `export_document.py` imports `css_bar` **from** graphics at its own top, the failure cascaded: the `export_document` tool and the graphics test module were **un-importable on the Frappe 15 customer bench**.

The symbol was used in exactly one place — `fmt_pct` — only to read the site number-format **precision** (an int).

## Fix (Frappe 15 native)

This is the Frappe 15 support line, so precision is resolved the **Frappe 15 way, directly** — no version probing, no `try/except` fallback. A small `number_format_precision()` helper in `graphics.py`:

```python
def number_format_precision() -> int:
    fmt = frappe.db.get_default("number_format") or "#,###.##"
    return get_number_format_info(fmt)[2]
```

This is exactly how Frappe 15's own `fmt_money` computes precision, so `fmt_pct` gets the identical value the framework would — without inheriting `fmt_money`'s currency-precision default. `get_number_format_info` is a stable, native Frappe 15 API (module-top import, resolves on 15). Test stubs retarget to `graphics.number_format_precision`.

## Cross-verification (nothing else breaks on V15)

Ran an **AST scan of every `frappe` import in the app against the live Frappe 15 interpreter**, narrowed to the real risk class — **module-top, unguarded** imports (executed at load time):

| Location | Symbol | Verdict |
|---|---|---|
| `graphics.py:35` | `get_number_format` | **Fixed** (was module-top, unguarded) |
| `realtime/handlers.py:132` | `frappe.realtime.context.frappe_context` | **Report-only** — lazy import; the Frappe Python-realtime *process* that loads `handlers.py` does not exist on Frappe 15 (`frappe.realtime` is a module there, not a package), so the path is unreachable on the F15 bench. Not changed. |
| `compat.py` xlsx | `XLSXStyleBuilder` / `make_xlsx` | Safe — already inside `try/except` / F16-only lazy branch |

**Result: after this change, zero module-top unguarded Frappe-16-only imports remain.**

## Verification

- `test_export_document_graphics` — **45/45 green on Frappe 15** (was erroring at collection before).
- `test_compat_frappe_versions` — 15/15 green on Frappe 15.
- `ruff check` + `ruff format` clean; all pre-commit hooks pass.

## RCA

Same systemic cause as #904: the module was authored and CI'd against **Frappe 16 only**, and nothing in CI exercises Frappe 15, so a 16-only symbol shipped onto the 15 customer bench and failed at import. The lasting fix is a **Frappe 15 import-smoke lane in CI** (even just the AST scan above) — without it, the next 16-only import slips through the same way. Audit boundary for this PR: **import-time** failures are fully audited via AST across the app; runtime attribute access is spot-checked only.
