### PR TITLE
fix(wiki): collapse missing-vs-private into one error to close existence oracle (#733) (backport #984 → version-15)

### DIFF
--- a/jarvis/tests/test_wiki_scopes_api.py
+++ b/jarvis/tests/test_wiki_scopes_api.py
@@ -15,7 +15,7 @@ from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now_datetime
 
 from jarvis.chat import wiki
-from jarvis.exceptions import PermissionDeniedError
+from jarvis.exceptions import InvalidArgumentError
 from jarvis.permissions import JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE
 from jarvis.tools.read_wiki import read_wiki
 from jarvis.tools.update_wiki import update_wiki
@@ -549,8 +549,15 @@ class TestWikiToolVisibility(_WikiScopeFixture):
 		frappe.set_user(PLAIN_USER)
 		page = read_wiki(slug=slugs["org"])
 		self.assertEqual(page["slug"], slugs["org"])
-		with self.assertRaises(PermissionDeniedError):
+		# #733: a foreign private page and a missing page raise the
+		# byte-identical error, so the exception can't be used to learn
+		# a private page exists.
+		with self.assertRaises(InvalidArgumentError) as forbidden:
 			read_wiki(slug=slugs["kwu_user"])
+		self.assertEqual(str(forbidden.exception), f"unknown wiki page: {slugs['kwu_user']}")
+		with self.assertRaises(InvalidArgumentError) as missing:
+			read_wiki(slug="wkscope-missing-slug")
+		self.assertEqual(str(missing.exception), "unknown wiki page: wkscope-missing-slug")
 		# The owner still reads their own page.
 		frappe.set_user(KW_USER)
 		page = read_wiki(slug=slugs["kwu_user"])
@@ -653,11 +660,16 @@ class TestUpdateWikiScope(_WikiScopeFixture):
 	def test_foreign_user_page_not_writable_via_tool(self):
 		slugs = self._plant_matrix_pages()
 		frappe.set_user(PLAIN_USER)
-		with self.assertRaises(PermissionDeniedError):
+		# #733: masked as the same "missing title/page_type" error a create
+		# attempt against a genuinely unknown slug raises — a forbidden
+		# existing page can't be distinguished from one that doesn't exist.
+		with self.assertRaises(InvalidArgumentError) as forbidden:
 			update_wiki(slug=slugs["kwu_user"], append_md="- vandalism")
+		with self.assertRaises(InvalidArgumentError) as missing:
+			update_wiki(slug="wkscope-missing-write-slug", append_md="- vandalism")
+		self.assertEqual(str(forbidden.exception), str(missing.exception))
+		self.assertEqual(str(forbidden.exception), "creating a new wiki page requires title and page_type")
 
 	def test_invalid_scope_rejected(self):
-		from jarvis.exceptions import InvalidArgumentError
-
 		with self.assertRaises(InvalidArgumentError):
 			update_wiki(slug="org--wkscope-x", title="X", page_type="Org", scope="Team")

--- a/jarvis/tools/read_wiki.py
+++ b/jarvis/tools/read_wiki.py
@@ -65,12 +65,14 @@ def _get_by_slug(slug: str) -> dict:
 	if not name:
 		raise InvalidArgumentError(f"unknown wiki page: {slug}")
 	if not frappe.has_permission(WIKI, ptype="read", doc=name):
-		raise PermissionDeniedError(f"no read permission on {WIKI} {name}")
+		# #733: byte-identical to the missing-row error above — a caller must
+		# not be able to distinguish "no such page" from "exists but private".
+		raise InvalidArgumentError(f"unknown wiki page: {slug}")
 	doc = frappe.get_doc(WIKI, name)
 	# Scope visibility (explicit, on top of the has_permission hook): a Role/
 	# User page is only readable by its audience.
 	if not wiki_permissions.can_read_page(doc, frappe.session.user):
-		raise PermissionDeniedError(f"no read permission on {WIKI} {name}")
+		raise InvalidArgumentError(f"unknown wiki page: {slug}")
 	try:
 		sources = json.loads(doc.sources) if doc.sources else []
 	except Exception:

--- a/jarvis/tools/update_wiki.py
+++ b/jarvis/tools/update_wiki.py
@@ -125,7 +125,15 @@ def update_wiki(
 		# here + ignore_permissions replace the old doctype-perm probe, since
 		# write moved off Desk User). Role/User pages follow the human matrix.
 		if (doc.get("scope") or "Org") != "Org" and not wiki_permissions.can_edit_page(doc, user):
-			raise PermissionDeniedError(f"no write permission on {WIKI} {name}")
+			# #733: never let a forbidden existing page fall through to the
+			# create branch below — hitting the unique-slug duplicate-key
+			# error there would be an even louder existence leak. Mask it
+			# the same way a genuinely unknown slug is handled: the same
+			# missing-title/page_type message when a create was not even
+			# attempted, otherwise the same "unknown" message read_wiki uses.
+			if not (title and str(title).strip()) or not page_type:
+				raise InvalidArgumentError("creating a new wiki page requires title and page_type")
+			raise InvalidArgumentError(f"unknown wiki page: {slug}")
 		created = False
 		if title and str(title).strip():
 			doc.title = str(title).strip()[:140]


### PR DESCRIPTION
Backport of #984 to `version-15`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA