### PR TITLE
fix(maintenance): Desk widget self-heal — shared reactive state + poll

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -722,7 +722,7 @@ import { resizeFrom } from "./panel_size.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { classifyReadiness, degradedActionable, shouldWarnWorkers } from "./panel_readiness.mjs";
 import { sendRefusalMessage } from "./panel_send_copy.mjs";
-import { maintenanceActiveAfterSend } from "./panel_maintenance.mjs";
+import { maintenance, foldSend, startPollIfHeld } from "./maintenance_state.mjs";
 import {
 	emptyStream,
 	applyEvent,
@@ -1139,22 +1139,17 @@ function dismissFeedback() {
 // synchronously so there's no flash. Blank => Jarvis defaults.
 const brandName = (window.frappe?.boot?.jarvis_agent_name || "").trim() || "Jarvis";
 const brandLogoUrl = (window.frappe?.boot?.jarvis_brand_logo_url || "").trim();
-// Upgrade maintenance hold (Stream E): seeded from boot (jarvis_maintenance =
-// {active, message}, set_jarvis_boot), raised if a send is refused with reason
-// "maintenance" while the bubble is open, and cleared the moment a later send gets
-// through (the roll finished). The composer never blocks - a held send shows the
-// friendly refusal, not a dead box. The custom operator message (brand-scrubbed
-// server-side) wins over the branded default; the server refusal carries only the
-// reason, so the boot message is the source of the custom text.
-const _maint = window.frappe?.boot?.jarvis_maintenance || {};
-const maintenanceActive = ref(!!_maint.active);
-const maintenanceMessage = ref((_maint.message || "").trim());
+// Upgrade maintenance hold (Stream E): the panel + the FAB share ONE reactive source
+// (maintenance_state.mjs, seeded from boot) so they can never disagree, and a 60s poll
+// (armed on mount / on a raised send) lifts the banner when the roll finishes even on an
+// idle open bubble. The composer never blocks - a held send shows the friendly refusal,
+// not a dead box. The custom operator message (brand-scrubbed server-side) wins over the
+// branded default; the server refusal carries only the reason.
+const maintenanceActive = computed(() => maintenance.active);
+const maintenanceMessage = computed(() => maintenance.message);
 const maintenanceText = computed(
-	// Reuse the single-sourced copy (sendRefusalMessage) instead of a 3rd hardcoded copy of
-	// the sentence, so a wording change can't leave this banner out of sync with the inline
-	// refusal / the SPA. NOTE: there is no widget-side recheck()/poll - this desk bundle
-	// cannot import frontend/src (see panel_send_copy.mjs's header), so the hold clears on
-	// the next accepted send (maintenanceActiveAfterSend) or a Desk reload.
+	// Reuse the single-sourced copy (sendRefusalMessage) instead of a 3rd hardcoded copy of the
+	// sentence, so a wording change can't leave this banner out of sync with the inline refusal.
 	() => maintenanceMessage.value || sendRefusalMessage("maintenance", brandName)
 );
 // A turn is in flight from the moment the POST is away until the first token
@@ -1629,10 +1624,9 @@ async function send() {
 		const approvalTokens = orderedPending.value.map((p) => p.token);
 		const res = await sendMessage(convId.value, text, props.context, atts, approvalTokens);
 		if (res?.conversation_id) convId.value = res.conversation_id;
-		// Fold this response into the maintenance banner: raise on a "maintenance"
-		// refusal, clear once any send/confirm gets past the gate (proof it lifted).
-		const maintNext = maintenanceActiveAfterSend(res);
-		if (maintNext !== null) maintenanceActive.value = maintNext;
+		// Fold this response into the shared maintenance state: raise on a "maintenance"
+		// refusal (and arm the lift-poll), clear once any send/confirm gets past the gate.
+		foldSend(res);
 		// A send the server refused outright (e.g. a required app update, via the
 		// same validate_can_send gate as the full chat) starts no turn and returns
 		// no conversation. Surface the reason and STOP — otherwise the fall-through
@@ -1886,6 +1880,9 @@ function startPolling() {
 }
 
 onMounted(() => {
+	// Arm the maintenance lift-poll if the panel opens already held (the FAB self-arms it at
+	// module load too, so an unopened held bubble also self-heals).
+	startPollIfHeld();
 	isDark.value = isDarkNow();
 	unwatchTheme = watchTheme((d) => {
 		isDark.value = d;

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -81,6 +81,7 @@
 
 <script setup>
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
+import { maintenance, startPollIfHeld } from "./maintenance_state.mjs";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
 import { panelLayout } from "./panel_anchor.mjs";
@@ -164,10 +165,11 @@ const hasAccess = Boolean(window.frappe?.boot?.jarvis_has_access);
 // Whitelabel FAB label + mark (set_jarvis_boot); blank => Jarvis defaults.
 const brandName = (window.frappe?.boot?.jarvis_agent_name || "").trim() || "Jarvis";
 const brandLogoUrl = (window.frappe?.boot?.jarvis_brand_logo_url || "").trim();
-// Upgrade maintenance hold (Stream E): the FAB rests with sleepy lids + z z z during
-// a hold, mirroring the panel avatar. Read from boot at mount (whitelabel logo -> no
-// face, same as the spark branch).
-const maintenanceActive = Boolean(window.frappe?.boot?.jarvis_maintenance?.active);
+// Upgrade maintenance hold (Stream E): the FAB rests with sleepy lids + z z z during a
+// hold, mirroring the panel avatar. Reactive off the SHARED state (maintenance_state.mjs) so
+// the FAB and the open panel never disagree, and a 60s poll (armed in onMounted) lifts it
+// when the roll finishes - even if the panel is never opened (whitelabel logo -> no face).
+const maintenanceActive = computed(() => maintenance.active);
 
 // ---- Side chat panel: open state and the Desk record it is looking at. ----
 const panelRef = ref(null);
@@ -494,6 +496,9 @@ function onResize() {
 }
 
 onMounted(() => {
+	// Arm the maintenance lift-poll (the module self-arms at load too); the always-mounted FAB
+	// drives it so a held bubble self-heals even when the panel is never opened.
+	startPollIfHeld();
 	// The Desk's dark flag is read in JS, not CSS: this component's
 	// `:global([data-theme=dark]) .jvw-root` compiled to a bare
 	// `[data-theme=dark]` rule, so its custom properties landed on <html> and

--- a/jarvis/public/js/jarvis_chat/widget/maintenance_state.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/maintenance_state.mjs
@@ -1,0 +1,79 @@
+// Shared reactive upgrade-maintenance state for the Desk widget (Stream E, review finding #5).
+// Both the FAB (Widget.vue, always mounted) and the chat Panel (lazily mounted on first open)
+// import this ONE singleton, so they can never disagree on hold state. A 60s poll — armed at
+// module load if the boot state is held, and on every transition-into-held — lifts the banner
+// when the operator/roll clears the hold, so an idle bubble self-heals without a Desk reload.
+//
+// The pure decision (nextFromSend) lives in panel_maintenance.mjs so `node --test` can exercise
+// it without a bundler; this module holds only the reactive wrapper + poll (vue + the Desk
+// `frappe.call` global), which the flow review exercises in the browser.
+import { reactive } from "vue";
+import { nextFromSend } from "./panel_maintenance.mjs";
+
+const _boot =
+  (typeof window !== "undefined" && window.frappe?.boot?.jarvis_maintenance) ||
+  {};
+export const maintenance = reactive({
+  active: !!_boot.active,
+  message: (_boot.message || "").trim(),
+});
+
+let _timer = null;
+
+export function startPollIfHeld() {
+  // Poll only WHILE held (bounded work), coalesced by check()'s own 30s server-side cache.
+  if (!_timer && maintenance.active) {
+    _timer = setInterval(recheck, 60000);
+  }
+}
+
+export function stopPoll() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+// Fold a send() response into the shared state and re-sync the poll: a raised hold ARMS the
+// poll (so the tab that raised it still self-heals when idle), an accepted send stops it.
+export function foldSend(res) {
+  maintenance.active = nextFromSend(maintenance, res).active;
+  if (maintenance.active) {
+    startPollIfHeld();
+  } else {
+    stopPoll();
+  }
+}
+
+let _rechecking = false;
+
+// Re-pull the mirror from admin (jarvis.maintenance_notice.check) and fold it in. Keeps
+// last-known on any error or malformed shape (never clears a live hold on a flaky poll), and
+// never reloads the page.
+export async function recheck() {
+  if (_rechecking) {
+    return;
+  }
+  _rechecking = true;
+  try {
+    const r = await frappe.call({ method: "jarvis.maintenance_notice.check" });
+    const m = r && r.message;
+    if (m && typeof m === "object" && "active" in m) {
+      maintenance.active = !!m.active;
+      maintenance.message = (m.message || "").trim();
+    }
+  } catch (_e) {
+    // keep last-known
+  } finally {
+    _rechecking = false;
+  }
+  if (maintenance.active) {
+    startPollIfHeld();
+  } else {
+    stopPoll();
+  }
+}
+
+// Self-arm at module load so an idle FAB (panel never opened) still self-heals: this module is
+// imported by the always-mounted Widget, so this side-effect runs on every Desk page.
+startPollIfHeld();

--- a/jarvis/public/js/jarvis_chat/widget/panel_maintenance.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_maintenance.mjs
@@ -18,3 +18,11 @@ export function maintenanceActiveAfterSend(res) {
   }
   return false;
 }
+
+// The shared reactive state (maintenance_state.mjs) folds a send() response through this pure
+// reducer, so the code that actually runs (foldSend) is the code under test. Returns the next
+// {active}: a null from maintenanceActiveAfterSend (unrelated refusal) keeps the current state.
+export function nextFromSend(state, res) {
+  const next = maintenanceActiveAfterSend(res);
+  return next === null ? { active: state.active } : { active: next };
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_maintenance.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_maintenance.test.mjs
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { maintenanceActiveAfterSend } from "./panel_maintenance.mjs";
+import {
+  maintenanceActiveAfterSend,
+  nextFromSend,
+} from "./panel_maintenance.mjs";
 
 test("a maintenance refusal raises the banner", () => {
   assert.equal(
@@ -41,4 +44,40 @@ test("a confirmed parked card clears the banner — even a partial one (ok:false
 test("an empty/undefined response clears rather than sticking a stale hold", () => {
   assert.equal(maintenanceActiveAfterSend(undefined), false);
   assert.equal(maintenanceActiveAfterSend(null), false);
+});
+
+test("nextFromSend raises on a maintenance refusal", () => {
+  assert.deepEqual(
+    nextFromSend({ active: false }, { ok: false, reason: "maintenance" }),
+    {
+      active: true,
+    }
+  );
+});
+
+test("nextFromSend clears on an accepted send / confirmed card", () => {
+  assert.deepEqual(nextFromSend({ active: true }, { ok: true }), {
+    active: false,
+  });
+  assert.deepEqual(nextFromSend({ active: true }, { confirmed: true }), {
+    active: false,
+  });
+});
+
+test("nextFromSend keeps the current state on an unrelated refusal (null)", () => {
+  assert.deepEqual(
+    nextFromSend(
+      { active: true },
+      { ok: false, reason: "release_update_required" }
+    ),
+    {
+      active: true,
+    }
+  );
+  assert.deepEqual(
+    nextFromSend({ active: false }, { ok: false, reason: "usage_limit" }),
+    {
+      active: false,
+    }
+  );
 });


### PR DESCRIPTION
Wave B of the maintenance-hold remediation (review finding #5). The Desk widget had no poll (an idle bubble never recovered after the operator cleared a hold) and the FAB + the chat panel each read a separate boot-time boolean, so they could disagree. Fix:
- NEW maintenance_state.mjs: a module-singleton reactive {active,message} both the FAB (Widget.vue) and the panel (Panel.vue) import, so they share one source and can't disagree. A 60s poll runs ONLY while held and self-arms at module load (the always-mounted FAB drives it, so a never-opened held bubble still self-heals), on Widget/Panel mount, and on every send that raises a hold. recheck() keeps last-known on any error/malformed shape and never reloads.
- panel_maintenance.mjs: pure nextFromSend reducer (delegates to maintenanceActiveAfterSend), node-tested, so the code that runs (foldSend) is the code under test.
- Panel.vue / Widget.vue: maintenanceActive/Message are now computed off the shared singleton; send() folds via foldSend; both arm the poll on mount.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
