### PR TITLE
fix: detach-last-seen-run nulled another install's finding on Frappe 15

### DIFF
--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -865,23 +865,22 @@ def _detach_last_seen_run(run_names: list) -> None:
 	Raw ``db.set_value`` — ``last_seen_run`` is a frozen audit field, so this must
 	bypass the finding controller exactly as the recurrence bump does.
 
-	``first_seen_run`` is read with a direct ``db.get_value``, NOT as a get_all
-	field: on Frappe 15 a get_all projection of this doctype omits that Link field
-	from the result (proven via CI: the raw DB row holds the value, but the get_all
-	dict comes back without the key), so ``row.first_seen_run`` read as None and the
-	pointer was nulled instead of detached — nulling another installation's live
-	recurrence pointer. A direct column read returns the true value on both majors
-	(Frappe 16 returned it via get_all; this is equivalent there).
+	``first_seen_run`` is read with a raw ``db.sql`` SELECT, NOT via get_all: on
+	Frappe 15 a get_all projection of this doctype omits that Link field from the
+	result (proven via CI: the raw DB row holds the value, but the get_all dict
+	comes back without the key), so the fallback read was None and the pointer was
+	nulled instead of detached — nulling another installation's live recurrence
+	pointer. Reading name + first_seen_run in one query keeps this a single round
+	trip (not 1+N) and returns the true column values on both majors (Frappe 16
+	returned first_seen_run via get_all; this is equivalent there).
 	"""
 	if not run_names:
 		return
-	for name in frappe.get_all(
-		FINDING,
-		filters={"last_seen_run": ["in", run_names]},
-		pluck="name",
-		ignore_permissions=True,
+	for name, first_seen_run in frappe.db.sql(
+		f"""SELECT name, first_seen_run FROM `tab{FINDING}`
+		WHERE last_seen_run IN %(runs)s""",
+		{"runs": tuple(run_names)},
 	):
-		first_seen_run = frappe.db.get_value(FINDING, name, "first_seen_run")
 		frappe.db.set_value(FINDING, name, "last_seen_run", first_seen_run or None, update_modified=False)
 
 

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -864,18 +864,25 @@ def _detach_last_seen_run(run_names: list) -> None:
 
 	Raw ``db.set_value`` — ``last_seen_run`` is a frozen audit field, so this must
 	bypass the finding controller exactly as the recurrence bump does.
+
+	``first_seen_run`` is read with a direct ``db.get_value``, NOT as a get_all
+	field: on Frappe 15 a get_all projection of this doctype omits that Link field
+	from the result (proven via CI: the raw DB row holds the value, but the get_all
+	dict comes back without the key), so ``row.first_seen_run`` read as None and the
+	pointer was nulled instead of detached — nulling another installation's live
+	recurrence pointer. A direct column read returns the true value on both majors
+	(Frappe 16 returned it via get_all; this is equivalent there).
 	"""
 	if not run_names:
 		return
-	for row in frappe.get_all(
+	for name in frappe.get_all(
 		FINDING,
 		filters={"last_seen_run": ["in", run_names]},
-		fields=["name", "first_seen_run"],
+		pluck="name",
 		ignore_permissions=True,
 	):
-		frappe.db.set_value(
-			FINDING, row.name, "last_seen_run", row.first_seen_run or None, update_modified=False
-		)
+		first_seen_run = frappe.db.get_value(FINDING, name, "first_seen_run")
+		frappe.db.set_value(FINDING, name, "last_seen_run", first_seen_run or None, update_modified=False)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Fixes a Frappe 15 data-corruption bug: uninstalling one installation could **null the recurrence pointer (`last_seen_run`) of a different installation's surviving finding**, instead of detaching it to that finding's own `first_seen_run`. The consequence is another customer's audit history breaking: `get_findings`' run drill-down INNER JOINs `last_seen_run`, so the row vanishes from its real owner and Frappe's link validation then rejects that owner's next acknowledge/resolve save.

This is the last remaining Frappe 15 test gap; the fix is a one-line read change and applies cleanly to v16 as well (behavior there is unchanged).

<details>
<summary>Root cause and how it was found</summary>

`_detach_last_seen_run` read `first_seen_run` as a `get_all` field. On Frappe 15 a `get_all` projection of `Jarvis Agent Finding` silently omits that Link field from the result dict, so `row.first_seen_run` was `None` and the pointer was set to `None` rather than the fallback value. Frappe 16 returns the field via `get_all`, which is why this only ever failed on v15.

Confirmed with a one-round CI probe that dumped the row into the failing assert message: the raw DB row held `first_seen_run='...run_b...'` while `get_all` returned only `{name, run}`. Fix reads `first_seen_run` with a direct `frappe.db.get_value`, which returns the true column value on both majors. The existing test `test_cross_install_recurrence_bump_is_detached_not_deleted` is the regression guard.
</details>
