### PR TITLE
fix(v15): route set_delimiters_flag through compat probe (unbreak CI)

### DIFF
--- a/jarvis/compat.py
+++ b/jarvis/compat.py
@@ -29,6 +29,19 @@ import inspect
 import frappe
 
 
+def set_delimiters_flag(data_import_doc) -> None:
+	"""Apply a Data Import's custom CSV delimiter, where the framework supports it.
+
+	Frappe 16 added ``DataImport.set_delimiters_flag()`` (and the custom-delimiter
+	feature it drives); Frappe 15 has neither and always parses with a comma.
+	Calling it unconditionally was an ``AttributeError`` on 15, so skip it there:
+	with no delimiter feature, the default comma parse is already correct.
+	"""
+	fn = getattr(data_import_doc, "set_delimiters_flag", None)
+	if fn is not None:
+		fn()
+
+
 @functools.cache
 def _get_content_takes_encodings(cls) -> bool:
 	"""Does this File class accept ``get_content(encodings=...)``? (Frappe 16)"""

--- a/jarvis/tests/test_compat_frappe_versions.py
+++ b/jarvis/tests/test_compat_frappe_versions.py
@@ -284,3 +284,35 @@ class TestItemisedTaxAcrossMajors(FrappeTestCase):
 			self.assertIs(seen["target"], doc)
 		else:
 			self.assertEqual(list(seen["target"]), list(doc.get("taxes")))
+
+
+class TestSetDelimitersFlag(FrappeTestCase):
+	"""``compat.set_delimiters_flag`` probes for the method instead of calling it.
+
+	Frappe 16 added ``DataImport.set_delimiters_flag``; Frappe 15 has no such
+	method, and a Frappe 16 that later drops or renames it looks the same to us.
+	The old code called ``doc.set_delimiters_flag()`` directly and raised
+	``AttributeError`` on any framework lacking it, breaking every import-preview
+	call. Unlike the shims above, this contract is framework-shape-independent
+	(call iff present), so stand-in objects exercise both branches deterministically
+	rather than depending on which major the bench happens to carry.
+	"""
+
+	def test_calls_through_when_the_method_exists(self):
+		class WithFlag:
+			def __init__(self):
+				self.called = 0
+
+			def set_delimiters_flag(self):
+				self.called += 1
+
+		doc = WithFlag()
+		compat.set_delimiters_flag(doc)
+		self.assertEqual(doc.called, 1)
+
+	def test_is_a_noop_when_the_method_is_absent(self):
+		class WithoutFlag:
+			pass
+
+		# Must not raise AttributeError - this is the regression.
+		compat.set_delimiters_flag(WithoutFlag())

--- a/jarvis/tools/_import_preview.py
+++ b/jarvis/tools/_import_preview.py
@@ -23,6 +23,7 @@ import json
 
 import frappe
 
+from jarvis import compat
 from jarvis.chat._record_summary import fmt, is_secret
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools.read_file import _resolve_file
@@ -129,7 +130,7 @@ def build_import_preview(
 
 	# 6. Parse + preview via the ImportFile-level call (transient-safe). Any parse throw
 	#    (empty / non-UTF8 / non-table / malformed) becomes a clean tool error.
-	doc.set_delimiters_flag()
+	compat.set_delimiters_flag(doc)
 	try:
 		importer = doc.get_importer()
 		import_file = importer.import_file
@@ -353,7 +354,7 @@ def _resolve_mapping(mapping: dict, doc) -> dict:
 	drop a mis-keyed override to a harmless ``info`` warning).
 	"""
 	# Parse once without the override to learn the file's header order.
-	doc.set_delimiters_flag()
+	compat.set_delimiters_flag(doc)
 	base_importer = doc.get_importer()
 	headers = [c.header_title for c in base_importer.import_file.header.columns]
 	by_header = {h: i for i, h in enumerate(headers)}


### PR DESCRIPTION
## Summary

Fixes the version-15 branch's CI, which went red for every PR after the shared `jarvis-ci-base:v16` image was rebuilt today with a Frappe that no longer exposes `DataImport.set_delimiters_flag`. `jarvis/tools/_import_preview.py` called that method directly and raised `AttributeError`, failing ~66 import/preview tests and destabilising the whole run.

`develop` already routes this call through a probe-based shim (`jarvis.compat.set_delimiters_flag`) and stays green on the exact same image; the shim was simply never backported to version-15. This adds it verbatim from develop and swaps the two call sites.

## What changed
- `jarvis/compat.py`: add `set_delimiters_flag(doc)` (verbatim from develop) - `getattr`-probes the method and no-ops when the framework lacks it
- `jarvis/tools/_import_preview.py`: call `compat.set_delimiters_flag(doc)` instead of `doc.set_delimiters_flag()` at both sites; add the `compat` import
- `jarvis/tests/test_compat_frappe_versions.py`: unit-test both probe branches (calls through when present, no-ops when absent)

## Risk and verification
- Behavior-preserving on a Frappe that has the method (the shim calls straight through); the only change is that a framework lacking it no longer raises
- Matches develop, which is green on the same `:v16` image (run for `develop@2a408487` passed at 14:34 today while base `version-15` failed identically)

<details><summary>Root cause evidence</summary>

- Base `version-15` (run 32260184316) fails with `AttributeError: 'DataImport' object has no attribute 'set_delimiters_flag'` x66, plus cascade `db down` / `no such site` and 3 `orjson` errors (orjson is present in the image - develop imports it and passes - so those clear once the run stops falling over).
- Timeline: this branch was green at 13:21 today, red from ~13:48 - the window the base image was rebuilt. No version-15 code changed in between.
- develop's `jarvis/compat.py` docstring documents the same class of Frappe 15/16 drift and the probe-not-version-string doctrine.

</details>

## Pre-merge checklist

- [ ] **CI is green** - the `tests` check on this PR passes (this PR is the fix for it)
- [ ] Branch is **up to date with `main`** (n/a: targets `version-15`)
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff

https://claude.ai/code/session_01WZJ3nhp1CqHuWzhGibypRa
