### PR TITLE
fix(release): style the What's-new panel + render thematic breaks

### DIFF
--- a/frontend/src/components/chat/WhatsNewDialog.vue
+++ b/frontend/src/components/chat/WhatsNewDialog.vue
@@ -25,22 +25,18 @@
 				<span>You're all caught up.</span>
 			</div>
 
-			<!-- notes, newest first: version heading via {{ }} (never v-html), body
-			     via renderMarkdown (escape-first, XSS-safe) in a prose block -->
-			<div v-else class="flex flex-col gap-6">
-				<section v-for="note in notes" :key="note.version">
-					<div class="flex flex-wrap items-baseline gap-2">
-						<h3 class="text-base font-semibold text-ink-gray-9">
-							{{ note.version }}
-						</h3>
-						<span v-if="note.title" class="text-sm text-ink-gray-6">
-							{{ note.title }}
-						</span>
-					</div>
-					<div
-						class="prose prose-sm mt-1 max-w-none"
-						v-html="renderMarkdown(note.body)"
-					></div>
+			<!-- notes, newest first: version badge via {{ }} (never v-html), body
+			     via renderMarkdown (escape-first, XSS-safe). Styling is
+			     component-scoped on purpose: the app ships no Tailwind Typography
+			     plugin (so `prose` was inert here) and the chat's jv-md-* styles
+			     are scoped to Message.vue, so this panel styles the markup itself. -->
+			<div v-else class="wn-list">
+				<section v-for="note in notes" :key="note.version" class="wn-card">
+					<header class="wn-card-head">
+						<h3 class="wn-badge">{{ note.version }}</h3>
+						<span v-if="note.title" class="wn-card-title">{{ note.title }}</span>
+					</header>
+					<div class="wn-body" v-html="renderMarkdown(note.body)"></div>
 				</section>
 			</div>
 		</template>
@@ -113,3 +109,112 @@ watch(open, (isOpen) => {
 	if (isOpen) load();
 });
 </script>
