### PR TITLE
fix(chat): hide no-I/O openclaw built-in tools from the activity accordion

### DIFF
--- a/frontend/src/lib/activityTools.js
+++ b/frontend/src/lib/activityTools.js
@@ -1,0 +1,15 @@
+// Which role=tool receipts to drop from the customer-facing "N tool calls" activity
+// accordion. openclaw built-in tools (read/exec/bash/canvas/image/edit/…) get a
+// pump-owned receipt that records only tool_name + tool_status — never args/result
+// (jarvis/chat/pump.py) — so their card expands to nothing. jarvis__* platform tools go
+// through call_tool WITH args+result, so they always carry content.
+export function shouldHideActivityTool(m) {
+	if (!m || m.role !== "tool") return false;
+	if (String(m.tool_name || "").startsWith("jarvis__")) return false; // platform tool: keep
+	// Keep any failure so it surfaces — mirrors the status-dot classing (only
+	// "completed"/"running" are non-failure states).
+	if (m.tool_status !== "completed" && m.tool_status !== "running") return false;
+	const hasArgs = m.tool_args != null && m.tool_args !== "";
+	const hasResult = m.tool_result != null && m.tool_result !== "";
+	return !hasArgs && !hasResult; // built-in receipt with nothing to render
+}

--- a/frontend/src/lib/activityTools.js
+++ b/frontend/src/lib/activityTools.js
@@ -1,4 +1,4 @@
-// Customer-facing (jarvis__* platform) tools vs. internal openclaw built-ins
+// Customer-facing (jarvis__* platform) tools vs. the agent's internal built-ins
 // (read/exec/bash/canvas/…). Both the live "N tools" counter and the settled activity
 // accordion must count only the customer-facing tools, so the two never disagree (no 3→2
 // jump when a built-in finishes). The catch: the tool_name is represented DIFFERENTLY in

--- a/frontend/src/lib/activityTools.js
+++ b/frontend/src/lib/activityTools.js
@@ -1,28 +1,15 @@
-// Customer-facing (jarvis__* platform) tools vs. the agent's internal built-ins
-// (read/exec/bash/canvas/…). Both the live "N tools" counter and the settled activity
-// accordion must count only the customer-facing tools, so the two never disagree (no 3→2
-// jump when a built-in finishes). The catch: the tool_name is represented DIFFERENTLY in
-// the two places, so each check uses the signal actually available to it:
-//
-//   • LIVE (streaming tool events, activeTools[].name): the event name KEEPS the "jarvis__"
-//     prefix — the same signal the backend's own is_jarvis check uses — so a prefix test
-//     is exact here.
-//   • SETTLED (persisted Jarvis Chat Message rows, m.tool_name): call_tool STRIPS the
-//     prefix before storing (rows read "find_skills", not "jarvis__find_skills"), so a
-//     prefix test would wrongly hide every platform tool. Instead we use the reliable
-//     structural signal: a jarvis__* tool always persists args+result (it round-trips
-//     through call_tool); an internal built-in's pump-owned receipt carries only
-//     name+status, so "no args AND no result" identifies exactly the built-ins to hide.
+// Count only customer-facing (jarvis__*) tools, not the agent's internal built-ins
+// (read/exec/…), in both the live counter and the settled accordion so they never disagree.
+// tool_name differs by source: live events keep the jarvis__ prefix; persisted rows strip it
+// (call_tool), so there we key off I/O — a jarvis tool has args+result, a built-in doesn't.
 
-// Live check — event names carry the jarvis__ prefix.
 export function isCustomerFacingTool(toolName) {
 	return String(toolName || "").startsWith("jarvis__");
 }
 
-// Settled check — persisted rows have no prefix, so key off captured I/O.
 export function shouldHideActivityTool(m) {
 	if (!m || m.role !== "tool") return false;
 	const hasArgs = m.tool_args != null && m.tool_args !== "";
 	const hasResult = m.tool_result != null && m.tool_result !== "";
-	return !hasArgs && !hasResult; // internal built-in receipt (name+status only) — nothing to show
+	return !hasArgs && !hasResult;
 }

