### PR TITLE
fix(chat): name primary agent on sessions.create for 2026.9 multi-agent rosters

### DIFF
--- a/jarvis/chat/agent_client.py
+++ b/jarvis/chat/agent_client.py
@@ -117,6 +117,10 @@ CONNECT_OPEN_RETRY_BACKOFF_SECONDS = 2.0
 # openclaw accepts — send one of the seeded values, NOT a bare "http://localhost"
 # (which the old "*" config used to wave through and now gets rejected).
 _GATEWAY_ORIGIN = "http://127.0.0.1:18789"
+# The primary (default) agent id the fleet-agent template keys the main roster
+# entry as; named on sessions.create when a 2026.9+ multi-agent roster requires
+# explicit agent selection (see create_session).
+_PRIMARY_AGENT_ID = "main"
 # Wall-clock cap on one agent turn waiting for the WS lifecycle to
 # complete (final lifecycle "end" frame from openclaw). Was 180s when
 # the bench + openclaw container ran on the same host (sub-ms WS
@@ -692,7 +696,32 @@ class AgentSession:
 	# -- protocol methods -------------------------------------------------
 
 	def create_session(self, label: str = "jarvis-chat") -> str:
-		res = self._request("sessions.create", {"label": label}, timeout_s=CONNECT_TIMEOUT_SECONDS)
+		params = {"label": label}
+		try:
+			res = self._request("sessions.create", params, timeout_s=CONNECT_TIMEOUT_SECONDS)
+		except AgentUnreachableError as e:
+			# openclaw 2026.9+ makes a MULTI-AGENT roster (>=1 marketplace-agent
+			# delegate installed) reject an unscoped session and demand the caller
+			# name an agent. Retry naming the primary agent (the fleet-agent template
+			# keys it "main" - see _PRIMARY_AGENT_ID). Kept as a fallback rather than
+			# sent upfront so single-agent tenants and pre-2026.9 gateways - whose
+			# sessions.create rejects an unknown agentId - are untouched.
+			#
+			# openclaw sends only the GENERIC code "INVALID_REQUEST" with details=None
+			# for this (verified against 2026.9.3), so - unlike the structured
+			# _STALE_PAIRING_* classifier above - the code alone can't distinguish it
+			# from other INVALID_REQUEST rejections; the message substring is the only
+			# specific signal available. Gate on both (code narrows the class, prose
+			# pins the case). test_chat_agent_client pins the exact wire message so a
+			# future reword breaks CI instead of silently disabling the retry; if a
+			# later image adds a structured reason, prefer it.
+			if e.code != "INVALID_REQUEST" or "no explicit owner" not in str(e).lower():
+				raise
+			res = self._request(
+				"sessions.create",
+				{**params, "agentId": _PRIMARY_AGENT_ID},
+				timeout_s=CONNECT_TIMEOUT_SECONDS,
+			)
 		key = (res.get("payload") or {}).get("key")
 		if not key:
 			raise AgentUnreachableError(f"sessions.create returned no key: {res}")

--- a/jarvis/tests/test_chat_agent_client.py
+++ b/jarvis/tests/test_chat_agent_client.py
@@ -279,6 +279,76 @@ class TestCreateSession(FrappeTestCase):
 		with self.assertRaises(AgentUnreachableError):
 			sess.create_session()
 
