### PR TITLE
Hold a calm "confirming" screen after checkout instead of the panic card (backport #958)

### DIFF
--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -1,0 +1,1710 @@
+// The onboarding wizard's VIEW half - the paths that live in OnboardingView.vue
+// itself, not in the reducer or the orchestrator (those have their own specs).
+// This is the first spec to mount the view; it exists for the bench re-probe's
+// view-level gaps: provider discovery loading (X4) and fail-closed narrowing
+// (D10), the stale checkout-marker mount clear (X3), the defensive reconnect
+// identity fields (X7), and the refused-restart note (X8).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+import { CHECKOUT_NAV_KEY } from "@/onboarding/checkoutNav";
+import { STATES } from "@/onboarding/paymentMachine";
+import { ACTIONS } from "@/onboarding/paymentCodes";
+import { toast } from "frappe-ui";
+
+// A raw {status, body} envelope, exactly what the flow's codec decodes.
+const ENVELOPE = (data, over = {}) => ({
+	status: 200,
+	body: { message: { ok: true, contract_version: 2, data, context: {}, ...over } },
+});
+
+const api = vi.hoisted(() => ({
+	isReadyForChat: vi.fn(async () => ({ ready: false, reason: "" })),
+	getLlmSyncStatus: vi.fn(async () => ({})),
+	listPlans: vi.fn(async () => []),
+	listPaymentProviders: vi.fn(async () => ({
+		providers: ["razorpay", "cashfree"],
+		default: "razorpay",
+	})),
+	reconnectAvailable: vi.fn(async () => ({ available: false })),
+	startAccountReconnect: vi.fn(async () => ({})),
+	checkAccountReconnect: vi.fn(async () => ({})),
+	redeemReconnectCode: vi.fn(async () => ({})),
+	getAccountDefaults: vi.fn(async () => ({})),
+	captureOnboardingLead: vi.fn(async () => ({ ok: true })),
+	getTermsUrl: vi.fn(async () => ({ url: "" })),
+	onboardingPaymentApi: {
+		getOnboardingState: vi.fn(async () => ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })),
+		startSignup: vi.fn(),
+		initiateSignupPayment: vi.fn(),
+		checkSignupPaymentStatus: vi.fn(async () =>
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING" })
+		),
+		confirmSignupPayment: vi.fn(),
+		syncConnection: vi.fn(async () => ({ synced: false })),
+		resendVerification: vi.fn(),
+	},
+}));
+vi.mock("@/api", () => api);
+// The connect controller (plan-05) navigates via useRouter; stub it so mounting
+// the view here does not warn about a missing router injection.
+vi.mock("vue-router", () => ({ useRouter: () => ({ replace: vi.fn() }) }));
+vi.mock("frappe-ui", () => ({
+	Button: { name: "Button", template: "<button><slot /></button>" },
+	FormControl: { name: "FormControl", template: "<input />" },
+	ErrorMessage: {
+		name: "ErrorMessage",
+		props: ["message"],
+		template: '<div v-if="message">{{ message }}</div>',
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	Checkbox: {
+		name: "Checkbox",
+		props: ["modelValue", "label", "id"],
+		emits: ["update:modelValue"],
+		template:
+			'<input type="checkbox" :id="id" :checked="!!modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+	},
+	call: vi.fn(),
+	dayjs: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
+	toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import OnboardingView from "./OnboardingView.vue";
+
+const STUBS = {
+	LlmPoolEditor: true,
+	JvCombo: true,
+	JvSpinner: true,
+	JarvisMark: true,
+	Banner: true,
+	TourIntro: true,
+	SetupNeuralNet: true,
+};
+
+function mountView() {
+	return mount(OnboardingView, { global: { stubs: STUBS } });
+}
+
+// Fill every billing field the Details step now REQUIRES (contact + address + city +
+// state + pincode) so onDetailsSubmit's validation gate passes and a test can reach
+// the behaviour it targets. Country auto-defaults to India, so it is left alone.
+function fillRequiredBilling(wrapper) {
+	wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+	wrapper.vm.billing.setUserValue("address", "12 MG Road");
+	wrapper.vm.billing.setUserValue("city", "Chennai");
+	wrapper.vm.billing.setUserValue("state", "Tamil Nadu");
+	wrapper.vm.billing.setUserValue("pincode", "600001");
+}
+
+beforeEach(() => {
+	window.matchMedia = (q) => ({
+		matches: false,
+		media: q,
+		addEventListener() {},
+		removeEventListener() {},
+		addListener() {},
+		removeListener() {},
+		dispatchEvent() {},
+	});
+	// Reset the mutable mocks to their happy defaults.
+	api.listPaymentProviders.mockResolvedValue({
+		providers: ["razorpay", "cashfree"],
+		default: "razorpay",
+	});
+	api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+		ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })
+	);
+	try {
+		window.sessionStorage.clear();
+		// Also clear localStorage: the billing snapshot key is constant across the file
+		// (one host+user namespace), so without this a test's persisted billing/identity
+		// leaks into later tests and can mask a missing-field guard.
+		window.localStorage.clear();
+	} catch (e) {
+		/* jsdom */
+	}
+});
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("X4: provider discovery loading state", () => {
+	it("providersLoading is true while discovery is in flight and false once it resolves", async () => {
+		let resolveProviders;
+		api.listPaymentProviders.mockReturnValue(new Promise((r) => (resolveProviders = r)));
+		const wrapper = mountView();
+		// loadPaymentProviders is fired (not awaited) in onMounted and flips the flag
+		// true synchronously before its first await.
+		expect(wrapper.vm.state.providersLoading).toBe(true);
+		resolveProviders({ providers: ["razorpay", "cashfree"], default: "razorpay" });
+		await flushPromises();
+		expect(wrapper.vm.state.providersLoading).toBe(false);
+		expect(wrapper.vm.state.availableProviders).toEqual(["razorpay", "cashfree"]);
+	});
+});
+
+describe("D10 (view): provider discovery is narrowed to known families and fails closed", () => {
+	it("drops an unknown third gateway and keeps only the known ones", async () => {
+		api.listPaymentProviders.mockResolvedValue({
+			providers: ["stripe", "razorpay", "cashfree"],
+			default: "stripe",
+		});
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.state.availableProviders).toEqual(["razorpay", "cashfree"]);
+		// The default was the unknown gateway; the preselect must fall to a known one.
+		expect(["razorpay", "cashfree"]).toContain(wrapper.vm.state.paymentProvider);
+		expect(wrapper.vm.state.providersError).toBe(false);
+	});
+
+	it("an unknown-ONLY answer fails closed (no provider, error surfaced)", async () => {
+		api.listPaymentProviders.mockResolvedValue({ providers: ["stripe"], default: "stripe" });
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.state.availableProviders).toEqual([]);
+		expect(wrapper.vm.state.paymentProvider).toBe("");
+		expect(wrapper.vm.state.providersError).toBe(true);
+	});
+
+	it("the Secured-by label is empty for anything not a known gateway (never defaults to Razorpay)", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.paymentProvider = "stripe";
+		await flushPromises();
+		expect(wrapper.vm.securedProviderLabel).toBe("");
+		wrapper.vm.state.paymentProvider = "cashfree";
+		await flushPromises();
+		expect(wrapper.vm.securedProviderLabel).toBe("Cashfree");
+	});
+});
+
+describe("X3 (view-half): a stale external-checkout marker is cleared on mount", () => {
+	it("a leftover marker is dropped when the mount is not mid-sheet", async () => {
+		window.sessionStorage.setItem(CHECKOUT_NAV_KEY, "att_from_a_previous_attempt");
+		const wrapper = mountView();
+		await flushPromises();
+		// Fresh mount lands on the intro (not checkout_open/confirming), so the stale
+		// marker must be gone - it can no longer drive a returnFromCheckout into a
+		// later live sheet.
+		expect(wrapper.vm.pay.value).not.toBe(STATES.CHECKOUT_OPEN);
+		expect(window.sessionStorage.getItem(CHECKOUT_NAV_KEY)).toBeNull();
+	});
+});
+
+describe("X7: defensive reconnect identity fields", () => {
+	it("reconnectNeedsIdentity is true when reconnect is offered but no identity exists", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "ACCOUNT_RECONNECT_REQUIRED",
+				attempt_id: "att_1",
+				generation: 1,
+				can_reconnect: true,
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.RECONNECT);
+		expect(wrapper.vm.reconnectNeedsIdentity).toBe(true);
+	});
+
+	it("reconnectNeedsIdentity is false when server truth carries an identity", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "ACCOUNT_RECONNECT_REQUIRED",
+				attempt_id: "att_1",
+				generation: 1,
+				can_reconnect: true,
+				email: "known@example.com",
+				company: "Known Co",
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.RECONNECT);
+		expect(wrapper.vm.reconnectNeedsIdentity).toBe(false);
+	});
+});
+
+describe("operator-issued reconnect code: direct redeem vs emailed request", () => {
+	it("enterReconnectDirect opens the code screen in direct mode WITHOUT mailing a request", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.enterReconnectDirect();
+		expect(wrapper.vm.state.step).toBe("reconnect");
+		expect(wrapper.vm.state.reconnectDirect).toBe(true);
+		// A support code already exists out of band - never ask admin to mail one.
+		expect(api.startAccountReconnect).not.toHaveBeenCalled();
+	});
+
+	it("direct-mode submit redeems the code WITH the email, never the request poll", async () => {
+		api.redeemReconnectCode.mockResolvedValue({ status: "connected" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "known@example.com";
+		await wrapper.vm.submitReconnectCode();
+		expect(api.redeemReconnectCode).toHaveBeenCalledWith("ABCD2345", "known@example.com");
+		expect(api.checkAccountReconnect).not.toHaveBeenCalled();
+	});
+
+	it("a lapsed (renew_payment) landing hands off to the billing page, not Connect", async () => {
+		// The v1 fix for the shipped-gate strand: an Expired account's container was stopped on
+		// expiry, so the code re-authenticates but there is nothing to connect to. The bench must
+		// hand off to /jarvis/billing (the renew surface), never advance to Connect and strand.
+		const assign = vi.fn();
+		const realLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...realLocation, assign },
+		});
+		api.redeemReconnectCode.mockResolvedValue({ status: "renew_payment" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "known@example.com";
+		await wrapper.vm.submitReconnectCode();
+		expect(assign).toHaveBeenCalledWith("/jarvis/billing");
+		expect(wrapper.vm.state.step).not.toBe("connect");
+		Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+	});
+
+	it("request-mode submit polls the started request, never the direct redeem", async () => {
+		api.checkAccountReconnect.mockResolvedValue({ status: "connected" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = false;
+		wrapper.vm.state.reconnectRequestId = "rid-1";
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		await wrapper.vm.submitReconnectCode();
+		expect(api.checkAccountReconnect).toHaveBeenCalledWith("rid-1", "ABCD2345");
+		expect(api.redeemReconnectCode).not.toHaveBeenCalled();
+	});
+
+	it("direct-mode submit is blocked until the email is supplied (the 2nd factor)", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "   ";
+		await wrapper.vm.submitReconnectCode();
+		expect(api.redeemReconnectCode).not.toHaveBeenCalled();
+	});
+
+	it("a direct-mode invalid shows the code-or-email copy, never the confirmation-page one", async () => {
+		api.redeemReconnectCode.mockResolvedValue({ status: "invalid" });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "reconnect";
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectCode = "ABCD2345";
+		wrapper.vm.state.reconnectEmail = "known@example.com";
+		await wrapper.vm.submitReconnectCode();
+		// A support-code customer never saw a confirmation page - the copy must not send them there.
+		expect(wrapper.vm.state.payErr).not.toContain("confirmation page");
+		expect(wrapper.vm.state.payErr.toLowerCase()).toContain("email");
+	});
+
+	it("startReconnect (emailed path) clears direct-mode state so it can't leak in", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		// Simulate a prior direct attempt leaving residue.
+		wrapper.vm.state.reconnectDirect = true;
+		wrapper.vm.state.reconnectEmail = "stale@example.com";
+		await wrapper.vm.startReconnect();
+		expect(wrapper.vm.state.reconnectDirect).toBe(false);
+		expect(wrapper.vm.state.reconnectEmail).toBe("");
+	});
+});
+
+describe("X8: a refused restart explains itself instead of a silent no-op", () => {
+	it("sets restartHeldNote when restart is refused, and clears it on the next state change", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_1",
+				generation: 1,
+				can_initiate_payment: false,
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.CONFIRM_REQUIRED);
+		// "Start again" here is refused (a payment is still recoverable) - it must say
+		// so rather than appear to do nothing.
+		await wrapper.vm.onPayAction(ACTIONS.RESTART);
+		expect(wrapper.vm.restartHeldNote).toBeTruthy();
+		expect(wrapper.vm.state.step).not.toBe("details");
+		// A later real state change drops the note so it never lingers past the state
+		// it explained: a check that lands paid moves the machine off confirm_required.
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_ALREADY_ACTIVE",
+				subscription_status: "Active",
+				attempt_id: "att_1",
+				generation: 1,
+			})
+		);
+		await wrapper.vm.flow.checkStatus();
+		await flushPromises();
+		expect(wrapper.vm.restartHeldNote).toBe("");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// jarvis#297 P0-2a: the email-verification dead end - resend + change email.
+// ---------------------------------------------------------------------------
+describe("jarvis#297 P0-2a: verification is no longer a dead end", () => {
+	async function mountOnVerify(overrides = {}) {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_1",
+				generation: 0,
+				email: "typo@exmaple.com",
+				...overrides,
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
+		return wrapper;
+	}
+
+	it("RESEND is absent until the server grants can_resend_verification", async () => {
+		const wrapper = await mountOnVerify();
+		expect(wrapper.vm.verifyActions).toEqual([ACTIONS.VERIFY, ACTIONS.RESTART]);
+		expect(wrapper.vm.pay.canResendVerification).toBe(false);
+	});
+
+	it("RESEND appears once granted, sends, then disables itself for the cooldown", async () => {
+		const wrapper = await mountOnVerify({ can_resend_verification: true });
+		expect(wrapper.vm.verifyActions).toEqual([
+			ACTIONS.VERIFY,
+			ACTIONS.RESEND,
+			ACTIONS.RESTART,
+		]);
+		expect(wrapper.vm.payActionDisabled(ACTIONS.RESEND)).toBe(false);
+
+		api.onboardingPaymentApi.resendVerification.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_1",
+				generation: 0,
+				can_resend_verification: true,
+			})
+		);
+		await wrapper.vm.onPayAction(ACTIONS.RESEND);
+		await flushPromises();
+
+		expect(api.onboardingPaymentApi.resendVerification).toHaveBeenCalledTimes(1);
+		// Truthful confirmation, and the button cannot be spammed while it cools.
+		expect(wrapper.vm.resendNote).toBe("We sent a new link to typo@exmaple.com.");
+		expect(wrapper.vm.payActionDisabled(ACTIONS.RESEND)).toBe(true);
+	});
+
+	it("a failed resend claims nothing sent and starts no cooldown", async () => {
+		const wrapper = await mountOnVerify({ can_resend_verification: true });
+		api.onboardingPaymentApi.resendVerification.mockResolvedValue({
+			status: 0,
+			body: null,
+			networkError: true,
+		});
+		await wrapper.vm.onPayAction(ACTIONS.RESEND);
+		await flushPromises();
+
+		expect(wrapper.vm.resendNote).toBe("");
+		expect(wrapper.vm.payActionDisabled(ACTIONS.RESEND)).toBe(false);
+	});
+
+	it("'Use a different email' walks back to Details, ready to re-request verification", async () => {
+		const wrapper = await mountOnVerify();
+		expect(wrapper.vm.payActionLabel(ACTIONS.RESTART)).toBe("Use a different email");
+		await wrapper.vm.onPayAction(ACTIONS.RESTART);
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.state.step).toBe("details");
+		// The mistyped address the customer typed is still there to correct, not
+		// wiped along with the machine.
+		expect(wrapper.vm.state.email).toBe("typo@exmaple.com");
+
+		// Re-submitting a corrected address re-requests verification exactly like
+		// the first attempt did - the existing signup path, unchanged.
+		api.onboardingPaymentApi.startSignup.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_fixed",
+				generation: 0,
+				email: "real@example.com",
+			})
+		);
+		wrapper.vm.state.email = "real@example.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.planName = "pro";
+		await wrapper.vm.flow.submitReview({
+			email: "real@example.com",
+			company: "Acme",
+			plan: "pro",
+		});
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
+	});
+
+	it("VERIFY still works unchanged", async () => {
+		const wrapper = await mountOnVerify();
+		expect(wrapper.vm.payActionLabel(ACTIONS.VERIFY)).toBe("I've verified my email");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "SIGNUP_VERIFICATION_REQUIRED", pending_verification: true })
+		);
+		await wrapper.vm.onPayAction(ACTIONS.VERIFY);
+		await flushPromises();
+		// verifyAndContinue re-reads state exactly as it did before this change.
+		expect(api.onboardingPaymentApi.getOnboardingState).toHaveBeenCalled();
+		expect(wrapper.vm.pay.value).toBe(STATES.VERIFICATION_REQUIRED);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GST tax breakdown (2026-08): Review & pay card's Subtotal/GST/Total rows.
+// ---------------------------------------------------------------------------
+describe("GST tax breakdown: Review & pay Subtotal/GST/Total rows", () => {
+	it("a trial Standard plan with gst_percent 18 shows the base/GST/total split and a ₹0 due-today", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "standard",
+				plan_name: "Standard",
+				price_inr: 3500,
+				gst_percent: 18,
+				billing_cycle: "Monthly",
+				trial_days: 7,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		// The default pay machine state is STATES.REVIEW (initialState()), so a fresh
+		// mount with none of the paid/verify/confirming/busy/recovery/maintenance
+		// branches triggered lands on the Review & pay summary card.
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.pricing).toEqual({
+			subtotal: 3500,
+			gstPercent: 18,
+			gstAmount: 630,
+			total: 4130,
+		});
+		expect(wrapper.vm.dueTodayLabel).toBe("₹0 today · then ₹4,130/mo after 7 days");
+
+		const text = wrapper.text();
+		const html = wrapper.html();
+		expect(text).toContain("Subtotal");
+		expect(text).toContain("GST (18%)");
+		expect(text).toContain("₹630");
+		// A plain toContain("Total") would also pass if the Total row went missing,
+		// since "Subtotal" and "₹4,130" (from the due-today label) are already on
+		// the page - match the row's own span so it verifies the row itself renders.
+		expect(html).toMatch(/<span[^>]*class="text-ink-gray-5">Total<\/span>/);
+		expect(text).toContain("₹4,130");
+		expect(text).toContain("Due today");
+		expect(text).toContain("₹0 today");
+	});
+
+	it("a plan without gst_percent renders no Subtotal/GST/Total rows", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "legacy",
+				plan_name: "Legacy",
+				price_inr: 3500,
+				billing_cycle: "Monthly",
+				trial_days: 0,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "legacy";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.pricing.gstPercent).toBe(0);
+		const text = wrapper.text();
+		expect(text).not.toContain("Subtotal");
+		expect(text).not.toContain("GST (");
+	});
+
+	// #10-e: gstAmount/total can be a genuine fraction (price_inr=3475,
+	// gst_percent=18 -> gstAmount=625.5, total=4100.5), and the backend charges
+	// exactly that paise-precise value (to_paise -> 410050). The Review card
+	// must render the SAME value it will be charged - inrExact, not inr()'s
+	// bare one-decimal "₹4,100.5" and never a rounded-off "₹4,101".
+	it("a fractional GST split renders its exact paise-precise value on every row", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "standard",
+				plan_name: "Standard",
+				price_inr: 3475,
+				gst_percent: 18,
+				billing_cycle: "Monthly",
+				trial_days: 0,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		expect(wrapper.vm.pricing).toEqual({
+			subtotal: 3475,
+			gstPercent: 18,
+			gstAmount: 625.5,
+			total: 4100.5,
+		});
+		expect(wrapper.vm.dueTodayLabel).toBe("₹4,100.50");
+
+		const text = wrapper.text();
+		expect(text).toContain("₹3,475");
+		expect(text).toContain("₹625.50");
+		expect(text).toContain("₹4,100.50");
+		// Neither the collapsed one-decimal form nor a rounded integer may appear.
+		expect(text).not.toContain("₹625.5 ");
+		expect(text).not.toContain("₹4,101");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #10-e review: the plan-selection card's "excl. GST" caveat must track the
+// plan's own gst_percent, not render unconditionally.
+// ---------------------------------------------------------------------------
+describe("Plan step: excl. GST label tracks the plan's own gst_percent", () => {
+	async function mountOnPlanStep(plan) {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [plan];
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		return wrapper;
+	}
+
+	it("is absent when gst_percent is undefined (pre-companion-PR get_plans row)", async () => {
+		const wrapper = await mountOnPlanStep({
+			name: "legacy",
+			plan_name: "Legacy",
+			price_inr: 3999,
+			billing_cycle: "Monthly",
+		});
+		expect(wrapper.text()).not.toContain("excl. GST");
+	});
+
+	it("is absent when gst_percent is 0", async () => {
+		const wrapper = await mountOnPlanStep({
+			name: "zero-gst",
+			plan_name: "Zero GST",
+			price_inr: 3999,
+			billing_cycle: "Monthly",
+			gst_percent: 0,
+		});
+		expect(wrapper.text()).not.toContain("excl. GST");
+	});
+
+	it("is present when gst_percent is a positive number", async () => {
+		const wrapper = await mountOnPlanStep({
+			name: "standard",
+			plan_name: "Standard",
+			price_inr: 3999,
+			billing_cycle: "Monthly",
+			gst_percent: 18,
+		});
+		expect(wrapper.text()).toContain("excl. GST");
+	});
+});
+
+describe("B3: gateway picker shows on trial plans", () => {
+	it("a trial plan with one available provider still renders the gateway chooser", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.plans = [
+			{
+				name: "standard",
+				plan_name: "Standard",
+				price_inr: 3500,
+				gst_percent: 18,
+				billing_cycle: "Monthly",
+				trial_days: 7,
+				signup_fee_inr: 0,
+			},
+		];
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.availableProviders = ["razorpay"];
+		wrapper.vm.state.paymentProvider = "razorpay";
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.REVIEW);
+		expect(wrapper.vm.isTrialPlan).toBe(true);
+		expect(wrapper.vm.showProviderChooser).toBe(true);
+		expect(wrapper.find(".ob-provseg").exists()).toBe(true);
+		expect(wrapper.find('[aria-label="Payment method: Razorpay"]').exists()).toBe(true);
+	});
+});
+
+describe("812: Company field is constrained once ERPNext has real Company records", () => {
+	it("prefillAccount captures erpnext_installed and companies from the server", async () => {
+		api.getAccountDefaults.mockResolvedValue({
+			email: "",
+			company: "Acme",
+			companies: ["Acme", "Beta"],
+			erpnext_installed: true,
+		});
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.state.erpnextInstalled).toBe(true);
+		expect(wrapper.vm.state.companies).toEqual(["Acme", "Beta"]);
+	});
+
+	it("ERPNext installed with Company records: the field is a constrained picker", async () => {
+		api.getAccountDefaults.mockResolvedValue({
+			email: "",
+			company: "",
+			companies: ["Acme", "Beta"],
+			erpnext_installed: true,
+		});
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		const combo = wrapper.find("jv-combo-stub");
+		expect(combo.attributes("allowcustom")).toBe("false");
+	});
+
+	it("ERPNext absent: the field stays free text even with no companies", async () => {
+		api.getAccountDefaults.mockResolvedValue({
+			email: "",
+			company: "",
+			companies: [],
+			erpnext_installed: false,
+		});
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		const combo = wrapper.find("jv-combo-stub");
+		expect(combo.attributes("allowcustom")).toBe("true");
+	});
+
+	it("ERPNext installed but zero Company rows: the field stays free text (no dead end)", async () => {
+		api.getAccountDefaults.mockResolvedValue({
+			email: "",
+			company: "",
+			companies: [],
+			erpnext_installed: true,
+		});
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		const combo = wrapper.find("jv-combo-stub");
+		expect(combo.attributes("allowcustom")).toBe("true");
+	});
+});
+
+// Forced-reconnect gate: an eligible returning (email, company) may only reconnect,
+// keyed on the customer-ASSERTED identity (identityFromUser), never the admin prefill.
+describe("Returning-customer forced reconnect gate", () => {
+	async function detailsView({
+		eligible,
+		needs_company = false,
+		typed = true,
+		company = "Corp",
+	}) {
+		api.reconnectAvailable.mockResolvedValue({ eligible, needs_company });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		wrapper.vm.state.email = "back@corp.test";
+		wrapper.vm.state.company = company;
+		wrapper.vm.state.identityFromUser = typed; // typed => reconnectIdentity present
+		// Fill every field Details now requires so onDetailsSubmit's gate doesn't
+		// block these reconnect-flow tests on an unrelated field.
+		fillRequiredBilling(wrapper);
+		// The required T&C checkbox now lives on Details too, but these tests are
+		// about the reconnect gate specifically, so tick it by default (a
+		// dedicated test below asserts the reconnect branch does NOT need it).
+		wrapper.vm.state.termsAccepted = true;
+		await flushPromises();
+		return wrapper;
+	}
+
+	it("C1: forces reconnect (no goNext to plan) for an eligible account matching the typed identity", async () => {
+		api.startAccountReconnect.mockResolvedValue({ request: "req_1" });
+		const wrapper = await detailsView({ eligible: true });
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		// The await inside onDetailsSubmit resolved eligibility (it was NOT pre-settled
+		// by the debounce) - this is also the race-closure guarantee (C3).
+		expect(api.startAccountReconnect).toHaveBeenCalledWith("back@corp.test", "Corp");
+		expect(wrapper.vm.state.step).toBe("reconnect");
+	});
+
+	it("the required T&C checkbox does NOT gate the reconnect branch - a returning customer reconnecting an existing paid account never went through it before", async () => {
+		api.startAccountReconnect.mockResolvedValue({ request: "req_1" });
+		const wrapper = await detailsView({ eligible: true });
+		wrapper.vm.state.termsAccepted = false; // deliberately unticked
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(api.startAccountReconnect).toHaveBeenCalledWith("back@corp.test", "Corp");
+		expect(wrapper.vm.state.step).toBe("reconnect");
+	});
+
+	it("C1: does NOT force reconnect when the eligible email was only prefilled (not typed)", async () => {
+		const wrapper = await detailsView({ eligible: true, typed: false });
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(api.startAccountReconnect).not.toHaveBeenCalled();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("mustReconnect is true only when eligible AND the identity is asserted", async () => {
+		const wrapper = await detailsView({ eligible: true, typed: false });
+		wrapper.vm.state.reconnectEligible = true; // eligible, but prefill-only identity
+		await flushPromises();
+		expect(wrapper.vm.mustReconnect).toBe(false);
+		wrapper.vm.state.identityFromUser = true; // now asserted
+		await flushPromises();
+		expect(wrapper.vm.mustReconnect).toBe(true);
+	});
+
+	it("C2: two rapid submits fire exactly one reconnect request", async () => {
+		let resolveReq;
+		api.startAccountReconnect.mockReturnValue(new Promise((r) => (resolveReq = r)));
+		const wrapper = await detailsView({ eligible: true });
+		const p1 = wrapper.vm.onDetailsSubmit();
+		const p2 = wrapper.vm.onDetailsSubmit(); // second click during the await window
+		resolveReq({ request: "req_1" });
+		await Promise.all([p1, p2]);
+		await flushPromises();
+		expect(api.startAccountReconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it("C2: startReconnect ignores a re-entrant call while a request is in flight", async () => {
+		let resolveReq;
+		api.startAccountReconnect.mockReturnValue(new Promise((r) => (resolveReq = r)));
+		const wrapper = await detailsView({ eligible: true });
+		const p1 = wrapper.vm.startReconnect();
+		const p2 = wrapper.vm.startReconnect(); // e.g. a double-click on the Reconnect button
+		resolveReq({ request: "req_1" });
+		await Promise.all([p1, p2]);
+		await flushPromises();
+		expect(api.startAccountReconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it("C2: two rapid submits on a non-eligible identity reach 'plan', never skipping to 'pay'", async () => {
+		const wrapper = await detailsView({ eligible: false });
+		const p1 = wrapper.vm.onDetailsSubmit();
+		const p2 = wrapper.vm.onDetailsSubmit();
+		await Promise.all([p1, p2]);
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("C4: cancel then continue with the same identity reuses the request (no second call)", async () => {
+		api.startAccountReconnect.mockResolvedValue({ request: "req_1" });
+		const wrapper = await detailsView({ eligible: true });
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(api.startAccountReconnect).toHaveBeenCalledTimes(1);
+		wrapper.vm.cancelReconnect(); // back to details, clears reconnectRequestId
+		await flushPromises();
+		await wrapper.vm.onDetailsSubmit(); // same identity -> reuse, no fresh request
+		await flushPromises();
+		expect(api.startAccountReconnect).toHaveBeenCalledTimes(1);
+		expect(wrapper.vm.state.step).toBe("reconnect");
+		expect(wrapper.vm.state.reconnectRequestId).toBe("req_1");
+	});
+
+	it("C6: needs_company (email under a different company) does NOT gate - advances to plan", async () => {
+		const wrapper = await detailsView({
+			eligible: false,
+			needs_company: true,
+			company: "WrongCo",
+		});
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(api.startAccountReconnect).not.toHaveBeenCalled();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("a brand-new (non-eligible) customer advances normally to plan", async () => {
+		const wrapper = await detailsView({ eligible: false, company: "NewCo" });
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(api.startAccountReconnect).not.toHaveBeenCalled();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("a failed startReconnect on Details surfaces the error (no silent dead-end)", async () => {
+		api.startAccountReconnect.mockRejectedValue(
+			new Error("reconnect requests are rate limited")
+		);
+		const wrapper = await detailsView({ eligible: true });
+		await wrapper.vm.startReconnect();
+		await flushPromises();
+		// Stays on Details (never reached the reconnect screen)...
+		expect(wrapper.vm.state.step).toBe("details");
+		// ...and the failure is VISIBLE on the Details error banner, not swallowed.
+		expect(wrapper.vm.state.detailsErr).toBeTruthy();
+	});
+
+	it("fails closed: an admin error on the eligibility check advances to plan (no gate)", async () => {
+		api.reconnectAvailable.mockRejectedValue(new Error("admin down"));
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		wrapper.vm.state.email = "back@corp.test";
+		wrapper.vm.state.company = "Corp";
+		wrapper.vm.state.identityFromUser = true;
+		fillRequiredBilling(wrapper);
+		wrapper.vm.state.termsAccepted = true;
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(api.startAccountReconnect).not.toHaveBeenCalled();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	// Relies on the Button stub's `label` attr falling through to the root <button>.
+	it("renders the Reconnect CTA (not Continue) only when the gate applies", async () => {
+		const wrapper = await detailsView({ eligible: true });
+		wrapper.vm.state.reconnectEligible = true; // as if the debounce has settled
+		await flushPromises();
+		expect(wrapper.find('button[label="Reconnect to your workspace"]').exists()).toBe(true);
+		expect(wrapper.find('button[label="Continue"]').exists()).toBe(false);
+		// A prefill-only (unasserted) identity keeps the normal Continue button.
+		wrapper.vm.state.identityFromUser = false;
+		await flushPromises();
+		expect(wrapper.find('button[label="Reconnect to your workspace"]').exists()).toBe(false);
+		expect(wrapper.find('button[label="Continue"]').exists()).toBe(true);
+	});
+
+	it("resend keeps the reuse tracker on the fresh request, not the superseded one", async () => {
+		api.startAccountReconnect
+			.mockResolvedValueOnce({ request: "req_1" })
+			.mockResolvedValueOnce({ request: "req_2" });
+		const wrapper = await detailsView({ eligible: true });
+		vi.useFakeTimers();
+		try {
+			await wrapper.vm.onDetailsSubmit(); // issues req_1 -> reconnect screen
+			await flushPromises();
+			await wrapper.vm.resendReconnectCode(); // resend -> req_2 (supersedes req_1)
+			await flushPromises();
+			expect(wrapper.vm.state.reconnectRequestId).toBe("req_2");
+			wrapper.vm.cancelReconnect(); // back to Details (clears reconnectRequestId)
+			await flushPromises();
+			await wrapper.vm.onDetailsSubmit(); // same identity -> reuse the FRESH request
+			await flushPromises();
+			expect(wrapper.vm.state.reconnectRequestId).toBe("req_2");
+			expect(api.startAccountReconnect).toHaveBeenCalledTimes(2); // req_1 + resend; no 3rd
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("lead-capture + T&C (frozen contract)", () => {
+	it("captures a lead on entering the Plan step once email+company are present", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.email = "lead@example.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		expect(api.captureOnboardingLead).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: "lead@example.com",
+				company: "Acme",
+				step: "plan",
+			})
+		);
+	});
+
+	it("never captures before both email and company exist", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		api.captureOnboardingLead.mockClear();
+		wrapper.vm.state.email = "lead@example.com";
+		wrapper.vm.state.company = "";
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		expect(api.captureOnboardingLead).not.toHaveBeenCalled();
+	});
+
+	it("a capture rejection never breaks the step transition", async () => {
+		api.captureOnboardingLead.mockRejectedValueOnce(new Error("network"));
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.email = "lead@example.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.step = "plan";
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("Details renders no separate contact-consent checkbox (consent rides the T&C acceptance)", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		expect(wrapper.text()).not.toContain("okay to contact me");
+		expect(wrapper.vm.billing.consent).toBeUndefined();
+	});
+
+	it("Details renders the required T&C checkbox; Pay no longer renders it", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		expect(wrapper.find("#jv-ob-terms").exists()).toBe(true);
+
+		wrapper.vm.state.step = "pay";
+		await flushPromises();
+		expect(wrapper.find("#jv-ob-terms").exists()).toBe(false);
+	});
+
+	it("Details' Continue is blocked until the required T&C box is ticked, with a visible inline error (not a toast)", async () => {
+		// Not eligible for reconnect - keeps this on the normal Continue path
+		// the T&C gate actually guards (item 5: reconnect is exempt).
+		api.reconnectAvailable.mockResolvedValue({ eligible: false, needs_company: false });
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		wrapper.vm.state.email = "a@b.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.identityFromUser = true;
+		fillRequiredBilling(wrapper);
+		wrapper.vm.state.termsAccepted = false;
+		await flushPromises();
+
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("details");
+		expect(wrapper.vm.detailsFieldErrors.terms).toBeTruthy();
+		expect(wrapper.text()).toContain(wrapper.vm.detailsFieldErrors.terms);
+		expect(toast.error).not.toHaveBeenCalled();
+
+		wrapper.vm.state.termsAccepted = true;
+		await flushPromises();
+		await wrapper.vm.onDetailsSubmit();
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("plan");
+	});
+
+	it("Details' Continue button is faded (disabled) until the T&C box is ticked", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+		wrapper.vm.state.termsAccepted = false;
+		await flushPromises();
+		expect(wrapper.find('button[label="Continue"]').attributes("disabled")).toBeDefined();
+		wrapper.vm.state.termsAccepted = true;
+		await flushPromises();
+		expect(wrapper.find('button[label="Continue"]').attributes("disabled")).toBeUndefined();
+	});
+
+	it("Pay stays disabled until the required T&C box is ticked", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.paymentProvider = "razorpay";
+		wrapper.vm.state.termsAccepted = false;
+		await flushPromises();
+		expect(wrapper.vm.payDisabled).toBe(true);
+		wrapper.vm.state.termsAccepted = true;
+		await flushPromises();
+		expect(wrapper.vm.payDisabled).toBe(false);
+	});
+
+	it("onPayClick refuses to start a signup until T&C is ticked, then sends terms_accepted:true", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.email = "a@b.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.planName = "pro";
+		wrapper.vm.state.paymentProvider = "razorpay";
+		wrapper.vm.state.termsAccepted = false;
+		fillRequiredBilling(wrapper); // complete billing so this test exercises the T&C gate, not the completeness guard
+
+		await wrapper.vm.onPayClick();
+		expect(api.onboardingPaymentApi.startSignup).not.toHaveBeenCalled();
+
+		wrapper.vm.state.termsAccepted = true;
+		api.onboardingPaymentApi.startSignup.mockResolvedValue(
+			ENVELOPE({
+				code: "SIGNUP_VERIFICATION_REQUIRED",
+				pending_verification: true,
+				attempt_id: "att_1",
+				generation: 0,
+			})
+		);
+		await wrapper.vm.onPayClick();
+		expect(api.onboardingPaymentApi.startSignup).toHaveBeenCalledWith(
+			// contact_consent is granted BY the T&C acceptance (owner decision
+			// 2026-08-14): the same click that sends terms_accepted sends it.
+			expect.objectContaining({ terms_accepted: true, contact_consent: true }),
+			expect.anything()
+		);
+	});
+});
+
+// The recovery/summary card's Reference row and the support-ticket body both show
+// attemptId IN FULL now (owner decision), not the old `…`+last-6 mask.
+describe("payment intent reference is shown in full, not masked", () => {
+	it("intentRef, paySummaryRows and supportContext all carry the full attempt id", async () => {
+		const longAttemptId = "att_2f9c8b17e4a1d3509b";
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: longAttemptId,
+				generation: 1,
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.CONFIRM_REQUIRED);
+		expect(wrapper.vm.pay.attemptId).toBe(longAttemptId);
+
+		// Not truncated, no leading ellipsis - the whole id, unlike the old mask.
+		expect(wrapper.vm.intentRef).toBe(longAttemptId);
+		expect(wrapper.vm.intentRef).not.toContain("…");
+
+		const refRow = wrapper.vm.paySummaryRows.find((r) => r.label === "Reference");
+		expect(refRow?.value).toBe(longAttemptId);
+
+		expect(wrapper.vm.supportContext).toContain(`Reference: ${longAttemptId}`);
+	});
+});
+
+// jarvis onboarding-return-heal, fix 1: the FRESH-MOUNT return heal. `?pay=` on
+// first paint only proves the pay page sent the customer back top-level - the
+// passive hydrate (getOnboardingState) reads admin's last-known DB row, never
+// asks the gateway. A fresh mount can never be CHECKOUT_OPEN (paymentMachine.js
+// always initializes to REVIEW), so the in-memory RETURNED_FROM_CHECKOUT exit
+// (usePaymentFlow.hydrate's own frozen-checkout branch) is unreachable here;
+// these pin the mount-time active check (check_signup_payment_status) that
+// covers this path instead, mirroring BillingPage.vue's run-healer-once shape.
+describe("FRESH-MOUNT RETURN HEAL: a genuine top-level ?pay= return converges once", () => {
+	function atSearch(search) {
+		window.history.pushState(null, "", "/onboarding" + search);
+	}
+	afterEach(() => {
+		window.history.pushState(null, "", "/onboarding");
+	});
+
+	it("runs check_signup_payment_status exactly once when a mid-flight signup exists", async () => {
+		atSearch("?pay=failed");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_1", generation: 1 })
+		);
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT run the active check on an ordinary visit (no ?pay=)", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_1", generation: 1 })
+		);
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+	});
+
+	it("does NOT run the active check when there is no mid-flight signup (day one)", async () => {
+		atSearch("?pay=done");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })
+		);
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+	});
+
+	it("a stale (lower-generation) active answer cannot repaint the newer passive state", async () => {
+		atSearch("?pay=failed");
+		// The passive hydrate already knows generation 5 for this attempt.
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_1",
+				generation: 5,
+			})
+		);
+		// A stale active answer carrying an OLDER generation of the same attempt -
+		// the generation fence must drop it outright, never repainting backward.
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_DECLINED", attempt_id: "att_1", generation: 2 })
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+		expect(wrapper.vm.pay.value).toBe(STATES.CONFIRM_REQUIRED);
+	});
+
+	it("PAID stays a floor: no later active answer undoes it", async () => {
+		atSearch("?pay=failed");
+		// The passive hydrate already found the signup PAID.
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_ALREADY_ACTIVE", attempt_id: "att_1", generation: 2 })
+		);
+		// An ADVANCED-generation active answer (so the generation fence alone would
+		// let it through) that would otherwise walk the machine back to a decline -
+		// only the paid floor stops this one.
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_DECLINED", attempt_id: "att_1", generation: 3 })
+		);
+		const wrapper = mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+		// PAID is a floor: the machine may keep climbing forward off it (the
+		// paid->provisioning handoff fires on its own watcher), but the declined
+		// answer must never have walked it back to FAILED_RETRYABLE.
+		expect([STATES.PAID, STATES.PROVISIONING, STATES.PROVISIONING_DELAYED]).toContain(
+			wrapper.vm.pay.value
+		);
+	});
+});
+
+// jarvis onboarding-return-heal, fix 2: PAYMENT_CONFIRMATION_PENDING / UNKNOWN
+// used to do nothing on their own - every other wait in the wizard polls itself
+// (provisioning 45x2s, readiness 40x3s). These pin the bounded auto-poll: a
+// gentle interval, a hard ceiling with an honest stuck note, and a backoff on
+// PAYMENT_CHECK_RATE_LIMITED instead of hammering through the server's cooldown.
+describe("pending-payment auto-poll", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("auto-polls without a click and offers support within ~2 minutes", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.pay.value).toBe(STATES.UNKNOWN);
+		// Nothing fires before the first tick - a fresh mount already ran its own
+		// one-shot passive hydrate; the poll adds no immediate second call.
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+
+		// SUPPORT_AFTER_CHECKS is 2 (lowered from 4): two auto-polled ticks, no
+		// manual click, and the existing support-offer machinery (noteStatusCheck)
+		// picks them up the same way it counts a manual Check.
+		await vi.advanceTimersByTimeAsync(15_000);
+		await vi.advanceTimersByTimeAsync(15_000);
+
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(2);
+		expect(wrapper.vm.pay.supportOffered).toBe(true);
+	});
+
+	it("stops at the ceiling and shows the honest stuck note, never a silent forever-spinner", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+
+		await vi.advanceTimersByTimeAsync(8 * 15_000); // PENDING_CHECK_ATTEMPTS x interval
+
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(8);
+		expect(wrapper.vm.pendingPollStuck).toBe(true);
+
+		// The ceiling is a hard stop: more elapsed time fires no 9th check.
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(8);
+	});
+
+	it("backs off on a rate limit instead of polling straight through the cooldown", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus
+			.mockResolvedValueOnce({
+				status: 429,
+				body: {
+					message: {
+						ok: false,
+						error: { code: "PAYMENT_CHECK_RATE_LIMITED", retry_after_seconds: 40 },
+						context: {},
+					},
+				},
+			})
+			.mockResolvedValue(
+				ENVELOPE({
+					code: "PAYMENT_CONFIRMATION_PENDING",
+					attempt_id: "att_poll",
+					generation: 1,
+				})
+			);
+		vi.useFakeTimers();
+		mountView();
+		await flushPromises();
+
+		// First tick (t=15s): rate-limited.
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+
+		// The ordinary interval alone (t=30s) must NOT be enough - the server's
+		// 40s cooldown from the 429 is still running.
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+
+		// Once the cooldown has fully elapsed, the next attempt fires.
+		await vi.advanceTimersByTimeAsync(40_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(2);
+	});
+
+	it("stops when the customer leaves the Pay step - no late tick into a hidden step", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_CONFIRMATION_PENDING",
+				attempt_id: "att_poll",
+				generation: 1,
+			})
+		);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.state.step).toBe("pay");
+
+		wrapper.vm.state.step = "details";
+		await flushPromises();
+
+		await vi.advanceTimersByTimeAsync(120_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+	});
+});
+
+// The panic-page fix: a customer who COMPLETED checkout (?pay=done) and lands on
+// the coded PAYMENT_CONFIRMATION_PENDING wait (UNKNOWN) - because Razorpay's
+// confirmation webhook lags the browser redirect by seconds - must see the calm
+// "Confirming your payment / we're checking automatically" settling hold, NOT the
+// alarming "We have not confirmed this payment / Check the status before doing
+// anything else" recovery card, while the auto-poll works. The recovery card is
+// reached only once the poll gives up (pendingPollStuck). The gate is the completed
+// return, never UNKNOWN alone, so a failed/abandoned return still gets recovery.
+const SETTLING_TEXT = "You've completed checkout";
+const RECOVERY_PENDING_TEXT = "We have not confirmed this payment";
+describe("post-checkout settling hold (calm wait, not the panic card)", () => {
+	function atSearch(search) {
+		window.history.pushState(null, "", "/onboarding" + search);
+	}
+	afterEach(() => {
+		window.history.pushState(null, "", "/onboarding");
+		vi.useRealTimers();
+	});
+
+	// A completed checkout whose webhook has not landed yet: both the passive
+	// hydrate and the mount-time return-heal answer PENDING, so the machine settles
+	// on UNKNOWN with proof-of-completion in hand.
+	function pendingAfterDoneReturn() {
+		atSearch("?pay=done");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+	}
+
+	it("shows the calm settling screen (not the panic card) after a completed checkout", async () => {
+		pendingAfterDoneReturn();
+		const wrapper = mountView();
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.UNKNOWN);
+		expect(wrapper.vm.returnedFromCompletedCheckout).toBe(true);
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+		expect(wrapper.vm.showRecovery).toBe(false);
+		expect(wrapper.text()).toContain(SETTLING_TEXT);
+		expect(wrapper.text()).not.toContain(RECOVERY_PENDING_TEXT);
+	});
+
+	it("gates on the completed return: a ?pay=failed return still gets the recovery card", async () => {
+		atSearch("?pay=failed");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+		const wrapper = mountView();
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.UNKNOWN);
+		expect(wrapper.vm.returnedFromCompletedCheckout).toBe(false);
+		expect(wrapper.vm.showPaymentSettling).toBe(false);
+		expect(wrapper.vm.showRecovery).toBe(true);
+		expect(wrapper.text()).toContain(RECOVERY_PENDING_TEXT);
+		expect(wrapper.text()).not.toContain(SETTLING_TEXT);
+	});
+
+	it("escalates to the recovery card once the auto-poll gives up (~2 min)", async () => {
+		pendingAfterDoneReturn();
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+
+		// Run the auto-poll to its ceiling: early 4s check + 15s x 7 ≈ 2 min.
+		await vi.advanceTimersByTimeAsync(4_000 + 8 * 15_000);
+		expect(wrapper.vm.pendingPollStuck).toBe(true);
+		expect(wrapper.vm.showPaymentSettling).toBe(false);
+		expect(wrapper.vm.showRecovery).toBe(true);
+	});
+
+	it("leaves the settling hold the moment the payment confirms (poll answers PAID)", async () => {
+		atSearch("?pay=done");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+		// Mount-time return-heal still pending; the first auto-poll tick finds it PAID.
+		api.onboardingPaymentApi.checkSignupPaymentStatus
+			.mockResolvedValueOnce(
+				ENVELOPE({
+					code: "PAYMENT_CONFIRMATION_PENDING",
+					attempt_id: "att_s",
+					generation: 1,
+				})
+			)
+			.mockResolvedValue(
+				ENVELOPE({ code: "PAYMENT_ALREADY_ACTIVE", attempt_id: "att_s", generation: 2 })
+			);
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(4_000); // the early first re-check
+		await flushPromises();
+		expect(wrapper.vm.pay.value).not.toBe(STATES.UNKNOWN);
+		expect(wrapper.vm.showPaymentSettling).toBe(false);
+	});
+
+	// Finding 3: the early 4s first re-check is scoped to the completed-checkout
+	// case (a webhook expected within seconds). An in-app pending wait that never
+	// left the page keeps the ordinary 15s first interval and does not hit the
+	// rate-limited endpoint any sooner than before.
+	it("re-checks early (~4s) on the first auto-poll tick after a completed checkout", async () => {
+		pendingAfterDoneReturn();
+		vi.useFakeTimers();
+		mountView();
+		await flushPromises();
+		// The mount-time return-heal already fired one check; clear it so we are
+		// measuring the auto-poll's own first tick.
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockClear();
+		await vi.advanceTimersByTimeAsync(4_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the ordinary 15s first interval for an in-app pending wait (no completed checkout)", async () => {
+		// No ?pay= return, so returnedFromCompletedCheckout stays false.
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({ code: "PAYMENT_CONFIRMATION_PENDING", attempt_id: "att_s", generation: 1 })
+		);
+		vi.useFakeTimers();
+		mountView();
+		await flushPromises();
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+		// 4s must NOT be enough for the first tick here (unlike the checkout-return case).
+		await vi.advanceTimersByTimeAsync(4_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).not.toHaveBeenCalled();
+		// The ordinary 15s interval fires it.
+		await vi.advanceTimersByTimeAsync(11_000);
+		expect(api.onboardingPaymentApi.checkSignupPaymentStatus).toHaveBeenCalledTimes(1);
+	});
+
+	// The primary production path: the ₹0 auto-pay authorization lands on
+	// PAYMENT_AUTHORIZED_PENDING_CONFIRM (S.CONFIRM_REQUIRED) while the bank confirms the
+	// e-NACH mandate. The calm hold + auto-poll must cover this state too, not just the
+	// webhook-lag one - otherwise a customer who just authorized sees the recovery card's
+	// "Check payment status / Contact support / nothing has changed yet" chrome.
+	const AUTHORIZED_CALM = "we've got it from here";
+	const AUTHORIZED_RECOVERY = "We are watching for it";
+	// The auto-pay mandate authorization returns ?pay=PENDING, not ?pay=done - the admin
+	// pay page (billing/checkout/shell.py outcomeFor) emits `pending` for the "authorized,
+	// awaiting confirmation" (next_step poll/contact_support) case. Gating the calm hold on
+	// `done` alone silently missed this whole path; these tests pin the pending return.
+	function mandatePendingReturn() {
+		atSearch("?pay=pending");
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_m",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_m",
+				generation: 1,
+			})
+		);
+	}
+
+	it("shows the calm 'authorized' screen (not the recovery card) for a pending auto-pay mandate", async () => {
+		mandatePendingReturn();
+		const wrapper = mountView();
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.CONFIRM_REQUIRED);
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+		expect(wrapper.vm.showRecovery).toBe(false);
+		expect(wrapper.text()).toContain("Your payment is authorized");
+		expect(wrapper.text()).toContain(AUTHORIZED_CALM);
+		// The recovery card's own body / Contact-support chrome must NOT be showing.
+		expect(wrapper.text()).not.toContain(AUTHORIZED_RECOVERY);
+	});
+
+	it("a pending mandate WITHOUT a completed return still gets the recovery card", async () => {
+		api.onboardingPaymentApi.getOnboardingState.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_m",
+				generation: 1,
+			})
+		);
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue(
+			ENVELOPE({
+				code: "PAYMENT_AUTHORIZED_PENDING_CONFIRM",
+				attempt_id: "att_m",
+				generation: 1,
+			})
+		);
+		const wrapper = mountView();
+		await flushPromises();
+
+		expect(wrapper.vm.pay.value).toBe(STATES.CONFIRM_REQUIRED);
+		expect(wrapper.vm.showPaymentSettling).toBe(false);
+		expect(wrapper.vm.showRecovery).toBe(true);
+		expect(wrapper.text()).toContain(AUTHORIZED_RECOVERY);
+		expect(wrapper.text()).not.toContain(AUTHORIZED_CALM);
+	});
+
+	it("escalates the mandate wait to the recovery card once the auto-poll gives up", async () => {
+		mandatePendingReturn();
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(4_000 + 8 * 15_000);
+		expect(wrapper.vm.pendingPollStuck).toBe(true);
+		expect(wrapper.vm.showPaymentSettling).toBe(false);
+		expect(wrapper.vm.showRecovery).toBe(true);
+		expect(wrapper.text()).toContain(AUTHORIZED_RECOVERY);
+	});
+
+	// The regression that stranded a customer on the calm spinner for ~15 min: the
+	// server rate-limits the status check, so the auto-poll's 8-check ceiling
+	// (pendingPollStuck) may never fire in a reasonable time. The calm hold MUST still
+	// escalate on a hard ~2 min wall-clock so the customer always gets the manual
+	// "Check payment status" button. Here every check is rate-limited with a long
+	// cooldown, so the poll makes no progress - pendingPollStuck can NOT be the escape.
+	it("escalates on the ~2 min wall-clock even when the auto-poll is stalled by rate-limit cooldowns", async () => {
+		mandatePendingReturn();
+		api.onboardingPaymentApi.checkSignupPaymentStatus.mockResolvedValue({
+			status: 429,
+			body: {
+				message: {
+					ok: false,
+					error: { code: "PAYMENT_CHECK_RATE_LIMITED", retry_after_seconds: 300 },
+					context: {},
+				},
+			},
+		});
+		vi.useFakeTimers();
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+		expect(wrapper.vm.pendingPollStuck).toBe(false);
+
+		// Just before the ceiling: still the calm hold.
+		await vi.advanceTimersByTimeAsync(118_000);
+		expect(wrapper.vm.showPaymentSettling).toBe(true);
+
+		// Past the ceiling: escalated to the recovery card WITHOUT pendingPollStuck ever
+		// firing - the wall-clock deadline is the escape, exactly as the fix intends.
+		await vi.advanceTimersByTimeAsync(4_000);
+		expect(wrapper.vm.pendingPollStuck).toBe(false);
+		expect(wrapper.vm.showPaymentSettling).toBe(false);
+		expect(wrapper.vm.showRecovery).toBe(true);
+	});
+});
+
+// Review P2: changing Country must clear a state/region entered for the old country.
+// stateError accepts any non-empty region for a non-India country, so a leftover Indian
+// state (e.g. "United States / Tamil Nadu") would otherwise pass and be invoiced.
+describe("changing country clears a stale state/region", () => {
+	it("India -> foreign clears the Indian state and its error", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.billing.setUserValue("state", "Tamil Nadu");
+		wrapper.vm.detailsFieldErrors.state = "stale error";
+		wrapper.vm.onCountryChange("United States");
+		expect(wrapper.vm.billing.fields.country.value).toBe("United States");
+		expect(wrapper.vm.billing.fields.state.value).toBe("");
+		expect(wrapper.vm.detailsFieldErrors.state).toBe("");
+	});
+
+	it("re-selecting the same country leaves the state untouched", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.billing.setUserValue("state", "Tamil Nadu");
+		wrapper.vm.onCountryChange("India"); // country already defaults to India
+		expect(wrapper.vm.billing.fields.state.value).toBe("Tamil Nadu");
+	});
+});
+
+// Review P2: a resumed session can land directly on Review & Pay with a pre-change saved
+// state that never collected address/city/state/pincode. onPayClick must run the same
+// completeness guard as onDetailsSubmit and bounce back to Details, not submit.
+describe("resumed Pay enforces billing completeness", () => {
+	it("onPayClick with incomplete billing bounces to Details with per-field errors", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		wrapper.vm.state.planName = "standard";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.state.email = "acme@example.com";
+		wrapper.vm.state.termsAccepted = true;
+		// Only contact present; address / city / state / pincode missing (the pre-change shape).
+		wrapper.vm.billing.setUserValue("contact", "+91 98765 43210");
+		wrapper.vm.state.step = "pay";
+		await wrapper.vm.onPayClick();
+		expect(wrapper.vm.state.step).toBe("details");
+		expect(wrapper.vm.detailsFieldErrors.address).toBeTruthy();
+		expect(wrapper.vm.detailsFieldErrors.city).toBeTruthy();
+		expect(wrapper.vm.detailsFieldErrors.state).toBeTruthy();
+		expect(wrapper.vm.detailsFieldErrors.pincode).toBeTruthy();
+	});
+});
+
+// Review P1: countryError must reject a restored/defaulted value that isn't a real Country
+// (it never passed through the select), while normalising a known alias.
+describe("country validation rejects a non-canonical value", () => {
+	it("flags the old literal 'Other' and an unknown country; accepts a real name + alias", async () => {
+		const wrapper = mountView();
+		await flushPromises();
+		expect(wrapper.vm.countryError("Other")).toBeTruthy();
+		expect(wrapper.vm.countryError("Nowhereland")).toBeTruthy();
+		expect(wrapper.vm.countryError("")).toBeTruthy();
+		expect(wrapper.vm.countryError("India")).toBe("");
+		expect(wrapper.vm.countryError("Turkey")).toBe(""); // alias normalises to Türkiye
+	});
+});
+
+describe("Address consistency: State <-> Pincode <-> GSTIN (India)", () => {
+	it("blocks Continue and flags the pincode when it doesn't match the state", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		wrapper.vm.billing.setUserValue("state", "Maharashtra");
+		wrapper.vm.billing.setUserValue("pincode", "638108"); // a Tamil Nadu PIN
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(true);
+		expect(wrapper.vm.detailsFieldErrors.pincode).toMatch(/postal code/i);
+	});
+
+	it("clears once the pincode matches the state", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		// the address inconsistency must be the ONLY thing blocking, so satisfy email + company too
+		wrapper.vm.state.email = "test@acme.com";
+		wrapper.vm.state.company = "Acme";
+		wrapper.vm.billing.setUserValue("state", "Maharashtra");
+		wrapper.vm.billing.setUserValue("pincode", "638108");
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(true);
+		expect(wrapper.vm.detailsFieldErrors.pincode).toMatch(/postal code/i);
+		wrapper.vm.billing.setUserValue("pincode", "400001"); // a Maharashtra PIN
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(false);
+		expect(wrapper.vm.detailsFieldErrors.pincode).toBe("");
+	});
+
+	it("clears the India-only pincode message when the country switches overseas", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		wrapper.vm.billing.setUserValue("state", "Maharashtra");
+		wrapper.vm.billing.setUserValue("pincode", "638108");
+		wrapper.vm.touchPincodeField();
+		expect(wrapper.vm.detailsFieldErrors.pincode).toMatch(/postal code/i);
+		wrapper.vm.onCountryChange("United States"); // overseas -> the India-specific check no longer applies
+		expect(wrapper.vm.detailsFieldErrors.pincode).toBe("");
+	});
+
+	it("flags the GSTIN when its state code disagrees with the selected state", () => {
+		const wrapper = mountView();
+		fillRequiredBilling(wrapper);
+		wrapper.vm.billing.setUserValue("state", "Karnataka");
+		wrapper.vm.billing.setUserValue("pincode", "560001"); // Karnataka PIN (consistent with the state)
+		wrapper.vm.billing.setUserValue("gstin", "33ABCDE1234F1Z7"); // Tamil Nadu GSTIN -> mismatch
+		expect(wrapper.vm.billingDetailsInvalid()).toBe(true);
+		expect(wrapper.vm.detailsFieldErrors.gstin).toMatch(/GSTIN/i);
+	});
+});

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1168,6 +1168,37 @@
 									</div>
 								</div>
 							</template>
+							<!-- Settling: the customer COMPLETED checkout (pay=done) and the
+								 one-shot reconcile came back still-pending - either
+								 PAYMENT_CONFIRMATION_PENDING (webhook lag, S.UNKNOWN) or
+								 PAYMENT_AUTHORIZED_PENDING_CONFIRM (bank confirming the auto-pay
+								 mandate, S.CONFIRM_REQUIRED - the standard trial/auto-pay path).
+								 Both are the normal happy path, not a failure. Hold a calm, honest
+								 wait while the background auto-poll (runPendingAutoPoll, ~2 min)
+								 confirms, instead of dropping straight to the alarming recovery
+								 card. Escalates to showRecovery only once the poll gives up
+								 (pendingPollStuck) or a real code arrives. Copy is state-keyed
+								 (settlingCopy): only the genuinely-authorized state claims
+								 "authorized"; the webhook-lag state says "confirming", never
+								 "confirmed" - money truth stays server-owned (see paymentCodes.js and
+								 the 84s double-mandate incident that shaped that rule). -->
+							<template v-else-if="showPaymentSettling">
+								<div class="ob-body ob-body--center">
+									<div class="ob-head">
+										<h1 role="status">{{ settlingCopy.headline }}</h1>
+										<p>{{ settlingCopy.body }}</p>
+									</div>
+									<div class="mt-2.5 flex justify-center">
+										<JvSpinner :size="56" />
+									</div>
+									<p
+										class="mx-auto mt-4 max-w-[420px] text-center text-p-sm text-ink-gray-5"
+									>
+										Nothing to do here. Please keep this page open and don't
+										pay again.
+									</p>
+								</div>
+							</template>
 							<!-- Recovery: unknown / retryable / terminal / confirm-required /
 								 reconnect. Coded copy + the two named recovery actions in
 								 status-first order. -->
