### PR TITLE
Fix/create fill readonly fields

### DIFF
--- a/frontend/src/lib/draftApply.js
+++ b/frontend/src/lib/draftApply.js
@@ -1,6 +1,17 @@
-// Pure helpers for the record draft-panel apply path (ChatView.vue applyDraft).
-// Extracted so the read_only / create gating and value coercion are unit-testable
-// without mounting the view (mirrors chatAction.js / actionSummary.js).
+// Pure helpers for the record draft-panel apply + render path (ChatView.vue
+// applyDraft / draft template). Extracted so the read_only / create gating, value
+// coercion, and read-only display are unit-testable without mounting the view
+// (mirrors chatAction.js / actionSummary.js).
+
+// Which raw values count as a checked Check. Single source of truth for both the
+// display side (checkToYesNo, seeding the "Yes"/"No" control) and the submit side
+// (coerceCheck) so the two can never drift.
+const CHECK_TRUE = ["1", 1, "yes", "true", true, "on"];
+
+// Normalize a raw Check value to the "Yes"/"No" string the panel control binds to.
+export function checkToYesNo(v) {
+	return CHECK_TRUE.includes(typeof v === "string" ? v.toLowerCase() : v) ? "Yes" : "No";
+}
 
 // read_only is a Frappe form-UI flag, not a write barrier: the agent's direct
 // create_doc sets read_only fields too (e.g. Error Log method/error). A read_only
@@ -13,6 +24,24 @@ export function isFieldWritable(field, verb) {
 	return !field.read_only || (verb === "create" && !!field.proposed);
 }
 
