### PR TITLE
test(llm): stub post_rotate_llm_secret in the stored-key probe setUp

### DIFF
--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -472,6 +472,13 @@ class TestProbeWithAStoredKey(_RT3SettingsTestCase):
 		with (
 			mock.patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
 			mock.patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "creds_update"}),
+			# Without a seeded onboarding credential the inline _sync_via_admin raises
+			# AdminAuthError, and residual legacy llm_provider/model state from an earlier
+			# test can route this save down the key-rotation ("reload") path rather than the
+			# creds ("restart") path - so stub every admin push the save might pick, not just
+			# the two above. The probe under test cares only that the key is persisted, not
+			# which sync path the save takes.
+			mock.patch("jarvis.admin_client.post_rotate_llm_secret", return_value={"action": "reload"}),
 		):
 			settings.save()
 		frappe.db.commit()


### PR DESCRIPTION
TestProbeWithAStoredKey.setUp mocked post_update_llm_pool and post_update_llm_creds but not post_rotate_llm_secret. On a not-onboarded test site the inline _sync_via_admin raises AdminAuthError, and residual legacy llm_provider/model state from an earlier test can route the save down the key-rotation ("reload") path -- the one admin push the setUp did not stub -- so the 7 tests in this class errored order-dependently. Stub that third push too; the probe cares only that the key is persisted, not which sync path the save takes.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
