### PR TITLE
feat(chat): connect-first device pairing for openclaw 9.3 (Mechanism A)

### DIFF
--- a/frontend/src/lib/statusPhrase.js
+++ b/frontend/src/lib/statusPhrase.js
@@ -1,0 +1,22 @@
+/**
+ * Pre-connect chat status phrases — the copy shown before the first token
+ * streams, while the bench is still reaching (or setting up) the assistant.
+ *
+ * These take priority over tool/thinking phrases in ChatView's `liveStatus`
+ * because at this point no tool is running yet: the turn is blocked on the WS
+ * connect. Two phases live here:
+ *   - "waking"  — a cold/dormant container is spinning back up.
+ *   - "pairing" — the one-time device (re)pair (agent 9.3 "Mechanism A"):
+ *     the bench has to pair with the gateway before it can talk to it, which
+ *     can take tens of seconds. Rendering this (rather than a dead spinner or a
+ *     bare "_Stopped._") is the locked UX for the connect-first pairing flow.
+ *
+ * Kept as a pure function so it can be unit-tested without mounting the
+ * 10k-line ChatView SFC. Mirrored by the `liveStatus` computed in ChatView.vue
+ * (which calls this first); keep the two in sync.
+ */
+export function preConnectStatusLabel(phase) {
+	if (phase === "waking") return "Waking up your assistant…";
+	if (phase === "pairing") return "Setting up your assistant…";
+	return null;
+}

