### PR TITLE
feat(onboarding): collect billing State + Country for India Compliance

### DIFF
--- a/frontend/src/onboarding/indianStates.js
+++ b/frontend/src/onboarding/indianStates.js
@@ -1,0 +1,74 @@
+// The GST states/UTs, mirroring India Compliance's STATE_NUMBERS so the checkout
+// State picker offers exactly the values the books side (jarvis_billing) can map
+// to a place-of-supply code. Order follows the GST state-code sequence.
+//
+// State is a Select ONLY when Country is India (place of supply is the buyer's
+// state); for any other country it is a free-text region and India Compliance
+// treats the buyer as Overseas.
+
+export const INDIA = "India";
+
+export const INDIAN_STATES = [
+	"Jammu and Kashmir",
+	"Himachal Pradesh",
+	"Punjab",
+	"Chandigarh",
+	"Uttarakhand",
+	"Haryana",
+	"Delhi",
+	"Rajasthan",
+	"Uttar Pradesh",
+	"Bihar",
+	"Sikkim",
+	"Arunachal Pradesh",
+	"Nagaland",
+	"Manipur",
+	"Mizoram",
+	"Tripura",
+	"Meghalaya",
+	"Assam",
+	"West Bengal",
+	"Jharkhand",
+	"Odisha",
+	"Chhattisgarh",
+	"Madhya Pradesh",
+	"Gujarat",
+	"Dadra and Nagar Haveli and Daman and Diu",
+	"Maharashtra",
+	"Karnataka",
+	"Goa",
+	"Lakshadweep",
+	"Kerala",
+	"Tamil Nadu",
+	"Puducherry",
+	"Andaman and Nicobar Islands",
+	"Telangana",
+	"Andhra Pradesh",
+	"Ladakh",
+	"Other Territory",
+];
+
+const _STATE_SET = new Set(INDIAN_STATES.map((s) => s.toLowerCase()));
+
+// A short, curated country list — India first (the common case), then the
+// markets Jarvis sells into. "Other" lets a buyer name anything; the books side
+// only distinguishes India (domestic GST) from everything else (Overseas).
+export const COUNTRIES = [
+	"India",
+	"United States",
+	"United Kingdom",
+	"United Arab Emirates",
+	"Singapore",
+	"Australia",
+	"Canada",
+	"Germany",
+	"Other",
+];
+
+export function isIndia(country) {
+	return (country || "").trim().toLowerCase() === INDIA.toLowerCase();
+}
+
+export function isValidIndianState(state) {
+	return _STATE_SET.has((state || "").trim().toLowerCase());
+}

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -23,8 +23,19 @@
 
 import { reactive, ref, computed } from "vue";
 
-// The four Details-step inputs.
-export const BILLING_FIELDS = ["contact", "address", "city", "gstin"];
+// The Details-step billing inputs. State + Country drive India Compliance's place
+// of supply (State is a Select of Indian states when Country is India); the books
+// side maps them to a GST state code / Overseas.
+export const BILLING_FIELDS = [
+	"contact",
+	"address",
+	"address2",
+	"city",
+	"state",
+	"pincode",
+	"country",
+	"gstin",
+];
 
 // The two IDENTITY inputs (work email, company). They are not billing fields and
 // they carry no provenance, but they belong in the same snapshot for one blunt
@@ -43,7 +54,11 @@ export const IDENTITY_FIELDS = ["email", "company"];
 export const REQUEST_KEY = {
 	contact: "contact_number",
 	address: "address_line1",
+	address2: "address_line2",
 	city: "city",
+	state: "state",
+	pincode: "pincode",
+	country: "country",
 	gstin: "gstin",
 };
 
@@ -91,6 +106,8 @@ function fieldValuesFromDefaults(data) {
 		contact: (contact.phone || "").trim(),
 		address: (addr.address_line1 || "").trim(),
 		city: (addr.city || "").trim(),
+		state: (addr.state || "").trim(),
+		country: (addr.country || "").trim(),
 		gstin: (addr.gstin || "").trim(),
 	};
 }
@@ -103,6 +120,8 @@ function fieldValuesFromSummary(s) {
 		contact: (s.contact_number || "").trim(),
 		address: (s.address_line1 || "").trim(),
 		city: (s.city || "").trim(),
+		state: (s.state || "").trim(),
+		country: (s.country || "").trim(),
 		gstin: (s.gstin || "").trim(),
 	};
 }
