### PR TITLE
perf(connectors): list connector actions with one child-table query

### DIFF
--- a/jarvis/chat/connectors_api.py
+++ b/jarvis/chat/connectors_api.py
@@ -98,7 +98,7 @@ import frappe
 from frappe import _
 from frappe.utils import cint, get_datetime, get_system_timezone, get_url, now_datetime
 
-from jarvis.connectors import broker, catalog, mcp_oauth, mcp_oauth_store, oauth
+from jarvis.connectors import action_rows, broker, catalog, mcp_oauth, mcp_oauth_store, oauth
 from jarvis.permissions import has_jarvis_admin_access, require_jarvis_user
 
 CONNECTOR = "Jarvis Connector"
@@ -239,21 +239,12 @@ def _action_summary(allowed: int, total: int) -> dict:
 
 
 def _action_summaries(parent_names: list[str]) -> dict[str, dict]:
-	"""One aggregate query mapping ``connector name -> {allowed, total}`` over
-	its ``allowed_actions`` children — avoids an N+1 when listing."""
-	if not parent_names:
-		return {}
-	rows = frappe.get_all(
-		ACTION_DT,
-		filters={"parent": ["in", parent_names], "parenttype": CONNECTOR},
-		fields=["parent", "allowed"],
-	)
+	"""One bounded query mapping ``connector name -> {allowed, total}`` over
+	its ``allowed_actions`` children (``jarvis.connectors.action_rows``, shared
+	with the agent's discovery tool) — avoids an N+1 when listing."""
 	out: dict[str, dict] = {}
-	for row in rows:
-		summary = out.setdefault(row["parent"], _action_summary(0, 0))
-		summary["total"] += 1
-		if row["allowed"]:
-			summary["allowed"] += 1
+	for parent, rows in action_rows.by_parent(parent_names, ["allowed"]).items():
+		out[parent] = _action_summary(sum(1 for row in rows if row["allowed"]), len(rows))
 	return out
 
 

