### PR TITLE
feat(agents): cleaner marketplace cards with taller layout

### DIFF
--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -130,7 +130,7 @@
 						:key="a.agent_slug"
 						role="button"
 						tabindex="0"
-						class="flex cursor-pointer flex-col rounded-lg border bg-surface-white p-4 transition hover:bg-surface-gray-1"
+						class="flex cursor-pointer flex-col rounded-lg border bg-surface-white p-5 transition hover:bg-surface-gray-1 hover:shadow-sm"
 						@click="openAgent(a)"
 						@keydown.enter.prevent="openAgent(a)"
 						@keydown.space.prevent="openAgent(a)"
@@ -169,7 +169,7 @@
 							</div>
 						</div>
 
-						<p class="mt-3 line-clamp-2 min-h-10 text-base text-ink-gray-6">
+						<p class="mt-3 line-clamp-2 min-h-10 text-base leading-5 text-ink-gray-6">
 							{{ a.description }}
 						</p>
 


### PR DESCRIPTION
## Summary

Polishes the Agents marketplace cards so the grid reads cleanly. Cards get more breathing room and a soft hover shadow, and the 2-line description clamp is locked to a fixed height so short and long descriptions align across the grid. Body size stays at 14px (`text-base`).

Only `frontend/src/pages/agents/AgentsList.vue` changes (2 lines): `p-4`→`p-5` + `hover:shadow-sm` on the card, and `leading-5` on the clamped description to lock it to the reserved `min-h-10` height.

## Screenshot

<img width="1469" height="812" alt="agents-cards" src="https://github.com/user-attachments/assets/83b65c66-f63f-4407-9a15-95086f0285c4" />

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes) — CSS-only class change, no logic
- [x] I self-reviewed the diff

https://claude.ai/code/session_01HF5N2yxJeW1jcFk342rm8Y