### PR TITLE
feat(chat): consume MEDIA: marker — deliver native media inline, stri…

### DIFF
--- a/jarvis/chat/agent_client.py
+++ b/jarvis/chat/agent_client.py
@@ -1074,9 +1074,16 @@ class AgentSession:
 							"error": failed_final_error(failure_detail),
 						}
 						return
-					# Not a failed-final -> redact the surfaced reply + fire the
-					# once-per-turn tripwire (classification above ran on raw text).
-					yield {"kind": "relay:final", "text": egress_rules.redact_and_flag(text, run_id=run_id)}
+					# Not a failed-final -> consume the MEDIA marker, redact the surfaced
+					# reply + fire the once-per-turn tripwire (classification ran on raw
+					# text). media_rels rides the terminal so the worker seeds the image.
+					_red, _rels, _marked = egress_rules.redact_final_with_media(text, run_id=run_id)
+					_final = {"kind": "relay:final", "text": _red}
+					if _rels:  # fetchable media -> seed downstream (only set when present)
+						_final["media_rels"] = _rels
+					if _marked:  # any MEDIA: line stripped -> force the content overwrite
+						_final["marker_stripped"] = True
+					yield _final
 					return
 				if state in ("error", "aborted"):
 					yield {

--- a/jarvis/chat/egress_rules.py
+++ b/jarvis/chat/egress_rules.py
@@ -147,6 +147,30 @@ def redact_and_flag(text, *, conversation=None, run_id=None):
 		return text
 
 
+def redact_final_with_media(text, *, conversation=None, run_id=None):
+	"""Final-boundary redaction that FIRST consumes the native-media (``MEDIA:``)
+	marker, then redacts. Returns ``(redacted_text, media_rels, marker_stripped)``:
+
+	- ``media_rels`` — local media paths (detected on the RAW text) to fetch + seed
+	  downstream as inline images (the fetchable-image subset).
+	- ``marker_stripped`` — True if ANY ``MEDIA:`` line was removed (a superset of
+	  ``media_rels``: also the non-fetchable ``.pdf`` / external / traversal markers).
+	  The content-write gate uses it to force the stored-content overwrite even when
+	  the stripped text is empty, so NO recognized marker survives in stored content.
+	- the marker line(s) are STRIPPED before :func:`redact_and_flag` runs, so the
+	  egress ``/home/node`` backstop can't eat the path first (which would both lose
+	  the image and fire a false tripwire) and no raw container path survives.
+
+	Use at every terminal-text producer (direct relay, pump, recovery). Never raises
+	— detect/strip/has_media_marker are total and ``redact_and_flag`` fail-opens."""
+	from jarvis.chat import generated_media
+
+	rels = generated_media.detect_media_paths(text)
+	marker_stripped = generated_media.has_media_marker(text)
+	stripped = generated_media.strip_media_lines(text)
+	return redact_and_flag(stripped, conversation=conversation, run_id=run_id), rels, marker_stripped
+
+
 def _fire_tripwire(*, conversation=None, run_id=None) -> None:
 	"""Record ONE brand-free tripwire row via the existing client-error pipeline
 	(Jarvis Client Error -> the */5 error_push rollup -> the admin tenant error

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -252,9 +252,16 @@ def _effect_rich_outputs(ctx: _Ctx) -> None:
 	am = ctx.turn.get("assistant_message")
 	if not am:
 		return
-	from jarvis.chat import turn_handler
+	from jarvis.chat import settlement, turn_handler
 
-	turn_handler.persist_rich_outputs(am, ctx.conversation, ctx.owner, ctx.run_id, _turn_start_ms(ctx))
+	# Native-media paths ride the pump terminal_payload (set in relay_mux) onto the
+	# Turn row; re-read them here so the image is delivered on the pump (default)
+	# transport, not only on the direct-relay path (which passes media_rels inline).
+	payload = settlement._coerce_payload(frappe.db.get_value(TURN, ctx.run_id, "terminal_payload"))
+	media_rels = (payload or {}).get("media_rels") or None
+	turn_handler.persist_rich_outputs(
+		am, ctx.conversation, ctx.owner, ctx.run_id, _turn_start_ms(ctx), media_rels=media_rels
+	)
 
 
 def _effect_enrich_cards(ctx: _Ctx) -> None:

--- a/jarvis/chat/generated_media.py
+++ b/jarvis/chat/generated_media.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import base64
 import os
+import re
 
 import frappe
 
@@ -52,6 +53,21 @@ def _safe_filename(codex_name: str) -> str:
 	if ext.lower() not in _IMAGE_EXTS:
 		ext = ".png"
 	return "jarvis-image-" + (base[-10:] or "out") + ext
+
+
+def _append_canvas_items(assistant_msg_name: str, new_items: list[dict]) -> None:
+	"""Append canvas items to a message's ``canvas`` JSON in one read-modify-write.
+	Shared by the codex-image and native-media seeders.
+
+	NOTE: the read-append-write is not atomic (accepted pre-existing pattern); both
+	callers dedup by ``source`` first, so a finalize-effect retry re-appends nothing.
+	MUST run after ``canvas.persist_canvases`` (which overwrites the field wholesale),
+	which the worker guarantees by block order."""
+	existing = frappe.db.get_value(MSG, assistant_msg_name, "canvas")
+	items = (frappe.parse_json(existing) if existing else []) or []
+	items.extend(new_items)
+	frappe.db.set_value(MSG, assistant_msg_name, "canvas", frappe.as_json(items))
+	frappe.db.commit()
 
 
 def persist_generated_images(assistant_msg_name: str, conversation_id: str, turn_start_ms: int) -> list[dict]:
@@ -103,9 +119,256 @@ def persist_generated_images(assistant_msg_name: str, conversation_id: str, turn
 		seen.add(fn)
 
 	if new_items:
-		existing = frappe.db.get_value(MSG, assistant_msg_name, "canvas")
-		items = (frappe.parse_json(existing) if existing else []) or []
-		items.extend(new_items)
-		frappe.db.set_value(MSG, assistant_msg_name, "canvas", frappe.as_json(items))
-		frappe.db.commit()
+		_append_canvas_items(assistant_msg_name, new_items)
+	return new_items
+
+
+# --------------------------------------------------------------------------- #
+# Native media (``MEDIA:`` marker) consumer.
+#
+# agent's NATIVE image tool (distinct from the codex ``imagegen`` skill above)
+# writes to the agent media store and emits a protocol marker
+# ``MEDIA:<abs path>`` on its own line when reply delivery falls back to
+# ``automatic`` mode. Unlike codex images, this file IS served by the container
+# gateway at ``/__openclaw__/assistant-media?source=<path>`` (the same gateway
+# that serves canvas artifacts), so we fetch it directly like ``canvas.py`` —
+# no fleet-agent host-pull. The marker is detected + stripped from the reply
+# BEFORE egress redaction (so the raw container path never leaks and the file
+# is delivered as an inline image). See the Q3 plan.
+# --------------------------------------------------------------------------- #
+
+# A ``MEDIA:`` directive = a line that, after leading whitespace, starts with
+# ``MEDIA:`` (the agent runtime's contract: ``line.trimStart().toUpperCase().startsWith``).
+# ``\s*`` (not ``[ \t]*``) also catches NBSP / ideographic-space indentation like
+# the agent runtime's ``trimStart``. The payload is everything after ``MEDIA:``
+# (surrounding backticks trimmed). NOT fence-aware: an unbalanced/unterminated code
+# fence earlier in the reply must never let a real trailing marker survive — D2
+# already favours leak-safety over preserving a fenced example, so every such line
+# is consumed.
+_MEDIA_PREFIX = re.compile(r"^\s*MEDIA:\s*(.*?)\s*$", re.IGNORECASE)
+# Couples to the container HOME (fleet-agent compose). If the agent config dir is
+# ever renamed (Q2), update this literal AND the control-plane ``/home/node`` egress
+# rule together.
+_MEDIA_ROOT = "/home/node/.openclaw/media/"
+_MAX_MEDIA_PER_TURN = 8  # mirror canvas._MAX_CANVAS_PER_TURN (bound a hostile many-marker reply)
+_MAX_MEDIA_BYTES = 8 * 1024 * 1024  # bound worker memory; the source is LLM-influenced
+
+
+def _media_lines(text: str):
+	"""Yield ``(line_index, payload)`` for each line that is a ``MEDIA:`` directive.
+	``payload`` is the text after ``MEDIA:`` with surrounding backticks stripped —
+	used by ``detect_media_paths``; ``strip_media_lines`` removes the whole line
+	regardless of payload. Shared by both so they can never disagree. Total: a
+	non-string input yields nothing (keeps ``redact_final_with_media`` non-raising).
+
+	NOTE: the agent runtime emits exactly one marker per line for delivery, so a
+	degenerate two-markers-on-one-line reply collapses into one payload — it is still
+	stripped (no leak); at most its (bogus) path fails to fetch."""
+	if not isinstance(text, str):
+		return
+	for i, line in enumerate(text.splitlines()):
+		m = _MEDIA_PREFIX.match(line)
+		if m:
+			yield i, m.group(1).strip().strip("`").strip()
+
+
+def detect_media_paths(text: str) -> list[str]:
+	"""Full absolute container paths for line-anchored, local, image-extension
+	``MEDIA:`` markers under the agent media root, capped per turn.
+
+	The gateway resolves the full path against its own media roots, so we pass
+	the whole path (not a relpath). External URLs, non-image files, and traversal
+	attempts are excluded here — they are still stripped from the reply by
+	``strip_media_lines`` (strip-but-don't-fetch)."""
+	out: list[str] = []
+	exts = tuple(_IMAGE_EXTS)
+	for _, path in _media_lines(text):
+		if not path.startswith(_MEDIA_ROOT):
+			continue
+		rel = path[len(_MEDIA_ROOT) :]
+		# ``..`` can't escape the media root (the gateway also realpath-confines),
+		# but reject it here so we never even send a traversal path.
+		if not rel or rel.startswith("/") or ".." in rel.split("/"):
+			continue
+		if not path.lower().endswith(exts):
+			continue
+		out.append(path)
+		if len(out) >= _MAX_MEDIA_PER_TURN:
+			break
+	return out
+
+
+def strip_media_lines(text: str) -> str:
+	"""Remove EVERY line-anchored ``MEDIA:`` line from the visible reply — handled,
+	external, malformed, even a ``MEDIA:``-prefixed prose/fenced line.
+
+	Deliberately broader than the agent runtime (which keeps a ``MEDIA:``-prefixed
+	line whose payload is not a path, and preserves fenced examples): we favour
+	leak-safety over that fidelity (Q3 decision D2). Being fence-UNAWARE is
+	load-bearing — an unbalanced fence must never leave a real trailing marker."""
+	if not text:
+		return text
+	drop = {i for i, _ in _media_lines(text)}
+	if not drop:
+		return text  # nothing to strip -> return verbatim (no line-ending normalisation)
+	kept = [ln for i, ln in enumerate(text.splitlines()) if i not in drop]
+	return re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
+
+
+def has_media_marker(text: str) -> bool:
+	"""True if the reply has ANY line-anchored ``MEDIA:`` directive — qualifying
+	(fetchable image) or not (``.pdf`` / external / traversal). Broader than
+	``detect_media_paths``: used to force the stored-content overwrite so that NO
+	recognized marker survives in stored content, even one we don't fetch."""
+	return next(_media_lines(text), None) is not None
+
+
+def fetch_media(agent_url: str, token: str, source: str) -> bytes | None:
+	"""GET one media file from the container gateway (binary-safe,
+	redirect-disabled, size-bounded). Returns the raw bytes, or ``None`` on any
+	failure / oversize.
+
+	The host is ALWAYS the tenant's own gateway (``agent_url``); the LLM marker
+	supplies only the ``source`` path (URL-encoded so it cannot break out of the
+	query). ``allow_redirects=False`` because the route only ever returns 200 or
+	4xx/5xx — following a 3xx would let a compromised gateway pivot the bench at
+	an internal URL (SSRF), bypassing the ``call_tool`` permission layer."""
+	from urllib.parse import quote
+
+	import requests
+
+	from jarvis.chat.canvas import _http_base
+
+	base = _http_base(agent_url)
+	if not base or not token:
+		return None
+	url = f"{base}/__openclaw__/assistant-media?source={quote(source, safe='')}"
+	try:
+		# 15s (tighter than canvas's 20s): seed_media shares the ~180s finalize hop
+		# with the canvas + imagegen fetches, so up to 8 media fetches must not
+		# dominate that budget. A healthy same-infra gateway responds sub-second.
+		with requests.get(
+			url,
+			headers={"Authorization": f"Bearer {token}"},
+			timeout=15,
+			stream=True,
+			allow_redirects=False,
+		) as r:
+			if r.status_code != 200:
+				return None
+			buf = bytearray()
+			for chunk in r.iter_content(64 * 1024):
+				buf += chunk
+				if len(buf) > _MAX_MEDIA_BYTES:
+					return None  # oversize -> drop (the marker line is already stripped)
+	except Exception:
+		return None
+	return bytes(buf) or None
+
+
+def _pretty_media_title(basename: str) -> str:
+	"""Human title from a media filename: drop the extension and a trailing
+	``---<uuid>`` the tool appends, turn separators into spaces. Length-capped so a
+	hostile long filename can't produce an unbounded canvas-item title."""
+	stem = re.sub(r"\.\w+$", "", basename)
+	stem = re.sub(r"-{2,}[0-9a-fA-F-]{8,}$", "", stem)
+	stem = stem.replace("-", " ").replace("_", " ").strip()
+	return (stem.title() or basename)[:80]
+
+
+def _safe_media_filename(basename: str) -> str:
+	"""Bounded, sanitised File name from the marker basename (keep a known image
+	extension, else default to ``.png``)."""
+	base, ext = os.path.splitext(basename)
+	if ext.lower() not in _IMAGE_EXTS:
+		ext = ".png"
+	base = re.sub(r"[^\w.\-]", "", base)[-40:] or "image"
+	return "jarvis-media-" + base + ext
+
+
+def _media_dedup_key(source: str) -> str:
+	"""The canvas-item ``source`` / dedup key for a media path: the path RELATIVE to
+	the media root (e.g. ``tool-image-generation/<name>.png``), NEVER the full
+	``/home/node/.openclaw/...`` absolute path. The canvas item ships to the client
+	(live ``canvas`` event + raw on history reload) even though the frontend never
+	renders ``source``, so storing the absolute path would re-leak the runtime brand
+	+ container layout the rest of this change strips out. The relative form is
+	unique per image and brand/path-free."""
+	return source[len(_MEDIA_ROOT) :] if source.startswith(_MEDIA_ROOT) else source
+
+
+def _existing_media_sources(assistant_msg_name: str) -> set[str]:
+	"""Relative ``source`` keys already on THIS message's canvas, so a re-run (e.g. a
+	pump effect retry) never double-seeds the same media file."""
+	seen: set[str] = set()
+	canvas_json = frappe.db.get_value(MSG, assistant_msg_name, "canvas")
+	if not canvas_json:
+		return seen
+	try:
+		for item in frappe.parse_json(canvas_json) or []:
+			if isinstance(item, dict) and item.get("source"):
+				seen.add(item["source"])
+	except Exception:
+		pass
+	return seen
+
+
+def seed_media(assistant_msg_name: str, agent_url: str, token: str, sources: list[str]) -> list[dict]:
+	"""Fetch each media ``source`` (a full container path) from the gateway, save it
+	as a private File on the assistant message, append to its ``canvas`` JSON, and
+	return the new canvas items (so the caller can publish a ``canvas`` event).
+
+	Best-effort: a failed / oversize fetch is skipped (the raw marker line is already
+	stripped upstream, so nothing leaks even when the image is not delivered). The
+	stored ``source`` / dedup key is the RELATIVE path (see ``_media_dedup_key``),
+	keeping a re-run idempotent without shipping the absolute container path.
+
+	MUST run AFTER ``canvas.persist_canvases`` — that overwrites the ``canvas`` field
+	wholesale, whereas this appends; the worker calls the blocks in that order."""
+	from frappe.utils.file_manager import save_file
+
+	if not sources:
+		return []
+	seen = _existing_media_sources(assistant_msg_name)
+	new_items: list[dict] = []
+	failures = 0
+	for source in sources:
+		key = _media_dedup_key(source)
+		if key in seen:
+			continue
+		content = fetch_media(agent_url, token, source)  # fetch with the FULL path
+		if not content:
+			failures += 1
+			continue
+		basename = source.rsplit("/", 1)[-1]
+		try:
+			f = save_file(_safe_media_filename(basename), content, MSG, assistant_msg_name, is_private=1)
+		except Exception:
+			frappe.log_error(
+				title="chat worker: save native media failed",
+				message=frappe.get_traceback(),
+			)
+			continue
+		new_items.append(
+			{
+				"name": f.file_url,
+				"title": _pretty_media_title(basename),
+				"type": "image",
+				"file_url": f.file_url,
+				"source": key,  # RELATIVE path - dedup key, not brand/path-bearing
+			}
+		)
+		seen.add(key)
+
+	if failures:
+		# ONE aggregated signal per turn (not per file) so a silent fleet-wide
+		# degradation — e.g. a _MEDIA_ROOT / container-path drift where every marker
+		# is detected but every fetch 404s — surfaces in the Error Log instead of
+		# relying on a user complaint. Best-effort; never raises.
+		frappe.log_error(
+			title="chat worker: native media fetch returned no content",
+			message=f"{failures} of {len(sources)} media fetch(es) empty for {assistant_msg_name}",
+		)
+	if new_items:
+		_append_canvas_items(assistant_msg_name, new_items)
 	return new_items

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -2676,22 +2676,32 @@ def _resolve_recovery_tail(ctx: PumpContext, pr: _PendingRecovery, frame: dict) 
 	turn's answer), Amendment D 'never fabricate'."""
 	payload = frame.get("payload") or frame.get("result") or {}
 	messages = payload.get("messages") or []
-	from jarvis.chat.turn_recovery import _latest_assistant_text
+	from jarvis.chat import egress_rules
+	from jarvis.chat.turn_recovery import _latest_assistant_raw
 
-	text = _latest_assistant_text(messages, min_seq=pr.min_seq, max_seq=pr.max_seq)
-	if text:
-		_settle_recovered_final(ctx, pr.r, text)
+	raw = _latest_assistant_raw(messages, min_seq=pr.min_seq, max_seq=pr.max_seq)
+	text, _rels, marker_stripped = egress_rules.redact_final_with_media(raw)
+	# A media/marker-only reply strips to "" but IS real in-window output — settle
+	# final with the clean (empty) text so the raw marker never lingers in stored
+	# content, rather than erroring and leaving the streamed tail. Parity with cron
+	# _recover_one. An empty window with no marker still errors honestly (Amendment D).
+	if text or marker_stripped:
+		_settle_recovered_final(ctx, pr.r, text, marker_stripped=marker_stripped)
 	else:
 		_settle_recovered_errored(ctx, pr.r)
 
 
-def _settle_recovered_final(ctx: PumpContext, r: dict, text: str) -> None:
+def _settle_recovered_final(ctx: PumpContext, r: dict, text: str, *, marker_stripped: bool = False) -> None:
 	"""Genuine missed-terminal recovery: advance streaming->terminal_observed under
 	this epoch with the in-window durable text, mark ``was_recovered`` (SUX-6 — the
-	client may do a visible replacement), and settle to final."""
+	client may do a visible replacement), and settle to final. ``marker_stripped``
+	rides the payload so settlement forces the content overwrite on a marker-only
+	reply (empty text) instead of keeping the raw streamed tail."""
 	run_id = r["run_id"]
 	v = int(r["version"])
 	payload = {"text": text}
+	if marker_stripped:
+		payload["marker_stripped"] = True
 	if not ts.mark_terminal_observed(run_id, v, ctx.epoch, "relay:final", payload):
 		if _epoch_lost(ctx, run_id):
 			ts.lease_lost_exit(run_id)

--- a/jarvis/chat/relay_mux.py
+++ b/jarvis/chat/relay_mux.py
@@ -562,10 +562,18 @@ class RelayMux:
 					{"state": "failed_final", "error": failed_final_error(lane.failure_detail)},
 				)
 			else:
-				# Not a failed-final -> redact the surfaced reply + fire the once-
-				# per-turn tripwire (classification above ran on raw text).
+				# Not a failed-final -> consume the MEDIA marker, redact the surfaced
+				# reply + fire the once-per-turn tripwire (classification ran on raw
+				# text). media_rels rides term_payload -> the Turn row, where
+				# finalize._effect_rich_outputs re-reads it to seed the image (the
+				# pump is the default transport, so this is the primary delivery path).
 				term_kind = "relay:final"
-				term_payload = {"text": egress_rules.redact_and_flag(text, run_id=lane.run_id)}
+				_red, _rels, _marked = egress_rules.redact_final_with_media(text, run_id=lane.run_id)
+				term_payload = {"text": _red}
+				if _rels:  # fetchable media -> seed downstream (only set when present)
+					term_payload["media_rels"] = _rels
+				if _marked:  # any MEDIA: line stripped -> force the content overwrite
+					term_payload["marker_stripped"] = True
 		elif state in ("error", "aborted"):
 			term_kind = "relay:error"
 			term_payload = {

--- a/jarvis/chat/settlement.py
+++ b/jarvis/chat/settlement.py
@@ -110,13 +110,19 @@ def invoke_settlement(
 		pub_kind, pub_extra = "run:error", {"error": err, "code": _classify(err)}
 	else:
 		final_text = _final_text(terminal_payload)
+		# A media/marker-only reply strips to empty text; force the content overwrite
+		# whenever ANY MEDIA: marker was stripped, so the raw streamed batcher tail
+		# (which could carry the marker) can never survive into stored content. Coerce
+		# the payload — this boundary can receive a JSON string on the reconcile path.
+		_tp = _coerce_payload(terminal_payload)
+		marker_stripped = isinstance(_tp, dict) and bool(_tp.get("marker_stripped"))
 		# S1 final projection (final text beats the batcher tail); always clear
 		# streaming even when the terminal carried no text (matches legacy).
 		if am:
-			if final_text:
+			if final_text or marker_stripped:
 				ts._run_cas(
 					f"UPDATE `tab{MSG}` SET content=%(c)s, streaming=0 WHERE name=%(m)s",
-					{"c": final_text, "m": am},
+					{"c": final_text or "", "m": am},
 				)
 			else:
 				ts._run_cas(f"UPDATE `tab{MSG}` SET streaming=0 WHERE name=%(m)s", {"m": am})

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -93,11 +93,16 @@ def persist_rich_outputs(
 	user: str,
 	run_id: str,
 	turn_start_ms: int,
+	media_rels: list[str] | None = None,
 ) -> None:
 	"""Best-effort canvas + generated-image persistence and publish for one
 	finished turn. Shared by the worker's clean exit and snapshot recovery
 	(a recovered long turn is exactly the kind that produced charts).
-	Never raises."""
+
+	``media_rels`` (native ``MEDIA:`` marker paths, detected + stripped upstream
+	before egress) is passed on the delivering transports (direct relay inline;
+	pump via the Turn row in ``finalize``) and omitted on recovery (strip-but-
+	don't-deliver). Never raises."""
 	settings = frappe.get_single("Jarvis Settings")
 
 	# Rich outputs: detect any canvas/chart artifact the agent produced this
@@ -161,6 +166,49 @@ def persist_rich_outputs(
 	except Exception:
 		frappe.log_error(
 			title="chat worker: generated-image persist failed",
+			message=frappe.get_traceback(),
+		)
+
+	# Native media (MEDIA: marker): the agent's native image tool writes to the
+	# agent media store and emits a MEDIA:<path> marker; it's detected + the
+	# line stripped upstream (before egress), with the path(s) threaded here as
+	# media_rels. Fetch each directly from the container gateway + seed as a File
+	# + canvas item. MUST run AFTER the canvas block above — persist_canvases
+	# OVERWRITES the `canvas` field wholesale, whereas this appends; reordering
+	# would clobber these items. Failure never fails a turn.
+	try:
+		if media_rels:
+			from jarvis.chat import generated_media as gen_media
+
+			media_items = gen_media.seed_media(
+				assistant_msg_name,
+				settings.agent_url or "",
+				settings.get_password("agent_token", raise_exception=False) or "",
+				media_rels,
+			)
+			if media_items:
+				# The client 'canvas' event REPLACES the list (not merge), and this is
+				# the last of the three publishers (canvas/imagegen/media), so publish
+				# the CUMULATIVE canvas read back from the field — otherwise a same-turn
+				# chart/imagegen item would be transiently wiped from the live bubble
+				# until reload.
+				all_items = (
+					frappe.parse_json(frappe.db.get_value(MSG, assistant_msg_name, "canvas") or "[]")
+					or media_items
+				)
+				_publish_to_user(
+					user,
+					{
+						"kind": "canvas",
+						"conversation_id": conversation_id,
+						"message_id": assistant_msg_name,
+						"run_id": run_id,
+						"items": all_items,
+					},
+				)
+	except Exception:
+		frappe.log_error(
+			title="chat worker: native media persist failed",
 			message=frappe.get_traceback(),
 		)
 
@@ -1422,9 +1470,11 @@ def handle_chat_send(payload: dict) -> None:
 			)
 			_try_recover_now(conversation_id)
 			return
-		# relay:final - authoritative text beats the batcher tail.
-		if terminal.get("text"):
-			frappe.db.set_value(MSG, assistant_msg.name, "content", terminal["text"])
+		# relay:final - authoritative text beats the batcher tail. A media/marker-only
+		# reply strips to empty text but sets marker_stripped; overwrite (to "") anyway
+		# so the raw batcher tail can never survive the marker into stored content.
+		if terminal.get("text") or terminal.get("marker_stripped"):
+			frappe.db.set_value(MSG, assistant_msg.name, "content", terminal.get("text") or "")
 
 		# Streaming exited cleanly via lifecycle.end
 		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
@@ -1433,7 +1483,14 @@ def handle_chat_send(payload: dict) -> None:
 		# Canvas + generated-image persistence and publish (extracted so
 		# snapshot recovery can deliver the same rich outputs for a turn
 		# that finished via _finalize instead of this clean exit).
-		persist_rich_outputs(assistant_msg.name, conversation_id, user, run_id, turn_start_ms)
+		persist_rich_outputs(
+			assistant_msg.name,
+			conversation_id,
+			user,
+			run_id,
+			turn_start_ms,
+			media_rels=terminal.get("media_rels"),
+		)
 
 		# Chat-ask materialization (notify-approvals design Part 2): a final
 		# reply carrying a ```jarvis-ask fence surfaces on the Approval Board

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -74,14 +74,11 @@ def _age_minutes(dt) -> float:
 	return delta.total_seconds() / 60.0
 
 
-def _latest_assistant_text(messages: list, *, min_seq: int = 0, max_seq: int | None = None) -> str:
-	"""Newest assistant message text from a raw transcript. Handles a
-	plain-string content and the {type:"text", text} block list. Sorted by the
-	transcript seq so the latest turn wins. Every text source is type-guarded.
-
-	SIDE EFFECT: the returned text is run through the white-label egress redactor
-	and, on a redaction hit, fires the once-per-turn tripwire (egress_rules). Call
-	it once per recovered turn — a second call would re-flag (harmlessly folded).
+def _latest_assistant_raw(messages: list, *, min_seq: int = 0, max_seq: int | None = None) -> str:
+	"""Newest assistant message's RAW text from a raw transcript (no redaction, no
+	MEDIA-marker strip). Handles a plain-string content and the {type:"text", text}
+	block list. Sorted by the transcript seq so the latest turn wins. Every text
+	source is type-guarded.
 
 	``min_seq`` is the transcript-seq watermark captured before this turn's
 	chat.send: a message whose seq is <= min_seq predates this turn (or is a
@@ -107,12 +104,9 @@ def _latest_assistant_text(messages: list, *, min_seq: int = 0, max_seq: int | N
 			continue
 		if (m.get("role") or "").lower() != "assistant":
 			continue
-		# The refetched transcript bypasses the live stream, so redact + fire the
-		# once-per-turn tripwire here too (covers both the cron recovery and the
-		# pump recovery tail, which both call this).
 		c = m.get("content")
 		if isinstance(c, str) and c.strip():
-			return egress_rules.redact_and_flag(c)
+			return c
 		if isinstance(c, list):
 			parts = [
 				b.get("text", "")
@@ -124,11 +118,23 @@ def _latest_assistant_text(messages: list, *, min_seq: int = 0, max_seq: int | N
 			]
 			joined = "\n".join(p for p in parts if p.strip())
 			if joined.strip():
-				return egress_rules.redact_and_flag(joined)
+				return joined
 		t = m.get("text")
 		if isinstance(t, str) and t.strip():
-			return egress_rules.redact_and_flag(t)
+			return t
 	return ""
+
+
+def _latest_assistant_text(messages: list, *, min_seq: int = 0, max_seq: int | None = None) -> str:
+	"""Delivered form of :func:`_latest_assistant_raw`: the MEDIA: marker consumed
+	(stripped) and the text run through the white-label egress redactor.
+
+	SIDE EFFECT: on a redaction hit fires the once-per-turn tripwire (egress_rules).
+	Call once per recovered turn — a second call would re-flag (harmlessly folded).
+	The recovery path strips but does NOT re-deliver the image (D1)."""
+	return egress_rules.redact_final_with_media(
+		_latest_assistant_raw(messages, min_seq=min_seq, max_seq=max_seq)
+	)[0]
 
 
 def _conditional_clear(name: str, fields: dict) -> bool:
@@ -397,15 +403,20 @@ def _recover_one(sess: AgentSession, row: dict, active: dict) -> str:
 		return "active"
 	# Raw transcript (sessions.get), NOT chat.history -> no max_chars truncation (#1).
 	messages = sess.get_session_messages(session_key, limit=50)
-	text = _latest_assistant_text(
+	raw = _latest_assistant_raw(
 		messages,
 		min_seq=row.get("agent_seq_watermark") or 0,
 		max_seq=_next_turn_watermark(row["conversation"], row["seq"]),
 	)
-	if text:
+	text, _rels, marker_stripped = egress_rules.redact_final_with_media(raw)
+	# Finalize on real text OR when a MEDIA: marker was stripped to empty — a
+	# media-only reply IS real output (not "no output yet"), so finalize with the
+	# stripped text ("" when marker-only) to ensure the raw marker never lingers in
+	# stored content. D1: recovery strips but does not re-deliver the image.
+	if text or marker_stripped:
 		_finalize(row, text)
 		return "finalized"
-	return "waiting"  # no output yet; the ceiling backstop bounds the wait
+	return "waiting"  # genuinely no output yet; the ceiling backstop bounds the wait
 
 
 def _next_turn_watermark(conversation: str, seq: int) -> int | None:

--- a/jarvis/tests/test_media_markers.py
+++ b/jarvis/tests/test_media_markers.py
@@ -1,0 +1,470 @@
+"""Unit tests for the native-media (``MEDIA:`` marker) consumer in
+``jarvis.chat.generated_media`` — detection, stripping, the size-bounded
+gateway fetch, and the seed/dedup logic. The R2 wiring into the three chat
+transports is covered by the worker / pump / recovery tests.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from jarvis.chat import generated_media as gm
+
+# Import the root rather than re-hardcoding it — a Q2 rename that updates the
+# production constant must not leave the tests validating the old path.
+_ROOT = gm._MEDIA_ROOT
+_IMG = _ROOT + "tool-image-generation/black-hole---4de239c0-8d05-41e5-9f52-e404ee9f0b21.png"
+_IMG_REL = _IMG[len(_ROOT) :]
+
+
+class TestDetectMediaPaths(unittest.TestCase):
+	def test_local_image_marker(self):
+		self.assertEqual(gm.detect_media_paths(f"Here you go:\nMEDIA:{_IMG}"), [_IMG])
+
+	def test_case_insensitive(self):
+		self.assertEqual(gm.detect_media_paths(f"media:{_IMG}"), [_IMG])
+		self.assertEqual(gm.detect_media_paths(f"Media:{_IMG}"), [_IMG])
+
+	def test_surrounding_backticks(self):
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:`{_IMG}`"), [_IMG])
+
+	def test_multiple_markers(self):
+		a = _ROOT + "tool-image-generation/a.png"
+		b = _ROOT + "tool-image-generation/b.jpg"
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:{a}\nMEDIA:{b}"), [a, b])
+
+	def test_unicode_filename(self):
+		u = _ROOT + "tool-image-generation/图片---abcd1234.png"
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:{u}"), [u])
+
+	def test_fenced_marker_is_consumed(self):
+		# Fence-UNAWARE by design (D2 leak-safety): a marker inside a balanced fence
+		# is detected too. Preserving a fenced example is a nicety we forgo so an
+		# UNbalanced fence can never swallow a real trailing marker.
+		self.assertEqual(gm.detect_media_paths(f"```\nMEDIA:{_IMG}\n```"), [_IMG])
+		self.assertEqual(gm.detect_media_paths(f"~~~\nMEDIA:{_IMG}\n~~~"), [_IMG])
+
+	def test_unbalanced_fence_does_not_swallow_real_marker(self):
+		# THE critical case: an odd number of fence lines before the real trailing
+		# marker. A fence-toggle scanner would be "in fence" and miss it -> leak +
+		# no image. Fence-unaware detection finds it.
+		reply = f"Here's the API:\n```python\nimport foo\nMEDIA:{_IMG}\n"
+		self.assertEqual(gm.detect_media_paths(reply), [_IMG])
+
+	def test_unicode_whitespace_indent_detected(self):
+		# the agent runtime's trimStart() strips NBSP / ideographic space; \s* matches.
+		self.assertEqual(gm.detect_media_paths(f" MEDIA:{_IMG}"), [_IMG])
+		self.assertEqual(gm.detect_media_paths(f"　MEDIA:{_IMG}"), [_IMG])
+
+	def test_ignored_mid_line(self):
+		self.assertEqual(gm.detect_media_paths(f"see the file MEDIA:{_IMG} inline"), [])
+
+	def test_external_url_excluded(self):
+		self.assertEqual(gm.detect_media_paths("MEDIA:https://example.com/x.png"), [])
+
+	def test_outside_media_root_excluded(self):
+		self.assertEqual(gm.detect_media_paths("MEDIA:/home/node/.openclaw/credentials/x.png"), [])
+		self.assertEqual(gm.detect_media_paths("MEDIA:/etc/passwd.png"), [])
+
+	def test_traversal_excluded(self):
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:{_ROOT}../../etc/passwd.png"), [])
+
+	def test_non_image_excluded(self):
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:{_ROOT}tool-image-generation/report.pdf"), [])
+		# .svg is deliberately NOT in the raster-only allowlist
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:{_ROOT}tool-image-generation/chart.svg"), [])
+
+	def test_empty_rel_excluded(self):
+		self.assertEqual(gm.detect_media_paths(f"MEDIA:{_ROOT}"), [])
+
+	def test_cap_per_turn(self):
+		many = "\n".join(f"MEDIA:{_ROOT}tool-image-generation/c{i}.png" for i in range(12))
+		self.assertEqual(len(gm.detect_media_paths(many)), gm._MAX_MEDIA_PER_TURN)
+
+	def test_empty_and_none(self):
+		self.assertEqual(gm.detect_media_paths(""), [])
+		self.assertEqual(gm.detect_media_paths(None), [])
+
+	def test_has_media_marker(self):
+		# True for any MEDIA: line (qualifying OR not); False otherwise.
+		self.assertTrue(gm.has_media_marker(f"MEDIA:{_IMG}"))
+		self.assertTrue(gm.has_media_marker(f"MEDIA:{_ROOT}tool-image-generation/report.pdf"))  # non-raster
+		self.assertTrue(gm.has_media_marker("MEDIA:https://example.com/x.png"))  # external
+		self.assertFalse(gm.has_media_marker("a plain reply"))
+		self.assertFalse(gm.has_media_marker(""))
+		self.assertFalse(gm.has_media_marker(None))
+
+
+class TestStripMediaLines(unittest.TestCase):
+	def test_strips_handled_marker(self):
+		self.assertEqual(gm.strip_media_lines(f"Here:\nMEDIA:{_IMG}"), "Here:")
+
+	def test_strips_external_and_malformed(self):
+		self.assertEqual(gm.strip_media_lines("MEDIA:https://example.com/x.png\nok"), "ok")
+		# D2: a prose line that merely starts "MEDIA:" is removed (broader than the runtime)
+		self.assertEqual(gm.strip_media_lines("MEDIA: coverage was extensive\ndone"), "done")
+
+	def test_fenced_marker_is_stripped(self):
+		# Fence-UNAWARE (D2): even a fenced MEDIA line is stripped. The fence markers
+		# themselves remain.
+		out = gm.strip_media_lines(f"```\nMEDIA:{_IMG}\n```")
+		self.assertNotIn("MEDIA:", out)
+		self.assertNotIn("/home/node", out)
+
+	def test_unbalanced_fence_marker_is_stripped(self):
+		# THE critical leak case: a real trailing marker after an unbalanced fence
+		# must still be removed (no raw path survives).
+		out = gm.strip_media_lines(f"See:\n```python\nx=1\nMEDIA:{_IMG}\n")
+		self.assertNotIn("MEDIA:", out)
+		self.assertNotIn("/home/node", out)
+
+	def test_interior_backtick_line_is_stripped(self):
+		# An interior backtick must not let the line evade the strip (leak-safety).
+		out = gm.strip_media_lines(f"MEDIA: {_ROOT}tool-image-generation/foo`bar.png\nok")
+		self.assertNotIn("/home/node", out)
+		self.assertEqual(out, "ok")
+
+	def test_collapses_blank_runs(self):
+		text = f"Line one\n\nMEDIA:{_IMG}\n\nLine two"
+		self.assertEqual(gm.strip_media_lines(text), "Line one\n\nLine two")
+
+	def test_no_marker_returns_verbatim(self):
+		text = "A normal reply.\n\nWith paragraphs.\n"
+		self.assertEqual(gm.strip_media_lines(text), text)
+
+	def test_empty(self):
+		self.assertEqual(gm.strip_media_lines(""), "")
+		self.assertIsNone(gm.strip_media_lines(None))
+
+
+def _streamed_response(status=200, body=b"PNGDATA", chunk=64 * 1024):
+	"""A Mock mimicking requests' streamed response context manager."""
+	resp = Mock()
+	resp.status_code = status
+	resp.iter_content = Mock(return_value=[body[i : i + chunk] for i in range(0, len(body), chunk)] or [b""])
+	cm = Mock()
+	cm.__enter__ = Mock(return_value=resp)
+	cm.__exit__ = Mock(return_value=False)
+	return cm
+
+
+class TestFetchMedia(unittest.TestCase):
+	def test_url_header_and_ws_to_http(self):
+		with patch("requests.get", return_value=_streamed_response()) as rget:
+			out = gm.fetch_media("ws://agent.host:9000", "tok123", _IMG)
+		self.assertEqual(out, b"PNGDATA")
+		args, kwargs = rget.call_args
+		url = args[0]
+		self.assertTrue(url.startswith("http://agent.host:9000/__openclaw__/assistant-media?source="))
+		# the path is URL-encoded (slashes -> %2F), not raw
+		self.assertNotIn("/home/node", url.split("source=", 1)[1])
+		self.assertEqual(kwargs["headers"]["Authorization"], "Bearer tok123")
+		self.assertFalse(kwargs["allow_redirects"])
+		self.assertTrue(kwargs["stream"])
+
+	def test_wss_to_https(self):
+		with patch("requests.get", return_value=_streamed_response()) as rget:
+			gm.fetch_media("wss://agent.host:9000", "t", _IMG)
+		self.assertTrue(rget.call_args[0][0].startswith("https://agent.host:9000/"))
+
+	def test_non_200_returns_none(self):
+		for code in (302, 404, 500):
+			with patch("requests.get", return_value=_streamed_response(status=code)):
+				self.assertIsNone(gm.fetch_media("ws://h:1", "t", _IMG))
+
+	def test_oversize_aborts(self):
+		big = b"x" * (gm._MAX_MEDIA_BYTES + 1)
+		with patch("requests.get", return_value=_streamed_response(body=big)):
+			self.assertIsNone(gm.fetch_media("ws://h:1", "t", _IMG))
+
+	def test_oversize_stops_reading_early(self):
+		# Guards the "streamed, do NOT buffer whole" property: a lazy body that
+		# raises if read past the cap must NOT be fully consumed.
+		chunk = 64 * 1024
+
+		def gen():
+			for _ in range((gm._MAX_MEDIA_BYTES // chunk) + 1):
+				yield b"x" * chunk
+			raise AssertionError("fetch_media kept reading past the size cap")
+
+		resp = Mock()
+		resp.status_code = 200
+		resp.iter_content = Mock(return_value=gen())
+		cm = Mock()
+		cm.__enter__ = Mock(return_value=resp)
+		cm.__exit__ = Mock(return_value=False)
+		with patch("requests.get", return_value=cm):
+			self.assertIsNone(gm.fetch_media("ws://h:1", "t", _IMG))
+
+	def test_missing_base_or_token(self):
+		self.assertIsNone(gm.fetch_media("", "t", _IMG))
+		self.assertIsNone(gm.fetch_media("ws://h:1", "", _IMG))
+
+	def test_request_exception_returns_none(self):
+		with patch("requests.get", side_effect=RuntimeError("boom")):
+			self.assertIsNone(gm.fetch_media("ws://h:1", "t", _IMG))
+
+
+class TestSeedMedia(unittest.TestCase):
+	def _patch_db(self, existing_canvas=None):
+		"""Patch frappe DB + save_file; capture the final set_value payload."""
+		self.saved = []
+		self.set_values = []
+
+		def fake_save_file(name, content, dt, dn, is_private=1):
+			self.saved.append(name)
+			return Mock(file_url=f"/private/files/{name}")
+
+		def fake_get_value(dt, dn, field):
+			return existing_canvas
+
+		def fake_set_value(dt, dn, field, value):
+			self.set_values.append(value)
+
+		p1 = patch("frappe.utils.file_manager.save_file", side_effect=fake_save_file)
+		p2 = patch("frappe.db.get_value", side_effect=fake_get_value)
+		p3 = patch("frappe.db.set_value", side_effect=fake_set_value)
+		p4 = patch("frappe.db.commit")
+		return p1, p2, p3, p4
+
+	def test_seeds_and_builds_item(self):
+		a = _ROOT + "tool-image-generation/black-hole---abcd1234.png"
+		ps = self._patch_db(existing_canvas=None)
+		with ps[0], ps[1], ps[2], ps[3], patch.object(gm, "fetch_media", return_value=b"PNG"):
+			items = gm.seed_media("MSG-1", "ws://h:1", "tok", [a])
+		self.assertEqual(len(items), 1)
+		it = items[0]
+		self.assertEqual(it["type"], "image")
+		# source is the RELATIVE path (dedup key), NOT the brand/path-bearing absolute
+		self.assertEqual(it["source"], a[len(_ROOT) :])
+		self.assertNotIn("/home/node", it["source"])
+		self.assertEqual(it["title"], "Black Hole")  # uuid + ext stripped
+		self.assertTrue(it["file_url"].startswith("/private/files/jarvis-media-"))
+
+	def test_skips_failed_fetch_and_logs(self):
+		ps = self._patch_db(existing_canvas=None)
+		with (
+			ps[0],
+			ps[1],
+			ps[2],
+			ps[3],
+			patch.object(gm, "fetch_media", return_value=None),
+			patch("frappe.log_error") as log,
+		):
+			items = gm.seed_media("MSG-1", "ws://h:1", "tok", [_IMG])
+		self.assertEqual(items, [])
+		self.assertEqual(self.set_values, [])  # nothing written
+		log.assert_called_once()  # a silent fleet-wide degradation stays visible
+
+	def test_dedups_by_source(self):
+		import json
+
+		# existing canvas stores the RELATIVE source key (what seed_media writes)
+		existing = json.dumps([{"name": "x", "type": "image", "source": _IMG_REL}])
+		ps = self._patch_db(existing_canvas=existing)
+		with ps[0], ps[1], ps[2], ps[3], patch.object(gm, "fetch_media", return_value=b"PNG") as fm:
+			items = gm.seed_media("MSG-1", "ws://h:1", "tok", [_IMG])
+		self.assertEqual(items, [])
+		fm.assert_not_called()  # already present (by rel key) -> never fetched
+
+	def test_empty_sources(self):
+		with patch.object(gm, "fetch_media") as fm:
+			self.assertEqual(gm.seed_media("MSG-1", "ws://h:1", "tok", []), [])
+			fm.assert_not_called()
+
+
+class TestTitleAndFilename(unittest.TestCase):
+	def test_pretty_title_strips_uuid(self):
+		self.assertEqual(
+			gm._pretty_media_title("black-hole---4de239c0-8d05-41e5-9f52-e404ee9f0b21.png"),
+			"Black Hole",
+		)
+		self.assertEqual(gm._pretty_media_title("sales_report.png"), "Sales Report")
+
+	def test_pretty_title_length_capped(self):
+		self.assertLessEqual(len(gm._pretty_media_title("a" * 500 + ".png")), 80)
+
+	def test_safe_filename(self):
+		self.assertTrue(gm._safe_media_filename("a.png").startswith("jarvis-media-"))
+		self.assertTrue(gm._safe_media_filename("a.png").endswith(".png"))
+		# non-image ext -> forced .png
+		self.assertTrue(gm._safe_media_filename("weird.bin").endswith(".png"))
+
+
+class TestRedactFinalWithMedia(unittest.TestCase):
+	"""The shared terminal helper: consume the marker BEFORE egress, return
+	(redacted-and-stripped text, media_rels)."""
+
+	def test_strips_before_redact_and_returns_rels(self):
+		from jarvis.chat import egress_rules
+
+		# Identity redact so we isolate the strip+detect behaviour from DB rules.
+		with patch("jarvis.chat.egress_rules.redact_and_flag", side_effect=lambda t, **k: t):
+			text, rels, marked = egress_rules.redact_final_with_media(
+				f"Here you go:\nMEDIA:{_IMG}", run_id="R1"
+			)
+		self.assertEqual(text, "Here you go:")  # MEDIA line stripped before redact
+		self.assertEqual(rels, [_IMG])
+		self.assertTrue(marked)
+
+	def test_non_raster_marker_stripped_flag_without_rels(self):
+		from jarvis.chat import egress_rules
+
+		# A .pdf marker under the media root: stripped (marker_stripped True) but NOT
+		# a fetchable image (rels empty) -> the gate still forces the content clear.
+		pdf = _ROOT + "tool-image-generation/report.pdf"
+		with patch("jarvis.chat.egress_rules.redact_and_flag", side_effect=lambda t, **k: t):
+			text, rels, marked = egress_rules.redact_final_with_media(f"MEDIA:{pdf}")
+		self.assertEqual(text, "")
+		self.assertEqual(rels, [])
+		self.assertTrue(marked)
+
+	def test_no_marker_returns_empty_rels(self):
+		from jarvis.chat import egress_rules
+
+		with patch("jarvis.chat.egress_rules.redact_and_flag", side_effect=lambda t, **k: t):
+			text, rels, marked = egress_rules.redact_final_with_media("A plain reply.", run_id="R1")
+		self.assertEqual(text, "A plain reply.")
+		self.assertEqual(rels, [])
+		self.assertFalse(marked)
+
+	def test_none_text(self):
+		from jarvis.chat import egress_rules
+
+		with patch("jarvis.chat.egress_rules.redact_and_flag", side_effect=lambda t, **k: t):
+			text, rels, marked = egress_rules.redact_final_with_media(None)
+		self.assertIsNone(text)
+		self.assertEqual(rels, [])
+		self.assertFalse(marked)
+
+
+class TestPumpThreading(unittest.TestCase):
+	"""finalize._effect_rich_outputs must re-read media_rels off the Turn row and
+	pass it to persist_rich_outputs — the pump (default) transport delivery path
+	that a direct-relay-only wiring would silently drop."""
+
+	def test_effect_reads_media_rels_from_turn_row(self):
+		import json
+
+		from jarvis.chat import finalize
+
+		ctx = Mock()
+		ctx.turn = {"assistant_message": "MSG-1"}
+		ctx.conversation = "C1"
+		ctx.owner = "u@x"
+		ctx.run_id = "R1"
+
+		payload_json = json.dumps({"text": "clean reply", "media_rels": [_IMG]})
+
+		def fake_get_value(dt, dn, field):
+			if field == "terminal_payload":
+				return payload_json
+			return "2026-09-10 00:00:00"  # dispatching_at for _turn_start_ms
+
+		with (
+			patch("frappe.db.get_value", side_effect=fake_get_value),
+			patch("jarvis.chat.turn_handler.persist_rich_outputs") as pro,
+		):
+			finalize._effect_rich_outputs(ctx)
+
+		pro.assert_called_once()
+		self.assertEqual(pro.call_args.kwargs.get("media_rels"), [_IMG])
+
+	def test_effect_no_media_rels_passes_none(self):
+		import json
+
+		from jarvis.chat import finalize
+
+		ctx = Mock()
+		ctx.turn = {"assistant_message": "MSG-1"}
+		ctx.conversation = "C1"
+		ctx.owner = "u@x"
+		ctx.run_id = "R1"
+
+		def fake_get_value(dt, dn, field):
+			if field == "terminal_payload":
+				return json.dumps({"text": "clean reply"})
+			return "2026-09-10 00:00:00"
+
+		with (
+			patch("frappe.db.get_value", side_effect=fake_get_value),
+			patch("jarvis.chat.turn_handler.persist_rich_outputs") as pro,
+		):
+			finalize._effect_rich_outputs(ctx)
+
+		self.assertIsNone(pro.call_args.kwargs.get("media_rels"))
+
+
+class TestSeedBlockWiring(unittest.TestCase):
+	"""persist_rich_outputs' third block: when media_rels is present it must call
+	seed_media with the right args and publish a cumulative 'canvas' event."""
+
+	def test_media_block_seeds_and_publishes_cumulative(self):
+		import json
+
+		from jarvis.chat import turn_handler
+
+		settings = Mock(agent_url="ws://h:1")
+		settings.get_password = Mock(return_value="tok")
+
+		def fake_get_value(dt, dn, field):
+			if field == "content":
+				return ""  # no canvas refs, no "imagegen" -> first two blocks no-op
+			if field == "canvas":
+				return json.dumps([{"name": "chart", "type": "svg"}, {"name": "img", "type": "image"}])
+			return None
+
+		media_item = {"name": "img", "type": "image", "source": _IMG_REL}
+		published = []
+		with (
+			patch("frappe.get_single", return_value=settings),
+			patch("frappe.db.get_value", side_effect=fake_get_value),
+			patch("jarvis.chat.canvas.persist_canvases", return_value=[]),
+			patch("jarvis.chat.generated_media.seed_media", return_value=[media_item]) as sm,
+			patch("jarvis.chat.turn_handler._publish_to_user", side_effect=lambda u, p: published.append(p)),
+		):
+			turn_handler.persist_rich_outputs("MSG-1", "C1", "u@x", "run1", 0, media_rels=[_IMG])
+
+		sm.assert_called_once_with("MSG-1", "ws://h:1", "tok", [_IMG])
+		canvas_pubs = [p for p in published if p.get("kind") == "canvas"]
+		self.assertEqual(len(canvas_pubs), 1)
+		# cumulative: the published items include the pre-existing chart, not just media
+		self.assertEqual(len(canvas_pubs[0]["items"]), 2)
+
+	def test_no_media_rels_skips_seed(self):
+		from jarvis.chat import turn_handler
+
+		settings = Mock(agent_url="ws://h:1")
+		settings.get_password = Mock(return_value="tok")
+		with (
+			patch("frappe.get_single", return_value=settings),
+			patch("frappe.db.get_value", return_value=""),
+			patch("jarvis.chat.canvas.persist_canvases", return_value=[]),
+			patch("jarvis.chat.generated_media.seed_media") as sm,
+			patch("jarvis.chat.turn_handler._publish_to_user"),
+		):
+			turn_handler.persist_rich_outputs("MSG-1", "C1", "u@x", "run1", 0, media_rels=None)
+		sm.assert_not_called()
+
+
+class TestRecoveryStrip(unittest.TestCase):
+	"""Recovery (D1): _latest_assistant_text strips the marker at each return
+	(string / block-list / text), leaking no raw path, delivering no image."""
+
+	def test_string_content_marker_stripped(self):
+		from jarvis.chat import turn_recovery
+
+		out = turn_recovery._latest_assistant_text([{"role": "assistant", "content": f"done\nMEDIA:{_IMG}"}])
+		self.assertNotIn("MEDIA:", out)
+		self.assertNotIn("/home/node", out)
+
+	def test_block_list_content_marker_stripped(self):
+		from jarvis.chat import turn_recovery
+
+		msg = {"role": "assistant", "content": [{"type": "text", "text": f"ok\nMEDIA:{_IMG}"}]}
+		out = turn_recovery._latest_assistant_text([msg])
+		self.assertNotIn("MEDIA:", out)
+		self.assertNotIn("/home/node", out)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -650,6 +650,35 @@ class TestSnapshotRecoveryWindow(_PipelineCase):
 		end = next(p for p in self._pubs if p.get("kind") == "run:end")
 		self.assertTrue(end.get("was_recovered"), "run:end carries was_recovered for a real recovery")
 
+	def test_in_window_media_marker_only_recovers_final_with_clean_content(self):
+		"""Q3 leak-safety: a marker-ONLY in-window reply (seq 7 > watermark 5) must
+		settle FINAL with clean (empty) content — NOT errored, and NEVER leaving the
+		raw MEDIA:/home/node/... path in stored content (served raw on reload)."""
+		conv = self._mk_conv()
+		rid = "pmp_rec_media"
+		amsg, epoch = self._seed_streaming_gone(conv, rid, watermark=5)
+		double = self._double()
+		marker = "MEDIA:/home/node/.openclaw/media/tool-image-generation/black-hole---abcd1234.png"
+		double.arm_sessions_get(
+			"sess-rec",
+			[
+				{"role": "user", "content": "second question", "__openclaw": {"seq": 6}},
+				{"role": "assistant", "content": marker, "__openclaw": {"seq": 7}},
+			],
+		)
+		ctx = self._ctx_for(double, epoch)
+		self._pubs.clear()
+
+		pump._reconcile_on_start(ctx)
+		self._pump_until(ctx, lambda: self._state(rid) in ("errored", "finalizing", "done"))
+
+		self.assertEqual(self._state(rid), "finalizing", "marker-only IS real output -> final, not errored")
+		content = frappe.db.get_value(MSG, amsg, "content")
+		self.assertEqual(content, "", "marker stripped to empty clean content")
+		self.assertNotIn("/home/node", content or "")
+		self.assertNotIn("MEDIA:", content or "")
+		self.assertEqual(int(self._val(rid, "was_recovered")), 1)
+
 
 # --------------------------------------------------------------------------- #
 # 6. Two-writer settlement — exactly-once under a racing recovery (both orders)


### PR DESCRIPTION
…p leak

agent's native image tool writes to the openclaw media store and emits a protocol MEDIA:<path> marker on its own line; Jarvis chat had no consumer, so the raw container path leaked in the reply and the image was never delivered.

Detect + strip the marker BEFORE egress at all three terminal producers (direct relay, pump, recovery), thread the local media paths forward, and fetch each directly from the container gateway (/__openclaw__/assistant-media, mirroring canvas.py) + seed as a private File + canvas item. Recovery strips but does not re-deliver (best-effort, rare path).

- generated_media.py: detect_media_paths / strip_media_lines / fetch_media (redirect-disabled, 8MB streamed cap) / seed_media (dedup by source path)
- egress_rules.py: redact_final_with_media helper (consume before redact)
- agent_client / relay_mux / turn_recovery: strip at each redact site
- finalize._effect_rich_outputs: re-read media_rels off the Turn row (pump is the default transport)
- turn_handler.persist_rich_outputs: media_rels param + third seed block



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
