### PR TITLE
feat(onboarding): auto-restore skills + LLM after a container rebuild

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -2626,6 +2626,14 @@ def request_resync(settings) -> str:
 
 	if compute_pool_mode(settings):
 		settings._enqueue_pool_sync()
+		# Skills are orthogonal to LLM routing: the direct leg fires these via
+		# ``action="restart"`` (``_sync_via_admin``), but the pool leg returns here
+		# WITHOUT them, so a pool/subscription tenant's Resync (and any rebuild that
+		# routes through this leg) re-pushed the LLM but left ``custom_skills/`` +
+		# ``learned_skills/`` EMPTY. Fire them on the pool leg too so skills restore for
+		# every cohort. Both are no-op on zero rows, deduped, and never raise.
+		settings._resync_custom_skills_after_restart()
+		settings._resync_learned_skills_after_restart()
 		return "pool"
 	# Stamp the request time too (jarvis C2 time-box): a direct-leg Resync is a
 	# fresh apply request, so it must restart the llm_applying soft window the

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -2069,26 +2069,41 @@ def _resync_after_rebuild(settings) -> None:
 	"""Re-push the BENCH-owned state the fresh container came up empty of, after a rebuild.
 	The control plane re-applies its own carried config, but two things live ONLY on the
 	bench and must be re-synced FROM HERE (never from admin — the LLM-key invariant): the
-	LLM credential and the custom/learned skills.
+	custom/learned skills and the LLM credential.
 
-	- **LLM — only when a real credential exists:** ``request_resync`` re-drives the current
-	  config (direct-leg restart OR pool) and, as of the pool-leg fix, fires both skill
-	  resyncs on either leg. Gated on ``_has_llm_config`` so a revoked / never-configured
-	  tenant is not pushed an empty/broken config (it returns False there).
-	- **Skills — always:** when there is no LLM to drive, still restore skills directly; they
-	  are unrelated to the LLM and the CP holds no copy.
+	- **Skills — always, first, unconditionally.** Skills are orthogonal to the LLM leg and
+	  the CP holds no copy, so restore them regardless of whether an LLM is configured.
+	  Doing it here (not via ``request_resync``) is load-bearing: the LLM leg only re-pushes
+	  skills as a side effect on a SYNCHRONOUS ``applied`` (its direct-leg ``action="restart"``)
+	  or via the pool leg — and it also writes ``last_sync_status`` off the resetting marker,
+	  which makes the Ready branch (branch A, the other skills back-fill) unreachable. A DIRECT
+	  tenant whose apply converges async — the normal case — would otherwise get its LLM back
+	  but its skills lost. Both helpers are no-op on zero rows, deduped by job_id, never raise.
+	- **LLM — only when a real credential exists.** ``request_resync`` re-drives the current
+	  config (direct-leg restart OR pool). Gated on ``_has_llm_config`` so a revoked /
+	  never-configured tenant is not pushed an empty/broken config (it returns False there).
+	  On the pool leg ``request_resync`` also fires the two skill resyncs again; those coalesce
+	  with the unconditional pushes above via job-id dedup (same commit, ``enqueue_after_commit``).
 
-	Idempotent + safe by construction: every push dedups by job_id and none of
-	``request_resync`` / the two skill helpers raises. A repeat call for the same converging
-	container is a deduped no-op."""
+	Never raises: this runs inside the (otherwise unguarded) reset poll and the ``*/5``
+	reconcile, so a failure (e.g. redis unavailable) is logged and swallowed. That leaves
+	``last_sync_status`` at the resetting marker so a later tick retries, with the manual
+	"Resync" button as the backstop."""
 	from jarvis.account import _has_llm_config
-	from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import request_resync
 
-	if _has_llm_config(settings):
-		request_resync(settings)
-	else:
+	try:
 		settings._resync_custom_skills_after_restart()
 		settings._resync_learned_skills_after_restart()
+		has_llm = _has_llm_config(settings)
+		frappe.logger("jarvis").info(
+			f"reprovision auto-resync: skills re-pushed; llm={'yes' if has_llm else 'no'}"
+		)
+		if has_llm:
+			from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import request_resync
+
+			request_resync(settings)
+	except Exception:
+		frappe.log_error(title="Jarvis: reprovision auto-resync failed", message=frappe.get_traceback())
 
 
 def _workspace_reset_poll() -> dict:
@@ -2145,8 +2160,17 @@ def _workspace_reset_poll() -> dict:
 		# holds no copy). Without this a rebuilt DIRECT tenant stayed key-less and a
 		# subscription pool stayed "blocked" forever, and skills were lost for all. Hands
 		# convergence to the standard pending-applying machinery (runs once — agent_url is
-		# set after this; all pushes dedup).
+		# set after this; all pushes dedup). Never reached for a revoke-LLM reset:
+		# _reconnect_llm() forces ready=True the moment the container is reachable, so
+		# branch A (skills-only, correct for that cohort) always wins this elif.
 		write_connection(data)
+		# Commit the reconnected transport BEFORE the resync. request_resync's status write
+		# can hit a snapshot write-conflict inside the */5 background reconcile and take its
+		# rollback+retry branch; without this commit that rollback would also discard the
+		# (still-uncommitted) agent_url and strand the tenant transport-less while clearing
+		# the reset marker. Committing here scopes any later rollback to the resync's own
+		# writes. (reprovision review I-2.)
+		frappe.db.commit()
 		_resync_after_rebuild(settings)
 		frappe.db.commit()
 	return {
@@ -2163,7 +2187,12 @@ def reconcile_pending_workspace_reset() -> None:
 	s = frappe.get_single("Jarvis Settings")
 	if not (s.get("last_sync_status") or "").startswith(_RESETTING_STATUS):
 		return
-	_workspace_reset_poll()
+	try:
+		_workspace_reset_poll()
+	except Exception:
+		# A scheduled task must not die on one bad tick; the resetting marker persists so
+		# the next run retries. (reprovision review I-3.)
+		frappe.log_error(title="Jarvis: workspace-reset reconcile failed", message=frappe.get_traceback())
 
 
 @frappe.whitelist()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -2065,6 +2065,32 @@ def workspace_reset_state() -> dict:
 	return _workspace_reset_poll()
 
 
+def _resync_after_rebuild(settings) -> None:
+	"""Re-push the BENCH-owned state the fresh container came up empty of, after a rebuild.
+	The control plane re-applies its own carried config, but two things live ONLY on the
+	bench and must be re-synced FROM HERE (never from admin — the LLM-key invariant): the
+	LLM credential and the custom/learned skills.
+
+	- **LLM — only when a real credential exists:** ``request_resync`` re-drives the current
+	  config (direct-leg restart OR pool) and, as of the pool-leg fix, fires both skill
+	  resyncs on either leg. Gated on ``_has_llm_config`` so a revoked / never-configured
+	  tenant is not pushed an empty/broken config (it returns False there).
+	- **Skills — always:** when there is no LLM to drive, still restore skills directly; they
+	  are unrelated to the LLM and the CP holds no copy.
+
+	Idempotent + safe by construction: every push dedups by job_id and none of
+	``request_resync`` / the two skill helpers raises. A repeat call for the same converging
+	container is a deduped no-op."""
+	from jarvis.account import _has_llm_config
+	from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import request_resync
+
+	if _has_llm_config(settings):
+		request_resync(settings)
+	else:
+		settings._resync_custom_skills_after_restart()
+		settings._resync_learned_skills_after_restart()
+
+
 def _workspace_reset_poll() -> dict:
 	settings = frappe.get_single("Jarvis Settings")
 	req: dict = {}
@@ -2100,17 +2126,28 @@ def _workspace_reset_poll() -> dict:
 		# container holds no direct-leg credential yet. Keep the jarvis#841
 		# dedup stamp cleared so the next save always applies for real.
 		settings.db_set("llm_last_apply_fingerprint", "")
+		# Skills live only on the bench (the CP holds no copy) and the rebuilt container's
+		# skill dirs are empty; re-push them here WITHOUT touching last_sync_status (they use
+		# their own status fields), so the reset's terminal "ok" stands. The LLM is NOT driven
+		# from this terminal branch: a normal tenant only reaches Ready once its credential is
+		# applied (the reachable-not-ready branch drove it while converging), and a
+		# revoke-reconnect reset intentionally has none (the customer reconnects).
+		settings._resync_custom_skills_after_restart()
+		settings._resync_learned_skills_after_restart()
 		_bust_chat_gate()
 		frappe.db.commit()
 	elif _resetting() and data.get("agent_url") and not (settings.get("agent_url") or ""):
-		# New container reachable but not Ready yet: reconnect the transport and,
-		# for a pool tenant, re-push the stored spec + subscription blobs — OAuth
-		# creds never ride a rebuild, so without this a subscription pool stays
-		# "blocked" forever. Hands convergence to the standard pending-applying
-		# machinery (marker replaced; runs once — agent_url is set after this).
+		# New container reachable but not Ready yet: reconnect the transport, then re-push
+		# the bench-owned state the fresh container is missing. Previously this re-pushed
+		# ONLY a pool tenant's spec/subscription blobs; it now covers every cohort via
+		# _resync_after_rebuild — the LLM credential (direct api-key + pool + OAuth; the CP
+		# never carries the key, it is bench-sourced) AND the custom/learned skills (the CP
+		# holds no copy). Without this a rebuilt DIRECT tenant stayed key-less and a
+		# subscription pool stayed "blocked" forever, and skills were lost for all. Hands
+		# convergence to the standard pending-applying machinery (runs once — agent_url is
+		# set after this; all pushes dedup).
 		write_connection(data)
-		if settings.get("proxy_active"):
-			settings._enqueue_pool_sync()
+		_resync_after_rebuild(settings)
 		frappe.db.commit()
 	return {
 		"ready": ready,

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -748,6 +748,7 @@ class TestWorkspaceReset(FrappeTestCase):
 		s.db_set("agent_url", "")
 		s.db_set("proxy_active", 1)
 		frappe.db.commit()
+		JS = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.JarvisSettings"
 		try:
 			with (
 				patch(
@@ -762,9 +763,16 @@ class TestWorkspaceReset(FrappeTestCase):
 						"agent_token": "t2",
 					},
 				),
-				patch(
-					"jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.JarvisSettings._enqueue_pool_sync"
-				) as push,
+				# Branch B now routes the pool push through request_resync, whose pool-vs-direct
+				# split gates on compute_pool_mode (models[] rows), NOT the raw proxy_active flag
+				# this test sets. Pin it True so the pool leg is exercised deterministically
+				# rather than depending on ambient singleton fixture state (reprovision review I-1).
+				patch("jarvis.jarvis.pool_serialize.compute_pool_mode", return_value=True),
+				patch(f"{JS}._enqueue_pool_sync") as push,
+				# Skills now fire unconditionally in _resync_after_rebuild; isolate them so this
+				# test asserts only the pool-leg routing.
+				patch(f"{JS}._resync_custom_skills_after_restart"),
+				patch(f"{JS}._resync_learned_skills_after_restart"),
 			):
 				out = onboarding.workspace_reset_state()
 			push.assert_called_once()
@@ -830,16 +838,62 @@ class TestWorkspaceReset(FrappeTestCase):
 		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, "ok (workspace reset)")
 
 	def test_resync_after_rebuild_with_llm_calls_request_resync(self):
-		# A tenant that still has an LLM credential re-drives the full config via request_resync
-		# (which, with the pool-leg fix, restores LLM + skills on either leg).
+		# A tenant that still has an LLM credential re-drives the full config via request_resync,
+		# AND skills fire unconditionally (not only via the LLM leg) - a direct tenant whose apply
+		# converges async would otherwise lose skills (reprovision review: approach/correctness).
 		s = frappe.get_single("Jarvis Settings")
 		jsmod = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+		js = jsmod + ".JarvisSettings"
 		with (
 			patch("jarvis.account._has_llm_config", return_value=True),
 			patch(f"{jsmod}.request_resync") as rr,
+			patch(f"{js}._resync_custom_skills_after_restart") as cs,
+			patch(f"{js}._resync_learned_skills_after_restart") as ls,
 		):
 			onboarding._resync_after_rebuild(s)
 		rr.assert_called_once()
+		cs.assert_called_once()
+		ls.assert_called_once()
+
+	def test_resync_after_rebuild_swallows_request_resync_error(self):
+		# Must never raise into the (unguarded) reset poll / */5 reconcile: a raise from
+		# request_resync (e.g. redis down) is logged and swallowed (reprovision review I-3).
+		s = frappe.get_single("Jarvis Settings")
+		jsmod = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+		js = jsmod + ".JarvisSettings"
+		with (
+			patch("jarvis.account._has_llm_config", return_value=True),
+			patch(f"{jsmod}.request_resync", side_effect=RuntimeError("redis down")),
+			patch(f"{js}._resync_custom_skills_after_restart"),
+			patch(f"{js}._resync_learned_skills_after_restart"),
+			patch("frappe.log_error") as log_error,
+		):
+			onboarding._resync_after_rebuild(s)  # must not raise
+		log_error.assert_called()
+
+	def test_reset_poll_no_resync_when_not_resetting(self):
+		# Criterion #7: the auto-resync lives ONLY in the reset poll's _resetting() branches.
+		# A normal (non-reset) poll - last_sync_status is not the resetting marker - must NOT
+		# re-push anything, even when the container reports Ready.
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "ok (converged via admin reconcile)")
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		with (
+			patch("jarvis.onboarding.admin_client.reset_workspace_state", return_value={}),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+				},
+			),
+			patch("jarvis.onboarding._resync_after_rebuild") as resync,
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.workspace_reset_state()
+		resync.assert_not_called()
 
 	def test_resync_after_rebuild_without_llm_calls_skills_only(self):
 		# A revoked / never-configured tenant (no credential) must NOT be pushed an empty LLM

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -774,6 +774,109 @@ class TestWorkspaceReset(FrappeTestCase):
 			frappe.get_single("Jarvis Settings").db_set("proxy_active", 0)
 			frappe.db.commit()
 
+	# --- reprovision auto-resync (skills + bench-sourced LLM restore after a rebuild) ---
+
+	def test_reset_poll_reachable_triggers_resync_after_rebuild(self):
+		# Branch B (container reachable, not Ready yet): the fresh container must get the
+		# bench-owned state re-pushed via _resync_after_rebuild (LLM if a credential exists,
+		# + skills) - superseding the old pool-only re-push.
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		with (
+			patch("jarvis.onboarding.admin_client.reset_workspace_state", return_value={"status": "Applied"}),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Configuring",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+				},
+			),
+			patch("jarvis.onboarding._resync_after_rebuild") as resync,
+		):
+			out = onboarding.workspace_reset_state()
+		resync.assert_called_once()
+		self.assertFalse(out["ready"])
+		self.assertEqual(frappe.get_single("Jarvis Settings").agent_url, "ws://localhost:19100")
+
+	def test_reset_poll_ready_resyncs_skills_and_keeps_ok(self):
+		# Branch A (Ready terminal): the skills re-push fires, and last_sync_status stays the
+		# reset's terminal "ok" (skills helpers write their OWN status fields, not last_sync).
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		s.db_set("agent_url", "")
+		frappe.db.commit()
+		JS = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.JarvisSettings"
+		with (
+			patch("jarvis.onboarding.admin_client.reset_workspace_state", return_value={"status": "Applied"}),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+				},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+			patch(f"{JS}._resync_custom_skills_after_restart") as cs,
+			patch(f"{JS}._resync_learned_skills_after_restart") as ls,
+		):
+			out = onboarding.workspace_reset_state()
+		self.assertTrue(out["ready"])
+		cs.assert_called_once()
+		ls.assert_called_once()
+		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, "ok (workspace reset)")
+
+	def test_resync_after_rebuild_with_llm_calls_request_resync(self):
+		# A tenant that still has an LLM credential re-drives the full config via request_resync
+		# (which, with the pool-leg fix, restores LLM + skills on either leg).
+		s = frappe.get_single("Jarvis Settings")
+		jsmod = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+		with (
+			patch("jarvis.account._has_llm_config", return_value=True),
+			patch(f"{jsmod}.request_resync") as rr,
+		):
+			onboarding._resync_after_rebuild(s)
+		rr.assert_called_once()
+
+	def test_resync_after_rebuild_without_llm_calls_skills_only(self):
+		# A revoked / never-configured tenant (no credential) must NOT be pushed an empty LLM
+		# config; skills still restore.
+		s = frappe.get_single("Jarvis Settings")
+		jsmod = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+		js = jsmod + ".JarvisSettings"
+		with (
+			patch("jarvis.account._has_llm_config", return_value=False),
+			patch(f"{jsmod}.request_resync") as rr,
+			patch(f"{js}._resync_custom_skills_after_restart") as cs,
+			patch(f"{js}._resync_learned_skills_after_restart") as ls,
+		):
+			onboarding._resync_after_rebuild(s)
+		rr.assert_not_called()
+		cs.assert_called_once()
+		ls.assert_called_once()
+
+	def test_request_resync_pool_leg_now_fires_skills(self):
+		# D2: request_resync's pool leg re-pushes the pool LLM AND both skill resyncs (before,
+		# only the direct leg restored skills - pool tenants got their LLM back but no skills).
+		from jarvis.jarvis.doctype.jarvis_settings import jarvis_settings as js_mod
+
+		s = frappe.get_single("Jarvis Settings")
+		js = "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.JarvisSettings"
+		with (
+			patch("jarvis.jarvis.pool_serialize.compute_pool_mode", return_value=True),
+			patch(f"{js}._enqueue_pool_sync") as pool,
+			patch(f"{js}._resync_custom_skills_after_restart") as cs,
+			patch(f"{js}._resync_learned_skills_after_restart") as ls,
+		):
+			leg = js_mod.request_resync(s)
+		self.assertEqual(leg, "pool")
+		pool.assert_called_once()
+		cs.assert_called_once()
+		ls.assert_called_once()
+
 	def test_reset_wipe_data_deletes_content(self):
 		frappe.db.delete("Jarvis Macro", {"macro_name": "wipe-me"})
 		frappe.db.commit()


### PR DESCRIPTION
When a tenant's container is rebuilt (self-serve "Reset Workspace"), the fresh container comes up empty of the state that lives only on the bench: custom/learned skills and -- per the invariant that the LLM key is BENCH-sourced, never from admin -- the LLM credential. The reset poll previously re-pushed only a POOL tenant's LLM, leaving skills empty for everyone and a DIRECT tenant's key unset, so a rebuilt tenant needed a manual "Resync" (and for pool tenants even that did not restore skills -- see the pool-leg fix below).

jarvis app only; no control-plane change (there is no admin->bench channel; the bench is the source of truth and re-pushes).

- `onboarding._resync_after_rebuild(settings)`: re-push the bench-owned state after a rebuild -- the LLM via `request_resync` ONLY when a real credential exists (`_has_llm_config`, so a revoked / never-configured tenant is not pushed an empty/broken config), else skills-only. Idempotent (every push dedups by job_id) and never raises.
- Wired into both `_workspace_reset_poll` branches: the reachable-but-not-ready branch does the full LLM+skills re-push (superseding the old pool-only `_enqueue_pool_sync`); the Ready terminal branch does skills-only so its terminal "ok (workspace reset)" status stands (the skill helpers write their own status fields, not last_sync_status).
- `request_resync`'s POOL leg now also fires the two skill resyncs (previously only the DIRECT leg did, via `action="restart"`). This closes a live gap: pool/subscription tenants had NO working skills-restore path -- manual OR auto.

Scope: skills always; LLM bench-sourced. The operator host-move/evacuate rebuild path + a fast chat-gate detector are deliberately DEFERRED (rarer, operator-driven, manual-Resync backstop) -- to be folded into that flow when it is built. Design + /plan-check (2 opus critics) recorded in the local plan doc.

Tests (test_onboarding_sync.py::TestWorkspaceReset): `_resync_after_rebuild`'s LLM-vs-skills-only split; both reset-poll branch wirings (branch A keeps "ok"); the pool-leg skills fire.


## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
