### PR TITLE
backport(agents): cleaner marketplace cards with taller layout (version-15)

### DIFF
--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -130,7 +130,7 @@
 						:key="a.agent_slug"
 						role="button"
 						tabindex="0"
-						class="flex cursor-pointer flex-col rounded-lg border bg-surface-white p-4 transition hover:bg-surface-gray-1"
+						class="flex cursor-pointer flex-col rounded-lg border bg-surface-white p-5 transition hover:bg-surface-gray-1 hover:shadow-sm"
 						@click="openAgent(a)"
 						@keydown.enter.prevent="openAgent(a)"
 						@keydown.space.prevent="openAgent(a)"
@@ -169,7 +169,7 @@
 							</div>
 						</div>
 
-						<p class="mt-3 line-clamp-2 min-h-10 text-base text-ink-gray-6">
+						<p class="mt-3 line-clamp-2 min-h-10 text-base leading-5 text-ink-gray-6">
 							{{ a.description }}
 						</p>
 


### PR DESCRIPTION
Backport of #968 to `version-15`.

Clean cherry-pick (identical 2-line diff to `frontend/src/pages/agents/AgentsList.vue` — the file is byte-identical across develop/version-16/version-15). Review and screenshot live on #968.

## Summary

Roomier Agents marketplace cards: `p-4`→`p-5` + `hover:shadow-sm` on the card, and `leading-5` on the clamped description so the 2-line ellipsis locks to the reserved `min-h-10` height and cards align across the grid.

## Screenshot

<img width="1469" height="812" alt="agents-cards" src="https://github.com/user-attachments/assets/83b65c66-f63f-4407-9a15-95086f0285c4" />

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check passes
- [x] Clean cherry-pick of #968, no logic change
- [x] I self-reviewed the diff

https://claude.ai/code/session_01HF5N2yxJeW1jcFk342rm8Y