### PR TITLE
backport(dashboards): render saved dashboards reliably on cold loads (version-15)

### DIFF
--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -230,12 +230,36 @@ export const RUNTIME_JS = `(function () {
 
 	function boot() {
 		parseSources();
+		function postHeight() {
+			post({ type: "height", height: document.body ? document.body.scrollHeight : 0 });
+		}
 		if (typeof ResizeObserver !== "undefined" && document.body) {
-			new ResizeObserver(function () {
-				post({ type: "height", height: document.body.scrollHeight });
-			}).observe(document.body);
+			new ResizeObserver(postHeight).observe(document.body);
 		}
 		post({ type: "ready" });
+		// Height sync must not depend on the ResizeObserver alone: for a heavy srcdoc
+		// (the ~1MB inlined echarts chunk) it intermittently never fires even once,
+		// and the charts settle at an unpredictable time - later on a COLD load,
+		// where echarts is still downloading/parsing past any fixed timeout. Poll the
+		// body height and report every change until it holds steady, so the parent
+		// grows the frame to the real content height regardless of render timing.
+		if (typeof requestAnimationFrame === "function") requestAnimationFrame(postHeight);
+		var lastH = -1;
+		var stableMs = 0;
+		var elapsedMs = 0;
+		var iv = setInterval(function () {
+			var h = document.body ? document.body.scrollHeight : 0;
+			if (h !== lastH) {
+				lastH = h;
+				stableMs = 0;
+				postHeight();
+			} else {
+				stableMs += 200;
+			}
+			elapsedMs += 200;
+			// Stop once the height has held steady (content settled) or after a hard cap.
+			if ((h > 0 && stableMs >= 1200) || elapsedMs >= 20000) clearInterval(iv);
+		}, 200);
 	}
 	if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
 	else boot();

--- a/frontend/src/pages/dashboards/DashboardCanvas.spec.js
+++ b/frontend/src/pages/dashboards/DashboardCanvas.spec.js
@@ -118,6 +118,44 @@ describe("DashboardCanvas rebuild ordering", () => {
 	});
 });
 
+describe("DashboardCanvas single-navigation frame", () => {
+	it("never renders an empty iframe before the document is built", async () => {
+		// Hold rebuild's echarts await open so `doc` stays "" for a beat.
+		echartsGate.setManual();
+		const wrapper = mount(DashboardCanvas, {
+			props: { mode: "view", html: "A echarts", dashboard: { name: "d1" } },
+		});
+		await flushPromises();
+		// A frame mounted now (empty srcdoc) would be a FIRST navigation that the
+		// real document later replaces - and on a cold load that second navigation
+		// is intermittently dropped, stranding the frame on the blank page. So the
+		// frame must not exist until its real document does.
+		expect(wrapper.find("iframe").exists()).toBe(false);
+
+		// Once assembled, the frame appears already carrying the real srcdoc.
+		echartsGate.state.queue[0]("");
+		await flushPromises();
+		const iframe = wrapper.find("iframe");
+		expect(iframe.exists()).toBe(true);
+		expect(iframe.attributes("srcdoc")).toBe("DOC:A echarts");
+	});
+
+	it("grows the view frame to a reported height", async () => {
+		const wrapper = mount(DashboardCanvas, {
+			attachTo: document.body,
+			props: { mode: "view", html: "static only", dashboard: { name: "d1" } },
+		});
+		await flushPromises();
+		// Starts at the 480px floor; the frame is blank until a height frame lands.
+		expect(wrapper.find("iframe").attributes("style")).toContain("height: 480px");
+
+		sendFrameMessage(wrapper, { type: "height", height: 1200 });
+		await flushPromises();
+		expect(wrapper.find("iframe").attributes("style")).toContain("height: 1200px");
+		wrapper.unmount();
+	});
+});
+
 describe("DashboardCanvas data-phase spinner", () => {
 	it("keeps the spinner until a live dashboard's first data batch resolves", async () => {
 		// attachTo: the iframe only gets a real contentWindow (which onMessage

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -37,7 +37,13 @@
 			<!-- sandbox: allow-scripts ONLY (no allow-same-origin, no allow-popups) -
 			     paired with the srcdoc CSP (no network, inline-only) the dashboard
 			     runs fully isolated; all data arrives over postMessage. -->
+			<!-- v-if="doc": render only once the real document exists, so the frame
+			     never mounts on an empty srcdoc it would have to navigate away from
+			     (that empty-first-navigation is intermittently dropped on a cold load,
+			     stranding the frame blank). Paired with :key="frameKey", each element
+			     boots exactly one document in its lifetime. -->
 			<iframe
+				v-if="doc"
 				ref="frame"
 				:key="frameKey"
 				:srcdoc="doc"
@@ -51,7 +57,7 @@
 				v-if="loading"
 				class="absolute inset-0 flex items-center justify-center bg-surface-white/60"
 			>
-				<JvSpinner />
+				<JvSpinner :size="48" />
 			</div>
 		</template>
 	</div>
@@ -67,7 +73,7 @@
 // echarts source only loads (dynamic ?raw import, its own chunk) when the
 // html actually references echarts. The named dashboard theme (--jd-* vars)
 // owns the canvas look; switching it rebuilds the document.
-import { ref, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, watch, onBeforeUnmount } from "vue";
 import { Button, ErrorMessage, FeatherIcon } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc";
@@ -314,7 +320,12 @@ function onMessage(e) {
 	}
 }
 
-onMounted(() => window.addEventListener("message", onMessage));
+// Attach synchronously, NOT in onMounted: when the echarts chunk is already
+// cached, rebuild() resolves its await in a microtask and assigns `doc` (booting
+// the iframe) before onMounted would run - so the iframe's one-shot `ready` could
+// fire before the listener existed, leaving the spinner stuck until the 8s valve.
+// Registering here, during setup, guarantees the listener is in place first.
+window.addEventListener("message", onMessage);
 onBeforeUnmount(() => {
 	window.removeEventListener("message", onMessage);
 	clearTimeout(readyTimer);

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -51,7 +51,7 @@
 
 		<!-- loading -->
 		<div v-if="loading" class="flex flex-1 items-center justify-center">
-			<JvSpinner />
+			<JvSpinner :size="48" />
 		</div>
 
 		<!-- §3.8 permission-blocked state -->


### PR DESCRIPTION
Backport of #978 to `version-15`.

Clean cherry-pick — `version-15` carries the same dashboard code as develop (incl. the `#965` frameKey remount), so the patch applied without changes.

## Summary

Fixes the intermittent **blank saved-dashboard canvas** (and stuck spinner), mostly on cold/hard reloads:
- Report iframe height **proactively** (poll until settled) instead of relying only on a ResizeObserver that never fires for the heavy ~1 MB echarts document (`dashboardSrcdoc.js`).
- Render the iframe **only once the real document exists** (`v-if="doc"`, alongside `:key="frameKey"`), so its one navigation isn't a droppable second navigation.
- Attach the frame message listener synchronously (stuck-spinner race), and enlarge the loading spinner.
- Adds two regression tests.

Full detail + Before/After screenshots on #978. Verified there: 10/10 cold hard-reloads render.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check passes
- [x] Clean cherry-pick of #978, no logic change
- [x] I self-reviewed the diff

https://claude.ai/code/session_01HF5N2yxJeW1jcFk342rm8Y