### PR TITLE
feat(onboarding): validate State ↔ Pincode ↔ GSTIN address consistency

### DIFF
--- a/frontend/src/onboarding/address.js
+++ b/frontend/src/onboarding/address.js
@@ -1,0 +1,197 @@
+// Address consistency for an India buyer: State, GSTIN and Pincode must agree. Mirrors the admin control
+// plane's billing._validate_billing_state (gst_place_of_supply.py), which itself mirrors India Compliance's
+// validate_pincode — so the SPA blocks the same bad address the plane rejects and the books would REVIEW,
+// and the customer is told BEFORE checkout instead of after.
+//
+// Pure module — no Vue, no `@/` alias, no imports at all — so `node --test` runs it standalone and the two
+// sides never drift on what "consistent" means. SELF-CONTAINED: it carries its OWN copy of the GST state and
+// pincode tables and does NOT depend on India Compliance being installed anywhere (a jarvis tenant may not
+// have IC). Keep the tables in lockstep with the plane (which carries the same copy).
+
+// GST state/UT code -> canonical name (India Compliance STATE_NUMBERS; 97 = Other Territory).
+// Exported for the exhaustive parity test (address.test.js) that guards against a transcription slip.
+export const STATE_BY_CODE = {
+	"01": "Jammu and Kashmir",
+	"02": "Himachal Pradesh",
+	"03": "Punjab",
+	"04": "Chandigarh",
+	"05": "Uttarakhand",
+	"06": "Haryana",
+	"07": "Delhi",
+	"08": "Rajasthan",
+	"09": "Uttar Pradesh",
+	10: "Bihar",
+	11: "Sikkim",
+	12: "Arunachal Pradesh",
+	13: "Nagaland",
+	14: "Manipur",
+	15: "Mizoram",
+	16: "Tripura",
+	17: "Meghalaya",
+	18: "Assam",
+	19: "West Bengal",
+	20: "Jharkhand",
+	21: "Odisha",
+	22: "Chhattisgarh",
+	23: "Madhya Pradesh",
+	24: "Gujarat",
+	26: "Dadra and Nagar Haveli and Daman and Diu",
+	27: "Maharashtra",
+	29: "Karnataka",
+	30: "Goa",
+	31: "Lakshadweep Islands",
+	32: "Kerala",
+	33: "Tamil Nadu",
+	34: "Puducherry",
+	35: "Andaman and Nicobar Islands",
+	36: "Telangana",
+	37: "Andhra Pradesh",
+	38: "Ladakh",
+	97: "Other Territory",
+};
+
+// name (lowercased) -> code. Accepts the bare "lakshadweep" alias (the state dropdown emits it) but the
+// canonical name stays "Lakshadweep Islands" — the same alias the control plane keeps. Null-prototype so a
+// crafted state name ("__proto__"/"constructor") can't resolve to an inherited Object member (defensive
+// hardening — the state field is a closed dropdown today, but this module must stay safe if reused).
+const CODE_BY_NAME = Object.create(null);
+for (const [code, name] of Object.entries(STATE_BY_CODE)) CODE_BY_NAME[name.toLowerCase()] = code;
+CODE_BY_NAME["lakshadweep"] = "31";
+
+// canonical state name -> first-3-digit pincode range(s), per the GST e-Invoice Master Codes (India
+// Compliance STATE_PINCODE_MAPPING, VERBATIM). A [lo, hi] is one range; an array of them is several.
+// Exported for the exhaustive parity test (address.test.js).
+export const STATE_PINCODE_MAPPING = {
+	"Jammu and Kashmir": [180, 194],
+	"Himachal Pradesh": [171, 177],
+	Punjab: [140, 160],
+	Chandigarh: [
+		[140, 140],
+		[160, 160],
+	],
+	Uttarakhand: [244, 263],
+	Haryana: [121, 136],
+	Delhi: [110, 110],
+	Rajasthan: [301, 345],
+	"Uttar Pradesh": [201, 285],
+	Bihar: [800, 855],
+	Sikkim: [737, 737],
+	"Arunachal Pradesh": [790, 792],
+	Nagaland: [797, 798],
+	Manipur: [795, 795],
+	Mizoram: [796, 796],
+	Tripura: [799, 799],
+	Meghalaya: [793, 794],
+	Assam: [781, 788],
+	"West Bengal": [700, 743],
+	Jharkhand: [813, 835],
+	Odisha: [751, 770],
+	Chhattisgarh: [490, 497],
+	"Madhya Pradesh": [450, 488],
+	Gujarat: [360, 396],
+	"Dadra and Nagar Haveli and Daman and Diu": [
+		[362, 362],
+		[396, 396],
+	],
+	Maharashtra: [400, 445],
+	Karnataka: [560, 591],
+	Goa: [403, 403],
+	"Lakshadweep Islands": [682, 682],
+	Kerala: [670, 695],
+	"Tamil Nadu": [600, 643],
+	Puducherry: [
+		[533, 533],
+		[605, 605],
+		[607, 607],
+		[609, 609],
+		[673, 673],
+	],
+	"Andaman and Nicobar Islands": [744, 744],
+	"Andhra Pradesh": [500, 535],
+	Telangana: [
+		[500, 509],
+		[518, 518],
+		[533, 533],
+	],
+	Ladakh: [
+		[180, 180],
+		[181, 181],
+		[184, 184],
+		[190, 191],
+		[194, 194],
+	],
+};
+
+// A valid Indian PIN is 6 digits and cannot start with 0 (mirrors India Compliance PINCODE_FORMAT).
+const PINCODE_RE = /^[1-9][0-9]{5}$/;
+
+function isIndia(country) {
+	const c = (country || "").trim().toLowerCase();
+	return !c || c === "india";
+}
+
+export function stateCodeFromGstin(gstin) {
+	const code = (gstin || "").trim().toUpperCase().slice(0, 2);
+	return STATE_BY_CODE[code] ? code : null;
+}
+
+export function stateCodeFromName(name) {
+	return CODE_BY_NAME[(name || "").trim().toLowerCase()] || null;
+}
+
+// The India Compliance canonical state name for this buyer, resolved GSTIN-FIRST (the way the books pick
+// place of supply), else the state name — accepting the alias forms ("Lakshadweep" -> "Lakshadweep
+// Islands"). null when neither resolves to a known GST state.
+function canonicalStateName({ gstin, state }) {
+	const code = stateCodeFromGstin(gstin) || stateCodeFromName(state);
+	return code ? STATE_BY_CODE[code] : null;
+}
+
+// Whether the pincode's first three digits are associated with the buyer's state, mirroring IC's
+// validate_pincode. True when CONSISTENT or NOT-CHECKABLE (blank/malformed pincode, a state that resolves to
+// no canonical name, or a canonical state absent from the map). False ONLY on a definite out-of-range miss.
+export function pincodeMatchesState(pincode, state) {
+	const pin = (pincode || "").trim();
+	if (!PINCODE_RE.test(pin)) return true; // blank/malformed: a separate check, not a consistency question
+	const canonical = canonicalStateName({ state }); // keyed on the STATE NAME, mirroring IC's validate_pincode
+	let ranges = STATE_PINCODE_MAPPING[canonical];
+	if (!ranges) return true; // state not in the map (some UTs / Other Territory) — mirrors IC's own skip
+	if (typeof ranges[0] === "number") ranges = [ranges]; // normalize a single [lo, hi] to a list of ranges
+	const firstThree = parseInt(pin.slice(0, 3), 10);
+	return ranges.some(([lo, hi]) => lo <= firstThree && firstThree <= hi);
+}
+
+/**
+ * The GSTIN-vs-state message (surfaced on the GSTIN field), or "". Fires only when BOTH the GSTIN state code
+ * and the state resolve to a known code and they differ — a valid 99/25/28 GSTIN has no known canonical
+ * state and is never flagged (review D3). Overseas / blank inputs pass.
+ */
+export function gstinStateError({ country, state, gstin } = {}) {
+	if (!isIndia(country)) return "";
+	const g = stateCodeFromGstin(gstin);
+	const n = stateCodeFromName(state);
+	return g && n && g !== n ? "The GSTIN's state code doesn't match the state you selected." : "";
+}
+
+/**
+ * The pincode-vs-state message (surfaced on the pincode field), or "". Rejects a malformed pincode (6-digit,
+ * no leading zero) and a first-3-digit out-of-range for the state. Overseas / blank pincode or state pass.
+ */
+export function pincodeStateError({ country, state, pincode, gstin } = {}) {
+	if (!isIndia(country)) return "";
+	const pin = (pincode || "").trim();
+	if (pin && !PINCODE_RE.test(pin))
+		return "Postal code must be a 6-digit number and can't start with 0.";
+	if (pin && (state || "").trim() && !pincodeMatchesState(pin, state))
+		return "The postal code's first 3 digits don't match your state.";
+	return "";
+}
+
+/**
+ * The single customer-facing sentence for what is inconsistent across {country, state, pincode, gstin}, or ""
+ * when they agree / the check does not apply. Composes the two field-level checks (GSTIN-vs-state first).
+ * Mirrors the control plane's rejects by DEFECT CLASS, just before checkout instead of after.
+ */
+export function addressConsistencyError(o = {}) {
+	return gstinStateError(o) || pincodeStateError(o);
+}

