### PR TITLE
feat(chat): clearer, actionable low-worker warning copy (backport #1039)

### DIFF
--- a/frontend/src/branding.js
+++ b/frontend/src/branding.js
@@ -16,9 +16,9 @@ export const isWhitelabeled = agentName !== DEFAULT_NAME || !!brandLogoUrl;
 // Shared worker-warning banner copy: OnboardingGate.vue and OnboardingView.vue
 // both render this Banner for the same degraded-worker signal, and previously
 // hardcoded the identical title + interpolated message in two places.
-export const WORKER_WARNING_TITLE = "Background workers are low";
+export const WORKER_WARNING_TITLE = "Replies may be slow";
 export function workerWarningMessage(name) {
-	return `Your ${name} background workers look under-provisioned. Chat may be slow or stall until more workers are running.`;
+	return `${name} is low on background workers, so answers may take longer. Add more workers to your bench to speed this up.`;
 }
 
 // Patch the browser-tab title + favicon to the tenant brand. Called once at

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2626,7 +2626,7 @@
 				<Banner
 					v-else-if="workersWarnNotice"
 					type="warning"
-					title="Replies may be slow right now"
+					title="Replies may be slow"
 					:message="workersWarnNotice"
 					style="margin-bottom: 10px"
 				/>
@@ -4683,7 +4683,7 @@ const suspendedNotice = ref(null);
 // not a stop sign. Self-heals: cleared on the next successful retry/send, never
 // re-derived from a re-poll (checkReady() is memoized). Null while healthy.
 const workersWarnNotice = ref(null);
-const WORKERS_WARN_MSG = `${agentName} is busier than usual, so answers might take a little longer. You can keep chatting.`;
+const WORKERS_WARN_MSG = `${agentName} is low on background workers, so answers may take longer. Add more workers to your bench to speed this up.`;
 // A DIFFERENT not-ready reason (container_provisioning - e.g. the connected LLM
 // account itself ran out of quota, or a container is still coming up) - never a
 // billing lapse, so it gets its own quiet copy instead of suspendedNotice's "Chat is

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -179,10 +179,10 @@
 
 			<!-- Worker-degraded heads-up: a SEPARATE, additive signal from the
 			     readiness gate above (see workerWarning's declaration). Renders ONLY
-			     when readiness === "ready" - chat is fully usable, just maybe a
-			     little slow. "gate" has no thread to warn about, and "degraded"
+			     when readiness === "ready" - chat is fully usable, just maybe
+			     slower. "gate" has no thread to warn about, and "degraded"
 			     already shows .jvp-notice below saying replies may FAIL outright;
-			     stacking this "may be a little slower" banner under that would
+			     stacking this "replies may be slow" banner under that would
 			     contradict and undersell the real state, so degraded keeps its own
 			     banner instead of also getting this one. Non-blocking by
 			     construction either way - never disables the composer, never
@@ -207,7 +207,8 @@
 				class="jvp-worker-notice"
 				role="status"
 			>
-				Replies may be a little slower than usual right now.
+				{{ brandName }} is low on background workers, so answers may take longer. Add more
+				workers to your bench to speed this up.
 			</div>
 
 			<div class="jvp-body" ref="bodyEl" @scroll.passive="onBodyScroll">
@@ -2952,7 +2953,7 @@ defineExpose({ load, startNewChat, convId });
    compact and clearly non-blocking. Renders only on a fully "ready" workspace
    whose workers are merely stretched (see the template v-if) - readiness ===
    "degraded" already gets .jvp-notice's own "replies may fail" banner, and this
-   lighter "may be a little slower" one would undersell that, so the two never
+   lighter "replies may be slow" one would undersell that, so the two never
    stack. */
 .jvp-worker-notice {
 	flex: none;


### PR DESCRIPTION
## Summary

Backport of #1039 to `version-15-hotfix`. The low-worker banner now reads "Replies may be slow" with a plain next step, on the onboarding gate, chat view and Desk widget.

Cherry-picked with `-m 1 -x` from the develop merge commit.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`version-15-hotfix`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01GvEjfCozT55Ms6su4twbmc
