### PR TITLE
backport(v15): batch 5a - fix 5 test-infra assumptions about Frappe 16 internals

### DIFF
--- a/jarvis/tests/test_list_filters_smoke.py
+++ b/jarvis/tests/test_list_filters_smoke.py
@@ -116,12 +116,16 @@ _ALWAYS_SKIP = {"frappe", "cint", "cstr", "flt", "getdate", "now_datetime", "add
 
 def _whitelisted(module) -> list:
 	out = []
+	# Frappe records whitelisted functions in a global collection
+	# (frappe.whitelisted), not as an attribute on the function, and it
+	# registers the innermost function, so a decorated endpoint is matched
+	# through __wrapped__. That collection is a set on Frappe 16 but a plain
+	# list on Frappe 15, so coerce to a set once (it is stable for this scan)
+	# before intersecting per candidate.
+	whitelisted = set(frappe.whitelisted)
 	for name, fn in vars(module).items():
 		if name.startswith("_") or name in _ALWAYS_SKIP:
 			continue
-		# Frappe records whitelisted functions in a global SET (frappe.whitelisted),
-		# not as an attribute on the function — and it registers the innermost
-		# function, so a decorated endpoint is matched through __wrapped__.
 		if not callable(fn):
 			continue
 		candidates = {fn}
@@ -129,7 +133,7 @@ def _whitelisted(module) -> list:
 		while inner is not None:
 			candidates.add(inner)
 			inner = getattr(inner, "__wrapped__", None)
-		if not (candidates & frappe.whitelisted):
+		if not (candidates & whitelisted):
 			continue
 		if getattr(fn, "__module__", "") != module.__name__:
 			continue  # imported into this module, tested where it lives

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -650,7 +650,11 @@ class TestAgentCatalogPushTOCTOU(FrappeTestCase):
 			WHERE `doctype` = %(dt)s AND `field` = 'agent_catalog_version'""",
 			{"dt": SETTINGS},
 		)
-		frappe.db.value_cache[SETTINGS]["agent_catalog_version"] = 5
+		# Seed a stale cached single value. The singles cache is keyed
+		# value_cache[doctype][fieldname] on both majors, but the doctype
+		# sub-dict is created lazily by the first get_single_value; on Frappe 15
+		# nothing has populated it here yet, so index into it via setdefault.
+		frappe.db.value_cache.setdefault(SETTINGS, {})["agent_catalog_version"] = 5
 		agents_api._bump_catalog_version()
 		self.assertEqual(
 			frappe.utils.cint(_single("agent_catalog_version")),

--- a/jarvis/tests/test_realtime_handlers.py
+++ b/jarvis/tests/test_realtime_handlers.py
@@ -27,13 +27,32 @@ from jarvis.realtime import handlers
 
 class _FakeConf:
 	"""Minimal stand-in for frappe.conf in tests. The handler only reads
-	via ``frappe.conf.get(key)``, so we just need a .get implementation."""
+	via ``frappe.conf.get(key)``, so we override that with our mapping.
+
+	On Frappe 15 the dispatch path also reaches low-level framework code that
+	reads real *attributes* off ``frappe.conf`` (``_log_query`` -> ``conf.allow_tests``
+	and ``conf.logging``, ``RedisWrapper.make_key`` -> ``conf.db_name``, and more
+	down the same paths); Frappe 16 doesn't touch those here. Any attribute we
+	don't override delegates to the real conf, captured before ``patch.object``
+	swaps us in, so those framework reads still return true values (never None --
+	``db_name`` re-keys the whole cache namespace).
+
+	Isolation note: the code under test (jarvis.realtime.handlers) reads config
+	only via ``frappe.conf.get(key)``, which our mapping answers directly and never
+	routes through ``__getattr__``. So the handler's own reads stay fully isolated
+	to the values each test declares; the attribute delegation exists solely to
+	satisfy framework internals on the v15 path, not the code under test."""
 
 	def __init__(self, mapping):
 		self._d = dict(mapping)
+		self._real = frappe.conf
 
 	def get(self, key, default=None):
 		return self._d.get(key, default)
+
+	def __getattr__(self, name):
+		# Only called for attributes not found normally (_d, _real, get).
+		return getattr(self._real, name)
 
 
 class TestMaybeStartChatSubscriber(FrappeTestCase):


### PR DESCRIPTION
Backports batch 5a (#946) to `version-15` by cherry-pick. Five test-infra fixes where jarvis tests assumed Frappe 16 internals; test-only, so v16 was unaffected and its CI gate already proved it on develop. Drops the v15 count 19 -> 14.

- realtime dispatch (3): `_FakeConf` now delegates unknown attrs to the real conf so v15's low-level framework reads (`conf.allow_tests`, `conf.db_name`) resolve; the handler-under-test still reads via `.get()` and stays isolated.
- whitelisted (1): coerce `frappe.whitelisted` (a list on v15, set on v16) to a set before intersecting.
- singles value_cache (1): seed the stale value via `setdefault` since v15 creates the doctype sub-dict lazily.

Cherry-pick of merge `0bb409a` (`-x -m 1`), clean, no conflicts.
