### PR TITLE
fix(doc): consolidate local esc() helpers onto shared escapeHtml (#703) (backport #981 → version-16)

### DIFF
--- a/frontend/src/components/doc/DocMetaPanel.vue
+++ b/frontend/src/components/doc/DocMetaPanel.vue
@@ -232,7 +232,7 @@ import {
 } from "frappe-ui";
 import { listShareableUsers } from "@/api";
 import { timeAgo } from "@/utils/datetime";
-import { errHtml } from "@/lib/errors";
+import { errHtml, escapeHtml } from "@/lib/errors";
 
 const props = defineProps({
 	docmeta: { type: Object, required: true }, // useDocmeta() object
@@ -296,7 +296,7 @@ async function copyName() {
 function confirmDeleteAttachment(f) {
 	confirmDialog({
 		title: "Delete attachment?",
-		message: `Delete "${esc(f.file_name || f.file_url)}"? This can't be undone.`,
+		message: `Delete "${escapeHtml(f.file_name || f.file_url)}"? This can't be undone.`,
 		onConfirm: async ({ hideDialog }) => {
 			await props.docmeta.deleteAttachment(f.name);
 			hideDialog();
@@ -330,12 +330,6 @@ function uploadErrMsg(e) {
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
-function esc(s) {
-	return String(s).replace(
-		/[&<>"]/g,
-		(c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c])
-	);
-}
 function convertSize(bytes) {
 	const n = Number(bytes);
 	if (!n || n <= 0) return "";

--- a/frontend/src/components/shell/ConversationRow.vue
+++ b/frontend/src/components/shell/ConversationRow.vue
@@ -56,6 +56,7 @@ import { ref, computed, nextTick } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { Button, Dropdown, FeatherIcon, confirmDialog } from "frappe-ui";
 import { useShellStore } from "@/stores/shell";
+import { escapeHtml } from "@/lib/errors";
 
 const props = defineProps({
 	conv: { type: Object, required: true }, // {name, title, starred, last_active_at}
@@ -107,18 +108,10 @@ const menuOptions = computed(() => [
 	{ label: "Delete", icon: "trash-2", theme: "red", onClick: confirmDelete },
 ]);
 
-// ConfirmDialog renders `message` with v-html - escape the user-authored title.
-function esc(s) {
-	return String(s).replace(
-		/[&<>"']/g,
-		(c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])
-	);
-}
-
 function confirmDelete() {
 	confirmDialog({
 		title: "Delete chat?",
-		message: `Delete "${esc(props.conv.title || "this chat")}"? This can't be undone.`,
+		message: `Delete "${escapeHtml(props.conv.title || "this chat")}"? This can't be undone.`,
 		onConfirm: ({ hideDialog }) => {
 			store.archiveConversation(props.conv.name);
 			hideDialog();


### PR DESCRIPTION
Backport of #981 to `version-16`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA