### PR TITLE
fix(v15): batch 5b - formula-injection hardening + 12 v15 test fixes

### DIFF
--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -2,6 +2,7 @@
 /jarvis/billing SPA page. admin_client is mocked - these are unit tests of
 the customer-side glue, not of the admin endpoints themselves."""
 
+import datetime
 from unittest.mock import patch
 
 import frappe
@@ -577,11 +578,19 @@ class TestAdminChatGate(FrappeTestCase):
 		raw = account._settings_raw(account._GATE_STATE_FIELDS)
 		self.assertIsNone(raw.get("chat_was_ready_at"))
 		self.assertFalse(account._has_been_chat_ready(raw))
-		self.assertTrue(
-			frappe.db.get_value("Jarvis Settings", "Jarvis Settings", ["chat_was_ready_at"], as_dict=True)[
-				"chat_was_ready_at"
-			],
-			"if this ever reads falsy the cast changed and the raw read can be simplified",
+		# The framed-read cast differs by major: Frappe 16's get_value casts an
+		# empty Datetime single to datetime(1, 1, 1) (a TRUTHY sentinel), while
+		# Frappe 15's specific-fields Single read path applies no cast and returns
+		# None. Pin the intent that matters - an unset marker never reads as a
+		# real, meaningful timestamp - by accepting either representation.
+		framed_read = frappe.db.get_value(
+			"Jarvis Settings", "Jarvis Settings", ["chat_was_ready_at"], as_dict=True
+		)["chat_was_ready_at"]
+		self.assertIn(
+			framed_read,
+			(None, datetime.datetime(1, 1, 1)),
+			"an empty Datetime single must read as None (no cast) or the datetime(1,1,1) "
+			"cast sentinel, never a real timestamp that would make the marker look set",
 		)
 
 	def test_an_established_workspace_needs_its_admin_credentials_too(self):

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -12,7 +12,7 @@ import frappe
 import requests
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis import admin_client
+from jarvis import admin_client, compat
 from jarvis.admin_client import (
 	DEFAULT_ADMIN_URL,
 	DEFAULT_TIMEOUT_S,
@@ -2090,9 +2090,13 @@ class TestOAuthBearer(FrappeTestCase):
 		# A token with no usable lifetime must not be cached (else every call
 		# would miss and storm the token endpoint).
 		admin_client._cache_oauth_token({"access_token": "A", "expires_in": 0})
-		self.assertIsNone(frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY))
+		# Read through cache_get_fresh: on Frappe 15 a bare get_value on a miss
+		# poisons frappe.local.cache[key]=None, and a later bare read returns that
+		# poison from local cache before it ever consults expires. cache_get_fresh
+		# evicts the local entry first, so we observe what is actually in redis.
+		self.assertIsNone(compat.cache_get_fresh(admin_client._OAUTH_CACHE_KEY))
 		admin_client._cache_oauth_token({"access_token": "B", "expires_in": 900})
-		self.assertEqual(frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY)["access_token"], "B")
+		self.assertEqual(compat.cache_get_fresh(admin_client._OAUTH_CACHE_KEY)["access_token"], "B")
 		frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
 
 

--- a/jarvis/tests/test_bulk_tools.py
+++ b/jarvis/tests/test_bulk_tools.py
@@ -25,6 +25,12 @@ from jarvis.tools.delete_doc import delete_doc
 from jarvis.tools.submit_doc import submit_doc
 from jarvis.tools.update_doc import update_doc
 
+# A nonexistent User, used as a deliberately-bad Link value. Target the
+# allocated_to field, NOT assigned_by: ToDo's assigned_by_full_name fetches
+# from assigned_by, and Frappe 15's get_invalid_links silently skips the
+# invalid-link check for any Link field that has a fetch_from sibling (only
+# Frappe 16 raises there). allocated_to has no such sibling, so the check
+# fires identically on both majors.
 _BAD_USER = "no-such-user@invalid.example"
 
 
@@ -46,7 +52,7 @@ class TestCreateDocBulk(FrappeTestCase):
 					{"doctype": "ToDo", "values": {"description": "jbulk-create-ok"}},
 					{
 						"doctype": "ToDo",
-						"values": {"description": "jbulk-create-bad", "assigned_by": _BAD_USER},
+						"values": {"description": "jbulk-create-bad", "allocated_to": _BAD_USER},
 					},
 				]
 			)
@@ -78,7 +84,7 @@ class TestUpdateDocBulk(FrappeTestCase):
 				"ToDo",
 				updates=[
 					{"name": a, "changes": {"priority": "High"}},
-					{"name": b, "changes": {"assigned_by": _BAD_USER}},  # bad Link -> save fails
+					{"name": b, "changes": {"allocated_to": _BAD_USER}},  # bad Link -> save fails
 				],
 			)
 		# first update must have rolled back

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -919,7 +919,11 @@ class TestCreateDocsGate(FrappeTestCase):
 
 	def test_create_docs_bad_batch_bounces_at_park(self):
 		# A deterministic failure (bad link on the 2nd doc) returns an error to
-		# the model instead of parking a doomed card.
+		# the model instead of parking a doomed card. Use allocated_to, not
+		# assigned_by: assigned_by has a fetch_from sibling on ToDo
+		# (assigned_by_full_name), and Frappe 15's get_invalid_links silently
+		# skips the invalid-link check for such fields; allocated_to has none, so
+		# it bounces on both majors.
 		r = api._run_tool(
 			"create_docs",
 			{
@@ -929,7 +933,7 @@ class TestCreateDocsGate(FrappeTestCase):
 						"doctype": "ToDo",
 						"values": {
 							"description": "jarvis-gate-bad",
-							"assigned_by": "no-such-user@invalid.example",
+							"allocated_to": "no-such-user@invalid.example",
 						},
 					},
 				]

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -919,11 +919,8 @@ class TestCreateDocsGate(FrappeTestCase):
 
 	def test_create_docs_bad_batch_bounces_at_park(self):
 		# A deterministic failure (bad link on the 2nd doc) returns an error to
-		# the model instead of parking a doomed card. Use allocated_to, not
-		# assigned_by: assigned_by has a fetch_from sibling on ToDo
-		# (assigned_by_full_name), and Frappe 15's get_invalid_links silently
-		# skips the invalid-link check for such fields; allocated_to has none, so
-		# it bounces on both majors.
+		# the model instead of parking a doomed card. (allocated_to not
+		# assigned_by; see test_bulk_tools._BAD_USER for why.)
 		r = api._run_tool(
 			"create_docs",
 			{

--- a/jarvis/tests/test_create_docs.py
+++ b/jarvis/tests/test_create_docs.py
@@ -24,10 +24,7 @@ class TestCreateDocs(FrappeTestCase):
 	def test_rolls_back_whole_batch_on_failure(self):
 		# Second doc has a bad Link (allocated_to -> a non-existent User), which
 		# fails at insert AFTER the first doc inserted. The savepoint must undo it.
-		# (allocated_to, not assigned_by: assigned_by has a fetch_from sibling on
-		# ToDo - assigned_by_full_name - and Frappe 15's get_invalid_links silently
-		# skips the invalid-link check for such fields; allocated_to has none, so
-		# it raises on both majors.)
+		# (allocated_to not assigned_by; see test_bulk_tools._BAD_USER for why.)
 		with self.assertRaises(Exception):
 			create_docs(
 				[
@@ -65,8 +62,7 @@ class TestCreateDocs(FrappeTestCase):
 		# clear the commit/rollback callback queues. Without the fix, the first
 		# (successfully-inserted-then-rolled-back) doc's queued after_commit
 		# callbacks survive and would fire on the request's real commit.
-		# Bad Link uses allocated_to (not assigned_by) so it fails on Frappe 15
-		# too - see test_rolls_back_whole_batch_on_failure for why.
+		# Bad Link uses allocated_to (not assigned_by); see test_bulk_tools._BAD_USER.
 		before = len(frappe.db.after_commit._functions)
 		with self.assertRaises(Exception):
 			create_docs(

--- a/jarvis/tests/test_create_docs.py
+++ b/jarvis/tests/test_create_docs.py
@@ -22,8 +22,12 @@ class TestCreateDocs(FrappeTestCase):
 		self.assertTrue(frappe.db.exists("ToDo", {"description": "jarvis-batch-b"}))
 
 	def test_rolls_back_whole_batch_on_failure(self):
-		# Second doc has a bad Link (assigned_by -> a non-existent User), which
+		# Second doc has a bad Link (allocated_to -> a non-existent User), which
 		# fails at insert AFTER the first doc inserted. The savepoint must undo it.
+		# (allocated_to, not assigned_by: assigned_by has a fetch_from sibling on
+		# ToDo - assigned_by_full_name - and Frappe 15's get_invalid_links silently
+		# skips the invalid-link check for such fields; allocated_to has none, so
+		# it raises on both majors.)
 		with self.assertRaises(Exception):
 			create_docs(
 				[
@@ -32,7 +36,7 @@ class TestCreateDocs(FrappeTestCase):
 						"doctype": "ToDo",
 						"values": {
 							"description": "jarvis-batch-bad",
-							"assigned_by": "no-such-user@invalid.example",
+							"allocated_to": "no-such-user@invalid.example",
 						},
 					},
 				]
@@ -61,6 +65,8 @@ class TestCreateDocs(FrappeTestCase):
 		# clear the commit/rollback callback queues. Without the fix, the first
 		# (successfully-inserted-then-rolled-back) doc's queued after_commit
 		# callbacks survive and would fire on the request's real commit.
+		# Bad Link uses allocated_to (not assigned_by) so it fails on Frappe 15
+		# too - see test_rolls_back_whole_batch_on_failure for why.
 		before = len(frappe.db.after_commit._functions)
 		with self.assertRaises(Exception):
 			create_docs(
@@ -70,7 +76,7 @@ class TestCreateDocs(FrappeTestCase):
 						"doctype": "ToDo",
 						"values": {
 							"description": "jarvis-batch-cbq-bad",
-							"assigned_by": "no-such-user@invalid.example",
+							"allocated_to": "no-such-user@invalid.example",
 						},
 					},
 				]

--- a/jarvis/tests/test_export_seam.py
+++ b/jarvis/tests/test_export_seam.py
@@ -94,10 +94,21 @@ class TestFormulaEscape(FrappeTestCase):
 		for bad in ("=1+1", "+1", "-1", "@x", "\t=cmd", "\r=cmd"):
 			self.assertTrue(escape_formula(bad).startswith("'"), bad)
 
+	def test_whitespace_before_a_trigger_is_still_neutralized(self):
+		# A trigger char hidden behind leading whitespace must still be escaped:
+		# an importer that trims leading whitespace would otherwise evaluate it as
+		# a live formula. Includes the HTML-unwrap shape ("  =HYPERLINK(...)  ")
+		# that surfaced this gap on Frappe 15.
+		for bad in ('  =HYPERLINK("http://evil","x")  ', " +1", "\t -cmd", "   @SUM(1,1)"):
+			self.assertTrue(escape_formula(bad).startswith("'"), bad)
+
 	def test_safe_values_untouched(self):
 		self.assertEqual(escape_formula("Acme Ltd"), "Acme Ltd")
 		self.assertEqual(escape_formula("123"), "123")
 		self.assertEqual(escape_formula(""), "")
+		# Leading whitespace alone (no trigger char once stripped) is not escaped.
+		self.assertEqual(escape_formula("  hello"), "  hello")
+		self.assertEqual(escape_formula("   "), "   ")
 
 	def test_non_strings_pass_through(self):
 		self.assertEqual(escape_formula(42), 42)

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -195,7 +195,14 @@ class TestMintReliableIndex(FrappeTestCase):
 		landed. Guards the pop from being dropped (without it the verify reads the
 		stale local copy and falsely passes). Simulate by making the raw redis SET
 		raise ConnectionError, which set_value suppresses."""
