### PR TITLE
Perf/query acl memo

### DIFF
--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -22,6 +22,7 @@ from jarvis.exceptions import (
 	PermissionDeniedError,
 	ResultTooLargeError,
 )
+from jarvis.tools import query as query_mod
 from jarvis.tools.query import ROW_GUARD, query
 
 
@@ -3425,3 +3426,75 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 		self.assertIn("child_restricted", msg)
 		self.assertIn("permission level", msg)
 		self.assertIn(self.SCOPE_PARENT_A, msg)  # the parent that governs the permlevel
+
+	# ---- LANE 1: per-call permitted-field ACL memo -------------------
+
+	def test_acl_memo_cross_user_isolation(self):
+		"""One process, two users back-to-back: the per-call memo must NEVER serve
+		one user's permitted-field set to another. Restricted stays denied and
+		privileged stays allowed regardless of order. This is the guard against an
+		args-only / non-reset cache (the request_cache footgun the plan rejected)."""
+		# Restricted first, then privileged.
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError):
+			query({"from": self.PARENT_DT, "alias": "p", "select": ["p.public_field", "p.restricted_field"]})
+		frappe.set_user(self.USER_PRIVILEGED)
+		res = query(
+			{"from": self.PARENT_DT, "alias": "p", "select": ["p.public_field", "p.restricted_field"]}
+		)
+		self.assertIn("sql", res)  # privileged reads the permlevel field fine
+
+		# Reverse: privileged first POPULATES the memo, then restricted must still
+		# be denied (a leaked/args-only memo would wrongly admit it here).
+		frappe.set_user(self.USER_PRIVILEGED)
+		query({"from": self.PARENT_DT, "alias": "p", "select": ["p.restricted_field"]})
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError):
+			query({"from": self.PARENT_DT, "alias": "p", "select": ["p.public_field", "p.restricted_field"]})
+
+	def test_acl_memo_permitted_fields_computed_once_per_table(self):
+		"""A query referencing a table's fields many times computes the permitted-
+		field ACL ONCE (memoized), not once per column reference."""
+		frappe.set_user(self.USER_PRIVILEGED)
+		with patch.object(query_mod, "get_permitted_fields", wraps=query_mod.get_permitted_fields) as gpf:
+			query(
+				{
+					"from": self.PARENT_DT,
+					"alias": "p",
+					"select": ["p.public_field", "p.restricted_field"],
+					"where": [{"field": "p.public_field", "op": "=", "value": "x"}],
+					"order_by": [{"field": "p.restricted_field", "dir": "asc"}],
+				}
+			)
+		# 4 dotted business-field references, one table -> ACL computed exactly once.
+		self.assertEqual(gpf.call_count, 1)
+
+	def test_acl_memo_reset_between_calls(self):
+		"""The memo is per-CALL: a second query() recomputes rather than reusing the
+		first call's memo, so a permission change mid-request is always honored."""
+		frappe.set_user(self.USER_PRIVILEGED)
+		with patch.object(query_mod, "get_permitted_fields", wraps=query_mod.get_permitted_fields) as gpf:
+			query({"from": self.PARENT_DT, "alias": "p", "select": ["p.restricted_field"]})
+			first = gpf.call_count
+			query({"from": self.PARENT_DT, "alias": "p", "select": ["p.restricted_field"]})
+			second = gpf.call_count
+		self.assertEqual(first, 1)
+		self.assertEqual(second, 2)  # 2nd call recomputed (memo was reset at entry)
+
+	def test_acl_memo_kill_switch_recomputes_per_reference(self):
+		"""With the site-config kill switch set, the memo is bypassed and the ACL is
+		recomputed on every reference (the emergency straight-through fallback)."""
+		frappe.set_user(self.USER_PRIVILEGED)
+		frappe.conf["jarvis_disable_query_acl_memo"] = True
+		try:
+			with patch.object(query_mod, "get_permitted_fields", wraps=query_mod.get_permitted_fields) as gpf:
+				query(
+					{
+						"from": self.PARENT_DT,
+						"alias": "p",
+						"select": ["p.public_field", "p.restricted_field"],
+					}
+				)
+			self.assertEqual(gpf.call_count, 2)  # one per reference, no memo
+		finally:
+			frappe.conf.pop("jarvis_disable_query_acl_memo", None)

