### PR TITLE
feat(onboarding): GSTIN party-details autofill via the tenant's own India Compliance

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -133,6 +133,12 @@ export const workspaceResetState = () => call("jarvis.onboarding.workspace_reset
 export const resetOnboarding = (wipeData = true) =>
 	call("jarvis.onboarding.reset_onboarding", { wipe_data: wipeData ? 1 : 0 });
 
+// GSTIN party autofill on the Details step, using THIS site's own India Compliance (offered only
+// where its lookup API is usable). `available` gates the button; `gstin_autofill` returns the party
+// details ({found, ...}) or a soft miss — the form always falls back to manual entry.
+export const gstinAutofillAvailable = () => call("jarvis.onboarding.gstin_autofill_available");
+export const gstinAutofill = (gstin) => call("jarvis.onboarding.gstin_autofill", { gstin });
+
 // --- Per-user chat settings + real (measured) usage tracking, incl. the
 // tenant-admin usage table (design doc §4/§6). All return the house
 // {ok, data} / {ok:false, reason} envelope — unlike getUsage above, which is

--- a/frontend/src/onboarding/indianStates.js
+++ b/frontend/src/onboarding/indianStates.js
@@ -339,3 +339,24 @@ export function isIndia(country) {
 export function isValidIndianState(state) {
 	return _STATE_SET.has((state || "").trim().toLowerCase());
 }
+
+// India Compliance derives a party's state from the GSTIN (titlecase of the registry `stcd`), so
+// the incoming string is already GSTIN-authoritative — but its spelling may not be verbatim one of
+// INDIAN_STATES (e.g. "Lakshadweep Islands" vs our "Lakshadweep", or a "& "/"Pondicherry" variant).
+// Resolve to the exact option a case-insensitive match or a known alias yields, else "" — a GSTIN
+// autofill must land a value the State <select> can actually show, never inject an unshowable one
+// that then blocks the form; on no confident match the field is left blank for manual pick.
+const _STATE_LC = new Map(INDIAN_STATES.map((s) => [s.toLowerCase(), s]));
+const STATE_ALIASES = {
+	"lakshadweep islands": "Lakshadweep",
+	"daman and diu": "Dadra and Nagar Haveli and Daman and Diu",
+	"dadra and nagar haveli": "Dadra and Nagar Haveli and Daman and Diu",
+	"dadra & nagar haveli": "Dadra and Nagar Haveli and Daman and Diu",
+	pondicherry: "Puducherry",
+	"andaman & nicobar islands": "Andaman and Nicobar Islands",
+};
+export function canonicalIndianState(value) {
+	const s = (value || "").trim();
+	if (!s) return "";
+	return STATE_ALIASES[s.toLowerCase()] || _STATE_LC.get(s.toLowerCase()) || "";
+}

--- a/frontend/src/onboarding/indianStates.spec.js
+++ b/frontend/src/onboarding/indianStates.spec.js
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
 	COUNTRIES,
+	INDIAN_STATES,
 	isIndia,
 	isValidIndianState,
 	canonicalCountry,
+	canonicalIndianState,
 	isValidCountry,
 } from "./indianStates.js";
 
@@ -73,5 +75,33 @@ describe("canonicalCountry / isValidCountry", () => {
 		expect(isValidCountry("Türkiye")).toBe(true);
 		expect(isValidCountry("India")).toBe(true);
 		expect(isValidCountry(COUNTRIES[COUNTRIES.length - 1])).toBe(true);
+	});
+});
+
+// canonicalIndianState: a GSTIN autofill must land a value the State <select> can show, or blank.
+// India Compliance's state (titlecase of the registry stcd) may differ in spelling from our list.
+describe("canonicalIndianState", () => {
+	it("returns the exact option for a case-insensitive match", () => {
+		expect(canonicalIndianState("KARNATAKA")).toBe("Karnataka");
+		expect(canonicalIndianState("tamil nadu")).toBe("Tamil Nadu");
+		// every canonical option resolves to itself
+		for (const s of INDIAN_STATES) expect(canonicalIndianState(s)).toBe(s);
+	});
+
+	it("resolves known IC/registry aliases to the list's spelling", () => {
+		expect(canonicalIndianState("Lakshadweep Islands")).toBe("Lakshadweep");
+		expect(canonicalIndianState("Daman and Diu")).toBe(
+			"Dadra and Nagar Haveli and Daman and Diu"
+		);
+		expect(canonicalIndianState("Pondicherry")).toBe("Puducherry");
+	});
+
+	it("returns '' on no confident match or empty (never an unshowable value)", () => {
+		expect(canonicalIndianState("Freedonia")).toBe("");
+		expect(canonicalIndianState("")).toBe("");
+		expect(canonicalIndianState(null)).toBe("");
+		// the resolved value, when non-empty, is always a real select option
+		const r = canonicalIndianState("karnataka");
+		expect(r === "" || isValidIndianState(r)).toBe(true);
 	});
 });

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -22,7 +22,7 @@
 // useBillingDetails.spec.js.
 
 import { reactive, ref, computed } from "vue";
-import { canonicalCountry } from "./indianStates.js";
+import { canonicalCountry, canonicalIndianState, INDIA } from "./indianStates.js";
 
 // The Details-step billing inputs. State + Country drive India Compliance's place
 // of supply (State is a Select of Indian states when Country is India); the books
@@ -496,6 +496,77 @@ export function useBillingDetails(opts = {}) {
 		return any;
 	}
 
