### PR TITLE
fix(usage): retry until context capacity resolves, not just token freshness

### DIFF
--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -183,7 +183,7 @@ def fetch_fresh_session_row(sess, session_key: str, attempts: int = 3, delay_s: 
 	a model that has never run a turn in THIS container before can go fresh
 	(``totalTokensFresh``, real ``inputTokens``/``outputTokens``) before the
 	gateway has resolved that model's ``contextTokens`` (its context-window
-	capacity) into the row. Verified live on openclaw 2026.9.2: a freshly
+	capacity) into the row. Verified live on the agent runtime (2026.9.2): a freshly
 	pinned session's row read ``contextTokens: null`` right after its first
 	completed turn, while OTHER sessions already using that same model in the
 	same container read ``272000`` — the value arrives late, not never, and a

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -179,24 +179,52 @@ def fetch_fresh_session_row(sess, session_key: str, attempts: int = 3, delay_s: 
 	bounded number of times inside the same checkout closes that window
 	without holding the pooled connection indefinitely.
 
-	Returns the first row that is both present and fresh (has a non-null
-	``inputTokens`` or ``outputTokens``). If no attempt ever produces a fresh
-	row, returns the LAST row seen anyway (``record_turn_usage``'s own
-	freshness gate will just no-op it, same as before this retry existed) and
-	logs once so the miss is visible instead of silently dropped.
+	jarvis#1170: a SECOND, narrower gap on the same row — a session pinned to
+	a model that has never run a turn in THIS container before can go fresh
+	(``totalTokensFresh``, real ``inputTokens``/``outputTokens``) before the
+	gateway has resolved that model's ``contextTokens`` (its context-window
+	capacity) into the row. Verified live on openclaw 2026.9.2: a freshly
+	pinned session's row read ``contextTokens: null`` right after its first
+	completed turn, while OTHER sessions already using that same model in the
+	same container read ``272000`` — the value arrives late, not never, and a
+	later turn on the SAME session does pick it up (there is no separate
+	catalog RPC needed). So freshness alone no longer ends the poll: once the
+	row is fresh, keep retrying (same attempts/delay budget) until it also
+	carries a capacity, falling back to the last fresh row when the budget
+	runs out.
+
+	Returns the first row that is both fresh (non-null ``inputTokens`` or
+	``outputTokens``) AND carries a capacity, when the budget allows it.
+	If no attempt ever produces a fresh row, returns the LAST row seen anyway
+	(``record_turn_usage``'s own freshness gate will just no-op it, same as
+	before this retry existed) and logs once so the miss is visible instead of
+	silently dropped. If the row went fresh but capacity never arrived within
+	the budget, returns the last FRESH row (so the real usage still gets
+	recorded) and logs a warning, not an error - the ring is hidden for this
+	one reply and self-heals on the session's next turn.
 	"""
 	row: dict | None = None
+	last_fresh_row: dict | None = None
 	for attempt in range(attempts):
 		rows = sess.list_sessions()
 		row = next((r for r in rows if r.get("key") == session_key), None)
-		if (
+		fresh = bool(
 			row
 			and row.get("totalTokensFresh")
 			and (row.get("inputTokens") is not None or row.get("outputTokens") is not None)
-		):
-			return row
+		)
+		if fresh:
+			last_fresh_row = row
+			if int(row.get("contextTokens") or 0) > 0:
+				return row
 		if attempt < attempts - 1:
 			time.sleep(delay_s)
+	if last_fresh_row is not None:
+		frappe.logger().warning(
+			"jarvis usage: fresh row missing context capacity (ring hidden this turn, "
+			f"self-heals on next turn): session_key={session_key!r} row={last_fresh_row!r}"
+		)
+		return last_fresh_row
 	frappe.log_error(
 		title="jarvis usage: session row never went fresh (turn usage lost)",
 		message=f"session_key={session_key!r} last row={row!r}",

--- a/jarvis/tests/test_user_settings.py
+++ b/jarvis/tests/test_user_settings.py
@@ -362,7 +362,16 @@ class _PollingSess:
 class TestFetchFreshSessionRow(_UsageTestBase):
 	def test_retries_until_fresh(self):
 		stale = {"key": "agent:poll", "totalTokensFresh": False, "inputTokens": 1, "outputTokens": 1}
-		fresh = {"key": "agent:poll", "totalTokensFresh": True, "inputTokens": 5, "outputTokens": 3}
+		# contextTokens already resolved here - this fixture is exercising the
+		# TOKEN-freshness retry only; jarvis#1170's capacity retry has its own
+		# tests below.
+		fresh = {
+			"key": "agent:poll",
+			"totalTokensFresh": True,
+			"inputTokens": 5,
+			"outputTokens": 3,
+			"contextTokens": 272000,
+		}
 		sess = _PollingSess([[stale], [fresh]])
 		with patch("jarvis.chat.usage.time.sleep", return_value=None) as mock_sleep:
 			row = usage.fetch_fresh_session_row(sess, "agent:poll")
@@ -377,6 +386,47 @@ class TestFetchFreshSessionRow(_UsageTestBase):
 			row = usage.fetch_fresh_session_row(sess, "agent:neverfresh", attempts=3)
 		self.assertEqual(row, stale)
 		self.assertEqual(sess.calls, 3)
+
+	def test_retries_when_fresh_but_capacity_missing(self):
+		# jarvis#1170: a session pinned to a model that has never run in this
+		# container reads back fresh usage before the gateway has resolved
+		# the model's contextTokens (context-window capacity) into the row.
+		no_capacity = {
+			"key": "agent:pinned",
+			"totalTokensFresh": True,
+			"inputTokens": 5,
+			"outputTokens": 3,
+			"contextTokens": None,
+		}
+		with_capacity = {
+			"key": "agent:pinned",
+			"totalTokensFresh": True,
+			"inputTokens": 5,
+			"outputTokens": 3,
+			"contextTokens": 272000,
+		}
+		sess = _PollingSess([[no_capacity], [with_capacity]])
+		with patch("jarvis.chat.usage.time.sleep", return_value=None) as mock_sleep:
+			row = usage.fetch_fresh_session_row(sess, "agent:pinned")
+		self.assertEqual(row, with_capacity, "keeps polling past a fresh-but-capacity-less row")
+		self.assertEqual(sess.calls, 2)
+		mock_sleep.assert_called_once()
+
+	def test_capacity_never_arrives_returns_last_fresh_row(self):
+		# The budget is bounded: real usage must still be recorded (a fresh
+		# row, just never carrying a capacity) rather than retried forever.
+		no_capacity = {
+			"key": "agent:pinned-stuck",
+			"totalTokensFresh": True,
+			"inputTokens": 5,
+			"outputTokens": 3,
+			"contextTokens": 0,
+		}
+		sess = _PollingSess([[no_capacity]])
+		with patch("jarvis.chat.usage.time.sleep", return_value=None):
+			row = usage.fetch_fresh_session_row(sess, "agent:pinned-stuck", attempts=3)
+		self.assertEqual(row, no_capacity, "still returns the fresh row so usage is recorded")
+		self.assertEqual(sess.calls, 3, "exhausts the same bounded budget, no infinite retry")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Pinning a non-default model (gpt-5.5, luna, sol, astra) hid the context ring
because its usage row could go token-fresh before the gateway resolved the
model's context-window capacity — the polling loop stopped at the first
condition and never checked the second. Now it keeps polling (same bounded
budget) until both arrive, so usage still records even if capacity never
shows up in time.

Root cause verified live against the tenant/container the issue was filed
against (e2e.localhost, openclaw 2026.9.2): a model's very first turn in a
container can read back real usage with `contextTokens: null`, while other
sessions already using that model in the same container read the real value —
it's a resolution lag, not a permanent gap, and a Jarvis Chat Session row
that hit it stayed stuck at `context_capacity = 0` with no self-heal until
that same session ran a second turn.

<details>
<summary>Root cause detail</summary>

`fetch_fresh_session_row` returned as soon as `totalTokensFresh` flipped true,
regardless of `contextTokens`. `record_turn_usage` only writes
`context_capacity` when the row it was handed actually reports one, so a
session whose first (and often only) turn hit the lag never got a capacity —
and `context_payload`'s `fresh` flag (`last_usage_at` set AND `capacity > 0`)
stayed false forever, hiding the ring.

Confirmed on the exact tenant/container: a brand-new session pinned to
`gpt-5.5` (a model already warm in that container from earlier testing) got
`contextTokens: 272000` immediately, while an existing `gpt-6-astra` session
(pinned earlier, one turn recorded) still had `context_capacity = 0` in the
DB. Both `sessions.list`'s `defaults` block and a `models.list` RPC exist,
but neither is a reliable fallback — `models.list` only reports
`contextWindow` for the container's already-"configured"/default model, same
lazy-resolution gap as the session row itself — so the fix stays inside the
existing per-session retry rather than adding a new lookup.

</details>

Fixes #1170.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01SCaS6wwX9bbJk3Tm4yMMr2