--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -3498,3 +3498,23 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 			self.assertEqual(gpf.call_count, 2)  # one per reference, no memo
 		finally:
 			frappe.conf.pop("jarvis_disable_query_acl_memo", None)
+
+	def test_acl_memo_keys_on_base_doctype(self):
+		"""base_doctype is part of the memo key: the same child dt resolved under two
+		different owning parents (as an EXISTS sub-FROM's scope produces) must
+		compute SEPARATELY, never collide on a base-less key. Dropping base_doctype
+		from the key would collapse these to one entry and serve one parent's
+		permitted set for the other — this pins acceptance criterion #3."""
+		frappe.set_user(self.USER_SCOPE_AB)  # can read both scope parents
+		query_mod._reset_acl_memo()
+		with patch.object(query_mod, "get_permitted_fields", wraps=query_mod.get_permitted_fields) as gpf:
+			a1 = query_mod._permitted_read_fields(self.SCOPE_CHILD_DT, self.SCOPE_PARENT_A)
+			b1 = query_mod._permitted_read_fields(self.SCOPE_CHILD_DT, self.SCOPE_PARENT_B)
+			# Repeats must be memo HITS (no recompute), proving each base is its own key.
+			a2 = query_mod._permitted_read_fields(self.SCOPE_CHILD_DT, self.SCOPE_PARENT_A)
+			b2 = query_mod._permitted_read_fields(self.SCOPE_CHILD_DT, self.SCOPE_PARENT_B)
+		# Two distinct (dt, base) keys -> computed once each; a base-less key -> 1.
+		self.assertEqual(gpf.call_count, 2)
+		# Same key returns the identical cached object (frozenset), not a recompute.
+		self.assertIs(a1, a2)
+		self.assertIs(b1, b2)

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -558,7 +558,13 @@ def _reset_acl_memo() -> None:
 	switch). Called once at the top of ``query()``. Deliberately per-CALL, not
 	per-request: a permission mutation earlier in the same request (share_doc,
 	update_doc) must not let a later query() read a stale ACL. Resetting at entry
-	means each call starts clean and nothing else ever reads this attribute."""
+	means each call starts clean and nothing else ever reads this attribute.
+
+	(This is why ``frappe.request_cache`` is NOT used: it lives for the whole
+	request and would serve that stale ACL to a later query() in the same request;
+	it also keys on args only, so a user-in-key would be needed regardless. The
+	hand-rolled per-call reset keeps this behaviour-identical to get_list, which
+	recomputes the field ACL uncached every call.)"""
 	setattr(frappe.local, _ACL_MEMO_ATTR, {} if _acl_memo_enabled() else None)
 
 

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -184,6 +184,11 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 	if not isinstance(spec, dict):
 		raise InvalidArgumentError("spec must be a dict")
 
+	# Start a fresh per-call memo for the field-level ACL (see
+	# _permitted_read_fields). Per-call, so a permission change earlier in this
+	# request can't be served stale to this query.
+	_reset_acl_memo()
+
 	# Step 1: validate spec shape (lightweight; deep validation happens
 	# during translation when we have type context).
 	_validate_spec_shape(spec)
@@ -535,9 +540,59 @@ def _from_doctype(alias_map: dict) -> str:
 	return next(iter(alias_map.values()))[0]
 
 
