### PR TITLE
feat(settings): Reset Onboarding button on the Jarvis Settings form

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -153,105 +153,111 @@ frappe.ui.form.on("Jarvis Settings", {
 			)
 		);
 
-		// Reset onboarding: the bench-side half of a fresh start. Clears this
-		// bench's admin connection + LLM credentials (and, by default, all
-		// workspace content) so the setup wizard runs from step 1 again. Needed
-		// when the customer was purged on admin and the bench still holds the
-		// old credentials, which otherwise loops the wizard. The admin-side
-		// purge is separate and stays on admin. System Manager only (the
-		// endpoint enforces it); the dialog requires typing RESET so a stray
-		// click cannot wipe a workspace.
-		frm.add_custom_button(
-			__("Reset Onboarding"),
-			() => {
-				const d = new frappe.ui.Dialog({
-					title: __("Reset Onboarding"),
-					fields: [
-						{
-							fieldname: "warning",
-							fieldtype: "HTML",
-							options: `<p>${__(
-								"This disconnects the workspace from the admin plane and removes the saved AI credentials. The setup wizard starts from step 1. Billing on the admin plane is not changed."
-							)}</p>`,
-						},
-						{
-							fieldname: "wipe_data",
-							fieldtype: "Check",
-							label: __("Also delete all workspace content"),
-							default: 1,
-							description: __(
-								"Chats, skills, macros, triggers, learning data, wiki and dashboards. Leave unchecked to keep them."
-							),
-						},
-						{
-							fieldname: "confirm_text",
-							fieldtype: "Data",
-							label: __("Type RESET to confirm"),
-							reqd: 1,
-						},
-					],
-					primary_action_label: __("Reset Now"),
-					primary_action(values) {
-						if ((values.confirm_text || "").trim() !== "RESET") {
-							frappe.msgprint({
-								title: __("Not Reset"),
-								message: __("Type RESET (all capitals) to confirm."),
-								indicator: "orange",
-							});
-							return;
-						}
-						d.hide();
-						frappe
-							.call({
-								method: "jarvis.onboarding.reset_onboarding",
-								args: { wipe_data: values.wipe_data ? 1 : 0 },
-								freeze: true,
-								freeze_message: __("Resetting the workspace…"),
-							})
-							.then((r) => {
-								const m = r.message || {};
-								if (!m.ok) {
-									frappe.msgprint({
-										title: __("Reset Failed"),
-										message:
-											(m.error && m.error.message) || __("Unknown error"),
-										indicator: "red",
-									});
-									return;
-								}
-								const data = m.data || {};
-								const wiped = (data.wiped_doctypes || []).length;
+		// Developer mode only (owner directive 2026-09-11): this is an operator
+		// recovery tool for staging/local benches, not a customer-facing control.
+		// The endpoint itself stays System Manager only regardless of this gate.
+		if (frappe.boot.developer_mode) {
+			// Reset onboarding: the bench-side half of a fresh start. Clears this
+			// bench's admin connection + LLM credentials (and, by default, all
+			// workspace content) so the setup wizard runs from step 1 again. Needed
+			// when the customer was purged on admin and the bench still holds the
+			// old credentials, which otherwise loops the wizard. The admin-side
+			// purge is separate and stays on admin. System Manager only (the
+			// endpoint enforces it); the dialog requires typing RESET so a stray
+			// click cannot wipe a workspace.
+			frm.add_custom_button(
+				__("Reset Onboarding"),
+				() => {
+					const d = new frappe.ui.Dialog({
+						title: __("Reset Onboarding"),
+						fields: [
+							{
+								fieldname: "warning",
+								fieldtype: "HTML",
+								options: `<p>${__(
+									"This disconnects the workspace from the admin plane and removes the saved AI credentials. The setup wizard starts from step 1. Billing on the admin plane is not changed."
+								)}</p>`,
+							},
+							{
+								fieldname: "wipe_data",
+								fieldtype: "Check",
+								label: __("Also delete all workspace content"),
+								default: 1,
+								description: __(
+									"Chats, skills, macros, triggers, learning data, wiki and dashboards. Leave unchecked to keep them."
+								),
+							},
+							{
+								fieldname: "confirm_text",
+								fieldtype: "Data",
+								label: __("Type RESET to confirm"),
+								reqd: 1,
+							},
+						],
+						primary_action_label: __("Reset Now"),
+						primary_action(values) {
+							if ((values.confirm_text || "").trim() !== "RESET") {
 								frappe.msgprint({
-									title: __("Onboarding Reset"),
-									message: wiped
-										? __(
-												"Connection cleared and {0} content types deleted. Open Jarvis to run setup again.",
-												[wiped]
-										  )
-										: __(
-												"Connection cleared; workspace content kept. Open Jarvis to run setup again."
-										  ),
-									indicator: "green",
-									primary_action: {
-										label: __("Open Jarvis"),
-										action() {
-											window.location.href = "/jarvis";
-										},
-									},
+									title: __("Not Reset"),
+									message: __("Type RESET (all capitals) to confirm."),
+									indicator: "orange",
 								});
-								frm.reload_doc();
-							});
-					},
-				});
-				d.show();
-			},
-			__("Agent Recovery")
-		)?.attr(
-			"title",
-			__(
-				"Start onboarding from step 1 on this bench: clears the admin connection and AI credentials, optionally all workspace content. Use after the customer was purged on admin. System Manager only."
-			)
-		);
+								return;
+							}
+							d.hide();
+							frappe
+								.call({
+									method: "jarvis.onboarding.reset_onboarding",
+									args: { wipe_data: values.wipe_data ? 1 : 0 },
+									freeze: true,
+									freeze_message: __("Resetting the workspace…"),
+								})
+								.then((r) => {
+									const m = r.message || {};
+									if (!m.ok) {
+										frappe.msgprint({
+											title: __("Reset Failed"),
+											message:
+												(m.error && m.error.message) ||
+												__("Unknown error"),
+											indicator: "red",
+										});
+										return;
+									}
+									const data = m.data || {};
+									const wiped = (data.wiped_doctypes || []).length;
+									frappe.msgprint({
+										title: __("Onboarding Reset"),
+										message: wiped
+											? __(
+													"Connection cleared and {0} content types deleted. Open Jarvis to run setup again.",
+													[wiped]
+											  )
+											: __(
+													"Connection cleared; workspace content kept. Open Jarvis to run setup again."
+											  ),
+										indicator: "green",
+										primary_action: {
+											label: __("Open Jarvis"),
+											action() {
+												window.location.href = "/jarvis";
+											},
+										},
+									});
+									frm.reload_doc();
+								});
+						},
+					});
+					d.show();
+				},
+				__("Agent Recovery")
+			)?.attr(
+				"title",
+				__(
+					"Start onboarding from step 1 on this bench: clears the admin connection and AI credentials, optionally all workspace content. Use after the customer was purged on admin. System Manager only."
+				)
+			);
+		}
 
 		frm.add_custom_button(
 			__("Force Resync"),

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -153,9 +153,105 @@ frappe.ui.form.on("Jarvis Settings", {
 			)
 		);
 
-		// Reset onboarding moved to the `bench reset-onboarding` CLI command
-		// (jarvis.commands); a destructive dev reset no longer belongs on the
-		// HTTP form.
+		// Reset onboarding: the bench-side half of a fresh start. Clears this
+		// bench's admin connection + LLM credentials (and, by default, all
+		// workspace content) so the setup wizard runs from step 1 again. Needed
+		// when the customer was purged on admin and the bench still holds the
+		// old credentials, which otherwise loops the wizard. The admin-side
+		// purge is separate and stays on admin. System Manager only (the
+		// endpoint enforces it); the dialog requires typing RESET so a stray
+		// click cannot wipe a workspace.
+		frm.add_custom_button(
+			__("Reset Onboarding"),
+			() => {
+				const d = new frappe.ui.Dialog({
+					title: __("Reset Onboarding"),
+					fields: [
+						{
+							fieldname: "warning",
+							fieldtype: "HTML",
+							options: `<p>${__(
+								"This disconnects the workspace from the admin plane and removes the saved AI credentials. The setup wizard starts from step 1. Billing on the admin plane is not changed."
+							)}</p>`,
+						},
+						{
+							fieldname: "wipe_data",
+							fieldtype: "Check",
+							label: __("Also delete all workspace content"),
+							default: 1,
+							description: __(
+								"Chats, skills, macros, triggers, learning data, wiki and dashboards. Leave unchecked to keep them."
+							),
+						},
+						{
+							fieldname: "confirm_text",
+							fieldtype: "Data",
+							label: __("Type RESET to confirm"),
+							reqd: 1,
+						},
+					],
+					primary_action_label: __("Reset Now"),
+					primary_action(values) {
+						if ((values.confirm_text || "").trim() !== "RESET") {
+							frappe.msgprint({
+								title: __("Not Reset"),
+								message: __("Type RESET (all capitals) to confirm."),
+								indicator: "orange",
+							});
+							return;
+						}
+						d.hide();
+						frappe
+							.call({
+								method: "jarvis.onboarding.reset_onboarding",
+								args: { wipe_data: values.wipe_data ? 1 : 0 },
+								freeze: true,
+								freeze_message: __("Resetting the workspace…"),
+							})
+							.then((r) => {
+								const m = r.message || {};
+								if (!m.ok) {
+									frappe.msgprint({
+										title: __("Reset Failed"),
+										message:
+											(m.error && m.error.message) || __("Unknown error"),
+										indicator: "red",
+									});
+									return;
+								}
+								const data = m.data || {};
+								const wiped = (data.wiped_doctypes || []).length;
+								frappe.msgprint({
+									title: __("Onboarding Reset"),
+									message: wiped
+										? __(
+												"Connection cleared and {0} content types deleted. Open Jarvis to run setup again.",
+												[wiped]
+										  )
+										: __(
+												"Connection cleared; workspace content kept. Open Jarvis to run setup again."
+										  ),
+									indicator: "green",
+									primary_action: {
+										label: __("Open Jarvis"),
+										action() {
+											window.location.href = "/jarvis";
+										},
+									},
+								});
+								frm.reload_doc();
+							});
+					},
+				});
+				d.show();
+			},
+			__("Agent Recovery")
+		)?.attr(
+			"title",
+			__(
+				"Start onboarding from step 1 on this bench: clears the admin connection and AI credentials, optionally all workspace content. Use after the customer was purged on admin. System Manager only."
+			)
+		);
 
 		frm.add_custom_button(
 			__("Force Resync"),

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -156,7 +156,7 @@ frappe.ui.form.on("Jarvis Settings", {
 		// Developer mode only (owner directive 2026-09-11): this is an operator
 		// recovery tool for staging/local benches, not a customer-facing control.
 		// The endpoint itself stays System Manager only regardless of this gate.
-		if (frappe.boot.developer_mode) {
+		if (frappe.boot.developer_mode && frappe.user.has_role("System Manager")) {
 			// Reset onboarding: the bench-side half of a fresh start. Clears this
 			// bench's admin connection + LLM credentials (and, by default, all
 			// workspace content) so the setup wizard runs from step 1 again. Needed
@@ -182,9 +182,9 @@ frappe.ui.form.on("Jarvis Settings", {
 								fieldname: "wipe_data",
 								fieldtype: "Check",
 								label: __("Also delete all workspace content"),
-								default: 1,
+								default: 0,
 								description: __(
-									"Chats, skills, macros, triggers, learning data, wiki and dashboards. Leave unchecked to keep them."
+									"Chats, skills, macros, triggers, learning data, wiki and dashboards. Off by default: only the connection and AI credentials are cleared."
 								),
 							},
 							{
@@ -213,18 +213,9 @@ frappe.ui.form.on("Jarvis Settings", {
 									freeze_message: __("Resetting the workspace…"),
 								})
 								.then((r) => {
-									const m = r.message || {};
-									if (!m.ok) {
-										frappe.msgprint({
-											title: __("Reset Failed"),
-											message:
-												(m.error && m.error.message) ||
-												__("Unknown error"),
-											indicator: "red",
-										});
-										return;
-									}
-									const data = m.data || {};
+									// The endpoint raises on failure (frappe.call shows the server
+									// message); a resolved call is always {ok: true}.
+									const data = (r.message && r.message.data) || {};
 									const wiped = (data.wiped_doctypes || []).length;
 									frappe.msgprint({
 										title: __("Onboarding Reset"),
@@ -243,6 +234,19 @@ frappe.ui.form.on("Jarvis Settings", {
 												window.location.href = "/jarvis";
 											},
 										},
+									});
+									frm.reload_doc();
+								})
+								.catch(() => {
+									// Request-level failure (network, timeout, or a server
+									// exception mid-teardown): say so, and reload so the form
+									// shows whatever state the reset reached.
+									frappe.msgprint({
+										title: __("Reset Failed"),
+										message: __(
+											"The reset did not complete. Reload the page and check the connection fields before trying again."
+										),
+										indicator: "red",
 									});
 									frm.reload_doc();
 								});


### PR DESCRIPTION
## Summary

Adds a **Reset Onboarding** button to the Jarvis Settings Desk form (Agent Recovery menu). A System Manager who purged the customer on admin can now restart the setup wizard from the bench UI instead of the `bench reset-onboarding` CLI.

The SPA already has "Reset to onboarding" in Settings, General, but that dialog is gated off while the workspace is not onboarding-complete, which is exactly the stuck state after an admin purge. The Desk form stays reachable at `/app/jarvis-settings`.

- Shown only when `developer_mode` is on (owner directive): an operator recovery tool for local and staging benches, not a customer control.
- Calls the existing `jarvis.onboarding.reset_onboarding` endpoint (System Manager only, unchanged).
- Dialog requires typing `RESET`; an "Also delete all workspace content" checkbox is off by default (deletion is a separate, deliberate tick), then an "Open Jarvis" link leads into the wizard. A request-level failure shows a Reset Failed message and reloads the form.
- Menu entry is also gated client-side on the System Manager role, matching the endpoint.
- No backend change. Verified live on a local site: button, dialog, and the typed-confirmation guard (wrong word is rejected, dialog stays open). The destructive call itself is covered by the existing `test_dev.py` wrapper tests.

## Before / After

**Before** (develop): Agent Recovery menu has no reset entry.

<img width="1710" height="903" alt="reset-onboarding-before" src="https://github.com/user-attachments/assets/41b5c942-b885-467c-b71a-e4a074adeced" />

**After**: Reset Onboarding entry opens this dialog; a wrong confirmation word is rejected and the dialog stays open.

<img width="1710" height="903" alt="reset-onboarding-dialog" src="https://github.com/user-attachments/assets/65296699-029e-4308-af79-f66f68f2f5a1" />

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green

https://claude.ai/code/session_01RdyoBvAWj8Yt9WCnrxX8oU



