### PR TITLE
feat(agents): live step timeline for agent runs

### DIFF
--- a/frontend/src/api/agents.js
+++ b/frontend/src/api/agents.js
@@ -55,6 +55,13 @@ export const listAgentActivityPage = (p = {}) =>
 		page_length: p.page_length || 20,
 	});
 
+// One run's STEP TIMELINE, oldest first (jarvis#1062): what the bench observed
+// the run do - the launch dispatch, each jarvis__* tool the delegate called back
+// with, and the findings writeback. Steps carry shapes (DocType names, report
+// names, counts), never row contents. Ownership-gated server-side; a run the
+// caller cannot read returns an empty timeline. -> { steps: [...], count }
+export const listRunSteps = (run) => call(AG + "list_run_steps", { run });
+
 // Seed a new conversation from a finding and land the user in live chat.
 // -> { ok, conversation, run_id, reason }
 export const takeFindingToChat = (finding) => call(AG + "take_finding_to_chat", { finding });

--- a/frontend/src/pages/agents/FindingsPanel.spec.js
+++ b/frontend/src/pages/agents/FindingsPanel.spec.js
@@ -369,7 +369,7 @@ describe("C3b: a finished run keeps its timeline, collapsed", () => {
 		expect(apiAgents.listRunSteps.mock.calls.length).toBe(afterFlip);
 	});
 
-	it("shows an error step in the red tone", async () => {
+	it("shows an error step in the red tone, with the tool's message", async () => {
 		apiAgents.listRunSteps.mockResolvedValue({
 			steps: [
 				{
@@ -378,7 +378,7 @@ describe("C3b: a finished run keeps its timeline, collapsed", () => {
 					kind: "tool",
 					tool: "run_report",
 					label: "Ran report Trial Balance",
-					detail: "",
+					detail: "unknown Report: Trial Balance",
 					status: "error",
 					duration_ms: 40,
 					occurred_at: "2026-09-01 10:00:01",
@@ -393,6 +393,66 @@ describe("C3b: a finished run keeps its timeline, collapsed", () => {
 			.find((b) => b.text().includes("Steps (1)"))
 			.trigger("click");
 		expect(w.html()).toContain("text-ink-red-4");
+		// a bare red row explains nothing - the failure has to say what failed
+		expect(w.text()).toContain("unknown Report: Trial Balance");
+	});
+});
+
+describe("C3c: consecutive identical steps collapse into one row", () => {
+	function repeated(n, overrides = {}) {
+		return Array.from({ length: n }, (_, i) => ({
+			name: `R${i}`,
+			seq: i + 1,
+			kind: "tool",
+			tool: "get_list",
+			label: "Read Sales Invoice, 12 rows",
+			detail: "",
+			status: "ok",
+			duration_ms: 100,
+			occurred_at: `2026-09-01 10:00:0${i}`,
+			...overrides,
+		}));
+	}
+
+	it("folds a repeated read into a single row with an xN count", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: repeated(3), count: 3 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+
+		expect(w.text()).toContain("x3");
+		// one rendered row, but the header still reports every recorded step
+		expect(w.text().match(/Read Sales Invoice, 12 rows/g).length).toBe(1);
+		expect(w.text()).toContain("3 steps");
+	});
+
+	it("does not fold steps more than 5s apart", async () => {
+		const steps = repeated(2);
+		steps[1].occurred_at = "2026-09-01 10:00:30";
+		apiAgents.listRunSteps.mockResolvedValue({ steps, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+
+		expect(w.text()).not.toContain("x2");
+		expect(w.text().match(/Read Sales Invoice, 12 rows/g).length).toBe(2);
+	});
+
+	it("never folds a failure into a success", async () => {
+		const steps = repeated(2);
+		steps[1].status = "error";
+		steps[1].detail = "no permission to read Sales Invoice";
+		apiAgents.listRunSteps.mockResolvedValue({ steps, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+
+		expect(w.text()).not.toContain("x2");
+		expect(w.text()).toContain("no permission to read Sales Invoice");
+	});
+
+	it("marks only the last COLLAPSED row as current", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: repeated(3), count: 3 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(w.findAll(".badge").filter((b) => b.text() === "Now").length).toBe(1);
 	});
 });
 

--- a/frontend/src/pages/agents/FindingsPanel.spec.js
+++ b/frontend/src/pages/agents/FindingsPanel.spec.js
@@ -448,6 +448,29 @@ describe("C3c: consecutive identical steps collapse into one row", () => {
 		expect(w.text()).toContain("no permission to read Sales Invoice");
 	});
 
+	it("renders a measured 0ms rather than dropping it, but nothing for a missing one", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({
+			steps: [
+				{ ...STEPS[1], name: "Z1", duration_ms: 0, occurred_at: "2026-09-01 10:00:00" },
+				{
+					...STEPS[0],
+					name: "Z2",
+					label: "Dispatched to the agent",
+					duration_ms: null,
+					occurred_at: "2026-09-01 10:00:20",
+				},
+			],
+			count: 2,
+		});
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		// a step that finished inside the timer's resolution still reports a time
+		expect(w.text()).toContain("0ms");
+		// ...while a step that recorded none reports nothing at all
+		expect(w.text()).not.toContain("nullms");
+		expect(w.text()).not.toContain("NaN");
+	});
+
 	it("marks only the last COLLAPSED row as current", async () => {
 		apiAgents.listRunSteps.mockResolvedValue({ steps: repeated(3), count: 3 });
 		const w = mountPanel(baseRun({ status: "running" }));

--- a/frontend/src/pages/agents/FindingsPanel.spec.js
+++ b/frontend/src/pages/agents/FindingsPanel.spec.js
@@ -11,8 +11,9 @@ import { mount, flushPromises } from "@vue/test-utils";
  *   C2. A running run offers Stop -> stop_agent_run(run.name); success toasts
  *       and asks the parent (AgentRunsBoard) to refresh; failure toasts the
  *       error and leaves the run showing running.
- *   C3. A running run with no findings/pages yet shows a ticking elapsed-time
- *       label and the agent's recent activity, instead of a static sentence.
+ *   C3. A run shows its STEP TIMELINE - a ticking elapsed-time label plus the
+ *       steps the bench observed this run take (list_run_steps), polled every
+ *       5s while running and kept, collapsed, once it is over.
  */
 
 const api = vi.hoisted(() => ({
@@ -24,7 +25,7 @@ vi.mock("@/api", () => api);
 const apiAgents = vi.hoisted(() => ({
 	takeFindingToChat: vi.fn(),
 	stopAgentRun: vi.fn(),
-	listAgentActivityPage: vi.fn(),
+	listRunSteps: vi.fn(),
 }));
 vi.mock("@/api/agents", () => apiAgents);
 
@@ -110,6 +111,32 @@ function mountPanel(run) {
 	return mount(FindingsPanel, { props: { run } });
 }
 
+// list_run_steps rows: the launch dispatch plus one humanized tool call
+const STEPS = [
+	{
+		name: "S1",
+		seq: 1,
+		kind: "dispatched",
+		tool: "",
+		label: "Dispatched to the agent",
+		detail: "trigger: manual",
+		status: "ok",
+		duration_ms: null,
+		occurred_at: "2026-09-01 10:00:00",
+	},
+	{
+		name: "S2",
+		seq: 2,
+		kind: "tool",
+		tool: "get_list",
+		label: "Read Sales Invoice, 12 rows",
+		detail: "",
+		status: "ok",
+		duration_ms: 340,
+		occurred_at: "2026-09-01 10:00:04",
+	},
+];
+
 function setVisibility(state) {
 	Object.defineProperty(document, "visibilityState", {
 		value: state,
@@ -127,7 +154,7 @@ beforeEach(() => {
 		has_more: false,
 		severity_counts: {},
 	});
-	apiAgents.listAgentActivityPage.mockResolvedValue({ rows: [], total: 0, has_more: false });
+	apiAgents.listRunSteps.mockResolvedValue({ steps: [], count: 0 });
 });
 
 afterEach(() => {
@@ -199,7 +226,7 @@ describe("C2: Stop is reachable while running and idempotent-safe (no confirm)",
 	});
 });
 
-describe("C3: running-run progress - ticking elapsed time + recent activity", () => {
+describe("C3: the run step timeline - ticking elapsed time + observed steps", () => {
 	it("shows a ticking elapsed-time label instead of the static placeholder", async () => {
 		vi.useFakeTimers();
 		// setSystemTime only stamps Date.now() - only advanceTimersByTimeAsync
@@ -223,27 +250,29 @@ describe("C3: running-run progress - ticking elapsed time + recent activity", ()
 		expect(w.text()).toContain("01:05");
 	});
 
-	it("fetches and renders the agent's recent activity while running", async () => {
-		apiAgents.listAgentActivityPage.mockResolvedValue({
-			rows: [
-				{
-					name: "ACT-1",
-					action: "run_started",
-					detail: "",
-					creation: "2026-09-01 10:00:00",
-				},
-			],
-			total: 1,
-			has_more: false,
-		});
-		const w = mountPanel(baseRun({ status: "running" }));
+	it("fetches and renders THIS run's steps while it is running", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "running", name: "RUN-0042" }));
 		await flushPromises();
 
-		expect(apiAgents.listAgentActivityPage).toHaveBeenCalledWith({
-			agent: "close-auditor",
-			page_length: 5,
-		});
-		expect(w.text()).toContain("run started");
+		expect(apiAgents.listRunSteps).toHaveBeenCalledWith("RUN-0042");
+		expect(w.text()).toContain("Dispatched to the agent");
+		expect(w.text()).toContain("Read Sales Invoice, 12 rows");
+		expect(w.text()).toContain("2 steps");
+	});
+
+	it("marks the latest step as current while running, and only that one", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		const now = w.findAll(".badge").filter((b) => b.text() === "Now");
+		expect(now.length).toBe(1);
+	});
+
+	it("shows the empty state before the first step lands", async () => {
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(w.text()).toContain("Dispatched to the agent, waiting for the first step");
 	});
 
 	it("keeps the scribe placeholder wording distinct from the auditor one", async () => {
@@ -254,45 +283,116 @@ describe("C3: running-run progress - ticking elapsed time + recent activity", ()
 		expect(w.text()).toContain("pages appear here as they are written");
 	});
 
-	it("stops ticking after the component unmounts (no leaked interval)", async () => {
+	it("stops polling after the component unmounts (no leaked interval)", async () => {
 		vi.useFakeTimers();
 		const w = mountPanel(baseRun({ status: "running" }));
 		await flushPromises();
-		const callsBeforeUnmount = apiAgents.listAgentActivityPage.mock.calls.length;
+		const before = apiAgents.listRunSteps.mock.calls.length;
 		w.unmount();
 		await vi.advanceTimersByTimeAsync(30000);
 		await flushPromises();
-		expect(apiAgents.listAgentActivityPage.mock.calls.length).toBe(callsBeforeUnmount);
+		expect(apiAgents.listRunSteps.mock.calls.length).toBe(before);
 	});
 
-	it("does not show the running-progress block once findings exist", async () => {
+	it("keeps the timeline on screen once findings exist", async () => {
 		api.listAgentFindings.mockResolvedValue({
 			rows: [{ name: "F1", severity: "blocker", title: "x", state: "open" }],
 			total: 1,
 			has_more: false,
 			severity_counts: { blocker: 1 },
 		});
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
 		const w = mountPanel(baseRun({ status: "running" }));
 		await flushPromises();
-		expect(w.text()).not.toContain("Running for");
+		expect(w.text()).toContain("Running for");
+		expect(w.text()).toContain("Read Sales Invoice, 12 rows");
 	});
 
-	it("skips the 10s activity re-fetch while the tab is hidden, and resumes once visible", async () => {
+	it("skips the 5s re-fetch while the tab is hidden, and resumes once visible", async () => {
 		vi.useFakeTimers();
 		setVisibility("visible");
 		mountPanel(baseRun({ status: "running" }));
 		await flushPromises();
-		const callsAfterMount = apiAgents.listAgentActivityPage.mock.calls.length;
+		const callsAfterMount = apiAgents.listRunSteps.mock.calls.length;
 
 		setVisibility("hidden");
 		await vi.advanceTimersByTimeAsync(30000);
 		await flushPromises();
-		expect(apiAgents.listAgentActivityPage.mock.calls.length).toBe(callsAfterMount);
+		expect(apiAgents.listRunSteps.mock.calls.length).toBe(callsAfterMount);
 
 		setVisibility("visible");
-		await vi.advanceTimersByTimeAsync(10000);
+		await vi.advanceTimersByTimeAsync(5000);
 		await flushPromises();
-		expect(apiAgents.listAgentActivityPage.mock.calls.length).toBeGreaterThan(callsAfterMount);
+		expect(apiAgents.listRunSteps.mock.calls.length).toBeGreaterThan(callsAfterMount);
+	});
+});
+
+describe("C3b: a finished run keeps its timeline, collapsed", () => {
+	it("fetches steps once for a terminal run and does not poll", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		expect(apiAgents.listRunSteps).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders a collapsed Steps (N) disclosure that opens on click", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+
+		expect(w.text()).toContain("Steps (2)");
+		expect(w.text()).not.toContain("Read Sales Invoice, 12 rows");
+
+		const disclosure = w.findAll("button").find((b) => b.text().includes("Steps (2)"));
+		await disclosure.trigger("click");
+		expect(w.text()).toContain("Read Sales Invoice, 12 rows");
+	});
+
+	it("re-fetches once on the flip from running to terminal, then stops", async () => {
+		vi.useFakeTimers();
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		const whileRunning = apiAgents.listRunSteps.mock.calls.length;
+
+		await w.setProps({ run: baseRun({ status: "completed" }) });
+		await flushPromises();
+		const afterFlip = apiAgents.listRunSteps.mock.calls.length;
+		expect(afterFlip).toBe(whileRunning + 1);
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps.mock.calls.length).toBe(afterFlip);
+	});
+
+	it("shows an error step in the red tone", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({
+			steps: [
+				{
+					name: "S1",
+					seq: 1,
+					kind: "tool",
+					tool: "run_report",
+					label: "Ran report Trial Balance",
+					detail: "",
+					status: "error",
+					duration_ms: 40,
+					occurred_at: "2026-09-01 10:00:01",
+				},
+			],
+			count: 1,
+		});
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		await w
+			.findAll("button")
+			.find((b) => b.text().includes("Steps (1)"))
+			.trigger("click");
+		expect(w.html()).toContain("text-ink-red-4");
 	});
 });
 

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -53,6 +53,13 @@
 			</template>
 		</div>
 
+		<!-- Step timeline (jarvis#1062): the run's own narration, full width and
+		     directly under the header so it reads as part of the run, not as a
+		     placeholder inside an empty findings list. Deliberately OUTSIDE the
+		     scribe/auditor branches - both natures take the same steps - and kept
+		     after the run finishes (collapsed) so a completed run is inspectable. -->
+		<RunStepTimeline :steps="steps" :status="run.status" :elapsed="elapsedLabel" />
+
 		<!-- Scribe run: a Custom App Learning agent writes wiki pages, not findings.
 		     Show the pages it wrote (with links) instead of a findings list, so a
 		     successful run reads as "N pages written", never a failure / "0 findings". -->
@@ -96,23 +103,10 @@
 					<FeatherIcon name="external-link" class="size-3.5 shrink-0 text-ink-gray-5" />
 				</a>
 			</div>
-			<div
-				v-else-if="run.status === 'running'"
-				class="mt-2 flex flex-col items-center gap-2 rounded-lg border border-dashed py-8 text-center"
-			>
-				<span class="text-sm text-ink-gray-6">Running for {{ elapsedLabel }}</span>
-				<span class="text-sm text-ink-gray-5"
-					>Run in progress - pages appear here as they are written.</span
-				>
-				<div
-					v-if="recentActivity.length"
-					class="mt-2 w-full max-w-sm divide-y overflow-hidden rounded-lg border text-left"
-				>
-					<div v-for="a in recentActivity" :key="a.name" class="px-3 py-2 text-sm">
-						<span class="text-ink-gray-8">{{ activityLabel(a) }}</span>
-						<span class="text-ink-gray-5"> · {{ timeAgo(a.creation) }}</span>
-					</div>
-				</div>
+			<!-- the running state is the timeline above; this line only says where
+			     the pages will land -->
+			<div v-else-if="run.status === 'running'" class="mt-2 py-6 text-sm text-ink-gray-5">
+				Wiki pages appear here as they are written.
 			</div>
 			<div v-else class="mt-2 py-6 text-sm text-ink-gray-5">
 				No wiki pages were written this run.
@@ -157,26 +151,13 @@
 			<div v-else-if="loadError && !rows.length" class="py-8 text-sm text-ink-red-4">
 				{{ loadError }}
 			</div>
-			<!-- running-run progress (#1062 C3): only while there is no findings
-			     snapshot yet - a running run that already recorded findings shows
-			     them normally below, same as before. -->
+			<!-- a running run with no snapshot yet: the timeline above carries the
+			     progress, so this only says where the findings will land -->
 			<div
 				v-else-if="!rows.length && run.status === 'running'"
-				class="flex flex-col items-center gap-2 rounded-lg border border-dashed py-8 text-center"
+				class="py-8 text-sm text-ink-gray-5"
 			>
-				<span class="text-sm text-ink-gray-6">Running for {{ elapsedLabel }}</span>
-				<span class="text-sm text-ink-gray-5"
-					>Run in progress - findings appear when it completes.</span
-				>
-				<div
-					v-if="recentActivity.length"
-					class="mt-2 w-full max-w-sm divide-y overflow-hidden rounded-lg border text-left"
-				>
-					<div v-for="a in recentActivity" :key="a.name" class="px-3 py-2 text-sm">
-						<span class="text-ink-gray-8">{{ activityLabel(a) }}</span>
-						<span class="text-ink-gray-5"> · {{ timeAgo(a.creation) }}</span>
-					</div>
-				</div>
+				Findings appear here when the run completes.
 			</div>
 			<div v-else-if="!rows.length" class="py-8 text-sm text-ink-gray-5">
 				{{ emptyText }}
@@ -345,10 +326,11 @@ import { useRouter } from "vue-router";
 import { Badge, Button, FeatherIcon, FormControl, Tooltip, toast } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import Banner from "@/components/Banner.vue";
+import RunStepTimeline from "./RunStepTimeline.vue";
 import { timeAgo, exactDate, formatDate, toLocalMs, fmtElapsed } from "@/utils/datetime";
 import { renderMarkdown } from "@/markdown";
 import * as api from "@/api";
-import { takeFindingToChat, stopAgentRun, listAgentActivityPage } from "@/api/agents";
+import { takeFindingToChat, stopAgentRun, listRunSteps } from "@/api/agents";
 import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
@@ -408,13 +390,17 @@ const chatBusy = ref("");
 const stopping = ref(false);
 const expanded = ref(new Set());
 
-// ── #1062 C3: running-run progress (deliberately downscoped - NO per-step
-// timeline). A ticking elapsed-time label + the agent's recent activity feed,
-// so a running run reads as "alive" instead of a static "in progress" line. ──
+// ── #1062: the per-run STEP TIMELINE. A ticking elapsed-time label plus the
+// steps the bench observed THIS run take (list_run_steps), so a running run
+// reads as alive and step-by-step instead of a static "in progress" line. The
+// steps outlive the run: a finished one keeps them behind a collapsed
+// disclosure, which is why they are fetched for a terminal run too. ──────────
 const nowTick = ref(Date.now());
-const recentActivity = ref([]);
+const steps = ref([]);
 let elapsedTimer = null;
-let activityTimer = null;
+let stepsTimer = null;
+
+const STEPS_POLL_MS = 5000;
 
 const elapsedLabel = computed(() => {
 	const startMs = props.run && toLocalMs(props.run.started_at);
@@ -422,53 +408,44 @@ const elapsedLabel = computed(() => {
 	return fmtElapsed((nowTick.value - startMs) / 1000);
 });
 
-// list_agent_activity_page filters by agent (slug) / installation, not by run
-// (jarvis#1062 code map) - these are this AGENT's recent lifecycle events, not
-// strictly this run's, so the label below says so rather than implying a
-// per-run timeline this deliberately does not build.
-async function loadRecentActivity() {
-	if (!props.run || !props.run.agent) return;
+// Monotonic request id, like the findings load: rapid rail clicks must not land
+// another run's steps on the pinned run.
+let stepsReqId = 0;
+async function loadSteps() {
+	if (!props.run || !props.run.name) return;
+	const id = ++stepsReqId;
 	try {
-		const res = await listAgentActivityPage({ agent: props.run.agent, page_length: 5 });
-		recentActivity.value = (res && res.rows) || [];
+		const res = await listRunSteps(props.run.name);
+		if (id !== stepsReqId) return;
+		steps.value = (res && res.steps) || [];
 	} catch {
-		// best-effort supplementary context - a failed fetch must not break the
-		// running-progress display, which still has the elapsed timer.
+		// Best-effort narration: a failed fetch leaves the last steps on screen and
+		// the elapsed timer ticking. It must never turn a healthy run into an error
+		// state - the findings load owns that.
 	}
 }
-function startRunningProgress() {
+function startStepsPoll() {
 	if (elapsedTimer) return; // already running
 	nowTick.value = Date.now();
 	elapsedTimer = setInterval(() => (nowTick.value = Date.now()), 1000);
-	loadRecentActivity();
-	// #1062 review fix: skip the fetch while the tab is hidden, mirroring the
-	// rows-poll guard in AgentRunsBoard.vue - a backgrounded tab should not
-	// burn a request every 10s here either.
-	activityTimer = setInterval(() => {
-		if (document.visibilityState === "visible") loadRecentActivity();
-	}, 10000);
+	loadSteps();
+	// Visibility-guarded, mirroring the rows poll in AgentRunsBoard.vue: a
+	// backgrounded tab must not burn a request every 5s.
+	stepsTimer = setInterval(() => {
+		if (document.visibilityState === "visible") loadSteps();
+	}, STEPS_POLL_MS);
 }
-function stopRunningProgress() {
+function stopStepsPoll() {
 	if (elapsedTimer) {
 		clearInterval(elapsedTimer);
 		elapsedTimer = null;
 	}
-	if (activityTimer) {
-		clearInterval(activityTimer);
-		activityTimer = null;
+	if (stepsTimer) {
+		clearInterval(stepsTimer);
+		stepsTimer = null;
 	}
 }
-onBeforeUnmount(stopRunningProgress);
-
-// short, human label for an activity row - no icon/verb catalog (that lives in
-// AgentActivityTab); this is a supplementary glance, not a second feed to keep
-// in sync with it.
-function activityLabel(a) {
-	if (a.detail) return a.detail;
-	return String(a.action || "activity")
-		.split("_")
-		.join(" ");
-}
+onBeforeUnmount(stopStepsPoll);
 
 const runLabel = computed(() =>
 	props.run && props.run.started_at ? timeAgo(props.run.started_at) : props.run.name
@@ -592,12 +569,24 @@ function loadMore() {
 // refresh and object identity alone must not re-fetch findings.
 watch(
 	[() => props.run && props.run.name, () => props.run && props.run.status],
-	([name, status], [prevName] = []) => {
-		// running-progress timers: independent of the findings reload below, and
-		// evaluated first so the state-filter early-return further down never
-		// skips it.
-		if (status === "running") startRunningProgress();
-		else stopRunningProgress();
+	([name, status], [prevName, prevStatus] = []) => {
+		// Step timeline: independent of the findings reload below, and evaluated
+		// first so the state-filter early-return further down never skips it.
+		if (name !== prevName) steps.value = [];
+		if (status === "running") {
+			// switching from one running run to another must re-arm the poll, not
+			// leave it pointed at the previous run's elapsed clock
+			if (name !== prevName) stopStepsPoll();
+			startStepsPoll();
+		} else {
+			stopStepsPoll();
+			// One last fetch on the flip to terminal: the closing writeback step
+			// lands in the same instant the status changes, so stopping the interval
+			// alone would leave the timeline permanently one step short. A run
+			// selected while already finished takes this branch too, which is what
+			// fills its collapsed "Steps (N)" disclosure.
+			if (name && (name !== prevName || prevStatus === "running")) loadSteps();
+		}
 		if (name !== prevName) {
 			rows.value = [];
 			total.value = 0;

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -327,6 +327,10 @@ import { Badge, Button, FeatherIcon, FormControl, Tooltip, toast } from "frappe-
 import JvSpinner from "@/components/JvSpinner.vue";
 import Banner from "@/components/Banner.vue";
 import RunStepTimeline from "./RunStepTimeline.vue";
+// Shared, not a local copy: this panel's header pill is one of the surfaces
+// @/lib/agentRunStatus exists to keep in step with the rail and the Activity
+// feed (jarvis#1062). A second table here is exactly the drift it prevents.
+import { STATUS_THEME } from "@/lib/agentRunStatus";
 import { timeAgo, exactDate, formatDate, toLocalMs, fmtElapsed } from "@/utils/datetime";
 import { renderMarkdown } from "@/markdown";
 import * as api from "@/api";
@@ -350,13 +354,6 @@ const emit = defineEmits(["stopped"]);
 
 const router = useRouter();
 
-const STATUS_THEME = {
-	running: "blue",
-	completed: "green",
-	partial: "orange",
-	failed: "red",
-	stopped: "gray",
-};
 const SEVERITY_THEME = { blocker: "red", warning: "orange", note: "gray" };
 const SEVERITY_ORDER = ["blocker", "warning", "note"];
 const SEVERITY_LABEL = { blocker: "Blockers", warning: "Warnings", note: "Notes" };

--- a/frontend/src/pages/agents/RunStepTimeline.vue
+++ b/frontend/src/pages/agents/RunStepTimeline.vue
@@ -28,7 +28,7 @@
 		     title line, muted detail, relative time on the right). -->
 		<div v-if="expanded" class="mt-2 divide-y overflow-hidden rounded-lg border">
 			<div
-				v-for="(s, i) in steps"
+				v-for="(s, i) in rows"
 				:key="s.name"
 				class="flex items-start gap-3 px-3 py-2.5"
 				:class="isCurrent(i) ? 'bg-surface-gray-1' : ''"
@@ -45,6 +45,9 @@
 							:class="s.status === 'error' ? 'text-ink-red-4' : 'text-ink-gray-8'"
 						>
 							{{ s.label }}
+						</span>
+						<span v-if="s.repeats > 1" class="text-sm text-ink-gray-5">
+							x{{ s.repeats }}
 						</span>
 						<Badge v-if="isCurrent(i)" variant="subtle" theme="blue" label="Now" />
 					</div>
@@ -81,9 +84,14 @@
 // marked "Now". Once it is terminal the whole thing collapses behind a
 // "Steps (N)" disclosure, so a finished run stays inspectable without the
 // timeline competing with its findings.
+//
+// Consecutive IDENTICAL steps fold into a single row with an "xN" count (see
+// COLLAPSE_WINDOW_MS): an agent that polls one read in a loop otherwise buries
+// every step that actually differs. The fold is presentation only - the bench
+// keeps one row per step, and the header count still reports them all.
 import { ref, computed } from "vue";
 import { Badge, FeatherIcon, Tooltip } from "frappe-ui";
-import { timeAgo, exactDate } from "@/utils/datetime";
+import { timeAgo, exactDate, toLocalMs } from "@/utils/datetime";
 
 const props = defineProps({
 	// rows from agents_api.list_run_steps: {name, seq, kind, tool, label,
@@ -108,16 +116,60 @@ const KIND_COLOR = {
 	writeback: "text-ink-green-3",
 };
 
+// An agent polling the same read in a loop produced eight identical rows in a
+// row on the bench, which buries the steps that actually differ. Consecutive
+// IDENTICAL rows within this window fold into one "x8". The identity includes
+// status and detail, not just tool+label, so a failure is never folded into a
+// success and an error's message is never dropped behind a repeat count. The DB
+// keeps every row; this is presentation only.
+const COLLAPSE_WINDOW_MS = 5000;
+
 const open = ref(false);
 
 const isRunning = computed(() => props.status === "running");
+
+// [{...lastStepOfTheGroup, name: firstName, repeats, duration_ms: summed}]
+const rows = computed(() => {
+	const out = [];
+	for (const s of props.steps) {
+		const prev = out[out.length - 1];
+		if (prev && sameStep(prev, s) && withinWindow(prev.last_at, s)) {
+			prev.repeats += 1;
+			prev.duration_ms = (Number(prev.duration_ms) || 0) + (Number(s.duration_ms) || 0);
+			prev.last_at = stepTime(s);
+			prev.occurred_at = s.occurred_at;
+			prev.creation = s.creation;
+			continue;
+		}
+		out.push({ ...s, repeats: 1, last_at: stepTime(s) });
+	}
+	return out;
+});
+
 const expanded = computed(() => props.steps.length > 0 && (isRunning.value || open.value));
 const countLabel = computed(() =>
 	props.steps.length === 1 ? "1 step" : `${props.steps.length} steps`
 );
 
+function sameStep(a, b) {
+	return (
+		(a.tool || "") === (b.tool || "") &&
+		(a.label || "") === (b.label || "") &&
+		(a.status || "") === (b.status || "") &&
+		(a.detail || "") === (b.detail || "")
+	);
+}
+// Unparseable timestamps must not silently glue unrelated rows together, so an
+// unknown gap is treated as outside the window.
+function withinWindow(prevAt, s) {
+	const a = toLocalMs(prevAt);
+	const b = toLocalMs(stepTime(s));
+	if (a == null || b == null) return false;
+	return b - a <= COLLAPSE_WINDOW_MS;
+}
+
 function isCurrent(index) {
-	return isRunning.value && index === props.steps.length - 1;
+	return isRunning.value && index === rows.value.length - 1;
 }
 function stepIcon(s) {
 	if (s.status === "error") return "x-circle";

--- a/frontend/src/pages/agents/RunStepTimeline.vue
+++ b/frontend/src/pages/agents/RunStepTimeline.vue
@@ -135,7 +135,7 @@ const rows = computed(() => {
 		const prev = out[out.length - 1];
 		if (prev && sameStep(prev, s) && withinWindow(prev.last_at, s)) {
 			prev.repeats += 1;
-			prev.duration_ms = (Number(prev.duration_ms) || 0) + (Number(s.duration_ms) || 0);
+			prev.duration_ms = sumDurations(prev.duration_ms, s.duration_ms);
 			prev.last_at = stepTime(s);
 			prev.occurred_at = s.occurred_at;
 			prev.creation = s.creation;
@@ -151,6 +151,12 @@ const countLabel = computed(() =>
 	props.steps.length === 1 ? "1 step" : `${props.steps.length} steps`
 );
 
+// Two steps that both recorded NO duration must stay "no duration", not become a
+// measured 0 - the same distinction durationLabel keeps.
+function sumDurations(a, b) {
+	if (a == null && b == null) return null;
+	return (Number(a) || 0) + (Number(b) || 0);
+}
 function sameStep(a, b) {
 	return (
 		(a.tool || "") === (b.tool || "") &&
@@ -184,9 +190,14 @@ function stepTime(s) {
 }
 // Sub-second steps are the common case, so ms below a second and one decimal
 // above it - never a bare "0s" that reads as "did not happen".
+//
+// A measured 0 is DATA (a step that completed inside the timer's resolution) and
+// renders "0ms"; only a missing duration renders nothing. Testing truthiness
+// conflated the two and silently dropped the fastest steps' timing.
 function durationLabel(s) {
+	if (s.duration_ms == null || s.duration_ms === "") return "";
 	const ms = Number(s.duration_ms);
-	if (!ms || isNaN(ms) || ms < 0) return "";
+	if (isNaN(ms) || ms < 0) return "";
 	return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 </script>

--- a/frontend/src/pages/agents/RunStepTimeline.vue
+++ b/frontend/src/pages/agents/RunStepTimeline.vue
@@ -1,0 +1,140 @@
+<template>
+	<div class="mt-4">
+		<!-- header: a live "Running for mm:ss" + status pill while the run is in
+		     flight; a plain disclosure once it is over, so a finished run can still
+		     be inspected without the timeline stealing the page. -->
+		<div v-if="isRunning" class="flex items-center gap-2">
+			<span class="text-base font-medium text-ink-gray-8">Running for {{ elapsed }}</span>
+			<Badge variant="subtle" theme="blue" :label="status" />
+			<span class="flex-1" />
+			<span class="text-sm text-ink-gray-5">{{ countLabel }}</span>
+		</div>
+		<button
+			v-else-if="steps.length"
+			type="button"
+			class="flex w-full items-center gap-2 text-left"
+			:aria-expanded="open"
+			@click="open = !open"
+		>
+			<FeatherIcon
+				name="chevron-right"
+				class="size-4 shrink-0 text-ink-gray-5 transition-all duration-300 ease-in-out"
+				:class="{ 'rotate-90': open }"
+			/>
+			<span class="text-base font-medium text-ink-gray-8">Steps ({{ steps.length }})</span>
+		</button>
+
+		<!-- the timeline itself: the same row shape as the Activity tab (icon disc,
+		     title line, muted detail, relative time on the right). -->
+		<div v-if="expanded" class="mt-2 divide-y overflow-hidden rounded-lg border">
+			<div
+				v-for="(s, i) in steps"
+				:key="s.name"
+				class="flex items-start gap-3 px-3 py-2.5"
+				:class="isCurrent(i) ? 'bg-surface-gray-1' : ''"
+			>
+				<div
+					class="grid size-8 shrink-0 place-items-center rounded-full bg-surface-gray-2"
+				>
+					<FeatherIcon :name="stepIcon(s)" class="size-4" :class="stepColor(s)" />
+				</div>
+				<div class="min-w-0 flex-1">
+					<div class="flex flex-wrap items-baseline gap-x-2">
+						<span
+							class="text-base font-medium"
+							:class="s.status === 'error' ? 'text-ink-red-4' : 'text-ink-gray-8'"
+						>
+							{{ s.label }}
+						</span>
+						<Badge v-if="isCurrent(i)" variant="subtle" theme="blue" label="Now" />
+					</div>
+					<div v-if="s.detail" class="mt-0.5 truncate text-sm text-ink-gray-6">
+						{{ s.detail }}
+					</div>
+				</div>
+				<div class="flex shrink-0 items-baseline gap-2 text-sm text-ink-gray-5">
+					<span v-if="durationLabel(s)">{{ durationLabel(s) }}</span>
+					<Tooltip :text="exactDate(stepTime(s))">
+						<span>{{ timeAgo(stepTime(s)) }}</span>
+					</Tooltip>
+				</div>
+			</div>
+		</div>
+
+		<!-- before the delegate's first tool call there is exactly one thing to say,
+		     and it is not "no steps": the bench dispatched the turn and is waiting. -->
+		<div v-else-if="isRunning" class="mt-2 py-6 text-sm text-ink-gray-5">
+			Dispatched to the agent, waiting for the first step.
+		</div>
+	</div>
+</template>
+
+<script setup>
+// RunStepTimeline - the live per-run step feed (jarvis#1062, child of #1058).
+// The bench records one Jarvis Agent Run Step per observable step of a run: the
+// launch dispatch, every jarvis__* tool the delegate called back with, and the
+// findings writeback. This renders them in the Activity tab's row language
+// (icon disc + title + muted detail + relative time) rather than a bespoke
+// widget, so the Runs pane and the Activity tab read as one product.
+//
+// While the run is in flight the list is always open and the newest step is
+// marked "Now". Once it is terminal the whole thing collapses behind a
+// "Steps (N)" disclosure, so a finished run stays inspectable without the
+// timeline competing with its findings.
+import { ref, computed } from "vue";
+import { Badge, FeatherIcon, Tooltip } from "frappe-ui";
+import { timeAgo, exactDate } from "@/utils/datetime";
+
+const props = defineProps({
+	// rows from agents_api.list_run_steps: {name, seq, kind, tool, label,
+	// detail, status, duration_ms, occurred_at, creation}
+	steps: { type: Array, default: () => [] },
+	// the run's status - drives running vs collapsed-disclosure presentation
+	status: { type: String, default: "" },
+	// the parent's ticking "mm:ss" label (one timer for the whole panel)
+	elapsed: { type: String, default: "" },
+});
+
+// per-kind Feather icon, from the set the Agents pages already use. An error
+// step overrides both icon and colour: a failed step must read as failed at a
+// glance, exactly as run_failed does on the Activity tab.
+const KIND_ICON = {
+	dispatched: "play",
+	tool: "search",
+	writeback: "check-circle",
+	note: "activity",
+};
+const KIND_COLOR = {
+	writeback: "text-ink-green-3",
+};
+
+const open = ref(false);
+
+const isRunning = computed(() => props.status === "running");
+const expanded = computed(() => props.steps.length > 0 && (isRunning.value || open.value));
+const countLabel = computed(() =>
+	props.steps.length === 1 ? "1 step" : `${props.steps.length} steps`
+);
+
+function isCurrent(index) {
+	return isRunning.value && index === props.steps.length - 1;
+}
+function stepIcon(s) {
+	if (s.status === "error") return "x-circle";
+	return KIND_ICON[s.kind] || "activity";
+}
+function stepColor(s) {
+	if (s.status === "error") return "text-ink-red-4";
+	return KIND_COLOR[s.kind] || "text-ink-gray-5";
+}
+function stepTime(s) {
+	return s.occurred_at || s.creation;
+}
+// Sub-second steps are the common case, so ms below a second and one decimal
+// above it - never a bare "0s" that reads as "did not happen".
+function durationLabel(s) {
+	const ms = Number(s.duration_ms);
+	if (!ms || isNaN(ms) || ms < 0) return "";
+	return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+</script>

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -190,7 +190,12 @@ def _dispatch_from_session(
 			# reach ANY registered tool the run-as user's Frappe roles permit. Fails
 			# closed: a run with no snapshot and no legacy marker is refused outright.
 			# Non-delegate sessions (ordinary chat) resolve to None and are untouched.
-			denial = _delegate_capability.tool_denial(session_key, tool)
+			# ONE run-row read per plugin tool call: the capability contract is
+			# resolved here and handed to both consumers - the gate below and the
+			# #1062 step timeline further down, which needs the run's name, owner and
+			# status. A non-delegate session resolves to None and both are no-ops.
+			cap = _delegate_capability.resolve(session_key)
+			denial = _delegate_capability.tool_denial(session_key, tool, cap=cap)
 			if denial:
 				code = CapabilityDeniedError.__name__
 				hint = _hint_for(code, "")
@@ -253,12 +258,13 @@ def _dispatch_from_session(
 			# Resolve the conversation for this session up front so the
 			# confirmation gate can bind a parked write to it.
 			conv = frappe.db.get_value("Jarvis Conversation", {"session_key": session_key}, "name")
-			# STEP TIMELINE (#1062): resolve the running agent run BEFORE the tool
-			# executes. record_agent_run flips the run off ``running`` from inside
-			# the tool, so a status-gated lookup afterwards would find nothing for
-			# the very call that finishes the run. An ordinary chat session resolves
-			# to None here and nothing below does anything.
-			step_run = agent_run_steps.running_run_for_session(session_key)
+			# STEP TIMELINE (#1062): the run to file this call's step against, taken
+			# from the contract resolved above - BEFORE the tool executes.
+			# record_agent_run flips the run off ``running`` from inside the tool, so
+			# reading its status afterwards would find nothing for the very call that
+			# finishes the run. An ordinary chat session yields None and nothing below
+			# does anything.
+			step_run = agent_run_steps.step_target(cap)
 			started_ms = time.monotonic()
 			try:
 				result = _run_tool(tool, parsed_args, conversation=conv)
@@ -363,6 +369,12 @@ def _record_tool_step(
 		label, detail = agent_run_steps.humanize_tool_call(tool, args, data if ok else None)
 		if not ok:
 			detail = agent_run_steps.error_detail(error_message) or detail
+		elif agent_run_steps.is_pending_confirmation(data):
+			# A gated write returns ok but was only PARKED - the confirmation card is
+			# still sitting in front of a human. Narrating it as done would claim a
+			# write that may never happen, which is the one lie a timeline must not
+			# tell.
+			label, detail = agent_run_steps.pending_confirmation_step(label)
 		agent_run_steps.record_step(
 			step_run.get("name"),
 			kind="tool",

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -262,7 +262,7 @@ def _dispatch_from_session(
 			started_ms = time.monotonic()
 			try:
 				result = _run_tool(tool, parsed_args, conversation=conv)
-			except Exception:
+			except Exception as exc:
 				# A tool that raised past _run_tool's envelope translation is a real
 				# fault; try to leave an honest step saying the attempt happened and
 				# failed. Strictly best-effort: on a true 500 Frappe's request handler
@@ -271,17 +271,31 @@ def _dispatch_from_session(
 				# the raising tool made. The step that MATTERS is the ok=False envelope
 				# path below, which is how a tool error normally arrives. The re-raise
 				# is untouched either way.
-				_record_tool_step(step_run, tool, parsed_args, None, ok=False, started_ms=started_ms)
+				_record_tool_step(
+					step_run,
+					tool,
+					parsed_args,
+					None,
+					ok=False,
+					started_ms=started_ms,
+					error_message=str(exc),
+				)
 				raise
 			# Recorded BEFORE the result budget trims the payload, so a step's row
 			# count is the count the tool actually returned, not the truncated one.
+			_ok = bool(isinstance(result, dict) and result.get("ok"))
 			_record_tool_step(
 				step_run,
 				tool,
 				parsed_args,
 				result.get("data") if isinstance(result, dict) else None,
-				ok=bool(isinstance(result, dict) and result.get("ok")),
+				ok=_ok,
 				started_ms=started_ms,
+				error_message=(
+					((result.get("error") or {}).get("message") or "")
+					if (not _ok and isinstance(result, dict))
+					else ""
+				),
 			)
 			# Agent-boundary model-facing size cap. ONLY on this (agent session)
 			# path - the dashboard builder/desk/external call_tool callers go through
@@ -318,13 +332,26 @@ def _dispatch_from_session(
 _SELF_NARRATING_TOOLS = frozenset({"record_agent_run"})
 
 
-def _record_tool_step(step_run, tool: str, args, data, *, ok: bool, started_ms: float) -> None:
+def _record_tool_step(
+	step_run,
+	tool: str,
+	args,
+	data,
+	*,
+	ok: bool,
+	started_ms: float,
+	error_message: str = "",
+) -> None:
 	"""Append one ``tool`` step to a delegate run's timeline (#1062).
 
 	``step_run`` is the ``{name, owner}`` resolved before dispatch, or None when
 	the caller is not a delegate - in which case this is a no-op, so ordinary
 	chat is untouched. Best-effort throughout: narrating a tool call must never
 	be able to fail it.
+
+	On a failure the label stays the humanized ACTION and ``error_message``
+	becomes the detail, so the timeline says both what was attempted and why it
+	did not work instead of leaving a bare red row the customer cannot act on.
 	"""
 	if not step_run:
 		return
@@ -334,6 +361,8 @@ def _record_tool_step(step_run, tool: str, args, data, *, ok: bool, started_ms: 
 		if agent_run_steps.bare_tool(tool) in _SELF_NARRATING_TOOLS:
 			return
 		label, detail = agent_run_steps.humanize_tool_call(tool, args, data if ok else None)
+		if not ok:
+			detail = agent_run_steps.error_detail(error_message) or detail
 		agent_run_steps.record_step(
 			step_run.get("name"),
 			kind="tool",

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -264,8 +264,13 @@ def _dispatch_from_session(
 				result = _run_tool(tool, parsed_args, conversation=conv)
 			except Exception:
 				# A tool that raised past _run_tool's envelope translation is a real
-				# fault; the run still deserves an honest step saying the attempt
-				# happened and failed. The re-raise is untouched.
+				# fault; try to leave an honest step saying the attempt happened and
+				# failed. Strictly best-effort: on a true 500 Frappe's request handler
+				# rolls the whole transaction back and takes this row with it, and
+				# committing here to save it would also flush whatever partial writes
+				# the raising tool made. The step that MATTERS is the ok=False envelope
+				# path below, which is how a tool error normally arrives. The re-raise
+				# is untouched either way.
 				_record_tool_step(step_run, tool, parsed_args, None, ok=False, started_ms=started_ms)
 				raise
 			# Recorded BEFORE the result budget trims the payload, so a step's row

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -168,6 +168,7 @@ def _dispatch_from_session(
 	"""
 	# impersonate is session-safe: a bare frappe.set_user in this HTTP path
 	# would gut the caller's cookie session sid + data and log them out.
+	from jarvis.chat import agent_run_steps
 	from jarvis.tools import _agent_run_ctx, _delegate_capability
 
 	# Expose the caller's session_key to the tool for this dispatch (the LLM
@@ -252,7 +253,31 @@ def _dispatch_from_session(
 			# Resolve the conversation for this session up front so the
 			# confirmation gate can bind a parked write to it.
 			conv = frappe.db.get_value("Jarvis Conversation", {"session_key": session_key}, "name")
-			result = _run_tool(tool, parsed_args, conversation=conv)
+			# STEP TIMELINE (#1062): resolve the running agent run BEFORE the tool
+			# executes. record_agent_run flips the run off ``running`` from inside
+			# the tool, so a status-gated lookup afterwards would find nothing for
+			# the very call that finishes the run. An ordinary chat session resolves
+			# to None here and nothing below does anything.
+			step_run = agent_run_steps.running_run_for_session(session_key)
+			started_ms = time.monotonic()
+			try:
+				result = _run_tool(tool, parsed_args, conversation=conv)
+			except Exception:
+				# A tool that raised past _run_tool's envelope translation is a real
+				# fault; the run still deserves an honest step saying the attempt
+				# happened and failed. The re-raise is untouched.
+				_record_tool_step(step_run, tool, parsed_args, None, ok=False, started_ms=started_ms)
+				raise
+			# Recorded BEFORE the result budget trims the payload, so a step's row
+			# count is the count the tool actually returned, not the truncated one.
+			_record_tool_step(
+				step_run,
+				tool,
+				parsed_args,
+				result.get("data") if isinstance(result, dict) else None,
+				ok=bool(isinstance(result, dict) and result.get("ok")),
+				started_ms=started_ms,
+			)
 			# Agent-boundary model-facing size cap. ONLY on this (agent session)
 			# path - the dashboard builder/desk/external call_tool callers go through
 			# _dispatch_current_user and are deliberately uncapped.
@@ -279,6 +304,48 @@ def _dispatch_from_session(
 		_agent_run_ctx.clear_session_key()
 		_agent_run_ctx.take_armed_by_macro()  # belt: never leak an armed marker across dispatches
 		_agent_run_ctx.take_armed_by_skill()  # belt: same for the approved-skill-run marker
+
+
+#: The findings writeback narrates ITSELF (``record_agent_run`` records a
+#: ``writeback`` step naming the finding count it actually persisted), so the
+#: generic per-tool hook below skips it rather than writing a second row for the
+#: same act.
+_SELF_NARRATING_TOOLS = frozenset({"record_agent_run"})
+
+
+def _record_tool_step(step_run, tool: str, args, data, *, ok: bool, started_ms: float) -> None:
+	"""Append one ``tool`` step to a delegate run's timeline (#1062).
+
+	``step_run`` is the ``{name, owner}`` resolved before dispatch, or None when
+	the caller is not a delegate - in which case this is a no-op, so ordinary
+	chat is untouched. Best-effort throughout: narrating a tool call must never
+	be able to fail it.
+	"""
+	if not step_run:
+		return
+	try:
+		from jarvis.chat import agent_run_steps
+
+		if agent_run_steps.bare_tool(tool) in _SELF_NARRATING_TOOLS:
+			return
+		label, detail = agent_run_steps.humanize_tool_call(tool, args, data if ok else None)
+		agent_run_steps.record_step(
+			step_run.get("name"),
+			kind="tool",
+			tool=tool,
+			label=label,
+			detail=detail,
+			status="ok" if ok else "error",
+			duration_ms=int((time.monotonic() - started_ms) * 1000),
+			owner=step_run.get("owner"),
+		)
+	except Exception:
+		try:
+			frappe.logger("jarvis.agents").warning(
+				f"run-step hook failed for tool {tool}: {frappe.get_traceback()}"
+			)
+		except Exception:
+			pass
 
 
 _STALE_PAIRING_DEDUPE_TTL_S = 3600

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -106,18 +106,24 @@ def record_step(
 ) -> str | None:
 	"""Append ONE step to ``run_name``'s timeline. Returns its name, or None.
 
-	``owner`` pins the row to the human who owns the run. It has to be passed
-	explicitly and applied AFTER the insert, exactly like
-	``agent_activity.log_activity``: every caller here runs impersonated as the
-	run-as user (the plugin dispatcher) or as the scheduler's Administrator, and
-	``insert()`` stamps ``owner = frappe.session.user`` - so without this the
-	owner-scoped (``if_owner``) timeline would be invisible to the very customer
-	it is for.
+	``owner`` pins the row to the human who owns the run, and is applied AFTER the
+	insert exactly like ``agent_activity.log_activity``. This is not optional
+	bookkeeping: ``Document.insert`` stamps ``owner = frappe.session.user``
+	UNCONDITIONALLY (``set_user_and_timestamp`` assigns it, it does not defer to a
+	pre-set value), and every caller here runs impersonated as the run-as user or
+	as the scheduler's Administrator. Left alone, the owner-scoped (``if_owner``)
+	timeline would be invisible to the very customer it is for.
+
+	Omit ``owner`` and it is resolved from the RUN row instead. A step belongs to
+	whoever owns the run, never to whoever happened to be executing - so the
+	fallback is the rule restated, not a guess, and no future caller can leak a
+	step to the session user by forgetting the argument.
 
 	NEVER raises: a failed narration is logged and swallowed."""
 	if not run_name:
 		return None
 	try:
+		owner = owner or run_owner(run_name)
 		doc = frappe.get_doc(
 			{
 				"doctype": STEP,

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -1,0 +1,249 @@
+"""The per-run STEP TIMELINE: what an agent run is doing, while it does it.
+
+``Jarvis Agent Activity`` records a run's LIFECYCLE (started / completed /
+failed) - four rows at most, and nothing at all between the launch and the
+finish. A delegate audit takes minutes, so the customer watching a running run
+saw a static "Run in progress" line and had to trust it.
+
+The bench can do better, because it already SEES every step: the delegate calls
+back into it for each ``jarvis__*`` tool over the run's own session bearer. This
+module turns those observations into one append-only ``Jarvis Agent Run Step``
+row apiece, plus the two the bench knows first-hand - the launch ``dispatched``
+and the findings ``writeback``.
+
+Three rules hold everywhere here:
+
+* **Best-effort.** :func:`record_step` never raises. A timeline is a narration of
+  the run; failing to narrate a step must never fail the step.
+* **Cheap.** One insert, no commit of its own. It rides on the caller's
+  transaction so a rolled-back tool call leaves no phantom step behind.
+* **Shapes, never contents.** A step names DocTypes, reports, references and
+  counts. It never carries a row's field values, so the timeline is safe to show
+  to anyone permitted to read the run.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+STEP = "Jarvis Agent Run Step"
+RUN = "Jarvis Agent Run"
+
+#: Hard caps mirroring the DocType (``label`` is a Data(140); ``detail`` is a
+#: Small Text we keep short so the timeline row stays one glanceable line).
+LABEL_MAX = 140
+DETAIL_MAX = 500
+
+#: Tool names arrive from the agent registry as ``jarvis__get_list``; the bench
+#: dispatches the bare name. Both forms normalize to the bare one.
+_TOOL_PREFIX = "jarvis__"
+
+
+def _clip(value, limit: int) -> str:
+	text = str(value or "").strip()
+	return text[:limit]
+
+
+def bare_tool(tool) -> str:
+	"""``jarvis__get_list`` / ``get_list`` -> ``get_list``."""
+	name = str(tool or "").strip()
+	return name[len(_TOOL_PREFIX) :] if name.startswith(_TOOL_PREFIX) else name
+
+
+def _next_seq(run_name: str) -> int:
+	"""1-based position of the next step of ``run_name``.
+
+	MAX(seq)+1 rather than a row COUNT: a step is never deleted, but a count
+	would silently renumber from 1 if one ever were, and two rows sharing a seq
+	is exactly the ambiguity the column exists to remove. The gateway drives one
+	tool call at a time per run, so no lock is needed; ``list_run_steps`` orders
+	by ``seq, creation`` anyway so even a tie reads in insert order."""
+	try:
+		row = frappe.db.sql(
+			"select max(seq) from `tabJarvis Agent Run Step` where run = %s",
+			(run_name,),
+		)
+		current = (row and row[0] and row[0][0]) or 0
+		return int(current) + 1
+	except Exception:
+		return 1
+
+
+def record_step(
+	run_name: str,
+	*,
+	kind: str,
+	tool: str | None = None,
+	label: str,
+	detail: str | None = None,
+	status: str = "ok",
+	duration_ms: int | None = None,
+	owner: str | None = None,
+) -> str | None:
+	"""Append ONE step to ``run_name``'s timeline. Returns its name, or None.
+
+	``owner`` pins the row to the human who owns the run. It has to be passed
+	explicitly and applied AFTER the insert, exactly like
+	``agent_activity.log_activity``: every caller here runs impersonated as the
+	run-as user (the plugin dispatcher) or as the scheduler's Administrator, and
+	``insert()`` stamps ``owner = frappe.session.user`` - so without this the
+	owner-scoped (``if_owner``) timeline would be invisible to the very customer
+	it is for.
+
+	NEVER raises: a failed narration is logged and swallowed."""
+	if not run_name:
+		return None
+	try:
+		doc = frappe.get_doc(
+			{
+				"doctype": STEP,
+				"run": run_name,
+				"seq": _next_seq(run_name),
+				"kind": kind,
+				"tool": bare_tool(tool),
+				"label": _clip(label, LABEL_MAX) or kind,
+				"detail": _clip(detail, DETAIL_MAX),
+				"status": status if status in ("ok", "error") else "ok",
+				"duration_ms": int(duration_ms) if duration_ms is not None else None,
+				"occurred_at": frappe.utils.now(),
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		if owner and owner != doc.owner:
+			frappe.db.set_value(STEP, doc.name, "owner", owner, update_modified=False)
+		return doc.name
+	except Exception:
+		# The logger, not frappe.log_error: a step is decoration on a run that is
+		# working fine without it, and an Error Log row per missed narration would
+		# bury the surface where real run faults show up.
+		try:
+			frappe.logger("jarvis.agents").warning(
+				f"run-step not recorded for {run_name}: {frappe.get_traceback()}"
+			)
+		except Exception:
+			pass
+		return None
+
+
+def run_owner(run_name: str) -> str | None:
+	"""The human the run's rows belong to (the installation owner), for pinning a
+	step's owner from an impersonated context."""
+	try:
+		return frappe.db.get_value(RUN, run_name, "owner")
+	except Exception:
+		return None
+
+
+def running_run_for_session(session_key: str | None) -> dict | None:
+	"""``{name, owner}`` of the RUNNING agent run bound to ``session_key``, or None.
+
+	The same resolution ``record_agent_run`` uses: the run is found from the
+	CALLER's opaque session bearer, never from anything the model could author,
+	so a delegate can only ever narrate its own run. An ordinary chat session
+	resolves to None and the caller does nothing."""
+	key = (session_key or "").strip()
+	if not key:
+		return None
+	try:
+		return frappe.db.get_value(
+			RUN,
+			{"session_key": key, "status": "running"},
+			["name", "owner"],
+			as_dict=True,
+		)
+	except Exception:
+		return None
+
+
+# --------------------------------------------------------------------------- #
+# Humanizing a tool call
+# --------------------------------------------------------------------------- #
+def _n_rows(result) -> int | None:
+	"""Row count of a tool's data payload, when it has an obvious one."""
+	if isinstance(result, list):
+		return len(result)
+	if isinstance(result, dict):
+		for key in ("rows", "docs", "result"):
+			value = result.get(key)
+			if isinstance(value, list):
+				return len(value)
+		count = result.get("count")
+		if isinstance(count, int):
+			return count
+	return None
+
+
+def _plural(n: int, word: str) -> str:
+	return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
+def _title_case(tool: str) -> str:
+	"""``get_balance_on`` -> ``Get Balance On`` - the fallback label for a tool
+	with no bespoke phrasing. Readable, and it never invents a description of a
+	tool this module has not been taught."""
+	return " ".join(part.capitalize() for part in bare_tool(tool).split("_") if part) or "Step"
+
+
+def _query_doctype(args: dict) -> str:
+	"""The ``from`` DocType of a structured query spec (``query`` tool)."""
+	spec = args.get("spec")
+	if isinstance(spec, dict):
+		source = spec.get("from")
+		if isinstance(source, str):
+			return source
+	return ""
+
+
+def humanize_tool_call(tool, args, result) -> tuple[str, str]:
+	"""One short sentence describing a delegate tool call, plus an optional
+	second line. Returns ``(label, detail)``, both already clipped.
+
+	``args`` is the parsed argument dict the tool ran against; ``result`` is the
+	tool's DATA payload (the envelope's ``data``), or None when the call failed.
+
+	The copy is deliberately about SHAPES - the DocType read, the report run, how
+	many rows came back. It never quotes a value out of the payload, so a step is
+	as safe to render as the run itself."""
+	name = bare_tool(tool)
+	args = args if isinstance(args, dict) else {}
+	label = ""
+	detail = ""
+
+	if name == "get_list":
+		doctype = args.get("doctype") or "records"
+		n = _n_rows(result)
+		label = f"Read {doctype}" + (f", {_plural(n, 'row')}" if n is not None else "")
+	elif name == "get_doc":
+		doctype = args.get("doctype") or "document"
+		target = args.get("name")
+		if not target and isinstance(args.get("names"), list):
+			n = len(args["names"])
+			label = f"Read {doctype}, {_plural(n, 'document')}"
+		else:
+			label = f"Read {doctype} {target}".strip()
+	elif name == "run_report":
+		label = f"Ran report {args.get('report_name') or ''}".strip()
+		n = _n_rows(result)
+		if n is not None:
+			detail = _plural(n, "row")
+	elif name == "query":
+		doctype = _query_doctype(args)
+		label = f"Queried {doctype}".strip() if doctype else "Ran a query"
+		n = _n_rows(result)
+		if n is not None:
+			detail = _plural(n, "row")
+	elif name == "get_balance_on":
+		account = args.get("account") or args.get("party") or ""
+		label = f"Checked balance for {account}".strip() if account else "Checked a balance"
+	elif name == "record_agent_run":
+		n = _n_rows(args.get("findings"))
+		if n is None and isinstance(result, dict):
+			n = result.get("findings_count")
+		label = f"Recorded {_plural(int(n), 'finding')}" if isinstance(n, int) else "Recorded findings"
+	elif name == "save_agent_dashboard":
+		label = "Saved dashboard"
+	else:
+		label = _title_case(name)
+
+	return _clip(label, LABEL_MAX), _clip(detail, DETAIL_MAX)

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -38,6 +38,13 @@ DETAIL_MAX = 500
 #: enough to paste a traceback or a payload into the customer's view.
 ERROR_DETAIL_MAX = 300
 
+#: A parked write (``_run_tool`` returns ok with ``data.status ==
+#: "pending_confirmation"``) has not happened yet - a human still has to press
+#: the button. Narrating it as a completed action would be a lie, and the most
+#: consequential kind: the timeline would claim a write that may never occur.
+PENDING_CONFIRMATION_STATUS = "pending_confirmation"
+PENDING_CONFIRMATION_DETAIL = "waiting for a human to confirm"
+
 #: Bench-internal bookkeeping DocTypes an agent reads to orient itself before it
 #: touches any ERP data. Their real names are implementation vocabulary the
 #: customer has never seen and their row names are opaque hashes, so a step names
@@ -165,25 +172,24 @@ def run_owner(run_name: str) -> str | None:
 		return None
 
 
-def running_run_for_session(session_key: str | None) -> dict | None:
-	"""``{name, owner}`` of the RUNNING agent run bound to ``session_key``, or None.
+def step_target(cap) -> dict | None:
+	"""``{name, owner}`` of the run a step should be filed against, or None.
 
-	The same resolution ``record_agent_run`` uses: the run is found from the
-	CALLER's opaque session bearer, never from anything the model could author,
-	so a delegate can only ever narrate its own run. An ordinary chat session
-	resolves to None and the caller does nothing."""
-	key = (session_key or "").strip()
-	if not key:
+	``cap`` is the delegate capability contract ``_delegate_capability.resolve``
+	already produced for this dispatch - the run is resolved there from the
+	CALLER's opaque session bearer, never from anything the model could author, so
+	a delegate can only ever narrate its own run. Reusing that result is what keeps
+	a plugin tool call at ONE run-row read instead of two.
+
+	None (do nothing) for an ordinary chat session, and equally for a run that is
+	no longer ``running``: a bearer replayed after the run finished must not be
+	able to append to its history."""
+	if not isinstance(cap, dict):
 		return None
-	try:
-		return frappe.db.get_value(
-			RUN,
-			{"session_key": key, "status": "running"},
-			["name", "owner"],
-			as_dict=True,
-		)
-	except Exception:
+	if cap.get("status") != "running":
 		return None
+	name = cap.get("run")
+	return {"name": name, "owner": cap.get("owner")} if name else None
 
 
 # --------------------------------------------------------------------------- #
@@ -204,7 +210,10 @@ def _n_rows(result) -> int | None:
 	return None
 
 
-def _plural(n: int, word: str) -> str:
+def plural(n: int, word: str) -> str:
+	"""``1 finding`` / ``3 findings``. Public because the writeback step in
+	``jarvis.tools.record_agent_run`` builds its own label and must phrase a count
+	exactly the way every other step does."""
 	return f"{n} {word}" if n == 1 else f"{n} {word}s"
 
 
@@ -239,6 +248,19 @@ def _is_single(doctype: str) -> bool:
 		return False
 
 
+def is_pending_confirmation(data) -> bool:
+	"""True when a tool returned OK but only PARKED a gated write for a human."""
+	return isinstance(data, dict) and data.get("status") == PENDING_CONFIRMATION_STATUS
+
+
+def pending_confirmation_step(action: str) -> tuple[str, str]:
+	"""``(label, detail)`` for a parked write: it was proposed, not done."""
+	return (
+		_clip(f"Proposed {action}, awaiting confirmation", LABEL_MAX),
+		PENDING_CONFIRMATION_DETAIL,
+	)
+
+
 def error_detail(message) -> str:
 	"""The FIRST line of a tool's error message, clipped to
 	:data:`ERROR_DETAIL_MAX` - what failed, without a traceback or a payload."""
@@ -267,7 +289,13 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 
 	The copy is deliberately about SHAPES - the DocType read, the report run, how
 	many rows came back. It never quotes a value out of the payload, so a step is
-	as safe to render as the run itself."""
+	as safe to render as the run itself.
+
+	There is deliberately NO ``record_agent_run`` case: the writeback narrates
+	itself from inside the tool (only it knows how many findings survived
+	validation), and ``jarvis.api._SELF_NARRATING_TOOLS`` short-circuits before
+	reaching here, so a case for it could only ever be dead code that disagrees
+	with the row actually written."""
 	name = bare_tool(tool)
 	args = args if isinstance(args, dict) else {}
 	label = ""
@@ -282,9 +310,9 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			# the label as the plain sentence the customer reads.
 			label = internal
 			if n is not None:
-				detail = _plural(n, "row")
+				detail = plural(n, "row")
 		else:
-			label = f"Read {doctype}" + (f", {_plural(n, 'row')}" if n is not None else "")
+			label = f"Read {doctype}" + (f", {plural(n, 'row')}" if n is not None else "")
 	elif name == "get_doc":
 		doctype = args.get("doctype") or "document"
 		target = args.get("name")
@@ -297,9 +325,15 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			# Never the record name here either: an internal row's name is an opaque
 			# hash that means nothing to the customer and states nothing true.
 			label = internal
-		elif not target and isinstance(args.get("names"), list):
-			n = len(args["names"])
-			label = f"Read {doctype}, {_plural(n, 'document')}"
+		elif not target and isinstance(args.get("names"), list) and resolved:
+			# The REQUESTED count is a wish, not an outcome: a batch that asked for
+			# five and was permitted three must not read "Read ToDo, 5 documents".
+			# Prefer what actually came back; fall back to the request only when the
+			# payload exposes no count of its own.
+			n = _n_rows(result)
+			if n is None:
+				n = len(args["names"])
+			label = f"Read {doctype}, {plural(n, 'document')}"
 		elif _is_single(doctype):
 			# A Single's name IS its doctype - "Read Stock Settings", never twice.
 			label = f"Read {doctype}"
@@ -315,7 +349,7 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 		label = f"Ran report {args.get('report_name') or ''}".strip()
 		n = _n_rows(result)
 		if n is not None:
-			detail = _plural(n, "row")
+			detail = plural(n, "row")
 	elif name == "query":
 		doctype = _query_doctype(args)
 		internal = internal_doctype_label(doctype)
@@ -325,15 +359,10 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			label = f"Queried {doctype}".strip() if doctype else "Ran a query"
 		n = _n_rows(result)
 		if n is not None:
-			detail = _plural(n, "row")
+			detail = plural(n, "row")
 	elif name == "get_balance_on":
 		account = args.get("account") or args.get("party") or ""
 		label = f"Checked balance for {account}".strip() if account else "Checked a balance"
-	elif name == "record_agent_run":
-		n = _n_rows(args.get("findings"))
-		if n is None and isinstance(result, dict):
-			n = result.get("findings_count")
-		label = f"Recorded {_plural(int(n), 'finding')}" if isinstance(n, int) else "Recorded findings"
 	elif name == "save_agent_dashboard":
 		label = "Saved dashboard"
 	else:

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -33,6 +33,25 @@ RUN = "Jarvis Agent Run"
 #: Small Text we keep short so the timeline row stays one glanceable line).
 LABEL_MAX = 140
 DETAIL_MAX = 500
+#: A failed step carries the tool's own error message so the timeline explains
+#: what went wrong. First line only, and short: enough to name the fault, never
+#: enough to paste a traceback or a payload into the customer's view.
+ERROR_DETAIL_MAX = 300
+
+#: Bench-internal bookkeeping DocTypes an agent reads to orient itself before it
+#: touches any ERP data. Their real names are implementation vocabulary the
+#: customer has never seen and their row names are opaque hashes, so a step names
+#: the ACT instead of the record: "Read engagement configuration", never
+#: "Read Jarvis Agent Installation 8f3ac1...". Anything else under the same
+#: prefix is a doctype this map has not been taught, so it degrades to the
+#: honest generic rather than leaking a name.
+_INTERNAL_DOCTYPE_LABELS = {
+	"Jarvis Agent Installation": "Read engagement configuration",
+	"Jarvis Agent Listing": "Read agent definition",
+	"Jarvis Agent Run": "Checked run state",
+}
+_INTERNAL_DOCTYPE_PREFIX = "Jarvis Agent "
+_INTERNAL_DOCTYPE_FALLBACK = "Read agent metadata"
 
 #: Tool names arrive from the agent registry as ``jarvis__get_list``; the bench
 #: dispatches the bare name. Both forms normalize to the bare one.
@@ -53,11 +72,16 @@ def bare_tool(tool) -> str:
 def _next_seq(run_name: str) -> int:
 	"""1-based position of the next step of ``run_name``.
 
-	MAX(seq)+1 rather than a row COUNT: a step is never deleted, but a count
-	would silently renumber from 1 if one ever were, and two rows sharing a seq
-	is exactly the ambiguity the column exists to remove. The gateway drives one
-	tool call at a time per run, so no lock is needed; ``list_run_steps`` orders
-	by ``seq, creation`` anyway so even a tie reads in insert order."""
+	MAX(seq)+1 rather than a row COUNT, so a deleted row can never renumber the
+	rest. It is deliberately UNLOCKED and therefore best-effort: a delegate that
+	fires tool calls in parallel reads the same MAX in two requests and both
+	write the same seq (observed live on the bench - 2,2,2 then 3,3). Taking a
+	lock here would put a write barrier on the hot path of every plugin tool call
+	to order a decoration, which is the wrong trade.
+
+	So the stored ``seq`` is a hint, not the contract. ``list_run_steps`` orders
+	by ``occurred_at`` and RE-NUMBERS the response 1..n, which is what the UI
+	renders - duplicates in the column can never reach a customer."""
 	try:
 		row = frappe.db.sql(
 			"select max(seq) from `tabJarvis Agent Run Step` where run = %s",
@@ -185,6 +209,39 @@ def _title_case(tool: str) -> str:
 	return " ".join(part.capitalize() for part in bare_tool(tool).split("_") if part) or "Step"
 
 
+def internal_doctype_label(doctype) -> str | None:
+	"""The customer-facing phrasing for a read of a bench-internal DocType, or
+	None when it is ordinary ERP data the customer knows by name (and may see)."""
+	name = str(doctype or "").strip()
+	if not name:
+		return None
+	if name in _INTERNAL_DOCTYPE_LABELS:
+		return _INTERNAL_DOCTYPE_LABELS[name]
+	return _INTERNAL_DOCTYPE_FALLBACK if name.startswith(_INTERNAL_DOCTYPE_PREFIX) else None
+
+
+def _is_single(doctype: str) -> bool:
+	"""True for a Single DocType (Stock Settings, Selling Settings, ...).
+
+	A Single's document name IS its doctype, so ``get_doc("Stock Settings")``
+	rendered as "Read <doctype> <name>" reads "Read Stock Settings Stock
+	Settings". Metadata is cached, and an unknown/bogus doctype (exactly the
+	failed-lookup case) simply answers False."""
+	try:
+		return bool(frappe.get_meta(doctype).issingle)
+	except Exception:
+		return False
+
+
+def error_detail(message) -> str:
+	"""The FIRST line of a tool's error message, clipped to
+	:data:`ERROR_DETAIL_MAX` - what failed, without a traceback or a payload."""
+	text = str(message or "").strip()
+	if not text:
+		return ""
+	return text.splitlines()[0].strip()[:ERROR_DETAIL_MAX]
+
+
 def _query_doctype(args: dict) -> str:
 	"""The ``from`` DocType of a structured query spec (``query`` tool)."""
 	spec = args.get("spec")
@@ -213,15 +270,41 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 	if name == "get_list":
 		doctype = args.get("doctype") or "records"
 		n = _n_rows(result)
-		label = f"Read {doctype}" + (f", {_plural(n, 'row')}" if n is not None else "")
+		internal = internal_doctype_label(doctype)
+		if internal:
+			# The count is a shape, so it survives - but on the second line, leaving
+			# the label as the plain sentence the customer reads.
+			label = internal
+			if n is not None:
+				detail = _plural(n, "row")
+		else:
+			label = f"Read {doctype}" + (f", {_plural(n, 'row')}" if n is not None else "")
 	elif name == "get_doc":
 		doctype = args.get("doctype") or "document"
 		target = args.get("name")
-		if not target and isinstance(args.get("names"), list):
+		internal = internal_doctype_label(doctype)
+		# A record NAME is model-supplied: it is whatever the delegate guessed, and a
+		# wrong guess is exactly what produced "Read Company ignore" on the bench. So
+		# the name is only ever shown once the document actually came back.
+		resolved = isinstance(result, dict) and bool(result)
+		if internal:
+			# Never the record name here either: an internal row's name is an opaque
+			# hash that means nothing to the customer and states nothing true.
+			label = internal
+		elif not target and isinstance(args.get("names"), list):
 			n = len(args["names"])
 			label = f"Read {doctype}, {_plural(n, 'document')}"
+		elif _is_single(doctype):
+			# A Single's name IS its doctype - "Read Stock Settings", never twice.
+			label = f"Read {doctype}"
+		elif resolved and target:
+			label = f"Read {doctype} {target}"
+		elif resolved:
+			label = f"Read {doctype}"
 		else:
-			label = f"Read {doctype}" + (f" {target}" if target else "")
+			# The lookup did not resolve. Say what was attempted, not what was read;
+			# the error itself lands in `detail` (see the api.py step hook).
+			label = f"Looked up {doctype}"
 	elif name == "run_report":
 		label = f"Ran report {args.get('report_name') or ''}".strip()
 		n = _n_rows(result)
@@ -229,7 +312,11 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			detail = _plural(n, "row")
 	elif name == "query":
 		doctype = _query_doctype(args)
-		label = f"Queried {doctype}".strip() if doctype else "Ran a query"
+		internal = internal_doctype_label(doctype)
+		if internal:
+			label = internal
+		else:
+			label = f"Queried {doctype}".strip() if doctype else "Ran a query"
 		n = _n_rows(result)
 		if n is not None:
 			detail = _plural(n, "row")

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -221,7 +221,7 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			n = len(args["names"])
 			label = f"Read {doctype}, {_plural(n, 'document')}"
 		else:
-			label = f"Read {doctype} {target}".strip()
+			label = f"Read {doctype}" + (f" {target}" if target else "")
 	elif name == "run_report":
 		label = f"Ran report {args.get('report_name') or ''}".strip()
 		n = _n_rows(result)

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -325,6 +325,14 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			# Never the record name here either: an internal row's name is an opaque
 			# hash that means nothing to the customer and states nothing true.
 			label = internal
+		elif _is_single(doctype):
+			# Checked BEFORE names, mirroring get_doc's own precedence: the tool
+			# short-circuits a Single ahead of name/names, because its one document's
+			# name IS the doctype. So neither a stray name nor the empty names list a
+			# delegate sends when it has nothing sensible to put there changes what
+			# was read - and neither may be allowed to make this label say otherwise
+			# ("Read Stock Settings, 0 documents" was exactly that).
+			label = f"Read {doctype}" if resolved else f"Looked up {doctype}"
 		elif not target and isinstance(args.get("names"), list) and resolved:
 			# The REQUESTED count is a wish, not an outcome: a batch that asked for
 			# five and was permitted three must not read "Read ToDo, 5 documents".
@@ -334,9 +342,6 @@ def humanize_tool_call(tool, args, result) -> tuple[str, str]:
 			if n is None:
 				n = len(args["names"])
 			label = f"Read {doctype}, {plural(n, 'document')}"
-		elif _is_single(doctype):
-			# A Single's name IS its doctype - "Read Stock Settings", never twice.
-			label = f"Read {doctype}"
 		elif resolved and target:
 			label = f"Read {doctype} {target}"
 		elif resolved:

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -1224,6 +1224,22 @@ def _launch_audit(
 			# swaps which exception the caller re-raises.
 			frappe.throw(error_msg, title=_("Agent not applied"))
 		raise
+
+	# STEP TIMELINE (#1062): the run's first step, and the only one the bench
+	# writes before the delegate says anything. It is recorded only after the 202
+	# above - both failure branches raise before reaching here - so "Dispatched to
+	# the agent" on screen means the fleet really accepted the turn. Owner-pinned
+	# like every other row of this launch (the session is the run-as user by now).
+	from jarvis.chat.agent_run_steps import record_step
+
+	record_step(
+		run.name,
+		kind="dispatched",
+		label="Dispatched to the agent",
+		detail=f"trigger: {trigger}",
+		owner=owner,
+	)
+	frappe.db.commit()
 	return {"run": run.name, "conversation": conv.name, "session_key": session_key}
 
 

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -2181,9 +2181,15 @@ def list_run_steps(run: str) -> dict:
 
 	Gated exactly like :func:`list_findings`: the raw ``get_value`` below bypasses
 	permissions, so a run the caller neither owns nor administers returns an EMPTY
-	timeline - identical to an unknown run, never an existence oracle. Ordered by
-	``seq`` (creation is only the tiebreak: two steps can land inside the same
-	second and must still read in the order they happened)."""
+	timeline - identical to an unknown run, never an existence oracle.
+
+	Ordered by ``occurred_at`` (``creation`` breaks the tie), and the ``seq`` in
+	the RESPONSE is renumbered 1..n over that order. The stored ``seq`` is written
+	unlocked by ``record_step`` - a delegate firing tool calls in parallel reads
+	the same MAX(seq) twice and both rows land on the same number (observed live:
+	2,2,2 then 3,3). Putting a write barrier on the hot path of every plugin tool
+	call to order a decoration is the wrong trade, so the ordering contract lives
+	HERE instead, where it costs nothing and duplicates can never reach the UI."""
 	empty: dict = {"steps": [], "count": 0}
 	if not run:
 		return empty
@@ -2208,10 +2214,12 @@ def list_run_steps(run: str) -> dict:
 			"occurred_at",
 			"creation",
 		],
-		order_by="seq asc, creation asc",
+		order_by="occurred_at asc, creation asc",
 		limit_page_length=RUN_STEPS_CAP,
 		ignore_permissions=True,
 	)
+	for position, step in enumerate(steps, start=1):
+		step["seq"] = position
 	return {"steps": steps, "count": len(steps)}
 
 

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -32,6 +32,7 @@ from jarvis.permissions import (
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
+RUN_STEP = "Jarvis Agent Run Step"
 FINDING = "Jarvis Agent Finding"
 ACTIVITY = "Jarvis Agent Activity"
 DASHBOARD = "Jarvis Dashboard"
@@ -2159,6 +2160,59 @@ def list_findings(
 		"page_length": pl,
 		"severity_counts": severity_counts,
 	}
+
+
+#: Hard ceiling on one run's timeline. A run makes tens of tool calls, not
+#: hundreds; the cap exists so a pathological (or looping) run can never make the
+#: SPA's 5s poll expensive. The UI polls the whole list, so there is no cursor.
+RUN_STEPS_CAP = 200
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def list_run_steps(run: str) -> dict:
+	"""One run's STEP TIMELINE, oldest first: ``{steps, count}``.
+
+	Steps are what the bench OBSERVED the run do - the launch dispatch, each
+	``jarvis__*`` tool call the delegate made over its own session bearer, and the
+	findings writeback. They carry shapes, never row contents (see
+	``jarvis.chat.agent_run_steps``), so they are safe to render wherever the run
+	itself is.
+
+	Gated exactly like :func:`list_findings`: the raw ``get_value`` below bypasses
+	permissions, so a run the caller neither owns nor administers returns an EMPTY
+	timeline - identical to an unknown run, never an existence oracle. Ordered by
+	``seq`` (creation is only the tiebreak: two steps can land inside the same
+	second and must still read in the order they happened)."""
+	empty: dict = {"steps": [], "count": 0}
+	if not run:
+		return empty
+	me = frappe.session.user
+	run_row = frappe.db.get_value(RUN, run, ["name", "owner"], as_dict=True)
+	if not run_row:
+		return empty
+	if run_row.owner != me and not has_jarvis_admin_access(me):
+		return empty
+	steps = frappe.get_all(
+		RUN_STEP,
+		filters={"run": run_row.name},
+		fields=[
+			"name",
+			"seq",
+			"kind",
+			"tool",
+			"label",
+			"detail",
+			"status",
+			"duration_ms",
+			"occurred_at",
+			"creation",
+		],
+		order_by="seq asc, creation asc",
+		limit_page_length=RUN_STEPS_CAP,
+		ignore_permissions=True,
+	)
+	return {"steps": steps, "count": len(steps)}
 
 
 @frappe.whitelist()

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -541,6 +541,16 @@ NON_LIST_ENDPOINTS: dict[str, str] = {
 		"the edit-history feed of ONE wiki page — a per-document timeline, not a "
 		"collection (the chat equivalent of a form's version history)"
 	),
+	# jarvis#1062: the live step timeline of ONE agent run, rendered inside that
+	# run's own panel. The same shape as get_wiki_graph_history above — a
+	# per-document timeline read whole (capped at RUN_STEPS_CAP, ordered by the
+	# run's own `seq`), with no filter, sort or page contract to migrate. The
+	# browsable agent surfaces are the registered agent_runs / agent_findings /
+	# agent_activity views.
+	"jarvis.chat.agents_api.list_run_steps": (
+		"the step timeline of ONE agent run — a per-document timeline read whole, "
+		"not a filterable document-list view"
+	),
 	"jarvis.chat.triggers_api.activity_stats": (
 		"aggregate counters over Trigger Activity (a stats rollup), not a row "
 		"collection — the browsable feed is the registered trigger_activity view"

--- a/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.json
@@ -1,0 +1,113 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-09-02 09:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "run",
+  "seq",
+  "kind",
+  "tool",
+  "label",
+  "detail",
+  "status",
+  "duration_ms",
+  "occurred_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "run",
+   "fieldtype": "Data",
+   "label": "Run",
+   "search_index": 1,
+   "in_standard_filter": 1,
+   "description": "Run row name SNAPSHOT (Data, deliberately NOT a Link): the uninstall cascade hard-deletes installations, runs and findings, and this timeline must survive without LinkExistsError - exactly the rule Jarvis Agent Activity follows. Indexed: every read is 'the steps of ONE run'."
+  },
+  {
+   "fieldname": "seq",
+   "fieldtype": "Int",
+   "label": "Sequence",
+   "in_list_view": 1,
+   "description": "1-based position within the run. The timeline is ordered by this, not by creation - two steps recorded inside the same second must still read in the order they happened."
+  },
+  {
+   "fieldname": "kind",
+   "fieldtype": "Select",
+   "label": "Kind",
+   "options": "dispatched\ntool\nwriteback\nnote",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "tool",
+   "fieldtype": "Data",
+   "label": "Tool",
+   "description": "The bare bench tool name for a `tool` step (get_list, run_report, ...), blank for every other kind."
+  },
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "label": "Label",
+   "length": 140,
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "One short human sentence: what the agent did. DocType names, report names and counts only - never row contents."
+  },
+  {
+   "fieldname": "detail",
+   "fieldtype": "Small Text",
+   "label": "Detail",
+   "description": "Optional second line (capped server-side). Same rule as label: shapes and counts, never customer data."
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "ok\nerror",
+   "default": "ok",
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "duration_ms",
+   "fieldtype": "Int",
+   "label": "Duration (ms)"
+  },
+  {
+   "fieldname": "occurred_at",
+   "fieldtype": "Datetime",
+   "label": "Occurred At",
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-09-02 09:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Agent Run Step",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "if_owner": 1,
+   "read": 1,
+   "role": "Jarvis User"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "ASC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.py
@@ -1,0 +1,23 @@
+"""Jarvis Agent Run Step DocType controller.
+
+One append-only row per observable step of a ``Jarvis Agent Run``: the launch
+dispatch, every bench tool call the delegate made through the plugin endpoint,
+and the findings writeback. Together they are the run's live timeline - what the
+agent is doing right now, and what it did when the run is over.
+
+Like ``Jarvis Agent Activity``, every reference field is a Data SNAPSHOT and
+never a Link, so the uninstall cascade (which hard-deletes the installation, its
+runs and its findings) can never trip LinkExistsError here. Rows are
+server-generated, so ``Jarvis User`` gets ``if_owner`` READ only - the customer
+sees their own runs' steps and can neither forge nor edit one.
+
+Steps carry SHAPES, not data: DocType names, report names, counts. A step never
+records row contents, so the timeline is safe to render to anyone who may read
+the run.
+"""
+
+from frappe.model.document import Document
+
+
+class JarvisAgentRunStep(Document):
+	pass

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -261,6 +261,22 @@ class TestRecordStep(FrappeTestCase):
 		self.assertIsNone(agent_run_steps.step_target(None))
 		self.assertIsNone(agent_run_steps.step_target({}))
 
+	def test_step_target_tolerates_a_stubbed_contract(self):
+		"""Tests stub the dispatch path's collaborators wholesale. A stub must mean
+		"no step", never an exception out of the dispatcher."""
+		self.assertIsNone(agent_run_steps.step_target("conv1"))
+		self.assertIsNone(agent_run_steps.step_target(mock.MagicMock()))
+
+	def test_resolve_treats_a_wholesale_stubbed_get_value_as_a_non_delegate(self):
+		"""THE CI regression: test_api's budget cases patch frappe.db.get_value to
+		return ONE fixed string for every lookup on the dispatch path. That used to
+		be harmless because resolve only ran behind tool_denial, which those tests
+		also patch. It now runs directly, so a stubbed row must make the caller a
+		non-delegate instead of raising AttributeError out of the dispatcher."""
+		with mock.patch.object(frappe.db, "get_value", return_value="conv1"):
+			self.assertIsNone(_delegate_capability.resolve(self.key))
+			self.assertIsNone(_delegate_capability.tool_denial(self.key, "get_list"))
+
 
 # --------------------------------------------------------------------------- #
 # humanize_tool_call

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -430,6 +430,23 @@ class TestHumanizeToolCall(unittest.TestCase):
 		)
 		self.assertEqual(label, "Read System Settings")
 
+	def test_a_single_ignores_a_stray_name_or_an_empty_names_list(self):
+		"""get_doc short-circuits a Single AHEAD of name/names (#1062), because its
+		one document's name IS the doctype. A delegate with nothing sensible to put
+		there sends "" or [] - and the step must still read as the one document it
+		actually got, never "Read System Settings, 0 documents"."""
+		for args in (
+			{"doctype": "System Settings", "names": []},
+			{"doctype": "System Settings", "names": ["bogus", "also-bogus"]},
+			{"doctype": "System Settings", "name": "x"},
+		):
+			label, _ = agent_run_steps.humanize_tool_call("get_doc", args, {"name": "System Settings"})
+			self.assertEqual(label, "Read System Settings", args)
+
+	def test_a_single_that_did_not_resolve_claims_no_read(self):
+		label, _ = agent_run_steps.humanize_tool_call("get_doc", {"doctype": "System Settings"}, None)
+		self.assertEqual(label, "Looked up System Settings")
+
 	def test_an_unresolved_lookup_says_what_was_attempted(self):
 		"""The record name is MODEL-supplied. A wrong guess produced "Read Company
 		ignore" on the bench; an unresolved lookup must not claim a read at all."""

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -195,7 +195,7 @@ class TestRecordStep(FrappeTestCase):
 		_wipe(SLUG)
 		_mk_listing(SLUG)
 		self.key = f"agent:agent-{SLUG}:rs-run"
-		self.run = _mk_run(SLUG, self.owner, self.key)
+		self.run_name = _mk_run(SLUG, self.owner, self.key)
 
 	def tearDown(self):
 		_agent_run_ctx.clear_session_key()
@@ -205,35 +205,37 @@ class TestRecordStep(FrappeTestCase):
 
 	def test_steps_are_numbered_from_one_and_monotonic(self):
 		for label in ("first", "second", "third"):
-			agent_run_steps.record_step(self.run, kind="note", label=label)
-		self.assertEqual([s.seq for s in _steps(self.run)], [1, 2, 3])
-		self.assertEqual([s.label for s in _steps(self.run)], ["first", "second", "third"])
+			agent_run_steps.record_step(self.run_name, kind="note", label=label)
+		self.assertEqual([s.seq for s in _steps(self.run_name)], [1, 2, 3])
+		self.assertEqual([s.label for s in _steps(self.run_name)], ["first", "second", "third"])
 
 	def test_owner_is_pinned_to_the_run_owner_not_the_session_user(self):
 		"""The hook runs impersonated (the run-as user) or as the scheduler's
 		Administrator, so an unpinned row would be invisible on the owner-scoped
 		(if_owner) timeline it exists for."""
 		frappe.set_user("Administrator")
-		agent_run_steps.record_step(self.run, kind="note", label="pinned", owner=self.owner)
-		self.assertEqual(_steps(self.run)[0].owner, self.owner)
+		agent_run_steps.record_step(self.run_name, kind="note", label="pinned", owner=self.owner)
+		self.assertEqual(_steps(self.run_name)[0].owner, self.owner)
 
 	def test_owner_falls_back_to_the_run_owner_when_not_passed(self):
 		"""A caller that forgets ``owner`` must not leak the step to whoever is
 		executing. A step belongs to whoever owns the RUN, always."""
 		frappe.set_user("Administrator")
-		agent_run_steps.record_step(self.run, kind="note", label="no explicit owner")
-		self.assertEqual(_steps(self.run)[0].owner, self.owner)
+		agent_run_steps.record_step(self.run_name, kind="note", label="no explicit owner")
+		self.assertEqual(_steps(self.run_name)[0].owner, self.owner)
 
 	def test_label_and_detail_are_clipped(self):
-		agent_run_steps.record_step(self.run, kind="note", label="L" * 400, detail="D" * 900, status="error")
-		row = _steps(self.run)[0]
+		agent_run_steps.record_step(
+			self.run_name, kind="note", label="L" * 400, detail="D" * 900, status="error"
+		)
+		row = _steps(self.run_name)[0]
 		self.assertEqual(len(row.label), agent_run_steps.LABEL_MAX)
 		self.assertEqual(len(row.detail), agent_run_steps.DETAIL_MAX)
 		self.assertEqual(row.status, "error")
 
 	def test_an_unknown_status_falls_back_to_ok(self):
-		agent_run_steps.record_step(self.run, kind="note", label="x", status="weird")
-		self.assertEqual(_steps(self.run)[0].status, "ok")
+		agent_run_steps.record_step(self.run_name, kind="note", label="x", status="weird")
+		self.assertEqual(_steps(self.run_name)[0].status, "ok")
 
 	def test_a_missing_run_records_nothing_and_does_not_raise(self):
 		self.assertIsNone(agent_run_steps.record_step("", kind="note", label="orphan"))
@@ -241,19 +243,19 @@ class TestRecordStep(FrappeTestCase):
 	def test_a_failing_insert_is_swallowed(self):
 		"""Narration must never be able to fail the run it narrates."""
 		with mock.patch.object(frappe, "get_doc", side_effect=RuntimeError("db down")):
-			self.assertIsNone(agent_run_steps.record_step(self.run, kind="note", label="x"))
+			self.assertIsNone(agent_run_steps.record_step(self.run_name, kind="note", label="x"))
 
 	def test_step_target_reads_the_run_off_the_capability_contract(self):
 		"""The step's run comes from the contract the dispatcher already resolved -
 		that reuse is what keeps a tool call at one run-row read."""
 		cap = _delegate_capability.resolve(self.key)
 		got = agent_run_steps.step_target(cap)
-		self.assertEqual(got["name"], self.run)
+		self.assertEqual(got["name"], self.run_name)
 		self.assertEqual(got["owner"], self.owner)
 
 	def test_step_target_ignores_a_run_that_is_no_longer_running(self):
 		"""A bearer replayed after the run finished must not extend its history."""
-		frappe.db.set_value(RUN, self.run, "status", "completed", update_modified=False)
+		frappe.db.set_value(RUN, self.run_name, "status", "completed", update_modified=False)
 		self.assertIsNone(agent_run_steps.step_target(_delegate_capability.resolve(self.key)))
 
 	def test_step_target_of_a_non_delegate_is_none(self):
@@ -512,7 +514,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		_wipe(SLUG)
 		_mk_listing(SLUG)
 		self.key = f"agent:agent-{SLUG}:rs-dispatch"
-		self.run = _mk_run(SLUG, self.run_as, self.key)
+		self.run_name = _mk_run(SLUG, self.run_as, self.key)
 
 	def tearDown(self):
 		_agent_run_ctx.clear_session_key()
@@ -528,7 +530,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 	def test_a_delegate_tool_call_lands_one_step(self):
 		res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
 		self.assertTrue(res["ok"], res)
-		rows = _steps(self.run)
+		rows = _steps(self.run_name)
 		self.assertEqual(len(rows), 1, rows)
 		self.assertEqual(rows[0].kind, "tool")
 		self.assertEqual(rows[0].tool, "get_schema")
@@ -541,14 +543,14 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		almost all of the traffic on this endpoint."""
 		res = self._dispatch("chat-session-with-no-agent-run", "get_schema", {"doctype": "ToDo"})
 		self.assertTrue(res["ok"], res)
-		self.assertEqual(_steps(self.run), [])
+		self.assertEqual(_steps(self.run_name), [])
 
 	def test_a_terminal_run_records_nothing(self):
 		"""Only a RUNNING run has a timeline to extend; a bearer replayed after the
 		run finished must not append to its history."""
-		frappe.db.set_value(RUN, self.run, "status", "completed", update_modified=False)
+		frappe.db.set_value(RUN, self.run_name, "status", "completed", update_modified=False)
 		self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
-		self.assertEqual(_steps(self.run), [])
+		self.assertEqual(_steps(self.run_name), [])
 
 	def test_a_tool_error_envelope_leaves_an_error_step(self):
 		with mock.patch.object(
@@ -556,7 +558,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		):
 			res = self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
 		self.assertFalse(res["ok"], res)
-		rows = _steps(self.run)
+		rows = _steps(self.run_name)
 		self.assertEqual(len(rows), 1, rows)
 		self.assertEqual(rows[0].status, "error")
 		self.assertEqual(rows[0].label, "Read ToDo")
@@ -573,7 +575,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 			},
 		):
 			self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
-		row = _steps(self.run)[0]
+		row = _steps(self.run_name)[0]
 		self.assertEqual(row.label, "Read ToDo")
 		self.assertEqual(row.detail, "unknown Report: Foo")
 
@@ -584,7 +586,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 			return_value={"ok": False, "error": {"message": "boom\nTraceback: secret"}},
 		):
 			self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
-		self.assertEqual(_steps(self.run)[0].detail, "boom")
+		self.assertEqual(_steps(self.run_name)[0].detail, "boom")
 
 	def test_a_raising_tool_still_raises_and_still_leaves_an_error_step(self):
 		"""A fault past _run_tool's envelope translation is a real bug: it must
@@ -597,7 +599,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		with mock.patch.object(api, "_run_tool", side_effect=RuntimeError("boom")):
 			with self.assertRaises(RuntimeError):
 				self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
-		rows = _steps(self.run)
+		rows = _steps(self.run_name)
 		self.assertEqual(len(rows), 1, rows)
 		self.assertEqual(rows[0].status, "error")
 		self.assertEqual(rows[0].tool, "get_list")
@@ -608,7 +610,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		skip it rather than adding a second row for the same act."""
 		with mock.patch.object(api, "_run_tool", return_value={"ok": True, "data": {}}):
 			self._dispatch(self.key, "record_agent_run", {"findings": []})
-		self.assertEqual(_steps(self.run), [])
+		self.assertEqual(_steps(self.run_name), [])
 
 	def test_a_refused_tool_records_no_step(self):
 		"""A capability refusal never reaches dispatch, so there is no step to
@@ -616,7 +618,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		res = self._dispatch(self.key, "get_doc", {"doctype": "ToDo", "name": "nope"})
 		self.assertFalse(res["ok"], res)
 		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
-		self.assertEqual(_steps(self.run), [])
+		self.assertEqual(_steps(self.run_name), [])
 
 	def test_a_delegate_tool_call_reads_the_run_row_exactly_once(self):
 		"""The capability gate and the timeline both need the run row. They share
@@ -634,7 +636,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 			res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
 		self.assertTrue(res["ok"], res)
 		self.assertEqual(len(run_reads), 1, run_reads)
-		self.assertEqual(len(_steps(self.run)), 1)
+		self.assertEqual(len(_steps(self.run_name)), 1)
 
 	def test_an_ordinary_chat_session_costs_one_lookup_and_no_more(self):
 		"""The control: non-agent chat is almost all of this endpoint's traffic. It
@@ -664,7 +666,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		):
 			res = self._dispatch(self.key, "update_wiki", {"slug": "cash-flow"})
 		self.assertTrue(res["ok"], res)
-		row = _steps(self.run)[0]
+		row = _steps(self.run_name)[0]
 		self.assertEqual(row.kind, "tool")
 		self.assertEqual(row.status, "ok")
 		self.assertEqual(row.label, "Proposed Update Wiki, awaiting confirmation")
@@ -675,7 +677,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		record_agent_run writes its own step, phrased with the shared `plural`."""
 		from jarvis.tools import record_agent_run as rar
 
-		run_doc = frappe.get_doc(RUN, self.run)
+		run_doc = frappe.get_doc(RUN, self.run_name)
 		run_doc.findings_count = 3
 		run_doc.blocker_count = 0
 		with mock.patch("jarvis.chat.agent_runs.record_delegate_run", return_value=run_doc):
@@ -684,7 +686,7 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 				rar.record_agent_run(findings=[], coverage={})
 			finally:
 				_agent_run_ctx.clear_session_key()
-		rows = _steps(self.run)
+		rows = _steps(self.run_name)
 		self.assertEqual(len(rows), 1, rows)
 		self.assertEqual(rows[0].kind, "writeback")
 		self.assertEqual(rows[0].label, "Recorded 3 findings")
@@ -719,12 +721,12 @@ class TestListRunSteps(FrappeTestCase):
 		_wipe(SLUG)
 		_mk_listing(SLUG)
 		self.key = f"agent:agent-{SLUG}:rs-list"
-		self.run = _mk_run(SLUG, self.owner, self.key)
+		self.run_name = _mk_run(SLUG, self.owner, self.key)
 		agent_run_steps.record_step(
-			self.run, kind="dispatched", label="Dispatched to the agent", owner=self.owner
+			self.run_name, kind="dispatched", label="Dispatched to the agent", owner=self.owner
 		)
 		agent_run_steps.record_step(
-			self.run, kind="tool", tool="get_list", label="Read ToDo, 2 rows", owner=self.owner
+			self.run_name, kind="tool", tool="get_list", label="Read ToDo, 2 rows", owner=self.owner
 		)
 
 	def tearDown(self):
@@ -734,7 +736,7 @@ class TestListRunSteps(FrappeTestCase):
 
 	def test_the_owner_reads_their_timeline_in_sequence_order(self):
 		frappe.set_user(self.owner)
-		res = agents_api.list_run_steps(self.run)
+		res = agents_api.list_run_steps(self.run_name)
 		self.assertEqual(res["count"], 2)
 		self.assertEqual([s["kind"] for s in res["steps"]], ["dispatched", "tool"])
 		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2])
@@ -743,33 +745,33 @@ class TestListRunSteps(FrappeTestCase):
 		"""Identical to an unknown run: a stranger must not be able to tell that
 		this run exists, let alone how busy it was."""
 		frappe.set_user(self.stranger)
-		self.assertEqual(agents_api.list_run_steps(self.run), {"steps": [], "count": 0})
+		self.assertEqual(agents_api.list_run_steps(self.run_name), {"steps": [], "count": 0})
 		self.assertEqual(agents_api.list_run_steps("RUN-does-not-exist"), {"steps": [], "count": 0})
 
 	def test_a_jarvis_admin_may_read_someone_elses_run(self):
 		admin = _mk_user("rs-admin@example.com", roles=("Jarvis User", "System Manager"))
 		frappe.set_user(admin)
-		self.assertEqual(agents_api.list_run_steps(self.run)["count"], 2)
+		self.assertEqual(agents_api.list_run_steps(self.run_name)["count"], 2)
 
 	def test_duplicate_stored_seq_is_renumbered_in_the_response(self):
 		"""THE live defect: record_step's MAX(seq)+1 is unlocked, so parallel tool
 		calls land on the same number (2,2,2 then 3,3 on the bench). The stored
 		column may collide; what the UI reads must not."""
 		third = agent_run_steps.record_step(
-			self.run, kind="tool", tool="get_doc", label="Read ToDo T-1", owner=self.owner
+			self.run_name, kind="tool", tool="get_doc", label="Read ToDo T-1", owner=self.owner
 		)
 		# force the collision the race produces, and pin the true order via
 		# occurred_at (the column the response now sorts on)
 		frappe.db.set_value(STEP, third, "seq", 2, update_modified=False)
 		for name, occurred in zip(
-			[s.name for s in _steps_by_seq(self.run)],
+			[s.name for s in _steps_by_seq(self.run_name)],
 			["2026-09-02 10:00:00.000000", "2026-09-02 10:00:01.000000", "2026-09-02 10:00:02.000000"],
 			strict=False,
 		):
 			frappe.db.set_value(STEP, name, "occurred_at", occurred, update_modified=False)
 
 		frappe.set_user(self.owner)
-		res = agents_api.list_run_steps(self.run)
+		res = agents_api.list_run_steps(self.run_name)
 		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2, 3])
 		self.assertEqual(
 			[s["label"] for s in res["steps"]],
@@ -780,7 +782,7 @@ class TestListRunSteps(FrappeTestCase):
 		"""Ordering is occurred_at, not the racy stored seq: a step stamped later
 		reads later even when its seq says otherwise."""
 		frappe.set_user("Administrator")
-		rows = _steps_by_seq(self.run)
+		rows = _steps_by_seq(self.run_name)
 		frappe.db.set_value(
 			STEP, rows[0].name, "occurred_at", "2026-09-02 11:00:00.000000", update_modified=False
 		)
@@ -788,7 +790,7 @@ class TestListRunSteps(FrappeTestCase):
 			STEP, rows[1].name, "occurred_at", "2026-09-02 10:00:00.000000", update_modified=False
 		)
 		frappe.set_user(self.owner)
-		res = agents_api.list_run_steps(self.run)
+		res = agents_api.list_run_steps(self.run_name)
 		self.assertEqual([s["kind"] for s in res["steps"]], ["tool", "dispatched"])
 		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2])
 

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -20,7 +20,13 @@ What is proven here:
   * ``_launch_audit`` opens the timeline with a ``dispatched`` step only after the
     fleet accepted the turn;
   * ``list_run_steps`` is ownership-gated: a foreign run reads as an empty
-    timeline, never as an existence oracle.
+    timeline, never as an existence oracle;
+  * duplicate stored ``seq`` values (the unlocked MAX+1 race, seen live) never
+    reach the UI: the response is ordered by ``occurred_at`` and renumbered;
+  * bench-internal DocTypes read as plain English and never leak a record name;
+  * a Single DocType is not named twice, an unresolved lookup says "Looked up"
+    rather than claiming a read, and a failed step carries the tool's own error
+    message in ``detail``.
 
 Run:
   bench --site patterntest.localhost run-tests --app jarvis \
@@ -119,6 +125,18 @@ def _mk_run(slug: str, owner: str, session_key: str, status: str = "running") ->
 	run.insert(ignore_permissions=True)
 	frappe.db.set_value(RUN, run.name, "owner", owner, update_modified=False)
 	return run.name
+
+
+def _steps_by_seq(run: str) -> list:
+	"""Raw rows in STORED seq order (creation breaks the tie) - the pre-renumber
+	view, which is what the seq-race tests need to poke at."""
+	return frappe.get_all(
+		STEP,
+		filters={"run": run},
+		fields=["name", "seq", "kind", "label", "occurred_at"],
+		order_by="seq asc, creation asc",
+		ignore_permissions=True,
+	)
 
 
 def _steps(run: str) -> list:
@@ -286,6 +304,88 @@ class TestHumanizeToolCall(unittest.TestCase):
 		self.assertNotIn("Aerele", label + detail)
 		self.assertNotIn("900000", label + detail)
 
+	# ---- bench-internal DocTypes read as plain English -------------------- #
+	def test_internal_doctypes_are_named_by_what_they_are(self):
+		""" "Jarvis Agent Installation" is implementation vocabulary the customer
+		has never seen. The step names the ACT instead."""
+		cases = {
+			"Jarvis Agent Installation": "Read engagement configuration",
+			"Jarvis Agent Listing": "Read agent definition",
+			"Jarvis Agent Run": "Checked run state",
+			"Jarvis Agent Finding": "Read agent metadata",
+			"Jarvis Agent Provenance Event": "Read agent metadata",
+		}
+		for doctype, expected in cases.items():
+			label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": doctype}, [{}])
+			self.assertEqual(label, expected, doctype)
+
+	def test_an_internal_read_never_shows_the_record_name(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc",
+			{"doctype": "Jarvis Agent Installation", "name": "8f3ac1de99"},
+			{"name": "8f3ac1de99"},
+		)
+		self.assertEqual(label, "Read engagement configuration")
+		self.assertNotIn("8f3ac1de99", label)
+
+	def test_an_internal_list_keeps_its_row_count_on_the_second_line(self):
+		label, detail = agent_run_steps.humanize_tool_call(
+			"get_list", {"doctype": "Jarvis Agent Run"}, [{}, {}, {}]
+		)
+		self.assertEqual(label, "Checked run state")
+		self.assertEqual(detail, "3 rows")
+
+	def test_an_internal_query_is_mapped_too(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"query", {"spec": {"from": "Jarvis Agent Listing"}}, {"rows": []}
+		)
+		self.assertEqual(label, "Read agent definition")
+
+	def test_an_ordinary_erp_doctype_is_untouched(self):
+		"""The control: the mapping must not swallow the DocTypes the customer
+		does know by name."""
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "Sales Invoice"}, [{}, {}])
+		self.assertEqual(label, "Read Sales Invoice, 2 rows")
+
+	# ---- Singles, and names that did not resolve -------------------------- #
+	def test_a_single_doctype_is_not_named_twice(self):
+		""" "Read System Settings System Settings" - a Single's document name IS
+		its doctype."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc",
+			{"doctype": "System Settings", "name": "System Settings"},
+			{"name": "System Settings"},
+		)
+		self.assertEqual(label, "Read System Settings")
+
+	def test_an_unresolved_lookup_says_what_was_attempted(self):
+		"""The record name is MODEL-supplied. A wrong guess produced "Read Company
+		ignore" on the bench; an unresolved lookup must not claim a read at all."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "Company", "name": "ignore"}, None
+		)
+		self.assertEqual(label, "Looked up Company")
+
+	def test_a_resolved_lookup_still_names_the_document(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "Company", "name": "Aerele"}, {"name": "Aerele"}
+		)
+		self.assertEqual(label, "Read Company Aerele")
+
+	# ---- error detail ------------------------------------------------------ #
+	def test_error_detail_keeps_the_first_line_only(self):
+		self.assertEqual(
+			agent_run_steps.error_detail("unknown Report: Foo\nTraceback (most recent call last):"),
+			"unknown Report: Foo",
+		)
+
+	def test_error_detail_is_clipped(self):
+		self.assertEqual(len(agent_run_steps.error_detail("x" * 900)), agent_run_steps.ERROR_DETAIL_MAX)
+
+	def test_error_detail_of_nothing_is_empty(self):
+		self.assertEqual(agent_run_steps.error_detail(None), "")
+		self.assertEqual(agent_run_steps.error_detail("   "), "")
+
 	def test_labels_and_details_are_clipped(self):
 		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "D" * 400}, [])
 		self.assertLessEqual(len(label), agent_run_steps.LABEL_MAX)
@@ -355,6 +455,31 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		self.assertEqual(len(rows), 1, rows)
 		self.assertEqual(rows[0].status, "error")
 		self.assertEqual(rows[0].label, "Read ToDo")
+
+	def test_an_error_step_carries_the_tools_own_message(self):
+		"""A bare red row the customer cannot act on is not an explanation. The
+		label stays the humanized ACTION; the tool's message becomes the detail."""
+		with mock.patch.object(
+			api,
+			"_run_tool",
+			return_value={
+				"ok": False,
+				"error": {"code": "InvalidArgumentError", "message": "unknown Report: Foo"},
+			},
+		):
+			self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		row = _steps(self.run)[0]
+		self.assertEqual(row.label, "Read ToDo")
+		self.assertEqual(row.detail, "unknown Report: Foo")
+
+	def test_an_error_detail_is_the_first_line_only(self):
+		with mock.patch.object(
+			api,
+			"_run_tool",
+			return_value={"ok": False, "error": {"message": "boom\nTraceback: secret"}},
+		):
+			self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		self.assertEqual(_steps(self.run)[0].detail, "boom")
 
 	def test_a_raising_tool_still_raises_and_still_leaves_an_error_step(self):
 		"""A fault past _run_tool's envelope translation is a real bug: it must
@@ -448,6 +573,47 @@ class TestListRunSteps(FrappeTestCase):
 		admin = _mk_user("rs-admin@example.com", roles=("Jarvis User", "System Manager"))
 		frappe.set_user(admin)
 		self.assertEqual(agents_api.list_run_steps(self.run)["count"], 2)
+
+	def test_duplicate_stored_seq_is_renumbered_in_the_response(self):
+		"""THE live defect: record_step's MAX(seq)+1 is unlocked, so parallel tool
+		calls land on the same number (2,2,2 then 3,3 on the bench). The stored
+		column may collide; what the UI reads must not."""
+		third = agent_run_steps.record_step(
+			self.run, kind="tool", tool="get_doc", label="Read ToDo T-1", owner=self.owner
+		)
+		# force the collision the race produces, and pin the true order via
+		# occurred_at (the column the response now sorts on)
+		frappe.db.set_value(STEP, third, "seq", 2, update_modified=False)
+		for name, occurred in zip(
+			[s.name for s in _steps_by_seq(self.run)],
+			["2026-09-02 10:00:00.000000", "2026-09-02 10:00:01.000000", "2026-09-02 10:00:02.000000"],
+			strict=False,
+		):
+			frappe.db.set_value(STEP, name, "occurred_at", occurred, update_modified=False)
+
+		frappe.set_user(self.owner)
+		res = agents_api.list_run_steps(self.run)
+		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2, 3])
+		self.assertEqual(
+			[s["label"] for s in res["steps"]],
+			["Dispatched to the agent", "Read ToDo, 2 rows", "Read ToDo T-1"],
+		)
+
+	def test_the_response_is_ordered_by_when_the_step_happened(self):
+		"""Ordering is occurred_at, not the racy stored seq: a step stamped later
+		reads later even when its seq says otherwise."""
+		frappe.set_user("Administrator")
+		rows = _steps_by_seq(self.run)
+		frappe.db.set_value(
+			STEP, rows[0].name, "occurred_at", "2026-09-02 11:00:00.000000", update_modified=False
+		)
+		frappe.db.set_value(
+			STEP, rows[1].name, "occurred_at", "2026-09-02 10:00:00.000000", update_modified=False
+		)
+		frappe.set_user(self.owner)
+		res = agents_api.list_run_steps(self.run)
+		self.assertEqual([s["kind"] for s in res["steps"]], ["tool", "dispatched"])
+		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2])
 
 	def test_a_blank_run_is_an_empty_timeline(self):
 		frappe.set_user(self.owner)

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -358,8 +358,12 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 
 	def test_a_raising_tool_still_raises_and_still_leaves_an_error_step(self):
 		"""A fault past _run_tool's envelope translation is a real bug: it must
-		still reach Frappe's handler, and the run must still say the attempt
-		happened."""
+		still reach Frappe's handler, and the step must be ATTEMPTED on the way
+		out. In a real request the handler then rolls the transaction back and
+		takes the row with it - deliberately, since committing to save it would
+		also flush the raising tool's partial writes. The step that SURVIVES a
+		tool failure is the ok=False envelope one above, which is how a tool
+		error normally arrives."""
 		with mock.patch.object(api, "_run_tool", side_effect=RuntimeError("boom")):
 			with self.assertRaises(RuntimeError):
 				self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
@@ -398,6 +402,12 @@ class TestListRunSteps(FrappeTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		frappe.set_user("Administrator")
+		# CI runs a fresh DB: the role the timeline's if_owner read depends on has
+		# to exist before a user can be given it (the local bench is role-polluted
+		# and hides this).
+		from jarvis.permissions import ensure_jarvis_user_role
+
+		ensure_jarvis_user_role()
 		cls.owner = _mk_user("rs-mine@example.com", roles=("Jarvis User",))
 		cls.stranger = _mk_user("rs-stranger@example.com", roles=("Jarvis User",))
 		frappe.db.commit()

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -98,13 +98,26 @@ def _mk_listing(slug: str) -> None:
 	).insert(ignore_permissions=True)
 
 
+def _pin_owner(doctype: str, name: str, owner: str) -> None:
+	"""Set a row's owner AFTER insert.
+
+	``Document.insert`` stamps ``owner = frappe.session.user`` unconditionally
+	(``set_user_and_timestamp`` assigns it rather than deferring to a pre-set
+	value), so ``doc.owner = someone`` before ``insert()`` is silently discarded.
+	Every fixture here builds rows as Administrator, so without this the whole
+	cast would be owned by Administrator and every ``if_owner`` assertion below
+	would be testing nothing. Production hits the same rule, which is why
+	``_launch_audit`` and ``log_activity`` both re-stamp owner this same way."""
+	frappe.db.set_value(doctype, name, "owner", owner, update_modified=False)
+
+
 def _mk_run(slug: str, owner: str, session_key: str, status: str = "running") -> str:
 	inst = frappe.get_doc(
 		{"doctype": INSTALLATION, "agent": slug, "run_as_user": owner, "activation_state": "shadow"}
 	)
-	inst.owner = owner
 	inst.flags.ignore_permissions = True
 	inst.insert(ignore_permissions=True)
+	_pin_owner(INSTALLATION, inst.name, owner)
 	run = frappe.get_doc(
 		{
 			"doctype": RUN,
@@ -120,10 +133,9 @@ def _mk_run(slug: str, owner: str, session_key: str, status: str = "running") ->
 			"capability_writes_json": json.dumps([]),
 		}
 	)
-	run.owner = owner
 	run.flags.ignore_permissions = True
 	run.insert(ignore_permissions=True)
-	frappe.db.set_value(RUN, run.name, "owner", owner, update_modified=False)
+	_pin_owner(RUN, run.name, owner)
 	return run.name
 
 
@@ -196,6 +208,13 @@ class TestRecordStep(FrappeTestCase):
 		(if_owner) timeline it exists for."""
 		frappe.set_user("Administrator")
 		agent_run_steps.record_step(self.run, kind="note", label="pinned", owner=self.owner)
+		self.assertEqual(_steps(self.run)[0].owner, self.owner)
+
+	def test_owner_falls_back_to_the_run_owner_when_not_passed(self):
+		"""A caller that forgets ``owner`` must not leak the step to whoever is
+		executing. A step belongs to whoever owns the RUN, always."""
+		frappe.set_user("Administrator")
+		agent_run_steps.record_step(self.run, kind="note", label="no explicit owner")
 		self.assertEqual(_steps(self.run)[0].owner, self.owner)
 
 	def test_label_and_detail_are_clipped(self):
@@ -675,9 +694,15 @@ class TestLaunchRecordsDispatchedStep(unittest.TestCase):
 				"enabled": 1,
 			}
 		)
-		inst.owner = self.OWNER
 		inst.flags.ignore_permissions = True
 		inst.insert(ignore_permissions=True)
+		# THE CI failure this fixture caused: the pre-insert `inst.owner = OWNER`
+		# was discarded, so the installation belonged to Administrator, and
+		# _launch_audit (which correctly reads `owner = inst.owner`) pinned the run
+		# AND its first step to Administrator. Re-read so the doc handed to the
+		# launch carries the owner the database now holds.
+		_pin_owner(INSTALLATION, inst.name, self.OWNER)
+		inst = frappe.get_doc(INSTALLATION, inst.name)
 		frappe.db.commit()
 
 		orig = admin_client.post_agent_run
@@ -698,6 +723,11 @@ class TestLaunchRecordsDispatchedStep(unittest.TestCase):
 
 	def test_launch_opens_the_timeline_with_a_dispatched_step(self):
 		result = self._launch()
+		# Guard the PREMISE first. The step below can only be owner-pinned if the
+		# launch itself was, and a fixture whose installation quietly reverts to
+		# Administrator (Document.insert discards a pre-set owner - see _pin_owner)
+		# would otherwise fail on the step and read as a bug in the step code.
+		self.assertEqual(frappe.db.get_value(RUN, result["run"], "owner"), self.OWNER)
 		rows = _steps(result["run"])
 		self.assertEqual(len(rows), 1, rows)
 		self.assertEqual(rows[0].kind, "dispatched")

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -436,13 +436,21 @@ class TestHumanizeToolCall(unittest.TestCase):
 		"""get_doc short-circuits a Single AHEAD of name/names (#1062), because its
 		one document's name IS the doctype. A delegate with nothing sensible to put
 		there sends "" or [] - and the step must still read as the one document it
-		actually got, never "Read System Settings, 0 documents"."""
-		for args in (
-			{"doctype": "System Settings", "names": []},
-			{"doctype": "System Settings", "names": ["bogus", "also-bogus"]},
-			{"doctype": "System Settings", "name": "x"},
+		actually got, never "Read System Settings, 0 documents".
+
+		Each case carries the shape get_doc ACTUALLY returns for it: flat for
+		name/empty-names, and the batch envelope for a non-empty names list (a
+		caller that asked for the batch shape gets it back, holding the one
+		document). Feeding one flat dict to all three would pass either way and
+		prove nothing about the real contract."""
+		flat = {"name": "System Settings"}
+		batch = {"doctype": "System Settings", "docs": [flat], "count": 1}
+		for args, result in (
+			({"doctype": "System Settings", "names": []}, flat),
+			({"doctype": "System Settings", "names": ["bogus", "also-bogus"]}, batch),
+			({"doctype": "System Settings", "name": "x"}, flat),
 		):
-			label, _ = agent_run_steps.humanize_tool_call("get_doc", args, {"name": "System Settings"})
+			label, _ = agent_run_steps.humanize_tool_call("get_doc", args, result)
 			self.assertEqual(label, "Read System Settings", args)
 
 	def test_a_single_that_did_not_resolve_claims_no_read(self):

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -1,0 +1,545 @@
+"""jarvis#1062 — the per-run STEP TIMELINE.
+
+``Jarvis Agent Activity`` records a run's lifecycle (started / completed), and
+nothing at all in between, so a customer watching a running agent got a static
+"Run in progress" line for the whole audit. But the bench already SEES every
+step: the delegate calls back into it for each ``jarvis__*`` tool over the run's
+own session bearer.
+
+What is proven here:
+
+  * ``record_step`` appends monotonically-sequenced, owner-pinned rows and never
+    raises, whatever the caller does to it;
+  * ``humanize_tool_call`` turns a tool call into one short sentence about
+    SHAPES — DocType names, report names, counts — and never quotes a payload;
+  * the ``jarvis.api`` dispatch hook records a ``tool`` step for a delegate run
+    and records NOTHING for an ordinary chat session;
+  * a tool that fails still leaves an ``error`` step, and a tool that raises past
+    the envelope still leaves one AND still raises;
+  * ``record_agent_run`` narrates itself once (a ``writeback`` step), never twice;
+  * ``_launch_audit`` opens the timeline with a ``dispatched`` step only after the
+    fleet accepted the turn;
+  * ``list_run_steps`` is ownership-gated: a foreign run reads as an empty
+    timeline, never as an existence oracle.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_agent_run_steps
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api
+from jarvis.chat import agent_catalog, agent_run_steps, agent_scheduler, agents_api
+from jarvis.tools import _agent_run_ctx, _delegate_capability
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+STEP = "Jarvis Agent Run Step"
+SESSION = "Jarvis Chat Session"
+CONVERSATION = "Jarvis Conversation"
+
+SLUG = "rs-auditor"
+# Two reads plus the writeback pair: enough surface for the dispatch hook tests
+# without widening what a real auditor may do.
+TOOLS_ALLOW = ["jarvis__get_schema", "jarvis__get_list", "jarvis__record_agent_run", "canvas", "message"]
+
+
+def _mk_user(email: str, roles=("System Manager",)) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	existing = {r.role for r in frappe.get_doc("User", email).roles}
+	for role in roles:
+		if role not in existing:
+			frappe.get_doc("User", email).add_roles(role)
+	return email
+
+
+def _mk_listing(slug: str) -> None:
+	"""A dependency-free published listing (no min_apps / doctypes_required), so
+	the install-time installability preflight passes on any bench."""
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": LISTING,
+			"agent_slug": slug,
+			"title": f"Run steps {slug}",
+			"nature": "Auditor",
+			"delivery": "delegate",
+			"status": "Published",
+			"version": "0.1.0",
+			"rule_tokens": json.dumps([]),
+			"min_apps": json.dumps([]),
+			"doctypes_required": json.dumps([]),
+			"writes": json.dumps([]),
+		}
+	).insert(ignore_permissions=True)
+
+
+def _mk_run(slug: str, owner: str, session_key: str, status: str = "running") -> str:
+	inst = frappe.get_doc(
+		{"doctype": INSTALLATION, "agent": slug, "run_as_user": owner, "activation_state": "shadow"}
+	)
+	inst.owner = owner
+	inst.flags.ignore_permissions = True
+	inst.insert(ignore_permissions=True)
+	run = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": slug,
+			"installation": inst.name,
+			"trigger": "manual",
+			"status": status,
+			"started_at": frappe.utils.now(),
+			"session_key": session_key,
+			"capability_contract": _delegate_capability.CONTRACT_SNAPSHOT,
+			"tools_allow_json": json.dumps(TOOLS_ALLOW),
+			"capability_nature": "auditor",
+			"capability_writes_json": json.dumps([]),
+		}
+	)
+	run.owner = owner
+	run.flags.ignore_permissions = True
+	run.insert(ignore_permissions=True)
+	frappe.db.set_value(RUN, run.name, "owner", owner, update_modified=False)
+	return run.name
+
+
+def _steps(run: str) -> list:
+	return frappe.get_all(
+		STEP,
+		filters={"run": run},
+		fields=["name", "seq", "kind", "tool", "label", "detail", "status", "duration_ms", "owner"],
+		order_by="seq asc",
+		ignore_permissions=True,
+	)
+
+
+def _wipe(slug: str) -> None:
+	for run in frappe.get_all(RUN, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+		for step in frappe.get_all(STEP, filters={"run": run}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(STEP, step, force=True, ignore_permissions=True)
+	for dt in ("Jarvis Agent Activity", RUN, INSTALLATION):
+		for name in frappe.get_all(dt, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+
+
+# --------------------------------------------------------------------------- #
+# record_step
+# --------------------------------------------------------------------------- #
+class TestRecordStep(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("rs-owner@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(SLUG)
+		_mk_listing(SLUG)
+		self.key = f"agent:agent-{SLUG}:rs-run"
+		self.run = _mk_run(SLUG, self.owner, self.key)
+
+	def tearDown(self):
+		_agent_run_ctx.clear_session_key()
+		frappe.set_user("Administrator")
+		frappe.db.delete(SESSION, {"session_key": self.key})
+		_wipe(SLUG)
+
+	def test_steps_are_numbered_from_one_and_monotonic(self):
+		for label in ("first", "second", "third"):
+			agent_run_steps.record_step(self.run, kind="note", label=label)
+		self.assertEqual([s.seq for s in _steps(self.run)], [1, 2, 3])
+		self.assertEqual([s.label for s in _steps(self.run)], ["first", "second", "third"])
+
+	def test_owner_is_pinned_to_the_run_owner_not_the_session_user(self):
+		"""The hook runs impersonated (the run-as user) or as the scheduler's
+		Administrator, so an unpinned row would be invisible on the owner-scoped
+		(if_owner) timeline it exists for."""
+		frappe.set_user("Administrator")
+		agent_run_steps.record_step(self.run, kind="note", label="pinned", owner=self.owner)
+		self.assertEqual(_steps(self.run)[0].owner, self.owner)
+
+	def test_label_and_detail_are_clipped(self):
+		agent_run_steps.record_step(self.run, kind="note", label="L" * 400, detail="D" * 900, status="error")
+		row = _steps(self.run)[0]
+		self.assertEqual(len(row.label), agent_run_steps.LABEL_MAX)
+		self.assertEqual(len(row.detail), agent_run_steps.DETAIL_MAX)
+		self.assertEqual(row.status, "error")
+
+	def test_an_unknown_status_falls_back_to_ok(self):
+		agent_run_steps.record_step(self.run, kind="note", label="x", status="weird")
+		self.assertEqual(_steps(self.run)[0].status, "ok")
+
+	def test_a_missing_run_records_nothing_and_does_not_raise(self):
+		self.assertIsNone(agent_run_steps.record_step("", kind="note", label="orphan"))
+
+	def test_a_failing_insert_is_swallowed(self):
+		"""Narration must never be able to fail the run it narrates."""
+		with mock.patch.object(frappe, "get_doc", side_effect=RuntimeError("db down")):
+			self.assertIsNone(agent_run_steps.record_step(self.run, kind="note", label="x"))
+
+	def test_running_run_for_session_resolves_only_a_running_run(self):
+		got = agent_run_steps.running_run_for_session(self.key)
+		self.assertEqual(got["name"], self.run)
+		self.assertEqual(got["owner"], self.owner)
+		frappe.db.set_value(RUN, self.run, "status", "completed", update_modified=False)
+		self.assertIsNone(agent_run_steps.running_run_for_session(self.key))
+		self.assertIsNone(agent_run_steps.running_run_for_session("not-an-agent-session"))
+		self.assertIsNone(agent_run_steps.running_run_for_session(None))
+
+
+# --------------------------------------------------------------------------- #
+# humanize_tool_call
+# --------------------------------------------------------------------------- #
+class TestHumanizeToolCall(unittest.TestCase):
+	def test_get_list_names_the_doctype_and_the_row_count(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"jarvis__get_list", {"doctype": "Sales Invoice"}, [{"name": "SI-1"}, {"name": "SI-2"}]
+		)
+		self.assertEqual(label, "Read Sales Invoice, 2 rows")
+
+	def test_get_list_singular_row(self):
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "ToDo"}, [{"name": "T"}])
+		self.assertEqual(label, "Read ToDo, 1 row")
+
+	def test_get_doc_names_the_document(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "Journal Entry", "name": "JV-0007"}, {"name": "JV-0007"}
+		)
+		self.assertEqual(label, "Read Journal Entry JV-0007")
+
+	def test_get_doc_batch_counts_documents(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "ToDo", "names": ["a", "b", "c"]}, {"count": 3}
+		)
+		self.assertEqual(label, "Read ToDo, 3 documents")
+
+	def test_run_report_names_the_report_and_counts_result_rows(self):
+		label, detail = agent_run_steps.humanize_tool_call(
+			"run_report", {"report_name": "Trial Balance"}, {"columns": [], "result": [1, 2, 3]}
+		)
+		self.assertEqual(label, "Ran report Trial Balance")
+		self.assertEqual(detail, "3 rows")
+
+	def test_query_names_the_from_doctype(self):
+		label, detail = agent_run_steps.humanize_tool_call(
+			"query", {"spec": {"from": "GL Entry"}}, {"sql": "select 1", "rows": [1, 2]}
+		)
+		self.assertEqual(label, "Queried GL Entry")
+		self.assertEqual(detail, "2 rows")
+
+	def test_get_balance_on_names_the_account(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_balance_on", {"account": "Debtors - AB"}, {"balance": 1200.0}
+		)
+		self.assertEqual(label, "Checked balance for Debtors - AB")
+
+	def test_record_agent_run_counts_the_findings(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"jarvis__record_agent_run", {"findings": [{}, {}]}, {"findings_count": 2}
+		)
+		self.assertEqual(label, "Recorded 2 findings")
+
+	def test_save_agent_dashboard_has_fixed_copy(self):
+		label, _ = agent_run_steps.humanize_tool_call("save_agent_dashboard", {}, {"dashboard": "D-1"})
+		self.assertEqual(label, "Saved dashboard")
+
+	def test_an_unknown_tool_falls_back_to_a_title_cased_name(self):
+		label, _ = agent_run_steps.humanize_tool_call("jarvis__get_fiscal_year", {}, {})
+		self.assertEqual(label, "Get Fiscal Year")
+
+	def test_a_failed_call_still_yields_a_label(self):
+		"""``result`` is None on the error path — the step still has to say what
+		was attempted."""
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "ToDo"}, None)
+		self.assertEqual(label, "Read ToDo")
+
+	def test_the_label_never_quotes_the_payload(self):
+		"""A step carries shapes, not customer data: nothing from the returned row
+		may reach the label or the detail."""
+		label, detail = agent_run_steps.humanize_tool_call(
+			"get_list",
+			{"doctype": "Customer"},
+			[{"name": "CUST-1", "customer_name": "Aerele Technologies", "credit_limit": 900000}],
+		)
+		self.assertNotIn("Aerele", label + detail)
+		self.assertNotIn("900000", label + detail)
+
+	def test_labels_and_details_are_clipped(self):
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "D" * 400}, [])
+		self.assertLessEqual(len(label), agent_run_steps.LABEL_MAX)
+
+
+# --------------------------------------------------------------------------- #
+# the jarvis.api dispatch hook
+# --------------------------------------------------------------------------- #
+class TestDispatchHookRecordsSteps(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.run_as = _mk_user("rs-runas@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(SLUG)
+		_mk_listing(SLUG)
+		self.key = f"agent:agent-{SLUG}:rs-dispatch"
+		self.run = _mk_run(SLUG, self.run_as, self.key)
+
+	def tearDown(self):
+		_agent_run_ctx.clear_session_key()
+		frappe.set_user("Administrator")
+		frappe.db.delete(SESSION, {"session_key": self.key})
+		_wipe(SLUG)
+
+	def _dispatch(self, session_key: str, tool: str, args: dict | None = None) -> dict:
+		"""The REAL plugin dispatch entry point — impersonation, capability gate,
+		_run_tool, receipt — not a hand-rolled stand-in for it."""
+		return api._dispatch_from_session(self.run_as, session_key, tool, args or {})
+
+	def test_a_delegate_tool_call_lands_one_step(self):
+		res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		rows = _steps(self.run)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].kind, "tool")
+		self.assertEqual(rows[0].tool, "get_schema")
+		self.assertEqual(rows[0].status, "ok")
+		self.assertEqual(rows[0].owner, self.run_as)
+		self.assertIsNotNone(rows[0].duration_ms)
+
+	def test_an_ordinary_chat_session_records_nothing(self):
+		"""THE control: the hook must be invisible to non-agent chat, which is
+		almost all of the traffic on this endpoint."""
+		res = self._dispatch("chat-session-with-no-agent-run", "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		self.assertEqual(_steps(self.run), [])
+
+	def test_a_terminal_run_records_nothing(self):
+		"""Only a RUNNING run has a timeline to extend; a bearer replayed after the
+		run finished must not append to its history."""
+		frappe.db.set_value(RUN, self.run, "status", "completed", update_modified=False)
+		self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertEqual(_steps(self.run), [])
+
+	def test_a_tool_error_envelope_leaves_an_error_step(self):
+		with mock.patch.object(
+			api, "_run_tool", return_value={"ok": False, "error": {"code": "X", "message": "no"}}
+		):
+			res = self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		rows = _steps(self.run)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].status, "error")
+		self.assertEqual(rows[0].label, "Read ToDo")
+
+	def test_a_raising_tool_still_raises_and_still_leaves_an_error_step(self):
+		"""A fault past _run_tool's envelope translation is a real bug: it must
+		still reach Frappe's handler, and the run must still say the attempt
+		happened."""
+		with mock.patch.object(api, "_run_tool", side_effect=RuntimeError("boom")):
+			with self.assertRaises(RuntimeError):
+				self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		rows = _steps(self.run)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].status, "error")
+		self.assertEqual(rows[0].tool, "get_list")
+
+	def test_the_writeback_tool_is_not_double_narrated_by_the_hook(self):
+		"""``record_agent_run`` writes its OWN writeback step (it is the only caller
+		that knows how many findings actually persisted), so the generic hook must
+		skip it rather than adding a second row for the same act."""
+		with mock.patch.object(api, "_run_tool", return_value={"ok": True, "data": {}}):
+			self._dispatch(self.key, "record_agent_run", {"findings": []})
+		self.assertEqual(_steps(self.run), [])
+
+	def test_a_refused_tool_records_no_step(self):
+		"""A capability refusal never reaches dispatch, so there is no step to
+		record — the refusal is the receipt, and the audit trail already has it."""
+		res = self._dispatch(self.key, "get_doc", {"doctype": "ToDo", "name": "nope"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+		self.assertEqual(_steps(self.run), [])
+
+	def test_a_broken_step_hook_never_breaks_the_tool_call(self):
+		with mock.patch.object(agent_run_steps, "record_step", side_effect=RuntimeError("nope")):
+			res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+
+
+# --------------------------------------------------------------------------- #
+# list_run_steps
+# --------------------------------------------------------------------------- #
+class TestListRunSteps(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("rs-mine@example.com", roles=("Jarvis User",))
+		cls.stranger = _mk_user("rs-stranger@example.com", roles=("Jarvis User",))
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(SLUG)
+		_mk_listing(SLUG)
+		self.key = f"agent:agent-{SLUG}:rs-list"
+		self.run = _mk_run(SLUG, self.owner, self.key)
+		agent_run_steps.record_step(
+			self.run, kind="dispatched", label="Dispatched to the agent", owner=self.owner
+		)
+		agent_run_steps.record_step(
+			self.run, kind="tool", tool="get_list", label="Read ToDo, 2 rows", owner=self.owner
+		)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete(SESSION, {"session_key": self.key})
+		_wipe(SLUG)
+
+	def test_the_owner_reads_their_timeline_in_sequence_order(self):
+		frappe.set_user(self.owner)
+		res = agents_api.list_run_steps(self.run)
+		self.assertEqual(res["count"], 2)
+		self.assertEqual([s["kind"] for s in res["steps"]], ["dispatched", "tool"])
+		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2])
+
+	def test_a_foreign_run_reads_as_an_empty_timeline_not_an_oracle(self):
+		"""Identical to an unknown run: a stranger must not be able to tell that
+		this run exists, let alone how busy it was."""
+		frappe.set_user(self.stranger)
+		self.assertEqual(agents_api.list_run_steps(self.run), {"steps": [], "count": 0})
+		self.assertEqual(agents_api.list_run_steps("RUN-does-not-exist"), {"steps": [], "count": 0})
+
+	def test_a_jarvis_admin_may_read_someone_elses_run(self):
+		admin = _mk_user("rs-admin@example.com", roles=("Jarvis User", "System Manager"))
+		frappe.set_user(admin)
+		self.assertEqual(agents_api.list_run_steps(self.run)["count"], 2)
+
+	def test_a_blank_run_is_an_empty_timeline(self):
+		frappe.set_user(self.owner)
+		self.assertEqual(agents_api.list_run_steps("")["count"], 0)
+
+
+# --------------------------------------------------------------------------- #
+# the launch opens the timeline
+# --------------------------------------------------------------------------- #
+class TestLaunchRecordsDispatchedStep(unittest.TestCase):
+	"""``_launch_audit`` commits, so this class cleans up after itself rather than
+	relying on a test-case rollback."""
+
+	SLUG = "rs-launch-agent"
+	OWNER = "rs-launch-owner@example.com"
+	DECLARED = ["jarvis__get_schema", "jarvis__record_agent_run", "canvas", "message"]
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		_mk_user(cls.OWNER)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.created: list[tuple[str, str]] = []
+		_mk_listing(self.SLUG)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for run in frappe.get_all(RUN, filters={"agent": self.SLUG}, pluck="name", ignore_permissions=True):
+			for step in frappe.get_all(STEP, filters={"run": run}, pluck="name", ignore_permissions=True):
+				frappe.delete_doc(STEP, step, force=True, ignore_permissions=True)
+		for dt, name in self.created:
+			try:
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for dt in ("Jarvis Agent Activity", RUN, INSTALLATION):
+			for n in frappe.get_all(dt, filters={"agent": self.SLUG}, pluck="name", ignore_permissions=True):
+				try:
+					frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+				except Exception:
+					pass
+		if frappe.db.exists(LISTING, self.SLUG):
+			frappe.delete_doc(LISTING, self.SLUG, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _launch(self, post=None) -> dict:
+		import jarvis.admin_client as admin_client
+
+		inst = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": self.SLUG,
+				"run_as_user": self.OWNER,
+				"activation_state": "shadow",
+				"enabled": 1,
+			}
+		)
+		inst.owner = self.OWNER
+		inst.flags.ignore_permissions = True
+		inst.insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		orig = admin_client.post_agent_run
+		admin_client.post_agent_run = post or (lambda **kw: {"run_id": kw.get("run_id"), "status": "queued"})
+		frappe.set_user(self.OWNER)
+		try:
+			with mock.patch.object(agent_catalog, "registry_tools_allow", return_value=self.DECLARED):
+				result = agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+			admin_client.post_agent_run = orig
+		self.created.append((RUN, result["run"]))
+		self.created.append((CONVERSATION, result["conversation"]))
+		session = frappe.db.get_value(SESSION, {"session_key": result["session_key"]}, "name")
+		if session:
+			self.created.append((SESSION, session))
+		return result
+
+	def test_launch_opens_the_timeline_with_a_dispatched_step(self):
+		result = self._launch()
+		rows = _steps(result["run"])
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].kind, "dispatched")
+		self.assertEqual(rows[0].seq, 1)
+		self.assertEqual(rows[0].label, "Dispatched to the agent")
+		self.assertEqual(rows[0].owner, self.OWNER)
+
+	def test_a_failed_dispatch_opens_no_timeline(self):
+		""" "Dispatched" must mean the fleet really accepted the turn — a refused
+		dispatch has to leave the timeline empty, not claim a step that never
+		happened."""
+
+		def _boom(**kw):
+			raise RuntimeError("fleet said no")
+
+		with self.assertRaises(RuntimeError):
+			self._launch(post=_boom)
+		runs = frappe.get_all(RUN, filters={"agent": self.SLUG}, pluck="name", ignore_permissions=True)
+		self.assertTrue(runs)
+		for run in runs:
+			self.assertEqual(_steps(run), [])

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -444,8 +444,24 @@ class TestHumanizeToolCall(unittest.TestCase):
 			self.assertEqual(label, "Read System Settings", args)
 
 	def test_a_single_that_did_not_resolve_claims_no_read(self):
+		"""A Single is no longer a read that always succeeds: get_doc's Single branch
+		checks read permission explicitly (#1062), and Singles carry their own
+		DocPerms - Stock Settings is Stock Manager / Sales User only. A refusal must
+		read as an attempt, never as a read that happened."""
 		label, _ = agent_run_steps.humanize_tool_call("get_doc", {"doctype": "System Settings"}, None)
 		self.assertEqual(label, "Looked up System Settings")
+
+	def test_a_refused_single_read_says_attempt_plus_reason(self):
+		"""The two halves the step hook composes for get_doc's new Single permission
+		check: the label claims only an attempt, and the tool's own refusal is what
+		explains it."""
+		args = {"doctype": "Stock Settings"}
+		label, _ = agent_run_steps.humanize_tool_call("get_doc", args, None)
+		self.assertEqual(label, "Looked up Stock Settings")
+		self.assertEqual(
+			agent_run_steps.error_detail("no read permission on Stock Settings"),
+			"no read permission on Stock Settings",
+		)
 
 	def test_an_unresolved_lookup_says_what_was_attempted(self):
 		"""The record name is MODEL-supplied. A wrong guess produced "Read Company

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -54,7 +54,14 @@ CONVERSATION = "Jarvis Conversation"
 SLUG = "rs-auditor"
 # Two reads plus the writeback pair: enough surface for the dispatch hook tests
 # without widening what a real auditor may do.
-TOOLS_ALLOW = ["jarvis__get_schema", "jarvis__get_list", "jarvis__record_agent_run", "canvas", "message"]
+TOOLS_ALLOW = [
+	"jarvis__get_schema",
+	"jarvis__get_list",
+	"jarvis__update_wiki",  # a GATED write - the parked-confirmation step needs one
+	"jarvis__record_agent_run",
+	"canvas",
+	"message",
+]
 
 
 def _mk_user(email: str, roles=("System Manager",)) -> str:
@@ -236,14 +243,23 @@ class TestRecordStep(FrappeTestCase):
 		with mock.patch.object(frappe, "get_doc", side_effect=RuntimeError("db down")):
 			self.assertIsNone(agent_run_steps.record_step(self.run, kind="note", label="x"))
 
-	def test_running_run_for_session_resolves_only_a_running_run(self):
-		got = agent_run_steps.running_run_for_session(self.key)
+	def test_step_target_reads_the_run_off_the_capability_contract(self):
+		"""The step's run comes from the contract the dispatcher already resolved -
+		that reuse is what keeps a tool call at one run-row read."""
+		cap = _delegate_capability.resolve(self.key)
+		got = agent_run_steps.step_target(cap)
 		self.assertEqual(got["name"], self.run)
 		self.assertEqual(got["owner"], self.owner)
+
+	def test_step_target_ignores_a_run_that_is_no_longer_running(self):
+		"""A bearer replayed after the run finished must not extend its history."""
 		frappe.db.set_value(RUN, self.run, "status", "completed", update_modified=False)
-		self.assertIsNone(agent_run_steps.running_run_for_session(self.key))
-		self.assertIsNone(agent_run_steps.running_run_for_session("not-an-agent-session"))
-		self.assertIsNone(agent_run_steps.running_run_for_session(None))
+		self.assertIsNone(agent_run_steps.step_target(_delegate_capability.resolve(self.key)))
+
+	def test_step_target_of_a_non_delegate_is_none(self):
+		self.assertIsNone(agent_run_steps.step_target(_delegate_capability.resolve("plain-chat")))
+		self.assertIsNone(agent_run_steps.step_target(None))
+		self.assertIsNone(agent_run_steps.step_target({}))
 
 
 # --------------------------------------------------------------------------- #
@@ -266,11 +282,31 @@ class TestHumanizeToolCall(unittest.TestCase):
 		)
 		self.assertEqual(label, "Read Journal Entry JV-0007")
 
-	def test_get_doc_batch_counts_documents(self):
+	def test_get_doc_batch_counts_the_documents_actually_returned(self):
+		"""The REQUESTED count is a wish. A batch that asked for three and was
+		permitted two must say two."""
 		label, _ = agent_run_steps.humanize_tool_call(
-			"get_doc", {"doctype": "ToDo", "names": ["a", "b", "c"]}, {"count": 3}
+			"get_doc",
+			{"doctype": "ToDo", "names": ["a", "b", "c"]},
+			{"doctype": "ToDo", "docs": [{"name": "a"}, {"name": "b"}], "count": 2},
+		)
+		self.assertEqual(label, "Read ToDo, 2 documents")
+
+	def test_get_doc_batch_falls_back_to_the_requested_count(self):
+		"""When the payload exposes no count of its own, the request is the only
+		honest number available."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "ToDo", "names": ["a", "b", "c"]}, {"ok": True}
 		)
 		self.assertEqual(label, "Read ToDo, 3 documents")
+
+	def test_an_unresolved_batch_claims_no_documents(self):
+		"""THE defect: a failed batch used to report the requested count as though
+		it had read them."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "ToDo", "names": ["a", "b", "c"]}, None
+		)
+		self.assertEqual(label, "Looked up ToDo")
 
 	def test_run_report_names_the_report_and_counts_result_rows(self):
 		label, detail = agent_run_steps.humanize_tool_call(
@@ -292,11 +328,12 @@ class TestHumanizeToolCall(unittest.TestCase):
 		)
 		self.assertEqual(label, "Checked balance for Debtors - AB")
 
-	def test_record_agent_run_counts_the_findings(self):
-		label, _ = agent_run_steps.humanize_tool_call(
-			"jarvis__record_agent_run", {"findings": [{}, {}]}, {"findings_count": 2}
-		)
-		self.assertEqual(label, "Recorded 2 findings")
+	def test_plural_is_the_one_way_a_count_is_phrased(self):
+		"""The writeback step builds its own label from this helper, so the closing
+		step counts things exactly the way every other step does."""
+		self.assertEqual(agent_run_steps.plural(0, "finding"), "0 findings")
+		self.assertEqual(agent_run_steps.plural(1, "finding"), "1 finding")
+		self.assertEqual(agent_run_steps.plural(2, "finding"), "2 findings")
 
 	def test_save_agent_dashboard_has_fixed_copy(self):
 		label, _ = agent_run_steps.humanize_tool_call("save_agent_dashboard", {}, {"dashboard": "D-1"})
@@ -531,6 +568,78 @@ class TestDispatchHookRecordsSteps(FrappeTestCase):
 		self.assertFalse(res["ok"], res)
 		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
 		self.assertEqual(_steps(self.run), [])
+
+	def test_a_delegate_tool_call_reads_the_run_row_exactly_once(self):
+		"""The capability gate and the timeline both need the run row. They share
+		ONE read - this is the hot path of every plugin tool call, and it used to
+		fetch the same row twice."""
+		real_get_value = frappe.db.get_value
+		run_reads = []
+
+		def counting(doctype, *a, **kw):
+			if doctype == RUN:
+				run_reads.append(a[0] if a else kw.get("filters"))
+			return real_get_value(doctype, *a, **kw)
+
+		with mock.patch.object(frappe.db, "get_value", side_effect=counting):
+			res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		self.assertEqual(len(run_reads), 1, run_reads)
+		self.assertEqual(len(_steps(self.run)), 1)
+
+	def test_an_ordinary_chat_session_costs_one_lookup_and_no_more(self):
+		"""The control: non-agent chat is almost all of this endpoint's traffic. It
+		pays the single lookup that discovers there is no delegate run, and nothing
+		for the timeline on top of it."""
+		real_get_value = frappe.db.get_value
+		run_reads = []
+
+		def counting(doctype, *a, **kw):
+			if doctype == RUN:
+				run_reads.append(1)
+			return real_get_value(doctype, *a, **kw)
+
+		with mock.patch.object(frappe.db, "get_value", side_effect=counting):
+			res = self._dispatch("chat-session-with-no-agent-run", "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		# one lookup to discover there is no delegate run, and nothing more
+		self.assertEqual(len(run_reads), 1, run_reads)
+
+	def test_a_parked_gated_write_reads_as_a_proposal_not_an_act(self):
+		"""A gated write returns ok but only PARKS a confirmation card. Narrating it
+		as done would claim a write that may never happen."""
+		with mock.patch.object(
+			api,
+			"_run_tool",
+			return_value={"ok": True, "data": {"status": "pending_confirmation", "token": "t"}},
+		):
+			res = self._dispatch(self.key, "update_wiki", {"slug": "cash-flow"})
+		self.assertTrue(res["ok"], res)
+		row = _steps(self.run)[0]
+		self.assertEqual(row.kind, "tool")
+		self.assertEqual(row.status, "ok")
+		self.assertEqual(row.label, "Proposed Update Wiki, awaiting confirmation")
+		self.assertEqual(row.detail, "waiting for a human to confirm")
+
+	def test_the_writeback_step_reports_the_count_that_persisted(self):
+		"""The real writeback path (not the humanize table it was moved out of):
+		record_agent_run writes its own step, phrased with the shared `plural`."""
+		from jarvis.tools import record_agent_run as rar
+
+		run_doc = frappe.get_doc(RUN, self.run)
+		run_doc.findings_count = 3
+		run_doc.blocker_count = 0
+		with mock.patch("jarvis.chat.agent_runs.record_delegate_run", return_value=run_doc):
+			_agent_run_ctx.set_session_key(self.key)
+			try:
+				rar.record_agent_run(findings=[], coverage={})
+			finally:
+				_agent_run_ctx.clear_session_key()
+		rows = _steps(self.run)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].kind, "writeback")
+		self.assertEqual(rows[0].label, "Recorded 3 findings")
+		self.assertEqual(rows[0].owner, self.run_as)
 
 	def test_a_broken_step_hook_never_breaks_the_tool_call(self):
 		with mock.patch.object(agent_run_steps, "record_step", side_effect=RuntimeError("nope")):

--- a/jarvis/tools/_delegate_capability.py
+++ b/jarvis/tools/_delegate_capability.py
@@ -225,22 +225,31 @@ def resolve(session_key: str | None = None) -> dict | None:
 		],
 		as_dict=True,
 	)
-	if not run or not run.agent:
+	# Shape-checked, not just truthiness-checked. ``as_dict=True`` yields a
+	# frappe._dict or None in production, so the isinstance arm is unreachable
+	# there - but ``frappe.db.get_value`` is a seam tests stub WHOLESALE (test_api's
+	# budget cases patch it to return one fixed string for every lookup on the
+	# dispatch path), and this function now runs on that path directly rather than
+	# only behind ``tool_denial``. A stub must make the caller a non-delegate, never
+	# an AttributeError out of the dispatcher. ``.get`` below for the same reason: a
+	# plain dict stub has no attribute access.
+	if not isinstance(run, dict) or not run.get("agent"):
 		return None  # no delegate run bound -> not a delegate; leave the caller untouched
 
 	base = {
-		"run": run.name,
-		"owner": run.owner,
-		"status": run.status,
-		"agent": run.agent,
+		"run": run.get("name"),
+		"owner": run.get("owner"),
+		"status": run.get("status"),
+		"agent": run.get("agent"),
 		"run_as": frappe.session.user,
 	}
-	contract = (run.capability_contract or "").strip().lower()
+	contract = (run.get("capability_contract") or "").strip().lower()
 
-	if contract == CONTRACT_LEGACY or (not contract and _is_pre_patch(run.creation)):
+	if contract == CONTRACT_LEGACY or (not contract and _is_pre_patch(run.get("creation"))):
 		# Pre-JF-017 run: nature/writes come from the live listing, as they did
 		# before the snapshot existed, and no tools_allow gate applies.
-		listing = frappe.db.get_value(LISTING, run.agent, ["nature", "writes"], as_dict=True) or {}
+		listing = frappe.db.get_value(LISTING, run.get("agent"), ["nature", "writes"], as_dict=True) or {}
+		listing = listing if isinstance(listing, dict) else {}
 		return {
 			**base,
 			"legacy": True,
@@ -259,9 +268,9 @@ def resolve(session_key: str | None = None) -> dict | None:
 	return {
 		**base,
 		"legacy": False,
-		"tools_allow": _parse_list(run.tools_allow_json),
-		"nature": (run.capability_nature or "").strip().lower(),
-		"writes": parse_writes(run.capability_writes_json),
+		"tools_allow": _parse_list(run.get("tools_allow_json")),
+		"nature": (run.get("capability_nature") or "").strip().lower(),
+		"writes": parse_writes(run.get("capability_writes_json")),
 	}
 
 
@@ -313,7 +322,12 @@ def tool_denial(session_key: str | None, tool: str, cap=_UNRESOLVED) -> dict | N
 	contract is resolved here, exactly as before.
 	"""
 	cap = resolve(session_key) if cap is _UNRESOLVED else cap
-	if cap is None or cap["legacy"]:
+	# Shape-checked like resolve's own row guard: a non-delegate (None) and a
+	# stubbed/mocked cap both mean "nothing to enforce here", which is what a
+	# patched resolve already produced before the contract was passed in. ``.get``
+	# so a cap missing the key is treated as NOT legacy, i.e. enforced - the
+	# fail-closed direction.
+	if not isinstance(cap, dict) or cap.get("legacy"):
 		return None
 	allowed = bench_tools(cap["tools_allow"])
 	name = normalize_tool(tool)

--- a/jarvis/tools/_delegate_capability.py
+++ b/jarvis/tools/_delegate_capability.py
@@ -196,7 +196,11 @@ def resolve(session_key: str | None = None) -> dict | None:
 	id, so a delegate can only ever act as its own run); ``session_key=None`` reads
 	it from the request-scoped ``_agent_run_ctx``.
 
-	Returns ``{run, agent, legacy, tools_allow, nature, writes, run_as}``. ``legacy``
+	Returns ``{run, owner, status, agent, legacy, tools_allow, nature, writes,
+	run_as}``. ``owner`` and ``status`` are along for the ride so a caller that
+	needs the run ROW (the #1062 step timeline pins each step to the run owner and
+	only narrates a ``running`` run) does not have to fetch the same row a second
+	time on the hot path of every plugin tool call. ``legacy``
 	True means no snapshot governs this run — the caller falls back to pre-JF-017
 	behaviour. A run that is neither snapshotted nor legacy yields an EMPTY contract
 	with ``legacy`` False, i.e. everything is refused."""
@@ -210,6 +214,8 @@ def resolve(session_key: str | None = None) -> dict | None:
 		{"session_key": key},
 		[
 			"name",
+			"owner",
+			"status",
 			"agent",
 			"creation",
 			"capability_contract",
@@ -222,7 +228,13 @@ def resolve(session_key: str | None = None) -> dict | None:
 	if not run or not run.agent:
 		return None  # no delegate run bound -> not a delegate; leave the caller untouched
 
-	base = {"run": run.name, "agent": run.agent, "run_as": frappe.session.user}
+	base = {
+		"run": run.name,
+		"owner": run.owner,
+		"status": run.status,
+		"agent": run.agent,
+		"run_as": frappe.session.user,
+	}
 	contract = (run.capability_contract or "").strip().lower()
 
 	if contract == CONTRACT_LEGACY or (not contract and _is_pre_patch(run.creation)):
@@ -270,7 +282,13 @@ _CHAT_NO_SURFACE = (
 _RUN_ERROR_NO_SURFACE = "the agent's capability contract authorises no tools; refused at the first call"
 
 
-def tool_denial(session_key: str | None, tool: str) -> dict | None:
+#: Distinguishes "caller passed no contract" from "caller resolved and got None"
+#: (a non-delegate). Without it, a caller that correctly resolved None would make
+#: this function resolve all over again - the exact double read it exists to avoid.
+_UNRESOLVED = object()
+
+
+def tool_denial(session_key: str | None, tool: str, cap=_UNRESOLVED) -> dict | None:
 	"""The refusal for this delegate's ``tool`` call, or None when it may proceed.
 
 	None is also returned for a NON-delegate caller (nothing to enforce) and for a
@@ -289,8 +307,12 @@ def tool_denial(session_key: str | None, tool: str) -> dict | None:
 	    than leave it ``running`` for the 3h reaper to mislabel as a timeout.
 	  * ``chat_message`` vs ``message`` — plain language for the customer-visible
 	    transcript, contract vocabulary for the delegate and the audit trail.
+
+	``cap`` lets a caller that has ALREADY resolved this session's contract hand it
+	in instead of paying for a second identical run-row read. Omit it and the
+	contract is resolved here, exactly as before.
 	"""
-	cap = resolve(session_key)
+	cap = resolve(session_key) if cap is _UNRESOLVED else cap
 	if cap is None or cap["legacy"]:
 		return None
 	allowed = bench_tools(cap["tools_allow"])

--- a/jarvis/tools/record_agent_run.py
+++ b/jarvis/tools/record_agent_run.py
@@ -270,6 +270,23 @@ def record_agent_run(
 		rows_consumed=rows_consumed_val,
 	)
 
+	# STEP TIMELINE (#1062): the run's closing step. Recorded HERE rather than by
+	# the generic per-tool hook in ``jarvis.api`` for two reasons: only this
+	# function knows how many findings actually PERSISTED (invalid rows are dropped
+	# above, so the evaluator's own list would overcount), and the writeback flips
+	# the run off ``running``, so a post-call status-gated resolution would find no
+	# run to narrate. Owner-pinned - this tool runs impersonated as the run-as user.
+	from jarvis.chat.agent_run_steps import record_step
+
+	count = frappe.utils.cint(run_doc.findings_count)
+	record_step(
+		run_doc.name,
+		kind="writeback",
+		label=f"Recorded {count} finding{'' if count == 1 else 's'}",
+		detail=(f"{len(dropped)} row{'' if len(dropped) == 1 else 's'} dropped" if dropped else None),
+		owner=run_doc.owner,
+	)
+
 	return {
 		"run": run_doc.name,
 		"status": run_doc.status,

--- a/jarvis/tools/record_agent_run.py
+++ b/jarvis/tools/record_agent_run.py
@@ -276,14 +276,16 @@ def record_agent_run(
 	# above, so the evaluator's own list would overcount), and the writeback flips
 	# the run off ``running``, so a post-call status-gated resolution would find no
 	# run to narrate. Owner-pinned - this tool runs impersonated as the run-as user.
-	from jarvis.chat.agent_run_steps import record_step
+	from jarvis.chat.agent_run_steps import plural, record_step
 
 	count = frappe.utils.cint(run_doc.findings_count)
 	record_step(
 		run_doc.name,
 		kind="writeback",
-		label=f"Recorded {count} finding{'' if count == 1 else 's'}",
-		detail=(f"{len(dropped)} row{'' if len(dropped) == 1 else 's'} dropped" if dropped else None),
+		# `plural` is the shared phrasing helper every other step uses, so the
+		# closing step counts things the same way the rest of the timeline does.
+		label=f"Recorded {plural(count, 'finding')}",
+		detail=(f"{plural(len(dropped), 'row')} dropped" if dropped else None),
 		owner=run_doc.owner,
 	)
 


### PR DESCRIPTION
Part of #1058 (item 5, full scope). Stacked on #1085; retarget to `develop` once it merges.

## Summary

A running agent run now shows what the agent is actually doing, step by step, instead of a static "run in progress" line: every read, query, report and balance check the agent makes against the bench is recorded as a step and rendered as a live timeline in the run pane (also inspectable after the run ends).

- New `Jarvis Agent Run Step` DocType (Link-free like Activity), written from the plugin tool-call path when the calling session is an agent run: humanised labels ("Queried Warehouse, 4 rows", "Ran report Stock Balance", "Checked balance for Stock In Hand"), durations, and the tool's error text on failed steps. The agent's own config reads show as "Read engagement configuration". Never records row contents, only DocType names, counts and report names.
- "Dispatched to the agent" is recorded at launch and "Recorded N findings" at writeback, so a run that never starts or never writes back is visually obvious.
- `list_run_steps` endpoint (owner or Jarvis Admin), ordered by time with stable numbering; SPA `RunStepTimeline` built from frappe-ui Badge/FeatherIcon in the Activity tab's row style, polled every 5 s while running (visibility-guarded, single timer), consecutive identical steps folded into one row with a count.

Risk: one indexed lookup per plugin tool call to resolve the run; the step insert is best-effort and can never fail a tool call. 49 backend test cases, frontend 1487 green.

## Before / After

**Before**: the running pane only said "Run in progress, findings appear when it completes" with a loose activity box.
<img width="1710" height="847" alt="before: static running placeholder" src="https://github.com/user-attachments/assets/2fed8914-7039-47a1-8e82-881ed0fbf78c" />

**After** (integration bench, live run): header with elapsed time and step count, then the timeline.
<img width="1710" height="903" alt="after: live step timeline" src="https://github.com/user-attachments/assets/36de57df-b97b-4d8f-8874-673392134c0a" />

<details><summary>Design notes</summary>

Steps come from the bench side of every `jarvis__*` tool call (authenticated by the run session), so no container or plugin change is needed. Check-level progress reported by the delegate itself ("evaluating check 2 of 5") would need a plugin tool and bundle protocol; that is a follow-up. `record_agent_run` records its own writeback step because only it knows how many findings persisted. The raise-path step is lost on a real 500 (transaction rollback); the `ok: false` envelope path, which is how tool errors normally arrive, is covered.

</details>

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is up to date with its base and merges cleanly into develop
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01E4eSnE9iEkvPv3t11ucQJz