### PR TITLE
fix(tests): unbreak test_llm_key_probe after #388 (develop is red)

### DIFF
--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -469,10 +469,16 @@ class TestProbeWithAStoredKey(_RT3SettingsTestCase):
 		row.api_key = self.STORED
 		row.base_url = "https://api.openai.com/v1"
 		settings.append("models", row)
-		with (
-			mock.patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
-			mock.patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "creds_update"}),
-		):
+		# #388: _sync_via_admin now RE-RAISES a genuine AdminAuthError instead of
+		# swallowing it. Mocking only the two leaf HTTP calls (post_update_llm_pool /
+		# post_update_llm_creds) isn't enough: depending on what a prior test left in
+		# the legacy llm_provider/model/base_url mirror, this save's classifier can
+		# come out "reload" instead of "restart" - and "reload" calls the UNMOCKED
+		# post_rotate_llm_secret, which hits the real (not-onboarded-on-CI)
+		# admin_client._authenticated_post and raises. Mock the whole dispatcher, the
+		# same way TestOnUpdateClassification does: this class tests the key-probe
+		# endpoint, not admin sync, so neither leg should ever touch the network.
+		with mock.patch.object(type(settings), "_sync_via_admin"):
 			settings.save()
 		frappe.db.commit()
 		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")


### PR DESCRIPTION
## Summary
Develop CI is red: every test in `TestProbeWithAStoredKey` (jarvis.tests.test_llm_key_probe) ERRORs with `AdminAuthError: not onboarded`. This unbreaks it.

**Cause:** the class's `setUp` saves Jarvis Settings while mocking only the *restart*-leg leaf calls (`post_update_llm_pool`/`post_update_llm_creds`). Depending on prior test state the classifier picks the *reload* leg, whose **unmocked** `post_rotate_llm_secret` hits the real admin client and raises `AdminAuthError` on CI's fresh not-onboarded DB. Post-#388 that error re-raises (instead of being swallowed), so `setUp` dies. Doesn't reproduce locally because `site.jarvis` is onboarded.

**Fix:** mock the whole `_sync_via_admin` dispatcher during the save — the same pattern `TestOnUpdateClassification` already uses. Test-fixture-only; no product change; asserts unchanged.

<details><summary>Scope</summary>
Audited every `setUp`/`setUpClass` in `jarvis/tests/` — `TestProbeWithAStoredKey` is the only one that `.save()`s Jarvis Settings, so no other test file needs this. #388 itself doesn't over-reach.
</details>

Note: the #388 backports (#999 → version-16, #1006 → version-15) are red for the same reason and will get this fix too.

https://claude.ai/code/session_01HpbkcUnbmLZCH2ohy2q1pA