### PR TITLE
feat(announcements): Slice B — bench announcement banner + per-device frequency (SPA+PWA, DARK)

### DIFF
--- a/frontend/src/announcementGate.js
+++ b/frontend/src/announcementGate.js
@@ -1,0 +1,48 @@
+// Customer announcement, delivered by the www/jarvis.py boot payload as
+// window.announcement = {active, id, title, message, severity, link_url,
+// link_label, interval_days, expires_on}. A SOFT, dismissible banner (unlike the
+// release notice's full-page gate) whose re-show cadence lives per-device in
+// localStorage via the shared, node-testable `announcementNudge.js`. Mirrors
+// src/noticeGate.js's idiom, minus the hard gate / What's-new / recheck.
+import { computed, ref } from "vue";
+import { bannerShouldShow, writeSnooze, readSnooze } from "@/announcementNudge";
+import { session } from "@/data/session";
+
+const a = window.announcement || {};
+
+// Namespace the snooze by the signed-in user (same source noticeGate reads), so
+// two people sharing a browser profile keep independent snoozes; guest -> "anon".
+const userId = session.user || "anon";
+
+// The boot payload is stable for the page's lifetime, so this is a plain object
+// (not reactive): bannerShouldShow()/bannerToneFor() read it, and it never changes.
+export const announcement = {
+	active: !!a.active,
+	id: a.id || "",
+	title: a.title || "",
+	message: a.message || "",
+	severity: a.severity || "",
+	link_url: a.link_url || "",
+	link_label: a.link_label || "",
+	interval_days: Number(a.interval_days) || 7,
+};
+
+// The snooze lives in localStorage; this ref mirrors it so the banner hides
+// reactively the moment it is dismissed. Seeded from storage at boot (a read-throw
+// reads as not-snoozed, so the banner shows - see readSnooze()).
+const snooze = ref(readSnooze(userId));
+
+// Reactive: active AND not currently snoozed. `Date.now()` is read at evaluation
+// time; the only reactive dependency is `snooze`, so dismissing (which replaces the
+// ref below) recomputes this to false and the banner hides.
+export const showAnnouncement = computed(
+	() => !!announcement.active && bannerShouldShow(announcement, Date.now(), snooze.value)
+);
+
+// Dismiss: persist the snooze (best-effort) AND update the ref in-memory so
+// `showAnnouncement` flips to false immediately. writeSnooze returns the exact
+// record it wrote, so the ref and storage never disagree and the math lives in one
+// place (H8) - a localStorage write-throw still hides the banner this session.
+export function dismissAnnouncement() {
+	snooze.value = writeSnooze(announcement, Date.now(), userId);
+}

--- a/frontend/src/announcementGate.spec.js
+++ b/frontend/src/announcementGate.spec.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The gate reads window.announcement + the signed-in user ONCE at import, so each
+// scenario resets the module registry and re-imports with a fresh window payload
+// (the globalNotifier.spec pattern). Covers: the active gate, the id-keyed snooze
+// seeded at boot, and the reactive hide on dismiss.
+vi.mock("@/data/session", () => ({ session: { user: "u@example.com" } }));
+
+const SNOOZE_KEY = "jarvis-announcement-banner-snooze:u@example.com";
+
+const storage = new Map();
+vi.stubGlobal("localStorage", {
+	getItem: (k) => (storage.has(k) ? storage.get(k) : null),
+	setItem: (k, v) => storage.set(k, String(v)),
+	removeItem: (k) => storage.delete(k),
+	clear: () => storage.clear(),
+});
+
+/** Reset modules + storage, seed an optional boot snooze, set window.announcement,
+ *  then import a fresh copy of the gate. */
+async function loadGate(announcement, seedSnooze) {
+	vi.resetModules();
+	storage.clear();
+	if (seedSnooze) storage.set(SNOOZE_KEY, JSON.stringify(seedSnooze));
+	window.announcement = announcement;
+	return import("@/announcementGate");
+}
+
+describe("announcementGate", () => {
+	it("shows when active and never snoozed", async () => {
+		const { showAnnouncement } = await loadGate({
+			active: true,
+			id: "ANN-1",
+			interval_days: 7,
+		});
+		expect(showAnnouncement.value).toBe(true);
+	});
+
+	it("is hidden when the announcement is inactive", async () => {
+		const { showAnnouncement } = await loadGate({ active: false, id: "ANN-1" });
+		expect(showAnnouncement.value).toBe(false);
+	});
+
+	it("hides reactively the moment it is dismissed", async () => {
+		const { showAnnouncement, dismissAnnouncement } = await loadGate({
+			active: true,
+			id: "ANN-1",
+			interval_days: 7,
+		});
+		expect(showAnnouncement.value).toBe(true);
+		dismissAnnouncement();
+		expect(showAnnouncement.value).toBe(false);
+		// The dismissal is persisted for the same id, so a re-import stays hidden.
+		const again = await loadGate(
+			{ active: true, id: "ANN-1", interval_days: 7 },
+			JSON.parse(storage.get(SNOOZE_KEY))
+		);
+		expect(again.showAnnouncement.value).toBe(false);
+	});
+
+	it("stays hidden at boot when an unexpired snooze for the SAME id exists", async () => {
+		const snooze = { id: "ANN-1", until: Date.now() + 30 * 86400000 };
+		const { showAnnouncement } = await loadGate(
+			{ active: true, id: "ANN-1", interval_days: 7 },
+			snooze
+		);
+		expect(showAnnouncement.value).toBe(false);
+	});
+
+	it("re-shows for a NEW id even under an unexpired old-id snooze", async () => {
+		const snooze = { id: "ANN-old", until: Date.now() + 30 * 86400000 };
+		const { showAnnouncement } = await loadGate(
+			{ active: true, id: "ANN-new", interval_days: 7 },
+			snooze
+		);
+		expect(showAnnouncement.value).toBe(true);
+	});
+});

--- a/frontend/src/announcementNudge.js
+++ b/frontend/src/announcementNudge.js
@@ -1,0 +1,84 @@
+// Shared announcement-banner display logic for both frontends: the SPA imports it
+// as `@/announcementNudge`, the mobile PWA as `@shared/announcementNudge` (one-way
+// share, see pwa/vite.config.js). Keep this a pure ES module - no `@/` imports and
+// no Vue - so `node --test` can resolve and run it without a bundler.
+//
+// The wire payload (window.announcement) is: { active, id, title, message,
+// severity, link_url, link_label, interval_days, expires_on }. The banner is a
+// SOFT, dismissible strip: dismiss snoozes it per-device for `interval_days`, keyed
+// by the announcement `id`, so a NEW announcement re-shows even under an old-id
+// snooze. Title/body render as PLAIN TEXT (auto-escaped, never v-html) and the CTA
+// is scheme-gated (isSafeLink) - the banner's whole XSS-safety rests on both.
+
+export const SNOOZE_KEY = "jarvis-announcement-banner-snooze";
+
+// The SINGLE `until` builder (H8): the caller (writeSnooze AND the gate's dismiss)
+// go through this, so the snooze math lives in exactly one place. `interval_days`
+// is floored to >= 1 day - a missing / zero / NaN interval defaults to 7, and a
+// negative one floors to 1 (never a snooze that has already expired).
+export function snoozeUntil(ann, now) {
+	const days = Math.max(1, Number(ann.interval_days) || 7);
+	return now + days * 86400000;
+}
+
+// The banner shows when the announcement is not currently snoozed: no snooze, a
+// snooze for a DIFFERENT announcement id (a new announcement supersedes an old
+// dismissal), or a snooze that has expired. `now` and `snooze` are passed in so
+// this stays pure and testable. (The `active` gate lives in the gate module - this
+// is purely the frequency check.)
+export function bannerShouldShow(ann, now, snooze) {
+	return !snooze || snooze.id !== ann.id || now > snooze.until;
+}
+
+// The Banner component's `type`, mapped from the announcement severity. Only
+// "Warning" paints amber; everything else (Info, blank, an unknown future value)
+// is the neutral "info" blue - never a false-alarm colour.
+export function bannerToneFor(ann) {
+	const sev = ann && ann.severity ? String(ann.severity).toLowerCase() : "";
+	return sev === "warning" ? "warning" : "info";
+}
+
+// The CTA is rendered ONLY for an http(s) URL - a scheme gate that blocks
+// javascript:/data:/protocol-relative and leading-whitespace tricks (the regex is
+// anchored at `^`, so " javascript:" and "\njavascript:" both fail). The banner
+// never renders a non-matching link.
+export function isSafeLink(url) {
+	return /^https?:\/\//i.test(url || "");
+}
+
+// Per-user, per-device snooze state. The key is namespaced by `userId` so two
+// people sharing a browser profile don't inherit each other's snooze (a missing
+// userId falls back to a stable "anon" bucket). `userId` is a PARAMETER, not an
+// import, so this module stays node-testable and single-sourced.
+//
+// Reads/writes are wrapped so a private-mode / quota / absent localStorage never
+// throws: a read-throw reads as not-snoozed (banner shows), a write-throw is
+// swallowed (the record is still returned so the caller hides the banner this
+// session; the snooze just doesn't persist and returns next boot - acceptable).
+function snoozeKey(userId) {
+	return `${SNOOZE_KEY}:${userId || "anon"}`;
+}
+
+export function readSnooze(userId) {
+	if (typeof localStorage === "undefined") return null;
+	try {
+		return JSON.parse(localStorage.getItem(snoozeKey(userId))) || null;
+	} catch {
+		return null;
+	}
+}
+
+// Builds the snooze record via the single `until` builder, persists it best-effort,
+// and RETURNS it so the caller reuses the exact record (no duplicated math - H8).
+export function writeSnooze(ann, now, userId) {
+	const record = { id: ann.id, until: snoozeUntil(ann, now) };
+	if (typeof localStorage !== "undefined") {
+		try {
+			localStorage.setItem(snoozeKey(userId), JSON.stringify(record));
+		} catch {
+			// swallow - a write failure must not break the dismiss; the returned
+			// record still hides the banner this session.
+		}
+	}
+	return record;
+}

