### PR TITLE
ci: release automation (backport to version-16-hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+# Tags and publishes a release whenever a stable branch (version-N) moves. Under the hotfix
+# model the only thing that lands on a stable branch is the release PR from version-N-hotfix,
+# and that PR carries the __version__ bump (release-guard.yml refuses it otherwise), so every
+# push here IS a release: read __version__, tag the merge commit vN.x.y, publish a GitHub
+# Release with notes generated from the previous tag on the same line.
+#
+# Idempotent: if the tag already exists nothing happens, so a failed run can be re-run from
+# the Actions tab (workflow_dispatch) without side effects. "Latest" goes only to the highest
+# version-N line, so a v15 release never displaces the v16 one.
+#
+# The token is github-actions[bot]; the "Release tags" ruleset must list the GitHub Actions
+# app (Integration 15368) as a bypass actor or the tag push is refused.
+
+on:
+  push:
+    branches: [version-15, version-16]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Tag and publish if __version__ is new
+        run: |
+          set -euo pipefail
+          v="$(sed -n 's/^__version__ = "\([^"]*\)".*/\1/p' jarvis/__init__.py)"
+          line="${GITHUB_REF_NAME#version-}"
+          case "$GITHUB_REF_NAME" in
+            version-[0-9]*) ;;
+            *) echo "::error::Release runs only on a version-N branch (got $GITHUB_REF_NAME)"; exit 1 ;;
+          esac
+          if [ -z "$v" ] || [ "${v%%.*}" != "$line" ]; then
+            echo "::error::__version__ '$v' is not on the $line.x line of $GITHUB_REF_NAME"; exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/v$v" >/dev/null; then
+            echo "v$v already tagged, nothing to do"; exit 0
+          fi
+          prev="$(git tag -l "v$line.*" --sort=-v:refname | head -1)"
+          highest="$(git ls-remote --heads origin 'version-*' | sed -n 's|.*/version-\([0-9]*\)$|\1|p' | sort -n | tail -1)"
+          latest=false; [ "$line" = "$highest" ] && latest=true
+          echo "release v$v on $GITHUB_REF_NAME (previous: ${prev:-none}, latest=$latest)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$v" -m "v$v" "$GITHUB_SHA"
+          git push origin "v$v"
+          gh release create "v$v" --verify-tag --title "v$v" --generate-notes \
+            ${prev:+--notes-start-tag "$prev"} --latest="$latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,24 +41,30 @@ jobs:
         run: |
           set -euo pipefail
           v="$(sed -n 's/^__version__ = "\([^"]*\)".*/\1/p' jarvis/__init__.py)"
+          if [[ ! "$GITHUB_REF_NAME" =~ ^version-[0-9]+$ ]]; then
+            echo "::error::Release runs only on a version-N branch (got $GITHUB_REF_NAME)"; exit 1
+          fi
           line="${GITHUB_REF_NAME#version-}"
-          case "$GITHUB_REF_NAME" in
-            version-[0-9]*) ;;
-            *) echo "::error::Release runs only on a version-N branch (got $GITHUB_REF_NAME)"; exit 1 ;;
-          esac
           if [ -z "$v" ] || [ "${v%%.*}" != "$line" ]; then
             echo "::error::__version__ '$v' is not on the $line.x line of $GITHUB_REF_NAME"; exit 1
           fi
+          # Tag and Release are checked separately so a re-run finishes whatever step failed:
+          # a pushed tag with no Release (API hiccup) must still get its Release.
           if git rev-parse -q --verify "refs/tags/v$v" >/dev/null; then
-            echo "v$v already tagged, nothing to do"; exit 0
+            echo "tag v$v exists"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "v$v" -m "v$v" "$GITHUB_SHA"
+            git push origin "v$v"
+            echo "tagged v$v at $GITHUB_SHA"
           fi
-          prev="$(git tag -l "v$line.*" --sort=-v:refname | head -1)"
+          if gh release view "v$v" >/dev/null 2>&1; then
+            echo "release v$v exists, nothing to do"; exit 0
+          fi
+          prev="$(git tag -l "v$line.*" --sort=-v:refname | grep -vx "v$v" | head -1 || true)"
           highest="$(git ls-remote --heads origin 'version-*' | sed -n 's|.*/version-\([0-9]*\)$|\1|p' | sort -n | tail -1)"
           latest=false; [ "$line" = "$highest" ] && latest=true
-          echo "release v$v on $GITHUB_REF_NAME (previous: ${prev:-none}, latest=$latest)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$v" -m "v$v" "$GITHUB_SHA"
-          git push origin "v$v"
+          echo "publishing v$v on $GITHUB_REF_NAME (previous: ${prev:-none}, latest=$latest)"
           gh release create "v$v" --verify-tag --title "v$v" --generate-notes \
             ${prev:+--notes-start-tag "$prev"} --latest="$latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,10 @@ name: Release
 # the Actions tab (workflow_dispatch) without side effects. "Latest" goes only to the highest
 # version-N line, so a v15 release never displaces the v16 one.
 #
-# The token is github-actions[bot]; the "Release tags" ruleset must list the GitHub Actions
-# app (Integration 15368) as a bypass actor or the tag push is refused.
+# The token is github-actions[bot]. The "Release tags" ruleset therefore must NOT carry a
+# tag `creation` rule (GitHub refuses the built-in Actions app as a bypass actor); it keeps
+# `deletion`, `update` and the vN.N.N name pattern, which is what makes a published tag
+# immutable.
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,11 @@ inside the app.
   `develop` in its own PR so it is not lost on the next backport.
 - A release is one PR, `version-N-hotfix` -> `version-N`, titled `chore: release vN.x.y`,
   merged with a merge commit. Before opening it, bump `__version__` in `jarvis/__init__.py`
-  on the hotfix branch (feature backports bump minor, fix-only bumps patch). After the
-  merge, push an annotated tag `vN.x.y` on the merge commit and publish a GitHub Release
-  with generated notes from the previous tag.
+  on the hotfix branch (feature backports bump minor, fix-only bumps patch). On merge the
+  `Release` workflow (`.github/workflows/release.yml`) tags the merge commit `vN.x.y` and
+  publishes a GitHub Release with notes generated from the previous tag on that line.
+  Check the Releases page afterwards; if the run failed, re-run it from the Actions tab,
+  it is idempotent.
 - Never push directly to any of these five branches; everything lands through a PR.
   The `version-N` rulesets enforce this today, and the `version-N-hotfix` rulesets should
   match them (PR required, no force-push, no deletion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ inside the app.
   on the hotfix branch (feature backports bump minor, fix-only bumps patch). On merge the
   `Release` workflow (`.github/workflows/release.yml`) tags the merge commit `vN.x.y` and
   publishes a GitHub Release with notes generated from the previous tag on that line.
-  Check the Releases page afterwards; if the run failed, re-run it from the Actions tab,
-  it is idempotent.
+  Check the Releases page afterwards; if the run failed, re-run it from the Actions tab.
+  It resumes whatever step was missing (tag, Release, or nothing).
 - Never push directly to any of these five branches; everything lands through a PR.
   The `version-N` rulesets enforce this today, and the `version-N-hotfix` rulesets should
   match them (PR required, no force-push, no deletion).


### PR DESCRIPTION
## Summary

Backport of https://github.com/aerele/jarvis/pull/1098 to `version-16-hotfix`: the `Release` workflow that tags the merge commit and publishes a GitHub Release when a release PR merges into `version-16`. The open release PR picks this up automatically. Cherry-pick of `243019f0`; merge with a merge commit.

## Pre-merge checklist

- [x] CI is green
- [x] Branch is up to date with its base
- [ ] New/changed behavior has tests (workflow only)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01BhuU9nWobCxQe8JWiCzuo6