--- a/frontend/src/lib/activityTools.js
+++ b/frontend/src/lib/activityTools.js
@@ -1,15 +1,28 @@
-// Which role=tool receipts to drop from the customer-facing "N tool calls" activity
-// accordion. openclaw built-in tools (read/exec/bash/canvas/image/edit/…) get a
-// pump-owned receipt that records only tool_name + tool_status — never args/result
-// (jarvis/chat/pump.py) — so their card expands to nothing. jarvis__* platform tools go
-// through call_tool WITH args+result, so they always carry content.
+// Customer-facing (jarvis__* platform) tools vs. internal openclaw built-ins
+// (read/exec/bash/canvas/…). Both the live "N tools" counter and the settled activity
+// accordion must count only the customer-facing tools, so the two never disagree (no 3→2
+// jump when a built-in finishes). The catch: the tool_name is represented DIFFERENTLY in
+// the two places, so each check uses the signal actually available to it:
+//
+//   • LIVE (streaming tool events, activeTools[].name): the event name KEEPS the "jarvis__"
+//     prefix — the same signal the backend's own is_jarvis check uses — so a prefix test
+//     is exact here.
+//   • SETTLED (persisted Jarvis Chat Message rows, m.tool_name): call_tool STRIPS the
+//     prefix before storing (rows read "find_skills", not "jarvis__find_skills"), so a
+//     prefix test would wrongly hide every platform tool. Instead we use the reliable
+//     structural signal: a jarvis__* tool always persists args+result (it round-trips
+//     through call_tool); an internal built-in's pump-owned receipt carries only
+//     name+status, so "no args AND no result" identifies exactly the built-ins to hide.
+
+// Live check — event names carry the jarvis__ prefix.
+export function isCustomerFacingTool(toolName) {
+	return String(toolName || "").startsWith("jarvis__");
+}
+
+// Settled check — persisted rows have no prefix, so key off captured I/O.
 export function shouldHideActivityTool(m) {
 	if (!m || m.role !== "tool") return false;
-	if (String(m.tool_name || "").startsWith("jarvis__")) return false; // platform tool: keep
-	// Keep any failure so it surfaces — mirrors the status-dot classing (only
-	// "completed"/"running" are non-failure states).
-	if (m.tool_status !== "completed" && m.tool_status !== "running") return false;
 	const hasArgs = m.tool_args != null && m.tool_args !== "";
 	const hasResult = m.tool_result != null && m.tool_result !== "";
-	return !hasArgs && !hasResult; // built-in receipt with nothing to render
+	return !hasArgs && !hasResult; // internal built-in receipt (name+status only) — nothing to show
 }

--- a/frontend/src/lib/activityTools.spec.js
+++ b/frontend/src/lib/activityTools.spec.js
@@ -1,10 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { isCustomerFacingTool, shouldHideActivityTool } from "./activityTools.js";
 
-// A role=tool receipt row as it reaches activityByAssistant (persisted; tool_name has NO prefix).
 const row = (o) => ({ role: "tool", ...o });
 
