### PR TITLE
feat(maintenance): hard-block the composer during an upgrade hold (SP…

### DIFF
--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -236,6 +236,7 @@
 			@input="onInputInternal"
 			@keydown="onKeydownInternal"
 			@paste="onPasteInternal"
+			:disabled="disabled"
 			rows="1"
 			:placeholder="placeholder"
 			style="
@@ -250,7 +251,10 @@
 				background: transparent;
 				padding: 8px 8px 4px;
 			"
-			:style="{ maxHeight: maxHeight + 'px' }"
+			:style="{
+				maxHeight: maxHeight + 'px',
+				...(disabled ? { opacity: 0.55, cursor: 'not-allowed' } : {}),
+			}"
 		></textarea>
 		<input
 			ref="fileInputEl"
@@ -389,6 +393,9 @@ const props = defineProps({
 	attachments: { type: Array, default: () => [] },
 	// A turn is in flight: swaps Send for Stop and the hint for "Stop".
 	busy: { type: Boolean, default: false },
+	// Hard block (Stream E maintenance hold): greys the box + kills Send/Enter so the user
+	// cannot type or submit while a hold is active (the banner above says why). Default false.
+	disabled: { type: Boolean, default: false },
 	// Optional override for whether Send is armed. `null` (the default) derives
 	// it from text/attachments; chat passes its own (it also blocks on
 	// `sending` and a suspended subscription).
@@ -432,11 +439,12 @@ const text = computed({
 	set: (v) => emit("update:modelValue", v),
 });
 
-const sendable = computed(() =>
-	props.canSend === null
+const sendable = computed(() => {
+	if (props.disabled) return false;
+	return props.canSend === null
 		? props.modelValue.trim().length > 0 || props.attachments.length > 0
-		: props.canSend
-);
+		: props.canSend;
+});
 
 // ---- auto-grow ----
 function autoGrow() {

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -413,9 +413,10 @@ describe("ChatView banner chain order", () => {
 
 /**
  * Upgrade maintenance hold (Stream E). Same source-read technique as the suites
- * above (mounting ChatView is not viable). Pins the four load-bearing wiring
- * facts: the hold banner outranks the release nudge, the composer stays enabled,
- * and the send-gate branch mirrors the server's policy order without a reload.
+ * above (mounting ChatView is not viable). Pins the load-bearing wiring facts:
+ * the hold banner outranks the release nudge, the hold HARD-blocks the composer
+ * (canSend gated on holdActive + :disabled on the Composer), and the send-gate
+ * branch mirrors the server's policy order without a reload.
  */
 describe("maintenance hold banner + send gate", () => {
 	const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -438,11 +439,21 @@ describe("maintenance hold banner + send gate", () => {
 		expect(chatSrc.slice(start, end)).toContain("holdActive.value");
 	});
 
-	it("never gates canSend on holdActive (composer stays enabled - soft refusal only)", () => {
+	it("HARD-blocks: gates canSend on holdActive (Send dead during a hold)", () => {
+		// Reverses the earlier soft-block (composer-stays-enabled + soft refusal). The operator
+		// asked for a hard block, so Send is disabled during a hold (belt-and-suspenders with the
+		// :disabled binding below, which also blocks Enter / voice / programmatic sends).
 		const start = chatSrc.indexOf("const canSend = computed(");
 		expect(start, "ChatView must still define canSend").not.toBe(-1);
 		const end = chatSrc.indexOf("\n);", start);
-		expect(chatSrc.slice(start, end)).not.toContain("holdActive");
+		expect(chatSrc.slice(start, end)).toContain("!holdActive.value");
+	});
+
+	it("HARD-blocks: passes :disabled=holdActive to the Composer (greys the box + blocks typing)", () => {
+		const c = chatSrc.indexOf("<Composer");
+		expect(c, "ChatView must render the Composer").not.toBe(-1);
+		const end = chatSrc.indexOf(">", c);
+		expect(chatSrc.slice(c, end)).toContain(':disabled="holdActive"');
 	});
 
 	it("orders the send-gate maintenance branch between release-update and workspace-resetting", () => {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2742,6 +2742,7 @@
 						v-model="input"
 						:attachments="composerAttachments"
 						:busy="busy"
+						:disabled="holdActive"
 						:canSend="canSend"
 						:sendTitle="voiceSendBlockReason"
 						:placeholder="composerPlaceholder"
@@ -3330,6 +3331,7 @@
 							<button
 								class="jv-iconbtn"
 								title="Attach file"
+								:disabled="holdActive"
 								@click="pickFiles"
 								style="
 									width: 30px;
@@ -3412,6 +3414,7 @@
 										? 'Wiki grounding armed. Your next message will be answered from the wiki (click to turn off)'
 										: 'Ground your next message on the org wiki'
 								"
+								:disabled="holdActive"
 								@click="groundNextTurn = !groundNextTurn"
 								:aria-pressed="String(groundNextTurn)"
 								:style="{
@@ -3634,6 +3637,7 @@
 											? 'Stop dictation'
 											: 'Dictate (voice to text)'
 									"
+									:disabled="holdActive && micState !== 'recording'"
 									@click="micState === 'recording' ? stopMic() : startMic()"
 									style="
 										width: 30px;
@@ -6456,6 +6460,10 @@ const canSend = computed(
 		!compacting.value &&
 		// Suspended: the server rejects every send, so keep the button dead.
 		!suspendedNotice.value &&
+		// Maintenance hold (Stream E HARD block): the server refuses every send during an
+		// upgrade, so disable Send too (the composer is also greyed via :disabled below). This
+		// reverses the earlier soft-block (composer-stays-enabled); see readiness.spec.js.
+		!holdActive.value &&
 		// No model configured: nothing on the other end can answer, so prevent the
 		// send rather than reporting the failure after the fact.
 		!noAiConnected.value &&
@@ -9217,6 +9225,10 @@ function resendFailed(m) {
 let _prefillSendContext = null;
 async function send(textArg, resendAck) {
 	dismissFeedback(); // sending the next turn clears any pending feedback line
+	// Maintenance HARD block: once a hold is known, no send runs — this guards the paths that call
+	// send() directly (AskCard/answer/resend/prefill), not just the disabled composer. On the FIRST
+	// mid-session send holdActive is still false, so the detection branch below is preserved.
+	if (holdActive.value) return;
 	// Don't race a dictation that hasn't landed: sending now would drop the spoken words (the
 	// transcript would arrive AFTER the message left the composer). Block on the real busy
 	// signal — recording, or a recording still being transcribed — NOT hasUnfinished(), which
@@ -9452,9 +9464,9 @@ async function send(textArg, resendAck) {
 			}
 			// Maintenance hold (Stream E): the operator/roll raised an upgrade hold
 			// while this tab was open, so boot never carried it. Show the friendly
-			// "back shortly" banner + self-heal by re-checking the CP; the composer
-			// stays enabled, so the next send lands the moment the roll clears. No
-			// reload (unlike release_update_required) - an upgrade hold is transient.
+			// "back shortly" banner + self-heal by re-checking the CP; this HARD-blocks
+			// the composer (disabled until the hold lifts, then re-enabled reactively).
+			// No reload (unlike release_update_required) - an upgrade hold is transient.
 			if (r.reason === "maintenance") {
 				raiseHold(r.message);
 				recheckMaintenance();

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -614,7 +614,7 @@
 						class="jvp-cib"
 						type="button"
 						aria-label="Attach a file"
-						:disabled="uploading"
+						:disabled="uploading || maintenanceActive"
 						@click="pickFile"
 					>
 						<svg
@@ -638,6 +638,8 @@
 							contextText ? `Ask about ${contextText}…` : 'Ask Jarvis anything…'
 						"
 						v-model="draft"
+						:disabled="maintenanceActive"
+						:style="maintenanceActive ? 'opacity:0.55;cursor:not-allowed' : null"
 						@focus="composerFocused = true"
 						@blur="composerFocused = false"
 						@input="onComposerInput"
@@ -650,7 +652,7 @@
 						:class="{ 'jvp-cib--rec': recording }"
 						type="button"
 						:aria-label="recording ? 'Stop recording' : 'Dictate a message'"
-						:disabled="transcribing"
+						:disabled="transcribing || maintenanceActive"
 						@click="toggleVoice"
 					>
 						<svg
@@ -692,7 +694,7 @@
 						class="jvp-send"
 						type="button"
 						aria-label="Send message"
-						:disabled="!canSend"
+						:disabled="!canSend || maintenanceActive"
 						@click="send"
 					>
 						<svg
@@ -1583,6 +1585,9 @@ async function send() {
 	// never onboarded. Unresolved counts too: sending into a verdict that has not
 	// landed is exactly how a message got swallowed by the arriving gate.
 	if (readiness.value === null || readiness.value === "gate") return;
+	// Maintenance HARD block: guard the direct send() callers (retryLast etc.); the composer is
+	// disabled too. First mid-session send has maintenanceActive false, so detection is preserved.
+	if (maintenanceActive.value) return;
 	const text = draft.value.trim();
 	const atts = attachments.value.slice();
 	if ((!text && !atts.length) || sending.value || stream.value.live) return;

--- a/pwa/src/components/Composer.vue
+++ b/pwa/src/components/Composer.vue
@@ -9,6 +9,8 @@ const props = defineProps({
 	sending: { type: Boolean, default: false },
 	attachments: { type: Array, default: () => [] },
 	micEnabled: { type: Boolean, default: false },
+	// Hard block (Stream E maintenance hold): greys the box + kills typing/Send during a hold.
+	disabled: { type: Boolean, default: false },
 	placeholder: { type: String, default: () => `Message ${agentName}…` },
 });
 const emit = defineEmits([
@@ -133,7 +135,7 @@ defineExpose({ reset });
 			<button
 				class="jv-icon-btn"
 				aria-label="Attach a file"
-				:disabled="props.sending"
+				:disabled="props.sending || props.disabled"
 				@click="fileEl.click()"
 			>
 				<svg
@@ -158,6 +160,8 @@ defineExpose({ reset });
 					rows="1"
 					:value="props.modelValue"
 					:placeholder="props.placeholder"
+					:disabled="props.disabled"
+					:style="props.disabled ? 'opacity:0.55;cursor:not-allowed' : null"
 					@input="onInput"
 					@keydown="onKeydown"
 				/>
@@ -165,6 +169,7 @@ defineExpose({ reset });
 					v-if="props.micEnabled"
 					class="jv-mic"
 					aria-label="Dictate"
+					:disabled="props.disabled"
 					@click="emit('mic')"
 				>
 					<svg
@@ -197,7 +202,7 @@ defineExpose({ reset });
 				v-else
 				class="jv-send"
 				aria-label="Send"
-				:disabled="!canSend"
+				:disabled="!canSend || props.disabled"
 				@click="emit('send')"
 			>
 				<svg

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -291,7 +291,9 @@ async function loadPending() {
 async function send() {
 	const text = input.value.trim();
 	const ready = attachments.value.filter((a) => a.file_url);
-	if ((!text && !ready.length) || sending.value) return;
+	// Hard block (Stream E maintenance hold): the server refuses every send during a hold and the
+	// composer is disabled; guard here too so a queued/programmatic send can't slip through.
+	if ((!text && !ready.length) || sending.value || holdActive.value) return;
 
 	errorBanner.value = "";
 	input.value = "";
@@ -356,12 +358,12 @@ async function send() {
 			}
 			// Maintenance hold (Stream E): the operator/roll raised an upgrade hold
 			// while this tab was open. Raise the persistent top-of-app strip + self-
-			// heal by re-checking the CP; no reload (a hold is transient), composer
-			// stays enabled, so the next send lands the moment the roll clears.
+			// heal by re-checking the CP; no reload (a hold is transient). This HARD-
+			// blocks the composer (disabled until the hold lifts, then re-enabled).
 			if (res.reason === "maintenance") {
 				raiseHold(res.message);
 				recheckMaintenance();
-				input.value = text; // keep their typed text - the composer stays enabled, they can retry
+				input.value = text; // keep their draft so it's ready when the hold lifts
 				return;
 			}
 			errorBanner.value = res.reason || "Couldn't send that message.";
@@ -892,6 +894,7 @@ onUnmounted(() => {
 		:sending="sending"
 		:attachments="attachments"
 		:mic-enabled="micEnabled"
+		:disabled="holdActive"
 		@send="send"
 		@stop="stop"
 		@attach="attach"


### PR DESCRIPTION
…A + PWA + Desk)

Reverses the earlier soft-block (composer-stays-enabled + friendly refusal) per an operator decision: while a maintenance hold is active, disable ALL composer input — text, Send, file attach, and voice — on all three surfaces, keeping the "back shortly" banner above as the explanation, preserving any typed draft, and re-enabling reactively when the poll lifts the hold. The server already refuses sends during a hold; this is the client UX.

- SPA Composer.vue: new `disabled` prop greys + locks the textarea and forces sendable false. ChatView.vue: canSend gated on holdActive, :disabled=holdActive on the Composer, send() guarded, and the toolbar attach + wiki-ground + mic buttons disabled (mic keeps STOP available so a hold can't trap an in-progress recording). readiness.spec.js: the soft-block pin inverted.
- PWA Composer.vue: same `disabled` prop (textarea + Send + attach + mic). ChatView.vue: :disabled on the Composer + send() guard.
- Desk Panel.vue: textarea + Send + attach + mic disabled on maintenanceActive; send() guarded.

Independent review GREEN; SPA vitest 1851/1851; prettier + eslint clean.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
