### PR TITLE
test: enforce only_for denial assertions on Frappe 15

### DIFF
--- a/jarvis/tests/_role_guard.py
+++ b/jarvis/tests/_role_guard.py
@@ -1,0 +1,45 @@
+"""Make ``frappe.only_for()`` denial assertions hold on Frappe 15 and 16.
+
+Frappe 15's ``only_for()`` returns early when ``frappe.local.flags.in_test`` is
+set, so under the test runner a denial test never exercises the role check and
+``assertRaises(PermissionError)`` fails. Frappe 16 removed that bypass.
+Production requests never set the flag, so the guard is enforced on both
+majors; only the test runner's view differs.
+
+Following the :mod:`jarvis.compat` doctrine, this probes the behavior itself
+(does ``only_for``'s source consult the flag?) rather than branching on
+``frappe.__version__``, so the shim self-retires wherever the bypass is gone.
+"""
+
+import contextlib
+import functools
+import inspect
+
+import frappe
+
+
+@contextlib.contextmanager
+def enforced_role_guards():
+	"""Clear ``flags.in_test`` around a call so ``only_for()`` checks roles.
+
+	Wrap ONLY the denial assertion: the guard raises before the endpoint body
+	runs, so nothing else observes the cleared flag.
+	"""
+	if not _only_for_bypasses_in_test():
+		yield
+		return
+	flags = frappe.local.flags
+	prev = flags.get("in_test")
+	flags.in_test = False
+	try:
+		yield
+	finally:
+		flags.in_test = prev
+
+
+@functools.cache
+def _only_for_bypasses_in_test() -> bool:
+	try:
+		return "in_test" in inspect.getsource(frappe.only_for)
+	except (OSError, TypeError):
+		return False

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.api import call_tool
+from jarvis.tests._role_guard import enforced_role_guards
 
 
 class TestCallToolStandardAuth(FrappeTestCase):
@@ -944,7 +945,7 @@ class TestRotateAgentTokenEndpoint(FrappeTestCase):
 			frappe.db.commit()
 		try:
 			frappe.set_user(user_email)
-			with self.assertRaises(frappe.PermissionError):
+			with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 				self._call_rotate()
 		finally:
 			frappe.set_user("Administrator")

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -20,6 +20,7 @@ from jarvis.dev import (
 	_RESET_ZERO_FIELDS,
 	reset_onboarding,
 )
+from jarvis.tests._role_guard import enforced_role_guards
 
 SETTINGS = "Jarvis Settings"
 
@@ -126,7 +127,7 @@ class TestResetOnboardingGuards(FrappeTestCase):
 	def test_rejects_when_non_system_manager(self):
 		# Use a Guest who lacks System Manager role.
 		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
+		with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 			reset_onboarding()
 
 
@@ -222,7 +223,7 @@ class TestResetOnboardingEndpoint(FrappeTestCase):
 		from jarvis.onboarding import reset_onboarding as endpoint
 
 		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
+		with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 			endpoint()
 
 	def test_rejects_jarvis_admin_who_is_not_system_manager(self):
@@ -254,7 +255,7 @@ class TestResetOnboardingEndpoint(FrappeTestCase):
 		self.assertNotIn("System Manager", roles)
 
 		frappe.set_user(email)
-		with self.assertRaises(frappe.PermissionError):
+		with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 			endpoint()
 
 	@patch("jarvis.dev.reset_onboarding", return_value={"ok": True, "data": {}})

--- a/jarvis/tests/test_insight_skill_update.py
+++ b/jarvis/tests/test_insight_skill_update.py
@@ -27,6 +27,7 @@ from unittest import mock
 import frappe
 
 from jarvis.chat import learned_api
+from jarvis.tests._role_guard import enforced_role_guards
 
 JLP = "Jarvis Learned Pattern"
 SKILL = "Jarvis Custom Skill"
@@ -205,7 +206,7 @@ class TestInsightSkillUpdate(unittest.TestCase):
 	# ------------------------------------------------------------------ #
 	def test_non_sm_is_refused(self):
 		name = _mk("g1")
-		with _as(self.non_sm):
+		with _as(self.non_sm), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.draft_insight_skill_update(name)
 			with self.assertRaises(frappe.PermissionError):

--- a/jarvis/tests/test_learned_api.py
+++ b/jarvis/tests/test_learned_api.py
@@ -29,6 +29,7 @@ import frappe
 from frappe.utils import add_days, now_datetime
 
 from jarvis.chat import learned_api
