### PR TITLE
fix(chat): frame a dead container as an outage, not first-time setup (#885) (backport #988 → version-16)

### DIFF
--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -251,12 +251,38 @@ export async function billingNoticeOf() {
 // safe, please don't retry") - never a Renew or Reconnect action, both of which
 // could make it worse. Like container_provisioning it carries the backend's own
 // `detail`, so it belongs here rather than on any billing/AI-connect banner.
+// "container_unavailable" (jarvis#885) also shares this accessor for the
+// detail SENTENCE only - admin's health cron confirmed the container is dead,
+// and its own words are the whole point of this text, same as every other
+// reason here. It does NOT share the "Chat may not work yet" title though:
+// isContainerUnavailable() below gives ChatView its own outage-framed banner,
+// checked before the generic one in the v-else-if chain so it wins.
 export async function readinessDetailOf() {
 	const r = await checkReady();
 	if (!r || r.ready) return "";
-	if (r.reason === "container_provisioning" || r.reason === "authority_repair_required")
+	if (
+		r.reason === "container_provisioning" ||
+		r.reason === "authority_repair_required" ||
+		r.reason === "container_unavailable"
+	)
 		return r.detail || "";
 	return "";
+}
+
+// True when the workspace is not chat-ready because admin's health cron
+// confirmed the serving container is dead/unhealthy (jarvis#885, backend's
+// "Unavailable" chat_readiness). Its own accessor - same "one reason, one
+// accessor" convention as needsLlmConnection below - because this reason needs
+// its own OUTAGE-framed banner ("Chat is temporarily unavailable"), never the
+// generic "Chat may not work yet" title that readinessDetailOf's shared detail
+// text would otherwise fall into. ChatView checks this BEFORE the generic
+// notReadyNotice banner in its v-else-if chain, and still reads the detail
+// SENTENCE off readinessDetailOf above (which now also covers this reason) for
+// the message body - only the title/framing is different, never the source of
+// admin's own words.
+export async function isContainerUnavailable() {
+	const r = await checkReady();
+	return !!(r && !r.ready && r.reason === "container_unavailable");
 }
 
 // True when the workspace is not chat-ready specifically because it has no usable

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -21,6 +21,7 @@ const {
 	landingStep,
 	isLlmApplying,
 	isLlmApplyStuck,
+	isContainerUnavailable,
 	RECONNECT_INTENT_URL,
 } = await import("./readiness.js");
 
@@ -84,6 +85,20 @@ describe("readiness verdict ownership", () => {
 		expect(await needsLlmConnection()).toBe(false);
 	});
 
+	it("jarvis#885: surfaces container_unavailable's detail sentence, never the AI CTA", async () => {
+		// A dead container is not a missing LLM credential, so needsLlmConnection
+		// must stay silent for it (its dedicated banner is isContainerUnavailable(),
+		// checked separately by ChatView - see the exhaustive test below for the
+		// mutual-exclusion pin).
+		verdict({
+			ready: false,
+			reason: "container_unavailable",
+			detail: "Your workspace container stopped responding.",
+		});
+		expect(await readinessDetailOf()).toBe("Your workspace container stopped responding.");
+		expect(await needsLlmConnection()).toBe(false);
+	});
+
 	it("leaves subscription_suspended to its own Renew banner", async () => {
 		verdict({ ready: false, reason: "subscription_suspended", detail: "Renew to continue." });
 		expect(await readinessDetailOf()).toBe("");
@@ -112,6 +127,7 @@ describe("readiness verdict ownership", () => {
 			"llm_provisioning",
 			"container_provisioning",
 			"authority_repair_required",
+			"container_unavailable",
 			"subscription_suspended",
 			"llm_applying",
 			"llm_apply_stuck",
@@ -180,6 +196,39 @@ describe("llm_apply_stuck (jarvis#825)", () => {
 		// chat + history and gets a banner, never the setup poster. If this ever
 		// returns true, llm_apply_stuck was wrongly added to NOT_ONBOARDED_REASONS.
 		verdict({ ready: false, reason: "llm_apply_stuck" });
+		expect(await needsOnboarding()).toBe(false);
+	});
+});
+
+/**
+ * jarvis#885: a dead/unhealthy container must be its own honest, outage-framed
+ * banner - NOT the generic "Chat may not work yet" title (readinessDetailOf
+ * still supplies the detail SENTENCE, but isContainerUnavailable is what picks
+ * the banner), and NOT the full-screen onboarding gate (an established
+ * workspace whose container later died keeps its chat + history).
+ */
+describe("container_unavailable (jarvis#885)", () => {
+	it("isContainerUnavailable answers ONLY for its own reason", async () => {
+		verdict({ ready: false, reason: "container_unavailable" });
+		expect(await isContainerUnavailable()).toBe(true);
+		forgetReady();
+		verdict({ ready: false, reason: "container_provisioning" });
+		expect(await isContainerUnavailable()).toBe(false);
+		forgetReady();
+		verdict({ ready: true, reason: null });
+		expect(await isContainerUnavailable()).toBe(false);
+	});
+
+	it("never claims the llm_credentials CTA banner", async () => {
+		verdict({ ready: false, reason: "container_unavailable" });
+		expect(await needsLlmConnection()).toBe(false);
+	});
+
+	it("does NOT trip the full-screen onboarding gate", async () => {
+		// The workspace WAS established (it had a running container that then
+		// died), so it keeps its chat + history and gets a banner, never the
+		// setup poster.
+		verdict({ ready: false, reason: "container_unavailable" });
 		expect(await needsOnboarding()).toBe(false);
 	});
 });

--- a/frontend/src/onboarding/waitPhases.js
+++ b/frontend/src/onboarding/waitPhases.js
@@ -235,6 +235,25 @@ export function readinessPhase({ answered = false, reason = "", detail = "" } = 
 				detail: say,
 				stop: false,
 			};
+		case "container_unavailable":
+			// jarvis#885: admin's health cron confirmed the serving container is
+			// dead/unhealthy - a DIFFERENT fact than container_provisioning (the two
+			// states are mutually exclusive at the source). Waiting cannot heal a
+			// dead container from here, so this STOPS the wait like the
+			// paged/suspended/moved verdicts above, rather than falling into the
+			// "coming online" active-progress framing right above - telling a
+			// customer whose workspace just died that it is on its way up is false.
+			// Admin's own reason (`say`) is the body, never reworded.
+			return {
+				observed: true,
+				state: PHASE_STATE.UNKNOWN,
+				kind: PHASE_KIND.NONE,
+				label: "Chat is temporarily unavailable",
+				detail: say,
+				stop: true,
+				paged: false,
+				title: "Chat is temporarily unavailable",
+			};
 		case "readiness_unconfirmed":
 			return {
 				observed: true,

--- a/frontend/src/onboarding/waitPhases.test.js
+++ b/frontend/src/onboarding/waitPhases.test.js
@@ -108,10 +108,13 @@ test("readiness: authority_repair_required stops the wait, is paged, quotes admi
 // jarvis/account.py keeps subscription_suspended distinct from
 // container_provisioning precisely "so a suspended customer isn't told to wait
 // for a container that won't come back". site_replaced can never be resolved by
-// waiting either - the account lives on another site now. Both used to fall
-// through to the default and render as active progress.
+// waiting either - the account lives on another site now. jarvis#885 adds
+// container_unavailable to the same list: a confirmed-dead container cannot be
+// waited into life either. All three used to render as active progress -
+// subscription_suspended and site_replaced by falling through to the default,
+// container_unavailable by arriving pre-bucketed as container_provisioning.
 test("readiness: reasons that waiting cannot fix never render as progress", () => {
-	for (const reason of ["subscription_suspended", "site_replaced"]) {
+	for (const reason of ["subscription_suspended", "site_replaced", "container_unavailable"]) {
 		const p = readinessPhase({ answered: true, reason, detail: "why" });
 		assert.equal(p.stop, true, reason);
 		assert.notEqual(p.state, PHASE_STATE.ACTIVE, reason);
@@ -120,6 +123,19 @@ test("readiness: reasons that waiting cannot fix never render as progress", () =
 		assert.equal(p.paged, false, reason);
 		assert.ok(p.title, reason);
 	}
+});
+
+// jarvis#885: a dead container reads distinctly from the generic default, and
+// the container_provisioning phase it must never be confused with.
+test("readiness: container_unavailable is an outage, never the 'coming online' framing", () => {
+	const detail = "Your workspace container stopped responding. We're working to restore it.";
+	const p = readinessPhase({ answered: true, reason: "container_unavailable", detail });
+	assert.equal(p.stop, true);
+	assert.equal(p.detail, detail);
+	assert.equal(p.kind, PHASE_KIND.NONE);
+	assert.notEqual(p.state, PHASE_STATE.ACTIVE);
+	assert.doesNotMatch(p.label, /coming online|getting ready/i);
+	assert.match(p.label + " " + p.title, /unavailable/i);
 });
 
 test("readiness: only a paged repair claims support was already notified", () => {
@@ -133,6 +149,7 @@ test("readiness: only a paged repair claims support was already notified", () =>
 		"llm_rejected",
 		"reconnect_required",
 		"container_provisioning",
+		"container_unavailable",
 		"readiness_unconfirmed",
 		"unmapped",
 	]) {
@@ -169,6 +186,7 @@ test("readiness: only llm_rejected is editable - the three blocked stop cases ar
 		"subscription_suspended",
 		"site_replaced",
 		"reconnect_required",
+		"container_unavailable",
 	]) {
 		assert.notEqual(readinessPhase({ answered: true, reason }).editable, true, reason);
 	}
@@ -203,6 +221,7 @@ test("readiness: only reconnect_required carries the reconnect flag", () => {
 		"site_replaced",
 		"llm_rejected",
 		"container_provisioning",
+		"container_unavailable",
 		"readiness_unconfirmed",
 		"unmapped",
 	]) {
@@ -276,6 +295,7 @@ test("readiness: no branch ever claims setup is finishing on its own", () => {
 		"site_replaced",
 		"llm_rejected",
 		"reconnect_required",
+		"container_unavailable",
 		"unmapped",
 	];
 	for (const reason of reasons) {
@@ -322,6 +342,7 @@ test("setup headline: no unobserved or unnameable phase ever claims a subject", 
 		readinessPhase({ answered: true, reason: "authority_repair_required" }),
 		readinessPhase({ answered: true, reason: "subscription_suspended" }),
 		readinessPhase({ answered: true, reason: "site_replaced" }),
+		readinessPhase({ answered: true, reason: "container_unavailable" }),
 		readinessPhase({ answered: true, reason: "a_reason_this_build_never_heard_of" }),
 		null,
 		undefined,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2372,6 +2372,21 @@
 						</button>
 					</template>
 				</Banner>
+				<!-- jarvis#885: admin's health cron confirmed the serving container is
+					 dead/unhealthy (chat_readiness "Unavailable"), a DIFFERENT fact than
+					 "still starting up". This must be checked BEFORE the generic
+					 notReadyNotice banner below (same specific-before-generic ordering as
+					 noAiConnected above) or its "Chat may not work yet" title would win the
+					 v-else-if race and undersell a dead container as a maybe-slow one. No
+					 CTA: like notReadyNotice, there is nothing to renew or reconnect via us
+					 here - the message IS the admin's own diagnosis. -->
+				<Banner
+					v-else-if="containerUnavailable"
+					type="warning"
+					title="Chat is temporarily unavailable"
+					:message="notReadyNotice || 'We\'re working to bring your workspace back.'"
+					style="margin-bottom: 10px"
+				/>
 				<!-- Not chat-ready for a NON-billing reason (e.g. the connected LLM account
 					 itself is out of quota, or a container is still coming up). No CTA: unlike
 					 a lapsed subscription there's nothing to renew via us here - the detail
@@ -4124,6 +4139,7 @@ import {
 	needsLlmConnection,
 	isLlmApplying,
 	isLlmApplyStuck,
+	isContainerUnavailable,
 	forgetReady,
 } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
@@ -4225,6 +4241,15 @@ const suspendedNotice = ref(null);
 // onboarding's "Continue to Jarvis" while genuinely not ready used to land here to
 // dead silence - the real reason existed the whole time, nobody rendered it).
 const notReadyNotice = ref("");
+// jarvis#885: true when admin's health cron confirmed the serving container is
+// dead/unhealthy (chat_readiness "Unavailable" -> reason "container_unavailable").
+// Its own flag rather than folding into notReadyNotice: that banner's generic
+// "Chat may not work yet" title undersells a dead container as a maybe-slow one,
+// so this gets its own outage-framed banner, checked BEFORE the generic one in
+// the v-else-if chain below (order pinned the same way noAiConnected is). The
+// message body still reads notReadyNotice's text - readinessDetailOf() now
+// covers this reason too, so admin's own words are never duplicated.
+const containerUnavailable = ref(false);
 // No AI connected at all (is_ready_for_chat reason "llm_credentials"): the customer
 // disconnected their model, or the credential expired. Until now this reason was
 // handled by NEITHER the onboarding gate (correctly - see readiness.js) nor any
@@ -10325,6 +10350,15 @@ onMounted(async () => {
 	readinessDetailOf()
 		.then((detail) => {
 			notReadyNotice.value = detail;
+		})
+		.catch(() => {});
+	// ...and the container_unavailable half (jarvis#885): same fail-open posture,
+	// an unreachable backend just leaves the outage banner off. Rides the same
+	// memoized verdict as notReadyNotice above, so still no extra round trip -
+	// only WHICH banner title wins depends on this flag.
+	isContainerUnavailable()
+		.then((v) => {
+			containerUnavailable.value = v;
 		})
 		.catch(() => {});
 	// ...and the llm_credentials half of the same boot promise. Same fail-open

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -485,7 +485,9 @@ def _admin_chat_gate() -> dict:
 	code is ``"authority_repair_required"`` for ``SupportRequired`` (a paged
 	incident, no self-service action), ``"reconnect_required"`` for
 	``ReconnectRequired`` (slice 4b: reconnect the provider), ``"subscription_suspended"``
-	for ``Suspended`` (renew) and ``"container_provisioning"`` otherwise (wait) -
+	for ``Suspended`` (renew), ``"container_unavailable"`` for ``Unavailable``
+	(jarvis#885: admin's health cron confirmed the container is dead/unhealthy -
+	an outage, not a wait) and ``"container_provisioning"`` otherwise (wait) -
 	each kept distinct so a customer isn't told to wait for a container that won't
 	come back, or to keep spinning on a strand that only a reconnect can clear.
 
@@ -569,6 +571,20 @@ def _admin_chat_gate() -> dict:
 			return {
 				"ready": False,
 				"reason": "reconnect_required",
+				"billing_notice": {},
+				"detail": conn.get("chat_readiness_reason") or "",
+			}
+		# admin-v2's health cron marks a container "Unavailable" once it is
+		# confirmed dead/unhealthy - a DIFFERENT fact than "Provisioning"
+		# (the two states are mutually exclusive). Bucketing this into the
+		# generic "container_provisioning" fallback below tells a customer
+		# whose workspace just died that it is "coming online", which is
+		# false and stalls them on a spinner that never resolves. Its own
+		# reason lets the frontend render an honest outage message instead.
+		if conn["chat_readiness"] == "Unavailable":
+			return {
+				"ready": False,
+				"reason": "container_unavailable",
 				"billing_notice": {},
 				"detail": conn.get("chat_readiness_reason") or "",
 			}

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -356,6 +356,40 @@ class TestAdminChatGate(FrappeTestCase):
 				{"ready": False, "reason": "reconnect_required", "detail": "", "billing_notice": {}},
 			)
 
+	def test_container_unavailable_is_distinct_from_provisioning(self):
+		"""jarvis#885: admin-v2's health cron confirmed the serving container is
+		dead/unhealthy - a DIFFERENT fact than "still starting up" (the two states
+		are mutually exclusive at the source). Must not read as
+		"container_provisioning", which tells the customer their workspace is
+		coming online when it is not."""
+		reason = "Your workspace container stopped responding. We're working to restore it."
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "Unavailable",
+				"chat_readiness_reason": reason,
+			},
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{
+					"ready": False,
+					"reason": "container_unavailable",
+					"detail": reason,
+					"billing_notice": {},
+				},
+			)
+
+	def test_container_unavailable_without_reason_still_classifies(self):
+		"""Older admin sends the state with no sentence — the code must still be
+		the outage one; the SPA supplies its own fallback copy."""
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Unavailable"}):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{"ready": False, "reason": "container_unavailable", "detail": "", "billing_notice": {}},
+			)
+
 	def test_allows_when_admin_ready(self):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
 			self.assertEqual(


### PR DESCRIPTION
Backport of #988 to `version-16`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA