### PR TITLE
fix(agents): run-as install gate reads child tables via their parent

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -354,13 +354,34 @@ class JarvisAgentInstallation(Document):
 					_("This agent requires DocType {0}, which is not present on this site.").format(dt),
 					title=_("Agent not installable"),
 				)
-			if not frappe.has_permission(dt, "read", user=target):
+			if not self._run_as_can_read(dt, target):
 				frappe.throw(
 					_("Run-as user {0} lacks read access to {1}, which this agent requires.").format(
 						target, dt
 					)
 				)
 		self.scoped_visibility = 1 if self._detect_scoped_visibility(target) else 0
+
+	def _run_as_can_read(self, dt: str, target: str) -> bool:
+		"""Read check that understands child tables. A child DocType (``istable``)
+		carries NO DocPerm rows of its own — its readability rides the PARENT it is
+		embedded in — so a bare ``has_permission`` on it is False for every
+		non-Administrator user, wrongly refusing a run-as user who CAN read the parent
+		the agent scans it through. For a child, verify read via a parent that embeds it
+		(``has_permission(..., parent_doctype=p)`` — Frappe's own child-permission path):
+		readable when the user can read ANY embedding parent, refused when none is (so an
+		orphan child with no embedding parent refuses — fail-closed). Non-child unchanged."""
+		if not frappe.get_meta(dt).istable:
+			return bool(frappe.has_permission(dt, "read", user=target))
+		# Reuse the canonical parent finder (Table + Table MultiSelect, DocField + Custom
+		# Field) rather than a second copy that would drift. Drop a discovered parent that is
+		# no longer a real DocType (e.g. a Custom Field whose parent was later removed):
+		# has_permission would get_meta it and raise DoesNotExistError, turning a clean
+		# "lacks read access" refusal into a 500.
+		from jarvis.tools.get_list import _child_table_parents
+
+		parents = (p for p in _child_table_parents(dt) if frappe.db.exists("DocType", p))
+		return any(frappe.has_permission(dt, "read", user=target, parent_doctype=p) for p in parents)
 
 	def _required_doctypes(self) -> list[str]:
 		# R5-J8: return the FULL declared set (trimmed, non-empty strings) — no

--- a/jarvis/tests/test_agent_identity.py
+++ b/jarvis/tests/test_agent_identity.py
@@ -276,6 +276,70 @@ class TestAgentIdentity(unittest.TestCase):
 		self.assertEqual(int(frappe.db.get_value(INSTALLATION, clean, "scoped_visibility") or 0), 0)
 
 	# ------------------------------------------------------------------ #
