### PR TITLE
backport: v15 batch 4 (Frappe-15 cache-poisoning fix)

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -501,7 +501,7 @@ def _admin_chat_gate() -> dict:
 	raw = _settings_raw(_GATE_STATE_FIELDS)
 	cache = frappe.cache()
 	cache_key = f"{_CHAT_GATE_CACHE_KEY}:{_gate_revision(raw)}"
-	cached = cache.get_value(cache_key)
+	cached = cache.get_value(cache_key, expires=True)
 	if cached:
 		if isinstance(cached, dict) and cached.get("unconfirmed"):
 			return _admin_unreachable_verdict(
@@ -623,7 +623,7 @@ def _site_replacement() -> dict:
 	"""Cached {replaced, at, moved_to}. Cached both ways: a replaced site would
 	otherwise ask on every gate miss, and an unreplaced one on every admin blip."""
 	cache = frappe.cache()
-	hit = cache.get_value(_REPLACED_CACHE_KEY)
+	hit = cache.get_value(_REPLACED_CACHE_KEY, expires=True)
 	if isinstance(hit, dict):
 		return hit
 	try:
@@ -885,7 +885,7 @@ def _confirm_apply_via_admin(settings, *, is_pool: bool) -> bool:
 	"""
 	try:
 		cache = frappe.cache()
-		if cache.get_value(_APPLY_CONFIRM_MISS_KEY):
+		if cache.get_value(_APPLY_CONFIRM_MISS_KEY, expires=True):
 			return False
 		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
 			_admin_chat_readiness,

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -21,7 +21,7 @@ import hashlib
 
 import frappe
 
-from jarvis import admin_client, onboarding_contract, release_notice
+from jarvis import admin_client, compat, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
@@ -501,7 +501,7 @@ def _admin_chat_gate() -> dict:
 	raw = _settings_raw(_GATE_STATE_FIELDS)
 	cache = frappe.cache()
 	cache_key = f"{_CHAT_GATE_CACHE_KEY}:{_gate_revision(raw)}"
-	cached = cache.get_value(cache_key, expires=True)
+	cached = compat.cache_get_memoized(cache_key)
 	if cached:
 		if isinstance(cached, dict) and cached.get("unconfirmed"):
 			return _admin_unreachable_verdict(

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -640,7 +640,7 @@ def get_preset_catalog() -> list:
 	from jarvis._preset_catalog import BUNDLED_PRESET_CATALOG
 
 	cache = frappe.cache()
-	cached = cache.get_value(_PRESET_CATALOG_CACHE_KEY)
+	cached = cache.get_value(_PRESET_CATALOG_CACHE_KEY, expires=True)
 	if cached:
 		return cached
 	try:
@@ -711,12 +711,12 @@ def _fetch_model_catalog() -> list:
 	from jarvis._model_catalog import BUNDLED_MODEL_CATALOG
 
 	cache = frappe.cache()
-	cached = cache.get_value(_MODEL_CATALOG_CACHE_KEY)
+	cached = cache.get_value(_MODEL_CATALOG_CACHE_KEY, expires=True)
 	if cached:
 		return cached
 	# A recent failure short-circuits the network entirely. Without this, a
 	# hanging admin costs every chat send a full timeout.
-	if cache.get_value(_MODEL_CATALOG_FAIL_KEY):
+	if cache.get_value(_MODEL_CATALOG_FAIL_KEY, expires=True):
 		return BUNDLED_MODEL_CATALOG
 	try:
 		catalog = _post_guest(
@@ -767,7 +767,7 @@ def get_stt_config() -> dict | None:
 	slow/down admin can't make every SPA load pay a fresh round-trip.
 	Never raises."""
 	cache = frappe.cache()
-	cached = cache.get_value(_STT_CONFIG_CACHE_KEY)
+	cached = cache.get_value(_STT_CONFIG_CACHE_KEY, expires=True)
 	if cached == _STT_CONFIG_MISS:
 		return None
 	if cached:
@@ -1926,7 +1926,7 @@ def _admin_access_token(settings, admin_url: str, *, force_refresh: bool = False
 		return None
 
 	cache = frappe.cache()
-	cached = {} if force_refresh else (cache.get_value(_OAUTH_CACHE_KEY) or {})
+	cached = {} if force_refresh else (cache.get_value(_OAUTH_CACHE_KEY, expires=True) or {})
 	access = cached.get("access_token")
 	if access and (cached.get("access_expires_at", 0) - _OAUTH_EXPIRY_SKEW_S) > time.time():
 		return access

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -297,7 +297,7 @@ def _notify_stale_pairing(*, session_key: str, tool: str, tool_call_id: str | No
 	"""
 	dedupe_key = f"jarvis:stale_pairing_notified:{session_key}"
 	try:
-		if frappe.cache().get_value(dedupe_key):
+		if frappe.cache().get_value(dedupe_key, expires=True):
 			return
 	except Exception:
 		pass  # cache unavailable - fall through and notify anyway

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -1899,7 +1899,7 @@ def _rate_limit_apply() -> None:
 		return
 	me = frappe.session.user
 	key = f"jarvis_apply_agents_rl:{me}"
-	if frappe.cache().get_value(key):
+	if frappe.cache().get_value(key, expires=True):
 		frappe.throw(_("An apply is already in progress — please wait a moment."))
 	frappe.cache().set_value(key, "1", expires_in_sec=5)
 

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -2585,7 +2585,7 @@ def _turn_queue() -> str:
 	if CHAT_QUEUE not in (frappe.get_conf().get("workers") or {}):
 		return "long"
 	cache_key = "jarvis:turn_queue"
-	cached = frappe.cache().get_value(cache_key)
+	cached = frappe.cache().get_value(cache_key, expires=True)
 	if cached:
 		return cached
 	queue = "long"

--- a/jarvis/chat/custom_skills.py
+++ b/jarvis/chat/custom_skills.py
@@ -416,7 +416,7 @@ def personal_skill_clause(user: str | None = None) -> str:
 		return ""
 	cache = frappe.cache()
 	key = personal_skills_cache_key(user)
-	count = cache.get_value(key)
+	count = cache.get_value(key, expires=True)
 	if count is None:
 		# Exact scope match: NULL/empty scope rows are Org and never counted.
 		# "User" is the scope-ladder spelling of the old "Personal" (TASK 10).

--- a/jarvis/chat/customizations_clause.py
+++ b/jarvis/chat/customizations_clause.py
@@ -40,7 +40,7 @@ def customizations_clause() -> str:
 		if not clause_enabled():
 			return ""
 		cache = frappe.cache()
-		cached = cache.get_value(_CLAUSE_CACHE_KEY)
+		cached = cache.get_value(_CLAUSE_CACHE_KEY, expires=True)
 		if cached is not None:
 			return cached
 		clause = _build_clause()

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -843,7 +843,7 @@ def _log_schema_failure(view_key: str, root: str) -> None:
 	key = f"jarvis:list-filter-schema-fail:{view_key}"
 	try:
 		cache = frappe.cache()
-		if cache.get_value(key):
+		if cache.get_value(key, expires=True):
 			return
 		cache.set_value(key, "1", expires_in_sec=SCHEMA_FAILURE_LOG_TTL)
 	except Exception:
@@ -862,7 +862,7 @@ def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 	fingerprint = _meta_fingerprint(root, user)
 	key = _cache_key(view.view_key, user, fingerprint)
 	try:
-		cached = frappe.cache().get_value(key)
+		cached = frappe.cache().get_value(key, expires=True)
 	except Exception:
 		cached = None
 	if isinstance(cached, dict) and cached.get("contract_version") == CONTRACT_VERSION:
@@ -957,7 +957,7 @@ def _log_flag_misconfig(value: Any) -> None:
 	key = "jarvis:list-filter-flag-misconfig"
 	try:
 		cache = frappe.cache()
-		if cache.get_value(key):
+		if cache.get_value(key, expires=True):
 			return
 		cache.set_value(key, "1", expires_in_sec=FLAG_MISCONFIG_LOG_TTL)
 	except Exception:

--- a/jarvis/chat/list_filters.py
+++ b/jarvis/chat/list_filters.py
@@ -64,6 +64,7 @@ from typing import Any
 import frappe
 from frappe import _
 
+from jarvis import compat
 from jarvis.chat import list_registry
 from jarvis.permissions import require_jarvis_user
 
@@ -862,7 +863,7 @@ def _build_schema(view: list_registry.ListView, root: str, user: str) -> dict:
 	fingerprint = _meta_fingerprint(root, user)
 	key = _cache_key(view.view_key, user, fingerprint)
 	try:
-		cached = frappe.cache().get_value(key, expires=True)
+		cached = compat.cache_get_memoized(key)
 	except Exception:
 		cached = None
 	if isinstance(cached, dict) and cached.get("contract_version") == CONTRACT_VERSION:

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -339,7 +339,7 @@ def warm_prefix() -> bool:
 			# sweep still collects it) instead of losing the pointer to the one we
 			# just created, which would leak one every warm, forever.
 			last_key = _warm_last_key()
-			prev = cache.get_value(last_key)
+			prev = cache.get_value(last_key, expires=True)
 			# Remember WHEN as well as WHICH: the next warm needs the fire time to
 			# tell "this predecessor's run finished" from "this predecessor's run
 			# has not started yet", which sessions.list reports identically (issue

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -74,6 +74,7 @@ from dataclasses import dataclass, field
 
 import frappe
 
+from jarvis import compat
 from jarvis.chat import turn_state as ts
 from jarvis.chat.relay_mux import LaneHandler, RelayMux
 from jarvis.exceptions import AgentUnreachableError
@@ -678,7 +679,7 @@ def _lease_mirror_live(target: str) -> bool:
 	MariaDB would). A MISSING mirror is NEVER treated as proof of vacancy — the
 	caller falls through to the authoritative MariaDB read (D4-b)."""
 	try:
-		return bool(frappe.cache().get_value(_lease_mirror_key(target), use_local_cache=False))
+		return bool(compat.cache_get_fresh(_lease_mirror_key(target)))
 	except Exception:
 		return False
 
@@ -707,7 +708,7 @@ def _read_last_known_gateway_active(target: str) -> int | None:
 	"""CDX-11: the last-known foreign-usage count if still within its TTL, else None
 	(the observation aged out — treat foreign usage as genuinely unknown)."""
 	try:
-		v = frappe.cache().get_value(_gateway_active_key(target), use_local_cache=False)
+		v = compat.cache_get_fresh(_gateway_active_key(target))
 		if v is None:
 			return None
 		return int(v.decode() if isinstance(v, bytes) else v)
@@ -835,7 +836,7 @@ def _warn_provisioning_if_starved() -> None:
 	try:
 		site = frappe.local.site
 		key = f"jarvis:pump:provision_warn:{site}"
-		if frappe.cache().get_value(key):
+		if frappe.cache().get_value(key, expires=True):
 			return
 		frappe.cache().set_value(key, "1", expires_in_sec=300)
 	except Exception:
@@ -3117,7 +3118,7 @@ def _log_wedged_throttled(target: str, epoch: int) -> None:
 	"""Log a wedged-but-live-lease detection at most once per hour per shard (so a
 	persistently-wedged shard cannot flood the Error Log every watchdog tick)."""
 	key = f"jarvis_pump_wedged_logged::{target}"
-	if frappe.cache().get_value(key):
+	if frappe.cache().get_value(key, expires=True):
 		return
 	frappe.cache().set_value(key, "1", expires_in_sec=_WEDGED_LOG_TTL_S)
 	frappe.log_error(

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -694,7 +694,7 @@ def _maybe_nudge(conversation_id: str, user: str) -> None:
 	if cache.get_value(_NUDGE_OFF_KEY.format(conv=conversation_id), expires=True):
 		return
 	cooldown_key = _NUDGE_COOLDOWN_KEY.format(conv=conversation_id)
-	if cache.get_value(cooldown_key):
+	if cache.get_value(cooldown_key, expires=True):
 		return
 
 	entities = _nudge_entities(conversation_id)

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -402,7 +402,7 @@ def _has_active_pages() -> bool:
 	the Jarvis Wiki Page controller on insert/update/trash (the archive path
 	saves through on_update), with a short TTL as the backstop."""
 	cache = frappe.cache()
-	flag = cache.get_value(WIKI_HAS_PAGES_CACHE_KEY)
+	flag = cache.get_value(WIKI_HAS_PAGES_CACHE_KEY, expires=True)
 	if flag is None:
 		flag = 1 if frappe.db.exists(WIKI, {"status": "Active"}) else 0
 		cache.set_value(WIKI_HAS_PAGES_CACHE_KEY, flag, expires_in_sec=_HAS_PAGES_TTL_S)
@@ -691,7 +691,7 @@ def _maybe_nudge(conversation_id: str, user: str) -> None:
 	if not conv or cint(conv.file_box):
 		return
 	cache = frappe.cache()
-	if cache.get_value(_NUDGE_OFF_KEY.format(conv=conversation_id)):
+	if cache.get_value(_NUDGE_OFF_KEY.format(conv=conversation_id), expires=True):
 		return
 	cooldown_key = _NUDGE_COOLDOWN_KEY.format(conv=conversation_id)
 	if cache.get_value(cooldown_key):

--- a/jarvis/compat.py
+++ b/jarvis/compat.py
@@ -29,6 +29,36 @@ import inspect
 import frappe
 
 
+@functools.cache
+def _get_value_supports_use_local_cache() -> bool:
+	"""Does ``RedisWrapper.get_value`` accept ``use_local_cache=`` (Frappe 16)?"""
+	try:
+		sig = inspect.signature(frappe.cache().get_value)
+		return "use_local_cache" in sig.parameters
+	except (AttributeError, TypeError, ValueError):
+		return False
+
+
+def cache_get_fresh(key):
+	"""``get_value(key)`` that always reads Redis, bypassing the in-process
+	``frappe.local.cache``, on Frappe 15 and 16.
+
+	Frappe 16 has ``use_local_cache=False`` for exactly this. Frappe 15 lacks the
+	kwarg (passing it is a ``TypeError``) and has no read-side local-cache bypass,
+	but its ``get_value`` only consults ``local.cache`` for a key that was written
+	there -- and a TTL key never is (``set_value`` with ``expires_in_sec`` skips
+	local.cache on 15), provided reads pass ``expires=True`` so a miss does not
+	poison it. So ``expires=True`` yields the same always-fresh read on 15.
+
+	Callers use this only for cross-process leases/counters that must never serve a
+	stale in-process copy.
+	"""
+	cache = frappe.cache()
+	if _get_value_supports_use_local_cache():
+		return cache.get_value(key, use_local_cache=False)
+	return cache.get_value(key, expires=True)
+
+
 def in_test() -> bool:
 	"""True when running under the test runner, on Frappe 15 and 16.
 

--- a/jarvis/compat.py
+++ b/jarvis/compat.py
@@ -45,10 +45,10 @@ def cache_get_fresh(key):
 
 	Frappe 16 has ``use_local_cache=False`` for exactly this. Frappe 15 lacks the
 	kwarg (passing it is a ``TypeError``) and has no read-side local-cache bypass,
-	but its ``get_value`` only consults ``local.cache`` for a key that was written
-	there -- and a TTL key never is (``set_value`` with ``expires_in_sec`` skips
-	local.cache on 15), provided reads pass ``expires=True`` so a miss does not
-	poison it. So ``expires=True`` yields the same always-fresh read on 15.
+	so guarantee the fresh read directly: evict any local copy first, then read
+	with ``expires=True`` so the miss-path does not re-populate it. This holds
+	regardless of what any other code path left in ``local.cache``, so callers get
+	the live Redis state even for a key that was locally cached elsewhere.
 
 	Callers use this only for cross-process leases/counters that must never serve a
 	stale in-process copy.
@@ -56,7 +56,26 @@ def cache_get_fresh(key):
 	cache = frappe.cache()
 	if _get_value_supports_use_local_cache():
 		return cache.get_value(key, use_local_cache=False)
+	frappe.local.cache.pop(cache.make_key(key), None)
 	return cache.get_value(key, expires=True)
+
+
+def cache_get_memoized(key):
+	"""``get_value(key)`` for a TTL key that is re-read many times within one
+	request, keeping the per-request local-cache memoization on Frappe 15 and 16.
+
+	Plain ``get_value`` memoizes a hit into ``frappe.local.cache`` only when
+	``expires`` is falsy -- but a bare read of a TTL key poisons ``local.cache``
+	with ``None`` on a miss (Frappe 15), and ``expires=True`` avoids the poison at
+	the cost of that memoization. Bridge both: read with ``expires=True`` (never
+	poison), then store a real hit back into ``local.cache`` by hand, so later
+	reads in the same request are a dict lookup, not a Redis round-trip.
+	"""
+	cache = frappe.cache()
+	val = cache.get_value(key, expires=True)
+	if val is not None:
+		frappe.local.cache[cache.make_key(key)] = val
+	return val
 
 
 def in_test() -> bool:

--- a/jarvis/error_push.py
+++ b/jarvis/error_push.py
@@ -193,7 +193,7 @@ def _log_push_failure_throttled() -> None:
 	"""Log an unexpected push failure at most once per hour. Never raises."""
 	try:
 		hour = int(time.time()) // 3600
-		if frappe.cache.get_value(_LOG_THROTTLE_KEY) == hour:
+		if frappe.cache.get_value(_LOG_THROTTLE_KEY, expires=True) == hour:
 			return
 		frappe.cache.set_value(_LOG_THROTTLE_KEY, hour, expires_in_sec=7200)
 		frappe.log_error(title="jarvis errors: rollup push failed", message=frappe.get_traceback())

--- a/jarvis/learning/app_analysis.py
+++ b/jarvis/learning/app_analysis.py
@@ -157,7 +157,7 @@ def _approx_size_cached(app: str, src: str) -> tuple[int, int]:
 	last_run is fetched fresh (cheap + needs freshness)."""
 	cache = frappe.cache()
 	key = f"jarvis:app_learning:size:{app}"
-	cached = cache.get_value(key)
+	cached = cache.get_value(key, expires=True)
 	if isinstance(cached, (list, tuple)) and len(cached) == 2:
 		return int(cached[0]), int(cached[1])
 	val = _approx_size(src)
@@ -304,7 +304,7 @@ def _active_conversations() -> set[str]:
 	"""Conversation ids of non-terminal runs, cached — the turn-end hook runs
 	on EVERY turn, so the common no-run case must cost one redis read."""
 	try:
-		cached = frappe.cache().get_value(_ACTIVE_CONV_CACHE_KEY)
+		cached = frappe.cache().get_value(_ACTIVE_CONV_CACHE_KEY, expires=True)
 	except Exception:
 		cached = None
 	if isinstance(cached, list):

--- a/jarvis/learning/compiler.py
+++ b/jarvis/learning/compiler.py
@@ -404,7 +404,7 @@ def apply_in_progress() -> bool:
 	"""True while an Apply is between compile and its post-flip commit - the
 	un-approve TOCTOU window. ``learned_api.unapprove_learned_pattern`` reads it."""
 	try:
-		return bool(frappe.cache().get_value(_APPLY_MARKER))
+		return bool(frappe.cache().get_value(_APPLY_MARKER, expires=True))
 	except Exception:
 		return False
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -2449,7 +2449,7 @@ def resync_llm() -> dict:
 		return {**get_llm_sync_status(), "outcome": "converged", "leg": ""}
 
 	cache = frappe.cache()
-	if cache.get_value(_RESYNC_COOLDOWN_KEY):
+	if cache.get_value(_RESYNC_COOLDOWN_KEY, expires=True):
 		return {**get_llm_sync_status(), "outcome": "throttled", "leg": ""}
 
 	# Armed only once a push is actually queued. Arming it first would let a call

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -430,7 +430,7 @@ def _note_missing_field() -> None:
 	seconds; an un-throttled log here would bury the Error Log it is trying to
 	warn through."""
 	cache = frappe.cache()
-	if cache.get_value(_MISSING_FIELD_LOG_KEY):
+	if cache.get_value(_MISSING_FIELD_LOG_KEY, expires=True):
 		return
 	cache.set_value(_MISSING_FIELD_LOG_KEY, 1, expires_in_sec=3600)
 	frappe.log_error(

--- a/jarvis/preflight.py
+++ b/jarvis/preflight.py
@@ -266,7 +266,7 @@ def _probe_direct_subscription(settings) -> dict:
 	what the customer's real first turn would use."""
 	cache = frappe.cache()
 	cache_key = _probe_cache_key(settings)
-	cached = cache.get_value(cache_key)
+	cached = cache.get_value(cache_key, expires=True)
 	if isinstance(cached, dict) and cached.get("state"):
 		return cached
 	from jarvis.chat.agent_client import AgentSession, AgentUnreachableError, oneshot_run_id
@@ -286,7 +286,7 @@ def _probe_direct_subscription(settings) -> dict:
 	# Claimed only AFTER the no-gateway early return, which bills nothing and
 	# must not leave a 30s "already running" ghost behind (round-5 review).
 	inflight_key = f"{cache_key}:inflight"
-	if cache.get_value(inflight_key):
+	if cache.get_value(inflight_key, expires=True):
 		return {
 			"state": "unknown",
 			"detail": "A live check is already running.",

--- a/jarvis/release_notice.py
+++ b/jarvis/release_notice.py
@@ -83,7 +83,7 @@ def check() -> dict:
 	from jarvis import admin_client
 
 	cache = frappe.cache()
-	if not cache.get_value(_CHECK_CACHE_KEY):
+	if not cache.get_value(_CHECK_CACHE_KEY, expires=True):
 		cache.set_value(_CHECK_CACHE_KEY, "1", expires_in_sec=_CHECK_CACHE_TTL_S)
 		try:
 			conn = admin_client.get_connection(timeout_s=8) or {}

--- a/jarvis/telemetry.py
+++ b/jarvis/telemetry.py
@@ -153,7 +153,7 @@ def custom_doctype_set() -> frozenset:
 	under-report rather than error."""
 	try:
 		cache = frappe.cache()
-		cached = cache.get_value(DOCTYPE_SET_CACHE_KEY)
+		cached = cache.get_value(DOCTYPE_SET_CACHE_KEY, expires=True)
 		if cached is not None:
 			return frozenset(cached)
 		from jarvis.site_profile import apps as sp_apps
@@ -183,7 +183,7 @@ def _read_and_clear_turn_flag(conversation: str) -> bool:
 	try:
 		cache = frappe.cache()
 		key = _turn_flag_key(conversation)
-		flag = cache.get_value(key)
+		flag = cache.get_value(key, expires=True)
 		if flag:
 			cache.delete_value(key)
 		return bool(flag)

--- a/jarvis/tenant_authority.py
+++ b/jarvis/tenant_authority.py
@@ -144,7 +144,7 @@ def log_stale_once(stored_gen, incoming_gen) -> None:
 	arriving."""
 	key = f"jarvis:tenant_authority_stale:{stored_gen}:{incoming_gen}"
 	cache = frappe.cache()
-	if cache.get_value(key):
+	if cache.get_value(key, expires=True):
 		return
 	cache.set_value(key, 1, expires_in_sec=_STALE_LOG_TTL_S)
 	frappe.log_error(
@@ -167,7 +167,7 @@ def log_invariant_once(gen, stored_handle, incoming_handle) -> None:
 	that persists stays visible to operators."""
 	key = f"jarvis:tenant_authority_invariant:{gen}:{stored_handle}:{incoming_handle}"
 	cache = frappe.cache()
-	if cache.get_value(key):
+	if cache.get_value(key, expires=True):
 		return
 	cache.set_value(key, 1, expires_in_sec=_STALE_LOG_TTL_S)
 	frappe.log_error(

--- a/jarvis/tests/test_compat_frappe_versions.py
+++ b/jarvis/tests/test_compat_frappe_versions.py
@@ -351,3 +351,31 @@ class TestSetDelimitersFlagAcrossMajors(FrappeTestCase):
 
 		# Must not raise on a doc lacking the v16-only method (the Frappe 15 shape).
 		compat.set_delimiters_flag(Doc())
+
+
+class TestCacheGetFreshAcrossMajors(FrappeTestCase):
+	"""compat.cache_get_fresh() reads a TTL key straight from Redis, bypassing the
+	in-process local cache, on Frappe 15 (via expires=True) and 16 (via
+	use_local_cache=False). Guards the v15 local-cache poisoning fix: a cold read
+	must not pin None for a key that set_value later writes."""
+
+	def test_reads_a_ttl_key_written_before(self):
+		key = "jarvis-compat-fresh-probe"
+		frappe.cache().delete_value(key)
+		self.addCleanup(frappe.cache().delete_value, key)
+		frappe.cache().set_value(key, {"v": 1}, expires_in_sec=60)
+		self.assertEqual(compat.cache_get_fresh(key), {"v": 1})
+
+	def test_no_poison_after_cold_miss_then_set(self):
+		"""The exact v15 failure shape: read (miss) -> set(expires) -> read must
+		return the value, not a poisoned None."""
+		key = "jarvis-compat-fresh-poison"
+		frappe.cache().delete_value(key)
+		self.addCleanup(frappe.cache().delete_value, key)
+		self.assertIsNone(compat.cache_get_fresh(key))  # cold miss must not poison
+		frappe.cache().set_value(key, {"v": 2}, expires_in_sec=60)
+		self.assertEqual(compat.cache_get_fresh(key), {"v": 2})
+
+	def test_missing_key_is_none(self):
+		frappe.cache().delete_value("jarvis-compat-fresh-absent")
+		self.assertIsNone(compat.cache_get_fresh("jarvis-compat-fresh-absent"))

--- a/jarvis/tests/test_compat_frappe_versions.py
+++ b/jarvis/tests/test_compat_frappe_versions.py
@@ -379,3 +379,28 @@ class TestCacheGetFreshAcrossMajors(FrappeTestCase):
 	def test_missing_key_is_none(self):
 		frappe.cache().delete_value("jarvis-compat-fresh-absent")
 		self.assertIsNone(compat.cache_get_fresh("jarvis-compat-fresh-absent"))
+
+
+class TestCacheGetMemoizedAcrossMajors(FrappeTestCase):
+	"""compat.cache_get_memoized() keeps a TTL-key read memoized in
+	frappe.local.cache for the rest of the request, without the v15 miss-poison."""
+
+	def test_hit_is_memoized_in_local_cache(self):
+		key = "jarvis-compat-memo-probe"
+		cache = frappe.cache()
+		cache.delete_value(key)
+		self.addCleanup(cache.delete_value, key)
+		cache.set_value(key, {"v": 1}, expires_in_sec=60)
+		self.assertEqual(compat.cache_get_memoized(key), {"v": 1})
+		# a real hit is stored back so the next read is a dict lookup
+		self.assertEqual(frappe.local.cache.get(cache.make_key(key)), {"v": 1})
+
+	def test_miss_does_not_poison(self):
+		key = "jarvis-compat-memo-miss"
+		cache = frappe.cache()
+		cache.delete_value(key)
+		self.addCleanup(cache.delete_value, key)
+		self.assertIsNone(compat.cache_get_memoized(key))  # cold miss
+		self.assertNotIn(cache.make_key(key), frappe.local.cache)  # not poisoned
+		cache.set_value(key, {"v": 2}, expires_in_sec=60)
+		self.assertEqual(compat.cache_get_memoized(key), {"v": 2})

--- a/jarvis/tools/_source_mapper.py
+++ b/jarvis/tools/_source_mapper.py
@@ -72,7 +72,7 @@ def _mapper_map(source_doctype: str) -> dict:
 	lookup in ``resolve_mapper`` scrubs the caller's real doctype to match."""
 	cache = frappe.cache()
 	key = mapper_cache_key(source_doctype)
-	hit = cache.get_value(key)
+	hit = cache.get_value(key, expires=True)
 	if hit is not None:
 		return hit
 	out: dict = {}

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -325,7 +325,7 @@ def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> di
 	if refresh:
 		clear_cache_for(doctype)  # bust BOTH variants, not just the current one
 	else:
-		cached = cache.get_value(key)
+		cached = cache.get_value(key, expires=True)
 		if cached is not None:
 			return cached
 	result = _build_schema(doctype, verbose)

--- a/jarvis/triggers/engine.py
+++ b/jarvis/triggers/engine.py
@@ -31,6 +31,8 @@ import time
 import frappe
 from frappe.utils import cint
 
+from jarvis import compat
+
 TRIGGER = "Jarvis Trigger"
 ACTIVITY = "Jarvis Trigger Activity"
 
@@ -168,7 +170,7 @@ def _triggers_map() -> dict:
 	raise here would take down every request on the site. Triggers simply stay
 	inert until migrate runs; the empty map is NOT cached in Redis so recovery
 	is immediate after migration."""
-	cached = frappe.cache().get_value(_CACHE_KEY, expires=True)
+	cached = compat.cache_get_memoized(_CACHE_KEY)
 	if cached is None:
 		try:
 			cached = _build_triggers_map()

--- a/jarvis/triggers/engine.py
+++ b/jarvis/triggers/engine.py
@@ -168,7 +168,7 @@ def _triggers_map() -> dict:
 	raise here would take down every request on the site. Triggers simply stay
 	inert until migrate runs; the empty map is NOT cached in Redis so recovery
 	is immediate after migration."""
-	cached = frappe.cache().get_value(_CACHE_KEY)
+	cached = frappe.cache().get_value(_CACHE_KEY, expires=True)
 	if cached is None:
 		try:
 			cached = _build_triggers_map()

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -37,7 +37,7 @@ def _support_state() -> str:
 	A CP too old to send ``reason`` degrades safely: unavailable-without-a-reason is
 	treated as ``off`` (hide), which is exactly today's behaviour."""
 	cache = frappe.cache()
-	cached = cache.get_value(_SUPPORT_AVAILABLE_CACHE_KEY)
+	cached = cache.get_value(_SUPPORT_AVAILABLE_CACHE_KEY, expires=True)
 	if cached:
 		return cached
 	try:


### PR DESCRIPTION
## Summary

Backports **batch 4** (develop PR #939) to version-15: fixes the Frappe-15 local-cache poisoning that fails 11 tests on the v15 branch. Straight cherry-pick of both #939 commits, applied clean (no conflicts).

Root cause (verified against v15 `frappe/utils/redis_wrapper.py`): `get_value(key)` on a cold miss writes `frappe.local.cache[key] = None`, but `set_value(key, val, expires_in_sec=N)` never updates `local.cache` (Redis only). So a read → set-with-TTL → read forever returns the poisoned `None`, skipping Redis — and code that caches a verdict/token then re-reads it fires the underlying `get_connection`/mint twice. Frappe 16 masks the bug; v15 does not. The fix routes TTL-key reads through the `compat.cache_get_memoized` / `cache_get_fresh` shims.

## What changed
- Cherry-picks `5da3ed59` ("prevent Frappe 15 cache local-poisoning on TTL keys", 26 files) + `12e2e13c` ("fix missed wiki cooldown poison + preserve memoization + harden fresh read", 6 files) from develop
- Adds `cache_get_memoized` / `cache_get_fresh` to `jarvis/compat.py` and routes the affected read sites through them

## Risk and verification
- Clean cherry-pick of commits already merged + CI-green on develop
- Touched core files compile; the compat shims resolve on v15
- Fixes the 11 cache-poisoning failures (`test_admin_client` OAuth-bearer caching, `test_account` chat-gate/diagnostic caching, `test_customizations_clause`, `test_describe_customizations`)

## Not covered here (follow-up)
- **5 remaining failures** are a separate Frappe-15 **Link-existence validation** gap (`test_bulk_tools`, `test_create_docs`, `test_confirm_gate` — `LinkValidationError` not firing for a nonexistent User link). jarvis code is byte-identical across branches, so it is framework-level v15 behavior; mechanism is unsettled and needs a live v15 repro. Filed for a follow-up batch.
- The recent shard "hang" was transient: shards stalled in `apt-get update` (Ubuntu mirror), never ran a test. A `--fail-under`-style CI robustness tweak (apt retries + step timeout) is a separate small ci.yml change.

## Pre-merge checklist
- [ ] **CI is green** (clears the 11 cache failures; 5 Link-validation failures remain until the follow-up)
- [ ] Branch is **up to date with `main`** (n/a: targets `version-15`)
- [x] New/changed behavior has tests (carried from #939)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01WZJ3nhp1CqHuWzhGibypRa