-		with patch.object(frappe.cache(), "set", side_effect=redis.exceptions.ConnectionError("write blip")):
+		# set_value writes a TTL key. Frappe 16 always routes that through
+		# cache.set(ex=...), but Frappe 15 calls cache.setex() for expiring writes
+		# and never touches cache.set, so patching set alone would leave the real
+		# SETEX to succeed on v15. Patch both; setex is simply never hit on v16.
+		with (
+			patch.object(frappe.cache(), "set", side_effect=redis.exceptions.ConnectionError("write blip")),
+			patch.object(frappe.cache(), "setex", side_effect=redis.exceptions.ConnectionError("write blip")),
+		):
 			with patch.object(frappe, "log_error") as mock_log:
 				token = self._mint()
 		self.assertIsNone(token, "a swallowed set_value write must be caught by the verify -> rollback")

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis import compat
 from jarvis.chat import session_lifecycle
 from jarvis.chat.agent_client import AgentSession
 
@@ -19,7 +20,13 @@ def _lapse_cooldown(prewarm):
 	a test would be asserting the guard, not the reclaim. Backdating the stamp is
 	what the four-minute cooldown does in production."""
 	frappe.cache().delete_value(prewarm._warm_cooldown_key())
-	pointer = frappe.cache().get_value(prewarm._warm_last_key())
+	# cache_get_fresh, not a bare get_value: the warm-last key is a TTL key
+	# written via set_value (which skips local cache on Frappe 15). A bare read
+	# here would memoize the pre-backdate pointer into frappe.local.cache, and
+	# the product's own later read would then serve that stale copy from local
+	# cache before it consults expires. Evicting the local entry first keeps the
+	# backdated stamp the one that is seen.
+	pointer = compat.cache_get_fresh(prewarm._warm_last_key())
 	if isinstance(pointer, dict):
 		frappe.cache().set_value(
 			prewarm._warm_last_key(),

--- a/jarvis/tests/test_review_api_rework.py
+++ b/jarvis/tests/test_review_api_rework.py
@@ -476,7 +476,12 @@ class TestFollowup(unittest.TestCase):
 
 	def test_followup_refused_for_plain(self):
 		p = _mk_pattern("fu4")
-		with _as(PLAIN):
+		# enforced_role_guards(): Frappe 15's only_for() early-returns under
+		# frappe.flags.in_test (a bypass v16 dropped), so without this the role
+		# guard no-ops and the call falls through to a ValidationError instead of
+		# the PermissionError under test. The three sibling PLAIN tests already
+		# wrap this way; this one was the miss.
+		with _as(PLAIN), enforced_role_guards():
 			with self.assertRaises(frappe.PermissionError):
 				learned_api.trigger_followup_question(p, "x")
 

--- a/jarvis/tests/test_seq_watermark_migration.py
+++ b/jarvis/tests/test_seq_watermark_migration.py
@@ -33,6 +33,11 @@ class TestSeqWatermarkMigration(FrappeTestCase):
 	def _bust_columns_cache():
 		key = f"table_columns::tab{MSG}"
 		frappe.cache.delete_value(key)
+		# Frappe 15 caches table columns in a redis HASH ("table_columns", field
+		# "tab<doctype>"), not the "table_columns::tab<doctype>" string key Frappe
+		# 16 uses. Clear both shapes, else the stale pre-DDL column list survives
+		# and the patch's has-column guard no-ops. hdel is a harmless no-op on v16.
+		frappe.cache.hdel("table_columns", f"tab{MSG}")
 		try:
 			frappe.client_cache.delete_value(key)
 		except Exception:

--- a/jarvis/tools/_export/safety.py
+++ b/jarvis/tools/_export/safety.py
@@ -7,9 +7,12 @@ _TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
 
 def escape_formula(value):
 	"""Neutralise a formula-injection cell by prefixing a leading trigger char
