### PR TITLE
Perf/crud reorder delete scalar

### DIFF
--- a/jarvis/tests/test_amend_doc.py
+++ b/jarvis/tests/test_amend_doc.py
@@ -63,12 +63,18 @@ class TestAmendDocValidation(FrappeTestCase):
 
 class TestAmendDocPermissions(FrappeTestCase):
 	def test_rejects_when_user_lacks_amend_perm(self):
+		# get_doc is mocked because the reorder loads the source BEFORE the perm
+		# check; without it this would hit a real (erpnext) controller load.
 		with patch("frappe.get_meta", return_value=_fake_meta()):
-			with patch("frappe.has_permission", return_value=False):
-				with self.assertRaises(PermissionDeniedError):
-					amend_doc(doctype="Sales Invoice", name="SINV-001")
+			with patch("frappe.get_doc", return_value=_fake_source(docstatus=2)):
+				with patch("frappe.has_permission", return_value=False):
+					with self.assertRaises(PermissionDeniedError):
+						amend_doc(doctype="Sales Invoice", name="SINV-001")
 
-	def test_checks_amend_ptype_at_record_level(self):
+	def test_checks_amend_ptype_on_loaded_doc(self):
+		"""Amend perm is checked on the LOADED source Document object (not the
+		name string): passing the object skips has_permission's duplicate lazy
+		load. The check runs after get_doc and before copy_doc(source)."""
 		called_with = {}
 
 		def fake_perm(doctype, ptype=None, doc=None, **_):
@@ -77,14 +83,15 @@ class TestAmendDocPermissions(FrappeTestCase):
 			called_with["doc"] = doc
 			return True
 
+		source = _fake_source(docstatus=2)
 		with patch("frappe.get_meta", return_value=_fake_meta()):
 			with patch("frappe.has_permission", side_effect=fake_perm):
-				with patch("frappe.get_doc", return_value=_fake_source(docstatus=2)):
+				with patch("frappe.get_doc", return_value=source):
 					with patch("frappe.copy_doc", return_value=_fake_copy()):
 						amend_doc(doctype="Sales Invoice", name="SINV-001")
 
 		self.assertEqual(called_with["ptype"], "amend")
-		self.assertEqual(called_with["doc"], "SINV-001")
+		self.assertIs(called_with["doc"], source)
 
 
 class TestAmendDocStateMachine(FrappeTestCase):

--- a/jarvis/tests/test_cancel_doc.py
+++ b/jarvis/tests/test_cancel_doc.py
@@ -49,12 +49,17 @@ class TestCancelDocValidation(FrappeTestCase):
 
 class TestCancelDocPermissions(FrappeTestCase):
 	def test_rejects_when_user_lacks_cancel_perm(self):
+		# get_doc is mocked because the reorder loads the doc BEFORE the perm
+		# check; without it this would hit a real (erpnext) controller load.
 		with patch("frappe.get_meta", return_value=_fake_meta()):
-			with patch("frappe.has_permission", return_value=False):
-				with self.assertRaises(PermissionDeniedError):
-					cancel_doc(doctype="Sales Invoice", name="SINV-001")
+			with patch("frappe.get_doc", return_value=_fake_doc(docstatus=1)):
+				with patch("frappe.has_permission", return_value=False):
+					with self.assertRaises(PermissionDeniedError):
+						cancel_doc(doctype="Sales Invoice", name="SINV-001")
 
-	def test_checks_cancel_ptype_at_record_level(self):
+	def test_checks_cancel_ptype_on_loaded_doc(self):
+		"""Cancel perm is checked on the LOADED Document object (not the name
+		string): passing the object skips has_permission's duplicate lazy load."""
 		called_with = {}
 
 		def fake_perm(doctype, ptype=None, doc=None, **_):
@@ -63,13 +68,14 @@ class TestCancelDocPermissions(FrappeTestCase):
 			called_with["doc"] = doc
 			return True
 
