### PR TITLE
feat(chat): warn on fewer than 2 total workers, not just <2 long

### DIFF
--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -863,9 +863,15 @@ def _warn_provisioning_if_starved() -> None:
 # Two conditions, deliberately split so the fail-CLOSED chat block is flap-proof
 # on the managed fleet (a rolling worker restart must never block a paying
 # customer):
-#   * DEGRADED  -> warn only. The F1 self-starvation shape (_pump_shape_starves):
-#     turns run but strand for minutes. Surfaced as a non-blocking onboarding
-#     banner; chat still works.
+#   * DEGRADED  -> warn only. Fires when TOTAL live RQ workers (any queue) < 2,
+#     not the stricter F1 "< 2 `long` workers" shape (_pump_shape_starves) used
+#     by the ops provisioning warning. Rationale: the pump already reroutes
+#     prepare/finalize (control) jobs to `short` when `long` has < 2 workers
+#     (`_control_queue`), so 1 `long` worker plus a second worker to run those
+#     control jobs does NOT strand - the stricter "< 2 `long`" rule over-warned
+#     that case. The strand only truly happens with a single worker doing
+#     everything, so this warns on total headcount instead. Surfaced as a
+#     non-blocking onboarding banner; chat still works.
 #   * BLOCKED   -> block sends. CONFIDENT zero live workers on the turn queue,
 #     sustained past a short grace window. This is the only guaranteed-hang shape
 #     (no worker can pick a turn up at all). Never fires on a probe error.
@@ -951,15 +957,35 @@ def _turn_workers_confidently_zero() -> bool:
 	return _zero_persisted(_ZERO_GRACE_S)
 
 
