### PR TITLE
fix(onboarding): stop reporting expected company-defaults 404 as an error (#819) (backport #986 → version-16)

### DIFF
--- a/frontend/src/onboarding/companyDefaultsMiss.js
+++ b/frontend/src/onboarding/companyDefaultsMiss.js
@@ -1,0 +1,36 @@
+// Whether a getCompanyOnboardingDefaults rejection is the EXPECTED "no such
+// company" case, not a defect. fetchCompanyDefaults (OnboardingView.vue) fires
+// on every keystroke of the Company field, debounced but still constant, and
+// most of those keystrokes name no Company yet - the backend
+// (onboarding.get_company_onboarding_defaults) answers that with a real 4xx
+// and {ok:false, error:{code:"COMPANY_DEFAULTS_NOT_FOUND"}}, deliberately, the
+// same way for a blank/unresolved Company as for a genuinely custom name on a
+// frappe-only bench with no Company doctype (see C01-1 in onboarding.py). None
+// of that is worth a console/telemetry error on every keystroke; only
+// COMPANY_DEFAULTS_FORBIDDEN and real failures (network, 500s) still are.
+//
+// Pure, no Vue, no `@/` alias - node --test runs it standalone, same reasoning
+// as paymentCodec.js and gstin.js for keeping wire-shape decoding out of the
+// SFC.
+//
+// The backend never raises for this case, so frappe-ui's `call` (api.js) still
+// throws (the HTTP status is a real 4xx): the thrown Error's `.status` is that
+// status, and its `.messages` array carries the {ok:false, error:{code,...}}
+// envelope untouched as an OBJECT - `call`'s `JSON.parse` attempt on a
+// non-string fails and leaves it as-is. Same wire shape filterModel.js's
+// envelopeIn/filterErrorInfo reads for list_filter_* errors.
+
+function envelopeCode(candidate) {
+	if (!candidate || typeof candidate !== "object") return "";
+	const error = candidate.error;
+	return error && typeof error === "object" && typeof error.code === "string" ? error.code : "";
+}
+
+export function isExpectedCompanyDefaultsMiss(e) {
+	if (!e) return false;
+	if (e.status === 404) return true;
+	const candidates = [e, ...(Array.isArray(e.messages) ? e.messages : [])];
+	return candidates.some(
+		(candidate) => envelopeCode(candidate) === "COMPANY_DEFAULTS_NOT_FOUND"
+	);
+}

--- a/frontend/src/onboarding/companyDefaultsMiss.test.js
+++ b/frontend/src/onboarding/companyDefaultsMiss.test.js
@@ -1,0 +1,55 @@
+// isExpectedCompanyDefaultsMiss: distinguishing the EXPECTED "no such company"
+// rejection from a genuine failure. Pure module, node --test (see
+// vitest.config.js for why *.test.js and *.spec.js are split).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isExpectedCompanyDefaultsMiss } from "./companyDefaultsMiss.js";
+
+test("a 404 status alone is treated as the expected miss", () => {
+	const e = new Error("not found");
+	e.status = 404;
+	assert.equal(isExpectedCompanyDefaultsMiss(e), true);
+});
+
+test("COMPANY_DEFAULTS_NOT_FOUND carried in e.messages is treated as the expected miss", () => {
+	// frappe-ui's call() concats the response body's `message` key into
+	// e.messages; a coded {ok:false, error:{code}} envelope arrives as an
+	// OBJECT there because JSON.parse on a non-string leaves it untouched.
+	const e = new Error("unknown company");
+	e.status = 404;
+	e.messages = [
+		{ ok: false, error: { code: "COMPANY_DEFAULTS_NOT_FOUND", message: "unknown company" } },
+	];
+	assert.equal(isExpectedCompanyDefaultsMiss(e), true);
+});
+
+test("COMPANY_DEFAULTS_NOT_FOUND with no status set is still caught via e.messages", () => {
+	const e = { messages: [{ error: { code: "COMPANY_DEFAULTS_NOT_FOUND" } }] };
+	assert.equal(isExpectedCompanyDefaultsMiss(e), true);
+});
+
+test("COMPANY_DEFAULTS_FORBIDDEN (403) is NOT the expected miss - it is a real problem", () => {
+	const e = new Error("forbidden");
+	e.status = 403;
+	e.messages = [
+		{ ok: false, error: { code: "COMPANY_DEFAULTS_FORBIDDEN", message: "not permitted" } },
+	];
+	assert.equal(isExpectedCompanyDefaultsMiss(e), false);
+});
+
+test("a generic 500 / network failure is NOT the expected miss", () => {
+	const e = new Error("Internal Server Error");
+	e.status = 500;
+	e.messages = ["Internal Server Error"];
+	assert.equal(isExpectedCompanyDefaultsMiss(e), false);
+});
+
+test("a falsy or malformed error never throws and is never the expected miss", () => {
+	assert.equal(isExpectedCompanyDefaultsMiss(null), false);
+	assert.equal(isExpectedCompanyDefaultsMiss(undefined), false);
+	assert.equal(isExpectedCompanyDefaultsMiss({}), false);
+	assert.equal(isExpectedCompanyDefaultsMiss({ messages: "not-an-array" }), false);
+	assert.equal(isExpectedCompanyDefaultsMiss({ messages: [null, "string message", 42] }), false);
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1909,6 +1909,7 @@ import { makeTelemetryReporter } from "@/onboarding/paymentTelemetry";
 import { readCookie } from "@/lib/user";
 import { useBillingDetails, billingEditAction } from "@/onboarding/useBillingDetails";
 import { gstinError, GSTIN_PLACEHOLDER } from "@/onboarding/gstin";
+import { isExpectedCompanyDefaultsMiss } from "@/onboarding/companyDefaultsMiss";
 
 const router = useRouter();
 const { effectiveDark: dark, paletteVars } = useJarvisTheme();
@@ -2626,8 +2627,13 @@ async function fetchCompanyDefaults() {
 		if (resp && resp.ok) billing.applyDefaults(resp, gen, company);
 	} catch (e) {
 		// COMPANY_DEFAULTS_FORBIDDEN / _NOT_FOUND surface as a 4xx (thrown here);
-		// nothing to apply. Presence-only report, no PII.
-		reportError({ surface: "onboarding", error_code: "company_defaults", message: "" });
+		// nothing to apply. _NOT_FOUND is EXPECTED noise - this fires on every
+		// keystroke of a Company that hasn't resolved yet (debounced, but still
+		// constant), so it is never reported; genuinely unexpected failures
+		// (FORBIDDEN, network, 5xx) still are. Presence-only report, no PII.
+		if (!isExpectedCompanyDefaultsMiss(e)) {
+			reportError({ surface: "onboarding", error_code: "company_defaults", message: "" });
+		}
 	}
 }
 


### PR DESCRIPTION
Backport of #986 to `version-16`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA