### PR TITLE
Feat/release nudge slice3b

### DIFF
--- a/frontend/src/components/Banner.vue
+++ b/frontend/src/components/Banner.vue
@@ -26,7 +26,10 @@
   correct (LlmPoolEditor's .jv-status: a bare icon, no chip).
 -->
 <template>
-	<div class="flex items-start gap-2.5 rounded-md p-2.5" :class="variant.fill">
+	<div
+		class="flex gap-2.5 rounded-md p-2.5"
+		:class="[variant.fill, align === 'center' ? 'items-center' : 'items-start']"
+	>
 		<FeatherIcon
 			:name="variant.icon"
 			class="size-4 shrink-0"
@@ -47,7 +50,11 @@
 				 unaffected. -->
 			<slot />
 		</div>
-		<div v-if="$slots.action" class="mt-0.5 flex shrink-0 items-center gap-2">
+		<div
+			v-if="$slots.action"
+			class="flex shrink-0 items-center gap-2"
+			:class="align === 'center' ? '' : 'mt-0.5'"
+		>
 			<slot name="action" />
 		</div>
 	</div>
@@ -61,6 +68,11 @@ const props = defineProps({
 	type: { type: String, default: "error" }, // error | warning | info | success
 	title: { type: String, default: "" },
 	message: { type: String, default: "" },
+	// Vertical alignment of the icon/body/action row. Default "start" keeps the
+	// icon on line 1 for multi-line title+message banners (jarvis#725). A
+	// SINGLE-LINE, message-only banner with tall action buttons (e.g. the update
+	// banner) can opt into "center" so the message sits level with its buttons.
+	align: { type: String, default: "start" }, // start | center
 });
 
 // Typed fill + ink, straight off design.md §3.7's banner recipe and the same

--- a/frontend/src/components/chat/UpdateBanner.vue
+++ b/frontend/src/components/chat/UpdateBanner.vue
@@ -37,6 +37,7 @@ import { ref } from "vue";
 import Banner from "@/components/Banner.vue";
 import { FeatherIcon } from "frappe-ui";
 import { agentName } from "@/branding";
+import { bannerToneFor } from "@/releaseNudge";
 import { notice, snoozeBanner, openWhatsNew } from "@/noticeGate";
 
 const props = defineProps({
@@ -47,11 +48,14 @@ const props = defineProps({
 
 const message = `A new version of ${agentName} is available — ask your administrator to update.`;
 
-// Severity drives the Banner's colour, mirroring the pill: soft -> amber
-// (warning), severe -> red (error). `notice` is the stable, non-reactive boot
-// payload (see noticeGate.js), so these are plain consts, not computed().
-const bannerType = notice.tier === "severe" ? "error" : "warning";
-const toneClass = bannerType === "error" ? "jv-tone-red" : "jv-tone-amber";
+// Severity drives the Banner's colour, mirroring the pill - single-sourced via
+// bannerToneFor (releaseNudge.js) so the pill and banner can never disagree, and
+// an unknown future tier lands amber, not a wrong colour. Tone "red" -> Banner
+// type="error", else "warning". `notice` is the stable, non-reactive boot payload
+// (see noticeGate.js), so these are plain consts, not computed().
+const bannerTone = bannerToneFor(notice);
+const bannerType = bannerTone === "red" ? "error" : "warning";
+const toneClass = bannerTone === "red" ? "jv-tone-red" : "jv-tone-amber";
 
 const bannerEl = ref(null);
 const flipStyle = ref({});

--- a/frontend/src/components/chat/UpdateBanner.vue
+++ b/frontend/src/components/chat/UpdateBanner.vue
@@ -3,7 +3,7 @@
 	     the billing/readiness alerts use). The wrapper is the FLIP target that
 	     minimises into the version pill on dismiss. -->
 	<div ref="bannerEl" class="jv-updatebanner" :style="flipStyle">
-		<Banner type="info" :message="message">
+		<Banner type="info" :message="message" align="center">
 			<template #action>
 				<button class="jv-ub-btn" type="button" @click="onWhatsNew">What's new</button>
 				<button class="jv-ub-btn jv-ub-btn--ghost" type="button" @click="dismiss">

--- a/frontend/src/components/chat/UpdateBanner.vue
+++ b/frontend/src/components/chat/UpdateBanner.vue
@@ -1,9 +1,11 @@
 <template>
-	<!-- Soft update banner: top-of-chat, calm info/blue (NOT the amber warning
-	     the billing/readiness alerts use). The wrapper is the FLIP target that
-	     minimises into the version pill on dismiss. -->
-	<div ref="bannerEl" class="jv-updatebanner" :style="flipStyle">
-		<Banner type="info" :message="message" align="center">
+	<!-- Soft update banner: top-of-chat, coloured by severity - amber (soft) or
+	     red (severe), matching the version pill. The banner only ever renders
+	     for these two tiers (see bannerShouldShow in releaseNudge.js). The
+	     wrapper is the FLIP target that minimises into the version pill on
+	     dismiss. -->
+	<div ref="bannerEl" class="jv-updatebanner" :class="toneClass" :style="flipStyle">
+		<Banner :type="bannerType" :message="message" align="center">
 			<template #action>
 				<button class="jv-ub-btn" type="button" @click="onWhatsNew">What's new</button>
 				<button class="jv-ub-btn jv-ub-btn--ghost" type="button" @click="dismiss">
@@ -35,7 +37,7 @@ import { ref } from "vue";
 import Banner from "@/components/Banner.vue";
 import { FeatherIcon } from "frappe-ui";
 import { agentName } from "@/branding";
-import { snoozeBanner, openWhatsNew } from "@/noticeGate";
+import { notice, snoozeBanner, openWhatsNew } from "@/noticeGate";
 
 const props = defineProps({
 	// The VersionPill's exposed instance ({ getEl, pulse }); may be null if the
@@ -44,6 +46,12 @@ const props = defineProps({
 });
 
 const message = `A new version of ${agentName} is available — ask your administrator to update.`;
+
+// Severity drives the Banner's colour, mirroring the pill: soft -> amber
+// (warning), severe -> red (error). `notice` is the stable, non-reactive boot
+// payload (see noticeGate.js), so these are plain consts, not computed().
+const bannerType = notice.tier === "severe" ? "error" : "warning";
+const toneClass = bannerType === "error" ? "jv-tone-red" : "jv-tone-amber";
 
 const bannerEl = ref(null);
 const flipStyle = ref({});
@@ -120,25 +128,35 @@ function dismiss() {
 	margin: 12px 18px 0;
 }
 
+/* The tone the primary button (and its own focus ring) resolve to - amber for
+   soft, red for severe. Scoped on the same wrapper the tone class lands on. */
+.jv-tone-amber {
+	--jv-ub-tone: var(--amber);
+}
+.jv-tone-red {
+	--jv-ub-tone: var(--red);
+}
+
 /* Compact, quiet action buttons inside the banner's #action slot. Real
    <button>s (keyboard-reachable); styled here since Banner is a child scope.
-   Colours come from the app palette (theme-aware, resolved on .jv-root),
-   --link being the one sanctioned blue. */
+   The primary button's ink/border/focus follow --jv-ub-tone (the banner's
+   severity colour) so it doesn't clash with the now amber/red Banner fill;
+   ghost + × stay neutral (--text-2) below. */
 .jv-ub-btn {
 	height: 26px;
 	padding: 0 10px;
-	border: 1px solid color-mix(in srgb, var(--link) 40%, transparent);
+	border: 1px solid color-mix(in srgb, var(--jv-ub-tone) 40%, transparent);
 	border-radius: 7px;
 	background: transparent;
 	font-family: inherit;
 	font-size: 12px;
 	font-weight: 500;
-	color: var(--link);
+	color: var(--jv-ub-tone);
 	cursor: pointer;
 	white-space: nowrap;
 }
 .jv-ub-btn:hover {
-	background: color-mix(in srgb, var(--link) 12%, transparent);
+	background: color-mix(in srgb, var(--jv-ub-tone) 12%, transparent);
 }
 .jv-ub-btn--ghost {
 	border-color: transparent;
@@ -149,7 +167,7 @@ function dismiss() {
 }
 .jv-ub-btn:focus-visible,
 .jv-ub-x:focus-visible {
-	outline: 2px solid var(--link);
+	outline: 2px solid var(--jv-ub-tone);
 	outline-offset: 2px;
 }
 .jv-ub-x {

--- a/frontend/src/components/chat/UpdateBanner.vue
+++ b/frontend/src/components/chat/UpdateBanner.vue
@@ -23,12 +23,14 @@
 </template>
 
 <script setup>
-// UpdateBanner: the occasional soft nudge that a newer app version exists
-// (Slice 3b). Dismiss ("Remind me later" or ×) plays a short minimise-into-pill
-// FLIP, then snoozes per-device. Honors prefers-reduced-motion (instant hide +
-// snooze, no FLIP/pulse), and degrades to a plain hide when the pill rect can't
-// be measured. Mounting/visibility (yield to greeting/welcome/booting/urgent
-// alerts) is decided by the caller's v-if in ChatView.
+// UpdateBanner: the occasional soft/severe nudge that a newer app version exists
+// (Slice 3b, severity split in 3b.1) - non-blocking; the blocking "hard" tier has
+// no banner, it gets the full-page gate instead. Dismiss ("Remind me later" or ×)
+// plays a short minimise-into-pill FLIP, then snoozes per-device. Honors
+// prefers-reduced-motion (instant hide + snooze, no FLIP/pulse), and degrades to
+// a plain hide when the pill rect can't be measured. Mounting/visibility (yield
+// to greeting/booting/urgent alerts; shows over the welcome screen too) is
+// decided by the caller's v-if in ChatView.
 import { ref } from "vue";
 import Banner from "@/components/Banner.vue";
 import { FeatherIcon } from "frappe-ui";

--- a/frontend/src/components/chat/VersionPill.vue
+++ b/frontend/src/components/chat/VersionPill.vue
@@ -96,18 +96,28 @@ defineExpose({ getEl: () => btnEl.value, pulse });
 	white-space: nowrap;
 }
 
-/* Tone drives the dot AND the label colour, straight off the app palette. */
+/* Tone drives the dot, the label colour, AND a subtle border in the same hue
+   (color-mix'd down so it reads as a tint, not a solid tone-coloured chip). */
+.jv-tone-green {
+	border-color: color-mix(in srgb, var(--green) 40%, transparent);
+}
 .jv-tone-green .jv-pill-dot {
 	background: var(--green);
 }
 .jv-tone-green .jv-pill-label {
 	color: var(--green);
 }
+.jv-tone-amber {
+	border-color: color-mix(in srgb, var(--amber) 40%, transparent);
+}
 .jv-tone-amber .jv-pill-dot {
 	background: var(--amber);
 }
 .jv-tone-amber .jv-pill-label {
 	color: var(--amber);
+}
+.jv-tone-red {
+	border-color: color-mix(in srgb, var(--red) 40%, transparent);
 }
 .jv-tone-red .jv-pill-dot {
 	background: var(--red);

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -539,3 +539,47 @@ describe("landing step", () => {
 		);
 	});
 });
+
+/**
+ * Slice 3b review wave: the release-nudge banner's visibility is two computeds in
+ * ChatView.vue - hasUrgentAlert (what the soft banner yields to) and
+ * updateBannerVisible (when it renders). Mounting ChatView is not viable (see the
+ * source-slice suites above), so these slice the two computeds and pin the
+ * decision text, the same technique those suites already use on this file.
+ */
+describe("update-banner visibility rules (Slice 3b review wave)", () => {
+	const HERE = path.dirname(fileURLToPath(import.meta.url));
+	const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+	function sliceComputed(name) {
+		const start = chatSrc.indexOf(`const ${name} = computed(`);
+		expect(start, `ChatView must still define ${name}`).not.toBe(-1);
+		const end = chatSrc.indexOf(");", start);
+		expect(end, `${name} must be a closed computed(...)`).not.toBe(-1);
+		return chatSrc.slice(start, end);
+	}
+
+	it("hasUrgentAlert INCLUDES llmApplyStuck (chat genuinely can't answer, so the nudge yields)", () => {
+		// llmApplyStuck's own ref comment says chat "genuinely cannot answer" - an
+		// aged-out apply, not a still-converging one - so the update banner must
+		// yield to it. Dropping it (the pre-fix state) stacked a "please update"
+		// nudge over a chat that couldn't answer at all.
+		expect(sliceComputed("hasUrgentAlert")).toContain("llmApplyStuck");
+	});
+
+	it("hasUrgentAlert does NOT yield to the soft heads-ups (workersWarnNotice/llmApplying)", () => {
+		// Those keep chat working, so the update banner should show over them - a
+		// bench low on workers, or a routine mid-apply, would otherwise NEVER
+		// surface the nudge. ("llmApplyStuck" is present but does not match the
+		// "llmApplying" substring.)
+		const body = sliceComputed("hasUrgentAlert");
+		expect(body).not.toContain("workersWarnNotice");
+		expect(body).not.toContain("llmApplying");
+	});
+
+	it("updateBannerVisible no longer suppresses on showWelcome (banner shows over the welcome screen)", () => {
+		// The highest-traffic surface. Re-adding showWelcome here would hide the
+		// nudge from the users most likely to see only the welcome screen.
+		expect(sliceComputed("updateBannerVisible")).not.toContain("showWelcome");
+	});
+});

--- a/frontend/src/releaseNudge.js
+++ b/frontend/src/releaseNudge.js
@@ -17,16 +17,26 @@ export const SNOOZE_KEY = "jarvis-release-banner-snooze";
 // `agentName` is a PARAMETER (default "Jarvis"), not an import, so this module stays
 // node-testable and single-sourced - the caller passes the branded agent name in.
 //   - no notice / no target version -> hidden (never a false "on the latest").
+//   - tier "none" (a known version we're level with) -> green (current). This is
+//     the ONLY green: it is a positive all-clear, so it must never double as the
+//     catch-all fallback - an unrecognised future tier that carries a version is
+//     a real nudge, not proof we're up to date.
 //   - tier "hard" -> red   (N versions behind, or "Update required"). "hard" is
 //     block-only (critical release / below the floor version) and is normally
 //     hidden behind the full-page gate, so in practice the visible red pill is
 //     "severe" below - both render identically.
 //   - tier "severe" -> red (N versions behind, or "Update available"; NON-blocking:
 //     behind >= release_lag_threshold, chat stays open).
-//   - tier "soft" -> amber (N versions behind, or "Update available").
-//   - otherwise (tier "none", with a known version) -> green (current).
+//   - tier "soft" OR any unknown-but-versioned future tier -> amber (N versions
+//     behind, or "Update available"). Amber is the safe default for "there's a
+//     newer version, urgency unknown": a nudge, never a false green all-clear.
 export function pillFor(notice, agentName = "Jarvis") {
 	if (!notice || !notice.version) return { show: false };
+	// The ONE green case: a known target version we are level with. Green is a
+	// positive claim, so it is gated to "none" alone and never the fallback.
+	if (notice.tier === "none") {
+		return { show: true, tone: "green", label: `On the latest ${agentName}` };
+	}
 	const behind = Number(notice.behind) || 0;
 	if (notice.tier === "hard") {
 		return {
@@ -48,27 +58,39 @@ export function pillFor(notice, agentName = "Jarvis") {
 					: "Update available",
 		};
 	}
-	if (notice.tier === "soft") {
-		return {
-			show: true,
-			tone: "amber",
-			label:
-				behind >= 1
-					? `${behind} version${behind === 1 ? "" : "s"} behind`
-					: "Update available",
-		};
-	}
-	return { show: true, tone: "green", label: `On the latest ${agentName}` };
+	// soft OR any unknown-but-versioned future tier -> amber. Forward-compatible:
+	// a tier this build doesn't recognise still nudges (amber), never a false
+	// green "on the latest".
+	return {
+		show: true,
+		tone: "amber",
+		label:
+			behind >= 1
+				? `${behind} version${behind === 1 ? "" : "s"} behind`
+				: "Update available",
+	};
 }
 
-// The soft banner shows for the "soft" and "severe" tiers - both are non-blocking
-// nudges (chat stays open; "hard" is the only blocking tier and has no banner, it
-// gets the full-page gate instead) - and only when not currently snoozed: no
-// snooze, a snooze for a different (older) target version, or a snooze that has
-// expired. `now` and `snooze` are passed in so this stays pure and testable.
+// The banner's tone, single-sourced from pillFor so the pill and the banner can
+// never disagree on colour - whatever pillFor would paint the pill, the banner
+// matches ("green"/"amber"/"red"). In practice only called once bannerShouldShow
+// has cleared the notice (soft/severe/unknown, all versioned), so it returns
+// "amber" or "red"; the SPA maps "red" -> Banner type="error", else "warning",
+// and both frontends map the tone to their jv-tone-* class.
+export function bannerToneFor(notice) {
+	return pillFor(notice).tone;
+}
+
+// The banner shows for any versioned tier that is NOT the all-clear ("none") or
+// the blocking full-page gate ("hard") - so soft, severe, AND any unknown future
+// tier (which pillFor colours amber). Mirrors pillFor: it fires exactly when the
+// pill would be amber/red, never green and never the "hard" full-page path. Shows
+// only when not currently snoozed: no snooze, a snooze for a different (older)
+// target version, or a snooze that has expired. `now` and `snooze` are passed in
+// so this stays pure and testable.
 export function bannerShouldShow(notice, now, snooze) {
 	if (!notice || !notice.version) return false;
-	if (notice.tier !== "soft" && notice.tier !== "severe") return false;
+	if (notice.tier === "none" || notice.tier === "hard") return false;
 	return !snooze || snooze.version !== notice.version || now > snooze.until;
 }
 

--- a/frontend/src/releaseNudge.js
+++ b/frontend/src/releaseNudge.js
@@ -5,7 +5,10 @@
 //
 // The wire payload is minimal: { active, version, message, tier, behind,
 // banner_interval_days }. There is NO `state` field - the display state (current /
-// soft / hard / unknown) is derived here from `version` + `tier` + `behind`.
+// soft / severe / hard / unknown) is derived here from `version` + `tier` + `behind`.
+// Only "hard" is blocking (active=true, critical release or below the floor
+// version); "severe" (behind >= release_lag_threshold) is a red pill + banner
+// like "soft", non-blocking - see the Slice 3b.1 severity-split addendum.
 
 export const SNOOZE_KEY = "jarvis-release-banner-snooze";
 
@@ -14,7 +17,12 @@ export const SNOOZE_KEY = "jarvis-release-banner-snooze";
 // `agentName` is a PARAMETER (default "Jarvis"), not an import, so this module stays
 // node-testable and single-sourced - the caller passes the branded agent name in.
 //   - no notice / no target version -> hidden (never a false "on the latest").
-//   - tier "hard" -> red   (N versions behind, or "Update required").
+//   - tier "hard" -> red   (N versions behind, or "Update required"). "hard" is
+//     block-only (critical release / below the floor version) and is normally
+//     hidden behind the full-page gate, so in practice the visible red pill is
+//     "severe" below - both render identically.
+//   - tier "severe" -> red (N versions behind, or "Update available"; NON-blocking:
+//     behind >= release_lag_threshold, chat stays open).
 //   - tier "soft" -> amber (N versions behind, or "Update available").
 //   - otherwise (tier "none", with a known version) -> green (current).
 export function pillFor(notice, agentName = "Jarvis") {
@@ -30,6 +38,16 @@ export function pillFor(notice, agentName = "Jarvis") {
 					: "Update required",
 		};
 	}
+	if (notice.tier === "severe") {
+		return {
+			show: true,
+			tone: "red",
+			label:
+				behind >= 1
+					? `${behind} version${behind === 1 ? "" : "s"} behind`
+					: "Update available",
+		};
+	}
 	if (notice.tier === "soft") {
 		return {
 			show: true,
@@ -43,11 +61,14 @@ export function pillFor(notice, agentName = "Jarvis") {
 	return { show: true, tone: "green", label: `On the latest ${agentName}` };
 }
 
-// The soft banner shows only for the soft tier, and only when not currently snoozed:
-// no snooze, a snooze for a different (older) target version, or a snooze that has
+// The soft banner shows for the "soft" and "severe" tiers - both are non-blocking
+// nudges (chat stays open; "hard" is the only blocking tier and has no banner, it
+// gets the full-page gate instead) - and only when not currently snoozed: no
+// snooze, a snooze for a different (older) target version, or a snooze that has
 // expired. `now` and `snooze` are passed in so this stays pure and testable.
 export function bannerShouldShow(notice, now, snooze) {
-	if (!notice || !notice.version || notice.tier !== "soft") return false;
+	if (!notice || !notice.version) return false;
+	if (notice.tier !== "soft" && notice.tier !== "severe") return false;
 	return !snooze || snooze.version !== notice.version || now > snooze.until;
 }
 

--- a/frontend/src/releaseNudge.test.js
+++ b/frontend/src/releaseNudge.test.js
@@ -56,32 +56,60 @@ test("pillFor: hard -> red; behind>=1 shows the count, behind<1 falls back", () 
 	assert.equal(pillFor({ version: "16.4.0", tier: "hard", behind: 0 }).label, "Update required");
 });
 
+test("pillFor: severe -> red (non-blocking); behind>=1 shows the count, behind<1 falls back", () => {
+	assert.deepEqual(pillFor({ version: "16.4.0", tier: "severe", behind: 4 }), {
+		show: true,
+		tone: "red",
+		label: "4 versions behind",
+	});
+	// behind==1 is singular: "1 version behind", never "1 versions behind".
+	assert.equal(
+		pillFor({ version: "16.4.0", tier: "severe", behind: 1 }).label,
+		"1 version behind"
+	);
+	// severe's fallback is "Update available" (NOT "Update required" - that stays
+	// hard-only, since severe never blocks chat).
+	assert.equal(
+		pillFor({ version: "16.4.0", tier: "severe", behind: 0 }).label,
+		"Update available"
+	);
+	assert.equal(pillFor({ version: "16.4.0", tier: "severe" }).label, "Update available");
+});
+
 // ---- bannerShouldShow ----------------------------------------------------
 
 test("bannerShouldShow: soft + no snooze -> true", () => {
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "soft" }, 1000, null), true);
 });
 
-test("bannerShouldShow: only the soft tier with a version can show", () => {
+test("bannerShouldShow: severe + no snooze -> true (non-blocking nudge, same as soft)", () => {
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "severe" }, 1000, null), true);
+});
+
+test("bannerShouldShow: only soft/severe with a version can show - never hard/none/unknown", () => {
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "none" }, 1000, null), false);
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "hard" }, 1000, null), false);
 	assert.equal(bannerShouldShow({ version: "", tier: "soft" }, 1000, null), false);
+	assert.equal(bannerShouldShow({ version: "", tier: "severe" }, 1000, null), false);
 	assert.equal(bannerShouldShow(null, 1000, null), false);
 });
 
 test("bannerShouldShow: same version, unexpired snooze -> false", () => {
 	const snooze = { version: "16.4.0", until: 5000 };
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "soft" }, 1000, snooze), false);
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "severe" }, 1000, snooze), false);
 });
 
 test("bannerShouldShow: same version, expired snooze -> true", () => {
 	const snooze = { version: "16.4.0", until: 5000 };
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "soft" }, 9000, snooze), true);
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "severe" }, 9000, snooze), true);
 });
 
 test("bannerShouldShow: a newer target version supersedes an unexpired snooze -> true", () => {
 	const snooze = { version: "16.4.0", until: 999999 };
 	assert.equal(bannerShouldShow({ version: "16.5.0", tier: "soft" }, 1000, snooze), true);
+	assert.equal(bannerShouldShow({ version: "16.5.0", tier: "severe" }, 1000, snooze), true);
 });
 
 // ---- snooze read/write ---------------------------------------------------

--- a/frontend/src/releaseNudge.test.js
+++ b/frontend/src/releaseNudge.test.js
@@ -1,7 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { pillFor, bannerShouldShow, readSnooze, writeSnooze, SNOOZE_KEY } from "./releaseNudge.js";
+import {
+	pillFor,
+	bannerToneFor,
+	bannerShouldShow,
+	readSnooze,
+	writeSnooze,
+	SNOOZE_KEY,
+} from "./releaseNudge.js";
 
 const DAY = 86400000;
 