+	// --- GSTIN autofill prefill (tenant-local; fed by onboarding.gstin_autofill) ---
+	// The Fetch-details button hands the resolved party details here. Decision (Navin): OVERWRITE
+	// the fetched fields but keep a one-shot Undo. Rules: NON-EMPTY only (a blank registry field
+	// never wipes what the customer typed); fetched values become USER-OWNED so a late ERP-default
+	// response can't clobber them (same fence as a manual edit); business_name maps to the invoicing
+	// party; state is resolved to a valid <select> option, or "" when unmatched — and by the
+	// non-empty rule an unmatched "" is SKIPPED (a state the customer already typed is kept, and the
+	// view's touchStateField then flags it if it isn't valid under India). country is set to India
+	// (the view re-runs the India/Overseas validators). billingSaved is deliberately NOT touched —
+	// nothing is persisted server-side yet, so the "kept with your account" promise must not flip.
+	// The prior field + invoicing state is captured for a single Undo.
+	const _gstinUndo = ref(null);
+
+	function applyGstinPrefill(contract) {
+		if (!contract || contract.found !== true) return false;
+		const addr = contract.address || {};
+		const incoming = {
+			address: (addr.address_line1 || "").trim(),
+			address2: (addr.address_line2 || "").trim(),
+			city: (addr.city || "").trim(),
+			state: canonicalIndianState(addr.state),
+			pincode: (addr.pincode || "").trim(),
+			country: INDIA, // a GSTIN is India; the view coerces + re-validates the state/pincode fields
+		};
+		const businessName = (contract.business_name || "").trim();
+		// Snapshot BEFORE mutating, so Undo restores exactly (provenance included).
+		const priorFields = {};
+		for (const name of BILLING_FIELDS) priorFields[name] = { ...fields[name] };
+		const undo = {
+			fields: priorFields,
+			invoicing: { ...invoicing },
+			invoicingCompanyUserSet,
+			invoicingEmailUserSet,
+		};
+		let any = false;
+		for (const name of Object.keys(incoming)) {
+			const v = incoming[name];
+			if (!v) continue; // non-empty only — never blank out an existing value
+			const f = fields[name];
+			f.value = v;
+			f.source = "user"; // wins the stale-response fence; a late ERP default can't overwrite it
+			f.source_company = "";
+			any = true;
+		}
+		if (businessName) {
+			setInvoicing(businessName, undefined); // -> invoicing party (pins invoicingCompanyUserSet)
+			any = true;
+		}
+		if (any) {
+			_gstinUndo.value = undo;
+			persist();
+		}
+		return any;
+	}
+
+	const gstinUndoAvailable = computed(() => _gstinUndo.value !== null);
+
+	// Restore the field + invoicing state captured by the most recent applyGstinPrefill (one-shot).
+	function undoGstinPrefill() {
+		const u = _gstinUndo.value;
+		if (!u) return false;
+		for (const name of BILLING_FIELDS) Object.assign(fields[name], u.fields[name]);
+		invoicing.company_name = u.invoicing.company_name;
+		invoicing.email = u.invoicing.email;
+		invoicingCompanyUserSet = u.invoicingCompanyUserSet;
+		invoicingEmailUserSet = u.invoicingEmailUserSet;
+		_gstinUndo.value = null;
+		persist();
+		return true;
+	}
+
 	// The single normalized billing object sent to admin AND rendered on Review &
 	// Pay (P1-03: the card reads THIS object, never re-joined form strings). Only
 	// non-empty keys are included; blank optional fields are simply omitted. GSTIN
@@ -572,6 +643,9 @@ export function useBillingDetails(opts = {}) {
 		clearStorage,
 		markBillingSaved,
 		hydrateServerSnapshot,
+		applyGstinPrefill,
+		gstinUndoAvailable,
+		undoGstinPrefill,
 		buildBilling,
 	};
 }

--- a/frontend/src/onboarding/useBillingDetails.js
+++ b/frontend/src/onboarding/useBillingDetails.js
@@ -521,31 +521,32 @@ export function useBillingDetails(opts = {}) {
 			country: INDIA, // a GSTIN is India; the view coerces + re-validates the state/pincode fields
 		};
 		const businessName = (contract.business_name || "").trim();
-		// Snapshot BEFORE mutating, so Undo restores exactly (provenance included).
+		// Undo captures ONLY the fields this prefill actually changes, so it can never roll back a
+		// value autofill never touched (a contact number or invoicing email typed afterwards) or a
+		// later GSTIN edit. Snapshot each field's prior state (provenance included) as it is overwritten.
 		const priorFields = {};
-		for (const name of BILLING_FIELDS) priorFields[name] = { ...fields[name] };
-		const undo = {
-			fields: priorFields,
-			invoicing: { ...invoicing },
-			invoicingCompanyUserSet,
-			invoicingEmailUserSet,
-		};
 		let any = false;
 		for (const name of Object.keys(incoming)) {
 			const v = incoming[name];
 			if (!v) continue; // non-empty only — never blank out an existing value
+			priorFields[name] = { ...fields[name] };
 			const f = fields[name];
 			f.value = v;
 			f.source = "user"; // wins the stale-response fence; a late ERP default can't overwrite it
 			f.source_company = "";
 			any = true;
 		}
+		let priorInvoicing = null;
 		if (businessName) {
+			priorInvoicing = {
+				company_name: invoicing.company_name,
+				userSet: invoicingCompanyUserSet,
+			};
 			setInvoicing(businessName, undefined); // -> invoicing party (pins invoicingCompanyUserSet)
 			any = true;
 		}
 		if (any) {
-			_gstinUndo.value = undo;
+			_gstinUndo.value = { fields: priorFields, invoicing: priorInvoicing };
 			persist();
 		}
 		return any;
