### PR TITLE
docs(bench): document the reset-onboarding bench command + enforce sync

### DIFF
--- a/docs/bench-commands.md
+++ b/docs/bench-commands.md
@@ -1,0 +1,29 @@
+# jarvis — bench commands
+
+Custom `bench` CLI commands this app registers. All target one site: `bench --site <site> <command>`.
+
+> **Keep this in sync.** Every command in `jarvis/commands/__init__.py`'s `commands` list MUST be
+> documented here — `jarvis.tests.test_bench_commands_documented` fails CI otherwise.
+
+## Custom CLI commands
+
+### `reset-onboarding`
+DEV: flush a tenant site's Jarvis setup so the onboarding wizard runs fresh — connection + LLM
+credentials, and (unless `--keep-data`) all workspace content (chats, skills, macros, triggers, learning,
+wiki, dashboards). Admin-side records are NOT touched — use the control plane's `purge_customer` for that.
+
+| Option | Meaning |
+|---|---|
+| `--force` | Skip the confirmation prompt. |
+| `--keep-data` | Keep workspace content; only clear the connection + LLM setup. |
+
+```bash
+bench --site jarvis_2.local reset-onboarding             # prompts to confirm; wipes content
+bench --site jarvis_2.local reset-onboarding --keep-data # only clear connection + LLM setup
+bench --site jarvis_2.local reset-onboarding --force     # no prompt
+```
+
+## Related (control plane)
+Onboarding a tenant also involves the control plane (`jarvis_admin_v2`) — its `purge_customer` erases the
+admin-side customer, and it owns the billing/fleet bench commands. See
+`jarvis_admin_v2/docs/bench-commands.md`.

--- a/jarvis/tests/test_bench_commands_documented.py
+++ b/jarvis/tests/test_bench_commands_documented.py
@@ -1,0 +1,24 @@
+"""Enforce that every custom bench CLI command this app registers is documented in docs/bench-commands.md,
+so the reference doc can't silently rot when a command is added or renamed. If this fails, add the new
+command to the doc (as `name`)."""
+
+import pathlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.commands import commands as _COMMANDS
+
+
+class TestBenchCommandsDocumented(FrappeTestCase):
+	def test_every_registered_command_is_documented(self):
+		# repo-root docs/ (the module's own jarvis/docs/ is gitignored). get_app_path -> the module dir;
+		# .parent -> the repo root; then pathlib-join preserves the hyphen (get_app_path would scrub it).
+		doc = (pathlib.Path(frappe.get_app_path("jarvis")).parent / "docs" / "bench-commands.md").read_text()
+		missing = [c.name for c in _COMMANDS if f"`{c.name}`" not in doc]
+		self.assertEqual(
+			missing,
+			[],
+			f"Undocumented bench command(s): {missing}. Add each (as `<name>`) to "
+			"docs/bench-commands.md — this test enforces the doc stays in sync.",
+		)


### PR DESCRIPTION
Adds `docs/bench-commands.md` documenting the app's custom bench command (`reset-onboarding`) and a test (`jarvis/tests/test_bench_commands_documented`) that fails CI if any command registered in `commands/__init__.py` isn't documented — so a newly-introduced bench command can't ship undocumented.

Doc lives at the repo root `docs/` since the module's `jarvis/docs/` is gitignored. Mutation-verified: dropping a command from the doc fails the test.