### PR TITLE
style(release): drop em-dashes from the update banner + pill copy

### DIFF
--- a/frontend/src/components/chat/UpdateBanner.vue
+++ b/frontend/src/components/chat/UpdateBanner.vue
@@ -46,7 +46,7 @@ const props = defineProps({
 	pill: { type: Object, default: null },
 });
 
-const message = `A new version of ${agentName} is available — ask your administrator to update.`;
+const message = `A new version of ${agentName} is available. Ask your administrator to update.`;
 
 // Severity drives the Banner's colour, mirroring the pill - single-sourced via
 // bannerToneFor (releaseNudge.js) so the pill and banner can never disagree, and

--- a/frontend/src/components/chat/VersionPill.vue
+++ b/frontend/src/components/chat/VersionPill.vue
@@ -39,9 +39,9 @@ const pulsing = ref(false);
 
 // Boot payload is stable for the page's lifetime, so derive once.
 const pill = pillFor(notice, agentName);
-// The screen-reader label names the action ("… — see what's new"); the visible
+// The screen-reader label names the action ("…, see what's new"); the visible
 // text stays the terse status label. Only meaningful when the pill renders.
-const pillAriaLabel = pill.show ? `${pill.label} — see what's new` : "";
+const pillAriaLabel = pill.show ? `${pill.label}, see what's new` : "";
 
 // The soft banner's minimise-into-pill animation calls this as the banner
 // "arrives", for a small catch-pulse. Restart-safe on repeat dismisses; the

--- a/pwa/src/components/UpdateBanner.vue
+++ b/pwa/src/components/UpdateBanner.vue
@@ -18,7 +18,7 @@ import { agentName } from "@/branding";
 import { bannerToneFor } from "@shared/releaseNudge";
 import { notice, pillHandle, snoozeBanner, openWhatsNew } from "../noticeGate";
 
-const message = `A new version of ${agentName} is available — ask your administrator to update.`;
+const message = `A new version of ${agentName} is available. Ask your administrator to update.`;
 
 // Severity drives the banner's colour, mirroring the pill - single-sourced via
 // bannerToneFor (releaseNudge.js) so the pill and banner can never disagree, and

--- a/pwa/src/components/VersionPill.vue
+++ b/pwa/src/components/VersionPill.vue
@@ -16,9 +16,9 @@ const pulsing = ref(false);
 
 // Boot payload is stable for the page's lifetime, so derive once.
 const pill = pillFor(notice, agentName);
-// The screen-reader label names the action ("… — see what's new"); the visible
+// The screen-reader label names the action ("…, see what's new"); the visible
 // text stays the terse status label. Only meaningful when the pill renders.
-const pillAriaLabel = pill.show ? `${pill.label} — see what's new` : "";
+const pillAriaLabel = pill.show ? `${pill.label}, see what's new` : "";
 
 // The soft banner's minimise-into-pill animation calls this as the banner
 // "arrives", for a small catch-pulse. Restart-safe on repeat dismisses; the


### PR DESCRIPTION
The customer-facing banner message and the version pill's screen-reader label used an em-dash. Reword to a period (banner) and a comma (aria label) so the copy carries no em-dash. No behaviour change.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