+from jarvis.tests._role_guard import enforced_role_guards
 
 JLP = "Jarvis Learned Pattern"
 RUN = "Jarvis Pattern Run"
@@ -181,7 +182,7 @@ class TestLearnedApi(unittest.TestCase):
 	# ------------------------------------------------------------------ #
 	def test_non_sm_is_refused(self):
 		_mk("g1")
-		with _as(self.non_sm):
+		with _as(self.non_sm), enforced_role_guards():
 			for call in (
 				lambda: learned_api.list_learned_patterns_page(),
 				lambda: learned_api.pending_learned_count(),

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -21,6 +21,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat.custom_skills import build_push_payload, prefixed_slug
+from jarvis.tests._role_guard import enforced_role_guards
 
 SKILL = "Jarvis Custom Skill"
 RESV = "Jarvis Shared Skill Slug"
@@ -632,7 +633,7 @@ class TestSkillPromotionSurfacing(Part2Base):
 		# review surface is reviewer-gated end to end).
 		from jarvis.chat import custom_skills_api, learned_api
 
-		with _as(USER_B):
+		with _as(USER_B), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				custom_skills_api.list_skill_promotion_requests(status="Pending")
 			with self.assertRaises(frappe.PermissionError):

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -29,6 +29,7 @@ from pypika.terms import Field
 
 from jarvis import diagnostics
 from jarvis.chat import agents_api, usage
+from jarvis.tests._role_guard import enforced_role_guards
 
 SETTINGS = "Jarvis Settings"
 USER_SETTINGS = "Jarvis User Settings"
@@ -371,10 +372,10 @@ class TestOwnerSmOnlyCapabilities(Part4Base):
 	def test_rotate_agent_token_rejects_non_sm_admin(self):
 		from jarvis import api as jarvis_api
 
-		with _as(ADMIN):
+		with _as(ADMIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				jarvis_api.rotate_agent_token()
-		with _as(USER_A):
+		with _as(USER_A), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				jarvis_api.rotate_agent_token()
 

--- a/jarvis/tests/test_review_api_rework.py
+++ b/jarvis/tests/test_review_api_rework.py
@@ -30,6 +30,7 @@ from unittest import mock
 import frappe
 
 from jarvis.chat import learned_api, wiki
+from jarvis.tests._role_guard import enforced_role_guards
 
 JLP = "Jarvis Learned Pattern"
 PQ = "Jarvis Personalise Question"
@@ -297,7 +298,7 @@ class TestReviewGuards(unittest.TestCase):
 			self.assertTrue(out.get("ok"))
 
 	def test_plain_user_refused_everything(self):
-		with _as(PLAIN):
+		with _as(PLAIN), enforced_role_guards():
 			self._assert_refused(self._reviewer_calls())
 			self._assert_refused(self._admin_calls())
 			with self.assertRaises(frappe.PermissionError):
@@ -394,7 +395,7 @@ class TestPromotionFlow(unittest.TestCase):
 
 	def test_decide_promotion_refused_for_plain(self):
 		_page, req = _mk_promo(to_scope="Org")
-		with _as(PLAIN):
+		with _as(PLAIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.decide_promotion(req.name, 1, "x")
 
@@ -574,7 +575,7 @@ class TestGoToChat(unittest.TestCase):
 
 	def test_go_to_chat_refused_for_plain(self):
 		p = _mk_pattern("gc3")
-		with _as(PLAIN):
+		with _as(PLAIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.go_to_chat_context("pattern", p)
 


### PR DESCRIPTION
Fixes the 11 permission-denial tests that fail on a Frappe v15 bench: v15's only_for() skips the role check when the test-runner flag is set, so the assertions never saw the PermissionError. Test-only change; confirmed real v15 HTTP requests still enforce the guards, so there is no production security hole.

## What changed
- New jarvis/tests/_role_guard.py: enforced_role_guards() clears the test flag around a denial call so only_for() actually checks roles; probes the behavior instead of the version string, so it self-retires on v16.
- Wraps the 11 affected assertions across 7 test files. No app code touched.

## Risk and verification
- On v16 the helper is a no-op (probe finds no bypass), so the green develop suite is unaffected; v16 CI on this PR is the proof.
- On v15 the cherry-pick onto version-15 should cut its failure count from 163 to ~152.

https://claude.ai/code/session_01Ui9kZy3ZCgzkwz2jRb5uci
