### PR TITLE
fix(widget): lazy-mount the Desk chat panel so no-access users see no…

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -54,7 +54,13 @@
 			:class="{ 'jvw-backdrop--show': leaving }"
 			aria-hidden="true"
 		></div>
+		<!-- Lazily mounted: the Panel does not exist until the first open (v-if on
+		     panelMounted), so its onMounted fetches (get_chat_ui_settings /
+		     readiness) never fire on plain Desk page loads - and never pop the
+		     "You need the Jarvis User role" dialog for a role-less System User.
+		     It STAYS mounted after that; see onFabClick for the mount->reveal. -->
 		<Panel
+			v-if="panelMounted"
 			ref="panelRef"
 			:open="panelOpen"
 			:context="effectiveContext"
@@ -70,13 +76,14 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
 import { panelLayout } from "./panel_anchor.mjs";
 import * as panelSize from "./panel_size.mjs";
 import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import * as fabPos from "./fab_position.mjs";
+import { fabAction, panelTogglePlan } from "./fab_action.mjs";
 import Panel from "./Panel.vue";
 
 // ---- FAB: draggable, edge-snapping, idle-fading launcher button.
@@ -159,6 +166,11 @@ const panelRef = ref(null);
 const isDark = ref(false);
 let unwatchTheme = null;
 const panelOpen = ref(false);
+// The Panel is v-if'd on this: it mounts on the FIRST open and then STAYS mounted
+// (keep-mounted, so the conversation/scroll/draft survive a close->reopen - a bare
+// v-if="panelOpen" would tear all that down on every close). Latches true on the
+// first open; onFabClick owns the two-phase mount->reveal.
+const panelMounted = ref(false);
 const deskContext = ref(null);
 const contextDismissed = ref(false);
 
@@ -255,7 +267,7 @@ function readDeskContext() {
 }
 
 function closePanel() {
-	panelOpen.value = false;
+	panelOpen.value = false; // hide only - panelMounted stays true (the latch)
 	fabEl.value?.focus();
 }
 
@@ -430,18 +442,40 @@ function onFabClick() {
 		return;
 	}
 	wake();