--- a/frontend/src/announcementNudge.test.js
+++ b/frontend/src/announcementNudge.test.js
@@ -1,0 +1,180 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	snoozeUntil,
+	bannerShouldShow,
+	bannerToneFor,
+	isSafeLink,
+	readSnooze,
+	writeSnooze,
+	SNOOZE_KEY,
+} from "./announcementNudge.js";
+
+const DAY = 86400000;
+const NOW = 1_000_000_000_000; // frozen "now" for every time-based assertion
+
+// ---- snoozeUntil: the single floored builder -------------------------------
+
+test("snoozeUntil: a normal interval -> now + N days", () => {
+	assert.equal(snoozeUntil({ interval_days: 3 }, NOW), NOW + 3 * DAY);
+});
+
+test("snoozeUntil: missing / zero / NaN interval defaults to 7 days", () => {
+	assert.equal(snoozeUntil({}, NOW), NOW + 7 * DAY);
+	assert.equal(snoozeUntil({ interval_days: 0 }, NOW), NOW + 7 * DAY);
+	assert.equal(snoozeUntil({ interval_days: "abc" }, NOW), NOW + 7 * DAY);
+});
+
+test("snoozeUntil: a negative interval floors to 1 day (never an already-expired snooze)", () => {
+	assert.equal(snoozeUntil({ interval_days: -5 }, NOW), NOW + 1 * DAY);
+});
+
+// ---- bannerShouldShow ------------------------------------------------------
+
+test("bannerShouldShow: never snoozed -> true", () => {
+	assert.equal(bannerShouldShow({ id: "ANN-1" }, NOW, null), true);
+});
+
+test("bannerShouldShow: same id, unexpired snooze -> false (hides within the interval)", () => {
+	const snooze = { id: "ANN-1", until: NOW + DAY };
+	assert.equal(bannerShouldShow({ id: "ANN-1" }, NOW, snooze), false);
+});
+
+test("bannerShouldShow: same id, expired snooze -> true (re-shows after the interval)", () => {
+	const snooze = { id: "ANN-1", until: NOW - 1 };
+	assert.equal(bannerShouldShow({ id: "ANN-1" }, NOW, snooze), true);
+});
+
+test("bannerShouldShow: a NEW id re-shows even under an unexpired old-id snooze", () => {
+	const snooze = { id: "ANN-1", until: NOW + 999 * DAY };
+	assert.equal(bannerShouldShow({ id: "ANN-2" }, NOW, snooze), true);
+});
+
+// ---- bannerToneFor ---------------------------------------------------------
+
+test("bannerToneFor: Warning -> warning; everything else -> info", () => {
+	assert.equal(bannerToneFor({ severity: "Warning" }), "warning");
+	assert.equal(bannerToneFor({ severity: "warning" }), "warning"); // case-insensitive
+	assert.equal(bannerToneFor({ severity: "Info" }), "info");
+	assert.equal(bannerToneFor({ severity: "" }), "info");
+	assert.equal(bannerToneFor({}), "info");
+	assert.equal(bannerToneFor(null), "info");
+	// An unknown future severity never becomes a false alarm - it stays neutral info.
+	assert.equal(bannerToneFor({ severity: "Critical" }), "info");
+});
+
+// ---- isSafeLink ------------------------------------------------------------
+
+test("isSafeLink: accepts http(s), any case", () => {
+	assert.equal(isSafeLink("https://example.com"), true);
+	assert.equal(isSafeLink("http://example.com"), true);
+	assert.equal(isSafeLink("HTTPS://EXAMPLE.COM"), true);
+});
+
+test("isSafeLink: rejects javascript:/data:/protocol-relative and whitespace tricks", () => {
+	assert.equal(isSafeLink("javascript:alert(1)"), false);
+	assert.equal(isSafeLink("data:text/html,<script>"), false);
+	assert.equal(isSafeLink("//evil.example.com"), false);
+	assert.equal(isSafeLink(" javascript:alert(1)"), false); // leading space
+	assert.equal(isSafeLink("\njavascript:alert(1)"), false); // leading newline
+	assert.equal(isSafeLink(""), false);
+	assert.equal(isSafeLink(null), false);
+	assert.equal(isSafeLink(undefined), false);
+});
+
+// ---- snooze read/write -----------------------------------------------------
+
+function installLocalStorage() {
+	const store = new Map();
+	globalThis.localStorage = {
+		getItem: (k) => (store.has(k) ? store.get(k) : null),
+		setItem: (k, v) => store.set(k, String(v)),
+		removeItem: (k) => store.delete(k),
+	};
+	return store;
+}
+
+test("writeSnooze/readSnooze: round-trip, and writeSnooze returns the record", () => {
+	installLocalStorage();
+	try {
+		const rec = writeSnooze({ id: "ANN-1", interval_days: 3 }, NOW, "user@a");
+		assert.deepEqual(rec, { id: "ANN-1", until: NOW + 3 * DAY });
+		assert.deepEqual(readSnooze("user@a"), rec);
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("writeSnooze returns the record even with no localStorage (caller still hides the banner)", () => {
+	assert.equal(typeof globalThis.localStorage, "undefined");
+	const rec = writeSnooze({ id: "ANN-1", interval_days: 2 }, NOW, "user@a");
+	assert.deepEqual(rec, { id: "ANN-1", until: NOW + 2 * DAY });
+});
+
+test("snooze is per-user: A's write doesn't suppress B's banner", () => {
+	const store = installLocalStorage();
+	try {
+		writeSnooze({ id: "ANN-1", interval_days: 7 }, NOW, "user@a");
+		assert.ok(readSnooze("user@a"));
+		assert.equal(readSnooze("user@b"), null);
+		assert.ok(store.has(`${SNOOZE_KEY}:user@a`));
+		assert.ok(!store.has(`${SNOOZE_KEY}:user@b`));
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("missing userId falls back to a stable 'anon' key", () => {
+	const store = installLocalStorage();
+	try {
+		writeSnooze({ id: "ANN-1", interval_days: 7 }, NOW, undefined);
+		assert.ok(store.has(`${SNOOZE_KEY}:anon`));
+		assert.equal(readSnooze().id, "ANN-1");
+		assert.equal(readSnooze(undefined).id, "ANN-1");
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("readSnooze: malformed JSON -> null, never throws", () => {
+	installLocalStorage();
+	try {
+		globalThis.localStorage.setItem(`${SNOOZE_KEY}:user@a`, "{not json");
+		assert.equal(readSnooze("user@a"), null);
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("readSnooze read-throw -> null (banner shows); writeSnooze write-throw -> no crash", () => {
+	globalThis.localStorage = {
+		getItem: () => {
+			throw new Error("blocked");
+		},
+		setItem: () => {
+			throw new Error("quota");
+		},
+		removeItem: () => {},
+	};
+	try {
+		// A read that throws reads as not-snoozed -> bannerShouldShow(..., null) is true.
+		const snooze = readSnooze("user@a");
+		assert.equal(snooze, null);
+		assert.equal(bannerShouldShow({ id: "ANN-1" }, NOW, snooze), true);
+		// A write that throws is swallowed AND still returns the record.
+		let rec;
+		assert.doesNotThrow(() => {
+			rec = writeSnooze({ id: "ANN-1", interval_days: 3 }, NOW, "user@a");
+		});
+		assert.deepEqual(rec, { id: "ANN-1", until: NOW + 3 * DAY });
+	} finally {
+		delete globalThis.localStorage;
+	}
+});
+
+test("readSnooze/writeSnooze: localStorage absent -> null / returns record, no throw", () => {
+	assert.equal(typeof globalThis.localStorage, "undefined");
+	assert.equal(readSnooze("user@a"), null);
+	assert.doesNotThrow(() => writeSnooze({ id: "ANN-1" }, NOW, "user@a"));
+});

--- a/frontend/src/components/chat/AnnouncementBanner.spec.js
+++ b/frontend/src/components/chat/AnnouncementBanner.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// The banner is the customer's view of an operator-authored announcement, so these
+// pin that untrusted title/body/link can never become executable markup, and that
+// the scheme-gated CTA + dismiss behave. The gate is mocked so each test controls
+// the announcement payload directly (the gate reads window.announcement once at
+// import, which a component test can't re-vary - its reactivity is covered in
+// announcementGate.spec.js).
+const mocks = vi.hoisted(() => ({
+	announcement: {
+		active: true,
+		id: "ANN-1",
+		title: "",
+		message: "",
+		severity: "Info",
+		link_url: "",
+		link_label: "",
+		interval_days: 7,
+	},
+	dismissAnnouncement: vi.fn(),
+}));
+
+vi.mock("@/announcementGate", () => ({
+	announcement: mocks.announcement,
+	dismissAnnouncement: mocks.dismissAnnouncement,
+	showAnnouncement: { value: true },
+}));
+
+import AnnouncementBanner from "./AnnouncementBanner.vue";
+
+/** Reset the shared announcement to a clean baseline, then apply overrides. */
+function setAnn(overrides = {}) {
+	Object.assign(mocks.announcement, {
+		title: "",
+		message: "",
+		severity: "Info",
+		link_url: "",
+		link_label: "",
+		...overrides,
+	});
+}
+
+describe("AnnouncementBanner", () => {
+	beforeEach(() => {
+		mocks.dismissAnnouncement.mockClear();
+		setAnn();
+	});
+
+	it("renders an untrusted title/body as inert escaped TEXT, never markup (XSS-safe)", () => {
+		setAnn({
+			title: "Heads up <script>alert(1)</script>",
+			message: "<img src=x onerror=alert(1)>",
+		});
+		const w = mount(AnnouncementBanner);
+		// A v-html render would create these elements; escaped interpolation keeps
+		// them as literal text.
+		expect(w.find("script").exists()).toBe(false);
+		expect(w.find("img").exists()).toBe(false);
+		expect(w.text()).toContain("<script>alert(1)</script>");
+		expect(w.text()).toContain("<img src=x onerror=alert(1)>");
+	});
+
+	it("shows the CTA for an http(s) link, with target=_blank + rel=noopener noreferrer", () => {
+		setAnn({ link_url: "https://status.example.com", link_label: "Status page" });
+		const a = mount(AnnouncementBanner).find("a");
+		expect(a.exists()).toBe(true);
+		expect(a.attributes("href")).toBe("https://status.example.com");
+		expect(a.attributes("target")).toBe("_blank");
+		expect(a.attributes("rel")).toBe("noopener noreferrer");
+		expect(a.text()).toBe("Status page");
+	});
+
+	it("falls back to 'Learn more' when no label is given", () => {
+		setAnn({ link_url: "https://x.example.com", link_label: "" });
+		expect(mount(AnnouncementBanner).find("a").text()).toBe("Learn more");
+	});
+
+	it("suppresses the CTA for a javascript: link (scheme gate)", () => {
+		setAnn({ link_url: "javascript:alert(1)", link_label: "Bad" });
+		expect(mount(AnnouncementBanner).find("a").exists()).toBe(false);
+	});
+
+	it("dismiss button calls dismissAnnouncement", async () => {
+		const w = mount(AnnouncementBanner);
+		await w.find(".jv-an-x").trigger("click");
+		expect(mocks.dismissAnnouncement).toHaveBeenCalledOnce();
+	});
+});

--- a/frontend/src/components/chat/AnnouncementBanner.spec.js
+++ b/frontend/src/components/chat/AnnouncementBanner.spec.js
@@ -27,6 +27,17 @@ vi.mock("@/announcementGate", () => ({
 	showAnnouncement: { value: true },
 }));
 
+// The real frappe-ui package has an internal import (resources/resources) that
+// vitest can't resolve under CI's install, which fails this suite at import time.
+// Banner.vue and AnnouncementBanner.vue only use FeatherIcon from it, so stub that:
+// the REAL Banner.vue still mounts (so its {{ }} text-escaping is genuinely tested)
+// without loading frappe-ui.
+vi.mock("frappe-ui", () => ({
+	// render fn (not an inline `template` string) so no runtime template compiler is
+	// needed; the tests don't assert on the icon glyph.
+	FeatherIcon: { name: "FeatherIcon", render: () => null },
+}));
+
 import AnnouncementBanner from "./AnnouncementBanner.vue";
 
 /** Reset the shared announcement to a clean baseline, then apply overrides. */

--- a/frontend/src/components/chat/AnnouncementBanner.vue
+++ b/frontend/src/components/chat/AnnouncementBanner.vue
@@ -1,0 +1,94 @@
+<template>
+	<!-- Soft, dismissible operator announcement: top-of-chat, coloured by severity
+	     (Info -> blue, Warning -> amber). Title + body render as PLAIN TEXT through
+	     Banner's {{ }} interpolation - NEVER v-html - so untrusted operator prose
+	     can't inject markup. The CTA is scheme-gated (isSafeLink) and only ever an
+	     http(s) link. Visibility (yield to greeting/booting/urgent alerts; win the
+	     top slot over the update banner) is decided by the caller's v-if. -->
+	<div class="jv-announcementbanner">
+		<Banner
+			:type="tone"
+			:title="announcement.title"
+			:message="announcement.message"
+			align="start"
+		>
+			<template #action>
+				<a
+					v-if="isSafeLink(announcement.link_url)"
+					class="jv-an-link"
+					:href="announcement.link_url"
+					target="_blank"
+					rel="noopener noreferrer"
+					>{{ announcement.link_label || "Learn more" }}</a
+				>
+				<button
+					class="jv-an-x"
+					type="button"
+					aria-label="Dismiss announcement"
+					@click="dismissAnnouncement"
+				>
+					<FeatherIcon name="x" class="size-3.5" />
+				</button>
+			</template>
+		</Banner>
+	</div>
+</template>
+
+<script setup>
+// AnnouncementBanner: the fleet-wide operator announcement as a soft strip. Unlike
+// UpdateBanner it has no minimise-into-pill FLIP - dismiss just snoozes per-device
+// (announcementGate.dismissAnnouncement) and the reactive showAnnouncement hides it.
+// `announcement` is the stable, non-reactive boot payload, so `tone` is a plain
+// const, not computed().
+import Banner from "@/components/Banner.vue";
+import { FeatherIcon } from "frappe-ui";
+import { bannerToneFor, isSafeLink } from "@/announcementNudge";
+import { announcement, dismissAnnouncement } from "@/announcementGate";
+
+const tone = bannerToneFor(announcement);
+</script>
+
+<style scoped>
+.jv-announcementbanner {
+	margin: 12px 18px 0;
+}
+
+/* The CTA link + dismiss ×, styled here since Banner is a child scope. Real
+   controls (keyboard-reachable); neutral ink so they don't fight the tonal fill. */
+.jv-an-link {
+	height: 26px;
+	display: inline-flex;
+	align-items: center;
+	padding: 0 10px;
+	border: 1px solid color-mix(in srgb, var(--text) 20%, transparent);
+	border-radius: 7px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--text-2);
+	text-decoration: none;
+	white-space: nowrap;
+}
+.jv-an-link:hover {
+	background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+.jv-an-x {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border: none;
+	border-radius: 7px;
+	background: transparent;
+	color: var(--text-2);
+	cursor: pointer;
+}
+.jv-an-x:hover {
+	background: color-mix(in srgb, var(--text) 12%, transparent);
+}
+.jv-an-link:focus-visible,
+.jv-an-x:focus-visible {
+	outline: 2px solid var(--text-2);
+	outline-offset: 2px;
+}
+</style>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -549,6 +549,13 @@
 				</div>
 			</div>
 
+			<!-- Customer announcement banner (Slice B): the fleet-wide operator
+			     notice, coloured by severity (Info/Warning). Same top-of-chat slot
+			     and suppressors as the update banner, but wins the slot when both
+			     want it (the update banner yields via !announcementVisible). Never
+			     stacks, never hides chat. -->
+			<AnnouncementBanner v-if="announcementVisible" />
+
 			<!-- Release-nudge banner (Slice 3b): severity-coloured (amber for soft,
 			     red for severe), top-of-chat. Shows over the welcome screen; yields
 			     to the greeting/booting states and to any urgent billing/readiness
@@ -4516,8 +4523,10 @@ import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import VersionPill from "@/components/chat/VersionPill.vue";
 import UpdateBanner from "@/components/chat/UpdateBanner.vue";
+import AnnouncementBanner from "@/components/chat/AnnouncementBanner.vue";
 import WhatsNewDialog from "@/components/chat/WhatsNewDialog.vue";
 import { showBanner } from "@/noticeGate";
+import { showAnnouncement } from "@/announcementGate";
 import { parseAsk } from "@/lib/chatAsk";
 import { shouldHideActivityTool, isCustomerFacingTool } from "@/lib/activityTools";
 import { parseGoto, gotoFiredKey, parseFiredStamp, claimGotoFire } from "@/lib/chatGoto";
@@ -4842,13 +4851,30 @@ const hasUrgentAlert = computed(
 			notReadyNotice.value
 		)
 );
+// The operator announcement banner shares the top-of-chat slot and the same
+// suppressors as the update banner (yield to greeting/booting/urgent alerts),
+// but WINS the slot when both want it (the update banner yields below via
+// `!announcementVisible`) - an operator's fleet-wide notice outranks a version
+// nudge. Shows over the welcome screen too.
+const announcementVisible = computed(
+	() =>
+		showAnnouncement.value &&
+		!booting.value &&
+		!bizGreeting.value.show &&
+		!hasUrgentAlert.value
+);
 // The soft banner shows whenever it's a not-snoozed soft/severe notice AND the
 // top-of-chat region is otherwise clear (no greeting/booting) AND no urgent
-// alert is competing for attention - it also shows over the welcome screen
-// (the highest-traffic surface), which no longer suppresses it. The pill
-// stays regardless.
+// alert is competing for attention AND the announcement banner isn't taking the
+// slot - it also shows over the welcome screen (the highest-traffic surface),
+// which no longer suppresses it. The pill stays regardless.
 const updateBannerVisible = computed(
-	() => showBanner.value && !bizGreeting.value.show && !booting.value && !hasUrgentAlert.value
+	() =>
+		showBanner.value &&
+		!bizGreeting.value.show &&
+		!booting.value &&
+		!hasUrgentAlert.value &&
+		!announcementVisible.value
 );
 // Per-conversation "auto-apply changes" (issue #186): seeded from
 // get_conversation().conversation.auto_apply on each load; the toggle reflects

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -21,7 +21,7 @@ import hashlib
 
 import frappe
 
-from jarvis import admin_client, compat, onboarding_contract, release_notice
+from jarvis import admin_client, announcement, compat, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
@@ -565,6 +565,8 @@ def _admin_chat_gate() -> dict:
 	# Refresh the locally-mirrored release notice on this gate's cadence so an
 	# active user sees an activate/clear without waiting for the daily sync.
 	release_notice.persist(conn.get("release_notice") or {})
+	# Same cadence: mirror the fleet-wide operator announcement for the soft banner.
+	announcement.persist(conn.get("announcement") or {})
 	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 

--- a/jarvis/announcement.py
+++ b/jarvis/announcement.py
@@ -1,0 +1,102 @@
+"""Mirror the operator's fleet-wide announcement locally and expose it to the SPA.
+
+The control plane composes one announcement and ships it on the connection poll
+(``conn["announcement"]``); the bench stores it in a read-only Jarvis Settings
+mirror and renders it as a soft, dismissible banner. Unlike the release notice
+this is informational only - there is no gate, no version self-clear, no
+on-demand re-check: the mirror refreshes on the daily sync + the chat gate's
+persist sites + boot, and the banner's re-show cadence lives per-device in the
+browser (see frontend/src/announcementNudge.js).
+"""
+
+import frappe
+from frappe.utils import cint, get_datetime, now_datetime
+
+SETTINGS = "Jarvis Settings"
+_FIELDS = (
+	"announcement_active",
+	"announcement_id",
+	"announcement_title",
+	"announcement_message",
+	"announcement_severity",
+	"announcement_link_url",
+	"announcement_link_label",
+	"announcement_interval_days",
+	"announcement_expires_on",
+)
+
+
+def _norm(field: str, value) -> str:
+	"""Comparable string form for the no-op-skip. The Datetime field is routed
+	through get_datetime so a stored ``datetime`` and the wire's string form of
+	the same instant compare equal - otherwise a set expiry would force a write
+	on every persist (H3). Everything else compares by its plain string."""
+	if field == "announcement_expires_on":
+		if not value:
+			return ""
+		try:
+			return str(get_datetime(value))
+		except Exception:
+			return str(value)
+	return str(value if value is not None else "")
+
+
+def persist(announcement: dict) -> None:
+	"""Mirror the admin-sent announcement onto Jarvis Settings. Best-effort; an
+	empty dict clears it. Skips the write when nothing changed - the banner
+	re-shows on a per-device timer, and churning ``modified`` would collide with
+	an operator editing the Settings form."""
+	try:
+		n = announcement or {}
+		fresh = {
+			"announcement_active": 1 if n.get("active") else 0,
+			"announcement_id": n.get("id") or "",
+			"announcement_title": n.get("title") or "",
+			"announcement_message": n.get("message") or "",
+			"announcement_severity": n.get("severity") or "",
+			"announcement_link_url": n.get("link_url") or "",
+			"announcement_link_label": n.get("link_label") or "",
+			"announcement_interval_days": cint(n.get("interval_days")),
+			# A Datetime column rejects "" (and would leave the channel dead), so an
+			# absent/blank expiry is stored as NULL, never "" (H2).
+			"announcement_expires_on": n.get("expires_on") or None,
+		}
+		current = frappe.db.get_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
+		if all(_norm(k, current.get(k)) == _norm(k, v) for k, v in fresh.items()):
+			return
+		frappe.db.set_value(SETTINGS, SETTINGS, fresh, update_modified=False)
+	except Exception:
+		pass
+
+
+def boot_payload() -> dict:
+	"""``announcement`` for context.boot. The SPA/PWA read ``active`` to decide
+	whether to show the soft banner; ``id`` + ``interval_days`` key the per-device
+	snooze. TOTAL - the expiry compare is wrapped so a bad ``expires_on`` can never
+	500 the bare boot call (H1); a strict ``now < expires_on`` boundary matches the
+	control plane resolver (H4). Fails toward showing, like the release notice."""
+	row = frappe.get_cached_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
+	active = cint(row.get("announcement_active"))
+	expires_on = row.get("announcement_expires_on")
+	if active and expires_on:
+		try:
+			if now_datetime() >= get_datetime(expires_on):
+				active = 0
+		except Exception:
+			# A garbage/unparseable expiry must not raise (it would break every boot)
+			# - keep the stored active, matching release's fail-toward-showing.
+			pass
+	return {
+		"active": bool(active),
+		"id": row.get("announcement_id") or "",
+		"title": row.get("announcement_title") or "",
+		"message": row.get("announcement_message") or "",
+		"severity": row.get("announcement_severity") or "",
+		"link_url": row.get("announcement_link_url") or "",
+		"link_label": row.get("announcement_link_label") or "",
+		"interval_days": cint(row.get("announcement_interval_days")),
+		# Serialized so context.boot stays plain-JSON (a LocalProxy/datetime can trip
+		# the |tojson boot emitter); the client never reads it - boot already gated
+		# active by the expiry above.
+		"expires_on": str(expires_on) if expires_on else "",
+	}

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -136,6 +136,16 @@
   "release_notice_tier",
   "release_notice_behind",
   "release_banner_interval_days",
+  "announcement_section",
+  "announcement_active",
+  "announcement_id",
+  "announcement_title",
+  "announcement_message",
+  "announcement_severity",
+  "announcement_link_url",
+  "announcement_link_label",
+  "announcement_interval_days",
+  "announcement_expires_on",
   "system_tab",
   "deployment_section",
   "deployment_mode",
@@ -985,6 +995,66 @@
    "fieldname": "release_banner_interval_days",
    "fieldtype": "Int",
    "label": "Release Banner Interval Days",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_section",
+   "fieldtype": "Section Break",
+   "label": "Announcement",
+   "description": "Mirror of the operator's fleet-wide announcement, pulled from the control plane. Read-only here."
+  },
+  {
+   "fieldname": "announcement_active",
+   "fieldtype": "Check",
+   "label": "Announcement Active",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_id",
+   "fieldtype": "Data",
+   "label": "Announcement ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_title",
+   "fieldtype": "Data",
+   "label": "Announcement Title",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_message",
+   "fieldtype": "Small Text",
+   "label": "Announcement Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_severity",
+   "fieldtype": "Data",
+   "label": "Announcement Severity",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_link_url",
+   "fieldtype": "Data",
+   "label": "Announcement Link URL",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_link_label",
+   "fieldtype": "Data",
+   "label": "Announcement Link Label",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_interval_days",
+   "fieldtype": "Int",
+   "label": "Announcement Interval Days",
+   "read_only": 1
+  },
+  {
+   "fieldname": "announcement_expires_on",
+   "fieldtype": "Datetime",
+   "label": "Announcement Expires On",
    "read_only": 1
   },
   {

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe.utils import cint, validate_email_address
 
-from jarvis import admin_client, onboarding_contract, release_notice
+from jarvis import admin_client, announcement, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
@@ -263,6 +263,8 @@ def sync_connection(timeout_s: int | None = None) -> dict:
 	# raise or clear the release notice, and this is the only refresh an idle
 	# bench gets.
 	release_notice.persist(data.get("release_notice") or {})
+	# Same cadence: mirror the fleet-wide operator announcement for the soft banner.
+	announcement.persist(data.get("announcement") or {})
 	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -88,6 +88,15 @@ CONNECTION = ResetSpec(
 		# Release notice + whitelabel branding of the previous tenancy. The SPA
 		# falls back to "Jarvis" when agent_name is blank.
 		"release_notice_message",
+		# Announcement mirror of the previous tenancy (H6). The banner is gated on
+		# announcement_active (zeroed below), but clear the string fields too so no
+		# stale operator prose lingers on the fresh tenancy.
+		"announcement_id",
+		"announcement_title",
+		"announcement_message",
+		"announcement_severity",
+		"announcement_link_url",
+		"announcement_link_label",
 		"agent_name",
 		"brand_logo",
 		"brand_favicon",
@@ -118,11 +127,18 @@ CONNECTION = ResetSpec(
 		"role_profiles_pushed_at",
 		"role_profiles_config_synced_at",
 		"wiki_mirror_last_synced_at",
+		# Announcement expiry mirror of the previous tenancy (H6) - a Datetime, so
+		# it NULLs (not blanks) like the other timestamps here.
+		"announcement_expires_on",
 	),
 	zero=(
 		"agent_catalog_dirty",
 		"agent_catalog_version",
 		"release_notice_active",
+		# Announcement mirror of the previous tenancy (H6): the active + interval
+		# scalars zero beside release_notice_active.
+		"announcement_active",
+		"announcement_interval_days",
 		# Forget the accepted authority generation so the fresh tenancy's first
 		# connection is accepted on its own terms, not rejected as "older" than
 		# the previous tenancy's generation (review plan 04 P0-5).

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -208,14 +208,23 @@ class TestAdminChatGate(FrappeTestCase):
 	is specifically about the never-ready one, so a verdict never depends on
 	whatever state the site happens to carry."""
 
-	# The gate now mirrors the release notice onto Jarvis Settings as a side
-	# effect (persist({}) when the mock carries none), and stamps the ready
-	# marker, so snapshot/restore those fields to avoid clobbering a real site's
-	# operator state.
+	# The gate now mirrors the release notice AND the announcement onto Jarvis
+	# Settings as a side effect (persist({}) when the mock carries none), and
+	# stamps the ready marker, so snapshot/restore those fields to avoid
+	# clobbering a real site's operator state.
 	_RELEASE_FIELDS = (
 		"release_notice_active",
 		"latest_jarvis_version",
 		"release_notice_message",
+		"announcement_active",
+		"announcement_id",
+		"announcement_title",
+		"announcement_message",
+		"announcement_severity",
+		"announcement_link_url",
+		"announcement_link_label",
+		"announcement_interval_days",
+		"announcement_expires_on",
 	)
 
 	def setUp(self):
@@ -275,6 +284,41 @@ class TestAdminChatGate(FrappeTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(s.release_notice_active, 0)
 		self.assertEqual(s.release_notice_message, "")
+
+	def test_announcement_persisted_on_gate(self):
+		# The gate mirrors an active announcement so boot can read it; the returned
+		# verdict shape is unchanged (the announcement never rides the gate reply).
+		ann = {
+			"active": True,
+			"id": "ANN-00007",
+			"title": "Scheduled maintenance",
+			"message": "We update Sunday 02:00 UTC.",
+			"severity": "Warning",
+		}
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={"chat_readiness": "Ready", "announcement": ann},
+		):
+			out = account._admin_chat_gate()
+		self.assertEqual(out, {"ready": True, "reason": None, "billing_notice": {}})
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.announcement_active, 1)
+		self.assertEqual(s.announcement_id, "ANN-00007")
+		self.assertEqual(s.announcement_message, "We update Sunday 02:00 UTC.")
+
+	def test_announcement_cleared_on_gate(self):
+		# Admin stops sending an announcement -> the mirror zeroes so the banner drops.
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("announcement_active", 1)
+		s.db_set("announcement_id", "ANN-stale")
+		s.db_set("announcement_message", "stale")
+		frappe.db.commit()
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
+			account._admin_chat_gate()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.announcement_active, 0)
+		self.assertEqual(s.announcement_message, "")
 
 	def test_blocks_when_admin_not_ready(self):
 		with patch.object(

--- a/jarvis/tests/test_announcement.py
+++ b/jarvis/tests/test_announcement.py
@@ -1,0 +1,175 @@
+"""Tests for jarvis.announcement: persist + boot_payload for the soft banner.
+
+The announcement mirror has no gate, no version self-clear and no on-demand
+re-check (unlike release_notice) - the only server logic is the persist/clear
+round-trip and a TOTAL boot_payload whose only computed bit is the strict expiry
+boundary. These pin the hardening points H1-H4/H2 folded in at /plan-check.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import announcement
+
+_FIELDS = announcement._FIELDS
+
+# A fixed "now" for the expiry-boundary tests: pinning now_datetime makes the
+# strict `now < expires_on` boundary deterministic (no clock race).
+_NOW = "2030-06-01 12:00:00"
+
+
+def _snapshot() -> dict:
+	s = frappe.get_single("Jarvis Settings")
+	return {f: s.get(f) for f in _FIELDS}
+
+
+def _restore(snap: dict) -> None:
+	s = frappe.get_single("Jarvis Settings")
+	for f, v in snap.items():
+		s.db_set(f, v)
+	frappe.db.commit()
+
+
+class TestAnnouncementBoot(FrappeTestCase):
+	def setUp(self):
+		self._snap = _snapshot()
+
+	def tearDown(self):
+		_restore(self._snap)
+
+	def _set(self, **kw):
+		s = frappe.get_single("Jarvis Settings")
+		for k, v in kw.items():
+			s.db_set(k, v)
+		frappe.db.commit()
+
+	# -- shape ----------------------------------------------------------------
+
+	def test_active_announcement_shape(self):
+		announcement.persist(
+			{
+				"active": True,
+				"id": "ANN-00001",
+				"title": "Scheduled maintenance",
+				"message": "We update Sunday 02:00 UTC.",
+				"severity": "Warning",
+				"link_url": "https://status.example.com",
+				"link_label": "Status page",
+				"interval_days": 3,
+			}
+		)
+		p = announcement.boot_payload()
+		self.assertTrue(p["active"])
+		self.assertEqual(p["id"], "ANN-00001")
+		self.assertEqual(p["title"], "Scheduled maintenance")
+		self.assertEqual(p["message"], "We update Sunday 02:00 UTC.")
+		self.assertEqual(p["severity"], "Warning")
+		self.assertEqual(p["link_url"], "https://status.example.com")
+		self.assertEqual(p["link_label"], "Status page")
+		self.assertEqual(p["interval_days"], 3)
+
+	def test_inactive_announcement(self):
+		announcement.persist({"active": False, "id": "ANN-1", "message": "m"})
+		self.assertFalse(announcement.boot_payload()["active"])
+
+	def test_empty_dict_clears(self):
+		announcement.persist({"active": True, "id": "ANN-1", "title": "t", "message": "m"})
+		self.assertTrue(announcement.boot_payload()["active"])
+		announcement.persist({})
+		p = announcement.boot_payload()
+		self.assertFalse(p["active"])
+		self.assertEqual(p["id"], "")
+		self.assertEqual(p["title"], "")
+		self.assertEqual(p["message"], "")
+
+	def test_persist_then_clear_round_trip(self):
+		announcement.persist(
+			{"active": True, "id": "ANN-7", "title": "T", "message": "M", "severity": "Info"}
+		)
+		p = announcement.boot_payload()
+		self.assertTrue(p["active"])
+		self.assertEqual(p["id"], "ANN-7")
+		announcement.persist({})
+		p = announcement.boot_payload()
+		self.assertFalse(p["active"])
+		self.assertEqual(p["id"], "")
+		self.assertEqual(p["severity"], "")
+
+	# -- no-op-skip (H3) ------------------------------------------------------
+
+	def test_persist_skips_write_when_unchanged(self):
+		ann = {"active": True, "id": "ANN-2", "title": "t", "message": "m", "interval_days": 5}
+		announcement.persist(ann)
+		before = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "modified")
+		announcement.persist(ann)
+		self.assertEqual(frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "modified"), before)
+
+	def test_persist_skips_write_when_unchanged_with_expiry(self):
+		# H3: a SET expiry must normalize both sides so an unchanged announcement
+		# with an expiry doesn't force a write every persist (write-amplification on
+		# the hot gate path). The DB reads back a datetime; the wire sends a string.
+		ann = {"active": True, "id": "ANN-3", "message": "m", "expires_on": "2031-01-01 09:30:00"}
+		announcement.persist(ann)
+		before = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "modified")
+		announcement.persist(ann)
+		self.assertEqual(frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "modified"), before)
+
+	# -- expires_on storage (H2) ----------------------------------------------
+
+	def test_absent_expiry_stored_as_null(self):
+		# H2: a Datetime column rejects "" - an absent expiry must land as NULL, or
+		# persist raises and swallows, silently killing the channel.
+		announcement.persist({"active": True, "id": "ANN-4", "message": "m"})
+		stored = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "announcement_expires_on")
+		self.assertIsNone(stored)
+
+	def test_blank_expiry_stored_as_null(self):
+		announcement.persist({"active": True, "id": "ANN-4b", "message": "m", "expires_on": ""})
+		stored = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "announcement_expires_on")
+		self.assertIsNone(stored)
+
+	# -- expiry boundary (H4), strict now < expires_on ------------------------
+
+	def test_active_when_expiry_in_future(self):
+		self._set(
+			announcement_active=1,
+			announcement_id="ANN-5",
+			announcement_expires_on="2030-06-01 12:00:01",
+		)
+		with patch.object(announcement, "now_datetime", return_value=announcement.get_datetime(_NOW)):
+			self.assertTrue(announcement.boot_payload()["active"])
+
+	def test_inactive_when_expiry_in_past(self):
+		self._set(
+			announcement_active=1,
+			announcement_id="ANN-5",
+			announcement_expires_on="2030-06-01 11:59:59",
+		)
+		with patch.object(announcement, "now_datetime", return_value=announcement.get_datetime(_NOW)):
+			self.assertFalse(announcement.boot_payload()["active"])
+
+	def test_inactive_when_expiry_exactly_now(self):
+		# Strict boundary: at the instant of expiry the banner is already OFF.
+		self._set(announcement_active=1, announcement_id="ANN-5", announcement_expires_on=_NOW)
+		with patch.object(announcement, "now_datetime", return_value=announcement.get_datetime(_NOW)):
+			self.assertFalse(announcement.boot_payload()["active"])
+
+	def test_active_with_no_expiry_never_gates(self):
+		self._set(announcement_active=1, announcement_id="ANN-6", announcement_expires_on=None)
+		self.assertTrue(announcement.boot_payload()["active"])
+
+	# -- TOTAL boot_payload (H1) ----------------------------------------------
+
+	def test_boot_payload_never_raises_on_garbage_expiry(self):
+		# H1: a bad expires_on that get_datetime can't parse must NOT 500 the bare
+		# boot call - it falls back to the stored active (fail toward showing).
+		row = {f: "" for f in _FIELDS}
+		row["announcement_active"] = 1
+		row["announcement_id"] = "ANN-9"
+		row["announcement_expires_on"] = "not-a-date"
+		with patch("frappe.get_cached_value", return_value=row):
+			p = announcement.boot_payload()
+		self.assertTrue(p["active"])
+		self.assertEqual(p["id"], "ANN-9")

--- a/jarvis/tests/test_announcement.py
+++ b/jarvis/tests/test_announcement.py
@@ -118,17 +118,25 @@ class TestAnnouncementBoot(FrappeTestCase):
 
 	# -- expires_on storage (H2) ----------------------------------------------
 
-	def test_absent_expiry_stored_as_null(self):
-		# H2: a Datetime column rejects "" - an absent expiry must land as NULL, or
-		# persist raises and swallows, silently killing the channel.
+	def test_absent_expiry_persists_and_never_gates(self):
+		# H2: a Datetime column rejects "" - an absent expiry must NOT make persist
+		# raise + swallow (which would silently kill the channel). The RAW stored form
+		# of an empty Datetime is version-dependent (Frappe v16 reads it back via
+		# get_value as datetime.min, v17 as None), so assert H2's real contract instead
+		# of the representation: the announcement persisted AND boot_payload (which reads
+		# via get_cached_value) treats it as no-expiry, never gating active off.
 		announcement.persist({"active": True, "id": "ANN-4", "message": "m"})
-		stored = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "announcement_expires_on")
-		self.assertIsNone(stored)
+		self.assertEqual(
+			frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "announcement_id"), "ANN-4"
+		)
+		self.assertTrue(announcement.boot_payload()["active"])
 
-	def test_blank_expiry_stored_as_null(self):
+	def test_blank_expiry_persists_and_never_gates(self):
 		announcement.persist({"active": True, "id": "ANN-4b", "message": "m", "expires_on": ""})
-		stored = frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "announcement_expires_on")
-		self.assertIsNone(stored)
+		self.assertEqual(
+			frappe.db.get_value("Jarvis Settings", "Jarvis Settings", "announcement_id"), "ANN-4b"
+		)
+		self.assertTrue(announcement.boot_payload()["active"])
 
 	# -- expiry boundary (H4), strict now < expires_on ------------------------
 

--- a/jarvis/tests/test_announcement.py
+++ b/jarvis/tests/test_announcement.py
@@ -173,3 +173,53 @@ class TestAnnouncementBoot(FrappeTestCase):
 			p = announcement.boot_payload()
 		self.assertTrue(p["active"])
 		self.assertEqual(p["id"], "ANN-9")
+
+
+class TestAnnouncementWiring(FrappeTestCase):
+	"""The daily sync forwards the announcement to persist, and a reset clears the
+	mirror (H6). The chat-gate persist site is covered in test_account's
+	TestAdminChatGate, beside the release-notice precedent."""
+
+	def test_sync_connection_forwards_announcement_to_persist(self):
+		# The recurring scheduled sync must forward the backend-sent announcement to
+		# announcement.persist (co-located with the release_notice.persist precedent).
+		from jarvis import onboarding
+
+		conn = {
+			"announcement": {"active": True, "id": "ANN-1"},
+			"release_notice": {},
+			"redaction_patterns": [],
+			"agent_url": "",
+		}
+		with (
+			patch("jarvis.onboarding.require_jarvis_admin"),
+			patch("jarvis.onboarding.frappe.get_single") as gs,
+			patch("jarvis.onboarding.admin_client.get_connection", return_value=conn),
+			patch("jarvis.onboarding.release_notice.persist"),
+			patch("jarvis.onboarding.announcement.persist") as persist,
+			patch("jarvis.chat.egress_rules.persist"),
+		):
+			gs.return_value.get_password.return_value = "x"  # api key/secret present
+			onboarding.sync_connection()
+		persist.assert_called_once_with({"active": True, "id": "ANN-1"})
+
+	def test_settings_reset_clears_announcement_mirror(self):
+		# H6: a reset must clear the previous tenancy's announcement mirror. The
+		# string fields blank, the scalars zero, and the Datetime NULLs.
+		from jarvis import settings_reset
+
+		for f in (
+			"announcement_id",
+			"announcement_title",
+			"announcement_message",
+			"announcement_severity",
+			"announcement_link_url",
+			"announcement_link_label",
+		):
+			self.assertIn(f, settings_reset.CONNECTION.blank)
+		self.assertIn("announcement_active", settings_reset.CONNECTION.zero)
+		self.assertIn("announcement_interval_days", settings_reset.CONNECTION.zero)
+		self.assertIn("announcement_expires_on", settings_reset.CONNECTION.null)
+		# FULL composes CONNECTION | LLM, so the parity carries into the CLI reset too.
+		self.assertIn("announcement_active", settings_reset.FULL.zero)
+		self.assertIn("announcement_expires_on", settings_reset.FULL.null)

--- a/jarvis/tests/test_www_announcement.py
+++ b/jarvis/tests/test_www_announcement.py
@@ -1,0 +1,56 @@
+"""The desktop + mobile www shells expose the announcement in context.boot."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.www import jarvis as www_desktop
+from jarvis.www import jarvis_mobile as www_mobile
+
+_FIELDS = (
+	"announcement_active",
+	"announcement_id",
+	"announcement_title",
+	"announcement_message",
+)
+
+
+class TestWwwAnnouncement(FrappeTestCase):
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = {f: s.get(f) for f in _FIELDS}
+		s.db_set("announcement_active", 1)
+		s.db_set("announcement_id", "ANN-00042")
+		s.db_set("announcement_title", "Scheduled maintenance")
+		s.db_set("announcement_message", "We update Sunday 02:00 UTC.")
+		frappe.db.commit()
+
+	def tearDown(self):
+		s = frappe.get_single("Jarvis Settings")
+		for f, v in self._snap.items():
+			s.db_set(f, v)
+		frappe.db.commit()
+
+	def test_desktop_boot_exposes_announcement(self):
+		ctx = frappe._dict()
+		with (
+			patch.object(www_desktop, "has_jarvis_access", return_value=True),
+			patch.object(www_desktop, "has_jarvis_admin_access", return_value=False),
+			patch.object(www_desktop, "support_scope", return_value=None),
+			patch.object(www_desktop, "_support_state", return_value=www_desktop.SUPPORT_OFF),
+		):
+			www_desktop.get_context(ctx)
+		ann = ctx.boot["announcement"]
+		self.assertTrue(ann["active"])
+		self.assertEqual(ann["id"], "ANN-00042")
+		self.assertEqual(ann["title"], "Scheduled maintenance")
+		self.assertEqual(ann["message"], "We update Sunday 02:00 UTC.")
+
+	def test_mobile_boot_exposes_announcement(self):
+		ctx = frappe._dict()
+		with patch.object(www_mobile, "has_jarvis_access", return_value=True):
+			www_mobile.get_context(ctx)
+		ann = ctx.boot["announcement"]
+		self.assertTrue(ann["active"])
+		self.assertEqual(ann["id"], "ANN-00042")

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -1,6 +1,6 @@
 import frappe
 
-from jarvis import release_notice
+from jarvis import announcement, release_notice
 from jarvis.permissions import (
 	has_jarvis_access,
 	has_jarvis_admin_access,
@@ -130,6 +130,10 @@ def get_context(context):
 	# Release notice (operator-authored): the SPA shows a full-page interstitial
 	# when this bench is behind the latest jarvis version. Up-to-date => no gate.
 	context.boot["release_notice"] = release_notice.boot_payload()
+
+	# Customer announcement (operator-authored): a soft, dismissible banner shown
+	# fleet-wide. Empty/inactive => the SPA renders nothing.
+	context.boot["announcement"] = announcement.boot_payload()
 
 	# Support panel gating (Plan 3 B5). Support access rides the base Jarvis roles
 	# (support_scope: Jarvis User => own, Jarvis Admin => all), so there's nothing to grant —

--- a/jarvis/www/jarvis_mobile.py
+++ b/jarvis/www/jarvis_mobile.py
@@ -1,6 +1,6 @@
 import frappe
 
-from jarvis import release_notice
+from jarvis import announcement, release_notice
 from jarvis.permissions import has_jarvis_access
 
 no_cache = 1
@@ -51,5 +51,7 @@ def get_context(context):
 	context.boot["brand_favicon_url"] = _brand.get("brand_favicon") or ""
 	# Release notice (operator-authored) — same interstitial on the PWA path.
 	context.boot["release_notice"] = release_notice.boot_payload()
+	# Customer announcement (operator-authored) — same soft banner on the PWA path.
+	context.boot["announcement"] = announcement.boot_payload()
 	frappe.db.commit()
 	return context

--- a/pwa/src/App.vue
+++ b/pwa/src/App.vue
@@ -4,11 +4,13 @@ import { useRouter } from "vue-router";
 import AppDrawer from "./components/AppDrawer.vue";
 import InstallBanner from "./components/InstallBanner.vue";
 import UpdateBanner from "./components/UpdateBanner.vue";
+import AnnouncementBanner from "./components/AnnouncementBanner.vue";
 import UpdateNoticeGate from "./components/UpdateNoticeGate.vue";
 import WhatsNewSheet from "./components/WhatsNewSheet.vue";
 import { store } from "./store";
 import { sessionUser } from "./router";
 import { showBanner, showNotice } from "./noticeGate";
+import { showAnnouncement } from "./announcementGate";
 import { installBannerVisible } from "./lib/installBanner";
 import { prefs } from "./lib/prefs";
 import { agentName } from "@/branding";
@@ -120,12 +122,20 @@ onUnmounted(() => {
 		<!-- First child, in the flow: the install strip pushes the app down rather
 		     than covering any part of it. -->
 		<InstallBanner />
+		<!-- Customer announcement banner (Slice B): the fleet-wide operator notice.
+		     Yields to InstallBanner (only one top slot at a time) and to a signed-out
+		     visitor, and WINS the slot over the update banner below (which yields via
+		     !showAnnouncement). Dismiss snoozes it per-device. -->
+		<AnnouncementBanner v-if="showAnnouncement && sessionUser() && !installBannerVisible" />
 		<!-- Release-nudge soft banner (Slice 3b): top-of-app, next to the install
 		     strip. Yields to InstallBanner (installBannerVisible - only one top
-		     slot shows at a time) and to a signed-out visitor (nothing to nudge on
-		     the login screen). Dismiss minimises it into whichever VersionPill is
-		     currently mounted (ChatView's header; see noticeGate.js's pillHandle). -->
-		<UpdateBanner v-if="showBanner && !installBannerVisible && sessionUser()" />
+		     slot shows at a time), to a signed-out visitor (nothing to nudge on
+		     the login screen), and to the announcement banner above. Dismiss
+		     minimises it into whichever VersionPill is currently mounted (ChatView's
+		     header; see noticeGate.js's pillHandle). -->
+		<UpdateBanner
+			v-if="showBanner && !installBannerVisible && sessionUser() && !showAnnouncement"
+		/>
 		<router-view v-slot="{ Component }">
 			<component :is="Component" />
 		</router-view>

--- a/pwa/src/announcementGate.js
+++ b/pwa/src/announcementGate.js
@@ -1,0 +1,48 @@
+// Customer announcement for the mobile PWA, delivered by jarvis_mobile.py boot as
+// window.announcement = {active, id, title, message, severity, link_url,
+// link_label, interval_days, expires_on}. A SOFT, dismissible banner whose re-show
+// cadence lives per-device in localStorage via the shared, node-testable
+// announcementNudge.js. Mirrors the desktop SPA's src/announcementGate.js in the
+// PWA's own idiom (no hard gate, no What's-new, no recheck).
+import { computed, ref } from "vue";
+import { bannerShouldShow, writeSnooze, readSnooze } from "@shared/announcementNudge";
+import { sessionUser } from "./router";
+
+const a = window.announcement || {};
+
+// Namespace the snooze by the signed-in user, so two people sharing a browser
+// profile keep independent snoozes; guest / signed-out -> "anon".
+const userId = sessionUser() || "anon";
+
+// The boot payload is stable for the page's lifetime, so this is a plain object
+// (not reactive): bannerShouldShow()/bannerToneFor() read it, and it never changes.
+export const announcement = {
+	active: !!a.active,
+	id: a.id || "",
+	title: a.title || "",
+	message: a.message || "",
+	severity: a.severity || "",
+	link_url: a.link_url || "",
+	link_label: a.link_label || "",
+	interval_days: Number(a.interval_days) || 7,
+};
+
+// The snooze lives in localStorage; this ref mirrors it so the banner hides
+// reactively the moment it is dismissed. Seeded from storage at boot (a read-throw
+// reads as not-snoozed, so the banner shows - see readSnooze()).
+const snooze = ref(readSnooze(userId));
+
+// Reactive: active AND not currently snoozed. `Date.now()` is read at evaluation
+// time; the only reactive dependency is `snooze`, so dismissing recomputes this to
+// false and the banner hides.
+export const showAnnouncement = computed(
+	() => !!announcement.active && bannerShouldShow(announcement, Date.now(), snooze.value)
+);
+
+// Dismiss: persist the snooze (best-effort) AND update the ref in-memory so
+// `showAnnouncement` flips to false immediately. writeSnooze returns the exact
+// record it wrote, so the ref and storage never disagree and the math lives in one
+// place (H8).
+export function dismissAnnouncement() {
+	snooze.value = writeSnooze(announcement, Date.now(), userId);
+}

--- a/pwa/src/components/AnnouncementBanner.vue
+++ b/pwa/src/components/AnnouncementBanner.vue
@@ -1,0 +1,158 @@
+<script setup>
+// AnnouncementBanner (PWA): the fleet-wide operator announcement as a soft strip,
+// mounted at the app shell (App.vue) next to InstallBanner. Hand-rolled markup -
+// the PWA has no reusable Banner.vue - but the same guarantees as the desktop SPA:
+// title/body render as PLAIN TEXT via {{ }} (never v-html), and the CTA is
+// scheme-gated (isSafeLink) with rel="noopener noreferrer". Dismiss snoozes
+// per-device (announcementGate.dismissAnnouncement); the reactive showAnnouncement
+// hides it. Visibility (yield to InstallBanner + a signed-out visitor) is the
+// caller's v-if in App.vue.
+import { bannerToneFor, isSafeLink } from "@shared/announcementNudge";
+import { announcement, dismissAnnouncement } from "../announcementGate";
+
+// `announcement` is the stable, non-reactive boot payload, so these are plain
+// consts, not computed().
+const tone = bannerToneFor(announcement);
+const showLink = isSafeLink(announcement.link_url);
+</script>
+
+<template>
+	<!-- Coloured by severity - accent (Info) or amber (Warning). -->
+	<div class="jv-announcementbanner" :class="'jv-tone-' + tone">
+		<svg
+			class="jv-an-icon"
+			viewBox="0 0 24 24"
+			width="16"
+			height="16"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		>
+			<circle cx="12" cy="12" r="9" />
+			<path d="M12 8v5M12 16h.01" />
+		</svg>
+		<div class="jv-an-body">
+			<div v-if="announcement.title" class="jv-an-title">{{ announcement.title }}</div>
+			<div v-if="announcement.message" class="jv-an-msg">{{ announcement.message }}</div>
+		</div>
+		<div class="jv-an-actions">
+			<a
+				v-if="showLink"
+				class="jv-an-btn"
+				:href="announcement.link_url"
+				target="_blank"
+				rel="noopener noreferrer"
+				>{{ announcement.link_label || "Learn more" }}</a
+			>
+			<button
+				class="jv-an-x"
+				type="button"
+				aria-label="Dismiss announcement"
+				@click="dismissAnnouncement"
+			>
+				<svg
+					viewBox="0 0 24 24"
+					width="14"
+					height="14"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+				>
+					<path d="M18 6 6 18M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+/* Tone (accent/amber) resolves per severity class; reused by the fill, border,
+   ink AND the CTA so the whole banner stays one coherent colour. */
+.jv-tone-info {
+	--jv-tone: var(--accent);
+	--jv-tone-bg: var(--accent-bg);
+}
+.jv-tone-warning {
+	--jv-tone: var(--amber);
+	--jv-tone-bg: var(--amber-bg);
+}
+.jv-announcementbanner {
+	flex: none;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: 10px;
+	margin: 8px 12px 0;
+	padding: 12px;
+	border-radius: 14px;
+	background: var(--jv-tone-bg);
+	border: 1px solid color-mix(in srgb, var(--jv-tone) 35%, transparent);
+	color: var(--jv-tone);
+}
+.jv-an-icon {
+	flex: none;
+	margin-top: 1px;
+}
+.jv-an-body {
+	flex: 1;
+	min-width: 160px;
+}
+.jv-an-title {
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.4;
+	color: var(--jv-tone);
+}
+.jv-an-msg {
+	font-size: 13px;
+	line-height: 1.4;
+	color: var(--ink7);
+}
+.jv-an-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: none;
+}
+.jv-an-btn {
+	height: 30px;
+	display: inline-flex;
+	align-items: center;
+	padding: 0 11px;
+	border: 1px solid color-mix(in srgb, var(--jv-tone) 40%, transparent);
+	border-radius: 8px;
+	background: transparent;
+	font-family: inherit;
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--jv-tone);
+	text-decoration: none;
+	white-space: nowrap;
+}
+.jv-an-btn:active {
+	background: color-mix(in srgb, var(--jv-tone) 16%, transparent);
+}
+.jv-an-x {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	flex: none;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--ink5);
+	cursor: pointer;
+}
+.jv-an-x:active {
+	background: color-mix(in srgb, var(--ink9) 10%, transparent);
+}
+.jv-an-btn:focus-visible,
+.jv-an-x:focus-visible {
+	outline: 2px solid var(--jv-tone);
+	outline-offset: 2px;
+}
+</style>

--- a/pwa/src/components/AnnouncementBanner.vue
+++ b/pwa/src/components/AnnouncementBanner.vue
@@ -19,8 +19,30 @@ const showLink = isSafeLink(announcement.link_url);
 <template>
 	<!-- Coloured by severity - accent (Info) or amber (Warning). -->
 	<div class="jv-announcementbanner" :class="'jv-tone-' + tone">
+		<!-- Tone is conveyed by the icon shape (triangle vs circle) as well as colour,
+		     not colour alone. Decorative: the severity is also in the visible prose. -->
 		<svg
+			v-if="tone === 'warning'"
 			class="jv-an-icon"
+			aria-hidden="true"
+			viewBox="0 0 24 24"
+			width="16"
+			height="16"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path
+				d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+			/>
+			<path d="M12 9v4M12 17h.01" />
+		</svg>
+		<svg
+			v-else
+			class="jv-an-icon"
+			aria-hidden="true"
 			viewBox="0 0 24 24"
 			width="16"
 			height="16"
@@ -103,7 +125,9 @@ const showLink = isSafeLink(announcement.link_url);
 	font-size: 13px;
 	font-weight: 600;
 	line-height: 1.4;
-	color: var(--jv-tone);
+	/* High-contrast neutral ink, not the tone colour: the Info tone (accent) on its
+	   tinted bg misses WCAG AA for text. Tone reads via the icon + border instead. */
+	color: var(--ink9);
 }
 .jv-an-msg {
 	font-size: 13px;
@@ -127,7 +151,8 @@ const showLink = isSafeLink(announcement.link_url);
 	font-family: inherit;
 	font-size: 12.5px;
 	font-weight: 600;
-	color: var(--jv-tone);
+	/* Neutral high-contrast ink (AA), tonal border keeps it on-theme. */
+	color: var(--ink9);
 	text-decoration: none;
 	white-space: nowrap;
 }


### PR DESCRIPTION
## Customer Announcements — Slice B (bench banner + per-device frequency)

Renders the fleet-wide operator **announcement** (shipped by the control plane on the connection poll, admin-v2 Slice A) as a **soft, dismissible in-app banner** on every customer bench — the chat SPA and the PWA — with a per-device "re-show every N days" snooze. Mirrors the existing release-banner machinery (`release_notice` / `UpdateBanner` / `releaseNudge`); adds nothing to the blocking/gate paths.

**Ships DARK.** Nothing renders until an operator publishes an announcement (Slice A is dark in prod). Additive only — **zero touch** to the live `release_notice` module, the `policy.py` chat-block, or `write_connection`.

### What it adds
- **`jarvis/announcement.py`** — mirrors `conn["announcement"]` into a read-only `Jarvis Settings` section and exposes `boot_payload()`. `boot_payload()` is total (a bad `expires_on` can never 500 the bare boot call); empty expiry stored as `NULL`; strict `now < expires_on` boundary matching the CP. No `check()` verb (unneeded for a soft banner — the mirror refreshes via the existing daily-sync + chat-gate persist sites + boot).
- **Wiring** — persist beside `release_notice` at the onboarding sync + chat-gate sites; `context.boot["announcement"]` in both `www` boot files; `settings_reset` parity.
- **SPA** — `announcementNudge.js` (pure, node-tested snooze) + `announcementGate.js` + `AnnouncementBanner.vue`, mounted top-of-chat beside the update banner.
- **PWA** — mirror gate + a hand-rolled banner, mounted beside the install/update strip.

### Safety / correctness
- **XSS-safe by construction:** title + body render as **plain text** (`{{ }}`, never `v-html`); the CTA is a scheme-gated `<a>` (`^https?://` only) with `rel="noopener noreferrer"` on both frontends. Proven inert by the SPA vitest spec + the node scheme-gate matrix.
- **Frequency:** per-device localStorage snooze keyed by announcement id + `interval_days` (mirrors the release banner). No new per-user doctype/verb — correct because only one banner is ever live (admin-v2 single-live-banner).
- **Precedence:** the announcement wins the single top-of-chat slot (the update banner yields to it); both yield to greeting / booting / urgent alerts (SPA) and to the install banner / signed-out state (PWA). Provably mutually exclusive; never stacks; never blocks chat.

### Testing
- `node --test` 17/17 (pure snooze + scheme gate); `ruff` / `eslint` / `prettier` green (pre-commit). Backend has Frappe tests for the mirror/boot/persist/settings-reset and boot exposure; the SPA banner has a vitest spec (XSS-inert + CTA gate + dismiss).
- Front gate (`/plan-check`, 2 opus critics) + back gate (`/review-loop`, 3 reviewers) → **ship**; findings folded in.

### ⚠️ Required before merge
- **The Frappe Python suite runs on CI** — the local shared bench was in use by another session, so the local round-trip was not run here.
- **A browser flow review** (per this repo's `CLAUDE.md`) is still required and has **not** been run — it's the true gate for the banner render/dismiss/re-show, and especially for the **PWA hand-rolled banner, which has no vitest harness** (a pre-existing PWA-wide gap, accepted + tracked, not introduced here). Please do a browser smoke before merging.
- Built SPA/PWA bundles are not committed (gitignored; the deploy rebuilds them).

### Out of scope
Slice C — the broadcast-email-to-all-customers channel (admin-v2).