+	# (c2) A12 read-gate understands child tables (readability rides the parent)
+	# ------------------------------------------------------------------ #
+	def test_run_as_read_gate_child_table_rides_parent(self):
+		"""A child DocType (``istable``) carries no DocPerm rows of its own, so a bare
+		``has_permission`` on it is False for every non-Administrator user. The A12
+		read-gate must instead check the child through a parent that embeds it: a run-as
+		user who can read the parent passes; one who cannot is refused; the non-child
+		path is unchanged."""
+		doc = frappe.new_doc(INSTALLATION)
+		child, parent = "Sales Invoice Item", "Sales Invoice"
+		reader = self.owner  # holds Accounts User (setUpClass) -> reads Sales Invoice
+
+		# The bare check the gate USED to do is False even for a legitimate reader —
+		# this is the Frappe behavior the fix works around, asserted as a canary.
+		self.assertTrue(frappe.has_permission(parent, "read", user=reader))
+		self.assertFalse(frappe.has_permission(child, "read", user=reader))
+		# The fixed check rides the parent: readable.
+		self.assertTrue(doc._run_as_can_read(child, reader))
+
+		# Negative: a bare System User who cannot read the parent is refused the child
+		# (the gate is not silently relaxed to "any child is readable").
+		noreader = _ensure_plain_user("aid-noaccounts@example.com")
+		try:
+			self.assertFalse(frappe.has_permission(parent, "read", user=noreader))
+			self.assertFalse(doc._run_as_can_read(child, noreader))
+			# Non-child path unchanged: an unreadable normal DocType stays refused.
+			self.assertFalse(doc._run_as_can_read("GL Entry", noreader))
+		finally:
+			frappe.delete_doc("User", noreader, force=True, ignore_permissions=True)
+			frappe.db.commit()
+
+	def test_run_as_read_gate_child_branches(self):
+		"""Cover _run_as_can_read's child-table branches: an orphan child (no embedding
+		parent -> fail-closed refuse), a STALE discovered parent (no longer a DocType ->
+		dropped by the existence guard -> refuse, never an uncaught DoesNotExistError/500),
+		and the any()-over-parents semantics (readable via at least ONE parent allows,
+		which an all() regression would wrongly refuse)."""
+		from unittest import mock
+
+		doc = frappe.new_doc(INSTALLATION)
+		reader, child = self.owner, "Sales Invoice Item"
+		HELP = "jarvis.tools.get_list._child_table_parents"
+
+		# Orphan: nothing embeds it -> no parent to ride -> refuse.
+		with mock.patch(HELP, return_value=[]):
+			self.assertFalse(doc._run_as_can_read(child, reader))
+
+		# Stale parent: a discovered name that is no longer a DocType is dropped by the
+		# existence guard, so the call refuses cleanly instead of raising a 500.
+		with mock.patch(HELP, return_value=["No Such Parent DocType ZZZ"]):
+			self.assertFalse(doc._run_as_can_read(child, reader))
+
+		# any(): readable via ONE embedding parent allows, even when another discovered
+		# parent is unreadable — pinning any() (an all() regression would flip this False).
+		def _perm(*a, **kw):
+			return kw.get("parent_doctype") == "Sales Invoice"
+
+		with (
+			mock.patch(HELP, return_value=["Sales Invoice", "Sales Order"]),
+			mock.patch("frappe.has_permission", side_effect=_perm),
+		):
+			self.assertTrue(doc._run_as_can_read(child, reader))
+
+	# ------------------------------------------------------------------ #
 	# (d) _launch_audit mints the session + stamps watermark/scope
 	# ------------------------------------------------------------------ #
 	def test_launch_audit_mints_session_and_stamps_watermark(self):


### PR DESCRIPTION
## Problem
The A12 run-as read-gate (`JarvisAgentInstallation._validate_run_as_permissions`) called `has_permission(dt, "read")` on every `doctypes_required` entry. A child DocType (`istable`) has no DocPerm rows of its own — its readability rides the parent it is embedded in — so a bare `has_permission` on a child table is **False for every non-Administrator user**. That wrongly refused install for any least-privilege run-as user of an agent that declares a child table in `doctypes_required` (Sales Invoice Item, Purchase Invoice Item, Payment Entry Reference, Payroll Employee Detail, …) — several published auditors were un-installable under a realistic run-as user.

## Fix
- Check a child table's readability **through a parent that embeds it** (`has_permission(dt, "read", user, parent_doctype=p)` — Frappe's own child-permission path): readable when the user can read *any* embedding parent, refused when none is (an orphan child → fail-closed).
- Reuse the canonical `jarvis.tools.get_list._child_table_parents` (covers `Table` + `Table MultiSelect`, `DocField` + `Custom Field`) instead of a second, drift-prone copy.
- Drop a discovered parent that is no longer a real DocType before calling `has_permission`, so a stale `Custom Field` can't turn the clean "lacks read access" refusal into a `DoesNotExistError` 500.
- **Non-child path unchanged**; every branch is fail-closed (a user who can't read any embedding parent is still refused).

## Testing
- `test_run_as_read_gate_child_table_rides_parent` — positive (reader passes child via parent), negative (no-parent-read user still refused), non-child unchanged, plus a canary that the bare `has_permission(child)` is False.
- `test_run_as_read_gate_child_branches` — orphan, stale-parent existence-guard, and `any()`-vs-`all()` semantics (mock-verified to catch an `all()` regression).
- Full `jarvis.tests.test_agent_identity` module green (9/9); `ruff format` + `ruff check` clean.
- Verified end-to-end on a bench: the previously-blocked child-table auditors install through the fixed gate and dispatch/evaluate live.
