### PR TITLE
docs: install Jarvis from version-15 on Frappe 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ judgement.
 
 ## How to Install
 
-Jarvis supports Frappe 15 and 16.
+This branch supports Frappe 15. For Frappe 16, use the `version-16` branch.
 
 ### Self-hosted bench
 
 Run these commands from your Frappe bench:
 
 ```bash
-bench get-app https://github.com/aerele/jarvis.git --branch main
+bench get-app https://github.com/aerele/jarvis.git --branch version-15
 bench --site your-site.example install-app jarvis
 ```
 
@@ -92,7 +92,7 @@ bench --site your-site.example install-app jarvis
 On a private bench group:
 
 1. Open **Bench Group > Apps**, choose **Add App**, and add
-   `https://github.com/aerele/jarvis.git` from the `main` branch.
+   `https://github.com/aerele/jarvis.git` from the `version-15` branch.
 2. Deploy the bench update to your site.
 3. Open **Site > Apps**, choose **Install App**, and install **Jarvis**.
 

--- a/jarvis/compat.py
+++ b/jarvis/compat.py
@@ -1,9 +1,9 @@
 """Cross-major shims for the Frappe / ERPNext APIs this app calls.
 
-``pyproject.toml`` declares ``frappe = ">=15.0.0,<17.0.0"``, so the customer app
-has to run on both majors. Three APIs moved between 15 and 16 in ways that are
-not backward compatible, and each one was written against 16 and shipped onto
-15 benches, where it raised at call time:
+Jarvis ships separate branches for Frappe 15 and 16. These shims remain on both
+branches so compatibility fixes can be backported safely. Three APIs moved
+between 15 and 16 in ways that are not backward compatible, and each one was
+written against 16 and shipped onto 15 benches, where it raised at call time:
 
 * ``File.get_content`` grew an ``encodings`` kwarg in 16. Passing it on 15 is a
   ``TypeError``, which broke every chat attachment and every ``read_file`` call.

--- a/jarvis/tests/test_compat_frappe_versions.py
+++ b/jarvis/tests/test_compat_frappe_versions.py
@@ -1,8 +1,8 @@
 """Regression tests for the Frappe 15 / 16 shims in :mod:`jarvis.compat`.
 
-``pyproject.toml`` declares ``frappe = ">=15.0.0,<17.0.0"``, but three APIs were
-written against Frappe 16 and shipped onto Frappe 15 benches, where each raised
-at call time and nothing caught it:
+Jarvis ships separate branches for Frappe 15 and 16, with these cross-major
+shims carried on both. Three APIs were written against Frappe 16 and shipped
+onto Frappe 15 benches, where each raised at call time and nothing caught it:
 
 * ``File.get_content(encodings=[])`` is a ``TypeError`` on 15. ``read_file``
   re-raised it as an unhandled HTTP 500 for every file type, and the chat attach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,9 @@ name = "jarvis"
 # supports. erpnext/hrms are deliberately absent - jarvis runs on frappe-only
 # benches (app-gated skills/tools handle the rest).
 #
-# This is the version-15 branch: v15 only. A v16 bench installs from main, which
-# carries the v16 gate; disjoint ranges are what let bench and Frappe Cloud steer
-# each site to the right branch.
+# This is the version-15 branch: v15 only. A v16 bench installs from version-16,
+# which carries the v16 gate; disjoint ranges are what let bench and Frappe Cloud
+# steer each site to the right branch.
 [tool.bench.frappe-dependencies]
 frappe = ">=15.0.0,<16.0.0"
 


### PR DESCRIPTION
## Summary

- point self-hosted and Frappe Cloud installation guidance to `version-15`
- direct Frappe 16 users to `version-16`
- remove stale references implying that `main` carries the Frappe 16 release
- align compatibility documentation with the separate release branches

## Validation

- parsed `pyproject.toml` with Python `tomllib`
- asserted the Frappe range is `>=15.0.0,<16.0.0`
- ran pre-commit on every changed file
- ran `git diff --check`