### PR TITLE
feat(pool): warn upfront when a multi-subscription pool has no api-key backstop (#934) (backport #987 → version-15)

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -159,6 +159,31 @@
 				</button>
 			</div>
 
+			<!-- jarvis#934: non-blocking warning for a 2+-subscription pool with no
+			     api-key backstop - deliberately its OWN block (not the red `err`
+			     banner above, which is a hard save failure with a Retry button). This
+			     mirrors admin's `multi_sub_without_backstop` apply-time rule, but
+			     surfaces it here instead: at the moment the invalid combination
+			     exists, before a save is even attempted. -->
+			<div v-if="backstopWarning" class="jv-callout" style="margin-bottom: 12px">
+				<svg
+					width="15"
+					height="15"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.9"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path
+						d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+					/>
+					<path d="M12 9v4M12 17h.01" />
+				</svg>
+				<p>{{ backstopWarning }}</p>
+			</div>
+
 			<!-- template wrapper, not v-if on the row div itself: Vue 3 gives v-if
 			     higher precedence than v-for on the SAME element, so it would run
 			     before `row` exists in scope. See pendingAddUid's doc above for what
@@ -876,6 +901,30 @@
 								"
 							/>
 						</div>
+					</div>
+
+					<!-- jarvis#934: same non-blocking backstop warning as the main list,
+					     surfaced here too so it is seen BEFORE OAuth sign-in starts, not
+					     after. panelRow is already appended to rows.value at this point
+					     (openAdd appends up front), so backstopWarning already reflects
+					     picking this Provider - no separate computation needed. -->
+					<div v-if="backstopWarning" class="jv-callout" style="margin-bottom: 10px">
+						<svg
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.9"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path
+								d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+							/>
+							<path d="M12 9v4M12 17h.01" />
+						</svg>
+						<p>{{ backstopWarning }}</p>
 					</div>
 
 					<!-- Say what this sign-in will actually DO before it starts. The customer
@@ -2187,6 +2236,7 @@ import {
 	seedRowsFromConfig,
 	defaultSubscriptionModel,
 	subModelSuggestions,
+	poolBackstopWarning,
 	apiKeyModelHealth,
 	subscriptionAccountHealth,
 	dirtyAccountHealth,
@@ -2888,6 +2938,23 @@ const missingVendors = computed(() => {
 // preset currently selected (via selectPreset, reused verbatim by the
 // config-section's 'From a preset' source) with vendor keys still missing?"
 const saveBlocked = computed(() => !!selectedPreset.value && missingVendors.value.length > 0);
+
+// jarvis#934: warn the moment the pool becomes 2+ subscriptions on distinct
+// upstreams with no api-key backstop - previously this only surfaced as an
+// apply-time rejection, well after a second OAuth sign-in already happened.
+// Non-blocking (validatePool/buildSavePayload stays the hard gate at Save).
+//
+// isRowEmpty filters out a blank API-key placeholder row (load() seeds one
+// into an empty pool; an abandoned "+ Add a model" can leave one behind) -
+// left in, its mere presence would satisfy hasNonSubscriptionModel and hide
+// the exact warning #934 is about. Subscription rows are kept regardless of
+// emptiness (isRowEmpty calls an accountless one "empty" too) so the warning
+// still fires from the add/connect panel before any OAuth account exists.
+const backstopWarning = computed(() =>
+	poolBackstopWarning(
+		rows.value.filter((r) => r.credentialType === "subscription" || !isRowEmpty(r))
+	)
+);
 
 // Direct/Proxy badge - mirrors jarvis_account.js renderModeBadge().
 // Quick is always Direct (single model); Preset is Proxy once chosen; Custom

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -175,6 +175,48 @@ export function validatePool(models, preset) {
 	return { ok: true, error: "" };
 }
 
+// Client-side mirror of admin's `multi_sub_without_backstop` rule (jarvis#934):
+// a pool with 2+ chat-subscription models on DISTINCT upstreams and no
+// non-subscription (API-key) model has no fallback if a subscription is
+// rate-limited or its OAuth session drops - chat just stalls. That used to
+// surface only at apply time, from admin's rejection, well after the second
+// subscription was already wired up (and the OAuth dance already done).
+// Non-blocking: validatePool above stays the hard save-time gate; this is
+// only meant to speak up the moment the invalid combination exists, before
+// the customer has invested in a second sign-in.
+//
+// Two subscriptions on the SAME upstream do NOT warn - failing over between
+// two accounts on one upstream is still a real backstop, just not an
+// api-key one. ANY non-subscription row satisfies the backstop, including a
+// keyless local provider (Ollama/vLLM): the rule is "is there a
+// non-subscription leg to fall back to", not "is there a paid API key".
+//
+// Tolerates both shapes this module deals in, same as deriveMode above: raw
+// editor rows (credentialType + a top-level upstream) and the
+// validatePool/save shape (a `subscription` object, upstream only on its
+// accounts) - so a caller can pass rows straight from the editor with no
+// normalization step.
+export function poolBackstopWarning(models) {
+	const list = Array.isArray(models) ? models : [];
+	const isSubscription = (m) =>
+		!!(
+			m &&
+			(m.subscription ||
+				m.credentialType === "subscription" ||
+				m.credential_type === "subscription")
+		);
+	const upstreamOf = (m) => {
+		const accounts = (m.subscription && m.subscription.accounts) || m.accounts || [];
+		return m.upstream || (accounts[0] && accounts[0].upstream) || "openai";
+	};
+	const subUpstreams = new Set(list.filter(isSubscription).map(upstreamOf));
+	const hasNonSubscriptionModel = list.some((m) => m && !isSubscription(m));
+	if (subUpstreams.size >= 2 && !hasNonSubscriptionModel) {
+		return "A pool with 2+ subscription providers and no API-key-backed model has no backstop - if a subscription is rate-limited or drops, chat can stall. Add an API-key model as a fallback.";
+	}
+	return "";
+}
+
 // ---- provider id <-> label ------------------------------------------------
 // Ports jarvis_account.js's PROVIDER_LABEL_BY_ID / providerLabel() verbatim
 // (same ids, same labels) so the dropdown in the shared editor matches the

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -9,6 +9,7 @@ import {
 	buildCustomModels,
 	reorder,
 	validatePool,
+	poolBackstopWarning,
 } from "./pool.js";
 import { PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig } from "./pool.js";
 import { defaultSubscriptionModel, subModelSuggestions } from "./pool.js";
@@ -317,6 +318,146 @@ test("validatePool: Ollama/vLLM don't need a key (label or id, blank api_key)", 
 	assert.equal(
 		validatePool([{ provider: "openai", model: "gpt-5.5", api_key: "" }], null).ok,
 		false
+	);
+});
+test("poolBackstopWarning: fires for 2+ subscription models on distinct upstreams with no backstop", () => {
+	const models = [
+		{
+			provider: "OpenAI",
+			model: "gpt-5.5",
+			upstream: "openai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+		{
+			provider: "xAI Grok",
+			model: "grok-4.3",
+			upstream: "xai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+	];
+	assert.match(poolBackstopWarning(models), /backstop/i);
+});
+test("poolBackstopWarning: silent for 2 subscription models on the SAME upstream", () => {
+	// Failing over between two accounts on one upstream is still a real
+	// backstop, just not an api-key one - must NOT warn.
+	const models = [
+		{
+			provider: "OpenAI",
+			model: "gpt-5.5",
+			upstream: "openai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+		{
+			provider: "OpenAI",
+			model: "gpt-5.4",
+			upstream: "openai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+	];
+	assert.equal(poolBackstopWarning(models), "");
+});
+test("poolBackstopWarning: silent when an api-key model backstops 2 distinct-upstream subscriptions", () => {
+	const models = [
+		{
+			provider: "OpenAI",
+			model: "gpt-5.5",
+			upstream: "openai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+		{
+			provider: "xAI Grok",
+			model: "grok-4.3",
+			upstream: "xai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+		{ provider: "openai", model: "gpt-5.5", api_key: "k" },
+	];
+	assert.equal(poolBackstopWarning(models), "");
+});
+test("poolBackstopWarning: silent when a keyless local provider (Ollama/vLLM) backstops 2 distinct-upstream subscriptions", () => {
+	const models = [
+		{
+			provider: "OpenAI",
+			model: "gpt-5.5",
+			upstream: "openai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+		{
+			provider: "xAI Grok",
+			model: "grok-4.3",
+			upstream: "xai",
+			subscription: { rotation: "sticky", accounts: [] },
+		},
+		{ provider: "Ollama (local)", model: "llama3", api_key: "" },
+	];
+	assert.equal(poolBackstopWarning(models), "");
+});
+test("poolBackstopWarning: fires before any account is connected (pre-OAuth add-panel state)", () => {
+	// The whole point of #934: warn at the moment the SECOND subscription
+	// row exists, not after OAuth sign-in has already run - so this must
+	// fire off row.upstream alone, with zero accounts on either row.
+	const models = [
+		{
+			provider: "OpenAI",
+			model: "gpt-5.5",
+			upstream: "openai",
+			subscription: { accounts: [] },
+		},
+		{
+			provider: "xAI Grok",
+			model: "grok-4.3",
+			upstream: "xai",
+			subscription: { accounts: [] },
+		},
+	];
+	assert.notEqual(poolBackstopWarning(models), "");
+});
+test("poolBackstopWarning: tolerates raw editor-row shape (credentialType, no `subscription` object)", () => {
+	const rows = [
+		{
+			credentialType: "subscription",
+			provider: "",
+			model: "gpt-5.5",
+			upstream: "openai",
+			accounts: [],
+		},
+		{
+			credentialType: "subscription",
+			provider: "",
+			model: "grok-4.3",
+			upstream: "xai",
+			accounts: [],
+		},
+	];
+	assert.notEqual(poolBackstopWarning(rows), "");
+	assert.equal(
+		poolBackstopWarning([
+			...rows,
+			{ credentialType: "api_key", provider: "openai", model: "gpt-5.5" },
+		]),
+		""
+	);
+});
+test("poolBackstopWarning: a single subscription model never warns", () => {
+	assert.equal(
+		poolBackstopWarning([
+			{
+				provider: "OpenAI",
+				model: "gpt-5.5",
+				upstream: "openai",
+				subscription: { accounts: [] },
+			},
+		]),
+		""
+	);
+});
+test("poolBackstopWarning: an all-api-key pool never warns", () => {
+	assert.equal(
+		poolBackstopWarning([
+			{ provider: "openai", model: "gpt-5.5", api_key: "k" },
+			{ provider: "xai", model: "grok-4.3", api_key: "k" },
+		]),
+		""
 	);
 });
 test("effectiveApiKey: local providers get a placeholder only when blank and unsaved", () => {


### PR DESCRIPTION
Backport of #987 to `version-15`. Clean cherry-pick of the merged fix (already regression-tested + code-reviewed on develop).

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA