### PR TITLE
feat(chat): post-reply feedback line (SPA bar + mini widget pills)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -17,6 +17,15 @@ export const getCanvas = (message, name, dark) =>
 export const previewFile = (fileUrl) =>
 	call("jarvis.chat.api.preview_file", { file_url: fileUrl });
 export const createOrFocusEmpty = () => call("jarvis.chat.api.create_or_focus_empty");
+// Post-reply feedback: a thumbs up/down (+ optional note on a down) on one
+// assistant reply. Best-effort - the bench derives the metadata server-side and
+// forwards it to the admin fleet dashboard; the tap never blocks on that.
+export const submitFeedback = (message, rating, note) =>
+	call("jarvis.chat.feedback.submit_feedback", {
+		message_id: message,
+		rating,
+		note: note || "",
+	});
 export const archiveConversation = (conversation) =>
 	call("jarvis.chat.api.archive_conversation", { conversation });
 // Danger zone: permanently delete ALL of the user's conversations + messages.

--- a/frontend/src/components/chat/FeedbackBar.vue
+++ b/frontend/src/components/chat/FeedbackBar.vue
@@ -1,0 +1,261 @@
+<!--
+  Post-reply feedback line for the main chat. A quiet soft prompt bar under a
+  long reply: "Was this reply helpful?" + Yes/No. Yes is one tap; No opens an
+  optional "what went wrong" box. The rating commits the moment it is tapped
+  (the parent submits immediately), so an abandoned note box still records the
+  down. When/whether it appears is decided by the parent via lib/feedbackGate.
+-->
+<template>
+	<div class="jvfb-slot" :class="{ gone: state === 'gone' }">
+		<div v-if="state === 'idle'" class="jvfb-bar">
+			<span class="jvfb-q">Was this reply helpful?</span>
+			<span class="jvfb-acts">
+				<button class="jvfb-btn up" type="button" @click="rateUp" aria-label="Helpful">
+					<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path
+							d="M9 21h8.2a2 2 0 0 0 1.96-1.6l1.4-7A2 2 0 0 0 18.6 10H14V5a2.5 2.5 0 0 0-2.5-2.5L8 11v10zM2 11h4v10H2z"
+						/>
+					</svg>
+					Yes
+				</button>
+				<button
+					class="jvfb-btn down"
+					type="button"
+					@click="openComment"
+					aria-label="Not helpful"
+				>
+					<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path
+							d="M15 3H6.8a2 2 0 0 0-1.96 1.6l-1.4 7A2 2 0 0 0 5.4 14H10v5a2.5 2.5 0 0 0 2.5 2.5L16 13V3zM22 3h-4v10h4z"
+						/>
+					</svg>
+					No
+				</button>
+			</span>
+		</div>
+
+		<div v-else-if="state === 'comment'" class="jvfb-cmt">
+			<span class="jvfb-lead">What went wrong? <span class="opt">(optional)</span></span>
+			<textarea
+				ref="ta"
+				v-model="note"
+				class="jvfb-ta"
+				maxlength="1000"
+				rows="2"
+				placeholder="Tell Jarvis what to fix…"
+				@keydown.enter.exact.prevent="send"
+			></textarea>
+			<div class="jvfb-row">
+				<button class="jvfb-send" type="button" @click="send">Send</button>
+				<button class="jvfb-skip" type="button" @click="skip">Skip</button>
+			</div>
+		</div>
+
+		<div v-else-if="state === 'done'" class="jvfb-done">
+			<svg
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2.4"
+				aria-hidden="true"
+			>
+				<path d="M20 6 9 17l-5-5" />
+			</svg>
+			Thanks for the feedback
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { nextTick, ref } from "vue";
+
+const emit = defineEmits(["rate", "close"]);
+
+const state = ref("idle");
+const note = ref("");
+
+function toDone() {
+	state.value = "done";
+	setTimeout(() => {
+		state.value = "gone";
+		emit("close");
+	}, 1600);
+}
+
+function rateUp() {
+	emit("rate", { rating: "up", note: "" });
+	toDone();
+}
+
+function openComment() {
+	// Commit the down immediately; the note (if any) folds in on Send.
+	emit("rate", { rating: "down", note: "" });
+	state.value = "comment";
+	nextTick(() => {
+		const el = document.activeElement;
+		// focus the textarea without stealing it back if the user already moved on
+		if (el && el.tagName !== "TEXTAREA") {
+			const ta = document.querySelector(".jvfb-ta");
+			if (ta) ta.focus();
+		}
+	});
+}
+
+function send() {
+	const text = (note.value || "").trim();
+	if (text) emit("rate", { rating: "down", note: text });
+	toDone();
+}
+
+function skip() {
+	toDone();
+}
+</script>
+
+<style scoped>
+.jvfb-slot {
+	margin-top: 12px;
+	transition: opacity 0.35s ease;
+}
+.jvfb-slot.gone {
+	opacity: 0;
+}
+
+/* soft prompt bar */
+.jvfb-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 14px;
+	max-width: 440px;
+	padding: 9px 11px 9px 14px;
+	background: var(--surface-1);
+	border: 1px solid var(--border);
+	border-radius: 11px;
+}
+.jvfb-q {
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--text-2);
+}
+.jvfb-acts {
+	display: inline-flex;
+	gap: 8px;
+	flex: 0 0 auto;
+}
+.jvfb-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12.5px;
+	font-weight: 600;
+	cursor: pointer;
+	color: var(--text-2);
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 8px;
+	padding: 5px 11px;
+	transition: color 0.15s, border-color 0.15s;
+}
+.jvfb-btn svg {
+	width: 14px;
+	height: 14px;
+}
+.jvfb-btn:hover {
+	color: var(--text);
+	border-color: var(--text-3);
+}
+.jvfb-btn.up:hover {
+	color: var(--green);
+	border-color: var(--green);
+}
+.jvfb-btn.down:hover {
+	color: var(--red);
+	border-color: var(--red);
+}
+.jvfb-btn:focus-visible {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
+}
+
+/* comment box */
+.jvfb-cmt {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-width: 440px;
+}
+.jvfb-lead {
+	font-size: 11.5px;
+	font-weight: 500;
+	color: var(--text-3);
+}
+.jvfb-lead .opt {
+	opacity: 0.7;
+}
+.jvfb-ta {
+	width: 100%;
+	resize: vertical;
+	min-height: 54px;
+	font-family: inherit;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--text);
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 9px;
+	padding: 8px 10px;
+	outline: none;
+}
+.jvfb-ta:focus {
+	border-color: var(--cta);
+}
+.jvfb-ta::placeholder {
+	color: var(--text-3);
+}
+.jvfb-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+.jvfb-send {
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--cta-fg);
+	background: var(--cta);
+	border: 0;
+	border-radius: 8px;
+	padding: 6px 14px;
+	cursor: pointer;
+}
+.jvfb-skip {
+	font-size: 12px;
+	color: var(--text-3);
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+}
+.jvfb-skip:hover {
+	color: var(--text-2);
+}
+
+/* confirmation */
+.jvfb-done {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--green);
+}
+.jvfb-done svg {
+	width: 14px;
+	height: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.jvfb-slot {
+		transition: none;
+	}
+}
+</style>

--- a/frontend/src/lib/feedbackGate.js
+++ b/frontend/src/lib/feedbackGate.js
@@ -1,0 +1,101 @@
+// Client-side throttle for the post-reply feedback line. It decides whether the
+// "Was this reply helpful?" bar appears after a reply, and keeps the ask RARE so
+// it never nags. All state lives in localStorage, keyed per day, so no server
+// round-trip is needed to decide - and a reload / new day resets the caps.
+//
+// The rules (see the design plan): a reply must be genuinely long (> 1 min),
+// then only ~1 in 3 of those show it, with a cooldown between asks, a hard cap
+// per session, and it stops entirely once the user rates or ignores it twice.
+
+const KEY = "jvChatFeedback.v1";
+
+// The one-minute floor is the single knob to dial if it still feels too frequent
+// (raise to 90s / 120s). Shared with the mini widget.
+export const FEEDBACK_MIN_MS = 60000;
+
+const SHOW_PROB = 1 / 3; // among qualifying replies
+const COOLDOWN_REPLIES = 5; // replies between asks
+const SESSION_CAP = 2; // hard cap per day
+const IGNORE_CAP = 2; // stop after this many shown-and-ignored
+
+function today() {
+	return new Date().toISOString().slice(0, 10);
+}
+
+function fresh() {
+	return {
+		day: today(),
+		n: 0,
+		lastShown: null,
+		shown: 0,
+		rated: false,
+		ignores: 0,
+		stopped: false,
+	};
+}
+
+function load() {
+	try {
+		const raw = JSON.parse(localStorage.getItem(KEY) || "null");
+		if (!raw || raw.day !== today()) return fresh();
+		return {
+			day: raw.day,
+			n: raw.n | 0,
+			lastShown: raw.lastShown == null ? null : raw.lastShown | 0,
+			shown: raw.shown | 0,
+			rated: !!raw.rated,
+			ignores: raw.ignores | 0,
+			stopped: !!raw.stopped,
+		};
+	} catch {
+		return fresh();
+	}
+}
+
+function save(s) {
+	try {
+		localStorage.setItem(KEY, JSON.stringify(s));
+	} catch {
+		// private mode / storage disabled - degrade to "never show", never throw.
+	}
+}
+
+// Call once per completed reply. Advances the per-day reply counter and returns
+// true iff this reply should show the feedback bar. Mutates + persists state, so
+// the caller MUST guard against evaluating the same reply twice.
+export function shouldOfferFeedback(durationMs) {
+	const s = load();
+	s.n += 1;
+	let show = false;
+	const cooldownOk = s.lastShown === null || s.n - s.lastShown >= COOLDOWN_REPLIES;
+	if (
+		!s.stopped &&
+		!s.rated &&
+		s.shown < SESSION_CAP &&
+		Number(durationMs) >= FEEDBACK_MIN_MS &&
+		cooldownOk &&
+		Math.random() < SHOW_PROB
+	) {
+		show = true;
+		s.shown += 1;
+		s.lastShown = s.n;
+	}
+	save(s);
+	return show;
+}
+
+// The user gave a rating (up or down): stop asking for the rest of the session.
+export function markRated() {
+	const s = load();
+	s.rated = true;
+	save(s);
+}
+
+// The bar was shown and dismissed without a rating (moved on / typed next query).
+// Back off entirely after IGNORE_CAP of these.
+export function markIgnored() {
+	const s = load();
+	s.ignores += 1;
+	if (s.ignores >= IGNORE_CAP) s.stopped = true;
+	save(s);
+}

--- a/frontend/src/lib/feedbackGate.spec.js
+++ b/frontend/src/lib/feedbackGate.spec.js
@@ -1,0 +1,69 @@
+// Behavioural tests for the post-reply feedback throttle. jsdom gives us a real
+// localStorage; Math.random is stubbed so the ~1-in-3 dice are deterministic.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FEEDBACK_MIN_MS, markIgnored, markRated, shouldOfferFeedback } from "./feedbackGate";
+
+const LONG = FEEDBACK_MIN_MS + 5000;
+
+function passDice() {
+	vi.spyOn(Math, "random").mockReturnValue(0.05); // < 1/3
+}
+function failDice() {
+	vi.spyOn(Math, "random").mockReturnValue(0.99); // >= 1/3
+}
+
+beforeEach(() => {
+	localStorage.clear();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("feedbackGate", () => {
+	it("never shows on a reply shorter than the threshold", () => {
+		passDice();
+		expect(shouldOfferFeedback(FEEDBACK_MIN_MS - 1)).toBe(false);
+	});
+
+	it("shows on the first long reply when the dice pass", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true);
+	});
+
+	it("stays hidden when the ~1-in-3 dice fail", () => {
+		failDice();
+		expect(shouldOfferFeedback(LONG)).toBe(false);
+	});
+
+	it("enforces a cooldown of several replies between asks", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true); // shown at reply #1
+		for (let i = 0; i < 4; i++) expect(shouldOfferFeedback(LONG)).toBe(false); // within cooldown
+		expect(shouldOfferFeedback(LONG)).toBe(true); // cooldown elapsed -> 2nd show
+	});
+
+	it("caps at 2 shows per session", () => {
+		passDice();
+		let shows = 0;
+		for (let i = 0; i < 40; i++) if (shouldOfferFeedback(LONG)) shows++;
+		expect(shows).toBe(2);
+	});
+
+	it("stops asking once the user rates", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true);
+		markRated();
+		for (let i = 0; i < 20; i++) expect(shouldOfferFeedback(LONG)).toBe(false);
+	});
+
+	it("backs off after two ignores", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true); // show #1
+		markIgnored();
+		for (let i = 0; i < 4; i++) shouldOfferFeedback(LONG); // ride out the cooldown
+		expect(shouldOfferFeedback(LONG)).toBe(true); // show #2
+		markIgnored(); // second ignore -> stopped
+		for (let i = 0; i < 20; i++) expect(shouldOfferFeedback(LONG)).toBe(false);
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1780,6 +1780,11 @@
 										</button>
 									</div>
 								</div>
+								<FeedbackBar
+									v-if="feedbackFor === m.name"
+									@rate="onFeedbackRate"
+									@close="onFeedbackClose"
+								/>
 							</template>
 						</Message>
 					</template>
@@ -4090,6 +4095,8 @@ import {
 } from "vue";
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
 import * as api from "@/api";
+import FeedbackBar from "@/components/chat/FeedbackBar.vue";
+import { shouldOfferFeedback, markRated, markIgnored } from "@/lib/feedbackGate";
 import * as voice from "@/api/voice";
 import { agentName, isWhitelabeled } from "@/branding";
 import { useAudioRecorder } from "@/composables/useAudioRecorder";
@@ -4227,6 +4234,36 @@ const promptHistory = ref([]);
 const histIdx = ref(null);
 const histDraft = ref("");
 const sending = ref(false);
+
+// ---- post-reply feedback line (lib/feedbackGate decides IF/when it appears) ----
+const feedbackFor = ref(null); // message name currently showing the feedback bar
+const feedbackRated = ref(false); // did the user rate the current bar?
+const feedbackEvaluated = new Set(); // message names already run through the gate
+function maybeOfferFeedback(m) {
+	if (!m || m.role !== "assistant" || m.error || m.stopped) return;
+	if (feedbackEvaluated.has(m.name)) return;
+	feedbackEvaluated.add(m.name); // gate each reply exactly once
+	const secs = parseFloat(elapsedOf(m)) || 0;
+	if (shouldOfferFeedback(secs * 1000)) {
+		feedbackFor.value = m.name;
+		feedbackRated.value = false;
+	}
+}
+function onFeedbackRate({ rating, note }) {
+	feedbackRated.value = true;
+	markRated(); // any rating stops further asks this session
+	const target = feedbackFor.value;
+	if (target) api.submitFeedback(target, rating, note || "").catch(() => {}); // best-effort
+}
+function onFeedbackClose() {
+	feedbackFor.value = null;
+}
+function dismissFeedback() {
+	// Starting the next query clears a still-unanswered bar (counts as an ignore).
+	if (!feedbackFor.value) return;
+	if (!feedbackRated.value) markIgnored();
+	feedbackFor.value = null;
+}
 const waiting = ref(false);
 // Phase-0 admission (chat concurrency): when a send is accepted but QUEUED
 // (all in-flight slots taken), the reply hasn't started - we show a "~N ahead"
