### PR TITLE
test(learning): anchor the detector fixture calendar to today

### DIFF
--- a/jarvis/tests/learning/factory.py
+++ b/jarvis/tests/learning/factory.py
@@ -137,7 +137,7 @@ def _insert(doctype, name, fields, docstatus=1, creation=None, children=None):
 	doc.docstatus = docstatus
 	doc.db_insert()
 	ts = creation or (
-		str(fields.get("posting_date") or fields.get("transaction_date") or "2025-09-01") + " 10:00:00"
+		str(fields.get("posting_date") or fields.get("transaction_date") or _day(0)) + " 10:00:00"
 	)
 	frappe.db.set_value(doctype, name, {"creation": ts, "modified": ts}, update_modified=False)
 	for childfield, (child_dt, rows) in (children or {}).items():
@@ -157,11 +157,26 @@ def _insert(doctype, name, fields, docstatus=1, creation=None, children=None):
 	return name
 
 
+# Fixture calendar anchor, fixed once per build() so a midnight crossing mid-build
+# cannot split one dataset across two anchors. Every fixture date is
+# _day(ordinal) = anchor + ordinal days, with ordinals below ~110, so the whole
+# dataset always sits 230..335 days back: inside the tightest detector window
+# (12 months, with a month of headroom), never in the future, and older than the
+# engine's 180-day dormant-company cutoff exactly as the original literal dates
+# were. A literal anchor ("2025-09-01") aged out of the 12-month windows on
+# 2026-09-06 and mfg-default-bom-usage dropped below n_min.
+_ANCHOR_MONTHS_BACK = 11
+_anchor: str | None = None
+
+
 def _day(base_ordinal: int) -> str:
-	"""A distinct calendar day per index, inside the 18-month window (today is
-	well after 2025-09). Distinct days => spread gate passes and consecutive
-	rows never collapse as a creation burst."""
-	return frappe.utils.add_days("2025-09-01", base_ordinal)
+	"""A distinct calendar day per index, relative to the build anchor. Distinct
+	days => spread gate passes and consecutive rows never collapse as a creation
+	burst."""
+	global _anchor
+	if _anchor is None:
+		_anchor = frappe.utils.add_months(frappe.utils.today(), -_ANCHOR_MONTHS_BACK)
+	return frappe.utils.add_days(_anchor, base_ordinal)
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +186,8 @@ def build(commit: bool = False) -> None:
 	"""Idempotent: wipe any prior fixtures, then seed the mini-org. Detectors
 	can then run in the same transaction (tests, no commit) or the caller can
 	commit for the E2E harness."""
+	global _anchor
+	_anchor = None  # re-anchor to today for this build
 	wipe(commit=False)
 	_masters()
 	_selling_alpha()
@@ -638,7 +655,8 @@ def _beta_traps() -> None:
 			},
 		)
 	# go-live burst: 35 PIs, all one day and one creation second -> spread gate.
-	burst_ts = "2025-10-01 03:00:00"
+	burst_day = _day(30)
+	burst_ts = f"{burst_day} 03:00:00"
 	for i in range(35):
 		name = f"{PREFIX}PI-B-{i:04d}"
 		_insert(
@@ -647,7 +665,7 @@ def _beta_traps() -> None:
 			{
 				"supplier": f"{PREFIX}BetaSup",
 				"company": BETA,
-				"posting_date": "2025-10-01",
+				"posting_date": burst_day,
 				"update_stock": 1,
 			},
 			creation=burst_ts,


### PR DESCRIPTION
## Summary

Shard 4 fails on develop and both hotfix lines from 2026-09-06 because the learning-detector fixture dated every row from a literal 2025-09-01, and that morning the oldest Work Orders aged out of the 12-month window that `mfg-default-bom-usage` scans. Nobody notices in the product; this only unblocks CI. The same commit is cherry-picked onto the open #1142 backports (#1146, #1147), so the hotfix lines receive it there and this PR carries no backport labels.

**What changed**
- `factory._day(ordinal)` is now anchor plus ordinal days, with the anchor fixed once per `build()` at today minus 11 months.
- The Beta go-live burst and the `_insert` creation fallback ride the same anchor.
- The print-log tests keep their literal days on purpose: they assert exact periods and the watermark and are bucketed by print-log creation, not by these fixture dates. They expire around 2027-03 with the 18-month window and are a separate, pre-existing item.

**Risk and verification**
- One test-fixture file. The dataset always sits 230 to 335 days back: inside the tightest window with a month of headroom, never in the future, and still older than the engine's 180-day dormant cutoff, which is the age class the literal dates had (test_orchestrator patches around it). Hosted CI is the gate.

<details>
<summary>Root cause</summary>

`window_start = add_months(today, -12)`. The Widget Work Orders sit on `_day(0..23)` = 2025-09-01..24 and the gate is `n_min = 20`. On 2026-09-05 the window started at 2025-09-05, leaving indices 4..23 = 20 units, exactly at the gate. On 2026-09-06 it moved to 2025-09-06, leaving 19 units, so `reduce_units` produced no candidate. The failing run logged `rows_scanned=40, raw_candidate_count=0`: 19 Widget plus 21 Elec rows.

Four more detectors use a 12-month window (`cfg-naming-series`, `cfg-default-vs-usage`, `cfg-custom-field-always-filled`, `role-doctype-routing`) and one uses 24; they were on the same slope with more headroom, which is why the fix re-anchors the whole fixture instead of bumping one ordinal.
</details>

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01CkvbXsZAizy4UDh9ZWjn51

