### PR TITLE
feat(macro): arm/disarm from the SPA macro editor + 'Armed' badge in …

### DIFF
--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -65,6 +65,16 @@
 						description="Stop the chain if a step fails - otherwise it keeps going after an error."
 						:disabled="saving"
 					/>
+					<Switch
+						v-model="form.skip_confirmation"
+						label="Skip confirmation (run writes uncarded)"
+						:description="
+							canArm
+								? 'Admin only. This macro\'s runs execute writes WITHOUT a confirmation card - including run_method, send_email and run_import. delete/cancel/amend still park and stop the run. Arming trusts the owner for current and future steps.'
+								: 'Admin only - a Jarvis Admin or System Manager can arm this macro to run its writes without a confirmation card.'
+						"
+						:disabled="saving || !canArm"
+					/>
 				</div>
 			</DocSection>
 
@@ -229,6 +239,7 @@ const form = reactive({
 	description: "",
 	enabled: true,
 	stop_on_error: true,
+	skip_confirmation: false,
 	schedule_enabled: false,
 	schedule_frequency: "daily",
 	schedule_time: "09:00",
@@ -247,6 +258,11 @@ const docmeta = shallowRef(null); // useDocmeta instance (persisted macros only)
 const mergePending = computed(() => mergeStatus.value === "pending");
 const stepsWithPrompt = computed(() => form.steps.filter((s) => (s.prompt || "").trim()).length);
 
+// Arming a macro to skip confirmation is admin-only (the backend re-checks
+// require_jarvis_admin, so this is a UX gate, not the security boundary); a
+// non-admin sees the toggle disabled with the reason instead of a throw-on-save.
+const canArm = !!(window.is_jarvis_admin || window.is_system_manager);
+
 const dirty = computed(() => {
 	const snap = snapshot.value;
 	if (!snap || loading.value) return false;
@@ -255,6 +271,7 @@ const dirty = computed(() => {
 		(form.description || "") !== snap.description ||
 		(form.enabled ? 1 : 0) !== snap.enabled ||
 		(form.stop_on_error ? 1 : 0) !== snap.stop_on_error ||
+		(form.skip_confirmation ? 1 : 0) !== snap.skip_confirmation ||
 		(form.schedule_enabled ? 1 : 0) !== snap.schedule_enabled ||
 		(form.schedule_frequency || "daily") !== snap.schedule_frequency ||
 		(form.schedule_time || "") !== snap.schedule_time ||
@@ -319,6 +336,7 @@ function seed(data) {
 	form.description = data.description || "";
 	form.enabled = data.enabled == null ? true : !!data.enabled;
 	form.stop_on_error = !!data.stop_on_error;
+	form.skip_confirmation = !!data.skip_confirmation;
 	form.schedule_enabled = !!data.schedule_enabled;
 	form.schedule_frequency = data.schedule_frequency || "daily";
 	form.schedule_time = toHHMM(data.schedule_time) || "09:00";
@@ -332,6 +350,7 @@ function seed(data) {
 		description: form.description,
 		enabled: form.enabled ? 1 : 0,
 		stop_on_error: form.stop_on_error ? 1 : 0,
+		skip_confirmation: form.skip_confirmation ? 1 : 0,
 		schedule_enabled: form.schedule_enabled ? 1 : 0,
 		schedule_frequency: form.schedule_frequency,
 		schedule_time: form.schedule_time,
@@ -406,6 +425,7 @@ async function save() {
 			steps,
 			enabled: form.enabled ? 1 : 0,
 			stop_on_error: form.stop_on_error ? 1 : 0,
+			skip_confirmation: form.skip_confirmation ? 1 : 0,
 			schedule_enabled: form.schedule_enabled ? 1 : 0,
 			schedule_frequency: form.schedule_frequency || "daily",
 			schedule_time: form.schedule_time || "09:00",

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -51,6 +51,18 @@
 				/>
 			</template>
 
+			<template #cell-macro_name="{ row }">
+				<div class="flex items-center gap-2">
+					<span class="truncate">{{ row.macro_name }}</span>
+					<Tooltip
+						v-if="row.skip_confirmation"
+						text="Armed: this macro's runs execute writes without a confirmation card (admin-set)."
+					>
+						<Badge variant="subtle" theme="orange" label="Armed" />
+					</Tooltip>
+				</div>
+			</template>
+
 			<template #cell-step_count="{ row }">
 				<div class="flex w-full items-center justify-center text-base text-ink-gray-7">
 					{{ row.step_count || 0 }} {{ (row.step_count || 0) === 1 ? "step" : "steps" }}

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -189,7 +189,7 @@ def list_macros_page(
 
 	total = list_filters.bounded_sql(f"SELECT COUNT(*) FROM `tabJarvis Macro` WHERE {where}", params)[0][0]
 	rows = list_filters.bounded_sql(
-		f"""SELECT name, macro_name, description, enabled, stop_on_error,
+		f"""SELECT name, macro_name, description, enabled, stop_on_error, skip_confirmation,
 		schedule_enabled, schedule_frequency, schedule_time, next_run_at,
 		last_run_at, modified, merge_status,
 		CASE WHEN TRIM(COALESCE(merged_prompt, '')) != '' THEN 1 ELSE 0 END AS has_summary
@@ -238,6 +238,7 @@ def get_macro(name: str) -> dict:
 		"description": doc.description or "",
 		"enabled": int(doc.enabled or 0),
 		"stop_on_error": int(doc.stop_on_error or 0),
+		"skip_confirmation": int(doc.skip_confirmation or 0),
 		"schedule_enabled": int(doc.schedule_enabled or 0),
 		"schedule_frequency": doc.schedule_frequency or "daily",
 		"schedule_time": str(doc.schedule_time or ""),
@@ -274,12 +275,14 @@ def create_macro(
 	steps: str | list | None = None,
 	enabled: int = 1,
 	stop_on_error: int = 1,
+	skip_confirmation: int = 0,
 	schedule_enabled: int = 0,
 	schedule_frequency: str = "daily",
 	schedule_time: str | None = None,
 ) -> dict:
 	"""Create a macro. Validation (name/steps/caps) runs in the doctype validate().
-	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``)."""
+	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``). Arming
+	(``skip_confirmation`` 0 -> 1) is admin-gated in the doctype validate()."""
 	doc = frappe.get_doc(
 		{
 			"doctype": MACRO,
@@ -287,6 +290,7 @@ def create_macro(
 			"description": description or "",
 			"enabled": int(enabled or 0),
 			"stop_on_error": int(stop_on_error or 0),
+			"skip_confirmation": int(skip_confirmation or 0),
 			"schedule_enabled": int(schedule_enabled or 0),
 			"schedule_frequency": schedule_frequency or "daily",
 			"schedule_time": schedule_time or None,
@@ -307,6 +311,7 @@ def update_macro(
 	steps: str | list | None = None,
 	enabled: int | None = None,
 	stop_on_error: int | None = None,
+	skip_confirmation: int | None = None,
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
 	schedule_time: str | None = None,
@@ -326,6 +331,9 @@ def update_macro(
 		doc.enabled = int(enabled)
 	if stop_on_error is not None:
 		doc.stop_on_error = int(stop_on_error)
+	if skip_confirmation is not None:
+		# The doctype validate() admin-gates a 0 -> 1 transition; a non-admin flip raises.
+		doc.skip_confirmation = int(skip_confirmation)
 	if schedule_enabled is not None:
 		doc.schedule_enabled = int(schedule_enabled)
 	if schedule_frequency is not None:

--- a/jarvis/tests/test_macro_skip_confirmation.py
+++ b/jarvis/tests/test_macro_skip_confirmation.py
@@ -871,3 +871,57 @@ class TestReviewHardening(FrappeTestCase):
 		with patch("jarvis.api.dispatch", return_value={"ok": True}):
 			api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
 		self.assertEqual(_agent_run_ctx.take_armed_by_macro(), "an armed macro")
+
+
+class TestMacrosApiSkipConfirmation(FrappeTestCase):
+	"""The macros_api create/update/get thread skip_confirmation (so the SPA editor
+	can set + read it), and arming via the API still hits the admin guard."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+		_ensure_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		for owner in (NON_ADMIN_USER, ADMIN_USER):
+			for name in frappe.get_all(MACRO, filters={"owner": owner}, pluck="name"):
+				frappe.delete_doc(MACRO, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_create_macro_armed_by_admin_and_get_carries_it(self):
+		from jarvis.chat.macros_api import create_macro, get_macro
+
+		frappe.set_user(ADMIN_USER)
+		r = create_macro("api-armed", steps=[{"prompt": "do it"}], skip_confirmation=1)
+		name = r["data"]["name"]
+		self.assertEqual(int(frappe.db.get_value(MACRO, name, "skip_confirmation")), 1)
+		self.assertEqual(get_macro(name)["skip_confirmation"], 1)
+
+	def test_create_macro_armed_by_non_admin_rejected(self):
+		from jarvis.chat.macros_api import create_macro
+
+		frappe.set_user(NON_ADMIN_USER)
+		with self.assertRaises(frappe.PermissionError):
+			create_macro("api-armed-bad", steps=[{"prompt": "do it"}], skip_confirmation=1)
+
+	def test_update_macro_arm_rejected_for_non_admin(self):
+		from jarvis.chat.macros_api import create_macro, update_macro
+
+		frappe.set_user(NON_ADMIN_USER)
+		name = create_macro("api-upd", steps=[{"prompt": "do it"}])["data"]["name"]
+		with self.assertRaises(frappe.PermissionError):
+			update_macro(name=name, skip_confirmation=1)
+		self.assertEqual(int(frappe.db.get_value(MACRO, name, "skip_confirmation") or 0), 0)
+
+	def test_update_macro_arm_ok_for_admin(self):
+		from jarvis.chat.macros_api import create_macro, update_macro
+
+		frappe.set_user(ADMIN_USER)
+		name = create_macro("api-upd-admin", steps=[{"prompt": "do it"}])["data"]["name"]
+		update_macro(name=name, skip_confirmation=1)
+		self.assertEqual(int(frappe.db.get_value(MACRO, name, "skip_confirmation")), 1)


### PR DESCRIPTION
…the list

The doctype field alone only surfaced the toggle on the Desk form; the SPA (where customers manage macros) never showed it. Add an admin-gated 'Skip confirmation' toggle to the macro editor (MacroDetail.vue) - disabled with an explanation for non-admins (the backend re-checks require_jarvis_admin, so this is a UX gate) and a warning copy naming the broad covered set + the D6 trust model - and an 'Armed' badge on the macros list (MacrosList.vue).

macros_api.create_macro/update_macro now accept skip_confirmation (the doctype validate() admin-gates the 0->1 transition); get_macro + the list SELECT return it.
+ tests: API arming is admin-only, get carries the flag. SPA builds clean.


Claude-Session: https://claude.ai/code/session_01JsMwhHmVqKReu2F5jYUzDi

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
