### PR TITLE
fix(desk-nudge): match the CTA to the actual readiness reason

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,17 @@ jobs:
       - name: node:test (Desk widget + PWA lib)
         env:
           NODE_OPTIONS: --unhandled-rejections=strict
-        # These two suites are plain node:test with only sibling-module imports (no npm deps),
+        # These suites are plain node:test with only sibling-module imports (no npm deps),
         # so they run from the repo root with bare node - no `npm ci` needed. They were run by
         # NOTHING in CI before, which is exactly how a Desk-widget confirmation-card ordering
         # bug (a dropped field that renumbered a typed "confirm N" onto the wrong ERP write)
-        # shipped under a green build. Gate them here.
+        # shipped under a green build. Gate them here. jarvis_onboarding_banner.test.mjs is the
+        # same gap for the Desk nudge bundle: it `require()`s the bundle's CommonJS export guard
+        # rather than a plain sibling import (see that file's own comment), the one way this
+        # suite differs from the two globs beside it.
         run: |
           node --test jarvis/public/js/jarvis_chat/widget/*.test.mjs
+          node --test jarvis/public/js/jarvis_onboarding_banner.test.mjs
           node --test pwa/src/lib/*.test.js
 
   # The frontend-tests job above runs the SPA's *tests* but never *builds* it — so a Vite/build break

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -40,12 +40,44 @@
 	// bundle is loaded via app_include_js and cannot import from the widget
 	// module graph, so the string is kept in sync here by hand.
 	var AI_MODELS_SETTINGS_URL = "/jarvis/?settings=aimodels";
+	// The SPA's billing page (frontend/src/router/index.js's "Billing" route,
+	// mounted under createWebHistory("/jarvis")), used by the renew-plan CTA.
+	// Same hand-kept-in-sync constraint as AI_MODELS_SETTINGS_URL above.
+	var BILLING_URL = "/jarvis/billing";
 	// Floor between server re-checks for the chatty triggers (route change,
 	// tab focus). A bfcache restore bypasses it: that is the exact moment the
 	// flag is most likely stale and the user is looking straight at it.
 	var RECHECK_MIN_MS = 30 * 1000;
 	var lastCheckAt = 0;
 	var checking = false;
+
+	// jarvis#<this PR>: reasons that mean "an established workspace's control
+	// plane is between states" (still provisioning, a confirmed outage, an
+	// unresolved authority incident, or an account moved to a different site) -
+	// none of them are fixed by anything a Desk nudge can offer, and every one
+	// is reachable only AFTER is_ready_for_chat's local signup+credential
+	// checks already passed (account.py's _admin_chat_gate, or - for the two
+	// provisioning reasons - an established workspace whose apply-confirmed
+	// marker was cleared without a fresh apply timestamp to soften it into
+	// llm_applying/llm_apply_stuck). Sending any of these through the
+	// never-onboarded "Set up Jarvis" pitch would be exactly the bug this table
+	// exists to fix, and there is no honest, specific copy for them yet worth
+	// writing a whole bubble around - so the nudge stays quiet instead. The SPA
+	// gate (frontend/src/onboarding/readiness.js's NOT_ONBOARDED_REASONS) never
+	// force-redirects any of these either; it is the authority for which
+	// reasons truly mean "no history to protect" and this list is deliberately
+	// the complement of that.
+	var SUPPRESSED_REASONS = [
+		// jarvis C2 (pre-existing): an established workspace's first pool/direct
+		// leg is mid-apply.
+		"llm_applying",
+		"container_provisioning",
+		"container_unavailable",
+		"llm_pool_provisioning",
+		"llm_provisioning",
+		"authority_repair_required",
+		"site_replaced",
+	];
 
 	// ERPNext's own setup wizard must be finished first: completing it creates
 	// the first Company. Until then the desk IS the setup wizard, so nudging the
@@ -78,14 +110,13 @@
 	function shouldShow() {
 		if (!window.frappe || !frappe.boot) return false;
 		if (frappe.boot.jarvis_onboarded !== false) return false;
-		// jarvis C2: is_ready_for_chat itself returns ready:false for the soft
-		// "llm_applying" reason (an established workspace's first pool/direct leg
-		// is mid-apply), so jarvis_onboarded reads exactly like a never-set-up
-		// workspace here - but it is not one. Suppress the nudge entirely rather
-		// than routing it through nudgeVariant()'s reconnect copy: an established
-		// workspace mid-apply needs no Desk nudge at all, and the "Set up Jarvis"
-		// fallback pitch would be actively wrong for it.
-		if ((frappe.boot.jarvis_ready_reason || "") === "llm_applying") return false;
+		// is_ready_for_chat returns ready:false for several reasons that read
+		// exactly like a never-set-up workspace here (jarvis_onboarded === false)
+		// but are not one - see SUPPRESSED_REASONS above. Suppress the nudge
+		// entirely for those rather than routing them through nudgeVariant(): an
+		// established workspace between states needs no Desk nudge at all, and
+		// the "Set up Jarvis" fallback pitch would be actively wrong for it.
+		if (SUPPRESSED_REASONS.indexOf(frappe.boot.jarvis_ready_reason || "") !== -1) return false;
 		if (!erpnextSetupComplete()) return false;
 		// A second, sturdier setup signal alongside the sysdefaults flag above:
 		// the Company count (jarvis_site_setup_complete, set in jarvis.boot)
@@ -247,8 +278,62 @@
 				action: "resync",
 			};
 		}
-		// Every other reason (never onboarded, or an empty/unknown reason from an
-		// older boot payload) keeps the original pitch and destination.
+		// account.py only ever returns this once signup + credentials have
+		// already passed once (account._admin_chat_gate is the sole caller), so
+		// a lapsed subscription always means "was working, now paused" - never
+		// "never got that far". Renew is the one action that can fix it; the
+		// wizard's signup step cannot (jarvis review: it would dead-end at the
+		// duplicate-signup guard).
+		if (reason === "subscription_suspended") {
+			return {
+				name: agentName,
+				aria: "Renew " + agentName,
+				text:
+					"Your plan has lapsed, so " +
+					agentName +
+					" is paused. Renew to pick up where you left off.",
+				ctaLabel: "Renew plan →",
+				href: BILLING_URL,
+			};
+		}
+		// Slice 4b (C10b): the subscription leg's OAuth strand aged out mid-connect
+		// (account.py maps admin's chat_readiness "ReconnectRequired" here), also
+		// only reachable after signup + credentials passed once. The recovery is
+		// the wizard's OWN reconnect step (OnboardingView.vue's
+		// startAccountReconnect / can_reconnect offer) - there is no equivalent
+		// action in Settings, so this still points at /jarvis/onboarding, but
+		// with honest copy instead of the never-set-up "meet Jarvis" pitch below.
+		if (reason === "reconnect_required") {
+			return {
+				name: agentName,
+				aria: "Reconnect " + agentName,
+				text:
+					"Your AI subscription needs reconnecting, so " +
+					agentName +
+					" can't reply right now. Reconnect to pick up where you left off.",
+				ctaLabel: "Reconnect →",
+				href: "/jarvis/onboarding",
+			};
+		}
+		// Every other reason keeps the original never-set-up pitch and
+		// destination - deliberately, not just by omission:
+		//   - "signup" / "" / unrecognised: no admin api_key yet, or an older
+		//     boot payload with nothing to classify.
+		//   - "llm_setup": account.py's own docstring guarantees this fires ONLY
+		//     for a workspace that never finished onboarding (no LLM config ever
+		//     confirmed AND the subscription never went Active) - a half-created
+		//     signup, not an established one. Both frontend/src/onboarding/
+		//     readiness.js and the widget's panel_readiness.mjs gate on it as
+		//     "never onboarded" for the same reason.
+		//   - "llm_rejected": a first sync admin explicitly refused. Established
+		//     precedent (panel_readiness.mjs's own comment) is that "the desk
+		//     onboarding banner routes it to setup too" so the three desk
+		//     surfaces (SPA gate, widget, this nudge) agree - do not special-case
+		//     it here without updating that comment and the other two surfaces.
+		//   - "readiness_unconfirmed": account.py guarantees this only for a
+		//     workspace nothing has ever confirmed ready (an established one
+		//     fails OPEN through the same outage instead - _admin_unreachable_
+		//     verdict) - so it never fires on a workspace with history either.
 		return {
 			name: "Jarvis",
 			aria: "Set up Jarvis",
@@ -419,6 +504,16 @@
 		document.addEventListener("visibilitychange", function () {
 			if (document.visibilityState === "visible") syncAndVerify(false);
 		});
+	}
+
+	// Test-only export: this file is a plain script loaded via app_include_js
+	// (see the module comment at the top), not an ES module, so it cannot be
+	// `import`ed the way the widget's *.mjs files are. `module` only exists
+	// under CommonJS (node:test, which the sibling *.test.mjs file uses via
+	// createRequire) - a real browser has no `module` global, so this is inert
+	// in production and does not change what ships to the Desk.
+	if (typeof module !== "undefined" && module.exports) {
+		module.exports = { nudgeVariant: nudgeVariant };
 	}
 
 	if (window.frappe && window.frappe.router) {

--- a/jarvis/public/js/jarvis_onboarding_banner.test.mjs
+++ b/jarvis/public/js/jarvis_onboarding_banner.test.mjs
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+// jarvis_onboarding_banner.bundle.js is a plain script loaded via
+// app_include_js (not an ES module), so it cannot be `import`ed the way the
+// widget's *.mjs files are - it can only be `require`d as CommonJS (see the
+// test-only `module.exports` guard at the bottom of that file). require()
+// executes the file's top level immediately, which touches two browser
+// globals before nudgeVariant() is ever reachable: `window` (the
+// double-injection guard, `window.__jarvisOnboardingBanner`) and `document`
+// (the DOMContentLoaded fallback at the very end, since neither
+// `window.frappe.router` nor `window.$` is set here). Both are stubbed to the
+// bare minimum needed to survive that top level without touching a DOM.
+//
+// `window` is aliased to `globalThis` itself (as it is in a real browser, not
+// a separate object) because the bundle reads the frappe.boot.* fields via a
+// bare `frappe` identifier after a `window.frappe &&` guard - true only when
+// `window` and the global scope are the same object.
+globalThis.window = globalThis;
+globalThis.document = { addEventListener: () => {} };
+globalThis.frappe = undefined;
+
+const require = createRequire(import.meta.url);
+const { nudgeVariant } = require("./jarvis_onboarding_banner.bundle.js");
+
+function setReason(reason, agentName) {
+  globalThis.frappe = {
+    boot: { jarvis_ready_reason: reason, jarvis_agent_name: agentName },
+  };
+}
+
+test("nudgeVariant: subscription_suspended renews via billing, never the wizard", () => {
+  setReason("subscription_suspended", "Nova");
+  const v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Renew plan →");
+  assert.equal(v.href, "/jarvis/billing");
+  assert.match(v.text, /Nova/);
+  assert.doesNotMatch(v.href, /onboarding/);
+});
+
+test("nudgeVariant: reconnect_required uses honest copy, not the never-set-up pitch", () => {
+  setReason("reconnect_required", "Nova");
+  const v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Reconnect →");
+  assert.equal(v.href, "/jarvis/onboarding");
+  assert.match(v.text, /reconnecting/);
+  assert.doesNotMatch(v.text, /Hey/);
+});
+
+test("nudgeVariant: llm_credentials and llm_apply_stuck are unchanged", () => {
+  setReason("llm_credentials", "Nova");
+  let v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Reconnect a model →");
+  assert.equal(v.href, "/jarvis/?settings=aimodels");
+
+  setReason("llm_apply_stuck", "Nova");
+  v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Retry");
+  assert.equal(v.action, "resync");
+});
+
+test("nudgeVariant: reasons account.py guarantees have no history keep the wizard pitch", () => {
+  for (const reason of [
+    "signup",
+    "llm_setup",
+    "llm_rejected",
+    "readiness_unconfirmed",
+    "",
+    "some_future_reason",
+  ]) {
+    setReason(reason, "Nova");
+    const v = nudgeVariant();
+    assert.equal(v.ctaLabel, "Set up Jarvis →", `reason=${reason}`);
+    assert.equal(v.href, "/jarvis/onboarding", `reason=${reason}`);
+  }
+});
+
+test("nudgeVariant: white-label - only the never-set-up pitch says literal Jarvis", () => {
+  setReason("subscription_suspended", "Nova");
+  assert.equal(nudgeVariant().name, "Nova");
+
+  setReason("reconnect_required", "Nova");
+  assert.equal(nudgeVariant().name, "Nova");
+
+  setReason("signup", "Nova");
+  assert.equal(nudgeVariant().name, "Jarvis");
+});


### PR DESCRIPTION
## Summary

The Desk chat-bubble nudge sent every not-ready workspace to the onboarding wizard except `llm_credentials` and `llm_apply_stuck`. Customers see this after disconnecting all AI models in pool mode with no recent apply, or after a subscription lapses: the CTA now matches what actually applies, so an onboarded customer no longer gets bounced back through signup.

| Reason | Scenario | Old CTA | New CTA |
|---|---|---|---|
| `subscription_suspended` | cancelled/lapsed plan | Set up Jarvis → wizard | Renew plan → `/jarvis/billing` |
| `reconnect_required` | subscription OAuth strand aged out | Set up Jarvis → wizard | Reconnect → `/jarvis/onboarding` (its own reconnect step; only the copy changed) |
| `container_provisioning`, `container_unavailable`, `llm_pool_provisioning`, `llm_provisioning`, `authority_repair_required`, `site_replaced` | control-plane outage/incident, or an established pool workspace whose apply marker was cleared without a fresh apply timestamp | Set up Jarvis → wizard | nudge suppressed (nothing here is a Desk-nudge fix) |
| `llm_credentials`, `llm_apply_stuck` | unchanged | (existing) | (existing) |
| `signup`, `llm_setup`, `llm_rejected`, `readiness_unconfirmed`, unknown | genuinely never finished onboarding | Set up Jarvis → wizard | unchanged (account.py's own docstrings guarantee these fire only for a workspace with no history) |

`llm_setup` and `llm_rejected` deliberately keep the wizard pitch rather than getting the generic "creds-gone" treatment: `account.py`'s docstrings guarantee both only fire for a workspace that never finished onboarding, and both frontend surfaces (`readiness.js`, `panel_readiness.mjs`) already gate on them the same way — `panel_readiness.mjs`'s own comment says the desk nudge is expected to agree. The SPA and floating widget needed no change; neither's not-onboarded set includes any of the reasons fixed here.

### Test script
1. `bench --site <site> console`: as a System Manager with a completed workspace, `frappe.db.set_value("Jarvis Settings", "Jarvis Settings", {"llm_pool_synced_at": None, ...})` is not required to see the effect — inspect `nudgeVariant()` output directly via the node suite instead (see below), since live-flipping fields on a shared site risks destroying stored keys.
2. Load any Desk page as System Manager on a workspace with `frappe.boot.jarvis_ready_reason = "subscription_suspended"`: bubble reads "Your plan has lapsed…" with a **Renew plan →** button to `/jarvis/billing`.
3. Same with `"reconnect_required"`: bubble reads "…needs reconnecting…" with **Reconnect →** to `/jarvis/onboarding`.
4. Same with `"container_provisioning"` / `"llm_pool_provisioning"` / etc.: no bubble appears.
5. Same with `"signup"` / `"llm_setup"` / unset: unchanged "Hey 👋 I'm Jarvis…" pitch to `/jarvis/onboarding`.
6. `node --test jarvis/public/js/jarvis_onboarding_banner.test.mjs` — 5/5 pass.

### Checks run
- `node --check` on the bundle: passes.
- `node --test jarvis/public/js/jarvis_chat/widget/*.test.mjs jarvis/public/js/jarvis_onboarding_banner.test.mjs`: 157/157 pass (new file added to `ci.yml`'s existing node:test job).
- `pre-commit run` on the three changed files: passes (prettier reformatted the new test file).
- No live UI/desk verification: `bench build` builds the main checkout, not this worktree, and flipping readiness fields on a shared bench risks destroying stored model keys, so this rests on the code trace + unit tests above. A read-only `bench execute jarvis.account.is_ready_for_chat` on e2e.localhost confirmed the baseline `{ready: true}` shape; no state was changed there.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01HW2uHdQLPLoV8qVXm6Ppxu