+def _total_live_workers() -> "int | None":
+	"""Count of ALL live RQ workers on this bench, across every queue - not just
+	the pump's hop/control lanes. Returns ``None`` (not 0) on any probe trouble
+	so the caller fails SAFE (not degraded) rather than reading a broken probe
+	as a real shortage."""
+	try:
+		from frappe.utils.background_jobs import get_workers
+
+		return len(get_workers())
+	except Exception:
+		return None
+
+
 def chat_worker_status() -> dict:
 	"""Worker health for the onboarding warning + chat send block. Fails SAFE:
-	on any trouble reports neither blocked nor degraded."""
+	on any trouble reports neither blocked nor degraded.
+
+	``degraded`` fires on fewer than 2 TOTAL live RQ workers (any queue), not the
+	stricter F1 "< 2 `long` workers" shape - see the block comment above for the
+	rationale (the pump already reroutes control jobs off `long` when it has < 2
+	workers, so that stricter rule over-warned). A blocked state is always at
+	least degraded too."""
 	try:
 		blocked = _turn_workers_confidently_zero()
 	except Exception:
 		blocked = False
 	try:
-		degraded = _pump_shape_starves()
+		n = _total_live_workers()
+		degraded = n is not None and n < 2
 	except Exception:
 		degraded = False
 	return {"blocked": bool(blocked), "degraded": bool(blocked or degraded)}

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -2148,45 +2148,86 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 		with patch("frappe.utils.background_jobs.get_workers", side_effect=RuntimeError):
 			self.assertIsNone(pump._probe_worker_count("long"))
 
+	def test_total_live_workers_counts_all_queues(self):
+		fake_workers = [MagicMock(), MagicMock(), MagicMock()]
+		with patch("frappe.utils.background_jobs.get_workers", return_value=fake_workers):
+			self.assertEqual(pump._total_live_workers(), 3)
+
+	def test_total_live_workers_none_on_probe_error(self):
+		with patch("frappe.utils.background_jobs.get_workers", side_effect=RuntimeError):
+			self.assertIsNone(pump._total_live_workers())
+
 	def test_healthy_is_not_blocked_not_degraded(self):
 		with (
 			patch.object(pump, "_probe_worker_count", return_value=4),
-			patch.object(pump, "_pump_shape_starves", return_value=False),
+			patch.object(pump, "_total_live_workers", return_value=4),
 			patch("jarvis.chat.api._turn_queue", return_value="long"),
 		):
 			s = pump.chat_worker_status()
 			self.assertFalse(s["blocked"])
 			self.assertFalse(s["degraded"])
 
-	def test_one_worker_degraded_not_blocked(self):
+	def test_one_total_worker_degraded_not_blocked(self):
+		# 1 TOTAL live worker (any queue) -> degraded, even though the turn queue
+		# itself still shows a live worker (not blocked).
 		with (
 			patch.object(pump, "_probe_worker_count", return_value=1),
-			patch.object(pump, "_pump_shape_starves", return_value=True),
+			patch.object(pump, "_total_live_workers", return_value=1),
 			patch("jarvis.chat.api._turn_queue", return_value="long"),
 		):
 			s = pump.chat_worker_status()
 			self.assertFalse(s["blocked"])
 			self.assertTrue(s["degraded"])
 
+	def test_two_total_workers_not_degraded(self):
+		# The discriminating case: exactly 2 total workers must NOT warn (this is
+		# the F1 "1 long + 1 to run rerouted control jobs" shape that no longer
+		# strands, per `_control_queue`). Fails if the threshold were `<= 2`.
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=2),
+			patch.object(pump, "_total_live_workers", return_value=2),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			s = pump.chat_worker_status()
+			self.assertFalse(s["blocked"])
+			self.assertFalse(s["degraded"])
+
+	def test_total_worker_probe_error_not_degraded(self):
+		# Fail-safe: a probe error (_total_live_workers -> None) must never be
+		# read as a real shortage.
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=4),
+			patch.object(pump, "_total_live_workers", return_value=None),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			s = pump.chat_worker_status()
+			self.assertFalse(s["blocked"])
+			self.assertFalse(s["degraded"])
+
 	def test_probe_error_never_blocks(self):
 		with (
 			patch.object(pump, "_probe_worker_count", return_value=None),
-			patch.object(pump, "_pump_shape_starves", return_value=False),
+			patch.object(pump, "_total_live_workers", return_value=4),
 			patch("jarvis.chat.api._turn_queue", return_value="long"),
 		):
 			self.assertFalse(pump.chat_worker_status()["blocked"])
 
-	def test_zero_workers_blocks_only_after_grace(self):
+	def test_zero_workers_blocks_only_after_grace_and_is_degraded(self):
 		with (
 			patch.object(pump, "_probe_worker_count", return_value=0),
-			patch.object(pump, "_pump_shape_starves", return_value=True),
+			patch.object(pump, "_total_live_workers", return_value=0),
 			patch("jarvis.chat.api._turn_queue", return_value="long"),
 		):
-			# first observation: marker set, NOT yet blocked (debounce)
-			self.assertFalse(pump.chat_worker_status()["blocked"])
+			# first observation: marker set, NOT yet blocked (debounce); 0 total
+			# workers is already degraded regardless of the blocked debounce.
+			s = pump.chat_worker_status()
+			self.assertFalse(s["blocked"])
+			self.assertTrue(s["degraded"])
 			# simulate the marker aging past the grace window
 			pump._force_zero_marker_age(pump._ZERO_GRACE_S + 5)
-			self.assertTrue(pump.chat_worker_status()["blocked"])
+			s = pump.chat_worker_status()
+			self.assertTrue(s["blocked"])
+			self.assertTrue(s["degraded"])  # a blocked state is always at least degraded
 
 	def test_recovery_clears_marker(self):
 		with (
@@ -2201,14 +2242,14 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 		pump._force_zero_marker_age(pump._ZERO_GRACE_S + 5)
 		with (
 			patch.object(pump, "_probe_worker_count", return_value=3),
-			patch.object(pump, "_pump_shape_starves", return_value=False),
+			patch.object(pump, "_total_live_workers", return_value=3),
 			patch("jarvis.chat.api._turn_queue", return_value="long"),
 		):
 			self.assertFalse(pump.chat_worker_status()["blocked"])
 			# marker cleared: a later single 0 must re-arm the grace, not block instantly
 			with (
 				patch.object(pump, "_probe_worker_count", return_value=0),
-				patch.object(pump, "_pump_shape_starves", return_value=True),
+				patch.object(pump, "_total_live_workers", return_value=0),
 			):
 				self.assertFalse(pump.chat_worker_status()["blocked"])
 


### PR DESCRIPTION
## Summary

Relax the low-worker warning so it fires on **fewer than 2 total live RQ workers** (any queue), instead of the stricter "fewer than 2 `long` workers". The hard block (0 turn-queue workers, 20s-debounced) is unchanged.

Why: the pump already reroutes the prepare/finalize (control) jobs to `short` when `long` has under 2 workers (`_control_queue`), so **1 `long` worker plus a second worker to run those control jobs does not strand**. The old "2 on long" rule over-warned that shape. The turn only truly strands when a single worker has to run the hop and its control jobs by itself, i.e. fewer than 2 total workers.

Net effect:
- 1 worker total (the stock Frappe default) still warns.
- 2+ workers (e.g. 1 `long` + 1 `short`/generic) no longer warns.
- 0 turn-queue workers still blocks (unchanged).

**Backend-only** (`pump.py` + tests). No UI change: the banner and its copy are untouched, so there are no before/after screenshots (nothing visual differs; only the trigger condition). Follow-up to #1018; independent of the copy change in #1039.

## Verification
- `test_pump` 75/75, `test_chat_policy` 22/22, `test_account` 111/111; pre-commit clean.
- Fail-safe preserved: a worker-probe error reports not-degraded (never warns on an error). The ops-facing `_pump_shape_starves` provisioning warning keeps its old F1-shape meaning.

## Pre-merge checklist

> ℹ️ Branch protection is not enforced on GitHub Free; honoring this checklist keeps broken changes out of UAT.

- [ ] **CI is green** — hosted CI runs on open; do not merge on ❌
- [x] Branch is up to date with `develop`
- [x] New/changed behavior has tests (threshold discriminated: total=2 not degraded, total=1 degraded, probe-error not degraded)
- [x] I self-reviewed the diff
