### PR TITLE
backport: v15 compat batches 1-2 (only_for + import/report shims)

### DIFF
--- a/jarvis/compat.py
+++ b/jarvis/compat.py
@@ -29,6 +29,34 @@ import inspect
 import frappe
 
 
+def in_test() -> bool:
+	"""True when running under the test runner, on Frappe 15 and 16.
+
+	Frappe 16 exposes a module-level ``frappe.in_test``; Frappe 15 has no such
+	attribute and instead sets ``frappe.flags.in_test``. Reading ``frappe.in_test``
+	directly raised ``AttributeError`` on 15. Keep 16's check as the first operand
+	so its behavior is unchanged, then fall back to 15's flag.
+
+	Call this via the module (``compat.in_test()``) so tests can patch the one
+	seam on both majors; ``mock.patch("frappe.in_test", ...)`` cannot work on 15,
+	where the attribute does not exist to patch.
+	"""
+	return getattr(frappe, "in_test", False) or bool(frappe.flags.get("in_test"))
+
+
+def set_delimiters_flag(data_import_doc) -> None:
+	"""Apply a Data Import's custom CSV delimiter, where the framework supports it.
+
+	Frappe 16 added ``DataImport.set_delimiters_flag()`` (and the custom-delimiter
+	feature it drives); Frappe 15 has neither and always parses with a comma.
+	Calling it unconditionally was an ``AttributeError`` on 15, so skip it there:
+	with no delimiter feature, the default comma parse is already correct.
+	"""
+	fn = getattr(data_import_doc, "set_delimiters_flag", None)
+	if fn is not None:
+		fn()
+
+
 @functools.cache
 def _get_content_takes_encodings(cls) -> bool:
 	"""Does this File class accept ``get_content(encodings=...)``? (Frappe 16)"""

--- a/jarvis/compat.py
+++ b/jarvis/compat.py
@@ -34,14 +34,20 @@ def in_test() -> bool:
 
 	Frappe 16 exposes a module-level ``frappe.in_test``; Frappe 15 has no such
 	attribute and instead sets ``frappe.flags.in_test``. Reading ``frappe.in_test``
