### PR TITLE
backport(version-16): reconcile agent_token synchronously on reconnect landing (#1046)

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -239,9 +239,12 @@ def write_connection(data: dict) -> None:
 
 
 @frappe.whitelist()
-def sync_connection() -> dict:
+def sync_connection(timeout_s: int | None = None) -> dict:
 	"""Pull the container connection from admin and store it. Daily scheduled +
-	the page's 'Sync connection' button. No-op until onboarded/assigned.
+	the page's 'Sync connection' button + the reconnect landing. No-op until
+	onboarded/assigned.
+
+	``timeout_s`` bounds the admin fetch (None = default); the reconnect landing passes a short one.
 
 	Gated on System Manager: writes admin credentials and container connection
 	into Jarvis Settings (jarvis_admin_api_key, agent_url, agent_token). The
@@ -254,7 +257,8 @@ def sync_connection() -> dict:
 	api_secret = settings.get_password("jarvis_admin_api_secret", raise_exception=False) or ""
 	if not (api_key and api_secret):
 		return {"synced": False, "reason": "not onboarded"}
-	data = admin_client.get_connection()
+	get_conn_kwargs = {} if timeout_s is None else {"timeout_s": timeout_s}
+	data = admin_client.get_connection(**get_conn_kwargs)
 	# Outside the agent_url branch: a payload without one must still be able to
 	# raise or clear the release notice, and this is the only refresh an idle
 	# bench gets.
@@ -1544,6 +1548,13 @@ def _land_reconnect(data: dict) -> dict:
 		return {"status": "renew_payment"}
 	if (data.get("subscription_status") or "").strip() == "Pending Payment":
 		return {"status": "resume_payment"}
+	# The reconnect just rotated agent_token admin-side; pull it NOW (short budget,
+	# best-effort) not on the daily cron, or every call_tool 401s for up to a day.
+	# require_jarvis_admin (sync_connection's gate) already passed at the entry.
+	try:
+		sync_connection(timeout_s=15)
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "reconnect: eager agent_token sync failed")
 	return {"status": "connected"}
 
 

--- a/jarvis/tests/test_onboarding_reconnect_renew.py
+++ b/jarvis/tests/test_onboarding_reconnect_renew.py
@@ -15,12 +15,27 @@ from jarvis import onboarding
 
 def _land(data):
 	"""Drive _land_reconnect with the credential-writing side effects stubbed."""
-	with (
-		patch("jarvis.onboarding.write_connection"),
-		patch("jarvis.onboarding.grant_onboarding_admin"),
-		patch("jarvis.tenant_authority.clear"),
-	):
+	with _land_ctx():
 		return onboarding._land_reconnect(data)
+
+
+def _land_ctx(sync_side_effect=None):
+	"""Stub _land_reconnect's side effects; yield the sync_connection mock."""
+	from contextlib import contextmanager
+
+	@contextmanager
+	def _ctx():
+		with (
+			# get_single only feeds the patched tenant_authority.clear.
+			patch("jarvis.onboarding.frappe.get_single"),
+			patch("jarvis.onboarding.write_connection"),
+			patch("jarvis.onboarding.grant_onboarding_admin"),
+			patch("jarvis.tenant_authority.clear"),
+			patch("jarvis.onboarding.sync_connection", side_effect=sync_side_effect) as sync,
+		):
+			yield sync
+
+	return _ctx()
 
 
 _READY = {
@@ -58,6 +73,36 @@ class TestReconnectRenewLanding(FrappeTestCase):
 	def test_non_ready_bundle_is_surfaced_verbatim(self):
 		# Unchanged: anything not ready (invalid/expired/awaiting_code) passes through untouched.
 		self.assertEqual(_land({"status": "invalid"})["status"], "invalid")
+
+
+class TestReconnectEagerTokenSync(FrappeTestCase):
+	"""A ``connected`` reconnect syncs the token; the no-container outcomes must not."""
+
+	def test_connected_eagerly_syncs_token(self):
+		with _land_ctx() as sync:
+			out = onboarding._land_reconnect({**_READY, "subscription_status": "Active"})
+		self.assertEqual(out["status"], "connected")
+		sync.assert_called_once_with(timeout_s=15)
+
+	def test_renew_payment_does_not_sync(self):
+		# No running container to sync to; the token reconciles later at renew()/finish_payment.
+		with _land_ctx() as sync:
+			out = onboarding._land_reconnect({**_READY, "renew_required": True})
+		self.assertEqual(out["status"], "renew_payment")
+		sync.assert_not_called()
+
+	def test_resume_payment_does_not_sync(self):
+		with _land_ctx() as sync:
+			out = onboarding._land_reconnect({**_READY, "subscription_status": "Pending Payment"})
+		self.assertEqual(out["status"], "resume_payment")
+		sync.assert_not_called()
+
+	def test_sync_failure_still_lands_connected(self):
+		# Best-effort: a transient admin hiccup must not fail the landing (cron/button fall back).
+		with _land_ctx(sync_side_effect=RuntimeError("admin unreachable")) as sync:
+			out = onboarding._land_reconnect({**_READY, "subscription_status": "Active"})
+		self.assertEqual(out["status"], "connected")
+		sync.assert_called_once_with(timeout_s=15)
 
 
 class TestRenewForwardsTargetPlan(FrappeTestCase):

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -1883,15 +1883,18 @@ class TestAccountReconnect(FrappeTestCase):
 
 	def test_check_ready_persists_rotated_credentials(self):
 		_set_token("")
-		with patch(
-			"jarvis.onboarding.admin_client.get_reconnect_state",
-			return_value={
-				"status": "ready",
-				"api_key": "new-key",
-				"api_secret": "new-secret",
-				"customer": "someone@example.com",
-				"customer_password": "new-pass",
-			},
+		with (
+			patch("jarvis.onboarding.sync_connection"),  # connected branch: don't hit the real admin
+			patch(
+				"jarvis.onboarding.admin_client.get_reconnect_state",
+				return_value={
+					"status": "ready",
+					"api_key": "new-key",
+					"api_secret": "new-secret",
+					"customer": "someone@example.com",
+					"customer_password": "new-pass",
+				},
+			),
 		):
 			out = onboarding.check_account_reconnect("rid-1")
 		self.assertEqual(out["status"], "connected")
@@ -1944,16 +1947,19 @@ class TestAccountReconnect(FrappeTestCase):
 
 	def test_an_active_subscription_status_still_connects(self):
 		_set_token("")
-		with patch(
-			"jarvis.onboarding.admin_client.get_reconnect_state",
-			return_value={
-				"status": "ready",
-				"api_key": "a-key",
-				"api_secret": "a-secret",
-				"customer": "cust-def@jarvis.invalid",
-				"customer_password": "a-pass",
-				"subscription_status": "Active",
-			},
+		with (
+			patch("jarvis.onboarding.sync_connection"),  # connected branch: don't hit the real admin
+			patch(
+				"jarvis.onboarding.admin_client.get_reconnect_state",
+				return_value={
+					"status": "ready",
+					"api_key": "a-key",
+					"api_secret": "a-secret",
+					"customer": "cust-def@jarvis.invalid",
+					"customer_password": "a-pass",
+					"subscription_status": "Active",
+				},
+			),
 		):
 			out = onboarding.check_account_reconnect("rid-1")
 		self.assertEqual(out["status"], "connected")
@@ -1962,15 +1968,18 @@ class TestAccountReconnect(FrappeTestCase):
 		"""Forward compatibility runs one way only: this bench may talk to an admin
 		older than the key. Absent must mean the behaviour that shipped before it."""
 		_set_token("")
-		with patch(
-			"jarvis.onboarding.admin_client.get_reconnect_state",
-			return_value={
-				"status": "ready",
-				"api_key": "o-key",
-				"api_secret": "o-secret",
-				"customer": "cust-ghi@jarvis.invalid",
-				"customer_password": "o-pass",
-			},
+		with (
+			patch("jarvis.onboarding.sync_connection"),  # connected branch: don't hit the real admin
+			patch(
+				"jarvis.onboarding.admin_client.get_reconnect_state",
+				return_value={
+					"status": "ready",
+					"api_key": "o-key",
+					"api_secret": "o-secret",
+					"customer": "cust-ghi@jarvis.invalid",
+					"customer_password": "o-pass",
+				},
+			),
 		):
 			out = onboarding.check_account_reconnect("rid-1")
 		self.assertEqual(out["status"], "connected")
@@ -2012,16 +2021,19 @@ class TestAccountReconnect(FrappeTestCase):
 		"""The request-less path: forward exactly (code, email) to admin and land
 		the returned ready bundle the same way check_account_reconnect does."""
 		_set_token("")
-		with patch(
-			"jarvis.onboarding.admin_client.redeem_reconnect_code",
-			return_value={
-				"status": "ready",
-				"api_key": "rk-key",
-				"api_secret": "rk-secret",
-				"customer": "someone@example.com",
-				"customer_password": "rk-pass",
-			},
-		) as redeem:
+		with (
+			patch("jarvis.onboarding.sync_connection"),  # connected branch: don't hit the real admin
+			patch(
+				"jarvis.onboarding.admin_client.redeem_reconnect_code",
+				return_value={
+					"status": "ready",
+					"api_key": "rk-key",
+					"api_secret": "rk-secret",
+					"customer": "someone@example.com",
+					"customer_password": "rk-pass",
+				},
+			) as redeem,
+		):
 			out = onboarding.redeem_reconnect_code("ABCD2345", "someone@example.com")
 		# email is the second factor - it MUST reach admin (never dropped).
 		redeem.assert_called_once_with("ABCD2345", "someone@example.com")


### PR DESCRIPTION
Backport of #1046 to `version-16`.

Clean cherry-pick (no conflicts). For the `connected` reconnect outcome, `onboarding._land_reconnect` now reconciles `agent_token` synchronously via `sync_connection(timeout_s=15)` (best-effort, short budget) instead of riding the daily cron — closing the ~24h `call_tool` "invalid X-Jarvis-Token" drift window. `sync_connection` gains an optional `timeout_s`. See #1046 for full rationale + tests (reconnect_renew 10/10, onboarding_sync 106/106).
