### PR TITLE
feat(agents): land the #1058 stack (re-land of #1077, #1084, #1085, #1087) (backport #1095)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -764,10 +764,11 @@ export const listAgentRuns = (agent, limit) =>
 export const listAgentFindings = (p) => call(AG + "list_findings", p || {});
 export const setFindingState = (finding, state) =>
 	call(AG + "set_finding_state", { finding, state });
-// Role gating + listing admin (System Manager only - the server enforces it;
-// the SPA merely probes getAgentAdminOverview and hides the Admin tab on 403).
-export const setAgentRoles = (agent_slug, roles) =>
-	call(AG + "set_agent_roles", { agent_slug, roles: JSON.stringify(roles || []) });
+// Listing admin (System Manager only - the server enforces it; the SPA merely
+// probes getAgentAdminOverview and hides the Admin tab on 403). Access gating
+// moved to api/agents.setAgentAccess (jarvis#1062), which sets roles and named
+// users together; the set_agent_roles ENDPOINT survives as a compat shim for
+// cached older SPA builds, but nothing in this build calls it.
 export const setListingStatus = (agent_slug, status) =>
 	call(AG + "set_listing_status", { agent_slug, status });
 export const getAgentAdminOverview = () => call(AG + "get_agent_admin_overview");

--- a/frontend/src/api/agents.js
+++ b/frontend/src/api/agents.js
@@ -55,9 +55,20 @@ export const listAgentActivityPage = (p = {}) =>
 		page_length: p.page_length || 20,
 	});
 
+// One run's STEP TIMELINE, oldest first (jarvis#1062): what the bench observed
+// the run do - the launch dispatch, each jarvis__* tool the delegate called back
+// with, and the findings writeback. Steps carry shapes (DocType names, report
+// names, counts), never row contents. Ownership-gated server-side; a run the
+// caller cannot read returns an empty timeline. -> { steps: [...], count }
+export const listRunSteps = (run) => call(AG + "list_run_steps", { run });
+
 // Seed a new conversation from a finding and land the user in live chat.
 // -> { ok, conversation, run_id, reason }
 export const takeFindingToChat = (finding) => call(AG + "take_finding_to_chat", { finding });
+
+// #1061/#1062 operator stop: terminalize a RUNNING run early (idempotent on an
+// already-terminal one). -> { ok, status, idempotent? }
+export const stopAgentRun = (run) => call(AG + "stop_agent_run", { run });
 
 // ── PP-4 shadow -> live activation (jarvis#456) ──────────────────────────────
 // get_agent's `installation` shape is frozen (§8.3) and two in-flight PRs
@@ -86,3 +97,23 @@ export const promoteInstallation = (installation, justification) =>
 	call(AG + "promote_installation", { installation, justification: justification || "" });
 export const demoteInstallation = (installation, reason) =>
 	call(AG + "demote_installation", { installation, reason: reason || "" });
+
+// ── Access governance (jarvis#1062) ──────────────────────────────────────────
+// Replaces BOTH allow lists atomically. Access is deny-by-default: saving with
+// two empty lists CLOSES the agent to everyone but an admin, it does not reopen
+// it to everyone. `apply` additionally pushes the roster to the workspace (one
+// restart) - it belongs on the admin's action, never on a user's install.
+// -> { ok, allowed_roles: [str], allowed_users: [str], applied: bool }
+export const setAgentAccess = (agent_slug, roles, users, apply) =>
+	call(AG + "set_agent_access", {
+		agent_slug,
+		roles: JSON.stringify(roles || []),
+		users: JSON.stringify(users || []),
+		apply: apply ? 1 : 0,
+	});
+
+// Type-ahead source for the Access editor's user picker: enabled, named users
+// only (no Administrator/Guest - set_agent_access refuses them), capped at 20
+// server-side. Admin-gated, like the editor it feeds.
+// -> [{ name, full_name }]
+export const searchUsers = (q) => call(AG + "search_users", { q: q || "" });

--- a/frontend/src/components/doc/CommentsSection.vue
+++ b/frontend/src/components/doc/CommentsSection.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<div class="mb-4 flex items-center gap-2">
-			<span class="text-base font-semibold text-ink-gray-9">Comments</span>
+			<span class="text-base font-semibold text-ink-gray-9">{{ heading }}</span>
 			<Badge
 				v-if="comments.length"
 				variant="subtle"
@@ -57,7 +57,7 @@
 			</div>
 		</div>
 		<div v-else class="text-sm text-ink-gray-5">
-			No comments yet - be the first to add one.
+			{{ emptyText }}
 		</div>
 
 		<template v-if="canComment">
@@ -102,6 +102,10 @@ const CommentComposer = defineAsyncComponent(() => import("@/components/doc/Comm
 const props = defineProps({
 	docmeta: { type: Object, required: true }, // useDocmeta() object
 	canComment: { type: Boolean, default: false },
+	// jarvis#1062: Notes-on-a-Run (FindingsPanel.vue) reuses this same
+	// component/API against a different doctype - only the copy differs.
+	heading: { type: String, default: "Comments" },
+	emptyText: { type: String, default: "No comments yet - be the first to add one." },
 });
 
 const comments = computed(() => (props.docmeta.meta && props.docmeta.meta.comments) || []);

--- a/frontend/src/components/doc/DocSection.vue
+++ b/frontend/src/components/doc/DocSection.vue
@@ -1,16 +1,28 @@
 <template>
 	<div class="border-t py-4 first:border-t-0">
-		<div
-			class="flex h-8 max-w-fit items-center gap-1.5"
-			:class="{ 'cursor-pointer': collapsible }"
-			@click="collapsible && toggle()"
+		<!-- jarvis#1062 P0-1 (production-readiness audit): the toggle is
+		     scoped to this header button ONLY - a real <button>, not a <div>
+		     with @click, so it is keyboard-reachable (Enter/Space, native)
+		     and gets a visible focus-visible ring (P1-5) for free. The
+		     content below is a SEPARATE sibling with its own @click.stop
+		     belt-and-suspenders guard, so a click anywhere inside it (the
+		     textarea included) can never reach this handler regardless of
+		     how the slot content is structured. -->
+		<button
+			v-if="collapsible"
+			type="button"
+			class="flex h-8 max-w-fit items-center gap-1.5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+			@click="toggle"
 		>
 			<span
-				v-if="collapsible"
-				class="lucide-chevron-right h-4 text-ink-gray-9 transition-all duration-300 ease-in-out"
+				class="lucide-chevron-right h-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out"
 				:class="{ 'rotate-90': isOpened }"
 				aria-hidden="true"
 			/>
+			<span class="text-base font-semibold text-ink-gray-9">{{ label }}</span>
+			<slot name="header-suffix" />
+		</button>
+		<div v-else class="flex h-8 max-w-fit items-center gap-1.5">
 			<span class="text-base font-semibold text-ink-gray-9">{{ label }}</span>
 			<slot name="header-suffix" />
 		</div>
@@ -22,7 +34,7 @@
 			enter-from-class="max-h-0 overflow-hidden"
 			leave-to-class="max-h-0 overflow-hidden"
 		>
-			<div v-show="isOpened" class="pt-2">
+			<div v-show="isOpened" class="pt-2" @click.stop>
 				<slot />
 			</div>
 		</transition>
@@ -34,6 +46,24 @@
 // (rotate-90 when open), max-height transition, sections separated by border-t
 // (first:border-t-0). #header-suffix is additive (status badges next to the
 // label, e.g. macro "Summarized prompt").
+//
+// jarvis#1062 P0-1: production-readiness audit reported the Advanced (JSON)
+// panel (ConfigForm.vue) re-collapsing on a click inside its own expanded
+// textarea, with the chevron desynced from the content's open/closed state.
+// Neither reproduced here - an isolated DocSection mount and a full
+// ConfigForm mount both show a content click leaving `isOpened` (and
+// therefore both the chevron and the content) untouched, exactly as this
+// file's structure already implies (the header and the content are
+// SIBLINGS; only the header ever called toggle()). Most likely explanation:
+// a stale/different deployed build the audit ran against, or a live-only
+// CSS-transition screenshot-timing artifact on the chevron's own rotation
+// (a real click still flips the single `isOpened` ref both read from; jsdom
+// has no transition to lag). Hardened anyway, in case the real trigger is
+// something this reasoning missed: the header is now a real <button> (was a
+// <div> with @click - unreachable by keyboard and had no focus ring, a
+// separate defect worth fixing regardless) and the content wrapper carries
+// its own @click.stop, so a click inside it can never reach toggle() no
+// matter how the slotted content is restructured later.
 import { ref } from "vue";
 
 const props = defineProps({

--- a/frontend/src/components/doc/TechnicalDetails.spec.js
+++ b/frontend/src/components/doc/TechnicalDetails.spec.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import TechnicalDetails from "./TechnicalDetails.vue";
+
+// jarvis#1062 P0-2/P1-3 (production-readiness audit): TechnicalDetails is the
+// shared "collapsed, labelled, monospace" renderer for extractTechnicalDetails()
+// output, used by both a finding's expanded detail and the run coverage/warning
+// banners. It wraps DocSection directly (no frappe-ui import), so it can be
+// mounted for real here rather than stubbed.
+describe("TechnicalDetails", () => {
+	it("renders nothing at all - not even a header - when details is empty", () => {
+		const w = mount(TechnicalDetails, { props: { details: [] } });
+		expect(w.text()).toBe("");
+		expect(w.find("button").exists()).toBe(false);
+	});
+
+	it("renders a 'Technical details' header and one labelled dt/dd pair per entry", () => {
+		const w = mount(TechnicalDetails, {
+			props: {
+				details: [
+					{ label: "Rule", value: "nsv-tieout-7d92" },
+					{ label: "Field reference", value: "Warehouse.account" },
+				],
+			},
+		});
+		expect(w.text()).toContain("Technical details");
+		const rows = w.findAll("dl > div");
+		expect(rows).toHaveLength(2);
+		expect(rows[0].find("dt").text()).toBe("Rule");
+		expect(rows[0].find("dd").text()).toBe("nsv-tieout-7d92");
+		expect(rows[1].find("dt").text()).toBe("Field reference");
+		expect(rows[1].find("dd").text()).toBe("Warehouse.account");
+	});
+
+	it("is collapsed by default - the dl is present but not visible until the header is opened", () => {
+		const w = mount(TechnicalDetails, {
+			attachTo: document.body,
+			props: { details: [{ label: "Rule", value: "nsv-grad-7d92" }] },
+		});
+		expect(w.find("dl").isVisible()).toBe(false);
+		w.unmount();
+	});
+});

--- a/frontend/src/components/doc/TechnicalDetails.vue
+++ b/frontend/src/components/doc/TechnicalDetails.vue
@@ -1,0 +1,33 @@
+<template>
+	<DocSection
+		v-if="details.length"
+		label="Technical details"
+		:opened="false"
+		class="border-t-0 pt-0"
+	>
+		<dl class="space-y-1 text-xs">
+			<div v-for="(d, i) in details" :key="i" class="flex gap-2">
+				<dt class="w-32 shrink-0 text-ink-gray-5">{{ d.label }}</dt>
+				<dd class="min-w-0 flex-1 break-all font-mono text-ink-gray-7">{{ d.value }}</dd>
+			</div>
+		</dl>
+	</DocSection>
+</template>
+
+<script setup>
+// TechnicalDetails - jarvis#1062 P0-2/P1-3 (production-readiness audit):
+// findings and coverage banners are bundle-generated prose that carries
+// machine tokens (rule codes, boolean eval flags, "N class(es)
+// not_evaluable" counts, DocType.field references) - @/lib/findingText's
+// extractTechnicalDetails() pulls these out of the primary sentence; this
+// renders the result as a collapsed, labelled, monospace list. Shared by
+// FindingsPanel.vue's expanded finding AND its coverage/warning banners, so
+// there is exactly one place this ever renders differently.
+import DocSection from "@/components/doc/DocSection.vue";
+
+defineProps({
+	// [{label, value}] from extractTechnicalDetails - renders nothing (not
+	// even an empty DocSection header) when empty.
+	details: { type: Array, default: () => [] },
+});
+</script>

--- a/frontend/src/components/list/FilterValueControl.spec.js
+++ b/frontend/src/components/list/FilterValueControl.spec.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// frappe-ui's ESM entry does not resolve under vitest (see every other spec
+// in this app that imports from "frappe-ui").
+vi.mock("frappe-ui", () => ({
+	FormControl: {
+		name: "FormControl",
+		props: ["type", "label", "options", "modelValue", "placeholder", "ariaLabel"],
+		emits: ["update:modelValue"],
+		template: `<input class="fc-input" :type="type" :placeholder="placeholder" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+	Autocomplete: {
+		name: "Autocomplete",
+		props: ["options", "loading", "modelValue", "placeholder", "multiple"],
+		emits: ["update:query", "update:modelValue"],
+		template: `<div>
+			<input :placeholder="placeholder" @focus="$emit('update:query', '')" />
+			<button
+				v-for="o in options"
+				:key="o.value"
+				:data-option="o.value"
+				@click="$emit('update:modelValue', o)"
+			>{{ o.label }}</button>
+		</div>`,
+	},
+	DatePicker: { name: "DatePicker", template: "<div />" },
+	Badge: { name: "Badge", template: "<div><slot /><slot name='suffix' /></div>" },
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+}));
+
+const api = vi.hoisted(() => ({ searchLink: vi.fn().mockResolvedValue([]) }));
+vi.mock("@/api", () => api);
+
+import FilterValueControl from "./FilterValueControl.vue";
+
+// jarvis#1062 (composable extraction, useLinkSearch): FilterValueControl.vue's
+// Link search was the third of three near-identical debounced+fenced+primed
+// remote search copies, refactored onto the shared composable. It had no
+// spec at all before this - these cover the Link family end to end so the
+// refactor is actually verified, not just "the other two sites' tests still
+// pass".
+function linkEntry(overrides = {}) {
+	return {
+		fieldtype: "Link",
+		doctype: "Row DocType",
+		fieldname: "company",
+		options: "Company",
+		label: "Company",
+		...overrides,
+	};
+}
+
+function mountControl(entry, clauseOverrides = {}) {
+	return mount(FilterValueControl, {
+		props: {
+			entry,
+			clause: { fieldname: "company", operator: "=", value: "", ...clauseOverrides },
+		},
+	});
+}
+
+describe("FilterValueControl: Link search", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		api.searchLink.mockReset().mockResolvedValue([]);
+	});
+	afterEach(() => vi.useRealTimers());
+
+	it("primes on mount - the first page loads without a keystroke", async () => {
+		api.searchLink.mockResolvedValue([{ value: "Acme Ltd" }]);
+		const w = mountControl(linkEntry());
+		await vi.runAllTimersAsync();
+		await flushPromises();
+		expect(api.searchLink).toHaveBeenCalledWith("Company", "", 20, "Row DocType", "company");
+		expect(w.find('button[data-option="Acme Ltd"]').exists()).toBe(true);
+	});
+
+	it("debounces typing and picking a result emits the name, with the label kept as display", async () => {
+		api.searchLink.mockResolvedValue([{ value: "Acme Ltd" }]);
+		const w = mountControl(linkEntry());
+		await vi.runAllTimersAsync();
+		await flushPromises();
+		api.searchLink.mockClear();
+
+		w.findComponent({ name: "Autocomplete" }).vm.$emit("update:query", "ac");
+		expect(api.searchLink).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(300);
+		await flushPromises();
+		expect(api.searchLink).toHaveBeenCalledWith("Company", "ac", 20, "Row DocType", "company");
+
+		await w.find('button[data-option="Acme Ltd"]').trigger("click");
+		const emitted = w.emitted("update:value");
+		expect(emitted[emitted.length - 1][0]).toEqual({
+			value: "Acme Ltd",
+			display: null,
+			immediate: true,
+		});
+	});
+
+	it("sets a fallback reason and degrades to a text input when a typed query matches nothing, then recovers once results return", async () => {
+		const w = mountControl(linkEntry());
+		await vi.runAllTimersAsync();
+		await flushPromises();
+
+		api.searchLink.mockResolvedValueOnce([]);
+		w.findComponent({ name: "Autocomplete" }).vm.$emit("update:query", "zz");
+		await vi.advanceTimersByTimeAsync(300);
+		await flushPromises();
+		expect(w.text()).toContain("No Company matched. Enter the name directly.");
+		// the Link picker itself is gone - a single Link degrades to a name input
+		expect(w.findComponent({ name: "Autocomplete" }).exists()).toBe(false);
+
+		api.searchLink.mockResolvedValueOnce([{ value: "Acme Ltd" }]);
+		await w.find(".fc-input").setValue("ac");
+		await vi.advanceTimersByTimeAsync(300);
+		await flushPromises();
+		expect(w.text()).not.toContain("No Company matched");
+		// results came back - the picker is offered again
+		expect(w.findComponent({ name: "Autocomplete" }).exists()).toBe(true);
+	});
+
+	it("re-primes on a field/operator switch instead of keeping the old target's stale menu", async () => {
+		api.searchLink.mockResolvedValue([{ value: "Acme Ltd" }]);
+		const w = mountControl(linkEntry());
+		await vi.runAllTimersAsync();
+		await flushPromises();
+		expect(api.searchLink).toHaveBeenCalledTimes(1);
+
+		await w.setProps({
+			entry: linkEntry({ fieldname: "vendor", options: "Supplier" }),
+			clause: { fieldname: "vendor", operator: "=", value: "" },
+		});
+		await vi.runAllTimersAsync();
+		await flushPromises();
+		expect(api.searchLink).toHaveBeenCalledTimes(2);
+		expect(api.searchLink).toHaveBeenLastCalledWith(
+			"Supplier",
+			"",
+			20,
+			"Row DocType",
+			"vendor"
+		);
+	});
+});

--- a/frontend/src/components/list/FilterValueControl.vue
+++ b/frontend/src/components/list/FilterValueControl.vue
@@ -226,6 +226,7 @@ import {
 	TIMESPANS,
 } from "@/components/list/filterModel";
 import { searchLink } from "@/api";
+import { useLinkSearch } from "@/composables/useLinkSearch";
 
 const props = defineProps({
 	entry: { type: Object, default: null }, // schema field entry
@@ -383,22 +384,71 @@ function removeChip(i) {
 }
 
 // ── Link search (debounced + fenced) ────────────────────────────────────────
+// Shared debounce + fence + prime pattern (jarvis#1062, see useLinkSearch) -
 // 300ms debounce and a monotonic sequence, exactly like the DocType picker in
 // TriggerDetail: without the fence a slow "ab" response lands after "abcd" and
 // the dropdown shows options for a query the user has already moved past.
 const LINK_PAGE_LENGTH = 20; // plan §9's Link suggestion cap
-const linkOptions = ref([]);
-const linkLoading = ref(false);
 const linkTargetName = computed(() => linkTarget(props.entry));
 // Why the picker gave up, or "" while it is still useful.
 const linkFallbackReason = ref("");
 const linkFallback = computed(() => !linkTargetName.value || !!linkFallbackReason.value);
-let linkTimer = null;
-let linkSeq = 0;
+
+const linkSearch = useLinkSearch(
+	async (query) => {
+		const doctype = linkTargetName.value;
+		if (!doctype) return [];
+		// P1-06: pass WHERE this Link is used (its schema entry's own doctype +
+		// fieldname) so a custom search_link hook / user-permission rule can key
+		// off it. Untrusted context — the server still enforces the target's read
+		// permission — and the values come from the shared schema, not the client.
+		return searchLink(
+			doctype,
+			query,
+			LINK_PAGE_LENGTH,
+			props.entry && props.entry.doctype,
+			props.entry && props.entry.fieldname
+		);
+	},
+	{
+		mapper: (rows) =>
+			rows.map((r) => ({
+				// Title when the DocType has one, name otherwise; the VALUE is
+				// always the stable document name, which is what the filter submits.
+				label: r.label || r.value,
+				value: String(r.value),
+				description:
+					r.label && r.label !== r.value ? String(r.value) : r.description || "",
+			})),
+		onSettled({ rows, query, error }) {
+			const doctype = linkTargetName.value;
+			if (error) {
+				// A caller who may not search this DocType gets no suggestions; the
+				// clause is still usable by typing a name, so fall back instead of
+				// failing.
+				linkFallbackReason.value = `Can't search ${doctype}. Enter the name directly.`;
+				return;
+			}
+			if (rows.length) {
+				// Rows came back, so the picker is useful again. Clearing HERE
+				// rather than eagerly means the control never flickers while a
+				// query is in flight — and a typo downgrades the row only for as
+				// long as the typo lasts.
+				linkFallbackReason.value = "";
+			} else if (String(query || "").trim()) {
+				// Nothing came back for something the user actually typed: the
+				// picker has no more to offer, so hand them the input that can
+				// still express the filter rather than an empty dropdown.
+				linkFallbackReason.value = `No ${doctype} matched. Enter the name directly.`;
+			}
+		},
+	}
+);
+const linkOptions = linkSearch.options;
+const linkLoading = linkSearch.loading;
 
 function onLinkQuery(query) {
-	clearTimeout(linkTimer);
-	linkTimer = setTimeout(() => loadLinks(query || ""), 300);
+	linkSearch.onQuery(query);
 }
 
 // The picker opens with the first page already in it. Without this the dropdown
@@ -406,57 +456,8 @@ function onLinkQuery(query) {
 // DocType they were about to browse. Rows only mount when the panel opens, so
 // this costs one search per Link row per panel open.
 onMounted(() => {
-	if (control.value === "link" || control.value === "multi-link") loadLinks("");
+	if (control.value === "link" || control.value === "multi-link") linkSearch.prime();
 });
-
-async function loadLinks(query) {
-	const doctype = linkTargetName.value;
-	if (!doctype) return;
-	const seq = ++linkSeq;
-	linkLoading.value = true;
-	try {
-		// P1-06: pass WHERE this Link is used (its schema entry's own doctype +
-		// fieldname) so a custom search_link hook / user-permission rule can key
-		// off it. Untrusted context — the server still enforces the target's read
-		// permission — and the values come from the shared schema, not the client.
-		const rows = await searchLink(
-			doctype,
-			query,
-			LINK_PAGE_LENGTH,
-			props.entry && props.entry.doctype,
-			props.entry && props.entry.fieldname
-		);
-		if (seq !== linkSeq) return; // stale - a newer keystroke superseded this
-		linkOptions.value = (rows || []).map((r) => ({
-			// Title when the DocType has one, name otherwise; the VALUE is always
-			// the stable document name, which is what the filter submits.
-			label: r.label || r.value,
-			value: String(r.value),
-			description: r.label && r.label !== r.value ? String(r.value) : r.description || "",
-		}));
-		if (linkOptions.value.length) {
-			// Rows came back, so the picker is useful again. Clearing HERE rather
-			// than on entry to loadLinks means the control never flickers while a
-			// query is in flight — and it means a typo downgrades the row only for
-			// as long as the typo lasts.
-			linkFallbackReason.value = "";
-		} else if (String(query || "").trim()) {
-			// Nothing came back for something the user actually typed: the picker
-			// has no more to offer, so hand them the input that can still express
-			// the filter rather than an empty dropdown.
-			linkFallbackReason.value = `No ${doctype} matched. Enter the name directly.`;
-		}
-	} catch (e) {
-		// A caller who may not search this DocType gets no suggestions; the clause
-		// is still usable by typing a name, so fall back instead of failing.
-		if (seq === linkSeq) {
-			linkOptions.value = [];
-			linkFallbackReason.value = `Can't search ${doctype}. Enter the name directly.`;
-		}
-	} finally {
-		if (seq === linkSeq) linkLoading.value = false;
-	}
-}
 
 const linkModel = computed(() => {
 	if (control.value === "multi-link") return listModel.value;
@@ -495,16 +496,13 @@ function onListPick(options) {
 watch(
 	() => [props.clause.doctype, props.clause.fieldname, props.clause.operator].join("|"),
 	() => {
-		linkSeq += 1;
-		linkOptions.value = [];
-		linkLoading.value = false;
+		linkSearch.reprime(); // fences the old target's in-flight search, clears options
 		linkFallbackReason.value = "";
 		draft.value = "";
 		chipNote.value = "";
 		limitNote.value = "";
-		clearTimeout(linkTimer);
-		if (control.value === "link" || control.value === "multi-link") loadLinks("");
+		if (control.value === "link" || control.value === "multi-link") linkSearch.prime();
 	}
 );
-onBeforeUnmount(() => clearTimeout(linkTimer));
+onBeforeUnmount(() => linkSearch.cleanup());
 </script>

--- a/frontend/src/components/list/TabBar.spec.js
+++ b/frontend/src/components/list/TabBar.spec.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// frappe-ui's ESM entry does not resolve under vitest (see LlmPoolEditor.spec.js
+// and every other spec in this app that imports from "frappe-ui").
+vi.mock("frappe-ui", () => ({
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant", "size"],
+		template: `<span class="badge">{{ label }}</span>`,
+	},
+}));
+
+import TabBar from "./TabBar.vue";
+
+// jarvis#1062 P1-5 (production-readiness audit): a raw <button>, not
+// frappe-ui's <Button>, so it needs its own focus-visible ring - keyboard
+// tabbing through these tabs was otherwise invisible.
+describe("TabBar keyboard focus (jarvis#1062 P1-5)", () => {
+	it("every tab carries a focus-visible ring", () => {
+		const w = mount(TabBar, {
+			props: {
+				tabs: [
+					{ label: "Featured", value: "featured" },
+					{ label: "Available", value: "available" },
+				],
+				modelValue: "featured",
+			},
+		});
+		const tabs = w.findAll('[role="tab"]');
+		expect(tabs).toHaveLength(2);
+		for (const tab of tabs) {
+			expect(tab.classes()).toContain("focus-visible:ring-2");
+			expect(tab.classes()).toContain("focus-visible:ring-outline-gray-3");
+		}
+	});
+});

--- a/frontend/src/components/list/TabBar.vue
+++ b/frontend/src/components/list/TabBar.vue
@@ -1,11 +1,15 @@
 <template>
 	<div role="tablist" class="flex min-h-[45px] items-center gap-7.5 border-b px-5">
+		<!-- jarvis#1062 P1-5 (production-readiness audit): a raw <button>, so it
+		     needs its own focus-visible ring (frappe-ui's shared <Button>
+		     already carries one; this doesn't use that component) - keyboard
+		     tabbing through these tabs was otherwise invisible. -->
 		<button
 			v-for="tab in tabs"
 			:key="tab.value"
 			role="tab"
 			:aria-selected="modelValue === tab.value"
-			class="relative flex h-full min-h-[45px] items-center gap-1.5 text-base"
+			class="relative flex h-full min-h-[45px] items-center gap-1.5 rounded text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 			:class="
 				modelValue === tab.value
 					? 'text-ink-gray-9'

--- a/frontend/src/composables/useLinkSearch.js
+++ b/frontend/src/composables/useLinkSearch.js
@@ -1,0 +1,95 @@
+import { ref } from "vue";
+
+/**
+ * useLinkSearch - the debounced + monotonic-sequence + prime-on-focus remote
+ * search pattern, extracted from three near-identical copies (jarvis#1062):
+ * ConfigForm.vue's Company/Fiscal year picker, AgentAccessEditor.vue's people
+ * picker, and FilterValueControl.vue's generic Link search. All three share
+ * the same shape - an Autocomplete fed by a remote lookup that:
+ *
+ *   - loads its first page on focus/open rather than sitting empty until a
+ *     keystroke ("prime"), but only once per prime cycle;
+ *   - debounces further typing (each site's own interval - AgentAccessEditor
+ *     used 200ms, the other two 300ms, so the debounce here defaults to
+ *     300ms but stays a per-call option);
+ *   - fences every response with a monotonic sequence number, so a slow
+ *     earlier lookup can never overwrite a newer one's results; and
+ *   - can be told to forget it was ever primed - after a pick clears the
+ *     menu (AgentAccessEditor), or the search target itself changes
+ *     (FilterValueControl's field/operator switch) - so the next open (or an
+ *     immediate follow-up prime()) fetches fresh instead of reusing a stale
+ *     "already primed" flag.
+ *
+ * `fetcher(query)` is the only required argument - an async function
+ * returning raw rows (or throwing). Everything else is optional:
+ *   - `debounceMs` (default 300)
+ *   - `mapper(rows)` - reshape raw rows into whatever the caller's
+ *     Autocomplete needs (default: pass rows through unchanged), and
+ *   - `onSettled({ rows, query, error })` - a hook for state that depends on
+ *     how a search resolved beyond the options list itself (e.g.
+ *     FilterValueControl's "no matches, enter the name directly" fallback
+ *     copy). Never called for a response a newer request has superseded.
+ */
+export function useLinkSearch(fetcher, opts = {}) {
+	const { debounceMs = 300, mapper = (rows) => rows || [], onSettled } = opts;
+
+	const query = ref("");
+	const options = ref([]);
+	const loading = ref(false);
+	const primed = ref(false);
+	let seq = 0;
+	let timer = null;
+
+	async function runSearch(q) {
+		const mySeq = ++seq;
+		loading.value = true;
+		try {
+			const rows = (await fetcher(q || "")) || [];
+			if (mySeq !== seq) return; // a newer request already landed
+			options.value = mapper(rows);
+			loading.value = false;
+			if (onSettled) onSettled({ rows, query: q || "", error: null });
+		} catch (error) {
+			if (mySeq !== seq) return;
+			options.value = [];
+			loading.value = false;
+			if (onSettled) onSettled({ rows: [], query: q || "", error });
+		}
+	}
+
+	/** Loads the first page once per prime cycle - a no-op if already primed. */
+	function prime() {
+		if (primed.value) return;
+		primed.value = true;
+		runSearch(query.value);
+	}
+
+	/**
+	 * Forgets the current prime cycle and any in-flight/pending search, and
+	 * clears back to empty - the next prime() (immediate, or on the next
+	 * focus/open) fetches fresh. Does not fetch by itself; call prime()
+	 * right after it for an immediate reload.
+	 */
+	function reprime() {
+		seq += 1; // fence out a response still in flight from the old cycle
+		clearTimeout(timer);
+		primed.value = false;
+		query.value = "";
+		options.value = [];
+		loading.value = false;
+	}
+
+	function onQuery(q) {
+		query.value = q || "";
+		primed.value = true;
+		clearTimeout(timer);
+		timer = setTimeout(() => runSearch(query.value), debounceMs);
+	}
+
+	/** Cancels a pending debounced search - call from onBeforeUnmount. */
+	function cleanup() {
+		clearTimeout(timer);
+	}
+
+	return { options, query, onQuery, prime, reprime, loading, cleanup };
+}

--- a/frontend/src/composables/useLinkSearch.spec.js
+++ b/frontend/src/composables/useLinkSearch.spec.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useLinkSearch } from "./useLinkSearch";
+
+// jarvis#1062: the debounced + monotonic-sequence + prime-on-focus remote
+// search pattern, extracted from ConfigForm.vue, AgentAccessEditor.vue and
+// FilterValueControl.vue into one composable. These specs cover the
+// composable directly; each call site keeps its own specs unchanged to lock
+// in "zero behaviour change" from the refactor.
+describe("useLinkSearch", () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it("prime() fetches immediately with the current (empty) query, once per prime cycle", async () => {
+		const fetcher = vi.fn().mockResolvedValue([{ value: "a" }]);
+		const s = useLinkSearch(fetcher);
+		s.prime();
+		s.prime(); // no-op, already primed
+		await vi.runAllTimersAsync();
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		expect(fetcher).toHaveBeenCalledWith("");
+		expect(s.options.value).toEqual([{ value: "a" }]);
+	});
+
+	it("debounces onQuery - no fetch until the debounce interval elapses, then once", async () => {
+		const fetcher = vi.fn().mockResolvedValue([]);
+		const s = useLinkSearch(fetcher, { debounceMs: 300 });
+		s.onQuery("a");
+		s.onQuery("ab");
+		s.onQuery("abc");
+		expect(fetcher).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(300);
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		expect(fetcher).toHaveBeenCalledWith("abc");
+	});
+
+	it("honours a custom debounceMs", async () => {
+		const fetcher = vi.fn().mockResolvedValue([]);
+		const s = useLinkSearch(fetcher, { debounceMs: 200 });
+		s.onQuery("x");
+		await vi.advanceTimersByTimeAsync(199);
+		expect(fetcher).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores a stale response that resolves after a newer request", async () => {
+		let resolveFirst;
+		const fetcher = vi
+			.fn()
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+			.mockResolvedValueOnce([{ value: "second" }]);
+		const s = useLinkSearch(fetcher, { debounceMs: 0 });
+
+		s.onQuery("first");
+		await vi.advanceTimersByTimeAsync(0);
+		s.onQuery("second");
+		await vi.advanceTimersByTimeAsync(0);
+		// "second" resolves before "first" does
+		await Promise.resolve();
+		expect(s.options.value).toEqual([{ value: "second" }]);
+
+		resolveFirst([{ value: "first-stale" }]);
+		await Promise.resolve();
+		await Promise.resolve();
+		// the late "first" response must not clobber the newer "second" result
+		expect(s.options.value).toEqual([{ value: "second" }]);
+	});
+
+	it("applies mapper to raw rows and passes an empty array through unchanged when the fetcher returns nothing", async () => {
+		const fetcher = vi.fn().mockResolvedValue(null);
+		const s = useLinkSearch(fetcher, { mapper: (rows) => rows.map((r) => r.value) });
+		s.prime();
+		await vi.runAllTimersAsync();
+		expect(s.options.value).toEqual([]);
+	});
+
+	it("clears options and swallows the error on a rejected fetch", async () => {
+		const fetcher = vi.fn().mockRejectedValue(new Error("boom"));
+		const s = useLinkSearch(fetcher);
+		s.prime();
+		await vi.runAllTimersAsync();
+		expect(s.options.value).toEqual([]);
+	});
+
+	it("calls onSettled with the resolved rows and query, but not for a superseded response", async () => {
+		let resolveFirst;
+		const fetcher = vi
+			.fn()
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+			.mockResolvedValueOnce([{ value: "b" }]);
+		const onSettled = vi.fn();
+		const s = useLinkSearch(fetcher, { debounceMs: 0, onSettled });
+
+		s.onQuery("a");
+		await vi.advanceTimersByTimeAsync(0);
+		s.onQuery("b");
+		await vi.advanceTimersByTimeAsync(0);
+		await Promise.resolve();
+		expect(onSettled).toHaveBeenCalledTimes(1);
+		expect(onSettled).toHaveBeenCalledWith({
+			rows: [{ value: "b" }],
+			query: "b",
+			error: null,
+		});
+
+		resolveFirst([{ value: "a-stale" }]);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onSettled).toHaveBeenCalledTimes(1); // the stale "a" settle never fires
+	});
+
+	it("reprime() clears state and un-primes, so the next prime() fetches again", async () => {
+		const fetcher = vi.fn().mockResolvedValue([{ value: "a" }]);
+		const s = useLinkSearch(fetcher);
+		s.prime();
+		await vi.runAllTimersAsync();
+		expect(fetcher).toHaveBeenCalledTimes(1);
+
+		s.reprime();
+		expect(s.options.value).toEqual([]);
+		expect(s.query.value).toBe("");
+
+		s.prime();
+		await vi.runAllTimersAsync();
+		expect(fetcher).toHaveBeenCalledTimes(2);
+	});
+
+	it("reprime() cancels a pending debounced search so it never fires", async () => {
+		const fetcher = vi.fn().mockResolvedValue([]);
+		const s = useLinkSearch(fetcher, { debounceMs: 300 });
+		s.onQuery("partial");
+		s.reprime();
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("cleanup() cancels a pending debounced search", async () => {
+		const fetcher = vi.fn().mockResolvedValue([]);
+		const s = useLinkSearch(fetcher, { debounceMs: 300 });
+		s.onQuery("partial");
+		s.cleanup();
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/agentCategory.js
+++ b/frontend/src/lib/agentCategory.js
@@ -1,0 +1,23 @@
+/**
+ * Display title for an agent listing's `category` field.
+ *
+ * `sync_agent_listings` (agent_catalog.py) already maps the registry's
+ * `domain` code to a real label ("Accounts Payable", not "ap") before it ever
+ * reaches the SPA, so in the common case this is a passthrough. It still
+ * earns its keep for two edge cases:
+ *   - no category yet -> "Other"
+ *   - a raw slug a pre-migrate row might still carry (hyphen-split,
+ *     title-cased) until the next catalog sync overwrites it.
+ *
+ * Split out of AgentDetail.vue and AgentsList.vue (jarvis#1062 polish),
+ * where it was duplicated byte for byte.
+ *
+ * @param {unknown} value - `agent.category` (or any category-shaped string).
+ * @returns {string} a display-ready title.
+ */
+export function categoryTitle(value) {
+	return String(value || "Other")
+		.split("-")
+		.map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+		.join(" ");
+}

--- a/frontend/src/lib/agentCategory.spec.js
+++ b/frontend/src/lib/agentCategory.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { categoryTitle } from "./agentCategory";
+
+describe("categoryTitle", () => {
+	it("passes a real label straight through unchanged", () => {
+		expect(categoryTitle("Accounts Payable")).toBe("Accounts Payable");
+		expect(categoryTitle("CRM")).toBe("CRM");
+		expect(categoryTitle("Close and Reporting")).toBe("Close and Reporting");
+	});
+
+	it("falls back to Other for an empty/nullish category", () => {
+		expect(categoryTitle("")).toBe("Other");
+		expect(categoryTitle(null)).toBe("Other");
+		expect(categoryTitle(undefined)).toBe("Other");
+	});
+
+	it("title-cases a raw hyphenated slug (pre-migrate row fallback)", () => {
+		expect(categoryTitle("bank-recon")).toBe("Bank Recon");
+		expect(categoryTitle("hrms-payroll")).toBe("Hrms Payroll");
+	});
+});

--- a/frontend/src/lib/agentConfigFields.js
+++ b/frontend/src/lib/agentConfigFields.js
@@ -1,0 +1,193 @@
+/**
+ * The engagement-config keys ConfigForm.vue renders as real, purpose-built
+ * form fields (link pickers / dates / numbers / a select), in display order.
+ *
+ * Verified against the run path that actually reads them - not a schema:
+ *   - agent_scope.py's `_resolve`: company, fiscal_year, from_date, to_date -
+ *     the UNIVERSAL scope every run receives regardless of which agent it
+ *     is (`scope: true` below) - always rendered, flat (`path` === `key`).
+ *   - each agent's OWN bundle (jarvis-agents/agents/<slug>/evaluate.py) for
+ *     everything else - close-auditor's `_materiality_pl_balance` reads
+ *     benchmark_value/percentage/engagement_risk_level/rounding_step NESTED
+ *     under a top-level `materiality` object
+ *     (`config["materiality"]["benchmark_value"]`, etc - jarvis#1063
+ *     CRITICAL fix, they are NOT flat top-level keys), the only agent that
+ *     reads any agent-specific config today. Rendered only when the
+ *     listing's own `config_keys` (agents_api.py get_agent, jarvis#1063)
+ *     names the field's storage `path` (a dot path for a nested key) -
+ *     ConfigForm.vue filters this array by that list at render time.
+ *
+ * `key` is the LOCAL form-state / label / validation identity (unchanged by
+ * nesting); `path` is WHERE the value actually lives in the saved config
+ * JSON, as dot notation - `"company"` (flat, same as `key`) or
+ * `"materiality.benchmark_value"` (nested). ConfigForm.vue's seed()/save()
+ * read and write through `path`, with getPath/setPath/deletePath below;
+ * `key` alone would silently save to the wrong (flat, unread) location.
+ *
+ * A single exported constant on purpose (jarvis#1062 owner feedback): #1063
+ * (a per-agent DECLARED config schema) can swap this for a schema-generated
+ * list without touching ConfigForm's rendering logic, which only branches on
+ * `type` and filters agent-specific entries by `config_keys`.
+ *
+ * Shapes:
+ *   - {key, path, label, type: "link", linkDoctype, help, scope?}
+ *   - {keys: [from, to], paths: [from, to], labels: [from, to], type: "date-range", help, scope?}
+ *   - {key, path, label, type: "number", help, suffix?}
+ *   - {key, path, label, type: "select", options: [{label, value}, ...]}
+ */
+export const CONFIG_FIELD_SET = [
+	{
+		key: "company",
+		path: "company",
+		label: "Company",
+		type: "link",
+		linkDoctype: "Company",
+		help: "Defaults to your default company",
+		scope: true,
+	},
+	{
+		key: "fiscal_year",
+		path: "fiscal_year",
+		label: "Fiscal year",
+		type: "link",
+		linkDoctype: "Fiscal Year",
+		help: "Defaults to the current fiscal year",
+		scope: true,
+	},
+	{
+		type: "date-range",
+		keys: ["from_date", "to_date"],
+		paths: ["from_date", "to_date"],
+		labels: ["Period from", "Period to"],
+		help: "Optional; overrides the fiscal year",
+		scope: true,
+	},
+	{
+		key: "benchmark_value",
+		path: "materiality.benchmark_value",
+		label: "Materiality benchmark amount",
+		type: "number",
+		help: "Used to judge which differences matter",
+	},
+	{
+		key: "percentage",
+		path: "materiality.percentage",
+		label: "Materiality percentage",
+		type: "number",
+		suffix: "%",
+		help: "Auditors report checks as not evaluable when materiality is unset",
+	},
+	{
+		key: "engagement_risk_level",
+		path: "materiality.engagement_risk_level",
+		label: "Engagement risk level",
+		type: "select",
+		options: [
+			{ label: "-", value: "" },
+			{ label: "Low", value: "low" },
+			{ label: "Medium", value: "medium" },
+			{ label: "High", value: "high" },
+		],
+	},
+	{
+		key: "rounding_step",
+		path: "materiality.rounding_step",
+		label: "Rounding step",
+		type: "number",
+		help: "Step used to detect round-number plugs",
+	},
+];
+
+/** The always-rendered universal-scope subset (company/fiscal_year/period). */
+export const SCOPE_CONFIG_FIELDS = CONFIG_FIELD_SET.filter((f) => f.scope);
+
+/** The agent-specific subset - each rendered only when the listing's
+ * `config_keys` (get_agent) names its key. */
+export const AGENT_SPECIFIC_CONFIG_FIELDS = CONFIG_FIELD_SET.filter((f) => !f.scope);
+
+/** Every config key CONFIG_FIELD_SET renders a dedicated field for - anything
+ * else is an "unknown" key that ConfigForm.vue leaves untouched in its
+ * Advanced (JSON) editor. */
+export const KNOWN_CONFIG_KEYS = new Set(CONFIG_FIELD_SET.flatMap((f) => f.keys || [f.key]));
+
+/** key -> its field's human label, for save-time validation messages
+ * ("\"Materiality percentage\" must be a number."). */
+export const CONFIG_FIELD_LABELS = Object.fromEntries(
+	CONFIG_FIELD_SET.flatMap((f) =>
+		f.keys ? f.keys.map((k, i) => [k, f.labels[i]]) : [[f.key, f.label]]
+	)
+);
+
+/** The subset of known keys that are numeric on save (everyone else is a
+ * plain string, cleared to absent when blank). */
+export const NUMBER_CONFIG_KEYS = CONFIG_FIELD_SET.filter((f) => f.type === "number").map(
+	(f) => f.key
+);
+
+/** local form key -> its storage dot path ("company" flat, or
+ * "materiality.benchmark_value" nested). ConfigForm.vue's seed()/save() read
+ * and write through this, not the bare key - jarvis#1063 CRITICAL fix: a
+ * flat save of a key the bundle reads nested never reaches the evaluator. */
+export const KEY_TO_PATH = Object.fromEntries(
+	CONFIG_FIELD_SET.flatMap((f) =>
+		f.keys ? f.keys.map((k, i) => [k, (f.paths || f.keys)[i]]) : [[f.key, f.path || f.key]]
+	)
+);
+
+// ── dot-path get/set/delete over a plain JSON-shaped object ─────────────────
+// Depth is whatever a `path` names (1 for a flat key, 2 for "materiality.x");
+// these do not special-case depth. Exported so ConfigForm.vue's seed()/save()
+// and this module's own tests share one implementation.
+
+/** Reads `path` ("a.b.c") off `obj`; undefined if any segment is missing or
+ * not an object to descend into. */
+export function getPath(obj, path) {
+	let cur = obj;
+	for (const seg of path.split(".")) {
+		if (cur == null || typeof cur !== "object") return undefined;
+		cur = cur[seg];
+	}
+	return cur;
+}
+
+/** Sets `path` on `obj` to `value`, creating/reusing intermediate objects
+ * (an existing `materiality` object is MERGED into, not replaced). Mutates
+ * `obj`. */
+export function setPath(obj, path, value) {
+	const segs = path.split(".");
+	const last = segs.pop();
+	let cur = obj;
+	for (const seg of segs) {
+		if (cur[seg] === null || typeof cur[seg] !== "object" || Array.isArray(cur[seg])) {
+			cur[seg] = {};
+		}
+		cur = cur[seg];
+	}
+	cur[last] = value;
+}
+
+/** Deletes `path` off `obj`, then prunes any intermediate object left empty
+ * by the deletion (innermost first) - clearing the last `materiality.*`
+ * field drops the empty `materiality` object entirely, rather than leaving
+ * `{"materiality": {}}` behind. Mutates `obj`; no-ops if `path` does not
+ * resolve (already absent). */
+export function deletePath(obj, path) {
+	const segs = path.split(".");
+	const last = segs.pop();
+	const chain = [obj];
+	let cur = obj;
+	for (const seg of segs) {
+		if (cur == null || typeof cur !== "object" || !(seg in cur)) return;
+		cur = cur[seg];
+		chain.push(cur);
+	}
+	if (cur && typeof cur === "object") delete cur[last];
+	for (let i = chain.length - 1; i > 0; i--) {
+		const node = chain[i];
+		if (node && typeof node === "object" && Object.keys(node).length === 0) {
+			delete chain[i - 1][segs[i - 1]];
+		} else {
+			break;
+		}
+	}
+}

--- a/frontend/src/lib/agentConfigFields.spec.js
+++ b/frontend/src/lib/agentConfigFields.spec.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+	CONFIG_FIELD_SET,
+	SCOPE_CONFIG_FIELDS,
+	AGENT_SPECIFIC_CONFIG_FIELDS,
+	KNOWN_CONFIG_KEYS,
+	CONFIG_FIELD_LABELS,
+	NUMBER_CONFIG_KEYS,
+	KEY_TO_PATH,
+	getPath,
+	setPath,
+	deletePath,
+} from "./agentConfigFields";
+
+describe("CONFIG_FIELD_SET", () => {
+	it("covers exactly the 8 keys the run path reads (agent_scope.py + set_config docstring)", () => {
+		expect([...KNOWN_CONFIG_KEYS].sort()).toEqual(
+			[
+				"company",
+				"fiscal_year",
+				"from_date",
+				"to_date",
+				"benchmark_value",
+				"percentage",
+				"engagement_risk_level",
+				"rounding_step",
+			].sort()
+		);
+	});
+
+	it("orders Company, Fiscal year, the date pair, benchmark, percentage, risk, rounding", () => {
+		const order = CONFIG_FIELD_SET.map((f) => f.key || f.keys.join("/"));
+		expect(order).toEqual([
+			"company",
+			"fiscal_year",
+			"from_date/to_date",
+			"benchmark_value",
+			"percentage",
+			"engagement_risk_level",
+			"rounding_step",
+		]);
+	});
+
+	it("company and fiscal_year are link fields over the right DocType", () => {
+		const byKey = Object.fromEntries(
+			CONFIG_FIELD_SET.filter((f) => f.key).map((f) => [f.key, f])
+		);
+		expect(byKey.company).toMatchObject({ type: "link", linkDoctype: "Company" });
+		expect(byKey.fiscal_year).toMatchObject({ type: "link", linkDoctype: "Fiscal Year" });
+	});
+
+	it("engagement_risk_level offers exactly Low/Medium/High plus an unset option", () => {
+		const field = CONFIG_FIELD_SET.find((f) => f.key === "engagement_risk_level");
+		expect(field.options.map((o) => o.value)).toEqual(["", "low", "medium", "high"]);
+	});
+
+	it("only benchmark_value/percentage/rounding_step are numeric", () => {
+		expect(NUMBER_CONFIG_KEYS.sort()).toEqual(
+			["benchmark_value", "percentage", "rounding_step"].sort()
+		);
+	});
+
+	it("every field has a human label reachable from CONFIG_FIELD_LABELS", () => {
+		for (const key of KNOWN_CONFIG_KEYS) {
+			expect(CONFIG_FIELD_LABELS[key]).toBeTruthy();
+		}
+	});
+});
+
+// jarvis#1063 (jarvis-only half): ConfigForm.vue always renders
+// SCOPE_CONFIG_FIELDS and gates AGENT_SPECIFIC_CONFIG_FIELDS by the agent's
+// own config_keys - these two subsets must partition CONFIG_FIELD_SET.
+describe("SCOPE_CONFIG_FIELDS / AGENT_SPECIFIC_CONFIG_FIELDS", () => {
+	it("scope is exactly company, fiscal_year, the date pair - the universal dispatch scope", () => {
+		expect(SCOPE_CONFIG_FIELDS.map((f) => f.key || f.keys.join("/"))).toEqual([
+			"company",
+			"fiscal_year",
+			"from_date/to_date",
+		]);
+	});
+
+	it("agent-specific is exactly the close-auditor materiality/risk/rounding set", () => {
+		expect(AGENT_SPECIFIC_CONFIG_FIELDS.map((f) => f.key)).toEqual([
+			"benchmark_value",
+			"percentage",
+			"engagement_risk_level",
+			"rounding_step",
+		]);
+	});
+
+	it("the two subsets partition CONFIG_FIELD_SET with no overlap and no gap", () => {
+		expect(SCOPE_CONFIG_FIELDS.length + AGENT_SPECIFIC_CONFIG_FIELDS.length).toBe(
+			CONFIG_FIELD_SET.length
+		);
+		const scopeSet = new Set(SCOPE_CONFIG_FIELDS);
+		for (const f of AGENT_SPECIFIC_CONFIG_FIELDS) {
+			expect(scopeSet.has(f)).toBe(false);
+		}
+	});
+});
+
+// jarvis#1063 CRITICAL fix: close-auditor/evaluate.py reads its materiality
+// inputs NESTED under a top-level "materiality" object, not as flat
+// top-level keys - the scope keys stay flat (company, from_date, ...).
+describe("KEY_TO_PATH (local form key -> storage dot path)", () => {
+	it("scope keys are flat - path equals key", () => {
+		expect(KEY_TO_PATH.company).toBe("company");
+		expect(KEY_TO_PATH.fiscal_year).toBe("fiscal_year");
+		expect(KEY_TO_PATH.from_date).toBe("from_date");
+		expect(KEY_TO_PATH.to_date).toBe("to_date");
+	});
+
+	it("the materiality keys are nested dot paths", () => {
+		expect(KEY_TO_PATH.benchmark_value).toBe("materiality.benchmark_value");
+		expect(KEY_TO_PATH.percentage).toBe("materiality.percentage");
+		expect(KEY_TO_PATH.engagement_risk_level).toBe("materiality.engagement_risk_level");
+		expect(KEY_TO_PATH.rounding_step).toBe("materiality.rounding_step");
+	});
+});
+
+describe("getPath / setPath / deletePath (dot-path helpers)", () => {
+	it("getPath reads a flat and a nested path", () => {
+		const obj = { company: "Acme", materiality: { benchmark_value: 100 } };
+		expect(getPath(obj, "company")).toBe("Acme");
+		expect(getPath(obj, "materiality.benchmark_value")).toBe(100);
+	});
+
+	it("getPath returns undefined for a missing segment at any depth", () => {
+		expect(getPath({}, "materiality.benchmark_value")).toBeUndefined();
+		expect(getPath({ materiality: {} }, "materiality.benchmark_value")).toBeUndefined();
+		expect(getPath({ materiality: 5 }, "materiality.benchmark_value")).toBeUndefined();
+	});
+
+	it("setPath creates the intermediate object on a fresh target", () => {
+		const obj = {};
+		setPath(obj, "materiality.benchmark_value", 100);
+		expect(obj).toEqual({ materiality: { benchmark_value: 100 } });
+	});
+
+	it("setPath MERGES into an existing intermediate object rather than replacing it", () => {
+		const obj = { materiality: { pl_balance: 5000 } };
+		setPath(obj, "materiality.benchmark_value", 100);
+		expect(obj).toEqual({ materiality: { pl_balance: 5000, benchmark_value: 100 } });
+	});
+
+	it("deletePath removes just the leaf, siblings survive", () => {
+		const obj = { materiality: { benchmark_value: 100, percentage: 5 } };
+		deletePath(obj, "materiality.benchmark_value");
+		expect(obj).toEqual({ materiality: { percentage: 5 } });
+	});
+
+	it("deletePath prunes the intermediate object once it is left empty", () => {
+		const obj = { materiality: { benchmark_value: 100 } };
+		deletePath(obj, "materiality.benchmark_value");
+		expect(obj).toEqual({});
+	});
+
+	it("deletePath no-ops when the path does not resolve", () => {
+		const obj = { company: "Acme" };
+		deletePath(obj, "materiality.benchmark_value");
+		expect(obj).toEqual({ company: "Acme" });
+	});
+});

--- a/frontend/src/lib/agentRunStatus.js
+++ b/frontend/src/lib/agentRunStatus.js
@@ -1,0 +1,37 @@
+/**
+ * The Jarvis Agent Run lifecycle status -> frappe-ui Badge theme, in one
+ * place so every surface that shows a run's status (AgentRunsBoard's rail,
+ * AgentActivityTab's feed) reads the same colour for the same state.
+ *
+ * Split out of AgentRunsBoard.vue (jarvis#1062 owner feedback): the
+ * Activity feed's run rows need the SAME theme, not a second copy that can
+ * drift (e.g. "stopped" forgotten and falling back to the wrong grey).
+ */
+export const STATUS_THEME = {
+	running: "blue",
+	completed: "green",
+	partial: "orange",
+	failed: "red",
+	stopped: "gray",
+};
+
+/**
+ * jarvis#1062 P1-7 (production-readiness audit): a failed run and a stopped
+ * run both showed "0 findings" in the runs rail, with nothing distinguishing
+ * one from the other short of opening the run. A short, row-level reason:
+ * the first 60 chars of the recorded error for a failed run (truncated with
+ * an ellipsis, never the full trace - that lives in FindingsPanel's own
+ * failed-run banner), or the fixed "Stopped by operator." for a stopped run
+ * (an operator action, not a failure - no error text implied or needed).
+ * "" for every other status, so the row's v-if simply omits the line.
+ */
+export function runReason(row) {
+	if (!row) return "";
+	if (row.status === "failed") {
+		const err = String(row.error || "").trim();
+		if (!err) return "This run failed.";
+		return err.length > 60 ? err.slice(0, 60).trimEnd() + "…" : err;
+	}
+	if (row.status === "stopped") return "Stopped by operator.";
+	return "";
+}

--- a/frontend/src/lib/agentRunStatus.spec.js
+++ b/frontend/src/lib/agentRunStatus.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { STATUS_THEME, runReason } from "./agentRunStatus";
+
+describe("STATUS_THEME", () => {
+	it("covers every Jarvis Agent Run status with the app's theme colours", () => {
+		expect(STATUS_THEME).toEqual({
+			running: "blue",
+			completed: "green",
+			partial: "orange",
+			failed: "red",
+			stopped: "gray",
+		});
+	});
+});
+
+// jarvis#1062 P1-7 (production-readiness audit): failed vs stopped must be
+// distinguishable in the runs rail without opening the run.
+describe("runReason", () => {
+	it("returns the recorded error for a failed run, verbatim if 60 chars or under", () => {
+		expect(runReason({ status: "failed", error: "LLM timed out." })).toBe("LLM timed out.");
+	});
+
+	it("truncates a longer error to 60 chars with an ellipsis", () => {
+		const long = "A".repeat(80);
+		const out = runReason({ status: "failed", error: long });
+		expect(out).toBe("A".repeat(60) + "…");
+		expect(out.length).toBe(61);
+	});
+
+	it("falls back to a short generic message for a failed run with no recorded error", () => {
+		expect(runReason({ status: "failed", error: "" })).toBe("This run failed.");
+		expect(runReason({ status: "failed" })).toBe("This run failed.");
+	});
+
+	it("is always the fixed operator message for a stopped run, ignoring any error text", () => {
+		expect(runReason({ status: "stopped" })).toBe("Stopped by operator.");
+		expect(runReason({ status: "stopped", error: "whatever" })).toBe("Stopped by operator.");
+	});
+
+	it("is empty for every other status", () => {
+		expect(runReason({ status: "running" })).toBe("");
+		expect(runReason({ status: "completed" })).toBe("");
+		expect(runReason({ status: "partial" })).toBe("");
+	});
+
+	it("handles a missing row without throwing", () => {
+		expect(runReason(null)).toBe("");
+		expect(runReason(undefined)).toBe("");
+	});
+});

--- a/frontend/src/lib/agentsEmptyState.js
+++ b/frontend/src/lib/agentsEmptyState.js
@@ -1,0 +1,124 @@
+/**
+ * Which empty state the agents catalog shows, as a pure function of what we know.
+ *
+ * Split out of AgentsList.vue so it can be tested directly: mounting that view
+ * needs a router, useListPage, and half of frappe-ui, none of which have
+ * anything to do with the decision being made here.
+ *
+ * The decision that matters (jarvis#1062): agent access is DENY BY DEFAULT, so
+ * for a non-admin an empty list usually is not "the catalog is empty" but
+ * "nothing has been granted to you". Saying the former sends someone off to look
+ * for a bug that is not there, and the per-TAB copy is worse still - the
+ * Featured tab told them to go and browse the Available tab, which for that same
+ * user is equally empty. So a non-admin whose WHOLE visible catalog is empty
+ * gets one honest message on every tab, and no call to action, because there is
+ * no tab they could go to that would help.
+ *
+ * The per-tab states survive for everyone else: an admin (for whom an empty
+ * catalog really is an empty catalog), and a user who has some agents but none
+ * on the tab they are looking at.
+ */
+
+/** Copy for a non-admin who has been granted nothing at all. */
+export const NO_ACCESS_EMPTY_STATE = Object.freeze({
+	title: "No agents available to you",
+	description: "No agents have been made available to you yet. Ask your administrator.",
+	cta: false,
+});
+
+/**
+ * jarvis#1062 P2-9 (production-readiness audit): the session user
+ * "Administrator" (the Frappe superuser account, not a named person) is
+ * refused Install server-side (S3 owner-gate needs a real user) and the
+ * Install button is already disabled for it elsewhere (AgentDetail.vue) -
+ * but the empty Installed tab still said "install one to get started" with
+ * a working-looking CTA. Told straight instead: sign in as a named user.
+ */
+export const ADMINISTRATOR_CANNOT_INSTALL = Object.freeze({
+	title: "You haven't installed any agents yet",
+	description: "Administrator cannot install agents. Sign in as a named user.",
+	cta: false,
+});
+
+/**
+ * @param {object} state
+ * @param {string} state.tab              featured | available | installed
+ * @param {boolean} state.filtersActive   a search term or category is set
+ * @param {boolean} state.canAdminister   caps.admin - a tenant admin
+ * @param {boolean} [state.isAdministrator]
+ *        session.user === "Administrator" - the superuser account, refused
+ *        Install server-side regardless of caps.admin.
+ * @param {boolean|null} state.wholeCatalogEmpty
+ *        true/false once probed; null while unknown. Only meaningful for a
+ *        non-admin, and only probed when it is about to be needed.
+ * @returns {{title: string, description: string, cta: boolean}}
+ */
+export function agentsEmptyState({
+	tab,
+	filtersActive,
+	canAdminister,
+	isAdministrator,
+	wholeCatalogEmpty,
+}) {
+	// A filtered view that came back empty is about the FILTER, whoever is
+	// looking - checked first so it never gets misread as an access problem.
+	if (filtersActive) {
+		return {
+			title: "No agents match",
+			description: "Try clearing the search or category filter.",
+			cta: false,
+		};
+	}
+	// The access case wins over every per-tab message, on every tab.
+	if (!canAdminister && wholeCatalogEmpty === true) {
+		return { ...NO_ACCESS_EMPTY_STATE };
+	}
+	if (tab === "featured") {
+		return {
+			title: "No featured agents yet",
+			description: "Browse the Available tab for the full catalog.",
+			cta: true,
+		};
+	}
+	if (tab === "installed") {
+		if (isAdministrator) return { ...ADMINISTRATOR_CANNOT_INSTALL };
+		return {
+			title: "You haven't installed any agents yet",
+			description: "Browse the catalog and install one to get started.",
+			cta: true,
+		};
+	}
+	return {
+		title: "No agents available",
+		description: "The catalog is empty right now.",
+		cta: false,
+	};
+}
+
+/**
+ * Should the catalog be probed for "is this caller's whole catalog empty"?
+ *
+ * Deliberately LAZY - it costs a round trip, and the answer only changes what is
+ * rendered in the one situation where a tab has come back empty for a non-admin
+ * with no filters on. Probed once per mount: within one visit the set of agents
+ * granted to you does not change.
+ */
+export function shouldProbeWholeCatalog({
+	tab,
+	loading,
+	rowCount,
+	filtersActive,
+	canAdminister,
+	wholeCatalogEmpty,
+	probing,
+}) {
+	return (
+		["featured", "available", "installed"].includes(tab) &&
+		!loading &&
+		rowCount === 0 &&
+		!filtersActive &&
+		!canAdminister &&
+		wholeCatalogEmpty === null &&
+		!probing
+	);
+}

--- a/frontend/src/lib/agentsEmptyState.spec.js
+++ b/frontend/src/lib/agentsEmptyState.spec.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { agentsEmptyState, shouldProbeWholeCatalog } from "./agentsEmptyState";
+
+/**
+ * The bug this encodes: agent access is deny-by-default (jarvis#1062), so a
+ * plain user with nothing granted lands on the catalog and sees an empty list.
+ * The catalog opens on Featured, whose empty state said "No featured agents yet
+ * / Browse the Available tab for the full catalog" - pointing them at a tab that
+ * is just as empty, with a button that takes them there. The honest message has
+ * to win on EVERY tab for that user, and the call to action has to go, because
+ * there is nowhere to send them.
+ *
+ * The states it must NOT swallow are the reason this is a function and not an
+ * `if`: an admin looking at a genuinely empty catalog, and a user who has agents
+ * but none on the tab they happen to be on.
+ */
+
+const NO_ACCESS = "No agents have been made available to you yet. Ask your administrator.";
+
+const state = (over = {}) => ({
+	tab: "featured",
+	filtersActive: false,
+	canAdminister: false,
+	wholeCatalogEmpty: null,
+	...over,
+});
+
+// jarvis#1062 P2-9 (production-readiness audit): the Administrator session
+// (the Frappe superuser, not a named person) is refused Install
+// server-side (S3 owner-gate) - "Browse the catalog and install one to get
+// started" is a dead end for it specifically.
+describe("the Administrator session on the Installed tab", () => {
+	it("names Administrator specifically, no install CTA", () => {
+		const s = agentsEmptyState(
+			state({ tab: "installed", canAdminister: true, isAdministrator: true })
+		);
+		expect(s.title).toBe("You haven't installed any agents yet");
+		expect(s.description).toBe(
+			"Administrator cannot install agents. Sign in as a named user."
+		);
+		expect(s.cta).toBe(false);
+	});
+
+	it("does not apply to any other tab", () => {
+		for (const tab of ["featured", "available"]) {
+			const s = agentsEmptyState(state({ tab, canAdminister: true, isAdministrator: true }));
+			expect(s.description).not.toContain("Administrator cannot install");
+		}
+	});
+
+	it("does not apply to a named user, even with the same caps", () => {
+		const s = agentsEmptyState(
+			state({ tab: "installed", canAdminister: true, isAdministrator: false })
+		);
+		expect(s.description).toBe("Browse the catalog and install one to get started.");
+	});
+});
+
+describe("a non-admin with nothing granted", () => {
+	it.each(["featured", "available", "installed"])(
+		"shows the not-allowed copy on the %s tab",
+		(tab) => {
+			const s = agentsEmptyState(state({ tab, wholeCatalogEmpty: true }));
+			expect(s.description).toBe(NO_ACCESS);
+			expect(s.title).toBe("No agents available to you");
+		}
+	);
+
+	it("offers no call to action, since every tab is equally empty", () => {
+		// The regression itself: the Featured state's button sent them to Available.
+		const s = agentsEmptyState(state({ tab: "featured", wholeCatalogEmpty: true }));
+		expect(s.cta).toBe(false);
+	});
+
+	it("never mentions featured agents or browsing the catalog", () => {
+		for (const tab of ["featured", "available", "installed"]) {
+			const s = agentsEmptyState(state({ tab, wholeCatalogEmpty: true }));
+			expect(`${s.title} ${s.description}`).not.toMatch(/featured|browse/i);
+		}
+	});
+});
+
+describe("a non-admin who has some agents, just not here", () => {
+	it("keeps the per-tab installed copy", () => {
+		const s = agentsEmptyState(state({ tab: "installed", wholeCatalogEmpty: false }));
+		expect(s.title).toBe("You haven't installed any agents yet");
+		expect(s.description).toBe("Browse the catalog and install one to get started.");
+		expect(s.cta).toBe(true);
+	});
+
+	it("keeps the per-tab featured copy", () => {
+		const s = agentsEmptyState(state({ tab: "featured", wholeCatalogEmpty: false }));
+		expect(s.title).toBe("No featured agents yet");
+		expect(s.cta).toBe(true);
+	});
+});
+
+describe("an admin", () => {
+	it("gets the real 'catalog is empty' message, never the access one", () => {
+		// For an admin an empty catalog IS an empty catalog - telling them to ask
+		// their administrator would be telling them to ask themselves.
+		const s = agentsEmptyState(
+			state({ tab: "available", canAdminister: true, wholeCatalogEmpty: true })
+		);
+		expect(s.title).toBe("No agents available");
+		expect(s.description).toBe("The catalog is empty right now.");
+	});
+
+	it("keeps the per-tab states too", () => {
+		const s = agentsEmptyState(
+			state({ tab: "featured", canAdminister: true, wholeCatalogEmpty: true })
+		);
+		expect(s.title).toBe("No featured agents yet");
+	});
+});
+
+describe("filters", () => {
+	it("win over everything - an empty FILTERED view is about the filter", () => {
+		const s = agentsEmptyState(
+			state({ tab: "featured", filtersActive: true, wholeCatalogEmpty: true })
+		);
+		expect(s.title).toBe("No agents match");
+		expect(s.cta).toBe(false);
+	});
+});
+
+describe("before the probe answers", () => {
+	it("falls back to the per-tab copy rather than guessing at access", () => {
+		const s = agentsEmptyState(state({ tab: "featured", wholeCatalogEmpty: null }));
+		expect(s.title).toBe("No featured agents yet");
+	});
+});
+
+describe("shouldProbeWholeCatalog", () => {
+	const probe = (over = {}) => ({
+		tab: "featured",
+		loading: false,
+		rowCount: 0,
+		filtersActive: false,
+		canAdminister: false,
+		wholeCatalogEmpty: null,
+		probing: false,
+		...over,
+	});
+
+	it("probes for a non-admin looking at an unfiltered empty tab", () => {
+		expect(shouldProbeWholeCatalog(probe())).toBe(true);
+	});
+
+	it.each([
+		["the list still has rows", { rowCount: 3 }],
+		["the list is still loading", { loading: true }],
+		["a filter is narrowing it", { filtersActive: true }],
+		["the caller is an admin", { canAdminister: true }],
+		["the answer is already known", { wholeCatalogEmpty: false }],
+		["a probe is already in flight", { probing: true }],
+		["the tab is not a catalog tab", { tab: "activity" }],
+	])("does not probe when %s", (_why, over) => {
+		expect(shouldProbeWholeCatalog(probe(over))).toBe(false);
+	});
+});

--- a/frontend/src/lib/findingText.js
+++ b/frontend/src/lib/findingText.js
@@ -1,0 +1,121 @@
+/**
+ * jarvis#1062 P0-2 (production-readiness audit): findings/coverage text is
+ * bundle-generated prose (evaluator output, not authored copy) - it cannot be
+ * rewritten wholesale, but obvious machine tokens can be stripped/relocated
+ * where doing so is unambiguous and safe:
+ *
+ *   - a rule code ("nsv-grad-7d92", "nsv-tieout-7d92" - lowercase, hyphenated,
+ *     ending in an alnum id) read out of the sentence, not just the
+ *     structured `rule_id` field FindingsPanel.vue already has separately.
+ *   - an evaluation flag written as a parenthetical boolean,
+ *     e.g. "(clears reorder gate: False)".
+ *   - a DocType.field schema reference, e.g. "Warehouse.account".
+ *   - the literal token `not_evaluable` -> "not evaluable" wherever it
+ *     survives in running prose (the class-count case above already lifts
+ *     the common "N class(es) not_evaluable" phrasing out entirely; this is
+ *     a fallback for any other appearance).
+ *
+ * Conservative on purpose: unmatched text is returned untouched. A markdown
+ * link's `(url)` is never mistaken for a flag - the boolean-flag pattern
+ * requires a literal ": True"/": False" inside the parens, which a URL never
+ * contains - and a capitalised URL host inside a markdown link's target
+ * (e.g. "Example.com") is never mistaken for a DocType.field reference; see
+ * DOCTYPE_FIELD_RE below.
+ */
+
+// Rule ids in this codebase have an exact shape: <prefix>-<name>-<hex4>,
+// e.g. "nsv-grad-7d92", "nsv-tieout-7d92" (see jarvis-agents/agents/*/rules.
+// ids.json - the last segment is always exactly 4 lowercase hex chars, minted
+// as a truncated HMAC). Matching on "last segment has a digit" was too loose:
+// it also caught ordinary hyphenated prose ending in a number, e.g. an
+// "audit-run-2026" style phrase, and deleted it from the sentence. A bare
+// 4-char hex requirement alone still isn't enough - "2026" is itself valid
+// hex (all digits 0-9 are hex chars) - so the callback below additionally
+// requires the final segment to contain at least one a-f LETTER, matching
+// every id actually observed in rules.ids.json (7d92, 4b1c, 2a6f, e058) and
+// excluding plain 4-digit numbers like years.
+const RULE_CODE_RE = /\b([a-z][a-z0-9]*(?:-[a-z0-9]+)+-([0-9a-f]{4}))\b/g;
+const FLAG_RE = /\(([A-Za-z][\w\s]*:\s*(?:True|False))\)/g;
+const CLASS_COUNT_RE = /,?\s*with\s+(\d+)\s+class\(es\)\s+not_evaluable\b/gi;
+// DocType names are Title Case, one word ("Warehouse") in every example
+// observed in bundle prose; the field after the dot is always lower
+// snake_case. A multiword allowance was tried (per review suggestion, for
+// "Stock Ledger Entry.account") and reverted: bundle prose is imperative and
+// sentence-initial-capitalised constantly ("Configure Warehouse.account
+// first."), and there is no syntactic way to tell a real multiword DocType
+// name from an ordinary capitalised sentence-starter sitting in front of a
+// one-word reference - "Configure Warehouse.account" is indistinguishable
+// from "Stock Ledger Entry.account" by shape alone, and the former is far
+// more common here. Single-word only, so it never reaches backwards past a
+// word that isn't actually part of the reference.
+//
+// Review finding: a bare "[A-Z][A-Za-z]+\.[a-z]+" also matches a capitalised
+// URL host sitting inside a markdown link's target, e.g. "Example.com" in
+// "[the policy](https://Example.com/x)" - stripping it mangled the link.
+// Guarded on both sides against exactly that shape: not preceded by "//" (a
+// URL scheme/host) or "](" (a markdown link's target opening), and not
+// immediately followed by "/" (the rest of that URL) or ")" (the link's
+// closing paren) - a real DocType.field reference in running prose never
+// borders a URL like that. (The trailing guard's cost: "(Warehouse.account)"
+// with no space before the ")" is no longer extracted either - the same
+// heuristic the review asked for, applied evenly.)
+const DOCTYPE_FIELD_RE = /(?<!\/\/|\]\()\b([A-Z][A-Za-z]+\.[a-z][a-z_]*)\b(?![/)])/g;
+const RAW_TOKEN_RE = /\bnot_evaluable\b/g;
+
+/**
+ * Pulls the machine-shaped pieces of `text` out into a flat, de-duplicated
+ * list of labelled technical tokens, returning the REMAINING prose separately
+ * ({ text, details }). `details` is `[{label, value}]`, always monospace-safe
+ * plain strings - render it inside a "Technical details" block, never inline.
+ */
+export function extractTechnicalDetails(raw) {
+	let text = String(raw || "");
+	const details = [];
+	const seen = new Set();
+
+	function add(label, value) {
+		const key = label + ":" + value;
+		if (seen.has(key)) return;
+		seen.add(key);
+		details.push({ label, value });
+	}
+
+	text = text.replace(CLASS_COUNT_RE, (_, n) => {
+		add("Not evaluable", `${n} class${n === "1" ? "" : "es"}`);
+		return "";
+	});
+	text = text.replace(FLAG_RE, (_, flag) => {
+		add("Flag", flag);
+		return "";
+	});
+	text = text.replace(DOCTYPE_FIELD_RE, (m) => {
+		add("Field reference", m);
+		return "";
+	});
+	text = text.replace(RULE_CODE_RE, (m, _full, hex4) => {
+		if (!/[a-f]/.test(hex4)) return m; // e.g. "2026" - all-digit, not a real id suffix
+		add("Rule", m);
+		return "";
+	});
+	text = text.replace(RAW_TOKEN_RE, "not evaluable");
+	// collapse whitespace/punctuation debris left by the removals above -
+	// double spaces, a doubled ": :" where a rule code sat between two
+	// colons, a paren left with only leading/trailing space inside it once
+	// its own DocType.field content was pulled out ("(Warehouse.account
+	// empty)" -> "( empty)"), orphaned leading/trailing punctuation. This is
+	// tidy-up, not a grammar guarantee - arbitrary bundle prose run through
+	// a removal pass can still read slightly awkwardly; it is never left
+	// worse than the raw machine token it replaced.
+	text = text
+		.replace(/\(\s*\)/g, "")
+		.replace(/\(\s+/g, "(")
+		.replace(/\s+\)/g, ")")
+		.replace(/([,.;:])\s*\1+/g, "$1")
+		.replace(/\s{2,}/g, " ")
+		.replace(/\s+([,.;:])/g, "$1")
+		.replace(/^[\s,:;-]+/, "")
+		.replace(/[\s,:;-]+$/, "")
+		.trim();
+
+	return { text, details };
+}

--- a/frontend/src/lib/findingText.spec.js
+++ b/frontend/src/lib/findingText.spec.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { extractTechnicalDetails } from "./findingText";
+
+// jarvis#1062 P0-2 (production-readiness audit): findings/coverage prose is
+// bundle-generated - these fixtures are lifted verbatim (or near-verbatim)
+// from the audit's own screenshots, not invented examples.
+describe("extractTechnicalDetails", () => {
+	it("lifts a boolean evaluation flag out of its parenthetical", () => {
+		const { text, details } = extractTechnicalDetails(
+			"data-trust grade for Goods In Transit - ATD: FLAGGED (clears reorder gate: False)."
+		);
+		expect(text).not.toContain("clears reorder gate");
+		expect(text).not.toContain("False");
+		expect(details).toContainEqual({ label: "Flag", value: "clears reorder gate: False" });
+	});
+
+	it("lifts a 'N class(es) not_evaluable' phrase out entirely", () => {
+		const { text, details } = extractTechnicalDetails(
+			"graded on the classes that evaluated, with 1 class(es) not_evaluable."
+		);
+		expect(text).not.toContain("not_evaluable");
+		expect(text).not.toContain("class(es)");
+		expect(details).toContainEqual({ label: "Not evaluable", value: "1 class" });
+	});
+
+	it("pluralizes a multi-class count correctly", () => {
+		const { details } = extractTechnicalDetails("with 3 class(es) not_evaluable.");
+		expect(details).toContainEqual({ label: "Not evaluable", value: "3 classes" });
+	});
+
+	it("lifts a DocType.field schema reference", () => {
+		const { text, details } = extractTechnicalDetails(
+			"Configure no account<->warehouse mapping is populated (Warehouse.account empty)."
+		);
+		expect(text).not.toContain("Warehouse.account");
+		expect(details).toContainEqual({ label: "Field reference", value: "Warehouse.account" });
+	});
+
+	it("lifts a rule code (<prefix>-<name>-<hex4>, the real rules.ids.json shape)", () => {
+		const { text, details } = extractTechnicalDetails(
+			"nsv-tieout-7d92: Configure the mapping."
+		);
+		expect(text).not.toContain("nsv-tieout-7d92");
+		expect(details).toContainEqual({ label: "Rule", value: "nsv-tieout-7d92" });
+	});
+
+	it("never mistakes an ordinary English hyphenated compound for a rule code", () => {
+		const { text, details } = extractTechnicalDetails(
+			"This is an up-to-date, state-of-the-art check."
+		);
+		expect(text).toContain("up-to-date");
+		expect(text).toContain("state-of-the-art");
+		expect(details).toEqual([]);
+	});
+
+	it("never mistakes ordinary digit-bearing hyphenated prose for a rule code (last segment isn't 4 hex chars)", () => {
+		const { text, details } = extractTechnicalDetails(
+			"the form-16-reconciliation for q4-2026-close is not evaluable"
+		);
+		expect(text).toBe("the form-16-reconciliation for q4-2026-close is not evaluable");
+		expect(details).toEqual([]);
+	});
+
+	it("never mistakes an all-digit final segment (e.g. a year) for a rule-id hex suffix", () => {
+		const { text, details } = extractTechnicalDetails("see the audit-run-2026 log for detail");
+		expect(text).toBe("see the audit-run-2026 log for detail");
+		expect(details).toEqual([]);
+	});
+
+	it("substitutes a bare not_evaluable token that survives outside the class-count phrase", () => {
+		const { text } = extractTechnicalDetails("This check is not_evaluable right now.");
+		expect(text).toBe("This check is not evaluable right now.");
+	});
+
+	it("never mistakes a markdown link's (url) for a boolean flag", () => {
+		const { text, details } = extractTechnicalDetails(
+			"See [the policy](https://example.com/policy) for details."
+		);
+		expect(text).toContain("[the policy](https://example.com/policy)");
+		expect(details).toEqual([]);
+	});
+
+	it("never mangles a markdown link whose host happens to be capitalised", () => {
+		const { text, details } = extractTechnicalDetails(
+			"See [the policy](https://Example.com/policy) for details."
+		);
+		expect(text).toBe("See [the policy](https://Example.com/policy) for details.");
+		expect(details).toEqual([]);
+	});
+
+	it("never mangles a capitalised host in a protocol-less markdown link target either", () => {
+		const { text, details } = extractTechnicalDetails("See [the policy](Example.com/policy).");
+		expect(text).toBe("See [the policy](Example.com/policy).");
+		expect(details).toEqual([]);
+	});
+
+	it("still extracts a real DocType.field reference sitting next to a markdown link", () => {
+		const { text, details } = extractTechnicalDetails(
+			"See [the policy](https://example.com/policy) - Warehouse.account is empty."
+		);
+		expect(text).not.toContain("Warehouse.account");
+		expect(details).toContainEqual({ label: "Field reference", value: "Warehouse.account" });
+	});
+
+	it("never pulls a preceding capitalised sentence-starter into a one-word DocType.field reference", () => {
+		// A multiword allowance was tried and reverted: bundle prose is
+		// imperative and sentence-initial-capitalised constantly ("Configure
+		// Warehouse.account first."), and there is no syntactic way to tell a
+		// real multiword DocType name from an ordinary capitalised word sitting
+		// in front of a one-word reference.
+		const { text, details } = extractTechnicalDetails("Configure Warehouse.account first.");
+		expect(text).toBe("Configure first.");
+		expect(details).toContainEqual({ label: "Field reference", value: "Warehouse.account" });
+	});
+
+	it("does not extract a DocType.field reference with no space before its closing paren (the URL-guard's own cost)", () => {
+		const { text, details } = extractTechnicalDetails("(Warehouse.account)");
+		expect(text).toBe("(Warehouse.account)");
+		expect(details).toEqual([]);
+	});
+
+	it("handles the exact audit-screenshot coverage-note text without throwing, and pulls out both the rule code and the field reference", () => {
+		const raw =
+			"not evaluable: nsv-tieout-7d92: Configure no account<->warehouse mapping is populated for any scoped warehouse (Warehouse.account empty)";
+		const { text, details } = extractTechnicalDetails(raw);
+		expect(text).not.toContain("nsv-tieout-7d92");
+		expect(text).not.toContain("Warehouse.account");
+		expect(details).toContainEqual({ label: "Rule", value: "nsv-tieout-7d92" });
+		expect(details).toContainEqual({ label: "Field reference", value: "Warehouse.account" });
+	});
+
+	it("de-duplicates a token that appears more than once", () => {
+		const { details } = extractTechnicalDetails(
+			"nsv-grad-7d92 flagged this; see nsv-grad-7d92 for the rule."
+		);
+		expect(details.filter((d) => d.value === "nsv-grad-7d92")).toHaveLength(1);
+	});
+
+	it("returns an empty details list and the original text unchanged for plain prose", () => {
+		const { text, details } = extractTechnicalDetails("Everything looks fine.");
+		expect(text).toBe("Everything looks fine.");
+		expect(details).toEqual([]);
+	});
+
+	it("handles null/undefined/empty input without throwing", () => {
+		expect(extractTechnicalDetails(null)).toEqual({ text: "", details: [] });
+		expect(extractTechnicalDetails(undefined)).toEqual({ text: "", details: [] });
+		expect(extractTechnicalDetails("")).toEqual({ text: "", details: [] });
+	});
+});

--- a/frontend/src/lib/parseListField.js
+++ b/frontend/src/lib/parseListField.js
@@ -1,0 +1,26 @@
+/**
+ * Parse a backend "list field" that rides as either a JSON-array string
+ * (most listing fields - tools_required, min_apps, doctypes_required - are
+ * stored as JSON text) or an already-parsed array, into a plain string array.
+ *
+ * Split out of AgentDetail.vue (jarvis#1062 polish): `needs` (tools_required +
+ * min_apps) and `readsRecords` (doctypes_required) each reimplemented this
+ * exact parse-or-passthrough byte for byte. One helper, one place to fix a
+ * parse bug.
+ *
+ * @param {unknown} value - a JSON-array string, an array, or nullish/anything
+ *   else.
+ * @returns {string[]} the parsed values, coerced to strings; [] for anything
+ *   that isn't (or doesn't parse to) an array.
+ */
+export function parseListField(value) {
+	let v = value;
+	if (typeof v === "string" && v.trim()) {
+		try {
+			v = JSON.parse(v);
+		} catch (e) {
+			v = null;
+		}
+	}
+	return Array.isArray(v) ? v.map(String) : [];
+}

--- a/frontend/src/lib/parseListField.spec.js
+++ b/frontend/src/lib/parseListField.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { parseListField } from "./parseListField";
+
+describe("parseListField", () => {
+	it("parses a JSON-array string", () => {
+		expect(parseListField('["GL Entry","Account"]')).toEqual(["GL Entry", "Account"]);
+	});
+
+	it("passes an already-parsed array through, coercing entries to strings", () => {
+		expect(parseListField(["GL Entry", 1])).toEqual(["GL Entry", "1"]);
+	});
+
+	it("returns [] for an empty string", () => {
+		expect(parseListField("")).toEqual([]);
+	});
+
+	it("returns [] for null/undefined", () => {
+		expect(parseListField(null)).toEqual([]);
+		expect(parseListField(undefined)).toEqual([]);
+	});
+
+	it("returns [] for malformed JSON instead of throwing", () => {
+		expect(parseListField("{not json")).toEqual([]);
+	});
+
+	it("returns [] for valid JSON that isn't an array (e.g. an object)", () => {
+		expect(parseListField('{"a":1}')).toEqual([]);
+	});
+
+	it("returns [] for a whitespace-only string", () => {
+		expect(parseListField("   ")).toEqual([]);
+	});
+});

--- a/frontend/src/pages/agents/AgentAccessEditor.spec.js
+++ b/frontend/src/pages/agents/AgentAccessEditor.spec.js
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * AgentAccessEditor: the four behaviours that decide whether "Save access"
+ * means what an admin thinks it means.
+ *
+ *   1. The button is inert until something actually changed, and the unsaved
+ *      marker appears exactly when it is. The old two-step flow had a live Save
+ *      button and no marker, so an admin could not tell a saved list from a
+ *      half-edited one.
+ *   2. ONE save carries BOTH lists. Roles and users are two halves of one
+ *      access statement; saving them separately means passing through an access
+ *      state nobody chose.
+ *   3. The apply checkbox is what decides whether the workspace restarts, and
+ *      it is the ADMIN's choice - the toast differs so they know which of the
+ *      two things just happened.
+ *   4. A pending apply is polled to a terminal state, and a FAILED one says why
+ *      rather than reporting success.
+ */
+
+const agentsApi = vi.hoisted(() => ({
+	setAgentAccess: vi.fn(),
+	searchUsers: vi.fn(),
+}));
+vi.mock("@/api/agents", () => agentsApi);
+
+const api = vi.hoisted(() => ({ getAgentsSyncStatus: vi.fn() }));
+vi.mock("@/api", () => api);
+
+// frappe-ui's ESM entry does not resolve under vitest (see LlmPoolEditor.spec.js).
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("frappe-ui", () => ({
+	toast,
+	call: vi.fn(),
+	Button: {
+		name: "Button",
+		props: ["label", "loading", "disabled", "variant", "icon"],
+		emits: ["click"],
+		template: '<button :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
+	},
+	Autocomplete: {
+		name: "Autocomplete",
+		props: ["options", "modelValue", "placeholder"],
+		emits: ["update:modelValue", "update:query"],
+		template: "<div class='autocomplete'></div>",
+	},
+}));
+vi.mock("@/lib/errors", () => ({ errHtml: (e) => String((e && e.message) || e) }));
+
+import AgentAccessEditor from "./AgentAccessEditor.vue";
+
+const SAVED_ROLES = ["Accounts User"];
+const SAVED_USERS = ["ann@example.com"];
+
+function editor(props = {}) {
+	return mount(AgentAccessEditor, {
+		props: {
+			slug: "close-auditor",
+			roles: [...SAVED_ROLES],
+			users: [...SAVED_USERS],
+			allRoles: ["Accounts User", "Accounts Manager", "Stock User"],
+			...props,
+		},
+	});
+}
+
+const saveBtn = (w) => w.find('[data-test="save-access"]');
+// Roles first, People second - the same frappe-ui Autocomplete in both slots, which
+// is the point of the change: one control, one behaviour.
+const pickers = (w) => w.findAllComponents({ name: "Autocomplete" });
+const peoplePicker = (w) => pickers(w)[1];
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	agentsApi.setAgentAccess.mockReset();
+	agentsApi.searchUsers.mockReset().mockResolvedValue([]);
+	api.getAgentsSyncStatus.mockReset();
+	toast.success.mockReset();
+	toast.error.mockReset();
+	// Default: the save lands and reports back exactly what the draft asked for.
+	agentsApi.setAgentAccess.mockImplementation(async (slug, roles, users, apply) => ({
+		ok: true,
+		allowed_roles: roles,
+		allowed_users: users,
+		applied: !!apply,
+	}));
+});
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("dirty state", () => {
+	it("starts clean: no marker, save disabled", () => {
+		const w = editor();
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(false);
+		expect(saveBtn(w).attributes("disabled")).toBeDefined();
+	});
+
+	it("marks dirty and enables save once a role is removed", async () => {
+		const w = editor();
+		w.vm.roleDraft = [];
+		await flushPromises();
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(true);
+		expect(saveBtn(w).attributes("disabled")).toBeUndefined();
+	});
+
+	it("a change that nets out to the saved value is NOT dirty", async () => {
+		// Order must not count as a change: the server returns its own order and an
+		// admin who removes and re-adds the same role has changed nothing.
+		const w = editor({ roles: ["A", "B"], users: [] });
+		w.vm.roleDraft = ["B", "A"];
+		await flushPromises();
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(false);
+	});
+
+	it("goes clean again after a successful save", async () => {
+		api.getAgentsSyncStatus.mockResolvedValue({ pending: false, last_sync_status: "ok" });
+		const w = editor();
+		w.vm.roleDraft = ["Stock User"];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(false);
+	});
+});
+
+describe("one save carries both lists", () => {
+	it("sends roles AND users in a single call", async () => {
+		api.getAgentsSyncStatus.mockResolvedValue({ pending: false, last_sync_status: "ok" });
+		const w = editor();
+		w.vm.roleDraft = ["Stock User"];
+		w.vm.userDraft = ["bo@example.com"];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+
+		expect(agentsApi.setAgentAccess).toHaveBeenCalledTimes(1);
+		const [slug, roles, users] = agentsApi.setAgentAccess.mock.calls[0];
+		expect(slug).toBe("close-auditor");
+		expect(roles).toEqual(["Stock User"]);
+		expect(users).toEqual(["bo@example.com"]);
+	});
+
+	it("emits the saved value so the page can update without a refetch", async () => {
+		api.getAgentsSyncStatus.mockResolvedValue({ pending: false, last_sync_status: "ok" });
+		const w = editor();
+		w.vm.userDraft = [];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+		expect(w.emitted("saved")[0][0]).toEqual({
+			allowed_roles: SAVED_ROLES,
+			allowed_users: [],
+		});
+	});
+
+	it("saving an empty pair is allowed - it CLOSES the agent, it does not open it", async () => {
+		api.getAgentsSyncStatus.mockResolvedValue({ pending: false, last_sync_status: "ok" });
+		const w = editor();
+		w.vm.roleDraft = [];
+		w.vm.userDraft = [];
+		await flushPromises();
+		expect(saveBtn(w).attributes("disabled")).toBeUndefined();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+		const [, roles, users] = agentsApi.setAgentAccess.mock.calls[0];
+		expect(roles).toEqual([]);
+		expect(users).toEqual([]);
+	});
+});
+
+describe("saving always applies", () => {
+	it("offers no opt-out and always asks the server to apply", async () => {
+		// The checkbox is gone on purpose: access that is saved but not loaded is a
+		// half-done action, and the roster silently disagreeing with the database is
+		// the bug class this feature keeps designing around.
+		api.getAgentsSyncStatus.mockResolvedValue({ pending: false, last_sync_status: "ok" });
+		const w = editor();
+		expect(w.find('[data-test="apply-now"]').exists()).toBe(false);
+
+		w.vm.roleDraft = [];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+
+		expect(agentsApi.setAgentAccess.mock.calls[0][3]).toBe(true);
+	});
+
+	it("states the restart cost as a fact rather than a choice", async () => {
+		const w = editor();
+		const note = w.find('[data-test="apply-note"]').text();
+		expect(note).toContain("Saving loads this agent on your workspace");
+		expect(note).toContain("restarts for about 30 seconds");
+		expect(note).toContain("active chats are interrupted");
+	});
+});
+
+describe("apply progress", () => {
+	it("shows the pending badge, polls, then reports success", async () => {
+		api.getAgentsSyncStatus
+			.mockResolvedValueOnce({ pending: true })
+			.mockResolvedValueOnce({ pending: false, last_sync_status: "ok" });
+		const w = editor();
+		w.vm.roleDraft = [];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+
+		expect(w.find('[data-test="apply-pending"]').exists()).toBe(true);
+		expect(toast.success).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(3000);
+		await flushPromises();
+
+		expect(w.find('[data-test="apply-pending"]').exists()).toBe(false);
+		expect(toast.success).toHaveBeenCalledWith("Access saved and applied.");
+	});
+
+	it("a failed apply surfaces the reason, never a success toast", async () => {
+		api.getAgentsSyncStatus.mockResolvedValue({
+			pending: false,
+			last_sync_status: "failed: workspace refused the roster",
+		});
+		const w = editor();
+		w.vm.roleDraft = [];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+
+		// Classified by the real humaniseSyncStatus (not mocked here on purpose:
+		// the point is that this toast and the catalog's apply pill read the same
+		// status the same way).
+		expect(toast.error).toHaveBeenCalledWith(
+			expect.stringContaining("workspace refused the roster")
+		);
+		expect(toast.success).not.toHaveBeenCalled();
+		expect(w.find('[data-test="apply-pending"]').exists()).toBe(false);
+	});
+
+	it("a rejected save leaves the draft intact so the edit is not lost", async () => {
+		agentsApi.setAgentAccess.mockRejectedValue(new Error("You need the Jarvis Admin role"));
+		const w = editor();
+		w.vm.roleDraft = ["Stock User"];
+		await flushPromises();
+		await saveBtn(w).trigger("click");
+		await flushPromises();
+
+		expect(toast.error).toHaveBeenCalledWith("You need the Jarvis Admin role");
+		expect(w.vm.roleDraft).toEqual(["Stock User"]);
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(true);
+	});
+});
+
+describe("a props refresh mid-edit", () => {
+	it("keeps unsaved draft edits and stays dirty", async () => {
+		// The parent reloads the agent for unrelated reasons - toggling Enabled
+		// calls load() and reassigns `agent` - and that used to silently discard a
+		// half-finished access edit.
+		const w = editor();
+		w.vm.roleDraft = ["Stock User"];
+		await flushPromises();
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(true);
+
+		await w.setProps({ roles: ["Accounts Manager"], users: [...SAVED_USERS] });
+		await flushPromises();
+
+		expect(w.vm.roleDraft).toEqual(["Stock User"]);
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(true);
+	});
+
+	it("reseeds the drafts when there is nothing to lose", async () => {
+		const w = editor();
+		await w.setProps({ roles: ["Accounts Manager"], users: [] });
+		await flushPromises();
+
+		expect(w.vm.roleDraft).toEqual(["Accounts Manager"]);
+		expect(w.vm.userDraft).toEqual([]);
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(false);
+	});
+
+	it("a kept draft that now matches the new baseline reads as clean", async () => {
+		// dirty is recomputed against the NEW baseline, so the indicator never
+		// claims an unsaved change that the server already holds.
+		const w = editor();
+		w.vm.roleDraft = ["Stock User"];
+		await flushPromises();
+		await w.setProps({ roles: ["Stock User"], users: [...SAVED_USERS] });
+		await flushPromises();
+
+		expect(w.find('[data-test="access-dirty"]').exists()).toBe(false);
+	});
+});
+
+describe("out-of-order user searches", () => {
+	it("ignores a slow earlier response that lands after a newer one", async () => {
+		// Typing "ne" then "newe" and having "ne" resolve second used to repopulate
+		// the menu with results for a prefix the admin had already moved past.
+		let resolveFirst;
+		agentsApi.searchUsers
+			.mockImplementationOnce(() => new Promise((r) => (resolveFirst = r)))
+			.mockImplementationOnce(async () => [
+				{ name: "newer@example.com", full_name: "Newer" },
+			]);
+
+		const w = editor();
+		peoplePicker(w).vm.$emit("update:query", "ne");
+		await vi.advanceTimersByTimeAsync(200);
+		peoplePicker(w).vm.$emit("update:query", "newe");
+		await vi.advanceTimersByTimeAsync(200);
+		await flushPromises();
+
+		// The newer request has already landed; now the stale one answers.
+		resolveFirst([{ name: "stale@example.com", full_name: "Stale" }]);
+		await flushPromises();
+
+		expect(w.vm.userOptions.map((o) => o.value)).toEqual(["newer@example.com"]);
+	});
+});
+
+describe("opening the people picker", () => {
+	it("uses the same Autocomplete as the roles picker, not a bespoke widget", () => {
+		// Standing directive: SPA UI is frappe-ui, and a control must match the one
+		// beside it. This also fixed a transparent hand-rolled popup that read
+		// through onto the helper text and the Save button.
+		const w = editor();
+		expect(pickers(w)).toHaveLength(2);
+		expect(peoplePicker(w).props("placeholder")).toBe("Add a person…");
+	});
+
+	it("fetches with the current (empty) query and renders the results", async () => {
+		// The picker used to sit empty until the admin guessed a letter; search_users
+		// answers an empty term with the first 20 enabled users, which is the "who is
+		// there?" that opening it is actually asking.
+		agentsApi.searchUsers.mockResolvedValue([
+			{ name: "bo@example.com", full_name: "Bo" },
+			{ name: "cy@example.com", full_name: "Cy" },
+		]);
+		const w = editor();
+		w.vm.primeUserMenu();
+		await flushPromises();
+
+		expect(agentsApi.searchUsers).toHaveBeenCalledWith("");
+		// Fed to the picker as its options, in frappe-ui's {label, value} shape.
+		expect(
+			peoplePicker(w)
+				.props("options")
+				.map((o) => o.value)
+		).toEqual(["bo@example.com", "cy@example.com"]);
+	});
+
+	it("debounces typing into a remote search and adds the pick as a chip", async () => {
+		agentsApi.searchUsers.mockResolvedValue([{ name: "dee@example.com", full_name: "Dee" }]);
+		const w = editor();
+
+		peoplePicker(w).vm.$emit("update:query", "de");
+		expect(agentsApi.searchUsers).not.toHaveBeenCalled(); // debounced, not per keystroke
+		await vi.advanceTimersByTimeAsync(200);
+		await flushPromises();
+		expect(agentsApi.searchUsers).toHaveBeenCalledWith("de");
+
+		peoplePicker(w).vm.$emit("update:modelValue", { label: "Dee", value: "dee@example.com" });
+		await flushPromises();
+		expect(w.vm.userDraft).toContain("dee@example.com");
+		expect(w.findAll('[data-test="user-chip"]').length).toBe(2);
+	});
+
+	it("does not refetch while the menu is already primed", async () => {
+		agentsApi.searchUsers.mockResolvedValue([{ name: "bo@example.com", full_name: "Bo" }]);
+		const w = editor();
+		w.vm.primeUserMenu();
+		w.vm.primeUserMenu();
+		await flushPromises();
+		expect(agentsApi.searchUsers).toHaveBeenCalledTimes(1);
+	});
+
+	it("primes again after a pick, so reopening still offers people", async () => {
+		agentsApi.searchUsers.mockResolvedValue([{ name: "bo@example.com", full_name: "Bo" }]);
+		const w = editor();
+		w.vm.primeUserMenu();
+		await flushPromises();
+
+		w.vm.addUser("bo@example.com"); // selects, and clears the menu
+		expect(w.vm.userDraft).toContain("bo@example.com");
+
+		w.vm.primeUserMenu();
+		await flushPromises();
+		expect(agentsApi.searchUsers).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/pages/agents/AgentAccessEditor.vue
+++ b/frontend/src/pages/agents/AgentAccessEditor.vue
@@ -1,0 +1,341 @@
+<!-- The Admin tab's ONE access control (jarvis#1062).
+
+     It replaced a two-step flow: a role picker with its own "Save roles" button,
+     and no way at all to grant a single named person. Now roles and users are
+     edited together and saved once, because they are two halves of one
+     statement - moving somebody from a role grant to a named grant used to mean
+     two saves with an unintended access state in between.
+
+     Access is DENY BY DEFAULT. An empty pair does not mean "everyone"; it means
+     admins only, and the copy here says so rather than leaving the admin to
+     infer the inversion from a blank list.
+
+     Extracted from AgentDetail.vue so it can be spec-tested on its own: the
+     parent needs a router, a session and half of frappe-ui to mount at all. -->
+<template>
+	<section>
+		<div class="flex items-center gap-2">
+			<div class="text-base font-medium text-ink-gray-9">Access</div>
+			<span
+				v-if="dirty"
+				data-test="access-dirty"
+				title="Unsaved changes"
+				class="inline-flex items-center gap-1 text-sm text-ink-amber-2"
+			>
+				<span class="size-1.5 rounded-full bg-surface-amber-2"></span>
+				Unsaved changes
+			</span>
+		</div>
+		<div class="mt-2 text-sm text-ink-gray-5">
+			Choose who may install and run this agent. Access is enforced server-side on every
+			path. With no roles and no users selected, only administrators can use it.
+		</div>
+
+		<!-- roles -->
+		<div class="mt-5 text-sm font-medium text-ink-gray-7">Roles</div>
+		<div class="mt-2 flex flex-wrap gap-1.5">
+			<div
+				v-for="r in roleDraft"
+				:key="r"
+				data-test="role-chip"
+				class="flex h-6 items-center gap-1 rounded bg-surface-gray-2 px-2 text-sm text-ink-gray-8"
+			>
+				<span class="truncate">{{ r }}</span>
+				<Button
+					variant="ghost"
+					icon="x"
+					class="!h-4 !w-4"
+					:label="'Remove role ' + r"
+					@click="removeRole(r)"
+				/>
+			</div>
+			<span v-if="!roleDraft.length" class="text-sm text-ink-gray-4">No roles</span>
+		</div>
+		<div class="mt-2 w-72">
+			<Autocomplete
+				:options="roleOptions"
+				:modelValue="null"
+				placeholder="Add a role…"
+				@update:modelValue="(opt) => opt && addRole(opt.value)"
+			/>
+		</div>
+
+		<!-- users -->
+		<div class="mt-5 text-sm font-medium text-ink-gray-7">People</div>
+		<div class="mt-2 flex flex-wrap gap-1.5">
+			<div
+				v-for="u in userDraft"
+				:key="u"
+				data-test="user-chip"
+				class="flex h-6 items-center gap-1 rounded bg-surface-gray-2 px-2 text-sm text-ink-gray-8"
+			>
+				<span class="truncate">{{ u }}</span>
+				<Button
+					variant="ghost"
+					icon="x"
+					class="!h-4 !w-4"
+					:label="'Remove user ' + u"
+					@click="removeUser(u)"
+				/>
+			</div>
+			<span v-if="!userDraft.length" class="text-sm text-ink-gray-4">No people</span>
+		</div>
+		<!-- The SAME frappe-ui Autocomplete as the roles picker above, so the two
+		     halves of one statement look and behave alike; its popover is portaled
+		     (reka PopoverPortal) with a solid bg-surface-modal, so it cannot be
+		     clipped by this section's grid track or read through to the copy below.
+		     Remote-backed: @update:query drives a debounced search_users call and
+		     :options is re-fed from the response. focusin (which bubbles, unlike
+		     focus) and click prime it with the empty query on open, so the first 20
+		     people are there instead of an empty box that only fills once you guess
+		     a letter. -->
+		<div class="mt-2 w-72" @focusin="primeUserMenu" @click="primeUserMenu">
+			<Autocomplete
+				:options="userOptions"
+				:modelValue="null"
+				placeholder="Add a person…"
+				@update:query="onUserQuery"
+				@update:modelValue="(opt) => opt && addUser(opt.value)"
+			/>
+		</div>
+
+		<!-- Saving always applies, so the cost is stated as a fact rather than
+		     offered as a choice: an access change that is saved but not loaded is a
+		     half-done action, and the roster and the database silently disagreeing
+		     is the #457 class of bug this feature keeps having to design around. -->
+		<p data-test="apply-note" class="mt-5 max-w-md text-sm text-ink-gray-5">
+			Saving loads this agent on your workspace. If the set of loaded agents changes, the
+			workspace restarts for about 30 seconds and active chats are interrupted.
+		</p>
+
+		<div class="mt-4 flex items-center gap-2">
+			<Button
+				data-test="save-access"
+				label="Save access"
+				variant="solid"
+				:loading="saving"
+				:disabled="!dirty || saving"
+				@click="save"
+			/>
+			<Button v-if="dirty && !saving" label="Reset" variant="ghost" @click="reset" />
+			<span
+				v-if="pending"
+				data-test="apply-pending"
+				class="inline-flex h-5 items-center rounded-full bg-surface-amber-1 px-2 text-xs text-ink-amber-3"
+			>
+				Applying to workspace…
+			</span>
+		</div>
+	</section>
+</template>
+
+<script setup>
+import { computed, ref, watch, onBeforeUnmount } from "vue";
+import { Autocomplete, Button, toast } from "frappe-ui";
+import * as api from "@/api";
+import * as apiAgents from "@/api/agents";
+import { errHtml } from "@/lib/errors";
+import { humaniseSyncStatus } from "@/lib/syncStatus";
+import { useLinkSearch } from "@/composables/useLinkSearch";
+
+const props = defineProps({
+	slug: { type: String, required: true },
+	roles: { type: Array, default: () => [] }, // saved allowed_roles
+	users: { type: Array, default: () => [] }, // saved allowed_users
+	allRoles: { type: Array, default: () => [] }, // selectable Role names
+});
+const emit = defineEmits(["saved"]);
+
+// How long between polls while an apply is in flight. Matches AgentsList's apply
+// pill so the two surfaces report the same restart at the same cadence.
+const POLL_MS = 3000;
+
+// The SAVED baseline, owned here rather than read straight off the props. The
+// props are the parent's copy, and it only learns the new value from our own
+// `saved` emit - deriving "dirty" from them would leave the editor showing
+// unsaved changes after a save that demonstrably succeeded, until the parent got
+// around to re-rendering. The server's response is the authority for what is now
+// saved, so that is what the baseline becomes.
+const savedRoles = ref([...props.roles]);
+const savedUsers = ref([...props.users]);
+const roleDraft = ref([...props.roles]);
+const userDraft = ref([...props.users]);
+const saving = ref(false);
+
+// A props refresh always updates the BASELINE - that is the server's current
+// truth - but only reseeds the drafts when there is nothing to lose. The parent
+// reloads the agent for unrelated reasons (toggling Enabled calls load() and
+// reassigns `agent`), and blowing away a half-finished access edit because of a
+// switch somewhere else on the page is silent data loss. When the drafts are
+// kept, `dirty` is recomputed against the new baseline, so the indicator stays
+// honest: an edit that now matches what the server holds reads as clean.
+watch(
+	() => [props.roles, props.users],
+	() => {
+		const wasDirty = dirty.value;
+		savedRoles.value = [...props.roles];
+		savedUsers.value = [...props.users];
+		if (!wasDirty) {
+			roleDraft.value = [...props.roles];
+			userDraft.value = [...props.users];
+		}
+	}
+);
+
+// Order is not a change: the server returns its own order, and removing then
+// re-adding the same role has changed nothing.
+const sorted = (a) => [...a].sort().join("|");
+const dirty = computed(
+	() =>
+		sorted(roleDraft.value) !== sorted(savedRoles.value) ||
+		sorted(userDraft.value) !== sorted(savedUsers.value)
+);
+
+const roleOptions = computed(() => {
+	const taken = new Set(roleDraft.value);
+	return (props.allRoles || [])
+		.filter((r) => !taken.has(r))
+		.map((r) => ({ label: r, value: r }));
+});
+function addRole(r) {
+	if (!roleDraft.value.includes(r)) roleDraft.value = [...roleDraft.value, r];
+}
+function removeRole(r) {
+	roleDraft.value = roleDraft.value.filter((x) => x !== r);
+}
+
+// ── user type-ahead ──────────────────────────────────────────────────────────
+// Remote, not a local filter over a preloaded directory: a tenant's user list is
+// unbounded and search_users caps at 20 server-side. Shared debounce + fence +
+// prime pattern (jarvis#1062, see useLinkSearch) - 200ms here, this site's own
+// interval from before the extraction, kept as-is.
+const userSearch = useLinkSearch((q) => apiAgents.searchUsers(q), { debounceMs: 200 });
+
+function primeUserMenu() {
+	// The current query, which is usually empty - search_users answers an empty
+	// term with the first 20 enabled users, which is exactly the "who is there?"
+	// an admin opening the picker is asking.
+	userSearch.prime();
+}
+
+const userOptions = computed(() => {
+	const taken = new Set(userDraft.value);
+	return userSearch.options.value
+		.filter((u) => !taken.has(u.name))
+		.map((u) => ({
+			value: u.name,
+			label: u.full_name ? `${u.full_name} (${u.name})` : u.name,
+		}));
+});
+
+// Autocomplete owns its own search box and reports what was typed; selection is a
+// separate event, so unlike the previous free-text combobox there is no need to
+// guess whether a value is a keystroke or a pick.
+function onUserQuery(q) {
+	userSearch.onQuery(q);
+}
+
+function addUser(value) {
+	if (!value) return;
+	if (!userDraft.value.includes(value)) userDraft.value = [...userDraft.value, value];
+	// Selected people drop out of userOptions, so refetch on the next open rather
+	// than showing a menu one entry short of what the server would return.
+	userSearch.reprime();
+}
+function removeUser(u) {
+	userDraft.value = userDraft.value.filter((x) => x !== u);
+}
+
+// ── apply status ─────────────────────────────────────────────────────────────
+const pending = ref(false);
+let pollTimer = null;
+
+function stopPoll() {
+	clearTimeout(pollTimer);
+	pollTimer = null;
+}
+onBeforeUnmount(() => {
+	stopPoll();
+	userSearch.cleanup();
+});
+
+async function pollUntilTerminal() {
+	let s;
+	try {
+		s = (await api.getAgentsSyncStatus()) || {};
+	} catch (e) {
+		pending.value = false;
+		toast.error(errHtml(e));
+		return;
+	}
+	if (s.pending) {
+		pollTimer = setTimeout(pollUntilTerminal, POLL_MS);
+		return;
+	}
+	pending.value = false;
+	// Classified by the shared humaniser, not by a local "failed:" prefix strip, so
+	// this toast cannot drift from the apply pill on the catalog page - the two
+	// report the same pipeline and used to parse its status two different ways.
+	const human = humaniseSyncStatus(s.last_sync_status);
+	if (human.kind === "failed") {
+		// The DETAIL is the only thing that says WHY the workspace refused it, so it
+		// has to survive rather than being flattened to "apply failed".
+		toast.error(
+			human.detail ? `Access saved, but applying it failed - ${human.detail}` : human.text
+		);
+		return;
+	}
+	toast.success("Access saved and applied.");
+}
+
+async function save() {
+	if (saving.value || !dirty.value) return;
+	saving.value = true;
+	try {
+		// Always applies. The endpoint keeps its `apply` parameter defaulting to
+		// false for API compatibility, so this passes it explicitly.
+		const res = await apiAgents.setAgentAccess(
+			props.slug,
+			roleDraft.value,
+			userDraft.value,
+			true
+		);
+		const nextRoles = (res && res.allowed_roles) || [];
+		const nextUsers = (res && res.allowed_users) || [];
+		savedRoles.value = [...nextRoles];
+		savedUsers.value = [...nextUsers];
+		roleDraft.value = [...nextRoles];
+		userDraft.value = [...nextUsers];
+		emit("saved", { allowed_roles: nextRoles, allowed_users: nextUsers });
+		if (res && res.applied) {
+			pending.value = true;
+			stopPoll();
+			pollUntilTerminal();
+		} else {
+			// Defensive: with apply always requested the server should report
+			// applied. If it ever declines, say so rather than implying it is live.
+			toast.success("Access saved, but not loaded yet. Use Apply catalog changes.");
+		}
+	} catch (e) {
+		toast.error(errHtml(e));
+	} finally {
+		saving.value = false;
+	}
+}
+
+function reset() {
+	roleDraft.value = [...savedRoles.value];
+	userDraft.value = [...savedUsers.value];
+}
+
+defineExpose({
+	dirty,
+	roleDraft,
+	userDraft,
+	pending,
+	userOptions,
+	primeUserMenu,
+	onUserQuery,
+	addUser,
+});
+</script>

--- a/frontend/src/pages/agents/AgentActivityTab.spec.js
+++ b/frontend/src/pages/agents/AgentActivityTab.spec.js
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#1062 owner feedback on the Activity feed:
+ *   1. a run row's Badge reflects the run's CURRENT status (run_status, a
+ *      live join - agents_api.list_agent_activity_page), not the action
+ *      verb's point-in-time label.
+ *   2. clicking a row navigates: a run row -> that agent's Runs tab with the
+ *      run preselected (?run=<id>); anything else -> Overview.
+ *   3. the detail line clamps to one line, full text in a title attribute.
+ */
+
+const apiAgents = vi.hoisted(() => ({ listAgentActivityPage: vi.fn() }));
+vi.mock("@/api/agents", () => apiAgents);
+
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+vi.mock("vue-router", () => ({ useRouter: () => router }));
+
+// jsdom here has no usable localStorage, and useListPage's persisted view
+// state is beside the point for this test (see WikiTab.spec.js precedent).
+vi.mock("@vueuse/core", async (importOriginal) => {
+	const actual = await importOriginal();
+	const { ref } = await import("vue");
+	return { ...actual, useStorage: (_key, initial) => ref(initial) };
+});
+
+vi.mock("frappe-ui", () => ({
+	call: vi.fn(),
+	dayjs: () => ({ format: () => "" }),
+	dayjsLocal: (d) => ({
+		format: () => String(d || ""),
+		fromNow: () => "",
+		isValid: () => !!d,
+		valueOf: () => (d ? new Date(String(d).replace(" ", "T")).getTime() : 0),
+	}),
+	getConfig: () => null,
+	toast: { error: vi.fn(), success: vi.fn() },
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant"],
+		template: `<span class="badge" :data-theme="theme">{{ label }}</span>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "placeholder"],
+		emits: ["update:modelValue"],
+		template: `<input :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+	ListFooter: { name: "ListFooter", template: "<div />" },
+	Tooltip: { name: "Tooltip", template: `<span><slot /></span>` },
+}));
+
+import AgentActivityTab from "./AgentActivityTab.vue";
+
+function activityRow(overrides = {}) {
+	return {
+		name: "ACT-0001",
+		agent: "close-auditor",
+		agent_title: "Close Auditor",
+		action: "run_started",
+		run: "RUN-0001",
+		run_status: null,
+		detail: "",
+		creation: "2026-09-01 10:00:00",
+		...overrides,
+	};
+}
+
+function envelope(rows) {
+	return { rows, total: rows.length, has_more: false, start: 0, page_length: 20 };
+}
+
+async function mountTab(rows) {
+	apiAgents.listAgentActivityPage.mockResolvedValue(envelope(rows));
+	const w = mount(AgentActivityTab);
+	await flushPromises();
+	return w;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("the badge reflects the run's live status, not the action label", () => {
+	it("shows run_status even though the action still reads 'Run started'", async () => {
+		const w = await mountTab([activityRow({ action: "run_started", run_status: "failed" })]);
+		expect(w.text()).toContain("Run started");
+		const badge = w.find(".badge");
+		expect(badge.exists()).toBe(true);
+		expect(badge.text()).toBe("failed");
+		expect(badge.attributes("data-theme")).toBe("red");
+	});
+
+	it("uses the app's STATUS_THEME colours for every status", async () => {
+		const cases = [
+			["running", "blue"],
+			["completed", "green"],
+			["partial", "orange"],
+			["failed", "red"],
+			["stopped", "gray"],
+		];
+		for (const [status, theme] of cases) {
+			const w = await mountTab([activityRow({ run_status: status })]);
+			expect(w.find(".badge").attributes("data-theme")).toBe(theme);
+		}
+	});
+
+	it("renders no badge when run_status is null (no run, or the run was deleted)", async () => {
+		const w = await mountTab([activityRow({ action: "enabled", run: "", run_status: null })]);
+		expect(w.find(".badge").exists()).toBe(false);
+	});
+});
+
+describe("clicking a row navigates", () => {
+	it("a run row opens the agent's Runs tab with the run preselected", async () => {
+		const w = await mountTab([activityRow({ action: "run_failed", run: "RUN-0007" })]);
+		await w.find('[role="button"]').trigger("click");
+		expect(router.push).toHaveBeenCalledWith({
+			name: "AgentDetail",
+			params: { slug: "close-auditor" },
+			hash: "#runs",
+			query: { run: "RUN-0007" },
+		});
+	});
+
+	it("a non-run row opens Overview", async () => {
+		const w = await mountTab([activityRow({ action: "enabled", run: "" })]);
+		await w.find('[role="button"]').trigger("click");
+		expect(router.push).toHaveBeenCalledWith({
+			name: "AgentDetail",
+			params: { slug: "close-auditor" },
+			hash: "#overview",
+		});
+	});
+
+	it("Enter on a focused row navigates the same as a click", async () => {
+		const w = await mountTab([activityRow({ action: "promoted_to_live", run: "" })]);
+		await w.find('[role="button"]').trigger("keydown.enter");
+		expect(router.push).toHaveBeenCalledWith({
+			name: "AgentDetail",
+			params: { slug: "close-auditor" },
+			hash: "#overview",
+		});
+	});
+
+	it("a run action with no run recorded falls back to Overview, not a query-less Runs tab", async () => {
+		const w = await mountTab([activityRow({ action: "run_completed", run: "" })]);
+		await w.find('[role="button"]').trigger("click");
+		expect(router.push).toHaveBeenCalledWith({
+			name: "AgentDetail",
+			params: { slug: "close-auditor" },
+			hash: "#overview",
+		});
+	});
+});
+
+describe("the detail line clamps to one line with the full text in a title", () => {
+	it("truncates and carries the full text as a title attribute", async () => {
+		const longNote =
+			"Partial scan - coverage gaps: GL Entry, Account, Company were not fully evaluated this run, re-run advised";
+		const w = await mountTab([activityRow({ detail: longNote })]);
+		const detail = w.find(".truncate");
+		expect(detail.exists()).toBe(true);
+		expect(detail.attributes("title")).toBe(longNote);
+		expect(detail.text()).toBe(longNote);
+	});
+});
+
+// jarvis#1062 P1-5 (production-readiness audit): keyboard focus was
+// invisible here, same as every other role="button" row in this app.
+describe("activity row keyboard focus (jarvis#1062 P1-5)", () => {
+	it("carries a focus-visible ring", async () => {
+		const w = await mountTab([activityRow()]);
+		const row = w.find('[role="button"]');
+		expect(row.exists()).toBe(true);
+		expect(row.classes()).toContain("focus-visible:ring-2");
+		expect(row.classes()).toContain("focus-visible:ring-outline-gray-3");
+	});
+});
+
+// jarvis#1062 P2-9 (production-readiness audit): the empty Activity tab told
+// an Administrator session to wait for installs/schedule changes/runs to
+// show up - which never happens, since Administrator cannot install agents.
+describe("empty state names the Administrator case (jarvis#1062 P2-9)", () => {
+	it("shows the Administrator-specific copy when session.user is Administrator", async () => {
+		const { session } = await import("@/data/session");
+		const original = session.user;
+		session.user = "Administrator";
+		try {
+			const w = await mountTab([]);
+			expect(w.text()).toContain("Administrator cannot install agents.");
+			expect(w.text()).toContain("Sign in as a named user.");
+			expect(w.text()).not.toContain(
+				"Installs, schedule changes and runs will show up here."
+			);
+		} finally {
+			session.user = original;
+		}
+	});
+
+	it("shows the ordinary copy for a named user", async () => {
+		const { session } = await import("@/data/session");
+		const original = session.user;
+		session.user = "owner@example.com";
+		try {
+			const w = await mountTab([]);
+			expect(w.text()).toContain("Installs, schedule changes and runs will show up here.");
+			expect(w.text()).not.toContain("Administrator cannot install agents.");
+		} finally {
+			session.user = original;
+		}
+	});
+});

--- a/frontend/src/pages/agents/AgentActivityTab.vue
+++ b/frontend/src/pages/agents/AgentActivityTab.vue
@@ -31,13 +31,32 @@
 			>
 				<FeatherIcon name="activity" class="size-7.5 text-ink-gray-5" />
 				<span class="mt-2 text-lg font-medium text-ink-gray-8">No activity yet</span>
-				<span class="text-p-base text-ink-gray-6">
+				<!-- jarvis#1062 P2-9 (production-readiness audit): "Installs...
+				     will show up here" reads as an instruction to go install
+				     something, which the Administrator session can never do
+				     (Install is refused server-side, S3 owner-gate) - told
+				     straight instead. -->
+				<span v-if="isAdministrator" class="text-p-base text-ink-gray-6">
+					Administrator cannot install agents. Sign in as a named user.
+				</span>
+				<span v-else class="text-p-base text-ink-gray-6">
 					Installs, schedule changes and runs will show up here.
 				</span>
 			</div>
 
 			<div v-else class="divide-y">
-				<div v-for="r in rows" :key="r.name" class="flex items-start gap-3 py-3">
+				<!-- jarvis#1062 P1-5 (production-readiness audit): keyboard focus
+				     was invisible here, same as every other role="button" row in
+				     this app - added the same focus-visible ring. -->
+				<div
+					v-for="r in rows"
+					:key="r.name"
+					role="button"
+					tabindex="0"
+					class="flex cursor-pointer items-start gap-3 py-3 hover:bg-surface-gray-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3"
+					@click="openRow(r)"
+					@keydown.enter.prevent="openRow(r)"
+				>
 					<div
 						class="grid size-8 shrink-0 place-items-center rounded-full bg-surface-gray-2"
 					>
@@ -55,8 +74,21 @@
 							<span class="text-sm text-ink-gray-5">{{
 								actionLabel(r.action)
 							}}</span>
+							<!-- jarvis#1062: the action verb is a point-in-time label ("Run
+							     started"); this badge is the run's LIVE status, so a started
+							     run that later failed reads as failed here, not started. -->
+							<Badge
+								v-if="r.run_status"
+								variant="subtle"
+								:theme="STATUS_THEME[r.run_status] || 'gray'"
+								:label="r.run_status"
+							/>
 						</div>
-						<div v-if="r.detail" class="mt-0.5 truncate text-sm text-ink-gray-6">
+						<div
+							v-if="r.detail"
+							class="mt-0.5 truncate text-sm text-ink-gray-6"
+							:title="r.detail"
+						>
 							{{ r.detail }}
 						</div>
 					</div>
@@ -85,11 +117,48 @@
 // useListPage bound to list_agent_activity_page (owner-scoped, newest first),
 // its own debounced search and its own ListFooter, so AgentsList only mounts
 // it when #activity is active (lazy first fetch via useListPage's onMounted).
-// Rows are Link-free snapshots: {agent_title, action, detail, creation, run}.
-import { FeatherIcon, FormControl, ListFooter, Tooltip } from "frappe-ui";
+// Rows are Link-free snapshots: {agent, agent_title, action, detail, creation,
+// run, run_status}. run_status is a live join (agents_api.py), not part of
+// the snapshot itself.
+import { computed } from "vue";
+import { Badge, FeatherIcon, FormControl, ListFooter, Tooltip } from "frappe-ui";
+import { useRouter } from "vue-router";
 import { useListPage } from "@/composables/useListPage";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import { listAgentActivityPage } from "@/api/agents";
+import { STATUS_THEME } from "@/lib/agentRunStatus";
+import { session } from "@/data/session";
+
+const router = useRouter();
+// jarvis#1062 P2-9: the empty state names the Administrator case specifically
+// - it cannot install, so "will show up here" is never true for that session.
+const isAdministrator = computed(() => session.user === "Administrator");
+
+// jarvis#1062: a run row (its live status now shown as the badge above)
+// opens straight to that run in the Runs tab; every other lifecycle event
+// (installed, enabled, config_changed, promoted...) has no single run to
+// point at, so it opens the agent's Overview instead. router-driven, never
+// window.location - this stays an in-SPA navigation.
+const RUN_ACTIONS = new Set([
+	"run_started",
+	"run_completed",
+	"run_partial",
+	"run_failed",
+	"run_stopped",
+]);
+function openRow(r) {
+	if (!r || !r.agent) return;
+	if (RUN_ACTIONS.has(r.action) && r.run) {
+		router.push({
+			name: "AgentDetail",
+			params: { slug: r.agent },
+			hash: "#runs",
+			query: { run: r.run },
+		});
+	} else {
+		router.push({ name: "AgentDetail", params: { slug: r.agent }, hash: "#overview" });
+	}
+}
 
 // per-action Feather icon + label + ink color (lifecycle verbs from
 // agents_api.list_agent_activity_page)
@@ -108,6 +177,13 @@ const ACTIONS = {
 		color: "text-ink-amber-3",
 	},
 	run_failed: { icon: "x-circle", label: "Run failed", color: "text-ink-red-4" },
+	run_stopped: { icon: "square", label: "Run stopped" },
+	promoted_to_live: {
+		icon: "arrow-up-circle",
+		label: "Promoted to live",
+		color: "text-ink-green-3",
+	},
+	demoted_to_shadow: { icon: "eye", label: "Returned to preview", color: "text-ink-violet-1" },
 };
 function actionIcon(a) {
 	return (ACTIONS[a] || {}).icon || "activity";

--- a/frontend/src/pages/agents/AgentDetail.accessDraft.spec.js
+++ b/frontend/src/pages/agents/AgentDetail.accessDraft.spec.js
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createRouter, createMemoryHistory, RouterView } from "vue-router";
+import { h } from "vue";
+
+/**
+ * An unsaved Access draft must outlive the two ways it used to disappear.
+ *
+ *   1. A TAB switch. The Admin panel was the last arm of the tabs' v-if chain,
+ *      so Overview and back unmounted the editor and silently threw away a
+ *      half-finished grant. It is now hidden with v-show instead.
+ *   2. A ROUTE change. Leaving the agent page took the draft with it and said
+ *      nothing; there is now one confirmation, and only when there is really
+ *      something to lose.
+ *
+ * Mounted through a real memory router on purpose: onBeforeRouteLeave only
+ * registers for a component the router itself matched, so a direct mount would
+ * test nothing. Everything below AgentDetail is stubbed - the subject here is
+ * the page's own retention behaviour, not its children.
+ */
+
+const api = vi.hoisted(() => ({
+	installAgent: vi.fn(),
+	uninstallAgent: vi.fn(),
+	setEnabled: vi.fn(),
+	setSchedule: vi.fn(),
+	getAgentAdminOverview: vi.fn(),
+	applyAgents: vi.fn(),
+	getAgentsSyncStatus: vi.fn(),
+	setListingStatus: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+const apiAgents = vi.hoisted(() => ({
+	getAgent: vi.fn(),
+	getAgentsCaps: vi.fn(),
+	getInstallationActivation: vi.fn(),
+	stopAgentRun: vi.fn(),
+	promoteInstallation: vi.fn(),
+	demoteInstallation: vi.fn(),
+	setAgentAccess: vi.fn(),
+	searchUsers: vi.fn(),
+	listRunsPage: vi.fn(),
+	listAgentActivityPage: vi.fn(),
+	takeFindingToChat: vi.fn(),
+	listAgentsPage: vi.fn(),
+}));
+vi.mock("@/api/agents", () => apiAgents);
+
+const confirmDialog = vi.hoisted(() => vi.fn());
+vi.mock("frappe-ui", () => {
+	const passthrough = (name) => ({
+		name,
+		inheritAttrs: false,
+		setup:
+			(_, { slots }) =>
+			() =>
+				h("div", {}, slots.default ? slots.default() : []),
+	});
+	return {
+		confirmDialog,
+		toast: { success: vi.fn(), error: vi.fn() },
+		call: vi.fn(),
+		Badge: passthrough("Badge"),
+		Breadcrumbs: passthrough("Breadcrumbs"),
+		Button: passthrough("Button"),
+		Dropdown: passthrough("Dropdown"),
+		FeatherIcon: passthrough("FeatherIcon"),
+		FormControl: passthrough("FormControl"),
+		FormLabel: passthrough("FormLabel"),
+		ListView: passthrough("ListView"),
+		ListHeader: passthrough("ListHeader"),
+		ListHeaderItem: passthrough("ListHeaderItem"),
+		ListRows: passthrough("ListRows"),
+		ListRowItem: passthrough("ListRowItem"),
+		Switch: passthrough("Switch"),
+		TimePicker: passthrough("TimePicker"),
+		Tooltip: passthrough("Tooltip"),
+		Autocomplete: passthrough("Autocomplete"),
+	};
+});
+
+// The editor stub exposes `dirty` exactly as the real one does (defineExpose),
+// which is the only part of it this page reads.
+const editorState = vi.hoisted(() => ({ dirty: false }));
+vi.mock("@/pages/agents/AgentAccessEditor.vue", () => ({
+	default: {
+		name: "AgentAccessEditor",
+		setup(_, { expose }) {
+			expose(editorState);
+			return () => h("div", { class: "access-editor-stub" });
+		},
+	},
+}));
+
+vi.mock("@/markdown", () => ({ renderMarkdown: (s) => s || "" }));
+vi.mock("@/lib/errors", () => ({ errMessage: (e) => String(e), errHtml: (e) => String(e) }));
+vi.mock("@/utils/datetime", () => ({ timeAgo: () => "", exactDate: () => "" }));
+
+import AgentDetail from "./AgentDetail.vue";
+
+const SLUG = "close-auditor";
+const STUBS = {
+	LayoutHeader: true,
+	TabBar: true,
+	AgentRunsBoard: true,
+	ActivationPanel: true,
+	ConfigForm: true,
+	AppSourceConsentDialog: true,
+	JvSpinner: true,
+	ShadowChip: true,
+};
+
+async function page() {
+	const router = createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			{ path: "/agents/:slug", name: "AgentDetail", component: AgentDetail, props: true },
+			{
+				path: "/elsewhere",
+				name: "Elsewhere",
+				component: { template: "<div>elsewhere</div>" },
+			},
+		],
+	});
+	router.push(`/agents/${SLUG}`);
+	await router.isReady();
+	const w = mount(
+		{ render: () => h(RouterView) },
+		{ global: { plugins: [router], stubs: STUBS } }
+	);
+	await flushPromises();
+	return { w, router };
+}
+
+beforeEach(() => {
+	editorState.dirty = false;
+	confirmDialog.mockReset();
+	apiAgents.getAgent.mockResolvedValue({
+		name: SLUG,
+		agent_slug: SLUG,
+		title: "Close Auditor",
+		status: "Published",
+		nature: "Auditor",
+		allowed: 1,
+		allowed_roles: [],
+		allowed_users: [],
+		all_roles: ["Accounts User"], // presence of all_roles is the isSM signal
+		installation: null,
+		install_count: 0,
+	});
+	apiAgents.getAgentsCaps.mockResolvedValue({ review: true, admin: true });
+	api.getAgentAdminOverview.mockResolvedValue({ roles: [], listings: [] });
+});
+
+describe("the Access draft survives a tab switch", () => {
+	it("keeps the Admin panel mounted when another tab is shown", async () => {
+		const { w, router } = await page();
+
+		router.push("#admin");
+		await flushPromises();
+		expect(w.find(".access-editor-stub").exists()).toBe(true);
+
+		// Overview and back: with the old v-if chain the editor unmounted here and
+		// its draft went with it.
+		router.push("#");
+		await flushPromises();
+		expect(w.find(".access-editor-stub").exists()).toBe(true);
+
+		router.push("#admin");
+		await flushPromises();
+		expect(w.find(".access-editor-stub").exists()).toBe(true);
+	});
+});
+
+describe("leaving the page with an unsaved draft", () => {
+	it("asks once, and only once", async () => {
+		const { router } = await page();
+		editorState.dirty = true;
+
+		await router.push("/elsewhere");
+		await flushPromises();
+
+		expect(confirmDialog).toHaveBeenCalledTimes(1);
+		// Blocked for now - the user is still on the agent page.
+		expect(router.currentRoute.value.path).toBe(`/agents/${SLUG}`);
+
+		// Confirming lets the SAME navigation through without asking again.
+		confirmDialog.mock.calls[0][0].onConfirm({ hideDialog: () => {} });
+		await flushPromises();
+		expect(confirmDialog).toHaveBeenCalledTimes(1);
+		expect(router.currentRoute.value.path).toBe("/elsewhere");
+	});
+
+	it("does not ask when the draft is clean", async () => {
+		const { router } = await page();
+		editorState.dirty = false;
+
+		await router.push("/elsewhere");
+		await flushPromises();
+
+		expect(confirmDialog).not.toHaveBeenCalled();
+		expect(router.currentRoute.value.path).toBe("/elsewhere");
+	});
+
+	it("dismissing the dialog leaves routing usable, not wedged", async () => {
+		// The guard refuses the navigation outright rather than parking a `next`
+		// callback: a dismissed dialog never calls onConfirm, and a guard waiting on
+		// that callback would wedge routing for the rest of the session.
+		const { router } = await page();
+		editorState.dirty = true;
+
+		await router.push("/elsewhere");
+		await flushPromises();
+		expect(router.currentRoute.value.path).toBe(`/agents/${SLUG}`);
+
+		// No confirm, no re-push: the draft is saved, and leaving now works.
+		editorState.dirty = false;
+		await router.push("/elsewhere");
+		await flushPromises();
+		expect(router.currentRoute.value.path).toBe("/elsewhere");
+	});
+});

--- a/frontend/src/pages/agents/AgentDetail.spec.js
+++ b/frontend/src/pages/agents/AgentDetail.spec.js
@@ -1,0 +1,818 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#1062 polish - AgentDetail.vue:
+ *
+ *   5. Visible (not just tooltip) hints for the two other reasons Run Now can
+ *      be disabled - enabled-off and shadow-scribe - mirroring the existing
+ *      role-restricted hint.
+ *   6. doctypes_required rendered as "Reads these records" chips, and the
+ *      install-failure reason kept visible under the Install button (not only
+ *      a 2s toast) until the next attempt.
+ *   3. The Overview "Allowed roles" panel renders only when the payload
+ *      carries the (now admin-only) allowed_roles key.
+ */
+
+const api = vi.hoisted(() => ({
+	installAgent: vi.fn(),
+	runAgentNow: vi.fn(),
+	setAgentConfig: vi.fn(),
+	setAgentEnabled: vi.fn(),
+	setAgentRoles: vi.fn(),
+	setAgentSchedule: vi.fn(),
+	uninstallAgent: vi.fn(),
+	getAgentAdminOverview: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+const apiAgents = vi.hoisted(() => ({
+	getAgent: vi.fn(),
+	getInstallationActivation: vi.fn(),
+}));
+vi.mock("@/api/agents", () => apiAgents);
+
+const apiDocmeta = vi.hoisted(() => ({
+	getDocmeta: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/api/docmeta", () => apiDocmeta);
+
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+const routeMock = vi.hoisted(() => ({ hash: "", name: "AgentDetail", query: {}, params: {} }));
+vi.mock("vue-router", () => ({
+	useRouter: () => router,
+	useRoute: () => routeMock,
+	// jarvis#1062 access-governance merge: AgentDetail.vue now also guards
+	// leaving with an unsaved Access draft (onBeforeRouteLeave) - a no-op
+	// here, since none of this file's tests dirty the Access editor.
+	onBeforeRouteLeave: vi.fn(),
+}));
+
+const sessionMock = vi.hoisted(() => ({ session: { user: "owner@example.com" } }));
+vi.mock("@/data/session", () => sessionMock);
+
+// frappe-ui's ESM entry does not resolve under vitest (see LlmPoolEditor.spec.js).
+vi.mock("frappe-ui", () => ({
+	call: vi.fn(),
+	dayjs: () => ({ format: () => "" }),
+	dayjsLocal: (d) => ({
+		format: () => String(d || ""),
+		fromNow: () => "",
+		isValid: () => !!d,
+		valueOf: () => (d ? new Date(String(d).replace(" ", "T")).getTime() : 0),
+	}),
+	getConfig: () => null,
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		// mirrors real toast.promise's shape closely enough: attach a swallowed
+		// .catch so the component's own await/catch is the only thing under test.
+		promise: vi.fn((p) => {
+			p.catch(() => {});
+			return p;
+		}),
+	},
+	confirmDialog: vi.fn(),
+	Autocomplete: { name: "Autocomplete", template: "<div />" },
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant"],
+		template: `<span class="badge" :data-theme="theme">{{ label }}</span>`,
+	},
+	Breadcrumbs: {
+		name: "Breadcrumbs",
+		props: ["items"],
+		// jarvis#1062 P1-6: render each item's label + its #suffix scoped slot
+		// (the skeleton bar), matching frappe-ui's real Breadcrumbs API closely
+		// enough to test the loading-crumb behavior.
+		template: `<div>
+			<span v-for="(item, i) in items" :key="i" class="crumb" :data-loading="!!item.loading">
+				{{ item.label }}<slot name="suffix" :item="item" />
+			</span>
+		</div>`,
+	},
+	Button: {
+		name: "Button",
+		props: ["label", "disabled", "loading", "variant", "theme", "iconLeft", "tooltip"],
+		emits: ["click"],
+		template: `<button :disabled="disabled" :data-label="label" @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+	},
+	Dropdown: { name: "Dropdown", props: ["options"], template: "<div><slot /></div>" },
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "options", "disabled"],
+		emits: ["update:modelValue"],
+		template: `<select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)"></select>`,
+	},
+	FormLabel: { name: "FormLabel", template: "<label><slot /></label>" },
+	ListView: { name: "ListView", template: "<div />" },
+	ListHeader: { name: "ListHeader", template: "<div />" },
+	ListHeaderItem: { name: "ListHeaderItem", template: "<div />" },
+	ListRows: { name: "ListRows", template: "<div />" },
+	ListRowItem: { name: "ListRowItem", template: "<div />" },
+	Switch: {
+		name: "Switch",
+		props: ["modelValue", "label", "disabled"],
+		emits: ["update:modelValue"],
+		template: `<button :disabled="disabled" @click="$emit('update:modelValue', !modelValue)">{{ label }}</button>`,
+	},
+	// emit-capable so a time-only edit can be driven in a spec (jarvis#1062
+	// owner feedback: Save must hide again after a time-only save - the
+	// modelValue TimePicker emits can carry seconds, e.g. "10:30:00").
+	TimePicker: {
+		name: "TimePicker",
+		props: ["modelValue", "placeholder"],
+		emits: ["update:modelValue"],
+		template: `<button data-testid="time-picker" @click="$emit('update:modelValue', '10:30:00')">{{ modelValue }}</button>`,
+	},
+}));
+
+// LayoutHeader teleports to #app-header (absent in jsdom here) - a real mount
+// would render nothing at all, hiding the Install/Run Now buttons under test.
+vi.mock("@/components/LayoutHeader.vue", () => ({
+	default: {
+		name: "LayoutHeader",
+		template: `<div><slot name="left-header" /><slot name="right-header" /><slot /></div>`,
+	},
+}));
+vi.mock("@/components/list/TabBar.vue", () => ({
+	default: { name: "TabBar", props: ["tabs", "modelValue"], template: "<div />" },
+}));
+vi.mock("@/pages/agents/AgentRunsBoard.vue", () => ({
+	default: { name: "AgentRunsBoard", template: "<div />" },
+}));
+vi.mock("@/pages/agents/ActivationPanel.vue", () => ({
+	default: { name: "ActivationPanel", template: "<div />" },
+}));
+vi.mock("@/pages/agents/ConfigForm.vue", () => ({
+	default: { name: "ConfigForm", template: "<div />" },
+}));
+vi.mock("@/components/learning/AppSourceConsentDialog.vue", () => ({
+	default: { name: "AppSourceConsentDialog", template: "<div />" },
+}));
+vi.mock("@/components/JvSpinner.vue", () => ({
+	default: { name: "JvSpinner", template: `<div class="spinner" />` },
+}));
+vi.mock("@/markdown", () => ({ renderMarkdown: (s) => s }));
+vi.mock("@/lib/errors", () => ({
+	errMessage: (e) => (e && e.message) || String(e),
+	errHtml: (e) => (e && e.message) || String(e),
+}));
+
+import AgentDetail from "./AgentDetail.vue";
+
+function baseAgent(overrides = {}) {
+	return {
+		name: "close-auditor",
+		agent_slug: "close-auditor",
+		title: "Close Auditor",
+		description: "Checks the close.",
+		category: "Close and Reporting",
+		nature: "Auditor",
+		version: "1.0.0",
+		publisher: "Jarvis",
+		status: "Published",
+		tools_required: "[]",
+		min_apps: "[]",
+		rule_pack: "pack-1",
+		default_schedule: "{}",
+		validated_for_fy: "",
+		allowed_roles: [],
+		doctypes_required: "[]",
+		allowed: 1,
+		install_count: 3,
+		installation: null,
+		...overrides,
+	};
+}
+
+function installedInstallation(overrides = {}) {
+	return {
+		name: "INST-1",
+		enabled: 1,
+		installed_version: "1.0.0",
+		installed_at: "2026-01-01 00:00:00",
+		config: "{}",
+		sync_status: "",
+		synced_at: "",
+		schedule_enabled: 0,
+		schedule_frequency: "",
+		schedule_time: null,
+		next_run_at: null,
+		last_run_at: null,
+		...overrides,
+	};
+}
+
+async function mountDetail(agentFixture, activation = null) {
+	apiAgents.getAgent.mockResolvedValue(agentFixture);
+	apiAgents.getInstallationActivation.mockResolvedValue(activation);
+	const w = mount(AgentDetail, { props: { slug: agentFixture.agent_slug } });
+	await flushPromises();
+	await flushPromises();
+	return w;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	sessionMock.session.user = "owner@example.com";
+	routeMock.hash = "";
+});
+
+describe("Run Now disabled reasons get a visible hint, not only a tooltip", () => {
+	it("shows an enable-it hint when installed but not enabled", async () => {
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 0 }) })
+		);
+		expect(w.text()).toContain("Enable this agent to run it.");
+	});
+
+	it("does not show the enable-it hint once enabled", async () => {
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1 }) })
+		);
+		expect(w.text()).not.toContain("Enable this agent to run it.");
+	});
+
+	it("shows the shadow-scribe hint (existing tooltip text) for a shadow scribe", async () => {
+		const w = await mountDetail(
+			baseAgent({
+				nature: "Scribe",
+				installation: installedInstallation({ enabled: 1 }),
+			}),
+			{ activation_state: "shadow", reviewer: "owner@example.com" }
+		);
+		await flushPromises();
+		expect(w.text()).toContain(
+			"Still in shadow preview - promote it to live under Configure first"
+		);
+	});
+});
+
+describe("doctypes_required renders as Reads these records chips", () => {
+	it("lists each declared doctype as a chip", async () => {
+		const w = await mountDetail(baseAgent({ doctypes_required: '["GL Entry","Account"]' }));
+		expect(w.text()).toContain("Reads these records");
+		expect(w.text()).toContain("GL Entry");
+		expect(w.text()).toContain("Account");
+	});
+
+	it("omits the heading when nothing is declared", async () => {
+		const w = await mountDetail(baseAgent({ doctypes_required: "[]" }));
+		expect(w.text()).not.toContain("Reads these records");
+	});
+});
+
+describe("install-failure reason stays visible until the next attempt", () => {
+	it("shows the error inline under Install, not only via toast", async () => {
+		api.installAgent.mockRejectedValueOnce(new Error("no seats left"));
+		const w = await mountDetail(baseAgent({ installation: null }));
+		const installBtn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Install");
+		await installBtn.trigger("click");
+		await flushPromises();
+		expect(w.text()).toContain("no seats left");
+	});
+
+	it("clears the inline error on the next attempt", async () => {
+		api.installAgent.mockRejectedValueOnce(new Error("no seats left"));
+		const w = await mountDetail(baseAgent({ installation: null }));
+		const installBtn = () =>
+			w.findAll("button").find((b) => b.attributes("data-label") === "Install");
+		await installBtn().trigger("click");
+		await flushPromises();
+		expect(w.text()).toContain("no seats left");
+
+		api.installAgent.mockResolvedValueOnce({ ok: true });
+		await installBtn().trigger("click");
+		await flushPromises();
+		expect(w.text()).not.toContain("no seats left");
+	});
+});
+
+describe("Install is disabled for an Administrator session (jarvis#1062 polish)", () => {
+	it("disables the Install button and shows the visible hint", async () => {
+		sessionMock.session.user = "Administrator";
+		const w = await mountDetail(baseAgent({ installation: null }));
+		const installBtn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Install");
+		expect(installBtn.attributes("disabled")).not.toBeUndefined();
+		expect(w.text()).toContain("Log in as a named user to install this agent.");
+	});
+
+	it("a click while disabled never calls installAgent", async () => {
+		sessionMock.session.user = "Administrator";
+		const w = await mountDetail(baseAgent({ installation: null }));
+		const installBtn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Install");
+		await installBtn.trigger("click");
+		await flushPromises();
+		expect(api.installAgent).not.toHaveBeenCalled();
+	});
+
+	it("a named (non-Administrator) user sees no such hint and can install", async () => {
+		const w = await mountDetail(baseAgent({ installation: null }));
+		const installBtn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Install");
+		expect(installBtn.attributes("disabled")).toBeUndefined();
+		expect(w.text()).not.toContain("Log in as a named user to install this agent.");
+	});
+});
+
+describe("Overview Access panel: roster for admins only, never for a non-admin (governance + #1062 polish)", () => {
+	it("shows only the caller's own allowed/not-allowed state for a non-admin payload (no all_roles)", async () => {
+		const fixture = baseAgent();
+		delete fixture.allowed_roles;
+		delete fixture.allowed_users;
+		const w = await mountDetail(fixture);
+		expect(w.text()).toContain("Access");
+		expect(w.text()).toContain("You have access");
+		// never the roster, even if a stray allowed_roles key somehow rode along -
+		// isSM (all_roles presence), not key-presence, gates the roster now.
+		expect(w.text()).not.toContain("Accounts User");
+	});
+
+	it("shows the access roster for an admin payload (all_roles present)", async () => {
+		const w = await mountDetail(
+			baseAgent({
+				all_roles: ["Accounts User", "Jarvis Admin"],
+				allowed_roles: ["Accounts User"],
+				allowed_users: [],
+			})
+		);
+		expect(w.text()).toContain("Access");
+		expect(w.text()).toContain("Accounts User");
+	});
+});
+
+describe("Configure tab: two-column layout on lg+ (jarvis#1062 polish, matches the Admin tab)", () => {
+	it("wraps Configuration and Schedule in the same grid-cols-1 lg:grid-cols-2 pattern as Admin", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1 }) })
+		);
+		const grid = w.find(".grid.grid-cols-1.gap-10.lg\\:grid-cols-2.lg\\:items-start");
+		expect(grid.exists()).toBe(true);
+		expect(grid.text()).toContain("Schedule");
+		expect(grid.text()).toContain("Configuration");
+	});
+
+	// owner feedback: Configuration is the primary/left column now that
+	// Comments moved off this tab - Schedule moved to the right. Asserted on
+	// DOM order, not just presence, so a re-swap regresses visibly.
+	it("Configuration is the LEFT/primary column, Schedule is the RIGHT column", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1 }) })
+		);
+		const grid = w.find(".grid.grid-cols-1.gap-10.lg\\:grid-cols-2.lg\\:items-start");
+		const headings = grid
+			.findAll(".text-base.font-medium.text-ink-gray-9")
+			.map((h) => h.text());
+		expect(headings.indexOf("Configuration")).toBeGreaterThanOrEqual(0);
+		expect(headings.indexOf("Schedule")).toBeGreaterThanOrEqual(0);
+		expect(headings.indexOf("Configuration")).toBeLessThan(headings.indexOf("Schedule"));
+	});
+
+	// owner feedback: same section-heading style as the Admin tab's "Access"
+	// heading (AgentAccessEditor.vue) - text-base font-medium text-ink-gray-9,
+	// on both Configure columns, not just one.
+	it("both column headings match the Admin tab's Access heading style", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1 }) })
+		);
+		const grid = w.find(".grid.grid-cols-1.gap-10.lg\\:grid-cols-2.lg\\:items-start");
+		const headings = grid.findAll(".text-base.font-medium.text-ink-gray-9");
+		expect(headings.map((h) => h.text())).toEqual(["Configuration", "Schedule"]);
+	});
+
+	// jarvis#1062 owner decision: Comments moved off Configure onto the Run
+	// itself (FindingsPanel.vue's new Notes section) - no CommentsSection
+	// import remains here, so an accidental re-import would fail this mount
+	// outright rather than silently resolving to a stub. Also: no orphaned
+	// divider/empty space is left where Comments used to sit.
+	it("no longer renders Comments on the Configure tab, and left no orphaned divider", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1 }) })
+		);
+		expect(w.findComponent({ name: "CommentsSection" }).exists()).toBe(false);
+		expect(w.text()).not.toContain("Comments");
+		const grid = w.find(".grid.grid-cols-1.gap-10.lg\\:grid-cols-2.lg\\:items-start");
+		expect(grid.find(".border-t").exists()).toBe(false);
+	});
+});
+
+// owner feedback: "Save schedule" is not always-visible chrome, and the old
+// bare "Next run: ..." line becomes a one-line summary of the SAVED
+// schedule ("Scheduled monthly at 9:00 am. Next run: ...").
+describe("Configure tab: Schedule section - Save visibility, dirty tracking, saved-schedule summary", () => {
+	function scheduleSaveBtn(w) {
+		return w.findAll("button").find((b) => b.attributes("data-label") === "Save schedule");
+	}
+	function runAutomaticallyToggle(w) {
+		return w.findAll("button").find((b) => b.text() === "Run automatically");
+	}
+
+	it("Save is hidden when the form matches the saved installation (clean)", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "daily",
+					schedule_time: "09:00:00",
+					next_run_at: "2026-09-10 09:00:00",
+				}),
+			})
+		);
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+	});
+
+	it("Save appears once a control is edited (dirty) - toggling the switch", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1, schedule_enabled: 0 }) })
+		);
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+		await runAutomaticallyToggle(w).trigger("click");
+		expect(scheduleSaveBtn(w)).toBeTruthy();
+	});
+
+	it("Save appears when Frequency/Time change while already on", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "daily",
+					schedule_time: "09:00:00",
+					next_run_at: "2026-09-10 09:00:00",
+				}),
+			})
+		);
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+		const freqSelect = w.find("select");
+		await freqSelect.setValue("weekly");
+		expect(scheduleSaveBtn(w)).toBeTruthy();
+	});
+
+	it("Save disappears again once a save lands (installation refresh clears dirty)", async () => {
+		routeMock.hash = "#configure";
+		apiAgents.getAgent
+			.mockResolvedValueOnce(
+				baseAgent({
+					installation: installedInstallation({ enabled: 1, schedule_enabled: 0 }),
+				})
+			)
+			.mockResolvedValueOnce(
+				baseAgent({
+					installation: installedInstallation({
+						enabled: 1,
+						schedule_enabled: 1,
+						schedule_frequency: "daily",
+						schedule_time: "09:00:00",
+						next_run_at: "2026-09-10 09:00:00",
+					}),
+				})
+			);
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+		api.setAgentSchedule.mockResolvedValue({
+			ok: true,
+			data: { name: "INST-1", next_run_at: "2026-09-10 09:00:00" },
+		});
+		const w = mount(AgentDetail, { props: { slug: "close-auditor" } });
+		await flushPromises();
+		await flushPromises();
+
+		await runAutomaticallyToggle(w).trigger("click");
+		const btn = scheduleSaveBtn(w);
+		expect(btn).toBeTruthy();
+		await btn.trigger("click");
+		await flushPromises();
+		await flushPromises();
+
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+	});
+
+	it("off and saved (clean): only the toggle shows - no Frequency/Time, no Save", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 0,
+					next_run_at: null,
+				}),
+			})
+		);
+		expect(runAutomaticallyToggle(w)).toBeTruthy();
+		expect(w.find("select").exists()).toBe(false);
+		expect(w.findComponent({ name: "TimePicker" }).exists()).toBe(false);
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+	});
+
+	it("off and saved, but with a stale next_run_at (legacy row): no summary either - saved schedule is off", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 0,
+					next_run_at: "2026-09-10 09:00:00",
+				}),
+			})
+		);
+		expect(w.text()).not.toContain("Scheduled");
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+	});
+
+	it("a time-only edit round-trips through timeHHMM normalization - Save hides after save, not stuck on seconds", async () => {
+		// TimePicker's modelValue can carry seconds ("10:30:00"); savedSched is
+		// normalized ("HH:MM") - scheduleDirty must normalize both sides or
+		// Save never hides after a legitimate time-only save.
+		routeMock.hash = "#configure";
+		apiAgents.getAgent
+			.mockResolvedValueOnce(
+				baseAgent({
+					installation: installedInstallation({
+						enabled: 1,
+						schedule_enabled: 1,
+						schedule_frequency: "daily",
+						schedule_time: "09:00:00",
+						next_run_at: "2026-09-10 09:00:00",
+					}),
+				})
+			)
+			.mockResolvedValueOnce(
+				baseAgent({
+					installation: installedInstallation({
+						enabled: 1,
+						schedule_enabled: 1,
+						schedule_frequency: "daily",
+						schedule_time: "10:30:00",
+						next_run_at: "2026-09-10 10:30:00",
+					}),
+				})
+			);
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+		api.setAgentSchedule.mockResolvedValue({
+			ok: true,
+			data: { name: "INST-1", next_run_at: "2026-09-10 10:30:00" },
+		});
+		const w = mount(AgentDetail, { props: { slug: "close-auditor" } });
+		await flushPromises();
+		await flushPromises();
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+
+		await w.find('[data-testid="time-picker"]').trigger("click"); // emits "10:30:00"
+		expect(scheduleSaveBtn(w)).toBeTruthy();
+
+		await scheduleSaveBtn(w).trigger("click");
+		await flushPromises();
+		await flushPromises();
+
+		expect(scheduleSaveBtn(w)).toBeFalsy();
+	});
+
+	it("saved and enabled (clean): shows the one-line summary in the muted style", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "monthly",
+					schedule_time: "09:00:00",
+					next_run_at: "2026-10-03 09:00:00",
+				}),
+			})
+		);
+		const summary = w
+			.findAll("div.text-sm.text-ink-gray-5")
+			.find((d) => d.text().startsWith("Scheduled"));
+		expect(summary).toBeTruthy();
+		expect(summary.text()).toContain("Scheduled monthly at 9:00 am.");
+		expect(summary.text()).toContain("Next run:");
+	});
+
+	it("editing a control while a summary is showing hides the summary, not just shows Save", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "monthly",
+					schedule_time: "09:00:00",
+					next_run_at: "2026-10-03 09:00:00",
+				}),
+			})
+		);
+		expect(w.text()).toContain("Scheduled monthly");
+		await w.find("select").setValue("weekly");
+		expect(w.text()).not.toContain("Scheduled monthly");
+		expect(scheduleSaveBtn(w)).toBeTruthy();
+	});
+});
+
+describe("Configure tab: Next run line follows next_run_at, including after disabling the schedule", () => {
+	it("shows the Next run line when next_run_at is set", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({
+					enabled: 1,
+					schedule_enabled: 1,
+					schedule_frequency: "daily",
+					next_run_at: "2026-09-10 09:00:00",
+				}),
+			})
+		);
+		expect(w.text()).toContain("Next run:");
+	});
+
+	it("hides the Next run line when next_run_at is null (schedule off)", async () => {
+		routeMock.hash = "#configure";
+		const w = await mountDetail(
+			baseAgent({
+				installation: installedInstallation({ enabled: 1, next_run_at: null }),
+			})
+		);
+		expect(w.text()).not.toContain("Next run:");
+	});
+
+	it("re-fetching after a disable clears the line (agents#1062 next_run_at fix)", async () => {
+		// jarvis chat/agents_api.py's set_schedule now nulls next_run_at when the
+		// schedule is turned off; AgentDetail's saveSchedule() reloads via load(),
+		// so the next getAgent() response deciding this is the contract that matters
+		// here, not a client-side mutation of the previous response.
+		routeMock.hash = "#configure";
+		apiAgents.getAgent
+			.mockResolvedValueOnce(
+				baseAgent({
+					installation: installedInstallation({
+						enabled: 1,
+						schedule_enabled: 1,
+						schedule_frequency: "daily",
+						next_run_at: "2026-09-10 09:00:00",
+					}),
+				})
+			)
+			.mockResolvedValueOnce(
+				baseAgent({
+					installation: installedInstallation({
+						enabled: 1,
+						schedule_enabled: 0,
+						next_run_at: null,
+					}),
+				})
+			);
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+		const w = mount(AgentDetail, { props: { slug: "close-auditor" } });
+		await flushPromises();
+		await flushPromises();
+		expect(w.text()).toContain("Next run:");
+
+		api.setAgentSchedule.mockResolvedValue({
+			ok: true,
+			data: { name: "INST-1", next_run_at: null },
+		});
+		// Save is hidden until the form is actually dirty (owner feedback) -
+		// flip the switch off first, which is what makes it appear.
+		const toggle = w.findAll("button").find((b) => b.text() === "Run automatically");
+		await toggle.trigger("click");
+		const saveScheduleBtn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Save schedule");
+		expect(saveScheduleBtn).toBeTruthy();
+		await saveScheduleBtn.trigger("click");
+		await flushPromises();
+		await flushPromises();
+
+		expect(w.text()).not.toContain("Next run:");
+	});
+});
+
+describe("jarvis#1062 fix: a #runs deep link survives the pending agent/installation fetch", () => {
+	it("lands on Runs (not Overview) once installation resolves, from a hash requested before load", async () => {
+		routeMock.hash = "#runs";
+		routeMock.query = { run: "RUN-9" };
+		let resolveFetch;
+		apiAgents.getAgent.mockReturnValue(
+			new Promise((res) => {
+				resolveFetch = res;
+			})
+		);
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+
+		const w = mount(AgentDetail, { props: { slug: "close-auditor" } });
+		await flushPromises();
+		// Still loading - AgentRunsBoard cannot exist yet (no installation to
+		// gate it on), but the hash must not have been thrown away either.
+		expect(w.text()).toContain("Loading agent");
+		expect(w.findComponent({ name: "AgentRunsBoard" }).exists()).toBe(false);
+		expect(routeMock.query.run).toBe("RUN-9");
+
+		resolveFetch(baseAgent({ installation: installedInstallation({ enabled: 1 }) }));
+		await flushPromises();
+		await flushPromises();
+
+		expect(w.findComponent({ name: "AgentRunsBoard" }).exists()).toBe(true);
+		// AgentDetail's own job stops at landing on the right tab - it must not
+		// have consumed/cleared the run query itself; that is AgentRunsBoard's
+		// job (see AgentRunsBoard.spec.js), and it needs the query intact when
+		// it mounts.
+		expect(routeMock.query.run).toBe("RUN-9");
+	});
+
+	it("a non-run hash (#overview) is unaffected - resolves immediately, no wait needed", async () => {
+		routeMock.hash = "#overview";
+		routeMock.query = {};
+		let resolveFetch;
+		apiAgents.getAgent.mockReturnValue(
+			new Promise((res) => {
+				resolveFetch = res;
+			})
+		);
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+
+		const w = mount(AgentDetail, { props: { slug: "close-auditor" } });
+		await flushPromises();
+		expect(w.findComponent({ name: "AgentRunsBoard" }).exists()).toBe(false);
+
+		resolveFetch(baseAgent({ installation: installedInstallation({ enabled: 1 }) }));
+		await flushPromises();
+		await flushPromises();
+
+		expect(w.findComponent({ name: "AgentRunsBoard" }).exists()).toBe(false);
+		expect(w.findComponent({ name: "ConfigForm" }).exists()).toBe(false);
+	});
+
+	it("an eventually-invalid hash still falls back to Overview once the load truly settles", async () => {
+		routeMock.hash = "#nonexistent-tab";
+		routeMock.query = {};
+		const w = await mountDetail(
+			baseAgent({ installation: installedInstallation({ enabled: 1 }) })
+		);
+		// "nonexistent-tab" was never going to exist - overview wins once the
+		// load has settled, same as before this fix.
+		expect(w.findComponent({ name: "AgentRunsBoard" }).exists()).toBe(false);
+	});
+});
+
+// jarvis#1062 P1-6 (production-readiness audit): the breadcrumb used to
+// flash the raw slug before the agent loaded.
+describe("Breadcrumb: no slug flash while the agent is loading (jarvis#1062 P1-6)", () => {
+	it("shows an empty, loading crumb (skeleton) before the agent resolves - never the raw slug", async () => {
+		let resolveFetch;
+		apiAgents.getAgent.mockReturnValue(
+			new Promise((res) => {
+				resolveFetch = res;
+			})
+		);
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+		const w = mount(AgentDetail, { props: { slug: "negative-stock-valuation-auditor" } });
+		await flushPromises();
+
+		const crumbs = w.findAll(".crumb");
+		const lastCrumb = crumbs[crumbs.length - 1];
+		expect(lastCrumb.text()).not.toContain("negative-stock-valuation-auditor");
+		expect(lastCrumb.attributes("data-loading")).toBe("true");
+
+		resolveFetch(baseAgent({ agent_slug: "negative-stock-valuation-auditor" }));
+		await flushPromises();
+	});
+
+	it("shows the real title, loading marker gone, once the agent resolves", async () => {
+		const w = await mountDetail(baseAgent({ title: "Negative-Stock & Valuation Auditor" }));
+		const crumbs = w.findAll(".crumb");
+		const lastCrumb = crumbs[crumbs.length - 1];
+		expect(lastCrumb.text()).toContain("Negative-Stock & Valuation Auditor");
+		expect(lastCrumb.attributes("data-loading")).toBe("false");
+	});
+
+	// Review fix: get_agent failing left `agent` null forever, so the crumb
+	// showed a blank label AND a skeleton that never stopped spinning next to
+	// the error panel below it.
+	it("falls back to the slug and stops the skeleton when the agent fails to load", async () => {
+		apiAgents.getAgent.mockRejectedValue(new Error("Agent not found"));
+		apiAgents.getInstallationActivation.mockResolvedValue(null);
+		const w = mount(AgentDetail, { props: { slug: "negative-stock-valuation-auditor" } });
+		await flushPromises();
+		await flushPromises();
+
+		const crumbs = w.findAll(".crumb");
+		const lastCrumb = crumbs[crumbs.length - 1];
+		expect(lastCrumb.text()).toContain("negative-stock-valuation-auditor");
+		expect(lastCrumb.attributes("data-loading")).toBe("false");
+	});
+});

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -2,12 +2,34 @@
 	<div class="flex h-full flex-col overflow-hidden">
 		<LayoutHeader>
 			<template #left-header>
+				<!-- jarvis#1062 P1-6 (production-readiness audit): the raw slug
+				     ("negative-stock-valuation-auditor") used to flash here before
+				     the agent loaded, then get replaced by its real title - a
+				     visible, jarring swap. An empty crumb + a skeleton bar
+				     (item.loading, via Breadcrumbs' own #suffix slot) now render
+				     until the title is actually known; nothing ever flashes.
+				     Review fix: a failed load() left `agent` null forever, so a
+				     bare load failure showed a blank crumb AND a permanently
+				     spinning skeleton next to the error panel below. `error` set
+				     falls back to the slug (the old, pre-P1-6 behaviour) and
+				     stops the skeleton - there is nothing left to wait for. -->
 				<Breadcrumbs
 					:items="[
 						{ label: 'Agents', route: { name: 'AgentsList' } },
-						{ label: (agent && agent.title) || slug },
+						{
+							label: agent ? agent.title || props.slug : error ? props.slug : '',
+							loading: !agent && !error,
+						},
 					]"
-				/>
+				>
+					<template #suffix="{ item }">
+						<span
+							v-if="item.loading"
+							class="ml-1 inline-block h-4 w-32 animate-pulse rounded bg-surface-gray-3"
+							aria-hidden="true"
+						/>
+					</template>
+				</Breadcrumbs>
 			</template>
 			<template #right-header>
 				<template v-if="agent && !installation">
@@ -125,12 +147,14 @@
 						     is discussed - not only in the passive Runs-tab "Preview" pill
 						     (jarvis#456). The action itself lives in Configure. -->
 						<Badge
-							v-if="activation && activation.activation_state === 'live'"
+							v-if="
+								canReview && activation && activation.activation_state === 'live'
+							"
 							variant="subtle"
 							theme="green"
 							label="Live"
 						/>
-						<ShadowChip v-else-if="activation" label="Shadow (preview)" />
+						<ShadowChip v-else-if="canReview && activation" label="Shadow (preview)" />
 						<Switch
 							v-if="installation"
 							label="Enabled"
@@ -140,9 +164,39 @@
 						/>
 					</div>
 				</div>
-				<div v-if="!agent.allowed" class="mt-3 text-sm text-ink-gray-5">
-					Available to: {{ (agent.allowed_roles || []).join(", ") || "-" }} - ask your
-					administrator.
+				<!-- #1062 review fix: an installed-but-not-allowed row (role revoked
+				     after install) must say so visibly, not only via the disabled Run
+				     button's tooltip - a tooltip is easy to miss entirely. -->
+				<div v-if="installation && !agent.allowed" class="mt-3 text-sm text-ink-gray-5">
+					You do not have access to run this agent. Ask your administrator.
+				</div>
+				<!-- jarvis#1062 polish: the same visible-hint treatment for the other
+				     two reasons Run Now can be disabled - a tooltip alone is easy to
+				     miss. -->
+				<div
+					v-else-if="installation && !installation.enabled"
+					class="mt-3 text-sm text-ink-gray-5"
+				>
+					Enable this agent to run it.
+				</div>
+				<div v-else-if="shadowScribeBlocked" class="mt-3 text-sm text-ink-gray-5">
+					Still in shadow preview - promote it to live under Configure first
+				</div>
+				<!-- jarvis#1062 polish: install_agent refuses an Administrator run-as
+				     identity server-side ("agents cannot run as Administrator") - fail
+				     this visibly instead of letting the click round-trip into a
+				     toast-only refusal. -->
+				<div
+					v-if="!installation && isAdministratorSession"
+					class="mt-3 text-sm text-ink-gray-5"
+				>
+					Log in as a named user to install this agent.
+				</div>
+				<!-- jarvis#1062 polish: the install-failure toast auto-dismisses in
+				     ~2s - keep the reason visible under the Install button until the
+				     next attempt. -->
+				<div v-if="!installation && installError" class="mt-3 text-sm text-ink-red-4">
+					{{ installError }}
 				</div>
 			</div>
 
@@ -163,6 +217,23 @@
 						<div class="mt-2 flex flex-wrap gap-1.5">
 							<code
 								v-for="t in needs"
+								:key="t"
+								class="rounded bg-surface-gray-2 px-1.5 py-0.5 font-mono text-xs text-ink-gray-7"
+							>
+								{{ t }}
+							</code>
+						</div>
+					</div>
+					<!-- jarvis#1062 polish: doctypes_required (A12) rides in get_agent's
+					     payload but was never shown - a customer had no way to see which
+					     records the run-as user must be able to read. -->
+					<div v-if="readsRecords.length" class="mt-8">
+						<div class="text-base font-medium text-ink-gray-9">
+							Reads these records
+						</div>
+						<div class="mt-2 flex flex-wrap gap-1.5">
+							<code
+								v-for="t in readsRecords"
 								:key="t"
 								class="rounded bg-surface-gray-2 px-1.5 py-0.5 font-mono text-xs text-ink-gray-7"
 							>
@@ -226,18 +297,27 @@
 						</div>
 					</div>
 					<div>
-						<div class="text-sm font-medium text-ink-gray-5">Allowed roles</div>
-						<div class="mt-1 flex flex-wrap gap-1.5">
-							<template v-if="(agent.allowed_roles || []).length">
+						<div class="text-sm font-medium text-ink-gray-5">Access</div>
+						<!-- Admins see the roster; everyone else sees only whether THEY
+						     are allowed - who else has access is admin information. -->
+						<div v-if="isSM" class="mt-1 flex flex-wrap gap-1.5">
+							<template v-if="accessGrants.length">
 								<Badge
-									v-for="r in agent.allowed_roles"
-									:key="r"
+									v-for="g in accessGrants"
+									:key="g"
 									variant="subtle"
 									theme="gray"
-									:label="r"
+									:label="g"
 								/>
 							</template>
-							<span v-else class="text-base text-ink-gray-8">Everyone</span>
+							<span v-else class="text-base text-ink-gray-8">Admins only</span>
+						</div>
+						<div v-else class="mt-1 text-base text-ink-gray-8">
+							{{
+								agent.allowed
+									? "You have access"
+									: "No access - ask your administrator"
+							}}
 						</div>
 					</div>
 					<div>
@@ -248,11 +328,8 @@
 			</div>
 
 			<!-- ── Configure (installed; §14 F3 + D28 comments) ── -->
-			<div
-				v-else-if="tab === 'configure' && installation"
-				class="max-w-2xl shrink-0 space-y-10 px-5 py-6"
-			>
-				<section>
+			<div v-else-if="tab === 'configure' && installation" class="shrink-0 px-5 py-6">
+				<section v-if="canReview" class="mb-10 max-w-2xl">
 					<ActivationPanel
 						:installation-name="installation.name"
 						:agent-title="agent.title"
@@ -267,88 +344,109 @@
 					/>
 				</section>
 
-				<section>
-					<div class="text-base font-medium text-ink-gray-9">Schedule</div>
-					<div class="mt-3 space-y-4">
-						<Switch
-							label="Run automatically"
-							:modelValue="sched.enabled"
-							@update:modelValue="(v) => (sched.enabled = v)"
-						/>
-						<div
-							v-if="sched.enabled"
-							:class="[
-								'grid gap-4',
-								sched.frequency === 'daily' ? 'grid-cols-2' : 'grid-cols-3',
-							]"
-						>
-							<FormControl
-								type="select"
-								label="Frequency"
-								:options="FREQUENCY_OPTIONS"
-								:modelValue="sched.frequency"
-								@update:modelValue="(v) => (sched.frequency = v)"
+				<!-- Configuration on the left/primary column, Schedule on the right -
+				     the same 2-col-on-lg+ pattern as the Admin tab (Access left,
+				     Installs right), same section-heading style
+				     (text-base font-medium text-ink-gray-9, matching AgentAccessEditor's
+				     own "Access" heading) and the same lg:items-start so neither column
+				     stretches to the taller one's height - both start at the identical
+				     top edge. Comments moved OFF this tab onto the Run itself (owner
+				     decision, jarvis#1062) - a Note now belongs to what it is actually
+				     about; no divider/empty space is left behind for it. -->
+				<div class="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:items-start">
+					<div class="min-w-0">
+						<section>
+							<div class="text-base font-medium text-ink-gray-9">Configuration</div>
+							<!-- mt-2, matching AgentAccessEditor's own heading->content gap
+							     (its "Access" heading is immediately followed by an
+							     mt-2 description) - the Admin tab is the reference. -->
+							<ConfigForm
+								class="mt-2"
+								:config="parsedConfig"
+								:config-keys="configKeys"
+								:saving="savingConfig"
+								@save="saveConfig"
 							/>
-							<div>
-								<FormLabel label="Time" class="mb-1.5" />
-								<TimePicker
-									:modelValue="sched.time"
-									placeholder="09:00"
-									@update:modelValue="(v) => (sched.time = v)"
+						</section>
+					</div>
+
+					<div class="min-w-0">
+						<section>
+							<div class="text-base font-medium text-ink-gray-9">Schedule</div>
+							<!-- mt-2 for the same reason as Configuration above;
+							     space-y-5 (not -4) to match ConfigForm's own
+							     field-to-field rhythm - one consistent gap across
+							     both columns, not two different densities. -->
+							<div class="mt-2 space-y-5">
+								<Switch
+									label="Run automatically"
+									:modelValue="sched.enabled"
+									@update:modelValue="(v) => (sched.enabled = v)"
+								/>
+								<div
+									v-if="sched.enabled"
+									:class="[
+										'grid gap-4',
+										sched.frequency === 'daily'
+											? 'grid-cols-2'
+											: 'grid-cols-3',
+									]"
+								>
+									<FormControl
+										type="select"
+										label="Frequency"
+										:options="FREQUENCY_OPTIONS"
+										:modelValue="sched.frequency"
+										@update:modelValue="(v) => (sched.frequency = v)"
+									/>
+									<div>
+										<FormLabel label="Time" class="mb-1.5" />
+										<TimePicker
+											:modelValue="sched.time"
+											placeholder="09:00"
+											@update:modelValue="(v) => (sched.time = v)"
+										/>
+									</div>
+									<!-- weekly -> weekday name, monthly -> day of month; hidden for
+									     daily. Copies the Frequency control above exactly (same
+									     FormControl type=select shape) - jarvis#653. Monthly's 31
+									     rows overflow this Select's popover with no cap of its own
+									     (frappe-ui's Select sets no max-height on its content, unlike
+									     Combobox/Autocomplete/MultiSelect) - the fix lives in
+									     src/main.css's [role="listbox"] [data-slot="content-body"]
+									     rule, app-wide for every plain Select, not here (nothing to
+									     add on this control itself). -->
+									<FormControl
+										v-if="sched.frequency !== 'daily'"
+										type="select"
+										label="Day"
+										:options="dayOptions"
+										:modelValue="sched.day"
+										@update:modelValue="(v) => (sched.day = v)"
+									/>
+								</div>
+								<!-- owner feedback: the committed schedule + its next run, ONE
+								     line, shown only while the form matches what is actually
+								     saved (scheduleDirty false) - editing any control hides
+								     this and reveals Save instead (below). -->
+								<div v-if="scheduleSummary" class="text-sm text-ink-gray-5">
+									{{ scheduleSummary }}
+								</div>
+								<!-- owner feedback: Save is not always-on chrome - it appears
+								     only once the form actually differs from the saved
+								     installation (toggle/frequency/time), and disappears again
+								     once a save lands (scheduleDirty recomputes off
+								     `installation`, which `load()` refreshes post-save). -->
+								<Button
+									v-if="scheduleDirty"
+									label="Save schedule"
+									:loading="savingSchedule"
+									@click="saveSchedule"
 								/>
 							</div>
-							<!-- weekly -> weekday name, monthly -> day of month; hidden for
-							     daily. Copies the Frequency control above exactly (same
-							     FormControl type=select shape) - jarvis#653. Monthly's 31
-							     rows overflow this Select's popover with no cap of its own
-							     (frappe-ui's Select sets no max-height on its content, unlike
-							     Combobox/Autocomplete/MultiSelect) - the fix lives in
-							     src/main.css's [role="listbox"] [data-slot="content-body"]
-							     rule, app-wide for every plain Select, not here (nothing to
-							     add on this control itself). -->
-							<FormControl
-								v-if="sched.frequency !== 'daily'"
-								type="select"
-								label="Day"
-								:options="dayOptions"
-								:modelValue="sched.day"
-								@update:modelValue="(v) => (sched.day = v)"
-							/>
-						</div>
-						<div v-if="installation.next_run_at" class="text-sm text-ink-gray-5">
-							Next run: {{ fmtDt(installation.next_run_at) }}
-						</div>
-						<!-- owner feedback: the committed schedule, shown only while the form
-						     matches what is actually saved (scheduleDirty false) - editing any
-						     control hides this and reveals Save instead. -->
-						<div v-if="scheduleSummary" class="text-sm text-ink-gray-5">
-							{{ scheduleSummary }}
-						</div>
-						<!-- Save is not always-on chrome - it appears only once the form
-						     actually differs from the saved installation, and disappears
-						     again once a save lands. -->
-						<Button
-							v-if="scheduleDirty"
-							label="Save schedule"
-							:loading="savingSchedule"
-							@click="saveSchedule"
-						/>
+						</section>
 					</div>
-				</section>
-
-				<section>
-					<div class="text-base font-medium text-ink-gray-9">Configuration</div>
-					<ConfigForm
-						class="mt-3"
-						:config="parsedConfig"
-						:saving="savingConfig"
-						@save="saveConfig"
-					/>
-				</section>
-
-				<section class="border-t pt-6">
-					<CommentsSection :docmeta="docmeta" :can-comment="true" />
-				</section>
+				</div>
 			</div>
 
 			<!-- ── Runs (installed): two-pane master-detail board ── -->
@@ -356,147 +454,136 @@
 				v-else-if="tab === 'runs' && installation"
 				ref="runsBoard"
 				:agent-name="agent.name"
+				:can-review="canReview"
 			/>
 
 			<!-- ── Admin (SM only; server enforces every call). Listing status is
 			     publisher/catalog state curated in registry.json (it reverts on the
 			     next deploy) - deliberately NOT editable here. ── -->
-			<div
-				v-else-if="tab === 'admin' && isSM"
-				class="max-w-2xl shrink-0 space-y-10 px-5 py-6"
-			>
-				<section>
-					<div class="text-base font-medium text-ink-gray-9">Allowed roles</div>
-					<div class="mt-2 text-sm text-ink-gray-5">
-						Role gating is enforced server-side on every path. An empty list means
-						everyone.
-					</div>
-					<div class="mt-3 flex flex-wrap gap-1.5">
-						<div
-							v-for="r in roleDraft"
-							:key="r"
-							class="flex h-6 items-center gap-1 rounded bg-surface-gray-2 px-2 text-sm text-ink-gray-8"
-						>
-							<span class="truncate">{{ r }}</span>
-							<Button
-								variant="ghost"
-								icon="x"
-								class="!h-4 !w-4"
-								:label="'Remove role ' + r"
-								@click="removeRole(r)"
-							/>
-						</div>
-						<span v-if="!roleDraft.length" class="text-sm text-ink-gray-4">
-							Everyone - no restriction
-						</span>
-					</div>
-					<div class="mt-3 w-72">
-						<Autocomplete
-							:options="roleOptions"
-							:modelValue="null"
-							placeholder="Add a role…"
-							@update:modelValue="(opt) => opt && addRole(opt.value)"
-						/>
-					</div>
-					<div v-if="rolesDirty" class="mt-3 flex items-center gap-2">
-						<Button label="Save roles" :loading="savingRoles" @click="saveRoles" />
-						<Button label="Reset" variant="ghost" @click="resetRoles" />
-						<span v-if="!roleDraft.length" class="text-sm text-ink-gray-5">
-							Saving with none selected clears the restriction.
-						</span>
-					</div>
-				</section>
+			<!-- v-show, NOT v-else-if like the tabs above it: the Access editor holds
+			     an unsaved draft, and the v-if chain unmounted it on every tab switch,
+			     so a half-finished grant was silently thrown away by a trip to
+			     Overview and back. v-if="isSM" still gates it, so a non-admin renders
+			     no admin markup at all - only an admin pays the cost of keeping it
+			     mounted, and only for the life of this page. -->
+			<div v-if="isSM" v-show="tab === 'admin'" class="shrink-0 px-5 py-6">
+				<!-- Access and Installs are read together - you grant, then look at who
+				     actually has it - and the page had them stacked in a 2xl column that
+				     left most of the width empty. Side by side on lg+, stacked below,
+				     with the gap doing the separating that space-y-10 used to. -->
+				<div class="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:items-start">
+					<AgentAccessEditor
+						ref="accessEditor"
+						:slug="props.slug"
+						:roles="agent.allowed_roles || []"
+						:users="agent.allowed_users || []"
+						:all-roles="agent.all_roles || []"
+						@saved="onAccessSaved"
+					/>
 
-				<section>
-					<div class="text-base font-medium text-ink-gray-9">
-						Installs ({{ installRows.length }})
-					</div>
-					<div v-if="adminLoading && !adminData" class="mt-3 text-sm text-ink-gray-5">
-						Loading installs…
-					</div>
-					<div v-else-if="!installRows.length" class="mt-3 text-sm text-ink-gray-5">
-						No installs yet.
-					</div>
-					<ListView
-						v-else
-						class="mt-3"
-						:columns="INSTALL_COLUMNS"
-						:rows="installRows"
-						row-key="installation"
-						:options="{
-							selectable: false,
-							rowHeight: 40,
-							resizeColumn: false,
-							showTooltip: true,
-						}"
-					>
-						<template #default>
-							<ListHeader>
-								<ListHeaderItem
-									v-for="column in INSTALL_COLUMNS"
-									:key="column.key"
-									:item="column"
-								/>
-							</ListHeader>
-							<ListRows />
-						</template>
-						<template #cell="{ column, row, item, align }">
-							<template v-if="column.key === 'state'">
-								<!-- State precedence, most-actionable first: Blocked > Disabled >
-								     Live > Shadow. `installable` is a last-reconciled STORED flag
-								     (see get_agent_admin_overview), so Blocked reads "as last
-								     reconciled" rather than claiming a live guarantee. -->
-								<Tooltip v-if="!row.installable" :text="blockedReason(row)">
-									<Badge variant="subtle" theme="orange" label="Blocked" />
-								</Tooltip>
-								<Badge
-									v-else-if="!row.enabled"
-									variant="subtle"
-									theme="gray"
-									label="Disabled"
-								/>
-								<Badge
-									v-else-if="row.activation_state === 'live'"
-									variant="subtle"
-									theme="green"
-									label="Live"
-								/>
-								<ShadowChip v-else label="Shadow" />
+					<section class="min-w-0">
+						<div class="text-base font-medium text-ink-gray-9">
+							Installs ({{ installRows.length }})
+						</div>
+						<div
+							v-if="adminLoading && !adminData"
+							class="mt-3 text-sm text-ink-gray-5"
+						>
+							Loading installs…
+						</div>
+						<div v-else-if="!installRows.length" class="mt-3 text-sm text-ink-gray-5">
+							No installs yet.
+						</div>
+						<ListView
+							v-else
+							class="mt-3"
+							:columns="INSTALL_COLUMNS"
+							:rows="installRows"
+							row-key="installation"
+							:options="{
+								selectable: false,
+								rowHeight: 40,
+								resizeColumn: false,
+								showTooltip: true,
+							}"
+						>
+							<template #default>
+								<ListHeader>
+									<ListHeaderItem
+										v-for="column in INSTALL_COLUMNS"
+										:key="column.key"
+										:item="column"
+									/>
+								</ListHeader>
+								<ListRows />
 							</template>
-							<div
-								v-else-if="column.key === 'run_as_user'"
-								class="truncate text-base"
-							>
-								<span v-if="row.run_as_user">{{ row.run_as_user }}</span>
-								<Badge
+							<template #cell="{ column, row, item, align }">
+								<template v-if="column.key === 'state'">
+									<!-- State precedence, most-actionable first: Blocked > Disabled >
+									     Live > Shadow. `installable` is a last-reconciled STORED flag
+									     (see get_agent_admin_overview), so Blocked reads "as last
+									     reconciled" rather than claiming a live guarantee. -->
+									<Tooltip v-if="!row.installable" :text="blockedReason(row)">
+										<Badge variant="subtle" theme="orange" label="Blocked" />
+									</Tooltip>
+									<Badge
+										v-else-if="!row.enabled"
+										variant="subtle"
+										theme="gray"
+										label="Disabled"
+									/>
+									<Badge
+										v-else-if="row.activation_state === 'live'"
+										variant="subtle"
+										theme="green"
+										label="Live"
+									/>
+									<!-- jarvis#1062 P2-11 (production-readiness audit): the Blocked
+									     badge just above already explains itself on hover - Shadow
+									     is the only other State value that names a mode without
+									     saying what it means. -->
+									<Tooltip
+										v-else
+										text="Preview mode: runs are visible only to the reviewer until promoted to live."
+									>
+										<ShadowChip label="Shadow" />
+									</Tooltip>
+								</template>
+								<div
+									v-else-if="column.key === 'run_as_user'"
+									class="truncate text-base"
+								>
+									<span v-if="row.run_as_user">{{ row.run_as_user }}</span>
+									<Badge
+										v-else
+										variant="subtle"
+										theme="orange"
+										label="No run-as user"
+									/>
+								</div>
+								<div
+									v-else-if="column.key === 'last_run_at'"
+									class="truncate text-base"
+								>
+									{{ row.last_run_at ? timeAgo(row.last_run_at) : "-" }}
+								</div>
+								<div
+									v-else-if="column.key === 'sync_status'"
+									class="truncate text-base"
+								>
+									{{ row.sync_status || "-" }}
+								</div>
+								<ListRowItem
 									v-else
-									variant="subtle"
-									theme="orange"
-									label="No run-as user"
+									:column="column"
+									:row="row"
+									:item="item"
+									:align="align"
 								/>
-							</div>
-							<div
-								v-else-if="column.key === 'last_run_at'"
-								class="truncate text-base"
-							>
-								{{ row.last_run_at ? timeAgo(row.last_run_at) : "-" }}
-							</div>
-							<div
-								v-else-if="column.key === 'sync_status'"
-								class="truncate text-base"
-							>
-								{{ row.sync_status || "-" }}
-							</div>
-							<ListRowItem
-								v-else
-								:column="column"
-								:row="row"
-								:item="item"
-								:align="align"
-							/>
-						</template>
-					</ListView>
-				</section>
+							</template>
+						</ListView>
+					</section>
+				</div>
 			</div>
 		</div>
 
@@ -517,14 +604,14 @@
 // Marketplace template: de-texted hero (logo · name · one meta line ·
 // one-line tagline · category chips; install count + Enabled switch right) →
 // hash-synced tabs. Overview (markdown description + static facts panel) ·
-// Configure (schedule / ConfigForm / CommentsSection on the installation, D28)
-// · Runs (AgentRunsBoard: two-pane runs rail → findings pane) · Admin
-// (SM-only: roles editor + installs overview; listing status is registry.json
-// publisher state and intentionally has no tenant control here).
+// Configure (schedule / ConfigForm on the installation, D28) · Runs
+// (AgentRunsBoard: two-pane runs rail → findings pane, which now also carries
+// Notes-on-the-run, jarvis#1062 - Comments moved off this tab entirely) ·
+// Admin (admin-only: the Access editor + installs overview; listing status is
+// registry.json publisher state and intentionally has no tenant control here).
 import { ref, computed, watch, nextTick } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { onBeforeRouteLeave, useRoute, useRouter } from "vue-router";
 import {
-	Autocomplete,
 	Badge,
 	Breadcrumbs,
 	Button,
@@ -545,20 +632,21 @@ import {
 } from "frappe-ui";
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import TabBar from "@/components/list/TabBar.vue";
-import CommentsSection from "@/components/doc/CommentsSection.vue";
 import AgentRunsBoard from "@/pages/agents/AgentRunsBoard.vue";
 import ActivationPanel from "@/pages/agents/ActivationPanel.vue";
+import AgentAccessEditor from "@/pages/agents/AgentAccessEditor.vue";
 import ConfigForm from "@/pages/agents/ConfigForm.vue";
 import AppSourceConsentDialog from "@/components/learning/AppSourceConsentDialog.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
 import ShadowChip from "@/components/ShadowChip.vue";
-import { useDocmeta } from "@/composables/useDocmeta";
-import { session } from "@/data/session";
 import { timeAgo, exactDate as fmtDt } from "@/utils/datetime";
 import * as api from "@/api";
 import * as apiAgents from "@/api/agents";
 import { renderMarkdown } from "@/markdown";
 import { errMessage as errMsg, errHtml } from "@/lib/errors";
+import { session } from "@/data/session";
+import { parseListField } from "@/lib/parseListField";
+import { categoryTitle } from "@/lib/agentCategory";
 import {
 	WEEKDAY_OPTIONS,
 	DAY_OF_MONTH_OPTIONS,
@@ -573,11 +661,6 @@ const props = defineProps({
 const route = useRoute();
 const router = useRouter();
 
-// display metadata (mirrors AgentsList / registry.json domains)
-const DOMAINS = [
-	{ slug: "close", title: "Close & Reporting" },
-	{ slug: "bank-recon", title: "Bank & Reconciliation" },
-];
 const FREQUENCY_OPTIONS = [
 	{ label: "Daily", value: "daily" },
 	{ label: "Weekly", value: "weekly" },
@@ -618,6 +701,12 @@ function blockedReason(row) {
 // ── data ──────────────────────────────────────────────────────────────────────
 const agent = ref(null); // get_agent payload (§8.3)
 const error = ref("");
+// jarvis#1062 fix: Configure/Runs only exist once `installation` resolves
+// (tabs computed, below) - true only after this first settles (success or
+// error). applyHash() reads this to tell "the hash names a tab that does
+// not exist YET" (still loading - wait) apart from "...that never will"
+// (settled - give up to Overview for real).
+const initialLoadSettled = ref(false);
 
 async function load() {
 	try {
@@ -627,7 +716,10 @@ async function load() {
 		error.value = errMsg(e);
 	}
 }
-load().then(applyHash);
+load().then(() => {
+	initialLoadSettled.value = true;
+	applyHash();
+});
 watch(
 	() => props.slug,
 	() => {
@@ -635,7 +727,11 @@ watch(
 		error.value = "";
 		adminData.value = null;
 		activation.value = null;
-		load().then(applyHash);
+		initialLoadSettled.value = false;
+		load().then(() => {
+			initialLoadSettled.value = true;
+			applyHash();
+		});
 	}
 );
 
@@ -687,12 +783,23 @@ watch(
 	{ immediate: true }
 );
 
-// The named reviewer's sign-off, or a Jarvis Admin (agents_api mirrors this
-// server-side - this only decides whether to show the button, never grants
-// the action itself).
-const canActOnActivation = computed(
-	() => !!activation.value && (session.user === activation.value.reviewer || isSM.value)
-);
+// ── reviewer capability (jarvis#1062) ────────────────────────────────────────
+// The reviewer set (Jarvis Skill Reviewer / Jarvis Admin / System Manager), read
+// from get_agents_caps().review - the SAME capability apply_agents and
+// promote_installation gate on, so the button appears exactly when the call
+// would succeed. It replaced `session.user === activation.reviewer`: install_agent
+// stamps reviewer = the installer, so that test made every installer their own
+// approver and put the whole shadow/attestation vocabulary in front of people who
+// have no say over it. A plain user now sees nothing about shadow at all.
+const canReview = ref(false);
+(async () => {
+	try {
+		canReview.value = !!((await apiAgents.getAgentsCaps()) || {}).review;
+	} catch {
+		canReview.value = false; // fail closed: no control, no shadow copy
+	}
+})();
+const canActOnActivation = computed(() => !!activation.value && canReview.value);
 function onActivationChanged(next) {
 	activation.value = next;
 }
@@ -713,7 +820,21 @@ const tabs = computed(() => {
 
 function applyHash() {
 	const h = (route.hash || "").replace(/^#/, "");
-	tab.value = tabs.value.some((t) => t.value === h) ? h : "overview";
+	if (!h) {
+		tab.value = "overview";
+		return;
+	}
+	if (tabs.value.some((t) => t.value === h)) {
+		tab.value = h;
+		return;
+	}
+	// h names a tab that is not in the set RIGHT NOW - Configure/Runs need
+	// `installation`, which is only known once the async get_agent fetch
+	// resolves. Only a settled load makes "not in tabs.value" a real verdict;
+	// until then, leave tab.value alone (the page shows "Loading agent…"
+	// regardless) rather than lock in Overview and drop the requested tab -
+	// load()/the slug watcher re-run applyHash() once settled.
+	if (initialLoadSettled.value) tab.value = "overview";
 }
 function setTab(v) {
 	if (tab.value === v && route.hash === "#" + v) return;
@@ -734,19 +855,38 @@ watch(tabs, (list) => {
 
 // ── header actions ────────────────────────────────────────────────────────────
 const installing = ref(false);
+// jarvis#1062 polish: the toast auto-dismisses after ~2s, easy to miss - keep
+// a persistent inline echo under the Install button until the next attempt.
+const installError = ref("");
+// jarvis#1062 polish: install_agent refuses a run-as identity of
+// Administrator ("agents cannot run as Administrator") - read the session
+// user the same way @/data/session already exposes it elsewhere, and
+// disable Install client-side instead of letting the click round-trip into
+// a toast-only refusal.
+const isAdministratorSession = computed(() => session.user === "Administrator");
 const canInstall = computed(
-	() => !!(agent.value && agent.value.allowed && agent.value.status === "Published")
+	() =>
+		!!(
+			agent.value &&
+			agent.value.allowed &&
+			agent.value.status === "Published" &&
+			!isAdministratorSession.value
+		)
 );
 const installTooltip = computed(() => {
 	if (!agent.value || canInstall.value) return "";
+	if (isAdministratorSession.value) return "Log in as a named user to install this agent.";
+	// Never the roster: get_agent strips allowed_roles/allowed_users for non-admins,
+	// and naming who DOES have access is admin information anyway.
 	if (!agent.value.allowed)
-		return "Restricted to: " + ((agent.value.allowed_roles || []).join(", ") || "-");
+		return "You do not have access to this agent. Ask your administrator.";
 	return agent.value.status === "Coming Soon" ? "Coming soon" : "Not available to install";
 });
 
 async function install() {
 	if (installing.value || !canInstall.value) return;
 	installing.value = true;
+	installError.value = "";
 	const p = api.installAgent(props.slug);
 	toast.promise(p, {
 		loading: "Installing…",
@@ -756,6 +896,7 @@ async function install() {
 	try {
 		await p;
 	} catch (e) {
+		installError.value = errMsg(e);
 		installing.value = false;
 		return;
 	}
@@ -796,9 +937,14 @@ const runTooltip = computed(() => {
 	if (nature !== "Auditor" && nature !== "Scribe")
 		return "Operators draft through the Approval Board - no on-demand runs";
 	if (!installation.value.enabled) return "Enable the agent first";
-	if (!agent.value.allowed) return "Your roles do not permit this agent";
+	if (!agent.value.allowed) return "You do not have access to this agent";
+	// The shadow vocabulary is reviewer language (jarvis#1062): a plain user has
+	// no promote control and no say in the sign-off, so telling them to go and
+	// promote it names an action they cannot take.
 	if (shadowScribeBlocked.value)
-		return "Still in shadow preview - promote it to live under Configure first";
+		return canReview.value
+			? "Still in shadow preview - promote it to live under Configure first"
+			: "Not yet enabled for live runs - ask your administrator";
 	return nature === "Scribe" ? "Run this agent now" : "Run this audit now";
 });
 
@@ -847,9 +993,11 @@ function confirmUninstall() {
 	const name = installation.value.name;
 	confirmDialog({
 		title: `Uninstall ${agent.value.title}?`,
-		// the backend cascade-deletes findings → runs → installation
+		// the backend cascade-deletes findings → runs → installation, but never
+		// touches a run's linked Jarvis Dashboard (#1062 polish - the warning was
+		// overclaiming what actually gets deleted).
 		message:
-			"This removes the agent and ALL of its run history and findings. This can't be undone.",
+			"This removes the agent and its run history and findings; saved dashboards are kept. This can't be undone.",
 		onConfirm: async ({ hideDialog }) => {
 			try {
 				await api.uninstallAgent(name);
@@ -904,20 +1052,18 @@ const descriptionHtml = computed(() =>
 );
 const needs = computed(() => {
 	if (!agent.value) return [];
-	const out = [];
-	for (const key of ["tools_required", "min_apps"]) {
-		let v = agent.value[key];
-		if (typeof v === "string" && v.trim()) {
-			try {
-				v = JSON.parse(v);
-			} catch (e) {
-				v = null;
-			}
-		}
-		if (Array.isArray(v)) out.push(...v.map(String));
-	}
-	return out;
+	return ["tools_required", "min_apps"].flatMap((key) => parseListField(agent.value[key]));
 });
+// jarvis#1062 polish: shares parseListField with `needs`, its own field/
+// heading - doctypes_required (A12) is a distinct concept (records read,
+// not tools/apps).
+const readsRecords = computed(() =>
+	agent.value ? parseListField(agent.value.doctypes_required) : []
+);
+// jarvis#1063 (jarvis-only half): which agent-specific config keys this
+// agent's bundle actually reads (get_agent) - gates ConfigForm's
+// agent-specific fields; [] shows its "no additional settings" note.
+const configKeys = computed(() => (agent.value ? parseListField(agent.value.config_keys) : []));
 const defaultScheduleText = computed(() => {
 	let s = {};
 	try {
@@ -929,15 +1075,6 @@ const defaultScheduleText = computed(() => {
 	if (!freq) return "None - runs on demand.";
 	return s.schedule_enabled ? `On by default · ${freq}` : `Off by default · suggested ${freq}`;
 });
-function categoryTitle(slug) {
-	const d = DOMAINS.find((x) => x.slug === slug);
-	if (d) return d.title;
-	return String(slug || "other")
-		.split("-")
-		.map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
-		.join(" ");
-}
-
 // ── Configure: schedule ───────────────────────────────────────────────────────
 const sched = ref({ enabled: false, frequency: "daily", time: "09:00", day: "" });
 const savingSchedule = ref(false);
@@ -1097,9 +1234,9 @@ async function saveConfig(merged) {
 	}
 }
 
-// ── Configure: comments on the installation (D28, B3 contract) ───────────────
-const instName = computed(() => (installation.value && installation.value.name) || null);
-const docmeta = useDocmeta("Jarvis Agent Installation", instName);
+// jarvis#1062: Comments moved off Configure onto the Run itself
+// (FindingsPanel.vue's new Notes section) - existing installation comments
+// are deliberately left in the DB, unmigrated, just no longer surfaced here.
 
 // ── Admin (SM) ────────────────────────────────────────────────────────────────
 const adminData = ref(null); // {roles, listings} from get_agent_admin_overview
@@ -1130,59 +1267,64 @@ const adminListing = computed(() => {
 });
 const installRows = computed(() => (adminListing.value && adminListing.value.installs) || []);
 
-// roles editor (Autocomplete over all_roles → chips → Save)
-const roleDraft = ref([]);
-const savingRoles = ref(false);
-watch(
-	() => agent.value && agent.value.allowed_roles,
-	(v) => {
-		roleDraft.value = [...(v || [])];
-	},
-	{ immediate: true }
-);
-const roleOptions = computed(() => {
-	const all = (agent.value && agent.value.all_roles) || [];
-	const taken = new Set(roleDraft.value);
-	return all.filter((r) => !taken.has(r)).map((r) => ({ label: r, value: r }));
+// ── access (jarvis#1062) ──────────────────────────────────────────────────────
+// The editor itself is AgentAccessEditor.vue; the detail page only owns the
+// saved value, so the Overview summary and the Admin tab cannot disagree.
+const accessGrants = computed(() => [
+	...((agent.value && agent.value.allowed_roles) || []),
+	...((agent.value && agent.value.allowed_users) || []),
+]);
+function onAccessSaved(next) {
+	if (!agent.value) return;
+	agent.value.allowed_roles = next.allowed_roles || [];
+	agent.value.allowed_users = next.allowed_users || [];
+	load(); // re-read `allowed` - an admin can lock themselves out of the user surface
+}
+
+// ── leaving the page with an unsaved access draft ────────────────────────────
+// Keeping the editor mounted saves the draft from a TAB switch; this saves it
+// from a ROUTE change. frappe-ui's confirmDialog, not useConfirm(): its own docs
+// say the frappe-ui-styled list/detail pages (agents among them) use frappe-ui's
+// dialog and the jv- surfaces use the other one - "don't cross the streams".
+const accessEditor = ref(null);
+// Set only for the navigation we have already asked about, so confirming does
+// not re-open the dialog on the re-push below.
+let leaveConfirmed = false;
+
+onBeforeRouteLeave((to) => {
+	if (leaveConfirmed || !accessEditor.value?.dirty) return true;
+	confirmDialog({
+		title: "Discard unsaved access changes?",
+		message:
+			"Your changes to who can use this agent have not been saved. Leaving now discards them.",
+		onConfirm: ({ hideDialog }) => {
+			hideDialog();
+			leaveConfirmed = true;
+			router.push(to.fullPath);
+		},
+	});
+	// Refuse the navigation rather than holding a `next` callback open: a
+	// dismissed dialog (Escape, backdrop) never calls onConfirm, and a guard that
+	// was waiting on that callback would wedge routing for the rest of the
+	// session. Cancelling costs nothing - the user is already where they were.
+	return false;
 });
-const rolesDirty = computed(() => {
-	const a = [...roleDraft.value].sort().join("|");
-	const b = [...((agent.value && agent.value.allowed_roles) || [])].sort().join("|");
-	return a !== b;
-});
-function addRole(r) {
-	if (!roleDraft.value.includes(r)) roleDraft.value = [...roleDraft.value, r];
-}
-function removeRole(r) {
-	roleDraft.value = roleDraft.value.filter((x) => x !== r);
-}
-function resetRoles() {
-	roleDraft.value = [...((agent.value && agent.value.allowed_roles) || [])];
-}
-async function saveRoles() {
-	if (savingRoles.value) return;
-	savingRoles.value = true;
-	try {
-		const r = await api.setAgentRoles(props.slug, roleDraft.value);
-		agent.value.allowed_roles = (r && r.allowed_roles) || [];
-		roleDraft.value = [...agent.value.allowed_roles];
-		toast.success(
-			agent.value.allowed_roles.length
-				? "Roles saved"
-				: "Restriction cleared - available to everyone"
-		);
-		load(); // refresh allowed/lock state
-	} catch (e) {
-		toast.error(errHtml(e));
-	} finally {
-		savingRoles.value = false;
-	}
-}
 
 // ── formatting helpers ────────────────────────────────────────────────────────
 // "9:00:00" (python str(timedelta)) → "09:00" for the TimePicker
 function timeHHMM(s) {
 	const m = /^(\d{1,2}):(\d{2})/.exec(String(s || ""));
 	return m ? `${m[1].padStart(2, "0")}:${m[2]}` : "";
+}
+// "09:00" → "9:00 am" - mirrors TimePicker's OWN formatDisplay (frappe-ui,
+// use12Hour default) exactly, so the schedule summary line reads the same
+// way the picker itself would show that time.
+function formatTime12h(hhmm) {
+	const m = /^(\d{1,2}):(\d{2})/.exec(String(hhmm || ""));
+	if (!m) return "";
+	const h = parseInt(m[1], 10);
+	const am = h < 12;
+	const h12 = h % 12 === 0 ? 12 : h % 12;
+	return `${h12}:${m[2]} ${am ? "am" : "pm"}`;
 }
 </script>

--- a/frontend/src/pages/agents/AgentRunsBoard.spec.js
+++ b/frontend/src/pages/agents/AgentRunsBoard.spec.js
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#1062 - AgentRunsBoard's stopped status theme (C1) and the 10s poll
+ * that keeps a running run's rail row fresh without a manual refresh (C3):
+ * started while any VISIBLE run is running, cleared on tab-hidden and on
+ * unmount, and never a second competing refresh path alongside the existing
+ * visibilitychange machinery.
+ */
+
+const apiAgents = vi.hoisted(() => ({ listRunsPage: vi.fn() }));
+vi.mock("@/api/agents", () => apiAgents);
+
+const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
+const routeMock = vi.hoisted(() => ({ hash: "#runs", query: {} }));
+vi.mock("vue-router", () => ({
+	useRouter: () => router,
+	useRoute: () => routeMock,
+}));
+
+// frappe-ui's ESM entry does not resolve under vitest (see LlmPoolEditor.spec.js).
+vi.mock("frappe-ui", () => ({
+	dayjs: () => ({ format: () => "" }),
+	dayjsLocal: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
+	getConfig: () => null,
+	toast: { error: vi.fn(), success: vi.fn() },
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant"],
+		template: `<span class="badge" :data-theme="theme">{{ label }}</span>`,
+	},
+	Button: {
+		name: "Button",
+		props: ["label", "loading", "variant", "icon", "tooltip"],
+		emits: ["click"],
+		template: `<button @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "options", "placeholder"],
+		emits: ["update:modelValue"],
+		template: `<input :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+	Tooltip: { name: "Tooltip", template: `<span><slot /></span>` },
+}));
+
+vi.mock("@/components/JvSpinner.vue", () => ({
+	default: { name: "JvSpinner", template: `<div class="spinner" />` },
+}));
+// stubbed out entirely - its own behaviour is covered by FindingsPanel.spec.js;
+// mounting it for real here would also need a vue-router mock for no reason.
+vi.mock("@/pages/agents/FindingsPanel.vue", () => ({
+	default: {
+		name: "FindingsPanel",
+		props: ["run"],
+		emits: ["stopped"],
+		template: `<div class="findings-panel" />`,
+	},
+}));
+
+import AgentRunsBoard from "./AgentRunsBoard.vue";
+
+function runRow(overrides = {}) {
+	return {
+		name: "RUN-0001",
+		status: "running",
+		trigger: "manual",
+		started_at: "2026-09-01 10:00:00",
+		findings_count: 0,
+		blocker_count: 0,
+		nature: "Auditor",
+		...overrides,
+	};
+}
+
+function envelope(rows) {
+	return { rows, total: rows.length, has_more: false, start: 0, page_length: 20 };
+}
+
+function mountBoard() {
+	return mount(AgentRunsBoard, { props: { agentName: "close-auditor" } });
+}
+
+function setVisibility(state) {
+	Object.defineProperty(document, "visibilityState", {
+		value: state,
+		writable: true,
+		configurable: true,
+	});
+	document.dispatchEvent(new Event("visibilitychange"));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	setVisibility("visible");
+	routeMock.hash = "#runs";
+	routeMock.query = {};
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("C1: the rail's status theme covers stopped", () => {
+	it("renders the stopped status pill with the gray theme", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "stopped" })]));
+		const w = mountBoard();
+		await flushPromises();
+		const badges = w.findAll(".badge");
+		expect(
+			badges.some((b) => b.attributes("data-theme") === "gray" && b.text() === "stopped")
+		).toBe(true);
+	});
+});
+
+describe("C3: 10s poll while a visible run is running", () => {
+	it("polls the runs list every 10s while a running row is loaded", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "running" })]));
+		mountBoard();
+		await flushPromises();
+		const callsAfterMount = apiAgents.listRunsPage.mock.calls.length;
+
+		await vi.advanceTimersByTimeAsync(10000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBe(callsAfterMount + 1);
+
+		await vi.advanceTimersByTimeAsync(10000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBe(callsAfterMount + 2);
+	});
+
+	it("stops polling once no loaded row is running", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "running" })]));
+		mountBoard();
+		await flushPromises();
+
+		// the next poll observes the run finished - no more running rows loaded
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "completed" })]));
+		await vi.advanceTimersByTimeAsync(10000);
+		await flushPromises();
+		const callsOnceFinished = apiAgents.listRunsPage.mock.calls.length;
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBe(callsOnceFinished);
+	});
+
+	it("never runs while a running row is loaded but the tab is hidden", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "running" })]));
+		mountBoard();
+		await flushPromises();
+		const callsAfterMount = apiAgents.listRunsPage.mock.calls.length;
+
+		setVisibility("hidden");
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBe(callsAfterMount);
+
+		// visible again: the existing visibilitychange refresh fires once, and
+		// the poll resumes for subsequent ticks.
+		setVisibility("visible");
+		await flushPromises();
+		const callsOnVisible = apiAgents.listRunsPage.mock.calls.length;
+		expect(callsOnVisible).toBeGreaterThan(callsAfterMount);
+
+		await vi.advanceTimersByTimeAsync(10000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBeGreaterThan(callsOnVisible);
+	});
+
+	it("clears the interval on unmount (no leaked poll)", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "running" })]));
+		const w = mountBoard();
+		await flushPromises();
+		const callsBeforeUnmount = apiAgents.listRunsPage.mock.calls.length;
+
+		w.unmount();
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBe(callsBeforeUnmount);
+	});
+
+	it("never polls at all when no loaded row is running", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "completed" })]));
+		mountBoard();
+		await flushPromises();
+		const callsAfterMount = apiAgents.listRunsPage.mock.calls.length;
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunsPage.mock.calls.length).toBe(callsAfterMount);
+	});
+});
+
+describe("jarvis#1062: ?run=<id> query-param preselection (deep-linked from the Activity feed)", () => {
+	it("selects the row matching the query instead of the newest row", async () => {
+		routeMock.query = { run: "RUN-0002" };
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([runRow({ name: "RUN-0001" }), runRow({ name: "RUN-0002" })])
+		);
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.findComponent({ name: "FindingsPanel" }).props("run").name).toBe("RUN-0002");
+	});
+
+	it("clears the run param from the URL once applied, WITHOUT dropping the hash", async () => {
+		// jarvis#1062 fix: router.replace({query}) alone is a partial location
+		// that drops the current hash entirely (verified against real
+		// vue-router - {query} alone resolves to the bare path, no "#runs").
+		// That silently knocked AgentDetail back onto Overview a moment after
+		// landing on Runs, since route.hash changing to "" is exactly what its
+		// hash watcher reads as "go to the default tab".
+		routeMock.hash = "#runs";
+		routeMock.query = { run: "RUN-0002", other: "kept" };
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([runRow({ name: "RUN-0001" }), runRow({ name: "RUN-0002" })])
+		);
+		mountBoard();
+		await flushPromises();
+		expect(router.replace).toHaveBeenCalledWith({ hash: "#runs", query: { other: "kept" } });
+	});
+
+	it("falls back to the first row (and still clears the query, keeping the hash) when the id isn't in this page", async () => {
+		routeMock.hash = "#runs";
+		routeMock.query = { run: "RUN-NOT-LOADED" };
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ name: "RUN-0001" })]));
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.findComponent({ name: "FindingsPanel" }).props("run").name).toBe("RUN-0001");
+		expect(router.replace).toHaveBeenCalledWith({ hash: "#runs", query: {} });
+	});
+
+	it("is ignored on a later refresh once an explicit selection exists", async () => {
+		routeMock.query = {};
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([runRow({ name: "RUN-0001" }), runRow({ name: "RUN-0002" })])
+		);
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.findComponent({ name: "FindingsPanel" }).props("run").name).toBe("RUN-0001");
+
+		// a query appearing after the initial load (e.g. a stale route object in
+		// a test) must not hijack an already-explicit selection.
+		routeMock.query = { run: "RUN-0002" };
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([runRow({ name: "RUN-0001" }), runRow({ name: "RUN-0002" })])
+		);
+		await w.vm.reload();
+		await flushPromises();
+		expect(w.findComponent({ name: "FindingsPanel" }).props("run").name).toBe("RUN-0001");
+	});
+});
+
+// jarvis#1062 P1-7 (production-readiness audit): failed and stopped runs
+// both showed "0 findings" in the rail with no way to tell them apart
+// without opening the run.
+describe("run rows show a short reason for failed/stopped (jarvis#1062 P1-7)", () => {
+	it("shows the recorded error under a failed run's row", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([runRow({ status: "failed", error: "LLM timed out after 30s." })])
+		);
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.text()).toContain("LLM timed out after 30s.");
+	});
+
+	it("shows the fixed operator message under a stopped run's row", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow({ status: "stopped" })]));
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.text()).toContain("Stopped by operator.");
+	});
+
+	it("shows no reason line for a completed or running run", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([runRow({ status: "completed" }), runRow({ status: "running" })])
+		);
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.text()).not.toContain("Stopped by operator.");
+	});
+
+	it("failed and stopped read differently even with identical 0-findings counts", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(
+			envelope([
+				runRow({ name: "RUN-F", status: "failed", error: "boom" }),
+				runRow({ name: "RUN-S", status: "stopped" }),
+			])
+		);
+		const w = mountBoard();
+		await flushPromises();
+		expect(w.text()).toContain("boom");
+		expect(w.text()).toContain("Stopped by operator.");
+	});
+});
+
+// jarvis#1062 P1-5 (production-readiness audit): a raw <button> with no
+// focus-visible ring - keyboard tabbing through the runs rail was invisible.
+describe("run row keyboard focus (jarvis#1062 P1-5)", () => {
+	it("every run row carries a focus-visible ring", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow()]));
+		const w = mountBoard();
+		await flushPromises();
+		const row = w.find("button.flex.w-full.items-start");
+		expect(row.exists()).toBe(true);
+		expect(row.classes()).toContain("focus-visible:ring-2");
+		expect(row.classes()).toContain("focus-visible:ring-outline-gray-3");
+	});
+});
+
+// jarvis#1062 P2-12 (production-readiness audit): the rail was a hard
+// w-[360px] flex row item with no min-w-0 on the details pane - it
+// overflowed the page horizontally on a narrow viewport instead of
+// collapsing to a stacked layout.
+describe("responsive layout: stacks below lg, no fixed-width overflow (jarvis#1062 P2-12)", () => {
+	it("the rail is full-width and border-b below lg, fixed-width and border-r at lg+", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow()]));
+		const w = mountBoard();
+		await flushPromises();
+		const rail = w.find(".overflow-y-auto.border-b");
+		expect(rail.exists()).toBe(true);
+		expect(rail.classes()).toContain("w-full");
+		expect(rail.classes()).toContain("lg:w-[360px]");
+		expect(rail.classes()).toContain("lg:border-r");
+	});
+
+	it("the details pane carries min-w-0 so it can shrink instead of forcing overflow", async () => {
+		apiAgents.listRunsPage.mockResolvedValue(envelope([runRow()]));
+		const w = mountBoard();
+		await flushPromises();
+		const pane = w.find(".min-w-0.flex-1.overflow-y-auto");
+		expect(pane.exists()).toBe(true);
+	});
+});

--- a/frontend/src/pages/agents/AgentRunsBoard.vue
+++ b/frontend/src/pages/agents/AgentRunsBoard.vue
@@ -23,16 +23,27 @@
 			<Button :tooltip="'Refresh'" icon="refresh-cw" :loading="loading" @click="reload()" />
 		</div>
 
-		<div class="flex min-h-0 flex-1">
+		<!-- jarvis#1062 P2-12 (production-readiness audit): this was a plain
+		     `flex` row with a HARD w-[360px] rail and no min-w-0 on the details
+		     pane - at a narrow viewport (390px) that overflowed the page
+		     horizontally instead of collapsing. Stacked below lg (rail on top,
+		     capped height, its own scroll; details pane below, full width);
+		     side-by-side at lg+, unchanged from before. -->
+		<div class="flex min-h-0 flex-1 flex-col lg:flex-row">
 			<!-- LEFT rail: run history on a standing gray-1 surface so the selected
 			     row's white chip + shadow reads in light mode (§15.2 pattern) -->
-			<div class="w-[360px] shrink-0 overflow-y-auto border-r bg-surface-gray-1">
+			<div
+				class="max-h-[40vh] w-full shrink-0 overflow-y-auto border-b bg-surface-gray-1 lg:max-h-none lg:w-[360px] lg:border-b-0 lg:border-r"
+			>
 				<template v-if="rows.length">
 					<div class="flex flex-col divide-y">
+						<!-- jarvis#1062 P1-5 (production-readiness audit): a raw <button>
+						     with no focus-visible ring - keyboard tabbing through the
+						     runs rail was invisible. -->
 						<button
 							v-for="row in rows"
 							:key="row.name"
-							class="flex w-full items-start gap-3 px-4 py-3 text-left"
+							class="flex w-full items-start gap-3 px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3"
 							:class="
 								row.name === selectedId
 									? 'bg-surface-selected shadow-sm'
@@ -72,6 +83,21 @@
 										}}
 									</span>
 								</div>
+								<!-- jarvis#1062 P1-7 (production-readiness audit): failed and
+								     stopped both showed "0 findings" with nothing to tell them
+								     apart without opening the run. A short reason line now
+								     distinguishes them right in the row. -->
+								<div
+									v-if="runReason(row)"
+									class="mt-1 truncate text-sm"
+									:class="
+										row.status === 'failed'
+											? 'text-ink-red-4'
+											: 'text-ink-gray-5'
+									"
+								>
+									{{ runReason(row) }}
+								</div>
 							</div>
 							<!-- partial scans carry an extra indicator so truncated coverage
 							     never blends in with clean completed runs -->
@@ -92,7 +118,7 @@
 							     frappe-ui 0.1.278, so this reuses the app's violet-pill
 							     recipe (see triggers/TriggersListPane.vue). -->
 							<span
-								v-if="row.preparation_mode === 'shadow'"
+								v-if="canReview && row.preparation_mode === 'shadow'"
 								class="mt-0.5 inline-flex h-5 shrink-0 select-none items-center whitespace-nowrap rounded-full bg-surface-violet-1 px-1.5 text-xs text-ink-violet-1"
 							>
 								Preview
@@ -143,14 +169,17 @@
 				</div>
 			</div>
 
-			<!-- RIGHT pane: the selected run's findings -->
-			<div class="flex-1 overflow-y-auto">
+			<!-- RIGHT pane: the selected run's findings. min-w-0 - a flex item
+			     otherwise floors at its content's natural width (a long finding
+			     title, an action-button row), which is how the row overflowed
+			     the page instead of the CONTENT wrapping/scrolling in place. -->
+			<div class="min-w-0 flex-1 overflow-y-auto">
 				<!-- PP-4 shadow banner: the honest "Preview (shadow) - not a compliant
 				     attestation" statement must live in the reviewer's primary screen,
 				     not only in the detached fallback-dashboard HTML. Shown whenever the
 				     selected run was prepared in shadow, above the findings pane. -->
 				<div
-					v-if="selectedRun && selectedRun.preparation_mode === 'shadow'"
+					v-if="canReview && selectedRun && selectedRun.preparation_mode === 'shadow'"
 					class="flex items-start gap-2 border-b bg-surface-violet-1 px-6 py-2.5 text-sm text-ink-violet-1"
 				>
 					<FeatherIcon name="eye" class="size-4 shrink-0" />
@@ -172,7 +201,7 @@
 						</span>
 					</div>
 				</div>
-				<FindingsPanel v-else :run="selectedRun" />
+				<FindingsPanel v-else :run="selectedRun" @stopped="refreshKeep" />
 			</div>
 		</div>
 	</div>
@@ -187,15 +216,23 @@
 // reload({selectNewest: true}) through the exposed handle so the freshly
 // queued run is surfaced and selected even if a facet would hide it.
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { Badge, Button, FeatherIcon, FormControl, Tooltip } from "frappe-ui";
 import FindingsPanel from "@/pages/agents/FindingsPanel.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
 import { useListPage } from "@/composables/useListPage";
 import { timeAgo, exactDate } from "@/utils/datetime";
 import * as apiAgents from "@/api/agents";
+import { STATUS_THEME, runReason } from "@/lib/agentRunStatus";
 
 const props = defineProps({
 	agentName: { type: String, required: true }, // listing docname (list_runs_page filter)
+	// jarvis#1062: shadow/attestation is REVIEWER vocabulary. The pill and the
+	// banner below explain a distinction only a reviewer can act on (they hold the
+	// promote control), so a plain user sees neither - not a softened version of
+	// them, none. Defaults false so a caller that forgets the prop under-discloses
+	// rather than leaking the reviewer surface.
+	canReview: { type: Boolean, default: false },
 });
 
 // lifecycle status (did the run finish) is ONE axis; PP-4 preparation_mode
@@ -203,13 +240,15 @@ const props = defineProps({
 // is an orthogonal axis rendered separately as the "Preview" pill/banner above.
 // A shadow run must never read the same as a live one. preparation_mode is
 // supplied per row by list_runs_page (agents_api.py) — see cross-file note.
-const STATUS_THEME = { running: "blue", completed: "green", partial: "orange", failed: "red" };
+// STATUS_THEME itself lives in @/lib/agentRunStatus so AgentActivityTab's run
+// rows use the identical colours.
 const STATUS_OPTIONS = [
 	{ label: "All statuses", value: "" },
 	{ label: "Running", value: "running" },
 	{ label: "Completed", value: "completed" },
 	{ label: "Partial", value: "partial" },
 	{ label: "Failed", value: "failed" },
+	{ label: "Stopped", value: "stopped" },
 ];
 
 // ── rail data: useListPage + adapter onto listRunsPage's tab-less shape ──────
@@ -250,12 +289,53 @@ const emptyState = computed(() => {
 	};
 });
 
+// ── #1062 C3: poll the rail every 10s while any VISIBLE run is running, so a
+// running run's status/counters update without a manual refresh. This is the
+// ONE refresh path for the runs list - it extends the visibilitychange
+// machinery below (started/stopped from the same rows watcher, cleared on
+// unmount and on tab-hidden) rather than adding a second interval alongside
+// it. The tick itself re-checks visibility too (belt-and-braces against a
+// missed visibilitychange event) and skips a request already in flight.
+let pollTimer = null;
+function startPoll() {
+	if (pollTimer) return;
+	pollTimer = setInterval(() => {
+		if (!loading.value && document.visibilityState === "visible") refreshKeep();
+	}, 10000);
+}
+function stopPoll() {
+	if (pollTimer) {
+		clearInterval(pollTimer);
+		pollTimer = null;
+	}
+}
+
 // ── selection (local - runs live under the agent's hash tab, no :id route) ──
+const route = useRoute();
+const router = useRouter();
 const selectedRun = ref(null);
 const selectedId = computed(() => (selectedRun.value && selectedRun.value.name) || "");
 
 function selectRun(row) {
 	selectedRun.value = row;
+}
+
+// jarvis#1062: the Activity feed deep-links a run row here as ?run=<id>
+// (AgentActivityTab.vue). Applied at most once - only while nothing is
+// selected yet, i.e. the very first time rows loads - and cleared from the
+// URL immediately whether or not the id was found in this page, so a
+// refresh or a later facet change never re-triggers it and the query never
+// sits there unsatisfiable.
+function clearRunQuery() {
+	// jarvis#1062 fix: router.replace({query}) alone is a PARTIAL location - it
+	// does not implicitly keep the current hash, it DROPS it (verified against
+	// the real vue-router: {query} alone resolves to the bare path, no hash at
+	// all). That silently knocked AgentDetail off the Runs tab back to Overview
+	// a moment after landing on it - route.hash changing to "" is exactly what
+	// its own hash watcher treats as "go to the default tab". Pass hash back
+	// explicitly so this is a query-only edit, not a hash-clearing one too.
+	const { run: _run, ...rest } = route.query;
+	router.replace({ hash: route.hash, query: rest });
 }
 
 // auto-select the first row; on refresh, re-pin the selection to the fresh row
@@ -268,7 +348,17 @@ watch(rows, (r) => {
 		const again = r.find((x) => x.name === selectedRun.value.name);
 		selectedRun.value = again || r[0] || null;
 	} else if (r.length) {
-		selectRun(r[0]);
+		const queryRunId = route.query.run;
+		const wanted = queryRunId ? r.find((x) => x.name === queryRunId) : null;
+		selectRun(wanted || r[0]);
+		if (queryRunId) clearRunQuery();
+	}
+	// start/stop the poll from the SAME rows change that already drives
+	// selection - see the comment above startPoll/stopPoll.
+	if (r.some((x) => x.status === "running") && document.visibilityState === "visible") {
+		startPoll();
+	} else {
+		stopPoll();
 	}
 });
 
@@ -295,10 +385,20 @@ async function reload(opts = {}) {
 }
 defineExpose({ reload });
 
-// freshness: refetch the loaded window on tab-visible (running → completed)
+// freshness: refetch the loaded window on tab-visible (running → completed),
+// and resume the poll (#1062 C3) if a running run is still in the loaded
+// window; a hidden tab stops it outright rather than let it fire unseen.
 function onVisibility() {
-	if (document.visibilityState === "visible") refreshKeep();
+	if (document.visibilityState === "visible") {
+		refreshKeep();
+		if (rows.value.some((x) => x.status === "running")) startPoll();
+	} else {
+		stopPoll();
+	}
 }
 onMounted(() => document.addEventListener("visibilitychange", onVisibility));
-onBeforeUnmount(() => document.removeEventListener("visibilitychange", onVisibility));
+onBeforeUnmount(() => {
+	document.removeEventListener("visibilitychange", onVisibility);
+	stopPoll();
+});
 </script>

--- a/frontend/src/pages/agents/AgentsList.spec.js
+++ b/frontend/src/pages/agents/AgentsList.spec.js
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#1062 polish: a plain (non-admin, non-reviewer) user's catalog is
+ * deny-by-default (see @/lib/agentsEmptyState.js), so two of the four tabs -
+ * Featured and Installed - point at nothing for them. They get one tab that
+ * matters (the Available catalog, relabelled "Agents") plus Activity; an
+ * admin or a reviewer (the same caps probeCaps() already reads for the Apply
+ * button / empty-state copy) keeps the full four-tab set unchanged.
+ */
+
+const api = vi.hoisted(() => ({
+	listAgents: vi.fn(),
+	getAgentsSyncStatus: vi.fn(),
+	applyAgents: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+const agentsApi = vi.hoisted(() => ({
+	listAgentsPage: vi.fn(),
+	getAgentsCaps: vi.fn(),
+}));
+vi.mock("@/api/agents", () => agentsApi);
+
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+const route = vi.hoisted(() => ({ hash: "", name: "AgentsList", query: {}, params: {} }));
+// jarvis#1062 E2E defect: AgentsList.vue no longer imports onBeforeRouteLeave
+// (the in-SPA leave-confirm dialog was removed, along with the beforeunload
+// listener - see the no-leave-guard describe block below).
+vi.mock("vue-router", () => ({
+	useRouter: () => router,
+	useRoute: () => route,
+}));
+
+// jsdom here has no usable localStorage, and useListPage's persisted view
+// state is beside the point for this test (see WikiTab.spec.js precedent).
+vi.mock("@vueuse/core", async (importOriginal) => {
+	const actual = await importOriginal();
+	const { ref } = await import("vue");
+	return { ...actual, useStorage: (_key, initial) => ref(initial) };
+});
+
+vi.mock("frappe-ui", () => ({
+	call: vi.fn(),
+	toast: { success: vi.fn(), error: vi.fn() },
+	confirmDialog: vi.fn(),
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant"],
+		template: `<span class="badge">{{ label }}</span>`,
+	},
+	Breadcrumbs: { name: "Breadcrumbs", props: ["items"], template: "<div />" },
+	Button: {
+		name: "Button",
+		props: ["label", "disabled", "loading", "variant"],
+		emits: ["click"],
+		template: `<button :disabled="disabled" :data-label="label" @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+	},
+	Dialog: {
+		name: "Dialog",
+		props: ["modelValue", "options"],
+		template: `<div v-if="modelValue"><slot name="body-content" /><slot name="actions" /></div>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "options", "disabled"],
+		emits: ["update:modelValue"],
+		template: `<select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)"></select>`,
+	},
+	ListFooter: { name: "ListFooter", template: "<div />" },
+}));
+
+vi.mock("@/components/LayoutHeader.vue", () => ({
+	default: {
+		name: "LayoutHeader",
+		template: `<div><slot name="left-header" /><slot name="right-header" /><slot /></div>`,
+	},
+}));
+vi.mock("./AgentActivityTab.vue", () => ({
+	default: { name: "AgentActivityTab", template: "<div>activity feed</div>" },
+}));
+
+import AgentsList from "./AgentsList.vue";
+
+function tabButtons(w) {
+	return w.findAll('[role="tab"]');
+}
+function tabLabels(w) {
+	return tabButtons(w).map((b) => b.text());
+}
+function selectedTabLabel(w) {
+	const sel = tabButtons(w).filter((b) => b.attributes("aria-selected") === "true");
+	return sel.length ? sel[0].text() : null;
+}
+
+async function mountList({ caps = {}, hash = "", syncStatus = null, rows = [] } = {}) {
+	route.hash = hash;
+	agentsApi.getAgentsCaps.mockResolvedValue(caps);
+	agentsApi.listAgentsPage.mockResolvedValue({ rows, total: rows.length, has_more: false });
+	api.listAgents.mockResolvedValue([]);
+	api.getAgentsSyncStatus.mockResolvedValue(
+		syncStatus || { pending: false, dirty: false, status: "" }
+	);
+	const w = mount(AgentsList);
+	await flushPromises();
+	await flushPromises();
+	return w;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("a plain user (no review/admin caps) sees only Agents + Activity", () => {
+	it("tabs are exactly [Agents, Activity]", async () => {
+		const w = await mountList({ caps: { review: false, admin: false } });
+		expect(tabLabels(w)).toEqual(["Agents", "Activity"]);
+	});
+
+	it("lands on the Agents tab by default (no hash)", async () => {
+		const w = await mountList({ caps: { review: false, admin: false } });
+		expect(selectedTabLabel(w)).toBe("Agents");
+	});
+
+	it("falls back to Agents when deep-linked to an admin-only tab (#installed)", async () => {
+		const w = await mountList({ caps: { review: false, admin: false }, hash: "#installed" });
+		expect(tabLabels(w)).toEqual(["Agents", "Activity"]);
+		expect(selectedTabLabel(w)).toBe("Agents");
+	});
+
+	it("shows the no-access empty state on the Agents tab when nothing is granted", async () => {
+		// wholeCatalogEmpty is probed lazily off an "available" page-1 fetch;
+		// every listAgentsPage call in this test returns total 0, so it resolves
+		// true and the deny-by-default copy wins over the generic per-tab one.
+		const w = await mountList({ caps: { review: false, admin: false } });
+		await flushPromises();
+		expect(w.text()).toContain("No agents available to you");
+		expect(w.text()).toContain("No agents have been made available to you yet");
+	});
+});
+
+describe("an admin keeps the full four-tab catalog", () => {
+	it("tabs are the unchanged full set", async () => {
+		const w = await mountList({ caps: { review: false, admin: true } });
+		expect(tabLabels(w)).toEqual(["Featured", "Available", "Installed", "Activity"]);
+	});
+
+	it("lands on Featured by default (no hash)", async () => {
+		const w = await mountList({ caps: { review: false, admin: true } });
+		expect(selectedTabLabel(w)).toBe("Featured");
+	});
+
+	it("a reviewer (not admin) also keeps the full four-tab set", async () => {
+		const w = await mountList({ caps: { review: true, admin: false } });
+		expect(tabLabels(w)).toEqual(["Featured", "Available", "Installed", "Activity"]);
+	});
+});
+
+// jarvis#1062 E2E defect: a beforeunload listener used to fire the native
+// "leave site?" prompt on ordinary SPA navigation whenever the catalog was
+// dirty (canApply && sync.dirty). Removed outright - nothing is lost by
+// navigating, since the dirty state lives server-side - while the "Changes
+// pending" badge (the honest signal) stays.
+describe("no leave-guard of any kind, even when the catalog is dirty (only the badge)", () => {
+	it("never registers a beforeunload listener for a reviewer with unapplied changes", async () => {
+		const addSpy = vi.spyOn(window, "addEventListener");
+		const w = await mountList({
+			caps: { review: true, admin: false },
+			syncStatus: { pending: false, dirty: true, status: "" },
+		});
+		await flushPromises();
+
+		expect(w.text()).toContain("Changes pending");
+		expect(addSpy.mock.calls.some(([event]) => event === "beforeunload")).toBe(false);
+
+		addSpy.mockRestore();
+	});
+
+	it("never registers one for a non-reviewer either (canApply false)", async () => {
+		const addSpy = vi.spyOn(window, "addEventListener");
+		await mountList({
+			caps: { review: false, admin: false },
+			syncStatus: { pending: false, dirty: true, status: "" },
+		});
+		await flushPromises();
+
+		expect(addSpy.mock.calls.some(([event]) => event === "beforeunload")).toBe(false);
+
+		addSpy.mockRestore();
+	});
+
+	it("renders no leave-confirm Dialog while dirty - the badge is the only signal", async () => {
+		const w = await mountList({
+			caps: { review: true, admin: false },
+			syncStatus: { pending: false, dirty: true, status: "" },
+		});
+		await flushPromises();
+
+		expect(w.text()).toContain("Changes pending");
+		expect(w.text()).not.toContain("Unapplied catalog changes");
+		expect(w.text()).not.toContain("Leave anyway");
+		expect(w.find('[data-label="Leave anyway"]').exists()).toBe(false);
+	});
+});
+
+// jarvis#1062 P1-4 (production-readiness audit): a long agent title used to
+// be cut to one truncated line with no way to read the rest.
+describe("catalog card titles: two lines, full name in a title attribute", () => {
+	function longTitleAgent(overrides = {}) {
+		return {
+			agent_slug: "long-title-agent",
+			title: "Statutory Payroll Deposit Status & Compliance Cross-Checking Auditor",
+			status: "Published",
+			publisher: "Aerele",
+			version: "1.0.0",
+			description: "Checks payroll deposits.",
+			install_count: 0,
+			...overrides,
+		};
+	}
+
+	it("renders with line-clamp-2, not a single-line truncate", async () => {
+		const w = await mountList({
+			caps: { review: true, admin: false },
+			rows: [longTitleAgent()],
+		});
+		const title = w.findAll("span").find((s) => s.text() === longTitleAgent().title);
+		expect(title).toBeTruthy();
+		expect(title.classes()).toContain("line-clamp-2");
+		expect(title.classes()).not.toContain("truncate");
+	});
+
+	it("carries the full title in a title attribute for anything two lines still cannot fit", async () => {
+		const w = await mountList({
+			caps: { review: true, admin: false },
+			rows: [longTitleAgent()],
+		});
+		const title = w.findAll("span").find((s) => s.text() === longTitleAgent().title);
+		expect(title.attributes("title")).toBe(longTitleAgent().title);
+	});
+});
+
+// jarvis#1062 P1-5 (production-readiness audit): a plain role="button" div
+// carries no default browser focus outline the way a real <button> would.
+describe("catalog card keyboard focus (jarvis#1062 P1-5)", () => {
+	it("every card carries a focus-visible ring", async () => {
+		const w = await mountList({
+			caps: { review: true, admin: false },
+			rows: [
+				{
+					agent_slug: "close-auditor",
+					title: "Close Auditor",
+					status: "Published",
+					publisher: "Aerele",
+					version: "1.0.0",
+					description: "Checks the close.",
+					install_count: 3,
+				},
+			],
+		});
+		const card = w.find('[role="button"]');
+		expect(card.exists()).toBe(true);
+		expect(card.classes()).toContain("focus-visible:ring-2");
+		expect(card.classes()).toContain("focus-visible:ring-outline-gray-3");
+	});
+});
+
+// jarvis#1062 P2-9 (production-readiness audit): wired through to the real
+// component - agentsEmptyState.spec.js covers the pure-function decision.
+describe("Installed tab empty state names Administrator (jarvis#1062 P2-9)", () => {
+	it("shows the Administrator-specific copy, no install CTA", async () => {
+		const { session } = await import("@/data/session");
+		const original = session.user;
+		session.user = "Administrator";
+		try {
+			const w = await mountList({
+				caps: { review: false, admin: true },
+				hash: "#installed",
+			});
+			expect(w.text()).toContain("Administrator cannot install agents.");
+			expect(w.text()).toContain("Sign in as a named user.");
+		} finally {
+			session.user = original;
+		}
+	});
+});

--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -45,7 +45,8 @@
 			</template>
 		</LayoutHeader>
 
-		<!-- 4 hash-synced tabs (no hash = Featured; #available/#installed/#activity) -->
+		<!-- hash-synced tabs: 4 for an admin/reviewer (no hash = Featured), 2 for a
+		     plain user (Agents relabelling Available + Activity; no hash = Agents) -->
 		<TabBar class="shrink-0" :tabs="TABS" :model-value="tab" @update:model-value="setTab" />
 
 		<!-- persistent apply-failure banner: the reason must survive the toast and
@@ -96,7 +97,7 @@
 
 			<div class="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-4">
 				<div
-					v-if="loading && !rows.length"
+					v-if="(loading || probingCatalog) && !rows.length"
 					class="py-10 text-center text-sm text-ink-gray-5"
 				>
 					Loading the catalog…
@@ -125,12 +126,17 @@
 				</div>
 
 				<div v-else class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					<!-- jarvis#1062 P1-5 (production-readiness audit): keyboard focus
+					     on a card was invisible - a plain role="button" div carries no
+					     default browser outline the way a real <button> would, and had
+					     no explicit ring either. focus-visible:outline-none first, or
+					     the ring stacks on top of a still-visible default outline. -->
 					<div
 						v-for="a in rows"
 						:key="a.agent_slug"
 						role="button"
 						tabindex="0"
-						class="flex cursor-pointer flex-col rounded-lg border bg-surface-white p-5 transition hover:bg-surface-gray-1 hover:shadow-sm"
+						class="flex cursor-pointer flex-col rounded-lg border bg-surface-white p-5 transition hover:bg-surface-gray-1 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
 						@click="openAgent(a)"
 						@keydown.enter.prevent="openAgent(a)"
 						@keydown.space.prevent="openAgent(a)"
@@ -143,8 +149,18 @@
 								{{ logoText(a) }}
 							</div>
 							<div class="min-w-0 flex-1">
-								<div class="flex items-center gap-2">
-									<span class="truncate text-base font-semibold text-ink-gray-9">
+								<!-- jarvis#1062 P1-4 (production-readiness audit): a single-line
+								     truncate cut long agent names off mid-word with no way to
+								     read the rest. Two lines now (line-clamp-2), :title carries
+								     the full name for anything a second line still can't fit;
+								     items-start (not -center) keeps a status badge pinned to the
+								     title's first line rather than drifting to the middle of a
+								     wrapped block. -->
+								<div class="flex items-start gap-2">
+									<span
+										class="line-clamp-2 text-base font-semibold text-ink-gray-9"
+										:title="a.title"
+									>
 										{{ a.title }}
 									</span>
 									<Badge
@@ -197,11 +213,6 @@
 								label="Update available"
 							/>
 						</div>
-
-						<div v-if="!a.allowed" class="mt-2 text-sm text-ink-gray-5">
-							Available to: {{ (a.allowed_roles || []).join(", ") || "-" }} - ask
-							your administrator.
-						</div>
 					</div>
 				</div>
 			</div>
@@ -215,32 +226,6 @@
 				@loadMore="loadMore"
 			/>
 		</template>
-
-		<!-- leave-guard: SM with unapplied catalog changes (dirty) -->
-		<Dialog
-			v-model="leaveDialog.show"
-			:options="{ title: 'Unapplied catalog changes' }"
-			@close="resolveLeave(false)"
-		>
-			<template #body-content>
-				<p class="text-p-base text-ink-gray-6">
-					You have unapplied catalog changes. Apply them now, or leave anyway? Your
-					changes stay saved either way - they only reach the assistant after an Apply.
-				</p>
-			</template>
-			<template #actions>
-				<div class="flex items-center gap-2">
-					<Button
-						variant="solid"
-						label="Apply & leave"
-						:loading="applying"
-						@click="applyAndLeave"
-					/>
-					<Button label="Leave anyway" @click="resolveLeave(true)" />
-					<Button variant="ghost" label="Stay" @click="resolveLeave(false)" />
-				</div>
-			</template>
-		</Dialog>
 	</div>
 </template>
 
@@ -255,17 +240,19 @@
 //   Activity - the owner's lifecycle feed (AgentActivityTab, self-contained).
 // Reviewer/SM header action: prominent "Apply catalog changes" driven by
 // get_agents_sync_status().dirty (install/uninstall/enable since the last
-// successful Apply), with SyncPill-style pending/failed polling, plus a
-// route-leave + beforeunload guard while dirty. Gated on the skill-reviewer
-// capability (get_agents_caps().review) since apply_agents needs the reviewer
-// set, not System Manager.
+// successful Apply), with SyncPill-style pending/failed polling. jarvis#1062
+// E2E defect (both a beforeunload listener AND an in-SPA route-leave confirm
+// dialog used to nag while dirty): the dirty state lives server-side and
+// nothing is lost by navigating away, so BOTH leave-guards are removed - the
+// "Changes pending" badge above is the only signal now. Gated on the
+// skill-reviewer capability (get_agents_caps().review) since apply_agents
+// needs the reviewer set, not System Manager.
 import { reactive, ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
-import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import {
 	Badge,
 	Breadcrumbs,
 	Button,
-	Dialog,
 	FeatherIcon,
 	FormControl,
 	ListFooter,
@@ -279,36 +266,61 @@ import { useListPage } from "@/composables/useListPage";
 import * as api from "@/api";
 import * as agentsApi from "@/api/agents";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
+import { agentsEmptyState, shouldProbeWholeCatalog } from "@/lib/agentsEmptyState";
 import { errHtml } from "@/lib/errors";
+import { categoryTitle } from "@/lib/agentCategory";
+import { session } from "@/data/session";
 
 const route = useRoute();
 const router = useRouter();
 
-// Display metadata mirroring jarvis/agents/registry.json domains (unknown slugs
-// fall back to a prettified slug).
-const DOMAINS = [
-	{ slug: "close", title: "Close & Reporting" },
-	{ slug: "bank-recon", title: "Bank & Reconciliation" },
-];
+// ── Reviewer / admin capability probe (PART 3 remediation): apply_agents needs
+// the skill-reviewer set (Jarvis Skill Reviewer | Jarvis Admin | System
+// Manager), NOT System Manager. get_agents_caps().review drives the Apply
+// button so a reviewer-only System User (no SM) can see and use it; a plain
+// Jarvis User gets review=false and no button. Decoupled from the SM-only
+// cross-owner getAgentAdminOverview data. Declared here, ahead of the
+// hash-synced tabs below, because applyHash() (called synchronously at setup)
+// already needs isPrivileged.
+const canApply = ref(false);
+// The tenant-admin half of the same probe: it decides which EMPTY-STATE copy
+// is truthful (see emptyState) and, with canApply, which tab set renders -
+// never what the list contains, which stays server-side in _enriched_catalog.
+const canAdminister = ref(false);
+// jarvis#1062 polish: an admin or a reviewer keeps the full catalog chrome;
+// everyone else's access is deny-by-default (agentsEmptyState.js), so
+// Featured/Installed are two more tabs pointing at nothing for them.
+const isPrivileged = computed(() => canAdminister.value || canApply.value);
 
-// ── hash-synced tabs (AgentDetail pattern; no hash = Featured) ───────────────
-const TABS = [
+// ── hash-synced tabs (AgentDetail pattern; no hash = the privileged default) ─
+const FULL_TABS = [
 	{ label: "Featured", value: "featured" },
 	{ label: "Available", value: "available" },
 	{ label: "Installed", value: "installed" },
 	{ label: "Activity", value: "activity" },
 ];
+// A plain user's "Agents" IS the available catalog - same value, relabelled -
+// so every value/tab -> query mapping below (AGENT_TABS, listAgentsPage,
+// emptyState, shouldProbeWholeCatalog) needs no separate branch for them.
+const PLAIN_TABS = [
+	{ label: "Agents", value: "available" },
+	{ label: "Activity", value: "activity" },
+];
+const TABS = computed(() => (isPrivileged.value ? FULL_TABS : PLAIN_TABS));
 const AGENT_TABS = ["featured", "available", "installed"];
 
 const tab = ref("featured");
+function defaultTab() {
+	return isPrivileged.value ? "featured" : "available";
+}
 function applyHash() {
 	const h = (route.hash || "").replace(/^#/, "");
-	tab.value = TABS.some((t) => t.value === h) ? h : "featured";
+	tab.value = TABS.value.some((t) => t.value === h) ? h : defaultTab();
 }
 function setTab(v) {
 	if (tab.value === v) return;
 	tab.value = v;
-	router.push({ hash: v === "featured" ? "" : "#" + v });
+	router.push({ hash: v === defaultTab() ? "" : "#" + v });
 }
 applyHash();
 // back/forward restores the tab
@@ -318,6 +330,13 @@ watch(
 		if (route.name === "AgentsList") applyHash();
 	}
 );
+// Caps resolve async (probeCaps, below), so the very first applyHash() above
+// ran before isPrivileged was known. Re-validate once it is, so a deep link
+// to an admin-only tab (#installed, say) for a caller who turns out to be a
+// plain user falls back to Agents instead of sitting on a blank panel, and a
+// caller who turns out to be privileged gets Featured back instead of being
+// stuck on the plain default.
+watch(isPrivileged, () => applyHash());
 
 // ── catalog list: useListPage adapter over list_agents_page ─────────────────
 // The adapter closes over tab/category/sortChoice and maps useListPage's
@@ -356,9 +375,11 @@ watch([tab, category, sortChoice], ([t]) => {
 	resetLoad();
 });
 
-// ── category select options (distinct catalog categories, DOMAINS titles) ────
-// One cheap list_agents() call feeds the distinct set - server pages can't
-// (a page only sees its slice); DOMAINS is the fallback until/if it loads.
+// ── category select options (distinct catalog categories) ────────────────────
+// One cheap list_agents() call feeds the distinct set - server pages can't (a
+// page only sees its slice). sync_agent_listings (agent_catalog.py) already
+// sends a real label ("Accounts Payable", not "ap") as `category`, so this
+// list IS the display label - no separate frontend title map to keep in sync.
 const catalogCategories = ref(null);
 async function loadCategories() {
 	try {
@@ -366,66 +387,27 @@ async function loadCategories() {
 		const seen = new Set();
 		const out = [];
 		for (const a of all) {
-			const slug = a.category || "other";
-			if (seen.has(slug)) continue;
-			seen.add(slug);
-			out.push(slug);
+			const label = a.category || "Other";
+			if (seen.has(label)) continue;
+			seen.add(label);
+			out.push(label);
 		}
 		if (out.length) catalogCategories.value = out;
 	} catch (e) {
-		// keep the DOMAINS fallback - the select must not break the page
+		// no fallback list - "All categories" alone still renders a usable select
 	}
 }
 const categoryOptions = computed(() => {
-	const slugs = catalogCategories.value || DOMAINS.map((d) => d.slug);
+	const labels = catalogCategories.value || [];
 	return [
 		{ label: "All categories", value: "" },
-		...slugs.map((s) => ({ label: categoryTitle(s), value: s })),
+		...labels.map((l) => ({ label: l, value: l })),
 	];
-});
-
-// ── empty states (per-TAB copy - "catalog is empty" only when it truly is) ───
-const filtersActive = computed(() => !!(search.value || category.value));
-const emptyState = computed(() => {
-	if (filtersActive.value) {
-		return {
-			title: "No agents match",
-			description: "Try clearing the search or category filter.",
-			cta: false,
-		};
-	}
-	if (tab.value === "featured") {
-		return {
-			title: "No featured agents yet",
-			description: "Browse the Available tab for the full catalog.",
-			cta: true,
-		};
-	}
-	if (tab.value === "installed") {
-		return {
-			title: "You haven't installed any agents yet",
-			description: "Browse the catalog and install one to get started.",
-			cta: true,
-		};
-	}
-	return {
-		title: "No agents available",
-		description: "The catalog is empty right now.",
-		cta: false,
-	};
 });
 
 // ── display helpers ──────────────────────────────────────────────────────────
 function openAgent(a) {
 	router.push("/agents/" + a.agent_slug);
-}
-function categoryTitle(slug) {
-	const d = DOMAINS.find((x) => x.slug === slug);
-	if (d) return d.title;
-	return String(slug || "other")
-		.split("-")
-		.map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
-		.join(" ");
 }
 function logoText(a) {
 	return String(a.title || a.agent_slug || "?")
@@ -437,25 +419,82 @@ function installsLabel(n) {
 	return `${c} install${c === 1 ? "" : "s"}`;
 }
 
-// ── Reviewer capability probe (PART 3 remediation): apply_agents needs the
-// skill-reviewer set (Jarvis Skill Reviewer | Jarvis Admin | System Manager),
-// NOT System Manager. get_agents_caps().review drives the Apply button so a
-// reviewer-only System User (no SM) can see and use it; a plain Jarvis User
-// gets review=false and no button. Decoupled from the SM-only cross-owner
-// getAgentAdminOverview data. ─────────────────────────────────────────────────
-const canApply = ref(false);
+// canApply/canAdminister are declared above (near TABS - applyHash() needs
+// isPrivileged synchronously at setup); this just resolves them.
 async function probeCaps() {
 	try {
 		const caps = (await agentsApi.getAgentsCaps()) || {};
 		canApply.value = !!caps.review;
+		canAdminister.value = !!caps.admin;
 		if (canApply.value) {
 			await loadSyncStatus();
 			if (sync.pending) startSyncPoll();
 		}
 	} catch (e) {
 		canApply.value = false;
+		canAdminister.value = false;
 	}
 }
+
+// ── empty states ─────────────────────────────────────────────────────────────
+// The decision itself is a pure function in @/lib/agentsEmptyState (tested
+// there). Here we only supply what it needs, including the lazily-probed
+// "does this caller have ANY agents at all" signal below.
+const filtersActive = computed(() => !!(search.value || category.value));
+// jarvis#1062 P2-9: the Installed tab's empty state names the Administrator
+// case specifically - it cannot install, no matter caps.admin.
+const isAdministrator = computed(() => session.user === "Administrator");
+const emptyState = computed(() =>
+	agentsEmptyState({
+		tab: tab.value,
+		filtersActive: filtersActive.value,
+		canAdminister: canAdminister.value,
+		isAdministrator: isAdministrator.value,
+		wholeCatalogEmpty: wholeCatalogEmpty.value,
+	})
+);
+
+// ── "is this caller's whole catalog empty?" (jarvis#1062) ────────────────────
+// null until probed. ONE call answers it for every tab: server-side the
+// available tab is `status != Deprecated or installed`, so it is a superset of
+// both featured (Published only) and installed - a zero total there means the
+// caller can see no agent anywhere, which is the only thing we need to know.
+const wholeCatalogEmpty = ref(null);
+const probingCatalog = ref(false);
+
+async function probeWholeCatalog() {
+	probingCatalog.value = true;
+	try {
+		const res = (await agentsApi.listAgentsPage({ tab: "available", page_length: 1 })) || {};
+		wholeCatalogEmpty.value = (res.total || 0) === 0;
+	} catch {
+		// Fail to the per-tab copy rather than asserting an access problem we
+		// could not confirm.
+		wholeCatalogEmpty.value = false;
+	} finally {
+		probingCatalog.value = false;
+	}
+}
+
+watch(
+	[tab, rows, loading, filtersActive, canAdminister],
+	() => {
+		if (
+			shouldProbeWholeCatalog({
+				tab: tab.value,
+				loading: loading.value,
+				rowCount: rows.value.length,
+				filtersActive: filtersActive.value,
+				canAdminister: canAdminister.value,
+				wholeCatalogEmpty: wholeCatalogEmpty.value,
+				probing: probingCatalog.value,
+			})
+		) {
+			probeWholeCatalog();
+		}
+	},
+	{ immediate: true, deep: false }
+);
 
 // ── apply pipeline status (SyncPill pattern: 3s poll while pending) ──────────
 // dirty = the enabled set changed since the last successful Apply - drives the
@@ -517,45 +556,19 @@ async function applyCatalog() {
 	}
 }
 
-// ── leave-guard: can-apply + dirty (unapplied catalog changes) ───────────────
-const leaveDialog = reactive({ show: false, next: null });
-
-onBeforeRouteLeave((to, from, next) => {
-	// drilling into /agents/:slug stays inside the agents area - don't nag
-	if (!canApply.value || !sync.dirty || String(to.path || "").startsWith("/agents"))
-		return next();
-	leaveDialog.next = next;
-	leaveDialog.show = true;
-});
-
-function resolveLeave(go) {
-	const n = leaveDialog.next;
-	leaveDialog.next = null; // idempotent: Dialog @close re-fires after buttons
-	leaveDialog.show = false;
-	if (n) n(go);
-}
-
-async function applyAndLeave() {
-	const ok = await applyCatalog();
-	// apply request failed → stay so the SM can retry (error already toasted)
-	resolveLeave(ok);
-}
-
-// hard reloads / tab close while dirty → native browser prompt
-function onBeforeUnload(e) {
-	if (canApply.value && sync.dirty) {
-		e.preventDefault();
-		e.returnValue = ""; // Chrome requires returnValue to show the prompt
-	}
-}
+// jarvis#1062 E2E defect: this file used to carry TWO leave-guards while the
+// catalog was dirty (canApply && sync.dirty) - a beforeunload listener
+// firing the native "leave site?" prompt on ordinary SPA navigation, and an
+// in-SPA onBeforeRouteLeave confirm dialog nagging on route changes. Both
+// removed outright: the dirty state lives server-side (get_agents_sync_status)
+// and nothing is lost by navigating away - the "Changes pending" badge above
+// is the honest, non-blocking signal instead.
 
 onMounted(() => {
 	probeCaps();
 	loadCategories();
-	window.addEventListener("beforeunload", onBeforeUnload);
 });
 onBeforeUnmount(() => {
-	window.removeEventListener("beforeunload", onBeforeUnload);
 	stopSyncPoll();
 });
 </script>

--- a/frontend/src/pages/agents/ConfigForm.spec.js
+++ b/frontend/src/pages/agents/ConfigForm.spec.js
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#1062 owner feedback: the code-key reference list (no inputs) was not
+ * user friendly. ConfigForm.vue now renders a REAL form for the known
+ * engagement settings (CONFIG_FIELD_SET, @/lib/agentConfigFields) - link
+ * pickers for Company/Fiscal year, a date pair, number inputs, a select -
+ * with the merge semantics unchanged: known fields win on matching keys, an
+ * unrecognised key survives untouched in Advanced (JSON), and an empty field
+ * means the key is absent from the saved config.
+ *
+ * jarvis#1063 (jarvis-only half): the scope fields (Company/Fiscal
+ * year/Period) always render; the agent-specific fields (materiality
+ * amount/percentage, risk level, rounding step) render only when their
+ * storage PATH (a dot path for a nested key - close-auditor's evaluate.py
+ * reads them under a top-level `materiality` object) is in the `configKeys`
+ * prop (the listing's config_keys, get_agent, itself dot paths).
+ * mountForm()'s default configKeys covers all four so the pre-existing
+ * "always renders" tests below still describe a close-auditor-shaped agent;
+ * the dedicated "per-agent gating" describe block below covers the subset,
+ * empty and flat-legacy-migration cases.
+ */
+
+const ALL_AGENT_SPECIFIC_PATHS = [
+	"materiality.benchmark_value",
+	"materiality.percentage",
+	"materiality.engagement_risk_level",
+	"materiality.rounding_step",
+];
+
+const api = vi.hoisted(() => ({ searchLink: vi.fn().mockResolvedValue([]) }));
+vi.mock("@/api", () => api);
+
+vi.mock("frappe-ui", () => ({
+	Autocomplete: {
+		name: "Autocomplete",
+		props: ["options", "modelValue", "placeholder"],
+		emits: ["update:query", "update:modelValue"],
+		template: `<div>
+			<input :placeholder="placeholder" @input="$emit('update:query', $event.target.value)" />
+			<button
+				v-for="o in options"
+				:key="o.value"
+				:data-option="o.value"
+				type="button"
+				@click="$emit('update:modelValue', o)"
+			>{{ o.label }}</button>
+		</div>`,
+	},
+	Button: {
+		name: "Button",
+		props: ["label", "loading"],
+		emits: ["click"],
+		template: `<button :data-label="label" @click="$emit('click')">{{ label }}</button>`,
+	},
+	ErrorMessage: {
+		name: "ErrorMessage",
+		props: ["message"],
+		template: `<div class="error">{{ message }}</div>`,
+	},
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "label", "options", "description"],
+		emits: ["update:modelValue"],
+		template: `<div>
+			<span class="fc-label">{{ label }}</span>
+			<select
+				v-if="type === 'select'"
+				:data-label="label"
+				:value="modelValue"
+				@change="$emit('update:modelValue', $event.target.value)"
+			>
+				<option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option>
+			</select>
+			<textarea
+				v-else-if="type === 'textarea'"
+				:data-label="label"
+				:value="modelValue"
+				@input="$emit('update:modelValue', $event.target.value)"
+			/>
+			<input
+				v-else
+				:data-label="label"
+				:type="type"
+				:value="modelValue"
+				@input="$emit('update:modelValue', $event.target.value)"
+			/>
+			<slot name="suffix" />
+			<p v-if="description">{{ description }}</p>
+		</div>`,
+	},
+}));
+
+import ConfigForm from "./ConfigForm.vue";
+
+function mountForm(config = {}, extraProps = {}, mountOptions = {}) {
+	return mount(ConfigForm, {
+		props: { config, configKeys: ALL_AGENT_SPECIFIC_PATHS, saving: false, ...extraProps },
+		...mountOptions,
+	});
+}
+
+function field(w, label) {
+	return w.find(`[data-label="${label}"]`);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	api.searchLink.mockResolvedValue([]);
+});
+
+describe("the known-settings form always renders, config empty or not", () => {
+	it("renders every field with an empty config", () => {
+		const w = mountForm({});
+		expect(w.text()).toContain(
+			"Settings this agent reads when it runs. Leave a field empty to use the default."
+		);
+		expect(w.text()).toContain("Company");
+		expect(w.text()).toContain("Fiscal year");
+		expect(w.text()).toContain("Period from");
+		expect(w.text()).toContain("Period to");
+		expect(w.text()).toContain("Materiality benchmark amount");
+		expect(w.text()).toContain("Materiality percentage");
+		expect(w.text()).toContain("Engagement risk level");
+		expect(w.text()).toContain("Rounding step");
+		// the old code-key reference list (a <code> chip per key) is gone
+		expect(w.find("code").exists()).toBe(false);
+	});
+
+	it("shows each field's help text", () => {
+		const w = mountForm({});
+		expect(w.text()).toContain("Defaults to your default company");
+		expect(w.text()).toContain("Defaults to the current fiscal year");
+		expect(w.text()).toContain("Optional; overrides the fiscal year");
+		expect(w.text()).toContain("Used to judge which differences matter");
+		expect(w.text()).toContain(
+			"Auditors report checks as not evaluable when materiality is unset"
+		);
+		expect(w.text()).toContain("Step used to detect round-number plugs");
+	});
+});
+
+describe("existing values pre-fill every field", () => {
+	it("seeds the form from the installation's current config (materiality nested)", () => {
+		const w = mountForm({
+			company: "Acme Ltd",
+			fiscal_year: "2026",
+			from_date: "2026-04-01",
+			to_date: "2027-03-31",
+			materiality: {
+				benchmark_value: 1000000,
+				percentage: 5,
+				engagement_risk_level: "medium",
+				rounding_step: 100,
+			},
+		});
+		expect(field(w, "Period from").element.value).toBe("2026-04-01");
+		expect(field(w, "Period to").element.value).toBe("2027-03-31");
+		expect(field(w, "Materiality benchmark amount").element.value).toBe("1000000");
+		expect(field(w, "Materiality percentage").element.value).toBe("5");
+		expect(field(w, "Engagement risk level").element.value).toBe("medium");
+		expect(field(w, "Rounding step").element.value).toBe("100");
+		// Company/Fiscal year (Autocomplete) show the current value as the picked option
+		expect(w.text()).toContain("Acme Ltd");
+	});
+});
+
+describe("saving produces the right JSON", () => {
+	it("typing values into every field and saving merges them - materiality NESTED (jarvis#1063 CRITICAL)", async () => {
+		const w = mountForm({});
+		await field(w, "Period from").setValue("2026-04-01");
+		await field(w, "Period to").setValue("2027-03-31");
+		await field(w, "Materiality benchmark amount").setValue("1000000");
+		await field(w, "Materiality percentage").setValue("5");
+		await field(w, "Engagement risk level").setValue("high");
+		await field(w, "Rounding step").setValue("100");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+
+		expect(w.emitted("save")[0][0]).toEqual({
+			from_date: "2026-04-01",
+			to_date: "2027-03-31",
+			materiality: {
+				benchmark_value: 1000000,
+				percentage: 5,
+				engagement_risk_level: "high",
+				rounding_step: 100,
+			},
+		});
+	});
+
+	it("picking a Company/Fiscal year option saves the picked value", async () => {
+		api.searchLink.mockResolvedValue([{ value: "Acme Ltd" }]);
+		const w = mountForm({});
+		// primes on focus/click, per-field Autocomplete
+		const companyBox = w.findAll("input[placeholder^='Search']")[0];
+		await companyBox.trigger("focusin");
+		await flushPromises();
+		const pick = w.find('button[data-option="Acme Ltd"]');
+		expect(pick.exists()).toBe(true);
+		await pick.trigger("click");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({ company: "Acme Ltd" });
+	});
+});
+
+describe("clearing a field drops its key", () => {
+	it("clearing a populated field deletes its nested path, siblings under materiality survive", async () => {
+		const w = mountForm({ materiality: { rounding_step: 100, percentage: 5 } });
+		await field(w, "Rounding step").setValue("");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		const saved = w.emitted("save")[0][0];
+		expect(saved.materiality).not.toHaveProperty("rounding_step");
+		expect(saved.materiality.percentage).toBe(5);
+	});
+
+	it("clearing every materiality field drops the now-empty materiality object entirely", async () => {
+		const w = mountForm({ materiality: { rounding_step: 100 } });
+		await field(w, "Rounding step").setValue("");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({});
+	});
+
+	it("re-picking Company to a different value saves the new one, not a stale key", async () => {
+		api.searchLink.mockResolvedValue([{ value: "Other Co" }]);
+		const w = mountForm({ company: "Acme Ltd" });
+		expect(w.text()).toContain("Acme Ltd");
+		const companyBox = w.findAll("input[placeholder^='Search']")[0];
+		await companyBox.trigger("focusin");
+		await flushPromises();
+		await w.find('button[data-option="Other Co"]').trigger("click");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({ company: "Other Co" });
+	});
+});
+
+// jarvis#1062 P0-1 (production-readiness audit): the Advanced (JSON) panel
+// re-collapsed when clicked inside its own expanded textarea, with the
+// chevron desynced from the content's real open/closed state. Not
+// reproduced here - DocSection.vue's toggle was already scoped to the
+// header only (header and content are siblings, never ancestor/descendant)
+// - but the header is now a real, keyboard-reachable <button> and the
+// content wrapper carries its own @click.stop as defensive hardening.
+// These specs document and lock in the required behavior either way.
+describe("Advanced (JSON) panel: a content click never re-collapses it (jarvis#1062 P0-1)", () => {
+	function openAdvanced(w) {
+		return w.find(".border-t button").trigger("click");
+	}
+	function chevron(w) {
+		return w.find(".lucide-chevron-right");
+	}
+
+	it("starts collapsed (chevron not rotated, textarea not visible)", () => {
+		const w = mountForm({});
+		expect(chevron(w).classes()).not.toContain("rotate-90");
+		expect(w.find("textarea").isVisible()).toBe(false);
+	});
+
+	it("opens on a header click - chevron rotates, textarea becomes visible", async () => {
+		const w = mountForm({});
+		await openAdvanced(w);
+		expect(chevron(w).classes()).toContain("rotate-90");
+		expect(w.find("textarea").isVisible()).toBe(true);
+	});
+
+	it("a click INSIDE the open textarea keeps it open and does not desync the chevron", async () => {
+		const w = mountForm({}, {}, { attachTo: document.body });
+		await openAdvanced(w);
+		const textarea = w.find("textarea");
+		await textarea.trigger("click");
+		// jsdom does not perform default actions (focus-on-click) for a
+		// dispatched synthetic click the way a real browser does - call the
+		// native focus() a real click would trigger, so the assertion below
+		// reflects what a user actually experiences.
+		textarea.element.focus();
+		await w.vm.$nextTick();
+
+		expect(w.find("textarea").isVisible()).toBe(true);
+		expect(chevron(w).classes()).toContain("rotate-90");
+		expect(document.activeElement).toBe(textarea.element);
+		w.unmount();
+	});
+
+	it("clicking the header again still closes it (toggle still works after a content click)", async () => {
+		const w = mountForm({});
+		await openAdvanced(w);
+		await w.find("textarea").trigger("click");
+		await openAdvanced(w);
+		expect(w.find("textarea").isVisible()).toBe(false);
+		expect(chevron(w).classes()).not.toContain("rotate-90");
+	});
+});
+
+describe("Advanced (JSON) hint text", () => {
+	it("its example uses the NESTED materiality shape, not a flat key the form already renders a field for", () => {
+		// jarvis#1063 CRITICAL follow-up: the old example -
+		// {"benchmark_value": 1000000} - was exactly the flat legacy shape
+		// save() deletes (migration is one-directional, flat -> nested). A
+		// user following the hint verbatim would type a value that vanishes
+		// on save. The example must never again name a key the form itself
+		// covers.
+		const w = mountForm({});
+		const hint = w.text();
+		expect(hint).toContain('"materiality"');
+		expect(hint).not.toContain('"benchmark_value": 1000000');
+	});
+});
+
+describe("an unknown config key survives untouched in Advanced (JSON)", () => {
+	it("seeds an unrecognised key into Advanced, not a form field", () => {
+		const w = mountForm({ company: "Acme Ltd", custom_flag: true, nested: { a: 1 } });
+		const textarea = w.find("textarea");
+		const advanced = JSON.parse(textarea.element.value);
+		expect(advanced).toEqual({ custom_flag: true, nested: { a: 1 } });
+	});
+
+	it("keeps the unknown key on save alongside the known fields", async () => {
+		const w = mountForm({ custom_flag: true });
+		await field(w, "Rounding step").setValue("50");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({
+			custom_flag: true,
+			materiality: { rounding_step: 50 },
+		});
+	});
+
+	it("an UNKNOWN sibling under materiality (e.g. pl_balance) survives a rounding_step edit, not replaced", async () => {
+		const w = mountForm({ materiality: { pl_balance: 50000, rounding_step: 100 } });
+		const textarea = w.find("textarea");
+		expect(JSON.parse(textarea.element.value)).toEqual({ materiality: { pl_balance: 50000 } });
+
+		await field(w, "Rounding step").setValue("200");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({
+			materiality: { pl_balance: 50000, rounding_step: 200 },
+		});
+	});
+});
+
+// jarvis#1063 (jarvis-only half): agent-specific fields are gated by the
+// listing's config_keys, matched against each field's storage PATH (a dot
+// path for a nested key) - the scope fields never are.
+describe("per-agent gating via the configKeys prop", () => {
+	it("configKeys=[] (e.g. bank-recon-operator) renders only the scope fields, plus the note", () => {
+		const w = mountForm({}, { configKeys: [] });
+		expect(w.text()).toContain("Company");
+		expect(w.text()).toContain("Fiscal year");
+		expect(w.text()).toContain("Period from");
+		expect(w.text()).toContain("Period to");
+		expect(w.text()).not.toContain("Materiality benchmark amount");
+		expect(w.text()).not.toContain("Materiality percentage");
+		expect(w.text()).not.toContain("Engagement risk level");
+		expect(w.text()).not.toContain("Rounding step");
+		expect(w.text()).toContain("This agent has no additional settings.");
+	});
+
+	it("a partial configKeys (dot paths) renders only the matching agent-specific fields, no note", () => {
+		const w = mountForm(
+			{},
+			{ configKeys: ["materiality.percentage", "materiality.rounding_step"] }
+		);
+		expect(w.text()).toContain("Materiality percentage");
+		expect(w.text()).toContain("Rounding step");
+		expect(w.text()).not.toContain("Materiality benchmark amount");
+		expect(w.text()).not.toContain("Engagement risk level");
+		expect(w.text()).not.toContain("This agent has no additional settings.");
+	});
+
+	it("a bare flat key (no materiality. prefix) in configKeys matches nothing - paths are dot paths, not local keys", () => {
+		const w = mountForm({}, { configKeys: ["percentage"] });
+		expect(w.text()).not.toContain("Materiality percentage");
+		expect(w.text()).toContain("This agent has no additional settings.");
+	});
+
+	it("the full configKeys set (close-auditor) renders every agent-specific field, no note", () => {
+		const w = mountForm({});
+		expect(w.text()).not.toContain("This agent has no additional settings.");
+	});
+
+	it("a stale agent-specific value this agent doesn't declare stays visible in Advanced (JSON), not lost", async () => {
+		// e.g. a materiality.percentage saved on a non-close-auditor installation.
+		// With configKeys=[] the field has no control here - it must NOT
+		// silently vanish (unreadable, unclearable); it surfaces in Advanced
+		// (JSON) instead, same as any other unrecognised key, and round-trips
+		// unchanged on save.
+		const w = mountForm({ materiality: { percentage: 5 } }, { configKeys: [] });
+		const textarea = w.find("textarea");
+		expect(JSON.parse(textarea.element.value)).toEqual({ materiality: { percentage: 5 } });
+		expect(w.text()).not.toContain("Materiality percentage");
+
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({ materiality: { percentage: 5 } });
+	});
+
+	it("saving with configKeys=[] and nothing seeded emits an empty object", async () => {
+		const w = mountForm({}, { configKeys: [] });
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({});
+	});
+});
+
+// jarvis#1063 CRITICAL fix: close-auditor/evaluate.py reads materiality
+// config NESTED, not flat. Installations saved before this fix have it flat
+// at the top level - migrate transparently, one-directional (flat -> nested,
+// never back).
+describe("legacy flat-key migration (materiality.* used to be saved flat)", () => {
+	it("seed: pre-fills the field from a flat legacy key when the nested one is absent", () => {
+		const w = mountForm({ benchmark_value: 750000 });
+		expect(field(w, "Materiality benchmark amount").element.value).toBe("750000");
+	});
+
+	it("seed: the nested value wins over a flat legacy value when both are present", () => {
+		const w = mountForm({ benchmark_value: 1, materiality: { benchmark_value: 2 } });
+		expect(field(w, "Materiality benchmark amount").element.value).toBe("2");
+	});
+
+	it("seed: a flat legacy value does not leak into Advanced (JSON) once migrated into the form", () => {
+		const w = mountForm({ benchmark_value: 750000, custom_flag: true });
+		const textarea = w.find("textarea");
+		expect(JSON.parse(textarea.element.value)).toEqual({ custom_flag: true });
+	});
+
+	it("save: a migrated flat value is written nested, and the flat key is dropped", async () => {
+		const w = mountForm({ benchmark_value: 750000 });
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		const saved = w.emitted("save")[0][0];
+		expect(saved).toEqual({ materiality: { benchmark_value: 750000 } });
+		expect(saved).not.toHaveProperty("benchmark_value");
+	});
+
+	it("save: editing a migrated field and saving writes only the nested path", async () => {
+		const w = mountForm({ percentage: 5 });
+		await field(w, "Materiality percentage").setValue("7");
+		await w.find('[data-label="Save configuration"]').trigger("click");
+		expect(w.emitted("save")[0][0]).toEqual({ materiality: { percentage: 7 } });
+	});
+});

--- a/frontend/src/pages/agents/ConfigForm.vue
+++ b/frontend/src/pages/agents/ConfigForm.vue
@@ -1,35 +1,80 @@
 <template>
 	<div>
-		<div v-if="!fields.length && !hasAdvanced" class="text-sm text-ink-gray-5">
-			No configuration set yet - add keys under Advanced (JSON).
-		</div>
+		<p class="text-sm text-ink-gray-6">
+			Settings this agent reads when it runs. Leave a field empty to use the default.
+		</p>
 
-		<div v-if="fields.length" class="space-y-4">
-			<template v-for="f in fields" :key="f.key">
-				<Switch
-					v-if="f.type === 'boolean'"
-					:label="labelFor(f.key)"
-					:modelValue="f.value"
-					@update:modelValue="(v) => (f.value = v)"
+		<div class="mt-4 space-y-5">
+			<template v-for="f in visibleFields" :key="f.key || f.keys.join('-')">
+				<!-- Company / Fiscal year: frappe-ui Autocomplete fed by
+				     frappe.desk.search.search_link - the same whitelisted, generic
+				     Link-picker call every other Link field in this app uses
+				     (FilterValueControl.vue, TriggerDetail.vue). There is no single
+				     reusable <LinkField> component to import; this is that same
+				     small pattern, applied twice. -->
+				<div v-if="f.type === 'link'">
+					<label class="mb-1.5 block text-xs text-ink-gray-5">{{ f.label }}</label>
+					<div @focusin="linkFields[f.key].prime()" @click="linkFields[f.key].prime()">
+						<Autocomplete
+							:options="linkFields[f.key].options.value"
+							:modelValue="linkValue(f.key)"
+							:placeholder="`Search ${f.linkDoctype}…`"
+							@update:query="(q) => linkFields[f.key].onQuery(q)"
+							@update:modelValue="(opt) => onLinkPick(f.key, opt)"
+						/>
+					</div>
+					<p class="mt-1.5 text-p-xs text-ink-gray-5">{{ f.help }}</p>
+				</div>
+
+				<div v-else-if="f.type === 'date-range'">
+					<div class="grid grid-cols-2 gap-4">
+						<FormControl
+							type="date"
+							:label="f.labels[0]"
+							:modelValue="form[f.keys[0]]"
+							@update:modelValue="(v) => (form[f.keys[0]] = v)"
+						/>
+						<FormControl
+							type="date"
+							:label="f.labels[1]"
+							:modelValue="form[f.keys[1]]"
+							@update:modelValue="(v) => (form[f.keys[1]] = v)"
+						/>
+					</div>
+					<p class="mt-1.5 text-p-xs text-ink-gray-5">{{ f.help }}</p>
+				</div>
+
+				<FormControl
+					v-else-if="f.type === 'select'"
+					type="select"
+					:label="f.label"
+					:options="f.options"
+					:description="f.help"
+					:modelValue="form[f.key]"
+					@update:modelValue="(v) => (form[f.key] = v)"
 				/>
+
 				<FormControl
 					v-else-if="f.type === 'number'"
 					type="number"
-					:label="labelFor(f.key)"
-					:modelValue="f.value"
-					@update:modelValue="(v) => (f.value = v)"
-				/>
-				<FormControl
-					v-else
-					type="text"
-					:label="labelFor(f.key)"
-					:modelValue="f.value"
-					@update:modelValue="(v) => (f.value = v)"
-				/>
+					:label="f.label"
+					:description="f.help"
+					:modelValue="form[f.key]"
+					@update:modelValue="(v) => (form[f.key] = v)"
+				>
+					<template v-if="f.suffix" #suffix>
+						<span class="text-ink-gray-5">{{ f.suffix }}</span>
+					</template>
+				</FormControl>
 			</template>
+
+			<p v-if="!agentSpecificFields.length" class="text-p-xs text-ink-gray-5">
+				This agent has no additional settings.
+			</p>
 		</div>
 
-		<!-- §14 F3: arrays/objects + unknown/new keys live in Advanced only -->
+		<!-- §14 F3: any key outside CONFIG_FIELD_SET (unknown, or an array/object
+		     value) lives here only. -->
 		<DocSection label="Advanced (JSON)" :opened="false" class="mt-4">
 			<FormControl
 				type="textarea"
@@ -39,8 +84,10 @@
 				@update:modelValue="onAdvancedInput"
 			/>
 			<div class="mt-1 text-xs text-ink-gray-5">
-				Array/object values and new keys are edited here; form fields above win on matching
-				keys.
+				Enter values as JSON, for example {"company": "Acme Ltd", "materiality":
+				{"pl_balance": 50000}}. Form fields above win on matching keys - a value this page
+				renders a field for (e.g. "materiality": {"benchmark_value": ...}) belongs in that
+				field, not here.
 			</div>
 			<ErrorMessage class="mt-2" :message="advancedError" />
 		</DocSection>
@@ -52,60 +99,138 @@
 </template>
 
 <script setup>
-// ConfigForm - §14 F3: a real form generated from the installation's current
-// config object. boolean → Switch, number → FormControl type=number, string →
-// type=text; array/object values + unknown/new keys live in a collapsed
-// "Advanced (JSON)" DocSection (mono textarea, JSON.parse-validated). Save
-// merges the form values OVER the advanced JSON and emits the merged object;
-// the parent persists via setAgentConfig.
-import { ref, computed, watch } from "vue";
-import { Button, ErrorMessage, FormControl, Switch } from "frappe-ui";
+// ConfigForm - jarvis#1062 owner feedback: the known engagement settings
+// (CONFIG_FIELD_SET, @/lib/agentConfigFields) get real, purpose-built fields -
+// link pickers, dates, numbers, a select - ALWAYS rendered, not a code-key
+// reference list. Everything else (an unrecognised key, or any array/object
+// value) lives in the collapsed "Advanced (JSON)" editor (mono textarea,
+// JSON.parse-validated). Save merges the known fields OVER the advanced JSON
+// (form fields win on matching keys) and emits the merged object; the parent
+// persists via setAgentConfig. An empty field means the key is ABSENT from
+// the saved config, not saved as "" - that is what "leave it to use the
+// default" means server-side.
+import { computed, reactive, ref, watch } from "vue";
+import { Autocomplete, Button, ErrorMessage, FormControl } from "frappe-ui";
 import DocSection from "@/components/doc/DocSection.vue";
+import { searchLink } from "@/api";
+import { useLinkSearch } from "@/composables/useLinkSearch";
+import {
+	SCOPE_CONFIG_FIELDS,
+	AGENT_SPECIFIC_CONFIG_FIELDS,
+	CONFIG_FIELD_LABELS,
+	NUMBER_CONFIG_KEYS,
+	KEY_TO_PATH,
+	getPath,
+	setPath,
+	deletePath,
+} from "@/lib/agentConfigFields";
 
 const props = defineProps({
 	config: { type: Object, default: () => ({}) }, // parsed installation config
+	// jarvis#1063 (jarvis-only half): the current agent's Jarvis Agent Listing
+	// config_keys (get_agent), already parsed to a plain array by the parent.
+	// Gates which AGENT_SPECIFIC_CONFIG_FIELDS render - the scope fields
+	// (SCOPE_CONFIG_FIELDS) always render regardless.
+	configKeys: { type: Array, default: () => [] },
 	saving: { type: Boolean, default: false },
 });
 
+// The agent-specific fields this agent's config_keys actually names, in
+// CONFIG_FIELD_SET's display order.
+const agentSpecificFields = computed(() =>
+	AGENT_SPECIFIC_CONFIG_FIELDS.filter((f) =>
+		(f.paths || [f.path]).some((p) => props.configKeys.includes(p))
+	)
+);
+// Scope fields first (always), then whichever agent-specific fields apply -
+// the single list the template's v-for renders.
+const visibleFields = computed(() => [...SCOPE_CONFIG_FIELDS, ...agentSpecificFields.value]);
+// jarvis#1063: the key set for THIS agent's rendered fields - not the global
+// CONFIG_FIELD_SET. A key this agent's config_keys does not name (e.g. a
+// stale benchmark_value on a non-close-auditor installation, saved back when
+// every field always rendered) has no control here and must fall through to
+// Advanced (JSON) - seed()/save() key off this.
+const visibleKeys = computed(() => new Set(visibleFields.value.flatMap((f) => f.keys || [f.key])));
+
 const emit = defineEmits(["save"]);
 
-const fields = ref([]); // [{key, type: 'boolean'|'number'|'string', value}]
+// One string per known key - every control (link/date/number/select) binds
+// here as plain text; numbers are validated/coerced only on save.
+const form = reactive({
+	company: "",
+	fiscal_year: "",
+	from_date: "",
+	to_date: "",
+	benchmark_value: "",
+	percentage: "",
+	engagement_risk_level: "",
+	rounding_step: "",
+});
 const advanced = ref("{}");
 const advancedError = ref("");
 
 function seed(cfg) {
-	const scalars = [];
-	const complex = {};
-	for (const [key, value] of Object.entries(cfg || {})) {
-		if (typeof value === "boolean") scalars.push({ key, type: "boolean", value });
-		else if (typeof value === "number")
-			scalars.push({ key, type: "number", value: String(value) });
-		else if (typeof value === "string" || value == null)
-			scalars.push({ key, type: "string", value: value == null ? "" : value });
-		else complex[key] = value; // arrays + objects → Advanced
+	const c = cfg || {};
+	for (const key of Object.keys(form)) {
+		if (!visibleKeys.value.has(key)) {
+			// no rendered control here - leave it out of `form` entirely so
+			// save() (which only reads visibleKeys) never touches it; it stays
+			// visible and editable in Advanced (JSON) below instead of silently
+			// vanishing.
+			form[key] = "";
+			continue;
+		}
+		const path = KEY_TO_PATH[key] || key;
+		// jarvis#1063 CRITICAL fix: the nested path (e.g.
+		// "materiality.benchmark_value") is the source of truth. A flat
+		// top-level key of the same name (pre-nesting saves) is a MIGRATION
+		// fallback, read only when the nested value is absent - never the
+		// other way round.
+		let v = getPath(c, path);
+		if (v == null && path !== key) v = c[key];
+		form[key] = v == null ? "" : String(v);
 	}
-	fields.value = scalars;
-	advanced.value = JSON.stringify(complex, null, 2);
+	// Advanced (JSON) holds everything NOT covered by a visible field's path -
+	// a deep clone with each visible path (and its flat legacy counterpart,
+	// now migrated into `form` above) removed. deletePath also drops a
+	// now-empty intermediate object (e.g. `materiality`), so an installation
+	// whose only materiality keys are all rendered here does not leave a
+	// stray `{"materiality": {}}` in Advanced.
+	const rest = JSON.parse(JSON.stringify(c));
+	for (const key of visibleKeys.value) {
+		const path = KEY_TO_PATH[key] || key;
+		deletePath(rest, path);
+		if (path !== key) delete rest[key];
+	}
+	advanced.value = JSON.stringify(rest, null, 2);
 	advancedError.value = "";
 }
 
-watch(() => props.config, seed, { immediate: true });
-
-const hasAdvanced = computed(() => {
-	const t = advanced.value.trim();
-	return t !== "" && t !== "{}";
-});
+watch([() => props.config, visibleKeys], () => seed(props.config), { immediate: true });
 
 function onAdvancedInput(v) {
 	advanced.value = v;
 	advancedError.value = "";
 }
 
-function labelFor(key) {
-	return String(key)
-		.split(/[_-]/)
-		.map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
-		.join(" ");
+// ── Company / Fiscal year: debounced + fenced Link search, primed on open ───
+// (mirrors AgentAccessEditor.vue's people picker and FilterValueControl.vue's
+// generic Link control - all three now share useLinkSearch, jarvis#1062.)
+function makeLinkField(doctype) {
+	return useLinkSearch((q) => searchLink(doctype, q), {
+		mapper: (rows) => rows.map((r) => ({ label: r.value, value: r.value })),
+	});
+}
+
+const linkFields = {
+	company: makeLinkField("Company"),
+	fiscal_year: makeLinkField("Fiscal Year"),
+};
+function linkValue(key) {
+	return form[key] ? { label: form[key], value: form[key] } : null;
+}
+function onLinkPick(key, opt) {
+	form[key] = opt && opt.value ? String(opt.value) : "";
 }
 
 function save() {
@@ -124,25 +249,34 @@ function save() {
 			return;
 		}
 	}
-	// 2) form values merge over the JSON (§14 F3)
-	const merged = { ...base };
-	for (const f of fields.value) {
-		if (f.type === "boolean") {
-			merged[f.key] = !!f.value;
-		} else if (f.type === "number") {
-			const v = String(f.value ?? "").trim();
-			if (v === "") {
-				delete merged[f.key]; // cleared numeric → drop the key (round-2 parity)
-			} else {
-				const n = Number(v);
-				if (isNaN(n)) {
-					advancedError.value = `"${labelFor(f.key)}" must be a number.`;
-					return;
-				}
-				merged[f.key] = n;
+	// 2) the known fields merge OVER the JSON, WRITTEN THROUGH EACH FIELD'S
+	// PATH (jarvis#1063 CRITICAL fix - a flat save of a key the bundle reads
+	// nested, e.g. close-auditor's materiality.*, never reaches the
+	// evaluator). setPath merges into an existing object at that path rather
+	// than replacing it (an existing `materiality.pl_balance` from Advanced
+	// survives a benchmark_value edit); an empty field deletes its path
+	// rather than saving "" (§14 F3 / round-2 parity), pruning `materiality`
+	// entirely once every field under it is cleared. Either way, the
+	// migration is one-directional: a flat legacy key of the same name is
+	// always removed, since the nested path is now the source of truth.
+	const merged = JSON.parse(JSON.stringify(base));
+	for (const key of visibleKeys.value) {
+		const path = KEY_TO_PATH[key] || key;
+		const v = String(form[key] ?? "").trim();
+		if (path !== key) delete merged[key];
+		if (v === "") {
+			deletePath(merged, path);
+			continue;
+		}
+		if (NUMBER_CONFIG_KEYS.includes(key)) {
+			const n = Number(v);
+			if (isNaN(n)) {
+				advancedError.value = `"${CONFIG_FIELD_LABELS[key]}" must be a number.`;
+				return;
 			}
+			setPath(merged, path, n);
 		} else {
-			merged[f.key] = f.value ?? "";
+			setPath(merged, path, v);
 		}
 	}
 	advancedError.value = "";

--- a/frontend/src/pages/agents/FindingsPanel.spec.js
+++ b/frontend/src/pages/agents/FindingsPanel.spec.js
@@ -1,0 +1,903 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+/**
+ * jarvis#1062 - FindingsPanel's Open Chat gate, the operator Stop control, and
+ * the running-run progress display:
+ *
+ *   C1. "Open Chat" only renders once the run is no longer running, and a
+ *       `stopped` run's status pill carries the gray theme (not the "unknown
+ *       status" fallback gray by accident - the map has an explicit entry).
+ *   C2. A running run offers Stop -> stop_agent_run(run.name); success toasts
+ *       and asks the parent (AgentRunsBoard) to refresh; failure toasts the
+ *       error and leaves the run showing running.
+ *   C3. A run shows its STEP TIMELINE - a ticking elapsed-time label plus the
+ *       steps the bench observed this run take (list_run_steps), polled every
+ *       5s while running and kept, collapsed, once it is over.
+ */
+
+const api = vi.hoisted(() => ({
+	listAgentFindings: vi.fn(),
+	setFindingState: vi.fn(),
+}));
+vi.mock("@/api", () => api);
+
+const apiAgents = vi.hoisted(() => ({
+	takeFindingToChat: vi.fn(),
+	stopAgentRun: vi.fn(),
+	listRunSteps: vi.fn(),
+}));
+vi.mock("@/api/agents", () => apiAgents);
+
+// jarvis#1062: Notes-on-a-run reuses useDocmeta/CommentsSection, re-targeted
+// at "Jarvis Agent Run" - mock the network boundary (@/api/docmeta) and use
+// the REAL useDocmeta composable, so a test can assert the exact
+// (doctype, name) it calls through with; CommentsSection itself is stubbed
+// (DOMPurify/Avatar/Dropdown/an async TipTap composer are someone else's
+// coverage - AgentDetail.spec.js stubs it the same way) but the stub reads
+// real `docmeta.meta.comments` and calls the real `docmeta.addComment`.
+const apiDocmeta = vi.hoisted(() => ({
+	getDocmeta: vi.fn(),
+	addComment: vi.fn(),
+	updateComment: vi.fn(),
+	deleteComment: vi.fn(),
+}));
+vi.mock("@/api/docmeta", () => apiDocmeta);
+vi.mock("@/components/doc/CommentsSection.vue", () => ({
+	default: {
+		name: "CommentsSection",
+		props: ["docmeta", "canComment", "heading", "emptyText"],
+		template: `<div class="notes-section">
+			<div class="notes-heading">{{ heading }}</div>
+			<div
+				v-if="!(docmeta.meta && docmeta.meta.comments && docmeta.meta.comments.length)"
+				class="notes-empty"
+			>{{ emptyText }}</div>
+			<div v-for="c in (docmeta.meta && docmeta.meta.comments) || []" :key="c.name" class="note-row">
+				{{ c.content }}
+			</div>
+			<button data-testid="post-note" @click="docmeta.addComment('a note')">post</button>
+		</div>`,
+	},
+}));
+
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+vi.mock("vue-router", () => ({ useRouter: () => router }));
+
+// frappe-ui's ESM entry does not resolve under vitest (see LlmPoolEditor.spec.js).
+// dayjsLocal backs @/utils/datetime's toLocalMs/timeAgo/exactDate - it needs a
+// REAL epoch (valueOf) so the elapsed-time math under fake timers is honest,
+// not just a stub that always reads 0.
+vi.mock("frappe-ui", () => ({
+	call: vi.fn(),
+	dayjs: () => ({ format: () => "" }),
+	dayjsLocal: (d) => ({
+		format: () => String(d || ""),
+		fromNow: () => "",
+		isValid: () => !!d,
+		valueOf: () => (d ? new Date(String(d).replace(" ", "T")).getTime() : 0),
+	}),
+	getConfig: () => null,
+	toast: { success: vi.fn(), error: vi.fn() },
+	Badge: {
+		name: "Badge",
+		props: ["label", "theme", "variant"],
+		template: `<span class="badge" :data-theme="theme">{{ label }}</span>`,
+	},
+	Button: {
+		name: "Button",
+		props: ["label", "disabled", "loading", "variant", "theme", "iconLeft", "tooltip"],
+		emits: ["click"],
+		template: `<button :disabled="disabled" :data-label="label" @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+	},
+	FeatherIcon: { name: "FeatherIcon", template: "<i />" },
+	FormControl: {
+		name: "FormControl",
+		props: ["modelValue", "type", "options", "disabled"],
+		emits: ["update:modelValue"],
+		template: `<select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)"></select>`,
+	},
+	Tooltip: { name: "Tooltip", template: `<span><slot /></span>` },
+}));
+
+vi.mock("@/components/JvSpinner.vue", () => ({
+	default: { name: "JvSpinner", template: `<div class="spinner" />` },
+}));
+vi.mock("@/components/Banner.vue", () => ({
+	default: {
+		name: "Banner",
+		props: ["type", "message"],
+		// jarvis#1062 P0-2: the default slot is real Banner.vue's own
+		// "details expander" extension point (its own doc comment) - render
+		// it here too, or a TechnicalDetails passed into it would silently
+		// never appear under test.
+		template: `<div class="banner">{{ message }}<slot /></div>`,
+	},
+}));
+vi.mock("@/markdown", () => ({ renderMarkdown: (s) => s }));
+vi.mock("@/lib/errors", () => ({
+	errMessage: (e) => (e && e.message) || String(e),
+	errHtml: (e) => (e && e.message) || String(e),
+}));
+
+import FindingsPanel from "./FindingsPanel.vue";
+import * as findingText from "@/lib/findingText";
+
+function baseRun(overrides = {}) {
+	return {
+		name: "RUN-0001",
+		agent: "close-auditor",
+		status: "completed",
+		trigger: "manual",
+		started_at: "2026-09-01 10:00:00",
+		finished_at: "2026-09-01 10:05:00",
+		conversation: "CONV-0001",
+		dashboard: null,
+		findings_count: 0,
+		blocker_count: 0,
+		error: "",
+		coverage_note: "",
+		nature: "Auditor",
+		pages_written: 0,
+		pages_json: "[]",
+		...overrides,
+	};
+}
+
+function mountPanel(run) {
+	return mount(FindingsPanel, { props: { run } });
+}
+
+// list_run_steps rows: the launch dispatch plus one humanized tool call
+const STEPS = [
+	{
+		name: "S1",
+		seq: 1,
+		kind: "dispatched",
+		tool: "",
+		label: "Dispatched to the agent",
+		detail: "trigger: manual",
+		status: "ok",
+		duration_ms: null,
+		occurred_at: "2026-09-01 10:00:00",
+	},
+	{
+		name: "S2",
+		seq: 2,
+		kind: "tool",
+		tool: "get_list",
+		label: "Read Sales Invoice, 12 rows",
+		detail: "",
+		status: "ok",
+		duration_ms: 340,
+		occurred_at: "2026-09-01 10:00:04",
+	},
+];
+
+function setVisibility(state) {
+	Object.defineProperty(document, "visibilityState", {
+		value: state,
+		writable: true,
+		configurable: true,
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	setVisibility("visible");
+	api.listAgentFindings.mockResolvedValue({
+		rows: [],
+		total: 0,
+		has_more: false,
+		severity_counts: {},
+	});
+	apiAgents.listRunSteps.mockResolvedValue({ steps: [], count: 0 });
+	apiDocmeta.getDocmeta.mockResolvedValue({
+		comments: [],
+		assignees: [],
+		liked_by: [],
+		liked: false,
+		attachments: [],
+		shares: [],
+		created: { owner: "", full_name: "", creation: "" },
+		modified: { modified_by: "", full_name: "", modified: "" },
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("C1: Open Chat is gated on status, stopped renders a gray pill", () => {
+	it("hides Open Chat while the run is running, even with a conversation", async () => {
+		const w = mountPanel(baseRun({ status: "running", conversation: "CONV-0001" }));
+		await flushPromises();
+		expect(w.findAll("button").some((b) => b.text().includes("Open Chat"))).toBe(false);
+	});
+
+	it("shows Open Chat once the run is no longer running", async () => {
+		const w = mountPanel(baseRun({ status: "completed", conversation: "CONV-0001" }));
+		await flushPromises();
+		expect(w.findAll("button").some((b) => b.text().includes("Open Chat"))).toBe(true);
+	});
+
+	it("renders the stopped status pill with the gray theme", async () => {
+		const w = mountPanel(baseRun({ status: "stopped" }));
+		await flushPromises();
+		expect(w.find(".badge").attributes("data-theme")).toBe("gray");
+	});
+});
+
+describe("C2: Stop is reachable while running and idempotent-safe (no confirm)", () => {
+	function stopButton(w) {
+		return w.findAll("button").find((b) => b.text() === "Stop");
+	}
+
+	it("renders Stop only while running", async () => {
+		const running = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(stopButton(running)).toBeTruthy();
+
+		const completed = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		expect(stopButton(completed)).toBeUndefined();
+	});
+
+	it("calls stop_agent_run with the run name and emits stopped on success", async () => {
+		apiAgents.stopAgentRun.mockResolvedValue({ ok: true, status: "stopped" });
+		const w = mountPanel(baseRun({ status: "running", name: "RUN-0042" }));
+		await flushPromises();
+		await stopButton(w).trigger("click");
+		await flushPromises();
+
+		expect(apiAgents.stopAgentRun).toHaveBeenCalledWith("RUN-0042");
+		expect(w.emitted("stopped")).toBeTruthy();
+	});
+
+	it("toasts the error and does not emit stopped on failure", async () => {
+		const { toast } = await import("frappe-ui");
+		apiAgents.stopAgentRun.mockRejectedValue({ message: "That run no longer exists." });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		await stopButton(w).trigger("click");
+		await flushPromises();
+
+		expect(toast.error).toHaveBeenCalledWith("That run no longer exists.");
+		expect(w.emitted("stopped")).toBeFalsy();
+	});
+
+	it("does not render a confirm dialog before stopping", async () => {
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(w.find(".dialog").exists()).toBe(false);
+	});
+});
+
+describe("C3: the run step timeline - ticking elapsed time + observed steps", () => {
+	it("shows a ticking elapsed-time label instead of the static placeholder", async () => {
+		vi.useFakeTimers();
+		// setSystemTime only stamps Date.now() - only advanceTimersByTimeAsync
+		// moves BOTH the clock and the interval queue together, so every
+		// forward step below uses it exclusively (mixing the two produces a
+		// timer queue that disagrees with Date.now()).
+		vi.setSystemTime(new Date("2026-09-01T10:00:00"));
+		const w = mountPanel(
+			baseRun({ status: "running", started_at: "2026-09-01 10:00:00", conversation: "" })
+		);
+		await flushPromises();
+		expect(w.text()).toContain("Running for");
+		expect(w.text()).toContain("00:00");
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(w.text()).toContain("00:30");
+
+		await vi.advanceTimersByTimeAsync(35000);
+		await flushPromises();
+		expect(w.text()).toContain("01:05");
+	});
+
+	it("fetches and renders THIS run's steps while it is running", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "running", name: "RUN-0042" }));
+		await flushPromises();
+
+		expect(apiAgents.listRunSteps).toHaveBeenCalledWith("RUN-0042");
+		expect(w.text()).toContain("Dispatched to the agent");
+		expect(w.text()).toContain("Read Sales Invoice, 12 rows");
+		expect(w.text()).toContain("2 steps");
+	});
+
+	it("marks the latest step as current while running, and only that one", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		const now = w.findAll(".badge").filter((b) => b.text() === "Now");
+		expect(now.length).toBe(1);
+	});
+
+	it("shows the empty state before the first step lands", async () => {
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(w.text()).toContain("Dispatched to the agent, waiting for the first step");
+	});
+
+	it("keeps the scribe placeholder wording distinct from the auditor one", async () => {
+		const w = mountPanel(
+			baseRun({ status: "running", nature: "Scribe", pages_json: "[]", pages_written: 0 })
+		);
+		await flushPromises();
+		expect(w.text()).toContain("pages appear here as they are written");
+	});
+
+	it("stops polling after the component unmounts (no leaked interval)", async () => {
+		vi.useFakeTimers();
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		const before = apiAgents.listRunSteps.mock.calls.length;
+		w.unmount();
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps.mock.calls.length).toBe(before);
+	});
+
+	it("keeps the timeline on screen once findings exist", async () => {
+		api.listAgentFindings.mockResolvedValue({
+			rows: [{ name: "F1", severity: "blocker", title: "x", state: "open" }],
+			total: 1,
+			has_more: false,
+			severity_counts: { blocker: 1 },
+		});
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(w.text()).toContain("Running for");
+		expect(w.text()).toContain("Read Sales Invoice, 12 rows");
+	});
+
+	it("skips the 5s re-fetch while the tab is hidden, and resumes once visible", async () => {
+		vi.useFakeTimers();
+		setVisibility("visible");
+		mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		const callsAfterMount = apiAgents.listRunSteps.mock.calls.length;
+
+		setVisibility("hidden");
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps.mock.calls.length).toBe(callsAfterMount);
+
+		setVisibility("visible");
+		await vi.advanceTimersByTimeAsync(5000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps.mock.calls.length).toBeGreaterThan(callsAfterMount);
+	});
+});
+
+describe("C3b: a finished run keeps its timeline, collapsed", () => {
+	it("fetches steps once for a terminal run and does not poll", async () => {
+		vi.useFakeTimers();
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		expect(apiAgents.listRunSteps).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders a collapsed Steps (N) disclosure that opens on click", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: STEPS, count: 2 });
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+
+		expect(w.text()).toContain("Steps (2)");
+		expect(w.text()).not.toContain("Read Sales Invoice, 12 rows");
+
+		const disclosure = w.findAll("button").find((b) => b.text().includes("Steps (2)"));
+		await disclosure.trigger("click");
+		expect(w.text()).toContain("Read Sales Invoice, 12 rows");
+	});
+
+	it("re-fetches once on the flip from running to terminal, then stops", async () => {
+		vi.useFakeTimers();
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		const whileRunning = apiAgents.listRunSteps.mock.calls.length;
+
+		await w.setProps({ run: baseRun({ status: "completed" }) });
+		await flushPromises();
+		const afterFlip = apiAgents.listRunSteps.mock.calls.length;
+		expect(afterFlip).toBe(whileRunning + 1);
+
+		await vi.advanceTimersByTimeAsync(30000);
+		await flushPromises();
+		expect(apiAgents.listRunSteps.mock.calls.length).toBe(afterFlip);
+	});
+
+	it("shows an error step in the red tone, with the tool's message", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({
+			steps: [
+				{
+					name: "S1",
+					seq: 1,
+					kind: "tool",
+					tool: "run_report",
+					label: "Ran report Trial Balance",
+					detail: "unknown Report: Trial Balance",
+					status: "error",
+					duration_ms: 40,
+					occurred_at: "2026-09-01 10:00:01",
+				},
+			],
+			count: 1,
+		});
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		await w
+			.findAll("button")
+			.find((b) => b.text().includes("Steps (1)"))
+			.trigger("click");
+		expect(w.html()).toContain("text-ink-red-4");
+		// a bare red row explains nothing - the failure has to say what failed
+		expect(w.text()).toContain("unknown Report: Trial Balance");
+	});
+});
+
+describe("C3c: consecutive identical steps collapse into one row", () => {
+	function repeated(n, overrides = {}) {
+		return Array.from({ length: n }, (_, i) => ({
+			name: `R${i}`,
+			seq: i + 1,
+			kind: "tool",
+			tool: "get_list",
+			label: "Read Sales Invoice, 12 rows",
+			detail: "",
+			status: "ok",
+			duration_ms: 100,
+			occurred_at: `2026-09-01 10:00:0${i}`,
+			...overrides,
+		}));
+	}
+
+	it("folds a repeated read into a single row with an xN count", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: repeated(3), count: 3 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+
+		expect(w.text()).toContain("x3");
+		// one rendered row, but the header still reports every recorded step
+		expect(w.text().match(/Read Sales Invoice, 12 rows/g).length).toBe(1);
+		expect(w.text()).toContain("3 steps");
+	});
+
+	it("does not fold steps more than 5s apart", async () => {
+		const steps = repeated(2);
+		steps[1].occurred_at = "2026-09-01 10:00:30";
+		apiAgents.listRunSteps.mockResolvedValue({ steps, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+
+		expect(w.text()).not.toContain("x2");
+		expect(w.text().match(/Read Sales Invoice, 12 rows/g).length).toBe(2);
+	});
+
+	it("never folds a failure into a success", async () => {
+		const steps = repeated(2);
+		steps[1].status = "error";
+		steps[1].detail = "no permission to read Sales Invoice";
+		apiAgents.listRunSteps.mockResolvedValue({ steps, count: 2 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+
+		expect(w.text()).not.toContain("x2");
+		expect(w.text()).toContain("no permission to read Sales Invoice");
+	});
+
+	it("renders a measured 0ms rather than dropping it, but nothing for a missing one", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({
+			steps: [
+				{ ...STEPS[1], name: "Z1", duration_ms: 0, occurred_at: "2026-09-01 10:00:00" },
+				{
+					...STEPS[0],
+					name: "Z2",
+					label: "Dispatched to the agent",
+					duration_ms: null,
+					occurred_at: "2026-09-01 10:00:20",
+				},
+			],
+			count: 2,
+		});
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		// a step that finished inside the timer's resolution still reports a time
+		expect(w.text()).toContain("0ms");
+		// ...while a step that recorded none reports nothing at all
+		expect(w.text()).not.toContain("nullms");
+		expect(w.text()).not.toContain("NaN");
+	});
+
+	it("marks only the last COLLAPSED row as current", async () => {
+		apiAgents.listRunSteps.mockResolvedValue({ steps: repeated(3), count: 3 });
+		const w = mountPanel(baseRun({ status: "running" }));
+		await flushPromises();
+		expect(w.findAll(".badge").filter((b) => b.text() === "Now").length).toBe(1);
+	});
+});
+
+describe("stopped run explanation (jarvis#1062 polish)", () => {
+	it("shows the error row for a stopped run with a recorded error", async () => {
+		const w = mountPanel(baseRun({ status: "stopped", error: "operator stopped it" }));
+		await flushPromises();
+		expect(w.text()).toContain("operator stopped it");
+	});
+
+	it("falls back to a stopped-specific message when no error was recorded", async () => {
+		const w = mountPanel(baseRun({ status: "stopped", error: "" }));
+		await flushPromises();
+		expect(w.text()).toContain("This run was stopped before it reported findings.");
+	});
+
+	it("does not render the failed-run fallback text for a stopped run", async () => {
+		const w = mountPanel(baseRun({ status: "stopped", error: "" }));
+		await flushPromises();
+		expect(w.text()).not.toContain("This run failed before recording findings.");
+	});
+});
+
+describe("Discuss in chat honors ok/reason, not just conversation (jarvis#1062 polish)", () => {
+	function findingRow() {
+		return {
+			name: "F1",
+			rule_id: "R1",
+			severity: "blocker",
+			title: "A finding",
+			state: "open",
+			amount: null,
+			recurrence: "new",
+			detail_md: "",
+		};
+	}
+
+	async function expandAndDiscuss(w) {
+		await flushPromises();
+		const row = w.find('[role="button"]');
+		await row.trigger("click");
+		await flushPromises();
+		const btn = w
+			.findAll("button")
+			.find((b) => b.attributes("data-label") === "Discuss in chat");
+		await btn.trigger("click");
+		await flushPromises();
+	}
+
+	it("does not navigate and toasts the reason when ok is false", async () => {
+		api.listAgentFindings.mockResolvedValue({
+			rows: [findingRow()],
+			total: 1,
+			has_more: false,
+			severity_counts: { blocker: 1 },
+		});
+		apiAgents.takeFindingToChat.mockResolvedValue({
+			ok: false,
+			conversation: "CONV-9",
+			reason: "No LLM configured for this container.",
+		});
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await expandAndDiscuss(w);
+		expect(router.push).not.toHaveBeenCalled();
+		const { toast } = await import("frappe-ui");
+		expect(toast.error).toHaveBeenCalledWith("No LLM configured for this container.");
+	});
+
+	it("falls back to a generic message when ok is false with no reason", async () => {
+		api.listAgentFindings.mockResolvedValue({
+			rows: [findingRow()],
+			total: 1,
+			has_more: false,
+			severity_counts: { blocker: 1 },
+		});
+		apiAgents.takeFindingToChat.mockResolvedValue({ ok: false, conversation: "CONV-9" });
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await expandAndDiscuss(w);
+		expect(router.push).not.toHaveBeenCalled();
+		const { toast } = await import("frappe-ui");
+		expect(toast.error).toHaveBeenCalledWith("Could not open this finding in chat.");
+	});
+
+	it("navigates to the conversation when ok is true", async () => {
+		api.listAgentFindings.mockResolvedValue({
+			rows: [findingRow()],
+			total: 1,
+			has_more: false,
+			severity_counts: { blocker: 1 },
+		});
+		apiAgents.takeFindingToChat.mockResolvedValue({ ok: true, conversation: "CONV-9" });
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await expandAndDiscuss(w);
+		expect(router.push).toHaveBeenCalledWith("/c/CONV-9");
+	});
+});
+
+// jarvis#1062 owner decision: Notes moved off the Configure tab onto the Run
+// itself - the SAME CommentsSection/useDocmeta pair, re-targeted at
+// "Jarvis Agent Run" + this run's name instead of the installation.
+describe("Notes on the run (jarvis#1062)", () => {
+	it("requests the docmeta bundle for THIS run - doctype and name, not the installation", async () => {
+		const w = mountPanel(baseRun({ name: "RUN-NOTES-1", status: "completed" }));
+		await flushPromises();
+		expect(apiDocmeta.getDocmeta).toHaveBeenCalledWith("Jarvis Agent Run", "RUN-NOTES-1");
+		// "Run notes", not "Notes": SEVERITY_LABEL.note already renders a "Notes"
+		// heading in this same panel for note-severity findings.
+		expect(w.find(".notes-heading").text()).toBe("Run notes");
+	});
+
+	it("renders the run's existing comments", async () => {
+		apiDocmeta.getDocmeta.mockResolvedValue({
+			comments: [
+				{
+					name: "COMM-1",
+					content: "looked into the flagged ledger entry",
+					owner: "reviewer@example.com",
+					owner_name: "Reviewer",
+					owner_image: "",
+					creation: "2026-09-01 11:00:00",
+					modified: "2026-09-01 11:00:00",
+				},
+			],
+			assignees: [],
+			liked_by: [],
+			liked: false,
+			attachments: [],
+			shares: [],
+			created: { owner: "", full_name: "", creation: "" },
+			modified: { modified_by: "", full_name: "", modified: "" },
+		});
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		expect(w.text()).toContain("looked into the flagged ledger entry");
+		expect(w.find(".notes-empty").exists()).toBe(false);
+	});
+
+	it("shows the empty copy when the run has no notes yet", async () => {
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		expect(w.find(".notes-empty").text()).toBe("No notes on this run yet.");
+	});
+
+	it("posting calls the API with the run's reference (Jarvis Agent Run + this run's name)", async () => {
+		apiDocmeta.addComment.mockResolvedValue({
+			name: "COMM-9",
+			content: "a note",
+			owner: "me@example.com",
+			owner_name: "Me",
+			owner_image: "",
+			creation: "2026-09-01 12:00:00",
+			modified: "2026-09-01 12:00:00",
+		});
+		const w = mountPanel(baseRun({ name: "RUN-NOTES-2", status: "completed" }));
+		await flushPromises();
+		await w.find('[data-testid="post-note"]').trigger("click");
+		await flushPromises();
+		expect(apiDocmeta.addComment).toHaveBeenCalledWith(
+			"Jarvis Agent Run",
+			"RUN-NOTES-2",
+			"a note"
+		);
+	});
+
+	it("renders for a running run too, not only terminal statuses", async () => {
+		const w = mountPanel(baseRun({ status: "running", finished_at: "" }));
+		await flushPromises();
+		expect(w.find(".notes-section").exists()).toBe(true);
+	});
+
+	it("renders below the findings list, for a scribe (Custom App Learning) run too", async () => {
+		const w = mountPanel(
+			baseRun({ status: "completed", nature: "Scribe", pages_written: 1, pages_json: "[]" })
+		);
+		await flushPromises();
+		expect(w.find(".notes-section").exists()).toBe(true);
+	});
+
+	it("switching the selected run reloads Notes for the newly selected run", async () => {
+		const w = mountPanel(baseRun({ name: "RUN-A", status: "completed" }));
+		await flushPromises();
+		expect(apiDocmeta.getDocmeta).toHaveBeenLastCalledWith("Jarvis Agent Run", "RUN-A");
+
+		await w.setProps({ run: baseRun({ name: "RUN-B", status: "completed" }) });
+		await flushPromises();
+		expect(apiDocmeta.getDocmeta).toHaveBeenLastCalledWith("Jarvis Agent Run", "RUN-B");
+	});
+});
+
+// jarvis#1062 P0-2/P1-3 (production-readiness audit): demote engineering
+// output. The row shows the human title first, never an unlabeled truncated
+// rule-code column; the expanded finding shows the (token-cleaned) prose
+// first, with rule code / eval flags / not_evaluable counts / DocType.field
+// refs collapsed into a labelled "Technical details" block; the coverage
+// banner reads as a plain sentence with its own codes in the same block.
+describe("Findings demote engineering output (jarvis#1062 P0-2/P1-3)", () => {
+	function techFinding(overrides = {}) {
+		return {
+			name: "F1",
+			rule_id: "nsv-grad-7d92",
+			severity: "blocker",
+			title: "data-trust grade for Goods In Transit - ATD",
+			state: "open",
+			amount: null,
+			recurrence: "new",
+			detail_md:
+				"data-trust grade for Goods In Transit - ATD: FLAGGED (clears reorder gate: False). " +
+				"A derived-candidate summary of observed-fact counts; graded on the classes that " +
+				"evaluated, with 1 class(es) not_evaluable. Reorder is held for any non-clean warehouse.",
+			...overrides,
+		};
+	}
+
+	async function mountWithFinding(row, mountOptions = {}) {
+		api.listAgentFindings.mockResolvedValue({
+			rows: [row],
+			total: 1,
+			has_more: false,
+			severity_counts: { blocker: 1 },
+		});
+		const w = mount(FindingsPanel, {
+			props: { run: baseRun({ status: "completed" }) },
+			...mountOptions,
+		});
+		await flushPromises();
+		return w;
+	}
+
+	it("the collapsed row never shows the rule code - no unlabeled monospace column", async () => {
+		const w = await mountWithFinding(techFinding());
+		const row = w.find('[role="button"]');
+		expect(row.text()).not.toContain("nsv-grad-7d92");
+		expect(row.text()).toContain("data-trust grade for Goods In Transit - ATD");
+	});
+
+	it("expanding shows the human title/summary first, machine tokens stripped from the sentence", async () => {
+		const w = await mountWithFinding(techFinding());
+		await w.find('[role="button"]').trigger("click");
+		await flushPromises();
+
+		const prose = w.find(".prose");
+		expect(prose.text()).not.toContain("nsv-grad-7d92");
+		expect(prose.text()).not.toContain("clears reorder gate");
+		expect(prose.text()).not.toContain("not_evaluable");
+		expect(prose.text()).not.toContain("class(es)");
+		expect(prose.text()).toContain("data-trust grade for Goods In Transit");
+	});
+
+	it("the rule code, flag and not_evaluable count all land in a collapsed Technical details block", async () => {
+		// attachTo: document.body - isVisible() (via getComputedStyle) needs a
+		// connected tree to resolve v-show's inline display toggle reliably.
+		const w = await mountWithFinding(techFinding(), { attachTo: document.body });
+		await w.find('[role="button"]').trigger("click");
+		await flushPromises();
+
+		expect(w.text()).toContain("Technical details");
+		// collapsed by default - DocSection's own v-show, not removed from the DOM
+		const dl = w.find("dl");
+		expect(dl.exists()).toBe(true);
+		expect(dl.isVisible()).toBe(false);
+		expect(dl.text()).toContain("nsv-grad-7d92");
+		expect(dl.text()).toContain("clears reorder gate: False");
+		expect(dl.text()).toContain("1 class");
+
+		// opening it makes the same content visible, still nowhere near the
+		// primary sentence above
+		const detailsHeader = w.findAll("button").find((b) => b.text() === "Technical details");
+		await detailsHeader.trigger("click");
+		expect(w.find("dl").isVisible()).toBe(true);
+		w.unmount();
+	});
+
+	it("a finding with no machine tokens in its prose shows no Technical details block beyond a bare rule_id", async () => {
+		const w = await mountWithFinding(
+			techFinding({ rule_id: "", detail_md: "Everything about this looks fine." })
+		);
+		await w.find('[role="button"]').trigger("click");
+		await flushPromises();
+		expect(w.find("dl").exists()).toBe(false);
+	});
+
+	// Review fix: findingDisplay(f) used to be called 2-3 times per expanded
+	// row straight from the template (the v-if, the v-html source, and
+	// TechnicalDetails' :details prop), re-running the regex extraction pass
+	// each time. It is now memoized per finding (by f.name) in a computed
+	// Map, so extractTechnicalDetails runs exactly once per finding no
+	// matter how many places its result is read.
+	it("extracts a finding's technical details exactly once, however many times the expanded row reads it", async () => {
+		const spy = vi.spyOn(findingText, "extractTechnicalDetails");
+		spy.mockClear();
+		const w = await mountWithFinding(techFinding());
+		const callsAfterMount = spy.mock.calls.length;
+
+		await w.find('[role="button"]').trigger("click"); // expand - reads text, v-html source, details
+		await flushPromises();
+		// exactly one MORE call than after mount (the finding's own detail_md) -
+		// not the 2-3 a naive per-read call would add.
+		expect(spy.mock.calls.length).toBe(callsAfterMount + 1);
+
+		await w.find('[role="button"]').trigger("click"); // collapse
+		await w.find('[role="button"]').trigger("click"); // re-expand
+		await flushPromises();
+		// re-expanding the SAME finding does not re-run the extraction either -
+		// it is still the same computed Map entry.
+		expect(spy.mock.calls.length).toBe(callsAfterMount + 1);
+		spy.mockRestore();
+	});
+
+	it("the coverage/warning banner reads as a plain sentence, with its own code in the details block", async () => {
+		const w = mountPanel(
+			baseRun({
+				status: "partial",
+				coverage_note:
+					"not evaluable: nsv-tieout-7d92: Configure no account<->warehouse mapping " +
+					"is populated for any scoped warehouse (Warehouse.account empty)",
+			})
+		);
+		await flushPromises();
+
+		// the MESSAGE prop specifically (not the whole banner's rendered text,
+		// which also includes the nested TechnicalDetails slot by design) -
+		// this is the actual "primary sentence" a reviewer reads first.
+		const bannerComponent = w.findComponent({ name: "Banner" });
+		const message = bannerComponent.props("message");
+		expect(message).not.toContain("nsv-tieout-7d92");
+		expect(message).not.toContain("Warehouse.account");
+		expect(message).toContain("Partial scan");
+		expect(message).toContain("not evaluable");
+
+		const banner = w.find(".banner");
+		const dl = banner.find("dl");
+		expect(dl.exists()).toBe(true);
+		expect(dl.text()).toContain("nsv-tieout-7d92");
+		expect(dl.text()).toContain("Warehouse.account");
+	});
+});
+
+// jarvis#1062 P1-5 (production-readiness audit): the finding row is a plain
+// role="button" div - no default browser outline, and none was added.
+describe("finding row keyboard focus (jarvis#1062 P1-5)", () => {
+	it("carries a focus-visible ring", async () => {
+		api.listAgentFindings.mockResolvedValue({
+			rows: [
+				{
+					name: "F1",
+					rule_id: "R1",
+					severity: "blocker",
+					title: "A finding",
+					state: "open",
+					amount: null,
+					recurrence: "new",
+					detail_md: "",
+				},
+			],
+			total: 1,
+			has_more: false,
+			severity_counts: { blocker: 1 },
+		});
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		const row = w.find('[role="button"]');
+		expect(row.exists()).toBe(true);
+		expect(row.classes()).toContain("focus-visible:ring-2");
+		expect(row.classes()).toContain("focus-visible:ring-outline-gray-3");
+	});
+});
+
+// jarvis#1062 P2-12 (production-readiness audit): the status badge + up to
+// 3 action buttons had nowhere to go on a narrow screen except squeeze the
+// title down to nothing.
+describe("run header wraps instead of squeezing the title (jarvis#1062 P2-12)", () => {
+	it("the header row carries flex-wrap", async () => {
+		const w = mountPanel(baseRun({ status: "completed" }));
+		await flushPromises();
+		const header = w.find(".flex.flex-wrap.items-center.gap-3");
+		expect(header.exists()).toBe(true);
+	});
+});

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -1,7 +1,11 @@
 <template>
 	<div class="mx-auto w-full max-w-3xl px-6 py-6">
-		<!-- run header -->
-		<div class="flex items-center gap-3">
+		<!-- run header. jarvis#1062 P2-12 (production-readiness audit):
+		     flex-wrap - the status badge + up to 3 action buttons had nowhere
+		     to go on a narrow screen except squeeze the title down to
+		     nothing; they now wrap to their own line instead, title kept
+		     full-width and truncating on its own line above them. -->
+		<div class="flex flex-wrap items-center gap-3">
 			<h2 class="min-w-0 flex-1 truncate text-lg font-semibold text-ink-gray-9">
 				Run {{ runLabel }}
 			</h2>
@@ -18,11 +22,23 @@
 				@click="router.push('/dashboards/' + run.dashboard)"
 			/>
 			<Button
-				v-if="run.conversation"
+				v-if="run.conversation && run.status !== 'running'"
 				variant="subtle"
 				label="Open Chat"
 				iconLeft="message-circle"
 				@click="router.push('/c/' + run.conversation)"
+			/>
+			<!-- #1062 C2: no confirm dialog - stop is safe (soft) and idempotent
+			     server-side (a concurrent finish/second click just reports the
+			     terminal state it actually reached). -->
+			<Button
+				v-if="run.status === 'running'"
+				variant="subtle"
+				theme="red"
+				label="Stop"
+				iconLeft="square"
+				:loading="stopping"
+				@click="stopRun"
 			/>
 		</div>
 		<div class="mt-1 flex flex-wrap items-center gap-1.5 text-sm text-ink-gray-5">
@@ -40,6 +56,13 @@
 				</Tooltip>
 			</template>
 		</div>
+
+		<!-- Step timeline (jarvis#1062): the run's own narration, full width and
+		     directly under the header so it reads as part of the run, not as a
+		     placeholder inside an empty findings list. Deliberately OUTSIDE the
+		     scribe/auditor branches - both natures take the same steps - and kept
+		     after the run finishes (collapsed) so a completed run is inspectable. -->
+		<RunStepTimeline :steps="steps" :status="run.status" :elapsed="elapsedLabel" />
 
 		<!-- Scribe run: a Custom App Learning agent writes wiki pages, not findings.
 		     Show the pages it wrote (with links) instead of a findings list, so a
@@ -60,7 +83,9 @@
 				class="mt-4"
 				type="warning"
 				:message="`${coverageNote}.`"
-			/>
+			>
+				<TechnicalDetails :details="coverageDetails" />
+			</Banner>
 
 			<div class="mt-5 text-base font-medium text-ink-gray-9">
 				{{ scribePages.length || run.pages_written || 0 }} wiki page{{
@@ -84,8 +109,10 @@
 					<FeatherIcon name="external-link" class="size-3.5 shrink-0 text-ink-gray-5" />
 				</a>
 			</div>
+			<!-- the running state is the timeline above; this line only says where
+			     the pages will land -->
 			<div v-else-if="run.status === 'running'" class="mt-2 py-6 text-sm text-ink-gray-5">
-				Run in progress - pages appear here as they are written.
+				Wiki pages appear here as they are written.
 			</div>
 			<div v-else class="mt-2 py-6 text-sm text-ink-gray-5">
 				No wiki pages were written this run.
@@ -99,12 +126,15 @@
 				class="mt-4"
 				type="warning"
 				:message="`Partial scan - ${coverageNote}. Treat gaps as unreviewed, not clean.`"
-			/>
+			>
+				<TechnicalDetails :details="coverageDetails" />
+			</Banner>
 
-			<!-- failed run: surface the error; no findings snapshot was recorded.
-				 x-circle, not Banner's fixed error icon: see the scribe branch above. -->
+			<!-- failed/stopped run: surface the error; no findings snapshot was
+				 recorded. x-circle, not Banner's fixed error icon: see the scribe
+				 branch above. -->
 			<div
-				v-if="run.status === 'failed'"
+				v-if="run.status === 'failed' || (run.status === 'stopped' && run.error)"
 				class="mt-4 flex items-start gap-2 rounded-lg border border-outline-red-1 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
 			>
 				<FeatherIcon name="x-circle" class="size-4 shrink-0" />
@@ -129,6 +159,14 @@
 			<div v-else-if="loadError && !rows.length" class="py-8 text-sm text-ink-red-4">
 				{{ loadError }}
 			</div>
+			<!-- a running run with no snapshot yet: the timeline above carries the
+			     progress, so this only says where the findings will land -->
+			<div
+				v-else-if="!rows.length && run.status === 'running'"
+				class="py-8 text-sm text-ink-gray-5"
+			>
+				Findings appear here when the run completes.
+			</div>
 			<div v-else-if="!rows.length" class="py-8 text-sm text-ink-gray-5">
 				{{ emptyText }}
 			</div>
@@ -145,12 +183,14 @@
 				<div class="mt-2 divide-y overflow-hidden rounded-lg border">
 					<div v-for="f in group.rows" :key="f.name">
 						<!-- collapsed row (div, not button - it hosts the state select);
-					     role/tabindex + enter/space keep it keyboard-operable -->
+					     role/tabindex + enter/space keep it keyboard-operable.
+					     jarvis#1062 P1-5: focus-visible ring added - none of this was
+					     there before, so tabbing to a finding row was invisible. -->
 						<div
 							role="button"
 							tabindex="0"
 							:aria-expanded="isExpanded(f.name)"
-							class="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-surface-gray-1"
+							class="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-surface-gray-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3"
 							@click="toggleExpand(f.name)"
 							@keydown.enter.prevent="toggleExpand(f.name)"
 							@keydown.space.prevent="toggleExpand(f.name)"
@@ -166,9 +206,10 @@
 								:theme="SEVERITY_THEME[f.severity] || 'gray'"
 								:label="severityBadgeLabel(f.severity)"
 							/>
-							<span class="w-20 shrink-0 truncate font-mono text-sm text-ink-gray-5">
-								{{ f.rule_id || "-" }}
-							</span>
+							<!-- jarvis#1062 P0-2/P1-3: the rule code used to sit here as an
+							     unlabeled, truncated monospace column - engineering output
+							     ahead of the human summary. It now lives ONLY in the
+							     expanded finding's "Technical details" block, labelled. -->
 							<span class="min-w-0 flex-1 truncate text-base text-ink-gray-8">
 								{{ f.title }}
 							</span>
@@ -202,11 +243,17 @@
 							v-if="isExpanded(f.name)"
 							class="border-t bg-surface-gray-1 px-4 py-3"
 						>
-							<!-- O1: renderMarkdown from @/markdown (escapes HTML first - safe) -->
+							<!-- O1: renderMarkdown from @/markdown (escapes HTML first - safe).
+							     jarvis#1062 P0-2: the machine tokens findingDisplay() lifted
+							     out (rule codes, boolean eval flags, not_evaluable class
+							     counts, DocType.field refs) render ONLY in Technical details
+							     below - never in this primary sentence. displayFor(f.name)
+							     reads the precomputed findingDisplayMap entry - one
+							     extraction pass per finding, not one per template read. -->
 							<div
-								v-if="f.detail_md"
+								v-if="displayFor(f.name).text"
 								class="prose prose-sm max-w-none"
-								v-html="renderMarkdown(f.detail_md)"
+								v-html="renderMarkdown(displayFor(f.name).text)"
 							/>
 							<div v-else class="text-sm text-ink-gray-5">
 								No further detail recorded.
@@ -240,6 +287,11 @@
 							>
 								{{ caveatText(f) }}
 							</div>
+
+							<!-- jarvis#1062 P0-2/P1-3: rule code, evaluation flags,
+							     not_evaluable class counts and DocType.field references -
+							     collapsed, labelled, monospace. Never inline above. -->
+							<TechnicalDetails class="mt-1" :details="displayFor(f.name).details" />
 
 							<div class="mt-3 flex items-center gap-2">
 								<Button
@@ -279,6 +331,27 @@
 				>
 			</div>
 		</template>
+
+		<!-- Notes on THIS run (owner decision, jarvis#1062: moved off the
+		     Configure tab, which was per-installation - a note belongs to what
+		     it is actually about). Every run status, running included; same
+		     CommentsSection/useDocmeta pair the Configure tab used, re-targeted
+		     at "Jarvis Agent Run" + this run's name instead of the
+		     installation.
+
+		     "Run notes", not "Notes": this panel ALREADY renders a "Notes"
+		     heading a few hundred pixels up - SEVERITY_LABEL.note, the group of
+		     note-severity findings. Two identical headings on one screen meaning
+		     two unrelated things is a collision the merge created, not a naming
+		     preference. -->
+		<section class="mt-6 border-t pt-6">
+			<CommentsSection
+				:docmeta="runDocmeta"
+				:can-comment="true"
+				heading="Run notes"
+				empty-text="No notes on this run yet."
+			/>
+		</section>
 	</div>
 </template>
 
@@ -291,15 +364,24 @@
 // Discuss in chat (take_finding_to_chat → /c/:id), Open document, and the
 // open/acknowledged/resolved state select → setFindingState (optimistic).
 // No remediation text is ever fabricated - only what the run persisted.
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { Badge, Button, FeatherIcon, FormControl, Tooltip, toast } from "frappe-ui";
 import JvSpinner from "@/components/JvSpinner.vue";
 import Banner from "@/components/Banner.vue";
-import { timeAgo, exactDate, formatDate } from "@/utils/datetime";
+import RunStepTimeline from "./RunStepTimeline.vue";
+// Shared, not a local copy: this panel's header pill is one of the surfaces
+// @/lib/agentRunStatus exists to keep in step with the rail and the Activity
+// feed (jarvis#1062). A second table here is exactly the drift it prevents.
+import { STATUS_THEME } from "@/lib/agentRunStatus";
+import CommentsSection from "@/components/doc/CommentsSection.vue";
+import TechnicalDetails from "@/components/doc/TechnicalDetails.vue";
+import { useDocmeta } from "@/composables/useDocmeta";
+import { timeAgo, exactDate, formatDate, toLocalMs, fmtElapsed } from "@/utils/datetime";
 import { renderMarkdown } from "@/markdown";
+import { extractTechnicalDetails } from "@/lib/findingText";
 import * as api from "@/api";
-import { takeFindingToChat } from "@/api/agents";
+import { takeFindingToChat, stopAgentRun, listRunSteps } from "@/api/agents";
 import { errMessage as errMsg, errHtml } from "@/lib/errors";
 
 const props = defineProps({
@@ -313,10 +395,25 @@ const props = defineProps({
 	// appear (cross-file — see report notes).
 	run: { type: Object, required: true },
 });
+// stopped: the parent (AgentRunsBoard) owns the run list - refresh it after a
+// successful stop so the rail's status/badge picks up the terminal state.
+const emit = defineEmits(["stopped"]);
+
+// jarvis#1062: Notes-on-a-run - the SAME useDocmeta/CommentsSection pair the
+// Configure tab used for the installation, re-targeted at the run. A ref
+// (not a plain string) so switching the selected run (this panel is REUSED
+// across rail clicks, not remounted - see the findings watch below) reloads
+// the right run's comments; docmeta_api gates on doc.owner/System Manager,
+// which already resolves correctly for a run (its `owner` is reassigned to
+// the installation owner at launch, never Administrator - agent_scheduler.py
+// _launch_audit).
+const runDocmeta = useDocmeta(
+	"Jarvis Agent Run",
+	computed(() => props.run && props.run.name)
+);
 
 const router = useRouter();
 
-const STATUS_THEME = { running: "blue", completed: "green", partial: "orange", failed: "red" };
 const SEVERITY_THEME = { blocker: "red", warning: "orange", note: "gray" };
 const SEVERITY_ORDER = ["blocker", "warning", "note"];
 const SEVERITY_LABEL = { blocker: "Blockers", warning: "Warnings", note: "Notes" };
@@ -347,7 +444,65 @@ const loadError = ref("");
 const stateFilter = ref("");
 const busy = ref("");
 const chatBusy = ref("");
+const stopping = ref(false);
 const expanded = ref(new Set());
+
+// ── #1062: the per-run STEP TIMELINE. A ticking elapsed-time label plus the
+// steps the bench observed THIS run take (list_run_steps), so a running run
+// reads as alive and step-by-step instead of a static "in progress" line. The
+// steps outlive the run: a finished one keeps them behind a collapsed
+// disclosure, which is why they are fetched for a terminal run too. ──────────
+const nowTick = ref(Date.now());
+const steps = ref([]);
+let elapsedTimer = null;
+let stepsTimer = null;
+
+const STEPS_POLL_MS = 5000;
+
+const elapsedLabel = computed(() => {
+	const startMs = props.run && toLocalMs(props.run.started_at);
+	if (startMs == null) return fmtElapsed(0);
+	return fmtElapsed((nowTick.value - startMs) / 1000);
+});
+
+// Monotonic request id, like the findings load: rapid rail clicks must not land
+// another run's steps on the pinned run.
+let stepsReqId = 0;
+async function loadSteps() {
+	if (!props.run || !props.run.name) return;
+	const id = ++stepsReqId;
+	try {
+		const res = await listRunSteps(props.run.name);
+		if (id !== stepsReqId) return;
+		steps.value = (res && res.steps) || [];
+	} catch {
+		// Best-effort narration: a failed fetch leaves the last steps on screen and
+		// the elapsed timer ticking. It must never turn a healthy run into an error
+		// state - the findings load owns that.
+	}
+}
+function startStepsPoll() {
+	if (elapsedTimer) return; // already running
+	nowTick.value = Date.now();
+	elapsedTimer = setInterval(() => (nowTick.value = Date.now()), 1000);
+	loadSteps();
+	// Visibility-guarded, mirroring the rows poll in AgentRunsBoard.vue: a
+	// backgrounded tab must not burn a request every 5s.
+	stepsTimer = setInterval(() => {
+		if (document.visibilityState === "visible") loadSteps();
+	}, STEPS_POLL_MS);
+}
+function stopStepsPoll() {
+	if (elapsedTimer) {
+		clearInterval(elapsedTimer);
+		elapsedTimer = null;
+	}
+	if (stepsTimer) {
+		clearInterval(stepsTimer);
+		stepsTimer = null;
+	}
+}
+onBeforeUnmount(stopStepsPoll);
 
 const runLabel = computed(() =>
 	props.run && props.run.started_at ? timeAgo(props.run.started_at) : props.run.name
@@ -358,11 +513,16 @@ const coverageWarning = computed(
 		props.run.status === "partial" ||
 		(!!props.run.coverage_note && props.run.status !== "failed")
 );
+// jarvis#1062 P0-2: coverage_note is bundle-generated too - the same
+// extraction as findings' detail_md, so a rule code / DocType.field
+// reference in the coverage sentence lands in coverageDetails, never inline.
+const coverageExtract = computed(() => extractTechnicalDetails(props.run.coverage_note));
 const coverageNote = computed(() => {
-	const note = String(props.run.coverage_note || "").trim();
+	const note = coverageExtract.value.text.trim();
 	// the sentence supplies its own terminal punctuation
 	return note.replace(/[.\s]+$/, "") || "some records were not reviewed";
 });
+const coverageDetails = computed(() => coverageExtract.value.details);
 
 // Scribe runs (Custom App Learning) write wiki pages, not findings: render the
 // pages tally + links instead of the findings machinery.
@@ -380,10 +540,11 @@ const scribePages = computed(() => {
 function wikiUrl(slug) {
 	return `/app/jarvis-wiki-page/${encodeURIComponent(slug)}`;
 }
+// "running" is handled by its own branch above (#1062 C3 progress display) -
+// this only ever renders for a run that has already finished (or stopped).
 const emptyText = computed(() => {
-	if (props.run.status === "running")
-		return "Run in progress - findings appear when it completes.";
 	if (props.run.status === "failed") return "This run recorded no findings.";
+	if (props.run.status === "stopped") return "This run was stopped before it reported findings.";
 	return `No ${stateFilter.value ? stateFilter.value + " " : ""}findings for this run.`;
 });
 
@@ -470,7 +631,24 @@ function loadMore() {
 // refresh and object identity alone must not re-fetch findings.
 watch(
 	[() => props.run && props.run.name, () => props.run && props.run.status],
-	([name], [prevName] = []) => {
+	([name, status], [prevName, prevStatus] = []) => {
+		// Step timeline: independent of the findings reload below, and evaluated
+		// first so the state-filter early-return further down never skips it.
+		if (name !== prevName) steps.value = [];
+		if (status === "running") {
+			// switching from one running run to another must re-arm the poll, not
+			// leave it pointed at the previous run's elapsed clock
+			if (name !== prevName) stopStepsPoll();
+			startStepsPoll();
+		} else {
+			stopStepsPoll();
+			// One last fetch on the flip to terminal: the closing writeback step
+			// lands in the same instant the status changes, so stopping the interval
+			// alone would leave the timeline permanently one step short. A run
+			// selected while already finished takes this branch too, which is what
+			// fills its collapsed "Steps (N)" disclosure.
+			if (name && (name !== prevName || prevStatus === "running")) loadSteps();
+		}
 		if (name !== prevName) {
 			rows.value = [];
 			total.value = 0;
@@ -535,14 +713,33 @@ async function moveFinding(f, state) {
 	}
 }
 
+// ── #1062 C2: operator stop (soft, idempotent server-side - no confirm) ─────
+async function stopRun() {
+	if (stopping.value || props.run.status !== "running") return;
+	stopping.value = true;
+	try {
+		await stopAgentRun(props.run.name);
+		toast.success("Run stopped");
+		emit("stopped");
+	} catch (e) {
+		toast.error(errHtml(e));
+	} finally {
+		stopping.value = false;
+	}
+}
+
 // ── actions: take-to-chat + open-doc (decision: NO fabricated remediation) ──
 async function discussInChat(f) {
 	if (chatBusy.value) return;
 	chatBusy.value = f.name;
 	try {
 		const res = (await takeFindingToChat(f.name)) || {};
-		if (!res.conversation) {
-			throw new Error(res.reason || "Could not open a conversation for this finding.");
+		// take_finding_to_chat always creates the conversation, even when
+		// seeding it (send_message) fails - so `ok`, not `conversation`, is the
+		// real success signal (#1062 polish: this used to navigate regardless).
+		if (!res.ok) {
+			toast.error(errHtml(res.reason || "Could not open this finding in chat."));
+			return;
 		}
 		router.push("/c/" + res.conversation);
 	} catch (e) {
@@ -560,6 +757,35 @@ function refUrl(row) {
 		.toLowerCase()
 		.replace(/ /g, "-");
 	return `/app/${dt}/${encodeURIComponent(row.ref_name)}`;
+}
+// jarvis#1062 P0-2/P1-3: the primary sentence a reviewer reads, plus every
+// machine token pulled out of it (rule code, eval flags, not_evaluable class
+// counts, DocType.field refs) as a flat labelled list for the collapsed
+// "Technical details" block. f.rule_id is a SEPARATE structured field (not
+// necessarily repeated inside detail_md's prose) - folded in here too,
+// de-duplicated against whatever extraction already found.
+function findingDisplay(f) {
+	const { text, details } = extractTechnicalDetails(f && f.detail_md);
+	const all = [...details];
+	if (f && f.rule_id && !all.some((d) => d.value === f.rule_id)) {
+		all.unshift({ label: "Rule", value: f.rule_id });
+	}
+	return { text, details: all };
+}
+// Review fix: an expanded row's template read findingDisplay(f) 2-3 times
+// (the v-if, the v-html source, and TechnicalDetails' :details prop), each
+// call re-running the regex extraction pass over the same detail_md. Computed
+// once per finding here, keyed by the same f.name the row already keys on;
+// EMPTY_DISPLAY is a static fallback so a template read for a name not (yet)
+// in the map never throws.
+const EMPTY_DISPLAY = Object.freeze({ text: "", details: [] });
+const findingDisplayMap = computed(() => {
+	const map = new Map();
+	for (const f of rows.value) map.set(f.name, findingDisplay(f));
+	return map;
+});
+function displayFor(name) {
+	return findingDisplayMap.value.get(name) || EMPTY_DISPLAY;
 }
 // "Statutory basis: {section} (effective {date}). {disclaimer}" - only the
 // pieces the run recorded

--- a/frontend/src/pages/agents/RunStepTimeline.vue
+++ b/frontend/src/pages/agents/RunStepTimeline.vue
@@ -1,0 +1,203 @@
+<template>
+	<div class="mt-4">
+		<!-- header: a live "Running for mm:ss" + status pill while the run is in
+		     flight; a plain disclosure once it is over, so a finished run can still
+		     be inspected without the timeline stealing the page. -->
+		<div v-if="isRunning" class="flex items-center gap-2">
+			<span class="text-base font-medium text-ink-gray-8">Running for {{ elapsed }}</span>
+			<Badge variant="subtle" theme="blue" :label="status" />
+			<span class="flex-1" />
+			<span class="text-sm text-ink-gray-5">{{ countLabel }}</span>
+		</div>
+		<button
+			v-else-if="steps.length"
+			type="button"
+			class="flex w-full items-center gap-2 text-left"
+			:aria-expanded="open"
+			@click="open = !open"
+		>
+			<FeatherIcon
+				name="chevron-right"
+				class="size-4 shrink-0 text-ink-gray-5 transition-all duration-300 ease-in-out"
+				:class="{ 'rotate-90': open }"
+			/>
+			<span class="text-base font-medium text-ink-gray-8">Steps ({{ steps.length }})</span>
+		</button>
+
+		<!-- the timeline itself: the same row shape as the Activity tab (icon disc,
+		     title line, muted detail, relative time on the right). -->
+		<div v-if="expanded" class="mt-2 divide-y overflow-hidden rounded-lg border">
+			<div
+				v-for="(s, i) in rows"
+				:key="s.name"
+				class="flex items-start gap-3 px-3 py-2.5"
+				:class="isCurrent(i) ? 'bg-surface-gray-1' : ''"
+			>
+				<div
+					class="grid size-8 shrink-0 place-items-center rounded-full bg-surface-gray-2"
+				>
+					<FeatherIcon :name="stepIcon(s)" class="size-4" :class="stepColor(s)" />
+				</div>
+				<div class="min-w-0 flex-1">
+					<div class="flex flex-wrap items-baseline gap-x-2">
+						<span
+							class="text-base font-medium"
+							:class="s.status === 'error' ? 'text-ink-red-4' : 'text-ink-gray-8'"
+						>
+							{{ s.label }}
+						</span>
+						<span v-if="s.repeats > 1" class="text-sm text-ink-gray-5">
+							x{{ s.repeats }}
+						</span>
+						<Badge v-if="isCurrent(i)" variant="subtle" theme="blue" label="Now" />
+					</div>
+					<div v-if="s.detail" class="mt-0.5 truncate text-sm text-ink-gray-6">
+						{{ s.detail }}
+					</div>
+				</div>
+				<div class="flex shrink-0 items-baseline gap-2 text-sm text-ink-gray-5">
+					<span v-if="durationLabel(s)">{{ durationLabel(s) }}</span>
+					<Tooltip :text="exactDate(stepTime(s))">
+						<span>{{ timeAgo(stepTime(s)) }}</span>
+					</Tooltip>
+				</div>
+			</div>
+		</div>
+
+		<!-- before the delegate's first tool call there is exactly one thing to say,
+		     and it is not "no steps": the bench dispatched the turn and is waiting. -->
+		<div v-else-if="isRunning" class="mt-2 py-6 text-sm text-ink-gray-5">
+			Dispatched to the agent, waiting for the first step.
+		</div>
+	</div>
+</template>
+
+<script setup>
+// RunStepTimeline - the live per-run step feed (jarvis#1062, child of #1058).
+// The bench records one Jarvis Agent Run Step per observable step of a run: the
+// launch dispatch, every jarvis__* tool the delegate called back with, and the
+// findings writeback. This renders them in the Activity tab's row language
+// (icon disc + title + muted detail + relative time) rather than a bespoke
+// widget, so the Runs pane and the Activity tab read as one product.
+//
+// While the run is in flight the list is always open and the newest step is
+// marked "Now". Once it is terminal the whole thing collapses behind a
+// "Steps (N)" disclosure, so a finished run stays inspectable without the
+// timeline competing with its findings.
+//
+// Consecutive IDENTICAL steps fold into a single row with an "xN" count (see
+// COLLAPSE_WINDOW_MS): an agent that polls one read in a loop otherwise buries
+// every step that actually differs. The fold is presentation only - the bench
+// keeps one row per step, and the header count still reports them all.
+import { ref, computed } from "vue";
+import { Badge, FeatherIcon, Tooltip } from "frappe-ui";
+import { timeAgo, exactDate, toLocalMs } from "@/utils/datetime";
+
+const props = defineProps({
+	// rows from agents_api.list_run_steps: {name, seq, kind, tool, label,
+	// detail, status, duration_ms, occurred_at, creation}
+	steps: { type: Array, default: () => [] },
+	// the run's status - drives running vs collapsed-disclosure presentation
+	status: { type: String, default: "" },
+	// the parent's ticking "mm:ss" label (one timer for the whole panel)
+	elapsed: { type: String, default: "" },
+});
+
+// per-kind Feather icon, from the set the Agents pages already use. An error
+// step overrides both icon and colour: a failed step must read as failed at a
+// glance, exactly as run_failed does on the Activity tab.
+const KIND_ICON = {
+	dispatched: "play",
+	tool: "search",
+	writeback: "check-circle",
+	note: "activity",
+};
+const KIND_COLOR = {
+	writeback: "text-ink-green-3",
+};
+
+// An agent polling the same read in a loop produced eight identical rows in a
+// row on the bench, which buries the steps that actually differ. Consecutive
+// IDENTICAL rows within this window fold into one "x8". The identity includes
+// status and detail, not just tool+label, so a failure is never folded into a
+// success and an error's message is never dropped behind a repeat count. The DB
+// keeps every row; this is presentation only.
+const COLLAPSE_WINDOW_MS = 5000;
+
+const open = ref(false);
+
+const isRunning = computed(() => props.status === "running");
+
+// [{...lastStepOfTheGroup, name: firstName, repeats, duration_ms: summed}]
+const rows = computed(() => {
+	const out = [];
+	for (const s of props.steps) {
+		const prev = out[out.length - 1];
+		if (prev && sameStep(prev, s) && withinWindow(prev.last_at, s)) {
+			prev.repeats += 1;
+			prev.duration_ms = sumDurations(prev.duration_ms, s.duration_ms);
+			prev.last_at = stepTime(s);
+			prev.occurred_at = s.occurred_at;
+			prev.creation = s.creation;
+			continue;
+		}
+		out.push({ ...s, repeats: 1, last_at: stepTime(s) });
+	}
+	return out;
+});
+
+const expanded = computed(() => props.steps.length > 0 && (isRunning.value || open.value));
+const countLabel = computed(() =>
+	props.steps.length === 1 ? "1 step" : `${props.steps.length} steps`
+);
+
+// Two steps that both recorded NO duration must stay "no duration", not become a
+// measured 0 - the same distinction durationLabel keeps.
+function sumDurations(a, b) {
+	if (a == null && b == null) return null;
+	return (Number(a) || 0) + (Number(b) || 0);
+}
+function sameStep(a, b) {
+	return (
+		(a.tool || "") === (b.tool || "") &&
+		(a.label || "") === (b.label || "") &&
+		(a.status || "") === (b.status || "") &&
+		(a.detail || "") === (b.detail || "")
+	);
+}
+// Unparseable timestamps must not silently glue unrelated rows together, so an
+// unknown gap is treated as outside the window.
+function withinWindow(prevAt, s) {
+	const a = toLocalMs(prevAt);
+	const b = toLocalMs(stepTime(s));
+	if (a == null || b == null) return false;
+	return b - a <= COLLAPSE_WINDOW_MS;
+}
+
+function isCurrent(index) {
+	return isRunning.value && index === rows.value.length - 1;
+}
+function stepIcon(s) {
+	if (s.status === "error") return "x-circle";
+	return KIND_ICON[s.kind] || "activity";
+}
+function stepColor(s) {
+	if (s.status === "error") return "text-ink-red-4";
+	return KIND_COLOR[s.kind] || "text-ink-gray-5";
+}
+function stepTime(s) {
+	return s.occurred_at || s.creation;
+}
+// Sub-second steps are the common case, so ms below a second and one decimal
+// above it - never a bare "0s" that reads as "did not happen".
+//
+// A measured 0 is DATA (a step that completed inside the timer's resolution) and
+// renders "0ms"; only a missing duration renders nothing. Testing truthiness
+// conflated the two and silently dropped the fastest steps' timing.
+function durationLabel(s) {
+	if (s.duration_ms == null || s.duration_ms === "") return "";
+	const ms = Number(s.duration_ms);
+	if (isNaN(ms) || ms < 0) return "";
+	return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+</script>

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -66,3 +66,17 @@ export function dayLabel(d) {
 	if (diff > 1 && diff < 7) return dj.format("dddd");
 	return dj.format("D MMMM");
 }
+
+// A ticking elapsed-time label (jarvis#1062 C2/C3's running-run progress
+// display) - mm:ss under an hour, h:mm at/above it. Pure (no dayjs - the
+// caller supplies whole seconds, typically from toLocalMs(started_at)).
+// Negative/NaN input clamps to 0 (a clock started just before the caller's
+// first tick must never print a negative duration).
+export function fmtElapsed(totalSeconds) {
+	const sec = Math.max(0, Math.floor(Number(totalSeconds) || 0));
+	const h = Math.floor(sec / 3600);
+	const m = Math.floor((sec % 3600) / 60);
+	const s = sec % 60;
+	const pad = (n) => String(n).padStart(2, "0");
+	return h > 0 ? `${h}:${pad(m)}` : `${pad(m)}:${pad(s)}`;
+}

--- a/frontend/src/utils/datetime.spec.js
+++ b/frontend/src/utils/datetime.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+
+// frappe-ui's ESM entry does not resolve under vitest (see LlmPoolEditor.spec.js) -
+// fmtElapsed itself is pure, but datetime.js imports frappe-ui at module scope, so
+// any spec importing this module needs the mock even though fmtElapsed never calls it.
+vi.mock("frappe-ui", () => ({
+	call: vi.fn(),
+	dayjs: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
+	dayjsLocal: () => ({ format: () => "", fromNow: () => "", isValid: () => false }),
+	getConfig: () => null,
+}));
+
+import { fmtElapsed } from "./datetime";
+
+// jarvis#1062 C3: the running-run progress display's ticking elapsed-time
+// label - mm:ss under an hour, h:mm at/above it.
+describe("fmtElapsed", () => {
+	it("renders mm:ss under an hour", () => {
+		expect(fmtElapsed(0)).toBe("00:00");
+		expect(fmtElapsed(5)).toBe("00:05");
+		expect(fmtElapsed(65)).toBe("01:05");
+		expect(fmtElapsed(3599)).toBe("59:59");
+	});
+
+	it("renders h:mm at and above an hour", () => {
+		expect(fmtElapsed(3600)).toBe("1:00");
+		expect(fmtElapsed(3661)).toBe("1:01");
+		expect(fmtElapsed(7325)).toBe("2:02");
+	});
+
+	it("clamps negative/NaN/missing input to zero instead of printing garbage", () => {
+		expect(fmtElapsed(-5)).toBe("00:00");
+		expect(fmtElapsed(NaN)).toBe("00:00");
+		expect(fmtElapsed(undefined)).toBe("00:00");
+		expect(fmtElapsed(null)).toBe("00:00");
+	});
+
+	it("floors fractional seconds", () => {
+		expect(fmtElapsed(65.9)).toBe("01:05");
+	});
+});

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1373,13 +1373,6 @@ def post_push_agent_skills(agent_skills: list[dict]) -> dict:
 	restarts the container so agent re-scans ``workspace/skills``. An empty
 	list is a valid "remove all agent skills" reconcile.
 
-	NOTE: the admin endpoint ``jarvis_admin.api.tenant.push_agent_skills`` and the
-	fleet ``PUT /v1/containers/{name}/agent-skills`` are the B5 half of this work
-	(a sibling of the custom-skills chain). Until they ship this raises
-	``AdminValidationError`` (unknown method), which ``apply_agents`` records as a
-	terminal ``failed:`` status — the bench-side path is complete and structured
-	identically to ``post_push_custom_skills``.
-
 	Raises:
 		AdminAuthError, AdminUnreachableError, AdminValidationError
 		(rate-limit shares the rotate-secret bucket).

--- a/jarvis/agents/registry.json
+++ b/jarvis/agents/registry.json
@@ -87,7 +87,7 @@
       "nature": "operator",
       "delivery": "delegate",
       "version": "0.1.0",
-      "status": "Published",
+      "status": "Coming Soon",
       "description": "Assembles the PO, Goods Receipt and captured vendor invoice for each payable and works the exception tail: raises one evidence-carrying Approval Request per line that does not tie out (short-receipt, price variance, missing GRN, duplicate bill), and stages a draft Purchase Invoice only for invoices whose lines are all clean. Proposes only; a human confirms and submits every posting.",
       "tools_required": [
         "jarvis__get_list",
@@ -150,7 +150,7 @@
       "nature": "operator",
       "delivery": "delegate",
       "version": "0.1.0",
-      "status": "Published",
+      "status": "Coming Soon",
       "description": "Sweeps the overdue receivables book each day, nets the true residual per invoice, and risk-ranks who to chase. Stages a docstatus-0 draft Dunning per overdue customer with an escalating-by-bucket letter, and raises one Jarvis Approval Request carrying the prioritised follow-up worklist with per-account evidence. It proposes only; a human reviews the tone, sends, calls, and submits or discards every artifact. It never sends, reconciles, posts, or writes off.",
       "tools_required": [
         "jarvis__get_list",
@@ -272,7 +272,7 @@
       "nature": "operator",
       "delivery": "delegate",
       "version": "2.0.0",
-      "status": "Published",
+      "status": "Coming Soon",
       "description": "The reconciliation workbench as drafts and approvals: lists unreconciled Bank Transactions, proposes matches against submitted Payment Entries / invoices by reference, amount, date and party, and queues each proposal as a Jarvis Approval Request carrying both sides of the evidence. Unmatched lines become draft Payment Entry proposals. It proposes; a human confirms and reconciles every one — it never reconciles, allocates, or submits.",
       "tools_required": [
         "jarvis__get_list",
@@ -565,6 +565,12 @@
         "Account",
         "Company"
       ],
+      "config_keys": [
+        "materiality.benchmark_value",
+        "materiality.percentage",
+        "materiality.engagement_risk_level",
+        "materiality.rounding_step"
+      ],
       "rule_tokens": [
         "ca-cl-2b9d",
         "ca-cl-7f31",
@@ -634,7 +640,7 @@
       "nature": "operator",
       "delivery": "delegate",
       "version": "0.1.0",
-      "status": "Published",
+      "status": "Coming Soon",
       "description": "Runs a rolling cycle-count programme ERPNext has no native planner for: ranks the SKU book by value (ABC) and movement (velocity), reads how long since each item/warehouse was last counted, and for the lines due this cycle stages a docstatus-0 draft Stock Reconciliation per warehouse with item rows pre-filled and the counted quantity left blank for the human counter, plus one evidence-carrying Approval Request so a store lead approves the count list first. Proposes only; it never counts, never fills a quantity, and never submits a reconciliation.",
       "tools_required": [
         "jarvis__get_list",
@@ -1416,7 +1422,7 @@
       "nature": "operator",
       "delivery": "delegate",
       "version": "0.1.0",
-      "status": "Published",
+      "status": "Coming Soon",
       "description": "Watches stock position daily and works the replenishment tail: for each item whose velocity- and lead-time-aware reorder point is breached and is not already covered by open supply, it stages a docstatus-0 draft Material Request with a computed reorder qty, target warehouse and required-by date; where demand is ambiguous (no history, erratic, or slow/dead) it raises one evidence-carrying Approval Request instead of guessing. Proposes only; a human confirms and submits every request.",
       "tools_required": [
         "jarvis__get_list",

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -168,6 +168,7 @@ def _dispatch_from_session(
 	"""
 	# impersonate is session-safe: a bare frappe.set_user in this HTTP path
 	# would gut the caller's cookie session sid + data and log them out.
+	from jarvis.chat import agent_run_steps
 	from jarvis.tools import _agent_run_ctx, _delegate_capability
 
 	# Expose the caller's session_key to the tool for this dispatch (the LLM
@@ -189,7 +190,12 @@ def _dispatch_from_session(
 			# reach ANY registered tool the run-as user's Frappe roles permit. Fails
 			# closed: a run with no snapshot and no legacy marker is refused outright.
 			# Non-delegate sessions (ordinary chat) resolve to None and are untouched.
-			denial = _delegate_capability.tool_denial(session_key, tool)
+			# ONE run-row read per plugin tool call: the capability contract is
+			# resolved here and handed to both consumers - the gate below and the
+			# #1062 step timeline further down, which needs the run's name, owner and
+			# status. A non-delegate session resolves to None and both are no-ops.
+			cap = _delegate_capability.resolve(session_key)
+			denial = _delegate_capability.tool_denial(session_key, tool, cap=cap)
 			if denial:
 				code = CapabilityDeniedError.__name__
 				hint = _hint_for(code, "")
@@ -252,7 +258,51 @@ def _dispatch_from_session(
 			# Resolve the conversation for this session up front so the
 			# confirmation gate can bind a parked write to it.
 			conv = frappe.db.get_value("Jarvis Conversation", {"session_key": session_key}, "name")
-			result = _run_tool(tool, parsed_args, conversation=conv)
+			# STEP TIMELINE (#1062): the run to file this call's step against, taken
+			# from the contract resolved above - BEFORE the tool executes.
+			# record_agent_run flips the run off ``running`` from inside the tool, so
+			# reading its status afterwards would find nothing for the very call that
+			# finishes the run. An ordinary chat session yields None and nothing below
+			# does anything.
+			step_run = agent_run_steps.step_target(cap)
+			started_ms = time.monotonic()
+			try:
+				result = _run_tool(tool, parsed_args, conversation=conv)
+			except Exception as exc:
+				# A tool that raised past _run_tool's envelope translation is a real
+				# fault; try to leave an honest step saying the attempt happened and
+				# failed. Strictly best-effort: on a true 500 Frappe's request handler
+				# rolls the whole transaction back and takes this row with it, and
+				# committing here to save it would also flush whatever partial writes
+				# the raising tool made. The step that MATTERS is the ok=False envelope
+				# path below, which is how a tool error normally arrives. The re-raise
+				# is untouched either way.
+				_record_tool_step(
+					step_run,
+					tool,
+					parsed_args,
+					None,
+					ok=False,
+					started_ms=started_ms,
+					error_message=str(exc),
+				)
+				raise
+			# Recorded BEFORE the result budget trims the payload, so a step's row
+			# count is the count the tool actually returned, not the truncated one.
+			_ok = bool(isinstance(result, dict) and result.get("ok"))
+			_record_tool_step(
+				step_run,
+				tool,
+				parsed_args,
+				result.get("data") if isinstance(result, dict) else None,
+				ok=_ok,
+				started_ms=started_ms,
+				error_message=(
+					((result.get("error") or {}).get("message") or "")
+					if (not _ok and isinstance(result, dict))
+					else ""
+				),
+			)
 			# Agent-boundary model-facing size cap. ONLY on this (agent session)
 			# path - the dashboard builder/desk/external call_tool callers go through
 			# _dispatch_current_user and are deliberately uncapped.
@@ -279,6 +329,69 @@ def _dispatch_from_session(
 		_agent_run_ctx.clear_session_key()
 		_agent_run_ctx.take_armed_by_macro()  # belt: never leak an armed marker across dispatches
 		_agent_run_ctx.take_armed_by_skill()  # belt: same for the approved-skill-run marker
+
+
+#: The findings writeback narrates ITSELF (``record_agent_run`` records a
+#: ``writeback`` step naming the finding count it actually persisted), so the
+#: generic per-tool hook below skips it rather than writing a second row for the
+#: same act.
+_SELF_NARRATING_TOOLS = frozenset({"record_agent_run"})
+
+
+def _record_tool_step(
+	step_run,
+	tool: str,
+	args,
+	data,
+	*,
+	ok: bool,
+	started_ms: float,
+	error_message: str = "",
+) -> None:
+	"""Append one ``tool`` step to a delegate run's timeline (#1062).
+
+	``step_run`` is the ``{name, owner}`` resolved before dispatch, or None when
+	the caller is not a delegate - in which case this is a no-op, so ordinary
+	chat is untouched. Best-effort throughout: narrating a tool call must never
+	be able to fail it.
+
+	On a failure the label stays the humanized ACTION and ``error_message``
+	becomes the detail, so the timeline says both what was attempted and why it
+	did not work instead of leaving a bare red row the customer cannot act on.
+	"""
+	if not step_run:
+		return
+	try:
+		from jarvis.chat import agent_run_steps
+
+		if agent_run_steps.bare_tool(tool) in _SELF_NARRATING_TOOLS:
+			return
+		label, detail = agent_run_steps.humanize_tool_call(tool, args, data if ok else None)
+		if not ok:
+			detail = agent_run_steps.error_detail(error_message) or detail
+		elif agent_run_steps.is_pending_confirmation(data):
+			# A gated write returns ok but was only PARKED - the confirmation card is
+			# still sitting in front of a human. Narrating it as done would claim a
+			# write that may never happen, which is the one lie a timeline must not
+			# tell.
+			label, detail = agent_run_steps.pending_confirmation_step(label)
+		agent_run_steps.record_step(
+			step_run.get("name"),
+			kind="tool",
+			tool=tool,
+			label=label,
+			detail=detail,
+			status="ok" if ok else "error",
+			duration_ms=int((time.monotonic() - started_ms) * 1000),
+			owner=step_run.get("owner"),
+		)
+	except Exception:
+		try:
+			frappe.logger("jarvis.agents").warning(
+				f"run-step hook failed for tool {tool}: {frappe.get_traceback()}"
+			)
+		except Exception:
+			pass
 
 
 _STALE_PAIRING_DEDUPE_TTL_S = 3600

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -31,6 +31,43 @@ LISTING = "Jarvis Agent Listing"
 _AGENTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "agents")
 _REGISTRY_PATH = os.path.join(_AGENTS_DIR, "registry.json")
 
+# jarvis#1062 polish: no registry agent declares an explicit ``category`` today
+# (see ``sync_agent_listings`` below) - every listing's Category facet is
+# derived from ``domain``, which is a bare registry code (``ap``, ``hrms-payroll``,
+# ...), not something to show a customer. Map the known codes to real labels;
+# an unrecognised one still reads as English via the title-cased fallback.
+_DOMAIN_CATEGORY_LABELS = {
+	"ap": "Accounts Payable",
+	"ar": "Accounts Receivable",
+	"crm": "CRM",
+	"hrms": "HR and Payroll",
+	"hrms_payroll": "HR and Payroll",
+	"gst": "GST Compliance",
+	"gst_compliance": "GST Compliance",
+	"inventory": "Inventory",
+	"accounting": "Accounting",
+	"close": "Close and Reporting",
+	"india_compliance": "India Compliance",
+	"measurement": "Measurement",
+	"inventory_count": "Inventory Count",
+	"bank_recon": "Bank and Reconciliation",
+	"tds": "TDS Compliance",
+	"tds_compliance": "TDS Compliance",
+	"helpdesk": "Helpdesk",
+	"knowledge": "Knowledge Base",
+}
+
+
+def _category_from_domain(domain) -> str:
+	"""A registry ``domain`` code -> a display label for the marketplace's
+	Category facet. Falls back to a readable title-case (underscores as
+	spaces) for a domain outside the known set, rather than leaking the raw
+	registry slug."""
+	key = str(domain or "").strip().lower().replace("-", "_")
+	if not key:
+		return ""
+	return _DOMAIN_CATEGORY_LABELS.get(key) or key.replace("_", " ").title()
+
 
 # --------------------------------------------------------------------------- #
 # registry loading (bundled only — never a network fetch)
@@ -80,7 +117,10 @@ def sync_agent_listings() -> dict:
 			"agent_slug": slug,
 			"title": a.get("title") or slug,
 			"description": a.get("description") or "",
-			"category": a.get("domain") or a.get("category") or "",
+			# jarvis#1062 polish: an explicit registry ``category`` wins if ever
+			# declared; otherwise map ``domain`` to a real label instead of
+			# storing the bare registry code.
+			"category": (a.get("category") or "").strip() or _category_from_domain(a.get("domain")),
 			"nature": (a.get("nature") or "").strip().title() or "Auditor",
 			"delivery": delivery,
 			"version": a.get("version") or "",
@@ -92,6 +132,15 @@ def sync_agent_listings() -> dict:
 			# checkable at install/validate without leaking rule shape. For
 			# delegate agents this comes from the bundle-store manifest.
 			"doctypes_required": frappe.as_json(a.get("doctypes_required") or []),
+			# jarvis#1062/#1063: agent-specific installation config keys this
+			# agent's bundle actually reads, as dot paths for a nested key (e.g.
+			# close-auditor's materiality.benchmark_value/.percentage/
+			# .engagement_risk_level/.rounding_step - its evaluate.py reads them
+			# nested under a top-level "materiality" object, not flat) - excludes
+			# the universal scope keys every run gets regardless
+			# (company/fiscal_year/from_date/to_date, which stay flat). Drives
+			# ConfigForm.vue's per-agent field set; [] for an agent with none.
+			"config_keys": frappe.as_json(a.get("config_keys") or []),
 			# A2/A16: the delegate auditor's OPAQUE rule-token set, id-only. The
 			# bench needs it to validate a finding's rule in record_agent_run
 			# without ever holding a rule body/threshold. Empty for operators /
@@ -172,7 +221,7 @@ AGENT_PREFIX = "agent-"
 
 
 def build_agent_push_payload(owner: str | None = None) -> list[dict]:
-	"""Collect the ENABLED installed agents into the fleet push payload.
+	"""Collect the container's agent roster into the fleet push payload.
 
 	Every entry is a body-free DELEGATE ENABLEMENT SIGNAL (A2): ``{slug,
 	delivery:"delegate", tools_allow, model, timeout_s, nature}`` where ``slug``
@@ -181,19 +230,40 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	pushes it to fleet (Phase 2C). ``tools_allow``/``timeout_s``/``nature``/``model``
 	echo the BUNDLED registry (metadata, not IP) so admin can render the delegate.
 
-	Bench-global by design (one bench == one customer == one container), so all
-	enabled installs on the site are pushed; ``owner`` is accepted only to scope
-	tests. An empty list is a valid "remove all agent skills" reconcile.
+	The roster is the UNION of two legs, deduped by slug:
 
-	RBAC (defense in depth): an enabled install whose RUN-AS user's roles no longer
-	permit the agent is EXCLUDED from the push — the scheduler / run-now gates
-	already refuse to run it, but its enablement signal must not reach the
-	container either. The run-as user, not the owner, is the identity that decides
-	(#457): it is the one every dispatch gate applies, so gating the push on
-	anything else advertises a roster the bench will not honour. Identity (CX1-1,
-	the same reasoning): an enabled install with a BLANK run-as user is EXCLUDED
-	too — R1-F3 refuses it at every dispatch path, so pushing it would advertise an
-	agent this bench can never run.
+	  1. ALLOWED LISTINGS (jarvis#1062) — every Published, installable listing an
+	     admin has granted to at least one role or named user. This is the leg that
+	     makes the product work: under deny-by-default an admin ALLOWS an agent and
+	     applies once (the tenant-wide restart is the admin's cost to accept), and
+	     the allowed users can then self-install and run it WITHOUT each install
+	     triggering another restart of everyone's workspace.
+	  2. ENABLED INSTALLS — the historical leg, gated exactly as leg 1 is. Under
+	     deny-by-default it is largely SUBSUMED by leg 1 (an install can only pass
+	     the access gate on a listing that carries a grant, and such a listing is
+	     already shipped by leg 1); it still governs the per-owner build, which
+	     skips leg 1, and it still applies the per-INSTALL disqualifiers below.
+
+	Bench-global by design (one bench == one customer == one container). ``owner``
+	scopes the payload to one owner's enabled installs and is used only by tests;
+	the allowed-listings leg is skipped when it is set, because "this owner's
+	roster" is not a statement about listings nobody installed. An empty list is a
+	valid "remove all agent skills" reconcile.
+
+	RBAC (defense in depth): an enabled install whose RUN-AS user may no longer use
+	the agent is EXCLUDED from the push — the scheduler / run-now gates already
+	refuse to run it, but its enablement signal must not reach the container
+	either. The run-as user, not the owner, is the identity that decides (#457): it
+	is the one every dispatch gate applies, so gating the push on anything else
+	advertises a roster the bench will not honour. Identity (CX1-1, the same
+	reasoning): an enabled install with a BLANK run-as user is EXCLUDED too —
+	R1-F3 refuses it at every dispatch path.
+
+	Both legs use the ONE access predicate, so the roster can never admit what
+	dispatch would refuse. Existing installs keep working across the upgrade
+	because ``v2_18_agent_access_grandfather`` runs during migrate, before anything
+	can apply — the grandfather guarantee lives in the patch, not in a looser gate
+	here.
 
 	Installs are per-(owner, agent) but the payload is bench-global and keyed by
 	SLUG, so two users each enabling the SAME agent are ONE entry, not two —
@@ -201,7 +271,23 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	gates)."""
 	# Lazy import — agents_api imports build_agent_push_payload from this module
 	# at module level, so a top-level back-import would be circular.
-	from jarvis.chat.agents_api import _user_allowed_for_agent
+	from jarvis.chat.agents_api import _allowed_roles_map, _allowed_users_map, _is_allowed
+
+	# The whole catalog's grants in TWO queries, shared by both legs. The install
+	# leg used to call ``_user_allowed_for_agent`` per row, which is itself an N+1
+	# over both child tables — and this function runs twice per Apply.
+	roles_map = _allowed_roles_map()
+	users_map = _allowed_users_map()
+	granted = set(roles_map) | set(users_map)
+	# Memoized per distinct run-as identity: several installs commonly share one.
+	_identity_cache: dict[str, tuple[set[str], bool]] = {}
+
+	def _identity(user: str):
+		if user not in _identity_cache:
+			from jarvis.permissions import has_jarvis_admin_access
+
+			_identity_cache[user] = (set(frappe.get_roles(user)), has_jarvis_admin_access(user))
+		return _identity_cache[user]
 
 	# Delegate metadata (tools_allow / timeout_s / nature / model) lives in the
 	# BUNDLED registry, never the customer DB; the enablement signal echoes it so
@@ -303,7 +389,16 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		# while the run-as user kept it was dropped from the roster yet still
 		# dispatched (the reported phantom run), and the mirror case advertised a
 		# delegate the bench would refuse to run at every cadence.
-		if not _user_allowed_for_agent(row.agent, row.run_as_user):
+		# Gated on the RUN-AS user under the SAME deny-by-default predicate the
+		# dispatch paths use, from the batched maps above.
+		run_as_roles, run_as_is_admin = _identity(row.run_as_user)
+		if not _is_allowed(
+			roles_map.get(row.agent, []),
+			users_map.get(row.agent, []),
+			row.run_as_user,
+			user_roles=run_as_roles,
+			is_admin=run_as_is_admin,
+		):
 			continue
 
 		# Every gate has passed, so this agent is emitted and no later row for it can
@@ -312,22 +407,58 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		# it carries NO per-install data — so every row for an agent would yield a
 		# byte-identical entry.
 		seen_agents.add(row.agent)
-		slug = f"{AGENT_PREFIX}{listing.agent_slug}"
+		payload.append(_enablement_signal(listing.agent_slug, reg_by_slug))
 
-		# A2 enablement signal — body-free. Admin resolves the SKILL from the
-		# private bundle store by slug (Phase 2C). The body NEVER leaves it.
-		meta = reg_by_slug.get(listing.agent_slug) or {}
-		payload.append(
-			{
-				"slug": slug,
-				"delivery": "delegate",
-				"tools_allow": meta.get("tools_allow") or [],
-				"model": meta.get("model") or None,
-				"timeout_s": meta.get("timeout_s"),
-				"nature": (meta.get("nature") or "").strip().lower(),
-			}
+	# ── Leg 1: ALLOWED LISTINGS (jarvis#1062) ──────────────────────────────────
+	# Appended AFTER the install leg so ``seen_agents`` already holds everything
+	# that leg emitted and this one only adds slugs it did not. Skipped entirely
+	# for an owner-scoped build (see the docstring) — a listing nobody installed
+	# belongs to no owner.
+	if not owner:
+		from jarvis.chat.agent_installability import evaluate_installability
+
+		allowed_listings = frappe.get_all(
+			LISTING,
+			filters={"status": "Published"},
+			fields=["name", "agent_slug"],
+			order_by="name asc",
 		)
+		for lst in allowed_listings:
+			if lst.name in seen_agents or lst.name not in granted:
+				continue
+			# Same reasoning as the install leg's ``installable`` check: an agent
+			# whose min_apps / required DocTypes are absent has no data to evaluate,
+			# so advertising its delegate would seat a roster entry every dispatch
+			# path refuses. No install row exists here, so the site is evaluated
+			# directly rather than read off a reconciled per-install flag.
+			if not evaluate_installability(lst.name)[0]:
+				continue
+			seen_agents.add(lst.name)
+			payload.append(_enablement_signal(lst.agent_slug, reg_by_slug))
+
+	# Stable order regardless of which leg contributed an entry: the payload is a
+	# FULL RECONCILE that admin/fleet diffs against the container's current roster,
+	# and an entry moving between legs must not read as a change.
+	payload.sort(key=lambda e: e["slug"])
 	return payload
+
+
+def _enablement_signal(agent_slug: str, reg_by_slug: dict) -> dict:
+	"""The A2 enablement signal for one agent — body-free.
+
+	Admin resolves the SKILL from the private bundle store by slug (Phase 2C); the
+	body NEVER leaves it. Derived purely from the slug plus the BUNDLED registry,
+	which is why both legs of the roster can share it and why de-duping by slug is
+	safe: two sources for the same agent yield a byte-identical entry."""
+	meta = reg_by_slug.get(agent_slug) or {}
+	return {
+		"slug": f"{AGENT_PREFIX}{agent_slug}",
+		"delivery": "delegate",
+		"tools_allow": meta.get("tools_allow") or [],
+		"model": meta.get("model") or None,
+		"timeout_s": meta.get("timeout_s"),
+		"nature": (meta.get("nature") or "").strip().lower(),
+	}
 
 
 def registry_timeout_s(agent_slug: str, default: int = 600) -> int:

--- a/jarvis/chat/agent_run_steps.py
+++ b/jarvis/chat/agent_run_steps.py
@@ -1,0 +1,376 @@
+"""The per-run STEP TIMELINE: what an agent run is doing, while it does it.
+
+``Jarvis Agent Activity`` records a run's LIFECYCLE (started / completed /
+failed) - four rows at most, and nothing at all between the launch and the
+finish. A delegate audit takes minutes, so the customer watching a running run
+saw a static "Run in progress" line and had to trust it.
+
+The bench can do better, because it already SEES every step: the delegate calls
+back into it for each ``jarvis__*`` tool over the run's own session bearer. This
+module turns those observations into one append-only ``Jarvis Agent Run Step``
+row apiece, plus the two the bench knows first-hand - the launch ``dispatched``
+and the findings ``writeback``.
+
+Three rules hold everywhere here:
+
+* **Best-effort.** :func:`record_step` never raises. A timeline is a narration of
+  the run; failing to narrate a step must never fail the step.
+* **Cheap.** One insert, no commit of its own. It rides on the caller's
+  transaction so a rolled-back tool call leaves no phantom step behind.
+* **Shapes, never contents.** A step names DocTypes, reports, references and
+  counts. It never carries a row's field values, so the timeline is safe to show
+  to anyone permitted to read the run.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+STEP = "Jarvis Agent Run Step"
+RUN = "Jarvis Agent Run"
+
+#: Hard caps mirroring the DocType (``label`` is a Data(140); ``detail`` is a
+#: Small Text we keep short so the timeline row stays one glanceable line).
+LABEL_MAX = 140
+DETAIL_MAX = 500
+#: A failed step carries the tool's own error message so the timeline explains
+#: what went wrong. First line only, and short: enough to name the fault, never
+#: enough to paste a traceback or a payload into the customer's view.
+ERROR_DETAIL_MAX = 300
+
+#: A parked write (``_run_tool`` returns ok with ``data.status ==
+#: "pending_confirmation"``) has not happened yet - a human still has to press
+#: the button. Narrating it as a completed action would be a lie, and the most
+#: consequential kind: the timeline would claim a write that may never occur.
+PENDING_CONFIRMATION_STATUS = "pending_confirmation"
+PENDING_CONFIRMATION_DETAIL = "waiting for a human to confirm"
+
+#: Bench-internal bookkeeping DocTypes an agent reads to orient itself before it
+#: touches any ERP data. Their real names are implementation vocabulary the
+#: customer has never seen and their row names are opaque hashes, so a step names
+#: the ACT instead of the record: "Read engagement configuration", never
+#: "Read Jarvis Agent Installation 8f3ac1...". Anything else under the same
+#: prefix is a doctype this map has not been taught, so it degrades to the
+#: honest generic rather than leaking a name.
+_INTERNAL_DOCTYPE_LABELS = {
+	"Jarvis Agent Installation": "Read engagement configuration",
+	"Jarvis Agent Listing": "Read agent definition",
+	"Jarvis Agent Run": "Checked run state",
+}
+_INTERNAL_DOCTYPE_PREFIX = "Jarvis Agent "
+_INTERNAL_DOCTYPE_FALLBACK = "Read agent metadata"
+
+#: Tool names arrive from the agent registry as ``jarvis__get_list``; the bench
+#: dispatches the bare name. Both forms normalize to the bare one.
+_TOOL_PREFIX = "jarvis__"
+
+
+def _clip(value, limit: int) -> str:
+	text = str(value or "").strip()
+	return text[:limit]
+
+
+def bare_tool(tool) -> str:
+	"""``jarvis__get_list`` / ``get_list`` -> ``get_list``."""
+	name = str(tool or "").strip()
+	return name[len(_TOOL_PREFIX) :] if name.startswith(_TOOL_PREFIX) else name
+
+
+def _next_seq(run_name: str) -> int:
+	"""1-based position of the next step of ``run_name``.
+
+	MAX(seq)+1 rather than a row COUNT, so a deleted row can never renumber the
+	rest. It is deliberately UNLOCKED and therefore best-effort: a delegate that
+	fires tool calls in parallel reads the same MAX in two requests and both
+	write the same seq (observed live on the bench - 2,2,2 then 3,3). Taking a
+	lock here would put a write barrier on the hot path of every plugin tool call
+	to order a decoration, which is the wrong trade.
+
+	So the stored ``seq`` is a hint, not the contract. ``list_run_steps`` orders
+	by ``occurred_at`` and RE-NUMBERS the response 1..n, which is what the UI
+	renders - duplicates in the column can never reach a customer."""
+	try:
+		row = frappe.db.sql(
+			"select max(seq) from `tabJarvis Agent Run Step` where run = %s",
+			(run_name,),
+		)
+		current = (row and row[0] and row[0][0]) or 0
+		return int(current) + 1
+	except Exception:
+		return 1
+
+
+def record_step(
+	run_name: str,
+	*,
+	kind: str,
+	tool: str | None = None,
+	label: str,
+	detail: str | None = None,
+	status: str = "ok",
+	duration_ms: int | None = None,
+	owner: str | None = None,
+) -> str | None:
+	"""Append ONE step to ``run_name``'s timeline. Returns its name, or None.
+
+	``owner`` pins the row to the human who owns the run, and is applied AFTER the
+	insert exactly like ``agent_activity.log_activity``. This is not optional
+	bookkeeping: ``Document.insert`` stamps ``owner = frappe.session.user``
+	UNCONDITIONALLY (``set_user_and_timestamp`` assigns it, it does not defer to a
+	pre-set value), and every caller here runs impersonated as the run-as user or
+	as the scheduler's Administrator. Left alone, the owner-scoped (``if_owner``)
+	timeline would be invisible to the very customer it is for.
+
+	Omit ``owner`` and it is resolved from the RUN row instead. A step belongs to
+	whoever owns the run, never to whoever happened to be executing - so the
+	fallback is the rule restated, not a guess, and no future caller can leak a
+	step to the session user by forgetting the argument.
+
+	NEVER raises: a failed narration is logged and swallowed."""
+	if not run_name:
+		return None
+	try:
+		owner = owner or run_owner(run_name)
+		doc = frappe.get_doc(
+			{
+				"doctype": STEP,
+				"run": run_name,
+				"seq": _next_seq(run_name),
+				"kind": kind,
+				"tool": bare_tool(tool),
+				"label": _clip(label, LABEL_MAX) or kind,
+				"detail": _clip(detail, DETAIL_MAX),
+				"status": status if status in ("ok", "error") else "ok",
+				"duration_ms": int(duration_ms) if duration_ms is not None else None,
+				"occurred_at": frappe.utils.now(),
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		if owner and owner != doc.owner:
+			frappe.db.set_value(STEP, doc.name, "owner", owner, update_modified=False)
+		return doc.name
+	except Exception:
+		# The logger, not frappe.log_error: a step is decoration on a run that is
+		# working fine without it, and an Error Log row per missed narration would
+		# bury the surface where real run faults show up.
+		try:
+			frappe.logger("jarvis.agents").warning(
+				f"run-step not recorded for {run_name}: {frappe.get_traceback()}"
+			)
+		except Exception:
+			pass
+		return None
+
+
+def run_owner(run_name: str) -> str | None:
+	"""The human the run's rows belong to (the installation owner), for pinning a
+	step's owner from an impersonated context."""
+	try:
+		return frappe.db.get_value(RUN, run_name, "owner")
+	except Exception:
+		return None
+
+
+def step_target(cap) -> dict | None:
+	"""``{name, owner}`` of the run a step should be filed against, or None.
+
+	``cap`` is the delegate capability contract ``_delegate_capability.resolve``
+	already produced for this dispatch - the run is resolved there from the
+	CALLER's opaque session bearer, never from anything the model could author, so
+	a delegate can only ever narrate its own run. Reusing that result is what keeps
+	a plugin tool call at ONE run-row read instead of two.
+
+	None (do nothing) for an ordinary chat session, and equally for a run that is
+	no longer ``running``: a bearer replayed after the run finished must not be
+	able to append to its history."""
+	if not isinstance(cap, dict):
+		return None
+	if cap.get("status") != "running":
+		return None
+	name = cap.get("run")
+	return {"name": name, "owner": cap.get("owner")} if name else None
+
+
+# --------------------------------------------------------------------------- #
+# Humanizing a tool call
+# --------------------------------------------------------------------------- #
+def _n_rows(result) -> int | None:
+	"""Row count of a tool's data payload, when it has an obvious one."""
+	if isinstance(result, list):
+		return len(result)
+	if isinstance(result, dict):
+		for key in ("rows", "docs", "result"):
+			value = result.get(key)
+			if isinstance(value, list):
+				return len(value)
+		count = result.get("count")
+		if isinstance(count, int):
+			return count
+	return None
+
+
+def plural(n: int, word: str) -> str:
+	"""``1 finding`` / ``3 findings``. Public because the writeback step in
+	``jarvis.tools.record_agent_run`` builds its own label and must phrase a count
+	exactly the way every other step does."""
+	return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
+def _title_case(tool: str) -> str:
+	"""``get_balance_on`` -> ``Get Balance On`` - the fallback label for a tool
+	with no bespoke phrasing. Readable, and it never invents a description of a
+	tool this module has not been taught."""
+	return " ".join(part.capitalize() for part in bare_tool(tool).split("_") if part) or "Step"
+
+
+def internal_doctype_label(doctype) -> str | None:
+	"""The customer-facing phrasing for a read of a bench-internal DocType, or
+	None when it is ordinary ERP data the customer knows by name (and may see)."""
+	name = str(doctype or "").strip()
+	if not name:
+		return None
+	if name in _INTERNAL_DOCTYPE_LABELS:
+		return _INTERNAL_DOCTYPE_LABELS[name]
+	return _INTERNAL_DOCTYPE_FALLBACK if name.startswith(_INTERNAL_DOCTYPE_PREFIX) else None
+
+
+def _is_single(doctype: str) -> bool:
+	"""True for a Single DocType (Stock Settings, Selling Settings, ...).
+
+	A Single's document name IS its doctype, so ``get_doc("Stock Settings")``
+	rendered as "Read <doctype> <name>" reads "Read Stock Settings Stock
+	Settings". Metadata is cached, and an unknown/bogus doctype (exactly the
+	failed-lookup case) simply answers False."""
+	try:
+		return bool(frappe.get_meta(doctype).issingle)
+	except Exception:
+		return False
+
+
+def is_pending_confirmation(data) -> bool:
+	"""True when a tool returned OK but only PARKED a gated write for a human."""
+	return isinstance(data, dict) and data.get("status") == PENDING_CONFIRMATION_STATUS
+
+
+def pending_confirmation_step(action: str) -> tuple[str, str]:
+	"""``(label, detail)`` for a parked write: it was proposed, not done."""
+	return (
+		_clip(f"Proposed {action}, awaiting confirmation", LABEL_MAX),
+		PENDING_CONFIRMATION_DETAIL,
+	)
+
+
+def error_detail(message) -> str:
+	"""The FIRST line of a tool's error message, clipped to
+	:data:`ERROR_DETAIL_MAX` - what failed, without a traceback or a payload."""
+	text = str(message or "").strip()
+	if not text:
+		return ""
+	return text.splitlines()[0].strip()[:ERROR_DETAIL_MAX]
+
+
+def _query_doctype(args: dict) -> str:
+	"""The ``from`` DocType of a structured query spec (``query`` tool)."""
+	spec = args.get("spec")
+	if isinstance(spec, dict):
+		source = spec.get("from")
+		if isinstance(source, str):
+			return source
+	return ""
+
+
+def humanize_tool_call(tool, args, result) -> tuple[str, str]:
+	"""One short sentence describing a delegate tool call, plus an optional
+	second line. Returns ``(label, detail)``, both already clipped.
+
+	``args`` is the parsed argument dict the tool ran against; ``result`` is the
+	tool's DATA payload (the envelope's ``data``), or None when the call failed.
+
+	The copy is deliberately about SHAPES - the DocType read, the report run, how
+	many rows came back. It never quotes a value out of the payload, so a step is
+	as safe to render as the run itself.
+
+	There is deliberately NO ``record_agent_run`` case: the writeback narrates
+	itself from inside the tool (only it knows how many findings survived
+	validation), and ``jarvis.api._SELF_NARRATING_TOOLS`` short-circuits before
+	reaching here, so a case for it could only ever be dead code that disagrees
+	with the row actually written."""
+	name = bare_tool(tool)
+	args = args if isinstance(args, dict) else {}
+	label = ""
+	detail = ""
+
+	if name == "get_list":
+		doctype = args.get("doctype") or "records"
+		n = _n_rows(result)
+		internal = internal_doctype_label(doctype)
+		if internal:
+			# The count is a shape, so it survives - but on the second line, leaving
+			# the label as the plain sentence the customer reads.
+			label = internal
+			if n is not None:
+				detail = plural(n, "row")
+		else:
+			label = f"Read {doctype}" + (f", {plural(n, 'row')}" if n is not None else "")
+	elif name == "get_doc":
+		doctype = args.get("doctype") or "document"
+		target = args.get("name")
+		internal = internal_doctype_label(doctype)
+		# A record NAME is model-supplied: it is whatever the delegate guessed, and a
+		# wrong guess is exactly what produced "Read Company ignore" on the bench. So
+		# the name is only ever shown once the document actually came back.
+		resolved = isinstance(result, dict) and bool(result)
+		if internal:
+			# Never the record name here either: an internal row's name is an opaque
+			# hash that means nothing to the customer and states nothing true.
+			label = internal
+		elif _is_single(doctype):
+			# Checked BEFORE names, mirroring get_doc's own precedence: the tool
+			# short-circuits a Single ahead of name/names, because its one document's
+			# name IS the doctype. So neither a stray name nor the empty names list a
+			# delegate sends when it has nothing sensible to put there changes what
+			# was read - and neither may be allowed to make this label say otherwise
+			# ("Read Stock Settings, 0 documents" was exactly that).
+			label = f"Read {doctype}" if resolved else f"Looked up {doctype}"
+		elif not target and isinstance(args.get("names"), list) and resolved:
+			# The REQUESTED count is a wish, not an outcome: a batch that asked for
+			# five and was permitted three must not read "Read ToDo, 5 documents".
+			# Prefer what actually came back; fall back to the request only when the
+			# payload exposes no count of its own.
+			n = _n_rows(result)
+			if n is None:
+				n = len(args["names"])
+			label = f"Read {doctype}, {plural(n, 'document')}"
+		elif resolved and target:
+			label = f"Read {doctype} {target}"
+		elif resolved:
+			label = f"Read {doctype}"
+		else:
+			# The lookup did not resolve. Say what was attempted, not what was read;
+			# the error itself lands in `detail` (see the api.py step hook).
+			label = f"Looked up {doctype}"
+	elif name == "run_report":
+		label = f"Ran report {args.get('report_name') or ''}".strip()
+		n = _n_rows(result)
+		if n is not None:
+			detail = plural(n, "row")
+	elif name == "query":
+		doctype = _query_doctype(args)
+		internal = internal_doctype_label(doctype)
+		if internal:
+			label = internal
+		else:
+			label = f"Queried {doctype}".strip() if doctype else "Ran a query"
+		n = _n_rows(result)
+		if n is not None:
+			detail = plural(n, "row")
+	elif name == "get_balance_on":
+		account = args.get("account") or args.get("party") or ""
+		label = f"Checked balance for {account}".strip() if account else "Checked a balance"
+	elif name == "save_agent_dashboard":
+		label = "Saved dashboard"
+	else:
+		label = _title_case(name)
+
+	return _clip(label, LABEL_MAX), _clip(detail, DETAIL_MAX)

--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -78,7 +78,7 @@ def _default_dashboard_title(run_doc, listing_title: str) -> str:
 	if not period:
 		period = frappe.utils.today()
 	base = (listing_title or "Agent").strip()
-	return f"{base} — {period}"[:140]
+	return f"{base} - {period}"[:140]
 
 
 def _esc(value) -> str:
@@ -91,10 +91,10 @@ def _esc(value) -> str:
 # per state; rendered as a first-class block inside the document body, NEVER as a
 # detachable banner, so a crop/PDF keeps it.
 _STATE_HEADING = {
-	"evaluated_clean": ("Evaluated — clean coverage", "#065f46", "#d1fae5"),
-	"partial": ("Partial coverage — not a clean result", "#92400e", "#fef3c7"),
-	"not_evaluable": ("Not evaluable — required checks could not run", "#991b1b", "#fee2e2"),
-	"failed": ("Run failed — no result produced", "#991b1b", "#fee2e2"),
+	"evaluated_clean": ("Evaluated: clean coverage", "#065f46", "#d1fae5"),
+	"partial": ("Partial coverage: not a clean result", "#92400e", "#fef3c7"),
+	"not_evaluable": ("Not evaluable: required checks could not run", "#991b1b", "#fee2e2"),
+	"failed": ("Run failed: no result produced", "#991b1b", "#fee2e2"),
 }
 
 # PP-2: the empty-findings sentence is state-conditional. "No exceptions were
@@ -102,7 +102,7 @@ _STATE_HEADING = {
 _EMPTY_SENTENCE = {
 	"evaluated_clean": "No exceptions were found for this run.",
 	"partial": (
-		"Partial coverage — this run did not evaluate every required check; "
+		"Partial coverage: this run did not evaluate every required check; "
 		"absence of findings is not a clean result."
 	),
 	"not_evaluable": "This run could not evaluate the required checks (see reasons below).",
@@ -207,7 +207,7 @@ def _fallback_dashboard_html(
 		# clean sentence because condition 2 fails.
 		if shadow:
 			sentence = (
-				"Preview (shadow) run — findings are visible to the reviewer only; "
+				"Preview (shadow) run - findings are visible to the reviewer only; "
 				"no clean or compliant attestation is issued while this capability is in preview."
 			)
 		elif _clean_attestation_allowed(result_state, total, shadow=shadow):
@@ -227,7 +227,7 @@ def _fallback_dashboard_html(
 	# PP-4: in shadow the outward clean/compliant heading is REPLACED by a preview
 	# banner, so a computed evaluated_clean never surfaces as an outward attestation.
 	if shadow:
-		label, fg, bg = ("Preview (shadow) — not a compliant attestation", "#3730a3", "#e0e7ff")
+		label, fg, bg = ("Preview (shadow) - not a compliant attestation", "#3730a3", "#e0e7ff")
 		state_attr = "shadow"
 	else:
 		label, fg, bg = _STATE_HEADING.get(result_state, _STATE_HEADING["partial"])
@@ -260,7 +260,7 @@ def _fallback_dashboard_html(
 	gaps = ""
 	if coverage_notes:
 		items = "".join(
-			f'<li style="margin:0 0 6px"><strong>{_esc(n.get("reason_code"))}</strong> — '
+			f'<li style="margin:0 0 6px"><strong>{_esc(n.get("reason_code"))}</strong>: '
 			f"{_esc(n.get('remediation'))}"
 			f"{(' (' + _esc(n.get('detail')) + ')') if n.get('detail') else ''}</li>"
 			for n in coverage_notes
@@ -276,7 +276,7 @@ def _fallback_dashboard_html(
 		banner = (
 			f'<div style="margin:0 0 16px;padding:10px 14px;border-radius:8px;'
 			f"background:var(--jarvis-warn-bg,#fef3c7);color:var(--jarvis-warn-text,#92400e);"
-			f'font-size:13px">Partial run — {_esc(coverage_note)}</div>'
+			f'font-size:13px">Partial run - {_esc(coverage_note)}</div>'
 		)
 	return (
 		f'<!doctype html><html><head><meta charset="utf-8">'
@@ -850,11 +850,11 @@ def record_delegate_run(
 	if truncated:
 		note_parts.append("scan truncated; findings incomplete")
 	if wm_drift:
-		note_parts.append("GL changed during scan — re-run advised")
+		note_parts.append("GL changed during scan - re-run advised")
 	if scoped:
-		note_parts.append("scoped visibility — findings not auto-resolved")
+		note_parts.append("scoped visibility - findings not auto-resolved")
 	if row_shortfall:
-		note_parts.append("ledger under-read vs watermark — re-run advised")
+		note_parts.append("ledger under-read vs watermark - re-run advised")
 	if coverage_notes:
 		# PP-3: surface the CUSTOMER remediation sentence (placeholder-filled) that the
 		# amber "Partial scan — {coverageNote}" banner reads day to day, NOT the raw

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -809,6 +809,23 @@ def _reconcile_polled_run(row, state: dict, now) -> bool:
 		# concerned. Leave it alone — an unknown state is never a verdict.
 		return False
 
+	# The host can report a clean ``done`` while its OWN result says the turn never
+	# really finished - a gateway timeout/abort still writes a "done" run-state (the
+	# process exited), with the honest verdict buried in ``result`` instead. Read
+	# there BEFORE the writeback grace: waiting it out just delays the same "delegate
+	# finished without recording results" non-answer by five more minutes, discarding
+	# the real reason (``result.reply``) the gateway already handed us.
+	result = state.get("result")
+	if isinstance(result, dict):
+		gateway_status = result.get("gateway_status")
+		aborted = gateway_status not in ("ok", "completed", "", None) or result.get("summary") == "aborted"
+		if aborted:
+			return _terminalize_stuck_run(
+				row.name,
+				error=_gateway_abort_error_message(result, gateway_status),
+				detail=f"polled: gateway reported {gateway_status}",
+			)
+
 	# Finished on the host, still ``running`` on the bench: the writeback is either in
 	# flight or it is never coming. Wait out the grace before deciding, measured from the
 	# host's own finish time (see WRITEBACK_GRACE_SECONDS).
@@ -822,6 +839,19 @@ def _reconcile_polled_run(row, state: dict, now) -> bool:
 		error="delegate finished without recording results",
 		detail="polled: delegate finished without recording results",
 	)
+
+
+def _gateway_abort_error_message(result: dict, gateway_status) -> str:
+	"""The delegate's real abort sentence out of the fleet result's ``reply`` - its
+	first line, trimmed to the same 140-char budget every polled error uses - falling
+	back to a generic-but-honest sentence naming the gateway status when there is no
+	reply to read."""
+	reply = result.get("reply")
+	if isinstance(reply, str) and reply.strip():
+		first_line = reply.strip().splitlines()[0].strip()
+		if first_line:
+			return first_line[:140]
+	return f"the agent turn was aborted by the gateway ({gateway_status})"
 
 
 def _fleet_error_message(state: dict) -> str:
@@ -985,10 +1015,10 @@ def _launch_audit(
 	# run-as guard above, and ORDERED AFTER the authorization check for the same
 	# reason it precedes the bundle-configuration check below.
 	if (listing.status or "") != "Published":
+		# #1062 polish: one sentence, one action.
 		frappe.throw(
 			_(
-				"This agent is no longer published ({0}), so it is not deployed to run. "
-				"Uninstall it, or ask an admin to publish it again — nothing was started."
+				"This agent is no longer published ({0}); uninstall it or ask an admin to republish it."
 			).format(listing.status or "unknown")
 		)
 
@@ -1008,7 +1038,7 @@ def _launch_audit(
 			_(
 				"This agent's bundle declares no tools, so the run would be refused at "
 				"every step and could never finish. Reinstall or update the agent, or "
-				"contact support — nothing was started."
+				"contact support: nothing was started."
 			)
 		)
 
@@ -1167,20 +1197,54 @@ def _launch_audit(
 		)
 		frappe.db.commit()
 		raise
-	except Exception:
+	except Exception as e:
 		# The dispatch call itself failed, and CONFIRMEDLY: nothing was sent (a clean
 		# refusal / connect timeout), a 4xx rejection, or an auth denial. Mark THIS
 		# Run failed (mirror _record_failed's writeback onto the already-created
 		# "running" row so it is never orphaned), then re-raise so the caller's
 		# retry/notify path runs (scheduler: no next_run_at advance -> retry next
 		# hour; run_agent_now: surfaces the error to the UI).
+		#
+		# One confirmed failure has a self-service fix, so translate it rather than
+		# leaving a raw fleet 502: the fleet-agent's "agent_id '<x>' is not an
+		# installed delegate on <container>" means the agent is ENABLED on the bench
+		# but its skill was never pushed to the container. Enabling only flags the
+		# catalog dirty; the skill reaches the container on APPLY. So the operator
+		# skipped (or has a pending) "Apply catalog changes" -- tell them that
+		# instead of a stack trace.
+		#
+		# jarvis#1062: "them" is not always someone who CAN apply it. The catalog
+		# push needs a reviewer role (Jarvis Skill Reviewer / Jarvis Admin / System
+		# Manager — is_skill_reviewer). Branch on the INSTALLATION OWNER, never
+		# ``frappe.session.user``: by this point the session is impersonated as the
+		# run-as user (Phase 1 identity, see above), which is deliberately decoupled
+		# from the owner (R1-F3) and is not even always a human. The OWNER is who
+		# actually reads this message back on the Runs board (the Run row's owner is
+		# always the installation owner, never the run-as user), on both the manual
+		# and the cron path (run_due_agent_audits sweeps by owner too).
+		not_applied = "not an installed delegate" in str(e)
+		if not_applied:
+			from jarvis.permissions import is_skill_reviewer
+
+			if is_skill_reviewer(owner):
+				error_msg = _(
+					"This agent is not loaded on your container yet. Open the Agents page, "
+					'click "Apply catalog changes" to push it, then run it again.'
+				)
+			else:
+				error_msg = _(
+					"This agent is not ready on your workspace yet. Ask your administrator "
+					"to apply catalog changes."
+				)
+		else:
+			error_msg = "agent-run dispatch failed; see Error Log"
 		frappe.db.set_value(
 			RUN,
 			run.name,
 			{
 				"status": "failed",
 				"finished_at": frappe.utils.now(),
-				"error": "agent-run dispatch failed; see Error Log",
+				"error": error_msg,
 			},
 			update_modified=False,
 		)
@@ -1193,7 +1257,29 @@ def _launch_audit(
 			title=f"jarvis agent-run dispatch failed: {run.name}",
 			message=frappe.get_traceback(),
 		)
+		if not_applied:
+			# Surface the actionable message straight to the SPA (a clean user error),
+			# not the raw AdminUnreachableError 502/500 the fleet verb produced. The
+			# failed Run + session teardown above are already committed, so this only
+			# swaps which exception the caller re-raises.
+			frappe.throw(error_msg, title=_("Agent not applied"))
 		raise
+
+	# STEP TIMELINE (#1062): the run's first step, and the only one the bench
+	# writes before the delegate says anything. It is recorded only after the 202
+	# above - both failure branches raise before reaching here - so "Dispatched to
+	# the agent" on screen means the fleet really accepted the turn. Owner-pinned
+	# like every other row of this launch (the session is the run-as user by now).
+	from jarvis.chat.agent_run_steps import record_step
+
+	record_step(
+		run.name,
+		kind="dispatched",
+		label="Dispatched to the agent",
+		detail=f"trigger: {trigger}",
+		owner=owner,
+	)
+	frappe.db.commit()
 	return {"run": run.name, "conversation": conv.name, "session_key": session_key}
 
 
@@ -1558,7 +1644,7 @@ def _notify_owner(owner: str, row, reason: str | None = None) -> None:
 				),
 				"email_content": (
 					(
-						f"A scheduled agent run was skipped — {reason}. Runs resume next "
+						f"A scheduled agent run was skipped: {reason}. Runs resume next "
 						"month, or ask an admin to raise the monthly agent-run budget in "
 						"Jarvis Settings."
 					)

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -33,6 +33,7 @@ review:
 trigger takes the EXACT same code path as the scheduler.
 """
 
+import time
 from datetime import timedelta
 
 import frappe
@@ -68,6 +69,47 @@ MIN_AGENT_RUN_BUDGET_MONTHLY = 31
 # dead. Keep the two answers to "is this run alive?" on one number, or a run becomes
 # too old to count as live and too young to be reaped.
 STALE_RUN_AFTER_SECONDS = 3 * 3600
+
+# #1061 run poll (jarvis#1058). The reaper above is a 3h BACKSTOP; these are the
+# cutoffs of the 5-minute sweep that asks the fleet what actually happened, so a run
+# whose delegate died after dispatch is terminalized in minutes with its REAL error
+# instead of three hours later as a duration timeout it never hit.
+#
+# POLL_GRACE_SECONDS — how long a fresh dispatch is left alone. Below this the fleet
+# state is still ``queued``/``running`` in the normal case, so polling only costs an
+# admin round trip per run per tick.
+POLL_GRACE_SECONDS = 120
+# WRITEBACK_GRACE_SECONDS — how long the bench waits, AFTER the delegate finished, for
+# ``record_agent_run`` to land before calling the run finished-without-results. Measured
+# from the FLEET's ``finished_at``, never from the run's own age: a two-hour scribe is
+# already far past any grace the instant its fleet state flips to completed, and failing
+# it with the writeback seconds in flight would mislabel a success.
+WRITEBACK_GRACE_SECONDS = 600
+# MISSING_RECORD_FALLBACK_SECONDS — a 404 from the fleet ("unknown agent run") means the
+# host has NO record: either the run never landed, or its state file was pruned. Both are
+# indistinguishable from here, so a young run is left alone (the state file may not be
+# visible yet / the container may be mid-restart) and only an old one is failed.
+MISSING_RECORD_FALLBACK_SECONDS = 1800
+# The fleet-agent's own 404 text for a run it has no state file for
+# (``jarvis_fleet_agent/main.py``: ``NotFoundError(f"unknown agent run {run_id}")``),
+# relayed to the bench through admin as an Admin*Error message. Matched as a SUBSTRING,
+# the same idiom as the "not an installed delegate" translation in ``_launch_audit`` —
+# admin does not re-code this refusal, so the fleet's sentence is the only signal. A
+# CROSS-REPO literal: renaming it fleet-side turns every lost run back into a 3h reap.
+_FLEET_UNKNOWN_RUN = "unknown agent run"
+# The fleet-agent's words for a run that ENDED CLEANLY on the host. Its dispatch worker
+# stamps ``done`` when the container-side turn returns (fleet-agent ``main.py``,
+# ``_dispatch_agent_run``); ``completed`` is accepted too so a relay or a future fleet
+# that normalises the word cannot silently turn every clean exit back into "still in
+# flight" (the mistake this constant replaces: the poll originally matched only
+# ``completed`` and would never have seen a real ``done``).
+_FLEET_FINISHED_STATUSES = ("done", "completed")
+# Circuit breaker on the poll's outbound calls. The sweep is SEQUENTIAL and each admin
+# call can block for admin_client.DEFAULT_TIMEOUT_S (150s), so with admin down three
+# in-flight runs already outlast the 5-minute cron interval and sweeps start stacking.
+# Two consecutive transport failures is enough evidence that the RELAY is down rather
+# than any one run being odd, so the sweep abandons the rest of the tick.
+MAX_CONSECUTIVE_POLL_FAILURES = 2
 
 # #672: TTL on the per-installation DISPATCH lock, which is held across the slot
 # claim AND the whole launch, including the admin call (admin_client.DEFAULT_TIMEOUT_S
@@ -394,84 +436,19 @@ def reap_stale_agent_runs() -> int:
 	scan and its transition here. Each candidate is therefore re-read under a ROW LOCK
 	and transitioned with a COMPARE-AND-SET on ``status='running'``: a row a concurrent
 	finish already moved off running is LEFT ALONE, and the per-run session is torn down
-	only AFTER the transition is won + committed."""
-	from jarvis.chat import agent_runs
-	from jarvis.tools.record_app_wiki import reconcile_run_pages
-
+	only AFTER the transition is won + committed. That whole locked transition lives in
+	``_terminalize_stuck_run``, shared with the #1061 poll so the two sweeps cannot
+	drift apart on it."""
 	cutoff = now_datetime() - timedelta(seconds=STALE_RUN_AFTER_SECONDS)
 	reaped = 0
 	for r in _stale_candidates(cutoff):
 		try:
-			# Re-read under a ROW LOCK immediately before deciding. The row lock serializes
-			# against a concurrent record_app_wiki/finish (both write this row), so the
-			# status + tally we act on are current, not the possibly-stale scan snapshot.
-			cur = frappe.db.get_value(
-				RUN,
+			if _terminalize_stuck_run(
 				r.name,
-				["status", "pages_written", "agent", "session_key", "owner", "installation"],
-				as_dict=True,
-				for_update=True,
-			)
-			if not cur or cur.status != "running":
-				# A concurrent finish already moved it off running — leave it alone (never
-				# overwrite a completed run with failed). Release the lock and move on.
-				frappe.db.commit()
-				continue
-			nature = (frappe.db.get_value(LISTING, cur.agent, "nature") or "").strip().title()
-			pages = int(cur.pages_written or 0)
-			pages_meta = None
-			if nature == "Scribe" and pages == 0:
-				# CA2-3 fallback: rebuild the tally from page provenance before failing a
-				# scribe run whose stored tally reads zero, so real work is never lost.
-				pages_meta = reconcile_run_pages(r.name)
-				if pages_meta is None:
-					# CA3-4: the provenance QUERY failed — the true page count is UNKNOWN.
-					# Neither terminalization is safe (completing with 0 would drop real
-					# pages; failing would mislabel a success), so leave the run running and
-					# retry on the next sweep. Release the row lock and move on.
-					frappe.db.commit()
-					continue
-				pages = pages_meta["count"]
-			if nature == "Scribe" and pages > 0:
-				# Server-owned terminalization: the pages are already durably written,
-				# so this is an honest SUCCESS the model merely never finalized. Complete
-				# it with its tally rather than failing real work.
-				values = {"status": "completed", "finished_at": frappe.utils.now()}
-				if pages_meta is not None:
-					# CA3-4: the tally was rebuilt from provenance (the stored one read 0) —
-					# PERSIST the reconciled ``pages_written`` + ``pages_json`` in the SAME
-					# locked terminalization write, so a run completed off provenance shows
-					# its real page count + list in the durable tally + the Runs UI, never 0.
-					values["pages_written"] = pages
-					values["pages_json"] = frappe.as_json(pages_meta["pages"])[:60000]
-				frappe.db.set_value(RUN, r.name, values, update_modified=False)
-				frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
-				agent_runs.teardown_run_session(cur.session_key)
-				log_activity(
-					agent=cur.agent,
-					agent_title=frappe.db.get_value(LISTING, cur.agent, "title"),
-					installation=cur.installation,
-					action="run_completed",
-					run=r.name,
-					detail=f"reconciled to completed: scribe wrote {pages} page(s); finish not called",
-					owner=cur.owner,
-				)
-				frappe.db.commit()
-				reaped += 1
-				continue
-			# The row lock is already held and the compare-and-set above has already
-			# established that the row is still ``running``, so this goes straight to
-			# the shared terminalization tail.
-			_terminalize_failed(
-				r.name,
-				agent=cur.agent,
-				installation=cur.installation,
-				session_key=cur.session_key,
-				owner=cur.owner,
 				error="run exceeded max duration; reaped by the stale-run sweep (A8 backstop)",
 				detail="reaped: run exceeded max duration",
-			)
-			reaped += 1
+			):
+				reaped += 1
 		except Exception:
 			frappe.log_error(
 				title=f"jarvis agent: stale-run reap failed: {r.name}",
@@ -480,14 +457,117 @@ def reap_stale_agent_runs() -> int:
 	return reaped
 
 
+def _terminalize_stuck_run(run_name: str, *, error: str, detail: str) -> bool:
+	"""Terminalize ONE run that is still ``running`` when it should not be. Returns True
+	iff this call is the one that transitioned it.
+
+	Shared by both sweeps that terminalize from the outside — the 3h stale-run reaper
+	(A8) and the 5-minute fleet poll (#1061). One copy on purpose: they differ only in
+	WHEN they decide a run is stuck and in the sentence they record, never in how the
+	transition is made, and two copies of a compare-and-set are two chances to drift.
+
+	Re-reads under a ROW LOCK immediately before deciding. The row lock serializes
+	against a concurrent ``record_app_wiki``/``finish`` (both write this row), so the
+	status + tally acted on are current, not a possibly-stale scan snapshot; a row a
+	concurrent finish already moved off ``running`` is LEFT ALONE (never overwrite a
+	real outcome with failed), which is also what makes an operator's ``stopped`` win.
+
+	CA-4 (server-owned scribe completion): a Custom App Learning *scribe* whose durable
+	page tally proves it SUCCEEDED is reconciled to ``completed`` rather than mislabelled
+	``failed`` — completion must not depend on the model remembering to call finish. This
+	ruling belongs to the run's OWN durable evidence, not to the reason the caller decided
+	the run was stuck, which is why EVERY outside-in terminalization comes through here:
+	pages already written are pages already written, whether the sweep's trigger was the
+	3h clock, a fleet-reported failure, or a lost fleet record."""
+	from jarvis.chat import agent_runs
+	from jarvis.tools.record_app_wiki import reconcile_run_pages
+
+	frappe.db.commit()  # REPEATABLE-READ discipline: FOR UPDATE goes first
+	cur = frappe.db.get_value(
+		RUN,
+		run_name,
+		["status", "pages_written", "agent", "session_key", "owner", "installation"],
+		as_dict=True,
+		for_update=True,
+	)
+	if not cur or cur.status != "running":
+		# A concurrent finish / stop already moved it off running — leave it alone.
+		# Release the lock and move on.
+		frappe.db.commit()
+		return False
+	nature = (frappe.db.get_value(LISTING, cur.agent, "nature") or "").strip().title()
+	pages = int(cur.pages_written or 0)
+	pages_meta = None
+	if nature == "Scribe" and pages == 0:
+		# CA2-3 fallback: rebuild the tally from page provenance before failing a
+		# scribe run whose stored tally reads zero, so real work is never lost.
+		pages_meta = reconcile_run_pages(run_name)
+		if pages_meta is None:
+			# CA3-4: the provenance QUERY failed — the true page count is UNKNOWN.
+			# Neither terminalization is safe (completing with 0 would drop real
+			# pages; failing would mislabel a success), so leave the run running and
+			# retry on the next sweep. Release the row lock and move on.
+			frappe.db.commit()
+			return False
+		pages = pages_meta["count"]
+	if nature == "Scribe" and pages > 0:
+		# Server-owned terminalization: the pages are already durably written,
+		# so this is an honest SUCCESS the model merely never finalized. Complete
+		# it with its tally rather than failing real work.
+		values = {"status": "completed", "finished_at": frappe.utils.now()}
+		if pages_meta is not None:
+			# CA3-4: the tally was rebuilt from provenance (the stored one read 0) —
+			# PERSIST the reconciled ``pages_written`` + ``pages_json`` in the SAME
+			# locked terminalization write, so a run completed off provenance shows
+			# its real page count + list in the durable tally + the Runs UI, never 0.
+			values["pages_written"] = pages
+			values["pages_json"] = frappe.as_json(pages_meta["pages"])[:60000]
+		frappe.db.set_value(RUN, run_name, values, update_modified=False)
+		frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
+		agent_runs.teardown_run_session(cur.session_key)
+		log_activity(
+			agent=cur.agent,
+			agent_title=frappe.db.get_value(LISTING, cur.agent, "title"),
+			installation=cur.installation,
+			action="run_completed",
+			run=run_name,
+			detail=f"reconciled to completed: scribe wrote {pages} page(s); finish not called",
+			owner=cur.owner,
+		)
+		frappe.db.commit()
+		return True
+	# The row lock is already held and the compare-and-set above has already
+	# established that the row is still ``running``, so this goes straight to
+	# the shared terminalization tail.
+	_terminalize_failed(
+		run_name,
+		agent=cur.agent,
+		installation=cur.installation,
+		session_key=cur.session_key,
+		owner=cur.owner,
+		error=error,
+		detail=detail,
+	)
+	return True
+
+
 def _stale_candidates(cutoff) -> list:
-	"""Runs stuck ``running`` past ``cutoff`` — the reaper's candidate set. Factored so
-	the CA2-4 compare-and-set (re-read under a row lock before transitioning) can be
-	exercised against a deliberately-stale candidate snapshot in tests."""
+	"""Runs stuck ``running`` past ``cutoff`` — the candidate set of BOTH outside-in
+	sweeps (the A8 reaper at 3h, the #1061 poll at 2 minutes; only the cutoff differs).
+	Factored so the CA2-4 compare-and-set (re-read under a row lock before
+	transitioning) can be exercised against a deliberately-stale snapshot in tests."""
 	return frappe.get_all(
 		RUN,
 		filters={"status": "running", "started_at": ["<", cutoff]},
-		fields=["name", "session_key", "owner", "agent", "installation", "pages_written"],
+		fields=[
+			"name",
+			"session_key",
+			"owner",
+			"agent",
+			"installation",
+			"pages_written",
+			"started_at",
+		],
 	)
 
 
@@ -580,6 +660,211 @@ def fail_run(run_name: str, error: str, *, detail: str | None = None) -> bool:
 			message=frappe.get_traceback(),
 		)
 		return False
+
+
+# --------------------------------------------------------------------------- #
+# #1061 dispatched-run poll (jarvis#1058) — hooks cron, every 5 minutes
+# --------------------------------------------------------------------------- #
+def poll_dispatched_runs() -> int:
+	"""Ask the fleet what actually happened to each run the bench still believes is
+	``running``, and terminalize the ones that are over. Returns the count transitioned.
+	Runs as Administrator (scheduler); best-effort, never raises out.
+
+	The bench used to learn a run's outcome from exactly ONE source: the delegate's own
+	``record_agent_run`` writeback. A delegate that died after dispatch — a container
+	restart, a stale gateway roster (jarvis#1058), an exec failure the fleet recorded but
+	nobody read — therefore left the row ``running`` for three hours, blocking every
+	further run of that installation behind the #672 liveness guard, before the reaper
+	relabelled it "exceeded max duration": a timeout it never hit, and a diagnosis that
+	sent the customer looking in the wrong place.
+
+	This closes that loop from the other side. It NEVER touches a row that is not still
+	``running``: every terminal write goes through ``fail_run`` /
+	``_terminalize_stuck_run``, which re-read under a row lock and compare-and-set on
+	``status='running'``. So an operator's ``stop_agent_run``, a real writeback and this
+	sweep can race freely — the first to win the lock decides, and a later fleet flip can
+	never overwrite a stopped or completed run.
+
+	The reaper stays: it is the backstop for everything this cannot see (admin down, the
+	relay itself broken), which is why an unreachable admin here is a SKIP, never a
+	failure verdict."""
+	from jarvis import admin_client
+
+	now = now_datetime()
+	cutoff = now - timedelta(seconds=POLL_GRACE_SECONDS)
+	candidates = _stale_candidates(cutoff)
+	terminalized = 0
+	unreachable = 0
+	consecutive = 0
+	abandoned = 0
+	for i, r in enumerate(candidates):
+		# Per-run fault isolation (the health_check 1020 lesson): one poisoned row must
+		# never abort the sweep and starve every run behind it.
+		try:
+			try:
+				state = _polled_state(admin_client.get_agent_run_status(r.name))
+			except Exception as e:
+				# Deliberately caught by MESSAGE, not by class. A relayed fleet 404 arrives
+				# as an Admin*Error whose class is shared with genuine transport faults
+				# (AdminRejectedError IS an AdminUnreachableError), so branching on the
+				# class first would swallow every lost-record case forever.
+				if _FLEET_UNKNOWN_RUN not in str(e).lower():
+					# Transport / admin fault: skip this run, the reaper backstops it.
+					unreachable += 1
+					consecutive += 1
+					if consecutive >= MAX_CONSECUTIVE_POLL_FAILURES:
+						# CIRCUIT BREAKER. Each call can block for admin_client's full
+						# DEFAULT_TIMEOUT_S (150s), and this sweep is sequential on a 5-minute
+						# cron, so with admin down even three in-flight runs push one tick past
+						# the next and the sweeps stack — an outage would spend the scheduler
+						# on calls that are all going to time out anyway. Two consecutive
+						# transport failures is enough evidence that the relay, not the run, is
+						# the problem: abandon the rest of the sweep and let the next tick
+						# retry from the top.
+						abandoned = len(candidates) - (i + 1)
+						break
+					continue
+				state = {"status": "missing"}
+			consecutive = 0  # a readable answer (a relayed 404 included) closes the breaker
+			if _reconcile_polled_run(r, state, now):
+				terminalized += 1
+		except Exception:
+			frappe.log_error(
+				title=f"jarvis agent: run poll failed: {r.name}",
+				message=frappe.get_traceback(),
+			)
+	if unreachable:
+		# ONE line per sweep, not one per run: an admin outage would otherwise write an
+		# Error Log row for every in-flight run every five minutes.
+		frappe.log_error(
+			title="jarvis agent: run poll could not reach admin",
+			message=(
+				f"{unreachable} dispatched run(s) failed to poll and {abandoned} more were "
+				f"left unattempted (breaker opened after {MAX_CONSECUTIVE_POLL_FAILURES} "
+				"consecutive transport failures). No run state was changed; the next tick "
+				"retries and the stale-run reaper remains the backstop."
+			),
+		)
+	return terminalized
+
+
+def _polled_state(payload) -> dict:
+	"""The fleet's run-state record out of whatever the relay returned.
+
+	``admin_client._do_post`` already peels Frappe's ``message`` wrapper, but admin's OWN
+	success envelope survives it: ``api.tenant.agent_run_status`` returns
+	``{"ok": True, "data": {<run state>}}``, so the state sits one level further down than
+	``admin_client.get_agent_run_status``'s docstring suggests. Reading only the envelope
+	would be just as brittle in the other direction, so accept both shapes — a poll that
+	misreads the wrapper sees a blank status and silently never terminalizes anything,
+	which is the failure mode this whole sweep exists to remove."""
+	if not isinstance(payload, dict):
+		return {}
+	data = payload.get("data")
+	if isinstance(data, dict) and ("status" in data or "run_id" in data):
+		return data
+	return payload
+
+
+def _reconcile_polled_run(row, state: dict, now) -> bool:
+	"""Decide what the fleet's run-state means for a bench row still ``running``, and
+	transition it if it is over. Returns True iff this call terminalized it.
+
+	``state`` is the fleet's run-state record relayed verbatim through admin
+	(``{run_id, status: queued|running|completed|failed, error, finished_at, ...}``),
+	plus the synthetic ``missing`` this module uses for a relayed 404."""
+	status = (state.get("status") or "").strip().lower()
+
+	# Every terminal branch below goes through ``_terminalize_stuck_run``, never through
+	# ``fail_run`` directly: the CA-4 scribe ruling is keyed on the run's OWN durable page
+	# tally, not on why the sweep decided the run was over. Calling fail_run here stamped
+	# ``failed`` on a scribe that had already written its pages, while the reaper
+	# reconciled the identical row to ``completed`` — the same run reported two different
+	# outcomes depending on which sweep reached it first.
+	if status == "missing":
+		# The host has NO record of this run. Either it never landed, or its state file
+		# was pruned. Indistinguishable from here, so age is the only honest tiebreak:
+		# a young run may simply not be visible yet (container mid-restart, a state
+		# write not yet flushed) and is left alone.
+		if _run_age_seconds(row, now) < MISSING_RECORD_FALLBACK_SECONDS:
+			return False
+		return _terminalize_stuck_run(
+			row.name,
+			error="the agent host has no record of this run; it never started or its state was lost",
+			detail="polled: no run record on the host",
+		)
+
+	if status == "failed":
+		# The delegate really failed and the fleet knows why. Surface THAT sentence, not
+		# a generic one: this is the whole point of polling rather than waiting for the
+		# reaper's "exceeded max duration".
+		return _terminalize_stuck_run(
+			row.name,
+			error=_fleet_error_message(state),
+			detail="polled: the delegate reported a failure",
+		)
+
+	if status not in _FLEET_FINISHED_STATUSES:
+		# queued / running / anything unrecognised: still in flight as far as the host is
+		# concerned. Leave it alone — an unknown state is never a verdict.
+		return False
+
+	# Finished on the host, still ``running`` on the bench: the writeback is either in
+	# flight or it is never coming. Wait out the grace before deciding, measured from the
+	# host's own finish time (see WRITEBACK_GRACE_SECONDS).
+	if _writeback_grace_age(state, row, now) < WRITEBACK_GRACE_SECONDS:
+		return False
+	# Past the grace. A scribe whose durable page tally proves it wrote real pages is
+	# COMPLETED, not failed — the shared helper owns that ruling, exactly as the reaper
+	# gets it.
+	return _terminalize_stuck_run(
+		row.name,
+		error="delegate finished without recording results",
+		detail="polled: delegate finished without recording results",
+	)
+
+
+def _fleet_error_message(state: dict) -> str:
+	"""The delegate's real failure sentence out of the fleet run-state ``error``
+	(``{code, message}``), falling back to something honest rather than empty — an
+	error field the customer reads as blank is worse than a generic sentence."""
+	err = state.get("error")
+	if isinstance(err, dict):
+		msg = (err.get("message") or "").strip() or (err.get("code") or "").strip()
+		if msg:
+			return msg[:140]
+	elif isinstance(err, str) and err.strip():
+		return err.strip()[:140]
+	return "the agent host reported this run as failed"
+
+
+def _run_age_seconds(row, now) -> float:
+	"""Seconds since the bench dispatched this run. 0.0 when ``started_at`` is unreadable
+	— which reads as "too young to judge", the fail-safe direction for every caller here."""
+	try:
+		return (now - frappe.utils.get_datetime(row.started_at)).total_seconds()
+	except Exception:
+		return 0.0
+
+
+def _writeback_grace_age(state: dict, row, now) -> float:
+	"""Seconds since the DELEGATE finished — what the writeback grace must be measured
+	from. Anchoring it on the run's own age would fail any run longer than the grace the
+	instant its fleet state flipped to completed, with the writeback still seconds in
+	flight, which is precisely the long scribe run this sweep must not mislabel.
+
+	The fleet stamps ``finished_at`` as a UNIX epoch float (fleet-agent
+	``agent_run.new_run_state``). Falls back to the bench-side run age only when the
+	relayed state carries none."""
+	finished = state.get("finished_at")
+	if finished is not None:
+		try:
+			delta = time.time() - float(finished)
+		except (TypeError, ValueError):
+			delta = -1.0
+		if delta >= 0:
+			return delta
+	return _run_age_seconds(row, now)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -24,6 +24,7 @@ from jarvis.chat.filebox import _clamp_page, _lk
 from jarvis.chat.macro_scheduler import compute_next_run
 from jarvis.permissions import (
 	has_jarvis_admin_access,
+	is_skill_reviewer,
 	require_jarvis_admin,
 	require_jarvis_user,
 )
@@ -31,11 +32,13 @@ from jarvis.permissions import (
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
+RUN_STEP = "Jarvis Agent Run Step"
 FINDING = "Jarvis Agent Finding"
 ACTIVITY = "Jarvis Agent Activity"
 DASHBOARD = "Jarvis Dashboard"
 PROVENANCE = "Jarvis Agent Provenance Event"
 ALLOWED_ROLE = "Jarvis Agent Allowed Role"
+ALLOWED_USER = "Jarvis Agent Allowed User"
 _SETTINGS = "Jarvis Settings"
 
 # PP-6 — the stage-maximum global activation ceiling. The initial ceiling is 1
@@ -56,6 +59,12 @@ _FREQUENCIES = ("daily", "weekly", "monthly")
 _RUN_STATUSES = ("running", "completed", "partial", "failed", "stopped")
 # Statuses a bench admin may set via set_listing_status (Draft is registry-only).
 _ADMIN_STATUSES = ("Published", "Coming Soon", "Deprecated")
+# jarvis#1062 D2: statuses a non-admin may DISCOVER (browse to without having
+# installed it) - Published (live) and Coming Soon (the SPA's deliberate teaser:
+# AgentsList's "Coming Soon" badge, AgentDetail's "Coming soon" install tooltip).
+# Draft (registry-only, never shipped) and Deprecated (sunset) are excluded UNLESS
+# the caller already installed it - see _enriched_catalog / get_agent.
+_DISCOVERABLE_STATUSES = ("Published", "Coming Soon")
 # Never meaningful as an agent restriction ("All" == unrestricted; the other two
 # are identities, not grantable roles) and never offered in the admin picker.
 _NON_SELECTABLE_ROLES = ("Administrator", "Guest", "All")
@@ -67,35 +76,81 @@ DISPATCH_LOCK_WAIT_S = 5.0
 
 
 # --------------------------------------------------------------------------- #
-# role-based access (RBAC)
+# access governance (Interim A, jarvis#1062) — DENY BY DEFAULT
 # --------------------------------------------------------------------------- #
+# The model: an admin ALLOWS each agent for a set of ROLES (``allowed_roles``)
+# and/or a set of NAMED USERS (``allowed_users``). A listing with NEITHER is not
+# "unrestricted", it is CLOSED — reachable by Jarvis Admins / System Managers
+# only. That inversion is the whole point of this change: before it, every newly
+# synced listing shipped wide open to every Jarvis User on the tenant, and an
+# admin had to notice and narrow it. Now nothing is reachable until an admin says
+# who may reach it.
+#
+# There is no carve-out: every gate, including the container-push roster, asks
+# this one predicate. Existing installs survive the upgrade through the
+# ``v2_18_agent_access_grandfather`` patch, which runs during migrate before
+# anything can apply.
+def _is_allowed(
+	allowed_roles,
+	allowed_users,
+	user: str,
+	user_roles: set[str] | None = None,
+	is_admin: bool | None = None,
+) -> bool:
+	"""The ONE access predicate, pure over its inputs.
+
+	Both ``_user_allowed_for_agent`` (the server-side gate) and
+	``_enriched_catalog`` (the ``allowed`` display flag on every catalog row) call
+	this, so the flag a user is shown and the gate they hit can never disagree —
+	they used to be two hand-kept copies of the same boolean expression.
+
+	Every caller gets the SAME answer, including the container-push roster: a
+	roster that admitted more than dispatch would advertise agents the bench then
+	refuses to run.
+	"""
+	if is_admin is None:
+		is_admin = has_jarvis_admin_access(user)
+	if is_admin:
+		# PART 4 REVISED, TASK 49: admin parity — a Jarvis Admin / System Manager is
+		# ALWAYS allowed, in lockstep with the ``allowed`` display flag so an admin
+		# never sees an agent as installable but 403s on install. Checked FIRST now:
+		# under deny-by-default the empty-pair case is a denial, and an admin must
+		# not be denied by it.
+		return True
+	if user in (allowed_users or []):
+		return True
+	if not (allowed_roles or []):
+		return False  # deny by default
+	if user_roles is None:
+		user_roles = set(frappe.get_roles(user))
+	return bool(user_roles.intersection(allowed_roles))
+
+
 def _user_allowed_for_agent(listing, user: str | None = None) -> bool:
 	"""True iff ``user`` may install / run the agent.
 
-	Allowed iff the listing has NO ``allowed_roles`` rows (empty = unrestricted)
-	OR the user's roles intersect them. System Manager is ALWAYS allowed.
-	``listing`` may be a Jarvis Agent Listing doc or its name (agent_slug).
-	Fail-closed on the restricted side: an unknown user has no roles beyond
-	Guest/All, which never satisfy a restriction.
+	Allowed iff the user is named in ``allowed_users`` OR their roles intersect
+	``allowed_roles``. A listing carrying NEITHER is closed to everyone but a
+	Jarvis Admin / System Manager (deny by default). ``listing`` may be a Jarvis
+	Agent Listing doc or its name (agent_slug). Fail-closed: an unknown user has
+	no roles beyond Guest/All and appears in no allow list.
 	"""
 	user = user or frappe.session.user
 	if isinstance(listing, str):
-		allowed = frappe.get_all(
+		roles = frappe.get_all(
 			ALLOWED_ROLE,
 			filters={"parenttype": LISTING, "parent": listing},
 			pluck="role",
 		)
+		users = frappe.get_all(
+			ALLOWED_USER,
+			filters={"parenttype": LISTING, "parent": listing},
+			pluck="user",
+		)
 	else:
-		allowed = [row.role for row in (listing.get("allowed_roles") or [])]
-	if not allowed:
-		return True
-	# PART 4 REVISED, TASK 49: admin parity — a Jarvis Admin / System Manager is
-	# ALWAYS allowed, in lockstep with the widened ``allowed`` display flag so an
-	# admin never sees an agent as installable but 403s on install.
-	if has_jarvis_admin_access(user):
-		return True
-	roles = set(frappe.get_roles(user))
-	return bool(roles.intersection(allowed))
+		roles = [row.role for row in (listing.get("allowed_roles") or [])]
+		users = [row.user for row in (listing.get("allowed_users") or [])]
+	return _is_allowed(roles, users, user)
 
 
 def _allowed_roles_map() -> dict[str, list[str]]:
@@ -111,6 +166,19 @@ def _allowed_roles_map() -> dict[str, list[str]]:
 	return out
 
 
+def _allowed_users_map() -> dict[str, list[str]]:
+	"""All listings' allowed_users child rows in ONE query: {listing_name: [user, ...]}."""
+	out: dict[str, list[str]] = {}
+	for row in frappe.get_all(
+		ALLOWED_USER,
+		filters={"parenttype": LISTING, "parentfield": "allowed_users"},
+		fields=["parent", "user"],
+		order_by="parent asc, idx asc",
+	):
+		out.setdefault(row.parent, []).append(row.user)
+	return out
+
+
 # --------------------------------------------------------------------------- #
 # catalog + install state (read)
 # --------------------------------------------------------------------------- #
@@ -118,9 +186,10 @@ def _allowed_roles_map() -> dict[str, list[str]]:
 @require_jarvis_user
 def list_agents() -> list[dict]:
 	"""The full catalog plus THIS owner's install/enable/schedule state per
-	agent. Read-only — the catalog is visible to every logged-in user. Each row
-	also carries ``allowed_roles`` (empty = unrestricted) and ``allowed`` (0/1
-	for the CURRENT user; System Manager is always 1) — display state only, the
+	agent. Read-only, but ACCESS-FILTERED: a non-admin sees only rows they are
+	allowed for (or already installed). Each row carries ``allowed`` (0/1 for the
+	CURRENT user; a Jarvis Admin is always 1); ``allowed_roles`` /
+	``allowed_users`` ride along for admins ONLY — display state either way, the
 	real gate is server-side in install_agent / run_agent_now / the scheduler."""
 	return _enriched_catalog()
 
@@ -131,6 +200,7 @@ def _enriched_catalog() -> list[dict]:
 	never drift from the legacy full list."""
 	me = frappe.session.user
 	roles_map = _allowed_roles_map()
+	users_map = _allowed_users_map()
 	my_roles = set(frappe.get_roles(me))
 	# PART 4 REVISED, TASK 49(d): admin display parity — a Jarvis Admin sees every
 	# agent card as ``allowed`` (and _user_allowed_for_agent lets them install).
@@ -202,10 +272,36 @@ def _enriched_catalog() -> list[dict]:
 			1 if inst and inst.installed_version and inst.installed_version != lst.version else 0
 		)
 		allowed_roles = roles_map.get(lst.name, [])
+		allowed_users = users_map.get(lst.name, [])
 		lst["allowed_roles"] = allowed_roles
-		lst["allowed"] = 1 if (is_sm or not allowed_roles or my_roles.intersection(allowed_roles)) else 0
+		lst["allowed_users"] = allowed_users
+		# ONE predicate with the server-side gate (``_is_allowed``) — this used to be
+		# a hand-copied boolean and drifted from ``_user_allowed_for_agent`` the
+		# moment either changed.
+		lst["allowed"] = 1 if _is_allowed(allowed_roles, allowed_users, me, my_roles, is_admin=is_sm) else 0
 		lst["install_count"] = install_counts.get(lst.name, 0)
 		out.append(lst)
+	# jarvis#1062 D2 (revised): a non-admin never sees a row it may not
+	# DISCOVER, but a row it already INSTALLED stays visible regardless of role
+	# restriction — role gating governs marketplace discovery and running, not
+	# managing what you already have. Without this carve-out, a role revoked
+	# after install stranded the owner: the row vanished from their own
+	# Installed tab and get_agent 403'd, leaving no UI path to uninstall it.
+	# Hidden (not-installed) iff role-restricted (allowed == 0) OR the status
+	# isn't discoverable (_DISCOVERABLE_STATUSES — Draft/Deprecated are
+	# registry / lifecycle states, not something to discover before an admin
+	# ships or sunsets them; Coming Soon IS discoverable — it is the SPA's
+	# deliberate teaser). Admin display parity is untouched: an admin (is_sm)
+	# always sees every row, `allowed` computed exactly as before. The ONE
+	# choke point both list_agents and list_agents_page share, so neither can
+	# drift from the other.
+	if not is_sm:
+		out = [r for r in out if r["installed"] or (r["allowed"] and r["status"] in _DISCOVERABLE_STATUSES)]
+		for r in out:
+			# WHO ELSE has access is admin-only information: a plain user learns
+			# whether THEY are allowed (the ``allowed`` flag), never the roster.
+			r.pop("allowed_roles", None)
+			r.pop("allowed_users", None)
 	return out
 
 
@@ -283,11 +379,34 @@ def get_agent(agent_slug: str) -> dict:
 	(DESIGN-V3 §8.3 / D39). Any authenticated user may read (listing perms =
 	All read); the ``installation`` block is the caller's own install or None.
 	``all_roles`` rides along only for System Managers (Admin-tab roles editor)."""
-	listing = frappe.get_doc(LISTING, agent_slug)  # All-role read; 404s if unknown
+	try:
+		listing = frappe.get_doc(LISTING, agent_slug)  # All-role read; 404s if unknown
+	except frappe.DoesNotExistError:
+		# jarvis#1062 polish: a raw "Jarvis Agent Listing <slug> not found" leaks the
+		# doctype name and confirms the slug is a plausible one; a clean, generic
+		# message avoids giving an enumeration probe anything to key off.
+		frappe.throw(_("Agent not found."), frappe.DoesNotExistError)
 	me = frappe.session.user
 	# PART 4 REVISED, TASK 49(d): the Admin-tab signal (all_roles rider) rides for
 	# Jarvis Admins too — the SPA derives isSM from all_roles' presence.
 	is_sm = has_jarvis_admin_access(me)
+	allowed = _user_allowed_for_agent(listing, me)
+	installed_by_caller = bool(frappe.db.exists(INSTALLATION, {"owner": me, "agent": listing.name}))
+	# jarvis#1062 D2 (revised): the same visibility gate as list_agents/
+	# list_agents_page (_enriched_catalog) — a row hidden from the catalog must
+	# not be reachable by knowing (or guessing) its slug either — EXCEPT an
+	# installed row always passes, so a role revoked after install never
+	# strands the owner without a way to read (and uninstall) their own
+	# install. Coming Soon is DISCOVERABLE (_DISCOVERABLE_STATUSES — the SPA's
+	# deliberate teaser), so it passes like Published; Draft/Deprecated still
+	# need the install carve-out. Admin display parity is untouched: an admin
+	# (is_sm) always passes.
+	if (
+		not is_sm
+		and not installed_by_caller
+		and (not allowed or listing.status not in _DISCOVERABLE_STATUSES)
+	):
+		frappe.throw(_("You do not have access to this agent."), frappe.PermissionError)
 
 	out: dict = {
 		"name": listing.name,
@@ -308,8 +427,16 @@ def get_agent(agent_slug: str) -> dict:
 		# engine read it via generic REST / get_doc.
 		"default_schedule": listing.default_schedule,
 		"validated_for_fy": listing.validated_for_fy,
-		"allowed_roles": [row.role for row in (listing.allowed_roles or [])],
-		"allowed": 1 if _user_allowed_for_agent(listing, me) else 0,
+		# jarvis#1062 polish: doctypes_required (A12) so Overview can render
+		# "Reads these records" - unrelated to the access-roster fields below,
+		# which governance gates on is_sm further down (never added for a
+		# non-admin, not added-then-popped).
+		"doctypes_required": listing.doctypes_required,
+		# jarvis#1063 (jarvis-only half): which agent-specific config keys this
+		# agent's bundle actually reads - ConfigForm.vue only renders the
+		# corresponding fields when their key is in this list.
+		"config_keys": listing.config_keys,
+		"allowed": 1 if allowed else 0,
 		"install_count": frappe.db.count(INSTALLATION, {"agent": listing.name}),
 		"installation": None,
 	}
@@ -346,6 +473,11 @@ def get_agent(agent_slug: str) -> dict:
 		out["installation"] = i
 
 	if is_sm:
+		# The ACCESS ROSTER (who may use this agent) is admin-only, exactly like the
+		# ``all_roles`` picker source that rides with it. A non-admin gets only the
+		# ``allowed`` boolean above: whether THEY are allowed, never who else is.
+		out["allowed_roles"] = [row.role for row in (listing.allowed_roles or [])]
+		out["allowed_users"] = [row.user for row in (listing.allowed_users or [])]
 		out["all_roles"] = [
 			r
 			for r in frappe.get_all(
@@ -408,46 +540,186 @@ def get_installations() -> list[dict]:
 # --------------------------------------------------------------------------- #
 # admin surface (Jarvis Admin / System Manager — every check server-side)
 # --------------------------------------------------------------------------- #
-@frappe.whitelist()
-def set_agent_roles(agent_slug: str, roles: str | list | None = None) -> dict:
-	"""Restrict an agent listing to a set of Roles. Jarvis Admin / System Manager
-	(PART 4 REVISED, TASK 45; needs the Jarvis Admin write:1 row on Jarvis Agent
-	Listing — TASK 47 — for the perm-checked save).
+def _parse_name_list(raw, what: str) -> list[str]:
+	"""A JSON array (or already-decoded list) of names -> a trimmed, deduped list.
 
-	``roles`` is a JSON array of Role names; ``[]`` clears the restriction
-	(unrestricted). Roles are validated against the Role doctype; the
-	non-grantable Administrator/Guest/All are rejected (All would silently mean
-	unrestricted — force the explicit empty list instead)."""
-	require_jarvis_admin()
-	parsed = roles
+	``None`` is the empty list, so "clear this side of the grant" is expressible.
+	Anything else is a client bug and throws rather than being coerced: silently
+	dropping a malformed entry from an ACCESS list would grant or revoke access
+	nobody asked for."""
+	parsed = raw
 	if isinstance(parsed, str):
 		try:
 			parsed = frappe.parse_json(parsed)
 		except Exception:
-			frappe.throw(_("roles must be a JSON array of Role names."))
+			frappe.throw(_("{0} must be a JSON array of names.").format(what))
 	if parsed is None:
 		parsed = []
 	if not isinstance(parsed, list):
-		frappe.throw(_("roles must be a JSON array of Role names."))
-
+		frappe.throw(_("{0} must be a JSON array of names.").format(what))
 	clean: list[str] = []
-	for r in parsed:
-		if not isinstance(r, str) or not r.strip():
-			frappe.throw(_("roles must be a JSON array of Role names."))
-		r = r.strip()
+	for item in parsed:
+		if not isinstance(item, str) or not item.strip():
+			frappe.throw(_("{0} must be a JSON array of names.").format(what))
+		item = item.strip()
+		if item not in clean:
+			clean.append(item)
+	return clean
+
+
+@frappe.whitelist()
+def set_agent_access(
+	agent_slug: str,
+	roles: str | list | None = None,
+	users: str | list | None = None,
+	apply: str | int | bool | None = None,
+) -> dict:
+	"""Set WHO may install and run an agent: a set of Roles and a set of named Users.
+
+	Jarvis Admin / System Manager (needs the Jarvis Admin write:1 row on Jarvis
+	Agent Listing for the perm-checked save). Access is DENY BY DEFAULT
+	(jarvis#1062): saving with BOTH lists empty CLOSES the agent to everyone but
+	an admin — it does not reopen it to everyone, which is what the same call used
+	to mean.
+
+	Both tables are REPLACED atomically in one save, so an admin who moves a
+	person from a role grant to a named grant never passes through a moment where
+	they hold both or neither.
+
+	``apply`` (default false) additionally pushes the new roster to the container.
+	It belongs on the ADMIN's action, deliberately: the push restarts the tenant's
+	workspace for everyone, which is a cost only an admin can knowingly accept —
+	never something a user's own install may trigger.
+
+	Roles are validated against the Role doctype; the non-grantable
+	Administrator/Guest/All are rejected ("All" would be a backdoor re-grant of the
+	old everyone-by-default). A newly ADDED user must exist and be ENABLED — a
+	disabled user is how an offboarded person is revoked, so recording one as
+	allowed would write a grant that outlives the offboarding. Users already on the
+	list are carried forward without that check: see the comment there for why
+	re-validating them breaks unrelated edits."""
+	require_jarvis_admin()
+	roles_clean = _parse_name_list(roles, _("roles"))
+	users_clean = _parse_name_list(users, _("users"))
+
+	for r in roles_clean:
 		if r in _NON_SELECTABLE_ROLES:
-			frappe.throw(_("Role {0} cannot be used as an agent restriction.").format(r))
+			frappe.throw(_("Role {0} cannot be used to grant agent access.").format(r))
 		if not frappe.db.exists("Role", r):
 			frappe.throw(_("Role {0} does not exist.").format(r))
-		if r not in clean:
-			clean.append(r)
+	# Validation applies to what this call ADDS, never to what it merely carries
+	# forward. An agent granted to someone who has since been offboarded holds a
+	# row naming a DISABLED user, and grandfathered rows can name users who were
+	# later deleted outright. Re-validating those would make an unrelated edit -
+	# adding one role, or the set_agent_roles shim passing the existing people
+	# through untouched - fail with a message about somebody the admin never
+	# mentioned, and leave them no way to change the roles at all.
+	current_users = set(
+		frappe.get_all(
+			ALLOWED_USER,
+			filters={"parenttype": LISTING, "parentfield": "allowed_users", "parent": agent_slug},
+			pluck="user",
+		)
+	)
+	added = [u for u in users_clean if u not in current_users]
+	for u in added:
+		if u in ("Administrator", "Guest"):
+			frappe.throw(_("User {0} cannot be granted agent access.").format(u))
+	if added:
+		# ONE query for the whole added set, not a get_value per name: this is an
+		# admin picking a handful of people, but the loop shape is what turns into an
+		# N+1 the first time somebody pastes a department into it.
+		known = {
+			r.name: r.enabled
+			for r in frappe.get_all("User", filters={"name": ("in", added)}, fields=["name", "enabled"])
+		}
+		for u in added:
+			if u not in known:
+				frappe.throw(_("User {0} does not exist.").format(u))
+			if not known[u]:
+				frappe.throw(_("User {0} is disabled and cannot be granted agent access.").format(u))
+	# Kept rows are left exactly as they are, with ONE exception: a name whose User
+	# row is gone would fail the child table's Link validation and block the save
+	# outright, so it is dropped and logged rather than raised. A disabled user is
+	# NOT dropped - disabling is reversible, and silently discarding the grant would
+	# turn a temporary suspension into a permanent revocation nobody recorded.
+	kept = [u for u in users_clean if u in current_users]
+	if kept:
+		alive = set(frappe.get_all("User", filters={"name": ("in", kept)}, pluck="name"))
+		vanished = [u for u in kept if u not in alive]
+		if vanished:
+			frappe.logger("jarvis").info(
+				f"agent access {agent_slug}: dropping allowed_users rows for deleted "
+				f"user(s) {', '.join(vanished)}"
+			)
+			gone = set(vanished)
+			users_clean = [u for u in users_clean if u not in gone]
 
 	doc = frappe.get_doc(LISTING, agent_slug)
 	doc.check_permission("write")
-	doc.set("allowed_roles", [{"role": r} for r in clean])
+	doc.set("allowed_roles", [{"role": r} for r in roles_clean])
+	doc.set("allowed_users", [{"user": u} for u in users_clean])
 	doc.save()
+	# The allow lists are PUSH-VISIBLE now (build_agent_push_payload ships every
+	# allowed listing, not only the enabled-install set), so an access change moves
+	# the container roster exactly as install/enable does and must show as pending.
+	_mark_catalog_dirty()
 	frappe.db.commit()
-	return {"ok": True, "allowed_roles": [row.role for row in doc.allowed_roles]}
+
+	applied = False
+	if frappe.utils.cint(apply):
+		# Authority is already established: require_jarvis_admin above is a strict
+		# subset of the skill-reviewer set apply_agents gates on.
+		_enqueue_apply()
+		applied = True
+	return {
+		"ok": True,
+		"allowed_roles": [row.role for row in doc.allowed_roles],
+		"allowed_users": [row.user for row in doc.allowed_users],
+		"applied": applied,
+	}
+
+
+@frappe.whitelist()
+def set_agent_roles(agent_slug: str, roles: str | list | None = None) -> dict:
+	"""Compat shim over ``set_agent_access`` — sets the ROLE half, users untouched.
+
+	Kept because it is the shipped endpoint name and an older SPA build may still
+	be cached in a customer's browser after deploy. It reads the current
+	``allowed_users`` and passes them straight back, so calling it can never
+	silently revoke a named grant made through the new Access editor."""
+	require_jarvis_admin()
+	current_users = frappe.get_all(
+		ALLOWED_USER,
+		filters={"parenttype": LISTING, "parentfield": "allowed_users", "parent": agent_slug},
+		order_by="idx asc",
+		pluck="user",
+	)
+	res = set_agent_access(agent_slug, roles=roles, users=current_users)
+	return {"ok": True, "allowed_roles": res["allowed_roles"]}
+
+
+@frappe.whitelist()
+def search_users(q: str | None = None) -> list[dict]:
+	"""Enabled, named users matching ``q`` for the admin Access picker.
+
+	Jarvis Admin / System Manager: the endpoint enumerates the tenant's people, so
+	it carries the same gate as the editor it feeds. Capped at 20 rows — it backs a
+	type-ahead, not a directory export. Administrator/Guest are excluded because
+	``set_agent_access`` refuses them anyway, and offering an option the save
+	rejects is worse than not offering it."""
+	require_jarvis_admin()
+	term = (q or "").strip()
+	filters = {"enabled": 1, "name": ("not in", ["Administrator", "Guest"])}
+	or_filters = {"name": ("like", f"%{term}%"), "full_name": ("like", f"%{term}%")} if term else None
+	return frappe.get_all(
+		"User",
+		filters=filters,
+		or_filters=or_filters,
+		fields=["name", "full_name"],
+		order_by="full_name asc, name asc",
+		limit=20,
+	)
 
 
 @frappe.whitelist()
@@ -470,7 +742,16 @@ def set_listing_status(agent_slug: str, status: str) -> dict:
 	# mutation re-dirtied the flag. Only on an actual change, and only when some
 	# install would have carried the slug: a status flip on an agent nobody enabled
 	# pushes exactly the same payload.
-	if before != doc.status and frappe.db.exists(INSTALLATION, {"agent": doc.name, "enabled": 1}):
+	# jarvis#1062: the roster is no longer "enabled installs" alone — an ALLOWED
+	# listing ships even with zero installs — so a status flip on an allowed but
+	# uninstalled agent also moves the container roster. Without widening this the
+	# #457 bug returns in a new shape: the SPA shows no "Apply pending" and the
+	# roster silently disagrees with the DB until an unrelated mutation re-dirties.
+	if before != doc.status and (
+		frappe.db.exists(INSTALLATION, {"agent": doc.name, "enabled": 1})
+		or frappe.db.exists(ALLOWED_ROLE, {"parenttype": LISTING, "parent": doc.name})
+		or frappe.db.exists(ALLOWED_USER, {"parenttype": LISTING, "parent": doc.name})
+	):
 		_mark_catalog_dirty()
 	frappe.db.commit()
 	return {"ok": True, "status": doc.status}
@@ -497,6 +778,7 @@ def get_agent_admin_overview() -> dict:
 	]
 
 	roles_map = _allowed_roles_map()
+	users_map = _allowed_users_map()
 	installs_by_agent: dict[str, list[dict]] = {}
 	for i in frappe.get_all(
 		INSTALLATION,
@@ -563,6 +845,7 @@ def get_agent_admin_overview() -> dict:
 	)
 	for lst in listings:
 		lst["allowed_roles"] = roles_map.get(lst.name, [])
+		lst["allowed_users"] = users_map.get(lst.name, [])
 		lst["installs"] = installs_by_agent.get(lst.name, [])
 
 	return {"roles": roles, "listings": listings}
@@ -655,9 +938,9 @@ def _default_schedule_day_of_month(sched: dict) -> int | None:
 @require_jarvis_user
 def install_agent(agent_slug: str) -> dict:
 	"""Install a Published agent for the current user. The doctype validate()
-	enforces the per-owner cap + (owner, agent) uniqueness. Role-gated: a user
-	whose roles do not intersect the listing's allowed_roles is refused
-	server-side (System Manager always allowed)."""
+	enforces the per-owner cap + (owner, agent) uniqueness. Access-gated (deny by
+	default): a user an admin has not allowed for this agent — by role or by name —
+	is refused server-side (Jarvis Admin / System Manager always allowed)."""
 	listing = frappe.get_doc(LISTING, agent_slug)  # All-role read
 	me = frappe.session.user
 	# FIX 11: an agent runs AS a named user (run_as_user defaults to the installer),
@@ -665,9 +948,12 @@ def install_agent(agent_slug: str) -> dict:
 	# an actionable message instead of letting doc.insert() surface the raw validation
 	# throw ("Run-as user must be an existing, enabled, non-system user").
 	if me in ("Administrator", "Guest"):
-		frappe.throw(_("Log in as a named user, or map a run-as user — agents cannot run as Administrator."))
+		frappe.throw(_("Log in as a named user, or map a run-as user: agents cannot run as Administrator."))
 	if not _user_allowed_for_agent(listing, me):
-		frappe.throw(_("Your roles do not permit installing this agent."), frappe.PermissionError)
+		frappe.throw(
+			_("You do not have access to this agent. Ask your administrator."),
+			frappe.PermissionError,
+		)
 	if listing.status != "Published":
 		frappe.throw(_("This agent is not available to install."))
 	if frappe.db.exists(INSTALLATION, {"owner": me, "agent": listing.name}):
@@ -745,12 +1031,42 @@ def install_agent(agent_slug: str) -> dict:
 	return {"ok": True, "data": {"name": doc.name, "agent": listing.name}}
 
 
+def _check_installation_write(doc, ptype: str = "write") -> bool:
+	"""Who may mutate an installation: its OWNER, or a tenant admin (jarvis#1062).
+
+	The owner half is the DocType's ``if_owner`` row, enforced through
+	``check_permission`` exactly as before — ``get_doc`` alone does NOT enforce
+	``if_owner`` (S3).
+
+	The admin half is checked HERE, in app code, rather than being left to the
+	Jarvis Admin DocPerm row alone. That row exists and is correct (it is what a
+	tenant admin needs for Desk and generic REST), but ``check_permission`` is not
+	only a role check: ``get_doc_permissions`` also runs the document through
+	``has_user_permission``, so on a site where anything has created a User
+	Permission touching this doctype's link fields, a legitimate admin is refused
+	for a reason that has nothing to do with agent access. An admin's authority to
+	disable, stop or uninstall a runaway install should not be contingent on that,
+	so it is stated directly.
+
+	Returns True when the ADMIN half authorised the call. The caller needs that:
+	``doc.save()`` and ``frappe.delete_doc()`` re-run the very check we just
+	bypassed, so an admin authorised here would be refused a line later. Passing
+	``ignore_permissions`` on that write is safe precisely because authority has
+	already been established, in the open, right here - the same reasoning
+	``promote_installation`` uses.
+	"""
+	if has_jarvis_admin_access():
+		return True
+	doc.check_permission(ptype)
+	return False
+
+
 @frappe.whitelist()
 def set_enabled(installation: str, enabled: int) -> dict:
 	"""Enable/disable an installed agent — a pure DB write (O6: NO restart; the
 	bundle only reaches the container on the next Apply)."""
 	doc = frappe.get_doc(INSTALLATION, installation)
-	doc.check_permission("write")  # S3 owner-gate
+	via_admin = _check_installation_write(doc)  # S3 owner-gate, or a tenant admin
 	# R5-J8: never enable a non-installable capability (a min_apps dependency
 	# absent at install, or one that vanished after install and was reconciled to
 	# installable=0). Disabling is always allowed.
@@ -758,9 +1074,15 @@ def set_enabled(installation: str, enabled: int) -> dict:
 		from jarvis.chat.agent_installability import assert_installable
 
 		assert_installable(doc.agent)
+	before = int(doc.enabled or 0)
 	doc.enabled = int(enabled or 0)
-	doc.save()
-	_mark_catalog_dirty()
+	doc.save(ignore_permissions=via_admin)
+	# jarvis#1062 polish: only an ACTUAL flip changes the pushed bundle set - a
+	# no-op call (already-enabled row re-enabled, e.g. a stale/duplicate toggle)
+	# must not dirty the catalog and nag the SPA's leave-guard over nothing.
+	# Mirrors set_listing_status's before/after check above.
+	if before != doc.enabled:
+		_mark_catalog_dirty()
 	log_activity(
 		agent=doc.agent,
 		agent_title=frappe.db.get_value(LISTING, doc.agent, "title"),
@@ -781,7 +1103,10 @@ def set_schedule(
 	schedule_day_of_month: int | None = None,
 ) -> dict:
 	"""Set an installed agent's audit schedule — pure DB write (O6: no restart).
-	Recomputes ``next_run_at`` when the schedule is enabled.
+	Recomputes ``next_run_at`` when the schedule is enabled; CLEARS it when the
+	schedule is turned off (jarvis#1062 E2E defect: it previously kept the last
+	computed value, so the Configure tab kept showing a stale "Next run: ..."
+	after disabling the schedule).
 
 	``schedule_weekday``/``schedule_day_of_month`` (#653) are the weekly/monthly
 	anchors - optional, and only meaningful for their own frequency; the doctype's
@@ -818,6 +1143,8 @@ def set_schedule(
 			weekday=doc.schedule_weekday,
 			day_of_month=doc.schedule_day_of_month,
 		)
+	else:
+		doc.next_run_at = None
 	doc.save()
 	log_activity(
 		agent=doc.agent,
@@ -833,7 +1160,10 @@ def set_schedule(
 	frappe.db.commit()
 	return {
 		"ok": True,
-		"data": {"name": doc.name, "next_run_at": str(doc.next_run_at or "")},
+		"data": {
+			"name": doc.name,
+			"next_run_at": str(doc.next_run_at) if doc.next_run_at else None,
+		},
 	}
 
 
@@ -841,8 +1171,18 @@ def set_schedule(
 def set_config(installation: str, config: str) -> dict:
 	"""Persist an installed agent's engagement config JSON — a pure DB write
 	(O6: no restart; the delegate reads it on its installation on the next run).
-	Owner-gated (S3). Validates the payload is a JSON object (keys: benchmark_value,
-	percentage, engagement_risk_level, rounding_step, company, …)."""
+	Owner-gated (S3). Validates the payload is a JSON object.
+
+	Generic and agent-agnostic here on purpose — the SHAPE of "keys" is a
+	per-agent bundle contract, not a bench one (jarvis#1063: the shape lives
+	in each listing's ``config_keys``, dot-paths for a nested key). The
+	universal scope keys are flat top-level (company, fiscal_year, from_date,
+	to_date — agent_scope.py's ``_resolve``); close-auditor's materiality
+	inputs are nested under a top-level ``materiality`` object
+	(``materiality.benchmark_value`` / ``.percentage`` /
+	``.engagement_risk_level`` / ``.rounding_step`` — verified against
+	jarvis-agents/agents/close-auditor/evaluate.py's ``_materiality_pl_balance``,
+	the only bundle that reads any agent-specific config today)."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	doc.check_permission("write")  # S3 owner-gate
 	try:
@@ -984,7 +1324,7 @@ def uninstall_agent(installation: str) -> dict:
 	an Apply is now pending — but only when the install was ENABLED (a disabled
 	install was never in the pushed set, so removing it changes nothing)."""
 	doc = frappe.get_doc(INSTALLATION, installation)
-	doc.check_permission("delete")  # S3 owner-gate before touching linked rows
+	via_admin = _check_installation_write(doc, "delete")  # S3 owner-gate (or admin)
 	log_activity(
 		agent=doc.agent,
 		agent_title=frappe.db.get_value(LISTING, doc.agent, "title"),
@@ -1011,7 +1351,8 @@ def uninstall_agent(installation: str) -> dict:
 	_detach_last_seen_run(run_names)
 	for name in run_names:
 		frappe.delete_doc(RUN, name, ignore_permissions=True, force=True)
-	frappe.delete_doc(INSTALLATION, installation)  # honors if_owner
+	# honors if_owner for an owner; the admin path was authorised above.
+	frappe.delete_doc(INSTALLATION, installation, ignore_permissions=via_admin)
 	if doc.enabled:
 		_mark_catalog_dirty()
 	frappe.db.commit()
@@ -1065,7 +1406,7 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 	# helper.
 	if not _user_allowed_for_agent(doc.agent, run_as):
 		frappe.throw(
-			_("The run-as user's roles do not permit running this agent."),
+			_("The run-as user does not have access to this agent. Ask your administrator."),
 			frappe.PermissionError,
 		)
 	if not doc.enabled:
@@ -1130,7 +1471,7 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 		except ValueError as e:
 			frappe.throw(
 				_(
-					"Select which custom apps this run may read before starting it — {0}. "
+					"Select which custom apps this run may read before starting it: {0}. "
 					"Their source code is sent to the configured AI model provider."
 				).format(str(e))
 			)
@@ -1146,11 +1487,9 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 	# against. Checked before dispatch; a plain COUNT, identity-agnostic.
 	over, why = _over_run_budget(installation)
 	if over:
+		# #1062 polish: one sentence, one action - an admin can raise it now.
 		frappe.throw(
-			_(
-				"Monthly agent-run budget reached ({0}). Runs resume next month, or an "
-				"admin can raise the budget in Jarvis Settings."
-			).format(why)
+			_("Monthly agent-run budget reached ({0}); an admin can raise it in Jarvis Settings.").format(why)
 		)
 
 	# Fail-closed identity guard: refuse to run an audit AS Administrator / Guest /
@@ -1227,7 +1566,7 @@ def _guard_run_control(run_doc) -> None:
 	``_record_failed`` skip row) falls back to the run's own ``if_owner`` read gate,
 	which is still an ownership check — ``get_doc`` alone enforces neither."""
 	if run_doc.installation and frappe.db.exists(INSTALLATION, run_doc.installation):
-		frappe.get_doc(INSTALLATION, run_doc.installation).check_permission("write")
+		_check_installation_write(frappe.get_doc(INSTALLATION, run_doc.installation))
 		return
 	run_doc.check_permission("read")
 
@@ -1471,16 +1810,49 @@ def _rehome_installation_outputs(inst, to_owner: str) -> None:
 		frappe.db.set_value(ACTIVITY, an, "owner", to_owner, update_modified=False)
 
 
+def _require_activation_authority(user: str) -> None:
+	"""Who may promote an installation to live, or demote it back to shadow.
+
+	The REVIEWER SET (Jarvis Skill Reviewer / Jarvis Admin / System Manager), not
+	the installation's named ``reviewer`` field. jarvis#1062 removed the
+	self-sign-off leg: ``install_agent`` stamps ``reviewer = me``, so "the named
+	reviewer may promote" meant every installer could promote their OWN install to
+	live, unreviewed — the exact rubber stamp the PP-4 shadow period exists to
+	prevent. Promotion is now an act by someone with a reviewing role, and the
+	SPA hides the control (and the whole shadow/attestation vocabulary) from
+	everyone else.
+
+	``promoted_by``/``promoted_at`` still record WHO signed off, and the
+	installation's ``reviewer`` field still names who is accountable for it; only
+	the authority to flip the switch changed.
+
+	This is the ONLY gate on promote/demote, deliberately: it is the same set
+	``apply_agents`` requires, and like that endpoint it is NOT additionally
+	stacked under a Jarvis User check. A reviewer may hold Jarvis Skill Reviewer
+	and nothing else - reviewing is a job, not a seat on the chat surface - and
+	requiring Jarvis User as well would lock exactly that person out of the one
+	action the role exists for. The earlier worry it would have addressed (a user
+	whose Jarvis access was revoked keeping authority through the ``reviewer``
+	field) is moot now that authority comes from a reviewing ROLE, which is
+	revoked the same way any other role is."""
+	if not (is_skill_reviewer(user) or has_jarvis_admin_access(user)):
+		frappe.throw(
+			_("Only a reviewer or a Jarvis Admin may change an installation's activation state."),
+			frappe.PermissionError,
+		)
+
+
 @frappe.whitelist()
 def promote_installation(installation: str, justification: str | None = None) -> dict:
-	"""PP-4 — promote a shadow installation to LIVE by the named reviewer's explicit
+	"""PP-4 — promote a shadow installation to LIVE on a reviewer's explicit
 	sign-off. This is the SINGLE choke point PP-4 (calibration) and PP-6 (budget)
 	both enforce:
 
-	  * Authority: the named ``reviewer`` (their sign-off), or an authorised approver
-	    (Jarvis Admin / System Manager). NOT the owner surface — ``check_permission``
-	    gates on ``if_owner`` and the reviewer may not be the owner, so authority is
-	    checked explicitly here.
+	  * Authority: the reviewer set (Jarvis Skill Reviewer / Jarvis Admin / System
+	    Manager) — see ``_require_activation_authority``. NOT the owner surface
+	    (``check_permission`` gates on ``if_owner``, and the owner is precisely who
+	    must not sign off on their own install), and no longer the named
+	    ``reviewer`` field on its own.
 	  * PP-6 budget: refuse when this customer already has ``activation_module_ceiling``
 	    live modules (global across all packs, per customer; default 1).
 	  * Records who/when (``promoted_by``/``promoted_at``, track_changes audited) and
@@ -1491,11 +1863,7 @@ def promote_installation(installation: str, justification: str | None = None) ->
 
 	doc = frappe.get_doc(INSTALLATION, installation)
 	me = frappe.session.user
-	if me != doc.reviewer and not has_jarvis_admin_access(me):
-		frappe.throw(
-			_("Only the named reviewer or a Jarvis Admin may promote this installation to live."),
-			frappe.PermissionError,
-		)
+	_require_activation_authority(me)
 	if doc.activation_state == "live":
 		frappe.throw(_("This installation is already live."))
 
@@ -1511,7 +1879,7 @@ def promote_installation(installation: str, justification: str | None = None) ->
 	with redis_lock(f"jarvis_agent_activation:{owner}", timeout_s=30, blocking_timeout_s=10.0) as acquired:
 		if not acquired:
 			frappe.throw(
-				_("Another activation change for this customer is in progress — please retry in a moment.")
+				_("Another activation change for this customer is in progress. Please retry in a moment.")
 			)
 		frappe.db.commit()  # fresh snapshot under the lock (defeats stale REPEATABLE-READ count)
 		doc = frappe.get_doc(INSTALLATION, installation)  # re-read the row under the lock
@@ -1521,12 +1889,13 @@ def promote_installation(installation: str, justification: str | None = None) ->
 		ceiling = _activation_ceiling(owner)
 		live_count = frappe.db.count(INSTALLATION, {"owner": owner, "activation_state": "live"})
 		if live_count >= ceiling:
+			# #1062 polish: one sentence, one action - no UI exists to raise the
+			# ceiling, so don't point at one; demoting a live module is the actual
+			# available action.
 			frappe.throw(
 				_(
-					"Activation budget reached: this customer already has {0} live module(s) and the "
-					"activation ceiling is {1}. The initial budget is a single live module; a Jarvis Admin "
-					"can raise the ceiling to {2} once the reviewer covers a second pack."
-				).format(live_count, ceiling, _ACTIVATION_CEILING_MAX)
+					"Activation budget reached ({0} of {1} live); demote a module before promoting another."
+				).format(live_count, ceiling)
 			)
 
 		doc.activation_state = "live"
@@ -1569,16 +1938,12 @@ def promote_installation(installation: str, justification: str | None = None) ->
 def demote_installation(installation: str, reason: str | None = None) -> dict:
 	"""PP-4 — the demotion / kill path: send a live installation back to SHADOW
 	(re-closing the owner surface, freeing a global activation-budget slot). Same
-	authority as promotion (named reviewer or a Jarvis Admin). Clears the promotion
+	authority as promotion (the reviewer set). Clears the promotion
 	stamp and re-homes outputs back to the reviewer-only surface; audited via
 	track_changes + the activity feed."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	me = frappe.session.user
-	if me != doc.reviewer and not has_jarvis_admin_access(me):
-		frappe.throw(
-			_("Only the named reviewer or a Jarvis Admin may demote this installation."),
-			frappe.PermissionError,
-		)
+	_require_activation_authority(me)
 	if doc.activation_state != "live":
 		frappe.throw(_("This installation is not live."))
 	doc.activation_state = "shadow"
@@ -1682,6 +2047,10 @@ _RUN_LIST_FIELDS = [
 	# findings count; empty/0 for auditor/operator runs.
 	"pages_written",
 	"pages_json",
+	# PP-4 shadow/preview pill + attestation banner (AgentRunsBoard.vue) and the
+	# "Open dashboard" action (FindingsPanel.vue) both key off these.
+	"preparation_mode",
+	"dashboard",
 ]
 
 
@@ -1916,6 +2285,67 @@ def list_findings(
 	}
 
 
+#: Hard ceiling on one run's timeline. A run makes tens of tool calls, not
+#: hundreds; the cap exists so a pathological (or looping) run can never make the
+#: SPA's 5s poll expensive. The UI polls the whole list, so there is no cursor.
+RUN_STEPS_CAP = 200
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def list_run_steps(run: str) -> dict:
+	"""One run's STEP TIMELINE, oldest first: ``{steps, count}``.
+
+	Steps are what the bench OBSERVED the run do - the launch dispatch, each
+	``jarvis__*`` tool call the delegate made over its own session bearer, and the
+	findings writeback. They carry shapes, never row contents (see
+	``jarvis.chat.agent_run_steps``), so they are safe to render wherever the run
+	itself is.
+
+	Gated exactly like :func:`list_findings`: the raw ``get_value`` below bypasses
+	permissions, so a run the caller neither owns nor administers returns an EMPTY
+	timeline - identical to an unknown run, never an existence oracle.
+
+	Ordered by ``occurred_at`` (``creation`` breaks the tie), and the ``seq`` in
+	the RESPONSE is renumbered 1..n over that order. The stored ``seq`` is written
+	unlocked by ``record_step`` - a delegate firing tool calls in parallel reads
+	the same MAX(seq) twice and both rows land on the same number (observed live:
+	2,2,2 then 3,3). Putting a write barrier on the hot path of every plugin tool
+	call to order a decoration is the wrong trade, so the ordering contract lives
+	HERE instead, where it costs nothing and duplicates can never reach the UI."""
+	empty: dict = {"steps": [], "count": 0}
+	if not run:
+		return empty
+	me = frappe.session.user
+	run_row = frappe.db.get_value(RUN, run, ["name", "owner"], as_dict=True)
+	if not run_row:
+		return empty
+	if run_row.owner != me and not has_jarvis_admin_access(me):
+		return empty
+	steps = frappe.get_all(
+		RUN_STEP,
+		filters={"run": run_row.name},
+		fields=[
+			"name",
+			"seq",
+			"kind",
+			"tool",
+			"label",
+			"detail",
+			"status",
+			"duration_ms",
+			"occurred_at",
+			"creation",
+		],
+		order_by="occurred_at asc, creation asc",
+		limit_page_length=RUN_STEPS_CAP,
+		ignore_permissions=True,
+	)
+	for position, step in enumerate(steps, start=1):
+		step["seq"] = position
+	return {"steps": steps, "count": len(steps)}
+
+
 @frappe.whitelist()
 def set_finding_state(finding: str, state: str) -> dict:
 	"""Move a finding to open/acknowledged/resolved. Owner-gated (S3)."""
@@ -1942,7 +2372,10 @@ def list_agent_activity_page(
 	``{rows, total, has_more, start, page_length}``). Activity rows are
 	Link-free Data snapshots, so the feed survives the uninstall cascade —
 	``agent`` filters on the slug snapshot, ``action`` on the lifecycle verb.
-	Search matches agent_title/detail (LIKE-escaped)."""
+	Search matches agent_title/detail (LIKE-escaped). Each row also carries a
+	live-joined ``run_status`` (the named run's CURRENT status, not the
+	action verb's point-in-time label; ``None`` when the row names no run or
+	that run no longer exists)."""
 	me = frappe.session.user
 	start, pl = _clamp_page(start, page_length)
 	filters: dict = {"owner": me}
@@ -1974,6 +2407,23 @@ def list_agent_activity_page(
 		limit_start=start,
 		limit_page_length=pl,
 	)
+	# jarvis#1062: the action verb ("Run started") is a point-in-time label
+	# stamped when the row was written; the row's CURRENT run status (a
+	# "Run started" row whose run later failed) is a live join, not baked
+	# into the snapshot - one batched query for the whole page, never per
+	# row. A row whose run has since been deleted (or that names no run at
+	# all - every non-run action) gets run_status: None, so the SPA renders
+	# no badge rather than a stale or invented one.
+	run_names = {r["run"] for r in rows if r.get("run")}
+	status_by_run = {}
+	if run_names:
+		status_by_run = {
+			d.name: d.status
+			for d in frappe.get_all(RUN, filters={"name": ["in", list(run_names)]}, fields=["name", "status"])
+		}
+	for r in rows:
+		r["run_status"] = status_by_run.get(r["run"]) if r.get("run") else None
+
 	return {
 		"rows": rows,
 		"total": total,
@@ -1996,17 +2446,14 @@ def take_finding_to_chat(finding: str) -> dict:
 	doc = frappe.get_doc(FINDING, finding)
 	doc.check_permission("read")  # S3 owner-gate (owner via if_owner, or SM)
 
-	from jarvis.chat.api import send_message
+	from jarvis.chat.api import CONV, MSG, send_message
 
 	title = (doc.title or doc.rule_id or "finding").strip()
 	conv = frappe.get_doc(
 		{
-			"doctype": "Jarvis Conversation",
+			"doctype": CONV,
 			"title": f"Finding: {title}"[:140],
 			"status": "Active",
-			# Opened by the act-on-a-finding button with a pre-filled prompt, not
-			# by the user starting a chat - excluded from the session popup.
-			"agent_initiated": 1,
 		}
 	)
 	conv.insert()  # owned by the current user; respects perms
@@ -2031,8 +2478,25 @@ def take_finding_to_chat(finding: str) -> dict:
 		"documents or remediation steps the data does not support."
 	)
 	res = send_message(conversation=conv.name, message="\n".join(parts))
+	if not res.get("ok"):
+		# jarvis#1062 polish: the conversation above is committed BEFORE the seed
+		# is attempted, so a validate_can_send failure (no model configured, over
+		# quota, ...) left an orphaned, empty "Finding: ..." conversation behind on
+		# every failed click. Clean it up - and any partial seed message, belt-
+		# and-suspenders: send_message's own overload-race path already deletes
+		# its own Message row before returning ok:False - so a failed seed leaves
+		# no trace, mirroring filebox._cascade's cleanup shape.
+		frappe.db.delete(MSG, {"conversation": conv.name})
+		frappe.delete_doc(CONV, conv.name, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		return {
+			"ok": False,
+			"conversation": None,
+			"run_id": res.get("run_id"),
+			"reason": res.get("reason"),
+		}
 	return {
-		"ok": bool(res.get("ok")),
+		"ok": True,
 		"conversation": conv.name,
 		"run_id": res.get("run_id"),
 		"reason": res.get("reason"),
@@ -2097,6 +2561,23 @@ def apply_agents() -> dict:
 	from jarvis.permissions import require_skill_reviewer
 
 	require_skill_reviewer()
+	return _enqueue_apply()
+
+
+def _enqueue_apply() -> dict:
+	"""The apply pipeline itself, WITHOUT the authority check.
+
+	Split out of ``apply_agents`` so ``set_agent_access`` can offer "save the
+	access change and make it runnable" as ONE action, without re-implementing the
+	enqueue. Re-implementing it would drift: the deduped ``job_id``, the
+	inline-in-test flag, the pending stamp and the synchronous payload build (which
+	is what surfaces a size/cap error to the caller instead of burying it in a job)
+	all have to match exactly, and a second copy is where that stops being true.
+
+	Every caller MUST establish authority first — ``apply_agents`` via
+	``require_skill_reviewer``, ``set_agent_access`` via ``require_jarvis_admin``,
+	which is a strict SUBSET of the reviewer set (JARVIS_REVIEWER_ROLES contains
+	Jarvis Admin and System Manager), so the admin path grants nothing new."""
 	_rate_limit_apply()
 	payload = build_agent_push_payload()
 	frappe.db.set_single_value(_SETTINGS, "agent_skills_sync_status", "pending: applying agents")
@@ -2127,7 +2608,7 @@ def _rate_limit_apply() -> None:
 	me = frappe.session.user
 	key = f"jarvis_apply_agents_rl:{me}"
 	if frappe.cache().get_value(key, expires=True):
-		frappe.throw(_("An apply is already in progress — please wait a moment."))
+		frappe.throw(_("An apply is already in progress. Please wait a moment."))
 	frappe.cache().set_value(key, "1", expires_in_sec=5)
 
 

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -47,6 +47,13 @@ _PUSH_JOB_ID = "jarvis_agent_skills_push"
 _LOCK_NAME = "jarvis_agent_skills_push"
 
 _FREQUENCIES = ("daily", "weekly", "monthly")
+# #1061: every value the Jarvis Agent Run ``status`` Select accepts — the one list the
+# SPA's run-history filter is validated against. ``stopped`` is TERMINAL (an operator
+# ended the run early); it is deliberately NOT a synonym for ``failed``, because a
+# stopped run is neither a delegate fault nor a duration timeout and must not be
+# reported to the customer as either. Keep in lockstep with the DocType's Select
+# options — a value missing here is a filter the Runs page silently refuses.
+_RUN_STATUSES = ("running", "completed", "partial", "failed", "stopped")
 # Statuses a bench admin may set via set_listing_status (Draft is registry-only).
 _ADMIN_STATUSES = ("Published", "Coming Soon", "Deprecated")
 # Never meaningful as an agent restriction ("All" == unrestricted; the other two
@@ -1206,6 +1213,138 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# #1061 — the operator's soft stop
+# --------------------------------------------------------------------------- #
+def _guard_run_control(run_doc) -> None:
+	"""Who may STOP a run: exactly who may START one.
+
+	Deliberately NOT ``run_doc.check_permission("write")``. Jarvis User holds READ
+	ONLY (``if_owner``) on Jarvis Agent Run — the rows are server-owned, and granting
+	write so the owner could stop one would also let any customer rewrite a run's
+	status, error and result by hand, which is the audit trail. So the gate is the one
+	``run_agent_now`` already uses: WRITE on the run's own Jarvis Agent Installation
+	(its owner, or a System Manager). A run with no installation (a legacy row, or a
+	``_record_failed`` skip row) falls back to the run's own ``if_owner`` read gate,
+	which is still an ownership check — ``get_doc`` alone enforces neither."""
+	if run_doc.installation and frappe.db.exists(INSTALLATION, run_doc.installation):
+		frappe.get_doc(INSTALLATION, run_doc.installation).check_permission("write")
+		return
+	run_doc.check_permission("read")
+
+
+def _try_abort_gateway_session(session_key: str | None, run: str) -> None:
+	"""Best-effort hard abort of the delegate's gateway session. NEVER raises.
+
+	The soft stop (the terminal row + the revoked session bearer) is the guarantee;
+	this is the opportunistic other half. Mirrors ``chat/api.stop_run``'s abort — the
+	same ``agent_session_pool`` checkout against the same Settings gateway URL.
+
+	EXPECTED TO BE A NO-OP TODAY, on purpose: an agent run is dispatched container-side
+	as ``gateway call agent --expect-final`` on the cron lane, not as an interactive chat
+	session, so the gateway most likely has no abortable chat turn under this key and
+	answers with an error we swallow. It is wired anyway because it costs one bounded
+	call, it is the correct thing the moment the run lane grows an abort verb, and the
+	stop is already complete without it."""
+	key = (session_key or "").strip()
+	if not key:
+		return
+	try:
+		settings = frappe.get_cached_doc(_SETTINGS)
+		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
+		if not gateway_url:
+			return
+		from jarvis.chat import agent_session_pool
+
+		with agent_session_pool.checkout(gateway_url) as sess:
+			sess.chat_abort(key, run)
+	except Exception:
+		# Deliberately the LOGGER, not frappe.log_error. Failing here is the DOCUMENTED
+		# expected outcome described above, so an Error Log row would be written on
+		# essentially every stop — training operators to ignore the one surface where a
+		# real fault would show. The stop itself is already complete and committed.
+		frappe.logger("jarvis.agents").info(
+			f"stop gateway abort did not land for run {run} (run stays stopped): {frappe.get_traceback()}"
+		)
+
+
+@frappe.whitelist()
+def stop_agent_run(run: str) -> dict:
+	"""Stop a RUNNING agent run: terminalize it ``stopped``, revoke its session bearer
+	and best-effort abort its gateway session. Idempotent on an already-terminal run.
+
+	Before this, a dispatched run the delegate never finalized (a dead container, a
+	stale roster, a wedged turn) had no operator exit at all: it sat ``running`` for
+	three hours, held the installation's #672 liveness guard so no further run could
+	start, and was finally relabelled by the reaper as a duration timeout it never hit
+	(jarvis#1058).
+
+	Same concurrency discipline as ``agent_scheduler.fail_run``: commit first so the
+	``FOR UPDATE`` opens a fresh read view, then a COMPARE-AND-SET on
+	``status='running'`` under the row lock. That ordering is what makes a stop WIN
+	over a later fleet flip — ``poll_dispatched_runs`` and the reaper both re-read
+	under the same lock and transition only from ``running``, so neither can overwrite
+	a stopped row, and ``record_agent_run``'s writeback is already inert on a run that
+	is not ``running``.
+
+	SLOT PARITY (#672): stopping does NOT hand the schedule slot back. ``_claim_slot``
+	consumed the installation's ``next_run_at``/``last_run_at`` BEFORE the dispatch,
+	and neither the reaper nor ``_terminalize_failed`` ever unclaims it — a run that
+	really started spent its slot, and resurrecting it here would re-dispatch the same
+	slot on the next hourly tick. The A14 monthly BUDGET is a separate ledger and
+	deliberately differs from ``failed``: ``_runs_this_month`` excludes only ``failed``
+	rows (because every skip path writes one, which would make the cap
+	self-perpetuating), and that reasoning does not extend to an operator act. A
+	stopped run really did occupy the container, so it COUNTS — otherwise
+	start-then-stop would be an unlimited free-run loop around the budget."""
+	doc = frappe.get_doc(RUN, run)
+	_guard_run_control(doc)
+
+	frappe.db.commit()  # REPEATABLE-READ discipline: FOR UPDATE goes first
+	row = frappe.db.get_value(
+		RUN,
+		run,
+		["status", "session_key", "agent", "installation", "owner"],
+		as_dict=True,
+		for_update=True,
+	)
+	if not row:
+		frappe.db.commit()
+		frappe.throw(_("That run no longer exists."), frappe.DoesNotExistError)
+	if row.status != "running":
+		# Already terminal — a concurrent finish, reap or a second click. Release the
+		# row lock and report the state it actually reached; never overwrite it.
+		frappe.db.commit()
+		return {"ok": True, "status": row.status, "idempotent": True}
+
+	stop_error = _("Stopped by operator.")
+	frappe.db.set_value(
+		RUN,
+		run,
+		{"status": "stopped", "finished_at": frappe.utils.now(), "error": stop_error[:140]},
+		update_modified=False,
+	)
+	frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
+	# The session bearer must not outlive the run: with the row gone the delegate's
+	# late jarvis__* calls (record_agent_run included) resolve no identity and 401,
+	# so nothing it does after this can write back onto the stopped run.
+	from jarvis.chat import agent_runs
+
+	agent_runs.teardown_run_session(row.session_key)
+	_try_abort_gateway_session(row.session_key, run)
+	log_activity(
+		agent=row.agent,
+		agent_title=frappe.db.get_value(LISTING, row.agent, "title") if row.agent else "",
+		installation=row.installation,
+		action="run_stopped",
+		run=run,
+		detail=f"stopped by {frappe.session.user}",
+		owner=row.owner,
+	)
+	frappe.db.commit()
+	return {"ok": True, "status": "stopped"}
+
+
+# --------------------------------------------------------------------------- #
 # PP-4 shadow activation + PP-6 global activation budget
 # --------------------------------------------------------------------------- #
 def _has_ceiling_grant(customer: str) -> bool:
@@ -1602,7 +1741,7 @@ def list_runs_page(
 	if agent:
 		filters["agent"] = agent
 	if status:
-		if status not in ("running", "completed", "partial", "failed"):
+		if status not in _RUN_STATUSES:
 			frappe.throw(_("Invalid status filter."))
 		filters["status"] = status
 	or_filters = []

--- a/jarvis/chat/docmeta_api.py
+++ b/jarvis/chat/docmeta_api.py
@@ -47,9 +47,20 @@ ALLOWED_DOCTYPES = {
 	"Jarvis Macro",
 	"Jarvis Approval Request",
 	"Jarvis Agent Installation",
+	# jarvis#1062 owner decision: Notes moved OFF the Configure tab (the
+	# installation) onto the Run itself (FindingsPanel.vue) - comments/notes
+	# only, not assignable/shareable (below) - a run is not a work-item to
+	# hand off, just something to leave a note on. `doc.owner` already
+	# resolves correctly here with NO extra gating logic: agent_scheduler.py's
+	# _launch_audit reassigns a Run's `owner` to the INSTALLATION owner at
+	# launch (never Administrator, never the run-as user), for both a manual
+	# and a scheduled run - the exact "owner/admin only" the UI asked for is
+	# already what `_get_gated` below enforces for every allowed doctype.
+	"Jarvis Agent Run",
 }
 # §14 DA-09 / F1: skills keep their child-table share model (it feeds the sync
-# pipeline); ToDo assignment + DocShare sharing are NOT offered on them.
+# pipeline); ToDo assignment + DocShare sharing are NOT offered on them. Runs
+# are comment-only too (see ALLOWED_DOCTYPES above) - deliberately absent here.
 ASSIGNABLE_DOCTYPES = {"Jarvis Macro", "Jarvis Approval Request", "Jarvis Agent Installation"}
 SHAREABLE_DOCTYPES = {"Jarvis Macro", "Jarvis Approval Request", "Jarvis Agent Installation"}
 

--- a/jarvis/chat/list_registry.py
+++ b/jarvis/chat/list_registry.py
@@ -494,6 +494,15 @@ NON_LIST_ENDPOINTS: dict[str, str] = {
 		"Dashboard Builder history menu: a capped, owner-scoped slice of dashboard-origin "
 		"threads for the pane's own dropdown, not a browsable document list"
 	),
+	# jarvis#1062: a type-ahead SOURCE for the admin Access editor's people picker,
+	# not a document list. It returns at most 20 {name, full_name} pairs for a
+	# substring, has no filter/sort/page contract, and is gated require_jarvis_admin
+	# — there is no list VIEW here to register, and giving it one would imply a
+	# browsable directory of the tenant's users that the product deliberately lacks.
+	"jarvis.chat.agents_api.search_users": (
+		"admin Access-editor people picker: a capped type-ahead over enabled users, "
+		"not a browsable document list"
+	),
 	"jarvis.chat.approvals_api.list_approvals": "unpaginated companion of approvals (list_approvals_page)",
 	"jarvis.chat.custom_skills_api.list_custom_skills": (
 		"composer '/' autocomplete feed for skills; unpaginated companion of the skills view"
@@ -539,6 +548,16 @@ NON_LIST_ENDPOINTS: dict[str, str] = {
 	"jarvis.chat.wiki.get_wiki_graph_history": (
 		"the edit-history feed of ONE wiki page — a per-document timeline, not a "
 		"collection (the chat equivalent of a form's version history)"
+	),
+	# jarvis#1062: the live step timeline of ONE agent run, rendered inside that
+	# run's own panel. The same shape as get_wiki_graph_history above — a
+	# per-document timeline read whole (capped at RUN_STEPS_CAP, ordered by the
+	# run's own `seq`), with no filter, sort or page contract to migrate. The
+	# browsable agent surfaces are the registered agent_runs / agent_findings /
+	# agent_activity views.
+	"jarvis.chat.agents_api.list_run_steps": (
+		"the step timeline of ONE agent run — a per-document timeline read whole, "
+		"not a filterable document-list view"
 	),
 	"jarvis.chat.triggers_api.activity_stats": (
 		"aggregate counters over Trigger Activity (a stats rollup), not a row "

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -292,6 +292,14 @@ scheduler_events = {
 			# scheduler (a live scheduler that fails to POST = the tenant went dark).
 			# Self-gating (skips un-onboarded), never raises. Cheap: two indexed reads.
 			"jarvis.chat.heartbeat.push_bench_heartbeat",
+			# #1061: ask the fleet what actually happened to each run the bench still
+			# believes is `running`, and terminalize the ones that are over with their
+			# REAL error. Without it the only source of a run's outcome was the
+			# delegate's own writeback, so a delegate that died after dispatch sat
+			# `running` for three hours (blocking every further run of that
+			# installation) before the reaper below mislabelled it a duration timeout.
+			# Cheap no-op (one indexed status query) when nothing is in flight.
+			"jarvis.chat.agent_scheduler.poll_dispatched_runs",
 		],
 		"*/2 * * * *": [
 			"jarvis.chat.turn_recovery.recover_pending_turns",

--- a/jarvis/jarvis/doctype/jarvis_agent_activity/jarvis_agent_activity.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_activity/jarvis_agent_activity.json
@@ -37,7 +37,7 @@
    "fieldname": "action",
    "fieldtype": "Select",
    "label": "Action",
-   "options": "installed\nuninstalled\nenabled\ndisabled\nschedule_changed\nconfig_changed\nrun_as_changed\nrun_started\nrun_completed\nrun_partial\nrun_failed",
+   "options": "installed\nuninstalled\nenabled\ndisabled\nschedule_changed\nconfig_changed\nrun_as_changed\nrun_started\nrun_completed\nrun_partial\nrun_failed\nrun_stopped",
    "reqd": 1,
    "in_list_view": 1,
    "in_standard_filter": 1

--- a/jarvis/jarvis/doctype/jarvis_agent_allowed_user/jarvis_agent_allowed_user.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_allowed_user/jarvis_agent_allowed_user.json
@@ -1,0 +1,22 @@
+{
+  "doctype": "DocType",
+  "name": "Jarvis Agent Allowed User",
+  "module": "Jarvis",
+  "istable": 1,
+  "custom": 0,
+  "engine": "InnoDB",
+  "field_order": [
+    "user"
+  ],
+  "fields": [
+    {
+      "fieldname": "user",
+      "fieldtype": "Link",
+      "label": "User",
+      "options": "User",
+      "reqd": 1,
+      "in_list_view": 1
+    }
+  ],
+  "permissions": []
+}

--- a/jarvis/jarvis/doctype/jarvis_agent_allowed_user/jarvis_agent_allowed_user.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_allowed_user/jarvis_agent_allowed_user.py
@@ -1,0 +1,15 @@
+"""Jarvis Agent Allowed User — child rows of ``Jarvis Agent Listing.allowed_users``.
+
+One named User per row, the per-person half of the deny-by-default access model
+(jarvis#1062): access is granted to ROLES (``allowed_roles``) and/or to NAMED
+USERS (this table), and a listing with NEITHER is reachable by admins only.
+
+Bench-admin state set via ``agents_api.set_agent_access`` and by the one-time
+grandfather patch; the catalog sync never writes it.
+"""
+
+from frappe.model.document import Document
+
+
+class JarvisAgentAllowedUser(Document):
+	pass

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
@@ -211,7 +211,7 @@
  ],
  "index_web_pages_for_search": 0,
  "links": [],
- "modified": "2026-07-25 10:00:00.000000",
+ "modified": "2026-09-02 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Jarvis",
  "name": "Jarvis Agent Installation",
@@ -239,8 +239,10 @@
    "write": 1
   },
   {
+   "delete": 1,
    "read": 1,
-   "role": "Jarvis Admin"
+   "role": "Jarvis Admin",
+   "write": 1
   }
  ],
  "sort_field": "modified",

--- a/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
@@ -17,6 +17,7 @@
   "status",
   "tools_required",
   "doctypes_required",
+  "config_keys",
   "rule_tokens",
   "min_apps",
   "rule_pack",
@@ -24,7 +25,8 @@
   "skill_bundle",
   "default_schedule",
   "validated_for_fy",
-  "allowed_roles"
+  "allowed_roles",
+  "allowed_users"
  ],
  "fields": [
   {
@@ -103,6 +105,12 @@
    "description": "JSON array of DocTypes the run-as user MUST hold read on for this agent's aggregates to be numerically correct (A12). Checked at install/validate against the mapped run_as_user (fail-closed on a missing read). Declared here so it is checkable without leaking rule shape."
   },
   {
+   "fieldname": "config_keys",
+   "fieldtype": "Small Text",
+   "label": "Config Keys (JSON)",
+   "description": "JSON array of the agent-specific installation config keys this agent's bundle actually reads (jarvis#1063), as dot paths for a nested key - e.g. materiality.benchmark_value/materiality.percentage/materiality.engagement_risk_level/materiality.rounding_step for close-auditor (its evaluate.py reads them nested under a top-level materiality object). Excludes the universal scope keys (company/fiscal_year/from_date/to_date) every run receives regardless, which stay flat. Drives which agent-specific fields ConfigForm.vue renders; [] for an agent with none."
+  },
+  {
    "fieldname": "rule_tokens",
    "fieldtype": "Small Text",
    "label": "Rule Tokens (JSON)",
@@ -150,12 +158,19 @@
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Roles",
    "options": "Jarvis Agent Allowed Role",
-   "description": "Roles allowed to install/run this agent. Empty = unrestricted (any user). System Manager is always allowed. Bench-admin state — NEVER written by the catalog sync."
+   "description": "Roles allowed to install/run this agent. Access is DENY BY DEFAULT: a listing with no allowed roles AND no allowed users is reachable by Jarvis Admins only. Bench-admin state, NEVER written by the catalog sync."
+  },
+  {
+   "fieldname": "allowed_users",
+   "fieldtype": "Table MultiSelect",
+   "label": "Allowed Users",
+   "options": "Jarvis Agent Allowed User",
+   "description": "Named users allowed to install/run this agent, on top of any allowed roles. Access is DENY BY DEFAULT: a listing with no allowed roles AND no allowed users is reachable by Jarvis Admins only. Bench-admin state, NEVER written by the catalog sync."
   }
  ],
  "index_web_pages_for_search": 0,
  "links": [],
- "modified": "2026-07-05 10:00:00.000000",
+ "modified": "2026-09-03 13:00:00.000000",
  "modified_by": "Administrator",
  "module": "Jarvis",
  "name": "Jarvis Agent Listing",

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
@@ -66,7 +66,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "running\ncompleted\npartial\nfailed",
+   "options": "running\ncompleted\npartial\nfailed\nstopped",
    "in_list_view": 1,
    "in_standard_filter": 1
   },

--- a/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.json
@@ -1,0 +1,113 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-09-02 09:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "run",
+  "seq",
+  "kind",
+  "tool",
+  "label",
+  "detail",
+  "status",
+  "duration_ms",
+  "occurred_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "run",
+   "fieldtype": "Data",
+   "label": "Run",
+   "search_index": 1,
+   "in_standard_filter": 1,
+   "description": "Run row name SNAPSHOT (Data, deliberately NOT a Link): the uninstall cascade hard-deletes installations, runs and findings, and this timeline must survive without LinkExistsError - exactly the rule Jarvis Agent Activity follows. Indexed: every read is 'the steps of ONE run'."
+  },
+  {
+   "fieldname": "seq",
+   "fieldtype": "Int",
+   "label": "Sequence",
+   "in_list_view": 1,
+   "description": "1-based position within the run. The timeline is ordered by this, not by creation - two steps recorded inside the same second must still read in the order they happened."
+  },
+  {
+   "fieldname": "kind",
+   "fieldtype": "Select",
+   "label": "Kind",
+   "options": "dispatched\ntool\nwriteback\nnote",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "tool",
+   "fieldtype": "Data",
+   "label": "Tool",
+   "description": "The bare bench tool name for a `tool` step (get_list, run_report, ...), blank for every other kind."
+  },
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "label": "Label",
+   "length": 140,
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "One short human sentence: what the agent did. DocType names, report names and counts only - never row contents."
+  },
+  {
+   "fieldname": "detail",
+   "fieldtype": "Small Text",
+   "label": "Detail",
+   "description": "Optional second line (capped server-side). Same rule as label: shapes and counts, never customer data."
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "ok\nerror",
+   "default": "ok",
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "duration_ms",
+   "fieldtype": "Int",
+   "label": "Duration (ms)"
+  },
+  {
+   "fieldname": "occurred_at",
+   "fieldtype": "Datetime",
+   "label": "Occurred At",
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-09-02 09:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Agent Run Step",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "if_owner": 1,
+   "read": 1,
+   "role": "Jarvis User"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "ASC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_run_step/jarvis_agent_run_step.py
@@ -1,0 +1,23 @@
+"""Jarvis Agent Run Step DocType controller.
+
+One append-only row per observable step of a ``Jarvis Agent Run``: the launch
+dispatch, every bench tool call the delegate made through the plugin endpoint,
+and the findings writeback. Together they are the run's live timeline - what the
+agent is doing right now, and what it did when the run is over.
+
+Like ``Jarvis Agent Activity``, every reference field is a Data SNAPSHOT and
+never a Link, so the uninstall cascade (which hard-deletes the installation, its
+runs and its findings) can never trip LinkExistsError here. Rows are
+server-generated, so ``Jarvis User`` gets ``if_owner`` READ only - the customer
+sees their own runs' steps and can neither forge nor edit one.
+
+Steps carry SHAPES, not data: DocType names, report names, counts. A step never
+records row contents, so the timeline is safe to render to anyone who may read
+the run.
+"""
+
+from frappe.model.document import Document
+
+
+class JarvisAgentRunStep(Document):
+	pass

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -53,5 +53,6 @@ jarvis.patches.v2_14_backfill_wiki_enabled
 jarvis.patches.v2_15_reset_removed_gemini_subscription
 jarvis.patches.v2_16_retire_support_roles
 jarvis.patches.v2_17_drop_auto_apply_changes
+jarvis.patches.v2_18_agent_access_grandfather
 jarvis.patches.v2_19_clear_retired_openai_subscription_pins
 jarvis.patches.v2_19_clear_chat_device_for_9_3_reprovision

--- a/jarvis/patches/v2_18_agent_access_grandfather.py
+++ b/jarvis/patches/v2_18_agent_access_grandfather.py
@@ -1,0 +1,139 @@
+"""Grandfather every EXISTING agent installation into the deny-by-default access model.
+
+jarvis#1062 inverts the ``Jarvis Agent Listing`` access default. An empty
+``allowed_roles`` table used to mean "unrestricted — everyone may install and
+run this"; it now means CLOSED (only a Jarvis Admin / System Manager gets
+through), and access is granted explicitly to roles and/or to named users.
+
+Every listing in the shipped registry declares ``default_allowed_roles: []``, so
+on a live tenant the inversion closes ALL of them at once. Without this patch the
+upgrade would silently break every install that works today: the owner would lose
+the catalog row, ``run_agent_now`` would refuse, ``_sweep_one`` would skip the
+scheduled dispatch, and ``build_agent_push_payload`` would drop the slug from the
+container roster on the next Apply.
+
+What it does: for every ``Jarvis Agent Installation``, add its ``owner`` and its
+``run_as_user`` (the EXECUTING identity — the one the run gates actually litigate,
+and frequently NOT the owner after an admin re-target) to that listing's
+``allowed_users``. Both identities are grandfathered because both are gated:
+the owner drives catalog visibility and install-surface reads, the run-as user
+drives dispatch and the push.
+
+Deliberately NARROW in three ways:
+
+  * Only identities that ALREADY have a working install are added. Nobody gains
+    access they did not effectively have a minute before the migrate.
+  * An identity already allowed BY ROLE is skipped — the role grant is the
+    stronger, more durable statement, and pinning the person by name as well
+    would silently outlive the role being revoked.
+  * ``Administrator`` and ``Guest`` are never added. They are refused as run-as
+    identities everywhere else in this app (``permissions.is_valid_run_as`` and
+    the installation controller), so naming them here would record an allowance
+    no dispatch path would ever honour.
+
+Idempotent: re-running adds nothing. Written with direct child-row inserts rather
+than ``doc.save()`` on the parent listing, for the same reason as
+``v2_12_backfill_role_skill_allowed_roles`` — re-saving a legacy listing would
+re-run its whole controller validate chain against rows that predate those rules,
+and a throw there would block the entire migrate for a backfill unrelated to it.
+"""
+
+import frappe
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+ALLOWED_ROLE = "Jarvis Agent Allowed Role"
+ALLOWED_USER = "Jarvis Agent Allowed User"
+
+# Never grantable as an agent identity — mirrors permissions.is_valid_run_as and
+# agents_api._NON_SELECTABLE_ROLES.
+_NEVER_GRANT = ("Administrator", "Guest")
+
+
+def execute():
+	if not (
+		frappe.db.table_exists(INSTALLATION)
+		and frappe.db.table_exists(LISTING)
+		and frappe.db.table_exists(ALLOWED_USER)
+	):
+		return
+	grandfather_existing_installs()
+
+
+def grandfather_existing_installs() -> dict:
+	"""The patch body, callable directly so a test can drive it. -> {"added": n}."""
+	installs = frappe.get_all(INSTALLATION, fields=["agent", "owner", "run_as_user"])
+	if not installs:
+		return {"added": 0}
+
+	# Which identities each listing already admits, in two queries rather than two
+	# per install row.
+	listings = sorted({i.agent for i in installs if i.agent})
+	roles_by_listing: dict[str, set[str]] = {name: set() for name in listings}
+	users_by_listing: dict[str, set[str]] = {name: set() for name in listings}
+	if frappe.db.table_exists(ALLOWED_ROLE):
+		for row in frappe.get_all(
+			ALLOWED_ROLE,
+			filters={"parenttype": LISTING, "parentfield": "allowed_roles", "parent": ("in", listings)},
+			fields=["parent", "role"],
+		):
+			roles_by_listing.setdefault(row.parent, set()).add(row.role)
+	for row in frappe.get_all(
+		ALLOWED_USER,
+		filters={"parenttype": LISTING, "parentfield": "allowed_users", "parent": ("in", listings)},
+		fields=["parent", "user"],
+	):
+		users_by_listing.setdefault(row.parent, set()).add(row.user)
+
+	# Existence for every candidate identity in ONE query. This used to be a
+	# frappe.db.exists per identity inside the loop, which the docstring's batching
+	# claim did not cover: on a tenant with many installs that is exactly the N+1
+	# the two queries above exist to avoid, and it runs during migrate.
+	candidates = {
+		(v or "").strip()
+		for inst in installs
+		for v in (inst.owner, inst.run_as_user)
+		if (v or "").strip() and (v or "").strip() not in _NEVER_GRANT
+	}
+	live_users = (
+		set(frappe.get_all("User", filters={"name": ("in", list(candidates))}, pluck="name"))
+		if candidates
+		else set()
+	)
+
+	roles_by_user: dict[str, set[str]] = {}
+	added = 0
+	for inst in installs:
+		listing = inst.agent
+		if not listing or listing not in roles_by_listing:
+			# A listing deleted out from under its install: there is nothing to grant
+			# access ON, and the install is already inert at every gate.
+			continue
+		for identity in (inst.owner, inst.run_as_user):
+			identity = (identity or "").strip()
+			if not identity or identity in _NEVER_GRANT:
+				continue
+			if identity in users_by_listing.get(listing, set()):
+				continue
+			if identity not in live_users:
+				# A deleted user would fail the child row's Link validation and break
+				# the whole migrate for a row nothing can dispatch anyway.
+				continue
+			if identity not in roles_by_user:
+				roles_by_user[identity] = set(frappe.get_roles(identity))
+			if roles_by_user[identity] & roles_by_listing.get(listing, set()):
+				continue  # already allowed by role — the stronger grant, leave it alone
+			frappe.get_doc(
+				{
+					"doctype": ALLOWED_USER,
+					"parenttype": LISTING,
+					"parentfield": "allowed_users",
+					"parent": listing,
+					"user": identity,
+				}
+			).insert(ignore_permissions=True)
+			users_by_listing.setdefault(listing, set()).add(identity)
+			added += 1
+	if added:
+		frappe.db.commit()
+	return {"added": added}

--- a/jarvis/tests/_agent_access.py
+++ b/jarvis/tests/_agent_access.py
@@ -1,0 +1,88 @@
+"""Shared fixture helper for the DENY-BY-DEFAULT agent access gate (jarvis#1062).
+
+Before this gate landed, a ``Jarvis Agent Listing`` with no ``allowed_roles``
+rows was reachable by everyone, so a test could install and run an agent as a
+plain user with no setup at all. It is now CLOSED until an admin allows it, and
+that flipped the default for every fixture in the suite: an install/run/sweep/
+push test acting as a non-admin has to say who is allowed FIRST.
+
+Kept here rather than in one test module because a dozen modules need it and the
+alternative is a dozen slightly different copies (the exact drift ``_role_guard``
+and ``_transport_helpers`` already exist to prevent). Writes the child rows
+directly rather than through ``set_agent_access``: the fixture is describing a
+precondition, not exercising the endpoint, and going through the endpoint would
+make every one of those modules depend on the admin gate's behaviour too.
+"""
+
+import frappe
+
+LISTING = "Jarvis Agent Listing"
+ALLOWED_ROLE = "Jarvis Agent Allowed Role"
+ALLOWED_USER = "Jarvis Agent Allowed User"
+
+
+def allow_listing_for(listing: str, user: str | None = None, roles=None) -> None:
+	"""Grant ``user`` and/or ``roles`` access to ``listing`` (additive, idempotent).
+
+	``listing`` is the Jarvis Agent Listing docname (== its agent_slug). Silently
+	does nothing when the listing does not exist on this site, so a module can
+	grant for every slug it MIGHT touch without asserting the catalog's contents.
+	"""
+	if not frappe.db.exists(LISTING, listing):
+		return
+	for role in roles or []:
+		if not frappe.db.exists(
+			ALLOWED_ROLE,
+			{"parenttype": LISTING, "parentfield": "allowed_roles", "parent": listing, "role": role},
+		):
+			frappe.get_doc(
+				{
+					"doctype": ALLOWED_ROLE,
+					"parenttype": LISTING,
+					"parentfield": "allowed_roles",
+					"parent": listing,
+					"role": role,
+				}
+			).insert(ignore_permissions=True)
+	if user:
+		if not frappe.db.exists(
+			ALLOWED_USER,
+			{"parenttype": LISTING, "parentfield": "allowed_users", "parent": listing, "user": user},
+		):
+			frappe.get_doc(
+				{
+					"doctype": ALLOWED_USER,
+					"parenttype": LISTING,
+					"parentfield": "allowed_users",
+					"parent": listing,
+					"user": user,
+				}
+			).insert(ignore_permissions=True)
+	frappe.db.commit()
+
+
+def allow_all_listings_for(*users: str) -> None:
+	"""Open EVERY listing on the site to each named user.
+
+	The blunt instrument, for modules whose subject is not access control at all
+	(dispatch idempotency, run lifecycle, provenance) and which would otherwise
+	need the catalog's slug list hard-coded into their setUp — a list that goes
+	stale the next time registry.json grows an agent.
+	"""
+	for name in frappe.get_all(LISTING, pluck="name"):
+		for u in users:
+			allow_listing_for(name, user=u)
+
+
+def clear_listing_access(listing: str | None = None) -> None:
+	"""Drop every allow row (all listings, or just ``listing``) — the CLOSED state.
+
+	The deny-by-default precondition: a test asserting that a plain user cannot
+	see / install / run an agent starts from here.
+	"""
+	for doctype, parentfield in ((ALLOWED_ROLE, "allowed_roles"), (ALLOWED_USER, "allowed_users")):
+		filters = {"parenttype": LISTING, "parentfield": parentfield}
+		if listing:
+			filters["parent"] = listing
+		frappe.db.delete(doctype, filters)
+	frappe.db.commit()

--- a/jarvis/tests/test_agent_access_governance.py
+++ b/jarvis/tests/test_agent_access_governance.py
@@ -1,0 +1,712 @@
+"""Interim A access governance for the Agents Marketplace (jarvis#1062).
+
+The inversion these cover: an agent listing used to be reachable by everyone
+until an admin restricted it, and is now reachable by nobody until an admin
+allows it - by ROLE, by NAMED USER, or both. That is a security default, so the
+tests here are mostly about what does NOT happen: a plain user with no grant
+cannot see, install or run an agent, and an admin still can.
+
+Grouped by the thing that would break if the change were wrong:
+
+  * TestDenyByDefault      - the inversion itself, at all four gates.
+  * TestAllowedUsersPath   - a grant by NAME, with no role behind it.
+  * TestSetAgentAccess     - the admin endpoint's validation and atomicity.
+  * TestGrandfatherPatch   - nobody who worked before the upgrade stops working.
+  * TestPushRoster         - the container roster follows the grants.
+  * TestActivationAuthority- a named reviewer can no longer self sign-off.
+  * TestAdminInstallControl- a tenant admin can operate another owner's install.
+"""
+
+import json
+import unittest
+
+import frappe
+import frappe.permissions
+
+from jarvis.chat import agent_catalog, agents_api
+from jarvis.patches import v2_18_agent_access_grandfather as grandfather
+from jarvis.tests._agent_access import allow_listing_for, clear_listing_access
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+ALLOWED_USER = "Jarvis Agent Allowed User"
+
+SLUG = "access-gov-auditor"
+ROLE_GRANTED = "Jarvis Access Gov Role"
+REVIEWER_ROLE = "Jarvis Skill Reviewer"
+
+
+def _ensure_role(name: str) -> str:
+	if not frappe.db.exists("Role", name):
+		doc = frappe.get_doc({"doctype": "Role", "role_name": name, "desk_access": 1})
+		doc.flags.ignore_permissions = True
+		doc.insert()
+	return name
+
+
+def _ensure_user(email: str, roles=("Jarvis User",)) -> str:
+	from jarvis.permissions import ensure_jarvis_admin_role, ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	ensure_jarvis_admin_role()
+	if not frappe.db.exists("User", email):
+		doc = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert()
+	# Unconditional: on a shared bench the user may survive from an earlier run
+	# WITHOUT the roles this module needs, and an exists-guard would skip them.
+	held = set(frappe.get_roles(email))
+	missing = [r for r in roles if r not in held]
+	if missing:
+		frappe.get_doc("User", email).add_roles(*missing)
+	frappe.clear_cache(user=email)
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Access Governance Auditor",
+				"description": "fixture",
+				"nature": "Auditor",
+				"status": "Published",
+				"delivery": "delegate",
+				"version": "1.0.0",
+				"rule_pack": f"pack-{SLUG}",
+				# Explicitly dependency-free: this module is about ACCESS, and an
+				# installability refusal arriving first would mask every assertion.
+				"min_apps": json.dumps([]),
+				"doctypes_required": json.dumps([]),
+				"rule_tokens": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	frappe.db.set_value(LISTING, SLUG, {"status": "Published", "nature": "Auditor"}, update_modified=False)
+	return SLUG
+
+
+class AccessGovernanceCase(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		_ensure_role(ROLE_GRANTED)
+		cls.plain = _ensure_user("agov-plain@example.com")
+		cls.named = _ensure_user("agov-named@example.com")
+		cls.roled = _ensure_user("agov-roled@example.com", ("Jarvis User", ROLE_GRANTED))
+		cls.admin = _ensure_user("agov-admin@example.com", ("Jarvis User", "Jarvis Admin"))
+		cls.reviewer = _ensure_user("agov-reviewer@example.com", ("Jarvis User", REVIEWER_ROLE))
+		# Reviewing is a job, not a seat on the chat surface: this fixture holds the
+		# reviewing role and NOTHING else, which is the shape promote/demote must
+		# admit (see _require_activation_authority).
+		cls.reviewer_only = _ensure_user("agov-reviewer-only@example.com", (REVIEWER_ROLE,))
+		_mk_listing()
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		# The listing is bench-global state: leg 1 of build_agent_push_payload ships
+		# every GRANTED Published listing, so leaving this one behind (granted by a
+		# test that did not clean up) puts an unexpected slug in other modules'
+		# roster assertions. Shared-site hygiene, not politeness.
+		frappe.set_user("Administrator")
+		for name in frappe.get_all(INSTALLATION, filters={"agent": SLUG}, pluck="name"):
+			frappe.delete_doc(INSTALLATION, name, force=True, ignore_permissions=True)
+		clear_listing_access(SLUG)
+		if frappe.db.exists(LISTING, SLUG):
+			frappe.delete_doc(LISTING, SLUG, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._wipe()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		self._wipe()
+
+	def _wipe(self):
+		for name in frappe.get_all(INSTALLATION, filters={"agent": SLUG}, pluck="name"):
+			frappe.delete_doc(INSTALLATION, name, force=True, ignore_permissions=True)
+		clear_listing_access(SLUG)
+		frappe.db.commit()
+
+	def _as(self, user):
+		frappe.set_user(user)
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def _row(self, user):
+		"""This agent's row in ``user``'s catalog, or None if hidden from them."""
+		frappe.set_user(user)
+		try:
+			return next((r for r in agents_api.list_agents() if r["name"] == SLUG), None)
+		finally:
+			frappe.set_user("Administrator")
+
+
+# --------------------------------------------------------------------------- #
+# G1 - the inversion
+# --------------------------------------------------------------------------- #
+class TestDenyByDefault(AccessGovernanceCase):
+	def test_closed_listing_is_hidden_from_a_plain_user(self):
+		self.assertIsNone(
+			self._row(self.plain),
+			"a listing with no allowed roles and no allowed users must not appear in a plain user's catalog",
+		)
+
+	def test_closed_listing_cannot_be_read_by_slug(self):
+		# Hiding the row is not enough: guessing the slug must not be a way round it.
+		self._as(self.plain)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.get_agent(SLUG)
+
+	def test_closed_listing_cannot_be_installed(self):
+		self._as(self.plain)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.install_agent(SLUG)
+
+	def test_closed_listing_cannot_be_run(self):
+		# The run gate reads the INSTALLATION's run-as user, so this needs a row that
+		# already exists - the state a tenant lands in if access is revoked after
+		# install, and the state the grandfather patch exists to prevent on upgrade.
+		inst = _mk_install(self.plain)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		self._as(self.plain)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.run_agent_now(inst)
+
+	def test_admin_is_unaffected_by_the_closed_default(self):
+		row = self._row(self.admin)
+		self.assertIsNotNone(row, "a Jarvis Admin must still see a closed listing")
+		self.assertEqual(row["allowed"], 1)
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.admin))
+
+	def test_a_role_grant_opens_it_for_holders_only(self):
+		allow_listing_for(SLUG, roles=[ROLE_GRANTED])
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.roled))
+		self.assertFalse(agents_api._user_allowed_for_agent(SLUG, self.plain))
+		self.assertIsNotNone(self._row(self.roled))
+		self.assertIsNone(self._row(self.plain))
+
+	def test_display_flag_and_server_gate_agree(self):
+		"""The catalog's ``allowed`` flag and the gate come from one predicate.
+
+		They used to be two hand-copied boolean expressions, which is how a user
+		gets an enabled Install button that 403s."""
+		allow_listing_for(SLUG, user=self.named)
+		for user in (self.plain, self.named, self.roled, self.admin):
+			row = self._row(user)
+			flag = bool(row and row["allowed"])
+			self.assertEqual(
+				flag,
+				agents_api._user_allowed_for_agent(SLUG, user),
+				f"catalog flag and server gate disagree for {user}",
+			)
+
+
+# --------------------------------------------------------------------------- #
+# G1 - the named-user half
+# --------------------------------------------------------------------------- #
+class TestAllowedUsersPath(AccessGovernanceCase):
+	def test_named_user_is_allowed_with_no_role_grant_at_all(self):
+		allow_listing_for(SLUG, user=self.named)
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.named))
+		# and nobody else rides in on it
+		self.assertFalse(agents_api._user_allowed_for_agent(SLUG, self.plain))
+		self.assertFalse(agents_api._user_allowed_for_agent(SLUG, self.roled))
+
+	def test_named_user_can_install_and_the_row_carries_no_roster(self):
+		allow_listing_for(SLUG, user=self.named)
+		self._as(self.named)
+		res = agents_api.install_agent(SLUG)
+		self.assertTrue(res["ok"])
+		detail = agents_api.get_agent(SLUG)
+		self.assertEqual(detail["allowed"], 1)
+		# WHO ELSE has access is admin information.
+		self.assertNotIn("allowed_users", detail)
+		self.assertNotIn("allowed_roles", detail)
+
+	def test_admin_detail_carries_both_lists(self):
+		allow_listing_for(SLUG, user=self.named, roles=[ROLE_GRANTED])
+		self._as(self.admin)
+		detail = agents_api.get_agent(SLUG)
+		self.assertEqual(detail["allowed_roles"], [ROLE_GRANTED])
+		self.assertEqual(detail["allowed_users"], [self.named])
+
+
+# --------------------------------------------------------------------------- #
+# G3 - the admin endpoint
+# --------------------------------------------------------------------------- #
+class TestSetAgentAccess(AccessGovernanceCase):
+	def test_replaces_both_tables_in_one_call(self):
+		allow_listing_for(SLUG, user=self.named, roles=[ROLE_GRANTED])
+		self._as(self.admin)
+		res = agents_api.set_agent_access(SLUG, roles=["Jarvis User"], users=[self.plain])
+		self.assertEqual(res["allowed_roles"], ["Jarvis User"])
+		self.assertEqual(res["allowed_users"], [self.plain])
+		self.assertFalse(res["applied"])
+		# The previous grants are GONE, not merged - moving somebody from a role to a
+		# named grant must not leave them holding both.
+		frappe.set_user("Administrator")
+		detail = agents_api.get_agent(SLUG)
+		self.assertEqual(detail["allowed_roles"], ["Jarvis User"])
+		self.assertEqual(detail["allowed_users"], [self.plain])
+
+	def test_empty_pair_closes_rather_than_opens(self):
+		allow_listing_for(SLUG, roles=[ROLE_GRANTED])
+		self._as(self.admin)
+		agents_api.set_agent_access(SLUG, roles=[], users=[])
+		frappe.set_user("Administrator")
+		self.assertFalse(agents_api._user_allowed_for_agent(SLUG, self.roled))
+		self.assertFalse(agents_api._user_allowed_for_agent(SLUG, self.plain))
+
+	def test_requires_an_admin(self):
+		self._as(self.plain)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.set_agent_access(SLUG, roles=[ROLE_GRANTED])
+
+	def test_rejects_non_grantable_roles(self):
+		self._as(self.admin)
+		for role in ("Administrator", "Guest", "All"):
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_agent_access(SLUG, roles=[role])
+
+	def test_rejects_unknown_and_system_users(self):
+		self._as(self.admin)
+		with self.assertRaises(frappe.ValidationError):
+			agents_api.set_agent_access(SLUG, users=["nobody-at-all@example.com"])
+		for user in ("Administrator", "Guest"):
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_agent_access(SLUG, users=[user])
+
+	def test_rejects_a_disabled_user(self):
+		"""Disabling is how an offboarded person is revoked.
+
+		Recording one as allowed would write a grant that outlives the offboarding,
+		so the endpoint refuses it at the point of entry."""
+		frappe.db.set_value("User", self.named, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		try:
+			self._as(self.admin)
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_agent_access(SLUG, users=[self.named])
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.set_value("User", self.named, "enabled", 1, update_modified=False)
+			frappe.db.commit()
+
+	def test_a_stale_disabled_grant_does_not_block_an_unrelated_edit(self):
+		"""Validation applies to what a call ADDS, not to what it carries forward.
+
+		Somebody granted access and later offboarded leaves a row naming a DISABLED
+		user. Re-validating the whole submitted list made an edit that never
+		mentioned them - changing a role, or the set_agent_roles shim passing the
+		existing people through - fail with a message about that person, and left
+		the admin no way to change the roles at all."""
+		allow_listing_for(SLUG, user=self.named)
+		frappe.db.set_value("User", self.named, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		try:
+			self._as(self.admin)
+			# The shim: roles only, users forwarded untouched.
+			res = agents_api.set_agent_roles(SLUG, [ROLE_GRANTED])
+			self.assertEqual(res["allowed_roles"], [ROLE_GRANTED])
+			# ...and the stale grant is still there, not silently revoked: disabling
+			# is reversible, so dropping it would make a suspension permanent.
+			frappe.set_user("Administrator")
+			detail = agents_api.get_agent(SLUG)
+			self.assertIn(self.named, detail["allowed_users"])
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.set_value("User", self.named, "enabled", 1, update_modified=False)
+			frappe.db.commit()
+
+	def test_adding_a_disabled_user_still_raises(self):
+		"""The relaxation above is scoped to CARRIED-FORWARD names only."""
+		frappe.db.set_value("User", self.named, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		try:
+			self._as(self.admin)
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_agent_access(SLUG, roles=[], users=[self.named])
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.set_value("User", self.named, "enabled", 1, update_modified=False)
+			frappe.db.commit()
+
+	def test_a_grant_naming_a_deleted_user_is_dropped_not_raised(self):
+		"""A deleted user cannot stay: the child table's Link validation would
+		refuse the save outright and block every future access edit. It is dropped
+		(and logged) rather than raised, which is the one case where carrying a row
+		forward is impossible."""
+		ghost = _ensure_user("agov-ghost@example.com")
+		allow_listing_for(SLUG, user=ghost)
+		frappe.delete_doc("User", ghost, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+		self._as(self.admin)
+		res = agents_api.set_agent_access(SLUG, roles=[ROLE_GRANTED], users=[ghost])
+		self.assertEqual(res["allowed_roles"], [ROLE_GRANTED])
+		self.assertNotIn(ghost, res["allowed_users"])
+
+	def test_accepts_json_strings_from_the_http_layer(self):
+		# Over HTTP both lists arrive as JSON strings, not lists.
+		self._as(self.admin)
+		res = agents_api.set_agent_access(SLUG, roles=f'["{ROLE_GRANTED}"]', users=f'["{self.named}"]')
+		self.assertEqual(res["allowed_roles"], [ROLE_GRANTED])
+		self.assertEqual(res["allowed_users"], [self.named])
+
+	def test_set_agent_roles_shim_preserves_named_grants(self):
+		"""The old endpoint sets the ROLE half only.
+
+		A cached older SPA build calling it must not silently revoke a named grant
+		made through the new Access editor."""
+		allow_listing_for(SLUG, user=self.named)
+		self._as(self.admin)
+		res = agents_api.set_agent_roles(SLUG, [ROLE_GRANTED])
+		self.assertEqual(res["allowed_roles"], [ROLE_GRANTED])
+		frappe.set_user("Administrator")
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.named))
+
+	def test_search_users_is_admin_only_and_excludes_system_identities(self):
+		self._as(self.plain)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.search_users("a")
+		frappe.set_user(self.admin)
+		rows = agents_api.search_users("agov")
+		names = {r["name"] for r in rows}
+		self.assertIn(self.plain, names)
+		self.assertNotIn("Administrator", names)
+		self.assertNotIn("Guest", names)
+		self.assertLessEqual(len(rows), 20)
+
+
+# --------------------------------------------------------------------------- #
+# G2 - the upgrade path
+# --------------------------------------------------------------------------- #
+class TestGrandfatherPatch(AccessGovernanceCase):
+	def test_existing_install_keeps_working_after_the_inversion(self):
+		# Install while allowed, then simulate the upgrade: the listing's grants are
+		# gone (every shipped listing declares default_allowed_roles: []).
+		allow_listing_for(SLUG, user=self.named)
+		inst = _mk_install(self.named)
+		clear_listing_access(SLUG)
+		self.assertFalse(
+			agents_api._user_allowed_for_agent(SLUG, self.named),
+			"precondition: the upgrade closes the listing",
+		)
+
+		grandfather.grandfather_existing_installs()
+
+		allowed = frappe.get_all(
+			ALLOWED_USER,
+			filters={"parenttype": LISTING, "parentfield": "allowed_users", "parent": SLUG},
+			pluck="user",
+		)
+		self.assertIn(self.named, allowed)
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.named))
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "agent"), SLUG)
+
+	def test_grandfathers_the_run_as_user_too_not_only_the_owner(self):
+		"""The run-as user is the identity every dispatch gate litigates.
+
+		After an admin re-targets an install it is frequently NOT the owner, and
+		grandfathering the owner alone would leave the scheduled run refused."""
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "run_as_user", self.plain, update_modified=False)
+		frappe.db.commit()
+
+		grandfather.grandfather_existing_installs()
+
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.named))
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.plain))
+
+	def test_is_idempotent(self):
+		_mk_install(self.named)
+		first = grandfather.grandfather_existing_installs()["added"]
+		second = grandfather.grandfather_existing_installs()["added"]
+		self.assertGreater(first, 0)
+		self.assertEqual(second, 0, "re-running the patch must add nothing")
+
+	def test_skips_an_identity_already_allowed_by_role(self):
+		"""A role grant is the stronger, more durable statement.
+
+		Pinning the person by name as well would silently outlive the role being
+		revoked - the migration would have widened access, not preserved it."""
+		_mk_install(self.roled)
+		allow_listing_for(SLUG, roles=[ROLE_GRANTED])
+
+		grandfather.grandfather_existing_installs()
+
+		allowed = frappe.get_all(
+			ALLOWED_USER,
+			filters={"parenttype": LISTING, "parentfield": "allowed_users", "parent": SLUG},
+			pluck="user",
+		)
+		self.assertNotIn(self.roled, allowed)
+
+	def test_never_grants_administrator(self):
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "owner", "Administrator", update_modified=False)
+		frappe.db.commit()
+
+		grandfather.grandfather_existing_installs()
+
+		allowed = frappe.get_all(
+			ALLOWED_USER,
+			filters={"parenttype": LISTING, "parentfield": "allowed_users", "parent": SLUG},
+			pluck="user",
+		)
+		self.assertNotIn("Administrator", allowed)
+
+
+# --------------------------------------------------------------------------- #
+# G4 - the container roster
+# --------------------------------------------------------------------------- #
+class TestPushRoster(AccessGovernanceCase):
+	def _slugs(self):
+		return [e["slug"] for e in agent_catalog.build_agent_push_payload()]
+
+	def test_an_allowed_listing_ships_with_zero_installations(self):
+		"""The point of the whole design: an admin allows and applies ONCE, then
+		allowed users self-install without each install restarting the workspace."""
+		self.assertNotIn(f"agent-{SLUG}", self._slugs())
+		allow_listing_for(SLUG, roles=[ROLE_GRANTED])
+		self.assertIn(f"agent-{SLUG}", self._slugs())
+
+	def test_a_named_user_grant_alone_also_ships_it(self):
+		allow_listing_for(SLUG, user=self.named)
+		self.assertIn(f"agent-{SLUG}", self._slugs())
+
+	def test_an_unallowed_uninstalled_listing_does_not_ship(self):
+		self.assertNotIn(f"agent-{SLUG}", self._slugs())
+
+	def test_an_enabled_install_of_a_closed_listing_does_not_ship(self):
+		"""The roster admits exactly what dispatch admits.
+
+		An enabled install on a CLOSED listing is refused by run_agent_now and by
+		_sweep_one, so advertising its delegate would seat a roster entry the bench
+		will never honour - the #457 mismatch. The upgrade is protected by the
+		grandfather PATCH (which runs during migrate, before anything can apply),
+		not by a looser gate here - see the test below."""
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		self.assertFalse(agents_api._user_allowed_for_agent(SLUG, self.named))
+		self.assertNotIn(f"agent-{SLUG}", self._slugs())
+
+	def test_a_grandfathered_install_ships(self):
+		"""The upgrade path, end to end: install, close the listing (what the
+		inversion does to every shipped agent), run the patch, and the customer's
+		agent is back in the roster."""
+		allow_listing_for(SLUG, user=self.named)
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		clear_listing_access(SLUG)
+		self.assertNotIn(f"agent-{SLUG}", self._slugs())
+
+		grandfather.grandfather_existing_installs()
+
+		self.assertTrue(agents_api._user_allowed_for_agent(SLUG, self.named))
+		self.assertIn(f"agent-{SLUG}", self._slugs())
+
+	def test_a_restricted_listing_still_excludes_a_blocked_run_as_user(self):
+		"""#457 must not regress: the legacy carve-out is for the EMPTY pair only.
+
+		Once an admin has said who may use an agent, an enabled install whose
+		run-as user is not among them stays out of the roster."""
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		allow_listing_for(SLUG, roles=[ROLE_GRANTED])  # self.named does not hold it
+		frappe.db.commit()
+		# The blocked install contributes nothing: asserted on the per-OWNER build,
+		# which skips the allowed-listing leg.
+		self.assertEqual([e["slug"] for e in agent_catalog.build_agent_push_payload(owner=self.named)], [])
+		# The grant itself is real, though - the listing ships on its own account,
+		# so holders of ROLE_GRANTED can install and run it. Leg 1 and leg 2 answer
+		# different questions and both matter.
+		self.assertIn(f"agent-{SLUG}", self._slugs())
+
+	def test_only_published_listings_ship(self):
+		allow_listing_for(SLUG, roles=[ROLE_GRANTED])
+		frappe.db.set_value(LISTING, SLUG, "status", "Coming Soon", update_modified=False)
+		frappe.db.commit()
+		try:
+			self.assertNotIn(f"agent-{SLUG}", self._slugs())
+		finally:
+			frappe.db.set_value(LISTING, SLUG, "status", "Published", update_modified=False)
+			frappe.db.commit()
+
+	def test_the_two_legs_dedupe_to_one_entry(self):
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		allow_listing_for(SLUG, user=self.named)
+		frappe.db.commit()
+		self.assertEqual(self._slugs().count(f"agent-{SLUG}"), 1)
+
+
+# --------------------------------------------------------------------------- #
+# G6 - who may sign off
+# --------------------------------------------------------------------------- #
+class TestActivationAuthority(AccessGovernanceCase):
+	def test_the_named_reviewer_alone_cannot_promote(self):
+		"""install_agent stamps reviewer = the installer.
+
+		So "the named reviewer may promote" made every installer their own
+		approver, which is exactly the rubber stamp the shadow period exists to
+		prevent."""
+		inst = _mk_install(self.named, reviewer=self.named)
+		self._as(self.named)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.promote_installation(inst, justification="looks fine to me")
+
+	def test_a_skill_reviewer_can_promote(self):
+		inst = _mk_install(self.named, reviewer=self.named)
+		self._as(self.reviewer)
+		res = agents_api.promote_installation(inst, justification="reviewed 10 samples")
+		self.assertTrue(res["ok"])
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "activation_state"), "live")
+		# WHO signed off is still recorded - only the authority to do it changed.
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "promoted_by"), self.reviewer)
+
+	def test_a_reviewer_without_jarvis_user_can_still_promote(self):
+		"""Promote is gated on the reviewer set ALONE, like apply_agents.
+
+		Stacking a Jarvis User check on top would lock out exactly the person the
+		Jarvis Skill Reviewer role exists for. Asserted with a user who deliberately
+		holds no other Jarvis role."""
+		self.assertNotIn("Jarvis User", frappe.get_roles(self.reviewer_only))
+		inst = _mk_install(self.named, reviewer=self.named)
+		self._as(self.reviewer_only)
+		res = agents_api.promote_installation(inst, justification="reviewed, clean")
+		self.assertTrue(res["ok"])
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "activation_state"), "live")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "promoted_by"), self.reviewer_only)
+
+	def test_a_reviewer_without_jarvis_user_can_still_demote(self):
+		inst = _mk_install(self.named, reviewer=self.named)
+		frappe.set_user(self.reviewer_only)
+		agents_api.promote_installation(inst)
+		res = agents_api.demote_installation(inst, reason="false positives")
+		frappe.set_user("Administrator")
+		self.assertTrue(res["ok"])
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "activation_state"), "shadow")
+
+	def test_the_named_reviewer_alone_cannot_demote(self):
+		inst = _mk_install(self.named, reviewer=self.named)
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(inst)
+		self._as(self.named)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.demote_installation(inst, reason="changed my mind")
+
+
+# --------------------------------------------------------------------------- #
+# G7 - a tenant admin can operate other owners' installs
+# --------------------------------------------------------------------------- #
+class TestAdminInstallControl(AccessGovernanceCase):
+	def test_jarvis_admin_can_disable_another_owners_install(self):
+		"""Jarvis Admin held READ ONLY on Jarvis Agent Installation, so a tenant
+		admin could see a runaway install and do nothing about it."""
+		# Preconditions, asserted rather than assumed. These caught the real story
+		# once already: the role IS held and the DocPerm merge DOES grant write, yet
+		# check_permission still refused - because it also runs the document through
+		# has_user_permission, which a shared site can trip for reasons unrelated to
+		# agent access. That is why the endpoints gate the admin path explicitly
+		# (_check_installation_write) and the DocPerm row is defence in depth for
+		# Desk and generic REST rather than the thing this test rides on.
+		self.assertIn("Jarvis Admin", frappe.get_roles(self.admin))
+		self.assertNotIn("System Manager", frappe.get_roles(self.admin))  # must not pass via SM
+		self.assertEqual(
+			frappe.permissions.get_role_permissions(INSTALLATION, user=self.admin).get("write"),
+			1,
+			"Jarvis Admin has no non-owner write on Jarvis Agent Installation - the "
+			"DocPerm row in the DocType JSON has not reached this database (Desk and "
+			"generic REST would be broken for a tenant admin even though the "
+			"endpoints below still work)",
+		)
+		inst = _mk_install(self.named)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+
+		self._as(self.admin)
+		res = agents_api.set_enabled(inst, 0)
+		self.assertTrue(res["ok"])
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "enabled"), 0)
+
+	def test_jarvis_admin_can_stop_another_owners_run(self):
+		inst = _mk_install(self.named)
+		run = frappe.get_doc(
+			{
+				"doctype": "Jarvis Agent Run",
+				"agent": SLUG,
+				"installation": inst,
+				"status": "running",
+				"started_at": frappe.utils.now(),
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert(ignore_permissions=True)
+		frappe.db.set_value("Jarvis Agent Run", run.name, "owner", self.named, update_modified=False)
+		frappe.db.commit()
+		self.addCleanup(_delete_run, run.name)
+
+		self._as(self.admin)
+		res = agents_api.stop_agent_run(run.name)
+		self.assertTrue(res["ok"])
+		self.assertEqual(res["status"], "stopped")
+
+	def test_a_plain_non_owner_still_cannot(self):
+		"""The widened DocPerm is for ADMINS - it must not have opened the row to
+		every Jarvis User, whose grant is still if_owner."""
+		inst = _mk_install(self.named)
+		self._as(self.plain)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.set_enabled(inst, 0)
+
+
+def _delete_run(name: str) -> None:
+	frappe.set_user("Administrator")
+	if frappe.db.exists("Jarvis Agent Run", name):
+		frappe.delete_doc("Jarvis Agent Run", name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _mk_install(owner: str, reviewer: str | None = None) -> str:
+	"""An installation row for ``owner``, created directly.
+
+	Not via ``install_agent``: these tests need a row to exist in access states
+	that endpoint would refuse to create, which is the whole point of the
+	grandfather and revoked-after-install cases."""
+	doc = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": SLUG,
+			"enabled": 0,
+			"run_as_user": owner,
+			"activation_state": "shadow",
+			"reviewer": reviewer or owner,
+			"installed_version": frappe.db.get_value(LISTING, SLUG, "version"),
+			"installed_at": frappe.utils.now(),
+		}
+	)
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	frappe.db.commit()
+	return doc.name

--- a/jarvis/tests/test_agent_dispatch_idempotency.py
+++ b/jarvis/tests/test_agent_dispatch_idempotency.py
@@ -35,6 +35,7 @@ from frappe.utils import add_days, add_to_date, now_datetime
 
 from jarvis import admin_client
 from jarvis.chat import agent_catalog, agent_scheduler, agents_api
+from jarvis.tests._agent_access import allow_listing_for
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
@@ -115,6 +116,12 @@ class DispatchIdempotencyTestCase(FrappeTestCase):
 		frappe.set_user("Administrator")
 		cls.owner = _mk_user(OWNER)
 		_mk_listing()
+		# jarvis#1062: agent access is DENY BY DEFAULT, and this module's owner is a
+		# plain Jarvis User. Every dispatch path here (run_agent_now, the sweep,
+		# _launch_audit) gates on it, so without an explicit grant the whole module
+		# tests nothing but the refusal. Persists module-wide - neither _wipe() nor
+		# _mk_listing() touches the allow rows.
+		allow_listing_for(SLUG, user=cls.owner)
 		# The A14 ceiling counts every non-failed run on the SITE, including rows other
 		# platform-test modules commit and never clean, so it can refuse a legitimate
 		# dispatch here for reasons that have nothing to do with this module.

--- a/jarvis/tests/test_agent_identity.py
+++ b/jarvis/tests/test_agent_identity.py
@@ -23,6 +23,7 @@ import unittest
 import frappe
 
 from jarvis.chat import agent_catalog, agent_scheduler, agents_api
+from jarvis.tests._agent_access import allow_listing_for, clear_listing_access
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
@@ -153,12 +154,15 @@ class TestAgentIdentity(unittest.TestCase):
 		self._cleanup()
 
 	def _cleanup(self):
-		# A prior test may have left an agent role restriction — clear it so our
-		# users (plain Jarvis Users) can install the unrestricted catalog agent.
-		frappe.db.delete(
-			"Jarvis Agent Allowed Role",
-			{"parenttype": LISTING, "parentfield": "allowed_roles"},
-		)
+		# jarvis#1062 inverted the default: wiping the allow rows no longer leaves the
+		# listing "unrestricted", it CLOSES it. So this resets to a known state and
+		# then re-grants, rather than relying on emptiness to mean access. Granted to
+		# the users by NAME because this module's cast deliberately holds a mix of
+		# roles (plain, Jarvis Admin, System Manager, no-Jarvis-role) and a role grant
+		# would quietly change which of them the identity tests are exercising.
+		clear_listing_access()
+		for u in self.users:
+			allow_listing_for(AGENT, user=u)
 		for dt in (FINDING, RUN, INSTALLATION):
 			for u in self.users:
 				for n in frappe.get_all(dt, filters={"owner": u}, pluck="name"):
@@ -183,6 +187,8 @@ class TestAgentIdentity(unittest.TestCase):
 
 		# Legacy row whose owner is now disabled -> must be skipped, not crash.
 		disabled = _ensure_user("aid-disabled@example.com")
+		# Not in cls.users, so _cleanup's blanket grant does not cover it.
+		allow_listing_for(AGENT, user=disabled)
 		if frappe.db.exists("Role", "Accounts User"):
 			frappe.get_doc("User", disabled).add_roles("Accounts User")  # A12 GL read
 			frappe.clear_cache(user=disabled)

--- a/jarvis/tests/test_agent_run_lifecycle.py
+++ b/jarvis/tests/test_agent_run_lifecycle.py
@@ -217,6 +217,22 @@ class TestStoppedStatusIsTerminal(RunLifecycleTestCase):
 			frappe.set_user("Administrator")
 		self.assertIn(run, [r["name"] for r in rows])
 
+	def test_run_list_row_carries_preparation_mode_and_dashboard(self):
+		"""AgentRunsBoard's Preview pill/attestation banner and FindingsPanel's "Open
+		dashboard" button both key off these two fields on the row the list endpoint
+		returns: a row missing either key can never render them."""
+		inst = self._install()
+		run = self._run(inst, preparation_mode="shadow")
+		frappe.set_user(self.owner)
+		try:
+			rows = agents_api.list_runs_page()["rows"]
+		finally:
+			frappe.set_user("Administrator")
+		row = next(r for r in rows if r["name"] == run)
+		self.assertIn("preparation_mode", row)
+		self.assertIn("dashboard", row)
+		self.assertEqual(row["preparation_mode"], "shadow")
+
 	def test_stopped_run_is_not_live(self):
 		"""#672's liveness guard is keyed on ``status='running'``, so a stopped run must
 		not keep the installation's Run-now button (and the cron sweep) locked out."""
@@ -388,10 +404,22 @@ class TestPollDispatchedRuns(RunLifecycleTestCase):
 	def _fleet_failed(self, message: str) -> dict:
 		return self._relayed({"status": "failed", "error": {"code": "run_failed", "message": message}})
 
-	def _fleet_completed(self, *, finished_ago_s: float, status: str = "done") -> dict:
+	def _fleet_completed(
+		self, *, finished_ago_s: float, status: str = "done", result: dict | None = None
+	) -> dict:
 		# The fleet stamps finished_at as a UNIX epoch float, and its word for a clean
 		# exit is ``done`` (fleet-agent main.py, _dispatch_agent_run) - NOT ``completed``.
-		return self._relayed({"status": status, "finished_at": time.time() - finished_ago_s, "error": None})
+		# ``result`` (#1061 polish): a gateway timeout/abort still reports a clean
+		# "done" run-state - the honest verdict rides in result.gateway_status/summary
+		# instead of the top-level status.
+		return self._relayed(
+			{
+				"status": status,
+				"finished_at": time.time() - finished_ago_s,
+				"error": None,
+				"result": result,
+			}
+		)
 
 	# ------------------------------------------------------------------ #
 	def test_a_fleet_failure_is_surfaced_with_its_real_message(self):
@@ -474,6 +502,64 @@ class TestPollDispatchedRuns(RunLifecycleTestCase):
 		inst = self._install()
 		run = self._run(inst, age_s=agent_scheduler.STALE_RUN_AFTER_SECONDS - 60)
 		self._poll({run: self._fleet_completed(finished_ago_s=10)})
+		self.assertEqual(self._status(run), "running")
+
+	# ------------------------------------------------------------------ #
+	# #1061 polish - a gateway timeout/abort still reports "done" on the fleet
+	# side; the honest verdict rides in result.gateway_status/summary and must
+	# terminalize immediately, not wait out the writeback grace for a
+	# generic "delegate finished without recording results".
+	# ------------------------------------------------------------------ #
+	def test_a_gateway_timeout_fails_immediately_with_its_own_reply(self):
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		# finished 5s ago - well inside WRITEBACK_GRACE_SECONDS, proving this does
+		# NOT wait out the grace like a normal clean finish would.
+		self._poll(
+			{
+				run: self._fleet_completed(
+					finished_ago_s=5,
+					result={
+						"reply": "LLM request timed out.\nsome further detail on another line",
+						"gateway_status": "timeout",
+						"summary": "aborted",
+					},
+				)
+			}
+		)
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertEqual(row.error, "LLM request timed out.")
+
+	def test_summary_aborted_with_no_reply_falls_back_to_a_generic_sentence(self):
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll(
+			{
+				run: self._fleet_completed(
+					finished_ago_s=5,
+					result={"reply": "", "gateway_status": "ok", "summary": "aborted"},
+				)
+			}
+		)
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertEqual(row.error, "the agent turn was aborted by the gateway (ok)")
+
+	def test_a_normal_done_result_still_honours_the_writeback_grace(self):
+		"""Control: an ordinary clean result (gateway_status ok, no aborted summary)
+		must not trip the new immediate-fail path - it still waits out the grace
+		exactly as before."""
+		inst = self._install()
+		run = self._run(inst, age_s=agent_scheduler.STALE_RUN_AFTER_SECONDS - 60)
+		self._poll(
+			{
+				run: self._fleet_completed(
+					finished_ago_s=10,
+					result={"reply": "all good", "gateway_status": "ok", "summary": "ok"},
+				)
+			}
+		)
 		self.assertEqual(self._status(run), "running")
 
 	def test_a_finished_run_whose_writeback_never_came_fails_honestly(self):

--- a/jarvis/tests/test_agent_run_lifecycle.py
+++ b/jarvis/tests/test_agent_run_lifecycle.py
@@ -1,0 +1,588 @@
+"""#1061: an agent run must be STOPPABLE and must never sit ``running`` forever.
+
+Three lifecycle holes, one module:
+
+  * **A1** — ``stopped`` was not a Jarvis Agent Run status at all, so there was no
+    honest terminal state for "an operator ended this early". The only way to clear a
+    wedged run was to let the 3h reaper relabel it as a duration timeout it never hit.
+  * **A2** — ``stop_agent_run`` is the operator's soft stop: it terminalizes the row,
+    revokes the run's session bearer (so a late writeback is inert) and best-effort
+    aborts the gateway session.
+  * **A3** — ``poll_dispatched_runs`` closes the loop the other way. The fleet already
+    knows a run failed or finished; before this the bench learned that only from the
+    delegate's own writeback, so a delegate that died after dispatch left the row
+    ``running`` for three hours (jarvis#1058).
+
+The concurrency contract these tests defend is the one the reaper already had: every
+terminal transition is a COMPARE-AND-SET on ``status='running'`` under a row lock, so
+a bench-side stop always wins over a later fleet flip and no sweep ever overwrites a
+real outcome.
+
+Run:
+  bench --site test_site run-tests --app jarvis \
+    --module jarvis.tests.test_agent_run_lifecycle
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, add_to_date, now_datetime
+
+from jarvis import admin_client
+from jarvis.chat import agent_scheduler, agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+ACTIVITY = "Jarvis Agent Activity"
+SESSION = "Jarvis Chat Session"
+
+SLUG = "run-lifecycle-auditor"
+SCRIBE_SLUG = "run-lifecycle-scribe"
+OWNER = "run-lifecycle-owner@example.com"
+STRANGER = "run-lifecycle-stranger@example.com"
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		user.insert(ignore_permissions=True)
+		user.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing(slug: str, nature: str) -> str:
+	if not frappe.db.exists(LISTING, slug):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": slug,
+				"title": f"Run lifecycle {nature.lower()}",
+				"rule_tokens": json.dumps(["tok"]),
+				"doctypes_required": json.dumps([]),
+				"rule_pack": f"pack-{slug}",
+			}
+		).insert(ignore_permissions=True)
+	frappe.db.set_value(LISTING, slug, {"status": "Published", "nature": nature}, update_modified=False)
+	return slug
+
+
+def _wipe() -> None:
+	"""Everything these tests commit. The endpoints under test commit, so
+	FrappeTestCase's own rollback cannot reclaim any of it."""
+	for slug in (SLUG, SCRIBE_SLUG):
+		for name in frappe.get_all(RUN, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(RUN, name, force=True, ignore_permissions=True)
+		for name in frappe.get_all(ACTIVITY, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(ACTIVITY, name, force=True, ignore_permissions=True)
+		for name in frappe.get_all(
+			INSTALLATION, filters={"agent": slug}, pluck="name", ignore_permissions=True
+		):
+			frappe.delete_doc(INSTALLATION, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(
+		SESSION, filters={"session_key": ["like", "agent:agent-run-lifecycle%"]}, pluck="name"
+	):
+		frappe.delete_doc(SESSION, name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+class RunLifecycleTestCase(FrappeTestCase):
+	"""One published auditor + one published scribe, each installed for one owner."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user(OWNER)
+		cls.stranger = _mk_user(STRANGER)
+		_mk_listing(SLUG, "Auditor")
+		_mk_listing(SCRIBE_SLUG, "Scribe")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		_mk_listing(SLUG, "Auditor")
+		_mk_listing(SCRIBE_SLUG, "Scribe")
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	# ------------------------------------------------------------------ #
+	# fixtures
+	# ------------------------------------------------------------------ #
+	def _install(self, slug: str = SLUG) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": slug,
+				"run_as_user": self.owner,
+				"reviewer": self.owner,
+				"enabled": 1,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(INSTALLATION, doc.name, "owner", self.owner, update_modified=False)
+		# A claimed schedule slot (#672): _claim_slot advanced next_run_at BEFORE the
+		# dispatch, so these are the values a terminalization must leave untouched.
+		frappe.db.set_value(
+			INSTALLATION,
+			doc.name,
+			{
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"last_run_at": now_datetime(),
+				"next_run_at": add_days(now_datetime(), 1),
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		return doc.name
+
+	def _run(self, inst: str, *, slug: str = SLUG, status: str = "running", age_s: int = 0, **extra) -> str:
+		"""A committed run row, optionally aged so a sweep's cutoff sees it."""
+		started = add_to_date(now_datetime(), seconds=-age_s)
+		doc = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": slug,
+				"installation": inst,
+				"trigger": "manual",
+				"status": "running",
+				"started_at": started,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		session_key = f"agent:agent-{slug}:{doc.name}"
+		frappe.get_doc({"doctype": SESSION, "session_key": session_key, "user": self.owner}).insert(
+			ignore_permissions=True
+		)
+		values = {"owner": self.owner, "session_key": session_key, "started_at": started, **extra}
+		if status != "running":
+			values["status"] = status
+		frappe.db.set_value(RUN, doc.name, values, update_modified=False)
+		frappe.db.commit()
+		return doc.name
+
+	def _status(self, run: str) -> str:
+		return frappe.db.get_value(RUN, run, "status")
+
+	def _slot(self, inst: str) -> dict:
+		return frappe.db.get_value(INSTALLATION, inst, ["next_run_at", "last_run_at"], as_dict=True)
+
+
+# --------------------------------------------------------------------------- #
+# A1 — ``stopped`` is a real, terminal run status
+# --------------------------------------------------------------------------- #
+class TestStoppedStatusIsTerminal(RunLifecycleTestCase):
+	def test_doctype_offers_stopped(self):
+		options = frappe.get_meta(RUN).get_field("status").options.split("\n")
+		self.assertIn("stopped", options)
+
+	def test_the_accepted_status_list_matches_the_doctype(self):
+		"""``agents_api._RUN_STATUSES`` is hand-maintained and is what the Runs page
+		validates a filter against, so a status added to the DocType and forgotten here
+		is a value the customer can see on a row but never filter by — and one removed
+		from the DocType and left here is a filter that silently matches nothing."""
+		options = {o.strip() for o in frappe.get_meta(RUN).get_field("status").options.split("\n")}
+		self.assertEqual(set(agents_api._RUN_STATUSES), options - {""})
+
+	def test_run_history_filter_accepts_stopped(self):
+		"""The Runs page must be able to filter on the new status — an accepted value
+		the list endpoint refuses is a status the customer can never look up."""
+		inst = self._install()
+		run = self._run(inst, status="stopped")
+		frappe.set_user(self.owner)
+		try:
+			rows = agents_api.list_runs_page(status="stopped")["rows"]
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIn(run, [r["name"] for r in rows])
+
+	def test_stopped_run_is_not_live(self):
+		"""#672's liveness guard is keyed on ``status='running'``, so a stopped run must
+		not keep the installation's Run-now button (and the cron sweep) locked out."""
+		inst = self._install()
+		self._run(inst, status="stopped")
+		self.assertIsNone(agent_scheduler._live_run(inst))
+
+	def test_stopped_run_is_not_a_reaper_candidate(self):
+		"""The 3h backstop must never relabel an operator stop as a duration timeout."""
+		inst = self._install()
+		run = self._run(inst, status="stopped", age_s=agent_scheduler.STALE_RUN_AFTER_SECONDS + 60)
+		cutoff = add_to_date(now_datetime(), seconds=-agent_scheduler.STALE_RUN_AFTER_SECONDS)
+		self.assertNotIn(run, [r.name for r in agent_scheduler._stale_candidates(cutoff)])
+
+
+# --------------------------------------------------------------------------- #
+# A2 — stop_agent_run
+# --------------------------------------------------------------------------- #
+class TestStopAgentRun(RunLifecycleTestCase):
+	def _stop(self, run: str, *, as_user: str | None = None) -> dict:
+		"""Call the endpoint with the gateway abort stubbed out — it is best-effort and
+		its own test covers it; every other assertion here is about the durable state."""
+		user = as_user or self.owner
+		frappe.set_user(user)
+		try:
+			with patch.object(agents_api, "_try_abort_gateway_session"):
+				return agents_api.stop_agent_run(run)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_stop_terminalizes_a_running_run(self):
+		inst = self._install()
+		run = self._run(inst)
+		out = self._stop(run)
+
+		self.assertEqual(out["status"], "stopped")
+		row = frappe.db.get_value(RUN, run, ["status", "finished_at", "error"], as_dict=True)
+		self.assertEqual(row.status, "stopped")
+		self.assertTrue(row.finished_at)
+		self.assertIn("Stopped by operator", row.error)
+
+	def test_stop_revokes_the_run_session_bearer(self):
+		"""The bearer must not outlive the run: a late tool call from a delegate that is
+		still winding down must resolve no identity and 401, so nothing it does can write
+		back onto the stopped run."""
+		inst = self._install()
+		run = self._run(inst)
+		key = frappe.db.get_value(RUN, run, "session_key")
+		self.assertTrue(frappe.db.exists(SESSION, {"session_key": key}))
+		self._stop(run)
+		self.assertFalse(frappe.db.exists(SESSION, {"session_key": key}))
+
+	def test_stop_logs_the_activity(self):
+		inst = self._install()
+		run = self._run(inst)
+		self._stop(run)
+		rows = frappe.get_all(
+			ACTIVITY, filters={"run": run}, fields=["action", "owner"], ignore_permissions=True
+		)
+		self.assertEqual([r.action for r in rows], ["run_stopped"])
+		self.assertEqual(rows[0].owner, self.owner)
+
+	def test_stop_leaves_the_claimed_schedule_slot_consumed(self):
+		"""SLOT PARITY with the reaper: ``_claim_slot`` spent the slot BEFORE dispatch and
+		no terminalization hands it back, so a stopped run must not resurrect it — that
+		would re-dispatch the same slot on the next hourly tick."""
+		inst = self._install()
+		before = self._slot(inst)
+		run = self._run(inst)
+		self._stop(run)
+		self.assertEqual(self._slot(inst), before)
+
+	def test_a_stopped_run_still_counts_against_the_monthly_budget(self):
+		"""Deliberately UNLIKE ``failed`` (which A14 excludes so a skip path cannot make
+		the cap self-perpetuating): a stopped run really occupied the container, so
+		start-then-stop must not be an unlimited free-run loop around the budget."""
+		inst = self._install()
+		run = self._run(inst)
+		self._stop(run)
+		self.assertEqual(agent_scheduler._runs_this_month(installation=inst), 1)
+
+	def test_stop_is_idempotent_on_a_terminal_run(self):
+		"""A second click, or a stop racing a finish, must report the state the run
+		actually reached and never overwrite it."""
+		inst = self._install()
+		run = self._run(inst, status="completed")
+		out = self._stop(run)
+		self.assertEqual(out, {"ok": True, "status": "completed", "idempotent": True})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_stop_refuses_a_non_owner(self):
+		inst = self._install()
+		run = self._run(inst)
+		with self.assertRaises(frappe.PermissionError):
+			self._stop(run, as_user=self.stranger)
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_broken_gateway_abort_never_undoes_the_stop(self):
+		"""The soft stop is the guarantee; the gateway abort is opportunistic. The run
+		lane is dispatched with ``--expect-final`` rather than as a chat session, so this
+		call is expected to be a no-op in production — it must never raise out."""
+		inst = self._install()
+		run = self._run(inst)
+
+		class _Boom:
+			def __enter__(self):
+				raise RuntimeError("gateway down")
+
+			def __exit__(self, *a):
+				return False
+
+		frappe.set_user(self.owner)
+		try:
+			with patch("jarvis.chat.agent_session_pool.checkout", return_value=_Boom()):
+				out = agents_api.stop_agent_run(run)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(out["status"], "stopped")
+		self.assertEqual(self._status(run), "stopped")
+
+	def test_a_late_writeback_has_no_run_to_land_on(self):
+		"""``record_agent_run`` resolves its run SOLELY by the session_key on its bearer
+		row, and refuses anything that is not ``running``. Both doors are shut after a
+		stop: the bearer row is gone (so the lookup finds no run at all) and the status
+		is terminal (so even a surviving bearer would hit the idempotency branch)."""
+		inst = self._install()
+		run = self._run(inst)
+		key = frappe.db.get_value(RUN, run, "session_key")
+		self._stop(run)
+		self.assertFalse(frappe.db.exists(SESSION, {"session_key": key}))
+		self.assertNotEqual(self._status(run), "running")
+
+
+# --------------------------------------------------------------------------- #
+# A3 — poll_dispatched_runs
+# --------------------------------------------------------------------------- #
+# Comfortably past POLL_GRACE_SECONDS, so the row is a candidate for the sweep.
+DISPATCHED_S = agent_scheduler.POLL_GRACE_SECONDS + 180
+
+
+class TestPollDispatchedRuns(RunLifecycleTestCase):
+	def _poll(self, states: dict, default=None) -> list:
+		"""Run the sweep with the admin relay stubbed per run id. Returns the run ids it
+		was asked about, so a test can assert a run was NEVER polled (or count the calls
+		the circuit breaker allowed).
+
+		``default`` answers every run not named in ``states``, and defaults to "still
+		running" — this is a shared site and other modules leave ``running`` rows behind,
+		which the site-wide sweep would otherwise judge on this test's fixture."""
+		asked: list = []
+
+		def _status(run_id):
+			asked.append(run_id)
+			state = states.get(run_id, default if default is not None else {"status": "running"})
+			if isinstance(state, Exception):
+				raise state
+			return state
+
+		with patch.object(admin_client, "get_agent_run_status", side_effect=_status):
+			self.terminalized = agent_scheduler.poll_dispatched_runs()
+		return asked
+
+	def _relayed(self, state: dict) -> dict:
+		"""Admin's own success envelope around the fleet run-state — the shape the bench
+		really receives (``api/_responses._ok``), one level deeper than
+		``admin_client.get_agent_run_status``'s docstring reads."""
+		return {"ok": True, "data": state}
+
+	def _fleet_failed(self, message: str) -> dict:
+		return self._relayed({"status": "failed", "error": {"code": "run_failed", "message": message}})
+
+	def _fleet_completed(self, *, finished_ago_s: float, status: str = "done") -> dict:
+		# The fleet stamps finished_at as a UNIX epoch float, and its word for a clean
+		# exit is ``done`` (fleet-agent main.py, _dispatch_agent_run) - NOT ``completed``.
+		return self._relayed({"status": status, "finished_at": time.time() - finished_ago_s, "error": None})
+
+	# ------------------------------------------------------------------ #
+	def test_a_fleet_failure_is_surfaced_with_its_real_message(self):
+		"""The whole point of polling: the customer reads what actually broke, not the
+		reaper's "exceeded max duration" three hours later."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: self._fleet_failed("delegate exec died: exit 137")})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error", "finished_at"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("exit 137", row.error)
+		self.assertTrue(row.finished_at)
+
+	def test_a_young_run_is_never_polled(self):
+		"""A fresh dispatch is left alone entirely — no admin round trip per run per
+		tick while the delegate is still starting up."""
+		inst = self._install()
+		run = self._run(inst, age_s=10)
+		asked = self._poll({run: self._fleet_failed("should never be read")})
+		self.assertNotIn(run, asked)
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_stopped_run_is_never_reopened_by_a_later_fleet_flip(self):
+		"""The bench stop is authoritative. The fleet may report the same run failed
+		seconds later; the compare-and-set on ``status='running'`` is what keeps the
+		operator's verdict."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S, status="stopped")
+		self._poll({run: self._fleet_failed("late fleet failure")})
+		self.assertEqual(self._status(run), "stopped")
+
+	def test_an_unreachable_admin_leaves_every_run_alone(self):
+		"""A transport fault is never a verdict — the 3h reaper stays the backstop."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: AdminUnreachableError("admin is down")})
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_lost_run_record_is_left_alone_while_young(self):
+		"""A 404 from the host may just mean the state file is not visible yet
+		(container mid-restart), so a young run is not condemned on it."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: AdminUnreachableError("unknown agent run RUN-1")})
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_lost_run_record_fails_the_run_once_it_is_old(self):
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		run = self._run(inst, age_s=agent_scheduler.MISSING_RECORD_FALLBACK_SECONDS + 60)
+		self._poll({run: AdminUnreachableError("unknown agent run RUN-1")})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("no record of this run", row.error)
+
+	def test_the_relay_word_completed_is_read_like_the_fleet_word_done(self):
+		"""``done`` is what the fleet writes; ``completed`` must mean the same thing so a
+		normalising relay can never turn a clean exit back into "still in flight"."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll(
+			{
+				run: self._fleet_completed(
+					finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60, status="completed"
+				)
+			}
+		)
+		self.assertEqual(self._status(run), "failed")
+
+	def test_a_just_finished_run_is_given_its_writeback_grace(self):
+		"""Anchored on the HOST's finish time, not the run's age: this run is hours old
+		and finished ten seconds ago, so its writeback is still plausibly in flight."""
+		inst = self._install()
+		run = self._run(inst, age_s=agent_scheduler.STALE_RUN_AFTER_SECONDS - 60)
+		self._poll({run: self._fleet_completed(finished_ago_s=10)})
+		self.assertEqual(self._status(run), "running")
+
+	def test_a_finished_run_whose_writeback_never_came_fails_honestly(self):
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: self._fleet_completed(finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60)})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("delegate finished without recording results", row.error)
+
+	def test_a_scribe_with_pages_is_completed_not_failed(self):
+		"""CA-4: the pages are already durably written, so a scribe that merely forgot to
+		call finish is an honest SUCCESS. The poll must reach the same ruling the reaper
+		does — they share the transition helper precisely so they cannot diverge."""
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(inst, slug=SCRIBE_SLUG, age_s=DISPATCHED_S, pages_written=4)
+		self._poll({run: self._fleet_completed(finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60)})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_a_scribe_with_a_zero_tally_is_rebuilt_from_page_provenance(self):
+		"""CA2-3: a stored tally of 0 is rebuilt from the pages themselves before any
+		verdict, so real work is never failed away on a false zero."""
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(inst, slug=SCRIBE_SLUG, age_s=DISPATCHED_S, pages_written=0)
+		meta = {"count": 2, "pages": [{"slug": "a", "title": "A"}, {"slug": "b", "title": "B"}]}
+		with patch("jarvis.tools.record_app_wiki.reconcile_run_pages", return_value=meta) as recon:
+			self._poll(
+				{run: self._fleet_completed(finished_ago_s=agent_scheduler.WRITEBACK_GRACE_SECONDS + 60)}
+			)
+		recon.assert_called_once_with(run)
+
+		row = frappe.db.get_value(RUN, run, ["status", "pages_written"], as_dict=True)
+		self.assertEqual(row.status, "completed")
+		self.assertEqual(row.pages_written, 2)
+
+	def test_a_still_running_fleet_state_is_left_alone(self):
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: self._relayed({"status": "running"})})
+		self.assertEqual(self._status(run), "running")
+
+	def test_an_unenveloped_run_state_is_read_too(self):
+		"""The relay shape is a cross-repo contract. Misreading the wrapper would leave
+		every poll seeing a blank status and terminalizing nothing — silently — so both
+		the enveloped and the bare state must be understood."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S)
+		self._poll({run: {"status": "failed", "error": {"message": "bare shape"}}})
+		self.assertEqual(self._status(run), "failed")
+
+	# ------------------------------------------------------------------ #
+	# CA-4 parity: the scribe ruling is keyed on the run's own durable pages,
+	# NEVER on which sweep reached it or why.
+	# ------------------------------------------------------------------ #
+	def test_a_fleet_failed_scribe_with_pages_is_completed_not_failed(self):
+		"""A scribe that wrote its pages and then crashed late is a SUCCESS the delegate
+		merely never finalized. Failing it here would report the same row two different
+		ways depending on whether the poll or the 3h reaper got to it first."""
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(inst, slug=SCRIBE_SLUG, age_s=DISPATCHED_S, pages_written=5)
+		self._poll({run: self._fleet_failed("delegate exec died: exit 137")})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_a_lost_record_scribe_with_pages_is_completed_not_failed(self):
+		"""Same ruling when the host lost the run record entirely: the pages are in the
+		wiki either way, and a pruned state file is not evidence the work never happened."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install(SCRIBE_SLUG)
+		run = self._run(
+			inst,
+			slug=SCRIBE_SLUG,
+			age_s=agent_scheduler.MISSING_RECORD_FALLBACK_SECONDS + 60,
+			pages_written=3,
+		)
+		self._poll({run: AdminUnreachableError("unknown agent run RUN-1")})
+		self.assertEqual(self._status(run), "completed")
+
+	def test_a_fleet_failed_auditor_still_fails(self):
+		"""The CA-4 carve-out is for scribes with durable pages ONLY — an auditor has no
+		such evidence and must still be failed with the delegate's real message."""
+		inst = self._install()
+		run = self._run(inst, age_s=DISPATCHED_S, pages_written=4)
+		self._poll({run: self._fleet_failed("evaluator blew up")})
+
+		row = frappe.db.get_value(RUN, run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("evaluator blew up", row.error)
+
+	# ------------------------------------------------------------------ #
+	# outage circuit breaker
+	# ------------------------------------------------------------------ #
+	def test_the_sweep_stops_calling_admin_after_two_transport_failures(self):
+		"""The sweep is sequential and each admin call can block for the client's full
+		150s timeout, so with admin down a handful of in-flight runs would outlast the
+		5-minute cron interval and sweeps would stack. Two consecutive transport failures
+		is enough evidence that the relay, not any one run, is the problem."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		inst = self._install()
+		runs = [self._run(inst, age_s=DISPATCHED_S) for _ in range(3)]
+
+		with patch.object(frappe, "log_error") as logged:
+			asked = self._poll({}, default=AdminUnreachableError("admin is down"))
+
+		self.assertEqual(len(asked), agent_scheduler.MAX_CONSECUTIVE_POLL_FAILURES)
+		self.assertEqual(self.terminalized, 0)
+		# ONE aggregate line for the whole sweep, never one per run.
+		self.assertEqual(logged.call_count, 1)
+		for run in runs:
+			self.assertEqual(self._status(run), "running")

--- a/jarvis/tests/test_agent_run_steps.py
+++ b/jarvis/tests/test_agent_run_steps.py
@@ -1,0 +1,919 @@
+"""jarvis#1062 — the per-run STEP TIMELINE.
+
+``Jarvis Agent Activity`` records a run's lifecycle (started / completed), and
+nothing at all in between, so a customer watching a running agent got a static
+"Run in progress" line for the whole audit. But the bench already SEES every
+step: the delegate calls back into it for each ``jarvis__*`` tool over the run's
+own session bearer.
+
+What is proven here:
+
+  * ``record_step`` appends monotonically-sequenced, owner-pinned rows and never
+    raises, whatever the caller does to it;
+  * ``humanize_tool_call`` turns a tool call into one short sentence about
+    SHAPES — DocType names, report names, counts — and never quotes a payload;
+  * the ``jarvis.api`` dispatch hook records a ``tool`` step for a delegate run
+    and records NOTHING for an ordinary chat session;
+  * a tool that fails still leaves an ``error`` step, and a tool that raises past
+    the envelope still leaves one AND still raises;
+  * ``record_agent_run`` narrates itself once (a ``writeback`` step), never twice;
+  * ``_launch_audit`` opens the timeline with a ``dispatched`` step only after the
+    fleet accepted the turn;
+  * ``list_run_steps`` is ownership-gated: a foreign run reads as an empty
+    timeline, never as an existence oracle;
+  * duplicate stored ``seq`` values (the unlocked MAX+1 race, seen live) never
+    reach the UI: the response is ordered by ``occurred_at`` and renumbered;
+  * bench-internal DocTypes read as plain English and never leak a record name;
+  * a Single DocType is not named twice, an unresolved lookup says "Looked up"
+    rather than claiming a read, and a failed step carries the tool's own error
+    message in ``detail``.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_agent_run_steps
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api
+from jarvis.chat import agent_catalog, agent_run_steps, agent_scheduler, agents_api
+from jarvis.tools import _agent_run_ctx, _delegate_capability
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+STEP = "Jarvis Agent Run Step"
+SESSION = "Jarvis Chat Session"
+CONVERSATION = "Jarvis Conversation"
+
+SLUG = "rs-auditor"
+# Two reads plus the writeback pair: enough surface for the dispatch hook tests
+# without widening what a real auditor may do.
+TOOLS_ALLOW = [
+	"jarvis__get_schema",
+	"jarvis__get_list",
+	"jarvis__update_wiki",  # a GATED write - the parked-confirmation step needs one
+	"jarvis__record_agent_run",
+	"canvas",
+	"message",
+]
+
+
+def _mk_user(email: str, roles=("System Manager",)) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	existing = {r.role for r in frappe.get_doc("User", email).roles}
+	for role in roles:
+		if role not in existing:
+			frappe.get_doc("User", email).add_roles(role)
+	return email
+
+
+def _mk_listing(slug: str) -> None:
+	"""A dependency-free published listing (no min_apps / doctypes_required), so
+	the install-time installability preflight passes on any bench."""
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": LISTING,
+			"agent_slug": slug,
+			"title": f"Run steps {slug}",
+			"nature": "Auditor",
+			"delivery": "delegate",
+			"status": "Published",
+			"version": "0.1.0",
+			"rule_tokens": json.dumps([]),
+			"min_apps": json.dumps([]),
+			"doctypes_required": json.dumps([]),
+			"writes": json.dumps([]),
+		}
+	).insert(ignore_permissions=True)
+
+
+def _pin_owner(doctype: str, name: str, owner: str) -> None:
+	"""Set a row's owner AFTER insert.
+
+	``Document.insert`` stamps ``owner = frappe.session.user`` unconditionally
+	(``set_user_and_timestamp`` assigns it rather than deferring to a pre-set
+	value), so ``doc.owner = someone`` before ``insert()`` is silently discarded.
+	Every fixture here builds rows as Administrator, so without this the whole
+	cast would be owned by Administrator and every ``if_owner`` assertion below
+	would be testing nothing. Production hits the same rule, which is why
+	``_launch_audit`` and ``log_activity`` both re-stamp owner this same way."""
+	frappe.db.set_value(doctype, name, "owner", owner, update_modified=False)
+
+
+def _mk_run(slug: str, owner: str, session_key: str, status: str = "running") -> str:
+	inst = frappe.get_doc(
+		{"doctype": INSTALLATION, "agent": slug, "run_as_user": owner, "activation_state": "shadow"}
+	)
+	inst.flags.ignore_permissions = True
+	inst.insert(ignore_permissions=True)
+	_pin_owner(INSTALLATION, inst.name, owner)
+	run = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": slug,
+			"installation": inst.name,
+			"trigger": "manual",
+			"status": status,
+			"started_at": frappe.utils.now(),
+			"session_key": session_key,
+			"capability_contract": _delegate_capability.CONTRACT_SNAPSHOT,
+			"tools_allow_json": json.dumps(TOOLS_ALLOW),
+			"capability_nature": "auditor",
+			"capability_writes_json": json.dumps([]),
+		}
+	)
+	run.flags.ignore_permissions = True
+	run.insert(ignore_permissions=True)
+	_pin_owner(RUN, run.name, owner)
+	return run.name
+
+
+def _steps_by_seq(run: str) -> list:
+	"""Raw rows in STORED seq order (creation breaks the tie) - the pre-renumber
+	view, which is what the seq-race tests need to poke at."""
+	return frappe.get_all(
+		STEP,
+		filters={"run": run},
+		fields=["name", "seq", "kind", "label", "occurred_at"],
+		order_by="seq asc, creation asc",
+		ignore_permissions=True,
+	)
+
+
+def _steps(run: str) -> list:
+	return frappe.get_all(
+		STEP,
+		filters={"run": run},
+		fields=["name", "seq", "kind", "tool", "label", "detail", "status", "duration_ms", "owner"],
+		order_by="seq asc",
+		ignore_permissions=True,
+	)
+
+
+def _wipe(slug: str) -> None:
+	for run in frappe.get_all(RUN, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+		for step in frappe.get_all(STEP, filters={"run": run}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(STEP, step, force=True, ignore_permissions=True)
+	for dt in ("Jarvis Agent Activity", RUN, INSTALLATION):
+		for name in frappe.get_all(dt, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+
+
+# --------------------------------------------------------------------------- #
+# record_step
+# --------------------------------------------------------------------------- #
+class TestRecordStep(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("rs-owner@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(SLUG)
+		_mk_listing(SLUG)
+		self.key = f"agent:agent-{SLUG}:rs-run"
+		self.run_name = _mk_run(SLUG, self.owner, self.key)
+
+	def tearDown(self):
+		_agent_run_ctx.clear_session_key()
+		frappe.set_user("Administrator")
+		frappe.db.delete(SESSION, {"session_key": self.key})
+		_wipe(SLUG)
+
+	def test_steps_are_numbered_from_one_and_monotonic(self):
+		for label in ("first", "second", "third"):
+			agent_run_steps.record_step(self.run_name, kind="note", label=label)
+		self.assertEqual([s.seq for s in _steps(self.run_name)], [1, 2, 3])
+		self.assertEqual([s.label for s in _steps(self.run_name)], ["first", "second", "third"])
+
+	def test_owner_is_pinned_to_the_run_owner_not_the_session_user(self):
+		"""The hook runs impersonated (the run-as user) or as the scheduler's
+		Administrator, so an unpinned row would be invisible on the owner-scoped
+		(if_owner) timeline it exists for."""
+		frappe.set_user("Administrator")
+		agent_run_steps.record_step(self.run_name, kind="note", label="pinned", owner=self.owner)
+		self.assertEqual(_steps(self.run_name)[0].owner, self.owner)
+
+	def test_owner_falls_back_to_the_run_owner_when_not_passed(self):
+		"""A caller that forgets ``owner`` must not leak the step to whoever is
+		executing. A step belongs to whoever owns the RUN, always."""
+		frappe.set_user("Administrator")
+		agent_run_steps.record_step(self.run_name, kind="note", label="no explicit owner")
+		self.assertEqual(_steps(self.run_name)[0].owner, self.owner)
+
+	def test_label_and_detail_are_clipped(self):
+		agent_run_steps.record_step(
+			self.run_name, kind="note", label="L" * 400, detail="D" * 900, status="error"
+		)
+		row = _steps(self.run_name)[0]
+		self.assertEqual(len(row.label), agent_run_steps.LABEL_MAX)
+		self.assertEqual(len(row.detail), agent_run_steps.DETAIL_MAX)
+		self.assertEqual(row.status, "error")
+
+	def test_an_unknown_status_falls_back_to_ok(self):
+		agent_run_steps.record_step(self.run_name, kind="note", label="x", status="weird")
+		self.assertEqual(_steps(self.run_name)[0].status, "ok")
+
+	def test_a_missing_run_records_nothing_and_does_not_raise(self):
+		self.assertIsNone(agent_run_steps.record_step("", kind="note", label="orphan"))
+
+	def test_a_failing_insert_is_swallowed(self):
+		"""Narration must never be able to fail the run it narrates."""
+		with mock.patch.object(frappe, "get_doc", side_effect=RuntimeError("db down")):
+			self.assertIsNone(agent_run_steps.record_step(self.run_name, kind="note", label="x"))
+
+	def test_step_target_reads_the_run_off_the_capability_contract(self):
+		"""The step's run comes from the contract the dispatcher already resolved -
+		that reuse is what keeps a tool call at one run-row read."""
+		cap = _delegate_capability.resolve(self.key)
+		got = agent_run_steps.step_target(cap)
+		self.assertEqual(got["name"], self.run_name)
+		self.assertEqual(got["owner"], self.owner)
+
+	def test_step_target_ignores_a_run_that_is_no_longer_running(self):
+		"""A bearer replayed after the run finished must not extend its history."""
+		frappe.db.set_value(RUN, self.run_name, "status", "completed", update_modified=False)
+		self.assertIsNone(agent_run_steps.step_target(_delegate_capability.resolve(self.key)))
+
+	def test_step_target_of_a_non_delegate_is_none(self):
+		self.assertIsNone(agent_run_steps.step_target(_delegate_capability.resolve("plain-chat")))
+		self.assertIsNone(agent_run_steps.step_target(None))
+		self.assertIsNone(agent_run_steps.step_target({}))
+
+	def test_step_target_tolerates_a_stubbed_contract(self):
+		"""Tests stub the dispatch path's collaborators wholesale. A stub must mean
+		"no step", never an exception out of the dispatcher."""
+		self.assertIsNone(agent_run_steps.step_target("conv1"))
+		self.assertIsNone(agent_run_steps.step_target(mock.MagicMock()))
+
+	def test_resolve_treats_a_wholesale_stubbed_get_value_as_a_non_delegate(self):
+		"""THE CI regression: test_api's budget cases patch frappe.db.get_value to
+		return ONE fixed string for every lookup on the dispatch path. That used to
+		be harmless because resolve only ran behind tool_denial, which those tests
+		also patch. It now runs directly, so a stubbed row must make the caller a
+		non-delegate instead of raising AttributeError out of the dispatcher."""
+		with mock.patch.object(frappe.db, "get_value", return_value="conv1"):
+			self.assertIsNone(_delegate_capability.resolve(self.key))
+			self.assertIsNone(_delegate_capability.tool_denial(self.key, "get_list"))
+
+
+# --------------------------------------------------------------------------- #
+# humanize_tool_call
+# --------------------------------------------------------------------------- #
+class TestHumanizeToolCall(unittest.TestCase):
+	def test_get_list_names_the_doctype_and_the_row_count(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"jarvis__get_list", {"doctype": "Sales Invoice"}, [{"name": "SI-1"}, {"name": "SI-2"}]
+		)
+		self.assertEqual(label, "Read Sales Invoice, 2 rows")
+
+	def test_get_list_singular_row(self):
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "ToDo"}, [{"name": "T"}])
+		self.assertEqual(label, "Read ToDo, 1 row")
+
+	def test_get_doc_names_the_document(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "Journal Entry", "name": "JV-0007"}, {"name": "JV-0007"}
+		)
+		self.assertEqual(label, "Read Journal Entry JV-0007")
+
+	def test_get_doc_batch_counts_the_documents_actually_returned(self):
+		"""The REQUESTED count is a wish. A batch that asked for three and was
+		permitted two must say two."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc",
+			{"doctype": "ToDo", "names": ["a", "b", "c"]},
+			{"doctype": "ToDo", "docs": [{"name": "a"}, {"name": "b"}], "count": 2},
+		)
+		self.assertEqual(label, "Read ToDo, 2 documents")
+
+	def test_get_doc_batch_falls_back_to_the_requested_count(self):
+		"""When the payload exposes no count of its own, the request is the only
+		honest number available."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "ToDo", "names": ["a", "b", "c"]}, {"ok": True}
+		)
+		self.assertEqual(label, "Read ToDo, 3 documents")
+
+	def test_an_unresolved_batch_claims_no_documents(self):
+		"""THE defect: a failed batch used to report the requested count as though
+		it had read them."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "ToDo", "names": ["a", "b", "c"]}, None
+		)
+		self.assertEqual(label, "Looked up ToDo")
+
+	def test_run_report_names_the_report_and_counts_result_rows(self):
+		label, detail = agent_run_steps.humanize_tool_call(
+			"run_report", {"report_name": "Trial Balance"}, {"columns": [], "result": [1, 2, 3]}
+		)
+		self.assertEqual(label, "Ran report Trial Balance")
+		self.assertEqual(detail, "3 rows")
+
+	def test_query_names_the_from_doctype(self):
+		label, detail = agent_run_steps.humanize_tool_call(
+			"query", {"spec": {"from": "GL Entry"}}, {"sql": "select 1", "rows": [1, 2]}
+		)
+		self.assertEqual(label, "Queried GL Entry")
+		self.assertEqual(detail, "2 rows")
+
+	def test_get_balance_on_names_the_account(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_balance_on", {"account": "Debtors - AB"}, {"balance": 1200.0}
+		)
+		self.assertEqual(label, "Checked balance for Debtors - AB")
+
+	def test_plural_is_the_one_way_a_count_is_phrased(self):
+		"""The writeback step builds its own label from this helper, so the closing
+		step counts things exactly the way every other step does."""
+		self.assertEqual(agent_run_steps.plural(0, "finding"), "0 findings")
+		self.assertEqual(agent_run_steps.plural(1, "finding"), "1 finding")
+		self.assertEqual(agent_run_steps.plural(2, "finding"), "2 findings")
+
+	def test_save_agent_dashboard_has_fixed_copy(self):
+		label, _ = agent_run_steps.humanize_tool_call("save_agent_dashboard", {}, {"dashboard": "D-1"})
+		self.assertEqual(label, "Saved dashboard")
+
+	def test_an_unknown_tool_falls_back_to_a_title_cased_name(self):
+		label, _ = agent_run_steps.humanize_tool_call("jarvis__get_fiscal_year", {}, {})
+		self.assertEqual(label, "Get Fiscal Year")
+
+	def test_a_failed_call_still_yields_a_label(self):
+		"""``result`` is None on the error path — the step still has to say what
+		was attempted."""
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "ToDo"}, None)
+		self.assertEqual(label, "Read ToDo")
+
+	def test_the_label_never_quotes_the_payload(self):
+		"""A step carries shapes, not customer data: nothing from the returned row
+		may reach the label or the detail."""
+		label, detail = agent_run_steps.humanize_tool_call(
+			"get_list",
+			{"doctype": "Customer"},
+			[{"name": "CUST-1", "customer_name": "Aerele Technologies", "credit_limit": 900000}],
+		)
+		self.assertNotIn("Aerele", label + detail)
+		self.assertNotIn("900000", label + detail)
+
+	# ---- bench-internal DocTypes read as plain English -------------------- #
+	def test_internal_doctypes_are_named_by_what_they_are(self):
+		""" "Jarvis Agent Installation" is implementation vocabulary the customer
+		has never seen. The step names the ACT instead."""
+		cases = {
+			"Jarvis Agent Installation": "Read engagement configuration",
+			"Jarvis Agent Listing": "Read agent definition",
+			"Jarvis Agent Run": "Checked run state",
+			"Jarvis Agent Finding": "Read agent metadata",
+			"Jarvis Agent Provenance Event": "Read agent metadata",
+		}
+		for doctype, expected in cases.items():
+			label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": doctype}, [{}])
+			self.assertEqual(label, expected, doctype)
+
+	def test_an_internal_read_never_shows_the_record_name(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc",
+			{"doctype": "Jarvis Agent Installation", "name": "8f3ac1de99"},
+			{"name": "8f3ac1de99"},
+		)
+		self.assertEqual(label, "Read engagement configuration")
+		self.assertNotIn("8f3ac1de99", label)
+
+	def test_an_internal_list_keeps_its_row_count_on_the_second_line(self):
+		label, detail = agent_run_steps.humanize_tool_call(
+			"get_list", {"doctype": "Jarvis Agent Run"}, [{}, {}, {}]
+		)
+		self.assertEqual(label, "Checked run state")
+		self.assertEqual(detail, "3 rows")
+
+	def test_an_internal_query_is_mapped_too(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"query", {"spec": {"from": "Jarvis Agent Listing"}}, {"rows": []}
+		)
+		self.assertEqual(label, "Read agent definition")
+
+	def test_an_ordinary_erp_doctype_is_untouched(self):
+		"""The control: the mapping must not swallow the DocTypes the customer
+		does know by name."""
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "Sales Invoice"}, [{}, {}])
+		self.assertEqual(label, "Read Sales Invoice, 2 rows")
+
+	# ---- Singles, and names that did not resolve -------------------------- #
+	def test_a_single_doctype_is_not_named_twice(self):
+		""" "Read System Settings System Settings" - a Single's document name IS
+		its doctype."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc",
+			{"doctype": "System Settings", "name": "System Settings"},
+			{"name": "System Settings"},
+		)
+		self.assertEqual(label, "Read System Settings")
+
+	def test_a_single_ignores_a_stray_name_or_an_empty_names_list(self):
+		"""get_doc short-circuits a Single AHEAD of name/names (#1062), because its
+		one document's name IS the doctype. A delegate with nothing sensible to put
+		there sends "" or [] - and the step must still read as the one document it
+		actually got, never "Read System Settings, 0 documents".
+
+		Each case carries the shape get_doc ACTUALLY returns for it: flat for
+		name/empty-names, and the batch envelope for a non-empty names list (a
+		caller that asked for the batch shape gets it back, holding the one
+		document). Feeding one flat dict to all three would pass either way and
+		prove nothing about the real contract."""
+		flat = {"name": "System Settings"}
+		batch = {"doctype": "System Settings", "docs": [flat], "count": 1}
+		for args, result in (
+			({"doctype": "System Settings", "names": []}, flat),
+			({"doctype": "System Settings", "names": ["bogus", "also-bogus"]}, batch),
+			({"doctype": "System Settings", "name": "x"}, flat),
+		):
+			label, _ = agent_run_steps.humanize_tool_call("get_doc", args, result)
+			self.assertEqual(label, "Read System Settings", args)
+
+	def test_a_single_that_did_not_resolve_claims_no_read(self):
+		"""A Single is no longer a read that always succeeds: get_doc's Single branch
+		checks read permission explicitly (#1062), and Singles carry their own
+		DocPerms - Stock Settings is Stock Manager / Sales User only. A refusal must
+		read as an attempt, never as a read that happened."""
+		label, _ = agent_run_steps.humanize_tool_call("get_doc", {"doctype": "System Settings"}, None)
+		self.assertEqual(label, "Looked up System Settings")
+
+	def test_a_refused_single_read_says_attempt_plus_reason(self):
+		"""The two halves the step hook composes for get_doc's new Single permission
+		check: the label claims only an attempt, and the tool's own refusal is what
+		explains it."""
+		args = {"doctype": "Stock Settings"}
+		label, _ = agent_run_steps.humanize_tool_call("get_doc", args, None)
+		self.assertEqual(label, "Looked up Stock Settings")
+		self.assertEqual(
+			agent_run_steps.error_detail("no read permission on Stock Settings"),
+			"no read permission on Stock Settings",
+		)
+
+	def test_an_unresolved_lookup_says_what_was_attempted(self):
+		"""The record name is MODEL-supplied. A wrong guess produced "Read Company
+		ignore" on the bench; an unresolved lookup must not claim a read at all."""
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "Company", "name": "ignore"}, None
+		)
+		self.assertEqual(label, "Looked up Company")
+
+	def test_a_resolved_lookup_still_names_the_document(self):
+		label, _ = agent_run_steps.humanize_tool_call(
+			"get_doc", {"doctype": "Company", "name": "Aerele"}, {"name": "Aerele"}
+		)
+		self.assertEqual(label, "Read Company Aerele")
+
+	# ---- error detail ------------------------------------------------------ #
+	def test_error_detail_keeps_the_first_line_only(self):
+		self.assertEqual(
+			agent_run_steps.error_detail("unknown Report: Foo\nTraceback (most recent call last):"),
+			"unknown Report: Foo",
+		)
+
+	def test_error_detail_is_clipped(self):
+		self.assertEqual(len(agent_run_steps.error_detail("x" * 900)), agent_run_steps.ERROR_DETAIL_MAX)
+
+	def test_error_detail_of_nothing_is_empty(self):
+		self.assertEqual(agent_run_steps.error_detail(None), "")
+		self.assertEqual(agent_run_steps.error_detail("   "), "")
+
+	def test_labels_and_details_are_clipped(self):
+		label, _ = agent_run_steps.humanize_tool_call("get_list", {"doctype": "D" * 400}, [])
+		self.assertLessEqual(len(label), agent_run_steps.LABEL_MAX)
+
+
+# --------------------------------------------------------------------------- #
+# the jarvis.api dispatch hook
+# --------------------------------------------------------------------------- #
+class TestDispatchHookRecordsSteps(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.run_as = _mk_user("rs-runas@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(SLUG)
+		_mk_listing(SLUG)
+		self.key = f"agent:agent-{SLUG}:rs-dispatch"
+		self.run_name = _mk_run(SLUG, self.run_as, self.key)
+
+	def tearDown(self):
+		_agent_run_ctx.clear_session_key()
+		frappe.set_user("Administrator")
+		frappe.db.delete(SESSION, {"session_key": self.key})
+		_wipe(SLUG)
+
+	def _dispatch(self, session_key: str, tool: str, args: dict | None = None) -> dict:
+		"""The REAL plugin dispatch entry point — impersonation, capability gate,
+		_run_tool, receipt — not a hand-rolled stand-in for it."""
+		return api._dispatch_from_session(self.run_as, session_key, tool, args or {})
+
+	def test_a_delegate_tool_call_lands_one_step(self):
+		res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		rows = _steps(self.run_name)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].kind, "tool")
+		self.assertEqual(rows[0].tool, "get_schema")
+		self.assertEqual(rows[0].status, "ok")
+		self.assertEqual(rows[0].owner, self.run_as)
+		self.assertIsNotNone(rows[0].duration_ms)
+
+	def test_an_ordinary_chat_session_records_nothing(self):
+		"""THE control: the hook must be invisible to non-agent chat, which is
+		almost all of the traffic on this endpoint."""
+		res = self._dispatch("chat-session-with-no-agent-run", "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		self.assertEqual(_steps(self.run_name), [])
+
+	def test_a_terminal_run_records_nothing(self):
+		"""Only a RUNNING run has a timeline to extend; a bearer replayed after the
+		run finished must not append to its history."""
+		frappe.db.set_value(RUN, self.run_name, "status", "completed", update_modified=False)
+		self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertEqual(_steps(self.run_name), [])
+
+	def test_a_tool_error_envelope_leaves_an_error_step(self):
+		with mock.patch.object(
+			api, "_run_tool", return_value={"ok": False, "error": {"code": "X", "message": "no"}}
+		):
+			res = self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		rows = _steps(self.run_name)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].status, "error")
+		self.assertEqual(rows[0].label, "Read ToDo")
+
+	def test_an_error_step_carries_the_tools_own_message(self):
+		"""A bare red row the customer cannot act on is not an explanation. The
+		label stays the humanized ACTION; the tool's message becomes the detail."""
+		with mock.patch.object(
+			api,
+			"_run_tool",
+			return_value={
+				"ok": False,
+				"error": {"code": "InvalidArgumentError", "message": "unknown Report: Foo"},
+			},
+		):
+			self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		row = _steps(self.run_name)[0]
+		self.assertEqual(row.label, "Read ToDo")
+		self.assertEqual(row.detail, "unknown Report: Foo")
+
+	def test_an_error_detail_is_the_first_line_only(self):
+		with mock.patch.object(
+			api,
+			"_run_tool",
+			return_value={"ok": False, "error": {"message": "boom\nTraceback: secret"}},
+		):
+			self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		self.assertEqual(_steps(self.run_name)[0].detail, "boom")
+
+	def test_a_raising_tool_still_raises_and_still_leaves_an_error_step(self):
+		"""A fault past _run_tool's envelope translation is a real bug: it must
+		still reach Frappe's handler, and the step must be ATTEMPTED on the way
+		out. In a real request the handler then rolls the transaction back and
+		takes the row with it - deliberately, since committing to save it would
+		also flush the raising tool's partial writes. The step that SURVIVES a
+		tool failure is the ok=False envelope one above, which is how a tool
+		error normally arrives."""
+		with mock.patch.object(api, "_run_tool", side_effect=RuntimeError("boom")):
+			with self.assertRaises(RuntimeError):
+				self._dispatch(self.key, "get_list", {"doctype": "ToDo"})
+		rows = _steps(self.run_name)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].status, "error")
+		self.assertEqual(rows[0].tool, "get_list")
+
+	def test_the_writeback_tool_is_not_double_narrated_by_the_hook(self):
+		"""``record_agent_run`` writes its OWN writeback step (it is the only caller
+		that knows how many findings actually persisted), so the generic hook must
+		skip it rather than adding a second row for the same act."""
+		with mock.patch.object(api, "_run_tool", return_value={"ok": True, "data": {}}):
+			self._dispatch(self.key, "record_agent_run", {"findings": []})
+		self.assertEqual(_steps(self.run_name), [])
+
+	def test_a_refused_tool_records_no_step(self):
+		"""A capability refusal never reaches dispatch, so there is no step to
+		record — the refusal is the receipt, and the audit trail already has it."""
+		res = self._dispatch(self.key, "get_doc", {"doctype": "ToDo", "name": "nope"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+		self.assertEqual(_steps(self.run_name), [])
+
+	def test_a_delegate_tool_call_reads_the_run_row_exactly_once(self):
+		"""The capability gate and the timeline both need the run row. They share
+		ONE read - this is the hot path of every plugin tool call, and it used to
+		fetch the same row twice."""
+		real_get_value = frappe.db.get_value
+		run_reads = []
+
+		def counting(doctype, *a, **kw):
+			if doctype == RUN:
+				run_reads.append(a[0] if a else kw.get("filters"))
+			return real_get_value(doctype, *a, **kw)
+
+		with mock.patch.object(frappe.db, "get_value", side_effect=counting):
+			res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		self.assertEqual(len(run_reads), 1, run_reads)
+		self.assertEqual(len(_steps(self.run_name)), 1)
+
+	def test_an_ordinary_chat_session_costs_one_lookup_and_no_more(self):
+		"""The control: non-agent chat is almost all of this endpoint's traffic. It
+		pays the single lookup that discovers there is no delegate run, and nothing
+		for the timeline on top of it."""
+		real_get_value = frappe.db.get_value
+		run_reads = []
+
+		def counting(doctype, *a, **kw):
+			if doctype == RUN:
+				run_reads.append(1)
+			return real_get_value(doctype, *a, **kw)
+
+		with mock.patch.object(frappe.db, "get_value", side_effect=counting):
+			res = self._dispatch("chat-session-with-no-agent-run", "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+		# one lookup to discover there is no delegate run, and nothing more
+		self.assertEqual(len(run_reads), 1, run_reads)
+
+	def test_a_parked_gated_write_reads_as_a_proposal_not_an_act(self):
+		"""A gated write returns ok but only PARKS a confirmation card. Narrating it
+		as done would claim a write that may never happen."""
+		with mock.patch.object(
+			api,
+			"_run_tool",
+			return_value={"ok": True, "data": {"status": "pending_confirmation", "token": "t"}},
+		):
+			res = self._dispatch(self.key, "update_wiki", {"slug": "cash-flow"})
+		self.assertTrue(res["ok"], res)
+		row = _steps(self.run_name)[0]
+		self.assertEqual(row.kind, "tool")
+		self.assertEqual(row.status, "ok")
+		self.assertEqual(row.label, "Proposed Update Wiki, awaiting confirmation")
+		self.assertEqual(row.detail, "waiting for a human to confirm")
+
+	def test_the_writeback_step_reports_the_count_that_persisted(self):
+		"""The real writeback path (not the humanize table it was moved out of):
+		record_agent_run writes its own step, phrased with the shared `plural`."""
+		from jarvis.tools import record_agent_run as rar
+
+		run_doc = frappe.get_doc(RUN, self.run_name)
+		run_doc.findings_count = 3
+		run_doc.blocker_count = 0
+		with mock.patch("jarvis.chat.agent_runs.record_delegate_run", return_value=run_doc):
+			_agent_run_ctx.set_session_key(self.key)
+			try:
+				rar.record_agent_run(findings=[], coverage={})
+			finally:
+				_agent_run_ctx.clear_session_key()
+		rows = _steps(self.run_name)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].kind, "writeback")
+		self.assertEqual(rows[0].label, "Recorded 3 findings")
+		self.assertEqual(rows[0].owner, self.run_as)
+
+	def test_a_broken_step_hook_never_breaks_the_tool_call(self):
+		with mock.patch.object(agent_run_steps, "record_step", side_effect=RuntimeError("nope")):
+			res = self._dispatch(self.key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+
+
+# --------------------------------------------------------------------------- #
+# list_run_steps
+# --------------------------------------------------------------------------- #
+class TestListRunSteps(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		# CI runs a fresh DB: the role the timeline's if_owner read depends on has
+		# to exist before a user can be given it (the local bench is role-polluted
+		# and hides this).
+		from jarvis.permissions import ensure_jarvis_user_role
+
+		ensure_jarvis_user_role()
+		cls.owner = _mk_user("rs-mine@example.com", roles=("Jarvis User",))
+		cls.stranger = _mk_user("rs-stranger@example.com", roles=("Jarvis User",))
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(SLUG)
+		_mk_listing(SLUG)
+		self.key = f"agent:agent-{SLUG}:rs-list"
+		self.run_name = _mk_run(SLUG, self.owner, self.key)
+		agent_run_steps.record_step(
+			self.run_name, kind="dispatched", label="Dispatched to the agent", owner=self.owner
+		)
+		agent_run_steps.record_step(
+			self.run_name, kind="tool", tool="get_list", label="Read ToDo, 2 rows", owner=self.owner
+		)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete(SESSION, {"session_key": self.key})
+		_wipe(SLUG)
+
+	def test_the_owner_reads_their_timeline_in_sequence_order(self):
+		frappe.set_user(self.owner)
+		res = agents_api.list_run_steps(self.run_name)
+		self.assertEqual(res["count"], 2)
+		self.assertEqual([s["kind"] for s in res["steps"]], ["dispatched", "tool"])
+		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2])
+
+	def test_a_foreign_run_reads_as_an_empty_timeline_not_an_oracle(self):
+		"""Identical to an unknown run: a stranger must not be able to tell that
+		this run exists, let alone how busy it was."""
+		frappe.set_user(self.stranger)
+		self.assertEqual(agents_api.list_run_steps(self.run_name), {"steps": [], "count": 0})
+		self.assertEqual(agents_api.list_run_steps("RUN-does-not-exist"), {"steps": [], "count": 0})
+
+	def test_a_jarvis_admin_may_read_someone_elses_run(self):
+		admin = _mk_user("rs-admin@example.com", roles=("Jarvis User", "System Manager"))
+		frappe.set_user(admin)
+		self.assertEqual(agents_api.list_run_steps(self.run_name)["count"], 2)
+
+	def test_duplicate_stored_seq_is_renumbered_in_the_response(self):
+		"""THE live defect: record_step's MAX(seq)+1 is unlocked, so parallel tool
+		calls land on the same number (2,2,2 then 3,3 on the bench). The stored
+		column may collide; what the UI reads must not."""
+		third = agent_run_steps.record_step(
+			self.run_name, kind="tool", tool="get_doc", label="Read ToDo T-1", owner=self.owner
+		)
+		# force the collision the race produces, and pin the true order via
+		# occurred_at (the column the response now sorts on)
+		frappe.db.set_value(STEP, third, "seq", 2, update_modified=False)
+		for name, occurred in zip(
+			[s.name for s in _steps_by_seq(self.run_name)],
+			["2026-09-02 10:00:00.000000", "2026-09-02 10:00:01.000000", "2026-09-02 10:00:02.000000"],
+			strict=False,
+		):
+			frappe.db.set_value(STEP, name, "occurred_at", occurred, update_modified=False)
+
+		frappe.set_user(self.owner)
+		res = agents_api.list_run_steps(self.run_name)
+		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2, 3])
+		self.assertEqual(
+			[s["label"] for s in res["steps"]],
+			["Dispatched to the agent", "Read ToDo, 2 rows", "Read ToDo T-1"],
+		)
+
+	def test_the_response_is_ordered_by_when_the_step_happened(self):
+		"""Ordering is occurred_at, not the racy stored seq: a step stamped later
+		reads later even when its seq says otherwise."""
+		frappe.set_user("Administrator")
+		rows = _steps_by_seq(self.run_name)
+		frappe.db.set_value(
+			STEP, rows[0].name, "occurred_at", "2026-09-02 11:00:00.000000", update_modified=False
+		)
+		frappe.db.set_value(
+			STEP, rows[1].name, "occurred_at", "2026-09-02 10:00:00.000000", update_modified=False
+		)
+		frappe.set_user(self.owner)
+		res = agents_api.list_run_steps(self.run_name)
+		self.assertEqual([s["kind"] for s in res["steps"]], ["tool", "dispatched"])
+		self.assertEqual([s["seq"] for s in res["steps"]], [1, 2])
+
+	def test_a_blank_run_is_an_empty_timeline(self):
+		frappe.set_user(self.owner)
+		self.assertEqual(agents_api.list_run_steps("")["count"], 0)
+
+
+# --------------------------------------------------------------------------- #
+# the launch opens the timeline
+# --------------------------------------------------------------------------- #
+class TestLaunchRecordsDispatchedStep(unittest.TestCase):
+	"""``_launch_audit`` commits, so this class cleans up after itself rather than
+	relying on a test-case rollback."""
+
+	SLUG = "rs-launch-agent"
+	OWNER = "rs-launch-owner@example.com"
+	DECLARED = ["jarvis__get_schema", "jarvis__record_agent_run", "canvas", "message"]
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		_mk_user(cls.OWNER)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.created: list[tuple[str, str]] = []
+		_mk_listing(self.SLUG)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for run in frappe.get_all(RUN, filters={"agent": self.SLUG}, pluck="name", ignore_permissions=True):
+			for step in frappe.get_all(STEP, filters={"run": run}, pluck="name", ignore_permissions=True):
+				frappe.delete_doc(STEP, step, force=True, ignore_permissions=True)
+		for dt, name in self.created:
+			try:
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for dt in ("Jarvis Agent Activity", RUN, INSTALLATION):
+			for n in frappe.get_all(dt, filters={"agent": self.SLUG}, pluck="name", ignore_permissions=True):
+				try:
+					frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+				except Exception:
+					pass
+		if frappe.db.exists(LISTING, self.SLUG):
+			frappe.delete_doc(LISTING, self.SLUG, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _launch(self, post=None) -> dict:
+		import jarvis.admin_client as admin_client
+
+		inst = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": self.SLUG,
+				"run_as_user": self.OWNER,
+				"activation_state": "shadow",
+				"enabled": 1,
+			}
+		)
+		inst.flags.ignore_permissions = True
+		inst.insert(ignore_permissions=True)
+		# THE CI failure this fixture caused: the pre-insert `inst.owner = OWNER`
+		# was discarded, so the installation belonged to Administrator, and
+		# _launch_audit (which correctly reads `owner = inst.owner`) pinned the run
+		# AND its first step to Administrator. Re-read so the doc handed to the
+		# launch carries the owner the database now holds.
+		_pin_owner(INSTALLATION, inst.name, self.OWNER)
+		inst = frappe.get_doc(INSTALLATION, inst.name)
+		frappe.db.commit()
+
+		orig = admin_client.post_agent_run
+		admin_client.post_agent_run = post or (lambda **kw: {"run_id": kw.get("run_id"), "status": "queued"})
+		frappe.set_user(self.OWNER)
+		try:
+			with mock.patch.object(agent_catalog, "registry_tools_allow", return_value=self.DECLARED):
+				result = agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+			admin_client.post_agent_run = orig
+		self.created.append((RUN, result["run"]))
+		self.created.append((CONVERSATION, result["conversation"]))
+		session = frappe.db.get_value(SESSION, {"session_key": result["session_key"]}, "name")
+		if session:
+			self.created.append((SESSION, session))
+		return result
+
+	def test_launch_opens_the_timeline_with_a_dispatched_step(self):
+		result = self._launch()
+		# Guard the PREMISE first. The step below can only be owner-pinned if the
+		# launch itself was, and a fixture whose installation quietly reverts to
+		# Administrator (Document.insert discards a pre-set owner - see _pin_owner)
+		# would otherwise fail on the step and read as a bug in the step code.
+		self.assertEqual(frappe.db.get_value(RUN, result["run"], "owner"), self.OWNER)
+		rows = _steps(result["run"])
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].kind, "dispatched")
+		self.assertEqual(rows[0].seq, 1)
+		self.assertEqual(rows[0].label, "Dispatched to the agent")
+		self.assertEqual(rows[0].owner, self.OWNER)
+
+	def test_a_failed_dispatch_opens_no_timeline(self):
+		""" "Dispatched" must mean the fleet really accepted the turn — a refused
+		dispatch has to leave the timeline empty, not claim a step that never
+		happened."""
+
+		def _boom(**kw):
+			raise RuntimeError("fleet said no")
+
+		with self.assertRaises(RuntimeError):
+			self._launch(post=_boom)
+		runs = frappe.get_all(RUN, filters={"agent": self.SLUG}, pluck="name", ignore_permissions=True)
+		self.assertTrue(runs)
+		for run in runs:
+			self.assertEqual(_steps(run), [])

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -8,20 +8,33 @@ cover mutation authZ (S3), the deterministic Run+Findings persistence with
 dedupe (O2), and catalog-sync idempotency.
 """
 
+import json
 import unittest
 
 import frappe
 
 from jarvis.chat import agent_catalog, agent_scheduler, agents_api
+from jarvis.tests._agent_access import allow_listing_for, clear_listing_access
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
 FINDING = "Jarvis Agent Finding"
+ACTIVITY = "Jarvis Agent Activity"
 ALLOWED_ROLE = "Jarvis Agent Allowed Role"
 
 ROLE_X = "Jarvis Agent Test Role X"
 ROLE_Y = "Jarvis Agent Test Role Y"
+
+# Every catalog agent this module installs, runs or pushes. Granted to the whole
+# cast in setUp because access is deny-by-default (jarvis#1062); allow_listing_for
+# no-ops on a slug this site's registry does not carry.
+_MODULE_SLUGS = (
+	"close-auditor",
+	"bank-recon-operator",
+	"ledger-scrutiny-auditor",
+	"custom-app-learning",
+)
 
 
 def _ensure_role(role_name: str) -> str:
@@ -129,13 +142,22 @@ class TestAgentsMarketplace(unittest.TestCase):
 
 	def setUp(self):
 		frappe.set_user("Administrator")
-		# Clean this test's installs/runs/findings so reruns are deterministic.
-		for dt in (FINDING, RUN, INSTALLATION):
+		# Clean this test's installs/runs/findings/activity so reruns are
+		# deterministic (install_agent/log_activity commit; FrappeTestCase's
+		# rollback cannot reclaim them).
+		for dt in (FINDING, RUN, ACTIVITY, INSTALLATION):
 			for owner in (self.owner, self.other, self.admin):
 				for n in frappe.get_all(dt, filters={"owner": owner}, pluck="name"):
 					frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
-		# Clear any role restriction left by a previous test (bench-admin state).
-		frappe.db.delete(ALLOWED_ROLE, {"parenttype": LISTING, "parentfield": "allowed_roles"})
+		# jarvis#1062: access is DENY BY DEFAULT, so clearing the allow rows is no
+		# longer a way to make the catalog reachable - it is how you CLOSE it. Reset
+		# to a known state, then grant this module's cast by name so the tests whose
+		# subject is NOT access control (install, run, schedule, push) reach the code
+		# they mean to exercise. The RBAC tests below narrow it again via _restrict.
+		clear_listing_access()
+		for slug in _MODULE_SLUGS:
+			for u in (self.owner, self.other, self.admin):
+				allow_listing_for(slug, user=u)
 		frappe.db.commit()
 
 	def tearDown(self):
@@ -212,6 +234,76 @@ class TestAgentsMarketplace(unittest.TestCase):
 		conv_owner = frappe.db.get_value("Jarvis Conversation", result["data"]["conversation"], "owner")
 		self.assertEqual(conv_owner, self.owner)
 		self.assertNotEqual(conv_owner, "Administrator")
+
+	def _run_now_on_unapplied_agent(self, *, owner, run_as):
+		"""Shared drive for the "not an installed delegate" translation (jarvis#1062
+		D1): install as ``owner``, then redirect run_as_user to ``run_as`` - a
+		DIFFERENT identity when the two diverge, which is what pins the fix.
+		``_launch_audit`` runs impersonated AS run_as (R1-F3: deliberately
+		decoupled from the owner), so a caller passing owner != run_as proves the
+		message follows the OWNER (who actually reads it back on the Runs board),
+		never the impersonated session. Stubs the fleet 502 and asserts the Run
+		lands terminal FAILED with the translated message (never a raw 500 or a
+		stuck "running" row). Returns (raised exception message, persisted
+		run.error)."""
+		inst_name = _install_as(owner, "close-auditor")
+		frappe.db.set_value(INSTALLATION, inst_name, "run_as_user", run_as, update_modified=False)
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1)
+		agent = frappe.db.get_value(INSTALLATION, inst_name, "agent")
+		frappe.db.commit()
+
+		import jarvis.admin_client as admin_client
+		from jarvis.exceptions import AdminUnreachableError
+
+		orig_run = admin_client.post_agent_run
+
+		def _not_installed(**kw):
+			raise AdminUnreachableError(
+				"admin returned a 502 error: invalid_spec: agent_id "
+				f"'{kw.get('agent_id')}' is not an installed delegate on jarvis-pool-test"
+			)
+
+		admin_client.post_agent_run = _not_installed
+		try:
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agents_api.run_agent_now(inst_name)
+		finally:
+			admin_client.post_agent_run = orig_run
+
+		# The run must be terminal FAILED (never left stuck "running") and carry the
+		# same actionable message, not a raw fleet 502.
+		run = frappe.get_all(
+			RUN,
+			filters={"agent": agent, "owner": owner},
+			fields=["status", "error"],
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertTrue(run)
+		self.assertEqual(run[0].status, "failed")
+		return str(ctx.exception), run[0].error or ""
+
+	def test_run_now_on_unapplied_agent_follows_the_owner_not_the_impersonated_run_as(self):
+		# self.admin (System Manager, a reviewer) OWNS the install; the RUN-AS
+		# identity _launch_audit impersonates is self.owner (ROLE_X only, NOT a
+		# reviewer). The copy must still be the actionable reviewer copy, because
+		# it follows the OWNER - a regression back to frappe.session.user (the
+		# impersonated run-as) would flip this to the non-reviewer copy instead.
+		exc_msg, run_error = self._run_now_on_unapplied_agent(owner=self.admin, run_as=self.owner)
+		self.assertIn("Apply catalog changes", exc_msg)
+		self.assertIn("Apply catalog changes", run_error)
+
+	def test_run_now_on_unapplied_agent_tells_a_non_reviewer_owner_to_ask_an_admin(self):
+		# self.owner (ROLE_X only, NOT a reviewer) OWNS the install; the RUN-AS
+		# identity _launch_audit impersonates is self.admin (a reviewer). The
+		# message must still be the non-reviewer copy, because it follows the
+		# OWNER - proving the branch does not read the impersonated run-as
+		# session even when THAT identity happens to be a reviewer.
+		exc_msg, run_error = self._run_now_on_unapplied_agent(owner=self.owner, run_as=self.admin)
+		self.assertNotIn("Apply catalog changes", exc_msg)
+		self.assertIn("Ask your administrator", exc_msg)
+		self.assertNotIn("Apply catalog changes", run_error)
+		self.assertIn("Ask your administrator", run_error)
 
 	# ------------------------------------------------------------------ #
 	# (a2) Phase 2C — delegate dispatch routes through admin, not chat
@@ -334,10 +426,12 @@ class TestAgentsMarketplace(unittest.TestCase):
 		count2 = frappe.db.count(LISTING)
 		self.assertEqual(count1, count2)  # no dup rows on re-sync
 		self.assertEqual(r2["created"], 0)  # nothing created the second time
-		# The registry ships exactly the two delegate agents.
 		published = set(frappe.get_all(LISTING, filters={"status": "Published"}, pluck="name"))
 		self.assertIn("close-auditor", published)
-		self.assertIn("bank-recon-operator", published)
+		# jarvis#1062 polish: bank-recon-operator has no dispatch path yet and was
+		# flipped to Coming Soon in the registry - it must follow on sync, not
+		# stay Published.
+		self.assertEqual(frappe.db.get_value(LISTING, "bank-recon-operator", "status"), "Coming Soon")
 		# Every shipped agent is delegate and BODY-FREE: the proprietary SKILL must
 		# NEVER be stored in the customer DB (A2) — it lives only in the admin
 		# bundle store.
@@ -347,6 +441,170 @@ class TestAgentsMarketplace(unittest.TestCase):
 			bundle = frappe.parse_json(row.skill_bundle) or []
 			has_body = any((b or {}).get("body", "").strip() for b in bundle)
 			self.assertFalse(has_body, f"{slug} (delegate) leaked a skill body into the DB")
+
+	# ------------------------------------------------------------------ #
+	# (d3) jarvis#1062 polish: category derived from domain, mapped to a
+	# real label instead of a bare registry code
+	# ------------------------------------------------------------------ #
+	def test_category_from_domain_uses_the_real_label_map(self):
+		self.assertEqual(agent_catalog._category_from_domain("ap"), "Accounts Payable")
+		self.assertEqual(agent_catalog._category_from_domain("ar"), "Accounts Receivable")
+		self.assertEqual(agent_catalog._category_from_domain("crm"), "CRM")
+		self.assertEqual(agent_catalog._category_from_domain("hrms-payroll"), "HR and Payroll")
+		self.assertEqual(agent_catalog._category_from_domain("gst-compliance"), "GST Compliance")
+		self.assertEqual(agent_catalog._category_from_domain("inventory"), "Inventory")
+		self.assertEqual(agent_catalog._category_from_domain("accounting"), "Accounting")
+		self.assertEqual(agent_catalog._category_from_domain("close"), "Close and Reporting")
+		self.assertEqual(agent_catalog._category_from_domain("india-compliance"), "India Compliance")
+		self.assertEqual(agent_catalog._category_from_domain("measurement"), "Measurement")
+		self.assertEqual(agent_catalog._category_from_domain("inventory-count"), "Inventory Count")
+		self.assertEqual(agent_catalog._category_from_domain("bank-recon"), "Bank and Reconciliation")
+		self.assertEqual(agent_catalog._category_from_domain("tds-compliance"), "TDS Compliance")
+		self.assertEqual(agent_catalog._category_from_domain("helpdesk"), "Helpdesk")
+		self.assertEqual(agent_catalog._category_from_domain("knowledge"), "Knowledge Base")
+
+	def test_every_registry_domain_has_an_explicit_label_not_the_title_case_fallback(self):
+		"""Every ``domain`` the bundled registry actually declares must resolve
+		through ``_DOMAIN_CATEGORY_LABELS`` - the title-cased fallback exists for
+		a domain that has not shipped yet, never for a real one (a fallback label
+		reads worse: "Tds Compliance" instead of "TDS Compliance")."""
+		reg = agent_catalog._load_registry()
+		domains = {(a.get("domain") or "").strip().lower().replace("-", "_") for a in reg.get("agents") or []}
+		domains.discard("")
+		unmapped = domains - set(agent_catalog._DOMAIN_CATEGORY_LABELS)
+		self.assertEqual(unmapped, set(), f"registry domain(s) with no explicit category label: {unmapped}")
+
+	def test_category_from_domain_falls_back_to_title_case_for_unknown_codes(self):
+		self.assertEqual(agent_catalog._category_from_domain("widget-foo"), "Widget Foo")
+		self.assertEqual(agent_catalog._category_from_domain(""), "")
+		self.assertEqual(agent_catalog._category_from_domain(None), "")
+
+	def test_sync_agent_listings_writes_the_mapped_category_not_the_raw_domain(self):
+		agent_catalog.sync_agent_listings()
+		self.assertEqual(frappe.db.get_value(LISTING, "close-auditor", "category"), "Close and Reporting")
+		self.assertEqual(
+			frappe.db.get_value(LISTING, "bank-recon-operator", "category"), "Bank and Reconciliation"
+		)
+
+	# ------------------------------------------------------------------ #
+	# jarvis#1063 (jarvis-only half) - config_keys: which agent-specific
+	# installation config keys an agent's bundle actually reads (verified
+	# against jarvis-agents/agents/<slug>/evaluate.py; only close-auditor
+	# reads any today).
+	# ------------------------------------------------------------------ #
+	def test_sync_agent_listings_writes_config_keys_from_the_registry(self):
+		# dot paths - close-auditor/evaluate.py reads these NESTED under a
+		# top-level "materiality" object, not as flat top-level keys.
+		agent_catalog.sync_agent_listings()
+		self.assertEqual(
+			json.loads(frappe.db.get_value(LISTING, "close-auditor", "config_keys")),
+			[
+				"materiality.benchmark_value",
+				"materiality.percentage",
+				"materiality.engagement_risk_level",
+				"materiality.rounding_step",
+			],
+		)
+
+	def test_sync_agent_listings_defaults_config_keys_to_empty(self):
+		"""An agent the registry declares no config_keys for (everyone but
+		close-auditor today) gets [], not null/absent - ConfigForm.vue can
+		always safely parse it."""
+		agent_catalog.sync_agent_listings()
+		self.assertEqual(json.loads(frappe.db.get_value(LISTING, "bank-recon-operator", "config_keys")), [])
+
+	def test_get_agent_returns_config_keys(self):
+		agent_catalog.sync_agent_listings()
+		frappe.set_user(self.owner)
+		try:
+			out = agents_api.get_agent("close-auditor")
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(
+			json.loads(out["config_keys"]),
+			[
+				"materiality.benchmark_value",
+				"materiality.percentage",
+				"materiality.engagement_risk_level",
+				"materiality.rounding_step",
+			],
+		)
+
+	# ------------------------------------------------------------------ #
+	# jarvis#1062 E2E defect: turning a schedule off left the last computed
+	# next_run_at in place, so the Configure tab kept showing a stale
+	# "Next run: ..." line after disabling the schedule.
+	# ------------------------------------------------------------------ #
+	def test_set_schedule_clears_next_run_at_when_disabled(self):
+		inst = _install_as(self.owner, "close-auditor")
+		frappe.set_user(self.owner)
+		try:
+			on = agents_api.set_schedule(
+				inst, schedule_enabled=1, schedule_frequency="daily", schedule_time="09:00"
+			)
+			self.assertTrue(on["data"]["next_run_at"])
+			self.assertTrue(frappe.db.get_value(INSTALLATION, inst, "next_run_at"))
+
+			off = agents_api.set_schedule(inst, schedule_enabled=0)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIsNone(off["data"]["next_run_at"])
+		self.assertIsNone(frappe.db.get_value(INSTALLATION, inst, "next_run_at"))
+
+	# ------------------------------------------------------------------ #
+	# jarvis#1063 CRITICAL fix: close-auditor/evaluate.py reads its
+	# materiality inputs NESTED under a top-level "materiality" object
+	# (config["materiality"]["benchmark_value"], etc.), not as flat
+	# top-level keys. set_config is a generic passthrough - this just
+	# guards that the bench does not flatten/mangle a nested payload on
+	# the way to storage, which the delegate reads verbatim.
+	# ------------------------------------------------------------------ #
+	def test_set_config_persists_a_nested_materiality_object_unchanged(self):
+		inst = _install_as(self.owner, "close-auditor")
+		payload = {
+			"company": "Acme Ltd",
+			"materiality": {
+				"benchmark_value": 1000000,
+				"percentage": 5,
+				"engagement_risk_level": "medium",
+				"rounding_step": 100,
+			},
+		}
+		frappe.set_user(self.owner)
+		try:
+			agents_api.set_config(inst, json.dumps(payload))
+		finally:
+			frappe.set_user("Administrator")
+		stored = json.loads(frappe.db.get_value(INSTALLATION, inst, "config"))
+		self.assertEqual(stored, payload)
+
+	# ------------------------------------------------------------------ #
+	# (d4) jarvis#1062 polish: Published operator listings with no dispatch
+	# path were flipped to Coming Soon in the registry; a re-sync must carry
+	# an already-deployed Published row down with it.
+	# ------------------------------------------------------------------ #
+	def test_dispatchless_operators_downgrade_to_coming_soon_on_resync(self):
+		operator_slugs = [
+			"ap-3way-match-operator",
+			"ar-collections-operator",
+			"bank-recon-operator",
+			"cycle-count-planner-operator",
+			"reorder-replenishment-operator",
+		]
+		agent_catalog.sync_agent_listings()
+		# Simulate the pre-change deployed state, as if synced before the flip.
+		for slug in operator_slugs:
+			frappe.db.set_value(LISTING, slug, "status", "Published", update_modified=False)
+		frappe.db.commit()
+
+		agent_catalog.sync_agent_listings()
+
+		for slug in operator_slugs:
+			self.assertEqual(
+				frappe.db.get_value(LISTING, slug, "status"),
+				"Coming Soon",
+				f"{slug} must follow the registry's Coming Soon status on re-sync",
+			)
 
 	# ------------------------------------------------------------------ #
 	# (d2) Phase 0A — delegate agent stub + body-free enablement signal
@@ -390,10 +648,15 @@ class TestAgentsMarketplace(unittest.TestCase):
 	# (e) RBAC — role-gated install / run (server-side enforcement)
 	# ------------------------------------------------------------------ #
 	def _restrict(self, slug: str, roles: list) -> None:
+		"""Set the listing's access to exactly ``roles`` and NO named users.
+
+		Both halves, because setUp grants this module's cast by name: leaving those
+		rows in place would make every "restricted to ROLE_X" assertion below pass
+		for a reason that has nothing to do with the role."""
 		original = frappe.session.user
 		frappe.set_user("Administrator")
 		try:
-			agents_api.set_agent_roles(slug, roles)
+			agents_api.set_agent_access(slug, roles=roles, users=[])
 		finally:
 			frappe.set_user(original)
 
@@ -452,31 +715,220 @@ class TestAgentsMarketplace(unittest.TestCase):
 			admin_client.post_agent_run = orig_run
 
 	def test_list_agents_allowed_flags_and_roles_roundtrip(self):
+		# jarvis#1062 D2 (revised): list_agents (via _enriched_catalog) now
+		# HIDES a role-restricted row for a non-admin who has NOT installed
+		# it, instead of returning it disabled with allowed=0 - a blocked,
+		# never-installed user gets no row at all (an already-installed row
+		# survives a later restriction regardless - see
+		# test_installed_row_survives_a_role_revoked_after_install). An admin
+		# keeps EXACT parity with pre-D2 behavior: every row, `allowed`
+		# computed the same way, `allowed_roles` still present.
 		res = None
 		frappe.set_user("Administrator")
-		res = agents_api.set_agent_roles("close-auditor", [ROLE_X])
+		# set_agent_ACCESS, not the set_agent_roles shim: the shim preserves
+		# allowed_users by design, and setUp grants this module's cast by name -
+		# so the shim would leave self.other named and the "blocked" assertion
+		# below would pass on a listing that in fact still admits them.
+		res = agents_api.set_agent_access("close-auditor", roles=[ROLE_X], users=[])
 		self.assertEqual(res["allowed_roles"], [ROLE_X])
 
 		def _row(user):
 			frappe.set_user(user)
 			try:
-				return next(r for r in agents_api.list_agents() if r["name"] == "close-auditor")
+				return next((r for r in agents_api.list_agents() if r["name"] == "close-auditor"), None)
 			finally:
 				frappe.set_user("Administrator")
 
+		# self.other never installed close-auditor (setUp clears installs) and
+		# lacks ROLE_X -> hidden.
 		blocked = _row(self.other)
-		self.assertEqual(blocked["allowed"], 0)
-		self.assertEqual(blocked["allowed_roles"], [ROLE_X])
-		permitted = _row(self.owner)
-		self.assertEqual(permitted["allowed"], 1)
-		sm = _row(self.admin)  # System Manager: always allowed
-		self.assertEqual(sm["allowed"], 1)
+		self.assertIsNone(
+			blocked, "a role-restricted, never-installed row must be HIDDEN from a blocked user"
+		)
 
-		# [] clears the restriction -> unrestricted for everyone.
-		res = agents_api.set_agent_roles("close-auditor", [])
+		permitted = _row(self.owner)
+		self.assertIsNotNone(permitted)
+		self.assertEqual(permitted["allowed"], 1)
+		# non-admin payload: allowed_roles is stripped entirely (D2 knock-on) —
+		# nothing left for the removed "Available to: ..." card branch to read.
+		self.assertNotIn("allowed_roles", permitted)
+
+		sm = _row(self.admin)  # System Manager: admin parity — sees the row + allowed_roles
+		self.assertIsNotNone(sm)
+		self.assertEqual(sm["allowed"], 1)
+		self.assertEqual(sm["allowed_roles"], [ROLE_X])
+
+		# jarvis#1062: clearing the roles no longer means "unrestricted". With no
+		# roles and no users the listing is CLOSED, so the blocked user stays hidden
+		# - this is the inversion, asserted directly.
+		res = agents_api.set_agent_access("close-auditor", roles=[], users=[])
 		self.assertEqual(res["allowed_roles"], [])
-		self.assertEqual(_row(self.other)["allowed"], 1)
-		self.assertEqual(_row(self.other)["allowed_roles"], [])
+		self.assertEqual(res["allowed_users"], [])
+		self.assertIsNone(
+			_row(self.other),
+			"clearing every grant CLOSES the listing; it must not reopen it to everyone",
+		)
+		# An admin still sees it (admin parity), and still sees the empty roster.
+		closed_for_admin = _row(self.admin)
+		self.assertIsNotNone(closed_for_admin)
+		self.assertEqual(closed_for_admin["allowed"], 1)
+		self.assertEqual(closed_for_admin["allowed_roles"], [])
+
+		# Naming the user directly is the OTHER way in - no role involved.
+		agents_api.set_agent_access("close-auditor", roles=[], users=[self.other])
+		by_name = _row(self.other)
+		self.assertIsNotNone(by_name, "a user named in allowed_users must see the row")
+		self.assertEqual(by_name["allowed"], 1)
+		self.assertNotIn("allowed_users", by_name)  # roster is admin-only
+
+	def test_draft_listing_hidden_from_non_admin_unless_installed(self):
+		# jarvis#1062 D2: Draft is a registry-only lifecycle state (never
+		# shipped) a non-admin should not browse to before an admin publishes
+		# it — but an installed instance must not vanish out from under its own
+		# installer. (Coming Soon is a DIFFERENT case — see
+		# test_coming_soon_listing_is_discoverable_but_draft_is_not — it is the
+		# SPA's deliberate teaser and stays visible to everyone.)
+		_install_as(self.owner, "close-auditor")
+		frappe.db.set_value(LISTING, "close-auditor", "status", "Draft")
+		frappe.db.commit()
+
+		def _row(user):
+			frappe.set_user(user)
+			try:
+				return next((r for r in agents_api.list_agents() if r["name"] == "close-auditor"), None)
+			finally:
+				frappe.set_user("Administrator")
+
+		try:
+			# self.other never installed it -> hidden while Draft.
+			self.assertIsNone(_row(self.other))
+			# self.owner installed it -> stays visible to its own installer.
+			self.assertIsNotNone(_row(self.owner))
+			# Admin parity: unaffected by the Draft-hiding rule.
+			self.assertIsNotNone(_row(self.admin))
+		finally:
+			frappe.db.set_value(LISTING, "close-auditor", "status", "Published")
+			frappe.db.commit()
+
+	def test_coming_soon_listing_is_discoverable_but_draft_is_not(self):
+		# jarvis#1062 D2 (review fix): D2's original cut hid EVERY non-Published,
+		# not-installed row, which also hid Coming Soon - the SPA is explicitly
+		# built to show it as a teaser (AgentsList's "Coming Soon" badge,
+		# AgentDetail's "Coming soon" install tooltip). Coming Soon must be
+		# discoverable by a non-admin who never installed it; Draft must not.
+		frappe.db.set_value(LISTING, "close-auditor", "status", "Coming Soon")
+		frappe.db.commit()
+
+		def _row(user):
+			frappe.set_user(user)
+			try:
+				return next((r for r in agents_api.list_agents() if r["name"] == "close-auditor"), None)
+			finally:
+				frappe.set_user("Administrator")
+
+		try:
+			# self.other never installed it -> still visible (Coming Soon is
+			# discoverable), and get_agent reads it too (never installed, never
+			# role-restricted here).
+			row = _row(self.other)
+			self.assertIsNotNone(row, "a Coming Soon listing must be discoverable, not hidden")
+			self.assertEqual(row["status"], "Coming Soon")
+			frappe.set_user(self.other)
+			try:
+				out = agents_api.get_agent("close-auditor")
+			finally:
+				frappe.set_user("Administrator")
+			self.assertEqual(out["status"], "Coming Soon")
+
+			# Draft, by contrast, still hides for the same never-installed caller.
+			frappe.db.set_value(LISTING, "close-auditor", "status", "Draft")
+			frappe.db.commit()
+			self.assertIsNone(_row(self.other))
+			frappe.set_user(self.other)
+			try:
+				with self.assertRaises(frappe.PermissionError):
+					agents_api.get_agent("close-auditor")
+			finally:
+				frappe.set_user("Administrator")
+		finally:
+			frappe.db.set_value(LISTING, "close-auditor", "status", "Published")
+			frappe.db.commit()
+
+	def test_installed_row_survives_a_role_revoked_after_install(self):
+		# jarvis#1062 D2 (revised): role gating governs DISCOVERY and RUNNING,
+		# not managing what you already installed — otherwise a role revoked
+		# after install stranded the owner with no UI path to uninstall it.
+		# self.other installs while ALLOWED (setUp grants this module's cast by
+		# name), then the listing is narrowed to a role self.other does not hold.
+		inst_name = _install_as(self.other, "close-auditor")
+		self._restrict("close-auditor", [ROLE_X])
+		try:
+			frappe.set_user(self.other)
+			try:
+				# still listed - honestly disabled (allowed=0), not hidden.
+				row = next((r for r in agents_api.list_agents() if r["name"] == "close-auditor"), None)
+				self.assertIsNotNone(row, "an installed row must survive a role revoked after install")
+				self.assertEqual(row["allowed"], 0)
+
+				# still readable.
+				out = agents_api.get_agent("close-auditor")
+				self.assertEqual(out["agent_slug"], "close-auditor")
+				self.assertEqual(out["allowed"], 0)
+
+				# still uninstallable (uninstall is owner-gated, never
+				# allowed_roles-gated - the one way out of the stranded state).
+				res = agents_api.uninstall_agent(inst_name)
+				self.assertTrue(res["ok"])
+				self.assertFalse(frappe.db.exists(INSTALLATION, inst_name))
+			finally:
+				frappe.set_user("Administrator")
+		finally:
+			self._restrict("close-auditor", [])
+
+	def test_get_agent_throws_permission_error_when_hidden(self):
+		# Role-restricted: a caller outside the allowed set gets a PermissionError,
+		# not a 404 or a quiet payload — the same visibility the catalog enforces.
+		self._restrict("close-auditor", [ROLE_X])
+		try:
+			frappe.set_user(self.other)  # lacks ROLE_X
+			try:
+				with self.assertRaises(frappe.PermissionError):
+					agents_api.get_agent("close-auditor")
+			finally:
+				frappe.set_user("Administrator")
+			# self.owner holds ROLE_X -> still readable.
+			frappe.set_user(self.owner)
+			try:
+				out = agents_api.get_agent("close-auditor")
+			finally:
+				frappe.set_user("Administrator")
+			self.assertEqual(out["agent_slug"], "close-auditor")
+		finally:
+			# Re-grant rather than merely clearing: under deny-by-default an empty
+			# pair is itself a refusal, and the Draft assertion below would then pass
+			# for the wrong reason - on the status gate it is not testing.
+			self._restrict("close-auditor", ["Jarvis User"])
+
+		# Draft + never installed by this caller -> also a PermissionError.
+		frappe.db.set_value(LISTING, "close-auditor", "status", "Draft")
+		frappe.db.commit()
+		try:
+			frappe.set_user(self.other)
+			try:
+				with self.assertRaises(frappe.PermissionError):
+					agents_api.get_agent("close-auditor")
+			finally:
+				frappe.set_user("Administrator")
+			# Admin parity: a System Manager still reads it fine while Draft.
+			frappe.set_user(self.admin)
+			try:
+				out = agents_api.get_agent("close-auditor")
+			finally:
+				frappe.set_user("Administrator")
+			self.assertEqual(out["status"], "Draft")
+		finally:
+			frappe.db.set_value(LISTING, "close-auditor", "status", "Published")
+			frappe.db.commit()
 
 	# ------------------------------------------------------------------ #
 	# (f) RBAC — admin endpoints are System Manager ONLY
@@ -527,6 +979,11 @@ class TestAgentsMarketplace(unittest.TestCase):
 
 		row = next(l for l in out["listings"] if l["agent_slug"] == "close-auditor")
 		self.assertEqual(row["allowed_roles"], [ROLE_X])
+		# jarvis#1062: the overview feeds the admin Access editor, so it must carry
+		# BOTH halves of the grant. The named grants come from setUp; the shim above
+		# preserves them, which is the behaviour a cached older SPA build depends on.
+		self.assertIn("allowed_users", row)
+		self.assertIn(self.owner, row["allowed_users"])
 		self.assertEqual(row["status"], "Published")
 		install_row = next(i for i in row["installs"] if i["installation"] == inst)
 		self.assertEqual(install_row["owner"], self.owner)
@@ -681,7 +1138,10 @@ class TestAgentsMarketplace(unittest.TestCase):
 		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
 		self.assertEqual(payload, [])
 
-		self._restrict("close-auditor", [])  # clear -> included again
+		# Re-widening to a role the owner DOES hold includes it again. Not `[]`:
+		# under deny-by-default an empty pair is a refusal, not "unrestricted", so
+		# clearing would assert the opposite of what this step means.
+		self._restrict("close-auditor", ["Jarvis User"])
 		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
 		self.assertTrue(any(p["slug"] == "agent-close-auditor" for p in payload))
 
@@ -725,7 +1185,8 @@ class TestAgentsMarketplace(unittest.TestCase):
 		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
 
 		# ...and once BOTH rows qualify again it is still ONE entry, not two.
-		self._restrict("close-auditor", [])
+		# "Jarvis User" (which both fixtures hold), not `[]`: clearing now CLOSES.
+		self._restrict("close-auditor", ["Jarvis User"])
 		payload = agent_catalog.build_agent_push_payload()
 		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
 
@@ -792,32 +1253,56 @@ class TestAgentsMarketplace(unittest.TestCase):
 			reference |= {p["slug"] for p in agent_catalog.build_agent_push_payload(owner=o)}
 
 		payload = agent_catalog.build_agent_push_payload()
-		self.assertEqual({p["slug"] for p in payload}, reference)
+		# SUBSET, not equality (jarvis#1062): the bench-global build also carries the
+		# allowed-listing leg - every granted Published listing, installed or not -
+		# which a per-owner build deliberately skips, so the oracle cannot see those
+		# slugs. The claim under test is unchanged: the short-circuit must never LOSE
+		# a slug the per-owner builds prove is due.
+		self.assertLessEqual(reference, {p["slug"] for p in payload})
 		# ...and still exactly one entry per slug.
 		slugs = [p["slug"] for p in payload]
 		self.assertEqual(len(slugs), len(set(slugs)), f"duplicate slug in payload: {slugs}")
 		self.assertIn("agent-close-auditor", reference)
 		self.assertIn("agent-ledger-scrutiny-auditor", reference)
 
-	def test_push_payload_short_circuit_skips_the_per_row_rbac_query(self):
-		"""The RBAC gate (an N+1 on the allowed-role child table) is evaluated once
-		per distinct AGENT, not once per install row."""
+	def test_push_payload_reads_the_access_tables_once_not_per_row(self):
+		"""The access gate is answered from TWO batched queries, not per install row.
+
+		It used to call ``_user_allowed_for_agent`` per row, which is itself an N+1
+		over both child tables, and this function runs twice per Apply. The maps are
+		now built once and shared with the allowed-listing leg; the per-row helper
+		must not be reached at all."""
 		self._enable_for(self.owner, "close-auditor")
 		self._enable_for(self.other, "close-auditor")
 		self._enable_for(self.admin, "close-auditor")
 
-		calls = []
-		orig = agents_api._user_allowed_for_agent
-		agents_api._user_allowed_for_agent = lambda listing, user=None: (
-			calls.append(listing) or orig(listing, user)
-		)
+		counts = {"roles": 0, "users": 0}
+		orig_roles = agents_api._allowed_roles_map
+		orig_users = agents_api._allowed_users_map
+		orig_gate = agents_api._user_allowed_for_agent
+
+		def _roles():
+			counts["roles"] += 1
+			return orig_roles()
+
+		def _users():
+			counts["users"] += 1
+			return orig_users()
+
+		def _gate(*a, **kw):
+			raise AssertionError("per-row access query in the push payload (N+1 regression)")
+
+		agents_api._allowed_roles_map = _roles
+		agents_api._allowed_users_map = _users
+		agents_api._user_allowed_for_agent = _gate
 		try:
 			payload = agent_catalog.build_agent_push_payload()
 		finally:
-			agents_api._user_allowed_for_agent = orig
+			agents_api._allowed_roles_map = orig_roles
+			agents_api._allowed_users_map = orig_users
+			agents_api._user_allowed_for_agent = orig_gate
 
-		close_calls = [c for c in calls if c == "close-auditor"]
-		self.assertEqual(len(close_calls), 1, f"RBAC gate re-run per install row: {calls}")
+		self.assertEqual(counts, {"roles": 1, "users": 1})
 		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
 
 	# ------------------------------------------------------------------ #
@@ -1071,7 +1556,93 @@ class TestAgentsMarketplace(unittest.TestCase):
 
 		# Blanking the OTHER row too (no valid install left) drops the slug — proof
 		# the entry above came from the qualifying sibling, not from a leaky gate.
+		# Asserted on the per-OWNER builds: those skip the allowed-listing leg, which
+		# would otherwise ship this (granted, Published) slug on its own and say
+		# nothing about the install gate this test is actually about.
 		frappe.db.set_value(INSTALLATION, max(a, b), "run_as_user", None, update_modified=False)
 		frappe.db.commit()
-		payload = agent_catalog.build_agent_push_payload()
-		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 0)
+		for o in (self.owner, self.other):
+			payload = agent_catalog.build_agent_push_payload(owner=o)
+			self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 0)
+
+	# ------------------------------------------------------------------ #
+	# jarvis#1062 - list_agent_activity_page's live run_status join: the
+	# action verb ("Run started") is a point-in-time label; run_status is
+	# the run's CURRENT status, joined in one batched query for the page.
+	# ------------------------------------------------------------------ #
+	def _mk_run(self, owner: str, slug: str, inst: str, *, status: str) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": slug,
+				"installation": inst,
+				"trigger": "manual",
+				"status": status,
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(RUN, doc.name, "owner", owner, update_modified=False)
+		frappe.db.commit()
+		return doc.name
+
+	def _mk_activity(self, owner: str, slug: str, inst: str, *, action: str, run: str | None = None) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": ACTIVITY,
+				"agent": slug,
+				"agent_title": slug,
+				"installation": inst,
+				"action": action,
+				"run": run or "",
+			}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(ACTIVITY, doc.name, "owner", owner, update_modified=False)
+		frappe.db.commit()
+		return doc.name
+
+	def test_activity_page_joins_current_run_status(self):
+		inst = self._enable_for(self.owner, "close-auditor")
+		run_still_running = self._mk_run(self.owner, "close-auditor", inst, status="running")
+		run_now_failed = self._mk_run(self.owner, "close-auditor", inst, status="failed")
+
+		act_running = self._mk_activity(
+			self.owner, "close-auditor", inst, action="run_started", run=run_still_running
+		)
+		# The action verb here still reads "Run started" - written at dispatch
+		# time - but the run has SINCE failed. run_status must reflect that,
+		# not the stale action label.
+		act_stale_label = self._mk_activity(
+			self.owner, "close-auditor", inst, action="run_started", run=run_now_failed
+		)
+		act_no_run = self._mk_activity(self.owner, "close-auditor", inst, action="enabled")
+
+		frappe.set_user(self.owner)
+		try:
+			page = agents_api.list_agent_activity_page(agent="close-auditor")
+		finally:
+			frappe.set_user("Administrator")
+
+		by_name = {r["name"]: r for r in page["rows"]}
+		self.assertEqual(by_name[act_running]["run_status"], "running")
+		self.assertEqual(by_name[act_stale_label]["run_status"], "failed")
+		self.assertIsNone(by_name[act_no_run]["run_status"])
+
+	def test_activity_page_run_status_null_when_run_deleted(self):
+		inst = self._enable_for(self.owner, "close-auditor")
+		run = self._mk_run(self.owner, "close-auditor", inst, status="completed")
+		act = self._mk_activity(self.owner, "close-auditor", inst, action="run_completed", run=run)
+
+		frappe.delete_doc(RUN, run, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+		frappe.set_user(self.owner)
+		try:
+			page = agents_api.list_agent_activity_page(agent="close-auditor")
+		finally:
+			frappe.set_user("Administrator")
+
+		row = next(r for r in page["rows"] if r["name"] == act)
+		self.assertIsNone(row["run_status"])

--- a/jarvis/tests/test_chat_endpoint_gating.py
+++ b/jarvis/tests/test_chat_endpoint_gating.py
@@ -49,13 +49,19 @@ _GUARD_CALL_SUBSTRS = (
 	# fact gated harder than the sweep's own baseline.
 	"require_jarvis_admin",
 	"require_skill_reviewer",  # PART 2 TASK 12: skill-reviewer/admin gate (org-wide apply)
-	# Admin-level access CHECK (bool), the analogue of has_jarvis_access below. The
-	# reviewer-or-admin endpoints (agents_api.promote_installation /
-	# demote_installation) gate in-body on `me != doc.reviewer and not
-	# has_jarvis_admin_access(me)` -> frappe.throw(PermissionError) — a gate STRICTER
-	# than require_jarvis_user (the caller must be the named reviewer or a Jarvis
-	# Admin), so without this entry the sweep false-positived them as ungated.
+	# Admin-level access CHECK (bool), the analogue of has_jarvis_access below. Some
+	# endpoints gate in-body on `has_jarvis_admin_access(me)` -> frappe.throw(
+	# PermissionError) rather than through a require_* helper — a gate STRICTER than
+	# require_jarvis_user, so without this entry the sweep false-positives them as
+	# ungated. (agents_api.promote_installation / demote_installation used to be the
+	# example; jarvis#1062 moved their check into _require_activation_authority and
+	# they now also carry require_jarvis_access at the top.)
 	"has_jarvis_admin_access",
+	# jarvis#1062: the reviewer-or-admin activation gate promote/demote delegate to.
+	"_require_activation_authority",
+	# jarvis#1062: the installation write gate (owner via check_permission, or a
+	# tenant admin) that set_enabled / uninstall_agent / the run-control guard use.
+	"_check_installation_write",
 	"_require_system_user",
 	"only_for",  # frappe.only_for(...) — an SM/role gate, stricter than Jarvis User
 	"_guard",  # learned_api._guard / _admin_guard (reviewer/admin role gate)

--- a/jarvis/tests/test_docmeta_api.py
+++ b/jarvis/tests/test_docmeta_api.py
@@ -629,5 +629,125 @@ class TestDocmetaApi(unittest.TestCase):
 		self.assertEqual(liked, [USER_A])  # no duplicate entry
 
 
+# --------------------------------------------------------------------------- #
+# jarvis#1062 owner decision: Notes moved off the Configure tab (the
+# installation) onto the Run itself (FindingsPanel.vue). "Jarvis Agent Run"
+# joined ALLOWED_DOCTYPES with NO extra gating code - `_get_gated`'s existing
+# doc.owner/System Manager check already resolves correctly because
+# agent_scheduler.py's `_launch_audit` reassigns a Run's `owner` to the
+# INSTALLATION owner at launch (never Administrator, never the run-as user),
+# for both a manual and a scheduled run. This is a focused, standalone
+# fixture (a bare Run insert, not a full `_launch_audit` launch) rather than
+# folding into TestDocmetaApi's shared `all_docs` - Runs are comment-only
+# (not assignable/shareable), so they do not belong in that generic loop.
+# --------------------------------------------------------------------------- #
+RUN = "Jarvis Agent Run"
+
+
+class TestDocmetaApiAgentRun(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		cls.owner = _ensure_user("dm-run-owner@example.com")
+		cls.other = _ensure_user("dm-run-other@example.com")
+
+		agent_catalog.sync_agent_listings()
+		slug = "close-auditor"
+		if not frappe.db.exists(LISTING, slug):
+			slug = frappe.get_all(LISTING, filters={"status": "Published"}, pluck="name", limit=1)[0]
+		for n in frappe.get_all(INSTALLATION, filters={"owner": cls.owner}, pluck="name"):
+			frappe.delete_doc(INSTALLATION, n, force=True, ignore_permissions=True)
+		# close-auditor requires GL Entry / Account / Company read (install
+		# A12-gate) - grant it so the self-mapped install validates (mirrors
+		# TestDocmetaApi.setUpClass; ignore_permissions on the insert below
+		# skips permission checks, NOT validate()).
+		if frappe.db.exists("Role", "Accounts User"):
+			frappe.get_doc("User", cls.owner).add_roles("Accounts User")
+			frappe.clear_cache(user=cls.owner)
+		with _as(cls.owner):
+			inst = frappe.get_doc(
+				{
+					"doctype": INSTALLATION,
+					"agent": slug,
+					"enabled": 0,
+					"run_as_user": frappe.session.user,
+					"installed_version": frappe.db.get_value(LISTING, slug, "version"),
+					"installed_at": frappe.utils.now(),
+				}
+			)
+			inst.insert(ignore_permissions=True)
+		cls.installation = inst.name
+
+		# Bare Run insert (not a full _launch_audit launch) - this test is
+		# about the docmeta gate, not the launch pipeline. Owner reassigned
+		# server-side afterward, exactly as _launch_audit itself does (never
+		# left as Administrator / the inserting session's identity).
+		run = frappe.get_doc(
+			{
+				"doctype": RUN,
+				"agent": slug,
+				"installation": cls.installation,
+				"trigger": "manual",
+				"status": "completed",
+				"started_at": frappe.utils.now(),
+			}
+		)
+		run.flags.ignore_permissions = True
+		run.insert()
+		frappe.db.set_value(RUN, run.name, "owner", cls.owner, update_modified=False)
+		frappe.db.commit()
+		cls.run_name = run.name
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_clear_meta(RUN, cls.run_name)
+		frappe.delete_doc(RUN, cls.run_name, force=True, ignore_permissions=True)
+		frappe.delete_doc(INSTALLATION, cls.installation, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_clear_meta(RUN, self.run_name)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_run_owner_can_read_and_comment(self):
+		with _as(self.owner):
+			meta = docmeta_api.get_docmeta(RUN, self.run_name)
+			self.assertEqual(meta["created"]["owner"], self.owner)
+			row = docmeta_api.add_comment(RUN, self.run_name, "note on this run")
+			self.assertEqual(row["owner"], self.owner)
+			meta = docmeta_api.get_docmeta(RUN, self.run_name)
+			self.assertEqual([c["name"] for c in meta["comments"]], [row["name"]])
+
+	def test_non_owner_denied_on_a_run(self):
+		with _as(self.other):
+			with self.assertRaises(frappe.PermissionError):
+				docmeta_api.get_docmeta(RUN, self.run_name)
+			with self.assertRaises(frappe.PermissionError):
+				docmeta_api.add_comment(RUN, self.run_name, "nope")
+
+	def test_system_manager_allowed_on_a_run(self):
+		# Administrator is a System Manager and owns none of this fixture.
+		meta = docmeta_api.get_docmeta(RUN, self.run_name)
+		self.assertEqual(meta["created"]["owner"], self.owner)
+		row = docmeta_api.add_comment(RUN, self.run_name, "sm note")
+		self.assertEqual(row["owner"], "Administrator")
+
+	def test_run_is_not_assignable_or_shareable(self):
+		"""Comments only (jarvis#1062) - Runs deliberately never joined
+		ASSIGNABLE_DOCTYPES/SHAREABLE_DOCTYPES. Mirrors
+		test_toggle_assignment_excludes_custom_skill: this is the doctype
+		allowlist check (frappe.throw's default ValidationError), which runs
+		BEFORE any owner/write gate - not a PermissionError."""
+		with _as(self.owner):
+			with self.assertRaises(frappe.ValidationError):
+				docmeta_api.toggle_assignment(RUN, self.run_name, self.other, "add")
+			with self.assertRaises(frappe.ValidationError):
+				docmeta_api.toggle_share(RUN, self.run_name, self.other, "add")
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/jarvis/tests/test_get_doc.py
+++ b/jarvis/tests/test_get_doc.py
@@ -79,6 +79,84 @@ class TestGetDoc(FrappeTestCase):
 		with self.assertRaises(InvalidArgumentError):
 			get_doc(doctype="Customer", name="Definitely Not A Customer")
 
+	def test_unknown_doc_error_is_instructive(self):
+		"""#1062: was "unknown Customer: <name>" - a delegate reading this had no
+		next move. Names the DocType/name and points at the tool that finds
+		valid ones."""
+		with self.assertRaises(InvalidArgumentError) as ctx:
+			get_doc(doctype="Customer", name="Definitely Not A Customer")
+		self.assertEqual(
+			str(ctx.exception),
+			"No Customer named 'Definitely Not A Customer'. Use get_list to find valid names first.",
+		)
+
+	def test_missing_name_error_is_instructive(self):
+		"""#1062: a non-single doctype with no name/names gets told the actual
+		calling convention, including the single-doctype escape hatch."""
+		with self.assertRaises(InvalidArgumentError) as ctx:
+			get_doc(doctype="Customer")
+		self.assertEqual(
+			str(ctx.exception),
+			"Pass name (one document) or names (a non-empty list). For a single "
+			"record like Stock Settings call get_doc with only the doctype.",
+		)
+
+	def test_empty_names_list_error_is_instructive(self):
+		"""names=[] is the other shape of "nothing to identify a document with" -
+		same instructive message, not the old "must be a non-empty list"."""
+		with self.assertRaises(InvalidArgumentError) as ctx:
+			get_doc(doctype="Customer", names=[])
+		self.assertIn("Pass name (one document) or names", str(ctx.exception))
+
+	# ------------------------------------------------------------------ #
+	# #1062 live evidence: a delegate calling get_doc on a Single (Stock
+	# Settings) with names=[] or a bogus name got "names must be a non-empty
+	# list of document names" / "unknown Stock Settings: x" - wasted tool
+	# calls on a doctype that has exactly one document and needs no name at
+	# all.
+	# ------------------------------------------------------------------ #
+	def test_single_doctype_returns_its_one_document_without_a_name(self):
+		result = get_doc(doctype="Stock Settings")
+		self.assertEqual(result["name"], "Stock Settings")
+		self.assertEqual(result["doctype"], "Stock Settings")
+
+	def test_single_doctype_ignores_a_bogus_name(self):
+		"""name/names are meaningless for a Single - a delegate with nothing
+		sensible to pass must still get the one document that exists, not a
+		404 on a name it invented."""
+		result = get_doc(doctype="Stock Settings", name="this-name-does-not-exist")
+		self.assertEqual(result["name"], "Stock Settings")
+
+	def test_single_doctype_ignores_an_empty_names_list(self):
+		result = get_doc(doctype="Stock Settings", names=[])
+		self.assertEqual(result["name"], "Stock Settings")
+
+	def test_single_doctype_with_names_returns_the_batch_envelope(self):
+		"""Review fix: the Single short-circuit used to return the plain
+		document dict even when `names` was passed, silently ignoring that
+		the caller asked for the batch shape. A non-empty `names` on a
+		Single now gets the same {doctype, docs, count} envelope any other
+		doctype's batch call gets, wrapping that one document - names'
+		CONTENT is still meaningless (a Single has exactly one document,
+		whose name IS the doctype), only its presence switches the shape."""
+		result = get_doc(doctype="Stock Settings", names=["this-name-does-not-exist"])
+		self.assertEqual(result["doctype"], "Stock Settings")
+		self.assertEqual(result["count"], 1)
+		self.assertEqual(len(result["docs"]), 1)
+		self.assertEqual(result["docs"][0]["name"], "Stock Settings")
+
+	def test_single_doctype_without_names_still_returns_the_flat_dict(self):
+		"""The other half of the same fix: `name`/no-args at all must keep
+		the pre-existing flat-dict shape - only an explicit non-empty
+		`names` switches to the batch envelope."""
+		result = get_doc(doctype="Stock Settings")
+		self.assertNotIn("docs", result)
+		self.assertEqual(result["name"], "Stock Settings")
+
+		result = get_doc(doctype="Stock Settings", name="whatever")
+		self.assertNotIn("docs", result)
+		self.assertEqual(result["name"], "Stock Settings")
+
 	def test_permission_check_blocks_unauthorized_user(self):
 		user_email = "docless@example.com"
 		if not frappe.db.exists("User", user_email):
@@ -94,5 +172,27 @@ class TestGetDoc(FrappeTestCase):
 		try:
 			with self.assertRaises(PermissionDeniedError):
 				get_doc(doctype="Customer", name="Jarvis Test Customer")
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_single_doctype_still_enforces_read_permission(self):
+		"""#1062: frappe.get_single skips no permission check of its own - a
+		Single carries real DocPerms (Stock Settings: Stock Manager / Sales
+		User only), so a user holding neither must still be refused, not
+		waved through because reading a Single takes no name to gate on."""
+		user_email = "docless@example.com"
+		if not frappe.db.exists("User", user_email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user_email,
+					"first_name": "Docless",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+		frappe.set_user(user_email)
+		try:
+			with self.assertRaises(PermissionDeniedError):
+				get_doc(doctype="Stock Settings")
 		finally:
 			frappe.set_user("Administrator")

--- a/jarvis/tests/test_part3_security.py
+++ b/jarvis/tests/test_part3_security.py
@@ -24,6 +24,7 @@ from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, get_datetime, now_datetime
 
 from jarvis.chat import agents_api, approvals_api, docmeta_api, macro_scheduler
+from jarvis.tests._agent_access import allow_listing_for
 
 CONVERSATION = "Jarvis Conversation"
 MACRO = "Jarvis Macro"
@@ -210,6 +211,10 @@ class Part3Base(FrappeTestCase):
 					"skill_bundle": '[{"path":"SKILL.md","body":"PROPRIETARY VENDOR IP"}]',
 				}
 			).insert(ignore_permissions=True)
+		# jarvis#1062: deny-by-default access. USER_A reads this listing through
+		# get_agent (the skill_bundle-hiding test), which now 403s an ungranted
+		# non-admin before it can assert anything about the payload.
+		allow_listing_for(AGENT_SLUG, roles=["Jarvis User"])
 		frappe.db.commit()
 
 	@classmethod
@@ -229,6 +234,8 @@ class Part3Base(FrappeTestCase):
 		for dt, filt in (
 			(APPROVAL, {"title": ["like", f"{PFX}%"]}),
 			(MACRO, {"macro_name": ["like", f"{PFX}%"]}),
+			# take_finding_to_chat commits its seed conversation too.
+			(CONVERSATION, {"title": ["like", f"Finding: {PFX}%"]}),
 		):
 			for n in frappe.get_all(dt, filters=filt, pluck="name"):
 				if dt == MACRO:
@@ -553,3 +560,41 @@ class TestAgentScoping(Part3Base):
 				LISTING, filters={"agent_slug": AGENT_SLUG}, fields=["name", "skill_bundle"]
 			)
 		self.assertIn("skill_bundle", rows2[0])
+
+	# ------------------------------------------------------------------ #
+	# jarvis#1062 polish: take_finding_to_chat commits its seed conversation
+	# BEFORE attempting to seed it; a failed seed must not leave an orphaned,
+	# empty "Finding: ..." conversation behind (FindingsPanel no longer
+	# navigates on ok:False, so nothing cleans it up client-side either).
+	# ------------------------------------------------------------------ #
+	def test_take_finding_to_chat_seed_failure_leaves_no_conversation_row(self):
+		f = _mk_finding(USER_A, title=f"{PFX}-cleanup-fail")
+		conv_filters = {"title": f"Finding: {f.title}"[:140]}
+		self.assertFalse(frappe.db.exists(CONVERSATION, conv_filters))
+		with _as(USER_A):
+			with patch(
+				"jarvis.chat.api.send_message",
+				return_value={"ok": False, "reason": "llm_not_configured"},
+			):
+				res = agents_api.take_finding_to_chat(f.name)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["reason"], "llm_not_configured")
+		self.assertIsNone(res.get("conversation"))
+		self.assertFalse(
+			frappe.db.exists(CONVERSATION, conv_filters),
+			"a failed seed must not leave an orphaned conversation behind",
+		)
+
+	def test_take_finding_to_chat_seed_success_keeps_the_conversation(self):
+		"""Control: the cleanup path must not have swallowed the real case."""
+		f = _mk_finding(USER_A, title=f"{PFX}-cleanup-ok")
+		conv_filters = {"title": f"Finding: {f.title}"[:140]}
+		with _as(USER_A):
+			with patch(
+				"jarvis.chat.api.send_message",
+				return_value={"ok": True, "run_id": "r1", "message_id": "m1"},
+			):
+				res = agents_api.take_finding_to_chat(f.name)
+		self.assertTrue(res["ok"])
+		self.assertIsNotNone(res["conversation"])
+		self.assertTrue(frappe.db.exists(CONVERSATION, conv_filters))

--- a/jarvis/tests/test_platform_activation.py
+++ b/jarvis/tests/test_platform_activation.py
@@ -29,6 +29,10 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import agent_permissions, agent_runs, agents_api
 
+# The reviewing role promote/demote now demands (JARVIS_REVIEWER_ROLES). Created by
+# DocType sync - one DocType names it - so it exists on a fresh CI site.
+_REVIEWER_ROLE = "Jarvis Skill Reviewer"
+
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
@@ -237,7 +241,7 @@ class TestPP4ShadowVisibility(FrappeTestCase):
 			"T", [], {"blocker": 0, "warning": 0, "note": 0}, "", result_state="evaluated_clean", shadow=True
 		)
 		self.assertNotIn("No exceptions were found", html)
-		self.assertNotIn("Evaluated — clean coverage", html)
+		self.assertNotIn("Evaluated: clean coverage", html)
 		self.assertIn("Preview (shadow)", html)
 		self.assertIn('data-result-state="shadow"', html)
 
@@ -266,6 +270,14 @@ class TestPP4PromotionAndPP6Budget(FrappeTestCase):
 		cls.owner = _mk_user("pa-owner2@example.com")
 		cls.reviewer = _mk_user("pa-reviewer2@example.com")
 		cls.stranger = _mk_user("pa-stranger@example.com")
+		# jarvis#1062: promote/demote authority is the REVIEWER SET, no longer the
+		# installation's own `reviewer` field - install_agent stamps that field with
+		# the installer, so self-sign-off let anyone promote their own install. This
+		# fixture is the named reviewer AND must now hold a reviewing role. Applied
+		# unconditionally (outside _mk_user's exists-guard) because on a shared site
+		# the user may already exist without it.
+		frappe.get_doc("User", cls.reviewer).add_roles(_REVIEWER_ROLE)
+		frappe.clear_cache(user=cls.reviewer)
 		_mk_listing()
 		frappe.db.commit()
 

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -28,6 +28,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import agent_scheduler, agents_api
+from jarvis.tests._agent_access import allow_listing_for, clear_listing_access
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
@@ -36,6 +37,10 @@ ACTIVITY = "Jarvis Agent Activity"
 FINDING = "Jarvis Agent Finding"
 PROVENANCE = "Jarvis Agent Provenance Event"
 SETTINGS = "Jarvis Settings"
+
+# The reviewing role promote/demote demands (JARVIS_REVIEWER_ROLES). Created by
+# DocType sync - one DocType names it - so it exists on a fresh CI site.
+_REVIEWER_ROLE = "Jarvis Skill Reviewer"
 
 PREFIX = "hardening-h-"
 
@@ -76,6 +81,12 @@ def _mk_listing(slug: str) -> str:
 	else:
 		# A listing left by an earlier run may predate the rule_pack field.
 		frappe.db.set_value(LISTING, slug, "rule_pack", f"pack-{slug}", update_modified=False)
+	# jarvis#1062: a listing is CLOSED until somebody is allowed, and every fixture
+	# user in this module is a plain Jarvis User. Granted to the ROLE, not by name,
+	# so _restrict() below - which REPLACES allowed_roles - still takes the grant
+	# away when a test means to lock the agent down. Granting by name would leave a
+	# residue that made those gate assertions pass for the wrong reason.
+	allow_listing_for(slug, roles=["Jarvis User"])
 	return slug
 
 
@@ -271,6 +282,12 @@ class TestPerCustomerCeiling(FrappeTestCase):
 		cls.rev_b = _mk_user("h-rev-b@example.com")
 		cls.cust_c = _mk_user("h-cust-c@example.com")
 		cls.rev_c = _mk_user("h-rev-c@example.com")
+		# jarvis#1062: promoting is the reviewer set's act, not the named reviewer's
+		# own. Unconditional (outside _mk_user's exists-guard) - on a shared site the
+		# user may already exist without the role.
+		for r in (cls.rev_a, cls.rev_b, cls.rev_c):
+			frappe.get_doc("User", r).add_roles(_REVIEWER_ROLE)
+			frappe.clear_cache(user=r)
 		for s in cls.ALL:
 			_mk_listing(s)
 		frappe.db.commit()
@@ -335,6 +352,11 @@ class TestPromotionLockSerialization(FrappeTestCase):
 		frappe.set_user("Administrator")
 		cls.owner = _mk_user("h-lock-owner@example.com")
 		cls.reviewer = _mk_user("h-lock-rev@example.com")
+		# jarvis#1062: see TestPerCustomerCeiling - promote authority is the reviewer
+		# set now, so the lock tests need their actor to hold it or they never reach
+		# the lock they are about.
+		frappe.get_doc("User", cls.reviewer).add_roles(_REVIEWER_ROLE)
+		frappe.clear_cache(user=cls.reviewer)
 		_mk_listing(cls.SLUG)
 		frappe.db.commit()
 
@@ -925,8 +947,14 @@ def _set_roles(email: str, role: str, *, held: bool) -> None:
 
 
 def _restrict(slug: str, roles: list[str]) -> None:
+	"""Narrow the listing to exactly ``roles``, and to no named user.
+
+	Both halves (jarvis#1062): leaving allowed_users populated would mean a test
+	that restricts an agent to a role nobody holds still admits everyone named
+	there, and the gate it is asserting would never fire."""
 	doc = frappe.get_doc(LISTING, slug)
 	doc.set("allowed_roles", [{"role": r} for r in roles])
+	doc.set("allowed_users", [])
 	doc.flags.ignore_permissions = True
 	doc.save()
 
@@ -1240,16 +1268,96 @@ class TestSetListingStatusMarksCatalogDirty(FrappeTestCase):
 
 	def test_status_change_with_no_enabled_install_is_not_dirty(self):
 		"""The payload is identical either way, so do not manufacture a pending
-		Apply (and a container restart) out of nothing."""
+		Apply (and a container restart) out of nothing.
+
+		The listing must carry NO grant either (jarvis#1062): a granted listing is
+		in the roster whether or not anyone installed it, so a status flip on one
+		DOES change the payload - see the sibling test below. _mk_listing grants
+		Jarvis User so the module's other tests can install, hence the reset here."""
+		clear_listing_access(self.SLUG)
 		agents_api.set_listing_status(self.SLUG, "Deprecated")
 		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
 		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 3)
+
+	def test_status_change_with_a_grant_but_no_install_is_dirty(self):
+		"""jarvis#1062: the roster is no longer "enabled installs" alone.
+
+		An allowed Published listing ships with zero installations, so
+		publishing/deprecating one really does move the container roster and must
+		show as a pending Apply - the exact #457 class of bug (roster and DB
+		silently disagreeing) in its new shape."""
+		allow_listing_for(self.SLUG, roles=["Jarvis User"])
+		agents_api.set_listing_status(self.SLUG, "Deprecated")
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 1)
 
 	def test_setting_the_same_status_is_not_dirty(self):
 		_mk_gate_install(self.owner, self.SLUG, self.owner)
 		frappe.db.commit()
 		agents_api.set_listing_status(self.SLUG, "Published")
 		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
+
+
+class TestSetEnabledMarksCatalogDirtyOnlyOnAChange(FrappeTestCase):
+	"""jarvis#1062 polish: a no-op ``set_enabled`` call (re-enabling an
+	already-enabled row, or disabling an already-disabled one) was dirtying the
+	catalog unconditionally, unlike every other push-visible mutation here
+	(``set_listing_status`` above) - the SPA's leave-guard then nagged with a
+	native beforeunload prompt even though nothing the next Apply would push
+	had actually changed."""
+
+	SLUG = PREFIX + "enableddirty"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-enableddirty-owner@example.com")
+		_mk_listing(cls.SLUG)
+		cls._saved = {k: _single(k) for k in ("agent_catalog_dirty", "agent_catalog_version")}
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for k, v in cls._saved.items():
+			frappe.db.set_single_value(SETTINGS, k, v)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.set_value(LISTING, self.SLUG, "status", "Published", update_modified=False)
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_dirty", 0)
+		frappe.db.set_single_value(SETTINGS, "agent_catalog_version", 3)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		frappe.db.commit()
+
+	def test_re_enabling_an_already_enabled_install_is_not_dirty(self):
+		inst = _mk_gate_install(self.owner, self.SLUG, self.owner)  # starts enabled=1
+		frappe.db.commit()
+		agents_api.set_enabled(inst, 1)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 3)
+
+	def test_disabling_an_already_disabled_install_is_not_dirty(self):
+		inst = _mk_gate_install(self.owner, self.SLUG, self.owner)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		agents_api.set_enabled(inst, 0)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 0)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 3)
+
+	def test_an_actual_flip_still_marks_dirty(self):
+		"""Control: the fix must not have swallowed the real case."""
+		inst = _mk_gate_install(self.owner, self.SLUG, self.owner)  # starts enabled=1
+		frappe.db.commit()
+		agents_api.set_enabled(inst, 0)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_dirty")), 1)
+		self.assertEqual(frappe.utils.cint(_single("agent_catalog_version")), 4)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_platform_launch_provenance.py
+++ b/jarvis/tests/test_platform_launch_provenance.py
@@ -31,6 +31,7 @@ import frappe
 
 from jarvis._session import authenticated_user, impersonate
 from jarvis.chat import agent_catalog, agent_scheduler, agents_api
+from jarvis.tests._agent_access import allow_listing_for
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
@@ -97,6 +98,11 @@ class TestPlatformLaunchProvenance(unittest.TestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
 		self._cleanup()
+		# jarvis#1062: _cleanup() drops every allow row site-wide, so the grant has
+		# to be re-applied per test rather than once in setUpClass. Granted to the
+		# Jarvis User ROLE, which covers both the owner and the run-as identity -
+		# the two the install and dispatch gates litigate.
+		allow_listing_for(AGENT, roles=["Jarvis User"])
 		# Stub the fleet dispatch so _launch_audit completes without a live fleet.
 		import jarvis.admin_client as admin_client
 

--- a/jarvis/tests/test_platform_min_apps.py
+++ b/jarvis/tests/test_platform_min_apps.py
@@ -36,6 +36,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import agent_catalog, agent_installability, agent_scheduler, agents_api
+from jarvis.tests._agent_access import allow_listing_for
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
@@ -87,6 +88,13 @@ def _mk_listing(slug: str, *, min_apps=None, doctypes_required=None) -> str:
 			"rule_tokens": json.dumps([]),
 		}
 	).insert(ignore_permissions=True)
+	# jarvis#1062: a fresh listing is CLOSED (no roles, no users), and this module's
+	# only actor is a plain Jarvis User. Granted here rather than per test because
+	# the listings are built inside the test bodies, and because the subject of
+	# every one of them is INSTALLABILITY - an access refusal arriving first would
+	# make them assert the wrong refusal (and, for the two expecting
+	# ValidationError, the wrong exception type entirely).
+	allow_listing_for(slug, roles=["Jarvis User"])
 	return slug
 
 

--- a/jarvis/tests/test_platform_render_gate.py
+++ b/jarvis/tests/test_platform_render_gate.py
@@ -40,7 +40,7 @@ TOK_A = "tok_rg_a"
 TOK_B = "tok_rg_b"
 
 CLEAN_SENTENCE = "No exceptions were found"
-CLEAN_HEADING = "Evaluated — clean coverage"
+CLEAN_HEADING = "Evaluated: clean coverage"
 
 
 def _mk_user(email: str) -> str:

--- a/jarvis/tests/test_platform_writeback.py
+++ b/jarvis/tests/test_platform_writeback.py
@@ -345,7 +345,7 @@ class TestPP2FalseCleanUnreachable(FrappeTestCase):
 			result_state="partial",
 		)
 		# remove the banner substring entirely
-		banner_marker = "Partial run — "
+		banner_marker = "Partial run - "
 		self.assertIn(banner_marker, html)
 		stripped = html.split(banner_marker)[0] + html.split(banner_marker)[1].split("</div>", 1)[1]
 		self.assertIn('data-result-state="partial"', stripped)

--- a/jarvis/tests/test_v3_list_extensions.py
+++ b/jarvis/tests/test_v3_list_extensions.py
@@ -23,6 +23,7 @@ from jarvis.chat import agent_catalog, agents_api, custom_skills_api, macros_api
 from jarvis.chat.approvals_api import get_approval
 from jarvis.chat.custom_skills_api import delete_custom_skills_bulk, list_custom_skills_page
 from jarvis.chat.macros_api import delete_macros_bulk, list_macro_runs, list_macros_page
+from jarvis.tests._agent_access import allow_listing_for
 
 USER_A = "v3-user-a@example.com"
 USER_B = "v3-user-b@example.com"
@@ -404,6 +405,12 @@ class TestGetAgent(unittest.TestCase):
 			for u in (USER_A, USER_B):
 				frappe.get_doc("User", u).add_roles("Accounts User")
 				frappe.clear_cache(user=u)
+		# jarvis#1062: access is deny-by-default, and both fixtures are plain Jarvis
+		# Users. Load-bearing for USER_B, who never installs and so has no
+		# installed-row carve-out to fall back on - get_agent would 403 before the
+		# payload assertions below could run.
+		allow_listing_for(cls.slug, user=USER_A)
+		allow_listing_for(cls.slug, user=USER_B)
 
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -440,6 +447,8 @@ class TestGetAgent(unittest.TestCase):
 		self.assertIsNotNone(res["installation"])
 		self.assertEqual(res["installation"]["name"], self.installation)
 		self.assertNotIn("all_roles", res)  # SM-only payload
+		self.assertNotIn("allowed_roles", res)  # admin-only payload (#1062 polish)
+		self.assertIn("doctypes_required", res)
 		self.assertEqual(res["install_count"], frappe.db.count(INSTALLATION, {"agent": self.slug}))
 		self.assertGreaterEqual(res["install_count"], 1)
 
@@ -448,8 +457,13 @@ class TestGetAgent(unittest.TestCase):
 			res = agents_api.get_agent(self.slug)
 		self.assertIsNone(res["installation"])
 		self.assertNotIn("all_roles", res)
+		# A non-admin learns whether THEY are allowed...
 		self.assertIn("allowed", res)
-		self.assertIn("allowed_roles", res)
+		self.assertEqual(res["allowed"], 1)
+		# ...and never WHO ELSE is: jarvis#1062 moved the roster into the admin-only
+		# half of the payload, next to all_roles.
+		self.assertNotIn("allowed_roles", res)
+		self.assertNotIn("allowed_users", res)
 
 	def test_sm_gets_all_roles(self):
 		res = agents_api.get_agent(self.slug)  # Administrator
@@ -457,10 +471,15 @@ class TestGetAgent(unittest.TestCase):
 		self.assertTrue(isinstance(res["all_roles"], list) and res["all_roles"])
 		for banned in ("Administrator", "Guest", "All"):
 			self.assertNotIn(banned, res["all_roles"])
+		self.assertIn("allowed_roles", res)  # an admin still sees who is allowed
 
-	def test_unknown_agent_throws(self):
-		with self.assertRaises(frappe.DoesNotExistError):
+	def test_unknown_agent_throws_a_clean_not_found(self):
+		"""A bad slug must read like the access-refusal path (#1062 polish) - not
+		leak the doctype name or confirm the slug is a real one."""
+		with self.assertRaises(frappe.DoesNotExistError) as ctx:
 			agents_api.get_agent("v3-no-such-agent")
+		self.assertIn("Agent not found.", str(ctx.exception))
+		self.assertNotIn("Jarvis Agent Listing", str(ctx.exception))
 
 	def test_list_agents_rows_gain_install_count(self):
 		with _as(USER_A):

--- a/jarvis/tools/__init__.py
+++ b/jarvis/tools/__init__.py
@@ -17,12 +17,13 @@ from jarvis.exceptions import InvalidArgumentError
 def require_doctype_and_name(doctype: str, name: str) -> None:
 	"""Reject empty doctype / name with InvalidArgumentError.
 
-	Six tools (amend_doc, cancel_doc, delete_doc, get_doc, submit_doc,
-	update_doc) all start with the identical two-line guard; the
-	2026-06-16 review flagged this as duplicated prologue. Factored
-	here so future tools that take a (doctype, name) pair have one
-	place to import from and changes to the rejection message land
-	in one site.
+	Five tools (amend_doc, cancel_doc, delete_doc, submit_doc, update_doc) all
+	start with the identical two-line guard; the 2026-06-16 review flagged
+	this as duplicated prologue. Factored here so future tools that take a
+	(doctype, name) pair have one place to import from and changes to the
+	rejection message land in one site. get_doc (#1062) dropped out: its
+	name/names two-mode API and the Single-doctype short-circuit need their
+	own guard, so it no longer imports this helper.
 	"""
 	if not doctype:
 		raise InvalidArgumentError("doctype is required")

--- a/jarvis/tools/_delegate_capability.py
+++ b/jarvis/tools/_delegate_capability.py
@@ -196,7 +196,11 @@ def resolve(session_key: str | None = None) -> dict | None:
 	id, so a delegate can only ever act as its own run); ``session_key=None`` reads
 	it from the request-scoped ``_agent_run_ctx``.
 
-	Returns ``{run, agent, legacy, tools_allow, nature, writes, run_as}``. ``legacy``
+	Returns ``{run, owner, status, agent, legacy, tools_allow, nature, writes,
+	run_as}``. ``owner`` and ``status`` are along for the ride so a caller that
+	needs the run ROW (the #1062 step timeline pins each step to the run owner and
+	only narrates a ``running`` run) does not have to fetch the same row a second
+	time on the hot path of every plugin tool call. ``legacy``
 	True means no snapshot governs this run — the caller falls back to pre-JF-017
 	behaviour. A run that is neither snapshotted nor legacy yields an EMPTY contract
 	with ``legacy`` False, i.e. everything is refused."""
@@ -210,6 +214,8 @@ def resolve(session_key: str | None = None) -> dict | None:
 		{"session_key": key},
 		[
 			"name",
+			"owner",
+			"status",
 			"agent",
 			"creation",
 			"capability_contract",
@@ -219,16 +225,31 @@ def resolve(session_key: str | None = None) -> dict | None:
 		],
 		as_dict=True,
 	)
-	if not run or not run.agent:
+	# Shape-checked, not just truthiness-checked. ``as_dict=True`` yields a
+	# frappe._dict or None in production, so the isinstance arm is unreachable
+	# there - but ``frappe.db.get_value`` is a seam tests stub WHOLESALE (test_api's
+	# budget cases patch it to return one fixed string for every lookup on the
+	# dispatch path), and this function now runs on that path directly rather than
+	# only behind ``tool_denial``. A stub must make the caller a non-delegate, never
+	# an AttributeError out of the dispatcher. ``.get`` below for the same reason: a
+	# plain dict stub has no attribute access.
+	if not isinstance(run, dict) or not run.get("agent"):
 		return None  # no delegate run bound -> not a delegate; leave the caller untouched
 
-	base = {"run": run.name, "agent": run.agent, "run_as": frappe.session.user}
-	contract = (run.capability_contract or "").strip().lower()
+	base = {
+		"run": run.get("name"),
+		"owner": run.get("owner"),
+		"status": run.get("status"),
+		"agent": run.get("agent"),
+		"run_as": frappe.session.user,
+	}
+	contract = (run.get("capability_contract") or "").strip().lower()
 
-	if contract == CONTRACT_LEGACY or (not contract and _is_pre_patch(run.creation)):
+	if contract == CONTRACT_LEGACY or (not contract and _is_pre_patch(run.get("creation"))):
 		# Pre-JF-017 run: nature/writes come from the live listing, as they did
 		# before the snapshot existed, and no tools_allow gate applies.
-		listing = frappe.db.get_value(LISTING, run.agent, ["nature", "writes"], as_dict=True) or {}
+		listing = frappe.db.get_value(LISTING, run.get("agent"), ["nature", "writes"], as_dict=True) or {}
+		listing = listing if isinstance(listing, dict) else {}
 		return {
 			**base,
 			"legacy": True,
@@ -247,9 +268,9 @@ def resolve(session_key: str | None = None) -> dict | None:
 	return {
 		**base,
 		"legacy": False,
-		"tools_allow": _parse_list(run.tools_allow_json),
-		"nature": (run.capability_nature or "").strip().lower(),
-		"writes": parse_writes(run.capability_writes_json),
+		"tools_allow": _parse_list(run.get("tools_allow_json")),
+		"nature": (run.get("capability_nature") or "").strip().lower(),
+		"writes": parse_writes(run.get("capability_writes_json")),
 	}
 
 
@@ -270,7 +291,13 @@ _CHAT_NO_SURFACE = (
 _RUN_ERROR_NO_SURFACE = "the agent's capability contract authorises no tools; refused at the first call"
 
 
-def tool_denial(session_key: str | None, tool: str) -> dict | None:
+#: Distinguishes "caller passed no contract" from "caller resolved and got None"
+#: (a non-delegate). Without it, a caller that correctly resolved None would make
+#: this function resolve all over again - the exact double read it exists to avoid.
+_UNRESOLVED = object()
+
+
+def tool_denial(session_key: str | None, tool: str, cap=_UNRESOLVED) -> dict | None:
 	"""The refusal for this delegate's ``tool`` call, or None when it may proceed.
 
 	None is also returned for a NON-delegate caller (nothing to enforce) and for a
@@ -289,9 +316,18 @@ def tool_denial(session_key: str | None, tool: str) -> dict | None:
 	    than leave it ``running`` for the 3h reaper to mislabel as a timeout.
 	  * ``chat_message`` vs ``message`` — plain language for the customer-visible
 	    transcript, contract vocabulary for the delegate and the audit trail.
+
+	``cap`` lets a caller that has ALREADY resolved this session's contract hand it
+	in instead of paying for a second identical run-row read. Omit it and the
+	contract is resolved here, exactly as before.
 	"""
-	cap = resolve(session_key)
-	if cap is None or cap["legacy"]:
+	cap = resolve(session_key) if cap is _UNRESOLVED else cap
+	# Shape-checked like resolve's own row guard: a non-delegate (None) and a
+	# stubbed/mocked cap both mean "nothing to enforce here", which is what a
+	# patched resolve already produced before the contract was passed in. ``.get``
+	# so a cap missing the key is treated as NOT legacy, i.e. enforced - the
+	# fail-closed direction.
+	if not isinstance(cap, dict) or cap.get("legacy"):
 		return None
 	allowed = bench_tools(cap["tools_allow"])
 	name = normalize_tool(tool)

--- a/jarvis/tools/get_doc.py
+++ b/jarvis/tools/get_doc.py
@@ -1,8 +1,12 @@
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.tools import require_doctype_and_name
 from jarvis.tools._bulk import _MAX_BATCH
+
+_NO_NAME_MESSAGE = (
+	"Pass name (one document) or names (a non-empty list). For a single "
+	"record like Stock Settings call get_doc with only the doctype."
+)
 
 
 def get_doc(doctype: str, name: str | None = None, names: list | None = None) -> dict:
@@ -10,21 +14,51 @@ def get_doc(doctype: str, name: str | None = None, names: list | None = None) ->
 
 	Enforces read permission on EACH specific document for the current user.
 
-	Single: returns the document dict.
-	Batch: returns ``{"doctype","docs":[<doc>,...],"count":N}`` (fail-fast: a
-	missing or unreadable name raises, naming the offending record).
+	Single: returns the document dict - or, if the caller passed a non-empty
+	``names`` list, the SAME batch envelope as any other doctype
+	(``{"doctype","docs":[<the one doc>],"count":1}``), because a caller that
+	asked for the batch shape must get the batch shape back, not silently a
+	different one it has to special-case. ``name``/an empty or absent
+	``names`` are ignored: a Single DocType (e.g. Stock Settings) has exactly
+	one document, whose name IS the doctype - there is nothing else to pass,
+	and a delegate with nothing sensible to put there commonly sends "" or
+	[], which used to bounce back "names must be a non-empty list of document
+	names" or "unknown Stock Settings: x" instead of just reading the one
+	document that exists.
+	Batch (non-single): returns ``{"doctype","docs":[<doc>,...],"count":N}``
+	(fail-fast: a missing or unreadable name raises, naming the offending
+	record).
 	"""
+	if not doctype:
+		raise InvalidArgumentError("doctype is required")
+	if not frappe.db.exists("DocType", doctype):
+		raise InvalidArgumentError(f"unknown doctype: {doctype}")
+
+	if frappe.get_meta(doctype).issingle:
+		doc = _get_single(doctype)
+		# names=[...] on a Single is meaningless as a name list (its one
+		# document's name IS the doctype - see docstring), but a caller who
+		# passed it explicitly asked for the BATCH shape and must get it back,
+		# not the flat dict every other Single call returns. names=None/[]
+		# (the common "nothing sensible to pass" case) stays flat.
+		if isinstance(names, list) and names:
+			return {"doctype": doctype, "docs": [doc], "count": 1}
+		return doc
+
 	if names is not None:
+		if not isinstance(names, list) or not names:
+			raise InvalidArgumentError(_NO_NAME_MESSAGE)
 		return _get_doc_batch(doctype, names)
 
-	require_doctype_and_name(doctype, name)
+	if not name:
+		raise InvalidArgumentError(_NO_NAME_MESSAGE)
 	return _get_doc_one(doctype, name)
 
 
 def _get_doc_one(doctype: str, name: str) -> dict:
 	"""Existence + per-record read-permission check, then the doc dict."""
 	if not frappe.db.exists(doctype, name):
-		raise InvalidArgumentError(f"unknown {doctype}: {name}")
+		raise InvalidArgumentError(f"No {doctype} named '{name}'. Use get_list to find valid names first.")
 
 	# Load once, then check READ permission on the loaded object. has_permission
 	# (doc=<name string>) would lazy-load the parent row just to run the check -
@@ -41,11 +75,21 @@ def _get_doc_one(doctype: str, name: str) -> dict:
 	return doc.as_dict(no_default_fields=False)
 
 
+def _get_single(doctype: str) -> dict:
+	"""Frappe's documented idiom for reading a Single - ``get_single``, not
+	``get_doc(doctype, doctype)`` - plus the same read-permission check and
+	output shaping ``_get_doc_one`` gives every other document. No existence
+	check: a Single always exists (frappe.db.exists special-cases it), and
+	singles carry their own DocPerms, so the permission check still matters."""
+	if not frappe.has_permission(doctype, ptype="read", doc=doctype):
+		raise PermissionDeniedError(f"no read permission on {doctype}")
+
+	doc = frappe.get_single(doctype)
+	doc.apply_fieldlevel_read_permissions()
+	return doc.as_dict(no_default_fields=False)
+
+
 def _get_doc_batch(doctype: str, names: list) -> dict:
-	if not doctype:
-		raise InvalidArgumentError("doctype is required")
-	if not isinstance(names, list) or not names:
-		raise InvalidArgumentError("names must be a non-empty list of document names")
 	if len(names) > _MAX_BATCH:
 		raise InvalidArgumentError(f"too many names in one batch (max {_MAX_BATCH})")
 

--- a/jarvis/tools/record_agent_run.py
+++ b/jarvis/tools/record_agent_run.py
@@ -270,6 +270,25 @@ def record_agent_run(
 		rows_consumed=rows_consumed_val,
 	)
 
+	# STEP TIMELINE (#1062): the run's closing step. Recorded HERE rather than by
+	# the generic per-tool hook in ``jarvis.api`` for two reasons: only this
+	# function knows how many findings actually PERSISTED (invalid rows are dropped
+	# above, so the evaluator's own list would overcount), and the writeback flips
+	# the run off ``running``, so a post-call status-gated resolution would find no
+	# run to narrate. Owner-pinned - this tool runs impersonated as the run-as user.
+	from jarvis.chat.agent_run_steps import plural, record_step
+
+	count = frappe.utils.cint(run_doc.findings_count)
+	record_step(
+		run_doc.name,
+		kind="writeback",
+		# `plural` is the shared phrasing helper every other step uses, so the
+		# closing step counts things the same way the rest of the timeline does.
+		label=f"Recorded {plural(count, 'finding')}",
+		detail=(f"{plural(len(dropped), 'row')} dropped" if dropped else None),
+		owner=run_doc.owner,
+	)
+
 	return {
 		"run": run_doc.name,
 		"status": run_doc.status,


### PR DESCRIPTION
## Summary

Backport of #1095 to `version-15-hotfix`: the #1058 agents-runtime stack (#1077 runs UX, Stop button and progress polling; #1084 deny-by-default access with roles and named users, admin-owned restart, reviewer-gated promote; #1085 per-agent config form, run notes and audit fixes; #1087 live step timeline). None of the four stacked PRs ever reached this line on their own because each merged into the branch below it.

**Stacked on #1247 (the #1064 backport). Merge #1247 first**, then this PR shows only its own commit. Adds patch `v2_18_agent_access_grandfather` and a new child DocType, so the next release needs a migrate.

Cherry-picked with `-m 1 -x` from the develop merge commit. Conflicts and how they were resolved:

- `AgentDetail.vue`, `agents_api.py`, `list_registry.py`: both sides had changed (the #1104 day picker and #1142 dashboards entry are already on this line). Took develop's versions, then removed the two develop-only hunks this line does not have: the `agent_initiated` flag from #1210 and the MCP `list_connectors` registry entry from #1152.
- `patches.txt`: kept this line's v2_19 entries and added the v2_18 grandfather patch before them. The develop-only `v2_19_drop_connectors_kill_switch` is not brought over.
- `agent_scheduler.py`, `test_agents_marketplace.py`: this line never received the "agent not applied" dispatch-error translation that version-16 has, so #1095's edit to it had nothing to attach to. Took the resolved version-16 files; both lines are now byte-identical on every file this PR touches.

## Pre-merge checklist

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with its base** (`version-15-hotfix` + #1247)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff

https://claude.ai/code/session_01GvEjfCozT55Ms6su4twbmc
