### PR TITLE
fix(get_schema): gate child-table schema on parent read permission (backport #1031 → version-15)

### DIFF
--- a/jarvis/tests/test_get_schema.py
+++ b/jarvis/tests/test_get_schema.py
@@ -108,6 +108,49 @@ class TestGetSchema(FrappeTestCase):
 		finally:
 			frappe.set_user("Administrator")
 
+	def test_child_doctype_schema_allowed_via_parent_read_permission(self):
+		# A child (istable) DocType has NO standalone read perm, so get_schema must
+		# gate it on a parent that embeds it - otherwise the agent can never read a
+		# child-table schema (Report Column / Report Filter) to build a Report create.
+		user_email = "reportreader@example.com"
+		if not frappe.db.exists("User", user_email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user_email,
+					"first_name": "Report",
+					"send_welcome_email": 0,
+					"roles": [{"role": "System Manager"}],
+				}
+			).insert(ignore_permissions=True)
+		frappe.set_user(user_email)
+		try:
+			# no standalone read on the child, but Report (its parent) is readable
+			self.assertFalse(frappe.has_permission("Report Column", ptype="read"))
+			schema = get_schema(doctype="Report Column", refresh=True)
+			self.assertTrue(schema.get("fields"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_child_doctype_schema_denied_when_no_parent_is_readable(self):
+		# The roleless user can't read Report, so can't read its child schema either.
+		user_email = "schemaless@example.com"
+		if not frappe.db.exists("User", user_email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user_email,
+					"first_name": "Schemaless",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+		frappe.set_user(user_email)
+		try:
+			with self.assertRaises(PermissionDeniedError):
+				get_schema(doctype="Report Column", refresh=True)
+		finally:
+			frappe.set_user("Administrator")
+
 
 class _StubField:
 	"""Stands in for a meta DocField: _field_record only needs the five core

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -244,6 +244,15 @@ def clear_schema_cache(doc, method=None) -> None:
 		clear_cache_for(dt)
 
 
+def _parent_doctypes(child: str) -> list[str]:
+	"""DocTypes that embed ``child`` as a Table / Table MultiSelect field - the
+	parents whose read permission actually governs access to this child table."""
+	tbl = ["Table", "Table MultiSelect"]
+	std = frappe.get_all("DocField", filters={"fieldtype": ["in", tbl], "options": child}, pluck="parent")
+	custom = frappe.get_all("Custom Field", filters={"fieldtype": ["in", tbl], "options": child}, pluck="dt")
+	return list({p for p in (std + custom) if p})
+
+
 def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> dict:
 	"""Return live meta for a DocType: identity + the write-relevant
 	doctype-level flags + the field list.
@@ -317,7 +326,15 @@ def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> di
 	if not frappe.db.exists("DocType", doctype):
 		raise InvalidArgumentError(f"unknown DocType: {doctype}")
 
-	if not frappe.has_permission(doctype, ptype="read"):
+	# A child (istable) DocType carries NO standalone read perm - it is only ever
+	# reached through the parent that embeds it, whose verbose schema already
+	# exposes these very fields. So gate it on the parent(s), not on itself, or
+	# the agent can never read a child-table schema (e.g. Report Column /
+	# Report Filter while building a Report create) even as a System Manager.
+	allowed = frappe.has_permission(doctype, ptype="read")
+	if not allowed and frappe.get_meta(doctype).istable:
+		allowed = any(frappe.has_permission(p, ptype="read") for p in _parent_doctypes(doctype))
+	if not allowed:
 		raise PermissionDeniedError(f"no read permission on {doctype}")
 
 	cache = frappe.cache()


### PR DESCRIPTION
Backport of #1031 to this version branch (clean cherry-pick, identical context).

`get_schema` raised `PermissionDeniedError` on child (`istable`) DocTypes for every non-Administrator — `frappe.has_permission("Report Column", ptype="read")` is always `False` for child tables (no standalone read perm). This silently broke Report creation from chat: the agent's `get_schema("Report Column")` / `("Report Filter")` probes 403'd, and the model reported a spurious "you lack Report Manager / Script Manager" boundary even for a System Manager.

Fix: for an `istable` DocType that fails the standalone read check, allow it if the user can read a parent that embeds it (whose verbose schema already exposes those fields); no readable parent is still denied. +2 tests.

See #1031 for full detail.
