### PR TITLE
fix(chat): hide agent built-in tools from the activity view (backport #1071)

### DIFF
--- a/frontend/src/lib/activityTools.js
+++ b/frontend/src/lib/activityTools.js
@@ -1,0 +1,15 @@
+// Count only customer-facing (jarvis__*) tools, not the agent's internal built-ins
+// (read/exec/…), in both the live counter and the settled accordion so they never disagree.
+// tool_name differs by source: live events keep the jarvis__ prefix; persisted rows strip it
+// (call_tool), so there we key off I/O — a jarvis tool has args+result, a built-in doesn't.
+
+export function isCustomerFacingTool(toolName) {
+	return String(toolName || "").startsWith("jarvis__");
+}
+
+export function shouldHideActivityTool(m) {
+	if (!m || m.role !== "tool") return false;
+	const hasArgs = m.tool_args != null && m.tool_args !== "";
+	const hasResult = m.tool_result != null && m.tool_result !== "";
+	return !hasArgs && !hasResult;
+}

--- a/frontend/src/lib/activityTools.spec.js
+++ b/frontend/src/lib/activityTools.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { isCustomerFacingTool, shouldHideActivityTool } from "./activityTools.js";
+
+const row = (o) => ({ role: "tool", ...o });
+
+describe("isCustomerFacingTool (live event names — prefixed)", () => {
+	it("is true only for a jarvis__-prefixed name", () => {
+		expect(isCustomerFacingTool("jarvis__find_skills")).toBe(true);
+		expect(isCustomerFacingTool("jarvis__read_wiki")).toBe(true);
+	});
+
+	it("is false for built-ins and for missing names", () => {
+		for (const name of ["read", "exec", "bash", "canvas", "", null, undefined]) {
+			expect(isCustomerFacingTool(name)).toBe(false);
+		}
+	});
+});
+
+describe("shouldHideActivityTool (settled rows — keyed on I/O)", () => {
+	it("hides an internal built-in (no args, no result) — any status incl. failure", () => {
+		for (const tool_status of ["completed", "running", "error", "failed", null, undefined]) {
+			expect(shouldHideActivityTool(row({ tool_name: "read", tool_status }))).toBe(true);
+		}
+	});
+
+	it("keeps a jarvis tool that captured a result (persisted name has no prefix)", () => {
+		expect(
+			shouldHideActivityTool(row({ tool_name: "find_skills", tool_result: '{"ok":true}' }))
+		).toBe(false);
+		expect(
+			shouldHideActivityTool(row({ tool_name: "read_wiki", tool_args: '{"q":"x"}' }))
+		).toBe(false);
+	});
+
+	it("keeps any row that captured args OR result", () => {
+		expect(shouldHideActivityTool(row({ tool_name: "x", tool_args: '{"a":1}' }))).toBe(false);
+		expect(shouldHideActivityTool(row({ tool_name: "x", tool_result: "[]" }))).toBe(false);
+	});
+
+	it("treats empty-string args/result as no I/O (hidden)", () => {
+		expect(
+			shouldHideActivityTool(row({ tool_name: "read", tool_args: "", tool_result: "" }))
+		).toBe(true);
+	});
+
+	it("returns false for a non-tool row (only tool rows are filtered)", () => {
+		expect(shouldHideActivityTool({ role: "assistant", tool_name: "read" })).toBe(false);
+		expect(shouldHideActivityTool(null)).toBe(false);
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2021,7 +2021,8 @@
 								v-if="
 									!showActivityDetail ||
 									(waiting && !currentTool) ||
-									(!currentTool && statusPhase)
+									(!currentTool && statusPhase) ||
+									(!currentTool && !doneCount)
 								"
 								role="status"
 								aria-live="polite"
@@ -4177,6 +4178,7 @@ import FilePreview from "@/components/FilePreview.vue";
 import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
+import { shouldHideActivityTool, isCustomerFacingTool } from "@/lib/activityTools";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
 import { normaliseAction } from "@/lib/chatAction";
 import {
@@ -5116,13 +5118,22 @@ function onVisibilityChange() {
 	if (document.hidden) flushReveal();
 }
 const activeTools = ref([]); // [{ id, name, status }] for the in-flight run
+// Live COUNT + current-tool name exclude the agent's built-ins so the tally matches the
+// settled accordion (no 3→2 jump); raw activeTools still drives the "is working" gating.
+const visibleActiveTools = computed(() =>
+	activeTools.value.filter((t) => isCustomerFacingTool(t.name))
+);
 // Live activity shows ONE tool at a time: the most-recently-started tool that's
 // still running, plus a compact count of the ones already finished this turn.
 const currentTool = computed(
-	() => [...activeTools.value].reverse().find((t) => t.status === "running") || null
+	() => [...visibleActiveTools.value].reverse().find((t) => t.status === "running") || null
 );
-const doneCount = computed(() => activeTools.value.filter((t) => t.status !== "running").length);
-const failedCount = computed(() => activeTools.value.filter((t) => t.status === "error").length);
+const doneCount = computed(
+	() => visibleActiveTools.value.filter((t) => t.status !== "running").length
+);
+const failedCount = computed(
+	() => visibleActiveTools.value.filter((t) => t.status === "error").length
+);
 // ── Live status line ────────────────────────────────────────────────────────
 // Real progress instead of a blanket "Thinking…": phase transitions come from
 // the run's realtime events (run:start → tool:start/end → assistant:delta).
@@ -5569,8 +5580,8 @@ const activityByAssistant = computed(() => {
 			cur = m.name;
 			if (!map[cur]) map[cur] = [];
 		}
-		// action_outcome rows are receipt chips shown inline, not accordion tool calls.
-		else if (m.role === "tool" && cur && !m.action_outcome)
+		// action_outcome rows show inline as chips; no-I/O agent built-ins expand to nothing — skip both.
+		else if (m.role === "tool" && cur && !m.action_outcome && !shouldHideActivityTool(m))
 			(map[cur] || (map[cur] = [])).push(m);
 	}
 	return map;


### PR DESCRIPTION
Backport of #1071 to `version-15`.

Hides the agent's internal built-in tools (`read`/`exec`/…) from the chat "N tool calls" activity accordion — their receipts carry only name+status, so the card expands to nothing. Also keeps the live tool counter consistent with the settled accordion (no 3→2 jump when a built-in finishes). Frontend-only; a pure unit-tested predicate (`activityTools.js`) + a live-counter filter. See #1071 for full detail and the in-browser verification.
