### PR TITLE
chore: backport automation smoke test (docs-only)

### DIFF
--- a/docs/backport-smoke.md
+++ b/docs/backport-smoke.md
@@ -1,0 +1,4 @@
+# Mergify backport smoke test
+
+Temporary file to verify that merging a `backport-version-*` labelled PR
+auto-creates the backport PR. Safe to delete once confirmed.


### PR DESCRIPTION
**Purpose:** verify Mergify auto-creates a backport PR when a `backport-version-*` labelled PR is merged into develop.

Docs-only change (`docs/backport-smoke.md`). Labelled `backport-version-15` + `backport-version-16`.

**When you merge this**, Mergify should auto-open two backport PRs (to version-15 and version-16). If it does — automation works. If nothing appears in ~2 min — the engine still isn't activated. Either way, safe to revert the doc file afterward.