### PR TITLE
chat: make the egress redactor remove-only (drop the dead rename mach…

### DIFF
--- a/jarvis/chat/egress_redact.py
+++ b/jarvis/chat/egress_redact.py
@@ -1,31 +1,38 @@
 """Generic outbound-text redactor for the chat egress path.
 
-Scrubs a CONFIGURED set of patterns out of the agent's reply before it reaches
-the customer: brand-family matches become the tenant's whitelabel name, others
-are dropped. This module INTENTIONALLY carries no patterns of its own - the rules
-are supplied by the caller (sourced from control-plane config in a later slice),
-so it names nothing and reveals nothing even when the app is read publicly.
+Scrubs a CONFIGURED set of patterns out of the agent's reply before it reaches the
+customer: every match is DROPPED (removed). This module INTENTIONALLY carries no
+patterns of its own - the rules are supplied by the caller (sourced from
+control-plane config), so it names nothing and reveals nothing even when the app is
+read publicly. (An earlier version also supported a "rename the match to the
+tenant's whitelabel name" mode; a staging red-team showed renaming MISLABELS rather
+than protects - a "<brand> <version>" banner became "<whitelabel> <version>", so the
+version leaked, just relabelled - so the redactor is now REMOVE-ONLY. The
+conversational brand case
+is owned by the persona; see egress_rules / the control-plane _egress_patterns.)
 
 It runs on the chat delivery hot path, so it is TOTAL and FAIL-OPEN: any internal
 error returns the input unchanged - it never raises and never drops a reply.
 
-Patterns are OPERATOR-authored (control-plane config), not customer/attacker
-input, so they are trusted to be simple and anchored. ``compile_rules`` still
-rejects uncompilable, empty-matchable (would insert at every position), and
-unknown-mode rules defensively. A catastrophic-backtracking (ReDoS) pattern would
-still hang - the stdlib ``re`` has no timeout - so keep configured patterns
-literal/anchored; that residual is accepted given patterns are operator-controlled."""
+Patterns are OPERATOR-authored (control-plane config), not customer/attacker input,
+so they are trusted to be simple and anchored. ``compile_rules`` still rejects
+uncompilable, empty-matchable (would match at every position), and non-remove rules
+defensively. A catastrophic-backtracking (ReDoS) pattern would still hang - the
+stdlib ``re`` has no timeout - so keep configured patterns literal/anchored; that
+residual is accepted given patterns are operator-controlled."""
 
 from __future__ import annotations
 
 import re
 
-#: Fallback replacement when the tenant has no whitelabel name (or it is unsafe).
-_DEFAULT_REPLACEMENT = "Jarvis"
+#: The only rule mode: drop the match entirely. A rule whose mode is anything else
+#: is skipped by compile_rules - the redactor never renames.
+MODE_REMOVE = "remove"
 
-#: Rule modes.
-MODE_NAME = "name"  # replace the match with the whitelabel name
-MODE_REMOVE = "remove"  # drop the match entirely
+#: A non-empty, name-free placeholder delivered when redaction would ENTIRELY empty
+#: a non-empty message (see the INVARIANT in redact_egress). Never a tenant name -
+#: this module names nothing.
+_COLLAPSED_PLACEHOLDER = "…"
 
 #: Bound on the redaction fixpoint (below): re-run the rules until the text stops
 #: changing, but never more than this many passes so a pathological rule set can't
@@ -34,72 +41,65 @@ _MAX_PASSES = 5
 
 
 def compile_rules(raw_rules) -> list:
-	"""Compile ``[(pattern_str, mode), ...]`` into ``[(compiled_regex, mode), ...]``.
+	"""Compile ``[(pattern_str, mode), ...]`` into ``[compiled_regex, ...]``.
 
 	A rule is SKIPPED (never fatal, so one bad config entry can't disable the whole
-	redactor) when its pattern does not compile, when its mode is unknown, or when
-	it can match the EMPTY string (which would otherwise insert the replacement at
-	every position and corrupt the reply). The empty-match check catches literal
-	zero-width patterns (e.g. ``a*``) but not a pure lookaround (``(?<=x)``); those
-	are accepted under the operator-authored trust model (patterns are code-reviewed
-	control-plane config, never customer input)."""
+	redactor) when its pattern does not compile, when its mode is not ``remove`` (the
+	redactor never renames, so a non-remove rule is dropped rather than applied), or
+	when it can match the EMPTY string (which would otherwise match at every position
+	and corrupt the reply). The empty-match check catches literal zero-width patterns
+	(e.g. ``a*``) but not a pure lookaround (``(?<=x)``); those are accepted under the
+	operator-authored trust model (patterns are code-reviewed control-plane config,
+	never customer input)."""
 	compiled = []
 	# Tolerate a non-list raw_rules (a malformed cache blob) without raising here —
 	# a truthy non-iterable would otherwise blow up the whole compile.
 	for entry in raw_rules if isinstance(raw_rules, (list, tuple)) else []:
 		try:
 			pattern, mode = entry
-			if mode not in (MODE_NAME, MODE_REMOVE):
+			if mode != MODE_REMOVE:  # remove-only; a non-remove rule is skipped, never applied
 				continue
 			rx = re.compile(pattern, re.IGNORECASE)
-			if rx.search(""):  # empty-matchable -> would splice the name everywhere
+			if rx.search(""):  # empty-matchable -> would match at every position
 				continue
-			compiled.append((rx, mode))
+			compiled.append(rx)
 		except Exception:
 			continue
 	return compiled
 
 
-def redact_egress(text, rules, replacement=None):
-	"""Apply ``rules`` (``[(compiled_regex, mode), ...]``) to ``text``.
+def redact_egress(text, rules):
+	"""Apply ``rules`` (``[compiled_regex, ...]``) to ``text``, DROPPING every match.
 
 	Returns ``(redacted_text, hit)`` where ``hit`` is True iff the text actually
 	changed (the caller's tripwire reads ``hit``; computed by comparison, not by a
-	match count, so a replace-with-same-value never fires a spurious tripwire).
-	INVARIANT: a non-empty input never returns empty — content that reduces entirely
-	to nothing falls back to the whitelabel name (see below), so a delivered message
-	is never blanked by redaction.
+	match count, so an unchanged text never fires a spurious tripwire). INVARIANT: a
+	non-empty input never returns empty — content that reduces entirely to nothing
+	falls back to a name-free placeholder (see below), so a delivered message is
+	never blanked by redaction.
 
-	TOTAL / FAIL-OPEN: any error returns ``(text, False)`` unchanged - a redactor
-	bug must never break message delivery on the hot path. The match is inserted via
-	a CALLABLE replacement, so a ``replacement`` carrying regex-replacement
-	metacharacters (``\\1``, ``\\g<0>``, a lone backslash) is written LITERALLY. The
-	rules are re-run to a bounded fixpoint because a REMOVE rule can splice text into
-	a NEW match an earlier rule would have caught - one pass is not enough to
-	guarantee no brand token survives, and re-running is what makes
-	``redact(redact(x)) == redact(x)``. A whitelabel ``replacement`` that itself
-	trips a rule is swapped for a rule-safe default so it can't compound."""
+	TOTAL / FAIL-OPEN: any error returns ``(text, False)`` unchanged - a redactor bug
+	must never break message delivery on the hot path. The rules are re-run to a
+	bounded fixpoint because dropping a match can splice text into a NEW match an
+	earlier rule would have caught - one pass is not enough to guarantee no token
+	survives, and re-running is what makes ``redact(redact(x)) == redact(x)``."""
 	try:
 		if not isinstance(text, str) or not text or not rules:
 			return (text, False)
-		name = str(replacement or "").strip() or _DEFAULT_REPLACEMENT
-		if any(compiled.search(name) for compiled, _mode in rules):
-			name = _DEFAULT_REPLACEMENT
 		out = text
 		for _ in range(_MAX_PASSES):
 			before = out
-			for compiled, mode in rules:
-				repl = "" if mode == MODE_REMOVE else name
-				out = compiled.sub(lambda _m, r=repl: r, out)
+			for compiled in rules:
+				out = compiled.sub("", out)
 			if out == before:
 				break
 		# INVARIANT: a non-empty input never collapses to nothing. A reply / error /
-		# recovered text that was ENTIRELY brand tokens (a lone glyph, a bare brand
-		# URL) would otherwise blank the chat card and, on the recovery path, be read
-		# as "no output yet" and hang the turn to a false timeout. Substitute the
-		# whitelabel name so the message stays non-empty.
+		# recovered text that was ENTIRELY removable tokens (a lone glyph, a bare brand
+		# URL) would otherwise blank the chat card and, on the recovery path, be read as
+		# "no output yet" and hang the turn to a false timeout. Substitute a name-free
+		# placeholder so the message stays non-empty.
 		if text.strip() and not out.strip():
-			out = name
+			out = _COLLAPSED_PLACEHOLDER
 		return (out, out != text)
 	except Exception:
 		return (text, False)

--- a/jarvis/chat/egress_rules.py
+++ b/jarvis/chat/egress_rules.py
@@ -27,10 +27,6 @@ _SYNCED_AT_FIELD = "redaction_patterns_synced_at"
 #: changes) rather than served stale, while an unchanged blob skips recompilation.
 _MEMO_ATTR = "jarvis_egress_rules_memo"
 
-#: Fallback replacement when the tenant has set no white-label agent name. Matches
-#: the ``agent_name … or "Jarvis"`` resolution used elsewhere (e.g. pwa.py).
-_DEFAULT_NAME = "Jarvis"
-
 
 def persist(patterns) -> None:
 	"""Mirror the CP-sent redaction patterns onto Jarvis Settings.
@@ -90,7 +86,7 @@ def _invalidate_memo() -> None:
 
 
 def get_rules() -> list:
-	"""Compiled ``[(regex, mode), ...]`` from the cached CP patterns.
+	"""Compiled ``[regex, ...]`` (remove-only) from the cached CP patterns.
 
 	Returns ``[]`` when nothing is cached or on ANY error — fail-open: a redactor
 	that cannot load its rules must not break chat, and an empty rule set makes
@@ -112,22 +108,13 @@ def get_rules() -> list:
 		return []
 
 
-def get_replacement_name() -> str:
-	"""The tenant's white-label agent name, or ``"Jarvis"`` — the token the
-	brand-family rules replace matches with. Never raises."""
-	try:
-		return (frappe.db.get_single_value(SETTINGS, "agent_name", cache=True) or "").strip() or _DEFAULT_NAME
-	except Exception:
-		return _DEFAULT_NAME
-
-
 def redact(text):
 	"""Scrub the cached brand-family rules out of ``text`` and return the cleaned
 	text (dropping the tripwire signal). For the streaming / tool-title / error
 	boundaries that must not raise per frame. Total / fail-open: returns ``text``
 	unchanged on any error, and is a fast no-op when no rules are cached."""
 	try:
-		out, _hit = egress_redact.redact_egress(text, get_rules(), get_replacement_name())
+		out, _hit = egress_redact.redact_egress(text, get_rules())
 		return out
 	except Exception:
 		return text
@@ -152,7 +139,7 @@ def redact_and_flag(text, *, conversation=None, run_id=None):
 	try:
 		if not isinstance(text, str) or not text:
 			return text
-		out, hit = egress_redact.redact_egress(text, get_rules(), get_replacement_name())
+		out, hit = egress_redact.redact_egress(text, get_rules())
 		if hit:
 			_fire_tripwire(conversation=conversation, run_id=run_id)
 		return out

--- a/jarvis/tests/test_egress_redact.py
+++ b/jarvis/tests/test_egress_redact.py
@@ -1,139 +1,111 @@
-"""Tests for jarvis.chat.egress_redact - the generic outbound-text redactor.
+"""Tests for jarvis.chat.egress_redact - the generic REMOVE-ONLY outbound-text redactor.
 
-Deliberately uses a NEUTRAL fake brand ("acmebot" / an emoji / a fake env var)
-as the sample patterns, never the real runtime name: the module is generic and
-the real patterns arrive from control-plane config, so nothing in the app repo -
-source OR tests - names the runtime.
+Deliberately uses a NEUTRAL fake brand ("acmebot" / an emoji / a fake env var) as
+the sample patterns, never the real runtime name: the module is generic and the
+real patterns arrive from control-plane config, so nothing in the app repo - source
+OR tests - names the runtime.
 """
 
 import re
 import unittest
 
-from jarvis.chat.egress_redact import MODE_NAME, MODE_REMOVE, compile_rules, redact_egress
+from jarvis.chat.egress_redact import (
+	_COLLAPSED_PLACEHOLDER,
+	MODE_REMOVE,
+	compile_rules,
+	redact_egress,
+)
 
 
-def _rules(*specs):
-	return [(re.compile(p, re.IGNORECASE), m) for p, m in specs]
+def _rules(*patterns):
+	"""Build the redactor's rule shape: a list of compiled regexes (remove-only)."""
+	return [re.compile(p, re.IGNORECASE) for p in patterns]
 
 
 class TestRedactEgress(unittest.TestCase):
-	def test_name_mode_replaces_with_whitelabel(self):
-		out, hit = redact_egress("running on Acmebot v2", _rules((r"acmebot", MODE_NAME)), "Jarvis")
-		self.assertEqual(out, "running on Jarvis v2")
-		self.assertTrue(hit)
-
-	def test_remove_mode_drops_match(self):
-		rules = _rules((r"🤖", MODE_REMOVE), (r"ACMEBOT_[A-Z]+", MODE_REMOVE))
-		out, hit = redact_egress("status 🤖 ACMEBOT_TOKEN done", rules, "Jarvis")
+	def test_remove_drops_every_match(self):
+		rules = _rules(r"🤖", r"ACMEBOT_[A-Z]+", r"acmebot")
+		out, hit = redact_egress("status 🤖 ACMEBOT_TOKEN for acmebot done", rules)
 		self.assertNotIn("🤖", out)
 		self.assertNotIn("ACMEBOT_TOKEN", out)
+		self.assertNotIn("acmebot", out.lower())
 		self.assertTrue(hit)
 
 	def test_no_match_returns_hit_false(self):
-		out, hit = redact_egress("a perfectly clean reply", _rules((r"acmebot", MODE_NAME)), "Jarvis")
+		out, hit = redact_egress("a perfectly clean reply", _rules(r"acmebot"))
 		self.assertEqual(out, "a perfectly clean reply")
 		self.assertFalse(hit)
 
 	def test_fail_open_on_non_str_input(self):
-		rules = _rules((r"acmebot", MODE_NAME))
-		self.assertEqual(redact_egress(None, rules, "Jarvis"), (None, False))
-		self.assertEqual(redact_egress(123, rules, "Jarvis"), (123, False))
-		self.assertEqual(redact_egress("", rules, "Jarvis"), ("", False))
+		rules = _rules(r"acmebot")
+		self.assertEqual(redact_egress(None, rules), (None, False))
+		self.assertEqual(redact_egress(123, rules), (123, False))
+		self.assertEqual(redact_egress("", rules), ("", False))
 
 	def test_fail_open_when_a_rule_raises(self):
 		class Exploding:
 			def sub(self, *a, **k):
 				raise RuntimeError("boom")
 
-			def search(self, *a, **k):
-				return None
-
-		out, hit = redact_egress("acmebot here", [(Exploding(), MODE_NAME)], "Jarvis")
+		out, hit = redact_egress("acmebot here", [Exploding()])
 		self.assertEqual((out, hit), ("acmebot here", False))
 
-	def test_remove_rule_reconstruction_is_scrubbed(self):
-		# A REMOVE rule can splice text into a match an EARLIER rule would have
-		# caught: removing "XX" turns "acmeXXbot" into "acmebot". A single pass would
-		# ship that brand token; the bounded fixpoint re-runs and drops it.
-		rules = _rules((r"acmebot", MODE_REMOVE), (r"XX", MODE_REMOVE))
-		out, hit = redact_egress("acmeXXbot", rules, "Jarvis")
+	def test_remove_reconstruction_is_scrubbed(self):
+		# Removing "XX" turns "acmeXXbot" into "acmebot" - a match an EARLIER rule would
+		# have caught. A single pass would ship that token; the bounded fixpoint re-runs.
+		rules = _rules(r"acmebot", r"XX")
+		out, hit = redact_egress("acmeXXbot", rules)
 		self.assertNotIn("acmebot", out)
 		self.assertTrue(hit)
 
-	def test_hit_is_false_when_text_is_unchanged(self):
-		# A MODE_NAME match that already equals the name changes nothing; `hit` must
-		# be False (it feeds a tripwire - a match-count-based hit would be spurious).
-		rules = _rules((r"Jarvis", MODE_NAME))
-		out, hit = redact_egress("hello Jarvis", rules, "Jarvis")
-		self.assertEqual(out, "hello Jarvis")
-		self.assertFalse(hit)
+	def test_idempotent(self):
+		# redact(redact(x)) == redact(x)
+		rules = _rules(r"acmebot")
+		once, _ = redact_egress("on acmebot now", rules)
+		twice, _ = redact_egress(once, rules)
+		self.assertEqual(once, twice)
+		self.assertNotIn("acmebot", once.lower())
 
 	def test_compile_rules_skips_empty_matchable(self):
-		# An empty-matchable pattern ("a*") would splice the name at every position;
-		# it must be dropped so only the real token ("valid") is scrubbed.
-		compiled = compile_rules([("a*", MODE_NAME), ("valid", MODE_NAME)])
+		# An empty-matchable pattern ("a*") would match at every position; it must be
+		# dropped so only the real token ("valid") is scrubbed.
+		compiled = compile_rules([["a*", MODE_REMOVE], ["valid", MODE_REMOVE]])
 		self.assertEqual(len(compiled), 1)
-		out, _ = redact_egress("aaa valid aaa", compiled, "J")
-		self.assertEqual(out, "aaa J aaa")  # 'aaa' survived; only 'valid' -> 'J'
+		out, _ = redact_egress("aaa valid aaa", compiled)
+		self.assertEqual(out, "aaa  aaa")  # 'aaa' survived; only 'valid' removed
 
-	def test_compile_rules_skips_unknown_mode(self):
-		compiled = compile_rules([("valid", "delete"), ("valid2", MODE_NAME)])
+	def test_compile_rules_skips_non_remove_mode(self):
+		# Remove-only: any non-`remove` mode (including the RETIRED "name" rename mode)
+		# is skipped, not applied - a future CP rename rule is dropped rather than
+		# silently removing text the operator meant to relabel.
+		compiled = compile_rules([["a", "name"], ["b", "delete"], ["c", MODE_REMOVE]])
 		self.assertEqual(len(compiled), 1)
-
-	def test_injection_safe_replacement(self):
-		# A replacement carrying regex-replacement metacharacters must be inserted
-		# LITERALLY (callable replacement), never parsed as a backreference/group.
-		rules = _rules((r"acmebot", MODE_NAME))
-		out, hit = redact_egress("acmebot", rules, r"\1")
-		self.assertEqual(out, r"\1")
-		self.assertTrue(hit)
-		out2, _ = redact_egress("acmebot", rules, "a\\b\\g<0>")
-		self.assertEqual(out2, "a\\b\\g<0>")
-
-	def test_blank_replacement_falls_back(self):
-		rules = _rules((r"acmebot", MODE_NAME))
-		self.assertEqual(redact_egress("acmebot", rules, "")[0], "Jarvis")
-		self.assertEqual(redact_egress("acmebot", rules, None)[0], "Jarvis")
-
-	def test_idempotent_normal_replacement(self):
-		rules = _rules((r"acmebot", MODE_NAME))
-		once, _ = redact_egress("on acmebot now", rules, "Jarvis")
-		twice, _ = redact_egress(once, rules, "Jarvis")
-		self.assertEqual(once, twice)
-
-	def test_idempotent_with_brand_like_replacement(self):
-		# If the whitelabel name itself trips a rule, reusing it would COMPOUND on a
-		# second pass - the redactor must fall back to a rule-safe name.
-		rules = _rules((r"acme", MODE_NAME))
-		once, _ = redact_egress("acme runtime", rules, "acme-agent")
-		twice, _ = redact_egress(once, rules, "acme-agent")
-		self.assertEqual(once, twice)
-		self.assertNotIn("acme", once.lower())  # the brand-like name did not survive
 
 	def test_compile_rules_skips_uncompilable(self):
-		compiled = compile_rules([("valid", MODE_NAME), ("[unterminated", MODE_REMOVE)])
+		compiled = compile_rules([["valid", MODE_REMOVE], ["[unterminated", MODE_REMOVE]])
 		self.assertEqual(len(compiled), 1)
-		out, hit = redact_egress("valid here", compiled, "Jarvis")
+		_out, hit = redact_egress("valid here", compiled)
 		self.assertTrue(hit)
 
-	def test_full_removal_falls_back_to_name(self):
-		# INVARIANT: a non-empty input never collapses to empty. A reply that is
-		# ENTIRELY remove-match content (a lone glyph / a bare env token) falls back
-		# to the replacement name instead of "" (else the card blanks / recovery hangs).
-		rules = _rules((r"🦞", MODE_REMOVE), (r"ACMEBOT_[A-Z]+", MODE_REMOVE))
-		out, hit = redact_egress("🦞", rules, "Jarvis")
-		self.assertEqual(out, "Jarvis")
+	def test_full_removal_falls_back_to_placeholder(self):
+		# INVARIANT: a non-empty input never collapses to empty. A reply that is ENTIRELY
+		# remove-match content (a lone glyph / a bare env token) falls back to a name-free
+		# placeholder instead of "" (else the card blanks / recovery hangs to a false timeout).
+		rules = _rules(r"🦞", r"ACMEBOT_[A-Z]+")
+		out, hit = redact_egress("🦞", rules)
+		self.assertEqual(out, _COLLAPSED_PLACEHOLDER)
 		self.assertTrue(hit)
-		self.assertEqual(redact_egress("ACMEBOT_TOKEN", rules, "Jarvis")[0], "Jarvis")
-		# whitespace around a removed token also collapses -> name (never a blank card)
-		self.assertEqual(redact_egress("🦞   ", rules, "Jarvis")[0], "Jarvis")
+		self.assertEqual(redact_egress("ACMEBOT_TOKEN", rules)[0], _COLLAPSED_PLACEHOLDER)
+		# whitespace around a removed token also collapses -> placeholder (never a blank card)
+		self.assertEqual(redact_egress("🦞   ", rules)[0], _COLLAPSED_PLACEHOLDER)
+
+	def test_collapse_placeholder_names_nothing(self):
+		# The placeholder must NOT be a tenant/agent name - this module names nothing.
+		self.assertNotIn("jarvis", _COLLAPSED_PLACEHOLDER.lower())
 
 	def test_empty_input_stays_empty(self):
 		# The no-collapse invariant applies only to non-empty input; "" stays "".
-		self.assertEqual(redact_egress("", _rules((r"acme", MODE_NAME)), "Jarvis"), ("", False))
-
-	def test_whitespace_only_replacement_falls_back(self):
-		self.assertEqual(redact_egress("acmebot", _rules((r"acmebot", MODE_NAME)), "   ")[0], "Jarvis")
+		self.assertEqual(redact_egress("", _rules(r"acme")), ("", False))
 
 	def test_compile_rules_tolerates_non_list(self):
 		# A corrupt cache blob (non-iterable) must not raise out of compile_rules.

