### PR TITLE
feat(release): Slice 2 — bench mirrors + exposes the update tier

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -129,6 +129,7 @@
   "release_notice_active",
   "latest_jarvis_version",
   "release_notice_message",
+  "release_notice_tier",
   "system_tab",
   "deployment_section",
   "deployment_mode",
@@ -937,6 +938,12 @@
    "fieldname": "release_notice_message",
    "fieldtype": "Small Text",
    "label": "Release Notice Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "release_notice_tier",
+   "fieldtype": "Data",
+   "label": "Release Notice Tier",
    "read_only": 1
   },
   {

--- a/jarvis/release_notice.py
+++ b/jarvis/release_notice.py
@@ -14,6 +14,7 @@ _FIELDS = (
 	"release_notice_active",
 	"latest_jarvis_version",
 	"release_notice_message",
+	"release_notice_tier",
 )
 _CHECK_CACHE_KEY = "jarvis:release_notice_checked"
 _CHECK_CACHE_TTL_S = 30
@@ -49,6 +50,9 @@ def persist(notice: dict) -> None:
 			"release_notice_active": 1 if n.get("active") else 0,
 			"latest_jarvis_version": n.get("version") or "",
 			"release_notice_message": n.get("message") or "",
+			# Back-compat: an old CP omits `tier`, so derive it from `active` -- a hard
+			# gate still reads "hard", everything else "none".
+			"release_notice_tier": n.get("tier") or ("hard" if n.get("active") else "none"),
 		}
 		current = frappe.db.get_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
 		if all(current.get(k) == v for k, v in fresh.items()):
@@ -64,12 +68,15 @@ def boot_payload() -> dict:
 	target = (row.get("latest_jarvis_version") or "").strip()
 	# Self-clear: this bench is already at the target, so don't wait on the control
 	# plane to say so - otherwise an unreachable or mis-credentialed admin would
-	# keep an updated tenant blocked with no way out.
-	active = bool(row.get("release_notice_active")) and not _already_current(target)
+	# keep an updated tenant blocked with no way out. Clears BOTH tiers.
+	current = _already_current(target)
+	active = bool(row.get("release_notice_active")) and not current
+	tier = "none" if current else (row.get("release_notice_tier") or ("hard" if active else "none"))
 	return {
 		"active": active,
 		"version": target,
 		"message": row.get("release_notice_message") or "",
+		"tier": tier,
 	}
 
 

--- a/jarvis/tests/test_release_notice.py
+++ b/jarvis/tests/test_release_notice.py
@@ -17,6 +17,7 @@ _FIELDS = (
 	"release_notice_active",
 	"latest_jarvis_version",
 	"release_notice_message",
+	"release_notice_tier",
 )
 
 
@@ -116,6 +117,37 @@ class TestBootPayload(FrappeTestCase):
 		self.assertFalse(p["active"])
 		self.assertEqual(p["version"], "")
 		self.assertEqual(p["message"], "")
+
+	# -- tier (Slice 2) -------------------------------------------------------
+
+	def test_persist_and_boot_carry_tier(self):
+		release_notice.persist({"active": 0, "tier": "soft", "version": NEWER, "message": "m"})
+		p = release_notice.boot_payload()
+		self.assertEqual(p["tier"], "soft")
+		self.assertFalse(p["active"])
+
+	def test_hard_tier_sets_active(self):
+		release_notice.persist({"active": 1, "tier": "hard", "version": NEWER, "message": "m"})
+		p = release_notice.boot_payload()
+		self.assertEqual(p["tier"], "hard")
+		self.assertTrue(p["active"])
+
+	def test_missing_tier_derives_from_active(self):
+		# Old CP omits the tier key -> derive it from active (a hard gate reads hard).
+		release_notice.persist({"active": 1, "version": NEWER, "message": "m"})
+		self.assertEqual(release_notice.boot_payload()["tier"], "hard")
+
+	def test_self_clear_zeroes_both_tiers(self):
+		# Bench already at target -> both active and tier clear, even a stored hard.
+		release_notice.persist({"active": 1, "tier": "hard", "version": __version__, "message": "m"})
+		p = release_notice.boot_payload()
+		self.assertFalse(p["active"])
+		self.assertEqual(p["tier"], "none")
+
+	def test_empty_notice_clears_tier(self):
+		release_notice.persist({"active": 1, "tier": "hard", "version": NEWER, "message": "m"})
+		release_notice.persist({})
+		self.assertEqual(release_notice.boot_payload()["tier"], "none")
 
 
 class TestVersionParse(FrappeTestCase):


### PR DESCRIPTION
Bench half of the app update-nudge (dark; the SPA renders nothing new this slice — the existing hard gate still rides the active field, unchanged). Consumes the CP new release_notice.tier and threads it through the local mirror + boot payload.

- Jarvis Settings: +release_notice_tier (read-only mirror field).
- persist(): stores tier; back-compat — an old CP omits it, so derive from active (hard if active else none).
- boot_payload(): returns tier; the local self-clear now zeroes BOTH active and tier when this bench is already at the target (never strand an updated tenant).
- tests: tier persist/boot, hard-tier-sets-active, missing-tier derive (old-CP skew), self-clear zeroes both tiers, empty-notice clears tier.

Backport to version-15/version-16 MUST carry jarvis_settings.json AND release_notice.py together — boot_payload reads the new column unguarded.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
