### PR TITLE
feat(schedule): add a weekday and day-of-month picker to agent and macro schedules

### DIFF
--- a/frontend/src/components/list/ListPage.vue
+++ b/frontend/src/components/list/ListPage.vue
@@ -168,11 +168,30 @@
 			</template>
 			<!-- DA-08: cell renderers dispatch through ListView's named `cell` slot
 			     ({column, row, item, align}) and forward to #cell-<key> ({row, column, item});
-			     no page slot for a column ⇒ stock ListRowItem. -->
+			     no page slot for a column ⇒ stock ListRowItem.
+
+			     text-base here is the ONE font-size convention for every list cell
+			     in the app (jarvis#653 audit: several pages' custom #cell-<key>
+			     slots omitted it and rendered larger than their siblings, since
+			     nothing else in the ancestor chain sets a font-size - frappe-ui's
+			     own per-column wrapper in ListRow.vue only defaults the TEXT
+			     COLOR, not the size, and ListRowItem's stock fallback below
+			     already carries text-base itself, which is why a column with no
+			     custom slot never showed the bug). A plain <div> is safe to
+			     insert here: it is a block element with no width/flex opinion of
+			     its own, so it changes neither the grid-cell sizing that makes
+			     `truncate` work nor a page's own flex/gap layout inside the slot -
+			     only inherited typography (font-size, line-height) passes through
+			     it. A page's own explicit classes (font-medium, text-ink-gray-9
+			     for a name cell, text-ink-gray-4 for a muted dash) still win, and
+			     a Badge inside a cell carries its own font-size regardless of what
+			     an ancestor sets, so this is a strict default, not an override. -->
 			<template #cell="{ column, row, item, align }">
-				<slot :name="`cell-${column.key}`" v-bind="{ row, column, item }">
-					<ListRowItem :column="column" :row="row" :item="item" :align="align" />
-				</slot>
+				<div class="text-base">
+					<slot :name="`cell-${column.key}`" v-bind="{ row, column, item }">
+						<ListRowItem :column="column" :row="row" :item="item" :align="align" />
+					</slot>
+				</div>
 			</template>
 		</ListView>
 

--- a/frontend/src/lib/scheduleAnchor.js
+++ b/frontend/src/lib/scheduleAnchor.js
@@ -1,4 +1,4 @@
-// Shared weekly/monthly schedule-anchor helpers (jarvis#653) — the "which day"
+// Shared weekly/monthly schedule-anchor helpers (jarvis#653) - the "which day"
 // half of the Schedule section's Frequency/Time/Day trio, used by AgentDetail.vue,
 // MacroDetail.vue and MacrosList.vue so the three surfaces cannot drift on the
 // option lists, the ordinal spelling, or the summary wording.
@@ -7,7 +7,7 @@
 // modelValue, matching FormControl's own Frequency control): the weekday name
 // itself for weekly ("Monday"), or the day number as a string for monthly
 // ("15"). Comparing/deriving this as one shape (instead of two separately-typed
