### PR TITLE
fix(settings): surface admin auth-sync failures instead of logging them as success (#388) (backport #985 → version-16)

### DIFF
--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -89,11 +89,23 @@ def force_resync(action: str = "reload") -> dict:
 	require_jarvis_admin()
 	if action not in ("reload", "restart"):
 		raise frappe.ValidationError(f"invalid action {action!r}; expected reload or restart")
+	from jarvis import admin_client
+
 	settings = frappe.get_single("Jarvis Settings")
 	# Always the admin path: the legacy local-agent sync was retired with
 	# the managed fleet (its method no longer exists), and _sync_via_admin
 	# surfaces its own clear error on an unconfigured bench.
-	settings._sync_via_admin(action)
+	try:
+		settings._sync_via_admin(action)
+	except admin_client.AdminAuthError:
+		# #388: _sync_via_admin now re-raises a genuine (non-"not paid") auth
+		# failure instead of swallowing it, so the RQ-enqueued caller sees it.
+		# This is the one SYNCHRONOUS, whitelisted caller with a JSON {ok, ...}
+		# contract of its own to preserve - _sync_via_admin already wrote the
+		# terminal "failed: auth: ..." status onto Settings before raising, so
+		# swallow here and let the reload below report it the same way every
+		# other outcome of this endpoint is reported.
+		pass
 	settings.reload()
 	return {
 		"action": action,

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1467,11 +1467,29 @@ class JarvisSettings(Document):
 				self._resync_custom_skills_after_restart()
 				self._resync_learned_skills_after_restart()
 		except admin_client.AdminAuthError as e:
+			# #388: a genuine auth failure (revoked token, bad site secret) was
+			# recorded here and then SWALLOWED - the except body never re-raised,
+			# so the enqueuing rq job returned "success" while the credential push
+			# had actually failed. The one exception is the business-rule 403 this
+			# same exception type also carries (an unpaid/pending customer,
+			# CUSTOMER_NOT_PAID) - that is not an auth defect, it is an expected,
+			# recurring state for a tenant who hasn't paid yet, and raising it would
+			# turn an ordinary billing state into rq failures/alerts on every sync
+			# attempt until they pay. _is_never_paid_403 is the same classifier
+			# get_llm_apply_operation uses (jarvis.account), so the two surfaces
+			# agree on what counts as "not paid" including its old-admin prose
+			# fallback - a raw ``e.code == "CUSTOMER_NOT_PAID"`` check would miss
+			# that compatibility case and misclassify it as a genuine failure.
+			from jarvis.account import _is_never_paid_403
+
+			never_paid = _is_never_paid_403(e)
 			_write_settings_fields(
 				self,
 				{
 					"last_sync_at": frappe.utils.now(),
-					"last_sync_status": f"failed: auth: {e}",
+					"last_sync_status": (
+						"failed: not paid (CUSTOMER_NOT_PAID)" if never_paid else f"failed: auth: {e}"
+					),
 				},
 			)
 			_commit_terminal_sync_status()
@@ -1480,6 +1498,8 @@ class JarvisSettings(Document):
 				title="Jarvis: admin auth failed",
 				message=frappe.get_traceback(),
 			)
+			if not never_paid:
+				raise
 		except admin_client.AdminRejectedError as e:
 			# jarvis #542: admin was REACHED and permanently refused this config
 			# (an unknown provider slug, an unusable spec). The F2 handling below

--- a/jarvis/tests/test_diagnostics.py
+++ b/jarvis/tests/test_diagnostics.py
@@ -134,6 +134,20 @@ class TestForceResync(FrappeTestCase):
 			diagnostics.force_resync(action="reload")
 		sa.assert_called_once_with("reload")
 
+	def test_force_resync_survives_genuine_auth_error(self):
+		"""#388: _sync_via_admin now re-raises a genuine admin auth failure.
+		force_resync is the one SYNCHRONOUS, whitelisted caller with its own
+		{ok/status} JSON contract - it must swallow the raise and still return
+		its status dict (reflecting the terminal status _sync_via_admin wrote)
+		rather than letting the exception blow through the endpoint."""
+		from jarvis.exceptions import AdminAuthError
+
+		cls = frappe.get_single("Jarvis Settings").__class__
+		with patch.object(cls, "_sync_via_admin", side_effect=AdminAuthError("nope")):
+			out = diagnostics.force_resync(action="reload")
+		self.assertEqual(out["action"], "reload")
+		self.assertIn("last_sync_status", out)
+
 
 class TestChatRecoveryStats(FrappeTestCase):
 	"""jarvis.diagnostics.chat_recovery_stats - operator visibility into

--- a/jarvis/tests/test_installed_apps_sync.py
+++ b/jarvis/tests/test_installed_apps_sync.py
@@ -193,6 +193,9 @@ class TestInstalledAppsSync(FrappeTestCase):
 		from jarvis import admin_client
 
 		settings = frappe.get_doc("Jarvis Settings")
+		# AdminAuthError("nope") carries no code/status_code, so it classifies as
+		# a genuine auth failure (#388) and _sync_via_admin re-raises it after
+		# writing the terminal status - it's no longer swallowed.
 		with (
 			patch.object(type(settings), "_resolve_llm_secret_for_push", return_value="sk-test"),
 			patch(
@@ -202,5 +205,6 @@ class TestInstalledAppsSync(FrappeTestCase):
 			patch("frappe.log_error"),
 			patch("jarvis.installed_apps_sync.record_synced_snapshot") as stamp,
 		):
-			settings._sync_via_admin("restart")
+			with self.assertRaises(admin_client.AdminAuthError):
+				settings._sync_via_admin("restart")
 		stamp.assert_not_called()

--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -469,10 +469,16 @@ class TestProbeWithAStoredKey(_RT3SettingsTestCase):
 		row.api_key = self.STORED
 		row.base_url = "https://api.openai.com/v1"
 		settings.append("models", row)
-		with (
-			mock.patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
-			mock.patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "creds_update"}),
-		):
+		# #388: _sync_via_admin now RE-RAISES a genuine AdminAuthError instead of
+		# swallowing it. Mocking only the two leaf HTTP calls (post_update_llm_pool /
+		# post_update_llm_creds) isn't enough: depending on what a prior test left in
+		# the legacy llm_provider/model/base_url mirror, this save's classifier can
+		# come out "reload" instead of "restart" - and "reload" calls the UNMOCKED
+		# post_rotate_llm_secret, which hits the real (not-onboarded-on-CI)
+		# admin_client._authenticated_post and raises. Mock the whole dispatcher, the
+		# same way TestOnUpdateClassification does: this class tests the key-probe
+		# endpoint, not admin sync, so neither leg should ever touch the network.
+		with mock.patch.object(type(settings), "_sync_via_admin"):
 			settings.save()
 		frappe.db.commit()
 		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -282,9 +282,14 @@ class TestOnUpdateAdminDispatch(_SettingsSnapshotTestCase):
 
 		from jarvis.exceptions import AdminAuthError
 
-		# api_key rotation is now a reload-action → post_rotate_llm_secret
+		# api_key rotation is now a reload-action → post_rotate_llm_secret.
+		# #388: a genuine auth failure now propagates out of the in-test
+		# inline sync instead of being swallowed, so .save() raises it - the
+		# terminal status is still written (and durable) before that happens.
 		with patch("jarvis.admin_client.post_rotate_llm_secret", side_effect=AdminAuthError("invalid token")):
-			s = self._save_with_new_api_key("sk-auth-fail-test")
+			with self.assertRaises(AdminAuthError):
+				self._save_with_new_api_key("sk-auth-fail-test")
+		s = frappe.get_doc("Jarvis Settings", "Jarvis Settings")
 		self.assertTrue(s.last_sync_status.startswith("failed: auth:"))
 		self.assertIn("invalid token", s.last_sync_status)
 

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -610,10 +610,33 @@ class TestSyncViaAdminDispatch(_SettingsSingletonTestCase):
 		settings.db_set("llm_api_key", "sk-1", update_modified=False)
 		frappe.db.commit()
 		settings.reload()
-		settings._sync_via_admin("reload")
+		# #388: a genuine auth failure (no CUSTOMER_NOT_PAID code) is written
+		# terminally and then re-raised, so the caller sees it instead of a
+		# silently swallowed "success".
+		with self.assertRaises(AdminAuthError):
+			settings._sync_via_admin("reload")
 		settings.reload()
 		self.assertIn("failed", settings.last_sync_status or "")
 		self.assertIn("auth", settings.last_sync_status or "")
+
+	@patch("jarvis.admin_client.post_rotate_llm_secret")
+	def test_admin_auth_error_not_paid_does_not_raise(self, mock_rotate):
+		from jarvis.exceptions import AdminAuthError
+
+		mock_rotate.side_effect = AdminAuthError(
+			"Your subscription is not active.", status_code=403, code="CUSTOMER_NOT_PAID"
+		)
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("llm_api_key", "sk-1", update_modified=False)
+		frappe.db.commit()
+		settings.reload()
+		# The business-rule "not paid" case is expected and recurring - it must
+		# stay non-fatal so it doesn't raise rq failures/alerts on every sync
+		# attempt until the customer pays.
+		settings._sync_via_admin("reload")
+		settings.reload()
+		self.assertIn("failed: not paid", settings.last_sync_status or "")
+		self.assertIn("CUSTOMER_NOT_PAID", settings.last_sync_status or "")
 
 
 class TestOnUpdateAsyncPending(_SettingsSingletonTestCase):


### PR DESCRIPTION
Backport of #985 to `version-16`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA