### PR TITLE
backport(v15): fix detach-last-seen-run nulling another install's finding

### DIFF
--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -864,18 +864,24 @@ def _detach_last_seen_run(run_names: list) -> None:
 
 	Raw ``db.set_value`` — ``last_seen_run`` is a frozen audit field, so this must
 	bypass the finding controller exactly as the recurrence bump does.
+
+	``first_seen_run`` is read with a raw ``db.sql`` SELECT, NOT via get_all: on
+	Frappe 15 a get_all projection of this doctype omits that Link field from the
+	result (proven via CI: the raw DB row holds the value, but the get_all dict
+	comes back without the key), so the fallback read was None and the pointer was
+	nulled instead of detached — nulling another installation's live recurrence
+	pointer. Reading name + first_seen_run in one query keeps this a single round
+	trip (not 1+N) and returns the true column values on both majors (Frappe 16
+	returned first_seen_run via get_all; this is equivalent there).
 	"""
 	if not run_names:
 		return
-	for row in frappe.get_all(
-		FINDING,
-		filters={"last_seen_run": ["in", run_names]},
-		fields=["name", "first_seen_run"],
-		ignore_permissions=True,
+	for name, first_seen_run in frappe.db.sql(
+		f"""SELECT name, first_seen_run FROM `tab{FINDING}`
+		WHERE last_seen_run IN %(runs)s""",
+		{"runs": tuple(run_names)},
 	):
-		frappe.db.set_value(
-			FINDING, row.name, "last_seen_run", row.first_seen_run or None, update_modified=False
-		)
+		frappe.db.set_value(FINDING, name, "last_seen_run", first_seen_run or None, update_modified=False)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Backports #953 to `version-15`: the Frappe 15 data-corruption fix where uninstalling one installation nulled a different installation's finding recurrence pointer (v15 get_all omits the first_seen_run Link field; now read via bulk raw SQL). Closes the LAST v15 test gap - expected to take the v15 count 1 -> 0, fully green.

Cherry-pick of merge `73efff1` (`-x -m 1`), clean, no conflicts.