--- a/frontend/src/onboarding/address.test.js
+++ b/frontend/src/onboarding/address.test.js
@@ -1,0 +1,202 @@
+// Address consistency (State <-> GSTIN <-> Pincode). Pure, node --test. Mirrors the control-plane matrix.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	addressConsistencyError,
+	pincodeMatchesState,
+	stateCodeFromGstin,
+	stateCodeFromName,
+	STATE_BY_CODE,
+	STATE_PINCODE_MAPPING,
+} from "./address.js";
+
+const err = (o) => addressConsistencyError(o);
+
+test("consistent India address passes", () => {
+	assert.equal(err({ country: "India", state: "Maharashtra", pincode: "400001" }), "");
+	assert.equal(
+		err({
+			country: "India",
+			state: "Tamil Nadu",
+			pincode: "600001",
+			gstin: "33ABCDE1234F1Z7",
+		}),
+		""
+	);
+});
+
+test("pincode out of range for the state is flagged (the trigger case)", () => {
+	const m = err({ country: "India", state: "Maharashtra", pincode: "638108" }); // 638 is Tamil Nadu
+	assert.match(m, /postal code/i);
+	assert.equal(err({ country: "India", state: "Tamil Nadu", pincode: "638108" }), "");
+});
+
+test("GSTIN state code must match the state", () => {
+	assert.match(
+		err({ country: "India", state: "Karnataka", gstin: "33ABCDE1234F1Z7" }),
+		/GSTIN/i
+	); // 33 vs KA
+	assert.equal(err({ country: "India", state: "Tamil Nadu", gstin: "33ABCDE1234F1Z7" }), "");
+});
+
+test("GSTIN with no known canonical state (99 Centre Jurisdiction) is not false-flagged", () => {
+	assert.equal(stateCodeFromGstin("99AAAAA0000A1Z5"), null);
+	assert.equal(err({ country: "India", state: "Maharashtra", gstin: "99AAAAA0000A1Z5" }), "");
+});
+
+test("malformed pincode is flagged (6-digit, no leading zero)", () => {
+	for (const bad of ["1234", "12345", "0400001", "038108"]) {
+		assert.match(
+			err({ country: "India", state: "Maharashtra", pincode: bad }),
+			/6-digit/i,
+			bad
+		);
+	}
+});
+
+test("not-checkable inputs pass: blank pincode, blank state, overseas, unmapped state", () => {
+	assert.equal(err({ country: "India", state: "Maharashtra", pincode: "" }), "");
+	assert.equal(err({ country: "India", state: "", pincode: "400001" }), "");
+	assert.equal(err({ country: "United States", state: "California", pincode: "638108" }), ""); // overseas
+	assert.equal(err({ country: "India", state: "Other Territory", pincode: "638108" }), ""); // not in map
+	assert.equal(err({}), "");
+});
+
+test("the bare 'Lakshadweep' alias is canonicalized so the pincode check runs (review D2)", () => {
+	assert.equal(err({ country: "India", state: "Lakshadweep", pincode: "682555" }), ""); // 682 in range
+	assert.match(
+		err({ country: "India", state: "Lakshadweep", pincode: "700001" }),
+		/postal code/i
+	); // 700 out
+});
+
+test("the pincode check keys on the state name, not the GSTIN", () => {
+	// mirrors IC's validate_pincode (address.state); a pincode that matches the state passes regardless of GSTIN
+	assert.ok(pincodeMatchesState("560001", "Karnataka")); // 560 in Karnataka
+	assert.ok(!pincodeMatchesState("638108", "Karnataka")); // 638 is Tamil Nadu, not Karnataka
+});
+
+test("a crafted state name can't resolve via the prototype chain (hardening)", () => {
+	assert.equal(stateCodeFromName("__proto__"), null);
+	assert.equal(stateCodeFromName("constructor"), null);
+	assert.equal(stateCodeFromName("hasOwnProperty"), null);
+	assert.equal(err({ country: "India", state: "__proto__", pincode: "400001" }), "");
+});
+
+test("PARITY GUARD: the self-contained tables match India Compliance's exactly", () => {
+	// review D4: the SPA carries its OWN copy of the GST tables (no India Compliance dependency). This
+	// EXHAUSTIVE assertion forces any future edit to STATE_PINCODE_MAPPING / STATE_BY_CODE through a visible
+	// diff, so a transcription slip in any of the 37 entries fails CI instead of drifting silently from the
+	// control plane. Expected values are India Compliance's authoritative STATE_PINCODE_MAPPING + STATE_NUMBERS.
+	assert.deepEqual(STATE_PINCODE_MAPPING, {
+		"Jammu and Kashmir": [180, 194],
+		"Himachal Pradesh": [171, 177],
+		Punjab: [140, 160],
+		Chandigarh: [
+			[140, 140],
+			[160, 160],
+		],
+		Uttarakhand: [244, 263],
+		Haryana: [121, 136],
+		Delhi: [110, 110],
+		Rajasthan: [301, 345],
+		"Uttar Pradesh": [201, 285],
+		Bihar: [800, 855],
+		Sikkim: [737, 737],
+		"Arunachal Pradesh": [790, 792],
+		Nagaland: [797, 798],
+		Manipur: [795, 795],
+		Mizoram: [796, 796],
+		Tripura: [799, 799],
+		Meghalaya: [793, 794],
+		Assam: [781, 788],
+		"West Bengal": [700, 743],
+		Jharkhand: [813, 835],
+		Odisha: [751, 770],
+		Chhattisgarh: [490, 497],
+		"Madhya Pradesh": [450, 488],
+		Gujarat: [360, 396],
+		"Dadra and Nagar Haveli and Daman and Diu": [
+			[362, 362],
+			[396, 396],
+		],
+		Maharashtra: [400, 445],
+		Karnataka: [560, 591],
+		Goa: [403, 403],
+		"Lakshadweep Islands": [682, 682],
+		Kerala: [670, 695],
+		"Tamil Nadu": [600, 643],
+		Puducherry: [
+			[533, 533],
+			[605, 605],
+			[607, 607],
+			[609, 609],
+			[673, 673],
+		],
+		"Andaman and Nicobar Islands": [744, 744],
+		"Andhra Pradesh": [500, 535],
+		Telangana: [
+			[500, 509],
+			[518, 518],
+			[533, 533],
+		],
+		Ladakh: [
+			[180, 180],
+			[181, 181],
+			[184, 184],
+			[190, 191],
+			[194, 194],
+		],
+	});
+	assert.deepEqual(STATE_BY_CODE, {
+		"01": "Jammu and Kashmir",
+		"02": "Himachal Pradesh",
+		"03": "Punjab",
+		"04": "Chandigarh",
+		"05": "Uttarakhand",
+		"06": "Haryana",
+		"07": "Delhi",
+		"08": "Rajasthan",
+		"09": "Uttar Pradesh",
+		10: "Bihar",
+		11: "Sikkim",
+		12: "Arunachal Pradesh",
+		13: "Nagaland",
+		14: "Manipur",
+		15: "Mizoram",
+		16: "Tripura",
+		17: "Meghalaya",
+		18: "Assam",
+		19: "West Bengal",
+		20: "Jharkhand",
+		21: "Odisha",
+		22: "Chhattisgarh",
+		23: "Madhya Pradesh",
+		24: "Gujarat",
+		26: "Dadra and Nagar Haveli and Daman and Diu",
+		27: "Maharashtra",
+		29: "Karnataka",
+		30: "Goa",
+		31: "Lakshadweep Islands",
+		32: "Kerala",
+		33: "Tamil Nadu",
+		34: "Puducherry",
+		35: "Andaman and Nicobar Islands",
+		36: "Telangana",
+		37: "Andhra Pradesh",
+		38: "Ladakh",
+		97: "Other Territory",
+	});
+});
+
+test("multi-range states honor every disjoint range", () => {
+	assert.ok(pincodeMatchesState("140001", "Chandigarh")); // [140,140]
+	assert.ok(pincodeMatchesState("160001", "Chandigarh")); // [160,160]
+	assert.ok(!pincodeMatchesState("150001", "Chandigarh")); // gap between them
+	assert.ok(pincodeMatchesState("605001", "Puducherry")); // one of five
+	assert.ok(pincodeMatchesState("500001", "Telangana")); // [500,509]
+	assert.ok(pincodeMatchesState("194101", "Ladakh")); // [194,194]
+	assert.ok(pincodeMatchesState("500001", "Andhra Pradesh")); // overlaps Telangana (500-535)
+});

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -1661,3 +1661,50 @@ describe("country validation rejects a non-canonical value", () => {
 		expect(wrapper.vm.countryError("Turkey")).toBe(""); // alias normalises to Türkiye
 	});
 });
