### PR TITLE
feat(chat-spa): surface key Desk fields across six list/detail views

### DIFF
--- a/frontend/src/components/ShadowChip.vue
+++ b/frontend/src/components/ShadowChip.vue
@@ -1,0 +1,17 @@
+<template>
+	<span
+		class="inline-flex h-5 shrink-0 select-none items-center whitespace-nowrap rounded-full bg-surface-violet-1 px-2 text-xs text-ink-violet-1"
+	>
+		{{ label }}
+	</span>
+</template>
+
+<script setup>
+// The brand's shadow / preview state is violet, and frappe-ui's Badge ships no
+// violet theme (see ActivationPanel.vue) - so this small pill is the single home
+// for the hand-rolled violet chip rather than copy-pasting the classes at each
+// call site.
+defineProps({
+	label: { type: String, default: "Shadow" },
+});
+</script>

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -38,6 +38,23 @@
 					<PromotionStatusChip v-if="myPromo" :req="myPromo" noun="page" />
 				</div>
 
+				<!-- What this page documents: a deep link to the ERP record it's about. -->
+				<div v-if="refUrl" class="mt-2 flex items-center gap-1.5 text-sm text-ink-gray-5">
+					<span>About</span>
+					<a
+						:href="refUrl"
+						target="_blank"
+						rel="noopener"
+						class="flex min-w-0 items-center gap-1 text-ink-gray-8 hover:underline"
+					>
+						<span class="truncate">{{ page.ref_doctype }} · {{ page.ref_name }}</span>
+						<FeatherIcon
+							name="external-link"
+							class="size-3.5 shrink-0 text-ink-gray-5"
+						/>
+					</a>
+				</div>
+
 				<!-- Conflicting gets the same treatment as Stale: a badge alone is
 				     a red dead-end with no explanation or resolution path -->
 				<div
@@ -192,7 +209,16 @@
 // the page itself whenever it opens (v-model true + slug); emits `refresh`
 // after a save/archive/delete so the owning list refetches.
 import { ref, computed, watch } from "vue";
