### PR TITLE
fix(chat): never refuse a send on a stale RQ worker registry

### DIFF
--- a/frontend/src/lib/sendRejectionCopy.js
+++ b/frontend/src/lib/sendRejectionCopy.js
@@ -1,0 +1,32 @@
+// Human copy for a rejected send ({ ok: false, reason }). The server sends
+// machine codes for the gates it owns and plain sentences for one-off guards;
+// a code the SPA does not know must never reach a toast.
+const FALLBACK = "Couldn't send your message.";
+
+export function sendRejectionCopy(reason, agentName) {
+	const known = {
+		usage_limit: {
+			message: `You've reached your usage limit. Ask your ${agentName} admin to raise it.`,
+			type: "error",
+		},
+		llm_not_configured: {
+			message: "No AI model is connected. Connect one in Settings → AI models.",
+			type: "warning",
+		},
+		workspace_resetting: {
+			message: `${agentName} is being reset. Chat will be back in a few minutes.`,
+			type: "warning",
+		},
+		release_update_required: {
+			message: `${agentName} is being updated. Reload the page to continue.`,
+			type: "error",
+		},
+		subscription_suspended: {
+			message: "Your subscription has lapsed. Renew it to keep chatting.",
+			type: "error",
+		},
+	};
+	if (reason && known[reason]) return known[reason];
+	const sentence = typeof reason === "string" && reason.includes(" ") ? reason : "";
+	return { message: sentence || FALLBACK, type: "error" };
+}

--- a/frontend/src/lib/sendRejectionCopy.spec.js
+++ b/frontend/src/lib/sendRejectionCopy.spec.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { sendRejectionCopy } from "./sendRejectionCopy";
+
+const FALLBACK = "Couldn't send your message.";
+
+describe("sendRejectionCopy", () => {
+	it("maps usage_limit to the usage-limit copy", () => {
+		const r = sendRejectionCopy("usage_limit", "Jarvis");
+		expect(r.message).toContain("usage limit");
+		expect(r.message).toContain("Jarvis admin");
+		expect(r.type).toBe("error");
+	});
+
+	it("maps llm_not_configured to a warning that points at Settings", () => {
+		const r = sendRejectionCopy("llm_not_configured", "Jarvis");
+		expect(r.message).toContain("Settings");
+		expect(r.type).toBe("warning");
+	});
+
+	it("maps workspace_resetting to a warning naming the agent", () => {
+		const r = sendRejectionCopy("workspace_resetting", "Jarvis");
+		expect(r.message).toContain("Jarvis is being reset");
+		expect(r.type).toBe("warning");
+	});
+
+	it("maps release_update_required", () => {
+		expect(sendRejectionCopy("release_update_required", "Jarvis").message).toContain(
+			"being updated"
+		);
+	});
+
+	it("maps subscription_suspended", () => {
+		expect(sendRejectionCopy("subscription_suspended", "Jarvis").message).toContain(
+			"subscription"
+		);
+	});
+
+	it("shows a server sentence verbatim", () => {
+		const sentence = "A reply is already in progress.";
+		expect(sendRejectionCopy(sentence, "Jarvis").message).toBe(sentence);
+	});
+
+	it("never surfaces an unknown machine code", () => {
+		expect(sendRejectionCopy("insufficient_workers", "Jarvis").message).toBe(FALLBACK);
+	});
+
+	it("falls back when the reason is empty", () => {
+		expect(sendRejectionCopy("", "Jarvis").message).toBe(FALLBACK);
+		expect(sendRejectionCopy(undefined, "Jarvis").message).toBe(FALLBACK);
+	});
+});

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -402,112 +402,44 @@ describe("ChatView banner chain order", () => {
 		expect(applying).toBeLessThan(stuck);
 	});
 
-	it("orders the no-workers banner AFTER suspendedNotice (billing takes precedence, jarvis Task 8)", () => {
+	it("orders the soft workersWarnNotice banner AFTER suspendedNotice (billing takes precedence)", () => {
 		const suspended = chatSrc.indexOf('v-else-if="suspendedNotice"');
-		const workers = chatSrc.indexOf('v-else-if="workersNotice"');
-		expect(suspended, "ChatView must still render the suspendedNotice banner").not.toBe(-1);
-		expect(workers, "ChatView must render the workersNotice banner").not.toBe(-1);
-		expect(suspended).toBeLessThan(workers);
-	});
-
-	it("orders the soft workersWarnNotice banner AFTER the hard workersNotice block", () => {
-		// worker_blocked implies degraded, so the hard block must win the
-		// v-else-if race whenever both are true - the soft warning below it in
-		// the chain then only ever shows on its own.
-		const workers = chatSrc.indexOf('v-else-if="workersNotice"');
 		const warn = chatSrc.indexOf('v-else-if="workersWarnNotice"');
-		expect(workers, "ChatView must still render the workersNotice banner").not.toBe(-1);
+		expect(suspended, "ChatView must still render the suspendedNotice banner").not.toBe(-1);
 		expect(warn, "ChatView must render the workersWarnNotice banner").not.toBe(-1);
-		expect(workers).toBeLessThan(warn);
+		expect(suspended).toBeLessThan(warn);
 	});
 });
 
 /**
- * jarvis Task 8: insufficient_workers must be a PERSISTENT but SELF-HEALING
- * banner - unlike suspendedNotice (whose only exit is renewal), a dead worker
- * lane can come back on its own, and checkReady() is memoized (never re-polls),
- * so the banner cannot wait on a fresh readiness check to clear. Mounting
- * ChatView / driving send() is not viable here (same reasoning as the banner
- * chain order block above and dashboardOpen.test.js), so this pins the wiring
- * by source, the established technique for this SFC.
+ * The hard "no workers" block is gone: RQ's worker registry can read zero
+ * while every worker is alive (a worker hash that expired during a heartbeat
+ * gap comes back without its queues), so the server never refuses a send for
+ * it and the SPA must carry no branch for it. Source-pinned like the suites
+ * around it (mounting ChatView is not viable here).
  */