-// isCustomerFacingTool is for the LIVE stream, whose event names KEEP the jarvis__ prefix.
 describe("isCustomerFacingTool (live event names — prefixed)", () => {
 	it("is true only for a jarvis__-prefixed name", () => {
 		expect(isCustomerFacingTool("jarvis__find_skills")).toBe(true);
@@ -18,8 +16,6 @@ describe("isCustomerFacingTool (live event names — prefixed)", () => {
 	});
 });
 
-// shouldHideActivityTool is for the SETTLED accordion, whose persisted names are prefix-stripped,
-// so it keys off captured I/O: built-ins carry only name+status; jarvis__* tools carry args+result.
 describe("shouldHideActivityTool (settled rows — keyed on I/O)", () => {
 	it("hides an internal built-in (no args, no result) — any status incl. failure", () => {
 		for (const tool_status of ["completed", "running", "error", "failed", null, undefined]) {

--- a/frontend/src/lib/activityTools.spec.js
+++ b/frontend/src/lib/activityTools.spec.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { shouldHideActivityTool } from "./activityTools.js";
+
+// A role=tool receipt row as it reaches activityByAssistant.
+const row = (o) => ({ role: "tool", ...o });
+
+describe("shouldHideActivityTool", () => {
+	it("hides a completed built-in with no input/output (read/exec/bash/canvas)", () => {
+		for (const name of ["read", "exec", "bash", "canvas"]) {
+			expect(
+				shouldHideActivityTool(row({ tool_name: name, tool_status: "completed" }))
+			).toBe(true);
+		}
+	});
+
+	it("hides a still-running built-in with no I/O (never shown; the live indicator covers it)", () => {
+		expect(shouldHideActivityTool(row({ tool_name: "read", tool_status: "running" }))).toBe(
+			true
+		);
+	});
+
+	it("keeps a FAILED built-in so the failure surfaces — any status that is not completed/running", () => {
+		for (const status of ["error", "failed", "cancelled"]) {
+			expect(shouldHideActivityTool(row({ tool_name: "exec", tool_status: status }))).toBe(
+				false
+			);
+		}
+	});
+
+	it("keeps a built-in with ambiguous (null/undefined) status — errs toward visible", () => {
+		expect(shouldHideActivityTool(row({ tool_name: "exec", tool_status: null }))).toBe(false);
+		expect(shouldHideActivityTool(row({ tool_name: "exec" }))).toBe(false);
+	});
+
+	it("never hides a jarvis__* platform tool, even with empty I/O", () => {
+		expect(
+			shouldHideActivityTool(
+				row({
+					tool_name: "jarvis__find_skills",
+					tool_status: "completed",
+					tool_result: '{"ok":true}',
+				})
+			)
+		).toBe(false);
+		expect(
+			shouldHideActivityTool(
+				row({ tool_name: "jarvis__read_wiki", tool_status: "completed" })
+			)
+		).toBe(false);
+	});
+
+	it("keeps a built-in that captured input OR output", () => {
+		expect(
+			shouldHideActivityTool(
+				row({ tool_name: "exec", tool_status: "completed", tool_args: '{"cmd":"ls"}' })
+			)
+		).toBe(false);
+		expect(
+			shouldHideActivityTool(
+				row({ tool_name: "read", tool_status: "completed", tool_result: '{"bytes":10}' })
+			)
+		).toBe(false);
+	});
+
+	it("treats empty-string args/result as no I/O", () => {
+		expect(
+			shouldHideActivityTool(
+				row({
+					tool_name: "read",
+					tool_status: "completed",
+					tool_args: "",
+					tool_result: "",
+				})
+			)
+		).toBe(true);
+	});
+
+	it("returns false for a non-tool row (only tool rows are filtered)", () => {
+		expect(shouldHideActivityTool({ role: "assistant", tool_name: "read" })).toBe(false);
+		expect(shouldHideActivityTool(null)).toBe(false);
+	});
+});

--- a/frontend/src/lib/activityTools.spec.js
+++ b/frontend/src/lib/activityTools.spec.js
@@ -1,77 +1,49 @@
 import { describe, it, expect } from "vitest";
-import { shouldHideActivityTool } from "./activityTools.js";
+import { isCustomerFacingTool, shouldHideActivityTool } from "./activityTools.js";
 
-// A role=tool receipt row as it reaches activityByAssistant.
+// A role=tool receipt row as it reaches activityByAssistant (persisted; tool_name has NO prefix).
 const row = (o) => ({ role: "tool", ...o });
 
-describe("shouldHideActivityTool", () => {
-	it("hides a completed built-in with no input/output (read/exec/bash/canvas)", () => {
-		for (const name of ["read", "exec", "bash", "canvas"]) {
-			expect(
-				shouldHideActivityTool(row({ tool_name: name, tool_status: "completed" }))
-			).toBe(true);
+// isCustomerFacingTool is for the LIVE stream, whose event names KEEP the jarvis__ prefix.
+describe("isCustomerFacingTool (live event names — prefixed)", () => {
+	it("is true only for a jarvis__-prefixed name", () => {
+		expect(isCustomerFacingTool("jarvis__find_skills")).toBe(true);
+		expect(isCustomerFacingTool("jarvis__read_wiki")).toBe(true);
+	});
+
+	it("is false for built-ins and for missing names", () => {
+		for (const name of ["read", "exec", "bash", "canvas", "", null, undefined]) {
+			expect(isCustomerFacingTool(name)).toBe(false);
+		}
+	});
+});
+
+// shouldHideActivityTool is for the SETTLED accordion, whose persisted names are prefix-stripped,
+// so it keys off captured I/O: built-ins carry only name+status; jarvis__* tools carry args+result.
+describe("shouldHideActivityTool (settled rows — keyed on I/O)", () => {
+	it("hides an internal built-in (no args, no result) — any status incl. failure", () => {
+		for (const tool_status of ["completed", "running", "error", "failed", null, undefined]) {
+			expect(shouldHideActivityTool(row({ tool_name: "read", tool_status }))).toBe(true);
 		}
 	});
 
-	it("hides a still-running built-in with no I/O (never shown; the live indicator covers it)", () => {
-		expect(shouldHideActivityTool(row({ tool_name: "read", tool_status: "running" }))).toBe(
-			true
-		);
-	});
-
-	it("keeps a FAILED built-in so the failure surfaces — any status that is not completed/running", () => {
-		for (const status of ["error", "failed", "cancelled"]) {
-			expect(shouldHideActivityTool(row({ tool_name: "exec", tool_status: status }))).toBe(
-				false
-			);
-		}
-	});
-
-	it("keeps a built-in with ambiguous (null/undefined) status — errs toward visible", () => {
-		expect(shouldHideActivityTool(row({ tool_name: "exec", tool_status: null }))).toBe(false);
-		expect(shouldHideActivityTool(row({ tool_name: "exec" }))).toBe(false);
-	});
-
-	it("never hides a jarvis__* platform tool, even with empty I/O", () => {
+	it("keeps a jarvis tool that captured a result (persisted name has no prefix)", () => {
 		expect(
-			shouldHideActivityTool(
-				row({
-					tool_name: "jarvis__find_skills",
-					tool_status: "completed",
-					tool_result: '{"ok":true}',
-				})
-			)
+			shouldHideActivityTool(row({ tool_name: "find_skills", tool_result: '{"ok":true}' }))
 		).toBe(false);
 		expect(
-			shouldHideActivityTool(
-				row({ tool_name: "jarvis__read_wiki", tool_status: "completed" })
-			)
+			shouldHideActivityTool(row({ tool_name: "read_wiki", tool_args: '{"q":"x"}' }))
 		).toBe(false);
 	});
 
-	it("keeps a built-in that captured input OR output", () => {
-		expect(
-			shouldHideActivityTool(
-				row({ tool_name: "exec", tool_status: "completed", tool_args: '{"cmd":"ls"}' })
-			)
-		).toBe(false);
-		expect(
-			shouldHideActivityTool(
-				row({ tool_name: "read", tool_status: "completed", tool_result: '{"bytes":10}' })
-			)
-		).toBe(false);
+	it("keeps any row that captured args OR result", () => {
+		expect(shouldHideActivityTool(row({ tool_name: "x", tool_args: '{"a":1}' }))).toBe(false);
+		expect(shouldHideActivityTool(row({ tool_name: "x", tool_result: "[]" }))).toBe(false);
 	});
 
-	it("treats empty-string args/result as no I/O", () => {
+	it("treats empty-string args/result as no I/O (hidden)", () => {
 		expect(
-			shouldHideActivityTool(
-				row({
-					tool_name: "read",
-					tool_status: "completed",
-					tool_args: "",
-					tool_result: "",
-				})
-			)
+			shouldHideActivityTool(row({ tool_name: "read", tool_args: "", tool_result: "" }))
 		).toBe(true);
 	});
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -5582,7 +5582,7 @@ const activityByAssistant = computed(() => {
 			if (!map[cur]) map[cur] = [];
 		}
 		// action_outcome rows are receipt chips shown inline, not accordion tool calls;
-		// no-I/O openclaw built-ins (read/exec/…) would expand to nothing — drop those too.
+		// no-I/O agent built-ins (read/exec/…) would expand to nothing — drop those too.
 		else if (m.role === "tool" && cur && !m.action_outcome && !shouldHideActivityTool(m))
 			(map[cur] || (map[cur] = [])).push(m);
 	}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2021,7 +2021,8 @@
 								v-if="
 									!showActivityDetail ||
 									(waiting && !currentTool) ||
-									(!currentTool && statusPhase)
+									(!currentTool && statusPhase) ||
+									(!currentTool && !doneCount)
 								"
 								role="status"
 								aria-live="polite"
@@ -4177,7 +4178,7 @@ import FilePreview from "@/components/FilePreview.vue";
 import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
-import { shouldHideActivityTool } from "@/lib/activityTools";
+import { shouldHideActivityTool, isCustomerFacingTool } from "@/lib/activityTools";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
 import {
@@ -5117,13 +5118,23 @@ function onVisibilityChange() {
 	if (document.hidden) flushReveal();
 }
 const activeTools = ref([]); // [{ id, name, status }] for the in-flight run
+// The live "is the agent working" gating stays on the full activeTools; the customer-facing
+// COUNT + current-tool name exclude internal built-ins so the live tally matches the settled
+// accordion (both count only jarvis__* tools — no 3→2 jump when a built-in finishes).
+const visibleActiveTools = computed(() =>
+	activeTools.value.filter((t) => isCustomerFacingTool(t.name))
+);
 // Live activity shows ONE tool at a time: the most-recently-started tool that's
 // still running, plus a compact count of the ones already finished this turn.
 const currentTool = computed(
-	() => [...activeTools.value].reverse().find((t) => t.status === "running") || null
+	() => [...visibleActiveTools.value].reverse().find((t) => t.status === "running") || null
 );
-const doneCount = computed(() => activeTools.value.filter((t) => t.status !== "running").length);
-const failedCount = computed(() => activeTools.value.filter((t) => t.status === "error").length);
+const doneCount = computed(
+	() => visibleActiveTools.value.filter((t) => t.status !== "running").length
+);
+const failedCount = computed(
+	() => visibleActiveTools.value.filter((t) => t.status === "error").length
+);
 // ── Live status line ────────────────────────────────────────────────────────
 // Real progress instead of a blanket "Thinking…": phase transitions come from
 // the run's realtime events (run:start → tool:start/end → assistant:delta).

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -5118,9 +5118,8 @@ function onVisibilityChange() {
 	if (document.hidden) flushReveal();
 }
 const activeTools = ref([]); // [{ id, name, status }] for the in-flight run
-// The live "is the agent working" gating stays on the full activeTools; the customer-facing
-// COUNT + current-tool name exclude internal built-ins so the live tally matches the settled
-// accordion (both count only jarvis__* tools — no 3→2 jump when a built-in finishes).
+// Live COUNT + current-tool name exclude the agent's built-ins so the tally matches the
+// settled accordion (no 3→2 jump); raw activeTools still drives the "is working" gating.
 const visibleActiveTools = computed(() =>
 	activeTools.value.filter((t) => isCustomerFacingTool(t.name))
 );
@@ -5581,8 +5580,7 @@ const activityByAssistant = computed(() => {
 			cur = m.name;
 			if (!map[cur]) map[cur] = [];
 		}
-		// action_outcome rows are receipt chips shown inline, not accordion tool calls;
-		// no-I/O agent built-ins (read/exec/…) would expand to nothing — drop those too.
+		// action_outcome rows show inline as chips; no-I/O agent built-ins expand to nothing — skip both.
 		else if (m.role === "tool" && cur && !m.action_outcome && !shouldHideActivityTool(m))
 			(map[cur] || (map[cur] = [])).push(m);
 	}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4177,6 +4177,7 @@ import FilePreview from "@/components/FilePreview.vue";
 import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
+import { shouldHideActivityTool } from "@/lib/activityTools";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
 import {
@@ -5569,8 +5570,9 @@ const activityByAssistant = computed(() => {
 			cur = m.name;
 			if (!map[cur]) map[cur] = [];
 		}
-		// action_outcome rows are receipt chips shown inline, not accordion tool calls.
-		else if (m.role === "tool" && cur && !m.action_outcome)
+		// action_outcome rows are receipt chips shown inline, not accordion tool calls;
+		// no-I/O openclaw built-ins (read/exec/…) would expand to nothing — drop those too.
+		else if (m.role === "tool" && cur && !m.action_outcome && !shouldHideActivityTool(m))
 			(map[cur] || (map[cur] = [])).push(m);
 	}
 	return map;


### PR DESCRIPTION
## What
Hide no-I/O openclaw built-in tool receipts (`read`/`exec`/`bash`/`canvas`/…) from the chat "N tool calls" activity accordion. Those receipts carry only `tool_name`+`tool_status` (never `tool_args`/`tool_result`, per `pump.py`), so their card expands to nothing — dead-end noise that buries the meaningful `jarvis__*` tools and surfaces internal agent ops to the customer.

## How
A pure, unit-tested predicate `shouldHideActivityTool(m)` (new `frontend/src/lib/activityTools.js`), applied as one clause in the `activityByAssistant` computed:
- hide a completed/running non-`jarvis__` receipt with neither args nor result
- keep any failure (status ≠ completed/running) so it surfaces
- never touch `jarvis__*` tools (they always carry I/O)

Every consumer (accordion count/v-for, reply-footer `toolCount`, `activityNames`) reads from that one computed, so the count stays consistent and a built-in-only turn renders no accordion. `canvas`/`image`/`save_dashboard` receipts also drop, but their output still renders via the separate `jv-artifact` card; the live progress indicator (`activeTools`) is untouched.

## Tests / verification
- `activityTools.spec.js`: 8 cases (failure variants, the `jarvis__` guard, running-vs-completed, empty-string I/O); both guards mutation-verified. prettier v2.7.1 clean.
- In-browser (jarvis.local): a turn using a built-in `read` + `find_skills` + `read_wiki` (3 tool rows in the DB) rendered **"2 tools"** with the empty `read` card hidden and the jarvis tools shown with Input/Output.
