### PR TITLE
fix(chat): self-heal agent-token drift on the readiness gate

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -558,9 +558,39 @@ def _admin_chat_gate() -> dict:
 			incoming_url = (conn.get("agent_url") or "").strip()
 			incoming_token = conn.get("agent_token") or ""
 			if incoming_url != current_url or (incoming_token and incoming_token != current_token):
-				from jarvis.onboarding import write_connection
+				from jarvis import tenant_authority
 
-				write_connection(conn)
+				# Pre-check the PURE guard decision (no I/O, no state advance)
+				# before writing. write_connection ends in an unconditional
+				# _bust_chat_gate, a Redis KEYS scan its own docstring says must
+				# never run on a hot per-request path. A REJECT (stale
+				# generation) or HOLD (equal generation, different handle)
+				# means write_connection would refuse the write anyway, and the
+				# diff above would never resolve, so every later uncached gate
+				# call for this tenant would re-run the bust forever. Only call
+				# it when the payload would actually land.
+				try:
+					outcome = tenant_authority.decide(
+						settings.get(tenant_authority.GEN_FIELD),
+						settings.get(tenant_authority.HANDLE_FIELD) or None,
+						conn.get(tenant_authority.GEN_FIELD),
+						conn.get(tenant_authority.HANDLE_FIELD) or None,
+					)
+				except tenant_authority.AuthorityInvariantError:
+					outcome = None  # HOLD: never write
+				if outcome in (tenant_authority.ACCEPT, tenant_authority.COMPAT):
+					from jarvis.onboarding import write_connection
+
+					write_connection(conn)
+					# write_connection may have moved agent_url/agent_token or
+					# advanced the authority generation, all of which the
+					# cached verdict's identity and the ready-marker's anchor
+					# are keyed on. Reusing the pre-write raw/cache_key below
+					# would stamp the marker with the OLD authority (hard
+					# blocking a healthy, just-healed tenant on a later admin
+					# outage) and cache the verdict under a now-dead revision.
+					raw = _settings_raw(_GATE_STATE_FIELDS)
+					cache_key = f"{_CHAT_GATE_CACHE_KEY}:{_gate_revision(raw)}"
 	except Exception:
 		# A reconcile failure must never break the ready-gate.
 		frappe.log_error(title="chat gate: agent-token reconcile failed", message=frappe.get_traceback())

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -538,6 +538,32 @@ def _admin_chat_gate() -> dict:
 	# Refresh the locally-mirrored release notice on this gate's cadence so an
 	# active user sees an activate/clear without waiting for the daily sync.
 	release_notice.persist(conn.get("release_notice") or {})
+	# Fleet-side agent-token self-heal. A destroyed-and-reassigned tenant gets a
+	# fresh gateway token on its new container and admin's own record is
+	# updated, but nothing on the fleet side can push that to THIS bench -
+	# the only other path is the DAILY sync_connection cron, so an otherwise
+	# active customer could sit on a stale token (401s on jarvis.api.call_tool)
+	# for up to 24h. This gate already holds a fresh connection payload on
+	# every uncached call, so reconcile agent_url/agent_token from it here too,
+	# on the gate's own cadence. Diff-gated: steady state (every other call)
+	# writes nothing, so this never busts the chat-gate cache or churns the
+	# encrypted agent_token field for no reason. write_connection() runs the
+	# tenant-authority guard() itself, so a stale or divergent payload cannot
+	# regress an already-accepted container - never write agent_token directly.
+	try:
+		if conn.get("agent_url"):
+			settings = frappe.get_single(SETTINGS)
+			current_url = (settings.get("agent_url") or "").strip()
+			current_token = settings.get_password("agent_token", raise_exception=False) or ""
+			incoming_url = (conn.get("agent_url") or "").strip()
+			incoming_token = conn.get("agent_token") or ""
+			if incoming_url != current_url or (incoming_token and incoming_token != current_token):
+				from jarvis.onboarding import write_connection
+
+				write_connection(conn)
+	except Exception:
+		# A reconcile failure must never break the ready-gate.
+		frappe.log_error(title="chat gate: agent-token reconcile failed", message=frappe.get_traceback())
 	notice = conn.get("billing_notice") or {}
 	if "chat_readiness" in conn and conn["chat_readiness"] != "Ready":
 		# Authority-repair incident (review plan 04 P0-6): admin's strict resolver

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -225,8 +225,15 @@ class TestAdminChatGate(FrappeTestCase):
 		self._marker_snap = account._settings_raw(("chat_was_ready_at",)).get("chat_was_ready_at")
 		self._key_snap = _set_stored_connection(True)
 		_set_ready_marker("2026-01-01 00:00:00")