+		doc = _fake_doc(docstatus=1)
 		with patch("frappe.get_meta", return_value=_fake_meta()):
 			with patch("frappe.has_permission", side_effect=fake_perm):
-				with patch("frappe.get_doc", return_value=_fake_doc(docstatus=1)):
+				with patch("frappe.get_doc", return_value=doc):
 					cancel_doc(doctype="Sales Invoice", name="SINV-001")
 
 		self.assertEqual(called_with["ptype"], "cancel")
-		self.assertEqual(called_with["doc"], "SINV-001")
+		self.assertIs(called_with["doc"], doc)
 
 
 class TestCancelDocStateMachine(FrappeTestCase):

--- a/jarvis/tests/test_delete_doc.py
+++ b/jarvis/tests/test_delete_doc.py
@@ -8,7 +8,7 @@ Permission and submitted-doc gate tests use mocks because there's no
 easy way to construct a submitted state on a non-submittable DocType.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -30,12 +30,6 @@ def _make_note(title: str = "jarvis-delete-test") -> str:
 	doc.insert(ignore_permissions=True)
 	frappe.db.commit()
 	return doc.name
-
-
-def _fake_submitted_doc() -> MagicMock:
-	d = MagicMock()
-	d.docstatus = 1
-	return d
 
 
 class TestDeleteDocValidation(FrappeTestCase):
@@ -83,13 +77,20 @@ class TestDeleteDocSubmittedGuard(FrappeTestCase):
 	Pre-checking gives the agent a clear "cancel first" message instead
 	of Frappe's generic "cannot delete submitted document" error."""
 
-	def test_rejects_submitted_doc(self):
+	def test_rejects_submitted_doc_via_scalar_docstatus(self):
+		"""The submitted gate reads docstatus with a single-column get_value and
+		must NOT load the whole doc (parent + every child table) just to read one
+		int - frappe.delete_doc re-loads its own doc for the trash hooks anyway."""
 		with patch("frappe.has_permission", return_value=True):
-			with patch("frappe.get_doc", return_value=_fake_submitted_doc()):
-				with self.assertRaises(InvalidArgumentError) as ctx:
-					delete_doc(doctype="Sales Invoice", name="SINV-001")
+			with patch("frappe.db.get_value", return_value=1) as gv:
+				with patch("frappe.get_doc") as gd:
+					with self.assertRaises(InvalidArgumentError) as ctx:
+						delete_doc(doctype="Sales Invoice", name="SINV-001")
 		self.assertIn("Submitted", str(ctx.exception))
 		self.assertIn("cancel_doc", str(ctx.exception))
+		gv.assert_called_once_with("Sales Invoice", "SINV-001", "docstatus")
+		# The wasteful full-document load is gone: the tool never calls get_doc.
+		gd.assert_not_called()
 
 
 class TestDeleteDocHappyPath(FrappeTestCase):

--- a/jarvis/tests/test_get_doc_perm.py
+++ b/jarvis/tests/test_get_doc_perm.py
@@ -1,0 +1,54 @@
+"""Mock-based tests for get_doc's permission-check ordering.
+
+The end-to-end get_doc tests (test_get_doc.py) build erpnext fixtures in
+setUpClass, so they can't run on an erpnext-less site. These mock-based tests
+cover the permission/loading CONTRACT the perf reorder touches - existence gate,
+the read-permission check on the LOADED doc object (not the name string), and
+that field-level masking still runs after the check - without erpnext.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools.get_doc import _get_doc_one
+
+
+class TestGetDocOnePerm(FrappeTestCase):
+	def test_unknown_record_raises_invalid_argument(self):
+		with patch("frappe.db.exists", return_value=False):
+			with self.assertRaises(InvalidArgumentError):
+				_get_doc_one("Note", "MISSING")
+
+	def test_rejects_when_user_lacks_read_perm(self):
+		with patch("frappe.db.exists", return_value=True):
+			with patch("frappe.get_doc", return_value=MagicMock()):
+				with patch("frappe.has_permission", return_value=False):
+					with self.assertRaises(PermissionDeniedError):
+						_get_doc_one("Note", "N-1")
+
+	def test_checks_read_perm_on_loaded_doc(self):
+		"""Read perm is checked on the LOADED Document object (not the name
+		string), and field-level masking runs AFTER the check passes."""
+		called_with = {}
+
+		def fake_perm(doctype, ptype=None, doc=None, **_):
+			called_with["doctype"] = doctype
+			called_with["ptype"] = ptype
+			called_with["doc"] = doc
+			return True
+
+		doc = MagicMock()
+		doc.as_dict.return_value = {"name": "N-1", "doctype": "Note"}
+		with patch("frappe.db.exists", return_value=True):
+			with patch("frappe.get_doc", return_value=doc):
+				with patch("frappe.has_permission", side_effect=fake_perm):
+					result = _get_doc_one("Note", "N-1")
+
+		self.assertEqual(called_with["doctype"], "Note")
+		self.assertEqual(called_with["ptype"], "read")
+		self.assertIs(called_with["doc"], doc)
+		# permlevel masking still runs (after the check, before as_dict).
+		doc.apply_fieldlevel_read_permissions.assert_called_once()
+		self.assertEqual(result["name"], "N-1")

--- a/jarvis/tests/test_get_itemised_tax_breakup_perm.py
+++ b/jarvis/tests/test_get_itemised_tax_breakup_perm.py
@@ -1,0 +1,59 @@
+"""Mock-based tests for get_itemised_tax_breakup's permission-check ordering.
+
+The tool wraps an ERPNext helper, so its integration behaviour is covered by
+test_tier2a_erpnext_reads (which needs erpnext). These tests verify only the
+permission/loading CONTRACT the perf reorder touches - existence gate, the
+read-permission check runs on the LOADED doc object (not the name string), and
+denial - all without an erpnext-bearing site.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools.get_itemised_tax_breakup import get_itemised_tax_breakup
+
+DT = "Sales Invoice"
+NAME = "SINV-001"
+
+
+class TestGetItemisedTaxBreakupPerm(FrappeTestCase):
+	def test_unknown_record_raises_invalid_argument(self):
+		with patch("frappe.db.exists", return_value=False):
+			with self.assertRaises(InvalidArgumentError):
+				get_itemised_tax_breakup(doctype=DT, name=NAME)
+
+	def test_rejects_when_user_lacks_read_perm(self):
+		# get_doc is loaded before the perm check; mock it so no real (erpnext)
+		# controller load is needed.
+		with patch("frappe.db.exists", return_value=True):
+			with patch("frappe.get_doc", return_value=MagicMock()):
+				with patch("frappe.has_permission", return_value=False):
+					with self.assertRaises(PermissionDeniedError):
+						get_itemised_tax_breakup(doctype=DT, name=NAME)
+
+	def test_checks_read_perm_on_loaded_doc(self):
+		"""Read perm is checked on the LOADED Document object (not the name
+		string), after get_doc and before the erpnext tax computation."""
+		called_with = {}
+
+		def fake_perm(doctype, ptype=None, doc=None, **_):
+			called_with["doctype"] = doctype
+			called_with["ptype"] = ptype
+			called_with["doc"] = doc
+			return True
+
+		doc = MagicMock()
+		with patch("frappe.db.exists", return_value=True):
+			with patch("frappe.get_doc", return_value=doc):
+				with patch("frappe.has_permission", side_effect=fake_perm):
+					with patch("jarvis.compat.itemised_tax", return_value={"ITEM-1": {}}) as itax:
+						result = get_itemised_tax_breakup(doctype=DT, name=NAME)
+
+		self.assertEqual(called_with["doctype"], DT)
+		self.assertEqual(called_with["ptype"], "read")
+		self.assertIs(called_with["doc"], doc)
+		# The loaded doc (not the name) is handed to the erpnext helper.
+		itax.assert_called_once_with(doc, with_tax_account=True)
+		self.assertEqual(result["itemised_tax"], {"ITEM-1": {}})

