### PR TITLE
fix(pool): backfill base_url from catalog default for deepseek/groq (#767) (backport #983 → version-16)

### DIFF
--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -428,6 +428,38 @@ def _upstream_has_renderer(upstream: str) -> bool:
 	return False
 
 
+_BASE_URL_BACKFILL_PROVIDERS = ("groq", "deepseek")
+
+
+def _catalog_default_base_url(provider: str) -> str:
+	"""Return the bundled catalog's ``default_base_url`` for a normalized
+	``provider`` id, or "" if it is not one of the providers this backfill
+	is scoped to.
+
+	Used to backfill build_pool_payload's emitted base_url when the operator
+	left it blank on an api_key model: without this, cliproxy receives an
+	entry with no endpoint and must guess one, and a wrong guess breaks every
+	chat turn on that model (jarvis#767). Deliberately narrowed to
+	_BASE_URL_BACKFILL_PROVIDERS (the issue's exact scope) rather than every
+	catalog provider with a default_base_url, so this fix cannot change the
+	emitted spec shape for any other provider. Reads the BUNDLED
+	(checked-into-git) catalog like _upstream_has_renderer above, for the
+	same reason: a pure function of stored settings, never a live-fetched
+	admin catalog.
+	"""
+	from jarvis._model_catalog import BUNDLED_MODEL_CATALOG
+
+	needle = (provider or "").strip().lower()
+	if needle not in _BASE_URL_BACKFILL_PROVIDERS:
+		return ""
+	for entry in BUNDLED_MODEL_CATALOG:
+		pid = (entry.get("provider_id") or "").strip().lower()
+		cid = (entry.get("catalog_id") or "").strip().lower()
+		if needle in (pid, cid):
+			return (entry.get("default_base_url") or "").strip()
+	return ""
+
+
 def _lone_direct_capable(settings) -> bool:
 	"""True when this settings' lone enabled model needs no Bifrost/cliproxy
 	sidecar at all - it can be served entirely by agent's native oauth
@@ -770,9 +802,16 @@ def build_pool_payload(settings):
 			# Also emit provider/base_url for api_key models
 			provider = (m.provider if hasattr(m, "provider") else m.get("provider", "")) or ""
 			base_url = (m.base_url if hasattr(m, "base_url") else m.get("base_url", "")) or ""
+			provider = normalize_provider(provider)
+			# Operator left base_url blank: backfill from the catalog's default
+			# for this provider rather than emitting a spec the proxy must
+			# guess an endpoint for (jarvis#767). Never overrides an
+			# operator-supplied value, and only ever changes the in-memory
+			# entry — the stored doc row is untouched.
+			if not base_url:
+				base_url = _catalog_default_base_url(provider)
 			if base_url:
 				entry["base_url"] = base_url
-			provider = normalize_provider(provider)
 			if provider:
 				# Wire-only collapse (e.g. "zai" -> "openai_compat"): the
 				# stored/displayed identity stays "zai"; only the Bifrost

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -399,6 +399,81 @@ class TestProviderNormalization(FrappeTestCase):
 			f"expected a base_url error for a zai_coding row with no base_url, got: {errors}",
 		)
 
+	# ------------------------------------------------------------------ #
+	# jarvis#767: blank base_url on groq/deepseek is backfilled from the
+	# bundled catalog's default_base_url, so the emitted pool spec never
+	# asks cliproxy to guess an endpoint. Deliberately narrowed to just
+	# these two providers (the issue's exact scope) - every other catalog
+	# provider with a default_base_url (openai, mistral, xai, zai, ...)
+	# keeps today's behavior: a blank base_url stays blank in the spec.
+	# ------------------------------------------------------------------ #
+
+	def test_groq_blank_base_url_is_backfilled_from_catalog(self):
+		from jarvis.jarvis.pool_serialize import build_pool_payload
+
+		groq = _api_key_model(
+			provider="groq", model="llama-3.3-70b-versatile", base_url="", api_key="gk", order=0
+		)
+		settings = _make_settings_with_models([groq])
+		spec, _api_keys, _ = build_pool_payload(settings)
+		self.assertEqual(spec["models"][0]["base_url"], "https://api.groq.com/openai/v1")
+
+	def test_deepseek_blank_base_url_is_backfilled_from_catalog(self):
+		from jarvis.jarvis.pool_serialize import build_pool_payload
+
+		deepseek = _api_key_model(
+			provider="deepseek", model="deepseek-v4-flash", base_url="", api_key="dk", order=0
+		)
+		settings = _make_settings_with_models([deepseek])
+		spec, _api_keys, _ = build_pool_payload(settings)
+		self.assertEqual(spec["models"][0]["base_url"], "https://api.deepseek.com")
+
+	def test_explicit_base_url_is_never_overridden_by_the_catalog_default(self):
+		# An operator-supplied base_url (even one pointed at a proxy/mirror
+		# that differs from the catalog default) must pass through unchanged
+		# - the backfill only ever fills a BLANK value, never second-guesses one.
+		from jarvis.jarvis.pool_serialize import build_pool_payload
+
+		groq = _api_key_model(
+			provider="groq",
+			model="llama-3.3-70b-versatile",
+			base_url="https://groq.my-mirror.example.com/v1",
+			api_key="gk",
+			order=0,
+		)
+		settings = _make_settings_with_models([groq])
+		spec, _api_keys, _ = build_pool_payload(settings)
+		self.assertEqual(spec["models"][0]["base_url"], "https://groq.my-mirror.example.com/v1")
+
+	def test_validate_models_passes_for_groq_and_deepseek_with_blank_base_url(self):
+		# The backfill happens in build_pool_payload only; validate_models
+		# must already treat groq/deepseek as not requiring an operator-typed
+		# base_url (they were never in the openai_compat/vllm/zai/zai_coding
+		# gate at pool_serialize.py:592), and this fix must not change that.
+		from jarvis.jarvis.pool_serialize import validate_models
+
+		groq = _api_key_model(
+			provider="groq", model="llama-3.3-70b-versatile", base_url="", api_key="gk", order=0
+		)
+		deepseek = _api_key_model(
+			provider="deepseek", model="deepseek-v4-flash", base_url="", api_key="dk", order=1
+		)
+		settings = _make_settings_with_models([groq, deepseek])
+		self.assertEqual(validate_models(settings), [])
+
+	def test_backfill_is_scoped_to_groq_and_deepseek_only(self):
+		# Regression lock for the narrowing: openai has a non-empty
+		# default_base_url in the bundled catalog too, but jarvis#767's
+		# backfill must NOT extend to it (or to any provider besides groq
+		# and deepseek) - a blank base_url on any other provider stays
+		# blank in the emitted spec, exactly like before this fix.
+		from jarvis.jarvis.pool_serialize import build_pool_payload
+
+		openai = _api_key_model(provider="openai", model="gpt-4o", base_url="", api_key="ok", order=0)
+		settings = _make_settings_with_models([openai])
+		spec, _api_keys, _ = build_pool_payload(settings)
+		self.assertNotIn("base_url", spec["models"][0])
+
 
 class TestPoolSerializeFromSettings(FrappeTestCase):
 	"""Task 2: Direct-call tests for build_pool_payload / validate_models / compute_proxy_active."""


### PR DESCRIPTION
Backport of #983 to `version-16`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA