### PR TITLE
fix(chat): New Chat dead on hotfix — drop orphaned connectorFocus ref

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -9005,12 +9005,6 @@ async function newChat() {
 	// _checkPulseOnce (keyed on this id, not _shownConvId) keeps this from
 	// double-firing when the first reply's loadConversation reload runs next.
 	_checkPulseOnce(currentId.value);
-	// loadConversation does not run on this path (see below), so reload THIS
-	// conversation's own connector-focus pick here instead of leaving the ref
-	// on whatever the PREVIOUS chat had armed - createOrFocusEmpty can return
-	// an already-existing empty conversation, so this is a real reload (its
-	// own stored pick, if any), not just a reset to null.
-	connectorFocus.value = _loadConnectorFocusFor(currentId.value);
 	// This conversation IS the unsaved new-chat composer getting its id. The recovered/typed
 	// new-chat draft (already restored into `input` by swapDraft above) and its still-retained
 	// voice records lived under the _NEW_CHAT_SCOPE sentinel — migrate draft + records + mirror +


### PR DESCRIPTION
newChat() referenced `connectorFocus` / `_loadConnectorFocusFor`, which are defined NOWHERE on the hotfix branches: the #1210 (session-feedback) backport pulled in the connector-focus USE without the feature's declarations. Because newChat() is async, the `ReferenceError: connectorFocus is not defined` at ChatView.vue:9013 rejected the promise silently (not a caught API error, so no toast) and aborted before `router.replace`, so New Chat did nothing from an existing conversation — a dead button, no error surfaced.

The connector-focus feature isn't on this branch — `connectorFocus` appears on that one line and nowhere else — so remove the orphaned statement and its comment. Every other symbol newChat() uses is defined; the frontend builds clean and New Chat runs to completion again.



## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ A red check only blocks the merge where the branch ruleset lists it as required.
> Honoring this checklist is what keeps broken changes out of UAT. See
> [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with its base** (`develop`, or `version-N-hotfix` for a backport)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
- [ ] If the base is `version-N`: this is the release PR from `version-N-hotfix`, `__version__` is bumped, and `release-source` is green
