### PR TITLE
test: fix pypika .run and orjson test-infra gaps on Frappe 15

### DIFF
--- a/jarvis/tests/__init__.py
+++ b/jarvis/tests/__init__.py
@@ -102,3 +102,23 @@ def _install_network_block() -> None:
 
 
 _install_network_block()
+
+
+def dumps_like_response(obj, default):
+	"""Serialize the way THIS Frappe serializes an HTTP response body, so a test
+	reproduces the exact ``json_handler`` path production uses: orjson on Frappe 16
+	(``frappe.utils.response`` calls ``orjson_dumps``), stdlib json on Frappe 15
+	(it calls ``json.dumps``). Frappe 15 does not depend on orjson at all.
+
+	Returns ``bytes`` or ``str``; ``json.loads`` accepts either. Not hardcoded to
+	orjson because the R9 regression it guards (orjson renders a non-exact-dict
+	Mapping as a list of its KEYS via ``default``) is a v16 production behavior,
+	while v15 must still be exercised through its own real serializer.
+	"""
+	try:
+		import orjson
+	except ImportError:
+		import json
+
+		return json.dumps(obj, default=default)
+	return orjson.dumps(obj, default=default)

--- a/jarvis/tests/__init__.py
+++ b/jarvis/tests/__init__.py
@@ -106,19 +106,24 @@ _install_network_block()
 
 def dumps_like_response(obj, default):
 	"""Serialize the way THIS Frappe serializes an HTTP response body, so a test
-	reproduces the exact ``json_handler`` path production uses: orjson on Frappe 16
-	(``frappe.utils.response`` calls ``orjson_dumps``), stdlib json on Frappe 15
-	(it calls ``json.dumps``). Frappe 15 does not depend on orjson at all.
+	reproduces the exact ``json_handler`` path production uses: orjson on Frappe 16,
+	stdlib json on Frappe 15.
 
-	Returns ``bytes`` or ``str``; ``json.loads`` accepts either. Not hardcoded to
-	orjson because the R9 regression it guards (orjson renders a non-exact-dict
-	Mapping as a list of its KEYS via ``default``) is a v16 production behavior,
-	while v15 must still be exercised through its own real serializer.
+	Discriminate on ``frappe.utils.orjson_dumps`` -- the v16-only symbol that IS the
+	production response serializer (``frappe/utils/response.py`` calls it) -- not on
+	whether ``orjson`` merely imports. Keying on the import would (a) silently mask a
+	broken orjson on v16, where production would be 500ing on its own top-level
+	``import orjson`` while these tests stayed green, and (b) route a v15 run through
+	orjson if the package happened to be present transitively, when v15 production
+	uses stdlib json. This mirrors ``_patch_qb_run``: probe the real framework state.
+
+	Returns ``bytes`` or ``str``; ``json.loads`` accepts either.
 	"""
-	try:
-		import orjson
-	except ImportError:
-		import json
+	import frappe.utils
 
-		return json.dumps(obj, default=default)
-	return orjson.dumps(obj, default=default)
+	orjson_dumps = getattr(frappe.utils, "orjson_dumps", None)
+	if orjson_dumps is not None:
+		return orjson_dumps(obj, default=default)
+	import json
+
+	return json.dumps(obj, default=default)

--- a/jarvis/tests/test_model_catalog.py
+++ b/jarvis/tests/test_model_catalog.py
@@ -369,16 +369,18 @@ class TestChatUiSettingsServesApiKeyModels(FrappeTestCase):
 		# so an unwrapped Mapping silently serialises to its KEYS: the response
 		# would carry ["OpenAI", ...] instead of {"OpenAI": [...], ...} with no
 		# error raised. chat/api.py must wrap these in dict().
-		import orjson
+		import json
+
 		from frappe.utils.response import json_handler
 
 		from jarvis.chat.api import get_chat_ui_settings
+		from jarvis.tests import dumps_like_response
 
 		with patch.object(admin_client, "get_model_catalog", return_value=_PAYLOAD):
 			out = get_chat_ui_settings()
 		for key in ("subscription_models", "default_models", "api_key_models"):
 			self.assertIsInstance(out[key], dict, f"{key} must be a real dict before serialisation")
-			decoded = orjson.loads(orjson.dumps(out[key], default=json_handler))
+			decoded = json.loads(dumps_like_response(out[key], json_handler))
 			self.assertIsInstance(decoded, dict, f"{key} serialised to a non-object")
 
 	def test_api_key_models_excludes_subscription_rows(self):