+
+describe("Address consistency: State <-> Pincode <-> GSTIN (India)", () => {
+	it("blocks Continue and flags the pincode when it doesn't match the state", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		wrapper.vm.billing.setUserValue("state", "Maharashtra");
+		wrapper.vm.billing.setUserValue("pincode", "638108"); // a Tamil Nadu PIN
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(true);
+		expect(wrapper.vm.detailsFieldErrors.pincode).toMatch(/postal code/i);
+	});
+
+	it("clears once the pincode matches the state", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		// the address inconsistency must be the ONLY thing blocking, so satisfy email + company too
+		wrapper.vm.state.email = "test@acme.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.billing.setUserValue("state", "Maharashtra");
+		wrapper.vm.billing.setUserValue("pincode", "638108");
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(true);
+		expect(wrapper.vm.detailsFieldErrors.pincode).toMatch(/postal code/i);
+		wrapper.vm.billing.setUserValue("pincode", "400001"); // a Maharashtra PIN
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(false);
+		expect(wrapper.vm.detailsFieldErrors.pincode).toBe("");
+	});
+
+	it("clears the India-only pincode message when the country switches overseas", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		wrapper.vm.billing.setUserValue("state", "Maharashtra");
+		wrapper.vm.billing.setUserValue("pincode", "638108");
+		wrapper.vm.touchPincodeField();
+		expect(wrapper.vm.detailsFieldErrors.pincode).toMatch(/postal code/i);
+		wrapper.vm.onCountryChange("United States"); // overseas -> the India-specific check no longer applies
+		expect(wrapper.vm.detailsFieldErrors.pincode).toBe("");
+	});
+
+	it("flags the GSTIN when its state code disagrees with the selected state", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		wrapper.vm.billing.setUserValue("state", "Karnataka");
+		wrapper.vm.billing.setUserValue("pincode", "560001"); // Karnataka PIN (consistent with the state)
+		wrapper.vm.billing.setUserValue("gstin", "33ABCDE1234F1Z7"); // Tamil Nadu GSTIN -> mismatch
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(true);
+		expect(wrapper.vm.detailsFieldErrors.gstin).toMatch(/GSTIN/i);
+	});
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -616,7 +616,9 @@
 													billing.setUserValue('pincode', v);
 													clearFieldErrorIfValid(
 														'pincode',
-														pincodeError,
+														(val) =>
+															pincodeError(val) ||
+															pincodeStateError(_billingAddr()),
 														v
 													);
 												}