--- a/jarvis/tests/test_submit_doc.py
+++ b/jarvis/tests/test_submit_doc.py
@@ -67,13 +67,18 @@ class TestSubmitDocPermissions(FrappeTestCase):
 	"""Caller needs WRITE-equivalent submit perm on the record itself."""
 
 	def test_rejects_when_user_lacks_submit_perm(self):
+		# get_doc is mocked because the reorder loads the doc BEFORE the perm
+		# check; without it this would hit a real (erpnext) controller load.
 		with patch("frappe.get_meta", return_value=_fake_meta()):
-			with patch("frappe.has_permission", return_value=False):
-				with self.assertRaises(PermissionDeniedError):
-					submit_doc(doctype="Sales Invoice", name="SINV-001")
+			with patch("frappe.get_doc", return_value=_fake_doc(docstatus=0)):
+				with patch("frappe.has_permission", return_value=False):
+					with self.assertRaises(PermissionDeniedError):
+						submit_doc(doctype="Sales Invoice", name="SINV-001")
 
-	def test_checks_submit_ptype_at_record_level(self):
-		"""Like update_doc, submit perm is record-scoped (doc=name passed)."""
+	def test_checks_submit_ptype_on_loaded_doc(self):
+		"""Submit perm is record-scoped and checked on the LOADED Document object
+		(not the name string): passing the object skips has_permission's duplicate
+		lazy load. The check runs after get_doc and before doc.submit()."""
 		called_with = {}
 
 		def fake_perm(doctype, ptype=None, doc=None, **_):
@@ -82,14 +87,15 @@ class TestSubmitDocPermissions(FrappeTestCase):
 			called_with["doc"] = doc
 			return True
 
+		doc = _fake_doc(docstatus=0)
 		with patch("frappe.get_meta", return_value=_fake_meta()):
 			with patch("frappe.has_permission", side_effect=fake_perm):
-				with patch("frappe.get_doc", return_value=_fake_doc(docstatus=0)):
+				with patch("frappe.get_doc", return_value=doc):
 					submit_doc(doctype="Sales Invoice", name="SINV-001")
 
 		self.assertEqual(called_with["doctype"], "Sales Invoice")
 		self.assertEqual(called_with["ptype"], "submit")
-		self.assertEqual(called_with["doc"], "SINV-001")
+		self.assertIs(called_with["doc"], doc)
 
 
 class TestSubmitDocStateMachine(FrappeTestCase):

--- a/jarvis/tests/test_update_doc.py
+++ b/jarvis/tests/test_update_doc.py
@@ -86,15 +86,31 @@ class TestUpdateDocPermissions(FrappeTestCase):
 					changes={"content": "new"},
 				)
 
-	def test_passes_doc_to_has_permission(self):
-		"""Permission is checked record-level (with doc=name), not just at
-		the DocType level."""
+	def test_denied_write_leaves_row_unchanged(self):
+		"""No partial write: a denied update must not have committed a DB change.
+		Guards that the has_permission check runs BEFORE doc.save() (the exact
+		before-doc.set() ordering is asserted in test_checks_permission_on_loaded_doc)."""
+		before = frappe.db.get_value(NOTE_DT, self.note, "content")
+		with patch("frappe.has_permission", return_value=False):
+			with self.assertRaises(PermissionDeniedError):
+				update_doc(doctype=NOTE_DT, name=self.note, changes={"content": "tampered"})
+		after = frappe.db.get_value(NOTE_DT, self.note, "content")
+		self.assertEqual(after, before)
+
+	def test_checks_permission_on_loaded_doc(self):
+		"""Permission is checked record-level on the LOADED Document object (not a
+		bare name string): passing the object skips has_permission's duplicate
+		lazy parent-row load while yielding the identical verdict. Also asserts the
+		check runs on the UNMUTATED doc (before the doc.set() loop) - the field the
+		verdict could key on still holds its pristine DB value at check time."""
 		called_with = {}
 
 		def fake_perm(doctype, ptype=None, doc=None, **_):
 			called_with["doctype"] = doctype
 			called_with["ptype"] = ptype
 			called_with["doc"] = doc
