### PR TITLE
feat(settings): group agent-recovery actions under an "Agent Recovery" menu with tooltips

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -94,7 +94,12 @@ frappe.ui.form.on("Jarvis Settings", {
 					}
 				);
 			},
-			__("Diagnostics")
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Use when the agent rejects the connection (e.g. a device/token mismatch) and chat will not connect. Re-pairs this device; instant, no container downtime."
+			)
 		);
 
 		// Rotates the plugin agent_token (X-Jarvis-Token / Boundary 6). Distinct
@@ -140,7 +145,12 @@ frappe.ui.form.on("Jarvis Settings", {
 					}
 				);
 			},
-			__("Diagnostics")
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Use when tool calls fail with 'invalid X-Jarvis-Token' or 'agent_token expired', or after a suspected token leak. Issues a NEW token and recreates the container (~10–30s). System Manager only."
+			)
 		);
 
 		// Reset onboarding moved to the `bench reset-onboarding` CLI command
@@ -191,7 +201,12 @@ frappe.ui.form.on("Jarvis Settings", {
 				});
 				d.show();
 			},
-			__("Diagnostics")
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Use when a Settings or LLM-key change has not taken effect, or setup is stuck on 'Applying your AI configuration'. Re-pushes the current config to the container; changes no secrets."
+			)
 		);
 	},
 });


### PR DESCRIPTION
## Summary

The Jarvis Settings **Diagnostics** menu had grown to five buttons, three of which are *recovery* actions that are easy to confuse — they touch different credentials with different blast radius (see #1010 discussion). This groups them under a dedicated **Agent Recovery** dropdown and adds a symptom-first tooltip to each.

## Changes

- **Agent Recovery** group: Reset Agent Pairing · Rotate Agent Token · Force Resync — each with a `title` tooltip stating the symptom it fixes.
- **Diagnostics** keeps the two read-only checks (Test Admin/Agent Connection).
- No behavior change to the actions. `?.attr()` guards `add_custom_button` returning `undefined` for an already-present grouped button.

## Scope

Single file, `jarvis_settings.js`. Prettier clean.

## Verification

Flow-verified in-browser on `jarvis.local` Desk: both groups render, all three tooltips present and correct.
