### PR TITLE
chat: drop session_status from the role-profile standard allow-list

### DIFF
--- a/jarvis/chat/role_profiles.py
+++ b/jarvis/chat/role_profiles.py
@@ -5,8 +5,10 @@ Spec: ``docs/superpowers/specs/2026-08-16-role-profile-agents-design.md``.
 Two independent axes, both curated data (spec §5), never runtime discovery:
 
 * **Tool tier**: the jarvis-plane role decides ``full`` (today's 94 tools)
-  vs ``standard`` (68 tools; ``STANDARD_DROP_TOOLS`` is the 26-tool drop
-  list, spec §3).
+  vs ``standard`` (67 tools; ``STANDARD_DROP_TOOLS`` is the 27-tool drop
+  list). Spec §3 sized these 68/26; ``session_status`` was later pulled to the
+  drop list (denied fleet-wide for the white-label leak, not a tier call), so
+  the split is 67/27 with the 94-tool universe unchanged.
 * **Skill set**: ERPNext roles decide which of the 6 named skill sets
   (``SKILL_SETS``), plus the always-on ``SHARED_CORE_SKILLS``, a user's
   profile includes.
@@ -34,7 +36,8 @@ _SETTINGS = "Jarvis Settings"
 
 FULL_TIER_ROLES: frozenset[str] = frozenset({"Jarvis Admin", "System Manager"})
 
-# Verified drop list (26 tools, spec §3): app-learning tools (system-initiated
+# Verified drop list (27 tools; 26 per spec §3, plus session_status pulled here
+# for the fleet-wide white-label deny): app-learning tools (system-initiated
 # learning runs only, which always run `full`), session/infra tools (zero
 # references in live-tenant transcripts), file-editing tools (skills only
 # need `exec` + `read`), cron/browser (Frappe-side scheduling covers cron;
@@ -55,6 +58,7 @@ STANDARD_DROP_TOOLS: frozenset[str] = frozenset(
 		"sessions_list",
 		"sessions_history",
 		"sessions_yield",
+		"session_status",  # denied globally (white-label leak); not for the standard tier
 		"subagents",
 		"nodes",
 		"gateway",
@@ -143,13 +147,13 @@ _STANDARD_TOOLS_ALLOW = [
 	"message",
 	"pdf",
 	"read",
-	"session_status",
 	"update_goal",
 ]
 
 
 def standard_tools_allow() -> list[str]:
-	"""The 68-tool allow list for the ``standard`` tier (spec §3)."""
+	"""The 67-tool allow list for the ``standard`` tier (spec §3 sized 68;
+	session_status pulled to the drop list for the fleet-wide white-label deny)."""
 	return list(_STANDARD_TOOLS_ALLOW)
 
 

--- a/jarvis/tests/test_role_profiles.py
+++ b/jarvis/tests/test_role_profiles.py
@@ -73,7 +73,7 @@ class TestRoleProfiles(FrappeTestCase):
 
 	def test_standard_tools_allow_excludes_drops_keeps_features(self):
 		allow = set(role_profiles.standard_tools_allow())
-		self.assertEqual(len(allow), 68)
+		self.assertEqual(len(allow), 67)
 		for kept in (
 			"exec",
 			"read",
@@ -93,18 +93,19 @@ class TestRoleProfiles(FrappeTestCase):
 			"browser",
 			"web_search",
 			"sessions_spawn",
+			"session_status",
 			"jarvis__record_agent_run",
 			"skill_workshop",
 		):
 			self.assertNotIn(dropped, allow)
 
 	def test_tool_universe_is_94(self):
-		# standard_tools_allow() (68) + STANDARD_DROP_TOOLS (26) must
+		# standard_tools_allow() (67) + STANDARD_DROP_TOOLS (27) must
 		# reconstruct the full evidence-captured 94-tool universe with no
 		# overlap and no gap (spec §2).
 		allow = set(role_profiles.standard_tools_allow())
 		drop = set(role_profiles.STANDARD_DROP_TOOLS)
-		self.assertEqual(len(drop), 26)
+		self.assertEqual(len(drop), 27)
 		self.assertEqual(allow & drop, set())
 		self.assertEqual(len(allow | drop), 94)
 
@@ -869,7 +870,7 @@ class TestSessionProfilePick(FrappeTestCase):
 		row = frappe.get_doc(SESSION, {"session_key": key})
 		self.assertEqual(row.profile_agent_id, "role-hr")
 		self.assertEqual(row.profile_tier, "standard")
-		self.assertEqual(row.profile_n_tools, 68)
+		self.assertEqual(row.profile_n_tools, 67)
 
 	def test_flag_off_uses_legacy_create_session_path(self):
 		settings = self._fake_settings(enable_role_profiles=False)


### PR DESCRIPTION
Coordinates with the fleet-agent change that denies session_status fleet-wide at tools.deny (white-label leak). session_status moves from _STANDARD_TOOLS_ALLOW to STANDARD_DROP_TOOLS: the 94-tool universe is unchanged (allow 68->67, drop 26->27), and the standard tier no longer advertises a tool that is globally denied.

Pure hygiene, no functional change: role-profile agents are delegates, which openclaw already denies session_status for by default, and the top-level tools.deny covers all agents regardless. Source-comment counts + the 3 test counts updated to 67/27; the divergence from spec §3 (68/26) is a global deny, not a tier decision.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