@@ -125,7 +144,14 @@ export function useBillingDetails(opts = {}) {
 	const fields = reactive({
 		contact: { value: "", source: "empty", source_company: "", last_auto_value: "" },
 		address: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		address2: { value: "", source: "empty", source_company: "", last_auto_value: "" },
 		city: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		state: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		pincode: { value: "", source: "empty", source_company: "", last_auto_value: "" },
+		// Country defaults to India (this is an India-first GST product) so the value
+		// is actually captured, not just displayed — the field is required. Kept at
+		// source "empty" so an ERP company default or a resumed snapshot still wins.
+		country: { value: "India", source: "empty", source_company: "", last_auto_value: "" },
 		gstin: { value: "", source: "empty", source_company: "", last_auto_value: "" },
 	});
 
@@ -136,6 +162,34 @@ export function useBillingDetails(opts = {}) {
 	// deliberately dumb: last write wins, no provenance, because unlike the billing
 	// fields nothing auto-fills these behind the customer's back.
 	const identity = reactive({ email: "", company: "" });
+
+	// Invoicing Details: the party the GST invoice is raised to. Optional overrides — blank means
+	// the invoice falls back to the customer's own company (identity.company) + account email. Simple
+	// values (no ERP-default provenance), persisted + restored like identity so a checkout round
+	// trip keeps them.
+	const invoicing = reactive({ company_name: "", email: "" });
+	// The invoicing company name + email DEFAULT to the chosen company + work email and follow them,
+	// until the customer edits that invoicing field — then it is user-owned and stops auto-tracking.
+	let invoicingCompanyUserSet = false;
+	let invoicingEmailUserSet = false;
+	function setInvoicing(company_name, email) {
+		if (company_name !== undefined) {
+			invoicing.company_name = company_name == null ? "" : String(company_name);
+			invoicingCompanyUserSet = true;
+		}
+		if (email !== undefined) {
+			invoicing.email = email == null ? "" : String(email);
+			invoicingEmailUserSet = true;
+		}
+		persist();
+	}
+	// Mirror the company + work email into the invoicing party, unless the customer overrode them.
+	// The view calls this whenever the company / work email changes — INCLUDING the prefilled
+	// defaults on mount, which is why the default must live here and not in setIdentity.
+	function syncInvoicingDefaults(company, email) {
+		if (!invoicingCompanyUserSet) invoicing.company_name = (company || "").trim();
+		if (!invoicingEmailUserSet) invoicing.email = (email || "").trim();
+	}
 	// No contact-consent state here any more: the Details-step "okay to contact
 	// me" checkbox was folded into the required T&C acceptance on Review & Pay
 	// (owner decision 2026-08-14), so consent rides start_signup as a literal
@@ -243,10 +297,16 @@ export function useBillingDetails(opts = {}) {
 				JSON.stringify({
 					contact: fields.contact.value,
 					address: fields.address.value,
+					address2: fields.address2.value,
 					city: fields.city.value,
+					state: fields.state.value,
+					pincode: fields.pincode.value,
+					country: fields.country.value,
 					gstin: fields.gstin.value,
 					email: identity.email,
 					company: identity.company,
+					invoice_company_name: invoicing.company_name,
+					invoice_email: invoicing.email,
 					// Stamped on every write so restore() can bound how long this PII
 					// lives, whatever happens to the session that wrote it.
 					saved_at: now(),
@@ -304,6 +364,17 @@ export function useBillingDetails(opts = {}) {
 				identity[name] = v;
 				any = true;
 			}
+		}
+		// Invoicing overrides restore into whatever is still blank (like identity, no provenance).
+		if (d && d.invoice_company_name && !invoicing.company_name) {
+			invoicing.company_name = d.invoice_company_name;
+			invoicingCompanyUserSet = true; // a resumed value must not be clobbered by a company change
+			any = true;
+		}
+		if (d && d.invoice_email && !invoicing.email) {
+			invoicing.email = d.invoice_email;
+			invoicingEmailUserSet = true;
+			any = true;
 		}
 		// A `contact_consent` key from a snapshot written by an older build is
 		// simply ignored: the consent checkbox no longer exists (it lives inside
@@ -369,6 +440,16 @@ export function useBillingDetails(opts = {}) {
 				any = true;
 			}
 		}
+		if (summary.company_name) {
+			invoicing.company_name = String(summary.company_name);
+			invoicingCompanyUserSet = true; // server truth is authoritative; do not auto-track after
+			any = true;
+		}
+		if (summary.email) {
+			invoicing.email = String(summary.email);
+			invoicingEmailUserSet = true;
+			any = true;
+		}
 		if (summary.source_company) sourceCompany.value = String(summary.source_company);
 		if (summary.source_address) sourceAddress.value = String(summary.source_address);
 		if (any) {
@@ -392,6 +473,12 @@ export function useBillingDetails(opts = {}) {
 			if (name === "gstin") v = v.toUpperCase();
 			if (v) out[REQUEST_KEY[name]] = v;
 		}
+		// Invoicing Details party (admin's _normalize_billing maps company_name -> billing_company_name,
+		// email -> billing_email). Blank => omitted, so admin falls back to the customer's own company.
+		const invCompany = (invoicing.company_name || "").trim();
+		if (invCompany) out.company_name = invCompany;
+		const invEmail = (invoicing.email || "").trim();
+		if (invEmail) out.email = invEmail;
 		if (Object.keys(out).length) {
 			if (sourceCompany.value) out.source_company = sourceCompany.value;
 			if (sourceAddress.value) out.source_address = sourceAddress.value;
@@ -404,9 +491,15 @@ export function useBillingDetails(opts = {}) {
 	const reviewRows = computed(() => {
 		const b = buildBilling();
 		const labels = {
+			company_name: "Invoicing company",
+			email: "Invoicing email",
 			contact_number: "Contact",
 			address_line1: "Billing address",
+			address_line2: "Address line 2",
 			city: "City",
+			state: "State",
+			pincode: "Pincode",
+			country: "Country",
 			gstin: "GSTIN",
 		};
 		return Object.keys(labels)
@@ -422,6 +515,9 @@ export function useBillingDetails(opts = {}) {
 		fields,
 		identity,
 		setIdentity,
+		invoicing,
+		setInvoicing,
+		syncInvoicingDefaults,
 		finish,
 		billingSaved,
 		sourceCompany,

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -307,14 +307,88 @@ describe("Review & Pay card equals the normalized payload (P1-03)", () => {
 		expect(b.reviewRows.value.some((r) => r.key === "source_company")).toBe(false);
 	});
 
-	it("omits blank optional fields from both payload and card", () => {
+	it("omits blank optional fields from both payload and card (country defaults to India)", () => {
 		const b = useBillingDetails({ site: "s1", user: "u1" });
 		b.setUserValue("contact", "+91 90000 00000");
 		const payload = b.buildBilling();
-		expect(payload).toEqual({ contact_number: "+91 90000 00000" });
+		// Country is a required field defaulting to India, so it is always captured;
+		// every other untouched field is still omitted.
+		expect(payload).toEqual({ contact_number: "+91 90000 00000", country: "India" });
 		expect(b.reviewRows.value).toEqual([
 			{ key: "contact_number", label: "Contact", value: "+91 90000 00000" },
+			{ key: "country", label: "Country", value: "India" },
 		]);
+	});
+
+	it("defaults country to India so it is captured, not just displayed", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.fields.country.value).toBe("India");
+		// still source 'empty' so an ERP company default / resumed snapshot can win
+		expect(b.fields.country.source).toBe("empty");
+	});
+});
+
+describe("Invoicing Details party (billing_company_name / billing_email)", () => {
+	it("setInvoicing adds company_name + email to the payload; blanks are omitted", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("contact", "+91 90000 00000");
+		b.setInvoicing("Acme Invoicing Pvt Ltd", "invoices@acme.test");
+		const payload = b.buildBilling();
+		expect(payload.company_name).toBe("Acme Invoicing Pvt Ltd");
+		expect(payload.email).toBe("invoices@acme.test");
+		// no invoicing entered -> omitted (admin falls back to the customer's own company)
+		const b2 = useBillingDetails({ site: "s2", user: "u2" });
+		b2.setUserValue("contact", "+91 90000 00000");
+		expect(b2.buildBilling().company_name).toBeUndefined();
+		expect(b2.buildBilling().email).toBeUndefined();
+	});
+
+	it("persists + restores the invoicing party across a reload", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setInvoicing("Acme Invoicing Pvt Ltd", "invoices@acme.test");
+		const fresh = useBillingDetails({ site: "s1", user: "u1" });
+		fresh.restore();
+		expect(fresh.invoicing.company_name).toBe("Acme Invoicing Pvt Ltd");
+		expect(fresh.invoicing.email).toBe("invoices@acme.test");
+	});
+
+	it("hydrates the invoicing party from the server summary", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.hydrateServerSnapshot({ company_name: "Server Co", email: "server@acme.test" });
+		expect(b.invoicing.company_name).toBe("Server Co");
+		expect(b.invoicing.email).toBe("server@acme.test");
+	});
+
+	it("shows the invoicing party on the Review card", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setInvoicing("Acme Invoicing Pvt Ltd", "invoices@acme.test");
+		const rows = Object.fromEntries(b.reviewRows.value.map((r) => [r.key, r.value]));
+		expect(rows.company_name).toBe("Acme Invoicing Pvt Ltd");
+		expect(rows.email).toBe("invoices@acme.test");
+	});
+
+	it("defaults the invoicing party from the company + work email, follows them, until edited", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.syncInvoicingDefaults("Acme Pvt Ltd", "acct@acme.test");
+		expect(b.invoicing.company_name).toBe("Acme Pvt Ltd");
+		expect(b.invoicing.email).toBe("acct@acme.test");
+		b.syncInvoicingDefaults("Acme Holdings", "acct2@acme.test"); // follows changes
+		expect(b.invoicing.company_name).toBe("Acme Holdings");
+		expect(b.invoicing.email).toBe("acct2@acme.test");
+		// editing the invoicing company stops ITS tracking; the email keeps following
+		b.setInvoicing("Custom Co", undefined);
+		b.syncInvoicingDefaults("Acme Reborn", "acct3@acme.test");
+		expect(b.invoicing.company_name).toBe("Custom Co");
+		expect(b.invoicing.email).toBe("acct3@acme.test");
+	});
+
+	it("carries address line 2 + pincode in the payload", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("address2", "Level 4");
+		b.setUserValue("pincode", "600001");
+		const p = b.buildBilling();
+		expect(p.address_line2).toBe("Level 4");
+		expect(p.pincode).toBe("600001");
 	});
 });
 
@@ -395,5 +469,28 @@ describe("the snapshot has a bounded lifetime (retention)", () => {
 		window.localStorage.setItem(b.storageKey, JSON.stringify({ city: "Chennai" }));
 		expect(b.restore()).toBe(false);
 		expect(window.localStorage.getItem(b.storageKey)).toBeNull();
+	});
+});
+
+describe("state + country (India Compliance place of supply)", () => {
+	it("round-trips state and country through buildBilling under the contract keys", () => {
+		const b = useBillingDetails({ site: "sc1", user: "uc1" });
+		b.setUserValue("city", "Bengaluru");
+		b.setUserValue("state", "Karnataka");
+		b.setUserValue("country", "India");
+		const out = b.buildBilling();
+		expect(out.city).toBe("Bengaluru");
+		expect(out.state).toBe("Karnataka");
+		expect(out.country).toBe("India");
+	});
+
+	it("persists and restores state + country for the same site/user", () => {
+		const b1 = useBillingDetails({ site: "sc2", user: "uc2" });
+		b1.setUserValue("state", "Tamil Nadu");
+		b1.setUserValue("country", "India");
+		const b2 = useBillingDetails({ site: "sc2", user: "uc2" });
+		expect(b2.restore()).toBe(true);
+		expect(b2.fields.state.value).toBe("Tamil Nadu");
+		expect(b2.fields.country.value).toBe("India");
 	});
 });

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -87,6 +87,17 @@ function mountView() {
 	return mount(OnboardingView, { global: { stubs: STUBS } });
 }
 
