### PR TITLE
feat(chat): warn on fewer than 2 total workers, not just <2 long (backport #1040)

### DIFF
--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -859,14 +859,20 @@ def _warn_provisioning_if_starved() -> None:
 		pass
 
 
-# --- Chat worker health (drives the onboarding warning) ----------------------
+# --- Chat worker health (drives onboarding warning + chat send block) ---------
 #
 # Two conditions, deliberately split so the fail-CLOSED chat block is flap-proof
 # on the managed fleet (a rolling worker restart must never block a paying
 # customer):
-#   * DEGRADED  -> warn only. The F1 self-starvation shape (_pump_shape_starves):
-#     turns run but strand for minutes. Surfaced as a non-blocking onboarding
-#     banner; chat still works.
+#   * DEGRADED  -> warn only. Fires when TOTAL live RQ workers (any queue) < 2,
+#     not the stricter F1 "< 2 `long` workers" shape (_pump_shape_starves) used
+#     by the ops provisioning warning. Rationale: the pump already reroutes
+#     prepare/finalize (control) jobs to `short` when `long` has < 2 workers
+#     (`_control_queue`), so 1 `long` worker plus a second worker to run those
+#     control jobs does NOT strand - the stricter "< 2 `long`" rule over-warned
+#     that case. The strand only truly happens with a single worker doing
+#     everything, so this warns on total headcount instead. Surfaced as a
+#     non-blocking onboarding banner; chat still works.
 #   * No hard block. RQ's registry can read zero workers while every worker is
 #     alive: a worker hash that expired during a heartbeat gap comes back with
 #     only `last_heartbeat` (no `queues`), and a queue-Redis restart empties
@@ -920,6 +926,21 @@ def _registry_is_stale(workers=None) -> bool:
 		return True
 
 
+def _total_live_workers() -> "int | None":
+	"""Count of ALL live RQ workers on this bench, across every queue - not just
+	the pump's hop/control lanes. Falls back to heartbeat hashes when the registry
+	lists nobody (a queue-Redis restart empties ``rq:workers`` while the workers
+	keep running). Returns ``None`` (not 0) on any probe trouble so the caller
+	fails SAFE (not degraded) rather than reading a broken probe as a real
+	shortage."""
+	try:
+		from frappe.utils.background_jobs import get_workers
+
+		return len(get_workers()) or _fresh_heartbeat_count()
+	except Exception:
+		return None
+
+
 def _fresh_heartbeat_count() -> "int | None":
 	"""Workers whose registry hash carries a recent ``last_heartbeat``, found by
 	scanning ``rq:worker:*`` directly. Survives both registry failures: a hash
@@ -958,11 +979,12 @@ def chat_worker_status() -> dict:
 	"""Worker health for the onboarding warning. Fails SAFE: on any trouble
 	reports not degraded.
 
-	``degraded`` is the F1 self-starvation shape (``_pump_shape_starves``). It is
-	a banner, never a send block: the registry it reads can misreport zero
-	(``_registry_is_stale``)."""
+	``degraded`` fires on fewer than 2 TOTAL live RQ workers (any queue) - see
+	the block comment above. It is a banner, never a send block: the registry it
+	reads can misreport zero (``_registry_is_stale``)."""
 	try:
-		degraded = _pump_shape_starves()
+		n = _total_live_workers()
+		degraded = n is not None and n < 2
 	except Exception:
 		degraded = False
 	return {"degraded": bool(degraded)}

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -2192,6 +2192,24 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 		):
 			self.assertEqual(pump._probe_worker_count("long"), 1)
 
+	def test_total_live_workers_counts_all_queues(self):
+		fake_workers = [MagicMock(), MagicMock(), MagicMock()]
+		with patch("frappe.utils.background_jobs.get_workers", return_value=fake_workers):
+			self.assertEqual(pump._total_live_workers(), 3)
+
+	def test_total_live_workers_none_on_probe_error(self):
+		with patch("frappe.utils.background_jobs.get_workers", side_effect=RuntimeError):
+			self.assertIsNone(pump._total_live_workers())
+
+	def test_total_live_workers_falls_back_to_heartbeats_when_the_registry_is_empty(self):
+		# A queue-Redis restart empties `rq:workers` while the workers keep running
+		# and heartbeating; their hashes are still there to count.
+		with (
+			patch("frappe.utils.background_jobs.get_workers", return_value=[]),
+			patch.object(pump, "_fresh_heartbeat_count", return_value=2),
+		):
+			self.assertEqual(pump._total_live_workers(), 2)
+
 	def test_fresh_heartbeat_count_reads_recent_worker_hashes(self):
 		from datetime import datetime, timedelta, timezone
 
@@ -2261,16 +2279,24 @@ class TestWorkerStatus(FrappeTestCase):  # reuse module base
 			self.assertFalse(pump._registry_is_stale())
 
 	def test_healthy_is_not_degraded(self):
-		with patch.object(pump, "_pump_shape_starves", return_value=False):
+		with patch.object(pump, "_total_live_workers", return_value=4):
 			s = pump.chat_worker_status()
 			self.assertFalse(s["degraded"])
 			self.assertNotIn("blocked", s)
 
-	def test_starved_shape_is_degraded(self):
-		with patch.object(pump, "_pump_shape_starves", return_value=True):
+	def test_one_total_worker_is_degraded(self):
+		with patch.object(pump, "_total_live_workers", return_value=1):
 			self.assertTrue(pump.chat_worker_status()["degraded"])
 
-	def test_shape_probe_error_not_degraded(self):
-		# Fail-safe: a probe error must never be read as a real shortage.
-		with patch.object(pump, "_pump_shape_starves", side_effect=RuntimeError):
+	def test_two_total_workers_not_degraded(self):
+		# The discriminating case: exactly 2 total workers must NOT warn (this is
+		# the F1 "1 long + 1 to run rerouted control jobs" shape that no longer
+		# strands, per `_control_queue`). Fails if the threshold were `<= 2`.
+		with patch.object(pump, "_total_live_workers", return_value=2):
+			self.assertFalse(pump.chat_worker_status()["degraded"])
+
+	def test_total_worker_probe_error_not_degraded(self):
+		# Fail-safe: a probe error (_total_live_workers -> None) must never be
+		# read as a real shortage.
+		with patch.object(pump, "_total_live_workers", return_value=None):
 			self.assertFalse(pump.chat_worker_status()["degraded"])


### PR DESCRIPTION
## Summary

Backport of #1040 to `version-16-hotfix`. The degraded banner fires on fewer than 2 total live RQ workers on any queue, not on fewer than 2 long workers, so a 1 long + 1 short bench no longer over-warns.

Cherry-picked with `-m 1 -x` from the develop merge commit. pump.py and test_pump.py conflicted with the #1127 backport already on this line (the send block was removed there); resolved by taking develop's versions of both files, which is exactly #1040 as it sits on top of #1127. These are the hunks dropped by hand during the #1127 backport, now restored on purpose.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`version-16-hotfix`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01GvEjfCozT55Ms6su4twbmc