--- a/jarvis/connectors/action_rows.py
+++ b/jarvis/connectors/action_rows.py
@@ -1,0 +1,41 @@
+"""The ``allowed_actions`` child rows of a set of connectors, in ONE bounded
+``frappe.get_all``. Shared by the agent-facing discovery tool
+(``jarvis.tools.list_connector_actions``) and the Settings list
+(``jarvis.chat.connectors_api``) so the N+1 avoidance and its permission
+reasoning live in exactly one place.
+
+``get_all`` skips Frappe's permission check and a child DocType has no
+permission hook of its own, so ``parent_names`` MUST come from a
+permission-checked parent query (``frappe.get_list`` under the calling user).
+That bounding is the permission boundary; nothing in here adds one.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+CONNECTOR_DOCTYPE = "Jarvis Connector"
+ACTION_DOCTYPE = "Jarvis Connector Action"
+ACTIONS_FIELD = "allowed_actions"
+
+
+def by_parent(parent_names: list[str], fields: list[str]) -> dict[str, list[dict]]:
+	"""``{connector name: [child row, ...]}`` for ``parent_names``, each row
+	carrying ``fields`` plus ``parent``, in stored (``idx``) order. A parent
+	with no rows is absent, so read with ``.get(name, [])``."""
+	if not parent_names:
+		return {}
+	rows = frappe.get_all(
+		ACTION_DOCTYPE,
+		filters={
+			"parent": ["in", parent_names],
+			"parenttype": CONNECTOR_DOCTYPE,
+			"parentfield": ACTIONS_FIELD,
+		},
+		fields=["parent", *fields],
+		order_by="parent asc, idx asc",
+	)
+	grouped: dict[str, list[dict]] = {}
+	for row in rows:
+		grouped.setdefault(row["parent"], []).append(row)
+	return grouped

--- a/jarvis/tests/test_connector_tools.py
+++ b/jarvis/tests/test_connector_tools.py
@@ -13,7 +13,8 @@ these run with no site. What is proven here:
     the broker's own, more specific error instead;
   * when the connector is ready, ``call_connector`` delegates to
     ``jarvis.connectors.broker.call`` verbatim (result unmodified);
-  * ``list_connector_actions`` dedupes Personal-over-Shared by key and
+  * ``list_connector_actions`` dedupes Personal-over-Shared by key, fetches
+    child rows in one bounded ``get_all``, and
     surfaces only the actions ``policy.action_decision`` currently allows.
 
 Real broker dispatch (row resolution, credential decrypt, the allowed-actions
@@ -139,77 +140,100 @@ class TestCallConnectorReadiness(unittest.TestCase):
 		self.assertEqual(result, broker_result)
 
 
-class _Row(dict):
-	"""Minimal Document-like stand-in exposing attribute access + ``.get``,
-	matching what ``jarvis.connectors.policy`` and the tool expect."""
-
-	def __getattr__(self, name):
-		try:
-			return self[name]
-		except KeyError as exc:
-			raise AttributeError(name) from exc
-
-
 class TestListConnectorActionsShape(unittest.TestCase):
-	"""Enabled path: dedupe-by-key (Personal wins), and only policy-allowed
+	"""Enabled path: dedupe-by-key (Personal wins), child rows fetched in ONE
+	``get_all`` bounded to the surviving parent names, and only policy-allowed
 	actions are surfaced. Exercises the real ``jarvis.connectors.policy`` gate
-	(frappe-free), with ``frappe.get_list``/``get_doc`` mocked."""
+	(frappe-free), with ``frappe.get_list``/``get_all`` mocked."""
 
-	def _action(self, action, allowed=0, read_only=0, destructive=0, description="d"):
-		return _Row(
-			action=action,
-			allowed=allowed,
-			read_only=read_only,
-			destructive=destructive,
-			description=description,
-		)
+	def _action(self, parent, action, allowed=0, read_only=0, destructive=0, description="d"):
+		return {
+			"parent": parent,
+			"action": action,
+			"allowed": allowed,
+			"read_only": read_only,
+			"destructive": destructive,
+			"description": description,
+		}
 
-	def _connector_doc(self, name, key, label, scope, actions):
-		return _Row(name=name, key=key, label=label, scope=scope, allowed_actions=actions)
+	def _fake_frappe(self, connectors, actions):
+		fake = mock.MagicMock()
+		fake.get_list.return_value = connectors
+		# Set explicitly in every test: a bare MagicMock iterates as empty, so a
+		# forgotten return value would pass vacuously with zero actions.
+		fake.get_all.return_value = actions
+		return fake
+
+	def _run(self, fake_frappe, connector=None):
+		with mock.patch.object(list_connector_actions, "frappe", fake_frappe):
+			return list_connector_actions.list_connector_actions(connector)
 
 	def test_personal_wins_over_shared_same_key(self):
-		fake_frappe = mock.MagicMock()
-		# order_by="scope asc, ..." puts Personal ("P") before Shared ("S").
-		fake_frappe.get_list.return_value = [
-			{"name": "conn-personal", "key": "github", "label": "My GitHub", "scope": "Personal"},
-			{"name": "conn-shared", "key": "github", "label": "Team GitHub", "scope": "Shared"},
-		]
-		personal_doc = self._connector_doc(
-			"conn-personal",
-			"github",
-			"My GitHub",
-			"Personal",
-			[self._action("read_issue", read_only=1)],
+		fake = self._fake_frappe(
+			[
+				# order_by="scope asc, ..." puts Personal ("P") before Shared ("S").
+				{"name": "conn-personal", "key": "github", "label": "My GitHub", "scope": "Personal"},
+				{"name": "conn-shared", "key": "github", "label": "Team GitHub", "scope": "Shared"},
+			],
+			[self._action("conn-personal", "read_issue", read_only=1)],
 		)
-		fake_frappe.get_doc.return_value = personal_doc
-		with mock.patch.object(list_connector_actions, "frappe", fake_frappe):
-			result = list_connector_actions.list_connector_actions()
+		result = self._run(fake)
 		self.assertEqual(len(result["connectors"]), 1)
 		self.assertEqual(result["connectors"][0]["scope"], "Personal")
-		fake_frappe.get_doc.assert_called_once_with("Jarvis Connector", "conn-personal")
+		self.assertEqual([a["action"] for a in result["connectors"][0]["actions"]], ["read_issue"])
+		# One child-table query, bounded to the surviving parent only: the
+		# shadowed Shared duplicate's rows are never fetched, and no full
+		# document is ever loaded.
+		fake.get_all.assert_called_once()
+		self.assertEqual(fake.get_all.call_args.args[0], "Jarvis Connector Action")
+		filters = fake.get_all.call_args.kwargs["filters"]
+		self.assertEqual(filters["parent"], ["in", ["conn-personal"]])
+		self.assertEqual(filters["parenttype"], "Jarvis Connector")
+		self.assertEqual(filters["parentfield"], "allowed_actions")
+		fake.get_doc.assert_not_called()
 
 	def test_only_policy_allowed_actions_are_surfaced(self):
-		fake_frappe = mock.MagicMock()
-		fake_frappe.get_list.return_value = [
-			{"name": "conn-1", "key": "github", "label": "GitHub", "scope": "Shared"}
-		]
-		doc = self._connector_doc(
-			"conn-1",
-			"github",
-			"GitHub",
-			"Shared",
+		fake = self._fake_frappe(
+			[{"name": "conn-1", "key": "github", "label": "GitHub", "scope": "Shared"}],
 			[
-				self._action("read_issue", read_only=1, destructive=0),
-				self._action("delete_repo", read_only=0, destructive=1, allowed=0),
-				self._action("create_issue", allowed=1),
+				self._action("conn-1", "read_issue", read_only=1, destructive=0),
+				self._action("conn-1", "delete_repo", read_only=0, destructive=1, allowed=0),
+				self._action("conn-1", "create_issue", allowed=1),
 			],
 		)
-		fake_frappe.get_doc.return_value = doc
-		with mock.patch.object(list_connector_actions, "frappe", fake_frappe):
-			result = list_connector_actions.list_connector_actions()
+		result = self._run(fake)
 		actions = {a["action"] for a in result["connectors"][0]["actions"]}
 		self.assertEqual(actions, {"read_issue", "create_issue"})
 		self.assertNotIn("delete_repo", actions)
+
+	def test_child_rows_are_grouped_per_connector_in_query_order(self):
+		fake = self._fake_frappe(
+			[
+				{"name": "conn-gh", "key": "github", "label": "GitHub", "scope": "Shared"},
+				{"name": "conn-jira", "key": "jira", "label": "Jira", "scope": "Shared"},
+			],
+			[
+				self._action("conn-gh", "read_issue", read_only=1),
+				self._action("conn-jira", "create_issue", allowed=1),
+				self._action("conn-gh", "create_pr", allowed=1),
+			],
+		)
+		result = self._run(fake)
+		by_key = {c["connector"]: [a["action"] for a in c["actions"]] for c in result["connectors"]}
+		self.assertEqual(by_key, {"github": ["read_issue", "create_pr"], "jira": ["create_issue"]})
+
+	def test_connector_without_child_rows_has_empty_actions(self):
+		fake = self._fake_frappe(
+			[{"name": "conn-1", "key": "github", "label": "GitHub", "scope": "Shared"}], []
+		)
+		result = self._run(fake)
+		self.assertEqual(result["connectors"][0]["actions"], [])
+
+	def test_no_visible_connectors_skips_child_query(self):
+		fake = self._fake_frappe([], [])
+		result = self._run(fake)
+		self.assertEqual(result, {"connectors": []})
+		fake.get_all.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/jarvis/tests/test_connector_tools.py
+++ b/jarvis/tests/test_connector_tools.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
+from jarvis.connectors import action_rows
 from jarvis.tools import call_connector, list_connector_actions
 
 
@@ -144,7 +145,7 @@ class TestListConnectorActionsShape(unittest.TestCase):
 	"""Enabled path: dedupe-by-key (Personal wins), child rows fetched in ONE
 	``get_all`` bounded to the surviving parent names, and only policy-allowed
 	actions are surfaced. Exercises the real ``jarvis.connectors.policy`` gate