@@ -76,6 +83,42 @@ test("pillFor: severe -> red (non-blocking); behind>=1 shows the count, behind<1
 	assert.equal(pillFor({ version: "16.4.0", tier: "severe" }).label, "Update available");
 });
 
+test("pillFor: an unknown-but-versioned future tier -> amber, NEVER a false green", () => {
+	// Forward-compat: a tier this build doesn't recognise still carries a version,
+	// so it's a real nudge - amber, not the green "on the latest" all-clear.
+	assert.deepEqual(pillFor({ version: "16.4.0", tier: "whoa", behind: 3 }), {
+		show: true,
+		tone: "amber",
+		label: "3 versions behind",
+	});
+	// ...and with no behind it still falls back to amber "Update available", never green.
+	const p = pillFor({ version: "16.4.0", tier: "whoa" });
+	assert.equal(p.tone, "amber");
+	assert.equal(p.label, "Update available");
+	assert.notEqual(p.tone, "green");
+});
+
+test("pillFor: green is reserved for tier 'none' alone (not the catch-all)", () => {
+	// Regression pin for the forward-compat fix: only "none" is green; every other
+	// versioned tier is amber/red. Guards against green becoming the fallback again.
+	assert.equal(pillFor({ version: "16.4.0", tier: "none" }).tone, "green");
+	assert.equal(pillFor({ version: "16.4.0", tier: "soft" }).tone, "amber");
+	assert.equal(pillFor({ version: "16.4.0", tier: "severe" }).tone, "red");
+	assert.equal(pillFor({ version: "16.4.0", tier: "hard" }).tone, "red");
+	assert.equal(pillFor({ version: "16.4.0", tier: "future-thing" }).tone, "amber");
+});
+
+// ---- bannerToneFor: single-sourced from pillFor --------------------------
+
+test("bannerToneFor: returns pillFor's tone (green/amber/red), single-sourced", () => {
+	assert.equal(bannerToneFor({ version: "16.4.0", tier: "none" }), "green");
+	assert.equal(bannerToneFor({ version: "16.4.0", tier: "soft" }), "amber");
+	assert.equal(bannerToneFor({ version: "16.4.0", tier: "severe" }), "red");
+	assert.equal(bannerToneFor({ version: "16.4.0", tier: "hard" }), "red");
+	// An unknown-but-versioned tier -> amber, matching the pill.
+	assert.equal(bannerToneFor({ version: "16.4.0", tier: "whoa" }), "amber");
+});
+
 // ---- bannerShouldShow ----------------------------------------------------
 
 test("bannerShouldShow: soft + no snooze -> true", () => {
@@ -86,12 +129,25 @@ test("bannerShouldShow: severe + no snooze -> true (non-blocking nudge, same as 
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "severe" }, 1000, null), true);
 });
 
