### PR TITLE
feat(chat): context meter and Compact with hint (backport #1136)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,6 +39,16 @@ export const setAutoApply = (conversation, value) =>
 // null/zeros until then (design doc §6, UsagePane's "Measured usage" block).
 export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" });
+// Context-window meter for one chat: {used, capacity, pct, warn_pct,
+// auto_compact_pct, route, compaction_count, last_compacted_at, compacting,
+// fresh}. Bench snapshot, refreshed after every completed turn.
+export const getConversationContext = (conversation) =>
+	call("jarvis.chat.api.get_conversation_context", { conversation });
+// Summarise older turns. Optional hint = what to keep. Resolves to
+// {ok, queued} or {ok:false, reason}; the result arrives later as a
+// context:compacted / context:compact_failed event.
+export const compactConversation = (conversation, hint = "") =>
+	call("jarvis.chat.api.compact_conversation", { conversation, hint: hint || null });
 // Tool runs recorded in one chat, newest turn first, from the PERSISTED tool
 // rows: the same rows the thread's Activity accordion renders. The Settings
 // Activity pane used to derive this from the browser's live run stream, which

--- a/frontend/src/components/chat/CompactDialog.spec.js
+++ b/frontend/src/components/chat/CompactDialog.spec.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("frappe-ui", () => ({
+	Dialog: {
+		props: ["modelValue", "options"],
+		template: "<div><slot name='body-content'/><slot name='actions'/></div>",
+	},
+	Button: {
+		props: ["label", "variant", "disabled", "loading"],
+		emits: ["click"],
+		template: "<button :disabled='disabled' @click=\"$emit('click')\">{{ label }}</button>",
+	},
+	FormControl: {
+		props: ["modelValue", "label", "placeholder", "type"],
+		emits: ["update:modelValue"],
+		template:
+			"<textarea :value='modelValue' @input=\"$emit('update:modelValue', $event.target.value)\"/>",
+	},
+}));
+
+import CompactDialog from "./CompactDialog.vue";
+
+describe("CompactDialog", () => {
+	it("confirms with the trimmed hint", async () => {
+		const w = mount(CompactDialog, { props: { modelValue: true } });
+		await w.find("textarea").setValue("  keep the invoice inputs ");
+		await w.findAll("button").at(-1).trigger("click");
+		expect(w.emitted("confirm")[0]).toEqual(["keep the invoice inputs"]);
+	});
+	it("disables Compact with the busy reason", () => {
+		const w = mount(CompactDialog, {
+			props: { modelValue: true, busyReason: "A reply is in progress" },
+		});
+		expect(w.findAll("button").at(-1).attributes("disabled")).toBeDefined();
+		expect(w.text()).toContain("A reply is in progress");
+	});
+});

--- a/frontend/src/components/chat/CompactDialog.vue
+++ b/frontend/src/components/chat/CompactDialog.vue
@@ -1,0 +1,55 @@
+<template>
+	<Dialog
+		:modelValue="modelValue"
+		:options="{ title: 'Compact this chat', size: 'sm' }"
+		@update:modelValue="$emit('update:modelValue', $event)"
+	>
+		<template #body-content>
+			<p class="text-sm text-ink-gray-6">Older turns are summarised, not deleted.</p>
+			<FormControl
+				v-model="hint"
+				class="mt-3"
+				type="textarea"
+				label="Anything to keep? (optional)"
+				placeholder="e.g. keep the invoice inputs"
+				:maxlength="500"
+			/>
+			<p v-if="busyReason" class="mt-3 text-xs text-ink-gray-5">{{ busyReason }}</p>
+		</template>
+		<template #actions>
+			<div class="flex justify-end gap-2">
+				<Button label="Cancel" @click="$emit('update:modelValue', false)" />
+				<Button
+					label="Compact"
+					variant="solid"
+					:disabled="!!busyReason || submitting"
+					:loading="submitting"
+					@click="confirm"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+import { ref, watch } from "vue";
+import { Dialog, Button, FormControl } from "frappe-ui";
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+	busyReason: { type: String, default: "" },
+	submitting: { type: Boolean, default: false },
+	initialHint: { type: String, default: "" },
+});
+const emit = defineEmits(["update:modelValue", "confirm"]);
+const hint = ref(props.initialHint);
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (open) hint.value = props.initialHint;
+	}
+);
+function confirm() {
+	emit("confirm", hint.value.trim());
+}
+</script>

--- a/frontend/src/components/chat/ContextRing.spec.js
+++ b/frontend/src/components/chat/ContextRing.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("frappe-ui", () => ({
+	Popover: {
+		props: ["placement"],
+		template:
+			"<div><slot name='target' :togglePopover='() => {}'/><slot name='body' :close='() => {}'/></div>",
+	},
+	Button: {
+		props: ["label", "variant", "size", "disabled"],
+		emits: ["click"],
+		template: "<button :disabled='disabled' @click=\"$emit('click')\">{{ label }}</button>",
+	},
+}));
+
+import ContextRing from "./ContextRing.vue";
+
+const ctx = (over = {}) => ({
+	used: 42000,
+	capacity: 200000,
+	pct: 21,
+	warn_pct: 80,
+	auto_compact_pct: 90,
+	route: "fits",
+	compaction_count: 0,
+	last_compacted_at: null,
+	last_in: 559,
+	last_out: 5,
+	model: "gpt-5.5",
+	compacting: false,
+	fresh: true,
+	...over,
+});
+
+describe("ContextRing", () => {
+	it("is hidden until measured", () => {
+		const w = mount(ContextRing, { props: { context: ctx({ fresh: false }) } });
+		expect(w.find("[data-testid=context-ring]").exists()).toBe(false);
+	});
+
+	it("accessible name leads with used of capacity", () => {
+		const w = mount(ContextRing, { props: { context: ctx() } });
+		expect(w.find("[data-testid=context-ring]").attributes("aria-label")).toMatch(
+			/^42k of 200k/
+		);
+	});
+
+	it("turns warn at 84 percent", () => {
+		const w = mount(ContextRing, { props: { context: ctx({ used: 168000, pct: 84 }) } });
+		expect(w.find("[data-testid=context-ring]").classes()).toContain("jv-ctx-warn");
+	});
+
+	it("shows the busy class while compacting", () => {
+		const w = mount(ContextRing, { props: { context: ctx(), compacting: true } });
+		expect(w.find("[data-testid=context-ring]").classes()).toContain("jv-ctx-busy");
+	});
+
+	it("shows the done class once compacted", () => {
+		const w = mount(ContextRing, { props: { context: ctx(), compacted: true } });
+		expect(w.find("[data-testid=context-ring]").classes()).toContain("jv-ctx-done");
+	});
+
+	it("shows auto-compact and last-reply rows in the popover", () => {
+		const w = mount(ContextRing, { props: { context: ctx() } });
+		expect(w.text()).toContain("Auto-compacts at");
+		expect(w.text()).toContain("180k (90%)");
+		expect(w.text()).toContain("Last reply");
+		expect(w.text()).toContain("559 in · 5 out");
+	});
+
+	it("disables the popover's Compact button while compacting", () => {
+		const w = mount(ContextRing, { props: { context: ctx(), compacting: true } });
+		expect(
+			w.find("button:not([data-testid=context-ring])").attributes("disabled")
+		).toBeDefined();
+	});
+
+	it("emits compact when the Compact button is clicked", async () => {
+		const w = mount(ContextRing, { props: { context: ctx() } });
+		await w.find("button:not([data-testid=context-ring])").trigger("click");
+		expect(w.emitted("compact")).toHaveLength(1);
+	});
+});

--- a/frontend/src/components/chat/ContextRing.vue
+++ b/frontend/src/components/chat/ContextRing.vue
@@ -1,0 +1,235 @@
+<template>
+	<Popover v-if="context && context.fresh" placement="top-end">
+		<template #target="{ togglePopover }">
+			<button
+				type="button"
+				data-testid="context-ring"
+				class="jv-ctx-ring"
+				:class="{
+					'jv-ctx-warn': warn,
+					'jv-ctx-busy': compacting,
+					'jv-ctx-done': compacted,
+				}"
+				:title="title"
+				:aria-label="title"
+				@click="togglePopover()"
+			>
+				<svg width="18" height="18" viewBox="0 0 20 20" aria-hidden="true">
+					<defs>
+						<linearGradient :id="gradId" x1="0" y1="0" x2="1" y2="1">
+							<stop offset="0%" stop-color="#6e8bff" />
+							<stop offset="100%" stop-color="#8b5cf6" />
+						</linearGradient>
+					</defs>
+					<circle
+						cx="10"
+						cy="10"
+						r="7.5"
+						fill="none"
+						stroke="var(--text-3)"
+						stroke-opacity="0.45"
+						stroke-width="2.6"
+					/>
+					<circle
+						v-if="!compacted"
+						class="jv-ctx-fillarc"
+						:class="{ 'jv-ctx-spin': compacting }"
+						cx="10"
+						cy="10"
+						r="7.5"
+						fill="none"
+						:stroke="warn ? 'var(--jv-terra)' : `url(#${gradId})`"
+						stroke-width="2.6"
+						stroke-linecap="round"
+						:stroke-dasharray="compacting ? '22 47.12' : dashArray"
+					/>
+					<path
+						v-if="compacted"
+						d="M6.5 10.2l2.3 2.3 4.7-4.8"
+						fill="none"
+						stroke="var(--ok, #16a34a)"
+						stroke-width="1.6"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					/>
+				</svg>
+			</button>
+		</template>
+		<template #body="{ close }">
+			<div
+				class="my-2 min-w-60 rounded-lg bg-surface-modal p-2 shadow-2xl ring-1 ring-black ring-opacity-5 w-72 p-3"
+			>
+				<div class="flex items-baseline justify-between">
+					<h3 class="text-base font-semibold text-ink-gray-9">Context</h3>
+					<span class="text-p-sm text-ink-gray-6" :class="{ 'jv-ctx-warn-text': warn }">
+						{{ compacting ? "Compacting…" : `${pct}% of ${fmtTokens(capacity)}` }}
+					</span>
+				</div>
+
+				<div class="mt-3 h-1.5 overflow-hidden rounded-full bg-surface-gray-3">
+					<div
+						class="h-full rounded-full"
+						:class="warn ? 'jv-ctx-bar-warn' : 'bg-surface-gray-7'"
+						:style="{ width: (compacted ? 0 : pct) + '%' }"
+					/>
+				</div>
+
+				<div class="mt-2">
+					<KvRow label="In use" :value="inUseLabel" />
+					<KvRow
+						label="Auto-compacts at"
+						:value="`${fmtTokens(autoTokens)} (${autoCompactPct}%)`"
+					/>
+					<KvRow
+						v-if="lastIn || lastOut"
+						label="Last reply"
+						:value="`${fmtTokens(lastIn)} in · ${fmtTokens(lastOut)} out`"
+					/>
+					<KvRow label="Compacted" :value="compactedLabel" />
+				</div>
+
+				<div class="mt-3 flex justify-end">
+					<Button
+						variant="solid"
+						size="sm"
+						label="Compact"
+						:disabled="compacting"
+						@click="
+							close();
+							$emit('compact');
+						"
+					/>
+				</div>
+			</div>
+		</template>
+	</Popover>
+</template>
+
+<script>
+// Module-scope counter (shared across instances, unlike anything declared in
+// <script setup>) so two mounted rings never collide on the same gradient id.
+let gradSeq = 0;
+</script>
+
+<script setup>
+// ContextRing replaces ContextPill (#1136, design variant A): an 18px ring
+// with no text and no tick line - details move into a click-to-open popover.
+// Same fill-gradient / warn / busy / done language the pill used, just drawn
+// as an SVG arc instead of a bar.
+import { computed } from "vue";
+import { Popover, Button } from "frappe-ui";
+import KvRow from "@/components/settings/KvRow.vue";
+import { fmtTokens } from "@/lib/tokens";
+import { timeAgo } from "@/utils/datetime";
+
+const props = defineProps({
+	context: { type: Object, default: null },
+	compacting: { type: Boolean, default: false },
+	compacted: { type: Boolean, default: false },
+});
+defineEmits(["compact"]);
+
+const gradId = `jv-ctx-grad-${++gradSeq}`;
+
+const used = computed(() => Number(props.context?.used || 0));
+const capacity = computed(() => Number(props.context?.capacity || 0));
+const warnPct = computed(() => Number(props.context?.warn_pct ?? 80));
+const autoCompactPct = computed(() => Number(props.context?.auto_compact_pct || 0));
+const autoTokens = computed(() => Math.round((capacity.value * autoCompactPct.value) / 100));
+const pct = computed(() =>
+	Math.round(Math.min(100, Math.max(0, Number(props.context?.pct || 0))))
+);
+const warn = computed(() => !!props.context && pct.value >= warnPct.value);
+const lastIn = computed(() => Number(props.context?.last_in || 0));
+const lastOut = computed(() => Number(props.context?.last_out || 0));
+const compactionCount = computed(() => Number(props.context?.compaction_count || 0));
+const lastCompactedAt = computed(() => props.context?.last_compacted_at || null);
+
+// Fraction of the 47.12 (2*pi*7.5) circumference to fill, clockwise from the
+// -90deg (12 o'clock) start baked into the .jv-ctx-fillarc CSS transform.
+const dashArray = computed(() => `${((pct.value / 100) * 47.12).toFixed(2)} 47.12`);
+
+const inUseLabel = computed(() =>
+	props.compacted ? "Compacted, measuring on next reply" : `${fmtTokens(used.value)} tokens`
+);
+
+const compactedLabel = computed(() =>
+	compactionCount.value > 0
+		? `${compactionCount.value}×, ${timeAgo(lastCompactedAt.value)}`
+		: "never"
+);
+
+const title = computed(() => {
+	if (props.compacting) return "Compacting this chat";
+	if (props.compacted) return "Context compacted. The meter updates after your next message.";
+	return `${fmtTokens(used.value)} of ${fmtTokens(capacity.value)} (${
+		pct.value
+	}%). Context in use.`;
+});
+</script>
+
+<style>
+/* Unscoped on purpose: frappe-ui's Popover teleports the #body slot out of
+   this component's DOM subtree (reka-ui PopoverPortal), so a scoped custom
+   property - only inherited within our own tree - would not reach it, and
+   .jv-dark (ChatView's root class) is not an ancestor of the teleported
+   node either. `data-theme` on <html> (set by theme.js's applyTheme,
+   ChatView's own bridge to frappe-ui) IS an ancestor of any teleported
+   content, so key the override on that instead of prefers-color-scheme -
+   this follows the theme the user actually picked, not the OS setting
+   underneath it. .jv-dark is kept alongside it for the ring itself, which
+   never leaves ChatView's tree. */
+:root {
+	--jv-terra: #c9623f;
+}
+:root[data-theme="dark"],
+.jv-dark {
+	--jv-terra: #e08a66;
+}
+</style>
+
+<style scoped>
+.jv-ctx-ring {
+	width: 30px;
+	height: 30px;
+	display: grid;
+	place-items: center;
+	border: 0;
+	background: transparent;
+	border-radius: 8px;
+	cursor: pointer;
+}
+.jv-ctx-ring:hover {
+	background: var(--surface-3);
+}
+.jv-ctx-ring:focus-visible {
+	outline: 2px solid var(--brand-1);
+	outline-offset: 1px;
+}
+.jv-ctx-fillarc {
+	transform-origin: 10px 10px;
+	transform: rotate(-90deg);
+}
+.jv-ctx-fillarc.jv-ctx-spin {
+	animation: jv-ctx-spin 1.1s linear infinite;
+}
+@keyframes jv-ctx-spin {
+	from {
+		transform: rotate(-90deg);
+	}
+	to {
+		transform: rotate(270deg);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-ctx-fillarc.jv-ctx-spin {
+		animation: none;
+	}
+}
+.jv-ctx-warn-text {
+	color: var(--jv-terra);
+}
+.jv-ctx-bar-warn {
+	background: var(--jv-terra);
+}
+</style>

--- a/frontend/src/components/settings/GeneralPane.spec.js
+++ b/frontend/src/components/settings/GeneralPane.spec.js
@@ -341,3 +341,28 @@ describe("GeneralPane Reset onboarding button", () => {
 		// flow review — jsdom makes window.location.assign non-stubbable.
 	});
 });
