### PR TITLE
fix(support): derive support access from base Jarvis roles (backport #990 → version-16)

### DIFF
--- a/jarvis/install.py
+++ b/jarvis/install.py
@@ -10,10 +10,9 @@ DocType sync auto-creates any role named in a permission row
 absent on such a site before this hook existed:
 
   * "Knowledge Wiki Manager"  (wiki curator rights, wiki_permissions.py)
-  * "Jarvis Support User" / "Jarvis Support Admin"  (support panel scope)
 
-Observed live on a freshly reinstalled tenant: all three synced roles present,
-all three of the above missing.
+Observed live on a freshly reinstalled tenant: the synced roles present, the
+one above missing.
 
 The Agents Marketplace catalog (``Jarvis Agent Listing``) has the same shape:
 it is synced from the bundled registry ONLY by the ``after_migrate`` hook, so a
@@ -31,16 +30,11 @@ import frappe
 
 from jarvis.chat.wiki_permissions import WIKI_MANAGER_ROLE
 from jarvis.learning.roles import after_migrate as seed_roles_and_settings
-from jarvis.permissions import JARVIS_SUPPORT_ADMIN_ROLE, JARVIS_SUPPORT_USER_ROLE
 
 # The roles no DocType names, i.e. the ones that exist ONLY because this hook
 # (or a later migrate) seeded them. Verified below because the seeder cannot
 # report its own failure -- see after_install.
-_INSTALL_ONLY_ROLES = (
-	WIKI_MANAGER_ROLE,
-	JARVIS_SUPPORT_USER_ROLE,
-	JARVIS_SUPPORT_ADMIN_ROLE,
-)
+_INSTALL_ONLY_ROLES = (WIKI_MANAGER_ROLE,)
 
 
 def after_install() -> None:
@@ -56,8 +50,7 @@ def after_install() -> None:
 	# when a user hits a permission wall.
 	#
 	# So verify, and fail the install loudly instead. A provisioning run that
-	# fails and gets retried beats a tenant that is silently missing its wiki
-	# and support roles.
+	# fails and gets retried beats a tenant that is silently missing its wiki role.
 	missing = [r for r in _INSTALL_ONLY_ROLES if not frappe.db.exists("Role", r)]
 	if missing:
 		frappe.throw(

--- a/jarvis/learning/roles.py
+++ b/jarvis/learning/roles.py
@@ -26,11 +26,9 @@ from frappe.utils import cint
 
 from jarvis.permissions import (
 	JARVIS_ADMIN_ROLE,
-	JARVIS_SUPPORT_USER_ROLE,
 	JARVIS_USER_ROLE,
 	ensure_jarvis_admin_role,
 	ensure_jarvis_user_role,
-	ensure_support_roles,
 )
 
 # _v2: the cached value is now {"roles": [...], "derived": bool}, not a bare
@@ -242,11 +240,6 @@ def after_migrate() -> None:
 		# definition in jarvis/permissions.py. Idempotent.
 		if not frappe.db.exists("Role", JARVIS_ADMIN_ROLE):
 			ensure_jarvis_admin_role()
-			created = True
-		# Support panel roles (single-source in jarvis/permissions.py). The default grant to
-		# chat users happens lazily at boot (www/jarvis.py) so we never mass-iterate users here.
-		if not frappe.db.exists("Role", JARVIS_SUPPORT_USER_ROLE):
-			ensure_support_roles()
 			created = True
 		if created:
 			frappe.db.commit()

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -51,3 +51,4 @@ jarvis.patches.v2_13_unique_agent_installation
 jarvis.patches.v2_14_reconcile_token_limit_to_alltime
 jarvis.patches.v2_14_backfill_wiki_enabled
 jarvis.patches.v2_15_reset_removed_gemini_subscription
+jarvis.patches.v2_16_retire_support_roles

--- a/jarvis/patches/v2_16_retire_support_roles.py
+++ b/jarvis/patches/v2_16_retire_support_roles.py
@@ -1,0 +1,24 @@
+import frappe
+
+# The two roles retired in this change. Support access now rides the base Jarvis
+# roles (Jarvis User -> own scope, Jarvis Admin -> all scope), so these — and the
+# `Has Role` rows the old lazy boot-grant scattered across nearly every chat user —
+# are dead weight.
+_RETIRED_ROLES = ("Jarvis Support User", "Jarvis Support Admin")
+
+
+def execute():
+	"""Delete the standalone support panel roles and every assignment of them.
+
+	The old model gave each chat user `Jarvis Support User` lazily at boot, so a
+	live tenant carries one `Has Role` row per user plus the two `Role` docs.
+	Nothing reads these roles any more. Drop the assignments first (a `Role`
+	cannot be deleted while `Has Role` rows reference it), then the roles. Both
+	steps are exists-guarded, so a re-run is a no-op. `force=True` clears any
+	stray reference (e.g. a Role Profile) the assignment sweep did not.
+	"""
+	for role in _RETIRED_ROLES:
+		if not frappe.db.exists("Role", role):
+			continue
+		frappe.db.delete("Has Role", {"role": role})
+		frappe.delete_doc("Role", role, ignore_permissions=True, force=True)

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -44,13 +44,6 @@ JARVIS_ACCESS_ROLES = ("System Manager", JARVIS_USER_ROLE, JARVIS_ADMIN_ROLE)
 # implicitly allowed by has_jarvis_admin_access).
 JARVIS_ADMIN_ROLES = ("System Manager", JARVIS_ADMIN_ROLE)
 
-# Support panel roles. Support User sees only tickets they raised (scope=own); Support Admin
-# (and System Manager) see the whole tenant's queue (scope=all). Enforced in code here + at
-# the control-plane proxy; no DocPerm rows.
-JARVIS_SUPPORT_USER_ROLE = "Jarvis Support User"
-JARVIS_SUPPORT_ADMIN_ROLE = "Jarvis Support Admin"
-_SUPPORT_ALL_ROLES = ("System Manager", JARVIS_SUPPORT_ADMIN_ROLE)
-
 # Reviewer set authorized for org-wide skill / pattern / wiki effects (security
 # review PART 2, TASK 15 — RATIFIED). Housed in this lightweight module (no heavy
 # imports) so the Jarvis Custom Skill controller / skill_permissions can import it
@@ -276,51 +269,24 @@ def grant_onboarding_admin(user: str | None = None) -> None:
 		frappe.clear_cache(user=user)
 
 
-def ensure_support_roles() -> None:
-	"""Idempotently create the two support panel roles (desk-access)."""
-	for role_name in (JARVIS_SUPPORT_USER_ROLE, JARVIS_SUPPORT_ADMIN_ROLE):
-		if not frappe.db.exists("Role", role_name):
-			frappe.get_doc(
-				{"doctype": "Role", "role_name": role_name, "desk_access": 1, "is_custom": 1}
-			).insert(ignore_permissions=True)
-
-
 def support_scope(user: str | None = None) -> str | None:
-	"""``"all"`` for System Manager / Support Admin, ``"own"`` for Support User, else ``None``
-	(no support access). The bench forwards this to the control plane as a filter."""
+	"""Support access rides the base Jarvis roles — no dedicated support role:
+
+	* ``"all"`` for a Jarvis Admin (also System Manager / Administrator): the whole
+	  organisation's ticket queue.
+	* ``"own"`` for any Jarvis chat user: only the tickets they raised.
+	* ``None`` for anyone without Jarvis access (Guest, portal users).
+
+	The bench forwards this to the control plane as a filter. Admin is checked first
+	so an admin gets ``all``, never ``own``."""
 	user = user or frappe.session.user
-	roles = set(frappe.get_roles(user))
-	if user == "Administrator" or (set(_SUPPORT_ALL_ROLES) & roles):
+	if user == "Guest":
+		return None
+	if has_jarvis_admin_access(user):
 		return "all"
-	if JARVIS_SUPPORT_USER_ROLE in roles:
+	if has_jarvis_access(user):
 		return "own"
 	return None
-
-
-def grant_default_support(user: str | None = None) -> None:
-	"""Grant ``Jarvis Support User`` to a chat user so support isn't dark by default (P2).
-	Idempotent; never Administrator/Guest; only if they hold no support role already."""
-	ensure_support_roles()
-	user = user or frappe.session.user
-	if not user or user in ("Administrator", "Guest"):
-		return
-	if support_scope(user) is not None:
-		return
-	if not frappe.db.exists(
-		"Has Role", {"parenttype": "User", "parent": user, "role": JARVIS_SUPPORT_USER_ROLE}
-	):
-		frappe.get_doc(
-			{
-				"doctype": "Has Role",
-				"parenttype": "User",
-				"parentfield": "roles",
-				"parent": user,
-				"role": JARVIS_SUPPORT_USER_ROLE,
-			}
-		).insert(ignore_permissions=True)
-		# Invalidate the role cache so support_scope() sees the grant in the SAME request
-		# (the lazy grant-at-boot then computes has_support_access right after).
-		frappe.clear_cache(user=user)
 
 
 def require_jarvis_user(fn):

--- a/jarvis/tests/test_personalise_doctypes.py
+++ b/jarvis/tests/test_personalise_doctypes.py
@@ -158,12 +158,7 @@ class TestPersonaliseRoleSeeding(PersonaliseDoctypeTestCase):
 		Nothing in Frappe enforces that agreement, so this test is the guard: if
 		a future Frappe changes what sync stamps, or someone flips a helper back
 		to 1, the mismatch surfaces here instead of silently misdescribing every
-		live site.
-
-		Deliberately EXCLUDES the two support roles: no DocType names them, so
-		ensure_support_roles genuinely creates them and its is_custom=1 does take
-		effect. That asymmetry is real, and is spelled out here so it does not
-		get "fixed" by accident."""
+		live site."""
 		learning_roles.after_migrate()
 		for role in (
 			"Jarvis User",

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -5,11 +5,8 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis import admin_client
 from jarvis.permissions import (
-	JARVIS_SUPPORT_ADMIN_ROLE,
-	JARVIS_SUPPORT_USER_ROLE,
+	JARVIS_ADMIN_ROLE,
 	JARVIS_USER_ROLE,
-	ensure_support_roles,
-	grant_default_support,
 	support_scope,
 )
 
@@ -20,6 +17,7 @@ def _user(roles):
 			"doctype": "User",
 			"email": f"{frappe.generate_hash(length=8)}@sup.test",
 			"first_name": "S",
+			"user_type": "System User",
 			"send_welcome_email": 0,
 		}
 	)
@@ -29,28 +27,30 @@ def _user(roles):
 
 
 class TestSupportScope(FrappeTestCase):
-	def setUp(self):
-		ensure_support_roles()
+	"""Support access rides the base Jarvis roles: any chat user (Jarvis User) gets
+	own-scope, any admin (Jarvis Admin / System Manager / Administrator) gets all-scope."""
 
-	def test_none_without_role(self):
+	def test_none_without_any_jarvis_role(self):
 		self.assertIsNone(support_scope(_user([])))
 
-	def test_own_for_support_user(self):
-		self.assertEqual(support_scope(_user([JARVIS_SUPPORT_USER_ROLE])), "own")
+	def test_own_for_jarvis_user(self):
+		self.assertEqual(support_scope(_user([JARVIS_USER_ROLE])), "own")
 
-	def test_all_for_support_admin(self):
-		self.assertEqual(support_scope(_user([JARVIS_SUPPORT_ADMIN_ROLE])), "all")
+	def test_all_for_jarvis_admin(self):
+		self.assertEqual(support_scope(_user([JARVIS_ADMIN_ROLE])), "all")
 
-	def test_default_grant_gives_own_to_jarvis_user(self):
-		u = _user([JARVIS_USER_ROLE])
-		self.assertIsNone(support_scope(u))
-		grant_default_support(u)
-		self.assertEqual(support_scope(u), "own")
+	def test_all_for_system_manager(self):
+		self.assertEqual(support_scope(_user(["System Manager"])), "all")
 
-	def test_default_grant_skips_administrator_and_guest(self):
-		for u in ("Administrator", "Guest"):
-			grant_default_support(u)
-			self.assertFalse(frappe.db.exists("Has Role", {"parent": u, "role": JARVIS_SUPPORT_USER_ROLE}))
+	def test_all_for_administrator(self):
+		self.assertEqual(support_scope("Administrator"), "all")
+
+	def test_none_for_guest(self):
+		self.assertIsNone(support_scope("Guest"))
+
+	def test_admin_beats_user_when_holding_both(self):
+		# a user with both roles is an admin → all, never own
+		self.assertEqual(support_scope(_user([JARVIS_USER_ROLE, JARVIS_ADMIN_ROLE])), "all")
 
 
 class TestAdminClientSupport(FrappeTestCase):

--- a/jarvis/tests/test_www_release_notice.py
+++ b/jarvis/tests/test_www_release_notice.py
@@ -35,7 +35,6 @@ class TestWwwReleaseNotice(FrappeTestCase):
 		with (
 			patch.object(www_desktop, "has_jarvis_access", return_value=True),
 			patch.object(www_desktop, "has_jarvis_admin_access", return_value=False),
-			patch.object(www_desktop, "grant_default_support", lambda: None),
 			patch.object(www_desktop, "support_scope", return_value=None),
 			# _support_state, not _support_available: get_context calls the former now, so
 			# patching the old name left this test making a REAL admin_client round-trip.

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -2,7 +2,6 @@ import frappe
 
 from jarvis import release_notice
 from jarvis.permissions import (
-	grant_default_support,
 	has_jarvis_access,
 	has_jarvis_admin_access,
 	support_scope,
@@ -123,10 +122,9 @@ def get_context(context):
 	# when this bench is behind the latest jarvis version. Up-to-date => no gate.
 	context.boot["release_notice"] = release_notice.boot_payload()
 
-	# Support panel gating (Plan 3 B5). Lazy-grant the default support role to this chat user so
-	# support isn't dark (P2 — grant_default_support clears the role cache so support_scope sees
-	# it in this same request), then expose both the per-user access flag and the fleet kill switch.
-	grant_default_support()
+	# Support panel gating (Plan 3 B5). Support access rides the base Jarvis roles
+	# (support_scope: Jarvis User => own, Jarvis Admin => all), so there's nothing to grant —
+	# just expose the per-user access flag and the fleet kill switch.
 	context.boot["has_support_access"] = support_scope() is not None
 	# Both flags, deliberately: `support_available` keeps its exact boolean meaning for
 	# every existing reader, and `support_state` lets the SPA tell an actionable


### PR DESCRIPTION
## Backport of #990

Clean cherry-pick of `ae05316e` (PR #990 → `develop`) onto this release branch. The change collapses support-ticket access onto the base Jarvis roles and retires the two dedicated support roles + the boot auto-grant.

- **Create (own):** any chat user (`Jarvis User`) files their own tickets.
- **See-all (org queue):** `Jarvis Admin` / System Manager / Administrator.
- Migration `v2_16_retire_support_roles` deletes the two roles + their `Has Role` assignments (idempotent).

## Backport verification

- This release branch was **identical to `develop` on all 9 touched files** before the pick, so the cherry-pick applied with **zero conflicts** and the resulting files are **byte-for-byte identical** to the reviewed develop change.
- ruff clean. Behavioural correctness was established on `develop` (27/2/47 tests green + live migration run + independent adversarial review GREEN); the code here is the same bytes.
- `v2_16` is the next free patch number on this branch (it also ended at `v2_15`).

See #990 for the full rationale and review.
