### PR TITLE
feat(usage): per-user daily buckets and context fullness in the usage push

### DIFF
--- a/jarvis/api_errors.py
+++ b/jarvis/api_errors.py
@@ -381,6 +381,21 @@ def _parse_traceback(traceback: str) -> tuple[str, str, list[str]]:
 	return exc_class, exc_message, frames
 
 
+#: Error Log.owner values that are not a real reporting user - mirrors the
+#: convention used elsewhere in this app (e.g. jarvis.chat.agent_runs).
+_NON_USER_OWNERS = ("Administrator", "Guest")
+
+
+def _error_log_user_ref(owner: str | None) -> str:
+	"""``owner`` when it names a real user, else "" - the same per-user
+	attribution ``_collect_ui_errors`` already sends for UI errors
+	(``jarvis.error_push``), extended to code-level exceptions so admin's
+	per-user error rollup covers both lanes."""
+	if not owner or owner in _NON_USER_OWNERS:
+		return ""
+	return owner
+
+
 def collect_error_log(since: str | None, limit: int = ERROR_LOG_SCAN_LIMIT) -> dict:
 	"""Read new ``Error Log`` rows after ``since``, keep only jarvis-origin ones,
 	and normalize them into the push shape.
@@ -392,7 +407,7 @@ def collect_error_log(since: str | None, limit: int = ERROR_LOG_SCAN_LIMIT) -> d
 	logs = frappe.get_all(
 		"Error Log",
 		filters=filters,
-		fields=["name", "method", "error", "creation"],
+		fields=["name", "method", "error", "creation", "owner"],
 		order_by="creation asc",
 		limit=limit,
 	)
@@ -416,6 +431,7 @@ def collect_error_log(since: str | None, limit: int = ERROR_LOG_SCAN_LIMIT) -> d
 				"fingerprint": _traceback_fingerprint(exc_class, frames),
 				"occurred_at": str(log.creation),
 				"severity": "error",
+				"user_ref": _error_log_user_ref(log.owner),
 			}
 		)
 	return {"rows": rows, "watermark": watermark}

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -200,6 +200,43 @@ def _context_capacity_and_pct(row: dict | None, used_tokens: int) -> tuple[int, 
 	return capacity, round(100 * used_tokens / capacity, 1)
 
 
+def _refresh_session_context_snapshot(
+	session_key: str, context_tokens: int, context_capacity: int, context_pct: float
+) -> None:
+	"""Snapshot-only UPDATE (no token/run-count accrual) of a Chat Session's
+	context fields - used on ``record_turn_usage``'s VALID_ZERO path, where
+	there is no token delta to accrue but the row's context snapshot can
+	still have moved.
+
+	Mirrors ``refresh_session_snapshots``'s capacity guard: ``context_capacity``
+	/ ``context_pct`` are only written when THIS row actually reported a
+	capacity (``context_capacity > 0``) - a row that carries none must never
+	clobber a previously known capacity with 0. Uncommitted, matching the
+	VALID_ZERO/RETRY paths' no-commit contract (see ``record_turn_usage``'s
+	docstring) - the caller's outer commit (RECORDED) or the finalize effect's
+	own commit covers it."""
+	params = {
+		"ctx": context_tokens,
+		"now": frappe.utils.now_datetime(),
+		"session_key": session_key,
+	}
+	capacity_set_sql = ""
+	if context_capacity > 0:
+		capacity_set_sql = "context_capacity = %(ctx_cap)s, context_pct = %(ctx_pct)s,"
+		params["ctx_cap"] = context_capacity
+		params["ctx_pct"] = context_pct
+	frappe.db.sql(
+		f"""
+		UPDATE `tabJarvis Chat Session`
+		SET last_total_tokens = %(ctx)s,
+			{capacity_set_sql}
+			last_usage_at = %(now)s
+		WHERE session_key = %(session_key)s
+		""",
+		params,
+	)
+
+
 def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = None) -> str:
 	"""Record one completed turn's token delta from a ``sessions.list`` row.
 
@@ -256,14 +293,19 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 			or {}
 		)
 		user = session.get("user") or ""
+		context_tokens = int(row.get("totalTokens") or 0)
+		context_capacity, context_pct = _context_capacity_and_pct(row, context_tokens)
 		if delta <= 0:
 			# Task U1: attribution is still worth recording even though there is
 			# no token delta - the turn happened and this is the only record of
 			# WHO it happened for. Isolated + never raises (see the docstring).
 			_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens, session)
+			# C1 review: a zero-delta turn is still a real turn - the session's
+			# context snapshot (and, when this row reports one, its capacity)
+			# can have moved even though no tokens were spent this turn. Same
+			# no-commit contract as the rest of this branch (see docstring).
+			_refresh_session_context_snapshot(session_key, context_tokens, context_capacity, context_pct)
 			return USAGE_VALID_ZERO
-		context_tokens = int(row.get("totalTokens") or 0)
-		context_capacity, context_pct = _context_capacity_and_pct(row, context_tokens)
 
 		if not user:
 			# CDX-6: a FRESH POSITIVE token delta with no `Jarvis Chat Session` user
@@ -763,39 +805,45 @@ def refresh_session_snapshots(rows: list[dict]) -> dict:
 			context_tokens = int(row.get("totalTokens") or 0)
 			context_capacity, context_pct = _context_capacity_and_pct(row, context_tokens)
 			updated_ms = row.get("updatedAt")
-			if updated_ms:
-				# Naive system-tz datetime, matching how Frappe stores Datetime.
-				last_at = datetime.fromtimestamp(int(updated_ms) / 1000)
-				frappe.db.sql(
-					"""
-					UPDATE `tabJarvis Chat Session`
-					SET last_total_tokens = %(ctx)s, context_capacity = %(ctx_cap)s,
-						context_pct = %(ctx_pct)s, last_usage_at = %(at)s
-					WHERE session_key = %(session_key)s
-					""",
-					{
-						"ctx": context_tokens,
-						"ctx_cap": context_capacity,
-						"ctx_pct": context_pct,
-						"at": last_at,
-						"session_key": session_key,
-					},
-				)
-			else:
-				frappe.db.sql(
-					"""
-					UPDATE `tabJarvis Chat Session`
-					SET last_total_tokens = %(ctx)s, context_capacity = %(ctx_cap)s,
-						context_pct = %(ctx_pct)s
-					WHERE session_key = %(session_key)s
-					""",
-					{
-						"ctx": context_tokens,
-						"ctx_cap": context_capacity,
-						"ctx_pct": context_pct,
-						"session_key": session_key,
-					},
-				)
+			# Naive system-tz datetime, matching how Frappe stores Datetime.
+			last_at = datetime.fromtimestamp(int(updated_ms) / 1000) if updated_ms else None
+			# ONE update (review: two near-duplicate UPDATEs made "newest row"
+			# ordering unreliable elsewhere - a row with no updatedAt never
+			# stamped last_usage_at, and a raw SQL UPDATE never bumps modified
+			# on its own). COALESCE keeps a real prior last_usage_at over a
+			# missing updatedAt stamp, falling back to the sweep's own `now`
+			# (the Python-side stamp computed once above, NOT SQL's NOW() -
+			# NOW() is the DB session's timezone, which need not match the
+			# site's system tz that every other write to these columns uses,
+			# and MariaDB's NOW() is second-precision, too coarse to always
+			# order two sweeps run back-to-back) only when this session has
+			# never had one; modified = %(now)s always advances, so ordering
+			# by either column is reliable that this row was just synced.
+			# context_capacity / context_pct are set ONLY when THIS row
+			# actually reported a capacity (review: a sweep row that carries
+			# none must never clobber a previously known capacity with 0).
+			params = {
+				"ctx": context_tokens,
+				"usage_at": last_at,
+				"now": now,
+				"session_key": session_key,
+			}
+			capacity_set_sql = ""
+			if context_capacity > 0:
+				capacity_set_sql = "context_capacity = %(ctx_cap)s, context_pct = %(ctx_pct)s,"
+				params["ctx_cap"] = context_capacity
+				params["ctx_pct"] = context_pct
+			frappe.db.sql(
+				f"""
+				UPDATE `tabJarvis Chat Session`
+				SET last_total_tokens = %(ctx)s,
+					{capacity_set_sql}
+					last_usage_at = COALESCE(%(usage_at)s, last_usage_at, %(now)s),
+					modified = %(now)s
+				WHERE session_key = %(session_key)s
+				""",
+				params,
+			)
 			touched_users.add(user)
 			bucket = summary.setdefault(user, {"sessions": 0, "last_total_tokens": 0})
 			bucket["sessions"] += 1

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -808,20 +808,19 @@ def refresh_session_snapshots(rows: list[dict]) -> dict:
 			# Naive system-tz datetime, matching how Frappe stores Datetime.
 			last_at = datetime.fromtimestamp(int(updated_ms) / 1000) if updated_ms else None
 			# ONE update (review: two near-duplicate UPDATEs made "newest row"