+			# Capture the field value AT CHECK TIME to prove the doc is unmutated.
+			called_with["content_at_check"] = doc.get("content") if hasattr(doc, "get") else None
 			return True
 
 		with patch("frappe.has_permission", side_effect=fake_perm):
@@ -106,7 +122,30 @@ class TestUpdateDocPermissions(FrappeTestCase):
 
 		self.assertEqual(called_with["doctype"], NOTE_DT)
 		self.assertEqual(called_with["ptype"], "write")
-		self.assertEqual(called_with["doc"], self.note)
+		# doc is the loaded Document, not the name string.
+		passed = called_with["doc"]
+		self.assertNotIsInstance(passed, str)
+		self.assertEqual(getattr(passed, "doctype", None), NOTE_DT)
+		self.assertEqual(getattr(passed, "name", None), self.note)
+		# The check ran BEFORE doc.set("content", "new"): the doc still carries the
+		# original content. A reorder that checked after the mutation would see "new".
+		self.assertEqual(called_with["content_at_check"], "before")
+
+	def test_enforce_update_runs_before_permission_check(self):
+		"""The delegate writes[] contract (enforce_update) must be evaluated
+		BEFORE the Frappe permission check - a delegate is bounced by its own
+		contract first."""
+		order = []
+		with patch(
+			"jarvis.tools.update_doc.enforce_update",
+			side_effect=lambda *a, **k: order.append("enforce_update"),
+		):
+			with patch(
+				"frappe.has_permission",
+				side_effect=lambda *a, **k: order.append("has_permission") or True,
+			):
+				update_doc(doctype=NOTE_DT, name=self.note, changes={"content": "new"})
+		self.assertEqual(order, ["enforce_update", "has_permission"])
 
 
 class TestUpdateDocHappyPath(FrappeTestCase):

--- a/jarvis/tools/amend_doc.py
+++ b/jarvis/tools/amend_doc.py
@@ -68,10 +68,14 @@ def _amend_one(doctype: str, name: str) -> "frappe.model.document.Document":
 			f"{doctype} is not submittable - amendment only applies to docstatus-tracked DocTypes"
 		)
 
-	if not frappe.has_permission(doctype, ptype="amend", doc=name):
+	# Load once, then check permission on the loaded source object (has_permission
+	# with a name string would lazy-load the parent row this get_doc already
+	# fetches). The check runs before copy_doc(source) below, which does not
+	# mutate source; the docstatus reads don't either.
+	source = frappe.get_doc(doctype, name)
+	if not frappe.has_permission(doctype, ptype="amend", doc=source):
 		raise PermissionDeniedError(f"no amend permission on {doctype} '{name}'")
 
-	source = frappe.get_doc(doctype, name)
 	if source.docstatus == 0:
 		raise InvalidArgumentError(
 			f"{doctype} '{name}' is in Draft (docstatus=0); amend is for "

--- a/jarvis/tools/cancel_doc.py
+++ b/jarvis/tools/cancel_doc.py
@@ -59,10 +59,13 @@ def _cancel_one(doctype: str, name: str) -> "frappe.model.document.Document":
 			f"available to you."
 		)
 