-	if (!hasAccess) {
+	const action = fabAction(hasAccess, window.innerWidth, PANEL_MIN_VIEWPORT_PX);
+	if (action === "no-access") {
+		// A no-access user never opens the panel, so the Panel (and its on-mount,
+		// access-gated get_chat_ui_settings()/readiness calls that PermissionError
+		// for a role-less user) never mounts - no red dialog. See fab_action.mjs.
 		window.location.assign("/jarvis-no-access");
 		return;
 	}
-	// Below the threshold a 400px panel is most of the screen, so fall back to
-	// the full SPA rather than designing a third layout for it.
-	if (window.innerWidth < PANEL_MIN_VIEWPORT_PX) {
+	if (action === "full") {
+		// Below the threshold a 400px panel is most of the screen, so fall back to
+		// the full SPA rather than designing a third layout for it.
 		window.location.assign(FULL_CHAT_URL);
 		return;
 	}
-	if (!panelOpen.value) readDeskContext();
-	panelOpen.value = !panelOpen.value;
+	const plan = panelTogglePlan({ mounted: panelMounted.value, open: panelOpen.value });
+	if (plan.mount) panelMounted.value = true;
+	if (plan.deferReveal) {
+		// FIRST open: the Panel just mounted CLOSED; flip it open on the NEXT tick so
+		// Panel.vue's non-immediate watch(props.open) observes false->true and runs
+		// the first-open load() (conversation restore), ensureRealtime() and focus.
+		// Revealing in this same tick makes the Panel mount already-open, the watch
+		// never fires, and the panel opens blank (first send mints a NEW conversation).
+		// Scheduled BEFORE the throw-prone readDeskContext() below so a context-read
+		// failure can never strand the panel unopened. Do NOT collapse the two ticks.
+		nextTick(() => {
+			panelOpen.value = plan.open;
+		});
+		readDeskContext();
+		return;
+	}
+	// Already mounted: a plain open/close toggle. Re-read the record context when
+	// opening (never on close), matching the old read-context-before-open behaviour.
+	if (plan.readContext) readDeskContext();
+	panelOpen.value = plan.open;
 }
 
 // Re-clamps the FAB into the (possibly resized) dockable band; ratio-based

--- a/jarvis/public/js/jarvis_chat/widget/fab_action.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/fab_action.mjs
@@ -1,0 +1,69 @@
+// What a tap on the floating Jarvis button (FAB) should do, as pure functions so
+// the load-bearing bits can be unit-tested away from the Desk DOM. Widget.vue's
+// onFabClick wires these to frappe.boot, window.innerWidth, and Vue refs.
+//
+// Two decisions live here:
+//
+//   fabAction()       - route the tap: no-access redirect vs full-SPA handoff vs
+//                       open/close the in-place side panel.
+//   panelTogglePlan() - once the tap is a "toggle", how to drive the lazily
+//                       mounted Panel, including the two-tick FIRST-open sequence.
+//
+// Both exist to keep the side-chat Panel from ever mounting for a user without
+// Jarvis access: the Panel calls get_chat_ui_settings() (and other access-gated
+// endpoints) on mount, which the server rejects with a PermissionError - a red
+// "Message" dialog - for anyone lacking the Jarvis User role. So the widget
+// mounts the FAB for everyone (preserving the /jarvis-no-access self-heal
+// redirect) but only OPENS - and thus only lazily mounts - the Panel for a user
+// who has access.
+
+/**
+ * Route a FAB tap.
+ *
+ *   - "no-access": redirect to /jarvis-no-access (no panel; no server call).
+ *   - "full":      hand off to the full chat SPA (a 400px panel is most of a
+ *                  narrow screen, so there is no in-place layout for it).
+ *   - "toggle":    open/close the in-place side panel.
+ *
+ * `hasAccess` is Boolean(frappe.boot.jarvis_has_access) - the same
+ * has_jarvis_access() verdict the server enforces (jarvis/boot.py), read
+ * fail-closed so a missing/undefined flag routes to the recoverable no-access
+ * page rather than opening a panel that would just pop the error dialog.
+ */
+export function fabAction(hasAccess, viewportWidth, minViewportPx) {
+  if (!hasAccess) return "no-access";
+  if (viewportWidth < minViewportPx) return "full";
+  return "toggle";
+}
+
+/**
+ * Given the Panel's current mount/open state, describe how a "toggle" tap should
+ * drive it. Split out of onFabClick so the FIRST-open sequence - the easy thing
+ * to get subtly wrong - is unit-testable without a DOM.
+ *
+ *   - mount:       lazily mount the Panel now if it is not mounted yet.
+ *   - open:        the Panel's target open state after this tap.
+ *   - deferReveal: on the FIRST open the Panel must mount CLOSED and flip open on
+ *                  the NEXT tick, so Panel.vue's non-immediate watch(() =>
+ *                  props.open) observes a false->true transition and runs its
+ *                  first-open load() (conversation restore), ensureRealtime() and
+ *                  focus. Revealing in the same tick as the mount makes the Panel
+ *                  mount already-open, the watch never fires, and the panel opens
+ *                  BLANK (and the first send mints a NEW conversation). Only the
+ *                  first open needs this; a reopen toggles a Panel that is already
+ *                  mounted and watching.
+ *   - readContext: re-read the Desk record context. Done when opening (first open
+ *                  or reopen), never on a close.
+ */
+export function panelTogglePlan({ mounted, open }) {
+  if (!mounted) {
+    return { mount: true, open: true, deferReveal: true, readContext: true };
+  }
+  const opening = !open;
+  return {
+    mount: false,
+    open: opening,
+    deferReveal: false,
+    readContext: opening,
+  };
+}

--- a/jarvis/public/js/jarvis_chat/widget/fab_action.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/fab_action.test.mjs
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fabAction, panelTogglePlan } from "./fab_action.mjs";
+
+const MIN = 600; // stand-in for PANEL_MIN_VIEWPORT_PX
+
+// ---- fabAction: routing the tap -------------------------------------------
+
+test("fabAction: no access -> no-access page, never opens the panel", () => {
+  // The gate: a role-less user never opens (so never mounts) the Panel, so its
+  // on-mount get_chat_ui_settings() PermissionError dialog cannot fire. Viewport
+  // is irrelevant when there is no access.
+  assert.equal(fabAction(false, 1200, MIN), "no-access");
+  assert.equal(fabAction(false, 400, MIN), "no-access");
+});
+
+test("fabAction: no access wins over a narrow viewport", () => {
+  // Access is checked first, so a role-less user on a phone still lands on the
+  // recoverable no-access page, not the full chat SPA.
+  assert.equal(fabAction(false, 320, MIN), "no-access");
+});
+
+test("fabAction: access on a wide viewport -> toggle the in-place panel", () => {
+  assert.equal(fabAction(true, 1200, MIN), "toggle");
+  assert.equal(fabAction(true, MIN, MIN), "toggle"); // exactly at the threshold
+});
+
+test("fabAction: access on a narrow viewport -> hand off to the full chat SPA", () => {
+  assert.equal(fabAction(true, MIN - 1, MIN), "full");
+  assert.equal(fabAction(true, 320, MIN), "full");
+});
+
+// ---- panelTogglePlan: driving the lazily mounted Panel --------------------
+
+test("panelTogglePlan: FIRST open mounts closed and defers the reveal a tick", () => {
+  // Regression guard: on the first open the reveal MUST be deferred so Panel.vue's
+  // non-immediate watch(open) sees false->true and restores the conversation. A
+  // same-tick reveal opens the panel blank and mints a new conversation.
+  assert.deepEqual(panelTogglePlan({ mounted: false, open: false }), {
+    mount: true,
+    open: true,
+    deferReveal: true,
+    readContext: true,
+  });
+});
+
+test("panelTogglePlan: reopen toggles an already-mounted panel in the same tick", () => {
+  // Already mounted and watching, so no deferral: open synchronously and re-read
+  // the record context (matches the old read-context-before-open behaviour).
+  assert.deepEqual(panelTogglePlan({ mounted: true, open: false }), {
+    mount: false,
+    open: true,
+    deferReveal: false,
+    readContext: true,
+  });
+});
+
+test("panelTogglePlan: closing hides without re-reading context or deferring", () => {
+  // Negative case: a close must not re-read the Desk context and must not defer.
+  assert.deepEqual(panelTogglePlan({ mounted: true, open: true }), {
+    mount: false,
+    open: false,
+    deferReveal: false,
+    readContext: false,
+  });
+});


