### PR TITLE
feat(onboarding): hide + clear GSTIN for a foreign customer

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -732,7 +732,13 @@
 											:message="detailsFieldErrors.state"
 										/>
 									</div>
-									<div class="col-span-2 flex flex-col gap-1">
+									<!-- GSTIN is India-only (place-of-supply / GST invoice). Hidden for a
+										 foreign customer; the watcher on billingIsIndia also CLEARS any value
+										 so a stale GSTIN is never submitted for a non-India customer. -->
+									<div
+										v-if="billingIsIndia"
+										class="col-span-2 flex flex-col gap-1"
+									>
 										<FormControl
 											type="text"
 											variant="outline"
@@ -2925,6 +2931,16 @@ const stateOptions = [
 	...INDIAN_STATES.map((s) => ({ label: s, value: s })),
 ];
 const billingIsIndia = computed(() => isIndia(billing.fields.country.value || "India"));
+// GSTIN is an India-only identifier, so a foreign customer must never carry one.
+// Whenever the country becomes non-India — the user picking it, an ERP-prefill, or a
+// resumed snapshot — clear the value (so it is never submitted) and drop any stale
+// error. The field itself is hidden via v-if="billingIsIndia" in the template.
+watch(billingIsIndia, (isIndiaNow) => {
+	if (!isIndiaNow && billing.fields.gstin.value) {
+		billing.setUserValue("gstin", "");
+		detailsFieldErrors.gstin = "";
+	}
+});
 function stateError(v) {
 	const s = (v || "").trim();
 	if (!billingIsIndia.value) return s ? "" : "Enter your state or region."; // non-India: free-text, required


### PR DESCRIPTION
## What

GSTIN is an India-only identifier (GST place-of-supply / invoice). For a **foreign (non-India) customer** the onboarding Details step now **hides** the GSTIN field and **clears** any value so it's never submitted.

## How (one file, `OnboardingView.vue`)

- **Hide:** the GSTIN field is gated with `v-if="billingIsIndia"` — mirroring the existing **State** field, which already switches to a free-text "State / Region" for non-India via the same `billingIsIndia` computed (`isIndia(country)` from `address.js`).
- **Clear:** a `watch(billingIsIndia, …)` clears `billing.fields.gstin` (+ its error) the moment the country becomes non-India. A watcher (rather than only the interactive `onCountryChange`) also covers a **programmatic** country change — an ERP-prefill or a resumed snapshot — so a stale GSTIN can never be submitted for a foreign customer.

No backend change: GSTIN is already optional server-side, and the client validators (`gstinError` / `gstinStateError`) already short-circuit for non-India — submitting blank is correct.

## Verification

- Diff is scoped to the one field + watcher; `prettier@2.7.1` clean; no `openclaw` leak.
- **Build gate = CI** (the isolated worktree couldn't run `vite build` locally under node 20; CI runs the frontend build + vitest authoritatively).
- **Browser walk deferred** — verifying in-browser needs a main-tree rebuild, which is disruptive on this bench right now. Happy to do a browser pass on request.

## Design notes / deferred

- The watcher fires on all *reactive* country changes. A purely synchronous initial-load state that is already foreign **and** already carries a GSTIN would not trigger it — but that state doesn't occur (GSTIN is India-only); `{ immediate: true }` is the one-flag fix if ever needed.