--- a/jarvis/tests/test_egress_rules.py
+++ b/jarvis/tests/test_egress_rules.py
@@ -4,7 +4,7 @@ control-plane-owned egress redaction rules.
 Uses a NEUTRAL fake brand ("acme") for the sample patterns — the real patterns
 arrive from the control plane, so nothing in the app repo (source or tests) names
 the runtime. Exercises the cache round-trip, fail-open behaviour, per-request
-memoization, and the replacement-name resolution.
+memoization, and the remove-only apply wrappers.
 """
 
 from unittest.mock import patch
@@ -32,38 +32,38 @@ class TestPersist(FrappeTestCase):
 		egress_rules._invalidate_memo()
 
 	def test_stores_blob_and_stamps_synced_at(self):
-		egress_rules.persist([["acme", "name"]])
+		egress_rules.persist([["acme", "remove"]])
 		blob = frappe.db.get_single_value(SETTINGS, _PATTERNS_FIELD)
-		self.assertEqual(frappe.parse_json(blob), [["acme", "name"]])
+		self.assertEqual(frappe.parse_json(blob), [["acme", "remove"]])
 		self.assertIsNotNone(frappe.db.get_single_value(SETTINGS, _SYNCED_AT_FIELD))
 
 	def test_skips_write_when_unchanged(self):
-		egress_rules.persist([["acme", "name"]])
+		egress_rules.persist([["acme", "remove"]])
 		# A repeat of the identical list must not touch the row — churning `modified`
 		# would collide with an operator editing the Settings form, and this runs on
 		# every connection poll.
 		with patch.object(frappe.db, "set_value", wraps=frappe.db.set_value) as sv:
-			egress_rules.persist([["acme", "name"]])
+			egress_rules.persist([["acme", "remove"]])
 			sv.assert_not_called()
 
 	def test_none_keeps_last_known_good(self):
 		# A degraded/old CP payload omits the key -> persist(None) must NOT wipe a
 		# working backstop; it keeps the last-known-good list.
-		egress_rules.persist([["acme", "name"]])
+		egress_rules.persist([["acme", "remove"]])
 		egress_rules.persist(None)
 		self.assertEqual(
-			frappe.parse_json(frappe.db.get_single_value(SETTINGS, _PATTERNS_FIELD)), [["acme", "name"]]
+			frappe.parse_json(frappe.db.get_single_value(SETTINGS, _PATTERNS_FIELD)), [["acme", "remove"]]
 		)
 
 	def test_explicit_empty_list_clears(self):
 		# The deliberate kill-switch: an explicit [] (CP blanked the constant) clears.
-		egress_rules.persist([["acme", "name"]])
+		egress_rules.persist([["acme", "remove"]])
 		egress_rules.persist([])
 		self.assertEqual(frappe.parse_json(frappe.db.get_single_value(SETTINGS, _PATTERNS_FIELD)), [])
 
 	def test_never_raises(self):
 		with patch.object(frappe.db, "set_value", side_effect=RuntimeError("boom")):
-			egress_rules.persist([["acme", "name"]])  # fail-open: no exception escapes
+			egress_rules.persist([["acme", "remove"]])  # fail-open: no exception escapes
 
 
 class TestGetRules(FrappeTestCase):
@@ -71,7 +71,7 @@ class TestGetRules(FrappeTestCase):
 		egress_rules._invalidate_memo()
 
 	def test_returns_compiled_rules(self):
-		_set_raw(frappe.as_json([["acme", "name"], [_LOBSTER, "remove"]]))
+		_set_raw(frappe.as_json([["acme", "remove"], [_LOBSTER, "remove"]]))
 		self.assertEqual(len(egress_rules.get_rules()), 2)
 
 	def test_empty_when_nothing_cached(self):
@@ -90,49 +90,36 @@ class TestGetRules(FrappeTestCase):
 		# 'acme' + 'ok' valid; '[unterminated' uncompilable; 'a*' empty-matchable —
 		# the last two are dropped by compile_rules, never fatal to the whole set.
 		_set_raw(
-			frappe.as_json([["acme", "name"], ["[unterminated", "remove"], ["a*", "name"], ["ok", "remove"]])
+			frappe.as_json(
+				[["acme", "remove"], ["[unterminated", "remove"], ["a*", "remove"], ["ok", "remove"]]
+			)
 		)
 		self.assertEqual(len(egress_rules.get_rules()), 2)
 
 	def test_memoized_until_blob_changes(self):
-		_set_raw(frappe.as_json([["acme", "name"]]))
+		_set_raw(frappe.as_json([["acme", "remove"]]))
 		first = egress_rules.get_rules()
 		self.assertIs(egress_rules.get_rules(), first)  # same object -> compile memoized
-		_set_raw(frappe.as_json([["acme", "name"], ["beta", "remove"]]))
+		_set_raw(frappe.as_json([["acme", "remove"], ["beta", "remove"]]))
 		second = egress_rules.get_rules()
 		self.assertIsNot(second, first)  # blob changed -> recompiled
 		self.assertEqual(len(second), 2)
-
-
-class TestReplacementName(FrappeTestCase):
-	def _set_agent_name(self, value):
-		frappe.db.set_value(SETTINGS, SETTINGS, "agent_name", value, update_modified=False)
-		frappe.clear_document_cache(SETTINGS, SETTINGS)
-
-	def test_default_when_unset(self):
-		self._set_agent_name("")
-		self.assertEqual(egress_rules.get_replacement_name(), "Jarvis")
-
-	def test_uses_trimmed_agent_name(self):
-		self._set_agent_name("  Acme Bot  ")
-		self.assertEqual(egress_rules.get_replacement_name(), "Acme Bot")
 
 
 class TestRedact(FrappeTestCase):
 	def setUp(self):
 		egress_rules._invalidate_memo()
 
-	def test_redacts_with_cached_rules_and_name(self):
-		_set_raw(frappe.as_json([["acme", "name"]]))
-		frappe.db.set_value(SETTINGS, SETTINGS, "agent_name", "", update_modified=False)
-		frappe.clear_document_cache(SETTINGS, SETTINGS)
-		self.assertEqual(egress_rules.redact("run on acme now"), "run on Jarvis now")
+	def test_redacts_with_cached_rules(self):
+		# Remove-only: a matched token is DROPPED (not renamed).
+		_set_raw(frappe.as_json([["acme", "remove"]]))
+		self.assertEqual(egress_rules.redact("run on acme now"), "run on  now")
 
 	def test_noop_when_no_rules_cached(self):
 		_set_raw("")
 		self.assertEqual(egress_rules.redact("run on acme now"), "run on acme now")
 
 	def test_failopen_on_non_str(self):
-		_set_raw(frappe.as_json([["acme", "name"]]))
+		_set_raw(frappe.as_json([["acme", "remove"]]))
 		self.assertEqual(egress_rules.redact(None), None)
 		self.assertEqual(egress_rules.redact(123), 123)

--- a/jarvis/tests/test_egress_wiring.py
+++ b/jarvis/tests/test_egress_wiring.py
@@ -25,12 +25,11 @@ from jarvis.chat.settlement import _error_text
 from jarvis.chat.turn_recovery import _latest_assistant_text
 
 _LOBSTER = "\U0001f99e"
-_RULES = [["acme", "name"], [_LOBSTER, "remove"]]
+_RULES = [["acme", "remove"], [_LOBSTER, "remove"]]
 
 
 def _cache_rules(rules=_RULES):
 	frappe.db.set_value(SETTINGS, SETTINGS, _PATTERNS_FIELD, frappe.as_json(rules), update_modified=False)
-	frappe.db.set_value(SETTINGS, SETTINGS, "agent_name", "", update_modified=False)  # -> "Jarvis"
 	frappe.clear_document_cache(SETTINGS, SETTINGS)
 	egress_rules._invalidate_memo()
 
@@ -41,16 +40,16 @@ class TestParseEventRedaction(FrappeTestCase):
 
 	def test_assistant_text_and_delta_redacted(self):
 		out = parse_event({"stream": "assistant", "data": {"text": "on acme", "delta": "acme"}})
-		self.assertEqual(out["text"], "on Jarvis")
-		self.assertEqual(out["delta"], "Jarvis")
+		self.assertEqual(out["text"], "on ")
+		self.assertEqual(out["delta"], "…")
 
 	def test_tool_title_redacted(self):
 		out = parse_event({"stream": "item", "data": {"kind": "tool", "title": "run acme now"}})
-		self.assertEqual(out["tool_title"], "run Jarvis now")
+		self.assertEqual(out["tool_title"], "run  now")
 
 	def test_lifecycle_error_redacted(self):
 		out = parse_event({"stream": "lifecycle", "data": {"phase": "error", "error": "acme failed"}})
-		self.assertEqual(out["error"], "Jarvis failed")
+		self.assertEqual(out["error"], " failed")
 
 	def test_no_rules_is_passthrough(self):
 		_cache_rules([])
@@ -117,7 +116,7 @@ class TestFinalCallSiteRedaction(FrappeTestCase):
 			mux.dispatch()
 		kind, payload = rec.terminal
 		self.assertEqual(kind, "relay:final")
-		self.assertEqual(payload["text"], "on Jarvis")
+		self.assertEqual(payload["text"], "on ")
 		fire.assert_called_once()
 		self.assertEqual(fire.call_args.kwargs.get("run_id"), "run-xyz")  # OP#4 transcript pointer
 
@@ -130,7 +129,7 @@ class TestFinalCallSiteRedaction(FrappeTestCase):
 		mux.dispatch()
 		kind, payload = rec.terminal
 		self.assertEqual(kind, "relay:error")
-		self.assertEqual(payload["error"], "Jarvis failed")
+		self.assertEqual(payload["error"], " failed")
 
 
 class TestRecoveryRedaction(FrappeTestCase):
@@ -140,27 +139,27 @@ class TestRecoveryRedaction(FrappeTestCase):
 	def test_recovery_string_content_redacted_and_flagged(self):
 		msgs = [{"role": "assistant", "content": "recovered acme"}]
 		with patch.object(egress_rules, "_fire_tripwire") as fire:
-			self.assertEqual(_latest_assistant_text(msgs), "recovered Jarvis")
+			self.assertEqual(_latest_assistant_text(msgs), "recovered ")
 			fire.assert_called_once()
 
 	def test_recovery_block_list_redacted(self):
 		msgs = [{"role": "assistant", "content": [{"type": "text", "text": "back to acme"}]}]
 		with patch.object(egress_rules, "_fire_tripwire"):
-			self.assertEqual(_latest_assistant_text(msgs), "back to Jarvis")
+			self.assertEqual(_latest_assistant_text(msgs), "back to ")
 
 	def test_recovery_bare_text_field_redacted(self):
 		# The third return path: a message with a bare `text` (no `content`).
 		msgs = [{"role": "assistant", "text": "text field acme"}]
 		with patch.object(egress_rules, "_fire_tripwire") as fire:
-			self.assertEqual(_latest_assistant_text(msgs), "text field Jarvis")
+			self.assertEqual(_latest_assistant_text(msgs), "text field ")
 			fire.assert_called_once()
 
-	def test_recovery_all_remove_falls_back_to_name(self):
+	def test_recovery_all_remove_falls_back_to_placeholder(self):
 		# F1 on the recovery path: an all-remove reply must not collapse to "" (which
 		# _recover_one reads as "no output yet" and hangs the turn to a false timeout).
 		msgs = [{"role": "assistant", "content": _LOBSTER}]
 		with patch.object(egress_rules, "_fire_tripwire"):
-			self.assertEqual(_latest_assistant_text(msgs), "Jarvis")
+			self.assertEqual(_latest_assistant_text(msgs), "…")
 
 	def test_recovery_clean_text_does_not_flag(self):
 		msgs = [{"role": "assistant", "content": "all good"}]
@@ -176,10 +175,10 @@ class TestErrorBannerRedaction(FrappeTestCase):
 	def test_failed_final_error_redacts_provider_detail(self):
 		out = failed_final_error("acme gateway error (429): quota exceeded")
 		self.assertNotIn("acme", out.lower())
-		self.assertIn("Jarvis", out)
+		self.assertIn("quota exceeded", out)
 
 	def test_error_text_redacts(self):
-		self.assertEqual(_error_text({"error": "acme exploded"}), "Jarvis exploded")
+		self.assertEqual(_error_text({"error": "acme exploded"}), " exploded")
 
 	def test_error_text_fallback_unaffected(self):
 		self.assertEqual(_error_text({}), "The run ended with an error.")
@@ -219,7 +218,7 @@ class TestPersistWiring(FrappeTestCase):
 		# egress_rules.persist (co-located with the release_notice.persist precedent).
 		from jarvis import onboarding
 
-		conn = {"redaction_patterns": [["x", "name"]], "release_notice": {}, "agent_url": ""}
+		conn = {"redaction_patterns": [["x", "remove"]], "release_notice": {}, "agent_url": ""}
 		with (
 			patch("jarvis.onboarding.require_jarvis_admin"),
 			patch("jarvis.onboarding.frappe.get_single") as gs,
@@ -229,4 +228,4 @@ class TestPersistWiring(FrappeTestCase):
 		):
 			gs.return_value.get_password.return_value = "x"  # api key/secret present
 			onboarding.sync_connection()
-		persist.assert_called_once_with([["x", "name"]])
+		persist.assert_called_once_with([["x", "remove"]])


### PR DESCRIPTION
…inery)

Follows the control-plane switch to remove-only egress patterns: with no rule ever renaming, the redactor's rename path was dead. Removes it properly:

- egress_redact: drop MODE_NAME + the whitelabel-name replacement; redact_egress is now `(text, rules)` and DROPS every match. The blank-collapse invariant (a non-empty reply that reduces entirely to nothing must not blank the card / hang recovery) now substitutes a name-free placeholder, so the module stays self-contained and names nothing. compile_rules returns `[regex]` and skips any non-`remove` rule defensively (a future CP rename rule is dropped, never applied).
- egress_rules: drop get_replacement_name + the _DEFAULT_NAME fallback; the apply wrappers call redact_egress(text, get_rules()).
- Tests rewritten for the remove-only contract (net -56 lines).

No behavior change vs the deployed CP patterns (already all-remove); this just deletes the now-unreachable rename surface. Pairs with the persona hardening + the CP remove-only patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
