### PR TITLE
fix(dashboards): blank canvas + live spinner + #887 cleanups (backport #967 → version-15)

### DIFF
--- a/frontend/src/lib/dashboardEcharts.js
+++ b/frontend/src/lib/dashboardEcharts.js
@@ -1,0 +1,14 @@
+// The echarts runtime, as raw source, for injection into the sandboxed dashboard
+// srcdoc. Loaded only when the dashboard html actually references echarts; the
+// deep filesystem-relative ?raw import ships it as its own lazy chunk (echarts'
+// exports map blocks bare deep imports).
+//
+// This lives in its own module (rather than inline in DashboardCanvas.rebuild())
+// so the async boundary is isolated and mockable: rebuild() awaits this, and
+// overlapping rebuilds race on whichever load resolves last — the canvas guards
+// that race with a generation counter, and the test drives it through here.
+export async function loadEchartsSource(html) {
+	if (!/\becharts\b/i.test(String(html || ""))) return "";
+	const mod = await import("../../node_modules/echarts/dist/echarts.min.js?raw");
+	return (mod && mod.default) || "";
+}

--- a/frontend/src/pages/dashboards/DashboardCanvas.spec.js
+++ b/frontend/src/pages/dashboards/DashboardCanvas.spec.js
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#887 / builder blank-canvas regressions. Two guarantees:
+ *
+ *  1. Overlapping rebuilds are ordered by a generation counter, so a SLOWER
+ *     earlier rebuild that resolves last cannot re-navigate the iframe to a
+ *     stale document (the intermittent blank canvas).
+ *  2. The spinner spans the DATA phase for live dashboards - `loading` stays
+ *     true past the iframe's DOM-parse `ready` until the first data batch
+ *     resolves; static dashboards (no declared sources) clear on `ready`.
+ */
+
+// echarts load is the async boundary rebuild() races on. Default: resolve
+// immediately. Guard test flips to "manual" to hold each call open and resolve
+// them out of order.
+const echartsGate = vi.hoisted(() => {
+	const state = { mode: "auto", queue: [] };
+	return {
+		state,
+		setManual: () => (state.mode = "manual"),
+		load: vi.fn(() =>
+			state.mode === "manual"
+				? new Promise((resolve) => state.queue.push(resolve))
+				: Promise.resolve("")
+		),
+	};
+});
+vi.mock("@/lib/dashboardEcharts", () => ({ loadEchartsSource: echartsGate.load }));
+
+// buildSrcdoc → a marker carrying the html it was built from, so a test can read
+// the iframe's srcdoc and know which rebuild won; spied so a test can count how
+// many rebuilds actually re-navigated the frame. parseSourcesBlock → "live" iff
+// the html opts in with the word "sources".
+const srcdoc = vi.hoisted(() => ({ build: vi.fn((html) => "DOC:" + html) }));
+vi.mock("@/lib/dashboardSrcdoc", () => ({
+	buildSrcdoc: srcdoc.build,
+	parseSourcesBlock: (html) =>
+		String(html || "").includes("sources")
+			? [{ source_name: "s1", tool: "query", spec: {} }]
+			: [],
+}));
+
+vi.mock("@/lib/dashboardThemes", () => ({
+	THEMES: { jarvis: {} },
+	DEFAULT_THEME: "jarvis",
+	themeKey: () => "jarvis",
+}));
+vi.mock("@/lib/dashboardExport", () => ({
+	loadCaptureLib: vi.fn(async () => ""),
+	downloadPng: vi.fn(),
+	downloadPdf: vi.fn(),
+}));
+vi.mock("@/lib/errors", () => ({ errMessage: (e) => String((e && e.message) || e) }));
+
+const api = vi.hoisted(() => ({
+	runDashboardSource: vi.fn(async () => ({ ok: true, data: [{ a: 1 }] })),
+	callDashboardTool: vi.fn(async () => ({ ok: true, data: [{ a: 1 }] })),
+}));
+vi.mock("@/api/dashboards", () => api);
+
+vi.mock("frappe-ui", () => ({
+	Button: {
+		name: "Button",
+		props: ["label", "loading"],
+		template: "<button>{{ label }}</button>",
+	},
+	ErrorMessage: {
+		name: "ErrorMessage",
+		props: ["message"],
+		template: "<div>{{ message }}</div>",
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+}));
+vi.mock("@/components/JvSpinner.vue", () => ({
+	default: { name: "JvSpinner", template: "<i class='spinner' />" },
+}));
+
+import DashboardCanvas from "./DashboardCanvas.vue";
+
+// Deliver a validated frame message: onMessage requires e.source === the iframe's
+// own contentWindow and a jarvis:1 stamp.
+function sendFrameMessage(wrapper, data) {
+	const fw = wrapper.find("iframe").element.contentWindow;
+	const ev = new MessageEvent("message", { data: { jarvis: 1, ...data } });
+	Object.defineProperty(ev, "source", { value: fw });
+	window.dispatchEvent(ev);
+}
+
+const spinnerShown = (wrapper) => wrapper.find(".spinner").exists();
+
+beforeEach(() => {
+	echartsGate.state.mode = "auto";
+	echartsGate.state.queue.length = 0;
+	vi.clearAllMocks();
+});
+
+describe("DashboardCanvas rebuild ordering", () => {
+	it("drops a stale rebuild that resolves after a newer one (no blank canvas)", async () => {
+		echartsGate.setManual();
+		const wrapper = mount(DashboardCanvas, {
+			props: { mode: "view", html: "A echarts", dashboard: { name: "d1" } },
+		});
+		// First rebuild (A) is now awaiting its echarts load.
+		await wrapper.setProps({ html: "B echarts" });
+		// Two rebuilds in flight; resolve the NEWER (B) first, the stale (A) last.
+		expect(echartsGate.state.queue.length).toBe(2);
+		srcdoc.build.mockClear();
+		echartsGate.state.queue[1]("");
+		echartsGate.state.queue[0]("");
+		await flushPromises();
+
+		// Only the winning (newer) rebuild re-navigates the frame; the stale one
+		// bails instead of re-assigning `doc` (which would blank the booted frame).
+		expect(srcdoc.build).toHaveBeenCalledTimes(1);
+		expect(wrapper.find("iframe").attributes("srcdoc")).toBe("DOC:B echarts");
+	});
+});
+
+describe("DashboardCanvas data-phase spinner", () => {
+	it("keeps the spinner until a live dashboard's first data batch resolves", async () => {
+		// attachTo: the iframe only gets a real contentWindow (which onMessage
+		// validates e.source against) when attached to the document.
+		const wrapper = mount(DashboardCanvas, {
+			attachTo: document.body,
+			props: { mode: "view", html: "live sources", dashboard: { name: "d1" } },
+		});
+		await flushPromises();
+		expect(spinnerShown(wrapper)).toBe(true);
+
+		// DOM parsed, but live data has not arrived - spinner must stay.
+		sendFrameMessage(wrapper, { type: "ready" });
+		await flushPromises();
+		expect(spinnerShown(wrapper)).toBe(true);
+
+		// The widget requests its data; once it drains, the spinner clears.
+		sendFrameMessage(wrapper, { type: "data", id: "1", name: "s1", tool: "query", spec: {} });
+		await flushPromises();
+		expect(api.runDashboardSource).toHaveBeenCalledWith("d1", "s1");
+		expect(spinnerShown(wrapper)).toBe(false);
+		wrapper.unmount();
+	});
+
+	it("clears the spinner on ready for a static dashboard (no sources)", async () => {
+		const wrapper = mount(DashboardCanvas, {
+			attachTo: document.body,
+			props: { mode: "view", html: "static only", dashboard: { name: "d1" } },
+		});
+		await flushPromises();
+		expect(spinnerShown(wrapper)).toBe(true);
+
+		sendFrameMessage(wrapper, { type: "ready" });
+		await flushPromises();
+		expect(spinnerShown(wrapper)).toBe(false);
+		wrapper.unmount();
+	});
+});
+
+describe("DashboardCanvas re-drive reload (#965)", () => {
+	it("remounts the iframe on a rebuild with identical html (forces a real reload)", async () => {
+		const wrapper = mount(DashboardCanvas, {
+			attachTo: document.body,
+			props: { mode: "builder", html: "static only" },
+		});
+		await flushPromises();
+		const first = wrapper.find("iframe").element;
+
+		// The tab-return re-drive: rebuild() with the SAME html. Assigning an
+		// identical srcdoc string would not reload the frame; a changing :key must.
+		await wrapper.vm.rebuild();
+		await flushPromises();
+		const second = wrapper.find("iframe").element;
+
+		expect(second).not.toBe(first);
+		wrapper.unmount();
+	});
+});

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -39,6 +39,7 @@
 			     runs fully isolated; all data arrives over postMessage. -->
 			<iframe
 				ref="frame"
+				:key="frameKey"
 				:srcdoc="doc"
 				sandbox="allow-scripts"
 				class="w-full border-0"
@@ -70,6 +71,7 @@ import { ref, watch, onMounted, onBeforeUnmount } from "vue";
 import { Button, ErrorMessage, FeatherIcon } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc";
+import { loadEchartsSource } from "@/lib/dashboardEcharts";
 import { THEMES, DEFAULT_THEME, themeKey } from "@/lib/dashboardThemes";
 import { loadCaptureLib, downloadPng, downloadPdf } from "@/lib/dashboardExport";
 import { runDashboardSource, callDashboardTool } from "@/api/dashboards";
@@ -96,6 +98,12 @@ const loading = ref(false);
 const building = ref(false);
 const buildError = ref("");
 const frameH = ref(480); // view mode: grown by the iframe's height frames
+// Bumped on every (re)build so the iframe REMOUNTS, not just re-`srcdoc`s. A
+// re-drive (e.g. returning to a builder tab that ran hidden at 0x0) often
+// rebuilds a byte-identical document; assigning the same string to :srcdoc is a
+// no-op in Vue and would not reload the frame, leaving the 0x0 charts blank. A
+// changing :key forces a fresh element that boots against the now-visible size.
+const frameKey = ref(0);
 
 function postToFrame(msg) {
 	const fw = frame.value && frame.value.contentWindow;
@@ -103,39 +111,66 @@ function postToFrame(msg) {
 }
 
 // ── srcdoc assembly ──────────────────────────────────────────────────────────
+// rebuild() is async (it awaits the echarts chunk) and fires from three racing
+// triggers: the html watcher, the theme watcher, and the builder page's
+// tab-visibility re-drive. Without ordering, a SLOWER earlier rebuild can
+// resolve last and reassign `doc` after a newer one already booted its iframe -
+// re-navigating the frame to a stale document, which is the intermittent blank
+// canvas. `rebuildSeq` is that ordering: each call takes a ticket and a call
+// that has been superseded across its await bails instead of clobbering.
 let readyTimer = null;
+let rebuildSeq = 0;
+// Data-phase loading (the spinner): live dashboards keep spinning past the
+// iframe's DOM-parse `ready` until their first data batch resolves; static
+// dashboards (no declared sources) have nothing more to wait for.
+let readyFired = false;
+let firstDataSettled = false;
+let hasSources = false;
+let pendingData = 0;
+
+function stopLoading() {
+	loading.value = false;
+	clearTimeout(readyTimer);
+}
+
 async function rebuild() {
 	if (!props.html) {
 		doc.value = "";
 		emit("state", "empty");
 		return;
 	}
+	const gen = ++rebuildSeq;
 	building.value = true;
 	buildError.value = "";
 	loading.value = true;
+	readyFired = false;
+	firstDataSettled = false;
+	pendingData = 0;
+	hasSources = parseSourcesBlock(props.html).length > 0;
 	emit("state", "loading");
 	try {
-		let echartsSource = "";
-		if (/\becharts\b/i.test(props.html)) {
-			// Filesystem-relative ?raw import: echarts' exports map blocks bare
-			// deep imports; the raw source ships as its own lazy chunk.
-			const mod = await import("../../../node_modules/echarts/dist/echarts.min.js?raw");
-			echartsSource = (mod && mod.default) || "";
-		}
+		const echartsSource = await loadEchartsSource(props.html);
+		// A newer rebuild started while we awaited - drop this stale result so it
+		// can't re-navigate the frame out from under the current document.
+		if (gen !== rebuildSeq) return;
 		doc.value = buildSrcdoc(props.html, {
 			echartsSource,
 			theme: THEMES[themeKey(props.theme)],
 		});
-		// Safety valve: if the frame never posts ready (user script threw before
-		// our runtime's DOMContentLoaded, etc.) don't spin forever.
+		// Force a fresh iframe even if `doc` is unchanged (see frameKey) - this is
+		// what makes a re-drive actually reload a frame that booted blank at 0x0.
+		frameKey.value++;
+		// Safety valve covers both "frame never posts ready" and "a live source
+		// never resolves" - don't spin forever either way.
 		clearTimeout(readyTimer);
-		readyTimer = setTimeout(() => (loading.value = false), 8000);
+		readyTimer = setTimeout(stopLoading, 8000);
 	} catch (e) {
+		if (gen !== rebuildSeq) return;
 		buildError.value = errMsg(e);
-		loading.value = false;
+		stopLoading();
 		emit("state", "error");
 	} finally {
-		building.value = false;
+		if (gen === rebuildSeq) building.value = false;
 	}
 }
 
@@ -167,6 +202,7 @@ function dataPayload(data) {
 }
 
 async function handleData(d) {
+	pendingData++;
 	let reply;
 	try {
 		// call_tool dispatches kwargs: query takes its DSL object under the
@@ -201,6 +237,13 @@ async function handleData(d) {
 	// Data failures render per-widget INSIDE the iframe (jarvis.renderError) -
 	// never a toast out here.
 	postToFrame({ type: "data:result", id: d.id, ...reply });
+	// First drained data batch after `ready` clears the spinner. Only the initial
+	// load shows it - later ad-hoc data calls don't re-raise it (no flicker).
+	pendingData = Math.max(0, pendingData - 1);
+	if (readyFired && !firstDataSettled && pendingData === 0) {
+		firstDataSettled = true;
+		stopLoading();
+	}
 }
 
 // ── export (lib injection + downloads live in lib/dashboardExport) ───────────
@@ -245,9 +288,14 @@ function onMessage(e) {
 	const d = e.data;
 	if (!d || d.jarvis !== 1) return;
 	if (d.type === "ready") {
-		clearTimeout(readyTimer);
-		loading.value = false;
+		readyFired = true;
 		emit("state", "ready");
+		// Static dashboards are done at DOM parse; live ones keep the spinner
+		// until handleData drains their first data batch (or the 8s valve fires).
+		if (!hasSources) {
+			firstDataSettled = true;
+			stopLoading();
+		}
 	} else if (d.type === "height") {
 		if (props.mode === "view") frameH.value = Math.max(480, Math.ceil(d.height || 0));
 	} else if (d.type === "data") {

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -708,8 +708,8 @@ async function onDashboardSaved({ name } = {}) {
 	try {
 		d = await getDashboard(name);
 	} catch (e) {
-		// The save itself already succeeded server-side (the pane's own
-		// confirmation card said so before this event ever fired); a blip
+		// The save already succeeded server-side — this event only fires after
+		// save_dashboard committed the row and published its frame — so a blip
 		// fetching it back is not worth interrupting the builder over.
 		return;
 	}

--- a/jarvis/tools/_save_guards.py
+++ b/jarvis/tools/_save_guards.py
@@ -1,0 +1,50 @@
+"""Shared entry guards for the agent-session dashboard-save tools (jarvis#887).
+
+``save_dashboard`` (chat/builder) and ``save_agent_dashboard`` (delegate runs)
+persist agent-authored HTML through different backends, but share the same three
+guards: a non-empty document, a caller ``session_key`` (never a model-supplied
+id), and mapping the persistence layer's ``ValidationError`` onto
+``InvalidArgumentError`` so the model reads the message and re-saves instead of
+dying on a 500. Factored here so the two tools cannot drift.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def require_html(html: str | None, tool: str) -> None:
+	"""Reject an empty/blank document before any work; ``tool`` names the caller
+	in the message the model sees."""
+	if not (html or "").strip():
+		raise InvalidArgumentError(f"{tool} requires a non-empty html document")
+
+
+def require_session_key(no_key_message: str) -> str:
+	"""The caller's plugin ``session_key``, or ``InvalidArgumentError`` when absent.
+
+	Absent outside a plugin dispatch (standard Frappe auth, direct-Python, or a
+	test that did not set it), so a save tool with no session context refuses
+	rather than guessing an identity.
+	"""
+	from jarvis.tools._agent_run_ctx import get_session_key
+
+	session_key = get_session_key()
+	if not session_key:
+		raise InvalidArgumentError(no_key_message)
+	return session_key
+
+
+@contextmanager
+def validation_as_invalid_argument():
+	"""Map the persistence layer's ``ValidationError`` (caps, scope, sources
+	shape, the theme validator) onto ``InvalidArgumentError`` — the model gets the
+	validator's message and re-saves a fixed document instead of dying on a 500."""
+	try:
+		yield
+	except frappe.ValidationError as e:
+		raise InvalidArgumentError(str(e))

--- a/jarvis/tools/save_agent_dashboard.py
+++ b/jarvis/tools/save_agent_dashboard.py
@@ -98,19 +98,16 @@ def save_agent_dashboard(
 	run's existing dashboard (idempotent).
 	"""
 	from jarvis.chat import agent_runs
-	from jarvis.tools._agent_run_ctx import get_session_key
+	from jarvis.tools._save_guards import require_html, require_session_key, validation_as_invalid_argument
 
-	if not (html or "").strip():
-		raise InvalidArgumentError("save_agent_dashboard requires a non-empty html document")
+	require_html(html, "save_agent_dashboard")
 
 	# The run is resolved from the CALLER's session bearer, never a model-supplied
 	# id — so a delegate can only ever attach a dashboard to its own run.
-	session_key = get_session_key()
-	if not session_key:
-		raise InvalidArgumentError(
-			"save_agent_dashboard must be called by an agent delegate over its run "
-			"session (no session_key in context)"
-		)
+	session_key = require_session_key(
+		"save_agent_dashboard must be called by an agent delegate over its run "
+		"session (no session_key in context)"
+	)
 
 	run_row = frappe.db.get_value(
 		RUN,
@@ -154,7 +151,10 @@ def save_agent_dashboard(
 	shadow = (inst.get("activation_state") or "shadow") == "shadow"
 	persist_html = _shadow_gate_html(html) if shadow else html
 
-	try:
+	# Caps/scope errors from the DocType controller surface as ValidationError; the
+	# guard gives the delegate a clean, non-fatal message (the run's findings
+	# writeback still proceeds).
+	with validation_as_invalid_argument():
 		dashboard = agent_runs.persist_agent_dashboard(
 			run_doc,
 			inst,
@@ -163,10 +163,6 @@ def save_agent_dashboard(
 			description=description,
 			owner_override=visibility_owner,
 		)
-	except frappe.ValidationError as e:
-		# Caps/scope errors from the DocType controller — give the delegate a
-		# clean, non-fatal message (the run's findings writeback still proceeds).
-		raise InvalidArgumentError(str(e))
 
 	# PP-4 enforcement (1), made effective: Frappe stamps ``owner = session.user`` at
 	# insert (``document.set_user_and_timestamp``), OVERWRITING the pre-set

--- a/jarvis/tools/save_dashboard.py
+++ b/jarvis/tools/save_dashboard.py
@@ -54,16 +54,12 @@ def save_dashboard(
 	"""
 	from jarvis.chat import dashboards_api
 	from jarvis.chat.events import publish_to_user
-	from jarvis.tools._agent_run_ctx import get_session_key
+	from jarvis.tools._save_guards import require_html, require_session_key, validation_as_invalid_argument
 
-	if not (html or "").strip():
-		raise InvalidArgumentError("save_dashboard requires a non-empty html document")
-
-	session_key = get_session_key()
-	if not session_key:
-		raise InvalidArgumentError(
-			"save_dashboard must be called from a chat agent session (no session_key in context)"
-		)
+	require_html(html, "save_dashboard")
+	session_key = require_session_key(
+		"save_dashboard must be called from a chat agent session (no session_key in context)"
+	)
 
 	conv = frappe.db.get_value(
 		CONVERSATION,
@@ -98,12 +94,10 @@ def save_dashboard(
 	if description:
 		fields["description"] = description
 
-	try:
+	# Caps, scope, sources shape, and the theme validator all raise ValidationError;
+	# the guard hands the model the message so it can fix the document and re-save.
+	with validation_as_invalid_argument():
 		result = dashboards_api.save_dashboard(payload=frappe.as_json(fields))
-	except frappe.ValidationError as e:
-		# Caps, scope, sources shape, and the theme validator all land here —
-		# hand the model the message so it can fix the document and re-save.
-		raise InvalidArgumentError(str(e))
 
 	detail = (result or {}).get("data") or {}
 	saved_name = detail.get("name")


### PR DESCRIPTION
## Summary

Backport of #967 to **version-15**. The net diff applied unchanged — the target files were byte-identical to develop.

Fixes the blank dashboard canvas and the missing Live loader, three root causes in `DashboardCanvas.vue`:

1. **Rebuild race** — a superseded async rebuild could re-navigate the iframe after a newer one booted it. Generation counter fixes ordering.
2. **Re-drive no-op (#965)** — returning to a hidden builder tab rebuilt a byte-identical `srcdoc`, which doesn't reload the iframe; a changing `:key` forces a remount.
3. **Missing loader** — spinner cleared on DOM-parse `ready`, not when live data arrived; now holds until the first data batch drains.

Plus the #887 cleanups: shared save-tool guards (`jarvis/tools/_save_guards.py`) and a corrected `onDashboardSaved` comment.

Verified locally on this branch: 11 dashboard tests pass, prettier (2.7.1) clean.

Closes #965. Refs #887. Backport of #967.

https://claude.ai/code/session_011RNSCv4qHonJMmcQbkQ1z5