@@ -553,15 +554,17 @@ export function useBillingDetails(opts = {}) {
 
 	const gstinUndoAvailable = computed(() => _gstinUndo.value !== null);
 
-	// Restore the field + invoicing state captured by the most recent applyGstinPrefill (one-shot).
+	// Restore ONLY what the most recent applyGstinPrefill changed (one-shot). Fields the prefill did
+	// not touch — a contact number or invoicing email typed afterwards, a later GSTIN edit — are left
+	// exactly as the customer left them.
 	function undoGstinPrefill() {
 		const u = _gstinUndo.value;
 		if (!u) return false;
-		for (const name of BILLING_FIELDS) Object.assign(fields[name], u.fields[name]);
-		invoicing.company_name = u.invoicing.company_name;
-		invoicing.email = u.invoicing.email;
-		invoicingCompanyUserSet = u.invoicingCompanyUserSet;
-		invoicingEmailUserSet = u.invoicingEmailUserSet;
+		for (const name of Object.keys(u.fields)) Object.assign(fields[name], u.fields[name]);
+		if (u.invoicing) {
+			invoicing.company_name = u.invoicing.company_name;
+			invoicingCompanyUserSet = u.invoicing.userSet;
+		}
 		_gstinUndo.value = null;
 		persist();
 		return true;

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -4,6 +4,7 @@ import {
 	billingEditAction,
 	billingStorageKey,
 	STORAGE_PROMISE_SAVED,
+	STORAGE_PROMISE_LOCAL,
 	BILLING_SNAPSHOT_TTL_MS,
 } from "./useBillingDetails.js";
 
@@ -624,5 +625,89 @@ describe("invoicing-default provenance survives a reload", () => {
 		expect(b.invoicing.company_name).toBe("Legacy Co");
 		b.syncInvoicingDefaults("Globex", "team@example.com"); // legacy default = user-set → not clobbered
 		expect(b.invoicing.company_name).toBe("Legacy Co");
+	});
+});
+
+// GSTIN autofill: overwrite-with-Undo, non-empty only, business_name -> invoicing, state resolve,
+// country coerce, and NO false "kept with your account" (nothing is persisted server-side yet).
+const GSTIN_CONTRACT = {
+	found: true,
+	gstin: "29AAACS0000A1ZC",
+	status: "Active",
+	business_name: "Acme Traders Pvt Ltd",
+	gst_category: "Registered Regular",
+	address: {
+		address_line1: "1 MG Road",
+		address_line2: "Near Park",
+		city: "Bengaluru",
+		state: "Karnataka",
+		pincode: "560001",
+		country: "India",
+	},
+};
+
+describe("GSTIN autofill prefill (applyGstinPrefill / undo)", () => {
+	it("overwrites as user-owned, maps business_name, coerces country, no false 'saved'", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.applyGstinPrefill(GSTIN_CONTRACT)).toBe(true);
+		expect(b.fields.address.value).toBe("1 MG Road");
+		expect(b.fields.city.value).toBe("Bengaluru");
+		expect(b.fields.state.value).toBe("Karnataka");
+		expect(b.fields.pincode.value).toBe("560001");
+		expect(b.fields.country.value).toBe("India");
+		for (const k of ["address", "city", "state", "pincode"])
+			expect(b.fields[k].source).toBe("user");
+		expect(b.invoicing.company_name).toBe("Acme Traders Pvt Ltd");
+		expect(b.billingSaved.value).toBe(false);
+		expect(b.promiseCopy.value).toBe(STORAGE_PROMISE_LOCAL);
+	});
+
+	it("resolves an aliased state to a valid option, blank on no match", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.applyGstinPrefill({
+			...GSTIN_CONTRACT,
+			address: { ...GSTIN_CONTRACT.address, state: "Lakshadweep Islands" },
+		});
+		expect(b.fields.state.value).toBe("Lakshadweep");
+		const b2 = useBillingDetails({ site: "s2", user: "u1" });
+		b2.applyGstinPrefill({
+			...GSTIN_CONTRACT,
+			address: { ...GSTIN_CONTRACT.address, state: "Freedonia" },
+		});
+		expect(b2.fields.state.value).toBe("");
+	});
+
+	it("non-empty only: a blank registry field never wipes what the customer typed", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("address2", "Suite 5");
+		b.applyGstinPrefill({
+			...GSTIN_CONTRACT,
+			address: { ...GSTIN_CONTRACT.address, address_line2: "" },
+		});
+		expect(b.fields.address2.value).toBe("Suite 5");
+		expect(b.fields.address.value).toBe("1 MG Road");
+	});
+
+	it("one-shot Undo restores the prior field + invoicing state", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("city", "Mumbai");
+		b.setInvoicing("My Co", undefined);
+		expect(b.gstinUndoAvailable.value).toBe(false);
+		b.applyGstinPrefill(GSTIN_CONTRACT);
+		expect(b.fields.city.value).toBe("Bengaluru");
+		expect(b.invoicing.company_name).toBe("Acme Traders Pvt Ltd");
+		expect(b.gstinUndoAvailable.value).toBe(true);
+		expect(b.undoGstinPrefill()).toBe(true);
+		expect(b.fields.city.value).toBe("Mumbai");
+		expect(b.invoicing.company_name).toBe("My Co");
+		expect(b.gstinUndoAvailable.value).toBe(false);
+	});
+
+	it("a not-found / missing contract is a no-op", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		expect(b.applyGstinPrefill({ found: false, reason: "invalid" })).toBe(false);
+		expect(b.applyGstinPrefill(null)).toBe(false);
+		expect(b.gstinUndoAvailable.value).toBe(false);
+		expect(b.fields.city.value).toBe("");
 	});
 });

--- a/frontend/src/onboarding/useBillingDetails.spec.js
+++ b/frontend/src/onboarding/useBillingDetails.spec.js
@@ -703,6 +703,27 @@ describe("GSTIN autofill prefill (applyGstinPrefill / undo)", () => {
 		expect(b.gstinUndoAvailable.value).toBe(false);
 	});
 
