### PR TITLE
feat(support): report app branch and release tag

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -907,14 +907,24 @@ def get_connection(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	finished the apply (F2). Pass a short ``timeout_s`` for those hot status
 	probes so a slow admin can't stretch a convergence loop past its job budget.
 
-	Also reports this bench's jarvis version so the control plane can close out a
-	release rollout; an older admin ignores the key.
+	Also reports this bench's Jarvis version, checked-out branch and exact release
+	tag. The control plane uses the version to close release rollouts and exposes
+	the source details to support; an older admin ignores the extra keys.
 	"""
 	from jarvis import __version__
+	from jarvis.source_version import source_details
+
+	source = source_details()
 
 	return _post(
 		path=_m("api.tenant.get_connection"),
-		body={"jarvis_version": __version__},
+		body={
+			"jarvis_version": __version__,
+			# Empty is intentional: it lets a checkout that moves off a branch/tag
+			# clear stale source metadata in the control plane.
+			"jarvis_branch": source["branch"] or "",
+			"jarvis_tag": source["tag"] or "",
+		},
 		timeout_s=timeout_s,
 	)
 

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -914,19 +914,16 @@ def get_connection(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	from jarvis import __version__
 	from jarvis.source_version import source_details
 
+	body = {"jarvis_version": __version__}
 	source = source_details()
+	# A value Git confirmed is sent even when empty, so a checkout that moved off a
+	# branch or tag clears stale metadata upstream. A value Git could not give in
+	# time is left out, and the control plane keeps what it already has.
+	for key, value in (("jarvis_branch", source["branch"]), ("jarvis_tag", source["tag"])):
+		if value is not None:
+			body[key] = value
 
-	return _post(
-		path=_m("api.tenant.get_connection"),
-		body={
-			"jarvis_version": __version__,
-			# Empty is intentional: it lets a checkout that moves off a branch/tag
-			# clear stale source metadata in the control plane.
-			"jarvis_branch": source["branch"] or "",
-			"jarvis_tag": source["tag"] or "",
-		},
-		timeout_s=timeout_s,
-	)
+	return _post(path=_m("api.tenant.get_connection"), body=body, timeout_s=timeout_s)
 
 
 def get_role_profile_config(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:

--- a/jarvis/source_version.py
+++ b/jarvis/source_version.py
@@ -1,0 +1,37 @@
+"""Best-effort source revision details for this Jarvis checkout."""
+
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+_GIT_TIMEOUT_SECONDS = 2
+
+
+@lru_cache(maxsize=1)
+def source_details() -> dict[str, str | None]:
+	"""Return the checked-out branch and exact release tag, when Git can prove them.
+
+	Packaged installs and detached checkouts may have neither value. Those are reported as
+	``None`` rather than inferred from ``__version__`` so support never sees a made-up revision.
+	"""
+	return {
+		"branch": _git_value("branch", "--show-current"),
+		"tag": _git_value("describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"),
+	}
+
+
+def _git_value(*args: str) -> str | None:
+	try:
+		result = subprocess.run(
+			["git", "-C", str(_REPOSITORY_ROOT), *args],
+			capture_output=True,
+			text=True,
+			timeout=_GIT_TIMEOUT_SECONDS,
+			check=False,
+		)
+	except (OSError, subprocess.TimeoutExpired):
+		return None
+	if result.returncode:
+		return None
+	return result.stdout.strip() or None

--- a/jarvis/source_version.py
+++ b/jarvis/source_version.py
@@ -1,24 +1,44 @@
 """Best-effort source revision details for this Jarvis checkout."""
 
+import re
 import subprocess
-from functools import lru_cache
 from pathlib import Path
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 _GIT_TIMEOUT_SECONDS = 2
+_RELEASE_TAG = re.compile(r"^v\d+\.\d+\.\d+$")
+_QUERIES = {
+	"branch": ("branch", "--show-current"),
+	"tag": ("describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"),
+}
+
+# Only answers Git actually gave are kept; an unknown value is asked again on the next call.
+_known: dict[str, str] = {}
 
 
-@lru_cache(maxsize=1)
 def source_details() -> dict[str, str | None]:
-	"""Return the checked-out branch and exact release tag, when Git can prove them.
+	"""Return the checked-out branch and exact ``vN.N.N`` release tag.
 
-	Packaged installs and detached checkouts may have neither value. Those are reported as
-	``None`` rather than inferred from ``__version__`` so support never sees a made-up revision.
+	Three outcomes per value, and the difference matters to the control plane: a non-empty
+	string is the revision, an empty string means Git answered and there is none (detached,
+	untagged, not a Git checkout), and ``None`` means Git did not answer in time, so the value
+	is unknown and must not be reported as blank. Nothing is ever inferred from ``__version__``,
+	so support never sees a made-up revision.
 	"""
-	return {
-		"branch": _git_value("branch", "--show-current"),
-		"tag": _git_value("describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"),
-	}
+	details: dict[str, str | None] = {}
+	for key, args in _QUERIES.items():
+		if key not in _known:
+			value = _git_value(*args)
+			if value is None:
+				details[key] = None
+				continue
+			_known[key] = value
+		details[key] = _known[key]
+	return details
+
+
+def reset_cache() -> None:
+	_known.clear()
 
 
 def _git_value(*args: str) -> str | None:
@@ -33,5 +53,8 @@ def _git_value(*args: str) -> str | None:
 	except (OSError, subprocess.TimeoutExpired):
 		return None
 	if result.returncode:
-		return None
-	return result.stdout.strip() or None
+		return ""
+	value = result.stdout.strip()
+	if args[0] == "describe" and not _RELEASE_TAG.match(value):
+		return ""
+	return value

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1097,6 +1097,25 @@ class TestOnboardingClient(FrappeTestCase):
 			},
 		)
 