-	directly raised ``AttributeError`` on 15. Keep 16's check as the first operand
-	so its behavior is unchanged, then fall back to 15's flag.
+	directly raised ``AttributeError`` on 15.
+
+	Branch on which flag the framework actually maintains, rather than ORing both:
+	on 16 the module attribute is canonical, so a stray ``flags.in_test`` must not
+	widen this to True and let a scheduler-paused guard run work inline in
+	production. On 15 the module attribute is absent, so the flag is authoritative.
 
 	Call this via the module (``compat.in_test()``) so tests can patch the one
 	seam on both majors; ``mock.patch("frappe.in_test", ...)`` cannot work on 15,
 	where the attribute does not exist to patch.
 	"""
-	return getattr(frappe, "in_test", False) or bool(frappe.flags.get("in_test"))
+	if hasattr(frappe, "in_test"):
+		return bool(frappe.in_test)
+	return bool(frappe.flags.get("in_test"))
 
 
 def set_delimiters_flag(data_import_doc) -> None:

--- a/jarvis/tests/_role_guard.py
+++ b/jarvis/tests/_role_guard.py
@@ -1,0 +1,45 @@
+"""Make ``frappe.only_for()`` denial assertions hold on Frappe 15 and 16.
+
+Frappe 15's ``only_for()`` returns early when ``frappe.local.flags.in_test`` is
+set, so under the test runner a denial test never exercises the role check and
+``assertRaises(PermissionError)`` fails. Frappe 16 removed that bypass.
+Production requests never set the flag, so the guard is enforced on both
+majors; only the test runner's view differs.
+
+Following the :mod:`jarvis.compat` doctrine, this probes the behavior itself
+(does ``only_for``'s source consult the flag?) rather than branching on
+``frappe.__version__``, so the shim self-retires wherever the bypass is gone.
+"""
+
+import contextlib
+import functools
+import inspect
+
+import frappe
+
+
+@contextlib.contextmanager
+def enforced_role_guards():
+	"""Clear ``flags.in_test`` around a call so ``only_for()`` checks roles.
+
+	Wrap ONLY the denial assertion: the guard raises before the endpoint body
+	runs, so nothing else observes the cleared flag.
+	"""
+	if not _only_for_bypasses_in_test():
+		yield
+		return
+	flags = frappe.local.flags
+	prev = flags.get("in_test")
+	flags.in_test = False
+	try:
+		yield
+	finally:
+		flags.in_test = prev
+
+
+@functools.cache
+def _only_for_bypasses_in_test() -> bool:
+	try:
+		return "in_test" in inspect.getsource(frappe.only_for)
+	except (OSError, TypeError):
+		return False

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.api import call_tool
+from jarvis.tests._role_guard import enforced_role_guards
 
 
 class TestCallToolStandardAuth(FrappeTestCase):
@@ -944,7 +945,7 @@ class TestRotateAgentTokenEndpoint(FrappeTestCase):
 			frappe.db.commit()
 		try:
 			frappe.set_user(user_email)
-			with self.assertRaises(frappe.PermissionError):
+			with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 				self._call_rotate()
 		finally:
 			frappe.set_user("Administrator")

--- a/jarvis/tests/test_compat_frappe_versions.py
+++ b/jarvis/tests/test_compat_frappe_versions.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import datetime
 import io
+from unittest.mock import patch
 
 import frappe
 import openpyxl
@@ -259,7 +260,6 @@ class TestItemisedTaxAcrossMajors(FrappeTestCase):
 		if "erpnext" not in frappe.get_installed_apps():
 			self.skipTest("erpnext not installed on this site")
 		import inspect
-		from unittest.mock import patch
 
 		from erpnext.controllers.taxes_and_totals import get_itemised_tax
 
@@ -284,3 +284,70 @@ class TestItemisedTaxAcrossMajors(FrappeTestCase):
 			self.assertIs(seen["target"], doc)
 		else:
 			self.assertEqual(list(seen["target"]), list(doc.get("taxes")))
+
+
+class TestInTestAcrossMajors(FrappeTestCase):
+	"""Exercise compat.in_test()'s real body, not a mock of it. Frappe 16 keeps a
+	module attribute; Frappe 15 keeps only frappe.flags.in_test."""
+
+	def test_true_under_the_runner(self):
+		# We are running under the test runner right now, on whichever major.
+		self.assertTrue(compat.in_test())
+
+	def test_module_attr_is_authoritative_and_not_widened_by_flag(self):
+		"""On a major that has frappe.in_test (16), a stray flags.in_test must NOT
+		flip the result - that is what would let a paused-scheduler guard run work
+		inline in production."""
+		if not hasattr(frappe, "in_test"):
+			self.skipTest("frappe.in_test absent (Frappe 15) - covered by the fallback test")
+		saved_flag = frappe.flags.get("in_test")
+		try:
+			with patch.object(frappe, "in_test", False):
+				frappe.flags.in_test = True
+				self.assertFalse(compat.in_test())  # flag must not widen it
+			with patch.object(frappe, "in_test", True):
+				frappe.flags.in_test = False
+				self.assertTrue(compat.in_test())
+		finally:
+			frappe.flags.in_test = saved_flag
+
+	def test_falls_back_to_flag_when_module_attr_absent(self):
+		"""Simulate Frappe 15 (no module attribute): the flag is authoritative."""
+		had = hasattr(frappe, "in_test")
+		saved_attr = getattr(frappe, "in_test", None)
+		saved_flag = frappe.flags.get("in_test")
+		try:
+			if had:
+				delattr(frappe, "in_test")
+			frappe.flags.in_test = True
+			self.assertTrue(compat.in_test())
+			frappe.flags.in_test = False
+			self.assertFalse(compat.in_test())
+		finally:
+			if had:
+				frappe.in_test = saved_attr
+			frappe.flags.in_test = saved_flag
+
+
+class TestSetDelimitersFlagAcrossMajors(FrappeTestCase):
+	"""compat.set_delimiters_flag() calls the method on Frappe 16, where DataImport
+	has it, and is a no-op on Frappe 15, where it does not exist."""
+
+	def test_calls_the_method_when_present(self):
+		class Doc:
+			def __init__(self):
+				self.called = False
+
+			def set_delimiters_flag(self):
+				self.called = True
+
+		doc = Doc()
+		compat.set_delimiters_flag(doc)
+		self.assertTrue(doc.called)
+
+	def test_no_op_when_absent(self):
+		class Doc:
+			pass
+
+		# Must not raise on a doc lacking the v16-only method (the Frappe 15 shape).
+		compat.set_delimiters_flag(Doc())

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -20,6 +20,7 @@ from jarvis.dev import (
 	_RESET_ZERO_FIELDS,
 	reset_onboarding,
 )
+from jarvis.tests._role_guard import enforced_role_guards
 
 SETTINGS = "Jarvis Settings"
 
@@ -126,7 +127,7 @@ class TestResetOnboardingGuards(FrappeTestCase):
 	def test_rejects_when_non_system_manager(self):
 		# Use a Guest who lacks System Manager role.
 		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
+		with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 			reset_onboarding()
 
 
@@ -222,7 +223,7 @@ class TestResetOnboardingEndpoint(FrappeTestCase):
 		from jarvis.onboarding import reset_onboarding as endpoint
 
 		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
+		with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 			endpoint()
 
 	def test_rejects_jarvis_admin_who_is_not_system_manager(self):
@@ -254,7 +255,7 @@ class TestResetOnboardingEndpoint(FrappeTestCase):
 		self.assertNotIn("System Manager", roles)
 
 		frappe.set_user(email)
-		with self.assertRaises(frappe.PermissionError):
+		with enforced_role_guards(), self.assertRaises(frappe.PermissionError):
 			endpoint()
 
 	@patch("jarvis.dev.reset_onboarding", return_value={"ok": True, "data": {}})

--- a/jarvis/tests/test_insight_skill_update.py
+++ b/jarvis/tests/test_insight_skill_update.py
@@ -27,6 +27,7 @@ from unittest import mock
 import frappe
 
 from jarvis.chat import learned_api
+from jarvis.tests._role_guard import enforced_role_guards
 
 JLP = "Jarvis Learned Pattern"
 SKILL = "Jarvis Custom Skill"
@@ -205,7 +206,7 @@ class TestInsightSkillUpdate(unittest.TestCase):
 	# ------------------------------------------------------------------ #
 	def test_non_sm_is_refused(self):
 		name = _mk("g1")
-		with _as(self.non_sm):
+		with _as(self.non_sm), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.draft_insight_skill_update(name)
 			with self.assertRaises(frappe.PermissionError):

--- a/jarvis/tests/test_learned_api.py
+++ b/jarvis/tests/test_learned_api.py
@@ -29,6 +29,7 @@ import frappe
 from frappe.utils import add_days, now_datetime
 
 from jarvis.chat import learned_api
+from jarvis.tests._role_guard import enforced_role_guards
 
 JLP = "Jarvis Learned Pattern"
 RUN = "Jarvis Pattern Run"
@@ -181,7 +182,7 @@ class TestLearnedApi(unittest.TestCase):
 	# ------------------------------------------------------------------ #
 	def test_non_sm_is_refused(self):
 		_mk("g1")
-		with _as(self.non_sm):
+		with _as(self.non_sm), enforced_role_guards():
 			for call in (
 				lambda: learned_api.list_learned_patterns_page(),
 				lambda: learned_api.pending_learned_count(),

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -21,6 +21,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat.custom_skills import build_push_payload, prefixed_slug
+from jarvis.tests._role_guard import enforced_role_guards
 
 SKILL = "Jarvis Custom Skill"
 RESV = "Jarvis Shared Skill Slug"
@@ -632,7 +633,7 @@ class TestSkillPromotionSurfacing(Part2Base):
 		# review surface is reviewer-gated end to end).
 		from jarvis.chat import custom_skills_api, learned_api
 
-		with _as(USER_B):
+		with _as(USER_B), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				custom_skills_api.list_skill_promotion_requests(status="Pending")
 			with self.assertRaises(frappe.PermissionError):

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -29,6 +29,7 @@ from pypika.terms import Field
 
 from jarvis import diagnostics
 from jarvis.chat import agents_api, usage
+from jarvis.tests._role_guard import enforced_role_guards
 
 SETTINGS = "Jarvis Settings"
 USER_SETTINGS = "Jarvis User Settings"
@@ -371,10 +372,10 @@ class TestOwnerSmOnlyCapabilities(Part4Base):
 	def test_rotate_agent_token_rejects_non_sm_admin(self):
 		from jarvis import api as jarvis_api
 
-		with _as(ADMIN):
+		with _as(ADMIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				jarvis_api.rotate_agent_token()
-		with _as(USER_A):
+		with _as(USER_A), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				jarvis_api.rotate_agent_token()
 

--- a/jarvis/tests/test_review_api_rework.py
+++ b/jarvis/tests/test_review_api_rework.py
@@ -30,6 +30,7 @@ from unittest import mock
 import frappe
 
 from jarvis.chat import learned_api, wiki
+from jarvis.tests._role_guard import enforced_role_guards
 
 JLP = "Jarvis Learned Pattern"
 PQ = "Jarvis Personalise Question"
@@ -297,7 +298,7 @@ class TestReviewGuards(unittest.TestCase):
 			self.assertTrue(out.get("ok"))
 
 	def test_plain_user_refused_everything(self):
-		with _as(PLAIN):
+		with _as(PLAIN), enforced_role_guards():
 			self._assert_refused(self._reviewer_calls())
 			self._assert_refused(self._admin_calls())
 			with self.assertRaises(frappe.PermissionError):
@@ -394,7 +395,7 @@ class TestPromotionFlow(unittest.TestCase):
 
 	def test_decide_promotion_refused_for_plain(self):
 		_page, req = _mk_promo(to_scope="Org")
-		with _as(PLAIN):
+		with _as(PLAIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.decide_promotion(req.name, 1, "x")
 
@@ -574,7 +575,7 @@ class TestGoToChat(unittest.TestCase):
 
 	def test_go_to_chat_refused_for_plain(self):
 		p = _mk_pattern("gc3")
-		with _as(PLAIN):
+		with _as(PLAIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.go_to_chat_context("pattern", p)
 

--- a/jarvis/tests/test_run_import.py
+++ b/jarvis/tests/test_run_import.py
@@ -175,7 +175,7 @@ class TestRunImportGating(FrappeTestCase):
 		# scheduler must NOT stage an import that would sit Pending forever.
 		before = frappe.db.count("Data Import")
 		with (
-			patch.object(frappe, "in_test", False),
+			patch("jarvis.compat.in_test", return_value=False),
 			patch.dict(frappe.conf, {"developer_mode": 0}),
 			patch("jarvis.tools.run_import.is_scheduler_inactive", return_value=True),
 		):

--- a/jarvis/tests/test_run_report.py
+++ b/jarvis/tests/test_run_report.py
@@ -164,7 +164,7 @@ class TestRunReportPrepared(FrappeTestCase):
 	def test_scheduler_paused_raises_without_triggering(self):
 		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
 		with (
-			patch.object(frappe, "in_test", False),
+			patch("jarvis.compat.in_test", return_value=False),
 			patch.dict(frappe.conf, {"developer_mode": 0}),
 			patch("jarvis.tools._prepared_reports.is_scheduler_inactive", return_value=True),
 		):
@@ -175,7 +175,7 @@ class TestRunReportPrepared(FrappeTestCase):
 	def test_queue_unreachable_raises_without_triggering(self):
 		before = frappe.db.count("Prepared Report", {"report_name": PREP_REPORT})
 		with (
-			patch.object(frappe, "in_test", False),
+			patch("jarvis.compat.in_test", return_value=False),
 			patch.dict(frappe.conf, {"developer_mode": 0}),
 			patch("jarvis.tools._prepared_reports.is_scheduler_inactive", return_value=False),
 			patch("jarvis.tools._prepared_reports._queue_reachable", return_value=False),

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -397,10 +397,15 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		orig = frappe.db.get_value
 		seen = {}
 
-		def spy(dt, name=None, field=None, *args, **kwargs):
-			if dt == WIKI and field == "manual_links":
+		def spy(*args, **kwargs):
+			# Signature-flexible: Frappe 15 internals call get_value with a
+			# different positional/keyword mix than 16, so match on values, not
+			# on a fixed parameter list, and pass through verbatim.
+			doctype = args[0] if args else kwargs.get("doctype")
+			fieldname = args[2] if len(args) > 2 else kwargs.get("fieldname")
+			if doctype == WIKI and fieldname == "manual_links":
 				seen["for_update"] = kwargs.get("for_update")
-			return orig(dt, name, field, *args, **kwargs)
+			return orig(*args, **kwargs)
 
 		with patch.object(frappe.db, "get_value", side_effect=spy):
 			wiki_mod.add_wiki_link(p.name, a.name)
@@ -519,10 +524,15 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		orig = frappe.db.get_value
 		seen = {}
 
-		def spy(dt, name=None, field=None, *args, **kwargs):
-			if dt == WIKI and field == "manual_links":
+		def spy(*args, **kwargs):
+			# Signature-flexible: Frappe 15 internals call get_value with a
+			# different positional/keyword mix than 16, so match on values, not
+			# on a fixed parameter list, and pass through verbatim.
+			doctype = args[0] if args else kwargs.get("doctype")
+			fieldname = args[2] if len(args) > 2 else kwargs.get("fieldname")
+			if doctype == WIKI and fieldname == "manual_links":
 				seen["for_update"] = kwargs.get("for_update")
-			return orig(dt, name, field, *args, **kwargs)
+			return orig(*args, **kwargs)
 
 		with patch.object(frappe.db, "get_value", side_effect=spy):
 			wiki_mod.remove_wiki_link(p.name, a.name)

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -34,6 +34,25 @@ def _delete_pages():
 		frappe.delete_doc(WIKI, name, force=True, ignore_permissions=True)
 
 
+def _manual_links_lock_spy(orig, seen: dict):
+	"""A ``frappe.db.get_value`` side_effect that records ``for_update`` on the
+	``manual_links`` read, so the locking-read tests can assert the mechanism.
+
+	Signature-flexible on purpose: Frappe 15 internals call ``get_value`` with a
+	different positional/keyword mix than 16, so match on values rather than a
+	fixed parameter list, and pass through to ``orig`` verbatim.
+	"""
+
+	def spy(*args, **kwargs):
+		doctype = args[0] if args else kwargs.get("doctype")
+		fieldname = args[2] if len(args) > 2 else kwargs.get("fieldname")
+		if doctype == WIKI and fieldname == "manual_links":
+			seen["for_update"] = kwargs.get("for_update")
+		return orig(*args, **kwargs)
+
+	return spy
+
+
 class WikiGraphTestCase(FrappeTestCase):
 	"""Page fixtures swept by slug prefix, shared by the compute tests and the
 	reader-tool tests below."""
@@ -397,15 +416,7 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		orig = frappe.db.get_value
 		seen = {}
 
-		def spy(*args, **kwargs):
-			# Signature-flexible: Frappe 15 internals call get_value with a
-			# different positional/keyword mix than 16, so match on values, not
-			# on a fixed parameter list, and pass through verbatim.
-			doctype = args[0] if args else kwargs.get("doctype")
-			fieldname = args[2] if len(args) > 2 else kwargs.get("fieldname")
-			if doctype == WIKI and fieldname == "manual_links":
-				seen["for_update"] = kwargs.get("for_update")
-			return orig(*args, **kwargs)
+		spy = _manual_links_lock_spy(orig, seen)
 
 		with patch.object(frappe.db, "get_value", side_effect=spy):
 			wiki_mod.add_wiki_link(p.name, a.name)
@@ -524,15 +535,7 @@ class TestWikiGraphCompute(WikiGraphTestCase):
 		orig = frappe.db.get_value
 		seen = {}
 
-		def spy(*args, **kwargs):
-			# Signature-flexible: Frappe 15 internals call get_value with a
-			# different positional/keyword mix than 16, so match on values, not
-			# on a fixed parameter list, and pass through verbatim.
-			doctype = args[0] if args else kwargs.get("doctype")
-			fieldname = args[2] if len(args) > 2 else kwargs.get("fieldname")
-			if doctype == WIKI and fieldname == "manual_links":
-				seen["for_update"] = kwargs.get("for_update")
-			return orig(*args, **kwargs)
+		spy = _manual_links_lock_spy(orig, seen)
 
 		with patch.object(frappe.db, "get_value", side_effect=spy):
 			wiki_mod.remove_wiki_link(p.name, a.name)

--- a/jarvis/tools/_import_preview.py
+++ b/jarvis/tools/_import_preview.py
@@ -23,6 +23,7 @@ import json
 
 import frappe
 
+from jarvis import compat
 from jarvis.chat._record_summary import fmt, is_secret
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools.read_file import _resolve_file
@@ -129,7 +130,7 @@ def build_import_preview(
 
 	# 6. Parse + preview via the ImportFile-level call (transient-safe). Any parse throw
 	#    (empty / non-UTF8 / non-table / malformed) becomes a clean tool error.
-	doc.set_delimiters_flag()
+	compat.set_delimiters_flag(doc)
 	try:
 		importer = doc.get_importer()
 		import_file = importer.import_file
@@ -353,7 +354,7 @@ def _resolve_mapping(mapping: dict, doc) -> dict:
 	drop a mis-keyed override to a harmless ``info`` warning).
 	"""
 	# Parse once without the override to learn the file's header order.
-	doc.set_delimiters_flag()
+	compat.set_delimiters_flag(doc)
 	base_importer = doc.get_importer()
 	headers = [c.header_title for c in base_importer.import_file.header.columns]
 	by_header = {h: i for i, h in enumerate(headers)}

--- a/jarvis/tools/_prepared_reports.py
+++ b/jarvis/tools/_prepared_reports.py
@@ -49,6 +49,7 @@ from frappe.utils import cint
 from frappe.utils.background_jobs import get_redis_conn
 from frappe.utils.scheduler import is_scheduler_inactive
 
+from jarvis import compat
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
 # Cap rows folded into the envelope. A prepared report is the likeliest place to
@@ -326,7 +327,7 @@ def _report_timeout(report_name: str) -> int:
 def _require_worker() -> None:
 	"""Raise if the background queue can't run the report, so we never leave an
 	orphan Queued row. Tests / developer_mode run inline, so skip the check."""
-	if frappe.in_test or frappe.conf.get("developer_mode"):
+	if compat.in_test() or frappe.conf.get("developer_mode"):
 		return
 	if is_scheduler_inactive():
 		raise InvalidArgumentError(

--- a/jarvis/tools/run_import.py
+++ b/jarvis/tools/run_import.py
@@ -17,6 +17,7 @@ import json
 import frappe
 from frappe.utils.scheduler import is_scheduler_inactive
 
+from jarvis import compat
 from jarvis.exceptions import FeatureDisabledError, InvalidArgumentError
 from jarvis.tools._import_preview import build_import_preview
 
@@ -60,7 +61,7 @@ def run_import(
 
 	# Refuse cleanly BEFORE creating anything if the scheduler is paused, so a staged
 	# import never sits Pending with nothing to run it. Test / developer_mode run inline.
-	run_now = frappe.in_test or frappe.conf.developer_mode
+	run_now = compat.in_test() or frappe.conf.developer_mode
 	if not run_now and is_scheduler_inactive():
 		# FeatureDisabledError (not InvalidArgumentError): a paused scheduler is an ops
 		# condition, so the model must NOT be nudged to "check the fields and retry" - the


### PR DESCRIPTION
Backports batches 1 and 2 of the Frappe v15 compatibility burn-down onto the version-15 branch (born on develop as #930 and #931). Should drop this branch's v15 CI failure count from 163 to ~108.

## What changed (cherry-picks, no new code)
- #930: enforce only_for denial assertions on v15 (test-only, ~11 tests).
- #931: compat.in_test() and compat.set_delimiters_flag() shims + wiki spy fix + compat unit tests (~44 tests).

## Risk and verification
- Pure cherry-picks of commits already green on develop's v16 CI; all three applied with no conflicts.
- The real proof is THIS PR's v15 CI run: expect the tests job to still be red but with a materially lower failure count (~108 vs 163). Remaining reds are batches 3-5 (pypika/orjson test-infra, cache, singletons), tracked separately.

https://claude.ai/code/session_01Ui9kZy3ZCgzkwz2jRb5uci
