### PR TITLE
feat(tools): validate_script static checker for safe_exec scripts (backport #1030 → version-15)

### DIFF
--- a/jarvis/tests/test_validate_script.py
+++ b/jarvis/tests/test_validate_script.py
@@ -92,6 +92,28 @@ class TestValidateScript(unittest.TestCase):
 		self.assertTrue(out["ok"], out["errors"])
 		self.assertEqual(out["errors"], [])
 
+	def test_frappe_qb_is_rejected_as_permission_bypass(self):
+		# frappe.qb runs raw SQL (bypasses User Permissions) + Sum/Count NameError.
+		code = "si = frappe.qb.DocType('Sales Invoice')\nresult = frappe.qb.from_(si).select(si.name).run()\ndata = result\n"
+		out = validate_script(code, script_type="Script Report")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("frappe.qb" in e for e in out["errors"]))
+		# deduped to a single error even though frappe.qb appears twice
+		self.assertEqual(len([e for e in out["errors"] if "frappe.qb" in e]), 1)
+
+	def test_result_columns_pair_is_warned(self):
+		# result = [columns, rows] renders blank; the pair must go in `data`.
+		code = "columns = [{'label': 'A'}]\nrows = []\nresult = [columns, rows]\n"
+		out = validate_script(code, script_type="Script Report")
+		self.assertTrue(out["ok"], out["errors"])
+		self.assertTrue(any("data" in w and "blank" in w for w in out["warnings"]))
+
+	def test_correct_data_pair_is_not_warned(self):
+		code = "columns = [{'label': 'A'}]\nrows = [{'a': 1}]\ndata = [columns, rows]\n"
+		out = validate_script(code, script_type="Script Report")
+		self.assertTrue(out["ok"], out["errors"])
+		self.assertEqual(out["warnings"], [])
+
 	def test_syntax_error_is_reported(self):
 		out = validate_script("def broken(:\n    pass\n")
 		self.assertFalse(out["ok"])

