### PR TITLE
Feat/release nudge slice3b

### DIFF
--- a/frontend/src/components/chat/UpdateBanner.vue
+++ b/frontend/src/components/chat/UpdateBanner.vue
@@ -1,0 +1,168 @@
+<template>
+	<!-- Soft update banner: top-of-chat, calm info/blue (NOT the amber warning
+	     the billing/readiness alerts use). The wrapper is the FLIP target that
+	     minimises into the version pill on dismiss. -->
+	<div ref="bannerEl" class="jv-updatebanner" :style="flipStyle">
+		<Banner type="info" :message="message">
+			<template #action>
+				<button class="jv-ub-btn" type="button" @click="onWhatsNew">What's new</button>
+				<button class="jv-ub-btn jv-ub-btn--ghost" type="button" @click="dismiss">
+					Remind me later
+				</button>
+				<button
+					class="jv-ub-x"
+					type="button"
+					aria-label="Dismiss update banner"
+					@click="dismiss"
+				>
+					<FeatherIcon name="x" class="size-3.5" />
+				</button>
+			</template>
+		</Banner>
+	</div>
+</template>
+
+<script setup>
+// UpdateBanner: the occasional soft nudge that a newer app version exists
+// (Slice 3b). Dismiss ("Remind me later" or ×) plays a short minimise-into-pill
+// FLIP, then snoozes per-device. Honors prefers-reduced-motion (instant hide +
+// snooze, no FLIP/pulse), and degrades to a plain hide when the pill rect can't
+// be measured. Mounting/visibility (yield to greeting/welcome/booting/urgent
+// alerts) is decided by the caller's v-if in ChatView.
+import { ref } from "vue";
+import Banner from "@/components/Banner.vue";
+import { FeatherIcon } from "frappe-ui";
+import { agentName } from "@/branding";
+import { snoozeBanner, openWhatsNew } from "@/noticeGate";
+
+const props = defineProps({
+	// The VersionPill's exposed instance ({ getEl, pulse }); may be null if the
+	// pill isn't mounted/shown, in which case we skip the FLIP.
+	pill: { type: Object, default: null },
+});
+
+const message = `A new version of ${agentName} is available — ask your administrator to update.`;
+
+const bannerEl = ref(null);
+const flipStyle = ref({});
+
+function reducedMotion() {
+	try {
+		return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+	} catch (e) {
+		return false;
+	}
+}
+
+function onWhatsNew() {
+	openWhatsNew();
+}
+
+function dismiss() {
+	const el = bannerEl.value;
+	const pillEl = props.pill && props.pill.getEl ? props.pill.getEl() : null;
+
+	// Reduced motion, or no banner element: instant hide + snooze.
+	if (reducedMotion() || !el) {
+		snoozeBanner();
+		return;
+	}
+
+	const from = el.getBoundingClientRect();
+	const to = pillEl && pillEl.getBoundingClientRect ? pillEl.getBoundingClientRect() : null;
+
+	// Pill rect unmeasurable (hidden/offscreen): degrade to a plain hide + snooze.
+	if (!to || !to.width || !to.height) {
+		snoozeBanner();
+		return;
+	}
+
+	const dx = to.left + to.width / 2 - (from.left + from.width / 2);
+	const dy = to.top + to.height / 2 - (from.top + from.height / 2);
+
+	// Small catch-pulse on the pill as the banner arrives (~end of the hop).
+	setTimeout(() => {
+		if (props.pill && props.pill.pulse) props.pill.pulse();
+	}, 380);
+
+	flipStyle.value = {
+		transition: "transform 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.5s ease",
+		transformOrigin: "center",
+		willChange: "transform, opacity",
+	};
+	requestAnimationFrame(() => {
+		flipStyle.value = {
+			...flipStyle.value,
+			transform: `translate(${dx}px, ${dy}px) scale(0.05)`,
+			opacity: 0,
+			pointerEvents: "none",
+		};
+	});
+
+	// Snooze (which unmounts us via the reactive showBanner) once the hop ends.
+	// transitionend fires per-property; `done` guards the double fire, and the
+	// timeout is a safety net if transitionend never arrives.
+	let done = false;
+	const finish = () => {
+		if (done) return;
+		done = true;
+		snoozeBanner();
+	};
+	el.addEventListener("transitionend", finish, { once: true });
+	setTimeout(finish, 650);
+}
+</script>
+
+<style scoped>
+.jv-updatebanner {
+	margin: 12px 18px 0;
+}
+
+/* Compact, quiet action buttons inside the banner's #action slot. Real
+   <button>s (keyboard-reachable); styled here since Banner is a child scope.
+   Colours come from the app palette (theme-aware, resolved on .jv-root),
+   --link being the one sanctioned blue. */
+.jv-ub-btn {
+	height: 26px;
+	padding: 0 10px;
+	border: 1px solid color-mix(in srgb, var(--link) 40%, transparent);
+	border-radius: 7px;
+	background: transparent;
+	font-family: inherit;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--link);
+	cursor: pointer;
+	white-space: nowrap;
+}
+.jv-ub-btn:hover {
+	background: color-mix(in srgb, var(--link) 12%, transparent);
+}
+.jv-ub-btn--ghost {
+	border-color: transparent;
+	color: var(--text-2);
+}
+.jv-ub-btn--ghost:hover {
+	background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+.jv-ub-btn:focus-visible,
+.jv-ub-x:focus-visible {
+	outline: 2px solid var(--link);
+	outline-offset: 2px;
+}
+.jv-ub-x {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border: none;
+	border-radius: 7px;
+	background: transparent;
+	color: var(--text-2);
+	cursor: pointer;
+}
+.jv-ub-x:hover {
+	background: color-mix(in srgb, var(--text) 12%, transparent);
+}
+</style>

--- a/frontend/src/components/chat/VersionPill.vue
+++ b/frontend/src/components/chat/VersionPill.vue
@@ -1,0 +1,136 @@
+<template>
+	<!-- Always-on version status in the chat top bar. A real focusable button
+	     whose aria-label matches its visible label; click opens What's-new. No
+	     pill at all when the target version is unknown (never a false "current"). -->
+	<button
+		v-if="pill.show"
+		ref="btnEl"
+		type="button"
+		class="jv-versionpill"
+		:class="['jv-tone-' + pill.tone, { 'jv-pill-pulse': pulsing }]"
+		:aria-label="pill.label"
+		:title="title"
+		@click="openWhatsNew"
+		@animationend="pulsing = false"
+	>
+		<span class="jv-pill-dot" aria-hidden="true"></span>
+		<span class="jv-pill-label">{{ pill.label }}</span>
+	</button>
+</template>
+
+<script setup>
+// VersionPill: the customer-facing "how current is my Jarvis" signal (Slice 3b).
+// Hand-styled to mirror the header's .jv-modelpill (a coloured dot + label),
+// tone driven by the app palette vars (--green/--amber/--red) rather than a
+// frappe-ui Badge (there is no "amber" Badge theme). The label text is derived
+// once from the stable boot payload (pillFor) - no per-render work.
+import { ref } from "vue";
+import { pillFor } from "@/releaseNudge";
+import { notice, openWhatsNew } from "@/noticeGate";
+import { agentName } from "@/branding";
+
+defineProps({
+	// Hover tooltip; the visible label already lives in the pill + aria-label.
+	title: { type: String, default: "See what's new" },
+});
+
+const btnEl = ref(null);
+const pulsing = ref(false);
+
+// Boot payload is stable for the page's lifetime, so derive once.
+const pill = pillFor(notice, agentName);
+
+// The soft banner's minimise-into-pill animation calls this as the banner
+// "arrives", for a small catch-pulse. Restart-safe on repeat dismisses; the
+// CSS keyframe is disabled under prefers-reduced-motion (below).
+function pulse() {
+	pulsing.value = false;
+	requestAnimationFrame(() => {
+		pulsing.value = true;
+	});
+}
+
+// The banner (a sibling) needs the pill's rect (FLIP target) and the pulse.
+// getEl() returns the raw element (or null when the pill is hidden).
+defineExpose({ getEl: () => btnEl.value, pulse });
+</script>
+
+<style scoped>
+/* Mirrors .jv-modelpill in ChatView.vue: same rounded, bordered chip on the
+   surface-1 fill, but with a leading tone dot instead of the action icon. */
+.jv-versionpill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 5px 10px;
+	background: var(--surface-1);
+	border: 1px solid var(--border);
+	border-radius: 20px;
+	cursor: pointer;
+	font-family: inherit;
+	line-height: 1;
+}
+.jv-versionpill:hover {
+	border-color: var(--border-2);
+	background: var(--surface-2);
+}
+.jv-versionpill:focus-visible {
+	outline: 2px solid var(--link);
+	outline-offset: 2px;
+}
+
+.jv-pill-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	flex: none;
+	background: var(--text-3);
+}
+.jv-pill-label {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--text-2);
+	white-space: nowrap;
+}
+
+/* Tone drives the dot AND the label colour, straight off the app palette. */
+.jv-tone-green .jv-pill-dot {
+	background: var(--green);
+}
+.jv-tone-green .jv-pill-label {
+	color: var(--green);
+}
+.jv-tone-amber .jv-pill-dot {
+	background: var(--amber);
+}
+.jv-tone-amber .jv-pill-label {
+	color: var(--amber);
+}
+.jv-tone-red .jv-pill-dot {
+	background: var(--red);
+}
+.jv-tone-red .jv-pill-label {
+	color: var(--red);
+}
+
+/* Catch-pulse when the soft banner minimises into the pill. */
+@keyframes jvPillPulse {
+	0% {
+		transform: scale(1);
+	}
+	45% {
+		transform: scale(1.16);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+.jv-pill-pulse {
+	animation: jvPillPulse 0.45s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-pill-pulse {
+		animation: none;
+	}
+}
+</style>

--- a/frontend/src/components/chat/VersionPill.vue
+++ b/frontend/src/components/chat/VersionPill.vue
@@ -8,7 +8,7 @@
 		type="button"
 		class="jv-versionpill"
 		:class="['jv-tone-' + pill.tone, { 'jv-pill-pulse': pulsing }]"
-		:aria-label="pill.label"
+		:aria-label="pillAriaLabel"
 		:title="title"
 		@click="openWhatsNew"
 		@animationend="pulsing = false"
@@ -39,6 +39,9 @@ const pulsing = ref(false);
 
 // Boot payload is stable for the page's lifetime, so derive once.
 const pill = pillFor(notice, agentName);
+// The screen-reader label names the action ("… — see what's new"); the visible
+// text stays the terse status label. Only meaningful when the pill renders.
+const pillAriaLabel = pill.show ? `${pill.label} — see what's new` : "";
 
 // The soft banner's minimise-into-pill animation calls this as the banner
 // "arrives", for a small catch-pulse. Restart-safe on repeat dismisses; the

--- a/frontend/src/components/chat/WhatsNewDialog.vue
+++ b/frontend/src/components/chat/WhatsNewDialog.vue
@@ -1,0 +1,109 @@
+<template>
+	<Dialog v-model="open" :options="{ title: whatsNewTitle, size: 'lg' }">
+		<template #body-content>
+			<!-- loading: between open and the notes() resolve -->
+			<div v-if="loading" class="flex justify-center py-10">
+				<JvSpinner :size="28" label="Loading release notes…" />
+			</div>
+
+			<!-- error: friendly, never raw control-plane text -->
+			<div
+				v-else-if="error"
+				class="flex flex-col items-center gap-2 py-10 text-center text-sm text-ink-gray-6"
+			>
+				<FeatherIcon name="alert-triangle" class="size-5 text-ink-amber-3" />
+				<span>Couldn't load release notes. Please try again in a moment.</span>
+				<Button label="Retry" variant="subtle" @click="load(true)" />
+			</div>
+
+			<!-- empty: nothing newer than this workspace -->
+			<div
+				v-else-if="!notes.length"
+				class="flex flex-col items-center gap-2 py-10 text-center text-sm text-ink-gray-6"
+			>
+				<FeatherIcon name="check-circle" class="size-5 text-ink-green-3" />
+				<span>You're all caught up.</span>
+			</div>
+
+			<!-- notes, newest first: version heading via {{ }} (never v-html), body
+			     via renderMarkdown (escape-first, XSS-safe) in a prose block -->
+			<div v-else class="flex flex-col gap-6">
+				<section v-for="note in notes" :key="note.version">
+					<div class="flex flex-wrap items-baseline gap-2">
+						<h3 class="text-base font-semibold text-ink-gray-9">
+							{{ note.version }}
+						</h3>
+						<span v-if="note.title" class="text-sm text-ink-gray-6">
+							{{ note.title }}
+						</span>
+					</div>
+					<div
+						class="prose prose-sm mt-1 max-w-none"
+						v-html="renderMarkdown(note.body)"
+					></div>
+				</section>
+			</div>
+		</template>
+
+		<template #actions>
+			<Button label="Close" variant="solid" class="w-full" @click="open = false" />
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// WhatsNewDialog: the fetch-on-click "What's new" panel (Slice 3b), opened from
+// the version pill, the soft banner, and the hard gate (all via the shared
+// `whatsNewOpen` ref in noticeGate). Modeled on ConnectPhoneDialog / NoteDetailModal
+// (frappe-ui Dialog, portals to <body>).
+//
+// The bench owns the version, so notes() takes no arguments (it derives
+// track + since from jarvis.__version__). The result is cached per target
+// version so re-opening the panel never refetches - `notice.version` is stable
+// for the page's lifetime (a hard-gate recheck forces a full reload).
+import { ref, watch } from "vue";
+import { Dialog, Button, FeatherIcon, call } from "frappe-ui";
+import JvSpinner from "@/components/JvSpinner.vue";
+import { renderMarkdown } from "@/markdown";
+import { notice, whatsNewOpen } from "@/noticeGate";
+import { agentName } from "@/branding";
+
+const whatsNewTitle = `What's new in ${agentName}`;
+
+// Module-scope cache keyed by target version, so it survives close/reopen (and
+// is shared across the ChatView and hard-gate instances of this dialog).
+const NOTES_CACHE = new Map();
+
+const open = whatsNewOpen;
+const loading = ref(false);
+const error = ref(false);
+const notes = ref([]);
+
+async function load(force = false) {
+	const key = notice.version || "";
+	if (!force && NOTES_CACHE.has(key)) {
+		notes.value = NOTES_CACHE.get(key);
+		loading.value = false;
+		error.value = false;
+		return;
+	}
+	loading.value = true;
+	error.value = false;
+	try {
+		const res = await call("jarvis.release_notice.notes");
+		const list = (res && res.notes) || [];
+		NOTES_CACHE.set(key, list);
+		notes.value = list;
+	} catch (e) {
+		// Never surface raw CP prose - a lapsed customer (AdminAuthError) or an
+		// unreachable admin both land here as the same friendly error state.
+		error.value = true;
+	} finally {
+		loading.value = false;
+	}
+}
+
+watch(open, (isOpen) => {
+	if (isOpen) load();
+});
+</script>

--- a/frontend/src/components/chat/WhatsNewDialog.vue
+++ b/frontend/src/components/chat/WhatsNewDialog.vue
@@ -91,6 +91,12 @@ async function load(force = false) {
 	error.value = false;
 	try {
 		const res = await call("jarvis.release_notice.notes");
+		// A flagged fetch failure degrades to the friendly error state, NOT the
+		// "all caught up" empty state - and is never cached, so Retry refetches.
+		if (res && res.error) {
+			error.value = true;
+			return;
+		}
 		const list = (res && res.notes) || [];
 		NOTES_CACHE.set(key, list);
 		notes.value = list;

--- a/frontend/src/components/shell/UpdateNoticeGate.vue
+++ b/frontend/src/components/shell/UpdateNoticeGate.vue
@@ -23,15 +23,22 @@
 			<button class="jv-gate-btn" :disabled="checking" @click="recheck">
 				{{ checking ? "Checking…" : "I've updated, check again" }}
 			</button>
+
+			<button type="button" class="jv-gate-link" @click="openWhatsNew">
+				See what's new
+			</button>
 		</div>
+
+		<WhatsNewDialog />
 	</div>
 </template>
 
 <script setup>
 import { onMounted, onBeforeUnmount } from "vue";
 import JarvisMark from "@/components/JarvisMark.vue";
+import WhatsNewDialog from "@/components/chat/WhatsNewDialog.vue";
 import { agentName } from "@/branding";
-import { checking, notice, recheck } from "@/noticeGate";
+import { checking, notice, openWhatsNew, recheck } from "@/noticeGate";
 
 // Boot read a mirror that may predate the update, so re-pull once on mount and
 // then poll: an open tab has no other way to learn the notice was lifted.
@@ -155,5 +162,25 @@ onBeforeUnmount(() => clearInterval(timer));
 .jv-gate-btn:disabled {
 	opacity: 0.6;
 	cursor: default;
+}
+
+.jv-gate-link {
+	margin-top: 14px;
+	border: none;
+	background: transparent;
+	font-size: 13.5px;
+	font-weight: 500;
+	color: var(--link, #1579d0);
+	cursor: pointer;
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+.jv-gate-link:hover {
+	opacity: 0.82;
+}
+.jv-gate-link:focus-visible {
+	outline: 2px solid var(--link, #1579d0);
+	outline-offset: 2px;
+	border-radius: 4px;
 }
 </style>

--- a/frontend/src/noticeGate.js
+++ b/frontend/src/noticeGate.js
@@ -6,8 +6,13 @@
 import { computed, ref } from "vue";
 import { call } from "frappe-ui";
 import { bannerShouldShow, writeSnooze, readSnooze } from "@/releaseNudge";
+import { session } from "@/data/session";
 
 const n = window.release_notice || {};
+
+// Namespace the snooze by the signed-in user (same source globalNotifier reads),
+// so two people sharing a browser profile keep independent snoozes; guest -> "anon".
+const userId = session.user || "anon";
 
 // The boot payload is stable for the page's lifetime, so this is a plain object
 // (not reactive): pillFor()/bannerShouldShow() read it, and it never changes.
@@ -31,7 +36,7 @@ export const showNotice = computed(() => notice.active && !cleared.value);
 // The snooze lives in localStorage; this ref mirrors it so the banner hides
 // reactively the moment it is snoozed. Seeded from storage at boot (a read-throw
 // reads as not-snoozed, so the banner shows - see readSnooze()).
-const snooze = ref(readSnooze());
+const snooze = ref(readSnooze(userId));
 
 // Reactive: soft tier AND not currently snoozed. `Date.now()` is read at
 // evaluation time; the only reactive dependency is `snooze`, so snoozing (which
@@ -45,7 +50,7 @@ export const showBanner = computed(() => bannerShouldShow(notice, Date.now(), sn
 // next boot - the accepted edge behaviour, spec §6).
 export function snoozeBanner() {
 	const now = Date.now();
-	writeSnooze(notice, now);
+	writeSnooze(notice, now, userId);
 	const days = notice.banner_interval_days || 7;
 	snooze.value = { until: now + days * 86400000, version: notice.version };
 }

--- a/frontend/src/noticeGate.js
+++ b/frontend/src/noticeGate.js
@@ -1,14 +1,23 @@
 // Release notice, delivered by the www/jarvis.py boot payload as
-// window.release_notice = {active, version, message}.
+// window.release_notice = {active, version, message, tier, behind,
+// banner_interval_days}. The hard gate keys off `active`; the customer-facing
+// version pill + soft banner (Slice 3b) derive their display state from
+// `version` + `tier` + `behind` via the shared, node-testable `releaseNudge.js`.
 import { computed, ref } from "vue";
 import { call } from "frappe-ui";
+import { bannerShouldShow, writeSnooze, readSnooze } from "@/releaseNudge";
 
 const n = window.release_notice || {};
 
+// The boot payload is stable for the page's lifetime, so this is a plain object
+// (not reactive): pillFor()/bannerShouldShow() read it, and it never changes.
 export const notice = {
 	active: !!n.active,
 	version: (n.version || "").trim(),
 	message: n.message || "",
+	tier: n.tier || "none",
+	behind: Number(n.behind) || 0,
+	banner_interval_days: Number(n.banner_interval_days) || 7,
 };
 
 const cleared = ref(false);
@@ -17,6 +26,39 @@ export const checking = ref(false);
 // Hard gate: no dismiss. It lifts only when the control plane stops serving the
 // notice (this tenant updated, or the operator retired it).
 export const showNotice = computed(() => notice.active && !cleared.value);
+
+// ---- Soft banner (snooze-per-device) ---------------------------------------
+// The snooze lives in localStorage; this ref mirrors it so the banner hides
+// reactively the moment it is snoozed. Seeded from storage at boot (a read-throw
+// reads as not-snoozed, so the banner shows - see readSnooze()).
+const snooze = ref(readSnooze());
+
+// Reactive: soft tier AND not currently snoozed. `Date.now()` is read at
+// evaluation time; the only reactive dependency is `snooze`, so snoozing (which
+// replaces the ref below) recomputes this to false and the banner hides.
+export const showBanner = computed(() => bannerShouldShow(notice, Date.now(), snooze.value));
+
+// Dismiss the soft banner: persist the snooze (best-effort) AND update the ref
+// in-memory so `showBanner` flips to false immediately. The in-memory update
+// mirrors writeSnooze()'s payload exactly, so a localStorage write-throw still
+// hides the banner this session (the snooze just isn't persisted and returns
+// next boot - the accepted edge behaviour, spec §6).
+export function snoozeBanner() {
+	const now = Date.now();
+	writeSnooze(notice, now);
+	const days = notice.banner_interval_days || 7;
+	snooze.value = { until: now + days * 86400000, version: notice.version };
+}
+
+// ---- What's-new dialog (shared open state) ---------------------------------
+// The pill, the soft banner, and the hard gate all open the same What's-new
+// panel. The gate replaces the whole app (AppShell renders it in place of the
+// router view), so ChatView and the gate each mount their own <WhatsNewDialog>;
+// this single ref keeps whichever one is live driven by all three triggers.
+export const whatsNewOpen = ref(false);
+export function openWhatsNew() {
+	whatsNewOpen.value = true;
+}
 
 // Boot reads a mirror that may predate the tenant's update, and an open tab never
 // re-reads it at all, so the gate re-pulls from admin itself.

--- a/frontend/src/releaseNudge.js
+++ b/frontend/src/releaseNudge.js
@@ -1,0 +1,72 @@
+// Shared release-nudge display logic for both frontends: the SPA imports it as
+// `@/releaseNudge`, the mobile PWA as `@shared/releaseNudge` (one-way share, see
+// pwa/vite.config.js). Keep this a pure ES module - no `@/` imports and no Vue - so
+// `node --test` can resolve and run it without a bundler.
+//
+// The wire payload is minimal: { active, version, message, tier, behind,
+// banner_interval_days }. There is NO `state` field - the display state (current /
+// soft / hard / unknown) is derived here from `version` + `tier` + `behind`.
+
+export const SNOOZE_KEY = "jarvis-release-banner-snooze";
+
+// The version pill's tone and (stable) label for a boot-payload notice.
+//
+// `agentName` is a PARAMETER (default "Jarvis"), not an import, so this module stays
+// node-testable and single-sourced - the caller passes the branded agent name in.
+//   - no notice / no target version -> hidden (never a false "on the latest").
+//   - tier "hard" -> red   (N versions behind, or "Update required").
+//   - tier "soft" -> amber (N versions behind, or "Update available").
+//   - otherwise (tier "none", with a known version) -> green (current).
+export function pillFor(notice, agentName = "Jarvis") {
+	if (!notice || !notice.version) return { show: false };
+	const behind = Number(notice.behind) || 0;
+	if (notice.tier === "hard") {
+		return {
+			show: true,
+			tone: "red",
+			label: behind >= 1 ? `${behind} versions behind` : "Update required",
+		};
+	}
+	if (notice.tier === "soft") {
+		return {
+			show: true,
+			tone: "amber",
+			label: behind >= 1 ? `${behind} versions behind` : "Update available",
+		};
+	}
+	return { show: true, tone: "green", label: `On the latest ${agentName}` };
+}
+
+// The soft banner shows only for the soft tier, and only when not currently snoozed:
+// no snooze, a snooze for a different (older) target version, or a snooze that has
+// expired. `now` and `snooze` are passed in so this stays pure and testable.
+export function bannerShouldShow(notice, now, snooze) {
+	if (!notice || !notice.version || notice.tier !== "soft") return false;
+	return !snooze || snooze.version !== notice.version || now > snooze.until;
+}
+
+// Per-device snooze state. Reads/writes are wrapped so a private-mode / quota / absent
+// localStorage never throws: a read-throw reads as not-snoozed (banner shows), a
+// write-throw is swallowed (the dismiss animation still completes; snooze just doesn't
+// persist and the banner returns next boot - acceptable).
+export function readSnooze() {
+	if (typeof localStorage === "undefined") return null;
+	try {
+		return JSON.parse(localStorage.getItem(SNOOZE_KEY)) || null;
+	} catch {
+		return null;
+	}
+}
+
+export function writeSnooze(notice, now) {
+	if (typeof localStorage === "undefined") return;
+	try {
+		const days = notice.banner_interval_days || 7;
+		localStorage.setItem(
+			SNOOZE_KEY,
+			JSON.stringify({ until: now + days * 86400000, version: notice.version })
+		);
+	} catch {
+		// swallow - a write failure must not break the dismiss animation.
+	}
+}

--- a/frontend/src/releaseNudge.js
+++ b/frontend/src/releaseNudge.js
@@ -24,14 +24,20 @@ export function pillFor(notice, agentName = "Jarvis") {
 		return {
 			show: true,
 			tone: "red",
-			label: behind >= 1 ? `${behind} versions behind` : "Update required",
+			label:
+				behind >= 1
+					? `${behind} version${behind === 1 ? "" : "s"} behind`
+					: "Update required",
 		};
 	}
 	if (notice.tier === "soft") {
 		return {
 			show: true,
 			tone: "amber",
-			label: behind >= 1 ? `${behind} versions behind` : "Update available",
+			label:
+				behind >= 1
+					? `${behind} version${behind === 1 ? "" : "s"} behind`
+					: "Update available",
 		};
 	}
 	return { show: true, tone: "green", label: `On the latest ${agentName}` };
@@ -45,25 +51,35 @@ export function bannerShouldShow(notice, now, snooze) {
 	return !snooze || snooze.version !== notice.version || now > snooze.until;
 }
 
-// Per-device snooze state. Reads/writes are wrapped so a private-mode / quota / absent
-// localStorage never throws: a read-throw reads as not-snoozed (banner shows), a
-// write-throw is swallowed (the dismiss animation still completes; snooze just doesn't
-// persist and the banner returns next boot - acceptable).
-export function readSnooze() {
+// Per-user, per-device snooze state. The key is namespaced by `userId` so two
+// people sharing a browser profile don't inherit each other's snooze (a missing
+// userId falls back to a stable "anon" bucket). `userId` is a PARAMETER, not an
+// import, so this module stays node-testable and single-sourced - the caller
+// passes the current user in.
+//
+// Reads/writes are wrapped so a private-mode / quota / absent localStorage never
+// throws: a read-throw reads as not-snoozed (banner shows), a write-throw is
+// swallowed (the dismiss animation still completes; snooze just doesn't persist
+// and the banner returns next boot - acceptable).
+function snoozeKey(userId) {
+	return `${SNOOZE_KEY}:${userId || "anon"}`;
+}
+
+export function readSnooze(userId) {
 	if (typeof localStorage === "undefined") return null;
 	try {
-		return JSON.parse(localStorage.getItem(SNOOZE_KEY)) || null;
+		return JSON.parse(localStorage.getItem(snoozeKey(userId))) || null;
 	} catch {
 		return null;
 	}
 }
 
-export function writeSnooze(notice, now) {
+export function writeSnooze(notice, now, userId) {
 	if (typeof localStorage === "undefined") return;
 	try {
 		const days = notice.banner_interval_days || 7;
 		localStorage.setItem(
-			SNOOZE_KEY,
+			snoozeKey(userId),
 			JSON.stringify({ until: now + days * 86400000, version: notice.version })
 		);
 	} catch {

--- a/frontend/src/releaseNudge.test.js
+++ b/frontend/src/releaseNudge.test.js
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { pillFor, bannerShouldShow, readSnooze, writeSnooze, SNOOZE_KEY } from "./releaseNudge.js";
+
+const DAY = 86400000;
+
+// ---- pillFor: tone/label derivation --------------------------------------
+
+test("pillFor: no notice or no target version -> hidden (never a false 'on the latest')", () => {
+	assert.deepEqual(pillFor(null), { show: false });
+	assert.deepEqual(pillFor(undefined), { show: false });
+	assert.deepEqual(pillFor({}), { show: false });
+	assert.deepEqual(pillFor({ version: "" }), { show: false });
+});
+
+test("pillFor: current (tier none, known version) -> green, branded label", () => {
+	const p = pillFor({ version: "16.4.0", tier: "none", behind: 0 });
+	assert.deepEqual(p, { show: true, tone: "green", label: "On the latest Jarvis" });
+});
+
+test("pillFor: agentName param brands the green label (not an import)", () => {
+	assert.equal(pillFor({ version: "16.4.0", tier: "none" }, "Aida").label, "On the latest Aida");
+});
+
+test("pillFor: soft -> amber; behind>=1 shows the count, behind<1 falls back", () => {
+	assert.deepEqual(pillFor({ version: "16.4.0", tier: "soft", behind: 2 }), {
+		show: true,
+		tone: "amber",
+		label: "2 versions behind",
+	});
+	assert.equal(
+		pillFor({ version: "16.4.0", tier: "soft", behind: 0 }).label,
+		"Update available"
+	);
+	// Old CP: soft without a behind -> 0 -> the fallback label, still amber.
+	assert.equal(pillFor({ version: "16.4.0", tier: "soft" }).label, "Update available");
+});
+
+test("pillFor: hard -> red; behind>=1 shows the count, behind<1 falls back", () => {
+	assert.deepEqual(pillFor({ version: "16.4.0", tier: "hard", behind: 5 }), {
+		show: true,
+		tone: "red",
+		label: "5 versions behind",
+	});
+	assert.equal(pillFor({ version: "16.4.0", tier: "hard", behind: 0 }).label, "Update required");
+});
+
+// ---- bannerShouldShow ----------------------------------------------------
+
+test("bannerShouldShow: soft + no snooze -> true", () => {
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "soft" }, 1000, null), true);
+});
+
+test("bannerShouldShow: only the soft tier with a version can show", () => {
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "none" }, 1000, null), false);
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "hard" }, 1000, null), false);
+	assert.equal(bannerShouldShow({ version: "", tier: "soft" }, 1000, null), false);
+	assert.equal(bannerShouldShow(null, 1000, null), false);
+});
+
+test("bannerShouldShow: same version, unexpired snooze -> false", () => {
+	const snooze = { version: "16.4.0", until: 5000 };
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "soft" }, 1000, snooze), false);
+});
+
+test("bannerShouldShow: same version, expired snooze -> true", () => {
+	const snooze = { version: "16.4.0", until: 5000 };
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "soft" }, 9000, snooze), true);
+});
+
+test("bannerShouldShow: a newer target version supersedes an unexpired snooze -> true", () => {
+	const snooze = { version: "16.4.0", until: 999999 };
+	assert.equal(bannerShouldShow({ version: "16.5.0", tier: "soft" }, 1000, snooze), true);
+});
+
+// ---- snooze read/write ---------------------------------------------------
+
+function installLocalStorage() {
+	const store = new Map();
+	globalThis.localStorage = {
+		getItem: (k) => (store.has(k) ? store.get(k) : null),
+		setItem: (k, v) => store.set(k, String(v)),
+		removeItem: (k) => store.delete(k),
+	};
+	return store;
+}
+
+test("writeSnooze/readSnooze: round-trip with a present localStorage", () => {
+	installLocalStorage();
+	try {
+		writeSnooze({ version: "16.4.0", banner_interval_days: 7 }, 1_000_000);
+		const snooze = readSnooze();
+		assert.equal(snooze.version, "16.4.0");
+		assert.equal(snooze.until, 1_000_000 + 7 * DAY);
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("writeSnooze: missing/zero interval defaults to 7 days", () => {
+	installLocalStorage();
+	try {
+		writeSnooze({ version: "16.4.0" }, 0);
+		assert.equal(readSnooze().until, 7 * DAY);
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("readSnooze: malformed JSON -> null, never throws", () => {
+	installLocalStorage();
+	try {
+		globalThis.localStorage.setItem(SNOOZE_KEY, "{not json");
+		assert.equal(readSnooze(), null);
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("readSnooze/writeSnooze: localStorage absent -> null / no-op, no throw", () => {
+	assert.equal(typeof globalThis.localStorage, "undefined");
+	assert.equal(readSnooze(), null);
+	assert.doesNotThrow(() => writeSnooze({ version: "16.4.0" }, 1000));
+});

--- a/frontend/src/releaseNudge.test.js
+++ b/frontend/src/releaseNudge.test.js
@@ -29,6 +29,11 @@ test("pillFor: soft -> amber; behind>=1 shows the count, behind<1 falls back", (
 		tone: "amber",
 		label: "2 versions behind",
 	});
+	// behind==1 is singular: "1 version behind", never "1 versions behind".
+	assert.equal(
+		pillFor({ version: "16.4.0", tier: "soft", behind: 1 }).label,
+		"1 version behind"
+	);
 	assert.equal(
 		pillFor({ version: "16.4.0", tier: "soft", behind: 0 }).label,
 		"Update available"
@@ -43,6 +48,11 @@ test("pillFor: hard -> red; behind>=1 shows the count, behind<1 falls back", () 
 		tone: "red",
 		label: "5 versions behind",
 	});
+	// behind==1 is singular: "1 version behind", never "1 versions behind".
+	assert.equal(
+		pillFor({ version: "16.4.0", tier: "hard", behind: 1 }).label,
+		"1 version behind"
+	);
 	assert.equal(pillFor({ version: "16.4.0", tier: "hard", behind: 0 }).label, "Update required");
 });
 
@@ -89,8 +99,8 @@ function installLocalStorage() {
 test("writeSnooze/readSnooze: round-trip with a present localStorage", () => {
 	installLocalStorage();
 	try {
-		writeSnooze({ version: "16.4.0", banner_interval_days: 7 }, 1_000_000);
-		const snooze = readSnooze();
+		writeSnooze({ version: "16.4.0", banner_interval_days: 7 }, 1_000_000, "user@a");
+		const snooze = readSnooze("user@a");
 		assert.equal(snooze.version, "16.4.0");
 		assert.equal(snooze.until, 1_000_000 + 7 * DAY);
 	} finally {
@@ -101,8 +111,39 @@ test("writeSnooze/readSnooze: round-trip with a present localStorage", () => {
 test("writeSnooze: missing/zero interval defaults to 7 days", () => {
 	installLocalStorage();
 	try {
-		writeSnooze({ version: "16.4.0" }, 0);
-		assert.equal(readSnooze().until, 7 * DAY);
+		writeSnooze({ version: "16.4.0" }, 0, "user@a");
+		assert.equal(readSnooze("user@a").until, 7 * DAY);
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("snooze is per-user: user A's write doesn't suppress user B's banner", () => {
+	const store = installLocalStorage();
+	try {
+		writeSnooze({ version: "16.4.0", banner_interval_days: 7 }, 1_000_000, "user@a");
+		// A is snoozed...
+		assert.ok(readSnooze("user@a"));
+		// ...but B, who never dismissed, reads no snooze -> the banner still shows.
+		assert.equal(readSnooze("user@b"), null);
+		// The two keys are genuinely distinct in storage.
+		assert.notEqual(`${SNOOZE_KEY}:user@a`, `${SNOOZE_KEY}:user@b`);
+		assert.ok(store.has(`${SNOOZE_KEY}:user@a`));
+		assert.ok(!store.has(`${SNOOZE_KEY}:user@b`));
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("missing userId falls back to a stable 'anon' key (round-trips + matches undefined)", () => {
+	const store = installLocalStorage();
+	try {
+		writeSnooze({ version: "16.4.0", banner_interval_days: 7 }, 1_000_000, undefined);
+		// The write lands under the literal ":anon" bucket...
+		assert.ok(store.has(`${SNOOZE_KEY}:anon`));
+		// ...and a later read with no userId finds the very same snooze (stable key).
+		assert.equal(readSnooze().version, "16.4.0");
+		assert.equal(readSnooze(undefined).version, "16.4.0");
 	} finally {
 		delete globalThis.localStorage;
 	}
@@ -111,8 +152,8 @@ test("writeSnooze: missing/zero interval defaults to 7 days", () => {
 test("readSnooze: malformed JSON -> null, never throws", () => {
 	installLocalStorage();
 	try {
-		globalThis.localStorage.setItem(SNOOZE_KEY, "{not json");
-		assert.equal(readSnooze(), null);
+		globalThis.localStorage.setItem(`${SNOOZE_KEY}:user@a`, "{not json");
+		assert.equal(readSnooze("user@a"), null);
 	} finally {
 		delete globalThis.localStorage;
 	}
@@ -120,6 +161,6 @@ test("readSnooze: malformed JSON -> null, never throws", () => {
 
 test("readSnooze/writeSnooze: localStorage absent -> null / no-op, no throw", () => {
 	assert.equal(typeof globalThis.localStorage, "undefined");
-	assert.equal(readSnooze(), null);
-	assert.doesNotThrow(() => writeSnooze({ version: "16.4.0" }, 1000));
+	assert.equal(readSnooze("user@a"), null);
+	assert.doesNotThrow(() => writeSnooze({ version: "16.4.0" }, 1000, "user@a"));
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -91,6 +91,10 @@
 					<span style="font-size: 11.5px; color: var(--text-3)">{{ headerSub }}</span>
 				</div>
 				<div style="margin-left: auto; display: flex; align-items: center; gap: 8px">
+					<!-- Release-nudge version pill (Slice 3b): always-on "how current is
+					     my Jarvis" status; click opens What's-new. Hidden when the target
+					     version is unknown (VersionPill's own v-if). -->
+					<VersionPill ref="versionPillRef" />
 					<!-- "Go to Desk" — at the rightmost end of the cluster (chat only, via CSS order)
 					     (uniform with LayoutHeader across every page) -->
 					<button
@@ -544,6 +548,12 @@
 					</div>
 				</div>
 			</div>
+
+			<!-- Release-nudge soft banner (Slice 3b): calm info/blue, top-of-chat.
+			     Yields to the greeting/welcome/booting states and to any urgent
+			     billing/readiness alert (updateBannerVisible); dismiss minimises it
+			     into the version pill. Never stacks, never hides chat. -->
+			<UpdateBanner v-if="updateBannerVisible" :pill="versionPillRef" />
 
 			<!-- initial load: a quiet spinner so the welcome screen doesn't flash
 			     before the open conversation finishes loading on refresh -->
@@ -4278,6 +4288,10 @@
 			@confirm="runCompact"
 		/>
 
+		<!-- What's-new panel (Slice 3b): opened by the version pill and the soft
+		     banner via the shared whatsNewOpen ref in noticeGate. -->
+		<WhatsNewDialog />
+
 		<!-- Preview a file the user attached in the composer (before send). Images
 		     enlarge, PDFs/others render in-app; loads over the session cookie so a
 		     private File just works. Sent-message attachments use the artifact
@@ -4366,6 +4380,10 @@ import Composer from "@/components/chat/Composer.vue";
 import FilePreview from "@/components/FilePreview.vue";
 import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import AskCard from "@/components/chat/AskCard.vue";
+import VersionPill from "@/components/chat/VersionPill.vue";
+import UpdateBanner from "@/components/chat/UpdateBanner.vue";
+import WhatsNewDialog from "@/components/chat/WhatsNewDialog.vue";
+import { showBanner } from "@/noticeGate";
 import { parseAsk } from "@/lib/chatAsk";
 import { shouldHideActivityTool, isCustomerFacingTool } from "@/lib/activityTools";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
@@ -4664,6 +4682,39 @@ const billingAlert = computed(() => {
 function dismissBillingAlert() {
 	billingDismissedPhase.value = (billingAlert.value && billingAlert.value.phase) || "";
 }
+
+// ---- Release-nudge soft banner (Slice 3b) ----------------------------------
+// The version pill (header) exposes { getEl, pulse }; the soft banner reaches
+// for it to minimise-into-pill on dismiss.
+const versionPillRef = ref(null);
+// Any composer-region billing/readiness alert that is live. The soft update
+// banner yields to all of them (never stacks, never competes with something the
+// customer must act on) - it is the least urgent surface here.
+const hasUrgentAlert = computed(
+	() =>
+		!!(
+			replacedAlert.value ||
+			billingAlert.value ||
+			suspendedNotice.value ||
+			workersWarnNotice.value ||
+			noAiConnected.value ||
+			containerUnavailable.value ||
+			notReadyNotice.value ||
+			llmApplying.value ||
+			llmApplyStuck.value
+		)
+);
+// The soft banner shows only when: it's a not-snoozed soft notice AND the
+// top-of-chat region is otherwise clear (no greeting/welcome/booting) AND no
+// urgent alert is competing for attention. The pill stays regardless.
+const updateBannerVisible = computed(
+	() =>
+		showBanner.value &&
+		!bizGreeting.value.show &&
+		!showWelcome.value &&
+		!booting.value &&
+		!hasUrgentAlert.value
+);
 // Per-conversation "auto-apply changes" (issue #186): seeded from
 // get_conversation().conversation.auto_apply on each load; the toggle reflects
 // THIS chat. autoApplyNote surfaces the admin-only-enable message.

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -944,6 +944,24 @@ def get_role_profile_config(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	)
 
 
+def get_release_notes(track: str, since_version: str, *, timeout_s: int = 8) -> dict:
+	"""Fetch the cumulative changelog notes newer than ``since_version`` for a
+	release ``track`` (the tenant's major line, e.g. "16").
+
+	Fetched on demand when the customer opens the What's-new panel, so it carries a
+	short 8s budget by default - a slow control plane must not stall the click.
+	``_post`` (via ``_do_post``) unwraps the ``{"ok", "data"}`` envelope, so this
+	returns the bare ``{"notes": [...]}`` payload. Raises the usual
+	``AdminAuthError`` / ``AdminUnreachableError`` family, which the caller
+	(``jarvis.release_notice.notes``) degrades to an empty list.
+	"""
+	return _post(
+		path=_m("api.tenant.get_release_notes"),
+		body={"track": track, "since_version": since_version},
+		timeout_s=timeout_s,
+	)
+
+
 # --------------------------------------------------------------------------- #
 # Support panel proxies (Plan 3 B2). The customer bench forwards requesting_user +
 # scope to the control-plane support endpoints, which re-derive the customer from the

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -130,6 +130,8 @@
   "latest_jarvis_version",
   "release_notice_message",
   "release_notice_tier",
+  "release_notice_behind",
+  "release_banner_interval_days",
   "system_tab",
   "deployment_section",
   "deployment_mode",
@@ -944,6 +946,18 @@
    "fieldname": "release_notice_tier",
    "fieldtype": "Data",
    "label": "Release Notice Tier",
+   "read_only": 1
+  },
+  {
+   "fieldname": "release_notice_behind",
+   "fieldtype": "Int",
+   "label": "Release Notice Behind",
+   "read_only": 1
+  },
+  {
+   "fieldname": "release_banner_interval_days",
+   "fieldtype": "Int",
+   "label": "Release Banner Interval Days",
    "read_only": 1
   },
   {

--- a/jarvis/release_notice.py
+++ b/jarvis/release_notice.py
@@ -6,6 +6,7 @@ tenant that has updated is never stranded by an unreachable control plane.
 """
 
 import frappe
+from frappe.utils import cint
 
 from jarvis import __version__
 
@@ -15,6 +16,8 @@ _FIELDS = (
 	"latest_jarvis_version",
 	"release_notice_message",
 	"release_notice_tier",
+	"release_notice_behind",
+	"release_banner_interval_days",
 )
 _CHECK_CACHE_KEY = "jarvis:release_notice_checked"
 _CHECK_CACHE_TTL_S = 30
@@ -53,6 +56,10 @@ def persist(notice: dict) -> None:
 			# Back-compat: an old CP omits `tier`, so derive it from `active` -- a hard
 			# gate still reads "hard", everything else "none".
 			"release_notice_tier": n.get("tier") or ("hard" if n.get("active") else "none"),
+			# `behind` powers the pill/banner copy; an old CP omits it -> 0. The banner
+			# reappear interval is operator-tunable, defaulting to 7 when absent/0.
+			"release_notice_behind": cint(n.get("behind")),
+			"release_banner_interval_days": cint(n.get("banner_interval_days")) or 7,
 		}
 		current = frappe.db.get_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
 		if all(current.get(k) == v for k, v in fresh.items()):
@@ -63,12 +70,14 @@ def persist(notice: dict) -> None:
 
 
 def boot_payload() -> dict:
-	"""``release_notice`` for context.boot. The SPA gates on `active`."""
+	"""``release_notice`` for context.boot. The SPA gates the hard lockout on
+	`active`; the always-on pill and the soft banner derive their display state
+	from `version`/`tier`/`behind` (no `state` travels on the wire)."""
 	row = frappe.get_cached_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
 	target = (row.get("latest_jarvis_version") or "").strip()
 	# Self-clear: this bench is already at the target, so don't wait on the control
 	# plane to say so - otherwise an unreachable or mis-credentialed admin would
-	# keep an updated tenant blocked with no way out. Clears BOTH tiers.
+	# keep an updated tenant blocked with no way out. Clears BOTH tiers and behind.
 	current = _already_current(target)
 	active = bool(row.get("release_notice_active")) and not current
 	tier = "none" if current else (row.get("release_notice_tier") or ("hard" if active else "none"))
@@ -77,6 +86,8 @@ def boot_payload() -> dict:
 		"version": target,
 		"message": row.get("release_notice_message") or "",
 		"tier": tier,
+		"behind": 0 if current else cint(row.get("release_notice_behind")),
+		"banner_interval_days": cint(row.get("release_banner_interval_days")) or 7,
 	}
 
 
@@ -98,3 +109,29 @@ def check() -> dict:
 		except Exception:
 			pass
 	return boot_payload()
+
+
+@frappe.whitelist(methods=["POST"])
+def notes() -> dict:
+	"""Cumulative "what's new" notes for this bench's major line, fetched on demand
+	when the customer opens the panel. The bench owns the version, so the client
+	passes nothing. Any admin failure (unreachable, or an ``AdminAuthError`` from a
+	lapsed customer behind a stale pill) degrades to an empty list - the panel shows
+	a friendly error, never raw control-plane prose - and is logged."""
+	from jarvis import admin_client
+
+	major = _version(__version__)[0]
+	if major < 15:
+		return {"notes": []}
+	try:
+		res = admin_client.get_release_notes(str(major), __version__, timeout_s=8) or {}
+	except Exception:
+		try:
+			frappe.log_error(
+				title="release_notice.notes: admin unreachable",
+				message=frappe.get_traceback(),
+			)
+		except Exception:
+			pass
+		return {"notes": []}
+	return {"notes": res.get("notes") or []}

--- a/jarvis/release_notice.py
+++ b/jarvis/release_notice.py
@@ -122,6 +122,7 @@ def notes() -> dict:
 
 	major = _version(__version__)[0]
 	if major < 15:
+		# Nothing to show for an unversioned line - NOT an error, so no error flag.
 		return {"notes": []}
 	try:
 		res = admin_client.get_release_notes(str(major), __version__, timeout_s=8) or {}
@@ -133,5 +134,8 @@ def notes() -> dict:
 			)
 		except Exception:
 			pass
-		return {"notes": []}
+		# A genuine fetch failure (unreachable admin, or an AdminAuthError from a
+		# lapsed customer): flag it so the panel shows its error state + Retry,
+		# never the misleading "all caught up".
+		return {"notes": [], "error": True}
 	return {"notes": res.get("notes") or []}

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1040,6 +1040,16 @@ class TestOnboardingClient(FrappeTestCase):
 			out = admin_client.get_plans()
 		self.assertEqual(out[0]["name"], "p1")
 
+	def test_get_release_notes_posts_track_and_since_with_short_budget(self):
+		with patch.object(admin_client, "_post", return_value={"notes": [{"version": "16.4.0"}]}) as mp:
+			out = admin_client.get_release_notes("16", "16.2.0")
+		mp.assert_called_once_with(
+			path=admin_client._m("api.tenant.get_release_notes"),
+			body={"track": "16", "since_version": "16.2.0"},
+			timeout_s=8,
+		)
+		self.assertEqual(out["notes"][0]["version"], "16.4.0")
+
 	def test_get_connection_unwraps_data(self):
 		_settings_for_admin()
 		with patch(

--- a/jarvis/tests/test_release_notice.py
+++ b/jarvis/tests/test_release_notice.py
@@ -18,6 +18,8 @@ _FIELDS = (
 	"latest_jarvis_version",
 	"release_notice_message",
 	"release_notice_tier",
+	"release_notice_behind",
+	"release_banner_interval_days",
 )
 
 
@@ -148,6 +150,115 @@ class TestBootPayload(FrappeTestCase):
 		release_notice.persist({"active": 1, "tier": "hard", "version": NEWER, "message": "m"})
 		release_notice.persist({})
 		self.assertEqual(release_notice.boot_payload()["tier"], "none")
+
+	# -- behind / banner interval (Slice 3b) ----------------------------------
+
+	def test_boot_soft(self):
+		self._set(
+			release_notice_active=0,
+			latest_jarvis_version=NEWER,
+			release_notice_tier="soft",
+			release_notice_behind=2,
+			release_banner_interval_days=14,
+		)
+		p = release_notice.boot_payload()
+		self.assertEqual(p["tier"], "soft")
+		self.assertEqual(p["behind"], 2)
+		self.assertFalse(p["active"])
+		self.assertEqual(p["banner_interval_days"], 14)
+
+	def test_boot_hard_active_true(self):
+		self._set(
+			release_notice_active=1,
+			latest_jarvis_version=NEWER,
+			release_notice_tier="hard",
+			release_notice_behind=4,
+		)
+		p = release_notice.boot_payload()
+		self.assertEqual(p["tier"], "hard")
+		self.assertTrue(p["active"])
+		self.assertEqual(p["behind"], 4)
+
+	def test_boot_current_zeroes_behind(self):
+		# Bench already at/past target: `behind` reads 0 regardless of a stale stored value.
+		self._set(
+			release_notice_active=1,
+			latest_jarvis_version=__version__,
+			release_notice_tier="hard",
+			release_notice_behind=9,
+		)
+		p = release_notice.boot_payload()
+		self.assertEqual(p["behind"], 0)
+		self.assertEqual(p["tier"], "none")
+		self.assertFalse(p["active"])
+
+	def test_self_clear_forces_current(self):
+		# The bench holds the target version -> everything reads current even with a
+		# stored hard tier and a non-zero behind (control plane need not be reachable).
+		release_notice.persist(
+			{"active": 1, "tier": "hard", "version": __version__, "message": "m", "behind": 5}
+		)
+		p = release_notice.boot_payload()
+		self.assertFalse(p["active"])
+		self.assertEqual(p["tier"], "none")
+		self.assertEqual(p["behind"], 0)
+
+	def test_active_equals_tier_hard(self):
+		# The load-bearing invariant: active is true exactly when the tier is hard,
+		# across every producible tier.
+		for tier, act in (("hard", 1), ("soft", 0), ("none", 0)):
+			release_notice.persist(
+				{"active": act, "tier": tier, "version": NEWER, "message": "m", "behind": 1}
+			)
+			p = release_notice.boot_payload()
+			self.assertEqual(p["active"], p["tier"] == "hard", tier)
+
+	def test_oldcp_no_behind_defaults_zero(self):
+		# An old CP omits `behind`; persist stores 0 and boot reports 0 (no crash, no stale).
+		release_notice.persist({"active": 0, "tier": "soft", "version": NEWER, "message": "m"})
+		self.assertEqual(release_notice.boot_payload()["behind"], 0)
+
+	def test_oldcp_no_interval_defaults_seven(self):
+		# An old CP omits `banner_interval_days`; persist/boot default it to 7.
+		release_notice.persist({"active": 0, "tier": "soft", "version": NEWER, "message": "m"})
+		self.assertEqual(release_notice.boot_payload()["banner_interval_days"], 7)
+
+
+class TestNotes(FrappeTestCase):
+	"""jarvis.release_notice.notes() derives the track + since-version from the bench's
+	own version and degrades every admin failure to an empty list."""
+
+	def test_notes_derives_track_and_since(self):
+		with (
+			patch.object(release_notice, "__version__", "16.2.0"),
+			patch(
+				"jarvis.admin_client.get_release_notes",
+				return_value={"notes": [{"version": "16.4.0"}]},
+			) as gn,
+		):
+			out = release_notice.notes()
+		gn.assert_called_once_with("16", "16.2.0", timeout_s=8)
+		self.assertEqual(out, {"notes": [{"version": "16.4.0"}]})
+
+	def test_notes_swallows_and_logs_admin_error(self):
+		with (
+			patch.object(release_notice, "__version__", "16.2.0"),
+			patch("jarvis.admin_client.get_release_notes", side_effect=RuntimeError("boom")),
+			patch("frappe.log_error") as log,
+		):
+			out = release_notice.notes()
+		self.assertEqual(out, {"notes": []})
+		log.assert_called_once()
+
+	def test_notes_unversioned_empty(self):
+		# major < 15 short-circuits before any admin round-trip.
+		with (
+			patch.object(release_notice, "__version__", "0.0.1"),
+			patch("jarvis.admin_client.get_release_notes") as gn,
+		):
+			out = release_notice.notes()
+		self.assertEqual(out, {"notes": []})
+		gn.assert_not_called()
 
 
 class TestVersionParse(FrappeTestCase):

--- a/jarvis/tests/test_release_notice.py
+++ b/jarvis/tests/test_release_notice.py
@@ -239,6 +239,9 @@ class TestNotes(FrappeTestCase):
 			out = release_notice.notes()
 		gn.assert_called_once_with("16", "16.2.0", timeout_s=8)
 		self.assertEqual(out, {"notes": [{"version": "16.4.0"}]})
+		# A clean success never carries the error flag -> the panel shows notes /
+		# "all caught up", never its error state.
+		self.assertNotIn("error", out)
 
 	def test_notes_swallows_and_logs_admin_error(self):
 		with (
@@ -247,17 +250,37 @@ class TestNotes(FrappeTestCase):
 			patch("frappe.log_error") as log,
 		):
 			out = release_notice.notes()
-		self.assertEqual(out, {"notes": []})
+		# A genuine fetch failure flags the error so the panel shows its error state
+		# (+ Retry), NOT the misleading "all caught up" empty state.
+		self.assertEqual(out, {"notes": [], "error": True})
 		log.assert_called_once()
 
+	def test_notes_auth_error_returns_empty(self):
+		# A lapsed customer behind a stale pill: get_release_notes raises AdminAuthError.
+		# notes() must swallow it (never propagate raw CP prose) and flag the error state.
+		from jarvis.exceptions import AdminAuthError
+
+		with (
+			patch.object(release_notice, "__version__", "16.2.0"),
+			patch(
+				"jarvis.admin_client.get_release_notes",
+				side_effect=AdminAuthError("lapsed", status_code=403),
+			),
+			patch("frappe.log_error"),
+		):
+			out = release_notice.notes()
+		self.assertEqual(out, {"notes": [], "error": True})
+
 	def test_notes_unversioned_empty(self):
-		# major < 15 short-circuits before any admin round-trip.
+		# major < 15 short-circuits before any admin round-trip. "Nothing to show" is
+		# NOT an error, so no error flag travels -> the panel shows "all caught up".
 		with (
 			patch.object(release_notice, "__version__", "0.0.1"),
 			patch("jarvis.admin_client.get_release_notes") as gn,
 		):
 			out = release_notice.notes()
 		self.assertEqual(out, {"notes": []})
+		self.assertNotIn("error", out)
 		gn.assert_not_called()
 
 

--- a/pwa/src/App.vue
+++ b/pwa/src/App.vue
@@ -3,10 +3,13 @@ import { onMounted, onUnmounted, inject } from "vue";
 import { useRouter } from "vue-router";
 import AppDrawer from "./components/AppDrawer.vue";
 import InstallBanner from "./components/InstallBanner.vue";
+import UpdateBanner from "./components/UpdateBanner.vue";
 import UpdateNoticeGate from "./components/UpdateNoticeGate.vue";
+import WhatsNewSheet from "./components/WhatsNewSheet.vue";
 import { store } from "./store";
 import { sessionUser } from "./router";
-import { showNotice } from "./noticeGate";
+import { showBanner, showNotice } from "./noticeGate";
+import { installBannerVisible } from "./lib/installBanner";
 import { prefs } from "./lib/prefs";
 import { agentName } from "@/branding";
 import { flushBuffered } from "@shared/lib/errorReporter";
@@ -117,6 +120,12 @@ onUnmounted(() => {
 		<!-- First child, in the flow: the install strip pushes the app down rather
 		     than covering any part of it. -->
 		<InstallBanner />
+		<!-- Release-nudge soft banner (Slice 3b): top-of-app, next to the install
+		     strip. Yields to InstallBanner (installBannerVisible - only one top
+		     slot shows at a time) and to a signed-out visitor (nothing to nudge on
+		     the login screen). Dismiss minimises it into whichever VersionPill is
+		     currently mounted (ChatView's header; see noticeGate.js's pillHandle). -->
+		<UpdateBanner v-if="showBanner && !installBannerVisible && sessionUser()" />
 		<router-view v-slot="{ Component }">
 			<component :is="Component" />
 		</router-view>
@@ -124,5 +133,9 @@ onUnmounted(() => {
 		<!-- Release-notice overlay: a hard block above the app for a signed-in
 		     user, until the control plane stops serving the notice. -->
 		<UpdateNoticeGate v-if="showNotice && sessionUser()" />
+		<!-- What's-new sheet (Slice 3b): ONE global instance, opened from the
+		     pill, the soft banner above, and the hard gate's "See what's new"
+		     link, all via the shared whatsNewOpen ref. -->
+		<WhatsNewSheet />
 	</div>
 </template>

--- a/pwa/src/components/InstallBanner.vue
+++ b/pwa/src/components/InstallBanner.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watchEffect } from "vue";
 import { installPrompt, isStandalone } from "../install";
 import { agentName } from "@/branding";
 import BrandMark from "./BrandMark.vue";
+import { installBannerVisible } from "../lib/installBanner";
 
 // "Add Jarvis to your home screen." Two different worlds:
 //  - Chrome/Android fires beforeinstallprompt. That event is captured in
@@ -38,6 +39,13 @@ const show = computed(
 		!isStandalone() &&
 		(!!installPrompt.value || isIos.value || insecure.value)
 );
+
+// Slice 3b: expose this banner's visibility so App.vue can keep the
+// release-nudge banner out of the same top-of-app slot (see
+// lib/installBanner.js and App.vue's UpdateBanner v-if).
+watchEffect(() => {
+	installBannerVisible.value = show.value;
+});
 
 async function install() {
 	const e = installPrompt.value;

--- a/pwa/src/components/UpdateBanner.vue
+++ b/pwa/src/components/UpdateBanner.vue
@@ -1,0 +1,207 @@
+<script setup>
+// UpdateBanner: the occasional soft nudge that a newer app version exists
+// (Slice 3b), mirroring the desktop SPA's chat/UpdateBanner.vue in the PWA's
+// own idiom. Mounted at the app shell (App.vue), right next to InstallBanner -
+// NOT inside ChatView - because in the PWA the version pill is chat-only but
+// this nudge is app-wide (see noticeGate.js's pillHandle for how the two find
+// each other across that split).
+//
+// Dismiss ("Remind me later" or x) plays a short minimise-into-pill FLIP
+// toward whichever VersionPill instance is currently registered (null when the
+// user isn't on the Chat route, or before ChatView has mounted one - in which
+// case this degrades to a plain hide), then snoozes per-device. Honors
+// prefers-reduced-motion (instant hide + snooze, no FLIP/pulse). Visibility
+// (yield to InstallBanner, and to a signed-out visitor) is decided by the
+// caller's v-if in App.vue.
+import { ref } from "vue";
+import { agentName } from "@/branding";
+import { pillHandle, snoozeBanner, openWhatsNew } from "../noticeGate";
+
+const message = `A new version of ${agentName} is available — ask your administrator to update.`;
+
+const bannerEl = ref(null);
+const flipStyle = ref({});
+
+function reducedMotion() {
+	try {
+		return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+	} catch (e) {
+		return false;
+	}
+}
+
+function dismiss() {
+	const el = bannerEl.value;
+	const pill = pillHandle.current;
+	const pillEl = pill && pill.getEl ? pill.getEl() : null;
+
+	// Reduced motion, or no banner element: instant hide + snooze.
+	if (reducedMotion() || !el) {
+		snoozeBanner();
+		return;
+	}
+
+	const from = el.getBoundingClientRect();
+	const to = pillEl && pillEl.getBoundingClientRect ? pillEl.getBoundingClientRect() : null;
+
+	// No pill registered right now (not on the Chat route), or its rect is
+	// unmeasurable (hidden/offscreen): degrade to a plain hide + snooze.
+	if (!to || !to.width || !to.height) {
+		snoozeBanner();
+		return;
+	}
+
+	const dx = to.left + to.width / 2 - (from.left + from.width / 2);
+	const dy = to.top + to.height / 2 - (from.top + from.height / 2);
+
+	// Small catch-pulse on the pill as the banner arrives (~end of the hop).
+	setTimeout(() => {
+		if (pill && pill.pulse) pill.pulse();
+	}, 380);
+
+	flipStyle.value = {
+		transition: "transform 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.5s ease",
+		transformOrigin: "center",
+		willChange: "transform, opacity",
+	};
+	requestAnimationFrame(() => {
+		flipStyle.value = {
+			...flipStyle.value,
+			transform: `translate(${dx}px, ${dy}px) scale(0.05)`,
+			opacity: 0,
+			pointerEvents: "none",
+		};
+	});
+
+	// Snooze (which unmounts us via the reactive showBanner) once the hop ends.
+	// transitionend fires per-property; `done` guards the double fire, and the
+	// timeout is a safety net if transitionend never arrives.
+	let done = false;
+	const finish = () => {
+		if (done) return;
+		done = true;
+		snoozeBanner();
+	};
+	el.addEventListener("transitionend", finish, { once: true });
+	setTimeout(finish, 650);
+}
+</script>
+
+<template>
+	<!-- Calm info/blue treatment - NOT the alarm amber the hard gate implies.
+	     The wrapper is the FLIP target that minimises into the version pill on
+	     dismiss. -->
+	<div ref="bannerEl" class="jv-updatebanner" :style="flipStyle">
+		<svg
+			class="jv-ub-icon"
+			viewBox="0 0 24 24"
+			width="16"
+			height="16"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		>
+			<circle cx="12" cy="12" r="9" />
+			<path d="M12 8v5M12 16h.01" />
+		</svg>
+		<div class="jv-ub-text">{{ message }}</div>
+		<div class="jv-ub-actions">
+			<button class="jv-ub-btn" type="button" @click="openWhatsNew">What's new</button>
+			<button class="jv-ub-btn jv-ub-btn--ghost" type="button" @click="dismiss">
+				Remind me later
+			</button>
+			<button
+				class="jv-ub-x"
+				type="button"
+				aria-label="Dismiss update banner"
+				@click="dismiss"
+			>
+				<svg
+					viewBox="0 0 24 24"
+					width="14"
+					height="14"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+				>
+					<path d="M18 6 6 18M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.jv-updatebanner {
+	flex: none;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 10px;
+	margin: 8px 12px 0;
+	padding: 12px;
+	border-radius: 14px;
+	background: var(--blue-bg);
+	border: 1px solid color-mix(in srgb, var(--blue) 35%, transparent);
+	color: var(--blue);
+}
+.jv-ub-icon {
+	flex: none;
+}
+.jv-ub-text {
+	flex: 1;
+	min-width: 160px;
+	font-size: 13px;
+	line-height: 1.4;
+	color: var(--ink7);
+}
+.jv-ub-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: none;
+}
+.jv-ub-btn {
+	height: 30px;
+	padding: 0 11px;
+	border: 1px solid color-mix(in srgb, var(--blue) 40%, transparent);
+	border-radius: 8px;
+	background: transparent;
+	font-family: inherit;
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--blue);
+	cursor: pointer;
+	white-space: nowrap;
+}
+.jv-ub-btn--ghost {
+	border-color: transparent;
+	color: var(--ink6);
+}
+.jv-ub-btn:active {
+	background: color-mix(in srgb, var(--blue) 16%, transparent);
+}
+.jv-ub-btn:focus-visible,
+.jv-ub-x:focus-visible {
+	outline: 2px solid var(--blue);
+	outline-offset: 2px;
+}
+.jv-ub-x {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	flex: none;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--ink5);
+	cursor: pointer;
+}
+.jv-ub-x:active {
+	background: color-mix(in srgb, var(--ink9) 10%, transparent);
+}
+</style>

--- a/pwa/src/components/UpdateNoticeGate.vue
+++ b/pwa/src/components/UpdateNoticeGate.vue
@@ -2,7 +2,7 @@
 import { onMounted, onBeforeUnmount } from "vue";
 import BrandMark from "./BrandMark.vue";
 import { agentName } from "@/branding";
-import { checking, notice, recheck } from "../noticeGate";
+import { checking, notice, openWhatsNew, recheck } from "../noticeGate";
 
 // The PWA never calls the chat-readiness gate, so this is its only way to learn
 // the notice was lifted short of the daily sync.
@@ -34,6 +34,8 @@ onBeforeUnmount(() => clearInterval(timer));
 			<button class="jv-nu-btn" :disabled="checking" @click="recheck">
 				{{ checking ? "Checking…" : "I've updated, check again" }}
 			</button>
+
+			<button type="button" class="jv-nu-link" @click="openWhatsNew">See what's new</button>
 		</div>
 	</div>
 </template>
@@ -106,5 +108,21 @@ onBeforeUnmount(() => clearInterval(timer));
 .jv-nu-btn:disabled {
 	opacity: 0.6;
 	cursor: default;
+}
+.jv-nu-link {
+	margin-top: 2px;
+	border: none;
+	background: transparent;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--accent, #6e5cf6);
+	cursor: pointer;
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+.jv-nu-link:focus-visible {
+	outline: 2px solid var(--accent, #6e5cf6);
+	outline-offset: 2px;
+	border-radius: 4px;
 }
 </style>

--- a/pwa/src/components/VersionPill.vue
+++ b/pwa/src/components/VersionPill.vue
@@ -1,0 +1,141 @@
+<script setup>
+// VersionPill: the customer-facing "how current is my Jarvis" signal
+// (Slice 3b), mirroring the desktop SPA's chat/VersionPill.vue in the PWA's
+// own hand-styled .jv- idiom. Mounted in ChatView's tight .jv-bar header row,
+// so it stays compact: a coloured dot + a label that truncates rather than
+// wrapping. The label is derived once from the stable boot payload (pillFor) -
+// no per-render work. No pill at all when the target version is unknown
+// (never a false "current").
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import { pillFor } from "@shared/releaseNudge";
+import { notice, openWhatsNew, pillHandle } from "../noticeGate";
+import { agentName } from "@/branding";
+
+const btnEl = ref(null);
+const pulsing = ref(false);
+
+// Boot payload is stable for the page's lifetime, so derive once.
+const pill = pillFor(notice, agentName);
+
+// The soft banner's minimise-into-pill animation calls this as the banner
+// "arrives", for a small catch-pulse. Restart-safe on repeat dismisses; the
+// CSS keyframe is disabled under prefers-reduced-motion (below).
+function pulse() {
+	pulsing.value = false;
+	requestAnimationFrame(() => {
+		pulsing.value = true;
+	});
+}
+
+// The app-shell UpdateBanner (a different template entirely - see
+// noticeGate.js) needs this pill's rect (FLIP target) and its pulse(). Register
+// on mount, clear on unmount, so a banner shown outside the Chat route finds no
+// target and degrades to a plain hide.
+const handle = { getEl: () => btnEl.value, pulse };
+onMounted(() => {
+	pillHandle.current = handle;
+});
+onBeforeUnmount(() => {
+	if (pillHandle.current === handle) pillHandle.current = null;
+});
+
+defineExpose({ getEl: handle.getEl, pulse });
+</script>
+
+<template>
+	<button
+		v-if="pill.show"
+		ref="btnEl"
+		type="button"
+		class="jv-versionpill"
+		:class="['jv-tone-' + pill.tone, { 'jv-pill-pulse': pulsing }]"
+		:aria-label="pill.label"
+		:title="pill.label"
+		@click="openWhatsNew"
+		@animationend="pulsing = false"
+	>
+		<span class="jv-pill-dot" aria-hidden="true"></span>
+		<span class="jv-pill-label">{{ pill.label }}</span>
+	</button>
+</template>
+
+<style scoped>
+.jv-versionpill {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	max-width: 112px;
+	flex: none;
+	padding: 5px 9px;
+	background: var(--card2);
+	border: 1px solid var(--border2);
+	border-radius: 20px;
+	cursor: pointer;
+	font-family: inherit;
+	line-height: 1;
+}
+.jv-versionpill:active {
+	background: var(--card3);
+}
+.jv-versionpill:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.jv-pill-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	flex: none;
+	background: var(--ink5);
+}
+.jv-pill-label {
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--ink6);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* Tone drives the dot AND the label colour, straight off the app palette. */
+.jv-tone-green .jv-pill-dot {
+	background: var(--green);
+}
+.jv-tone-green .jv-pill-label {
+	color: var(--green);
+}
+.jv-tone-amber .jv-pill-dot {
+	background: var(--amber);
+}
+.jv-tone-amber .jv-pill-label {
+	color: var(--amber);
+}
+.jv-tone-red .jv-pill-dot {
+	background: var(--red);
+}
+.jv-tone-red .jv-pill-label {
+	color: var(--red);
+}
+
+/* Catch-pulse when the soft banner minimises into the pill. */
+@keyframes jvPillPulse {
+	0% {
+		transform: scale(1);
+	}
+	45% {
+		transform: scale(1.16);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+.jv-pill-pulse {
+	animation: jvPillPulse 0.45s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-pill-pulse {
+		animation: none;
+	}
+}
+</style>

--- a/pwa/src/components/VersionPill.vue
+++ b/pwa/src/components/VersionPill.vue
@@ -16,6 +16,9 @@ const pulsing = ref(false);
 
 // Boot payload is stable for the page's lifetime, so derive once.
 const pill = pillFor(notice, agentName);
+// The screen-reader label names the action ("… — see what's new"); the visible
+// text stays the terse status label. Only meaningful when the pill renders.
+const pillAriaLabel = pill.show ? `${pill.label} — see what's new` : "";
 
 // The soft banner's minimise-into-pill animation calls this as the banner
 // "arrives", for a small catch-pulse. Restart-safe on repeat dismisses; the
@@ -49,7 +52,7 @@ defineExpose({ getEl: handle.getEl, pulse });
 		type="button"
 		class="jv-versionpill"
 		:class="['jv-tone-' + pill.tone, { 'jv-pill-pulse': pulsing }]"
-		:aria-label="pill.label"
+		:aria-label="pillAriaLabel"
 		:title="pill.label"
 		@click="openWhatsNew"
 		@animationend="pulsing = false"

--- a/pwa/src/components/WhatsNewSheet.vue
+++ b/pwa/src/components/WhatsNewSheet.vue
@@ -1,0 +1,221 @@
+<script setup>
+// WhatsNewSheet: the fetch-on-click "What's new" panel (Slice 3b), mirroring
+// the desktop SPA's WhatsNewDialog.vue - but as a bottom Sheet (modeled on
+// DecisionSheet.vue), since there is no frappe-ui Dialog anywhere in this app.
+// Mounted ONCE at the app shell (App.vue) and opened from three places - the
+// version pill, the soft banner, and the hard gate - all via the shared
+// `whatsNewOpen` ref in noticeGate.js.
+//
+// The bench owns the version, so notes() takes no arguments (it derives track
+// + since from jarvis.__version__). The result is cached per target version so
+// re-opening the sheet never refetches - `notice.version` is stable for the
+// page's lifetime (a hard-gate recheck forces a full reload).
+import { ref, watch } from "vue";
+import { call } from "frappe-ui";
+import Sheet from "./Sheet.vue";
+import { renderMarkdown } from "@shared/markdown.js";
+import { notice, whatsNewOpen } from "../noticeGate";
+import { agentName } from "@/branding";
+
+// Module-scope cache keyed by target version, so it survives close/reopen.
+const NOTES_CACHE = new Map();
+
+const loading = ref(false);
+const error = ref(false);
+const notes = ref([]);
+
+async function load(force = false) {
+	const key = notice.version || "";
+	if (!force && NOTES_CACHE.has(key)) {
+		notes.value = NOTES_CACHE.get(key);
+		loading.value = false;
+		error.value = false;
+		return;
+	}
+	loading.value = true;
+	error.value = false;
+	try {
+		const res = await call("jarvis.release_notice.notes");
+		const list = (res && res.notes) || [];
+		NOTES_CACHE.set(key, list);
+		notes.value = list;
+	} catch (e) {
+		// Never surface raw CP prose - a lapsed customer (AdminAuthError) or an
+		// unreachable admin both land here as the same friendly error state.
+		error.value = true;
+	} finally {
+		loading.value = false;
+	}
+}
+
+watch(whatsNewOpen, (isOpen) => {
+	if (isOpen) load();
+});
+
+function close() {
+	whatsNewOpen.value = false;
+}
+</script>
+
+<template>
+	<Sheet :open="whatsNewOpen" @close="close">
+		<div class="jv-wnew">
+			<div class="jv-wnew-head">
+				<div class="jv-wnew-title">What's new in {{ agentName }}</div>
+				<button class="jv-icon-btn" aria-label="Close" @click="close">
+					<svg
+						viewBox="0 0 24 24"
+						width="18"
+						height="18"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+					>
+						<path d="M18 6 6 18M6 6l12 12" />
+					</svg>
+				</button>
+			</div>
+
+			<div class="jv-wnew-body">
+				<!-- loading: between open and the notes() resolve -->
+				<div v-if="loading" class="jv-wnew-state">
+					<span class="jv-spinner" />
+				</div>
+
+				<!-- error: friendly, never raw control-plane text -->
+				<div v-else-if="error" class="jv-wnew-state is-error">
+					<span>Couldn't load release notes. Please try again in a moment.</span>
+					<button class="jv-wnew-retry" type="button" @click="load(true)">Retry</button>
+				</div>
+
+				<!-- empty: nothing newer than this workspace -->
+				<div v-else-if="!notes.length" class="jv-wnew-state">
+					<span>You're all caught up.</span>
+				</div>
+
+				<!-- notes, newest first: version heading via {{ }} (never v-html),
+				     body via renderMarkdown (escape-first, XSS-safe) in a prose block -->
+				<div v-else class="jv-wnew-notes">
+					<section v-for="note in notes" :key="note.version">
+						<div class="jv-wnew-note-head">
+							<h3 class="jv-wnew-note-version">{{ note.version }}</h3>
+							<span v-if="note.title" class="jv-wnew-note-title">{{
+								note.title
+							}}</span>
+						</div>
+						<div
+							class="prose prose-sm max-w-none jv-wnew-note-body"
+							v-html="renderMarkdown(note.body)"
+						></div>
+					</section>
+				</div>
+			</div>
+		</div>
+	</Sheet>
+</template>
+
+<style scoped>
+/* This sheet is reachable from the hard gate (UpdateNoticeGate, z-index 1000)
+   via its "See what's new" link, so it must render above it - Sheet.vue's own
+   z-index (60) is meant for the ordinary case of one sheet over the thread.
+   No :deep() needed: a child component's ROOT node carries this component's
+   own scope attribute too (same convention as ChatView.vue's ".jv-tools"
+   comment), and .jv-sheet-root is Sheet.vue's root. */
+.jv-sheet-root {
+	z-index: 1100;
+}
+
+.jv-wnew {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	max-height: 80dvh;
+}
+.jv-wnew-head {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 8px 10px 20px;
+	border-bottom: 1px solid var(--border);
+	flex: none;
+}
+.jv-wnew-title {
+	flex: 1;
+	min-width: 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--ink9);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-wnew-body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 16px 20px 24px;
+}
+.jv-wnew-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+	padding: 40px 16px;
+	font-size: 13.5px;
+	color: var(--ink5);
+	text-align: center;
+}
+.jv-wnew-state.is-error {
+	color: var(--ink6);
+}
+.jv-wnew-retry {
+	padding: 8px 16px;
+	border: 1px solid var(--border2);
+	border-radius: 9px;
+	background: var(--card);
+	color: var(--ink8);
+	font: inherit;
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
+}
+.jv-wnew-notes {
+	display: flex;
+	flex-direction: column;
+	gap: 22px;
+}
+.jv-wnew-note-head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 8px;
+}
+.jv-wnew-note-version {
+	margin: 0;
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--ink9);
+}
+.jv-wnew-note-title {
+	font-size: 13px;
+	color: var(--ink6);
+}
+.jv-wnew-note-body {
+	margin-top: 4px;
+	color: var(--ink7);
+}
+.jv-spinner {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	border: 2px solid var(--card3);
+	border-top-color: var(--accent);
+	animation: jv-spin 0.7s linear infinite;
+}
+@keyframes jv-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/pwa/src/components/WhatsNewSheet.vue
+++ b/pwa/src/components/WhatsNewSheet.vue
@@ -36,6 +36,12 @@ async function load(force = false) {
 	error.value = false;
 	try {
 		const res = await call("jarvis.release_notice.notes");
+		// A flagged fetch failure degrades to the friendly error state, NOT the
+		// "all caught up" empty state - and is never cached, so Retry refetches.
+		if (res && res.error) {
+			error.value = true;
+			return;
+		}
 		const list = (res && res.notes) || [];
 		NOTES_CACHE.set(key, list);
 		notes.value = list;

--- a/pwa/src/index.css
+++ b/pwa/src/index.css
@@ -36,6 +36,10 @@
 	--amber: #b35309;
 	--amber-bg: #fff7d3;
 	--amber-dot: #db7706;
+	/* Calm "info" tone for the release-nudge soft banner (Slice 3b) - distinct
+	   from the amber/red alert tones above, which read as warnings. */
+	--blue: #1c6dc4;
+	--blue-bg: #e8f2fc;
 	--inv-bg: #171717;
 	--inv-ink: #ffffff;
 	--scrim: rgba(20, 20, 22, 0.34);
@@ -82,6 +86,8 @@
 		--amber: #e8a845;
 		--amber-bg: #3a2c1c;
 		--amber-dot: #e37d00;
+		--blue: #6fb3f5;
+		--blue-bg: #1c2c3d;
 		--inv-bg: #f5f4ee;
 		--inv-ink: #262624;
 		--scrim: rgba(0,0,0,0.6);
@@ -113,6 +119,8 @@
 	--amber: #e8a845;
 	--amber-bg: #3a2c1c;
 	--amber-dot: #e37d00;
+	--blue: #6fb3f5;
+	--blue-bg: #1c2c3d;
 	--inv-bg: #f5f4ee;
 	--inv-ink: #262624;
 	--scrim: rgba(0,0,0,0.6);

--- a/pwa/src/lib/installBanner.js
+++ b/pwa/src/lib/installBanner.js
@@ -1,0 +1,9 @@
+import { ref } from "vue";
+
+// InstallBanner's visibility, lifted out of its own private `show` computed
+// (Slice 3b) so App.vue can gate the release-nudge banner on it: only one
+// top-of-app strip shows at a time - the install offer and the soft update
+// nudge must never stack in the same slot. InstallBanner keeps owning the real
+// dismissed/isIos/insecure state that decides `show`; this ref is just that
+// derived boolean, kept in sync by a watchEffect over there.
+export const installBannerVisible = ref(false);

--- a/pwa/src/noticeGate.js
+++ b/pwa/src/noticeGate.js
@@ -7,8 +7,13 @@
 import { computed, ref } from "vue";
 import { call } from "frappe-ui";
 import { bannerShouldShow, writeSnooze, readSnooze } from "@shared/releaseNudge";
+import { sessionUser } from "./router";
 
 const n = window.release_notice || {};
+
+// Namespace the snooze by the signed-in user, so two people sharing a browser
+// profile keep independent snoozes; guest / signed-out -> "anon".
+const userId = sessionUser() || "anon";
 
 // The boot payload is stable for the page's lifetime, so this is a plain object
 // (not reactive): pillFor()/bannerShouldShow() read it, and it never changes.
@@ -32,7 +37,7 @@ export const showNotice = computed(() => notice.active && !cleared.value);
 // The snooze lives in localStorage; this ref mirrors it so the banner hides
 // reactively the moment it is snoozed. Seeded from storage at boot (a read-throw
 // reads as not-snoozed, so the banner shows - see readSnooze()).
-const snooze = ref(readSnooze());
+const snooze = ref(readSnooze(userId));
 
 // Reactive: soft tier AND not currently snoozed. `Date.now()` is read at
 // evaluation time; the only reactive dependency is `snooze`, so snoozing (which
@@ -46,7 +51,7 @@ export const showBanner = computed(() => bannerShouldShow(notice, Date.now(), sn
 // next boot - the accepted edge behaviour, spec §6).
 export function snoozeBanner() {
 	const now = Date.now();
-	writeSnooze(notice, now);
+	writeSnooze(notice, now, userId);
 	const days = notice.banner_interval_days || 7;
 	snooze.value = { until: now + days * 86400000, version: notice.version };
 }

--- a/pwa/src/noticeGate.js
+++ b/pwa/src/noticeGate.js
@@ -1,24 +1,79 @@
 // Release notice for the mobile PWA, delivered by jarvis_mobile.py boot as
-// window.release_notice = {active, version, message}. Mirrors src/noticeGate.js.
+// window.release_notice = {active, version, message, tier, behind,
+// banner_interval_days}. The hard gate keys off `active`; the customer-facing
+// version pill + soft banner (Slice 3b) derive their display state from
+// `version` + `tier` + `behind` via the shared, node-testable `releaseNudge.js`.
+// Mirrors the desktop SPA's src/noticeGate.js in the PWA's own idiom.
 import { computed, ref } from "vue";
 import { call } from "frappe-ui";
+import { bannerShouldShow, writeSnooze, readSnooze } from "@shared/releaseNudge";
 
 const n = window.release_notice || {};
 
+// The boot payload is stable for the page's lifetime, so this is a plain object
+// (not reactive): pillFor()/bannerShouldShow() read it, and it never changes.
 export const notice = {
 	active: !!n.active,
 	version: (n.version || "").trim(),
 	message: n.message || "",
+	tier: n.tier || "none",
+	behind: Number(n.behind) || 0,
+	banner_interval_days: Number(n.banner_interval_days) || 7,
 };
 
 const cleared = ref(false);
 export const checking = ref(false);
 
-// Hard gate: no dismiss. It lifts only when the control plane stops serving it.
+// Hard gate: no dismiss. It lifts only when the control plane stops serving the
+// notice (this tenant updated, or the operator retired it).
 export const showNotice = computed(() => notice.active && !cleared.value);
 
-// The PWA never calls the chat-readiness gate, so without this it would stay
-// blocked until the daily sync even after the tenant updated.
+// ---- Soft banner (snooze-per-device) ---------------------------------------
+// The snooze lives in localStorage; this ref mirrors it so the banner hides
+// reactively the moment it is snoozed. Seeded from storage at boot (a read-throw
+// reads as not-snoozed, so the banner shows - see readSnooze()).
+const snooze = ref(readSnooze());
+
+// Reactive: soft tier AND not currently snoozed. `Date.now()` is read at
+// evaluation time; the only reactive dependency is `snooze`, so snoozing (which
+// replaces the ref below) recomputes this to false and the banner hides.
+export const showBanner = computed(() => bannerShouldShow(notice, Date.now(), snooze.value));
+
+// Dismiss the soft banner: persist the snooze (best-effort) AND update the ref
+// in-memory so `showBanner` flips to false immediately. The in-memory update
+// mirrors writeSnooze()'s payload exactly, so a localStorage write-throw still
+// hides the banner this session (the snooze just isn't persisted and returns
+// next boot - the accepted edge behaviour, spec §6).
+export function snoozeBanner() {
+	const now = Date.now();
+	writeSnooze(notice, now);
+	const days = notice.banner_interval_days || 7;
+	snooze.value = { until: now + days * 86400000, version: notice.version };
+}
+
+// ---- What's-new sheet (shared open state) ----------------------------------
+// The pill (ChatView's header), the soft banner (the app shell), and the hard
+// gate all open the SAME What's-new sheet, mounted once in App.vue - unlike the
+// desktop SPA, App.vue is never replaced by the gate (it overlays it instead),
+// so a single global instance is enough and avoids two sheets racing to open.
+export const whatsNewOpen = ref(false);
+export function openWhatsNew() {
+	whatsNewOpen.value = true;
+}
+
+// ---- Version pill handle -----------------------------------------------------
+// The pill lives inside ChatView's header (the Chat route only); the soft
+// banner lives at the app shell (every route - see App.vue), so - unlike the
+// desktop SPA, where the pill and the banner are siblings in the same template
+// - they are never rendered together here. This tiny handle is how the banner
+// finds the pill's element + pulse() for its minimise-into-pill FLIP: VersionPill
+// registers itself on mount and clears itself on unmount, so a banner dismissed
+// outside the Chat route (or before any pill has mounted) simply finds no
+// target and degrades to a plain hide (see UpdateBanner.vue).
+export const pillHandle = { current: null };
+
+// Boot reads a mirror that may predate the tenant's update, and an open tab never
+// re-reads it at all, so the gate re-pulls from admin itself.
 export async function recheck() {
 	if (checking.value) return;
 	checking.value = true;

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -41,6 +41,7 @@ import RecordCards from "../components/RecordCards.vue";
 import Sheet from "../components/Sheet.vue";
 import SkillChips from "../components/SkillChips.vue";
 import ThinkingIndicator from "../components/ThinkingIndicator.vue";
+import VersionPill from "../components/VersionPill.vue";
 // Lazy: the voice sheet pulls in the shared audio recorder, and a user who never
 // taps the mic should never pay for it.
 const VoiceSheet = defineAsyncComponent(() => import("../components/VoiceSheet.vue"));
@@ -678,6 +679,10 @@ onUnmounted(() => {
 			<div class="jv-head-title">{{ title }}</div>
 			<div class="jv-head-sub">{{ model ? `${agentName} · ${model}` : agentName }}</div>
 		</div>
+		<!-- Release-nudge version pill (Slice 3b): always-on "how current is my
+		     Jarvis" status; click opens What's-new. Hidden when the target
+		     version is unknown (VersionPill's own v-if). -->
+		<VersionPill />
 		<button
 			v-if="convId"
 			class="jv-icon-btn"


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