+
+describe("GeneralPane, Context section", () => {
+	it("shows the measured context in use for this chat, under its own unbadged heading", async () => {
+		api.getUsage.mockImplementation(() =>
+			Promise.resolve({
+				chat_tokens: 999,
+				context: { used: 42000, capacity: 200000, fresh: true },
+			})
+		);
+		const w = await mountAs({ admin: false });
+		expect(w.text()).toContain("42k of 200k context");
+		expect(w.text()).toContain("Context");
+	});
+
+	it("falls back to not measured yet", async () => {
+		api.getUsage.mockImplementation(() =>
+			Promise.resolve({
+				chat_tokens: 999,
+				context: { used: 0, capacity: 0, fresh: false },
+			})
+		);
+		const w = await mountAs({ admin: false });
+		expect(w.text()).toContain("Not measured yet");
+	});
+});

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -129,12 +129,18 @@
 
 		<hr class="my-8" />
 
+		<h3 class="text-base font-semibold text-ink-gray-9">Context</h3>
+		<div class="mt-2">
+			<KvRow label="This chat" :value="context.text" />
+		</div>
+
+		<hr class="my-8" />
+
 		<h3 class="flex items-center gap-2 text-base font-semibold text-ink-gray-9">
 			Token usage
 			<Badge label="est." theme="gray" variant="subtle" size="sm" />
 		</h3>
 		<div class="mt-2">
-			<KvRow label="This chat" :value="usage ? fmtTokens(usage.chat_tokens) : '-'" />
 			<KvRow
 				:label="usage ? usage.month_label : 'This month'"
 				:value="usage ? fmtTokens(usage.month_tokens) : '-'"
@@ -301,6 +307,7 @@ import { humaniseSyncStatus } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
 import * as api from "@/api";
 import { errHtml } from "@/lib/errors";
+import { fmtTokens, contextReading } from "@/lib/tokens.js";
 
 const store = useShellStore();
 
