### PR TITLE
fix(dashboards): render saved dashboards reliably on cold loads

### DIFF
--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -230,12 +230,36 @@ export const RUNTIME_JS = `(function () {
 
 	function boot() {
 		parseSources();
+		function postHeight() {
+			post({ type: "height", height: document.body ? document.body.scrollHeight : 0 });
+		}
 		if (typeof ResizeObserver !== "undefined" && document.body) {
-			new ResizeObserver(function () {
-				post({ type: "height", height: document.body.scrollHeight });
-			}).observe(document.body);
+			new ResizeObserver(postHeight).observe(document.body);
 		}
 		post({ type: "ready" });
+		// Height sync must not depend on the ResizeObserver alone: for a heavy srcdoc
+		// (the ~1MB inlined echarts chunk) it intermittently never fires even once,
+		// and the charts settle at an unpredictable time - later on a COLD load,
+		// where echarts is still downloading/parsing past any fixed timeout. Poll the
+		// body height and report every change until it holds steady, so the parent
+		// grows the frame to the real content height regardless of render timing.
+		if (typeof requestAnimationFrame === "function") requestAnimationFrame(postHeight);
+		var lastH = -1;
+		var stableMs = 0;
+		var elapsedMs = 0;
+		var iv = setInterval(function () {
+			var h = document.body ? document.body.scrollHeight : 0;
+			if (h !== lastH) {
+				lastH = h;
+				stableMs = 0;
+				postHeight();
+			} else {
+				stableMs += 200;
+			}
+			elapsedMs += 200;
+			// Stop once the height has held steady (content settled) or after a hard cap.
+			if ((h > 0 && stableMs >= 1200) || elapsedMs >= 20000) clearInterval(iv);
+		}, 200);
 	}
 	if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
 	else boot();

--- a/frontend/src/pages/dashboards/DashboardCanvas.spec.js
+++ b/frontend/src/pages/dashboards/DashboardCanvas.spec.js
@@ -118,6 +118,44 @@ describe("DashboardCanvas rebuild ordering", () => {
 	});
 });
 
+describe("DashboardCanvas single-navigation frame", () => {
+	it("never renders an empty iframe before the document is built", async () => {
+		// Hold rebuild's echarts await open so `doc` stays "" for a beat.
+		echartsGate.setManual();
+		const wrapper = mount(DashboardCanvas, {
+			props: { mode: "view", html: "A echarts", dashboard: { name: "d1" } },
+		});
+		await flushPromises();
+		// A frame mounted now (empty srcdoc) would be a FIRST navigation that the
+		// real document later replaces - and on a cold load that second navigation
+		// is intermittently dropped, stranding the frame on the blank page. So the
+		// frame must not exist until its real document does.
+		expect(wrapper.find("iframe").exists()).toBe(false);
+
+		// Once assembled, the frame appears already carrying the real srcdoc.
+		echartsGate.state.queue[0]("");
+		await flushPromises();
+		const iframe = wrapper.find("iframe");
+		expect(iframe.exists()).toBe(true);
+		expect(iframe.attributes("srcdoc")).toBe("DOC:A echarts");
+	});
+
+	it("grows the view frame to a reported height", async () => {
+		const wrapper = mount(DashboardCanvas, {
+			attachTo: document.body,
+			props: { mode: "view", html: "static only", dashboard: { name: "d1" } },
+		});
+		await flushPromises();
+		// Starts at the 480px floor; the frame is blank until a height frame lands.
+		expect(wrapper.find("iframe").attributes("style")).toContain("height: 480px");
+
+		sendFrameMessage(wrapper, { type: "height", height: 1200 });
+		await flushPromises();
+		expect(wrapper.find("iframe").attributes("style")).toContain("height: 1200px");
+		wrapper.unmount();
+	});
+});
+
 describe("DashboardCanvas data-phase spinner", () => {
 	it("keeps the spinner until a live dashboard's first data batch resolves", async () => {
 		// attachTo: the iframe only gets a real contentWindow (which onMessage

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -37,7 +37,13 @@
 			<!-- sandbox: allow-scripts ONLY (no allow-same-origin, no allow-popups) -
 			     paired with the srcdoc CSP (no network, inline-only) the dashboard
 			     runs fully isolated; all data arrives over postMessage. -->
+			<!-- v-if="doc": render only once the real document exists, so the frame
+			     never mounts on an empty srcdoc it would have to navigate away from
+			     (that empty-first-navigation is intermittently dropped on a cold load,
+			     stranding the frame blank). Paired with :key="frameKey", each element
+			     boots exactly one document in its lifetime. -->
 			<iframe
+				v-if="doc"
 				ref="frame"
 				:key="frameKey"
 				:srcdoc="doc"
@@ -51,7 +57,7 @@
 				v-if="loading"
 				class="absolute inset-0 flex items-center justify-center bg-surface-white/60"
 			>
-				<JvSpinner />
+				<JvSpinner :size="48" />
 			</div>
 		</template>
 	</div>
@@ -67,7 +73,7 @@
 // echarts source only loads (dynamic ?raw import, its own chunk) when the
 // html actually references echarts. The named dashboard theme (--jd-* vars)
 // owns the canvas look; switching it rebuilds the document.
-import { ref, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, watch, onBeforeUnmount } from "vue";
 import { Button, ErrorMessage, FeatherIcon } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc";
@@ -314,7 +320,12 @@ function onMessage(e) {
 	}
 }
 
-onMounted(() => window.addEventListener("message", onMessage));
+// Attach synchronously, NOT in onMounted: when the echarts chunk is already
+// cached, rebuild() resolves its await in a microtask and assigns `doc` (booting
+// the iframe) before onMounted would run - so the iframe's one-shot `ready` could
+// fire before the listener existed, leaving the spinner stuck until the 8s valve.
+// Registering here, during setup, guarantees the listener is in place first.
+window.addEventListener("message", onMessage);
 onBeforeUnmount(() => {
 	window.removeEventListener("message", onMessage);
 	clearTimeout(readyTimer);

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -51,7 +51,7 @@
 
 		<!-- loading -->
 		<div v-if="loading" class="flex flex-1 items-center justify-center">
-			<JvSpinner />
+			<JvSpinner :size="48" />
 		</div>
 
 		<!-- §3.8 permission-blocked state -->


### PR DESCRIPTION
## Summary

Saved dashboards intermittently rendered a **blank canvas** or a spinner that never cleared — most often on a hard (cold) reload. Two root causes in the sandboxed-iframe render path, on top of the existing `frameKey` remount (#965):

1. **Height never synced.** The iframe reports its content height to the parent via a `ResizeObserver` that intermittently never fires for the heavy ~1 MB (inlined echarts) document, so the frame stayed pinned at its 480px floor — the content rendered but was clipped to blank. → Report height **proactively, polling until it settles** (`dashboardSrcdoc.js`).
2. **Empty-first-navigation.** Render the iframe only once `doc` exists (`v-if`), so it never mounts on an empty srcdoc it must navigate away from — that second navigation is intermittently **dropped** on a cold load, stranding the frame blank (no `ready`, no `height`). With the existing `:key="frameKey"`, each element boots exactly one document.

Also: attach the frame message listener **synchronously** (a cached-echarts fast boot could fire `ready` before an `onMounted` listener existed — stuck spinner), and **enlarge the loading spinner** in the full-page view and builder preview.

Adds two regression tests (iframe never rendered with an empty srcdoc; a view-mode height frame grows the iframe past its floor).

**Verified on the fix branch: 10/10 cold hard-reloads render** (before: blank ~1 in 3). Dashboard specs pass (6/6).

## Before / After

**Before** — saved dashboard stuck blank (content clipped to the 480px floor)
<img width="2000" height="1103" alt="dash-before" src="https://github.com/user-attachments/assets/9536cf29-23a0-4544-9925-4c5af7527ffa" />

**After** — renders reliably, iframe grown to content height
<img width="1512" height="785" alt="dash-after" src="https://github.com/user-attachments/assets/a5d40787-c259-4af5-9d22-b2dad7c6ae56" />

<details><summary>Root cause detail</summary>

The failing recorder trace showed `docAt` set (document assembled) but `readyAt: null` and zero height messages — the iframe never booted the real document at all (dropped second navigation). A separate failure mode showed `ready` firing but no `height` ever arriving (observer never fired). The two fixes close both.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check passes (never merge on ❌)
- [ ] Branch is **up to date with `main`**
- [x] New/changed behavior has tests
- [x] I self-reviewed the diff

https://claude.ai/code/session_01HF5N2yxJeW1jcFk342rm8Y