-			# ordering unreliable elsewhere - a row with no updatedAt never
-			# stamped last_usage_at, and a raw SQL UPDATE never bumps modified
-			# on its own). COALESCE keeps a real prior last_usage_at over a
-			# missing updatedAt stamp, falling back to the sweep's own `now`
-			# (the Python-side stamp computed once above, NOT SQL's NOW() -
-			# NOW() is the DB session's timezone, which need not match the
-			# site's system tz that every other write to these columns uses,
-			# and MariaDB's NOW() is second-precision, too coarse to always
-			# order two sweeps run back-to-back) only when this session has
-			# never had one; modified = %(now)s always advances, so ordering
-			# by either column is reliable that this row was just synced.
-			# context_capacity / context_pct are set ONLY when THIS row
-			# actually reported a capacity (review: a sweep row that carries
-			# none must never clobber a previously known capacity with 0).
+			# ordering unreliable elsewhere - a raw SQL UPDATE never bumps
+			# modified on its own). last_usage_at means "last REAL usage", not
+			# sync time (test_user_settings.TestAdminSync.
+			# test_refreshes_snapshots_without_accumulating pins this: a row
+			# with no updatedAt must leave last_usage_at exactly as it was -
+			# untouched if never set, unchanged if it was), so COALESCE has NO
+			# now()/`now` fallback here - only the row's own updatedAt stamp,
+			# else whatever is already stored. modified = %(now)s always
+			# advances regardless, so "just synced" stays orderable even when
+			# last_usage_at itself doesn't move. context_capacity /
+			# context_pct are set ONLY when THIS row actually reported a
+			# capacity (review: a sweep row that carries none must never
+			# clobber a previously known capacity with 0).
 			params = {
 				"ctx": context_tokens,
 				"usage_at": last_at,
@@ -838,7 +837,7 @@ def refresh_session_snapshots(rows: list[dict]) -> dict:
 				UPDATE `tabJarvis Chat Session`
 				SET last_total_tokens = %(ctx)s,
 					{capacity_set_sql}
-					last_usage_at = COALESCE(%(usage_at)s, last_usage_at, %(now)s),
+					last_usage_at = COALESCE(%(usage_at)s, last_usage_at),
 					modified = %(now)s
 				WHERE session_key = %(session_key)s
 				""",

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -186,6 +186,20 @@ def resolved_model_identity(row: dict | None) -> tuple[str, str]:
 	return (row.get("model") or "").strip(), (row.get("modelProvider") or "").strip()
 
 
+def _context_capacity_and_pct(row: dict | None, used_tokens: int) -> tuple[int, float]:
+	"""``(context_capacity, context_pct)`` from a ``sessions.list`` row.
+
+	``contextTokens`` is the model's context-WINDOW CAPACITY (verified live,
+	2026-09-04: 200000), distinct from ``totalTokens`` (context tokens actually
+	USED, already read as ``context_tokens`` by every caller here). ``pct`` is
+	``100 * used_tokens / capacity`` rounded to 1 decimal, or ``0`` when the row
+	never reported a capacity (``contextTokens`` missing/zero)."""
+	capacity = int((row or {}).get("contextTokens") or 0)
+	if capacity <= 0:
+		return 0, 0.0
+	return capacity, round(100 * used_tokens / capacity, 1)
+
+
 def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = None) -> str:
 	"""Record one completed turn's token delta from a ``sessions.list`` row.
 
@@ -249,6 +263,7 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 			_write_turn_usage_row(session_key, row, run_id, input_tokens, output_tokens, session)
 			return USAGE_VALID_ZERO
 		context_tokens = int(row.get("totalTokens") or 0)
+		context_capacity, context_pct = _context_capacity_and_pct(row, context_tokens)
 
 		if not user:
 			# CDX-6: a FRESH POSITIVE token delta with no `Jarvis Chat Session` user
@@ -269,6 +284,8 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 			"out": output_tokens,
 			"delta": delta,
 			"ctx": context_tokens,
+			"ctx_cap": context_capacity,
+			"ctx_pct": context_pct,
 			"month": month,
 			"now": now,
 			"user": user,
@@ -303,6 +320,8 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 				output_tokens = output_tokens + %(out)s,
 				run_count = run_count + 1,
 				last_total_tokens = %(ctx)s,
+				context_capacity = %(ctx_cap)s,
+				context_pct = %(ctx_pct)s,
 				last_usage_at = %(now)s
 			WHERE session_key = %(session_key)s
 			""",
@@ -742,6 +761,7 @@ def refresh_session_snapshots(rows: list[dict]) -> dict:
 			if not user:
 				continue
 			context_tokens = int(row.get("totalTokens") or 0)
+			context_capacity, context_pct = _context_capacity_and_pct(row, context_tokens)
 			updated_ms = row.get("updatedAt")
 			if updated_ms:
 				# Naive system-tz datetime, matching how Frappe stores Datetime.
@@ -749,19 +769,32 @@ def refresh_session_snapshots(rows: list[dict]) -> dict:
 				frappe.db.sql(
 					"""
 					UPDATE `tabJarvis Chat Session`
-					SET last_total_tokens = %(ctx)s, last_usage_at = %(at)s
+					SET last_total_tokens = %(ctx)s, context_capacity = %(ctx_cap)s,
+						context_pct = %(ctx_pct)s, last_usage_at = %(at)s
 					WHERE session_key = %(session_key)s
 					""",
-					{"ctx": context_tokens, "at": last_at, "session_key": session_key},
+					{
+						"ctx": context_tokens,
+						"ctx_cap": context_capacity,
+						"ctx_pct": context_pct,
+						"at": last_at,
+						"session_key": session_key,
+					},
 				)
 			else:
 				frappe.db.sql(
 					"""
 					UPDATE `tabJarvis Chat Session`
-					SET last_total_tokens = %(ctx)s
+					SET last_total_tokens = %(ctx)s, context_capacity = %(ctx_cap)s,
+						context_pct = %(ctx_pct)s
 					WHERE session_key = %(session_key)s
 					""",
-					{"ctx": context_tokens, "session_key": session_key},
+					{
+						"ctx": context_tokens,
+						"ctx_cap": context_capacity,
+						"ctx_pct": context_pct,
+						"session_key": session_key,
+					},
 				)
 			touched_users.add(user)
 			bucket = summary.setdefault(user, {"sessions": 0, "last_total_tokens": 0})

--- a/jarvis/chat/usage_push.py
+++ b/jarvis/chat/usage_push.py
@@ -43,6 +43,12 @@ _USERS_DAILY_ROW_CAP = 5000
 _USERS_DAILY_PER_MODEL_CAP = 20
 _CONTEXT_OVER_PCT = 80
 
+# Built once (review: was re-constructed on every _iso_utc_z call). UTC is a
+# fixed offset, unlike the site's system timezone (frappe.utils.
+# get_system_timezone()), which genuinely varies per request in a multi-site
+# process and so cannot be hoisted the same way.
+_UTC = ZoneInfo("UTC")
+
 # Mirrors the admin ingest validator exactly (contract settled 2026-08-17): a
 # bare name, or a "jarvis__" prefixed tool with an UNBOUNDED suffix. A name
 # that matches neither would 400 the whole push (payload-atomic), so it is
@@ -110,7 +116,10 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 		agg = turn_aggregates_by_user.get(s.user, {})
 		users.append(
 			{
-				"email": s.user,
+				# Lowercased (review): users_daily already lowercases its
+				# email and admin lowercases on ingest anyway - matching
+				# here just keeps the payload self-consistent.
+				"email": (s.user or "").strip().lower(),
 				"tokens_in": int(s.month_input_tokens or 0),
 				"tokens_out": int(s.month_output_tokens or 0),
 				"total_tokens": int(s.month_tokens or 0),
@@ -408,7 +417,7 @@ def _iso_utc_z(value) -> str | None:
 		return None
 	dt = frappe.utils.get_datetime(value)
 	aware = dt.replace(tzinfo=ZoneInfo(frappe.utils.get_system_timezone()))
-	return aware.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
+	return aware.astimezone(_UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _context_by_user(users: list[str]) -> dict[str, dict]:
@@ -417,69 +426,63 @@ def _context_by_user(users: list[str]) -> dict[str, dict]:
 	``last_total_tokens`` are ``usage.record_turn_usage`` and
 	``usage.refresh_session_snapshots``).
 
-	``used_max`` is the largest ``last_total_tokens`` across the user's
-	sessions; ``capacity`` comes from whichever of the user's sessions most
-	recently reported a non-zero ``context_capacity`` (a user's sessions can,
-	in principle, run different models with different context windows, so
-	"the newest row with one" per the spec, not an arbitrary/first row);
-	``pct_max`` is recomputed from ``used_max`` / that ``capacity`` rather than
-	trusting any single session's stored ``context_pct``, since the session
-	that had the highest usage need not be the same one capacity was read
-	from. Returns ``{}`` for an empty ``users`` list; callers fall back to
-	``_EMPTY_CONTEXT`` per user."""
+	Review fix: a user's sessions can run different models with different
+	context windows, so pairing the session with the highest ``used`` against
+	a DIFFERENT session's ``capacity`` (e.g. "the newest row with one") can
+	report a nonsensical pct (or the wrong one). Instead, ``pct`` is computed
+	PER SESSION (``last_total_tokens / context_capacity`` of that SAME
+	session, only over sessions that have actually reported a capacity), and
+	the session with the HIGHEST own pct wins: its own ``used``/``capacity``/
+	``pct`` become ``used_max``/``capacity``/``pct_max``. ``sessions_over_80``
+	counts sessions whose OWN pct is >= ``_CONTEXT_OVER_PCT``. ``last_seen_at``
+	is unrelated to capacity - it stays the newest ``last_usage_at`` across
+	ALL of the user's sessions, capacity-reporting or not. Returns ``{}`` for
+	an empty ``users`` list; callers fall back to ``_EMPTY_CONTEXT`` per user
+	(also what a user with sessions but none reporting a capacity gets, since
+	pct/used_max/capacity are then undefined)."""
 	if not users:
 		return {}
-	summary = {
-		r.user: r
+	last_seen_by_user = {
+		r.user: r.last_seen_at
 		for r in frappe.db.sql(
 			"""