+
+<style scoped>
+.wn-list {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+/* Each release is its own card, so stacked notes read as distinct entries. */
+.wn-card {
+	border: 1px solid var(--ink-gray-3, #e5e7eb);
+	border-radius: 12px;
+	padding: 16px 18px;
+	background: var(--surface-white, #fff);
+}
+
+.wn-card-head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 8px;
+	margin-bottom: 10px;
+}
+
+/* Version as an accent pill (matches the update-gate badge). Kept an <h3> so
+   each release stays a screen-reader sub-heading under the dialog title. */
+.wn-badge {
+	display: inline-block;
+	margin: 0;
+	padding: 3px 10px;
+	border-radius: 999px;
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.2px;
+	color: #6e5cf6;
+	background: rgba(110, 92, 246, 0.12);
+}
+
+.wn-card-title {
+	font-size: 13px;
+	color: var(--ink-gray-6, #6b7280);
+}
+
+/* Markdown body. The renderer emits jv-md-* classes and bare <strong>/<em>/
+   <a>; style them here via :deep() since the v-html'd nodes carry no scope
+   attribute. */
+.wn-body {
+	font-size: 14px;
+	line-height: 1.6;
+	color: var(--ink-gray-7, #4b5563);
+}
+.wn-body :deep(.jv-md-p) {
+	margin: 0 0 8px;
+}
+.wn-body :deep(.jv-md-p:last-child) {
+	margin-bottom: 0;
+}
+/* A bold-only line is how notes label a section (e.g. "**✨ New**"); give it a
+   little air above so sections separate, and let the emphasis carry weight. */
+.wn-body :deep(strong) {
+	font-weight: 600;
+	color: var(--ink-gray-9, #171717);
+}
+.wn-body :deep(.jv-md-list + .jv-md-p) {
+	margin-top: 12px;
+}
+.wn-body :deep(.jv-md-list) {
+	margin: 4px 0 10px;
+	padding-left: 20px;
+	list-style: disc;
+}
+.wn-body :deep(ol.jv-md-list) {
+	list-style: decimal;
+}
+.wn-body :deep(.jv-md-list li) {
+	margin: 3px 0;
+}
+.wn-body :deep(.jv-md-list:last-child) {
+	margin-bottom: 0;
+}
+.wn-body :deep(.jv-md-h) {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--ink-gray-9, #171717);
+	margin: 14px 0 6px;
+}
+.wn-body :deep(.jv-md-hr) {
+	border: none;
+	border-top: 1px solid var(--ink-gray-3, #e5e7eb);
+	margin: 12px 0;
+}
+.wn-body :deep(.jv-md-code) {
+	font-family: var(--font-mono, ui-monospace, monospace);
+	font-size: 12.5px;
+	padding: 1px 5px;
+	border-radius: 5px;
+	background: var(--surface-gray-2, #f3f4f6);
+}
+.wn-body :deep(.jv-md-link) {
+	color: #6e5cf6;
+	text-decoration: underline;
+}
+.wn-body :deep(.jv-md-quote) {
+	margin: 8px 0;
+	padding-left: 10px;
+	border-left: 3px solid var(--ink-gray-3, #e5e7eb);
+	color: var(--ink-gray-6, #6b7280);
+}
+</style>

--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -1,7 +1,7 @@
 // Compact GFM renderer - enough for agent replies: paragraphs, bold/italic,
 // strikethrough, inline code, links, nested bullet/number lists, blockquotes,
-// and pipe tables (rendered into the imported design's table look via the
-// .jv-md classes in ChatView's styles).
+// thematic breaks (---/***/___), and pipe tables (rendered into the imported
+// design's table look via the .jv-md classes in ChatView's styles).
 function esc(s) {
 	return String(s).replace(
 		/[&<>"]/g,
@@ -242,6 +242,17 @@ export function renderMarkdown(src) {
 				i++;
 			}
 			out.push(`<blockquote class="jv-md-quote">${inline(q.join(" "))}</blockquote>`);
+			continue;
+		}
+		// thematic break: a line of 3+ of the same -, * or _ (spaces allowed
+		// between). The standard Markdown section divider - release notes and
+		// agent replies use it, and without this branch it fell through to a
+		// paragraph and rendered as literal "---". Checked BEFORE the list branch
+		// so a spaced "- - -" reads as a rule, not a "- " item whose text is "- -".
+		if (/^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/.test(line)) {
+			flushPara();
+			out.push('<hr class="jv-md-hr">');
+			i++;
 			continue;
 		}
 		// bullet / numbered lists, indent-nested.

--- a/frontend/src/markdown.test.js
+++ b/frontend/src/markdown.test.js
@@ -178,3 +178,34 @@ test("an /app/ path inside BACKTICKS used as a markdown link's text also avoids 
 		"the path still renders as code, just not as its own link, inside the outer anchor"
 	);
 });
+
+// Thematic break: a release note (and agents) use "---" to divide sections. It
+// fell through to a paragraph and showed as literal "---" in the What's-new
+// panel; it must render as an <hr>.
+test("renders a thematic break (---, ***, ___, and spaced/longer runs) as an <hr>", () => {
+	for (const rule of ["---", "***", "___", "- - -", "****", "- - - -"]) {
+		const html = renderMarkdown(`New in 1.2\n\n${rule}\n\nOlder note`);
+		assert.ok(html.includes('<hr class="jv-md-hr">'), `"${rule}" becomes an <hr>`);
+		assert.ok(
+			!html.includes(`<p class="jv-md-p">${rule}</p>`),
+			`"${rule}" is not left as a literal paragraph`
+		);
+	}
+});
+
+test("a bullet list is NOT mistaken for a thematic break (checked before the list branch)", () => {
+	const html = renderMarkdown("- one\n- two");
+	assert.ok(!html.includes("<hr"), "list stays a list, no stray rule");
+	assert.ok(html.includes("<ul") && html.includes("<li>one"), "renders the list items");
+});
+
+test("fewer than three markers is NOT a thematic break", () => {
+	assert.ok(!renderMarkdown("--").includes("<hr"), '"--" stays a paragraph');
+	assert.ok(!renderMarkdown("**").includes("<hr"), '"**" stays a paragraph');
+});
+
+test("a pipe table separator row is not swallowed by the thematic-break rule", () => {
+	const html = renderMarkdown(["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n"));
+	assert.ok(html.includes("<table"), "the table still renders");
+	assert.ok(!html.includes("<hr"), "the |---| separator did not become a rule");
+});

--- a/pwa/src/components/WhatsNewSheet.vue
+++ b/pwa/src/components/WhatsNewSheet.vue
@@ -101,19 +101,17 @@ function close() {
 				</div>
 
 				<!-- notes, newest first: version heading via {{ }} (never v-html),
-				     body via renderMarkdown (escape-first, XSS-safe) in a prose block -->
+				     body via renderMarkdown (escape-first, XSS-safe), styled in
+				     component (`prose` is inert - no Tailwind Typography plugin) -->
 				<div v-else class="jv-wnew-notes">
-					<section v-for="note in notes" :key="note.version">
+					<section v-for="note in notes" :key="note.version" class="jv-wnew-card">
 						<div class="jv-wnew-note-head">
-							<h3 class="jv-wnew-note-version">{{ note.version }}</h3>
+							<h3 class="jv-wnew-badge">{{ note.version }}</h3>
 							<span v-if="note.title" class="jv-wnew-note-title">{{
 								note.title
 							}}</span>
 						</div>
-						<div
-							class="prose prose-sm max-w-none jv-wnew-note-body"
-							v-html="renderMarkdown(note.body)"
-						></div>
+						<div class="jv-wnew-note-body" v-html="renderMarkdown(note.body)"></div>
 					</section>
 				</div>
 			</div>
@@ -189,27 +187,100 @@ function close() {
 .jv-wnew-notes {
 	display: flex;
 	flex-direction: column;
-	gap: 22px;
+	gap: 14px;
+}
+/* Each release is its own card, so stacked notes read as distinct entries. */
+.jv-wnew-card {
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	padding: 14px 16px;
+	background: var(--card);
 }
 .jv-wnew-note-head {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: baseline;
 	gap: 8px;
+	margin-bottom: 10px;
 }
-.jv-wnew-note-version {
+/* Version as an accent pill (matches the update banner/pill). Kept an <h3> so
+   each release stays a screen-reader sub-heading under the sheet title. */
+.jv-wnew-badge {
+	display: inline-block;
 	margin: 0;
-	font-size: 15px;
-	font-weight: 700;
-	color: var(--ink9);
+	padding: 3px 10px;
+	border-radius: 999px;
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.2px;
+	color: var(--accent);
+	background: var(--accent-bg);
 }
 .jv-wnew-note-title {
 	font-size: 13px;
 	color: var(--ink6);
 }
+/* Markdown body: the renderer emits jv-md-* classes + bare <strong>/<em>/<a>;
+   style via :deep() since the v-html'd nodes carry no scope attribute. */
 .jv-wnew-note-body {
-	margin-top: 4px;
+	font-size: 14px;
+	line-height: 1.6;
 	color: var(--ink7);
+}
+.jv-wnew-note-body :deep(.jv-md-p) {
+	margin: 0 0 8px;
+}
+.jv-wnew-note-body :deep(.jv-md-p:last-child) {
+	margin-bottom: 0;
+}
+.jv-wnew-note-body :deep(strong) {
+	font-weight: 600;
+	color: var(--ink9);
+}
+.jv-wnew-note-body :deep(.jv-md-list + .jv-md-p) {
+	margin-top: 12px;
+}
+.jv-wnew-note-body :deep(.jv-md-list) {
+	margin: 4px 0 10px;
+	padding-left: 20px;
+	list-style: disc;
+}
+.jv-wnew-note-body :deep(ol.jv-md-list) {
+	list-style: decimal;
+}
+.jv-wnew-note-body :deep(.jv-md-list li) {
+	margin: 3px 0;
+}
+.jv-wnew-note-body :deep(.jv-md-list:last-child) {
+	margin-bottom: 0;
+}
+.jv-wnew-note-body :deep(.jv-md-h) {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--ink9);
+	margin: 14px 0 6px;
+}
+.jv-wnew-note-body :deep(.jv-md-hr) {
+	border: none;
+	border-top: 1px solid var(--border2);
+	margin: 12px 0;
+}
+.jv-wnew-note-body :deep(.jv-md-code) {
+	font-family: ui-monospace, monospace;
+	font-size: 12.5px;
+	padding: 1px 5px;
+	border-radius: 5px;
+	background: var(--card2);
+}
+.jv-wnew-note-body :deep(.jv-md-link) {
+	color: var(--accent);
+	text-decoration: underline;
+}
+.jv-wnew-note-body :deep(.jv-md-quote) {
+	margin: 8px 0;
+	padding-left: 10px;
+	border-left: 3px solid var(--border2);
+	color: var(--ink6);
 }
 .jv-spinner {
 	width: 20px;


### PR DESCRIPTION
The What's-new panel (WhatsNewDialog + the pwa WhatsNewSheet) rendered release-note bodies with no styling: the `prose` classes were inert (the app ships no Tailwind Typography plugin) and the chat's jv-md-* styles are scoped to Message.vue, so notes fell back to bare browser defaults. A "---" section divider in a note body also showed as literal text, because the shared markdown renderer had no thematic-break branch.

- markdown.js: render 3+ of -, * or _ (spaces allowed between) as <hr class="jv-md-hr">, checked BEFORE the list branch so a spaced "- - -" reads as a rule, not a "- " item. Guarded so a |---| table separator is not swallowed. + unit tests (positive, list/table negatives, <3 markers).
- WhatsNewDialog.vue / WhatsNewSheet.vue: per-release cards, version as an accent pill (kept an <h3> so each release stays a screen-reader sub-heading), and component-scoped :deep() markdown styling (paragraphs, strong, lists, hr, code, links, quotes). The pwa uses its own theme tokens, so dark mode is covered too.

Backend-unchanged; SPA source only (bundles build at deploy). Verified: shared markdown suite green (22), both SPAs build, prettier + eslint clean.


## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