-	with an apostrophe, so spreadsheets render it as literal text. Applied to
-	EVERY cell AND header of a CSV/XLSX export. Non-strings pass through
-	unchanged (numbers/dates are not an injection vector)."""
-	if isinstance(value, str) and value[:1] in _TRIGGERS:
+	with an apostrophe, so spreadsheets render it as literal text. Checks both
+	the raw first char (so tab/CR triggers stay covered) and the
+	whitespace-stripped first char (so a payload like " =HYPERLINK(...)" - e.g.
+	produced by unwrapping HTML to text - can't smuggle a formula past a leading
+	space). Applied to EVERY cell AND header of a CSV/XLSX export. Non-strings
+	pass through unchanged (numbers/dates are not an injection vector)."""
+	if isinstance(value, str) and (value[:1] in _TRIGGERS or value.lstrip()[:1] in _TRIGGERS):
 		return "'" + value
 	return value


### PR DESCRIPTION
Fixes a CSV/XLSX formula-injection bypass and clears 12 of the 13 remaining Frappe 15 test failures (batch 5b of the v15 support burn-down). One product/security change; the rest are test-only, so v16 behavior is unchanged and its CI gate proves it. Diagnosed against a real `frappe@version-15` checkout.

**Security fix (live on v16 today, not just v15):** `escape_formula` in `jarvis/tools/_export/safety.py` only checked the raw first character of a cell, so any value with a leading space in front of a trigger char, e.g. `" =HYPERLINK(\"http://evil\",\"x\")"`, was exported as a live formula. It now also checks the whitespace-stripped first char (OR, so genuine tab/CR-leading cells stay escaped). Verified bypassable against the current v16 bench; v15 only surfaced it first because its older `markdownify` pin adds leading whitespace when unwrapping `<p>` HTML.

