### PR TITLE
backport(v15): feat(support): move the waiting-reply signal to a header count pill (#1103)

### DIFF
--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -20,20 +20,6 @@
 				     (design.md §2.2). idlePeek: this is the one mark that sits resting on
 				     every route, so it's the chosen surface for the designed idle blink. -->
 				<JarvisMark :size="28" :radius="7" :peek="brandPeek" idlePeek />
-				<!-- Resting badge: a waiting reply has to register on every route, so it
-				     lives here on the avatar - the SOLE unread indicator now (the
-				     chat-header jv-support-dot was removed; that control is new-ticket
-				     only). Red + pulse to actually pull the eye: an unheard reply is a
-				     pending action ON the user, the same semantic (bg-surface-red-5) as
-				     Sidebar.vue's approvals dot. motion-safe so reduced-motion stays calm. -->
-				<div
-					v-if="supportOn && store.awaitingCount"
-					class="absolute left-7 top-1 size-2 rounded-full bg-surface-red-5 motion-safe:animate-pulse"
-					:aria-label="`${store.awaitingCount} ${
-						store.awaitingCount === 1 ? 'ticket' : 'tickets'
-					} awaiting your reply`"
-					role="status"
-				/>
 				<div
 					class="flex flex-1 flex-col overflow-hidden text-left duration-300 ease-in-out"
 					:class="isCollapsed ? 'ml-0 w-0 opacity-0' : 'ml-2 w-auto opacity-100'"
@@ -87,8 +73,12 @@ const session = inject("$session");
 const { effectiveDark, toggleTheme } = useJarvisTheme();
 
 // Support panel: `store` is the shared support-store singleton, kept fresh here
-// by this poll timer so the avatar's resting badge and the ticket list always
-// read the same awaiting-count value without each needing to run its own poller.
+// by this poll timer so the chat header's count pill (ChatView.vue's
+// jv-support-btn), this menu's "Support tickets · N" row, and the ticket
+// list always read the same awaiting-count value without each needing to
+// run its own poller. The avatar used to carry its own resting dot fed by
+// this same poll - removed once the header pill became the primary signal,
+// so a waiting reply now shows in exactly one place instead of two.
 const router = useRouter();
 const supportOn = window.support_available && window.has_support_access;
 const store = useSupportStore();
@@ -155,8 +145,9 @@ const menuOptions = computed(() => [
 				? []
 				: [
 						{
-							// Count flag mirrors the avatar's resting dot, so opening the
-							// menu confirms where the waiting reply is.
+							// Count flag mirrors the chat header's pill (ChatView.vue's
+							// jv-support-btn), so opening this menu confirms where the
+							// waiting reply is.
 							label: store.awaitingCount
 								? `Support tickets · ${store.awaitingCount}`
 								: "Support tickets",

--- a/frontend/src/lib/supportHeaderPill.js
+++ b/frontend/src/lib/supportHeaderPill.js
@@ -1,0 +1,36 @@
+// Pure helpers for the chat header's support-button count pill (ChatView.vue's
+// jv-support-btn) - the header-side sibling of lib/supportCopyFormat.js, which
+// already extracts that same button's copy-to-ticket formatting for the same
+// reason: dependency-free logic is unit-testable without mounting the view.
+
+// The pill and the button's title/aria-label cap the SAME way: single digits
+// read fine at 17px, but a wide count would blow past the button's own 32px
+// box, so anything double-digit reads as "9+" rather than truncating oddly.
+export function supportPillLabel(count) {
+	const n = Number(count) || 0;
+	if (n <= 0) return "";
+	return n > 9 ? "9+" : String(n);
+}
+
+// The plain "N ticket(s) awaiting your reply" phrase, shared by the button's
+// title (as-is) and its aria-label (prefixed with "Support, " at the call
+// site) - one singular/plural rule instead of two copies drifting apart.
+export function supportAwaitingPhrase(count) {
+	const n = Number(count) || 0;
+	return `${n} ${n === 1 ? "ticket" : "tickets"} awaiting your reply`;
+}
+
+// Where the header menu's "Tickets awaiting reply" row sends the viewer.
+//
+// A previous version routed straight to a ticket's thread when the count was
+// exactly 1 and the store's already-loaded ticket list agreed on which one.
+// Dropped: awaitingCount is a 60s-polled number (UserMenu's timer) while
+// store.tickets is only populated by an actual visit to a Support page and is
+// never re-fetched here, so the two can drift - a customer could reply on
+// another tab, or a second ticket could get a reply between the poll and the
+// click, and the "confident" single match would then route to a ticket that
+// is no longer (or never uniquely) the one awaiting a reply. The list route
+// is always correct, so it is the only route.
+export function supportAwaitingRoute() {
+	return { name: "Support", query: { status: "awaiting" } };
+}

--- a/frontend/src/lib/supportHeaderPill.spec.js
+++ b/frontend/src/lib/supportHeaderPill.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+	supportPillLabel,
+	supportAwaitingPhrase,
+	supportAwaitingRoute,
+} from "./supportHeaderPill";
+
+describe("supportPillLabel", () => {
+	it("is blank at zero - the pill is hidden, not '0'", () => {
+		expect(supportPillLabel(0)).toBe("");
+	});
+
+	it("shows the exact count for a single digit", () => {
+		expect(supportPillLabel(3)).toBe("3");
+	});
+
+	it("caps at 9+ once double digits would blow past the 17px pill", () => {
+		expect(supportPillLabel(12)).toBe("9+");
+		expect(supportPillLabel(10)).toBe("9+");
+	});
+});
+
+describe("supportAwaitingPhrase", () => {
+	it("uses singular ticket for exactly one", () => {
+		expect(supportAwaitingPhrase(1)).toBe("1 ticket awaiting your reply");
+	});
+
+	it("uses plural tickets for zero and for more than one", () => {
+		expect(supportAwaitingPhrase(0)).toBe("0 tickets awaiting your reply");
+		expect(supportAwaitingPhrase(3)).toBe("3 tickets awaiting your reply");
+	});
+});
+
+describe("supportAwaitingRoute", () => {
+	// A shortcut here once routed straight to a single ticket's thread when
+	// the awaiting_count total was 1 and the store's already-loaded ticket
+	// list agreed. Dropped (hard review finding): awaitingCount is polled
+	// every 60s while store.tickets is only populated by an actual visit to a
+	// Support page and never re-fetched here, so the two numbers can drift
+	// and the "confident" match could route to a ticket that is no longer the
+	// one awaiting a reply. The list route is now the only route, always.
+	it("always routes to the list with the awaiting quick filter", () => {
+		expect(supportAwaitingRoute()).toEqual({
+			name: "Support",
+			query: { status: "awaiting" },
+		});
+	});
+});

--- a/frontend/src/pages/support/SupportListPage.vue
+++ b/frontend/src/pages/support/SupportListPage.vue
@@ -96,7 +96,7 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
 import { Badge, Button, Tooltip } from "frappe-ui";
 import ListPage from "@/components/list/ListPage.vue";
@@ -104,6 +104,7 @@ import SupportShell from "@/components/support/SupportShell.vue";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { useSupportStore, badgeFor, priorityBadge } from "@/stores/support";
 
+const route = useRoute();
 const router = useRouter();
 const store = useSupportStore();
 
@@ -118,6 +119,7 @@ const STATUS_OPTIONS = [
 	{ label: "Open", value: "open" },
 	{ label: "Closed", value: "closed" },
 ];
+const KNOWN_STATUS_VALUES = STATUS_OPTIONS.map((o) => o.value).filter(Boolean);
 
 const ALL_COLUMNS = [
 	{ label: "Subject", key: "subject", width: 3 },
@@ -206,6 +208,48 @@ function setFilters(next) {
 	for (const k of Object.keys(filters)) delete filters[k];
 	Object.assign(filters, next || {});
 }
+
+// Deep-link seed (?status=). NOT a one-time setup read: AppShell's single
+// router-view reuses THIS component instance across a same-route navigation
+// (e.g. the chat header pill's "Tickets awaiting reply" row pushing
+// {name:"Support", query:{status:"awaiting"}} while the user is already on
+// /support with some other filter picked) - setup only runs once per mount,
+// so a plain "read route.query.status at setup" misses every later arrival
+// at the same route. `immediate: true` covers the first mount too, so this
+// replaces that old one-shot seed rather than sitting alongside it. Unknown
+// values are ignored (filters.status is left as the user set it) rather than
+// cleared, so a stray/foreign query param can never blank out a filter picked
+// by hand - same as ApprovalsBoard's initialStatus validation, just re-run on
+// every arrival instead of once.
+watch(
+	() => route.query.status,
+	(status) => {
+		if (KNOWN_STATUS_VALUES.includes(status)) setFilters({ ...filters, status });
+	},
+	{ immediate: true }
+);
+
+// The other direction: keep the URL's ?status= matching a filter change the
+// user makes by hand (quick filter / filter popover), not only the one above.
+// Without this, the sequence that shipped the bug is: the header pill routes
+// here once (?status=awaiting), the user hand-picks a DIFFERENT status (the
+// URL is now stale), they leave for chat, then click the pill again - that
+// pushes the exact same {status:"awaiting"} location, which is NOT a value
+// change from vue-router's point of view, so the watch above never fires and
+// the stale hand-picked filter is left showing. Syncing the URL on every
+// hand-picked change keeps a later pill click a real query change again.
+// router.replace (not push): this is bookkeeping, not a navigation the user
+// should be able to Back through.
+watch(
+	() => filters.status,
+	(status) => {
+		if ((route.query.status || "") === (status || "")) return; // already in sync
+		const nextQuery = { ...route.query };
+		if (status) nextQuery.status = status;
+		else delete nextQuery.status;
+		router.replace({ query: nextQuery });
+	}
+);
 
 function onPageLength(v) {
 	pageLength.value = v;

--- a/frontend/src/pages/support/SupportThreadPage.vue
+++ b/frontend/src/pages/support/SupportThreadPage.vue
@@ -326,6 +326,17 @@ async function closeThisTicket() {
 	if (ok) {
 		toast.success("Ticket closed. Reply anytime to reopen it.");
 		await store.loadTickets({ quiet: true });
+		// Closed drops out of the awaiting set (stores/support.js's AWAITING is
+		// Replied/Resolved only) - refresh here too so the header pill's count
+		// doesn't linger on a ticket the customer just closed themselves. Not
+		// awaited: it drives an ambient badge (refreshAwaiting already catches
+		// internally and never rejects - same reasoning as SupportListPage's
+		// onMounted call), and awaiting it here would delay the loadThread
+		// refresh below by one extra CP round trip for no benefit. The .catch
+		// is a second layer of the same belt-and-braces: even though the real
+		// store never rejects, an un-awaited rejection here would otherwise be
+		// an unhandled promise rejection that could crash something unrelated.
+		store.refreshAwaiting().catch(() => {});
 		// Refresh the thread too, so the details panel's status/SLA and the header
 		// badge/Resolve reflect Closed immediately instead of lagging 30s to the
 		// next poll (they read store.thread.meta, which only get_thread repopulates).
@@ -508,6 +519,16 @@ async function send() {
 		}
 
 		await store.loadTickets({ quiet: true });
+		// A customer reply moves the ball back to support (helpdesk_client.py's
+		// post_reply reopens a Resolved/Closed ticket on "Received"), so it drops
+		// out of the awaiting set too - refresh here rather than waiting up to
+		// 60s for UserMenu's poll, so the header pill clears as soon as the
+		// customer actually replies. Not awaited, same reasoning as
+		// closeThisTicket's call above: an ambient badge refresh that already
+		// catches internally must not delay the loadThread refresh that shows
+		// the user their own reply. .catch() for the same belt-and-braces
+		// reason as that call too.
+		store.refreshAwaiting().catch(() => {});
 		// The reply/upload above correctly target tName (the ticket we replied
 		// to), but this DISPLAY refresh must not stomp the thread if the user has
 		// since navigated to a different ticket — if store.thread.ticket no

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -170,14 +170,29 @@ function setCopyPref(v) {
 	updateMySettings({ support_context_copy_pref: v }).catch(() => {});
 }
 
+// De-dupes concurrent callers into ONE request, same idea as getCopyPref's
+// loadingCopyPref above. Two callers can land in the same tick on a normal
+// page load - UserMenu's own immediate poll call and ChatView's one-shot
+// mount refresh both fire on mount, and either can also overlap a
+// SupportThreadPage close/reply refresh - so without this every one of them
+// would round-trip supportAwaitingCount() separately for the exact same
+// number.
+let refreshingAwaiting = null;
 async function refreshAwaiting() {
-	try {
-		const r = await supportAwaitingCount();
-		awaitingCount.value = (r && r.data && r.data.count) || 0;
-	} catch (e) {
-		// Best-effort: this drives an ambient badge, so a failure must never
-		// interrupt whatever the user is actually doing. Intentionally silent.
+	if (!refreshingAwaiting) {
+		refreshingAwaiting = (async () => {
+			try {
+				const r = await supportAwaitingCount();
+				awaitingCount.value = (r && r.data && r.data.count) || 0;
+			} catch (e) {
+				// Best-effort: this drives an ambient badge, so a failure must never
+				// interrupt whatever the user is actually doing. Intentionally silent.
+			} finally {
+				refreshingAwaiting = null;
+			}
+		})();
 	}
+	return refreshingAwaiting;
 }
 
 async function createTicket(subject, body) {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -289,9 +289,78 @@
 					     button replaces that entry rather than duplicating it. Unconfigured
 					     gets the same jv-unavailable + aria-disabled treatment the STT/wiki
 					     buttons use for their own "visible but not usable yet" state, so a
-					     screen-reader user hears it's inert before clicking, not after. -->
+					     screen-reader user hears it's inert before clicking, not after.
+
+					     A waiting reply now surfaces HERE too (a red count pill, see
+					     jv-support-pill below) rather than only on the sidebar avatar dot -
+					     that dot is gone (UserMenu.vue). Two branches render the SAME
+					     button markup: with a waiting reply the button becomes a
+					     frappe-ui Dropdown trigger (two rows: go to the awaiting list, or
+					     start a new ticket); with nothing waiting it stays the plain
+					     new-ticket button it always was, so a zero-count click is byte-for-
+					     byte the old behaviour. No jv- palette rebind needed on the portal:
+					     the menu is pure frappe-ui (label/icon/text-ink-red-4 suffix), and
+					     frappe-ui's own theming already flips off the `data-theme` attribute
+					     theme.js sets on <html> - jv-* vars are only for THIS view's own
+					     hand-styled surface, which the portal content never touches. -->
+					<Dropdown
+						v-if="supportEntryVisible && supportHasAwaiting"
+						:options="supportMenuOptions"
+						placement="right"
+					>
+						<template #trigger>
+							<button
+								class="jv-iconbtn jv-support-btn"
+								:title="supportAwaitingPhraseText"
+								:aria-label="`Support, ${supportAwaitingPhraseText}`"
+								style="
+									position: relative;
+									width: 32px;
+									height: 32px;
+									display: flex;
+									align-items: center;
+									justify-content: center;
+									background: transparent;
+									border: 1px solid var(--border);
+									border-radius: 7px;
+									cursor: pointer;
+								"
+							>
+								<svg
+									width="16"
+									height="16"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="var(--text-2)"
+									stroke-width="1.7"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M3 18v-6a9 9 0 0 1 18 0v6" />
+									<path
+										d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"
+									/>
+								</svg>
+								<span
+									class="jv-support-pill bg-surface-red-5"
+									role="status"
+									aria-live="polite"
+								>
+									<span aria-hidden="true">{{ supportPillLabel }}</span>
+									<!-- sr-only: the button's own aria-label already carries this
+									     phrase for a focused/click read, but role="status" here is
+									     what makes it ANNOUNCE on its own while the user is heads-
+									     down typing elsewhere in chat - the same job the removed
+									     avatar dot's role="status" did. jv-sr is the same visually-
+									     hidden utility the turn-completion live region (srMessage,
+									     below in this template) uses. -->
+									<span class="jv-sr">{{ supportAwaitingPhraseText }}</span>
+								</span>
+							</button>
+						</template>
+					</Dropdown>
 					<button
-						v-if="supportEntryVisible"
+						v-else-if="supportEntryVisible"
 						class="jv-iconbtn jv-support-btn"
 						:class="{ 'jv-unavailable': supportUnconfigured }"
 						:aria-disabled="supportUnconfigured ? 'true' : undefined"
@@ -4139,6 +4208,7 @@
 import {
 	ref,
 	computed,
+	h,
 	inject,
 	onMounted,
 	onBeforeUnmount,
@@ -4148,6 +4218,7 @@ import {
 	watchEffect,
 } from "vue";
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
+import { Dropdown } from "frappe-ui";
 import * as api from "@/api";
 import * as voice from "@/api/voice";
 import { agentName, isWhitelabeled } from "@/branding";
@@ -4174,6 +4245,11 @@ import { useConfirm } from "@/composables/useConfirm";
 import { promptSupportCopy } from "@/composables/useSupportCopyPrompt";
 import { useSupportStore } from "@/stores/support";
 import { formatRecentMessagesForSupport } from "@/lib/supportCopyFormat";
+import {
+	supportPillLabel as supportPillLabelFor,
+	supportAwaitingPhrase,
+	supportAwaitingRoute,
+} from "@/lib/supportHeaderPill";
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
 import { formatDate, exactDate, dayLabel } from "@/utils/datetime";
 import { fenceReject, fenceAccept } from "@/utils/eventFence";
@@ -4565,9 +4641,11 @@ async function openSupport() {
 		explainUnavailable("Support");
 		return;
 	}
-	// This header control is the NEW-TICKET entry point only. The "you have a
-	// waiting reply" signal + its route to the inbox now live solely on the
-	// avatar's resting badge (UserMenu), so the two concerns don't share a button.
+	// This function is the NEW-TICKET action specifically: with a waiting reply
+	// the header button opens a menu instead of calling this directly (see
+	// supportMenuOptions below), and its "New ticket from this chat" row calls
+	// straight into this same function - so openSupport() itself never needs to
+	// know which of the two paths got it here.
 	if (openSupportInFlight) return;
 	openSupportInFlight = true;
 	try {
@@ -4600,6 +4678,69 @@ async function openSupport() {
 		openSupportInFlight = false;
 	}
 }
+// Waiting-reply count pill (header headphones button). awaiting_count is a
+// cheap poll-driven number (stores/support.js's refreshAwaiting, already run
+// by UserMenu's 60s poll timer - no second poller started here); reading
+// zero for a not-yet-primed store is the correct "nothing waiting" default.
+// The label/phrase/routing math itself lives in lib/supportHeaderPill.js,
+// pure and unit-tested there (the same split lib/supportCopyFormat.js already
+// uses for this button's copy-to-ticket formatting) - this view just wires
+// the store's numbers through it.
+const supportAwaitingCount = computed(() => (supportStore ? supportStore.awaitingCount : 0));
+const supportHasAwaiting = computed(() => supportAwaitingCount.value > 0);
+const supportPillLabel = computed(() => supportPillLabelFor(supportAwaitingCount.value));
+const supportAwaitingPhraseText = computed(() =>
+	supportAwaitingPhrase(supportAwaitingCount.value)
+);
+function goToAwaitingTickets() {
+	router.push(supportAwaitingRoute());
+}
+const supportMenuOptions = computed(() => [
+	{
+		group: "Support",
+		hideLabel: true,
+		items: [
+			{
+				label: "Tickets awaiting reply",
+				icon: "life-buoy",
+				onClick: goToAwaitingTickets,
+				slots: {
+					// The raw count, not the "9+"-capped supportPillLabel: this row has
+					// room for it, and UserMenu's sibling "Support tickets · N" row
+					// already shows the uncapped number, so the two should never disagree.
+					suffix: () =>
+						h(
+							"span",
+							{ class: "text-ink-red-4 font-medium tabular-nums" },
+							String(supportAwaitingCount.value)
+						),
+				},
+			},
+			{
+				label: "New ticket from this chat",
+				icon: "plus",
+				onClick: openSupport,
+			},
+		],
+	},
+]);
+// This view only READS supportStore.awaitingCount - the 60s poll that keeps
+// it fresh belongs to UserMenu.vue (always mounted alongside chat), so no
+// second poller starts here. But that poller is on a timer, not a mount
+// hook, so the pill's FIRST paint here could be showing a stale/empty count
+// for up to 60s. It could also simply be wrong on any load where UserMenu
+// isn't mounted at all (collapsed/off-canvas sidebar on phone), not only
+// that one case. One extra one-shot refresh on this view's own mount closes
+// that gap without adding a second timer. It DOES fire on every normal load
+// alongside UserMenu's own immediate call - refreshAwaiting() in
+// stores/support.js de-dupes concurrent callers into one request, so this
+// never becomes two round trips for the same number. .catch() for the same
+// reason as SupportThreadPage's calls: an un-awaited rejection here would
+// otherwise be unhandled (the real store already catches its own errors, so
+// this is belt-and-braces).
+onMounted(() => {
+	if (supportOn) supportStore.refreshAwaiting().catch(() => {});
+});
 // One-shot "ground on wiki": when armed, the NEXT message carries a
 // context.ground_wiki flag so the backend injects relevant wiki page bodies
 // into that turn. Cleared after each send (see send()).
@@ -11410,6 +11551,36 @@ onUnmounted(() => {
 	background: transparent !important;
 	color: var(--text-3) !important;
 	stroke: currentColor !important;
+}
+/* Waiting-reply count pill on the header's support button (jv-support-btn).
+   The bg-surface-red-5 Tailwind class (not var(--red), THIS view's own
+   red for inline error states - a different, unrelated token) is the same
+   class Sidebar.vue's approvals badge/dot paint with, kept as a literal
+   utility class rather than a hand-copied hex so it keeps tracking that
+   token if it's ever retuned. It already flips with data-theme (theme.js's
+   applyTheme sets that on <html> for every frappe-ui consumer), independent
+   of this view's own jv-dark/paletteVars system. The 2px ring is
+   var(--surface): this header paints no background of its own, so
+   var(--surface) IS what actually shows behind the button, and using it
+   (rather than a literal white) keeps the ring correct if the header ever
+   grows a background. */
+.jv-support-pill {
+	position: absolute;
+	top: -5px;
+	right: -5px;
+	min-width: 17px;
+	height: 17px;
+	padding: 0 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 999px;
+	color: #fff;
+	font-size: 11px;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	box-shadow: 0 0 0 2px var(--surface);
+	pointer-events: none;
 }
 .jv-nudge-actions {
 	display: flex;

--- a/frontend/tests/support-extraction/support-badge.test.js
+++ b/frontend/tests/support-extraction/support-badge.test.js
@@ -43,7 +43,14 @@ const opts = {
 	},
 };
 
-describe("UserMenu resting support badge", () => {
+describe("UserMenu resting support badge (removed - see the chat header pill)", () => {
+	// The avatar's resting dot (a bare `[role="status"]` div, fed by this same
+	// store) is GONE: a waiting reply now surfaces on the chat header's
+	// headphones button instead (ChatView.vue's jv-support-btn count pill), so
+	// it registers on the one screen the customer is actually looking at,
+	// rather than a corner of the sidebar. These assertions guard against the
+	// dot coming back by accident; the "Support tickets · N" menu row below is
+	// still the read path and is unaffected.
 	beforeEach(() => {
 		vi.stubGlobal("matchMedia", () => ({
 			matches: false,
@@ -55,34 +62,18 @@ describe("UserMenu resting support badge", () => {
 		store.awaitingCount = 0;
 	});
 
-	it("shows no dot when nothing is awaiting", () => {
+	it("never renders a status dot when nothing is awaiting", () => {
 		const w = mount(UserMenu, opts);
 		expect(w.find('[role="status"]').exists()).toBe(false);
 	});
 
-	it("shows the dot with an accessible label when a reply is waiting", () => {
-		// The whole point of the resting dot: it must register while the user is
-		// heads-down in chat, WITHOUT opening the menu — and a bare coloured dot
-		// is invisible to a screen reader, so the label is not optional. The
-		// count is TICKETS (Replied/Resolved), not individual replies — the
-		// original "N support reply/replies awaiting you" wording misnamed the
-		// unit.
+	it("never renders a status dot even with a reply waiting - that signal moved to the header pill", () => {
 		store.awaitingCount = 2;
 		const w = mount(UserMenu, opts);
-		const dot = w.find('[role="status"]');
-		expect(dot.exists()).toBe(true);
-		expect(dot.attributes("aria-label")).toBe("2 tickets awaiting your reply");
+		expect(w.find('[role="status"]').exists()).toBe(false);
 	});
 
-	it("singularises one ticket", () => {
-		store.awaitingCount = 1;
-		const w = mount(UserMenu, opts);
-		expect(w.find('[role="status"]').attributes("aria-label")).toBe(
-			"1 ticket awaiting your reply"
-		);
-	});
-
-	it("never shows the dot when support is switched off, even with a stale count", () => {
+	it("never renders a status dot when support is switched off, even with a stale count", () => {
 		store.awaitingCount = 5;
 		window.support_available = false;
 		const w = mount(UserMenu, opts);

--- a/frontend/tests/support-extraction/support-list.test.js
+++ b/frontend/tests/support-extraction/support-list.test.js
@@ -7,7 +7,32 @@ vi.mock("frappe-ui", () => ({
 	Button: { template: "<button/>" },
 	Tooltip: { template: "<div><slot/></div>" },
 }));
-vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+// query is mutated per-test (see the route-query preselect describe block
+// below); useRoute() must keep returning the SAME object so a mount picks
+// up whatever the test set on it just before mounting. reactive(), not a
+// plain object: the page's watch(() => route.query.status, ...) needs a
+// tracked dependency to react to a mutation made AFTER mount (the "reused
+// component instance on a same-route navigation" case) - a plain object
+// mutation is invisible to Vue's reactivity system.
+const routeDouble = reactive({ query: {} });
+// A shared, stable double (not a fresh {push: vi.fn()} per useRouter() call):
+// the round-trip URL sync test below needs to both inspect replace() calls
+// AND have replace() actually apply the new query onto routeDouble, the same
+// way real vue-router would - otherwise there is no way to drive the
+// "push the identical location a second time" regression scenario at all.
+const routerDouble = {
+	push: vi.fn(),
+	replace: vi.fn((loc) => {
+		if (loc && loc.query) {
+			for (const k of Object.keys(routeDouble.query)) delete routeDouble.query[k];
+			Object.assign(routeDouble.query, loc.query);
+		}
+	}),
+};
+vi.mock("vue-router", () => ({
+	useRouter: () => routerDouble,
+	useRoute: () => routeDouble,
+}));
 
 // reactive(), not a plain object: the real store (stores/support.js) wraps its
 // state the same way, and the refresh/paging tests below reassign
@@ -89,7 +114,10 @@ async function applyFilters(w, next) {
 }
 
 describe("SupportListPage", () => {
-	beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => {
+		vi.clearAllMocks();
+		routeDouble.query = {};
+	});
 
 	it("defaults to most-recently-updated first, the house default sort", async () => {
 		const w = mountList();
@@ -245,5 +273,140 @@ describe("mobile column drop does not empty the grid (fix 4)", () => {
 			.props("columns")
 			.map((c) => c.key);
 		expect(keys).toContain("name");
+	});
+});
+
+// The chat header's ticket-count pill (ChatView.vue) routes here with
+// ?status=awaiting when the viewer clicks "Tickets awaiting reply", so the
+// list must open pre-filtered rather than making them re-pick the filter they just
+// clicked for.
+describe("deep-link seed from ?status= (header pill preselect)", () => {
+	beforeEach(() => {
+		routerDouble.push.mockClear();
+		routerDouble.replace.mockClear();
+	});
+	afterEach(() => {
+		routeDouble.query = {};
+	});
+
+	it("seeds filters.status from a known ?status= value", async () => {
+		routeDouble.query = { status: "awaiting" };
+		expect(
+			mountList()
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toEqual(["T-2", "T-3"]);
+	});
+
+	it("ignores an unknown ?status= value and falls back to All", async () => {
+		routeDouble.query = { status: "not-a-real-status" };
+		expect(
+			mountList()
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toHaveLength(5);
+	});
+
+	it("falls back to All with no ?status= at all", async () => {
+		expect(
+			mountList()
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toHaveLength(5);
+	});
+
+	// AppShell's single router-view reuses THIS component instance across a
+	// same-route navigation (clicking the header pill's list link while
+	// already on /support does not remount the page), so the seed must be a
+	// live watch, not a one-time setup read - regression guard for that.
+	it("re-applies a NEW ?status= value on an already-mounted instance (reused router-view case)", async () => {
+		const w = mountList(); // no query - starts on "All"
+		expect(w.findComponent(ListPageStub).props("rows")).toHaveLength(5);
+
+		routeDouble.query.status = "awaiting";
+		await w.vm.$nextTick();
+
+		expect(
+			w
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toEqual(["T-2", "T-3"]);
+	});
+
+	it("does not clear a hand-picked filter when the route query later carries an unknown status", async () => {
+		const w = mountList();
+		await applyFilters(w, { status: "closed" }); // the user picks a filter by hand
+
+		routeDouble.query.status = "not-a-real-status";
+		await w.vm.$nextTick();
+
+		expect(
+			w
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toEqual(["T-4"]); // still the hand-picked "closed" filter, untouched
+	});
+
+	it("keeps the URL's ?status= in sync with a hand-picked filter, so a LATER identical pill click is a real query change again", async () => {
+		// The exact sequence a hard review caught: header pill -> ?status=awaiting
+		// (filter applied) -> user hand-picks a different quick filter (the URL
+		// still says awaiting) -> user leaves for chat and clicks the pill again,
+		// which pushes the SAME {status:"awaiting"} location. Without the URL
+		// staying in sync with the hand pick, that second push is not a value
+		// change to vue-router, the route.query watch never fires, and the STALE
+		// hand-picked filter is left showing instead of "Awaiting you".
+		routeDouble.query = { status: "awaiting" };
+		const w = mountList();
+		expect(
+			w
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toEqual(["T-2", "T-3"]);
+
+		// The user hand-picks "Closed" - this must sync the URL too.
+		await applyFilters(w, { status: "closed" });
+		await w.vm.$nextTick();
+		expect(routeDouble.query.status).toBe("closed");
+
+		// The user leaves for chat, then clicks the header pill again - same
+		// simulated push as ChatView's goToAwaitingTickets(), landing on the
+		// SAME nominal location the first mount started on.
+		routerDouble.push({ name: "Support", query: { status: "awaiting" } });
+		// Simulate the router actually applying that push (our double's push()
+		// itself is a bare spy - real vue-router would update route.query here).
+		routeDouble.query = { status: "awaiting" };
+		await w.vm.$nextTick();
+
+		expect(
+			w
+				.findComponent(ListPageStub)
+				.props("rows")
+				.map((r) => r.name)
+		).toEqual(["T-2", "T-3"]); // back to "Awaiting you", not stuck on "Closed"
+	});
+
+	it("clears ?status= from the URL when the user picks All by hand", async () => {
+		routeDouble.query = { status: "awaiting" };
+		const w = mountList();
+		await applyFilters(w, {}); // ListPage's own "All" clear (no status key)
+		await w.vm.$nextTick();
+
+		expect(routeDouble.query.status).toBeUndefined();
+	});
+
+	it("does not call router.replace when the filter change already matches the URL (no-op guard)", async () => {
+		routeDouble.query = { status: "awaiting" };
+		const w = mountList();
+		await w.vm.$nextTick();
+
+		// The seed watch itself set filters.status to match route.query.status -
+		// that must not ALSO trigger a redundant replace() back onto the URL.
+		expect(routerDouble.replace).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/tests/support-extraction/support-store.test.js
+++ b/frontend/tests/support-extraction/support-store.test.js
@@ -95,6 +95,34 @@ describe("support store", () => {
 		expect(s.awaitingCount).toBe(0);
 	});
 
+	it("concurrent callers before a fetch resolves share ONE request, not one each", async () => {
+		// UserMenu's own immediate poll call and ChatView's one-shot mount
+		// refresh land in the same tick on a normal page load (and a
+		// SupportThreadPage close/reply refresh can overlap either) - without
+		// de-duping, each caller would fire its own round trip for the exact
+		// same number.
+		const s = useSupportStore();
+		let resolve;
+		api.supportAwaitingCount.mockReturnValue(new Promise((r) => (resolve = r)));
+		const a = s.refreshAwaiting();
+		const b = s.refreshAwaiting();
+		resolve({ data: { count: 3 } });
+		await a;
+		await b;
+		expect(s.awaitingCount).toBe(3);
+		expect(api.supportAwaitingCount).toHaveBeenCalledTimes(1);
+	});
+
+	it("a later call after the first settles starts a genuinely NEW request", async () => {
+		const s = useSupportStore();
+		api.supportAwaitingCount.mockResolvedValueOnce({ data: { count: 1 } });
+		await s.refreshAwaiting();
+		api.supportAwaitingCount.mockResolvedValueOnce({ data: { count: 2 } });
+		await s.refreshAwaiting();
+		expect(s.awaitingCount).toBe(2);
+		expect(api.supportAwaitingCount).toHaveBeenCalledTimes(2);
+	});
+
 	it("uploads every file even when one fails, and returns the succeeded FILE REFERENCES (not a count)", async () => {
 		// Fix 2: the caller (useStagedFiles's settleUpload) needs to know exactly
 		// which files landed so a retry only re-sends the failures — Helpdesk's

--- a/frontend/tests/support-extraction/support-thread.test.js
+++ b/frontend/tests/support-extraction/support-thread.test.js
@@ -20,6 +20,9 @@ vi.mock("frappe-ui/editor-style.css", () => ({}));
 vi.mock("frappe-ui", () => ({
 	Badge: { name: "Badge", template: "<span/>" },
 	Button: {
+		// name so the refresh-on-close test below can pick the Resolve button
+		// out of a tree that has several unlabelled <button> stubs.
+		name: "Button",
 		props: ["label", "disabled", "loading"],
 		template: "<button :disabled='disabled'><slot/></button>",
 	},
@@ -81,6 +84,13 @@ const storeDouble = {
 	loadTickets: vi.fn(),
 	loadThread: vi.fn(),
 	closeTicket: vi.fn(),
+	// async, matching the real store's contract (an `async function`, so it
+	// ALWAYS returns a Promise even though it catches its own errors
+	// internally) - the call sites chain .catch() on this, so a default
+	// double that returns bare `undefined` would throw "Cannot read
+	// properties of undefined (reading 'catch')" in every test that reaches
+	// a successful close/reply and never overrides this mock.
+	refreshAwaiting: vi.fn(async () => {}),
 	reply: vi.fn(async () => true),
 	// Fix 2: uploadTo returns the succeeded FILE REFERENCES, not a count — a
 	// realistic default double is "everything I was given succeeded".
@@ -1043,5 +1053,113 @@ describe("poll / focus / watermark subsystem (fix 3 + 4)", () => {
 		w.unmount();
 		expect(clearSpy).toHaveBeenCalled();
 		clearSpy.mockRestore();
+	});
+});
+
+// The header pill (ChatView.vue) reads store.awaitingCount, which UserMenu's
+// poll only refreshes every 60s - so a reply or a close should refresh it
+// immediately too, rather than leaving the pill stale for up to a minute.
+describe("refreshAwaiting after reply/close (header pill freshness)", () => {
+	// beforeEach, not afterEach: earlier describe blocks in this file freely
+	// reassign storeDouble.reply/closeTicket/etc without restoring them
+	// afterward (the file has no top-level reset), so each test here needs a
+	// known-clean slate on the way IN, not just a courtesy reset on the way
+	// out.
+	beforeEach(() => {
+		storeDouble.closeTicket = vi.fn();
+		storeDouble.reply = vi.fn(async () => true);
+		storeDouble.refreshAwaiting = vi.fn(async () => {});
+		storeDouble.loadThread = vi.fn();
+		storeDouble.loadTickets = vi.fn();
+	});
+
+	it("refreshes the awaiting count after a successful close", async () => {
+		storeDouble.closeTicket = vi.fn(async () => true);
+		const w = mountWith([]);
+
+		const resolveBtn = w
+			.findAllComponents({ name: "Button" })
+			.find((b) => b.props("label") === "Resolve");
+		expect(resolveBtn).toBeTruthy();
+		await resolveBtn.trigger("click");
+		await flushPromises();
+
+		expect(storeDouble.refreshAwaiting).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not refresh the awaiting count when the close call itself fails", async () => {
+		storeDouble.closeTicket = vi.fn(async () => false);
+		const w = mountWith([]);
+
+		const resolveBtn = w
+			.findAllComponents({ name: "Button" })
+			.find((b) => b.props("label") === "Resolve");
+		await resolveBtn.trigger("click");
+		await flushPromises();
+
+		expect(storeDouble.refreshAwaiting).not.toHaveBeenCalled();
+	});
+
+	it("a rejected refreshAwaiting after close does not throw or block the thread refresh", async () => {
+		storeDouble.closeTicket = vi.fn(async () => true);
+		storeDouble.refreshAwaiting = vi.fn(async () => {
+			throw new Error("network blip");
+		});
+		const w = mountWith([]);
+
+		const resolveBtn = w
+			.findAllComponents({ name: "Button" })
+			.find((b) => b.props("label") === "Resolve");
+		// The point of the test: a rejecting refreshAwaiting must not surface as
+		// an unhandled rejection (vitest fails the whole run on one - this is
+		// what the .catch() guard on that call exists to prevent) or stop the
+		// rest of the close flow from completing.
+		await resolveBtn.trigger("click");
+		await flushPromises();
+
+		// The rest of the close flow still ran - the rejection was contained,
+		// not swallowed at the cost of everything after it.
+		expect(storeDouble.loadThread).toHaveBeenCalledWith("T1", { quiet: true });
+	});
+
+	it("refreshes the awaiting count after a successful reply", async () => {
+		const w = mountWith([]);
+		const c = w.findComponent(SupportReplyBox);
+		c.vm.$emit("update:modelValue", "<p>thanks</p>");
+		await w.vm.$nextTick();
+		c.vm.$emit("submit");
+		await flushPromises();
+
+		expect(storeDouble.refreshAwaiting).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not refresh the awaiting count when the reply itself fails", async () => {
+		storeDouble.reply = vi.fn(async () => false);
+		const w = mountWith([]);
+		const c = w.findComponent(SupportReplyBox);
+		c.vm.$emit("update:modelValue", "<p>thanks</p>");
+		await w.vm.$nextTick();
+		c.vm.$emit("submit");
+		await flushPromises();
+
+		expect(storeDouble.refreshAwaiting).not.toHaveBeenCalled();
+	});
+
+	it("a rejected refreshAwaiting after a reply does not throw or block the thread refresh", async () => {
+		storeDouble.refreshAwaiting = vi.fn(async () => {
+			throw new Error("network blip");
+		});
+		const w = mountWith([]);
+		const c = w.findComponent(SupportReplyBox);
+		c.vm.$emit("update:modelValue", "<p>thanks</p>");
+		await w.vm.$nextTick();
+
+		// Same point as the close-side test above: a rejecting refreshAwaiting
+		// must not surface as an unhandled rejection or stop the rest of send()
+		// (the loadThread refresh below) from completing.
+		c.vm.$emit("submit");
+		await flushPromises();
+
+		expect(storeDouble.loadThread).toHaveBeenCalledWith("T1");
 	});
 });


### PR DESCRIPTION
## Summary

Backports the support waiting-reply signal from a tiny sidebar avatar dot to a red count pill on the chat header's support button, where the customer actually looks. Anyone using a v15 site sees the count pill with the two-row menu instead of the dot.

Backport of #1103 (merge ab8892a6).

No hunks dropped, no v16-only APIs. Clean cherry-pick (git auto-merged the one shared file, `ChatView.vue`).

Test script (from the source PR):
1. As a customer with no waiting tickets: no pill; clicking the headphones button opens a new ticket as before.
2. With support replies waiting: the button shows a red count; the sidebar avatar shows no dot.
3. Click the button: menu with "Tickets awaiting reply · N" and "New ticket from this chat".
4. Click the first row: the Support list opens with the "Awaiting you" filter applied (`/support?status=awaiting`), also when already on `/support`.
5. Click the second row: a new ticket opens, same as always.
6. Reply to or close a ticket from its thread: the count updates without waiting for the 60s poll.

## Pre-merge checklist

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01HW2uHdQLPLoV8qVXm6Ppxu