-def _permitted_read_fields(dt: str, base_doctype: str | None) -> set[str]:
-	"""Fields on ``dt`` the current user may READ (the field-level permlevel
-	ACL), mirroring ``get_list``'s ``apply_fieldlevel_read_permissions``.
+_ACL_MEMO_ATTR = "_jarvis_query_permitted_fields_memo"
+
+
+def _acl_memo_enabled() -> bool:
+	"""Kill switch for the per-call permitted-field memo. Set
+	``jarvis_disable_query_acl_memo: true`` in site_config (then restart the
+	workers) to bypass it and recompute the field ACL fresh on every column
+	reference. An emergency escape hatch: there is no runtime signal that would
+	catch a memo bug in prod, so operators must be able to turn it off live
+	without a code redeploy."""
+	return not frappe.conf.get("jarvis_disable_query_acl_memo")
+
+
+def _reset_acl_memo() -> None:
+	"""Start a FRESH memo for one ``query()`` call (or disable it under the kill
+	switch). Called once at the top of ``query()``. Deliberately per-CALL, not
+	per-request: a permission mutation earlier in the same request (share_doc,
+	update_doc) must not let a later query() read a stale ACL. Resetting at entry
+	means each call starts clean and nothing else ever reads this attribute."""
+	setattr(frappe.local, _ACL_MEMO_ATTR, {} if _acl_memo_enabled() else None)
+
+
+def _permitted_read_fields(dt: str, base_doctype: str | None) -> frozenset[str]:
+	"""Fields on ``dt`` the current user may READ (the field-level permlevel ACL),
+	memoized for the lifetime of one ``query()`` call.
+
+	The underlying ``get_permitted_fields`` is NOT cached by Frappe and is called
+	once per concrete column reference (select/where/having/group-by/order-by/
+	join-on/EXISTS), so a wide query recomputed the identical ACL set — plus, in
+	the no-permlevel-0 branch, a ``get_shared`` DB query — many times. Memoize on
+	``(user, dt, base_doctype)``:
+	  - ``user`` — belt-and-suspenders so the set can never be read across an
+	    identity switch (the memo is per-call and one call is one user, but the
+	    key makes a cross-user read structurally impossible).
+	  - ``base_doctype`` — load-bearing: an EXISTS sub-FROM resolves the same
+	    ``dt`` under a different base, which legitimately yields a DIFFERENT
+	    permitted set (parenttype None vs the base).
+	The result is a ``frozenset`` so a caller can never mutate the cached value.
+	"""
+	memo = getattr(frappe.local, _ACL_MEMO_ATTR, None)
+	key = (frappe.session.user, dt, base_doctype)
+	# ``key in memo``, not truthiness: an empty permitted set (e.g. a child-as-FROM
+	# with zero readable parents) is a real, cacheable answer, not a miss.
+	if memo is not None and key in memo:
+		return memo[key]
+	result = _compute_permitted_read_fields(dt, base_doctype)
+	if memo is not None:
+		memo[key] = result
+	return result
+
+
+def _compute_permitted_read_fields(dt: str, base_doctype: str | None) -> frozenset[str]:
+	"""The uncached ACL computation behind ``_permitted_read_fields``.
 
 	A child (istable) DocType carries no permissions of its own, so
 	``get_permitted_fieldnames`` short-circuits to an EMPTY list for
@@ -555,7 +610,7 @@ def _permitted_read_fields(dt: str, base_doctype: str | None) -> set[str]:
 	"""
 	if not frappe.get_meta(dt).istable:
 		parenttype = None if (base_doctype is None or dt == base_doctype) else base_doctype
-		return set(
+		return frozenset(
 			get_permitted_fields(
 				doctype=dt,
 				parenttype=parenttype,
@@ -586,7 +641,7 @@ def _permitted_read_fields(dt: str, base_doctype: str | None) -> set[str]:
 				ignore_virtual=True,
 			)
 		)
-	return permitted
+	return frozenset(permitted)
 
 
 def _validate_column(dt: str, field: str, base_doctype: str | None = None) -> None:


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