-// fields) is what keeps the dirty-check symmetric — see AGENT-653 notes in
+// fields) is what keeps the dirty-check symmetric - see AGENT-653 notes in
 // AgentDetail.vue / MacroDetail.vue.
 
 export const WEEKDAY_OPTIONS = [
@@ -45,7 +45,7 @@ export function ordinal(n) {
 }
 
 // The Day control's model value for a (frequency, weekday, day_of_month) triple
-// read off a saved row — "" when the frequency doesn't use a day anchor, or when
+// read off a saved row - "" when the frequency doesn't use a day anchor, or when
 // no anchor was ever saved for it (a legacy row, or the anchor cleared).
 export function deriveScheduleDay(frequency, weekday, dayOfMonth) {
 	if (frequency === "weekly") return weekday || "";
@@ -53,7 +53,7 @@ export function deriveScheduleDay(frequency, weekday, dayOfMonth) {
 	return "";
 }
 
-// "on Monday" / "on the 15th" / "" — the anchor clause the summary line
+// "on Monday" / "on the 15th" / "" - the anchor clause the summary line
 // appends after the frequency word. Empty when there is no day to name (daily,
 // or a weekly/monthly row with no anchor saved) so the legacy summary wording
 // ("Scheduled monthly at 9:00 am...") is preserved verbatim for those rows.

--- a/frontend/src/lib/scheduleAnchor.js
+++ b/frontend/src/lib/scheduleAnchor.js
@@ -1,0 +1,68 @@
+// Shared weekly/monthly schedule-anchor helpers (jarvis#653) — the "which day"
+// half of the Schedule section's Frequency/Time/Day trio, used by AgentDetail.vue,
+// MacroDetail.vue and MacrosList.vue so the three surfaces cannot drift on the
+// option lists, the ordinal spelling, or the summary wording.
+//
+// The Day control's model value is always a STRING (a native <select>'s
+// modelValue, matching FormControl's own Frequency control): the weekday name
+// itself for weekly ("Monday"), or the day number as a string for monthly
+// ("15"). Comparing/deriving this as one shape (instead of two separately-typed
+// fields) is what keeps the dirty-check symmetric — see AGENT-653 notes in
+// AgentDetail.vue / MacroDetail.vue.
+
+export const WEEKDAY_OPTIONS = [
+	{ label: "Monday", value: "Monday" },
+	{ label: "Tuesday", value: "Tuesday" },
+	{ label: "Wednesday", value: "Wednesday" },
+	{ label: "Thursday", value: "Thursday" },
+	{ label: "Friday", value: "Friday" },
+	{ label: "Saturday", value: "Saturday" },
+	{ label: "Sunday", value: "Sunday" },
+];
+
+export const DAY_OF_MONTH_OPTIONS = Array.from({ length: 31 }, (_, i) => {
+	const n = i + 1;
+	return { label: ordinal(n), value: String(n) };
+});
+
+// 1st, 2nd, 3rd, 4th ... 11th, 12th, 13th (the teens are all "th", the classic
+// exception to the mod-10 rule) ... 21st, 22nd, 23rd ... 31st.
+export function ordinal(n) {
+	const v = Number(n);
+	if (!Number.isFinite(v)) return String(n);
+	const mod100 = Math.abs(v) % 100;
+	if (mod100 >= 11 && mod100 <= 13) return `${v}th`;
+	switch (Math.abs(v) % 10) {
+		case 1:
+			return `${v}st`;
+		case 2:
+			return `${v}nd`;
+		case 3:
+			return `${v}rd`;
+		default:
+			return `${v}th`;
+	}
+}
+
+// The Day control's model value for a (frequency, weekday, day_of_month) triple
+// read off a saved row — "" when the frequency doesn't use a day anchor, or when
+// no anchor was ever saved for it (a legacy row, or the anchor cleared).
+export function deriveScheduleDay(frequency, weekday, dayOfMonth) {
+	if (frequency === "weekly") return weekday || "";
+	if (frequency === "monthly") return dayOfMonth ? String(dayOfMonth) : "";
+	return "";
+}
+
+// "on Monday" / "on the 15th" / "" — the anchor clause the summary line
+// appends after the frequency word. Empty when there is no day to name (daily,
+// or a weekly/monthly row with no anchor saved) so the legacy summary wording
+// ("Scheduled monthly at 9:00 am...") is preserved verbatim for those rows.
+export function scheduleAnchorPhrase(frequency, day) {
+	if (!day) return "";
+	if (frequency === "weekly") return `on ${day}`;
+	if (frequency === "monthly") {
+		const n = Number(day);
+		return Number.isFinite(n) ? `on the ${ordinal(n)}` : "";
+	}
+	return "";
+}

--- a/frontend/src/lib/scheduleAnchor.spec.js
+++ b/frontend/src/lib/scheduleAnchor.spec.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+	ordinal,
+	deriveScheduleDay,
+	scheduleAnchorPhrase,
+	WEEKDAY_OPTIONS,
+	DAY_OF_MONTH_OPTIONS,
+} from "./scheduleAnchor";
+
+describe("ordinal", () => {
+	it("handles the 11/12/13 exception", () => {
+		expect(ordinal(11)).toBe("11th");
+		expect(ordinal(12)).toBe("12th");
+		expect(ordinal(13)).toBe("13th");
+	});
+	it("handles the mod-10 cases outside the teens", () => {
+		expect(ordinal(1)).toBe("1st");
+		expect(ordinal(2)).toBe("2nd");
+		expect(ordinal(3)).toBe("3rd");
+		expect(ordinal(21)).toBe("21st");
+		expect(ordinal(22)).toBe("22nd");
+		expect(ordinal(23)).toBe("23rd");
+		expect(ordinal(31)).toBe("31st");
+	});
+	it("defaults to th for everything else", () => {
+		expect(ordinal(4)).toBe("4th");
+		expect(ordinal(15)).toBe("15th");
+		expect(ordinal(20)).toBe("20th");
+	});
+});
+
+describe("option lists", () => {
+	it("WEEKDAY_OPTIONS has all 7 days, Monday first", () => {
+		expect(WEEKDAY_OPTIONS).toHaveLength(7);
+		expect(WEEKDAY_OPTIONS[0].value).toBe("Monday");
+		expect(WEEKDAY_OPTIONS[6].value).toBe("Sunday");
+	});
+	it("DAY_OF_MONTH_OPTIONS covers 1..31 with ordinal labels", () => {
+		expect(DAY_OF_MONTH_OPTIONS).toHaveLength(31);
+		expect(DAY_OF_MONTH_OPTIONS[0]).toEqual({ label: "1st", value: "1" });
+		expect(DAY_OF_MONTH_OPTIONS[30]).toEqual({ label: "31st", value: "31" });
+	});
+});
+
+describe("deriveScheduleDay", () => {
+	it("reads the weekday for a weekly row", () => {
+		expect(deriveScheduleDay("weekly", "Wednesday", null)).toBe("Wednesday");
+	});
+	it("reads the day of month (stringified) for a monthly row", () => {
+		expect(deriveScheduleDay("monthly", null, 15)).toBe("15");
+	});
+	it("is empty for daily, or a weekly/monthly row with no anchor saved", () => {
+		expect(deriveScheduleDay("daily", "Wednesday", 15)).toBe("");
+		expect(deriveScheduleDay("weekly", null, null)).toBe("");
+		expect(deriveScheduleDay("monthly", null, null)).toBe("");
+		expect(deriveScheduleDay("monthly", null, 0)).toBe("");
+	});
+});
+
+describe("scheduleAnchorPhrase", () => {
+	it("names the weekday for weekly", () => {
+		expect(scheduleAnchorPhrase("weekly", "Monday")).toBe("on Monday");
+	});
+	it("names the ordinal day for monthly", () => {
+		expect(scheduleAnchorPhrase("monthly", "15")).toBe("on the 15th");
+	});
+	it("is empty with no day, or for daily", () => {
+		expect(scheduleAnchorPhrase("weekly", "")).toBe("");
+		expect(scheduleAnchorPhrase("monthly", "")).toBe("");
+		expect(scheduleAnchorPhrase("daily", "")).toBe("");
+	});
+});

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -200,3 +200,28 @@ body {
 .PopoverContent {
 	z-index: 120;
 }
+
+/* jarvis#653: frappe-ui's FormControl type="select" (reka-ui's SelectContent
+   under the hood) sets NO height cap on its popover - unlike Combobox/
+   Autocomplete/MultiSelect, whose own inner viewport already carries a
+   max-height + overflow-auto class. With few options that is invisible; the
+   Schedule section's monthly Day control (1st..31st, 31 rows) grew the
+   popover past the bottom of the viewport with no way to reach the later
+   rows - page scroll does not move a portaled popover, and there was no
+   internal scrollbar to scroll instead.
+
+   [data-slot="content-body"] is the wrapper Select/Combobox/MultiSelect all
+   render (see their own scoped <style> blocks for the exact selector); a
+   redundant cap on Combobox/MultiSelect's OUTER wrapper is harmless since
+   their own inner viewport is already smaller. overflow-y is !important
+   because Select's own class list already carries `overflow-hidden`
+   (Tailwind, same specificity as this attribute selector) and load order
+   between the two stylesheets is not something to rely on.
+
+   App-wide for the same reason as the two rules above: every Select in the
+   app (not just this one page) portals identically and none of them wants an
+   unreachable tail once its option list is long enough. */
+[data-slot="content-body"] {
+	max-height: 40vh;
+	overflow-y: auto !important;
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -202,26 +202,38 @@ body {
 }
 
 /* jarvis#653: frappe-ui's FormControl type="select" (reka-ui's SelectContent
-   under the hood) sets NO height cap on its popover - unlike Combobox/
-   Autocomplete/MultiSelect, whose own inner viewport already carries a
-   max-height + overflow-auto class. With few options that is invisible; the
-   Schedule section's monthly Day control (1st..31st, 31 rows) grew the
-   popover past the bottom of the viewport with no way to reach the later
-   rows - page scroll does not move a portaled popover, and there was no
-   internal scrollbar to scroll instead.
+   under the hood) sets NO height cap on its popover. With few options that is
+   invisible; the Schedule section's monthly Day control (1st..31st, 31 rows)
+   grew the popover past the bottom of the viewport with no way to reach the
+   later rows - page scroll does not move a portaled popover, and there was
+   no internal scrollbar to scroll instead.
 
-   [data-slot="content-body"] is the wrapper Select/Combobox/MultiSelect all
-   render (see their own scoped <style> blocks for the exact selector); a
-   redundant cap on Combobox/MultiSelect's OUTER wrapper is harmless since
-   their own inner viewport is already smaller. overflow-y is !important
-   because Select's own class list already carries `overflow-hidden`
-   (Tailwind, same specificity as this attribute selector) and load order
-   between the two stylesheets is not something to rely on.
+   [data-slot="content-body"] is the wrapper div Select renders (see its own
+   scoped <style> block below), but Combobox and MultiSelect ALSO render an
+   element with that same data-slot, and both already cap their own inner
+   viewport (max-h-60/overflow-auto in ComboboxResults.vue) plus carry a
+   search input. A first version of this rule matched all three: on a short
+   viewport (about 500px, where 40vh is only 200px) that produced two nested
+   scroll regions, with Combobox/MultiSelect's search input scrolling away
+   independently of its own results below it.
 
-   App-wide for the same reason as the two rules above: every Select in the
-   app (not just this one page) portals identically and none of them wants an
-   unreachable tail once its option list is long enough. */
-[data-slot="content-body"] {
+   The selector below scopes to Select ONLY. reka-ui's SelectContentImpl sets
+   role="listbox" on the popover's own outer element (an ANCESTOR of
+   [data-slot="content-body"], not the element itself - see
+   reka-ui/src/Select/SelectContentImpl.vue); neither ComboboxContentImpl nor
+   MultiSelect (built on the same ComboboxContent) ever sets that role
+   anywhere in their DOM. Verified by reading both trees in node_modules
+   rather than assumed - `role="listbox"` does not appear once in
+   reka-ui/src/Combobox/ or frappe-ui/src/components/MultiSelect/.
+
+   overflow-y is !important because Select's own class list already carries
+   `overflow-hidden` (Tailwind, same specificity as this attribute selector)
+   and load order between the two stylesheets is not something to rely on.
+
+   App-wide for the same reason as the two rules above: every plain Select in
+   the app (not just this one page) portals identically and none of them
+   wants an unreachable tail once its option list is long enough. */
+[role="listbox"] [data-slot="content-body"] {
 	max-height: 40vh;
 	overflow-y: auto !important;
 }

--- a/frontend/src/pages/agents/AgentDetail.spec.js
+++ b/frontend/src/pages/agents/AgentDetail.spec.js
@@ -198,6 +198,8 @@ function installedInstallation(overrides = {}) {
 		synced_at: "",
 		schedule_enabled: 0,
 		schedule_frequency: "",
+		schedule_weekday: null,
+		schedule_day_of_month: null,
 		schedule_time: null,
 		next_run_at: null,
 		last_run_at: null,
@@ -581,6 +583,189 @@ describe("Configure tab: Schedule section - Save visibility, dirty tracking, sav
 		await flushPromises();
 
 		expect(scheduleSaveBtn(w)).toBeFalsy();
+	});
+
+	// jarvis#653: the weekly/monthly Day control - copies the Frequency
+	// FormControl exactly. `label` is not a declared prop on the FormControl
+	// stub, so it falls through as a plain attribute on the stub's single root
+	// element (a bare <select>) - a reliable way to pick the Day control out
+	// from the Frequency one, since the stub renders no <option>s for either
+	// (asserting the native <select>'s own .value would just read back "",
+	// which is why these check the component's modelValue/options PROPS
+	// instead of the DOM value).
+	function dayControl(w) {
+		return w
+			.findAllComponents({ name: "FormControl" })
+			.find((c) => c.attributes("label") === "Day");
+	}
+
+	it("no Day select for daily", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "daily",
+					schedule_time: "09:00:00",
+				}),
+			})
+		);
+		expect(dayControl(w)).toBeFalsy();
+	});
+
+	it("Day select renders with weekday options for weekly", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "weekly",
+					schedule_weekday: "Wednesday",
+					schedule_time: "09:00:00",
+				}),
+			})
+		);
+		const day = dayControl(w);
+		expect(day).toBeTruthy();
+		expect(day.props("modelValue")).toBe("Wednesday");
+		expect(day.props("options").map((o) => o.value)).toEqual([
+			"Monday",
+			"Tuesday",
+			"Wednesday",
+			"Thursday",
+			"Friday",
+			"Saturday",
+			"Sunday",
+		]);
+	});
+
+	it("Day select renders with day-of-month options for monthly", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "monthly",
+					schedule_day_of_month: 15,
+					schedule_time: "09:00:00",
+				}),
+			})
+		);
+		const day = dayControl(w);
+		expect(day).toBeTruthy();
+		expect(day.props("modelValue")).toBe("15");
+		expect(day.props("options")).toHaveLength(31);
+		expect(day.props("options")[14]).toEqual({ label: "15th", value: "15" });
+	});
+
+	it("save payload carries schedule_weekday for a weekly schedule", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "weekly",
+					schedule_weekday: "Friday",
+					schedule_time: "09:00:00",
+				}),
+			})
+		);
+		// dirty it with a time edit so Save appears, then save
+		await w.find('[data-testid="time-picker"]').trigger("click");
+		const btn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Save schedule");
+		api.setAgentSchedule.mockResolvedValue({
+			ok: true,
+			data: { name: "INST-1", next_run_at: null },
+		});
+		await btn.trigger("click");
+		await flushPromises();
+		expect(api.setAgentSchedule).toHaveBeenCalledWith(
+			"INST-1",
+			expect.objectContaining({
+				schedule_frequency: "weekly",
+				schedule_weekday: "Friday",
+				schedule_day_of_month: 0,
+			})
+		);
+	});
+
+	it("save payload carries schedule_day_of_month for a monthly schedule", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "monthly",
+					schedule_day_of_month: 15,
+					schedule_time: "09:00:00",
+				}),
+			})
+		);
+		await w.find('[data-testid="time-picker"]').trigger("click");
+		const btn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Save schedule");
+		api.setAgentSchedule.mockResolvedValue({
+			ok: true,
+			data: { name: "INST-1", next_run_at: null },
+		});
+		await btn.trigger("click");
+		await flushPromises();
+		expect(api.setAgentSchedule).toHaveBeenCalledWith(
+			"INST-1",
+			expect.objectContaining({
+				schedule_frequency: "monthly",
+				schedule_weekday: "",
+				schedule_day_of_month: 15,
+			})
+		);
+	});
+
+	it("summary line names the weekday for weekly", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "weekly",
+					schedule_weekday: "Monday",
+					schedule_time: "09:00:00",
+					next_run_at: "2026-10-05 09:00:00",
+				}),
+			})
+		);
+		const summary = w
+			.findAll("div.text-sm.text-ink-gray-5")
+			.find((d) => d.text().startsWith("Scheduled"));
+		expect(summary.text()).toContain("Scheduled weekly on Monday at 9:00 am.");
+	});
+
+	it("summary line names the ordinal day for monthly", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "monthly",
+					schedule_day_of_month: 15,
+					schedule_time: "09:00:00",
+					next_run_at: "2026-10-15 09:00:00",
+				}),
+			})
+		);
+		const summary = w
+			.findAll("div.text-sm.text-ink-gray-5")
+			.find((d) => d.text().startsWith("Scheduled"));
+		expect(summary.text()).toContain("Scheduled monthly on the 15th at 9:00 am.");
 	});
 
 	it("saved and enabled (clean): shows the one-line summary in the muted style", async () => {

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -383,7 +383,15 @@
 									:modelValue="sched.enabled"
 									@update:modelValue="(v) => (sched.enabled = v)"
 								/>
-								<div v-if="sched.enabled" class="grid grid-cols-2 gap-4">
+								<div
+									v-if="sched.enabled"
+									:class="[
+										'grid gap-4',
+										sched.frequency === 'daily'
+											? 'grid-cols-2'
+											: 'grid-cols-3',
+									]"
+								>
 									<FormControl
 										type="select"
 										label="Frequency"
@@ -399,6 +407,17 @@
 											@update:modelValue="(v) => (sched.time = v)"
 										/>
 									</div>
+									<!-- weekly -> weekday name, monthly -> day of month; hidden for
+									     daily. Copies the Frequency control above exactly (same
+									     FormControl type=select shape) - jarvis#653. -->
+									<FormControl
+										v-if="sched.frequency !== 'daily'"
+										type="select"
+										label="Day"
+										:options="dayOptions"
+										:modelValue="sched.day"
+										@update:modelValue="(v) => (sched.day = v)"
+									/>
 								</div>
 								<!-- owner feedback: the committed schedule + its next run, ONE
 								     line, shown only while the form matches what is actually
@@ -622,6 +641,12 @@ import { errMessage as errMsg, errHtml } from "@/lib/errors";
 import { session } from "@/data/session";
 import { parseListField } from "@/lib/parseListField";
 import { categoryTitle } from "@/lib/agentCategory";
+import {
+	WEEKDAY_OPTIONS,
+	DAY_OF_MONTH_OPTIONS,
+	deriveScheduleDay,
+	scheduleAnchorPhrase,
+} from "@/lib/scheduleAnchor";
 
 const props = defineProps({
 	slug: { type: String, required: true },
@@ -1045,21 +1070,61 @@ const defaultScheduleText = computed(() => {
 	return s.schedule_enabled ? `On by default · ${freq}` : `Off by default · suggested ${freq}`;
 });
 // ── Configure: schedule ───────────────────────────────────────────────────────
-const sched = ref({ enabled: false, frequency: "daily", time: "09:00" });
+const sched = ref({ enabled: false, frequency: "daily", time: "09:00", day: "" });
 const savingSchedule = ref(false);
+// jarvis#653: weekly -> weekday names, monthly -> 1..31 (ordinal labels) - the
+// Day control's own option list, keyed off the DRAFT frequency so it flips the
+// instant Frequency changes, before any save.
+const dayOptions = computed(() =>
+	sched.value.frequency === "weekly" ? WEEKDAY_OPTIONS : DAY_OF_MONTH_OPTIONS
+);
+// jarvis#653: guards the interactive-frequency-change watcher below from firing
+// off the SEED watch's own frequency+day assignment (which legitimately sets
+// day to "" for a legacy row with no anchor saved - the defaulting watcher must
+// not treat that as "needs a default"). True for exactly the synchronous
+// pre-flush window the seed watch's own effect runs in; nextTick clears it once
+// the DOM update (and any watcher chained off THIS assignment) has settled.
+let seedingSchedule = false;
 // seed once per installation (a background reload must not clobber edits)
 watch(
 	() => installation.value && installation.value.name,
 	(name) => {
 		if (!name) return;
+		seedingSchedule = true;
 		const inst = installation.value;
+		const freq = inst.schedule_frequency || "daily";
 		sched.value = {
 			enabled: !!inst.schedule_enabled,
-			frequency: inst.schedule_frequency || "daily",
+			frequency: freq,
 			time: timeHHMM(inst.schedule_time) || "09:00",
+			day: deriveScheduleDay(freq, inst.schedule_weekday, inst.schedule_day_of_month),
 		};
+		nextTick(() => {
+			seedingSchedule = false;
+		});
 	},
 	{ immediate: true }
+);
+// jarvis#653: an interactive Frequency change (NOT the seed above, guarded off
+// by `seedingSchedule`) needs its OWN default day - "Monday" for weekly, the
+// 1st for monthly - so the Day select never shows a visible option ("Monday")
+// while the model is empty (a phantom selection that would silently save
+// nothing). Only fills in when the current day does not already belong to the
+// new frequency's own option set, so switching away and back keeps whatever
+// the owner picked.
+watch(
+	() => sched.value.frequency,
+	(freq) => {
+		if (seedingSchedule) return;
+		if (freq === "weekly" && !WEEKDAY_OPTIONS.some((o) => o.value === sched.value.day)) {
+			sched.value.day = "Monday";
+		} else if (
+			freq === "monthly" &&
+			!DAY_OF_MONTH_OPTIONS.some((o) => o.value === sched.value.day)
+		) {
+			sched.value.day = "1";
+		}
+	}
 );
 // owner feedback: the ACTUAL saved shape, in `sched`'s own shape, derived
 // live off `installation` (not a second seeded ref) - so it tracks a
@@ -1067,10 +1132,16 @@ watch(
 // dirty-reset bookkeeping to get wrong.
 const savedSched = computed(() => {
 	const inst = installation.value;
+	const freq = (inst && inst.schedule_frequency) || "daily";
 	return {
 		enabled: !!(inst && inst.schedule_enabled),
-		frequency: (inst && inst.schedule_frequency) || "daily",
+		frequency: freq,
 		time: timeHHMM(inst && inst.schedule_time) || "09:00",
+		day: deriveScheduleDay(
+			freq,
+			inst && inst.schedule_weekday,
+			inst && inst.schedule_day_of_month
+		),
 	};
 });
 const scheduleDirty = computed(
@@ -1081,21 +1152,28 @@ const scheduleDirty = computed(
 		// carry seconds ("10:30:00"), while savedSched.time is already
 		// normalized to "HH:MM"; comparing raw would leave Save stuck visible
 		// after a successful time-only save (the two would never look equal).
-		timeHHMM(sched.value.time) !== savedSched.value.time
+		timeHHMM(sched.value.time) !== savedSched.value.time ||
+		// both sides are always the SAME string shape (deriveScheduleDay / a
+		// native select's modelValue), so a plain compare is enough - no
+		// int-vs-string mismatch to normalize the way schedule_day_of_month
+		// arrives from the server.
+		sched.value.day !== savedSched.value.day
 );
-// "Scheduled monthly at 9:00 am. Next run: Sat, Oct 3, 2026 9:00 AM" - the
-// SAVED frequency/time (never the unsaved draft) plus the existing
-// next_run_at rendering (fmtDt); empty while dirty (would describe a state
-// that no longer matches the form), when nothing is actually scheduled, or
-// when the SAVED schedule is off (a legacy/stale next_run_at must not be
-// narrated as a live schedule - "saved AND enabled").
+// "Scheduled monthly on the 15th at 9:00 am. Next run: Sat, Oct 3, 2026 9:00 AM"
+// (or, with no day anchor saved, the plain legacy wording: "Scheduled monthly
+// at 9:00 am. ...") - the SAVED frequency/time/day (never the unsaved draft)
+// plus the existing next_run_at rendering (fmtDt); empty while dirty (would
+// describe a state that no longer matches the form), when nothing is actually
+// scheduled, or when the SAVED schedule is off (a legacy/stale next_run_at
+// must not be narrated as a live schedule - "saved AND enabled").
 const scheduleSummary = computed(() => {
 	if (scheduleDirty.value || !savedSched.value.enabled) return "";
 	const nextRunAt = installation.value && installation.value.next_run_at;
 	if (!nextRunAt) return "";
+	const anchor = scheduleAnchorPhrase(savedSched.value.frequency, savedSched.value.day);
 	return (
-		`Scheduled ${savedSched.value.frequency} at ${formatTime12h(savedSched.value.time)}. ` +
-		`Next run: ${fmtDt(nextRunAt)}`
+		`Scheduled ${savedSched.value.frequency}${anchor ? ` ${anchor}` : ""} ` +
+		`at ${formatTime12h(savedSched.value.time)}. Next run: ${fmtDt(nextRunAt)}`
 	);
 });
 
@@ -1107,6 +1185,9 @@ async function saveSchedule() {
 			schedule_enabled: sched.value.enabled ? 1 : 0,
 			schedule_frequency: sched.value.frequency,
 			schedule_time: sched.value.time || "",
+			schedule_weekday: sched.value.frequency === "weekly" ? sched.value.day || "" : "",
+			schedule_day_of_month:
+				sched.value.frequency === "monthly" ? Number(sched.value.day) || 0 : 0,
 		});
 		toast.success("Schedule saved");
 		await load();

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -409,7 +409,12 @@
 									</div>
 									<!-- weekly -> weekday name, monthly -> day of month; hidden for
 									     daily. Copies the Frequency control above exactly (same
-									     FormControl type=select shape) - jarvis#653. -->
+									     FormControl type=select shape) - jarvis#653. Monthly's 31
+									     rows overflow this Select's popover with no cap of its own
+									     (frappe-ui's Select, unlike Combobox/Autocomplete/MultiSelect,
+									     sets no max-height on its content) - the fix lives in
+									     src/main.css's [data-slot="content-body"] rule, app-wide, not
+									     here (nothing to add on this control itself). -->
 									<FormControl
 										v-if="sched.frequency !== 'daily'"
 										type="select"

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -411,10 +411,11 @@
 									     daily. Copies the Frequency control above exactly (same
 									     FormControl type=select shape) - jarvis#653. Monthly's 31
 									     rows overflow this Select's popover with no cap of its own
-									     (frappe-ui's Select, unlike Combobox/Autocomplete/MultiSelect,
-									     sets no max-height on its content) - the fix lives in
-									     src/main.css's [data-slot="content-body"] rule, app-wide, not
-									     here (nothing to add on this control itself). -->
+									     (frappe-ui's Select sets no max-height on its content, unlike
+									     Combobox/Autocomplete/MultiSelect) - the fix lives in
+									     src/main.css's [role="listbox"] [data-slot="content-body"]
+									     rule, app-wide for every plain Select, not here (nothing to
+									     add on this control itself). -->
 									<FormControl
 										v-if="sched.frequency !== 'daily'"
 										type="select"

--- a/frontend/src/pages/dashboards/SavedDashboardsTab.vue
+++ b/frontend/src/pages/dashboards/SavedDashboardsTab.vue
@@ -29,7 +29,7 @@
 		@refresh="resetLoad"
 	>
 		<template #cell-dashboard_title="{ row }">
-			<div class="truncate text-base font-medium text-ink-gray-8">
+			<div class="truncate text-base font-medium text-ink-gray-9">
 				{{ row.dashboard_title || row.name }}
 			</div>
 		</template>

--- a/frontend/src/pages/files/FilesList.vue
+++ b/frontend/src/pages/files/FilesList.vue
@@ -114,7 +114,9 @@
 			<template #cell-title="{ row }">
 				<div class="flex items-center gap-2 overflow-hidden">
 					<FeatherIcon name="file-text" class="size-4 shrink-0 text-ink-gray-5" />
-					<div class="truncate text-base">{{ stripTitle(row.title) }}</div>
+					<div class="truncate text-base font-medium text-ink-gray-9">
+						{{ stripTitle(row.title) }}
+					</div>
 				</div>
 			</template>
 

--- a/frontend/src/pages/macros/MacroDetail.spec.js
+++ b/frontend/src/pages/macros/MacroDetail.spec.js
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#653 regression coverage: the Frequency-change watcher that auto-fills
+ * a default Day ("Monday" / "1") must NOT fire off seed()'s own frequency+day
+ * assignment - opening an existing weekly/monthly macro with no anchor saved
+ * (schedule_weekday / schedule_day_of_month both null) must load CLEAN (no
+ * Save enabled), not silently dirty the page with a fabricated day nobody
+ * chose. And the schedule summary must be built from the SAVED snapshot only,
+ * blank while the form is dirty - never narrating an uncommitted draft against
+ * a stale next_run_at.
+ */
+
+const api = vi.hoisted(() => ({
+	getMacro: vi.fn(),
+	createMacro: vi.fn(),
+	updateMacro: vi.fn(),
+	runMacro: vi.fn(),
+	deleteMacro: vi.fn(),
+	summarizeMacro: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
+vi.mock("vue-router", () => ({
+	useRouter: () => router,
+	onBeforeRouteLeave: vi.fn(),
+}));
+
+vi.mock("frappe-ui", () => ({
+	dayjsLocal: (d) => ({
+		format: () => String(d || ""),
+		fromNow: () => "",
+		isValid: () => !!d,
+		valueOf: () => (d ? new Date(String(d).replace(" ", "T")).getTime() : 0),
+	}),
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		create: vi.fn(),
+	},
+	confirmDialog: vi.fn(),
+	Button: {
+		name: "Button",
+		props: ["label", "disabled", "loading", "variant", "iconLeft", "tooltip", "icon"],
+		emits: ["click"],
+		template: `<button :disabled="disabled" :data-label="label" @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+	},
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant"],
+		template: `<span>{{ label }}</span>`,
+	},
+	Dropdown: { name: "Dropdown", props: ["options"], template: "<div><slot /></div>" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "options", "disabled"],
+		emits: ["update:modelValue"],
+		template: `<select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)"></select>`,
+	},
+	Switch: {
+		name: "Switch",
+		props: ["modelValue", "label", "disabled"],
+		emits: ["update:modelValue"],
+		template: `<button :disabled="disabled" @click="$emit('update:modelValue', !modelValue)">{{ label }}</button>`,
+	},
+	TimePicker: {
+		name: "TimePicker",
+		props: ["modelValue", "placeholder"],
+		emits: ["update:modelValue"],
+		template: `<button data-testid="time-picker" @click="$emit('update:modelValue', '10:30:00')">{{ modelValue }}</button>`,
+	},
+}));
+
+vi.mock("@/components/doc/DocPage.vue", () => ({
+	default: {
+		name: "DocPage",
+		props: ["breadcrumbs", "title", "statusBadge", "dirty", "loading", "error"],
+		template: `<div><slot name="actions" /><slot name="main" /><slot name="aside" /><slot name="footer" /></div>`,
+	},
+}));
+vi.mock("@/components/doc/DocSection.vue", () => ({
+	default: {
+		name: "DocSection",
+		props: ["label", "opened"],
+		template: `<div><slot /><slot name="header-suffix" /></div>`,
+	},
+}));
+vi.mock("@/components/doc/DocMetaPanel.vue", () => ({
+	default: { name: "DocMetaPanel", template: "<div />" },
+}));
+vi.mock("@/components/doc/CommentsSection.vue", () => ({
+	default: { name: "CommentsSection", template: "<div />" },
+}));
+vi.mock("@/pages/macros/StepsBuilder.vue", () => ({
+	default: { name: "StepsBuilder", template: "<div />" },
+}));
+vi.mock("@/composables/useDocmeta", () => ({ useDocmeta: () => ({}) }));
+vi.mock("@/composables/macroPrefill", () => ({ takeMacroPrefill: () => null }));
+vi.mock("@/branding", () => ({ agentName: "Jarvis" }));
+vi.mock("@/lib/errors", () => ({
+	errMessage: (e) => (e && e.message) || String(e),
+	errHtml: (e) => (e && e.message) || String(e),
+}));
+
+import MacroDetail from "./MacroDetail.vue";
+
+function baseMacro(overrides = {}) {
+	return {
+		name: "MACRO-1",
+		macro_name: "Month-end close",
+		description: "",
+		enabled: 1,
+		stop_on_error: 1,
+		skip_confirmation: 0,
+		schedule_enabled: 1,
+		schedule_frequency: "daily",
+		schedule_weekday: null,
+		schedule_day_of_month: null,
+		schedule_time: "09:00:00",
+		next_run_at: null,
+		merged_prompt: "",
+		merge_status: "",
+		steps: [
+			{
+				label: "",
+				prompt: "do the thing",
+				model_override: "",
+				thinking_override: "",
+				skills: [],
+			},
+		],
+		...overrides,
+	};
+}
+
+async function mountDetail(macroFixture) {
+	api.getMacro.mockResolvedValue(macroFixture);
+	const w = mount(MacroDetail, {
+		props: { id: macroFixture.name, isNew: false },
+		global: { provide: { $socket: null } },
+	});
+	await flushPromises();
+	await flushPromises();
+	return w;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+function saveBtn(w) {
+	return w.findAll("button").find((b) => b.attributes("data-label") === "Save");
+}
+
+describe("MacroDetail Schedule section: seeding must not fabricate a day", () => {
+	it("loading a weekly macro with no saved weekday loads clean (no Save)", async () => {
+		const w = await mountDetail(
+			baseMacro({ schedule_frequency: "weekly", schedule_weekday: null, next_run_at: null })
+		);
+		expect(saveBtn(w).attributes("disabled")).toBeDefined();
+	});
+
+	it("loading a monthly macro with no saved day-of-month loads clean (no Save)", async () => {
+		const w = await mountDetail(
+			baseMacro({
+				schedule_frequency: "monthly",
+				schedule_day_of_month: null,
+				next_run_at: null,
+			})
+		);
+		expect(saveBtn(w).attributes("disabled")).toBeDefined();
+	});
+
+	it("loading a weekly macro WITH a saved weekday loads clean and keeps it", async () => {
+		const w = await mountDetail(
+			baseMacro({
+				schedule_frequency: "weekly",
+				schedule_weekday: "Wednesday",
+				next_run_at: null,
+			})
+		);
+		expect(saveBtn(w).attributes("disabled")).toBeDefined();
+	});
+
+	it("an interactive Frequency change to weekly DOES default the day (and dirties the form)", async () => {
+		const w = await mountDetail(baseMacro({ schedule_frequency: "daily", next_run_at: null }));
+		expect(saveBtn(w).attributes("disabled")).toBeDefined();
+		// The FormControl stub renders a plain <select> with NO <option>s, so a
+		// native setValue("weekly") can never actually take (jsdom keeps a
+		// <select>'s .value at "" with no matching option to select) - drive
+		// the update the way the real component would receive it, straight
+		// through the component's own update:modelValue emit.
+		const freqControl = w
+			.findAllComponents({ name: "FormControl" })
+			.find((c) => c.attributes("label") === "Frequency");
+		expect(freqControl).toBeTruthy();
+		await freqControl.vm.$emit("update:modelValue", "weekly");
+		expect(saveBtn(w).attributes("disabled")).toBeUndefined();
+		// And the Day control picked up the fallback default, not a phantom
+		// empty selection.
+		const dayControl = w
+			.findAllComponents({ name: "FormControl" })
+			.find((c) => c.attributes("label") === "Day");
+		expect(dayControl.props("modelValue")).toBe("Monday");
+	});
+});
+
+describe("MacroDetail Schedule section: summary line reflects the SAVED snapshot only", () => {
+	it("shows the summary when clean and a next_run_at is present", async () => {
+		const w = await mountDetail(
+			baseMacro({
+				schedule_frequency: "monthly",
+				schedule_day_of_month: 15,
+				next_run_at: "2026-10-15 09:00:00",
+			})
+		);
+		expect(w.text()).toContain("Scheduled monthly on the 15th at 9:00 am.");
+		expect(w.text()).toContain("Next run:");
+	});
+
+	it("blanks the summary while the schedule time itself is being edited (unsaved)", async () => {
+		const w = await mountDetail(
+			baseMacro({
+				schedule_frequency: "monthly",
+				schedule_day_of_month: 15,
+				next_run_at: "2026-10-15 09:00:00",
+			})
+		);
+		expect(w.text()).toContain("Scheduled monthly");
+		// dirty the schedule time (unsaved) - the summary must not narrate the
+		// draft against the SAVED next_run_at, which never recomputes on its own.
+		await w.find('[data-testid="time-picker"]').trigger("click");
+		expect(w.text()).not.toContain("Scheduled monthly on the 15th at 9:00 am.");
+	});
+
+	it("blanks the summary even when an UNRELATED field is dirtied (macro_name)", async () => {
+		// jarvis#653 defect 2: the summary must be gated on the whole-form dirty
+		// flag, not a schedule-only one - MacroDetail has a single Save button
+		// for the whole page, so an edit anywhere leaves the page in a draft
+		// state the summary must not narrate as committed.
+		const w = await mountDetail(
+			baseMacro({
+				schedule_frequency: "monthly",
+				schedule_day_of_month: 15,
+				next_run_at: "2026-10-15 09:00:00",
+			})
+		);
+		expect(w.text()).toContain("Scheduled monthly");
+		// The FormControl stub has no <option>s, so drive the change through
+		// the component's own emit (see the Frequency test above for why a
+		// native setValue on this stub cannot be trusted).
+		const nameControl = w
+			.findAllComponents({ name: "FormControl" })
+			.find((c) => c.attributes("label") === "Name");
+		expect(nameControl).toBeTruthy();
+		await nameControl.vm.$emit("update:modelValue", "Renamed macro");
+		expect(w.text()).not.toContain("Scheduled monthly on the 15th at 9:00 am.");
+	});
+});

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -104,12 +104,26 @@
 								:disabled="saving"
 							/>
 						</div>
+						<!-- weekly -> weekday name, monthly -> day of month; hidden for
+						     daily. Copies the Frequency control above exactly - jarvis#653. -->
+						<FormControl
+							v-if="form.schedule_frequency !== 'daily'"
+							class="flex-1"
+							type="select"
+							label="Day"
+							:options="dayOptions"
+							:modelValue="form.schedule_day"
+							:disabled="saving"
+							@update:modelValue="(v) => (form.schedule_day = v)"
+						/>
 					</div>
 					<div
 						v-if="!isNew && form.schedule_enabled && nextRunAt"
 						class="text-sm text-ink-gray-5"
 					>
-						Next run: {{ nextRunAt }}
+						Scheduled {{ form.schedule_frequency
+						}}{{ scheduleAnchorText ? ` ${scheduleAnchorText}` : "" }} at
+						{{ formatTime12h(form.schedule_time) }}. Next run: {{ nextRunAt }}
 					</div>
 				</div>
 			</DocSection>
@@ -206,6 +220,12 @@ import { useDocmeta } from "@/composables/useDocmeta";
 import StepsBuilder from "./StepsBuilder.vue";
 import { takeMacroPrefill } from "@/composables/macroPrefill";
 import { exactDate } from "@/utils/datetime";
+import {
+	WEEKDAY_OPTIONS,
+	DAY_OF_MONTH_OPTIONS,
+	deriveScheduleDay,
+	scheduleAnchorPhrase,
+} from "@/lib/scheduleAnchor";
 import * as api from "@/api";
 import { agentName } from "@/branding";
 import { errMessage as errMsg, errHtml } from "@/lib/errors";
@@ -243,9 +263,40 @@ const form = reactive({
 	schedule_enabled: false,
 	schedule_frequency: "daily",
 	schedule_time: "09:00",
+	schedule_day: "",
 	steps: [],
 	merged_prompt: "",
 });
+// jarvis#653: weekly -> weekday names, monthly -> 1..31 (ordinal labels) - the
+// Day control's own option list, keyed off the DRAFT frequency so it flips the
+// instant Frequency changes, before any save.
+const dayOptions = computed(() =>
+	form.schedule_frequency === "weekly" ? WEEKDAY_OPTIONS : DAY_OF_MONTH_OPTIONS
+);
+// "on Monday" / "on the 15th" / "" for the Next-run line below.
+const scheduleAnchorText = computed(() =>
+	scheduleAnchorPhrase(form.schedule_frequency, form.schedule_day)
+);
+// jarvis#653: an interactive Frequency change needs its OWN default day -
+// "Monday" for weekly, the 1st for monthly - so the Day select never shows a
+// visible option ("Monday") while the model is empty (a phantom selection that
+// would silently save nothing). Only fills in when the current day does not
+// already belong to the new frequency's own option set, so switching away and
+// back keeps whatever was picked (and `seed()` above, which sets frequency+day
+// together, never trips this into overwriting a loaded value).
+watch(
+	() => form.schedule_frequency,
+	(freq) => {
+		if (freq === "weekly" && !WEEKDAY_OPTIONS.some((o) => o.value === form.schedule_day)) {
+			form.schedule_day = "Monday";
+		} else if (
+			freq === "monthly" &&
+			!DAY_OF_MONTH_OPTIONS.some((o) => o.value === form.schedule_day)
+		) {
+			form.schedule_day = "1";
+		}
+	}
+);
 // Saved-state copy for the dirty compare (set by seed). MUST be a ref: on
 // /macros/:id the dirty computed first evaluates while the load is in flight,
 // and with a plain variable the `!snapshot` short-circuit would track zero
@@ -275,6 +326,7 @@ const dirty = computed(() => {
 		(form.schedule_enabled ? 1 : 0) !== snap.schedule_enabled ||
 		(form.schedule_frequency || "daily") !== snap.schedule_frequency ||
 		(form.schedule_time || "") !== snap.schedule_time ||
+		(form.schedule_day || "") !== (snap.schedule_day || "") ||
 		JSON.stringify(cleanSteps(form.steps)) !== snap.stepsJson ||
 		(form.merged_prompt || "") !== snap.merged_prompt
 	);
@@ -329,6 +381,16 @@ function toHHMM(t) {
 	const m = /^(\d{1,2}):(\d{2})/.exec(String(t || ""));
 	return m ? `${m[1].padStart(2, "0")}:${m[2]}` : "";
 }
+// "09:00" -> "9:00 am" - mirrors TimePicker's OWN formatDisplay (frappe-ui,
+// use12Hour default), matching AgentDetail.vue's own copy of this helper.
+function formatTime12h(hhmm) {
+	const m = /^(\d{1,2}):(\d{2})/.exec(String(hhmm || ""));
+	if (!m) return "";
+	const h = parseInt(m[1], 10);
+	const am = h < 12;
+	const h12 = h % 12 === 0 ? 12 : h % 12;
+	return `${h12}:${m[2]} ${am ? "am" : "pm"}`;
+}
 
 // ── load / init (re-runs when /macros/new saves and replaces to /macros/:id) ─
 function seed(data) {
@@ -340,6 +402,11 @@ function seed(data) {
 	form.schedule_enabled = !!data.schedule_enabled;
 	form.schedule_frequency = data.schedule_frequency || "daily";
 	form.schedule_time = toHHMM(data.schedule_time) || "09:00";
+	form.schedule_day = deriveScheduleDay(
+		form.schedule_frequency,
+		data.schedule_weekday,
+		data.schedule_day_of_month
+	);
 	form.steps = mapSteps(data.steps);
 	if (!form.steps.length) form.steps = [{ label: "", prompt: "", skills: [] }];
 	form.merged_prompt = data.merged_prompt || "";
@@ -354,6 +421,7 @@ function seed(data) {
 		schedule_enabled: form.schedule_enabled ? 1 : 0,
 		schedule_frequency: form.schedule_frequency,
 		schedule_time: form.schedule_time,
+		schedule_day: form.schedule_day,
 		stepsJson: JSON.stringify(cleanSteps(form.steps)),
 		merged_prompt: form.merged_prompt,
 	};
@@ -429,6 +497,9 @@ async function save() {
 			schedule_enabled: form.schedule_enabled ? 1 : 0,
 			schedule_frequency: form.schedule_frequency || "daily",
 			schedule_time: form.schedule_time || "09:00",
+			schedule_weekday: form.schedule_frequency === "weekly" ? form.schedule_day || "" : "",
+			schedule_day_of_month:
+				form.schedule_frequency === "monthly" ? Number(form.schedule_day) || 0 : 0,
 		};
 		// Summary handling (update only): an edited summary is explicit intent →
 		// send it; a rename-only save keeps the stored one; changed steps with an

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -105,7 +105,12 @@
 							/>
 						</div>
 						<!-- weekly -> weekday name, monthly -> day of month; hidden for
-						     daily. Copies the Frequency control above exactly - jarvis#653. -->
+						     daily. Copies the Frequency control above exactly - jarvis#653.
+						     Monthly's 31 rows overflow this Select's popover with no cap of
+						     its own (frappe-ui's Select, unlike Combobox/Autocomplete/
+						     MultiSelect, sets no max-height on its content) - the fix lives
+						     in src/main.css's [data-slot="content-body"] rule, app-wide,
+						     not here (nothing to add on this control itself). -->
 						<FormControl
 							v-if="form.schedule_frequency !== 'daily'"
 							class="flex-1"

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -117,13 +117,8 @@
 							@update:modelValue="(v) => (form.schedule_day = v)"
 						/>
 					</div>
-					<div
-						v-if="!isNew && form.schedule_enabled && nextRunAt"
-						class="text-sm text-ink-gray-5"
-					>
-						Scheduled {{ form.schedule_frequency
-						}}{{ scheduleAnchorText ? ` ${scheduleAnchorText}` : "" }} at
-						{{ formatTime12h(form.schedule_time) }}. Next run: {{ nextRunAt }}
+					<div v-if="scheduleSummary" class="text-sm text-ink-gray-5">
+						{{ scheduleSummary }}
 					</div>
 				</div>
 			</DocSection>
@@ -196,6 +191,7 @@ import {
 	reactive,
 	computed,
 	watch,
+	nextTick,
 	shallowRef,
 	inject,
 	onMounted,
@@ -273,20 +269,25 @@ const form = reactive({
 const dayOptions = computed(() =>
 	form.schedule_frequency === "weekly" ? WEEKDAY_OPTIONS : DAY_OF_MONTH_OPTIONS
 );
-// "on Monday" / "on the 15th" / "" for the Next-run line below.
-const scheduleAnchorText = computed(() =>
-	scheduleAnchorPhrase(form.schedule_frequency, form.schedule_day)
-);
-// jarvis#653: an interactive Frequency change needs its OWN default day -
-// "Monday" for weekly, the 1st for monthly - so the Day select never shows a
-// visible option ("Monday") while the model is empty (a phantom selection that
-// would silently save nothing). Only fills in when the current day does not
-// already belong to the new frequency's own option set, so switching away and
-// back keeps whatever was picked (and `seed()` above, which sets frequency+day
-// together, never trips this into overwriting a loaded value).
+// jarvis#653: guards the interactive-frequency-change watcher below from firing
+// off `seed()`'s own frequency+day assignment (which legitimately sets day to
+// "" for a legacy row with no anchor saved - the defaulting watcher must not
+// treat that as "needs a default"). True for exactly the synchronous pre-flush
+// window seed()'s own assignment runs in; nextTick clears it once the DOM
+// update (and any watcher chained off THIS assignment) has settled. Mirrors
+// AgentDetail.vue's `seedingSchedule` guard exactly.
+let seedingSchedule = false;
+// jarvis#653: an interactive Frequency change (NOT `seed()`, guarded off by
+// `seedingSchedule`) needs its OWN default day - "Monday" for weekly, the 1st
+// for monthly - so the Day select never shows a visible option ("Monday")
+// while the model is empty (a phantom selection that would silently save
+// nothing). Only fills in when the current day does not already belong to the
+// new frequency's own option set, so switching away and back keeps whatever
+// was picked.
 watch(
 	() => form.schedule_frequency,
 	(freq) => {
+		if (seedingSchedule) return;
 		if (freq === "weekly" && !WEEKDAY_OPTIONS.some((o) => o.value === form.schedule_day)) {
 			form.schedule_day = "Monday";
 		} else if (
@@ -343,6 +344,22 @@ const breadcrumbs = computed(() => [
 ]);
 
 const nextRunAt = computed(() => exactDate(nextRunRaw.value));
+// "Scheduled monthly on the 15th at 9:00 am. Next run: ..." - built from the
+// SAVED snapshot only (never the live draft), mirroring AgentDetail.vue's own
+// scheduleSummary exactly: blank while `dirty` (would narrate a schedule that
+// no longer matches the form - nextRunAt never recomputes off an unsaved
+// edit, it only ever changes on the next load()/seed()), when there is no
+// next_run_at, or when the SAVED schedule is off.
+const scheduleSummary = computed(() => {
+	const snap = snapshot.value;
+	if (!snap || props.isNew || dirty.value || !snap.schedule_enabled) return "";
+	if (!nextRunAt.value) return "";
+	const anchor = scheduleAnchorPhrase(snap.schedule_frequency, snap.schedule_day);
+	return (
+		`Scheduled ${snap.schedule_frequency}${anchor ? ` ${anchor}` : ""} ` +
+		`at ${formatTime12h(snap.schedule_time)}. Next run: ${nextRunAt.value}`
+	);
+});
 
 const overflowOptions = computed(() => {
 	const opts = [];
@@ -394,6 +411,12 @@ function formatTime12h(hhmm) {
 
 // ── load / init (re-runs when /macros/new saves and replaces to /macros/:id) ─
 function seed(data) {
+	// jarvis#653: guard the frequency-change watcher above from the assignment
+	// two lines down - a legacy row with schedule_frequency weekly/monthly and
+	// NO anchor saved must seed schedule_day as "" (matching the snapshot below
+	// verbatim), not have the watcher fabricate "Monday"/"1" and leave the page
+	// dirty before the owner has touched anything.
+	seedingSchedule = true;
 	form.macro_name = data.macro_name || "";
 	form.description = data.description || "";
 	form.enabled = data.enabled == null ? true : !!data.enabled;
@@ -407,6 +430,9 @@ function seed(data) {
 		data.schedule_weekday,
 		data.schedule_day_of_month
 	);
+	nextTick(() => {
+		seedingSchedule = false;
+	});
 	form.steps = mapSteps(data.steps);
 	if (!form.steps.length) form.steps = [{ label: "", prompt: "", skills: [] }];
 	form.merged_prompt = data.merged_prompt || "";

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -107,10 +107,11 @@
 						<!-- weekly -> weekday name, monthly -> day of month; hidden for
 						     daily. Copies the Frequency control above exactly - jarvis#653.
 						     Monthly's 31 rows overflow this Select's popover with no cap of
-						     its own (frappe-ui's Select, unlike Combobox/Autocomplete/
-						     MultiSelect, sets no max-height on its content) - the fix lives
-						     in src/main.css's [data-slot="content-body"] rule, app-wide,
-						     not here (nothing to add on this control itself). -->
+						     its own (frappe-ui's Select sets no max-height on its content,
+						     unlike Combobox/Autocomplete/MultiSelect) - the fix lives in
+						     src/main.css's [role="listbox"] [data-slot="content-body"]
+						     rule, app-wide for every plain Select, not here (nothing to add
+						     on this control itself). -->
 						<FormControl
 							v-if="form.schedule_frequency !== 'daily'"
 							class="flex-1"

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -53,7 +53,9 @@
 
 			<template #cell-macro_name="{ row }">
 				<div class="flex items-center gap-2">
-					<span class="truncate">{{ row.macro_name }}</span>
+					<span class="truncate text-base font-medium text-ink-gray-9">{{
+						row.macro_name
+					}}</span>
 					<Tooltip
 						v-if="row.skip_confirmation"
 						text="Armed: this macro's runs execute writes without a confirmation card (admin-set)."

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -153,6 +153,7 @@ import { useListPage } from "@/composables/useListPage";
 import { macrosListFetch } from "@/pages/list/listFetchers";
 import RunsTab from "./RunsTab.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
+import { deriveScheduleDay, scheduleAnchorPhrase } from "@/lib/scheduleAnchor";
 import * as api from "@/api";
 import * as apiMacros from "@/api/macros";
 import { errHtml } from "@/lib/errors";
@@ -345,7 +346,12 @@ onBeforeUnmount(() => {
 // ── cell helpers ─────────────────────────────────────────────────────────────
 function scheduleLabel(row) {
 	const freq = row.schedule_frequency || "scheduled";
-	const label = freq.charAt(0).toUpperCase() + freq.slice(1);
+	let label = freq.charAt(0).toUpperCase() + freq.slice(1);
+	// jarvis#653: "Weekly on Monday" / "Monthly on the 15th" when the row has an
+	// anchor saved; unchanged ("Weekly") for a legacy row with none.
+	const day = deriveScheduleDay(freq, row.schedule_weekday, row.schedule_day_of_month);
+	const anchor = scheduleAnchorPhrase(freq, day);
+	if (anchor) label = `${label} ${anchor}`;
 	const t = toHHMM(row.schedule_time);
 	return t ? `${label} · ${t}` : label;
 }

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -105,7 +105,9 @@
 
 			<template #cell-title="{ row }">
 				<div class="flex items-center gap-2 overflow-hidden">
-					<div class="truncate text-base">{{ row.title || row.slug }}</div>
+					<div class="truncate text-base font-medium text-ink-gray-9">
+						{{ row.title || row.slug }}
+					</div>
 					<Badge
 						v-if="row.contradiction_flag"
 						variant="subtle"

--- a/frontend/src/pages/triggers/ActivityTab.vue
+++ b/frontend/src/pages/triggers/ActivityTab.vue
@@ -48,7 +48,7 @@
 			     recoverable on hover -->
 			<template #cell-trigger_label="{ row }">
 				<div
-					class="truncate text-base font-medium text-ink-gray-8"
+					class="truncate text-base font-medium text-ink-gray-9"
 					:title="row.trigger_label || row.trigger"
 				>
 					{{ row.trigger_label || row.trigger }}

--- a/frontend/src/pages/triggers/TriggersListPane.vue
+++ b/frontend/src/pages/triggers/TriggersListPane.vue
@@ -64,7 +64,7 @@
 		     recoverable on hover -->
 		<template #cell-trigger_name="{ row }">
 			<div
-				class="truncate text-base font-medium text-ink-gray-8"
+				class="truncate text-base font-medium text-ink-gray-9"
 				:title="row.trigger_name || row.name"
 			>
 				{{ row.trigger_name || row.name }}

--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -988,7 +988,12 @@ def record_delegate_run(
 	# next_run_at only for a scheduled install.
 	inst_values = {"last_run_at": frappe.utils.now()}
 	if inst.schedule_enabled:
-		inst_values["next_run_at"] = compute_next_run(inst.schedule_frequency, inst.schedule_time)
+		inst_values["next_run_at"] = compute_next_run(
+			inst.schedule_frequency,
+			inst.schedule_time,
+			weekday=inst.schedule_weekday,
+			day_of_month=inst.schedule_day_of_month,
+		)
 	frappe.db.set_value(INSTALLATION, inst.name, inst_values, update_modified=False)
 	# Under FrappeTestCase the enclosing transaction is rolled back at teardown; a
 	# mid-test commit would defeat that and leak Run/Finding/Provenance/Dashboard

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -137,6 +137,8 @@ def run_due_agent_audits() -> None:
 			"agent",
 			"schedule_frequency",
 			"schedule_time",
+			"schedule_weekday",
+			"schedule_day_of_month",
 			"installable",
 			"source_apps_json",
 			"activation_state",
@@ -1566,7 +1568,13 @@ def _advance(row, now) -> None:
 		row.name,
 		{
 			"last_run_at": now,
-			"next_run_at": compute_next_run(row.schedule_frequency, row.schedule_time, from_dt=now),
+			"next_run_at": compute_next_run(
+				row.schedule_frequency,
+				row.schedule_time,
+				from_dt=now,
+				weekday=row.schedule_weekday,
+				day_of_month=row.schedule_day_of_month,
+			),
 		},
 		update_modified=False,
 	)

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -905,6 +905,35 @@ def _bump_catalog_version() -> None:
 	frappe.clear_document_cache(_SETTINGS, _SETTINGS)
 
 
+def _default_schedule_weekday(sched: dict) -> str | None:
+	"""#653: resolve a listing's ``default_schedule`` weekday anchor, tolerantly
+	- an admin-authored default must never break an install (the controller's
+	own ``validate()`` is the throwing gate for a user-entered value; a bad
+	default here just falls back to "no anchor set" instead).
+
+	Reuses ``macro_scheduler._normalize_weekday``, the SAME reader every other
+	weekday input (the SPA, ``set_schedule``, the DocType controllers) goes
+	through - a listing default is not exempt from accepting the ISO-int form
+	(1-7) those callers all accept; a bespoke string-only check here silently
+	dropped a valid int weekday instead of resolving it. That reader returns a
+	0-6 index (Monday=0); convert it back to the Select field's own weekday
+	name for storage. Extracted as its own function (rather than inlined in
+	``install_agent``) so it is unit-testable without a DB fixture."""
+	from jarvis.chat.macro_scheduler import _WEEKDAY_NAMES, _normalize_weekday
+
+	idx = _normalize_weekday(sched.get("schedule_weekday"))
+	return _WEEKDAY_NAMES[idx] if idx is not None else None
+
+
+def _default_schedule_day_of_month(sched: dict) -> int | None:
+	"""#653 twin of ``_default_schedule_weekday``, for the monthly anchor."""
+	try:
+		day = int(sched.get("schedule_day_of_month"))
+	except (TypeError, ValueError):
+		return None
+	return day if 1 <= day <= 31 else None
+
+
 @frappe.whitelist()
 @require_jarvis_user
 def install_agent(agent_slug: str) -> dict:
@@ -946,21 +975,11 @@ def install_agent(agent_slug: str) -> dict:
 	if freq not in _FREQUENCIES:
 		freq = "daily"
 	# #653: the two weekly/monthly anchors ride the same default_schedule JSON,
-	# tolerantly — an admin-authored listing default must never BREAK an install
+	# tolerantly - an admin-authored listing default must never BREAK an install
 	# (the controller's own validate() is the throwing gate for a user-entered
 	# value; a bad default here just falls back to "no anchor set" instead).
-	from jarvis.chat.macro_scheduler import _WEEKDAY_NAMES
-
-	weekday = str(sched.get("schedule_weekday") or "").strip().capitalize()
-	if weekday not in _WEEKDAY_NAMES:
-		weekday = None
-	try:
-		day_of_month = int(sched.get("schedule_day_of_month"))
-	except (TypeError, ValueError):
-		day_of_month = None
-	else:
-		if not (1 <= day_of_month <= 31):
-			day_of_month = None
+	weekday = _default_schedule_weekday(sched)
+	day_of_month = _default_schedule_day_of_month(sched)
 
 	doc = frappe.get_doc(
 		{
@@ -1090,7 +1109,7 @@ def set_schedule(
 	after disabling the schedule).
 
 	``schedule_weekday``/``schedule_day_of_month`` (#653) are the weekly/monthly
-	anchors — optional, and only meaningful for their own frequency; the doctype's
+	anchors - optional, and only meaningful for their own frequency; the doctype's
 	own ``validate()`` re-checks both ranges (a Desk edit or data import bypasses
 	this endpoint entirely, so the range check cannot live here alone)."""
 	doc = frappe.get_doc(INSTALLATION, installation)

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -238,6 +238,8 @@ def _enriched_catalog() -> list[dict]:
 				"sync_status",
 				"schedule_enabled",
 				"schedule_frequency",
+				"schedule_weekday",
+				"schedule_day_of_month",
 				"schedule_time",
 				"next_run_at",
 				"last_run_at",
@@ -262,6 +264,8 @@ def _enriched_catalog() -> list[dict]:
 		lst["installed_version"] = inst.installed_version if inst else None
 		lst["schedule_enabled"] = int(inst.schedule_enabled) if inst else 0
 		lst["schedule_frequency"] = inst.schedule_frequency if inst else None
+		lst["schedule_weekday"] = inst.schedule_weekday if inst else None
+		lst["schedule_day_of_month"] = (inst.schedule_day_of_month or None) if inst else None
 		lst["schedule_time"] = str(inst.schedule_time) if (inst and inst.schedule_time) else None
 		lst["next_run_at"] = str(inst.next_run_at) if (inst and inst.next_run_at) else None
 		lst["update_available"] = (
@@ -450,6 +454,8 @@ def get_agent(agent_slug: str) -> dict:
 			"synced_at",
 			"schedule_enabled",
 			"schedule_frequency",
+			"schedule_weekday",
+			"schedule_day_of_month",
 			"schedule_time",
 			"next_run_at",
 			"last_run_at",
@@ -460,6 +466,7 @@ def get_agent(agent_slug: str) -> dict:
 		i = inst[0]
 		i["enabled"] = int(i.enabled or 0)
 		i["schedule_enabled"] = int(i.schedule_enabled or 0)
+		i["schedule_day_of_month"] = i.schedule_day_of_month or None
 		i["schedule_time"] = str(i.schedule_time) if i.schedule_time else None
 		i["next_run_at"] = str(i.next_run_at) if i.next_run_at else None
 		i["last_run_at"] = str(i.last_run_at) if i.last_run_at else None
@@ -510,6 +517,8 @@ def get_installations() -> list[dict]:
 			"synced_at",
 			"schedule_enabled",
 			"schedule_frequency",
+			"schedule_weekday",
+			"schedule_day_of_month",
 			"schedule_time",
 			"next_run_at",
 			"last_run_at",
@@ -784,6 +793,8 @@ def get_agent_admin_overview() -> dict:
 			"not_installable_reason",
 			"schedule_enabled",
 			"schedule_frequency",
+			"schedule_weekday",
+			"schedule_day_of_month",
 			"next_run_at",
 			"last_run_at",
 			"sync_status",
@@ -810,6 +821,8 @@ def get_agent_admin_overview() -> dict:
 				"not_installable_reason": i.not_installable_reason or None,
 				"schedule_enabled": int(i.schedule_enabled or 0),
 				"schedule_frequency": i.schedule_frequency,
+				"schedule_weekday": i.schedule_weekday or None,
+				"schedule_day_of_month": i.schedule_day_of_month or None,
 				"next_run_at": str(i.next_run_at) if i.next_run_at else None,
 				"last_run_at": str(i.last_run_at) if i.last_run_at else None,
 				"sync_status": i.sync_status,
@@ -932,6 +945,22 @@ def install_agent(agent_slug: str) -> dict:
 	freq = str(sched.get("schedule_frequency") or "daily").strip().lower()
 	if freq not in _FREQUENCIES:
 		freq = "daily"
+	# #653: the two weekly/monthly anchors ride the same default_schedule JSON,
+	# tolerantly — an admin-authored listing default must never BREAK an install
+	# (the controller's own validate() is the throwing gate for a user-entered
+	# value; a bad default here just falls back to "no anchor set" instead).
+	from jarvis.chat.macro_scheduler import _WEEKDAY_NAMES
+
+	weekday = str(sched.get("schedule_weekday") or "").strip().capitalize()
+	if weekday not in _WEEKDAY_NAMES:
+		weekday = None
+	try:
+		day_of_month = int(sched.get("schedule_day_of_month"))
+	except (TypeError, ValueError):
+		day_of_month = None
+	else:
+		if not (1 <= day_of_month <= 31):
+			day_of_month = None
 
 	doc = frappe.get_doc(
 		{
@@ -953,6 +982,8 @@ def install_agent(agent_slug: str) -> dict:
 			"installed_at": frappe.utils.now(),
 			"schedule_enabled": int(sched.get("schedule_enabled") or 0),
 			"schedule_frequency": freq,
+			"schedule_weekday": weekday,
+			"schedule_day_of_month": day_of_month,
 		}
 	)
 	try:
@@ -1049,12 +1080,19 @@ def set_schedule(
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
 	schedule_time: str | None = None,
+	schedule_weekday: str | None = None,
+	schedule_day_of_month: int | None = None,
 ) -> dict:
 	"""Set an installed agent's audit schedule — pure DB write (O6: no restart).
 	Recomputes ``next_run_at`` when the schedule is enabled; CLEARS it when the
 	schedule is turned off (jarvis#1062 E2E defect: it previously kept the last
 	computed value, so the Configure tab kept showing a stale "Next run: ..."
-	after disabling the schedule)."""
+	after disabling the schedule).
+
+	``schedule_weekday``/``schedule_day_of_month`` (#653) are the weekly/monthly
+	anchors — optional, and only meaningful for their own frequency; the doctype's
+	own ``validate()`` re-checks both ranges (a Desk edit or data import bypasses
+	this endpoint entirely, so the range check cannot live here alone)."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	doc.check_permission("write")  # S3 owner-gate
 	# R5-J8: turning a schedule ON is a run commitment — refuse it for a
@@ -1072,9 +1110,20 @@ def set_schedule(
 		doc.schedule_frequency = freq
 	if schedule_time is not None:
 		doc.schedule_time = schedule_time or None
+	if schedule_weekday is not None:
+		doc.schedule_weekday = schedule_weekday or None
+	if schedule_day_of_month is not None:
+		# cint (not the raw arg) so a stray "" or a non-numeric SPA payload lands
+		# on the doctype's own 1-31 validate() rather than a TypeError here.
+		doc.schedule_day_of_month = frappe.utils.cint(schedule_day_of_month) or None
 
 	if doc.schedule_enabled:
-		doc.next_run_at = compute_next_run(doc.schedule_frequency, doc.schedule_time)
+		doc.next_run_at = compute_next_run(
+			doc.schedule_frequency,
+			doc.schedule_time,
+			weekday=doc.schedule_weekday,
+			day_of_month=doc.schedule_day_of_month,
+		)
 	else:
 		doc.next_run_at = None
 	doc.save()

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -21,6 +21,7 @@ the macro's owner (so the result conversation is theirs) and advancing
   try/except, so one bad row aborted the sweep for every other macro on the bench.
 """
 
+import calendar
 import datetime
 
 import frappe
@@ -98,7 +99,16 @@ def run_due_macros() -> None:
 	due = frappe.get_all(
 		MACRO,
 		filters={"schedule_enabled": 1, "next_run_at": ["<=", now]},
-		fields=["name", "macro_name", "owner", "enabled", "schedule_frequency", "schedule_time"],
+		fields=[
+			"name",
+			"macro_name",
+			"owner",
+			"enabled",
+			"schedule_frequency",
+			"schedule_time",
+			"schedule_weekday",
+			"schedule_day_of_month",
+		],
 	)
 	if not due:
 		return
@@ -219,7 +229,15 @@ def _consume_slot(m, now, *, stamp_last_run: bool = True) -> None:
 	``stamp_last_run=False`` moves the schedule on WITHOUT claiming a run happened:
 	``last_run_at`` is what the SPA renders as "last run", so stamping it for a slot
 	nothing executed is the #471 "the UI reports success" limb."""
-	values = {"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now)}
+	values = {
+		"next_run_at": compute_next_run(
+			m.schedule_frequency,
+			m.schedule_time,
+			from_dt=now,
+			weekday=m.schedule_weekday,
+			day_of_month=m.schedule_day_of_month,
+		)
+	}
 	if stamp_last_run:
 		values["last_run_at"] = now
 	frappe.db.set_value(MACRO, m.name, values, update_modified=False)
@@ -274,20 +292,56 @@ def _notify_owner(m, reason: str) -> None:
 	)
 
 
-def compute_next_run(frequency: str, schedule_time, from_dt=None) -> datetime.datetime:
+_WEEKDAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+def compute_next_run(
+	frequency: str,
+	schedule_time,
+	from_dt=None,
+	weekday: str | int | None = None,
+	day_of_month: int | None = None,
+) -> datetime.datetime:
 	"""Next fire time strictly after ``from_dt`` (default now) at ``schedule_time``
 	on the given ``frequency`` (daily/weekly/monthly).
 
-	TOTAL by construction (#472): ``_time_to_seconds`` can only return a real time of
-	day, so ``base.replace(hour=...)`` can no longer raise ``ValueError`` on a value
-	that reached the row before this validation existed. That matters because the
-	function is called from the cron's bookkeeping, where a raise skipped every macro
-	after the offending one."""
+	``weekday`` (weekly) and ``day_of_month`` (monthly) are optional anchors
+	(#653): when given, the next occurrence lands ON that weekday / day of month
+	rather than simply +7 days / +1 month from ``from_dt``. Omitted or invalid
+	entirely (either argument), the function falls back to the original plain
+	advance — every existing caller that does not pass them keeps its old
+	behaviour verbatim.
+
+	TOTAL by construction (#472, extended by #653 to the two new anchors):
+	``_time_to_seconds`` can only return a real time of day, and
+	``_normalize_weekday``/``_normalize_day_of_month`` can only return a valid
+	index or ``None`` — never raise — so a garbage anchor is treated the same as
+	an absent one. That matters because the function is called from the cron's
+	bookkeeping, where a raise skipped every macro/install after the offending
+	one."""
 	base = get_datetime(from_dt) if from_dt else now_datetime()
 	secs = _time_to_seconds(schedule_time)
-	cand = base.replace(hour=secs // 3600, minute=(secs % 3600) // 60, second=0, microsecond=0)
+	hour, minute = secs // 3600, (secs % 3600) // 60
+	freq = str(frequency or "daily").strip().lower()
+	weekday_idx = _normalize_weekday(weekday) if freq == "weekly" else None
+	day = _normalize_day_of_month(day_of_month) if freq == "monthly" else None
+
+	if weekday_idx is not None:
+		cand = _weekly_candidate(base, hour, minute, weekday_idx)
+		while cand <= base:
+			cand = _weekly_candidate(cand + datetime.timedelta(days=1), hour, minute, weekday_idx)
+		return cand
+
+	if day is not None:
+		cand = _monthly_candidate(base, hour, minute, day)
+		while cand <= base:
+			anchor = add_to_date(cand.replace(day=1), months=1)
+			cand = _monthly_candidate(anchor, hour, minute, day)
+		return cand
+
+	cand = base.replace(hour=hour, minute=minute, second=0, microsecond=0)
 	while cand <= base:
-		cand = _advance(cand, frequency)
+		cand = _advance(cand, freq)
 	return cand
 
 
@@ -297,6 +351,61 @@ def _advance(dt: datetime.datetime, frequency: str) -> datetime.datetime:
 	if frequency == "monthly":
 		return add_to_date(dt, months=1)
 	return add_to_date(dt, days=1)
+
+
+def _weekly_candidate(
+	base_date: datetime.datetime, hour: int, minute: int, weekday_idx: int
+) -> datetime.datetime:
+	"""The occurrence of ``weekday_idx`` (0=Monday..6=Sunday, ``datetime.weekday()``
+	convention) at ``hour``:``minute`` in the week containing ``base_date`` — which
+	may fall BEFORE ``base_date`` itself; the caller's ``while cand <= base`` loop
+	is what pushes it into the following week when that happens."""
+	delta = (weekday_idx - base_date.weekday()) % 7
+	day = base_date + datetime.timedelta(days=delta)
+	return day.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def _monthly_candidate(base_date: datetime.datetime, hour: int, minute: int, day: int) -> datetime.datetime:
+	"""The occurrence of day-of-month ``day`` (1-31) at ``hour``:``minute`` in
+	``base_date``'s own month, clamped to that month's last day (#653: day 31 in
+	February lands on the 28th/29th)."""
+	last_day = calendar.monthrange(base_date.year, base_date.month)[1]
+	return base_date.replace(day=min(day, last_day), hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def _normalize_weekday(value) -> int | None:
+	"""Weekday index (0=Monday..6=Sunday) from a weekday name (case-insensitive,
+	matching the Select field's options) or an ISO weekday int (1=Monday..7=Sunday).
+	``None`` for anything else — a missing, blank, or garbage value included — so
+	the caller falls back to the plain +7-days advance (#653, extending #472's
+	TOTAL guarantee to this anchor)."""
+	if value is None or value == "":
+		return None
+	if isinstance(value, str):
+		name = value.strip().capitalize()
+		if name in _WEEKDAY_NAMES:
+			return _WEEKDAY_NAMES.index(name)
+		try:
+			value = int(value)
+		except ValueError:
+			return None
+	try:
+		n = int(value)
+	except (TypeError, ValueError):
+		return None
+	return n - 1 if 1 <= n <= 7 else None
+
+
+def _normalize_day_of_month(value) -> int | None:
+	"""1-31, or ``None`` for anything else — including the ``0`` an unset Int
+	field reads as (Frappe coerces a blank Int to 0, not ``None``) and any
+	garbage that reached the row before validation existed (#653, same TOTAL
+	shape as ``_normalize_weekday``)."""
+	try:
+		n = int(value)
+	except (TypeError, ValueError):
+		return None
+	return n if 1 <= n <= 31 else None
 
 
 def parse_schedule_seconds(t) -> int | None:
@@ -381,6 +490,23 @@ def validate_schedule_time_or_throw(value) -> None:
 		frappe.throw(
 			frappe._("Schedule time must be a time of day between 00:00:00 and 23:59:59."),
 			title=frappe._("Invalid schedule time"),
+		)
+
+
+def validate_schedule_day_of_month_or_throw(value) -> None:
+	"""Refuse a ``schedule_day_of_month`` that is not 1-31, with the field error the
+	SPA renders. Companion to ``validate_schedule_time_or_throw`` — same ONE-definition
+	reasoning, called by both ``JarvisMacro`` and ``JarvisAgentInstallation`` (#653).
+
+	``0`` is exempt alongside ``None``/``""``: Frappe coerces a blank Int field to
+	``0`` rather than ``None``, so an unset value reaches here as ``0`` on every
+	normal save path — that is "not set", not "the 0th day"."""
+	if value in (None, "", 0):
+		return
+	if _normalize_day_of_month(value) is None:
+		frappe.throw(
+			frappe._("Day of month must be between 1 and 31."),
+			title=frappe._("Invalid schedule day"),
 		)
 
 

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -309,13 +309,13 @@ def compute_next_run(
 	(#653): when given, the next occurrence lands ON that weekday / day of month
 	rather than simply +7 days / +1 month from ``from_dt``. Omitted or invalid
 	entirely (either argument), the function falls back to the original plain
-	advance — every existing caller that does not pass them keeps its old
+	advance - every existing caller that does not pass them keeps its old
 	behaviour verbatim.
 
 	TOTAL by construction (#472, extended by #653 to the two new anchors):
 	``_time_to_seconds`` can only return a real time of day, and
 	``_normalize_weekday``/``_normalize_day_of_month`` can only return a valid
-	index or ``None`` — never raise — so a garbage anchor is treated the same as
+	index or ``None`` - never raise - so a garbage anchor is treated the same as
 	an absent one. That matters because the function is called from the cron's
 	bookkeeping, where a raise skipped every macro/install after the offending
 	one."""
@@ -357,7 +357,7 @@ def _weekly_candidate(
 	base_date: datetime.datetime, hour: int, minute: int, weekday_idx: int
 ) -> datetime.datetime:
 	"""The occurrence of ``weekday_idx`` (0=Monday..6=Sunday, ``datetime.weekday()``
-	convention) at ``hour``:``minute`` in the week containing ``base_date`` — which
+	convention) at ``hour``:``minute`` in the week containing ``base_date`` - which
 	may fall BEFORE ``base_date`` itself; the caller's ``while cand <= base`` loop
 	is what pushes it into the following week when that happens."""
 	delta = (weekday_idx - base_date.weekday()) % 7
@@ -376,7 +376,7 @@ def _monthly_candidate(base_date: datetime.datetime, hour: int, minute: int, day
 def _normalize_weekday(value) -> int | None:
 	"""Weekday index (0=Monday..6=Sunday) from a weekday name (case-insensitive,
 	matching the Select field's options) or an ISO weekday int (1=Monday..7=Sunday).
-	``None`` for anything else — a missing, blank, or garbage value included — so
+	``None`` for anything else - a missing, blank, or garbage value included - so
 	the caller falls back to the plain +7-days advance (#653, extending #472's
 	TOTAL guarantee to this anchor)."""
 	if value is None or value == "":
@@ -397,7 +397,7 @@ def _normalize_weekday(value) -> int | None:
 
 
 def _normalize_day_of_month(value) -> int | None:
-	"""1-31, or ``None`` for anything else — including the ``0`` an unset Int
+	"""1-31, or ``None`` for anything else - including the ``0`` an unset Int
 	field reads as (Frappe coerces a blank Int to 0, not ``None``) and any
 	garbage that reached the row before validation existed (#653, same TOTAL
 	shape as ``_normalize_weekday``)."""
@@ -495,12 +495,12 @@ def validate_schedule_time_or_throw(value) -> None:
 
 def validate_schedule_day_of_month_or_throw(value) -> None:
 	"""Refuse a ``schedule_day_of_month`` that is not 1-31, with the field error the
-	SPA renders. Companion to ``validate_schedule_time_or_throw`` — same ONE-definition
+	SPA renders. Companion to ``validate_schedule_time_or_throw`` - same ONE-definition
 	reasoning, called by both ``JarvisMacro`` and ``JarvisAgentInstallation`` (#653).
 
 	``0`` is exempt alongside ``None``/``""``: Frappe coerces a blank Int field to
 	``0`` rather than ``None``, so an unset value reaches here as ``0`` on every
-	normal save path — that is "not set", not "the 0th day"."""
+	normal save path - that is "not set", not "the 0th day"."""
 	if value in (None, "", 0):
 		return
 	if _normalize_day_of_month(value) is None:

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -98,6 +98,8 @@ def list_macros() -> list[dict]:
 			"stop_on_error",
 			"schedule_enabled",
 			"schedule_frequency",
+			"schedule_weekday",
+			"schedule_day_of_month",
 			"schedule_time",
 			"next_run_at",
 			"last_run_at",
@@ -190,7 +192,8 @@ def list_macros_page(
 	total = list_filters.bounded_sql(f"SELECT COUNT(*) FROM `tabJarvis Macro` WHERE {where}", params)[0][0]
 	rows = list_filters.bounded_sql(
 		f"""SELECT name, macro_name, description, enabled, stop_on_error, skip_confirmation,
-		schedule_enabled, schedule_frequency, schedule_time, next_run_at,
+		schedule_enabled, schedule_frequency, schedule_weekday, schedule_day_of_month,
+		schedule_time, next_run_at,
 		last_run_at, modified, merge_status,
 		CASE WHEN TRIM(COALESCE(merged_prompt, '')) != '' THEN 1 ELSE 0 END AS has_summary
 		FROM `tabJarvis Macro`
@@ -241,6 +244,8 @@ def get_macro(name: str) -> dict:
 		"skip_confirmation": int(doc.skip_confirmation or 0),
 		"schedule_enabled": int(doc.schedule_enabled or 0),
 		"schedule_frequency": doc.schedule_frequency or "daily",
+		"schedule_weekday": doc.schedule_weekday or None,
+		"schedule_day_of_month": doc.schedule_day_of_month or None,
 		"schedule_time": str(doc.schedule_time or ""),
 		"next_run_at": str(doc.next_run_at or ""),
 		"merged_prompt": doc.merged_prompt or "",
@@ -279,10 +284,13 @@ def create_macro(
 	schedule_enabled: int = 0,
 	schedule_frequency: str = "daily",
 	schedule_time: str | None = None,
+	schedule_weekday: str | None = None,
+	schedule_day_of_month: int | None = None,
 ) -> dict:
-	"""Create a macro. Validation (name/steps/caps) runs in the doctype validate().
-	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``). Arming
-	(``skip_confirmation`` 0 -> 1) is admin-gated in the doctype validate()."""
+	"""Create a macro. Validation (name/steps/caps, and the two schedule anchors'
+	ranges) runs in the doctype validate(). Per-step tagged skills arrive INSIDE
+	each step dict (``steps[].skills``). Arming (``skip_confirmation`` 0 -> 1) is
+	admin-gated in the doctype validate()."""
 	doc = frappe.get_doc(
 		{
 			"doctype": MACRO,
@@ -294,6 +302,8 @@ def create_macro(
 			"schedule_enabled": int(schedule_enabled or 0),
 			"schedule_frequency": schedule_frequency or "daily",
 			"schedule_time": schedule_time or None,
+			"schedule_weekday": schedule_weekday or None,
+			"schedule_day_of_month": frappe.utils.cint(schedule_day_of_month) or None,
 			"steps": _parse_steps(steps),
 		}
 	)
@@ -315,6 +325,8 @@ def update_macro(
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
 	schedule_time: str | None = None,
+	schedule_weekday: str | None = None,
+	schedule_day_of_month: int | None = None,
 	merged_prompt: str | None = None,
 ) -> dict:
 	"""Update provided fields of a macro (owner-gated). When ``steps`` is given it
@@ -340,6 +352,12 @@ def update_macro(
 		doc.schedule_frequency = schedule_frequency
 	if schedule_time is not None:
 		doc.schedule_time = schedule_time or None
+	if schedule_weekday is not None:
+		doc.schedule_weekday = schedule_weekday or None
+	if schedule_day_of_month is not None:
+		# cint (not the raw arg) so a stray "" or a non-numeric SPA payload lands
+		# on the doctype's own 1-31 validate() rather than a TypeError here.
+		doc.schedule_day_of_month = frappe.utils.cint(schedule_day_of_month) or None
 	if steps is not None:
 		doc.set("steps", _parse_steps(steps))
 		if merged_prompt is None:

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
@@ -25,6 +25,8 @@
   "schedule_section",
   "schedule_enabled",
   "schedule_frequency",
+  "schedule_weekday",
+  "schedule_day_of_month",
   "schedule_time",
   "next_run_at",
   "last_run_at"
@@ -118,6 +120,21 @@
    "fieldtype": "Select",
    "label": "Frequency",
    "options": "daily\nweekly\nmonthly"
+  },
+  {
+   "depends_on": "eval:doc.schedule_enabled && doc.schedule_frequency=='weekly'",
+   "fieldname": "schedule_weekday",
+   "fieldtype": "Select",
+   "label": "Day of week",
+   "options": "\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday\nSunday",
+   "description": "Which weekday a weekly schedule fires on (defaults to the day of the first fire when unset)."
+  },
+  {
+   "depends_on": "eval:doc.schedule_enabled && doc.schedule_frequency=='monthly'",
+   "fieldname": "schedule_day_of_month",
+   "fieldtype": "Int",
+   "label": "Day of month",
+   "description": "Which day of the month (1-31) a monthly schedule fires on, clamped to the last day of short months (defaults to the day of the first fire when unset)."
   },
   {
    "depends_on": "eval:doc.schedule_enabled",

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -47,6 +47,7 @@ class JarvisAgentInstallation(Document):
 		self._validate_owner_cap()
 		self._validate_run_as_user()
 		self._validate_schedule_time()
+		self._validate_schedule_day_of_month()
 		self._validate_schedule_budget()
 		self._guard_activation_transition()
 
@@ -169,6 +170,18 @@ class JarvisAgentInstallation(Document):
 		from jarvis.chat.macro_scheduler import validate_schedule_time_or_throw
 
 		validate_schedule_time_or_throw(self.schedule_time)
+
+	def _validate_schedule_day_of_month(self):
+		"""#653: the agent twin of ``JarvisMacro._validate_schedule_day_of_month`` —
+		refuse a ``schedule_day_of_month`` outside 1-31 on every save surface, for the
+		same reason ``_validate_schedule_time`` above gives (a Desk edit / data import /
+		direct ``doc.save()`` all bypass ``agents_api.set_schedule``). The weekday Select
+		is range-checked by the framework's own ``_validate_selects``; this Int field is
+		not, so the check is explicit. Shared rule lives in ``macro_scheduler`` so this
+		controller and ``JarvisMacro`` cannot drift apart."""
+		from jarvis.chat.macro_scheduler import validate_schedule_day_of_month_or_throw
+
+		validate_schedule_day_of_month_or_throw(self.schedule_day_of_month)
 
 	def _validate_schedule_budget(self):
 		"""A14: warn (do not hard-block) when an enabled schedule's expected monthly

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -172,7 +172,7 @@ class JarvisAgentInstallation(Document):
 		validate_schedule_time_or_throw(self.schedule_time)
 
 	def _validate_schedule_day_of_month(self):
-		"""#653: the agent twin of ``JarvisMacro._validate_schedule_day_of_month`` —
+		"""#653: the agent twin of ``JarvisMacro._validate_schedule_day_of_month`` -
 		refuse a ``schedule_day_of_month`` outside 1-31 on every save surface, for the
 		same reason ``_validate_schedule_time`` above gives (a Desk edit / data import /
 		direct ``doc.save()`` all bypass ``agents_api.set_schedule``). The weekday Select

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.json
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.json
@@ -19,6 +19,8 @@
   "schedule_section",
   "schedule_enabled",
   "schedule_frequency",
+  "schedule_weekday",
+  "schedule_day_of_month",
   "schedule_time",
   "last_run_at",
   "next_run_at"
@@ -107,6 +109,21 @@
    "options": "daily\nweekly\nmonthly",
    "default": "daily",
    "depends_on": "eval:doc.schedule_enabled"
+  },
+  {
+   "fieldname": "schedule_weekday",
+   "fieldtype": "Select",
+   "label": "Day of week",
+   "options": "\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday\nSunday",
+   "depends_on": "eval:doc.schedule_enabled && doc.schedule_frequency=='weekly'",
+   "description": "Which weekday a weekly schedule fires on (defaults to the day of the first fire when unset)."
+  },
+  {
+   "fieldname": "schedule_day_of_month",
+   "fieldtype": "Int",
+   "label": "Day of month",
+   "depends_on": "eval:doc.schedule_enabled && doc.schedule_frequency=='monthly'",
+   "description": "Which day of the month (1-31) a monthly schedule fires on, clamped to the last day of short months (defaults to the day of the first fire when unset)."
   },
   {
    "fieldname": "schedule_time",

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.py
@@ -30,6 +30,7 @@ class JarvisMacro(Document):
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
 		self._validate_schedule_time()
+		self._validate_schedule_day_of_month()
 		self._guard_skip_confirmation_enable()
 		self._recompute_next_run()
 
@@ -118,6 +119,16 @@ class JarvisMacro(Document):
 
 		validate_schedule_time_or_throw(self.schedule_time)
 
+	def _validate_schedule_day_of_month(self):
+		"""#653: refuse a ``schedule_day_of_month`` outside 1-31, same reasoning and
+		timing as ``_validate_schedule_time`` above (a Select-field weekday is
+		range-checked by the framework's own ``_validate_selects``; this Int field is
+		not, so the check is explicit here). Shared with ``JarvisAgentInstallation``
+		via ``macro_scheduler.validate_schedule_day_of_month_or_throw``."""
+		from jarvis.chat.macro_scheduler import validate_schedule_day_of_month_or_throw
+
+		validate_schedule_day_of_month_or_throw(self.schedule_day_of_month)
+
 	def _recompute_next_run(self):
 		"""Keep ``next_run_at`` in sync with the schedule fields. The scheduler
 		(``jarvis.chat.macro_scheduler``) advances it after each run via a raw
@@ -131,12 +142,19 @@ class JarvisMacro(Document):
 			or self.has_value_changed("schedule_enabled")
 			or self.has_value_changed("schedule_frequency")
 			or self.has_value_changed("schedule_time")
+			or self.has_value_changed("schedule_weekday")
+			or self.has_value_changed("schedule_day_of_month")
 			or not self.next_run_at
 		)
 		if changed:
 			from jarvis.chat.macro_scheduler import compute_next_run
 
-			self.next_run_at = compute_next_run(self.schedule_frequency, self.schedule_time)
+			self.next_run_at = compute_next_run(
+				self.schedule_frequency,
+				self.schedule_time,
+				weekday=self.schedule_weekday,
+				day_of_month=self.schedule_day_of_month,
+			)
 
 
 def on_doctype_update():

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -773,6 +773,15 @@ class TestDefaultScheduleAnchors(FrappeTestCase):
 		if not listing_name:
 			self.skipTest("close-auditor listing not present on this site")
 		owner = _ensure_user("msched-int-weekday@example.com", enabled=1)
+		# close-auditor declares doctypes_required (GL Entry / Account / Company);
+		# JarvisAgentInstallation._validate_run_as_user refuses to install unless
+		# the run-as user already holds read on those - the same A12 gate
+		# test_agents_marketplace.py and test_platform_agents_api_hardening.py
+		# satisfy for their own fixtures. Accounts User grants them. This is a
+		# real-access grant, not a bypass of the check itself.
+		if frappe.db.exists("Role", "Accounts User"):
+			if "Accounts User" not in set(frappe.get_roles(owner)):
+				frappe.get_doc("User", owner).add_roles("Accounts User")
 		original_schedule = frappe.db.get_value("Jarvis Agent Listing", listing_name, "default_schedule")
 		frappe.db.set_value(
 			"Jarvis Agent Listing",

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -581,3 +581,136 @@ class TestScheduleTimeValidation(MacroSchedulerBase):
 			with self.subTest(bad=bad):
 				nxt = macro_scheduler.compute_next_run("daily", bad)
 				self.assertEqual((nxt.hour, nxt.minute), (9, 0))
+
+
+class TestScheduleDayOfMonthValidation(MacroSchedulerBase):
+	"""The #653 twin of ``TestScheduleTimeValidation`` above: ``schedule_day_of_month``
+	is an Int field Frappe never range-checks on its own, so a bad value must be
+	refused the same way an out-of-range ``schedule_time`` is."""
+
+	def _save(self, tag: str, day_of_month, frequency: str = "monthly"):
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": f"{PFX}-{tag}",
+				"enabled": 1,
+				"schedule_enabled": 1,
+				"schedule_frequency": frequency,
+				"schedule_day_of_month": day_of_month,
+				"steps": [{"prompt": "p1"}],
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		return doc
+
+	def test_out_of_range_day_of_month_is_refused_cleanly(self):
+		for bad in (0, 32, -1, 100):
+			with self.subTest(bad=bad):
+				with self.assertRaises(frappe.ValidationError):
+					self._save(f"bad-{bad}", bad)
+
+	def test_valid_days_of_month_are_accepted_and_scheduled(self):
+		for good in (1, 15, 31):
+			with self.subTest(good=good):
+				doc = self._save(f"ok-{good}", good)
+				self.assertTrue(doc.next_run_at, "a valid day must still produce a next_run_at")
+
+	def test_unset_day_of_month_is_exempt(self):
+		# An Int field left blank reaches validate() as 0, not None - "not set",
+		# never "the 0th day" (#653's exemption, mirroring the empty-string exemption
+		# schedule_time gets).
+		doc = self._save("unset", None)
+		self.assertTrue(doc.next_run_at)
+
+	def test_out_of_range_weekday_select_is_refused_by_the_framework(self):
+		# schedule_weekday is a Select field - Frappe's own _validate_selects()
+		# refuses a value outside its options list, so no bespoke throw is needed
+		# here (unlike the Int field above).
+		doc = frappe.get_doc(
+			{
+				"doctype": MACRO,
+				"macro_name": f"{PFX}-bad-weekday",
+				"enabled": 1,
+				"schedule_enabled": 1,
+				"schedule_frequency": "weekly",
+				"schedule_weekday": "Blursday",
+				"steps": [{"prompt": "p1"}],
+			}
+		)
+		doc.flags.ignore_permissions = True
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert()
+
+
+class TestComputeNextRunAnchors(FrappeTestCase):
+	"""Pure arithmetic, no DB writes needed - the anchors compute_next_run gained
+	for #653 (weekly weekday, monthly day-of-month), and the TOTAL guarantee
+	(#472) extended to cover them: a missing, None, or garbage anchor value must
+	fall back to the plain +7-days / +1-month advance and never raise."""
+
+	def test_weekly_anchor_skips_to_next_occurrence_when_todays_has_passed(self):
+		# Monday 10:00, target Monday 09:00 -> already passed today, so next Monday.
+		nxt = macro_scheduler.compute_next_run(
+			"weekly", "09:00:00", from_dt="2026-09-07 10:00:00", weekday="Monday"
+		)
+		self.assertEqual(nxt.strftime("%A"), "Monday")
+		self.assertEqual(nxt.date().isoformat(), "2026-09-14")
+
+	def test_weekly_anchor_same_day_when_the_time_has_not_passed_yet(self):
+		nxt = macro_scheduler.compute_next_run(
+			"weekly", "09:00:00", from_dt="2026-09-07 08:00:00", weekday="Monday"
+		)
+		self.assertEqual(nxt.date().isoformat(), "2026-09-07")
+
+	def test_weekly_anchor_picks_a_different_weekday(self):
+		nxt = macro_scheduler.compute_next_run(
+			"weekly", "09:00:00", from_dt="2026-09-07 08:00:00", weekday="Friday"
+		)
+		self.assertEqual(nxt.strftime("%A"), "Friday")
+		self.assertEqual(nxt.date().isoformat(), "2026-09-11")
+
+	def test_monthly_anchor_clamps_day_31_in_february_then_returns_to_31_in_march(self):
+		# 2026 is not a leap year: Feb has 28 days.
+		feb = macro_scheduler.compute_next_run(
+			"monthly", "09:00:00", from_dt="2026-01-31 09:00:01", day_of_month=31
+		)
+		self.assertEqual(feb.date().isoformat(), "2026-02-28")
+
+		mar = macro_scheduler.compute_next_run("monthly", "09:00:00", from_dt=str(feb), day_of_month=31)
+		self.assertEqual(mar.date().isoformat(), "2026-03-31")
+
+	def test_monthly_anchor_clamps_to_29_in_a_leap_february(self):
+		nxt = macro_scheduler.compute_next_run(
+			"monthly", "09:00:00", from_dt="2028-01-31 09:00:01", day_of_month=31
+		)
+		self.assertEqual(nxt.date().isoformat(), "2028-02-29")
+
+	def test_no_anchor_falls_back_to_the_plain_advance(self):
+		# Same shape every pre-#653 caller still uses: weekday/day_of_month omitted.
+		weekly = macro_scheduler.compute_next_run("weekly", "09:00:00", from_dt="2026-09-07 10:00:00")
+		self.assertEqual(weekly.date().isoformat(), "2026-09-14")
+		monthly = macro_scheduler.compute_next_run("monthly", "09:00:00", from_dt="2026-01-31 10:00:00")
+		self.assertEqual(monthly.date().isoformat(), "2026-02-28")
+
+	def test_garbage_anchors_never_raise_and_fall_back_to_the_plain_advance(self):
+		for weekday in ("Blursday", 0, 8, "", [], {}):
+			with self.subTest(weekday=weekday):
+				nxt = macro_scheduler.compute_next_run(
+					"weekly", "09:00:00", from_dt="2026-09-07 10:00:00", weekday=weekday
+				)
+				self.assertEqual(nxt.date().isoformat(), "2026-09-14")
+		for day in (0, 32, -1, "abc", None, [], {}):
+			with self.subTest(day=day):
+				nxt = macro_scheduler.compute_next_run(
+					"monthly", "09:00:00", from_dt="2026-01-31 10:00:00", day_of_month=day
+				)
+				self.assertEqual(nxt.date().isoformat(), "2026-02-28")
+
+	def test_a_garbage_schedule_time_still_never_raises_alongside_a_valid_anchor(self):
+		# #472's TOTAL guarantee and #653's anchors compose: a bad time AND a good
+		# anchor together still fall back cleanly (09:00 default time).
+		nxt = macro_scheduler.compute_next_run(
+			"weekly", "not-a-time", from_dt="2026-09-07 10:00:00", weekday="Monday"
+		)
+		self.assertEqual((nxt.hour, nxt.minute), (9, 0))

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -714,3 +714,85 @@ class TestComputeNextRunAnchors(FrappeTestCase):
 			"weekly", "not-a-time", from_dt="2026-09-07 10:00:00", weekday="Monday"
 		)
 		self.assertEqual((nxt.hour, nxt.minute), (9, 0))
+
+
+class TestDefaultScheduleAnchors(FrappeTestCase):
+	"""``agents_api.install_agent`` resolves a listing's ``default_schedule`` JSON
+	into the two anchors a fresh installation is born with. A first version of
+	this reimplemented weekday normalization as a bespoke string-only check
+	instead of reusing ``macro_scheduler._normalize_weekday`` (the reader every
+	OTHER weekday input - the SPA, ``set_schedule``, both DocType controllers -
+	goes through), so a listing authored with the ISO-int form (e.g. 3 for
+	Wednesday) silently landed with no weekday at all. These call the exact
+	functions ``install_agent`` calls, no DB fixture needed."""
+
+	def test_int_weekday_in_default_schedule_resolves_to_its_name(self):
+		from jarvis.chat.agents_api import _default_schedule_weekday
+
+		# ISO weekday: 1=Monday .. 7=Sunday.
+		cases = {1: "Monday", 3: "Wednesday", 7: "Sunday"}
+		for iso, name in cases.items():
+			with self.subTest(iso=iso):
+				self.assertEqual(_default_schedule_weekday({"schedule_weekday": iso}), name)
+
+	def test_weekday_name_in_default_schedule_still_works(self):
+		from jarvis.chat.agents_api import _default_schedule_weekday
+
+		self.assertEqual(_default_schedule_weekday({"schedule_weekday": "Friday"}), "Friday")
+		self.assertEqual(_default_schedule_weekday({"schedule_weekday": "friday"}), "Friday")
+
+	def test_garbage_weekday_in_default_schedule_resolves_to_none(self):
+		from jarvis.chat.agents_api import _default_schedule_weekday
+
+		for bad in ("Blursday", 0, 8, "", None, [], {}):
+			with self.subTest(bad=bad):
+				self.assertIsNone(_default_schedule_weekday({"schedule_weekday": bad}))
+
+	def test_day_of_month_in_default_schedule(self):
+		from jarvis.chat.agents_api import _default_schedule_day_of_month
+
+		self.assertEqual(_default_schedule_day_of_month({"schedule_day_of_month": 15}), 15)
+		for bad in (0, 32, -1, "abc", None):
+			with self.subTest(bad=bad):
+				self.assertIsNone(_default_schedule_day_of_month({"schedule_day_of_month": bad}))
+
+	def test_install_agent_applies_an_int_weekday_default_schedule(self):
+		# End-to-end through install_agent itself: a listing whose default_schedule
+		# carries an ISO-int weekday must land on the installation AS ITS NAME, not
+		# be silently dropped.
+		from jarvis.chat import agents_api
+
+		listing_name = frappe.db.get_value("Jarvis Agent Listing", {"agent_slug": "close-auditor"}, "name")
+		if not listing_name:
+			self.skipTest("close-auditor listing not present on this site")
+		owner = _ensure_user("msched-int-weekday@example.com", enabled=1)
+		original_schedule = frappe.db.get_value("Jarvis Agent Listing", listing_name, "default_schedule")
+		frappe.db.set_value(
+			"Jarvis Agent Listing",
+			listing_name,
+			"default_schedule",
+			frappe.as_json({"schedule_enabled": 0, "schedule_frequency": "weekly", "schedule_weekday": 3}),
+			update_modified=False,
+		)
+		frappe.db.commit()
+		original_user = frappe.session.user
+		try:
+			frappe.set_user(owner)
+			frappe.db.delete("Jarvis Agent Installation", {"owner": owner, "agent": listing_name})
+			frappe.db.commit()
+			agents_api.install_agent("close-auditor")
+			weekday = frappe.db.get_value(
+				"Jarvis Agent Installation", {"owner": owner, "agent": listing_name}, "schedule_weekday"
+			)
+			self.assertEqual(weekday, "Wednesday")
+		finally:
+			frappe.set_user(original_user)
+			frappe.db.delete("Jarvis Agent Installation", {"owner": owner, "agent": listing_name})
+			frappe.db.set_value(
+				"Jarvis Agent Listing",
+				listing_name,
+				"default_schedule",
+				original_schedule,
+				update_modified=False,
+			)
+			frappe.db.commit()

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -605,7 +605,10 @@ class TestScheduleDayOfMonthValidation(MacroSchedulerBase):
 		return doc
 
 	def test_out_of_range_day_of_month_is_refused_cleanly(self):
-		for bad in (0, 32, -1, 100):
+		# 0 is deliberately NOT here: Frappe coerces a blank Int field to 0 (not
+		# None), so the validator exempts it as "unset", not "the 0th day" - see
+		# test_unset_day_of_month_is_exempt below.
+		for bad in (32, -1, 100):
 			with self.subTest(bad=bad):
 				with self.assertRaises(frappe.ValidationError):
 					self._save(f"bad-{bad}", bad)
@@ -619,9 +622,12 @@ class TestScheduleDayOfMonthValidation(MacroSchedulerBase):
 	def test_unset_day_of_month_is_exempt(self):
 		# An Int field left blank reaches validate() as 0, not None - "not set",
 		# never "the 0th day" (#653's exemption, mirroring the empty-string exemption
-		# schedule_time gets).
-		doc = self._save("unset", None)
-		self.assertTrue(doc.next_run_at)
+		# schedule_time gets). Both the None a caller might pass and the literal 0
+		# Frappe coerces it to must be accepted, not refused.
+		for unset in (None, 0):
+			with self.subTest(unset=unset):
+				doc = self._save(f"unset-{unset}", unset)
+				self.assertTrue(doc.next_run_at)
 
 	def test_out_of_range_weekday_select_is_refused_by_the_framework(self):
 		# schedule_weekday is a Select field - Frappe's own _validate_selects()
@@ -761,6 +767,7 @@ class TestDefaultScheduleAnchors(FrappeTestCase):
 		# carries an ISO-int weekday must land on the installation AS ITS NAME, not
 		# be silently dropped.
 		from jarvis.chat import agents_api
+		from jarvis.tests._agent_access import allow_listing_for, clear_listing_access
 
 		listing_name = frappe.db.get_value("Jarvis Agent Listing", {"agent_slug": "close-auditor"}, "name")
 		if not listing_name:
@@ -775,6 +782,12 @@ class TestDefaultScheduleAnchors(FrappeTestCase):
 			update_modified=False,
 		)
 		frappe.db.commit()
+		# Agent access is deny-by-default (jarvis#1062 / PR #1095) - grant this
+		# test's user access to the listing the same way test_agents_marketplace
+		# and test_platform_agents_api_hardening do, or install_agent refuses
+		# with a PermissionError before ever reaching the schedule handling this
+		# test is about. _ensure_user already grants the Jarvis User role.
+		allow_listing_for(listing_name, roles=["Jarvis User"])
 		original_user = frappe.session.user
 		try:
 			frappe.set_user(owner)
@@ -787,6 +800,7 @@ class TestDefaultScheduleAnchors(FrappeTestCase):
 			self.assertEqual(weekday, "Wednesday")
 		finally:
 			frappe.set_user(original_user)
+			clear_listing_access(listing_name)
 			frappe.db.delete("Jarvis Agent Installation", {"owner": owner, "agent": listing_name})
 			frappe.db.set_value(
 				"Jarvis Agent Listing",


### PR DESCRIPTION
## Summary

Agents and macros can now pin a weekly schedule to a weekday and a monthly schedule to a day of the month (1 to 31, clamped to the last day of short months). Anyone using the Schedule section on an Agent or Macro page sees a new Day control beside Frequency and Time; existing schedules keep their old behaviour until a day is chosen. List views across the SPA also get one consistent cell font (the Macros name cell was rendering larger than its row).

Backend: `compute_next_run` takes optional `weekday` and `day_of_month` anchors and stays total (garbage or missing anchors fall back to the plain advance). Both DocTypes gain the two fields with validation; every scheduler and API call site passes them through.

Note for reviewers: frappe-ui's `Select` popover has no max height, so 31 rows ran off the viewport. The fix is a global rule in `frontend/src/main.css` on `[data-slot="content-body"]` (max-height 40vh, scroll) that applies to every frappe-ui Select in the app, not only the Day control.

Live-tested on e2e.localhost from the local integration branch (screenshots below).

Test script:
1. Open a macro, enable the schedule, set Frequency to Weekly: a Day select with weekday names appears. Pick Friday, save. Summary reads "Scheduled weekly on Friday at 9:00 am. Next run: Fri, Sep 4, 2026".
2. Set Frequency to Monthly: Day shows 1st to 31st. Pick 31st, save. Next run lands on Sep 30 (clamp).
3. Set Frequency to Daily: the Day control disappears.
4. Repeat on an installed agent's Configure tab. A pre-existing weekly install opens with Day empty, not a fabricated Monday.
5. Save day of month 32 through the API: clean validation error, not a 500.

## Before / After

Before (Frequency and Time only; weekly and monthly just advanced 7 days / 1 month; recreated on the integration build by hiding the Day control via JS):

<img width="1500" alt="before" src="https://github.com/user-attachments/assets/907958c5-73ed-4e06-8df8-c18039b7aab1" />

After, Weekly: a Day select with weekday names:

<img width="1500" alt="weekly day list" src="https://github.com/user-attachments/assets/9b8fd184-3246-44ec-b5ca-b5017479c03c" />

After, Monthly: 1st to 31st in a scrollable list:

<img width="1500" alt="monthly day list" src="https://github.com/user-attachments/assets/648f700a-5077-40cb-a7bf-8cba855c427d" />

Saved on the 31st: the next run clamps to Sep 30:

<img width="1500" alt="monthly saved" src="https://github.com/user-attachments/assets/b1bcc25f-f401-47a3-ac86-5b63d9cf748c" />

The agent Configure tab has the same control (verified live, weekly on Wednesday saved and summarised correctly).

Also in this PR (owner request): list cells now share one text size across the SPA. The shared `ListPage` cell wrapper defaults every custom cell to `text-base`, and name cells in Macros, Files, Wiki, Dashboards and Triggers use the Skills list convention (`text-base font-medium text-ink-gray-9`). Macros list after:

<img width="1500" alt="macros list" src="https://github.com/user-attachments/assets/1f95bedf-9e6e-4661-9297-b61278d00b83" />

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01HW2uHdQLPLoV8qVXm6Ppxu
