### PR TITLE
feat(chat): customer-facing upgrade maintenance hold (SPA, PWA, Desk …

### DIFF
--- a/frontend/src/components/JarvisMark.vue
+++ b/frontend/src/components/JarvisMark.vue
@@ -7,11 +7,14 @@
 
 	     `mood` turns the mark into a tiny reacting face for the moments that have
 	     one: eyes that glance while a reply is being written (thinking), widen
-	     while the mic is capturing (listening), and a one-off smile when the
-	     answer lands (happy). Default "star" renders exactly the resting spark, so
-	     the existing call sites need no change. The face is white on the same
-	     brand gradient as the spark - it never introduces a colour of its own, and
-	     the whitelabel <img> branch ignores mood entirely. -->
+	     while the mic is capturing (listening), a one-off smile when the answer
+	     lands (happy), and heavy sleepy lids with a soft "z z z" while the agent is
+	     being upgraded (upgrading). Default "star" renders exactly the resting
+	     spark, so the existing call sites need no change. The face is white on the
+	     same brand gradient as the spark - it never introduces a colour of its
+	     own, and the whitelabel <img> branch ignores mood entirely (a tenant with
+	     an uploaded logo keeps their logo during an upgrade; the maintenance
+	     banner still carries the "back shortly" message). -->
 	<img
 		v-if="brandLogoUrl"
 		class="jv-mark jv-mark-img"
@@ -38,6 +41,9 @@
 			<span class="jv-eyes"><i class="jv-eye"></i><i class="jv-eye"></i></span>
 			<span class="jv-mouth"></span>
 		</span>
+		<span v-if="mood === 'upgrading'" class="jv-zzz" aria-hidden="true"
+			><i>z</i><i>z</i><i>z</i></span
+		>
 	</span>
 </template>
 
@@ -54,11 +60,12 @@ const props = defineProps({
 	 * "thinking"  eyes glance around  - while a reply is being written
 	 * "listening" eyes widen + pulse  - while voice/mic is capturing
 	 * "happy"     smile, plays once   - the moment an answer lands
+	 * "upgrading" sleepy lids + z z z  - while the agent is being upgraded
 	 */
 	mood: {
 		type: String,
 		default: "star",
-		validator: (v) => ["star", "thinking", "listening", "happy"].includes(v),
+		validator: (v) => ["star", "thinking", "listening", "happy", "upgrading"].includes(v),
 	},
 	/** Sidebar/brand use: reveal a friendly blink on hover, calm otherwise. */
 	hoverPeek: { type: Boolean, default: false },
@@ -325,6 +332,87 @@ const markStyle = computed(() => ({
 	}
 }
 
+/* UPGRADING - the maintenance mood. The same white pills the other moods use,
+   drooped to heavy sleepy lids that slow-blink, over a soft breath, with a faint
+   "z z z" rising in the corner: the mark reads as "resting, back shortly" while
+   the agent is being upgraded. Everything stays inside the mark (which clips to
+   its rounded square), so nothing is cut off; a whitelabel <img> shows no face,
+   and the maintenance banner carries the message there. */
+.jv-mood-upgrading .jv-face {
+	animation: jvm-rest-breathe 4.6s ease-in-out infinite;
+}
+.jv-mood-upgrading .jv-eye {
+	height: calc(var(--jv-mark-size) * 0.055);
+	animation: jvm-rest-lid 4.6s ease-in-out infinite;
+}
+.jv-mood-upgrading .jv-eye:first-child {
+	transform: rotate(-13deg);
+}
+.jv-mood-upgrading .jv-eye:last-child {
+	transform: rotate(13deg);
+}
+@keyframes jvm-rest-breathe {
+	0%,
+	100% {
+		transform: scale(0.99);
+	}
+	50% {
+		transform: scale(1.02);
+	}
+}
+@keyframes jvm-rest-lid {
+	0%,
+	100% {
+		height: calc(var(--jv-mark-size) * 0.055);
+	}
+	50% {
+		height: calc(var(--jv-mark-size) * 0.022);
+	}
+}
+/* The sleep "z z z", white on the gradient, rising and fading in the corner.
+   Bounded travel so it fades before the clip edge rather than being cut. */
+.jv-zzz {
+	position: absolute;
+	top: 9%;
+	right: 8%;
+	display: flex;
+	align-items: flex-end;
+	gap: 1px;
+	line-height: 1;
+	pointer-events: none;
+}
+.jv-zzz i {
+	font-style: normal;
+	font-weight: 800;
+	color: #fff;
+	opacity: 0;
+}
+.jv-zzz i:nth-child(1) {
+	font-size: calc(var(--jv-mark-size) * 0.13);
+	animation: jvm-zfloat 3.2s ease-out infinite;
+}
+.jv-zzz i:nth-child(2) {
+	font-size: calc(var(--jv-mark-size) * 0.17);
+	animation: jvm-zfloat 3.2s ease-out 0.6s infinite;
+}
+.jv-zzz i:nth-child(3) {
+	font-size: calc(var(--jv-mark-size) * 0.22);
+	animation: jvm-zfloat 3.2s ease-out 1.2s infinite;
+}
+@keyframes jvm-zfloat {
+	0% {
+		opacity: 0;
+		transform: translateY(20%) scale(0.7);
+	}
+	30% {
+		opacity: 0.85;
+	}
+	100% {
+		opacity: 0;
+		transform: translateY(-30%) scale(1.05);
+	}
+}
+
 /* PEEK - resting star until triggered, then the same "thinking" glance the
    thinking mood uses (eyes look around, with a soft blink) rather than a quick
    one-off blink, so a resting mark is clearly, visibly alive. Triggered by
@@ -358,6 +446,17 @@ const markStyle = computed(() => ({
 	}
 	.jv-mood-thinking .jv-eye {
 		transform: translateY(-8%);
+	}
+	/* Upgrading: hold a calm sleeping frame - heavy lids, the z z z shown
+	   statically so it still reads as resting without any motion. */
+	.jv-mood-upgrading .jv-eye {
+		height: calc(var(--jv-mark-size) * 0.055);
+	}
+	.jv-zzz i {
+		/* Stop the rise/fade (an animation would otherwise override this static
+		   opacity); hold the z's visible so the frame still reads as resting. */
+		animation: none !important;
+		opacity: 0.8;
 	}
 }
 </style>

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -19,7 +19,13 @@
 				     exactly what let the chat welcome mark drift to a different colour
 				     (design.md §2.2). idlePeek: this is the one mark that sits resting on
 				     every route, so it's the chosen surface for the designed idle blink. -->
-				<JarvisMark :size="28" :radius="7" :peek="brandPeek" idlePeek />
+				<JarvisMark
+					:size="28"
+					:radius="7"
+					:peek="brandPeek"
+					:mood="holdActive ? 'upgrading' : 'star'"
+					idlePeek
+				/>
 				<div
 					class="flex flex-1 flex-col overflow-hidden text-left duration-300 ease-in-out"
 					:class="isCollapsed ? 'ml-0 w-0 opacity-0' : 'ml-2 w-auto opacity-100'"
@@ -50,6 +56,7 @@ import { useShellStore } from "@/stores/shell";
 import { useSupportStore } from "@/stores/support";
 import { useJarvisTheme } from "@/theme";
 import { agentName } from "@/branding";
+import { holdActive } from "@/maintenanceGate";
 
 const props = defineProps({
 	isCollapsed: { type: Boolean, default: false },

--- a/frontend/src/maintenanceGate.js
+++ b/frontend/src/maintenanceGate.js
@@ -1,0 +1,90 @@
+// Maintenance hold, delivered by the www/jarvis.py boot payload as
+// window.maintenance = { active, message }. The sibling of noticeGate.js, with one
+// deliberate difference: this state is REACTIVE, not a page-lifetime constant. A
+// release nudge is true for the whole session; an upgrade hold is raised and
+// cleared WHILE the customer is mid-chat, so the banner, the avatar's "upgrading"
+// mood and the send refusal must all be able to flip live.
+//
+// It is a PURE TOGGLE (no TTL, no tier) already resolved on the control plane
+// (tenant -> host -> cell) with the fleet-wide kill-switch applied; this module
+// only decides whether to show the "back shortly" banner and with what text, and
+// re-checks the CP so an open tab lifts the hold promptly when the roll clears it.
+import { computed, ref } from "vue";
+import { call } from "frappe-ui";
+import { holdShouldShow, holdMessage, nextNotice } from "@/maintenanceHold";
+import { agentName } from "@/branding";
+
+const boot = window.maintenance || {};
+const notice = ref({ active: !!boot.active, message: (boot.message || "").trim() });
+
+// True while the upgrade hold is up. Single source of truth for the top-of-chat
+// banner, the presence avatar's "upgrading" mood, and the send refusal.
+export const holdActive = computed(() => holdShouldShow(notice.value));
+
+// The banner / refusal sentence, white-label aware: agentName comes from branding
+// (the operator's custom message, already brand-scrubbed server-side, wins when set).
+export const holdText = computed(() => holdMessage(notice.value, agentName));
+
+export const rechecking = ref(false);
+
+// Raise the hold locally from a server refusal. If the customer already had the tab
+// open when the operator set the hold, boot never carried it; the first blocked send
+// comes back with reason "maintenance", and ChatView calls this so the banner + mood
+// appear without a reload. The server refusal carries only a reason today (no message),
+// so `message` is normally empty and the boot-seeded / branded-default copy is kept; a
+// future server that attaches a pre-scrubbed message would surface it here.
+export function raiseHold(message) {
+	const msg = (message || "").trim();
+	notice.value = { active: true, message: msg || notice.value.message };
+	_startPoll();
+}
+
+// Clear the hold locally. Called when a send is ACCEPTED - which proves the CP-side
+// gate passed, i.e. the roll has finished - so the banner + avatar lift immediately
+// instead of waiting for a reload or the next poll. Idempotent.
+export function clearHold() {
+	if (notice.value.active) notice.value = { active: false, message: "" };
+	_stopPoll();
+}
+
+// Re-pull the hold from the control plane. Keeps the last-known notice on any error or
+// malformed shape (via nextNotice) - a failed poll must never flip a live hold off.
+export async function recheck() {
+	if (rechecking.value) return holdActive.value;
+	rechecking.value = true;
+	try {
+		const fresh = await call("jarvis.maintenance_notice.check");
+		notice.value = nextNotice(notice.value, fresh);
+	} catch (e) {
+		/* keep last-known: a failed poll must not clear a live hold */
+	} finally {
+		rechecking.value = false;
+	}
+	// Keep the poll in lockstep with the actual state: a recheck usually CLEARS the
+	// hold (stop polling), but folding in a genuinely-new CP hold could re-raise it, so
+	// (re)start rather than only ever stopping.
+	if (holdActive.value) _startPoll();
+	else _stopPoll();
+	return holdActive.value;
+}
+
+// While a hold is up, re-check the CP on a slow cadence so an IDLE tab (one that never
+// sends again after the roll finishes) still lifts the banner. The send path clears it
+// instantly for an active user (clearHold); this covers the rest. Mirrors the release
+// gate's 60s poll (UpdateNoticeGate.vue). Runs only while held: started on raise / boot,
+// stopped on clear.
+const POLL_MS = 60000;
+let _pollTimer = null;
+function _startPoll() {
+	if (_pollTimer || typeof setInterval !== "function") return;
+	_pollTimer = setInterval(() => {
+		recheck();
+	}, POLL_MS);
+}
+function _stopPoll() {
+	if (_pollTimer) {
+		clearInterval(_pollTimer);
+		_pollTimer = null;
+	}
+}
+if (notice.value.active) _startPoll();

--- a/frontend/src/maintenanceGate.spec.js
+++ b/frontend/src/maintenanceGate.spec.js
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// frappe-ui's `call` is the control-plane round-trip recheck() makes; mock it.
+const callMock = vi.fn();
+vi.mock("frappe-ui", () => ({ call: (...a) => callMock(...a) }));
+
+// The gate reads window.maintenance at import time, so seed it then dynamic-import
+// with a fresh module registry so each test gets its own module state.
+async function loadGate(boot) {
+	vi.resetModules();
+	window.maintenance = boot;
+	return import("./maintenanceGate.js");
+}
+
+beforeEach(() => {
+	// The gate polls via setInterval while a hold is up; fake timers keep those out of
+	// the event loop (no real 60s timer leaks across the resetModules-per-test).
+	vi.useFakeTimers();
+	callMock.mockReset();
+	delete window.agent_name; // -> agentName defaults to "Jarvis"
+});
+
+afterEach(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+});
+
+describe("maintenanceGate", () => {
+	it("seeds holdActive + branded holdText from the boot payload", async () => {
+		const g = await loadGate({ active: true, message: "" });
+		expect(g.holdActive.value).toBe(true);
+		expect(g.holdText.value).toBe("Jarvis is upgrading and will be back shortly.");
+	});
+
+	it("is not held when boot is absent or inactive", async () => {
+		expect((await loadGate(undefined)).holdActive.value).toBe(false);
+		expect((await loadGate({ active: false })).holdActive.value).toBe(false);
+	});
+
+	it("shows the operator's custom message when set", async () => {
+		const g = await loadGate({ active: true, message: "Scheduled upgrade, ~5 min." });
+		expect(g.holdText.value).toBe("Scheduled upgrade, ~5 min.");
+	});
+
+	it("uses the white-label agent name in the default copy", async () => {
+		window.agent_name = "Acme AI";
+		const g = await loadGate({ active: true, message: "" });
+		expect(g.holdText.value).toBe("Acme AI is upgrading and will be back shortly.");
+	});
+
+	it("raiseHold turns a not-held tab into held with the server message", async () => {
+		const g = await loadGate({ active: false, message: "" });
+		expect(g.holdActive.value).toBe(false);
+		g.raiseHold("We're upgrading now.");
+		expect(g.holdActive.value).toBe(true);
+		expect(g.holdText.value).toBe("We're upgrading now.");
+	});
+
+	it("recheck lifts the hold when the CP reports it cleared", async () => {
+		const g = await loadGate({ active: true, message: "x" });
+		callMock.mockResolvedValueOnce({ active: false, message: "" });
+		const stillHeld = await g.recheck();
+		expect(callMock).toHaveBeenCalledWith("jarvis.maintenance_notice.check");
+		expect(g.holdActive.value).toBe(false);
+		expect(stillHeld).toBe(false);
+	});
+
+	it("recheck keeps the last-known hold when the poll throws (never clears on error)", async () => {
+		const g = await loadGate({ active: true, message: "held" });
+		callMock.mockRejectedValueOnce(new Error("offline"));
+		await g.recheck();
+		expect(g.holdActive.value).toBe(true);
+		expect(g.holdText.value).toBe("held");
+	});
+
+	it("recheck keeps the last-known hold when the CP payload is malformed (missing active)", async () => {
+		const g = await loadGate({ active: true, message: "held" });
+		callMock.mockResolvedValueOnce({ message: "no active key" });
+		await g.recheck();
+		expect(g.holdActive.value).toBe(true);
+	});
+
+	it("clearHold lifts an active hold (self-heal when a send is accepted)", async () => {
+		const g = await loadGate({ active: true, message: "up" });
+		expect(g.holdActive.value).toBe(true);
+		g.clearHold();
+		expect(g.holdActive.value).toBe(false);
+	});
+});

--- a/frontend/src/maintenanceHold.js
+++ b/frontend/src/maintenanceHold.js
@@ -1,0 +1,36 @@
+// Shared maintenance-hold display logic for both frontends: the SPA imports it as
+// `@/maintenanceHold`, the mobile PWA as `@shared/maintenanceHold` (one-way share, see
+// pwa/vite.config.js). Keep this a pure ES module - no `@/` imports and no Vue - so
+// `node --test` can resolve and run it without a bundler.
+//
+// The wire payload is minimal: { active, message }. It is a PURE TOGGLE (no TTL, no
+// tier) resolved on the control plane tenant -> host -> cell; the bench mirrors it and
+// this module only decides whether to show the "back shortly" banner and with what text.
+
+// Show the hold banner iff the resolved notice is active. `active` is the single source
+// of truth (the CP already applied the kill-switch + scope resolution).
+export function holdShouldShow(notice) {
+	return !!(notice && notice.active);
+}
+
+// The banner / refusal sentence. `brandName` is a PARAMETER (default "Jarvis"), not an
+// import, so this module stays node-testable and single-sourced - the caller passes the
+// white-label agent name in, and a customer who renamed the assistant never sees
+// "Jarvis" leak. The operator's custom message (already brand-scrubbed server-side)
+// wins when present; otherwise the branded default.
+export function holdMessage(notice, brandName = "Jarvis") {
+	const brand = (brandName || "").trim() || "Jarvis";
+	const custom = notice && notice.message ? String(notice.message).trim() : "";
+	return custom || `${brand} is upgrading and will be back shortly.`;
+}
+
+// Fold a fresh control-plane payload into the current notice, applying the same
+// present-vs-unknown discipline the bench uses (Stream E decision 3): a well-formed
+// payload (an object that carries `active`) is authoritative and replaces the notice; a
+// missing or malformed one is UNKNOWN and keeps the last-known notice, so a partial /
+// failed poll can never silently flip a live hold off. Pure, so both the SPA and PWA
+// gates share one tested implementation instead of each trusting a raw payload shape.
+export function nextNotice(current, fresh) {
+	if (!fresh || typeof fresh !== "object" || !("active" in fresh)) return current;
+	return { active: !!fresh.active, message: (fresh.message || "").trim() };
+}

--- a/frontend/src/maintenanceHold.test.js
+++ b/frontend/src/maintenanceHold.test.js
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { holdShouldShow, holdMessage, nextNotice } from "./maintenanceHold.js";
+
+test("holdShouldShow: only when active", () => {
+	assert.equal(holdShouldShow({ active: true }), true);
+	assert.equal(holdShouldShow({ active: false }), false);
+	assert.equal(holdShouldShow({}), false);
+	assert.equal(holdShouldShow(null), false);
+	assert.equal(holdShouldShow(undefined), false);
+});
+
+test("holdMessage: operator message wins when present", () => {
+	assert.equal(holdMessage({ active: true, message: "Back at 3pm." }, "Aida"), "Back at 3pm.");
+});
+
+test("holdMessage: branded default when no message", () => {
+	assert.equal(
+		holdMessage({ active: true }, "Aida"),
+		"Aida is upgrading and will be back shortly."
+	);
+	assert.equal(holdMessage({}, "Aida"), "Aida is upgrading and will be back shortly.");
+});
+
+test("holdMessage: white-label - blank/missing brand falls back to Jarvis", () => {
+	const expected = "Jarvis is upgrading and will be back shortly.";
+	assert.equal(holdMessage({}, ""), expected);
+	assert.equal(holdMessage({}, "   "), expected);
+	assert.equal(holdMessage({}), expected);
+});
+
+test("holdMessage: a whitespace-only operator message falls back to the branded default", () => {
+	assert.equal(
+		holdMessage({ message: "   " }, "Aida"),
+		"Aida is upgrading and will be back shortly."
+	);
+});
+
+test("nextNotice: a well-formed payload is authoritative (sets and clears)", () => {
+	const cur = { active: true, message: "old" };
+	assert.deepEqual(nextNotice(cur, { active: false }), { active: false, message: "" });
+	assert.deepEqual(nextNotice(cur, { active: true, message: " up " }), {
+		active: true,
+		message: "up",
+	});
+});
+
+test("nextNotice: a missing/malformed payload keeps the last-known notice (never clears on garbage)", () => {
+	const cur = { active: true, message: "held" };
+	assert.equal(nextNotice(cur, undefined), cur);
+	assert.equal(nextNotice(cur, null), cur);
+	assert.equal(nextNotice(cur, "nope"), cur);
+	// A payload missing `active` entirely is UNKNOWN, not "inactive" - keep last-known
+	// rather than let !!undefined silently flip a live hold off.
+	assert.equal(nextNotice(cur, { message: "x" }), cur);
+});

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -412,6 +412,69 @@ describe("ChatView banner chain order", () => {
 });
 
 /**
+ * Upgrade maintenance hold (Stream E). Same source-read technique as the suites
+ * above (mounting ChatView is not viable). Pins the four load-bearing wiring
+ * facts: the hold banner outranks the release nudge, the composer stays enabled,
+ * and the send-gate branch mirrors the server's policy order without a reload.
+ */
+describe("maintenance hold banner + send gate", () => {
+	const HERE = path.dirname(fileURLToPath(import.meta.url));
+	const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+	it("renders the hold banner before (above) the release-nudge update banner", () => {
+		const hold = chatSrc.indexOf('v-if="holdActive"');
+		const update = chatSrc.indexOf('v-if="updateBannerVisible"');
+		expect(hold, "ChatView must render the maintenance hold banner").not.toBe(-1);
+		expect(update, "ChatView must still render the update banner").not.toBe(-1);
+		// The hold is the more urgent state; the two must never stack (holdActive is
+		// also in hasUrgentAlert, which suppresses updateBannerVisible).
+		expect(hold).toBeLessThan(update);
+	});
+
+	it("suppresses the update banner while a hold is active (holdActive in hasUrgentAlert)", () => {
+		const start = chatSrc.indexOf("const hasUrgentAlert = computed(");
+		expect(start, "ChatView must still define hasUrgentAlert").not.toBe(-1);
+		const end = chatSrc.indexOf(");", start);
+		expect(chatSrc.slice(start, end)).toContain("holdActive.value");
+	});
+
+	it("never gates canSend on holdActive (composer stays enabled - soft refusal only)", () => {
+		const start = chatSrc.indexOf("const canSend = computed(");
+		expect(start, "ChatView must still define canSend").not.toBe(-1);
+		const end = chatSrc.indexOf("\n);", start);
+		expect(chatSrc.slice(start, end)).not.toContain("holdActive");
+	});
+
+	it("orders the send-gate maintenance branch between release-update and workspace-resetting", () => {
+		// Searched from send()'s start so retry()'s own maintenance branch (earlier
+		// in the file) doesn't shadow these positions.
+		const sendStart = chatSrc.indexOf("async function send(");
+		expect(sendStart, "ChatView must still define send()").not.toBe(-1);
+		const rel = chatSrc.indexOf('r.reason === "release_update_required"', sendStart);
+		const maint = chatSrc.indexOf('r.reason === "maintenance"', sendStart);
+		const reset = chatSrc.indexOf('r.reason === "workspace_resetting"', sendStart);
+		expect(rel).not.toBe(-1);
+		expect(maint, "send() must handle the maintenance reason").not.toBe(-1);
+		expect(reset).not.toBe(-1);
+		// Mirrors jarvis.chat.policy.validate_can_send: release_update_required ->
+		// maintenance -> workspace_resetting.
+		expect(rel).toBeLessThan(maint);
+		expect(maint).toBeLessThan(reset);
+	});
+
+	it("raises the hold (no reload) in the send-gate maintenance branch", () => {
+		const sendStart = chatSrc.indexOf("async function send(");
+		const maint = chatSrc.indexOf('r.reason === "maintenance"', sendStart);
+		const reset = chatSrc.indexOf('r.reason === "workspace_resetting"', sendStart);
+		const branch = chatSrc.slice(maint, reset);
+		// Self-heal via raiseHold + recheck, NOT a page reload (a hold is transient,
+		// unlike release_update_required which reloads onto the full-page gate).
+		expect(branch).toContain("raiseHold");
+		expect(branch).not.toContain("window.location.reload");
+	});
+});
+
+/**
  * The hard "no workers" block is gone: RQ's worker registry can read zero
  * while every worker is alive (a worker hash that expired during a heartbeat
  * gap comes back without its queues), so the server never refuses a send for

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -556,6 +556,17 @@
 			     stacks, never hides chat. -->
 			<AnnouncementBanner v-if="announcementVisible" />
 
+			<!-- Upgrade maintenance hold (Stream E): a friendly "back shortly" while
+			     this tenant's agent is being upgraded (an image roll / reprovision).
+			     Same top-of-chat slot and warning register as the update banner, but
+			     the composer STAYS enabled - the send-gate gives a soft refusal and
+			     self-heals when the roll clears (see send()'s "maintenance" branch).
+			     Takes precedence over the release-nudge soft banner (holdActive is in
+			     hasUrgentAlert), so the two never stack. role/aria-live announce it. -->
+			<div v-if="holdActive" role="status" aria-live="polite" style="margin: 12px 18px 0">
+				<Banner type="warning" :message="holdText" align="center" />
+			</div>
+
 			<!-- Release-nudge banner (Slice 3b): severity-coloured (amber for soft,
 			     red for severe), top-of-chat. Shows over the welcome screen; yields
 			     to the greeting/booting states and to any urgent billing/readiness
@@ -607,7 +618,12 @@
 							overflow-wrap: anywhere;
 						"
 					>
-						<JarvisMark :size="38" :radius="11" style="flex: none" />
+						<JarvisMark
+							:size="38"
+							:radius="11"
+							:mood="holdActive ? 'upgrading' : 'star'"
+							style="flex: none"
+						/>
 						<span>{{ greeting }}, {{ firstName }}</span>
 					</h1>
 					<p class="jv-welcome-sub">
@@ -4530,6 +4546,14 @@ import AnnouncementBanner from "@/components/chat/AnnouncementBanner.vue";
 import WhatsNewDialog from "@/components/chat/WhatsNewDialog.vue";
 import { showBanner } from "@/noticeGate";
 import { showAnnouncement } from "@/announcementGate";
+
+import {
+	holdActive,
+	holdText,
+	raiseHold,
+	clearHold,
+	recheck as recheckMaintenance,
+} from "@/maintenanceGate";
 import { parseAsk } from "@/lib/chatAsk";
 import { sendRejectionCopy } from "@/lib/sendRejectionCopy";
 import { shouldHideActivityTool, isCustomerFacingTool } from "@/lib/activityTools";
@@ -4846,13 +4870,18 @@ const versionPillRef = ref(null);
 const hasUrgentAlert = computed(
 	() =>
 		!!(
-			replacedAlert.value ||
-			billingAlert.value ||
-			suspendedNotice.value ||
-			noAiConnected.value ||
-			containerUnavailable.value ||
-			llmApplyStuck.value ||
-			notReadyNotice.value
+			// An active upgrade maintenance hold pauses chat too (Stream E), so the
+			// release-nudge soft banner yields to the "back shortly" banner.
+			(
+				holdActive.value ||
+				replacedAlert.value ||
+				billingAlert.value ||
+				suspendedNotice.value ||
+				noAiConnected.value ||
+				containerUnavailable.value ||
+				llmApplyStuck.value ||
+				notReadyNotice.value
+			)
 		)
 );
 // The operator announcement banner shares the top-of-chat slot and the same
@@ -9139,6 +9168,10 @@ async function retry(messageId) {
 			// not a toast that vanishes before they can renew.
 			if (r.reason === "subscription_suspended") {
 				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
+			} else if (r.reason === "maintenance") {
+				// Same as send(): raise the hold banner + self-heal, no toast.
+				raiseHold(r.message);
+				recheckMaintenance();
 			} else {
 				// e.g. the single-flight guard ("a reply is already in progress").
 				notify(r.reason || "Couldn't retry that.", { type: "error" });
@@ -9146,6 +9179,8 @@ async function retry(messageId) {
 		}
 		if (r && r.ok !== false) {
 			workersWarnNotice.value = null; // a retry got through: workers are back
+			// A retry that got through also proves any maintenance hold lifted.
+			clearHold();
 		}
 	} catch (e) {
 		sending.value = false;
@@ -9415,6 +9450,16 @@ async function send(textArg, resendAck) {
 				setTimeout(() => window.location.reload(), 1500);
 				return;
 			}
+			// Maintenance hold (Stream E): the operator/roll raised an upgrade hold
+			// while this tab was open, so boot never carried it. Show the friendly
+			// "back shortly" banner + self-heal by re-checking the CP; the composer
+			// stays enabled, so the next send lands the moment the roll clears. No
+			// reload (unlike release_update_required) - an upgrade hold is transient.
+			if (r.reason === "maintenance") {
+				raiseHold(r.message);
+				recheckMaintenance();
+				return;
+			}
 			if (r.reason === "workspace_resetting") {
 				notify(`${agentName} is being reset. Chat will be back in a few minutes.`, {
 					type: "warning",
@@ -9440,6 +9485,10 @@ async function send(textArg, resendAck) {
 		}
 		if (r && r.ok !== false) {
 			workersWarnNotice.value = null; // a send got through: workers are back
+			// An accepted send proves the CP-side gate passed, i.e. any upgrade
+			// maintenance hold has lifted - clear the banner + wake the avatar now
+			// rather than stranding them until a reload (self-heal).
+			clearHold();
 		}
 		// Send accepted — the one-shot grounding/prefill context is now consumed.
 		// Cleared HERE, not before the await: a rejected send (r.ok === false, above)

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -567,10 +567,10 @@ def _admin_chat_gate() -> dict:
 	release_notice.persist(conn.get("release_notice") or {})
 	# Same cadence: mirror the fleet-wide operator announcement for the soft banner.
 	announcement.persist(conn.get("announcement") or {})
-	# Same cadence for the maintenance hold. Present key = authoritative (set/clear);
-	# absent = unknown -> keep last-known (decision 3), so a partial payload can't clear
-	# a live hold mid-teardown.
-	maintenance_notice.persist(conn["maintenance"] if "maintenance" in conn else None)
+	# Same cadence for the maintenance hold. Marker-aware (see persist_from_connection): an
+	# old/rolled-back CP (no marker) clears; present key = authoritative; an absent key on a
+	# current CP = transient -> keep last-known, so a partial payload can't clear a live hold.
+	maintenance_notice.persist_from_connection(conn)
 	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -21,7 +21,7 @@ import hashlib
 
 import frappe
 
-from jarvis import admin_client, announcement, compat, onboarding_contract, release_notice
+from jarvis import admin_client, announcement, compat, maintenance_notice, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
@@ -567,6 +567,10 @@ def _admin_chat_gate() -> dict:
 	release_notice.persist(conn.get("release_notice") or {})
 	# Same cadence: mirror the fleet-wide operator announcement for the soft banner.
 	announcement.persist(conn.get("announcement") or {})
+	# Same cadence for the maintenance hold. Present key = authoritative (set/clear);
+	# absent = unknown -> keep last-known (decision 3), so a partial payload can't clear
+	# a live hold mid-teardown.
+	maintenance_notice.persist(conn["maintenance"] if "maintenance" in conn else None)
 	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 

--- a/jarvis/boot.py
+++ b/jarvis/boot.py
@@ -113,3 +113,15 @@ def set_jarvis_boot(bootinfo):
 	except Exception:
 		bootinfo.jarvis_agent_name = ""
 		bootinfo.jarvis_brand_logo_url = ""
+
+	# Upgrade maintenance hold (Stream E) for the desk floating widget: the same
+	# {active, message} the SPA/PWA get via their own boot payloads, so the bubble
+	# can show the "back shortly" banner + sleepy avatar proactively (Panel.vue
+	# reads window.frappe.boot.jarvis_maintenance synchronously, so no flash).
+	# Fail-safe to not-held: a boot error must never wedge the widget into a hold.
+	try:
+		from jarvis import maintenance_notice
+
+		bootinfo.jarvis_maintenance = maintenance_notice.boot_payload()
+	except Exception:
+		bootinfo.jarvis_maintenance = {"active": False, "message": ""}

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -68,6 +68,9 @@ _BLOCK_SENTENCE = {
 	"workspace_resetting": (
 		"Scheduled run deferred: the workspace is being rebuilt. It will retry on the next hourly tick."
 	),
+	"maintenance": (
+		"Scheduled run deferred: this workspace is being upgraded. It will retry on the next hourly tick."
+	),
 	BLOCK_STEP_BUDGET: (
 		"Scheduled run skipped: this month's budget for scheduled macro runs is used up. "
 		"Runs resume next month, or ask an admin to raise the budget in Jarvis Settings."
@@ -85,6 +88,7 @@ _BLOCK_SENTENCE = {
 _TRANSIENT_BLOCKS = {
 	"release_update_required",
 	"workspace_resetting",
+	"maintenance",
 	BLOCK_DISPATCH_FAILED,
 }
 

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -102,6 +102,7 @@ _BLOCK_MESSAGE = {
 	"subscription_suspended": "Your subscription does not currently include chat, so this macro cannot run.",
 	"release_update_required": "A Jarvis update is rolling out. Try this macro again in a few minutes.",
 	"workspace_resetting": "Your workspace is being rebuilt. Try this macro again in a few minutes.",
+	"maintenance": "Jarvis is being upgraded. Try this macro again in a few minutes.",
 	"llm_not_configured": "Connect an AI model before running a macro.",
 	BLOCK_STEP_BUDGET: "This month's budget for scheduled macro runs is used up.",
 	BLOCK_DISPATCH_FAILED: "This macro could not be started. Please try again in a few minutes.",

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -9,8 +9,9 @@ this module's contract.
 Returns (True, None) on success or (False, reason: str) on rejection. The
 reason is a machine code the SPA maps to a human toast: ``"usage_limit"`` for
 enforcement, ``"subscription_suspended"`` for billing,
-and ``"release_update_required"`` while a release rollout is blocking this
-bench. Worker health is never a gate here: RQ's worker registry can read zero
+``"release_update_required"`` while a release rollout is blocking this
+bench, and ``"maintenance"`` during an upgrade maintenance hold. Worker
+health is never a gate here: RQ's worker registry can read zero
 while every worker is alive (see ``jarvis.chat.pump._registry_is_stale``), and a
 turn nobody picks up is the orphan sweep's job (``stale_scan``).
 """
@@ -32,6 +33,11 @@ def validate_can_send(user: str, model: str | None = None) -> tuple[bool, str | 
 		return False, "subscription_suspended"
 	if _release_update_required():
 		return False, "release_update_required"
+	# Upgrade maintenance hold (operator- or roll-driven, resolved on the control plane).
+	# Before _workspace_resetting so the "upgrading, back shortly" copy wins over the
+	# generic "resetting" copy during a roll.
+	if _maintenance_hold():
+		return False, "maintenance"
 	if _workspace_resetting():
 		return False, "workspace_resetting"
 	if _llm_not_configured():
@@ -61,6 +67,26 @@ def _release_update_required() -> bool:
 			title="jarvis policy: release-notice check failed (allowing send)",
 			message=frappe.get_traceback(),
 		)
+		return False
+
+
+def _maintenance_hold() -> bool:
+	"""True while an upgrade maintenance hold applies to this bench (operator- or
+	roll-driven, resolved on the control plane, mirrored locally). Reads the local
+	mirror (no admin round-trip) so the send gate and the UI banner agree. Fails OPEN."""
+	try:
+		from jarvis import maintenance_notice
+
+		return bool(maintenance_notice.boot_payload().get("active"))
+	except Exception:
+		# See _workspace_resetting: don't let a logging failure defeat fail-open.
+		try:
+			frappe.log_error(
+				title="jarvis policy: maintenance-hold check failed (allowing send)",
+				message=frappe.get_traceback(),
+			)
+		except Exception:
+			pass
 		return False
 
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -156,7 +156,10 @@
   "admin_connection_col",
   "jarvis_admin_customer_email",
   "jarvis_admin_customer_password",
-  "signup_context"
+  "signup_context",
+  "maintenance_notice_section",
+  "maintenance_active",
+  "maintenance_message"
  ],
  "fields": [
   {
@@ -1134,6 +1137,26 @@
    "label": "Signup Context",
    "read_only": 1,
    "description": "Non-secret JSON snapshot of the in-flight signup: attempt id, the customer's real email + company as admin holds them, plan/provider, the amount and what is due today, the last contract code, and the contract version. Written by jarvis.onboarding_contract so a reloaded payment page renders whose signup it is showing instead of the site admin's prefill. NO SECRETS EVER GO IN THIS FIELD - permlevel is not a container for one: a Single's value is reachable through frappe.client.get_value / get_single_value by anyone who can read the doctype, and the permlevel only governs the form. Secrets belong in the Password fields above, which encrypt into __Auth. jarvis_admin_customer_email above holds admin's SYNTHETIC login (cust-<hash>@jarvis.invalid), which is not an address and must never be shown to anyone."
+  },
+  {
+   "fieldname": "maintenance_notice_section",
+   "fieldtype": "Section Break",
+   "label": "Maintenance Hold",
+   "collapsible": 1,
+   "description": "Mirror of the operator's upgrade maintenance hold, pulled from the control plane. Read-only here."
+  },
+  {
+   "fieldname": "maintenance_active",
+   "fieldtype": "Check",
+   "label": "In Maintenance",
+   "read_only": 1,
+   "default": "0"
+  },
+  {
+   "fieldname": "maintenance_message",
+   "fieldtype": "Small Text",
+   "label": "Maintenance Message",
+   "read_only": 1
   }
  ],
  "permissions": [

--- a/jarvis/maintenance_notice.py
+++ b/jarvis/maintenance_notice.py
@@ -3,11 +3,13 @@
 The control plane resolves the hold (tenant -> host -> cell) and the bench stores +
 renders it. Pure toggle owned by the CP -- there is NO local TTL / self-clear.
 
-Key discipline (Stream E decision 3): a PRESENT notice dict is authoritative (it sets
-OR clears the mirror); an ABSENT notice (``None``) means the CP could not resolve one
-(a transient / partial payload -- e.g. the destroy+reprovision window) -> KEEP the
-last-known state, so a brief unresolved poll can't flip a live hold off and dump the
-customer into a raw error mid-teardown.
+Key discipline (Stream E, marker-aware -- see ``persist_from_connection``): the CP stamps a
+``maintenance_supported`` capability marker on every payload. Marker ABSENT = an old /
+rolled-back CP -> CLEAR (never strand the bench behind a hold the old CP can't lift). Marker
+present + a PRESENT ``maintenance`` dict = authoritative (sets OR clears). Marker present + an
+ABSENT key = the CP could not resolve one (a transient / partial payload -- e.g. the
+destroy+reprovision window, or a resolver error) -> KEEP the last-known state, so a brief
+unresolved poll can't flip a live hold off and dump the customer into a raw error mid-teardown.
 
 Clearing happens on the CP (operator / roll ``clear_maintenance`` or the fleet-wide
 ``disable_maintenance_hold`` kill-switch); the bench reflects it on the next refresh.
@@ -64,6 +66,30 @@ def boot_payload() -> dict:
 		return {"active": False, "message": ""}
 
 
+def persist_from_connection(conn: dict) -> None:
+	"""Apply the maintenance mirror from a full get_connection payload, honouring the CP
+	capability marker (Stream E review App-1/#1). Three cases:
+
+	- marker ABSENT -> the CP does not speak maintenance (old / rolled back): clear the mirror
+	  authoritatively so a bench is never stranded behind a hold the old CP can no longer lift.
+	- marker present, ``maintenance`` key PRESENT -> authoritative (dict sets or clears).
+	- marker present, ``maintenance`` key ABSENT -> transient / partial payload (destroy window,
+	  or a CP resolver error that omitted the key) -> keep last-known.
+
+	DEPLOY-ORDER GUARDRAIL: a NEW bench must never poll an OLD (un-upgraded) CP while a hold is
+	live, or this clears it every poll -- deploy the CP before the app, and set no hold until both
+	are live. The breadcrumb below is the diagnostic if that ordering is ever violated."""
+	if not conn.get("maintenance_supported"):
+		if boot_payload().get("active"):
+			frappe.logger("jarvis").info(
+				"maintenance: clearing hold -- connection lacks maintenance_supported "
+				"(old/rolled-back control plane); confirm CP-before-app deploy order"
+			)
+		persist({"active": False})  # authoritative clear -- no strand on rollback
+		return
+	persist(conn.get("maintenance"))  # present dict = authoritative; absent -> None -> keep
+
+
 @frappe.whitelist(methods=["POST"])
 def check() -> dict:
 	"""Re-pull the connection from admin and refresh the local maintenance mirror, so an
@@ -79,8 +105,7 @@ def check() -> dict:
 		try:
 			conn = admin_client.get_connection(timeout_s=8) or {}
 			release_notice.persist(conn.get("release_notice") or {})
-			# Present key = authoritative; absent = unknown -> keep last-known (decision 3).
-			persist(conn["maintenance"] if "maintenance" in conn else None)
+			persist_from_connection(conn)
 		except Exception:
 			frappe.log_error(title="maintenance_notice.check failed", message=frappe.get_traceback())
 	return boot_payload()

--- a/jarvis/maintenance_notice.py
+++ b/jarvis/maintenance_notice.py
@@ -1,0 +1,86 @@
+"""Mirror the operator's resolved upgrade-maintenance hold locally and expose it to chat.
+
+The control plane resolves the hold (tenant -> host -> cell) and the bench stores +
+renders it. Pure toggle owned by the CP -- there is NO local TTL / self-clear.
+
+Key discipline (Stream E decision 3): a PRESENT notice dict is authoritative (it sets
+OR clears the mirror); an ABSENT notice (``None``) means the CP could not resolve one
+(a transient / partial payload -- e.g. the destroy+reprovision window) -> KEEP the
+last-known state, so a brief unresolved poll can't flip a live hold off and dump the
+customer into a raw error mid-teardown.
+
+Clearing happens on the CP (operator / roll ``clear_maintenance`` or the fleet-wide
+``disable_maintenance_hold`` kill-switch); the bench reflects it on the next refresh.
+"""
+
+import frappe
+
+SETTINGS = "Jarvis Settings"
+_FIELDS = ("maintenance_active", "maintenance_message")
+# One maintenance check refreshes BOTH notices (release + maintenance) from a single
+# get_connection, so an active hold doesn't add a second admin round-trip. This throttle
+# is INDEPENDENT of release_notice's own (different key) - the two check endpoints don't
+# share a window, so polling both within 30s can still make two calls.
+_CHECK_CACHE_KEY = "jarvis:maintenance_checked"
+_CHECK_CACHE_TTL_S = 30
+
+
+def persist(notice: dict | None) -> None:
+	"""Mirror the admin-sent maintenance notice onto Jarvis Settings.
+
+	``notice`` is a dict (authoritative: ``active`` True sets, False/`{}` clears) or
+	``None`` (unknown -> keep the last-known mirror; see the module docstring). Skips a
+	no-op write so it doesn't churn ``modified`` under an operator editing the form."""
+	try:
+		if notice is None:
+			return
+		fresh = {
+			"maintenance_active": 1 if notice.get("active") else 0,
+			"maintenance_message": notice.get("message") or "",
+		}
+		current = frappe.db.get_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
+		if (
+			frappe.utils.cint(current.get("maintenance_active")) == fresh["maintenance_active"]
+			and (current.get("maintenance_message") or "") == fresh["maintenance_message"]
+		):
+			return
+		frappe.db.set_value(SETTINGS, SETTINGS, fresh, update_modified=False)
+	except Exception:
+		frappe.log_error(title="maintenance_notice.persist failed", message=frappe.get_traceback())
+
+
+def boot_payload() -> dict:
+	"""``maintenance`` for context.boot and the send gate. active iff the mirror flag is
+	set (pure toggle -- the CP owns clearing it; this bench reflects the last-known state
+	until the next poll refreshes it). Fails to not-held on any read error."""
+	try:
+		row = frappe.get_cached_value(SETTINGS, SETTINGS, list(_FIELDS), as_dict=True) or {}
+		return {
+			"active": bool(frappe.utils.cint(row.get("maintenance_active"))),
+			"message": row.get("maintenance_message") or "",
+		}
+	except Exception:
+		frappe.log_error(title="maintenance_notice.boot_payload failed", message=frappe.get_traceback())
+		return {"active": False, "message": ""}
+
+
+@frappe.whitelist(methods=["POST"])
+def check() -> dict:
+	"""Re-pull the connection from admin and refresh the local maintenance mirror, so an
+	open chat tab lifts the hold promptly when the operator/roll clears it. One admin
+	round-trip refreshes BOTH notices (release + maintenance) -- an active maintenance
+	poll therefore keeps the release mirror fresh too, not a wasted second call. The
+	round-trip is cached briefly so many gated tabs cost one call."""
+	from jarvis import admin_client, release_notice
+
+	cache = frappe.cache()
+	if not cache.get_value(_CHECK_CACHE_KEY, expires=True):
+		cache.set_value(_CHECK_CACHE_KEY, "1", expires_in_sec=_CHECK_CACHE_TTL_S)
+		try:
+			conn = admin_client.get_connection(timeout_s=8) or {}
+			release_notice.persist(conn.get("release_notice") or {})
+			# Present key = authoritative; absent = unknown -> keep last-known (decision 3).
+			persist(conn["maintenance"] if "maintenance" in conn else None)
+		except Exception:
+			frappe.log_error(title="maintenance_notice.check failed", message=frappe.get_traceback())
+	return boot_payload()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe.utils import cint, validate_email_address
 
-from jarvis import admin_client, announcement, onboarding_contract, release_notice
+from jarvis import admin_client, announcement, maintenance_notice, onboarding_contract, release_notice
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
@@ -265,6 +265,9 @@ def sync_connection(timeout_s: int | None = None) -> dict:
 	release_notice.persist(data.get("release_notice") or {})
 	# Same cadence: mirror the fleet-wide operator announcement for the soft banner.
 	announcement.persist(data.get("announcement") or {})
+	# Same cadence for the maintenance hold. Present key = authoritative; absent = unknown
+	# -> keep last-known (decision 3).
+	maintenance_notice.persist(data["maintenance"] if "maintenance" in data else None)
 	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -265,9 +265,9 @@ def sync_connection(timeout_s: int | None = None) -> dict:
 	release_notice.persist(data.get("release_notice") or {})
 	# Same cadence: mirror the fleet-wide operator announcement for the soft banner.
 	announcement.persist(data.get("announcement") or {})
-	# Same cadence for the maintenance hold. Present key = authoritative; absent = unknown
-	# -> keep last-known (decision 3).
-	maintenance_notice.persist(data["maintenance"] if "maintenance" in data else None)
+	# Same cadence for the maintenance hold. Marker-aware (see persist_from_connection): an
+	# old/rolled-back CP (no marker) clears; present key = authoritative; absent key = keep.
+	maintenance_notice.persist_from_connection(data)
 	# Same cadence: mirror the backend-owned egress redaction rules for the chat backstop.
 	from jarvis.chat import egress_rules
 

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -68,8 +68,16 @@
 				></div>
 			</template>
 			<div class="jvp-head">
-				<div class="jvp-avatar">
+				<div class="jvp-avatar" :class="{ 'jvp-sleeping': maintenanceActive }">
 					<img v-if="brandLogoUrl" :src="brandLogoUrl" class="jvp-avatar-img" alt="" />
+					<!-- Upgrading: sleepy drooping lids (the desk twin of JarvisMark's
+					     "upgrading" mood). The online dot goes amber via .jvp-sleeping. -->
+					<span v-else-if="maintenanceActive" class="jvp-face" aria-hidden="true">
+						<i class="jvp-eye"></i><i class="jvp-eye"></i>
+					</span>
+					<span v-if="maintenanceActive" class="jvp-zzz" aria-hidden="true"
+						><i>z</i><i>z</i><i>z</i></span
+					>
 					<svg v-else viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
 						<path
 							d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
@@ -181,6 +189,19 @@
 			     replaces the conversation below it. Sits above the scrollable thread
 			     so it reads as a thin banner at the top, not inline with any one
 			     message. -->
+			<!-- Upgrade maintenance hold (Stream E): a proactive "back shortly" strip,
+			     shown regardless of readiness. The composer stays enabled below; a held
+			     send gets the friendly refusal and this self-clears when one gets
+			     through. Amber, like the worker notice; aria-live announces it. -->
+			<div
+				v-if="maintenanceActive"
+				class="jvp-maint-notice"
+				role="status"
+				aria-live="polite"
+			>
+				{{ maintenanceText }}
+			</div>
+
 			<div
 				v-if="workerWarning && readiness === 'ready'"
 				class="jvp-worker-notice"
@@ -239,8 +260,16 @@
 						v-else-if="!shownMessages.length && !stream.live && !thinking"
 						class="jvp-welcome"
 					>
-						<div class="jvp-hero">
-							<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
+						<div class="jvp-hero" :class="{ 'jvp-sleeping': maintenanceActive }">
+							<!-- Upgrading: the hero mark sleeps too, so it matches the header
+							     avatar instead of showing a wide-awake face during a hold. -->
+							<span v-if="maintenanceActive" class="jvp-face" aria-hidden="true">
+								<i class="jvp-eye"></i><i class="jvp-eye"></i>
+							</span>
+							<span v-if="maintenanceActive" class="jvp-zzz" aria-hidden="true"
+								><i>z</i><i>z</i><i>z</i></span
+							>
+							<svg v-else viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
 								<path
 									d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
 								/>
@@ -693,6 +722,7 @@ import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { classifyReadiness, degradedActionable, shouldWarnWorkers } from "./panel_readiness.mjs";
 import { sendRefusalMessage } from "./panel_send_copy.mjs";
+import { maintenanceActiveAfterSend } from "./panel_maintenance.mjs";
 import {
 	emptyStream,
 	applyEvent,
@@ -1109,6 +1139,24 @@ function dismissFeedback() {
 // synchronously so there's no flash. Blank => Jarvis defaults.
 const brandName = (window.frappe?.boot?.jarvis_agent_name || "").trim() || "Jarvis";
 const brandLogoUrl = (window.frappe?.boot?.jarvis_brand_logo_url || "").trim();
+// Upgrade maintenance hold (Stream E): seeded from boot (jarvis_maintenance =
+// {active, message}, set_jarvis_boot), raised if a send is refused with reason
+// "maintenance" while the bubble is open, and cleared the moment a later send gets
+// through (the roll finished). The composer never blocks - a held send shows the
+// friendly refusal, not a dead box. The custom operator message (brand-scrubbed
+// server-side) wins over the branded default; the server refusal carries only the
+// reason, so the boot message is the source of the custom text.
+const _maint = window.frappe?.boot?.jarvis_maintenance || {};
+const maintenanceActive = ref(!!_maint.active);
+const maintenanceMessage = ref((_maint.message || "").trim());
+const maintenanceText = computed(
+	// Reuse the single-sourced copy (sendRefusalMessage) instead of a 3rd hardcoded copy of
+	// the sentence, so a wording change can't leave this banner out of sync with the inline
+	// refusal / the SPA. NOTE: there is no widget-side recheck()/poll - this desk bundle
+	// cannot import frontend/src (see panel_send_copy.mjs's header), so the hold clears on
+	// the next accepted send (maintenanceActiveAfterSend) or a Desk reload.
+	() => maintenanceMessage.value || sendRefusalMessage("maintenance", brandName)
+);
 // A turn is in flight from the moment the POST is away until the first token
 // lands. Without this the panel looks inert for the whole worker round-trip.
 const greeting = computed(() => {
@@ -1581,6 +1629,10 @@ async function send() {
 		const approvalTokens = orderedPending.value.map((p) => p.token);
 		const res = await sendMessage(convId.value, text, props.context, atts, approvalTokens);
 		if (res?.conversation_id) convId.value = res.conversation_id;
+		// Fold this response into the maintenance banner: raise on a "maintenance"
+		// refusal, clear once any send/confirm gets past the gate (proof it lifted).
+		const maintNext = maintenanceActiveAfterSend(res);
+		if (maintNext !== null) maintenanceActive.value = maintNext;
 		// A send the server refused outright (e.g. a required app update, via the
 		// same validate_can_send gate as the full chat) starts no turn and returns
 		// no conversation. Surface the reason and STOP — otherwise the fall-through
@@ -1590,6 +1642,13 @@ async function send() {
 		if (res && res.ok === false && !res.confirmed) {
 			sending.value = false;
 			messages.value = messages.value.filter((m) => !String(m.name).startsWith("local-"));
+			if (res.reason === "maintenance") {
+				// The proactive amber banner (raised above) carries the message; restore
+				// the typed text and do NOT set the red loadError - on an empty conversation
+				// that would replace the whole welcome screen.
+				draft.value = lastSent.value;
+				return;
+			}
 			loadError.value =
 				res.reason === "release_update_required"
 					? sendRefusalMessage(res.reason, brandName)
@@ -2079,6 +2138,7 @@ defineExpose({ load, startNewChat, convId });
 }
 .jvp-avatar {
 	position: relative;
+	--sz: 30px;
 	width: 30px;
 	height: 30px;
 	flex: 0 0 auto;
@@ -2330,6 +2390,10 @@ defineExpose({ load, startNewChat, convId });
 	padding: 24px 9px 8px;
 }
 .jvp-hero {
+	/* position: relative so the sleepy .jvp-face (position:absolute) centres inside
+	   this 52px tile, not against the whole panel - matching .jvp-avatar. */
+	position: relative;
+	--sz: 52px;
 	width: 52px;
 	height: 52px;
 	border-radius: 14px;
@@ -2896,6 +2960,122 @@ defineExpose({ load, startNewChat, convId });
 	font-size: 12px;
 	line-height: 1.4;
 	text-align: center;
+}
+
+/* ---- upgrade maintenance hold (Stream E) ---- */
+.jvp-maint-notice {
+	flex: none;
+	margin: 10px 15px 0;
+	padding: 6px 11px;
+	border: 1px solid var(--jv-warn-bd);
+	border-radius: 9px;
+	background: var(--jv-warn-bg);
+	color: var(--jv-warn);
+	font-size: 12px;
+	line-height: 1.4;
+	text-align: center;
+	/* The message is operator-authored (maintenance_message); a long unbroken token
+	   (e.g. a status-page URL) must wrap, not overflow the fixed-width panel. */
+	overflow-wrap: anywhere;
+}
+/* Sleepy header avatar: heavy drooping white pill lids over the brand tile - the
+   desk twin of JarvisMark's "upgrading" mood. #fff explicit (the tile fills the
+   spark). The online dot goes amber to match the paused state. */
+.jvp-face {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: calc(var(--sz) * 0.19);
+	animation: jvp-breathe 4.6s ease-in-out infinite;
+}
+.jvp-eye {
+	width: calc(var(--sz) * 0.135);
+	height: calc(var(--sz) * 0.055);
+	background: #fff;
+	border-radius: 999px;
+	animation: jvp-lid 4.6s ease-in-out infinite;
+}
+.jvp-eye:first-child {
+	transform: rotate(-13deg);
+}
+.jvp-eye:last-child {
+	transform: rotate(13deg);
+}
+.jvp-sleeping .jvp-online {
+	background: var(--jv-warn, #e8a845);
+}
+/* Sleep "z z z", white over the gradient tile - the z's fade out as they rise
+   past the tile edge, so only the on-tile part shows (overflow is visible). */
+.jvp-zzz {
+	position: absolute;
+	top: 9%;
+	right: 8%;
+	display: flex;
+	align-items: flex-end;
+	gap: 1px;
+	line-height: 1;
+	pointer-events: none;
+}
+.jvp-zzz i {
+	font-style: normal;
+	font-weight: 800;
+	color: #fff;
+	opacity: 0;
+}
+.jvp-zzz i:nth-child(1) {
+	font-size: calc(var(--sz) * 0.14);
+	animation: jvp-zfloat 3.2s ease-out infinite;
+}
+.jvp-zzz i:nth-child(2) {
+	font-size: calc(var(--sz) * 0.18);
+	animation: jvp-zfloat 3.2s ease-out 0.6s infinite;
+}
+.jvp-zzz i:nth-child(3) {
+	font-size: calc(var(--sz) * 0.24);
+	animation: jvp-zfloat 3.2s ease-out 1.2s infinite;
+}
+@keyframes jvp-zfloat {
+	0% {
+		opacity: 0;
+		transform: translateY(20%) scale(0.7);
+	}
+	30% {
+		opacity: 0.9;
+	}
+	100% {
+		opacity: 0;
+		transform: translateY(-30%) scale(1.05);
+	}
+}
+@keyframes jvp-breathe {
+	0%,
+	100% {
+		transform: scale(0.99);
+	}
+	50% {
+		transform: scale(1.02);
+	}
+}
+@keyframes jvp-lid {
+	0%,
+	100% {
+		height: calc(var(--sz) * 0.055);
+	}
+	50% {
+		height: calc(var(--sz) * 0.022);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.jvp-face,
+	.jvp-eye,
+	.jvp-zzz i {
+		animation: none;
+	}
+	.jvp-zzz i {
+		opacity: 0.85;
+	}
 }
 
 /* ---- pending write confirmation ---- */

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -14,6 +14,7 @@
 				'jvw-fab--faded': faded && !dragging,
 				'jvw-fab--dock-left': side === 'left',
 				'jvw-fab--peek': autoPeek,
+				'jvw-fab--maint': maintenanceActive,
 			}"
 			:style="fabStyle"
 			:aria-label="panelOpen ? `Close ${brandName}` : `Ask ${brandName}`"
@@ -44,6 +45,9 @@
 			<span v-if="!brandLogoUrl" class="jvw-face" aria-hidden="true">
 				<i class="jvw-eye"></i><i class="jvw-eye"></i>
 			</span>
+			<span v-if="!brandLogoUrl && maintenanceActive" class="jvw-zzz" aria-hidden="true"
+				><i>z</i><i>z</i><i>z</i></span
+			>
 		</button>
 
 		<!-- Dimming backdrop for the expand-into-the-big-chat handoff: fades the
@@ -160,6 +164,10 @@ const hasAccess = Boolean(window.frappe?.boot?.jarvis_has_access);
 // Whitelabel FAB label + mark (set_jarvis_boot); blank => Jarvis defaults.
 const brandName = (window.frappe?.boot?.jarvis_agent_name || "").trim() || "Jarvis";
 const brandLogoUrl = (window.frappe?.boot?.jarvis_brand_logo_url || "").trim();
+// Upgrade maintenance hold (Stream E): the FAB rests with sleepy lids + z z z during
+// a hold, mirroring the panel avatar. Read from boot at mount (whitelabel logo -> no
+// face, same as the spark branch).
+const maintenanceActive = Boolean(window.frappe?.boot?.jarvis_maintenance?.active);
 
 // ---- Side chat panel: open state and the Desk record it is looking at. ----
 const panelRef = ref(null);
@@ -704,6 +712,69 @@ onBeforeUnmount(() => {
 .jvw-fab--peek .jvw-face {
 	opacity: 1;
 }
+/* Upgrade maintenance hold (Stream E): the FAB rests permanently sleepy - spark
+   hidden, sleepy lids, a soft "z z z" in the corner. No transform on the eyes
+   (the dock-scale owns child transforms); the lid is a height animation. */
+.jvw-fab--maint > svg {
+	opacity: 0;
+}
+.jvw-fab--maint .jvw-face {
+	opacity: 1;
+}
+.jvw-fab--maint .jvw-eye {
+	height: 3px;
+	animation: jvw-lid 4.6s ease-in-out infinite;
+}
+.jvw-zzz {
+	position: absolute;
+	top: 12%;
+	right: 12%;
+	display: flex;
+	align-items: flex-end;
+	gap: 1px;
+	line-height: 1;
+	pointer-events: none;
+}
+.jvw-zzz i {
+	font-style: normal;
+	font-weight: 800;
+	color: #fff;
+	opacity: 0;
+}
+.jvw-zzz i:nth-child(1) {
+	font-size: 8px;
+	animation: jvw-zfloat 3.2s ease-out infinite;
+}
+.jvw-zzz i:nth-child(2) {
+	font-size: 10px;
+	animation: jvw-zfloat 3.2s ease-out 0.6s infinite;
+}
+.jvw-zzz i:nth-child(3) {
+	font-size: 13px;
+	animation: jvw-zfloat 3.2s ease-out 1.2s infinite;
+}
+@keyframes jvw-lid {
+	0%,
+	100% {
+		height: 3px;
+	}
+	50% {
+		height: 1.5px;
+	}
+}
+@keyframes jvw-zfloat {
+	0% {
+		opacity: 0;
+		transform: translateY(20%) scale(0.7);
+	}
+	30% {
+		opacity: 0.9;
+	}
+	100% {
+		opacity: 0;
+		transform: translateY(-30%) scale(1.05);
+	}
+}
 
 @keyframes jvw-blink {
 	0%,
@@ -770,6 +841,18 @@ onBeforeUnmount(() => {
 	}
 	.jvw-grip {
 		transition: none;
+	}
+}
+
+/* Freeze the FAB maintenance sleeping frame under reduced-motion (the FAB's other
+   animations are gated behind no-preference; these were added unconditionally). */
+@media (prefers-reduced-motion: reduce) {
+	.jvw-fab--maint .jvw-eye,
+	.jvw-zzz i {
+		animation: none;
+	}
+	.jvw-zzz i {
+		opacity: 0.85;
 	}
 }
 </style>

--- a/jarvis/public/js/jarvis_chat/widget/panel_maintenance.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_maintenance.mjs
@@ -1,0 +1,20 @@
+// Pure decision for the desk widget's upgrade-maintenance banner state, extracted so the
+// send() state machine is unit-tested — the widget SFC itself isn't, and the widget
+// convention is to keep logic in a .mjs sibling (panel_readiness.mjs, panel_welcome.mjs,
+// panel_size.mjs, …). Stream E.
+//
+// Given a send() response, return the next value for `maintenanceActive`:
+//   - a "maintenance" refusal RAISES the banner (true).
+//   - any response that got PAST the send gate — an accepted turn OR a confirmed parked
+//     card (even a partially-applied one) — PROVES the hold has lifted, so it CLEARS
+//     (false). Reaching either of those means validate_can_send passed, i.e. the mirror
+//     is not held.
+//   - a non-maintenance refusal leaves it unchanged (null → the caller keeps the current
+//     state, e.g. a release-update or usage-limit refusal that has nothing to do with a
+//     hold).
+export function maintenanceActiveAfterSend(res) {
+  if (res && res.ok === false && !res.confirmed) {
+    return res.reason === "maintenance" ? true : null;
+  }
+  return false;
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_maintenance.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_maintenance.test.mjs
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { maintenanceActiveAfterSend } from "./panel_maintenance.mjs";
+
+test("a maintenance refusal raises the banner", () => {
+  assert.equal(
+    maintenanceActiveAfterSend({ ok: false, reason: "maintenance" }),
+    true
+  );
+});
+
+test("a non-maintenance refusal leaves the banner unchanged (null)", () => {
+  assert.equal(
+    maintenanceActiveAfterSend({
+      ok: false,
+      reason: "release_update_required",
+    }),
+    null
+  );
+  assert.equal(
+    maintenanceActiveAfterSend({ ok: false, reason: "usage_limit" }),
+    null
+  );
+});
+
+test("an accepted send clears the banner (proof the gate passed)", () => {
+  assert.equal(maintenanceActiveAfterSend({ conversation_id: "c1" }), false);
+  assert.equal(maintenanceActiveAfterSend({ ok: true }), false);
+});
+
+test("a confirmed parked card clears the banner — even a partial one (ok:false + confirmed)", () => {
+  assert.equal(maintenanceActiveAfterSend({ confirmed: true }), false);
+  // A partially-applied confirmation still got past validate_can_send, so the hold is
+  // gone — this is the case Edge review #1 flagged as leaving a stale banner.
+  assert.equal(
+    maintenanceActiveAfterSend({ ok: false, confirmed: true }),
+    false
+  );
+});
+
+test("an empty/undefined response clears rather than sticking a stale hold", () => {
+  assert.equal(maintenanceActiveAfterSend(undefined), false);
+  assert.equal(maintenanceActiveAfterSend(null), false);
+});

--- a/jarvis/public/js/jarvis_chat/widget/panel_send_copy.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_send_copy.mjs
@@ -20,5 +20,8 @@ export function sendRefusalMessage(reason, brandName = "Jarvis") {
   if (reason === "release_update_required") {
     return `A new ${brand} version is required. Please ask your administrator to update.`;
   }
+  if (reason === "maintenance") {
+    return `${brand} is upgrading and will be back shortly.`;
+  }
   return "That couldn't be sent. Please try again.";
 }

--- a/jarvis/public/js/jarvis_chat/widget/panel_send_copy.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_send_copy.test.mjs
@@ -25,6 +25,18 @@ test("sendRefusalMessage: a blank/missing brand falls back to 'Jarvis'", () => {
   assert.equal(sendRefusalMessage("release_update_required"), expected);
 });
 
+test("sendRefusalMessage: maintenance -> branded back-shortly line", () => {
+  assert.equal(
+    sendRefusalMessage("maintenance", "Aida"),
+    "Aida is upgrading and will be back shortly."
+  );
+  // white-label brand honoured; a blank brand falls back to 'Jarvis'
+  assert.equal(
+    sendRefusalMessage("maintenance", ""),
+    "Jarvis is upgrading and will be back shortly."
+  );
+});
+
 test("sendRefusalMessage: any other refusal -> the generic try-again line", () => {
   assert.equal(
     sendRefusalMessage("something_else", "Aida"),

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -49,6 +49,34 @@ class TestValidateCanSend(FrappeTestCase):
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
 
+	def test_maintenance_blocks_send(self):
+		"""An active upgrade maintenance hold refuses the send with reason "maintenance"."""
+		with patch("jarvis.maintenance_notice.boot_payload", return_value={"active": True}):
+			ok, reason = validate_can_send("Administrator")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "maintenance")
+
+	def test_release_update_wins_over_maintenance(self):
+		"""Precedence: a blocking release rollout is reported before a maintenance hold."""
+		with (
+			patch("jarvis.release_notice.boot_payload", return_value={"active": True}),
+			patch("jarvis.maintenance_notice.boot_payload", return_value={"active": True}),
+		):
+			ok, reason = validate_can_send("Administrator")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "release_update_required")
+
+	def test_maintenance_wins_over_workspace_resetting(self):
+		"""Precedence: the "upgrading, back shortly" copy wins over the reset copy
+		(maintenance is checked before _workspace_resetting)."""
+		with (
+			patch("jarvis.maintenance_notice.boot_payload", return_value={"active": True}),
+			patch("jarvis.chat.policy._workspace_resetting", return_value=True),
+		):
+			ok, reason = validate_can_send("Administrator")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "maintenance")
+
 	def test_administrator_can_send(self):
 		ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)

--- a/jarvis/tests/test_maintenance_notice.py
+++ b/jarvis/tests/test_maintenance_notice.py
@@ -1,8 +1,9 @@
 """Stream E — bench maintenance-hold mirror + send gate (app tasks A1 + A2).
 
-Pure toggle owned by the control plane: the bench mirrors {active, message}. An ABSENT
-notice keeps the last-known state (decision 3) so the destroy+reprovision window can't
-flip a live hold off. The send gate reads the mirror and refuses with reason
+Pure toggle owned by the control plane: the bench mirrors {active, message} via the
+marker-aware persist_from_connection (old CP / no marker -> clear; present key ->
+authoritative; marker present + absent key -> keep last-known, so the destroy+reprovision
+window can't flip a live hold off). The send gate reads the mirror and refuses with reason
 "maintenance". CP resolver/verb coverage lives in the jarvis_admin_v2 suite.
 """
 
@@ -89,6 +90,7 @@ class TestMaintenanceCheck(FrappeTestCase):
 
 	def test_check_refreshes_both_notices_and_applies_maintenance(self):
 		conn = {
+			"maintenance_supported": True,
 			"maintenance": {"active": True, "message": "rolling"},
 			"release_notice": {"active": False},
 		}
@@ -102,11 +104,87 @@ class TestMaintenanceCheck(FrappeTestCase):
 		self.assertEqual(out["message"], "rolling")
 
 	def test_check_absent_maintenance_key_keeps_last_known(self):
+		# Current CP (marker present), transient payload with no maintenance key -> keep last-known.
 		maintenance_notice.persist({"active": True, "message": "up"})
-		conn = {"release_notice": {"active": False}}  # no "maintenance" key at all
+		conn = {"maintenance_supported": True, "release_notice": {"active": False}}
 		with (
 			patch("jarvis.admin_client.get_connection", return_value=conn),
 			patch("jarvis.release_notice.persist"),
 		):
 			out = maintenance_notice.check()
-		self.assertTrue(out["active"])  # absent key = unknown -> keep last-known (decision 3)
+		self.assertTrue(out["active"])  # marker present + absent key -> keep last-known
+
+	def test_check_old_cp_clears_not_strands(self):
+		# A rolled-back CP that no longer speaks maintenance (no marker) -> the bench CLEARS its
+		# mirror rather than stranding forever behind a hold the old CP can't lift (finding App-1/#3).
+		maintenance_notice.persist({"active": True, "message": "up"})
+		conn = {"release_notice": {"active": False}}  # old CP: no marker, no maintenance key
+		with (
+			patch("jarvis.admin_client.get_connection", return_value=conn),
+			patch("jarvis.release_notice.persist"),
+		):
+			out = maintenance_notice.check()
+		self.assertFalse(out["active"])
+
+
+class TestPersistFromConnection(FrappeTestCase):
+	"""The marker-aware entry point every full-payload persist site calls (review App-1/#1/#3)."""
+
+	def tearDown(self):
+		maintenance_notice.persist({"active": False})
+
+	def test_marker_absent_clears_mirror(self):
+		# Old / rolled-back CP (no marker) must CLEAR, not strand -- even with a present hold dict.
+		maintenance_notice.persist({"active": True, "message": "up"})
+		maintenance_notice.persist_from_connection({"maintenance": {"active": True}})
+		self.assertFalse(maintenance_notice.boot_payload()["active"])
+
+	def test_marker_present_absent_key_keeps(self):
+		# Current CP, transient/partial payload (no maintenance key) -> keep last-known.
+		maintenance_notice.persist({"active": True, "message": "up"})
+		maintenance_notice.persist_from_connection({"maintenance_supported": True})
+		self.assertTrue(maintenance_notice.boot_payload()["active"])
+
+	def test_marker_present_key_is_authoritative(self):
+		maintenance_notice.persist({"active": False})
+		maintenance_notice.persist_from_connection(
+			{"maintenance_supported": True, "maintenance": {"active": True, "message": "up"}}
+		)
+		self.assertTrue(maintenance_notice.boot_payload()["active"])
+		maintenance_notice.persist_from_connection({"maintenance_supported": True, "maintenance": {}})
+		self.assertFalse(maintenance_notice.boot_payload()["active"])  # {} = authoritative clear
+
+	def test_empty_connection_clears(self):
+		# A degenerate/empty success ({} -- no marker) clears (conscious fail = un-hold, not strand).
+		maintenance_notice.persist({"active": True})
+		maintenance_notice.persist_from_connection({})
+		self.assertFalse(maintenance_notice.boot_payload()["active"])
+
+	def test_breadcrumb_only_when_clearing_active_hold(self):
+		# AC2 anti-spam: the deploy-order diagnostic fires when a markerless (old-CP) payload clears
+		# an ACTIVE hold, but NOT on a markerless not-held poll (else every poll would log-spam).
+		def _logged_clear(logger):
+			return any(
+				c.args and "clearing hold" in str(c.args[0]) for c in logger.return_value.info.call_args_list
+			)
+
+		maintenance_notice.persist({"active": True, "message": "up"})
+		with patch("frappe.logger") as logger:
+			maintenance_notice.persist_from_connection({})  # old CP, hold ACTIVE -> clear + log
+			self.assertTrue(_logged_clear(logger))
+		with patch("frappe.logger") as logger:
+			maintenance_notice.persist_from_connection({})  # already not held -> clear no-op, no log
+			self.assertFalse(_logged_clear(logger))
+
+	def test_write_connection_does_not_mirror_maintenance(self):
+		# A4 canary: the CP billing/confirm_payment path (_billing_actions) bypasses
+		# _connection_payload, so its payload carries NO maintenance_supported marker. That is
+		# harmless ONLY because finish_payment -> write_connection does not mirror maintenance; if
+		# it did, a marker-less billing payload would CLEAR a live hold. Pin the invariant.
+		import inspect
+
+		from jarvis import onboarding
+
+		# Assert the persist CALL is absent (not the bare word "maintenance", which could appear in an
+		# innocuous comment) -- the real invariant is "write_connection does not mirror maintenance".
+		self.assertNotIn("maintenance_notice", inspect.getsource(onboarding.write_connection))

--- a/jarvis/tests/test_maintenance_notice.py
+++ b/jarvis/tests/test_maintenance_notice.py
@@ -1,0 +1,112 @@
+"""Stream E — bench maintenance-hold mirror + send gate (app tasks A1 + A2).
+
+Pure toggle owned by the control plane: the bench mirrors {active, message}. An ABSENT
+notice keeps the last-known state (decision 3) so the destroy+reprovision window can't
+flip a live hold off. The send gate reads the mirror and refuses with reason
+"maintenance". CP resolver/verb coverage lives in the jarvis_admin_v2 suite.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import maintenance_notice
+
+
+class TestMaintenanceNotice(FrappeTestCase):
+	def tearDown(self):
+		maintenance_notice.persist({"active": False})
+
+	def test_persist_active_and_boot(self):
+		maintenance_notice.persist({"active": True, "message": "up"})
+		p = maintenance_notice.boot_payload()
+		self.assertTrue(p["active"])
+		self.assertEqual(p["message"], "up")
+
+	def test_present_false_clears(self):
+		maintenance_notice.persist({"active": True})
+		maintenance_notice.persist({"active": False})
+		self.assertFalse(maintenance_notice.boot_payload()["active"])
+
+	def test_absent_key_keeps_last_known(self):
+		# The D-path unresolved-payload case: None must NOT clear a live hold.
+		maintenance_notice.persist({"active": True, "message": "up"})
+		maintenance_notice.persist(None)
+		self.assertTrue(maintenance_notice.boot_payload()["active"])
+
+
+class TestMaintenanceGate(FrappeTestCase):
+	def test_gate_blocks_when_active(self):
+		from jarvis.chat.policy import _maintenance_hold
+
+		with patch("jarvis.maintenance_notice.boot_payload", return_value={"active": True}):
+			self.assertTrue(_maintenance_hold())
+
+	def test_gate_allows_when_inactive(self):
+		from jarvis.chat.policy import _maintenance_hold
+
+		with patch("jarvis.maintenance_notice.boot_payload", return_value={"active": False}):
+			self.assertFalse(_maintenance_hold())
+
+	def test_gate_fails_open(self):
+		from jarvis.chat.policy import _maintenance_hold
+
+		with patch("jarvis.maintenance_notice.boot_payload", side_effect=RuntimeError):
+			self.assertFalse(_maintenance_hold())
+
+
+class TestMaintenanceCheck(FrappeTestCase):
+	"""check() re-pulls the connection from admin and refreshes the local mirror. It is
+	de-duped by a short cache and folds the release refresh into the same round-trip; a
+	failed round-trip must never drop a live hold."""
+
+	def setUp(self):
+		frappe.cache().delete_value(maintenance_notice._CHECK_CACHE_KEY)
+		maintenance_notice.persist({"active": False})
+
+	def tearDown(self):
+		frappe.cache().delete_value(maintenance_notice._CHECK_CACHE_KEY)
+		maintenance_notice.persist({"active": False})
+
+	def test_check_keeps_last_known_on_admin_error(self):
+		maintenance_notice.persist({"active": True, "message": "up"})
+		with patch("jarvis.admin_client.get_connection", side_effect=RuntimeError("down")):
+			out = maintenance_notice.check()  # must not raise
+		self.assertTrue(out["active"])  # a failed poll must not clear a live hold
+		self.assertTrue(maintenance_notice.boot_payload()["active"])
+
+	def test_check_throttles_to_one_round_trip_in_window(self):
+		with (
+			patch(
+				"jarvis.admin_client.get_connection", return_value={"maintenance": {"active": False}}
+			) as gc,
+			patch("jarvis.release_notice.persist"),
+		):
+			maintenance_notice.check()
+			maintenance_notice.check()  # within the cache window -> no second call
+		self.assertEqual(gc.call_count, 1)
+
+	def test_check_refreshes_both_notices_and_applies_maintenance(self):
+		conn = {
+			"maintenance": {"active": True, "message": "rolling"},
+			"release_notice": {"active": False},
+		}
+		with (
+			patch("jarvis.admin_client.get_connection", return_value=conn),
+			patch("jarvis.release_notice.persist") as rp,
+		):
+			out = maintenance_notice.check()
+		rp.assert_called_once()  # one round-trip refreshes the release mirror too
+		self.assertTrue(out["active"])
+		self.assertEqual(out["message"], "rolling")
+
+	def test_check_absent_maintenance_key_keeps_last_known(self):
+		maintenance_notice.persist({"active": True, "message": "up"})
+		conn = {"release_notice": {"active": False}}  # no "maintenance" key at all
+		with (
+			patch("jarvis.admin_client.get_connection", return_value=conn),
+			patch("jarvis.release_notice.persist"),
+		):
+			out = maintenance_notice.check()
+		self.assertTrue(out["active"])  # absent key = unknown -> keep last-known (decision 3)

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -1,6 +1,6 @@
 import frappe
 
-from jarvis import announcement, release_notice
+from jarvis import announcement, maintenance_notice, release_notice
 from jarvis.permissions import (
 	has_jarvis_access,
 	has_jarvis_admin_access,
@@ -130,6 +130,7 @@ def get_context(context):
 	# Release notice (operator-authored): the SPA shows a full-page interstitial
 	# when this bench is behind the latest jarvis version. Up-to-date => no gate.
 	context.boot["release_notice"] = release_notice.boot_payload()
+	context.boot["maintenance"] = maintenance_notice.boot_payload()
 
 	# Customer announcement (operator-authored): a soft, dismissible banner shown
 	# fleet-wide. Empty/inactive => the SPA renders nothing.

--- a/jarvis/www/jarvis_mobile.py
+++ b/jarvis/www/jarvis_mobile.py
@@ -1,6 +1,6 @@
 import frappe
 
-from jarvis import announcement, release_notice
+from jarvis import announcement, maintenance_notice, release_notice
 from jarvis.permissions import has_jarvis_access
 
 no_cache = 1
@@ -53,5 +53,6 @@ def get_context(context):
 	context.boot["release_notice"] = release_notice.boot_payload()
 	# Customer announcement (operator-authored) — same soft banner on the PWA path.
 	context.boot["announcement"] = announcement.boot_payload()
+	context.boot["maintenance"] = maintenance_notice.boot_payload()
 	frappe.db.commit()
 	return context

--- a/pwa/src/App.vue
+++ b/pwa/src/App.vue
@@ -11,6 +11,7 @@ import { store } from "./store";
 import { sessionUser } from "./router";
 import { showBanner, showNotice } from "./noticeGate";
 import { showAnnouncement } from "./announcementGate";
+import { holdActive, holdText } from "./maintenanceGate";
 import { installBannerVisible } from "./lib/installBanner";
 import { prefs } from "./lib/prefs";
 import { agentName } from "@/branding";
@@ -119,6 +120,20 @@ onUnmounted(() => {
 
 <template>
 	<div class="jv-app">
+		<!-- Upgrade maintenance hold (Stream E): a persistent "back shortly" strip
+		     while this tenant's agent is being upgraded. Top-of-app on every route
+		     (before the install strip), like the desktop banner; the composer stays
+		     enabled and the send-gate self-heals when the roll clears. Shown only to
+		     a signed-in user - nothing to hold on the login screen. Amber tokens flip
+		     with the theme. role/aria-live announce it to screen readers. -->
+		<div
+			v-if="holdActive && sessionUser()"
+			class="jv-maint-strip"
+			role="status"
+			aria-live="polite"
+		>
+			{{ holdText }}
+		</div>
 		<!-- First child, in the flow: the install strip pushes the app down rather
 		     than covering any part of it. -->
 		<InstallBanner />
@@ -134,7 +149,13 @@ onUnmounted(() => {
 		     minimises it into whichever VersionPill is currently mounted (ChatView's
 		     header; see noticeGate.js's pillHandle). -->
 		<UpdateBanner
-			v-if="showBanner && !installBannerVisible && sessionUser() && !showAnnouncement"
+			v-if="
+				showBanner &&
+				!installBannerVisible &&
+				sessionUser() &&
+				!showAnnouncement &&
+				!holdActive
+			"
 		/>
 		<router-view v-slot="{ Component }">
 			<component :is="Component" />
@@ -149,3 +170,21 @@ onUnmounted(() => {
 		<WhatsNewSheet />
 	</div>
 </template>
+
+<style scoped>
+/* Upgrade maintenance hold strip - an amber card matching the InstallBanner /
+   UpdateBanner idiom (rounded + margin), not a full-bleed bar. Amber tokens flip
+   with the theme (see index.css). */
+.jv-maint-strip {
+	margin: 10px 12px 0;
+	padding: 10px 14px;
+	background: var(--amber-bg);
+	color: var(--amber);
+	border: 1px solid color-mix(in srgb, var(--amber) 35%, transparent);
+	border-radius: 12px;
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.35;
+	text-align: center;
+}
+</style>

--- a/pwa/src/components/BrandMark.vue
+++ b/pwa/src/components/BrandMark.vue
@@ -9,14 +9,27 @@ import { brandLogoUrl } from "@/branding";
 // The star path is the web logo, verbatim from the native component (viewBox
 // 0 0 24 24); size/radius follow the same ratios (radius 25%, star 57%).
 // When the tenant has uploaded a whitelabel logo we render it in place.
+//
+// `mood="upgrading"` (Stream E): while this tenant's agent is being upgraded the
+// tile shows a sleepy face — heavy drooping lids + a soft "z z z" — the mobile
+// twin of the desktop JarvisMark's "upgrading" mood, so the character reads the
+// same "resting, back shortly" on both surfaces. The whitelabel <img> branch
+// ignores mood (a tenant logo stays put; the top-of-app hold strip carries the
+// message there), matching the desktop mark.
 const props = defineProps({
 	size: { type: Number, default: 40 },
+	mood: {
+		type: String,
+		default: "star",
+		validator: (v) => ["star", "upgrading"].includes(v),
+	},
 });
 
 const style = computed(() => ({
 	width: `${props.size}px`,
 	height: `${props.size}px`,
 	borderRadius: `${Math.round(props.size * 0.25)}px`,
+	"--sz": `${props.size}px`,
 }));
 </script>
 
@@ -28,8 +41,16 @@ const style = computed(() => ({
 		:style="style"
 		alt=""
 	/>
-	<span v-else class="jv-mark" :style="style">
-		<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+	<span v-else class="jv-mark" :class="{ 'jv-mark-up': mood === 'upgrading' }" :style="style">
+		<!-- Upgrading: sleepy lids + z z z (kept inside the tile, which clips its
+		     corners). The star (the ::before mask) is hidden while this shows. -->
+		<template v-if="mood === 'upgrading'">
+			<span class="bm-face" aria-hidden="true"
+				><i class="bm-eye"></i><i class="bm-eye"></i
+			></span>
+			<span class="bm-zzz" aria-hidden="true"><i>z</i><i>z</i><i>z</i></span>
+		</template>
+		<svg v-else viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 			<path d="M12 2.5 14 10 21.5 12 14 14 12 21.5 10 14 2.5 12 10 10Z" />
 		</svg>
 	</span>
@@ -40,5 +61,107 @@ const style = computed(() => ({
 	object-fit: cover;
 	display: block;
 	flex-shrink: 0;
+}
+
+/* Upgrading: hide the masked star (the global .jv-mark::before) so only the face
+   shows. Higher specificity than the global rule, so display:none wins. */
+.jv-mark-up::before {
+	display: none;
+}
+/* Sleepy white pill eyes, the mobile twin of JarvisMark's "upgrading" mood
+   (same .135/.2 proportions, drooped to heavy lids). #fff explicitly — the tile
+   sets color:transparent, which would otherwise blank a currentColor fill. */
+.bm-face {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: calc(var(--sz) * 0.19);
+	animation: bm-breathe 4.6s ease-in-out infinite;
+}
+.bm-eye {
+	width: calc(var(--sz) * 0.135);
+	height: calc(var(--sz) * 0.055);
+	background: #fff;
+	border-radius: 999px;
+	animation: bm-lid 4.6s ease-in-out infinite;
+}
+.bm-eye:first-child {
+	transform: rotate(-13deg);
+}
+.bm-eye:last-child {
+	transform: rotate(13deg);
+}
+@keyframes bm-breathe {
+	0%,
+	100% {
+		transform: scale(0.99);
+	}
+	50% {
+		transform: scale(1.02);
+	}
+}
+@keyframes bm-lid {
+	0%,
+	100% {
+		height: calc(var(--sz) * 0.055);
+	}
+	50% {
+		height: calc(var(--sz) * 0.022);
+	}
+}
+/* The sleep "z z z", white on the gradient, rising and fading in the corner.
+   Bounded travel so it fades before the tile's clipped edge. */
+.bm-zzz {
+	position: absolute;
+	top: 9%;
+	right: 8%;
+	display: flex;
+	align-items: flex-end;
+	gap: 1px;
+	line-height: 1;
+	pointer-events: none;
+}
+.bm-zzz i {
+	font-style: normal;
+	font-weight: 800;
+	color: #fff;
+	opacity: 0;
+}
+.bm-zzz i:nth-child(1) {
+	font-size: calc(var(--sz) * 0.13);
+	animation: bm-z 3.2s ease-out infinite;
+}
+.bm-zzz i:nth-child(2) {
+	font-size: calc(var(--sz) * 0.17);
+	animation: bm-z 3.2s ease-out 0.6s infinite;
+}
+.bm-zzz i:nth-child(3) {
+	font-size: calc(var(--sz) * 0.22);
+	animation: bm-z 3.2s ease-out 1.2s infinite;
+}
+@keyframes bm-z {
+	0% {
+		opacity: 0;
+		transform: translateY(20%) scale(0.7);
+	}
+	30% {
+		opacity: 0.85;
+	}
+	100% {
+		opacity: 0;
+		transform: translateY(-30%) scale(1.05);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.bm-face,
+	.bm-eye,
+	.bm-zzz i {
+		animation: none;
+	}
+	.bm-zzz i {
+		opacity: 0.8;
+	}
 }
 </style>

--- a/pwa/src/maintenanceGate.js
+++ b/pwa/src/maintenanceGate.js
@@ -1,0 +1,86 @@
+// Maintenance hold for the mobile PWA, delivered by jarvis_mobile.py boot as
+// window.maintenance = { active, message }. Mirrors the desktop SPA's
+// frontend/src/maintenanceGate.js in the PWA's idiom, and is the sibling of this
+// dir's noticeGate.js. One deliberate difference from noticeGate: this state is
+// REACTIVE, not a page-lifetime constant - an upgrade hold is raised and cleared
+// WHILE the customer is mid-chat, so the strip, the avatar's "upgrading" mood and
+// the send refusal must all flip live. Pure toggle (no TTL/tier), already resolved
+// + kill-switched on the control plane.
+import { computed, ref } from "vue";
+import { call } from "frappe-ui";
+import { holdShouldShow, holdMessage, nextNotice } from "@shared/maintenanceHold";
+import { agentName } from "@/branding";
+
+const boot = window.maintenance || {};
+const notice = ref({ active: !!boot.active, message: (boot.message || "").trim() });
+
+// True while the upgrade hold is up. Drives the top-of-app strip, the empty-state
+// avatar's "upgrading" mood, and the send refusal.
+export const holdActive = computed(() => holdShouldShow(notice.value));
+
+// The strip / refusal sentence, white-label aware (agentName from branding; the
+// operator's brand-scrubbed custom message wins when set).
+export const holdText = computed(() => holdMessage(notice.value, agentName));
+
+export const rechecking = ref(false);
+
+// Raise the hold locally from a server refusal: if the tab was already open when the
+// operator set the hold, boot never carried it; the first blocked send comes back with
+// reason "maintenance", and ChatView calls this so the strip + mood show without a
+// reload. The server refusal carries only a reason today (no message), so `message` is
+// normally empty and the boot-seeded / branded-default copy is kept.
+export function raiseHold(message) {
+	const msg = (message || "").trim();
+	notice.value = { active: true, message: msg || notice.value.message };
+	_startPoll();
+}
+
+// Clear the hold locally. Called when a send is ACCEPTED - proof the CP-side gate passed
+// (the roll finished) - so the strip + avatar lift immediately instead of on reload or
+// the next poll. Idempotent.
+export function clearHold() {
+	if (notice.value.active) notice.value = { active: false, message: "" };
+	_stopPoll();
+}
+
+// Re-pull the hold from the control plane so an open tab lifts it promptly when the roll
+// clears. Keeps the last-known notice on any error or malformed shape (via nextNotice) -
+// a failed poll must never flip a live hold off.
+export async function recheck() {
+	if (rechecking.value) return holdActive.value;
+	rechecking.value = true;
+	try {
+		const fresh = await call("jarvis.maintenance_notice.check");
+		notice.value = nextNotice(notice.value, fresh);
+	} catch (e) {
+		/* keep last-known: a failed poll must not clear a live hold */
+	} finally {
+		rechecking.value = false;
+	}
+	// Keep the poll in lockstep with the actual state: a recheck usually CLEARS the
+	// hold (stop polling), but folding in a genuinely-new CP hold could re-raise it, so
+	// (re)start rather than only ever stopping.
+	if (holdActive.value) _startPoll();
+	else _stopPoll();
+	return holdActive.value;
+}
+
+// While a hold is up, re-check the CP on a slow cadence so an IDLE tab (one that never
+// sends again after the roll finishes) still lifts the strip. The send path clears it
+// instantly for an active user (clearHold); this covers the rest. Runs only while held:
+// started on raise / boot, stopped on clear.
+const POLL_MS = 60000;
+let _pollTimer = null;
+function _startPoll() {
+	if (_pollTimer || typeof setInterval !== "function") return;
+	_pollTimer = setInterval(() => {
+		recheck();
+	}, POLL_MS);
+}
+function _stopPoll() {
+	if (_pollTimer) {
+		clearInterval(_pollTimer);
+		_pollTimer = null;
+	}
+}
+if (notice.value.active) _startPoll();

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -10,6 +10,12 @@ import {
 	watch,
 } from "vue";
 import BrandMark from "../components/BrandMark.vue";
+import {
+	holdActive,
+	raiseHold,
+	clearHold,
+	recheck as recheckMaintenance,
+} from "../maintenanceGate";
 import { agentName } from "@/branding";
 import { useRouter } from "vue-router";
 // The desktop SPA's renderer — dependency-free, and sharing it means an agent
@@ -326,6 +332,9 @@ async function send() {
 		// exist. The receipt chip in the reloaded thread is what the user sees.
 		if (res?.confirmed) {
 			sendBusy.value = false;
+			// A parked-card confirmation also got past the send gate, so any maintenance
+			// hold has lifted - clear the strip now instead of waiting for the poll.
+			clearHold();
 			messages.value = messages.value.filter((m) => !m.optimistic);
 			if (res.ok === false)
 				errorBanner.value =
@@ -345,9 +354,22 @@ async function send() {
 				setTimeout(() => window.location.reload(), 1500);
 				return;
 			}
+			// Maintenance hold (Stream E): the operator/roll raised an upgrade hold
+			// while this tab was open. Raise the persistent top-of-app strip + self-
+			// heal by re-checking the CP; no reload (a hold is transient), composer
+			// stays enabled, so the next send lands the moment the roll clears.
+			if (res.reason === "maintenance") {
+				raiseHold(res.message);
+				recheckMaintenance();
+				input.value = text; // keep their typed text - the composer stays enabled, they can retry
+				return;
+			}
 			errorBanner.value = res.reason || "Couldn't send that message.";
 			return;
 		}
+		// An accepted send proves the maintenance hold lifted - clear the strip + wake
+		// the avatar now instead of stranding them until a reload (self-heal).
+		clearHold();
 		// First send of a brand-new chat: adopt the id the backend just created,
 		// and put the row in the list without a refetch.
 		const id = res?.conversation_id;
@@ -699,7 +721,7 @@ onUnmounted(() => {
 
 	<div ref="scroller" class="jv-scroll jv-thread" @scroll.passive="onScroll">
 		<div v-if="!items.length && !live && !loading" class="jv-empty">
-			<BrandMark :size="52" />
+			<BrandMark :size="52" :mood="holdActive ? 'upgrading' : 'star'" />
 			<div style="font-size: 16px; font-weight: 600; color: var(--ink9)">
 				What can I do for you?
 			</div>

--- a/pwa/src/views/NewChatView.vue
+++ b/pwa/src/views/NewChatView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, defineAsyncComponent, onMounted, onUnmounted, ref } from "vue";
 import BrandMark from "../components/BrandMark.vue";
+import { holdActive } from "../maintenanceGate";
 import { agentName } from "@/branding";
 import { useRouter } from "vue-router";
 import * as api from "../api";
@@ -207,7 +208,7 @@ onUnmounted(() => attachments.value.forEach((a) => a.preview && URL.revokeObject
 	</div>
 
 	<div class="jv-hero">
-		<BrandMark :size="56" />
+		<BrandMark :size="56" :mood="holdActive ? 'upgrading' : 'star'" />
 		<h1 class="jv-greeting">{{ greeting }}</h1>
 	</div>
 


### PR DESCRIPTION
…widget)

During an openclaw image upgrade the tenant's agent is briefly unavailable. Show a friendly "Jarvis is upgrading, back shortly" hold instead of raw errors: a top banner, a sleeping avatar, and a soft send-refusal that self-heals when the roll clears — on all three chat surfaces.

The hold STATE is owned by the control plane (pure toggle, no bench-side TTL); the bench mirrors {active, message} onto Jarvis Settings and only displays / refuses:

- jarvis/maintenance_notice.py: mirror module — persist() keeps last-known on an absent notice (destroy+reprovision window), boot_payload() fails not-held, and a whitelisted check() refreshes release+maintenance in ONE admin round-trip.
- 2 new Jarvis Settings fields (Single/EAV — no data patch needed; fail-safe read).
- jarvis/chat/policy.py: _maintenance_hold() send gate (fail-open) ordered between release_update_required and workspace_resetting.
- boot: window.maintenance (SPA/PWA via www/*.py) + frappe.boot.jarvis_maintenance (Desk via boot.py); persisted on the connection-sync paths (present-key aware).
- SPA/PWA: maintenanceGate.js reactive gate (holdActive/holdText/raiseHold/ clearHold/recheck; shared pure nextNotice keeps last-known on a malformed poll); amber banner/strip; JarvisMark/BrandMark "upgrading" mood (sleepy lids + z z z); the persistent UserMenu sidebar mark; send/retry self-heal (clear on an accepted send + a 60s poll while held).
- Desk widget: proactive banner, sleepy header/hero/FAB marks, panel_maintenance decision helper, single-sourced refusal copy.

Composer stays enabled throughout (soft refusal, never a dead box); reduced-motion holds a static frame; a white-label logo keeps its logo (the banner carries the message). Reviewed via an 8-lane panel + 2 adversarial verify passes and a live browser flow on all three surfaces.


Claude-Session: https://claude.ai/code/session_01U58ULgQYW6itViDSKTfetA

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
