### PR TITLE
Backport/1028 1029 macro skip confirmation version 15

### DIFF
--- a/frontend/src/components/ReceiptChip.vue
+++ b/frontend/src/components/ReceiptChip.vue
@@ -42,6 +42,19 @@
 				<path d="M5.6 5.6l12.8 12.8" />
 			</svg>
 			<svg
+				v-else-if="view.icon === 'auto_applied'"
+				width="14"
+				height="14"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M13 2 3 14h7l-1 8 10-12h-7z" />
+			</svg>
+			<svg
 				v-else
 				width="14"
 				height="14"
@@ -58,6 +71,12 @@
 		<div class="jv-receipt-main">
 			<div class="jv-receipt-line">
 				<span class="jv-receipt-title">{{ view.title }}</span>
+				<span
+					v-if="armedMacro"
+					class="jv-receipt-armed"
+					:title="'Ran automatically under the armed macro ' + armedMacro"
+					>· {{ armedMacro }}</span
+				>
 				<a
 					v-if="singleUrl"
 					:href="singleUrl"
@@ -143,6 +162,11 @@ const view = computed(() => {
 	);
 });
 
+// Provenance for an armed-macro receipt: which macro authorized running this write
+// without a confirmation card. Shown on both auto_applied (ran ok) and a failed
+// armed write (labelled "failed" but still carrying the provenance).
+const armedMacro = computed(() => props.message.armed_by_macro || "");
+
 // A single-record outcome with a Desk link → show a compact "open" affordance
 // (the record name is already in the title). Bulk uses the details expander.
 const singleUrl = computed(() => {
@@ -194,6 +218,18 @@ const ts = computed(() => {
 }
 .jv-receipt-ico.confirmed {
 	color: var(--green);
+}
+.jv-receipt-ico.auto_applied {
+	color: var(--green);
+}
+.jv-receipt-armed {
+	flex: 0 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	color: var(--text-3);
 }
 .jv-receipt-ico.discarded {
 	color: var(--text-3);

--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -173,7 +173,7 @@ function receiptNames(tool, args, data, outcome) {
 			return data.sent.map((d) => (d && (d.recipients || d.name)) || "").filter(Boolean);
 		if (tool === "send_email" && data.recipients) return [].concat(data.recipients);
 		if (data.name) return [data.name];
-		if (outcome === "confirmed") return [];
+		if (outcome === "confirmed" || outcome === "auto_applied") return [];
 	}
 	if (Array.isArray(args.names)) return args.names.slice();
 	if (Array.isArray(args.updates)) return args.updates.map((u) => u && u.name).filter(Boolean);
@@ -200,10 +200,12 @@ export function receiptView(tool, args, result, outcome) {
 		(Array.isArray(args.docs) && args.docs[0] && args.docs[0].doctype) ||
 		"record";
 	const action = args.action || data.action || "";
+	// auto_applied (an armed macro ran it uncarded) is a real execution, like confirmed.
+	const ran = outcome === "confirmed" || outcome === "auto_applied";
 	const count =
-		outcome === "confirmed" && typeof data.count === "number"
+		ran && typeof data.count === "number"
 			? data.count
-			: outcome === "confirmed"
+			: ran
 			? names.length || argCount(args)
 			: argCount(args);
 
@@ -252,6 +254,12 @@ export function receiptView(tool, args, result, outcome) {
 						count
 				  )} were ${verb.past.toLowerCase()}`
 				: `Failed — ${subject} was not ${verb.past.toLowerCase()}`;
+	} else if (outcome === "auto_applied") {
+		// An armed macro ran this write WITHOUT a confirmation card. Render a distinct
+		// receipt (not an identical "confirmed" chip) so it never reads as a silent run.
+		icon = "auto_applied";
+		tone = "success";
+		title = `${verb.past} ${wfPrefix}${subject} — automatically, no confirmation`;
 	} else {
 		icon = "confirmed";
 		tone = "success";

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -271,3 +271,33 @@ test("receiptView: a create links the record it made", () => {
 	);
 	assert.ok(v.targets[0].url.includes("TASK-0002"));
 });
+
+test("receiptView: an auto_applied (armed macro) write is a DISTINCT receipt, not a plain confirmed", () => {
+	const v = receiptView(
+		"submit_doc",
+		{ doctype: "Sales Order", name: "SO-0001" },
+		{ ok: true, data: {} },
+		"auto_applied"
+	);
+	assert.equal(v.icon, "auto_applied");
+	assert.equal(v.tone, "success");
+	assert.notEqual(v.icon, "confirmed");
+	assert.match(v.title, /no confirmation/);
+});
+
+test("receiptView: auto_applied counts like a real execution (from data), not the args", () => {
+	const v = receiptView(
+		"create_doc",
+		{ doctype: "Task" },
+		{
+			ok: true,
+			data: {
+				doctype: "Task",
+				name: "TASK-9001",
+				created: [{ doctype: "Task", name: "TASK-9001" }],
+			},
+		},
+		"auto_applied"
+	);
+	assert.ok(v.targets[0].url.includes("TASK-9001"));
+});

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -65,6 +65,16 @@
 						description="Stop the chain if a step fails - otherwise it keeps going after an error."
 						:disabled="saving"
 					/>
+					<Switch
+						v-model="form.skip_confirmation"
+						label="Skip confirmation (run writes uncarded)"
+						:description="
+							canArm
+								? 'Admin only. This macro\'s runs execute writes WITHOUT a confirmation card - including run_method, send_email and run_import. delete/cancel/amend still park and stop the run. Arming trusts the owner for current and future steps.'
+								: 'Admin only - a Jarvis Admin or System Manager can arm this macro to run its writes without a confirmation card.'
+						"
+						:disabled="saving || !canArm"
+					/>
 				</div>
 			</DocSection>
 
@@ -229,6 +239,7 @@ const form = reactive({
 	description: "",
 	enabled: true,
 	stop_on_error: true,
+	skip_confirmation: false,
 	schedule_enabled: false,
 	schedule_frequency: "daily",
 	schedule_time: "09:00",
@@ -247,6 +258,11 @@ const docmeta = shallowRef(null); // useDocmeta instance (persisted macros only)
 const mergePending = computed(() => mergeStatus.value === "pending");
 const stepsWithPrompt = computed(() => form.steps.filter((s) => (s.prompt || "").trim()).length);
 
+// Arming a macro to skip confirmation is admin-only (the backend re-checks
+// require_jarvis_admin, so this is a UX gate, not the security boundary); a
+// non-admin sees the toggle disabled with the reason instead of a throw-on-save.
+const canArm = !!(window.is_jarvis_admin || window.is_system_manager);
+
 const dirty = computed(() => {
 	const snap = snapshot.value;
 	if (!snap || loading.value) return false;
@@ -255,6 +271,7 @@ const dirty = computed(() => {
 		(form.description || "") !== snap.description ||
 		(form.enabled ? 1 : 0) !== snap.enabled ||
 		(form.stop_on_error ? 1 : 0) !== snap.stop_on_error ||
+		(form.skip_confirmation ? 1 : 0) !== snap.skip_confirmation ||
 		(form.schedule_enabled ? 1 : 0) !== snap.schedule_enabled ||
 		(form.schedule_frequency || "daily") !== snap.schedule_frequency ||
 		(form.schedule_time || "") !== snap.schedule_time ||
@@ -319,6 +336,7 @@ function seed(data) {
 	form.description = data.description || "";
 	form.enabled = data.enabled == null ? true : !!data.enabled;
 	form.stop_on_error = !!data.stop_on_error;
+	form.skip_confirmation = !!data.skip_confirmation;
 	form.schedule_enabled = !!data.schedule_enabled;
 	form.schedule_frequency = data.schedule_frequency || "daily";
 	form.schedule_time = toHHMM(data.schedule_time) || "09:00";
@@ -332,6 +350,7 @@ function seed(data) {
 		description: form.description,
 		enabled: form.enabled ? 1 : 0,
 		stop_on_error: form.stop_on_error ? 1 : 0,
+		skip_confirmation: form.skip_confirmation ? 1 : 0,
 		schedule_enabled: form.schedule_enabled ? 1 : 0,
 		schedule_frequency: form.schedule_frequency,
 		schedule_time: form.schedule_time,
@@ -406,6 +425,7 @@ async function save() {
 			steps,
 			enabled: form.enabled ? 1 : 0,
 			stop_on_error: form.stop_on_error ? 1 : 0,
+			skip_confirmation: form.skip_confirmation ? 1 : 0,
 			schedule_enabled: form.schedule_enabled ? 1 : 0,
 			schedule_frequency: form.schedule_frequency || "daily",
 			schedule_time: form.schedule_time || "09:00",

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -51,6 +51,18 @@
 				/>
 			</template>
 
+			<template #cell-macro_name="{ row }">
+				<div class="flex items-center gap-2">
+					<span class="truncate">{{ row.macro_name }}</span>
+					<Tooltip
+						v-if="row.skip_confirmation"
+						text="Armed: this macro's runs execute writes without a confirmation card (admin-set)."
+					>
+						<Badge variant="subtle" theme="orange" label="Armed" />
+					</Tooltip>
+				</div>
+			</template>
+
 			<template #cell-step_count="{ row }">
 				<div class="flex w-full items-center justify-center text-base text-ink-gray-7">
 					{{ row.step_count || 0 }} {{ (row.step_count || 0) === 1 ? "step" : "steps" }}

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -275,6 +275,7 @@ def _dispatch_from_session(
 			return result
 	finally:
 		_agent_run_ctx.clear_session_key()
+		_agent_run_ctx.take_armed_by_macro()  # belt: never leak an armed marker across dispatches
 
 
 _STALE_PAIRING_DEDUPE_TTL_S = 3600
@@ -340,7 +341,29 @@ def _persist_and_publish_tool_call(
 	conv_name = frappe.db.get_value("Jarvis Conversation", {"session_key": session_key}, "name")
 	if not conv_name:
 		return
-	persist_tool_receipt(conv_name, tool, args, result, tool_call_id=tool_call_id)
+	# T8: an armed-skip write set a request-local provenance marker (consume-once).
+	# Label its receipt auto_applied + armed_by_macro so the SPA renders a distinct
+	# "ran without confirmation - armed macro X" chip and the row is queryable, instead
+	# of a silent Activity-accordion tool row.
+	from jarvis.tools import _agent_run_ctx
+
+	armed_by_macro = _agent_run_ctx.take_armed_by_macro()
+	# A FAILED armed write must still be visible (it ran uncarded, unattended, and
+	# broke - exactly what T8 surfaces): label it "failed" (a red chip carrying the
+	# macro provenance) rather than letting it fall into the collapsed Activity row.
+	if armed_by_macro:
+		armed_outcome = "auto_applied" if (isinstance(result, dict) and result.get("ok")) else "failed"
+	else:
+		armed_outcome = None
+	persist_tool_receipt(
+		conv_name,
+		tool,
+		args,
+		result,
+		action_outcome=armed_outcome,
+		armed_by_macro=armed_by_macro if armed_outcome else None,
+		tool_call_id=tool_call_id,
+	)
 
 
 def _locked_insert_chat_message(
@@ -383,6 +406,7 @@ def persist_tool_receipt(
 	result: dict | None,
 	*,
 	action_outcome: str | None = None,
+	armed_by_macro: str | None = None,
 	tool_call_id: str | None = None,
 ) -> None:
 	"""Write a role=tool Jarvis Chat Message receipt into ``conv_name`` and
@@ -455,6 +479,7 @@ def persist_tool_receipt(
 				"tool_status": status,
 				"tool_call_id": tool_call_id or None,
 				"action_outcome": action_outcome or None,
+				"armed_by_macro": armed_by_macro or None,
 				"ref_doctype": ref_doctype,
 				"ref_name": ref_name,
 				"content": f"{tool} → {action_outcome or status}",
@@ -740,6 +765,36 @@ _DESTRUCTIVE = frozenset(
 # default-unrestricted allowlist under auto-apply + a prompt injection would be
 # an unconfirmed arbitrary whitelisted method call, so it never fast-paths.
 _AUTO_APPLYABLE = frozenset({"create_doc", "update_doc"})
+# Armed-skip (macro skip-confirmation): an admin-armed macro (Jarvis Macro
+# .skip_confirmation, stamped onto its run conversation's skip_confirmation) runs
+# these WITHOUT a confirmation card - the BROAD covered set, far wider than the
+# create/update-only _AUTO_APPLYABLE, and INCLUDING run_method (which gates in
+# ordinary chat; skips only inside an armed macro). This is an explicit ALLOWLIST,
+# NOT `_GATED_WRITES - _ARMED_SKIP_NEVER`: a new gated tool must NOT become
+# armed-skippable by default. The partition invariant (test_armed_skip_partition)
+# asserts COVERED and NEVER are disjoint and together == _GATED_WRITES, so adding a
+# gated tool to neither set turns that test RED until a human consciously files it.
+# The irreversible trio (_ARMED_SKIP_NEVER) always parks; an armed macro that hits
+# one stops the run (D5). Bulk covered writes DO skip; the F16 over-size cap still
+# bounces them. A gated tool NOT in COVERED (e.g. a bulk light write) parks in an
+# armed run like any other excluded write.
+_ARMED_SKIP_COVERED = frozenset(
+	{
+		"create_doc",
+		"create_docs",
+		"update_doc",
+		"submit_doc",
+		"run_method",
+		"run_import",
+		"apply_workflow_action",
+		"send_email",
+		"share_doc",
+		"assign_to",
+		"create_custom_skill",
+		"update_wiki",
+	}
+)
+_ARMED_SKIP_NEVER = frozenset({"cancel_doc", "delete_doc", "amend_doc"})
 # Gated writes we dry-run in the sandbox AT PARK TIME and BLOCK on if the dry-run
 # fails, so a deterministic failure (missing mandatory field, bad link, no create
 # permission) is returned to the model BEFORE a confirmation card is shown instead
@@ -810,6 +865,14 @@ def _as_bool(value) -> bool:
 	if isinstance(value, str):
 		return value.strip().lower() in ("1", "true", "yes", "on")
 	return bool(value)
+
+
+def _armed_skip_disabled() -> bool:
+	"""Site-wide kill switch for admin-armed macro skip-confirmation. When the
+	operator flips ``Jarvis Settings.disable_armed_skip`` on, every armed covered
+	write re-gates behind its card immediately, no deploy - the escape hatch if an
+	armed macro misbehaves. Read only when an armed covered write is about to skip."""
+	return bool(frappe.utils.cint(frappe.db.get_single_value("Jarvis Settings", "disable_armed_skip")))
 
 
 def _run_preview(tool: str, args: dict) -> dict:
@@ -1349,13 +1412,72 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 		owner_user = (
 			frappe.db.get_value("Jarvis Conversation", conv, "owner") if conv else None
 		) or exec_user
-		# Auto-apply bypass (issue #186, Task 4 + #5): the ONLY path where a gated
+		# One flags read shared by the two skip-the-card bypasses below (both key off
+		# the conversation row). An empty/unresolved conv -> {} -> every flag OFF (the
+		# safe default: the write parks).
+		_conv_flags = (
+			frappe.db.get_value(
+				"Jarvis Conversation", conv, ["auto_apply", "file_box", "skip_confirmation"], as_dict=True
+			)
+			if conv
+			else None
+		) or {}
+		# Armed-skip bypass (macro skip-confirmation): an admin-armed macro's run
+		# conversation carries skip_confirmation=1 (stamped by run_macro), so the
+		# BROAD covered set - incl. run_method / submit / send_email / run_import -
+		# runs uncarded. This is distinct from and wider than the create/update-only
+		# auto_apply below. The irreversible trio (delete/cancel/amend) is NOT in
+		# _ARMED_SKIP_COVERED, so it falls through to park (an armed macro that hits
+		# one stops the run - D5). Cheap frozenset membership test first; the
+		# kill-switch Settings read runs only when a covered write is actually armed.
+		# Bulk covered writes skip too (an automation must not stall on a batch card);
+		# the F16 over-size cap above still bounces an oversized batch.
+		if (
+			tool in _ARMED_SKIP_COVERED
+			and _conv_flags.get("skip_confirmation")
+			and not _armed_skip_disabled()
+		):
+			result = dispatch_confirmed(tool, args)
+			# Provenance for the receipt (T8): which armed macro authorized this uncarded
+			# write. Consumed once by the receipt persist, which labels the row
+			# action_outcome=auto_applied + armed_by_macro so an armed write is a visible,
+			# queryable receipt - not silence-by-omission.
+			from jarvis.tools import _agent_run_ctx
+
+			# Always label an armed write (we are in the armed branch, so it IS armed):
+			# resolve the human macro_name (Jarvis Macro autoname is a hash, so the run's
+			# `macro` docname is opaque) and fall back to a generic marker if the run-row
+			# lookup misses (the abnormal lingering-flag state) - never silently unlabelled.
+			_armed_run_macro = frappe.db.get_value(
+				"Jarvis Macro Run", {"conversation": conv, "status": "running"}, "macro"
+			)
+			_agent_run_ctx.set_armed_by_macro(
+				(
+					frappe.db.get_value("Jarvis Macro", _armed_run_macro, "macro_name")
+					if _armed_run_macro
+					else None
+				)
+				or "an armed macro"
+			)
+			if tool == "run_import":
+				# The armed branch bypasses _confirm_core, which is where a CONFIRMED
+				# run_import normally gets its completion announcement bound. Bind it here
+				# too so an armed (unattended) import still reports done/failed into the run
+				# log. Synthesize the record from the gate locals (conv + owner_user) - there
+				# is no pending-confirm record on this path. Self-gating + best-effort (it
+				# no-ops on a non-ok result, a missing data_import, or the kill switch).
+				from jarvis.chat.import_announce import bind_after_run_import
+
+				bind_after_run_import(
+					{"tool": "run_import", "conversation": conv, "owner": owner_user}, result
+				)
+			return result
+		# Auto-apply bypass (issue #186, Task 4 + #5): the OTHER path where a gated
 		# write runs without a confirmation token. Strictly limited to
 		# {a resolved conversation, admin-enabled auto_apply, an _AUTO_APPLYABLE
-		# (reversible create/update) tool}. An empty/unresolved conv is treated
-		# as OFF (safe default). Everything outside create/update - submit_doc,
-		# run_method, and every destructive tool (delete/cancel/amend/send_email)
-		# - ALWAYS parks, even with auto_apply on.
+		# (reversible create/update) tool}. Everything outside create/update -
+		# submit_doc, and every destructive tool (delete/cancel/amend/send_email) -
+		# ALWAYS parks under auto_apply (only armed-skip above runs the wider set).
 		#
 		# conv is never a client claim - it is resolved server-side from the
 		# session_key upstream - so there is no owner to re-check here: an
@@ -1372,11 +1494,7 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 			# run where nobody can click a confirm card and review happens on
 			# the created Draft + the approval board. Both flags are
 			# server-controlled and admin-gated against generic saves.
-			flags = (
-				frappe.db.get_value("Jarvis Conversation", conv, ["auto_apply", "file_box"], as_dict=True)
-				or {}
-			)
-			if flags.get("auto_apply") or flags.get("file_box"):
+			if _conv_flags.get("auto_apply") or _conv_flags.get("file_box"):
 				return dispatch_confirmed(tool, args)
 		# Sequential confirmation (F16): at most ONE live confirmation card per
 		# conversation. If one is already awaiting the user here, REFUSE to park a

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -357,6 +357,14 @@ _INVALID_CONFIRM = {
 	},
 }
 
+_ARMED_RUN_CONFIRM_WITHDRAWN = {
+	"ok": False,
+	"error": {
+		"type": "InvalidConfirmation",
+		"message": "This macro run is stopping; that confirmation was withdrawn and nothing ran.",
+	},
+}
+
 _CONFIRMATION_UNAVAILABLE = {
 	"ok": False,
 	"error": {
@@ -460,6 +468,17 @@ def _confirm_core(token: str, conversation: str | None = None, *, batch: bool = 
 		record = pending_confirm.peek(token, strict=True)
 		if not record:
 			return _INVALID_CONFIRM
+
+		# Defense-in-depth (security review): an armed macro-run conversation must have
+		# NO human-confirmable card. The only card that parks there is a D5 excluded
+		# (delete/cancel/amend) write, which stop-and-report sweeps in advance_after_turn.
+		# Refuse a racing Confirm published-at-park before that sweep - WITHOUT consuming
+		# the token, so the sweep still clears it - else the excluded write would run and
+		# fire an armed continuation turn. Keyed on the flag (the single source of truth);
+		# the typed-approval path is already blocked upstream in send_message.
+		token_conv = record.get("conversation")
+		if token_conv and frappe.db.get_value("Jarvis Conversation", token_conv, "skip_confirmation"):
+			return _ARMED_RUN_CONFIRM_WITHDRAWN
 
 		# Real conversation guard (#11): if the caller passed the conversation the
 		# click came from, enforce it; otherwise fall back to the record's own

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -38,6 +38,26 @@ def _get_owned_conversation(conversation: str):
 	return doc
 
 
+def _reject_send_into_armed_conversation(conv_doc) -> None:
+	"""A macro-run conversation carries ``skip_confirmation=1`` (armed): it is a
+	watchable RUN LOG, not a continuable chat. Refuse an interactive turn-entry
+	(``send_message`` / ``retry_message``) so a human can never inject a turn that
+	runs the armed, uncarded covered set on it - the flag itself (not the
+	owner-deletable Macro Run row) is the human-inert guarantee, and the write gate
+	reads this same flag. Macro STEPS dispatch via ``_enqueue_turn``, not these
+	endpoints, so they are unaffected. Disarming (``skip_confirmation`` -> 0, e.g.
+	when the run ends) reopens the conversation."""
+	if conv_doc and conv_doc.get("skip_confirmation"):
+		from frappe import _
+
+		frappe.throw(
+			_(
+				"This is a macro run - you can watch it, but not chat into it. "
+				"Start a new chat to talk to Jarvis."
+			)
+		)
+
+
 # Every attachment (image or not) is stored as a canvas item on the user message
 # so the SPA and the PWA render it as a clickable, previewable card - images as
 # inline thumbnails, other files as a chip that opens the file preview.
@@ -1285,6 +1305,8 @@ def send_message(
 		conversation = create_or_focus_empty()
 		conv_doc = _get_owned_conversation(conversation)
 
+	_reject_send_into_armed_conversation(conv_doc)
+
 	# A typed go-ahead on a parked confirmation card is the SAME act as clicking
 	# Confirm, so it runs the confirmation instead of becoming a chat turn. Placed
 	# here on purpose: ownership of the conversation is settled, but nothing has
@@ -2372,7 +2394,9 @@ def retry_message(message: str) -> dict:
 	# Ownership is enforced on the PARENT conversation: message rows can be
 	# inserted by the RQ worker under a different session user, so the
 	# conversation's owner is the authority, not the message row's owner.
-	_get_owned_conversation(doc.conversation)
+	# A retry is a human turn-entry too, so an armed macro-run conversation refuses
+	# it (T4): re-running a step there would run the covered set uncarded on demand.
+	_reject_send_into_armed_conversation(_get_owned_conversation(doc.conversation))
 	# Flag ON: a retry racing a live turn QUEUES (accept_or_queue) rather than
 	# rejecting; flag OFF keeps the legacy single-flight reject.
 	if admission.turn_machine_enabled():

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -128,19 +128,43 @@ def _cas_run_status(run_name: str, expect: str, new: str, **extra) -> bool:
 	for i, (col, val) in enumerate(extra.items()):
 		sets.append(f"`{col}`=%(x{i})s")
 		params[f"x{i}"] = val
-	return (
+	ok = (
 		_run_cas(
 			f"UPDATE `tab{RUN}` SET {', '.join(sets)} WHERE name=%(n)s AND status=%(expect)s",
 			params,
 		)
 		== 1
 	)
+	# Clear the armed flag on every terminal transition driven through the CAS
+	# (reap, resume-incompatible compensation, ...) - not only via _finish (T5).
+	if ok and new in _TERMINAL_RUN_STATUSES:
+		_disarm_run_conversation(run_name)
+	return ok
 
 
 def _run_status_now(run_name: str) -> str | None:
 	"""The run's CURRENT durable status (its own function so the CDX-22 pre-enqueue eligibility
 	re-check is a clean, patchable seam)."""
 	return frappe.db.get_value(RUN, run_name, "status")
+
+
+_TERMINAL_RUN_STATUSES = ("completed", "failed", "stopped")
+
+
+def _disarm_conversation(conversation: str | None) -> None:
+	"""Clear an armed run conversation's ``skip_confirmation`` when its run reaches a
+	terminal state, so the flag never outlives the run. Belt-and-suspenders on top of
+	the human-inert send-block (T4): the send-block already keeps a lingering flag
+	un-exploitable (send/retry are refused while set), but clearing keeps state clean
+	and stops any re-dispatched turn from running armed after the run is over. No-op
+	when unset. Caller commits (consistent with ``_cas_run_status``)."""
+	if conversation and frappe.db.get_value(CONV, conversation, "skip_confirmation"):
+		frappe.db.set_value(CONV, conversation, "skip_confirmation", 0, update_modified=False)
+
+
+def _disarm_run_conversation(run_name: str) -> None:
+	"""Disarm by run name (for the _cas terminal paths, which only have the run)."""
+	_disarm_conversation(frappe.db.get_value(RUN, run_name, "conversation"))
 
 
 # --------------------------------------------------------------------------- #
@@ -224,6 +248,16 @@ def run_macro(macro_name: str, *, trigger: str = "manual") -> dict:
 	if owner != frappe.session.user:
 		for dt, name in ((CONV, conv.name), (MSG, intro.name), (RUN, run.name)):
 			frappe.db.set_value(dt, name, "owner", owner, update_modified=False)
+	# Arm the run conversation when the macro is armed (doc.skip_confirmation, set
+	# only by a Jarvis Admin - guarded on the macro controller). Stamped via a raw
+	# db.set_value, the File-Box pattern that bypasses the conversation controller's
+	# admin guard: the value derives from the already-admin-gated macro flag, so a
+	# re-check would just refuse a legitimate non-admin owner running their own armed
+	# macro. The gate reads THIS conversation flag; the conversation is human-inert
+	# while set (send_message / retry_message are blocked, T4), so only macro-step
+	# turns ever run on it. Cleared on every run-terminal transition (T5).
+	if doc.skip_confirmation:
+		frappe.db.set_value(CONV, conv.name, "skip_confirmation", 1, update_modified=False)
 	frappe.db.commit()
 
 	# Scheduled runs surface via the proactive "conversation:new" toast; manual
@@ -265,6 +299,43 @@ def run_macro(macro_name: str, *, trigger: str = "manual") -> dict:
 	return {"ok": True, "data": {"macro_run": run.name, "conversation": conv.name}}
 
 
+def _armed_run_parked_card(conversation: str, owner: str) -> dict | None:
+	"""The first live confirmation card STRICTLY bound to ``conversation`` (or None).
+
+	An armed macro runs the covered set uncarded, so the ONLY thing that parks a card
+	on its run is an EXCLUDED tool (delete/cancel/amend) - i.e. the D5 stop signal.
+	Mirrors the gate's own strict-conversation filter (a conv-less token surfaces
+	under any filter). A storage error is swallowed to None: a pending-confirm outage
+	must not strand the run - it then advances as before, and the human-inert send
+	block + clear-on-terminal still hold the security line."""
+	from jarvis.chat import pending_confirm
+
+	try:
+		for rec in pending_confirm.list_for_owner(owner, conversation=conversation, strict=True):
+			if rec.get("conversation") == conversation:
+				return rec
+	except Exception:
+		return None
+	return None
+
+
+def _armed_stop_message(current_step: int, parked: dict) -> str:
+	"""D5 stop reason - names the un-clickable action AND the re-run hazard (§7): the
+	covered steps before it already ran, so re-running the whole macro repeats them.
+
+	``current_step`` is already the 1-based number of the step that just ran and parked
+	(``_run_step`` sets ``current_step = index + 1`` before the turn), so it is used
+	as-is (floored at 1 for the merged/edge case), NOT +1."""
+	step = max(int(current_step or 0), 1)
+	what = parked.get("summary") or parked.get("tool") or "a confirmation"
+	return (
+		f"Stopped at step {step}: this step needs a confirmation that can't be "
+		f"shown in an unattended run ({what}). The steps before it already ran, so "
+		f"re-running the whole macro would repeat them - fix this step's data or run it "
+		f"interactively, don't re-run the macro. Nothing after this step ran."
+	)[:500]
+
+
 def advance_after_turn(conversation_id: str, *, errored: bool) -> None:
 	"""Chaining hook, called from ``turn_handler`` after every terminal turn
 	outcome. If the conversation belongs to a ``running`` Macro Run, advance it:
@@ -293,6 +364,33 @@ def advance_after_turn(conversation_id: str, *, errored: bool) -> None:
 			macro_doc = frappe.get_doc(MACRO, run.macro)
 			steps = macro_doc.steps or []
 			total = min(run.total_steps or len(steps), len(steps))
+
+			# D5 (armed runs only): the step that just ran parked a confirmation card.
+			# In an armed run the covered set runs uncarded, so a parked card means an
+			# EXCLUDED tool (delete/cancel/amend) - and this is an unattended run with
+			# nobody to click it. Advancing would report a false "completed" with the
+			# destructive step silently never run. Detect it (a park returns ok:True, so
+			# `errored` is False - the only per-step signal is the parked token itself),
+			# STOP the run with a legible re-run-hazard message, and SWEEP the token so
+			# the card can't be confirmed later and fire an armed continuation turn.
+			# Checked BEFORE the stop_on_error / next_index decisions, so a merged-mode
+			# (single-turn) run is covered too.
+			if frappe.db.get_value(CONV, run.conversation, "skip_confirmation"):
+				owner_user = frappe.db.get_value(CONV, run.conversation, "owner")
+				parked = _armed_run_parked_card(run.conversation, owner_user)
+				if parked:
+					from jarvis.chat import pending_confirm
+
+					# SWEEP the token FIRST, then terminalize. _finish disarms the
+					# conversation (skip_confirmation -> 0), and the _confirm_core armed
+					# guard keys off that flag - so if we disarmed before sweeping, a Confirm
+					# racing in that window would read flag=0, bypass the guard, and run the
+					# destructive write. Consuming the token first makes a racing Confirm hit
+					# a dead token and be refused regardless of the flag (deterministic).
+					pending_confirm.clear_for_conversation(owner_user, run.conversation)
+					_finish(run, "failed", error=_armed_stop_message(run.current_step or 0, parked))
+					_publish_done(run, macro_doc, "failed")
+					return
 
 			if errored and macro_doc.stop_on_error:
 				_finish(run, "failed", error=f"Step {run.current_step} failed.")
@@ -455,6 +553,7 @@ def stop_macro_run(run_name: str) -> dict:
 		# stoppable too — otherwise the resume cron would keep re-attempting a run the user stopped.
 		if frappe.db.get_value(RUN, run_name, "status") in ("running", "waiting_capacity"):
 			frappe.db.set_value(RUN, run.name, {"status": "stopped", "finished_at": frappe.utils.now()})
+			_disarm_conversation(run.conversation)  # the flag never outlives the run (T5)
 			frappe.db.commit()
 			try:
 				_publish_done(run, frappe.get_doc(MACRO, run.macro), "stopped")
@@ -1031,6 +1130,7 @@ def _finish(run, status: str, error: str | None = None) -> None:
 		run.name,
 		{"status": status, "finished_at": frappe.utils.now(), "error": (error or "")[:500]},
 	)
+	_disarm_conversation(run.conversation)  # the flag never outlives the run (T5)
 	frappe.db.commit()
 
 

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -189,7 +189,7 @@ def list_macros_page(
 
 	total = list_filters.bounded_sql(f"SELECT COUNT(*) FROM `tabJarvis Macro` WHERE {where}", params)[0][0]
 	rows = list_filters.bounded_sql(
-		f"""SELECT name, macro_name, description, enabled, stop_on_error,
+		f"""SELECT name, macro_name, description, enabled, stop_on_error, skip_confirmation,
 		schedule_enabled, schedule_frequency, schedule_time, next_run_at,
 		last_run_at, modified, merge_status,
 		CASE WHEN TRIM(COALESCE(merged_prompt, '')) != '' THEN 1 ELSE 0 END AS has_summary
@@ -238,6 +238,7 @@ def get_macro(name: str) -> dict:
 		"description": doc.description or "",
 		"enabled": int(doc.enabled or 0),
 		"stop_on_error": int(doc.stop_on_error or 0),
+		"skip_confirmation": int(doc.skip_confirmation or 0),
 		"schedule_enabled": int(doc.schedule_enabled or 0),
 		"schedule_frequency": doc.schedule_frequency or "daily",
 		"schedule_time": str(doc.schedule_time or ""),
@@ -274,12 +275,14 @@ def create_macro(
 	steps: str | list | None = None,
 	enabled: int = 1,
 	stop_on_error: int = 1,
+	skip_confirmation: int = 0,
 	schedule_enabled: int = 0,
 	schedule_frequency: str = "daily",
 	schedule_time: str | None = None,
 ) -> dict:
 	"""Create a macro. Validation (name/steps/caps) runs in the doctype validate().
-	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``)."""
+	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``). Arming
+	(``skip_confirmation`` 0 -> 1) is admin-gated in the doctype validate()."""
 	doc = frappe.get_doc(
 		{
 			"doctype": MACRO,
@@ -287,6 +290,7 @@ def create_macro(
 			"description": description or "",
 			"enabled": int(enabled or 0),
 			"stop_on_error": int(stop_on_error or 0),
+			"skip_confirmation": int(skip_confirmation or 0),
 			"schedule_enabled": int(schedule_enabled or 0),
 			"schedule_frequency": schedule_frequency or "daily",
 			"schedule_time": schedule_time or None,
@@ -307,6 +311,7 @@ def update_macro(
 	steps: str | list | None = None,
 	enabled: int | None = None,
 	stop_on_error: int | None = None,
+	skip_confirmation: int | None = None,
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
 	schedule_time: str | None = None,
@@ -326,6 +331,9 @@ def update_macro(
 		doc.enabled = int(enabled)
 	if stop_on_error is not None:
 		doc.stop_on_error = int(stop_on_error)
+	if skip_confirmation is not None:
+		# The doctype validate() admin-gates a 0 -> 1 transition; a non-admin flip raises.
+		doc.skip_confirmation = int(skip_confirmation)
 	if schedule_enabled is not None:
 		doc.schedule_enabled = int(schedule_enabled)
 	if schedule_frequency is not None:

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -707,6 +707,12 @@ def assemble_prompt(
 	# knows whether to confirm mutating ops. Default (off) = confirm; the persona
 	# confirms by default, so we only signal the non-default "auto" mode.
 	auto_apply = "; auto-apply changes: ON" if conv.auto_apply else ""
+	# Armed macro run: this run's conversation carries skip_confirmation=1 (an admin
+	# armed the macro). Signal the persona to call EVERY write tool directly - incl.
+	# create/update, which it would otherwise route through a jarvis-action card,
+	# leaving armed-skip inert on those two. The bench still enforces the gate; this
+	# only changes which shape the agent emits. Server-set flag, never a client claim.
+	armed_run = "; armed macro run: apply changes directly" if conv.skip_confirmation else ""
 	# Custom-skill invocation: if the user typed /slug for an enabled custom
 	# skill, name it in the system context so the agent activates it
 	# deterministically (the agent has no documented user-invocable trigger).
@@ -818,7 +824,7 @@ def assemble_prompt(
 		# customizations clause is org-level too, so it sits with the org
 		# clauses - before personal, which stays last.
 		f"[Context: today is {today}{locale_clause}{assistant_name_clause}{persona_clause}; chat user: {chat_user}"
-		f"; conv: {conversation_id}{auto_apply}{skill_clause}{learned_clause}"
+		f"; conv: {conversation_id}{auto_apply}{armed_run}{skill_clause}{learned_clause}"
 		f"{wiki_notes_clause}{custom_site_clause}{server_scripts_clause}{personal_clause}{notes_clause}]"
 		f"{ground_block}"
 		f"\n\n{user_message or ''}"

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -24,6 +24,7 @@
     "tool_status",
     "tool_call_id",
     "action_outcome",
+    "armed_by_macro",
     "ref_doctype",
     "ref_name",
     "canvas",
@@ -153,10 +154,19 @@
       "fieldname": "action_outcome",
       "fieldtype": "Select",
       "label": "Action Outcome",
-      "options": "\nconfirmed\ndiscarded\nfailed",
+      "options": "\nconfirmed\ndiscarded\nfailed\nauto_applied",
       "read_only": 1,
       "depends_on": "eval:doc.role=='tool'",
-      "description": "Set on tool rows that originated from a confirmation card: 'confirmed' (user clicked Confirm and the write ran), 'discarded' (user declined - nothing ran), or 'failed' (confirmed but the write errored/rolled back). Non-empty => the SPA renders this row as an inline receipt chip instead of an Activity-accordion tool row. Empty on ordinary (non-carded) tool calls."
+      "description": "Set on tool rows that originated from a confirmation card OR ran under an armed macro: 'confirmed' (user clicked Confirm and the write ran), 'discarded' (user declined - nothing ran), 'failed' (confirmed but the write errored/rolled back), or 'auto_applied' (ran WITHOUT a card under an armed macro's skip_confirmation - see armed_by_macro). Non-empty => the SPA renders this row as an inline receipt chip instead of an Activity-accordion tool row. Empty on ordinary (non-carded) tool calls."
+    },
+    {
+      "fieldname": "armed_by_macro",
+      "fieldtype": "Data",
+      "label": "Armed By Macro",
+      "read_only": 1,
+      "no_copy": 1,
+      "depends_on": "eval:doc.action_outcome=='auto_applied'",
+      "description": "On an armed-skip tool row (action_outcome='auto_applied'), the name of the Jarvis Macro whose skip_confirmation authorized running this write without a confirmation card. Provenance for the audit trail and the receipt label; empty otherwise."
     },
     {
       "fieldname": "ref_doctype",

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -68,6 +68,15 @@
    "description": "Set by the File Box drop path. When 1, reversible create/update tool calls execute directly (no confirmation card) because the run is unattended and review happens on the created Draft + the approval board; destructive ops still park. Server-set only; enabling via a generic save requires System Manager, like auto_apply."
   },
   {
+   "fieldname": "skip_confirmation",
+   "fieldtype": "Check",
+   "label": "Skip confirmation (armed macro run)",
+   "default": "0",
+   "hidden": 1,
+   "no_copy": 1,
+   "description": "Set by an armed macro run (Jarvis Macro.skip_confirmation) on its own disposable run conversation. When 1, every covered gated tool call executes without a confirmation card; the irreversible trio (delete/cancel/amend) still parks. The conversation is human-inert while set - interactive send and retry are blocked. Server-set only; enabling via a generic save requires the Jarvis Admin / System Manager role. Cleared when the run reaches a terminal state."
+  },
+  {
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.py
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.py
@@ -22,6 +22,7 @@ class JarvisConversation(Document):
 	def validate(self):
 		self._guard_auto_apply_enable()
 		self._guard_file_box_enable()
+		self._guard_skip_confirmation_enable()
 
 	def _guard_auto_apply_enable(self):
 		"""Defense-in-depth backstop for the admin-gated ``auto_apply`` flag
@@ -77,5 +78,30 @@ class JarvisConversation(Document):
 		if not has_jarvis_admin_access(frappe.session.user):
 			frappe.throw(
 				_("Enabling File Box mode requires a Jarvis Admin or System Manager role."),
+				frappe.PermissionError,
+			)
+
+	def _guard_skip_confirmation_enable(self):
+		"""``skip_confirmation`` is the flag the write-confirmation gate reads to run
+		a macro's writes uncarded (the BROAD covered set - run_method/send_email/etc.,
+		not just the create/update ``auto_apply`` covers). The one legitimate enabler
+		is an armed macro run (``jarvis.chat.macros.run_macro`` -> raw
+		``frappe.db.set_value``, which bypasses this controller).
+
+		This guards every OTHER path: the field is owner-writable with no
+		permlevel, so a non-admin owner must not flip it 0 -> 1 through a generic
+		``doc.save()`` / ``update_doc`` / ``frappe.client.set_value`` and turn their
+		own chat into an uncarded-write conversation. This is LOAD-BEARING (the gate
+		reads THIS field), not mere defense-in-depth. Only 0/unset -> 1 is gated;
+		disabling and no-op saves stay free for the owner.
+		"""
+		if not self.skip_confirmation:
+			return
+		previous = self.get_doc_before_save()
+		if previous and bool(previous.skip_confirmation):
+			return
+		if not has_jarvis_admin_access(frappe.session.user):
+			frappe.throw(
+				_("Enabling skip-confirmation requires a Jarvis Admin or System Manager role."),
 				frappe.PermissionError,
 			)

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.json
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.json
@@ -9,6 +9,7 @@
  "field_order": [
   "macro_name",
   "enabled",
+  "skip_confirmation",
   "stop_on_error",
   "description",
   "steps",
@@ -38,6 +39,15 @@
    "default": "1",
    "in_list_view": 1,
    "description": "When off, the macro is a draft: hidden from the run menu and skipped by the scheduler."
+  },
+  {
+   "fieldname": "skip_confirmation",
+   "fieldtype": "Check",
+   "label": "Skip confirmation (run writes uncarded)",
+   "default": "0",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "ADMIN ONLY. When on, this macro's runs execute gated writes WITHOUT a confirmation card - including run_method, send_email and run_import. The irreversible trio (delete/cancel/amend) still parks and STOPS the run. Enabling requires the Jarvis Admin / System Manager role. Trust model: arming trusts this macro's OWNER for its current AND future steps - editing steps does not clear it. Re-running a stopped run repeats earlier steps."
   },
   {
    "fieldname": "stop_on_error",

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
@@ -14,6 +14,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from jarvis.permissions import has_jarvis_admin_access
+
 MAX_NAME_LEN = 80
 MAX_DESC_LEN = 500
 MAX_STEPS = 25
@@ -28,7 +30,30 @@ class JarvisMacro(Document):
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
 		self._validate_schedule_time()
+		self._guard_skip_confirmation_enable()
 		self._recompute_next_run()
+
+	def _guard_skip_confirmation_enable(self):
+		"""ARM the macro = run its writes uncarded (the broad covered set, incl.
+		run_method/send_email/run_import; the irreversible trio still parks + stops
+		the run). Only a Jarvis Admin / System Manager may enable it - a plain owner
+		may RUN a macro (``if_owner`` write) but must not self-grant the bypass.
+
+		Only the 0/unset -> 1 transition is gated; disabling and every other edit
+		(including editing steps while it stays on - the arm persists across step
+		edits by design, D6) are free for the owner. Enabling the macro flag is what
+		later drives ``run_macro``'s stamp of the run conversation's own
+		``skip_confirmation`` (guarded there too)."""
+		if not self.skip_confirmation:
+			return
+		previous = self.get_doc_before_save()
+		if previous and bool(previous.skip_confirmation):
+			return
+		if not has_jarvis_admin_access(frappe.session.user):
+			frappe.throw(
+				_("Arming a macro to skip confirmation requires a Jarvis Admin or System Manager role."),
+				frappe.PermissionError,
+			)
 
 	def _validate_name(self):
 		self.macro_name = (self.macro_name or "").strip()

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -89,7 +89,7 @@
   "chat_device_token",
   "agent_tools_section",
   "run_query_doctype_allowlist",
-  "auto_apply_changes",
+  "disable_armed_skip",
   "core_apps_override",
   "enable_customizations_clause",
   "enable_role_profiles",
@@ -668,11 +668,11 @@
    "description": "Defense-in-depth restriction for the run_query agent tool. Comma- or newline-separated list of DocType names. When non-empty, run_query refuses any query referencing a DocType not on this list - even if the calling user has read permission on it through Frappe's normal permission system. Leave empty (default) to allow any DocType the user can read. Use this to lock the agent to a known-good slice of your data (e.g. 'Sales Invoice, Customer, Item, Sales Invoice Item') so a future allowlist bypass in the SQL parser still can't reach the rest of the bench."
   },
   {
-   "fieldname": "auto_apply_changes",
+   "fieldname": "disable_armed_skip",
    "fieldtype": "Check",
-   "label": "Auto-apply changes (skip confirmation)",
+   "label": "Disable armed skip-confirmation (kill switch)",
    "default": "0",
-   "description": "DEPRECATED (issue #186): auto-apply is now per-conversation and admin-gated (Jarvis Conversation.auto_apply). This site-wide Single field is no longer read or written; left in place to avoid a destructive schema change."
+   "description": "Emergency kill switch. When 1, armed macros (Jarvis Macro.skip_confirmation) STOP skipping confirmation cards immediately, site-wide, with no deploy - every covered write re-gates behind its card. The escape hatch if an armed macro ever misbehaves. Default 0."
   },
   {
    "fieldname": "core_apps_override",

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -52,3 +52,4 @@ jarvis.patches.v2_14_reconcile_token_limit_to_alltime
 jarvis.patches.v2_14_backfill_wiki_enabled
 jarvis.patches.v2_15_reset_removed_gemini_subscription
 jarvis.patches.v2_16_retire_support_roles
+jarvis.patches.v2_17_drop_auto_apply_changes

--- a/jarvis/patches/v2_17_drop_auto_apply_changes.py
+++ b/jarvis/patches/v2_17_drop_auto_apply_changes.py
@@ -1,0 +1,19 @@
+"""Drop the retired auto_apply_changes field's leftover row from Jarvis Settings.
+
+auto_apply_changes was a site-wide "skip confirmation" toggle deprecated in
+issue #186 (auto-apply moved to per-conversation Jarvis Conversation.auto_apply)
+and was never read or written since. It is now removed from the Jarvis Settings
+schema. Jarvis Settings is a Single, so any value lived as a row in tabSingles -
+delete it so nothing lingers. Keyed on doctype AND field so sibling Settings
+values are untouched. Idempotent: a DELETE of an absent row is a no-op.
+
+(This is not a rejection of a site-wide skip switch - the field simply never
+worked; the live control is the admin-armed per-macro skip_confirmation.)
+"""
+
+import frappe
+
+
+def execute():
+	frappe.db.delete("Singles", {"doctype": "Jarvis Settings", "field": "auto_apply_changes"})
+	frappe.clear_cache(doctype="Jarvis Settings")

--- a/jarvis/tests/test_auto_apply.py
+++ b/jarvis/tests/test_auto_apply.py
@@ -454,3 +454,15 @@ class TestTurnContextReflectsFlag(FrappeTestCase):
 		frappe.db.commit()
 		msg = self._capture_message_sent()
 		self.assertNotIn("auto-apply changes: ON", msg)
+
+	def test_context_line_shows_armed_run_when_skip_confirmation_set(self):
+		# The armed-macro signal tells the persona to call create/update directly so
+		# the bench's armed-skip gate runs them uncarded (else it is inert on those two).
+		frappe.db.set_value(CONV, self.conv, "skip_confirmation", 1, update_modified=False)
+		frappe.db.commit()
+		msg = self._capture_message_sent()
+		self.assertIn("armed macro run: apply changes directly", msg)
+
+	def test_context_line_no_armed_run_when_flag_clear(self):
+		msg = self._capture_message_sent()  # skip_confirmation defaults 0
+		self.assertNotIn("armed macro run", msg)

--- a/jarvis/tests/test_macro_skip_confirmation.py
+++ b/jarvis/tests/test_macro_skip_confirmation.py
@@ -871,3 +871,57 @@ class TestReviewHardening(FrappeTestCase):
 		with patch("jarvis.api.dispatch", return_value={"ok": True}):
 			api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
 		self.assertEqual(_agent_run_ctx.take_armed_by_macro(), "an armed macro")
+
+
+class TestMacrosApiSkipConfirmation(FrappeTestCase):
+	"""The macros_api create/update/get thread skip_confirmation (so the SPA editor
+	can set + read it), and arming via the API still hits the admin guard."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+		_ensure_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		for owner in (NON_ADMIN_USER, ADMIN_USER):
+			for name in frappe.get_all(MACRO, filters={"owner": owner}, pluck="name"):
+				frappe.delete_doc(MACRO, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_create_macro_armed_by_admin_and_get_carries_it(self):
+		from jarvis.chat.macros_api import create_macro, get_macro
+
+		frappe.set_user(ADMIN_USER)
+		r = create_macro("api-armed", steps=[{"prompt": "do it"}], skip_confirmation=1)
+		name = r["data"]["name"]
+		self.assertEqual(int(frappe.db.get_value(MACRO, name, "skip_confirmation")), 1)
+		self.assertEqual(get_macro(name)["skip_confirmation"], 1)
+
+	def test_create_macro_armed_by_non_admin_rejected(self):
+		from jarvis.chat.macros_api import create_macro
+
+		frappe.set_user(NON_ADMIN_USER)
+		with self.assertRaises(frappe.PermissionError):
+			create_macro("api-armed-bad", steps=[{"prompt": "do it"}], skip_confirmation=1)
+
+	def test_update_macro_arm_rejected_for_non_admin(self):
+		from jarvis.chat.macros_api import create_macro, update_macro
+
+		frappe.set_user(NON_ADMIN_USER)
+		name = create_macro("api-upd", steps=[{"prompt": "do it"}])["data"]["name"]
+		with self.assertRaises(frappe.PermissionError):
+			update_macro(name=name, skip_confirmation=1)
+		self.assertEqual(int(frappe.db.get_value(MACRO, name, "skip_confirmation") or 0), 0)
+
+	def test_update_macro_arm_ok_for_admin(self):
+		from jarvis.chat.macros_api import create_macro, update_macro
+
+		frappe.set_user(ADMIN_USER)
+		name = create_macro("api-upd-admin", steps=[{"prompt": "do it"}])["data"]["name"]
+		update_macro(name=name, skip_confirmation=1)
+		self.assertEqual(int(frappe.db.get_value(MACRO, name, "skip_confirmation")), 1)

--- a/jarvis/tests/test_macro_skip_confirmation.py
+++ b/jarvis/tests/test_macro_skip_confirmation.py
@@ -1,0 +1,873 @@
+"""Tests for admin-armed macro "skip confirmation".
+
+An admin arms a Jarvis Macro (``skip_confirmation``); its runs then execute the
+covered gated writes without a confirmation card. The single source of truth the
+write-confirmation gate reads is ``Jarvis Conversation.skip_confirmation``, stamped
+onto an armed macro's run conversation. This module covers the admin guards on both
+flags (this file), the gate branch, the run stamp + human-inert block, the
+clear-on-terminal, and D5 stop-and-report.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api
+from jarvis.api import _ARMED_SKIP_COVERED, _ARMED_SKIP_NEVER, _GATED_WRITES
+from jarvis.permissions import ensure_jarvis_user_role
+from jarvis.tests.test_auto_apply import (
+	NON_ADMIN_USER,
+	_ensure_non_admin_user,
+	_make_conv,
+)
+from jarvis.tests.test_chat_api import TEST_USER, _ensure_test_user
+
+CONV = "Jarvis Conversation"
+MACRO = "Jarvis Macro"
+
+# A Jarvis Admin who is NOT a System Manager - proves the guard admits the
+# Jarvis Admin tier specifically, not only System Manager (edge-case review).
+ADMIN_USER = "jarvis-skip-admin@example.com"
+
+
+def _ensure_admin_user() -> None:
+	"""A Jarvis Admin (+ Jarvis User so it can own/write a macro), NOT System Manager."""
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", ADMIN_USER):
+		doc = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": ADMIN_USER,
+				"first_name": "Skip",
+				"last_name": "Admin",
+				"enabled": 1,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		)
+		doc.insert(ignore_permissions=True)
+	user = frappe.get_doc("User", ADMIN_USER)
+	roles = set(frappe.get_roles(ADMIN_USER))
+	if "System Manager" in roles:
+		user.remove_roles("System Manager")
+	for role in ("Jarvis Admin", "Jarvis User"):
+		if role not in roles:
+			user.add_roles(role)  # add_roles auto-vivifies a missing Role row
+	frappe.db.commit()
+
+
+def _make_macro(owner: str, *, armed: bool = False, name: str = "skip-conf test macro") -> str:
+	"""Create a Jarvis Macro owned by ``owner`` with one step; return its name.
+	``armed`` stamps skip_confirmation via a raw db write (bypassing the guard),
+	simulating an already-armed macro."""
+	orig = frappe.session.user
+	frappe.set_user(owner)
+	try:
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": name,
+				"steps": [{"prompt": "do the thing"}],
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		frappe.db.commit()
+		if armed:
+			frappe.db.set_value(MACRO, doc.name, "skip_confirmation", 1, update_modified=False)
+			frappe.db.commit()
+		return doc.name
+	finally:
+		frappe.set_user(orig)
+
+
+class TestConversationSkipConfirmationGuard(FrappeTestCase):
+	"""The LOAD-BEARING guard: the gate reads Jarvis Conversation.skip_confirmation,
+	which is owner-writable with no permlevel. A non-admin owner must not flip it
+	0 -> 1 through a generic save; only a Jarvis Admin / System Manager may."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_test_user()
+		_ensure_non_admin_user()
+		_ensure_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		# _make_conv commits, so FrappeTestCase's class-rollback won't undo it.
+		for owner in (NON_ADMIN_USER, ADMIN_USER):
+			for name in frappe.get_all(CONV, filters={"owner": owner}, pluck="name"):
+				frappe.delete_doc(CONV, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_non_admin_owner_save_cannot_enable(self):
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.set_user(NON_ADMIN_USER)
+		doc = frappe.get_doc(CONV, conv)
+		doc.skip_confirmation = 1
+		with self.assertRaises(frappe.PermissionError):
+			doc.save()
+		self.assertEqual(int(frappe.db.get_value(CONV, conv, "skip_confirmation") or 0), 0)
+
+	def test_jarvis_admin_save_can_enable(self):
+		conv = _make_conv(ADMIN_USER)
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc(CONV, conv)
+		doc.skip_confirmation = 1
+		doc.save()
+		self.assertEqual(int(frappe.db.get_value(CONV, conv, "skip_confirmation")), 1)
+
+	def test_non_admin_owner_save_can_disable(self):
+		conv = _make_conv(NON_ADMIN_USER)
+		# Server stamped it on (the run_macro raw path), then the owner disarms.
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		frappe.set_user(NON_ADMIN_USER)
+		doc = frappe.get_doc(CONV, conv)
+		doc.skip_confirmation = 0
+		doc.save()
+		self.assertEqual(int(frappe.db.get_value(CONV, conv, "skip_confirmation") or 0), 0)
+
+	def test_raw_stamp_bypasses_the_guard(self):
+		"""The sanctioned run_macro path (raw db.set_value) sets the flag on a
+		non-admin owner's conversation without tripping the controller guard."""
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		self.assertEqual(int(frappe.db.get_value(CONV, conv, "skip_confirmation")), 1)
+
+
+class TestMacroSkipConfirmationGuard(FrappeTestCase):
+	"""Arming a macro (Jarvis Macro.skip_confirmation 0 -> 1) requires admin;
+	editing steps while armed keeps it armed (D6 trust model)."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+		_ensure_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		for owner in (NON_ADMIN_USER, ADMIN_USER):
+			for name in frappe.get_all(MACRO, filters={"owner": owner}, pluck="name"):
+				frappe.delete_doc(MACRO, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_non_admin_owner_cannot_arm(self):
+		macro = _make_macro(NON_ADMIN_USER)
+		frappe.set_user(NON_ADMIN_USER)
+		doc = frappe.get_doc(MACRO, macro)
+		doc.skip_confirmation = 1
+		with self.assertRaises(frappe.PermissionError):
+			doc.save()
+		self.assertEqual(int(frappe.db.get_value(MACRO, macro, "skip_confirmation") or 0), 0)
+
+	def test_jarvis_admin_can_arm_own_macro(self):
+		macro = _make_macro(ADMIN_USER)
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc(MACRO, macro)
+		doc.skip_confirmation = 1
+		doc.save()
+		self.assertEqual(int(frappe.db.get_value(MACRO, macro, "skip_confirmation")), 1)
+
+	def test_editing_steps_keeps_arm_for_non_admin_owner(self):
+		"""D6 trust model: an admin armed the macro; its NON-admin owner can later
+		edit the steps (a no-op 1 -> 1 transition on skip_confirmation) without admin
+		rights and without disarming - arming trusts the owner for future steps too."""
+		macro = _make_macro(NON_ADMIN_USER, armed=True)
+		frappe.set_user(NON_ADMIN_USER)
+		doc = frappe.get_doc(MACRO, macro)
+		doc.steps[0].prompt = "do a different thing"
+		doc.save()  # must not raise; arm persists
+		self.assertEqual(int(frappe.db.get_value(MACRO, macro, "skip_confirmation")), 1)
+
+	def test_owner_can_disarm(self):
+		macro = _make_macro(ADMIN_USER, armed=True)
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc(MACRO, macro)
+		doc.skip_confirmation = 0
+		doc.save()
+		self.assertEqual(int(frappe.db.get_value(MACRO, macro, "skip_confirmation") or 0), 0)
+
+
+class TestArmedSkipPartition(FrappeTestCase):
+	"""Fail-closed allowlist: COVERED and NEVER partition _GATED_WRITES exactly.
+	A new gated tool added to neither set makes this RED, forcing a conscious
+	skip-vs-park classification instead of a silent fail-open default."""
+
+	def test_covered_and_never_partition_gated_writes(self):
+		self.assertEqual(_ARMED_SKIP_COVERED & _ARMED_SKIP_NEVER, frozenset(), "sets must be disjoint")
+		self.assertEqual(
+			_ARMED_SKIP_COVERED | _ARMED_SKIP_NEVER,
+			_GATED_WRITES,
+			"every gated write must be classified as covered (skips when armed) or "
+			"never (always parks) - a tool in neither is an unclassified fail-open gap",
+		)
+
+	def test_irreversible_trio_never_skips(self):
+		self.assertEqual(_ARMED_SKIP_NEVER, frozenset({"cancel_doc", "delete_doc", "amend_doc"}))
+
+	def test_run_method_is_covered(self):
+		# run_method gates in ordinary chat but skips inside an armed macro (D5).
+		self.assertIn("run_method", _ARMED_SKIP_COVERED)
+
+
+class TestArmedSkipGate(FrappeTestCase):
+	"""The gate: an armed conversation (skip_confirmation=1) runs the covered set
+	uncarded; the irreversible trio still parks; the kill switch re-gates."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_test_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+		frappe.set_user(TEST_USER)
+
+	def tearDown(self):
+		frappe.db.set_value("Jarvis Settings", None, "disable_armed_skip", 0, update_modified=False)
+		frappe.set_user(self._orig)
+		for dt in (CONV, "ToDo"):
+			for name in frappe.get_all(dt, filters={"owner": TEST_USER}, pluck="name"):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _armed_conv(self) -> str:
+		conv = _make_conv(TEST_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		return conv
+
+	def test_run_method_runs_when_armed(self):
+		conv = self._armed_conv()
+		with patch("jarvis.api.dispatch", return_value={"ok": True}) as disp:
+			r = api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
+		self.assertTrue(disp.called, "armed run_method must reach dispatch, not park")
+		self.assertNotEqual(r["data"].get("status"), "pending_confirmation")
+
+	def test_run_method_parks_when_not_armed(self):
+		conv = _make_conv(TEST_USER)  # skip_confirmation defaults 0
+		with patch("jarvis.api.dispatch") as disp:
+			r = api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertFalse(disp.called)
+
+	def test_send_email_runs_when_armed(self):
+		conv = self._armed_conv()
+		with patch("jarvis.api.dispatch", return_value={"ok": True}) as disp:
+			r = api._run_tool(
+				"send_email",
+				{"recipients": "x@example.com", "subject": "s", "content": "b"},
+				conversation=conv,
+			)
+		self.assertTrue(disp.called)
+		self.assertNotEqual(r["data"].get("status"), "pending_confirmation")
+
+	def test_delete_doc_still_parks_when_armed(self):
+		conv = self._armed_conv()
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "skip-del-x"}).insert(
+			ignore_permissions=True
+		)
+		frappe.db.commit()
+		r = api._run_tool("delete_doc", {"doctype": "ToDo", "name": todo.name}, conversation=conv)
+		self.assertEqual(r["data"]["status"], "pending_confirmation", "delete always parks")
+		self.assertTrue(frappe.db.exists("ToDo", todo.name))
+
+	def test_kill_switch_regates(self):
+		conv = self._armed_conv()
+		frappe.db.set_value("Jarvis Settings", None, "disable_armed_skip", 1, update_modified=False)
+		with patch("jarvis.api.dispatch") as disp:
+			r = api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
+		self.assertEqual(r["data"]["status"], "pending_confirmation", "kill switch must re-gate")
+		self.assertFalse(disp.called)
+
+	def test_bulk_covered_runs_when_armed(self):
+		conv = self._armed_conv()
+		with patch("jarvis.api.dispatch", return_value={"ok": True}) as disp:
+			r = api._run_tool(
+				"create_docs",
+				{"docs": [{"doctype": "ToDo", "values": {"description": "b1"}}]},
+				conversation=conv,
+			)
+		self.assertTrue(disp.called, "a bulk covered write skips the batch card when armed")
+		self.assertNotEqual(r["data"].get("status"), "pending_confirmation")
+
+	def test_bulk_over_cap_still_bounces_when_armed(self):
+		from jarvis.tools._bulk import _MAX_BATCH
+
+		conv = self._armed_conv()
+		docs = [{"doctype": "ToDo", "values": {"description": f"b{i}"}} for i in range(_MAX_BATCH + 1)]
+		with patch("jarvis.api.dispatch") as disp:
+			r = api._run_tool("create_docs", {"docs": docs}, conversation=conv)
+		self.assertFalse(r["ok"], "an over-size batch must bounce, even when armed")
+		self.assertEqual(r["error"]["code"], "InvalidArgumentError")
+		self.assertFalse(disp.called, "the F16 cap bounces before dispatch, armed or not")
+
+
+class TestRunMacroStampAndInert(FrappeTestCase):
+	"""run_macro stamps the run conversation when the macro is armed; the armed
+	conversation is human-inert (send_message / retry_message refuse it), keyed on
+	the flag itself so deleting the Macro Run row cannot re-open it."""
+
+	MSG = "Jarvis Chat Message"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		for dt in ("Jarvis Macro Run", MACRO, CONV):
+			for name in frappe.get_all(dt, filters={"owner": NON_ADMIN_USER}, pluck="name"):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _run(self, macro_name: str) -> str:
+		from jarvis.chat import macros
+
+		frappe.set_user(NON_ADMIN_USER)
+		with (
+			patch.object(macros, "_run_step"),
+			patch.object(macros, "_run_merged"),
+			patch.object(macros, "entitlement_block", return_value=None),
+		):
+			res = macros.run_macro(macro_name)
+		return res["data"]["conversation"]
+
+	def test_run_macro_stamps_armed_conversation(self):
+		macro = _make_macro(NON_ADMIN_USER, armed=True, name="armed-run")
+		conv = self._run(macro)
+		# A non-admin owner ran their own admin-armed macro: the raw stamp set the
+		# flag without tripping the conversation controller guard.
+		self.assertEqual(int(frappe.db.get_value(CONV, conv, "skip_confirmation")), 1)
+
+	def test_run_macro_unarmed_does_not_stamp(self):
+		macro = _make_macro(NON_ADMIN_USER, armed=False, name="plain-run")
+		conv = self._run(macro)
+		self.assertEqual(int(frappe.db.get_value(CONV, conv, "skip_confirmation") or 0), 0)
+
+	def test_send_message_rejected_on_armed_conversation(self):
+		from jarvis.chat import api as chat_api
+
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		frappe.set_user(NON_ADMIN_USER)
+		with patch.object(chat_api, "validate_can_send", return_value=(True, None)):
+			with self.assertRaises(frappe.ValidationError):
+				chat_api.send_message(conversation=conv, message="let me in")
+
+	def test_send_message_allowed_after_disarm(self):
+		"""Disarming (flag -> 0) re-opens the conversation to interactive sends."""
+		from jarvis.chat import api as chat_api
+
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 0, update_modified=False)
+		frappe.set_user(NON_ADMIN_USER)
+		# The reject helper must NOT fire on an unarmed conversation.
+		doc = chat_api._get_owned_conversation(conv)
+		chat_api._reject_send_into_armed_conversation(doc)  # no raise
+
+	def test_armed_conversation_with_no_run_row_still_rejects(self):
+		"""The block keys on the conversation flag, NOT on a Jarvis Macro Run row, so
+		deleting the run (owner has delete rights) cannot re-open an armed conv."""
+		from jarvis.chat import api as chat_api
+
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		self.assertFalse(frappe.db.exists("Jarvis Macro Run", {"conversation": conv}))
+		frappe.set_user(NON_ADMIN_USER)
+		doc = chat_api._get_owned_conversation(conv)
+		with self.assertRaises(frappe.ValidationError):
+			chat_api._reject_send_into_armed_conversation(doc)
+
+	def test_retry_message_rejected_on_armed_conversation(self):
+		from jarvis.chat import api as chat_api
+
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		msg = frappe.get_doc(
+			{
+				"doctype": self.MSG,
+				"conversation": conv,
+				"seq": 2,
+				"role": "assistant",
+				"content": "boom",
+				"error": "some error",
+			}
+		)
+		msg.flags.ignore_permissions = True
+		msg.insert()
+		frappe.db.commit()
+		frappe.set_user(NON_ADMIN_USER)
+		with patch.object(chat_api, "validate_can_send", return_value=(True, None)):
+			with self.assertRaises(frappe.ValidationError):
+				chat_api.retry_message(msg.name)
+
+
+class TestClearOnTerminal(FrappeTestCase):
+	"""The armed flag is cleared on EVERY run-terminal transition (T5): _finish,
+	stop_macro_run, and any _cas terminal (reap / resume-compensate); a non-terminal
+	_cas transition leaves it armed."""
+
+	RUN = "Jarvis Macro Run"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		for dt in ("Jarvis Macro Run", MACRO, CONV):
+			for name in frappe.get_all(dt, filters={"owner": NON_ADMIN_USER}, pluck="name"):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _make_run(self, *, armed: bool = True, status: str = "running", name: str = "term-macro"):
+		macro = _make_macro(NON_ADMIN_USER, name=name)
+		frappe.set_user(NON_ADMIN_USER)
+		conv = frappe.get_doc({"doctype": CONV, "title": "run conv"})
+		conv.flags.ignore_permissions = True
+		conv.insert()
+		if armed:
+			frappe.db.set_value(CONV, conv.name, "skip_confirmation", 1, update_modified=False)
+		run = frappe.get_doc(
+			{
+				"doctype": self.RUN,
+				"macro": macro,
+				"conversation": conv.name,
+				"status": status,
+				"current_step": 0,
+				"total_steps": 1,
+				"trigger": "manual",
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		frappe.db.commit()
+		return run.name, conv.name
+
+	def _armed(self, conv) -> int:
+		return int(frappe.db.get_value(CONV, conv, "skip_confirmation") or 0)
+
+	def test_finish_clears_flag(self):
+		from jarvis.chat import macros
+
+		run_name, conv = self._make_run(name="fin-macro")
+		macros._finish(frappe.get_doc(self.RUN, run_name), "completed")
+		self.assertEqual(self._armed(conv), 0)
+
+	def test_stop_macro_run_clears_flag(self):
+		from jarvis.chat import macros
+
+		run_name, conv = self._make_run(name="stop-macro")
+		frappe.set_user(NON_ADMIN_USER)
+		macros.stop_macro_run(run_name)
+		self.assertEqual(self._armed(conv), 0)
+
+	def test_cas_terminal_clears_flag(self):
+		from jarvis.chat import macros
+
+		run_name, conv = self._make_run(name="cas-macro")
+		self.assertTrue(macros._cas_run_status(run_name, "running", "failed"))
+		frappe.db.commit()
+		self.assertEqual(self._armed(conv), 0)
+
+	def test_cas_nonterminal_keeps_flag(self):
+		from jarvis.chat import macros
+
+		run_name, conv = self._make_run(name="cas2-macro")
+		self.assertTrue(macros._cas_run_status(run_name, "running", "waiting_capacity"))
+		frappe.db.commit()
+		self.assertEqual(self._armed(conv), 1, "a non-terminal transition must not disarm")
+
+
+class TestD5StopAndReport(FrappeTestCase):
+	"""An armed macro whose step parks a card (an excluded delete/cancel/amend) must
+	STOP the run and report - not advance with a false 'completed' - and sweep the
+	token so the card can't be confirmed later. Armed-only; merged mode covered."""
+
+	RUN = "Jarvis Macro Run"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		from jarvis.chat import pending_confirm
+
+		for conv in frappe.get_all(CONV, filters={"owner": NON_ADMIN_USER}, pluck="name"):
+			try:
+				pending_confirm.clear_for_conversation(NON_ADMIN_USER, conv)
+			except Exception:
+				pass
+		for dt in ("Jarvis Macro Run", MACRO, CONV, "ToDo"):
+			for name in frappe.get_all(dt, filters={"owner": NON_ADMIN_USER}, pluck="name"):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _run_and_conv(self, *, armed: bool, current_step: int = 0, total: int = 1, name="d5-macro"):
+		macro = _make_macro(NON_ADMIN_USER, name=name)
+		frappe.set_user(NON_ADMIN_USER)
+		conv = frappe.get_doc({"doctype": CONV, "title": "d5 run"})
+		conv.flags.ignore_permissions = True
+		conv.insert()
+		if armed:
+			frappe.db.set_value(CONV, conv.name, "skip_confirmation", 1, update_modified=False)
+		run = frappe.get_doc(
+			{
+				"doctype": self.RUN,
+				"macro": macro,
+				"conversation": conv.name,
+				"status": "running",
+				"current_step": current_step,
+				"total_steps": total,
+				"trigger": "manual",
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		frappe.db.commit()
+		return run.name, conv.name
+
+	def _park_delete_card(self, conv: str) -> None:
+		"""Park a real confirmation card on the conversation: delete_doc is excluded,
+		so it parks even on an armed conversation (mints a live pending token)."""
+		frappe.set_user(NON_ADMIN_USER)
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "d5-doomed"}).insert(ignore_permissions=True)
+		frappe.db.commit()
+		r = api._run_tool("delete_doc", {"doctype": "ToDo", "name": todo.name}, conversation=conv)
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+
+	def _pending_count(self, conv: str) -> int:
+		from jarvis.chat import pending_confirm
+
+		return sum(
+			1
+			for rec in pending_confirm.list_for_owner(NON_ADMIN_USER, conversation=conv)
+			if rec.get("conversation") == conv
+		)
+
+	def test_armed_run_stops_and_sweeps_when_step_parks(self):
+		from jarvis.chat import macros
+
+		run_name, conv = self._run_and_conv(armed=True)
+		self._park_delete_card(conv)
+		self.assertEqual(self._pending_count(conv), 1)
+
+		macros.advance_after_turn(conv, errored=False)
+
+		self.assertEqual(frappe.db.get_value(self.RUN, run_name, "status"), "failed")
+		err = frappe.db.get_value(self.RUN, run_name, "error") or ""
+		self.assertIn("unattended run", err)
+		# Step number is 1-based and not overshot (current_step floored at 1 here).
+		self.assertIn("Stopped at step 1", err)
+		self.assertEqual(self._pending_count(conv), 0, "the parked token must be swept")
+
+	def test_armed_merged_run_stops_when_it_would_otherwise_finish(self):
+		"""Merged mode: current_step already at total, so without D5 it would report
+		completed. The detector runs before that decision, so it still stops."""
+		from jarvis.chat import macros
+
+		run_name, conv = self._run_and_conv(armed=True, current_step=1, total=1, name="d5-merged")
+		self._park_delete_card(conv)
+		macros.advance_after_turn(conv, errored=False)
+		self.assertEqual(frappe.db.get_value(self.RUN, run_name, "status"), "failed")
+
+	def test_armed_run_advances_when_no_card(self):
+		from jarvis.chat import macros
+
+		# current_step==total so a clean advance finishes 'completed' (no dispatch).
+		run_name, conv = self._run_and_conv(armed=True, current_step=1, total=1, name="d5-clean")
+		macros.advance_after_turn(conv, errored=False)
+		self.assertEqual(
+			frappe.db.get_value(self.RUN, run_name, "status"), "completed", "no card -> normal advance"
+		)
+
+	def test_non_armed_run_not_stopped_by_d5(self):
+		"""D5 is armed-only: a non-armed run with a parked card is NOT stopped here
+		(the pre-existing behaviour is out of scope) and the card is not swept."""
+		from jarvis.chat import macros
+
+		run_name, conv = self._run_and_conv(armed=False, current_step=1, total=1, name="d5-plain")
+		self._park_delete_card(conv)
+		macros.advance_after_turn(conv, errored=False)
+		self.assertEqual(frappe.db.get_value(self.RUN, run_name, "status"), "completed")
+		self.assertEqual(self._pending_count(conv), 1, "non-armed run must not sweep the card")
+
+
+class TestArmedRunImportAnnouncement(FrappeTestCase):
+	"""An armed run_import bypasses the confirm path, so it must bind its completion
+	announcement itself (T7) - otherwise an unattended import never reports done."""
+
+	ANNOUNCE = "Jarvis Import Announcement"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_test_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+		frappe.set_user(TEST_USER)
+
+	def tearDown(self):
+		frappe.set_user(self._orig)
+		for di in ("DI-ARMED-TEST-1", "DI-UNARMED-TEST-1"):
+			for name in frappe.get_all(self.ANNOUNCE, filters={"data_import": di}, pluck="name"):
+				frappe.delete_doc(self.ANNOUNCE, name, force=True, ignore_permissions=True)
+		for name in frappe.get_all(CONV, filters={"owner": TEST_USER}, pluck="name"):
+			frappe.delete_doc(CONV, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _armed_conv(self) -> str:
+		conv = _make_conv(TEST_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		return conv
+
+	def test_armed_run_import_binds_announcement(self):
+		"""The armed branch must call bind_after_run_import with a synthesized
+		{tool, conversation, owner} record + the wrapped result. (bind's own row
+		creation is existing, separately-tested code that link-validates data_import.)"""
+		conv = self._armed_conv()
+		with (
+			patch("jarvis.api.dispatch", return_value={"data_import": "DI-ARMED-TEST-1"}),
+			patch("jarvis.chat.import_announce.bind_after_run_import") as bind,
+		):
+			r = api._run_tool("run_import", {"filename": "x.csv"}, conversation=conv)
+		self.assertNotEqual(r["data"].get("status"), "pending_confirmation")
+		self.assertTrue(bind.called, "an armed run_import must bind its completion announcement")
+		record, result = bind.call_args[0]
+		self.assertEqual(record["tool"], "run_import")
+		self.assertEqual(record["conversation"], conv)
+		self.assertEqual(record["owner"], TEST_USER)  # the conversation owner
+		self.assertEqual(result["data"]["data_import"], "DI-ARMED-TEST-1")
+
+	def test_armed_non_import_tool_binds_no_announcement(self):
+		# The bind is run_import-specific: another armed covered tool (run_method) runs
+		# uncarded but must NOT create an import announcement.
+		conv = self._armed_conv()
+		before = frappe.db.count(self.ANNOUNCE)
+		with patch("jarvis.api.dispatch", return_value={"ok": True}):
+			api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
+		self.assertEqual(frappe.db.count(self.ANNOUNCE), before)
+
+
+class TestArmedReceiptProvenance(FrappeTestCase):
+	"""An armed write is a VISIBLE, queryable receipt (T8): the row is labelled
+	action_outcome=auto_applied with the arming macro as armed_by_macro."""
+
+	MSG = "Jarvis Chat Message"
+	RUN = "Jarvis Macro Run"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_test_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+		frappe.set_user(TEST_USER)
+
+	def tearDown(self):
+		from jarvis.tools import _agent_run_ctx
+
+		_agent_run_ctx.take_armed_by_macro()  # never leak a marker between tests
+		frappe.set_user(self._orig)
+		for dt in (self.RUN, MACRO, self.MSG, CONV):
+			for name in frappe.get_all(dt, filters={"owner": TEST_USER}, pluck="name"):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_armed_branch_sets_macro_provenance(self):
+		from jarvis.tools import _agent_run_ctx
+
+		macro = _make_macro(TEST_USER, name="prov-macro")
+		conv = _make_conv(TEST_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		run = frappe.get_doc(
+			{
+				"doctype": self.RUN,
+				"macro": macro,
+				"conversation": conv,
+				"status": "running",
+				"current_step": 0,
+				"total_steps": 1,
+				"trigger": "manual",
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		frappe.db.commit()
+
+		with patch("jarvis.api.dispatch", return_value={"ok": True}):
+			api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
+		# The armed branch stashed the arming macro; consume it and confirm.
+		# The marker is the human macro_NAME (Jarvis Macro autoname is a hash), not the
+		# opaque run.macro docname.
+		self.assertNotEqual("prov-macro", macro)  # sanity: name != hash docname
+		self.assertEqual(_agent_run_ctx.take_armed_by_macro(), "prov-macro")
+
+	def test_persist_labels_armed_receipt(self):
+		from jarvis.tools import _agent_run_ctx
+
+		conv = _make_conv(TEST_USER)
+		sk = "sk-armed-receipt-test"
+		frappe.db.set_value(CONV, conv, "session_key", sk, update_modified=False)
+		_agent_run_ctx.set_armed_by_macro("MACRO-PROV-X")
+		api._persist_and_publish_tool_call(
+			session_key=sk,
+			tool="submit_doc",
+			args={"doctype": "ToDo", "name": "x"},
+			result={"ok": True, "data": {}},
+			tool_call_id="tc-armed-1",
+		)
+		row = frappe.get_all(
+			self.MSG,
+			filters={"conversation": conv, "role": "tool", "tool_call_id": "tc-armed-1"},
+			fields=["action_outcome", "armed_by_macro"],
+		)
+		self.assertEqual(len(row), 1)
+		self.assertEqual(row[0].action_outcome, "auto_applied")
+		self.assertEqual(row[0].armed_by_macro, "MACRO-PROV-X")
+		# Consumed: a later ordinary receipt must NOT inherit the label.
+		self.assertIsNone(_agent_run_ctx.take_armed_by_macro())
+
+	def test_ordinary_receipt_not_labelled(self):
+		conv = _make_conv(TEST_USER)
+		sk = "sk-plain-receipt-test"
+		frappe.db.set_value(CONV, conv, "session_key", sk, update_modified=False)
+		# No marker set -> an ordinary inline tool call stays unlabelled.
+		api._persist_and_publish_tool_call(
+			session_key=sk,
+			tool="get_doc",
+			args={},
+			result={"ok": True, "data": {}},
+			tool_call_id="tc-plain-1",
+		)
+		row = frappe.get_all(
+			self.MSG,
+			filters={"conversation": conv, "tool_call_id": "tc-plain-1"},
+			fields=["action_outcome", "armed_by_macro"],
+		)
+		self.assertEqual(len(row), 1)
+		self.assertFalse(row[0].action_outcome)
+		self.assertFalse(row[0].armed_by_macro)
+
+	def test_failed_armed_write_still_labelled_failed_with_provenance(self):
+		"""A FAILED armed write must stay visible: labelled 'failed' (a red chip) with
+		the macro provenance, not collapsed into a silent Activity row."""
+		from jarvis.tools import _agent_run_ctx
+
+		conv = _make_conv(TEST_USER)
+		sk = "sk-armed-fail-test"
+		frappe.db.set_value(CONV, conv, "session_key", sk, update_modified=False)
+		_agent_run_ctx.set_armed_by_macro("MACRO-FAIL-X")
+		api._persist_and_publish_tool_call(
+			session_key=sk,
+			tool="submit_doc",
+			args={"doctype": "ToDo", "name": "x"},
+			result={"ok": False, "error": {"message": "boom"}},
+			tool_call_id="tc-armed-fail-1",
+		)
+		row = frappe.get_all(
+			self.MSG,
+			filters={"conversation": conv, "tool_call_id": "tc-armed-fail-1"},
+			fields=["action_outcome", "armed_by_macro"],
+		)
+		self.assertEqual(len(row), 1)
+		self.assertEqual(row[0].action_outcome, "failed")
+		self.assertEqual(row[0].armed_by_macro, "MACRO-FAIL-X")
+
+
+class TestReviewHardening(FrappeTestCase):
+	"""Security-review follow-ups: a racing Confirm on an armed conversation is
+	refused (the D5 card waits for the sweep), and an armed write is always labelled
+	even if the run-row lookup misses."""
+
+	RUN = "Jarvis Macro Run"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_non_admin_user()
+
+	def setUp(self):
+		self._orig = frappe.session.user
+
+	def tearDown(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.tools import _agent_run_ctx
+
+		_agent_run_ctx.take_armed_by_macro()
+		frappe.set_user(self._orig)
+		for conv in frappe.get_all(CONV, filters={"owner": NON_ADMIN_USER}, pluck="name"):
+			try:
+				pending_confirm.clear_for_conversation(NON_ADMIN_USER, conv)
+			except Exception:
+				pass
+		for dt in (self.RUN, MACRO, CONV, "ToDo"):
+			for name in frappe.get_all(dt, filters={"owner": NON_ADMIN_USER}, pluck="name"):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_confirm_refused_on_armed_conversation(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import _confirm_core
+
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		frappe.set_user(NON_ADMIN_USER)
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "confirm-race"}).insert(
+			ignore_permissions=True
+		)
+		frappe.db.commit()
+		r = api._run_tool("delete_doc", {"doctype": "ToDo", "name": todo.name}, conversation=conv)
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		recs = [
+			t
+			for t in pending_confirm.list_for_owner(NON_ADMIN_USER, conversation=conv)
+			if t.get("conversation") == conv
+		]
+		self.assertEqual(len(recs), 1)
+		token = recs[0]["token"]
+
+		res = _confirm_core(token, conv)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["type"], "InvalidConfirmation")
+		self.assertTrue(frappe.db.exists("ToDo", todo.name), "the delete must not have run")
+		still = [
+			t
+			for t in pending_confirm.list_for_owner(NON_ADMIN_USER, conversation=conv)
+			if t.get("conversation") == conv
+		]
+		self.assertEqual(len(still), 1, "the token survives (uncomsumed) for the D5 sweep")
+
+	def test_armed_write_labelled_even_without_running_run(self):
+		from jarvis.tools import _agent_run_ctx
+
+		conv = _make_conv(NON_ADMIN_USER)
+		frappe.db.set_value(CONV, conv, "skip_confirmation", 1, update_modified=False)
+		# No Jarvis Macro Run bound: the run-row lookup returns None (abnormal state).
+		frappe.set_user(NON_ADMIN_USER)
+		with patch("jarvis.api.dispatch", return_value={"ok": True}):
+			api._run_tool("run_method", {"method": "frappe.ping"}, conversation=conv)
+		self.assertEqual(_agent_run_ctx.take_armed_by_macro(), "an armed macro")

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -155,11 +155,25 @@ class TestJarvisSettings(FrappeTestCase):
 			self.assertEqual(self._tab_of(meta, fieldname), "account_tab")
 		for fieldname in (
 			"run_query_doctype_allowlist",
-			"auto_apply_changes",
+			"disable_armed_skip",
 			"core_apps_override",
 			"enable_customizations_clause",
 		):
 			self.assertEqual(self._tab_of(meta, fieldname), "agent_tab")
+
+	def test_dead_auto_apply_changes_field_removed(self):
+		"""The deprecated site-wide auto_apply_changes toggle (issue #186) is gone;
+		the live skip control is the admin-armed per-macro skip_confirmation."""
+		meta = frappe.get_meta("Jarvis Settings")
+		fieldnames = {f.fieldname for f in meta.fields}
+		self.assertNotIn("auto_apply_changes", fieldnames)
+
+	def test_disable_armed_skip_killswitch_present(self):
+		"""The armed-skip kill switch replaced the dead field in the same slot."""
+		meta = frappe.get_meta("Jarvis Settings")
+		field = next((f for f in meta.fields if f.fieldname == "disable_armed_skip"), None)
+		self.assertIsNotNone(field, "disable_armed_skip kill-switch field must exist")
+		self.assertEqual(field.fieldtype, "Check")
 
 	def test_operator_fields_are_readonly(self):
 		"""All 5 operator fields are system-populated and must be read-only."""
@@ -310,3 +324,49 @@ class TestOnUpdateAdminDispatch(_SettingsSnapshotTestCase):
 # TestOnUpdateLocalDispatchWhenAdminUrlEmpty removed: post-unification (2026-05-29)
 # on_update always routes through _sync_via_admin. The bench-local push path
 # is gone; the test exercising it is no longer meaningful.
+
+
+class TestDropAutoApplyChangesPatch(FrappeTestCase):
+	"""v2_17: the leftover tabSingles row for the removed auto_apply_changes field
+	is deleted, keyed on doctype+field so sibling Settings values survive, and the
+	patch is idempotent."""
+
+	_FIELD = "auto_apply_changes"
+	_SIBLING = "run_query_doctype_allowlist"
+
+	def _row_count(self, field):
+		return frappe.db.count("Singles", {"doctype": "Jarvis Settings", "field": field})
+
+	def setUp(self):
+		# Snapshot the real sibling (a live run_query defense-in-depth allowlist) we
+		# borrow to prove the patch leaves it untouched, and restore it in tearDown -
+		# so this test can never corrupt it even if a future edit adds a commit.
+		self._sibling_snapshot = frappe.db.get_single_value("Jarvis Settings", self._SIBLING)
+
+	def tearDown(self):
+		frappe.db.set_value(
+			"Jarvis Settings", None, self._SIBLING, self._sibling_snapshot, update_modified=False
+		)
+
+	def test_patch_drops_only_the_dead_row_and_is_idempotent(self):
+		from jarvis.patches.v2_17_drop_auto_apply_changes import execute
+
+		# Seed a leftover row for the removed field (simulating a pre-migration site)
+		# and make sure a sibling row exists so we can prove it is untouched.
+		frappe.db.delete("Singles", {"doctype": "Jarvis Settings", "field": self._FIELD})
+		frappe.db.set_value("Jarvis Settings", None, self._SIBLING, "Note", update_modified=False)
+		frappe.db.sql(
+			"INSERT INTO tabSingles (doctype, field, value) VALUES (%s, %s, %s)",
+			("Jarvis Settings", self._FIELD, "0"),
+		)
+		self.assertEqual(self._row_count(self._FIELD), 1)
+		self.assertGreaterEqual(self._row_count(self._SIBLING), 1)
+
+		execute()
+
+		self.assertEqual(self._row_count(self._FIELD), 0, "dead row must be deleted")
+		self.assertGreaterEqual(self._row_count(self._SIBLING), 1, "sibling Settings value must survive")
+
+		# Idempotent: a second run on the now-absent row is a clean no-op.
+		execute()
+		self.assertEqual(self._row_count(self._FIELD), 0)

--- a/jarvis/tools/_agent_run_ctx.py
+++ b/jarvis/tools/_agent_run_ctx.py
@@ -38,3 +38,26 @@ def clear_session_key() -> None:
 			delattr(frappe.local, _ATTR)
 		except Exception:
 			setattr(frappe.local, _ATTR, None)
+
+
+_ARMED_ATTR = "jarvis_armed_by_macro"
+
+
+def set_armed_by_macro(macro: str | None) -> None:
+	"""Record that the write just dispatched ran uncarded under an armed macro's
+	skip_confirmation (the gate's armed branch sets this). Read once by the receipt
+	persist so the row is labelled ``auto_applied`` with this macro as provenance."""
+	setattr(frappe.local, _ARMED_ATTR, (macro or "") or None)
+
+
+def take_armed_by_macro() -> str | None:
+	"""Read AND clear the armed-by-macro marker (consume-once), so an armed write's
+	receipt is labelled exactly once and the marker can never leak onto the next,
+	unrelated tool call's receipt in a reused request/worker."""
+	val = getattr(frappe.local, _ARMED_ATTR, None)
+	if hasattr(frappe.local, _ARMED_ATTR):
+		try:
+			delattr(frappe.local, _ARMED_ATTR)
+		except Exception:
+			setattr(frappe.local, _ARMED_ATTR, None)
+	return val


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