@@ -739,7 +741,13 @@
 											@update:model-value="
 												(v) => {
 													billing.setUserValue('gstin', v);
-													clearFieldErrorIfValid('gstin', gstinError, v);
+													clearFieldErrorIfValid(
+														'gstin',
+														(val) =>
+															gstinError(val) ||
+															gstinStateError(_billingAddr()),
+														v
+													);
 												}
 											"
 											:placeholder="GSTIN_PLACEHOLDER"
@@ -2173,6 +2181,7 @@ import { makeTelemetryReporter } from "@/onboarding/paymentTelemetry";
 import { readCookie } from "@/lib/user";
 import { useBillingDetails, billingEditAction } from "@/onboarding/useBillingDetails";
 import { gstinError, GSTIN_PLACEHOLDER } from "@/onboarding/gstin";
+import { gstinStateError, pincodeStateError } from "@/onboarding/address";
 import {
 	INDIAN_STATES,
 	COUNTRIES,
@@ -2925,6 +2934,9 @@ function stateError(v) {
 }
 function touchStateField() {
 	detailsFieldErrors.state = stateError(billing.fields.state.value);
+	// a state change re-decides the pincode<->state and GSTIN<->state consistency shown on those fields
+	touchPincodeField();
+	touchGstinField();
 }
 function touchEmailField() {
 	detailsFieldErrors.email = emailError(state.email);
@@ -2941,14 +2953,29 @@ function touchAddressField() {
 function touchCityField() {
 	detailsFieldErrors.city = cityError(billing.fields.city.value);
 }
+// Pincode + GSTIN also carry a CROSS-FIELD consistency check (State <-> Pincode <-> GSTIN must agree,
+// mirroring the admin control plane / India Compliance) so an inconsistent India address is caught HERE, not
+// as a silent operator REVIEW when the books build the invoice. The required/format error wins first; the
+// consistency message only shows when the field is otherwise fine. Surfaced on the field the mismatch is
+// about — pincode-vs-state on pincode, GSTIN-vs-state on GSTIN.
+function _billingAddr() {
+	return {
+		country: billing.fields.country.value || "India",
+		state: billing.fields.state.value,
+		pincode: billing.fields.pincode.value,
+		gstin: billing.fields.gstin.value,
+	};
+}
 function touchPincodeField() {
-	detailsFieldErrors.pincode = pincodeError(billing.fields.pincode.value);
+	detailsFieldErrors.pincode =
+		pincodeError(billing.fields.pincode.value) || pincodeStateError(_billingAddr());
 }
 function touchCountryField() {
 	detailsFieldErrors.country = countryError(billing.fields.country.value || "India");
 }
 function touchGstinField() {
-	detailsFieldErrors.gstin = gstinError(billing.fields.gstin.value);
+	detailsFieldErrors.gstin =
+		gstinError(billing.fields.gstin.value) || gstinStateError(_billingAddr());
 }
 // Called on every keystroke: only ever CLEARS an error that no longer applies
 // - it never shows a NEW one while the customer is still typing. Full
@@ -2995,6 +3022,10 @@ function onCountryChange(v) {
 		detailsFieldErrors.state = "";
 	}
 	clearFieldErrorIfValid("country", countryError, v);
+	// The pincode/GSTIN consistency messages are country-dependent (India-only), so a country change must
+	// re-decide them too — else a stale "doesn't match your state" lingers after switching to overseas.
+	touchPincodeField();
+	touchGstinField();
 }
 
 // ERP-derived billing defaults for the selected Company. Debounced (the Company


### PR DESCRIPTION
Reject a billing address whose **State, postal code, and GSTIN state code disagree** before it reaches invoicing — e.g. State=Maharashtra with a Tamil-Nadu PIN would otherwise book the wrong GST place of supply.

SPA mirror of the jarvis_admin_v2 control-plane authority (see the paired admin-v2 PR): a shared State↔PIN-prefix↔GST-code table (`address.js`) drives a live on-blur check on the onboarding Details step — the postal code's first 3 digits and the GSTIN's state code must agree with the selected state. The plane re-validates on signup, so the SPA is never the only guard. Byte-parity with jarvis_admin_v2 + India Compliance verified.

**Tests:** `address.test.js` (11, node --test) + `OnboardingView.spec` (82, vitest). Reviewed GREEN (code + flow, in-browser on jarvis_2.local); prettier v2.7.1 clean.