@@ -8354,6 +8391,7 @@ function resendFailed(m) {
 // optional `context`, e.g. a dashboard): consumed by the first send below.
 let _prefillSendContext = null;
 async function send(textArg, resendAck) {
+	dismissFeedback(); // sending the next turn clears any pending feedback line
 	// Don't race a dictation that hasn't landed: sending now would drop the spoken words (the
 	// transcript would arrive AFTER the message left the composer). Block on the real busy
 	// signal — recording, or a recording still being transcribed — NOT hasUnfinished(), which
@@ -9003,6 +9041,9 @@ function onEvent(p) {
 					},
 				};
 			}
+			// Post-reply feedback line: offer it (throttled) now the reply is
+			// finalized and its duration is stamped. Only here - never on history load.
+			if (m) maybeOfferFeedback(m);
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;
@@ -10223,6 +10264,7 @@ function openUserFile(a) {
 // ---- mentions (@ user, / doctype·tool) ----
 let _mentionSeq = 0;
 function onInput() {
+	dismissFeedback(); // starting the next query clears any pending feedback line
 	histIdx.value = null; // typing exits prompt-history navigation
 	const el = composerRef.value?.el;
 	if (!el) return;

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1779,6 +1779,15 @@ def push_bench_heartbeat(heartbeat: dict) -> dict:
 	return _post(path=_m("api.tenant.ingest_bench_heartbeat"), body={"heartbeat": heartbeat})
 
 
+def push_chat_feedback(item: dict) -> dict:
+	"""Push one chat-reply rating (thumbs up/down + optional note) to admin for the
+	tenant-wise Feedback dashboard. Admin upserts on (tenant, message). Called
+	best-effort from jarvis.chat.feedback.submit_feedback, which swallows failures
+	so a lost rating never blocks the tap.
+	Raises AdminAuthError / AdminUnreachableError / AdminValidationError."""
+	return _post(path=_m("api.tenant.ingest_chat_feedback"), body={"item": item})
+
+
 def pair_chat_device(public_key: str, device_id: str, *, request_timeout_s: int = 30) -> dict:
 	"""POST customer's chat device pubkey to admin; admin asks the fleet-agent
 	to write a PairedDevice record into the customer's agent container and

--- a/jarvis/chat/feedback.py
+++ b/jarvis/chat/feedback.py
@@ -1,0 +1,96 @@
+"""Post-reply chat feedback: a thumbs up/down (with an optional note on a down)
+on an assistant reply, forwarded to the admin fleet dashboard.
+
+Direct-send, no local table: this bench keeps NO copy. ``submit_feedback``
+derives every piece of metadata server-side (tenant is derived on the admin side
+from the authenticated principal), then forwards it best-effort. A failed forward
+is dropped silently - feedback is low-stakes, and a blocked tap is not acceptable.
+The reply text is never sent; only the rating, refs, and a bounded optional note.
+
+Only the caller's OWN assistant messages can be rated (ownership via the same
+gate the rest of the chat surface uses, ``chat.api._get_owned_conversation``).
+"""
+
+from __future__ import annotations
+
+import re
+
+import frappe
+
+from jarvis.chat.api import _get_owned_conversation
+from jarvis.permissions import require_jarvis_access
+
+MSG = "Jarvis Chat Message"
+CONV = "Jarvis Conversation"
+
+_RATINGS = {"up", "down"}
+_MAX_NOTE = 1000
+#: The openclaw session UUID lives as the last segment of a composite session_key
+#: like "agent:main:dashboard:<uuid>"; the admin transcript viewer keys on the
+#: bare UUID (fleet.transcripts._SESSION_ID_RE). Empty when absent/malformed - the
+#: rating still records, only the Support deep-link is best-effort.
+_SESSION_UUID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
+
+
+@frappe.whitelist()
+def submit_feedback(message_id: str, rating: str, note: str | None = None) -> dict:
+	"""Record a thumbs up/down on one assistant reply and forward it to admin.
+
+	Args:
+		message_id: the Jarvis Chat Message name of the assistant reply.
+		rating: "up" or "down".
+		note: optional free text, kept only on a "down".
+
+	The rating commits on the first call (thumbs tap); a later call carrying the
+	note folds onto the same admin row (upsert). Returns ``{"ok": True}`` even when
+	the forward fails - the tap must never surface an error.
+	"""
+	require_jarvis_access()
+	rating = (rating or "").strip()
+	if rating not in _RATINGS:
+		frappe.throw("rating must be 'up' or 'down'", frappe.ValidationError)
+
+	# Raw db read bypasses field permlevel; we only need these four columns.
+	msg = frappe.db.get_value(
+		MSG, message_id, ["conversation", "role", "model", "reply_duration_ms"], as_dict=True
+	)
+	if not msg:
+		frappe.throw("message not found", frappe.DoesNotExistError)
+	if msg.role != "assistant":
+		frappe.throw("can only rate assistant replies", frappe.ValidationError)
+
+	# Ownership: the canonical chat gate (raises PermissionError for another user's
+	# conversation, DoesNotExistError if it vanished). session_key is permlevel-1;
+	# read it via db.get_value to bypass that, matching how the worker touches it.
+	_get_owned_conversation(msg.conversation)
+	session_key = frappe.db.get_value(CONV, msg.conversation, "session_key")
+
+	payload = {
+		"rating": rating,
+		"message_ref": message_id,
+		"conversation_ref": msg.conversation,
+		"session_id": _session_uuid(session_key),
+		"model": msg.model or "",
+		"user_ref": frappe.session.user,
+		"reply_duration_ms": msg.reply_duration_ms or 0,
+		"note": (note or "").strip()[:_MAX_NOTE] if rating == "down" else "",
+	}
+	_forward(payload)
+	return {"ok": True}
+
+
+def _session_uuid(session_key: str | None) -> str:
+	"""Bare openclaw session UUID from a composite session_key, or "" when absent."""
+	tail = (session_key or "").rsplit(":", 1)[-1]
+	return tail if _SESSION_UUID_RE.match(tail) else ""
+
+
+def _forward(payload: dict) -> None:
+	"""Best-effort forward to admin. NEVER raises to the caller: a lost rating is
+	acceptable (low-stakes), a blocked or errored tap is not."""
+	try:
+		from jarvis import admin_client
+
+		admin_client.push_chat_feedback(payload)
+	except Exception:
+		frappe.log_error(title="chat feedback forward failed")

--- a/jarvis/chat/feedback.py
+++ b/jarvis/chat/feedback.py
@@ -25,10 +25,9 @@ CONV = "Jarvis Conversation"
 
 _RATINGS = {"up", "down"}
 _MAX_NOTE = 1000
-#: The openclaw session UUID lives as the last segment of a composite session_key
-#: like "agent:main:dashboard:<uuid>"; the admin transcript viewer keys on the
-#: bare UUID (fleet.transcripts._SESSION_ID_RE). Empty when absent/malformed - the
-#: rating still records, only the Support deep-link is best-effort.
+#: The agent session UUID lives as the last segment of a composite session_key
+#: like "agent:main:dashboard:<uuid>". Empty when absent/malformed - the rating
+#: still records; only the admin-side deep-link is best-effort.
 _SESSION_UUID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
 
 
@@ -80,7 +79,7 @@ def submit_feedback(message_id: str, rating: str, note: str | None = None) -> di
 
 
 def _session_uuid(session_key: str | None) -> str:
-	"""Bare openclaw session UUID from a composite session_key, or "" when absent."""
+	"""Bare agent session UUID from a composite session_key, or "" when absent."""
 	tail = (session_key or "").rsplit(":", 1)[-1]
 	return tail if _SESSION_UUID_RE.match(tail) else ""
 

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -301,6 +301,63 @@
 								</div>
 								<div class="jvp-m-bot jv-md" v-html="renderReply(m.content)"></div>
 							</div>
+							<div v-if="fbFor === m.name" class="jvp-fb">
+								<div v-if="fbState === 'idle'" class="jvp-fb-pills">
+									<span class="jvp-fb-q">Was this helpful?</span>
+									<button
+										type="button"
+										class="jvp-fb-pill"
+										@click="fbUp(m.name)"
+									>
+										<svg
+											viewBox="0 0 24 24"
+											fill="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												d="M9 21h8.2a2 2 0 0 0 1.96-1.6l1.4-7A2 2 0 0 0 18.6 10H14V5a2.5 2.5 0 0 0-2.5-2.5L8 11v10zM2 11h4v10H2z"
+											/></svg
+										>Yes
+									</button>
+									<button
+										type="button"
+										class="jvp-fb-pill"
+										@click="fbNo(m.name)"
+									>
+										<svg
+											viewBox="0 0 24 24"
+											fill="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												d="M15 3H6.8a2 2 0 0 0-1.96 1.6l-1.4 7A2 2 0 0 0 5.4 14H10v5a2.5 2.5 0 0 0 2.5 2.5L16 13V3zM22 3h-4v10h4z"
+											/></svg
+										>No
+									</button>
+								</div>
+								<div v-else-if="fbState === 'comment'" class="jvp-fb-cmt">
+									<textarea
+										v-model="fbNote"
+										class="jvp-fb-ta"
+										rows="2"
+										maxlength="1000"
+										placeholder="What went wrong? (optional)"
+									></textarea>
+									<div class="jvp-fb-actions">
+										<button
+											type="button"
+											class="jvp-fb-send"
+											@click="fbSend(m.name)"
+										>
+											Send
+										</button>
+										<button type="button" class="jvp-fb-skip" @click="fbSkip">
+											Skip
+										</button>
+									</div>
+								</div>
+								<div v-else class="jvp-fb-done">Thanks for the feedback</div>
+							</div>
 						</template>
 
 						<div v-if="stream.live && stream.live.text" class="jvp-row">
@@ -637,7 +694,9 @@ import {
 	getChatUiSettings,
 	isReadyForChat,
 	resyncLlm,
+	submitFeedback,
 } from "./panel_api.mjs";
+import { shouldOfferFeedback, markRated, markIgnored } from "./feedback_gate.mjs";
 
 const props = defineProps({
 	open: { type: Boolean, default: false },
@@ -961,6 +1020,71 @@ const rootStyle = computed(() => {
 // Tool rows and empty shells are filtered out: this panel is text-only, and
 // the raw list is mostly machine chatter (see chat_stream.visibleMessages).
 const shownMessages = computed(() => visibleMessages(messages.value));
+
+// ---- post-reply feedback pills (feedback_gate decides IF/when they appear) ----
+const fbFor = ref(null); // message name currently showing the pills
+const fbState = ref("idle"); // idle | comment | done
+const fbNote = ref("");
+const fbRated = ref(false);
+const fbSeen = new Set(); // message names already run through the gate
+let fbAwaiting = false; // a user-initiated turn is in flight
+function offerFeedbackFor(m) {
+	if (!m || m.role !== "assistant" || m.streaming || m.error) return;
+	if (fbSeen.has(m.name)) return;
+	fbSeen.add(m.name);
+	if (shouldOfferFeedback(Number(m.reply_duration_ms || 0))) {
+		fbFor.value = m.name;
+		fbState.value = "idle";
+		fbNote.value = "";
+		fbRated.value = false;
+	}
+}
+watch(shownMessages, (list) => {
+	// Only after a turn the user just sent settles as an assistant reply - never
+	// on history load (fbAwaiting is false then).
+	if (!fbAwaiting) return;
+	const last = list[list.length - 1];
+	if (last && last.role === "assistant" && !last.streaming) {
+		fbAwaiting = false;
+		offerFeedbackFor(last);
+	}
+});
+function fbCommit(name, rating, note) {
+	fbRated.value = true;
+	markRated();
+	submitFeedback(name, rating, note || "").catch(() => {});
+}
+function fbDone() {
+	fbState.value = "done";
+	setTimeout(() => {
+		fbFor.value = null;
+		fbState.value = "idle";
+		fbNote.value = "";
+	}, 1600);
+}
+function fbUp(name) {
+	fbCommit(name, "up", "");
+	fbDone();
+}
+function fbNo(name) {
+	fbCommit(name, "down", ""); // commit the down; note folds in on Send
+	fbState.value = "comment";
+}
+function fbSend(name) {
+	const t = (fbNote.value || "").trim();
+	if (t) fbCommit(name, "down", t);
+	fbDone();
+}
+function fbSkip() {
+	fbDone();
+}
+function dismissFeedback() {
+	if (!fbFor.value) return;
+	if (!fbRated.value) markIgnored();
+	fbFor.value = null;
+	fbState.value = "idle";
+	fbNote.value = "";
+}
 // Whitelabel: the desk widget reads branding from bootinfo (set_jarvis_boot),
 // synchronously so there's no flash. Blank => Jarvis defaults.
 const brandName = (window.frappe?.boot?.jarvis_agent_name || "").trim() || "Jarvis";
@@ -1396,6 +1520,8 @@ async function send() {
 	const atts = attachments.value.slice();
 	if ((!text && !atts.length) || sending.value || stream.value.live) return;
 	sending.value = true;
+	dismissFeedback(); // a new turn clears any pending feedback pills
+	fbAwaiting = true; // watch shownMessages for this turn's reply
 	loadError.value = "";
 	// A new attempt supersedes the previous failure's notice.
 	clearTurnError();
@@ -2368,6 +2494,94 @@ defineExpose({ load, startNewChat, convId });
 	line-height: 1.5;
 	color: var(--jv-ink);
 	overflow-wrap: anywhere;
+}
+
+/* post-reply feedback pills (mini widget) */
+.jvp-fb {
+	margin: 8px 0 2px 36px;
+}
+.jvp-fb-pills {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 7px;
+}
+.jvp-fb-q {
+	font-size: 12px;
+	color: var(--jv-ink-2);
+}
+.jvp-fb-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	padding: 4px 10px;
+	border-radius: 20px;
+	border: 1px solid var(--jv-rule-2);
+	color: var(--jv-accent);
+	background: var(--jv-chip-3);
+	transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.jvp-fb-pill svg {
+	width: 13px;
+	height: 13px;
+}
+.jvp-fb-pill:hover {
+	background: var(--jv-accent);
+	color: #fff;
+	border-color: var(--jv-accent);
+}
+.jvp-fb-cmt {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+	max-width: calc(100% - 36px);
+}
+.jvp-fb-ta {
+	width: 100%;
+	resize: vertical;
+	min-height: 46px;
+	font-family: inherit;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--jv-ink);
+	background: var(--jv-comp-bg);
+	border: 1px solid var(--jv-comp-bd);
+	border-radius: 10px;
+	padding: 7px 9px;
+	outline: none;
+}
+.jvp-fb-ta:focus {
+	border-color: var(--jv-accent);
+}
+.jvp-fb-actions {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+}
+.jvp-fb-send {
+	font-size: 12px;
+	font-weight: 600;
+	color: #fff;
+	background: var(--jv-grad);
+	border: 0;
+	border-radius: 8px;
+	padding: 5px 13px;
+	cursor: pointer;
+}
+.jvp-fb-skip {
+	font-size: 12px;
+	color: var(--jv-ink-3);
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+}
+.jvp-fb-done {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--jv-accent);
 }
 
 /* "Open in full chat" chip: stands in for content this panel can't draw

--- a/jarvis/public/js/jarvis_chat/widget/feedback_gate.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/feedback_gate.mjs
@@ -1,0 +1,90 @@
+// Client-side throttle for the mini-widget feedback pills. Mirrors the main
+// SPA's lib/feedbackGate.js and shares its localStorage key, so the per-day caps
+// are unified across both chat surfaces (a user who rates in the SPA won't also
+// be nagged in the widget the same day). Keep the two in sync if either changes.
+
+const KEY = "jvChatFeedback.v1";
+
+export const FEEDBACK_MIN_MS = 60000; // only genuinely long replies (> 1 min)
+
+const SHOW_PROB = 1 / 3;
+const COOLDOWN_REPLIES = 5;
+const SESSION_CAP = 2;
+const IGNORE_CAP = 2;
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function fresh() {
+  return {
+    day: today(),
+    n: 0,
+    lastShown: null,
+    shown: 0,
+    rated: false,
+    ignores: 0,
+    stopped: false,
+  };
+}
+
+function load() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) || "null");
+    if (!raw || raw.day !== today()) return fresh();
+    return {
+      day: raw.day,
+      n: raw.n | 0,
+      lastShown: raw.lastShown == null ? null : raw.lastShown | 0,
+      shown: raw.shown | 0,
+      rated: !!raw.rated,
+      ignores: raw.ignores | 0,
+      stopped: !!raw.stopped,
+    };
+  } catch {
+    return fresh();
+  }
+}
+
+function save(s) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch {
+    /* storage disabled - degrade to "never show" */
+  }
+}
+
+export function shouldOfferFeedback(durationMs) {
+  const s = load();
+  s.n += 1;
+  let show = false;
+  const cooldownOk =
+    s.lastShown === null || s.n - s.lastShown >= COOLDOWN_REPLIES;
+  if (
+    !s.stopped &&
+    !s.rated &&
+    s.shown < SESSION_CAP &&
+    Number(durationMs) >= FEEDBACK_MIN_MS &&
+    cooldownOk &&
+    Math.random() < SHOW_PROB
+  ) {
+    show = true;
+    s.shown += 1;
+    s.lastShown = s.n;
+  }
+  save(s);
+  return show;
+}
+
+export function markRated() {
+  const s = load();
+  s.rated = true;
+  save(s);
+}
+
+export function markIgnored() {
+  const s = load();
+  s.ignores += 1;
+  if (s.ignores >= IGNORE_CAP) s.stopped = true;
+  save(s);
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -106,6 +106,15 @@ export async function transcribeAudio(blob, durationS) {
 export const stopRun = (conversation, runId) =>
   call(CHAT + "stop_run", { conversation, run_id: runId || "" });
 
+// Post-reply feedback: a thumbs up/down (+ optional note on a down) on one
+// assistant reply. Best-effort - the bench forwards it to the admin dashboard.
+export const submitFeedback = (messageId, rating, note) =>
+  call("jarvis.chat.feedback.submit_feedback", {
+    message_id: messageId,
+    rating,
+    note: note || "",
+  });
+
 // Resolves a write-confirmation gate raised by an `action:pending` frame.
 export const confirmTool = (token, conversation) =>
   call(ACTIONS + "confirm_tool", { token, conversation: conversation || "" });

--- a/jarvis/tests/test_chat_feedback.py
+++ b/jarvis/tests/test_chat_feedback.py
@@ -1,0 +1,153 @@
+"""Tests for jarvis.chat.feedback.submit_feedback.
+
+Runs as a dedicated fixture user so cleanups stay scoped to disposable rows.
+The admin forward is mocked (never hits a real admin); these assert the
+server-side derivation, the ownership gate, and the best-effort swallow.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import create_conversation
+from jarvis.chat.feedback import submit_feedback
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TEST_USER = "jarvis-feedback-test@example.com"
+
+_UUID = "12345678-1234-1234-1234-123456789abc"
+_SESSION_KEY = f"agent:main:dashboard:{_UUID}"
+
+
+def _ensure_test_user(user: str = TEST_USER) -> None:
+	if frappe.db.exists("User", user):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": user,
+			"first_name": "Feedback",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	).insert(ignore_permissions=True)
+	doc.add_roles("System Manager")
+	frappe.db.commit()
+
+
+def _delete_conv(name: str) -> None:
+	for child in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
+		frappe.delete_doc(MSG, child, ignore_permissions=True, force=True)
+	if frappe.db.exists(CONV, name):
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	frappe.db.commit()
+
+
+def _cleanup_user_conversations(user: str = TEST_USER) -> None:
+	for name in frappe.get_all(CONV, filters={"owner": user}, pluck="name"):
+		_delete_conv(name)
+
+
+def _add_msg(conversation, role="assistant", model="gpt-5.5", duration=84000, seq=2):
+	m = frappe.get_doc(
+		{"doctype": MSG, "conversation": conversation, "seq": seq, "role": role, "content": "answer"}
+	).insert(ignore_permissions=True)
+	if role == "assistant":
+		frappe.db.set_value(MSG, m.name, {"model": model, "reply_duration_ms": duration})
+	frappe.db.commit()
+	return m.name
+
+
+class _FeedbackTestCase(FrappeTestCase):
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv = create_conversation()
+		frappe.db.set_value(CONV, self.conv, "session_key", _SESSION_KEY)
+		self.msg = _add_msg(self.conv)
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _item(self, push):
+		push.assert_called_once()
+		return push.call_args.args[0]
+
+
+class TestSubmitFeedback(_FeedbackTestCase):
+	def test_up_forwards_derived_payload(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			res = submit_feedback(message_id=self.msg, rating="up")
+		self.assertEqual(res, {"ok": True})
+		item = self._item(push)
+		self.assertEqual(item["rating"], "up")
+		self.assertEqual(item["message_ref"], self.msg)
+		self.assertEqual(item["conversation_ref"], self.conv)
+		self.assertEqual(item["session_id"], _UUID)  # extracted from composite session_key
+		self.assertEqual(item["model"], "gpt-5.5")
+		self.assertEqual(item["reply_duration_ms"], 84000)
+		self.assertEqual(item["user_ref"], TEST_USER)
+		self.assertEqual(item["note"], "")
+
+	def test_down_keeps_stripped_note(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			submit_feedback(message_id=self.msg, rating="down", note="  too slow  ")
+		item = self._item(push)
+		self.assertEqual(item["rating"], "down")
+		self.assertEqual(item["note"], "too slow")
+
+	def test_up_never_carries_a_note(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			submit_feedback(message_id=self.msg, rating="up", note="should be dropped")
+		self.assertEqual(self._item(push)["note"], "")
+
+	def test_rejects_bad_rating(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			with self.assertRaises(frappe.ValidationError):
+				submit_feedback(message_id=self.msg, rating="meh")
+		push.assert_not_called()
+
+	def test_rejects_non_assistant_message(self):
+		user_msg = _add_msg(self.conv, role="user", seq=1)
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			with self.assertRaises(frappe.ValidationError):
+				submit_feedback(message_id=user_msg, rating="up")
+		push.assert_not_called()
+
+	def test_rejects_missing_message(self):
+		with self.assertRaises(frappe.DoesNotExistError):
+			submit_feedback(message_id="does-not-exist", rating="up")
+
+	def test_rejects_another_users_message(self):
+		frappe.set_user("Administrator")
+		other = create_conversation()
+		other_msg = _add_msg(other)
+		self.addCleanup(_delete_conv, other)
+		frappe.set_user(TEST_USER)
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			with self.assertRaises(frappe.PermissionError):
+				submit_feedback(message_id=other_msg, rating="up")
+		push.assert_not_called()
+
+	def test_forward_failure_is_swallowed(self):
+		with patch("jarvis.admin_client.push_chat_feedback", side_effect=RuntimeError("admin down")):
+			res = submit_feedback(message_id=self.msg, rating="up")
+		self.assertEqual(res, {"ok": True})  # best-effort: the tap never surfaces the error
+
+	def test_missing_session_key_still_records(self):
+		frappe.db.set_value(CONV, self.conv, "session_key", None)
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			submit_feedback(message_id=self.msg, rating="up")
+		self.assertEqual(self._item(push)["session_id"], "")  # link best-effort, rating still forwarded
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Quiet thumbs up/down after a long (>1 min) assistant reply, throttled entirely client-side (~1-in-3 of qualifying replies, cooldown, max 2/session, backs off after a rating or two ignores). Thumbs-down opens an optional "what went wrong" note; the line dismisses when you start the next query.

Direct-send, no customer-side table: `submit_feedback` verifies the caller owns the rated message, derives tenant/session/model/duration server-side, and forwards best-effort to the admin fleet dashboard (dropped silently if admin is unreachable — the tap never blocks).

Surfaces: SPA soft prompt bar (`FeedbackBar.vue` + `lib/feedbackGate.js`, unit-tested) wired at run:end in `ChatView.vue`; mini widget accent pills (`Panel.vue`) sharing the same throttle via `widget/feedback_gate.mjs`.

Pairs with **jarvis-admin-v2#458** (doctype + ingest + dashboard) — merge together.