### PR TITLE
fix: Force Resync reconciles proxy sidecars for pool tenants

### DIFF
--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -81,36 +81,96 @@ def ping_agent() -> dict:
 
 @frappe.whitelist()
 def force_resync(action: str = "reload") -> dict:
-	"""Bypass on_update change-detection. Run the same sync path on
-	current Settings values. action in {'reload', 'restart'}.
+	"""Bypass on_update change-detection. Re-drive the CURRENT Settings through
+	admin, branching pool vs direct like every other dispatch path.
+
+	A pool/subscription tenant goes through the /llm-pool leg so the Bifrost +
+	CLIProxyAPI sidecars are reconciled; a direct/api-key tenant keeps the
+	/llm-creds leg. Before this branch existed the button used /llm-creds
+	unconditionally and never touched a pool tenant's sidecars.
+
+	action in {'reload', 'restart'}:
+	- direct leg: 'reload' hot-rotates the key, 'restart' re-renders + bounces
+	  the container (and re-pushes skills), as before.
+	- pool leg: the fleet's /llm-pool apply is health-aware - it bounces the
+	  container when the config drifted or the container is unhealthy, and
+	  no-ops an already-correct healthy one. 'restart' additionally re-pushes
+	  custom + learned skills (no-op when the tenant has none). A wedged but
+	  healthy pool container is a reprovision, not a resync - out of scope here.
+
+	Returns ``{action, state, last_sync_at, last_sync_status}`` where ``state``
+	is one of applied / applying / failed / skipped (the pool leg hands its
+	converge tail to an async worker, so ``applying`` is a normal outcome).
 
 	Gated on ``require_jarvis_admin`` (PART 4 REVISED, TASK 45): a restart
-	reconciles + recreates the tenant container (DoS-class)."""
+	reconciles + bounces the tenant container (DoS-class)."""
 	require_jarvis_admin()
 	if action not in ("reload", "restart"):
 		raise frappe.ValidationError(f"invalid action {action!r}; expected reload or restart")
 	from jarvis import admin_client
+	from jarvis.jarvis.pool_serialize import compute_pool_mode
 
 	settings = frappe.get_single("Jarvis Settings")
-	# Always the admin path: the legacy local-agent sync was retired with
-	# the managed fleet (its method no longer exists), and _sync_via_admin
-	# surfaces its own clear error on an unconfigured bench.
-	try:
-		settings._sync_via_admin(action)
-	except admin_client.AdminAuthError:
-		# #388: _sync_via_admin now re-raises a genuine (non-"not paid") auth
-		# failure instead of swallowing it, so the RQ-enqueued caller sees it.
-		# This is the one SYNCHRONOUS, whitelisted caller with a JSON {ok, ...}
-		# contract of its own to preserve - _sync_via_admin already wrote the
-		# terminal "failed: auth: ..." status onto Settings before raising, so
-		# swallow here and let the reload below report it the same way every
-		# other outcome of this endpoint is reported.
-		pass
+	# Branch on pool vs direct the way every other dispatch path does (on_update,
+	# request_resync). A pool/subscription tenant's proxy sidecars (Bifrost +
+	# CLIProxyAPI) live ONLY on the /llm-pool leg: _sync_via_admin's /llm-creds path
+	# rotates the key or re-pushes a single model and never rebuilds the sidecars
+	# (see jarvis_settings.py's _sync_via_admin docstring). Without this branch a
+	# "Force Resync" on a pool tenant silently used the wrong wire contract and left
+	# the sidecars untouched.
+	skipped = False
+	if compute_pool_mode(settings):
+		# sync_pool_now does the bounded /llm-pool push - the fleet re-materializes
+		# Bifrost + CLIProxyAPI and bounces the container when the config drifted or
+		# it is unhealthy, and force_probe=True fires a live chat-completion probe so a
+		# byte-identical healthy no-op still returns an honest verdict instead of doing
+		# nothing. It handles its own admin errors (writing a terminal status) and hands
+		# the converge tail to the async worker - this mirrors save_llm_pool's
+		# settings-save flow (bounded push + async converge), NOT the SPA "Resync"
+		# button, which enqueues fully async via request_resync/_enqueue_pool_sync.
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import sync_pool_now
+
+		outcome = sync_pool_now(force_probe=True) or {}
+		skipped = bool(outcome.get("skipped"))
+		if action == "restart":
+			# Match the direct leg's restart: restore custom + learned skills a
+			# container (re)provision would have wiped. Both no-op when the tenant has
+			# no such skills, so a plain subscription tenant pays no extra restart.
+			settings._resync_custom_skills_after_restart()
+			settings._resync_learned_skills_after_restart()
+	else:
+		# Direct (api-key / lone-subscription) tenant: no sidecars to reconcile, so the
+		# legacy /llm-creds leg is correct and ``action`` still selects reload vs
+		# restart. The local-agent sync was retired with the managed fleet.
+		try:
+			settings._sync_via_admin(action)
+		except admin_client.AdminAuthError:
+			# #388: _sync_via_admin now re-raises a genuine (non-"not paid") auth
+			# failure instead of swallowing it, so the RQ-enqueued caller sees it.
+			# This is the one SYNCHRONOUS, whitelisted caller with a JSON {ok, ...}
+			# contract of its own to preserve - _sync_via_admin already wrote the
+			# terminal "failed: auth: ..." status onto Settings before raising, so
+			# swallow here and let the reload below report it the same way every
+			# other outcome of this endpoint is reported.
+			pass
 	settings.reload()
+	# Report an explicit state instead of making the caller parse the status string.
+	# The pool leg stamps "pending: ..." synchronously and converges async, so
+	# ``applying`` is a normal, non-error outcome (the Desk toast keys off this).
+	status = settings.get("last_sync_status") or ""
+	if skipped:
+		state = "skipped"
+	elif status.startswith("ok"):
+		state = "applied"
+	elif status.startswith("failed"):
+		state = "failed"
+	else:
+		state = "applying"
 	return {
 		"action": action,
+		"state": state,
 		"last_sync_at": str(settings.get("last_sync_at") or ""),
-		"last_sync_status": settings.get("last_sync_status") or "",
+		"last_sync_status": status,
 	}
 
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -171,7 +171,7 @@ frappe.ui.form.on("Jarvis Settings", {
 							default: "reload",
 							reqd: 1,
 							description: __(
-								"reload = hot-swap LLM key only. restart = re-render config and bounce the container."
+								"reload = re-push the current config (hot-swap the key where possible). restart = also restore skills and bounce the container when the config drifted or it is unhealthy."
 							),
 						},
 					],
@@ -184,15 +184,37 @@ frappe.ui.form.on("Jarvis Settings", {
 							})
 							.then((r) => {
 								const m = r.message || {};
-								const ok = (m.last_sync_status || "").startsWith("ok");
+								// state (applied/applying/failed/skipped) is authoritative;
+								// fall back to the status string for an older backend. A pool
+								// resync converges async, so "applying" is normal, not a failure.
+								const state =
+									m.state ||
+									((m.last_sync_status || "").startsWith("ok")
+										? "applied"
+										: "failed");
+								const meta = {
+									applied: { title: __("Resync OK"), indicator: "green" },
+									applying: { title: __("Resync Queued"), indicator: "blue" },
+									skipped: {
+										title: __("Nothing to Resync"),
+										indicator: "orange",
+									},
+									failed: {
+										title: __("Resync Reported a Problem"),
+										indicator: "red",
+									},
+								}[state] || {
+									title: __("Resync Reported a Problem"),
+									indicator: "red",
+								};
 								frappe.msgprint({
-									title: ok ? __("Resync OK") : __("Resync Reported a Problem"),
+									title: meta.title,
 									message: __("Action: {0}<br>At: {1}<br>Status: {2}", [
 										m.action || "?",
 										m.last_sync_at || "(no timestamp)",
 										m.last_sync_status || "(no status)",
 									]),
-									indicator: ok ? "green" : "red",
+									indicator: meta.indicator,
 								});
 								frm.reload_doc();
 							});

--- a/jarvis/tests/test_diagnostics.py
+++ b/jarvis/tests/test_diagnostics.py
@@ -122,28 +122,96 @@ class TestPingAgent(FrappeTestCase):
 
 
 class TestForceResync(FrappeTestCase):
+	# force_resync branches on compute_pool_mode: a pool/subscription tenant must go
+	# through the /llm-pool leg (which reconciles the Bifrost + CLIProxyAPI sidecars),
+	# a direct/api-key tenant keeps the legacy /llm-creds leg (no sidecars to touch).
+	SYNC_POOL_NOW = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.sync_pool_now"
+	POOL_MODE = "jarvis.jarvis.pool_serialize.compute_pool_mode"
+
 	def test_rejects_invalid_action(self):
 		with self.assertRaises(frappe.ValidationError):
 			diagnostics.force_resync(action="blowup")
 
-	def test_force_resync_always_uses_admin_path(self):
-		"""Post-unification (2026-05-29): on_update always routes via admin.
-		force_resync inherits the same path."""
+	def test_direct_tenant_uses_creds_leg(self):
+		"""A non-pool (direct / api-key) tenant reconciles through
+		_sync_via_admin's /llm-creds leg - there are no sidecars to rebuild, and
+		the pool leg must NOT be invoked."""
 		cls = frappe.get_single("Jarvis Settings").__class__
-		with patch.object(cls, "_sync_via_admin") as sa:
-			diagnostics.force_resync(action="reload")
+		with (
+			patch(self.POOL_MODE, return_value=False),
+			patch(self.SYNC_POOL_NOW) as pool,
+			patch.object(cls, "_sync_via_admin") as sa,
+		):
+			out = diagnostics.force_resync(action="reload")
 		sa.assert_called_once_with("reload")