+	def test_get_connection_omits_unknown_source_but_sends_confirmed_blanks(self):
+		"""None means Git did not answer (the admin keeps its stored value); an empty
+		string means Git confirmed there is no tag (the admin clears its stored value)."""
+		from jarvis import __version__
+
+		_settings_for_admin()
+		captured = {}
+
+		def _fake_post(url, headers=None, json=None, timeout=None):
+			captured["body"] = json
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
+
+		with (
+			patch("requests.post", side_effect=_fake_post),
+			patch("jarvis.source_version.source_details", return_value={"branch": None, "tag": ""}),
+		):
+			admin_client.get_connection()
+		self.assertEqual(captured["body"], {"jarvis_version": __version__, "jarvis_tag": ""})
+
 	def test_renew_posts_to_renew_and_unwraps_order(self):
 		_settings_for_admin(api_key="renew-key", api_secret="renew-secret")
 		captured = {}

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1067,9 +1067,10 @@ class TestOnboardingClient(FrappeTestCase):
 			out = admin_client.get_connection()
 		self.assertEqual(out["agent_url"], "ws://localhost:19000")
 
-	def test_get_connection_reports_jarvis_version(self):
+	def test_get_connection_reports_jarvis_version_and_source(self):
 		"""The control plane closes out a release rollout from this — a tenant that
-		has updated stops being served the release notice."""
+		has updated stops being served the release notice. Support also gets the
+		actual branch and exact release tag."""
 		from jarvis import __version__
 
 		_settings_for_admin()
@@ -1079,9 +1080,22 @@ class TestOnboardingClient(FrappeTestCase):
 			captured["body"] = json
 			return _mock_response(200, json_body={"message": {"ok": True, "data": {}}})
 
-		with patch("requests.post", side_effect=_fake_post):
+		with (
+			patch("requests.post", side_effect=_fake_post),
+			patch(
+				"jarvis.source_version.source_details",
+				return_value={"branch": "version-16", "tag": "v16.1.0"},
+			),
+		):
 			admin_client.get_connection()
-		self.assertEqual(captured["body"]["jarvis_version"], __version__)
+		self.assertEqual(
+			captured["body"],
+			{
+				"jarvis_version": __version__,
+				"jarvis_branch": "version-16",
+				"jarvis_tag": "v16.1.0",
+			},
+		)
 
 	def test_renew_posts_to_renew_and_unwraps_order(self):
 		_settings_for_admin(api_key="renew-key", api_secret="renew-secret")

--- a/jarvis/tests/test_source_version.py
+++ b/jarvis/tests/test_source_version.py
@@ -1,4 +1,4 @@
-"""Source revision reporting is exact and fails soft outside a Git checkout."""
+"""Source revision reporting is exact, remembers only real answers, and fails soft."""
 
 import subprocess
 from types import SimpleNamespace
@@ -8,9 +8,16 @@ from unittest.mock import patch
 from jarvis import source_version
 
 
+def _git(returncode: int, stdout: str) -> SimpleNamespace:
+	return SimpleNamespace(returncode=returncode, stdout=stdout)
+
+
 class TestSourceDetails(TestCase):
+	def setUp(self):
+		source_version.reset_cache()
+
 	def tearDown(self):
-		source_version.source_details.cache_clear()
+		source_version.reset_cache()
 
 	def test_reports_branch_and_exact_release_tag(self):
 		with patch.object(source_version, "_git_value", side_effect=["version-16", "v16.1.0"]):
@@ -19,20 +26,42 @@ class TestSourceDetails(TestCase):
 				{"branch": "version-16", "tag": "v16.1.0"},
 			)
 
-	def test_values_are_cached_for_repeated_connection_polls(self):
-		with patch.object(source_version, "_git_value", side_effect=["develop", None]) as git_value:
+	def test_answers_are_cached_for_repeated_connection_polls(self):
+		# An empty answer is still an answer (detached / untagged) and is cached like any other.
+		with patch.object(source_version, "_git_value", side_effect=["develop", ""]) as git_value:
 			source_version.source_details()
-			source_version.source_details()
+			self.assertEqual(source_version.source_details(), {"branch": "develop", "tag": ""})
 		self.assertEqual(git_value.call_count, 2)
 
-	def test_git_failure_and_detached_head_are_unknown(self):
+	def test_unknown_value_is_reported_as_none_and_asked_again(self):
+		# A timed-out git call must not be memoised as "no branch": the next poll retries it, and
+		# in the meantime the caller sees None rather than a blank it would clear upstream with.
+		with patch.object(
+			source_version, "_git_value", side_effect=[None, "v16.1.0", "version-16"]
+		) as git_value:
+			self.assertEqual(source_version.source_details(), {"branch": None, "tag": "v16.1.0"})
+			self.assertEqual(source_version.source_details(), {"branch": "version-16", "tag": "v16.1.0"})
+		self.assertEqual(git_value.call_count, 3)
+
+
+class TestGitValue(TestCase):
+	def test_detached_head_and_missing_tag_are_confirmed_blanks(self):
+		with patch.object(source_version.subprocess, "run", side_effect=[_git(0, "\n"), _git(128, "")]):
+			self.assertEqual(source_version._git_value("branch", "--show-current"), "")
+			self.assertEqual(source_version._git_value("describe", "--tags", "--exact-match"), "")
+
+	def test_timeout_and_os_error_are_unknown(self):
 		with patch.object(
 			source_version.subprocess,
 			"run",
-			side_effect=[
-				SimpleNamespace(returncode=0, stdout="\n"),
-				subprocess.TimeoutExpired("git", 2),
-			],
+			side_effect=[subprocess.TimeoutExpired("git", 2), OSError("fork failed")],
 		):
 			self.assertIsNone(source_version._git_value("branch", "--show-current"))
 			self.assertIsNone(source_version._git_value("describe", "--tags", "--exact-match"))
+
+	def test_only_a_release_shaped_tag_counts(self):
+		with patch.object(
+			source_version.subprocess, "run", side_effect=[_git(0, "v1-beta\n"), _git(0, "v16.2.0\n")]
+		):
+			self.assertEqual(source_version._git_value("describe", "--tags", "--exact-match"), "")
+			self.assertEqual(source_version._git_value("describe", "--tags", "--exact-match"), "v16.2.0")

--- a/jarvis/tests/test_source_version.py
+++ b/jarvis/tests/test_source_version.py
@@ -1,0 +1,38 @@
+"""Source revision reporting is exact and fails soft outside a Git checkout."""
+
+import subprocess
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from jarvis import source_version
+
+
+class TestSourceDetails(TestCase):
+	def tearDown(self):
+		source_version.source_details.cache_clear()
+
+	def test_reports_branch_and_exact_release_tag(self):
+		with patch.object(source_version, "_git_value", side_effect=["version-16", "v16.1.0"]):
+			self.assertEqual(
+				source_version.source_details(),
+				{"branch": "version-16", "tag": "v16.1.0"},
+			)
+
+	def test_values_are_cached_for_repeated_connection_polls(self):
+		with patch.object(source_version, "_git_value", side_effect=["develop", None]) as git_value:
+			source_version.source_details()
+			source_version.source_details()
+		self.assertEqual(git_value.call_count, 2)
+
+	def test_git_failure_and_detached_head_are_unknown(self):
+		with patch.object(
+			source_version.subprocess,
+			"run",
+			side_effect=[
+				SimpleNamespace(returncode=0, stdout="\n"),
+				subprocess.TimeoutExpired("git", 2),
+			],
+		):
+			self.assertIsNone(source_version._git_value("branch", "--show-current"))
+			self.assertIsNone(source_version._git_value("describe", "--tags", "--exact-match"))


### PR DESCRIPTION
## Summary

Customer benches now tell the control plane which Git branch and exact release tag they run, so support sees "Branch: version-16 / Version: v16.2.0" on a Helpdesk ticket instead of inferring it from the package version.

- The connection sync (`get_connection`) sends `jarvis_branch` and `jarvis_tag` alongside `jarvis_version`.
- Detection is best-effort and never guesses. When Git confirms there is no branch or tag (detached, untagged, not a Git checkout) the bench sends `""` so stale metadata upstream is cleared. When Git does not answer in time the key is omitted, the admin keeps what it has, and the value is asked again on the next poll.
- Only real answers are cached per process, so the ~2 min connection poll never re-forks git and a one-off timeout can never be memoised as a blank.

**Compatibility and rollout**
- An older admin ignores the extra keys (Frappe filters kwargs to the endpoint signature), so this can ship in any order without breaking the poll.
- Intended deploy order: 1. jarvis-admin-v2 migrate, 2. this customer app update, 3. jarvis-helpdesk migrate. Existing tickets pick the rows up on their next context refresh.

**Companion PRs**
- Control plane: https://github.com/Aerele-RnD/jarvis-admin-v2/pull/481
- Helpdesk: https://github.com/Aerele-RnD/jarvis-helpdesk/pull/10

**Tests run**
- `python -m unittest jarvis.tests.test_source_version`: 6 passed
- `bench --site site.jarvis run-tests --app jarvis --module jarvis.tests.test_admin_client`: 118 passed
- `ruff check` on the four touched files and pre-commit with the pinned ruff v0.14.10: clean

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01J9uEnRVbk6kxw2Qr5K5eMU
