### PR TITLE
chore: mergify backport smoke test (delete after)

### DIFF
--- a/.github/mergify-backport-smoke.md
+++ b/.github/mergify-backport-smoke.md
@@ -1,0 +1,4 @@
+# Mergify backport smoke test
+
+Throwaway file: verifies Mergify auto-opens version-15-hotfix / version-16-hotfix
+backport PRs when a develop PR carries the backport labels. Delete after confirming.


### PR DESCRIPTION
Throwaway PR to confirm Mergify auto-opens version-15-hotfix / version-16-hotfix backport PRs on merge of a labeled develop PR. Adds one .md file; close/delete after verifying.