### PR TITLE
fix(tests): freeze now in detector tests so fixed-date fixtures stay …

### DIFF
--- a/jarvis/tests/learning/test_detectors.py
+++ b/jarvis/tests/learning/test_detectors.py
@@ -14,6 +14,8 @@ engine's table-diff integration test (Wave B engine).
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -28,6 +30,18 @@ from jarvis.learning.executor import (
 )
 from jarvis.learning.readonly_db import PatternDB
 from jarvis.tests.learning import factory
+
+# The factory seeds fixtures at fixed calendar dates (2025-09-01 onward), but
+# detector windows are computed relative to "now" (window_start = today - N
+# months). Once the real run date advances far enough, the earliest fixtures
+# age out of the shorter windows: e.g. mfg-default-bom-usage (12-month window,
+# n_min=20) seeds 24 Widget Work Orders from 2025-09-01, and once today passes
+# ~2026-09 the first five fall before the cutoff, leaving 19 in-window -- below
+# the gate -- so the detector finds nothing and the test fails. Pin today() to a
+# stable date after the fixtures (comfortably inside even the 12-month window,
+# and after the latest ~2025-11 fixture) so every window covers them
+# deterministically, whatever the real date the suite runs on.
+_FROZEN_NOW = "2026-04-01"
 from jarvis.tests.learning.test_snapshots import seed_print_log, wipe_print_state
 
 
@@ -75,7 +89,11 @@ class TestTier1Detectors(FrappeTestCase):
 		super().tearDownClass()
 
 	def _run(self, detector_id, company):
-		return run_detector(registry.get_detector(detector_id), company, PatternDB())
+		# Pin today() so detector windows deterministically cover the fixed-date
+		# fixtures regardless of the real run date (see _FROZEN_NOW). window_start
+		# reads frappe.utils.today(); patch it with stdlib mock (no freezegun in CI).
+		with patch("frappe.utils.today", return_value=_FROZEN_NOW):
+			return run_detector(registry.get_detector(detector_id), company, PatternDB())
 
 	# --- selling ------------------------------------------------------------
 	def test_customer_price_list_finds_dealer_and_silent_on_sole_value(self):
@@ -744,7 +762,11 @@ class TestTier2Detectors(FrappeTestCase):
 		super().tearDownClass()
 
 	def _run(self, detector_id, company):
-		return run_detector(registry.get_detector(detector_id), company, PatternDB())
+		# Pin today() so detector windows deterministically cover the fixed-date
+		# fixtures regardless of the real run date (see _FROZEN_NOW). window_start
+		# reads frappe.utils.today(); patch it with stdlib mock (no freezegun in CI).
+		with patch("frappe.utils.today", return_value=_FROZEN_NOW):
+			return run_detector(registry.get_detector(detector_id), company, PatternDB())
 
 	# --- S5 realized-vs-master payment terms ---------------------------------
 	def test_customer_payment_terms_divergence_and_master_match_trap(self):


### PR DESCRIPTION
…in-window

The Tier-1/Tier-2 detector tests seed factory fixtures at fixed calendar dates (2025-09-01 onward), but detector windows are relative to now (window_start = today - N months). Once the real run date advanced past ~2026-09, the earliest fixtures aged out of the shortest (12-month) window: mfg-default-bom-usage seeds 24 Widget Work Orders from 2025-09-01 with n_min=20, and the first five slipped before the cutoff, leaving 19 in-window -> below the gate -> zero candidates -> the test failed (this only surfaces in the full-erpnext 'CI (from scratch)' run, which is why develop's own from-scratch CI is red on it).

Freeze now to a stable date (2026-04-01) in both detector classes' _run, comfortably inside even the 12-month window and after the latest fixture, so every window deterministically covers the fixtures regardless of the real date the suite runs on. Verified: all 68 detector tests pass on a fresh-erpnext bench (erpnext 17-dev).



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
