### PR TITLE
feat(settings): group agent-recovery actions under an "Agent Recovery" menu with tooltips (backport)

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -94,7 +94,12 @@ frappe.ui.form.on("Jarvis Settings", {
 					}
 				);
 			},
-			__("Diagnostics")
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Use when the agent rejects the connection (e.g. a device/token mismatch) and chat will not connect. Re-pairs this device; instant, no container downtime."
+			)
 		);
 
 		// Rotates the plugin agent_token (X-Jarvis-Token / Boundary 6). Distinct
@@ -140,7 +145,12 @@ frappe.ui.form.on("Jarvis Settings", {
 					}
 				);
 			},
-			__("Diagnostics")
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Use when tool calls fail with 'invalid X-Jarvis-Token' or 'agent_token expired', or after a suspected token leak. Issues a NEW token and recreates the container (~10–30s). System Manager only."
+			)
 		);
 
 		// Reset onboarding moved to the `bench reset-onboarding` CLI command
@@ -191,7 +201,12 @@ frappe.ui.form.on("Jarvis Settings", {
 				});
 				d.show();
 			},
-			__("Diagnostics")
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Use when a Settings or LLM-key change has not taken effect, or setup is stuck on 'Applying your AI configuration'. Re-pushes the current config to the container; changes no secrets."
+			)
 		);
 	},
 });


### PR DESCRIPTION
Backport of #1019 (`5d9dcfa4`) to `version-16`. Clean cherry-pick - `jarvis_settings.js` is identical to develop on this branch. Client-script-only UI change (groups the agent-recovery actions under an "Agent Recovery" menu + tooltips).