### PR TITLE
Perf/skill child table batch

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
@@ -142,6 +142,54 @@ def _child_values(skill, fieldname: str, value_field: str, child_doctype: str) -
 	return values
 
 
+def prefetch_child_values(skills: list) -> None:
+	"""Batch-load ``shared_with`` + ``allowed_roles`` onto a list of skill rows so
+	``user_can_use_skill``'s per-row ``_child_values`` fallback does not fire.
+
+	find_skills / get_skill fetch scalar-only candidate rows (no child tables), so
+	each row would otherwise trigger up to two per-row ``get_all`` lookups inside
+	the visibility check (an N+1). This resolves both child tables for the whole
+	batch in two queries and attaches the results in place.
+
+	Contract (must match ``_child_values`` exactly):
+	- Seed EVERY row with a list (``[]`` when it has no child rows). A MISSING key
+	  leaves ``skill.get(fieldname)`` as ``None`` → the per-row fallback re-fires,
+	  silently undoing the batch.
+	- Keep ``parenttype=SKILL_DOCTYPE``: ``Jarvis Custom Skill Allowed Role`` is a
+	  child of BOTH this doctype and Jarvis Skill Promotion Request, so a bare
+	  ``parent in names`` could pull a promotion request's rows.
+	- Drop falsy values, mirroring ``_child_values``' ``if value`` filter.
+
+	Caller must SKIP this for Administrator / System Manager (they short-circuit
+	``user_can_use_skill`` before any child read); it is also pointless for a
+	single-row batch.
+	"""
+	names = [s.get("name") for s in skills if s.get("name")]
+	if not names:
+		return
+	shares = _batch_child_values(names, "Jarvis Custom Skill Share", "user")
+	roles = _batch_child_values(names, "Jarvis Custom Skill Allowed Role", "role")
+	for s in skills:
+		name = s.get("name")
+		s["shared_with"] = shares.get(name, [])
+		s["allowed_roles"] = roles.get(name, [])
+
+
+def _batch_child_values(names: list, child_doctype: str, value_field: str) -> dict:
+	"""``{parent: [value, ...]}`` for ``child_doctype`` rows under ``names``, in one
+	query. Scoped by ``parenttype`` and falsy-filtered to match ``_child_values``."""
+	grouped: dict = {}
+	for row in frappe.get_all(
+		child_doctype,
+		filters={"parenttype": SKILL_DOCTYPE, "parent": ["in", names]},
+		fields=["parent", value_field],
+	):
+		value = row.get(value_field)
+		if value:
+			grouped.setdefault(row.parent, []).append(value)
+	return grouped
+
+
 class JarvisCustomSkill(Document):
 	def validate(self):
 		self._validate_slug()

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
@@ -177,7 +177,14 @@ def prefetch_child_values(skills: list) -> None:
 
 def _batch_child_values(names: list, child_doctype: str, value_field: str) -> dict:
 	"""``{parent: [value, ...]}`` for ``child_doctype`` rows under ``names``, in one
-	query. Scoped by ``parenttype`` and falsy-filtered to match ``_child_values``."""
+	query, scoped by ``parenttype``.
+
+	The ``if value`` drop matches ``_child_values``' LIST branch (which every
+	batch-attached row goes through) — the authoritative filter also used on the
+	SPA/ORM Document path. Both child fields (``user``/``role``) are ``reqd: 1``
+	and the controller writes only non-empty values, so a falsy value is not
+	reachable through any app write; the filter is defensive alignment, not a
+	behaviour change for real data."""
 	grouped: dict = {}
 	for row in frappe.get_all(
 		child_doctype,

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -782,7 +782,21 @@ class TestSkillChildTableBatch(SkillToolsTestCase):
 
 	def test_gate_fires_for_multi_row_normal_user(self):
 		with patch(_PREFETCH) as pf:
-			rows = [{"name": "x"}, {"name": "y"}]
+			rows = [{"name": "x", "owner": "other@example.com"}, {"name": "y", "owner": "other@example.com"}]
+			_maybe_prefetch_children(rows, "u@example.com", ["Jarvis User"])
+		pf.assert_called_once_with(rows)
+
+	def test_gate_skips_when_all_rows_owned_by_caller(self):
+		# Every row the caller owns short-circuits user_can_use_skill before any
+		# child read, so there is nothing to batch.
+		rows = [{"name": "x", "owner": "u@example.com"}, {"name": "y", "owner": "u@example.com"}]
+		with patch(_PREFETCH) as pf:
+			_maybe_prefetch_children(rows, "u@example.com", ["Jarvis User"])
+		pf.assert_not_called()
+
+	def test_gate_fires_when_any_row_owned_by_other(self):
+		rows = [{"name": "x", "owner": "u@example.com"}, {"name": "y", "owner": "other@example.com"}]
+		with patch(_PREFETCH) as pf:
 			_maybe_prefetch_children(rows, "u@example.com", ["Jarvis User"])
 		pf.assert_called_once_with(rows)
 

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -24,9 +24,12 @@ from jarvis.chat.custom_skills import (
 	prefixed_slug,
 )
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
+	prefetch_child_values as _real_prefetch,
+)
 from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
 from jarvis.tools.create_custom_skill import create_custom_skill
-from jarvis.tools.find_skills import find_skills
+from jarvis.tools.find_skills import _maybe_prefetch_children, find_skills
 from jarvis.tools.get_skill import (
 	_LEARNED_PREFIX,
 	_MISS_AUDIT_PREFIX,
@@ -734,3 +737,95 @@ class TestReceiptRefStamping(SkillToolsTestCase):
 		self.assertFalse(row.ref_doctype)
 		self.assertFalse(row.ref_name)
 		self.assertEqual(row.tool_status, "error")
+
+
+# Patch target for the lazy import inside _maybe_prefetch_children.
+_PREFETCH = "jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill.prefetch_child_values"
+_CHILD_DTS = ("Jarvis Custom Skill Share", "Jarvis Custom Skill Allowed Role")
+
+
+@contextlib.contextmanager
+def _count_child_get_all():
+	"""Count frappe.get_all calls against the skill child tables, so we can prove
+	the per-row _child_values fallback (an N+1) was replaced by one batch."""
+	counts = {"total": 0}
+	real = frappe.get_all
+
+	def spy(doctype, *a, **k):
+		if doctype in _CHILD_DTS:
+			counts["total"] += 1
+		return real(doctype, *a, **k)
+
+	with patch("frappe.get_all", side_effect=spy):
+		yield counts
+
+
+class TestSkillChildTableBatch(SkillToolsTestCase):
+	"""LANE 2: find_skills/get_skill batch-load the visibility child tables in one
+	query instead of a per-candidate _child_values fallback (N+1)."""
+
+	# --- the prefetch gate (pure unit tests) ---
+	def test_gate_skips_single_row(self):
+		with patch(_PREFETCH) as pf:
+			_maybe_prefetch_children([{"name": "x"}], "u@example.com", ["Jarvis User"])
+		pf.assert_not_called()
+
+	def test_gate_skips_system_manager(self):
+		with patch(_PREFETCH) as pf:
+			_maybe_prefetch_children([{"name": "x"}, {"name": "y"}], "u@example.com", ["System Manager"])
+		pf.assert_not_called()
+
+	def test_gate_skips_administrator(self):
+		with patch(_PREFETCH) as pf:
+			_maybe_prefetch_children([{"name": "x"}, {"name": "y"}], "Administrator", [])
+		pf.assert_not_called()
+
+	def test_gate_fires_for_multi_row_normal_user(self):
+		with patch(_PREFETCH) as pf:
+			rows = [{"name": "x"}, {"name": "y"}]
+			_maybe_prefetch_children(rows, "u@example.com", ["Jarvis User"])
+		pf.assert_called_once_with(rows)
+
+	# --- integration: the N+1 is gone, verdicts unchanged ---
+	def test_find_skills_batches_child_reads(self):
+		"""3 Org skills, non-owner caller: child tables read in 2 batched queries,
+		not 2-per-row (6). Also proves []-seeded rows evaluate to the same verdict
+		(all three stay visible)."""
+		for slug in ("sttool-batch-a", "sttool-batch-b", "sttool-batch-c"):
+			_make_skill(OWNER, slug, "batchmatch org skill", scope="Org")
+		with _as(PEER), _count_child_get_all() as counts:
+			res = find_skills("batchmatch")
+		names = {s["skill_name"] for s in res["skills"]}
+		self.assertEqual(names, {"sttool-batch-a", "sttool-batch-b", "sttool-batch-c"})
+		# 2 batched child reads (one per child table) regardless of row count;
+		# the old per-row fallback would be 2 x 3 = 6.
+		self.assertEqual(counts["total"], 2)
+
+	def test_batch_grouping_is_per_parent(self):
+		"""Shares must be grouped strictly by parent: a share on skill A must not
+		leak visibility of a different, unshared skill B."""
+		_make_skill(OWNER, "sttool-grp-a", "grpmatch", scope="User", shared_with=[PEER])
+		_make_skill(OWNER, "sttool-grp-b", "grpmatch", scope="User")  # NOT shared
+		with _as(PEER):
+			res = find_skills("grpmatch")
+		names = {s["skill_name"] for s in res["skills"]}
+		self.assertIn("sttool-grp-a", names)  # shared with PEER
+		self.assertNotIn("sttool-grp-b", names)  # User-scope, unshared -> invisible
+
+	def test_get_skill_single_row_no_batch(self):
+		"""A unique slug matches one row (the common case): no batch, no waste."""
+		_make_skill(OWNER, "sttool-solo", "solo skill", scope="Org")
+		with patch(_PREFETCH) as pf, _as(OWNER):
+			res = get_skill("sttool-solo")
+		self.assertEqual(res["skill_name"], "sttool-solo")
+		pf.assert_not_called()
+
+	def test_get_skill_multi_row_caller_own_wins_and_batches(self):
+		"""Same slug as an Org shared skill AND the caller's own private override:
+		>1 row matches so the batch fires, and the caller's OWN row wins."""
+		_make_skill(OWNER, "sttool-dup", "org-shared-desc", scope="Org")  # visible to all
+		_make_skill(PEER, "sttool-dup", "peer-private-desc", scope="User")  # PEER's own
+		with patch(_PREFETCH, wraps=_real_prefetch) as pf, _as(PEER):
+			res = get_skill("sttool-dup")
+		pf.assert_called_once()  # R>1 -> batched
+		self.assertEqual(res["description"], "peer-private-desc")  # caller's own row wins