@@ -3441,6 +3472,24 @@ const resending = computed(() => pay.value.busy === "resending");
 const confirmingReturn = ref(false);
 const showConfirming = computed(() => !payBusyView.value && confirmingReturn.value);
 
+// PROOF the customer actually finished checkout on this mount: the pay page appends
+// `?pay=done` (payment confirmed) or `?pay=pending` (authorized, awaiting async
+// confirmation - the auto-pay mandate case) after the Razorpay flow finishes
+// (jarvis_admin_v2's billing/checkout/shell.py outcomeFor vocabulary), and onMounted's
+// readCheckoutOutcome reads it. Set true for done OR pending - both prove the flow
+// finished - and nothing else. It is the discriminator the calm settling hold
+// (showPaymentSettling) gates on, because a pending state alone cannot tell a
+// webhook-still-in-flight from a checkout the customer never touched (see paymentCodes.js
+// PAYMENT_CONFIRMATION_PENDING). Without this proof we never soften the copy; a `failed`
+// return does not soften it either. In-memory
+// for the session: a hard reload strips the param and drops to the recovery card,
+// which is honest (see PR notes), not a regression. Same for the signal-less return
+// paths (bfcache restore / tab-focus regain -> handleCheckoutReturn): they carry no
+// ?pay= outcome, so they cannot prove completion and keep the recovery card. The
+// flag is reset to false whenever a checkout (re)opens - see the CHECKOUT_OPEN watch
+// below - so proof from one attempt can never soften a later, unrelated wait.
+const returnedFromCompletedCheckout = ref(false);
+
 /** Hold the confirming screen for the duration of a post-checkout reconcile. */
 async function whileConfirmingReturn(run) {
 	confirmingReturn.value = true;
@@ -3450,15 +3499,91 @@ async function whileConfirmingReturn(run) {
 		confirmingReturn.value = false;
 	}
 }
+// The pending states the background auto-poll covers AND the calm settling hold
+// fronts. Kept as ONE predicate so the loop guards, restartPendingAutoPoll and the
+// settling computed can never drift apart:
+//   - S.UNKNOWN                 PAYMENT_CONFIRMATION_PENDING (webhook lag after checkout)
+//   - S.CONFIRM_REQUIRED        PAYMENT_AUTHORIZED_PENDING_CONFIRM (bank confirming the
+//                               auto-pay e-NACH mandate - the standard trial/auto-pay
+//                               signup lands HERE, so it is the primary panic in prod)
+// Both are "authorized/paid, admin just hasn't confirmed yet" waits, never a dead end.
+// CONFIRM_REQUIRED can pend past the ceiling (e-NACH is slow by design); the ceiling +
+// honest escalation below is exactly what bounds it, so the calm hold never hangs
+// forever (the concern that originally kept this state out).
+function isAutoPollable(v) {
+	return v === S.UNKNOWN || v === S.CONFIRM_REQUIRED;
+}
 const showRecovery = computed(
 	() =>
 		!payBusyView.value &&
 		!showConfirming.value &&
+		// The calm settling hold owns the pending window right after a completed
+		// checkout; recovery only takes over once that hold releases (poll gave up,
+		// or the state moved on). Everything else here is unchanged.
+		!showPaymentSettling.value &&
 		(pay.value.value === S.UNKNOWN ||
 			pay.value.value === S.FAILED_RETRYABLE ||
 			pay.value.value === S.FAILED_TERMINAL ||
 			pay.value.value === S.CONFIRM_REQUIRED ||
 			pay.value.value === S.RECONNECT)
+);
+// The calm "we're confirming, hang tight" hold shown INSTEAD of the recovery card
+// during the normal post-checkout wait. Conditions, all required:
+//   - the customer actually completed checkout this session (returnedFromCompletedCheckout)
+//   - the machine is on an auto-pollable pending state (isAutoPollable): the coded
+//     PAYMENT_CONFIRMATION_PENDING / PAYMENT_AUTHORIZED_PENDING_CONFIRM waits, or a return
+//     not yet resolved - the same states the auto-poll (runPendingAutoPoll) covers
+//   - the auto-poll has NOT given up (!pendingPollStuck)
+//   - we are not already showing the one-shot confirming spinner or a busy screen
+const showPaymentSettlingCandidate = computed(
+	() =>
+		!payBusyView.value &&
+		!showConfirming.value &&
+		returnedFromCompletedCheckout.value &&
+		!pendingPollStuck.value &&
+		isAutoPollable(pay.value.value)
+);
+// HARD wall-clock ceiling on the calm hold. pendingPollStuck alone is NOT a reliable
+// escape hatch: the server rate-limits the status check (every 429 adds a cooldown the
+// poll must wait out) and browsers throttle background-tab timers, so the poll's "8
+// checks" can take FAR longer than 2 minutes - a customer sat on the calm spinner for
+// ~15 min in testing because pendingPollStuck never fired in time. This deadline flips
+// the hold to the recovery card (with its manual "Check payment status" button) after
+// ~2 min no matter what the poll is doing, so the calm hold can never trap the customer.
+// Measured from when the hold first appears; a re-entry restarts the clock. The Pay-step
+// cooldown ticker updates nowMs every 1s, so this escalates within ~1s of the ceiling.
+const SETTLING_MAX_MS = 120_000;
+const settlingStartedAt = ref(0);
+watch(showPaymentSettlingCandidate, (on) => {
+	settlingStartedAt.value = on ? Date.now() : 0;
+});
+const settlingExpired = computed(
+	() => settlingStartedAt.value > 0 && nowMs.value - settlingStartedAt.value >= SETTLING_MAX_MS
+);
+const showPaymentSettling = computed(
+	() => showPaymentSettlingCandidate.value && !settlingExpired.value
+);
+// The calm-screen copy, keyed off which pending state we are settling. The state's OWN
+// coded headline is used only where it already reads calm: PAYMENT_AUTHORIZED_PENDING_CONFIRM
+// is a real authorization at the gateway, so "Your payment is authorized" is both true and
+// reassuring. PAYMENT_CONFIRMATION_PENDING's coded headline is the alarming "We have not
+// confirmed this payment" - the whole point of this hold is to NOT show that during the
+// normal wait, so it gets bespoke calm copy instead.
+const settlingCopy = computed(() =>
+	pay.value.value === S.CONFIRM_REQUIRED
+		? {
+				headline: "You're almost set up",
+				body:
+					"Your payment is authorized. We're waiting for a final confirmation from " +
+					"your bank, which usually takes just a few minutes. Sit tight, we've got " +
+					"it from here.",
+		  }
+		: {
+				headline: "Confirming your payment",
+				body:
+					"You've completed checkout. We're waiting for your payment provider to confirm " +
+					"it, which can take up to a minute, and we're checking automatically.",
+		  }
 );
 // role=alert only for an actionable failure; role=status for pending/info
 // (plan 02 §a11y - a pending payment announced as an alert on every poll is a