-test("bannerShouldShow: only soft/severe with a version can show - never hard/none/unknown", () => {
+test("bannerShouldShow: any versioned tier except none/hard shows - even an unknown one", () => {
+	// Forward-compat mirror of pillFor: none (all-clear) and hard (full-page gate)
+	// never banner; soft, severe AND any unknown-but-versioned future tier do.
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "none" }, 1000, null), false);
 	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "hard" }, 1000, null), false);
+	// An unrecognised future tier with a version -> banner (amber), never dropped.
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "whoa" }, 1000, null), true);
+	// A tier without a version can never banner, whatever it is.
 	assert.equal(bannerShouldShow({ version: "", tier: "soft" }, 1000, null), false);
 	assert.equal(bannerShouldShow({ version: "", tier: "severe" }, 1000, null), false);
+	assert.equal(bannerShouldShow({ version: "", tier: "whoa" }, 1000, null), false);
 	assert.equal(bannerShouldShow(null, 1000, null), false);
+});
+
+test("bannerShouldShow: an unknown-versioned tier still respects an unexpired snooze", () => {
+	// The forward-compat "unknown shows" must not bypass snooze - same rule as soft/severe.
+	const snooze = { version: "16.4.0", until: 5000 };
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "whoa" }, 1000, snooze), false);
+	assert.equal(bannerShouldShow({ version: "16.4.0", tier: "whoa" }, 9000, snooze), true);
 });
 
 test("bannerShouldShow: same version, unexpired snooze -> false", () => {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -549,10 +549,11 @@
 				</div>
 			</div>
 
-			<!-- Release-nudge soft banner (Slice 3b): calm info/blue, top-of-chat.
-			     Yields to the greeting/welcome/booting states and to any urgent
-			     billing/readiness alert (updateBannerVisible); dismiss minimises it
-			     into the version pill. Never stacks, never hides chat. -->
+			<!-- Release-nudge banner (Slice 3b): severity-coloured (amber for soft,
+			     red for severe), top-of-chat. Shows over the welcome screen; yields
+			     to the greeting/booting states and to any urgent billing/readiness
+			     alert, including a stuck apply (updateBannerVisible). Dismiss
+			     minimises it into the version pill. Never stacks, never hides chat. -->
 			<UpdateBanner v-if="updateBannerVisible" :pill="versionPillRef" />
 
 			<!-- initial load: a quiet spinner so the welcome screen doesn't flash
@@ -4689,10 +4690,13 @@ function dismissBillingAlert() {
 const versionPillRef = ref(null);
 // Composer-region alerts that make the chat genuinely UNUSABLE or paused - a
 // "please update" nudge on top of one of these is noise, so the soft banner
-// yields to them. It does NOT yield to the soft, chat-still-works heads-ups
-// (workersWarnNotice, llmApplying, llmApplyStuck): those render above the
-// composer, don't visually conflict with the top-of-chat banner, and are common
-// (a bench low on workers would otherwise NEVER show the update banner).
+// yields to them. llmApplyStuck is one of these: its own ref comment says chat
+// "genuinely cannot answer" (an aged-out apply, not a still-converging one), so
+// the update banner yields to it too. It does NOT yield to the soft,
+// chat-still-works heads-ups - workersWarnNotice (a bench low on workers, which
+// would otherwise NEVER show the update banner) and llmApplying (a quiet "still
+// converging" heads-up): those render above the composer, don't visually
+// conflict with the top-of-chat banner, and chat still works under them.
 const hasUrgentAlert = computed(
 	() =>
 		!!(
@@ -4701,6 +4705,7 @@ const hasUrgentAlert = computed(
 			suspendedNotice.value ||
 			noAiConnected.value ||
 			containerUnavailable.value ||
+			llmApplyStuck.value ||
 			notReadyNotice.value
 		)
 );

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4704,16 +4704,13 @@ const hasUrgentAlert = computed(
 			llmApplyStuck.value
 		)
 );
-// The soft banner shows only when: it's a not-snoozed soft notice AND the
-// top-of-chat region is otherwise clear (no greeting/welcome/booting) AND no
-// urgent alert is competing for attention. The pill stays regardless.
+// The soft banner shows whenever it's a not-snoozed soft/severe notice AND the
+// top-of-chat region is otherwise clear (no greeting/booting) AND no urgent
+// alert is competing for attention - it also shows over the welcome screen
+// (the highest-traffic surface), which no longer suppresses it. The pill
+// stays regardless.
 const updateBannerVisible = computed(
-	() =>
-		showBanner.value &&
-		!bizGreeting.value.show &&
-		!showWelcome.value &&
-		!booting.value &&
-		!hasUrgentAlert.value
+	() => showBanner.value && !bizGreeting.value.show && !booting.value && !hasUrgentAlert.value
 );
 // Per-conversation "auto-apply changes" (issue #186): seeded from
 // get_conversation().conversation.auto_apply on each load; the toggle reflects

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4687,21 +4687,21 @@ function dismissBillingAlert() {
 // The version pill (header) exposes { getEl, pulse }; the soft banner reaches
 // for it to minimise-into-pill on dismiss.
 const versionPillRef = ref(null);
-// Any composer-region billing/readiness alert that is live. The soft update
-// banner yields to all of them (never stacks, never competes with something the
-// customer must act on) - it is the least urgent surface here.
+// Composer-region alerts that make the chat genuinely UNUSABLE or paused - a
+// "please update" nudge on top of one of these is noise, so the soft banner
+// yields to them. It does NOT yield to the soft, chat-still-works heads-ups
+// (workersWarnNotice, llmApplying, llmApplyStuck): those render above the
+// composer, don't visually conflict with the top-of-chat banner, and are common
+// (a bench low on workers would otherwise NEVER show the update banner).
 const hasUrgentAlert = computed(
 	() =>
 		!!(
 			replacedAlert.value ||
 			billingAlert.value ||
 			suspendedNotice.value ||
-			workersWarnNotice.value ||
 			noAiConnected.value ||
 			containerUnavailable.value ||
-			notReadyNotice.value ||
-			llmApplying.value ||
-			llmApplyStuck.value
+			notReadyNotice.value
 		)
 );
 // The soft banner shows whenever it's a not-snoozed soft/severe notice AND the

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -692,6 +692,7 @@ import { renderReply } from "./panel_markdown.mjs";
 import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { classifyReadiness, degradedActionable, shouldWarnWorkers } from "./panel_readiness.mjs";
+import { sendRefusalMessage } from "./panel_send_copy.mjs";
 import {
 	emptyStream,
 	applyEvent,
@@ -1591,8 +1592,8 @@ async function send() {
 			messages.value = messages.value.filter((m) => !String(m.name).startsWith("local-"));
 			loadError.value =
 				res.reason === "release_update_required"
-					? `A new ${brandName} version is required. Please ask your administrator to update.`
-					: res.error?.message || "That couldn't be sent. Please try again.";
+					? sendRefusalMessage(res.reason, brandName)
+					: res.error?.message || sendRefusalMessage(res.reason, brandName);
 			return;
 		}
 		// A go-ahead on the parked card ran the confirmation instead of starting a

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1580,6 +1580,21 @@ async function send() {
 		const approvalTokens = orderedPending.value.map((p) => p.token);
 		const res = await sendMessage(convId.value, text, props.context, atts, approvalTokens);
 		if (res?.conversation_id) convId.value = res.conversation_id;
+		// A send the server refused outright (e.g. a required app update, via the
+		// same validate_can_send gate as the full chat) starts no turn and returns
+		// no conversation. Surface the reason and STOP — otherwise the fall-through
+		// below flips the panel busy and polls for a run that never comes. The full
+		// nudge (pill/banner) stays off the bubble by design; this is just the
+		// legible reason for the refusal.
+		if (res && res.ok === false && !res.confirmed) {
+			sending.value = false;
+			messages.value = messages.value.filter((m) => !String(m.name).startsWith("local-"));
+			loadError.value =
+				res.reason === "release_update_required"
+					? `A new ${brandName} version is required. Please ask your administrator to update.`
+					: res.error?.message || "That couldn't be sent. Please try again.";
+			return;
+		}
 		// A go-ahead on the parked card ran the confirmation instead of starting a
 		// turn. No run is coming, so marking the panel busy would spin forever, and
 		// nothing was persisted for the typed words. Reload: the durable receipt

--- a/jarvis/public/js/jarvis_chat/widget/panel_send_copy.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_send_copy.mjs
@@ -1,0 +1,24 @@
+// Copy for a send the server refused outright, extracted from Panel.vue so the
+// decision (refusal reason -> user-facing sentence) is a pure, node-testable
+// function rather than an inline ternary buried in the send() handler.
+//
+// Plain .mjs by necessity, not choice: this widget is served straight into Desk
+// (see jarvis_widget.bundle.js) and cannot import from frontend/src or use the
+// SPA's "@/" alias - the same constraint that forces panel_readiness.mjs to
+// duplicate readiness.js. Keep the SPA's own equivalent copy in sync BY HAND.
+//
+// The full update nudge (pill/banner) stays off the bubble by design; this is
+// only the legible reason shown when a send is rejected.
+
+// `brandName` is a PARAMETER (default "Jarvis"), not an import, so this module
+// stays pure and testable - the caller passes the white-label agent name in.
+//   - "release_update_required": the branded "a new <brand> version is required"
+//     line, so a customer who renamed the assistant never sees "Jarvis" leak.
+//   - anything else (a generic/unknown refusal): a neutral "try again" line.
+export function sendRefusalMessage(reason, brandName = "Jarvis") {
+  const brand = (brandName || "").trim() || "Jarvis";
+  if (reason === "release_update_required") {
+    return `A new ${brand} version is required. Please ask your administrator to update.`;
+  }
+  return "That couldn't be sent. Please try again.";
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_send_copy.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_send_copy.test.mjs
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sendRefusalMessage } from "./panel_send_copy.mjs";
+
+test("sendRefusalMessage: release_update_required -> branded update line", () => {
+  assert.equal(
+    sendRefusalMessage("release_update_required", "Jarvis"),
+    "A new Jarvis version is required. Please ask your administrator to update."
+  );
+});
+
+test("sendRefusalMessage: the update line uses the passed (white-label) brand name", () => {
+  // A customer who renamed the assistant must not see "Jarvis" leak.
+  assert.equal(
+    sendRefusalMessage("release_update_required", "Aida"),
+    "A new Aida version is required. Please ask your administrator to update."
+  );
+});
+
+test("sendRefusalMessage: a blank/missing brand falls back to 'Jarvis'", () => {
+  const expected =
+    "A new Jarvis version is required. Please ask your administrator to update.";
+  assert.equal(sendRefusalMessage("release_update_required", ""), expected);
+  assert.equal(sendRefusalMessage("release_update_required", "   "), expected);
+  assert.equal(sendRefusalMessage("release_update_required"), expected);
+});
+
+test("sendRefusalMessage: any other refusal -> the generic try-again line", () => {
+  assert.equal(
+    sendRefusalMessage("something_else", "Aida"),
+    "That couldn't be sent. Please try again."
+  );
+  // Brand is irrelevant to the generic line - it names no product.
+  assert.equal(
+    sendRefusalMessage("something_else"),
+    "That couldn't be sent. Please try again."
+  );
+});
+
+test("sendRefusalMessage: an unknown/empty reason -> the generic line, never branded", () => {
+  const generic = "That couldn't be sent. Please try again.";
+  assert.equal(sendRefusalMessage("", "Aida"), generic);
+  assert.equal(sendRefusalMessage(undefined, "Aida"), generic);
+  assert.equal(sendRefusalMessage(null, "Aida"), generic);
+});

--- a/jarvis/tests/test_release_notice.py
+++ b/jarvis/tests/test_release_notice.py
@@ -179,6 +179,20 @@ class TestBootPayload(FrappeTestCase):
 		self.assertTrue(p["active"])
 		self.assertEqual(p["behind"], 4)
 
+	def test_boot_severe_active_false(self):
+		# Slice 3b.1 severity split: "severe" (behind >= release_lag_threshold) is a
+		# red pill + banner but NON-blocking - unlike "hard", it must NOT set active.
+		self._set(
+			release_notice_active=0,
+			latest_jarvis_version=NEWER,
+			release_notice_tier="severe",
+			release_notice_behind=4,
+		)
+		p = release_notice.boot_payload()
+		self.assertEqual(p["tier"], "severe")
+		self.assertEqual(p["behind"], 4)
+		self.assertFalse(p["active"])
+
 	def test_boot_current_zeroes_behind(self):
 		# Bench already at/past target: `behind` reads 0 regardless of a stale stored value.
 		self._set(
@@ -205,8 +219,8 @@ class TestBootPayload(FrappeTestCase):
 
 	def test_active_equals_tier_hard(self):
 		# The load-bearing invariant: active is true exactly when the tier is hard,
-		# across every producible tier.
-		for tier, act in (("hard", 1), ("soft", 0), ("none", 0)):
+		# across every producible tier ("severe" is non-blocking, like "soft").
+		for tier, act in (("hard", 1), ("severe", 0), ("soft", 0), ("none", 0)):
 			release_notice.persist(
 				{"active": act, "tier": tier, "version": NEWER, "message": "m", "behind": 1}
 			)

--- a/pwa/src/components/UpdateBanner.vue
+++ b/pwa/src/components/UpdateBanner.vue
@@ -15,9 +15,14 @@
 // caller's v-if in App.vue.
 import { ref } from "vue";
 import { agentName } from "@/branding";
-import { pillHandle, snoozeBanner, openWhatsNew } from "../noticeGate";
+import { notice, pillHandle, snoozeBanner, openWhatsNew } from "../noticeGate";
 
 const message = `A new version of ${agentName} is available — ask your administrator to update.`;
+
+// Severity drives the banner's colour, mirroring the pill: soft -> amber,
+// severe -> red. `notice` is the stable, non-reactive boot payload (see
+// noticeGate.js), so this is a plain const, not computed().
+const bannerTone = notice.tier === "severe" ? "red" : "amber";
 
 const bannerEl = ref(null);
 const flipStyle = ref({});
@@ -88,10 +93,16 @@ function dismiss() {
 </script>
 
 <template>
-	<!-- Calm info/blue treatment - NOT the alarm amber the hard gate implies.
-	     The wrapper is the FLIP target that minimises into the version pill on
-	     dismiss. -->
-	<div ref="bannerEl" class="jv-updatebanner" :style="flipStyle">
+	<!-- Coloured by severity - amber (soft) or red (severe), matching the
+	     version pill. The banner only ever renders for these two tiers (see
+	     bannerShouldShow in releaseNudge.js). The wrapper is the FLIP target
+	     that minimises into the version pill on dismiss. -->
+	<div
+		ref="bannerEl"
+		class="jv-updatebanner"
+		:class="'jv-tone-' + bannerTone"
+		:style="flipStyle"
+	>
 		<svg
 			class="jv-ub-icon"
 			viewBox="0 0 24 24"
@@ -134,6 +145,17 @@ function dismiss() {
 </template>
 
 <style scoped>
+/* Tone (amber/red) resolves per severity class below; reused by the fill,
+   border, ink AND the action buttons so the whole banner + its controls stay
+   one coherent colour. */
+.jv-tone-amber {
+	--jv-tone: var(--amber);
+	--jv-tone-bg: var(--amber-bg);
+}
+.jv-tone-red {
+	--jv-tone: var(--red);
+	--jv-tone-bg: var(--red-bg);
+}
 .jv-updatebanner {
 	flex: none;
 	display: flex;
@@ -143,9 +165,9 @@ function dismiss() {
 	margin: 8px 12px 0;
 	padding: 12px;
 	border-radius: 14px;
-	background: var(--blue-bg);
-	border: 1px solid color-mix(in srgb, var(--blue) 35%, transparent);
-	color: var(--blue);
+	background: var(--jv-tone-bg);
+	border: 1px solid color-mix(in srgb, var(--jv-tone) 35%, transparent);
+	color: var(--jv-tone);
 }
 .jv-ub-icon {
 	flex: none;
@@ -166,13 +188,13 @@ function dismiss() {
 .jv-ub-btn {
 	height: 30px;
 	padding: 0 11px;
-	border: 1px solid color-mix(in srgb, var(--blue) 40%, transparent);
+	border: 1px solid color-mix(in srgb, var(--jv-tone) 40%, transparent);
 	border-radius: 8px;
 	background: transparent;
 	font-family: inherit;
 	font-size: 12.5px;
 	font-weight: 600;
-	color: var(--blue);
+	color: var(--jv-tone);
 	cursor: pointer;
 	white-space: nowrap;
 }
@@ -181,11 +203,11 @@ function dismiss() {
 	color: var(--ink6);
 }
 .jv-ub-btn:active {
-	background: color-mix(in srgb, var(--blue) 16%, transparent);
+	background: color-mix(in srgb, var(--jv-tone) 16%, transparent);
 }
 .jv-ub-btn:focus-visible,
 .jv-ub-x:focus-visible {
-	outline: 2px solid var(--blue);
+	outline: 2px solid var(--jv-tone);
 	outline-offset: 2px;
 }
 .jv-ub-x {

--- a/pwa/src/components/UpdateBanner.vue
+++ b/pwa/src/components/UpdateBanner.vue
@@ -15,14 +15,16 @@
 // caller's v-if in App.vue.
 import { ref } from "vue";
 import { agentName } from "@/branding";
+import { bannerToneFor } from "@shared/releaseNudge";
 import { notice, pillHandle, snoozeBanner, openWhatsNew } from "../noticeGate";
 
 const message = `A new version of ${agentName} is available — ask your administrator to update.`;
 
-// Severity drives the banner's colour, mirroring the pill: soft -> amber,
-// severe -> red. `notice` is the stable, non-reactive boot payload (see
-// noticeGate.js), so this is a plain const, not computed().
-const bannerTone = notice.tier === "severe" ? "red" : "amber";
+// Severity drives the banner's colour, mirroring the pill - single-sourced via
+// bannerToneFor (releaseNudge.js) so the pill and banner can never disagree, and
+// an unknown future tier lands amber. `notice` is the stable, non-reactive boot
+// payload (see noticeGate.js), so this is a plain const, not computed().
+const bannerTone = bannerToneFor(notice);
 
 const bannerEl = ref(null);
 const flipStyle = ref({});

--- a/pwa/src/components/VersionPill.vue
+++ b/pwa/src/components/VersionPill.vue
@@ -101,18 +101,28 @@ defineExpose({ getEl: handle.getEl, pulse });
 	text-overflow: ellipsis;
 }
 
-/* Tone drives the dot AND the label colour, straight off the app palette. */
+/* Tone drives the dot, the label colour, AND a subtle border in the same hue
+   (color-mix'd down so it reads as a tint, not a solid tone-coloured chip). */
+.jv-tone-green {
+	border-color: color-mix(in srgb, var(--green) 40%, transparent);
+}
 .jv-tone-green .jv-pill-dot {
 	background: var(--green);
 }
 .jv-tone-green .jv-pill-label {
 	color: var(--green);
 }
+.jv-tone-amber {
+	border-color: color-mix(in srgb, var(--amber) 40%, transparent);
+}
 .jv-tone-amber .jv-pill-dot {
 	background: var(--amber);
 }
 .jv-tone-amber .jv-pill-label {
 	color: var(--amber);
+}
+.jv-tone-red {
+	border-color: color-mix(in srgb, var(--red) 40%, transparent);
 }
 .jv-tone-red .jv-pill-dot {
 	background: var(--red);

--- a/pwa/src/index.css
+++ b/pwa/src/index.css
@@ -36,8 +36,6 @@
 	--amber: #b35309;
 	--amber-bg: #fff7d3;
 	--amber-dot: #db7706;
-	/* Calm "info" tone for the release-nudge soft banner (Slice 3b) - distinct
-	   from the amber/red alert tones above, which read as warnings. */
 	--inv-bg: #171717;
 	--inv-ink: #ffffff;
 	--scrim: rgba(20, 20, 22, 0.34);

--- a/pwa/src/index.css
+++ b/pwa/src/index.css
@@ -38,8 +38,6 @@
 	--amber-dot: #db7706;
 	/* Calm "info" tone for the release-nudge soft banner (Slice 3b) - distinct
 	   from the amber/red alert tones above, which read as warnings. */
-	--blue: #1c6dc4;
-	--blue-bg: #e8f2fc;
 	--inv-bg: #171717;
 	--inv-ink: #ffffff;
 	--scrim: rgba(20, 20, 22, 0.34);
@@ -86,8 +84,6 @@
 		--amber: #e8a845;
 		--amber-bg: #3a2c1c;
 		--amber-dot: #e37d00;
-		--blue: #6fb3f5;
-		--blue-bg: #1c2c3d;
 		--inv-bg: #f5f4ee;
 		--inv-ink: #262624;
 		--scrim: rgba(0,0,0,0.6);
@@ -119,8 +115,6 @@
 	--amber: #e8a845;
 	--amber-bg: #3a2c1c;
 	--amber-dot: #e37d00;
-	--blue: #6fb3f5;
-	--blue-bg: #1c2c3d;
 	--inv-bg: #f5f4ee;
 	--inv-ink: #262624;
 	--scrim: rgba(0,0,0,0.6);


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