@@ -522,17 +529,14 @@ const statusTheme = computed(() => {
 
 // Estimated token usage — the dialog fetches its own data on open.
 const usage = ref(null);
+// This chat's context reading (usage.context, from get_usage()'s
+// per-conversation block).
+const context = computed(() => contextReading(usage.value));
 const usagePct = computed(() => {
 	const u = usage.value;
 	if (!u || !u.budget_monthly) return 0;
 	return Math.min(100, Math.round((u.month_tokens / u.budget_monthly) * 100));
 });
-function fmtTokens(n) {
-	n = Number(n || 0);
-	if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
-	if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
-	return String(n);
-}
 
 onMounted(async () => {
 	try {

--- a/frontend/src/components/settings/UsagePane.spec.js
+++ b/frontend/src/components/settings/UsagePane.spec.js
@@ -189,3 +189,40 @@ describe("UsagePane metering error/retry", () => {
 		expect(w.find(".stub-errormessage").exists()).toBe(true);
 	});
 });
+
+describe("UsagePane, this chat context", () => {
+	// This row lives in its own unbadged "Context" section, independent of the
+	// "Measured usage" block below it - it must show even when there are no
+	// account-wide measured totals yet (measured.total_tokens is 0, hasMeasured
+	// false), as long as this chat's own context reading is fresh.
+	it("shows context in use for this chat when measured", async () => {
+		api.getUsage.mockResolvedValue({
+			chat_tokens: 999,
+			measured: { total_tokens: 500000, month_tokens: 100000 },
+			context: { used: 42000, capacity: 200000, fresh: true },
+		});
+		const w = await mountAs({ isSM: false, isAdmin: false });
+		expect(w.text()).toContain("42k of 200k context in use");
+	});
+
+	it("shows the row even with no measured totals yet, when this chat's context is fresh", async () => {
+		api.getUsage.mockResolvedValue({
+			chat_tokens: 999,
+			measured: { total_tokens: 0, month_tokens: 0 },
+			context: { used: 42000, capacity: 200000, fresh: true },
+		});
+		const w = await mountAs({ isSM: false, isAdmin: false });
+		expect(w.text()).toContain("42k of 200k context in use");
+		expect(w.text()).not.toContain("Measured usage");
+	});
+
+	it("falls back to not measured", async () => {
+		api.getUsage.mockResolvedValue({
+			chat_tokens: 999,
+			measured: { total_tokens: 500000, month_tokens: 100000 },
+			context: { used: 0, capacity: 0, fresh: false },
+		});
+		const w = await mountAs({ isSM: false, isAdmin: false });
+		expect(w.text()).toContain("Not measured yet");
+	});
+});

--- a/frontend/src/components/settings/UsagePane.vue
+++ b/frontend/src/components/settings/UsagePane.vue
@@ -1,5 +1,14 @@
 <template>
 	<SettingsPane title="Usage" :description="paneDescription" :error="meteringErrorMessage">
+		<template v-if="usage">
+			<h3 class="text-base font-semibold text-ink-gray-9">Context</h3>
+			<div class="mt-2">
+				<KvRow label="This chat" :value="context.text" />
+			</div>
+
+			<hr class="my-8" />
+		</template>
+
 		<template v-if="hasMeasured">
 			<h3 class="text-base font-semibold text-ink-gray-9">Measured usage</h3>
 			<div class="mt-2">
@@ -105,19 +114,14 @@
 					{{ s ? `${s.starredCount} starred` : "no chat" }}
 				</div>
 			</div>
-			<div class="rounded-md border p-4">
-				<div class="text-2xl font-medium text-ink-gray-8">
-					{{ usage ? fmtTokens(usage.chat_tokens) : "-" }}
-				</div>
-				<div class="mt-1 text-sm text-ink-gray-6">This chat</div>
-				<div class="mt-1 text-xs text-ink-gray-5">tokens</div>
-			</div>
 			<!-- The month / all-time estimates are dropped once measured usage
 			     exists: the block above already carries both labels from the
 			     gateway's own counters, and showing an estimate of the stored
 			     transcript beside a measurement of what was actually sent put two
-			     very different numbers under one heading (#551). "This chat" stays
-			     because the measured counters have no per-chat breakdown. -->
+			     very different numbers under one heading (#551). "This chat"
+			     (usage.context) has its own unbadged "Context" section above,
+			     independent of hasMeasured, since a fresh per-chat reading can
+			     exist with no account-wide measured totals yet. -->
 			<template v-if="!hasMeasured">
 				<div class="rounded-md border p-4">
 					<div class="text-2xl font-medium text-ink-gray-8">
@@ -303,6 +307,7 @@ import JvChart from "@/charts/JvChart.vue";
 import EChart from "@/charts/EChart.vue";
 import { budgetGaugeOption, perModelBarSpec, formatUsd } from "@/charts/usageCharts.js";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
+import { fmtTokens, contextReading } from "@/lib/tokens.js";
 import { connectionModeLabel } from "@/llm/pool";
 import { useJarvisTheme } from "@/theme";
 import * as api from "@/api";
@@ -337,6 +342,10 @@ const measured = computed(() => (usage.value && usage.value.measured) || null);
 // showing both once real counters exist. So the block appears only once there is
 // something measured to show.
 const hasMeasured = computed(() => !!(measured.value && Number(measured.value.total_tokens || 0)));
+// This chat's context reading (usage.context, from get_usage()'s
+// per-conversation block), independent of hasMeasured - see the "Context"
+// section above, which renders whenever usage itself has loaded.
+const context = computed(() => contextReading(usage.value));
 // All-time: compares against total_tokens (the cumulative, never-reset
 // counter), not month_tokens. See jarvis.chat.policy._over_total_limit.
 const measuredPct = computed(() => {
@@ -364,13 +373,6 @@ async function loadUsage() {
 	} catch {
 		usage.value = null;
 	}
-}
-
-function fmtTokens(n) {
-	n = Number(n || 0);
-	if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
-	if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
-	return String(n);
 }
 
 const usagePct = computed(() => {

--- a/frontend/src/lib/artifactActivityCard.test.js
+++ b/frontend/src/lib/artifactActivityCard.test.js
@@ -256,9 +256,12 @@ test("the common card is gated on artifactKind, mutually exclusive with the morp
 		chatSrc,
 		/v-if="artifactKind && \(activeTools\.length \|\| waiting\) && !queuedTurn"/
 	);
+	// Also excludes a live compaction (F7): the compacting banner owns the row
+	// while a compact is in flight, so the generic activity line must not
+	// render alongside it either.
 	assert.match(
 		chatSrc,
-		/v-if="\s*\(activeTools\.length \|\| waiting\) &&\s*!queuedTurn &&\s*!artifactKind &&\s*!gotoMorph\s*"/
+		/v-if="\s*\(activeTools\.length \|\| waiting\) &&\s*!queuedTurn &&\s*!artifactKind &&\s*!gotoMorph &&\s*!compacting\s*"/
 	);
 });
 

--- a/frontend/src/lib/compact.js
+++ b/frontend/src/lib/compact.js
@@ -1,0 +1,22 @@
+// The composer shortcut: "/compact" or "/compact <what to keep>" runs the
+// compact action instead of sending a turn. Case-insensitive, optional colon.
+export function parseCompactCommand(text) {
+	const m = /^\s*\/compact(?:\s*:\s*|\s+|$)(.*)$/i.exec(text || "");
+	if (!m) return null;
+	return { hint: (m[1] || "").trim() };
+}
+
+const COPY = {
+	runtime_declined: "Nothing to compact yet",
+	runtime_failed: "Could not compact this chat right now, try again later",
+	nothing_to_compact: "Nothing new to compact yet",
+	conversation_busy: "A reply is in progress, try again in a moment",
+	already_compacting: "Already compacting this chat",
+	macro_armed: "This chat is running a macro",
+	bad_hint: "The hint cannot start with a slash",
+	timeout: "Compacting took too long, try again",
+	gateway_unreachable: "Could not reach your assistant, try again",
+};
+export function compactFailureCopy(reason) {
+	return COPY[reason] || "Could not compact this chat";
+}

--- a/frontend/src/lib/compact.spec.js
+++ b/frontend/src/lib/compact.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { parseCompactCommand, compactFailureCopy } from "./compact.js";
+
+describe("parseCompactCommand", () => {
+	it("returns null for normal text", () => {
+		expect(parseCompactCommand("compact the invoice")).toBeNull();
+		expect(parseCompactCommand("/compactor")).toBeNull();
+	});
+	it("parses the bare command and a hint", () => {
+		expect(parseCompactCommand("/compact")).toEqual({ hint: "" });
+		expect(parseCompactCommand("  /compact keep the invoice inputs ")).toEqual({
+			hint: "keep the invoice inputs",
+		});
+		expect(parseCompactCommand("/COMPACT: keep totals")).toEqual({ hint: "keep totals" });
+	});
+});
+
+describe("compactFailureCopy", () => {
+	it("maps reasons to copy", () => {
+		expect(compactFailureCopy("runtime_declined")).toBe("Nothing to compact yet");
+		expect(compactFailureCopy("runtime_failed")).toBe(
+			"Could not compact this chat right now, try again later"
+		);
+		expect(compactFailureCopy("nothing_to_compact")).toBe("Nothing new to compact yet");
+		expect(compactFailureCopy("conversation_busy")).toBe(
+			"A reply is in progress, try again in a moment"
+		);
+		expect(compactFailureCopy("whatever")).toBe("Could not compact this chat");
+	});
+});

--- a/frontend/src/lib/tokens.js
+++ b/frontend/src/lib/tokens.js
@@ -1,0 +1,24 @@
+/** Shared token-count formatting for the context meter and usage panes. */
+
+/** "42000" -> "42k", "1500000" -> "1.5M". Strips a trailing ".0" so a round
+ * thousand/million reads "42k" rather than "42.0k". */
+export function fmtTokens(n) {
+	n = Number(n || 0);
+	if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+	if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
+	return String(n);
+}
+
+/** What GeneralPane and UsagePane's "This chat" / "Context" row shows, from
+ * get_usage()'s per-conversation `usage.context` block. `fresh` is a live
+ * reading; otherwise the context has not been measured yet. */
+export function contextReading(usage) {
+	const context = usage && usage.context;
+	const fresh = !!(context && context.fresh);
+	return {
+		fresh,
+		text: fresh
+			? `${fmtTokens(context.used)} of ${fmtTokens(context.capacity)} context in use`
+			: "Not measured yet",
+	};
+}

--- a/frontend/src/lib/tokens.spec.js
+++ b/frontend/src/lib/tokens.spec.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { fmtTokens, contextReading } from "./tokens.js";
+
+describe("fmtTokens", () => {
+	it("renders an even thousand without a decimal", () => {
+		expect(fmtTokens(42000)).toBe("42k");
+	});
+	it("renders an even hundred-thousand without a decimal", () => {
+		expect(fmtTokens(200000)).toBe("200k");
+	});
+});
+
+describe("contextReading", () => {
+	it("reads the used/capacity pair when fresh", () => {
+		const r = contextReading({ context: { used: 42000, capacity: 200000, fresh: true } });
+		expect(r).toEqual({ fresh: true, text: "42k of 200k context in use" });
+	});
+	it("falls back to not measured yet when not fresh", () => {
+		const r = contextReading({ context: { used: 0, capacity: 0, fresh: false } });
+		expect(r).toEqual({ fresh: false, text: "Not measured yet" });
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -248,6 +248,37 @@
 										>
 									</span>
 								</button>
+								<button
+									v-if="currentId"
+									role="menuitem"
+									class="jv-create-item"
+									@click="
+										createMenuOpen = false;
+										openCompactDialog('');
+									"
+								>
+									<svg
+										width="17"
+										height="17"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="var(--text-2)"
+										stroke-width="1.7"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path d="M8 3v4a1 1 0 0 1-1 1H3" />
+										<path d="M21 8h-4a1 1 0 0 1-1-1V3" />
+										<path d="M3 16h4a1 1 0 0 1 1 1v4" />
+										<path d="M16 21v-4a1 1 0 0 1 1-1h4" />
+									</svg>
+									<span class="jv-create-item-txt">
+										<span class="jv-create-item-t">Compact chat</span>
+										<span class="jv-create-item-s"
+											>Summarise older turns to free up space</span
+										>
+									</span>
+								</button>
 							</div>
 						</template>
 					</div>
@@ -2035,7 +2066,8 @@
 							(activeTools.length || waiting) &&
 							!queuedTurn &&
 							!artifactKind &&
-							!gotoMorph
+							!gotoMorph &&
+							!compacting
 						"
 						style="display: flex; gap: 12px"
 					>
@@ -2104,10 +2136,11 @@
 							</div>
 							<div
 								v-if="
-									!showActivityDetail ||
-									(waiting && !currentTool) ||
-									(!currentTool && statusPhase) ||
-									(!currentTool && !doneCount)
+									(!showActivityDetail ||
+										(waiting && !currentTool) ||
+										(!currentTool && statusPhase) ||
+										(!currentTool && !doneCount)) &&
+									!compacting
 								"
 								role="status"
 								aria-live="polite"
@@ -2171,6 +2204,59 @@
 								<span>{{ recoveringLabel }}</span>
 							</div>
 						</div>
+					</div>
+
+					<!-- Compacting: older turns are being summarised (auto mid-turn, or a
+					     manual Compact chat / /compact). The composer stays LOCKED (a
+					     compact and a turn must never race the same context write). -->
+					<div
+						v-if="compacting"
+						style="display: flex; gap: 12px"
+						data-testid="compacting-banner"
+					>
+						<JarvisMark
+							:size="28"
+							:radius="7"
+							mood="thinking"
+							style="margin-top: 2px"
+						/>
+						<div style="flex: 1; min-width: 0; padding-top: 3px">
+							<div
+								role="status"
+								aria-live="polite"
+								style="
+									display: flex;
+									align-items: center;
+									gap: 7px;
+									font-size: 12px;
+									color: var(--text-3);
+								"
+							>
+								<svg
+									class="jv-spin"
+									width="13"
+									height="13"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="var(--text-3)"
+									stroke-width="2"
+									stroke-linecap="round"
+								>
+									<path d="M12 3a9 9 0 1 0 9 9" />
+								</svg>
+								Compacting this chat{{
+									compactHintSeed ? " · “" + compactHintSeed + "”" : ""
+								}}
+							</div>
+							<div class="jv-fold" aria-hidden="true">
+								<i></i><i></i><i></i><i></i><i></i><i></i>
+							</div>
+						</div>
+					</div>
+					<div v-else-if="compactedChip" style="display: flex; justify-content: center">
+						<span class="jv-ctx-chip" role="status"
+							>Context compacted. The meter updates after your next message.</span
+						>
 					</div>
 
 					<!-- SUX-3: immediate "change saved" acknowledgment after a confirm
@@ -3440,6 +3526,12 @@
 							     linger a session if an admin flips it, but the server clause
 							     (_persona_clause) re-reads it every turn, so behaviour is always
 							     correct - voice-only cosmetic lag that self-heals on next boot. -->
+							<ContextRing
+								:context="contextInfo"
+								:compacting="compacting"
+								:compacted="compactedChip"
+								@compact="openCompactDialog('')"
+							/>
 							<ModelEffortPicker
 								:model-override="modelOverride"
 								:default-model="ui.llm_model || ''"
@@ -4173,6 +4265,14 @@
 
 		<ConnectPhoneDialog v-model="showConnect" />
 
+		<CompactDialog
+			v-model="compactDialogOpen"
+			:busy-reason="compactBusyReason"
+			:submitting="compactSubmitting"
+			:initial-hint="compactHintSeed"
+			@confirm="runCompact"
+		/>
+
 		<!-- Preview a file the user attached in the composer (before send). Images
 		     enlarge, PDFs/others render in-app; loads over the session cookie so a
 		     private File just works. Sent-message attachments use the artifact
@@ -4206,6 +4306,9 @@ import {
 } from "vue";
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
 import { Dropdown } from "frappe-ui";
+import ContextRing from "@/components/chat/ContextRing.vue";
+import CompactDialog from "@/components/chat/CompactDialog.vue";
+import { parseCompactCommand, compactFailureCopy } from "@/lib/compact";
 import * as api from "@/api";
 import * as voice from "@/api/voice";
 import { agentName, isWhitelabeled } from "@/branding";
@@ -4340,6 +4443,16 @@ watch(currentId, (id) => {
 	// from; never carry it into a different chat.
 	queuedTurn.value = null;
 	confirmedAck.value = false;
+	// The context meter's transient state is per-conversation too: a chip, a
+	// compacting lock, or a stale token count from the chat we left must never
+	// bleed into the one we just opened. Not every currentId change routes
+	// through loadConversation() (newChat() does not), so null contextInfo
+	// here rather than relying on that reload to do it; whichever load path
+	// does run (loadConversation, or loadContext directly) repopulates it off
+	// server truth.
+	contextInfo.value = null;
+	compactedChip.value = false;
+	compacting.value = false;
 	try {
 		id
 			? localStorage.setItem("jarvis-last-conv", id)
@@ -5034,6 +5147,83 @@ watch(
 	}
 );
 const usage = ref(null); // { estimated, chat_tokens, month_tokens, total_tokens, budget_monthly, month_label }
+
+// ---- chat context meter + Compact (sub-project B) ----
+const contextInfo = ref(null); // get_conversation_context payload for the open chat
+const compacting = ref(false); // a compaction we started (or one the runtime is doing mid-turn)
+const compactedChip = ref(false); // after-chip + pill "Compacted" until the next run:end
+const compactDialogOpen = ref(false);
+const compactSubmitting = ref(false);
+const compactHintSeed = ref("");
+const compactBusyReason = computed(() => {
+	if (compacting.value) return "Already compacting this chat";
+	if (sending.value || waiting.value || currentRunId.value)
+		return "A reply is in progress, try again in a moment";
+	return "";
+});
+
+// Best-effort context refresh for the open chat. The ring stays mounted through
+// a compacting/compacted transition (ContextRing only hides on !context.fresh):
+// a payload that hasn't been measured yet (fresh:false, e.g. right after
+// context:compacted, before the runtime re-measures) must NOT overwrite the
+// last fresh snapshot, or the pill would vanish mid-transition instead of
+// showing the compacted state.
+// `applyCompacting` is true only from the conversation-open path
+// (loadConversation): there, a fetch may CLEAR the optimistic lock, since it
+// is the authoritative read for a chat that just came on screen. Anywhere
+// else a stale, slow GET racing a fresh compact click must not flip a live
+// lock back off - such a fetch may only turn compacting ON, never off; the
+// run:end / run:error / run:recovering / context:compacted /
+// context:compact_failed events (plus the dropped-frame progress guards in
+// assistant:delta / tool:start) are the only other clearers.
+async function loadContext({ applyCompacting = false } = {}) {
+	const id = currentId.value;
+	if (!id) {
+		contextInfo.value = null;
+		return;
+	}
+	try {
+		const c = await api.getConversationContext(id);
+		// Stale-response guard (mirrors loadConversation): a slow response for a
+		// chat the user has since left must not stamp ITS compacting/context state
+		// onto whichever chat is on screen now.
+		if (currentId.value !== id) return;
+		if (c && c.fresh) contextInfo.value = c;
+		if (applyCompacting) {
+			compacting.value = !!(c && c.compacting);
+		} else if (c && c.compacting) {
+			compacting.value = true;
+		}
+	} catch {
+		/* meter is best-effort */
+	}
+}
+
+function openCompactDialog(seed = "") {
+	compactHintSeed.value = seed;
+	compactDialogOpen.value = true;
+}
+
+async function runCompact(hint) {
+	if (!currentId.value) return;
+	compactSubmitting.value = true;
+	try {
+		const res = await api.compactConversation(currentId.value, hint);
+		if (!res || !res.ok) {
+			notify(compactFailureCopy(res && res.reason), { type: "error" });
+			return;
+		}
+		compacting.value = true;
+		compactedChip.value = false;
+		compactHintSeed.value = hint || "";
+		compactDialogOpen.value = false;
+	} catch (e) {
+		notify(errMessage(e) || compactFailureCopy(), { type: "error" });
+	} finally {
+		compactSubmitting.value = false;
+	}
+}
+
 // Compact token count: 1234 → "1.2k", 2_500_000 → "2.5M".
 function fmtTokens(n) {
 	n = Number(n || 0);
@@ -5916,6 +6106,11 @@ const canSend = computed(
 	() =>
 		(input.value.trim().length > 0 || pendingFiles.value.length > 0) &&
 		!sending.value &&
+		// A compaction (auto mid-turn, or one we started) must never race a turn
+		// writing the same context — Composer has no bare `disabled` prop, so this
+		// is the equivalent binding: fold `compacting` into the same gate `sending`
+		// already uses.
+		!compacting.value &&
 		// Suspended: the server rejects every send, so keep the button dead.
 		!suspendedNotice.value &&
 		// No model configured: nothing on the other end can answer, so prevent the
@@ -6141,7 +6336,9 @@ const triggerMode = ref(false);
 // "Ask Jarvis" style) instead of a chip list, and a small marker sits above it.
 const TRIGGER_PLACEHOLDER = "e.g. Warn me when a Sales Invoice over 1 lakh is submitted";
 const composerPlaceholder = computed(() =>
-	triggerMode.value
+	compacting.value
+		? "Compacting this chat, try again in a moment"
+		: triggerMode.value
 		? TRIGGER_PLACEHOLDER
 		: `Ask ${agentName}…   @ to mention a user, / for a doctype or tool`
 );
@@ -8112,6 +8309,7 @@ async function loadConversation(id) {
 		histIdx.value = null;
 		histDraft.value = "";
 		loadedConvTitle.value = "";
+		contextInfo.value = null;
 		return;
 	}
 	const d = await api.getConversation(id);
@@ -8122,6 +8320,11 @@ async function loadConversation(id) {
 	// does a single clean load, would put it right. (Root cause of "open a
 	// chat, switch away and back, it shows empty until I refresh".)
 	if (currentId.value !== id) return;
+	// Context meter: best-effort, off the critical path (never awaited) — a slow
+	// or failed get_conversation_context must not delay messages rendering.
+	// This is the conversation-open path, so this fetch is authoritative for
+	// the lock too (applyCompacting) - unlike the mid-turn refreshes elsewhere.
+	loadContext({ applyCompacting: true });
 	// Flush any in-flight reveal BEFORE swapping in the freshly-loaded rows. On a
 	// reconnect resync the socket may have missed a run's terminal (fire-and-forget
 	// pub/sub, no replay), so flushReveal(message_id) never ran for it; a leftover
@@ -8663,6 +8866,25 @@ async function send(textArg, resendAck) {
 	const _sentScope = _currentScope();
 	const fromMain = typeof textArg !== "string";
 	const text = (fromMain ? input.value : textArg).trim();
+	const compactCmd = parseCompactCommand(text);
+	if (compactCmd) {
+		if (fromMain) input.value = "";
+		if (compacting.value) {
+			notify("Already compacting this chat", { type: "info" });
+			return;
+		}
+		if (compactCmd.hint) await runCompact(compactCmd.hint);
+		else openCompactDialog("");
+		return;
+	}
+	// A compaction in flight must never race a turn writing the same context.
+	// canSend already darkens Send while compacting, but Enter routes here
+	// directly (same gap noAiConnected below closes for that reason) and a
+	// programmatic send never sees the button at all.
+	if (compacting.value) {
+		notify("Compacting this chat, try again in a moment", { type: "info" });
+		return;
+	}
 	// PAYLOAD-bound voice release: bind the release to the transcribed recordings whose text is
 	// ACTUALLY PRESENT in THIS outgoing payload — captured NOW, before the POST. A recording the
 	// user EDITED or DELETED out of the composer is absent from `text`, so captureSentInPayload
@@ -9091,6 +9313,11 @@ function onEvent(p) {
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;
+			// run:status "compacting" is lossy on the transport and its "compacted"
+			// counterpart can be dropped — never leave the composer locked waiting
+			// for an event that may never arrive. A parked/recovering turn is, by
+			// definition, no longer mid-compaction from this tab's point of view.
+			compacting.value = false;
 			activeTools.value = [];
 			currentRunId.value = null;
 			store.streamingConvId = null;
@@ -9099,6 +9326,26 @@ function onEvent(p) {
 			// Lightweight progress signal (e.g. waking a cold container) between
 			// run:start and the first token — keeps the connect window honest.
 			if (p.status === "waking") statusPhase.value = "waking";
+			if (p.status === "compacting") {
+				statusPhase.value = "compacting";
+				compacting.value = true;
+			}
+			if (p.status === "compacted") {
+				statusPhase.value = null;
+				compacting.value = false;
+				compactedChip.value = true;
+			}
+			break;
+		case "context:compacted":
+			compacting.value = false;
+			compactedChip.value = true;
+			compactHintSeed.value = "";
+			loadContext();
+			break;
+		case "context:compact_failed":
+			compacting.value = false;
+			compactHintSeed.value = "";
+			notify(compactFailureCopy(p.reason), { type: "error" });
 			break;
 		case "run:start":
 			// CDX-3: a stale-epoch run:start (a pump that lost the lease, or one that
@@ -9161,6 +9408,15 @@ function onEvent(p) {
 			// bypass and are always applied, unchanged.
 			if (pumpFenceReject(p)) break;
 			pumpFenceAccept(p, false);
+			// The "compacted" run:status frame is lossy (see the run:status case
+			// below); if it never arrived, real progress after a "compacting"
+			// marker means the compaction already ended, so clear the stuck lock
+			// here rather than leave the activity row hidden for the rest of the
+			// turn.
+			if (compacting.value && statusPhase.value === "compacting") {
+				compacting.value = false;
+				statusPhase.value = null;
+			}
 			waiting.value = false;
 			statusPhase.value = null;
 			recovering.value = null;
@@ -9184,6 +9440,13 @@ function onEvent(p) {
 			if (pumpFenceReject(p)) break; // CDX-3 (epoch-less legacy tool events bypass)
 			if (toolEventIsStale(p)) break;
 			pumpFenceAccept(p, false);
+			// See the matching guard in assistant:delta: a dropped "compacted"
+			// run:status frame must not leave compacting stuck true once the turn
+			// has visibly moved on.
+			if (compacting.value && statusPhase.value === "compacting") {
+				compacting.value = false;
+				statusPhase.value = null;
+			}
 			const id = p.tool_call_id || `${p.tool_name}-${activeTools.value.length}`;
 			activeTools.value = [
 				...activeTools.value,
@@ -9295,6 +9558,12 @@ function onEvent(p) {
 					},
 				};
 			}
+			// The compacted after-chip and the compacting lock are both scoped to a
+			// single turn: the NEXT run:end always clears them and refetches the
+			// meter, whether or not this particular turn itself compacted.
+			compactedChip.value = false;
+			compacting.value = false;
+			loadContext();
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;
@@ -9463,6 +9732,10 @@ function onEvent(p) {
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;
+			// run:status "compacting" is lossy on the transport and its "compacted"
+			// counterpart can be dropped — an errored turn must not leave the
+			// composer locked waiting for an event that may never arrive.
+			compacting.value = false;
 			activeTools.value = [];
 			currentRunId.value = null;
 			store.streamingConvId = null;
@@ -11687,6 +11960,90 @@ onUnmounted(() => {
 @keyframes jv-spin {
 	to {
 		transform: rotate(360deg);
+	}
+}
+/* Compacting banner: folding lines settle into one summary line, on loop. */
+.jv-fold {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	width: 150px;
+	margin-top: 8px;
+}
+.jv-fold i {
+	display: block;
+	height: 6px;
+	border-radius: 99px;
+	background: var(--surface-3);
+	transform-origin: top;
+	animation: jv-foldline 3.2s ease-in-out infinite;
+}
+.jv-fold i:nth-child(2) {
+	width: 88%;
+	animation-delay: 0.12s;
+}
+.jv-fold i:nth-child(3) {
+	width: 70%;
+	animation-delay: 0.24s;
+}
+.jv-fold i:nth-child(4) {
+	width: 92%;
+	animation-delay: 0.36s;
+}
+.jv-fold i:nth-child(5) {
+	width: 60%;
+	animation-delay: 0.48s;
+}
+.jv-fold i:last-child {
+	width: 44%;
+	background: var(--brand-grad, linear-gradient(135deg, #6e8bff, #8b5cf6));
+	animation: jv-summary 3.2s ease-in-out infinite;
+}
+@keyframes jv-foldline {
+	0%,
+	25% {
+		opacity: 1;
+		transform: scaleY(1) translateY(0);
+	}
+	55%,
+	100% {
+		opacity: 0;
+		transform: scaleY(0.1) translateY(-26px);
+	}
+}
+@keyframes jv-summary {
+	0%,
+	50% {
+		opacity: 0;
+		transform: translateY(-14px);
+	}
+	70%,
+	100% {
+		opacity: 1;
+		transform: translateY(-32px);
+	}
+}
+.jv-ctx-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12px;
+	color: var(--text-2);
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: 99px;
+	padding: 4px 11px;
+}
+.jv-ctx-chip::before {
+	content: "";
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: #16a34a;
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-fold i {
+		animation: none;
 	}
 }
 /* Phase-0 admission: Cancel affordance on the queued chip. Text-button idiom

--- a/jarvis/chat/agent_client.py
+++ b/jarvis/chat/agent_client.py
@@ -753,6 +753,49 @@ class AgentSession:
 			params["runId"] = run_id
 		return self._request("chat.abort", params, timeout_s=timeout_s)
 
+	def compact_session(
+		self,
+		session_key: str,
+		hint: str | None = None,
+		*,
+		timeout_s: float = 200.0,
+	) -> dict:
+		"""Compact one session by sending the runtime's text command
+		``/compact <hint>`` through chat.send (the ONLY surface that accepts a
+		hint; the sessions.compact RPC has none). The command path emits no
+		agent lifecycle frames, only session.message frames and one ``chat``
+		event with a terminal state, so this waits for THAT and nothing else.
+		Verified live 2026-09-05: about 6 s, notice text
+		"⚙️ Compacted (58k before) • Context 58k/200k (29%)"."""
+		message = "/compact" + (f" {hint.strip()}" if hint and hint.strip() else "")
+		run_id = uuid.uuid4().hex
+		self.subscribe_session(session_key)
+		ack = self.chat_send(session_key, message, run_id, timeout_s=CONNECT_TIMEOUT_SECONDS)
+		rid = ack.get("runId") or run_id
+		deadline = time.monotonic() + timeout_s
+		while time.monotonic() < deadline:
+			try:
+				frame = self._recv(min(5.0, max(deadline - time.monotonic(), 0.01)))
+			except AgentUnreachableError as e:
+				# A hard close after the ack is the same "sent it, never heard
+				# back" outcome as a plain timeout (the command may have
+				# landed) - recode a codeless close so the caller's
+				# code == "compact-timeout" check still routes it that way.
+				if getattr(e, "code", None):
+					raise
+				raise AgentUnreachableError(str(e), code="compact-timeout") from e
+			if not frame or frame.get("type") != "event" or frame.get("event") != "chat":
+				continue
+			payload = frame.get("payload") or {}
+			if payload.get("runId") != rid or payload.get("sessionKey") != session_key:
+				continue
+			state = payload.get("state")
+			if state == "final":
+				return {"state": "final", "text": _chat_final_text(payload), "run_id": rid}
+			if state in ("error", "aborted"):
+				return {"state": state, "text": str(payload.get("errorMessage") or state), "run_id": rid}
+		raise AgentUnreachableError("compact timed out", code="compact-timeout")
+
 	def subscribe_session(
 		self,
 		session_key: str,

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -899,6 +899,10 @@ def _conversation_busy(conversation: str) -> bool:
 	composer is intentionally unlocked while recovering), and a stale streaming
 	row from a crashed worker ages out of the freshness window (stale_scan
 	finalizes it) so it never blocks sends forever."""
+	from jarvis.chat import compaction
+
+	if compaction.is_compacting(conversation):
+		return True
 	rows = frappe.db.sql(
 		"""SELECT streaming, recovering, modified FROM `tabJarvis Chat Message`
 		WHERE conversation = %s AND role = 'assistant'
@@ -923,6 +927,15 @@ def _conversation_busy(conversation: str) -> bool:
 		return False
 	age = (frappe.utils.now_datetime() - frappe.utils.get_datetime(last)).total_seconds()
 	return age < _INFLIGHT_FRESH_SECONDS
+
+
+def _compacting_reject(conversation: str) -> dict | None:
+	"""The send-path front door while a compaction holds the conversation."""
+	from jarvis.chat import compaction
+
+	if compaction.is_compacting(conversation):
+		return {"ok": False, "reason": _("Compacting this chat, try again in a moment")}
+	return None
 
 
 def _ordered_parked_cards(user: str, conversation: str) -> list[dict] | None:
@@ -1329,12 +1342,21 @@ def send_message(
 	# second turn becomes a durable QUEUED turn with a visible position. So skip
 	# the legacy reject and let accept_or_queue serialize + queue it. We still
 	# reject up front on OVERLOAD (queue too deep) before inserting the user row,
-	# so an overloaded site never accretes orphaned messages.
+	# so an overloaded site never accretes orphaned messages, and the compaction
+	# front door (_compacting_reject) still gates both branches below it.
 	if admission.turn_machine_enabled():
 		if admission.shard_overloaded(conversation):
 			return {"ok": False, "reason": _("The site is busy — please try again in a moment.")}
-	elif _conversation_busy(conversation):
-		return {"ok": False, "reason": _("a reply is already in progress - hang on a moment")}
+		if _rej := _compacting_reject(conversation):
+			return _rej
+	else:
+		# Check the compaction front door first so a compacting conversation
+		# doesn't pay for is_compacting twice (once here, once inside the
+		# _conversation_busy() call below).
+		if _rej := _compacting_reject(conversation):
+			return _rej
+		if _conversation_busy(conversation):
+			return {"ok": False, "reason": _("a reply is already in progress - hang on a moment")}
 
 	# Apply model override BEFORE enqueueing so the worker sees the new value
 	# when it loads the conversation. (If we set this after the enqueue, the
@@ -2262,6 +2284,9 @@ def get_usage(conversation: str | None = None) -> dict:
 	# is the ownership check: this endpoint never loads the conversation doc.
 	if conversation and conversation in convs:
 		out["chat_tool_calls"] = sum(r["tools"] for r in _tool_runs(conversation))
+		from jarvis.chat import compaction
+
+		out["context"] = compaction.context_payload(conversation)
 
 	rows = frappe.get_all(
 		MSG,
@@ -2276,6 +2301,63 @@ def get_usage(conversation: str | None = None) -> dict:
 		if conversation and m.conversation == conversation:
 			out["chat_tokens"] += t
 	return out
+
+
+@frappe.whitelist()
+def get_conversation_context(conversation: str) -> dict:
+	"""Context-window meter for one conversation (owner only). Bench snapshot
+	only; never calls the runtime."""
+	require_jarvis_access()
+	_get_owned_conversation(conversation)
+	from jarvis.chat import compaction
+
+	return compaction.context_payload(conversation)
+
+
+@frappe.whitelist()
+def compact_conversation(conversation: str, hint: str | None = None) -> dict:
+	"""Summarise older turns of one conversation (owner only). Refuses with a
+	typed reason while a turn or another compaction is in flight; otherwise
+	takes the lock and enqueues jarvis.chat.compaction.run_compact."""
+	require_jarvis_access()
+	doc = _get_owned_conversation(conversation)
+	from jarvis.chat import compaction
+
+	if doc.get("skip_confirmation"):
+		return {"ok": False, "reason": "macro_armed"}
+	if not (doc.get("session_key") or "").strip():
+		return {"ok": False, "reason": "nothing_to_compact"}
+	# A second Compact with no turn in between would just re-summarise the summary:
+	# refuse it the same way as "nothing to compact" rather than burn a gateway
+	# round trip. run_compact stamps last_compacted_at but never last_usage_at;
+	# record_turn_usage stamps last_usage_at on the NEXT completed turn, so
+	# last_compacted_at >= last_usage_at (or no usage at all yet) means no turn
+	# has run since the last compaction.
+	session_row = (
+		frappe.db.get_value(
+			"Jarvis Chat Session",
+			{"session_key": doc.session_key},
+			["last_compacted_at", "last_usage_at"],
+			as_dict=True,
+		)
+		or {}
+	)
+	last_compacted_at = session_row.get("last_compacted_at")
+	last_usage_at = session_row.get("last_usage_at")
+	if last_compacted_at and (not last_usage_at or last_compacted_at >= last_usage_at):
+		return {"ok": False, "reason": "nothing_to_compact"}
+	# This check races the same way is_compacting below does - the compare-and-set
+	# in compaction.start_compaction is the actual authority, this is just a
+	# cheap pre-check that saves a gateway round trip for the common case.
+	if compaction.is_compacting(conversation):
+		return {"ok": False, "reason": "already_compacting"}
+	if _conversation_busy(conversation) or admission._conv_has_other_active_turn(conversation, ""):
+		return {"ok": False, "reason": "conversation_busy"}
+	try:
+		clean = compaction.sanitize_hint(hint)
+	except frappe.ValidationError:
+		return {"ok": False, "reason": "bad_hint"}
+	return compaction.start_compaction(conversation, frappe.session.user, clean)
 
 
 @frappe.whitelist()
@@ -2425,8 +2507,16 @@ def retry_message(message: str) -> dict:
 	if admission.turn_machine_enabled():
 		if admission.shard_overloaded(doc.conversation):
 			return {"ok": False, "reason": _("The site is busy — please try again in a moment.")}
-	elif _conversation_busy(doc.conversation):
-		return {"ok": False, "reason": _("a reply is already in progress - hang on a moment")}
+		if _rej := _compacting_reject(doc.conversation):
+			return _rej
+	else:
+		# Check the compaction front door first so a compacting conversation
+		# doesn't pay for is_compacting twice (once here, once inside the
+		# _conversation_busy() call below).
+		if _rej := _compacting_reject(doc.conversation):
+			return _rej
+		if _conversation_busy(doc.conversation):
+			return {"ok": False, "reason": _("a reply is already in progress - hang on a moment")}
 	if doc.role != "assistant":
 		return {"ok": False, "reason": _("only assistant messages can be retried")}
 	if not doc.error:

--- a/jarvis/chat/compaction.py
+++ b/jarvis/chat/compaction.py
@@ -1,0 +1,280 @@
+"""Per-conversation context meter and manual compaction.
+
+Spec: docs/superpowers/specs/2026-09-05-chat-context-meter-compact-design.md
+
+The runtime keeps the context snapshot on its sessions row (used = totalTokens,
+capacity = contextTokens) and ``jarvis.chat.usage`` already mirrors it into
+``Jarvis Chat Session`` after every completed turn. This module adds the read
+payload for the UI, the compact job, and the per-conversation lock the send
+path honours while a compaction is in flight.
+
+Facts verified live 2026-09-05 (image 2026.6.8, e2e.localhost):
+- the ONLY way to pass a "what to keep" hint is the runtime's text command
+  ``/compact <hint>`` over chat.send; the sessions.compact RPC has no hint;
+- the command path answers with one ``chat`` final event carrying a notice
+  ("⚙️ Compacted (58k before) • ...", or "⚙️ Compaction skipped: ...") and
+  emits no lifecycle frames;
+- after compaction the row's totalTokens is null / not fresh until the NEXT
+  turn, so this job never rewrites last_total_tokens or context_pct.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import frappe
+from frappe import _
+
+from jarvis.chat.events import publish_to_user
+
+CONV = "Jarvis Conversation"
+CHAT_SESSION = "Jarvis Chat Session"
+TURN_USAGE = "Jarvis Turn Usage"
+
+COMPACT_LOCK_SECONDS = 300
+HINT_MAX_CHARS = 500
+WARN_PCT = 80
+DEFAULT_RESERVE_TOKENS = 20000
+COMPACT_JOB_TIMEOUT_S = 260
+COMPACT_RPC_TIMEOUT_S = 200.0
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def sanitize_hint(hint: str | None) -> str:
+	"""Trim, strip control characters, collapse whitespace, cap the length.
+	A hint starting with ``/`` would be read by the runtime as ANOTHER
+	command, so it is refused outright."""
+	text = _CONTROL_CHARS.sub("", str(hint or ""))
+	text = " ".join(text.split())
+	if text.startswith("/"):
+		frappe.throw(_("The hint cannot start with a slash."), frappe.ValidationError)
+	return text[:HINT_MAX_CHARS]
+
+
+def _is_fresh_lock(since) -> bool:
+	"""True while ``since`` (a ``compacting_since`` value already read by the
+	caller) still falls inside the lock window. Shared by ``is_compacting``
+	and ``context_payload`` so a caller that already has the row need not
+	re-read ``compacting_since`` a second time."""
+	if not since:
+		return False
+	age = (frappe.utils.now_datetime() - frappe.utils.get_datetime(since)).total_seconds()
+	return 0 <= age < COMPACT_LOCK_SECONDS
+
+
+def is_compacting(conversation: str) -> bool:
+	since = frappe.db.get_value(CONV, conversation, "compacting_since")
+	return _is_fresh_lock(since)
+
+
+def classify_notice(text: str) -> str:
+	"""``compacted`` when the runtime's notice says it compacted, ``skipped``
+	when it says there was nothing to compact, else ``failed`` (the runtime
+	reported a failure, or the notice is missing or unexpected)."""
+	t = (text or "").strip().lstrip("⚙️").strip().lower()
+	if t.startswith("compacted"):
+		return "compacted"
+	if t.startswith("compaction skipped"):
+		return "skipped"
+	return "failed"
+
+
+def _session_row(session_key: str) -> dict:
+	if not session_key:
+		return {}
+	return (
+		frappe.db.get_value(
+			CHAT_SESSION,
+			{"session_key": session_key},
+			[
+				"last_total_tokens",
+				"context_capacity",
+				"context_pct",
+				"last_usage_at",
+				"budget_route",
+				"reserve_tokens",
+				"compaction_count",
+				"last_compacted_at",
+			],
+			as_dict=True,
+		)
+		or {}
+	)
+
+
+def _last_turn_usage(session_key: str) -> dict:
+	"""The newest ``Jarvis Turn Usage`` row for this session, for the ring
+	popover's "Last reply" / "Model" rows. Empty when the session has no
+	recorded turn yet."""
+	if not session_key:
+		return {}
+	rows = frappe.get_all(
+		TURN_USAGE,
+		filters={"session_key": session_key},
+		fields=["tokens_in", "tokens_out", "model"],
+		order_by="creation desc",
+		limit=1,
+	)
+	return rows[0] if rows else {}
+
+
+def context_payload(conversation: str) -> dict:
+	"""What the context ring renders. Reads only the bench snapshot; never
+	touches the gateway."""
+	conv = frappe.db.get_value(CONV, conversation, ["session_key", "compacting_since"], as_dict=True) or {}
+	session_key = conv.get("session_key") or ""
+	row = _session_row(session_key)
+	capacity = int(row.get("context_capacity") or 0)
+	used = int(row.get("last_total_tokens") or 0)
+	reserve = int(row.get("reserve_tokens") or 0) or DEFAULT_RESERVE_TOKENS
+	pct = round(100 * used / capacity, 1) if capacity > 0 else 0.0
+	auto_pct = round(100 * (capacity - reserve) / capacity, 1) if capacity > reserve > 0 else 0.0
+	last_turn = _last_turn_usage(session_key)
+	return {
+		"used": used,
+		"capacity": capacity,
+		"pct": pct,
+		"warn_pct": WARN_PCT,
+		"auto_compact_pct": auto_pct,
+		"route": row.get("budget_route") or "",
+		"compaction_count": int(row.get("compaction_count") or 0),
+		"last_compacted_at": row.get("last_compacted_at"),
+		"compacting": _is_fresh_lock(conv.get("compacting_since")),
+		"fresh": bool(row.get("last_usage_at")) and capacity > 0,
+		"last_in": int(last_turn.get("tokens_in") or 0),
+		"last_out": int(last_turn.get("tokens_out") or 0),
+		"model": last_turn.get("model") or "",
+	}
+
+
+def _try_take_lock(conversation: str) -> bool:
+	"""Atomic compare-and-set on compacting_since: wins only when the lock is
+	empty or expired. This, not any caller's earlier read, is the sole
+	authority on which of two near-simultaneous callers may proceed."""
+	now = frappe.utils.now_datetime()
+	frappe.db.sql(
+		"""UPDATE `tabJarvis Conversation`
+		SET compacting_since = %(now)s
+		WHERE name = %(name)s
+		  AND (compacting_since IS NULL OR compacting_since < %(expired)s)""",
+		{
+			"now": now,
+			"name": conversation,
+			"expired": frappe.utils.add_to_date(now, seconds=-COMPACT_LOCK_SECONDS),
+		},
+	)
+	won = frappe.db.sql("SELECT ROW_COUNT()")[0][0] > 0
+	frappe.db.commit()
+	return won
+
+
+def start_compaction(conversation: str, user: str, hint: str) -> dict:
+	"""Take the lock via compare-and-set and enqueue the job. Callers have
+	already checked the conversation looks idle (api.compact_conversation),
+	but that earlier check is only an optimization - the CAS here is what
+	actually serializes two near-simultaneous callers."""
+	if not _try_take_lock(conversation):
+		return {"ok": False, "reason": "already_compacting"}
+	# ``jarvis_compact_queue`` (site config) lets a sidecar deployment route the
+	# job to a dedicated worker; production stays on the shared long queue.
+	frappe.enqueue(
+		method="jarvis.chat.compaction.run_compact",
+		queue=frappe.conf.get("jarvis_compact_queue") or "long",
+		timeout=COMPACT_JOB_TIMEOUT_S,
+		at_front=True,
+		job_id=f"jarvis-compact::{conversation}::{uuid.uuid4().hex[:8]}",
+		conversation=conversation,
+		user=user,
+		hint=hint,
+	)
+	return {"ok": True, "queued": True}
+
+
+def write_compaction_result(session_key: str, row: dict | None) -> None:
+	"""Stamp the compaction on the session snapshot. Does NOT touch
+	last_total_tokens / context_pct: the runtime row is stale until the next
+	turn (verified live)."""
+	from jarvis.chat import usage
+
+	usage._write_budget_fields(session_key, row)
+	frappe.db.sql(
+		"""UPDATE `tabJarvis Chat Session`
+		SET compaction_count = GREATEST(IFNULL(compaction_count, 0), 1),
+			last_compacted_at = %(now)s
+		WHERE session_key = %(key)s""",
+		{"now": frappe.utils.now_datetime(), "key": session_key},
+	)
+
+
+def _clear_lock(conversation: str) -> None:
+	frappe.db.set_value(CONV, conversation, "compacting_since", None, update_modified=False)
+	frappe.db.commit()
+
+
+def _gateway_session_row(sess, session_key: str) -> dict:
+	"""The gateway's own row for this session, or {} if it has none. Shared by
+	the before and after reads in run_compact - both want the same lookup."""
+	rows = [r for r in (sess.list_sessions() or []) if r.get("key") == session_key]
+	return rows[0] if rows else {}
+
+
+def run_compact(conversation: str, user: str, hint: str = "") -> None:
+	"""RQ entry point. One pooled gateway session for the whole operation."""
+	from jarvis.chat import agent_session_pool, usage
+	from jarvis.chat.agent_client import AgentUnreachableError
+
+	conv = frappe.db.get_value(CONV, conversation, ["session_key"], as_dict=True) or {}
+	session_key = conv.get("session_key") or ""
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
+	reason: str | None = None
+	before = 0
+	capacity = 0
+	count = 0
+	try:
+		with agent_session_pool.checkout(gateway_url) as sess:
+			row = _gateway_session_row(sess, session_key)
+			before = int(row.get("totalTokens") or 0)
+			capacity = int(row.get("contextTokens") or 0)
+			res = sess.compact_session(session_key, hint or None, timeout_s=COMPACT_RPC_TIMEOUT_S)
+			outcome = classify_notice(res.get("text") or "") if res.get("state") == "final" else "failed"
+			if outcome != "compacted":
+				reason = "runtime_declined" if outcome == "skipped" else "runtime_failed"
+				frappe.logger("jarvis.chat").warning(
+					"compact declined conv=%s state=%s text=%s",
+					conversation,
+					res.get("state"),
+					res.get("text"),
+				)
+			else:
+				after_row = _gateway_session_row(sess, session_key) or None
+				write_compaction_result(session_key, after_row)
+				frappe.db.commit()
+				count = int(
+					frappe.db.get_value(CHAT_SESSION, {"session_key": session_key}, "compaction_count") or 0
+				)
+	except AgentUnreachableError as e:
+		reason = "timeout" if getattr(e, "code", None) == "compact-timeout" else "gateway_unreachable"
+	except Exception:
+		frappe.log_error(title="chat: compact job failed", message=frappe.get_traceback())
+		reason = "unknown"
+	finally:
+		_clear_lock(conversation)
+
+	if reason:
+		publish_to_user(
+			user, {"kind": "context:compact_failed", "conversation_id": conversation, "reason": reason}
+		)
+		return
+	publish_to_user(
+		user,
+		{
+			"kind": "context:compacted",
+			"conversation_id": conversation,
+			"before": before,
+			"capacity": capacity,
+			"compaction_count": count,
+		},
+	)

--- a/jarvis/chat/events.py
+++ b/jarvis/chat/events.py
@@ -65,6 +65,17 @@ def parse_event(payload: dict[str, Any]) -> dict[str, Any] | None:
 			"delta": egress_rules.redact(data.get("delta", "")),
 		}
 
+	if stream == "compaction":
+		# The runtime brackets an automatic (threshold or overflow) compaction
+		# with this stream. Mapped so the chat can show "reorganising" while the
+		# run is still alive; nothing else changes on the terminal path.
+		phase = str(data.get("phase") or "")
+		return {
+			"kind": "compaction",
+			"phase": "start" if phase in ("start", "before") else "end",
+			"completed": bool(data.get("completed")),
+		}
+
 	return None
 
 

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -2290,6 +2290,31 @@ def _make_handler(ctx: PumpContext, rs: _RunState) -> LaneHandler:
 			return
 		ctx.deps.apply_tool(ctx, rs, event)
 
+	def on_status(event_seq: int, status: str) -> None:
+		# LOSSY (like a delta): a raise here drops this one frame and continues
+		# the lane — a transient "compacting"/"compacted" marker is never worth
+		# quarantining a turn over. Flush any batched deltas first so the
+		# realtime order matches the frame order (same discipline as on_tool).
+		if ctx.lease_lost:
+			return
+		try:
+			_flush_deltas(ctx, rs)
+		except ts.LeaseLostExit:
+			ctx.lease_lost = rs.run_id
+			return
+		if rs.owner:
+			ts.publish_fenced(
+				rs.owner,
+				"run:status",
+				conversation_id=rs.conversation,
+				run_id=rs.run_id,
+				event_seq=event_seq,
+				message_id=rs.assistant_message,
+				status=status,
+				pump_epoch=ctx.epoch,
+				relay_target_id=ctx.relay_target_id,
+			)
+
 	def on_terminal(kind: str, payload: dict) -> None:
 		if ctx.lease_lost:
 			return
@@ -2343,6 +2368,7 @@ def _make_handler(ctx: PumpContext, rs: _RunState) -> LaneHandler:
 		on_terminal=on_terminal,
 		on_quarantine=on_quarantine,
 		on_closing=on_closing,
+		on_status=on_status,
 	)
 
 

--- a/jarvis/chat/relay_mux.py
+++ b/jarvis/chat/relay_mux.py
@@ -229,6 +229,9 @@ class LaneHandler:
 	    fault, precious overflow). The pump parks the turn toward ``recovering``.
 	  * ``on_closing(sentinel: str)`` — the socket died: this lane lost its
 	    transport. The pump re-attaches from durable state on the next hop.
+	  * ``on_status(event_seq: int, status: str)`` — a transient run-status
+	    marker (e.g. an in-flight compaction) (LOSSY, like a delta): a raise
+	    drops the frame, counts it, and continues the same lane.
 	"""
 
 	on_delta: Callable[[int, str, str], None] | None = None
@@ -236,6 +239,7 @@ class LaneHandler:
 	on_terminal: Callable[[str, dict], None] | None = None
 	on_quarantine: Callable[[str], None] | None = None
 	on_closing: Callable[[str], None] | None = None
+	on_status: Callable[[int, str], None] | None = None
 
 
 class _Lane:
@@ -536,7 +540,15 @@ class RelayMux:
 					"title": parsed.get("tool_title"),
 				},
 			)
-		else:  # pragma: no cover - parse_event only yields the three kinds
+		elif kind == "compaction":
+			seq = lane.next_seq()
+			ev = _LaneEvent(
+				cls=LOSSY,
+				kind="status",
+				event_seq=seq,
+				data={"status": "compacting" if parsed.get("phase") == "start" else "compacted"},
+			)
+		else:  # pragma: no cover - parse_event only yields the four kinds above
 			return
 		self._offer(lane, ev)
 
@@ -775,6 +787,9 @@ class RelayMux:
 			elif ev.kind == "tool":
 				if h.on_tool is not None:
 					h.on_tool({"event_seq": ev.event_seq, **ev.data})
+			elif ev.kind == "status":
+				if h.on_status is not None:
+					h.on_status(ev.event_seq, ev.data["status"])
 			elif ev.kind == "terminal":
 				if h.on_terminal is not None:
 					h.on_terminal(ev.data["terminal_kind"], ev.data["payload"])
@@ -789,7 +804,8 @@ class RelayMux:
 				# fault NEVER parks the turn.
 				self._bump("deltas_dropped")
 				_logger.debug(
-					"relay_mux: poison delta on run=%s seq=%s dropped+continued",
+					"relay_mux: poison %s on run=%s seq=%s dropped+continued",
+					ev.kind,
 					lane.run_id,
 					ev.event_seq,
 					exc_info=True,

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -2322,6 +2322,20 @@ def _handle_event_inner(
 		# lifecycle start is a no-op (we already published run:start)
 		return
 
+	if kind == "compaction":
+		batcher.flush()
+		_publish_to_user(
+			user,
+			{
+				"kind": "run:status",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg_name,
+				"run_id": run_id,
+				"status": "compacting" if event.get("phase") == "start" else "compacted",
+			},
+		)
+		return
+
 	if kind == "assistant":
 		text = event.get("text", "")
 		# Hot path: buffer the cumulative text + maybe-flush. The

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -200,6 +200,65 @@ def _context_capacity_and_pct(row: dict | None, used_tokens: int) -> tuple[int, 
 	return capacity, round(100 * used_tokens / capacity, 1)
 
 
+def budget_fields_from_row(row: dict | None) -> tuple[str, int, int]:
+	"""``(budget_route, reserve_tokens, compaction_count)`` from a sessions row.
+
+	``contextBudgetStatus`` is an OBJECT on the runtime row (pre-prompt
+	estimate; ``route`` is one of fits / compact_only /
+	truncate_tool_results_only / compact_then_truncate). Absent or malformed
+	values read as empty/zero so a missing field never breaks a turn."""
+	row = row or {}
+	status = row.get("contextBudgetStatus")
+	if not isinstance(status, dict):
+		status = {}
+	route = str(status.get("route") or "")[:40]
+	try:
+		reserve = int(status.get("reserveTokens") or 0)
+	except (TypeError, ValueError):
+		reserve = 0
+	try:
+		count = int(row.get("compactionCheckpointCount") or 0)
+	except (TypeError, ValueError):
+		count = 0
+	return route, max(reserve, 0), max(count, 0)
+
+
+def _write_budget_fields(session_key: str, row: dict | None) -> None:
+	"""UPDATE the budget snapshot columns. Same no-commit contract as
+	``_refresh_session_context_snapshot``. ``compaction_count`` only moves
+	forward (the row is authoritative when it reports one).
+
+	Compaction amendment (context-meter task 4): the runtime CLEARS
+	``contextBudgetStatus`` on a compaction turn, so a row with no status is
+	not "route/reserve are now empty" - it is "this row didn't report a
+	budget this time". Blanking ``budget_route``/``reserve_tokens`` on such a
+	row would erase a good reserve right after a compaction, so when the
+	status is absent this only advances ``compaction_count`` and leaves the
+	other two columns untouched. A row that DOES carry a status still writes
+	all three, same as before."""
+	route, reserve, count = budget_fields_from_row(row)
+	if not isinstance((row or {}).get("contextBudgetStatus"), dict):
+		frappe.db.sql(
+			"""
+			UPDATE `tabJarvis Chat Session`
+			SET compaction_count = GREATEST(IFNULL(compaction_count, 0), %(count)s)
+			WHERE session_key = %(session_key)s
+			""",
+			{"count": count, "session_key": session_key},
+		)
+		return
+	frappe.db.sql(
+		"""
+		UPDATE `tabJarvis Chat Session`
+		SET budget_route = %(route)s,
+			reserve_tokens = %(reserve)s,
+			compaction_count = GREATEST(IFNULL(compaction_count, 0), %(count)s)
+		WHERE session_key = %(session_key)s
+		""",
+		{"route": route, "reserve": reserve, "count": count, "session_key": session_key},
+	)
+
+
 def _refresh_session_context_snapshot(
 	session_key: str, context_tokens: int, context_capacity: int, context_pct: float
 ) -> None:
@@ -305,6 +364,7 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 			# can have moved even though no tokens were spent this turn. Same
 			# no-commit contract as the rest of this branch (see docstring).
 			_refresh_session_context_snapshot(session_key, context_tokens, context_capacity, context_pct)
+			_write_budget_fields(session_key, row)
 			return USAGE_VALID_ZERO
 
 		if not user:
@@ -369,6 +429,7 @@ def record_turn_usage(session_key: str, row: dict | None, run_id: str | None = N
 			""",
 			params,
 		)
+		_write_budget_fields(session_key, row)
 		# Per-model attribution (fleet spec §7): the gateway sessions row
 		# carries whatever model the SESSION resolved to for this turn
 		# (turn_handler._session_model_for). For a pinned model that's the
@@ -843,6 +904,7 @@ def refresh_session_snapshots(rows: list[dict]) -> dict:
 				""",
 				params,
 			)
+			_write_budget_fields(session_key, row)
 			touched_users.add(user)
 			bucket = summary.setdefault(user, {"sessions": 0, "last_total_tokens": 0})
 			bucket["sessions"] += 1

--- a/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
@@ -23,7 +23,11 @@
     "last_total_tokens",
     "context_capacity",
     "context_pct",
-    "last_usage_at"
+    "last_usage_at",
+    "budget_route",
+    "reserve_tokens",
+    "compaction_count",
+    "last_compacted_at"
   ],
   "fields": [
     {
@@ -156,6 +160,32 @@
       "read_only": 1,
       "no_copy": 1,
       "description": "When usage was last recorded or synced for this session."
+    },
+    {
+      "fieldname": "budget_route",
+      "fieldtype": "Data",
+      "label": "Budget Route",
+      "length": 40,
+      "read_only": 1
+    },
+    {
+      "fieldname": "reserve_tokens",
+      "fieldtype": "Int",
+      "label": "Reserve Tokens",
+      "read_only": 1
+    },
+    {
+      "fieldname": "compaction_count",
+      "fieldtype": "Int",
+      "label": "Compaction Count",
+      "default": "0",
+      "read_only": 1
+    },
+    {
+      "fieldname": "last_compacted_at",
+      "fieldtype": "Datetime",
+      "label": "Last Compacted At",
+      "read_only": 1
     }
   ],
   "permissions": [

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -18,7 +18,8 @@
   "pending_agent_notes",
   "auto_expired",
   "expired_at",
-  "origin_page"
+  "origin_page",
+  "compacting_since"
  ],
  "fields": [
   {
@@ -161,6 +162,13 @@
    "no_copy": 1,
    "read_only": 1,
    "description": "The builder page this conversation was started from (\"dashboards\" / \"triggers\"), stamped by jarvis.chat.api.send_message from the context allow-list. The builder chats are ordinary conversations that also show up in the main chat list, where nothing else distinguishes a dashboard artifact from any other html canvas - this is that marker. Server-set only."
+  },
+  {
+   "fieldname": "compacting_since",
+   "fieldtype": "Datetime",
+   "label": "Compacting Since",
+   "hidden": 1,
+   "read_only": 1
   }
  ],
  "permissions": [

--- a/jarvis/tests/test_chat_admission.py
+++ b/jarvis/tests/test_chat_admission.py
@@ -217,6 +217,57 @@ class TestAcceptOrQueueBasics(_AdmissionTestCase):
 		self.assertEqual(frappe.db.count(TURN, {"run_id": "dup"}), 1)
 
 
+class TestCompactionQueuesInsteadOfRejects(_AdmissionTestCase):
+	"""A compacting conversation is not a hard reject in admission - it is the
+	same "busy" signal a live turn or a recovering turn already is:
+	``_conv_legacy_busy`` -> ``api._conversation_busy`` returns True while
+	``compaction.is_compacting`` (see api.py), so accept queues instead of
+	dispatching and ``_pick_next``'s ``eligible()`` skips it on promotion until
+	the lock clears. The front door (send_message / retry_message) is what
+	actually refuses a compacting send to the user; this class covers the
+	machine's own queue-then-promote-later behavior."""
+
+	def test_accept_or_queue_queues_while_compacting(self):
+		conv = self._mk_conv()
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		seed = self._mk_msg(conv, 1)
+		calls = []
+		with patch.object(admission, "_max_inflight", return_value=4):
+			res = self._accept(conv, "compact-run", seed, calls=calls)
+		self.assertTrue(res["ok"])
+		self.assertFalse(res["dispatched"], "must not dispatch onto the transcript a compaction is rewriting")
+		self.assertIsNotNone(res["queued_position"])
+		self.assertEqual(self._state("compact-run"), "queued")
+		self.assertEqual(calls, [], "no dispatch fired for a queued (not rejected) turn")
+
+	def test_promote_next_skips_while_compacting_then_promotes_once_cleared(self):
+		conv = self._mk_conv()
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		seed = self._mk_msg(conv, 1)
+		self._insert_turn(conv, "queued1", seed, "queued")
+		dispatched = []
+		with (
+			patch.object(admission, "_max_inflight", return_value=4),
+			patch.object(
+				chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+			),
+		):
+			# Blocked while the lock is fresh.
+			admission.promote_next(admission.DEFAULT_RELAY_TARGET)
+			self.assertEqual(self._state("queued1"), "queued", "not promoted while compacting")
+			self.assertEqual(dispatched, [])
+			# The lock clears (compaction finished) - the next sweep promotes it.
+			frappe.db.set_value(CONV, conv, "compacting_since", None, update_modified=False)
+			frappe.db.commit()
+			admission.promote_next(admission.DEFAULT_RELAY_TARGET)
+		self.assertEqual(self._state("queued1"), "dispatching", "promoted once the lock cleared")
+		self.assertEqual(dispatched, ["queued1"], "dispatched exactly once")
+
+
 class TestSimultaneousSendsCASRace(_AdmissionTestCase):
 	def test_two_simultaneous_sends_cap_one(self):
 		"""Barrier-synchronized threads, real separate DB connections, cap 1:

--- a/jarvis/tests/test_chat_agent_client.py
+++ b/jarvis/tests/test_chat_agent_client.py
@@ -1032,3 +1032,95 @@ class TestSessionsListModelIdentity(FrappeTestCase):
 
 		self.assertEqual(resolved_model_identity(rows[0]), ("", ""))
 		self.assertEqual(resolved_model_identity(None), ("", ""))
+
+
+# --- TestCompactSession ----------------------------------------------------
+
+
+def _session_with_scripted_frames(frames: list) -> AgentSession:
+	"""Build a handshaken AgentSession (via _build_session) whose WS then
+	plays back `frames` in order. Each dict with type == "res" gets its "id"
+	substituted at recv time with the id of the request most recently sent on
+	this connection (mirrors _build_session._ok / TestCreateSession's _resp
+	pattern), so the caller doesn't need to predict request ids; every other
+	frame (an "event") is replayed verbatim."""
+	sess, ws = _build_session()
+
+	def _make(d: dict):
+		if d.get("type") == "res":
+
+			def _resp(d=d):
+				return _frame({**d, "id": ws.sent[-1]["id"]})
+
+			return _resp
+		return _frame(d)
+
+	ws._frames.extend(_make(f) for f in frames)
+	return sess
+
+
+class TestCompactSession(FrappeTestCase):
+	def test_compact_session_waits_for_chat_final(self):
+		key = "agent:main:k1"
+		frames = [
+			{"type": "res", "id": "<sub>", "ok": True, "payload": {"subscribed": True}},
+			{"type": "res", "id": "<send>", "ok": True, "payload": {"runId": "r1", "status": "started"}},
+			{"type": "event", "event": "session.message", "payload": {"sessionKey": key}},
+			{
+				"type": "event",
+				"event": "agent",
+				"payload": {"runId": "r1", "stream": "lifecycle", "data": {"phase": "start"}},
+			},
+			{
+				"type": "event",
+				"event": "chat",
+				"payload": {
+					"runId": "r1",
+					"sessionKey": key,
+					"state": "final",
+					"message": {
+						"role": "assistant",
+						"content": [
+							{"type": "text", "text": "⚙️ Compacted (58k before) • Context 58k/200k (29%)"}
+						],
+					},
+				},
+			},
+		]
+		sess = _session_with_scripted_frames(frames)
+		out = sess.compact_session(key, "keep the invoice inputs", timeout_s=5)
+		self.assertEqual(out["state"], "final")
+		self.assertIn("Compacted", out["text"])
+		sent = sess._ws.sent
+		self.assertEqual(sent[-1]["params"]["message"], "/compact keep the invoice inputs")
+
+	def test_compact_session_times_out(self):
+		key = "agent:main:k2"
+		frames = [
+			{"type": "res", "id": "<sub>", "ok": True, "payload": {}},
+			{"type": "res", "id": "<send>", "ok": True, "payload": {"runId": "r2"}},
+		]
+		sess = _session_with_scripted_frames(frames)
+		with self.assertRaises(AgentUnreachableError) as cm:
+			sess.compact_session(key, None, timeout_s=0.2)
+		self.assertEqual(cm.exception.code, "compact-timeout")
+
+	def test_compact_session_recodes_mid_wait_close_as_compact_timeout(self):
+		# A hard close AFTER the ack (command already accepted, may have
+		# landed) must route the same as a plain timeout, not surface the
+		# codeless AgentUnreachableError _recv_with_timeout raises on a
+		# real socket close.
+		key = "agent:main:k3"
+
+		def _raise_closed():
+			raise websocket.WebSocketConnectionClosedException("closed")
+
+		frames = [
+			{"type": "res", "id": "<sub>", "ok": True, "payload": {}},
+			{"type": "res", "id": "<send>", "ok": True, "payload": {"runId": "r3"}},
+		]
+		sess = _session_with_scripted_frames(frames)
+		sess._ws._frames.append(_raise_closed)
+		with self.assertRaises(AgentUnreachableError) as cm:
+			sess.compact_session(key, None, timeout_s=5)
+		self.assertEqual(cm.exception.code, "compact-timeout")

--- a/jarvis/tests/test_chat_compaction.py
+++ b/jarvis/tests/test_chat_compaction.py
@@ -1,0 +1,486 @@
+"""Context meter + Compact (spec 2026-09-05-chat-context-meter-compact-design)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import api as chat_api
+from jarvis.chat import compaction
+from jarvis.chat.events import parse_event
+
+CHAT_SESSION = "Jarvis Chat Session"
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TURN_USAGE = "Jarvis Turn Usage"
+
+
+def _mk_conversation(session_key: str | None) -> str:
+	doc = frappe.get_doc({"doctype": CONV, "title": "compact test", "session_key": session_key or ""})
+	doc.insert(ignore_permissions=True)
+	if session_key and not frappe.db.exists(CHAT_SESSION, {"session_key": session_key}):
+		frappe.get_doc({"doctype": CHAT_SESSION, "session_key": session_key, "user": "Administrator"}).insert(
+			ignore_permissions=True
+		)
+	return doc.name
+
+
+def _cleanup() -> None:
+	"""These fixtures are inserted as Administrator (see ``_mk_conversation``) and
+	the compaction job commits, so a test-transaction rollback cannot undo them -
+	delete by name/session_key explicitly so a fresh CI DB stays clean."""
+	convs = frappe.get_all(CONV, filters={"title": "compact test"}, pluck="name")
+	if convs:
+		# retry_message fixtures insert real Message rows under these conversations
+		# (force=True on the conversation delete below only ignores the link, it
+		# does not cascade), so drop them first to avoid leaving orphan rows.
+		frappe.db.delete(MSG, {"conversation": ["in", convs]})
+	for name in convs:
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	for name in frappe.get_all(
+		CHAT_SESSION, filters={"session_key": ["like", "agent:main:c-%"]}, pluck="name"
+	):
+		frappe.delete_doc(CHAT_SESSION, name, ignore_permissions=True, force=True)
+	for name in frappe.get_all(TURN_USAGE, filters={"session_key": ["like", "agent:main:c-%"]}, pluck="name"):
+		frappe.delete_doc(TURN_USAGE, name, ignore_permissions=True, force=True)
+
+
+class TestCompactionFields(FrappeTestCase):
+	def test_session_has_budget_fields(self):
+		meta = frappe.get_meta(CHAT_SESSION)
+		for f, t in (
+			("budget_route", "Data"),
+			("reserve_tokens", "Int"),
+			("compaction_count", "Int"),
+			("last_compacted_at", "Datetime"),
+		):
+			self.assertEqual(meta.get_field(f).fieldtype, t, f)
+
+	def test_conversation_has_compacting_since(self):
+		self.assertEqual(frappe.get_meta(CONV).get_field("compacting_since").fieldtype, "Datetime")
+
+
+class TestCompactionHelpers(FrappeTestCase):
+	def tearDown(self):
+		_cleanup()
+		frappe.db.commit()
+
+	def test_sanitize_hint(self):
+		self.assertEqual(
+			compaction.sanitize_hint("  keep the invoice\x00 inputs  "), "keep the invoice inputs"
+		)
+		self.assertEqual(len(compaction.sanitize_hint("x" * 900)), compaction.HINT_MAX_CHARS)
+		self.assertEqual(compaction.sanitize_hint(None), "")
+		with self.assertRaises(frappe.ValidationError):
+			compaction.sanitize_hint("/reset")
+
+	def test_classify_notice(self):
+		self.assertEqual(
+			compaction.classify_notice("⚙️ Compacted (58k before) • Context 58k/200k"), "compacted"
+		)
+		self.assertEqual(compaction.classify_notice("⚙️ Compaction skipped: nothing compactable"), "skipped")
+		self.assertEqual(compaction.classify_notice("⚙️ Compaction failed: rate limited"), "failed")
+		self.assertEqual(compaction.classify_notice(""), "failed")
+
+	def test_is_compacting_window(self):
+		conv = _mk_conversation("agent:main:c-lock")
+		self.assertFalse(compaction.is_compacting(conv))
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		self.assertTrue(compaction.is_compacting(conv))
+		self.assertTrue(compaction.context_payload(conv)["compacting"])
+		frappe.db.set_value(
+			CONV,
+			conv,
+			"compacting_since",
+			frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), seconds=-(compaction.COMPACT_LOCK_SECONDS + 5)
+			),
+			update_modified=False,
+		)
+		self.assertFalse(compaction.is_compacting(conv))
+		self.assertFalse(compaction.context_payload(conv)["compacting"])
+
+	def test_context_payload_fresh_and_unmeasured(self):
+		conv = _mk_conversation("agent:main:c-pay")
+		p = compaction.context_payload(conv)
+		self.assertFalse(p["fresh"])
+		self.assertEqual(p["warn_pct"], 80)
+		frappe.db.sql(
+			"""UPDATE `tabJarvis Chat Session` SET last_total_tokens=50000, context_capacity=200000,
+			context_pct=25, last_usage_at=NOW(), reserve_tokens=20000, budget_route='fits', compaction_count=1
+			WHERE session_key=%s""",
+			("agent:main:c-pay",),
+		)
+		frappe.get_doc(
+			{
+				"doctype": TURN_USAGE,
+				"session_key": "agent:main:c-pay",
+				"user": "Administrator",
+				"profile_agent_id": "",
+				"profile_tier": "full",
+				"model": "gpt-5.5",
+				"tokens_in": 1200,
+				"tokens_out": 300,
+				"cache_read": 0,
+				"cache_write": 0,
+				"cache_reported": 0,
+				"tool_calls": 0,
+				"day": frappe.utils.today(),
+				"run_id": "",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		p = compaction.context_payload(conv)
+		self.assertTrue(p["fresh"])
+		self.assertEqual((p["used"], p["capacity"], p["pct"]), (50000, 200000, 25.0))
+		self.assertEqual(p["auto_compact_pct"], 90.0)
+		self.assertEqual(p["route"], "fits")
+		self.assertEqual(p["compaction_count"], 1)
+		self.assertEqual((p["last_in"], p["last_out"], p["model"]), (1200, 300, "gpt-5.5"))
+
+	def test_context_payload_no_session(self):
+		conv = _mk_conversation(None)
+		p = compaction.context_payload(conv)
+		self.assertEqual((p["used"], p["capacity"], p["fresh"]), (0, 0, False))
+		self.assertEqual((p["last_in"], p["last_out"], p["model"]), (0, 0, ""))
+
+
+class TestCompactionLock(FrappeTestCase):
+	"""R1: start_compaction's lock is a compare-and-set, not a plain read-then-write,
+	so two near-simultaneous callers can't both win it."""
+
+	def tearDown(self):
+		_cleanup()
+		frappe.db.commit()
+
+	def test_fresh_lock_refuses_and_does_not_enqueue(self):
+		conv = _mk_conversation("agent:main:c-lock1")
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			out = compaction.start_compaction(conv, "Administrator", "")
+		self.assertEqual(out, {"ok": False, "reason": "already_compacting"})
+		enq.assert_not_called()
+
+	def test_expired_lock_is_taken_and_enqueues(self):
+		conv = _mk_conversation("agent:main:c-lock2")
+		frappe.db.set_value(
+			CONV,
+			conv,
+			"compacting_since",
+			frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), seconds=-(compaction.COMPACT_LOCK_SECONDS + 5)
+			),
+			update_modified=False,
+		)
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			out = compaction.start_compaction(conv, "Administrator", "")
+		self.assertEqual(out, {"ok": True, "queued": True})
+		enq.assert_called_once()
+		self.assertTrue(compaction.is_compacting(conv))
+
+	def test_back_to_back_calls_only_the_first_wins(self):
+		conv = _mk_conversation("agent:main:c-lock3")
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			first = compaction.start_compaction(conv, "Administrator", "")
+			second = compaction.start_compaction(conv, "Administrator", "")
+		self.assertEqual(first, {"ok": True, "queued": True})
+		self.assertEqual(second, {"ok": False, "reason": "already_compacting"})
+		enq.assert_called_once()
+
+
+class TestRunCompact(FrappeTestCase):
+	def tearDown(self):
+		_cleanup()
+		frappe.db.commit()
+
+	def _run(self, conv, sess):
+		with (
+			patch("jarvis.chat.agent_session_pool.checkout") as co,
+			patch("jarvis.chat.compaction.publish_to_user") as pub,
+		):
+			co.return_value.__enter__.return_value = sess
+			compaction.run_compact(conv, "Administrator", "keep invoices")
+		return pub
+
+	def test_happy_path_writes_result_and_publishes(self):
+		key = "agent:main:c-run1"
+		conv = _mk_conversation(key)
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		sess = MagicMock()
+		sess.list_sessions.return_value = [
+			{
+				"key": key,
+				"totalTokens": 58000,
+				"totalTokensFresh": True,
+				"contextTokens": 200000,
+				"compactionCheckpointCount": 1,
+				"contextBudgetStatus": {"route": "fits", "reserveTokens": 20000},
+			}
+		]
+		sess.compact_session.return_value = {
+			"state": "final",
+			"text": "⚙️ Compacted (58k before)",
+			"run_id": "r",
+		}
+		pub = self._run(conv, sess)
+		sess.compact_session.assert_called_once_with(
+			key, "keep invoices", timeout_s=compaction.COMPACT_RPC_TIMEOUT_S
+		)
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("context:compacted", kinds)
+		got = frappe.db.get_value(
+			CHAT_SESSION, {"session_key": key}, ["compaction_count", "last_compacted_at"], as_dict=True
+		)
+		self.assertEqual(got.compaction_count, 1)
+		self.assertIsNotNone(got.last_compacted_at)
+		self.assertIsNone(frappe.db.get_value(CONV, conv, "compacting_since"))
+
+	def test_declined_publishes_failure_and_clears_lock(self):
+		key = "agent:main:c-run2"
+		conv = _mk_conversation(key)
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		sess = MagicMock()
+		sess.list_sessions.return_value = [{"key": key, "totalTokens": 1000, "totalTokensFresh": True}]
+		sess.compact_session.return_value = {
+			"state": "final",
+			"text": "⚙️ Compaction skipped: nothing",
+			"run_id": "r",
+		}
+		pub = self._run(conv, sess)
+		payload = [c.args[1] for c in pub.call_args_list if c.args[1]["kind"] == "context:compact_failed"][0]
+		self.assertEqual(payload["reason"], "runtime_declined")
+		self.assertIsNone(frappe.db.get_value(CONV, conv, "compacting_since"))
+
+	def test_failed_notice_publishes_runtime_failed(self):
+		key = "agent:main:c-run2b"
+		conv = _mk_conversation(key)
+		sess = MagicMock()
+		sess.list_sessions.return_value = [{"key": key, "totalTokens": 1000, "totalTokensFresh": True}]
+		sess.compact_session.return_value = {
+			"state": "final",
+			"text": "⚙️ Compaction failed: rate limited",
+			"run_id": "r",
+		}
+		pub = self._run(conv, sess)
+		payload = [c.args[1] for c in pub.call_args_list if c.args[1]["kind"] == "context:compact_failed"][0]
+		self.assertEqual(payload["reason"], "runtime_failed")
+
+	def test_timeout_reason(self):
+		from jarvis.chat.agent_client import AgentUnreachableError
+
+		key = "agent:main:c-run3"
+		conv = _mk_conversation(key)
+		sess = MagicMock()
+		sess.list_sessions.return_value = []
+		sess.compact_session.side_effect = AgentUnreachableError("t", code="compact-timeout")
+		pub = self._run(conv, sess)
+		payload = [c.args[1] for c in pub.call_args_list if c.args[1]["kind"] == "context:compact_failed"][0]
+		self.assertEqual(payload["reason"], "timeout")
+
+	def test_gateway_unreachable_reason(self):
+		from jarvis.chat.agent_client import AgentUnreachableError
+
+		key = "agent:main:c-run4"
+		conv = _mk_conversation(key)
+		with (
+			patch("jarvis.chat.agent_session_pool.checkout", side_effect=AgentUnreachableError("down")),
+			patch("jarvis.chat.compaction.publish_to_user") as pub,
+		):
+			compaction.run_compact(conv, "Administrator", "")
+		payload = [c.args[1] for c in pub.call_args_list if c.args[1]["kind"] == "context:compact_failed"][0]
+		self.assertEqual(payload["reason"], "gateway_unreachable")
+
+
+class TestCompactEndpoints(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		_cleanup()
+		frappe.db.commit()
+
+	def test_get_conversation_context_shape(self):
+		conv = _mk_conversation("agent:main:c-ep1")
+		out = chat_api.get_conversation_context(conv)
+		for k in (
+			"used",
+			"capacity",
+			"pct",
+			"warn_pct",
+			"auto_compact_pct",
+			"route",
+			"compaction_count",
+			"last_compacted_at",
+			"compacting",
+			"fresh",
+		):
+			self.assertIn(k, out)
+
+	def test_compact_refuses_without_session(self):
+		conv = _mk_conversation(None)
+		self.assertEqual(chat_api.compact_conversation(conv), {"ok": False, "reason": "nothing_to_compact"})
+
+	def test_compact_refuses_when_nothing_new_since_last_compaction(self):
+		key = "agent:main:c-ep11"
+		conv = _mk_conversation(key)
+		now = frappe.utils.now_datetime()
+		frappe.db.set_value(
+			CHAT_SESSION,
+			{"session_key": key},
+			{
+				"last_compacted_at": now,
+				"last_usage_at": frappe.utils.add_to_date(now, seconds=-60),
+			},
+		)
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			out = chat_api.compact_conversation(conv, "keep invoices")
+		self.assertEqual(out, {"ok": False, "reason": "nothing_to_compact"})
+		enq.assert_not_called()
+
+	def test_compact_proceeds_after_a_turn_since_last_compaction(self):
+		key = "agent:main:c-ep12"
+		conv = _mk_conversation(key)
+		now = frappe.utils.now_datetime()
+		frappe.db.set_value(
+			CHAT_SESSION,
+			{"session_key": key},
+			{
+				"last_compacted_at": now,
+				"last_usage_at": frappe.utils.add_to_date(now, seconds=1),
+			},
+		)
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			out = chat_api.compact_conversation(conv, "keep invoices")
+		self.assertEqual(out, {"ok": True, "queued": True})
+		enq.assert_called_once()
+
+	def test_compact_refuses_when_already_compacting(self):
+		conv = _mk_conversation("agent:main:c-ep2")
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		self.assertEqual(chat_api.compact_conversation(conv), {"ok": False, "reason": "already_compacting"})
+
+	def test_compact_refuses_when_busy(self):
+		conv = _mk_conversation("agent:main:c-ep3")
+		with patch("jarvis.chat.api._conversation_busy", return_value=True):
+			self.assertEqual(
+				chat_api.compact_conversation(conv), {"ok": False, "reason": "conversation_busy"}
+			)
+
+	def test_compact_bad_hint(self):
+		conv = _mk_conversation("agent:main:c-ep4")
+		self.assertEqual(chat_api.compact_conversation(conv, "/new"), {"ok": False, "reason": "bad_hint"})
+
+	def test_compact_enqueues(self):
+		conv = _mk_conversation("agent:main:c-ep5")
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			out = chat_api.compact_conversation(conv, "keep the invoice inputs")
+		self.assertEqual(out, {"ok": True, "queued": True})
+		self.assertEqual(enq.call_args.kwargs["hint"], "keep the invoice inputs")
+		self.assertEqual(enq.call_args.kwargs["method"], "jarvis.chat.compaction.run_compact")
+		self.assertTrue(compaction.is_compacting(conv))
+
+	def test_compact_queue_name_from_site_config(self):
+		conv = _mk_conversation("agent:main:c-ep-queue")
+		with patch("jarvis.chat.compaction.frappe.enqueue") as enq:
+			chat_api.compact_conversation(conv, "keep totals")
+		self.assertEqual(enq.call_args.kwargs["queue"], "long")
+		conv2 = _mk_conversation("agent:main:c-ep-queue2")
+		with (
+			patch("jarvis.chat.compaction.frappe.enqueue") as enq,
+			patch.dict(frappe.conf, {"jarvis_compact_queue": "compact"}),
+		):
+			chat_api.compact_conversation(conv2, "keep totals")
+		self.assertEqual(enq.call_args.kwargs["queue"], "compact")
+
+	def test_conversation_busy_while_compacting(self):
+		conv = _mk_conversation("agent:main:c-ep6")
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		self.assertTrue(chat_api._conversation_busy(conv))
+
+	def test_get_usage_carries_context(self):
+		conv = _mk_conversation("agent:main:c-ep7")
+		out = chat_api.get_usage(conv)
+		self.assertIn("context", out)
+		self.assertIn("capacity", out["context"])
+
+	def test_send_message_refuses_while_compacting_machine_enabled(self):
+		conv = _mk_conversation("agent:main:c-ep8")
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		with (
+			patch.object(chat_api.admission, "turn_machine_enabled", return_value=True),
+			patch("jarvis.chat.api.validate_can_send", return_value=(True, None)),
+		):
+			out = chat_api.send_message(conv, "hello")
+		self.assertEqual(out, {"ok": False, "reason": "Compacting this chat, try again in a moment"})
+		self.assertFalse(frappe.db.exists(MSG, {"conversation": conv}))
+
+	def test_send_message_refuses_while_compacting_legacy(self):
+		conv = _mk_conversation("agent:main:c-ep9")
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		with (
+			patch.object(chat_api.admission, "turn_machine_enabled", return_value=False),
+			patch("jarvis.chat.api.validate_can_send", return_value=(True, None)),
+		):
+			out = chat_api.send_message(conv, "hello")
+		self.assertEqual(out, {"ok": False, "reason": "Compacting this chat, try again in a moment"})
+		self.assertFalse(frappe.db.exists(MSG, {"conversation": conv}))
+
+	def test_retry_message_refuses_while_compacting(self):
+		conv = _mk_conversation("agent:main:c-ep10")
+		frappe.db.set_value(
+			CONV, conv, "compacting_since", frappe.utils.now_datetime(), update_modified=False
+		)
+		user_doc = frappe.get_doc(
+			{"doctype": MSG, "conversation": conv, "seq": 1, "role": "user", "content": "hi"}
+		)
+		user_doc.insert(ignore_permissions=True)
+		asst_doc = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conv,
+				"seq": 2,
+				"role": "assistant",
+				"content": "",
+				"error": "rate limit",
+			}
+		)
+		asst_doc.insert(ignore_permissions=True)
+		with (
+			patch.object(chat_api.admission, "turn_machine_enabled", return_value=True),
+			patch("jarvis.chat.api.validate_can_send", return_value=(True, None)),
+		):
+			out = chat_api.retry_message(asst_doc.name)
+		self.assertEqual(out, {"ok": False, "reason": "Compacting this chat, try again in a moment"})
+
+
+class TestCompactionEvent(FrappeTestCase):
+	def test_parse_event_maps_compaction(self):
+		self.assertEqual(
+			parse_event({"stream": "compaction", "data": {"phase": "start"}}),
+			{"kind": "compaction", "phase": "start", "completed": False},
+		)
+		self.assertEqual(
+			parse_event({"stream": "compaction", "data": {"phase": "end", "completed": True}}),
+			{"kind": "compaction", "phase": "end", "completed": True},
+		)
+		self.assertEqual(parse_event({"stream": "compaction", "data": {"phase": "before"}})["phase"], "start")
+		self.assertEqual(parse_event({"stream": "compaction", "data": {"phase": "after"}})["phase"], "end")

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -1880,6 +1880,35 @@ class TestPublishFencing(_PumpTestCase):
 		self.assertIn("run:end", by_kind)
 		self.assertEqual(by_kind["run:end"]["pump_epoch"], ctx.epoch)
 
+	def test_on_status_publishes_run_status(self):
+		"""Task 6 fix: the lane handler's ``on_status`` (wired from
+		``relay_mux``'s new ``status`` lane-event kind) publishes a fenced
+		``run:status`` carrying the run's conversation/run_id/message_id, exactly
+		like ``on_tool``'s ``tool:start``/``tool:end`` publishes above."""
+		conv = self._mk_conv()
+		deps = self._deps()
+		ctx = self._make_ctx(deps, with_mux=False)
+		rs = pump._RunState(
+			run_id="pmp_status1",
+			conversation=conv,
+			owner="u@x",
+			assistant_message="msg1",
+			session_key="sess-pmp_status1",
+			version=1,
+		)
+		handler = pump._make_handler(ctx, rs)
+		captured = []
+		with patch.object(ts, "publish_to_user", side_effect=lambda u, p: captured.append(p)):
+			handler.on_status(3, "compacting")
+		self.assertEqual(len(captured), 1)
+		payload = captured[0]
+		self.assertEqual(payload["kind"], "run:status")
+		self.assertEqual(payload["status"], "compacting")
+		self.assertEqual(payload["conversation_id"], conv)
+		self.assertEqual(payload["run_id"], "pmp_status1")
+		self.assertEqual(payload["message_id"], "msg1")
+		self.assertEqual(payload["pump_epoch"], ctx.epoch)
+
 
 # --------------------------------------------------------------------------- #
 # CDX-4 — watchdog EFFECT scan (recover a lost enqueue_finalize)

--- a/jarvis/tests/test_relay_mux.py
+++ b/jarvis/tests/test_relay_mux.py
@@ -56,14 +56,22 @@ class _Recorder:
 	is injected by making a specific callback raise — integrity-class behaviour
 	is driven by the mux, not by the raise itself (OAR-7)."""
 
-	def __init__(self, *, poison_delta_seq: int | None = None, poison_terminal: bool = False):
+	def __init__(
+		self,
+		*,
+		poison_delta_seq: int | None = None,
+		poison_terminal: bool = False,
+		poison_status_seq: int | None = None,
+	):
 		self.deltas: list[tuple[int, str, str]] = []
 		self.tools: list[dict] = []
+		self.statuses: list[tuple[int, str]] = []
 		self.terminal: tuple[str, dict] | None = None
 		self.quarantined: str | None = None
 		self.closing: str | None = None
 		self.poison_delta_seq = poison_delta_seq
 		self.poison_terminal = poison_terminal
+		self.poison_status_seq = poison_status_seq
 		self.done = threading.Event()  # set on terminal | quarantine | closing
 
 	def handler(self) -> LaneHandler:
@@ -73,6 +81,7 @@ class _Recorder:
 			on_terminal=self._on_terminal,
 			on_quarantine=self._on_quarantine,
 			on_closing=self._on_closing,
+			on_status=self._on_status,
 		)
 
 	def _on_delta(self, seq, text, delta):
@@ -82,6 +91,11 @@ class _Recorder:
 
 	def _on_tool(self, ev):
 		self.tools.append(ev)
+
+	def _on_status(self, seq, status):
+		if self.poison_status_seq is not None and seq == self.poison_status_seq:
+			raise RuntimeError(f"poison status seq={seq}")
+		self.statuses.append((seq, status))
 
 	def _on_terminal(self, kind, payload):
 		if self.poison_terminal:
@@ -478,6 +492,33 @@ class TestRelayMuxWhiteBox(FrappeTestCase):
 			mux._classify(_agent_frame("r", "s", "assistant", {"text": f"t{i}", "delta": f"d{i}"}))
 		self.assertEqual(lane.state, "active")  # never quarantines on lossy
 		self.assertGreaterEqual(mux.stats()["deltas_dropped"], 5)
+
+	def test_compaction_frame_routes_to_status_event(self):
+		"""Task 6 fix: a ``compaction`` agent frame is routed (via ``parse_event``)
+		to a LOSSY ``status`` lane event, and ``_apply`` calls
+		``on_status(event_seq, status)`` with the mapped compacting/compacted
+		status — the counterpart of the assistant/tool branches above."""
+		mux = self._mux()
+		rec = _Recorder()
+		mux.register_run("r", rec.handler(), session_key="s")
+		mux._classify(_agent_frame("r", "s", "compaction", {"phase": "start"}))
+		mux._classify(_agent_frame("r", "s", "compaction", {"phase": "end", "completed": True}))
+		mux.dispatch()
+		self.assertEqual(rec.statuses, [(1, "compacting"), (2, "compacted")])
+
+	def test_poison_status_drops_and_continues_lossy(self):
+		"""A raising ``on_status`` behaves exactly like a poison delta (OAR-7):
+		drop+count the ONE frame and continue the same lane — never quarantine,
+		proving the new ``status`` lane event is classified LOSSY."""
+		mux = self._mux()
+		rec = _Recorder(poison_status_seq=1)
+		lane = mux.register_run("r", rec.handler(), session_key="s")
+		mux._classify(_agent_frame("r", "s", "compaction", {"phase": "start"}))
+		mux._classify(_agent_frame("r", "s", "compaction", {"phase": "end", "completed": True}))
+		mux.dispatch()
+		self.assertEqual(lane.state, "active", "a poison status never quarantines the lane")
+		self.assertEqual(rec.statuses, [(2, "compacted")], "only the poisoned frame was dropped")
+		self.assertGreaterEqual(mux.stats()["deltas_dropped"], 1)
 
 	def test_lane_fairness_hot_lane_does_not_starve_cold(self):
 		# CDX-13: a backed-up hot lane must not monopolise one dispatch — the per-lane

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -468,3 +468,33 @@ class TestPrepareErrorCodeOverride(FrappeTestCase):
 	def test_no_explicit_code_falls_back_to_classify_error(self):
 		published = self._run(error="insufficient credit")
 		self.assertEqual(published.get("code"), "provider")
+
+
+class TestCompactionEventPublishesRunStatus(FrappeTestCase):
+	"""The runtime brackets an automatic compaction with a ``compaction``
+	stream event; the turn handler must surface it to the chat as a
+	``run:status`` so the UI can show a transient "reorganising" state
+	without treating the run as errored or finished."""
+
+	def test_compaction_event_publishes_run_status(self):
+		with patch.object(turn_handler, "_publish_to_user") as pub:
+			turn_handler._handle_event_inner(
+				{"kind": "compaction", "phase": "start", "completed": False},
+				conversation_id="c1",
+				assistant_msg_name="m1",
+				tool_msg_by_call_id={},
+				user="Administrator",
+				run_id="r1",
+				batcher=MagicMock(),
+			)
+			turn_handler._handle_event_inner(
+				{"kind": "compaction", "phase": "end", "completed": True},
+				conversation_id="c1",
+				assistant_msg_name="m1",
+				tool_msg_by_call_id={},
+				user="Administrator",
+				run_id="r1",
+				batcher=MagicMock(),
+			)
+		statuses = [c.args[1]["status"] for c in pub.call_args_list if c.args[1]["kind"] == "run:status"]
+		self.assertEqual(statuses, ["compacting", "compacted"])

--- a/jarvis/tests/test_turn_usage.py
+++ b/jarvis/tests/test_turn_usage.py
@@ -402,6 +402,65 @@ class TestTurnUsage(FrappeTestCase):
 		tool_calls = frappe.db.get_value(TURN_USAGE, {"session_key": "agent:tu-norun"}, "tool_calls")
 		self.assertEqual(tool_calls, 0)
 
+	# -- budget/compaction snapshot fields (context-meter task 2) ------------ #
+	def test_budget_fields_from_row(self):
+		row = {
+			"contextBudgetStatus": {"route": "compact_only", "reserveTokens": 20000},
+			"compactionCheckpointCount": 2,
+		}
+		self.assertEqual(usage.budget_fields_from_row(row), ("compact_only", 20000, 2))
+		self.assertEqual(usage.budget_fields_from_row({}), ("", 0, 0))
+		self.assertEqual(usage.budget_fields_from_row({"contextBudgetStatus": "junk"}), ("", 0, 0))
+
+	def test_write_budget_fields_keeps_route_when_status_absent(self):
+		# jarvis#chat-context-meter amendment: the runtime clears
+		# contextBudgetStatus on compaction, so a write with no status must not
+		# blank a previously-known route/reserve - only compaction_count may
+		# move (and only forward).
+		key = "agent:tu-budget-keep"
+		_make_session(key, USER_A)
+		usage._write_budget_fields(key, {"contextBudgetStatus": {"route": "fits", "reserveTokens": 16384}})
+		frappe.db.commit()
+		usage._write_budget_fields(key, {"compactionCheckpointCount": 2})
+		frappe.db.commit()
+		got = frappe.db.get_value(
+			SESSION,
+			{"session_key": key},
+			["budget_route", "reserve_tokens", "compaction_count"],
+			as_dict=True,
+		)
+		self.assertEqual((got.budget_route, got.reserve_tokens, got.compaction_count), ("fits", 16384, 2))
+
+	def test_record_turn_usage_writes_budget_fields(self):
+		# USER_A (not Administrator) so the RECORDED path's commit - the
+		# Chat Session row, its Turn Usage row, and the Jarvis User Settings
+		# row get_or_create_user_settings creates - is fully hermetic: the
+		# shared _cleanup() helper (setUp/tearDown) already removes all three
+		# for USER_A, including the settings row a raw Administrator fixture
+		# would otherwise leave behind permanently on a fresh (CI) DB.
+		key = "agent:tu-budget"
+		_make_session(key, USER_A)
+		row = {
+			"key": key,
+			"inputTokens": 100,
+			"outputTokens": 10,
+			"totalTokens": 5000,
+			"totalTokensFresh": True,
+			"contextTokens": 200000,
+			"contextBudgetStatus": {"route": "fits", "reserveTokens": 16384},
+			"compactionCheckpointCount": 1,
+			"model": "m",
+			"modelProvider": "p",
+		}
+		usage.record_turn_usage(key, row)
+		got = frappe.db.get_value(
+			SESSION,
+			{"session_key": key},
+			["budget_route", "reserve_tokens", "compaction_count"],
+			as_dict=True,
+		)
+		self.assertEqual((got.budget_route, got.reserve_tokens, got.compaction_count), ("fits", 16384, 1))
+
 
 def _seed_turn_row(
 	session_key: str,


### PR DESCRIPTION
Backport of #1136 to `version-15-hotfix`: context ring with a details popover, Compact with an optional hint, sends refused while compacting, Settings "This chat" context reading.

## What changed
- Same change as #1136, cherry-picked from its merge commit (`git cherry-pick -m 1 -x 7a7c2fd`).
- One conflict resolved in `frontend/src/views/ChatView.vue`: the develop-only post-reply feedback call is not on this line, so only the meter lines were kept in the run-end handler.

## Risk and verification
- Mergify could not open this automatically: the source PR contained a merge commit (its "merge develop into branch" update), which Mergify refuses to cherry-pick. Manual backport per the repo recipe.
- Hosted CI on this PR is the gate.

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01B3y7PDPWZZtNVRRQbjTCmD
