### PR TITLE
feat(agents): register close-auditor unposted-voucher token; allow Journal Entry as a finding ref

### DIFF
--- a/jarvis/agents/registry.json
+++ b/jarvis/agents/registry.json
@@ -574,6 +574,7 @@
       "rule_tokens": [
         "ca-cl-2b9d",
         "ca-cl-7f31",
+        "ca-cl-9d20",
         "ca-cl-a4e6",
         "ca-cl-c058"
       ],

--- a/jarvis/tools/record_agent_run.py
+++ b/jarvis/tools/record_agent_run.py
@@ -225,8 +225,15 @@ def record_agent_run(
 	run_doc = frappe.get_doc(RUN, run_row.name)
 
 	# The agent's bench-held id-only token manifest + allowed ref doctypes. Tokens
-	# are opaque (A2); allowed refs = the agent's declared doctypes_required plus
-	# the aggregate dims (Company/Account) an evaluator may key a finding on.
+	# are opaque (A2); allowed refs = the agent's declared doctypes_required plus the
+	# universal accounting anchors (Company/Account) and the universal transaction
+	# (Journal Entry) an evaluator may key a finding on. These anchors are ALLOWED as
+	# finding references but are NOT added to doctypes_required, so they never become
+	# a mandatory install permission (doctypes_required gates run-as read at install;
+	# an auditor must not be blocked from installing just because it *may* reference a
+	# Journal Entry). A referenced record is still verified to exist AND be readable by
+	# the run-as user below (_ref_verifiable), so widening the anchor set cannot leak an
+	# unreadable record.
 	listing = (
 		frappe.db.get_value(
 			LISTING,
@@ -237,7 +244,7 @@ def record_agent_run(
 		or {}
 	)
 	token_set = set(_as_list(listing.get("rule_tokens")))
-	allowed_refs = set(_as_list(listing.get("doctypes_required"))) | {"Company", "Account"}
+	allowed_refs = set(_as_list(listing.get("doctypes_required"))) | {"Company", "Account", "Journal Entry"}
 
 	raw_findings = _as_list(findings)
 	coverage = _as_dict(coverage)


### PR DESCRIPTION
## What

Bench side of the close-auditor **CLOSE-UNPOSTED-VOUCHER** check. Two changes:

1. **`jarvis/agents/registry.json`** — add rule token `ca-cl-9d20` to the close-auditor listing (so `record_agent_run` accepts the new finding's token). Journal Entry is **deliberately not** added to `doctypes_required`.
2. **`jarvis/tools/record_agent_run.py`** — add `Journal Entry` to the finding-ref anchor set (alongside `Company`/`Account`).

## Why the two are separate (review comment)

`doctypes_required` is dual-use: it gates run-as read permission **at install** (`JarvisAgentInstallation._validate_run_as_permissions`) *and* seeds the finding-ref allowlist (`record_agent_run.allowed_refs`). Adding Journal Entry to it would block a run-as user who can read GL Entry / Account / Company but not Journal Entry from installing the auditor **at all** — losing the other four checks over one new check.

So this decouples them: Journal Entry is an **allowed finding reference** (anchor) without being a **mandatory install permission**. A referenced record is still verified to exist and be readable by the run-as user (`_ref_verifiable`), so widening the anchor set cannot leak an unreadable record. A user without Journal Entry read installs fine; the unposted tie degrades to `permission_slice` for them.

## Verified

Re-synced the listing and re-ran the auditor with Journal Entry **out** of `doctypes_required`: `dropped: []`, the JE-ref findings (`ACC-JV-2026-00029`, `...00051`) still land via the anchor (`last_seen_run` = the new run), coverage `ca-cl-9d20` = evaluated.

## Pairs with

Aerele-RnD/jarvis-agents#6.