### PR TITLE
feat(feedback): thumbs bar, session popup and pulse survey (backport #1088, #1210, #1213)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -17,6 +17,15 @@ export const getCanvas = (message, name, dark) =>
 export const previewFile = (fileUrl) =>
 	call("jarvis.chat.api.preview_file", { file_url: fileUrl });
 export const createOrFocusEmpty = () => call("jarvis.chat.api.create_or_focus_empty");
+// Post-reply feedback: a thumbs up/down (+ optional note on a down) on one
+// assistant reply. Best-effort - the bench derives the metadata server-side and
+// forwards it to the admin fleet dashboard; the tap never blocks on that.
+export const submitFeedback = (message, rating, note) =>
+	call("jarvis.chat.feedback.submit_feedback", {
+		message_id: message,
+		rating,
+		note: note || "",
+	});
 export const archiveConversation = (conversation) =>
 	call("jarvis.chat.api.archive_conversation", { conversation });
 // Danger zone: permanently delete ALL of the user's conversations + messages.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -26,6 +26,35 @@ export const submitFeedback = (message, rating, note) =>
 		rating,
 		note: note || "",
 	});
+// Once-per-session popup ("How did this session go?"): status poll (is it due
+// for this conversation right now?) and the answer/Skip submission. Mirrors
+// submitFeedback's best-effort contract - see SessionFeedbackDialog.vue.
+export const sessionFeedbackStatus = (conversation) =>
+	call("jarvis.chat.feedback.session_feedback_status", { conversation });
+export const submitSessionFeedback = (conversation, chip_value, note) =>
+	call("jarvis.chat.feedback.submit_session_feedback", {
+		conversation,
+		chip_value: chip_value || undefined,
+		note: note || "",
+	});
+// Periodic "business pulse" survey: a due-check run on chat open (also CLAIMS
+// the offer server-side, see feedback.pulse_context) and the answer submission.
+// Mirrors submitFeedback's best-effort contract - see PulseFeedbackDialog.vue.
+export const pulseContext = () => call("jarvis.chat.feedback.pulse_context", {});
+export const submitPulseFeedback = (
+	stars,
+	features_offered,
+	features_selected,
+	use_case_text,
+	note
+) =>
+	call("jarvis.chat.feedback.submit_pulse_feedback", {
+		stars,
+		features_offered: JSON.stringify(features_offered || []),
+		features_selected: JSON.stringify(features_selected || []),
+		use_case_text: use_case_text || "",
+		note: note || "",
+	});
 export const archiveConversation = (conversation) =>
 	call("jarvis.chat.api.archive_conversation", { conversation });
 // Danger zone: permanently delete ALL of the user's conversations + messages.
@@ -245,12 +274,18 @@ export async function sendMessage(
 	modelOverride,
 	attachments,
 	context,
-	approvalTokens
+	approvalTokens,
+	voice
 ) {
 	// Empty conversation is allowed: the backend creates (or focuses) an empty
 	// conversation itself and returns its id as `conversation_id` - saves the
 	// SPA a createOrFocusEmpty round-trip before the first send (latency plan).
 	const args = { conversation: conversation || "", message };
+	// Dictated-and-sent flag (via_voice on the persisted Jarvis Chat Message):
+	// true only when ChatView's send() found a non-empty voice-ack token for
+	// this payload. Omitted (not even `voice: 0`) for every ordinary typed
+	// send, matching every existing caller that doesn't pass this arg.
+	if (voice) args.voice = 1;
 	if (modelOverride) args.model_override = modelOverride;
 	if (attachments && attachments.length) args.attachments = JSON.stringify(attachments);
 	// The ordered tokens of the confirmation cards on screen. A typed "confirm 2"

--- a/frontend/src/components/chat/FeedbackBar.vue
+++ b/frontend/src/components/chat/FeedbackBar.vue
@@ -1,0 +1,261 @@
+<!--
+  Post-reply feedback line for the main chat. A quiet soft prompt bar under a
+  long reply: "Was this reply helpful?" + Yes/No. Yes is one tap; No opens an
+  optional "what went wrong" box. The rating commits the moment it is tapped
+  (the parent submits immediately), so an abandoned note box still records the
+  down. When/whether it appears is decided by the parent via lib/feedbackGate.
+-->
+<template>
+	<div class="jvfb-slot" :class="{ gone: state === 'gone' }">
+		<div v-if="state === 'idle'" class="jvfb-bar">
+			<span class="jvfb-q">Was this reply helpful?</span>
+			<span class="jvfb-acts">
+				<button class="jvfb-btn up" type="button" @click="rateUp" aria-label="Helpful">
+					<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path
+							d="M9 21h8.2a2 2 0 0 0 1.96-1.6l1.4-7A2 2 0 0 0 18.6 10H14V5a2.5 2.5 0 0 0-2.5-2.5L8 11v10zM2 11h4v10H2z"
+						/>
+					</svg>
+					Yes
+				</button>
+				<button
+					class="jvfb-btn down"
+					type="button"
+					@click="openComment"
+					aria-label="Not helpful"
+				>
+					<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path
+							d="M15 3H6.8a2 2 0 0 0-1.96 1.6l-1.4 7A2 2 0 0 0 5.4 14H10v5a2.5 2.5 0 0 0 2.5 2.5L16 13V3zM22 3h-4v10h4z"
+						/>
+					</svg>
+					No
+				</button>
+			</span>
+		</div>
+
+		<div v-else-if="state === 'comment'" class="jvfb-cmt">
+			<span class="jvfb-lead">What went wrong? <span class="opt">(optional)</span></span>
+			<textarea
+				ref="ta"
+				v-model="note"
+				class="jvfb-ta"
+				maxlength="1000"
+				rows="2"
+				placeholder="Tell Jarvis what to fix…"
+				@keydown.enter.exact.prevent="send"
+			></textarea>
+			<div class="jvfb-row">
+				<button class="jvfb-send" type="button" @click="send">Send</button>
+				<button class="jvfb-skip" type="button" @click="skip">Skip</button>
+			</div>
+		</div>
+
+		<div v-else-if="state === 'done'" class="jvfb-done">
+			<svg
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2.4"
+				aria-hidden="true"
+			>
+				<path d="M20 6 9 17l-5-5" />
+			</svg>
+			Thanks for the feedback
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { nextTick, ref } from "vue";
+
+const emit = defineEmits(["rate", "close"]);
+
+const state = ref("idle");
+const note = ref("");
+
+function toDone() {
+	state.value = "done";
+	setTimeout(() => {
+		state.value = "gone";
+		emit("close");
+	}, 1600);
+}
+
+function rateUp() {
+	emit("rate", { rating: "up", note: "" });
+	toDone();
+}
+
+function openComment() {
+	// Commit the down immediately; the note (if any) folds in on Send.
+	emit("rate", { rating: "down", note: "" });
+	state.value = "comment";
+	nextTick(() => {
+		const el = document.activeElement;
+		// focus the textarea without stealing it back if the user already moved on
+		if (el && el.tagName !== "TEXTAREA") {
+			const ta = document.querySelector(".jvfb-ta");
+			if (ta) ta.focus();
+		}
+	});
+}
+
+function send() {
+	const text = (note.value || "").trim();
+	if (text) emit("rate", { rating: "down", note: text });
+	toDone();
+}
+
+function skip() {
+	toDone();
+}
+</script>
+
+<style scoped>
+.jvfb-slot {
+	margin-top: 12px;
+	transition: opacity 0.35s ease;
+}
+.jvfb-slot.gone {
+	opacity: 0;
+}
+
+/* soft prompt bar */
+.jvfb-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 14px;
+	max-width: 440px;
+	padding: 9px 11px 9px 14px;
+	background: var(--surface-1);
+	border: 1px solid var(--border);
+	border-radius: 11px;
+}
+.jvfb-q {
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--text-2);
+}
+.jvfb-acts {
+	display: inline-flex;
+	gap: 8px;
+	flex: 0 0 auto;
+}
+.jvfb-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12.5px;
+	font-weight: 600;
+	cursor: pointer;
+	color: var(--text-2);
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 8px;
+	padding: 5px 11px;
+	transition: color 0.15s, border-color 0.15s;
+}
+.jvfb-btn svg {
+	width: 14px;
+	height: 14px;
+}
+.jvfb-btn:hover {
+	color: var(--text);
+	border-color: var(--text-3);
+}
+.jvfb-btn.up:hover {
+	color: var(--green);
+	border-color: var(--green);
+}
+.jvfb-btn.down:hover {
+	color: var(--red);
+	border-color: var(--red);
+}
+.jvfb-btn:focus-visible {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
+}
+
+/* comment box */
+.jvfb-cmt {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-width: 440px;
+}
+.jvfb-lead {
+	font-size: 11.5px;
+	font-weight: 500;
+	color: var(--text-3);
+}
+.jvfb-lead .opt {
+	opacity: 0.7;
+}
+.jvfb-ta {
+	width: 100%;
+	resize: vertical;
+	min-height: 54px;
+	font-family: inherit;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--text);
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 9px;
+	padding: 8px 10px;
+	outline: none;
+}
+.jvfb-ta:focus {
+	border-color: var(--cta);
+}
+.jvfb-ta::placeholder {
+	color: var(--text-3);
+}
+.jvfb-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+.jvfb-send {
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--cta-fg);
+	background: var(--cta);
+	border: 0;
+	border-radius: 8px;
+	padding: 6px 14px;
+	cursor: pointer;
+}
+.jvfb-skip {
+	font-size: 12px;
+	color: var(--text-3);
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+}
+.jvfb-skip:hover {
+	color: var(--text-2);
+}
+
+/* confirmation */
+.jvfb-done {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--green);
+}
+.jvfb-done svg {
+	width: 14px;
+	height: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.jvfb-slot {
+		transition: none;
+	}
+}
+</style>