-			SELECT user,
-				   MAX(last_total_tokens) AS used_max,
-				   SUM(CASE WHEN context_pct >= %(over_pct)s THEN 1 ELSE 0 END) AS sessions_over_80,
-				   MAX(last_usage_at) AS last_seen_at
+			SELECT user, MAX(last_usage_at) AS last_seen_at
 			FROM `tabJarvis Chat Session`
 			WHERE user IN %(users)s
 			GROUP BY user
 			""",
-			{"users": tuple(users), "over_pct": _CONTEXT_OVER_PCT},
+			{"users": tuple(users)},
 			as_dict=True,
 		)
 	}
-	# COALESCE(last_usage_at, modified): refresh_session_snapshots only stamps
-	# last_usage_at when the gateway row carried updatedAt (see its docstring);
-	# a session refreshed without one still has a real context_capacity, and
-	# without the fallback it would silently lose the newest-row-wins ordering
-	# (NULL never wins a MAX/join match against a real timestamp).
-	capacity_by_user: dict[str, int] = {}
+	best_by_user: dict[str, dict] = {}
+	over_80_by_user: dict[str, int] = {}
 	for r in frappe.db.sql(
 		"""
-		SELECT t1.user AS user, t1.context_capacity AS context_capacity
-		FROM `tabJarvis Chat Session` t1
-		INNER JOIN (
-			SELECT user, MAX(COALESCE(last_usage_at, modified)) AS max_at
-			FROM `tabJarvis Chat Session`
-			WHERE user IN %(users)s AND context_capacity > 0
-			GROUP BY user
-		) newest ON newest.user = t1.user AND newest.max_at = COALESCE(t1.last_usage_at, t1.modified)
-		WHERE t1.context_capacity > 0
+		SELECT user, last_total_tokens, context_capacity
+		FROM `tabJarvis Chat Session`
+		WHERE user IN %(users)s AND context_capacity > 0
 		""",
 		{"users": tuple(users)},
 		as_dict=True,
 	):
-		# A tie on last_usage_at (rare) just keeps whichever row SQL returns
-		# last; both would carry the same model's capacity in practice.
-		capacity_by_user[r.user] = int(r.context_capacity or 0)
+		used = int(r.last_total_tokens or 0)
+		capacity = int(r.context_capacity or 0)
+		pct = round(100 * used / capacity, 1)
+		if pct >= _CONTEXT_OVER_PCT:
+			over_80_by_user[r.user] = over_80_by_user.get(r.user, 0) + 1
+		best = best_by_user.get(r.user)
+		if best is None or pct > best["pct_max"]:
+			best_by_user[r.user] = {"used_max": used, "capacity": capacity, "pct_max": pct}
 	out: dict[str, dict] = {}
 	for user in users:
-		row = summary.get(user)
-		used_max = int(row.used_max or 0) if row else 0
-		capacity = capacity_by_user.get(user)
+		best = best_by_user.get(user)
 		out[user] = {
-			"used_max": used_max,
-			"capacity": capacity,
-			"pct_max": round(100 * used_max / capacity, 1) if capacity else None,
-			"sessions_over_80": int(row.sessions_over_80 or 0) if row else 0,
-			"last_seen_at": _iso_utc_z(row.last_seen_at) if row else None,
+			"used_max": best["used_max"] if best else 0,
+			"capacity": best["capacity"] if best else None,
+			"pct_max": best["pct_max"] if best else None,
+			"sessions_over_80": over_80_by_user.get(user, 0),
+			"last_seen_at": _iso_utc_z(last_seen_by_user.get(user)),
 		}
 	return out
 

--- a/jarvis/chat/usage_push.py
+++ b/jarvis/chat/usage_push.py
@@ -11,6 +11,7 @@ push; admin then shows "no usage".
 from __future__ import annotations
 
 import re
+from zoneinfo import ZoneInfo
 
 import frappe
 
@@ -20,6 +21,7 @@ from jarvis.exceptions import AdminAuthError
 USER_SETTINGS = usage.USER_SETTINGS
 MODEL_USAGE = usage.MODEL_USAGE
 MODEL_USAGE_FIELD = usage.MODEL_USAGE_FIELD
+TURN_USAGE = usage.TURN_USAGE
 
 # Hard cap on users per push (spec §7). Bounds payload size; extra users are
 # dropped (highest-usage first kept) and the truncation is logged.
@@ -28,6 +30,18 @@ _MAX_USERS = 500
 # Caps on the rollup's task-U2 aggregate lists (contract settled 2026-08-17).
 _TOP_TOOLS_USER_CAP = 10
 _TOP_TOOLS_TENANT_CAP = 15
+
+# Sub-project C1, pinned wire contract (schema_version 2): the "who's using
+# Jarvis most" admin dashboard adds a per-user context snapshot and a daily
+# per-(user, day, model) breakdown on top of the month-to-date rollup above.
+# ``users_daily`` window/caps and ``context`` null-handling are all spelled
+# out in the pinned contract - do not add/rename/reshape keys without
+# re-checking it, the admin ingest side is built from the same text.
+SCHEMA_VERSION = 2
+_USERS_DAILY_WINDOW_DAYS = 35
+_USERS_DAILY_ROW_CAP = 5000
+_USERS_DAILY_PER_MODEL_CAP = 20
+_CONTEXT_OVER_PCT = 80
 
 # Mirrors the admin ingest validator exactly (contract settled 2026-08-17): a
 # bare name, or a "jarvis__" prefixed tool with an UNBOUNDED suffix. A name
@@ -67,7 +81,16 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 	user's profile attribution, cache/tool-call aggregates and top_tools, plus
 	the tenant-wide ``by_profile`` and ``top_tools`` blocks. ``users[]`` stays
 	settings-sourced - a settings row with no Turn Usage rows this month just
-	gets the empty/zero defaults, never an entry invented from Turn Usage."""
+	gets the empty/zero defaults, never an entry invented from Turn Usage.
+
+	Schema version 2 (sub-project C1) adds, on top of the unchanged shape
+	above: ``schema_version``, a per-user ``context`` block (from ``Jarvis Chat
+	Session`` snapshots - see ``usage._context_capacity_and_pct``) and a
+	top-level ``users_daily`` list (from ``Jarvis Turn Usage``, grouped by
+	user/day/model, last 35 days including today). Both are additive and
+	optional per the pinned contract: an old-shape rollup (no Turn Usage /
+	Chat Session data at all) still round-trips, ``context`` fields going null
+	and ``users_daily`` going empty rather than either key being fabricated."""
 	month = usage.current_month_key()
 	start, next_month = _month_range(month)
 	rows = frappe.get_all(
@@ -81,6 +104,7 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 	per_model_by_user = _per_model_totals([s.user for s in rows], month)
 	turn_aggregates_by_user = _turn_usage_user_aggregates(start, next_month)
 	top_tools_by_user, tool_calls_by_user, top_tools_tenant = _tool_message_aggregates(start, next_month)
+	context_by_user = _context_by_user([s.user for s in rows])
 	users = []
 	for s in rows:
 		agg = turn_aggregates_by_user.get(s.user, {})
@@ -101,13 +125,16 @@ def _build_rollup(cap: int = _MAX_USERS) -> tuple[dict, bool]:
 				# Turn Usage - see that function's docstring (finding #2).
 				"tool_calls": tool_calls_by_user.get(s.user, 0),
 				"top_tools": top_tools_by_user.get(s.user, []),
+				"context": context_by_user.get(s.user, _EMPTY_CONTEXT),
 			}
 		)
 	rollup = {
 		"month_key": month,
+		"schema_version": SCHEMA_VERSION,
 		"users": users,
 		"by_profile": _by_profile(start, next_month),
 		"top_tools": top_tools_tenant,
+		"users_daily": _users_daily_rollup(),
 	}
 	return rollup, truncated
 
@@ -357,6 +384,174 @@ def _per_model_totals(users: list[str], month: str) -> dict[str, dict[str, dict]
 			"out": int(r.out_ or 0),
 		}
 	return out
+
+
+# Contract default for a user with no Jarvis Chat Session data at all: the
+# object is always present (never omitted), with every field null/zero per
+# the pinned contract ("capacity null when no session has reported one").
+_EMPTY_CONTEXT = {
+	"used_max": 0,
+	"capacity": None,
+	"pct_max": None,
+	"sessions_over_80": 0,
+	"last_seen_at": None,
+}
+
+
+def _iso_utc_z(value) -> str | None:
+	"""A stored ``Datetime`` value (naive, SYSTEM timezone - see
+	``frappe.utils.now_datetime``, the writer of ``Jarvis Chat
+	Session.last_usage_at``) as an ISO-8601 UTC string with a trailing ``Z``,
+	per the pinned contract's ``context.last_seen_at``. ``None``/falsy passes
+	through as ``None``."""
+	if not value:
+		return None
+	dt = frappe.utils.get_datetime(value)
+	aware = dt.replace(tzinfo=ZoneInfo(frappe.utils.get_system_timezone()))
+	return aware.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _context_by_user(users: list[str]) -> dict[str, dict]:
+	"""Per-user context-usage summary from ``Jarvis Chat Session`` snapshots
+	(the only writers of ``context_capacity`` / ``context_pct`` /
+	``last_total_tokens`` are ``usage.record_turn_usage`` and
+	``usage.refresh_session_snapshots``).
+
+	``used_max`` is the largest ``last_total_tokens`` across the user's
+	sessions; ``capacity`` comes from whichever of the user's sessions most
+	recently reported a non-zero ``context_capacity`` (a user's sessions can,
+	in principle, run different models with different context windows, so
+	"the newest row with one" per the spec, not an arbitrary/first row);
+	``pct_max`` is recomputed from ``used_max`` / that ``capacity`` rather than
+	trusting any single session's stored ``context_pct``, since the session
+	that had the highest usage need not be the same one capacity was read
+	from. Returns ``{}`` for an empty ``users`` list; callers fall back to
+	``_EMPTY_CONTEXT`` per user."""
+	if not users:
+		return {}
+	summary = {
+		r.user: r
+		for r in frappe.db.sql(
+			"""
+			SELECT user,
+				   MAX(last_total_tokens) AS used_max,
+				   SUM(CASE WHEN context_pct >= %(over_pct)s THEN 1 ELSE 0 END) AS sessions_over_80,
+				   MAX(last_usage_at) AS last_seen_at
+			FROM `tabJarvis Chat Session`
+			WHERE user IN %(users)s
+			GROUP BY user
+			""",
+			{"users": tuple(users), "over_pct": _CONTEXT_OVER_PCT},
+			as_dict=True,
+		)
+	}
+	# COALESCE(last_usage_at, modified): refresh_session_snapshots only stamps
+	# last_usage_at when the gateway row carried updatedAt (see its docstring);
+	# a session refreshed without one still has a real context_capacity, and
+	# without the fallback it would silently lose the newest-row-wins ordering
+	# (NULL never wins a MAX/join match against a real timestamp).
+	capacity_by_user: dict[str, int] = {}
+	for r in frappe.db.sql(
+		"""
+		SELECT t1.user AS user, t1.context_capacity AS context_capacity
+		FROM `tabJarvis Chat Session` t1
+		INNER JOIN (
+			SELECT user, MAX(COALESCE(last_usage_at, modified)) AS max_at
+			FROM `tabJarvis Chat Session`
+			WHERE user IN %(users)s AND context_capacity > 0
+			GROUP BY user
+		) newest ON newest.user = t1.user AND newest.max_at = COALESCE(t1.last_usage_at, t1.modified)
+		WHERE t1.context_capacity > 0
+		""",
+		{"users": tuple(users)},
+		as_dict=True,
+	):
+		# A tie on last_usage_at (rare) just keeps whichever row SQL returns
+		# last; both would carry the same model's capacity in practice.
+		capacity_by_user[r.user] = int(r.context_capacity or 0)
+	out: dict[str, dict] = {}
+	for user in users:
+		row = summary.get(user)
+		used_max = int(row.used_max or 0) if row else 0
+		capacity = capacity_by_user.get(user)
+		out[user] = {
+			"used_max": used_max,
+			"capacity": capacity,
+			"pct_max": round(100 * used_max / capacity, 1) if capacity else None,
+			"sessions_over_80": int(row.sessions_over_80 or 0) if row else 0,
+			"last_seen_at": _iso_utc_z(row.last_seen_at) if row else None,
+		}
+	return out
+
+
+def _users_daily_rollup() -> list[dict]:
+	"""Per-(user, day, model) breakdown from ``Jarvis Turn Usage`` for the last
+	``_USERS_DAILY_WINDOW_DAYS`` days INCLUDING today (site-local day, matching
+	the ``day`` column - the pinned contract labels this "the bench day").
+
+	Only days with at least one turn are emitted (a plain GROUP BY over an
+	append-only table naturally skips empty days). One row per (email, day);
+	``per_model`` capped at ``_USERS_DAILY_PER_MODEL_CAP`` entries, highest
+	token volume first (the SQL ORDER BY ensures the first models folded into
+	each bucket below are the biggest ones) - a day's ``turns`` /
+	``tokens_in`` / ``tokens_out`` totals still cover EVERY model that day,
+	even one that overflowed the per_model cap; only the per-model breakdown
+	is trimmed. Total row count is capped at ``_USERS_DAILY_ROW_CAP``,
+	trimming the LOWEST-token rows first and logging once (spec: bench trims,
+	admin 400s if it ever still sees more)."""
+	today = frappe.utils.today()
+	start = frappe.utils.add_days(today, -(_USERS_DAILY_WINDOW_DAYS - 1))
+	grouped: dict[tuple[str, str], dict] = {}
+	for r in frappe.db.sql(
+		f"""
+		SELECT user, day, model,
+			   COUNT(*) AS turns,
+			   SUM(tokens_in) AS tokens_in,
+			   SUM(tokens_out) AS tokens_out
+		FROM `tab{TURN_USAGE}`
+		WHERE user != '' AND day >= %(start)s AND day <= %(today)s
+		GROUP BY user, day, model
+		ORDER BY user, day, (SUM(tokens_in) + SUM(tokens_out)) DESC
+		""",
+		{"start": start, "today": today},
+		as_dict=True,
+	):
+		email = (r.user or "").strip().lower()
+		if not email:
+			continue
+		key = (email, str(r.day))
+		bucket = grouped.setdefault(
+			key,
+			{"email": email, "day": str(r.day), "turns": 0, "tokens_in": 0, "tokens_out": 0, "per_model": {}},
+		)
+		tokens_in = int(r.tokens_in or 0)
+		tokens_out = int(r.tokens_out or 0)
+		bucket["turns"] += int(r.turns or 0)
+		bucket["tokens_in"] += tokens_in
+		bucket["tokens_out"] += tokens_out
+		model = (r.model or "").strip()
+		if model and len(bucket["per_model"]) < _USERS_DAILY_PER_MODEL_CAP:
+			bucket["per_model"][model] = {"in": tokens_in, "out": tokens_out}
+	return _trim_users_daily_rows(list(grouped.values()))
+
+
+def _trim_users_daily_rows(rows: list[dict], cap: int = _USERS_DAILY_ROW_CAP) -> list[dict]:
+	"""Enforce the pinned contract's ``users_daily`` row cap: at most ``cap``
+	rows, dropping the LOWEST-token rows first and logging once when trimming
+	actually occurs (spec: bench trims and warns; admin 400s if it ever still
+	sees more than the cap). Split out as its own pure function - unlike the
+	grouping above, this is a plain list transform, so cap behaviour is
+	unit-testable directly without seeding thousands of Turn Usage rows
+	against a live bench."""
+	if len(rows) <= cap:
+		return rows
+	rows = sorted(rows, key=lambda row: row["tokens_in"] + row["tokens_out"])
+	dropped = len(rows) - cap
+	kept = rows[dropped:]
+	frappe.logger("jarvis.usage_push").warning(
+		"users_daily rollup trimmed %s lowest-token rows (cap %s)", dropped, cap
+	)
+	return kept
 
 
 def push_usage_rollup() -> None:

--- a/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
@@ -21,6 +21,8 @@
     "output_tokens",
     "run_count",
     "last_total_tokens",
+    "context_capacity",
+    "context_pct",
     "last_usage_at"
   ],
   "fields": [
@@ -130,6 +132,22 @@
       "read_only": 1,
       "no_copy": 1,
       "description": "Snapshot of the gateway's totalTokens (context size) at the last recorded turn / sync."
+    },
+    {
+      "fieldname": "context_capacity",
+      "fieldtype": "Int",
+      "label": "Context Capacity",
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Snapshot of the gateway's contextTokens (the model's context-window capacity) at the last recorded turn / sync. 0 when the row never reported one."
+    },
+    {
+      "fieldname": "context_pct",
+      "fieldtype": "Percent",
+      "label": "Context Percent",
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "100 * last_total_tokens / context_capacity, rounded to 1 decimal. 0 when context_capacity is not yet known."
     },
     {
       "fieldname": "last_usage_at",

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -357,6 +357,53 @@ class TestErrorLogReader(ApiErrorsBase):
 		self.assertEqual(vrow["kind"], "exception")
 		self.assertIsNotNone(result["watermark"])
 
+	# -- C1: user_ref from Error Log.owner (code-level exceptions) ---------- #
+	def test_user_ref_unit(self):
+		self.assertEqual(api_errors._error_log_user_ref(USER), USER)
+		self.assertEqual(api_errors._error_log_user_ref("Administrator"), "")
+		self.assertEqual(api_errors._error_log_user_ref("Guest"), "")
+		self.assertEqual(api_errors._error_log_user_ref(None), "")
+		self.assertEqual(api_errors._error_log_user_ref(""), "")
+
+	def test_collect_error_log_sets_user_ref_from_real_owner(self):
+		# `since` pinned to just before the insert (not None): on a live-used
+		# site collect_error_log(since=None) scans oldest-first and a fresh row
+		# can fall outside the `limit` window, same trap the neighbouring
+		# jarvis-origin test above doesn't yet guard against.
+		since = str(frappe.utils.now_datetime())
+		tb = (
+			"Traceback (most recent call last):\n"
+			'  File "/home/x/apps/jarvis/jarvis/chat/api.py", line 1, in f\n'
+			"    boom()\n"
+			"ValueError: real owner boom"
+		)
+		with _as(USER):
+			doc = frappe.get_doc({"doctype": "Error Log", "method": "jarvis.chat.api.f", "error": tb})
+			doc.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Error Log", doc.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		result = api_errors.collect_error_log(since=since, limit=500)
+		row = next(r for r in result["rows"] if "real owner boom" in r["stack"])
+		self.assertEqual(row["user_ref"], USER)
+
+	def test_collect_error_log_blanks_user_ref_for_administrator_owner(self):
+		since = str(frappe.utils.now_datetime())
+		tb = (
+			"Traceback (most recent call last):\n"
+			'  File "/home/x/apps/jarvis/jarvis/chat/api.py", line 2, in g\n'
+			"    boom()\n"
+			"TypeError: admin owner boom"
+		)
+		# No _as() wrapper: the test runner's session user (Administrator) is
+		# stamped as owner, which must NOT be forwarded as a per-user attribution.
+		doc = frappe.get_doc({"doctype": "Error Log", "method": "jarvis.chat.api.g", "error": tb})
+		doc.insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Error Log", doc.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		result = api_errors.collect_error_log(since=since, limit=500)
+		row = next(r for r in result["rows"] if "admin owner boom" in r["stack"])
+		self.assertEqual(row["user_ref"], "")
+
 
 # --------------------------------------------------------------------------- #
 # Push job — self-gating + never-raise

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -102,6 +102,7 @@ class TestTurnUsage(FrappeTestCase):
 			"inputTokens": 0,
 			"outputTokens": 0,
 			"totalTokens": 0,
+			"contextTokens": 0,
 			"model": "gpt-5.5",
 			"modelProvider": "openai",
 		}
@@ -144,6 +145,57 @@ class TestTurnUsage(FrappeTestCase):
 		self.assertEqual(row.cache_read, 0)
 		self.assertEqual(row.cache_write, 0)
 		self.assertEqual(row.cache_reported, 0)
+
+	# -- (a2) C1: contextTokens -> context_capacity / context_pct on the session #
+	def test_recorded_row_stores_context_capacity_and_pct(self):
+		# Live fact (2026-09-04): contextTokens is the model's context-window
+		# CAPACITY, distinct from totalTokens (context tokens actually USED).
+		_make_session("agent:tu-ctx", USER_A)
+		outcome = usage.record_turn_usage(
+			"agent:tu-ctx",
+			self._row(inputTokens=10, outputTokens=5, totalTokens=116399, contextTokens=200000),
+		)
+		self.assertEqual(outcome, usage.USAGE_RECORDED)
+		row = frappe.db.get_value(
+			SESSION,
+			{"session_key": "agent:tu-ctx"},
+			["last_total_tokens", "context_capacity", "context_pct"],
+			as_dict=True,
+		)
+		self.assertEqual(row.last_total_tokens, 116399)
+		self.assertEqual(row.context_capacity, 200000)
+		self.assertEqual(row.context_pct, 58.2)
+
+	def test_recorded_row_no_capacity_reported_leaves_pct_zero(self):
+		# A row that never reports contextTokens (missing/zero) must not
+		# fabricate a percentage.
+		_make_session("agent:tu-ctx-none", USER_A)
+		usage.record_turn_usage(
+			"agent:tu-ctx-none", self._row(inputTokens=1, outputTokens=1, totalTokens=500)
+		)
+		row = frappe.db.get_value(
+			SESSION,
+			{"session_key": "agent:tu-ctx-none"},
+			["context_capacity", "context_pct"],
+			as_dict=True,
+		)
+		self.assertEqual(row.context_capacity, 0)
+		self.assertEqual(row.context_pct, 0)
+
+	def test_refresh_session_snapshots_stores_context_capacity_and_pct(self):
+		_make_session("agent:tu-ctx-sync", USER_A)
+		usage.refresh_session_snapshots(
+			[{"key": "agent:tu-ctx-sync", "totalTokens": 50000, "contextTokens": 200000}]
+		)
+		row = frappe.db.get_value(
+			SESSION,
+			{"session_key": "agent:tu-ctx-sync"},
+			["last_total_tokens", "context_capacity", "context_pct"],
+			as_dict=True,
+		)
+		self.assertEqual(row.last_total_tokens, 50000)
+		self.assertEqual(row.context_capacity, 200000)
+		self.assertEqual(row.context_pct, 25.0)
 
 	# -- (b) VALID_ZERO path still writes a row (attribution, zero tokens) -- #
 	def test_valid_zero_row_writes_attribution(self):
@@ -262,6 +314,7 @@ def _seed_turn_row(
 	tool_calls: int = 0,
 	creation=None,
 	day=None,
+	model: str = "gpt-5.5",
 ) -> str:
 	"""Insert a bare Jarvis Turn Usage row (task U2 rollup tests): the rollup
 	builder consumes these rows directly, so seeding them straight (rather
@@ -270,7 +323,10 @@ def _seed_turn_row(
 	today (the real current month); pass an explicit day to land a row in a
 	synthetic month a test has pinned via current_month_key, keeping it
 	isolated from this bench's real Turn Usage traffic in the real current
-	month (see test_empty_month_yields_old_shape_plus_empty_new_fields)."""
+	month (see test_empty_month_yields_old_shape_plus_empty_new_fields).
+	``model`` (C1: per-model users_daily rollup) defaults to the same
+	"gpt-5.5" every other fixture in this module used before C1, so no
+	existing call site needs to change."""
 	doc = frappe.get_doc(
 		{
 			"doctype": TURN_USAGE,
@@ -278,7 +334,7 @@ def _seed_turn_row(
 			"user": user,
 			"profile_agent_id": profile_agent_id,
 			"profile_tier": "full",
-			"model": "gpt-5.5",
+			"model": model,
 			"tokens_in": tokens_in,
 			"tokens_out": tokens_out,
 			"cache_read": cache_read,
@@ -368,13 +424,22 @@ class TestUsageRollup(FrappeTestCase):
 		# chat traffic), so the CURRENT month is never genuinely empty here -
 		# pin the builder to a month key no fixture or real traffic can have
 		# written to, which is what "empty month" actually needs to exercise.
-		with patch("jarvis.chat.usage.current_month_key", return_value="2000-01"):
+		# users_daily (C1) is windowed on the last 35 REAL days, not on
+		# current_month_key, so it can't be pinned away the same way - it is
+		# patched here for the same live-traffic-pollution reason; its own
+		# grouping/window/cap behaviour gets dedicated hermetic tests below.
+		with (
+			patch("jarvis.chat.usage.current_month_key", return_value="2000-01"),
+			patch.object(usage_push, "_users_daily_rollup", return_value=[]),
+		):
 			rollup, truncated = usage_push._build_rollup()
 		self.assertFalse(truncated)
 		self.assertEqual(rollup["month_key"], "2000-01")
+		self.assertEqual(rollup["schema_version"], 2)
 		self.assertEqual(rollup["users"], [])
 		self.assertEqual(rollup["by_profile"], [])
 		self.assertEqual(rollup["top_tools"], [])
+		self.assertEqual(rollup["users_daily"], [])
 
 	# -- (b) per-user sums + profile attribution + cache_reported ----------- #
 	def test_per_user_sums_and_profile_attribution(self):
@@ -588,3 +653,176 @@ class TestUsageRollup(FrappeTestCase):
 		rollup, _ = usage_push._build_rollup()
 		self.assertEqual(len(rollup["top_tools"]), 15)
 		self.assertEqual([t["tool"] for t in rollup["top_tools"]], sorted(names)[:15])
+
+
+class TestUsageRollupContextAndUsersDaily(FrappeTestCase):
+	"""Sub-project C1, schema_version 2: the per-user ``context`` block and the
+	top-level ``users_daily`` list. Hermetic like TestUsageRollup - fixtures
+	are disposable and cleaned up via the module-level ``_cleanup``."""
+
+	def setUp(self):
+		self._orig_user = frappe.session.user
+		frappe.set_user("Administrator")
+		_ensure_user(USER_A)
+		_ensure_user(USER_B)
+		_cleanup()
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_cleanup()
+		frappe.db.commit()
+		frappe.set_user(self._orig_user)
+
+	def _seed_settings(self, user: str, tokens: int) -> None:
+		doc = usage.get_or_create_user_settings(user)
+		frappe.db.set_value(
+			USETT,
+			doc.name,
+			{
+				"usage_month": usage.current_month_key(),
+				"month_input_tokens": tokens,
+				"month_output_tokens": tokens,
+				"month_tokens": tokens * 2,
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	# -- context block: sourced from Jarvis Chat Session snapshots ---------- #
+	def test_context_block_from_chat_sessions(self):
+		self._seed_settings(USER_A, 10)
+		_make_session("agent:tu-roll-ctx1", USER_A)
+		_make_session("agent:tu-roll-ctx2", USER_A)
+		frappe.db.set_value(
+			SESSION,
+			{"session_key": "agent:tu-roll-ctx1"},
+			{
+				"last_total_tokens": 50000,
+				"context_capacity": 200000,
+				"context_pct": 25.0,
+				"last_usage_at": frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-10),
+			},
+			update_modified=False,
+		)
+		frappe.db.set_value(
+			SESSION,
+			{"session_key": "agent:tu-roll-ctx2"},
+			{
+				"last_total_tokens": 170000,
+				"context_capacity": 200000,
+				"context_pct": 85.0,
+				"last_usage_at": frappe.utils.now_datetime(),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		rollup, _ = usage_push._build_rollup()
+		ctx = {u["email"]: u for u in rollup["users"]}[USER_A]["context"]
+		self.assertEqual(ctx["used_max"], 170000)
+		self.assertEqual(ctx["capacity"], 200000)
+		self.assertEqual(ctx["pct_max"], 85.0)
+		self.assertEqual(ctx["sessions_over_80"], 1)
+		self.assertIsNotNone(ctx["last_seen_at"])
+		self.assertTrue(ctx["last_seen_at"].endswith("Z"))
+
+	def test_context_block_null_when_no_session_reported_capacity(self):
+		# A user with a settings row but no Chat Session that ever reported a
+		# capacity (e.g. pre-C1 sessions) must not fabricate one.
+		self._seed_settings(USER_A, 10)
+		rollup, _ = usage_push._build_rollup()
+		ctx = {u["email"]: u for u in rollup["users"]}[USER_A]["context"]
+		self.assertEqual(ctx, usage_push._EMPTY_CONTEXT)
+
+	# -- users_daily: grouping, window, per_model cap, email case ----------- #
+	def test_users_daily_rollup_groups_by_user_day_model(self):
+		today = frappe.utils.today()
+		yesterday = frappe.utils.add_days(today, -1)
+		_seed_turn_row("agent:tu-roll-ud1", USER_A, tokens_in=100, tokens_out=20, model="gpt-5.5", day=today)
+		_seed_turn_row(
+			"agent:tu-roll-ud2", USER_A, tokens_in=50, tokens_out=10, model="claude-sonnet", day=today
+		)
+		_seed_turn_row(
+			"agent:tu-roll-ud3", USER_A, tokens_in=30, tokens_out=5, model="gpt-5.5", day=yesterday
+		)
+		rows = usage_push._users_daily_rollup()
+		by_key = {(r["email"], r["day"]): r for r in rows}
+		today_row = by_key[(USER_A.lower(), str(today))]
+		self.assertEqual(today_row["turns"], 2)
+		self.assertEqual(today_row["tokens_in"], 150)
+		self.assertEqual(today_row["tokens_out"], 30)
+		self.assertEqual(
+			today_row["per_model"],
+			{"gpt-5.5": {"in": 100, "out": 20}, "claude-sonnet": {"in": 50, "out": 10}},
+		)
+		yest_row = by_key[(USER_A.lower(), str(yesterday))]
+		self.assertEqual(yest_row["turns"], 1)
+		self.assertEqual(yest_row["tokens_in"], 30)
+
+	def test_users_daily_rollup_window_is_35_days_including_today(self):
+		today = frappe.utils.today()
+		in_window_day = frappe.utils.add_days(today, -34)  # 35th day back - still inside
+		out_of_window_day = frappe.utils.add_days(today, -35)  # 36 days back - outside
+		_seed_turn_row("agent:tu-roll-win-in", USER_A, tokens_in=5, tokens_out=1, day=in_window_day)
+		_seed_turn_row("agent:tu-roll-win-out", USER_A, tokens_in=999, tokens_out=999, day=out_of_window_day)
+		rows = usage_push._users_daily_rollup()
+		days = {r["day"] for r in rows if r["email"] == USER_A.lower()}
+		self.assertIn(str(in_window_day), days)
+		self.assertNotIn(str(out_of_window_day), days)
+
+	def test_users_daily_email_lowercased(self):
+		today = frappe.utils.today()
+		_seed_turn_row("agent:tu-roll-case", "MixedCase@Example.Test", tokens_in=5, tokens_out=1, day=today)
+		rows = usage_push._users_daily_rollup()
+		emails = {r["email"] for r in rows if r["day"] == str(today)}
+		self.assertIn("mixedcase@example.test", emails)
+
+	def test_users_daily_per_model_capped_at_20_but_day_totals_cover_all(self):
+		today = frappe.utils.today()
+		for i in range(25):
+			_seed_turn_row(
+				f"agent:tu-roll-pm{i:02d}",
+				USER_A,
+				tokens_in=100 - i,
+				tokens_out=1,
+				model=f"model-{i:02d}",
+				day=today,
+			)
+		rows = usage_push._users_daily_rollup()
+		today_row = next(r for r in rows if r["email"] == USER_A.lower() and r["day"] == str(today))
+		self.assertEqual(today_row["turns"], 25)
+		self.assertEqual(len(today_row["per_model"]), usage_push._USERS_DAILY_PER_MODEL_CAP)
+		self.assertEqual(today_row["tokens_in"], sum(100 - i for i in range(25)))
+
+	def test_users_daily_rollup_empty_returns_empty_list(self):
+		# Hermetic (no real Turn Usage rows touched): the query itself is
+		# mocked away, isolating the "no rows at all" shape from this bench's
+		# live traffic.
+		with patch.object(frappe.db, "sql", return_value=[]):
+			self.assertEqual(usage_push._users_daily_rollup(), [])
+
+	# -- users_daily row cap: trims lowest-token rows first, no DB needed --- #
+	def test_trim_users_daily_rows_keeps_highest_token_rows(self):
+		rows = [
+			{
+				"email": f"u{i}@example.test",
+				"day": "2026-09-01",
+				"turns": 1,
+				"tokens_in": i,
+				"tokens_out": 0,
+				"per_model": {},
+			}
+			for i in range(10)
+		]
+		with patch.object(frappe, "logger") as mock_logger:
+			kept = usage_push._trim_users_daily_rows(rows, cap=5)
+		self.assertEqual(len(kept), 5)
+		self.assertEqual({r["tokens_in"] for r in kept}, {5, 6, 7, 8, 9})
+		mock_logger.return_value.warning.assert_called_once()
+
+	def test_trim_users_daily_rows_no_op_under_cap(self):
+		rows = [{"email": "u@example.test", "day": "2026-09-01", "turns": 1, "tokens_in": 1, "tokens_out": 0}]
+		with patch.object(frappe, "logger") as mock_logger:
+			kept = usage_push._trim_users_daily_rows(rows, cap=5000)
+		self.assertEqual(kept, rows)
+		mock_logger.assert_not_called()

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -222,27 +222,42 @@ class TestTurnUsage(FrappeTestCase):
 	# -- review fix 3: last_usage_at/modified reliably order "newest" even -- #
 	# -- when the gateway row carries no updatedAt --------------------------- #
 	def test_refresh_session_snapshots_stamps_last_usage_at_without_updated_at(self):
+		# last_usage_at means "last REAL usage" (test_user_settings.
+		# TestAdminSync.test_refreshes_snapshots_without_accumulating pins
+		# this: a session with no updatedAt keeps last_usage_at exactly as it
+		# was - a sweep must never fabricate a usage time from sync time).
+		# `modified`, unrelated to that meaning, must still advance on every
+		# sweep so "just synced" stays orderable.
 		_make_session("agent:tu-ctx-stamp", USER_A)
-		before = frappe.db.get_value(SESSION, {"session_key": "agent:tu-ctx-stamp"}, "last_usage_at")
-		self.assertIsNone(before, "a fresh session has never had a usage stamp")
-		# No "updatedAt" key at all - the branch that previously never touched
-		# last_usage_at / modified.
+		before = frappe.db.get_value(
+			SESSION, {"session_key": "agent:tu-ctx-stamp"}, ["last_usage_at", "modified"], as_dict=True
+		)
+		self.assertIsNone(before.last_usage_at, "a fresh session has never had a usage stamp")
+		# No "updatedAt" key at all - last_usage_at must stay None, not get
+		# fabricated from sync time.
 		usage.refresh_session_snapshots([{"key": "agent:tu-ctx-stamp", "totalTokens": 1000}])
 		after = frappe.db.get_value(
 			SESSION, {"session_key": "agent:tu-ctx-stamp"}, ["last_usage_at", "modified"], as_dict=True
 		)
-		self.assertIsNotNone(after.last_usage_at, "COALESCE(..., NOW()) must stamp a first usage time")
-		first_stamp = after.last_usage_at
-		first_modified = after.modified
-		# A second no-updatedAt sweep must PRESERVE the prior last_usage_at
-		# (COALESCE keeps the real stored value over a missing one) while
-		# still advancing `modified`, so "just synced" is still orderable.
+		self.assertIsNone(after.last_usage_at, "no updatedAt must not stamp last_usage_at")
+		self.assertNotEqual(after.modified, before.modified, "modified must still advance on every sweep")
+		# Once a real usage stamp exists (a row that DOES carry updatedAt), a
+		# later no-updatedAt sweep must PRESERVE it, not clobber it - COALESCE
+		# keeps the real stored value over a missing one, and `modified` keeps
+		# advancing regardless.
+		usage.refresh_session_snapshots(
+			[{"key": "agent:tu-ctx-stamp", "totalTokens": 1500, "updatedAt": 1700000000000}]
+		)
+		stamped = frappe.db.get_value(
+			SESSION, {"session_key": "agent:tu-ctx-stamp"}, ["last_usage_at", "modified"], as_dict=True
+		)
+		self.assertIsNotNone(stamped.last_usage_at)
 		usage.refresh_session_snapshots([{"key": "agent:tu-ctx-stamp", "totalTokens": 2000}])
 		again = frappe.db.get_value(
 			SESSION, {"session_key": "agent:tu-ctx-stamp"}, ["last_usage_at", "modified"], as_dict=True
 		)
-		self.assertEqual(again.last_usage_at, first_stamp, "last_usage_at must not be clobbered by NOW()")
-		self.assertNotEqual(again.modified, first_modified, "modified must still advance on every sweep")
+		self.assertEqual(again.last_usage_at, stamped.last_usage_at, "last_usage_at unchanged, not clobbered")
+		self.assertNotEqual(again.modified, stamped.modified, "modified must still advance on every sweep")
 
 	# -- (b) VALID_ZERO path still writes a row (attribution, zero tokens) -- #
 	def test_valid_zero_row_writes_attribution(self):

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -197,6 +197,53 @@ class TestTurnUsage(FrappeTestCase):
 		self.assertEqual(row.context_capacity, 200000)
 		self.assertEqual(row.context_pct, 25.0)
 
+	# -- review fix 1: a sweep row with no capacity must not clobber a ------ #
+	# -- previously known one with 0 ----------------------------------------- #
+	def test_refresh_session_snapshots_keeps_stored_capacity_when_row_has_none(self):
+		_make_session("agent:tu-ctx-keep", USER_A)
+		usage.refresh_session_snapshots(
+			[{"key": "agent:tu-ctx-keep", "totalTokens": 50000, "contextTokens": 200000}]
+		)
+		# A later sweep row for the same session that reports no contextTokens
+		# (e.g. the gateway omitted it this cycle) - last_total_tokens still
+		# moves (it is the row's own honest snapshot), but capacity/pct must
+		# NOT be zeroed out just because this particular row didn't carry one.
+		usage.refresh_session_snapshots([{"key": "agent:tu-ctx-keep", "totalTokens": 60000}])
+		row = frappe.db.get_value(
+			SESSION,
+			{"session_key": "agent:tu-ctx-keep"},
+			["last_total_tokens", "context_capacity", "context_pct"],
+			as_dict=True,
+		)
+		self.assertEqual(row.last_total_tokens, 60000, "the fresh snapshot always moves")
+		self.assertEqual(row.context_capacity, 200000, "stored capacity must survive a capacity-less row")
+		self.assertEqual(row.context_pct, 25.0, "stored pct must survive a capacity-less row")
+
+	# -- review fix 3: last_usage_at/modified reliably order "newest" even -- #
+	# -- when the gateway row carries no updatedAt --------------------------- #
+	def test_refresh_session_snapshots_stamps_last_usage_at_without_updated_at(self):
+		_make_session("agent:tu-ctx-stamp", USER_A)
+		before = frappe.db.get_value(SESSION, {"session_key": "agent:tu-ctx-stamp"}, "last_usage_at")
+		self.assertIsNone(before, "a fresh session has never had a usage stamp")
+		# No "updatedAt" key at all - the branch that previously never touched
+		# last_usage_at / modified.
+		usage.refresh_session_snapshots([{"key": "agent:tu-ctx-stamp", "totalTokens": 1000}])
+		after = frappe.db.get_value(
+			SESSION, {"session_key": "agent:tu-ctx-stamp"}, ["last_usage_at", "modified"], as_dict=True
+		)
+		self.assertIsNotNone(after.last_usage_at, "COALESCE(..., NOW()) must stamp a first usage time")
+		first_stamp = after.last_usage_at
+		first_modified = after.modified
+		# A second no-updatedAt sweep must PRESERVE the prior last_usage_at
+		# (COALESCE keeps the real stored value over a missing one) while
+		# still advancing `modified`, so "just synced" is still orderable.
+		usage.refresh_session_snapshots([{"key": "agent:tu-ctx-stamp", "totalTokens": 2000}])
+		again = frappe.db.get_value(
+			SESSION, {"session_key": "agent:tu-ctx-stamp"}, ["last_usage_at", "modified"], as_dict=True
+		)
+		self.assertEqual(again.last_usage_at, first_stamp, "last_usage_at must not be clobbered by NOW()")
+		self.assertNotEqual(again.modified, first_modified, "modified must still advance on every sweep")
+
 	# -- (b) VALID_ZERO path still writes a row (attribution, zero tokens) -- #
 	def test_valid_zero_row_writes_attribution(self):
 		_make_session("agent:tu-zero", USER_A, profile_agent_id="", profile_tier="full")
@@ -211,6 +258,46 @@ class TestTurnUsage(FrappeTestCase):
 		self.assertEqual(rows[0].user, USER_A)
 		self.assertEqual(rows[0].tokens_in, 0)
 		self.assertEqual(rows[0].tokens_out, 0)
+
+	# -- review fix 4: VALID_ZERO must still refresh the context snapshot --- #
+	def test_valid_zero_row_refreshes_context_snapshot(self):
+		_make_session("agent:tu-zero-ctx", USER_A)
+		outcome = usage.record_turn_usage(
+			"agent:tu-zero-ctx",
+			self._row(inputTokens=0, outputTokens=0, totalTokens=42000, contextTokens=200000),
+		)
+		self.assertEqual(outcome, usage.USAGE_VALID_ZERO)
+		row = frappe.db.get_value(
+			SESSION,
+			{"session_key": "agent:tu-zero-ctx"},
+			["last_total_tokens", "context_capacity", "context_pct", "last_usage_at"],
+			as_dict=True,
+		)
+		self.assertEqual(row.last_total_tokens, 42000)
+		self.assertEqual(row.context_capacity, 200000)
+		self.assertEqual(row.context_pct, 21.0)
+		self.assertIsNotNone(row.last_usage_at)
+
+	def test_valid_zero_row_no_capacity_does_not_clobber_stored_one(self):
+		# Same no-clobber guard as refresh_session_snapshots (fix 1), on the
+		# record_turn_usage VALID_ZERO path.
+		_make_session("agent:tu-zero-keep", USER_A)
+		usage.record_turn_usage(
+			"agent:tu-zero-keep",
+			self._row(inputTokens=1, outputTokens=1, totalTokens=50000, contextTokens=200000),
+		)
+		usage.record_turn_usage(
+			"agent:tu-zero-keep", self._row(inputTokens=0, outputTokens=0, totalTokens=51000)
+		)
+		row = frappe.db.get_value(
+			SESSION,
+			{"session_key": "agent:tu-zero-keep"},
+			["last_total_tokens", "context_capacity", "context_pct"],
+			as_dict=True,
+		)
+		self.assertEqual(row.last_total_tokens, 51000)
+		self.assertEqual(row.context_capacity, 200000)
+		self.assertEqual(row.context_pct, 25.0)
 
 	# -- (c) RETRY path writes nothing ---------------------------------------- #
 	def test_retry_path_writes_nothing(self):
@@ -733,6 +820,112 @@ class TestUsageRollupContextAndUsersDaily(FrappeTestCase):
 		rollup, _ = usage_push._build_rollup()
 		ctx = {u["email"]: u for u in rollup["users"]}[USER_A]["context"]
 		self.assertEqual(ctx, usage_push._EMPTY_CONTEXT)
+
+	# -- review fix 2: pct is computed PER SESSION, not used_max paired with -#
+	# -- a DIFFERENT session's capacity --------------------------------------#
+	def test_context_block_picks_highest_pct_session_not_highest_used_session(self):
+		self._seed_settings(USER_A, 10)
+		# Session 1: a huge-context model, LOW pct despite the highest raw
+		# used_max (190000 tokens).
+		_make_session("agent:tu-roll-pct1", USER_A)
+		frappe.db.set_value(
+			SESSION,
+			{"session_key": "agent:tu-roll-pct1"},
+			{
+				"last_total_tokens": 190000,
+				"context_capacity": 1000000,
+				"last_usage_at": frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-10),
+			},
+			update_modified=False,
+		)
+		# Session 2: a small-context model, HIGH pct despite fewer raw tokens.
+		# The buggy pairing (highest used_max + "newest" capacity) would have
+		# reported used_max=190000 against capacity=100000 -> a nonsensical
+		# 190% - or, if session 1 happened to be "newest", the right capacity
+		# by luck; this fixture makes session 2 the newest too, so the OLD
+		# code's "capacity from the newest row" would have picked session 2's
+		# capacity (100000) but still used_max from session 1 (190000).
+		_make_session("agent:tu-roll-pct2", USER_A)
+		frappe.db.set_value(
+			SESSION,
+			{"session_key": "agent:tu-roll-pct2"},
+			{
+				"last_total_tokens": 90000,
+				"context_capacity": 100000,
+				"last_usage_at": frappe.utils.now_datetime(),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		rollup, _ = usage_push._build_rollup()
+		ctx = {u["email"]: u for u in rollup["users"]}[USER_A]["context"]
+		# Session 2 has the higher OWN pct (90% vs 19%), so it must win -
+		# never a used_max/capacity pair that spans two different sessions.
+		self.assertEqual(ctx["used_max"], 90000)
+		self.assertEqual(ctx["capacity"], 100000)
+		self.assertEqual(ctx["pct_max"], 90.0)
+		self.assertEqual(ctx["sessions_over_80"], 1)
+
+	# -- review fix 5: users[].email lowercased, matching users_daily -------- #
+	def test_users_email_lowercased_in_rollup(self):
+		mixed_email = "MixedCase@Example.Test"
+		lower_email = mixed_email.lower()
+		_ensure_user(lower_email)
+		doc = frappe.get_doc({"doctype": USETT, "user": mixed_email, "owner": lower_email})
+		doc.insert(ignore_permissions=True)
+		# Frappe's own Link-field validation canonicalizes `user` to the DB's
+		# stored (lowercase) docname BEFORE autoname runs (base_document.py:
+		# "MySQL is case insensitive. Preserve case of the original docname"),
+		# so doc.name is already lowercase here - a normal insert can never
+		# seed a mixed-case row. Force the STORED row to mixed case directly
+		# (a legacy row / data anomaly is exactly what this fix defends
+		# against) so the test exercises _build_rollup's own lowering, not
+		# Frappe's.
+		self.assertEqual(doc.name, lower_email, "sanity: Frappe already lowercased this on insert")
+		frappe.db.sql(
+			"UPDATE `tabJarvis User Settings` SET name=%(mixed)s, user=%(mixed)s WHERE name=%(lower)s",
+			{"mixed": mixed_email, "lower": lower_email},
+		)
+
+		def _cleanup_mixed_case_row():
+			frappe.db.sql(
+				"DELETE FROM `tabJarvis User Settings` WHERE name=%(mixed)s", {"mixed": mixed_email}
+			)
+			frappe.db.commit()
+
+		self.addCleanup(_cleanup_mixed_case_row)
+		frappe.db.set_value(
+			USETT,
+			mixed_email,
+			{
+				"usage_month": usage.current_month_key(),
+				"month_input_tokens": 1,
+				"month_output_tokens": 1,
+				"month_tokens": 2,
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		rollup, _ = usage_push._build_rollup()
+		emails = [u["email"] for u in rollup["users"]]
+		self.assertIn(lower_email, emails)
+		self.assertNotIn(mixed_email, emails)
+
+	# -- review fix 6: the UTC ZoneInfo is built once at module level -------- #
+	def test_iso_utc_z_reuses_module_level_utc_zoneinfo(self):
+		from zoneinfo import ZoneInfo as RealZoneInfo
+
+		calls = []
+
+		def spy(key):
+			calls.append(key)
+			return RealZoneInfo(key)
+
+		with patch("jarvis.chat.usage_push.ZoneInfo", side_effect=spy):
+			usage_push._iso_utc_z(frappe.utils.now_datetime())
+			usage_push._iso_utc_z(frappe.utils.now_datetime())
+		self.assertNotIn("UTC", calls, "UTC must come from the module-level _UTC, not a fresh ZoneInfo call")
+		self.assertIsInstance(usage_push._UTC, RealZoneInfo)
 
 	# -- users_daily: grouping, window, per_model cap, email case ----------- #
 	def test_users_daily_rollup_groups_by_user_day_model(self):


### PR DESCRIPTION
## Summary

The daily usage push now carries per-user daily buckets and context fullness, so the admin fleet console can show who uses Jarvis most, whose context is filling up, and who hits errors. No customer-facing UI changes.

- `Jarvis Chat Session` gains `context_capacity` and `context_pct`, written from the agent's `contextTokens` on every turn and on the admin usage sync.
- `push_usage_rollup` sends `schema_version` 2, a per-user `context` block, and `users_daily` (last 35 days, active days only, capped at 5000 rows). Older admins ignore the new keys.
- Code exceptions forwarded by the error push now carry the Error Log owner as `user_ref`.

Admin side: jarvis-admin-v2 usage dashboard PRs (backend and SPA).

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_014XnuuU2sGmbjwUzWim7xM9