+	# The EXACT wire message the create_session fallback keys off (openclaw 2026.9+
+	# multi-agent). Pinned here so a gateway reword breaks CI instead of silently
+	# disabling the retry -> dead chat for every multi-agent tenant.
+	_NO_OWNER_MSG = (
+		'Multiple agents are configured, but session key "main" has no explicit '
+		"owner. Pass agentId or use an agent-prefixed session key."
+	)
+
+	def _reject(self, ws, code, message):
+		def _resp():
+			return _frame(
+				{
+					"type": "res",
+					"id": ws.sent[-1]["id"],
+					"ok": False,
+					"error": {"code": code, "message": message},
+				}
+			)
+
+		return _resp
+
+	def _ok(self, ws, key):
+		def _resp():
+			return _frame({"type": "res", "id": ws.sent[-1]["id"], "ok": True, "payload": {"key": key}})
+
+		return _resp
+
+	def test_retries_naming_primary_agent_on_no_explicit_owner(self):
+		sess, ws = _build_session()
+		ws._frames.append(self._reject(ws, "INVALID_REQUEST", self._NO_OWNER_MSG))
+		ws._frames.append(self._ok(ws, "session-xyz"))
+
+		key = sess.create_session()
+
+		self.assertEqual(key, "session-xyz")
+		# First create is unscoped; the retry names the primary agent "main".
+		self.assertEqual(len(ws.sent), 2)
+		self.assertNotIn("agentId", ws.sent[0]["params"])
+		self.assertEqual(ws.sent[1]["params"]["agentId"], "main")
+		self.assertEqual(ws.sent[1]["params"]["label"], ws.sent[0]["params"]["label"])
+
+	def test_second_no_owner_rejection_propagates_without_looping(self):
+		sess, ws = _build_session()
+		ws._frames.append(self._reject(ws, "INVALID_REQUEST", self._NO_OWNER_MSG))
+		ws._frames.append(self._reject(ws, "INVALID_REQUEST", self._NO_OWNER_MSG))
+
+		with self.assertRaises(AgentUnreachableError):
+			sess.create_session()
+		# Retried exactly once (single-shot fallback), no infinite loop.
+		self.assertEqual(len(ws.sent), 2)
+
+	def test_other_invalid_request_raises_without_retry(self):
+		# A different INVALID_REQUEST (no "no explicit owner") must NOT retry -
+		# single-agent + pre-2026.9 gateways stay byte-identical.
+		sess, ws = _build_session()
+		ws._frames.append(self._reject(ws, "INVALID_REQUEST", "some other validation failure"))
+
+		with self.assertRaises(AgentUnreachableError):
+			sess.create_session()
+		self.assertEqual(len(ws.sent), 1)
+
+	def test_non_invalid_request_code_raises_without_retry(self):
+		# Even if the phrase appeared under a different code, the code gate blocks the retry.
+		sess, ws = _build_session()
+		ws._frames.append(self._reject(ws, "UNAVAILABLE", self._NO_OWNER_MSG))
+
+		with self.assertRaises(AgentUnreachableError):
+			sess.create_session()
+		self.assertEqual(len(ws.sent), 1)
+
 
 # --- TestStreamAgentTurn --------------------------------------------------
 

--- a/jarvis/tests/test_chat_agent_client.py
+++ b/jarvis/tests/test_chat_agent_client.py
@@ -279,9 +279,9 @@ class TestCreateSession(FrappeTestCase):
 		with self.assertRaises(AgentUnreachableError):
 			sess.create_session()
 
-	# The EXACT wire message the create_session fallback keys off (openclaw 2026.9+
-	# multi-agent). Pinned here so a gateway reword breaks CI instead of silently
-	# disabling the retry -> dead chat for every multi-agent tenant.
+	# The EXACT wire message the create_session fallback keys off (a 2026.9+
+	# multi-agent gateway). Pinned here so a gateway reword breaks CI instead of
+	# silently disabling the retry -> dead chat for every multi-agent tenant.
 	_NO_OWNER_MSG = (
 		'Multiple agents are configured, but session key "main" has no explicit '
 		"owner. Pass agentId or use an agent-prefixed session key."


### PR DESCRIPTION
## What
openclaw 2026.9+ rejects an unscoped `main` session on a MULTI-AGENT roster (>=1 marketplace-agent delegate) with "no explicit owner" and demands the caller name an agent. `create_session` now retries naming the primary agent (`agentId="main"`) on that specific rejection.

## Why
Multi-agent tenants on a 2026.9.x image cannot start ANY chat session or agent run — the bench sends a bare `main` session key. Diagnosed live (agent runs + chat prewarm failing at sessions.create).

## Design
- **Fallback, not upfront** — single-agent + pre-2026.9 gateways (strict schema) stay byte-identical; the retry fires only on the specific rejection.
- Gated on `code == INVALID_REQUEST` **and** the wire-message substring: the gateway exposes no structured reason for this (`details=None`, verified via probe), so the message is the only specific signal. The exact wire message is pinned in a test so a reword breaks CI instead of silently disabling the retry.

## Tests
4 new `create_session` cases (retry→success, second-reject→propagate, non-owner→no-retry, non-INVALID_REQUEST→no-retry). `test_chat_agent_client` 43 OK. ruff 0.14.10 clean.

## ⚠️ Deploy ordering
Pairs with the **jarvis-fleet-agent** `agents.ownership` change (separate PR). **Deploy this bench fix at or before** the fleet-agent change reaches any 2026.9 multi-agent tenant — the reverse order boots the container but leaves chat dead until this ships.