### PR TITLE
feat(chat): carry time-of-day + platform-app versions in the turn con…

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -506,6 +506,42 @@ def _org_locale_clause() -> str:
 	return ("; " + "; ".join(parts)) if parts else ""
 
 
+# The apps a "what version / what environment are you" question is actually
+# about - the Jarvis + ERPNext platform stack, in this order (jarvis FIRST: it is
+# the agent's own identity). DELIBERATELY curated, not every installed app: this
+# clause rides EVERY turn's context, so it stays bounded by construction (like the
+# capping the sibling clauses do) instead of growing with whatever community/custom
+# apps a tenant carries, and it skips apps nobody asks a version for (telephony,
+# webshop, ...). Only the ones actually installed on the site are named.
+_VERSION_APPS: tuple[str, ...] = ("jarvis", "frappe", "erpnext", "hrms", "india_compliance")
+
+
+def _app_versions_clause() -> str:
+	"""The platform-stack app versions, folded into the turn's ``[Context: ...]``
+	line so the agent answers "what version / what environment are you running in"
+	TRUTHFULLY - Jarvis is one app among the others in the customer's Frappe/ERPNext
+	bench - instead of guessing, or naming the runtime beneath it. Reads module
+	``__version__`` only (import-cached, cheap, no DB). Each app's read is isolated:
+	one app lacking ``__version__`` (``frappe.get_attr`` raises ``AttributeError``,
+	it has no default) skips only THAT app, not the whole clause; any wider failure
+	yields '' so a version lookup can never break a turn."""
+	try:
+		installed = set(frappe.get_installed_apps())
+	except Exception:
+		return ""
+	parts = []
+	for app in _VERSION_APPS:
+		if app not in installed:
+			continue
+		try:
+			ver = str(frappe.get_attr(f"{app}.__version__") or "").strip()
+		except Exception:
+			continue
+		if ver:
+			parts.append(f"{app} {ver}")
+	return f"; apps: {', '.join(parts)}" if parts else ""
+
+
 def _assistant_name_clause(settings) -> str:
 	"""Whitelabel assistant name folded into the turn's trusted [Context:] line
 	so the agent refers to itself by the customer's chosen name. "" when unset
@@ -682,7 +718,12 @@ def assemble_prompt(
 	# get_list on User. The persisted user_message in the DB is
 	# unchanged; only the value sent over to agent is augmented.
 	now = frappe.utils.now_datetime()
-	today = now.strftime("%Y-%m-%d (%A)")
+	# Time-of-day (HH:MM) rides the date because this bracket is the agent's
+	# PRIMARY clock - the built-in session_status tool (its only other time
+	# source) is denied for white-label reasons, so the bracket must carry the
+	# wall-clock too. Site-local (now_datetime), matching the tz the locale
+	# clause reports below.
+	today = now.strftime("%Y-%m-%d %H:%M (%A)")
 	# Fold the auto-apply preference into the system context line so the agent
 	# knows whether to confirm mutating ops. Default (off) = confirm; the persona
 	# confirms by default, so we only signal the non-default "auto" mode.
@@ -708,6 +749,10 @@ def assemble_prompt(
 	# Org locale (default Company country/currency + site date/number/tz) so the
 	# agent formats for the org's region instead of defaulting to US conventions.
 	locale_clause = _org_locale_clause()
+	# Installed-app versions (white-label): lets the agent answer "what version /
+	# what environment are you" with the real Frappe/app versions - Jarvis as one
+	# app among the others - instead of guessing or naming the runtime beneath it.
+	versions_clause = _app_versions_clause()
 	# Whitelabel assistant name (Phase 3): folded into the trusted [Context:] line
 	# so the agent refers to itself by the customer's chosen name. "" when unset.
 	assistant_name_clause = _assistant_name_clause(settings)
@@ -794,7 +839,7 @@ def assemble_prompt(
 		# (skill_clause) stays intentional and is not demoted. The
 		# customizations clause is org-level too, so it sits with the org
 		# clauses - before personal, which stays last.
-		f"[Context: today is {today}{locale_clause}{assistant_name_clause}{persona_clause}; chat user: {chat_user}"
+		f"[Context: today is {today}{locale_clause}{versions_clause}{assistant_name_clause}{persona_clause}; chat user: {chat_user}"
 		f"; conv: {conversation_id}{auto_apply}{skill_clause}{learned_clause}"
 		f"{wiki_notes_clause}{custom_site_clause}{personal_clause}{notes_clause}]"
 		f"{ground_block}"

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -292,6 +292,13 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 		message_sent = positional[1] if len(positional) >= 2 else kwargs.get("message")
 		self.assertIsNotNone(message_sent)
 		self.assertIn("[Context: today is ", message_sent)
+		# Wall-clock time-of-day (HH:MM) rides the date - the agent's PRIMARY clock
+		# now that the built-in session_status tool is denied. Assert the FORMAT.
+		self.assertRegex(message_sent, r"today is \d{4}-\d{2}-\d{2} \d{2}:\d{2} \(\w+\)")
+		# The curated platform-stack versions ride the bracket so the agent answers
+		# "what version / what environment are you" truthfully, jarvis first (its own
+		# identity). jarvis is installed here and carries __version__.
+		self.assertIn("apps: jarvis ", message_sent)
 		# Chat user (conv.owner) is in the same bracket so the agent can
 		# answer "who am I" / "what perms do I have" without round-tripping.
 		self.assertIn(f"chat user: {TEST_USER}", message_sent)

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -305,6 +305,65 @@ class TestOrgLocaleClause(unittest.TestCase):
 		self.assertEqual(self._run(company=None, default=None), "")
 
 
+class TestAppVersionsClause(unittest.TestCase):
+	"""_app_versions_clause names the CURATED platform-stack apps + versions
+	(jarvis first) in the context line so the agent answers "what version / what
+	environment are you" truthfully - Jarvis as one app among the others in the
+	customer's Frappe/ERPNext bench. Each app's read is isolated; a wider failure
+	degrades to ''."""
+
+	def _run(self, *, installed, versions):
+		# An app NOT in ``versions`` => ``frappe.get_attr`` RAISES AttributeError,
+		# exactly as the real accessor does for an app whose __init__ has no
+		# __version__ (getattr with no default). Mirroring that is what lets these
+		# tests actually exercise the per-app skip path.
+		def fake_get_attr(dotted):
+			app = dotted.split(".", 1)[0]
+			if app not in versions:
+				raise AttributeError(f"module '{app}' has no attribute '__version__'")
+			return versions[app]
+
+		with (
+			patch("frappe.get_installed_apps", return_value=installed),
+			patch("frappe.get_attr", side_effect=fake_get_attr),
+		):
+			return turn_handler._app_versions_clause()
+
+	def test_names_curated_stack_jarvis_first(self):
+		clause = self._run(
+			installed=["frappe", "erpnext", "jarvis", "hrms"],
+			versions={"jarvis": "1.4.0", "frappe": "15.1.0", "erpnext": "15.2.0", "hrms": "15.0.0"},
+		)
+		# Curated order (jarvis first), not install order; india_compliance absent.
+		self.assertEqual(clause, "; apps: jarvis 1.4.0, frappe 15.1.0, erpnext 15.2.0, hrms 15.0.0")
+
+	def test_only_curated_apps_are_named(self):
+		# telephony is installed + versioned but NOT in the platform stack -> omitted.
+		clause = self._run(
+			installed=["frappe", "jarvis", "telephony"],
+			versions={"jarvis": "1.4.0", "frappe": "15.1.0", "telephony": "0.0.1"},
+		)
+		self.assertEqual(clause, "; apps: jarvis 1.4.0, frappe 15.1.0")
+		self.assertNotIn("telephony", clause)
+
+	def test_uninstalled_curated_app_is_skipped(self):
+		clause = self._run(installed=["frappe", "jarvis"], versions={"jarvis": "1.4.0", "frappe": "15.1.0"})
+		self.assertEqual(clause, "; apps: jarvis 1.4.0, frappe 15.1.0")
+
+	def test_one_version_read_failure_skips_only_that_app(self):
+		# frappe is installed but has no resolvable __version__ (get_attr raises);
+		# jarvis still renders - the clause is NOT blanked. Per-app isolation guard.
+		clause = self._run(installed=["jarvis", "frappe"], versions={"jarvis": "1.4.0"})
+		self.assertEqual(clause, "; apps: jarvis 1.4.0")
+
+	def test_no_resolvable_versions_yields_empty_clause(self):
+		self.assertEqual(self._run(installed=["jarvis", "frappe"], versions={}), "")
+
+	def test_installed_apps_failure_yields_empty_clause(self):
+		with patch("frappe.get_installed_apps", side_effect=RuntimeError("boom")):
+			self.assertEqual(turn_handler._app_versions_clause(), "")
+
+
 class TestClassifyError(unittest.TestCase):
 	"""_classify_error is the single, shared source for a turn error's `code`
 	(#702) - settlement.py, pump.py and prepare.py all delegate to it, and


### PR DESCRIPTION
…text bracket

White-label remediation (slice 1). So the agent answers "what time is it" and "what version / what environment are you running in" TRUTHFULLY from its own context - Jarvis is one Frappe app among the others in the customer's ERPNext bench - instead of reaching for openclaw's session_status tool (denied in a later slice) or naming the runtime beneath it.

- The date bracket now carries HH:MM. It is the agent's PRIMARY clock once session_status is denied; site-local (now_datetime), matching the tz the locale clause already reports.
- New best-effort _app_versions_clause() names the CURATED platform stack (jarvis first, then frappe/erpnext/hrms/india_compliance when installed) with their __version__ - bounded by construction like the sibling clauses, not every installed app. Each app's read is isolated (frappe.get_attr raises with no default), so one version-less app skips only itself rather than blanking the whole clause; any wider failure yields "" so a version lookup can never break a turn.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
