### PR TITLE
feat(chat): clearer, actionable low-worker warning copy

### DIFF
--- a/frontend/src/branding.js
+++ b/frontend/src/branding.js
@@ -16,9 +16,9 @@ export const isWhitelabeled = agentName !== DEFAULT_NAME || !!brandLogoUrl;
 // Shared worker-warning banner copy: OnboardingGate.vue and OnboardingView.vue
 // both render this Banner for the same degraded-worker signal, and previously
 // hardcoded the identical title + interpolated message in two places.
-export const WORKER_WARNING_TITLE = "Background workers are low";
+export const WORKER_WARNING_TITLE = "Replies may be slow";
 export function workerWarningMessage(name) {
-	return `Your ${name} background workers look under-provisioned. Chat may be slow or stall until more workers are running.`;
+	return `${name} is low on background workers, so answers may take longer. Add more workers to your bench to speed this up.`;
 }
 
 // Patch the browser-tab title + favicon to the tenant brand. Called once at

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2363,7 +2363,7 @@
 				<Banner
 					v-else-if="workersWarnNotice"
 					type="warning"
-					title="Replies may be slow right now"
+					title="Replies may be slow"
 					:message="workersWarnNotice"
 					style="margin-bottom: 10px"
 				/>
@@ -4275,7 +4275,7 @@ const WORKERS_BLOCKED_MSG =
 // cleared on the next successful retry/send, never re-derived from a re-poll
 // (checkReady() is memoized).
 const workersWarnNotice = ref(null);
-const WORKERS_WARN_MSG = `${agentName} is busier than usual, so answers might take a little longer. You can keep chatting.`;
+const WORKERS_WARN_MSG = `${agentName} is low on background workers, so answers may take longer. Add more workers to your bench to speed this up.`;
 // A DIFFERENT not-ready reason (container_provisioning - e.g. the connected LLM
 // account itself ran out of quota, or a container is still coming up) - never a
 // billing lapse, so it gets its own quiet copy instead of suspendedNotice's "Chat is

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -186,8 +186,8 @@
 				class="jvp-worker-notice"
 				role="status"
 			>
-				{{ brandName }} is low on background workers, so answers may take
-				longer. Add more workers to your bench to speed this up.
+				{{ brandName }} is low on background workers, so answers may take longer. Add more
+				workers to your bench to speed this up.
 			</div>
 
 			<div class="jvp-body" ref="bodyEl" @scroll.passive="onBodyScroll">

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -171,10 +171,10 @@
 
 			<!-- Worker-degraded heads-up: a SEPARATE, additive signal from the
 			     readiness gate above (see workerWarning's declaration). Renders ONLY
-			     when readiness === "ready" - chat is fully usable, just maybe a
-			     little slow. "gate" has no thread to warn about, and "degraded"
+			     when readiness === "ready" - chat is fully usable, just maybe
+			     slower. "gate" has no thread to warn about, and "degraded"
 			     already shows .jvp-notice below saying replies may FAIL outright;
-			     stacking this "may be a little slower" banner under that would
+			     stacking this "replies may be slow" banner under that would
 			     contradict and undersell the real state, so degraded keeps its own
 			     banner instead of also getting this one. Non-blocking by
 			     construction either way - never disables the composer, never
@@ -186,7 +186,8 @@
 				class="jvp-worker-notice"
 				role="status"
 			>
-				Replies may be a little slower than usual right now.
+				{{ brandName }} is low on background workers, so answers may take
+				longer. Add more workers to your bench to speed this up.
 			</div>
 
 			<div class="jvp-body" ref="bodyEl" @scroll.passive="onBodyScroll">
@@ -2630,7 +2631,7 @@ defineExpose({ load, startNewChat, convId });
    compact and clearly non-blocking. Renders only on a fully "ready" workspace
    whose workers are merely stretched (see the template v-if) - readiness ===
    "degraded" already gets .jvp-notice's own "replies may fail" banner, and this
-   lighter "may be a little slower" one would undersell that, so the two never
+   lighter "replies may be slow" one would undersell that, so the two never
    stack. */
 .jvp-worker-notice {
 	flex: none;


### PR DESCRIPTION
## Summary

Clearer, actionable copy for the low-background-workers warning banner. The old wording ("busier than usual" / "under-provisioned") was vague and gave no fix; this replaces it with a single message that tells the reader what to do.

Shown identically in onboarding, the main chat, and the desk popup (whitelabel-safe via the agent name):
- **Title:** Replies may be slow
- **Message:** `<Agent> is low on background workers, so answers may take longer. Add more workers to your bench to speed this up.`

Copy-only. Behavior is unchanged: non-blocking (composer stays enabled), self-clears on a successful send, and fires on the same condition as before (no dedicated `jarvis_chat` lane and fewer than 2 `long` workers). Follow-up to #1018.

## Screenshots

Live on e2e.localhost (onboarding gate), worker-low state forced to show the wording (the trigger is unchanged from #1018).

**Before**

![Before: Background workers are low / under-provisioned](https://github.com/user-attachments/assets/ddbbfd2e-1ed0-4b69-9440-ed4b269aea41)

**After**

![After: Replies may be slow / add more workers to your bench](https://github.com/user-attachments/assets/b07e7d53-d516-40bd-8d0e-d6f837f0b7e3)

The same message renders identically in the main chat and the desk popup.

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (hosted CI runs on open; do not merge on ❌)
- [x] Branch is **up to date with `develop`** (branched from the latest `develop` tip)
- [x] New/changed behavior has tests (copy-only; existing banner tests stay green)
- [x] I self-reviewed the diff