--- a/jarvis/tests/test_validate_script.py
+++ b/jarvis/tests/test_validate_script.py
@@ -1,0 +1,61 @@
+"""validate_script static-checks a Server Script / Script Report body against
+the safe_exec sandbox without running it."""
+
+import unittest
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools.validate_script import validate_script
+
+
+class TestValidateScript(unittest.TestCase):
+	def test_clean_get_list_script_is_ok(self):
+		code = (
+			"rows = frappe.get_list('Sales Invoice', filters={'docstatus': 1}, fields=['grand_total'])\n"
+			"total = sum(r.grand_total for r in rows)\n"
+			"columns = [{'label': 'Total', 'fieldname': 'total', 'fieldtype': 'Currency'}]\n"
+			"result = [{'total': total}]\n"
+			"data = [columns, result]\n"
+		)
+		out = validate_script(code, script_type="Script Report")
+		self.assertTrue(out["ok"], out["errors"])
+		self.assertEqual(out["errors"], [])
+
+	def test_import_is_rejected(self):
+		out = validate_script("import os\nx = 1\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("import" in e for e in out["errors"]))
+
+	def test_from_import_is_rejected(self):
+		out = validate_script("from frappe.utils import flt\nx = flt('1')\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("import" in e for e in out["errors"]))
+
+	def test_get_all_is_rejected_as_permission_bypass(self):
+		out = validate_script("rows = frappe.get_all('Sales Invoice')\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("User Permissions" in e and "get_list" in e for e in out["errors"]))
+
+	def test_db_sql_is_rejected_as_permission_bypass(self):
+		out = validate_script("rows = frappe.db.sql('select name from `tabSales Invoice`')\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("User Permissions" in e for e in out["errors"]))
+
+	def test_open_and_eval_are_rejected(self):
+		out = validate_script("f = open('/etc/passwd')\ny = eval('1+1')\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("open" in e for e in out["errors"]))
+		self.assertTrue(any("eval" in e for e in out["errors"]))
+
+	def test_dunder_access_is_rejected(self):
+		out = validate_script("cls = doc.__class__\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("dunder" in e or "__class__" in e for e in out["errors"]))
+
+	def test_syntax_error_is_reported(self):
+		out = validate_script("def broken(:\n    pass\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("SyntaxError" in e for e in out["errors"]))
+
+	def test_empty_code_raises(self):
+		with self.assertRaises(InvalidArgumentError):
+			validate_script("   ")

--- a/jarvis/tests/test_validate_script.py
+++ b/jarvis/tests/test_validate_script.py
@@ -19,6 +19,7 @@ class TestValidateScript(unittest.TestCase):
 		out = validate_script(code, script_type="Script Report")
 		self.assertTrue(out["ok"], out["errors"])
 		self.assertEqual(out["errors"], [])
+		self.assertEqual(out["warnings"], [])
 
 	def test_import_is_rejected(self):
 		out = validate_script("import os\nx = 1\n")
@@ -50,6 +51,46 @@ class TestValidateScript(unittest.TestCase):
 		out = validate_script("cls = doc.__class__\n")
 		self.assertFalse(out["ok"])
 		self.assertTrue(any("dunder" in e or "__class__" in e for e in out["errors"]))
+
+	def test_sql_function_field_warns_not_errors(self):
+		# get_list with an SQL function as a string field: compiles fine, so it is a
+		# warning (ok stays True), not an error - Frappe rejects it only at query time.
+		code = "rows = frappe.get_list('Sales Invoice', fields=['customer', 'sum(grand_total) as total'], group_by='customer')\n"
+		out = validate_script(code, script_type="Script Report")
+		self.assertTrue(out["ok"], out["errors"])
+		self.assertEqual(out["errors"], [])
+		self.assertTrue(
+			any("SQL function" in w and "get_list" in w for w in out["warnings"]), out["warnings"]
+		)
+
+	def test_sql_function_outside_fields_is_not_warned(self):
+		# a `sum(` in an unrelated string (a message) must not false-warn.
+		out = validate_script("frappe.msgprint('The sum(x) total is below')\ndata = 1\n")
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["warnings"], [])
+
+	def test_frappe_defaults_is_flagged_as_out_of_namespace(self):
+		# frappe.defaults.* compiles but is None in safe_exec -> runtime NoneType error.
+		out = validate_script("b = frappe.defaults.get_user_default('Branch')\ndata = b\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("frappe.defaults" in e and "safe_exec namespace" in e for e in out["errors"]))
+
+	def test_get_user_default_is_flagged_as_out_of_namespace(self):
+		out = validate_script("c = frappe.get_user_default('Company')\ndata = c\n")
+		self.assertFalse(out["ok"])
+		self.assertTrue(any("frappe.get_user_default" in e for e in out["errors"]))
+
+	def test_valid_frappe_namespace_calls_are_not_flagged(self):
+		# get_list / get_doc / get_meta / db.get_default / utils are all in the namespace.
+		code = (
+			"co = frappe.db.get_default('company')\n"
+			"rows = frappe.get_list('Sales Invoice', fields=['grand_total'], limit_page_length=0)\n"
+			"m = frappe.get_meta('Sales Invoice')\n"
+			"data = rows\n"
+		)
+		out = validate_script(code, script_type="Script Report")
+		self.assertTrue(out["ok"], out["errors"])
+		self.assertEqual(out["errors"], [])
 
 	def test_syntax_error_is_reported(self):
 		out = validate_script("def broken(:\n    pass\n")

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -45,6 +45,10 @@ _TOOL_NAMES: tuple[str, ...] = (
 	# Batch, atomic create for a doc's missing dependencies (one gated card).
 	"create_docs",
 	"preview_doc",
+	# Read-only: static-check a Server Script / Script Report body against the
+	# safe_exec sandbox (imports, get_all/db.sql, RestrictedPython compile) before
+	# staging its create. See the frappe-scripting skill.
+	"validate_script",
 	# CSV / file import: preview_import (read-only) shows what a raw file load would
 	# produce; run_import (gated) stages a Frappe Data Import and starts it. For data
 	# that needs any processing first, create_doc(docs=[...]) stays the path - import

--- a/jarvis/tools/tool-names.json
+++ b/jarvis/tools/tool-names.json
@@ -18,7 +18,7 @@
     "repo copies are compared by it, because no CI job can see both repos."
   ],
   "contract_version": 1,
-  "digest": "sha256:5956acaed23f3096f10be2a6724e77be91e77928bc29ac7910408a0a9080f0b4",
+  "digest": "sha256:1fb1a5fd9068e9c81c140a50b27f730aad04e6c6c294424bf378fb5ecc3632ca",
   "tools": [
     "add_comment",
     "add_tag",
@@ -92,7 +92,8 @@
     "unshare_doc",
     "update_comment",
     "update_doc",
-    "update_wiki"
+    "update_wiki",
+    "validate_script"
   ],
   "backend_only": {
     "create_docs": "Deprecated compat shim for already-shipped plugin bundles that still advertise jarvis__create_docs; bulk create is create_doc(docs=[...]) now. Re-adding a descriptor would resurrect the retired surface. Delete the module (and this entry) once no deployed bundle references it."

--- a/jarvis/tools/validate_script.py
+++ b/jarvis/tools/validate_script.py
@@ -1,0 +1,109 @@
+"""Static validation of a Server Script / Script Report body against the
+safe_exec sandbox - WITHOUT running it.
+
+Two passes, both side-effect free:
+1. An AST scan for the constructs safe_exec forbids, with a clear message each
+   (imports, `frappe.get_all` / `frappe.db.sql` which bypass User Permissions,
+   `open`/`eval`/`exec`/`__import__`, dunder access).
+2. `frappe.utils.safe_exec._compile_code` - the EXACT RestrictedPython compile
+   safe_exec uses (FrappeTransformer policy), so a compile the agent's draft
+   would fail is caught here instead of at runtime.
+
+Read-only: parses/compiles, never executes, so nothing runs and no doc is touched.
+"""
+
+from __future__ import annotations
+
+import ast
+
+# frappe attribute chains that compile fine but are BANNED for Jarvis-authored
+# scripts because they read past User Permissions (cross-company/branch leak).
+_PERMISSION_BYPASS = {"frappe.get_all", "frappe.db.get_all", "frappe.db.sql"}
+# names that simply don't exist in the safe_exec namespace.
+_BANNED_NAMES = {"open", "eval", "exec", "compile", "__import__", "input", "globals", "locals"}
+
+
+def _dotted(node: ast.Attribute) -> str | None:
+	"""Reconstruct a static attribute chain (frappe.db.sql). None if the base
+	isn't a plain name (so aliased/indexed access is left to the compile pass)."""
+	parts = []
+	cur: ast.AST = node
+	while isinstance(cur, ast.Attribute):
+		parts.append(cur.attr)
+		cur = cur.value
+	if not isinstance(cur, ast.Name):
+		return None
+	parts.append(cur.id)
+	return ".".join(reversed(parts))
+
+
+def _ast_scan(code: str) -> list[str]:
+	errors: list[str] = []
+	tree = ast.parse(code)  # SyntaxError handled by the caller
+	for node in ast.walk(tree):
+		if isinstance(node, (ast.Import, ast.ImportFrom)):
+			errors.append(
+				f"line {node.lineno}: `import` is not allowed in safe_exec - no imports, "
+				"no third-party packages, no app functions. Use only the frappe namespace "
+				"(HTTP via frappe.make_post_request / FrappeClient, JSON via the injected json)."
+			)
+		elif isinstance(node, ast.Attribute):
+			dotted = _dotted(node)
+			if dotted in _PERMISSION_BYPASS:
+				errors.append(
+					f"line {node.lineno}: `{dotted}` bypasses User Permissions "
+					"(cross-company/branch/dimension leak). Use `frappe.get_list` for every read."
+				)
+			elif node.attr.startswith("__") and node.attr.endswith("__"):
+				errors.append(f"line {node.lineno}: dunder access `{node.attr}` is blocked in safe_exec.")
+		elif isinstance(node, ast.Name) and node.id in _BANNED_NAMES:
+			errors.append(f"line {node.lineno}: `{node.id}` is not available in safe_exec.")
+	return errors
+
+
+def validate_script(code, script_type=None) -> dict:
+	"""Static-check a Server Script or a Script Report's ``report_script`` against
+	Frappe's safe_exec sandbox WITHOUT running it. Call this before staging a
+	Server Script / Script Report create, and fix every error before drafting.
+
+	Catches: any `import` / third-party / app-function use, `frappe.get_all` and
+	`frappe.db.sql` (both bypass User Permissions - use `frappe.get_list`),
+	`open`/`eval`/`exec`/`__import__`, dunder access, and any RestrictedPython
+	compile error (the exact compile safe_exec runs). It never executes the code.
+
+	- ``code``: the script body (str).
+	- ``script_type``: optional hint ("Script Report", "DocType Event", "API",
+	  "Permission Query", "Scheduler Event"); advisory, does not change the checks.
+
+	Result: ``{"ok": bool, "errors": [str], "warnings": [str]}``. ``ok`` is True
+	only when there are no errors. See the ``frappe-scripting`` skill for the
+	allowed namespace and per-type contract.
+	"""
+	from jarvis.exceptions import InvalidArgumentError
+
+	if not isinstance(code, str) or not code.strip():
+		raise InvalidArgumentError("`code` must be a non-empty script body.")
+
+	errors: list[str] = []
+	warnings: list[str] = []
+
+	try:
+		errors.extend(_ast_scan(code))
+	except SyntaxError as e:
+		return {"ok": False, "errors": [f"SyntaxError: {e.msg} (line {e.lineno})"], "warnings": warnings}
+
+	# The authoritative RestrictedPython compile safe_exec itself uses. Private
+	# frappe helper, so guard it: if it moves, the AST scan above still stands.
+	try:
+		from frappe.utils.safe_exec import _compile_code
+
+		_compile_code(code, filename="<validate_script>")
+	except SyntaxError as e:
+		loc = f" (line {e.lineno})" if getattr(e, "lineno", None) else ""
+		errors.append(f"RestrictedPython rejected the script: {e.msg}{loc}")
+	except ImportError:
+		warnings.append("Could not run the RestrictedPython compile pass; relied on the static scan only.")
+	except Exception as e:  # any compile failure is a real error to surface
+		errors.append(f"RestrictedPython compile failed: {e}")
+
+	return {"ok": not errors, "errors": errors, "warnings": warnings}

--- a/jarvis/tools/validate_script.py
+++ b/jarvis/tools/validate_script.py
@@ -150,6 +150,23 @@ def _ast_scan(tree: ast.AST) -> tuple[list[str], list[str]]:
 	return errors, warnings
 
 
+def _restricted_compile(code: str) -> None:
+	"""Run the exact RestrictedPython compile safe_exec uses, across Frappe
+	versions. v16 exposes ``_compile_code``; older Frappe (v15) does not, so fall
+	back to the ``compile_restricted`` + ``FrappeTransformer`` it wraps - same
+	compile. Raises the compile's ``SyntaxError``; ``ImportError`` only if neither
+	entrypoint is importable (then the caller degrades to the AST scan)."""
+	try:
+		from frappe.utils.safe_exec import _compile_code
+	except ImportError:
+		from frappe.utils.safe_exec import FrappeTransformer
+		from RestrictedPython import compile_restricted
+
+		compile_restricted(code, filename="<validate_script>", policy=FrappeTransformer, mode="exec")
+	else:
+		_compile_code(code, filename="<validate_script>")
+
+
 def validate_script(code, script_type=None) -> dict:
 	"""Static-check a Server Script or a Script Report's ``report_script`` against
 	Frappe's safe_exec sandbox WITHOUT running it. Call this before staging a
@@ -201,12 +218,10 @@ def validate_script(code, script_type=None) -> dict:
 	except Exception:
 		pass
 
-	# The authoritative RestrictedPython compile safe_exec itself uses. Private
-	# frappe helper, so guard it: if it moves, the AST scan above still stands.
+	# The authoritative RestrictedPython compile safe_exec itself uses. Guarded:
+	# if neither entrypoint exists, the AST scan above still stands.
 	try:
-		from frappe.utils.safe_exec import _compile_code
-
-		_compile_code(code, filename="<validate_script>")
+		_restricted_compile(code)
 	except SyntaxError as e:
 		loc = f" (line {e.lineno})" if getattr(e, "lineno", None) else ""
 		errors.append(f"RestrictedPython rejected the script: {e.msg}{loc}")

--- a/jarvis/tools/validate_script.py
+++ b/jarvis/tools/validate_script.py
@@ -1,11 +1,15 @@
 """Static validation of a Server Script / Script Report body against the
 safe_exec sandbox - WITHOUT running it.
 
-Two passes, both side-effect free:
+Three passes, all side-effect free:
 1. An AST scan for the constructs safe_exec forbids, with a clear message each
    (imports, `frappe.get_all` / `frappe.db.sql` which bypass User Permissions,
-   `open`/`eval`/`exec`/`__import__`, dunder access).
-2. `frappe.utils.safe_exec._compile_code` - the EXACT RestrictedPython compile
+   `open`/`eval`/`exec`/`__import__`, dunder access), plus a warning on SQL
+   functions passed as `get_list` string fields.
+2. A namespace check: `frappe.<attr>` chains whose first level is absent from the
+   real `get_safe_globals()` (e.g. `frappe.defaults`, `frappe.get_user_default`) -
+   they compile but are None at runtime.
+3. `frappe.utils.safe_exec._compile_code` - the EXACT RestrictedPython compile
    safe_exec uses (FrappeTransformer policy), so a compile the agent's draft
    would fail is caught here instead of at runtime.
 
@@ -15,12 +19,19 @@ Read-only: parses/compiles, never executes, so nothing runs and no doc is touche
 from __future__ import annotations
 
 import ast
+import re
 
 # frappe attribute chains that compile fine but are BANNED for Jarvis-authored
 # scripts because they read past User Permissions (cross-company/branch leak).
 _PERMISSION_BYPASS = {"frappe.get_all", "frappe.db.get_all", "frappe.db.sql"}
 # names that simply don't exist in the safe_exec namespace.
 _BANNED_NAMES = {"open", "eval", "exec", "compile", "__import__", "input", "globals", "locals"}
+# read calls whose `fields=` list Frappe screens for SQL functions.
+_FIELD_READ_METHODS = {"get_list", "get_all", "get_value", "get_values"}
+# SQL aggregate/functions Frappe v16 rejects when passed as a string field.
+_SQL_FUNC_FIELD = re.compile(
+	r"\b(sum|count|avg|min|max|group_concat|std|variance|stddev)\s*\(", re.IGNORECASE
+)
 
 
 def _dotted(node: ast.Attribute) -> str | None:
@@ -37,9 +48,57 @@ def _dotted(node: ast.Attribute) -> str | None:
 	return ".".join(reversed(parts))
 
 
-def _ast_scan(code: str) -> list[str]:
+def _agg_field_warnings(call: ast.Call) -> list[str]:
+	"""Flag SQL functions passed as string `fields` to a read call (e.g.
+	`get_list(fields=["sum(grand_total) as t"])`). safe_exec compiles them fine,
+	but Frappe rejects SQL functions in SELECT at query time - so they pass the
+	compile pass yet throw when the report runs. Aggregate in Python instead."""
+	func = _dotted(call.func) if isinstance(call.func, ast.Attribute) else None
+	if not func or func.split(".")[-1] not in _FIELD_READ_METHODS:
+		return []
+	fields = next((kw.value for kw in call.keywords if kw.arg == "fields"), None)
+	if not isinstance(fields, ast.List):
+		return []
+	out = []
+	for elt in fields.elts:
+		if isinstance(elt, ast.Constant) and isinstance(elt.value, str) and _SQL_FUNC_FIELD.search(elt.value):
+			out.append(
+				f"line {call.lineno}: `{func.split('.')[-1]}` field {elt.value!r} uses an SQL "
+				"function as a string - Frappe rejects SQL functions in SELECT at query time. "
+				"Fetch plain fields (limit_page_length=0) and aggregate/sort/slice in Python."
+			)
+	return out
+
+
+def _namespace_errors(tree: ast.AST, frappe_keys: set[str]) -> list[str]:
+	"""Flag `frappe.<attr>` chains whose first level is NOT in the real safe_exec
+	namespace (e.g. `frappe.defaults.*`, `frappe.get_user_default`). They compile
+	fine but are None at runtime -> `TypeError: 'NoneType' object is not callable`.
+	First-level only, so valid deeper access (frappe.db.x, frappe.utils.x) is left
+	to the compile/runtime; one error per missing attribute."""
 	errors: list[str] = []
-	tree = ast.parse(code)  # SyntaxError handled by the caller
+	seen: set[str] = set()
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.Attribute):
+			continue
+		dotted = _dotted(node)
+		if not dotted or not dotted.startswith("frappe."):
+			continue
+		first = dotted.split(".")[1]
+		if first in frappe_keys or first in seen:
+			continue
+		seen.add(first)
+		errors.append(
+			f"line {node.lineno}: `frappe.{first}` is not in the safe_exec namespace "
+			"(compiles but is None at runtime). Use only the curated frappe namespace - "
+			"a default value is `frappe.db.get_default(key)`, not `frappe.defaults` / `frappe.get_user_default`."
+		)
+	return errors
+
+
+def _ast_scan(tree: ast.AST) -> tuple[list[str], list[str]]:
+	errors: list[str] = []
+	warnings: list[str] = []
 	for node in ast.walk(tree):
 		if isinstance(node, (ast.Import, ast.ImportFrom)):
 			errors.append(
@@ -58,7 +117,9 @@ def _ast_scan(code: str) -> list[str]:
 				errors.append(f"line {node.lineno}: dunder access `{node.attr}` is blocked in safe_exec.")
 		elif isinstance(node, ast.Name) and node.id in _BANNED_NAMES:
 			errors.append(f"line {node.lineno}: `{node.id}` is not available in safe_exec.")
-	return errors
+		elif isinstance(node, ast.Call):
+			warnings.extend(_agg_field_warnings(node))
+	return errors, warnings
 
 
 def validate_script(code, script_type=None) -> dict:
@@ -70,6 +131,10 @@ def validate_script(code, script_type=None) -> dict:
 	`frappe.db.sql` (both bypass User Permissions - use `frappe.get_list`),
 	`open`/`eval`/`exec`/`__import__`, dunder access, and any RestrictedPython
 	compile error (the exact compile safe_exec runs). It never executes the code.
+	Also flags `frappe.<attr>` calls outside the safe_exec namespace (e.g.
+	`frappe.defaults` / `frappe.get_user_default` - use `frappe.db.get_default`).
+	Warns (not an error) on SQL functions passed as `get_list` string fields
+	(`sum(...) as x`), which Frappe rejects at query time - aggregate in Python.
 
 	- ``code``: the script body (str).
 	- ``script_type``: optional hint ("Script Report", "DocType Event", "API",
@@ -88,9 +153,24 @@ def validate_script(code, script_type=None) -> dict:
 	warnings: list[str] = []
 
 	try:
-		errors.extend(_ast_scan(code))
+		tree = ast.parse(code)
 	except SyntaxError as e:
 		return {"ok": False, "errors": [f"SyntaxError: {e.msg} (line {e.lineno})"], "warnings": warnings}
+
+	scan_errors, scan_warnings = _ast_scan(tree)
+	errors.extend(scan_errors)
+	warnings.extend(scan_warnings)
+
+	# Flag frappe.* attributes absent from the real safe_exec namespace (best-effort:
+	# needs a frappe context, so guard it; the AST scan + compile pass stand without it).
+	try:
+		from frappe.utils.safe_exec import get_safe_globals
+
+		frappe_ns = get_safe_globals().get("frappe")
+		if frappe_ns is not None:
+			errors.extend(_namespace_errors(tree, set(frappe_ns.keys())))
+	except Exception:
+		pass
 
 	# The authoritative RestrictedPython compile safe_exec itself uses. Private
 	# frappe helper, so guard it: if it moves, the AST scan above still stands.

--- a/jarvis/tools/validate_script.py
+++ b/jarvis/tools/validate_script.py
@@ -96,9 +96,27 @@ def _namespace_errors(tree: ast.AST, frappe_keys: set[str]) -> list[str]:
 	return errors
 
 
+def _result_shape_warning(assign: ast.Assign) -> list[str]:
+	"""Flag `result = [columns, ...]` - a Script Report's columns/rows pair must go
+	in `data` (`data = [columns, rows]`), not `result`, or Frappe uses the report's
+	own (empty) columns and renders blank rows."""
+	for tgt in assign.targets:
+		if isinstance(tgt, ast.Name) and tgt.id == "result":
+			val = assign.value
+			if isinstance(val, ast.List) and val.elts:
+				first = val.elts[0]
+				if isinstance(first, ast.Name) and first.id == "columns":
+					return [
+						f"line {assign.lineno}: `result = [columns, ...]` renders a Script Report "
+						"blank - the columns/rows pair goes in `data`: `data = [columns, rows]`."
+					]
+	return []
+
+
 def _ast_scan(tree: ast.AST) -> tuple[list[str], list[str]]:
 	errors: list[str] = []
 	warnings: list[str] = []
+	qb_flagged = False
 	for node in ast.walk(tree):
 		if isinstance(node, (ast.Import, ast.ImportFrom)):
 			errors.append(
@@ -113,12 +131,22 @@ def _ast_scan(tree: ast.AST) -> tuple[list[str], list[str]]:
 					f"line {node.lineno}: `{dotted}` bypasses User Permissions "
 					"(cross-company/branch/dimension leak). Use `frappe.get_list` for every read."
 				)
+			elif dotted and (dotted == "frappe.qb" or dotted.startswith("frappe.qb.")):
+				if not qb_flagged:
+					qb_flagged = True
+					errors.append(
+						f"line {node.lineno}: `frappe.qb` runs raw SQL that bypasses User "
+						"Permissions, and its `Sum`/`Count` helpers aren't in the sandbox "
+						"(NameError). Read via `frappe.get_list` and aggregate in Python."
+					)
 			elif node.attr.startswith("__") and node.attr.endswith("__"):
 				errors.append(f"line {node.lineno}: dunder access `{node.attr}` is blocked in safe_exec.")
 		elif isinstance(node, ast.Name) and node.id in _BANNED_NAMES:
 			errors.append(f"line {node.lineno}: `{node.id}` is not available in safe_exec.")
 		elif isinstance(node, ast.Call):
 			warnings.extend(_agg_field_warnings(node))
+		elif isinstance(node, ast.Assign):
+			warnings.extend(_result_shape_warning(node))
 	return errors, warnings
 
 
@@ -127,14 +155,15 @@ def validate_script(code, script_type=None) -> dict:
 	Frappe's safe_exec sandbox WITHOUT running it. Call this before staging a
 	Server Script / Script Report create, and fix every error before drafting.
 
-	Catches: any `import` / third-party / app-function use, `frappe.get_all` and
-	`frappe.db.sql` (both bypass User Permissions - use `frappe.get_list`),
-	`open`/`eval`/`exec`/`__import__`, dunder access, and any RestrictedPython
-	compile error (the exact compile safe_exec runs). It never executes the code.
-	Also flags `frappe.<attr>` calls outside the safe_exec namespace (e.g.
-	`frappe.defaults` / `frappe.get_user_default` - use `frappe.db.get_default`).
-	Warns (not an error) on SQL functions passed as `get_list` string fields
-	(`sum(...) as x`), which Frappe rejects at query time - aggregate in Python.
+	Catches: any `import` / third-party / app-function use, `frappe.get_all`,
+	`frappe.db.sql`, and `frappe.qb` (all bypass User Permissions - use
+	`frappe.get_list`), `open`/`eval`/`exec`/`__import__`, dunder access, and any
+	RestrictedPython compile error (the exact compile safe_exec runs). It never
+	executes the code. Also flags `frappe.<attr>` calls outside the safe_exec
+	namespace (e.g. `frappe.defaults` / `frappe.get_user_default` - use
+	`frappe.db.get_default`). Warns on SQL functions passed as `get_list` string
+	fields (`sum(...) as x`), and on `result = [columns, ...]` (a Script Report's
+	columns/rows pair goes in `data`, not `result`, or it renders blank).
 
 	- ``code``: the script body (str).
 	- ``script_type``: optional hint ("Script Report", "DocType Event", "API",


### PR DESCRIPTION
Backport of #1030 to this version branch — clean cherry-pick of its three commits (the version branch's tool set + `tool-names.json` are identical to develop, so the regenerated contract matches byte-for-byte).

Adds **`jarvis__validate_script`** — a static checker for the `safe_exec` sandbox (Server Scripts + Script Report `report_script`). AST scan + `_compile_code` (never executes) flags: imports, dunders, banned builtins, the permission-bypass reads `get_all`/`db.sql`/`frappe.qb`, out-of-namespace `frappe.<attr>` (e.g. `frappe.defaults`), plus warnings for SQL functions in `get_list` fields and `result = [columns, ...]`. Returns `{ok, errors, warnings}`.

Files: `validate_script.py`, `registry.py` (+`validate_script`), `tool-names.json` (regenerated, digest refreshed), `test_validate_script.py` (20 tests).

See #1030 for full detail. Pairs with the plugin descriptor (jarvis-openclaw-plugin #80) and the `frappe-scripting` skill (jarvis-persona #211).
