### PR TITLE
chore(white-label): soften internal-architecture jargon in comments

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -540,7 +540,7 @@ def _admin_chat_gate() -> dict:
 	# Refresh the locally-mirrored release notice on this gate's cadence so an
 	# active user sees an activate/clear without waiting for the daily sync.
 	release_notice.persist(conn.get("release_notice") or {})
-	# Same cadence: mirror the CP-owned egress redaction rules for the chat backstop.
+	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 
 	egress_rules.persist(conn.get("redaction_patterns"))
@@ -792,7 +792,7 @@ def _ready_verdict() -> dict:
 	# keeps serving its previous config. A fresh tenant whose FIRST sync
 	# is still pending or failed is NOT ready: sending them to chat
 	# guarantees failing turns while onboarding still shows "provisioning"
-	# (JARVIS-2026-07-08 split-brain).
+	# (JARVIS-2026-07-08 state mismatch).
 	#
 	# Deliberately NOT a last_sync_status check: that field is shared with
 	# the single-model sync, so a stale legacy "ok (reload via admin)" from

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -647,7 +647,7 @@ def capture_onboarding_lead(
 		return {"ok": False}
 
 
-# The Terms of Service moved from the admin plane to the public marketing site
+# The Terms of Service moved from the backend to the public marketing site
 # (jarvis_frappe_cloud); linking it directly skips admin's compatibility 301.
 MARKETING_TERMS_URL = "https://jarvis.aerele.in/terms"
 # Aerele's own stock admin origin. Deliberately a literal, NOT imported from
@@ -1001,8 +1001,8 @@ def support_upload(
 	scope: str,
 	comm: str | None = None,
 ) -> dict:
-	# Bytes ride b64-in-JSON (the CP media.upload decodes) -> plain _post, no binary helper.
-	# comm (optional): the reply Communication to attach the File to so it renders inline; the CP
+	# Bytes ride b64-in-JSON (the backend's media.upload decodes) -> plain _post, no binary helper.
+	# comm (optional): the reply Communication to attach the File to so it renders inline; the backend
 	# re-checks it belongs to the ticket before honoring it.
 	return _post(
 		path=_m("support.media.upload"),
@@ -1019,7 +1019,7 @@ def support_upload(
 
 
 def support_download(*, ticket: str, file_url: str, requesting_user: str, scope: str):
-	"""Raw streamed fetch of a Helpdesk file via the CP proxy. Returns
+	"""Raw streamed fetch of a Helpdesk file via the backend proxy. Returns
 	(content_bytes, content_type, content_disposition)."""
 	resp = _authenticated_raw(
 		_m("support.media.download"),
@@ -1610,7 +1610,7 @@ def unpair_chat_devices() -> dict:
 # --------------------------------------------------------------------------- #
 def reset_workspace(reason: str = "") -> dict:
 	"""Self-serve container rebuild (keeps customer + subscription + site data).
-	Container-recreate class op — destroy + warm-pool claim happen inline."""
+	Container-recreate class op — destroy + spare-capacity claim happen inline."""
 	return _post(path=_m("api.tenant_request.reset_workspace"), body={"reason": reason}, timeout_s=180)
 
 

--- a/jarvis/chat/egress_rules.py
+++ b/jarvis/chat/egress_rules.py
@@ -29,10 +29,10 @@ _MEMO_ATTR = "jarvis_egress_rules_memo"
 
 
 def persist(patterns) -> None:
-	"""Mirror the CP-sent redaction patterns onto Jarvis Settings.
+	"""Mirror the backend-sent redaction patterns onto Jarvis Settings.
 
-	LAST-KNOWN-GOOD: ``patterns is None`` (the CP omitted the key — a degraded/
-	pending/suspended connection payload, or a control plane predating this
+	LAST-KNOWN-GOOD: ``patterns is None`` (the backend omitted the key — a degraded/
+	pending/suspended connection payload, or a backend predating this
 	feature) is treated as "no update", NOT as "clear" — a transient degraded poll
 	must never wipe a working backstop. Only an explicit list (including ``[]``, the
 	deliberate kill-switch) is written.

--- a/jarvis/chat/heartbeat.py
+++ b/jarvis/chat/heartbeat.py
@@ -1,9 +1,9 @@
-"""GAP 1 (Track B) — the bench heartbeat emitter: the data-plane half of the
+"""GAP 1 (Track B) — the bench heartbeat emitter: the bench-side half of the
 scheduler dead-man's-switch.
 
-An UNCONDITIONAL ``*/5`` cron POSTs a small liveness VECTOR to the control plane on
+An UNCONDITIONAL ``*/5`` cron POSTs a small liveness VECTOR to the backend on
 every tick — even with zero turns and zero errors. That unconditional cadence IS the
-switch: if the site scheduler dies, the POSTs stop and the CP (Track C) alarms on the
+switch: if the site scheduler dies, the POSTs stop and the backend (Track C) alarms on the
 tenant's silence. The vector also carries symptom signals so a scheduler that is alive
 but whose recovery machinery is wedged is still visible:
 
@@ -94,10 +94,10 @@ def push_bench_heartbeat() -> None:
 
 		admin_client.push_bench_heartbeat(bench_liveness_vector())
 	except (AdminAuthError, AdminUnreachableError, AdminRateLimitedError, AdminValidationError):
-		# Best-effort telemetry: ANY push the CP does not accept — not onboarded, admin
+		# Best-effort telemetry: ANY push the backend does not accept — not onboarded, admin
 		# down, throttled, or a 4xx (INCLUDING the ingest endpoint not existing yet, before
 		# Track C ships, and any rejected payload) — is not a bench-side actionable bug.
-		# Stay silent: the CP's dead-man's-switch alarms on the ABSENCE of heartbeats, so a
+		# Stay silent: the backend's dead-man's-switch alarms on the ABSENCE of heartbeats, so a
 		# rejected one is harmless, and logging it would spam the Error Log fleet-wide.
 		return
 	except Exception:

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -186,7 +186,7 @@ def stt_config() -> dict | None:
 STT_OK = "ok"
 STT_OFF = "off"  # an admin deliberately turned voice features off
 STT_UNCONFIGURED = "unconfigured"  # no key anywhere — an admin can still set it up
-STT_ERROR = "error"  # transient: the CP lookup blew up; self-heals
+STT_ERROR = "error"  # transient: the backend lookup blew up; self-heals
 
 
 def stt_state() -> str:

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -288,7 +288,7 @@ scheduler_events = {
 			# no-op when there is nothing new to push.
 			"jarvis.error_push.push_error_rollup",
 			# GAP 1 dead-man's-switch (Track B): UNCONDITIONAL bench-liveness heartbeat to
-			# the control plane every tick — its silence is how the CP detects a dead
+			# the backend every tick — its silence is how the backend detects a dead
 			# scheduler (a live scheduler that fails to POST = the tenant went dark).
 			# Self-gating (skips un-onboarded), never raises. Cheap: two indexed reads.
 			"jarvis.chat.heartbeat.push_bench_heartbeat",

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -263,7 +263,7 @@ def sync_connection(timeout_s: int | None = None) -> dict:
 	# raise or clear the release notice, and this is the only refresh an idle
 	# bench gets.
 	release_notice.persist(data.get("release_notice") or {})
-	# Same cadence: mirror the CP-owned egress redaction rules for the chat backstop.
+	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 
 	egress_rules.persist(data.get("redaction_patterns"))
@@ -820,7 +820,7 @@ def save_llm_pool(
 # credentials, but they are cleared deliberately: is_ready_for_chat treats a
 # stamped marker as "this tenant has applied at least once, so keep chat open
 # through a transient pending". Leaving them set would let the NEXT connection
-# open chat before its first apply is confirmed - exactly the split-brain the
+# open chat before its first apply is confirmed - exactly the state mismatch the
 # markers exist to prevent. A disconnect ends that history.
 _DISCONNECTED_LLM_FIELDS = {
 	"llm_provider": "",

--- a/jarvis/onboarding_contract.py
+++ b/jarvis/onboarding_contract.py
@@ -389,7 +389,7 @@ def augment_pay_page(data: dict) -> dict:
 	    from it; empty fails closed.
 	  * ``pay_origin_attested`` — True iff ``pay_origin`` is set AND its sha256
 	    digest equals admin's non-navigable ``pay_origin_digest`` (§R P0-3). The
-	    frontend refuses to navigate unless this is True, so a config split-brain
+	    frontend refuses to navigate unless this is True, so a config state mismatch
 	    (bench pointed at one origin, admin minted a token for another) fails
 	    closed instead of sending the customer to the wrong host.
 

--- a/jarvis/support/media.py
+++ b/jarvis/support/media.py
@@ -1,7 +1,7 @@
 """Bench-side media proxy (Plan 3 B4).
 
-download streams a Helpdesk file from the control plane back to the browser (same-origin, so the
-SPA can point <img>/<a> at it). upload reads the posted file, base64s it, and forwards to the CP
+download streams a Helpdesk file from the backend back to the browser (same-origin, so the
+SPA can point <img>/<a> at it). upload reads the posted file, base64s it, and forwards to the backend
 (which decodes, caps, allowlist-checks, and attaches it to the ticket). Role-gated like api.py.
 """
 
@@ -44,7 +44,7 @@ def download(ticket: str, file_url: str):
 @frappe.whitelist()
 def upload(ticket: str, comm: str | None = None) -> dict:
 	# comm (optional): the reply Communication this upload belongs to. Frappe maps the multipart form
-	# field onto it, same as `ticket`. Forwarded to the CP, which attaches the File to that Communication
+	# field onto it, same as `ticket`. Forwarded to the backend, which attaches the File to that Communication
 	# (so it renders inline) after re-checking the comm belongs to the ticket.
 	scope = _scope()
 	f = frappe.request.files.get("file") if frappe.request else None

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -2245,7 +2245,7 @@ class TestTermsUrl(FrappeTestCase):
 	"""terms_url() is the one legal-page URL the checkout flow hands out.
 
 	The terms moved to the public marketing site (2026-08-17): Aerele's stock
-	deployment must link it directly (the admin plane only 301s /terms
+	deployment must link it directly (the backend only 301s /terms
 	there), while a rebranded deployment (admin base resolving away from
 	Aerele's stock admin, by either documented rebrand path) keeps its own
 	admin's /terms.

--- a/jarvis/tests/test_bench_heartbeat.py
+++ b/jarvis/tests/test_bench_heartbeat.py
@@ -1,4 +1,4 @@
-"""GAP 1 (Track B) — the bench heartbeat emitter (dead-man's-switch, data-plane half)."""
+"""GAP 1 (Track B) — the bench heartbeat emitter (dead-man's-switch, bench-side half)."""
 
 from __future__ import annotations
 
@@ -75,7 +75,7 @@ class TestBenchHeartbeatPush(_PumpTestCase):
 			heartbeat.push_bench_heartbeat()  # must not raise
 
 	def test_b3_silent_on_admin_validation_error(self):
-		"""A 4xx from the CP — INCLUDING the ingest endpoint not existing yet (before Track
+		"""A 4xx from the backend — INCLUDING the ingest endpoint not existing yet (before Track
 		C ships) — is silently swallowed, never logged fleet-wide."""
 		with (
 			patch.object(heartbeat, "_admin_configured", return_value=True),

--- a/jarvis/tests/test_egress_wiring.py
+++ b/jarvis/tests/test_egress_wiring.py
@@ -214,7 +214,7 @@ class TestPersistWiring(FrappeTestCase):
 		egress_rules._invalidate_memo()
 
 	def test_sync_connection_forwards_patterns_to_persist(self):
-		# The recurring scheduled sync must forward the CP-sent redaction_patterns to
+		# The recurring scheduled sync must forward the backend-sent redaction_patterns to
 		# egress_rules.persist (co-located with the release_notice.persist precedent).
 		from jarvis import onboarding
 

--- a/jarvis/tests/test_pay_page_cutover.py
+++ b/jarvis/tests/test_pay_page_cutover.py
@@ -68,7 +68,7 @@ class TestAugmentPayPage(FrappeTestCase):
 		self.assertTrue(out["pay_origin_attested"])
 
 	def test_token_with_a_MISMATCHED_digest_is_NOT_attested(self):
-		# The digest assertion: a split-brain (the bench's admin URL is one origin,
+		# The digest assertion: a state mismatch (the bench's admin URL is one origin,
 		# admin minted a token for another) fails closed - never navigates.
 		out = oc.augment_pay_page({"pay_page_token": "tok", "pay_origin_digest": "deadbeef"})
 		self.assertEqual(out["pay_origin"], self.ORIGIN)

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -700,7 +700,7 @@ class TestWatchdog(_PumpTestCase):
 
 	def test_b1_watchdog_early_return_does_not_stamp(self):
 		"""B1 (GAP 1): an early exit (target enumeration fails) must NOT stamp completion,
-		so the bench heartbeat's watchdog age keeps growing and the CP still sees a stalled
+		so the bench heartbeat's watchdog age keeps growing and the backend still sees a stalled
 		cron rather than a falsely-fresh one."""
 		key = "jarvis_pump_watchdog_last_completed"
 		old = "2020-01-01 00:00:00"

--- a/jarvis/tests/test_settings_sync_conflict.py
+++ b/jarvis/tests/test_settings_sync_conflict.py
@@ -36,7 +36,7 @@ inside ``frappe.db.sql`` at the statement that can still conflict after the fix
 (the ``tabSingles`` DELETE). It is still raised from Python: MariaDB never sees
 the statement, so no test here exercises a genuine engine-produced ER_CHECKREAD,
 and nothing here would catch a divergence between the real error and this
-reconstruction. That is the same limitation the admin-plane fix
+reconstruction. That is the same limitation the backend fix
 (jarvis-admin-v2 PR #264) recorded, and it is not fixable in this repo's CI: CI runs
 MariaDB 10.11, which has no ``innodb_snapshot_isolation`` at all and cannot raise
 1020 for this reason under any query. Reproducing the real error needs MariaDB

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -3389,7 +3389,7 @@ class TestFT4bValidateModelsNeverRaises(_RT3SettingsTestCase):
 
 # ---------------------------------------------------------------------------
 # JARVIS-2026-07-08 onboarding-audit fixes: durable sync status + honest
-# pool readiness. (Faults (a)/(c) of the incident + the split-brain gate.)
+# pool readiness. (Faults (a)/(c) of the incident + the state-mismatch gate.)
 # ---------------------------------------------------------------------------
 
 from unittest.mock import patch

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -24,16 +24,16 @@ SUPPORT_ERROR = "error"
 
 
 def _support_state() -> str:
-	"""Fleet-wide support state, Redis-cached (P8) so boot never blocks on a CP round-trip.
+	"""Fleet-wide support state, Redis-cached (P8) so boot never blocks on a backend round-trip.
 	Uses support_status (relaxed auth) — NOT get_connection, which 403s suspended customers (P7).
 
-	Returns one of ``ok`` / ``unconfigured`` / ``off`` / ``error``. The CP has always known
+	Returns one of ``ok`` / ``unconfigured`` / ``off`` / ``error``. The backend has always known
 	which of those it means; the bench used to collapse them into one boolean, so a
-	transient CP blip was indistinguishable from "support was never set up" and both just
+	transient backend blip was indistinguishable from "support was never set up" and both just
 	hid the button. ``error`` is kept distinct precisely so a self-healing blip does NOT
 	render as "support is not set up" — it stays hidden and retries in a minute.
 
-	A CP too old to send ``reason`` degrades safely: unavailable-without-a-reason is
+	A backend too old to send ``reason`` degrades safely: unavailable-without-a-reason is
 	treated as ``off`` (hide), which is exactly today's behaviour."""
 	cache = frappe.cache()
 	cached = cache.get_value(_SUPPORT_AVAILABLE_CACHE_KEY, expires=True)


### PR DESCRIPTION
Ahead of open-sourcing the app, neutralize the sharpest internal-ops jargon in comments and docstrings (comment text ONLY, no code): control-plane shorthand 'the CP' / 'admin|data plane' -> 'the backend', 'split-brain' -> 'state mismatch', 'warm-pool' -> 'spare capacity'. Meaning and the 'why' are preserved. The pervasive generic 'fleet' / 'control plane' / 'admin-v2' vocabulary is intentionally left as a separate, larger call.


## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
