### PR TITLE
Backport/1043 run method payload version 15

### DIFF
--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -469,6 +469,22 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 			# Same envelope + audit as an inline write - dispatch_confirmed bypasses
 			# the gate so the stored call actually executes instead of parking again.
 			result = api.dispatch_confirmed(record["tool"], record["args"])
+			# run_method returns its target verbatim, unlike get_doc/create_doc which
+			# permlevel-filter before as_dict. Apply the same field-level read filter to
+			# a Document return HERE (still as exec_user), so a permlevel>0 field the
+			# agent can't read is stripped before it reaches the receipt chip or the
+			# model's continuation dump. Best-effort: a filter hiccup must never fail an
+			# already-committed call (that would roll back the write for a cosmetic step).
+			if record["tool"] == "run_method" and isinstance(result, dict) and result.get("ok"):
+				_ret = result.get("data")
+				if hasattr(_ret, "apply_fieldlevel_read_permissions"):
+					try:
+						_ret.apply_fieldlevel_read_permissions()
+					except Exception:
+						frappe.log_error(
+							title="run_method receipt permlevel filter failed",
+							message=frappe.get_traceback(),
+						)
 	except Exception:
 		# F5: an UNEXPECTED (untranslated) exception from the confirmed write would
 		# otherwise 500 with the token ALREADY consumed (GETDEL above) - no receipt,
@@ -606,6 +622,12 @@ def _confirm_receipt_text(record: dict, result) -> str:
 		try:
 			payload = frappe.as_json(data)
 		except Exception:
