### PR TITLE
test(feedback): add the in-flight dismissal spec for the pulse gate

### DIFF
--- a/frontend/src/lib/pulseFeedbackGate.spec.js
+++ b/frontend/src/lib/pulseFeedbackGate.spec.js
@@ -79,4 +79,25 @@ describe("pulseFeedbackGate", () => {
 		// after "Maybe later" must not re-offer (and re-burn the monthly cap).
 		expect(apiModule.pulseContext).toHaveBeenCalledTimes(1);
 	});
+
+	// Two chat opens in quick succession both pass the "dismissed?" gate before
+	// either pulseContext() call returns. If the survey the first one opened is
+	// dismissed while the second request is still in flight, the second must
+	// not reopen it on top of the dismissal: the gate has to be re-checked
+	// AFTER the await, not only before it.
+	it("does not reopen when the survey was dismissed while a check was still in flight", async () => {
+		vi.resetModules();
+		const fresh = await import("./pulseFeedbackGate");
+		let resolveInFlight;
+		apiModule.pulseContext.mockImplementation(
+			() => new Promise((resolve) => (resolveInFlight = resolve))
+		);
+
+		const inFlight = fresh.maybeOpenPulseFeedback(); // passes the gate, awaits
+		fresh.closePulseFeedback(); // user dismisses meanwhile
+		resolveInFlight({ due: true, features_offered: [] });
+		await inFlight;
+
+		expect(fresh.pulseFeedbackOpen.value).toBe(false);
+	});
 });


### PR DESCRIPTION
Adds the one regression spec from the #1210 review round that was left out of commit 137b963b: the pulse survey must not reopen when it was dismissed while a second check was still in flight.

## What changed
- One new case in `frontend/src/lib/pulseFeedbackGate.spec.js`; no runtime code.

## Risk and verification
- Test only. Fails 1/6 against the pre-fix gate, passes 6/6 on develop (fix already merged in #1210).

https://claude.ai/code/session_0121RjwTjC4SaFQMn1vHTbvB