### PR TITLE
feat(patch): clear stale chat-device pairing on the 9.3 reprovision u…

### DIFF
--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -56,3 +56,4 @@ jarvis.patches.v2_17_drop_auto_apply_changes
 jarvis.patches.v2_18_agent_access_grandfather
 jarvis.patches.v2_19_drop_connectors_kill_switch
 jarvis.patches.v2_19_clear_retired_openai_subscription_pins
+jarvis.patches.v2_19_clear_chat_device_for_9_3_reprovision

--- a/jarvis/patches/v2_19_clear_chat_device_for_9_3_reprovision.py
+++ b/jarvis/patches/v2_19_clear_chat_device_for_9_3_reprovision.py
@@ -1,22 +1,30 @@
-"""9.3 reprovision: clear the stale chat-device pairing so it re-bootstraps clean.
+"""9.3 reprovision: restore the bench-owned state the fresh container came up empty of.
 
-The 6.8 -> 9.3 upgrade rebuilds each tenant's container FRESH (the old openclaw state
-can't migrate in place), so the bench's stored chat-device token is stale -- the new
-container's SQLite has no record of it, and every connect would fail with
-"device token mismatch" until something re-pairs. Clearing the four chat_device_*
-credentials flips ``device.needs_bootstrap`` True, so the bench's NEXT connection
-re-pairs cleanly -- via Mechanism A on a 9.3 container, or the legacy forge if the
-container is somehow still 6.8 (the re-pair adapts to the tenant's image).
+The 6.8 -> 9.3 upgrade rebuilds each tenant's agent container FRESH (the old agent state
+can't migrate in place). Two things that live ONLY on the bench are lost to the new
+container and are restored here, proactively on the post-reprovision app upgrade -- the
+operator reprovision never runs the customer-driven reset poll that normally drives this:
 
-Why a patch and not only the connect-time self-heal: this fires PROACTIVELY on the
-post-reprovision app upgrade, so the re-pair does not depend on the reactive
-device_token_mismatch detection firing, nor on the customer chatting first. The
-self-heal still covers any future stale-token case; this just de-risks the bulk roll.
+1. **Chat-device pairing.** The stored chat-device token is stale (the new container has
+   no record of it), so every connect fails with "device token mismatch". Clearing the
+   four chat_device_* credentials flips ``device.needs_bootstrap`` True, so the bench's
+   next connection re-pairs cleanly -- Mechanism A on a 9.3 container, or the legacy forge
+   if it is somehow still 6.8 (the re-pair adapts to the tenant's image). Firing here is
+   proactive: the re-pair no longer depends on the reactive device_token_mismatch
+   self-heal, nor on the customer chatting first.
 
-One-time (patches run once, tracked). Idempotent -- a second run on already-empty
-fields is a no-op. ``chat_device_token`` / ``chat_device_private_key`` are Password
-fields (stored in __Auth); ``db.set_value`` clears both those and the two plain
-fields. Dropping the keypair is safe: the next bootstrap regenerates a stable one.
+2. **Skills + LLM credential.** The control plane re-carries its own config, but the
+   custom/learned skills and the LLM credential live ONLY on the bench (the LLM-key
+   invariant -- admin holds no copy). ``_resync_after_rebuild`` re-pushes the skills
+   (always) and re-drives the LLM config (when one exists); both legs enqueue + dedupe and
+   never raise. Without this the fresh container would pair but have no model creds or
+   skills, because the resync's normal trigger -- the ``workspace_reset_state`` poll -- is
+   customer-SPA-driven, and an operator-initiated upgrade never fires it.
+
+One-time (patches run once, tracked). Idempotent. ``chat_device_token`` /
+``chat_device_private_key`` are Password fields (in __Auth); ``db.set_value`` clears those
+and the two plain fields. Dropping the keypair is safe: bootstrap regenerates a stable one.
+The connect-time self-heal still covers any future stale-token case; this de-risks the roll.
 """
 
 import frappe
@@ -25,6 +33,7 @@ import frappe
 def execute():
 	if not frappe.db.exists("DocType", "Jarvis Settings"):
 		return
+	# 1. Clear the stale chat-device pairing -> clean re-pair on the next connection.
 	frappe.db.set_value(
 		"Jarvis Settings",
 		"Jarvis Settings",
@@ -36,3 +45,8 @@ def execute():
 		},
 	)
 	frappe.clear_cache(doctype="Jarvis Settings")
+	# 2. Re-push the bench-owned skills + LLM credential the fresh container lacks (CP
+	#    carries its own config; these live only on the bench). Enqueued; never raises.
+	from jarvis.onboarding import _resync_after_rebuild
+
+	_resync_after_rebuild(frappe.get_single("Jarvis Settings"))

--- a/jarvis/patches/v2_19_clear_chat_device_for_9_3_reprovision.py
+++ b/jarvis/patches/v2_19_clear_chat_device_for_9_3_reprovision.py
@@ -1,0 +1,38 @@
+"""9.3 reprovision: clear the stale chat-device pairing so it re-bootstraps clean.
+
+The 6.8 -> 9.3 upgrade rebuilds each tenant's container FRESH (the old openclaw state
+can't migrate in place), so the bench's stored chat-device token is stale -- the new
+container's SQLite has no record of it, and every connect would fail with
+"device token mismatch" until something re-pairs. Clearing the four chat_device_*
+credentials flips ``device.needs_bootstrap`` True, so the bench's NEXT connection
+re-pairs cleanly -- via Mechanism A on a 9.3 container, or the legacy forge if the
+container is somehow still 6.8 (the re-pair adapts to the tenant's image).
+
+Why a patch and not only the connect-time self-heal: this fires PROACTIVELY on the
+post-reprovision app upgrade, so the re-pair does not depend on the reactive
+device_token_mismatch detection firing, nor on the customer chatting first. The
+self-heal still covers any future stale-token case; this just de-risks the bulk roll.
+
+One-time (patches run once, tracked). Idempotent -- a second run on already-empty
+fields is a no-op. ``chat_device_token`` / ``chat_device_private_key`` are Password
+fields (stored in __Auth); ``db.set_value`` clears both those and the two plain
+fields. Dropping the keypair is safe: the next bootstrap regenerates a stable one.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Jarvis Settings"):
+		return
+	frappe.db.set_value(
+		"Jarvis Settings",
+		"Jarvis Settings",
+		{
+			"chat_device_id": "",
+			"chat_device_public_key": "",
+			"chat_device_token": "",
+			"chat_device_private_key": "",
+		},
+	)
+	frappe.clear_cache(doctype="Jarvis Settings")

--- a/jarvis/tests/test_clear_chat_device_patch.py
+++ b/jarvis/tests/test_clear_chat_device_patch.py
@@ -1,0 +1,35 @@
+"""Unit test for the 9.3 reprovision chat-device clear patch (mocked, no bench state)."""
+
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.patches.v2_19_clear_chat_device_for_9_3_reprovision import execute
+
+FIELDS = {"chat_device_id", "chat_device_public_key", "chat_device_token", "chat_device_private_key"}
+
+
+class TestClearChatDevicePatch(FrappeTestCase):
+	def test_clears_all_four_chat_device_fields_empty(self):
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.db.set_value") as sv,
+			patch("frappe.clear_cache"),
+		):
+			execute()
+		sv.assert_called_once()
+		args = sv.call_args.args
+		self.assertEqual(args[0], "Jarvis Settings")
+		self.assertEqual(args[1], "Jarvis Settings")
+		cleared = args[2]
+		self.assertEqual(set(cleared), FIELDS)
+		self.assertTrue(all(v == "" for v in cleared.values()))
+
+	def test_noop_when_settings_doctype_absent(self):
+		with (
+			patch("frappe.db.exists", return_value=False),
+			patch("frappe.db.set_value") as sv,
+			patch("frappe.clear_cache"),
+		):
+			execute()
+		sv.assert_not_called()

--- a/jarvis/tests/test_clear_chat_device_patch.py
+++ b/jarvis/tests/test_clear_chat_device_patch.py
@@ -1,6 +1,6 @@
-"""Unit test for the 9.3 reprovision chat-device clear patch (mocked, no bench state)."""
+"""Unit test for the 9.3 reprovision bench-restore patch (mocked, no bench state)."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from frappe.tests.utils import FrappeTestCase
 
@@ -10,13 +10,16 @@ FIELDS = {"chat_device_id", "chat_device_public_key", "chat_device_token", "chat
 
 
 class TestClearChatDevicePatch(FrappeTestCase):
-	def test_clears_all_four_chat_device_fields_empty(self):
+	def test_clears_device_and_triggers_resync(self):
 		with (
 			patch("frappe.db.exists", return_value=True),
 			patch("frappe.db.set_value") as sv,
 			patch("frappe.clear_cache"),
+			patch("frappe.get_single", return_value=MagicMock()) as gs,
+			patch("jarvis.onboarding._resync_after_rebuild") as resync,
 		):
 			execute()
+		# device pairing cleared (all four fields emptied)
 		sv.assert_called_once()
 		args = sv.call_args.args
 		self.assertEqual(args[0], "Jarvis Settings")
@@ -24,12 +27,16 @@ class TestClearChatDevicePatch(FrappeTestCase):
 		cleared = args[2]
 		self.assertEqual(set(cleared), FIELDS)
 		self.assertTrue(all(v == "" for v in cleared.values()))
+		# and the bench-owned skills + LLM credential are re-pushed
+		resync.assert_called_once_with(gs.return_value)
 
 	def test_noop_when_settings_doctype_absent(self):
 		with (
 			patch("frappe.db.exists", return_value=False),
 			patch("frappe.db.set_value") as sv,
 			patch("frappe.clear_cache"),
+			patch("jarvis.onboarding._resync_after_rebuild") as resync,
 		):
 			execute()
 		sv.assert_not_called()
+		resync.assert_not_called()


### PR DESCRIPTION
…pgrade

The 6.8->9.3 upgrade rebuilds each tenant's container fresh, so the bench's stored chat-device token is stale -- the new container's SQLite has no record of it, and connects fail with device_token_mismatch until something re-pairs. This one-time patch clears the four chat_device_* credentials on the app upgrade (which follows the container reprovision), so the next connection re-bootstraps cleanly via Mechanism A -- proactively, rather than depending on the reactive device_token_mismatch self-heal to fire or on the customer chatting first. Complements (does not replace) the connect-time self-heal, which still covers future stale-token cases. Idempotent; the keypair is regenerated on the next bootstrap.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