--- a/frontend/src/components/chat/PulseFeedbackDialog.spec.js
+++ b/frontend/src/components/chat/PulseFeedbackDialog.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("frappe-ui", () => ({
+	Dialog: {
+		props: ["modelValue", "options"],
+		emits: ["update:modelValue"],
+		// Exposes a `close` button standing in for Dialog's own Escape / outside
+		// -click / X-button close paths, none of which are driven by the
+		// consumer's "Maybe later" button - they all funnel through Dialog's
+		// internal close(), which only ever emits update:modelValue (see real
+		// Dialog.vue). A plain v-model here would bypass closePulseFeedback().
+		template:
+			"<div><slot name='body-content'/><slot name='actions'/><button data-test='dialog-escape' @click=\"$emit('update:modelValue', false)\">escape</button></div>",
+	},
+	Button: {
+		props: ["label", "variant", "disabled"],
+		emits: ["click"],
+		template: "<button :disabled='disabled' @click=\"$emit('click')\">{{ label }}</button>",
+	},
+	FormControl: {
+		props: ["modelValue", "type", "rows"],
+		emits: ["update:modelValue"],
+		template:
+			"<textarea :value='modelValue' @input=\"$emit('update:modelValue', $event.target.value)\"/>",
+	},
+}));
+
+vi.mock("@/branding", () => ({ agentName: "Jarvis" }));
+
+vi.mock("@/api", () => ({
+	submitPulseFeedback: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// Real gate behavior, but with closePulseFeedback spied so a test can tell
+// "went through the one dismiss path" apart from "the ref just happened to
+// end up false" -- both look identical if you only check pulseFeedbackOpen.
+vi.mock("@/lib/pulseFeedbackGate", async (importOriginal) => {
+	const actual = await importOriginal();
+	return { ...actual, closePulseFeedback: vi.fn(actual.closePulseFeedback) };
+});
+
+import * as api from "@/api";
+import PulseFeedbackDialog from "./PulseFeedbackDialog.vue";
+import {
+	pulseFeedbackOpen,
+	pulseFeedbackContext,
+	closePulseFeedback,
+} from "@/lib/pulseFeedbackGate";
+
+describe("PulseFeedbackDialog", () => {
+	beforeEach(() => {
+		pulseFeedbackOpen.value = false;
+		pulseFeedbackContext.value = null;
+		vi.clearAllMocks();
+	});
+
+	it("hides the chip question entirely when features_offered is empty", () => {
+		pulseFeedbackContext.value = {
+			period_label: "This month, Sep 2026",
+			features_offered: [],
+		};
+		pulseFeedbackOpen.value = true;
+		const w = mount(PulseFeedbackDialog);
+		expect(w.text()).not.toContain("Which do you use most?");
+	});
+
+	it("renders chips with voice_chat mapped to Notes and dictation, not Voice chat", () => {
+		pulseFeedbackContext.value = {
+			period_label: "This month, Sep 2026",
+			features_offered: ["file_box", "voice_chat", "skills"],
+		};
+		pulseFeedbackOpen.value = true;
+		const w = mount(PulseFeedbackDialog);
+		expect(w.text()).toContain("Which do you use most?");
+		expect(w.text()).toContain("Notes and dictation");
+		expect(w.text()).not.toContain("Voice chat");
+		expect(w.text()).toContain("File box");
+		expect(w.text()).toContain("Skills");
+	});
+
+	it("Send is disabled until a star is picked, then submits with offered+selected", async () => {
+		pulseFeedbackContext.value = {
+			period_label: "This month",
+			features_offered: ["file_box"],
+		};
+		pulseFeedbackOpen.value = true;
+		const w = mount(PulseFeedbackDialog);
+		const sendBtn = () => w.findAll("button").find((b) => b.text() === "Send feedback");
+		expect(sendBtn().attributes("disabled")).toBeDefined();
+
+		const stars = w.findAll("button").filter((b) => b.text() === "★");
+		await stars[2].trigger("click"); // 3rd star = 3 stars
+		expect(sendBtn().attributes("disabled")).toBeUndefined();
+
+		await w
+			.findAll("button")
+			.find((b) => b.text() === "File box")
+			.trigger("click");
+		await sendBtn().trigger("click");
+		expect(api.submitPulseFeedback).toHaveBeenCalledWith(
+			3,
+			["file_box"],
+			["file_box"],
+			"",
+			""
+		);
+	});
+
+	it("Maybe later closes without submitting", async () => {
+		pulseFeedbackContext.value = { period_label: "This month", features_offered: [] };
+		pulseFeedbackOpen.value = true;
+		const w = mount(PulseFeedbackDialog);
+		await w
+			.findAll("button")
+			.find((b) => b.text() === "Maybe later")
+			.trigger("click");
+		expect(api.submitPulseFeedback).not.toHaveBeenCalled();
+		expect(pulseFeedbackOpen.value).toBe(false);
+	});
+
+	it("Escape/outside-click/X (Dialog's own close, not the Maybe later button) still counts as a dismissal", async () => {
+		// Dialog drives these three itself and only ever emits
+		// update:modelValue(false) - never a click on "Maybe later". Before this
+		// fix, a plain v-model wrote pulseFeedbackOpen.value = false directly on
+		// that emit, skipping closePulseFeedback() entirely, so the "one offer
+		// per page load" rule silently didn't apply to these three closes.
+		pulseFeedbackContext.value = { period_label: "This month", features_offered: [] };
+		pulseFeedbackOpen.value = true;
+		const w = mount(PulseFeedbackDialog);
+		await w.find("[data-test='dialog-escape']").trigger("click");
+		expect(pulseFeedbackOpen.value).toBe(false);
+		expect(closePulseFeedback).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/components/chat/PulseFeedbackDialog.vue
+++ b/frontend/src/components/chat/PulseFeedbackDialog.vue
@@ -1,0 +1,158 @@
+<!-- Periodic "business pulse" survey popup. Opened via the shared
+     pulseFeedbackOpen ref (see @/lib/pulseFeedbackGate), same pattern as
+     SessionFeedbackDialog + noticeGate's whatsNewOpen. The server is the real
+     gate (pulse_last_period_key / pulse_offer_count on Jarvis User Settings,
+     claimed by pulse_context()); this component only renders + submits. -->
+<template>
+	<Dialog
+		:model-value="open"
+		@update:model-value="onDialogModelUpdate"
+		:options="{ title: `How is ${agentName} doing for your business?`, size: 'md' }"
+	>
+		<template #body-content>
+			<span
+				class="mb-3 inline-block rounded-full bg-surface-gray-2 px-2 py-0.5 text-xs font-semibold text-ink-gray-7"
+			>
+				{{ ctx?.period_label || "This month" }}
+			</span>
+			<div class="mb-4">
+				<label class="mb-1.5 block text-sm font-medium"
+					>Overall, how satisfied are you this month?</label
+				>
+				<div class="flex gap-1 text-2xl">
+					<button
+						v-for="n in 5"
+						:key="n"
+						type="button"
+						class="leading-none"
+						:class="n <= stars ? 'text-ink-amber-3' : 'text-ink-gray-3'"
+						@click="stars = n"
+					>
+						★
+					</button>
+				</div>
+			</div>
+			<div v-if="features.length" class="mb-4">
+				<label class="mb-1.5 block text-sm font-medium">
+					Which do you use most?
+					<span class="font-normal text-ink-gray-5"
+						>only what you've used this month</span
+					>
+				</label>
+				<div class="flex flex-wrap gap-1.5">
+					<button
+						v-for="f in features"
+						:key="f"
+						type="button"
+						class="rounded-full border px-2.5 py-1 text-xs"
+						:class="
+							selectedFeatures.includes(f)
+								? 'border-outline-gray-4 bg-surface-gray-2 font-medium'
+								: 'border-outline-gray-2 text-ink-gray-6'
+						"
+						@click="toggleFeature(f)"
+					>
+						{{ FEATURE_LABELS[f] || f }}
+					</button>
+				</div>
+			</div>
+			<div class="mb-4">
+				<label class="mb-1.5 block text-sm font-medium">
+					Is {{ agentName }} solving your business use case? If so, what?
+				</label>
+				<FormControl v-model="useCaseText" type="textarea" :rows="3" />
+			</div>
+			<div>
+				<label class="mb-1.5 block text-sm font-medium">
+					Anything else? <span class="font-normal text-ink-gray-5">optional</span>
+				</label>
+				<FormControl v-model="note" type="textarea" :rows="2" />
+			</div>
+		</template>
+		<template #actions>
+			<div class="flex justify-between">
+				<Button label="Maybe later" variant="subtle" @click="close" />
+				<Button label="Send feedback" variant="solid" :disabled="!stars" @click="submit" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from "vue";
+import { Dialog, Button, FormControl } from "frappe-ui";
+import * as api from "@/api";
+import { agentName } from "@/branding";
+import {
+	pulseFeedbackOpen,
+	pulseFeedbackContext,
+	closePulseFeedback,
+} from "@/lib/pulseFeedbackGate";
+
+// Mirrors jarvis.chat.feature_usage.FEATURES server-side (the allowlist
+// pulse_context/_feature_keys filters through) - keep the two in step.
+// voice_chat is deliberately NOT labeled "Voice chat": the capture path never
+// sets a kind=Voice marker, so real recordings land as kind=Text same as typed
+// notes, and this key actually covers notes and dictation broadly.
+const FEATURE_LABELS = {
+	file_box: "File box",
+	dashboard_builder: "Dashboard builder",
+	skills: "Skills",
+	macros: "Macros",
+	triggers_connectors: "Triggers & Connectors",
+	voice_chat: "Notes and dictation",
+	wiki: "Wiki",
+};
+
+const open = pulseFeedbackOpen;
+const ctx = pulseFeedbackContext;
+const features = computed(() => ctx.value?.features_offered || []);
+
+const stars = ref(0);
+const selectedFeatures = ref([]);
+const useCaseText = ref("");
+const note = ref("");
+
+watch(open, (isOpen) => {
+	if (isOpen) {
+		stars.value = 0;
+		selectedFeatures.value = [];
+		useCaseText.value = "";
+		note.value = "";
+	}
+});
+
+function toggleFeature(f) {
+	const i = selectedFeatures.value.indexOf(f);
+	if (i === -1) selectedFeatures.value.push(f);
+	else selectedFeatures.value.splice(i, 1);
+}
+
+function close() {
+	closePulseFeedback();
+}
+
+// A plain `v-model="open"` would let Dialog write `pulseFeedbackOpen.value =
+// false` directly on Escape, the X button, or an outside click -- all close
+// paths Dialog drives itself, bypassing closePulseFeedback() and its
+// "dismissed this page load" bookkeeping (see pulseFeedbackGate.js). Routing
+// every close through here, same as the "Maybe later" button already does,
+// makes ALL dismissals count, not just the explicit one.
+function onDialogModelUpdate(value) {
+	if (!value) closePulseFeedback();
+}
+
+async function submit() {
+	if (!stars.value) return;
+	const offered = features.value;
+	const selected = selectedFeatures.value;
+	const text = useCaseText.value;
+	const n = note.value;
+	closePulseFeedback();
+	try {
+		await api.submitPulseFeedback(stars.value, offered, selected, text, n);
+	} catch (e) {
+		/* best-effort */
+	}
+}
+</script>

--- a/frontend/src/components/chat/SessionFeedbackDialog.spec.js
+++ b/frontend/src/components/chat/SessionFeedbackDialog.spec.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("frappe-ui", () => ({
+	Dialog: {
+		props: ["modelValue", "options"],
+		emits: ["close"],
+		template: "<div><slot name='body-content'/><slot name='actions'/></div>",
+	},
+	Button: {
+		props: ["label", "variant", "disabled"],
+		emits: ["click"],
+		template: "<button :disabled='disabled' @click=\"$emit('click')\">{{ label }}</button>",
+	},
+	FormControl: {
+		props: ["modelValue", "placeholder", "type"],
+		emits: ["update:modelValue"],
+		template:
+			"<input :value='modelValue' @input=\"$emit('update:modelValue', $event.target.value)\"/>",
+	},
+}));
+
+vi.mock("@/api", () => ({
+	submitSessionFeedback: vi.fn().mockResolvedValue({ ok: true, recorded: true }),
+}));
+
+import * as api from "@/api";
+import { Dialog } from "frappe-ui";
+import SessionFeedbackDialog from "./SessionFeedbackDialog.vue";
+import {
+	sessionFeedbackOpen,
+	sessionFeedbackConversation,
+	openSessionFeedback,
+} from "@/lib/sessionFeedbackGate";
+
+describe("SessionFeedbackDialog", () => {
+	beforeEach(() => {
+		sessionFeedbackOpen.value = false;
+		sessionFeedbackConversation.value = null;
+		vi.clearAllMocks();
+	});
+
+	it("shows all 5 chips and no note field until a low chip is selected", async () => {
+		openSessionFeedback("conv-1");
+		const w = mount(SessionFeedbackDialog);
+		const buttons = w.findAll("button");
+		// 5 chips + Skip + Send = 7 buttons
+		const chipButtons = buttons.filter((b) =>
+			["Great", "Good", "Okay", "Not great", "Frustrating"].some((v) => b.text().includes(v))
+		);
+		expect(chipButtons).toHaveLength(5);
+		expect(w.find("input").exists()).toBe(false);
+	});
+
+	it("shows the note field only for Okay/Not great/Frustrating, not Great/Good", async () => {
+		openSessionFeedback("conv-1");
+		const w = mount(SessionFeedbackDialog);
+		const chip = (label) => w.findAll("button").find((b) => b.text().includes(label));
+
+		await chip("Great, got what I needed").trigger("click");
+		expect(w.find("input").exists()).toBe(false);
+
+		await chip("Good, mostly helpful").trigger("click");
+		expect(w.find("input").exists()).toBe(false);
+
+		await chip("Okay, so-so").trigger("click");
+		expect(w.find("input").exists()).toBe(true);
+
+		await chip("Not great, missed the mark").trigger("click");
+		expect(w.find("input").exists()).toBe(true);
+
+		await chip("Frustrating, wasted my time").trigger("click");
+		expect(w.find("input").exists()).toBe(true);
+	});
+
+	it("disables Send until a chip is selected, then submits with chip_value + note", async () => {
+		openSessionFeedback("conv-1");
+		const w = mount(SessionFeedbackDialog);
+		const sendBtn = () => w.findAll("button").find((b) => b.text() === "Send");
+		expect(sendBtn().attributes("disabled")).toBeDefined();
+
+		await w
+			.findAll("button")
+			.find((b) => b.text().includes("Okay, so-so"))
+			.trigger("click");
+		expect(sendBtn().attributes("disabled")).toBeUndefined();
+
+		await w.find("input").setValue("it hallucinated a total");
+		await sendBtn().trigger("click");
+		expect(api.submitSessionFeedback).toHaveBeenCalledWith(
+			"conv-1",
+			"Okay",
+			"it hallucinated a total"
+		);
+	});
+
+	it("Skip submits with chip_value omitted (null) and closes", async () => {
+		openSessionFeedback("conv-1");
+		const w = mount(SessionFeedbackDialog);
+		await w
+			.findAll("button")
+			.find((b) => b.text() === "Skip")
+			.trigger("click");
+		expect(api.submitSessionFeedback).toHaveBeenCalledWith("conv-1", null, "");
+		expect(sessionFeedbackOpen.value).toBe(false);
+	});
+
+	it("an Escape/X/outside-click dismissal (Dialog's close event) claims the offer exactly like Skip", async () => {
+		// Regression: frappe-ui's Dialog fires `close` on Escape, its ghost X
+		// button, and an outside click — all bypass this component's own Skip/
+		// Send handlers. Without @close wired to skip(), session_feedback_asked_at
+		// never gets stamped, so the next reply re-polls as still due and the
+		// popup reopens on top of it (and burns feedbackGate's IGNORE_CAP).
+		openSessionFeedback("conv-1");
+		const w = mount(SessionFeedbackDialog);
+		await w.findComponent(Dialog).vm.$emit("close");
+		expect(api.submitSessionFeedback).toHaveBeenCalledWith("conv-1", null, "");
+		expect(sessionFeedbackOpen.value).toBe(false);
+	});
+});

--- a/frontend/src/components/chat/SessionFeedbackDialog.vue
+++ b/frontend/src/components/chat/SessionFeedbackDialog.vue
@@ -1,0 +1,109 @@
+<!-- Once-per-session "How did this session go?" popup. Opened via the shared
+     sessionFeedbackOpen ref (see @/lib/sessionFeedbackGate), same pattern as
+     WhatsNewDialog + noticeGate's whatsNewOpen. The server is the real gate
+     (session_feedback_asked_at); this component only renders + submits. -->
+<template>
+	<Dialog
+		v-model="open"
+		:options="{ title: 'How did this session go?', size: 'sm' }"
+		@close="skip"
+	>
+		<template #body-content>
+			<p class="mb-3 text-sm text-ink-gray-6">
+				Takes 2 seconds. Helps us improve {{ agentName }}.
+			</p>
+			<div class="flex flex-col gap-1.5">
+				<button
+					v-for="c in CHIPS"
+					:key="c.value"
+					type="button"
+					class="flex items-center gap-2 rounded-md border px-2.5 py-2 text-left text-sm"
+					:class="
+						selected === c.value
+							? 'border-outline-gray-4 bg-surface-gray-2 font-medium'
+							: 'border-outline-gray-2'
+					"
+					@click="selected = c.value"
+				>
+					<span>{{ c.emoji }}</span>
+					<span>{{ c.label }}</span>
+				</button>
+			</div>
+			<div v-if="showNote" class="mt-3">
+				<label class="mb-1 block text-xs font-medium text-ink-gray-6">
+					What went wrong? (optional)
+				</label>
+				<FormControl v-model="note" type="text" placeholder="What happened" />
+			</div>
+		</template>
+		<template #actions>
+			<div class="flex justify-end gap-2">
+				<Button label="Skip" variant="subtle" @click="skip" />
+				<Button label="Send" variant="solid" :disabled="!selected" @click="submit" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from "vue";
+import { Dialog, Button, FormControl } from "frappe-ui";
+import * as api from "@/api";
+import { agentName } from "@/branding";
+import {
+	sessionFeedbackOpen,
+	sessionFeedbackConversation,
+	closeSessionFeedback,
+} from "@/lib/sessionFeedbackGate";
+
+const CHIPS = [
+	{ value: "Great", emoji: "🎉", label: "Great, got what I needed" },
+	{ value: "Good", emoji: "🙂", label: "Good, mostly helpful" },
+	{ value: "Okay", emoji: "😐", label: "Okay, so-so" },
+	{ value: "Not great", emoji: "😕", label: "Not great, missed the mark" },
+	{ value: "Frustrating", emoji: "😞", label: "Frustrating, wasted my time" },
+];
+const LOW_CHIPS = new Set(["Okay", "Not great", "Frustrating"]);
+
+const open = sessionFeedbackOpen;
+const selected = ref(null);
+const note = ref("");
+const showNote = computed(() => LOW_CHIPS.has(selected.value));
+
+watch(open, (isOpen) => {
+	if (isOpen) {
+		selected.value = null;
+		note.value = "";
+	}
+});
+
+async function submit() {
+	if (!selected.value) return;
+	const conversation = sessionFeedbackConversation.value;
+	closeSessionFeedback();
+	try {
+		await api.submitSessionFeedback(conversation, selected.value, note.value);
+	} catch (e) {
+		/* best-effort, matches the existing thumbs feedback contract */
+	}
+}
+
+// Also wired to the Dialog's `@close` (Escape / the ghost X button / an
+// outside click) so ANY dismissal claims the offer, not just this explicit
+// button — otherwise session_feedback_asked_at never gets stamped, the next
+// reply re-polls as still due, and the popup reopens on top of it, silently
+// burning through feedbackGate's IGNORE_CAP on repeat Escapes. Safe to call
+// more than once: closeSessionFeedback()/submitSessionFeedback are idempotent
+// no-ops on an already-closed dialog, and the explicit Skip click here never
+// re-triggers Dialog's `close` emit (that only fires from Dialog's OWN
+// internal state changes, not from this ref being set externally).
+async function skip() {
+	const conversation = sessionFeedbackConversation.value;
+	closeSessionFeedback();
+	try {
+		await api.submitSessionFeedback(conversation, null, "");
+	} catch (e) {
+		/* best-effort */
+	}
+}
+</script>

--- a/frontend/src/lib/feedbackGate.js
+++ b/frontend/src/lib/feedbackGate.js
@@ -1,0 +1,101 @@
+// Client-side throttle for the post-reply feedback line. It decides whether the
+// "Was this reply helpful?" bar appears after a reply, and keeps the ask RARE so
+// it never nags. All state lives in localStorage, keyed per day, so no server
+// round-trip is needed to decide - and a reload / new day resets the caps.
+//
+// The rules (see the design plan): a reply must be genuinely long (> 1 min),
+// then only ~1 in 3 of those show it, with a cooldown between asks, a hard cap
+// per session, and it stops entirely once the user rates or ignores it twice.
+
+const KEY = "jvChatFeedback.v1";
+
+// The one-minute floor is the single knob to dial if it still feels too frequent
+// (raise to 90s / 120s). Shared with the mini widget.
+export const FEEDBACK_MIN_MS = 60000;
+
+const SHOW_PROB = 1 / 3; // among qualifying replies
+const COOLDOWN_REPLIES = 5; // replies between asks
+const SESSION_CAP = 2; // hard cap per day
+const IGNORE_CAP = 2; // stop after this many shown-and-ignored
+
+function today() {
+	return new Date().toISOString().slice(0, 10);
+}
+
+function fresh() {
+	return {
+		day: today(),
+		n: 0,
+		lastShown: null,
+		shown: 0,
+		rated: false,
+		ignores: 0,
+		stopped: false,
+	};
+}
+
+function load() {
+	try {
+		const raw = JSON.parse(localStorage.getItem(KEY) || "null");
+		if (!raw || raw.day !== today()) return fresh();
+		return {
+			day: raw.day,
+			n: raw.n | 0,
+			lastShown: raw.lastShown == null ? null : raw.lastShown | 0,
+			shown: raw.shown | 0,
+			rated: !!raw.rated,
+			ignores: raw.ignores | 0,
+			stopped: !!raw.stopped,
+		};
+	} catch {
+		return fresh();
+	}
+}
+
+function save(s) {
+	try {
+		localStorage.setItem(KEY, JSON.stringify(s));
+	} catch {
+		// private mode / storage disabled - degrade to "never show", never throw.
+	}
+}
+
+// Call once per completed reply. Advances the per-day reply counter and returns
+// true iff this reply should show the feedback bar. Mutates + persists state, so
+// the caller MUST guard against evaluating the same reply twice.
+export function shouldOfferFeedback(durationMs) {
+	const s = load();
+	s.n += 1;
+	let show = false;
+	const cooldownOk = s.lastShown === null || s.n - s.lastShown >= COOLDOWN_REPLIES;
+	if (
+		!s.stopped &&
+		!s.rated &&
+		s.shown < SESSION_CAP &&
+		Number(durationMs) >= FEEDBACK_MIN_MS &&
+		cooldownOk &&
+		Math.random() < SHOW_PROB
+	) {
+		show = true;
+		s.shown += 1;
+		s.lastShown = s.n;
+	}
+	save(s);
+	return show;
+}
+
+// The user gave a rating (up or down): stop asking for the rest of the session.
+export function markRated() {
+	const s = load();
+	s.rated = true;
+	save(s);
+}
+
+// The bar was shown and dismissed without a rating (moved on / typed next query).
+// Back off entirely after IGNORE_CAP of these.
+export function markIgnored() {
+	const s = load();
+	s.ignores += 1;
+	if (s.ignores >= IGNORE_CAP) s.stopped = true;
+	save(s);
+}

--- a/frontend/src/lib/feedbackGate.spec.js
+++ b/frontend/src/lib/feedbackGate.spec.js
@@ -1,0 +1,69 @@
+// Behavioural tests for the post-reply feedback throttle. jsdom gives us a real
+// localStorage; Math.random is stubbed so the ~1-in-3 dice are deterministic.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FEEDBACK_MIN_MS, markIgnored, markRated, shouldOfferFeedback } from "./feedbackGate";
+
+const LONG = FEEDBACK_MIN_MS + 5000;
+
+function passDice() {
+	vi.spyOn(Math, "random").mockReturnValue(0.05); // < 1/3
+}
+function failDice() {
+	vi.spyOn(Math, "random").mockReturnValue(0.99); // >= 1/3
+}
+
+beforeEach(() => {
+	localStorage.clear();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("feedbackGate", () => {
+	it("never shows on a reply shorter than the threshold", () => {
+		passDice();
+		expect(shouldOfferFeedback(FEEDBACK_MIN_MS - 1)).toBe(false);
+	});
+
+	it("shows on the first long reply when the dice pass", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true);
+	});
+
+	it("stays hidden when the ~1-in-3 dice fail", () => {
+		failDice();
+		expect(shouldOfferFeedback(LONG)).toBe(false);
+	});
+
+	it("enforces a cooldown of several replies between asks", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true); // shown at reply #1
+		for (let i = 0; i < 4; i++) expect(shouldOfferFeedback(LONG)).toBe(false); // within cooldown
+		expect(shouldOfferFeedback(LONG)).toBe(true); // cooldown elapsed -> 2nd show
+	});
+
+	it("caps at 2 shows per session", () => {
+		passDice();
+		let shows = 0;
+		for (let i = 0; i < 40; i++) if (shouldOfferFeedback(LONG)) shows++;
+		expect(shows).toBe(2);
+	});
+
+	it("stops asking once the user rates", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true);
+		markRated();
+		for (let i = 0; i < 20; i++) expect(shouldOfferFeedback(LONG)).toBe(false);
+	});
+
+	it("backs off after two ignores", () => {
+		passDice();
+		expect(shouldOfferFeedback(LONG)).toBe(true); // show #1
+		markIgnored();
+		for (let i = 0; i < 4; i++) shouldOfferFeedback(LONG); // ride out the cooldown
+		expect(shouldOfferFeedback(LONG)).toBe(true); // show #2
+		markIgnored(); // second ignore -> stopped
+		for (let i = 0; i < 20; i++) expect(shouldOfferFeedback(LONG)).toBe(false);
+	});
+});

--- a/frontend/src/lib/pulseFeedbackGate.js
+++ b/frontend/src/lib/pulseFeedbackGate.js
@@ -1,0 +1,42 @@
+// Periodic business-pulse survey. Unlike sessionFeedbackGate, this one owns
+// its own trigger check (pulse_context is cheap and self-gating -- see spec
+// Performance review), so callers just invoke maybeOpenPulseFeedback() once
+// per chat open rather than passing a precomputed condition.
+import { ref } from "vue";
+import { pulseContext } from "@/api";
+
+export const pulseFeedbackOpen = ref(false);
+export const pulseFeedbackContext = ref(null); // {period_label, period_key, features_offered}
+
+// Client-side "at most one offer per page load" rule. The server enforces its
+// own 3-per-month cap (see pulse_context's docstring), but that cap is keyed
+// only to the calendar period, not to a single browsing session: without this
+// flag, dismissing the survey ("Maybe later") in one conversation and then
+// switching to another conversation re-triggers _checkPulseOnce, which calls
+// pulse_context() again, which is still due -- reopening the survey and
+// burning another one of the three monthly offers. A page reload resets this
+// (module state, not persisted), which is the intended boundary.
+let _dismissedThisLoad = false;
+
+export async function maybeOpenPulseFeedback() {
+	if (_dismissedThisLoad) return;
+	try {
+		const ctx = await pulseContext();
+		// Re-check after the await: two chat opens in quick succession both pass
+		// the gate above before either request returns. If the first one's
+		// survey was dismissed while the second request was still in flight, the
+		// second must not reopen it on top of the dismissal.
+		if (_dismissedThisLoad) return;
+		if (ctx && ctx.due) {
+			pulseFeedbackContext.value = ctx;
+			pulseFeedbackOpen.value = true;
+		}
+	} catch (e) {
+		/* offline or admin unreachable -- skip silently, try again next open */
+	}
+}
+
+export function closePulseFeedback() {
+	pulseFeedbackOpen.value = false;
+	_dismissedThisLoad = true;
+}

--- a/frontend/src/lib/pulseFeedbackGate.spec.js
+++ b/frontend/src/lib/pulseFeedbackGate.spec.js
@@ -1,0 +1,82 @@
+// vi.mock("@/api", () => ({...})) is this repo's established idiom for
+// mocking @/api in a module that imports it directly (see
+// SessionFeedbackDialog.spec.js) - vi.spyOn on the live module's named export
+// is not reliably interceptable through the Vite/vitest ESM boundary here.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/api", () => ({
+	pulseContext: vi.fn(),
+}));
+
+import * as apiModule from "@/api";
+import {
+	pulseFeedbackOpen,
+	pulseFeedbackContext,
+	maybeOpenPulseFeedback,
+	closePulseFeedback,
+} from "./pulseFeedbackGate";
+
+describe("pulseFeedbackGate", () => {
+	beforeEach(() => {
+		pulseFeedbackOpen.value = false;
+		pulseFeedbackContext.value = null;
+		vi.clearAllMocks();
+	});
+
+	it("opens and stores context when pulseContext() says due", async () => {
+		apiModule.pulseContext.mockResolvedValue({
+			due: true,
+			period_label: "This month, Sep 2026",
+			features_offered: ["file_box"],
+		});
+		await maybeOpenPulseFeedback();
+		expect(pulseFeedbackOpen.value).toBe(true);
+		expect(pulseFeedbackContext.value.features_offered).toEqual(["file_box"]);
+	});
+
+	it("stays closed when pulseContext() says not due", async () => {
+		apiModule.pulseContext.mockResolvedValue({ due: false });
+		await maybeOpenPulseFeedback();
+		expect(pulseFeedbackOpen.value).toBe(false);
+	});
+
+	it("stays closed and does not throw when pulseContext() rejects", async () => {
+		apiModule.pulseContext.mockRejectedValue(new Error("offline"));
+		await expect(maybeOpenPulseFeedback()).resolves.not.toThrow();
+		expect(pulseFeedbackOpen.value).toBe(false);
+	});
+
+	it("closePulseFeedback closes without clearing context", () => {
+		pulseFeedbackContext.value = { due: true, features_offered: [] };
+		pulseFeedbackOpen.value = true;
+		closePulseFeedback();
+		expect(pulseFeedbackOpen.value).toBe(false);
+		expect(pulseFeedbackContext.value).not.toBeNull();
+	});
+
+	// The "dismissed this page load" flag is module-private state with no
+	// reset hook (by design -- it is meant to last for the page's lifetime,
+	// only a real reload clears it), so a plain `it` block sharing the
+	// already-imported module would see whatever an earlier test in this file
+	// left behind (e.g. the "closePulseFeedback closes..." case above already
+	// dismisses it). vi.resetModules() + a fresh dynamic import gives this
+	// test its own module instance, the same isolation announcementGate.spec.js
+	// uses for its own module-private state.
+	it("does not call pulseContext() again after the survey was dismissed this page load", async () => {
+		vi.resetModules();
+		const fresh = await import("./pulseFeedbackGate");
+		apiModule.pulseContext.mockResolvedValue({ due: true, features_offered: [] });
+
+		await fresh.maybeOpenPulseFeedback();
+		expect(apiModule.pulseContext).toHaveBeenCalledTimes(1);
+		expect(fresh.pulseFeedbackOpen.value).toBe(true);
+
+		fresh.closePulseFeedback();
+		await fresh.maybeOpenPulseFeedback();
+
+		// Still exactly one call: the second maybeOpenPulseFeedback() returned
+		// early instead of hitting the backend again -- switching conversations
+		// after "Maybe later" must not re-offer (and re-burn the monthly cap).
+		expect(apiModule.pulseContext).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/lib/pulseFeedbackGate.spec.js
+++ b/frontend/src/lib/pulseFeedbackGate.spec.js
@@ -79,4 +79,25 @@ describe("pulseFeedbackGate", () => {
 		// after "Maybe later" must not re-offer (and re-burn the monthly cap).
 		expect(apiModule.pulseContext).toHaveBeenCalledTimes(1);
 	});
+
+	// Two chat opens in quick succession both pass the "dismissed?" gate before
+	// either pulseContext() call returns. If the survey the first one opened is
+	// dismissed while the second request is still in flight, the second must
+	// not reopen it on top of the dismissal: the gate has to be re-checked
+	// AFTER the await, not only before it.
+	it("does not reopen when the survey was dismissed while a check was still in flight", async () => {
+		vi.resetModules();
+		const fresh = await import("./pulseFeedbackGate");
+		let resolveInFlight;
+		apiModule.pulseContext.mockImplementation(
+			() => new Promise((resolve) => (resolveInFlight = resolve))
+		);
+
+		const inFlight = fresh.maybeOpenPulseFeedback(); // passes the gate, awaits
+		fresh.closePulseFeedback(); // user dismisses meanwhile
+		resolveInFlight({ due: true, features_offered: [] });
+		await inFlight;
+
+		expect(fresh.pulseFeedbackOpen.value).toBe(false);
+	});
 });

--- a/frontend/src/lib/sessionFeedbackGate.js
+++ b/frontend/src/lib/sessionFeedbackGate.js
@@ -1,0 +1,18 @@
+// Once-per-session feedback popup, opened the same way WhatsNewDialog is:
+// a shared ref set from wherever the trigger condition is detected
+// (ChatView.vue, after a reply crosses the turn threshold), watched by the
+// dialog component below. Server-side "already asked" (session_feedback_asked_at)
+// is the real guarantee; this ref only controls whether it's ON SCREEN right now.
+import { ref } from "vue";
+
+export const sessionFeedbackOpen = ref(false);
+export const sessionFeedbackConversation = ref(null);
+
+export function openSessionFeedback(conversation) {
+	sessionFeedbackConversation.value = conversation;
+	sessionFeedbackOpen.value = true;
+}
+
+export function closeSessionFeedback() {
+	sessionFeedbackOpen.value = false;
+}

--- a/frontend/src/lib/sessionFeedbackGate.spec.js
+++ b/frontend/src/lib/sessionFeedbackGate.spec.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	sessionFeedbackOpen,
+	sessionFeedbackConversation,
+	openSessionFeedback,
+	closeSessionFeedback,
+} from "./sessionFeedbackGate";
+
+describe("sessionFeedbackGate", () => {
+	beforeEach(() => {
+		sessionFeedbackOpen.value = false;
+		sessionFeedbackConversation.value = null;
+	});
+
+	it("openSessionFeedback sets the conversation and opens the dialog", () => {
+		openSessionFeedback("conv-123");
+		expect(sessionFeedbackOpen.value).toBe(true);
+		expect(sessionFeedbackConversation.value).toBe("conv-123");
+	});
+
+	it("closeSessionFeedback closes without clearing the conversation", () => {
+		openSessionFeedback("conv-123");
+		closeSessionFeedback();
+		expect(sessionFeedbackOpen.value).toBe(false);
+		expect(sessionFeedbackConversation.value).toBe("conv-123");
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1930,6 +1930,11 @@
 										</button>
 									</div>
 								</div>
+								<FeedbackBar
+									v-if="feedbackFor === m.name"
+									@rate="onFeedbackRate"
+									@close="onFeedbackClose"
+								/>
 							</template>
 						</Message>
 					</template>
@@ -4355,6 +4360,8 @@ import { myUsage, loadMyUsage, takeUsage } from "@/stores/usage";
 import CompactDialog from "@/components/chat/CompactDialog.vue";
 import { parseCompactCommand, compactFailureCopy } from "@/lib/compact";
 import * as api from "@/api";
+import FeedbackBar from "@/components/chat/FeedbackBar.vue";
+import { shouldOfferFeedback, markRated, markIgnored } from "@/lib/feedbackGate";
 import * as voice from "@/api/voice";
 import { agentName, isWhitelabeled } from "@/branding";
 import { useAudioRecorder } from "@/composables/useAudioRecorder";
@@ -4531,6 +4538,36 @@ const promptHistory = ref([]);
 const histIdx = ref(null);
 const histDraft = ref("");
 const sending = ref(false);
+
+// ---- post-reply feedback line (lib/feedbackGate decides IF/when it appears) ----
+const feedbackFor = ref(null); // message name currently showing the feedback bar
+const feedbackRated = ref(false); // did the user rate the current bar?
+const feedbackEvaluated = new Set(); // message names already run through the gate
+function maybeOfferFeedback(m) {
+	if (!m || m.role !== "assistant" || m.error || m.stopped) return;
+	if (feedbackEvaluated.has(m.name)) return;
+	feedbackEvaluated.add(m.name); // gate each reply exactly once
+	const secs = parseFloat(elapsedOf(m)) || 0;
+	if (shouldOfferFeedback(secs * 1000)) {
+		feedbackFor.value = m.name;
+		feedbackRated.value = false;
+	}
+}
+function onFeedbackRate({ rating, note }) {
+	feedbackRated.value = true;
+	markRated(); // any rating stops further asks this session
+	const target = feedbackFor.value;
+	if (target) api.submitFeedback(target, rating, note || "").catch(() => {}); // best-effort
+}
+function onFeedbackClose() {
+	feedbackFor.value = null;
+}
+function dismissFeedback() {
+	// Starting the next query clears a still-unanswered bar (counts as an ignore).
+	if (!feedbackFor.value) return;
+	if (!feedbackRated.value) markIgnored();
+	feedbackFor.value = null;
+}
 const waiting = ref(false);
 // Phase-0 admission (chat concurrency): when a send is accepted but QUEUED
 // (all in-flight slots taken), the reply hasn't started - we show a "~N ahead"
@@ -8984,6 +9021,7 @@ async function send(textArg, resendAck) {
 	// send() directly (AskCard/answer/resend/prefill), not just the disabled composer. On the FIRST
 	// mid-session send holdActive is still false, so the detection branch below is preserved.
 	if (holdActive.value) return;
+	dismissFeedback(); // sending the next turn clears any pending feedback line
 	// Don't race a dictation that hasn't landed: sending now would drop the spoken words (the
 	// transcript would arrive AFTER the message left the composer). Block on the real busy
 	// signal — recording, or a recording still being transcribed — NOT hasUnfinished(), which
@@ -9709,6 +9747,9 @@ function onEvent(p) {
 			compactedChip.value = false;
 			compacting.value = false;
 			loadContext();
+			// Post-reply feedback line: offer it (throttled) now the reply is
+			// finalized and its duration is stamped. Only here - never on history load.
+			if (m) maybeOfferFeedback(m);
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;
@@ -10933,6 +10974,7 @@ function openUserFile(a) {
 // ---- mentions (@ user, / doctype·tool) ----
 let _mentionSeq = 0;
 function onInput() {
+	dismissFeedback(); // starting the next query clears any pending feedback line
 	histIdx.value = null; // typing exits prompt-history navigation
 	const el = composerRef.value?.el;
 	if (!el) return;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4321,6 +4321,14 @@
 		     banner via the shared whatsNewOpen ref in noticeGate. -->
 		<WhatsNewDialog />
 
+		<!-- Once-per-session "how did this session go?" popup: opened by
+		     maybeCheckSessionFeedback below, following the same shared-ref
+		     pattern as WhatsNewDialog/noticeGate. -->
+		<SessionFeedbackDialog />
+		<!-- Periodic business-pulse survey: opened by maybeOpenPulseFeedback,
+		     checked once per genuine chat-open event. -->
+		<PulseFeedbackDialog />
+
 		<!-- Preview a file the user attached in the composer (before send). Images
 		     enlarge, PDFs/others render in-app; loads over the session cookie so a
 		     private File just works. Sent-message attachments use the artifact
@@ -4415,6 +4423,10 @@ import VersionPill from "@/components/chat/VersionPill.vue";
 import UpdateBanner from "@/components/chat/UpdateBanner.vue";
 import AnnouncementBanner from "@/components/chat/AnnouncementBanner.vue";
 import WhatsNewDialog from "@/components/chat/WhatsNewDialog.vue";
+import SessionFeedbackDialog from "@/components/chat/SessionFeedbackDialog.vue";
+import PulseFeedbackDialog from "@/components/chat/PulseFeedbackDialog.vue";
+import { openSessionFeedback } from "@/lib/sessionFeedbackGate";
+import { maybeOpenPulseFeedback } from "@/lib/pulseFeedbackGate";
 import { showBanner } from "@/noticeGate";
 import { showAnnouncement } from "@/announcementGate";
 
@@ -4551,6 +4563,43 @@ function maybeOfferFeedback(m) {
 	if (shouldOfferFeedback(secs * 1000)) {
 		feedbackFor.value = m.name;
 		feedbackRated.value = false;
+	}
+}
+// Session popup takes priority over the per-message thumbs bar on the SAME
+// reply: if it fires, FeedbackBar is suppressed for this reply (maybeOfferFeedback,
+// the only writer of feedbackFor, is simply never called for this m) and the
+// popup counts against feedbackGate's own per-day cap (markIgnored keeps the
+// bar's cooldown/cap bookkeeping consistent either way).
+async function maybeCheckSessionFeedback(m) {
+	if (!m || m.role !== "assistant" || m.error || m.stopped) return;
+	// Same one-shot guard maybeOfferFeedback uses, checked up front so a reply
+	// already evaluated (belt-and-braces alongside the CDX-3 run:end fence
+	// upstream, which already blocks a repeat equal-epoch terminal) never
+	// re-polls the server or double-counts.
+	if (feedbackEvaluated.has(m.name)) return;
+	const conv = currentId.value;
+	if (!conv) {
+		maybeOfferFeedback(m);
+		return;
+	}
+	let due = false;
+	try {
+		const status = await api.sessionFeedbackStatus(conv);
+		due = !!(status && status.due);
+	} catch (e) {
+		due = false; // offline / error: fall back to the thumbs bar behavior
+	}
+	// The user may have switched conversations while this read was in flight.
+	// Never surface a popup for a chat no longer on screen (matches "never on
+	// history load" — the reply just gets no prompt), and re-check the guard
+	// in case a second run:end for this same reply raced in during the await.
+	if (currentId.value !== conv || feedbackEvaluated.has(m.name)) return;
+	if (due) {
+		feedbackEvaluated.add(m.name); // gate this reply exactly once, like maybeOfferFeedback
+		markIgnored();
+		openSessionFeedback(conv);
+	} else {
+		maybeOfferFeedback(m);
 	}
 }
 function onFeedbackRate({ rating, note }) {
@@ -8445,6 +8494,20 @@ let _shownConvId = null;
 // ResizeObserver, cancelled by any deliberate scroll.
 let _restoreTop = null;
 let _restoreUntil = 0;
+// One-shot guard for the business-pulse check, separate from _shownConvId
+// (which loadConversation alone owns, for scroll-restore). THREE places can
+// make a conversation id newly "current": loadConversation's genuine-switch
+// branch, newChat(), and the send-from-home id-adoption in send() — a fresh
+// chat's first reply reloads via loadConversation on the SAME id newChat()
+// already checked, which _sameConv alone doesn't catch (loadConversation
+// never ran for that id before, so _sameConv reads false again). Keying on
+// the id itself instead makes the check idempotent across all three sites.
+let _pulseCheckedConvId = null;
+function _checkPulseOnce(id) {
+	if (!id || _pulseCheckedConvId === id) return;
+	_pulseCheckedConvId = id;
+	maybeOpenPulseFeedback();
+}
 
 async function loadConversation(id) {
 	// Preserve the reader's position across an in-place resync. Captured BEFORE
@@ -8594,6 +8657,14 @@ async function loadConversation(id) {
 	// after a turn settles (or after a card is applied/discarded) used to fling a
 	// reader who had scrolled up back to the bottom, which is exactly what makes a
 	// long reply unreadable. Restore where they were and let the arrow stand.
+	// Business-pulse survey check: fire once per GENUINE chat open, not on an
+	// in-place resync of the conversation already on screen (tab-focus onResync,
+	// a turn settling, a card apply/discard — all re-run loadConversation on the
+	// SAME id). `_sameConv` above already draws exactly this distinction for the
+	// scroll-position logic; `_checkPulseOnce` additionally guards against a
+	// fresh chat's first reload here re-firing what newChat()/send() already
+	// checked for this same id. Cheap and self-gating server-side (pulse_context).
+	if (!_sameConv) _checkPulseOnce(id);
 	_shownConvId = id;
 	await nextTick();
 	if (_keepScrollTop !== null && threadEl.value) {
@@ -8874,6 +8945,19 @@ async function newChat() {
 	swapDraft(null);
 	resetRunState();
 	currentId.value = conv?.name || conv;
+	// loadConversation does not run on this path, so the `!_sameConv` pulse
+	// check there never fires for a new chat — this is a genuine chat-open
+	// event too (pulse is gated per-user-period, not per-conversation, so an
+	// empty fresh chat is a valid open). Cheap and self-gating; no await needed.
+	// _checkPulseOnce (keyed on this id, not _shownConvId) keeps this from
+	// double-firing when the first reply's loadConversation reload runs next.
+	_checkPulseOnce(currentId.value);
+	// loadConversation does not run on this path (see below), so reload THIS
+	// conversation's own connector-focus pick here instead of leaving the ref
+	// on whatever the PREVIOUS chat had armed - createOrFocusEmpty can return
+	// an already-existing empty conversation, so this is a real reload (its
+	// own stored pick, if any), not just a reset to null.
+	connectorFocus.value = _loadConnectorFocusFor(currentId.value);
 	// This conversation IS the unsaved new-chat composer getting its id. The recovered/typed
 	// new-chat draft (already restored into `input` by swapDraft above) and its still-retained
 	// voice records lived under the _NEW_CHAT_SCOPE sentinel — migrate draft + records + mirror +
@@ -9187,7 +9271,12 @@ async function send(textArg, resendAck) {
 			undefined,
 			attachments,
 			sendCtx,
-			approvalTokens
+			approvalTokens,
+			// Same voice-ack token voiceDictationStore.captureSentInPayload already
+			// computed above (for releasing local audio blobs) — non-empty iff this
+			// payload's text came from a dictation, so reuse it verbatim rather than
+			// adding new detection logic.
+			!!(_voiceAck && _voiceAck.length)
 		);
 		// A typed go-ahead was consumed as an approval, not rejected as a send, so it
 		// must not fall into the rejection branch below even when the confirmation
@@ -9358,6 +9447,12 @@ async function send(textArg, resendAck) {
 					originOf.value = "";
 					if (route.params.id !== r.conversation_id)
 						router.replace("/c/" + r.conversation_id);
+					// A brand-new/fallback conversation becoming current is a genuine
+					// chat-open too (e.g. the very first message sent from the home/
+					// welcome screen, never touching newChat() or loadConversation).
+					// _checkPulseOnce keys on the id itself, so this can't double-fire
+					// with the loadConversation/newChat sites either.
+					_checkPulseOnce(r.conversation_id);
 				}
 				// Empties are hidden from the sidebar; surface the row now it has a message.
 				if (!store.conversations.some((c) => c.name === currentId.value))
@@ -9741,15 +9836,17 @@ function onEvent(p) {
 					},
 				};
 			}
+			// Post-reply feedback line: offer it (throttled) now the reply is
+			// finalized and its duration is stamped. Only here - never on history load.
+			// The once-per-session popup takes priority on this same reply (see
+			// maybeCheckSessionFeedback) - never both prompts on one reply.
+			if (m) maybeCheckSessionFeedback(m);
 			// The compacted after-chip and the compacting lock are both scoped to a
 			// single turn: the NEXT run:end always clears them and refetches the
 			// meter, whether or not this particular turn itself compacted.
 			compactedChip.value = false;
 			compacting.value = false;
 			loadContext();
-			// Post-reply feedback line: offer it (throttled) now the reply is
-			// finalized and its duration is stamped. Only here - never on history load.
-			if (m) maybeOfferFeedback(m);
 			waiting.value = false;
 			sending.value = false;
 			statusPhase.value = null;

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1825,6 +1825,15 @@ def push_bench_heartbeat(heartbeat: dict) -> dict:
 	return _post(path=_m("api.tenant.ingest_bench_heartbeat"), body={"heartbeat": heartbeat})
 
 
+def push_chat_feedback(item: dict) -> dict:
+	"""Push one chat-reply rating (thumbs up/down + optional note) to admin for the
+	tenant-wise Feedback dashboard. Admin upserts on (tenant, message). Called
+	best-effort from jarvis.chat.feedback.submit_feedback, which swallows failures
+	so a lost rating never blocks the tap.
+	Raises AdminAuthError / AdminUnreachableError / AdminValidationError."""
+	return _post(path=_m("api.tenant.ingest_chat_feedback"), body={"item": item})
+
+
 def pair_chat_device(public_key: str, device_id: str, *, request_timeout_s: int = 30) -> dict:
 	"""POST customer's chat device pubkey to admin; admin asks the fleet-agent
 	to write a PairedDevice record into the customer's agent container and

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1834,6 +1834,40 @@ def push_chat_feedback(item: dict) -> dict:
 	return _post(path=_m("api.tenant.ingest_chat_feedback"), body={"item": item})
 
 
+# Short timeout for the two feedback pushes below, for the same reason as
+# _MODEL_CATALOG_TIMEOUT_S: they run SYNCHRONOUSLY inside a customer web request
+# (submit_session_feedback / submit_pulse_feedback, neither is enqueued), so at
+# the DEFAULT_TIMEOUT_S = 150 an admin that hangs rather than refuses would pin
+# a web worker for 2.5 minutes per submit. Both callers already treat any
+# failure as "lost response, acceptable", so a timeout is just the same loss
+# reached sooner. Admin's ingest is a single upsert; 10s is generous for it.
+# push_chat_feedback above predates this and keeps the default on purpose: it
+# is out of this change's scope, not a considered exception.
+_FEEDBACK_TIMEOUT_S = 10
+
+
+def push_session_feedback(item: dict) -> dict:
+	"""Push one once-per-session popup response to admin. Called best-effort
+	from jarvis.chat.feedback._forward_session, which swallows failures -- a
+	lost response is acceptable, a blocked popup is not.
+	Raises AdminAuthError / AdminUnreachableError / AdminValidationError."""
+	return _post(
+		path=_m("api.tenant.ingest_session_feedback"),
+		body={"item": item},
+		timeout_s=_FEEDBACK_TIMEOUT_S,
+	)
+
+
+def push_pulse_feedback(item: dict) -> dict:
+	"""Push one periodic business-pulse response to admin. Same best-effort
+	contract as push_session_feedback."""
+	return _post(
+		path=_m("api.tenant.ingest_pulse_feedback"),
+		body={"item": item},
+		timeout_s=_FEEDBACK_TIMEOUT_S,
+	)
+
+
 def pair_chat_device(public_key: str, device_id: str, *, request_timeout_s: int = 30) -> dict:
 	"""POST customer's chat device pubkey to admin; admin asks the fleet-agent
 	to write a PairedDevice record into the customer's agent container and

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -743,8 +743,16 @@ def _launch_audit(
 	try:
 		# Fresh conversation. ROW ownership is the human owner (reassigned below) so
 		# if_owner visibility works; the ERP-read identity is the run-as user.
-		# ignore_permissions matches the macro engine.
-		conv = frappe.get_doc({"doctype": CONV, "title": f"{listing.title} audit"[:140], "status": "Active"})
+		# ignore_permissions matches the macro engine. agent_initiated: a scheduled
+		# audit run log, not a chat session the user chose to start.
+		conv = frappe.get_doc(
+			{
+				"doctype": CONV,
+				"title": f"{listing.title} audit"[:140],
+				"status": "Active",
+				"agent_initiated": 1,
+			}
+		)
 		conv.flags.ignore_permissions = True
 		conv.insert()
 

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -1865,6 +1865,9 @@ def take_finding_to_chat(finding: str) -> dict:
 			"doctype": "Jarvis Conversation",
 			"title": f"Finding: {title}"[:140],
 			"status": "Active",
+			# Opened by the act-on-a-finding button with a pre-filled prompt, not
+			# by the user starting a chat - excluded from the session popup.
+			"agent_initiated": 1,
 		}
 	)
 	conv.insert()  # owned by the current user; respects perms

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1258,6 +1258,7 @@ def send_message(
 	thinking_override: str | None = None,
 	background: int = 0,
 	approval_tokens: str | list | None = None,
+	voice: bool = False,
 ) -> dict:
 	"""Validate, persist the user message, enqueue the worker.
 
@@ -1299,6 +1300,10 @@ def send_message(
 	resets to the model default. None leaves the existing value unchanged.
 	Note: this differs from `model_override`, which treats both None and empty
 	string as "leave the existing value alone".
+
+	`voice` (optional): True when this message's text came from mic dictation
+	rather than typing. Stamped verbatim onto the created user message's
+	`via_voice` column; no other behaviour changes.
 
 	Returns {ok: True, run_id, message_id, conversation_id} on success or
 	{ok: False, reason: str} on validation failure. A human (non-delegated) send
@@ -1505,6 +1510,7 @@ def send_message(
 			"content": display_content,
 			"streaming": 0,
 			"canvas": canvas_json,
+			"via_voice": 1 if voice else 0,
 		}
 	)
 	# Delegated re-entry (scheduler/approval-resume/agent-run/File-Box): the

--- a/jarvis/chat/feature_usage.py
+++ b/jarvis/chat/feature_usage.py
@@ -1,0 +1,318 @@
+"""Which of the 7 tracked Jarvis features a user has actually used in a given
+window. Backs the periodic pulse survey's dynamic feature-chip question.
+
+Every source is read from data that already exists for its own reason - there
+is no new event-log doctype and no new write on any hot path. Six sources are
+plain owner/user-scoped column reads; Skills is reconstructed from stored
+message content using the SAME validated slug matching
+``jarvis.api._resolve_approve_run_offer`` uses to recover a past invocation
+(``invoked_skill_slugs`` is the single source of truth, so the two can never
+drift); Wiki is a JSON-array scan because ``frappe.qb`` has no JSON-containment
+filter.
+
+Two accuracy caveats are deliberate and carried from the design:
+
+* **Skills** resolves against the *current* ``Jarvis Custom Skill`` state, so a
+  since-disabled skill will not match a historical ``/slug`` mention (false
+  negative) and a since-created skill reusing a slug matches retroactively
+  (false positive). Fine for a "what do you use" prompt; NOT a historically
+  accurate record.
+* **Triggers** attributes via ``Jarvis Trigger Activity.event_user`` - the user
+  whose document event FIRED the trigger, which is not necessarily the user who
+  authored it. Same axis the triggers activity list already reports on.
+
+Identity: ``user`` is an explicit parameter, never ``frappe.session.user``. The
+reads therefore use the permission-skipping ``frappe.get_all`` /
+``frappe.db.get_value`` / ``frappe.qb`` family with an explicit owner filter,
+exactly as ``jarvis.chat.custom_skills.invoked_skill_slugs`` does and for the
+same reason: the pulse survey may be computed for a user other than whoever is
+logged in (a background continuation), where ``get_list`` would silently answer
+"no features used". Nothing but a per-feature timestamp leaves this module - no
+row content is returned to the caller.
+
+See docs/superpowers/specs/2026-09-08-session-feedback-design.md.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+from jarvis.chat.custom_skills import invoked_skill_slugs
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+MACRO_RUN = "Jarvis Macro Run"
+TRIGGER_ACTIVITY = "Jarvis Trigger Activity"
+CONNECTOR_LOG = "Jarvis Connector Log"
+VOICE_NOTE = "Jarvis Voice Note"
+WIKI = "Jarvis Wiki Page"
+
+# The durable ``role=tool`` receipt for a jarvis__* tool is written by
+# ``jarvis.api._persist_and_publish_tool_call`` from the name ``call_tool``
+# received, and ``call_tool`` is dispatched on BARE registry ids (the worker
+# explicitly skips persisting jarvis__* rows - see turn_handler's ``is_jarvis``
+# branch). So the bare form is what is actually in the table; the prefixed form
+# is kept only so a runtime that ever persists the agent-side name still counts.
+_DASHBOARD_TOOLS = (
+	"save_dashboard",
+	"save_agent_dashboard",
+	"jarvis__save_dashboard",
+	"jarvis__save_agent_dashboard",
+)
+
+# Bounded: one user's own recent messages, not fleet-wide. A user whose only
+# skill invocation in the window is older than this many slug-shaped messages
+# reads as "no skills used" - acceptable for a survey prompt.
+_SKILLS_SCAN_LIMIT = 200
+_WIKI_SCAN_LIMIT = 500
+
+#: Feature keys this module can report, in the order they are computed.
+FEATURES = (
+	"file_box",
+	"dashboard_builder",
+	"skills",
+	"macros",
+	"triggers_connectors",
+	"voice_chat",
+	"wiki",
+)
+
+
+def get_used_features(user: str, since) -> dict[str, str]:
+	"""``{feature: last_used}`` for every one of the 7 tracked features ``user``
+	has used since ``since``. A feature absent from the dict was not used in the
+	window, so an empty dict means "hide the question".
+
+	One source's failure must drop that one feature's entry, never blank the
+	whole survey - each source runs inside its own guard.
+	"""
+	since_dt = frappe.utils.get_datetime(since) if since else None
+	if not user or not since_dt:
+		return {}
+	out: dict[str, str] = {}
+	# Looked up through module globals on every call so a caller (or a test)
+	# that swaps one source function out is honoured.
+	for name in FEATURES:
+		try:
+			last = globals()[f"_{name}"](user, since_dt)
+		except Exception:
+			frappe.log_error(
+				title=f"get_used_features: {name} source failed",
+				message=frappe.get_traceback(),
+			)
+			last = None
+		if last:
+			out[name] = last
+	return out
+
+
+def _iso(value) -> str | None:
+	"""A Datetime/Date column value (or ``None``) as a sortable string."""
+	return str(value) if value else None
+
+
+def _latest(*values) -> str | None:
+	"""The newest of several already-stringified timestamps, ignoring blanks.
+	ISO-shaped strings sort chronologically, so ``max`` is the right pick."""
+	present = [v for v in values if v]
+	return max(present) if present else None
+
+
+def _file_box(user: str, since) -> str | None:
+	"""A File-Box drop creates its conversation with ``file_box=1`` at drop time
+	(``jarvis.chat.filebox.drop_file``), so ``creation`` IS the usage moment -
+	no later toggle to chase."""
+	# get_all/get_value here read under the explicit `user` argument, not the
+	# session (see module docstring).
+	return _iso(
+		frappe.db.get_value(
+			CONV,
+			{"owner": user, "file_box": 1, "creation": [">=", since]},
+			"creation",
+			order_by="creation desc",
+		)
+	)
+
+
+def _dashboard_builder(user: str, since) -> str | None:
+	"""Creating a dashboard, never viewing one. Attribution is by CONVERSATION
+	owner: Jarvis Chat Message carries no user field and a tool receipt's own
+	``owner`` is whichever server identity wrote it, so this joins exactly the
+	way ``jarvis.chat.usage_push`` already attributes tool calls."""
+	msg = frappe.qb.DocType(MSG)
+	conv = frappe.qb.DocType(CONV)
+	rows = (
+		frappe.qb.from_(msg)
+		.inner_join(conv)
+		.on(msg.conversation == conv.name)
+		.select(msg.creation)
+		.where(
+			(conv.owner == user)
+			& (msg.role == "tool")
+			& (msg.tool_name.isin(_DASHBOARD_TOOLS))
+			& (msg.creation >= since)
+		)
+		.orderby(msg.creation, order=frappe.qb.desc)
+		.limit(1)
+	).run(as_dict=True)
+	return _iso(rows[0].creation) if rows else None
+
+
+def _skills(user: str, since) -> str | None:
+	"""Re-resolve ``/slug`` invocations out of the user's own stored messages.
+
+	``invoked_skill_slugs`` stays the single authority on "did this message
+	invoke a skill", but its owner/shared/role lookups depend only on ``user``,
+	never on the message - so calling it once per candidate row would be a query
+	loop. Instead: ONE resolution pass over the joined candidate text tells us
+	which slugs resolve at all (the regex is ``(?:^|\\s)/slug``, and joining on
+	"\\n" keeps every row's leading boundary intact, so the joined match set is
+	exactly the union of the per-row match sets). Rows are then walked
+	newest-first with a cheap substring prefilter, and the canonical function
+	makes the final per-row call - typically two round-trips in total.
+	"""
+	rows = frappe.get_all(
+		MSG,
+		filters={
+			"owner": user,
+			"role": "user",
+			"hidden": 0,
+			"content": ["like", "%/%"],
+			"creation": [">=", since],
+		},
+		fields=["content", "creation"],
+		order_by="creation desc",
+		limit_page_length=_SKILLS_SCAN_LIMIT,
+	)
+	contents = [(row.content or "") for row in rows]
+	resolved = invoked_skill_slugs("\n".join(contents), user=user)
+	if not resolved:
+		return None
+	tokens = tuple(f"/{slug}" for slug in resolved)
+	for row, content in zip(rows, contents, strict=True):
+		if not any(token in content for token in tokens):
+			continue
+		if invoked_skill_slugs(content, user=user):
+			return _iso(row.creation)
+	return None
+
+
+def _macros(user: str, since) -> str | None:
+	"""Macro runs are attributed by the run row's own ``owner``: every writer
+	hands ownership to the macro owner right after insert
+	(``jarvis.chat.macros.run_macro``, ``macro_scheduler``), the table carries a
+	composite ``(owner, creation)`` index for exactly this filter+sort, and the
+	list/stats endpoints already read it this way.
+
+	Deliberately NOT joined through ``Jarvis Macro Run.conversation``: that link
+	is nulled when a conversation is deleted (``jarvis/chat/api.py`` -
+	``UPDATE tabJarvis Macro Run SET conversation = NULL``), so a join would
+	silently lose runs. ``creation`` rather than ``started_at`` for the same
+	reason it is indexed - and because ``started_at`` is unset on a run that
+	never started.
+	"""
+	return _iso(
+		frappe.db.get_value(
+			MACRO_RUN,
+			{"owner": user, "creation": [">=", since]},
+			"creation",
+			order_by="creation desc",
+		)
+	)
+
+
+def _triggers_connectors(user: str, since) -> str | None:
+	"""One chip for both automation surfaces. ``event_user`` is the user whose
+	document event fired the trigger (see the module docstring's caveat);
+	``Jarvis Connector Log.user`` is the caller of the connector."""
+	trigger = _iso(
+		frappe.db.get_value(
+			TRIGGER_ACTIVITY,
+			{"event_user": user, "creation": [">=", since]},
+			"creation",
+			order_by="creation desc",
+		)
+	)
+	connector = _iso(
+		frappe.db.get_value(
+			CONNECTOR_LOG,
+			{"user": user, "creation": [">=", since]},
+			"creation",
+			order_by="creation desc",
+		)
+	)
+	return _latest(trigger, connector)
+
+
+def _voice_chat(user: str, since) -> str | None:
+	"""Voice notes and mic dictation are one chip. Every ``Jarvis Voice Note``
+	kind counts (the doctype IS the notes feature; Text/Attachment/Link are the
+	same capture surface), matching the design's "filtered by owner" source.
+
+	``via_voice`` is added by the send-time dictation task later in this train,
+	so guard on the column: running ahead of that migrate must degrade to the
+	Voice Note signal, not raise.
+	"""
+	note = _iso(
+		frappe.db.get_value(
+			VOICE_NOTE,
+			{"owner": user, "creation": [">=", since]},
+			"creation",
+			order_by="creation desc",
+		)
+	)
+	dictated = None
+	if frappe.db.has_column(MSG, "via_voice"):
+		dictated = _iso(
+			frappe.db.get_value(
+				MSG,
+				{"owner": user, "via_voice": 1, "creation": [">=", since]},
+				"creation",
+				order_by="creation desc",
+			)
+		)
+	return _latest(note, dictated)
+
+
+def _wiki(user: str, since) -> str | None:
+	"""``sources`` is a JSON provenance array per page
+	(``jarvis.chat.wiki.append_source`` -> ``{date, kind, ref, user}``, newest
+	20 kept) and ``frappe.qb`` has no JSON-containment filter, so this scans in
+	Python.
+
+	Bounded twice over: every writer appends a source through ``doc.save()`` /
+	``doc.insert()`` (no ``update_modified=False`` path touches ``sources``), so
+	a page carrying an entry from the window must itself have been modified in
+	the window - the ``modified`` filter is a sound superset, not a heuristic.
+
+	``date`` is day-granular, so the cutoff is compared at day granularity: a
+	page edited earlier on the cutoff day still counts. The returned value is
+	therefore a ``YYYY-MM-DD`` date, not a datetime, unlike the other sources.
+	"""
+	since_str = str(since)[:10]
+	pages = frappe.get_all(
+		WIKI,
+		filters={"modified": [">=", since_str]},
+		fields=["sources"],
+		order_by="modified desc",
+		limit_page_length=_WIKI_SCAN_LIMIT,
+	)
+	latest = None
+	for page in pages:
+		if not page.sources:
+			continue
+		try:
+			entries = json.loads(page.sources)
+		except Exception:
+			continue
+		if not isinstance(entries, list):
+			continue
+		for entry in entries:
+			if not isinstance(entry, dict) or entry.get("user") != user:
+				continue
+			date = entry.get("date") or ""
+			if date >= since_str:
+				latest = _latest(latest, date)
+	return latest

--- a/jarvis/chat/feature_usage.py
+++ b/jarvis/chat/feature_usage.py
@@ -235,14 +235,19 @@ def _triggers_connectors(user: str, since) -> str | None:
 			order_by="creation desc",
 		)
 	)
-	connector = _iso(
-		frappe.db.get_value(
-			CONNECTOR_LOG,
-			{"user": user, "creation": [">=", since]},
-			"creation",
-			order_by="creation desc",
+	# Backport adaptation: the connectors DocType does not exist on this
+	# release line (connectors are develop-only), and one failing lookup
+	# would drop the whole chip, triggers included. Probe it only if present.
+	connector = None
+	if frappe.db.exists("DocType", CONNECTOR_LOG):
+		connector = _iso(
+			frappe.db.get_value(
+				CONNECTOR_LOG,
+				{"user": user, "creation": [">=", since]},
+				"creation",
+				order_by="creation desc",
+			)
 		)
-	)
 	return _latest(trigger, connector)
 
 

--- a/jarvis/chat/feedback.py
+++ b/jarvis/chat/feedback.py
@@ -1,0 +1,95 @@
+"""Post-reply chat feedback: a thumbs up/down (with an optional note on a down)
+on an assistant reply, forwarded to the admin fleet dashboard.
+
+Direct-send, no local table: this bench keeps NO copy. ``submit_feedback``
+derives every piece of metadata server-side (tenant is derived on the admin side
+from the authenticated principal), then forwards it best-effort. A failed forward
+is dropped silently - feedback is low-stakes, and a blocked tap is not acceptable.
+The reply text is never sent; only the rating, refs, and a bounded optional note.
+
+Only the caller's OWN assistant messages can be rated (ownership via the same
+gate the rest of the chat surface uses, ``chat.api._get_owned_conversation``).
+"""
+
+from __future__ import annotations
+
+import re
+
+import frappe
+
+from jarvis.chat.api import _get_owned_conversation
+from jarvis.permissions import require_jarvis_access
+
+MSG = "Jarvis Chat Message"
+CONV = "Jarvis Conversation"
+
+_RATINGS = {"up", "down"}
+_MAX_NOTE = 1000
+#: The agent session UUID lives as the last segment of a composite session_key
+#: like "agent:main:dashboard:<uuid>". Empty when absent/malformed - the rating
+#: still records; only the admin-side deep-link is best-effort.
+_SESSION_UUID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
+
+
+@frappe.whitelist()
+def submit_feedback(message_id: str, rating: str, note: str | None = None) -> dict:
+	"""Record a thumbs up/down on one assistant reply and forward it to admin.
+
+	Args:
+		message_id: the Jarvis Chat Message name of the assistant reply.
+		rating: "up" or "down".
+		note: optional free text, kept only on a "down".
+
+	The rating commits on the first call (thumbs tap); a later call carrying the
+	note folds onto the same admin row (upsert). Returns ``{"ok": True}`` even when
+	the forward fails - the tap must never surface an error.
+	"""
+	require_jarvis_access()
+	rating = (rating or "").strip()
+	if rating not in _RATINGS:
+		frappe.throw("rating must be 'up' or 'down'", frappe.ValidationError)
+
+	# Raw db read bypasses field permlevel; we only need these four columns.
+	msg = frappe.db.get_value(
+		MSG, message_id, ["conversation", "role", "model", "reply_duration_ms"], as_dict=True
+	)
+	if not msg:
+		frappe.throw("message not found", frappe.DoesNotExistError)
+	if msg.role != "assistant":
+		frappe.throw("can only rate assistant replies", frappe.ValidationError)
+
+	# Ownership: the canonical chat gate (raises PermissionError for another user's
+	# conversation, DoesNotExistError if it vanished). session_key is permlevel-1;
+	# read it via db.get_value to bypass that, matching how the worker touches it.
+	_get_owned_conversation(msg.conversation)
+	session_key = frappe.db.get_value(CONV, msg.conversation, "session_key")
+
+	payload = {
+		"rating": rating,
+		"message_ref": message_id,
+		"conversation_ref": msg.conversation,
+		"session_id": _session_uuid(session_key),
+		"model": msg.model or "",
+		"user_ref": frappe.session.user,
+		"reply_duration_ms": msg.reply_duration_ms or 0,
+		"note": (note or "").strip()[:_MAX_NOTE] if rating == "down" else "",
+	}
+	_forward(payload)
+	return {"ok": True}
+
+
+def _session_uuid(session_key: str | None) -> str:
+	"""Bare agent session UUID from a composite session_key, or "" when absent."""
+	tail = (session_key or "").rsplit(":", 1)[-1]
+	return tail if _SESSION_UUID_RE.match(tail) else ""
+
+
+def _forward(payload: dict) -> None:
+	"""Best-effort forward to admin. NEVER raises to the caller: a lost rating is
+	acceptable (low-stakes), a blocked or errored tap is not."""
+	try:
+		from jarvis import admin_client
+
+		admin_client.push_chat_feedback(payload)
+	except Exception:
+		frappe.log_error(title="chat feedback forward failed")

--- a/jarvis/chat/feedback.py
+++ b/jarvis/chat/feedback.py
@@ -9,6 +9,21 @@ The reply text is never sent; only the rating, refs, and a bounded optional note
 
 Only the caller's OWN assistant messages can be rated (ownership via the same
 gate the rest of the chat surface uses, ``chat.api._get_owned_conversation``).
+
+The same direct-send, no-local-table rule governs the once-per-session popup
+("How did this session go?") at the bottom of this module: only the popup's
+own metadata (``Jarvis Conversation.session_feedback_asked_at``, and the
+``turn_count`` that triggers it) is kept on the bench - the response itself
+lives only on the admin side.
+
+The periodic "business pulse" survey (last section) follows the same rule and
+keeps exactly two fields, both on ``Jarvis User Settings``:
+``pulse_last_period_key`` and ``pulse_offer_count``. There is no cron behind
+it - the fleet scheduler is paused, so a scheduled survey would silently never
+run. Instead it reuses the lazy period-key rollover the per-user token cap
+already ships (``jarvis.chat.usage.current_period_key``, jarvis#1165): the
+current monthly bucket is compared against the stored key on chat open, and a
+mismatch IS the rollover.
 """
 
 from __future__ import annotations
@@ -22,6 +37,7 @@ from jarvis.permissions import require_jarvis_access
 
 MSG = "Jarvis Chat Message"
 CONV = "Jarvis Conversation"
+USER_SETTINGS = "Jarvis User Settings"
 
 _RATINGS = {"up", "down"}
 _MAX_NOTE = 1000
@@ -29,6 +45,18 @@ _MAX_NOTE = 1000
 #: like "agent:main:dashboard:<uuid>". Empty when absent/malformed - the rating
 #: still records; only the admin-side deep-link is best-effort.
 _SESSION_UUID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
+
+#: Turns a conversation must have settled before the once-per-session popup is
+#: due. Hardcoded for v1 (spec "Settings"): there is no precedent for admin
+#: pushing a setting down to bench Jarvis Settings, so a configurable field would
+#: be a surface with no way to drive it.
+SESSION_FEEDBACK_TURN_THRESHOLD = 10
+#: The five preset reactions the popup offers, worst to best. Mirrored by the
+#: admin ingest's own allowlist (never trust the bench) and by the SPA dialog.
+_SESSION_CHIP_VALUES = {"Great", "Good", "Okay", "Not great", "Frustrating"}
+#: The reactions that reveal the optional "what went wrong?" line. "Okay" counts:
+#: the spec's rule is "Okay or worse", not just the bottom two.
+_SESSION_LOW_CHIPS = {"Okay", "Not great", "Frustrating"}
 
 
 @frappe.whitelist()
@@ -93,3 +121,448 @@ def _forward(payload: dict) -> None:
 		admin_client.push_chat_feedback(payload)
 	except Exception:
 		frappe.log_error(title="chat feedback forward failed")
+
+
+# --------------------------------------------------------------------------- #
+# Once-per-session popup ("How did this session go?")
+# --------------------------------------------------------------------------- #
+
+
+@frappe.whitelist()
+def session_feedback_status(conversation: str) -> dict:
+	"""Whether the once-per-session popup is due for this conversation now.
+
+	Costs ONE indexed row read (the ownership gate's own load) and no scan:
+	``turn_count`` is a maintained counter bumped per settled turn by
+	``jarvis.chat.settlement._bump_turn_count``, never a live ``COUNT(*)`` - this
+	is polled after every assistant reply, so a scan here would be the most
+	expensive query the feature adds.
+
+	Not due for a conversation the user did not start: a File Box drop
+	(``file_box``) or an agent-opened run log (``agent_initiated`` - a macro run,
+	a macro merge, an app-learning run, a scheduled audit, a proactive message,
+	an act-on-a-finding chat). Not due either once the popup has been answered or
+	skipped here - ``session_feedback_asked_at`` is final, so Skip means "never
+	again in this conversation" and survives a reload or a second tab.
+	"""
+	require_jarvis_access()
+	# The canonical ownership gate; it already loads the row, so read the four
+	# fields off the doc it returns rather than issuing a second query.
+	conv = _get_owned_conversation(conversation)
+	if conv.file_box or conv.agent_initiated:
+		return {"due": False}
+	due = int(conv.turn_count or 0) >= SESSION_FEEDBACK_TURN_THRESHOLD and not conv.session_feedback_asked_at
+	return {"due": bool(due)}
+
+
+@frappe.whitelist(methods=["POST"])
+def submit_session_feedback(
+	conversation: str, chip_value: str | None = None, note: str | None = None
+) -> dict:
+	"""Record the once-per-session popup's answer, or a Skip (``chip_value`` unset).
+
+	The response is recorded AT MOST ONCE per conversation. Claiming the popup and
+	stamping ``session_feedback_asked_at`` is a single compare-and-set (see
+	``_claim_session_feedback``) that is committed before the admin forward, so two
+	tabs - or a double-click that beats the dialog's own disable - cannot both
+	forward: the loser returns ``recorded: False`` and forwards nothing, and the
+	winner never holds a row lock across the network call. A Skip claims the popup exactly the
+	same way and is never forwarded to admin (there is no response to store); a
+	real reaction is forwarded best-effort. The optional note is kept only on
+	"Okay" or worse - the popup only reveals the field there, and a note typed
+	before switching to a positive reaction must not ride along.
+
+	A malformed reaction is rejected BEFORE the claim: the one-shot popup is the
+	user's only chance to answer in this conversation, so a broken client must
+	not silently burn it.
+
+	Returns ``{"ok": True, "recorded": <bool>}`` even when the forward fails: like
+	the thumbs tap, a lost response is acceptable and a blocked popup is not.
+	"""
+	require_jarvis_access()
+	conv = _get_owned_conversation(conversation)
+	if chip_value and chip_value not in _SESSION_CHIP_VALUES:
+		frappe.throw("chip_value is not one of the preset reactions", frappe.ValidationError)
+
+	# Short-circuit on the already-loaded doc first (the common repeat: a reload or
+	# a second tab opened later), then settle a genuine race with the CAS.
+	if conv.session_feedback_asked_at or not _claim_session_feedback(conversation):
+		return {"ok": True, "recorded": False}
+	# Durability-before-external-call (the ONE sanctioned reason for an explicit
+	# commit here, and the same thing api.create_conversation does): make the claim
+	# durable and RELEASE the conversation row lock BEFORE the admin HTTPS forward
+	# below. Frappe would otherwise not commit until the end of the request, holding
+	# that row lock for the whole admin round-trip - up to admin_client's timeout
+	# when admin is unreachable. Anything touching this conversation meanwhile would
+	# block on it: settlement's turn-count bump (delaying a run:end), and
+	# admission.accept_or_queue's _lock_conversation - which waits while holding the
+	# SITE-WIDE shard lock, turning one slow popup into a shard-wide send stall.
+	frappe.db.commit()
+	if not chip_value:
+		return {"ok": True, "recorded": False}
+
+	payload = {
+		"kind": "Session",
+		"session_ref": conversation,
+		"chip_value": chip_value,
+		"user_ref": frappe.session.user,
+		"note": (note or "").strip()[:_MAX_NOTE] if chip_value in _SESSION_LOW_CHIPS else "",
+	}
+	_forward_session(payload)
+	return {"ok": True, "recorded": True}
+
+
+def _claim_session_feedback(conversation: str) -> bool:
+	"""Stamp ``session_feedback_asked_at`` and return True iff THIS call claimed
+	the one-shot popup.
+
+	A conditional UPDATE rather than ``db.set_value``, because a read-then-write
+	leaves a window in which two tabs (or a double-click that beats the dialog's
+	disable) both decide the popup is unanswered and both forward. The admin side
+	upserts on ``(tenant, kind, session_ref)``, so the second push would silently
+	OVERWRITE the user's real first answer rather than duplicate it - a lost
+	response, not just a noisy one. ``session_feedback_asked_at IS NULL`` in the
+	WHERE makes the claim atomic: exactly one caller sees rowcount 1.
+
+	``modified`` is deliberately left alone (the ``update_modified=False``
+	equivalent): this is server-set popup metadata, not a user edit of the
+	conversation, and must not reorder the sidebar."""
+	frappe.db.sql(
+		f"""UPDATE `tab{CONV}` SET session_feedback_asked_at=%(now)s
+		WHERE name=%(c)s AND session_feedback_asked_at IS NULL""",
+		{"now": frappe.utils.now(), "c": conversation},
+	)
+	# Rowcount is read BEFORE any commit (a commit can reset the cursor) - the same
+	# discipline jarvis.chat.turn_state._run_cas and admission._run_cas follow.
+	cursor = getattr(frappe.db, "_cursor", None)
+	return bool(cursor and int(cursor.rowcount) == 1)
+
+
+def _forward_session(payload: dict) -> None:
+	"""Best-effort forward to admin, same contract as ``_forward`` above: a lost
+	response is acceptable, a blocked popup is not. Named verbatim in
+	``admin_client.push_session_feedback``'s docstring - keep the two in step."""
+	try:
+		from jarvis import admin_client
+
+		admin_client.push_session_feedback(payload)
+	except Exception:
+		frappe.log_error(title="session feedback forward failed")
+
+
+# --------------------------------------------------------------------------- #
+# Periodic "business pulse" survey
+# --------------------------------------------------------------------------- #
+
+#: Cadence of the pulse survey, spelled the way ``usage.current_period_key``
+#: expects it (it shares ``limit_period``'s vocabulary). Hardcoded for v1, for
+#: the same reason as SESSION_FEEDBACK_TURN_THRESHOLD above.
+PULSE_SURVEY_CADENCE = "Monthly"
+#: Offers per period before the survey goes quiet. "Maybe later" is not
+#: recorded anywhere: it simply lets the next chat open offer again, three
+#: times in all, rather than nagging for the rest of the month. Answering
+#: stores this value outright - see ``_store_pulse_state``.
+PULSE_MAX_OFFERS = 3
+#: The window "used this period" is measured over. Monthly cadence -> the last
+#: 30 days (spec: "monthly -> last 30 days"), a rolling window rather than the
+#: calendar bucket, so a survey offered on the 2nd still has something to show.
+_PULSE_WINDOW_DAYS = 30
+#: Bound on the free-text "is Jarvis solving your business use case?" answer.
+_MAX_USE_CASE = 1000
+
+
+def _pulse_state_columns_present() -> bool:
+	"""False while the app runs ahead of ``bench migrate`` (a dev-server reload,
+	a worker restarted early). Reading or writing a column that is not there yet
+	would 500 the chat open, where "never due" is the right fallback: the survey
+	is not worth an error, and it comes back on its own after the migrate.
+
+	Same guard, and same reasoning, as ``usage.period_select_fields``; Frappe
+	caches the table's column list, so this is not a per-call DESCRIBE."""
+	try:
+		return bool(frappe.db.has_column(USER_SETTINGS, "pulse_last_period_key"))
+	except Exception:
+		return False
+
+
+def _pulse_window_start():
+	"""Start of the rolling usage window the survey asks about."""
+	return frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-_PULSE_WINDOW_DAYS)
+
+
+def _pulse_period_label(now=None) -> str:
+	"""Badge text for the dialog, e.g. "This month, Sep 2026"."""
+	now = now or frappe.utils.now_datetime()
+	return now.strftime("This month, %b %Y")
+
+
+def _turns_since(user: str, since) -> int:
+	"""Total settled turns across this user's OWN conversations last active
+	since ``since``.
+
+	A real SUM of the maintained ``turn_count`` counter, not a proxy like "has a
+	conversation": a user who opened chats but never sent anything has not used
+	Jarvis this period and must not be surveyed. ``file_box`` and
+	``agent_initiated`` conversations contribute 0 by construction (the counter
+	never advances on them - see ``settlement._bump_turn_count``), so they are
+	excluded without needing a filter.
+
+	One query, scoped to one user, and NOT on a hot path: it is reached only
+	after the period-key gate says an offer is still possible, so once the user
+	has any turns at all it runs at most ``PULSE_MAX_OFFERS`` times per period.
+	``owner`` carries no index on this table (Frappe indexes only ``modified``
+	by default), so this is a per-tenant table scan - acceptable at that rate,
+	and precisely why it must stay behind the cheap gate."""
+	from frappe.query_builder.functions import Sum
+
+	conv = frappe.qb.DocType(CONV)
+	rows = (
+		frappe.qb.from_(conv)
+		.select(Sum(conv.turn_count).as_("total"))
+		.where((conv.owner == user) & (conv.last_active_at >= since))
+	).run(as_dict=True)
+	return int((rows[0].total if rows else 0) or 0)
+
+
+def _store_pulse_state(settings_name: str, period_key: str, offer_count: int) -> None:
+	"""Stamp the period key and the offer count on the user's settings row.
+	The ANSWER path's write: unconditional, because an answer always wins over
+	whatever the offer count was. Offers themselves go through
+	``_claim_pulse_offer`` below, which is conditional.
+
+	``update_modified=False``: server-owned app state (permlevel 1), not a user
+	edit of their settings.
+
+	Callers pass ``PULSE_MAX_OFFERS`` to mean "quiet for the rest of this
+	period". Two states share that value deliberately - "answered" and "offered
+	three times" - because the outcome is identical and the spec allots the
+	survey exactly two fields."""
+	if not _pulse_state_columns_present():
+		return
+	frappe.db.set_value(
+		USER_SETTINGS,
+		settings_name,
+		{"pulse_last_period_key": period_key, "pulse_offer_count": offer_count},
+		update_modified=False,
+	)
+
+
+def _claim_pulse_offer(settings_name: str, period_key: str, seen_count: int, same_period: bool) -> bool:
+	"""Advance the offer count to ``seen_count + 1`` and return True iff THIS
+	call claimed the offer, i.e. the row still read exactly as the caller saw it.
+
+	A compare-and-set rather than ``_store_pulse_state``, for the same reason
+	``_claim_session_feedback`` is one. ``pulse_context`` reads the count, then
+	runs the comparatively slow feature-usage sweep, then writes. In that window
+	the user can ANSWER the survey in another tab (``submit_pulse_feedback``
+	stores ``PULSE_MAX_OFFERS``), and a blind ``count + 1`` write afterwards
+	would drag the answered marker back DOWN to 2 and re-offer a survey the user
+	already filled in. The same window lets two chat opens racing on one
+	settings row both read 0 and both burn an offer. With the WHERE clause
+	pinned to what was read, exactly one writer sees rowcount 1; the others
+	report "not due" and burn nothing.
+
+	Two predicates, not one NULL-safe expression, because the two branches
+	compare different things:
+	  * same period - the key matches AND the count is still what we read;
+	  * rollover (or a row created moments ago by ``get_or_create_user_settings``,
+	    whose key is NULL and count 0) - the key is anything but the current one.
+	    The count is NOT compared here: last period's total is irrelevant, and
+	    the reset to 1 is the whole point.
+
+	Raw SQL is the standing-rule exception the session claim already takes:
+	``db.set_value`` cannot express a conditional write, and the rowcount is
+	read BEFORE any commit (a commit can reset the cursor), the discipline
+	``turn_state._run_cas`` and ``admission._run_cas`` follow. ``modified`` is
+	left alone: server-owned state, not a user edit."""
+	if same_period:
+		frappe.db.sql(
+			f"""UPDATE `tab{USER_SETTINGS}`
+			SET pulse_offer_count=%(next)s
+			WHERE name=%(n)s AND pulse_last_period_key=%(k)s AND pulse_offer_count=%(seen)s""",
+			{"n": settings_name, "k": period_key, "seen": seen_count, "next": seen_count + 1},
+		)
+	else:
+		frappe.db.sql(
+			f"""UPDATE `tab{USER_SETTINGS}`
+			SET pulse_last_period_key=%(k)s, pulse_offer_count=1
+			WHERE name=%(n)s AND (pulse_last_period_key IS NULL OR pulse_last_period_key != %(k)s)""",
+			{"n": settings_name, "k": period_key},
+		)
+	cursor = getattr(frappe.db, "_cursor", None)
+	return bool(cursor and int(cursor.rowcount) == 1)
+
+
+@frappe.whitelist(methods=["POST"])
+def pulse_context() -> dict:
+	"""Whether the periodic business-pulse survey is due for the current user
+	right now and, if so, the period label and the dynamic feature list.
+
+	POST-only despite the getter-shaped name, and that is load-bearing: this
+	endpoint WRITES (it claims the offer below), and Frappe commits only for
+	unsafe methods - reached over GET the claim would be rolled back silently
+	and the anti-nag cap would never advance. Same reason, and the same
+	annotation, as ``release_notice.check`` and ``maintenance_notice.check``.
+
+	Called on every chat open, so it is ordered cheapest-gate-first and returns
+	``{"due": False}`` almost always. The comparatively expensive feature-usage
+	sweep (7 sources, two of them bounded scans) runs ONLY once the period key
+	and the turn gate have both said an offer is really happening - it must
+	never be computed speculatively (spec: performance review).
+
+	Returning ``due`` also CLAIMS the offer: the count is incremented here, not
+	when the user answers, because "Maybe later" and a closed tab look the same
+	to the server and both have to count against the cap."""
+	require_jarvis_access()
+	if not _pulse_state_columns_present():
+		return {"due": False}
+	from jarvis.chat.usage import current_period_key
+
+	user = frappe.session.user
+	current_key = current_period_key(PULSE_SURVEY_CADENCE)
+	# READ, never ``get_doc``: the settings doc carries a child table
+	# (``user_model_usage``) and this runs on every chat open, so the deciding
+	# path is three columns off one row - the same shape ``greeting._get_pref``
+	# uses for its own proactive-card state. ``get_or_create_user_settings``
+	# stays for the one path that genuinely needs a row: claiming an offer.
+	row = frappe.db.get_value(
+		USER_SETTINGS,
+		{"user": user},
+		["name", "pulse_last_period_key", "pulse_offer_count"],
+		as_dict=True,
+	)
+	same_period = bool(row) and row.pulse_last_period_key == current_key
+	# A key from an earlier period IS the rollover: the count restarts at 0
+	# rather than carrying last month's exhausted total forward.
+	offer_count = int(row.pulse_offer_count or 0) if same_period else 0
+	if offer_count >= PULSE_MAX_OFFERS:
+		return {"due": False}
+	since = _pulse_window_start()
+	if _turns_since(user, since) < 1:
+		return {"due": False}
+	from jarvis.chat.feature_usage import get_used_features
+
+	# May be empty, and the survey is still due: the stars and the open question
+	# are worth asking regardless. Only the chip question hides (spec: "hidden
+	# if empty"), which the dialog decides from this list.
+	features = get_used_features(user, since)
+	# A user chatting before their settings row exists is normal (the row is
+	# created lazily by whichever surface needs it first), and an offer has to be
+	# recorded somewhere, so this is where the create belongs.
+	if row:
+		settings_name = row.name
+	else:
+		from jarvis.chat.usage import get_or_create_user_settings
+
+		settings_name = get_or_create_user_settings(user).name
+	# Conditional on the row still reading as it did above: the sweep just ran
+	# is exactly the window in which an answer in another tab, or a second chat
+	# open, can have moved it. Losing the race means "not due", never a
+	# re-offer of an answered survey (see _claim_pulse_offer).
+	if not _claim_pulse_offer(settings_name, current_key, offer_count, same_period):
+		return {"due": False}
+	return {
+		"due": True,
+		"period_label": _pulse_period_label(),
+		"period_key": current_key,
+		"features_offered": _feature_keys(list(features)),
+	}
+
+
+def _feature_keys(value) -> list:
+	"""The tracked feature keys in ``value``, in ``feature_usage.FEATURES``
+	order.
+
+	An allowlist filter of the same shape as ``_SESSION_CHIP_VALUES`` above,
+	not just a length bound: the submitted lists come from the client, so only
+	keys this bench can actually report survive. That drops junk and duplicates
+	and caps the list at 7 by construction. The JSON string form is accepted
+	too - ``frappe.client`` passes list arguments as JSON over HTTP."""
+	from jarvis.chat.feature_usage import FEATURES
+
+	if isinstance(value, str):
+		try:
+			value = frappe.parse_json(value)
+		except Exception:
+			return []
+	if not isinstance(value, list):
+		return []
+	picked = {item for item in value if isinstance(item, str)}
+	return [feature for feature in FEATURES if feature in picked]
+
+
+@frappe.whitelist(methods=["POST"])
+def submit_pulse_feedback(
+	stars: int,
+	features_offered: list | str,
+	features_selected: list | str,
+	use_case_text: str = "",
+	note: str | None = None,
+) -> dict:
+	"""Record one business-pulse response: forward it to admin, then silence the
+	survey for the rest of this period.
+
+	POST-only for the same reason as ``pulse_context`` above: it writes, and a
+	GET would be rolled back - here that would forward the answer to admin and
+	then re-offer the survey on the next chat open.
+
+	The full set that was OFFERED rides along with the subset the user picked as
+	most used, so the admin dashboard can tell "used it but did not pick it as
+	top" from "never offered because unused" (spec: Dynamic feature list).
+
+	A malformed rating is rejected BEFORE anything is written or sent, so a
+	broken client cannot burn the user's survey for the month on a value that
+	was never a real answer.
+
+	Forward first, THEN write: ``frappe.db.set_value`` holds the settings row
+	lock until the request commits, and that row is the one every turn's usage
+	accounting also updates. Writing first would hold that lock across the admin
+	HTTPS round-trip - up to ``admin_client``'s timeout when admin is
+	unreachable - and stall this user's own chat, the same hazard
+	``submit_session_feedback`` commits early to avoid. The write still happens
+	when the forward fails: the user answered, and asking them again is worse
+	than losing one low-stakes response (the trade the thumbs tap already
+	makes)."""
+	require_jarvis_access()
+	try:
+		stars = int(stars)
+	except (TypeError, ValueError):
+		# Over HTTP every argument arrives as a string, so a broken client sends
+		# a non-numeric rating as easily as an out-of-range one; both are the
+		# same 417 to the caller, never a 500.
+		frappe.throw("stars must be between 1 and 5", frappe.ValidationError)
+	if not 1 <= stars <= 5:
+		frappe.throw("stars must be between 1 and 5", frappe.ValidationError)
+	from jarvis.chat.usage import current_period_key, get_or_create_user_settings
+
+	current_key = current_period_key(PULSE_SURVEY_CADENCE)
+	payload = {
+		"kind": "Pulse",
+		"period_key": current_key,
+		"stars": stars,
+		"features_offered": _feature_keys(features_offered),
+		"features_selected": _feature_keys(features_selected),
+		"use_case_text": (use_case_text or "").strip()[:_MAX_USE_CASE],
+		"user_ref": frappe.session.user,
+		"note": (note or "").strip()[:_MAX_NOTE],
+	}
+	_forward_pulse(payload)
+	# Resolved AFTER the forward for the same reason the write is: on a user
+	# whose settings row does not exist yet this INSERTs one, and an uncommitted
+	# insert holds its own row lock just as an update does.
+	row = get_or_create_user_settings(frappe.session.user)
+	_store_pulse_state(row.name, current_key, PULSE_MAX_OFFERS)
+	return {"ok": True}
+
+
+def _forward_pulse(payload: dict) -> None:
+	"""Best-effort forward to admin, same contract as ``_forward`` and
+	``_forward_session`` above: a lost response is acceptable, a blocked dialog
+	is not. Named verbatim in ``admin_client.push_pulse_feedback``'s docstring -
+	keep the two in step."""
+	try:
+		from jarvis import admin_client
+
+		admin_client.push_pulse_feedback(payload)
+	except Exception:
+		frappe.log_error(title="pulse feedback forward failed")

--- a/jarvis/chat/macros.py
+++ b/jarvis/chat/macros.py
@@ -203,8 +203,12 @@ def run_macro(macro_name: str, *, trigger: str = "manual") -> dict:
 		frappe.throw(_(_BLOCK_MESSAGE.get(blocked, "This macro cannot run right now.")))
 
 	# Fresh conversation titled after the macro, seeded with an intro so the
-	# transcript reads as a self-contained run.
-	conv = frappe.get_doc({"doctype": CONV, "title": doc.macro_name[:140], "status": "Active"})
+	# transcript reads as a self-contained run. agent_initiated: that run log is
+	# not a chat session the user chose to start (and unlike skip_confirmation,
+	# this marker is NOT cleared when the run ends).
+	conv = frappe.get_doc(
+		{"doctype": CONV, "title": doc.macro_name[:140], "status": "Active", "agent_initiated": 1}
+	)
 	conv.flags.ignore_permissions = True
 	conv.insert()
 	intro = frappe.get_doc(

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -584,6 +584,7 @@ def summarize_macro(name: str) -> dict:
 			"doctype": "Jarvis Conversation",
 			"title": f"Merge: {doc.macro_name}"[:140],
 			"status": "Active",  # enqueue against Active; hidden right after
+			"agent_initiated": 1,  # a merge run log, not a chat the user started
 		}
 	)
 	conv.flags.ignore_permissions = True

--- a/jarvis/chat/proactive.py
+++ b/jarvis/chat/proactive.py
@@ -31,7 +31,8 @@ def start_conversation(message: str, *, title: str | None = None, user: str | No
 		frappe.throw("message is required")
 	title = (title or "Message from Jarvis")[:140]
 
-	conv = frappe.get_doc({"doctype": CONV, "title": title, "status": "Active"})
+	# agent_initiated: Jarvis opened this thread; the user did not ask for it.
+	conv = frappe.get_doc({"doctype": CONV, "title": title, "status": "Active", "agent_initiated": 1})
 	conv.flags.ignore_permissions = True
 	conv.insert()
 

--- a/jarvis/chat/settlement.py
+++ b/jarvis/chat/settlement.py
@@ -160,6 +160,11 @@ def invoke_settlement(
 
 	frappe.db.commit()  # slot released; the NEXT turn can be promoted
 
+	# The maintained per-conversation turn counter that drives the once-per-session
+	# feedback popup. Runs BEFORE the terminal publish so the client's
+	# ``session_feedback_status`` call on ``run:end`` already sees this turn counted.
+	_bump_turn_count(conversation, run_id)
+
 	# S5 — authoritative fenced terminal event, ONLY after the winning commit. CDX-3:
 	# the terminal carries pump_epoch so the client permanently blocks any later
 	# lower-epoch straggler (a stale pump's late delta / run:start) for this turn. CDX-12:
@@ -185,6 +190,101 @@ def invoke_settlement(
 
 	# S6 — enqueue enrichment (idempotent per (turn, effect_name); force-done at 3).
 	deps.enqueue_finalize(run_id, relay_target_id)
+
+
+def _is_hidden_turn(run_id: str) -> bool:
+	"""True when this turn's SEED user message is hidden from the transcript - an
+	internal system prompt rather than something a human typed.
+
+	``chat.api.enqueue_continuation`` is the ONLY producer that passes
+	``hidden=True`` today (checked: macro steps and app-learning prompts call
+	``_enqueue_turn`` WITHOUT it - those conversations are excluded by
+	``agent_initiated`` instead). Every human Apply/Confirm click dispatches such a
+	continuation, and it rides this same pump path, so without this guard ONE user
+	action (send a message that stages a write, then click Apply) counts as TWO
+	turns and the popup fires at roughly half the intended engagement depth.
+
+	``hidden`` lives on the seed Message, not on the Turn row, so this is a
+	two-table read - one statement via ``frappe.qb`` with an explicit join (the
+	multi-table read rule), two primary-key seeks. A turn with no seed message (a
+	recovered / synthesised terminal) yields no row and counts as a normal turn."""
+	t = frappe.qb.DocType(TURN)
+	m = frappe.qb.DocType(MSG)
+	rows = (
+		frappe.qb.from_(t).inner_join(m).on(m.name == t.seed_message).select(m.hidden).where(t.name == run_id)
+	).run()
+	return bool(rows and rows[0][0])
+
+
+def _bump_turn_count(conversation: str, run_id: str) -> None:
+	"""Advance ``Jarvis Conversation.turn_count`` by one for a settled turn.
+
+	O(1) indexed single-row UPDATE, never a ``COUNT(*)`` over ``tabJarvis Chat
+	Message``: this is the highest-frequency path the session-feedback feature
+	touches (every assistant reply, every conversation, fleet-wide), so the
+	popup's trigger check must be a plain integer read, not a scan. Same shape as
+	``greeting.increment_new_chat_count`` - an ATOMIC ``col = col + 1`` rather
+	than a read-modify-write, so two settlements racing on one conversation
+	(reconcile + terminal) can never lose an increment.
+
+	Three exclusions, so the counter measures HUMAN engagement and nothing else
+	(spec: File Box and agent-initiated conversations are excluded from turn
+	counting):
+	  * ``file_box=0`` - an unattended drop, never a chat session;
+	  * ``agent_initiated=0`` - a macro / merge / app-learning / scheduled-audit /
+	    proactive / act-on-a-finding run log the user did not open;
+	  * ``_is_hidden_turn`` - a confirmation continuation, which is part of the
+	    user's PREVIOUS action, not a new turn.
+	The first two ride the same indexed lookup and cost nothing extra; a 0-row
+	update is the intended outcome there, so the rowcount is not consulted. The
+	third is checked FIRST so an excluded turn skips the UPDATE and its commit
+	entirely.
+
+	DELIBERATELY its OWN transaction, AFTER the settlement commit above, NOT
+	inside the fenced settlement txn. ``Jarvis Conversation`` is rank 2 in the
+	canonical lock order (control -> conversation -> turn -> message, OAR-6) and
+	the settlement txn already holds turn (rank 3) and message (rank 4) row locks;
+	taking a conversation lock there would invert against
+	``admission.accept_or_queue`` (shard -> conversation -> turn) and could
+	deadlock a concurrent send. The codebase already draws this line explicitly:
+	``admission._sweep_age_out`` and the user-cancel path both COMMIT their turn
+	CAS before calling ``_write_cancel_marker``, which takes the conversation
+	lock. This txn holds exactly one row lock and never waits while holding
+	another, so it cannot be part of a cycle.
+
+	Cost of the split: a crash between the settlement commit and this bump
+	undercounts one turn (a re-settle returns early on the already-advanced
+	state). Acceptable - the counter is an advisory engagement signal, and the
+	popup simply fires one turn later.
+
+	NEVER raises: a failed bump must not cost the turn its terminal publish or
+	its finalize enqueue, and must not leave an open txn/row lock across the
+	realtime publish that follows."""
+	try:
+		if _is_hidden_turn(run_id):
+			return
+		frappe.db.sql(
+			f"""UPDATE `tab{CONV}` SET turn_count = turn_count + 1
+			WHERE name=%(c)s AND file_box=0 AND agent_initiated=0""",
+			{"c": conversation},
+		)
+		# Own short transaction (see above): commit immediately so the conversation
+		# row lock is released before the publish, and is never held across it.
+		frappe.db.commit()
+	except Exception:
+		# Guarded like turn_state.lease_lost_exit's: on a connection-level fault the
+		# rollback itself can raise, and "never raises" has to hold literally.
+		try:
+			frappe.db.rollback()
+		except Exception:
+			pass
+		# Same guard on the error log: it INSERTs an Error Log row over the very
+		# connection that just failed, so during a DB outage it raises too, and an
+		# escape here would cost the turn its run:end publish and finalize enqueue.
+		try:
+			frappe.log_error(title="settlement.bump_turn_count", message=frappe.get_traceback())
+		except Exception:
+			pass
 
 
 def _extra_with_pending(extra: dict, owner: str | None, conversation: str) -> dict:

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -11,6 +11,7 @@
     "seq",
     "role",
     "content",
+    "via_voice",
     "streaming",
     "error",
     "recovering",
@@ -64,6 +65,14 @@
       "fieldname": "content",
       "fieldtype": "Long Text",
       "label": "Content"
+    },
+    {
+      "fieldname": "via_voice",
+      "fieldtype": "Check",
+      "label": "Via Voice",
+      "default": 0,
+      "depends_on": "eval:doc.role=='user'",
+      "description": "Set when this message's text came from mic dictation rather than typing. No audio or transcript-origin metadata beyond this flag."
     },
     {
       "fieldname": "streaming",

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -19,7 +19,10 @@
   "auto_expired",
   "expired_at",
   "origin_page",
-  "compacting_since"
+  "compacting_since",
+  "agent_initiated",
+  "turn_count",
+  "session_feedback_asked_at"
  ],
  "fields": [
   {
@@ -169,6 +172,35 @@
    "label": "Compacting Since",
    "hidden": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "agent_initiated",
+   "fieldtype": "Check",
+   "label": "Agent-initiated conversation",
+   "default": "0",
+   "hidden": 1,
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "Set at insert by the server-side producers that open a conversation the user did not ask for: macro runs, macro merges, app-learning runs, scheduled agent audits, proactive messages, and the act-on-a-finding chat. Such a conversation is a run log the user may reply to, not a chat session they chose to start, so it is excluded from turn counting and from the once-per-session feedback popup (spec: \"agent-initiated conversations are excluded from both\"). Distinct from skip_confirmation, which is armed-macro-only and is cleared when the run ends. Server-set only."
+  },
+  {
+   "fieldname": "turn_count",
+   "fieldtype": "Int",
+   "label": "Turn Count",
+   "default": "0",
+   "hidden": 1,
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "Maintained counter, incremented once per settled user-visible turn by jarvis.chat.settlement._bump_turn_count. NOT a live COUNT(*): the once-per-session feedback trigger reads it after every assistant reply, fleet-wide, so it must never scan tabJarvis Chat Message. Stays 0 on file_box and agent_initiated conversations, and does not count a turn whose seed message is hidden (a confirmation continuation or a macro step). Server-set only."
+  },
+  {
+   "fieldname": "session_feedback_asked_at",
+   "fieldtype": "Datetime",
+   "label": "Session Feedback Asked At",
+   "hidden": 1,
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "Set once the once-per-session feedback popup has been answered or skipped for this conversation, by jarvis.chat.feedback.submit_session_feedback. Server-side (not localStorage) so the \"asked once\" guarantee survives a reload and a second tab. Server-set only."
   }
  ],
  "permissions": [

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -18,6 +18,8 @@
     "business_greeting_state",
     "business_greeting_chat_count",
     "business_greeting_hidden_at_count",
+    "pulse_last_period_key",
+    "pulse_offer_count",
     "sidebar_order",
     "prompt_suggestions",
     "prompt_suggestions_at",
@@ -120,6 +122,25 @@
       "read_only": 1,
       "no_copy": 1,
       "description": "Merged from Jarvis User Preference. Chat count at which the card was last 'Maybe later'-ed; keeps a refresh from re-showing it. Permlevel 1: server-owned (jarvis.chat.greeting), read-only to a Jarvis User."
+    },
+    {
+      "fieldname": "pulse_last_period_key",
+      "fieldtype": "Data",
+      "label": "Pulse Last Period Key",
+      "permlevel": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Value of jarvis.chat.usage.current_period_key('Monthly') the last time the periodic business-pulse survey was offered or answered for this user, e.g. 'M:2026-09'. A key different from the current one means a new period: the offer count restarts. Permlevel 1: server-owned app state (jarvis.chat.feedback.pulse_context / submit_pulse_feedback write it through raw db calls that bypass permlevel), read-only to a Jarvis User."
+    },
+    {
+      "fieldname": "pulse_offer_count",
+      "fieldtype": "Int",
+      "label": "Pulse Offer Count",
+      "default": "0",
+      "permlevel": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Offers of the business-pulse survey already shown in the period named by pulse_last_period_key, capped at jarvis.chat.feedback.PULSE_MAX_OFFERS (3) so 'Maybe later' re-asks a couple of times and then goes quiet. Answering the survey stores the cap outright, which is what makes 'answered' and 'nagged enough' the same quiet state. Permlevel 1: server-owned, read-only to a Jarvis User."
     },
     {
       "fieldname": "sidebar_order",

--- a/jarvis/learning/app_analysis.py
+++ b/jarvis/learning/app_analysis.py
@@ -728,6 +728,7 @@ def start_run(run_name: str) -> None:
 				"doctype": CONV,
 				"title": f"App learning: {run.app}"[:140],
 				"status": "Active",
+				"agent_initiated": 1,  # an unattended run log, not a chat session
 			}
 		)
 		conv.flags.ignore_permissions = True

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -330,6 +330,63 @@
 								</div>
 								<div class="jvp-m-bot jv-md" v-html="renderReply(m.content)"></div>
 							</div>
+							<div v-if="fbFor === m.name" class="jvp-fb">
+								<div v-if="fbState === 'idle'" class="jvp-fb-pills">
+									<span class="jvp-fb-q">Was this helpful?</span>
+									<button
+										type="button"
+										class="jvp-fb-pill"
+										@click="fbUp(m.name)"
+									>
+										<svg
+											viewBox="0 0 24 24"
+											fill="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												d="M9 21h8.2a2 2 0 0 0 1.96-1.6l1.4-7A2 2 0 0 0 18.6 10H14V5a2.5 2.5 0 0 0-2.5-2.5L8 11v10zM2 11h4v10H2z"
+											/></svg
+										>Yes
+									</button>
+									<button
+										type="button"
+										class="jvp-fb-pill"
+										@click="fbNo(m.name)"
+									>
+										<svg
+											viewBox="0 0 24 24"
+											fill="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												d="M15 3H6.8a2 2 0 0 0-1.96 1.6l-1.4 7A2 2 0 0 0 5.4 14H10v5a2.5 2.5 0 0 0 2.5 2.5L16 13V3zM22 3h-4v10h4z"
+											/></svg
+										>No
+									</button>
+								</div>
+								<div v-else-if="fbState === 'comment'" class="jvp-fb-cmt">
+									<textarea
+										v-model="fbNote"
+										class="jvp-fb-ta"
+										rows="2"
+										maxlength="1000"
+										placeholder="What went wrong? (optional)"
+									></textarea>
+									<div class="jvp-fb-actions">
+										<button
+											type="button"
+											class="jvp-fb-send"
+											@click="fbSend(m.name)"
+										>
+											Send
+										</button>
+										<button type="button" class="jvp-fb-skip" @click="fbSkip">
+											Skip
+										</button>
+									</div>
+								</div>
+								<div v-else class="jvp-fb-done">Thanks for the feedback</div>
+							</div>
 						</template>
 
 						<div v-if="stream.live && stream.live.text" class="jvp-row">
@@ -688,7 +745,9 @@ import {
 	getChatUiSettings,
 	isReadyForChat,
 	resyncLlm,
+	submitFeedback,
 } from "./panel_api.mjs";
+import { shouldOfferFeedback, markRated, markIgnored } from "./feedback_gate.mjs";
 
 const props = defineProps({
 	open: { type: Boolean, default: false },
@@ -1012,6 +1071,71 @@ const rootStyle = computed(() => {
 // Tool rows and empty shells are filtered out: this panel is text-only, and
 // the raw list is mostly machine chatter (see chat_stream.visibleMessages).
 const shownMessages = computed(() => visibleMessages(messages.value));
+
+// ---- post-reply feedback pills (feedback_gate decides IF/when they appear) ----
+const fbFor = ref(null); // message name currently showing the pills
+const fbState = ref("idle"); // idle | comment | done
+const fbNote = ref("");
+const fbRated = ref(false);
+const fbSeen = new Set(); // message names already run through the gate
+let fbAwaiting = false; // a user-initiated turn is in flight
+function offerFeedbackFor(m) {
+	if (!m || m.role !== "assistant" || m.streaming || m.error) return;
+	if (fbSeen.has(m.name)) return;
+	fbSeen.add(m.name);
+	if (shouldOfferFeedback(Number(m.reply_duration_ms || 0))) {
+		fbFor.value = m.name;
+		fbState.value = "idle";
+		fbNote.value = "";
+		fbRated.value = false;
+	}
+}
+watch(shownMessages, (list) => {
+	// Only after a turn the user just sent settles as an assistant reply - never
+	// on history load (fbAwaiting is false then).
+	if (!fbAwaiting) return;
+	const last = list[list.length - 1];
+	if (last && last.role === "assistant" && !last.streaming) {
+		fbAwaiting = false;
+		offerFeedbackFor(last);
+	}
+});
+function fbCommit(name, rating, note) {
+	fbRated.value = true;
+	markRated();
+	submitFeedback(name, rating, note || "").catch(() => {});
+}
+function fbDone() {
+	fbState.value = "done";
+	setTimeout(() => {
+		fbFor.value = null;
+		fbState.value = "idle";
+		fbNote.value = "";
+	}, 1600);
+}
+function fbUp(name) {
+	fbCommit(name, "up", "");
+	fbDone();
+}
+function fbNo(name) {
+	fbCommit(name, "down", ""); // commit the down; note folds in on Send
+	fbState.value = "comment";
+}
+function fbSend(name) {
+	const t = (fbNote.value || "").trim();
+	if (t) fbCommit(name, "down", t);
+	fbDone();
+}
+function fbSkip() {
+	fbDone();
+}
+function dismissFeedback() {
+	if (!fbFor.value) return;
+	if (!fbRated.value) markIgnored();
+	fbFor.value = null;
+	fbState.value = "idle";
+	fbNote.value = "";
+}
 // Whitelabel: the desk widget reads branding from bootinfo (set_jarvis_boot),
 // synchronously so there's no flash. Blank => Jarvis defaults.
 const brandName = (window.frappe?.boot?.jarvis_agent_name || "").trim() || "Jarvis";
@@ -1467,6 +1591,8 @@ async function send() {
 	const atts = attachments.value.slice();
 	if ((!text && !atts.length) || sending.value || stream.value.live) return;
 	sending.value = true;
+	dismissFeedback(); // a new turn clears any pending feedback pills
+	fbAwaiting = true; // watch shownMessages for this turn's reply
 	loadError.value = "";
 	// A new attempt supersedes the previous failure's notice.
 	clearTurnError();
@@ -2472,6 +2598,94 @@ defineExpose({ load, startNewChat, convId });
 	line-height: 1.5;
 	color: var(--jv-ink);
 	overflow-wrap: anywhere;
+}
+
+/* post-reply feedback pills (mini widget) */
+.jvp-fb {
+	margin: 8px 0 2px 36px;
+}
+.jvp-fb-pills {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 7px;
+}
+.jvp-fb-q {
+	font-size: 12px;
+	color: var(--jv-ink-2);
+}
+.jvp-fb-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	padding: 4px 10px;
+	border-radius: 20px;
+	border: 1px solid var(--jv-rule-2);
+	color: var(--jv-accent);
+	background: var(--jv-chip-3);
+	transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.jvp-fb-pill svg {
+	width: 13px;
+	height: 13px;
+}
+.jvp-fb-pill:hover {
+	background: var(--jv-accent);
+	color: #fff;
+	border-color: var(--jv-accent);
+}
+.jvp-fb-cmt {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+	max-width: calc(100% - 36px);
+}
+.jvp-fb-ta {
+	width: 100%;
+	resize: vertical;
+	min-height: 46px;
+	font-family: inherit;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--jv-ink);
+	background: var(--jv-comp-bg);
+	border: 1px solid var(--jv-comp-bd);
+	border-radius: 10px;
+	padding: 7px 9px;
+	outline: none;
+}
+.jvp-fb-ta:focus {
+	border-color: var(--jv-accent);
+}
+.jvp-fb-actions {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+}
+.jvp-fb-send {
+	font-size: 12px;
+	font-weight: 600;
+	color: #fff;
+	background: var(--jv-grad);
+	border: 0;
+	border-radius: 8px;
+	padding: 5px 13px;
+	cursor: pointer;
+}
+.jvp-fb-skip {
+	font-size: 12px;
+	color: var(--jv-ink-3);
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+}
+.jvp-fb-done {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--jv-accent);
 }
 
 /* "Open in full chat" chip: stands in for content this panel can't draw

--- a/jarvis/public/js/jarvis_chat/widget/feedback_gate.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/feedback_gate.mjs
@@ -1,0 +1,90 @@
+// Client-side throttle for the mini-widget feedback pills. Mirrors the main
+// SPA's lib/feedbackGate.js and shares its localStorage key, so the per-day caps
+// are unified across both chat surfaces (a user who rates in the SPA won't also
+// be nagged in the widget the same day). Keep the two in sync if either changes.
+
+const KEY = "jvChatFeedback.v1";
+
+export const FEEDBACK_MIN_MS = 60000; // only genuinely long replies (> 1 min)
+
+const SHOW_PROB = 1 / 3;
+const COOLDOWN_REPLIES = 5;
+const SESSION_CAP = 2;
+const IGNORE_CAP = 2;
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function fresh() {
+  return {
+    day: today(),
+    n: 0,
+    lastShown: null,
+    shown: 0,
+    rated: false,
+    ignores: 0,
+    stopped: false,
+  };
+}
+
+function load() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) || "null");
+    if (!raw || raw.day !== today()) return fresh();
+    return {
+      day: raw.day,
+      n: raw.n | 0,
+      lastShown: raw.lastShown == null ? null : raw.lastShown | 0,
+      shown: raw.shown | 0,
+      rated: !!raw.rated,
+      ignores: raw.ignores | 0,
+      stopped: !!raw.stopped,
+    };
+  } catch {
+    return fresh();
+  }
+}
+
+function save(s) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch {
+    /* storage disabled - degrade to "never show" */
+  }
+}
+
+export function shouldOfferFeedback(durationMs) {
+  const s = load();
+  s.n += 1;
+  let show = false;
+  const cooldownOk =
+    s.lastShown === null || s.n - s.lastShown >= COOLDOWN_REPLIES;
+  if (
+    !s.stopped &&
+    !s.rated &&
+    s.shown < SESSION_CAP &&
+    Number(durationMs) >= FEEDBACK_MIN_MS &&
+    cooldownOk &&
+    Math.random() < SHOW_PROB
+  ) {
+    show = true;
+    s.shown += 1;
+    s.lastShown = s.n;
+  }
+  save(s);
+  return show;
+}
+
+export function markRated() {
+  const s = load();
+  s.rated = true;
+  save(s);
+}
+
+export function markIgnored() {
+  const s = load();
+  s.ignores += 1;
+  if (s.ignores >= IGNORE_CAP) s.stopped = true;
+  save(s);
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -106,6 +106,15 @@ export async function transcribeAudio(blob, durationS) {
 export const stopRun = (conversation, runId) =>
   call(CHAT + "stop_run", { conversation, run_id: runId || "" });
 
+// Post-reply feedback: a thumbs up/down (+ optional note on a down) on one
+// assistant reply. Best-effort - the bench forwards it to the admin dashboard.
+export const submitFeedback = (messageId, rating, note) =>
+  call("jarvis.chat.feedback.submit_feedback", {
+    message_id: messageId,
+    rating,
+    note: note || "",
+  });
+
 // Resolves a write-confirmation gate raised by an `action:pending` frame.
 export const confirmTool = (token, conversation) =>
   call(ACTIONS + "confirm_tool", { token, conversation: conversation || "" });

--- a/jarvis/tests/test_admin_client_feedback_push.py
+++ b/jarvis/tests/test_admin_client_feedback_push.py
@@ -1,0 +1,48 @@
+"""Tests for admin_client.push_session_feedback / push_pulse_feedback.
+
+Both mirror push_chat_feedback's shape (POST {"item": item} to an admin
+endpoint path) with one deliberate difference: a SHORT timeout, because both
+run synchronously inside a customer web request. _post is mocked so these
+never hit a real admin.
+"""
+
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import admin_client
+
+
+class TestAdminClientFeedbackPush(FrappeTestCase):
+	@patch.object(admin_client, "_post")
+	def test_push_session_feedback_posts_to_correct_path(self, mock_post):
+		mock_post.return_value = {"ok": True}
+		admin_client.push_session_feedback({"kind": "Session"})
+		mock_post.assert_called_once()
+		_, kwargs = mock_post.call_args
+		self.assertIn("ingest_session_feedback", kwargs["path"])
+		self.assertEqual(kwargs["body"], {"item": {"kind": "Session"}})
+
+	@patch.object(admin_client, "_post")
+	def test_push_pulse_feedback_posts_to_correct_path(self, mock_post):
+		mock_post.return_value = {"ok": True}
+		admin_client.push_pulse_feedback({"kind": "Pulse"})
+		mock_post.assert_called_once()
+		_, kwargs = mock_post.call_args
+		self.assertIn("ingest_pulse_feedback", kwargs["path"])
+		self.assertEqual(kwargs["body"], {"item": {"kind": "Pulse"}})
+
+	@patch.object(admin_client, "_post")
+	def test_both_pushes_use_a_short_timeout_not_the_150s_default(self, mock_post):
+		"""Both are called synchronously from a whitelisted submit endpoint, so an
+		admin that hangs rather than refuses would otherwise pin a customer web
+		worker for DEFAULT_TIMEOUT_S (2.5 minutes) per submit."""
+		mock_post.return_value = {"ok": True}
+		for push in (admin_client.push_session_feedback, admin_client.push_pulse_feedback):
+			with self.subTest(push=push.__name__):
+				mock_post.reset_mock()
+				push({"kind": "x"})
+				_, kwargs = mock_post.call_args
+				self.assertEqual(kwargs["timeout_s"], admin_client._FEEDBACK_TIMEOUT_S)
+				self.assertLess(kwargs["timeout_s"], admin_client.DEFAULT_TIMEOUT_S)
+				self.assertLessEqual(kwargs["timeout_s"], 15)

--- a/jarvis/tests/test_chat_feedback.py
+++ b/jarvis/tests/test_chat_feedback.py
@@ -1,0 +1,153 @@
+"""Tests for jarvis.chat.feedback.submit_feedback.
+
+Runs as a dedicated fixture user so cleanups stay scoped to disposable rows.
+The admin forward is mocked (never hits a real admin); these assert the
+server-side derivation, the ownership gate, and the best-effort swallow.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import create_conversation
+from jarvis.chat.feedback import submit_feedback
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TEST_USER = "jarvis-feedback-test@example.com"
+
+_UUID = "12345678-1234-1234-1234-123456789abc"
+_SESSION_KEY = f"agent:main:dashboard:{_UUID}"
+
+
+def _ensure_test_user(user: str = TEST_USER) -> None:
+	if frappe.db.exists("User", user):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": user,
+			"first_name": "Feedback",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	).insert(ignore_permissions=True)
+	doc.add_roles("System Manager")
+	frappe.db.commit()
+
+
+def _delete_conv(name: str) -> None:
+	for child in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
+		frappe.delete_doc(MSG, child, ignore_permissions=True, force=True)
+	if frappe.db.exists(CONV, name):
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	frappe.db.commit()
+
+
+def _cleanup_user_conversations(user: str = TEST_USER) -> None:
+	for name in frappe.get_all(CONV, filters={"owner": user}, pluck="name"):
+		_delete_conv(name)
+
+
+def _add_msg(conversation, role="assistant", model="gpt-5.5", duration=84000, seq=2):
+	m = frappe.get_doc(
+		{"doctype": MSG, "conversation": conversation, "seq": seq, "role": role, "content": "answer"}
+	).insert(ignore_permissions=True)
+	if role == "assistant":
+		frappe.db.set_value(MSG, m.name, {"model": model, "reply_duration_ms": duration})
+	frappe.db.commit()
+	return m.name
+
+
+class _FeedbackTestCase(FrappeTestCase):
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv = create_conversation()
+		frappe.db.set_value(CONV, self.conv, "session_key", _SESSION_KEY)
+		self.msg = _add_msg(self.conv)
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _item(self, push):
+		push.assert_called_once()
+		return push.call_args.args[0]
+
+
+class TestSubmitFeedback(_FeedbackTestCase):
+	def test_up_forwards_derived_payload(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			res = submit_feedback(message_id=self.msg, rating="up")
+		self.assertEqual(res, {"ok": True})
+		item = self._item(push)
+		self.assertEqual(item["rating"], "up")
+		self.assertEqual(item["message_ref"], self.msg)
+		self.assertEqual(item["conversation_ref"], self.conv)
+		self.assertEqual(item["session_id"], _UUID)  # extracted from composite session_key
+		self.assertEqual(item["model"], "gpt-5.5")
+		self.assertEqual(item["reply_duration_ms"], 84000)
+		self.assertEqual(item["user_ref"], TEST_USER)
+		self.assertEqual(item["note"], "")
+
+	def test_down_keeps_stripped_note(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			submit_feedback(message_id=self.msg, rating="down", note="  too slow  ")
+		item = self._item(push)
+		self.assertEqual(item["rating"], "down")
+		self.assertEqual(item["note"], "too slow")
+
+	def test_up_never_carries_a_note(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			submit_feedback(message_id=self.msg, rating="up", note="should be dropped")
+		self.assertEqual(self._item(push)["note"], "")
+
+	def test_rejects_bad_rating(self):
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			with self.assertRaises(frappe.ValidationError):
+				submit_feedback(message_id=self.msg, rating="meh")
+		push.assert_not_called()
+
+	def test_rejects_non_assistant_message(self):
+		user_msg = _add_msg(self.conv, role="user", seq=1)
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			with self.assertRaises(frappe.ValidationError):
+				submit_feedback(message_id=user_msg, rating="up")
+		push.assert_not_called()
+
+	def test_rejects_missing_message(self):
+		with self.assertRaises(frappe.DoesNotExistError):
+			submit_feedback(message_id="does-not-exist", rating="up")
+
+	def test_rejects_another_users_message(self):
+		frappe.set_user("Administrator")
+		other = create_conversation()
+		other_msg = _add_msg(other)
+		self.addCleanup(_delete_conv, other)
+		frappe.set_user(TEST_USER)
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			with self.assertRaises(frappe.PermissionError):
+				submit_feedback(message_id=other_msg, rating="up")
+		push.assert_not_called()
+
+	def test_forward_failure_is_swallowed(self):
+		with patch("jarvis.admin_client.push_chat_feedback", side_effect=RuntimeError("admin down")):
+			res = submit_feedback(message_id=self.msg, rating="up")
+		self.assertEqual(res, {"ok": True})  # best-effort: the tap never surfaces the error
+
+	def test_missing_session_key_still_records(self):
+		frappe.db.set_value(CONV, self.conv, "session_key", None)
+		with patch("jarvis.admin_client.push_chat_feedback") as push:
+			submit_feedback(message_id=self.msg, rating="up")
+		self.assertEqual(self._item(push)["session_id"], "")  # link best-effort, rating still forwarded
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_feature_usage.py
+++ b/jarvis/tests/test_feature_usage.py
@@ -204,6 +204,8 @@ class TestGetUsedFeatures(FrappeTestCase):
 		self.assertIn("triggers_connectors", get_used_features(USER, self.since))
 
 	def test_connector_log_detected(self):
+		if not frappe.db.exists("DocType", "Jarvis Connector Log"):
+			self.skipTest("connectors DocType is not on this release line")
 		frappe.get_doc(
 			{
 				"doctype": "Jarvis Connector Log",

--- a/jarvis/tests/test_feature_usage.py
+++ b/jarvis/tests/test_feature_usage.py
@@ -1,0 +1,306 @@
+"""Coverage for ``jarvis.chat.feature_usage.get_used_features`` - one positive
+test per tracked feature, the "nothing used" case, the ``since`` cutoff, and
+the "one broken source must not blank the survey" guarantee.
+
+Ownership note that applies to nearly every fixture here: Frappe's
+``set_user_and_timestamp`` overwrites ``owner`` with the session user on EVERY
+insert, so an ``"owner"`` key in a ``get_doc`` payload is silently discarded.
+Every row that has to belong to the test user is therefore re-owned with
+``frappe.db.set_value(..., update_modified=False)`` afterwards, the same way
+``test_chat_mining`` and ``test_agent_run_steps`` do it.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+import jarvis.chat.feature_usage as fu
+from jarvis.chat.feature_usage import get_used_features
+
+USER = "test_feature_usage@example.com"
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+
+
+class TestGetUsedFeatures(FrappeTestCase):
+	def setUp(self):
+		self.addCleanup(frappe.db.rollback)
+		if not frappe.db.exists("User", USER):
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": USER,
+					"first_name": "Feature Usage Test",
+					"send_welcome_email": 0,
+					"enabled": 1,
+					"user_type": "System User",
+				}
+			)
+			user.flags.ignore_permissions = True
+			user.insert(ignore_permissions=True)
+		self.since = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-7)
+
+	# ---------------------------------------------------------------- helpers
+	def _own(self, doctype: str, name: str) -> str:
+		"""Hand a just-inserted row to USER (see the module docstring)."""
+		frappe.db.set_value(doctype, name, "owner", USER, update_modified=False)
+		return name
+
+	def _conv(self, file_box=0, **kwargs) -> str:
+		doc = frappe.get_doc({"doctype": CONV, "title": "feature usage test", **kwargs})
+		doc.insert(ignore_permissions=True)
+		if file_box:
+			# ``file_box`` 0 -> 1 is admin-gated in the controller; the real
+			# enabler (filebox.drop_file) writes it with db.set_value too.
+			frappe.db.set_value(CONV, doc.name, "file_box", 1, update_modified=False)
+		return self._own(CONV, doc.name)
+
+	def _msg(self, conversation: str, seq: int, role: str, *, own=False, **kwargs) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conversation,
+				"seq": seq,
+				"role": role,
+				**kwargs,
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		return self._own(MSG, doc.name) if own else doc.name
+
+	def _backdate(self, doctype: str, name: str, days: int) -> None:
+		old = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=days)
+		frappe.db.set_value(doctype, name, "creation", old, update_modified=False)
+
+	# -------------------------------------------------------------- file box
+	def test_file_box_detected(self):
+		self._conv(file_box=1)
+		self.assertIn("file_box", get_used_features(USER, self.since))
+
+	def test_file_box_outside_window_not_detected(self):
+		conv = self._conv(file_box=1)
+		self._backdate(CONV, conv, days=-30)
+		self.assertNotIn("file_box", get_used_features(USER, self.since))
+
+	def test_another_users_file_box_not_detected(self):
+		doc = frappe.get_doc({"doctype": CONV, "title": "someone else", "file_box": 0})
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(CONV, doc.name, "file_box", 1, update_modified=False)
+		self.assertNotIn("file_box", get_used_features(USER, self.since))
+
+	# ------------------------------------------------------ dashboard builder
+	def test_dashboard_builder_detected_via_tool_message(self):
+		conv = self._conv()
+		# BARE registry id: jarvis__* tool receipts are persisted by
+		# jarvis.api.call_tool, which is dispatched on bare names, and the chat
+		# worker explicitly skips persisting a duplicate jarvis__ row.
+		self._msg(
+			conv,
+			1,
+			"tool",
+			tool_name="save_dashboard",
+			content="save_dashboard → completed",
+		)
+		self.assertIn("dashboard_builder", get_used_features(USER, self.since))
+
+	def test_dashboard_builder_ignores_unrelated_tools(self):
+		conv = self._conv()
+		self._msg(conv, 1, "tool", tool_name="get_list", content="get_list → completed")
+		self.assertNotIn("dashboard_builder", get_used_features(USER, self.since))
+
+	# ---------------------------------------------------------------- skills
+	def _skill(self, slug: str) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": "Jarvis Custom Skill",
+				"skill_name": slug,
+				"description": "feature usage test skill",
+				"instructions": "Do the thing.",
+				"enabled": 1,
+				"scope": "User",
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		return self._own("Jarvis Custom Skill", doc.name)
+
+	def test_skills_detected_from_message_content(self):
+		conv = self._conv()
+		self._skill("recon-helper")
+		self._msg(
+			conv,
+			1,
+			"user",
+			hidden=0,
+			content="hey /recon-helper can you check this",
+			own=True,
+		)
+		self.assertIn("skills", get_used_features(USER, self.since))
+
+	def test_skills_not_detected_for_unknown_slug(self):
+		conv = self._conv()
+		self._msg(
+			conv,
+			1,
+			"user",
+			hidden=0,
+			content="check /this-is-not-a-real-skill please",
+			own=True,
+		)
+		self.assertNotIn("skills", get_used_features(USER, self.since))
+
+	def test_skills_reports_the_newest_invoking_message(self):
+		"""The joined-text gate must not cost per-row accuracy: with one real
+		and one bogus slug present, the timestamp comes from the real one."""
+		conv = self._conv()
+		self._skill("recon-helper")
+		older = self._msg(conv, 1, "user", hidden=0, content="run /recon-helper", own=True)
+		self._msg(conv, 2, "user", hidden=0, content="and /not-a-skill too", own=True)
+		self._backdate(MSG, older, days=-1)
+		result = get_used_features(USER, self.since)
+		self.assertIn("skills", result)
+		self.assertEqual(result["skills"], str(frappe.db.get_value(MSG, older, "creation")))
+
+	def test_skills_ignores_hidden_continuation_messages(self):
+		conv = self._conv()
+		self._skill("recon-helper")
+		self._msg(conv, 1, "user", hidden=1, content="run /recon-helper", own=True)
+		self.assertNotIn("skills", get_used_features(USER, self.since))
+
+	# ---------------------------------------------------------------- macros
+	def test_macros_detected(self):
+		conv = self._conv()
+		doc = frappe.get_doc(
+			{
+				"doctype": "Jarvis Macro Run",
+				"conversation": conv,
+				"status": "completed",
+				"started_at": frappe.utils.now_datetime(),
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		self._own("Jarvis Macro Run", doc.name)
+		self.assertIn("macros", get_used_features(USER, self.since))
+
+	def test_macros_detected_when_the_conversation_link_was_nulled(self):
+		"""A deleted conversation nulls Jarvis Macro Run.conversation, which is
+		exactly why this source reads the run's own owner instead of joining."""
+		doc = frappe.get_doc({"doctype": "Jarvis Macro Run", "status": "completed"})
+		doc.insert(ignore_permissions=True)
+		self._own("Jarvis Macro Run", doc.name)
+		self.assertIn("macros", get_used_features(USER, self.since))
+
+	# --------------------------------------------------- triggers/connectors
+	def test_trigger_activity_detected(self):
+		frappe.get_doc(
+			{
+				"doctype": "Jarvis Trigger Activity",
+				"trigger": "t-feature-usage",
+				"status": "Success",
+				"event_user": USER,
+			}
+		).insert(ignore_permissions=True)
+		self.assertIn("triggers_connectors", get_used_features(USER, self.since))
+
+	def test_connector_log_detected(self):
+		frappe.get_doc(
+			{
+				"doctype": "Jarvis Connector Log",
+				"connector": "c-feature-usage",
+				"user": USER,
+				"action": "call",
+				"status": "Success",
+			}
+		).insert(ignore_permissions=True)
+		self.assertIn("triggers_connectors", get_used_features(USER, self.since))
+
+	# ------------------------------------------------------------ voice chat
+	def test_voice_note_detected(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Jarvis Voice Note",
+				"kind": "Voice",
+				"transcript": "remember to invoice acme",
+				"context_type": "Business",
+				"status": "New",
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		self._own("Jarvis Voice Note", doc.name)
+		self.assertIn("voice_chat", get_used_features(USER, self.since))
+
+	# ------------------------------------------------------------------ wiki
+	def test_wiki_detected_from_sources_provenance(self):
+		frappe.get_doc(
+			{
+				"doctype": "Jarvis Wiki Page",
+				"slug": "feature-usage-test-page",
+				"title": "Feature usage test page",
+				"page_type": "Process",
+				"scope": "Org",
+				"status": "Active",
+				"sources": frappe.as_json(
+					[{"date": frappe.utils.today(), "kind": "manual", "ref": None, "user": USER}]
+				),
+			}
+		).insert(ignore_permissions=True)
+		self.assertIn("wiki", get_used_features(USER, self.since))
+
+	def test_wiki_not_detected_for_another_users_provenance(self):
+		frappe.get_doc(
+			{
+				"doctype": "Jarvis Wiki Page",
+				"slug": "feature-usage-other-page",
+				"title": "Someone else's page",
+				"page_type": "Process",
+				"scope": "Org",
+				"status": "Active",
+				"sources": frappe.as_json(
+					[
+						{
+							"date": frappe.utils.today(),
+							"kind": "manual",
+							"ref": None,
+							"user": "someone@else.invalid",
+						}
+					]
+				),
+			}
+		).insert(ignore_permissions=True)
+		self.assertNotIn("wiki", get_used_features(USER, self.since))
+
+	def test_wiki_tolerates_a_corrupt_sources_value(self):
+		page = frappe.get_doc(
+			{
+				"doctype": "Jarvis Wiki Page",
+				"slug": "feature-usage-corrupt-page",
+				"title": "Corrupt sources",
+				"page_type": "Process",
+				"scope": "Org",
+				"status": "Active",
+			}
+		)
+		page.insert(ignore_permissions=True)
+		frappe.db.set_value("Jarvis Wiki Page", page.name, "sources", '["not-a-dict"]')
+		self._conv(file_box=1)
+		result = get_used_features(USER, self.since)
+		self.assertNotIn("wiki", result)
+		self.assertIn("file_box", result)
+
+	# ------------------------------------------------------------ aggregates
+	def test_no_features_used_returns_empty_dict(self):
+		self._conv()  # a conversation with no matching signals
+		self.assertEqual(get_used_features(USER, self.since), {})
+
+	def test_blank_arguments_return_empty_dict(self):
+		self._conv(file_box=1)
+		self.assertEqual(get_used_features(USER, None), {})
+		self.assertEqual(get_used_features("", self.since), {})
+
+	def test_one_source_failing_does_not_blank_others(self):
+		self._conv(file_box=1)
+		with patch.object(fu, "_macros", side_effect=RuntimeError("boom")):
+			result = get_used_features(USER, self.since)
+		self.assertIn("file_box", result)
+		self.assertNotIn("macros", result)

--- a/jarvis/tests/test_pulse_feedback.py
+++ b/jarvis/tests/test_pulse_feedback.py
@@ -1,0 +1,372 @@
+"""Tests for the periodic business-pulse survey's backend: the lazy
+period-key gate on ``Jarvis User Settings`` and the two whitelisted endpoints.
+
+Fixture shape mirrors ``test_session_feedback.py`` (a dedicated disposable
+user, real conversations via ``create_conversation``) rather than a
+rollback-only one: the settings row is created by
+``usage.get_or_create_user_settings`` and other tests commit, so every case
+resets the two pulse fields itself instead of trusting a clean row.
+
+The admin forward is always mocked - these never hit a real admin.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.exceptions import FrappeTypeError
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import create_conversation
+from jarvis.chat.feedback import (
+	PULSE_MAX_OFFERS,
+	PULSE_SURVEY_CADENCE,
+	pulse_context,
+	submit_pulse_feedback,
+)
+from jarvis.chat.usage import current_period_key, get_or_create_user_settings
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TURN = "Jarvis Chat Turn"
+SETTINGS = "Jarvis User Settings"
+TEST_USER = "jarvis-pulse-feedback-test@example.com"
+
+_PUSH = "jarvis.admin_client.push_pulse_feedback"
+_FEATURES = "jarvis.chat.feature_usage.get_used_features"
+#: A key that can never be the current one, so the row reads as "last offered
+#: in some earlier period".
+_STALE_KEY = "M:1999-01"
+
+
+def _ensure_test_user(user: str = TEST_USER) -> None:
+	if frappe.db.exists("User", user):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": user,
+			"first_name": "Pulse",
+			"last_name": "Feedback",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	).insert(ignore_permissions=True)
+	doc.add_roles("System Manager")
+	frappe.db.commit()
+
+
+def _delete_conv(name: str) -> None:
+	for turn in frappe.get_all(TURN, filters={"conversation": name}, pluck="name"):
+		frappe.delete_doc(TURN, turn, ignore_permissions=True, force=True)
+	for child in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
+		frappe.delete_doc(MSG, child, ignore_permissions=True, force=True)
+	if frappe.db.exists(CONV, name):
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	frappe.db.commit()
+
+
+def _cleanup_user_conversations(user: str = TEST_USER) -> None:
+	for name in frappe.get_all(CONV, filters={"owner": user}, pluck="name"):
+		_delete_conv(name)
+
+
+class _PulseTestCase(FrappeTestCase):
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.settings = get_or_create_user_settings(TEST_USER).name
+		self._set_pulse(None, 0)
+		# One conversation with a settled turn inside the window, so the "had at
+		# least one turn in the period" gate passes unless a case says otherwise.
+		self.conv = create_conversation()
+		self._set_turns(5)
+
+	def tearDown(self):
+		self._set_pulse(None, 0)
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _set_pulse(self, key, count):
+		frappe.db.set_value(
+			SETTINGS,
+			self.settings,
+			{"pulse_last_period_key": key, "pulse_offer_count": count},
+			update_modified=False,
+		)
+
+	def _pulse(self):
+		return frappe.db.get_value(
+			SETTINGS, self.settings, ["pulse_last_period_key", "pulse_offer_count"], as_dict=True
+		)
+
+	def _set_turns(self, count, *, days_ago=0, conversation=None):
+		frappe.db.set_value(
+			CONV,
+			conversation or self.conv,
+			{
+				"turn_count": count,
+				"last_active_at": frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-days_ago),
+			},
+			update_modified=False,
+		)
+
+
+class TestPulseContext(_PulseTestCase):
+	def test_due_when_never_offered(self):
+		with patch(_FEATURES, return_value={}):
+			result = pulse_context()
+		self.assertTrue(result["due"])
+		self.assertEqual(result["period_key"], current_period_key(PULSE_SURVEY_CADENCE))
+		self.assertTrue(result["period_label"].startswith("This month,"))
+
+	def test_an_offer_stamps_the_current_period_and_counts_one(self):
+		with patch(_FEATURES, return_value={}):
+			pulse_context()
+		row = self._pulse()
+		self.assertEqual(row.pulse_last_period_key, current_period_key(PULSE_SURVEY_CADENCE))
+		self.assertEqual(row.pulse_offer_count, 1)
+
+	def test_maybe_later_re_offers_up_to_the_cap_then_goes_quiet(self):
+		"""'Maybe later' is not recorded anywhere - the survey simply comes back
+		on the next chat opens, three times in all, and then stops nagging."""
+		with patch(_FEATURES, return_value={}):
+			for expected in range(1, PULSE_MAX_OFFERS + 1):
+				self.assertTrue(pulse_context()["due"], f"offer {expected} should be due")
+				self.assertEqual(self._pulse().pulse_offer_count, expected)
+			self.assertFalse(pulse_context()["due"], "capped, so quiet for the rest of the period")
+		self.assertEqual(self._pulse().pulse_offer_count, PULSE_MAX_OFFERS, "the cap is not exceeded")
+
+	def test_a_new_period_resets_the_offer_count(self):
+		"""The cap must RESET on rollover, not merely stop decrementing: a user
+		exhausted last month is due again this month, at count 1."""
+		self._set_pulse(_STALE_KEY, PULSE_MAX_OFFERS)
+		with patch(_FEATURES, return_value={}):
+			self.assertTrue(pulse_context()["due"])
+		row = self._pulse()
+		self.assertEqual(row.pulse_last_period_key, current_period_key(PULSE_SURVEY_CADENCE))
+		self.assertEqual(row.pulse_offer_count, 1)
+
+	def test_capped_never_computes_the_feature_list(self):
+		"""The cheap period-key comparison gates the comparatively expensive
+		feature-usage sweep (spec: performance review)."""
+		self._set_pulse(current_period_key(PULSE_SURVEY_CADENCE), PULSE_MAX_OFFERS)
+		with patch(_FEATURES) as features:
+			self.assertFalse(pulse_context()["due"])
+		features.assert_not_called()
+
+	def test_no_turns_at_all_is_not_due(self):
+		self._set_turns(0)
+		with patch(_FEATURES) as features:
+			self.assertFalse(pulse_context()["due"])
+		features.assert_not_called()
+		self.assertIsNone(self._pulse().pulse_last_period_key, "a non-offer burns nothing")
+
+	def test_turns_only_outside_the_window_are_not_due(self):
+		self._set_turns(50, days_ago=60)
+		with patch(_FEATURES) as features:
+			self.assertFalse(pulse_context()["due"])
+		features.assert_not_called()
+
+	def test_turns_are_summed_across_the_users_conversations(self):
+		"""A user with several shallow conversations still qualifies: the gate is
+		the SUM of turn_count in the window, not any single conversation."""
+		self._set_turns(0)
+		second = create_conversation()
+		self._set_turns(1, conversation=second)
+		with patch(_FEATURES, return_value={}):
+			self.assertTrue(pulse_context()["due"])
+
+	def test_features_offered_may_be_empty_but_the_survey_is_still_due(self):
+		# Stars and the open question are still worth asking; only the chip
+		# question hides client-side when this list is empty.
+		with patch(_FEATURES, return_value={}):
+			result = pulse_context()
+		self.assertTrue(result["due"])
+		self.assertEqual(result["features_offered"], [])
+
+	def test_both_endpoints_are_post_only(self):
+		"""Both WRITE, and Frappe commits only for unsafe methods: reached over
+		GET, pulse_context's offer claim (and a submit's silencing write) would
+		be rolled back silently and the cap would never advance."""
+		for fn in (pulse_context, submit_pulse_feedback):
+			with self.subTest(fn=fn.__name__):
+				self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[fn], ["POST"])
+
+	def test_a_user_with_no_settings_row_yet_is_offered_and_the_row_is_created(self):
+		"""The settings row is created lazily by whichever surface needs it
+		first, so the deciding read must tolerate its absence - and claiming the
+		offer is the one path that creates it."""
+		frappe.delete_doc(SETTINGS, self.settings, ignore_permissions=True, force=True)
+		with patch(_FEATURES, return_value={}):
+			self.assertTrue(pulse_context()["due"])
+		self.settings = get_or_create_user_settings(TEST_USER).name
+		row = self._pulse()
+		self.assertEqual(row.pulse_last_period_key, current_period_key(PULSE_SURVEY_CADENCE))
+		self.assertEqual(row.pulse_offer_count, 1)
+
+	def test_features_offered_are_the_used_keys_in_canonical_order(self):
+		# feature_usage.FEATURES order, not alphabetical: the dialog renders the
+		# chips in the order it receives them, and both endpoints agree on it.
+		with patch(_FEATURES, return_value={"dashboard_builder": "2026-09-01", "file_box": "2026-09-02"}):
+			result = pulse_context()
+		self.assertEqual(result["features_offered"], ["file_box", "dashboard_builder"])
+
+	def test_an_answer_during_the_sweep_is_never_overwritten_by_the_offer(self):
+		"""The reviewer's repro: pulse_context reads count=1, then the (slow)
+		feature sweep runs, and in that window the user answers the survey in
+		another tab, which stores PULSE_MAX_OFFERS. A blind ``count + 1`` write
+		afterwards dragged the answered marker back down to 2 and re-offered a
+		survey already filled in. The offer is a compare-and-set now: it loses,
+		reports not due, and the answered marker stays put."""
+		current = current_period_key(PULSE_SURVEY_CADENCE)
+		self._set_pulse(current, 1)
+
+		def answer_in_another_tab(*_args, **_kwargs):
+			# Exactly what submit_pulse_feedback writes, landing mid-sweep.
+			self._set_pulse(current, PULSE_MAX_OFFERS)
+			return {}
+
+		with patch(_FEATURES, side_effect=answer_in_another_tab):
+			result = pulse_context()
+		self.assertFalse(result["due"], "the offer lost the race and must not fire")
+		row = self._pulse()
+		self.assertEqual(row.pulse_offer_count, PULSE_MAX_OFFERS, "answered marker was not dragged back down")
+		self.assertEqual(row.pulse_last_period_key, current)
+
+	def test_two_chat_opens_racing_burn_exactly_one_offer(self):
+		"""Both tabs read count=0 before either writes. Only the first claim sees
+		rowcount 1; the second reads the row as already moved and reports not
+		due instead of burning a second of the three monthly offers."""
+		current = current_period_key(PULSE_SURVEY_CADENCE)
+
+		def other_tab_claims_first(*_args, **_kwargs):
+			# The concurrent open's claim, landing between this call's read and
+			# its own claim: key stamped, count 0 -> 1.
+			self._set_pulse(current, 1)
+			return {}
+
+		with patch(_FEATURES, side_effect=other_tab_claims_first):
+			result = pulse_context()
+		self.assertFalse(result["due"])
+		self.assertEqual(self._pulse().pulse_offer_count, 1, "one offer burned, not two")
+
+	def test_a_rollover_claim_is_conditional_too(self):
+		"""Same race across a period boundary: the stale-key branch must also
+		lose to a write that landed first, not stamp over it."""
+		self._set_pulse(_STALE_KEY, PULSE_MAX_OFFERS)
+		current = current_period_key(PULSE_SURVEY_CADENCE)
+
+		def answer_lands_first(*_args, **_kwargs):
+			self._set_pulse(current, PULSE_MAX_OFFERS)
+			return {}
+
+		with patch(_FEATURES, side_effect=answer_lands_first):
+			result = pulse_context()
+		self.assertFalse(result["due"])
+		self.assertEqual(self._pulse().pulse_offer_count, PULSE_MAX_OFFERS)
+
+
+class TestSubmitPulseFeedback(_PulseTestCase):
+	def _item(self, push):
+		push.assert_called_once()
+		return push.call_args.args[0]
+
+	def test_forwards_a_derived_payload(self):
+		with patch(_PUSH) as push:
+			res = submit_pulse_feedback(
+				stars=4,
+				features_offered=["file_box", "wiki"],
+				features_selected=["file_box"],
+				use_case_text="  saves us hours a week  ",
+				note="  more charts please  ",
+			)
+		self.assertEqual(res, {"ok": True})
+		item = self._item(push)
+		self.assertEqual(item["kind"], "Pulse")
+		self.assertEqual(item["stars"], 4)
+		self.assertEqual(item["period_key"], current_period_key(PULSE_SURVEY_CADENCE))
+		self.assertEqual(item["features_offered"], ["file_box", "wiki"])
+		self.assertEqual(item["features_selected"], ["file_box"])
+		self.assertEqual(item["use_case_text"], "saves us hours a week")
+		self.assertEqual(item["note"], "more charts please")
+		self.assertEqual(item["user_ref"], TEST_USER)
+
+	def test_accepts_json_encoded_lists_from_the_client(self):
+		# frappe.client passes list args as JSON strings over HTTP.
+		with patch(_PUSH) as push:
+			submit_pulse_feedback(stars=5, features_offered='["wiki"]', features_selected='["wiki"]')
+		item = self._item(push)
+		self.assertEqual(item["features_offered"], ["wiki"])
+		self.assertEqual(item["features_selected"], ["wiki"])
+
+	def test_unknown_feature_keys_are_dropped(self):
+		with patch(_PUSH) as push:
+			submit_pulse_feedback(
+				stars=3, features_offered=["wiki", "not_a_feature", 7], features_selected=["nope"]
+			)
+		item = self._item(push)
+		self.assertEqual(item["features_offered"], ["wiki"])
+		self.assertEqual(item["features_selected"], [])
+
+	def test_rejects_stars_outside_one_to_five(self):
+		# Non-numeric values are rejected too, but by a DIFFERENT layer: under a
+		# request or a test run, @frappe.whitelist wraps the function in
+		# validate_argument_types, so "abc"/None never reach the body and raise
+		# FrappeTypeError (a TypeError) rather than our ValidationError. The
+		# body's own int() guard still matters for non-request callers.
+		for bad in (0, 6, -1, "abc", None):
+			with self.subTest(stars=bad):
+				with patch(_PUSH) as push:
+					with self.assertRaises((frappe.ValidationError, FrappeTypeError)):
+						submit_pulse_feedback(stars=bad, features_offered=[], features_selected=[])
+				push.assert_not_called()
+				self.assertIsNone(
+					self._pulse().pulse_last_period_key, "a rejected submit must not silence the survey"
+				)
+
+	def test_accepts_the_whole_one_to_five_range(self):
+		for stars in range(1, 6):
+			with self.subTest(stars=stars):
+				with patch(_PUSH) as push:
+					submit_pulse_feedback(stars=stars, features_offered=[], features_selected=[])
+				self.assertEqual(self._item(push)["stars"], stars)
+
+	def test_answering_silences_the_survey_for_the_rest_of_the_period(self):
+		with patch(_PUSH):
+			submit_pulse_feedback(stars=5, features_offered=[], features_selected=[])
+		row = self._pulse()
+		self.assertEqual(row.pulse_last_period_key, current_period_key(PULSE_SURVEY_CADENCE))
+		self.assertEqual(row.pulse_offer_count, PULSE_MAX_OFFERS)
+		with patch(_FEATURES) as features:
+			self.assertFalse(pulse_context()["due"])
+		features.assert_not_called()
+
+	def test_answering_does_not_silence_the_next_period(self):
+		with patch(_PUSH):
+			submit_pulse_feedback(stars=5, features_offered=[], features_selected=[])
+		# Simulate the rollover the same way a real month boundary presents it.
+		self._set_pulse(_STALE_KEY, PULSE_MAX_OFFERS)
+		with patch(_FEATURES, return_value={}):
+			self.assertTrue(pulse_context()["due"])
+
+	def test_a_failed_forward_never_surfaces_and_still_silences(self):
+		with patch(_PUSH, side_effect=RuntimeError("admin down")):
+			res = submit_pulse_feedback(stars=2, features_offered=[], features_selected=[])
+		self.assertEqual(res, {"ok": True})
+		self.assertEqual(self._pulse().pulse_offer_count, PULSE_MAX_OFFERS)
+
+	def test_free_text_is_bounded(self):
+		with patch(_PUSH) as push:
+			submit_pulse_feedback(
+				stars=1,
+				features_offered=[],
+				features_selected=[],
+				use_case_text="x" * 5000,
+				note="y" * 5000,
+			)
+		item = self._item(push)
+		self.assertEqual(len(item["use_case_text"]), 1000)
+		self.assertEqual(len(item["note"]), 1000)

--- a/jarvis/tests/test_send_message_voice_flag.py
+++ b/jarvis/tests/test_send_message_voice_flag.py
@@ -1,0 +1,58 @@
+"""Tests for the `via_voice` flag on `Jarvis Chat Message` and the matching
+`voice` param on `jarvis.chat.api.send_message` (2026-09-08 session-feedback
+plan, Task 6).
+
+Mirrors `test_chat_attachments.py`'s fixture pattern: a dedicated test user
+(never Administrator) and `frappe.enqueue` patched out so no real turn runs.
+
+Run ONLY this module (the full suite is destructive on a live dev site):
+    bench --site <site> run-tests --app jarvis \\
+        --module jarvis.tests.test_send_message_voice_flag
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import create_conversation, send_message
+from jarvis.tests.test_chat_api import TEST_USER, _cleanup_user_conversations, _ensure_test_user
+
+MSG = "Jarvis Chat Message"
+
+
+def _send(conv, message="", voice=False):
+	"""Persist a user message without enqueueing a real turn."""
+	with patch("frappe.enqueue"):
+		return send_message(conv, message, voice=voice)
+
+
+class TestSendMessageVoiceFlag(FrappeTestCase):
+	"""Runs as the fixture user (never Administrator) so a run cannot wipe real
+	chat history; only TEST_USER's own conversations are created + cleaned."""
+
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv = create_conversation()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_typed_message_has_via_voice_false(self):
+		res = _send(self.conv, "typed by hand", voice=False)
+		self.assertFalse(bool(frappe.db.get_value(MSG, res["message_id"], "via_voice")))
+
+	def test_dictated_message_has_via_voice_true(self):
+		res = _send(self.conv, "said out loud", voice=True)
+		self.assertTrue(bool(frappe.db.get_value(MSG, res["message_id"], "via_voice")))
+
+	def test_voice_defaults_false_when_param_omitted(self):
+		"""Every existing caller (approvals_api, filebox, agents_api) omits
+		`voice` entirely — it must keep defaulting to false, not error."""
+		with patch("frappe.enqueue"):
+			res = send_message(self.conv, "no voice kwarg at all")
+		self.assertFalse(bool(frappe.db.get_value(MSG, res["message_id"], "via_voice")))

--- a/jarvis/tests/test_session_feedback.py
+++ b/jarvis/tests/test_session_feedback.py
@@ -1,0 +1,341 @@
+"""Tests for the once-per-session feedback popup's backend: the maintained
+``Jarvis Conversation.turn_count`` counter and the two whitelisted endpoints.
+
+Runs as a dedicated fixture user so cleanups stay scoped to disposable rows,
+and mirrors ``test_chat_feedback.py``'s fixture shape rather than a
+rollback-based one: ``settlement._bump_turn_count`` commits its own tiny
+transaction by design, so an ``addCleanup(frappe.db.rollback)`` would be
+hollow. The admin forward is always mocked - these never hit a real admin.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import create_conversation
+from jarvis.chat.feedback import (
+	SESSION_FEEDBACK_TURN_THRESHOLD,
+	session_feedback_status,
+	submit_session_feedback,
+)
+from jarvis.chat.settlement import _bump_turn_count
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TURN = "Jarvis Chat Turn"
+TEST_USER = "jarvis-session-feedback-test@example.com"
+
+_PUSH = "jarvis.admin_client.push_session_feedback"
+
+
+def _ensure_test_user(user: str = TEST_USER) -> None:
+	if frappe.db.exists("User", user):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": user,
+			"first_name": "Session",
+			"last_name": "Feedback",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	).insert(ignore_permissions=True)
+	doc.add_roles("System Manager")
+	frappe.db.commit()
+
+
+def _delete_conv(name: str) -> None:
+	for turn in frappe.get_all(TURN, filters={"conversation": name}, pluck="name"):
+		frappe.delete_doc(TURN, turn, ignore_permissions=True, force=True)
+	for child in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
+		frappe.delete_doc(MSG, child, ignore_permissions=True, force=True)
+	if frappe.db.exists(CONV, name):
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	frappe.db.commit()
+
+
+def _cleanup_user_conversations(user: str = TEST_USER) -> None:
+	for name in frappe.get_all(CONV, filters={"owner": user}, pluck="name"):
+		_delete_conv(name)
+
+
+class _SessionFeedbackTestCase(FrappeTestCase):
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv = create_conversation()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _turn_count(self, conversation=None):
+		return frappe.db.get_value(CONV, conversation or self.conv, "turn_count")
+
+	def _set_turns(self, n, conversation=None):
+		frappe.db.set_value(CONV, conversation or self.conv, "turn_count", n, update_modified=False)
+
+	def _mk_turn(self, run_id, *, hidden=0, conversation=None):
+		"""A settled turn's row plus the seed user message the bump inspects."""
+		conv = conversation or self.conv
+		seed = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conv,
+				# Unique per conversation, the way api._next_seq allocates it.
+				"seq": frappe.db.count(MSG, {"conversation": conv}) + 1,
+				"role": "user",
+				"content": "hi",
+				"streaming": 0,
+				"hidden": hidden,
+			}
+		).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": TURN,
+				"run_id": run_id,
+				"conversation": conv,
+				"relay_target_id": "default",
+				"turn_class": "interactive",
+				"state": "finalizing",
+				"seed_message": seed.name,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return run_id
+
+
+class TestTurnCounter(_SessionFeedbackTestCase):
+	def test_turn_count_increments_once_per_bump(self):
+		for i in range(3):
+			_bump_turn_count(self.conv, self._mk_turn(f"sfrun{i}"))
+		self.assertEqual(self._turn_count(), 3)
+
+	def test_turn_count_never_counts_messages(self):
+		"""The counter is MAINTAINED, not derived: three bumps against ONE turn
+		reach 3 while the conversation still holds a single message. A live
+		COUNT(*) over the message table could only ever report 1 here, so this
+		fails the moment the implementation starts scanning."""
+		run = self._mk_turn("sfrunA")
+		for _ in range(3):
+			_bump_turn_count(self.conv, run)
+		self.assertEqual(frappe.db.count(MSG, {"conversation": self.conv}), 1)
+		self.assertEqual(self._turn_count(), 3)
+
+	def test_file_box_conversation_is_not_counted(self):
+		# Server-set path: the controller gates a generic save that ENABLES
+		# file_box, exactly as the real File Box drop path bypasses it.
+		frappe.db.set_value(CONV, self.conv, "file_box", 1, update_modified=False)
+		_bump_turn_count(self.conv, self._mk_turn("sfrunB"))
+		self.assertEqual(self._turn_count(), 0)
+
+	def test_agent_initiated_conversation_is_not_counted(self):
+		# A macro / app-learning / scheduled-audit / proactive run log: the user
+		# never chose to start it, so its turns are not engagement.
+		frappe.db.set_value(CONV, self.conv, "agent_initiated", 1, update_modified=False)
+		_bump_turn_count(self.conv, self._mk_turn("sfrunC"))
+		self.assertEqual(self._turn_count(), 0)
+
+	def test_hidden_continuation_turn_is_not_counted(self):
+		"""Every human Apply/Confirm click dispatches a HIDDEN continuation turn
+		through this same path. Counting it would make one user action worth two
+		turns and fire the popup at half the intended depth."""
+		_bump_turn_count(self.conv, self._mk_turn("sfrunD", hidden=1))
+		self.assertEqual(self._turn_count(), 0)
+
+	def test_visible_and_hidden_turns_mixed(self):
+		_bump_turn_count(self.conv, self._mk_turn("sfrunE"))
+		_bump_turn_count(self.conv, self._mk_turn("sfrunF", hidden=1))
+		_bump_turn_count(self.conv, self._mk_turn("sfrunG"))
+		self.assertEqual(self._turn_count(), 2, "only the two user-visible turns count")
+
+	def test_bump_is_a_no_op_on_a_missing_conversation(self):
+		# A settled turn whose conversation was deleted must not cost the turn its
+		# terminal publish. The UPDATE simply matches 0 rows (it does not raise);
+		# the raising branch is covered by the stubbed-frappe harness.
+		_bump_turn_count("does-not-exist", "sfrun-missing")
+
+	def test_bump_never_raises_even_when_the_error_log_itself_fails(self):
+		"""A DB outage mid-bump: the UPDATE raises, the rollback raises, and the
+		Error Log INSERT (over the same dead connection) raises too. "NEVER
+		raises" has to hold through all three, or the turn loses its run:end
+		publish and finalize enqueue (settlement calls the bump right before
+		them). rollback/commit are stubbed so the real ones cannot discard this
+		test's own transaction state."""
+		with (
+			patch.object(frappe.db, "sql", side_effect=RuntimeError("db gone")),
+			patch.object(frappe.db, "rollback", side_effect=RuntimeError("still gone")),
+			patch.object(frappe.db, "commit"),
+			patch("frappe.log_error", side_effect=RuntimeError("cannot insert Error Log")) as log,
+		):
+			_bump_turn_count(self.conv, "sfrun-outage")  # must not raise
+		log.assert_called_once()
+		self.assertEqual(self._turn_count(), 0, "nothing was counted during the outage")
+
+
+class TestSessionFeedbackStatus(_SessionFeedbackTestCase):
+	def test_not_due_below_threshold(self):
+		self._set_turns(SESSION_FEEDBACK_TURN_THRESHOLD - 1)
+		self.assertFalse(session_feedback_status(self.conv)["due"])
+
+	def test_due_at_threshold(self):
+		self._set_turns(SESSION_FEEDBACK_TURN_THRESHOLD)
+		self.assertTrue(session_feedback_status(self.conv)["due"])
+
+	def test_still_due_above_threshold(self):
+		self._set_turns(SESSION_FEEDBACK_TURN_THRESHOLD + 5)
+		self.assertTrue(session_feedback_status(self.conv)["due"])
+
+	def test_file_box_conversation_never_due(self):
+		frappe.db.set_value(CONV, self.conv, "file_box", 1, update_modified=False)
+		self._set_turns(999)
+		self.assertFalse(session_feedback_status(self.conv)["due"])
+
+	def test_agent_initiated_conversation_never_due(self):
+		# Defence in depth: the counter never advances for these anyway, but an
+		# older row (created before this field existed) must not fire the popup
+		# on what is really an automated run log.
+		frappe.db.set_value(CONV, self.conv, "agent_initiated", 1, update_modified=False)
+		self._set_turns(999)
+		self.assertFalse(session_feedback_status(self.conv)["due"])
+
+	def test_rejects_another_users_conversation(self):
+		frappe.set_user("Administrator")
+		other = create_conversation()
+		frappe.set_user(TEST_USER)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				session_feedback_status(other)
+		finally:
+			frappe.set_user("Administrator")
+			_delete_conv(other)
+			frappe.set_user(TEST_USER)
+
+
+class TestSubmitSessionFeedback(_SessionFeedbackTestCase):
+	def setUp(self):
+		super().setUp()
+		self._set_turns(SESSION_FEEDBACK_TURN_THRESHOLD)
+
+	def _item(self, push):
+		push.assert_called_once()
+		return push.call_args.args[0]
+
+	def _reopen(self):
+		"""Clear the claim so the next submit is a first submit again - the popup
+		is genuinely one-shot per conversation, so a loop over chips has to."""
+		frappe.db.set_value(CONV, self.conv, "session_feedback_asked_at", None, update_modified=False)
+
+	def test_chip_forwards_derived_payload(self):
+		with patch(_PUSH) as push:
+			res = submit_session_feedback(self.conv, "Good")
+		self.assertEqual(res, {"ok": True, "recorded": True})
+		item = self._item(push)
+		self.assertEqual(item["kind"], "Session")
+		self.assertEqual(item["session_ref"], self.conv)
+		self.assertEqual(item["chip_value"], "Good")
+		self.assertEqual(item["user_ref"], TEST_USER)
+		self.assertEqual(item["note"], "")
+
+	def test_answering_stamps_asked_and_the_popup_never_fires_again(self):
+		with patch(_PUSH):
+			submit_session_feedback(self.conv, "Good")
+		self.assertTrue(frappe.db.get_value(CONV, self.conv, "session_feedback_asked_at"))
+		self.assertFalse(session_feedback_status(self.conv)["due"])
+
+	def test_skip_stamps_asked_without_recording_or_forwarding(self):
+		with patch(_PUSH) as push:
+			res = submit_session_feedback(self.conv)
+		self.assertEqual(res, {"ok": True, "recorded": False})
+		push.assert_not_called()
+		self.assertTrue(frappe.db.get_value(CONV, self.conv, "session_feedback_asked_at"))
+		self.assertFalse(session_feedback_status(self.conv)["due"])
+
+	def test_okay_or_worse_keeps_the_stripped_note(self):
+		# "Okay" counts as low - the popup reveals the note field at "Okay or
+		# worse", not only for the bottom two chips.
+		for chip in ("Okay", "Not great", "Frustrating"):
+			with self.subTest(chip=chip):
+				self._reopen()
+				with patch(_PUSH) as push:
+					submit_session_feedback(self.conv, chip, note="  it lost the thread  ")
+				self.assertEqual(self._item(push)["note"], "it lost the thread")
+
+	def test_positive_chip_never_carries_a_note(self):
+		for chip in ("Great", "Good"):
+			with self.subTest(chip=chip):
+				self._reopen()
+				with patch(_PUSH) as push:
+					submit_session_feedback(self.conv, chip, note="should be dropped")
+				self.assertEqual(self._item(push)["note"], "")
+
+	def test_note_is_bounded(self):
+		with patch(_PUSH) as push:
+			submit_session_feedback(self.conv, "Frustrating", note="x" * 5000)
+		self.assertEqual(len(self._item(push)["note"]), 1000)
+
+	def test_rejects_invalid_chip_value_without_burning_the_popup(self):
+		with patch(_PUSH) as push:
+			with self.assertRaises(frappe.ValidationError):
+				submit_session_feedback(self.conv, "not-a-real-chip")
+		push.assert_not_called()
+		# A broken client must not consume the user's one chance to answer.
+		self.assertFalse(frappe.db.get_value(CONV, self.conv, "session_feedback_asked_at"))
+		self.assertTrue(session_feedback_status(self.conv)["due"])
+
+	def test_a_second_submit_records_and_forwards_nothing(self):
+		"""Two tabs, or a double-click that beats the dialog's disable: the claim
+		is a compare-and-set, so only the first call forwards."""
+		with patch(_PUSH) as push:
+			first = submit_session_feedback(self.conv, "Great")
+			second = submit_session_feedback(self.conv, "Frustrating", note="second tab")
+		self.assertEqual(first, {"ok": True, "recorded": True})
+		self.assertEqual(second, {"ok": True, "recorded": False})
+		self.assertEqual(self._item(push)["chip_value"], "Great", "the first answer is the one kept")
+
+	def test_a_second_skip_records_nothing(self):
+		with patch(_PUSH) as push:
+			submit_session_feedback(self.conv)
+			second = submit_session_feedback(self.conv)
+		self.assertEqual(second, {"ok": True, "recorded": False})
+		push.assert_not_called()
+
+	def test_a_chip_after_a_skip_is_not_recorded(self):
+		# Skip is final for the conversation - a later chip must not sneak in.
+		with patch(_PUSH) as push:
+			submit_session_feedback(self.conv)
+			late = submit_session_feedback(self.conv, "Great")
+		self.assertEqual(late, {"ok": True, "recorded": False})
+		push.assert_not_called()
+
+	def test_a_failed_forward_never_surfaces(self):
+		with patch(_PUSH, side_effect=RuntimeError("admin down")):
+			res = submit_session_feedback(self.conv, "Great")
+		self.assertEqual(res, {"ok": True, "recorded": True})
+
+	def test_rejects_another_users_conversation(self):
+		frappe.set_user("Administrator")
+		other = create_conversation()
+		frappe.set_user(TEST_USER)
+		try:
+			with patch(_PUSH) as push:
+				with self.assertRaises(frappe.PermissionError):
+					submit_session_feedback(other, "Good")
+			push.assert_not_called()
+			self.assertFalse(frappe.db.get_value(CONV, other, "session_feedback_asked_at"))
+		finally:
+			frappe.set_user("Administrator")
+			_delete_conv(other)
+			frappe.set_user(TEST_USER)
+
+	def test_is_post_only(self):
+		"""It WRITES (a compare-and-set claim plus an explicit commit) and forwards
+		to admin, exactly like its pulse siblings (see
+		test_pulse_feedback.py::test_both_endpoints_are_post_only) - reached over
+		GET, Frappe would not enforce CSRF on it."""
+		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[submit_session_feedback], ["POST"])

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -692,7 +692,19 @@ class TestReceiptRefStamping(SkillToolsTestCase):
 			filters={"title": self.CONV_TITLE},
 			pluck="name",
 		):
+			# The receipts themselves, not just their conversation: a role=tool
+			# message left behind here is counted by usage_push's tenant-wide
+			# top_tools scan for the month and broke
+			# test_turn_usage.test_top_tools_tenant_wide_cap whenever CI sharded
+			# this module ahead of it.
+			for msg in frappe.get_all("Jarvis Chat Message", filters={"conversation": name}, pluck="name"):
+				frappe.delete_doc("Jarvis Chat Message", msg, force=True, ignore_permissions=True)
 			frappe.delete_doc("Jarvis Conversation", name, force=True, ignore_permissions=True)
+		# Make the cleanup durable: persist_tool_receipt COMMITS (durability
+		# before its realtime publish), so the rows above outlive the class
+		# rollback while an uncommitted delete here does not, and the next
+		# module in the shard inherits them.
+		frappe.db.commit()
 		super().tearDown()
 
 	def _conv(self) -> str:


### PR DESCRIPTION
## Summary

Manual chain backport of the chat feedback feature to `version-15-hotfix`: Mergify refused #1210 (merge commit in its source history), and #1088 had never been backported even though #1210 depends on it. Picked in order onto one branch:

1. `4f514bba` (#1088) - post-reply thumbs feedback line
2. `6a081bee` (#1210) - session popup + monthly pulse survey
3. `50615c73` (#1213) - in-flight dismissal spec

Conflicts were both in `frontend/src/views/ChatView.vue`:
- Pick 1: two hunks where an unrelated hotfix-only line (`holdActive` maintenance block, `compactedChip`/`loadContext` reset) sat next to the new feedback call; kept both sides.
- Pick 2: develop's diff removed the old `maybeOfferFeedback` call and replaced it with `maybeCheckSessionFeedback`, but on the hotfix line that call sits after a different `compactedChip`/`loadContext` block than on develop, so the 3-way merge produced an empty-HEAD hunk plus a stale untouched old call; resolved by placing the `maybeCheckSessionFeedback` call at the conflict site and removing the now-duplicate old `maybeOfferFeedback` call (it's already invoked internally by `maybeCheckSessionFeedback`). A stray indentation slip from that manual edit was fixed and folded back into the #1210 commit via fixup+autosquash before push.
- Pick 3: clean, no conflicts.

`jarvis/patches.txt` was untouched by all three picks; all three touched DocType JSON files (`jarvis_chat_message`, `jarvis_conversation`, `jarvis_user_settings`) validated with `json.load`. `ruff format`/`check` and `prettier --check` are clean on every touched file, and `pre-commit run --files` passed all hooks.

Supersedes #1214.

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** - the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_0121RjwTjC4SaFQMn1vHTbvB
