### PR TITLE
fix: declare nh3 as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ dependencies = [
     # but html5lib has no other requirer, so pin all three explicitly for the FC image.
     "tinycss2>=1.1",
     "html5lib>=1.1",
+    # HTML sanitizer for document export (jarvis/tools/_export/document/sanitizer.py).
+    # Declared explicitly: frappe only started shipping nh3 itself in v16, so relying
+    # on the transitive install breaks every Frappe v15 bench at import time. The
+    # range stays inside frappe v16's own "nh3~=0.3.2" pin so the two never conflict.
+    "nh3>=0.2,<0.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,11 @@ dependencies = [
     # HTML sanitizer for document export (jarvis/tools/_export/document/sanitizer.py).
     # Declared explicitly: frappe only started shipping nh3 itself in v16, so relying
     # on the transitive install breaks every Frappe v15 bench at import time. The
-    # range stays inside frappe v16's own "nh3~=0.3.2" pin so the two never conflict.
-    "nh3>=0.2,<0.4",
+    # floor matters: sanitizer.py passes clean_content_tags= on every nh3.clean()
+    # call, and nh3 < 0.2.5 rejects that kwarg with a TypeError. Mirroring frappe
+    # v16's own "nh3~=0.3.2" pin keeps the two ranges identical, so they can never
+    # conflict and a v15 bench resolves the same nh3 a v16 bench gets.
+    "nh3~=0.3.2",
 ]
 
 [build-system]


### PR DESCRIPTION
jarvis imports nh3 (the document-export HTML sanitizer) without declaring it, which crashes every Frappe v15 bench at import time; this declares it.

## What changed
- pyproject.toml declares nh3 with a range inside frappe v16's own pin, so nothing changes on v16 benches and v15 benches stop crashing.

## Risk and verification
- No code change; on v16 the same nh3 version is already installed via frappe, so this is a no-op there.
- Found by the first v15 CI run on #927; the cherry-pick of this commit onto that PR is what proves it on a real v15 bench.

https://claude.ai/code/session_01Ui9kZy3ZCgzkwz2jRb5uci
