### PR TITLE
test(patch): stop the v2_19 pin test leaking Jarvis Settings past the class rollback

### DIFF
--- a/jarvis/tests/test_patch_clear_retired_openai_subscription_pins.py
+++ b/jarvis/tests/test_patch_clear_retired_openai_subscription_pins.py
@@ -9,6 +9,7 @@ those ids.
 """
 
 import json
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -61,7 +62,13 @@ class _PinPatchBase(FrappeTestCase):
 		return frappe.db.get_value(POOL_ROW, name, "model")
 
 	def _pinned(self, model):
-		name = create_conversation()
+		# create_conversation commits. Inside a FrappeTestCase that commit would
+		# make this test's Jarvis Settings writes durable while the cleanup
+		# restore below stays uncommitted and is rolled back at class end, so
+		# every later test that saves Jarvis Settings on the legacy path would
+		# hit "API-key auth mode requires llm_api_key".
+		with patch.object(frappe.db, "commit"):
+			name = create_conversation()
 		frappe.db.set_value(CONV, name, "model_override", model)
 		return name
 
@@ -111,8 +118,6 @@ class TestClearRetiredPinsOnSubscriptionSite(_PinPatchBase):
 
 class TestRetiredPinsSurviveOnApiKeySite(_PinPatchBase):
 	def test_api_key_site_is_untouched(self):
-		from unittest.mock import patch
-
 		from jarvis.patches import v2_19_clear_retired_openai_subscription_pins as p
 
 		self._site("api_key", "openai", model="gpt-5.4")


### PR DESCRIPTION
## Summary

Test-only. The v2_19 retired-pin patch tests leaked Jarvis Settings past their class rollback, and on the version-15 and version-16 hotfix lines that broke 36 unrelated tests later in the same CI shard (#1196, #1197). Develop passes only because its shard order masks the leak.

The tests call the chat API's create-conversation function, which commits. That commit made the test's api-key-mode plus gpt-5.4 settings writes durable while the cleanup restore stayed uncommitted, so it was rolled back at class end. Every later test that saved Jarvis Settings on the legacy path then failed with "API-key auth mode requires llm_api_key". The helper now suppresses that commit so the class rollback cleans up.

The same commit is cherry-picked into #1196 and #1197 by hand, so no backport labels here.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01Vwziri1iqkgohdteb28qNU
