### PR TITLE
fix(create-card): carry the document name for Prompt-autonamed DocTypes (backport #1032 → version-16)

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6462,10 +6462,21 @@ async function buildDraftModel(a) {
 			origJson: JSON.stringify(verb === "update" ? baseRows : null),
 		});
 	}
+	// A Prompt-autonamed DocType (e.g. Server Script) carries its document name as a
+	// proposed "name" field, not a real DocField, so it never lands in `fields`.
+	// Capture it here so applyDraft sends it as `name` (the backend folds it into
+	// the create values). Field/series-named DocTypes have no such field -> "".
+	const proposedCreateName =
+		verb === "update"
+			? ""
+			: String(
+					((a.fields || []).find((x) => String(x.label || "").toLowerCase() === "name") || {})
+						.value ?? ""
+				);
 	return {
 		verb,
 		doctype: a.doctype,
-		docName: verb === "update" ? a.name || "" : "",
+		docName: verb === "update" ? a.name || "" : proposedCreateName,
 		title: a.title || "",
 		titleField: meta.title_field || "",
 		submittable: !!meta.is_submittable,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6470,9 +6470,12 @@ async function buildDraftModel(a) {
 		verb === "update"
 			? ""
 			: String(
-					((a.fields || []).find((x) => String(x.label || "").toLowerCase() === "name") || {})
-						.value ?? ""
-				);
+					(
+						(a.fields || []).find(
+							(x) => String(x.label || "").toLowerCase() === "name"
+						) || {}
+					).value ?? ""
+			  );
 	return {
 		verb,
 		doctype: a.doctype,

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -233,6 +233,20 @@ def apply_action(action: dict | str | None = None) -> dict:
 		raise InvalidArgumentError("conversation is required")
 	_require_own_conversation(conversation)
 
+	# A Prompt-autonamed DocType (e.g. Server Script) has NO `name` FIELD - the
+	# human-entered document name arrives only as `name`, never inside `values`
+	# (the panel builds values from DocFields). Fold it in for a create so the doc
+	# gets a name; without this the insert fails "Please set the document name".
+	# That error is raised ONLY by _prompt_autoname (frappe/model/naming.py), for
+	# autoname.startswith("prompt") - i.e. "Set by user". Every other naming rule
+	# either derives the name from a field already in `values` (By fieldname / By
+	# Naming Series) or auto-generates it (Autoincrement / Expression / Random /
+	# UUID / By script), so it needs no fold and folding could override it. Match
+	# Frappe's own check exactly so the scope stays correct.
+	if verb == "create" and name and "name" not in values:
+		if (frappe.get_meta(doctype).autoname or "").lower().startswith("prompt"):
+			values = {**values, "name": name}
+
 	from jarvis import api
 
 	# The audit/receipt args, built up front (independent of the write outcome);


### PR DESCRIPTION
Backport of #1032 to this version branch. **Adapted** (not a clean cherry-pick): the frontend hunk targets `buildDraftModel` — this branch's draft-model builder — whereas develop's location shifted after a refactor. Backend change and logic are identical.

## The bug
Confirming a chat **Create** card for a **Prompt-autonamed DocType** (e.g. `Server Script`) failed **"Please set the document name."** Such DocTypes have no `name` *field* — the name is the identifier — so it never landed in the draft panel's `values` (built from DocFields), and the insert ran nameless. `Report` etc. were unaffected (their name comes from a real field).

## Fix
- **Frontend** (`ChatView.vue` `buildDraftModel`): capture the proposed `name` field into the create model's `docName`, so `applyDraft` sends it (it already sends `name: p.docName`). Verified the confirm path here uses `buildDraftModel` → `summaryState.model` → `confirmSummary` → `applyDraft`.
- **Backend** (`apply_action`): fold the received `name` into the create `values`, scoped to `autoname.lower().startswith("prompt")` — the exact condition `_prompt_autoname` (`frappe/model/naming.py`) raises the error on. Every other naming rule (By fieldname / Naming Series → field already in values; Autoincrement / Expression / Random / UUID / By script → auto-generated) needs no fold.

See #1032 for full detail; the fix was verified end-to-end in-browser on develop (a Server Script now creates from the chat card).