-describe("workersNotice self-heal (jarvis Task 8)", () => {
+describe("no hard workers block", () => {
 	const HERE = path.dirname(fileURLToPath(import.meta.url));
 	const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
 
-	it("raises the persistent banner when retry() is rejected for insufficient_workers", () => {
-		// retry() (~line 8234) sits earlier in the file than send() (~line 8467), so
-		// this is the FIRST occurrence of the reason check.
-		const idx = chatSrc.indexOf('r.reason === "insufficient_workers"');
-		expect(idx, "retry() must check r.reason === insufficient_workers").not.toBe(-1);
-		const nearby = chatSrc.slice(idx, idx + 320);
-		// Sets the persistent banner ref directly, not a toast that would vanish
-		// before the customer can act on it.
-		expect(nearby).toContain("workersNotice.value = WORKERS_BLOCKED_MSG");
+	it("carries no insufficient_workers branch in retry() or send()", () => {
+		expect(chatSrc).not.toContain('"insufficient_workers"');
 	});
 
-	it("mirrors the same insufficient_workers handling in send()", () => {
-		const first = chatSrc.indexOf('r.reason === "insufficient_workers"');
-		const second = chatSrc.indexOf('r.reason === "insufficient_workers"', first + 1);
-		expect(second, "send() must also check r.reason === insufficient_workers").not.toBe(-1);
-		expect(chatSrc.slice(second, second + 200)).toContain(
-			"workersNotice.value = WORKERS_BLOCKED_MSG"
-		);
+	it("renders no blocking workers banner", () => {
+		expect(chatSrc).not.toContain('v-else-if="workersNotice"');
+		expect(chatSrc).not.toContain("WORKERS_BLOCKED_MSG");
 	});
 
-	it("clears the banner on the next successful retry (self-heal, no reload)", () => {
-		// retry() sits earlier in the file than send(), so this is the FIRST
-		// occurrence of the clear.
-		const fnStart = chatSrc.indexOf("async function retry(messageId)");
-		const fnEnd = chatSrc.indexOf("\nasync function send(", fnStart);
-		expect(fnStart, "ChatView must still define retry()").not.toBe(-1);
-		expect(fnEnd, "ChatView must still define send() after retry()").not.toBe(-1);
-		const body = chatSrc.slice(fnStart, fnEnd);
-		const awaitIdx = body.indexOf("await api.retryMessage(messageId)");
-		const idx = body.indexOf("workersNotice.value = null");
-		expect(awaitIdx, "retry() must still await api.retryMessage").not.toBe(-1);
-		expect(idx, "retry() must clear workersNotice on a successful response").not.toBe(-1);
-		// Only AFTER the await (never optimistically, before the server has
-		// actually answered) and gated on r.ok !== false (a genuinely accepted
-		// retry), not folded into the rejection branch that raises the banner.
-		expect(idx).toBeGreaterThan(awaitIdx);
-		const before = body.slice(Math.max(0, idx - 120), idx);
-		expect(before).toContain("r.ok !== false");
-	});
-
-	it("also clears the banner on the next successful send (mirrors retry())", () => {
-		const first = chatSrc.indexOf("workersNotice.value = null");
-		const second = chatSrc.indexOf("workersNotice.value = null", first + 1);
-		expect(second, "send() must also clear workersNotice on a successful response").not.toBe(
-			-1
-		);
-		const before = chatSrc.slice(Math.max(0, second - 120), second);
-		expect(before).toContain("r.ok !== false");
-	});
-
-	it("never gates canSend on workersNotice (composer must stay enabled to self-heal)", () => {
-		// A disabled composer paired with a memoized (never re-polling) checkReady()
-		// could never recover without a full page reload, contradicting the banner's
-		// own "try again shortly" copy - the server gate, not the client, is the
-		// authority on whether a send is allowed through.
-		const start = chatSrc.indexOf("const canSend = computed(");
-		expect(start, "ChatView must still define canSend").not.toBe(-1);
-		const end = chatSrc.indexOf("\n);", start);
-		expect(chatSrc.slice(start, end)).not.toContain("workersNotice");
-	});
-
-	it("seeds workersNotice from the boot readiness poll's worker_blocked field", () => {
-		const idx = chatSrc.indexOf("r && r.worker_blocked");
-		expect(idx, "the boot checkReady().then() block must read r.worker_blocked").not.toBe(-1);
-		expect(chatSrc.slice(idx, idx + 80)).toContain("WORKERS_BLOCKED_MSG");
+	it("does not read a worker_blocked field from the readiness poll", () => {
+		expect(chatSrc).not.toContain("worker_blocked");
 	});
 });
 
 /**
- * Soft, non-blocking counterpart to workersNotice above: is_ready_for_chat's
- * worker_warning fires for degraded/under-provisioned workers, distinct from
- * the hard worker_blocked zero-workers state. Same source-proximity technique
- * as the workersNotice suite (mounting ChatView is not viable here either).
+ * Soft, non-blocking worker warning: is_ready_for_chat's worker_warning fires
+ * for degraded/under-provisioned workers. Same source-proximity technique as
+ * the suites above (mounting ChatView is not viable here either).
  */
 describe("workersWarnNotice self-heal (round 2 mainchat warning)", () => {
 	const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -519,7 +451,7 @@ describe("workersWarnNotice self-heal (round 2 mainchat warning)", () => {
 		expect(chatSrc.slice(idx, idx + 80)).toContain("WORKERS_WARN_MSG");
 	});
 
-	it("clears workersWarnNotice on the next successful retry, alongside workersNotice", () => {
+	it("clears workersWarnNotice on the next successful retry", () => {
 		const fnStart = chatSrc.indexOf("async function retry(messageId)");
 		const fnEnd = chatSrc.indexOf("\nasync function send(", fnStart);
 		expect(fnStart, "ChatView must still define retry()").not.toBe(-1);
@@ -527,11 +459,10 @@ describe("workersWarnNotice self-heal (round 2 mainchat warning)", () => {
 		const body = chatSrc.slice(fnStart, fnEnd);
 		const idx = body.indexOf("workersWarnNotice.value = null");
 		expect(idx, "retry() must clear workersWarnNotice on a successful response").not.toBe(-1);
-		// Same self-heal spot as workersNotice's own clear, immediately after it.
-		const notice = body.indexOf("workersNotice.value = null");
-		expect(notice).toBeGreaterThan(-1);
-		expect(idx).toBeGreaterThan(notice);
-		expect(idx - notice).toBeLessThan(80);
+		// Only after the server answered, gated on a genuinely accepted retry.
+		const awaitIdx = body.indexOf("await api.retryMessage(messageId)");
+		expect(idx).toBeGreaterThan(awaitIdx);
+		expect(body.slice(Math.max(0, idx - 120), idx)).toContain("r.ok !== false");
 	});
 
 	it("also clears workersWarnNotice on the next successful send (mirrors retry())", () => {
@@ -541,11 +472,8 @@ describe("workersWarnNotice self-heal (round 2 mainchat warning)", () => {
 			second,
 			"send() must also clear workersWarnNotice on a successful response"
 		).not.toBe(-1);
-		// Sits right after send()'s own workersNotice clear, same as retry() above.
-		const notice = chatSrc.indexOf("workersNotice.value = null", first + 1);
-		expect(notice).toBeGreaterThan(-1);
-		expect(second).toBeGreaterThan(notice);
-		expect(second - notice).toBeLessThan(80);
+		// Gated on a genuinely accepted send, same as retry() above.
+		expect(chatSrc.slice(Math.max(0, second - 120), second)).toContain("r.ok !== false");
 	});
 
 	it("never gates canSend on workersWarnNotice (composer must stay enabled - heads-up only)", () => {

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -274,6 +274,7 @@ import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards";
 import { listPendingConfirmations, confirmTool, dismissTool } from "@/api";
 import { agentName } from "@/branding";
 import { errHtml } from "@/lib/errors";
+import { sendRejectionCopy } from "@/lib/sendRejectionCopy";
 
 // get_dashboards_caps payload (creatable_scopes/manageable_roles feed the save
 // dialog; stt_enabled - when the backend sends it - gates the mic)
@@ -662,7 +663,8 @@ async function send(gotoMessageId = "") {
 			messages.value = messages.value.filter((m) => m.name !== tmpName);
 			if (!draft.value) draft.value = text;
 			forgetGotoClaim(gotoMessageId);
-			toast.error(r.reason || "Couldn't send your message.");
+			const { message, type } = sendRejectionCopy(r.reason, agentName);
+			(toast[type] || toast.error)(message);
 			return;
 		}
 		if (r.conversation_id && r.conversation_id !== conversation.value) {

--- a/frontend/src/utils/voiceSendGlue.test.js
+++ b/frontend/src/utils/voiceSendGlue.test.js
@@ -931,7 +931,7 @@ test("jarvis#496 source pin: ChatView clears _prefillSendContext only on the acc
 	// be textually after a bare "if (r && r.ok === false)" search, but sits BEFORE this closing
 	// sequence, so it fails here. The rejection block's final `return;` and closing brace are
 	// immediately followed by the workers-notice self-heal block's `if`, not directly by the
-	// "// Send accepted" comment (a workersNotice/workersWarnNotice self-heal block now sits
+	// "// Send accepted" comment (a workersWarnNotice self-heal block now sits
 	// between the two), so anchor on that sibling `if` instead of the comment.
 	const rejectBlockCloseIdx = sendSrc.indexOf("return;\n\t\t}\n\t\tif (r && r.ok !== false) {");
 	const clearIdx = sendSrc.indexOf("_prefillSendContext = null;");

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2471,23 +2471,10 @@
 						<button class="jv-btn jv-btn--sm" @click="goRenew">Renew</button>
 					</template>
 				</Banner>
-				<!-- No live background worker to run a turn. AFTER suspendedNotice (billing
-					 takes precedence) - ORDER MATTERS, pinned by readiness.spec.js. The
-					 composer stays enabled (see canSend): a send re-raises this if the lane
-					 is still dead, or clears it if the worker came back (self-heal). -->
-				<Banner
-					v-else-if="workersNotice"
-					type="warning"
-					title="Chat is paused"
-					:message="workersNotice"
-					style="margin-bottom: 10px"
-				/>
-				<!-- Soft counterpart to workersNotice above: worker_warning (degraded /
-					 under-provisioned workers) rather than the hard zero-workers block.
-					 AFTER workersNotice - ORDER MATTERS, pinned by readiness.spec.js: the
-					 block wins the v-else-if race whenever both are true (worker_blocked
-					 implies degraded), so this only ever shows on its own. Non-blocking -
-					 the composer stays enabled (see canSend), this is a heads-up only. -->
+				<!-- Soft worker warning: worker_warning (degraded / under-provisioned
+					 workers). AFTER suspendedNotice (billing takes precedence) - ORDER
+					 MATTERS, pinned by readiness.spec.js. Non-blocking - the composer stays
+					 enabled (see canSend), this is a heads-up only. -->
 				<Banner
 					v-else-if="workersWarnNotice"
 					type="warning"
@@ -4439,22 +4426,11 @@ watch(
 // Renew-banner copy when the subscription has lapsed; null while entitled.
 // The composer is disabled alongside it (no send can succeed while stopped).
 const suspendedNotice = ref(null);
-// Chat is blocked because the site has no live background worker to run a turn.
-// Persistent (not a toast), but UNLIKE suspendedNotice the composer stays enabled:
-// checkReady() is memoized and never re-polls, so a disabled composer could never
-// recover without a full reload. Instead this self-heals - a still-dead lane
-// re-raises it on the next rejected send, a recovered lane clears it on the next
-// successful one (see send()). Null while healthy.
-const workersNotice = ref(null);
-const WORKERS_BLOCKED_MSG =
-	"Chat is paused: no background workers are running to handle messages. Please try again shortly.";
-// Soft, non-blocking counterpart to workersNotice above: worker_warning fires
-// when workers are merely under-provisioned/degraded, distinct from the hard
-// worker_blocked zero-workers state. The composer stays enabled - canSend
-// must never gate on this (see the "never gates canSend" test) - this is a
-// heads-up only, not a stop sign. Self-heals the same way workersNotice does:
-// cleared on the next successful retry/send, never re-derived from a re-poll
-// (checkReady() is memoized).
+// Soft, non-blocking worker warning: worker_warning fires when workers are
+// under-provisioned/degraded. The composer stays enabled - canSend must never
+// gate on this (see the "never gates canSend" test) - this is a heads-up only,
+// not a stop sign. Self-heals: cleared on the next successful retry/send, never
+// re-derived from a re-poll (checkReady() is memoized). Null while healthy.
 const workersWarnNotice = ref(null);
 const WORKERS_WARN_MSG = `${agentName} is low on background workers, so answers may take longer. Add more workers to your bench to speed this up.`;
 // A DIFFERENT not-ready reason (container_provisioning - e.g. the connected LLM
@@ -8668,18 +8644,13 @@ async function retry(messageId) {
 			// not a toast that vanishes before they can renew.
 			if (r.reason === "subscription_suspended") {
 				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
-			} else if (r.reason === "insufficient_workers") {
-				// No live worker to run the retried turn - same persistent, self-healing
-				// banner a blocked send raises (see send()).
-				if (!workersNotice.value) workersNotice.value = WORKERS_BLOCKED_MSG;
 			} else {
 				// e.g. the single-flight guard ("a reply is already in progress").
 				notify(r.reason || "Couldn't retry that.", { type: "error" });
 			}
 		}
 		if (r && r.ok !== false) {
-			workersNotice.value = null; // a retry got through: workers are back
-			workersWarnNotice.value = null; // same self-heal for the soft warning
+			workersWarnNotice.value = null; // a retry got through: workers are back
 		}
 	} catch (e) {
 		sending.value = false;
@@ -8931,13 +8902,6 @@ async function send(textArg, resendAck) {
 				});
 				return;
 			}
-			// No live worker to run this turn: raise the persistent, self-healing
-			// banner (composer stays enabled - see canSend/workersNotice) rather than
-			// a toast that vanishes before the lane recovers.
-			if (r.reason === "insufficient_workers") {
-				if (!workersNotice.value) workersNotice.value = WORKERS_BLOCKED_MSG;
-				return;
-			}
 			notify(
 				// Period-neutral copy: "usage_limit" fires from BOTH the all-time
 				// aggregate cap (jarvis.chat.policy._over_total_limit) and the
@@ -8951,8 +8915,7 @@ async function send(textArg, resendAck) {
 			return;
 		}
 		if (r && r.ok !== false) {
-			workersNotice.value = null; // a send got through: workers are back
-			workersWarnNotice.value = null; // same self-heal for the soft warning
+			workersWarnNotice.value = null; // a send got through: workers are back
 		}
 		// Send accepted — the one-shot grounding/prefill context is now consumed.
 		// Cleared HERE, not before the await: a rejected send (r.ok === false, above)
@@ -10773,14 +10736,9 @@ onMounted(async () => {
 			// reason gets its own honest, CTA-less banner below.
 			suspendedNotice.value =
 				r && r.reason === "subscription_suspended" ? suspensionNotice(r) : null;
-			// Seed the workers banner from the same boot verdict. checkReady() is
-			// memoized and never re-polls, so this is a ONE-TIME seed only - the
-			// banner then self-heals through send()'s rejection/success branches,
-			// never through a re-check here.
-			workersNotice.value = r && r.worker_blocked ? WORKERS_BLOCKED_MSG : null;
-			// Same one-time seed for the soft counterpart: worker_warning is a
-			// distinct, non-blocking degraded-workers signal (see workersWarnNotice
-			// above). It also self-heals through send()/retry() only, never here.
+			// Seed the soft workers banner from the same boot verdict. checkReady() is
+			// memoized and never re-polls, so this is a ONE-TIME seed only - the banner
+			// then self-heals through send()/retry() success, never through a re-check.
 			workersWarnNotice.value = r && r.worker_warning ? WORKERS_WARN_MSG : null;
 		})
 		.catch(() => {});

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -768,28 +768,22 @@ def is_ready_for_chat() -> dict:
 	  reassurance (see ``_admin_chat_gate``, review plan 04 P0-6).
 	- ``None`` when ``ready`` is True.
 
-	Also carries two non-blocking worker-health fields, merged in AFTER the
+	Also carries one non-blocking worker-health field, merged in AFTER the
 	verdict above and never able to change ``ready``/``reason``:
 
 	- ``worker_warning`` (bool) - the background worker lane looks degraded
 	  (``jarvis.chat.pump.chat_worker_status()['degraded']``). Soft: banner only.
-	- ``worker_blocked`` (bool) - workers confidently read as zero
-	  (``...['blocked']``). Still non-blocking here - the hard block on actually
-	  SENDING a chat message lives in chat/policy.py, not in this readiness read.
 
-	Fails safe: any exception probing worker health leaves both fields False
+	Fails safe: any exception probing worker health leaves the field False
 	rather than raising or affecting the verdict above.
 	"""
 	verdict = _ready_verdict()
 	try:
 		from jarvis.chat.pump import chat_worker_status
 
-		w = chat_worker_status()
-		verdict["worker_warning"] = bool(w.get("degraded"))
-		verdict["worker_blocked"] = bool(w.get("blocked"))
+		verdict["worker_warning"] = bool(chat_worker_status().get("degraded"))
 	except Exception:
 		verdict.setdefault("worker_warning", False)
-		verdict.setdefault("worker_blocked", False)
 	return verdict
 
 

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -81,13 +81,10 @@ _BLOCK_SENTENCE = {
 # #468: a refusal that CLEARS ON ITS OWN within minutes leaves the slot due, so the
 # next hourly tick retries it (the sibling's O4 shape). Everything else is an
 # entitlement decision that cannot clear inside the hour — consume the slot, or the
-# cadence relogs the same dead end 24 times a day. ``insufficient_workers`` belongs
-# here too: it is a confidently-zero-workers snapshot that self-heals within the
-# worker lane's 20s debounce, not an entitlement decision.
+# cadence relogs the same dead end 24 times a day.
 _TRANSIENT_BLOCKS = {
 	"release_update_required",
 	"workspace_resetting",
-	"insufficient_workers",
 	BLOCK_DISPATCH_FAILED,
 }
 

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -9,9 +9,10 @@ this module's contract.
 Returns (True, None) on success or (False, reason: str) on rejection. The
 reason is a machine code the SPA maps to a human toast: ``"usage_limit"`` for
 enforcement, ``"subscription_suspended"`` for billing,
-``"release_update_required"`` while a release rollout is blocking this bench,
-and ``"insufficient_workers"`` when the site has confidently zero background
-workers able to run a chat turn.
+and ``"release_update_required"`` while a release rollout is blocking this
+bench. Worker health is never a gate here: RQ's worker registry can read zero
+while every worker is alive (see ``jarvis.chat.pump._registry_is_stale``), and a
+turn nobody picks up is the orphan sweep's job (``stale_scan``).
 """
 
 from __future__ import annotations
@@ -35,8 +36,6 @@ def validate_can_send(user: str, model: str | None = None) -> tuple[bool, str | 
 		return False, "workspace_resetting"
 	if _llm_not_configured():
 		return False, "llm_not_configured"
-	if _insufficient_workers():
-		return False, "insufficient_workers"
 	# Per-model cap: only when a concrete model is known. ``model`` is resolved
 	# in chat.api (which knows the conversation) and passed in as a plain string,
 	# so policy never imports turn_handler (no import cycle). Pool "Auto" resolves
@@ -131,34 +130,6 @@ def _llm_not_configured() -> bool:
 		try:
 			frappe.log_error(
 				title="jarvis policy: llm-configured check failed (allowing send)",
-				message=frappe.get_traceback(),
-			)
-		except Exception:
-			pass
-		return False
-
-
-def _insufficient_workers() -> bool:
-	"""True when the site has CONFIDENTLY zero background workers able to run a
-	chat turn (sustained past a grace window). Without this a send queues against
-	a dead worker lane and hangs with no feedback. Fails OPEN: a probe/import
-	error must never block a paying customer - only chat_worker_status's
-	debounced, confident 0-worker verdict blocks.
-
-	CI runs bench tests with NO live RQ workers, so the 0-worker reading is
-	genuinely confident there and would reject every chat-send test. Like
-	_llm_not_configured, the gate is inert under test unless a suite opts in via
-	``frappe.flags.test_worker_gate``."""
-	if frappe.flags.in_test and not frappe.flags.get("test_worker_gate"):
-		return False
-	try:
-		from jarvis.chat.pump import chat_worker_status
-
-		return bool(chat_worker_status().get("blocked"))
-	except Exception:
-		try:
-			frappe.log_error(
-				title="jarvis policy: worker check failed (allowing send)",
 				message=frappe.get_traceback(),
 			)
 		except Exception:

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -71,6 +71,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 import frappe
 
@@ -872,123 +873,114 @@ def _warn_provisioning_if_starved() -> None:
 #     that case. The strand only truly happens with a single worker doing
 #     everything, so this warns on total headcount instead. Surfaced as a
 #     non-blocking onboarding banner; chat still works.
-#   * BLOCKED   -> block sends. CONFIDENT zero live workers on the turn queue,
-#     sustained past a short grace window. This is the only guaranteed-hang shape
-#     (no worker can pick a turn up at all). Never fires on a probe error.
+#   * No hard block. RQ's registry can read zero workers while every worker is
+#     alive: a worker hash that expired during a heartbeat gap comes back with
+#     only `last_heartbeat` (no `queues`), and a queue-Redis restart empties
+#     `rq:workers` for good while the workers keep running. So a zero reading is
+#     never a send block; `_registry_is_stale` names that shape and the readers
+#     treat it as "unknown". A turn nobody picks up is the orphan sweep's job
+#     (stale_scan), not this probe's.
 
-_ZERO_GRACE_S = 20  # a 0 reading must persist this long before it blocks sends
-_ZERO_KEY = "jarvis:workers:zero_since"
+_HEARTBEAT_FRESH_S = 480  # RQ's default worker_ttl (420s) plus its heartbeat slack
 
 
 def _probe_worker_count(queue_name: str) -> "int | None":
 	"""Live RQ worker count on ``queue_name`` - like ``_live_worker_count`` but
 	returns ``None`` (not 0) on any probe trouble, so a caller can tell a
-	CONFIDENT zero apart from a broken probe and fail OPEN on the latter."""
+	CONFIDENT zero apart from a broken probe and fail OPEN on the latter.
+
+	A live worker with no queue names is such trouble: its registry hash was
+	recreated by a heartbeat after expiring, so which queues it serves is
+	unknown."""
 	try:
 		from frappe.utils.background_jobs import generate_qname, get_workers
 
+		workers = get_workers()
+		if any(not w.queue_names() for w in workers):
+			return None
 		qname = generate_qname(queue_name)
-		return sum(1 for w in get_workers() if qname in (w.queue_names() or []))
+		return sum(1 for w in workers if qname in w.queue_names())
 	except Exception:
 		return None
 
 
-def _zero_marker_cache_key() -> str:
+def _registry_is_stale() -> bool:
+	"""True when the RQ registry cannot be trusted: it lists no worker, or a
+	worker with no queues, while some worker still heartbeats. False on probe
+	trouble (the registry is then taken at face value)."""
 	try:
-		return f"{_ZERO_KEY}:{frappe.local.site}"
-	except Exception:
-		return _ZERO_KEY
+		from frappe.utils.background_jobs import get_workers
 
-
-def _clear_zero_marker() -> None:
-	try:
-		frappe.cache().delete_value(_zero_marker_cache_key())
-	except Exception:
-		pass
-
-
-def _force_zero_marker_age(age_s: int) -> None:
-	"""Test helper: rewind the zero-marker so it reads as ``age_s`` seconds old."""
-	from frappe.utils import add_to_date, now_datetime
-
-	frappe.cache().set_value(
-		_zero_marker_cache_key(),
-		add_to_date(now_datetime(), seconds=-age_s).isoformat(),
-		expires_in_sec=300,
-	)
-
-
-def _zero_persisted(grace_s: int) -> bool:
-	"""True once a 0-worker reading has persisted at least ``grace_s`` seconds.
-	First 0 sets the marker and returns False (debounce)."""
-	from frappe.utils import get_datetime, now_datetime, time_diff_in_seconds
-
-	key = _zero_marker_cache_key()
-	now = now_datetime()
-	try:
-		since = frappe.cache().get_value(key, expires=True)
-		if not since:
-			frappe.cache().set_value(key, now.isoformat(), expires_in_sec=300)
+		workers = get_workers()
+		if workers and all(w.queue_names() for w in workers):
 			return False
-		# Refresh the TTL while zero persists so a lane dead longer than the TTL
-		# never evicts the marker (which would briefly flip the block OFF and
-		# re-arm the grace every ~5 min). `since` is kept anchored to the first
-		# zero reading, so the grace calculation is unchanged.
-		frappe.cache().set_value(key, since, expires_in_sec=300)
-		return time_diff_in_seconds(now, get_datetime(since)) >= grace_s
+		return bool(_fresh_heartbeat_count())
 	except Exception:
-		return False  # cache trouble => fail OPEN (do not block)
-
-
-def _turn_workers_confidently_zero() -> bool:
-	try:
-		from jarvis.chat.api import _turn_queue
-
-		q = _turn_queue()
-	except Exception:
-		_clear_zero_marker()
 		return False
-	n = _probe_worker_count(q)
-	if n is None:
-		return False  # probe failed => fail OPEN, leave marker untouched
-	if n > 0:
-		_clear_zero_marker()
-		return False
-	return _zero_persisted(_ZERO_GRACE_S)
 
 
 def _total_live_workers() -> "int | None":
 	"""Count of ALL live RQ workers on this bench, across every queue - not just
-	the pump's hop/control lanes. Returns ``None`` (not 0) on any probe trouble
-	so the caller fails SAFE (not degraded) rather than reading a broken probe
-	as a real shortage."""
+	the pump's hop/control lanes. Falls back to heartbeat hashes when the registry
+	lists nobody (a queue-Redis restart empties ``rq:workers`` while the workers
+	keep running). Returns ``None`` (not 0) on any probe trouble so the caller
+	fails SAFE (not degraded) rather than reading a broken probe as a real
+	shortage."""
 	try:
 		from frappe.utils.background_jobs import get_workers
 
-		return len(get_workers())
+		return len(get_workers()) or _fresh_heartbeat_count()
 	except Exception:
 		return None
 
 
-def chat_worker_status() -> dict:
-	"""Worker health for the onboarding warning + chat send block. Fails SAFE:
-	on any trouble reports neither blocked nor degraded.
-
-	``degraded`` fires on fewer than 2 TOTAL live RQ workers (any queue), not the
-	stricter F1 "< 2 `long` workers" shape - see the block comment above for the
-	rationale (the pump already reroutes control jobs off `long` when it has < 2
-	workers, so that stricter rule over-warned). A blocked state is always at
-	least degraded too."""
+def _fresh_heartbeat_count() -> "int | None":
+	"""Workers whose registry hash carries a recent ``last_heartbeat``, found by
+	scanning ``rq:worker:*`` directly. Survives both registry failures: a hash
+	recreated without its queues still heartbeats, and a worker pruned from
+	``rq:workers`` still owns its hash. ``None`` on probe trouble."""
 	try:
-		blocked = _turn_workers_confidently_zero()
+		from frappe.utils.background_jobs import get_redis_conn
+
+		conn = get_redis_conn()
+		now = datetime.now(timezone.utc)
+		fresh = 0
+		for key in conn.scan_iter(match="rq:worker:*"):
+			seen = _heartbeat_time(conn.hget(key, "last_heartbeat"))
+			if seen and (now - seen).total_seconds() <= _HEARTBEAT_FRESH_S:
+				fresh += 1
+		return fresh
 	except Exception:
-		blocked = False
+		return None
+
+
+def _heartbeat_time(raw) -> "datetime | None":
+	"""Parse RQ's ``last_heartbeat`` (``%Y-%m-%dT%H:%M:%S.%fZ``, older releases
+	without the fraction) as an aware UTC datetime; None when absent or odd."""
+	if not raw:
+		return None
+	text = (raw.decode() if isinstance(raw, bytes) else str(raw)).rstrip("Z")
+	for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+		try:
+			return datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
+		except ValueError:
+			continue
+	return None
+
+
+def chat_worker_status() -> dict:
+	"""Worker health for the onboarding warning. Fails SAFE: on any trouble
+	reports not degraded.
+
+	``degraded`` fires on fewer than 2 TOTAL live RQ workers (any queue) - see
+	the block comment above. It is a banner, never a send block: the registry it
+	reads can misreport zero (``_registry_is_stale``)."""
 	try:
 		n = _total_live_workers()
 		degraded = n is not None and n < 2
 	except Exception:
 		degraded = False
-	return {"blocked": bool(blocked), "degraded": bool(blocked or degraded)}
+	return {"degraded": bool(degraded)}
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -889,34 +889,41 @@ def _probe_worker_count(queue_name: str) -> "int | None":
 	returns ``None`` (not 0) on any probe trouble, so a caller can tell a
 	CONFIDENT zero apart from a broken probe and fail OPEN on the latter.
 
-	A live worker with no queue names is such trouble: its registry hash was
-	recreated by a heartbeat after expiring, so which queues it serves is
-	unknown."""
+	A zero with a live worker that carries no queue names is such trouble: that
+	worker's registry hash was recreated by a heartbeat after expiring, so it
+	may well be the one serving this queue. A positive count stands regardless:
+	a bare worker elsewhere on the bench must not blank out real evidence."""
 	try:
 		from frappe.utils.background_jobs import generate_qname, get_workers
 
 		workers = get_workers()
-		if any(not w.queue_names() for w in workers):
-			return None
 		qname = generate_qname(queue_name)
-		return sum(1 for w in workers if qname in w.queue_names())
+		n = sum(1 for w in workers if qname in (w.queue_names() or []))
+		if n == 0 and any(not w.queue_names() for w in workers):
+			return None
+		return n
 	except Exception:
 		return None
 
 
-def _registry_is_stale() -> bool:
+def _registry_is_stale(workers=None) -> bool:
 	"""True when the RQ registry cannot be trusted: it lists no worker, or a
-	worker with no queues, while some worker still heartbeats. False on probe
-	trouble (the registry is then taken at face value)."""
+	worker with no queues, and the heartbeat scan either finds a live worker or
+	cannot say. Only a readable scan that finds nobody confirms the registry.
+	``workers`` lets a caller that already holds a registry snapshot reuse it,
+	so one sweep never reads Redis twice and disagrees with itself. Probe
+	trouble reads as stale: "unknown" must never become "nobody listens"."""
 	try:
-		from frappe.utils.background_jobs import get_workers
+		if workers is None:
+			from frappe.utils.background_jobs import get_workers
 
-		workers = get_workers()
+			workers = get_workers()
 		if workers and all(w.queue_names() for w in workers):
 			return False
-		return bool(_fresh_heartbeat_count())
+		fresh = _fresh_heartbeat_count()
+		return fresh is None or fresh > 0
 	except Exception:
-		return False
+		return True
 
 
 def _total_live_workers() -> "int | None":

--- a/jarvis/chat/stale_scan.py
+++ b/jarvis/chat/stale_scan.py
@@ -129,8 +129,15 @@ def _sweep_orphan_turns(now) -> int:
 
 	live_qnames = set()
 	try:
-		for w in get_workers():
-			live_qnames.update(w.queue_names() or [])
+		from jarvis.chat.pump import _registry_is_stale
+
+		if _registry_is_stale():
+			# Workers alive but unregistered (a heartbeat gap or a queue-Redis
+			# restart): the queue is draining toward them, never "nobody listens".
+			live_qnames = None
+		else:
+			for w in get_workers():
+				live_qnames.update(w.queue_names() or [])
 	except Exception:
 		live_qnames = None  # probe trouble: treat queued jobs as draining
 

--- a/jarvis/chat/stale_scan.py
+++ b/jarvis/chat/stale_scan.py
@@ -131,12 +131,14 @@ def _sweep_orphan_turns(now) -> int:
 	try:
 		from jarvis.chat.pump import _registry_is_stale
 
-		if _registry_is_stale():
+		workers = get_workers()
+		if _registry_is_stale(workers):
 			# Workers alive but unregistered (a heartbeat gap or a queue-Redis
-			# restart): the queue is draining toward them, never "nobody listens".
+			# restart), or unverifiable: the queue is draining toward them, never
+			# "nobody listens".
 			live_qnames = None
 		else:
-			for w in get_workers():
+			for w in workers:
 				live_qnames.update(w.queue_names() or [])
 	except Exception:
 		live_qnames = None  # probe trouble: treat queued jobs as draining

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -958,7 +958,7 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 			patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}),
 			patch(
 				"jarvis.chat.pump.chat_worker_status",
-				return_value={"blocked": False, "degraded": False, "workers": 3},
+				return_value={"degraded": False},
 			),
 		):
 			out = account.is_ready_for_chat()
@@ -969,7 +969,6 @@ class TestIsReadyForChatCohorts(FrappeTestCase):
 				"reason": None,
 				"billing_notice": {},
 				"worker_warning": False,
-				"worker_blocked": False,
 			},
 		)
 
@@ -1879,12 +1878,14 @@ class TestReadinessWorkerFields(FrappeTestCase):
 	def test_ready_dict_carries_worker_warning_without_flipping_ready(self):
 		with patch(
 			"jarvis.chat.pump.chat_worker_status",
-			return_value={"blocked": False, "degraded": True, "workers": 1},
+			return_value={"degraded": True},
 		):
 			r = account.is_ready_for_chat()
 			self.assertIn("worker_warning", r)
 			self.assertTrue(r["worker_warning"])
-			self.assertFalse(r.get("worker_blocked"))
+			# The hard zero-workers verdict is gone: the registry cannot be trusted
+			# for it (see pump._registry_is_stale), so readiness never carries it.
+			self.assertNotIn("worker_blocked", r)
 			# worker health must NOT change the ready/reason verdict
 			self.assertIn("ready", r)
 
@@ -1892,4 +1893,4 @@ class TestReadinessWorkerFields(FrappeTestCase):
 		with patch("jarvis.chat.pump.chat_worker_status", side_effect=RuntimeError):
 			r = account.is_ready_for_chat()
 			self.assertFalse(r.get("worker_warning"))
-			self.assertFalse(r.get("worker_blocked"))
+			self.assertNotIn("worker_blocked", r)

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch
 
-import frappe
 from frappe.tests.utils import FrappeTestCase
 
 import jarvis.account as account
@@ -255,41 +254,19 @@ class TestLlmConfiguredGate(FrappeTestCase):
 		self.assertIsNone(reason)
 
 
-class TestInsufficientWorkers(FrappeTestCase):  # reuse module base
-	def setUp(self):
-		frappe.flags.test_worker_gate = True  # opt into the real gate under test
-
-	def tearDown(self):
-		frappe.flags.test_worker_gate = False
-
-	def test_blocked_returns_reason(self):
-		with patch(
-			"jarvis.chat.pump.chat_worker_status",
-			return_value={"blocked": True, "degraded": True, "workers": 0},
-		):
-			self.assertTrue(policy._insufficient_workers())
-
-	def test_healthy_returns_false(self):
-		with patch(
-			"jarvis.chat.pump.chat_worker_status",
-			return_value={"blocked": False, "degraded": False, "workers": 4},
-		):
-			self.assertFalse(policy._insufficient_workers())
-
-	def test_fails_open_on_error(self):
-		with patch("jarvis.chat.pump.chat_worker_status", side_effect=RuntimeError):
-			self.assertFalse(policy._insufficient_workers())
-
-	def test_validate_can_send_surfaces_reason(self):
-		# A user that clears every OTHER gate, but has 0 workers, is blocked here.
+class TestWorkerRegistryNeverBlocks(FrappeTestCase):  # reuse module base
+	def test_validate_can_send_ignores_a_zero_worker_reading(self):
+		# The RQ registry can read "zero workers" while workers are alive (a worker
+		# hash that expired and came back without its queues), so a worker reading
+		# must never refuse a send. A user that clears every other gate goes through.
 		with (
 			patch.object(policy, "_over_total_limit", return_value=False),
 			patch.object(policy, "_subscription_suspended", return_value=False),
 			patch.object(policy, "_release_update_required", return_value=False),
 			patch.object(policy, "_workspace_resetting", return_value=False),
 			patch.object(policy, "_llm_not_configured", return_value=False),
-			patch.object(policy, "_insufficient_workers", return_value=True),
+			patch("jarvis.chat.pump._total_live_workers", return_value=0),
 		):
 			ok, reason = policy.validate_can_send("someone@acme.com")
-			self.assertFalse(ok)
-			self.assertEqual(reason, "insufficient_workers")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)

--- a/jarvis/tests/test_chat_stale_scan.py
+++ b/jarvis/tests/test_chat_stale_scan.py
@@ -200,11 +200,14 @@ class TestOrphanRedispatchOverload(FrappeTestCase):
 		with (
 			patch("frappe.utils.background_jobs.get_job_status", return_value="queued"),
 			patch("frappe.utils.background_jobs.get_job", return_value=job),
-			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]) as registry,
 			patch.object(pump, "_fresh_heartbeat_count", return_value=0),
 			patch.object(api, "_dispatch_turn", side_effect=lambda *a, **k: None),
 		):
 			stale_scan._sweep_orphan_turns(now_datetime())
+		# One registry snapshot per sweep: the staleness check and the queue map
+		# must not read Redis twice and disagree with each other.
+		self.assertEqual(registry.call_count, 1)
 		job.cancel.assert_called_once()
 		self.assertEqual(
 			int(frappe.db.get_value(MSG, uid, "was_recovered") or 0), 1, "heal consumed the strike"

--- a/jarvis/tests/test_chat_stale_scan.py
+++ b/jarvis/tests/test_chat_stale_scan.py
@@ -5,7 +5,7 @@ chat history on a dev site.
 """
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -165,6 +165,50 @@ class TestOrphanRedispatchOverload(FrappeTestCase):
 		frappe.db.sql("UPDATE `tabJarvis Chat Message` SET creation=%s WHERE name=%s", (old, doc.name))
 		frappe.db.commit()
 		return doc.name
+
+	def _queued_job(self):
+		job = MagicMock()
+		job.origin = "bench:long"
+		job.kwargs = {}
+		return job
+
+	def test_a_stale_registry_leaves_a_queued_orphan_alone(self):
+		# Workers alive but invisible in the RQ registry (bare or empty after a
+		# heartbeat gap or a queue-Redis restart): the queued job is draining toward
+		# them, so the sweep must not cancel and re-dispatch it.
+		from jarvis.chat import pump, stale_scan
+
+		uid = self._mk_orphan()
+		job = self._queued_job()
+		with (
+			patch("frappe.utils.background_jobs.get_job_status", return_value="queued"),
+			patch("frappe.utils.background_jobs.get_job", return_value=job),
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=2),
+		):
+			stale_scan._sweep_orphan_turns(now_datetime())
+		job.cancel.assert_not_called()
+		self.assertEqual(int(frappe.db.get_value(MSG, uid, "was_recovered") or 0), 0, "no heal")
+		self.assertEqual(frappe.db.count(self.TURN, {"conversation": self.conv}), 0, "no replacement Turn")
+
+	def test_a_truly_empty_registry_still_heals_a_queued_orphan(self):
+		# Nobody heartbeats: the queue really is dead, the existing heal path stands.
+		from jarvis.chat import api, pump, stale_scan
+
+		uid = self._mk_orphan()
+		job = self._queued_job()
+		with (
+			patch("frappe.utils.background_jobs.get_job_status", return_value="queued"),
+			patch("frappe.utils.background_jobs.get_job", return_value=job),
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=0),
+			patch.object(api, "_dispatch_turn", side_effect=lambda *a, **k: None),
+		):
+			stale_scan._sweep_orphan_turns(now_datetime())
+		job.cancel.assert_called_once()
+		self.assertEqual(
+			int(frappe.db.get_value(MSG, uid, "was_recovered") or 0), 1, "heal consumed the strike"
+		)
 
 	def test_overload_does_not_consume_healing_strike(self):
 		from jarvis.chat import admission, api, stale_scan

--- a/jarvis/tests/test_macro_scheduler.py
+++ b/jarvis/tests/test_macro_scheduler.py
@@ -314,18 +314,10 @@ class TestScheduledMacroCaps(MacroSchedulerBase):
 		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
 		self.assertEqual(after, before, "a rollout that clears in minutes cost the macro its slot")
 
-	def test_insufficient_workers_block_leaves_the_slot_due_for_a_retry(self):
-		# #468's TRANSIENT shape now also covers a confidently-zero-workers snapshot:
-		# it self-heals within the worker lane's debounce, so the slot must stay due
-		# for the next hourly tick rather than being consumed like an entitlement
-		# refusal.
-		m = _mk_macro(OWNER_OK, "workers-low")
-		before = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
-		with patch("jarvis.chat.policy.validate_can_send", return_value=(False, "insufficient_workers")):
-			self._run_due_gated()
-		self.assertEqual([r.status for r in _runs_for(m.name)], ["failed"])
-		after = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
-		self.assertEqual(after, before, "a worker shortage that clears in seconds cost the macro its slot")
+	def test_a_zero_worker_reading_is_not_a_block_reason_any_more(self):
+		# The RQ registry can misreport zero workers while they are alive, so chat
+		# no longer refuses sends for it; the scheduler must not expect that reason.
+		self.assertNotIn("insufficient_workers", macro_scheduler._TRANSIENT_BLOCKS)
 
 	def test_the_gate_creates_nothing_before_refusing(self):
 		# A refused run must leave no conversation and no intro message behind —

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -2138,14 +2138,16 @@ class TestConservativeAdmission(_PumpTestCase):
 
 
 class TestWorkerStatus(FrappeTestCase):  # reuse module base
-	def setUp(self):
-		pump._clear_zero_marker()
-
-	def tearDown(self):
-		pump._clear_zero_marker()
-
 	def test_probe_returns_none_on_error(self):
 		with patch("frappe.utils.background_jobs.get_workers", side_effect=RuntimeError):
+			self.assertIsNone(pump._probe_worker_count("long"))
+
+	def test_probe_returns_none_when_a_worker_lost_its_queues(self):
+		# An RQ worker hash that expired and was recreated by a heartbeat carries no
+		# `queues`. That is "unknown", never "not listening on this queue".
+		bare = MagicMock()
+		bare.queue_names.return_value = []
+		with patch("frappe.utils.background_jobs.get_workers", return_value=[bare]):
 			self.assertIsNone(pump._probe_worker_count("long"))
 
 	def test_total_live_workers_counts_all_queues(self):
@@ -2157,119 +2159,83 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 		with patch("frappe.utils.background_jobs.get_workers", side_effect=RuntimeError):
 			self.assertIsNone(pump._total_live_workers())
 
-	def test_healthy_is_not_blocked_not_degraded(self):
+	def test_total_live_workers_falls_back_to_heartbeats_when_the_registry_is_empty(self):
+		# A queue-Redis restart empties `rq:workers` while the workers keep running
+		# and heartbeating; their hashes are still there to count.
 		with (
-			patch.object(pump, "_probe_worker_count", return_value=4),
-			patch.object(pump, "_total_live_workers", return_value=4),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=2),
 		):
-			s = pump.chat_worker_status()
-			self.assertFalse(s["blocked"])
-			self.assertFalse(s["degraded"])
+			self.assertEqual(pump._total_live_workers(), 2)
 
-	def test_one_total_worker_degraded_not_blocked(self):
-		# 1 TOTAL live worker (any queue) -> degraded, even though the turn queue
-		# itself still shows a live worker (not blocked).
+	def test_fresh_heartbeat_count_reads_recent_worker_hashes(self):
+		from datetime import datetime, timedelta, timezone
+
+		now = datetime.now(timezone.utc)
+		recent = now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+		old = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+		conn = MagicMock()
+		conn.scan_iter.return_value = [b"rq:worker:a", b"rq:worker:b", b"rq:worker:c"]
+		conn.hget.side_effect = [recent.encode(), old.encode(), None]
+		with patch("frappe.utils.background_jobs.get_redis_conn", return_value=conn):
+			self.assertEqual(pump._fresh_heartbeat_count(), 1)
+
+	def test_fresh_heartbeat_count_none_on_error(self):
+		with patch("frappe.utils.background_jobs.get_redis_conn", side_effect=RuntimeError):
+			self.assertIsNone(pump._fresh_heartbeat_count())
+
+	def test_registry_is_stale_when_bare_but_a_worker_still_heartbeats(self):
+		bare = MagicMock()
+		bare.queue_names.return_value = []
 		with (
-			patch.object(pump, "_probe_worker_count", return_value=1),
-			patch.object(pump, "_total_live_workers", return_value=1),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
+			patch("frappe.utils.background_jobs.get_workers", return_value=[bare]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=1),
 		):
+			self.assertTrue(pump._registry_is_stale())
+
+	def test_registry_is_stale_when_empty_but_a_worker_still_heartbeats(self):
+		with (
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=1),
+		):
+			self.assertTrue(pump._registry_is_stale())
+
+	def test_registry_is_not_stale_without_heartbeats(self):
+		# Nobody heartbeats: the workers really are gone, the registry is right.
+		with (
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=0),
+		):
+			self.assertFalse(pump._registry_is_stale())
+
+	def test_registry_is_not_stale_when_workers_carry_queues(self):
+		w = MagicMock()
+		w.queue_names.return_value = ["bench:long"]
+		with (
+			patch("frappe.utils.background_jobs.get_workers", return_value=[w]),
+			patch.object(pump, "_fresh_heartbeat_count", side_effect=AssertionError("no scan needed")),
+		):
+			self.assertFalse(pump._registry_is_stale())
+
+	def test_healthy_is_not_degraded(self):
+		with patch.object(pump, "_total_live_workers", return_value=4):
 			s = pump.chat_worker_status()
-			self.assertFalse(s["blocked"])
-			self.assertTrue(s["degraded"])
+			self.assertFalse(s["degraded"])
+			self.assertNotIn("blocked", s)
+
+	def test_one_total_worker_is_degraded(self):
+		with patch.object(pump, "_total_live_workers", return_value=1):
+			self.assertTrue(pump.chat_worker_status()["degraded"])
 
 	def test_two_total_workers_not_degraded(self):
 		# The discriminating case: exactly 2 total workers must NOT warn (this is
 		# the F1 "1 long + 1 to run rerouted control jobs" shape that no longer
 		# strands, per `_control_queue`). Fails if the threshold were `<= 2`.
-		with (
-			patch.object(pump, "_probe_worker_count", return_value=2),
-			patch.object(pump, "_total_live_workers", return_value=2),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
-		):
-			s = pump.chat_worker_status()
-			self.assertFalse(s["blocked"])
-			self.assertFalse(s["degraded"])
+		with patch.object(pump, "_total_live_workers", return_value=2):
+			self.assertFalse(pump.chat_worker_status()["degraded"])
 
 	def test_total_worker_probe_error_not_degraded(self):
 		# Fail-safe: a probe error (_total_live_workers -> None) must never be
 		# read as a real shortage.
-		with (
-			patch.object(pump, "_probe_worker_count", return_value=4),
-			patch.object(pump, "_total_live_workers", return_value=None),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
-		):
-			s = pump.chat_worker_status()
-			self.assertFalse(s["blocked"])
-			self.assertFalse(s["degraded"])
-
-	def test_probe_error_never_blocks(self):
-		with (
-			patch.object(pump, "_probe_worker_count", return_value=None),
-			patch.object(pump, "_total_live_workers", return_value=4),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
-		):
-			self.assertFalse(pump.chat_worker_status()["blocked"])
-
-	def test_zero_workers_blocks_only_after_grace_and_is_degraded(self):
-		with (
-			patch.object(pump, "_probe_worker_count", return_value=0),
-			patch.object(pump, "_total_live_workers", return_value=0),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
-		):
-			# first observation: marker set, NOT yet blocked (debounce); 0 total
-			# workers is already degraded regardless of the blocked debounce.
-			s = pump.chat_worker_status()
-			self.assertFalse(s["blocked"])
-			self.assertTrue(s["degraded"])
-			# simulate the marker aging past the grace window
-			pump._force_zero_marker_age(pump._ZERO_GRACE_S + 5)
-			s = pump.chat_worker_status()
-			self.assertTrue(s["blocked"])
-			self.assertTrue(s["degraded"])  # a blocked state is always at least degraded
-
-	def test_recovery_clears_marker(self):
-		with (
-			patch.object(pump, "_probe_worker_count", return_value=0),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
-		):
-			pump.chat_worker_status()  # sets marker
-		# Age the ORIGINAL marker past grace before the recovery step. If the
-		# recovery reading below fails to clear it, this aged, still-live marker
-		# would make the later fresh 0-reading block IMMEDIATELY (no debounce),
-		# so the final assertion below only holds if recovery actually cleared it.
-		pump._force_zero_marker_age(pump._ZERO_GRACE_S + 5)
-		with (
-			patch.object(pump, "_probe_worker_count", return_value=3),
-			patch.object(pump, "_total_live_workers", return_value=3),
-			patch("jarvis.chat.api._turn_queue", return_value="long"),
-		):
-			self.assertFalse(pump.chat_worker_status()["blocked"])
-			# marker cleared: a later single 0 must re-arm the grace, not block instantly
-			with (
-				patch.object(pump, "_probe_worker_count", return_value=0),
-				patch.object(pump, "_total_live_workers", return_value=0),
-			):
-				self.assertFalse(pump.chat_worker_status()["blocked"])
-
-	def test_zero_still_present_refreshes_ttl(self):
-		"""When the marker is PRESENT and the reading is still zero, `_zero_persisted`
-		must RE-WRITE it (same `since`, fresh TTL) rather than leaving it untouched.
-		Without the refresh, a lane dead longer than the 300s TTL loses the marker in
-		Redis; the next zero reading re-seeds it from scratch and returns False, briefly
-		flipping the fail-closed chat block OFF for a fresh 20s grace window on a lane
-		that has been dead the whole time. This test fails if the refresh line is
-		removed (set_value would then never be called for a still-present marker)."""
-		fixed_since = "2020-01-01 00:00:00.000000"
-		mock_cache = MagicMock()
-		mock_cache.get_value.return_value = fixed_since
-		with patch.object(pump.frappe, "cache", return_value=mock_cache):
-			result = pump._zero_persisted(pump._ZERO_GRACE_S)
-		# `since` is ancient, so with grace elapsed this must report persisted.
-		self.assertTrue(result)
-		# The marker must be RE-WRITTEN with the SAME `since` and a fresh TTL -
-		# never left untouched while zero readings keep coming in.
-		mock_cache.set_value.assert_called_once_with(
-			pump._zero_marker_cache_key(), fixed_since, expires_in_sec=300
-		)
+		with patch.object(pump, "_total_live_workers", return_value=None):
+			self.assertFalse(pump.chat_worker_status()["degraded"])

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -2150,6 +2150,19 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 		with patch("frappe.utils.background_jobs.get_workers", return_value=[bare]):
 			self.assertIsNone(pump._probe_worker_count("long"))
 
+	def test_probe_keeps_a_confident_count_when_an_unrelated_worker_is_bare(self):
+		# One worker lost its queues, but another provably serves this queue: the
+		# positive evidence stands, so routing must not collapse to "unknown".
+		serving = MagicMock()
+		serving.queue_names.return_value = ["bench:long"]
+		bare = MagicMock()
+		bare.queue_names.return_value = []
+		with (
+			patch("frappe.utils.background_jobs.get_workers", return_value=[serving, bare]),
+			patch("frappe.utils.background_jobs.generate_qname", return_value="bench:long"),
+		):
+			self.assertEqual(pump._probe_worker_count("long"), 1)
+
 	def test_total_live_workers_counts_all_queues(self):
 		fake_workers = [MagicMock(), MagicMock(), MagicMock()]
 		with patch("frappe.utils.background_jobs.get_workers", return_value=fake_workers):
@@ -2199,6 +2212,25 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 			patch.object(pump, "_fresh_heartbeat_count", return_value=1),
 		):
 			self.assertTrue(pump._registry_is_stale())
+
+	def test_registry_is_stale_when_the_heartbeat_probe_fails(self):
+		# An empty registry plus an unreadable heartbeat scan is "unknown", never a
+		# confirmed zero: the orphan sweep must not cancel on it.
+		with (
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=None),
+		):
+			self.assertTrue(pump._registry_is_stale())
+
+	def test_registry_is_stale_takes_a_registry_snapshot(self):
+		# Callers that already hold the registry pass it in; no second read.
+		bare = MagicMock()
+		bare.queue_names.return_value = []
+		with (
+			patch("frappe.utils.background_jobs.get_workers", side_effect=AssertionError("no re-read")),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=1),
+		):
+			self.assertTrue(pump._registry_is_stale([bare]))
 
 	def test_registry_is_not_stale_without_heartbeats(self):
 		# Nobody heartbeats: the workers really are gone, the registry is right.


### PR DESCRIPTION
## Summary

Chat no longer refuses to send with `insufficient_workers` when the background workers are alive but RQ's worker registry has gone stale. Users on an affected bench got that error on every message until a worker restart; the dashboard builder showed it as a raw code.

## What changed
- The hard "zero workers" send block is removed. Worker health stays a soft banner only, and a turn nobody picks up remains the orphan sweep's job.
- A worker whose registry entry lost its queues now reads as "unknown", and the total worker count falls back to live heartbeat hashes when the registry is empty.
- The orphan sweep leaves queued turns alone while the registry is stale instead of cancelling them.
- The readiness verdict drops the `worker_blocked` field; the SPA drops the matching banner.
- The dashboard chat pane maps rejection reasons to copy, so no machine code reaches a toast.

## Risk and verification
- With workers truly gone, the first send hangs until the orphan sweep errors it after 3 minutes instead of an instant banner. Accepted: on the managed fleet the false positive was more common than the real case.
- Tests were written first and watched fail: policy, pump, stale scan, account and macro scheduler suites, plus two vitest specs. Verified on the live local bench in the stale state: gate allows, no degraded banner. Owner tested on e2e.localhost via `integration/demote-worker-block`.

<details><summary>Root cause</summary>

RQ keeps each worker in a Redis hash with a 420 s TTL refreshed by heartbeats. If the hash expires during a heartbeat gap (a laptop sleep locally; a container pause or a queue-Redis outage in production), the next heartbeat recreates it with only `last_heartbeat`, so `queue_names()` is empty. Any reader that hits the registry during the gap also prunes the worker from `rq:workers` for good. RQ never re-registers a worker after startup. `_probe_worker_count` read either shape as a confident zero on the `long` queue and, after a 20 s grace, blocked every send. Reproduced in isolation on rq 2.6.1; rq 1.15.1 and 2.12.0 behave the same. Same block exists on version-15 and version-16, hence the backport labels.

</details>

## Before / After

Before: the dashboard builder toasted the raw code on every send while the workers were alive.

<img width="1000" alt="before: raw insufficient_workers toast in the dashboard builder" src="https://github.com/user-attachments/assets/258a4fbb-fae3-4ce1-ac74-6434f6fe8fd8" />

After: the same builder on the same stale registry accepts the send and starts the turn.

<img width="1000" alt="after: dashboard builder send accepted, turn running" src="https://github.com/user-attachments/assets/0b08125a-ca70-4c13-b2c6-3a46f7be53b6" />

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01WSDfCaikikyY9jq3BhDvYz