-import { Badge, Button, Dialog, FormControl, Tooltip, toast, confirmDialog } from "frappe-ui";
+import {
+	Badge,
+	Button,
+	Dialog,
+	FeatherIcon,
+	FormControl,
+	Tooltip,
+	toast,
+	confirmDialog,
+} from "frappe-ui";
 import { renderMarkdown } from "@/markdown";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import {
@@ -292,6 +318,13 @@ const scopeTarget = computed(() => {
 	if (page.value.scope === "Role") return page.value.target_role || "";
 	if (page.value.scope === "User") return page.value.target_user || "";
 	return "";
+});
+// The ERP record this page documents (ref_doctype/ref_name) as a Desk deep link -
+// same doctype-route transform as ActivityDetailDialog's target link.
+const refUrl = computed(() => {
+	if (!page.value || !page.value.ref_doctype || !page.value.ref_name) return "";
+	const dt = page.value.ref_doctype.toLowerCase().replace(/ /g, "-");
+	return `/app/${dt}/${encodeURIComponent(page.value.ref_name)}`;
 });
 // "From a voice note by X, Jul 7" - the page's latest source entry. Pages a
 // pipeline wrote (not a person) earn trust by saying where they came from.

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -130,12 +130,7 @@
 							theme="green"
 							label="Live"
 						/>
-						<span
-							v-else-if="activation"
-							class="inline-flex h-5 shrink-0 select-none items-center whitespace-nowrap rounded-full bg-surface-violet-1 px-2 text-xs text-ink-violet-1"
-						>
-							Shadow (preview)
-						</span>
+						<ShadowChip v-else-if="activation" label="Shadow (preview)" />
 						<Switch
 							v-if="installation"
 							label="Enabled"
@@ -413,12 +408,28 @@
 							<ListRows />
 						</template>
 						<template #cell="{ column, row, item, align }">
-							<Badge
-								v-if="column.key === 'enabled'"
-								variant="subtle"
-								:theme="row.enabled ? 'green' : 'gray'"
-								:label="row.enabled ? 'Enabled' : 'Disabled'"
-							/>
+							<template v-if="column.key === 'state'">
+								<!-- State precedence, most-actionable first: Blocked > Disabled >
+								     Live > Shadow. `installable` is a last-reconciled STORED flag
+								     (see get_agent_admin_overview), so Blocked reads "as last
+								     reconciled" rather than claiming a live guarantee. -->
+								<Tooltip v-if="!row.installable" :text="blockedReason(row)">
+									<Badge variant="subtle" theme="orange" label="Blocked" />
+								</Tooltip>
+								<Badge
+									v-else-if="!row.enabled"
+									variant="subtle"
+									theme="gray"
+									label="Disabled"
+								/>
+								<Badge
+									v-else-if="row.activation_state === 'live'"
+									variant="subtle"
+									theme="green"
+									label="Live"
+								/>
+								<ShadowChip v-else label="Shadow" />
+							</template>
 							<div
 								v-else-if="column.key === 'run_as_user'"
 								class="truncate text-base"
@@ -495,6 +506,7 @@ import {
 	ListRowItem,
 	Switch,
 	TimePicker,
+	Tooltip,
 	confirmDialog,
 	toast,
 } from "frappe-ui";
@@ -506,6 +518,7 @@ import ActivationPanel from "@/pages/agents/ActivationPanel.vue";
 import ConfigForm from "@/pages/agents/ConfigForm.vue";
 import AppSourceConsentDialog from "@/components/learning/AppSourceConsentDialog.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
+import ShadowChip from "@/components/ShadowChip.vue";
 import { useDocmeta } from "@/composables/useDocmeta";
 import { session } from "@/data/session";
 import { timeAgo, exactDate as fmtDt } from "@/utils/datetime";
@@ -537,10 +550,31 @@ const INSTALL_COLUMNS = [
 	// misconfigured row that every dispatch path refuses to run, so it is surfaced
 	// here (as a badge) to give an admin an in-product path to the offending row.
 	{ label: "Runs as", key: "run_as_user", width: 2 },
-	{ label: "Enabled", key: "enabled", width: "7rem" },
+	{ label: "State", key: "state", width: "8rem" },
 	{ label: "Last run", key: "last_run_at", width: "8rem" },
 	{ label: "Sync", key: "sync_status", width: "7rem" },
 ];
+
+// not_installable_reason is a machine enum; humanise it for the admin's Blocked
+// tooltip. Unknown values fall back to a de-underscored form so a newly-added
+// reason still reads rather than showing a raw token.
+const REASON_LABELS = {
+	app_absent_or_ineligible: "Required app is missing or ineligible",
+	permission_slice: "Missing a required permission",
+	configuration_missing: "Configuration is incomplete",
+	record_coverage_insufficient: "Not enough records to run on",
+	source_stale: "Source data is stale",
+	rule_expired: "An activation rule has expired",
+	external_evidence_absent: "Required external evidence is absent",
+	run_truncated_watermark: "A prior run was truncated",
+	unsupported_customisation: "An unsupported customisation blocks it",
+};
+function blockedReason(row) {
+	const r = row.not_installable_reason;
+	const human = r ? REASON_LABELS[r] || r.replace(/_/g, " ") : "";
+	// "as last reconciled": installable is a stored flag, not a live re-check.
+	return human ? `Can't run (as last reconciled): ${human}.` : "Can't run, as last reconciled.";
+}
 
 // ── data ──────────────────────────────────────────────────────────────────────
 const agent = ref(null); // get_agent payload (§8.3)

--- a/frontend/src/pages/dashboards/SavedDashboardsTab.vue
+++ b/frontend/src/pages/dashboards/SavedDashboardsTab.vue
@@ -45,19 +45,7 @@
 		</template>
 
 		<template #cell-scope="{ row }">
-			<Badge
-				v-if="row.scope === 'Role'"
-				variant="subtle"
-				theme="blue"
-				:label="row.target_role || 'Role'"
-			/>
-			<Badge
-				v-else-if="row.scope === 'Org'"
-				variant="subtle"
-				theme="blue"
-				label="Everyone"
-			/>
-			<Badge v-else variant="subtle" theme="gray" label="Private" />
+			<Badge variant="subtle" :theme="visBadge(row).theme" :label="visBadge(row).label" />
 		</template>
 
 		<template #cell-modified="{ row }">
@@ -80,6 +68,7 @@ import ListPage from "@/components/list/ListPage.vue";
 import { useListPage } from "@/composables/useListPage";
 import { dashboardsListFetch } from "@/pages/list/listFetchers";
 import { timeAgo, exactDate } from "@/utils/datetime";
+import { session } from "@/data/session";
 
 // /dashboards is a TABBED route (Builder | Saved): the `fv2` payload carries its
 // view key, and every tab navigation carries the query (judgment C08-7).
@@ -106,6 +95,27 @@ const columns = [
 	{ label: "Owner", key: "owner", width: "10rem" },
 	{ label: "Updated", key: "modified", width: "8rem" },
 ];
+
+// Visibility badge themes match the shared scope convention used across the app
+// (WikiTab / WikiPageDialog / PersonalisationSettings): Org=gray, Role=blue,
+// User=green - replacing this tab's older Org+Role both-blue.
+const SCOPE_THEME = { Org: "gray", Role: "blue", User: "green" };
+// The audience behind the scope, resolved for the current VIEWER. "Just you" is
+// viewer-dependent: it holds only when this row's target_user IS the viewer - an
+// admin looking at someone else's personal dashboard must not read "just you".
+// Empty targets degrade to a sensible label rather than the raw scope word.
+function visBadge(row) {
+	const theme = SCOPE_THEME[row.scope] || "gray";
+	if (row.scope === "Org") return { theme, label: "Everyone" };
+	if (row.scope === "Role") return { theme, label: row.target_role || "Shared with a role" };
+	if (row.scope === "User") {
+		if (row.target_user && row.target_user === session.user)
+			return { theme, label: "Just you" };
+		if (row.target_user) return { theme, label: row.target_user };
+		return { theme, label: "Private" };
+	}
+	return { theme, label: "Private" };
+}
 
 // search rides the quick-filter strip (MacrosList idiom): it lives in the
 // filters object for a controlled input, and fetchFn moves it onto the

--- a/frontend/src/pages/macros/RunsTab.vue
+++ b/frontend/src/pages/macros/RunsTab.vue
@@ -61,11 +61,27 @@
 			</template>
 			<template #cell="{ column, row, item, align }">
 				<template v-if="column.key === 'status'">
-					<Badge
-						variant="subtle"
-						:theme="RUN_THEMES[row.status] || 'gray'"
-						:label="statusLabel(row.status)"
-					/>
+					<div class="flex items-center gap-1.5">
+						<Badge
+							variant="subtle"
+							:theme="RUN_THEMES[row.status] || 'gray'"
+							:label="statusLabel(row.status)"
+						/>
+						<!-- A run that errored explains itself: hover = short error,
+						     click = dialog with the full error + finish time + run mode.
+						     Keyed on `error` PRESENCE, not status, so a user-cancelled
+						     `stopped` run (empty error) shows no affordance. @click.stop so
+						     it never bubbles into openRow's conversation navigation. -->
+						<Tooltip v-if="row.error" :text="shortError(row.error)">
+							<button
+								type="button"
+								class="flex text-ink-gray-5 hover:text-ink-gray-7"
+								@click.stop.prevent="openError(row)"
+							>
+								<FeatherIcon name="info" class="size-3.5" />
+							</button>
+						</Tooltip>
+					</div>
 				</template>
 				<template v-else-if="column.key === 'started_at'">
 					<Tooltip :text="exactDate(row.started_at || row.creation)">
@@ -136,6 +152,31 @@
 			@update:modelValue="(v) => (pageLength = v)"
 			@loadMore="loadMore"
 		/>
+
+		<!-- failure detail (purpose-built, NOT the shared triggers dialog): a run's
+		     error can be a full traceback, so it earns a dialog over a tooltip alone. -->
+		<Dialog v-model="errDialog.show" :options="{ title: errDialogTitle, size: 'lg' }">
+			<template #body-content>
+				<div v-if="errDialog.row" class="flex flex-col gap-3">
+					<div class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-ink-gray-6">
+						<span v-if="errDialog.row.macro_name">{{ errDialog.row.macro_name }}</span>
+						<span v-if="errDialog.row.finished_at">
+							Finished {{ timeAgo(errDialog.row.finished_at) }}
+						</span>
+						<span v-if="runModeLabel(errDialog.row.run_mode)">
+							{{ runModeLabel(errDialog.row.run_mode) }} run
+						</span>
+					</div>
+					<div>
+						<div class="mb-1 text-sm font-medium text-ink-gray-7">Error</div>
+						<pre
+							class="max-h-80 overflow-auto whitespace-pre-wrap rounded-md bg-surface-gray-2 p-3 text-xs text-ink-gray-8"
+							>{{ errDialog.row.error }}</pre
+						>
+					</div>
+				</div>
+			</template>
+		</Dialog>
 	</div>
 </template>
 
@@ -159,6 +200,7 @@ import {
 	Button,
 	Badge,
 	FormControl,
+	Dialog,
 	FeatherIcon,
 	Tooltip,
 	toast,
@@ -214,6 +256,11 @@ const macro = ref("");
 const pageLength = useStorage("jarvis-pl-macro-runs", 20);
 const stats = ref(null);
 const macrosList = ref([]); // macro filter dropdown (list_macros)
+// failure-detail dialog (RunsTab-local; a run's error can be a full traceback)
+const errDialog = ref({ show: false, row: null });
+const errDialogTitle = computed(() =>
+	errDialog.value.row && errDialog.value.row.status === "stopped" ? "Run stopped" : "Run failed"
+);
 
 const macroOptions = computed(() => [
 	{ label: "All macros", value: "" },
@@ -313,6 +360,10 @@ function openRow(row) {
 	if (row.conversation) router.push("/c/" + row.conversation);
 }
 
+function openError(row) {
+	errDialog.value = { show: true, row };
+}
+
 async function stopRun(row) {
 	try {
 		await api.stopMacroRun(row.name);
@@ -358,5 +409,22 @@ function fmtDuration(sec) {
 	if (m < 60) return s ? `${m}m ${s}s` : `${m}m`;
 	const h = Math.floor(m / 60);
 	return `${h}h ${m % 60}m`;
+}
+// run_mode is a stored Select with no default: NULL on legacy/parked runs, so
+// render nothing rather than "null".
+function runModeLabel(m) {
+	if (m === "merged") return "Merged";
+	if (m === "stepped") return "Stepped";
+	return "";
+}
+// First non-blank line of the error, clipped - the tooltip is the teaser; the
+// dialog carries the full text.
+function shortError(e) {
+	if (!e) return "";
+	const first =
+		String(e)
+			.split("\n")
+			.find((l) => l.trim()) || "";
+	return first.length > 140 ? first.slice(0, 139) + "…" : first;
 }
 </script>

--- a/frontend/src/pages/support/SupportListPage.vue
+++ b/frontend/src/pages/support/SupportListPage.vue
@@ -72,6 +72,16 @@
 				/>
 			</template>
 
+			<template #cell-priority="{ row }">
+				<Badge
+					v-if="priorityBadge(row.priority)"
+					:variant="priorityBadge(row.priority).variant"
+					:theme="priorityBadge(row.priority).theme"
+					:label="priorityBadge(row.priority).label"
+				/>
+				<span v-else class="text-base text-ink-gray-4">-</span>
+			</template>
+
 			<template #cell-modified="{ row }">
 				<div class="flex w-full items-center justify-end">
 					<Tooltip v-if="row.modified" :text="exactDate(row.modified)">
@@ -92,7 +102,7 @@ import { Badge, Button, Tooltip } from "frappe-ui";
 import ListPage from "@/components/list/ListPage.vue";
 import SupportShell from "@/components/support/SupportShell.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
-import { useSupportStore, badgeFor } from "@/stores/support";
+import { useSupportStore, badgeFor, priorityBadge } from "@/stores/support";
 
 const router = useRouter();
 const store = useSupportStore();
@@ -113,6 +123,7 @@ const ALL_COLUMNS = [
 	{ label: "Subject", key: "subject", width: 3 },
 	{ label: "Ticket", key: "name", width: "9rem" },
 	{ label: "Status", key: "status", width: "8rem" },
+	{ label: "Priority", key: "priority", width: "7rem" },
 	{ label: "Updated", key: "modified", width: "8rem", align: "right" },
 ];
 
@@ -142,12 +153,23 @@ onUnmounted(() => {
 // hid Subject/Status/Updated so "Ticket" is the only column left, the mobile
 // drop must not remove it as well and render an empty grid.
 const userHiddenCols = useStorage("jarvis-cols-support", []);
+// Priority is self-activating: the control plane only began returning `priority`
+// after a later deploy, so until a row actually carries it we omit the column
+// rather than render an all-blank one that reads as broken. It lights up on its
+// own the moment the data arrives.
+const hasPriority = computed(() => store.tickets.some((t) => t.priority));
+// Secondary fixed-width columns shed below ~640px so Ticket+Status+Priority+Updated
+// don't overflow a phone. Both `name` and `priority` are in the drop set.
+const NARROW_DROP = ["name", "priority"];
 const columns = computed(() => {
-	if (!isNarrow.value) return ALL_COLUMNS;
-	const otherVisible = ALL_COLUMNS.some(
-		(c) => c.key !== "name" && !userHiddenCols.value.includes(c.key)
+	const base = ALL_COLUMNS.filter((c) => c.key !== "priority" || hasPriority.value);
+	if (!isNarrow.value) return base;
+	// Guard against zero visible columns: if the user has already hidden everything
+	// except the drop-set columns, keep the full set rather than render an empty grid.
+	const survivors = base.filter(
+		(c) => !NARROW_DROP.includes(c.key) && !userHiddenCols.value.includes(c.key)
 	);
-	return otherVisible ? ALL_COLUMNS.filter((c) => c.key !== "name") : ALL_COLUMNS;
+	return survivors.length ? base.filter((c) => !NARROW_DROP.includes(c.key)) : base;
 });
 
 // Search rides the quick-filter strip as a text control, exactly as every other

--- a/frontend/src/pages/triggers/ActivityDetailDialog.vue
+++ b/frontend/src/pages/triggers/ActivityDetailDialog.vue
@@ -94,7 +94,7 @@
 					<div class="flex items-center justify-between py-2">
 						<span class="text-sm text-ink-gray-6">User</span>
 						<span class="truncate text-base text-ink-gray-8">{{
-							row.event_user || "-"
+							row.event_user || "System"
 						}}</span>
 					</div>
 					<div class="h-px bg-surface-gray-2" />

--- a/frontend/src/pages/triggers/ActivityTab.vue
+++ b/frontend/src/pages/triggers/ActivityTab.vue
@@ -101,6 +101,17 @@
 				<span v-else class="text-base text-ink-gray-4">-</span>
 			</template>
 
+			<template #cell-event_user="{ row }">
+				<!-- Blank actor = an automated / system-initiated event; show "System"
+				     (matches the detail dialog's User row) rather than an empty cell. -->
+				<div
+					class="truncate text-base text-ink-gray-7"
+					:title="row.event_user || 'System'"
+				>
+					{{ row.event_user || "System" }}
+				</div>
+			</template>
+
 			<template #cell-summary="{ row }">
 				<div class="truncate text-base text-ink-gray-7" :title="row.summary || undefined">
 					{{ row.summary || "-" }}
@@ -160,15 +171,29 @@ const ACTION_OPTIONS = [
 
 // Event gets 10.5rem so the longest label ("Before Save (blockable)") shows
 // its qualifier instead of clipping.
-const columns = [
+const BASE_COLUMNS = [
 	{ label: "Status", key: "status", width: "6rem" },
 	{ label: "Trigger", key: "trigger_label", width: 2 },
 	{ label: "Target", key: "target", width: 2 },
 	{ label: "Event", key: "doc_event", width: "10.5rem" },
 	{ label: "Action", key: "action_type", width: "5rem" },
+	// "User", not "By": matches the detail dialog's own KV label for this field
+	// and the all-nouns column convention.
+	{ label: "User", key: "event_user", width: "9rem" },
 	{ label: "Summary", key: "summary", width: 2 },
 	{ label: "When", key: "creation", width: "7rem" },
 ];
+// The actor also shows in the row's detail dialog, so below ~640px - where this
+// 8-column row would overflow - we shed the User column rather than force a
+// horizontal scroll (matchMedia mirrors SupportListPage's narrow-drop).
+const isNarrow = ref(false);
+let narrowMq = null;
+function onNarrowChange(e) {
+	isNarrow.value = e.matches;
+}
+const columns = computed(() =>
+	isNarrow.value ? BASE_COLUMNS.filter((c) => c.key !== "event_user") : BASE_COLUMNS
+);
 
 // search + the text-y filters ride the quick strip (FilterButton only builds
 // select/daterange rows); trigger id is filterable for the ?trigger= deep link.
@@ -299,9 +324,15 @@ function onEvent(p) {
 
 onMounted(() => {
 	socket && socket.on && socket.on("jarvis:event", onEvent);
+	if (typeof window !== "undefined" && window.matchMedia) {
+		narrowMq = window.matchMedia("(max-width: 640px)");
+		isNarrow.value = narrowMq.matches;
+		narrowMq.addEventListener("change", onNarrowChange);
+	}
 });
 onBeforeUnmount(() => {
 	socket && socket.off && socket.off("jarvis:event", onEvent);
 	clearTimeout(rtTimer);
+	if (narrowMq) narrowMq.removeEventListener("change", onNarrowChange);
 });
 </script>

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -50,6 +50,11 @@ export function badgeFor(status) {
 	return { label: "Open", theme: "gray", variant: "solid" };
 }
 
+// priorityBadge lives in the dependency-free supportBadges module so it stays
+// unit-testable (importing this store drags in frappe-ui + @/api); re-exported
+// here so `from "@/stores/support"` keeps resolving it.
+export { priorityBadge } from "./supportBadges";
+
 const tickets = ref([]);
 const ticketsLoading = ref(false);
 const ticketsError = ref("");

--- a/frontend/src/stores/supportBadges.js
+++ b/frontend/src/stores/supportBadges.js
@@ -1,0 +1,17 @@
+// Pure, dependency-free support presentation helpers, split out of the support
+// store so they're unit-testable: importing the store itself drags in frappe-ui
+// and @/api, which the vitest harness can't resolve. Re-exported from
+// stores/support.js so existing `from "@/stores/support"` imports keep working.
+
+// Helpdesk ticket priorities are Urgent / High / Medium / Low. Restricted palette
+// (no blue/purple, matching the status badges): only the two that warrant
+// attention carry colour - Urgent (red) and High (orange) - so they draw the eye,
+// while Medium and Low stay quiet gray. A blank/unknown priority returns null so
+// the cell renders nothing: the Priority column is self-activating (it only
+// appears once a row actually carries the field), so an empty value is the normal
+// transitional state, not an error.
+const PRIORITY_THEME = { Urgent: "red", High: "orange", Medium: "gray", Low: "gray" };
+export function priorityBadge(priority) {
+	if (!priority) return null;
+	return { label: priority, theme: PRIORITY_THEME[priority] || "gray", variant: "subtle" };
+}

--- a/frontend/src/stores/supportBadges.spec.js
+++ b/frontend/src/stores/supportBadges.spec.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { priorityBadge } from "@/stores/supportBadges";
+
+describe("priorityBadge", () => {
+	it("colours only the attention priorities; Medium/Low stay quiet gray", () => {
+		expect(priorityBadge("Urgent")).toEqual({
+			label: "Urgent",
+			theme: "red",
+			variant: "subtle",
+		});
+		expect(priorityBadge("High")).toEqual({
+			label: "High",
+			theme: "orange",
+			variant: "subtle",
+		});
+		expect(priorityBadge("Medium")).toEqual({
+			label: "Medium",
+			theme: "gray",
+			variant: "subtle",
+		});
+		expect(priorityBadge("Low")).toEqual({ label: "Low", theme: "gray", variant: "subtle" });
+	});
+
+	it("returns null for a blank/absent priority so the self-activating column renders nothing", () => {
+		expect(priorityBadge("")).toBeNull();
+		expect(priorityBadge(null)).toBeNull();
+		expect(priorityBadge(undefined)).toBeNull();
+	});
+
+	it("falls back to gray for an unrecognised priority rather than throwing", () => {
+		expect(priorityBadge("Critical")).toEqual({
+			label: "Critical",
+			theme: "gray",
+			variant: "subtle",
+		});
+	});
+});

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -490,6 +490,9 @@ def get_agent_admin_overview() -> dict:
 			"owner",
 			"run_as_user",
 			"enabled",
+			"activation_state",
+			"installable",
+			"not_installable_reason",
 			"schedule_enabled",
 			"schedule_frequency",
 			"next_run_at",
@@ -508,6 +511,14 @@ def get_agent_admin_overview() -> dict:
 				# WHICH row it is here, rather than having to open raw Desk.
 				"run_as_user": i.run_as_user or None,
 				"enabled": int(i.enabled or 0),
+				# Promotion axis. Null legacy rows are Shadow everywhere in the backend
+				# (coalesced), so match that here rather than invent an "unknown" state.
+				"activation_state": i.activation_state or "shadow",
+				# Last-reconciled install state (a STORED flag refreshed on after_migrate
+				# by reconcile_installations — NOT a live re-evaluation). The SPA words
+				# the Blocked hint as "as last reconciled" so it never claims live truth.
+				"installable": int(i.installable or 0),
+				"not_installable_reason": i.not_installable_reason or None,
 				"schedule_enabled": int(i.schedule_enabled or 0),
 				"schedule_frequency": i.schedule_frequency,
 				"next_run_at": str(i.next_run_at) if i.next_run_at else None,

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -474,7 +474,7 @@ def list_macro_runs(status: str = "", macro: str = "", limit: int | str = 30, st
 		f"""
 		SELECT r.name, r.macro, COALESCE(m.macro_name, r.macro) AS macro_name,
 		       r.conversation, r.status, r.current_step, r.total_steps,
-		       r.`trigger` AS `trigger`, r.creation, r.started_at, r.finished_at, r.error,
+		       r.`trigger` AS `trigger`, r.creation, r.started_at, r.finished_at, r.error, r.run_mode,
 		       CASE WHEN r.started_at IS NOT NULL AND r.finished_at IS NOT NULL
 		            THEN TIMESTAMPDIFF(SECOND, r.started_at, r.finished_at)
 		       END AS duration_s


### PR DESCRIPTION
Doctype-by-doctype field-coverage pass on the customer chat SPA so important details are no longer missing from the customer's only window into these records. Additive and display-only; no schema or migrations.

Macro Run: a failed run now explains itself - hover the Status badge for the short error, click for a dialog with the full error, finish time and run mode (keyed on `error` presence, so user-cancelled stopped runs stay quiet). Backend list_macro_runs now returns run_mode.

Support: a self-activating Priority column - it appears only once the control plane returns `priority`, and drops on narrow screens. priorityBadge extracted to a pure, unit-tested supportBadges module.

Wiki: the detail dialog gains an "About: <ref>" Desk deep link (the list already shows Stale/Conflicting badges).

Agent Installation: the install table's Enabled column becomes a consolidated State column with precedence Blocked > Disabled > Live > Shadow; Blocked explains itself via a "last-reconciled" tooltip. Backend get_agent_admin_overview now returns activation_state, installable and not_installable_reason. The violet Shadow pill is extracted to ShadowChip.

Dashboards: the Visibility cell now shows the audience, viewer-aware ("just you" only for the viewer's own rows), aligned to the shared scope theme (Org=gray, Role=blue, User=green).

Trigger Activity: adds a droppable "User" column (event_user); system actors read as "System" in both the column and the detail dialog.

Follow-up (admin-v2 phase): the control plane returns `priority` on support.api.list_tickets so the Support column populates.


## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
