### PR TITLE
feat(settings): add Rotate Agent Token button to Jarvis Settings (backport version-15)

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -97,6 +97,52 @@ frappe.ui.form.on("Jarvis Settings", {
 			__("Diagnostics")
 		);
 
+		// Rotates the plugin agent_token (X-Jarvis-Token / Boundary 6). Distinct
+		// from "Reset Agent Pairing" above, which resets the chat-device pairing
+		// (Boundary 5). Use this when tool calls fail plugin-auth with
+		// "invalid X-Jarvis-Token" or "agent_token expired".
+		frm.add_custom_button(
+			__("Rotate Agent Token"),
+			() => {
+				frappe.confirm(
+					__(
+						"Rotate the agent token? A fresh token is pushed to the container, which is briefly recreated (~10–30s downtime). Chat history and the device pairing are preserved. Use this if tool calls fail with an 'invalid X-Jarvis-Token' or 'agent_token expired' error."
+					),
+					() => {
+						frappe
+							.call({
+								method: "jarvis.api.rotate_agent_token",
+								freeze: true,
+								freeze_message: __(
+									"Rotating the agent token and recreating the container…"
+								),
+							})
+							.then((r) => {
+								const m = r.message || {};
+								if (m.ok) {
+									frappe.msgprint({
+										title: __("Agent Token Rotated"),
+										message: __("Rotated at: {0}", [
+											(m.data && m.data.rotated_at) || "(no timestamp)",
+										]),
+										indicator: "green",
+									});
+									frm.reload_doc();
+								} else {
+									const err = m.error || {};
+									frappe.msgprint({
+										title: __("Rotate Failed ({0})", [err.code || "error"]),
+										message: err.message || "unknown",
+										indicator: "red",
+									});
+								}
+							});
+					}
+				);
+			},
+			__("Diagnostics")
+		);
+
 		// Reset onboarding moved to the `bench reset-onboarding` CLI command
 		// (jarvis.commands); a destructive dev reset no longer belongs on the
 		// HTTP form.


### PR DESCRIPTION
## Summary

Adds a **Rotate Agent Token** button to Jarvis Settings → Diagnostics (tenant Desk), giving operators one-click recovery for plugin agent-token drift (X-Jarvis-Token / Boundary 6).

When `call_tool` fails plugin-auth with `invalid X-Jarvis-Token` or `agent_token expired`, the customer can still chat but every tool call 401s. Until now the only fix was `bench --site <tenant> execute jarvis.api.rotate_agent_token` or the raw API — not reachable from the UI.

## How

- New button in the **existing Diagnostics group**, placed after **Reset Agent Pairing** (the *different* device-pairing recovery — Boundary 5, not to be confused with this token rotation).
- A confirm dialog spells out the ~10–30s container recreate and that **chat history and device pairing are preserved**.
- Calls the **existing** `jarvis.api.rotate_agent_token` (System Manager only; orchestrates admin → fleet-agent → container recreate with rollback). **No backend change** — purely the missing UI affordance.
- Green/red `msgprint` on the result; reloads the form on success.

## Scope

Single file, +46 lines (`jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js`). No conflict with the trunk (it hasn't touched this file). Backport branches `backport/rotate-agent-token-button-version-15` and `-version-16` are already pushed.

## Verification

Verified in-browser on `jarvis.local` Desk: the button renders in the Diagnostics dropdown and the confirm dialog shows the correct copy. No automated test (Desk client-side button wiring; behavior is exercised through the existing `rotate_agent_token` backend, which is covered on the admin side).

## Related

Completes the operator/tenant recovery surface for agent-token drift:
- **jarvis-admin-v2 #444** — operator "Resync agent token" (fleet console / Jarvis Tenant form)
- **jarvis-admin-v2 #445** — cold-path token carry-over (prevention)
- **jarvis #993** — bench self-heal on readiness (already shipped)