### PR TITLE
feat(agents): stop control + fail-fast poll for dispatched agent runs (backport #1064)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1373,13 +1373,6 @@ def post_push_agent_skills(agent_skills: list[dict]) -> dict:
 	restarts the container so agent re-scans ``workspace/skills``. An empty
 	list is a valid "remove all agent skills" reconcile.
 
-	NOTE: the admin endpoint ``jarvis_admin.api.tenant.push_agent_skills`` and the
-	fleet ``PUT /v1/containers/{name}/agent-skills`` are the B5 half of this work
-	(a sibling of the custom-skills chain). Until they ship this raises
-	``AdminValidationError`` (unknown method), which ``apply_agents`` records as a
-	terminal ``failed:`` status — the bench-side path is complete and structured
-	identically to ``post_push_custom_skills``.
-
 	Raises:
 		AdminAuthError, AdminUnreachableError, AdminValidationError
 		(rate-limit shares the rotate-secret bucket).

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -33,6 +33,7 @@ review:
 trigger takes the EXACT same code path as the scheduler.
 """
 
+import time
 from datetime import timedelta
 
 import frappe
@@ -68,6 +69,47 @@ MIN_AGENT_RUN_BUDGET_MONTHLY = 31
 # dead. Keep the two answers to "is this run alive?" on one number, or a run becomes
 # too old to count as live and too young to be reaped.
 STALE_RUN_AFTER_SECONDS = 3 * 3600
+
+# #1061 run poll (jarvis#1058). The reaper above is a 3h BACKSTOP; these are the
+# cutoffs of the 5-minute sweep that asks the fleet what actually happened, so a run
+# whose delegate died after dispatch is terminalized in minutes with its REAL error
+# instead of three hours later as a duration timeout it never hit.
+#
+# POLL_GRACE_SECONDS — how long a fresh dispatch is left alone. Below this the fleet
+# state is still ``queued``/``running`` in the normal case, so polling only costs an
+# admin round trip per run per tick.
+POLL_GRACE_SECONDS = 120
+# WRITEBACK_GRACE_SECONDS — how long the bench waits, AFTER the delegate finished, for
+# ``record_agent_run`` to land before calling the run finished-without-results. Measured
+# from the FLEET's ``finished_at``, never from the run's own age: a two-hour scribe is
+# already far past any grace the instant its fleet state flips to completed, and failing
+# it with the writeback seconds in flight would mislabel a success.
+WRITEBACK_GRACE_SECONDS = 600
+# MISSING_RECORD_FALLBACK_SECONDS — a 404 from the fleet ("unknown agent run") means the
+# host has NO record: either the run never landed, or its state file was pruned. Both are
+# indistinguishable from here, so a young run is left alone (the state file may not be
+# visible yet / the container may be mid-restart) and only an old one is failed.
+MISSING_RECORD_FALLBACK_SECONDS = 1800
+# The fleet-agent's own 404 text for a run it has no state file for
+# (``jarvis_fleet_agent/main.py``: ``NotFoundError(f"unknown agent run {run_id}")``),
+# relayed to the bench through admin as an Admin*Error message. Matched as a SUBSTRING,
+# the same idiom as the "not an installed delegate" translation in ``_launch_audit`` —
+# admin does not re-code this refusal, so the fleet's sentence is the only signal. A
+# CROSS-REPO literal: renaming it fleet-side turns every lost run back into a 3h reap.
+_FLEET_UNKNOWN_RUN = "unknown agent run"
+# The fleet-agent's words for a run that ENDED CLEANLY on the host. Its dispatch worker
+# stamps ``done`` when the container-side turn returns (fleet-agent ``main.py``,
+# ``_dispatch_agent_run``); ``completed`` is accepted too so a relay or a future fleet
+# that normalises the word cannot silently turn every clean exit back into "still in
+# flight" (the mistake this constant replaces: the poll originally matched only
+# ``completed`` and would never have seen a real ``done``).
+_FLEET_FINISHED_STATUSES = ("done", "completed")
+# Circuit breaker on the poll's outbound calls. The sweep is SEQUENTIAL and each admin
+# call can block for admin_client.DEFAULT_TIMEOUT_S (150s), so with admin down three
+# in-flight runs already outlast the 5-minute cron interval and sweeps start stacking.
+# Two consecutive transport failures is enough evidence that the RELAY is down rather
+# than any one run being odd, so the sweep abandons the rest of the tick.
+MAX_CONSECUTIVE_POLL_FAILURES = 2
 
 # #672: TTL on the per-installation DISPATCH lock, which is held across the slot
 # claim AND the whole launch, including the admin call (admin_client.DEFAULT_TIMEOUT_S
@@ -394,84 +436,19 @@ def reap_stale_agent_runs() -> int:
 	scan and its transition here. Each candidate is therefore re-read under a ROW LOCK
 	and transitioned with a COMPARE-AND-SET on ``status='running'``: a row a concurrent
 	finish already moved off running is LEFT ALONE, and the per-run session is torn down
-	only AFTER the transition is won + committed."""
-	from jarvis.chat import agent_runs
-	from jarvis.tools.record_app_wiki import reconcile_run_pages
-
+	only AFTER the transition is won + committed. That whole locked transition lives in
+	``_terminalize_stuck_run``, shared with the #1061 poll so the two sweeps cannot
+	drift apart on it."""
 	cutoff = now_datetime() - timedelta(seconds=STALE_RUN_AFTER_SECONDS)
 	reaped = 0
 	for r in _stale_candidates(cutoff):
 		try:
-			# Re-read under a ROW LOCK immediately before deciding. The row lock serializes
-			# against a concurrent record_app_wiki/finish (both write this row), so the
-			# status + tally we act on are current, not the possibly-stale scan snapshot.
-			cur = frappe.db.get_value(
-				RUN,
+			if _terminalize_stuck_run(
 				r.name,
-				["status", "pages_written", "agent", "session_key", "owner", "installation"],
-				as_dict=True,
-				for_update=True,
-			)
-			if not cur or cur.status != "running":
-				# A concurrent finish already moved it off running — leave it alone (never
-				# overwrite a completed run with failed). Release the lock and move on.
-				frappe.db.commit()
-				continue
-			nature = (frappe.db.get_value(LISTING, cur.agent, "nature") or "").strip().title()
-			pages = int(cur.pages_written or 0)
-			pages_meta = None
-			if nature == "Scribe" and pages == 0:
-				# CA2-3 fallback: rebuild the tally from page provenance before failing a
-				# scribe run whose stored tally reads zero, so real work is never lost.
-				pages_meta = reconcile_run_pages(r.name)
-				if pages_meta is None:
-					# CA3-4: the provenance QUERY failed — the true page count is UNKNOWN.
-					# Neither terminalization is safe (completing with 0 would drop real
-					# pages; failing would mislabel a success), so leave the run running and
-					# retry on the next sweep. Release the row lock and move on.
-					frappe.db.commit()
-					continue
-				pages = pages_meta["count"]
-			if nature == "Scribe" and pages > 0:
-				# Server-owned terminalization: the pages are already durably written,
-				# so this is an honest SUCCESS the model merely never finalized. Complete
-				# it with its tally rather than failing real work.
-				values = {"status": "completed", "finished_at": frappe.utils.now()}
-				if pages_meta is not None:
-					# CA3-4: the tally was rebuilt from provenance (the stored one read 0) —
-					# PERSIST the reconciled ``pages_written`` + ``pages_json`` in the SAME
-					# locked terminalization write, so a run completed off provenance shows
-					# its real page count + list in the durable tally + the Runs UI, never 0.
-					values["pages_written"] = pages
-					values["pages_json"] = frappe.as_json(pages_meta["pages"])[:60000]
-				frappe.db.set_value(RUN, r.name, values, update_modified=False)
-				frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
-				agent_runs.teardown_run_session(cur.session_key)
-				log_activity(
-					agent=cur.agent,
-					agent_title=frappe.db.get_value(LISTING, cur.agent, "title"),
-					installation=cur.installation,
-					action="run_completed",
-					run=r.name,
-					detail=f"reconciled to completed: scribe wrote {pages} page(s); finish not called",
-					owner=cur.owner,
-				)
-				frappe.db.commit()
-				reaped += 1
-				continue
-			# The row lock is already held and the compare-and-set above has already
-			# established that the row is still ``running``, so this goes straight to
-			# the shared terminalization tail.
-			_terminalize_failed(
-				r.name,
-				agent=cur.agent,
-				installation=cur.installation,
-				session_key=cur.session_key,
-				owner=cur.owner,
 				error="run exceeded max duration; reaped by the stale-run sweep (A8 backstop)",
 				detail="reaped: run exceeded max duration",
-			)
-			reaped += 1
+			):
+				reaped += 1
 		except Exception:
 			frappe.log_error(
 				title=f"jarvis agent: stale-run reap failed: {r.name}",
@@ -480,14 +457,117 @@ def reap_stale_agent_runs() -> int:
 	return reaped
 
 
+def _terminalize_stuck_run(run_name: str, *, error: str, detail: str) -> bool:
+	"""Terminalize ONE run that is still ``running`` when it should not be. Returns True
+	iff this call is the one that transitioned it.
+
+	Shared by both sweeps that terminalize from the outside — the 3h stale-run reaper
+	(A8) and the 5-minute fleet poll (#1061). One copy on purpose: they differ only in
+	WHEN they decide a run is stuck and in the sentence they record, never in how the
+	transition is made, and two copies of a compare-and-set are two chances to drift.
+
+	Re-reads under a ROW LOCK immediately before deciding. The row lock serializes
+	against a concurrent ``record_app_wiki``/``finish`` (both write this row), so the
+	status + tally acted on are current, not a possibly-stale scan snapshot; a row a
+	concurrent finish already moved off ``running`` is LEFT ALONE (never overwrite a
+	real outcome with failed), which is also what makes an operator's ``stopped`` win.
+
+	CA-4 (server-owned scribe completion): a Custom App Learning *scribe* whose durable
+	page tally proves it SUCCEEDED is reconciled to ``completed`` rather than mislabelled
+	``failed`` — completion must not depend on the model remembering to call finish. This
+	ruling belongs to the run's OWN durable evidence, not to the reason the caller decided
+	the run was stuck, which is why EVERY outside-in terminalization comes through here:
+	pages already written are pages already written, whether the sweep's trigger was the
+	3h clock, a fleet-reported failure, or a lost fleet record."""
+	from jarvis.chat import agent_runs
+	from jarvis.tools.record_app_wiki import reconcile_run_pages
+
+	frappe.db.commit()  # REPEATABLE-READ discipline: FOR UPDATE goes first
+	cur = frappe.db.get_value(
+		RUN,
+		run_name,
+		["status", "pages_written", "agent", "session_key", "owner", "installation"],
+		as_dict=True,
+		for_update=True,
+	)
+	if not cur or cur.status != "running":
+		# A concurrent finish / stop already moved it off running — leave it alone.
+		# Release the lock and move on.
+		frappe.db.commit()
+		return False
+	nature = (frappe.db.get_value(LISTING, cur.agent, "nature") or "").strip().title()
+	pages = int(cur.pages_written or 0)
+	pages_meta = None
+	if nature == "Scribe" and pages == 0:
+		# CA2-3 fallback: rebuild the tally from page provenance before failing a
+		# scribe run whose stored tally reads zero, so real work is never lost.
+		pages_meta = reconcile_run_pages(run_name)
+		if pages_meta is None:
+			# CA3-4: the provenance QUERY failed — the true page count is UNKNOWN.
+			# Neither terminalization is safe (completing with 0 would drop real
+			# pages; failing would mislabel a success), so leave the run running and
+			# retry on the next sweep. Release the row lock and move on.
+			frappe.db.commit()
+			return False
+		pages = pages_meta["count"]
+	if nature == "Scribe" and pages > 0:
+		# Server-owned terminalization: the pages are already durably written,
+		# so this is an honest SUCCESS the model merely never finalized. Complete
+		# it with its tally rather than failing real work.
+		values = {"status": "completed", "finished_at": frappe.utils.now()}
+		if pages_meta is not None:
+			# CA3-4: the tally was rebuilt from provenance (the stored one read 0) —
+			# PERSIST the reconciled ``pages_written`` + ``pages_json`` in the SAME
+			# locked terminalization write, so a run completed off provenance shows
+			# its real page count + list in the durable tally + the Runs UI, never 0.
+			values["pages_written"] = pages
+			values["pages_json"] = frappe.as_json(pages_meta["pages"])[:60000]
+		frappe.db.set_value(RUN, run_name, values, update_modified=False)
+		frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
+		agent_runs.teardown_run_session(cur.session_key)
+		log_activity(
+			agent=cur.agent,
+			agent_title=frappe.db.get_value(LISTING, cur.agent, "title"),
+			installation=cur.installation,
+			action="run_completed",
+			run=run_name,
+			detail=f"reconciled to completed: scribe wrote {pages} page(s); finish not called",
+			owner=cur.owner,
+		)
+		frappe.db.commit()
+		return True
+	# The row lock is already held and the compare-and-set above has already
+	# established that the row is still ``running``, so this goes straight to
+	# the shared terminalization tail.
+	_terminalize_failed(
+		run_name,
+		agent=cur.agent,
+		installation=cur.installation,
+		session_key=cur.session_key,
+		owner=cur.owner,
+		error=error,
+		detail=detail,
+	)
+	return True
+
+
 def _stale_candidates(cutoff) -> list:
-	"""Runs stuck ``running`` past ``cutoff`` — the reaper's candidate set. Factored so
-	the CA2-4 compare-and-set (re-read under a row lock before transitioning) can be
-	exercised against a deliberately-stale candidate snapshot in tests."""
+	"""Runs stuck ``running`` past ``cutoff`` — the candidate set of BOTH outside-in
+	sweeps (the A8 reaper at 3h, the #1061 poll at 2 minutes; only the cutoff differs).
+	Factored so the CA2-4 compare-and-set (re-read under a row lock before
+	transitioning) can be exercised against a deliberately-stale snapshot in tests."""
 	return frappe.get_all(
 		RUN,
 		filters={"status": "running", "started_at": ["<", cutoff]},
-		fields=["name", "session_key", "owner", "agent", "installation", "pages_written"],
+		fields=[
+			"name",
+			"session_key",
+			"owner",
+			"agent",
+			"installation",
+			"pages_written",
+			"started_at",
+		],
 	)
 
 
@@ -580,6 +660,211 @@ def fail_run(run_name: str, error: str, *, detail: str | None = None) -> bool:
 			message=frappe.get_traceback(),
 		)
 		return False
+
+
+# --------------------------------------------------------------------------- #
+# #1061 dispatched-run poll (jarvis#1058) — hooks cron, every 5 minutes
+# --------------------------------------------------------------------------- #
+def poll_dispatched_runs() -> int:
+	"""Ask the fleet what actually happened to each run the bench still believes is
+	``running``, and terminalize the ones that are over. Returns the count transitioned.
+	Runs as Administrator (scheduler); best-effort, never raises out.
+
+	The bench used to learn a run's outcome from exactly ONE source: the delegate's own
+	``record_agent_run`` writeback. A delegate that died after dispatch — a container
+	restart, a stale gateway roster (jarvis#1058), an exec failure the fleet recorded but
+	nobody read — therefore left the row ``running`` for three hours, blocking every
+	further run of that installation behind the #672 liveness guard, before the reaper
+	relabelled it "exceeded max duration": a timeout it never hit, and a diagnosis that
+	sent the customer looking in the wrong place.
+
+	This closes that loop from the other side. It NEVER touches a row that is not still
+	``running``: every terminal write goes through ``fail_run`` /
+	``_terminalize_stuck_run``, which re-read under a row lock and compare-and-set on
+	``status='running'``. So an operator's ``stop_agent_run``, a real writeback and this
+	sweep can race freely — the first to win the lock decides, and a later fleet flip can
+	never overwrite a stopped or completed run.
+
+	The reaper stays: it is the backstop for everything this cannot see (admin down, the
+	relay itself broken), which is why an unreachable admin here is a SKIP, never a
+	failure verdict."""
+	from jarvis import admin_client
+
+	now = now_datetime()
+	cutoff = now - timedelta(seconds=POLL_GRACE_SECONDS)
+	candidates = _stale_candidates(cutoff)
+	terminalized = 0
+	unreachable = 0
+	consecutive = 0
+	abandoned = 0
+	for i, r in enumerate(candidates):
+		# Per-run fault isolation (the health_check 1020 lesson): one poisoned row must
+		# never abort the sweep and starve every run behind it.
+		try:
+			try:
+				state = _polled_state(admin_client.get_agent_run_status(r.name))
+			except Exception as e:
+				# Deliberately caught by MESSAGE, not by class. A relayed fleet 404 arrives
+				# as an Admin*Error whose class is shared with genuine transport faults
+				# (AdminRejectedError IS an AdminUnreachableError), so branching on the
+				# class first would swallow every lost-record case forever.
+				if _FLEET_UNKNOWN_RUN not in str(e).lower():
+					# Transport / admin fault: skip this run, the reaper backstops it.
+					unreachable += 1
+					consecutive += 1
+					if consecutive >= MAX_CONSECUTIVE_POLL_FAILURES:
+						# CIRCUIT BREAKER. Each call can block for admin_client's full
+						# DEFAULT_TIMEOUT_S (150s), and this sweep is sequential on a 5-minute
+						# cron, so with admin down even three in-flight runs push one tick past
+						# the next and the sweeps stack — an outage would spend the scheduler
+						# on calls that are all going to time out anyway. Two consecutive
+						# transport failures is enough evidence that the relay, not the run, is
+						# the problem: abandon the rest of the sweep and let the next tick
+						# retry from the top.
+						abandoned = len(candidates) - (i + 1)
+						break
+					continue
+				state = {"status": "missing"}
+			consecutive = 0  # a readable answer (a relayed 404 included) closes the breaker
+			if _reconcile_polled_run(r, state, now):
+				terminalized += 1
+		except Exception:
+			frappe.log_error(
+				title=f"jarvis agent: run poll failed: {r.name}",
+				message=frappe.get_traceback(),
+			)
+	if unreachable:
+		# ONE line per sweep, not one per run: an admin outage would otherwise write an
+		# Error Log row for every in-flight run every five minutes.
+		frappe.log_error(
+			title="jarvis agent: run poll could not reach admin",
+			message=(
+				f"{unreachable} dispatched run(s) failed to poll and {abandoned} more were "
+				f"left unattempted (breaker opened after {MAX_CONSECUTIVE_POLL_FAILURES} "
+				"consecutive transport failures). No run state was changed; the next tick "
+				"retries and the stale-run reaper remains the backstop."
+			),
+		)
+	return terminalized
+
+
+def _polled_state(payload) -> dict:
+	"""The fleet's run-state record out of whatever the relay returned.
+
+	``admin_client._do_post`` already peels Frappe's ``message`` wrapper, but admin's OWN
+	success envelope survives it: ``api.tenant.agent_run_status`` returns
+	``{"ok": True, "data": {<run state>}}``, so the state sits one level further down than
+	``admin_client.get_agent_run_status``'s docstring suggests. Reading only the envelope
+	would be just as brittle in the other direction, so accept both shapes — a poll that
+	misreads the wrapper sees a blank status and silently never terminalizes anything,
+	which is the failure mode this whole sweep exists to remove."""
+	if not isinstance(payload, dict):
+		return {}
+	data = payload.get("data")
+	if isinstance(data, dict) and ("status" in data or "run_id" in data):
+		return data
+	return payload
+
+
+def _reconcile_polled_run(row, state: dict, now) -> bool:
+	"""Decide what the fleet's run-state means for a bench row still ``running``, and
+	transition it if it is over. Returns True iff this call terminalized it.
+
+	``state`` is the fleet's run-state record relayed verbatim through admin
+	(``{run_id, status: queued|running|completed|failed, error, finished_at, ...}``),
+	plus the synthetic ``missing`` this module uses for a relayed 404."""
+	status = (state.get("status") or "").strip().lower()
+
+	# Every terminal branch below goes through ``_terminalize_stuck_run``, never through
+	# ``fail_run`` directly: the CA-4 scribe ruling is keyed on the run's OWN durable page
+	# tally, not on why the sweep decided the run was over. Calling fail_run here stamped
+	# ``failed`` on a scribe that had already written its pages, while the reaper
+	# reconciled the identical row to ``completed`` — the same run reported two different
+	# outcomes depending on which sweep reached it first.
+	if status == "missing":
+		# The host has NO record of this run. Either it never landed, or its state file
+		# was pruned. Indistinguishable from here, so age is the only honest tiebreak:
+		# a young run may simply not be visible yet (container mid-restart, a state
+		# write not yet flushed) and is left alone.
+		if _run_age_seconds(row, now) < MISSING_RECORD_FALLBACK_SECONDS:
+			return False
+		return _terminalize_stuck_run(
+			row.name,
+			error="the agent host has no record of this run; it never started or its state was lost",
+			detail="polled: no run record on the host",
+		)
+
+	if status == "failed":
+		# The delegate really failed and the fleet knows why. Surface THAT sentence, not
+		# a generic one: this is the whole point of polling rather than waiting for the
+		# reaper's "exceeded max duration".
+		return _terminalize_stuck_run(
+			row.name,
+			error=_fleet_error_message(state),
+			detail="polled: the delegate reported a failure",
+		)
+
+	if status not in _FLEET_FINISHED_STATUSES:
+		# queued / running / anything unrecognised: still in flight as far as the host is
+		# concerned. Leave it alone — an unknown state is never a verdict.
+		return False
+
+	# Finished on the host, still ``running`` on the bench: the writeback is either in
+	# flight or it is never coming. Wait out the grace before deciding, measured from the
+	# host's own finish time (see WRITEBACK_GRACE_SECONDS).
+	if _writeback_grace_age(state, row, now) < WRITEBACK_GRACE_SECONDS:
+		return False
+	# Past the grace. A scribe whose durable page tally proves it wrote real pages is
+	# COMPLETED, not failed — the shared helper owns that ruling, exactly as the reaper
+	# gets it.
+	return _terminalize_stuck_run(
+		row.name,
+		error="delegate finished without recording results",
+		detail="polled: delegate finished without recording results",
+	)
+
+
+def _fleet_error_message(state: dict) -> str:
+	"""The delegate's real failure sentence out of the fleet run-state ``error``
+	(``{code, message}``), falling back to something honest rather than empty — an
+	error field the customer reads as blank is worse than a generic sentence."""
+	err = state.get("error")
+	if isinstance(err, dict):
+		msg = (err.get("message") or "").strip() or (err.get("code") or "").strip()
+		if msg:
+			return msg[:140]
+	elif isinstance(err, str) and err.strip():
+		return err.strip()[:140]
+	return "the agent host reported this run as failed"
+
+
+def _run_age_seconds(row, now) -> float:
+	"""Seconds since the bench dispatched this run. 0.0 when ``started_at`` is unreadable
+	— which reads as "too young to judge", the fail-safe direction for every caller here."""
+	try:
+		return (now - frappe.utils.get_datetime(row.started_at)).total_seconds()
+	except Exception:
+		return 0.0
+
+
+def _writeback_grace_age(state: dict, row, now) -> float:
+	"""Seconds since the DELEGATE finished — what the writeback grace must be measured
+	from. Anchoring it on the run's own age would fail any run longer than the grace the
+	instant its fleet state flipped to completed, with the writeback still seconds in
+	flight, which is precisely the long scribe run this sweep must not mislabel.
+
+	The fleet stamps ``finished_at`` as a UNIX epoch float (fleet-agent
+	``agent_run.new_run_state``). Falls back to the bench-side run age only when the
+	relayed state carries none."""
+	finished = state.get("finished_at")
+	if finished is not None:
+		try:
+			delta = time.time() - float(finished)
+		except (TypeError, ValueError):
+			delta = -1.0
+		if delta >= 0:
+			return delta
+	return _run_age_seconds(row, now)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -47,6 +47,13 @@ _PUSH_JOB_ID = "jarvis_agent_skills_push"
 _LOCK_NAME = "jarvis_agent_skills_push"
 
 _FREQUENCIES = ("daily", "weekly", "monthly")
+# #1061: every value the Jarvis Agent Run ``status`` Select accepts — the one list the
+# SPA's run-history filter is validated against. ``stopped`` is TERMINAL (an operator
+# ended the run early); it is deliberately NOT a synonym for ``failed``, because a
+# stopped run is neither a delegate fault nor a duration timeout and must not be
+# reported to the customer as either. Keep in lockstep with the DocType's Select
+# options — a value missing here is a filter the Runs page silently refuses.
+_RUN_STATUSES = ("running", "completed", "partial", "failed", "stopped")
 # Statuses a bench admin may set via set_listing_status (Draft is registry-only).
 _ADMIN_STATUSES = ("Published", "Coming Soon", "Deprecated")
 # Never meaningful as an agent restriction ("All" == unrestricted; the other two
@@ -1206,6 +1213,138 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# #1061 — the operator's soft stop
+# --------------------------------------------------------------------------- #
+def _guard_run_control(run_doc) -> None:
+	"""Who may STOP a run: exactly who may START one.
+
+	Deliberately NOT ``run_doc.check_permission("write")``. Jarvis User holds READ
+	ONLY (``if_owner``) on Jarvis Agent Run — the rows are server-owned, and granting
+	write so the owner could stop one would also let any customer rewrite a run's
+	status, error and result by hand, which is the audit trail. So the gate is the one
+	``run_agent_now`` already uses: WRITE on the run's own Jarvis Agent Installation
+	(its owner, or a System Manager). A run with no installation (a legacy row, or a
+	``_record_failed`` skip row) falls back to the run's own ``if_owner`` read gate,
+	which is still an ownership check — ``get_doc`` alone enforces neither."""
+	if run_doc.installation and frappe.db.exists(INSTALLATION, run_doc.installation):
+		frappe.get_doc(INSTALLATION, run_doc.installation).check_permission("write")
+		return
+	run_doc.check_permission("read")
+
+
+def _try_abort_gateway_session(session_key: str | None, run: str) -> None:
+	"""Best-effort hard abort of the delegate's gateway session. NEVER raises.
+
+	The soft stop (the terminal row + the revoked session bearer) is the guarantee;
+	this is the opportunistic other half. Mirrors ``chat/api.stop_run``'s abort — the
+	same ``agent_session_pool`` checkout against the same Settings gateway URL.
+
+	EXPECTED TO BE A NO-OP TODAY, on purpose: an agent run is dispatched container-side
+	as ``gateway call agent --expect-final`` on the cron lane, not as an interactive chat
+	session, so the gateway most likely has no abortable chat turn under this key and
+	answers with an error we swallow. It is wired anyway because it costs one bounded
+	call, it is the correct thing the moment the run lane grows an abort verb, and the
+	stop is already complete without it."""
+	key = (session_key or "").strip()
+	if not key:
+		return
+	try:
+		settings = frappe.get_cached_doc(_SETTINGS)
+		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
+		if not gateway_url:
+			return
+		from jarvis.chat import agent_session_pool
+
+		with agent_session_pool.checkout(gateway_url) as sess:
+			sess.chat_abort(key, run)
+	except Exception:
+		# Deliberately the LOGGER, not frappe.log_error. Failing here is the DOCUMENTED
+		# expected outcome described above, so an Error Log row would be written on
+		# essentially every stop — training operators to ignore the one surface where a
+		# real fault would show. The stop itself is already complete and committed.
+		frappe.logger("jarvis.agents").info(
+			f"stop gateway abort did not land for run {run} (run stays stopped): {frappe.get_traceback()}"
+		)
+
+
+@frappe.whitelist()
+def stop_agent_run(run: str) -> dict:
+	"""Stop a RUNNING agent run: terminalize it ``stopped``, revoke its session bearer
+	and best-effort abort its gateway session. Idempotent on an already-terminal run.
+
+	Before this, a dispatched run the delegate never finalized (a dead container, a
+	stale roster, a wedged turn) had no operator exit at all: it sat ``running`` for
+	three hours, held the installation's #672 liveness guard so no further run could
+	start, and was finally relabelled by the reaper as a duration timeout it never hit
+	(jarvis#1058).
+
+	Same concurrency discipline as ``agent_scheduler.fail_run``: commit first so the
+	``FOR UPDATE`` opens a fresh read view, then a COMPARE-AND-SET on
+	``status='running'`` under the row lock. That ordering is what makes a stop WIN
+	over a later fleet flip — ``poll_dispatched_runs`` and the reaper both re-read
+	under the same lock and transition only from ``running``, so neither can overwrite
+	a stopped row, and ``record_agent_run``'s writeback is already inert on a run that
+	is not ``running``.
+
+	SLOT PARITY (#672): stopping does NOT hand the schedule slot back. ``_claim_slot``
+	consumed the installation's ``next_run_at``/``last_run_at`` BEFORE the dispatch,
+	and neither the reaper nor ``_terminalize_failed`` ever unclaims it — a run that
+	really started spent its slot, and resurrecting it here would re-dispatch the same
+	slot on the next hourly tick. The A14 monthly BUDGET is a separate ledger and
+	deliberately differs from ``failed``: ``_runs_this_month`` excludes only ``failed``
+	rows (because every skip path writes one, which would make the cap
+	self-perpetuating), and that reasoning does not extend to an operator act. A
+	stopped run really did occupy the container, so it COUNTS — otherwise
+	start-then-stop would be an unlimited free-run loop around the budget."""
+	doc = frappe.get_doc(RUN, run)
+	_guard_run_control(doc)
+
+	frappe.db.commit()  # REPEATABLE-READ discipline: FOR UPDATE goes first
+	row = frappe.db.get_value(
+		RUN,
+		run,
+		["status", "session_key", "agent", "installation", "owner"],
+		as_dict=True,
+		for_update=True,
+	)
+	if not row:
+		frappe.db.commit()
+		frappe.throw(_("That run no longer exists."), frappe.DoesNotExistError)
+	if row.status != "running":
+		# Already terminal — a concurrent finish, reap or a second click. Release the
+		# row lock and report the state it actually reached; never overwrite it.
+		frappe.db.commit()
+		return {"ok": True, "status": row.status, "idempotent": True}
+
+	stop_error = _("Stopped by operator.")
+	frappe.db.set_value(
+		RUN,
+		run,
+		{"status": "stopped", "finished_at": frappe.utils.now(), "error": stop_error[:140]},
+		update_modified=False,
+	)
+	frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
+	# The session bearer must not outlive the run: with the row gone the delegate's
+	# late jarvis__* calls (record_agent_run included) resolve no identity and 401,
+	# so nothing it does after this can write back onto the stopped run.
+	from jarvis.chat import agent_runs
+
+	agent_runs.teardown_run_session(row.session_key)
+	_try_abort_gateway_session(row.session_key, run)
+	log_activity(
+		agent=row.agent,
+		agent_title=frappe.db.get_value(LISTING, row.agent, "title") if row.agent else "",
+		installation=row.installation,
+		action="run_stopped",
+		run=run,
+		detail=f"stopped by {frappe.session.user}",
+		owner=row.owner,
+	)
+	frappe.db.commit()
+	return {"ok": True, "status": "stopped"}
+
+
+# --------------------------------------------------------------------------- #
 # PP-4 shadow activation + PP-6 global activation budget
 # --------------------------------------------------------------------------- #
 def _has_ceiling_grant(customer: str) -> bool:
@@ -1602,7 +1741,7 @@ def list_runs_page(
 	if agent:
 		filters["agent"] = agent
 	if status:
-		if status not in ("running", "completed", "partial", "failed"):
+		if status not in _RUN_STATUSES:
 			frappe.throw(_("Invalid status filter."))
 		filters["status"] = status
 	or_filters = []

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -292,6 +292,14 @@ scheduler_events = {
 			# scheduler (a live scheduler that fails to POST = the tenant went dark).
 			# Self-gating (skips un-onboarded), never raises. Cheap: two indexed reads.
 			"jarvis.chat.heartbeat.push_bench_heartbeat",
+			# #1061: ask the fleet what actually happened to each run the bench still
+			# believes is `running`, and terminalize the ones that are over with their
+			# REAL error. Without it the only source of a run's outcome was the
+			# delegate's own writeback, so a delegate that died after dispatch sat
+			# `running` for three hours (blocking every further run of that
+			# installation) before the reaper below mislabelled it a duration timeout.
+			# Cheap no-op (one indexed status query) when nothing is in flight.
+			"jarvis.chat.agent_scheduler.poll_dispatched_runs",
 		],
 		"*/2 * * * *": [
 			"jarvis.chat.turn_recovery.recover_pending_turns",

--- a/jarvis/jarvis/doctype/jarvis_agent_activity/jarvis_agent_activity.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_activity/jarvis_agent_activity.json
@@ -37,7 +37,7 @@
    "fieldname": "action",
    "fieldtype": "Select",
    "label": "Action",
-   "options": "installed\nuninstalled\nenabled\ndisabled\nschedule_changed\nconfig_changed\nrun_as_changed\nrun_started\nrun_completed\nrun_partial\nrun_failed",
+   "options": "installed\nuninstalled\nenabled\ndisabled\nschedule_changed\nconfig_changed\nrun_as_changed\nrun_started\nrun_completed\nrun_partial\nrun_failed\nrun_stopped",
    "reqd": 1,
    "in_list_view": 1,
    "in_standard_filter": 1

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
@@ -66,7 +66,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "running\ncompleted\npartial\nfailed",
+   "options": "running\ncompleted\npartial\nfailed\nstopped",
    "in_list_view": 1,
    "in_standard_filter": 1
   },

--- a/jarvis/tests/test_agent_run_lifecycle.py
+++ b/jarvis/tests/test_agent_run_lifecycle.py
@@ -1,0 +1,588 @@
+"""#1061: an agent run must be STOPPABLE and must never sit ``running`` forever.
+
+Three lifecycle holes, one module:
+
+  * **A1** — ``stopped`` was not a Jarvis Agent Run status at all, so there was no
+    honest terminal state for "an operator ended this early". The only way to clear a
+    wedged run was to let the 3h reaper relabel it as a duration timeout it never hit.
+  * **A2** — ``stop_agent_run`` is the operator's soft stop: it terminalizes the row,
+    revokes the run's session bearer (so a late writeback is inert) and best-effort
+    aborts the gateway session.
+  * **A3** — ``poll_dispatched_runs`` closes the loop the other way. The fleet already
+    knows a run failed or finished; before this the bench learned that only from the
+    delegate's own writeback, so a delegate that died after dispatch left the row
+    ``running`` for three hours (jarvis#1058).
+
+The concurrency contract these tests defend is the one the reaper already had: every
+terminal transition is a COMPARE-AND-SET on ``status='running'`` under a row lock, so
+a bench-side stop always wins over a later fleet flip and no sweep ever overwrites a
+real outcome.
+
+Run:
+  bench --site test_site run-tests --app jarvis \
+    --module jarvis.tests.test_agent_run_lifecycle
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, add_to_date, now_datetime
+
+from jarvis import admin_client
+from jarvis.chat import agent_scheduler, agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+ACTIVITY = "Jarvis Agent Activity"
+SESSION = "Jarvis Chat Session"
+
+SLUG = "run-lifecycle-auditor"
+SCRIBE_SLUG = "run-lifecycle-scribe"
+OWNER = "run-lifecycle-owner@example.com"
+STRANGER = "run-lifecycle-stranger@example.com"
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		user.insert(ignore_permissions=True)
+		user.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing(slug: str, nature: str) -> str:
+	if not frappe.db.exists(LISTING, slug):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": slug,
+				"title": f"Run lifecycle {nature.lower()}",
+				"rule_tokens": json.dumps(["tok"]),
+				"doctypes_required": json.dumps([]),
+				"rule_pack": f"pack-{slug}",
+			}
+		).insert(ignore_permissions=True)
+	frappe.db.set_value(LISTING, slug, {"status": "Published", "nature": nature}, update_modified=False)
+	return slug
+
+
+def _wipe() -> None:
+	"""Everything these tests commit. The endpoints under test commit, so
+	FrappeTestCase's own rollback cannot reclaim any of it."""
+	for slug in (SLUG, SCRIBE_SLUG):
+		for name in frappe.get_all(RUN, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(RUN, name, force=True, ignore_permissions=True)
+		for name in frappe.get_all(ACTIVITY, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(ACTIVITY, name, force=True, ignore_permissions=True)
+		for name in frappe.get_all(
+			INSTALLATION, filters={"agent": slug}, pluck="name", ignore_permissions=True
+		):
+			frappe.delete_doc(INSTALLATION, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(
+		SESSION, filters={"session_key": ["like", "agent:agent-run-lifecycle%"]}, pluck="name"
+	):
+		frappe.delete_doc(SESSION, name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+class RunLifecycleTestCase(FrappeTestCase):
+	"""One published auditor + one published scribe, each installed for one owner."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user(OWNER)
+		cls.stranger = _mk_user(STRANGER)
+		_mk_listing(SLUG, "Auditor")
+		_mk_listing(SCRIBE_SLUG, "Scribe")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		_mk_listing(SLUG, "Auditor")
+		_mk_listing(SCRIBE_SLUG, "Scribe")
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	# ------------------------------------------------------------------ #
+	# fixtures
+	# ------------------------------------------------------------------ #
+	def _install(self, slug: str = SLUG) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": slug,
+				"run_as_user": self.owner,
+				"reviewer": self.owner,
+				"enabled": 1,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(INSTALLATION, doc.name, "owner", self.owner, update_modified=False)
+		# A claimed schedule slot (#672): _claim_slot advanced next_run_at BEFORE the
+		# dispatch, so these are the values a terminalization must leave untouched.
+		frappe.db.set_value(
+			INSTALLATION,
+			doc.name,
+			{
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"last_run_at": now_datetime(),
+				"next_run_at": add_days(now_datetime(), 1),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		return doc.name
+
+	def _run(self, inst: str, *, slug: str = SLUG, status: str = "running", age_s: int = 0, **extra) -> str:
+		"""A committed run row, optionally aged so a sweep's cutoff sees it."""
+		started = add_to_date(now_datetime(), seconds=-age_s)
+		doc = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": slug,
+				"installation": inst,
+				"trigger": "manual",
+				"status": "running",
+				"started_at": started,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		session_key = f"agent:agent-{slug}:{doc.name}"
+		frappe.get_doc({"doctype": SESSION, "session_key": session_key, "user": self.owner}).insert(
+			ignore_permissions=True
+		)
+		values = {"owner": self.owner, "session_key": session_key, "started_at": started, **extra}
+		if status != "running":
+			values["status"] = status
+		frappe.db.set_value(RUN, doc.name, values, update_modified=False)
+		frappe.db.commit()
+		return doc.name
+
+	def _status(self, run: str) -> str:
+		return frappe.db.get_value(RUN, run, "status")
+
+	def _slot(self, inst: str) -> dict:
+		return frappe.db.get_value(INSTALLATION, inst, ["next_run_at", "last_run_at"], as_dict=True)
+
+
+# --------------------------------------------------------------------------- #
+# A1 — ``stopped`` is a real, terminal run status
+# --------------------------------------------------------------------------- #
+class TestStoppedStatusIsTerminal(RunLifecycleTestCase):
+	def test_doctype_offers_stopped(self):
+		options = frappe.get_meta(RUN).get_field("status").options.split("\n")
+		self.assertIn("stopped", options)
+
+	def test_the_accepted_status_list_matches_the_doctype(self):
+		"""``agents_api._RUN_STATUSES`` is hand-maintained and is what the Runs page
+		validates a filter against, so a status added to the DocType and forgotten here
+		is a value the customer can see on a row but never filter by — and one removed
+		from the DocType and left here is a filter that silently matches nothing."""
+		options = {o.strip() for o in frappe.get_meta(RUN).get_field("status").options.split("\n")}
+		self.assertEqual(set(agents_api._RUN_STATUSES), options - {""})
+
+	def test_run_history_filter_accepts_stopped(self):
+		"""The Runs page must be able to filter on the new status — an accepted value
+		the list endpoint refuses is a status the customer can never look up."""
+		inst = self._install()
+		run = self._run(inst, status="stopped")
+		frappe.set_user(self.owner)
+		try:
+			rows = agents_api.list_runs_page(status="stopped")["rows"]
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn(run, [r["name"] for r in rows])
+
+	def test_stopped_run_is_not_live(self):
+		"""#672's liveness guard is keyed on ``status='running'``, so a stopped run must
+		not keep the installation's Run-now button (and the cron sweep) locked out."""
+		inst = self._install()
+		self._run(inst, status="stopped")
+		self.assertIsNone(agent_scheduler._live_run(inst))
+
+	def test_stopped_run_is_not_a_reaper_candidate(self):
+		"""The 3h backstop must never relabel an operator stop as a duration timeout."""
+		inst = self._install()
+		run = self._run(inst, status="stopped", age_s=agent_scheduler.STALE_RUN_AFTER_SECONDS + 60)
+		cutoff = add_to_date(now_datetime(), seconds=-agent_scheduler.STALE_RUN_AFTER_SECONDS)
+		self.assertNotIn(run, [r.name for r in agent_scheduler._stale_candidates(cutoff)])
+
+
+# --------------------------------------------------------------------------- #
+# A2 — stop_agent_run
+# --------------------------------------------------------------------------- #
+class TestStopAgentRun(RunLifecycleTestCase):
+	def _stop(self, run: str, *, as_user: str | None = None) -> dict:
+		"""Call the endpoint with the gateway abort stubbed out — it is best-effort and
+		its own test covers it; every other assertion here is about the durable state."""
+		user = as_user or self.owner
+		frappe.set_user(user)
+		try:
+			with patch.object(agents_api, "_try_abort_gateway_session"):
+				return agents_api.stop_agent_run(run)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_stop_terminalizes_a_running_run(self):
+		inst = self._install()
+		run = self._run(inst)
+		out = self._stop(run)
+
+		self.assertEqual(out["status"], "stopped")
+		row = frappe.db.get_value(RUN, run, ["status", "finished_at", "error"], as_dict=True)
+		self.assertEqual(row.status, "stopped")
+		self.assertTrue(row.finished_at)
+		self.assertIn("Stopped by operator", row.error)
+
+	def test_stop_revokes_the_run_session_bearer(self):
+		"""The bearer must not outlive the run: a late tool call from a delegate that is
+		still winding down must resolve no identity and 401, so nothing it does can write
+		back onto the stopped run."""
+		inst = self._install()
+		run = self._run(inst)
+		key = frappe.db.get_value(RUN, run, "session_key")
+		self.assertTrue(frappe.db.exists(SESSION, {"session_key": key}))
+		self._stop(run)
+		self.assertFalse(frappe.db.exists(SESSION, {"session_key": key}))
+
+	def test_stop_logs_the_activity(self):
+		inst = self._install()
+		run = self._run(inst)
+		self._stop(run)
+		rows = frappe.get_all(
+			ACTIVITY, filters={"run": run}, fields=["action", "owner"], ignore_permissions=True
+		)
+		self.assertEqual([r.action for r in rows], ["run_stopped"])
+		self.assertEqual(rows[0].owner, self.owner)
+
+	def test_stop_leaves_the_claimed_schedule_slot_consumed(self):
+		"""SLOT PARITY with the reaper: ``_claim_slot`` spent the slot BEFORE dispatch and
+		no terminalization hands it back, so a stopped run must not resurrect it — that
+		would re-dispatch the same slot on the next hourly tick."""
+		inst = self._install()
+		before = self._slot(inst)
+		run = self._run(inst)
+		self._stop(run)
+		self.assertEqual(self._slot(inst), before)
+
+	def test_a_stopped_run_still_counts_against_the_monthly_budget(self):
+		"""Deliberately UNLIKE ``failed`` (which A14 excludes so a skip path cannot make
+		the cap self-perpetuating): a stopped run really occupied the container, so
+		start-then-stop must not be an unlimited free-run loop around the budget."""
+		inst = self._install()
+		run = self._run(inst)
+		self._stop(run)
+		self.assertEqual(agent_scheduler._runs_this_month(installation=inst), 1)
+
+	def test_stop_is_idempotent_on_a_terminal_run(self):
+		"""A second click, or a stop racing a finish, must report the state the run
+		actually reached and never overwrite it."""
+		inst = self._install()
+		run = self._run(inst, status="completed")
+		out = self._stop(run)
+		self.assertEqual(out, {"ok": True, "status": "completed", "idempotent": True})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_stop_refuses_a_non_owner(self):
+		inst = self._install()
+		run = self._run(inst)
+		with self.assertRaises(frappe.PermissionError):
+			self._stop(run, as_user=self.stranger)
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_broken_gateway_abort_never_undoes_the_stop(self):
+		"""The soft stop is the guarantee; the gateway abort is opportunistic. The run
+		lane is dispatched with ``--expect-final`` rather than as a chat session, so this
+		call is expected to be a no-op in production — it must never raise out."""
+		inst = self._install()
+		run = self._run(inst)
+
+		class _Boom:
+			def __enter__(self):
+				raise RuntimeError("gateway down")
+
+			def __exit__(self, *a):
+				return False
+
+		frappe.set_user(self.owner)
+		try:
+			with patch("jarvis.chat.agent_session_pool.checkout", return_value=_Boom()):
+				out = agents_api.stop_agent_run(run)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(out["status"], "stopped")
+		self.assertEqual(self._status(run), "stopped")
+
+	def test_a_late_writeback_has_no_run_to_land_on(self):
+		"""``record_agent_run`` resolves its run SOLELY by the session_key on its bearer
+		row, and refuses anything that is not ``running``. Both doors are shut after a
+		stop: the bearer row is gone (so the lookup finds no run at all) and the status
+		is terminal (so even a surviving bearer would hit the idempotency branch)."""
+		inst = self._install()
+		run = self._run(inst)
+		key = frappe.db.get_value(RUN, run, "session_key")
+		self._stop(run)
+		self.assertFalse(frappe.db.exists(SESSION, {"session_key": key}))
+		self.assertNotEqual(self._status(run), "running")
+
+
+# --------------------------------------------------------------------------- #
+# A3 — poll_dispatched_runs
+# --------------------------------------------------------------------------- #
+# Comfortably past POLL_GRACE_SECONDS, so the row is a candidate for the sweep.
+DISPATCHED_S = agent_scheduler.POLL_GRACE_SECONDS + 180
+
+
+class TestPollDispatchedRuns(RunLifecycleTestCase):
+	def _poll(self, states: dict, default=None) -> list:
+		"""Run the sweep with the admin relay stubbed per run id. Returns the run ids it
+		was asked about, so a test can assert a run was NEVER polled (or count the calls
+		the circuit breaker allowed).
+
+		``default`` answers every run not named in ``states``, and defaults to "still
+		running" — this is a shared site and other modules leave ``running`` rows behind,
+		which the site-wide sweep would otherwise judge on this test's fixture."""
+		asked: list = []
+
+		def _status(run_id):
+			asked.append(run_id)
+			state = states.get(run_id, default if default is not None else {"status": "running"})
+			if isinstance(state, Exception):
+				raise state
+			return state
+
+		with patch.object(admin_client, "get_agent_run_status", side_effect=_status):
+			self.terminalized = agent_scheduler.poll_dispatched_runs()
+		return asked
+
+	def _relayed(self, state: dict) -> dict:
+		"""Admin's own success envelope around the fleet run-state — the shape the bench
+		really receives (``api/_responses._ok``), one level deeper than
+		``admin_client.get_agent_run_status``'s docstring reads."""
+		return {"ok": True, "data": state}
+
+	def _fleet_failed(self, message: str) -> dict:
+		return self._relayed({"status": "failed", "error": {"code": "run_failed", "message": message}})
+
+	def _fleet_completed(self, *, finished_ago_s: float, status: str = "done") -> dict:
+		# The fleet stamps finished_at as a UNIX epoch float, and its word for a clean
+		# exit is ``done`` (fleet-agent main.py, _dispatch_agent_run) - NOT ``completed``.
+		return self._relayed({"status": status, "finished_at": time.time() - finished_ago_s, "error": None})
+
+	# ------------------------------------------------------------------ #
+	def test_a_fleet_failure_is_surfaced_with_its_real_message(self):
+		"""The whole point of polling: the customer reads what actually broke, not the
+		reaper's "exceeded max duration" three hours later."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: self._fleet_failed("delegate exec died: exit 137")})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error", "finished_at"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("exit 137", row.error)
+		self.assertTrue(row.finished_at)
+
+	def test_a_young_run_is_never_polled(self):
+		"""A fresh dispatch is left alone entirely — no admin round trip per run per
+		tick while the delegate is still starting up."""
+		inst = self._install()
+		run = self._run(inst, age_s=10)
+		asked = self._poll({run: self._fleet_failed("should never be read")})
+		self.assertNotIn(run, asked)
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_stopped_run_is_never_reopened_by_a_later_fleet_flip(self):
+		"""The bench stop is authoritative. The fleet may report the same run failed
+		seconds later; the compare-and-set on ``status='running'`` is what keeps the
+		operator's verdict."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S, status="stopped")
+		self._poll({run: self._fleet_failed("late fleet failure")})
+		self.assertEqual(self._status(run), "stopped")
+
+	def test_an_unreachable_admin_leaves_every_run_alone(self):
+		"""A transport fault is never a verdict — the 3h reaper stays the backstop."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: AdminUnreachableError("admin is down")})
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_lost_run_record_is_left_alone_while_young(self):
+		"""A 404 from the host may just mean the state file is not visible yet
+		(container mid-restart), so a young run is not condemned on it."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: AdminUnreachableError("unknown agent run RUN-1")})
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_lost_run_record_fails_the_run_once_it_is_old(self):
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		run = self._run(inst, age_s=agent_scheduler.MISSING_RECORD_FALLBACK_SECONDS + 60)
+		self._poll({run: AdminUnreachableError("unknown agent run RUN-1")})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("no record of this run", row.error)
+
+	def test_the_relay_word_completed_is_read_like_the_fleet_word_done(self):
+		"""``done`` is what the fleet writes; ``completed`` must mean the same thing so a
+		normalising relay can never turn a clean exit back into "still in flight"."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll(
+			{
+				run: self._fleet_completed(
+					finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60, status="completed"
+				)
+			}
+		)
+		self.assertEqual(self._status(run), "failed")
+
+	def test_a_just_finished_run_is_given_its_writeback_grace(self):
+		"""Anchored on the HOST's finish time, not the run's age: this run is hours old
+		and finished ten seconds ago, so its writeback is still plausibly in flight."""
+		inst = self._install()
+		run = self._run(inst, age_s=agent_scheduler.STALE_RUN_AFTER_SECONDS - 60)
+		self._poll({run: self._fleet_completed(finished_ago_s=10)})
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_finished_run_whose_writeback_never_came_fails_honestly(self):
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: self._fleet_completed(finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60)})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("delegate finished without recording results", row.error)
+
+	def test_a_scribe_with_pages_is_completed_not_failed(self):
+		"""CA-4: the pages are already durably written, so a scribe that merely forgot to
+		call finish is an honest SUCCESS. The poll must reach the same ruling the reaper
+		does — they share the transition helper precisely so they cannot diverge."""
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(inst, slug=SCRIBE_SLUG, age_s=DISPATCHED_S, pages_written=4)
+		self._poll({run: self._fleet_completed(finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60)})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_a_scribe_with_a_zero_tally_is_rebuilt_from_page_provenance(self):
+		"""CA2-3: a stored tally of 0 is rebuilt from the pages themselves before any
+		verdict, so real work is never failed away on a false zero."""
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(inst, slug=SCRIBE_SLUG, age_s=DISPATCHED_S, pages_written=0)
+		meta = {"count": 2, "pages": [{"slug": "a", "title": "A"}, {"slug": "b", "title": "B"}]}
+		with patch("jarvis.tools.record_app_wiki.reconcile_run_pages", return_value=meta) as recon:
+			self._poll(
+				{run: self._fleet_completed(finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60)}
+			)
+		recon.assert_called_once_with(run)
+
+		row = frappe.db.get_value(RUN, run, ["status", "pages_written"], as_dict=True)
+		self.assertEqual(row.status, "completed")
+		self.assertEqual(row.pages_written, 2)
+
+	def test_a_still_running_fleet_state_is_left_alone(self):
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: self._relayed({"status": "running"})})
+		self.assertEqual(self._status(run), "running")
+
+	def test_an_unenveloped_run_state_is_read_too(self):
+		"""The relay shape is a cross-repo contract. Misreading the wrapper would leave
+		every poll seeing a blank status and terminalizing nothing — silently — so both
+		the enveloped and the bare state must be understood."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: {"status": "failed", "error": {"message": "bare shape"}}})
+		self.assertEqual(self._status(run), "failed")
+
+	# ------------------------------------------------------------------ #
+	# CA-4 parity: the scribe ruling is keyed on the run's own durable pages,
+	# NEVER on which sweep reached it or why.
+	# ------------------------------------------------------------------ #
+	def test_a_fleet_failed_scribe_with_pages_is_completed_not_failed(self):
+		"""A scribe that wrote its pages and then crashed late is a SUCCESS the delegate
+		merely never finalized. Failing it here would report the same row two different
+		ways depending on whether the poll or the 3h reaper got to it first."""
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(inst, slug=SCRIBE_SLUG, age_s=DISPATCHED_S, pages_written=5)
+		self._poll({run: self._fleet_failed("delegate exec died: exit 137")})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_a_lost_record_scribe_with_pages_is_completed_not_failed(self):
+		"""Same ruling when the host lost the run record entirely: the pages are in the
+		wiki either way, and a pruned state file is not evidence the work never happened."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(
+			inst,
+			slug=SCRIBE_SLUG,
+			age_s=agent_scheduler.MISSING_RECORD_FALLBACK_SECONDS + 60,
+			pages_written=3,
+		)
+		self._poll({run: AdminUnreachableError("unknown agent run RUN-1")})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_a_fleet_failed_auditor_still_fails(self):
+		"""The CA-4 carve-out is for scribes with durable pages ONLY — an auditor has no
+		such evidence and must still be failed with the delegate's real message."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S, pages_written=4)
+		self._poll({run: self._fleet_failed("evaluator blew up")})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("evaluator blew up", row.error)
+
+	# ------------------------------------------------------------------ #
+	# outage circuit breaker
+	# ------------------------------------------------------------------ #
+	def test_the_sweep_stops_calling_admin_after_two_transport_failures(self):
+		"""The sweep is sequential and each admin call can block for the client's full
+		150s timeout, so with admin down a handful of in-flight runs would outlast the
+		5-minute cron interval and sweeps would stack. Two consecutive transport failures
+		is enough evidence that the relay, not any one run, is the problem."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		runs = [self._run(inst, age_s=DISPATCHED_S) for _ in range(3)]
+
+		with patch.object(frappe, "log_error") as logged:
+			asked = self._poll({}, default=AdminUnreachableError("admin is down"))
+
+		self.assertEqual(len(asked), agent_scheduler.MAX_CONSECUTIVE_POLL_FAILURES)
+		self.assertEqual(self.terminalized, 0)
+		# ONE aggregate line for the whole sweep, never one per run.
+		self.assertEqual(logged.call_count, 1)
+		for run in runs:
+			self.assertEqual(self._status(run), "running")


### PR DESCRIPTION
## Summary

Backport of #1064 to `version-15-hotfix`. Operators can stop a running agent run, and a run whose delegate died after dispatch fails within minutes via a 5-minute poll instead of sitting running for 3 hours. Adds the `stopped` status on two DocTypes, so the release needs a migrate.

Cherry-picked with `-m 1 -x` from the develop merge commit.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`version-15-hotfix`)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01GvEjfCozT55Ms6su4twbmc