+		pool.assert_not_called()
+		self.assertIn("state", out)
+
+	def test_pool_reload_reconciles_sidecars_only(self):
+		"""THE FIX (sidecar reconcile): a pool/subscription tenant pushes through
+		sync_pool_now (/llm-pool - rebuilds Bifrost + CLIProxyAPI) with a live probe,
+		NOT the legacy /llm-creds leg. 'reload' does NOT re-push skills."""
+		cls = frappe.get_single("Jarvis Settings").__class__
+		with (
+			patch(self.POOL_MODE, return_value=True),
+			patch(self.SYNC_POOL_NOW, return_value={}) as pool,
+			patch.object(cls, "_sync_via_admin") as sa,
+			patch.object(cls, "_resync_custom_skills_after_restart") as cs,
+			patch.object(cls, "_resync_learned_skills_after_restart") as ls,
+		):
+			out = diagnostics.force_resync(action="reload")
+		pool.assert_called_once_with(force_probe=True)
+		sa.assert_not_called()
+		cs.assert_not_called()
+		ls.assert_not_called()
+		self.assertIn("state", out)
+
+	def test_pool_restart_also_repushes_skills(self):
+		"""'restart' on a pool tenant reconciles the sidecars AND re-pushes custom +
+		learned skills (which restore skills and bounce the container), matching the
+		reload/restart + skills-re-push semantics the direct leg has."""
+		cls = frappe.get_single("Jarvis Settings").__class__
+		with (
+			patch(self.POOL_MODE, return_value=True),
+			patch(self.SYNC_POOL_NOW, return_value={}) as pool,
+			patch.object(cls, "_sync_via_admin") as sa,
+			patch.object(cls, "_resync_custom_skills_after_restart") as cs,
+			patch.object(cls, "_resync_learned_skills_after_restart") as ls,
+		):
+			out = diagnostics.force_resync(action="restart")
+		pool.assert_called_once_with(force_probe=True)
+		sa.assert_not_called()
+		cs.assert_called_once_with()
+		ls.assert_called_once_with()
+		self.assertEqual(out["action"], "restart")
+
+	def test_pool_skipped_outcome_reports_skipped_state(self):
+		"""When sync_pool_now reports the spec was not pushable (skipped), the
+		endpoint surfaces state='skipped' instead of echoing a stale status."""
+		cls = frappe.get_single("Jarvis Settings").__class__
+		with (
+			patch(self.POOL_MODE, return_value=True),
+			patch(self.SYNC_POOL_NOW, return_value={"skipped": True}),
+			patch.object(cls, "_resync_custom_skills_after_restart"),
+			patch.object(cls, "_resync_learned_skills_after_restart"),
+		):
+			out = diagnostics.force_resync(action="reload")
+		self.assertEqual(out["state"], "skipped")
 
 	def test_force_resync_survives_genuine_auth_error(self):
 		"""#388: _sync_via_admin now re-raises a genuine admin auth failure.
 		force_resync is the one SYNCHRONOUS, whitelisted caller with its own
 		{ok/status} JSON contract - it must swallow the raise and still return
 		its status dict (reflecting the terminal status _sync_via_admin wrote)
-		rather than letting the exception blow through the endpoint."""
+		rather than letting the exception blow through the endpoint. Applies to
+		the direct leg (the pool leg's sync_pool_now handles its own errors)."""
 		from jarvis.exceptions import AdminAuthError
 
 		cls = frappe.get_single("Jarvis Settings").__class__
-		with patch.object(cls, "_sync_via_admin", side_effect=AdminAuthError("nope")):
+		with (
+			patch(self.POOL_MODE, return_value=False),
+			patch.object(cls, "_sync_via_admin", side_effect=AdminAuthError("nope")),
+		):
 			out = diagnostics.force_resync(action="reload")
 		self.assertEqual(out["action"], "reload")
 		self.assertIn("last_sync_status", out)


### PR DESCRIPTION
## Summary

The staff "Force Resync" button in Jarvis Settings (Desk) now works for subscription/pool tenants: it reconciles their Bifrost + CLIProxyAPI proxy sidecars instead of silently doing nothing. Before, the button always used the direct credential path, which never touches the sidecars, so a proxy tenant's resync had no effect on its proxy.

**What changed**
- Branches on pool vs direct like every other sync path. Pool tenants go through the pool apply (rebuilds the sidecars, bounces the container on config drift or when unhealthy, and live-probes an already-correct one); direct/api-key tenants keep the credential path unchanged.
- Pool "restart" also re-pushes custom and learned skills, matching the direct leg (no-op when the tenant has none).
- Returns an explicit state (applied / applying / failed / skipped); the Desk toast renders the normal async "applying" as a blue "Queued" instead of a red error.
- Dialog text no longer promises an unconditional container bounce.

Customer-facing SPA Resync/Retry buttons already used the pool path and are unchanged.

**Verification**
- Staff-only Desk diagnostic; jarvis-only, no admin/fleet change.
- 16/16 diagnostics unit tests pass (pool reload, pool restart + skills, direct leg, skipped state); pre-commit clean.
- Deployed to a local integration branch and tested on a live subscription tenant (e2e.localhost): reload and restart both routed through the pool apply.

**Desk toast (Jarvis Settings, Agent Recovery > Force Resync)**

Dialog, updated wording:

<img width="640" alt="Force Resync dialog" src="https://github.com/user-attachments/assets/f3b786bb-5e55-4a23-b2d6-1b59caa10a6e" />

Live click on the pool tenant. New blue "Resync Queued" state, and the status line "pending: provisioning container (pool)" confirms the /llm-pool leg ran:

<img width="640" alt="Resync Queued toast" src="https://github.com/user-attachments/assets/2c859f45-9d7b-4a49-8c76-98c3f1ffce4a" />

Success state, green "Resync OK" (rendered from the applied state: the local test tenant is mid-cooldown so it stays converging and cannot reach a live "ok" right now):

<img width="640" alt="Resync OK toast" src="https://github.com/user-attachments/assets/7d60aa68-1066-4fc0-a2d5-2cc414458328" />

<details><summary>Root cause</summary>

`force_resync` called `_sync_via_admin(action)` unconditionally, with no `compute_pool_mode` branch (unlike `on_update` and `request_resync`). For a pool tenant that pushes through the `/llm-creds` path, which per `_sync_via_admin`'s own docstring "never tears the Bifrost/cliproxy sidecars down", so the sidecars were never reconciled. Routing pool tenants through `sync_pool_now(force_probe=True)` uses the `/llm-pool` apply, which is health-aware: it re-materializes the sidecars and bounces the container only on config drift or an unhealthy container (verified against fleet-agent's `_pool_apply_is_noop`, which compares the on-disk sidecar config plus a `docker inspect` health check), and no-ops an already-correct healthy one.

</details>

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01CbJcFctYibnXhwEQrpnHM3