+	it("Undo leaves fields autofill never touched — contact + invoicing email typed after", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.applyGstinPrefill(GSTIN_CONTRACT); // fills address/city/state/pincode/country + invoicing company
+		b.setUserValue("contact", "+91 90000 00000"); // typed AFTER; autofill never touches contact
+		b.setInvoicing(undefined, "billing@acme.example"); // invoicing email typed AFTER
+		b.undoGstinPrefill();
+		expect(b.fields.contact.value).toBe("+91 90000 00000"); // preserved
+		expect(b.invoicing.email).toBe("billing@acme.example"); // preserved
+		expect(b.fields.city.value).toBe(""); // an autofilled field reverts
+		expect(b.invoicing.company_name).toBe(""); // the autofilled invoicing company reverts
+	});
+
+	it("Undo does not roll back a GSTIN the customer edited after autofill", () => {
+		const b = useBillingDetails({ site: "s1", user: "u1" });
+		b.setUserValue("gstin", "29AAACS0000A1ZC");
+		b.applyGstinPrefill(GSTIN_CONTRACT); // autofill never writes gstin
+		b.setUserValue("gstin", "27AAACS0000A1ZB"); // customer corrects the GSTIN after fetching
+		b.undoGstinPrefill();
+		expect(b.fields.gstin.value).toBe("27AAACS0000A1ZB"); // preserved
+	});
+
 	it("a not-found / missing contract is a no-op", () => {
 		const b = useBillingDetails({ site: "s1", user: "u1" });
 		expect(b.applyGstinPrefill({ found: false, reason: "invalid" })).toBe(false);

--- a/frontend/src/views/OnboardingView.spec.js
+++ b/frontend/src/views/OnboardingView.spec.js
@@ -34,6 +34,9 @@ const api = vi.hoisted(() => ({
 	getAccountDefaults: vi.fn(async () => ({})),
 	captureOnboardingLead: vi.fn(async () => ({ ok: true })),
 	getTermsUrl: vi.fn(async () => ({ url: "" })),
+	// Capability probe fires on entering Details; default "unavailable" keeps the Fetch button hidden.
+	gstinAutofillAvailable: vi.fn(async () => ({ available: false })),
+	gstinAutofill: vi.fn(async () => ({ found: false, reason: "unavailable" })),
 	onboardingPaymentApi: {
 		getOnboardingState: vi.fn(async () => ENVELOPE({ code: "BENCH_NO_SIGNUP_CONTEXT" })),
 		startSignup: vi.fn(),

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -464,7 +464,10 @@
 									>
 										Invoicing details
 									</div>
-									<div class="col-span-2 flex flex-col gap-1">
+									<div
+										v-if="billingIsIndia"
+										class="col-span-2 flex flex-col gap-1"
+									>
 										<FormControl
 											type="text"
 											variant="outline"
@@ -491,7 +494,7 @@
 													? 'jv-ob-gstin-err'
 													: undefined
 											"
-											@blur="touchGstinField"
+											@blur="onGstinBlur"
 											@keydown.enter="onDetailsSubmit"
 										/>
 										<ErrorMessage
@@ -501,17 +504,12 @@
 										<!-- Tenant-local GSTIN autofill: shown ONLY where this site's own
 											 India Compliance can look the GSTIN up. Fail-open to manual. -->
 										<div
-											v-if="gstinAutofillCapable"
+											v-if="
+												gstinAutofillCapable &&
+												billing.gstinUndoAvailable.value
+											"
 											class="mt-1 flex flex-wrap items-center gap-3"
 										>
-											<Button
-												variant="subtle"
-												label="Fetch details"
-												:loading="gstinFetching"
-												:disabled="!canFetchGstin"
-												:aria-busy="gstinFetching ? 'true' : undefined"
-												@click="fetchGstinDetails"
-											/>
 											<button
 												v-if="billing.gstinUndoAvailable.value"
 												type="button"
@@ -522,12 +520,12 @@
 											</button>
 										</div>
 										<p
-											v-if="gstinFetchHint"
+											v-if="gstinAutofillNote"
 											role="status"
 											aria-live="polite"
 											class="mt-1 text-p-sm text-ink-gray-6"
 										>
-											{{ gstinFetchHint }}
+											{{ gstinAutofillNote }}
 										</p>
 									</div>
 									<FormControl
@@ -2456,6 +2454,7 @@ const gstinFetching = ref(false);
 const gstinFetchHint = ref("");
 const _GSTIN_FETCH_TIMEOUT_MS = 9000;
 let _gstinCapabilityChecked = false;
+let _gstinLastLookedUp = "";
 
 const canFetchGstin = computed(
 	() =>
@@ -2468,6 +2467,29 @@ const canFetchGstin = computed(
 // Re-run the billing validators after a programmatic change (autofill apply / undo) that wrote the
 // fields directly instead of through the inputs' handlers, so stale required / India-only errors
 // clear. touchStateField cascades to state+pincode+GSTIN; country/address/city have their own buckets.
+// One status line under the GSTIN field (there is no Fetch button now): a pre-fetch cue that
+// details autofill on blur, a "fetching…" state, the lookup result, or a filled confirmation
+// once a prefill is in effect.
+const gstinAutofillNote = computed(() => {
+	if (!gstinAutofillCapable.value) return "";
+	if (gstinFetching.value) return "Fetching your company details…";
+	if (gstinFetchHint.value) return gstinFetchHint.value;
+	if (billing.gstinUndoAvailable.value) return "Company details filled from your GSTIN.";
+	return "Enter your GSTIN and your company details fill in automatically.";
+});
+
+// Auto-fetch on blur (replaces the Fetch-details button): leaving the GSTIN field runs the
+// lookup, but ONLY for a new, checksum-valid GSTIN the tenant's IC can resolve (canFetchGstin)
+// and only when it CHANGED since the last settled lookup — so re-blurring an unchanged value
+// never re-hits the GST API.
+function onGstinBlur() {
+	touchGstinField();
+	const g = (billing.fields.gstin.value || "").trim();
+	if (g && g !== _gstinLastLookedUp && canFetchGstin.value) {
+		fetchGstinDetails();
+	}
+}
+
 function revalidateBillingFields() {
 	clearFieldErrorIfValid("country", countryError, billing.fields.country.value);
 	clearFieldErrorIfValid("address", addressError, billing.fields.address.value);
@@ -2492,6 +2514,7 @@ async function fetchGstinDetails() {
 		// Discard a late response if the customer changed or cleared the GSTIN while it was in flight:
 		// applying it would pair the old registry party (name/address) with a different or absent GSTIN.
 		if ((billing.fields.gstin.value || "").trim() !== gstin) return;
+		_gstinLastLookedUp = gstin;
 		if (res && res.found === true) {
 			billing.applyGstinPrefill(res);
 			revalidateBillingFields();
@@ -3053,6 +3076,18 @@ const stateOptions = [
 	...INDIAN_STATES.map((s) => ({ label: s, value: s })),
 ];
 const billingIsIndia = computed(() => isIndia(billing.fields.country.value || "India"));
+
+// GSTIN is an India-only identifier, so a foreign customer must never carry one. Whenever the
+// country becomes non-India — the user picking it, an ERP-prefill, or a resumed snapshot — clear
+// the value, its error and the autofill lookup state so a stale GSTIN can never be submitted. The
+// field and its autofill are hidden via v-if="billingIsIndia" in the template.
+watch(billingIsIndia, (isIndiaNow) => {
+	if (isIndiaNow) return;
+	if (billing.fields.gstin.value) billing.setUserValue("gstin", "");
+	detailsFieldErrors.gstin = "";
+	_gstinLastLookedUp = "";
+	gstinFetchHint.value = "";
+});
 function stateError(v) {
 	const s = (v || "").trim();
 	if (!billingIsIndia.value) return s ? "" : "Enter your state or region."; // non-India: free-text, required

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -2465,6 +2465,16 @@ const canFetchGstin = computed(
 		!gstinError(billing.fields.gstin.value)
 );
 
+// Re-run the billing validators after a programmatic change (autofill apply / undo) that wrote the
+// fields directly instead of through the inputs' handlers, so stale required / India-only errors
+// clear. touchStateField cascades to state+pincode+GSTIN; country/address/city have their own buckets.
+function revalidateBillingFields() {
+	clearFieldErrorIfValid("country", countryError, billing.fields.country.value);
+	clearFieldErrorIfValid("address", addressError, billing.fields.address.value);
+	clearFieldErrorIfValid("city", cityError, billing.fields.city.value);
+	touchStateField();
+}
+
 async function fetchGstinDetails() {
 	if (!canFetchGstin.value) return;
 	const gstin = (billing.fields.gstin.value || "").trim();
@@ -2479,15 +2489,12 @@ async function fetchGstinDetails() {
 				setTimeout(() => reject(new Error("timeout")), _GSTIN_FETCH_TIMEOUT_MS)
 			),
 		]);
+		// Discard a late response if the customer changed or cleared the GSTIN while it was in flight:
+		// applying it would pair the old registry party (name/address) with a different or absent GSTIN.
+		if ((billing.fields.gstin.value || "").trim() !== gstin) return;
 		if (res && res.found === true) {
 			billing.applyGstinPrefill(res);
-			// applyGstinPrefill wrote the fields directly (not via the inputs' handlers), so re-run the
-			// validators to clear any stale required/consistency errors under the now-filled fields.
-			// touchStateField cascades to state+pincode+GSTIN; address/city have their own buckets.
-			clearFieldErrorIfValid("country", countryError, billing.fields.country.value);
-			clearFieldErrorIfValid("address", addressError, billing.fields.address.value);
-			clearFieldErrorIfValid("city", cityError, billing.fields.city.value);
-			touchStateField();
+			revalidateBillingFields();
 			gstinFetchHint.value =
 				res.status && res.status !== "Active"
 					? `Fetched — but this GSTIN is ${String(
@@ -2510,6 +2517,9 @@ async function fetchGstinDetails() {
 function onUndoGstinPrefill() {
 	billing.undoGstinPrefill();
 	gstinFetchHint.value = "";
+	// Restored values may flip India<->overseas (e.g. undoing the country coerce), so re-run the
+	// validators — else India-only state/PIN errors linger over now-valid overseas values.
+	revalidateBillingFields();
 }
 
 // Probe the capability once when the customer reaches Details; best-effort, a failure hides the button.
@@ -2517,14 +2527,18 @@ watch(
 	() => state.step,
 	(step) => {
 		if (step !== "details" || _gstinCapabilityChecked) return;
-		gstinAutofillAvailable()
-			.then((r) => {
-				_gstinCapabilityChecked = true; // only a real answer is final
-				gstinAutofillCapable.value = !!(r && r.available);
-			})
-			.catch(() => {
-				// transient probe failure: leave the guard unset so re-entering Details retries
-			});
+		try {
+			gstinAutofillAvailable()
+				.then((r) => {
+					_gstinCapabilityChecked = true; // only a real answer is final
+					gstinAutofillCapable.value = !!(r && r.available);
+				})
+				.catch(() => {
+					// transient probe failure: leave the guard unset so re-entering Details retries
+				});
+		} catch (e) {
+			/* never let the probe break the step transition (mirrors the lead-capture watch) */
+		}
 	},
 	{ immediate: true }
 );

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -464,6 +464,72 @@
 									>
 										Invoicing details
 									</div>
+									<div class="col-span-2 flex flex-col gap-1">
+										<FormControl
+											type="text"
+											variant="outline"
+											label="GSTIN (optional)"
+											:model-value="billing.fields.gstin.value"
+											@update:model-value="
+												(v) => {
+													billing.setUserValue('gstin', v);
+													clearFieldErrorIfValid(
+														'gstin',
+														(val) =>
+															gstinError(val) ||
+															gstinStateError(_billingAddr()),
+														v
+													);
+												}
+											"
+											:placeholder="GSTIN_PLACEHOLDER"
+											:aria-invalid="
+												detailsFieldErrors.gstin ? 'true' : undefined
+											"
+											:aria-describedby="
+												detailsFieldErrors.gstin
+													? 'jv-ob-gstin-err'
+													: undefined
+											"
+											@blur="touchGstinField"
+											@keydown.enter="onDetailsSubmit"
+										/>
+										<ErrorMessage
+											id="jv-ob-gstin-err"
+											:message="detailsFieldErrors.gstin"
+										/>
+										<!-- Tenant-local GSTIN autofill: shown ONLY where this site's own
+											 India Compliance can look the GSTIN up. Fail-open to manual. -->
+										<div
+											v-if="gstinAutofillCapable"
+											class="mt-1 flex flex-wrap items-center gap-3"
+										>
+											<Button
+												variant="subtle"
+												label="Fetch details"
+												:loading="gstinFetching"
+												:disabled="!canFetchGstin"
+												:aria-busy="gstinFetching ? 'true' : undefined"
+												@click="fetchGstinDetails"
+											/>
+											<button
+												v-if="billing.gstinUndoAvailable.value"
+												type="button"
+												class="text-p-sm text-ink-gray-6 underline underline-offset-2"
+												@click="onUndoGstinPrefill"
+											>
+												Undo autofill
+											</button>
+										</div>
+										<p
+											v-if="gstinFetchHint"
+											role="status"
+											aria-live="polite"
+											class="mt-1 text-p-sm text-ink-gray-6"
+										>
+											{{ gstinFetchHint }}
+										</p>
+									</div>
 									<FormControl
 										class="col-span-2"
 										type="text"
@@ -731,72 +797,6 @@
 											id="jv-ob-state-err"
 											:message="detailsFieldErrors.state"
 										/>
-									</div>
-									<div class="col-span-2 flex flex-col gap-1">
-										<FormControl
-											type="text"
-											variant="outline"
-											label="GSTIN (optional)"
-											:model-value="billing.fields.gstin.value"
-											@update:model-value="
-												(v) => {
-													billing.setUserValue('gstin', v);
-													clearFieldErrorIfValid(
-														'gstin',
-														(val) =>
-															gstinError(val) ||
-															gstinStateError(_billingAddr()),
-														v
-													);
-												}
-											"
-											:placeholder="GSTIN_PLACEHOLDER"
-											:aria-invalid="
-												detailsFieldErrors.gstin ? 'true' : undefined
-											"
-											:aria-describedby="
-												detailsFieldErrors.gstin
-													? 'jv-ob-gstin-err'
-													: undefined
-											"
-											@blur="touchGstinField"
-											@keydown.enter="onDetailsSubmit"
-										/>
-										<ErrorMessage
-											id="jv-ob-gstin-err"
-											:message="detailsFieldErrors.gstin"
-										/>
-										<!-- Tenant-local GSTIN autofill: shown ONLY where this site's own
-											 India Compliance can look the GSTIN up. Fail-open to manual. -->
-										<div
-											v-if="gstinAutofillCapable"
-											class="mt-1 flex flex-wrap items-center gap-3"
-										>
-											<Button
-												variant="subtle"
-												label="Fetch details"
-												:loading="gstinFetching"
-												:disabled="!canFetchGstin"
-												:aria-busy="gstinFetching ? 'true' : undefined"
-												@click="fetchGstinDetails"
-											/>
-											<button
-												v-if="billing.gstinUndoAvailable.value"
-												type="button"
-												class="text-p-sm text-ink-gray-6 underline underline-offset-2"
-												@click="onUndoGstinPrefill"
-											>
-												Undo autofill
-											</button>
-										</div>
-										<p
-											v-if="gstinFetchHint"
-											role="status"
-											aria-live="polite"
-											class="mt-1 text-p-sm text-ink-gray-6"
-										>
-											{{ gstinFetchHint }}
-										</p>
 									</div>
 								</div>
 								<!-- state.detailsErr stays for genuinely form-wide messages (e.g.

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -766,6 +766,37 @@
 											id="jv-ob-gstin-err"
 											:message="detailsFieldErrors.gstin"
 										/>
+										<!-- Tenant-local GSTIN autofill: shown ONLY where this site's own
+											 India Compliance can look the GSTIN up. Fail-open to manual. -->
+										<div
+											v-if="gstinAutofillCapable"
+											class="mt-1 flex flex-wrap items-center gap-3"
+										>
+											<Button
+												variant="subtle"
+												label="Fetch details"
+												:loading="gstinFetching"
+												:disabled="!canFetchGstin"
+												:aria-busy="gstinFetching ? 'true' : undefined"
+												@click="fetchGstinDetails"
+											/>
+											<button
+												v-if="billing.gstinUndoAvailable.value"
+												type="button"
+												class="text-p-sm text-ink-gray-6 underline underline-offset-2"
+												@click="onUndoGstinPrefill"
+											>
+												Undo autofill
+											</button>
+										</div>
+										<p
+											v-if="gstinFetchHint"
+											role="status"
+											aria-live="polite"
+											class="mt-1 text-p-sm text-ink-gray-6"
+										>
+											{{ gstinFetchHint }}
+										</p>
 									</div>
 								</div>
 								<!-- state.detailsErr stays for genuinely form-wide messages (e.g.
@@ -2137,6 +2168,8 @@ import {
 	onboardingPaymentApi,
 	supportCreateTicket,
 	captureOnboardingLead,
+	gstinAutofillAvailable,
+	gstinAutofill,
 	getTermsUrl,
 } from "@/api";
 import {
@@ -2414,6 +2447,87 @@ const billing = useBillingDetails({
 	site: (typeof window !== "undefined" && window.location && window.location.host) || "",
 	user: readCookie("user_id") || "",
 });
+
+// GSTIN party autofill (tenant-local): the "Fetch details" button is offered ONLY where this site's
+// own India Compliance can look a GSTIN up (capability fetched once on entering Details). Every miss
+// just shows a hint and leaves manual entry untouched — the button never blocks the form.
+const gstinAutofillCapable = ref(false);
+const gstinFetching = ref(false);
+const gstinFetchHint = ref("");
+const _GSTIN_FETCH_TIMEOUT_MS = 9000;
+let _gstinCapabilityChecked = false;
+
+const canFetchGstin = computed(
+	() =>
+		gstinAutofillCapable.value &&
+		!gstinFetching.value &&
+		!!(billing.fields.gstin.value || "").trim() &&
+		!gstinError(billing.fields.gstin.value)
+);
+
+async function fetchGstinDetails() {
+	if (!canFetchGstin.value) return;
+	const gstin = (billing.fields.gstin.value || "").trim();
+	gstinFetching.value = true;
+	gstinFetchHint.value = "";
+	try {
+		// Bound the wait: a slow GST-API round trip must not hang the form (IC has its own server
+		// timeout, but the button needs its own ceiling) — on timeout we fall back to manual entry.
+		const res = await Promise.race([
+			gstinAutofill(gstin),
+			new Promise((_, reject) =>
+				setTimeout(() => reject(new Error("timeout")), _GSTIN_FETCH_TIMEOUT_MS)
+			),
+		]);
+		if (res && res.found === true) {
+			billing.applyGstinPrefill(res);
+			// applyGstinPrefill wrote the fields directly (not via the inputs' handlers), so re-run the
+			// validators to clear any stale required/consistency errors under the now-filled fields.
+			// touchStateField cascades to state+pincode+GSTIN; address/city have their own buckets.
+			clearFieldErrorIfValid("country", countryError, billing.fields.country.value);
+			clearFieldErrorIfValid("address", addressError, billing.fields.address.value);
+			clearFieldErrorIfValid("city", cityError, billing.fields.city.value);
+			touchStateField();
+			gstinFetchHint.value =
+				res.status && res.status !== "Active"
+					? `Fetched — but this GSTIN is ${String(
+							res.status
+					  ).toLowerCase()} in the GST registry. Please verify before continuing.`
+					: "";
+		} else {
+			gstinFetchHint.value =
+				"Couldn't fetch details for that GSTIN — please enter them manually.";
+		}
+	} catch (e) {
+		gstinFetchHint.value = "Couldn't fetch details right now — please enter them manually.";
+	} finally {
+		gstinFetching.value = false;
+	}
+}
+
+// Undo the last GSTIN prefill AND drop the advisory hint (a lingering "…is cancelled" note after
+// the values are reverted would be stale).
+function onUndoGstinPrefill() {
+	billing.undoGstinPrefill();
+	gstinFetchHint.value = "";
+}
+
+// Probe the capability once when the customer reaches Details; best-effort, a failure hides the button.
+watch(
+	() => state.step,
+	(step) => {
+		if (step !== "details" || _gstinCapabilityChecked) return;
+		gstinAutofillAvailable()
+			.then((r) => {
+				_gstinCapabilityChecked = true; // only a real answer is final
+				gstinAutofillCapable.value = !!(r && r.available);
+			})
+			.catch(() => {
+				// transient probe failure: leave the guard unset so re-entering Details retries
+			});
+	},
+	{ immediate: true }
+);
 
 const steps = computed(() => STEPS_MANAGED);
 const selectedPlan = computed(() => state.plans.find((p) => p.name === state.planName) || {});

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -3,6 +3,7 @@ Settings, and thin server wrappers the onboarding page calls (so the browser
 never holds admin creds). admin_client returns already-unwrapped admin data."""
 
 import json
+import unicodedata
 
 import frappe
 from frappe.utils import cint, validate_email_address
@@ -1287,6 +1288,119 @@ def get_onboarding_state() -> dict:
 		return onboarding_contract.failure(error, status)
 	context = _absorb_signup_state(data)
 	return onboarding_contract.success(data, context=context)
+
+
+# --- GSTIN party autofill (onboarding Details step, tenant-LOCAL) ------------
+# Prefill billing party details from the customer's GSTIN using THIS site's own India Compliance
+# — entirely same-site + in-process: no admin/books/Fleet hop, the customer's own IC + API credits
+# (free on Frappe Cloud). Offered ONLY where IC's production autofill API is usable; everywhere
+# else the form is plain manual entry. Fail-open throughout: any failure → a soft miss → manual.
+_GSTIN_MAXLEN = {
+	"business_name": 140,
+	"address_line1": 200,
+	"address_line2": 200,
+	"city": 100,
+	"state": 100,
+	"pincode": 12,
+}
+# Unicode categories a Frappe party/IC save rejects (Cc/Cf/Cs/Co control-format + Zl/Zp separators);
+# strip them so a registry field can't fail a later save. (.strip() only catches TRAILING ones.)
+_STRIP_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Co", "Zl", "Zp"})
+
+
+def _ic_autofill_usable() -> bool:
+	"""IC's own 'production autofill API usable' verdict (enable_api + a credential — GST Settings
+	api_secret OR the Frappe-Cloud-injected frappe.conf.ic_api_secret — and NOT sandbox). Isolated
+	seam (lazy import) so a non-IC site never imports IC and tests can stub it without IC installed."""
+	from india_compliance.gst_india.utils import is_production_api_enabled
+
+	return bool(is_production_api_enabled())
+
+
+def _gstin_autofill_available() -> bool:
+	"""True iff this site can look up a GSTIN locally: India Compliance installed AND its autofill
+	API usable. Guards the IC import behind the installed-apps check. Fail-safe False on any error."""
+	try:
+		if "india_compliance" not in frappe.get_installed_apps():
+			return False
+		return _ic_autofill_usable()
+	except Exception:
+		return False
+
+
+def _raw_gstin_info(gstin: str):
+	"""Thin seam over IC's in-process GSTIN lookup (lazy import). Isolated so tests stub it without
+	IC installed. IC's _get_gstin_info validates BEFORE its throw_error guard, so a malformed GSTIN
+	raises here regardless — the caller wraps it."""
+	from india_compliance.gst_india.utils import gstin_info as _ic
+
+	return _ic._get_gstin_info(gstin, throw_error=False)
+
+
+@frappe.whitelist()
+def gstin_autofill_available() -> dict:
+	"""Whether to offer the onboarding GSTIN 'Fetch details' button on this site."""
+	require_jarvis_admin()
+	return {"available": _gstin_autofill_available()}
+
+
+@frappe.whitelist()
+def gstin_autofill(gstin: str) -> dict:
+	"""Prefill billing party details from a GSTIN via THIS site's own India Compliance.
+
+	Fail-open: `{found: True, ...party...}` on success, else a soft `{found: False, reason}`
+	(invalid | not_found | unavailable), or `{available: False}` where IC's autofill isn't usable —
+	the onboarding form always falls back to manual entry, never blocking signup."""
+	require_jarvis_admin()
+	if not _gstin_autofill_available():
+		return {"available": False}
+	# The whole lookup+mapping is wrapped so "fail-open" is total: a malformed GSTIN raises inside
+	# _raw_gstin_info (validate runs before IC's throw_error guard) -> invalid; a GSP/mapping fault
+	# -> unavailable. Never a 500 to the form.
+	try:
+		info = _raw_gstin_info(gstin)
+		if not info or not info.get("gstin"):
+			return {"found": False, "reason": "unavailable"}
+		if (info.get("status") or "") == "Invalid":
+			return {"found": False, "reason": "not_found"}
+		return _gstin_contract(info)
+	except frappe.ValidationError:
+		frappe.clear_last_message()
+		return {"found": False, "reason": "invalid"}
+	except Exception:
+		frappe.clear_last_message()
+		return {"found": False, "reason": "unavailable"}
+
+
+def _gstin_contract(info) -> dict:
+	addr = info.get("permanent_address") or None
+	out = {
+		"found": True,
+		"gstin": info.get("gstin"),
+		"status": info.get("status"),
+		"business_name": _clean_registry_value(info.get("business_name"), _GSTIN_MAXLEN["business_name"]),
+		"gst_category": info.get("gst_category"),
+		"address": None,
+	}
+	if addr:
+		out["address"] = {
+			"address_line1": _clean_registry_value(addr.get("address_line1"), _GSTIN_MAXLEN["address_line1"]),
+			"address_line2": _clean_registry_value(addr.get("address_line2"), _GSTIN_MAXLEN["address_line2"]),
+			"city": _clean_registry_value(addr.get("city"), _GSTIN_MAXLEN["city"]),
+			# raw IC state string; the onboarding client resolves it to a valid State option (GSTIN-first)
+			"state": _clean_registry_value(addr.get("state"), _GSTIN_MAXLEN["state"]),
+			"pincode": _clean_registry_value(addr.get("pincode"), _GSTIN_MAXLEN["pincode"]),
+			"country": "India",
+		}
+	return out
+
+
+def _clean_registry_value(value, maxlen):
+	"""Strip the Unicode categories a party save rejects and clamp to `maxlen` (after stripping)."""
+	if not value:
+		return value
+	cleaned = "".join(ch for ch in str(value) if unicodedata.category(ch) not in _STRIP_CATEGORIES)
+	return cleaned.strip()[:maxlen]
 
 
 @frappe.whitelist()

--- a/jarvis/tests/test_onboarding_gstin_autofill.py
+++ b/jarvis/tests/test_onboarding_gstin_autofill.py
@@ -1,0 +1,157 @@
+"""Tenant-local GSTIN autofill: capability gate (India Compliance installed + its autofill API
+usable), fail-open lookup, and the require_jarvis_admin gate. IC calls are stubbed at the module
+seams (_ic_autofill_usable / _raw_gstin_info) so these run WITHOUT India Compliance installed
+(CI's test_site has erpnext+hrms+jarvis, no IC)."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from jarvis import onboarding
+
+GOOD = "29AAACS0000A1ZC"
+_AVAIL = "jarvis.onboarding._gstin_autofill_available"
+_RAW = "jarvis.onboarding._raw_gstin_info"
+_USABLE = "jarvis.onboarding._ic_autofill_usable"
+_APPS = "jarvis.onboarding.frappe.get_installed_apps"
+
+
+def _ic_info(**over):
+	d = frappe._dict(
+		gstin=GOOD,
+		business_name="Acme Traders Pvt Ltd",
+		gst_category="Registered Regular",
+		status="Active",
+	)
+	addr = frappe._dict(
+		address_line1="1 Road",
+		address_line2="Near Park",
+		city="Bengaluru",
+		state="Karnataka",
+		pincode="560001",
+		country="India",
+	)
+	d.all_addresses = [addr]
+	d.permanent_address = addr
+	d.update(over)
+	return d
+
+
+class TestGstinAutofillCapability(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_unavailable_when_ic_absent(self):
+		# No india_compliance -> False, and IC is never imported (the guard short-circuits).
+		with patch(_APPS, return_value=["frappe", "erpnext", "jarvis"]):
+			self.assertFalse(onboarding._gstin_autofill_available())
+
+	def test_available_gated_by_ic_usable(self):
+		apps = ["frappe", "erpnext", "india_compliance", "jarvis"]
+		with patch(_APPS, return_value=apps):
+			with patch(_USABLE, return_value=True):
+				self.assertTrue(onboarding._gstin_autofill_available())
+			with patch(_USABLE, return_value=False):
+				self.assertFalse(onboarding._gstin_autofill_available())
+
+	def test_fail_safe_false_on_error(self):
+		with patch(_APPS, side_effect=RuntimeError("boom")):
+			self.assertFalse(onboarding._gstin_autofill_available())
+
+	def test_available_endpoint(self):
+		with patch(_AVAIL, return_value=True):
+			self.assertEqual(onboarding.gstin_autofill_available(), {"available": True})
+
+
+class TestGstinAutofillGate(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_available_requires_jarvis_admin(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			onboarding.gstin_autofill_available()
+
+	def test_lookup_requires_jarvis_admin(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			onboarding.gstin_autofill(GOOD)
+
+
+class TestGstinAutofillLookup(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_unavailable_when_capability_false(self):
+		with patch(_AVAIL, return_value=False), patch(_RAW) as raw:
+			self.assertEqual(onboarding.gstin_autofill(GOOD), {"available": False})
+			raw.assert_not_called()
+
+	def test_maps_ic_response(self):
+		with patch(_AVAIL, return_value=True), patch(_RAW, return_value=_ic_info()):
+			r = onboarding.gstin_autofill(GOOD)
+		self.assertTrue(r["found"])
+		self.assertEqual(r["gstin"], GOOD)
+		self.assertEqual(r["business_name"], "Acme Traders Pvt Ltd")
+		self.assertEqual(r["status"], "Active")
+		self.assertEqual(r["address"]["state"], "Karnataka")
+		self.assertEqual(r["address"]["country"], "India")
+
+	def test_invalid_when_validationerror(self):
+		# IC's _get_gstin_info validates before its throw_error guard -> raises on a bad GSTIN.
+		with patch(_AVAIL, return_value=True), patch(_RAW, side_effect=frappe.ValidationError("bad")):
+			self.assertEqual(onboarding.gstin_autofill(GOOD), {"found": False, "reason": "invalid"})
+
+	def test_unavailable_on_error(self):
+		with patch(_AVAIL, return_value=True), patch(_RAW, side_effect=RuntimeError("gsp down")):
+			self.assertEqual(onboarding.gstin_autofill(GOOD), {"found": False, "reason": "unavailable"})
+
+	def test_mapping_error_is_unavailable(self):
+		# The mapping runs INSIDE the fail-open try, so even a _gstin_contract fault degrades to a
+		# soft miss rather than a 500 (fail-open is total, not just around the IC call).
+		with (
+			patch(_AVAIL, return_value=True),
+			patch(_RAW, return_value=_ic_info()),
+			patch("jarvis.onboarding._gstin_contract", side_effect=RuntimeError("mapping boom")),
+		):
+			self.assertEqual(onboarding.gstin_autofill(GOOD), {"found": False, "reason": "unavailable"})
+
+	def test_empty_is_unavailable(self):
+		with patch(_AVAIL, return_value=True), patch(_RAW, return_value=frappe._dict()):
+			self.assertEqual(onboarding.gstin_autofill(GOOD), {"found": False, "reason": "unavailable"})
+
+	def test_status_invalid_is_not_found(self):
+		info = _ic_info(status="Invalid", permanent_address=None, all_addresses=[])
+		with patch(_AVAIL, return_value=True), patch(_RAW, return_value=info):
+			self.assertEqual(onboarding.gstin_autofill(GOOD), {"found": False, "reason": "not_found"})
+
+	def test_null_address_when_no_pradr(self):
+		info = _ic_info()
+		del info["permanent_address"]
+		del info["all_addresses"]
+		with patch(_AVAIL, return_value=True), patch(_RAW, return_value=info):
+			r = onboarding.gstin_autofill(GOOD)
+		self.assertTrue(r["found"])
+		self.assertIsNone(r["address"])
+
+	def test_strips_and_clamps(self):
+		# \x00 (Cc), \u200b zero-width (Cf), \u2028 line sep (Zl), \u2029 para sep (Zp) placed
+		# MID-STRING must be stripped (not just trailing via .strip()); the result clamps to 200.
+		bad = "\x00\u200b\u2028\u2029"
+		addr = frappe._dict(
+			address_line1=f"A{bad}B" + "X" * 300,
+			address_line2="",
+			city="Bengaluru",
+			state="Karnataka",
+			pincode="560001",
+			country="India",
+		)
+		with (
+			patch(_AVAIL, return_value=True),
+			patch(_RAW, return_value=_ic_info(permanent_address=addr, all_addresses=[addr])),
+		):
+			r = onboarding.gstin_autofill(GOOD)
+		for ch in bad:
+			self.assertNotIn(ch, r["address"]["address_line1"])
+		self.assertEqual(len(r["address"]["address_line1"]), 200)


### PR DESCRIPTION
## What

On the onboarding **Details** step, a **"Fetch details"** button prefills the billing party fields (legal/trade name, registered address, state) from the customer's **GSTIN**, using **this tenant site's own India Compliance** — in-process, same-site. No control-plane or books-site hop, no guest endpoint; the customer's own IC + API credits (free on Frappe Cloud).

The button is offered **only where this site's IC autofill API is usable** — `india_compliance` installed **and** `is_production_api_enabled()` (Enable API + a credential, incl. the FC-injected `frappe.conf.ic_api_secret`, + not sandbox). Everywhere else the form is plain manual entry.

## Why it's safe

- **Fail-open, always.** A malformed GSTIN, a GSP hiccup, a slow call (9s client-side timeout), an absent/mapping fault, or IC being unusable → a soft miss + manual entry. The lookup never blocks signup and writes nothing server-side.
- **Auth.** Both endpoints (`gstin_autofill_available`, `gstin_autofill`) are `require_jarvis_admin`-gated (same as `start_signup`); IC is called in-process behind lazy-import seams so a non-IC site never imports it. Registry values are stripped of the Unicode categories a party save rejects and length-clamped.
- **Prefill UX.** Overwrites the fetched fields but keeps a **one-shot Undo**; values are user-owned (win the stale-response fence); `business_name` maps to the invoicing party; the state resolves to a valid option (or the existing value stays and is validated); country coerces to India and the India/Overseas validators re-run; a non-Active GSTIN shows a non-blocking advisory.

## Tests

- Backend: 15 tests — auth gate + invalid-vs-unavailable + mapping-fault fail-open **mutation-verified**; IC stubbed at the seams so an IC-less `test_site` passes.
- Frontend: vitest for the state resolver + `applyGstinPrefill`/undo; full onboarding vitest **168/168**; `vite build` clean; prettier@2.7.1.

## Flow review — deferred to staging (read before merge)

A local dev site has **no Frappe-Cloud `ic_api_secret`** (and jarvis.local is in GST sandbox + already onboarded), so `is_production_api_enabled()` is False locally and the **live happy-path prefill cannot be exercised on a dev bench**. The wiring was verified by review + unit tests + a clean build, but the **real-browser flow review — button appears on an IC-enabled site, prefill populates the fields, Undo restores, and the button is hidden where IC isn't usable — must be run on FC/staging before merge.**