+// Whether a main field should paint the required "missing" cue. Read-only fields are
+// excluded: the user can't fill them, so the amber "fill me" prompt (and the earlier
+// editable-input-that-discards-your-value trap) must not fire on them.
+export function isFieldMissing(field) {
+	return !!field.reqd && !field.read_only && !String(field.value ?? "").trim();
+}
+
+// Display form of a read-only main field's value in the muted static span. Empty ->
+// an em-dash so the cell reads as "no value yet" rather than blank/broken; a datetime
+// swaps the input-format "T" separator for a space (the raw value is machine-format
+// for the native picker, which the span has no chrome to reformat).
+export function readonlyDisplay(field) {
+	const v = field.value == null ? "" : String(field.value);
+	if (v === "") return "—";
+	if (field.control === "datetime") return v.replace("T", " ");
+	return v;
+}
+
 // A main-field panel value -> its create_doc/update_doc payload form.
 export function coerceOut(field) {
 	if (field.control === "check") return field.value === "Yes" ? 1 : 0;
@@ -20,10 +49,8 @@ export function coerceOut(field) {
 	return field.value;
 }
 
-const CHECK_TRUE = ["1", 1, "yes", "true", true, "on"];
-
 function coerceCheck(v) {
-	return CHECK_TRUE.includes(typeof v === "string" ? v.toLowerCase() : v) ? 1 : 0;
+	return checkToYesNo(v) === "Yes" ? 1 : 0;
 }
 
 // A child-table row -> the submittable subset. On CREATE a read_only column that
@@ -31,8 +58,8 @@ function coerceCheck(v) {
 // field there is no per-cell `proposed` flag - child rows never carry schema
 // defaults (an unproposed cell is "" and is skipped below), so non-emptiness stands
 // in for `proposed` and no default-clobber guard is needed here. A Check cell holds
-// a raw value (not the "Yes"/"No" string the main control uses), so normalize it the
-// same way _checkToYesNo does rather than Number(v) - which turns "Yes"/"true" -> 0.
+// a raw value (not the "Yes"/"No" string the main control uses), so normalize it via
+// checkToYesNo rather than Number(v) - which turns "Yes"/"true" -> 0.
 export function coerceRow(table, row, verb) {
 	const out = {};
 	for (const c of table.columns) {

--- a/frontend/src/lib/draftApply.js
+++ b/frontend/src/lib/draftApply.js
@@ -1,0 +1,47 @@
+// Pure helpers for the record draft-panel apply path (ChatView.vue applyDraft).
+// Extracted so the read_only / create gating and value coercion are unit-testable
+// without mounting the view (mirrors chatAction.js / actionSummary.js).
+
+// read_only is a Frappe form-UI flag, not a write barrier: the agent's direct
+// create_doc sets read_only fields too (e.g. Error Log method/error). A read_only
+// MAIN field is therefore submitted only when the agent PROPOSED a value for it on
+// a CREATE. Gate on `proposed`, not mere non-emptiness: an unproposed required
+// read_only Check renders as "No"/0 and would otherwise clobber a schema default of
+// 1. UPDATE always strips read_only (a confirm card must not overwrite a
+// server-managed field on an existing doc).
+export function isFieldWritable(field, verb) {
+	return !field.read_only || (verb === "create" && !!field.proposed);
+}
+
+// A main-field panel value -> its create_doc/update_doc payload form.
+export function coerceOut(field) {
+	if (field.control === "check") return field.value === "Yes" ? 1 : 0;
+	if (field.control === "number") return field.value === "" ? "" : Number(field.value);
+	return field.value;
+}
+
+const CHECK_TRUE = ["1", 1, "yes", "true", true, "on"];
+
+function coerceCheck(v) {
+	return CHECK_TRUE.includes(typeof v === "string" ? v.toLowerCase() : v) ? 1 : 0;
+}
+
+// A child-table row -> the submittable subset. On CREATE a read_only column that
+// carries a value is filled; every other verb strips read_only. Unlike the main
+// field there is no per-cell `proposed` flag - child rows never carry schema
+// defaults (an unproposed cell is "" and is skipped below), so non-emptiness stands
+// in for `proposed` and no default-clobber guard is needed here. A Check cell holds
+// a raw value (not the "Yes"/"No" string the main control uses), so normalize it the
+// same way _checkToYesNo does rather than Number(v) - which turns "Yes"/"true" -> 0.
+export function coerceRow(table, row, verb) {
+	const out = {};
+	for (const c of table.columns) {
+		if (c.read_only && verb !== "create") continue;
+		let v = row[c.fieldname];
+		if (v === "" || v == null) continue;
+		if (["Int", "Float", "Currency", "Percent"].includes(c.fieldtype)) v = Number(v);
+		if (c.fieldtype === "Check") v = coerceCheck(v);
+		out[c.fieldname] = v;
+	}
+	return out;
+}

--- a/frontend/src/lib/draftApply.spec.js
+++ b/frontend/src/lib/draftApply.spec.js
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { coerceOut, coerceRow, isFieldWritable } from "./draftApply";
+import {
+	checkToYesNo,
+	coerceOut,
+	coerceRow,
+	isFieldMissing,
+	isFieldWritable,
+	readonlyDisplay,
+} from "./draftApply";
 
 describe("isFieldWritable", () => {
 	it("create: a read_only field the agent PROPOSED is written", () => {
@@ -15,6 +22,50 @@ describe("isFieldWritable", () => {
 	it("a non-read_only field is always writable", () => {
 		expect(isFieldWritable({ read_only: 0, proposed: false }, "create")).toBe(true);
 		expect(isFieldWritable({ read_only: 0, proposed: false }, "update")).toBe(true);
+	});
+});
+
+describe("isFieldMissing", () => {
+	it("required + editable + empty -> missing", () => {
+		expect(isFieldMissing({ reqd: 1, read_only: 0, value: "" })).toBe(true);
+	});
+	it("required + read_only + empty -> NOT missing (user can't fill it)", () => {
+		expect(isFieldMissing({ reqd: 1, read_only: 1, value: "" })).toBe(false);
+	});
+	it("required + editable + filled -> not missing", () => {
+		expect(isFieldMissing({ reqd: 1, read_only: 0, value: "x" })).toBe(false);
+	});
+	it("not required -> never missing", () => {
+		expect(isFieldMissing({ reqd: 0, read_only: 0, value: "" })).toBe(false);
+	});
+});
+
+describe("readonlyDisplay", () => {
+	it("empty -> em dash", () => {
+		expect(readonlyDisplay({ value: "" })).toBe("—");
+		expect(readonlyDisplay({ value: null })).toBe("—");
+	});
+	it("datetime -> T swapped for a space", () => {
+		expect(readonlyDisplay({ control: "datetime", value: "2026-08-31T14:30" })).toBe(
+			"2026-08-31 14:30"
+		);
+	});
+	it("other controls pass through verbatim", () => {
+		expect(readonlyDisplay({ control: "data", value: "hello" })).toBe("hello");
+		expect(readonlyDisplay({ control: "date", value: "2026-08-31" })).toBe("2026-08-31");
+	});
+});
+
+describe("checkToYesNo", () => {
+	it("truthy tokens -> Yes", () => {
+		for (const v of ["1", 1, "yes", "Yes", "true", true, "on"]) {
+			expect(checkToYesNo(v)).toBe("Yes");
+		}
+	});
+	it("everything else -> No", () => {
+		for (const v of ["0", 0, "", "no", false, "2"]) {
+			expect(checkToYesNo(v)).toBe("No");
+		}
 	});
 });
 
@@ -43,20 +94,25 @@ describe("coerceRow", () => {
 		const t = { columns: [col({ read_only: 1 })] };
 		expect(coerceRow(t, { c: "v" }, "update")).toEqual({});
 	});
+	it("verb omitted (origJson baseline) strips read_only, same as update", () => {
+		const t = { columns: [col({ read_only: 1 })] };
+		expect(coerceRow(t, { c: "v" })).toEqual({});
+	});
 	it("empty / null cells are skipped", () => {
 		const t = { columns: [col(), { fieldname: "d", fieldtype: "Data" }] };
 		expect(coerceRow(t, { c: "", d: null }, "create")).toEqual({});
 	});
-	it("Check: truthy string tokens normalize to 1 (not Number(v) -> 0)", () => {
+	it("Check: truthy tokens normalize to 1 (not Number(v) -> 0)", () => {
 		const t = { columns: [{ fieldname: "c", fieldtype: "Check", read_only: 0 }] };
-		expect(coerceRow(t, { c: "Yes" }, "create")).toEqual({ c: 1 });
-		expect(coerceRow(t, { c: "true" }, "create")).toEqual({ c: 1 });
-		expect(coerceRow(t, { c: "1" }, "create")).toEqual({ c: 1 });
-		expect(coerceRow(t, { c: 1 }, "create")).toEqual({ c: 1 });
+		for (const v of ["Yes", "true", "on", "1", 1, true]) {
+			expect(coerceRow(t, { c: v }, "create")).toEqual({ c: 1 });
+		}
 		expect(coerceRow(t, { c: "No" }, "create")).toEqual({ c: 0 });
 	});
 	it("numeric fieldtypes coerce to Number", () => {
-		const t = { columns: [{ fieldname: "n", fieldtype: "Float", read_only: 0 }] };
-		expect(coerceRow(t, { n: "3.5" }, "create")).toEqual({ n: 3.5 });
+		for (const ft of ["Int", "Float", "Currency", "Percent"]) {
+			const t = { columns: [{ fieldname: "n", fieldtype: ft, read_only: 0 }] };
+			expect(coerceRow(t, { n: "3.5" }, "create")).toEqual({ n: 3.5 });
+		}
 	});
 });

--- a/frontend/src/lib/draftApply.spec.js
+++ b/frontend/src/lib/draftApply.spec.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { coerceOut, coerceRow, isFieldWritable } from "./draftApply";
+
+describe("isFieldWritable", () => {
+	it("create: a read_only field the agent PROPOSED is written", () => {
+		expect(isFieldWritable({ read_only: 1, proposed: true }, "create")).toBe(true);
+	});
+	it("create: an UNPROPOSED read_only field is not written (reqd-Check default clobber)", () => {
+		expect(isFieldWritable({ read_only: 1, proposed: false }, "create")).toBe(false);
+	});
+	it("update: a read_only field is never written, even if proposed", () => {
+		expect(isFieldWritable({ read_only: 1, proposed: true }, "update")).toBe(false);
+	});
+	it("a non-read_only field is always writable", () => {
+		expect(isFieldWritable({ read_only: 0, proposed: false }, "create")).toBe(true);
+		expect(isFieldWritable({ read_only: 0, proposed: false }, "update")).toBe(true);
+	});
+});
+
+describe("coerceOut", () => {
+	it("check -> 1/0 from the Yes/No control string", () => {
+		expect(coerceOut({ control: "check", value: "Yes" })).toBe(1);
+		expect(coerceOut({ control: "check", value: "No" })).toBe(0);
+	});
+	it("number -> Number, empty stays empty", () => {
+		expect(coerceOut({ control: "number", value: "5" })).toBe(5);
+		expect(coerceOut({ control: "number", value: "" })).toBe("");
+	});
+	it("other controls pass through", () => {
+		expect(coerceOut({ control: "text", value: "hi" })).toBe("hi");
+	});
+});
+
+describe("coerceRow", () => {
+	const col = (o) => ({ fieldname: "c", fieldtype: "Data", read_only: 0, ...o });
+
+	it("create: a read_only child column carrying a value is filled", () => {
+		const t = { columns: [col({ read_only: 1 })] };
+		expect(coerceRow(t, { c: "v" }, "create")).toEqual({ c: "v" });
+	});
+	it("update: a read_only child column is stripped", () => {
+		const t = { columns: [col({ read_only: 1 })] };
+		expect(coerceRow(t, { c: "v" }, "update")).toEqual({});
+	});
+	it("empty / null cells are skipped", () => {
+		const t = { columns: [col(), { fieldname: "d", fieldtype: "Data" }] };
+		expect(coerceRow(t, { c: "", d: null }, "create")).toEqual({});
+	});
+	it("Check: truthy string tokens normalize to 1 (not Number(v) -> 0)", () => {
+		const t = { columns: [{ fieldname: "c", fieldtype: "Check", read_only: 0 }] };
+		expect(coerceRow(t, { c: "Yes" }, "create")).toEqual({ c: 1 });
+		expect(coerceRow(t, { c: "true" }, "create")).toEqual({ c: 1 });
+		expect(coerceRow(t, { c: "1" }, "create")).toEqual({ c: 1 });
+		expect(coerceRow(t, { c: 1 }, "create")).toEqual({ c: 1 });
+		expect(coerceRow(t, { c: "No" }, "create")).toEqual({ c: 0 });
+	});
+	it("numeric fieldtypes coerce to Number", () => {
+		const t = { columns: [{ fieldname: "n", fieldtype: "Float", read_only: 0 }] };
+		expect(coerceRow(t, { n: "3.5" }, "create")).toEqual({ n: 3.5 });
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6475,6 +6475,7 @@ async function buildDraftModel(a) {
 		// Show: agent-proposed fields + required fields + (update) filled fields the agent referenced
 		if (!has && !f.reqd) continue;
 		const pf = _panelField(f, has ? proposed[f.fieldname] : baseV);
+		pf.proposed = has; // agent set a value for this field (vs. shown only because reqd)
 		if (verb === "update")
 			pf.orig =
 				baseV == null ? "" : String(pf.control === "check" ? _checkToYesNo(baseV) : baseV);
@@ -6745,10 +6746,14 @@ function _coerceOut(f) {
 	if (f.control === "number") return f.value === "" ? "" : Number(f.value);
 	return f.value;
 }
-function _coerceRow(t, r) {
+function _coerceRow(t, r, verb) {
 	const out = {};
 	for (const c of t.columns) {
-		if (c.read_only) continue;
+		// Match the main-field rule (applyDraft): on CREATE, fill a read_only
+		// child column that carries a value; every other verb strips it. Both
+		// update call sites (current rows pass 'update', the origJson baseline
+		// omits verb) are verb !== "create", so update keeps stripping.
+		if (c.read_only && verb !== "create") continue;
 		let v = r[c.fieldname];
 		if (v === "" || v == null) continue;
 		if (["Int", "Float", "Currency", "Percent"].includes(c.fieldtype)) v = Number(v);
@@ -6763,13 +6768,24 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 	if (!p || p.applying) return;
 	const values = {};
 	for (const f of p.fields) {
-		if (f.read_only) continue;
+		// read_only is a form-UI flag, not a write barrier: the agent's direct
+		// create_doc already sets read_only fields (e.g. Error Log method/error),
+		// so on a CREATE a confirm card fills a read_only field the agent PROPOSED
+		// a value for, rather than silently dropping it. Gate on `proposed`, not
+		// just "non-empty": an unproposed reqd read_only Check renders as "No"/0 and
+		// would otherwise clobber a schema default of 1. UPDATE always strips
+		// read_only - a confirm card must not overwrite a server-managed field on an
+		// existing doc. permlevel>0 fields stay guarded by Frappe's insert-time
+		// reset (see test_permlevel_leak: TestCreateDocPermlevelWriteReset).
+		if (f.read_only && !(p.verb === "create" && f.proposed)) continue;
 		const changed = String(f.value) !== String(f.orig);
 		if (p.verb === "create" ? String(f.value).trim() !== "" : changed)
 			values[f.fieldname] = _coerceOut(f);
 	}
 	for (const t of p.tables) {
-		const rows = t.rows.map((r) => _coerceRow(t, r)).filter((r) => Object.keys(r).length);
+		const rows = t.rows
+			.map((r) => _coerceRow(t, r, p.verb))
+			.filter((r) => Object.keys(r).length);
 		if (p.verb === "create") {
 			if (rows.length) values[t.fieldname] = rows;
 		} else if (

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3712,7 +3712,7 @@
 								:key="f.fieldname"
 								class="jv-draft-fld"
 								:class="{
-									missing: f.reqd && !String(f.value).trim(),
+									missing: f.reqd && !f.read_only && !String(f.value).trim(),
 									changed: f.changed,
 								}"
 							>
@@ -3721,7 +3721,10 @@
 									}}<span v-if="f.reqd" class="jv-req"> *</span></label
 								>
 								<div class="jv-draft-ctl">
-									<template v-if="f.control === 'link'">
+									<span v-if="f.read_only" class="jv-draft-ro">{{
+										f.value
+									}}</span>
+									<template v-else-if="f.control === 'link'">
 										<input
 											class="jv-action-input"
 											v-model="f.value"
@@ -4137,6 +4140,7 @@ import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
+import { coerceOut, coerceRow, isFieldWritable } from "@/lib/draftApply";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { shouldFollowBottom } from "@/lib/chatScroll";
 import { createRevealer } from "@/lib/streamReveal";
@@ -6741,50 +6745,23 @@ watch(actionFor, () => {
 
 // --- apply wiring: draft panel create/update round-trip via apply_action ---
 
-function _coerceOut(f) {
-	if (f.control === "check") return f.value === "Yes" ? 1 : 0;
-	if (f.control === "number") return f.value === "" ? "" : Number(f.value);
-	return f.value;
-}
-function _coerceRow(t, r, verb) {
-	const out = {};
-	for (const c of t.columns) {
-		// Match the main-field rule (applyDraft): on CREATE, fill a read_only
-		// child column that carries a value; every other verb strips it. Both
-		// update call sites (current rows pass 'update', the origJson baseline
-		// omits verb) are verb !== "create", so update keeps stripping.
-		if (c.read_only && verb !== "create") continue;
-		let v = r[c.fieldname];
-		if (v === "" || v == null) continue;
-		if (["Int", "Float", "Currency", "Percent"].includes(c.fieldtype)) v = Number(v);
-		if (c.fieldtype === "Check") v = Number(v) ? 1 : 0;
-		out[c.fieldname] = v;
-	}
-	return out;
-}
-
 async function applyDraft(submitFlag, model = draftPanel.value) {
 	const p = model;
 	if (!p || p.applying) return;
 	const values = {};
 	for (const f of p.fields) {
-		// read_only is a form-UI flag, not a write barrier: the agent's direct
-		// create_doc already sets read_only fields (e.g. Error Log method/error),
-		// so on a CREATE a confirm card fills a read_only field the agent PROPOSED
-		// a value for, rather than silently dropping it. Gate on `proposed`, not
-		// just "non-empty": an unproposed reqd read_only Check renders as "No"/0 and
-		// would otherwise clobber a schema default of 1. UPDATE always strips
-		// read_only - a confirm card must not overwrite a server-managed field on an
-		// existing doc. permlevel>0 fields stay guarded by Frappe's insert-time
-		// reset (see test_permlevel_leak: TestCreateDocPermlevelWriteReset).
-		if (f.read_only && !(p.verb === "create" && f.proposed)) continue;
+		// read_only gating + coercion live in lib/draftApply (unit-tested there): a
+		// read_only field is submitted only when the agent proposed it on a create;
+		// permlevel>0 fields stay guarded by Frappe's insert-time reset (see
+		// test_permlevel_leak: TestCreateDocPermlevelWriteReset).
+		if (!isFieldWritable(f, p.verb)) continue;
 		const changed = String(f.value) !== String(f.orig);
 		if (p.verb === "create" ? String(f.value).trim() !== "" : changed)
-			values[f.fieldname] = _coerceOut(f);
+			values[f.fieldname] = coerceOut(f);
 	}
 	for (const t of p.tables) {
 		const rows = t.rows
-			.map((r) => _coerceRow(t, r, p.verb))
+			.map((r) => coerceRow(t, r, p.verb))
 			.filter((r) => Object.keys(r).length);
 		if (p.verb === "create") {
 			if (rows.length) values[t.fieldname] = rows;
@@ -6792,7 +6769,7 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 			JSON.stringify(rows) !==
 			JSON.stringify(
 				(JSON.parse(t.origJson) || []).map((r) =>
-					_coerceRow(
+					coerceRow(
 						t,
 						Object.fromEntries(
 							Object.entries(r).map(([k, v]) => [k, v == null ? "" : String(v)])
@@ -14272,6 +14249,15 @@ onUnmounted(() => {
 }
 .jv-draft-ctl {
 	position: relative;
+}
+/* A read_only main field is shown, not editable: a muted static value (mirrors the
+   child-grid jv-grid-ro treatment) so the user can't type into a field the confirm
+   would discard. A proposed read_only value still shows here for review. */
+.jv-draft-ro {
+	display: inline-block;
+	padding: 4px 0;
+	color: var(--text-3);
+	word-break: break-word;
 }
 .jv-draft-table-title {
 	font-size: 12px;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3712,17 +3712,19 @@
 								:key="f.fieldname"
 								class="jv-draft-fld"
 								:class="{
-									missing: f.reqd && !f.read_only && !String(f.value).trim(),
+									missing: isFieldMissing(f),
 									changed: f.changed,
 								}"
 							>
 								<label
 									>{{ f.label
-									}}<span v-if="f.reqd" class="jv-req"> *</span></label
+									}}<span v-if="f.reqd && !f.read_only" class="jv-req">
+										*</span
+									></label
 								>
 								<div class="jv-draft-ctl">
 									<span v-if="f.read_only" class="jv-draft-ro">{{
-										f.value
+										readonlyDisplay(f)
 									}}</span>
 									<template v-else-if="f.control === 'link'">
 										<input
@@ -4140,7 +4142,14 @@ import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
-import { coerceOut, coerceRow, isFieldWritable } from "@/lib/draftApply";
+import {
+	checkToYesNo,
+	coerceOut,
+	coerceRow,
+	isFieldMissing,
+	isFieldWritable,
+	readonlyDisplay,
+} from "@/lib/draftApply";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { shouldFollowBottom } from "@/lib/chatScroll";
 import { createRevealer } from "@/lib/streamReveal";
@@ -6287,10 +6296,6 @@ function _actField(meta, label) {
 	}
 	return null;
 }
-function _checkToYesNo(v) {
-	const s = typeof v === "string" ? v.toLowerCase() : v;
-	return ["1", 1, "yes", "true", true, "on"].includes(s) ? "Yes" : "No";
-}
 // --- Record draft panel: the action JSON is the draft; edits are local; apply
 // posts to actions_api (no LLM round-trip). ---
 const draftPanel = ref(null);
@@ -6399,7 +6404,7 @@ function _panelField(metaField, value) {
 	if (["date", "datetime", "time"].includes(control)) v = _normDateVal(metaField.fieldtype, v);
 	let orig = v;
 	if (control === "check") {
-		v = _checkToYesNo(v);
+		v = checkToYesNo(v);
 		orig = v;
 	}
 	if (control === "select" && Array.isArray(options) && v && !options.includes(v))
@@ -6482,7 +6487,7 @@ async function buildDraftModel(a) {
 		pf.proposed = has; // agent set a value for this field (vs. shown only because reqd)
 		if (verb === "update")
 			pf.orig =
-				baseV == null ? "" : String(pf.control === "check" ? _checkToYesNo(baseV) : baseV);
+				baseV == null ? "" : String(pf.control === "check" ? checkToYesNo(baseV) : baseV);
 		pf.changed = verb === "update" && String(pf.value) !== String(pf.orig);
 		fields.push(pf);
 		seen.add(f.fieldname);
@@ -6773,7 +6778,8 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 						t,
 						Object.fromEntries(
 							Object.entries(r).map(([k, v]) => [k, v == null ? "" : String(v)])
-						)
+						),
+						"update"
 					)
 				)
 			)
@@ -14256,7 +14262,7 @@ onUnmounted(() => {
 .jv-draft-ro {
 	display: inline-block;
 	padding: 4px 0;
-	color: var(--text-3);
+	color: var(--text-2);
 	word-break: break-word;
 }
 .jv-draft-table-title {

--- a/jarvis/tests/test_permlevel_leak.py
+++ b/jarvis/tests/test_permlevel_leak.py
@@ -357,3 +357,43 @@ class TestPreviewDocTotalsPermlevelLeak(PermlevelLeakTestCase):
 			result = preview_doc(DT_NAME, {FIELD_PUBLIC: "visible"})
 		self.assertTrue(result["valid"])
 		self.assertEqual(float(result["totals"][FIELD_TOTAL]), SECRET_TOTAL)
+
+
+class TestCreateDocPermlevelWriteReset(PermlevelLeakTestCase):
+	"""Write-side guard for the SPA change that stops stripping read_only fields
+	from a CREATE confirm payload (ChatView ``applyDraft``): read_only is a
+	form-UI flag, not a write barrier, so an agent-proposed read_only field now
+	reaches ``create_doc`` from the confirm card. read_only and permlevel are
+	orthogonal, and the security boundary is Frappe's WRITE-side permlevel reset
+	inside ``doc.insert()``: a caller without permlevel-1 write CANNOT persist a
+	value to a permlevel-1 field even by passing it explicitly - Frappe silently
+	resets it to the field default. This proves that guard (which create_doc
+	relies on) still holds, so widening what the card sends cannot become a
+	permlevel write hole.
+
+	NB: assert the PERSISTED value (raw ``frappe.db.get_value``), not the
+	returned dict - create_doc permlevel-read-filters its return, so the
+	restricted field always reads back None there regardless of what was stored
+	(that read-side leak is covered by TestCreateDocPermlevelLeak)."""
+
+	def test_restricted_user_cannot_persist_permlevel_field(self):
+		with _as(USER_RESTRICTED):
+			result = create_doc(
+				doctype=DT_NAME,
+				values={FIELD_PUBLIC: "created", FIELD_RESTRICTED: "attacker-supplied"},
+			)
+			name = result["name"]
+		# Raw DB read (permlevel does not gate frappe.db) - what actually landed.
+		stored = frappe.db.get_value(DT_NAME, name, FIELD_RESTRICTED)
+		self.assertEqual(stored, SECRET_VALUE)  # reset to default, NOT the caller's value
+		self.assertNotEqual(stored, "attacker-supplied")
+
+	def test_privileged_user_can_persist_permlevel_field(self):
+		with _as(USER_PRIVILEGED):
+			result = create_doc(
+				doctype=DT_NAME,
+				values={FIELD_PUBLIC: "created", FIELD_RESTRICTED: "legit-value"},
+			)
+			name = result["name"]
+		stored = frappe.db.get_value(DT_NAME, name, FIELD_RESTRICTED)
+		self.assertEqual(stored, "legit-value")


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