--- a/jarvis/tools/find_skills.py
+++ b/jarvis/tools/find_skills.py
@@ -57,6 +57,12 @@ def _maybe_prefetch_children(rows: list, user: str, user_roles: list[str]) -> No
 		return
 	if user == "Administrator" or "System Manager" in user_roles:
 		return
+	# Every row the caller OWNS short-circuits user_can_use_skill before any child
+	# read, so if the caller owns them all there is nothing to batch (those rows
+	# cost 0 child queries on the per-row path — batching would only add 2). Fire
+	# only when at least one row belongs to someone else.
+	if not any(r.get("owner") != user for r in rows):
+		return
 	from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
 		prefetch_child_values,
 	)

--- a/jarvis/tools/find_skills.py
+++ b/jarvis/tools/find_skills.py
@@ -47,6 +47,23 @@ def _visible(row, user: str, user_roles: list[str]) -> bool:
 	return user_can_use_skill(row, user, user_roles)
 
 
+def _maybe_prefetch_children(rows: list, user: str, user_roles: list[str]) -> None:
+	"""Batch-load child tables (shared_with/allowed_roles) for the visibility
+	check, so ``_visible`` doesn't fire a per-row fallback query per candidate.
+	Skipped when it wouldn't help: a single candidate (no batching win), or an
+	Administrator / System Manager caller (``user_can_use_skill`` short-circuits
+	before any child read)."""
+	if len(rows) <= 1:
+		return
+	if user == "Administrator" or "System Manager" in user_roles:
+		return
+	from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
+		prefetch_child_values,
+	)
+
+	prefetch_child_values(rows)
+
+
 def find_skills(query: str, limit: int = 10) -> dict:
 	"""Search enabled skills by name/description; returns only skills the
 	calling user may use. ``{"skills": [{skill_name, scope, description,
@@ -75,6 +92,7 @@ def find_skills(query: str, limit: int = 10) -> dict:
 		as_dict=True,
 	)
 	user_roles = frappe.get_roles(user)
+	_maybe_prefetch_children(rows, user, user_roles)
 	skills = []
 	for row in rows:
 		if not _visible(row, user, user_roles):

--- a/jarvis/tools/get_skill.py
+++ b/jarvis/tools/get_skill.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.tools.find_skills import _require_system_user, _visible
+from jarvis.tools.find_skills import _maybe_prefetch_children, _require_system_user, _visible
 
 SKILL = "Jarvis Custom Skill"
 _CUSTOM_PREFIX = "custom-"
@@ -69,6 +69,10 @@ def get_skill(skill_name: str) -> dict:
 		raise InvalidArgumentError(f"unknown skill: {skill_name}")
 
 	user_roles = frappe.get_roles(user)
+	# Batch child tables only when more than one row matched the slug (a single
+	# row - the common case, unique per owner - short-circuits or fallback-reads
+	# at most once, so batching would only add queries).
+	_maybe_prefetch_children(rows, user, user_roles)
 	usable = [r for r in rows if _visible(r, user, user_roles)]
 	if not usable:
 		_audit_learned_miss(raw, user, "denied")


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