### PR DESCRIPTION
… popup

Combines #969 and #966. The floating chat FAB rendered <Panel> eagerly on every Desk page, so Panel's onMounted fired get_chat_ui_settings()/readiness on every full page load. For a System User without the Jarvis User role those endpoints 403 via require_jarvis_access(), and Frappe surfaced the throw as a red "You need the Jarvis User role" dialog on every Desk page.

Gate the Panel behind v-if="panelMounted" so it mounts only on the first open and then stays mounted (keep-mounted, so conversation/scroll/draft survive a close->reopen). onFabClick already redirects no-access users to /jarvis-no-access before opening, so a role-less user mounts nothing.

Two pure helpers, unit-tested with node:test (positive + negative):

  - fabAction()       routes the tap: no-access / full-SPA / toggle.
  - panelTogglePlan() drives the lazily mounted Panel. On the FIRST open the
                      Panel mounts CLOSED and reveals on the next tick so
                      Panel.vue's non-immediate watch(props.open) observes a
                      false->true transition and runs its first-open load()
                      (conversation restore), ensureRealtime() and focus.
                      Revealing in the same tick would mount the Panel
                      already-open, skip that watch, and open it blank (the
                      first send minting a NEW conversation). The reveal is
                      scheduled before the throw-prone readDeskContext() so a
                      context-read failure cannot strand the panel unopened.

Supersedes #969 (first-open correctness) and #966 (fabAction extraction + tests); both edit the same Widget.vue lines and should be closed.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