+// Fill every billing field the Details step now REQUIRES (contact + address + city +
+// state + pincode) so onDetailsSubmit's validation gate passes and a test can reach
+// the behaviour it targets. Country auto-defaults to India, so it is left alone.
+function fillRequiredBilling(wrapper) {
+	wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+	wrapper.vm.billing.setUserValue("address", "12 MG Road");
+	wrapper.vm.billing.setUserValue("city", "Chennai");
+	wrapper.vm.billing.setUserValue("state", "Tamil Nadu");
+	wrapper.vm.billing.setUserValue("pincode", "600001");
+}
+
 beforeEach(() => {
 	window.matchMedia = (q) => ({
 		matches: false,
@@ -733,9 +744,9 @@ describe("Returning-customer forced reconnect gate", () => {
 		wrapper.vm.state.email = "back@corp.test";
 		wrapper.vm.state.company = company;
 		wrapper.vm.state.identityFromUser = typed; // typed => reconnectIdentity present
-		// Contact number is mandatory on Details now; fill it so onDetailsSubmit's
-		// gate doesn't block these reconnect-flow tests on an unrelated field.
-		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		// Fill every field Details now requires so onDetailsSubmit's gate doesn't
+		// block these reconnect-flow tests on an unrelated field.
+		fillRequiredBilling(wrapper);
 		// The required T&C checkbox now lives on Details too, but these tests are
 		// about the reconnect gate specifically, so tick it by default (a
 		// dedicated test below asserts the reconnect branch does NOT need it).
@@ -872,7 +883,7 @@ describe("Returning-customer forced reconnect gate", () => {
 		wrapper.vm.state.email = "back@corp.test";
 		wrapper.vm.state.company = "Corp";
 		wrapper.vm.state.identityFromUser = true;
-		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		fillRequiredBilling(wrapper);
 		wrapper.vm.state.termsAccepted = true;
 		await wrapper.vm.onDetailsSubmit();
 		await flushPromises();
@@ -988,7 +999,7 @@ describe("lead-capture + T&C (frozen contract)", () => {
 		wrapper.vm.state.email = "a@b.com";
 		wrapper.vm.state.company = "Acme";
 		wrapper.vm.state.identityFromUser = true;
-		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		fillRequiredBilling(wrapper);
 		wrapper.vm.state.termsAccepted = false;
 		await flushPromises();
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -318,9 +318,9 @@
 									<div
 										class="col-span-2 -mb-1 mt-2 text-base font-semibold text-ink-gray-9 first:mt-0"
 									>
-										Account
+										Company details
 									</div>
-									<div class="flex flex-col gap-1">
+									<div class="col-span-2 flex flex-col gap-1">
 										<FormControl
 											type="email"
 											variant="outline"
@@ -352,42 +352,6 @@
 										<ErrorMessage
 											id="jv-ob-email-err"
 											:message="detailsFieldErrors.email"
-										/>
-									</div>
-									<div class="flex flex-col gap-1">
-										<FormControl
-											type="tel"
-											variant="outline"
-											label="Contact number"
-											:model-value="billing.fields.contact.value"
-											@update:model-value="
-												(v) => {
-													billing.setUserValue('contact', v);
-													clearFieldErrorIfValid(
-														'contact',
-														contactError,
-														v
-													);
-												}
-											"
-											placeholder="+91 98765 43210"
-											autocomplete="tel"
-											required
-											aria-required="true"
-											:aria-invalid="
-												detailsFieldErrors.contact ? 'true' : undefined
-											"
-											:aria-describedby="
-												detailsFieldErrors.contact
-													? 'jv-ob-contact-err'
-													: undefined
-											"
-											@blur="touchContactField"
-											@keydown.enter="onDetailsSubmit"
-										/>
-										<ErrorMessage
-											id="jv-ob-contact-err"
-											:message="detailsFieldErrors.contact"
 										/>
 									</div>
 									<!-- No separate contact-consent checkbox here (owner decision
@@ -498,34 +462,289 @@
 									<div
 										class="col-span-2 mt-2 text-base font-semibold text-ink-gray-9"
 									>
-										Billing
+										Invoicing details
 									</div>
 									<FormControl
 										class="col-span-2"
 										type="text"
 										variant="outline"
-										label="Billing address (optional)"
-										:model-value="billing.fields.address.value"
+										label="Invoicing company name (optional)"
+										:model-value="billing.invoicing.company_name"
 										@update:model-value="
-											(v) => billing.setUserValue('address', v)
+											(v) => billing.setInvoicing(v, undefined)
 										"
-										placeholder="Street, area"
-										autocomplete="street-address"
+										placeholder="Defaults to your company name"
 										@keydown.enter="onDetailsSubmit"
 									/>
 									<FormControl
-										type="text"
+										type="email"
 										variant="outline"
-										label="City (optional)"
-										:model-value="billing.fields.city.value"
+										label="Invoicing email (optional)"
+										:model-value="billing.invoicing.email"
 										@update:model-value="
-											(v) => billing.setUserValue('city', v)
+											(v) => billing.setInvoicing(undefined, v)
 										"
-										placeholder="Chennai"
-										autocomplete="address-level2"
+										:placeholder="state.email || 'billing@company.com'"
+										autocomplete="email"
 										@keydown.enter="onDetailsSubmit"
 									/>
 									<div class="flex flex-col gap-1">
+										<FormControl
+											type="tel"
+											variant="outline"
+											label="Contact number"
+											:model-value="billing.fields.contact.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('contact', v);
+													clearFieldErrorIfValid(
+														'contact',
+														contactError,
+														v
+													);
+												}
+											"
+											placeholder="+91 98765 43210"
+											autocomplete="tel"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.contact ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.contact
+													? 'jv-ob-contact-err'
+													: undefined
+											"
+											@blur="touchContactField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage
+											id="jv-ob-contact-err"
+											:message="detailsFieldErrors.contact"
+										/>
+									</div>
+									<div class="col-span-2 flex flex-col gap-1">
+										<FormControl
+											type="text"
+											variant="outline"
+											label="Address line 1"
+											:model-value="billing.fields.address.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('address', v);
+													clearFieldErrorIfValid(
+														'address',
+														addressError,
+														v
+													);
+												}
+											"
+											placeholder="Street, area"
+											autocomplete="street-address"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.address ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.address
+													? 'jv-ob-address-err'
+													: undefined
+											"
+											@blur="touchAddressField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage
+											id="jv-ob-address-err"
+											:message="detailsFieldErrors.address"
+										/>
+									</div>
+									<FormControl
+										class="col-span-2"
+										type="text"
+										variant="outline"
+										label="Address line 2 (optional)"
+										:model-value="billing.fields.address2.value"
+										@update:model-value="
+											(v) => billing.setUserValue('address2', v)
+										"
+										placeholder="Landmark, area"
+										autocomplete="address-line2"
+										@keydown.enter="onDetailsSubmit"
+									/>
+									<div class="flex flex-col gap-1">
+										<FormControl
+											type="text"
+											variant="outline"
+											label="City/Town"
+											:model-value="billing.fields.city.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('city', v);
+													clearFieldErrorIfValid('city', cityError, v);
+												}
+											"
+											placeholder="Chennai"
+											autocomplete="address-level2"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.city ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.city
+													? 'jv-ob-city-err'
+													: undefined
+											"
+											@blur="touchCityField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage
+											id="jv-ob-city-err"
+											:message="detailsFieldErrors.city"
+										/>
+									</div>
+									<div class="flex flex-col gap-1">
+										<FormControl
+											type="text"
+											variant="outline"
+											label="Postal Code"
+											:model-value="billing.fields.pincode.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('pincode', v);
+													clearFieldErrorIfValid(
+														'pincode',
+														pincodeError,
+														v
+													);
+												}
+											"
+											placeholder="600001"
+											autocomplete="postal-code"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.pincode ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.pincode
+													? 'jv-ob-pincode-err'
+													: undefined
+											"
+											@blur="touchPincodeField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage
+											id="jv-ob-pincode-err"
+											:message="detailsFieldErrors.pincode"
+										/>
+									</div>
+									<div class="flex flex-col gap-1">
+										<FormControl
+											type="select"
+											variant="outline"
+											label="Country"
+											:options="countryOptions"
+											:model-value="billing.fields.country.value || 'India'"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('country', v);
+													clearFieldErrorIfValid(
+														'country',
+														countryError,
+														v
+													);
+													clearFieldErrorIfValid(
+														'state',
+														stateError,
+														billing.fields.state.value
+													);
+												}
+											"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.country ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.country
+													? 'jv-ob-country-err'
+													: undefined
+											"
+											@blur="touchCountryField"
+										/>
+										<ErrorMessage
+											id="jv-ob-country-err"
+											:message="detailsFieldErrors.country"
+										/>
+									</div>
+									<!-- State: place of supply for India Compliance. A Select of Indian
+										 states when the Country is India (required — it's the GST invoice's
+										 place of supply); a free-text region otherwise. -->
+									<div v-if="billingIsIndia" class="flex flex-col gap-1">
+										<FormControl
+											type="select"
+											variant="outline"
+											label="State"
+											:options="stateOptions"
+											:model-value="billing.fields.state.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('state', v);
+													clearFieldErrorIfValid('state', stateError, v);
+												}
+											"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.state ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.state
+													? 'jv-ob-state-err'
+													: undefined
+											"
+											@blur="touchStateField"
+										/>
+										<ErrorMessage
+											id="jv-ob-state-err"
+											:message="detailsFieldErrors.state"
+										/>
+									</div>
+									<div v-else class="flex flex-col gap-1">
+										<FormControl
+											type="text"
+											variant="outline"
+											label="State / Region"
+											:model-value="billing.fields.state.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('state', v);
+													clearFieldErrorIfValid('state', stateError, v);
+												}
+											"
+											placeholder="Region"
+											required
+											aria-required="true"
+											:aria-invalid="
+												detailsFieldErrors.state ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.state
+													? 'jv-ob-state-err'
+													: undefined
+											"
+											@blur="touchStateField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage
+											id="jv-ob-state-err"
+											:message="detailsFieldErrors.state"
+										/>
+									</div>
+									<div class="col-span-2 flex flex-col gap-1">
 										<FormControl
 											type="text"
 											variant="outline"
@@ -1968,6 +2187,7 @@ import { makeTelemetryReporter } from "@/onboarding/paymentTelemetry";
 import { readCookie } from "@/lib/user";
 import { useBillingDetails, billingEditAction } from "@/onboarding/useBillingDetails";
 import { gstinError, GSTIN_PLACEHOLDER } from "@/onboarding/gstin";
+import { INDIAN_STATES, COUNTRIES, isIndia, isValidIndianState } from "@/onboarding/indianStates";
 import { isExpectedCompanyDefaultsMiss } from "@/onboarding/companyDefaultsMiss";
 
 const router = useRouter();
@@ -2301,6 +2521,13 @@ watch(
 watch(
 	() => state.company,
 	() => scheduleCompanyDefaults()
+);
+// Default the Invoicing details party from the chosen company + work email — including the values
+// prefilled on mount. Fires on any state.company/state.email change; billing.restore() runs before
+// prefillAccount() in onMounted and marks a resumed invoicing value user-owned, so
+// syncInvoicingDefaults preserves a resume and stops mirroring once the customer edits the field.
+watch([() => state.company, () => state.email], ([company, email]) =>
+	billing.syncInvoicingDefaults(company, email)
 );
 const frameSub = computed(() => FRAME_SUBS[state.step] || "Set up your workspace");
 
@@ -2636,6 +2863,20 @@ function companyError(value) {
 function contactError(value) {
 	return (value || "").trim() ? "" : "Enter a contact number.";
 }
+function addressError(value) {
+	return (value || "").trim() ? "" : "Enter your billing address.";
+}
+function cityError(value) {
+	return (value || "").trim() ? "" : "Enter your city or town.";
+}
+function pincodeError(value) {
+	return (value || "").trim() ? "" : "Enter your postal code.";
+}
+// Country is always populated (defaults to India, no blank option), so this is
+// practically unreachable; kept for the required marker + a defensive gate.
+function countryError(value) {
+	return (value || "").trim() ? "" : "Select your country.";
+}
 // gstinError (gstin.js) already treats a blank value as "" (GSTIN is optional).
 // Required T&C checkbox (moved here from Review & Pay 2026-08-16): unlike the
 // other Details fields this isn't touched on blur (a checkbox has none worth
@@ -2653,7 +2894,40 @@ function termsError(value) {
 // no tie to what's wrong. Set all at once by onDetailsSubmit (every failure
 // shown together, not one submit per error); state.detailsErr stays reserved
 // for genuinely form-wide messages (see onPayClick's missing-details guard).
-const detailsFieldErrors = reactive({ email: "", company: "", contact: "", gstin: "", terms: "" });
+const detailsFieldErrors = reactive({
+	email: "",
+	company: "",
+	contact: "",
+	address: "",
+	city: "",
+	pincode: "",
+	country: "",
+	gstin: "",
+	state: "",
+	terms: "",
+});
+
+// Place of supply for India Compliance: State is a Select of Indian states when the
+// Country is India (the common case, so a blank Country reads as India), and it is
+// REQUIRED then because the GST invoice's place of supply is the buyer's state. For
+// any other country State is a free-text region and the books side treats the buyer
+// as Overseas (export → operator review in this phase).
+const countryOptions = COUNTRIES.map((c) => ({ label: c, value: c }));
+const stateOptions = [
+	{ label: "Select state…", value: "" },
+	...INDIAN_STATES.map((s) => ({ label: s, value: s })),
+];
+const billingIsIndia = computed(() => isIndia(billing.fields.country.value || "India"));
+function stateError(v) {
+	const s = (v || "").trim();
+	if (!billingIsIndia.value) return s ? "" : "Enter your state or region."; // non-India: free-text, required
+	if (!s) return "Select your state — it's the place of supply on your GST invoice.";
+	if (!isValidIndianState(s)) return "Select a valid Indian state.";
+	return "";
+}
+function touchStateField() {
+	detailsFieldErrors.state = stateError(billing.fields.state.value);
+}
 function touchEmailField() {
 	detailsFieldErrors.email = emailError(state.email);
 }
@@ -2662,6 +2936,18 @@ function touchCompanyField() {
 }
 function touchContactField() {
 	detailsFieldErrors.contact = contactError(billing.fields.contact.value);
+}
+function touchAddressField() {
+	detailsFieldErrors.address = addressError(billing.fields.address.value);
+}
+function touchCityField() {
+	detailsFieldErrors.city = cityError(billing.fields.city.value);
+}
+function touchPincodeField() {
+	detailsFieldErrors.pincode = pincodeError(billing.fields.pincode.value);
+}
+function touchCountryField() {
+	detailsFieldErrors.country = countryError(billing.fields.country.value || "India");
 }
 function touchGstinField() {
 	detailsFieldErrors.gstin = gstinError(billing.fields.gstin.value);
@@ -2725,12 +3011,22 @@ async function onDetailsSubmit() {
 	touchEmailField();
 	touchCompanyField();
 	touchContactField();
+	touchAddressField();
+	touchCityField();
+	touchPincodeField();
+	touchCountryField();
 	touchGstinField();
+	touchStateField();
 	if (
 		detailsFieldErrors.email ||
 		detailsFieldErrors.company ||
 		detailsFieldErrors.contact ||
-		detailsFieldErrors.gstin
+		detailsFieldErrors.address ||
+		detailsFieldErrors.city ||
+		detailsFieldErrors.pincode ||
+		detailsFieldErrors.country ||
+		detailsFieldErrors.gstin ||
+		detailsFieldErrors.state
 	)
 		return;
 	billing.persist();
@@ -5769,5 +6065,13 @@ onUnmounted(() => {
 	}
 	/* StepProgress.vue owns its own reduced-motion fallback for the
 	   indeterminate fill/segment pulse. */
+}
+
+/* frappe-ui's Select trigger is inline-flex, so it sizes to its content — Country
+   ("India") renders narrower than the paired State ("Select state…") and than the
+   text inputs. Force the details-form select triggers to fill their grid cell so
+   every paired field lines up at equal width. */
+.ob-details-form :deep(button[role="combobox"]) {
+	width: 100%;
 }
 </style>

--- a/jarvis/tests/fixtures/billing_contract/PROVENANCE.md
+++ b/jarvis/tests/fixtures/billing_contract/PROVENANCE.md
@@ -15,7 +15,7 @@ it, so the two repos cannot drift silently:
 | twin repo | `git@github.com:Aerele-RnD/jarvis-admin-v2.git` |
 | twin branch | `feat/plan01-billing-persistence` |
 | twin path | `jarvis_admin_v2/tests/billing/fixtures/billing_contract/billing_snapshot.json` |
-| sha256 | `c370ecf920f61212f2f3f2359f28fca375a8e417573daabb6f735d6d222e03a2` |
+| sha256 | `95b5460b850e45bc1c8c3de198f7ddd74d747daa541a0d3b6f16984d46c2ddc1` |
 
 The sha pin is what enforces byte-identity: `test_billing_contract.py`
 recomputes the sha of this file and fails on a mismatch, and the admin twin pins

--- a/jarvis/tests/fixtures/billing_contract/billing_snapshot.json
+++ b/jarvis/tests/fixtures/billing_contract/billing_snapshot.json
@@ -3,6 +3,8 @@
   "name": "billing_snapshot",
   "description": "Plan 01 billing-object contract, shared byte-for-byte by jarvis and jarvis-admin-v2. request_billing is the typed object the bench sends admin (start_signup -> admin_client.signup / resume_pending_signup / update_pending_billing). normalized_summary is the allowlisted snapshot admin returns (get_signup_payment_state.data.billing and update_pending_billing.data.billing) and keys are IDENTICAL to the request (admin stores each key on a Jarvis Customer field and reads it back out under the same key). ack is the C01-5 version-skew acknowledgement echoed only after a durable write.",
   "request_billing": {
+    "company_name": "Acme Invoicing Pvt Ltd",
+    "email": "invoices@acme.test",
     "contact_number": "+91 98765 43210",
     "address_line1": "12 MG Road",
     "address_line2": "Suite 4",
@@ -15,6 +17,8 @@
     "source_address": "Aerele-Billing"
   },
   "normalized_summary": {
+    "company_name": "Acme Invoicing Pvt Ltd",
+    "email": "invoices@acme.test",
     "contact_number": "+91 98765 43210",
     "address_line1": "12 MG Road",
     "address_line2": "Suite 4",

--- a/jarvis/tests/test_billing_contract.py
+++ b/jarvis/tests/test_billing_contract.py
@@ -16,7 +16,7 @@ from jarvis import admin_client
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "billing_contract" / "billing_snapshot.json"
 # sha256 of the shared billing_snapshot.json; the admin twin pins the same value.
-_FIXTURE_SHA = "c370ecf920f61212f2f3f2359f28fca375a8e417573daabb6f735d6d222e03a2"
+_FIXTURE_SHA = "95b5460b850e45bc1c8c3de198f7ddd74d747daa541a0d3b6f16984d46c2ddc1"
 
 
 class TestBillingContract(FrappeTestCase):


### PR DESCRIPTION
## What
The onboarding **Details** step collected only address / city / GSTIN, so the books side (jarvis_billing + India Compliance) had **no place of supply** and REVIEWed every invoice. This adds **Country** + **State** to the billing form.

- **State** is a **Select of the 37 GST states/UTs** (mirroring India Compliance's `STATE_NUMBERS`) when **Country = India**, and is **required** — it's the invoice's place of supply. For any other country it's a **free-text region** and the books side treats the buyer as Overseas.
- `state` + `country` thread through the whole billing model (`BILLING_FIELDS` / `REQUEST_KEY` / ERP-default & summary mappers / persist / restore / review rows). The shared billing contract (`billing_snapshot.json`) **already carried both keys** — the form just wasn't sending them.
- New `indianStates.js` (GST states + a curated country list + `isIndia` / `isValidIndianState`).
- Required + valid-GST-state validation on submit.

## Testing
- Frontend spec: **+2** (state/country round-trip through `buildBilling`; persist/restore); full `useBillingDetails.spec.js` **29 green**; `npm run build` clean.
- **Browser flow (executed on the live onboarding form):** State renders as a Select of the GST states in code order; selection persists; Country toggles State to a free-text region for non-India and restores the Select on switching back; **no console errors**.

## Paired change
Backend GST-state validation (an India buyer's state must be a real GST state — fail closed at signup, not a silent books REVIEW) is in **jarvis_admin_v2** (`feat/invoice-integration`, commit `832e303`).

## Scope
Domestic (India) place-of-supply. Overseas remains operator-REVIEW (auto export invoicing is a documented fast-follow).