### PR TITLE
fix(agents): inject as-of report_date so findings cap at today, not a future to_date

### DIFF
--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -906,7 +906,23 @@ def record_delegate_run(
 		"coverage_json": coverage_blob[:60000],
 	}
 	if scope:
-		run_values["scope_json"] = frappe.as_json(scope)[:60000]
+		# Merge the delegate's writeback scope ONTO the trigger-stamped scope rather
+		# than overwriting it. The delegate forwards only the core dims (company,
+		# fiscal_year, from_date, to_date), so a blind overwrite drops the
+		# bench-stamped as-of date (report_date) and prior-FY bounds -- and a run
+		# persisted without report_date replays against to_date, changing findings and
+		# the integrity digest. Delegate values win where present; bench-only keys survive.
+		import json as _json
+
+		base = {}
+		try:
+			base = _json.loads(frappe.db.get_value(RUN, run_doc.name, "scope_json") or "{}")
+			if not isinstance(base, dict):
+				base = {}
+		except Exception:
+			base = {}
+		base.update(scope)
+		run_values["scope_json"] = frappe.as_json(base)[:60000]
 	if integrity_digest:
 		run_values["integrity_digest"] = str(integrity_digest)[:64]
 	if canvas_ref:

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -1403,11 +1403,12 @@ def _audit_prompt(listing, inst, trigger: str, scope: dict | None = None) -> str
 		scope_block += f"\n\nAUTHORIZED APPS (the ONLY apps you may read source from or write about): {apps}."
 	if scope and scope.get("company"):
 		scope_block += (
-			"\n\nEXPLICIT SCOPE (use these EXACT values; never infer the period): "
+			"\n\nEXPLICIT SCOPE (use these EXACT values; never infer the period or the current date): "
 			f'company="{scope.get("company")}", '
 			f'fiscal_year="{scope.get("fiscal_year")}", '
 			f'from_date="{scope.get("from_date")}", '
 			f'to_date="{scope.get("to_date")}", '
+			f'report_date="{scope.get("report_date")}", '
 			f'prior_fy_start="{scope.get("prior_fy_start")}", '
 			f'prior_fy_end="{scope.get("prior_fy_end")}".'
 		)

--- a/jarvis/chat/agent_scope.py
+++ b/jarvis/chat/agent_scope.py
@@ -96,6 +96,12 @@ def _resolve(company, fiscal_year, from_date, to_date) -> dict:
 		"to_date": to_date,
 		"prior_fy_start": prior["py_start"] if prior else None,
 		"prior_fy_end": prior["py_end"] if prior else None,
+		# The run's as-of date (site date, never a container clock). to_date bounds
+		# the analysis window and MAY be in the future (a user-set or fiscal-year
+		# end), but a period-end finding must not assess data that has not happened
+		# yet: an evaluator caps its "due" cutoff at report_date so future-dated
+		# schedule rows (e.g. the rest of the year's depreciation) are never flagged.
+		"report_date": frappe.utils.today(),
 	}
 
 

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -390,6 +390,7 @@ class TestAgentsMarketplace(unittest.TestCase):
 			"fiscal_year": "2026-2027",
 			"from_date": "2026-04-01",
 			"to_date": "2027-03-31",
+			"report_date": "2026-09-11",
 			"prior_fy_start": "2025-04-01",
 			"prior_fy_end": "2026-03-31",
 		}
@@ -399,7 +400,21 @@ class TestAgentsMarketplace(unittest.TestCase):
 			self.assertNotIn(leak, gen)
 		self.assertIn("EXPLICIT SCOPE", gen)
 		self.assertIn("2026-04-01", gen)  # scope injected verbatim (A6)
+		self.assertIn("2026-09-11", gen)  # as-of report_date conveyed to the delegate
 		self.assertIn(inst_name, gen)  # installation pointer
+
+	def test_resolve_scope_injects_report_date_and_preserves_to_date(self):
+		"""to_date bounds the analysis window (may be a future FY end) and is left
+		as-is; report_date is the site's today, injected so a period-end finding can
+		cap due-ness at the as-of date instead of a future to_date."""
+		from jarvis.chat import agent_scope
+
+		company = frappe.db.get_value("Company", {}, "name")
+		if not company:
+			self.skipTest("no Company on the test site")
+		sc = agent_scope._resolve(company, None, "2026-04-01", "2027-03-31")
+		self.assertEqual(sc["to_date"], "2027-03-31")  # window preserved, never clamped
+		self.assertEqual(sc["report_date"], frappe.utils.today())  # as-of = site today
 
 	# ------------------------------------------------------------------ #
 	# (b) mutation authZ (S3)