-	if not frappe.has_permission(doctype, ptype="cancel", doc=name):
+	# Load once, then check permission on the loaded object (has_permission with a
+	# name string would lazy-load the parent row this get_doc already fetches).
+	# The check runs before doc.cancel() below; the docstatus reads don't mutate.
+	doc = frappe.get_doc(doctype, name)
+	if not frappe.has_permission(doctype, ptype="cancel", doc=doc):
 		raise PermissionDeniedError(f"no cancel permission on {doctype} '{name}'")
 
-	doc = frappe.get_doc(doctype, name)
 	if doc.docstatus == 0:
 		raise InvalidArgumentError(
 			f"{doctype} '{name}' is in Draft (docstatus=0); only Submitted "

--- a/jarvis/tools/delete_doc.py
+++ b/jarvis/tools/delete_doc.py
@@ -38,10 +38,20 @@ def _delete_one(doctype: str, name: str) -> str:
 	if not frappe.has_permission(doctype, ptype="delete", doc=name):
 		raise PermissionDeniedError(f"no delete permission on {doctype} '{name}'")
 
-	# Pre-load the doc to check docstatus - gives a clearer error than
-	# Frappe's "cannot delete a submitted document".
-	doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing
-	if getattr(doc, "docstatus", 0) == 1:
+	# Read ONLY docstatus to gate the submitted-doc case - a clearer error than
+	# Frappe's "cannot delete a submitted document". A scalar get_value avoids
+	# loading the whole doc + every child table just to read one int (the doc is
+	# not otherwise used here; frappe.delete_doc below re-loads its own for the
+	# trash hooks).
+	docstatus = frappe.db.get_value(doctype, name, "docstatus")
+	if docstatus is None:
+		# No such row. Preserve the pre-refactor contract (the old get_doc
+		# pre-load raised DoesNotExistError here) - it is NOT covered downstream:
+		# has_permission above short-circuits True for Administrator WITHOUT
+		# loading the doc, and frappe.delete_doc defaults ignore_missing=True, so
+		# a missing name would otherwise be a silent no-op success.
+		raise frappe.DoesNotExistError(f"{doctype} {name} not found")
+	if docstatus == 1:
 		raise InvalidArgumentError(
 			f"{doctype} '{name}' is Submitted (docstatus=1); cancel it first (cancel_doc) before deleting"
 		)

--- a/jarvis/tools/get_doc.py
+++ b/jarvis/tools/get_doc.py
@@ -60,10 +60,17 @@ def _get_doc_one(doctype: str, name: str) -> dict:
 	if not frappe.db.exists(doctype, name):
 		raise InvalidArgumentError(f"No {doctype} named '{name}'. Use get_list to find valid names first.")
 
-	if not frappe.has_permission(doctype, ptype="read", doc=name):
+	# Load once, then check READ permission on the loaded object. has_permission
+	# (doc=<name string>) would lazy-load the parent row just to run the check -
+	# a load this get_doc already does. Passing the pristine object gives an
+	# identical verdict and drops the duplicate read. The check must precede
+	# apply_fieldlevel_read_permissions() below, which mutates the doc to mask
+	# permlevel-restricted fields. The exists() guard above keeps the friendly
+	# "No <doctype> named ..." message (get_doc alone would raise DoesNotExist).
+	doc = frappe.get_doc(doctype, name)
+	if not frappe.has_permission(doctype, ptype="read", doc=doc):
 		raise PermissionDeniedError(f"no read permission on {doctype} {name}")
 
-	doc = frappe.get_doc(doctype, name)
 	doc.apply_fieldlevel_read_permissions()
 	return doc.as_dict(no_default_fields=False)
 

--- a/jarvis/tools/get_itemised_tax_breakup.py
+++ b/jarvis/tools/get_itemised_tax_breakup.py
@@ -46,10 +46,14 @@ def get_itemised_tax_breakup(doctype: str, name: str) -> dict:
 		)
 	if not frappe.db.exists(doctype, name):
 		raise InvalidArgumentError(f"unknown {doctype}: {name}")
