### PR TITLE
fix(create-card): carry the document name for Prompt-autonamed DocTypes

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6529,10 +6529,21 @@ async function buildDraftModel(a) {
 			origJson: JSON.stringify(verb === "update" ? baseRows : null),
 		});
 	}
+	// A Prompt-autonamed DocType (e.g. Server Script) carries its document name as a
+	// proposed "name" field, not a real DocField, so it never lands in `fields`.
+	// Capture it here so applyDraft sends it as `name` (the backend folds it into
+	// the create values). Field/series-named DocTypes have no such field -> "".
+	const proposedCreateName =
+		verb === "update"
+			? ""
+			: String(
+					((a.fields || []).find((x) => String(x.label || "").toLowerCase() === "name") || {})
+						.value ?? ""
+				);
 	return {
 		verb,
 		doctype: a.doctype,
-		docName: verb === "update" ? a.name || "" : "",
+		docName: verb === "update" ? a.name || "" : proposedCreateName,
 		title: a.title || "",
 		titleField: meta.title_field || "",
 		submittable: !!meta.is_submittable,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6537,9 +6537,12 @@ async function buildDraftModel(a) {
 		verb === "update"
 			? ""
 			: String(
-					((a.fields || []).find((x) => String(x.label || "").toLowerCase() === "name") || {})
-						.value ?? ""
-				);
+					(
+						(a.fields || []).find(
+							(x) => String(x.label || "").toLowerCase() === "name"
+						) || {}
+					).value ?? ""
+			  );
 	return {
 		verb,
 		doctype: a.doctype,

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -233,6 +233,15 @@ def apply_action(action: dict | str | None = None) -> dict:
 		raise InvalidArgumentError("conversation is required")
 	_require_own_conversation(conversation)
 
+	# A Prompt-autonamed DocType (e.g. Server Script) has NO `name` FIELD - the
+	# human-entered document name arrives only as `name`, never inside `values`
+	# (the panel builds values from DocFields). Fold it in for a create so the doc
+	# gets a name; without this the insert fails "Please set the document name".
+	# Scoped to autoname=Prompt so field/series/hash-named DocTypes are untouched.
+	if verb == "create" and name and "name" not in values:
+		if (frappe.get_meta(doctype).autoname or "").lower() == "prompt":
+			values = {**values, "name": name}
+
 	from jarvis import api
 
 	# The audit/receipt args, built up front (independent of the write outcome);

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -237,9 +237,14 @@ def apply_action(action: dict | str | None = None) -> dict:
 	# human-entered document name arrives only as `name`, never inside `values`
 	# (the panel builds values from DocFields). Fold it in for a create so the doc
 	# gets a name; without this the insert fails "Please set the document name".
-	# Scoped to autoname=Prompt so field/series/hash-named DocTypes are untouched.
+	# That error is raised ONLY by _prompt_autoname (frappe/model/naming.py), for
+	# autoname.startswith("prompt") - i.e. "Set by user". Every other naming rule
+	# either derives the name from a field already in `values` (By fieldname / By
+	# Naming Series) or auto-generates it (Autoincrement / Expression / Random /
+	# UUID / By script), so it needs no fold and folding could override it. Match
+	# Frappe's own check exactly so the scope stays correct.
 	if verb == "create" and name and "name" not in values:
-		if (frappe.get_meta(doctype).autoname or "").lower() == "prompt":
+		if (frappe.get_meta(doctype).autoname or "").lower().startswith("prompt"):
 			values = {**values, "name": name}
 
 	from jarvis import api


### PR DESCRIPTION
## The bug

Confirming a chat **"Create"** card for a **Prompt-autonamed DocType** (e.g. `Server Script`) failed with **"Please set the document name."** Such DocTypes have no `name` *field* — the name IS the identifier, entered by the user — so it never lands in the draft panel's `values` (which are built from DocFields), and the insert ran nameless.

Found while creating Server Scripts (DocType Event / API / Scheduler) from chat. `Report` etc. were unaffected because their name derives from a real field (`report_name`).

## Root cause

- The agent's action block carries the name as a proposed `{"label":"name","value":"…"}` field. `buildSummaryModel` matches proposed fields to meta DocFields; `name` has none, so it was silently dropped, and for a create `docName` was hardcoded to `""`.
- `apply_action` (create path) called `create_doc(doctype, values)` and never folded in the `name` it received.

## Fix

- **Frontend** (`ChatView.vue`): capture the proposed `name` field into the create model's `docName`, so `applyDraft` sends it (it already sends `name: p.docName`).
- **Backend** (`actions_api.apply_action`): fold the received `name` into the create `values`, **scoped to `autoname=Prompt`** so field/series/hash-named DocTypes are untouched (`create_doc` already permits an explicit name for prompt autoname).

## Verification

- End-to-end: a `Server Script` now creates from the chat card (persisted: `Scheduler Event`, Daily, enabled). All three script types (DocType Event, API, Scheduler) were separately confirmed to run correctly.
- Frontend suite **1328/1328** green; `ruff` clean.