+		# Several tests here mock get_connection with a bare agent_url (no
+		# authority fields), which is not this class's concern - the
+		# agent-token reconcile added on this same gate would otherwise run
+		# write_connection for real and overwrite this site's actual agent_url.
+		self._wc = patch("jarvis.onboarding.write_connection")
+		self._wc.start()
 
 	def tearDown(self):
+		self._wc.stop()
 		account._bust_chat_gate()
 		_set_ready_marker(self._marker_snap)
 		frappe.db.set_value(
@@ -1306,8 +1313,16 @@ class TestExplicitReadyOnlyMarker(FrappeTestCase):
 			account._READY_MARKER_FIELD
 		)
 		_set_ready_marker(None)
+		# test_missing_chat_readiness_allows_but_does_not_mint_the_marker mocks
+		# get_connection with a bare agent_url (no authority fields) - not this
+		# class's concern, and the agent-token reconcile on this same gate
+		# would otherwise run write_connection for real and overwrite this
+		# site's actual agent_url.
+		self._wc = patch("jarvis.onboarding.write_connection")
+		self._wc.start()
 
 	def tearDown(self):
+		self._wc.stop()
 		account._bust_chat_gate()
 		_set_ready_marker(self._marker_snap)
 		frappe.db.set_value(

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -269,6 +269,8 @@ _RECONCILE_FIELDS = (
 	"agent_token",
 	"tenant_authority_generation",
 	"tenant_authority_handle",
+	"chat_was_ready_at",
+	"chat_ready_authority",
 )
 
 
@@ -377,3 +379,87 @@ class TestChatGateReconcilesAgentTokenDrift(FrappeTestCase):
 			out = account._admin_chat_gate()
 		self.assertTrue(out["ready"])
 		self.assertIsNone(out["reason"])
+
+	def test_heal_stamps_new_authority_anchor_not_stale(self):
+		"""The reconcile writes a NEW authority generation, so the ready-marker
+		it mints afterwards (chat_readiness: Ready in the same payload) must be
+		bound to the POST-write authority, not the one captured before the
+		write. A marker stamped against the stale (pre-write) authority would
+		mismatch the real current authority the moment it is recomputed - and
+		that mismatch hard-blocks a healthy, just-healed tenant the very next
+		time admin cannot be reached, exactly the outage this marker exists to
+		survive."""
+		# _has_been_chat_ready also requires a present admin key (the OTHER
+		# half of "established" - see test_account.py's _set_stored_connection);
+		# a bare presence mask is enough, no real __Auth secret needed, since
+		# this test's principal term is empty either way and only the
+		# generation term is what's under test.
+		key_field = "jarvis_admin_api_key"
+		prior_key = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", key_field)
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", key_field, "*" * 10, update_modified=False)
+		self.addCleanup(
+			lambda: frappe.db.set_value(
+				"Jarvis Settings", "Jarvis Settings", key_field, prior_key, update_modified=False
+			)
+		)
+		payload = {
+			"agent_url": "wss://old-container.example/ws",
+			"agent_token": "new-token",
+			"tenant_authority_generation": 2,
+			"tenant_authority_handle": "handle-new",
+			"chat_readiness": "Ready",
+		}
+		with patch.object(account.admin_client, "get_connection", return_value=payload):
+			out = account._admin_chat_gate()
+		self.assertTrue(out["ready"])
+
+		# Force the SECOND call to read purely off DB state instead of
+		# reusing whatever this call just cached - the same thing a real
+		# uncached load after an outage would do.
+		account._bust_chat_gate()
+		with patch.object(account.admin_client, "get_connection", side_effect=Exception("admin down")):
+			second = account._admin_chat_gate()
+		self.assertTrue(
+			second["ready"],
+			"a tenant just healed by this reconcile must ride the established "
+			"marker through an outage, not hard-block on a stale authority anchor",
+		)
+
+	def test_reject_or_hold_payload_does_not_call_write_connection(self):
+		"""A payload whose authority the guard would REJECT (a stale
+		generation) or HOLD (equal generation, a divergent handle) must never
+		reach write_connection. write_connection ends in an unconditional
+		_bust_chat_gate - a Redis KEYS scan its own docstring says must never
+		run on a hot per-request path - and since the diff never resolves for
+		either outcome, calling it anyway would re-run that scan on EVERY
+		later uncached gate call for this tenant, indefinitely."""
+		# REJECT: incoming generation (0) lower than stored (1).
+		reject_payload = {
+			"agent_url": "wss://old-container.example/ws",
+			"agent_token": "new-token",
+			"tenant_authority_generation": 0,
+			"tenant_authority_handle": "handle-old",
+			"tenant_status": "running",
+		}
+		with (
+			patch.object(account.admin_client, "get_connection", return_value=reject_payload),
+			patch("jarvis.onboarding.write_connection") as wc,
+		):
+			account._admin_chat_gate()
+		wc.assert_not_called()
+
+		# HOLD: same generation (1) as stored, but a DIFFERENT serving handle.
+		account._bust_chat_gate()
+		hold_payload = {
+			"agent_url": "wss://old-container.example/ws",
+			"agent_token": "new-token",
+			"tenant_authority_generation": 1,
+			"tenant_authority_handle": "handle-divergent",
+			"tenant_status": "running",
+		}
+		with (
+			patch.object(account.admin_client, "get_connection", return_value=hold_payload),
+			patch("jarvis.onboarding.write_connection") as wc,
+		):
+			account._admin_chat_gate()
+		wc.assert_not_called()

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 import jarvis.account as account
@@ -251,3 +252,128 @@ class TestLlmConfiguredGate(FrappeTestCase):
 			ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
+
+
+# --- agent-token drift self-heal (fix/agent-token-selfheal-on-chat-gate) ---
+#
+# When a tenant is destroyed and reassigned, the new container mints a fresh
+# gateway token and admin's Jarvis Tenant.agent_token is updated, but
+# nothing pushes that to the customer bench - the bench only re-pulls
+# agent_url/agent_token via the DAILY sync_connection cron. _admin_chat_gate
+# already fetches the connection payload on every uncached readiness check, so
+# it reconciles agent_url/agent_token from that SAME payload, diff-gated so a
+# call that changed nothing writes nothing.
+
+_RECONCILE_FIELDS = (
+	"agent_url",
+	"agent_token",
+	"tenant_authority_generation",
+	"tenant_authority_handle",
+)
+
+
+def _snapshot_reconcile_fields() -> dict:
+	s = frappe.get_single("Jarvis Settings")
+	snap = {}
+	for f in _RECONCILE_FIELDS:
+		v = s.get_password(f, raise_exception=False) if f == "agent_token" else s.get(f)
+		snap[f] = v or ""
+	return snap
+
+
+def _restore_reconcile_fields(snap: dict) -> None:
+	from frappe.utils.password import remove_encrypted_password
+
+	# The production write path (write_connection -> set_settings_password)
+	# stores agent_token in __Auth with a masked column, so a column-only
+	# restore would leave a test's token readable via get_password's __Auth
+	# fallback in the NEXT test - same trap test_onboarding_sync.py documents.
+	remove_encrypted_password("Jarvis Settings", "Jarvis Settings", "agent_token")
+	s = frappe.get_single("Jarvis Settings")
+	for f, v in snap.items():
+		s.db_set(f, v, update_modified=False)
+	frappe.db.commit()
+
+
+class TestChatGateReconcilesAgentTokenDrift(FrappeTestCase):
+	"""jarvis.account._admin_chat_gate's opportunistic agent_url/agent_token
+	reconcile. admin_client.get_connection is mocked; the gate cache is busted
+	in setUp/tearDown (same as TestAdminChatGate in test_account.py) so a
+	cached verdict from an earlier test never short-circuits the admin call
+	this reconcile depends on. Jarvis Settings is a Single (never rolled back
+	between tests), so the fields this reconcile touches are snapshotted and
+	restored like test_onboarding_sync.py's _snapshot_settings/_restore_settings."""
+
+	def setUp(self):
+		account._bust_chat_gate()
+		self._snap = _snapshot_reconcile_fields()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("agent_url", "wss://old-container.example/ws", update_modified=False)
+		from jarvis._password_utils import set_settings_password
+
+		set_settings_password(s, "agent_token", "old-token")
+		# A stored generation lower than every drift-heal payload's, so guard()
+		# ACCEPTs (higher incoming generation) rather than HOLDing on an
+		# equal-generation identity check.
+		s.db_set("tenant_authority_generation", 1, update_modified=False)
+		s.db_set("tenant_authority_handle", "handle-old", update_modified=False)
+		frappe.db.commit()
+
+	def tearDown(self):
+		account._bust_chat_gate()
+		_restore_reconcile_fields(self._snap)
+
+	def test_chat_gate_reconciles_drifted_agent_token(self):
+		"""The drift-heal case: a fleet-side rotation changed the token (and
+		bumped the authority generation, as a real reassign does) but the
+		agent_url is unchanged. After one gate call the new token must be
+		live on Jarvis Settings - no more waiting for the daily cron."""
+		payload = {
+			"agent_url": "wss://old-container.example/ws",
+			"agent_token": "new-token",
+			"tenant_authority_generation": 2,
+			"tenant_authority_handle": "handle-new",
+			"tenant_status": "running",
+		}
+		with patch.object(account.admin_client, "get_connection", return_value=payload):
+			out = account._admin_chat_gate()
+		self.assertTrue(out["ready"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("agent_token", raise_exception=False), "new-token")
+
+	def test_no_drift_does_not_write(self):
+		"""Steady state: every field in the payload matches what's already
+		stored, so write_connection must never be called - the reconcile must
+		not bust the chat-gate cache or churn the encrypted agent_token field
+		on a call that changed nothing."""
+		payload = {
+			"agent_url": "wss://old-container.example/ws",
+			"agent_token": "old-token",
+			"tenant_authority_generation": 1,
+			"tenant_authority_handle": "handle-old",
+			"tenant_status": "running",
+		}
+		with (
+			patch.object(account.admin_client, "get_connection", return_value=payload),
+			patch("jarvis.onboarding.write_connection") as wc,
+		):
+			account._admin_chat_gate()
+		wc.assert_not_called()
+
+	def test_reconcile_failure_does_not_break_the_gate(self):
+		"""A reconcile failure must never break the ready-gate: the gate's
+		normal verdict still comes back even when write_connection raises."""
+		payload = {
+			"agent_url": "wss://old-container.example/ws",
+			"agent_token": "new-token",
+			"tenant_authority_generation": 2,
+			"tenant_authority_handle": "handle-new",
+			"tenant_status": "running",
+		}
+		with (
+			patch.object(account.admin_client, "get_connection", return_value=payload),
+			patch("jarvis.onboarding.write_connection", side_effect=RuntimeError("boom")),
+		):
+			out = account._admin_chat_gate()
+		self.assertTrue(out["ready"])
+		self.assertIsNone(out["reason"])


### PR DESCRIPTION
## Summary

Tool calls in chat now recover on their own after a tenant is reassigned, instead of failing with 401 for up to a day.

When a tenant is destroyed and reassigned, its new container gets a fresh gateway token and admin's record is updated, but nothing on the fleet side can push that token to the customer bench. The bench validates the container's token against `Jarvis Settings.agent_token`, so every `jarvis.api.call_tool` returned 401 until the daily `sync_connection` cron re-pulled the token. Chat looked fine; only tool calls broke.

This reconciles `agent_url`/`agent_token` from the connection payload the chat readiness gate already fetches on every uncached call. It is diff-gated (steady state writes nothing, so the gate cache and the encrypted token field are untouched) and routed through `write_connection`, so the existing tenant-authority guard still governs the write. A drifted customer now self-heals on their next readiness check, with no operator or customer action.

<details><summary>Root cause and why the gate</summary>

The bench only rewrote `agent_token` via the daily `sync_connection`; every frequent convergence path (`_admin_chat_gate`, the `*/5` llm-sync reconcile) fetched `get_connection` but discarded `agent_token`. Admin cannot push to the bench (polling only), so the reconcile has to ride an existing bench-initiated pull. The gate already does this for the release notice on the same cadence, so the token reconcile sits beside it. Reassignment bumps `tenant_authority_generation`, so `guard()` returns ACCEPT and the write lands.
</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `develop`**
- [x] New/changed behavior has tests (3 new cases in `test_chat_policy.py`: drift heals, no-drift no-write, reconcile failure never breaks the gate)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01X7AxG9txaafJjixTaSyCWb