@@ -3636,7 +3761,17 @@ async function runStatusCheck() {
 // every check and waits it out before the next attempt, instead of a fixed
 // interval that could poll straight through a 429.
 const PENDING_CHECK_INTERVAL_MS = 15_000;
-const PENDING_CHECK_ATTEMPTS = 8; // ~15s x 8 ≈ 2 minutes
+// The FIRST re-check is deliberately early - but ONLY for a completed-checkout
+// return (returnedFromCompletedCheckout). That is the one case with a physical
+// reason to expect an answer within seconds: the confirmation webhook usually
+// lands just behind the browser redirect, so this resolves it while the customer
+// is still watching the calm settling screen, before the steady 15s cadence kicks
+// in. An in-app pending wait that never left the page has no such reason, so it
+// keeps the ordinary 15s first interval and does not hit the rate-limited endpoint
+// any sooner than before (code review finding 3). The server's own cooldown
+// (checkCooldownUntil, applied below) still protects against a 429 either way.
+const PENDING_FIRST_CHECK_MS = 4_000;
+const PENDING_CHECK_ATTEMPTS = 8; // ~4s + 15s x 7 ≈ 2 minutes
 // Set once the ceiling is reached with no resolution - an honest "we stopped
 // auto-checking" note, never a spinner that quietly gives up. Cleared the moment
 // the state leaves UNKNOWN (resolved) or Pay is left (see restartPendingAutoPoll).
@@ -3648,10 +3783,14 @@ let pendingPollRun = 0;
 
 async function runPendingAutoPoll(myRun) {
 	for (let i = 0; i < PENDING_CHECK_ATTEMPTS; i++) {
-		await _sleep(PENDING_CHECK_INTERVAL_MS);
-		if (pendingPollRun !== myRun || pay.value.value !== S.UNKNOWN) return;
+		await _sleep(
+			i === 0 && returnedFromCompletedCheckout.value
+				? PENDING_FIRST_CHECK_MS
+				: PENDING_CHECK_INTERVAL_MS
+		);
+		if (pendingPollRun !== myRun || !isAutoPollable(pay.value.value)) return;
 		await flow.checkStatus();
-		if (pendingPollRun !== myRun || pay.value.value !== S.UNKNOWN) return;
+		if (pendingPollRun !== myRun || !isAutoPollable(pay.value.value)) return;
 		// A rate limit says nothing about the money (see paymentCodes.js) - wait
 		// out the SERVER's own cooldown ON TOP OF the ordinary interval already
 		// elapsed, so the next attempt cannot land inside it and poll straight
@@ -3661,10 +3800,10 @@ async function runPendingAutoPoll(myRun) {
 		const waitMs = (pay.value.checkCooldownUntil || 0) - Date.now();
 		if (waitMs > 0) {
 			await _sleep(waitMs);
-			if (pendingPollRun !== myRun || pay.value.value !== S.UNKNOWN) return;
+			if (pendingPollRun !== myRun || !isAutoPollable(pay.value.value)) return;
 		}
 	}
-	if (pendingPollRun === myRun && pay.value.value === S.UNKNOWN) {
+	if (pendingPollRun === myRun && isAutoPollable(pay.value.value)) {
 		pendingPollStuck.value = true;
 	}
 }
@@ -3677,11 +3816,35 @@ async function runPendingAutoPoll(myRun) {
 function restartPendingAutoPoll() {
 	pendingPollRun += 1; // supersede whatever was already running
 	pendingPollStuck.value = false;
-	if (pay.value.value === S.UNKNOWN && state.step === "pay") {
+	if (isAutoPollable(pay.value.value) && state.step === "pay") {
 		runPendingAutoPoll(pendingPollRun);
 	}
+	// NOTE: the value-change watch fires restartPendingAutoPoll on a
+	// S.UNKNOWN -> S.CONFIRM_REQUIRED transition too, resetting the loop to its first
+	// tick. So a signup that passes through both waits can sit on the calm hold for up
+	// to ~2 min PER state (~4 min total) before escalating. Acceptable: both are
+	// genuine "authorized/paid, awaiting confirmation" waits, and the escalation is a
+	// ceiling on each, never a forever-spinner.
 }
 watch(() => pay.value.value, restartPendingAutoPoll);
+// Clear the completed-checkout proof the instant a (new or resumed) checkout opens.
+// From CHECKOUT_OPEN, the ONLY thing that may re-arm the calm settling hold is a
+// fresh ?pay=done full-navigation return (set in onMounted). This does two things:
+//   - fixes staleness (code review finding 1): the flag can no longer carry proof
+//     from an earlier attempt into a later, unrelated pending wait.
+//   - keeps the signal-less return paths honest (code review bfcache/tab-focus gap):
+//     handleCheckoutReturn -> flow.returnFromCheckout() transits CHECKOUT_OPEN and
+//     carries NO ?pay= outcome, so it must NOT soften the copy - a customer who
+//     alt-tabbed back from an unpaid sheet would otherwise be told "you've completed
+//     checkout". With the flag cleared here, that path lands on the honest recovery
+//     card, exactly as it does today. Softening it would need a completion signal we
+//     do not have on that path (see returnedFromCompletedCheckout's declaration).
+watch(
+	() => pay.value.value,
+	(v) => {
+		if (v === S.CHECKOUT_OPEN) returnedFromCompletedCheckout.value = false;
+	}
+);
 
 // ---- "Resend the link" (jarvis#297 P0-2a) -----------------------------------
 // A truthful confirmation line, not a toast that could be missed off-screen -
@@ -5441,6 +5604,16 @@ onMounted(async () => {
 		state.step = "pay";
 		confirmingReturn.value = true;
 	}
+	// A `done` OR `pending` return both prove the customer FINISHED the Razorpay flow;
+	// only the outcome differs - `done` = payment confirmed, `pending` = authorized and
+	// awaiting async confirmation. The admin pay page (billing/checkout/shell.py
+	// outcomeFor) returns `pending` for exactly the PAYMENT_AUTHORIZED_PENDING_CONFIRM
+	// auto-pay-mandate case this hold exists for (next_step "poll"/"contact_support"),
+	// so gating on `done` alone missed the PRIMARY path. A `failed` return, or a bare
+	// reload with no ?pay= (a checkout nobody finished), still falls to the recovery
+	// card. See returnedFromCompletedCheckout's declaration.
+	returnedFromCompletedCheckout.value =
+		checkoutReturn === "done" || checkoutReturn === "pending";
 	// Restore the namespaced local billing snapshot FIRST: restored values are
 	// user-owned (local_restore), so the Company-defaults fetch prefillAccount
 	// triggers can only fill fields the customer left blank.


### PR DESCRIPTION
## Summary

Backport of #958 to `version-16-hotfix`. After checkout the wizard holds a calm confirming screen while the bank and webhook settle, instead of showing the failed-payment card.

Cherry-picked with `-m 1 -x` from the develop merge commit. OnboardingView.spec.js had been deleted on this line by the GST onboarding commits; restored from develop, where it matches the identical OnboardingView.vue.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`version-16-hotfix`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01GvEjfCozT55Ms6su4twbmc