--- a/frontend/src/lib/statusPhrase.spec.js
+++ b/frontend/src/lib/statusPhrase.spec.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+import { preConnectStatusLabel } from "./statusPhrase";
+
+describe("preConnectStatusLabel", () => {
+	it("renders the one-time device (re)pair state (agent 9.3 connect-first)", () => {
+		expect(preConnectStatusLabel("pairing")).toBe("Setting up your assistant…");
+	});
+
+	it("renders the cold-container waking state", () => {
+		expect(preConnectStatusLabel("waking")).toBe("Waking up your assistant…");
+	});
+
+	it("returns null for every other phase so tool/thinking phrases win", () => {
+		expect(preConnectStatusLabel("model")).toBeNull();
+		expect(preConnectStatusLabel("analyzing")).toBeNull();
+		expect(preConnectStatusLabel("compacting")).toBeNull();
+		expect(preConnectStatusLabel(null)).toBeNull();
+		expect(preConnectStatusLabel(undefined)).toBeNull();
+		expect(preConnectStatusLabel("")).toBeNull();
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4613,6 +4613,7 @@ import {
 } from "@/lib/draftApply";
 import { stripBlocks } from "@/lib/chatBlocks";
 import { shouldFollowBottom } from "@/lib/chatScroll";
+import { preConnectStatusLabel } from "@/lib/statusPhrase";
 import { createRevealer } from "@/lib/streamReveal";
 import { sortPendingCards } from "@/lib/sortPendingCards";
 import { errMessage, turnErrorInfo } from "@/lib/errors";
@@ -5910,7 +5911,10 @@ function toolPhrase(tool) {
 	return tpl + "…";
 }
 const liveStatus = computed(() => {
-	if (statusPhase.value === "waking") return "Waking up your assistant…";
+	// Pre-connect phases ("waking" / "pairing") win over tool/thinking phrases:
+	// the turn is still blocked on the WS connect, no tool is running yet.
+	const preConnect = preConnectStatusLabel(statusPhase.value);
+	if (preConnect) return preConnect;
 	if (currentTool.value) return toolPhrase(currentTool.value);
 	if (statusPhase.value === "analyzing") return "Analyzing the results…";
 	if (waiting.value || sending.value || statusPhase.value === "model") return "Working on it…";
@@ -9869,6 +9873,9 @@ function onEvent(p) {
 			// Lightweight progress signal (e.g. waking a cold container) between
 			// run:start and the first token — keeps the connect window honest.
 			if (p.status === "waking") statusPhase.value = "waking";
+			// One-time device (re)pair (agent 9.3 connect-first): shown as
+			// "Setting up your assistant…" while the bench pairs with the gateway.
+			if (p.status === "pairing") statusPhase.value = "pairing";
 			if (p.status === "compacting") {
 				statusPhase.value = "compacting";
 				compacting.value = true;

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1885,6 +1885,38 @@ def pair_chat_device(public_key: str, device_id: str, *, request_timeout_s: int 
 	)
 
 
+def request_chat_pairing(public_key: str, device_id: str, *, request_timeout_s: int = 30) -> dict:
+	"""Additive successor to ``pair_chat_device`` for the agent 9.3
+	device-pairing fix (Mechanism A). POSTs the customer's chat device pubkey to
+	the CP, which decides - per its own per-tenant gate - HOW this tenant pairs
+	and returns an ACK describing the ``mode`` (NOT necessarily a token):
+
+	  - ``{"mode": "legacy", "device_token": "..."}`` - un-upgraded / 6.8 tenant:
+	    the CP forged a device token synchronously (identical to what
+	    ``pair_chat_device`` returns today). The bench presents that token
+	    (steady-state connect, unchanged).
+	  - ``{"mode": "mechanism_a", "accepted": true}`` - 9.x tenant: NO token yet.
+	    The CP has told the fleet-agent to poll + approve this deviceId; the
+	    gateway issues the device token on the bench's approved connect. The bench
+	    connects token-less (gateway-token bootstrap) and adopts the reissued token
+	    (see ``jarvis.chat.device._pair_mechanism_a`` / ``agent_client``).
+
+	Additive on purpose (plan-check gap #1 / D-b): ``pair_chat_device`` is left
+	intact for old/6.8 benches so a CP deploy never flips pairing semantics under
+	a not-yet-upgraded bench. Authenticates the caller as the tenant exactly like
+	``pair_chat_device`` (same signed ``_post`` transport). ``request_timeout_s``
+	is the budget the bench asks the CP to allow for its CP -> fleet-agent leg
+	(the CP clamps it), same contract as ``pair_chat_device``."""
+	return _post(
+		path=_m("api.tenant.request_chat_pairing"),
+		body={
+			"public_key": public_key,
+			"device_id": device_id,
+			"request_timeout_s": request_timeout_s,
+		},
+	)
+
+
 def get_account_summary() -> dict:
 	"""Fetch the customer's plan + validity + upgrade-eligible plans. Used by
 	the /jarvis/billing SPA page to render the plan cards and the settings

--- a/jarvis/chat/agent_client.py
+++ b/jarvis/chat/agent_client.py
@@ -306,6 +306,66 @@ def _is_stale_pairing(err: Exception) -> bool:
 	return details.get("code") in _STALE_PAIRING_DETAIL_CODES
 
 
+# --- Mechanism A: connect-first device pairing ------------------------------
+#
+# On a Mechanism-A tenant (openclaw 9.x) the bench has a STABLE keypair but no
+# device token yet. It presents the shared gateway token (auth.token) on a
+# signed connect; openclaw answers NOT_PAIRED and opens a DURABLE pending pairing
+# request, then closes the socket (WS 1008) with a pauseReconnect hint. The CP
+# has told the fleet-agent to poll + approve this deviceId; on the approved
+# reconnect openclaw issues the device token on hello-ok.auth.deviceToken. We
+# drive that by reconnecting on OUR OWN timer, ignoring the pause hint.
+#
+# Bounded (D-e): ONE pairing episode per turn-that-needs-pairing, capped WELL
+# inside openclaw's ~5-min pending TTL and the chat-turn budget; fail-closed at
+# the cap (D-d). The deadline sits a little above the fleet-agent's
+# tens-of-seconds poll+approve window so an approval lands within one turn.
+PAIRING_APPROVAL_DEADLINE_SECONDS = 75
+PAIRING_RECONNECT_BACKOFF_SECONDS = 3.0
+
+# User-facing copy for a pairing that has not been approved yet when we hit the
+# cap (fail-closed). Honest, not a fake success or a dead card: normal chat
+# resumes on the next turn once the fleet-agent's approval lands. Kept generic so
+# _classify_error still files it under "unreachable" (assistant starting up).
+PAIRING_PENDING_USER_MESSAGE = "Still getting your assistant ready — try again in a moment."
+
+# openclaw's wire signal for "presented the gateway token, no paired device yet"
+# (spike-proven on the real 9.3 dist, invariant #3): error.code NOT_PAIRED, and
+# on the generic INVALID_REQUEST envelope the machine-readable marker sits in
+# error.details.code = PAIRING_REQUIRED / error.details.{authReason,reason} =
+# not-paired. This set is DISJOINT from the stale-pairing markers above
+# (device_token_mismatch / AUTH_DEVICE_TOKEN_MISMATCH), and the two paths are
+# further separated by connect MODE - a bootstrap connect presents auth.token
+# (no deviceToken to mismatch), a steady-state connect presents auth.deviceToken
+# - so a NOT_PAIRED response can never route into the keypair-wiping
+# stale-pairing repair path (plan-check gap #3).
+_NOT_PAIRED_CODES = frozenset({"NOT_PAIRED"})
+_NOT_PAIRED_DETAIL_CODES = frozenset({"PAIRING_REQUIRED", "NOT_PAIRED"})
+_NOT_PAIRED_REASONS = frozenset({"not-paired"})
+
+
+def _is_not_paired(err: Exception) -> bool:
+	"""Return True iff ``err`` is openclaw's connect-first PENDING signal: the
+	bench presented the gateway token (bootstrap) and openclaw created/returned a
+	pending pairing request instead of authenticating.
+
+	Strictly typed, exactly like ``_is_stale_pairing``: only ``.code``/``.details``
+	are consulted, never message text. This is the ONLY classifier the bootstrap
+	loop reads, so a NOT_PAIRED response is structurally kept OUT of the
+	keypair-wiping stale-pairing self-heal."""
+	code = getattr(err, "code", None)
+	if code in _NOT_PAIRED_CODES:
+		return True
+	details = getattr(err, "details", None)
+	if not isinstance(details, dict):
+		return False
+	if details.get("code") in _NOT_PAIRED_DETAIL_CODES:
+		return True
+	if details.get("authReason") in _NOT_PAIRED_REASONS:
+		return True
+	return details.get("reason") in _NOT_PAIRED_REASONS
+
+
 def _chat_final_text(payload: dict) -> str | None:
 	"""Authoritative final text from a chat final event: joined text blocks
 	of payload.message.content; None for silent finals."""
@@ -518,6 +578,16 @@ class AgentSession:
 		t_pair_start = time.monotonic()
 		creds = ensure_paired()
 		t_pair_done = time.monotonic()
+
+		# Mechanism-A tenant with no device token yet: take the connect-first
+		# bootstrap path. It presents the gateway token, drives NOT_PAIRED ->
+		# approved on its own bounded timer, and adopts the reissued device token.
+		# DISJOINT from the stale-pairing repair below: it never wipes the stable
+		# keypair (a wiped keypair mints a new deviceId every turn -> a pending the
+		# fleet-agent can never approve -> thrash, plan-check gap #3).
+		if creds.needs_bootstrap:
+			return cls._bootstrap_pair_connect(gateway_url, creds, t_pair_start=t_pair_start)
+
 		ws = cls._open_ws_with_retry(gateway_url)
 		t_ws_done = time.monotonic()
 
@@ -554,6 +624,114 @@ class AgentSession:
 			gateway_url,
 		)
 		return cls(ws, creds)
+
+	@classmethod
+	def _bootstrap_pair_connect(
+		cls,
+		gateway_url: str,
+		creds: ChatDeviceCredentials,
+		*,
+		t_pair_start: float | None = None,
+	) -> AgentSession:
+		"""Connect-first device pairing (Mechanism A).
+
+		The bench has a stable keypair but NO device token. It presents the
+		gateway token (``auth.token``) on a signed connect; openclaw answers
+		NOT_PAIRED and opens a durable pending request (and closes the socket with
+		a pauseReconnect hint). The CP has already told the fleet-agent to poll +
+		approve this deviceId. We ignore the pause and reconnect on our own timer
+		until the approval lands, at which point openclaw issues the device token
+		on ``hello-ok.auth.deviceToken`` and we adopt it (steady state from there).
+
+		DISJOINT from the stale-pairing self-heal (``_repair_and_reconnect``): this
+		NEVER wipes the keypair. Wiping it would mint a new deviceId every turn ->
+		a moving target the fleet-agent can never approve (thrash, plan-check gap
+		#3). Token-absent is a valid state; the keypair stays put and the pending is
+		re-found/re-created each turn until approved.
+
+		Bounded (D-e): ONE episode per turn-that-needs-pairing, capped at
+		PAIRING_APPROVAL_DEADLINE_SECONDS (well inside the 5-min pending TTL and the
+		chat-turn budget). Fail-CLOSED at the cap (D-d): raise the honest
+		"still getting ready" error, NEVER fabricate a token.
+		"""
+		if not creds.bootstrap_token:
+			# Can neither present nor sign a bootstrap connect without the gateway
+			# token. Fail closed rather than send an unsignable/empty auth.
+			raise AgentUnreachableError(
+				"device pairing needs the gateway token but none is set",
+				code="pairing-no-bootstrap-token",
+			)
+
+		t_start = t_pair_start if t_pair_start is not None else time.monotonic()
+		deadline = time.monotonic() + PAIRING_APPROVAL_DEADLINE_SECONDS
+		attempt = 0
+		while True:
+			attempt += 1
+			ws = cls._open_ws_with_retry(gateway_url)
+			try:
+				reissued_token = cls._handshake(ws, creds)
+			except AgentUnreachableError as e:
+				try:
+					ws.close()
+				except Exception:
+					pass
+				if _is_not_paired(e):
+					# Still pending. Reconnect on our own timer within the deadline;
+					# openclaw's pauseReconnect hint is deliberately ignored.
+					if time.monotonic() < deadline:
+						_logger.info(
+							"chat pairing: pending approval device_id=%s attempt=%d elapsed_ms=%d",
+							creds.device_id,
+							attempt,
+							int((time.monotonic() - t_start) * 1000),
+						)
+						time.sleep(PAIRING_RECONNECT_BACKOFF_SECONDS)
+						continue
+					# Cap reached: fail closed (D-d). This is the new NOT_PAIRED
+					# branch's own distinct log line (D-f).
+					_logger.warning(
+						"chat pairing: NOT approved within %ss device_id=%s attempts=%d - failing closed",
+						PAIRING_APPROVAL_DEADLINE_SECONDS,
+						creds.device_id,
+						attempt,
+					)
+					raise AgentUnreachableError(
+						PAIRING_PENDING_USER_MESSAGE,
+						code="pairing-pending",
+					) from e
+				# Any non-NOT_PAIRED failure is a real error - do NOT loop on it.
+				raise
+			except Exception:
+				try:
+					ws.close()
+				except Exception:
+					pass
+				raise
+
+			# hello-ok arrived: the pending was approved and the gateway issued the
+			# device token. Adopt it (persist + in-memory) and proceed steady-state.
+			if not reissued_token:
+				try:
+					ws.close()
+				except Exception:
+					pass
+				_logger.warning(
+					"chat pairing: approved connect issued NO device token device_id=%s - failing closed",
+					creds.device_id,
+				)
+				raise AgentUnreachableError(
+					PAIRING_PENDING_USER_MESSAGE,
+					code="pairing-no-token",
+				)
+			creds = cls._adopt_reissued_token(creds, reissued_token)
+			_logger.info(
+				"chat pairing: approved device_id=%s attempts=%d total_ms=%d gateway=%s",
+				creds.device_id,
+				attempt,
+				int((time.monotonic() - t_start) * 1000),
+				gateway_url,
+			)
+			return cls(ws, creds)
 
 	@classmethod
 	def _open_ws_with_retry(cls, gateway_url: str):
@@ -1240,13 +1418,21 @@ class AgentSession:
 	def _handshake(cls, ws: websocket.WebSocket, creds: ChatDeviceCredentials) -> str | None:
 		"""Receive connect.challenge → sign v3 payload → send connect → expect hello-ok.
 
+		Presents ``auth`` per connect mode and signs the v3 payload's token slot
+		with the SAME token (spike invariant #2 - openclaw derives the signature
+		token via ``resolveSignatureToken`` = ``auth.token ?? auth.deviceToken ??
+		auth.bootstrapToken``, so the two MUST match or the signature is rejected):
+		  - steady state (device token in hand): ``auth.deviceToken`` = device token
+		    (today's behaviour, unchanged);
+		  - bootstrap / token-fetch (Mechanism A, no device token yet):
+		    ``auth.token`` = the shared gateway token.
+
 		Returns the REISSUED device token from hello-ok's ``auth.deviceToken``
-		when the gateway rotated it (None otherwise). openclaw's gateway
-		replaces the stored device token at connect whenever the existing
-		entry no longer lines up with the requested scopes/issuer; the new
-		token is already durable on the gateway side when hello-ok arrives,
-		so the caller MUST adopt it or every following connect fails with
-		"device token mismatch"."""
+		when the gateway issued/rotated one (None otherwise). In bootstrap this is
+		how the newly-approved device token reaches the bench; in steady state it
+		is the gateway rotating the stored token. Either way the new token is
+		already durable gateway-side when hello-ok arrives, so the caller MUST
+		adopt it or every following connect fails with "device token mismatch"."""
 		deadline = time.monotonic() + CONNECT_TIMEOUT_SECONDS
 
 		# 1. Wait for the challenge event.
@@ -1262,6 +1448,17 @@ class AgentSession:
 			raise AgentUnreachableError("did not receive connect.challenge before timeout")
 
 		# 2. Sign + send the connect frame.
+		# Build the auth block first, then derive the token slot FROM it in
+		# openclaw's exact resolveSignatureToken precedence, so the presented
+		# token and the signed token can never drift (invariant #2). Bootstrap
+		# (no device token) presents auth.token=<gateway token>; steady state
+		# presents auth.deviceToken=<device token>.
+		if creds.device_token:
+			auth = {"deviceToken": creds.device_token}
+		else:
+			auth = {"token": creds.bootstrap_token}
+		signing_token = auth.get("token") or auth.get("deviceToken") or auth.get("bootstrapToken") or ""
+
 		signed_at_ms = int(time.time() * 1000)
 		payload = build_payload_v3(
 			device_id=creds.device_id,
@@ -1270,7 +1467,7 @@ class AgentSession:
 			role=_ROLE,
 			scopes=_REQUESTED_SCOPES,
 			signed_at_ms=signed_at_ms,
-			device_token=creds.device_token,
+			device_token=signing_token,
 			nonce=nonce,
 			platform=_PLATFORM,
 			device_family="",
@@ -1288,7 +1485,7 @@ class AgentSession:
 			},
 			"role": _ROLE,
 			"scopes": _REQUESTED_SCOPES,
-			"auth": {"deviceToken": creds.device_token},
+			"auth": auth,
 			"device": {
 				"id": creds.device_id,
 				"publicKey": creds.public_key,

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 from dataclasses import dataclass
 
 import frappe
@@ -23,13 +24,31 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from jarvis import admin_client
 from jarvis.exceptions import AgentUnreachableError
 
+_logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class ChatDeviceCredentials:
 	device_id: str
 	public_key: str  # base64url, no padding
 	private_key: Ed25519PrivateKey
-	device_token: str  # bearer for auth.deviceToken at connect
+	device_token: str  # bearer for auth.deviceToken at connect ("" until paired, Mechanism A)
+	# Gateway (shared) token from Jarvis Settings ``agent_token``, carried ONLY on
+	# a Mechanism-A pairing that has no device token yet. The connect-first
+	# bootstrap presents it as ``auth.token`` and signs the v3 payload's token
+	# slot with it (spike invariant #2); steady state and legacy leave it "".
+	bootstrap_token: str = ""
+
+	@property
+	def needs_bootstrap(self) -> bool:
+		"""True for a Mechanism-A pairing with no device token yet: the connect
+		must present the gateway token (``auth.token``) to create/await a pending
+		pairing request and receive the device token on the approved reconnect.
+
+		Steady state (``device_token`` set) and the legacy path (token forged
+		synchronously by the CP) are both False -> today's steady-state connect,
+		unchanged."""
+		return not self.device_token and bool(self.bootstrap_token)
 
 
 def _b64u(raw: bytes) -> str:
@@ -78,6 +97,71 @@ def _save_credentials(
 	frappe.db.commit()
 
 
+def _priv_b64u(priv: Ed25519PrivateKey) -> str:
+	"""base64url-no-padding of an Ed25519 private key's raw bytes."""
+	return _b64u(
+		priv.private_bytes(
+			encoding=serialization.Encoding.Raw,
+			format=serialization.PrivateFormat.Raw,
+			encryption_algorithm=serialization.NoEncryption(),
+		)
+	)
+
+
+def _save_keypair(*, device_id: str, public_key_b64u: str, private_key_b64u: str) -> None:
+	"""Persist ONLY the stable keypair (device_id + public + private), no token.
+
+	Mechanism A separates keypair persistence from token acquisition: the keypair
+	is written once, under the cold-start lock, and stays stable across every
+	connect/approve/reconnect so the deviceId never moves (a moving deviceId is a
+	pending the fleet-agent can never catch up to -> thrash). The device token is
+	written LATER, out of the lock, by ``update_device_token`` once the gateway
+	issues it on the approved connect."""
+	from jarvis._password_utils import set_settings_password
+
+	settings_doc = frappe.get_single("Jarvis Settings")
+	settings_doc.db_set("chat_device_id", device_id)
+	settings_doc.db_set("chat_device_public_key", public_key_b64u)
+	set_settings_password(settings_doc, "chat_device_private_key", private_key_b64u)
+	frappe.db.commit()
+
+
+def _read_keypair() -> tuple[str, str, Ed25519PrivateKey] | None:
+	"""Return the persisted STABLE keypair ``(device_id, public_key_b64u,
+	private_key)``, or None when it is absent/corrupt (caller generates a fresh
+	one). Deliberately does NOT require a device token: a Mechanism-A bench that
+	is paired-pending (keypair present, no token yet) must be able to reuse its
+	keypair without regenerating it."""
+	s = frappe.get_single("Jarvis Settings")
+	device_id = (s.chat_device_id or "").strip()
+	public_key = (s.chat_device_public_key or "").strip()
+	private_key_b64u = (s.get_password("chat_device_private_key", raise_exception=False) or "").strip()
+	if not (device_id and public_key and private_key_b64u):
+		return None
+	try:
+		priv = _load_private_key(private_key_b64u)
+	except (ValueError, TypeError):
+		return None
+	return device_id, public_key, priv
+
+
+def _read_gateway_token() -> str:
+	"""The shared gateway token from Jarvis Settings ``agent_token`` (a Password
+	field). This is the ``auth.token`` the Mechanism-A bootstrap connect presents
+	(spike invariant #2). Empty string when unset -> the caller fails closed."""
+	s = frappe.get_single("Jarvis Settings")
+	return (s.get_password("agent_token", raise_exception=False) or "").strip()
+
+
+def has_paired_token(settings_doc=None) -> bool:
+	"""Cheap UX gate for the turn path: True iff a chat device token is already
+	persisted (steady state). When False the next connect must (re)pair, so the
+	turn renders a "Setting up your assistant…" state before it blocks on the
+	connect. Accepts an already-loaded Settings doc to avoid a second fetch."""
+	s = settings_doc or frappe.get_single("Jarvis Settings")
+	return bool((s.get_password("chat_device_token", raise_exception=False) or "").strip())
+
+
 def _read_credentials() -> ChatDeviceCredentials | None:
 	"""Load creds from Jarvis Settings, or None if any field is missing.
 
@@ -105,59 +189,144 @@ def _read_credentials() -> ChatDeviceCredentials | None:
 
 
 def ensure_paired() -> ChatDeviceCredentials:
-	"""Return current chat device credentials, generating + registering them
-	if missing. Idempotent: a fully-populated Settings row is reused as-is.
+	"""Return current chat device credentials, establishing them if missing.
+	Idempotent: a fully-populated Settings row (keypair + device token) is the
+	steady-state hot path and is reused as-is with NO round-trip.
 
-	Raises AgentUnreachableError if pairing fails (no creds to fall back
-	to - the caller has no way to chat without them, so we surface the error
-	cleanly instead of half-persisting an unusable state).
+	Raises AgentUnreachableError if pairing fails (no creds to fall back to - the
+	caller has no way to chat without them, so we surface the error cleanly
+	instead of half-persisting an unusable state).
 
-	Cold-start concurrency: send_message (web) and the RQ worker (background)
-	both call ensure_paired before each turn. On a fresh bench (no
-	credentials persisted yet) two concurrent callers both observe
-	``_read_credentials() is None`` and both call ``_generate_and_pair``,
-	each generating a different Ed25519 keypair and each round-tripping to
-	admin.pair_chat_device. Last writer to Jarvis Settings wins; the other
-	caller holds in-memory creds that admin's PairedDevice row doesn't know
-	about. Cross-repo punch-list "Race: send_message + RQ worker both invoke
-	ensure_paired() concurrently" from the 2026-06-16 review.
-
-	Fix: serialize the generate+pair window under a Redis advisory lock.
-	Double-checked: re-read inside the lock so the second arrival finds the
-	winner's creds and skips the duplicate pair entirely. The lock has a
-	60s TTL backstop so a crashed holder can't deadlock cold-start forever;
-	on lock unavailability we fall through and pair anyway (better one
-	duplicate keypair than a permanently broken chat).
-	"""
+	When there is no usable device token yet, the actual work is delegated to
+	``_establish_pairing`` - which keeps the keypair stable and forks on the CP's
+	pairing ``mode`` (legacy synchronous forge vs Mechanism-A connect-first)."""
 	existing = _read_credentials()
 	if existing is not None:
 		return existing
-	return _generate_and_pair_under_lock()
+	return _establish_pairing()
 
 
-def _generate_and_pair_under_lock() -> ChatDeviceCredentials:
-	"""Convoy-collapse helper for the cold-start race. Acquires the
-	chat_device_initial_pair lock with a bounded wait; inside the lock,
-	re-reads to see if the winner already paired; if so, returns their
-	creds; if not, runs the actual pair flow."""
+def _establish_pairing() -> ChatDeviceCredentials:
+	"""Establish a pairing when no usable device token is persisted.
+
+	Two-stage, and the split is load-bearing (plan-check gap #10):
+
+	  1. Ensure a STABLE keypair (generate + persist only if absent). This is the
+	     ONLY step serialized under the ``chat_device_initial_pair`` Redis lock:
+	     two cold-start callers must not each mint a different keypair (two
+	     deviceIds -> the fleet-agent can never converge on one pending -> thrash).
+	  2. Fork on the CP's pairing ``mode``, OUTSIDE the lock:
+	       - ``legacy``       -> the CP forged a device token synchronously
+	                             (today's behaviour): persist + present it.
+	       - ``mechanism_a``  -> NO token yet; return bootstrap creds so the
+	                             connect-first flow in ``agent_client`` obtains the
+	                             token on the gateway-approved reconnect.
+
+	Keeping the CP call + the connect/approve/token cascade OUT of the lock is
+	safe precisely BECAUSE the keypair is now stable: concurrent callers act on
+	the SAME deviceId (idempotent), rather than the pre-fix race where each minted
+	a fresh keypair and flapped the container's pairing state.
+	"""
+	device_id, pub_b64u, priv = _ensure_keypair_under_lock()
+
+	# A peer may have finished pairing (adopted + persisted a token) while we ran
+	# keypair-gen; reuse it rather than re-requesting.
+	existing = _read_credentials()
+	if existing is not None:
+		return existing
+
+	try:
+		resp = admin_client.request_chat_pairing(public_key=pub_b64u, device_id=device_id) or {}
+	except Exception as e:
+		raise AgentUnreachableError(f"chat device pairing request failed: {e}") from e
+
+	mode = (resp.get("mode") or "").strip()
+	if mode == "legacy":
+		return _pair_legacy(resp, device_id=device_id, pub_b64u=pub_b64u, priv=priv)
+	if mode == "mechanism_a":
+		return _pair_mechanism_a(device_id=device_id, pub_b64u=pub_b64u, priv=priv)
+	# Unknown/blank mode: fail closed (D-d) - never fabricate a credential.
+	raise AgentUnreachableError(f"request_chat_pairing returned unknown mode {mode!r}")
+
+
+def _ensure_keypair_under_lock() -> tuple[str, str, Ed25519PrivateKey]:
+	"""Return a STABLE ``(device_id, public_key_b64u, private_key)``, generating +
+	persisting a fresh keypair only when none exists yet.
+
+	Keypair generation is the ONLY thing under the ``chat_device_initial_pair``
+	lock (plan-check gap #10): the token cascade runs outside it. Double-checked
+	inside the lock so a contended cold-start mints exactly one keypair - the
+	winner persists, followers read it back. Lock unavailable + no keypair: fall
+	through and generate anyway (a Redis outage must not wedge chat forever;
+	at-worst-one-duplicate-keypair beats permanently-broken, and the stable-write
+	below means a duplicate is quickly reconciled by the next read)."""
+	existing = _read_keypair()
+	if existing is not None:
+		return existing
+
 	from jarvis._redis_lock import redis_lock
 
 	with redis_lock(
 		"chat_device_initial_pair",
 		timeout_s=60,
 		blocking_timeout_s=30.0,
-	) as _acquired:  # deliberately unchecked - see below
-		# Re-check inside the lock window. The winner of a contended cold-
-		# start has already populated Jarvis Settings; followers read those
-		# creds and return without a second pair_chat_device round-trip.
-		existing = _read_credentials()
+	) as _acquired:  # unchecked: see the fall-through note above
+		existing = _read_keypair()
 		if existing is not None:
 			return existing
-		# Lock-unavailable + no creds: a Redis outage during cold-start
-		# would otherwise block the bench's chat path indefinitely.
-		# Falling through accepts at-worst-one-duplicate-pair; that's a
-		# strictly better failure mode than chat-permanently-broken.
-		return _generate_and_pair()
+		priv, _pub_raw, pub_b64u, device_id = _generate_keypair()
+		_save_keypair(device_id=device_id, public_key_b64u=pub_b64u, private_key_b64u=_priv_b64u(priv))
+		return device_id, pub_b64u, priv
+
+
+def _pair_legacy(
+	resp: dict, *, device_id: str, pub_b64u: str, priv: Ed25519PrivateKey
+) -> ChatDeviceCredentials:
+	"""Legacy / 6.8 tenant: the CP forged a device token synchronously (today's
+	behaviour, routed via ``request_chat_pairing`` mode=legacy). Persist + present
+	it. A missing token fails closed - never half-persist an unusable state."""
+	device_token = ((resp or {}).get("device_token") or "").strip()
+	if not device_token:
+		raise AgentUnreachableError("request_chat_pairing (legacy mode) returned no device_token")
+	settings = frappe.get_single("Jarvis Settings")
+	_save_credentials(
+		settings_doc=settings,
+		private_key_b64u=_priv_b64u(priv),
+		public_key_b64u=pub_b64u,
+		device_id=device_id,
+		device_token=device_token,
+	)
+	_logger.info("chat pairing: legacy mode device_id=%s", device_id)
+	return ChatDeviceCredentials(
+		device_id=device_id,
+		public_key=pub_b64u,
+		private_key=priv,
+		device_token=device_token,
+	)
+
+
+def _pair_mechanism_a(*, device_id: str, pub_b64u: str, priv: Ed25519PrivateKey) -> ChatDeviceCredentials:
+	"""Mechanism-A tenant (9.x): there is NO token yet, and that is a VALID state.
+	The CP has told the fleet-agent to poll + approve this deviceId; the gateway
+	issues the device token on the approved connect. Return bootstrap creds
+	carrying the gateway ``agent_token`` so ``agent_client`` can connect-first
+	(present ``auth.token``), drive NOT_PAIRED -> approved, and adopt the reissued
+	token. The stable keypair is already persisted, so re-requesting per turn
+	never regenerates the deviceId (no thrash).
+
+	Fail closed (D-d) if the gateway token is unset: without it the bootstrap
+	connect can neither be presented nor signed."""
+	bootstrap_token = _read_gateway_token()
+	if not bootstrap_token:
+		raise AgentUnreachableError("mechanism_a pairing needs the gateway agent_token, but none is set")
+	_logger.info("chat pairing: mechanism_a connect-first device_id=%s", device_id)
+	return ChatDeviceCredentials(
+		device_id=device_id,
+		public_key=pub_b64u,
+		private_key=priv,
+		device_token="",
+		bootstrap_token=bootstrap_token,
+	)
 
 
 def _generate_and_pair() -> ChatDeviceCredentials:
@@ -165,20 +334,17 @@ def _generate_and_pair() -> ChatDeviceCredentials:
 	relays to the customer's openclaw container as a PairedDevice
 	record), and persist the resulting credentials.
 
-	Shared between ensure_paired (cold-start path) and
-	rotate_chat_device (operator-triggered rotation path). The two
-	previously share-and-fork happened inline; pulling it out lets
-	rotation reuse the validation + error surface without
-	duplicating the keypair generation logic.
+	Used ONLY by ``rotate_chat_device`` now (the operator-triggered
+	force-repair): it still routes through the legacy synchronous forge
+	(``admin_client.pair_chat_device``), which the CP keeps intact per the
+	additive-endpoint decision. The cold-start / first-turn pairing path moved to
+	``_establish_pairing`` (mode fork). Operator rotation under Mechanism A -
+	regenerate keypair, then connect-first to re-pair - is a named follow-on
+	(same family as the deferred ``unpair_devices`` fix); on a Mechanism-A tenant
+	the CP's legacy forge is the broken path, so this stays legacy-only until then.
 	"""
 	priv, _pub_raw, pub_b64u, device_id = _generate_keypair()
-	priv_b64u = _b64u(
-		priv.private_bytes(
-			encoding=serialization.Encoding.Raw,
-			format=serialization.PrivateFormat.Raw,
-			encryption_algorithm=serialization.NoEncryption(),
-		)
-	)
+	priv_b64u = _priv_b64u(priv)
 
 	try:
 		resp = admin_client.pair_chat_device(public_key=pub_b64u, device_id=device_id)

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1181,6 +1181,30 @@ def handle_chat_send(payload: dict) -> None:
 					"status": "waking",
 				},
 			)
+		# Connect-first device pairing (Mechanism A): a bench that has not yet
+		# obtained its device token must (re)pair before it can reach the gateway.
+		# The connect below drives that one-time pairing (NOT_PAIRED -> approved ->
+		# token) and can take tens of seconds, so tell the user we're setting the
+		# assistant up rather than leaving a dead spinner. On the fail-closed cap
+		# the connect raises an honest "still getting ready" error handled below.
+		# Cheap + best-effort: only fires when no device token is persisted yet
+		# (steady-state turns skip it); a UX hint must never break the turn.
+		try:
+			from jarvis.chat.device import has_paired_token
+
+			if not has_paired_token(settings):
+				_publish_to_user(
+					user,
+					{
+						"kind": "run:status",
+						"conversation_id": conversation_id,
+						"message_id": assistant_msg.name,
+						"run_id": run_id,
+						"status": "pairing",
+					},
+				)
+		except Exception:
+			pass
 		try:
 			t_checkout = time.monotonic()
 			with agent_session_pool.checkout(gateway_url) as sess:

--- a/jarvis/tests/test_chat_agent_client.py
+++ b/jarvis/tests/test_chat_agent_client.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 
 import websocket
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat.agent_client import AgentSession
@@ -1194,3 +1194,322 @@ class TestCompactSession(FrappeTestCase):
 		with self.assertRaises(AgentUnreachableError) as cm:
 			sess.compact_session(key, None, timeout_s=5)
 		self.assertEqual(cm.exception.code, "compact-timeout")
+
+
+# --- Mechanism A: connect-first device pairing ------------------------------
+
+
+def _make_bootstrap_creds(gateway_token: str = "gw-tok") -> ChatDeviceCredentials:
+	"""A Mechanism-A pairing with a stable keypair but NO device token yet."""
+	import hashlib
+
+	priv = Ed25519PrivateKey.generate()
+	pub_raw = priv.public_key().public_bytes(
+		encoding=serialization.Encoding.Raw,
+		format=serialization.PublicFormat.Raw,
+	)
+	return ChatDeviceCredentials(
+		device_id=hashlib.sha256(pub_raw).hexdigest(),
+		public_key=_b64u(pub_raw),
+		private_key=priv,
+		device_token="",
+		bootstrap_token=gateway_token,
+	)
+
+
+def _not_paired_error(ws) -> str:
+	"""the agent's connect-first PENDING wire shape (spike invariant #3)."""
+	return _frame(
+		{
+			"type": "res",
+			"id": ws.sent[-1]["id"],
+			"ok": False,
+			"error": {
+				"code": "NOT_PAIRED",
+				"message": "pairing required",
+				"details": {"code": "PAIRING_REQUIRED", "reason": "not-paired"},
+			},
+		}
+	)
+
+
+class TestIsNotPaired(FrappeTestCase):
+	"""The NOT_PAIRED classifier is strictly typed (code/details only, never
+	message text) and DISJOINT from the stale-pairing classifier - the two never
+	both fire, so a NOT_PAIRED response can never reach the keypair-wiping repair
+	path (plan-check gap #3)."""
+
+	def _err(self, *, code=None, details=None):
+		return AgentUnreachableError("x", code=code, details=details)
+
+	def test_outer_code_not_paired(self):
+		from jarvis.chat.agent_client import _is_not_paired
+
+		self.assertTrue(_is_not_paired(self._err(code="NOT_PAIRED")))
+
+	def test_details_code_pairing_required(self):
+		from jarvis.chat.agent_client import _is_not_paired
+
+		self.assertTrue(
+			_is_not_paired(self._err(code="INVALID_REQUEST", details={"code": "PAIRING_REQUIRED"}))
+		)
+
+	def test_details_auth_reason_not_paired(self):
+		from jarvis.chat.agent_client import _is_not_paired
+
+		self.assertTrue(
+			_is_not_paired(self._err(code="INVALID_REQUEST", details={"authReason": "not-paired"}))
+		)
+
+	def test_details_reason_not_paired(self):
+		from jarvis.chat.agent_client import _is_not_paired
+
+		self.assertTrue(_is_not_paired(self._err(code="INVALID_REQUEST", details={"reason": "not-paired"})))
+
+	def test_no_code_or_details_is_false(self):
+		from jarvis.chat.agent_client import _is_not_paired
+
+		self.assertFalse(_is_not_paired(self._err()))
+		self.assertFalse(_is_not_paired(self._err(code="INVALID_REQUEST", details="not-a-dict")))
+
+	def test_disjoint_from_stale_pairing(self):
+		"""A stale-token rejection classifies as stale, NOT as not-paired, and a
+		not-paired classifies as not-paired, NOT as stale - the two are mutually
+		exclusive so the bootstrap loop and the stale-repair path never overlap."""
+		from jarvis.chat.agent_client import _is_not_paired, _is_stale_pairing
+
+		stale = self._err(
+			code="INVALID_REQUEST",
+			details={"code": "AUTH_DEVICE_TOKEN_MISMATCH", "authReason": "device_token_mismatch"},
+		)
+		self.assertTrue(_is_stale_pairing(stale))
+		self.assertFalse(_is_not_paired(stale))
+
+		pending = self._err(code="NOT_PAIRED", details={"reason": "not-paired"})
+		self.assertTrue(_is_not_paired(pending))
+		self.assertFalse(_is_stale_pairing(pending))
+
+
+class TestBootstrapPairConnect(FrappeTestCase):
+	"""Connect-first pairing (Mechanism A): the bench presents the gateway token,
+	drives NOT_PAIRED -> approved on its own bounded timer, and adopts the
+	reissued device token - WITHOUT ever wiping the stable keypair."""
+
+	def _pending_then_approved(self, token: str = "tok-issued"):
+		first = _ScriptedWS([_challenge(), None])
+		second = _ScriptedWS([_challenge(), None])
+		first._frames[1] = lambda: _not_paired_error(first)
+		second._frames[1] = lambda: _frame(
+			{
+				"type": "res",
+				"id": second.sent[-1]["id"],
+				"ok": True,
+				"payload": {"auth": {"deviceToken": token}},
+			}
+		)
+		return first, second
+
+	def test_not_paired_then_approved_adopts_token(self):
+		first, second = self._pending_then_approved("tok-issued")
+		ws_iter = iter([first, second])
+		creds = _make_bootstrap_creds("gw-tok")
+		update_mock = MagicMock(return_value=True)
+		clear_mock = MagicMock()
+		with (
+			patch(
+				"jarvis.chat.agent_client.websocket.create_connection",
+				side_effect=lambda *a, **kw: next(ws_iter),
+			),
+			patch("jarvis.chat.agent_client.ensure_paired", return_value=creds),
+			patch("jarvis.chat.agent_client.update_device_token", update_mock),
+			patch("jarvis.chat.agent_client.clear_credentials", clear_mock),
+			patch("jarvis.chat.agent_client.time.sleep"),
+		):
+			sess = AgentSession.connect("ws://t")
+		# The reissued token was adopted, in-memory and persisted.
+		self.assertEqual(sess._creds.device_token, "tok-issued")
+		update_mock.assert_called_once_with("tok-issued", device_id=creds.device_id)
+		# DISJOINT from the stale-pairing self-heal: the keypair was NEVER wiped.
+		clear_mock.assert_not_called()
+		self.assertTrue(first.closed)
+		sess.close()
+
+	def test_not_paired_never_wipes_keypair_and_fails_closed_at_cap(self):
+		"""At the deadline with no approval: fail closed (D-d) with the honest
+		user message, and NEVER call clear_credentials (gap #3)."""
+		from jarvis.chat import agent_client
+
+		ws = _ScriptedWS([_challenge(), None])
+		ws._frames[1] = lambda: _not_paired_error(ws)
+		clear_mock = MagicMock()
+		with (
+			patch("jarvis.chat.agent_client.websocket.create_connection", return_value=ws),
+			patch("jarvis.chat.agent_client.ensure_paired", return_value=_make_bootstrap_creds("gw-tok")),
+			patch("jarvis.chat.agent_client.clear_credentials", clear_mock),
+			patch("jarvis.chat.agent_client.time.sleep"),
+			patch("jarvis.chat.agent_client.PAIRING_APPROVAL_DEADLINE_SECONDS", 0),
+		):
+			with self.assertRaises(AgentUnreachableError) as cm:
+				AgentSession.connect("ws://t")
+		self.assertEqual(cm.exception.code, "pairing-pending")
+		self.assertEqual(str(cm.exception), agent_client.PAIRING_PENDING_USER_MESSAGE)
+		clear_mock.assert_not_called()  # the #1 trap: NOT_PAIRED must never wipe the keypair
+		self.assertTrue(ws.closed)
+
+	def test_non_not_paired_error_does_not_loop(self):
+		"""A non-NOT_PAIRED rejection during bootstrap is a real error: raise
+		immediately, no retry loop, no keypair wipe."""
+		ws = _ScriptedWS([_challenge(), None])
+		ws._frames[1] = lambda: _frame(
+			{
+				"type": "res",
+				"id": ws.sent[-1]["id"],
+				"ok": False,
+				"error": {"code": "UNAUTHORIZED", "message": "bad signature"},
+			}
+		)
+		cc = MagicMock(return_value=ws)
+		clear_mock = MagicMock()
+		with (
+			patch("jarvis.chat.agent_client.websocket.create_connection", cc),
+			patch("jarvis.chat.agent_client.ensure_paired", return_value=_make_bootstrap_creds("gw-tok")),
+			patch("jarvis.chat.agent_client.clear_credentials", clear_mock),
+			patch("jarvis.chat.agent_client.time.sleep"),
+		):
+			with self.assertRaises(AgentUnreachableError) as cm:
+				AgentSession.connect("ws://t")
+		self.assertIn("UNAUTHORIZED", str(cm.exception))
+		self.assertEqual(cc.call_count, 1)  # no reconnect loop on a real error
+		clear_mock.assert_not_called()
+
+	def test_approved_but_no_token_fails_closed(self):
+		"""An approved connect that issues no device token fails closed rather
+		than proceeding token-less."""
+		ws = _ScriptedWS([_challenge(), None])
+		ws._frames[1] = lambda: _frame(
+			{"type": "res", "id": ws.sent[-1]["id"], "ok": True, "payload": {"auth": {}}}
+		)
+		update_mock = MagicMock(return_value=True)
+		with (
+			patch("jarvis.chat.agent_client.websocket.create_connection", return_value=ws),
+			patch("jarvis.chat.agent_client.ensure_paired", return_value=_make_bootstrap_creds("gw-tok")),
+			patch("jarvis.chat.agent_client.update_device_token", update_mock),
+			patch("jarvis.chat.agent_client.time.sleep"),
+		):
+			with self.assertRaises(AgentUnreachableError) as cm:
+				AgentSession.connect("ws://t")
+		self.assertEqual(cm.exception.code, "pairing-no-token")
+		update_mock.assert_not_called()
+
+	def test_missing_gateway_token_fails_closed_without_opening_ws(self):
+		"""The bootstrap guard: no gateway token -> fail closed before any connect
+		(can neither present nor sign an auth block)."""
+		import hashlib
+
+		priv = Ed25519PrivateKey.generate()
+		pub_raw = priv.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+		creds = ChatDeviceCredentials(
+			device_id=hashlib.sha256(pub_raw).hexdigest(),
+			public_key=_b64u(pub_raw),
+			private_key=priv,
+			device_token="",
+			bootstrap_token="",
+		)
+		cc = MagicMock()
+		with patch("jarvis.chat.agent_client.websocket.create_connection", cc):
+			with self.assertRaises(AgentUnreachableError) as cm:
+				AgentSession._bootstrap_pair_connect("ws://t", creds)
+		self.assertEqual(cm.exception.code, "pairing-no-bootstrap-token")
+		cc.assert_not_called()
+
+
+def _verify_connect_signature(sent_connect: dict, presented_token: str, public_key_b64u: str) -> None:
+	"""Rebuild the v3 payload the client MUST have signed (token slot ==
+	``presented_token``) and verify the sent signature against the public key.
+	Raises cryptography.InvalidSignature if the client signed with a DIFFERENT
+	token than it presented - i.e. this is the invariant #2 guard."""
+	from jarvis.chat.agent_client import (
+		_CLIENT_ID,
+		_CLIENT_MODE,
+		_PLATFORM,
+		_REQUESTED_SCOPES,
+		_ROLE,
+	)
+	from jarvis.chat.device import build_payload_v3
+
+	dev = sent_connect["device"]
+	payload = build_payload_v3(
+		device_id=dev["id"],
+		client_id=_CLIENT_ID,
+		client_mode=_CLIENT_MODE,
+		role=_ROLE,
+		scopes=_REQUESTED_SCOPES,
+		signed_at_ms=dev["signedAt"],
+		device_token=presented_token,
+		nonce=dev["nonce"],
+		platform=_PLATFORM,
+		device_family="",
+	)
+	sig = base64.urlsafe_b64decode(dev["signature"] + "=" * (-len(dev["signature"]) % 4))
+	pub_raw = base64.urlsafe_b64decode(public_key_b64u + "=" * (-len(public_key_b64u) % 4))
+	Ed25519PublicKey.from_public_bytes(pub_raw).verify(sig, payload.encode("utf-8"))
+
+
+class TestHandshakeSignsPresentedToken(FrappeTestCase):
+	"""Spike invariant #2: the agent derives the signed payload's token slot as
+	auth.token ?? auth.deviceToken ?? auth.bootstrapToken, so the bench MUST sign
+	the slot with the SAME token it presents in ``auth``. These verify the
+	signature end-to-end for both connect modes."""
+
+	def test_steady_state_presents_and_signs_device_token(self):
+		creds = _make_creds()  # device_token="tok-test"
+
+		def _ok():
+			return _frame({"type": "res", "id": ws.sent[-1]["id"], "ok": True, "payload": {}})
+
+		ws = _ScriptedWS([_challenge(), _ok])
+		with (
+			patch("jarvis.chat.agent_client.websocket.create_connection", return_value=ws),
+			patch("jarvis.chat.agent_client.ensure_paired", return_value=creds),
+		):
+			sess = AgentSession.connect("ws://t")
+		sent = ws.sent[0]["params"]
+		self.assertEqual(sent["auth"], {"deviceToken": "tok-test"})
+		# Signature verifies against the PRESENTED token...
+		_verify_connect_signature(sent, "tok-test", creds.public_key)
+		# ...and would NOT verify against any other token (invariant #2 mutation guard).
+		with self.assertRaises(Exception):
+			_verify_connect_signature(sent, "some-other-token", creds.public_key)
+		sess.close()
+
+	def test_bootstrap_presents_and_signs_gateway_token(self):
+		creds = _make_bootstrap_creds("gw-tok")
+
+		def _ok():
+			return _frame(
+				{
+					"type": "res",
+					"id": ws.sent[-1]["id"],
+					"ok": True,
+					"payload": {"auth": {"deviceToken": "tok-issued"}},
+				}
+			)
+
+		ws = _ScriptedWS([_challenge(), _ok])
+		with (
+			patch("jarvis.chat.agent_client.websocket.create_connection", return_value=ws),
+			patch("jarvis.chat.agent_client.ensure_paired", return_value=creds),
+			patch("jarvis.chat.agent_client.update_device_token", MagicMock(return_value=True)),
+			patch("jarvis.chat.agent_client.time.sleep"),
+		):
+			sess = AgentSession.connect("ws://t")
+		sent = ws.sent[0]["params"]
+		# Bootstrap presents auth.token (the gateway token), NOT a deviceToken.
+		self.assertEqual(sent["auth"], {"token": "gw-tok"})
+		self.assertNotIn("deviceToken", sent["auth"])
+		# Signature verifies against the presented gateway token (invariant #2)...
+		_verify_connect_signature(sent, "gw-tok", creds.public_key)
+		# ...and NOT against the empty device_token the pre-fix code would have signed.
+		with self.assertRaises(Exception):
+			_verify_connect_signature(sent, "", creds.public_key)
+		sess.close()

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -80,22 +80,31 @@ def _clear_settings():
 
 
 class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
+	"""ensure_paired() forks on the CP's pairing ``mode`` (agent 9.3
+	device-pairing fix). The cold-start path now calls the additive
+	``request_chat_pairing`` (not the legacy ``pair_chat_device``): LEGACY mode
+	reproduces today's synchronous-token behaviour, MECHANISM_A returns
+	token-absent bootstrap creds (see TestEnsurePairedMechanismA). A fully
+	populated (keypair + token) Settings row is still the steady-state hot path,
+	reused with no CP call."""
+
 	def setUp(self):
 		_clear_settings()
 
-	def test_generates_keypair_calls_admin_and_persists(self):
+	def test_legacy_mode_generates_keypair_and_persists(self):
 		captured = {}
 
-		def _fake_pair(public_key, device_id):
+		def _fake_request(public_key, device_id, **kw):
 			captured["public_key"] = public_key
 			captured["device_id"] = device_id
-			return {"device_token": "tok-from-admin"}
+			return {"mode": "legacy", "device_token": "tok-from-cp"}
 
-		with patch("jarvis.chat.device.admin_client.pair_chat_device", side_effect=_fake_pair):
+		with patch("jarvis.chat.device.admin_client.request_chat_pairing", side_effect=_fake_request):
 			creds = chat_device.ensure_paired()
 
-		# Returned object is internally consistent.
-		self.assertEqual(creds.device_token, "tok-from-admin")
+		# Returned object is internally consistent + a steady-state (not bootstrap) pairing.
+		self.assertEqual(creds.device_token, "tok-from-cp")
+		self.assertFalse(creds.needs_bootstrap)
 		self.assertEqual(creds.public_key, captured["public_key"])
 		self.assertEqual(creds.device_id, captured["device_id"])
 		# deviceId must match sha256(rawPublicKey) - same invariant agent enforces.
@@ -105,11 +114,11 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(s.chat_device_id, creds.device_id)
 		self.assertEqual(s.chat_device_public_key, creds.public_key)
-		self.assertEqual(s.get_password("chat_device_token"), "tok-from-admin")
+		self.assertEqual(s.get_password("chat_device_token"), "tok-from-cp")
 		self.assertTrue(s.get_password("chat_device_private_key"))
 
-	def test_reuses_existing_creds_without_admin_call(self):
-		# Seed Settings with a valid keypair + token.
+	def test_reuses_existing_creds_without_cp_call(self):
+		# Seed Settings with a valid keypair + token (steady state).
 		priv = Ed25519PrivateKey.generate()
 		pub_raw = priv.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
 		priv_raw = priv.private_bytes(
@@ -122,49 +131,55 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 		s.db_set("chat_device_token", "tok-existing")
 		frappe.db.commit()
 
-		with patch("jarvis.chat.device.admin_client.pair_chat_device") as mock_pair:
+		with patch("jarvis.chat.device.admin_client.request_chat_pairing") as mock_req:
 			creds = chat_device.ensure_paired()
-		self.assertFalse(mock_pair.called)
+		self.assertFalse(mock_req.called)
 		self.assertEqual(creds.device_token, "tok-existing")
+		self.assertFalse(creds.needs_bootstrap)
 		self.assertEqual(creds.device_id, hashlib.sha256(pub_raw).hexdigest())
 
-	def test_admin_failure_raises_and_does_not_persist(self):
-		with patch("jarvis.chat.device.admin_client.pair_chat_device", side_effect=RuntimeError("boom")):
+	def test_cp_failure_raises_and_persists_no_token(self):
+		"""A CP failure surfaces as AgentUnreachableError and NEVER persists a
+		device TOKEN. The stable keypair MAY be persisted (that is the deliberate
+		anti-thrash design - token-absent is a valid state), so the assertion is
+		on the usable credential (the token), not on the keypair."""
+		with patch("jarvis.chat.device.admin_client.request_chat_pairing", side_effect=RuntimeError("boom")):
 			with self.assertRaises(AgentUnreachableError):
 				chat_device.ensure_paired()
-		# Nothing persisted on failure.
 		s = frappe.get_single("Jarvis Settings")
-		self.assertFalse(s.chat_device_id)
-		self.assertFalse(s.get_password("chat_device_private_key", raise_exception=False))
+		self.assertFalse(s.get_password("chat_device_token", raise_exception=False) or "")
 
-	def test_empty_device_token_raises_unreachable(self):
-		with patch("jarvis.chat.device.admin_client.pair_chat_device", return_value={"device_token": ""}):
+	def test_legacy_empty_token_raises(self):
+		with patch(
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "legacy", "device_token": ""},
+		):
 			with self.assertRaises(AgentUnreachableError):
 				chat_device.ensure_paired()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.get_password("chat_device_token", raise_exception=False) or "")
 
-	def test_concurrent_callers_share_one_admin_pair_call(self):
-		"""Cold-start convoy collapse. Cross-repo punch-list "Race:
-		send_message + RQ worker both invoke ensure_paired() concurrently".
+	def test_unknown_mode_fails_closed(self):
+		"""An unrecognised/blank mode must fail closed - never fabricate a
+		credential (D-d)."""
+		with patch(
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "something-new"},
+		):
+			with self.assertRaises(AgentUnreachableError):
+				chat_device.ensure_paired()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.get_password("chat_device_token", raise_exception=False) or "")
 
-		Before the fix: a fresh bench with no chat_device_* fields and
-		two concurrent callers (web request + RQ worker) BOTH observed
-		``_read_credentials() is None`` and BOTH called
-		``_generate_and_pair`` - last writer to Jarvis Settings wins;
-		the other caller holds in-memory creds that don't match what
-		admin saw.
+	def test_concurrent_callers_share_one_pairing(self):
+		"""Cold-start convoy collapse (now on the keypair-gen lock). A follower
+		that enters the lock after the winner populated Settings reads the
+		winner's creds and returns without any CP round-trip.
 
-		After the fix: a Redis lock collapses the convoy. The first
-		caller pairs; the second waits on the lock, re-reads inside it,
-		and returns the winner's creds without a second admin call.
-
-		Real concurrency on a single-threaded test runner is tricky to
-		stage. We simulate the convoy by patching the lock context
-		manager so the "second" caller pre-populates Settings before
-		entering the lock body - the re-check inside the lock must
-		short-circuit on those existing creds.
-		"""
-		# First caller paints credentials into Settings as if it had won
-		# the lock race.
+		Real concurrency on a single-threaded test runner is tricky to stage; we
+		simulate the convoy by patching the lock context manager so the "second"
+		caller pre-populates Settings before entering the lock body - the re-check
+		inside the lock must short-circuit on those existing creds."""
 		first_priv = Ed25519PrivateKey.generate()
 		first_pub_raw = first_priv.public_key().public_bytes(
 			serialization.Encoding.Raw,
@@ -197,24 +212,22 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 			def __exit__(_self, *a):
 				return False
 
-		mock_pair = patch("jarvis.chat.device.admin_client.pair_chat_device").start()
+		mock_req = patch("jarvis.chat.device.admin_client.request_chat_pairing").start()
 		mock_lock = patch("jarvis._redis_lock.redis_lock", return_value=_FakeLockCtx()).start()
 		try:
 			creds = chat_device.ensure_paired()
 		finally:
 			patch.stopall()
 
-		# Second caller picked up the winner's creds; no admin pair call
-		# was made.
-		self.assertFalse(mock_pair.called)
+		# Follower picked up the winner's creds; no CP request was made.
+		self.assertFalse(mock_req.called)
 		self.assertEqual(creds.device_token, "tok-winner")
 		self.assertEqual(creds.device_id, first_device_id)
 		self.assertTrue(mock_lock.called)
 
-	def test_partial_state_triggers_repair(self):
-		"""If only some fields are set, treat the whole pairing as missing
-		so the next call re-pairs atomically - protects against half-failed
-		writes from a previous deploy/migration."""
+	def test_partial_state_regenerates_keypair(self):
+		"""Only device_id set (a half-failed prior write): the keypair itself is
+		absent, so a fresh one is generated and a legacy token acquired."""
 		s = frappe.get_single("Jarvis Settings")
 		s.db_set("chat_device_id", "abc")
 		s.db_set("chat_device_public_key", "")  # incomplete
@@ -223,11 +236,149 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 		frappe.db.commit()
 
 		with patch(
-			"jarvis.chat.device.admin_client.pair_chat_device", return_value={"device_token": "tok-repaired"}
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "legacy", "device_token": "tok-repaired"},
 		):
 			creds = chat_device.ensure_paired()
 		self.assertEqual(creds.device_token, "tok-repaired")
 		self.assertNotEqual(creds.device_id, "abc")  # fresh keypair was generated
+
+
+class TestEnsurePairedMechanismA(_SettingsSnapshotMixin, FrappeTestCase):
+	"""Mechanism-A (agent 9.x) pairing: ensure_paired returns token-absent
+	bootstrap creds, the keypair stays STABLE across pending turns (no deviceId
+	thrash - plan-check gap #3), and it fails closed without a gateway token."""
+
+	def setUp(self):
+		_clear_settings()
+		# The gateway token the bootstrap connect presents (auth.token). Not
+		# covered by _SettingsSnapshotMixin, so snapshot + restore it ourselves.
+		s = frappe.get_single("Jarvis Settings")
+		self._agent_token_snap = s.get_password("agent_token", raise_exception=False) or ""
+		self._set_agent_token("gw-secret")
+
+	def tearDown(self):
+		self._set_agent_token(self._agent_token_snap)
+
+	def _set_agent_token(self, value):
+		from frappe.utils.password import remove_encrypted_password
+
+		from jarvis._password_utils import set_settings_password
+
+		s = frappe.get_single("Jarvis Settings")
+		if value:
+			set_settings_password(s, "agent_token", value)
+		else:
+			s.db_set("agent_token", "")
+			remove_encrypted_password("Jarvis Settings", "Jarvis Settings", "agent_token")
+		frappe.db.commit()
+
+	def test_returns_bootstrap_creds_with_no_token(self):
+		with patch(
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "mechanism_a", "accepted": True},
+		):
+			creds = chat_device.ensure_paired()
+		# Token-absent is a VALID state; the gateway token rides bootstrap_token.
+		self.assertEqual(creds.device_token, "")
+		self.assertEqual(creds.bootstrap_token, "gw-secret")
+		self.assertTrue(creds.needs_bootstrap)
+		raw = base64.urlsafe_b64decode(creds.public_key + "=" * (-len(creds.public_key) % 4))
+		self.assertEqual(creds.device_id, hashlib.sha256(raw).hexdigest())
+		# Keypair persisted; token NOT persisted.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.chat_device_id, creds.device_id)
+		self.assertTrue(s.get_password("chat_device_private_key"))
+		self.assertFalse(s.get_password("chat_device_token", raise_exception=False) or "")
+
+	def test_without_gateway_token_fails_closed(self):
+		self._set_agent_token("")
+		with patch(
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "mechanism_a", "accepted": True},
+		):
+			with self.assertRaises(AgentUnreachableError):
+				chat_device.ensure_paired()
+		# Fail-closed: no device token fabricated.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.get_password("chat_device_token", raise_exception=False) or "")
+
+	def test_keypair_is_stable_across_pending_turns(self):
+		"""THE anti-thrash guarantee (plan-check gap #3): while pairing is pending
+		(no token yet), every ensure_paired returns the SAME deviceId. A keypair
+		regenerated each turn would be a moving target the fleet-agent can never
+		approve."""
+		with patch(
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "mechanism_a", "accepted": True},
+		):
+			first = chat_device.ensure_paired()
+			second = chat_device.ensure_paired()
+		self.assertEqual(first.device_id, second.device_id)
+		self.assertEqual(first.public_key, second.public_key)
+
+	def test_token_adoption_switches_to_steady_state_same_keypair(self):
+		"""Once the gateway-issued token is persisted (adopted), ensure_paired
+		returns STEADY-state creds (needs_bootstrap False) on the SAME keypair -
+		the pending->paired transition never changes the deviceId."""
+		with patch(
+			"jarvis.chat.device.admin_client.request_chat_pairing",
+			return_value={"mode": "mechanism_a", "accepted": True},
+		):
+			pending = chat_device.ensure_paired()
+		# Gateway approves + issues a token; the bench adopts it.
+		self.assertTrue(chat_device.update_device_token("tok-issued", device_id=pending.device_id))
+		with patch("jarvis.chat.device.admin_client.request_chat_pairing") as mock_req:
+			steady = chat_device.ensure_paired()
+		self.assertFalse(mock_req.called)
+		self.assertFalse(steady.needs_bootstrap)
+		self.assertEqual(steady.device_token, "tok-issued")
+		self.assertEqual(steady.device_id, pending.device_id)
+
+
+class TestNeedsBootstrap(FrappeTestCase):
+	"""The connect-mode discriminator: needs_bootstrap is True ONLY for a
+	Mechanism-A pairing with no device token yet (token absent + gateway token
+	present)."""
+
+	def _creds(self, *, device_token, bootstrap_token):
+		priv = Ed25519PrivateKey.generate()
+		return chat_device.ChatDeviceCredentials(
+			device_id="d",
+			public_key="p",
+			private_key=priv,
+			device_token=device_token,
+			bootstrap_token=bootstrap_token,
+		)
+
+	def test_true_only_when_token_absent_and_bootstrap_present(self):
+		self.assertTrue(self._creds(device_token="", bootstrap_token="gw").needs_bootstrap)
+
+	def test_steady_state_is_not_bootstrap(self):
+		self.assertFalse(self._creds(device_token="tok", bootstrap_token="gw").needs_bootstrap)
+		self.assertFalse(self._creds(device_token="tok", bootstrap_token="").needs_bootstrap)
+
+	def test_no_gateway_token_is_not_bootstrap(self):
+		self.assertFalse(self._creds(device_token="", bootstrap_token="").needs_bootstrap)
+
+
+class TestHasPairedToken(_SettingsSnapshotMixin, FrappeTestCase):
+	"""The cheap UX gate the turn path reads to decide whether to render the
+	'Setting up your assistant…' state before it connects."""
+
+	def setUp(self):
+		_clear_settings()
+
+	def test_true_when_token_present(self):
+		from jarvis._password_utils import set_settings_password
+
+		s = frappe.get_single("Jarvis Settings")
+		set_settings_password(s, "chat_device_token", "tok")
+		frappe.db.commit()
+		self.assertTrue(chat_device.has_paired_token())
+
+	def test_false_when_token_absent(self):
+		self.assertFalse(chat_device.has_paired_token())
 
 
 class TestRotateChatDevice(_SettingsSnapshotMixin, FrappeTestCase):


### PR DESCRIPTION
openclaw 9.3 moved paired devices to SQLite, so the fleet-agent's paired.json forge never reaches verifyDeviceToken and every 9.3 tenant's chat dies with device_token_mismatch. Fix the bench half of Mechanism A: pair via openclaw's own supported approval flow instead of a forged record.

device.py:
- ensure_paired() forks on the CP's pairing mode via the new additive admin_client.request_chat_pairing(public_key, device_id):
    * legacy      -> the CP forged a token synchronously (today's path), present it.
    * mechanism_a -> no token yet; return token-absent bootstrap creds carrying
      the gateway agent_token. Token-absent is now a VALID state.
- The keypair is generated + persisted ONCE and stays stable across every
  connect/approve/reconnect (new _read_keypair / _save_keypair /
  _ensure_keypair_under_lock). Only keypair-gen is under the
  chat_device_initial_pair Redis lock; the CP call + token cascade run outside
  it. A stable deviceId is what makes the fleet-agent's poll+approve converge
  (a regenerated keypair per turn would thrash).
- ChatDeviceCredentials gains bootstrap_token + needs_bootstrap; has_paired_token
  is a cheap UX gate for the turn path.

agent_client.py:
- New _bootstrap_pair_connect state machine: present the gateway token (auth.token), drive NOT_PAIRED -> approved on our own bounded timer (ignoring openclaw's pauseReconnect hint), and adopt the reissued device token from hello-ok.auth.deviceToken. DISJOINT from the stale-pairing self-heal: it NEVER wipes the keypair. Bounded to one episode per turn; fail-closed at the cap.
- _handshake now builds the connect frame's auth block first, then derives the signed v3 payload's token slot FROM it (auth.token ?? auth.deviceToken ?? auth.bootstrapToken) so the presented token and the signed token can never drift (spike invariant #2). Steady state is unchanged (auth.deviceToken).
- New strictly-typed _is_not_paired classifier, disjoint from _is_stale_pairing.

UX: the turn renders a "Setting up your assistant…" state during the one-time (re)pair (new run:status "pairing" + a testable preConnectStatusLabel lib), and an honest "Still getting your assistant ready…" error on fail-closed.

Tests: mode fork, keypair stability, token-absent-valid, fail-closed paths, NOT_PAIRED-never-wipes-keypair, invariant-#2 signature verification (both modes), the classifier's disjointness, and the status-phrase lib. Python tests need a bench (borrow-run); the frontend needs a browser smoke.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