-	if not frappe.has_permission(doctype, "read", doc=name):
+
+	# Load once, then check permission on the loaded object (has_permission with a
+	# name string would lazy-load the parent row this get_doc already fetches).
+	# The full doc - with its tax/item child tables - is needed by compat below.
+	doc = frappe.get_doc(doctype, name)
+	if not frappe.has_permission(doctype, "read", doc=doc):
 		raise PermissionDeniedError(f"no read permission on {doctype} {name}")
 
-	doc = frappe.get_doc(doctype, name)
 	# ERPNext 15 wants the taxes child table here, ERPNext 16 wants the parent
 	# doc. Passing `doc` unconditionally was a TypeError ('SalesInvoice' object
 	# is not iterable) on every ERPNext 15 call.

--- a/jarvis/tools/read_wiki.py
+++ b/jarvis/tools/read_wiki.py
@@ -64,11 +64,14 @@ def _get_by_slug(slug: str) -> dict:
 	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
 	if not name:
 		raise InvalidArgumentError(f"unknown wiki page: {slug}")
-	if not frappe.has_permission(WIKI, ptype="read", doc=name):
+	# Load once, then check permission on the loaded object: has_permission with a
+	# name string would lazy-load this page a second time, and the full page is
+	# needed below for both the payload and the scope check.
+	doc = frappe.get_doc(WIKI, name)
+	if not frappe.has_permission(WIKI, ptype="read", doc=doc):
 		# #733: byte-identical to the missing-row error above — a caller must
 		# not be able to distinguish "no such page" from "exists but private".
 		raise InvalidArgumentError(f"unknown wiki page: {slug}")
-	doc = frappe.get_doc(WIKI, name)
 	# Scope visibility (explicit, on top of the has_permission hook): a Role/
 	# User page is only readable by its audience.
 	if not wiki_permissions.can_read_page(doc, frappe.session.user):

--- a/jarvis/tools/submit_doc.py
+++ b/jarvis/tools/submit_doc.py
@@ -60,10 +60,13 @@ def _submit_one(doctype: str, name: str) -> "frappe.model.document.Document":
 			f"actions available to you."
 		)
 
-	if not frappe.has_permission(doctype, ptype="submit", doc=name):
+	# Load once, then check permission on the loaded object (has_permission with a
+	# name string would lazy-load the parent row this get_doc already fetches).
+	# The check runs before doc.submit() below; the docstatus reads don't mutate.
+	doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing
+	if not frappe.has_permission(doctype, ptype="submit", doc=doc):
 		raise PermissionDeniedError(f"no submit permission on {doctype} '{name}'")
 
-	doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing
 	if doc.docstatus == 1:
 		raise InvalidArgumentError(f"{doctype} '{name}' is already submitted (docstatus=1)")
 	if doc.docstatus == 2:

--- a/jarvis/tools/update_doc.py
+++ b/jarvis/tools/update_doc.py
@@ -69,10 +69,16 @@ def _update_one(doctype: str, name: str, changes: dict) -> "frappe.model.documen
 	# (docstatus==0), and only a row owned by its run-as identity.
 	enforce_update(doctype, name)
 
-	if not frappe.has_permission(doctype, ptype="write", doc=name):
+	# Load the doc first, then check WRITE permission on the loaded object rather
+	# than by name. has_permission(doc=<name string>) lazy-loads the parent row
+	# just to evaluate the check - work this get_doc (needed for save() anyway)
+	# already does. Passing the loaded, UNMUTATED object yields an identical
+	# verdict and drops the duplicate load. Order is load-bearing: the check must
+	# run BEFORE any doc.set() below, so the verdict is on pristine DB values.
+	doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing
+	if not frappe.has_permission(doctype, ptype="write", doc=doc):
 		raise PermissionDeniedError(f"no write permission on {doctype} '{name}'")
 
-	doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing
 	for field, value in changes.items():
 		doc.set(field, value)
 	doc.save()  # runs DocType validate() and on_update hooks


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