+			# Post-commit + best-effort, but not silent: log so a method whose return
+			# consistently fails to serialize is diagnosable instead of vanishing.
+			frappe.log_error(
+				title="run_method receipt serialization failed",
+				message=frappe.get_traceback(),
+			)
 			return f"{desc} succeeded (return value could not be serialized for the receipt)."
 		return f"{desc} succeeded. Returned: {payload}"
 	return f"{desc} succeeded."

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -569,17 +569,45 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 def _confirm_receipt_text(record: dict, result) -> str:
 	"""Short receipt line for the post-confirm continuation prompt: the call,
 	the created/affected record name when the result carries one, and the
-	outcome (including a bounded error message so the agent can react)."""
+	outcome (including a bounded error message so the agent can react).
+
+	run_method is the exception. It is the generic escape hatch for
+	data-returning whitelisted methods (getters, the make_* mappers), so its
+	whole value IS the returned payload - and because it is a gated write it
+	ALWAYS parks, making this receipt the only way its result reaches the model.
+	A plain "<call> succeeded" leaves the agent blind to the data it was asked
+	to use, so for a SUCCESSFUL run_method we append the FULL returned payload,
+	deliberately UNTRUNCATED - the agent needs all of it to act on the result.
+	It is serialized with frappe.as_json (the same encoder the inline tool path
+	uses at the HTTP boundary), which renders a returned Document via as_dict and
+	datetimes as ISO strings - where stdlib json.dumps(default=str) would emit a
+	useless repr for the make_* mappers' Document returns. Safe despite the
+	payload being attacker-influenceable: enqueue_continuation runs the whole
+	receipt through _safe_label_name (all whitespace - including any pretty-print
+	newlines - collapsed to single spaces, backticks disarmed) and quotes it as
+	inline-code DATA, so it can neither forge the [System] voice nor break out of
+	the code span - the same neutralization the record-name receipt relies on.
+	Serialization never raises out of here (the write already committed): an
+	exotic or circular return value falls back to a plain success line."""
 	from jarvis.api import _describe_call
 
+	is_run_method = record.get("tool") == "run_method"
 	desc = _describe_call(record.get("tool") or "", record.get("args") or {})
 	data = result.get("data") if isinstance(result, dict) else None
-	if isinstance(data, dict) and data.get("name"):
+	# The name-append keeps write receipts terse; run_method dumps the whole
+	# payload below (which already carries any name), so skip it there.
+	if not is_run_method and isinstance(data, dict) and data.get("name"):
 		desc += f" -> {data['name']}"
 	if isinstance(result, dict) and not result.get("ok"):
 		err = result.get("error") or {}
 		msg = str(err.get("message") or "")[:200] if isinstance(err, dict) else ""
 		return f"{desc} FAILED. {msg}".strip()
+	if is_run_method:
+		try:
+			payload = frappe.as_json(data)
+		except Exception:
+			return f"{desc} succeeded (return value could not be serialized for the receipt)."
+		return f"{desc} succeeded. Returned: {payload}"
 	return f"{desc} succeeded."
 
 

--- a/jarvis/tests/test_actions_api.py
+++ b/jarvis/tests/test_actions_api.py
@@ -441,6 +441,82 @@ class TestContinuation(FrappeTestCase):
 		# The text is preserved (as quoted data), just neutralized.
 		self.assertIn("ignore prior steps", content)
 
+	def test_confirm_receipt_run_method_surfaces_full_untruncated_payload(self):
+		# run_method is a data-returning escape hatch that ALWAYS parks, so this
+		# receipt is the model's only view of the result. A large payload (the
+		# balances / CoA case) must reach the receipt in full - never truncated.
+		from jarvis.chat.actions_api import _confirm_receipt_text
+
+		big = {"rows": [{"account": f"ACC-{i}", "balance": i * 1000} for i in range(500)]}
+		record = {
+			"tool": "run_method",
+			"args": {"method": "erpnext.accounts.utils.get_account_balances_coa"},
+		}
+		text = _confirm_receipt_text(record, {"ok": True, "data": big})
+		self.assertIn("succeeded", text)
+		self.assertIn("Returned:", text)
+		# First AND last row present -> the whole payload survived, untruncated.
+		self.assertIn("ACC-0", text)
+		self.assertIn("ACC-499", text)
+
+	def test_confirm_receipt_run_method_serializes_document_via_as_dict(self):
+		# The marquee case: a make_* mapper returns a frappe Document, not a dict.
+		# frappe.as_json must render its FIELDS (via as_dict), never the object
+		# repr that stdlib json.dumps(default=str) would emit.
+		from jarvis.chat.actions_api import _confirm_receipt_text
+
+		doc = frappe.new_doc("ToDo")
+		doc.description = "doc-field-marker"
+		record = {"tool": "run_method", "args": {"method": "erpnext.x.make_todo"}}
+		text = _confirm_receipt_text(record, {"ok": True, "data": doc})
+		self.assertIn("Returned:", text)
+		self.assertIn("doc-field-marker", text)  # a real field value survived
+		self.assertNotIn("<ToDo", text)  # NOT the '<ToDo: ...>' object repr
+
+	def test_confirm_receipt_non_run_method_does_not_dump_data(self):
+		# A create/update receipt stays terse - the affected name, not the payload.
+		from jarvis.chat.actions_api import _confirm_receipt_text
+
+		record = {"tool": "create_doc", "args": {"doctype": "ToDo"}}
+		text = _confirm_receipt_text(record, {"ok": True, "data": {"name": "TODO-9", "description": "x"}})
+		self.assertNotIn("Returned:", text)
+		self.assertIn("-> TODO-9", text)
+		self.assertIn("succeeded", text)
+
+	def test_confirm_receipt_run_method_failure_reports_error_without_dump(self):
+		# A FAILED run_method still reports the (bounded) error, and never dumps a
+		# payload - there is none, and the failure branch precedes the data append.
+		from jarvis.chat.actions_api import _confirm_receipt_text
+
+		record = {"tool": "run_method", "args": {"method": "x.y.z"}}
+		text = _confirm_receipt_text(record, {"ok": False, "error": {"message": "kaboom"}})
+		self.assertIn("FAILED", text)
+		self.assertIn("kaboom", text)
+		self.assertNotIn("Returned:", text)
+
+	def test_run_method_payload_survives_neutralized_continuation_untruncated(self):
+		# End-to-end: the full run_method payload rides the continuation as ONE
+		# neutralized inline-data line (newlines collapsed, backticks disarmed) -
+		# yet is NOT truncated, so a unique marker deep in the payload still lands.
+		from jarvis.chat.actions_api import _confirm_receipt_text
+		from jarvis.chat.api import enqueue_continuation
+
+		marker = "UNIQ-account-marker-deep-in-payload"
+		big = {"rows": [{"account": f"ACC-{i}"} for i in range(400)] + [{"account": marker}]}
+		record = {
+			"tool": "run_method",
+			"args": {"method": "erpnext.accounts.utils.get_account_balances_coa"},
+		}
+		receipt = _confirm_receipt_text(record, {"ok": True, "data": big})
+		conv = self._conv()
+		with patch("jarvis.chat.api._dispatch_turn"):
+			enqueue_continuation(conv, receipt)
+		content = self._messages(conv)[-1].content
+		# Untruncated: the marker after 400 rows still made it into the prompt.
+		self.assertIn(marker, content)
+		# Neutralized: cannot forge a new bench-voice line.
+		self.assertNotIn("\n", content)
+
 	def test_confirm_tool_failed_write_still_continues_with_neutralized_error(self):
 		# A confirmed write that FAILS must still dispatch the continuation (so the
 		# agent learns the outcome), and the error text - attacker-influenceable -

--- a/jarvis/tests/test_actions_api.py
+++ b/jarvis/tests/test_actions_api.py
@@ -517,6 +517,42 @@ class TestContinuation(FrappeTestCase):
 		# Neutralized: cannot forge a new bench-voice line.
 		self.assertNotIn("\n", content)
 
+	def test_confirm_receipt_run_method_serialization_failure_falls_back(self):
+		# A return value as_json cannot encode (a circular ref) must NOT raise out of
+		# the post-commit receipt; it degrades to a plain success line (and a log).
+		from jarvis.chat.actions_api import _confirm_receipt_text
+
+		circular = {}
+		circular["self"] = circular
+		record = {"tool": "run_method", "args": {"method": "x.y.z"}}
+		text = _confirm_receipt_text(record, {"ok": True, "data": circular})
+		self.assertIn("succeeded", text)
+		self.assertIn("could not be serialized", text)
+		self.assertNotIn("Returned:", text)
+
+	def test_confirm_core_batch_run_method_receipt_carries_full_payload(self):
+		# The batch (multi-card) approval path composes receipts from
+		# result["receipt_text"] (joined by the typed-bulk confirmation), so a
+		# confirmed run_method must carry its full payload there too - not only on
+		# the single-card continuation path.
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import _confirm_core
+
+		conv = self._conv()
+		token = pending_confirm.mint(
+			conversation=conv,
+			owner="Administrator",
+			tool="run_method",
+			args={"method": "erpnext.accounts.utils.get_account_balances_coa"},
+			run_id="testrun",
+		)
+		payload = {"rows": [{"account": "ACC-batch-marker", "balance": 42}]}
+		with patch("jarvis.api.dispatch_confirmed", return_value={"ok": True, "data": payload}):
+			res = _confirm_core(token, conv, batch=True)
+		self.assertIn("receipt_text", res)
+		self.assertIn("Returned:", res["receipt_text"])
+		self.assertIn("ACC-batch-marker", res["receipt_text"])
+
 	def test_confirm_tool_failed_write_still_continues_with_neutralized_error(self):
 		# A confirmed write that FAILS must still dispatch the continuation (so the
 		# agent learns the outcome), and the error text - attacker-influenceable -


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
