### PR TITLE
chore: remove mergify backport smoke test file

### DIFF
--- a/.github/mergify-backport-smoke.md
+++ b/.github/mergify-backport-smoke.md
@@ -1,4 +1,0 @@
-# Mergify backport smoke test
-
-Throwaway file: verifies Mergify auto-opens version-15-hotfix / version-16-hotfix
-backport PRs when a develop PR carries the backport labels. Delete after confirming.


### PR DESCRIPTION
Removes the throwaway `.github/mergify-backport-smoke.md` added by #1115 to smoke-test Mergify. The test confirmed auto-backports fire (#1115 -> #1117/#1118, since closed). No backport labels: this file was never meant for the hotfix branches.