### PR TITLE
chore: backport onboarding + low-worker guards to version-15 (#1018)

### DIFF
--- a/frontend/src/branding.js
+++ b/frontend/src/branding.js
@@ -13,6 +13,14 @@ export const brandFaviconUrl = (window.brand_favicon_url || "").trim();
 // decide between "Jarvis" defaults and the tenant brand.
 export const isWhitelabeled = agentName !== DEFAULT_NAME || !!brandLogoUrl;
 
+// Shared worker-warning banner copy: OnboardingGate.vue and OnboardingView.vue
+// both render this Banner for the same degraded-worker signal, and previously
+// hardcoded the identical title + interpolated message in two places.
+export const WORKER_WARNING_TITLE = "Background workers are low";
+export function workerWarningMessage(name) {
+	return `Your ${name} background workers look under-provisioned. Chat may be slow or stall until more workers are running.`;
+}
+
 // Patch the browser-tab title + favicon to the tenant brand. Called once at
 // boot from main.js; safe before mount. Best-effort - never blocks boot.
 export function applyBrandChrome() {

--- a/frontend/src/components/shell/OnboardingGate.vue
+++ b/frontend/src/components/shell/OnboardingGate.vue
@@ -17,6 +17,14 @@
 				Finish setting up {{ agentName }}
 			</h1>
 
+			<Banner
+				v-if="workerWarning"
+				type="warning"
+				:title="WORKER_WARNING_TITLE"
+				:message="workerWarningMessage(agentName)"
+				class="mb-5"
+			/>
+
 			<p v-if="isSystemManager" class="mb-7 text-p-base text-ink-gray-6">
 				This workspace isn't connected to an AI agent yet. Complete a short setup to start
 				chatting with {{ agentName }} about your ERPNext data.
@@ -52,7 +60,8 @@
 import { useRouter } from "vue-router";
 import { Button } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
-import { agentName } from "@/branding";
+import Banner from "@/components/Banner.vue";
+import { agentName, WORKER_WARNING_TITLE, workerWarningMessage } from "@/branding";
 
 const router = useRouter();
 
@@ -65,6 +74,9 @@ const router = useRouter();
 // gets the "ask your administrator" copy instead. PART 4 REVISED TASK 49(c):
 // widened to the Jarvis Admin tenant-admin tier.
 const isSystemManager = !!(window.is_system_manager || window.is_jarvis_admin);
+
+// Non-blocking: warns without gating either CTA below (Task 5's boot flag).
+const workerWarning = !!window.jarvis_worker_warning;
 
 function goOnboard() {
 	router.push({ name: "Onboarding" });

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -401,6 +401,159 @@ describe("ChatView banner chain order", () => {
 		// lapsed - never over a retry that just flipped the reason back to applying.
 		expect(applying).toBeLessThan(stuck);
 	});
+
+	it("orders the no-workers banner AFTER suspendedNotice (billing takes precedence, jarvis Task 8)", () => {
+		const suspended = chatSrc.indexOf('v-else-if="suspendedNotice"');
+		const workers = chatSrc.indexOf('v-else-if="workersNotice"');
+		expect(suspended, "ChatView must still render the suspendedNotice banner").not.toBe(-1);
+		expect(workers, "ChatView must render the workersNotice banner").not.toBe(-1);
+		expect(suspended).toBeLessThan(workers);
+	});
+
+	it("orders the soft workersWarnNotice banner AFTER the hard workersNotice block", () => {
+		// worker_blocked implies degraded, so the hard block must win the
+		// v-else-if race whenever both are true - the soft warning below it in
+		// the chain then only ever shows on its own.
+		const workers = chatSrc.indexOf('v-else-if="workersNotice"');
+		const warn = chatSrc.indexOf('v-else-if="workersWarnNotice"');
+		expect(workers, "ChatView must still render the workersNotice banner").not.toBe(-1);
+		expect(warn, "ChatView must render the workersWarnNotice banner").not.toBe(-1);
+		expect(workers).toBeLessThan(warn);
+	});
+});
+
+/**
+ * jarvis Task 8: insufficient_workers must be a PERSISTENT but SELF-HEALING
+ * banner - unlike suspendedNotice (whose only exit is renewal), a dead worker
+ * lane can come back on its own, and checkReady() is memoized (never re-polls),
+ * so the banner cannot wait on a fresh readiness check to clear. Mounting
+ * ChatView / driving send() is not viable here (same reasoning as the banner
+ * chain order block above and dashboardOpen.test.js), so this pins the wiring
+ * by source, the established technique for this SFC.
+ */
+describe("workersNotice self-heal (jarvis Task 8)", () => {
+	const HERE = path.dirname(fileURLToPath(import.meta.url));
+	const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+	it("raises the persistent banner when retry() is rejected for insufficient_workers", () => {
+		// retry() (~line 8234) sits earlier in the file than send() (~line 8467), so
+		// this is the FIRST occurrence of the reason check.
+		const idx = chatSrc.indexOf('r.reason === "insufficient_workers"');
+		expect(idx, "retry() must check r.reason === insufficient_workers").not.toBe(-1);
+		const nearby = chatSrc.slice(idx, idx + 320);
+		// Sets the persistent banner ref directly, not a toast that would vanish
+		// before the customer can act on it.
+		expect(nearby).toContain("workersNotice.value = WORKERS_BLOCKED_MSG");
+	});
+
+	it("mirrors the same insufficient_workers handling in send()", () => {
+		const first = chatSrc.indexOf('r.reason === "insufficient_workers"');
+		const second = chatSrc.indexOf('r.reason === "insufficient_workers"', first + 1);
+		expect(second, "send() must also check r.reason === insufficient_workers").not.toBe(-1);
+		expect(chatSrc.slice(second, second + 200)).toContain(
+			"workersNotice.value = WORKERS_BLOCKED_MSG"
+		);
+	});
+
+	it("clears the banner on the next successful retry (self-heal, no reload)", () => {
+		// retry() sits earlier in the file than send(), so this is the FIRST
+		// occurrence of the clear.
+		const fnStart = chatSrc.indexOf("async function retry(messageId)");
+		const fnEnd = chatSrc.indexOf("\nasync function send(", fnStart);
+		expect(fnStart, "ChatView must still define retry()").not.toBe(-1);
+		expect(fnEnd, "ChatView must still define send() after retry()").not.toBe(-1);
+		const body = chatSrc.slice(fnStart, fnEnd);
+		const awaitIdx = body.indexOf("await api.retryMessage(messageId)");
+		const idx = body.indexOf("workersNotice.value = null");
+		expect(awaitIdx, "retry() must still await api.retryMessage").not.toBe(-1);
+		expect(idx, "retry() must clear workersNotice on a successful response").not.toBe(-1);
+		// Only AFTER the await (never optimistically, before the server has
+		// actually answered) and gated on r.ok !== false (a genuinely accepted
+		// retry), not folded into the rejection branch that raises the banner.
+		expect(idx).toBeGreaterThan(awaitIdx);
+		const before = body.slice(Math.max(0, idx - 120), idx);
+		expect(before).toContain("r.ok !== false");
+	});
+
+	it("also clears the banner on the next successful send (mirrors retry())", () => {
+		const first = chatSrc.indexOf("workersNotice.value = null");
+		const second = chatSrc.indexOf("workersNotice.value = null", first + 1);
+		expect(second, "send() must also clear workersNotice on a successful response").not.toBe(
+			-1
+		);
+		const before = chatSrc.slice(Math.max(0, second - 120), second);
+		expect(before).toContain("r.ok !== false");
+	});
+
+	it("never gates canSend on workersNotice (composer must stay enabled to self-heal)", () => {
+		// A disabled composer paired with a memoized (never re-polling) checkReady()
+		// could never recover without a full page reload, contradicting the banner's
+		// own "try again shortly" copy - the server gate, not the client, is the
+		// authority on whether a send is allowed through.
+		const start = chatSrc.indexOf("const canSend = computed(");
+		expect(start, "ChatView must still define canSend").not.toBe(-1);
+		const end = chatSrc.indexOf("\n);", start);
+		expect(chatSrc.slice(start, end)).not.toContain("workersNotice");
+	});
+
+	it("seeds workersNotice from the boot readiness poll's worker_blocked field", () => {
+		const idx = chatSrc.indexOf("r && r.worker_blocked");
+		expect(idx, "the boot checkReady().then() block must read r.worker_blocked").not.toBe(-1);
+		expect(chatSrc.slice(idx, idx + 80)).toContain("WORKERS_BLOCKED_MSG");
+	});
+});
+
+/**
+ * Soft, non-blocking counterpart to workersNotice above: is_ready_for_chat's
+ * worker_warning fires for degraded/under-provisioned workers, distinct from
+ * the hard worker_blocked zero-workers state. Same source-proximity technique
+ * as the workersNotice suite (mounting ChatView is not viable here either).
+ */
+describe("workersWarnNotice self-heal (round 2 mainchat warning)", () => {
+	const HERE = path.dirname(fileURLToPath(import.meta.url));
+	const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+	it("seeds workersWarnNotice from the boot readiness poll's worker_warning field", () => {
+		const idx = chatSrc.indexOf("r && r.worker_warning");
+		expect(idx, "the boot checkReady().then() block must read r.worker_warning").not.toBe(-1);
+		expect(chatSrc.slice(idx, idx + 80)).toContain("WORKERS_WARN_MSG");
+	});
+
+	it("clears workersWarnNotice on the next successful retry, alongside workersNotice", () => {
+		const fnStart = chatSrc.indexOf("async function retry(messageId)");
+		const fnEnd = chatSrc.indexOf("\nasync function send(", fnStart);
+		expect(fnStart, "ChatView must still define retry()").not.toBe(-1);
+		expect(fnEnd, "ChatView must still define send() after retry()").not.toBe(-1);
+		const body = chatSrc.slice(fnStart, fnEnd);
+		const idx = body.indexOf("workersWarnNotice.value = null");
+		expect(idx, "retry() must clear workersWarnNotice on a successful response").not.toBe(-1);
+		// Same self-heal spot as workersNotice's own clear, immediately after it.
+		const notice = body.indexOf("workersNotice.value = null");
+		expect(notice).toBeGreaterThan(-1);
+		expect(idx).toBeGreaterThan(notice);
+		expect(idx - notice).toBeLessThan(80);
+	});
+
+	it("also clears workersWarnNotice on the next successful send (mirrors retry())", () => {
+		const first = chatSrc.indexOf("workersWarnNotice.value = null");
+		const second = chatSrc.indexOf("workersWarnNotice.value = null", first + 1);
+		expect(
+			second,
+			"send() must also clear workersWarnNotice on a successful response"
+		).not.toBe(-1);
+		// Sits right after send()'s own workersNotice clear, same as retry() above.
+		const notice = chatSrc.indexOf("workersNotice.value = null", first + 1);
+		expect(notice).toBeGreaterThan(-1);
+		expect(second).toBeGreaterThan(notice);
+		expect(second - notice).toBeLessThan(80);
+	});
+
+	it("never gates canSend on workersWarnNotice (composer must stay enabled - heads-up only)", () => {
+		const start = chatSrc.indexOf("const canSend = computed(");
+		expect(start, "ChatView must still define canSend").not.toBe(-1);
+		const end = chatSrc.indexOf("\n);", start);
+		expect(chatSrc.slice(start, end)).not.toContain("workersWarnNotice");
+	});
 });
 
 describe("replaced-site banner", () => {

--- a/frontend/src/utils/voiceSendGlue.test.js
+++ b/frontend/src/utils/voiceSendGlue.test.js
@@ -929,8 +929,11 @@ test("jarvis#496 source pin: ChatView clears _prefillSendContext only on the acc
 	// check. A regression that clears the context as the FIRST statement inside the rejected branch
 	// (unconditionally wiping it on every rejection, reintroducing the jarvis#496 bug) would still
 	// be textually after a bare "if (r && r.ok === false)" search, but sits BEFORE this closing
-	// sequence, so it fails here.
-	const rejectBlockCloseIdx = sendSrc.indexOf("return;\n\t\t}\n\t\t// Send accepted");
+	// sequence, so it fails here. The rejection block's final `return;` and closing brace are
+	// immediately followed by the workers-notice self-heal block's `if`, not directly by the
+	// "// Send accepted" comment (a workersNotice/workersWarnNotice self-heal block now sits
+	// between the two), so anchor on that sibling `if` instead of the comment.
+	const rejectBlockCloseIdx = sendSrc.indexOf("return;\n\t\t}\n\t\tif (r && r.ok !== false) {");
 	const clearIdx = sendSrc.indexOf("_prefillSendContext = null;");
 	assert.ok(
 		awaitIdx > -1 && rejectBlockCloseIdx > -1 && clearIdx > -1,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2343,6 +2343,30 @@
 						<button class="jv-btn jv-btn--sm" @click="goRenew">Renew</button>
 					</template>
 				</Banner>
+				<!-- No live background worker to run a turn. AFTER suspendedNotice (billing
+					 takes precedence) - ORDER MATTERS, pinned by readiness.spec.js. The
+					 composer stays enabled (see canSend): a send re-raises this if the lane
+					 is still dead, or clears it if the worker came back (self-heal). -->
+				<Banner
+					v-else-if="workersNotice"
+					type="warning"
+					title="Chat is paused"
+					:message="workersNotice"
+					style="margin-bottom: 10px"
+				/>
+				<!-- Soft counterpart to workersNotice above: worker_warning (degraded /
+					 under-provisioned workers) rather than the hard zero-workers block.
+					 AFTER workersNotice - ORDER MATTERS, pinned by readiness.spec.js: the
+					 block wins the v-else-if race whenever both are true (worker_blocked
+					 implies degraded), so this only ever shows on its own. Non-blocking -
+					 the composer stays enabled (see canSend), this is a heads-up only. -->
+				<Banner
+					v-else-if="workersWarnNotice"
+					type="warning"
+					title="Replies may be slow right now"
+					:message="workersWarnNotice"
+					style="margin-bottom: 10px"
+				/>
 				<!-- No model configured: the workspace was disconnected, or its credential
 					 expired. The composer is disabled alongside this (see canSend) - every
 					 send would fail at the agent, and letting it be tried just turns a clear
@@ -4234,6 +4258,24 @@ watch(
 // Renew-banner copy when the subscription has lapsed; null while entitled.
 // The composer is disabled alongside it (no send can succeed while stopped).
 const suspendedNotice = ref(null);
+// Chat is blocked because the site has no live background worker to run a turn.
+// Persistent (not a toast), but UNLIKE suspendedNotice the composer stays enabled:
+// checkReady() is memoized and never re-polls, so a disabled composer could never
+// recover without a full reload. Instead this self-heals - a still-dead lane
+// re-raises it on the next rejected send, a recovered lane clears it on the next
+// successful one (see send()). Null while healthy.
+const workersNotice = ref(null);
+const WORKERS_BLOCKED_MSG =
+	"Chat is paused: no background workers are running to handle messages. Please try again shortly.";
+// Soft, non-blocking counterpart to workersNotice above: worker_warning fires
+// when workers are merely under-provisioned/degraded, distinct from the hard
+// worker_blocked zero-workers state. The composer stays enabled - canSend
+// must never gate on this (see the "never gates canSend" test) - this is a
+// heads-up only, not a stop sign. Self-heals the same way workersNotice does:
+// cleared on the next successful retry/send, never re-derived from a re-poll
+// (checkReady() is memoized).
+const workersWarnNotice = ref(null);
+const WORKERS_WARN_MSG = `${agentName} is busier than usual, so answers might take a little longer. You can keep chatting.`;
 // A DIFFERENT not-ready reason (container_provisioning - e.g. the connected LLM
 // account itself ran out of quota, or a container is still coming up) - never a
 // billing lapse, so it gets its own quiet copy instead of suspendedNotice's "Chat is
@@ -8265,10 +8307,18 @@ async function retry(messageId) {
 			// not a toast that vanishes before they can renew.
 			if (r.reason === "subscription_suspended") {
 				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
+			} else if (r.reason === "insufficient_workers") {
+				// No live worker to run the retried turn - same persistent, self-healing
+				// banner a blocked send raises (see send()).
+				if (!workersNotice.value) workersNotice.value = WORKERS_BLOCKED_MSG;
 			} else {
 				// e.g. the single-flight guard ("a reply is already in progress").
 				notify(r.reason || "Couldn't retry that.", { type: "error" });
 			}
+		}
+		if (r && r.ok !== false) {
+			workersNotice.value = null; // a retry got through: workers are back
+			workersWarnNotice.value = null; // same self-heal for the soft warning
 		}
 	} catch (e) {
 		sending.value = false;
@@ -8514,6 +8564,13 @@ async function send(textArg, resendAck) {
 				});
 				return;
 			}
+			// No live worker to run this turn: raise the persistent, self-healing
+			// banner (composer stays enabled - see canSend/workersNotice) rather than
+			// a toast that vanishes before the lane recovers.
+			if (r.reason === "insufficient_workers") {
+				if (!workersNotice.value) workersNotice.value = WORKERS_BLOCKED_MSG;
+				return;
+			}
 			notify(
 				// Period-neutral copy: "usage_limit" fires from BOTH the all-time
 				// aggregate cap (jarvis.chat.policy._over_total_limit) and the
@@ -8525,6 +8582,10 @@ async function send(textArg, resendAck) {
 				{ type: "error" }
 			);
 			return;
+		}
+		if (r && r.ok !== false) {
+			workersNotice.value = null; // a send got through: workers are back
+			workersWarnNotice.value = null; // same self-heal for the soft warning
 		}
 		// Send accepted — the one-shot grounding/prefill context is now consumed.
 		// Cleared HERE, not before the await: a rejected send (r.ok === false, above)
@@ -10341,6 +10402,15 @@ onMounted(async () => {
 			// reason gets its own honest, CTA-less banner below.
 			suspendedNotice.value =
 				r && r.reason === "subscription_suspended" ? suspensionNotice(r) : null;
+			// Seed the workers banner from the same boot verdict. checkReady() is
+			// memoized and never re-polls, so this is a ONE-TIME seed only - the
+			// banner then self-heals through send()'s rejection/success branches,
+			// never through a re-check here.
+			workersNotice.value = r && r.worker_blocked ? WORKERS_BLOCKED_MSG : null;
+			// Same one-time seed for the soft counterpart: worker_warning is a
+			// distinct, non-blocking degraded-workers signal (see workersWarnNotice
+			// above). It also self-heals through send()/retry() only, never here.
+			workersWarnNotice.value = r && r.worker_warning ? WORKERS_WARN_MSG : null;
 		})
 		.catch(() => {});
 	// Same boot promise, the container_provisioning half: readinessDetailOf reads the

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -33,6 +33,16 @@
 						>
 					</div>
 
+					<!-- Worker-warning banner: non-blocking, shown above every step (never
+						 gates a CTA). Task 5's boot flag; copy identical to OnboardingGate's. -->
+					<Banner
+						v-if="workerWarning"
+						type="warning"
+						:title="WORKER_WARNING_TITLE"
+						:message="workerWarningMessage(agentName)"
+						class="mb-4 w-full max-w-[720px]"
+					/>
+
 					<!-- step rail: flat progress segments with labels (design.md §4.3 —
 					 no numbered circles, no connector lines). Hidden on the intro
 					 tour (chromeless). variant="steps" opts out of the 2026-08-16
@@ -46,6 +56,24 @@
 					<div
 						class="w-full overflow-hidden rounded-2xl border border-outline-gray-1 bg-surface-white shadow-2xl"
 					>
+						<!-- ===== Local/non-public host block: first in the chain, ahead of
+							 even the support panel, because a blocked host can never
+							 onboard on any step - the server enforces the same block at
+							 start_signup, this just stops the customer from reaching a dead
+							 CTA. ===== -->
+						<section v-if="showHostBlock" class="ob-screen">
+							<div class="ob-body ob-body--center">
+								<div class="ob-head">
+									<h1>Setup isn't available on this address</h1>
+									<p>
+										This site is running on a local or non-public address, so
+										sign-in links and agent connections can't reach it. Ask
+										your administrator to set a public host name for this site,
+										then reload this page.
+									</p>
+								</div>
+							</div>
+						</section>
 						<!-- ===== Contact support: a real ticket, filed from here. Hoisted
 							 above every step (not just Pay, where it started) so ANY screen
 							 that offers the support action - the payment recovery/terminal/
@@ -55,7 +83,7 @@
 							 binds on its own root. The action it replaces was a bare
 							 mailto:, which did nothing at all on a machine with no mail
 							 client. ===== -->
-						<section v-if="supportOpen" class="ob-screen">
+						<section v-else-if="supportOpen" class="ob-screen">
 							<div class="ob-body">
 								<div class="ob-head">
 									<h1>Get help with this</h1>
@@ -1917,7 +1945,7 @@ import {
 import { forgetReady, hasReconnectIntent, landingStep } from "@/onboarding/readiness.js";
 import { errMessage as errMsg } from "@/lib/errors";
 import { report as reportError } from "@/lib/errorReporter";
-import { agentName } from "@/branding";
+import { agentName, WORKER_WARNING_TITLE, workerWarningMessage } from "@/branding";
 import { createPaymentFlow } from "@/onboarding/usePaymentFlow";
 import {
 	STATES as PAY_STATES,
@@ -1944,6 +1972,16 @@ import { isExpectedCompanyDefaultsMiss } from "@/onboarding/companyDefaultsMiss"
 
 const router = useRouter();
 const { effectiveDark: dark, paletteVars } = useJarvisTheme();
+
+// Server-authoritative: onboarding is blocked when the bench is on a
+// local/non-public host (magic links + agent callbacks can't reach it).
+// jarvis_public_host_ok is purely host-based (the site's public host_name) -
+// there is no separate dev-bypass flag; a dev/e2e bench opts in by giving
+// itself a public-looking host_name, same as production.
+const hostOk = window.jarvis_public_host_ok !== false;
+
+// Non-blocking: warns without gating any step's CTA (Task 5's boot flag).
+const workerWarning = !!window.jarvis_worker_warning;
 
 // The 4 named wizard steps shown on the rail. The intro tour is chromeless
 // (no rail entry).
@@ -2394,7 +2432,7 @@ const payProviderReady = computed(() => !!state.paymentProvider);
 // payBusyView is declared further down; safe to close over here since this
 // getter only runs at render, after the whole setup script has executed.
 const payDisabled = computed(
-	() => payBusyView.value || !payProviderReady.value || !state.termsAccepted
+	() => payBusyView.value || !payProviderReady.value || !state.termsAccepted || !hostOk
 );
 // #669: how long the checkout link is good for. Reads the machine's own
 // payTokenExpiresInS, which is cleared with the token it belongs to, so this
@@ -3222,6 +3260,10 @@ const provisioningDelayed = computed(() => pay.value.value === S.PROVISIONING_DE
 // fall back to (owner decision 4). Only replaces the FRESH review card; a customer
 // with real server state (paid, verifying, a recovery) still sees their own state.
 const showMaintenanceHold = computed(() => !state.paymentUiV2 && pay.value.value === S.REVIEW);
+// Unlike showMaintenanceHold (a pay-step-only sub-state), a blocked host can
+// never onboard on any step, so this gates the wizard's top-level v-if chain
+// (rendered before even the intro tour) rather than the pay step's sub-chain.
+const showHostBlock = computed(() => !hostOk);
 
 // The busy-screen line. CHECKOUT_OPEN is the copy MOMENT before the browser
 // top-level-navigates to the admin-hosted pay page (WS7).
@@ -3739,6 +3781,7 @@ watch(
 // once through the flow; the machine takes it from there (verify / checkout /
 // parked-money / duplicate all land on their own sub-screen).
 async function onPayClick() {
+	if (!hostOk) return; // localhost/non-public bench: server rejects signup anyway
 	// plan-09 07-c: the CTA is hidden behind the maintenance hold when the flag is
 	// off; guard the handler too so a stray/programmatic click cannot start a signup.
 	if (!state.paymentUiV2) return;

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -738,7 +738,34 @@ def is_ready_for_chat() -> dict:
 	  customer must NOT retry payment or reconnect; ``detail`` carries admin's own
 	  reassurance (see ``_admin_chat_gate``, review plan 04 P0-6).
 	- ``None`` when ``ready`` is True.
+
+	Also carries two non-blocking worker-health fields, merged in AFTER the
+	verdict above and never able to change ``ready``/``reason``:
+
+	- ``worker_warning`` (bool) - the background worker lane looks degraded
+	  (``jarvis.chat.pump.chat_worker_status()['degraded']``). Soft: banner only.
+	- ``worker_blocked`` (bool) - workers confidently read as zero
+	  (``...['blocked']``). Still non-blocking here - the hard block on actually
+	  SENDING a chat message lives in chat/policy.py, not in this readiness read.
+
+	Fails safe: any exception probing worker health leaves both fields False
+	rather than raising or affecting the verdict above.
 	"""
+	verdict = _ready_verdict()
+	try:
+		from jarvis.chat.pump import chat_worker_status
+
+		w = chat_worker_status()
+		verdict["worker_warning"] = bool(w.get("degraded"))
+		verdict["worker_blocked"] = bool(w.get("blocked"))
+	except Exception:
+		verdict.setdefault("worker_warning", False)
+		verdict.setdefault("worker_blocked", False)
+	return verdict
+
+
+def _ready_verdict() -> dict:
+	"""Verdict body of ``is_ready_for_chat``; reason codes documented there."""
 	settings = frappe.get_single("Jarvis Settings")
 
 	admin_api_key = (

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -271,6 +271,63 @@ def _public_origin(trust_host: bool = False) -> str:
 	return base
 
 
+def _onboarding_host_ok() -> bool:
+	"""True only when this bench has a CONFIGURED public https host. Reads only
+	site_config ``host_name`` (never the request Host header, which is
+	spoofable), validates it with ``_is_real_public_host``. No ``host_name``, a
+	non-https scheme, or a localhost/reserved/IP ``host_name``, blocks. Drives
+	the localhost onboarding hard-block.
+
+	Dev/e2e benches that need onboarding to work set a public-looking
+	``host_name`` (e.g. ``https://jarvis-e2e.aerele.in``) in site_config - not
+	a backdoor flag.
+
+	CI runs on a fresh site with no configured host, so - like
+	policy._llm_not_configured - the gate is inert under test unless a test opts
+	in via ``frappe.flags.test_host_guard``. Otherwise every existing test that
+	calls start_signup would fail on CI's fresh DB.
+
+	Fails OPEN on any error: a probe failure must never block a legitimate
+	signup - only a CONFIDENT localhost/reserved/IP reading blocks."""
+	if frappe.flags.in_test and not frappe.flags.get("test_host_guard"):
+		return True
+	try:
+		host_name = (frappe.conf.get("host_name") or frappe.conf.get("hostname") or "").strip()
+		if not host_name:
+			return False
+		from urllib.parse import urlsplit
+
+		if not host_name.startswith(("http://", "https://")):
+			host_name = "https://" + host_name
+		parts = urlsplit(host_name)
+		if parts.scheme != "https":
+			# Match _public_origin: a non-https host_name is not used there
+			# either (it falls back to the spoofable request Host), so it must
+			# not pass the guard.
+			return False
+		host = (parts.hostname or "").lower().rstrip(".")
+		return _is_real_public_host(host)
+	except Exception:
+		return True
+
+
+def assert_public_onboarding_host() -> None:
+	"""Hard-block onboarding on a local/non-public bench (magic links + agent
+	callbacks would silently fail). Purely host-based: dev/e2e benches need a
+	public-looking ``host_name`` in site_config, not a bypass flag. Raises a
+	user-facing ValidationError."""
+	if _onboarding_host_ok():
+		return
+	frappe.throw(
+		frappe._(
+			"This site is running on a local or non-public address, so sign-in "
+			"links and agent connections cannot reach it. Set a public host_name "
+			"for this site and try again."
+		),
+		title=frappe._("Onboarding is not available here"),
+	)
+
+
 def signup(
 	email: str,
 	company_name: str,

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -80,8 +80,15 @@ _BLOCK_SENTENCE = {
 # #468: a refusal that CLEARS ON ITS OWN within minutes leaves the slot due, so the
 # next hourly tick retries it (the sibling's O4 shape). Everything else is an
 # entitlement decision that cannot clear inside the hour — consume the slot, or the
-# cadence relogs the same dead end 24 times a day.
-_TRANSIENT_BLOCKS = {"release_update_required", "workspace_resetting", BLOCK_DISPATCH_FAILED}
+# cadence relogs the same dead end 24 times a day. ``insufficient_workers`` belongs
+# here too: it is a confidently-zero-workers snapshot that self-heals within the
+# worker lane's 20s debounce, not an entitlement decision.
+_TRANSIENT_BLOCKS = {
+	"release_update_required",
+	"workspace_resetting",
+	"insufficient_workers",
+	BLOCK_DISPATCH_FAILED,
+}
 
 
 def run_due_macros() -> None:

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -8,8 +8,10 @@ this module's contract.
 
 Returns (True, None) on success or (False, reason: str) on rejection. The
 reason is a machine code the SPA maps to a human toast: ``"usage_limit"`` for
-enforcement, ``"subscription_suspended"`` for billing, and
-``"release_update_required"`` while a release rollout is blocking this bench.
+enforcement, ``"subscription_suspended"`` for billing,
+``"release_update_required"`` while a release rollout is blocking this bench,
+and ``"insufficient_workers"`` when the site has confidently zero background
+workers able to run a chat turn.
 """
 
 from __future__ import annotations
@@ -33,6 +35,8 @@ def validate_can_send(user: str, model: str | None = None) -> tuple[bool, str | 
 		return False, "workspace_resetting"
 	if _llm_not_configured():
 		return False, "llm_not_configured"
+	if _insufficient_workers():
+		return False, "insufficient_workers"
 	# Per-model cap: only when a concrete model is known. ``model`` is resolved
 	# in chat.api (which knows the conversation) and passed in as a plain string,
 	# so policy never imports turn_handler (no import cycle). Pool "Auto" resolves
@@ -127,6 +131,34 @@ def _llm_not_configured() -> bool:
 		try:
 			frappe.log_error(
 				title="jarvis policy: llm-configured check failed (allowing send)",
+				message=frappe.get_traceback(),
+			)
+		except Exception:
+			pass
+		return False
+
+
+def _insufficient_workers() -> bool:
+	"""True when the site has CONFIDENTLY zero background workers able to run a
+	chat turn (sustained past a grace window). Without this a send queues against
+	a dead worker lane and hangs with no feedback. Fails OPEN: a probe/import
+	error must never block a paying customer - only chat_worker_status's
+	debounced, confident 0-worker verdict blocks.
+
+	CI runs bench tests with NO live RQ workers, so the 0-worker reading is
+	genuinely confident there and would reject every chat-send test. Like
+	_llm_not_configured, the gate is inert under test unless a suite opts in via
+	``frappe.flags.test_worker_gate``."""
+	if frappe.flags.in_test and not frappe.flags.get("test_worker_gate"):
+		return False
+	try:
+		from jarvis.chat.pump import chat_worker_status
+
+		return bool(chat_worker_status().get("blocked"))
+	except Exception:
+		try:
+			frappe.log_error(
+				title="jarvis policy: worker check failed (allowing send)",
 				message=frappe.get_traceback(),
 			)
 		except Exception:

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -787,14 +787,11 @@ def _live_worker_count(queue_name: str) -> int:
 	"""Number of RQ workers currently listening on ``queue_name`` (0 on any probe
 	trouble). Same ``get_workers()``/``generate_qname`` path ``api._turn_queue``
 	uses; best-effort — a probe hiccup must never break an enqueue, so the caller
-	treats 0 as "not safely provisioned" and falls back to ``short``."""
-	try:
-		from frappe.utils.background_jobs import generate_qname, get_workers
+	treats 0 as "not safely provisioned" and falls back to ``short``.
 
-		qname = generate_qname(queue_name)
-		return sum(1 for w in get_workers() if qname in (w.queue_names() or []))
-	except Exception:
-		return 0
+	Delegates to ``_probe_worker_count``, which does the identical live probe but
+	returns ``None`` (not 0) on trouble so ITS callers can fail open instead."""
+	return _probe_worker_count(queue_name) or 0
 
 
 def _control_queue() -> str:
@@ -859,6 +856,113 @@ def _warn_provisioning_if_starved() -> None:
 		)
 	except Exception:
 		pass
+
+
+# --- Chat worker health (drives onboarding warning + chat send block) ---------
+#
+# Two conditions, deliberately split so the fail-CLOSED chat block is flap-proof
+# on the managed fleet (a rolling worker restart must never block a paying
+# customer):
+#   * DEGRADED  -> warn only. The F1 self-starvation shape (_pump_shape_starves):
+#     turns run but strand for minutes. Surfaced as a non-blocking onboarding
+#     banner; chat still works.
+#   * BLOCKED   -> block sends. CONFIDENT zero live workers on the turn queue,
+#     sustained past a short grace window. This is the only guaranteed-hang shape
+#     (no worker can pick a turn up at all). Never fires on a probe error.
+
+_ZERO_GRACE_S = 20  # a 0 reading must persist this long before it blocks sends
+_ZERO_KEY = "jarvis:workers:zero_since"
+
+
+def _probe_worker_count(queue_name: str) -> "int | None":
+	"""Live RQ worker count on ``queue_name`` - like ``_live_worker_count`` but
+	returns ``None`` (not 0) on any probe trouble, so a caller can tell a
+	CONFIDENT zero apart from a broken probe and fail OPEN on the latter."""
+	try:
+		from frappe.utils.background_jobs import generate_qname, get_workers
+
+		qname = generate_qname(queue_name)
+		return sum(1 for w in get_workers() if qname in (w.queue_names() or []))
+	except Exception:
+		return None
+
+
+def _zero_marker_cache_key() -> str:
+	try:
+		return f"{_ZERO_KEY}:{frappe.local.site}"
+	except Exception:
+		return _ZERO_KEY
+
+
+def _clear_zero_marker() -> None:
+	try:
+		frappe.cache().delete_value(_zero_marker_cache_key())
+	except Exception:
+		pass
+
+
+def _force_zero_marker_age(age_s: int) -> None:
+	"""Test helper: rewind the zero-marker so it reads as ``age_s`` seconds old."""
+	from frappe.utils import add_to_date, now_datetime
+
+	frappe.cache().set_value(
+		_zero_marker_cache_key(),
+		add_to_date(now_datetime(), seconds=-age_s).isoformat(),
+		expires_in_sec=300,
+	)
+
+
+def _zero_persisted(grace_s: int) -> bool:
+	"""True once a 0-worker reading has persisted at least ``grace_s`` seconds.
+	First 0 sets the marker and returns False (debounce)."""
+	from frappe.utils import get_datetime, now_datetime, time_diff_in_seconds
+
+	key = _zero_marker_cache_key()
+	now = now_datetime()
+	try:
+		since = frappe.cache().get_value(key, expires=True)
+		if not since:
+			frappe.cache().set_value(key, now.isoformat(), expires_in_sec=300)
+			return False
+		# Refresh the TTL while zero persists so a lane dead longer than the TTL
+		# never evicts the marker (which would briefly flip the block OFF and
+		# re-arm the grace every ~5 min). `since` is kept anchored to the first
+		# zero reading, so the grace calculation is unchanged.
+		frappe.cache().set_value(key, since, expires_in_sec=300)
+		return time_diff_in_seconds(now, get_datetime(since)) >= grace_s
+	except Exception:
+		return False  # cache trouble => fail OPEN (do not block)
+
+
+def _turn_workers_confidently_zero() -> bool:
+	try:
+		from jarvis.chat.api import _turn_queue
+
+		q = _turn_queue()
+	except Exception:
+		_clear_zero_marker()
+		return False
+	n = _probe_worker_count(q)
+	if n is None:
+		return False  # probe failed => fail OPEN, leave marker untouched
+	if n > 0:
+		_clear_zero_marker()
+		return False
+	return _zero_persisted(_ZERO_GRACE_S)
+
+
+def chat_worker_status() -> dict:
+	"""Worker health for the onboarding warning + chat send block. Fails SAFE:
+	on any trouble reports neither blocked nor degraded."""
+	try:
+		blocked = _turn_workers_confidently_zero()
+	except Exception:
+		blocked = False
+	try:
+		degraded = _pump_shape_starves()
+	except Exception:
+		degraded = False
+	return {"blocked": bool(blocked), "degraded": bool(blocked or degraded)}
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -1012,6 +1012,10 @@ def start_signup(
 	if not validate_email_address(email, throw=False):
 		frappe.throw("Enter a valid email address.")
 	_require_admin_url()
+	# Hard-block onboarding on a local/non-public bench: magic links and agent
+	# callbacks built from this site's URL would silently fail. Dev/e2e benches
+	# set a public-looking host_name in site_config so this passes.
+	admin_client.assert_public_onboarding_host()
 	# Money the gateway is holding that an operator has not been able to place
 	# stops the WHOLE endpoint, not just the resume half below. The context is
 	# bench-level, so a raised flag means THIS bench's money is parked — and

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -169,6 +169,26 @@
 				</button>
 			</div>
 
+			<!-- Worker-degraded heads-up: a SEPARATE, additive signal from the
+			     readiness gate above (see workerWarning's declaration). Renders ONLY
+			     when readiness === "ready" - chat is fully usable, just maybe a
+			     little slow. "gate" has no thread to warn about, and "degraded"
+			     already shows .jvp-notice below saying replies may FAIL outright;
+			     stacking this "may be a little slower" banner under that would
+			     contradict and undersell the real state, so degraded keeps its own
+			     banner instead of also getting this one. Non-blocking by
+			     construction either way - never disables the composer, never
+			     replaces the conversation below it. Sits above the scrollable thread
+			     so it reads as a thin banner at the top, not inline with any one
+			     message. -->
+			<div
+				v-if="workerWarning && readiness === 'ready'"
+				class="jvp-worker-notice"
+				role="status"
+			>
+				Replies may be a little slower than usual right now.
+			</div>
+
 			<div class="jvp-body" ref="bodyEl" @scroll.passive="onBodyScroll">
 				<!-- Never onboarded (readiness === "gate"): the panel cannot possibly
 				     chat, so the whole body - welcome, history, composer below - is
@@ -601,7 +621,7 @@ import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import { renderReply } from "./panel_markdown.mjs";
 import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
-import { classifyReadiness, degradedActionable } from "./panel_readiness.mjs";
+import { classifyReadiness, degradedActionable, shouldWarnWorkers } from "./panel_readiness.mjs";
 import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
 import { sortPendingCards } from "./pending_order.mjs";
 import { ONBOARDING_URL } from "./config.mjs";
@@ -907,6 +927,14 @@ const readinessCta = ref(null);
 // True while a Retry (resyncLlm, for a stuck apply - jarvis#825) is in flight, so
 // the CTA shows progress and cannot be double-clicked into the server's throttle.
 const retryingApply = ref(false);
+// SEPARATE, additive signal from `readiness` above: is_ready_for_chat also
+// returns worker_warning (bool) when background workers are under-provisioned
+// but chat still works. Read from the same resolveReadiness() response, but
+// never folds into the ready/gate/degraded verdict - a worker-degraded-but-
+// usable workspace is still "ready" (see panel_readiness.mjs's shouldWarnWorkers),
+// so this needs its own ref and its own template v-if. Fails CLOSED (false) on
+// a missing/thrown response, same as shouldWarnWorkers itself.
+const workerWarning = ref(false);
 // Only an admin who can actually reach the wizard gets the CTA button in the
 // gate state, mirroring OnboardingGate.vue's isSystemManager split. Read off
 // frappe.boot.user.roles - core Frappe bootinfo (User.load_user), already
@@ -1252,11 +1280,13 @@ function refreshReadiness() {
 				readinessNotice.value = "";
 				readinessCta.value = null;
 			}
+			workerWarning.value = shouldWarnWorkers(r);
 		})
 		.catch(() => {
 			readiness.value = classifyReadiness(null);
 			readinessNotice.value = "";
 			readinessCta.value = null;
+			workerWarning.value = false;
 		});
 }
 
@@ -2592,6 +2622,27 @@ defineExpose({ load, startNewChat, convId });
 	height: 26px;
 	padding: 0 11px;
 	font-size: 12px;
+}
+
+/* ---- worker-degraded heads-up (workerWarning) ----
+   A lighter, one-line sibling of .jvp-notice above: same amber "heads-up, not an
+   error" tokens, but no icon/CTA/wrapping body - just a thin strip so it reads as
+   compact and clearly non-blocking. Renders only on a fully "ready" workspace
+   whose workers are merely stretched (see the template v-if) - readiness ===
+   "degraded" already gets .jvp-notice's own "replies may fail" banner, and this
+   lighter "may be a little slower" one would undersell that, so the two never
+   stack. */
+.jvp-worker-notice {
+	flex: none;
+	margin: 10px 15px 0;
+	padding: 6px 11px;
+	border: 1px solid var(--jv-warn-bd);
+	border-radius: 9px;
+	background: var(--jv-warn-bg);
+	color: var(--jv-warn);
+	font-size: 12px;
+	line-height: 1.4;
+	text-align: center;
 }
 
 /* ---- pending write confirmation ---- */

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -201,3 +201,20 @@ export function degradedActionable(
   }
   return { text: degradedMessage(resp, agentName), cta: null };
 }
+
+// A SEPARATE, additive signal from the ready/gate/degraded verdict above:
+// is_ready_for_chat now also returns worker_warning (bool) on an otherwise-usable
+// workspace whose background workers are under-provisioned. It is deliberately
+// non-blocking - unlike a degraded verdict, it never gates the composer or
+// replaces the panel - so it is read independently of classifyReadiness() rather
+// than folded into its three-way return.
+//
+// Fails CLOSED (false) on a missing/thrown response, the opposite of
+// classifyReadiness's fail-OPEN-to-"ready": a check that could not run should
+// produce no banner, not manufacture a warning nobody confirmed. The panel's
+// caller still wraps the isReadyForChat() call in its own try/catch (mirroring
+// how it already resolves `readiness` on a thrown fetch), so this only needs to
+// handle a resp that is present but shaped unexpectedly.
+export function shouldWarnWorkers(resp) {
+  return !!(resp && resp.worker_warning);
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -4,6 +4,7 @@ import {
   classifyReadiness,
   degradedMessage,
   degradedActionable,
+  shouldWarnWorkers,
   SUSPENDED_FALLBACK,
 } from "./panel_readiness.mjs";
 
@@ -197,4 +198,30 @@ test("degradedActionable: a member gets no CTA for a stuck apply", () => {
   );
   assert.equal(out.cta, null);
   assert.match(out.text, /administrator/i);
+});
+
+// worker_warning is a separate, additive signal from the ready/gate/degraded
+// verdict: a workspace can be fully "ready" and still carry a worker warning.
+test("shouldWarnWorkers: true only when the backend flag is explicitly true", () => {
+  assert.equal(shouldWarnWorkers({ ready: true, worker_warning: true }), true);
+  assert.equal(
+    shouldWarnWorkers({
+      ready: false,
+      reason: "llm_credentials",
+      worker_warning: true,
+    }),
+    true
+  );
+  assert.equal(
+    shouldWarnWorkers({ ready: true, worker_warning: false }),
+    false
+  );
+  assert.equal(shouldWarnWorkers({ ready: true }), false);
+});
+
+// Fails CLOSED, the opposite of classifyReadiness's fail-open: a missing or
+// thrown response must never manufacture a warning nobody confirmed.
+test("shouldWarnWorkers: fails CLOSED on a missing response", () => {
+  assert.equal(shouldWarnWorkers(null), false);
+  assert.equal(shouldWarnWorkers(undefined), false);
 });

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -949,9 +949,29 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 		self.assertTrue(out["ready"])
 
 	def test_the_happy_path_is_unchanged(self):
-		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
+		# chat_worker_status is pinned deterministically here (Task 5): the
+		# ready/reason/billing_notice verdict is what this test names as
+		# "unchanged", and the two worker fields it now also carries would
+		# otherwise depend on whatever the test runner's actual worker state
+		# happens to be.
+		with (
+			patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}),
+			patch(
+				"jarvis.chat.pump.chat_worker_status",
+				return_value={"blocked": False, "degraded": False, "workers": 3},
+			),
+		):
 			out = account.is_ready_for_chat()
-		self.assertEqual(out, {"ready": True, "reason": None, "billing_notice": {}})
+		self.assertEqual(
+			out,
+			{
+				"ready": True,
+				"reason": None,
+				"billing_notice": {},
+				"worker_warning": False,
+				"worker_blocked": False,
+			},
+		)
 
 	def test_a_never_configured_subscription_gets_the_missing_verdict_not_provisioning(self):
 		"""jarvis#755 review: a subscription tenant that never configured
@@ -1853,3 +1873,23 @@ class TestBillingPaymentRecovery(FrappeTestCase):
 				account.check_billing_payment_status()
 		state.assert_not_called()
 		check.assert_not_called()
+
+
+class TestReadinessWorkerFields(FrappeTestCase):
+	def test_ready_dict_carries_worker_warning_without_flipping_ready(self):
+		with patch(
+			"jarvis.chat.pump.chat_worker_status",
+			return_value={"blocked": False, "degraded": True, "workers": 1},
+		):
+			r = account.is_ready_for_chat()
+			self.assertIn("worker_warning", r)
+			self.assertTrue(r["worker_warning"])
+			self.assertFalse(r.get("worker_blocked"))
+			# worker health must NOT change the ready/reason verdict
+			self.assertIn("ready", r)
+
+	def test_worker_probe_error_leaves_fields_false(self):
+		with patch("jarvis.chat.pump.chat_worker_status", side_effect=RuntimeError):
+			r = account.is_ready_for_chat()
+			self.assertFalse(r.get("worker_warning"))
+			self.assertFalse(r.get("worker_blocked"))

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -2,9 +2,11 @@
 
 from unittest.mock import patch
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 import jarvis.account as account
+from jarvis.chat import policy
 from jarvis.chat.policy import validate_can_send
 
 # Entitled verdict. Patched in by default so these tests never depend on the
@@ -251,3 +253,43 @@ class TestLlmConfiguredGate(FrappeTestCase):
 			ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
+
+
+class TestInsufficientWorkers(FrappeTestCase):  # reuse module base
+	def setUp(self):
+		frappe.flags.test_worker_gate = True  # opt into the real gate under test
+
+	def tearDown(self):
+		frappe.flags.test_worker_gate = False
+
+	def test_blocked_returns_reason(self):
+		with patch(
+			"jarvis.chat.pump.chat_worker_status",
+			return_value={"blocked": True, "degraded": True, "workers": 0},
+		):
+			self.assertTrue(policy._insufficient_workers())
+
+	def test_healthy_returns_false(self):
+		with patch(
+			"jarvis.chat.pump.chat_worker_status",
+			return_value={"blocked": False, "degraded": False, "workers": 4},
+		):
+			self.assertFalse(policy._insufficient_workers())
+
+	def test_fails_open_on_error(self):
+		with patch("jarvis.chat.pump.chat_worker_status", side_effect=RuntimeError):
+			self.assertFalse(policy._insufficient_workers())
+
+	def test_validate_can_send_surfaces_reason(self):
+		# A user that clears every OTHER gate, but has 0 workers, is blocked here.
+		with (
+			patch.object(policy, "_over_total_limit", return_value=False),
+			patch.object(policy, "_subscription_suspended", return_value=False),
+			patch.object(policy, "_release_update_required", return_value=False),
+			patch.object(policy, "_workspace_resetting", return_value=False),
+			patch.object(policy, "_llm_not_configured", return_value=False),
+			patch.object(policy, "_insufficient_workers", return_value=True),
+		):
+			ok, reason = policy.validate_can_send("someone@acme.com")
+			self.assertFalse(ok)
+			self.assertEqual(reason, "insufficient_workers")

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -314,6 +314,19 @@ class TestScheduledMacroCaps(MacroSchedulerBase):
 		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
 		self.assertEqual(after, before, "a rollout that clears in minutes cost the macro its slot")
 
+	def test_insufficient_workers_block_leaves_the_slot_due_for_a_retry(self):
+		# #468's TRANSIENT shape now also covers a confidently-zero-workers snapshot:
+		# it self-heals within the worker lane's debounce, so the slot must stay due
+		# for the next hourly tick rather than being consumed like an entitlement
+		# refusal.
+		m = _mk_macro(OWNER_OK, "workers-low")
+		before = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "insufficient_workers")):
+			self._run_due_gated()
+		self.assertEqual([r.status for r in _runs_for(m.name)], ["failed"])
+		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertEqual(after, before, "a worker shortage that clears in seconds cost the macro its slot")
+
 	def test_the_gate_creates_nothing_before_refusing(self):
 		# A refused run must leave no conversation and no intro message behind —
 		# only the scheduler's own failed record.

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import json
 import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -2129,4 +2129,106 @@ class TestConservativeAdmission(_PumpTestCase):
 		amsgA = self._val(ridA, "assistant_message")
 		self.assertTrue(
 			(frappe.db.get_value(MSG, amsgA, "content") or "").strip(), "deltas applied to the in-flight lane"
+		)
+
+
+# --------------------------------------------------------------------------- #
+# Chat worker-status probe (Task 3 - onboarding guards)
+# --------------------------------------------------------------------------- #
+
+
+class TestWorkerStatus(FrappeTestCase):  # reuse module base
+	def setUp(self):
+		pump._clear_zero_marker()
+
+	def tearDown(self):
+		pump._clear_zero_marker()
+
+	def test_probe_returns_none_on_error(self):
+		with patch("frappe.utils.background_jobs.get_workers", side_effect=RuntimeError):
+			self.assertIsNone(pump._probe_worker_count("long"))
+
+	def test_healthy_is_not_blocked_not_degraded(self):
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=4),
+			patch.object(pump, "_pump_shape_starves", return_value=False),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			s = pump.chat_worker_status()
+			self.assertFalse(s["blocked"])
+			self.assertFalse(s["degraded"])
+
+	def test_one_worker_degraded_not_blocked(self):
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=1),
+			patch.object(pump, "_pump_shape_starves", return_value=True),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			s = pump.chat_worker_status()
+			self.assertFalse(s["blocked"])
+			self.assertTrue(s["degraded"])
+
+	def test_probe_error_never_blocks(self):
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=None),
+			patch.object(pump, "_pump_shape_starves", return_value=False),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			self.assertFalse(pump.chat_worker_status()["blocked"])
+
+	def test_zero_workers_blocks_only_after_grace(self):
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=0),
+			patch.object(pump, "_pump_shape_starves", return_value=True),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			# first observation: marker set, NOT yet blocked (debounce)
+			self.assertFalse(pump.chat_worker_status()["blocked"])
+			# simulate the marker aging past the grace window
+			pump._force_zero_marker_age(pump._ZERO_GRACE_S + 5)
+			self.assertTrue(pump.chat_worker_status()["blocked"])
+
+	def test_recovery_clears_marker(self):
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=0),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			pump.chat_worker_status()  # sets marker
+		# Age the ORIGINAL marker past grace before the recovery step. If the
+		# recovery reading below fails to clear it, this aged, still-live marker
+		# would make the later fresh 0-reading block IMMEDIATELY (no debounce),
+		# so the final assertion below only holds if recovery actually cleared it.
+		pump._force_zero_marker_age(pump._ZERO_GRACE_S + 5)
+		with (
+			patch.object(pump, "_probe_worker_count", return_value=3),
+			patch.object(pump, "_pump_shape_starves", return_value=False),
+			patch("jarvis.chat.api._turn_queue", return_value="long"),
+		):
+			self.assertFalse(pump.chat_worker_status()["blocked"])
+			# marker cleared: a later single 0 must re-arm the grace, not block instantly
+			with (
+				patch.object(pump, "_probe_worker_count", return_value=0),
+				patch.object(pump, "_pump_shape_starves", return_value=True),
+			):
+				self.assertFalse(pump.chat_worker_status()["blocked"])
+
+	def test_zero_still_present_refreshes_ttl(self):
+		"""When the marker is PRESENT and the reading is still zero, `_zero_persisted`
+		must RE-WRITE it (same `since`, fresh TTL) rather than leaving it untouched.
+		Without the refresh, a lane dead longer than the 300s TTL loses the marker in
+		Redis; the next zero reading re-seeds it from scratch and returns False, briefly
+		flipping the fail-closed chat block OFF for a fresh 20s grace window on a lane
+		that has been dead the whole time. This test fails if the refresh line is
+		removed (set_value would then never be called for a still-present marker)."""
+		fixed_since = "2020-01-01 00:00:00.000000"
+		mock_cache = MagicMock()
+		mock_cache.get_value.return_value = fixed_since
+		with patch.object(pump.frappe, "cache", return_value=mock_cache):
+			result = pump._zero_persisted(pump._ZERO_GRACE_S)
+		# `since` is ancient, so with grace elapsed this must report persisted.
+		self.assertTrue(result)
+		# The marker must be RE-WRITTEN with the SAME `since` and a fresh TTL -
+		# never left untouched while zero readings keep coming in.
+		mock_cache.set_value.assert_called_once_with(
+			pump._zero_marker_cache_key(), fixed_since, expires_in_sec=300
 		)

--- a/jarvis/tests/test_start_signup_validation.py
+++ b/jarvis/tests/test_start_signup_validation.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis import onboarding
+from jarvis import admin_client, onboarding
 
 
 class TestStartSignupEmailValidation(FrappeTestCase):
@@ -40,5 +40,76 @@ class TestStartSignupEmailValidation(FrappeTestCase):
 					company="Acme",
 					plan="pro",
 					billing={"contact_number": "+91 90000 00000"},
+					terms_accepted=True,
+				)
+
+
+class TestOnboardingHostGuard(FrappeTestCase):
+	"""The guard reads ONLY site_config ``host_name`` (never the request Host
+	header, which is spoofable), so every case here drives it by mutating
+	``frappe.conf`` rather than mocking ``_public_origin`` - the old
+	implementation's dependency, which the guard no longer calls at all."""
+
+	def setUp(self):
+		frappe.flags.test_host_guard = True  # opt this suite into the real gate
+
+	def tearDown(self):
+		frappe.flags.test_host_guard = False
+
+	def test_no_host_name_blocks(self):
+		"""The key security case: with no configured public host, onboarding is
+		blocked regardless of any request Host - there is nothing left for a
+		spoofed header to influence."""
+		with patch.dict(frappe.conf, {}, clear=False):
+			frappe.conf.pop("host_name", None)
+			frappe.conf.pop("hostname", None)
+			self.assertFalse(admin_client._onboarding_host_ok())
+			with self.assertRaises(frappe.ValidationError):
+				admin_client.assert_public_onboarding_host()
+
+	def test_localhost_host_name_blocked(self):
+		with patch.dict(frappe.conf, {"host_name": "https://foo.localhost"}, clear=False):
+			self.assertFalse(admin_client._onboarding_host_ok())
+
+	def test_ip_host_name_blocked(self):
+		with patch.dict(frappe.conf, {"host_name": "https://203.0.113.5"}, clear=False):
+			self.assertFalse(admin_client._onboarding_host_ok())
+
+	def test_http_scheme_host_name_blocked(self):
+		"""_public_origin's host_name short-circuit only fires for https - a
+		non-https host_name falls through to the spoofable request Host there,
+		so the guard must reject it too rather than accept a real-looking
+		domain reached over plain http."""
+		with patch.dict(frappe.conf, {"host_name": "http://acme.klerk.in"}, clear=False):
+			self.assertFalse(admin_client._onboarding_host_ok())
+
+	def test_public_host_name_allows(self):
+		"""The e2e path: a genuinely public ``host_name`` (as e2e sites configure)
+		is what makes onboarding work, independent of the request's own Host."""
+		with patch.dict(frappe.conf, {"host_name": "https://jarvis-e2e.aerele.in"}, clear=False):
+			self.assertTrue(admin_client._onboarding_host_ok())
+			admin_client.assert_public_onboarding_host()  # no raise
+
+	def test_bare_public_host_name_allows(self):
+		"""A scheme-less host_name (bare domain) is accepted - the impl adds https."""
+		with patch.dict(frappe.conf, {"host_name": "jarvis-e2e.aerele.in"}, clear=False):
+			self.assertTrue(admin_client._onboarding_host_ok())
+
+	def test_probe_error_fails_open(self):
+		with patch.dict(frappe.conf, {"host_name": "https://acme.example.com"}, clear=False):
+			with patch.object(admin_client, "_is_real_public_host", side_effect=RuntimeError("boom")):
+				self.assertTrue(admin_client._onboarding_host_ok())  # error => allow
+
+	def test_start_signup_blocks_on_localhost(self):
+		# setUp already set frappe.flags.test_host_guard = True.
+		frappe.set_user("Administrator")
+		with patch.dict(frappe.conf, {}, clear=False):
+			frappe.conf.pop("host_name", None)
+			frappe.conf.pop("hostname", None)
+			with self.assertRaisesRegex(frappe.ValidationError, "local or non-public address"):
+				onboarding.start_signup(
+					email="x@acme.com",
+					company="Acme",
+					plan="Pro",
 					terms_accepted=True,
 				)

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -133,5 +133,22 @@ def get_context(context):
 	context.boot["support_state"] = state
 	context.boot["support_available"] = state == SUPPORT_OK
 
+	# Onboarding guards: the localhost/non-public-host hard-block and the
+	# background-worker health warning, both surfaced up front so the SPA wizard
+	# and readiness banner don't need an extra round trip to learn them. Each
+	# fails to the non-blocking default on any probe error - never falsely gate
+	# or warn the customer off a transient blip.
+	from jarvis import admin_client
+	from jarvis.chat import pump
+
+	try:
+		context.boot["jarvis_public_host_ok"] = admin_client._onboarding_host_ok()
+	except Exception:
+		context.boot["jarvis_public_host_ok"] = True  # never falsely block the wizard
+	try:
+		context.boot["jarvis_worker_warning"] = bool(pump.chat_worker_status().get("degraded"))
+	except Exception:
+		context.boot["jarvis_worker_warning"] = False
+
 	frappe.db.commit()
 	return context


### PR DESCRIPTION
Backport of #1018 to `version-15`.

Onboarding localhost guard (configured https `host_name` required, request `Host` not trusted, no bypass flag) plus the low-worker warning/block (onboarding, main chat, desk popup) and the code-review fixes. Cherry-picked cleanly from the develop merge commit `00150fb7` with no manual conflict resolution. CI validates against version-15.