### PR TITLE
fix(widget): lazy-mount the Desk chat panel so the permission check w…

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -54,7 +54,12 @@
 			:class="{ 'jvw-backdrop--show': leaving }"
 			aria-hidden="true"
 		></div>
+		<!-- Lazily mounted: the Panel does not exist until the first open (v-if on
+		     panelMounted), so its onMounted fetches (get_chat_ui_settings /
+		     readiness) never fire on plain Desk page loads. It STAYS mounted after
+		     that. See onFabClick for the two-phase mount->reveal. -->
 		<Panel
+			v-if="panelMounted"
 			ref="panelRef"
 			:open="panelOpen"
 			:context="effectiveContext"
@@ -70,7 +75,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
 import { panelLayout } from "./panel_anchor.mjs";
@@ -159,6 +164,11 @@ const panelRef = ref(null);
 const isDark = ref(false);
 let unwatchTheme = null;
 const panelOpen = ref(false);
+// The Panel is v-if'd on this: it mounts on the FIRST open and then STAYS mounted
+// (keep-mounted, so the conversation/scroll/draft survive a close->reopen - a bare
+// v-if="panelOpen" would tear all that down on every close). onFabClick owns the
+// two-phase mount->reveal.
+const panelMounted = ref(false);
 const deskContext = ref(null);
 const contextDismissed = ref(false);
 
@@ -255,7 +265,7 @@ function readDeskContext() {
 }
 
 function closePanel() {
-	panelOpen.value = false;
+	panelOpen.value = false; // hide only - panelMounted stays true (the latch)
 	fabEl.value?.focus();
 }
 
@@ -440,8 +450,27 @@ function onFabClick() {
 		window.location.assign(FULL_CHAT_URL);
 		return;
 	}
-	if (!panelOpen.value) readDeskContext();
-	panelOpen.value = !panelOpen.value;
+	if (!panelMounted.value) {
+		// FIRST open: mount the Panel now (open stays false), then flip open->true on
+		// the NEXT tick so Panel.vue's non-immediate watch on `props.open` observes a
+		// false->true transition and runs the first-open load() (conversation restore),
+		// ensureRealtime(), focus and watchBodyGrowth(). Mounting with open already true
+		// skips that watcher and the panel opens blank (and the first send would mint a
+		// NEW conversation). Schedule the reveal BEFORE the throw-prone readDeskContext()
+		// below, so a context-read failure can never strand the panel unopened. Do NOT
+		// collapse the two ticks into one.
+		panelMounted.value = true;
+		nextTick(() => {
+			panelOpen.value = true;
+		});
+		readDeskContext();
+		return;
+	}
+	// Already mounted: a plain open/close toggle. A reopen re-reads the record context,
+	// matching the old "read context before opening" behaviour.
+	const opening = !panelOpen.value;
+	panelOpen.value = opening;
+	if (opening) readDeskContext();
 }
 
 // Re-clamps the FAB into the (possibly resized) dockable band; ratio-based


### PR DESCRIPTION
…aits for the click

The floating chat FAB rendered its <Panel> unconditionally on every Desk page, so Panel's onMounted fired get_chat_ui_settings() (and refreshReadiness) on every full page load - for every System User. For users without the Jarvis User role that endpoint 403s via require_jarvis_access(), and Frappe surfaced the thrown message as a red "You need the Jarvis User role" popup on every Desk page. It also did needless work every load (an uncached Jarvis Settings read, per-row password decryptions, a wiki-count query, and on managed tenants a control-plane round-trip) just to compute the one mic flag the widget reads.

Gate the Panel behind v-if="panelMounted" so it mounts only on the first open, then stays mounted (keep-mounted, so the conversation/scroll/draft survive a close->reopen). onFabClick already redirects non-access users to /jarvis-no-access before opening, so the permission check now happens on the click: non-access users mount nothing and see no popup; access users hit the endpoint once, on open, never on plain page loads.

First open mounts with open=false then flips open->true on the next tick so Panel's non-immediate watch(props.open) observes the false->true transition and runs first-open conversation restore / realtime / focus; the reveal is scheduled before the throw-prone readDeskContext() so a context-read failure cannot strand the panel unopened.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