-	(frappe-free), with ``frappe.get_list``/``get_all`` mocked."""
+	(frappe-free), with ``frappe.get_list`` and the shared ``action_rows`` fetch mocked."""
 
 	def _action(self, parent, action, allowed=0, read_only=0, destructive=0, description="d"):
 		return {
@@ -165,7 +166,10 @@ class TestListConnectorActionsShape(unittest.TestCase):
 		return fake
 
 	def _run(self, fake_frappe, connector=None):
-		with mock.patch.object(list_connector_actions, "frappe", fake_frappe):
+		with (
+			mock.patch.object(list_connector_actions, "frappe", fake_frappe),
+			mock.patch.object(action_rows, "frappe", fake_frappe),
+		):
 			return list_connector_actions.list_connector_actions(connector)
 
 	def test_personal_wins_over_shared_same_key(self):

--- a/jarvis/tools/list_connector_actions.py
+++ b/jarvis/tools/list_connector_actions.py
@@ -8,11 +8,11 @@ query ALONE: connectors come from ``frappe.get_list`` (permission-checked,
 unlike ``get_all``) under the caller's impersonated identity, never
 hand-filtered by owner, so it cannot leak a row the permission hook would have
 denied. The child rows then come from ONE ``frappe.get_all`` on ``Jarvis
-Connector Action`` bounded to exactly those surviving parent names (plus
-``parenttype``/``parentfield``, so it reads only this table field's own rows).
-``get_all`` skips Frappe's permission check and a child DocType has no
-permission hook of its own, so that bounding is load-bearing: it is safe only
-because ``names`` never holds a row the caller could not list.
+Connector Action`` (``jarvis.connectors.action_rows``, shared with the
+Settings list) bounded to exactly those surviving parent names. ``get_all``
+skips Frappe's permission check and a child DocType has no permission hook of
+its own, so that bounding is load-bearing: it is safe only because ``names``
+never holds a row the caller could not list.
 
 Why not ``frappe.get_doc`` per connector: nothing here mutates a document or
 needs a Document method, and a full load pulls every parent column (the whole
@@ -32,11 +32,10 @@ from __future__ import annotations
 
 import frappe
 
-from jarvis.connectors import policy
+from jarvis.connectors import action_rows, policy
+from jarvis.connectors.action_rows import ACTIONS_FIELD, CONNECTOR_DOCTYPE
 
-CONNECTOR_DOCTYPE = "Jarvis Connector"
-ACTION_DOCTYPE = "Jarvis Connector Action"
-ACTIONS_FIELD = "allowed_actions"
+_ACTION_FIELDS = ["action", "allowed", "read_only", "destructive", "description"]
 
 _MAX_CONNECTORS = 30
 _MAX_ACTIONS_PER_CONNECTOR = 50
@@ -74,7 +73,7 @@ def list_connector_actions(connector: str | None = None) -> dict:
 	for row in rows:
 		by_key.setdefault(row["key"], row)
 
-	actions_by_parent = _actions_by_parent([row["name"] for row in by_key.values()])
+	actions_by_parent = action_rows.by_parent([row["name"] for row in by_key.values()], _ACTION_FIELDS)
 	return {
 		"connectors": [
 			{
@@ -86,24 +85,6 @@ def list_connector_actions(connector: str | None = None) -> dict:
 			for row in by_key.values()
 		]
 	}
-
-
-def _actions_by_parent(names: list[str]) -> dict[str, list[dict]]:
-	"""One query for every surviving connector's ``allowed_actions`` rows,
-	grouped by parent in stored (``idx``) order. ``names`` must come from the
-	permission-checked parent query (see the module docstring)."""
-	if not names:
-		return {}
-	children = frappe.get_all(
-		ACTION_DOCTYPE,
-		filters={"parent": ["in", names], "parenttype": CONNECTOR_DOCTYPE, "parentfield": ACTIONS_FIELD},
-		fields=["parent", "action", "allowed", "read_only", "destructive", "description"],
-		order_by="parent asc, idx asc",
-	)
-	grouped: dict[str, list[dict]] = {}
-	for child in children:
-		grouped.setdefault(child["parent"], []).append(child)
-	return grouped
 
 
 def _allowed_actions(children: list[dict]) -> list[dict]:

--- a/jarvis/tools/list_connector_actions.py
+++ b/jarvis/tools/list_connector_actions.py
@@ -3,11 +3,21 @@ allowed actions) the calling user may reach through ``call_connector``.
 
 Per-user, like the SPA pane: a Shared connector is visible to every tenant
 user, a Personal connector only to its owner
-(``jarvis.chat.connector_permissions``). This tool relies ENTIRELY on Frappe
-row permissions under the caller's impersonated identity - it queries with
-``frappe.get_list`` (permission-checked, unlike ``get_all``) and never
-hand-filters by owner itself, so it cannot leak a row the permission hook
-would have denied.
+(``jarvis.chat.connector_permissions``). The permission boundary is the parent
+query ALONE: connectors come from ``frappe.get_list`` (permission-checked,
+unlike ``get_all``) under the caller's impersonated identity, never
+hand-filtered by owner, so it cannot leak a row the permission hook would have
+denied. The child rows then come from ONE ``frappe.get_all`` on ``Jarvis
+Connector Action`` bounded to exactly those surviving parent names (plus
+``parenttype``/``parentfield``, so it reads only this table field's own rows).
+``get_all`` skips Frappe's permission check and a child DocType has no
+permission hook of its own, so that bounding is load-bearing: it is safe only
+because ``names`` never holds a row the caller could not list.
+
+Why not ``frappe.get_doc`` per connector: nothing here mutates a document or
+needs a Document method, and a full load pulls every parent column (the whole
+``tools_cache`` blob and the encrypted credential included) plus a child SELECT
+each, per connector, per chat turn, just to read four flags per action.
 
 Each connector's actions are read from its ``allowed_actions`` child rows (the
 same stored flags ``jarvis.connectors.broker``/``policy`` gate a real call
@@ -25,6 +35,8 @@ import frappe
 from jarvis.connectors import policy
 
 CONNECTOR_DOCTYPE = "Jarvis Connector"
+ACTION_DOCTYPE = "Jarvis Connector Action"
+ACTIONS_FIELD = "allowed_actions"
 
 _MAX_CONNECTORS = 30
 _MAX_ACTIONS_PER_CONNECTOR = 50
@@ -62,31 +74,50 @@ def list_connector_actions(connector: str | None = None) -> dict:
 	for row in rows:
 		by_key.setdefault(row["key"], row)
 
-	connectors = []
-	for row in by_key.values():
-		doc = frappe.get_doc(CONNECTOR_DOCTYPE, row["name"])
-		connectors.append(
+	actions_by_parent = _actions_by_parent([row["name"] for row in by_key.values()])
+	return {
+		"connectors": [
 			{
-				"connector": doc.key,
-				"label": doc.label,
-				"scope": doc.scope,
-				"actions": _allowed_actions(doc),
+				"connector": row["key"],
+				"label": row["label"],
+				"scope": row["scope"],
+				"actions": _allowed_actions(actions_by_parent.get(row["name"], [])),
 			}
-		)
-	return {"connectors": connectors}
+			for row in by_key.values()
+		]
+	}
 
 
-def _allowed_actions(doc) -> list[dict]:
-	"""The subset of ``doc``'s configured actions ``policy.action_decision``
-	currently permits, each trimmed to a compact ``{action, description}``."""
+def _actions_by_parent(names: list[str]) -> dict[str, list[dict]]:
+	"""One query for every surviving connector's ``allowed_actions`` rows,
+	grouped by parent in stored (``idx``) order. ``names`` must come from the
+	permission-checked parent query (see the module docstring)."""
+	if not names:
+		return {}
+	children = frappe.get_all(
+		ACTION_DOCTYPE,
+		filters={"parent": ["in", names], "parenttype": CONNECTOR_DOCTYPE, "parentfield": ACTIONS_FIELD},
+		fields=["parent", "action", "allowed", "read_only", "destructive", "description"],
+		order_by="parent asc, idx asc",
+	)
+	grouped: dict[str, list[dict]] = {}
+	for child in children:
+		grouped.setdefault(child["parent"], []).append(child)
+	return grouped
+
+
+def _allowed_actions(children: list[dict]) -> list[dict]:
+	"""The subset of ``children`` ``policy.action_decision`` currently permits,
+	each trimmed to a compact ``{action, description}``."""
+	row = {ACTIONS_FIELD: children}
 	actions = []
-	for child in doc.allowed_actions or []:
-		if policy.action_decision(doc, child.action) is not None:
+	for child in children:
+		if policy.action_decision(row, child["action"]) is not None:
 			continue
 		actions.append(
 			{
-				"action": child.action,
-				"description": (child.description or "")[:_DESCRIPTION_MAX],
+				"action": child["action"],
+				"description": (child.get("description") or "")[:_DESCRIPTION_MAX],
 			}
 		)
 		if len(actions) >= _MAX_ACTIONS_PER_CONNECTOR:


### PR DESCRIPTION
## Summary

The agent's connector discovery tool now reads each connector's allowed actions with one narrow child-table query instead of loading the full document per connector. Nobody sees a behaviour change. A chat turn that lists connectors runs 2 queries instead of 1 plus 2 per connector, and no longer loads and parses every connector's cached tool-schema blob and encrypted credential just to read four flags per action.

**What changed**
- New `jarvis.connectors.action_rows.by_parent`: one `get_all` on Jarvis Connector Action bounded to the permission-checked parent names (parent in names, plus parenttype and parentfield), grouped per connector in stored order.
- The agent tool `list_connector_actions` and the Settings list (`_action_summaries` in connectors_api) both use it. Review of the first commit found the two had drifted (one filtered by parentfield, one did not); now there is one implementation.
- Module docstring states the real permission boundary: the parent `get_list` is the check, the child query is bounded by it.
- Tests cover: child rows fetched once, the shadowed Shared duplicate never queried, grouping per connector in stored order, no child rows, no visible connectors.

**Risk and verification**
- Output unchanged: live before/after on e2e.localhost against a real connector returned identical JSON for both the tool and the Settings list.
- 21 frappe-free unit tests pass; the 6 Settings-list test classes (22 tests) pass on a bench site; pre-commit (ruff) passes.

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_0144RLWnUVMuf2H1AARESuPQ
