### PR TITLE
fix(desk-nudge): match the CTA to the actual readiness reason

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,17 @@ jobs:
       - name: node:test (Desk widget + PWA lib)
         env:
           NODE_OPTIONS: --unhandled-rejections=strict
-        # These two suites are plain node:test with only sibling-module imports (no npm deps),
+        # These suites are plain node:test with only sibling-module imports (no npm deps),
         # so they run from the repo root with bare node - no `npm ci` needed. They were run by
         # NOTHING in CI before, which is exactly how a Desk-widget confirmation-card ordering
         # bug (a dropped field that renumbered a typed "confirm N" onto the wrong ERP write)
-        # shipped under a green build. Gate them here.
+        # shipped under a green build. Gate them here. jarvis_onboarding_banner.test.mjs is the
+        # same gap for the Desk nudge bundle: it `require()`s the bundle's CommonJS export guard
+        # rather than a plain sibling import (see that file's own comment), the one way this
+        # suite differs from the two globs beside it.
         run: |
           node --test jarvis/public/js/jarvis_chat/widget/*.test.mjs
+          node --test jarvis/public/js/jarvis_onboarding_banner.test.mjs
           node --test pwa/src/lib/*.test.js
 
   # The frontend-tests job above runs the SPA's *tests* but never *builds* it — so a Vite/build break

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,14 +133,21 @@ jobs:
         # so they run from the repo root with bare node - no `npm ci` needed. They were run by
         # NOTHING in CI before, which is exactly how a Desk-widget confirmation-card ordering
         # bug (a dropped field that renumbered a typed "confirm N" onto the wrong ERP write)
-        # shipped under a green build. Gate them here. The second glob covers
-        # jarvis_onboarding_banner.test.mjs (the same gap for the Desk nudge bundle: it
-        # `require()`s the bundle's CommonJS export guard rather than a plain sibling import,
-        # see that file's own comment) and any future *.test.mjs dropped straight into
-        # jarvis/public/js/ alongside it, the same way the widget glob above covers its directory.
+        # shipped under a green build. Gate them here.
+        #
+        # Each glob is `dir/*.test.mjs` - NOT recursive - so it covers only *.test.mjs files
+        # sitting directly in that one directory, never a subdirectory's. jarvis/public/js/
+        # has two: jarvis_onboarding_banner.test.mjs directly in it (the same gap as the
+        # widget's, for the Desk nudge bundle - it `require()`s the bundle's CommonJS export
+        # guard rather than a plain sibling import, see that file's own comment) and
+        # pump_fence.test.mjs under shared/, which needs its own explicit pattern for exactly
+        # this reason - it went ungated for a while after jarvis/public/js/*.test.mjs was
+        # added, on the same silent-mismatch shape this whole job exists to close. A NEW
+        # subdirectory under jarvis/public/js/ with its own *.test.mjs needs the same: add its
+        # own line/pattern here, do not assume an existing glob already reaches it.
         run: |
           node --test jarvis/public/js/jarvis_chat/widget/*.test.mjs
-          node --test jarvis/public/js/*.test.mjs
+          node --test jarvis/public/js/*.test.mjs jarvis/public/js/shared/*.test.mjs
           node --test pwa/src/lib/*.test.js
 
   # The frontend-tests job above runs the SPA's *tests* but never *builds* it — so a Vite/build break

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,14 @@ jobs:
         # so they run from the repo root with bare node - no `npm ci` needed. They were run by
         # NOTHING in CI before, which is exactly how a Desk-widget confirmation-card ordering
         # bug (a dropped field that renumbered a typed "confirm N" onto the wrong ERP write)
-        # shipped under a green build. Gate them here. jarvis_onboarding_banner.test.mjs is the
-        # same gap for the Desk nudge bundle: it `require()`s the bundle's CommonJS export guard
-        # rather than a plain sibling import (see that file's own comment), the one way this
-        # suite differs from the two globs beside it.
+        # shipped under a green build. Gate them here. The second glob covers
+        # jarvis_onboarding_banner.test.mjs (the same gap for the Desk nudge bundle: it
+        # `require()`s the bundle's CommonJS export guard rather than a plain sibling import,
+        # see that file's own comment) and any future *.test.mjs dropped straight into
+        # jarvis/public/js/ alongside it, the same way the widget glob above covers its directory.
         run: |
           node --test jarvis/public/js/jarvis_chat/widget/*.test.mjs
-          node --test jarvis/public/js/jarvis_onboarding_banner.test.mjs
+          node --test jarvis/public/js/*.test.mjs
           node --test pwa/src/lib/*.test.js
 
   # The frontend-tests job above runs the SPA's *tests* but never *builds* it — so a Vite/build break

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -307,6 +307,31 @@ def _has_been_chat_ready(raw: dict) -> bool:
 	return True
 
 
+def has_been_chat_ready() -> bool:
+	"""Public, fail-safe wrapper around ``_has_been_chat_ready`` for callers
+	outside this module that only need the established/never-established
+	fact - not a full readiness verdict.
+
+	jarvis.boot.set_jarvis_boot is the motivating caller: ``jarvis_ready_reason``
+	alone cannot tell a brand-new tenant whose first sync is still pending from
+	an established workspace whose apply-confirmed marker was cleared - both
+	produce the SAME ``llm_pool_provisioning`` / ``llm_provisioning`` reason
+	(``_provisioning_verdict``'s hard-reason exit fires on either). This is the
+	same lightweight, uncached ``tabSingles`` read (``_settings_raw`` over
+	``_GATE_STATE_FIELDS``) that ``is_ready_for_chat``'s own gates already do on
+	nearly every call - a single extra SQL select, never a second readiness
+	computation or an admin round trip.
+
+	Fails safe to ``False`` on any error, matching every other boot.py flag: a
+	boot-time failure here must degrade to "cannot prove this is established",
+	not silently claim it is.
+	"""
+	try:
+		return _has_been_chat_ready(_settings_raw(_GATE_STATE_FIELDS))
+	except Exception:
+		return False
+
+
 def _marker_is_fresh(current) -> bool:
 	"""Is the stored marker recent enough to leave alone? An unset or unreadable
 	stamp is NOT fresh - rewriting it is how a corrupted value heals."""

--- a/jarvis/boot.py
+++ b/jarvis/boot.py
@@ -17,6 +17,13 @@ Keys we set:
   "llm_credentials"``) without a second round trip, so the banner can
   send the second case to the AI models settings pane instead of
   restarting the wizard.
+- ``jarvis_has_been_ready`` - whether this workspace has EVER been
+  confirmed chat-ready (``jarvis.account.has_been_chat_ready``). Some
+  reasons alone are ambiguous: ``llm_pool_provisioning`` /
+  ``llm_provisioning`` fire both for a brand-new tenant whose first sync
+  is still pending AND for an established workspace whose apply-confirmed
+  marker was cleared (e.g. disconnecting all models). This flag is the
+  disambiguator the desk banner needs to pick the right CTA for the two.
 - ``jarvis_has_access`` - whether the current user may reach Jarvis at
   all (``jarvis.permissions.has_jarvis_access``). Lets the desk's
   floating Jarvis button send an unauthorized user to
@@ -50,6 +57,19 @@ def set_jarvis_boot(bootinfo):
 	except Exception:
 		bootinfo.jarvis_onboarded = True  # fail-safe: never nag on a boot error
 		bootinfo.jarvis_ready_reason = ""
+
+	# has_been_chat_ready() is its own fail-safe (returns False on error) and
+	# reads the same lightweight raw-settings fields is_ready_for_chat's own
+	# gates already read - a single extra SQL select, never a second admin
+	# round trip - so this is a plain call, not folded into the try/except
+	# above: a failure in is_ready_for_chat() must not also blank this flag,
+	# and a failure here must not affect jarvis_onboarded/jarvis_ready_reason.
+	try:
+		from jarvis.account import has_been_chat_ready
+
+		bootinfo.jarvis_has_been_ready = bool(has_been_chat_ready())
+	except Exception:
+		bootinfo.jarvis_has_been_ready = False  # fail-safe: never claim established on a boot error
 
 	# Drives the desk's floating Jarvis button: an unauthorized user is routed
 	# to /jarvis-no-access instead of the chat panel opening. Import kept

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -40,12 +40,44 @@
 	// bundle is loaded via app_include_js and cannot import from the widget
 	// module graph, so the string is kept in sync here by hand.
 	var AI_MODELS_SETTINGS_URL = "/jarvis/?settings=aimodels";
+	// The SPA's billing page (frontend/src/router/index.js's "Billing" route,
+	// mounted under createWebHistory("/jarvis")), used by the renew-plan CTA.
+	// Same hand-kept-in-sync constraint as AI_MODELS_SETTINGS_URL above.
+	var BILLING_URL = "/jarvis/billing";
 	// Floor between server re-checks for the chatty triggers (route change,
 	// tab focus). A bfcache restore bypasses it: that is the exact moment the
 	// flag is most likely stale and the user is looking straight at it.
 	var RECHECK_MIN_MS = 30 * 1000;
 	var lastCheckAt = 0;
 	var checking = false;
+
+	// jarvis#<this PR>: reasons that mean "an established workspace's control
+	// plane is between states" (still provisioning, a confirmed outage, an
+	// unresolved authority incident, or an account moved to a different site) -
+	// none of them are fixed by anything a Desk nudge can offer, and every one
+	// is reachable only AFTER is_ready_for_chat's local signup+credential
+	// checks already passed (account.py's _admin_chat_gate, or - for the two
+	// provisioning reasons - an established workspace whose apply-confirmed
+	// marker was cleared without a fresh apply timestamp to soften it into
+	// llm_applying/llm_apply_stuck). Sending any of these through the
+	// never-onboarded "Set up Jarvis" pitch would be exactly the bug this table
+	// exists to fix, and there is no honest, specific copy for them yet worth
+	// writing a whole bubble around - so the nudge stays quiet instead. The SPA
+	// gate (frontend/src/onboarding/readiness.js's NOT_ONBOARDED_REASONS) never
+	// force-redirects any of these either; it is the authority for which
+	// reasons truly mean "no history to protect" and this list is deliberately
+	// the complement of that.
+	var SUPPRESSED_REASONS = [
+		// jarvis C2 (pre-existing): an established workspace's first pool/direct
+		// leg is mid-apply.
+		"llm_applying",
+		"container_provisioning",
+		"container_unavailable",
+		"llm_pool_provisioning",
+		"llm_provisioning",
+		"authority_repair_required",
+		"site_replaced",
+	];
 
 	// ERPNext's own setup wizard must be finished first: completing it creates
 	// the first Company. Until then the desk IS the setup wizard, so nudging the
@@ -78,14 +110,13 @@
 	function shouldShow() {
 		if (!window.frappe || !frappe.boot) return false;
 		if (frappe.boot.jarvis_onboarded !== false) return false;
-		// jarvis C2: is_ready_for_chat itself returns ready:false for the soft
-		// "llm_applying" reason (an established workspace's first pool/direct leg
-		// is mid-apply), so jarvis_onboarded reads exactly like a never-set-up
-		// workspace here - but it is not one. Suppress the nudge entirely rather
-		// than routing it through nudgeVariant()'s reconnect copy: an established
-		// workspace mid-apply needs no Desk nudge at all, and the "Set up Jarvis"
-		// fallback pitch would be actively wrong for it.
-		if ((frappe.boot.jarvis_ready_reason || "") === "llm_applying") return false;
+		// is_ready_for_chat returns ready:false for several reasons that read
+		// exactly like a never-set-up workspace here (jarvis_onboarded === false)
+		// but are not one - see SUPPRESSED_REASONS above. Suppress the nudge
+		// entirely for those rather than routing them through nudgeVariant(): an
+		// established workspace between states needs no Desk nudge at all, and
+		// the "Set up Jarvis" fallback pitch would be actively wrong for it.
+		if (SUPPRESSED_REASONS.indexOf(frappe.boot.jarvis_ready_reason || "") !== -1) return false;
 		if (!erpnextSetupComplete()) return false;
 		// A second, sturdier setup signal alongside the sysdefaults flag above:
 		// the Company count (jarvis_site_setup_complete, set in jarvis.boot)
@@ -247,8 +278,62 @@
 				action: "resync",
 			};
 		}
-		// Every other reason (never onboarded, or an empty/unknown reason from an
-		// older boot payload) keeps the original pitch and destination.
+		// account.py only ever returns this once signup + credentials have
+		// already passed once (account._admin_chat_gate is the sole caller), so
+		// a lapsed subscription always means "was working, now paused" - never
+		// "never got that far". Renew is the one action that can fix it; the
+		// wizard's signup step cannot (jarvis review: it would dead-end at the
+		// duplicate-signup guard).
+		if (reason === "subscription_suspended") {
+			return {
+				name: agentName,
+				aria: "Renew " + agentName,
+				text:
+					"Your plan has lapsed, so " +
+					agentName +
+					" is paused. Renew to pick up where you left off.",
+				ctaLabel: "Renew plan →",
+				href: BILLING_URL,
+			};
+		}
+		// Slice 4b (C10b): the subscription leg's OAuth strand aged out mid-connect
+		// (account.py maps admin's chat_readiness "ReconnectRequired" here), also
+		// only reachable after signup + credentials passed once. The recovery is
+		// the wizard's OWN reconnect step (OnboardingView.vue's
+		// startAccountReconnect / can_reconnect offer) - there is no equivalent
+		// action in Settings, so this still points at /jarvis/onboarding, but
+		// with honest copy instead of the never-set-up "meet Jarvis" pitch below.
+		if (reason === "reconnect_required") {
+			return {
+				name: agentName,
+				aria: "Reconnect " + agentName,
+				text:
+					"Your AI subscription needs reconnecting, so " +
+					agentName +
+					" can't reply right now. Reconnect to pick up where you left off.",
+				ctaLabel: "Reconnect →",
+				href: "/jarvis/onboarding",
+			};
+		}
+		// Every other reason keeps the original never-set-up pitch and
+		// destination - deliberately, not just by omission:
+		//   - "signup" / "" / unrecognised: no admin api_key yet, or an older
+		//     boot payload with nothing to classify.
+		//   - "llm_setup": account.py's own docstring guarantees this fires ONLY
+		//     for a workspace that never finished onboarding (no LLM config ever
+		//     confirmed AND the subscription never went Active) - a half-created
+		//     signup, not an established one. Both frontend/src/onboarding/
+		//     readiness.js and the widget's panel_readiness.mjs gate on it as
+		//     "never onboarded" for the same reason.
+		//   - "llm_rejected": a first sync admin explicitly refused. Established
+		//     precedent (panel_readiness.mjs's own comment) is that "the desk
+		//     onboarding banner routes it to setup too" so the three desk
+		//     surfaces (SPA gate, widget, this nudge) agree - do not special-case
+		//     it here without updating that comment and the other two surfaces.
+		//   - "readiness_unconfirmed": account.py guarantees this only for a
+		//     workspace nothing has ever confirmed ready (an established one
+		//     fails OPEN through the same outage instead - _admin_unreachable_
+		//     verdict) - so it never fires on a workspace with history either.
 		return {
 			name: "Jarvis",
 			aria: "Set up Jarvis",
@@ -419,6 +504,16 @@
 		document.addEventListener("visibilitychange", function () {
 			if (document.visibilityState === "visible") syncAndVerify(false);
 		});
+	}
+
+	// Test-only export: this file is a plain script loaded via app_include_js
+	// (see the module comment at the top), not an ES module, so it cannot be
+	// `import`ed the way the widget's *.mjs files are. `module` only exists
+	// under CommonJS (node:test, which the sibling *.test.mjs file uses via
+	// createRequire) - a real browser has no `module` global, so this is inert
+	// in production and does not change what ships to the Desk.
+	if (typeof module !== "undefined" && module.exports) {
+		module.exports = { nudgeVariant: nudgeVariant };
 	}
 
 	if (window.frappe && window.frappe.router) {

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -44,6 +44,13 @@
 	// mounted under createWebHistory("/jarvis")), used by the renew-plan CTA.
 	// Same hand-kept-in-sync constraint as AI_MODELS_SETTINGS_URL above.
 	var BILLING_URL = "/jarvis/billing";
+	// The wizard resumes whatever step was last persisted unless the URL
+	// explicitly says otherwise - a bare /jarvis/onboarding link lands a
+	// reconnecting customer back on that stale step, not the reconnect offer.
+	// Must match readiness.js's RECONNECT_INTENT_URL (hasReconnectIntent() is
+	// what OnboardingView.vue checks), same hand-kept-in-sync constraint as the
+	// two constants above.
+	var RECONNECT_INTENT_URL = "/jarvis/onboarding?reconnect=1";
 	// Floor between server re-checks for the chatty triggers (route change,
 	// tab focus). A bfcache restore bypasses it: that is the exact moment the
 	// flag is most likely stale and the user is looking straight at it.
@@ -51,33 +58,36 @@
 	var lastCheckAt = 0;
 	var checking = false;
 
-	// jarvis#<this PR>: reasons that mean "an established workspace's control
-	// plane is between states" (still provisioning, a confirmed outage, an
-	// unresolved authority incident, or an account moved to a different site) -
-	// none of them are fixed by anything a Desk nudge can offer, and every one
-	// is reachable only AFTER is_ready_for_chat's local signup+credential
-	// checks already passed (account.py's _admin_chat_gate, or - for the two
-	// provisioning reasons - an established workspace whose apply-confirmed
-	// marker was cleared without a fresh apply timestamp to soften it into
-	// llm_applying/llm_apply_stuck). Sending any of these through the
-	// never-onboarded "Set up Jarvis" pitch would be exactly the bug this table
-	// exists to fix, and there is no honest, specific copy for them yet worth
-	// writing a whole bubble around - so the nudge stays quiet instead. The SPA
-	// gate (frontend/src/onboarding/readiness.js's NOT_ONBOARDED_REASONS) never
-	// force-redirects any of these either; it is the authority for which
-	// reasons truly mean "no history to protect" and this list is deliberately
-	// the complement of that.
+	// Reasons that mean "an established workspace's control plane is between
+	// states" (still mid-apply, a confirmed outage, an unresolved authority
+	// incident, or an account moved to a different site) - none of them are
+	// fixed by anything a Desk nudge can offer, every one is reachable only
+	// AFTER is_ready_for_chat's local signup+credential checks already passed
+	// (account.py's _admin_chat_gate), and there is no honest, specific copy
+	// for them yet worth writing a whole bubble around - so the nudge stays
+	// quiet instead. The SPA gate (frontend/src/onboarding/readiness.js's
+	// NOT_ONBOARDED_REASONS) never force-redirects any of these either.
+	//
+	// Deliberately NOT here: llm_pool_provisioning / llm_provisioning. Those
+	// two ALSO cover the exact "disconnected all models, apply-confirmed
+	// marker cleared with no fresh apply timestamp to soften it into
+	// llm_applying" shape for an established workspace (account.py's
+	// _provisioning_verdict), and nothing else on the Desk offers that
+	// workspace a CTA - suppressing them here would leave it with no way
+	// back in. See nudgeVariant()'s own case for the two.
 	var SUPPRESSED_REASONS = [
-		// jarvis C2 (pre-existing): an established workspace's first pool/direct
+		// Pre-existing (jarvis C2): an established workspace's first pool/direct
 		// leg is mid-apply.
 		"llm_applying",
 		"container_provisioning",
 		"container_unavailable",
-		"llm_pool_provisioning",
-		"llm_provisioning",
 		"authority_repair_required",
 		"site_replaced",
 	];
+
+	function isSuppressedReason(reason) {
+		return SUPPRESSED_REASONS.indexOf(reason || "") !== -1;
+	}
 
 	// ERPNext's own setup wizard must be finished first: completing it creates
 	// the first Company. Until then the desk IS the setup wizard, so nudging the
@@ -116,7 +126,7 @@
 		// entirely for those rather than routing them through nudgeVariant(): an
 		// established workspace between states needs no Desk nudge at all, and
 		// the "Set up Jarvis" fallback pitch would be actively wrong for it.
-		if (SUPPRESSED_REASONS.indexOf(frappe.boot.jarvis_ready_reason || "") !== -1) return false;
+		if (isSuppressedReason(frappe.boot.jarvis_ready_reason)) return false;
 		if (!erpnextSetupComplete()) return false;
 		// A second, sturdier setup signal alongside the sysdefaults flag above:
 		// the Company count (jarvis_site_setup_complete, set in jarvis.boot)
@@ -301,8 +311,12 @@
 		// only reachable after signup + credentials passed once. The recovery is
 		// the wizard's OWN reconnect step (OnboardingView.vue's
 		// startAccountReconnect / can_reconnect offer) - there is no equivalent
-		// action in Settings, so this still points at /jarvis/onboarding, but
-		// with honest copy instead of the never-set-up "meet Jarvis" pitch below.
+		// action in Settings, so this still points at the wizard, but with honest
+		// copy instead of the never-set-up "meet Jarvis" pitch below, and at
+		// RECONNECT_INTENT_URL rather than a bare /jarvis/onboarding: without the
+		// reconnect=1 flag OnboardingView.vue resumes whatever step was last
+		// persisted instead of rendering the reconnect offer, landing this
+		// customer on the wrong screen.
 		if (reason === "reconnect_required") {
 			return {
 				name: agentName,
@@ -312,7 +326,27 @@
 					agentName +
 					" can't reply right now. Reconnect to pick up where you left off.",
 				ctaLabel: "Reconnect →",
-				href: "/jarvis/onboarding",
+				href: RECONNECT_INTENT_URL,
+			};
+		}
+		// account.py's _provisioning_verdict: an established workspace (one
+		// _has_been_chat_ready has already confirmed) whose apply-confirmed
+		// marker was cleared - e.g. "disconnect AI model connections" in pool or
+		// subscription mode - and whose last_sync_requested_at is either unset or
+		// too stale to soften this into llm_applying/llm_apply_stuck. Unlike
+		// those two soft reasons this is not necessarily still converging, so
+		// point at Settings to check/redo the connection rather than promising a
+		// Retry that may have nothing in flight to retry.
+		if (reason === "llm_pool_provisioning" || reason === "llm_provisioning") {
+			return {
+				name: agentName,
+				aria: "Check " + agentName + " AI models",
+				text:
+					"Your AI model connection is not finished applying, so " +
+					agentName +
+					" can't reply yet. Check it in Settings.",
+				ctaLabel: "Check AI models →",
+				href: AI_MODELS_SETTINGS_URL,
 			};
 		}
 		// Every other reason keeps the original never-set-up pitch and
@@ -513,7 +547,7 @@
 	// createRequire) - a real browser has no `module` global, so this is inert
 	// in production and does not change what ships to the Desk.
 	if (typeof module !== "undefined" && module.exports) {
-		module.exports = { nudgeVariant: nudgeVariant };
+		module.exports = { nudgeVariant: nudgeVariant, isSuppressedReason: isSuppressedReason };
 	}
 
 	if (window.frappe && window.frappe.router) {

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -3,8 +3,13 @@
 // user to finish setup and start easing their ERP workflows. Replaces the old
 // top banner with a friendlier, on-brand "Jarvis is chatting" bubble thread.
 //
-// Reads `frappe.boot.jarvis_onboarded` (set in jarvis.boot.set_jarvis_boot)
-// and `frappe.boot.sysdefaults.setup_complete` (frappe.is_setup_complete()).
+// Reads `frappe.boot.jarvis_onboarded` and `frappe.boot.jarvis_ready_reason`
+// (both set in jarvis.boot.set_jarvis_boot from is_ready_for_chat's verdict),
+// `frappe.boot.jarvis_has_been_ready` (same file, from account.
+// has_been_chat_ready - disambiguates a never-established workspace from an
+// established one for the two reasons that alone cannot tell the two apart,
+// see nudgeVariant()'s llm_pool_provisioning/llm_provisioning case), and
+// `frappe.boot.sysdefaults.setup_complete` (frappe.is_setup_complete()).
 // Shows only for a not-onboarded System Manager AFTER ERPNext's own setup
 // wizard is finished, so it never pops over the wizard. Dismissal is
 // per-tab-session (sessionStorage) so it returns next fresh session until
@@ -69,12 +74,17 @@
 	// NOT_ONBOARDED_REASONS) never force-redirects any of these either.
 	//
 	// Deliberately NOT here: llm_pool_provisioning / llm_provisioning. Those
-	// two ALSO cover the exact "disconnected all models, apply-confirmed
-	// marker cleared with no fresh apply timestamp to soften it into
-	// llm_applying" shape for an established workspace (account.py's
-	// _provisioning_verdict), and nothing else on the Desk offers that
-	// workspace a CTA - suppressing them here would leave it with no way
-	// back in. See nudgeVariant()'s own case for the two.
+	// two reasons are AMBIGUOUS by themselves (account.py's
+	// _provisioning_verdict returns the same hard reason whenever
+	// _has_been_chat_ready(raw) is false, which covers both a brand-new
+	// tenant whose first sync is still pending AND an established workspace
+	// whose apply-confirmed marker was cleared - e.g. disconnecting all
+	// models - with no fresh apply timestamp to soften it into
+	// llm_applying). nudgeVariant() resolves the ambiguity with
+	// frappe.boot.jarvis_has_been_ready instead of suppressing outright:
+	// established gets its own CTA (nothing else on the Desk offers one -
+	// the floating widget still gates these to setup too), never-established
+	// falls through to the same wizard pitch it would have gotten anyway.
 	var SUPPRESSED_REASONS = [
 		// Pre-existing (jarvis C2): an established workspace's first pool/direct
 		// leg is mid-apply.
@@ -329,15 +339,25 @@
 				href: RECONNECT_INTENT_URL,
 			};
 		}
-		// account.py's _provisioning_verdict: an established workspace (one
-		// _has_been_chat_ready has already confirmed) whose apply-confirmed
-		// marker was cleared - e.g. "disconnect AI model connections" in pool or
-		// subscription mode - and whose last_sync_requested_at is either unset or
-		// too stale to soften this into llm_applying/llm_apply_stuck. Unlike
-		// those two soft reasons this is not necessarily still converging, so
-		// point at Settings to check/redo the connection rather than promising a
-		// Retry that may have nothing in flight to retry.
-		if (reason === "llm_pool_provisioning" || reason === "llm_provisioning") {
+		// account.py's _provisioning_verdict returns these two whenever
+		// _has_been_chat_ready(raw) is false - which is ALSO true for a
+		// brand-new tenant whose very first sync is still pending, not only
+		// for an established workspace whose apply-confirmed marker was
+		// cleared (e.g. "disconnect AI model connections" in pool or
+		// subscription mode). The reason string alone cannot tell the two
+		// apart, so this branches on frappe.boot.jarvis_has_been_ready (set in
+		// jarvis.boot.set_jarvis_boot from account.has_been_chat_ready, the
+		// SAME check _has_been_chat_ready itself makes): only an established
+		// workspace gets the Settings CTA below - Retry would have nothing in
+		// flight to retry, unlike llm_applying/llm_apply_stuck's soft window.
+		// A brand-new tenant (flag false, or absent on an older boot payload)
+		// falls through to the unchanged wizard pitch, which is exactly what
+		// a customer mid-first-sync should see.
+		if (
+			(reason === "llm_pool_provisioning" || reason === "llm_provisioning") &&
+			frappe.boot &&
+			frappe.boot.jarvis_has_been_ready === true
+		) {
 			return {
 				name: agentName,
 				aria: "Check " + agentName + " AI models",
@@ -368,6 +388,11 @@
 		//     workspace nothing has ever confirmed ready (an established one
 		//     fails OPEN through the same outage instead - _admin_unreachable_
 		//     verdict) - so it never fires on a workspace with history either.
+		//   - "llm_pool_provisioning" / "llm_provisioning" WITHOUT
+		//     jarvis_has_been_ready === true: the ambiguous case above resolved
+		//     to "never established" (or the flag is missing/false on an older
+		//     boot payload), so this is exactly the first-sync-still-pending
+		//     tenant the wizard pitch is for.
 		return {
 			name: "Jarvis",
 			aria: "Set up Jarvis",

--- a/jarvis/public/js/jarvis_onboarding_banner.test.mjs
+++ b/jarvis/public/js/jarvis_onboarding_banner.test.mjs
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+// jarvis_onboarding_banner.bundle.js is a plain script loaded via
+// app_include_js (not an ES module), so it cannot be `import`ed the way the
+// widget's *.mjs files are - it can only be `require`d as CommonJS (see the
+// test-only `module.exports` guard at the bottom of that file). require()
+// executes the file's top level immediately, which touches two browser
+// globals before nudgeVariant() is ever reachable: `window` (the
+// double-injection guard, `window.__jarvisOnboardingBanner`) and `document`
+// (the DOMContentLoaded fallback at the very end, since neither
+// `window.frappe.router` nor `window.$` is set here). Both are stubbed to the
+// bare minimum needed to survive that top level without touching a DOM.
+//
+// `window` is aliased to `globalThis` itself (as it is in a real browser, not
+// a separate object) because the bundle reads the frappe.boot.* fields via a
+// bare `frappe` identifier after a `window.frappe &&` guard - true only when
+// `window` and the global scope are the same object.
+globalThis.window = globalThis;
+globalThis.document = { addEventListener: () => {} };
+globalThis.frappe = undefined;
+
+const require = createRequire(import.meta.url);
+const { nudgeVariant } = require("./jarvis_onboarding_banner.bundle.js");
+
+function setReason(reason, agentName) {
+  globalThis.frappe = {
+    boot: { jarvis_ready_reason: reason, jarvis_agent_name: agentName },
+  };
+}
+
+test("nudgeVariant: subscription_suspended renews via billing, never the wizard", () => {
+  setReason("subscription_suspended", "Nova");
+  const v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Renew plan →");
+  assert.equal(v.href, "/jarvis/billing");
+  assert.match(v.text, /Nova/);
+  assert.doesNotMatch(v.href, /onboarding/);
+});
+
+test("nudgeVariant: reconnect_required uses honest copy, not the never-set-up pitch", () => {
+  setReason("reconnect_required", "Nova");
+  const v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Reconnect →");
+  assert.equal(v.href, "/jarvis/onboarding");
+  assert.match(v.text, /reconnecting/);
+  assert.doesNotMatch(v.text, /Hey/);
+});
+
+test("nudgeVariant: llm_credentials and llm_apply_stuck are unchanged", () => {
+  setReason("llm_credentials", "Nova");
+  let v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Reconnect a model →");
+  assert.equal(v.href, "/jarvis/?settings=aimodels");
+
+  setReason("llm_apply_stuck", "Nova");
+  v = nudgeVariant();
+  assert.equal(v.ctaLabel, "Retry");
+  assert.equal(v.action, "resync");
+});
+
+test("nudgeVariant: reasons account.py guarantees have no history keep the wizard pitch", () => {
+  for (const reason of [
+    "signup",
+    "llm_setup",
+    "llm_rejected",
+    "readiness_unconfirmed",
+    "",
+    "some_future_reason",
+  ]) {
+    setReason(reason, "Nova");
+    const v = nudgeVariant();
+    assert.equal(v.ctaLabel, "Set up Jarvis →", `reason=${reason}`);
+    assert.equal(v.href, "/jarvis/onboarding", `reason=${reason}`);
+  }
+});
+
+test("nudgeVariant: white-label - only the never-set-up pitch says literal Jarvis", () => {
+  setReason("subscription_suspended", "Nova");
+  assert.equal(nudgeVariant().name, "Nova");
+
+  setReason("reconnect_required", "Nova");
+  assert.equal(nudgeVariant().name, "Nova");
+
+  setReason("signup", "Nova");
+  assert.equal(nudgeVariant().name, "Jarvis");
+});

--- a/jarvis/public/js/jarvis_onboarding_banner.test.mjs
+++ b/jarvis/public/js/jarvis_onboarding_banner.test.mjs
@@ -29,9 +29,18 @@ const {
   isSuppressedReason,
 } = require("./jarvis_onboarding_banner.bundle.js");
 
-function setReason(reason, agentName) {
+// `hasBeenReady` defaults to `undefined` - an absent jarvis_has_been_ready key
+// on the boot object, exactly like an older boot payload that predates the
+// flag - rather than to `false`, so a caller that does not pass it exercises
+// the "missing" case, not the "explicitly false" one. Pass it explicitly
+// wherever the distinction matters.
+function setReason(reason, agentName, hasBeenReady) {
   globalThis.frappe = {
-    boot: { jarvis_ready_reason: reason, jarvis_agent_name: agentName },
+    boot: {
+      jarvis_ready_reason: reason,
+      jarvis_agent_name: agentName,
+      jarvis_has_been_ready: hasBeenReady,
+    },
   };
 }
 
@@ -54,14 +63,36 @@ test("nudgeVariant: reconnect_required carries the reconnect intent flag, not a 
   assert.doesNotMatch(v.text, /Hey/);
 });
 
-test("nudgeVariant: llm_pool_provisioning and llm_provisioning point at AI models settings, not the wizard", () => {
+test("nudgeVariant: llm_pool_provisioning/llm_provisioning + jarvis_has_been_ready true points at AI models settings", () => {
   for (const reason of ["llm_pool_provisioning", "llm_provisioning"]) {
-    setReason(reason, "Nova");
+    setReason(reason, "Nova", true);
     const v = nudgeVariant();
     assert.equal(v.ctaLabel, "Check AI models →", `reason=${reason}`);
     assert.equal(v.href, "/jarvis/?settings=aimodels", `reason=${reason}`);
     assert.match(v.text, /Nova/, `reason=${reason}`);
     assert.doesNotMatch(v.href, /onboarding/, `reason=${reason}`);
+  }
+});
+
+test("nudgeVariant: llm_pool_provisioning/llm_provisioning + jarvis_has_been_ready false keeps the wizard pitch", () => {
+  for (const reason of ["llm_pool_provisioning", "llm_provisioning"]) {
+    setReason(reason, "Nova", false);
+    const v = nudgeVariant();
+    assert.equal(v.ctaLabel, "Set up Jarvis →", `reason=${reason}`);
+    assert.equal(v.href, "/jarvis/onboarding", `reason=${reason}`);
+  }
+});
+
+test("nudgeVariant: llm_pool_provisioning/llm_provisioning + jarvis_has_been_ready absent keeps the wizard pitch", () => {
+  // Absent (older boot payload, or the boot-time try/except's fail-safe False
+  // never having reached this session's cached boot object) must behave like
+  // "not established", never like "established" - the safer failure mode when
+  // the disambiguator itself is missing.
+  for (const reason of ["llm_pool_provisioning", "llm_provisioning"]) {
+    setReason(reason, "Nova"); // hasBeenReady omitted -> undefined
+    const v = nudgeVariant();
+    assert.equal(v.ctaLabel, "Set up Jarvis →", `reason=${reason}`);
+    assert.equal(v.href, "/jarvis/onboarding", `reason=${reason}`);
   }
 });
 
@@ -100,7 +131,7 @@ test("nudgeVariant: white-label - only the never-set-up pitch says literal Jarvi
   setReason("reconnect_required", "Nova");
   assert.equal(nudgeVariant().name, "Nova");
 
-  setReason("llm_pool_provisioning", "Nova");
+  setReason("llm_pool_provisioning", "Nova", true);
   assert.equal(nudgeVariant().name, "Nova");
 
   setReason("signup", "Nova");

--- a/jarvis/public/js/jarvis_onboarding_banner.test.mjs
+++ b/jarvis/public/js/jarvis_onboarding_banner.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // jarvis_onboarding_banner.bundle.js is a plain script loaded via
 // app_include_js (not an ES module), so it cannot be `import`ed the way the
@@ -22,7 +24,10 @@ globalThis.document = { addEventListener: () => {} };
 globalThis.frappe = undefined;
 
 const require = createRequire(import.meta.url);
-const { nudgeVariant } = require("./jarvis_onboarding_banner.bundle.js");
+const {
+  nudgeVariant,
+  isSuppressedReason,
+} = require("./jarvis_onboarding_banner.bundle.js");
 
 function setReason(reason, agentName) {
   globalThis.frappe = {
@@ -39,13 +44,25 @@ test("nudgeVariant: subscription_suspended renews via billing, never the wizard"
   assert.doesNotMatch(v.href, /onboarding/);
 });
 
-test("nudgeVariant: reconnect_required uses honest copy, not the never-set-up pitch", () => {
+test("nudgeVariant: reconnect_required carries the reconnect intent flag, not a bare wizard link", () => {
   setReason("reconnect_required", "Nova");
   const v = nudgeVariant();
   assert.equal(v.ctaLabel, "Reconnect →");
-  assert.equal(v.href, "/jarvis/onboarding");
+  assert.equal(v.href, "/jarvis/onboarding?reconnect=1");
+  assert.match(v.href, /[?&]reconnect=1(&|$)/);
   assert.match(v.text, /reconnecting/);
   assert.doesNotMatch(v.text, /Hey/);
+});
+
+test("nudgeVariant: llm_pool_provisioning and llm_provisioning point at AI models settings, not the wizard", () => {
+  for (const reason of ["llm_pool_provisioning", "llm_provisioning"]) {
+    setReason(reason, "Nova");
+    const v = nudgeVariant();
+    assert.equal(v.ctaLabel, "Check AI models →", `reason=${reason}`);
+    assert.equal(v.href, "/jarvis/?settings=aimodels", `reason=${reason}`);
+    assert.match(v.text, /Nova/, `reason=${reason}`);
+    assert.doesNotMatch(v.href, /onboarding/, `reason=${reason}`);
+  }
 });
 
 test("nudgeVariant: llm_credentials and llm_apply_stuck are unchanged", () => {
@@ -83,6 +100,67 @@ test("nudgeVariant: white-label - only the never-set-up pitch says literal Jarvi
   setReason("reconnect_required", "Nova");
   assert.equal(nudgeVariant().name, "Nova");
 
+  setReason("llm_pool_provisioning", "Nova");
+  assert.equal(nudgeVariant().name, "Nova");
+
   setReason("signup", "Nova");
   assert.equal(nudgeVariant().name, "Jarvis");
+});
+
+test("isSuppressedReason: the outage/incident reasons hide the nudge entirely", () => {
+  for (const reason of [
+    "llm_applying",
+    "container_provisioning",
+    "container_unavailable",
+    "authority_repair_required",
+    "site_replaced",
+  ]) {
+    assert.equal(isSuppressedReason(reason), true, `reason=${reason}`);
+  }
+});
+
+test("isSuppressedReason: every reason with its own nudgeVariant() is never suppressed", () => {
+  for (const reason of [
+    "llm_credentials",
+    "llm_apply_stuck",
+    "subscription_suspended",
+    "reconnect_required",
+    "llm_pool_provisioning",
+    "llm_provisioning",
+    "signup",
+    "llm_setup",
+    "llm_rejected",
+    "readiness_unconfirmed",
+    "",
+    "some_future_reason",
+  ]) {
+    assert.equal(isSuppressedReason(reason), false, `reason=${reason}`);
+  }
+});
+
+// Route-drift guards: nudgeVariant()'s destinations are strings hand-kept in
+// sync with the SPA router rather than imported (this bundle cannot import
+// from frontend/src - see the module comment in the bundle itself), so a
+// route rename on the SPA side would silently 404 the CTA instead of failing
+// anywhere. Reading the source files as text and asserting on the literal
+// each constant was copied from turns that into a loud CI failure.
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+test("BILLING_URL: frontend/src/router/index.js still registers /billing", () => {
+  const routerSrc = readFileSync(
+    `${repoRoot}/frontend/src/router/index.js`,
+    "utf8"
+  );
+  assert.match(routerSrc, /path:\s*"\/billing"/);
+});
+
+test("RECONNECT_INTENT_URL: frontend/src/onboarding/readiness.js still exports the same literal", () => {
+  const readinessSrc = readFileSync(
+    `${repoRoot}/frontend/src/onboarding/readiness.js`,
+    "utf8"
+  );
+  assert.match(
+    readinessSrc,
+    /RECONNECT_INTENT_URL\s*=\s*"\/jarvis\/onboarding\?reconnect=1"/
+  );
 });

--- a/jarvis/tests/test_boot_site_setup.py
+++ b/jarvis/tests/test_boot_site_setup.py
@@ -57,3 +57,41 @@ class TestBootSiteSetupFlag(FrappeTestCase):
 			b = self._boot()
 		self.assertTrue(b.jarvis_site_setup_complete)
 		self.assertFalse(b.jarvis_onboarded)
+
+
+class TestBootHasBeenReadyFlag(FrappeTestCase):
+	"""jarvis_has_been_ready disambiguates the two reasons that alone cannot
+	tell a brand-new tenant (first sync still pending) from an established
+	workspace (apply-confirmed marker cleared) - see jarvis.account.
+	has_been_chat_ready and the desk banner's llm_pool_provisioning /
+	llm_provisioning variant."""
+
+	def _boot(self):
+		b = frappe._dict()
+		set_jarvis_boot(b)
+		return b
+
+	def test_established_workspace_reads_true(self):
+		with patch("jarvis.account.has_been_chat_ready", return_value=True):
+			self.assertTrue(self._boot().jarvis_has_been_ready)
+
+	def test_never_established_workspace_reads_false(self):
+		with patch("jarvis.account.has_been_chat_ready", return_value=False):
+			self.assertFalse(self._boot().jarvis_has_been_ready)
+
+	def test_a_boot_error_fails_safe_to_false(self):
+		"""Matches every other boot.py flag: a boot-time failure must not
+		claim a workspace is established when nothing confirmed that."""
+		with patch("jarvis.account.has_been_chat_ready", side_effect=Exception("boom")):
+			self.assertFalse(self._boot().jarvis_has_been_ready)
+
+	def test_independent_of_the_readiness_call_failing(self):
+		"""is_ready_for_chat() throwing must not also blank this flag - the
+		two try/except blocks in set_jarvis_boot are deliberately separate."""
+		with (
+			patch("jarvis.account.is_ready_for_chat", side_effect=Exception("boom")),
+			patch("jarvis.account.has_been_chat_ready", return_value=True),
+		):
+			b = self._boot()
+		self.assertTrue(b.jarvis_onboarded)  # the readiness fail-safe: never nag on a boot error
+		self.assertTrue(b.jarvis_has_been_ready)


### PR DESCRIPTION
## Summary

The Desk chat-bubble nudge sent every not-ready workspace to the onboarding wizard except two reasons, so a customer who cancelled their plan or lost their AI model connection was bounced back through signup. The CTA now matches the readiness reason, and an onboarded workspace is never sent to the wizard.

| Reason | CTA |
|---|---|
| `subscription_suspended` | Renew plan, to `/jarvis/billing` |
| `llm_pool_provisioning`, `llm_provisioning` | Check AI models, to AI models settings |
| `reconnect_required` | Reconnect, to the wizard's own reconnect step (`?reconnect=1`) |
| `llm_credentials`, `llm_apply_stuck` | unchanged |
| `llm_applying`, `container_*`, `authority_repair_required`, `site_replaced` | no bubble |
| `signup`, `llm_setup`, `llm_rejected`, unknown | unchanged "Set up Jarvis" (never-onboarded only) |

The SPA gate and the floating widget already handled these reasons correctly; no change there. The new node test file is wired into CI with a glob, and two guard tests fail CI if the billing route or the reconnect-intent URL is renamed.

Live-tested on e2e.localhost with the readiness verdict held at each reason (screenshots below). Note: the billing page requires the Jarvis Admin role, which the onboarding admin holds.

Test script:
1. On the Desk with `jarvis_ready_reason` = `subscription_suspended`: bubble says Renew plan and links to `/jarvis/billing`.
2. `llm_pool_provisioning`: Check AI models, links to `/jarvis/?settings=aimodels`.
3. `reconnect_required`: Reconnect, links to `/jarvis/onboarding?reconnect=1`.
4. `container_provisioning`: no bubble.
5. `signup`: original Set up Jarvis pitch.
6. `node --test jarvis/public/js/*.test.mjs` passes.

## Before / After

Before: every not-ready reason on an onboarded workspace showed the never-onboarded pitch and linked to the wizard (this is what a lapsed plan or a lost model connection produced; captured on the integration build with the reason held at `signup`, which still renders this unchanged bubble):

<img width="1500" alt="before" src="https://github.com/user-attachments/assets/494e7dd2-3e9a-475d-9f21-74cad58a4f69" />

After, `subscription_suspended`: Renew plan, to the billing page:

<img width="1500" alt="renew plan" src="https://github.com/user-attachments/assets/beba666f-f242-44f1-86d1-8f0ccd568128" />

After, `llm_pool_provisioning` / `llm_provisioning`: Check AI models, to settings:

<img width="1500" alt="check ai models" src="https://github.com/user-attachments/assets/20b4c392-e815-49ab-88ad-ac215c1d0730" />

After, `reconnect_required`: Reconnect, to the wizard's reconnect step:

<img width="1500" alt="reconnect" src="https://github.com/user-attachments/assets/78135353-19e8-4790-9c46-470507964fff" />

Captured on e2e.localhost with the readiness verdict held at each reason; `signup` still shows the original pitch, `container_provisioning` shows nothing.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01HW2uHdQLPLoV8qVXm6Ppxu