--- a/jarvis/tests/test_platform_writeback.py
+++ b/jarvis/tests/test_platform_writeback.py
@@ -467,6 +467,36 @@ class TestWritebackIntegration(FrappeTestCase):
 		)
 		self.assertEqual(frappe.db.get_value(RUN, run.name, "result_state"), "evaluated_clean")
 
+	def test_scope_merge_preserves_bench_stamped_report_date(self):
+		# The bench stamps report_date (+ prior-FY) at trigger; the delegate's writeback
+		# scope carries only the core dims. record_delegate_run MERGES onto the existing
+		# stamp rather than overwriting, so the persisted scope keeps report_date -- a run
+		# missing it would replay against to_date and change findings + digest.
+		import json as _j
+
+		run = _mk_run(
+			self.owner,
+			scope_json='{"company": "Stale Co", "to_date": "2027-03-31", '
+			'"report_date": "2026-09-11", "prior_fy_end": "2026-03-31"}',
+		)
+		agent_runs.record_delegate_run(
+			run,
+			self.inst,
+			[],
+			coverage={TOKEN: "evaluated"},
+			scope={
+				"company": self.company,
+				"fiscal_year": "2026-2027",
+				"from_date": "2026-04-01",
+				"to_date": "2027-03-31",
+			},
+		)
+		sj = _j.loads(frappe.db.get_value(RUN, run.name, "scope_json"))
+		self.assertEqual(sj["report_date"], "2026-09-11")  # bench-only key survives
+		self.assertEqual(sj["prior_fy_end"], "2026-03-31")
+		self.assertEqual(sj["company"], self.company)  # delegate value wins
+		self.assertEqual(sj["from_date"], "2026-04-01")  # delegate-added key present
+
 	def test_not_evaluable_persisted_when_all_required_unevaluated(self):
 		run = _mk_run(self.owner)
 		agent_runs.record_delegate_run(


### PR DESCRIPTION
## Problem

An audit's `to_date` bounds the analysis window and **may be a future fiscal-year end** — it's derived from the installation's `fiscal_year` (`agent_scope._resolve` sets `to_date = year_end_date`). But a period-end finding must not assess data that hasn't happened yet. Concretely, the Fixed Asset & Depreciation Auditor was flagging the **rest of the year's not-yet-due depreciation** as "did not post" (seven rows, 2026-09-30 → 2027-03-31, when today is 2026-09-11).

## Fix

Give the delegate an explicit **as-of date** and let evaluators cap on it, without shrinking the analysis window:

- `agent_scope._resolve()` injects `report_date = frappe.utils.today()` (the **site** date, never a container clock). `to_date` is left unchanged.
- `agent_scheduler._audit_prompt()` conveys `report_date` in the EXPLICIT SCOPE block, verbatim.

A global `to_date` clamp was considered and **rejected** — it would shrink the window and drop future-dated vouchers from the analysis. The right cut is per-finding: evaluators cap due-ness at `min(report_date, to_date)`. The fixed-asset auditor's evaluator does this in `Aerele-RnD/jarvis-agents` PR #5.

## Back-compat

Purely additive. An evaluator that ignores `report_date` is unaffected; one that reads it falls back to `to_date` when it's absent (so an un-upgraded bundle is byte-identical). `scope_json` is `frappe.as_json`'d (tolerates the extra key) and the prompt lists fields explicitly (no leak surface).

## Tests

- `test_generic_prompt_is_non_leaky` — the prompt conveys `report_date`, non-leak assertions still hold.
- `test_resolve_scope_injects_report_date_and_preserves_to_date` — `_resolve` injects `report_date`==site-today while preserving `to_date`.

Both pass on a migrated `test_jarvis`; ruff-format clean.

## Verified live (ERPNext v16)

- Before: FAD-COMPL flagged the seven future rows as "did not post".
- After (report_date deployed): `evaluated_clean`, completeness evaluated with zero exceptions while the 21 future rows remain unposted in the data, `to_date` still 2027-03-31, and only the legitimate near-salvage write-off candidate survives.