### PR TITLE
feat(chat): surface Server Scripts capability in the turn context line (backport)

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -506,6 +506,26 @@ def _org_locale_clause() -> str:
 	return ("; " + "; ".join(parts)) if parts else ""
 
 
+# safe_exec (Script Reports / System Console / Server Scripts) only matters on
+# report/script/console turns, so gate the clause on that - most turns pay nothing,
+# like the sibling clauses that return "" when they don't apply.
+_SERVER_SCRIPTS_TRIGGERS = ("report", "script", "console")
+
+
+def _server_scripts_clause(user_message: str) -> str:
+	"""Script Reports on/off for the report-drafting policy, read from the same gate
+	``safe_exec`` checks (``is_safe_exec_enabled``); only on report/script/console
+	turns (else '', a Query-Report default), and '' on any failure."""
+	if not any(t in (user_message or "").lower() for t in _SERVER_SCRIPTS_TRIGGERS):
+		return ""
+	try:
+		from frappe.utils.safe_exec import is_safe_exec_enabled
+
+		return "; server scripts: on" if is_safe_exec_enabled() else "; server scripts: off"
+	except Exception:
+		return ""
+
+
 def _assistant_name_clause(settings) -> str:
 	"""Whitelabel assistant name folded into the turn's trusted [Context:] line
 	so the agent refers to itself by the customer's chosen name. "" when unset
@@ -708,6 +728,9 @@ def assemble_prompt(
 	# Org locale (default Company country/currency + site date/number/tz) so the
 	# agent formats for the org's region instead of defaulting to US conventions.
 	locale_clause = _org_locale_clause()
+	# Script Reports on/off (the safe_exec gate) for the report-drafting policy, only
+	# on report/script/console turns; rides with the org/site clauses below.
+	server_scripts_clause = _server_scripts_clause(user_message)
 	# Whitelabel assistant name (Phase 3): folded into the trusted [Context:] line
 	# so the agent refers to itself by the customer's chosen name. "" when unset.
 	assistant_name_clause = _assistant_name_clause(settings)
@@ -796,7 +819,7 @@ def assemble_prompt(
 		# clauses - before personal, which stays last.
 		f"[Context: today is {today}{locale_clause}{assistant_name_clause}{persona_clause}; chat user: {chat_user}"
 		f"; conv: {conversation_id}{auto_apply}{skill_clause}{learned_clause}"
-		f"{wiki_notes_clause}{custom_site_clause}{personal_clause}{notes_clause}]"
+		f"{wiki_notes_clause}{custom_site_clause}{server_scripts_clause}{personal_clause}{notes_clause}]"
 		f"{ground_block}"
 		f"\n\n{user_message or ''}"
 	)

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -305,6 +305,31 @@ class TestOrgLocaleClause(unittest.TestCase):
 		self.assertEqual(self._run(company=None, default=None), "")
 
 
+class TestServerScriptsClause(unittest.TestCase):
+	"""_server_scripts_clause: gated to report/script/console turns; on/off from
+	is_safe_exec_enabled, '' otherwise / on failure."""
+
+	def test_enabled_yields_on(self):
+		with patch("frappe.utils.safe_exec.is_safe_exec_enabled", return_value=True):
+			self.assertEqual(turn_handler._server_scripts_clause("create a report"), "; server scripts: on")
+
+	def test_disabled_yields_off(self):
+		with patch("frappe.utils.safe_exec.is_safe_exec_enabled", return_value=False):
+			self.assertEqual(
+				turn_handler._server_scripts_clause("build a query report"), "; server scripts: off"
+			)
+
+	def test_non_report_turn_skips_the_gate(self):
+		# No report/script/console word -> "" without even hitting the gate.
+		with patch("frappe.utils.safe_exec.is_safe_exec_enabled", return_value=True) as gate:
+			self.assertEqual(turn_handler._server_scripts_clause("hi, show me overdue invoices"), "")
+			gate.assert_not_called()
+
+	def test_gate_error_yields_empty(self):
+		with patch("frappe.utils.safe_exec.is_safe_exec_enabled", side_effect=RuntimeError("boom")):
+			self.assertEqual(turn_handler._server_scripts_clause("script report please"), "")
+
+
 class TestClassifyError(unittest.TestCase):
 	"""_classify_error is the single, shared source for a turn error's `code`
 	(#702) - settlement.py, pump.py and prepare.py all delegate to it, and


### PR DESCRIPTION
Backport of #1021 to `version-15` (companion to the `version-16` backport #1022).

`_server_scripts_clause()` folds `; server scripts: on/off` into the turn `[Context:]` line via the same gate `safe_exec` checks (`is_safe_exec_enabled`). `version-15` lacks `_app_versions_clause`, so the clause is placed after `_org_locale_clause` and its test before `TestClassifyError`; body/wiring/tests are byte-identical to #1021.