The 12 test-only fixes fall in three buckets: bad-Link fixtures retargeted so v15 actually rejects them, cache reads routed so v15's local-cache semantics do not serve a stale value, and one role-guard wrapper that three sibling tests already use.

**Not included: 1 of 14 deferred.** `test_cross_install_recurrence_bump_is_detached_not_deleted` is not cache-related and its mechanism is not yet pinned (it needs a live jarvis-on-v15 site or a one-CI-round diagnostic that prints the queried row). It is a candidate real data bug on v15 (uninstalling one install may null another install's `last_seen_run`), so it is deliberately left failing, not skipped. After this merges and backports, the v15 count is **1, not 0**; the close-out items (coverage floor, branch protection, FC install proof) stay blocked on that one.

<details>
<summary>Per-fix detail and the v15 framework caveat</summary>

- 5 atomic-rollback tests (`test_create_docs`, `test_bulk_tools`, `test_confirm_gate`): the bad-Link fixture used `assigned_by`, which has a `fetch_from` sibling on ToDo (`assigned_by_full_name`); Frappe 15's `get_invalid_links` silently skips the invalid-link check for any Link field with such a sibling. Retargeted to `allocated_to` (no sibling), rejected on both majors. Confirmed `allocated_to` is not in either tool's `PROTECTED_FIELDS`, so the batch still fails at insert of doc 2, not vacuously at arg-parse.
- `test_account` datetime canary: accept both `None` (v15, no cast) and `datetime(1,1,1)` (v16 cast sentinel) for an empty Datetime single.
- `test_admin_client`, `test_prewarm`: route TTL-key reads through `compat.cache_get_fresh`. On v15 `get_value` returns a locally-memoized value before it consults `expires`, so `expires=True` alone does not protect against a poison an earlier bare read left.
- `test_pending_confirm` mint: also patch `cache.setex`; v15 `set_value` routes TTL writes through `setex`, not `set`.
- `test_seq_watermark_migration`: also bust the v15 table-columns redis hash (`"table_columns"`, field `"tab<doctype>"`), not just the v16 string key.
- `test_review_api_rework` followup: add the `enforced_role_guards()` wrapper (v15 `only_for` no-ops under `frappe.flags.in_test`).

Framework caveat worth knowing about the v15 offering: because of the `get_invalid_links` gap above, on a live v15 site any Jarvis write that sets a Link field with a `fetch_from` sibling to a dangling target will save silently instead of erroring. That is a Frappe 15 framework weakness, not something jarvis introduces or can fix.
</details>