@@ -398,10 +400,12 @@ class TestModelCatalogUiEndpoint(FrappeTestCase):
 		self.addCleanup(_clear_sub_model_cache)
 
 	def test_returns_the_three_catalog_slices_as_json_objects(self):
-		import orjson
+		import json
+
 		from frappe.utils.response import json_handler
 
 		from jarvis.chat.api import get_model_catalog_ui
+		from jarvis.tests import dumps_like_response
 
 		with patch.object(admin_client, "get_model_catalog", return_value=_PAYLOAD):
 			out = get_model_catalog_ui()
@@ -409,7 +413,7 @@ class TestModelCatalogUiEndpoint(FrappeTestCase):
 			self.assertIn(key, out)
 			# R9: a bare Mapping would serialise to its KEYS with no error.
 			self.assertIsInstance(out[key], dict)
-			self.assertIsInstance(orjson.loads(orjson.dumps(out[key], default=json_handler)), dict)
+			self.assertIsInstance(json.loads(dumps_like_response(out[key], json_handler)), dict)
 
 	def test_kimi_is_keyed_by_its_subscription_label(self):
 		from jarvis.chat.api import get_model_catalog_ui

--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -25,6 +25,22 @@ from jarvis.exceptions import (
 from jarvis.tools.query import ROW_GUARD, query
 
 
+def _patch_qb_run():
+	"""Patch the frappe query-builder's ``.run`` so these tests capture generated
+	SQL without hitting the DB, on Frappe 15 and 16.
+
+	Frappe 16 attaches ``.run`` to the base ``pypika.queries.QueryBuilder``;
+	Frappe 15 attaches it to the dialect subclass (``frappe.qb._BuilderClasss``)
+	and leaves the base without it, so ``patch("pypika...QueryBuilder.run")`` raised
+	AttributeError there. Target whichever class actually carries ``.run``. Returns
+	a fresh single-use patcher per call.
+	"""
+	from pypika.queries import QueryBuilder
+
+	target = QueryBuilder if "run" in QueryBuilder.__dict__ else frappe.qb._BuilderClasss
+	return patch.object(target, "run", return_value=[])
+
+
 class TestQuerySpecValidation(FrappeTestCase):
 	"""Top-of-pipe shape checks. Fail before any DB call."""
 
@@ -128,7 +144,7 @@ class TestQueryPermissions(FrappeTestCase):
 		with (
 			patch("frappe.has_permission", side_effect=fake_has_perm),
 			patch("frappe.database.query.Engine") as fake_engine,
-			patch("pypika.queries.QueryBuilder.run", return_value=[]),
+			_patch_qb_run(),
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			query(
@@ -206,7 +222,7 @@ class TestQueryQbTranslation(FrappeTestCase):
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			# We let the real qb run; patch only the actual SQL exec.
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]) as _:
+			with _patch_qb_run() as _:
 				result = query(spec)
 		return result["sql"]
 
@@ -316,7 +332,7 @@ class TestQueryPermissionConditionsWoven(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = sentinel
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query({"from": "DocType", "select": ["name"]})
 
 		self.assertIn("sentinel-marker", result["sql"])
@@ -329,7 +345,7 @@ class TestQueryPermissionConditionsWoven(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query({"from": "DocType", "select": ["name"]})
 
 		# No WHERE clause should appear when nothing constrains the query.
@@ -429,7 +445,7 @@ class TestQueryV02Additions(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(spec)
 		return result["sql"]
 
@@ -920,7 +936,7 @@ class TestQueryV03ExistsSubquerySecurityHardening(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine_cls,
 		):
 			fake_engine_cls.return_value.get_permission_conditions.side_effect = _perm_conds
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(
 					{
 						"from": "DocType",
@@ -1070,7 +1086,7 @@ class TestQueryV03ExistsSubquerySecurityHardening(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine_cls,
 		):
 			fake_engine_cls.return_value.get_permission_conditions.side_effect = _perm_conds
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(
 					{
 						"from": "DocType",
@@ -1148,7 +1164,7 @@ class TestQueryV03ExistsSubquerySecurityHardening(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine_cls,
 		):
 			fake_engine_cls.return_value.get_permission_conditions.side_effect = _capture
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				query(
 					{
 						"from": "DocType",
@@ -1184,7 +1200,7 @@ class TestQueryV03ExistsSubquerySecurityHardening(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine_cls,
 		):
 			fake_engine_cls.return_value.get_permission_conditions.side_effect = _capture
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				query(
 					{
 						"from": "DocType",
@@ -1417,7 +1433,7 @@ class TestQueryExprDSLPhase1Dates(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(spec)
 		return result["sql"]
 
@@ -1745,7 +1761,7 @@ class TestQueryExprDSLPhase2NullAndArithmetic(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(spec)
 		return result["sql"]
 
@@ -1933,7 +1949,7 @@ class TestQueryExprDSLPhase3CaseWhen(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(spec)
 		return result["sql"]
 
@@ -2130,7 +2146,7 @@ class TestQueryExprDSLPhase4StringHelpers(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(spec)
 		return result["sql"]
 
@@ -2262,7 +2278,7 @@ class TestQuerySqlInjectionHardening(FrappeTestCase):
 			patch("frappe.database.query.Engine") as fake_engine,
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
-			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with _patch_qb_run():
 				result = query(spec)
 		return result["sql"]
 
@@ -2867,7 +2883,7 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 				return_value=[self.PARENT_DT],
 			),
 			patch("frappe.database.query.Engine") as fake_engine,
-			patch("pypika.queries.QueryBuilder.run", return_value=[]),
+			_patch_qb_run(),
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			result = query(
@@ -2896,7 +2912,7 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 				return_value=[self.PARENT_DT],
 			),
 			patch("frappe.database.query.Engine") as fake_engine,
-			patch("pypika.queries.QueryBuilder.run", return_value=[]),
+			_patch_qb_run(),
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			result = query(
@@ -2934,7 +2950,7 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 				return_value=[self.PARENT_DT],
 			),
 			patch("frappe.database.query.Engine") as fake_engine,
-			patch("pypika.queries.QueryBuilder.run", return_value=[]),
+			_patch_qb_run(),
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			result = query(
@@ -3053,7 +3069,7 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 				return_value=[self.PARENT_DT],
 			),
 			patch("frappe.database.query.Engine") as fake_engine,
-			patch("pypika.queries.QueryBuilder.run", return_value=[]),
+			_patch_qb_run(),
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			result = query(
@@ -3100,7 +3116,7 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 				return_value=[self.PARENT_DT],
 			),
 			patch("frappe.database.query.Engine") as fake_engine,
-			patch("pypika.queries.QueryBuilder.run", return_value=[]),
+			_patch_qb_run(),
 		):
 			fake_engine.return_value.get_permission_conditions.return_value = None
 			result = query(

--- a/jarvis/tests/test_subscription_models.py
+++ b/jarvis/tests/test_subscription_models.py
@@ -39,11 +39,12 @@ class TestSubscriptionCatalogue(unittest.TestCase):
 		# additionally locks the R9 rule: production serialises with orjson +
 		# frappe's json_handler, which turns a BARE Mapping into a list of its
 		# KEYS with no error raised.
-		import orjson
 		from frappe.utils.response import json_handler
 
+		from jarvis.tests import dumps_like_response
+
 		json.dumps(dict(cat.SUBSCRIPTION_MODELS))  # must not raise
-		decoded = orjson.loads(orjson.dumps(dict(cat.SUBSCRIPTION_MODELS), default=json_handler))
+		decoded = json.loads(dumps_like_response(dict(cat.SUBSCRIPTION_MODELS), json_handler))
 		self.assertIsInstance(decoded, dict, "catalogue must serialise to a JSON object")
 		for value in cat.SUBSCRIPTION_MODELS.values():
 			self.assertIsInstance(value, list)


### PR DESCRIPTION
Fixes ~60 tests that fail on a Frappe v15 bench, from two test-infrastructure gaps. No app code changes.

## What changed
- test_query.py: 19 sites patched pypika's base QueryBuilder.run, which only exists on v16 (v15 attaches .run to the dialect subclass). Added _patch_qb_run() that targets whichever class actually carries .run. App code was never affected.
- orjson: v16 frappe serialises responses with orjson and ships it; v15 uses stdlib json and does not. Added dumps_like_response() that serialises the way the installed frappe does, and routed the 3 round-trip tests through it; the dict-ness assertions still run on both.

## Risk and verification
- On v16 both helpers resolve to the current behavior (base QueryBuilder.run; orjson), so the green develop suite is unaffected; v16 CI here proves it.
- On v15 the cherry-pick onto version-15 should cut its failure count from ~108 to ~48.

https://claude.ai/code/session_01Ui9kZy3ZCgzkwz2jRb5uci
